### PR TITLE
Fix missing Objection Id columns

### DIFF
--- a/app/models/billing-batch.model.js
+++ b/app/models/billing-batch.model.js
@@ -14,6 +14,10 @@ class BillingBatchModel extends BaseModel {
     return 'water.billing_batches'
   }
 
+  static get idColumn () {
+    return 'billing_batch_id'
+  }
+
   static get relationMappings () {
     return {
       region: {

--- a/app/models/billing-charge-category.model.js
+++ b/app/models/billing-charge-category.model.js
@@ -14,6 +14,10 @@ class BillingChargeCategoryModel extends BaseModel {
     return 'water.billing_charge_categories'
   }
 
+  static get idColumn () {
+    return 'billing_charge_category_id'
+  }
+
   static get relationMappings () {
     return {
       chargeElement: {

--- a/app/models/charge-element.model.js
+++ b/app/models/charge-element.model.js
@@ -14,6 +14,10 @@ class ChargeElementModel extends BaseModel {
     return 'water.charge_elements'
   }
 
+  static get idColumn () {
+    return 'charge_element_id'
+  }
+
   static get relationMappings () {
     return {
       chargeVersion: {

--- a/app/models/charge-purpose.model.js
+++ b/app/models/charge-purpose.model.js
@@ -14,6 +14,10 @@ class ChargePurposeModel extends BaseModel {
     return 'water.charge_purposes'
   }
 
+  static get idColumn () {
+    return 'charge_purpose_id'
+  }
+
   static get relationMappings () {
     return {
       chargeElement: {

--- a/app/models/charge-version.model.js
+++ b/app/models/charge-version.model.js
@@ -14,6 +14,10 @@ class ChargeVersionModel extends BaseModel {
     return 'water.charge_versions'
   }
 
+  static get idColumn () {
+    return 'charge_version_id'
+  }
+
   static get relationMappings () {
     return {
       licence: {

--- a/app/models/event.model.js
+++ b/app/models/event.model.js
@@ -11,6 +11,10 @@ class EventModel extends BaseModel {
   static get tableName () {
     return 'water.events'
   }
+
+  static get idColumn () {
+    return 'event_id'
+  }
 }
 
 module.exports = EventModel

--- a/app/models/licence.model.js
+++ b/app/models/licence.model.js
@@ -14,6 +14,10 @@ class LicenceModel extends BaseModel {
     return 'water.licences'
   }
 
+  static get idColumn () {
+    return 'licence_id'
+  }
+
   static get relationMappings () {
     return {
       chargeVersions: {

--- a/app/models/region.model.js
+++ b/app/models/region.model.js
@@ -14,6 +14,10 @@ class RegionModel extends BaseModel {
     return 'water.regions'
   }
 
+  static get idColumn () {
+    return 'region_id'
+  }
+
   static get relationMappings () {
     return {
       licences: {


### PR DESCRIPTION
It was spotted whilst working on [Update "create bill run" endpoint to create a bill run](https://github.com/DEFRA/water-abstraction-system/pull/56) that we had an issue with our [Objection models](https://vincit.github.io/objection.js/).

The previous team didn't use the convention of just calling the unique identifier in each table `id`. Instead, they incorporate the table name, for example, `billing_batch_id`. **Objection** is expecting the identifier column to be `id` and is failing when in some cases.

Because of this, we need to go back and specify [idColumn](https://vincit.github.io/objection.js/api/model/static-properties.html#static-idcolumn) in all our models.