### PR TITLE
Fix database health check test

### DIFF
--- a/test/controllers/health/database.controller.test.js
+++ b/test/controllers/health/database.controller.test.js
@@ -31,13 +31,7 @@ describe('Database controller', () => {
     it('returns stats about each table', async () => {
       const response = await server.inject(options)
 
-      const payload = JSON.parse(response.payload)
-
       expect(response.statusCode).to.equal(200)
-
-      // We expect at least 5 tables to exist and be returned in the results
-      expect(payload.length).to.be.at.least(5)
-      expect(payload[0].relname).to.exist()
     })
   })
 })

--- a/test/services/database_health_check.service.test.js
+++ b/test/services/database_health_check.service.test.js
@@ -14,12 +14,4 @@ describe('Database Health Check service', () => {
   it('confirms connection to the db by not throwing an error', async () => {
     await expect(DatabaseHealthCheckService.go()).to.not.reject()
   })
-
-  it('returns stats about each table', async () => {
-    const result = await DatabaseHealthCheckService.go()
-
-    // We expect at least 5 tables to exist and be returned in the results
-    expect(result.length).to.be.at.least(5)
-    expect(result[0].relname).to.exist()
-  })
 })


### PR DESCRIPTION
We copied the existing `test/services/database_health_check.service.test.js` directly from [sroc-charging-module-api](https://github.com/DEFRA/sroc-charging-module-api). In that project we expect 5 key tables to exist. Or, we did at the time we wrote the test. We would now expect more!

When we copied the test across it all workec fine because we were again pointing at an existing DB with lots of tables. However, when this project got pushed to GitHub the CI started failing because we're connecting to a DB that has nothing!

We've yet to add any migrations so nothing exists but the DB. We've confirmed that as long as the DB exists the connection works and that is sufficient as a health check.

Rather than force a result from PostgreSQL we're happy the fact we don't error is confirmation that the DB is 'healthy'.