### PR TITLE
Fix test licences query

### DIFF
--- a/app/services/supplementary-billing/fetch-licences.service.js
+++ b/app/services/supplementary-billing/fetch-licences.service.js
@@ -25,6 +25,7 @@ async function go (region) {
 
 async function _fetch (region) {
   const result = await LicenceModel.query()
+    .distinctOn('licence_id')
     .innerJoinRelated('chargeVersions')
     .where('region_id', region.regionId)
     .where('include_in_supplementary_billing', 'yes')

--- a/test/services/supplementary-billing/fetch-licences.service.test.js
+++ b/test/services/supplementary-billing/fetch-licences.service.test.js
@@ -42,6 +42,20 @@ describe('Fetch Licences service', () => {
         })
       })
 
+      describe('and that have multiple SROC charge versions', () => {
+        beforeEach(async () => {
+          await ChargeVersionHelper.add({}, testRecords[0])
+          await ChargeVersionHelper.add({}, testRecords[0])
+        })
+
+        it('returns a licence only once in the results', async () => {
+          const result = await FetchLicencesService.go(region)
+
+          expect(result.length).to.equal(1)
+          expect(result[0].licenceId).to.equal(testRecords[0].licenceId)
+        })
+      })
+
       describe('but do not have an SROC charge version', () => {
         it('returns no results', async () => {
           const result = await FetchLicencesService.go(region)


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3787

We've built a query to demonstrate what licences we are considering when building an SROC supplementary bill run. It's been highlighted that the query is returning duplicate results. A quick check found it's where we have a licence flagged for supplementary billing that has more than 1 SROC charge version. The inner join means we get a row per charge version.

This change fixes the issue, making our results distinct.