### PR TITLE
Switch from CommonJS to ES6 modules

### DIFF
--- a/.labrc.js
+++ b/.labrc.js
@@ -1,5 +1,3 @@
-'use strict'
-
 module.exports = {
   verbose: true,
   coverage: true,

--- a/app/controllers/health/airbrake.controller.js
+++ b/app/controllers/health/airbrake.controller.js
@@ -1,5 +1,3 @@
-'use strict'
-
 class AirbrakeController {
   static async index (req, _h) {
     // First section tests connecting to Airbrake through a manual notification
@@ -18,4 +16,4 @@ class AirbrakeController {
   }
 }
 
-module.exports = AirbrakeController
+export default AirbrakeController

--- a/app/controllers/health/database.controller.js
+++ b/app/controllers/health/database.controller.js
@@ -1,6 +1,4 @@
-'use strict'
-
-const DatabaseHealthCheckService = require('../../services/database_health_check.service.js')
+import DatabaseHealthCheckService from '../../services/database_health_check.service.js'
 
 class DatabaseController {
   static async index (_req, h) {
@@ -10,4 +8,4 @@ class DatabaseController {
   }
 }
 
-module.exports = DatabaseController
+export default DatabaseController

--- a/app/controllers/root.controller.js
+++ b/app/controllers/root.controller.js
@@ -1,6 +1,4 @@
-'use strict'
-
-const ServiceStatusService = require('../services/service_status.service')
+import ServiceStatusService from '../services/service_status.service.js'
 
 class RootController {
   static async index (_req, _h) {
@@ -25,4 +23,4 @@ class RootController {
   }
 }
 
-module.exports = RootController
+export default RootController

--- a/app/lib/base_notifier.lib.js
+++ b/app/lib/base_notifier.lib.js
@@ -1,13 +1,11 @@
-'use strict'
-
 /**
  * @module BaseNotifierLib
  */
 
-const { Notifier } = require('@airbrake/node')
-const Pino = require('pino')
+import { Notifier } from '@airbrake/node'
+import Pino from 'pino'
 
-const AirbrakeConfig = require('../../config/airbrake.config.js')
+import AirbrakeConfig from '../../config/airbrake.config.js'
 
 /**
  * Based class for combined logging and Airbrake (Errbit) notification managers
@@ -164,4 +162,4 @@ class BaseNotifierLib {
   }
 }
 
-module.exports = BaseNotifierLib
+export default BaseNotifierLib

--- a/app/lib/boom_notifier.lib.js
+++ b/app/lib/boom_notifier.lib.js
@@ -1,12 +1,10 @@
-'use strict'
-
 /**
  * @module BoomNotifierLib
  */
 
-const RequestNotifierLib = require('./request_notifier.lib.js')
+import RequestNotifierLib from './request_notifier.lib.js'
 
-const Boom = require('@hapi/boom')
+import Boom from '@hapi/boom'
 
 /**
  * A combined logging and Airbrake (Errbit) notification manager which extends RequestNotifierLib to also throw a Boom
@@ -31,4 +29,4 @@ class BoomNotifierLib extends RequestNotifierLib {
   }
 }
 
-module.exports = BoomNotifierLib
+export default BoomNotifierLib

--- a/app/lib/request_notifier.lib.js
+++ b/app/lib/request_notifier.lib.js
@@ -1,10 +1,8 @@
-'use strict'
-
 /**
  * @module RequestNotifierLib
  */
 
-const BaseNotifierLib = require('./base_notifier.lib.js')
+import BaseNotifierLib from './base_notifier.lib.js'
 
 /**
  * A combined logging and Airbrake (Errbit) notification manager for actions that take place within a
@@ -89,4 +87,4 @@ class RequestNotifierLib extends BaseNotifierLib {
   }
 }
 
-module.exports = RequestNotifierLib
+export default RequestNotifierLib

--- a/app/plugins/airbrake.plugin.js
+++ b/app/plugins/airbrake.plugin.js
@@ -1,5 +1,3 @@
-'use strict'
-
 /**
  * @module AirbrakePlugin
  */
@@ -17,8 +15,8 @@
  * {@link https://github.com/DEFRA/charging-module-api/blob/master/app/plugins/airbrake.js}
  */
 
-const { Notifier } = require('@airbrake/node')
-const AirbrakeConfig = require('../../config/airbrake.config.js')
+import { Notifier } from '@airbrake/node'
+import AirbrakeConfig from '../../config/airbrake.config.js'
 
 const AirbrakePlugin = {
   name: 'airbrake',
@@ -57,4 +55,4 @@ const AirbrakePlugin = {
   }
 }
 
-module.exports = AirbrakePlugin
+export default AirbrakePlugin

--- a/app/plugins/blipp.plugin.js
+++ b/app/plugins/blipp.plugin.js
@@ -1,5 +1,3 @@
-'use strict'
-
 /**
  * Plugin to output the routes table to console at startup.
  *
@@ -24,7 +22,7 @@
  * @module BlippPlugin
  */
 
-const Blipp = require('blipp')
+import Blipp from 'blipp'
 
 const BlippPlugin = {
   plugin: Blipp,
@@ -34,4 +32,4 @@ const BlippPlugin = {
   }
 }
 
-module.exports = BlippPlugin
+export default BlippPlugin

--- a/app/plugins/error_pages.plugin.js
+++ b/app/plugins/error_pages.plugin.js
@@ -1,5 +1,3 @@
-'use strict'
-
 /**
  * Add an `onPreResponse` listener to return error pages
  *
@@ -39,4 +37,4 @@ const ErrorPagesPlugin = {
   }
 }
 
-module.exports = ErrorPagesPlugin
+export default ErrorPagesPlugin

--- a/app/plugins/hapi_pino.plugin.js
+++ b/app/plugins/hapi_pino.plugin.js
@@ -1,5 +1,3 @@
-'use strict'
-
 /**
  * Plugin that handles logging for the application
  *
@@ -9,7 +7,7 @@
  *
  * @module HapiPinoPlugin
  */
-const HapiPino = require('hapi-pino')
+import HapiPino from 'hapi-pino'
 
 /**
  * Return test configuration options for the logger
@@ -54,4 +52,4 @@ const HapiPinoPlugin = logInTest => {
   }
 }
 
-module.exports = HapiPinoPlugin
+export default HapiPinoPlugin

--- a/app/plugins/request_notifier.plugin.js
+++ b/app/plugins/request_notifier.plugin.js
@@ -1,5 +1,3 @@
-'use strict'
-
 /**
  * Add an instance of `RequestNotifierLib` to the `request.app` as part of every request.
  *
@@ -9,7 +7,7 @@
  * @module RequestNotifierPlugin
  */
 
-const RequestNotifierLib = require('../lib/request_notifier.lib.js')
+import RequestNotifierLib from '../lib/request_notifier.lib.js'
 
 const RequestNotifierPlugin = {
   name: 'Notifier',
@@ -22,4 +20,4 @@ const RequestNotifierPlugin = {
   }
 }
 
-module.exports = RequestNotifierPlugin
+export default RequestNotifierPlugin

--- a/app/plugins/router.plugin.js
+++ b/app/plugins/router.plugin.js
@@ -1,5 +1,3 @@
-'use strict'
-
 /**
  * Our router plugin which pulls in the various routes we have defined ready to be registered with the Hapi server
  * (server.js).
@@ -11,13 +9,13 @@
  * @module RouterPlugin
  */
 
-const FilterRoutesService = require('../services/plugins/filter_routes.service.js')
-const AirbrakeConfig = require('../../config/airbrake.config.js')
+import FilterRoutesService from '../services/plugins/filter_routes.service.js'
+import AirbrakeConfig from '../../config/airbrake.config.js'
 
-const AirbrakeRoutes = require('../routes/airbrake.routes.js')
-const AssetRoutes = require('../routes/assets.routes.js')
-const DatabaseRoutes = require('../routes/database.routes.js')
-const RootRoutes = require('../routes/root.routes.js')
+import AirbrakeRoutes from '../routes/airbrake.routes.js'
+import AssetRoutes from '../routes/assets.routes.js'
+import DatabaseRoutes from '../routes/database.routes.js'
+import RootRoutes from '../routes/root.routes.js'
 
 const routes = [
   ...RootRoutes,
@@ -37,4 +35,4 @@ const RouterPlugin = {
   }
 }
 
-module.exports = RouterPlugin
+export default RouterPlugin

--- a/app/plugins/stop.plugin.js
+++ b/app/plugins/stop.plugin.js
@@ -1,5 +1,3 @@
-'use strict'
-
 /**
  * Handle `SIGTERM` and `SIGINT` calls to the app
  *
@@ -55,4 +53,4 @@ const StopPlugin = {
   }
 }
 
-module.exports = StopPlugin
+export default StopPlugin

--- a/app/plugins/views.plugin.js
+++ b/app/plugins/views.plugin.js
@@ -1,5 +1,3 @@
-'use strict'
-
 /**
  * Our views plugin which serves views using nunjucks and govuk-frontend.
  *
@@ -10,15 +8,19 @@
  * @module ViewsPlugin
  */
 
+import path from 'path'
+import nunjucks from 'nunjucks'
+import Vision from '@hapi/vision'
+
+import ServerConfig from '../../config/server.config.js'
+
 const SERVICE_NAME = 'Manage your water abstraction or impoundment licence'
 
-const path = require('path')
-const nunjucks = require('nunjucks')
-const pkg = require('../../package.json')
-const ServerConfig = require('../../config/server.config.js')
+// thanks to https://stackoverflow.com/a/66651120/19939610
+const __dirname = new URL('.', import.meta.url).pathname
 
 const ViewsPlugin = {
-  plugin: require('@hapi/vision'),
+  plugin: Vision,
   options: {
     engines: {
       // The 'engine' is the file extension this applies to; in this case, .njk
@@ -48,7 +50,7 @@ const ViewsPlugin = {
     // layout.njk as the path to get static assets like client-side javascript. These are added to or overridden in the
     // h.view() call in a controller.
     context: {
-      appVersion: pkg.version,
+      appVersion: process.env.npm_package_version,
       assetPath: '/assets',
       serviceName: SERVICE_NAME,
       pageTitle: `${SERVICE_NAME} - GOV.UK`
@@ -56,4 +58,4 @@ const ViewsPlugin = {
   }
 }
 
-module.exports = ViewsPlugin
+export default ViewsPlugin

--- a/app/routes/airbrake.routes.js
+++ b/app/routes/airbrake.routes.js
@@ -1,6 +1,4 @@
-'use strict'
-
-const AirbrakeController = require('../controllers/health/airbrake.controller.js')
+import AirbrakeController from '../controllers/health/airbrake.controller.js'
 
 const routes = [
   {
@@ -14,4 +12,4 @@ const routes = [
   }
 ]
 
-module.exports = routes
+export default routes

--- a/app/routes/assets.routes.js
+++ b/app/routes/assets.routes.js
@@ -1,5 +1,3 @@
-'use strict'
-
 const routes = [{
   method: 'GET',
   path: '/robots.txt',
@@ -26,4 +24,4 @@ const routes = [{
   }
 }]
 
-module.exports = routes
+export default routes

--- a/app/routes/database.routes.js
+++ b/app/routes/database.routes.js
@@ -1,6 +1,4 @@
-'use strict'
-
-const DatabaseController = require('../controllers/health/database.controller.js')
+import DatabaseController from '../controllers/health/database.controller.js'
 
 const routes = [
   {
@@ -14,4 +12,4 @@ const routes = [
   }
 ]
 
-module.exports = routes
+export default routes

--- a/app/routes/root.routes.js
+++ b/app/routes/root.routes.js
@@ -1,6 +1,4 @@
-'use strict'
-
-const RootController = require('../controllers/root.controller.js')
+import RootController from '../controllers/root.controller.js'
 
 const routes = [
   {
@@ -37,4 +35,4 @@ const routes = [
   }
 ]
 
-module.exports = routes
+export default routes

--- a/app/server.js
+++ b/app/server.js
@@ -1,23 +1,22 @@
-'use strict'
+import Hapi from '@hapi/hapi'
+import Inert from '@hapi/inert'
 
-const Hapi = require('@hapi/hapi')
+import ServerConfig from '../config/server.config.js'
+import TestConfig from '../config/test.config.js'
 
-const ServerConfig = require('../config/server.config.js')
-const TestConfig = require('../config/test.config.js')
-
-const AirbrakePlugin = require('./plugins/airbrake.plugin.js')
-const BlippPlugin = require('./plugins/blipp.plugin.js')
-const ErrorPagesPlugin = require('./plugins/error_pages.plugin.js')
-const HapiPinoPlugin = require('./plugins/hapi_pino.plugin.js')
-const RequestNotifierPlugin = require('./plugins/request_notifier.plugin.js')
-const RouterPlugin = require('./plugins/router.plugin.js')
-const StopPlugin = require('./plugins/stop.plugin.js')
-const ViewsPlugin = require('./plugins/views.plugin.js')
+import AirbrakePlugin from './plugins/airbrake.plugin.js'
+import BlippPlugin from './plugins/blipp.plugin.js'
+import ErrorPagesPlugin from './plugins/error_pages.plugin.js'
+import HapiPinoPlugin from './plugins/hapi_pino.plugin.js'
+import RequestNotifierPlugin from './plugins/request_notifier.plugin.js'
+import RouterPlugin from './plugins/router.plugin.js'
+import StopPlugin from './plugins/stop.plugin.js'
+import ViewsPlugin from './plugins/views.plugin.js'
 
 const registerPlugins = async (server) => {
   // Register the remaining plugins
   await server.register(StopPlugin)
-  await server.register(require('@hapi/inert'))
+  await server.register(Inert)
   await server.register(RouterPlugin)
   await server.register(HapiPinoPlugin(TestConfig.logInTest))
   await server.register(AirbrakePlugin)
@@ -53,4 +52,4 @@ process.on('unhandledRejection', err => {
   process.exit(1)
 })
 
-module.exports = { init, start }
+export { init, start }

--- a/app/services/database_health_check.service.js
+++ b/app/services/database_health_check.service.js
@@ -1,10 +1,8 @@
-'use strict'
-
 /**
  * @module DatabaseHealthCheckService
  */
 
-const { db } = require('../../db/db.js')
+import { db } from '../../db/db.js'
 
 /**
  * Generates an array of stats for each table in the database when `go()` is called
@@ -23,4 +21,4 @@ class DatabaseHealthCheckService {
   }
 }
 
-module.exports = DatabaseHealthCheckService
+export default DatabaseHealthCheckService

--- a/app/services/plugins/filter_routes.service.js
+++ b/app/services/plugins/filter_routes.service.js
@@ -1,5 +1,3 @@
-'use strict'
-
 /**
  * @module FilterRoutesService
  */
@@ -46,4 +44,4 @@ class FilterRoutesService {
   }
 }
 
-module.exports = FilterRoutesService
+export default FilterRoutesService

--- a/app/services/service_status.service.js
+++ b/app/services/service_status.service.js
@@ -1,5 +1,3 @@
-'use strict'
-
 /**
  * @module ServiceStatusService
  */
@@ -104,4 +102,4 @@ class ServiceStatusService {
   }
 }
 
-module.exports = ServiceStatusService
+export default ServiceStatusService

--- a/config/airbrake.config.js
+++ b/config/airbrake.config.js
@@ -1,12 +1,12 @@
-'use strict'
+import dotenv from 'dotenv'
 
-require('dotenv').config()
+dotenv.config()
 
-const config = {
+const AirbrakeConfig = {
   host: process.env.AIRBRAKE_HOST,
   projectKey: process.env.AIRBRAKE_KEY,
   projectId: 1,
   environment: process.env.ENVIRONMENT
 }
 
-module.exports = config
+export default AirbrakeConfig

--- a/config/database.config.js
+++ b/config/database.config.js
@@ -1,8 +1,8 @@
-'use strict'
+import dotenv from 'dotenv'
 
-require('dotenv').config()
+dotenv.config()
 
-const config = {
+const DatabaseConfig = {
   host: process.env.POSTGRES_HOST,
   user: process.env.POSTGRES_USER,
   password: process.env.POSTGRES_PASSWORD,
@@ -11,4 +11,4 @@ const config = {
   testDatabase: process.env.POSTGRES_DB_TEST
 }
 
-module.exports = config
+export default DatabaseConfig

--- a/config/server.config.js
+++ b/config/server.config.js
@@ -1,8 +1,8 @@
-'use strict'
+import dotenv from 'dotenv'
 
-require('dotenv').config()
+dotenv.config()
 
-const config = {
+const ServerConfig = {
   environment: process.env.NODE_ENV || 'development',
   hapi: {
     port: process.env.PORT,
@@ -22,4 +22,4 @@ const config = {
   }
 }
 
-module.exports = config
+export default ServerConfig

--- a/config/test.config.js
+++ b/config/test.config.js
@@ -1,11 +1,11 @@
-'use strict'
+import dotenv from 'dotenv'
 
-require('dotenv').config()
+dotenv.config()
 
-const config = {
+const TestConfig = {
   // Credit to https://stackoverflow.com/a/323546/6117745 for how to handle
   // converting the env var to a boolean
   logInTest: (String(process.env.LOG_IN_TEST) === 'true') || false
 }
 
-module.exports = config
+export default TestConfig

--- a/db/create.database.js
+++ b/db/create.database.js
@@ -1,8 +1,9 @@
-'use strict'
+import Knex from 'knex'
+import * as knexfile from '../knexfile.js'
 
 const environment = process.env.NODE_ENV || 'development'
 
-const dbConfig = require('../knexfile')[environment]
+const dbConfig = knexfile[environment]
 
 const databaseName = dbConfig.connection.database
 
@@ -10,7 +11,7 @@ const databaseName = dbConfig.connection.database
 // will already have instantiated using the actual db.
 // So we have to grab our config and instantiate it ourselves here so we can connect against the default 'postgres' db.
 // https://stackoverflow.com/a/31428260/6117745
-const knex = require('knex')({
+const postgresDbConfig = {
   client: 'pg',
   connection: {
     host: dbConfig.connection.host,
@@ -20,19 +21,20 @@ const knex = require('knex')({
     database: 'postgres',
     charset: 'utf8'
   }
-})
+}
 
-const up = async function (knex) {
+const up = async function (dbConfig) {
+  const db = Knex(dbConfig)
   try {
-    await knex.raw(`CREATE DATABASE ${databaseName}`)
+    await db.raw(`CREATE DATABASE ${databaseName}`)
     console.log(`Successfully created ${databaseName}`)
   } catch (error) {
     console.error(`Could not create ${databaseName}: ${error.message}`)
   } finally {
     // Kill the connection after running the command else the terminal will
     // appear to hang
-    await knex.destroy()
+    await db.destroy()
   }
 }
 
-up(knex)
+up(postgresDbConfig)

--- a/db/db.js
+++ b/db/db.js
@@ -1,8 +1,11 @@
-'use strict'
+import Knex from 'knex'
+import pg from 'pg'
+
+import * as KnexfileApplcation from '../knexfile.application.js'
 
 const environment = process.env.NODE_ENV || 'development'
 
-const dbConfig = require('../knexfile.application')[environment]
+const dbConfig = KnexfileApplcation.environments[environment]
 
 // Some of our db fields are of type BigInt. The 'pg' driver by default will return these as strings because of concerns
 // about precision loss (a pg BigInt has a bigger range than a JavaScript integer). However, a JavaScript integer has
@@ -12,10 +15,9 @@ const dbConfig = require('../knexfile.application')[environment]
 // as integers instead. See the following for more details about both the issue and this config change
 // https://github.com/brianc/node-postgres/pull/353
 // https://github.com/knex/knex/issues/387#issuecomment-51554522
-const pg = require('pg')
 // The magic number 20 comes from `SELECT oid FROM pg_type WHERE typname = 'int8';` and is unlikely to change.
 pg.types.setTypeParser(20, 'text', parseInt)
 
-const db = require('knex')(dbConfig)
+const db = Knex(dbConfig)
 
-module.exports = { db, dbConfig }
+export { db, dbConfig }

--- a/index.js
+++ b/index.js
@@ -1,5 +1,3 @@
-'use strict'
-
-const { start } = require('./app/server')
+import { start } from './app/server.js'
 
 start()

--- a/knexfile.application.js
+++ b/knexfile.application.js
@@ -1,6 +1,4 @@
-'use strict'
-
-const { knexSnakeCaseMappers } = require('objection')
+import { knexSnakeCaseMappers } from 'objection'
 
 /**
  * Passing in `knexSnakeCaseMappers` allows us to use camelCase everywhere and knex will convert it to snake_case on
@@ -22,10 +20,10 @@ const { knexSnakeCaseMappers } = require('objection')
  *
  */
 
-const knexfile = require('./knexfile')
+import * as knexfile from './knexfile.js'
 
 for (const environment in knexfile) {
   Object.assign(knexfile[environment], knexSnakeCaseMappers({ underscoreBeforeDigits: true }))
 }
 
-module.exports = { ...knexfile }
+export const environments = { ...knexfile }

--- a/knexfile.js
+++ b/knexfile.js
@@ -1,6 +1,4 @@
-'use strict'
-
-const DatabaseConfig = require('./config/database.config.js')
+import DatabaseConfig from './config/database.config.js'
 
 const defaultConfig = {
   client: 'postgres',
@@ -41,4 +39,4 @@ const production = {
   connection: defaultConnection
 }
 
-module.exports = { development, test, production }
+export { development, test, production }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "author": "Water service team",
   "license": "OGL-UK-3.0",
+  "type": "module",
   "dependencies": {
     "@airbrake/node": "^2.1.7",
     "@hapi/hapi": "^20.2.2",

--- a/test/controllers/health/airbrake.controller.test.js
+++ b/test/controllers/health/airbrake.controller.test.js
@@ -1,18 +1,16 @@
-'use strict'
-
 // Test framework dependencies
-const Lab = require('@hapi/lab')
-const Code = require('@hapi/code')
-const Sinon = require('sinon')
+import Lab from '@hapi/lab'
+import Code from '@hapi/code'
+import Sinon from 'sinon'
+
+// Things we need to stub
+import Airbrake from '@airbrake/node'
+
+// For running our service
+import { init } from '../../../app/server.js'
 
 const { describe, it, beforeEach, after, afterEach } = exports.lab = Lab.script()
 const { expect } = Code
-
-// For running our service
-const { init } = require('../../../app/server')
-
-// Things we need to stub
-const Airbrake = require('@airbrake/node')
 
 describe('Airbrake controller: GET /status/airbrake', () => {
   let server, airbrakeStub

--- a/test/controllers/health/database.controller.test.js
+++ b/test/controllers/health/database.controller.test.js
@@ -1,15 +1,13 @@
-'use strict'
-
 // Test framework dependencies
-const Lab = require('@hapi/lab')
-const Code = require('@hapi/code')
-const Sinon = require('sinon')
+import Lab from '@hapi/lab'
+import Code from '@hapi/code'
+import Sinon from 'sinon'
+
+// For running our service
+import { init } from '../../../app/server.js'
 
 const { describe, it, beforeEach, after } = exports.lab = Lab.script()
 const { expect } = Code
-
-// For running our service
-const { init } = require('../../../app/server')
 
 describe('Database controller', () => {
   let server

--- a/test/controllers/root.controller.test.js
+++ b/test/controllers/root.controller.test.js
@@ -1,14 +1,12 @@
-'use strict'
-
 // Test framework dependencies
-const Lab = require('@hapi/lab')
-const Code = require('@hapi/code')
+import Lab from '@hapi/lab'
+import Code from '@hapi/code'
+
+// For running our service
+import { init } from '../../app/server.js'
 
 const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
-
-// For running our service
-const { init } = require('../../app/server')
 
 describe('Root controller: GET /', () => {
   let server

--- a/test/lib/base_notifier.lib.test.js
+++ b/test/lib/base_notifier.lib.test.js
@@ -1,15 +1,13 @@
-'use strict'
-
 // Test framework dependencies
-const Lab = require('@hapi/lab')
-const Code = require('@hapi/code')
-const Sinon = require('sinon')
+import Lab from '@hapi/lab'
+import Code from '@hapi/code'
+import Sinon from 'sinon'
+
+// Thing under test
+import BaseNotifierLib from '../../app/lib/base_notifier.lib.js'
 
 const { describe, it, beforeEach, afterEach } = exports.lab = Lab.script()
 const { expect } = Code
-
-// Thing under test
-const BaseNotifierLib = require('../../app/lib/base_notifier.lib.js')
 
 describe('BaseNotifierLib class', () => {
   let airbrakeFake

--- a/test/lib/boom_notifier.lib.test.js
+++ b/test/lib/boom_notifier.lib.test.js
@@ -1,15 +1,13 @@
-'use strict'
-
 // Test framework dependencies
-const Lab = require('@hapi/lab')
-const Code = require('@hapi/code')
-const Sinon = require('sinon')
+import Lab from '@hapi/lab'
+import Code from '@hapi/code'
+import Sinon from 'sinon'
+
+// Thing under test
+import BoomNotifierLib from '../../app/lib/boom_notifier.lib.js'
 
 const { describe, it, beforeEach, afterEach } = exports.lab = Lab.script()
 const { expect } = Code
-
-// Thing under test
-const BoomNotifierLib = require('../../app/lib/boom_notifier.lib.js')
 
 describe('BoomNotifierLib class', () => {
   const id = '1234567890'

--- a/test/lib/request_notifier.lib.test.js
+++ b/test/lib/request_notifier.lib.test.js
@@ -1,15 +1,13 @@
-'use strict'
-
 // Test framework dependencies
-const Lab = require('@hapi/lab')
-const Code = require('@hapi/code')
-const Sinon = require('sinon')
+import Lab from '@hapi/lab'
+import Code from '@hapi/code'
+import Sinon from 'sinon'
+
+// Thing under test
+import RequestNotifierLib from '../../app/lib/request_notifier.lib.js'
 
 const { describe, it, beforeEach, afterEach } = exports.lab = Lab.script()
 const { expect } = Code
-
-// Thing under test
-const RequestNotifierLib = require('../../app/lib/request_notifier.lib.js')
 
 describe('RequestNotifierLib class', () => {
   const id = '1234567890'

--- a/test/services/database_health_check.service.test.js
+++ b/test/services/database_health_check.service.test.js
@@ -1,14 +1,12 @@
-'use strict'
-
 // Test framework dependencies
-const Lab = require('@hapi/lab')
-const Code = require('@hapi/code')
+import Lab from '@hapi/lab'
+import Code from '@hapi/code'
+
+// Thing under test
+import DatabaseHealthCheckService from '../../app/services/database_health_check.service.js'
 
 const { describe, it } = exports.lab = Lab.script()
 const { expect } = Code
-
-// Thing under test
-const DatabaseHealthCheckService = require('../../app/services/database_health_check.service.js')
 
 describe('Database Health Check service', () => {
   it('confirms connection to the db by not throwing an error', async () => {

--- a/test/services/plugins/filter_routes.service.test.js
+++ b/test/services/plugins/filter_routes.service.test.js
@@ -1,16 +1,13 @@
-'use strict'
-
 // Test framework dependencies
-const Lab = require('@hapi/lab')
-const Code = require('@hapi/code')
+import Lab from '@hapi/lab'
+import Code from '@hapi/code'
+import Hoek from '@hapi/hoek'
+
+// Thing under test
+import FilterRoutesService from '../../../app/services/plugins/filter_routes.service.js'
 
 const { describe, it } = exports.lab = Lab.script()
 const { expect } = Code
-
-const Hoek = require('@hapi/hoek')
-
-// Thing under test
-const FilterRoutesService = require('../../../app/services/plugins/filter_routes.service.js')
 
 describe('Filter routes service', () => {
   const routes = [

--- a/test/services/service_status.service.test.js
+++ b/test/services/service_status.service.test.js
@@ -1,14 +1,12 @@
-'use strict'
-
 // Test framework dependencies
-const Lab = require('@hapi/lab')
-const Code = require('@hapi/code')
+import Lab from '@hapi/lab'
+import Code from '@hapi/code'
+
+// Thing under test
+import ServiceStatusService from '../../app/services/service_status.service.js'
 
 const { describe, it } = exports.lab = Lab.script()
 const { expect } = Code
-
-// Thing under test
-const ServiceStatusService = require('../../app/services/service_status.service.js')
 
 const firstRow = [
   { text: 'Cell 1.1' },


### PR DESCRIPTION
Currently, when one file references another in the project we use the following

```javascript
const { InvoiceRebillingPresenter } = require('../presenters')
const InvoiceRebillingInitialiseService = require('./invoice_rebilling_initialise.service')
const InvoiceRebillingCopyService = require('./invoice_rebilling_copy.service')
```

This is known as *CommonJS* modules and up until the current LTS version of Node.js was the only type supported. In the meantime, the JavaScript language adopted *ES6* modules as its standard. With native support for them now in Node.js v14, we have the option to switch to them.

By switching we are keeping the code up to date with modern practices. We have also confirmed ES6 modules resolve an issue we have sometimes had to work around (circular dependencies). Finally, they are a bit more performant than CommonJS ones.

So, this change updates the whole project to switch over (our testing found that everything has to go at once; we can't just do a file at a time).