### PR TITLE
Tidy up environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,8 +8,8 @@ POSTGRES_USER=myuser
 POSTGRES_PASSWORD=password12345
 POSTGRES_HOST=db
 POSTGRES_PORT=5432
-POSTGRES_DB=sroc_charge
-POSTGRES_DB_TEST=sroc_charge_test
+POSTGRES_DB=wabs
+POSTGRES_DB_TEST=wabs_system_test
 
 # Server config
 PORT=3000

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,8 @@ jobs:
       POSTGRES_PASSWORD: password
       POSTGRES_HOST: localhost
       POSTGRES_PORT: 5432
-      POSTGRES_DB: wabs_test
-      POSTGRES_DB_TEST: wabs_test
+      POSTGRES_DB: wabs_system_test
+      POSTGRES_DB_TEST: wabs_system_test
       ENVIRONMENT: dev
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
         env:
           POSTGRES_USER: water_user
           POSTGRES_PASSWORD: password
-          POSTGRES_DB: wabs_test
+          POSTGRES_DB: wabs_system_test
         # Maps tcp port 5432 on service container to the host
         ports:
           - 5432:5432


### PR DESCRIPTION
We noticed we are still refering to SROC in our local environment variables. Also noticed the DB in the ci.yaml is different to the one we use locally.