### PR TITLE
Move location where 'dotenv' is being required

### DIFF
--- a/app/server.js
+++ b/app/server.js
@@ -1,5 +1,7 @@
 'use strict'
 
+require('dotenv').config()
+
 const Hapi = require('@hapi/hapi')
 
 const ServerConfig = require('../config/server.config.js')

--- a/index.js
+++ b/index.js
@@ -1,7 +1,5 @@
 'use strict'
 
-require('dotenv').config()
-
 const { start } = require('./app/server')
 
 start()


### PR DESCRIPTION
In a previous commit https://github.com/DEFRA/water-abstraction-system/pull/10 the 'dotenv' package was moved as early as possible in the application.

Unfortunately this has turned out to be a bit too early and is causing some issues when running the unit tests locally. The unit tests don't use the /index.js so 'dotenv' is never required.

The 'dotenv' require therefore needs to be moved up a level to /app/server.js.