### PR TITLE
Add pm2 config file

### DIFF
--- a/ecosystem.config.json
+++ b/ecosystem.config.json
@@ -1,0 +1,14 @@
+{
+  "apps": [
+    {
+      "name": "system",
+      "script": "index.js",
+      "combine_logs": true,
+      "env_production": {
+        "watch": false,
+        "instances" : "max",
+        "exec_mode" : "cluster"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/55

Currently, both in our local dev Vagrant box and our AWS environments we use pm2 to run the app. This is an architecture we have inherited.

Till such time as we have assimilated the other apps into this project, it will need to run alongside them in the same way.

So, to support this we need to add a [pm2 ecosystem file](https://pm2.keymetrics.io/docs/usage/application-declaration) to the project.

> Note - We don't include any 'watch' configuration, which is a deviation from the pattern used by the other apps. Because we now all run the projects within our dev Vagrant box pm2 watch doesn't work. This is a consequence of sharing files between the host and the box to allow us to edit on the host but run in the box. Therefore, it makes no sense to include configuration we never use. At some point, we'll bring the other apps in line with this one.