### PR TITLE
Refactor dotenv require

### DIFF
--- a/config/airbrake.config.js
+++ b/config/airbrake.config.js
@@ -1,7 +1,5 @@
 'use strict'
 
-require('dotenv').config()
-
 const config = {
   host: process.env.AIRBRAKE_HOST,
   projectKey: process.env.AIRBRAKE_KEY,

--- a/config/database.config.js
+++ b/config/database.config.js
@@ -1,7 +1,5 @@
 'use strict'
 
-require('dotenv').config()
-
 const config = {
   host: process.env.POSTGRES_HOST,
   user: process.env.POSTGRES_USER,

--- a/config/server.config.js
+++ b/config/server.config.js
@@ -1,7 +1,5 @@
 'use strict'
 
-require('dotenv').config()
-
 const config = {
   environment: process.env.NODE_ENV || 'development',
   hapi: {

--- a/config/services.config.js
+++ b/config/services.config.js
@@ -1,7 +1,5 @@
 'use strict'
 
-require('dotenv').config()
-
 const config = {
   addressFacade: {
     url: process.env.EA_ADDRESS_FACADE_URL

--- a/config/test.config.js
+++ b/config/test.config.js
@@ -1,7 +1,5 @@
 'use strict'
 
-require('dotenv').config()
-
 const config = {
   // Credit to https://stackoverflow.com/a/323546/6117745 for how to handle
   // converting the env var to a boolean

--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 'use strict'
 
+require('dotenv').config()
+
 const { start } = require('./app/server')
 
 start()


### PR DESCRIPTION
Currently 'dotenv' has been required in multiple places. This only needs to be done once and should be done as early as possible in the application.