### PR TITLE
Update licences response in supplementary

### DIFF
--- a/app/controllers/test/supplementary.controller.js
+++ b/app/controllers/test/supplementary.controller.js
@@ -5,14 +5,11 @@
  * @module SupplementaryController
  */
 
-const FetchRegionService = require('../../services/supplementary-billing/fetch-region.service.js')
 const SupplementaryService = require('../../services/supplementary-billing/supplementary.service.js')
 
 class SupplementaryController {
   static async index (request, h) {
-    const { regionId } = await FetchRegionService.go(request.query.region)
-
-    const result = await SupplementaryService.go(regionId)
+    const result = await SupplementaryService.go(request.query.region)
 
     return h.response(result).code(200)
   }

--- a/app/controllers/test/supplementary.controller.js
+++ b/app/controllers/test/supplementary.controller.js
@@ -5,12 +5,12 @@
  * @module SupplementaryController
  */
 
-const FindRegionService = require('../../services/supplementary-billing/find-region.service.js')
+const FetchRegionService = require('../../services/supplementary-billing/fetch-region.service.js')
 const SupplementaryService = require('../../services/supplementary-billing/supplementary.service.js')
 
 class SupplementaryController {
   static async index (request, h) {
-    const { regionId } = await FindRegionService.go(request.query.region)
+    const { regionId } = await FetchRegionService.go(request.query.region)
 
     const result = await SupplementaryService.go(regionId)
 

--- a/app/presenters/supplementary.presenter.js
+++ b/app/presenters/supplementary.presenter.js
@@ -14,44 +14,13 @@ class SupplementaryPresenter {
     return this._presentation(this._data)
   }
 
-  /**
-   * Creates an array of unique licence objects from the combined data received
-   *
-   * We know the main query in `SupplementaryService` is based on charge versions. As a licence may be linked to
-   * multiple charge versions, it is possible that the licence ID and reference will feature multiple times in the
-   * results.
-   *
-   * To make it easier to confirm we are including the right licences in the Supplementary bill run process we want to
-   * extract a unique list of licence ID's and references.
-   *
-   * @param {Object[]} chargeVersions Results of a call to SupplementaryService and the charge version info it returns
-   *
-   * @returns {Object[]} Array of objects representing the unique licence details in the charge versions passed in
-   */
-  _licences (chargeVersions) {
-    // Use map to generate an array of just licence IDs
-    const justLicenceIds = chargeVersions.map((chargeVersion) => chargeVersion.licenceId)
-    // Set is used to store unique values. So, if you what you pass in contains duplicates Set will return just the
-    // unique ones
-    const uniqueLicenceIds = new Set(justLicenceIds)
-
-    const licences = []
-    for (const id of uniqueLicenceIds) {
-      // Iterate through our unique Licence Id's and use them to find the index for the first matching entry in the
-      // charge versions data
-      const index = chargeVersions.findIndex((chargeVersion) => chargeVersion.licenceId === id)
-      // Destructure the licenceId and licenceRef from the matching object
-      const { licenceId, licenceRef } = chargeVersions[index]
-
-      // Push a new object into our array of licences
-      licences.push({ licenceId, licenceRef })
-    }
-
-    return licences
-  }
-
   _presentation (data) {
-    const licences = this._licences(data.chargeVersions)
+    const licences = data.licences.map((licence) => {
+      return {
+        licenceId: licence.licenceId,
+        licenceRef: licence.licenceRef
+      }
+    })
     const chargeVersions = data.chargeVersions.map((chargeVersion) => {
       return {
         chargeVersionId: chargeVersion.chargeVersionId,

--- a/app/services/supplementary-billing/fetch-licences.service.js
+++ b/app/services/supplementary-billing/fetch-licences.service.js
@@ -9,13 +9,12 @@ const LicenceModel = require('../../models/licence.model.js')
 
 class FetchLicencesService {
   /**
-   * Returns the `region_id` for the matching record in `water.regions`
+   * Fetches licences flagged for supplementary billing that are linked to the selected region
    *
-   * > This is a temporary service added whilst developing the new SROC supplementary bill run functionality. We expect
-   * > the region ID to be provided by the UI as part of the normal workflow
+   * This is a temporary service to help us confirm we are selecting the correct data to use when creating a
+   * supplementary bill run. Its primary aim is to meet the acceptance criteria defined in WATER-3787.
    *
-   * @param {string} naldRegionId The NALD region ID (a number between 1 to 9, 9 being the test region) for the region
-   * to find
+   * @param {Objecy} region Instance of `RegionModel` for the selected region
    *
    * @returns {Object[]} Array of matching `LicenceModel`
    */

--- a/app/services/supplementary-billing/fetch-licences.service.js
+++ b/app/services/supplementary-billing/fetch-licences.service.js
@@ -1,0 +1,37 @@
+'use strict'
+
+/**
+ * Fetches a region based on the NALD region ID provided
+ * @module FetchLicencesService
+ */
+
+const LicenceModel = require('../../models/licence.model.js')
+
+class FetchLicencesService {
+  /**
+   * Returns the `region_id` for the matching record in `water.regions`
+   *
+   * > This is a temporary service added whilst developing the new SROC supplementary bill run functionality. We expect
+   * > the region ID to be provided by the UI as part of the normal workflow
+   *
+   * @param {string} naldRegionId The NALD region ID (a number between 1 to 9, 9 being the test region) for the region
+   * to find
+   *
+   * @returns {Object[]} Array of matching `LicenceModel`
+   */
+  static async go (region) {
+    const licences = await this._fetch(region)
+
+    return licences
+  }
+
+  static async _fetch (region) {
+    const result = await LicenceModel.query()
+      .where('region_id', region.regionId)
+      .where('include_in_supplementary_billing', 'yes')
+
+    return result
+  }
+}
+
+module.exports = FetchLicencesService

--- a/app/services/supplementary-billing/fetch-region.service.js
+++ b/app/services/supplementary-billing/fetch-region.service.js
@@ -2,12 +2,12 @@
 
 /**
  * Fetches a region based on the NALD region ID provided
- * @module FindRegionService
+ * @module FetchRegionService
  */
 
 const { db } = require('../../../db/db.js')
 
-class FindRegionService {
+class FetchRegionService {
   /**
    * Returns the `region_id` for the matching record in `water.regions`
    *
@@ -20,12 +20,12 @@ class FindRegionService {
    * @returns {string} The region_id (a GUID) for the matching region
    */
   static async go (naldRegionId) {
-    const region = await this._fetchRegion(naldRegionId)
+    const region = await this._fetch(naldRegionId)
 
     return region
   }
 
-  static async _fetchRegion (naldRegionId) {
+  static async _fetch (naldRegionId) {
     const result = await db
       .select('region_id')
       .from('water.regions')
@@ -38,4 +38,4 @@ class FindRegionService {
   }
 }
 
-module.exports = FindRegionService
+module.exports = FetchRegionService

--- a/app/services/supplementary-billing/fetch-region.service.js
+++ b/app/services/supplementary-billing/fetch-region.service.js
@@ -9,15 +9,15 @@ const RegionModel = require('../../models/region.model.js')
 
 class FetchRegionService {
   /**
-   * Returns the `region_id` for the matching record in `water.regions`
+   * Fetches the region with the matching NALD Region ID
    *
-   * > This is a temporary service added whilst developing the new SROC supplementary bill run functionality. We expect
-   * > the region ID to be provided by the UI as part of the normal workflow
+   * This is a temporary service to help us confirm we are selecting the correct data to use when creating a
+   * supplementary bill run. Its primary aim is to meet the acceptance criteria defined in WATER-3787.
    *
    * @param {string} naldRegionId The NALD region ID (a number between 1 to 9, 9 being the test region) for the region
    * to find
    *
-   * @returns {string} The region_id (a GUID) for the matching region
+   * @returns {Object} Instance of `RegionModel` with the matching NALD Region ID
    */
   static async go (naldRegionId) {
     const region = await this._fetch(naldRegionId)

--- a/app/services/supplementary-billing/fetch-region.service.js
+++ b/app/services/supplementary-billing/fetch-region.service.js
@@ -5,7 +5,7 @@
  * @module FetchRegionService
  */
 
-const { db } = require('../../../db/db.js')
+const RegionModel = require('../../models/region.model.js')
 
 class FetchRegionService {
   /**
@@ -26,12 +26,8 @@ class FetchRegionService {
   }
 
   static async _fetch (naldRegionId) {
-    const result = await db
-      .select('region_id')
-      .from('water.regions')
-      .where({
-        nald_region_id: naldRegionId
-      })
+    const result = await RegionModel.query()
+      .where('nald_region_id', naldRegionId)
       .first()
 
     return result

--- a/app/services/supplementary-billing/supplementary.service.js
+++ b/app/services/supplementary-billing/supplementary.service.js
@@ -7,20 +7,22 @@
 
 const BillingPeriodService = require('./billing-period.service.js')
 const FetchChargeVersionsService = require('./fetch-charge-versions.service.js')
+const FetchLicencesService = require('./fetch-licences.service.js')
 const FetchRegionService = require('./fetch-region.service.js')
 const SupplementaryPresenter = require('../../presenters/supplementary.presenter.js')
 
 class SupplementaryService {
   static async go (naldRegionId) {
     const region = await FetchRegionService.go(naldRegionId)
-    const chargeVersions = await FetchChargeVersionsService.go(region.regionId)
     const billingPeriods = BillingPeriodService.go()
+    const licences = await FetchLicencesService.go(region)
+    const chargeVersions = await FetchChargeVersionsService.go(region.regionId)
 
-    return this._response(chargeVersions, billingPeriods)
+    return this._response({ billingPeriods, licences, chargeVersions })
   }
 
-  static _response (chargeVersions, billingPeriods) {
-    const presenter = new SupplementaryPresenter({ chargeVersions, billingPeriods })
+  static _response (data) {
+    const presenter = new SupplementaryPresenter(data)
 
     return presenter.go()
   }

--- a/app/services/supplementary-billing/supplementary.service.js
+++ b/app/services/supplementary-billing/supplementary.service.js
@@ -7,11 +7,13 @@
 
 const BillingPeriodService = require('./billing-period.service.js')
 const FetchChargeVersionsService = require('./fetch-charge-versions.service.js')
+const FetchRegionService = require('./fetch-region.service.js')
 const SupplementaryPresenter = require('../../presenters/supplementary.presenter.js')
 
 class SupplementaryService {
-  static async go (regionId) {
-    const chargeVersions = await FetchChargeVersionsService.go(regionId)
+  static async go (naldRegionId) {
+    const region = await FetchRegionService.go(naldRegionId)
+    const chargeVersions = await FetchChargeVersionsService.go(region.regionId)
     const billingPeriods = BillingPeriodService.go()
 
     return this._response(chargeVersions, billingPeriods)

--- a/test/controllers/test/supplementary.controller.test.js
+++ b/test/controllers/test/supplementary.controller.test.js
@@ -12,7 +12,7 @@ const { expect } = Code
 const LicenceHelper = require('../../support/helpers/licence.helper.js')
 
 // Things we need to stub
-const FindRegionService = require('../../../app/services/supplementary-billing/find-region.service.js')
+const FetchRegionService = require('../../../app/services/supplementary-billing/fetch-region.service.js')
 const SupplementaryService = require('../../../app/services/supplementary-billing/supplementary.service.js')
 
 // For running our service
@@ -38,7 +38,7 @@ describe('Supplementary controller', () => {
     let response
 
     beforeEach(async () => {
-      Sinon.stub(FindRegionService, 'go').resolves({ regionId: LicenceHelper.defaults().region_id })
+      Sinon.stub(FetchRegionService, 'go').resolves({ regionId: LicenceHelper.defaults().region_id })
       Sinon.stub(SupplementaryService, 'go').resolves({ chargeVersions: [] })
 
       response = await server.inject(options)

--- a/test/controllers/test/supplementary.controller.test.js
+++ b/test/controllers/test/supplementary.controller.test.js
@@ -8,11 +8,7 @@ const Sinon = require('sinon')
 const { describe, it, beforeEach, after } = exports.lab = Lab.script()
 const { expect } = Code
 
-// Test helpers
-const LicenceHelper = require('../../support/helpers/licence.helper.js')
-
 // Things we need to stub
-const FetchRegionService = require('../../../app/services/supplementary-billing/fetch-region.service.js')
 const SupplementaryService = require('../../../app/services/supplementary-billing/supplementary.service.js')
 
 // For running our service
@@ -38,8 +34,7 @@ describe('Supplementary controller', () => {
     let response
 
     beforeEach(async () => {
-      Sinon.stub(FetchRegionService, 'go').resolves({ regionId: LicenceHelper.defaults().region_id })
-      Sinon.stub(SupplementaryService, 'go').resolves({ chargeVersions: [] })
+      Sinon.stub(SupplementaryService, 'go').resolves({ billingPeriods: [], licences: [], chargeVersions: [] })
 
       response = await server.inject(options)
     })

--- a/test/presenters/supplementary.presenter.test.js
+++ b/test/presenters/supplementary.presenter.test.js
@@ -19,6 +19,9 @@ describe('Supplementary presenter', () => {
         billingPeriods: [
           { startDate: new Date(2022, 3, 1), endDate: new Date(2023, 2, 31) }
         ],
+        licences: [
+          { licenceId: '0000579f-0f8f-4e21-b63a-063384ad32c8', licenceRef: 'AT/SROC/SUPB/01' }
+        ],
         chargeVersions: [
           {
             chargeVersionId: '4b5cbe04-a0e2-468c-909e-1e2d93810ba8',
@@ -60,6 +63,7 @@ describe('Supplementary presenter', () => {
     beforeEach(() => {
       data = {
         billingPeriods: [],
+        licences: [],
         chargeVersions: []
       }
     })

--- a/test/services/supplementary-billing/billing-period.service.test.js
+++ b/test/services/supplementary-billing/billing-period.service.test.js
@@ -11,7 +11,7 @@ const { expect } = Code
 // Thing under test
 const BillingPeriodService = require('../../../app/services/supplementary-billing/billing-period.service.js')
 
-describe('BillingPeriod service', () => {
+describe('Billing Period service', () => {
   afterEach(() => {
     Sinon.restore()
   })

--- a/test/services/supplementary-billing/fetch-charge-versions.service.test.js
+++ b/test/services/supplementary-billing/fetch-charge-versions.service.test.js
@@ -15,7 +15,7 @@ const LicenceHelper = require('../../support/helpers/licence.helper.js')
 // Thing under test
 const FetchChargeVersionsService = require('../../../app/services/supplementary-billing/fetch-charge-versions.service.js')
 
-describe('FetchChargeVersions service', () => {
+describe('Fetch Charge Versions service', () => {
   const { region_id: regionId } = LicenceHelper.defaults()
   let testRecords
 

--- a/test/services/supplementary-billing/fetch-licences.service.test.js
+++ b/test/services/supplementary-billing/fetch-licences.service.test.js
@@ -14,7 +14,7 @@ const LicenceHelper = require('../../support/helpers/licence.helper.js')
 // Thing under test
 const FetchLicencesService = require('../../../app/services/supplementary-billing/fetch-licences.service.js')
 
-describe('FetchLicencesService service', () => {
+describe('Fetch Licences service', () => {
   const region = { regionId: LicenceHelper.defaults().region_id }
   let testRecords
 

--- a/test/services/supplementary-billing/fetch-licences.service.test.js
+++ b/test/services/supplementary-billing/fetch-licences.service.test.js
@@ -1,0 +1,63 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const DatabaseHelper = require('../../support/helpers/database.helper.js')
+const LicenceHelper = require('../../support/helpers/licence.helper.js')
+
+// Thing under test
+const FetchLicencesService = require('../../../app/services/supplementary-billing/fetch-licences.service.js')
+
+describe('FetchLicencesService service', () => {
+  const region = { regionId: LicenceHelper.defaults().region_id }
+  let testRecords
+
+  beforeEach(async () => {
+    await DatabaseHelper.clean()
+  })
+
+  describe('when there are licences for the matching region', () => {
+    describe('that are flagged to be included in supplementary billing', () => {
+      beforeEach(async () => {
+        testRecords = await LicenceHelper.add({ include_in_supplementary_billing: 'yes' })
+      })
+
+      it('returns results', async () => {
+        const result = await FetchLicencesService.go(region)
+
+        expect(result.length).to.equal(1)
+        expect(result[0].licenceId).to.equal(testRecords[0].licenceId)
+      })
+    })
+
+    describe('that are not flagged to be included in supplementary billing', () => {
+      beforeEach(async () => {
+        LicenceHelper.add()
+      })
+
+      it('returns no results', async () => {
+        const result = await FetchLicencesService.go(region)
+
+        expect(result.length).to.equal(0)
+      })
+    })
+  })
+
+  describe('when there are no licences for the matching region', () => {
+    beforeEach(async () => {
+      LicenceHelper.add({ region_id: '000446bd-182a-4340-be6b-d719855ace1a' })
+    })
+
+    it('returns no results', async () => {
+      const result = await FetchLicencesService.go(region)
+
+      expect(result.length).to.equal(0)
+    })
+  })
+})

--- a/test/services/supplementary-billing/fetch-region.service.test.js
+++ b/test/services/supplementary-billing/fetch-region.service.test.js
@@ -14,7 +14,7 @@ const RegionHelper = require('../../support/helpers/region.helper.js')
 // Thing under test
 const FetchRegionService = require('../../../app/services/supplementary-billing/fetch-region.service.js')
 
-describe('Fetch Regio Service', () => {
+describe('Fetch Region service', () => {
   const naldRegionId = 9
   let testRecords
 

--- a/test/services/supplementary-billing/fetch-region.service.test.js
+++ b/test/services/supplementary-billing/fetch-region.service.test.js
@@ -1,0 +1,48 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const DatabaseHelper = require('../../support/helpers/database.helper.js')
+const RegionHelper = require('../../support/helpers/region.helper.js')
+
+// Thing under test
+const FetchRegionService = require('../../../app/services/supplementary-billing/fetch-region.service.js')
+
+describe('Fetch Regio Service', () => {
+  const naldRegionId = 9
+  let testRecords
+
+  beforeEach(async () => {
+    await DatabaseHelper.clean()
+  })
+
+  describe('when there is a region with a matching NALD region id', () => {
+    beforeEach(async () => {
+      testRecords = await RegionHelper.add()
+    })
+
+    it('returns results', async () => {
+      const result = await FetchRegionService.go(naldRegionId)
+
+      expect(result.regionId).to.equal(testRecords[0].regionId)
+    })
+  })
+
+  describe('when there is no region with a matching NALD region id', () => {
+    beforeEach(async () => {
+      RegionHelper.add({ nald_region_id: 99 })
+    })
+
+    it('returns no results', async () => {
+      const result = await FetchRegionService.go(naldRegionId)
+
+      expect(result).to.be.undefined()
+    })
+  })
+})

--- a/test/services/supplementary-billing/supplementary.service.test.js
+++ b/test/services/supplementary-billing/supplementary.service.test.js
@@ -10,11 +10,16 @@ const { expect } = Code
 
 // Things we need to stub
 const FetchChargeVersionsService = require('../../../app/services/supplementary-billing/fetch-charge-versions.service.js')
+const FetchRegionService = require('../../../app/services/supplementary-billing/fetch-region.service.js')
 
 // Thing under test
 const SupplementaryService = require('../../../app/services/supplementary-billing/supplementary.service.js')
 
 describe('Supplementary service', () => {
+  beforeEach(async () => {
+    Sinon.stub(FetchRegionService, 'go').resolves({ regionId: 'bd114474-790f-4470-8ba4-7b0cc9c225d7' })
+  })
+
   afterEach(() => {
     Sinon.restore()
   })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3787

As part of our first pass at getting the supplementary process kicked off and working, we are just trying to ensure that the records we are working with match the acceptance criteria of the tickets the team have created.

The acceptance criteria for WATER-3787 is all licences flagged for supplementary billing for a selected region. At the moment the licence results we returned are generated by extracting the unique licence references from our charge versions results. This means we're only showing licences after an additional filter has been applied.

Currently, this is only for testing purposes so there is no fear of what we are doing making the final version. But to better align with the ticket and its acceptance criteria, this change updates the supplementary service to return a separate 'licences' result.