### PR TITLE
Fix issue with error-pages.plugin

### DIFF
--- a/app/plugins/error-pages.plugin.js
+++ b/app/plugins/error-pages.plugin.js
@@ -22,7 +22,7 @@ const ErrorPagesPlugin = {
 
         const { errorPages: pluginSettings } = request.route.settings.plugins
 
-        if (response.isBoom && !pluginSettings.plainOutput) {
+        if (response.isBoom && !pluginSettings?.plainOutput) {
           const { statusCode } = response.output
 
           if (statusCode === 404) {

--- a/test/plugins/error-pages.plugin.test.js
+++ b/test/plugins/error-pages.plugin.test.js
@@ -3,7 +3,7 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
-const Stub = require('sinon')
+const Sinon = require('sinon')
 
 const { describe, it, beforeEach, afterEach } = exports.lab = Lab.script()
 const { expect } = Code
@@ -15,7 +15,6 @@ const Boom = require('@hapi/boom')
 const { init } = require('../../app/server.js')
 const { Exception } = require('sass')
 const Sinon = require('sinon')
-const { afterDelete } = require('../../app/models/base.model')
 
 describe('Error Pages plugin', () => {
   const options = {
@@ -23,7 +22,6 @@ describe('Error Pages plugin', () => {
     url: '/error-pages'
   }
   let server
-
 
   beforeEach(async () => {
     // Create server before each test

--- a/test/plugins/error-pages.plugin.test.js
+++ b/test/plugins/error-pages.plugin.test.js
@@ -4,7 +4,7 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it , beforeEach } = exports.lab = Lab.script()
+const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers

--- a/test/plugins/error-pages.plugin.test.js
+++ b/test/plugins/error-pages.plugin.test.js
@@ -1,0 +1,143 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it , beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const Boom = require('@hapi/boom')
+
+// For running our service
+const { init } = require('../../app/server.js')
+const { Exception } = require('sass')
+
+describe('Error Pages plugin', () => {
+  const options = {
+    method: 'GET',
+    url: '/error-pages'
+  }
+  let server
+
+  // Create server before each test
+  beforeEach(async () => {
+    server = await init()
+  })
+
+  describe('When the error is a Boom error', () => {
+    describe('and it is not a 404', () => {
+      describe('and it is a route without errorPages options', () => {
+        beforeEach(async () => {
+          server.route({
+            method: 'GET',
+            path: '/error-pages',
+            handler: function (_request, _h) {
+              return Boom.badRequest('Things go boom')
+            }
+          })
+        })
+
+        it('returns our general error HTML page', async () => {
+          const response = await server.inject(options)
+
+          expect(response.statusCode).to.equal(400)
+          expect(response.statusMessage).to.equal('Bad Request')
+          expect(response.payload).startsWith('<!DOCTYPE html>')
+          expect(response.payload).contains('Sorry, there is a problem with the service')
+        })
+      })
+
+      describe('and it is a route with errorPages options', () => {
+        beforeEach(async () => {
+          server.route({
+            method: 'GET',
+            path: '/error-pages',
+            options: {
+              plugins: {
+                errorPages: {
+                  plainOutput: true
+                }
+              }
+            },
+            handler: function (_request, _h) {
+              return Boom.badRequest('Things go boom')
+            }
+          })
+        })
+
+        it('returns a plain response', async () => {
+          const response = await server.inject(options)
+
+          expect(response.statusCode).to.equal(400)
+          expect(response.statusMessage).to.equal('Bad Request')
+          expect(response.payload).not.to.startWith('<!DOCTYPE html>')
+          expect(response.payload).contains('Things go boom')
+        })
+      })
+    })
+
+    describe('and it is a 404', () => {
+      it('returns our 404 error HTML page', async () => {
+        const response = await server.inject({ method: 'GET', url: '/no-one-here' })
+
+        expect(response.statusCode).to.equal(404)
+        expect(response.statusMessage).to.equal('Not Found')
+        expect(response.payload).startsWith('<!DOCTYPE html>')
+        expect(response.payload).contains('Page not found')
+      })
+    })
+  })
+
+  describe('When the error is not a Boom error', () => {
+    describe('and it is a route without errorPages options', () => {
+      beforeEach(async () => {
+        server.route({
+          method: 'GET',
+          path: '/error-pages',
+          handler: function (_request, _h) {
+            throw new Exception('Things go boom')
+          }
+        })
+      })
+
+      it('returns our general error HTML page', async () => {
+        const response = await server.inject(options)
+
+        expect(response.statusCode).to.equal(500)
+        expect(response.statusMessage).to.equal('Internal Server Error')
+        expect(response.payload).startsWith('<!DOCTYPE html>')
+        expect(response.payload).contains('Sorry, there is a problem with the service')
+      })
+    })
+
+    describe('and it is a route with errorPages options', () => {
+      beforeEach(async () => {
+        server.route({
+          method: 'GET',
+          path: '/error-pages',
+          options: {
+            plugins: {
+              errorPages: {
+                plainOutput: true
+              }
+            }
+          },
+          handler: function (_request, _h) {
+            throw new Exception('Things go boom')
+          }
+        })
+      })
+
+      it('returns a plain response', async () => {
+        const response = await server.inject(options)
+
+        expect(response.statusCode).to.equal(500)
+        expect(response.statusMessage).to.equal('Internal Server Error')
+        expect(response.payload).not.to.startWith('<!DOCTYPE html>')
+        expect(response.payload).contains('An internal server error occurred')
+      })
+    })
+  })
+})

--- a/test/plugins/error-pages.plugin.test.js
+++ b/test/plugins/error-pages.plugin.test.js
@@ -14,7 +14,6 @@ const Boom = require('@hapi/boom')
 // For running our service
 const { init } = require('../../app/server.js')
 const { Exception } = require('sass')
-const Sinon = require('sinon')
 
 describe('Error Pages plugin', () => {
   const options = {

--- a/test/plugins/error-pages.plugin.test.js
+++ b/test/plugins/error-pages.plugin.test.js
@@ -3,8 +3,9 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
+const Stub = require('sinon')
 
-const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { describe, it, beforeEach, afterEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
@@ -13,6 +14,8 @@ const Boom = require('@hapi/boom')
 // For running our service
 const { init } = require('../../app/server.js')
 const { Exception } = require('sass')
+const Sinon = require('sinon')
+const { afterDelete } = require('../../app/models/base.model')
 
 describe('Error Pages plugin', () => {
   const options = {
@@ -21,9 +24,17 @@ describe('Error Pages plugin', () => {
   }
   let server
 
-  // Create server before each test
+
   beforeEach(async () => {
+    // Create server before each test
     server = await init()
+
+    // We silence any calls to server.logger made in the plugin to try and keep the test output as clean as possible
+    Sinon.stub(server, 'logger')
+  })
+
+  afterEach(() => {
+    Sinon.restore()
   })
 
   describe('When the error is a Boom error', () => {


### PR DESCRIPTION
In [Add Create Sroc Bill Run endpoint](https://github.com/DEFRA/water-abstraction-system/pull/51) we realised the `error-pages.plugin.js` had been written with the assumption we would always want to return an HTML response. But we're now building API-only endpoints for use by the other apps in the service. For this we want the standard response to be returned.

So, we tweaked and added additional options to the routes of our API-only endpoints that allow us to set whether error-pages should use 'plain output' (no HTML).

But in doing so we inadvertently broke things for routes that don't have that additional option set! 🤦

This change adds some tests in the hope we catch this sooner in future. It also fixes the issue.

```
Airbrake controller: GET /status/airbrake
  ✔ 19) returns a 500 error (6 ms)
Debug: internal, implementation, error 
    TypeError: Cannot read properties of undefined (reading 'plainOutput')
    at /home/repos/water-abstraction-system/app/plugins/error-pages.plugin.js:25:363
    at exports.Manager.execute (/home/repos/water-abstraction-system/node_modules/@hapi/hapi/lib/toolkit.js:57:29)
    at Request._invoke (/home/repos/water-abstraction-system/node_modules/@hapi/hapi/lib/request.js:397:55)
    at Request._postCycle (/home/repos/water-abstraction-system/node_modules/@hapi/hapi/lib/request.js:468:86)
    at Request._reply (/home/repos/water-abstraction-system/node_modules/@hapi/hapi/lib/request.js:447:20)
    at Request._execute (/home/repos/water-abstraction-system/node_modules/@hapi/hapi/lib/request.js:281:14)
```
