### PR TITLE
Select SROC supplementary charge versions for real

### DIFF
--- a/app/controllers/test/supplementary.controller.js
+++ b/app/controllers/test/supplementary.controller.js
@@ -1,10 +1,13 @@
 'use strict'
 
+const FindRegionService = require('../../services/test/find_region.service')
 const SupplementaryService = require('../../services/test/supplementary.service.js')
 
 class SupplementaryController {
-  static async index (_request, h) {
-    const result = await SupplementaryService.go()
+  static async index (request, h) {
+    const region = await FindRegionService.go(request.query.region)
+
+    const result = await SupplementaryService.go(region.regionId)
 
     return h.response(result).code(200)
   }

--- a/app/controllers/test/supplementary.controller.js
+++ b/app/controllers/test/supplementary.controller.js
@@ -5,9 +5,9 @@ const SupplementaryService = require('../../services/test/supplementary.service.
 
 class SupplementaryController {
   static async index (request, h) {
-    const region = await FindRegionService.go(request.query.region)
+    const { regionId } = await FindRegionService.go(request.query.region)
 
-    const result = await SupplementaryService.go(region.regionId)
+    const result = await SupplementaryService.go(regionId)
 
     return h.response(result).code(200)
   }

--- a/app/services/test/find_region.service.js
+++ b/app/services/test/find_region.service.js
@@ -1,0 +1,33 @@
+'use strict'
+
+/**
+ * @module FindRegionService
+ */
+
+const { db } = require('../../../db/db')
+
+/**
+ * @module FindRegionService
+ */
+
+class FindRegionService {
+  static async go (regionId) {
+    const region = await this._fetchRegion(regionId)
+
+    return region
+  }
+
+  static async _fetchRegion (regionId) {
+    const result = await db
+      .select('region_id')
+      .from('water.regions')
+      .where({
+        nald_region_id: regionId
+      })
+      .first()
+
+    return result
+  }
+}
+
+module.exports = FindRegionService

--- a/app/services/test/find_region.service.js
+++ b/app/services/test/find_region.service.js
@@ -11,18 +11,29 @@ const { db } = require('../../../db/db')
  */
 
 class FindRegionService {
-  static async go (regionId) {
-    const region = await this._fetchRegion(regionId)
+  /**
+   * Returns the `region_id` for the matching record in `water.regions`
+   *
+   * > This is a temporary service added whilst developing the new SROC supplementary bill run functionality. We expect
+   * > the region ID to be provided by the UI as part of the normal workflow
+   *
+   * @param {string} naldRegionId The NALD region ID (a number between 1 to 9, 9 being the test region) for the region
+   * to find
+   *
+   * @returns {string} The region_id (a GUID) for the matching region
+   */
+  static async go (naldRegionId) {
+    const region = await this._fetchRegion(naldRegionId)
 
     return region
   }
 
-  static async _fetchRegion (regionId) {
+  static async _fetchRegion (naldRegionId) {
     const result = await db
       .select('region_id')
       .from('water.regions')
       .where({
-        nald_region_id: regionId
+        nald_region_id: naldRegionId
       })
       .first()
 

--- a/app/services/test/supplementary.service.js
+++ b/app/services/test/supplementary.service.js
@@ -13,9 +13,7 @@ const { db } = require('../../../db/db')
 class SupplementaryService {
   static async go (regionId) {
     const chargeVersions = await this._fetchChargeVersions(regionId)
-    const response = {
-      chargeVersions
-    }
+    const response = { chargeVersions }
 
     return response
   }

--- a/app/services/test/supplementary.service.js
+++ b/app/services/test/supplementary.service.js
@@ -11,8 +11,8 @@ const { db } = require('../../../db/db')
  */
 
 class SupplementaryService {
-  static async go () {
-    const chargeVersions = await this._fetchChargeVersions()
+  static async go (regionId) {
+    const chargeVersions = await this._fetchChargeVersions(regionId)
     const response = {
       chargeVersions
     }
@@ -20,7 +20,7 @@ class SupplementaryService {
     return response
   }
 
-  static async _fetchChargeVersions () {
+  static async _fetchChargeVersions (regionId) {
     const chargeVersions = db
       .select('chargeVersionId', 'licences.licenceRef')
       .from('water.charge_versions')
@@ -30,7 +30,8 @@ class SupplementaryService {
         end_date: null
       })
       .andWhere({
-        'licences.include_in_supplementary_billing': 'yes'
+        'licences.include_in_supplementary_billing': 'yes',
+        'licences.region_id': regionId
       })
 
     return chargeVersions

--- a/app/services/test/supplementary.service.js
+++ b/app/services/test/supplementary.service.js
@@ -7,11 +7,9 @@
 const { db } = require('../../../db/db')
 
 /**
- * Returns charge versions selected for supplementary billing
- * At present this returns a set response until further development
-*/
+ * @module SupplementaryService
+ */
 
-// Format into the response and return the data
 class SupplementaryService {
   static async go () {
     const chargeVersions = await this._fetchChargeVersions()

--- a/app/services/test/supplementary.service.js
+++ b/app/services/test/supplementary.service.js
@@ -23,10 +23,17 @@ class SupplementaryService {
   }
 
   static async _fetchChargeVersions () {
-    const chargeVersions = db.table('water.charge_versions')
-      .where('scheme', 'sroc')
-      .select('chargeVersionId')
-      .select('licenceRef')
+    const chargeVersions = db
+      .select('chargeVersionId', 'licences.licenceRef')
+      .from('water.charge_versions')
+      .innerJoin('water.licences', 'charge_versions.licence_id', 'licences.licence_id')
+      .where({
+        scheme: 'sroc',
+        end_date: null
+      })
+      .andWhere({
+        'licences.include_in_supplementary_billing': 'yes'
+      })
 
     return chargeVersions
   }

--- a/db/migrations/20221111155222_create_licences.js
+++ b/db/migrations/20221111155222_create_licences.js
@@ -1,0 +1,35 @@
+'use strict'
+
+const tableName = 'licences'
+
+exports.up = async function (knex) {
+  await knex
+    .schema
+    .withSchema('water')
+    .createTable(tableName, table => {
+      // Primary Key
+      table.uuid('licence_id').primary().defaultTo(knex.raw('gen_random_uuid()'))
+
+      // Data
+      table.string('licence_ref')
+      table.string('include_in_supplementary_billing')
+
+      // Automatic timestamps
+      table.timestamps(false, true)
+    })
+
+  await knex.raw(`
+    CREATE TRIGGER update_timestamp
+    BEFORE UPDATE
+    ON water.${tableName}
+    FOR EACH ROW
+    EXECUTE PROCEDURE update_timestamp();
+  `)
+}
+
+exports.down = function (knex) {
+  return knex
+    .schema
+    .withSchema('water')
+    .dropTableIfExists(tableName)
+}

--- a/db/migrations/20221111184905_alter_charge_versions.js
+++ b/db/migrations/20221111184905_alter_charge_versions.js
@@ -1,0 +1,22 @@
+'use strict'
+
+const tableName = 'charge_versions'
+
+exports.up = async function (knex) {
+  await knex
+    .schema
+    .withSchema('water')
+    .alterTable(tableName, table => {
+      table.uuid('licence_id')
+      table.date('end_date')
+    })
+}
+
+exports.down = function (knex) {
+  return knex
+    .schema
+    .withSchema('water')
+    .alterTable(tableName, table => {
+      table.dropColumns('licence_id', 'end_date')
+    })
+}

--- a/db/migrations/20221114104700_create_regions.js
+++ b/db/migrations/20221114104700_create_regions.js
@@ -1,0 +1,35 @@
+'use strict'
+
+const tableName = 'regions'
+
+exports.up = async function (knex) {
+  await knex
+    .schema
+    .withSchema('water')
+    .createTable(tableName, table => {
+      // Primary Key
+      table.uuid('region_id').primary().defaultTo(knex.raw('gen_random_uuid()'))
+
+      // Data
+      table.string('charge_region_id')
+      table.integer('nald_region_id')
+
+      // Automatic timestamps
+      table.timestamps(false, true)
+    })
+
+  await knex.raw(`
+    CREATE TRIGGER update_timestamp
+    BEFORE UPDATE
+    ON water.${tableName}
+    FOR EACH ROW
+    EXECUTE PROCEDURE update_timestamp();
+  `)
+}
+
+exports.down = function (knex) {
+  return knex
+    .schema
+    .withSchema('water')
+    .dropTableIfExists(tableName)
+}

--- a/db/migrations/20221114155444_alter_licences.js
+++ b/db/migrations/20221114155444_alter_licences.js
@@ -1,0 +1,21 @@
+'use strict'
+
+const tableName = 'licences'
+
+exports.up = async function (knex) {
+  await knex
+    .schema
+    .withSchema('water')
+    .alterTable(tableName, table => {
+      table.uuid('region_id')
+    })
+}
+
+exports.down = function (knex) {
+  return knex
+    .schema
+    .withSchema('water')
+    .alterTable(tableName, table => {
+      table.dropColumns('region_id')
+    })
+}

--- a/test/controllers/test/supplementary.controller.test.js
+++ b/test/controllers/test/supplementary.controller.test.js
@@ -9,6 +9,7 @@ const { describe, it, beforeEach, after } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Things we need to stub
+const FindRegionService = require('../../../app/services/test/find_region.service')
 const SupplementaryService = require('../../../app/services/test/supplementary.service.js')
 
 // For running our service
@@ -28,12 +29,13 @@ describe('Supplementary controller', () => {
   describe('GET /test/supplementary', () => {
     const options = {
       method: 'GET',
-      url: '/test/supplementary'
+      url: '/test/supplementary?region=9'
     }
 
     let response
 
     beforeEach(async () => {
+      Sinon.stub(FindRegionService, 'go').resolves({ regionId: 'bd114474-790f-4470-8ba4-7b0cc9c225d7' })
       Sinon.stub(SupplementaryService, 'go').resolves({ chargeVersions: [] })
 
       response = await server.inject(options)

--- a/test/controllers/test/supplementary.controller.test.js
+++ b/test/controllers/test/supplementary.controller.test.js
@@ -8,6 +8,9 @@ const Sinon = require('sinon')
 const { describe, it, beforeEach, after } = exports.lab = Lab.script()
 const { expect } = Code
 
+// Test helpers
+const LicenceHelper = require('../../support/helpers/licence.helper.js')
+
 // Things we need to stub
 const FindRegionService = require('../../../app/services/test/find_region.service')
 const SupplementaryService = require('../../../app/services/test/supplementary.service.js')
@@ -35,7 +38,7 @@ describe('Supplementary controller', () => {
     let response
 
     beforeEach(async () => {
-      Sinon.stub(FindRegionService, 'go').resolves({ regionId: 'bd114474-790f-4470-8ba4-7b0cc9c225d7' })
+      Sinon.stub(FindRegionService, 'go').resolves({ regionId: LicenceHelper.defaults().region_id })
       Sinon.stub(SupplementaryService, 'go').resolves({ chargeVersions: [] })
 
       response = await server.inject(options)

--- a/test/services/test/supplementary.service.test.js
+++ b/test/services/test/supplementary.service.test.js
@@ -16,7 +16,7 @@ const LicenceHelper = require('../../support/helpers/licence.helper.js')
 const SupplementaryService = require('../../../app/services/test/supplementary.service.js')
 
 describe('Supplementary service', () => {
-  const regionId = LicenceHelper.defaults().region_id
+  const { region_id: regionId } = LicenceHelper.defaults()
   let testRecords
 
   beforeEach(async () => {

--- a/test/services/test/supplementary.service.test.js
+++ b/test/services/test/supplementary.service.test.js
@@ -8,13 +8,15 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const ChargeVersionHelper = require('../../support/helpers/charge_version.helper')
-const DatabaseHelper = require('../../support/helpers/database.helper')
+const ChargeVersionHelper = require('../../support/helpers/charge_version.helper.js')
+const DatabaseHelper = require('../../support/helpers/database.helper.js')
+const LicenceHelper = require('../../support/helpers/licence.helper.js')
 
 // Thing under test
 const SupplementaryService = require('../../../app/services/test/supplementary.service.js')
 
 describe('Supplementary service', () => {
+  const regionId = LicenceHelper.defaults().region_id
   let testRecords
 
   beforeEach(async () => {
@@ -39,7 +41,7 @@ describe('Supplementary service', () => {
     })
 
     it('returns only the current SROC charge versions that are applicable', async () => {
-      const result = await SupplementaryService.go()
+      const result = await SupplementaryService.go(regionId)
 
       expect(result.chargeVersions.length).to.equal(1)
       expect(result.chargeVersions[0].charge_version_id).to.equal(testRecords[0].charge_version_id)
@@ -56,7 +58,7 @@ describe('Supplementary service', () => {
       })
 
       it('returns no applicable charge versions', async () => {
-        const result = await SupplementaryService.go()
+        const result = await SupplementaryService.go(regionId)
 
         expect(result.chargeVersions.length).to.equal(0)
       })
@@ -73,7 +75,7 @@ describe('Supplementary service', () => {
       })
 
       it('returns no applicable charge versions', async () => {
-        const result = await SupplementaryService.go()
+        const result = await SupplementaryService.go(regionId)
 
         expect(result.chargeVersions.length).to.equal(0)
       })
@@ -90,7 +92,27 @@ describe('Supplementary service', () => {
       })
 
       it('returns no applicable charge versions', async () => {
-        const result = await SupplementaryService.go()
+        const result = await SupplementaryService.go(regionId)
+
+        expect(result.chargeVersions.length).to.equal(0)
+      })
+    })
+
+    describe('because there are no licences linked to the selected region', () => {
+      beforeEach(async () => {
+        // This creates an SROC charge version linked to an invalid region
+        const otherRegionChargeVersion = await ChargeVersionHelper.add(
+          {},
+          {
+            include_in_supplementary_billing: 'yes',
+            region_id: 'e117b501-e3c1-4337-ad35-21c60ed9ad73'
+          }
+        )
+        testRecords = [otherRegionChargeVersion]
+      })
+
+      it('returns no applicable charge versions', async () => {
+        const result = await SupplementaryService.go(regionId)
 
         expect(result.chargeVersions.length).to.equal(0)
       })

--- a/test/services/test/supplementary.service.test.js
+++ b/test/services/test/supplementary.service.test.js
@@ -48,7 +48,7 @@ describe('Supplementary service', () => {
     })
   })
 
-  describe('when there are no licences to be included in supplimentery billing', () => {
+  describe('when there are no licences to be included in supplementary billing', () => {
     describe("because none of them are marked 'include_in_supplimentary_billing'", () => {
       beforeEach(async () => {
         // This creates an SROC charge version linked to a licence. But the licence won't be marked for supplementary

--- a/test/services/test/supplementary.service.test.js
+++ b/test/services/test/supplementary.service.test.js
@@ -83,7 +83,7 @@ describe('Supplementary service', () => {
 
     describe('because there are no current charge versions (they all have end dates)', () => {
       beforeEach(async () => {
-        // This creates an SROC charge version with an edn date linked to a licence marked for supplementary billing
+        // This creates an SROC charge version with an end date linked to a licence marked for supplementary billing
         const alcsChargeVersion = await ChargeVersionHelper.add(
           { end_date: new Date(2022, 2, 1) }, // 2022-03-01 - Months are zero indexed :-)
           { include_in_supplementary_billing: 'yes' }
@@ -100,7 +100,7 @@ describe('Supplementary service', () => {
 
     describe('because there are no licences linked to the selected region', () => {
       beforeEach(async () => {
-        // This creates an SROC charge version linked to an invalid region
+        // This creates an SROC charge version linked to a licence with an different region than selected
         const otherRegionChargeVersion = await ChargeVersionHelper.add(
           {},
           {

--- a/test/services/test/supplementary.service.test.js
+++ b/test/services/test/supplementary.service.test.js
@@ -23,7 +23,7 @@ describe('Supplementary service', () => {
     await DatabaseHelper.clean()
   })
 
-  describe('when there are licences to be included in supplimentery billing', () => {
+  describe('when there are licences to be included in supplementary billing', () => {
     beforeEach(async () => {
       // This creates an SROC charge version linked to a licence marked for supplementary billing
       const srocChargeVersion = await ChargeVersionHelper.add(

--- a/test/services/test/supplementary.service.test.js
+++ b/test/services/test/supplementary.service.test.js
@@ -49,7 +49,7 @@ describe('Supplementary service', () => {
   })
 
   describe('when there are no licences to be included in supplementary billing', () => {
-    describe("because none of them are marked 'include_in_supplimentary_billing'", () => {
+    describe("because none of them are marked 'include_in_supplementary_billing'", () => {
       beforeEach(async () => {
         // This creates an SROC charge version linked to a licence. But the licence won't be marked for supplementary
         // billing

--- a/test/support/helpers/charge_version.helper.js
+++ b/test/support/helpers/charge_version.helper.js
@@ -29,7 +29,7 @@ class ChargeVersionHelper {
    */
   static async add (data = {}, licence = {}) {
     const licenceId = await this._addLicence(licence)
-    const insertData = this._defaults({ ...data, licence_id: licenceId })
+    const insertData = this.defaults({ ...data, licence_id: licenceId })
 
     const result = await db.table('water.charge_versions')
       .insert(insertData)
@@ -38,13 +38,15 @@ class ChargeVersionHelper {
     return result
   }
 
-  static async _addLicence (licence) {
-    const result = await LicenceHelper.add(licence)
-
-    return result[0].licenceId
-  }
-
-  static _defaults (data) {
+  /**
+   * Returns the defaults used when creating a new charge version
+   *
+   * It will override or append to them any data provided. Mainly used by the `add()` method, we make it available
+   * for use in tests to avoid having to duplicate values.
+   *
+   * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+   */
+  static defaults (data = {}) {
     const defaults = {
       licence_ref: '01/123',
       scheme: 'sroc'
@@ -54,6 +56,12 @@ class ChargeVersionHelper {
       ...defaults,
       ...data
     }
+  }
+
+  static async _addLicence (licence) {
+    const result = await LicenceHelper.add(licence)
+
+    return result[0].licenceId
   }
 }
 

--- a/test/support/helpers/charge_version.helper.js
+++ b/test/support/helpers/charge_version.helper.js
@@ -9,7 +9,25 @@ const { db } = require('../../../db/db')
 const LicenceHelper = require('./licence.helper.js')
 
 class ChargeVersionHelper {
-  static async add (data, licence = {}) {
+  /**
+   * Add a new charge version
+   *
+   * A charge version is always linked to a licence. So, creating a charge version will automatically create a new
+   * licence and handle linking the two together by `licence_id`.
+   *
+   * If no `data` is provided, default values will be used. These are
+   *
+   * - `scheme` - sroc
+   * - `licence_ref` - 01/123
+   *
+   * See `LicenceHelper` for the licence defaults
+   *
+   * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+   * @param {Object} [licence] Any licence data you want to use instead of the defaults used here or in the database
+   *
+   * @returns {string} The ID of the newly created record
+   */
+  static async add (data = {}, licence = {}) {
     const licenceId = await this._addLicence(licence)
     const insertData = this._defaults({ ...data, licence_id: licenceId })
 

--- a/test/support/helpers/charge_version.helper.js
+++ b/test/support/helpers/charge_version.helper.js
@@ -6,13 +6,36 @@
 
 const { db } = require('../../../db/db')
 
+const LicenceHelper = require('./licence.helper.js')
+
 class ChargeVersionHelper {
-  static async add (data) {
+  static async add (data, licence = {}) {
+    const licenceId = await this._addLicence(licence)
+    const insertData = this._defaults({ ...data, licence_id: licenceId })
+
     const result = await db.table('water.charge_versions')
-      .insert(data)
+      .insert(insertData)
       .returning('charge_version_id')
 
     return result
+  }
+
+  static async _addLicence (licence) {
+    const result = await LicenceHelper.add(licence)
+
+    return result[0].licenceId
+  }
+
+  static _defaults (data) {
+    const defaults = {
+      licence_ref: '01/123',
+      scheme: 'sroc'
+    }
+
+    return {
+      ...defaults,
+      ...data
+    }
   }
 }
 

--- a/test/support/helpers/database.helper.js
+++ b/test/support/helpers/database.helper.js
@@ -1,5 +1,9 @@
 'use strict'
 
+/**
+ * @module DatabaseHelper
+ */
+
 const { db } = require('../../../db/db.js')
 
 /**

--- a/test/support/helpers/licence.helper.js
+++ b/test/support/helpers/licence.helper.js
@@ -1,0 +1,31 @@
+'use strict'
+
+/**
+ * @module LicenceHelper
+ */
+
+const { db } = require('../../../db/db')
+
+class LicenceHelper {
+  static async add (data) {
+    const insertData = this._defaults(data)
+    const result = await db.table('water.licences')
+      .insert(insertData)
+      .returning('licence_id')
+
+    return result
+  }
+
+  static _defaults (data) {
+    const defaults = {
+      licence_ref: '01/123'
+    }
+
+    return {
+      ...defaults,
+      ...data
+    }
+  }
+}
+
+module.exports = LicenceHelper

--- a/test/support/helpers/licence.helper.js
+++ b/test/support/helpers/licence.helper.js
@@ -7,6 +7,17 @@
 const { db } = require('../../../db/db')
 
 class LicenceHelper {
+  /**
+   * Add a new licence
+   *
+   * If no `data` is provided, default values will be used. These are
+   *
+   * - `licence_ref` - 01/123
+   *
+   * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+   *
+   * @returns {string} The ID of the newly created record
+   */
   static async add (data) {
     const insertData = this._defaults(data)
     const result = await db.table('water.licences')

--- a/test/support/helpers/licence.helper.js
+++ b/test/support/helpers/licence.helper.js
@@ -13,6 +13,7 @@ class LicenceHelper {
    * If no `data` is provided, default values will be used. These are
    *
    * - `licence_ref` - 01/123
+   * - `region_id` - bd114474-790f-4470-8ba4-7b0cc9c225d7
    *
    * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
    *
@@ -20,6 +21,7 @@ class LicenceHelper {
    */
   static async add (data = {}) {
     const insertData = this.defaults(data)
+
     const result = await db.table('water.licences')
       .insert(insertData)
       .returning('licence_id')
@@ -27,6 +29,14 @@ class LicenceHelper {
     return result
   }
 
+  /**
+   * Returns the defaults used when creating a new licence
+   *
+   * It will override or append to them any data provided. Mainly used by the `add()` method, we make it available
+   * for use in tests to avoid having to duplicate values.
+   *
+   * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+   */
   static defaults (data = {}) {
     const defaults = {
       licence_ref: '01/123',

--- a/test/support/helpers/region.helper.js
+++ b/test/support/helpers/region.helper.js
@@ -1,36 +1,37 @@
 'use strict'
 
 /**
- * @module LicenceHelper
+ * @module RegionHelper
  */
 
 const { db } = require('../../../db/db')
 
-class LicenceHelper {
+class RegionHelper {
   /**
-   * Add a new licence
+   * Add a region
    *
    * If no `data` is provided, default values will be used. These are
    *
-   * - `licence_ref` - 01/123
+   * - `charge_region_id` - S
+   * - `nald_region_id` - 9
    *
    * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
    *
    * @returns {string} The ID of the newly created record
    */
-  static async add (data = {}) {
-    const insertData = this.defaults(data)
-    const result = await db.table('water.licences')
+  static async add (data) {
+    const insertData = this._defaults(data)
+    const result = await db.table('water.regions')
       .insert(insertData)
-      .returning('licence_id')
+      .returning('region_id')
 
     return result
   }
 
-  static defaults (data = {}) {
+  static _defaults (data) {
     const defaults = {
-      licence_ref: '01/123',
-      region_id: 'bd114474-790f-4470-8ba4-7b0cc9c225d7'
+      charge_region_id: 'S',
+      nald_region_id: 9
     }
 
     return {
@@ -40,4 +41,4 @@ class LicenceHelper {
   }
 }
 
-module.exports = LicenceHelper
+module.exports = RegionHelper

--- a/test/support/helpers/region.helper.js
+++ b/test/support/helpers/region.helper.js
@@ -8,7 +8,7 @@ const { db } = require('../../../db/db')
 
 class RegionHelper {
   /**
-   * Add a region
+   * Add a new region
    *
    * If no `data` is provided, default values will be used. These are
    *
@@ -19,8 +19,9 @@ class RegionHelper {
    *
    * @returns {string} The ID of the newly created record
    */
-  static async add (data) {
-    const insertData = this._defaults(data)
+  static async add (data = {}) {
+    const insertData = this.defaults(data)
+
     const result = await db.table('water.regions')
       .insert(insertData)
       .returning('region_id')
@@ -28,7 +29,15 @@ class RegionHelper {
     return result
   }
 
-  static _defaults (data) {
+  /**
+   * Returns the defaults used when creating a new region
+   *
+   * It will override or append to them any data provided. Mainly used by the `add()` method, we make it available
+   * for use in tests to avoid having to duplicate values.
+   *
+   * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+   */
+  static defaults (data = {}) {
     const defaults = {
       charge_region_id: 'S',
       nald_region_id: 9


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3787

In [Fetching the charge versions data](https://github.com/DEFRA/water-abstraction-system/pull/15) we added a new service to start selecting charge versions to be included in the Supplementary Bill run.

But at the moment, its only filter is all charge versions with the `scheme` SROC. We have test data and scenarios to work with so we can now start implementing the filter 'for real'.

This is the start of the process. We expect it's likely we'll be finessing the filter in subsequent PRs. But this gets the ball rolling.