### PR TITLE
Fix Objection model relations

### DIFF
--- a/app/models/charge-version.model.js
+++ b/app/models/charge-version.model.js
@@ -16,7 +16,7 @@ class ChargeVersionModel extends BaseModel {
 
   static get relationMappings () {
     return {
-      licences: {
+      licence: {
         relation: Model.BelongsToOneRelation,
         modelClass: 'licence.model',
         join: {

--- a/app/models/charge-version.model.js
+++ b/app/models/charge-version.model.js
@@ -11,7 +11,7 @@ const BaseModel = require('./base.model.js')
 
 class ChargeVersionModel extends BaseModel {
   static get tableName () {
-    return 'water.chargeVersions'
+    return 'water.charge_versions'
   }
 
   static get relationMappings () {

--- a/app/models/licence.model.js
+++ b/app/models/licence.model.js
@@ -24,7 +24,7 @@ class LicenceModel extends BaseModel {
           to: 'water.charge_versions.licence_id'
         }
       },
-      regions: {
+      region: {
         relation: Model.BelongsToOneRelation,
         modelClass: 'region.model',
         join: {

--- a/app/models/region.model.js
+++ b/app/models/region.model.js
@@ -17,7 +17,7 @@ class RegionModel extends BaseModel {
   static get relationMappings () {
     return {
       licences: {
-        relation: Model.BelongsToOneRelation,
+        relation: Model.HasManyRelation,
         modelClass: 'licence.model',
         join: {
           from: 'water.regions.region_id',

--- a/test/models/charge-version.model.test.js
+++ b/test/models/charge-version.model.test.js
@@ -11,9 +11,20 @@ const { expect } = Code
 const ChargeVersion = require('../../app/models/charge-version.model.js')
 
 describe('ChargeVersion model', () => {
-  it('returns data', async () => {
+  it('can successfully run a query', async () => {
     const query = await ChargeVersion.query()
 
     expect(query).to.exist()
+  })
+
+  describe('Relationships', () => {
+    describe('when linking to charge versions', () => {
+      it('can successfully run a query', async () => {
+        const query = await ChargeVersion.query()
+          .innerJoinRelated('licence')
+
+        expect(query).to.exist()
+      })
+    })
   })
 })

--- a/test/models/licence.model.test.js
+++ b/test/models/licence.model.test.js
@@ -11,9 +11,29 @@ const { expect } = Code
 const Licence = require('../../app/models/licence.model.js')
 
 describe('Licence model', () => {
-  it('returns data', async () => {
+  it('can successfully run a query', async () => {
     const query = await Licence.query()
 
     expect(query).to.exist()
+  })
+
+  describe('Relationships', () => {
+    describe('when linking to charge versions', () => {
+      it('can successfully run a query', async () => {
+        const query = await Licence.query()
+          .innerJoinRelated('chargeVersions')
+
+        expect(query).to.exist()
+      })
+    })
+
+    describe('when linking to region', () => {
+      it('can successfully run a query', async () => {
+        const query = await Licence.query()
+          .innerJoinRelated('region')
+
+        expect(query).to.exist()
+      })
+    })
   })
 })

--- a/test/models/region.model.test.js
+++ b/test/models/region.model.test.js
@@ -11,9 +11,20 @@ const { expect } = Code
 const Region = require('../../app/models/region.model.js')
 
 describe('Region model', () => {
-  it('returns data', async () => {
-    const query = await Region.query()
+  it('can successfully run a query', async () => {
+    const result = await Region.query()
 
-    expect(query).to.exist()
+    expect(result).to.exist()
+  })
+
+  describe('Relationships', () => {
+    describe('when linking to licences', () => {
+      it('can successfully run a query', async () => {
+        const result = await Region.query()
+          .innerJoinRelated('licences')
+
+        expect(result).to.exist()
+      })
+    })
   })
 })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3829

Our [first attempt](https://github.com/DEFRA/water-abstraction-system/pull/43) to generate a query that uses relations is erroring.

```text
Licence.relationMappings.charge-versions: join: either `from` or `to` must point to the owner model table and the other one to the related table. It might be that specified table 'water.charge_versions` is not correct
```

Initially, we thought it was the way we're working with schemas as highlighted in [this issue](https://github.com/Vincit/objection.js/issues/85). But actually, it was just a typo.

So, this change fixes that. It also corrects some other details of the relationships and adds some tests just to ensure they are working as expected.
