### PR TITLE
New charge purpose model for SROC supplementary bill run

### DIFF
--- a/app/models/charge-element.model.js
+++ b/app/models/charge-element.model.js
@@ -31,6 +31,14 @@ class ChargeElementModel extends BaseModel {
           from: 'water.charge_elements.billing_charge_category_id',
           to: 'water.billing_charge_categories.billing_charge_category_id'
         }
+      },
+      chargePurpose: {
+        relation: Model.HasManyRelation,
+        modelClass: 'charge-purpose.model',
+        join: {
+          from: 'water.charge_elements.charge_element_id',
+          to: 'water.charge_purposes.charge_element_id'
+        }
       }
     }
   }

--- a/app/models/charge-purpose.model.js
+++ b/app/models/charge-purpose.model.js
@@ -1,0 +1,31 @@
+'use strict'
+
+/**
+ * Model for water.charge_purposes
+ * @module ChargePurposeModel
+ */
+
+const { Model } = require('objection')
+
+const BaseModel = require('./base.model.js')
+
+class ChargePurposeModel extends BaseModel {
+  static get tableName () {
+    return 'water.charge_purposes'
+  }
+
+  static get relationMappings () {
+    return {
+      chargeElement: {
+        relation: Model.BelongsToOneRelation,
+        modelClass: 'charge-element.model',
+        join: {
+          from: 'water.charge_purposes.charge_element_id',
+          to: 'water.charge_elements.charge_element_id'
+        }
+      }
+    }
+  }
+}
+
+module.exports = ChargePurposeModel

--- a/db/migrations/20221216154722_create_charge_purposes.js
+++ b/db/migrations/20221216154722_create_charge_purposes.js
@@ -1,0 +1,49 @@
+'use strict'
+
+const tableName = 'charge_purposes'
+
+exports.up = async function (knex) {
+  await knex
+    .schema
+    .withSchema('water')
+    .createTable(tableName, table => {
+      // Primary Key
+      table.uuid('charge_purpose_id').primary().defaultTo(knex.raw('gen_random_uuid()'))
+
+      // Data
+      table.uuid('charge_element_id')
+      table.integer('abstraction_period_start_day')
+      table.integer('abstraction_period_start_month')
+      table.integer('abstraction_period_end_day')
+      table.integer('abstraction_period_end_month')
+      table.decimal('authorised_annual_quantity')
+      table.string('loss')
+      table.boolean('factors_overridden')
+      table.decimal('billable_annual_quantity')
+      table.date('time_limited_start_date')
+      table.date('time_limited_end_date')
+      table.string('description')
+      table.uuid('purpose_primary_id')
+      table.uuid('purpose_secondary_id')
+      table.uuid('purpose_use_id')
+      table.boolean('is_section_127_agreement_enabled')
+
+      // Automatic timestamps
+      table.timestamps(false, true)
+    })
+
+  await knex.raw(`
+    CREATE TRIGGER update_timestamp
+    BEFORE UPDATE
+    ON water.${tableName}
+    FOR EACH ROW
+    EXECUTE PROCEDURE update_timestamp();
+  `)
+}
+
+exports.down = function (knex) {
+  return knex
+    .schema
+    .withSchema('water')
+    .dropTableIfExists(tableName)
+}

--- a/test/models/charge-element.model.test.js
+++ b/test/models/charge-element.model.test.js
@@ -35,5 +35,14 @@ describe('Charge Element model', () => {
         expect(query).to.exist()
       })
     })
+
+    describe('when linking to charge purpose', () => {
+      it('can successfully run a query', async () => {
+        const query = await ChargeElement.query()
+          .innerJoinRelated('chargePurpose')
+
+        expect(query).to.exist()
+      })
+    })
   })
 })

--- a/test/models/charge-purpose.model.test.js
+++ b/test/models/charge-purpose.model.test.js
@@ -1,0 +1,30 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Thing under test
+const ChargePurpose = require('../../app/models/charge-purpose.model.js')
+
+describe('Charge Purpose model', () => {
+  it('can successfully run a query', async () => {
+    const query = await ChargePurpose.query()
+
+    expect(query).to.exist()
+  })
+
+  describe('Relationships', () => {
+    describe('when linking to charge element', () => {
+      it('can successfully run a query', async () => {
+        const query = await ChargePurpose.query()
+          .innerJoinRelated('chargeElement')
+
+        expect(query).to.exist()
+      })
+    })
+  })
+})

--- a/test/support/helpers/charge-purpose.helper.js
+++ b/test/support/helpers/charge-purpose.helper.js
@@ -1,0 +1,81 @@
+'use strict'
+
+/**
+ * @module ChargePurposeHelper
+ */
+
+const { db } = require('../../../db/db.js')
+
+/**
+ * Add a new charge purpose
+ *
+ * If no `data` is provided, default values will be used. These are
+ *
+ * - `charge_element_id` - 090f42a0-7718-453e-bc6a-d57ef8d65417
+ * - `abstraction_period_start_day` - 1
+ * - `abstraction_period_start_month` - 4
+ * - `abstraction_period_end_day` - 31
+ * - `abstraction_period_end_month` - 3
+ * - `authorised_annual_quantity` - 200
+ * - `loss` - low
+ * - `factors_overridden` - true
+ * - `billable_annual_quantity` - 4.55
+ * - `time_limited_start_date` - 2022-04-01
+ * - `time_limited_end_date` - 2030-03-30
+ * - `description` - Trickle Irrigation - Direct
+ * - `purpose_primary_id` - 383ab43e-6d0b-4be0-b5d2-4226f333f1d7
+ * - `purpose_secondary_id` - 0e92d79a-f17f-4364-955f-443360ebddb2
+ * - `purpose_use_id` - cc9f412c-22c6-483a-93b0-b955a3a644dc
+ * - `is_section_127_agreement_enabled` - true
+ *
+ * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ *
+ * @returns {string} The ID of the newly created record
+ */
+async function add (data = {}) {
+  const insertData = defaults(data)
+
+  const result = await db.table('water.charge_purposes')
+    .insert(insertData)
+    .returning('charge_purpose_id')
+
+  return result
+}
+
+/**
+ * Returns the defaults used when creating a new charge purpose
+ *
+ * It will override or append to them any data provided. Mainly used by the `add()` method, we make it available
+ * for use in tests to avoid having to duplicate values.
+ *
+ * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ */
+function defaults (data = {}) {
+  const defaults = {
+    charge_element_id: '090f42a0-7718-453e-bc6a-d57ef8d65417',
+    abstraction_period_start_day: 1,
+    abstraction_period_start_month: 4,
+    abstraction_period_end_day: 31,
+    abstraction_period_end_month: 3,
+    authorised_annual_quantity: 200,
+    loss: 'low',
+    factors_overridden: true,
+    billable_annual_quantity: 4.55,
+    time_limited_start_date: '2022-04-01',
+    time_limited_end_date: '2030-03-30',
+    description: 'Trickle Irrigation - Direct',
+    purpose_primary_id: '383ab43e-6d0b-4be0-b5d2-4226f333f1d7',
+    purpose_secondary_id: '0e92d79a-f17f-4364-955f-443360ebddb2',
+    purpose_use_id: 'cc9f412c-22c6-483a-93b0-b955a3a644dc',
+    is_section_127_agreement_enabled: true
+  }
+
+  return {
+    ...defaults,
+    ...data
+  }
+}
+
+module.exports = {
+  add
+}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3860

Behind the scenes, the charge references are held in the charge_elements table. They then link to charge_purposes which hold our abstraction periods.