### PR TITLE
Create `create.database.js` script

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ First clone the repository and then drop into your new local repo:
 git clone https://github.com/DEFRA/water-abstraction-system.git && cd water-abstraction-system
 ```
 
+Create the databases:
+
+```bash
+npm run create-db
+npm run create-test-db
+```
+
 Our preference is to run the database and API within Docker, so [install Docker](https://docs.docker.com/get-docker/) if you don't already have it.
 
 ## Configuration

--- a/db/create.database.js
+++ b/db/create.database.js
@@ -1,0 +1,38 @@
+'use strict'
+
+const environment = process.env.NODE_ENV || 'development'
+
+const dbConfig = require('../knexfile')[environment]
+
+const databaseName = dbConfig.connection.database
+
+// Connect to maintenance database. We can't use `knexfile.js` and require it as we would in other places because it
+// will already have instantiated using the actual db.
+// So we have to grab our config and instantiate it ourselves here so we can connect against the default 'postgres' db.
+// https://stackoverflow.com/a/31428260/6117745
+const knex = require('knex')({
+  client: 'pg',
+  connection: {
+    host: dbConfig.connection.host,
+    port: dbConfig.connection.port,
+    user: dbConfig.connection.user,
+    password: dbConfig.connection.password,
+    database: 'postgres',
+    charset: 'utf8'
+  }
+})
+
+const up = async function (knex) {
+  try {
+    await knex.raw(`CREATE DATABASE ${databaseName}`)
+    console.log(`Successfully created ${databaseName}`)
+  } catch (error) {
+    console.error(`Could not create ${databaseName}: ${error.message}`)
+  } finally {
+    // Kill the connection after running the command else the terminal will
+    // appear to hang
+    await knex.destroy()
+  }
+}
+
+up(knex)

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "main": "index.js",
   "scripts": {
     "start": "node index.js",
+    "create-db": "node db/create.database.js",
+    "create-test-db": "NODE_ENV=test node db/create.database.js",
     "lint": "standard",
     "test": "lab --silent-skips --shuffle"
   },


### PR DESCRIPTION
We started to work on the system and realised we didn't have the correct database setup! So we take the opportunity to create a `create.database.js` script which can be run from `npm` in order to set up the db.