### PR TITLE
Standardise naming of request object

### DIFF
--- a/app/controllers/health/airbrake.controller.js
+++ b/app/controllers/health/airbrake.controller.js
@@ -1,14 +1,14 @@
 'use strict'
 
 class AirbrakeController {
-  static async index (req, _h) {
+  static async index (request, _h) {
     // First section tests connecting to Airbrake through a manual notification
-    req.server.app.airbrake.notify({
+    request.server.app.airbrake.notify({
       message: 'Airbrake manual health check',
       error: new Error('Airbrake manual health check error'),
       session: {
         req: {
-          id: req.info.id
+          id: request.info.id
         }
       }
     })

--- a/app/controllers/health/database.controller.js
+++ b/app/controllers/health/database.controller.js
@@ -3,7 +3,7 @@
 const DatabaseHealthCheckService = require('../../services/database_health_check.service.js')
 
 class DatabaseController {
-  static async index (_req, h) {
+  static async index (_request, h) {
     const result = await DatabaseHealthCheckService.go()
 
     return h.response(result).code(200)

--- a/app/controllers/root.controller.js
+++ b/app/controllers/root.controller.js
@@ -3,11 +3,11 @@
 const ServiceStatusService = require('../services/service_status.service')
 
 class RootController {
-  static async index (_req, _h) {
+  static async index (_request, _h) {
     return { status: 'alive' }
   }
 
-  static helloWorld (_req, h) {
+  static helloWorld (_request, h) {
     return h.view('home.njk', {
       title: 'Hello',
       message: 'World',
@@ -15,7 +15,7 @@ class RootController {
     })
   }
 
-  static async serviceStatus (_req, h) {
+  static async serviceStatus (_request, h) {
     const pageData = await ServiceStatusService.go()
 
     return h.view('service_status.njk', {

--- a/app/controllers/test/supplementary.controller.js
+++ b/app/controllers/test/supplementary.controller.js
@@ -3,7 +3,7 @@
 const TestSupplementaryService = require('../../services/test/supplementary.service.js')
 
 class TestSupplementaryController {
-  static async index (_req, h) {
+  static async index (_request, h) {
     const result = await TestSupplementaryService.go()
 
     return h.response(result).code(200)

--- a/app/plugins/airbrake.plugin.js
+++ b/app/plugins/airbrake.plugin.js
@@ -35,14 +35,14 @@ const AirbrakePlugin = {
 
     // When Hapi emits a request event with an error we capture the details and use Airbrake to send a request to our
     // Errbit instance
-    server.events.on({ name: 'request', channels: 'error' }, (req, event, _tags) => {
+    server.events.on({ name: 'request', channels: 'error' }, (request, event, _tags) => {
       server.app.airbrake
         .notify({
           error: event.error,
           session: {
-            route: req.route.path,
-            method: req.method,
-            url: req.url.href
+            route: request.route.path,
+            method: request.method,
+            url: request.url.href
           }
         })
         .then(notice => {


### PR DESCRIPTION
In a few places in the code 'req' is the name given to the request object. The naming convention of the request object in Hapi is 'request'. Where 'req' has been used these will be replaced with 'request'.