### PR TITLE
Add initial generic http request module

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,10 @@ PORT=3000
 LOG_ASSET_REQUESTS=false
 LOG_IN_TEST=false
 
+# Request config
+REQUEST_TIMEOUT=5000
+http_proxy=http://myproxy:8080
+
 # External services
 EA_ADDRESS_FACADE_URL=http://localhost:8009
 CHARGING_MODULE_URL=http://localhost:8020

--- a/app/lib/request.lib.js
+++ b/app/lib/request.lib.js
@@ -4,6 +4,8 @@
  * @module RequestLib
  */
 
+const { HttpsProxyAgent } = require('hpagent')
+
 const requestConfig = require('../../config/request.config.js')
 
 async function get (url, additionalOptions = {}) {
@@ -48,6 +50,14 @@ async function _importGot () {
  */
 function _requestOptions (additionalOptions) {
   const defaultOptions = {
+    // This uses the spread operator and a logical AND short circuit evaluation to allow us to determine whether the
+    // following columns are added to the options or not. Thanks to https://stackoverflow.com/a/40560953/6117745 for
+    // this
+    ...(requestConfig.httpProxy && {
+      agent: {
+        https: new HttpsProxyAgent({ proxy: requestConfig.httpProxy })
+      }
+    }),
     // If we don't have this setting Got will throw its own HTTPError unless the result is 2xx or 3xx. That makes it
     // impossible to see what the status code was because it doesn't get set on the response object Got provides when
     // an error is thrown. With this set Got will treat a 404 in the same way it treats a 204.

--- a/app/lib/request.lib.js
+++ b/app/lib/request.lib.js
@@ -1,0 +1,78 @@
+'use strict'
+
+/**
+ * @module RequestLib
+ */
+
+const requestConfig = require('../../config/request.config.js')
+
+async function get (url, additionalOptions = {}) {
+  const got = await _importGot()
+  const result = {
+    succeeded: false,
+    response: null
+  }
+
+  try {
+    const options = _requestOptions(additionalOptions)
+
+    result.response = await got.get(url, options)
+
+    // If the result is not 2xx or 3xx Got will mark the result as unsuccesful using the response object's `ok:`
+    // property
+    result.succeeded = result.response.ok
+  } catch (error) {
+    // If it's a network error, for example 'ETIMEDOUT', we'll end up here
+    result.response = error
+  }
+
+  return result
+}
+
+async function _importGot () {
+  // As of v12, the got dependency no longer supports CJS modules. This causes us a problem as we are locked into
+  // using these for the time being. Some workarounds are provided here:
+  // https://github.com/sindresorhus/got/issues/1789 We have gone the route of using await import('got'). We cannot do
+  // this at the top level as Node doesn't support top level in CJS so we do it here instead.
+  const { got } = await import('got')
+
+  return got
+}
+
+/**
+ * Combines the custom Got options provided by the caller with our defaults
+ *
+ * Those that use this module can add to, extend or replace the options we pass to Got when a request is made.
+ *
+ * @param {Object} additionalOptions Object of custom options
+ */
+function _requestOptions (additionalOptions) {
+  const defaultOptions = {
+    // If we don't have this setting Got will throw its own HTTPError unless the result is 2xx or 3xx. That makes it
+    // impossible to see what the status code was because it doesn't get set on the response object Got provides when
+    // an error is thrown. With this set Got will treat a 404 in the same way it treats a 204.
+    throwHttpErrors: false,
+    // Got has a built in retry mechanism. We have found though you have to be careful with what gets retried. Our
+    // preference is to only retry in the event of a timeout on assumption the destination server might be busy but has
+    // a chance to succeed when attempted again
+    retry: {
+      // We ensure that the only network errors Got retries are timeout errors
+      errorCodes: ['ETIMEDOUT'],
+      // We set statusCodes as an empty array to ensure that 4xx, 5xx etc. errors are not retried
+      statusCodes: []
+    },
+    // Got states
+    //
+    // > It is a good practice to set a timeout to prevent hanging requests. By default, there is no timeout set.
+    timeout: {
+      request: requestConfig.timeout
+    }
+  }
+
+  // Copies properties from one object to another; Object.assign(target, source). Matching properties get overriden
+  return Object.assign(defaultOptions, additionalOptions)
+}
+
+module.exports = {
+  get
+}

--- a/app/lib/request.lib.js
+++ b/app/lib/request.lib.js
@@ -1,6 +1,7 @@
 'use strict'
 
 /**
+ * Use for making http requests to other services
  * @module RequestLib
  */
 
@@ -8,6 +9,26 @@ const { HttpsProxyAgent } = require('hpagent')
 
 const requestConfig = require('../../config/request.config.js')
 
+/**
+ * Make a GET request to the specified URL
+ *
+ * Use when you need to make a GET request. It returns a result tuple
+ *
+ * ```javascript
+ * {
+ *  succeeded: true,
+ *  response: {} // The full response from Got
+ * }
+ * ```
+ *
+ * Any 2xx or 3xx will be flagged as succeeded. Anything else and `succeeded:` will be false. As long as the other
+ * service responds, `response:` will be the full response Got returns. In the event of a network error `response:` will
+ * be a Got error instance.
+ *
+ * @param {string} url The full URL that you wish to connect to
+ * @param {Object} additionalOptions Append to or replace the options passed to Got when making the request
+ * @returns {Object} The result of the request; whether it succeeded and the response or error returned
+ */
 async function get (url, additionalOptions = {}) {
   const got = await _importGot()
   const result = {

--- a/app/lib/request.lib.js
+++ b/app/lib/request.lib.js
@@ -100,8 +100,7 @@ function _requestOptions (additionalOptions) {
     }
   }
 
-  // Copies properties from one object to another; Object.assign(target, source). Matching properties get overriden
-  return Object.assign(defaultOptions, additionalOptions)
+  return { ...defaultOptions, ...additionalOptions }
 }
 
 module.exports = {

--- a/app/lib/request.lib.js
+++ b/app/lib/request.lib.js
@@ -71,14 +71,15 @@ async function _importGot () {
  */
 function _requestOptions (additionalOptions) {
   const defaultOptions = {
-    // This uses the spread operator and a logical AND short circuit evaluation to allow us to determine whether the
-    // following columns are added to the options or not. Thanks to https://stackoverflow.com/a/40560953/6117745 for
-    // this
-    ...(requestConfig.httpProxy && {
-      agent: {
-        https: new HttpsProxyAgent({ proxy: requestConfig.httpProxy })
-      }
-    }),
+    // This uses the ternary operator to give either an `agent` object or an empty object, and the spread operator to
+    // bring the result back into the top level of the `defaultOptions` object.
+    ...(requestConfig.httpProxy
+      ? {
+          agent: {
+            https: new HttpsProxyAgent({ proxy: requestConfig.httpProxy })
+          }
+        }
+      : {}),
     // If we don't have this setting Got will throw its own HTTPError unless the result is 2xx or 3xx. That makes it
     // impossible to see what the status code was because it doesn't get set on the response object Got provides when
     // an error is thrown. With this set Got will treat a 404 in the same way it treats a 204.

--- a/config/request.config.js
+++ b/config/request.config.js
@@ -2,7 +2,7 @@
 
 const config = {
   timeout: parseInt(process.env.REQUEST_TIMEOUT) || 5000,
-  httpProxy: process.env.http_proxy || 'http:localhost:1100'
+  httpProxy: process.env.http_proxy
 }
 
 module.exports = config

--- a/config/request.config.js
+++ b/config/request.config.js
@@ -1,7 +1,8 @@
 'use strict'
 
 const config = {
-  timeout: parseInt(process.env.REQUEST_TIMEOUT) || 5000
+  timeout: parseInt(process.env.REQUEST_TIMEOUT) || 5000,
+  httpProxy: process.env.http_proxy || 'http:localhost:1100'
 }
 
 module.exports = config

--- a/config/request.config.js
+++ b/config/request.config.js
@@ -2,6 +2,8 @@
 
 const config = {
   timeout: parseInt(process.env.REQUEST_TIMEOUT) || 5000,
+  // Note - Why lowercase? It's just the convention for http_proxy, https_proxy
+  // and no_proxy. ¯\_(ツ)_/¯ https://unix.stackexchange.com/a/212972
   httpProxy: process.env.http_proxy
 }
 

--- a/config/request.config.js
+++ b/config/request.config.js
@@ -1,0 +1,7 @@
+'use strict'
+
+const config = {
+  timeout: parseInt(process.env.REQUEST_TIMEOUT) || 5000
+}
+
+module.exports = config

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "got": "^12.5.3",
         "govuk-frontend": "^4.4.0",
         "hapi-pino": "^11.0.1",
+        "hpagent": "^1.2.0",
         "joi": "^17.7.0",
         "knex": "^2.3.0",
         "nunjucks": "^3.2.3",
@@ -3545,6 +3546,14 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/hpagent": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/hpagent/-/hpagent-1.2.0.tgz",
+      "integrity": "sha512-A91dYTeIB6NoXG+PxTQpCCDDnfHsW9kc06Lvpu1TEe9gnd6ZFeiBoRO9JvzEv6xK7EX97/dUE8g/vBMTqTS3CA==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/http-cache-semantics": {
@@ -8811,6 +8820,11 @@
           }
         }
       }
+    },
+    "hpagent": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/hpagent/-/hpagent-1.2.0.tgz",
+      "integrity": "sha512-A91dYTeIB6NoXG+PxTQpCCDDnfHsW9kc06Lvpu1TEe9gnd6ZFeiBoRO9JvzEv6xK7EX97/dUE8g/vBMTqTS3CA=="
     },
     "http-cache-semantics": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "got": "^12.5.3",
     "govuk-frontend": "^4.4.0",
     "hapi-pino": "^11.0.1",
+    "hpagent": "^1.2.0",
     "joi": "^17.7.0",
     "knex": "^2.3.0",
     "nunjucks": "^3.2.3",

--- a/test/lib/request.lib.test.js
+++ b/test/lib/request.lib.test.js
@@ -23,88 +23,55 @@ describe('RequestLib', () => {
     Nock.cleanAll()
   })
 
-  describe('When a request succeeds', () => {
-    beforeEach(() => {
-      Nock(testDomain).get('/').reply(200, { data: 'hello world' })
-    })
-
-    describe('the result it returns', () => {
-      it("has a 'succeeded' property marked as true", async () => {
-        const result = await RequestLib.get(testDomain)
-
-        expect(result.succeeded).to.be.true()
-      })
-
-      it("has a 'response' property containg the web response", async () => {
-        const result = await RequestLib.get(testDomain)
-
-        expect(result.response).to.exist()
-        expect(result.response.statusCode).to.equal(200)
-        expect(result.response.body).to.equal('{"data":"hello world"}')
-      })
-    })
-  })
-
-  describe('When a request fails', () => {
-    describe('because the response was a 500', () => {
+  describe('#get()', () => {
+    describe('When a request succeeds', () => {
       beforeEach(() => {
-        Nock(testDomain).get('/').reply(500, { data: 'hello world' })
+        Nock(testDomain).get('/').reply(200, { data: 'hello world' })
       })
 
       describe('the result it returns', () => {
-        it("has a 'succeeded' property marked as false", async () => {
+        it("has a 'succeeded' property marked as true", async () => {
           const result = await RequestLib.get(testDomain)
 
-          expect(result.succeeded).to.be.false()
+          expect(result.succeeded).to.be.true()
         })
 
         it("has a 'response' property containg the web response", async () => {
           const result = await RequestLib.get(testDomain)
 
           expect(result.response).to.exist()
-          expect(result.response.statusCode).to.equal(500)
+          expect(result.response.statusCode).to.equal(200)
           expect(result.response.body).to.equal('{"data":"hello world"}')
         })
       })
     })
 
-    describe('because there was a network issue', () => {
-      beforeEach(() => {
-        Nock(testDomain).get('/').replyWithError({ code: 'ECONNRESET' })
-      })
-
-      describe('the result it returns', () => {
-        it("has a 'succeeded' property marked as false", async () => {
-          const result = await RequestLib.get(testDomain)
-
-          expect(result.succeeded).to.be.false()
+    describe('When a request fails', () => {
+      describe('because the response was a 500', () => {
+        beforeEach(() => {
+          Nock(testDomain).get('/').reply(500, { data: 'hello world' })
         })
 
-        it("has a 'response' property containg the error", async () => {
-          const result = await RequestLib.get(testDomain)
+        describe('the result it returns', () => {
+          it("has a 'succeeded' property marked as false", async () => {
+            const result = await RequestLib.get(testDomain)
 
-          expect(result.response).to.exist()
-          expect(result.response).to.be.an.error()
-          expect(result.response.code).to.equal('ECONNRESET')
+            expect(result.succeeded).to.be.false()
+          })
+
+          it("has a 'response' property containg the web response", async () => {
+            const result = await RequestLib.get(testDomain)
+
+            expect(result.response).to.exist()
+            expect(result.response.statusCode).to.equal(500)
+            expect(result.response.body).to.equal('{"data":"hello world"}')
+          })
         })
       })
-    })
 
-    describe('because request timed out', () => {
-      beforeEach(async () => {
-        // Set the timeout value to 50ms for these tests
-        Sinon.replace(requestConfig, 'timeout', 50)
-      })
-
-      // Because of the fake delay in this test, Lab will timeout (by default tests have 2 seconds to finish). So, we
-      // have to override the timeout for this specific test to all it to complete
-      describe('and all retries fail', { timeout: 5000 }, () => {
-        beforeEach(async () => {
-          Nock(testDomain)
-            .get(() => true)
-            .delay(100)
-            .reply(200, { data: 'hello world' })
-            .persist()
+      describe('because there was a network issue', () => {
+        beforeEach(() => {
+          Nock(testDomain).get('/').replyWithError({ code: 'ECONNRESET' })
         })
 
         describe('the result it returns', () => {
@@ -119,70 +86,105 @@ describe('RequestLib', () => {
 
             expect(result.response).to.exist()
             expect(result.response).to.be.an.error()
-            expect(result.response.code).to.equal('ETIMEDOUT')
+            expect(result.response.code).to.equal('ECONNRESET')
           })
         })
       })
 
-      describe('and a retry succeeds', () => {
+      describe('because request timed out', () => {
         beforeEach(async () => {
-          // The first response will time out, the second response will return OK
-          Nock(testDomain)
-            .get(() => true)
-            .delay(100)
-            .reply(200, { data: 'hello world' })
-            .get(() => true)
-            .reply(200, { data: 'hello world' })
+          // Set the timeout value to 50ms for these tests
+          Sinon.replace(requestConfig, 'timeout', 50)
         })
 
-        describe('the result it returns', () => {
-          it("has a 'succeeded' property marked as true", async () => {
-            const result = await RequestLib.get(testDomain)
-
-            expect(result.succeeded).to.be.true()
+        // Because of the fake delay in this test, Lab will timeout (by default tests have 2 seconds to finish). So, we
+        // have to override the timeout for this specific test to all it to complete
+        describe('and all retries fail', { timeout: 5000 }, () => {
+          beforeEach(async () => {
+            Nock(testDomain)
+              .get(() => true)
+              .delay(100)
+              .reply(200, { data: 'hello world' })
+              .persist()
           })
 
-          it("has a 'response' property containg the web response", async () => {
-            const result = await RequestLib.get(testDomain)
+          describe('the result it returns', () => {
+            it("has a 'succeeded' property marked as false", async () => {
+              const result = await RequestLib.get(testDomain)
 
-            expect(result.response).to.exist()
-            expect(result.response.statusCode).to.equal(200)
-            expect(result.response.body).to.equal('{"data":"hello world"}')
+              expect(result.succeeded).to.be.false()
+            })
+
+            it("has a 'response' property containg the error", async () => {
+              const result = await RequestLib.get(testDomain)
+
+              expect(result.response).to.exist()
+              expect(result.response).to.be.an.error()
+              expect(result.response.code).to.equal('ETIMEDOUT')
+            })
+          })
+        })
+
+        describe('and a retry succeeds', () => {
+          beforeEach(async () => {
+            // The first response will time out, the second response will return OK
+            Nock(testDomain)
+              .get(() => true)
+              .delay(100)
+              .reply(200, { data: 'hello world' })
+              .get(() => true)
+              .reply(200, { data: 'hello world' })
+          })
+
+          describe('the result it returns', () => {
+            it("has a 'succeeded' property marked as true", async () => {
+              const result = await RequestLib.get(testDomain)
+
+              expect(result.succeeded).to.be.true()
+            })
+
+            it("has a 'response' property containg the web response", async () => {
+              const result = await RequestLib.get(testDomain)
+
+              expect(result.response).to.exist()
+              expect(result.response.statusCode).to.equal(200)
+              expect(result.response.body).to.equal('{"data":"hello world"}')
+            })
           })
         })
       })
     })
-  })
 
-  describe('When I provide additional options', () => {
-    describe('and they expand the default options', () => {
-      beforeEach(() => {
-        Nock(testDomain).get('/').reply(200, { data: 'hello world' })
+    describe('When I provide additional options', () => {
+      describe('and they expand the default options', () => {
+        beforeEach(() => {
+          Nock(testDomain).get('/').reply(200, { data: 'hello world' })
+        })
+
+        it('adds them to the options used when making the request', async () => {
+          // We tell Got to return the response as json rather than text. We can confirm the option has been applied by
+          // checking the result.reponse.body below.
+          const options = { responseType: 'json' }
+          const result = await RequestLib.get(testDomain, options)
+
+          expect(result.succeeded).to.be.true()
+          expect(result.response.body).to.equal({ data: 'hello world' })
+        })
       })
 
-      it('adds them to the options used when making the request', async () => {
-        // We tell Got to return the response as json rather than text. We can confirm the option has been applied by
-        // checking the result.reponse.body below.
-        const options = { responseType: 'json' }
-        const result = await RequestLib.get(testDomain, options)
+      describe('and they replace a default option', () => {
+        beforeEach(() => {
+          Nock(testDomain).get('/').reply(500)
+        })
 
-        expect(result.succeeded).to.be.true()
-        expect(result.response.body).to.equal({ data: 'hello world' })
-      })
-    })
+        it('uses them in the options used when making the request', async () => {
+          // We tell Got throw an error if the response is not 2xx or 3xx
+          const options = { throwHttpErrors: true }
+          const result = await RequestLib.get(testDomain, options)
 
-    describe('and they replace a default option', () => {
-      beforeEach(() => {
-        Nock(testDomain).get('/').reply(500)
-      })
-
-      it('uses them in the options used when making the request', async () => {
-        // We tell Got throw an error if the response is not 2xx or 3xx
-        const options = { throwHttpErrors: true }
-        const result = await RequestLib.get(testDomain, options)
-
-        expect(result.succeeded).to.be.false()
-        expect(result.response).to.be.an.error()
+          expect(result.succeeded).to.be.false()
+          expect(result.response).to.be.an.error()
+        })
       })
     })
   })

--- a/test/lib/request.lib.test.js
+++ b/test/lib/request.lib.test.js
@@ -1,0 +1,190 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+const Nock = require('nock')
+
+const { describe, it, beforeEach, afterEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const requestConfig = require('../../config/request.config.js')
+
+// Thing under test
+const RequestLib = require('../../app/lib/request.lib.js')
+
+describe('RequestLib', () => {
+  const testDomain = 'http://example.com'
+
+  afterEach(() => {
+    Sinon.restore()
+    Nock.cleanAll()
+  })
+
+  describe('When a request succeeds', () => {
+    beforeEach(() => {
+      Nock(testDomain).get('/').reply(200, { data: 'hello world' })
+    })
+
+    describe('the result it returns', () => {
+      it("has a 'succeeded' property marked as true", async () => {
+        const result = await RequestLib.get(testDomain)
+
+        expect(result.succeeded).to.be.true()
+      })
+
+      it("has a 'response' property containg the web response", async () => {
+        const result = await RequestLib.get(testDomain)
+
+        expect(result.response).to.exist()
+        expect(result.response.statusCode).to.equal(200)
+        expect(result.response.body).to.equal('{"data":"hello world"}')
+      })
+    })
+  })
+
+  describe('When a request fails', () => {
+    describe('because the response was a 500', () => {
+      beforeEach(() => {
+        Nock(testDomain).get('/').reply(500, { data: 'hello world' })
+      })
+
+      describe('the result it returns', () => {
+        it("has a 'succeeded' property marked as false", async () => {
+          const result = await RequestLib.get(testDomain)
+
+          expect(result.succeeded).to.be.false()
+        })
+
+        it("has a 'response' property containg the web response", async () => {
+          const result = await RequestLib.get(testDomain)
+
+          expect(result.response).to.exist()
+          expect(result.response.statusCode).to.equal(500)
+          expect(result.response.body).to.equal('{"data":"hello world"}')
+        })
+      })
+    })
+
+    describe('because there was a network issue', () => {
+      beforeEach(() => {
+        Nock(testDomain).get('/').replyWithError({ code: 'ECONNRESET' })
+      })
+
+      describe('the result it returns', () => {
+        it("has a 'succeeded' property marked as false", async () => {
+          const result = await RequestLib.get(testDomain)
+
+          expect(result.succeeded).to.be.false()
+        })
+
+        it("has a 'response' property containg the error", async () => {
+          const result = await RequestLib.get(testDomain)
+
+          expect(result.response).to.exist()
+          expect(result.response).to.be.an.error()
+          expect(result.response.code).to.equal('ECONNRESET')
+        })
+      })
+    })
+
+    describe('because request timed out', () => {
+      beforeEach(async () => {
+        // Set the timeout value to 50ms for these tests
+        Sinon.replace(requestConfig, 'timeout', 50)
+      })
+
+      // Because of the fake delay in this test, Lab will timeout (by default tests have 2 seconds to finish). So, we
+      // have to override the timeout for this specific test to all it to complete
+      describe('and all retries fail', { timeout: 5000 }, () => {
+        beforeEach(async () => {
+          Nock(testDomain)
+            .get(() => true)
+            .delay(100)
+            .reply(200, { data: 'hello world' })
+            .persist()
+        })
+
+        describe('the result it returns', () => {
+          it("has a 'succeeded' property marked as false", async () => {
+            const result = await RequestLib.get(testDomain)
+
+            expect(result.succeeded).to.be.false()
+          })
+
+          it("has a 'response' property containg the error", async () => {
+            const result = await RequestLib.get(testDomain)
+
+            expect(result.response).to.exist()
+            expect(result.response).to.be.an.error()
+            expect(result.response.code).to.equal('ETIMEDOUT')
+          })
+        })
+      })
+
+      describe('and a retry succeeds', () => {
+        beforeEach(async () => {
+          // The first response will time out, the second response will return OK
+          Nock(testDomain)
+            .get(() => true)
+            .delay(100)
+            .reply(200, { data: 'hello world' })
+            .get(() => true)
+            .reply(200, { data: 'hello world' })
+        })
+
+        describe('the result it returns', () => {
+          it("has a 'succeeded' property marked as true", async () => {
+            const result = await RequestLib.get(testDomain)
+
+            expect(result.succeeded).to.be.true()
+          })
+
+          it("has a 'response' property containg the web response", async () => {
+            const result = await RequestLib.get(testDomain)
+
+            expect(result.response).to.exist()
+            expect(result.response.statusCode).to.equal(200)
+            expect(result.response.body).to.equal('{"data":"hello world"}')
+          })
+        })
+      })
+    })
+  })
+
+  describe('When I provide additional options', () => {
+    describe('and they expand the default options', () => {
+      beforeEach(() => {
+        Nock(testDomain).get('/').reply(200, { data: 'hello world' })
+      })
+
+      it('adds them to the options used when making the request', async () => {
+        // We tell Got to return the response as json rather than text. We can confirm the option has been applied by
+        // checking the result.reponse.body below.
+        const options = { responseType: 'json' }
+        const result = await RequestLib.get(testDomain, options)
+
+        expect(result.succeeded).to.be.true()
+        expect(result.response.body).to.equal({ data: 'hello world' })
+
+      })
+    })
+
+    describe('and they replace a default option', () => {
+      beforeEach(() => {
+        Nock(testDomain).get('/').reply(500)
+      })
+
+      it('uses them in the options used when making the request', async () => {
+        // We tell Got throw an error if the response is not 2xx or 3xx
+        const options = { throwHttpErrors: true }
+        const result = await RequestLib.get(testDomain, options)
+
+        expect(result.succeeded).to.be.false()
+        expect(result.response).to.be.an.error()
+      })
+    })
+  })
+})

--- a/test/lib/request.lib.test.js
+++ b/test/lib/request.lib.test.js
@@ -168,7 +168,6 @@ describe('RequestLib', () => {
 
         expect(result.succeeded).to.be.true()
         expect(result.response.body).to.equal({ data: 'hello world' })
-
       })
     })
 

--- a/test/lib/request.lib.test.js
+++ b/test/lib/request.lib.test.js
@@ -133,7 +133,7 @@ describe('RequestLib', () => {
               .delay(100)
               .reply(200, { data: 'hello world' })
               .get(() => true)
-              .reply(200, { data: 'hello world' })
+              .reply(200, { data: 'delayed hello world' })
           })
 
           describe('the result it returns', () => {
@@ -148,7 +148,7 @@ describe('RequestLib', () => {
 
               expect(result.response).to.exist()
               expect(result.response.statusCode).to.equal(200)
-              expect(result.response.body).to.equal('{"data":"hello world"}')
+              expect(result.response.body).to.equal('{"data":"delayed hello world"}')
             })
           })
         })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3833

Our `/service-status` page makes `GET` requests to the other services in order to check if they are 'alive'. We now need to start making requests to other external services, for example, the Charging Module API and AWS Cognito (to authenticate with the CHA API).

There are options we want to pass to [got](https://github.com/sindresorhus/got) all the time. Plus we want a standard way of handling the response. **got**, by default, will throw an error for anything other than a `2xx` or `3xx` response. But we normally want the response, including the status code and body as it will determine what we do next.

So, it's time to add a generic HTTP request module to centralise and standardise these things.