### PR TITLE
Add Create Sroc Bill Run endpoint

### DIFF
--- a/app/controllers/bill-runs.controller.js
+++ b/app/controllers/bill-runs.controller.js
@@ -1,0 +1,14 @@
+'use strict'
+
+/**
+ * Controller for /bill-runs endpoints
+ * @module BillRunsController
+ */
+
+async function createBillRun (_request, _h) {
+  return { test: 'ok' }
+}
+
+module.exports = {
+  createBillRun
+}

--- a/app/controllers/bill-runs.controller.js
+++ b/app/controllers/bill-runs.controller.js
@@ -20,7 +20,7 @@ async function createBillRun (request, h) {
     id: 'DUMMY_SROC_BATCH',
     region: validatedData.value.region,
     scheme: validatedData.value.scheme,
-    batchType: validatedData.value.type,
+    type: validatedData.value.type,
     status: 'ready'
   }
 }

--- a/app/controllers/bill-runs.controller.js
+++ b/app/controllers/bill-runs.controller.js
@@ -9,7 +9,7 @@ const Boom = require('@hapi/boom')
 
 const CreateBillRunValidator = require('../validators/bill-runs/create-bill-run.validator')
 
-async function createBillRun (request, h) {
+async function createBillRun (request, _h) {
   const validatedData = CreateBillRunValidator.go(request.payload)
 
   if (validatedData.error) {

--- a/app/controllers/bill-runs.controller.js
+++ b/app/controllers/bill-runs.controller.js
@@ -5,6 +5,8 @@
  * @module BillRunsController
  */
 
+const Boom = require('@hapi/boom')
+
 const CreateBillRunValidator = require('../validators/bill-runs/create-bill-run.validator')
 
 async function createBillRun (request, h) {
@@ -12,8 +14,12 @@ async function createBillRun (request, h) {
     const validatedData = await CreateBillRunValidator.go(request.payload)
     return validatedData
   } catch (error) {
-    return h.response(error.details[0]).code(400)
+    return _formattedValidationError(error)
   }
+}
+// Takes an error from a validator and returns a suitable Boom error
+function _formattedValidationError (e) {
+  return Boom.badRequest(e.details[0].message)
 }
 
 module.exports = {

--- a/app/controllers/bill-runs.controller.js
+++ b/app/controllers/bill-runs.controller.js
@@ -10,13 +10,15 @@ const Boom = require('@hapi/boom')
 const CreateBillRunValidator = require('../validators/bill-runs/create-bill-run.validator')
 
 async function createBillRun (request, h) {
-  try {
-    const validatedData = await CreateBillRunValidator.go(request.payload)
-    return validatedData
-  } catch (error) {
-    return _formattedValidationError(error)
+  const result = CreateBillRunValidator.go(request.payload)
+
+  if (result.error) {
+    return _formattedValidationError(result.error)
   }
+
+  return result.value
 }
+
 // Takes an error from a validator and returns a suitable Boom error
 function _formattedValidationError (e) {
   return Boom.badRequest(e.details[0].message)

--- a/app/controllers/bill-runs.controller.js
+++ b/app/controllers/bill-runs.controller.js
@@ -5,8 +5,15 @@
  * @module BillRunsController
  */
 
-async function createBillRun (_request, _h) {
-  return { test: 'ok' }
+const CreateBillRunValidator = require('../validators/bill-runs/create-bill-run.validator')
+
+async function createBillRun (request, h) {
+  try {
+    const validatedData = await CreateBillRunValidator.go(request.payload)
+    return validatedData
+  } catch (error) {
+    return h.response(error.details[0]).code(400)
+  }
 }
 
 module.exports = {

--- a/app/controllers/bill-runs.controller.js
+++ b/app/controllers/bill-runs.controller.js
@@ -10,13 +10,19 @@ const Boom = require('@hapi/boom')
 const CreateBillRunValidator = require('../validators/bill-runs/create-bill-run.validator')
 
 async function createBillRun (request, h) {
-  const result = CreateBillRunValidator.go(request.payload)
+  const validatedData = CreateBillRunValidator.go(request.payload)
 
-  if (result.error) {
-    return _formattedValidationError(result.error)
+  if (validatedData.error) {
+    return _formattedValidationError(validatedData.error)
   }
 
-  return result.value
+  return {
+    id: 'DUMMY_SROC_BATCH',
+    region: validatedData.value.region,
+    scheme: validatedData.value.scheme,
+    batchType: validatedData.value.type,
+    status: 'ready'
+  }
 }
 
 // Takes an error from a validator and returns a suitable Boom error

--- a/app/plugins/error-pages.plugin.js
+++ b/app/plugins/error-pages.plugin.js
@@ -1,7 +1,10 @@
 'use strict'
 
 /**
- * Add an `onPreResponse` listener to return error pages
+ * Add an `onPreResponse` listener to return HTML error pages for Boom errors.
+ *
+ * The plugin is configured in the route's `plugins.errorPages` object. If `plainOutput` is set to `true` then the
+ * output will not be put into an HTML template and will simply be returned as-is.
  *
  * The bulk of this is taken from https://github.com/DEFRA/hapi-web-boilerplate and tweaked to fit how we organise our
  * code. For now we have removed Google Analytics (which would have been added to the `context` option) as we can
@@ -17,7 +20,9 @@ const ErrorPagesPlugin = {
       server.ext('onPreResponse', (request, h) => {
         const { response } = request
 
-        if (response.isBoom) {
+        const { errorPages: pluginSettings } = request.route.settings.plugins
+
+        if (response.isBoom && !pluginSettings.plainOutput) {
           const { statusCode } = response.output
 
           if (statusCode === 404) {

--- a/app/plugins/router.plugin.js
+++ b/app/plugins/router.plugin.js
@@ -13,6 +13,7 @@
 
 const AirbrakeRoutes = require('../routes/airbrake.routes.js')
 const AssetRoutes = require('../routes/assets.routes.js')
+const BillRunRoutes = require('../routes/bill-runs.routes')
 const DatabaseRoutes = require('../routes/database.routes.js')
 const FilterRoutesService = require('../services/plugins/filter-routes.service.js')
 const RootRoutes = require('../routes/root.routes.js')
@@ -24,6 +25,7 @@ const routes = [
   ...RootRoutes,
   ...AirbrakeRoutes,
   ...AssetRoutes,
+  ...BillRunRoutes,
   ...DatabaseRoutes,
   ...TestRoutes
 ]

--- a/app/routes/bill-runs.routes.js
+++ b/app/routes/bill-runs.routes.js
@@ -8,7 +8,12 @@ const routes = [
     path: '/bill-runs',
     handler: BillRunsController.createBillRun,
     options: {
-      description: 'Used to create a bill run'
+      description: 'Used to create a bill run',
+      plugins: {
+        errorPages: {
+          plainOutput: true
+        }
+      }
     }
   }
 ]

--- a/app/routes/bill-runs.routes.js
+++ b/app/routes/bill-runs.routes.js
@@ -1,0 +1,16 @@
+'use strict'
+
+const BillRunsController = require('../controllers/bill-runs.controller.js')
+
+const routes = [
+  {
+    method: 'POST',
+    path: '/bill-runs',
+    handler: BillRunsController.createBillRun,
+    options: {
+      description: 'Used to create a bill run'
+    }
+  }
+]
+
+module.exports = routes

--- a/app/validators/bill-runs/create-bill-run.validator.js
+++ b/app/validators/bill-runs/create-bill-run.validator.js
@@ -13,6 +13,7 @@ function go (data) {
   const schema = Joi.object({
     type: Joi.string().valid('supplementary').required(),
     scheme: Joi.string().valid('sroc').required(),
+    region: Joi.string().guid().required(),
     previousBillRunId: Joi.string().guid().optional()
   })
 

--- a/app/validators/bill-runs/create-bill-run.validator.js
+++ b/app/validators/bill-runs/create-bill-run.validator.js
@@ -9,14 +9,14 @@ const Joi = require('joi')
 /**
  * Checks that the payload of a `create bill run` request is valid
 */
-async function go (data) {
+function go (data) {
   const schema = Joi.object({
     type: Joi.string().valid('supplementary').required(),
     scheme: Joi.string().valid('sroc').required(),
     previousBillRunId: Joi.string().guid().optional()
   })
 
-  return schema.validateAsync(data)
+  return schema.validate(data)
 }
 
 module.exports = {

--- a/app/validators/bill-runs/create-bill-run.validator.js
+++ b/app/validators/bill-runs/create-bill-run.validator.js
@@ -11,8 +11,8 @@ const Joi = require('joi')
 */
 async function go (data) {
   const schema = Joi.object({
-    type: Joi.string().required(),
-    scheme: Joi.string().required(),
+    type: Joi.string().valid('supplementary').required(),
+    scheme: Joi.string().valid('sroc').required(),
     previousBillRunId: Joi.string().guid().optional()
   })
 

--- a/app/validators/bill-runs/create-bill-run.validator.js
+++ b/app/validators/bill-runs/create-bill-run.validator.js
@@ -1,0 +1,24 @@
+'use strict'
+
+/**
+ * @module CreateBillRunValidator
+ */
+
+const Joi = require('joi')
+
+/**
+ * Checks that the payload of a `create bill run` request is valid
+*/
+async function go (data) {
+  const schema = Joi.object({
+    type: Joi.string().required(),
+    scheme: Joi.string().required(),
+    previousBillRunId: Joi.string().guid().optional()
+  })
+
+  return schema.validateAsync(data)
+}
+
+module.exports = {
+  go
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "license": "OGL-UK-3.0",
       "dependencies": {
         "@airbrake/node": "^2.1.8",
+        "@hapi/boom": "^10.0.0",
         "@hapi/hapi": "^21.1.0",
         "@hapi/inert": "^7.0.0",
         "@hapi/vision": "^7.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "got": "^12.5.3",
         "govuk-frontend": "^4.4.0",
         "hapi-pino": "^11.0.1",
+        "joi": "^17.7.0",
         "knex": "^2.3.0",
         "nunjucks": "^3.2.3",
         "objection": "^3.0.1",
@@ -3990,9 +3991,9 @@
       "dev": true
     },
     "node_modules/joi": {
-      "version": "17.6.2",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.6.2.tgz",
-      "integrity": "sha512-+gqqdh1xc1wb+Lor0J9toqgeReyDOCqOdG8QSdRcEvwrcRiFQZneUCGKjFjuyBWUb3uaFOgY56yMaZ5FIc+H4w==",
+      "version": "17.7.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.7.0.tgz",
+      "integrity": "sha512-1/ugc8djfn93rTE3WRKdCzGGt/EtiYKxITMO4Wiv6q5JL1gl9ePt4kBsl1S499nbosspfctIQTpYIhSmHA3WAg==",
       "dependencies": {
         "@hapi/hoek": "^9.0.0",
         "@hapi/topo": "^5.0.0",
@@ -9245,9 +9246,9 @@
       "dev": true
     },
     "joi": {
-      "version": "17.6.2",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.6.2.tgz",
-      "integrity": "sha512-+gqqdh1xc1wb+Lor0J9toqgeReyDOCqOdG8QSdRcEvwrcRiFQZneUCGKjFjuyBWUb3uaFOgY56yMaZ5FIc+H4w==",
+      "version": "17.7.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.7.0.tgz",
+      "integrity": "sha512-1/ugc8djfn93rTE3WRKdCzGGt/EtiYKxITMO4Wiv6q5JL1gl9ePt4kBsl1S499nbosspfctIQTpYIhSmHA3WAg==",
       "requires": {
         "@hapi/hoek": "^9.0.0",
         "@hapi/topo": "^5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "license": "OGL-UK-3.0",
       "dependencies": {
         "@airbrake/node": "^2.1.7",
-        "@hapi/boom": "^10.0.0",
         "@hapi/hapi": "^21.0.0",
         "@hapi/inert": "^7.0.0",
         "@hapi/vision": "^7.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "license": "OGL-UK-3.0",
       "dependencies": {
         "@airbrake/node": "^2.1.7",
+        "@hapi/boom": "^10.0.0",
         "@hapi/hapi": "^21.0.0",
         "@hapi/inert": "^7.0.0",
         "@hapi/vision": "^7.0.0",
@@ -456,14 +457,6 @@
         "@hapi/hoek": "^10.0.0"
       }
     },
-    "node_modules/@hapi/accept/node_modules/@hapi/boom": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-10.0.0.tgz",
-      "integrity": "sha512-1YVs9tLHhypBqqinKQRqh7FUERIolarQApO37OWkzD+z6y6USi871Sv746zBPKcIOBuI6g6y4FrwX87mmJ90Gg==",
-      "dependencies": {
-        "@hapi/hoek": "10.x.x"
-      }
-    },
     "node_modules/@hapi/ammo": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/ammo/-/ammo-6.0.0.tgz",
@@ -486,17 +479,12 @@
       "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
     },
     "node_modules/@hapi/boom": {
-      "version": "9.1.4",
-      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.4.tgz",
-      "integrity": "sha512-Ls1oH8jaN1vNsqcaHVYJrKmgMcKsC1wcp8bujvXrHaAqD2iDYq3HoOwsxwo09Cuda5R5nC0o0IxlrlTuvPuzSw==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-10.0.0.tgz",
+      "integrity": "sha512-1YVs9tLHhypBqqinKQRqh7FUERIolarQApO37OWkzD+z6y6USi871Sv746zBPKcIOBuI6g6y4FrwX87mmJ90Gg==",
       "dependencies": {
-        "@hapi/hoek": "9.x.x"
+        "@hapi/hoek": "10.x.x"
       }
-    },
-    "node_modules/@hapi/boom/node_modules/@hapi/hoek": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
-      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
     },
     "node_modules/@hapi/bossy": {
       "version": "6.0.0",
@@ -509,15 +497,6 @@
         "@hapi/bourne": "^3.0.0",
         "@hapi/hoek": "^10.0.0",
         "@hapi/validate": "^2.0.0"
-      }
-    },
-    "node_modules/@hapi/bossy/node_modules/@hapi/boom": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-10.0.0.tgz",
-      "integrity": "sha512-1YVs9tLHhypBqqinKQRqh7FUERIolarQApO37OWkzD+z6y6USi871Sv746zBPKcIOBuI6g6y4FrwX87mmJ90Gg==",
-      "dev": true,
-      "dependencies": {
-        "@hapi/hoek": "10.x.x"
       }
     },
     "node_modules/@hapi/bossy/node_modules/@hapi/topo": {
@@ -548,14 +527,6 @@
         "@hapi/hoek": "^10.0.0"
       }
     },
-    "node_modules/@hapi/bounce/node_modules/@hapi/boom": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-10.0.0.tgz",
-      "integrity": "sha512-1YVs9tLHhypBqqinKQRqh7FUERIolarQApO37OWkzD+z6y6USi871Sv746zBPKcIOBuI6g6y4FrwX87mmJ90Gg==",
-      "dependencies": {
-        "@hapi/hoek": "10.x.x"
-      }
-    },
     "node_modules/@hapi/bourne": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-3.0.0.tgz",
@@ -568,14 +539,6 @@
       "dependencies": {
         "@hapi/boom": "^10.0.0",
         "@hapi/hoek": "^10.0.0"
-      }
-    },
-    "node_modules/@hapi/call/node_modules/@hapi/boom": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-10.0.0.tgz",
-      "integrity": "sha512-1YVs9tLHhypBqqinKQRqh7FUERIolarQApO37OWkzD+z6y6USi871Sv746zBPKcIOBuI6g6y4FrwX87mmJ90Gg==",
-      "dependencies": {
-        "@hapi/hoek": "10.x.x"
       }
     },
     "node_modules/@hapi/catbox": {
@@ -596,22 +559,6 @@
       "dependencies": {
         "@hapi/boom": "^10.0.0",
         "@hapi/hoek": "^10.0.0"
-      }
-    },
-    "node_modules/@hapi/catbox-memory/node_modules/@hapi/boom": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-10.0.0.tgz",
-      "integrity": "sha512-1YVs9tLHhypBqqinKQRqh7FUERIolarQApO37OWkzD+z6y6USi871Sv746zBPKcIOBuI6g6y4FrwX87mmJ90Gg==",
-      "dependencies": {
-        "@hapi/hoek": "10.x.x"
-      }
-    },
-    "node_modules/@hapi/catbox/node_modules/@hapi/boom": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-10.0.0.tgz",
-      "integrity": "sha512-1YVs9tLHhypBqqinKQRqh7FUERIolarQApO37OWkzD+z6y6USi871Sv746zBPKcIOBuI6g6y4FrwX87mmJ90Gg==",
-      "dependencies": {
-        "@hapi/hoek": "10.x.x"
       }
     },
     "node_modules/@hapi/catbox/node_modules/@hapi/podium": {
@@ -666,14 +613,6 @@
         "@hapi/boom": "^10.0.0"
       }
     },
-    "node_modules/@hapi/content/node_modules/@hapi/boom": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-10.0.0.tgz",
-      "integrity": "sha512-1YVs9tLHhypBqqinKQRqh7FUERIolarQApO37OWkzD+z6y6USi871Sv746zBPKcIOBuI6g6y4FrwX87mmJ90Gg==",
-      "dependencies": {
-        "@hapi/hoek": "10.x.x"
-      }
-    },
     "node_modules/@hapi/cryptiles": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@hapi/cryptiles/-/cryptiles-5.1.0.tgz",
@@ -684,6 +623,19 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/@hapi/cryptiles/node_modules/@hapi/boom": {
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.4.tgz",
+      "integrity": "sha512-Ls1oH8jaN1vNsqcaHVYJrKmgMcKsC1wcp8bujvXrHaAqD2iDYq3HoOwsxwo09Cuda5R5nC0o0IxlrlTuvPuzSw==",
+      "dependencies": {
+        "@hapi/hoek": "9.x.x"
+      }
+    },
+    "node_modules/@hapi/cryptiles/node_modules/@hapi/hoek": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
     },
     "node_modules/@hapi/eslint-plugin": {
       "version": "6.0.0",
@@ -736,14 +688,6 @@
         "node": ">=14.15.0"
       }
     },
-    "node_modules/@hapi/hapi/node_modules/@hapi/boom": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-10.0.0.tgz",
-      "integrity": "sha512-1YVs9tLHhypBqqinKQRqh7FUERIolarQApO37OWkzD+z6y6USi871Sv746zBPKcIOBuI6g6y4FrwX87mmJ90Gg==",
-      "dependencies": {
-        "@hapi/hoek": "10.x.x"
-      }
-    },
     "node_modules/@hapi/hapi/node_modules/@hapi/podium": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/podium/-/podium-5.0.0.tgz",
@@ -789,14 +733,6 @@
         "@hapi/validate": "^2.0.0"
       }
     },
-    "node_modules/@hapi/heavy/node_modules/@hapi/boom": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-10.0.0.tgz",
-      "integrity": "sha512-1YVs9tLHhypBqqinKQRqh7FUERIolarQApO37OWkzD+z6y6USi871Sv746zBPKcIOBuI6g6y4FrwX87mmJ90Gg==",
-      "dependencies": {
-        "@hapi/hoek": "10.x.x"
-      }
-    },
     "node_modules/@hapi/heavy/node_modules/@hapi/topo": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-6.0.0.tgz",
@@ -830,14 +766,6 @@
         "@hapi/hoek": "^10.0.0",
         "@hapi/validate": "^2.0.0",
         "lru-cache": "^7.10.2"
-      }
-    },
-    "node_modules/@hapi/inert/node_modules/@hapi/boom": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-10.0.0.tgz",
-      "integrity": "sha512-1YVs9tLHhypBqqinKQRqh7FUERIolarQApO37OWkzD+z6y6USi871Sv746zBPKcIOBuI6g6y4FrwX87mmJ90Gg==",
-      "dependencies": {
-        "@hapi/hoek": "10.x.x"
       }
     },
     "node_modules/@hapi/inert/node_modules/@hapi/topo": {
@@ -874,6 +802,14 @@
         "@hapi/boom": "9.x.x",
         "@hapi/bourne": "2.x.x",
         "@hapi/cryptiles": "5.x.x",
+        "@hapi/hoek": "9.x.x"
+      }
+    },
+    "node_modules/@hapi/iron/node_modules/@hapi/boom": {
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.4.tgz",
+      "integrity": "sha512-Ls1oH8jaN1vNsqcaHVYJrKmgMcKsC1wcp8bujvXrHaAqD2iDYq3HoOwsxwo09Cuda5R5nC0o0IxlrlTuvPuzSw==",
+      "dependencies": {
         "@hapi/hoek": "9.x.x"
       }
     },
@@ -964,14 +900,6 @@
         "@hapi/hoek": "^10.0.0"
       }
     },
-    "node_modules/@hapi/pez/node_modules/@hapi/boom": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-10.0.0.tgz",
-      "integrity": "sha512-1YVs9tLHhypBqqinKQRqh7FUERIolarQApO37OWkzD+z6y6USi871Sv746zBPKcIOBuI6g6y4FrwX87mmJ90Gg==",
-      "dependencies": {
-        "@hapi/hoek": "10.x.x"
-      }
-    },
     "node_modules/@hapi/podium": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/@hapi/podium/-/podium-4.1.3.tgz",
@@ -1049,14 +977,6 @@
         "@hapi/hoek": "^10.0.0"
       }
     },
-    "node_modules/@hapi/statehood/node_modules/@hapi/boom": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-10.0.0.tgz",
-      "integrity": "sha512-1YVs9tLHhypBqqinKQRqh7FUERIolarQApO37OWkzD+z6y6USi871Sv746zBPKcIOBuI6g6y4FrwX87mmJ90Gg==",
-      "dependencies": {
-        "@hapi/hoek": "10.x.x"
-      }
-    },
     "node_modules/@hapi/statehood/node_modules/@hapi/cryptiles": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/cryptiles/-/cryptiles-6.0.0.tgz",
@@ -1109,14 +1029,6 @@
         "@hapi/hoek": "^10.0.0",
         "@hapi/pez": "^6.0.0",
         "@hapi/wreck": "^18.0.0"
-      }
-    },
-    "node_modules/@hapi/subtext/node_modules/@hapi/boom": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-10.0.0.tgz",
-      "integrity": "sha512-1YVs9tLHhypBqqinKQRqh7FUERIolarQApO37OWkzD+z6y6USi871Sv746zBPKcIOBuI6g6y4FrwX87mmJ90Gg==",
-      "dependencies": {
-        "@hapi/hoek": "10.x.x"
       }
     },
     "node_modules/@hapi/teamwork": {
@@ -1173,14 +1085,6 @@
         "@hapi/validate": "^2.0.0"
       }
     },
-    "node_modules/@hapi/vision/node_modules/@hapi/boom": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-10.0.0.tgz",
-      "integrity": "sha512-1YVs9tLHhypBqqinKQRqh7FUERIolarQApO37OWkzD+z6y6USi871Sv746zBPKcIOBuI6g6y4FrwX87mmJ90Gg==",
-      "dependencies": {
-        "@hapi/hoek": "10.x.x"
-      }
-    },
     "node_modules/@hapi/vision/node_modules/@hapi/topo": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-6.0.0.tgz",
@@ -1206,14 +1110,6 @@
         "@hapi/boom": "^10.0.0",
         "@hapi/bourne": "^3.0.0",
         "@hapi/hoek": "^10.0.0"
-      }
-    },
-    "node_modules/@hapi/wreck/node_modules/@hapi/boom": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-10.0.0.tgz",
-      "integrity": "sha512-1YVs9tLHhypBqqinKQRqh7FUERIolarQApO37OWkzD+z6y6USi871Sv746zBPKcIOBuI6g6y4FrwX87mmJ90Gg==",
-      "dependencies": {
-        "@hapi/hoek": "10.x.x"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -1463,6 +1359,19 @@
         "@types/node": "*",
         "joi": "^17.3.0"
       }
+    },
+    "node_modules/@types/hapi__hapi/node_modules/@hapi/boom": {
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.4.tgz",
+      "integrity": "sha512-Ls1oH8jaN1vNsqcaHVYJrKmgMcKsC1wcp8bujvXrHaAqD2iDYq3HoOwsxwo09Cuda5R5nC0o0IxlrlTuvPuzSw==",
+      "dependencies": {
+        "@hapi/hoek": "9.x.x"
+      }
+    },
+    "node_modules/@types/hapi__hapi/node_modules/@hapi/hoek": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
     },
     "node_modules/@types/hapi__mimos": {
       "version": "4.1.4",
@@ -6441,16 +6350,6 @@
       "requires": {
         "@hapi/boom": "^10.0.0",
         "@hapi/hoek": "^10.0.0"
-      },
-      "dependencies": {
-        "@hapi/boom": {
-          "version": "10.0.0",
-          "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-10.0.0.tgz",
-          "integrity": "sha512-1YVs9tLHhypBqqinKQRqh7FUERIolarQApO37OWkzD+z6y6USi871Sv746zBPKcIOBuI6g6y4FrwX87mmJ90Gg==",
-          "requires": {
-            "@hapi/hoek": "10.x.x"
-          }
-        }
       }
     },
     "@hapi/ammo": {
@@ -6477,18 +6376,11 @@
       }
     },
     "@hapi/boom": {
-      "version": "9.1.4",
-      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.4.tgz",
-      "integrity": "sha512-Ls1oH8jaN1vNsqcaHVYJrKmgMcKsC1wcp8bujvXrHaAqD2iDYq3HoOwsxwo09Cuda5R5nC0o0IxlrlTuvPuzSw==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-10.0.0.tgz",
+      "integrity": "sha512-1YVs9tLHhypBqqinKQRqh7FUERIolarQApO37OWkzD+z6y6USi871Sv746zBPKcIOBuI6g6y4FrwX87mmJ90Gg==",
       "requires": {
-        "@hapi/hoek": "9.x.x"
-      },
-      "dependencies": {
-        "@hapi/hoek": {
-          "version": "9.3.0",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
-          "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
-        }
+        "@hapi/hoek": "10.x.x"
       }
     },
     "@hapi/bossy": {
@@ -6504,15 +6396,6 @@
         "@hapi/validate": "^2.0.0"
       },
       "dependencies": {
-        "@hapi/boom": {
-          "version": "10.0.0",
-          "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-10.0.0.tgz",
-          "integrity": "sha512-1YVs9tLHhypBqqinKQRqh7FUERIolarQApO37OWkzD+z6y6USi871Sv746zBPKcIOBuI6g6y4FrwX87mmJ90Gg==",
-          "dev": true,
-          "requires": {
-            "@hapi/hoek": "10.x.x"
-          }
-        },
         "@hapi/topo": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-6.0.0.tgz",
@@ -6541,16 +6424,6 @@
       "requires": {
         "@hapi/boom": "^10.0.0",
         "@hapi/hoek": "^10.0.0"
-      },
-      "dependencies": {
-        "@hapi/boom": {
-          "version": "10.0.0",
-          "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-10.0.0.tgz",
-          "integrity": "sha512-1YVs9tLHhypBqqinKQRqh7FUERIolarQApO37OWkzD+z6y6USi871Sv746zBPKcIOBuI6g6y4FrwX87mmJ90Gg==",
-          "requires": {
-            "@hapi/hoek": "10.x.x"
-          }
-        }
       }
     },
     "@hapi/bourne": {
@@ -6565,16 +6438,6 @@
       "requires": {
         "@hapi/boom": "^10.0.0",
         "@hapi/hoek": "^10.0.0"
-      },
-      "dependencies": {
-        "@hapi/boom": {
-          "version": "10.0.0",
-          "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-10.0.0.tgz",
-          "integrity": "sha512-1YVs9tLHhypBqqinKQRqh7FUERIolarQApO37OWkzD+z6y6USi871Sv746zBPKcIOBuI6g6y4FrwX87mmJ90Gg==",
-          "requires": {
-            "@hapi/hoek": "10.x.x"
-          }
-        }
       }
     },
     "@hapi/catbox": {
@@ -6588,14 +6451,6 @@
         "@hapi/validate": "^2.0.0"
       },
       "dependencies": {
-        "@hapi/boom": {
-          "version": "10.0.0",
-          "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-10.0.0.tgz",
-          "integrity": "sha512-1YVs9tLHhypBqqinKQRqh7FUERIolarQApO37OWkzD+z6y6USi871Sv746zBPKcIOBuI6g6y4FrwX87mmJ90Gg==",
-          "requires": {
-            "@hapi/hoek": "10.x.x"
-          }
-        },
         "@hapi/podium": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/@hapi/podium/-/podium-5.0.0.tgz",
@@ -6637,16 +6492,6 @@
       "requires": {
         "@hapi/boom": "^10.0.0",
         "@hapi/hoek": "^10.0.0"
-      },
-      "dependencies": {
-        "@hapi/boom": {
-          "version": "10.0.0",
-          "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-10.0.0.tgz",
-          "integrity": "sha512-1YVs9tLHhypBqqinKQRqh7FUERIolarQApO37OWkzD+z6y6USi871Sv746zBPKcIOBuI6g6y4FrwX87mmJ90Gg==",
-          "requires": {
-            "@hapi/hoek": "10.x.x"
-          }
-        }
       }
     },
     "@hapi/code": {
@@ -6664,16 +6509,6 @@
       "integrity": "sha512-CEhs7j+H0iQffKfe5Htdak5LBOz/Qc8TRh51cF+BFv0qnuph3Em4pjGVzJMkI2gfTDdlJKWJISGWS1rK34POGA==",
       "requires": {
         "@hapi/boom": "^10.0.0"
-      },
-      "dependencies": {
-        "@hapi/boom": {
-          "version": "10.0.0",
-          "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-10.0.0.tgz",
-          "integrity": "sha512-1YVs9tLHhypBqqinKQRqh7FUERIolarQApO37OWkzD+z6y6USi871Sv746zBPKcIOBuI6g6y4FrwX87mmJ90Gg==",
-          "requires": {
-            "@hapi/hoek": "10.x.x"
-          }
-        }
       }
     },
     "@hapi/cryptiles": {
@@ -6682,6 +6517,21 @@
       "integrity": "sha512-fo9+d1Ba5/FIoMySfMqPBR/7Pa29J2RsiPrl7bkwo5W5o+AN1dAYQRi4SPrPwwVxVGKjgLOEWrsvt1BonJSfLA==",
       "requires": {
         "@hapi/boom": "9.x.x"
+      },
+      "dependencies": {
+        "@hapi/boom": {
+          "version": "9.1.4",
+          "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.4.tgz",
+          "integrity": "sha512-Ls1oH8jaN1vNsqcaHVYJrKmgMcKsC1wcp8bujvXrHaAqD2iDYq3HoOwsxwo09Cuda5R5nC0o0IxlrlTuvPuzSw==",
+          "requires": {
+            "@hapi/hoek": "9.x.x"
+          }
+        },
+        "@hapi/hoek": {
+          "version": "9.3.0",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+          "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
+        }
       }
     },
     "@hapi/eslint-plugin": {
@@ -6721,14 +6571,6 @@
         "@hapi/validate": "^2.0.0"
       },
       "dependencies": {
-        "@hapi/boom": {
-          "version": "10.0.0",
-          "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-10.0.0.tgz",
-          "integrity": "sha512-1YVs9tLHhypBqqinKQRqh7FUERIolarQApO37OWkzD+z6y6USi871Sv746zBPKcIOBuI6g6y4FrwX87mmJ90Gg==",
-          "requires": {
-            "@hapi/hoek": "10.x.x"
-          }
-        },
         "@hapi/podium": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/@hapi/podium/-/podium-5.0.0.tgz",
@@ -6773,14 +6615,6 @@
         "@hapi/validate": "^2.0.0"
       },
       "dependencies": {
-        "@hapi/boom": {
-          "version": "10.0.0",
-          "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-10.0.0.tgz",
-          "integrity": "sha512-1YVs9tLHhypBqqinKQRqh7FUERIolarQApO37OWkzD+z6y6USi871Sv746zBPKcIOBuI6g6y4FrwX87mmJ90Gg==",
-          "requires": {
-            "@hapi/hoek": "10.x.x"
-          }
-        },
         "@hapi/topo": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-6.0.0.tgz",
@@ -6818,14 +6652,6 @@
         "lru-cache": "^7.10.2"
       },
       "dependencies": {
-        "@hapi/boom": {
-          "version": "10.0.0",
-          "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-10.0.0.tgz",
-          "integrity": "sha512-1YVs9tLHhypBqqinKQRqh7FUERIolarQApO37OWkzD+z6y6USi871Sv746zBPKcIOBuI6g6y4FrwX87mmJ90Gg==",
-          "requires": {
-            "@hapi/hoek": "10.x.x"
-          }
-        },
         "@hapi/topo": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-6.0.0.tgz",
@@ -6862,6 +6688,14 @@
         "@hapi/hoek": "9.x.x"
       },
       "dependencies": {
+        "@hapi/boom": {
+          "version": "9.1.4",
+          "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.4.tgz",
+          "integrity": "sha512-Ls1oH8jaN1vNsqcaHVYJrKmgMcKsC1wcp8bujvXrHaAqD2iDYq3HoOwsxwo09Cuda5R5nC0o0IxlrlTuvPuzSw==",
+          "requires": {
+            "@hapi/hoek": "9.x.x"
+          }
+        },
         "@hapi/bourne": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-2.1.0.tgz",
@@ -6934,14 +6768,6 @@
           "integrity": "sha512-Es6o4BtzvMmNF28KJGuwUzUtMjF6ToZ1hQt3UOjaXc6TNkRefel+NyQSjc9b5q3Re7xwv23r0xK3Vo3yreaJHQ==",
           "requires": {
             "@hapi/hoek": "^10.0.0"
-          }
-        },
-        "@hapi/boom": {
-          "version": "10.0.0",
-          "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-10.0.0.tgz",
-          "integrity": "sha512-1YVs9tLHhypBqqinKQRqh7FUERIolarQApO37OWkzD+z6y6USi871Sv746zBPKcIOBuI6g6y4FrwX87mmJ90Gg==",
-          "requires": {
-            "@hapi/hoek": "10.x.x"
           }
         }
       }
@@ -7029,14 +6855,6 @@
             "@hapi/hoek": "^10.0.0"
           }
         },
-        "@hapi/boom": {
-          "version": "10.0.0",
-          "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-10.0.0.tgz",
-          "integrity": "sha512-1YVs9tLHhypBqqinKQRqh7FUERIolarQApO37OWkzD+z6y6USi871Sv746zBPKcIOBuI6g6y4FrwX87mmJ90Gg==",
-          "requires": {
-            "@hapi/hoek": "10.x.x"
-          }
-        },
         "@hapi/cryptiles": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/@hapi/cryptiles/-/cryptiles-6.0.0.tgz",
@@ -7088,16 +6906,6 @@
         "@hapi/hoek": "^10.0.0",
         "@hapi/pez": "^6.0.0",
         "@hapi/wreck": "^18.0.0"
-      },
-      "dependencies": {
-        "@hapi/boom": {
-          "version": "10.0.0",
-          "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-10.0.0.tgz",
-          "integrity": "sha512-1YVs9tLHhypBqqinKQRqh7FUERIolarQApO37OWkzD+z6y6USi871Sv746zBPKcIOBuI6g6y4FrwX87mmJ90Gg==",
-          "requires": {
-            "@hapi/hoek": "10.x.x"
-          }
-        }
       }
     },
     "@hapi/teamwork": {
@@ -7155,14 +6963,6 @@
         "@hapi/validate": "^2.0.0"
       },
       "dependencies": {
-        "@hapi/boom": {
-          "version": "10.0.0",
-          "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-10.0.0.tgz",
-          "integrity": "sha512-1YVs9tLHhypBqqinKQRqh7FUERIolarQApO37OWkzD+z6y6USi871Sv746zBPKcIOBuI6g6y4FrwX87mmJ90Gg==",
-          "requires": {
-            "@hapi/hoek": "10.x.x"
-          }
-        },
         "@hapi/topo": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-6.0.0.tgz",
@@ -7190,16 +6990,6 @@
         "@hapi/boom": "^10.0.0",
         "@hapi/bourne": "^3.0.0",
         "@hapi/hoek": "^10.0.0"
-      },
-      "dependencies": {
-        "@hapi/boom": {
-          "version": "10.0.0",
-          "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-10.0.0.tgz",
-          "integrity": "sha512-1YVs9tLHhypBqqinKQRqh7FUERIolarQApO37OWkzD+z6y6USi871Sv746zBPKcIOBuI6g6y4FrwX87mmJ90Gg==",
-          "requires": {
-            "@hapi/hoek": "10.x.x"
-          }
-        }
       }
     },
     "@humanwhocodes/config-array": {
@@ -7411,6 +7201,21 @@
         "@types/hapi__shot": "*",
         "@types/node": "*",
         "joi": "^17.3.0"
+      },
+      "dependencies": {
+        "@hapi/boom": {
+          "version": "9.1.4",
+          "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.4.tgz",
+          "integrity": "sha512-Ls1oH8jaN1vNsqcaHVYJrKmgMcKsC1wcp8bujvXrHaAqD2iDYq3HoOwsxwo09Cuda5R5nC0o0IxlrlTuvPuzSw==",
+          "requires": {
+            "@hapi/hoek": "9.x.x"
+          }
+        },
+        "@hapi/hoek": {
+          "version": "9.3.0",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+          "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
+        }
       }
     },
     "@types/hapi__mimos": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   "license": "OGL-UK-3.0",
   "dependencies": {
     "@airbrake/node": "^2.1.7",
-    "@hapi/boom": "^10.0.0",
     "@hapi/hapi": "^21.0.0",
     "@hapi/inert": "^7.0.0",
     "@hapi/vision": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "license": "OGL-UK-3.0",
   "dependencies": {
     "@airbrake/node": "^2.1.8",
+    "@hapi/boom": "^10.0.0",
     "@hapi/hapi": "^21.1.0",
     "@hapi/inert": "^7.0.0",
     "@hapi/vision": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "license": "OGL-UK-3.0",
   "dependencies": {
     "@airbrake/node": "^2.1.7",
+    "@hapi/boom": "^10.0.0",
     "@hapi/hapi": "^21.0.0",
     "@hapi/inert": "^7.0.0",
     "@hapi/vision": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "got": "^12.5.3",
     "govuk-frontend": "^4.4.0",
     "hapi-pino": "^11.0.1",
+    "joi": "^17.7.0",
     "knex": "^2.3.0",
     "nunjucks": "^3.2.3",
     "objection": "^3.0.1",

--- a/test/controllers/bill-runs.controller.test.js
+++ b/test/controllers/bill-runs.controller.test.js
@@ -26,15 +26,17 @@ describe('Bill Runs controller:', () => {
           url: '/bill-runs',
           payload: {
             type: 'supplementary',
-            scheme: 'sroc'
+            scheme: 'sroc',
+            region: '07ae7f3a-2677-4102-b352-cc006828948c'
           }
         }
 
         const response = await server.inject(options)
         const payload = JSON.parse(response.payload)
+        console.log('🚀 ~ file: bill-runs.controller.test.js:36 ~ it ~ payload', payload)
 
         expect(response.statusCode).to.equal(200)
-        expect(payload.type).to.equal('supplementary')
+        expect(payload.batchType).to.equal('supplementary')
       })
     })
 
@@ -45,7 +47,8 @@ describe('Bill Runs controller:', () => {
           url: '/bill-runs',
           payload: {
             type: 'supplementary',
-            scheme: 'INVALID'
+            scheme: 'INVALID',
+            region: '07ae7f3a-2677-4102-b352-cc006828948c'
           }
         }
 

--- a/test/controllers/bill-runs.controller.test.js
+++ b/test/controllers/bill-runs.controller.test.js
@@ -33,7 +33,6 @@ describe('Bill Runs controller:', () => {
 
         const response = await server.inject(options)
         const payload = JSON.parse(response.payload)
-        console.log('🚀 ~ file: bill-runs.controller.test.js:36 ~ it ~ payload', payload)
 
         expect(response.statusCode).to.equal(200)
         expect(payload.batchType).to.equal('supplementary')

--- a/test/controllers/bill-runs.controller.test.js
+++ b/test/controllers/bill-runs.controller.test.js
@@ -38,7 +38,7 @@ describe('Bill Runs controller:', () => {
       })
     })
 
-    describe('when an invvalid request is sent', () => {
+    describe('when an invalid request is sent', () => {
       it('returns an error response', async () => {
         const options = {
           method: 'POST',
@@ -50,8 +50,10 @@ describe('Bill Runs controller:', () => {
         }
 
         const response = await server.inject(options)
+        const payload = JSON.parse(response.payload)
 
         expect(response.statusCode).to.equal(400)
+        expect(payload.message).to.startWith('"scheme" must be')
       })
     })
   })

--- a/test/controllers/bill-runs.controller.test.js
+++ b/test/controllers/bill-runs.controller.test.js
@@ -19,17 +19,40 @@ describe('Bill Runs controller:', () => {
   })
 
   describe('POST /bill-runs', () => {
-    it('returns a dummy response', async () => {
-      const options = {
-        method: 'POST',
-        url: '/bill-runs'
-      }
+    describe('when a valid request is sent', () => {
+      it('returns a dummy response', async () => {
+        const options = {
+          method: 'POST',
+          url: '/bill-runs',
+          payload: {
+            type: 'supplementary',
+            scheme: 'sroc'
+          }
+        }
 
-      const response = await server.inject(options)
-      const payload = JSON.parse(response.payload)
+        const response = await server.inject(options)
+        const payload = JSON.parse(response.payload)
 
-      expect(response.statusCode).to.equal(200)
-      expect(payload.test).to.equal('ok')
+        expect(response.statusCode).to.equal(200)
+        expect(payload.type).to.equal('supplementary')
+      })
+    })
+
+    describe('when an invvalid request is sent', () => {
+      it('returns an error response', async () => {
+        const options = {
+          method: 'POST',
+          url: '/bill-runs',
+          payload: {
+            type: 'supplementary',
+            scheme: 'INVALID'
+          }
+        }
+
+        const response = await server.inject(options)
+
+        expect(response.statusCode).to.equal(400)
+      })
     })
   })
 })

--- a/test/controllers/bill-runs.controller.test.js
+++ b/test/controllers/bill-runs.controller.test.js
@@ -1,0 +1,35 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// For running our service
+const { init } = require('../../app/server.js')
+
+describe('Bill Runs controller:', () => {
+  let server
+
+  // Create server before each test
+  beforeEach(async () => {
+    server = await init()
+  })
+
+  describe('POST /bill-runs', () => {
+    it('returns a dummy response', async () => {
+      const options = {
+        method: 'POST',
+        url: '/bill-runs'
+      }
+
+      const response = await server.inject(options)
+      const payload = JSON.parse(response.payload)
+
+      expect(response.statusCode).to.equal(200)
+      expect(payload.test).to.equal('ok')
+    })
+  })
+})

--- a/test/controllers/bill-runs.controller.test.js
+++ b/test/controllers/bill-runs.controller.test.js
@@ -35,7 +35,7 @@ describe('Bill Runs controller:', () => {
         const payload = JSON.parse(response.payload)
 
         expect(response.statusCode).to.equal(200)
-        expect(payload.batchType).to.equal('supplementary')
+        expect(payload.type).to.equal('supplementary')
       })
     })
 

--- a/test/validators/bill-runs/create-bill-run.validator.js
+++ b/test/validators/bill-runs/create-bill-run.validator.js
@@ -16,6 +16,7 @@ describe('Create Bill Run validator', () => {
       const validData = {
         type: 'supplementary',
         scheme: 'sroc',
+        region: '07ae7f3a-2677-4102-b352-cc006828948c',
         previousBillRunId: '28a5fc2e-bdc9-4b48-96e7-5ee7b2f5d603'
       }
 
@@ -24,6 +25,7 @@ describe('Create Bill Run validator', () => {
       expect(result.value).to.equal({
         type: 'supplementary',
         scheme: 'sroc',
+        region: '07ae7f3a-2677-4102-b352-cc006828948c',
         previousBillRunId: '28a5fc2e-bdc9-4b48-96e7-5ee7b2f5d603'
       })
     })
@@ -32,14 +34,16 @@ describe('Create Bill Run validator', () => {
       it('returns validated data', async () => {
         const validData = {
           type: 'supplementary',
-          scheme: 'sroc'
+          scheme: 'sroc',
+          region: '07ae7f3a-2677-4102-b352-cc006828948c'
         }
 
         const result = await CreateBillRunValidator.go(validData)
 
         expect(result.value).to.equal({
           type: 'supplementary',
-          scheme: 'sroc'
+          scheme: 'sroc',
+          region: '07ae7f3a-2677-4102-b352-cc006828948c'
         })
       })
     })
@@ -49,7 +53,8 @@ describe('Create Bill Run validator', () => {
     describe('because `type` is missing', () => {
       it('returns an error', async () => {
         const invalidData = {
-          scheme: 'sroc'
+          scheme: 'sroc',
+          region: '07ae7f3a-2677-4102-b352-cc006828948c'
         }
 
         const result = await CreateBillRunValidator.go(invalidData)
@@ -61,7 +66,21 @@ describe('Create Bill Run validator', () => {
     describe('because `scheme` is missing', () => {
       it('returns an error', async () => {
         const invalidData = {
-          type: 'supplementary'
+          type: 'supplementary',
+          region: '07ae7f3a-2677-4102-b352-cc006828948c'
+        }
+
+        const result = await CreateBillRunValidator.go(invalidData)
+
+        expect(result.error).to.not.be.empty()
+      })
+    })
+
+    describe('because `region` is missing', () => {
+      it('returns an error', async () => {
+        const invalidData = {
+          type: 'supplementary',
+          scheme: 'sroc'
         }
 
         const result = await CreateBillRunValidator.go(invalidData)
@@ -88,6 +107,20 @@ describe('Create Bill Run validator', () => {
         const invalidData = {
           type: 'supplementary',
           scheme: 'INVALID'
+        }
+
+        const result = await CreateBillRunValidator.go(invalidData)
+
+        expect(result.error).to.not.be.empty()
+      })
+    })
+
+    describe('because `region` has an invalid value', () => {
+      it('returns an error', async () => {
+        const invalidData = {
+          type: 'supplementary',
+          scheme: 'sroc',
+          region: 'INVALID'
         }
 
         const result = await CreateBillRunValidator.go(invalidData)

--- a/test/validators/bill-runs/create-bill-run.validator.js
+++ b/test/validators/bill-runs/create-bill-run.validator.js
@@ -1,0 +1,55 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Thing under test
+const CreateBillRunValidator = require('../../../app/validators/bill-runs/create-bill-run.validator.js')
+
+describe('Create Bill Run validator', () => {
+  describe('when valid data is provided', () => {
+    it('returns validated data', async () => {
+      const validData = {
+        type: 'supplementary',
+        scheme: 'sroc',
+        previousBillRunId: '28a5fc2e-bdc9-4b48-96e7-5ee7b2f5d603'
+      }
+
+      const result = await CreateBillRunValidator.go(validData)
+
+      expect(result).to.equal({
+        type: 'supplementary',
+        scheme: 'sroc',
+        previousBillRunId: '28a5fc2e-bdc9-4b48-96e7-5ee7b2f5d603'
+      })
+    })
+
+    describe('which does not include `previousBillRunId`', () => {
+      it('returns validated data', async () => {
+        const validData = {
+          type: 'supplementary',
+          scheme: 'sroc'
+        }
+
+        const result = await CreateBillRunValidator.go(validData)
+
+        expect(result).to.equal({
+          type: 'supplementary',
+          scheme: 'sroc'
+        })
+      })
+    })
+  })
+
+  describe('when invalid data is provided', () => {
+    it('returns a promise that rejects', async () => {
+      const invalidData = { }
+
+      await expect(CreateBillRunValidator.go(invalidData)).to.reject()
+    })
+  })
+})

--- a/test/validators/bill-runs/create-bill-run.validator.js
+++ b/test/validators/bill-runs/create-bill-run.validator.js
@@ -46,10 +46,46 @@ describe('Create Bill Run validator', () => {
   })
 
   describe('when invalid data is provided', () => {
-    it('returns a promise that rejects', async () => {
-      const invalidData = { }
+    describe('because `type` is missing', () => {
+      it('returns a promise that rejects', async () => {
+        const invalidData = {
+          scheme: 'sroc'
+        }
 
-      await expect(CreateBillRunValidator.go(invalidData)).to.reject()
+        await expect(CreateBillRunValidator.go(invalidData)).to.reject()
+      })
+    })
+
+    describe('because `scheme` is missing', () => {
+      it('returns a promise that rejects', async () => {
+        const invalidData = {
+          type: 'supplementary'
+        }
+
+        await expect(CreateBillRunValidator.go(invalidData)).to.reject()
+      })
+    })
+
+    describe('because `type` has an invalid value', () => {
+      it('returns a promise that rejects', async () => {
+        const invalidData = {
+          type: 'INVALID',
+          scheme: 'sroc'
+        }
+
+        await expect(CreateBillRunValidator.go(invalidData)).to.reject()
+      })
+    })
+
+    describe('because `scheme` has an invalid value', () => {
+      it('returns a promise that rejects', async () => {
+        const invalidData = {
+          type: 'supplementary',
+          scheme: 'INVALID'
+        }
+
+        await expect(CreateBillRunValidator.go(invalidData)).to.reject()
+      })
     })
   })
 })

--- a/test/validators/bill-runs/create-bill-run.validator.js
+++ b/test/validators/bill-runs/create-bill-run.validator.js
@@ -21,11 +21,7 @@ describe('Create Bill Run validator', () => {
 
       const result = await CreateBillRunValidator.go(validData)
 
-      expect(result).to.equal({
-        type: 'supplementary',
-        scheme: 'sroc',
-        previousBillRunId: '28a5fc2e-bdc9-4b48-96e7-5ee7b2f5d603'
-      })
+      expect(result).to.equal(validData)
     })
 
     describe('which does not include `previousBillRunId`', () => {
@@ -37,10 +33,7 @@ describe('Create Bill Run validator', () => {
 
         const result = await CreateBillRunValidator.go(validData)
 
-        expect(result).to.equal({
-          type: 'supplementary',
-          scheme: 'sroc'
-        })
+        expect(result).to.equal(validData)
       })
     })
   })

--- a/test/validators/bill-runs/create-bill-run.validator.js
+++ b/test/validators/bill-runs/create-bill-run.validator.js
@@ -21,7 +21,11 @@ describe('Create Bill Run validator', () => {
 
       const result = await CreateBillRunValidator.go(validData)
 
-      expect(result).to.equal(validData)
+      expect(result.value).to.equal({
+        type: 'supplementary',
+        scheme: 'sroc',
+        previousBillRunId: '28a5fc2e-bdc9-4b48-96e7-5ee7b2f5d603'
+      })
     })
 
     describe('which does not include `previousBillRunId`', () => {
@@ -33,51 +37,62 @@ describe('Create Bill Run validator', () => {
 
         const result = await CreateBillRunValidator.go(validData)
 
-        expect(result).to.equal(validData)
+        expect(result.value).to.equal({
+          type: 'supplementary',
+          scheme: 'sroc'
+        })
       })
     })
   })
 
   describe('when invalid data is provided', () => {
     describe('because `type` is missing', () => {
-      it('returns a promise that rejects', async () => {
+      it('returns an error', async () => {
         const invalidData = {
           scheme: 'sroc'
         }
 
-        await expect(CreateBillRunValidator.go(invalidData)).to.reject()
+        const result = await CreateBillRunValidator.go(invalidData)
+
+        expect(result.error).to.not.be.empty()
       })
     })
 
     describe('because `scheme` is missing', () => {
-      it('returns a promise that rejects', async () => {
+      it('returns an error', async () => {
         const invalidData = {
           type: 'supplementary'
         }
 
-        await expect(CreateBillRunValidator.go(invalidData)).to.reject()
+        const result = await CreateBillRunValidator.go(invalidData)
+
+        expect(result.error).to.not.be.empty()
       })
     })
 
     describe('because `type` has an invalid value', () => {
-      it('returns a promise that rejects', async () => {
+      it('returns an error', async () => {
         const invalidData = {
           type: 'INVALID',
           scheme: 'sroc'
         }
 
-        await expect(CreateBillRunValidator.go(invalidData)).to.reject()
+        const result = await CreateBillRunValidator.go(invalidData)
+
+        expect(result.error).to.not.be.empty()
       })
     })
 
     describe('because `scheme` has an invalid value', () => {
-      it('returns a promise that rejects', async () => {
+      it('returns an error', async () => {
         const invalidData = {
           type: 'supplementary',
           scheme: 'INVALID'
         }
 
-        await expect(CreateBillRunValidator.go(invalidData)).to.reject()
+        const result = await CreateBillRunValidator.go(invalidData)
+
+        expect(result.error).to.not.be.empty()
       })
     })
   })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3854

We need to create an endpoint for the UI to hit in order to create an sroc supplementary bill run.

This PR is to create our initial endpoint and apply validation. Creating the billing batch will be done in a future PR.

Note that we expect to receive the bill run type (ie. `supplementary`) in the payload as `type`, and the object it returns also contains this as `type`. This is in contrast to the `water-abstraction-service` which refers to this as `batchType`. We chose not to use `batchType` as we aim to be consistent within this repo as far as possible, and therefore we don't refer to batches if we can help it. It will therefore be necessary when updating the service to ensure that we send and receive it as `type`.

Since this is the first time we're validating incoming data, we needed to decide on how we will implement validation. The solution we have come up with is to create `app/validators`, with validators sitting in an appropriate subfolder. In this case, since the validation relates to bill runs and specifically the create bill run endpoint, we create the file `app/validators/bill-runs/create-bill-run.validator.js`

As part of this we also updated `ErrorPagesPlugin` to accept a `plainOutput` setting, which when set `true` in an endpoint's route will not attempt to change the response to be an HTML page. We did this so that our endpoint will return a standard JSON error response.