### PR TITLE
New charge element model for SROC supplementary bill run

### DIFF
--- a/app/models/charge-element.model.js
+++ b/app/models/charge-element.model.js
@@ -1,0 +1,31 @@
+'use strict'
+
+/**
+ * Model for water.charge_elements
+ * @module ChargeElementModel
+ */
+
+const { Model } = require('objection')
+
+const BaseModel = require('./base.model.js')
+
+class ChargeElementModel extends BaseModel {
+  static get tableName () {
+    return 'water.charge_elements'
+  }
+
+  static get relationMappings () {
+    return {
+      chargeVersion: {
+        relation: Model.BelongsToOneRelation,
+        modelClass: 'charge-version.model',
+        join: {
+          from: 'water.charge_elements.charge_version_id',
+          to: 'water.charge_versions.charge_version_id'
+        }
+      }
+    }
+  }
+}
+
+module.exports = ChargeElementModel

--- a/app/models/charge-version.model.js
+++ b/app/models/charge-version.model.js
@@ -23,6 +23,14 @@ class ChargeVersionModel extends BaseModel {
           from: 'water.charge_versions.licence_id',
           to: 'water.licences.licence_id'
         }
+      },
+      chargeElements: {
+        relation: Model.HasManyRelation,
+        modelClass: 'charge-element.model',
+        join: {
+          from: 'water.charge_versions.charge_version_id',
+          to: 'water.charge_elements.charge_version_id'
+        }
       }
     }
   }

--- a/app/models/charge-version.model.js
+++ b/app/models/charge-version.model.js
@@ -24,7 +24,7 @@ class ChargeVersionModel extends BaseModel {
           to: 'water.licences.licence_id'
         }
       },
-      chargeElements: {
+      chargeElement: {
         relation: Model.HasManyRelation,
         modelClass: 'charge-element.model',
         join: {

--- a/db/migrations/20221215174926_create_charge_elements.js
+++ b/db/migrations/20221215174926_create_charge_elements.js
@@ -1,0 +1,46 @@
+'use strict'
+
+const tableName = 'charge_elements'
+
+exports.up = async function (knex) {
+  await knex
+    .schema
+    .withSchema('water')
+    .createTable(tableName, table => {
+      // Primary Key
+      table.uuid('charge_element_id').primary().defaultTo(knex.raw('gen_random_uuid()'))
+
+      // Data
+      table.uuid('charge_version_id')
+      table.string('source')
+      table.string('loss')
+      table.string('description')
+      table.boolean('is_section_127_agreement_enabled')
+      table.string('scheme')
+      table.boolean('is_restricted_source')
+      table.string('water_model')
+      table.decimal('volume')
+      table.uuid('billing_charge_category_id')
+      table.jsonb('additional_charges')
+      table.jsonb('adjustments')
+      table.string('eiuc_region')
+
+      // Automatic timestamps
+      table.timestamps(false, true)
+    })
+
+  await knex.raw(`
+    CREATE TRIGGER update_timestamp
+    BEFORE UPDATE
+    ON water.${tableName}
+    FOR EACH ROW
+    EXECUTE PROCEDURE update_timestamp();
+  `)
+}
+
+exports.down = function (knex) {
+  return knex
+    .schema
+    .withSchema('water')
+    .dropTableIfExists(tableName)
+}

--- a/test/models/charge-element.model.test.js
+++ b/test/models/charge-element.model.test.js
@@ -1,0 +1,30 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Thing under test
+const ChargeElement = require('../../app/models/charge-element.model.js')
+
+describe('Charge Element model', () => {
+  it('can successfully run a query', async () => {
+    const query = await ChargeElement.query()
+
+    expect(query).to.exist()
+  })
+
+  describe('Relationships', () => {
+    describe('when linking to charge version', () => {
+      it('can successfully run a query', async () => {
+        const query = await ChargeElement.query()
+          .innerJoinRelated('chargeVersion')
+
+        expect(query).to.exist()
+      })
+    })
+  })
+})

--- a/test/models/charge-version.model.test.js
+++ b/test/models/charge-version.model.test.js
@@ -18,10 +18,19 @@ describe('ChargeVersion model', () => {
   })
 
   describe('Relationships', () => {
-    describe('when linking to charge versions', () => {
+    describe('when linking to licence', () => {
       it('can successfully run a query', async () => {
         const query = await ChargeVersion.query()
           .innerJoinRelated('licence')
+
+        expect(query).to.exist()
+      })
+    })
+
+    describe('when linking to charge element', () => {
+      it('can successfully run a query', async () => {
+        const query = await ChargeVersion.query()
+          .innerJoinRelated('chargeElement')
 
         expect(query).to.exist()
       })

--- a/test/support/helpers/charge-element.helper.js
+++ b/test/support/helpers/charge-element.helper.js
@@ -1,0 +1,75 @@
+'use strict'
+
+/**
+ * @module ChargeElementHelper
+ */
+
+const { db } = require('../../../db/db.js')
+
+/**
+ * Add a new charge element
+ *
+ * If no `data` is provided, default values will be used. These are
+ *
+ * - `charge_version_id` - b033e8d1-3ad4-4782-930b-c1e10cb9110e
+ * - `source` - non-tidal
+ * - `loss` - low
+ * - `description` - Mineral washing
+ * - `is_section_127_agreement_enabled` - true
+ * - `scheme` - sroc
+ * - `is_restricted_source` - true
+ * - `water_model` - no model
+ * - `volume` - 6.819
+ * - `billing_charge_category_id` - cd9ca44d-2ddb-4d5d-ac62-79883176bdec
+ * - `additional_charges` - { isSupplyPublicWater: true }
+ * - `adjustments` - { s126: null, s127: false, s130: false, charge: null, winter: false, aggregate: 0.562114443 }
+ * - `eiuc_region` - Anglian
+ *
+ * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ *
+ * @returns {string} The ID of the newly created record
+ */
+async function add (data = {}) {
+  const insertData = defaults(data)
+
+  const result = await db.table('water.charge_elements')
+    .insert(insertData)
+    .returning('charge_element_id')
+
+  return result
+}
+
+/**
+ * Returns the defaults used when creating a new charge element
+ *
+ * It will override or append to them any data provided. Mainly used by the `add()` method, we make it available
+ * for use in tests to avoid having to duplicate values.
+ *
+ * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ */
+function defaults (data = {}) {
+  const defaults = {
+    charge_version_id: 'b033e8d1-3ad4-4782-930b-c1e10cb9110e',
+    source: 'non-tidal',
+    loss: 'low',
+    description: 'Mineral washing',
+    is_section_127_agreement_enabled: true,
+    scheme: 'sroc',
+    is_restricted_source: true,
+    water_model: 'no model',
+    volume: 6.819,
+    billing_charge_category_id: 'cd9ca44d-2ddb-4d5d-ac62-79883176bdec',
+    additional_charges: { isSupplyPublicWater: true },
+    adjustments: { s126: null, s127: false, s130: false, charge: null, winter: false, aggregate: 0.562114443 },
+    eiuc_region: 'Anglian'
+  }
+
+  return {
+    ...defaults,
+    ...data
+  }
+}
+
+module.exports = {
+  add
+}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3859

Behind the scenes, the charge references are held in the charge_elements table. They then link to charge_purposes which hold our abstraction periods.

To get to the charge_purposes from charge_versions we need a ChargeElement model.