### PR TITLE
Fix sonarcloud test coverage reporting

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,7 @@
 # Reference for all available properties
 # https://sonarcloud.io/documentation/analysis/analysis-parameters/
+# Reference for how to glob files
+# https://docs.sonarqube.org/latest/project-administration/narrowing-the-focus/
 
 # Project key is required. You'll find it in the SonarCloud UI
 sonar.projectKey=DEFRA_water-abstraction-system
@@ -14,15 +16,16 @@ sonar.links.ci=https://github.com/DEFRA/water-abstraction-system/actions
 sonar.links.scm=https://github.com/DEFRA/water-abstraction-system
 sonar.links.issue=https://github.com/DEFRA/water-abstraction-team/issues
 
-# Path is relative to the sonar-project.properties file. Replace "\" by "/" on
-# Windows.
-# SonarCloud seems to have little intelligence when it comes to code coverage.
-# Quite simply if it sees a code file, it checks it against our coverage report
-# and if not found flags it as uncovered. This also effects the overall coverage
-# score. In our case this means SonarCloud is flagging everything under test/
-# as lacking code coverage!
-sonar.sources=./app,./config
-sonar.tests=./test
+# Path is relative to the sonar-project.properties file.
+# SonarCloud seems to have little intelligence when it comes to code coverage. Quite simply if it sees a code file, it
+# checks it against our coverage report and if not found flags it as uncovered. This also effects the overall coverage
+# score. In our case this means SonarCloud could flag everything under test/ as lacking code coverage!
+# We have found this combinations of `sources`, `tests` and `tests.inclusions` means SonarCloud properly understands
+# what is code and what is a test file. Note the use of ./ in `sources`. This is the only way we found to include root
+# level files and ensure they are correctly resolved when SonarCloud scans the lcov coverage data.
+sonar.sources=app,config,./index.js
+sonar.tests=test
+sonar.test.inclusions=test/**/*.js
 
 # Encoding of the source code. Default is default system encoding
 sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
When we run our tests locally 94.24% is reported. However, SonarCloud is reporting 97.3%. We never understood this discrepancy in the SROC team. But when we came to WATER we were finally able to track it down to how things were configured in `sonar-project.properties`.

This change updates the file to bring in what we learnt and applied to our other **water-abstraction** projects.