### PR TITLE
Bump major version of @hapi/hapi

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,19 +11,19 @@
       "license": "OGL-UK-3.0",
       "dependencies": {
         "@airbrake/node": "^2.1.7",
-        "@hapi/hapi": "^20.2.2",
+        "@hapi/hapi": "^21.0.0",
         "@hapi/inert": "^7.0.0",
         "@hapi/vision": "^7.0.0",
         "blipp": "^4.0.2",
         "dotenv": "^16.0.3",
-        "got": "^12.5.2",
-        "govuk-frontend": "^4.3.1",
-        "hapi-pino": "^11.0.0",
+        "got": "^12.5.3",
+        "govuk-frontend": "^4.4.0",
+        "hapi-pino": "^11.0.1",
         "knex": "^2.3.0",
         "nunjucks": "^3.2.3",
         "objection": "^3.0.1",
         "pg": "^8.8.0",
-        "sass": "^1.55.0"
+        "sass": "^1.56.1"
       },
       "devDependencies": {
         "@hapi/code": "^9.0.1",
@@ -32,7 +32,7 @@
         "nock": "^13.2.9",
         "pino-pretty": "^9.1.1",
         "proxyquire": "^2.1.3",
-        "sinon": "^14.0.1",
+        "sinon": "^14.0.2",
         "standard": "^17.0.0"
       }
     },
@@ -447,31 +447,29 @@
       }
     },
     "node_modules/@hapi/accept": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@hapi/accept/-/accept-5.0.2.tgz",
-      "integrity": "sha512-CmzBx/bXUR8451fnZRuZAJRlzgm0Jgu5dltTX/bszmR2lheb9BpyN47Q1RbaGTsvFzn0PXAEs+lXDKfshccYZw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/accept/-/accept-6.0.0.tgz",
+      "integrity": "sha512-aG/Ml4kSBWCVmWvR8N8ULRuB385D8K/3OI7lquZQruH11eM7sHR5Nha30BbDzijJHtyV7Vwc6MlMwNfwb70ISg==",
       "dependencies": {
-        "@hapi/boom": "9.x.x",
-        "@hapi/hoek": "9.x.x"
+        "@hapi/boom": "^10.0.0",
+        "@hapi/hoek": "^10.0.0"
       }
     },
-    "node_modules/@hapi/accept/node_modules/@hapi/hoek": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
-      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
+    "node_modules/@hapi/accept/node_modules/@hapi/boom": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-10.0.0.tgz",
+      "integrity": "sha512-1YVs9tLHhypBqqinKQRqh7FUERIolarQApO37OWkzD+z6y6USi871Sv746zBPKcIOBuI6g6y4FrwX87mmJ90Gg==",
+      "dependencies": {
+        "@hapi/hoek": "10.x.x"
+      }
     },
     "node_modules/@hapi/ammo": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/ammo/-/ammo-5.0.1.tgz",
-      "integrity": "sha512-FbCNwcTbnQP4VYYhLNGZmA76xb2aHg9AMPiy18NZyWMG310P5KdFGyA9v2rm5ujrIny77dEEIkMOwl0Xv+fSSA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/ammo/-/ammo-6.0.0.tgz",
+      "integrity": "sha512-lhX7SYtWScQaeAIL5XnE54WzyDgS5RXVeEtFEovyZcTdVzTYbo0nem56Bwko1PBcRxRUIw1v2tMb6sjFs6vEwg==",
       "dependencies": {
-        "@hapi/hoek": "9.x.x"
+        "@hapi/hoek": "^10.0.0"
       }
-    },
-    "node_modules/@hapi/ammo/node_modules/@hapi/hoek": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
-      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
     },
     "node_modules/@hapi/b64": {
       "version": "5.0.0",
@@ -521,16 +519,6 @@
         "@hapi/hoek": "10.x.x"
       }
     },
-    "node_modules/@hapi/bossy/node_modules/@hapi/bounce": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/bounce/-/bounce-3.0.0.tgz",
-      "integrity": "sha512-L0G4NcwwOYRhpcXeL76hNrLTUcObqtZMB3z4kcRVUZcR/w3v6C5Q1cTElV4/V7og1fG+wOyDR55UMFA+tWfhtA==",
-      "dev": true,
-      "dependencies": {
-        "@hapi/boom": "^10.0.0",
-        "@hapi/hoek": "^10.0.0"
-      }
-    },
     "node_modules/@hapi/bossy/node_modules/@hapi/topo": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-6.0.0.tgz",
@@ -551,68 +539,114 @@
       }
     },
     "node_modules/@hapi/bounce": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/bounce/-/bounce-2.0.0.tgz",
-      "integrity": "sha512-JesW92uyzOOyuzJKjoLHM1ThiOvHPOLDHw01YV8yh5nCso7sDwJho1h0Ad2N+E62bZyz46TG3xhAi/78Gsct6A==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/bounce/-/bounce-3.0.0.tgz",
+      "integrity": "sha512-L0G4NcwwOYRhpcXeL76hNrLTUcObqtZMB3z4kcRVUZcR/w3v6C5Q1cTElV4/V7og1fG+wOyDR55UMFA+tWfhtA==",
       "dependencies": {
-        "@hapi/boom": "9.x.x",
-        "@hapi/hoek": "9.x.x"
+        "@hapi/boom": "^10.0.0",
+        "@hapi/hoek": "^10.0.0"
       }
     },
-    "node_modules/@hapi/bounce/node_modules/@hapi/hoek": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
-      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
+    "node_modules/@hapi/bounce/node_modules/@hapi/boom": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-10.0.0.tgz",
+      "integrity": "sha512-1YVs9tLHhypBqqinKQRqh7FUERIolarQApO37OWkzD+z6y6USi871Sv746zBPKcIOBuI6g6y4FrwX87mmJ90Gg==",
+      "dependencies": {
+        "@hapi/hoek": "10.x.x"
+      }
     },
     "node_modules/@hapi/bourne": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-3.0.0.tgz",
-      "integrity": "sha512-Waj1cwPXJDucOib4a3bAISsKJVb15MKi9IvmTI/7ssVEm6sywXGjVJDhl6/umt1pK1ZS7PacXU3A1PmFKHEZ2w==",
-      "dev": true
+      "integrity": "sha512-Waj1cwPXJDucOib4a3bAISsKJVb15MKi9IvmTI/7ssVEm6sywXGjVJDhl6/umt1pK1ZS7PacXU3A1PmFKHEZ2w=="
     },
     "node_modules/@hapi/call": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/call/-/call-8.0.1.tgz",
-      "integrity": "sha512-bOff6GTdOnoe5b8oXRV3lwkQSb/LAWylvDMae6RgEWWntd0SHtkYbQukDHKlfaYtVnSAgIavJ0kqszF/AIBb6g==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/call/-/call-9.0.0.tgz",
+      "integrity": "sha512-Z6byqbEtKF3RIH2kWG6cX64RwEqHBWYEVkNoEx6oKvkPaTrC6WTPRgr+ANo9Xa8G1GXyvs/NCMTnn3Mdj12TSA==",
       "dependencies": {
-        "@hapi/boom": "9.x.x",
-        "@hapi/hoek": "9.x.x"
+        "@hapi/boom": "^10.0.0",
+        "@hapi/hoek": "^10.0.0"
       }
     },
-    "node_modules/@hapi/call/node_modules/@hapi/hoek": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
-      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
+    "node_modules/@hapi/call/node_modules/@hapi/boom": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-10.0.0.tgz",
+      "integrity": "sha512-1YVs9tLHhypBqqinKQRqh7FUERIolarQApO37OWkzD+z6y6USi871Sv746zBPKcIOBuI6g6y4FrwX87mmJ90Gg==",
+      "dependencies": {
+        "@hapi/hoek": "10.x.x"
+      }
     },
     "node_modules/@hapi/catbox": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/@hapi/catbox/-/catbox-11.1.1.tgz",
-      "integrity": "sha512-u/8HvB7dD/6X8hsZIpskSDo4yMKpHxFd7NluoylhGrL6cUfYxdQPnvUp9YU2C6F9hsyBVLGulBd9vBN1ebfXOQ==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/catbox/-/catbox-12.1.0.tgz",
+      "integrity": "sha512-60MCN5lgaXcuRTjMZqLR+DV0clS5RAFAwfYAQU2/na6PqrXHDRQcJwVMwP7jJayCrJm4POJlLDzZLuh1ba5XUg==",
       "dependencies": {
-        "@hapi/boom": "9.x.x",
-        "@hapi/hoek": "9.x.x",
-        "@hapi/podium": "4.x.x",
-        "@hapi/validate": "1.x.x"
+        "@hapi/boom": "^10.0.0",
+        "@hapi/hoek": "^10.0.0",
+        "@hapi/podium": "^5.0.0",
+        "@hapi/validate": "^2.0.0"
       }
     },
     "node_modules/@hapi/catbox-memory": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/catbox-memory/-/catbox-memory-5.0.1.tgz",
-      "integrity": "sha512-QWw9nOYJq5PlvChLWV8i6hQHJYfvdqiXdvTupJFh0eqLZ64Xir7mKNi96d5/ZMUAqXPursfNDIDxjFgoEDUqeQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/catbox-memory/-/catbox-memory-6.0.0.tgz",
+      "integrity": "sha512-A1O30g8GdaODx/GinytF6jFm772pdTPVWJe0cF2RiTOfhgIAAagzCcpBqRgQ8olLui0F5bzUF/SAi4BmkZ4yxA==",
       "dependencies": {
-        "@hapi/boom": "9.x.x",
-        "@hapi/hoek": "9.x.x"
+        "@hapi/boom": "^10.0.0",
+        "@hapi/hoek": "^10.0.0"
       }
     },
-    "node_modules/@hapi/catbox-memory/node_modules/@hapi/hoek": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
-      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
+    "node_modules/@hapi/catbox-memory/node_modules/@hapi/boom": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-10.0.0.tgz",
+      "integrity": "sha512-1YVs9tLHhypBqqinKQRqh7FUERIolarQApO37OWkzD+z6y6USi871Sv746zBPKcIOBuI6g6y4FrwX87mmJ90Gg==",
+      "dependencies": {
+        "@hapi/hoek": "10.x.x"
+      }
     },
-    "node_modules/@hapi/catbox/node_modules/@hapi/hoek": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
-      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
+    "node_modules/@hapi/catbox/node_modules/@hapi/boom": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-10.0.0.tgz",
+      "integrity": "sha512-1YVs9tLHhypBqqinKQRqh7FUERIolarQApO37OWkzD+z6y6USi871Sv746zBPKcIOBuI6g6y4FrwX87mmJ90Gg==",
+      "dependencies": {
+        "@hapi/hoek": "10.x.x"
+      }
+    },
+    "node_modules/@hapi/catbox/node_modules/@hapi/podium": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/podium/-/podium-5.0.0.tgz",
+      "integrity": "sha512-SbhFdu8LOIscMS82Zsoj9abcllAqbK4qBgznzJ9yr+vS2j1EomJTukkhxb76Lml0BHCd4Hn79F+3EQg06kcf8g==",
+      "dependencies": {
+        "@hapi/hoek": "^10.0.0",
+        "@hapi/teamwork": "^6.0.0",
+        "@hapi/validate": "^2.0.0"
+      }
+    },
+    "node_modules/@hapi/catbox/node_modules/@hapi/teamwork": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/teamwork/-/teamwork-6.0.0.tgz",
+      "integrity": "sha512-05HumSy3LWfXpmJ9cr6HzwhAavrHkJ1ZRCmNE2qJMihdM5YcWreWPfyN0yKT2ZjCM92au3ZkuodjBxOibxM67A==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@hapi/catbox/node_modules/@hapi/topo": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-6.0.0.tgz",
+      "integrity": "sha512-aorJvN1Q1n5xrZuA50Z4X6adI6VAM2NalIVm46ALL9LUvdoqhof3JPY69jdJH8asM3PsWr2SUVYzp57EqUP41A==",
+      "dependencies": {
+        "@hapi/hoek": "^10.0.0"
+      }
+    },
+    "node_modules/@hapi/catbox/node_modules/@hapi/validate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/validate/-/validate-2.0.0.tgz",
+      "integrity": "sha512-w5m8MvBgqGndbMIB+AWmXTb8CLtF1DlIxbnbAHNAo7aFuNQuI1Ywc2e0zDLK5fbFXDoqRzNrHnC7JjNJ+hDigw==",
+      "dependencies": {
+        "@hapi/hoek": "^10.0.0",
+        "@hapi/topo": "^6.0.0"
+      }
     },
     "node_modules/@hapi/code": {
       "version": "9.0.1",
@@ -624,11 +658,19 @@
       }
     },
     "node_modules/@hapi/content": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@hapi/content/-/content-5.0.2.tgz",
-      "integrity": "sha512-mre4dl1ygd4ZyOH3tiYBrOUBzV7Pu/EOs8VLGf58vtOEECWed8Uuw6B4iR9AN/8uQt42tB04qpVaMyoMQh0oMw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/content/-/content-6.0.0.tgz",
+      "integrity": "sha512-CEhs7j+H0iQffKfe5Htdak5LBOz/Qc8TRh51cF+BFv0qnuph3Em4pjGVzJMkI2gfTDdlJKWJISGWS1rK34POGA==",
       "dependencies": {
-        "@hapi/boom": "9.x.x"
+        "@hapi/boom": "^10.0.0"
+      }
+    },
+    "node_modules/@hapi/content/node_modules/@hapi/boom": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-10.0.0.tgz",
+      "integrity": "sha512-1YVs9tLHhypBqqinKQRqh7FUERIolarQApO37OWkzD+z6y6USi871Sv746zBPKcIOBuI6g6y4FrwX87mmJ90Gg==",
+      "dependencies": {
+        "@hapi/hoek": "10.x.x"
       }
     },
     "node_modules/@hapi/cryptiles": {
@@ -661,57 +703,115 @@
       }
     },
     "node_modules/@hapi/file": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/file/-/file-2.0.0.tgz",
-      "integrity": "sha512-WSrlgpvEqgPWkI18kkGELEZfXr0bYLtr16iIN4Krh9sRnzBZN6nnWxHFxtsnP684wueEySBbXPDg/WfA9xJdBQ=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/file/-/file-3.0.0.tgz",
+      "integrity": "sha512-w+lKW+yRrLhJu620jT3y+5g2mHqnKfepreykvdOcl9/6up8GrQQn+l3FRTsjHTKbkbfQFkuksHpdv2EcpKcJ4Q=="
     },
     "node_modules/@hapi/hapi": {
-      "version": "20.2.2",
-      "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-20.2.2.tgz",
-      "integrity": "sha512-crhU6TIKt7QsksWLYctDBAXogk9PYAm7UzdpETyuBHC2pCa6/+B5NykiOVLG/3FCIgHo/raPVtan8bYtByHORQ==",
+      "version": "21.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-21.0.0.tgz",
+      "integrity": "sha512-gqGifa4X4nskhsmsgp3AwBq4LPIl7XOlnzpdWSogdc46Z4Hfy/WDjCcaO2yK84tQRmGSlg0nZowOfSCyeT0hRw==",
       "dependencies": {
-        "@hapi/accept": "^5.0.1",
-        "@hapi/ammo": "^5.0.1",
-        "@hapi/boom": "^9.1.0",
-        "@hapi/bounce": "^2.0.0",
-        "@hapi/call": "^8.0.0",
-        "@hapi/catbox": "^11.1.1",
-        "@hapi/catbox-memory": "^5.0.0",
-        "@hapi/heavy": "^7.0.1",
-        "@hapi/hoek": "^9.0.4",
-        "@hapi/mimos": "^6.0.0",
-        "@hapi/podium": "^4.1.1",
-        "@hapi/shot": "^5.0.5",
-        "@hapi/somever": "^3.0.0",
-        "@hapi/statehood": "^7.0.4",
-        "@hapi/subtext": "^7.0.3",
-        "@hapi/teamwork": "^5.1.1",
-        "@hapi/topo": "^5.0.0",
-        "@hapi/validate": "^1.1.1"
+        "@hapi/accept": "^6.0.0",
+        "@hapi/ammo": "^6.0.0",
+        "@hapi/boom": "^10.0.0",
+        "@hapi/bounce": "^3.0.0",
+        "@hapi/call": "^9.0.0",
+        "@hapi/catbox": "^12.0.0",
+        "@hapi/catbox-memory": "^6.0.0",
+        "@hapi/heavy": "^8.0.0",
+        "@hapi/hoek": "^10.0.0",
+        "@hapi/mimos": "^7.0.0",
+        "@hapi/podium": "^5.0.0",
+        "@hapi/shot": "^6.0.0",
+        "@hapi/somever": "^4.1.0",
+        "@hapi/statehood": "^8.0.0",
+        "@hapi/subtext": "^8.0.0",
+        "@hapi/teamwork": "^6.0.0",
+        "@hapi/topo": "^6.0.0",
+        "@hapi/validate": "^2.0.0"
       },
       "engines": {
         "node": ">=12.0.0"
       }
     },
-    "node_modules/@hapi/hapi/node_modules/@hapi/hoek": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
-      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
-    },
-    "node_modules/@hapi/heavy": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/heavy/-/heavy-7.0.1.tgz",
-      "integrity": "sha512-vJ/vzRQ13MtRzz6Qd4zRHWS3FaUc/5uivV2TIuExGTM9Qk+7Zzqj0e2G7EpE6KztO9SalTbiIkTh7qFKj/33cA==",
+    "node_modules/@hapi/hapi/node_modules/@hapi/boom": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-10.0.0.tgz",
+      "integrity": "sha512-1YVs9tLHhypBqqinKQRqh7FUERIolarQApO37OWkzD+z6y6USi871Sv746zBPKcIOBuI6g6y4FrwX87mmJ90Gg==",
       "dependencies": {
-        "@hapi/boom": "9.x.x",
-        "@hapi/hoek": "9.x.x",
-        "@hapi/validate": "1.x.x"
+        "@hapi/hoek": "10.x.x"
       }
     },
-    "node_modules/@hapi/heavy/node_modules/@hapi/hoek": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
-      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
+    "node_modules/@hapi/hapi/node_modules/@hapi/podium": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/podium/-/podium-5.0.0.tgz",
+      "integrity": "sha512-SbhFdu8LOIscMS82Zsoj9abcllAqbK4qBgznzJ9yr+vS2j1EomJTukkhxb76Lml0BHCd4Hn79F+3EQg06kcf8g==",
+      "dependencies": {
+        "@hapi/hoek": "^10.0.0",
+        "@hapi/teamwork": "^6.0.0",
+        "@hapi/validate": "^2.0.0"
+      }
+    },
+    "node_modules/@hapi/hapi/node_modules/@hapi/teamwork": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/teamwork/-/teamwork-6.0.0.tgz",
+      "integrity": "sha512-05HumSy3LWfXpmJ9cr6HzwhAavrHkJ1ZRCmNE2qJMihdM5YcWreWPfyN0yKT2ZjCM92au3ZkuodjBxOibxM67A==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@hapi/hapi/node_modules/@hapi/topo": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-6.0.0.tgz",
+      "integrity": "sha512-aorJvN1Q1n5xrZuA50Z4X6adI6VAM2NalIVm46ALL9LUvdoqhof3JPY69jdJH8asM3PsWr2SUVYzp57EqUP41A==",
+      "dependencies": {
+        "@hapi/hoek": "^10.0.0"
+      }
+    },
+    "node_modules/@hapi/hapi/node_modules/@hapi/validate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/validate/-/validate-2.0.0.tgz",
+      "integrity": "sha512-w5m8MvBgqGndbMIB+AWmXTb8CLtF1DlIxbnbAHNAo7aFuNQuI1Ywc2e0zDLK5fbFXDoqRzNrHnC7JjNJ+hDigw==",
+      "dependencies": {
+        "@hapi/hoek": "^10.0.0",
+        "@hapi/topo": "^6.0.0"
+      }
+    },
+    "node_modules/@hapi/heavy": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/heavy/-/heavy-8.0.0.tgz",
+      "integrity": "sha512-NpKo74mF66GSwYu31IZwp11/6NmaUYxHeMTKSky09XBs8fVbzQDP83856+l+Ji6wxGmUeg75itCu1ujvEF6mdA==",
+      "dependencies": {
+        "@hapi/boom": "^10.0.0",
+        "@hapi/hoek": "^10.0.0",
+        "@hapi/validate": "^2.0.0"
+      }
+    },
+    "node_modules/@hapi/heavy/node_modules/@hapi/boom": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-10.0.0.tgz",
+      "integrity": "sha512-1YVs9tLHhypBqqinKQRqh7FUERIolarQApO37OWkzD+z6y6USi871Sv746zBPKcIOBuI6g6y4FrwX87mmJ90Gg==",
+      "dependencies": {
+        "@hapi/hoek": "10.x.x"
+      }
+    },
+    "node_modules/@hapi/heavy/node_modules/@hapi/topo": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-6.0.0.tgz",
+      "integrity": "sha512-aorJvN1Q1n5xrZuA50Z4X6adI6VAM2NalIVm46ALL9LUvdoqhof3JPY69jdJH8asM3PsWr2SUVYzp57EqUP41A==",
+      "dependencies": {
+        "@hapi/hoek": "^10.0.0"
+      }
+    },
+    "node_modules/@hapi/heavy/node_modules/@hapi/validate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/validate/-/validate-2.0.0.tgz",
+      "integrity": "sha512-w5m8MvBgqGndbMIB+AWmXTb8CLtF1DlIxbnbAHNAo7aFuNQuI1Ywc2e0zDLK5fbFXDoqRzNrHnC7JjNJ+hDigw==",
+      "dependencies": {
+        "@hapi/hoek": "^10.0.0",
+        "@hapi/topo": "^6.0.0"
+      }
     },
     "node_modules/@hapi/hoek": {
       "version": "10.0.1",
@@ -731,29 +831,12 @@
         "lru-cache": "^7.10.2"
       }
     },
-    "node_modules/@hapi/inert/node_modules/@hapi/ammo": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/ammo/-/ammo-6.0.0.tgz",
-      "integrity": "sha512-lhX7SYtWScQaeAIL5XnE54WzyDgS5RXVeEtFEovyZcTdVzTYbo0nem56Bwko1PBcRxRUIw1v2tMb6sjFs6vEwg==",
-      "dependencies": {
-        "@hapi/hoek": "^10.0.0"
-      }
-    },
     "node_modules/@hapi/inert/node_modules/@hapi/boom": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-10.0.0.tgz",
       "integrity": "sha512-1YVs9tLHhypBqqinKQRqh7FUERIolarQApO37OWkzD+z6y6USi871Sv746zBPKcIOBuI6g6y4FrwX87mmJ90Gg==",
       "dependencies": {
         "@hapi/hoek": "10.x.x"
-      }
-    },
-    "node_modules/@hapi/inert/node_modules/@hapi/bounce": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/bounce/-/bounce-3.0.0.tgz",
-      "integrity": "sha512-L0G4NcwwOYRhpcXeL76hNrLTUcObqtZMB3z4kcRVUZcR/w3v6C5Q1cTElV4/V7og1fG+wOyDR55UMFA+tWfhtA==",
-      "dependencies": {
-        "@hapi/boom": "^10.0.0",
-        "@hapi/hoek": "^10.0.0"
       }
     },
     "node_modules/@hapi/inert/node_modules/@hapi/topo": {
@@ -840,52 +923,53 @@
       }
     },
     "node_modules/@hapi/mimos": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/mimos/-/mimos-6.0.0.tgz",
-      "integrity": "sha512-Op/67tr1I+JafN3R3XN5DucVSxKRT/Tc+tUszDwENoNpolxeXkhrJ2Czt6B6AAqrespHoivhgZBWYSuANN9QXg==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/mimos/-/mimos-7.0.0.tgz",
+      "integrity": "sha512-ALORTrZrrBPOUX05rW4htNajoekEjQtUi1PB+17/3xs/hkdQ+gSEFbs5GdJihA49qWf7td3v4PgnvOe8mcf/jQ==",
       "dependencies": {
-        "@hapi/hoek": "9.x.x",
-        "mime-db": "1.x.x"
+        "@hapi/hoek": "^10.0.0",
+        "mime-db": "^1.52.0"
       }
-    },
-    "node_modules/@hapi/mimos/node_modules/@hapi/hoek": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
-      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
     },
     "node_modules/@hapi/nigel": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@hapi/nigel/-/nigel-4.0.2.tgz",
-      "integrity": "sha512-ht2KoEsDW22BxQOEkLEJaqfpoKPXxi7tvabXy7B/77eFtOyG5ZEstfZwxHQcqAiZhp58Ae5vkhEqI03kawkYNw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/nigel/-/nigel-5.0.0.tgz",
+      "integrity": "sha512-I9eq43BnSdz1BkvMpG7mFL7J+SIfn6DLNThuxFpIOAMUnkWbPgtcFP+HHrBAeoFkowfgQrr02vsIAkAPml4hvw==",
       "dependencies": {
-        "@hapi/hoek": "^9.0.4",
-        "@hapi/vise": "^4.0.0"
+        "@hapi/hoek": "^10.0.0",
+        "@hapi/vise": "^5.0.0"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
       }
-    },
-    "node_modules/@hapi/nigel/node_modules/@hapi/hoek": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
-      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
     },
     "node_modules/@hapi/pez": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@hapi/pez/-/pez-5.0.3.tgz",
-      "integrity": "sha512-mpikYRJjtrbJgdDHG/H9ySqYqwJ+QU/D7FXsYciS9P7NYBXE2ayKDAy3H0ou6CohOCaxPuTV4SZ0D936+VomHA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/pez/-/pez-6.0.0.tgz",
+      "integrity": "sha512-3bMmsvlqrVNqaNEe4JWLZVpJ40jXuQ3vDy1+fbhyJmuAdMCMCkWexsKc7fT+mu18pFIwJzlenjc4/VE3weTq7w==",
       "dependencies": {
-        "@hapi/b64": "5.x.x",
-        "@hapi/boom": "9.x.x",
-        "@hapi/content": "^5.0.2",
-        "@hapi/hoek": "9.x.x",
-        "@hapi/nigel": "4.x.x"
+        "@hapi/b64": "^6.0.0",
+        "@hapi/boom": "^10.0.0",
+        "@hapi/content": "^6.0.0",
+        "@hapi/hoek": "^10.0.0",
+        "@hapi/nigel": "^5.0.0"
       }
     },
-    "node_modules/@hapi/pez/node_modules/@hapi/hoek": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
-      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
+    "node_modules/@hapi/pez/node_modules/@hapi/b64": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/b64/-/b64-6.0.0.tgz",
+      "integrity": "sha512-Es6o4BtzvMmNF28KJGuwUzUtMjF6ToZ1hQt3UOjaXc6TNkRefel+NyQSjc9b5q3Re7xwv23r0xK3Vo3yreaJHQ==",
+      "dependencies": {
+        "@hapi/hoek": "^10.0.0"
+      }
+    },
+    "node_modules/@hapi/pez/node_modules/@hapi/boom": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-10.0.0.tgz",
+      "integrity": "sha512-1YVs9tLHhypBqqinKQRqh7FUERIolarQApO37OWkzD+z6y6USi871Sv746zBPKcIOBuI6g6y4FrwX87mmJ90Gg==",
+      "dependencies": {
+        "@hapi/hoek": "10.x.x"
+      }
     },
     "node_modules/@hapi/podium": {
       "version": "4.1.3",
@@ -903,26 +987,38 @@
       "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
     },
     "node_modules/@hapi/shot": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@hapi/shot/-/shot-5.0.5.tgz",
-      "integrity": "sha512-x5AMSZ5+j+Paa8KdfCoKh+klB78otxF+vcJR/IoN91Vo2e5ulXIW6HUsFTCU+4W6P/Etaip9nmdAx2zWDimB2A==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/shot/-/shot-6.0.0.tgz",
+      "integrity": "sha512-RLGgzXy9GciJDunhY40NbVnLgYqp5gfBooZ2fOkAr4KbCEav/SJtYQS1N+knR7WFGzy8aooCR3XBUPI4ghHAkQ==",
       "dependencies": {
-        "@hapi/hoek": "9.x.x",
-        "@hapi/validate": "1.x.x"
+        "@hapi/hoek": "^10.0.0",
+        "@hapi/validate": "^2.0.0"
       }
     },
-    "node_modules/@hapi/shot/node_modules/@hapi/hoek": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
-      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
+    "node_modules/@hapi/shot/node_modules/@hapi/topo": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-6.0.0.tgz",
+      "integrity": "sha512-aorJvN1Q1n5xrZuA50Z4X6adI6VAM2NalIVm46ALL9LUvdoqhof3JPY69jdJH8asM3PsWr2SUVYzp57EqUP41A==",
+      "dependencies": {
+        "@hapi/hoek": "^10.0.0"
+      }
+    },
+    "node_modules/@hapi/shot/node_modules/@hapi/validate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/validate/-/validate-2.0.0.tgz",
+      "integrity": "sha512-w5m8MvBgqGndbMIB+AWmXTb8CLtF1DlIxbnbAHNAo7aFuNQuI1Ywc2e0zDLK5fbFXDoqRzNrHnC7JjNJ+hDigw==",
+      "dependencies": {
+        "@hapi/hoek": "^10.0.0",
+        "@hapi/topo": "^6.0.0"
+      }
     },
     "node_modules/@hapi/somever": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/somever/-/somever-3.0.1.tgz",
-      "integrity": "sha512-4ZTSN3YAHtgpY/M4GOtHUXgi6uZtG9nEZfNI6QrArhK0XN/RDVgijlb9kOmXwCR5VclDSkBul9FBvhSuKXx9+w==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/somever/-/somever-4.1.0.tgz",
+      "integrity": "sha512-koNBYu7Jdcb7gaC4VcnU78rFxSlsYwuElm6NMznE0EEeznzJtvLLmDZX0SPX8kXWC/E7ONlE29HF/yiSOgWG1Q==",
       "dependencies": {
-        "@hapi/bounce": "2.x.x",
-        "@hapi/hoek": "9.x.x"
+        "@hapi/bounce": "^3.0.0",
+        "@hapi/hoek": "^9.0.0"
       }
     },
     "node_modules/@hapi/somever/node_modules/@hapi/hoek": {
@@ -931,52 +1027,96 @@
       "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
     },
     "node_modules/@hapi/statehood": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/@hapi/statehood/-/statehood-7.0.4.tgz",
-      "integrity": "sha512-Fia6atroOVmc5+2bNOxF6Zv9vpbNAjEXNcUbWXavDqhnJDlchwUUwKS5LCi5mGtCTxRhUKKHwuxuBZJkmLZ7fw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/statehood/-/statehood-8.0.0.tgz",
+      "integrity": "sha512-umQTPID7BwmqAv9Rx7yLtbTNzsYg4va96aLqKneb3mlBQG32uq4iOQZ6luwBVACDFhqU3C3ewhznhukN09ZkZQ==",
       "dependencies": {
-        "@hapi/boom": "9.x.x",
-        "@hapi/bounce": "2.x.x",
-        "@hapi/bourne": "2.x.x",
-        "@hapi/cryptiles": "5.x.x",
-        "@hapi/hoek": "9.x.x",
-        "@hapi/iron": "6.x.x",
-        "@hapi/validate": "1.x.x"
+        "@hapi/boom": "^10.0.0",
+        "@hapi/bounce": "^3.0.0",
+        "@hapi/bourne": "^3.0.0",
+        "@hapi/cryptiles": "^6.0.0",
+        "@hapi/hoek": "^10.0.0",
+        "@hapi/iron": "^7.0.0",
+        "@hapi/validate": "^2.0.0"
       }
     },
-    "node_modules/@hapi/statehood/node_modules/@hapi/bourne": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-2.1.0.tgz",
-      "integrity": "sha512-i1BpaNDVLJdRBEKeJWkVO6tYX6DMFBuwMhSuWqLsY4ufeTKGVuV5rBsUhxPayXqnnWHgXUAmWK16H/ykO5Wj4Q=="
+    "node_modules/@hapi/statehood/node_modules/@hapi/b64": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/b64/-/b64-6.0.0.tgz",
+      "integrity": "sha512-Es6o4BtzvMmNF28KJGuwUzUtMjF6ToZ1hQt3UOjaXc6TNkRefel+NyQSjc9b5q3Re7xwv23r0xK3Vo3yreaJHQ==",
+      "dependencies": {
+        "@hapi/hoek": "^10.0.0"
+      }
     },
-    "node_modules/@hapi/statehood/node_modules/@hapi/hoek": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
-      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
+    "node_modules/@hapi/statehood/node_modules/@hapi/boom": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-10.0.0.tgz",
+      "integrity": "sha512-1YVs9tLHhypBqqinKQRqh7FUERIolarQApO37OWkzD+z6y6USi871Sv746zBPKcIOBuI6g6y4FrwX87mmJ90Gg==",
+      "dependencies": {
+        "@hapi/hoek": "10.x.x"
+      }
+    },
+    "node_modules/@hapi/statehood/node_modules/@hapi/cryptiles": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/cryptiles/-/cryptiles-6.0.0.tgz",
+      "integrity": "sha512-CUypQJI2F3HaKZjwlky3KyLu7p0O4WJXNJj+2AZ0czqwkwQIz8j+btOkzA3OMar8WTntnCrDx0f92PzxEK+JlA==",
+      "dependencies": {
+        "@hapi/boom": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@hapi/statehood/node_modules/@hapi/iron": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/iron/-/iron-7.0.0.tgz",
+      "integrity": "sha512-NNXJP5fpeiTCPj/4OJG2PWBjWC0/V5D8YggS9RZeuBbfUUuTYE6TbdGqLUsCzIpPI54I8W5dhwEGbRv1CnWQtw==",
+      "dependencies": {
+        "@hapi/b64": "^6.0.0",
+        "@hapi/boom": "^10.0.0",
+        "@hapi/bourne": "^3.0.0",
+        "@hapi/cryptiles": "^6.0.0",
+        "@hapi/hoek": "^10.0.0"
+      }
+    },
+    "node_modules/@hapi/statehood/node_modules/@hapi/topo": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-6.0.0.tgz",
+      "integrity": "sha512-aorJvN1Q1n5xrZuA50Z4X6adI6VAM2NalIVm46ALL9LUvdoqhof3JPY69jdJH8asM3PsWr2SUVYzp57EqUP41A==",
+      "dependencies": {
+        "@hapi/hoek": "^10.0.0"
+      }
+    },
+    "node_modules/@hapi/statehood/node_modules/@hapi/validate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/validate/-/validate-2.0.0.tgz",
+      "integrity": "sha512-w5m8MvBgqGndbMIB+AWmXTb8CLtF1DlIxbnbAHNAo7aFuNQuI1Ywc2e0zDLK5fbFXDoqRzNrHnC7JjNJ+hDigw==",
+      "dependencies": {
+        "@hapi/hoek": "^10.0.0",
+        "@hapi/topo": "^6.0.0"
+      }
     },
     "node_modules/@hapi/subtext": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/@hapi/subtext/-/subtext-7.0.4.tgz",
-      "integrity": "sha512-Y72moHhbRuO8kwBHFEnCRw7oOnhNh4Pl+aonxAze18jkyMpE4Gwz4lNID7ei8vd3lpXC2rKdkxXJgtfY+WttRw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/subtext/-/subtext-8.0.0.tgz",
+      "integrity": "sha512-fD+LY1U1SIUNHZJrNMIbuGl3CAd9JN8slljarFO4b8RrifkzjqbvdlZu/6iT6zlNM35GtDExf7hIepbUFUkT7A==",
       "dependencies": {
-        "@hapi/boom": "9.x.x",
-        "@hapi/bourne": "2.x.x",
-        "@hapi/content": "^5.0.2",
-        "@hapi/file": "2.x.x",
-        "@hapi/hoek": "9.x.x",
-        "@hapi/pez": "^5.0.1",
-        "@hapi/wreck": "17.x.x"
+        "@hapi/boom": "^10.0.0",
+        "@hapi/bourne": "^3.0.0",
+        "@hapi/content": "^6.0.0",
+        "@hapi/file": "^3.0.0",
+        "@hapi/hoek": "^10.0.0",
+        "@hapi/pez": "^6.0.0",
+        "@hapi/wreck": "^18.0.0"
       }
     },
-    "node_modules/@hapi/subtext/node_modules/@hapi/bourne": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-2.1.0.tgz",
-      "integrity": "sha512-i1BpaNDVLJdRBEKeJWkVO6tYX6DMFBuwMhSuWqLsY4ufeTKGVuV5rBsUhxPayXqnnWHgXUAmWK16H/ykO5Wj4Q=="
-    },
-    "node_modules/@hapi/subtext/node_modules/@hapi/hoek": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
-      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
+    "node_modules/@hapi/subtext/node_modules/@hapi/boom": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-10.0.0.tgz",
+      "integrity": "sha512-1YVs9tLHhypBqqinKQRqh7FUERIolarQApO37OWkzD+z6y6USi871Sv746zBPKcIOBuI6g6y4FrwX87mmJ90Gg==",
+      "dependencies": {
+        "@hapi/hoek": "10.x.x"
+      }
     },
     "node_modules/@hapi/teamwork": {
       "version": "5.1.1",
@@ -1014,17 +1154,12 @@
       "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
     },
     "node_modules/@hapi/vise": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/vise/-/vise-4.0.0.tgz",
-      "integrity": "sha512-eYyLkuUiFZTer59h+SGy7hUm+qE9p+UemePTHLlIWppEd+wExn3Df5jO04bFQTm7nleF5V8CtuYQYb+VFpZ6Sg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/vise/-/vise-5.0.0.tgz",
+      "integrity": "sha512-bz/PA7DHIvsd/2eoW7t9WpU8+k9pofZHppYEn1mCTOVnC/cGN3hCEYaoAe6BpoeJM72iJDKZEOWvQvfgCrmzxA==",
       "dependencies": {
-        "@hapi/hoek": "9.x.x"
+        "@hapi/hoek": "^10.0.0"
       }
-    },
-    "node_modules/@hapi/vise/node_modules/@hapi/hoek": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
-      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
     },
     "node_modules/@hapi/vision": {
       "version": "7.0.0",
@@ -1045,15 +1180,6 @@
         "@hapi/hoek": "10.x.x"
       }
     },
-    "node_modules/@hapi/vision/node_modules/@hapi/bounce": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/bounce/-/bounce-3.0.0.tgz",
-      "integrity": "sha512-L0G4NcwwOYRhpcXeL76hNrLTUcObqtZMB3z4kcRVUZcR/w3v6C5Q1cTElV4/V7og1fG+wOyDR55UMFA+tWfhtA==",
-      "dependencies": {
-        "@hapi/boom": "^10.0.0",
-        "@hapi/hoek": "^10.0.0"
-      }
-    },
     "node_modules/@hapi/vision/node_modules/@hapi/topo": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-6.0.0.tgz",
@@ -1072,24 +1198,22 @@
       }
     },
     "node_modules/@hapi/wreck": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-17.2.0.tgz",
-      "integrity": "sha512-pJ5kjYoRPYDv+eIuiLQqhGon341fr2bNIYZjuotuPJG/3Ilzr/XtI+JAp0A86E2bYfsS3zBPABuS2ICkaXFT8g==",
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-18.0.0.tgz",
+      "integrity": "sha512-Yk9STxoM06Hjjq58cH0KFG91u9F2h9eVE72o8vUr3AfK80qt7I2POG5+cDGTEntbnvvzm0ERow2sjG3QsqCWUA==",
       "dependencies": {
-        "@hapi/boom": "9.x.x",
-        "@hapi/bourne": "2.x.x",
-        "@hapi/hoek": "9.x.x"
+        "@hapi/boom": "^10.0.0",
+        "@hapi/bourne": "^3.0.0",
+        "@hapi/hoek": "^10.0.0"
       }
     },
-    "node_modules/@hapi/wreck/node_modules/@hapi/bourne": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-2.1.0.tgz",
-      "integrity": "sha512-i1BpaNDVLJdRBEKeJWkVO6tYX6DMFBuwMhSuWqLsY4ufeTKGVuV5rBsUhxPayXqnnWHgXUAmWK16H/ykO5Wj4Q=="
-    },
-    "node_modules/@hapi/wreck/node_modules/@hapi/hoek": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
-      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
+    "node_modules/@hapi/wreck/node_modules/@hapi/boom": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-10.0.0.tgz",
+      "integrity": "sha512-1YVs9tLHhypBqqinKQRqh7FUERIolarQApO37OWkzD+z6y6USi871Sv746zBPKcIOBuI6g6y4FrwX87mmJ90Gg==",
+      "dependencies": {
+        "@hapi/hoek": "10.x.x"
+      }
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.10.7",
@@ -6340,34 +6464,30 @@
       }
     },
     "@hapi/accept": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@hapi/accept/-/accept-5.0.2.tgz",
-      "integrity": "sha512-CmzBx/bXUR8451fnZRuZAJRlzgm0Jgu5dltTX/bszmR2lheb9BpyN47Q1RbaGTsvFzn0PXAEs+lXDKfshccYZw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/accept/-/accept-6.0.0.tgz",
+      "integrity": "sha512-aG/Ml4kSBWCVmWvR8N8ULRuB385D8K/3OI7lquZQruH11eM7sHR5Nha30BbDzijJHtyV7Vwc6MlMwNfwb70ISg==",
       "requires": {
-        "@hapi/boom": "9.x.x",
-        "@hapi/hoek": "9.x.x"
+        "@hapi/boom": "^10.0.0",
+        "@hapi/hoek": "^10.0.0"
       },
       "dependencies": {
-        "@hapi/hoek": {
-          "version": "9.3.0",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
-          "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
+        "@hapi/boom": {
+          "version": "10.0.0",
+          "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-10.0.0.tgz",
+          "integrity": "sha512-1YVs9tLHhypBqqinKQRqh7FUERIolarQApO37OWkzD+z6y6USi871Sv746zBPKcIOBuI6g6y4FrwX87mmJ90Gg==",
+          "requires": {
+            "@hapi/hoek": "10.x.x"
+          }
         }
       }
     },
     "@hapi/ammo": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/ammo/-/ammo-5.0.1.tgz",
-      "integrity": "sha512-FbCNwcTbnQP4VYYhLNGZmA76xb2aHg9AMPiy18NZyWMG310P5KdFGyA9v2rm5ujrIny77dEEIkMOwl0Xv+fSSA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/ammo/-/ammo-6.0.0.tgz",
+      "integrity": "sha512-lhX7SYtWScQaeAIL5XnE54WzyDgS5RXVeEtFEovyZcTdVzTYbo0nem56Bwko1PBcRxRUIw1v2tMb6sjFs6vEwg==",
       "requires": {
-        "@hapi/hoek": "9.x.x"
-      },
-      "dependencies": {
-        "@hapi/hoek": {
-          "version": "9.3.0",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
-          "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
-        }
+        "@hapi/hoek": "^10.0.0"
       }
     },
     "@hapi/b64": {
@@ -6422,16 +6542,6 @@
             "@hapi/hoek": "10.x.x"
           }
         },
-        "@hapi/bounce": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@hapi/bounce/-/bounce-3.0.0.tgz",
-          "integrity": "sha512-L0G4NcwwOYRhpcXeL76hNrLTUcObqtZMB3z4kcRVUZcR/w3v6C5Q1cTElV4/V7og1fG+wOyDR55UMFA+tWfhtA==",
-          "dev": true,
-          "requires": {
-            "@hapi/boom": "^10.0.0",
-            "@hapi/hoek": "^10.0.0"
-          }
-        },
         "@hapi/topo": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-6.0.0.tgz",
@@ -6454,74 +6564,117 @@
       }
     },
     "@hapi/bounce": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/bounce/-/bounce-2.0.0.tgz",
-      "integrity": "sha512-JesW92uyzOOyuzJKjoLHM1ThiOvHPOLDHw01YV8yh5nCso7sDwJho1h0Ad2N+E62bZyz46TG3xhAi/78Gsct6A==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/bounce/-/bounce-3.0.0.tgz",
+      "integrity": "sha512-L0G4NcwwOYRhpcXeL76hNrLTUcObqtZMB3z4kcRVUZcR/w3v6C5Q1cTElV4/V7og1fG+wOyDR55UMFA+tWfhtA==",
       "requires": {
-        "@hapi/boom": "9.x.x",
-        "@hapi/hoek": "9.x.x"
+        "@hapi/boom": "^10.0.0",
+        "@hapi/hoek": "^10.0.0"
       },
       "dependencies": {
-        "@hapi/hoek": {
-          "version": "9.3.0",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
-          "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
+        "@hapi/boom": {
+          "version": "10.0.0",
+          "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-10.0.0.tgz",
+          "integrity": "sha512-1YVs9tLHhypBqqinKQRqh7FUERIolarQApO37OWkzD+z6y6USi871Sv746zBPKcIOBuI6g6y4FrwX87mmJ90Gg==",
+          "requires": {
+            "@hapi/hoek": "10.x.x"
+          }
         }
       }
     },
     "@hapi/bourne": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-3.0.0.tgz",
-      "integrity": "sha512-Waj1cwPXJDucOib4a3bAISsKJVb15MKi9IvmTI/7ssVEm6sywXGjVJDhl6/umt1pK1ZS7PacXU3A1PmFKHEZ2w==",
-      "dev": true
+      "integrity": "sha512-Waj1cwPXJDucOib4a3bAISsKJVb15MKi9IvmTI/7ssVEm6sywXGjVJDhl6/umt1pK1ZS7PacXU3A1PmFKHEZ2w=="
     },
     "@hapi/call": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/call/-/call-8.0.1.tgz",
-      "integrity": "sha512-bOff6GTdOnoe5b8oXRV3lwkQSb/LAWylvDMae6RgEWWntd0SHtkYbQukDHKlfaYtVnSAgIavJ0kqszF/AIBb6g==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/call/-/call-9.0.0.tgz",
+      "integrity": "sha512-Z6byqbEtKF3RIH2kWG6cX64RwEqHBWYEVkNoEx6oKvkPaTrC6WTPRgr+ANo9Xa8G1GXyvs/NCMTnn3Mdj12TSA==",
       "requires": {
-        "@hapi/boom": "9.x.x",
-        "@hapi/hoek": "9.x.x"
+        "@hapi/boom": "^10.0.0",
+        "@hapi/hoek": "^10.0.0"
       },
       "dependencies": {
-        "@hapi/hoek": {
-          "version": "9.3.0",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
-          "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
+        "@hapi/boom": {
+          "version": "10.0.0",
+          "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-10.0.0.tgz",
+          "integrity": "sha512-1YVs9tLHhypBqqinKQRqh7FUERIolarQApO37OWkzD+z6y6USi871Sv746zBPKcIOBuI6g6y4FrwX87mmJ90Gg==",
+          "requires": {
+            "@hapi/hoek": "10.x.x"
+          }
         }
       }
     },
     "@hapi/catbox": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/@hapi/catbox/-/catbox-11.1.1.tgz",
-      "integrity": "sha512-u/8HvB7dD/6X8hsZIpskSDo4yMKpHxFd7NluoylhGrL6cUfYxdQPnvUp9YU2C6F9hsyBVLGulBd9vBN1ebfXOQ==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/catbox/-/catbox-12.1.0.tgz",
+      "integrity": "sha512-60MCN5lgaXcuRTjMZqLR+DV0clS5RAFAwfYAQU2/na6PqrXHDRQcJwVMwP7jJayCrJm4POJlLDzZLuh1ba5XUg==",
       "requires": {
-        "@hapi/boom": "9.x.x",
-        "@hapi/hoek": "9.x.x",
-        "@hapi/podium": "4.x.x",
-        "@hapi/validate": "1.x.x"
+        "@hapi/boom": "^10.0.0",
+        "@hapi/hoek": "^10.0.0",
+        "@hapi/podium": "^5.0.0",
+        "@hapi/validate": "^2.0.0"
       },
       "dependencies": {
-        "@hapi/hoek": {
-          "version": "9.3.0",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
-          "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
+        "@hapi/boom": {
+          "version": "10.0.0",
+          "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-10.0.0.tgz",
+          "integrity": "sha512-1YVs9tLHhypBqqinKQRqh7FUERIolarQApO37OWkzD+z6y6USi871Sv746zBPKcIOBuI6g6y4FrwX87mmJ90Gg==",
+          "requires": {
+            "@hapi/hoek": "10.x.x"
+          }
+        },
+        "@hapi/podium": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/@hapi/podium/-/podium-5.0.0.tgz",
+          "integrity": "sha512-SbhFdu8LOIscMS82Zsoj9abcllAqbK4qBgznzJ9yr+vS2j1EomJTukkhxb76Lml0BHCd4Hn79F+3EQg06kcf8g==",
+          "requires": {
+            "@hapi/hoek": "^10.0.0",
+            "@hapi/teamwork": "^6.0.0",
+            "@hapi/validate": "^2.0.0"
+          }
+        },
+        "@hapi/teamwork": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/@hapi/teamwork/-/teamwork-6.0.0.tgz",
+          "integrity": "sha512-05HumSy3LWfXpmJ9cr6HzwhAavrHkJ1ZRCmNE2qJMihdM5YcWreWPfyN0yKT2ZjCM92au3ZkuodjBxOibxM67A=="
+        },
+        "@hapi/topo": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-6.0.0.tgz",
+          "integrity": "sha512-aorJvN1Q1n5xrZuA50Z4X6adI6VAM2NalIVm46ALL9LUvdoqhof3JPY69jdJH8asM3PsWr2SUVYzp57EqUP41A==",
+          "requires": {
+            "@hapi/hoek": "^10.0.0"
+          }
+        },
+        "@hapi/validate": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@hapi/validate/-/validate-2.0.0.tgz",
+          "integrity": "sha512-w5m8MvBgqGndbMIB+AWmXTb8CLtF1DlIxbnbAHNAo7aFuNQuI1Ywc2e0zDLK5fbFXDoqRzNrHnC7JjNJ+hDigw==",
+          "requires": {
+            "@hapi/hoek": "^10.0.0",
+            "@hapi/topo": "^6.0.0"
+          }
         }
       }
     },
     "@hapi/catbox-memory": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/catbox-memory/-/catbox-memory-5.0.1.tgz",
-      "integrity": "sha512-QWw9nOYJq5PlvChLWV8i6hQHJYfvdqiXdvTupJFh0eqLZ64Xir7mKNi96d5/ZMUAqXPursfNDIDxjFgoEDUqeQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/catbox-memory/-/catbox-memory-6.0.0.tgz",
+      "integrity": "sha512-A1O30g8GdaODx/GinytF6jFm772pdTPVWJe0cF2RiTOfhgIAAagzCcpBqRgQ8olLui0F5bzUF/SAi4BmkZ4yxA==",
       "requires": {
-        "@hapi/boom": "9.x.x",
-        "@hapi/hoek": "9.x.x"
+        "@hapi/boom": "^10.0.0",
+        "@hapi/hoek": "^10.0.0"
       },
       "dependencies": {
-        "@hapi/hoek": {
-          "version": "9.3.0",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
-          "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
+        "@hapi/boom": {
+          "version": "10.0.0",
+          "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-10.0.0.tgz",
+          "integrity": "sha512-1YVs9tLHhypBqqinKQRqh7FUERIolarQApO37OWkzD+z6y6USi871Sv746zBPKcIOBuI6g6y4FrwX87mmJ90Gg==",
+          "requires": {
+            "@hapi/hoek": "10.x.x"
+          }
         }
       }
     },
@@ -6535,11 +6688,21 @@
       }
     },
     "@hapi/content": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@hapi/content/-/content-5.0.2.tgz",
-      "integrity": "sha512-mre4dl1ygd4ZyOH3tiYBrOUBzV7Pu/EOs8VLGf58vtOEECWed8Uuw6B4iR9AN/8uQt42tB04qpVaMyoMQh0oMw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/content/-/content-6.0.0.tgz",
+      "integrity": "sha512-CEhs7j+H0iQffKfe5Htdak5LBOz/Qc8TRh51cF+BFv0qnuph3Em4pjGVzJMkI2gfTDdlJKWJISGWS1rK34POGA==",
       "requires": {
-        "@hapi/boom": "9.x.x"
+        "@hapi/boom": "^10.0.0"
+      },
+      "dependencies": {
+        "@hapi/boom": {
+          "version": "10.0.0",
+          "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-10.0.0.tgz",
+          "integrity": "sha512-1YVs9tLHhypBqqinKQRqh7FUERIolarQApO37OWkzD+z6y6USi871Sv746zBPKcIOBuI6g6y4FrwX87mmJ90Gg==",
+          "requires": {
+            "@hapi/hoek": "10.x.x"
+          }
+        }
       }
     },
     "@hapi/cryptiles": {
@@ -6558,56 +6721,111 @@
       "requires": {}
     },
     "@hapi/file": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/file/-/file-2.0.0.tgz",
-      "integrity": "sha512-WSrlgpvEqgPWkI18kkGELEZfXr0bYLtr16iIN4Krh9sRnzBZN6nnWxHFxtsnP684wueEySBbXPDg/WfA9xJdBQ=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/file/-/file-3.0.0.tgz",
+      "integrity": "sha512-w+lKW+yRrLhJu620jT3y+5g2mHqnKfepreykvdOcl9/6up8GrQQn+l3FRTsjHTKbkbfQFkuksHpdv2EcpKcJ4Q=="
     },
     "@hapi/hapi": {
-      "version": "20.2.2",
-      "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-20.2.2.tgz",
-      "integrity": "sha512-crhU6TIKt7QsksWLYctDBAXogk9PYAm7UzdpETyuBHC2pCa6/+B5NykiOVLG/3FCIgHo/raPVtan8bYtByHORQ==",
+      "version": "21.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-21.0.0.tgz",
+      "integrity": "sha512-gqGifa4X4nskhsmsgp3AwBq4LPIl7XOlnzpdWSogdc46Z4Hfy/WDjCcaO2yK84tQRmGSlg0nZowOfSCyeT0hRw==",
       "requires": {
-        "@hapi/accept": "^5.0.1",
-        "@hapi/ammo": "^5.0.1",
-        "@hapi/boom": "^9.1.0",
-        "@hapi/bounce": "^2.0.0",
-        "@hapi/call": "^8.0.0",
-        "@hapi/catbox": "^11.1.1",
-        "@hapi/catbox-memory": "^5.0.0",
-        "@hapi/heavy": "^7.0.1",
-        "@hapi/hoek": "^9.0.4",
-        "@hapi/mimos": "^6.0.0",
-        "@hapi/podium": "^4.1.1",
-        "@hapi/shot": "^5.0.5",
-        "@hapi/somever": "^3.0.0",
-        "@hapi/statehood": "^7.0.4",
-        "@hapi/subtext": "^7.0.3",
-        "@hapi/teamwork": "^5.1.1",
-        "@hapi/topo": "^5.0.0",
-        "@hapi/validate": "^1.1.1"
+        "@hapi/accept": "^6.0.0",
+        "@hapi/ammo": "^6.0.0",
+        "@hapi/boom": "^10.0.0",
+        "@hapi/bounce": "^3.0.0",
+        "@hapi/call": "^9.0.0",
+        "@hapi/catbox": "^12.0.0",
+        "@hapi/catbox-memory": "^6.0.0",
+        "@hapi/heavy": "^8.0.0",
+        "@hapi/hoek": "^10.0.0",
+        "@hapi/mimos": "^7.0.0",
+        "@hapi/podium": "^5.0.0",
+        "@hapi/shot": "^6.0.0",
+        "@hapi/somever": "^4.1.0",
+        "@hapi/statehood": "^8.0.0",
+        "@hapi/subtext": "^8.0.0",
+        "@hapi/teamwork": "^6.0.0",
+        "@hapi/topo": "^6.0.0",
+        "@hapi/validate": "^2.0.0"
       },
       "dependencies": {
-        "@hapi/hoek": {
-          "version": "9.3.0",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
-          "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
+        "@hapi/boom": {
+          "version": "10.0.0",
+          "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-10.0.0.tgz",
+          "integrity": "sha512-1YVs9tLHhypBqqinKQRqh7FUERIolarQApO37OWkzD+z6y6USi871Sv746zBPKcIOBuI6g6y4FrwX87mmJ90Gg==",
+          "requires": {
+            "@hapi/hoek": "10.x.x"
+          }
+        },
+        "@hapi/podium": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/@hapi/podium/-/podium-5.0.0.tgz",
+          "integrity": "sha512-SbhFdu8LOIscMS82Zsoj9abcllAqbK4qBgznzJ9yr+vS2j1EomJTukkhxb76Lml0BHCd4Hn79F+3EQg06kcf8g==",
+          "requires": {
+            "@hapi/hoek": "^10.0.0",
+            "@hapi/teamwork": "^6.0.0",
+            "@hapi/validate": "^2.0.0"
+          }
+        },
+        "@hapi/teamwork": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/@hapi/teamwork/-/teamwork-6.0.0.tgz",
+          "integrity": "sha512-05HumSy3LWfXpmJ9cr6HzwhAavrHkJ1ZRCmNE2qJMihdM5YcWreWPfyN0yKT2ZjCM92au3ZkuodjBxOibxM67A=="
+        },
+        "@hapi/topo": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-6.0.0.tgz",
+          "integrity": "sha512-aorJvN1Q1n5xrZuA50Z4X6adI6VAM2NalIVm46ALL9LUvdoqhof3JPY69jdJH8asM3PsWr2SUVYzp57EqUP41A==",
+          "requires": {
+            "@hapi/hoek": "^10.0.0"
+          }
+        },
+        "@hapi/validate": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@hapi/validate/-/validate-2.0.0.tgz",
+          "integrity": "sha512-w5m8MvBgqGndbMIB+AWmXTb8CLtF1DlIxbnbAHNAo7aFuNQuI1Ywc2e0zDLK5fbFXDoqRzNrHnC7JjNJ+hDigw==",
+          "requires": {
+            "@hapi/hoek": "^10.0.0",
+            "@hapi/topo": "^6.0.0"
+          }
         }
       }
     },
     "@hapi/heavy": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/heavy/-/heavy-7.0.1.tgz",
-      "integrity": "sha512-vJ/vzRQ13MtRzz6Qd4zRHWS3FaUc/5uivV2TIuExGTM9Qk+7Zzqj0e2G7EpE6KztO9SalTbiIkTh7qFKj/33cA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/heavy/-/heavy-8.0.0.tgz",
+      "integrity": "sha512-NpKo74mF66GSwYu31IZwp11/6NmaUYxHeMTKSky09XBs8fVbzQDP83856+l+Ji6wxGmUeg75itCu1ujvEF6mdA==",
       "requires": {
-        "@hapi/boom": "9.x.x",
-        "@hapi/hoek": "9.x.x",
-        "@hapi/validate": "1.x.x"
+        "@hapi/boom": "^10.0.0",
+        "@hapi/hoek": "^10.0.0",
+        "@hapi/validate": "^2.0.0"
       },
       "dependencies": {
-        "@hapi/hoek": {
-          "version": "9.3.0",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
-          "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
+        "@hapi/boom": {
+          "version": "10.0.0",
+          "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-10.0.0.tgz",
+          "integrity": "sha512-1YVs9tLHhypBqqinKQRqh7FUERIolarQApO37OWkzD+z6y6USi871Sv746zBPKcIOBuI6g6y4FrwX87mmJ90Gg==",
+          "requires": {
+            "@hapi/hoek": "10.x.x"
+          }
+        },
+        "@hapi/topo": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-6.0.0.tgz",
+          "integrity": "sha512-aorJvN1Q1n5xrZuA50Z4X6adI6VAM2NalIVm46ALL9LUvdoqhof3JPY69jdJH8asM3PsWr2SUVYzp57EqUP41A==",
+          "requires": {
+            "@hapi/hoek": "^10.0.0"
+          }
+        },
+        "@hapi/validate": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@hapi/validate/-/validate-2.0.0.tgz",
+          "integrity": "sha512-w5m8MvBgqGndbMIB+AWmXTb8CLtF1DlIxbnbAHNAo7aFuNQuI1Ywc2e0zDLK5fbFXDoqRzNrHnC7JjNJ+hDigw==",
+          "requires": {
+            "@hapi/hoek": "^10.0.0",
+            "@hapi/topo": "^6.0.0"
+          }
         }
       }
     },
@@ -6629,29 +6847,12 @@
         "lru-cache": "^7.10.2"
       },
       "dependencies": {
-        "@hapi/ammo": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/@hapi/ammo/-/ammo-6.0.0.tgz",
-          "integrity": "sha512-lhX7SYtWScQaeAIL5XnE54WzyDgS5RXVeEtFEovyZcTdVzTYbo0nem56Bwko1PBcRxRUIw1v2tMb6sjFs6vEwg==",
-          "requires": {
-            "@hapi/hoek": "^10.0.0"
-          }
-        },
         "@hapi/boom": {
           "version": "10.0.0",
           "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-10.0.0.tgz",
           "integrity": "sha512-1YVs9tLHhypBqqinKQRqh7FUERIolarQApO37OWkzD+z6y6USi871Sv746zBPKcIOBuI6g6y4FrwX87mmJ90Gg==",
           "requires": {
             "@hapi/hoek": "10.x.x"
-          }
-        },
-        "@hapi/bounce": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@hapi/bounce/-/bounce-3.0.0.tgz",
-          "integrity": "sha512-L0G4NcwwOYRhpcXeL76hNrLTUcObqtZMB3z4kcRVUZcR/w3v6C5Q1cTElV4/V7og1fG+wOyDR55UMFA+tWfhtA==",
-          "requires": {
-            "@hapi/boom": "^10.0.0",
-            "@hapi/hoek": "^10.0.0"
           }
         },
         "@hapi/topo": {
@@ -6727,53 +6928,50 @@
       }
     },
     "@hapi/mimos": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/mimos/-/mimos-6.0.0.tgz",
-      "integrity": "sha512-Op/67tr1I+JafN3R3XN5DucVSxKRT/Tc+tUszDwENoNpolxeXkhrJ2Czt6B6AAqrespHoivhgZBWYSuANN9QXg==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/mimos/-/mimos-7.0.0.tgz",
+      "integrity": "sha512-ALORTrZrrBPOUX05rW4htNajoekEjQtUi1PB+17/3xs/hkdQ+gSEFbs5GdJihA49qWf7td3v4PgnvOe8mcf/jQ==",
       "requires": {
-        "@hapi/hoek": "9.x.x",
-        "mime-db": "1.x.x"
-      },
-      "dependencies": {
-        "@hapi/hoek": {
-          "version": "9.3.0",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
-          "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
-        }
+        "@hapi/hoek": "^10.0.0",
+        "mime-db": "^1.52.0"
       }
     },
     "@hapi/nigel": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@hapi/nigel/-/nigel-4.0.2.tgz",
-      "integrity": "sha512-ht2KoEsDW22BxQOEkLEJaqfpoKPXxi7tvabXy7B/77eFtOyG5ZEstfZwxHQcqAiZhp58Ae5vkhEqI03kawkYNw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/nigel/-/nigel-5.0.0.tgz",
+      "integrity": "sha512-I9eq43BnSdz1BkvMpG7mFL7J+SIfn6DLNThuxFpIOAMUnkWbPgtcFP+HHrBAeoFkowfgQrr02vsIAkAPml4hvw==",
       "requires": {
-        "@hapi/hoek": "^9.0.4",
-        "@hapi/vise": "^4.0.0"
-      },
-      "dependencies": {
-        "@hapi/hoek": {
-          "version": "9.3.0",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
-          "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
-        }
+        "@hapi/hoek": "^10.0.0",
+        "@hapi/vise": "^5.0.0"
       }
     },
     "@hapi/pez": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@hapi/pez/-/pez-5.0.3.tgz",
-      "integrity": "sha512-mpikYRJjtrbJgdDHG/H9ySqYqwJ+QU/D7FXsYciS9P7NYBXE2ayKDAy3H0ou6CohOCaxPuTV4SZ0D936+VomHA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/pez/-/pez-6.0.0.tgz",
+      "integrity": "sha512-3bMmsvlqrVNqaNEe4JWLZVpJ40jXuQ3vDy1+fbhyJmuAdMCMCkWexsKc7fT+mu18pFIwJzlenjc4/VE3weTq7w==",
       "requires": {
-        "@hapi/b64": "5.x.x",
-        "@hapi/boom": "9.x.x",
-        "@hapi/content": "^5.0.2",
-        "@hapi/hoek": "9.x.x",
-        "@hapi/nigel": "4.x.x"
+        "@hapi/b64": "^6.0.0",
+        "@hapi/boom": "^10.0.0",
+        "@hapi/content": "^6.0.0",
+        "@hapi/hoek": "^10.0.0",
+        "@hapi/nigel": "^5.0.0"
       },
       "dependencies": {
-        "@hapi/hoek": {
-          "version": "9.3.0",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
-          "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
+        "@hapi/b64": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/@hapi/b64/-/b64-6.0.0.tgz",
+          "integrity": "sha512-Es6o4BtzvMmNF28KJGuwUzUtMjF6ToZ1hQt3UOjaXc6TNkRefel+NyQSjc9b5q3Re7xwv23r0xK3Vo3yreaJHQ==",
+          "requires": {
+            "@hapi/hoek": "^10.0.0"
+          }
+        },
+        "@hapi/boom": {
+          "version": "10.0.0",
+          "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-10.0.0.tgz",
+          "integrity": "sha512-1YVs9tLHhypBqqinKQRqh7FUERIolarQApO37OWkzD+z6y6USi871Sv746zBPKcIOBuI6g6y4FrwX87mmJ90Gg==",
+          "requires": {
+            "@hapi/hoek": "10.x.x"
+          }
         }
       }
     },
@@ -6795,28 +6993,40 @@
       }
     },
     "@hapi/shot": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@hapi/shot/-/shot-5.0.5.tgz",
-      "integrity": "sha512-x5AMSZ5+j+Paa8KdfCoKh+klB78otxF+vcJR/IoN91Vo2e5ulXIW6HUsFTCU+4W6P/Etaip9nmdAx2zWDimB2A==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/shot/-/shot-6.0.0.tgz",
+      "integrity": "sha512-RLGgzXy9GciJDunhY40NbVnLgYqp5gfBooZ2fOkAr4KbCEav/SJtYQS1N+knR7WFGzy8aooCR3XBUPI4ghHAkQ==",
       "requires": {
-        "@hapi/hoek": "9.x.x",
-        "@hapi/validate": "1.x.x"
+        "@hapi/hoek": "^10.0.0",
+        "@hapi/validate": "^2.0.0"
       },
       "dependencies": {
-        "@hapi/hoek": {
-          "version": "9.3.0",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
-          "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
+        "@hapi/topo": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-6.0.0.tgz",
+          "integrity": "sha512-aorJvN1Q1n5xrZuA50Z4X6adI6VAM2NalIVm46ALL9LUvdoqhof3JPY69jdJH8asM3PsWr2SUVYzp57EqUP41A==",
+          "requires": {
+            "@hapi/hoek": "^10.0.0"
+          }
+        },
+        "@hapi/validate": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@hapi/validate/-/validate-2.0.0.tgz",
+          "integrity": "sha512-w5m8MvBgqGndbMIB+AWmXTb8CLtF1DlIxbnbAHNAo7aFuNQuI1Ywc2e0zDLK5fbFXDoqRzNrHnC7JjNJ+hDigw==",
+          "requires": {
+            "@hapi/hoek": "^10.0.0",
+            "@hapi/topo": "^6.0.0"
+          }
         }
       }
     },
     "@hapi/somever": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/somever/-/somever-3.0.1.tgz",
-      "integrity": "sha512-4ZTSN3YAHtgpY/M4GOtHUXgi6uZtG9nEZfNI6QrArhK0XN/RDVgijlb9kOmXwCR5VclDSkBul9FBvhSuKXx9+w==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/somever/-/somever-4.1.0.tgz",
+      "integrity": "sha512-koNBYu7Jdcb7gaC4VcnU78rFxSlsYwuElm6NMznE0EEeznzJtvLLmDZX0SPX8kXWC/E7ONlE29HF/yiSOgWG1Q==",
       "requires": {
-        "@hapi/bounce": "2.x.x",
-        "@hapi/hoek": "9.x.x"
+        "@hapi/bounce": "^3.0.0",
+        "@hapi/hoek": "^9.0.0"
       },
       "dependencies": {
         "@hapi/hoek": {
@@ -6827,54 +7037,95 @@
       }
     },
     "@hapi/statehood": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/@hapi/statehood/-/statehood-7.0.4.tgz",
-      "integrity": "sha512-Fia6atroOVmc5+2bNOxF6Zv9vpbNAjEXNcUbWXavDqhnJDlchwUUwKS5LCi5mGtCTxRhUKKHwuxuBZJkmLZ7fw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/statehood/-/statehood-8.0.0.tgz",
+      "integrity": "sha512-umQTPID7BwmqAv9Rx7yLtbTNzsYg4va96aLqKneb3mlBQG32uq4iOQZ6luwBVACDFhqU3C3ewhznhukN09ZkZQ==",
       "requires": {
-        "@hapi/boom": "9.x.x",
-        "@hapi/bounce": "2.x.x",
-        "@hapi/bourne": "2.x.x",
-        "@hapi/cryptiles": "5.x.x",
-        "@hapi/hoek": "9.x.x",
-        "@hapi/iron": "6.x.x",
-        "@hapi/validate": "1.x.x"
+        "@hapi/boom": "^10.0.0",
+        "@hapi/bounce": "^3.0.0",
+        "@hapi/bourne": "^3.0.0",
+        "@hapi/cryptiles": "^6.0.0",
+        "@hapi/hoek": "^10.0.0",
+        "@hapi/iron": "^7.0.0",
+        "@hapi/validate": "^2.0.0"
       },
       "dependencies": {
-        "@hapi/bourne": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-2.1.0.tgz",
-          "integrity": "sha512-i1BpaNDVLJdRBEKeJWkVO6tYX6DMFBuwMhSuWqLsY4ufeTKGVuV5rBsUhxPayXqnnWHgXUAmWK16H/ykO5Wj4Q=="
+        "@hapi/b64": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/@hapi/b64/-/b64-6.0.0.tgz",
+          "integrity": "sha512-Es6o4BtzvMmNF28KJGuwUzUtMjF6ToZ1hQt3UOjaXc6TNkRefel+NyQSjc9b5q3Re7xwv23r0xK3Vo3yreaJHQ==",
+          "requires": {
+            "@hapi/hoek": "^10.0.0"
+          }
         },
-        "@hapi/hoek": {
-          "version": "9.3.0",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
-          "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
+        "@hapi/boom": {
+          "version": "10.0.0",
+          "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-10.0.0.tgz",
+          "integrity": "sha512-1YVs9tLHhypBqqinKQRqh7FUERIolarQApO37OWkzD+z6y6USi871Sv746zBPKcIOBuI6g6y4FrwX87mmJ90Gg==",
+          "requires": {
+            "@hapi/hoek": "10.x.x"
+          }
+        },
+        "@hapi/cryptiles": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/@hapi/cryptiles/-/cryptiles-6.0.0.tgz",
+          "integrity": "sha512-CUypQJI2F3HaKZjwlky3KyLu7p0O4WJXNJj+2AZ0czqwkwQIz8j+btOkzA3OMar8WTntnCrDx0f92PzxEK+JlA==",
+          "requires": {
+            "@hapi/boom": "^10.0.0"
+          }
+        },
+        "@hapi/iron": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/@hapi/iron/-/iron-7.0.0.tgz",
+          "integrity": "sha512-NNXJP5fpeiTCPj/4OJG2PWBjWC0/V5D8YggS9RZeuBbfUUuTYE6TbdGqLUsCzIpPI54I8W5dhwEGbRv1CnWQtw==",
+          "requires": {
+            "@hapi/b64": "^6.0.0",
+            "@hapi/boom": "^10.0.0",
+            "@hapi/bourne": "^3.0.0",
+            "@hapi/cryptiles": "^6.0.0",
+            "@hapi/hoek": "^10.0.0"
+          }
+        },
+        "@hapi/topo": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-6.0.0.tgz",
+          "integrity": "sha512-aorJvN1Q1n5xrZuA50Z4X6adI6VAM2NalIVm46ALL9LUvdoqhof3JPY69jdJH8asM3PsWr2SUVYzp57EqUP41A==",
+          "requires": {
+            "@hapi/hoek": "^10.0.0"
+          }
+        },
+        "@hapi/validate": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@hapi/validate/-/validate-2.0.0.tgz",
+          "integrity": "sha512-w5m8MvBgqGndbMIB+AWmXTb8CLtF1DlIxbnbAHNAo7aFuNQuI1Ywc2e0zDLK5fbFXDoqRzNrHnC7JjNJ+hDigw==",
+          "requires": {
+            "@hapi/hoek": "^10.0.0",
+            "@hapi/topo": "^6.0.0"
+          }
         }
       }
     },
     "@hapi/subtext": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/@hapi/subtext/-/subtext-7.0.4.tgz",
-      "integrity": "sha512-Y72moHhbRuO8kwBHFEnCRw7oOnhNh4Pl+aonxAze18jkyMpE4Gwz4lNID7ei8vd3lpXC2rKdkxXJgtfY+WttRw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/subtext/-/subtext-8.0.0.tgz",
+      "integrity": "sha512-fD+LY1U1SIUNHZJrNMIbuGl3CAd9JN8slljarFO4b8RrifkzjqbvdlZu/6iT6zlNM35GtDExf7hIepbUFUkT7A==",
       "requires": {
-        "@hapi/boom": "9.x.x",
-        "@hapi/bourne": "2.x.x",
-        "@hapi/content": "^5.0.2",
-        "@hapi/file": "2.x.x",
-        "@hapi/hoek": "9.x.x",
-        "@hapi/pez": "^5.0.1",
-        "@hapi/wreck": "17.x.x"
+        "@hapi/boom": "^10.0.0",
+        "@hapi/bourne": "^3.0.0",
+        "@hapi/content": "^6.0.0",
+        "@hapi/file": "^3.0.0",
+        "@hapi/hoek": "^10.0.0",
+        "@hapi/pez": "^6.0.0",
+        "@hapi/wreck": "^18.0.0"
       },
       "dependencies": {
-        "@hapi/bourne": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-2.1.0.tgz",
-          "integrity": "sha512-i1BpaNDVLJdRBEKeJWkVO6tYX6DMFBuwMhSuWqLsY4ufeTKGVuV5rBsUhxPayXqnnWHgXUAmWK16H/ykO5Wj4Q=="
-        },
-        "@hapi/hoek": {
-          "version": "9.3.0",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
-          "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
+        "@hapi/boom": {
+          "version": "10.0.0",
+          "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-10.0.0.tgz",
+          "integrity": "sha512-1YVs9tLHhypBqqinKQRqh7FUERIolarQApO37OWkzD+z6y6USi871Sv746zBPKcIOBuI6g6y4FrwX87mmJ90Gg==",
+          "requires": {
+            "@hapi/hoek": "10.x.x"
+          }
         }
       }
     },
@@ -6915,18 +7166,11 @@
       }
     },
     "@hapi/vise": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/vise/-/vise-4.0.0.tgz",
-      "integrity": "sha512-eYyLkuUiFZTer59h+SGy7hUm+qE9p+UemePTHLlIWppEd+wExn3Df5jO04bFQTm7nleF5V8CtuYQYb+VFpZ6Sg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/vise/-/vise-5.0.0.tgz",
+      "integrity": "sha512-bz/PA7DHIvsd/2eoW7t9WpU8+k9pofZHppYEn1mCTOVnC/cGN3hCEYaoAe6BpoeJM72iJDKZEOWvQvfgCrmzxA==",
       "requires": {
-        "@hapi/hoek": "9.x.x"
-      },
-      "dependencies": {
-        "@hapi/hoek": {
-          "version": "9.3.0",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
-          "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
-        }
+        "@hapi/hoek": "^10.0.0"
       }
     },
     "@hapi/vision": {
@@ -6946,15 +7190,6 @@
           "integrity": "sha512-1YVs9tLHhypBqqinKQRqh7FUERIolarQApO37OWkzD+z6y6USi871Sv746zBPKcIOBuI6g6y4FrwX87mmJ90Gg==",
           "requires": {
             "@hapi/hoek": "10.x.x"
-          }
-        },
-        "@hapi/bounce": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@hapi/bounce/-/bounce-3.0.0.tgz",
-          "integrity": "sha512-L0G4NcwwOYRhpcXeL76hNrLTUcObqtZMB3z4kcRVUZcR/w3v6C5Q1cTElV4/V7og1fG+wOyDR55UMFA+tWfhtA==",
-          "requires": {
-            "@hapi/boom": "^10.0.0",
-            "@hapi/hoek": "^10.0.0"
           }
         },
         "@hapi/topo": {
@@ -6977,24 +7212,22 @@
       }
     },
     "@hapi/wreck": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-17.2.0.tgz",
-      "integrity": "sha512-pJ5kjYoRPYDv+eIuiLQqhGon341fr2bNIYZjuotuPJG/3Ilzr/XtI+JAp0A86E2bYfsS3zBPABuS2ICkaXFT8g==",
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-18.0.0.tgz",
+      "integrity": "sha512-Yk9STxoM06Hjjq58cH0KFG91u9F2h9eVE72o8vUr3AfK80qt7I2POG5+cDGTEntbnvvzm0ERow2sjG3QsqCWUA==",
       "requires": {
-        "@hapi/boom": "9.x.x",
-        "@hapi/bourne": "2.x.x",
-        "@hapi/hoek": "9.x.x"
+        "@hapi/boom": "^10.0.0",
+        "@hapi/bourne": "^3.0.0",
+        "@hapi/hoek": "^10.0.0"
       },
       "dependencies": {
-        "@hapi/bourne": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-2.1.0.tgz",
-          "integrity": "sha512-i1BpaNDVLJdRBEKeJWkVO6tYX6DMFBuwMhSuWqLsY4ufeTKGVuV5rBsUhxPayXqnnWHgXUAmWK16H/ykO5Wj4Q=="
-        },
-        "@hapi/hoek": {
-          "version": "9.3.0",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
-          "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
+        "@hapi/boom": {
+          "version": "10.0.0",
+          "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-10.0.0.tgz",
+          "integrity": "sha512-1YVs9tLHhypBqqinKQRqh7FUERIolarQApO37OWkzD+z6y6USi871Sv746zBPKcIOBuI6g6y4FrwX87mmJ90Gg==",
+          "requires": {
+            "@hapi/hoek": "10.x.x"
+          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "license": "OGL-UK-3.0",
   "dependencies": {
     "@airbrake/node": "^2.1.7",
-    "@hapi/hapi": "^20.2.2",
+    "@hapi/hapi": "^21.0.0",
     "@hapi/inert": "^7.0.0",
     "@hapi/vision": "^7.0.0",
     "blipp": "^4.0.2",

--- a/package.json
+++ b/package.json
@@ -29,14 +29,14 @@
     "@hapi/vision": "^7.0.0",
     "blipp": "^4.0.2",
     "dotenv": "^16.0.3",
-    "got": "^12.5.2",
-    "govuk-frontend": "^4.3.1",
-    "hapi-pino": "^11.0.0",
+    "got": "^12.5.3",
+    "govuk-frontend": "^4.4.0",
+    "hapi-pino": "^11.0.1",
     "knex": "^2.3.0",
     "nunjucks": "^3.2.3",
     "objection": "^3.0.1",
     "pg": "^8.8.0",
-    "sass": "^1.55.0"
+    "sass": "^1.56.1"
   },
   "devDependencies": {
     "@hapi/code": "^9.0.1",
@@ -45,7 +45,7 @@
     "nock": "^13.2.9",
     "pino-pretty": "^9.1.1",
     "proxyquire": "^2.1.3",
-    "sinon": "^14.0.1",
+    "sinon": "^14.0.2",
     "standard": "^17.0.0"
   }
 }


### PR DESCRIPTION
Noticed that @hapi/hapi is a major version out so thought I'd get it updated.

I'll also bump the minor and patch versions of the other packages as required. These have already been bumped in the lock file, just need to tidy up the package.json.