### PR TITLE
Update licence query to just return SROC

### DIFF
--- a/app/services/supplementary-billing/fetch-licences.service.js
+++ b/app/services/supplementary-billing/fetch-licences.service.js
@@ -26,8 +26,10 @@ class FetchLicencesService {
 
   static async _fetch (region) {
     const result = await LicenceModel.query()
+      .innerJoinRelated('chargeVersions')
       .where('region_id', region.regionId)
       .where('include_in_supplementary_billing', 'yes')
+      .where('chargeVersions.scheme', 'sroc')
 
     return result
   }

--- a/test/services/supplementary-billing/fetch-licences.service.test.js
+++ b/test/services/supplementary-billing/fetch-licences.service.test.js
@@ -8,6 +8,7 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
+const ChargeVersionHelper = require('../../support/helpers/charge-version.helper.js')
 const DatabaseHelper = require('../../support/helpers/database.helper.js')
 const LicenceHelper = require('../../support/helpers/licence.helper.js')
 
@@ -30,10 +31,10 @@ describe('Fetch Licences service', () => {
 
       describe('and that have an SROC charge version', () => {
         beforeEach(async () => {
-          // testRecords = await LicenceHelper.add({ include_in_supplementary_billing: 'yes' })
+          await ChargeVersionHelper.add({}, testRecords[0])
         })
 
-        it('returns results', async () => {
+        it.only('returns results', async () => {
           const result = await FetchLicencesService.go(region)
 
           expect(result.length).to.equal(1)

--- a/test/services/supplementary-billing/fetch-licences.service.test.js
+++ b/test/services/supplementary-billing/fetch-licences.service.test.js
@@ -34,7 +34,7 @@ describe('Fetch Licences service', () => {
           await ChargeVersionHelper.add({}, testRecords[0])
         })
 
-        it.only('returns results', async () => {
+        it('returns results', async () => {
           const result = await FetchLicencesService.go(region)
 
           expect(result.length).to.equal(1)

--- a/test/services/supplementary-billing/fetch-licences.service.test.js
+++ b/test/services/supplementary-billing/fetch-licences.service.test.js
@@ -28,11 +28,25 @@ describe('Fetch Licences service', () => {
         testRecords = await LicenceHelper.add({ include_in_supplementary_billing: 'yes' })
       })
 
-      it('returns results', async () => {
-        const result = await FetchLicencesService.go(region)
+      describe('and that have an SROC charge version', () => {
+        beforeEach(async () => {
+          // testRecords = await LicenceHelper.add({ include_in_supplementary_billing: 'yes' })
+        })
 
-        expect(result.length).to.equal(1)
-        expect(result[0].licenceId).to.equal(testRecords[0].licenceId)
+        it('returns results', async () => {
+          const result = await FetchLicencesService.go(region)
+
+          expect(result.length).to.equal(1)
+          expect(result[0].licenceId).to.equal(testRecords[0].licenceId)
+        })
+      })
+
+      describe('but do not have an SROC charge version', () => {
+        it('returns no results', async () => {
+          const result = await FetchLicencesService.go(region)
+
+          expect(result.length).to.equal(0)
+        })
       })
     })
 

--- a/test/support/helpers/charge-version.helper.js
+++ b/test/support/helpers/charge-version.helper.js
@@ -28,7 +28,11 @@ class ChargeVersionHelper {
    * @returns {string} The ID of the newly created record
    */
   static async add (data = {}, licence = {}) {
-    const licenceId = await this._addLicence(licence)
+    let licenceId = licence?.licenceId
+    if (!licenceId) {
+      licenceId = await this._addLicence(licence)
+    }
+
     const insertData = this.defaults({ ...data, licence_id: licenceId })
 
     const result = await db.table('water.charge_versions')


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3787

The original acceptance criteria for what licences to consider was anything flagged as 'include in supplementary billing'.

There are reasons why those that are void, deferred, revoked etc still need to be included. But our current scope is to generate SROC supplementary bill runs. So, on review, it makes sense that we only look at licences that have at least 1 SROC charge version.

This change updates our query to filter out anything that isn't SROC.