### PR TITLE
Improve model tests

### DIFF
--- a/app/models/billing-charge-category.model.js
+++ b/app/models/billing-charge-category.model.js
@@ -20,7 +20,7 @@ class BillingChargeCategoryModel extends BaseModel {
 
   static get relationMappings () {
     return {
-      chargeElement: {
+      chargeElements: {
         relation: Model.HasManyRelation,
         modelClass: 'charge-element.model',
         join: {

--- a/app/models/region.model.js
+++ b/app/models/region.model.js
@@ -30,7 +30,7 @@ class RegionModel extends BaseModel {
       },
       billingBatches: {
         relation: Model.HasManyRelation,
-        modelClass: 'billing_batch.model',
+        modelClass: 'billing-batch.model',
         join: {
           from: 'regions.regionId',
           to: 'billingBatches.regionId'

--- a/test/models/billing-batch.model.test.js
+++ b/test/models/billing-batch.model.test.js
@@ -4,26 +4,64 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it } = exports.lab = Lab.script()
+const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
+// Test helpers
+const BillingBatchHelper = require('../support/helpers/billing-batch.helper.js')
+const DatabaseHelper = require('../support/helpers/database.helper.js')
+const RegionHelper = require('../support/helpers/region.helper.js')
+const RegionModel = require('../../app/models/region.model.js')
+
 // Thing under test
-const BillingBatch = require('../../app/models/billing-batch.model.js')
+const BillingBatchModel = require('../../app/models/billing-batch.model.js')
 
 describe('Billing Batch model', () => {
-  it('can successfully run a query', async () => {
-    const query = await BillingBatch.query()
+  let testBillingBatch
 
-    expect(query).to.exist()
+  beforeEach(async () => {
+    await DatabaseHelper.clean()
+  })
+
+  describe('Basic query', () => {
+    beforeEach(async () => {
+      testBillingBatch = await BillingBatchHelper.add()
+    })
+
+    it('can successfully run a basic query', async () => {
+      const result = await BillingBatchModel.query().findById(testBillingBatch.billingBatchId)
+
+      expect(result).to.be.an.instanceOf(BillingBatchModel)
+      expect(result.billingBatchId).to.equal(testBillingBatch.billingBatchId)
+    })
   })
 
   describe('Relationships', () => {
     describe('when linking to region', () => {
-      it('can successfully run a query', async () => {
-        const query = await BillingBatch.query()
+      let testRegion
+
+      beforeEach(async () => {
+        testRegion = await RegionHelper.add()
+        testBillingBatch = await BillingBatchHelper.add({ regionId: testRegion.regionId })
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await BillingBatchModel.query()
           .innerJoinRelated('region')
 
         expect(query).to.exist()
+      })
+
+      it.only('can eager load the region', async () => {
+        const result = await BillingBatchModel.query()
+          .findById(testBillingBatch.billingBatchId)
+          .withGraphFetched('region')
+
+        expect(result).to.be.instanceOf(BillingBatchModel)
+        expect(result.billingBatchId).to.equal(testBillingBatch.billingBatchId)
+
+        expect(result.region).to.be.an.instanceOf(RegionModel)
+        expect(result.region).to.equal(testRegion)
       })
     })
   })

--- a/test/models/billing-batch.model.test.js
+++ b/test/models/billing-batch.model.test.js
@@ -52,7 +52,7 @@ describe('Billing Batch model', () => {
         expect(query).to.exist()
       })
 
-      it.only('can eager load the region', async () => {
+      it('can eager load the region', async () => {
         const result = await BillingBatchModel.query()
           .findById(testBillingBatch.billingBatchId)
           .withGraphFetched('region')

--- a/test/models/billing-batch.model.test.js
+++ b/test/models/billing-batch.model.test.js
@@ -17,7 +17,7 @@ const RegionModel = require('../../app/models/region.model.js')
 const BillingBatchModel = require('../../app/models/billing-batch.model.js')
 
 describe('Billing Batch model', () => {
-  let testBillingBatch
+  let testRecord
 
   beforeEach(async () => {
     await DatabaseHelper.clean()
@@ -25,14 +25,14 @@ describe('Billing Batch model', () => {
 
   describe('Basic query', () => {
     beforeEach(async () => {
-      testBillingBatch = await BillingBatchHelper.add()
+      testRecord = await BillingBatchHelper.add()
     })
 
     it('can successfully run a basic query', async () => {
-      const result = await BillingBatchModel.query().findById(testBillingBatch.billingBatchId)
+      const result = await BillingBatchModel.query().findById(testRecord.billingBatchId)
 
       expect(result).to.be.an.instanceOf(BillingBatchModel)
-      expect(result.billingBatchId).to.equal(testBillingBatch.billingBatchId)
+      expect(result.billingBatchId).to.equal(testRecord.billingBatchId)
     })
   })
 
@@ -42,7 +42,7 @@ describe('Billing Batch model', () => {
 
       beforeEach(async () => {
         testRegion = await RegionHelper.add()
-        testBillingBatch = await BillingBatchHelper.add({ regionId: testRegion.regionId })
+        testRecord = await BillingBatchHelper.add({ regionId: testRegion.regionId })
       })
 
       it('can successfully run a related query', async () => {
@@ -54,11 +54,11 @@ describe('Billing Batch model', () => {
 
       it('can eager load the region', async () => {
         const result = await BillingBatchModel.query()
-          .findById(testBillingBatch.billingBatchId)
+          .findById(testRecord.billingBatchId)
           .withGraphFetched('region')
 
         expect(result).to.be.instanceOf(BillingBatchModel)
-        expect(result.billingBatchId).to.equal(testBillingBatch.billingBatchId)
+        expect(result.billingBatchId).to.equal(testRecord.billingBatchId)
 
         expect(result.region).to.be.an.instanceOf(RegionModel)
         expect(result.region).to.equal(testRegion)

--- a/test/models/billing-charge-category.model.test.js
+++ b/test/models/billing-charge-category.model.test.js
@@ -4,26 +4,69 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it } = exports.lab = Lab.script()
+const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
+// Test helpers
+const BillingChargeCategoryHelper = require('../support/helpers/billing-charge-category.helper.js')
+const ChargeElementHelper = require('../support/helpers/charge-element.helper.js')
+const ChargeElementModel = require('../../app/models/charge-element.model.js')
+const DatabaseHelper = require('../support/helpers/database.helper.js')
+
 // Thing under test
-const BillingChargeCategory = require('../../app/models/billing-charge-category.model.js')
+const BillingChargeCategoryModel = require('../../app/models/billing-charge-category.model.js')
 
 describe('Billing Charge Category model', () => {
-  it('can successfully run a query', async () => {
-    const query = await BillingChargeCategory.query()
+  let testBillingChargeCategory
 
-    expect(query).to.exist()
+  beforeEach(async () => {
+    await DatabaseHelper.clean()
+
+    testBillingChargeCategory = await BillingChargeCategoryHelper.add()
+  })
+
+  describe('Basic query', () => {
+    it('can successfully run a basic query', async () => {
+      const result = await BillingChargeCategoryModel.query().findById(testBillingChargeCategory.billingChargeCategoryId)
+
+      expect(result).to.be.an.instanceOf(BillingChargeCategoryModel)
+      expect(result.billingChargeCategoryId).to.equal(testBillingChargeCategory.billingChargeCategoryId)
+    })
   })
 
   describe('Relationships', () => {
-    describe('when linking to charge element', () => {
-      it('can successfully run a query', async () => {
-        const query = await BillingChargeCategory.query()
-          .innerJoinRelated('chargeElement')
+    describe('when linking to charge elements', () => {
+      let testChargeElements
+
+      beforeEach(async () => {
+        const { billingChargeCategoryId } = testBillingChargeCategory
+
+        testChargeElements = []
+        for (let i = 0; i < 2; i++) {
+          const chargeElement = await ChargeElementHelper.add({ description: `CE ${i}`, billingChargeCategoryId })
+          testChargeElements.push(chargeElement)
+        }
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await BillingChargeCategoryModel.query()
+          .innerJoinRelated('chargeElements')
 
         expect(query).to.exist()
+      })
+
+      it('can eager load the charge elements', async () => {
+        const result = await BillingChargeCategoryModel.query()
+          .findById(testBillingChargeCategory.billingChargeCategoryId)
+          .withGraphFetched('chargeElements')
+
+        expect(result).to.be.instanceOf(BillingChargeCategoryModel)
+        expect(result.billingChargeCategoryId).to.equal(testBillingChargeCategory.billingChargeCategoryId)
+
+        expect(result.chargeElements).to.be.an.array()
+        expect(result.chargeElements[0]).to.be.an.instanceOf(ChargeElementModel)
+        expect(result.chargeElements).to.include(testChargeElements[0])
+        expect(result.chargeElements).to.include(testChargeElements[1])
       })
     })
   })

--- a/test/models/billing-charge-category.model.test.js
+++ b/test/models/billing-charge-category.model.test.js
@@ -17,20 +17,20 @@ const DatabaseHelper = require('../support/helpers/database.helper.js')
 const BillingChargeCategoryModel = require('../../app/models/billing-charge-category.model.js')
 
 describe('Billing Charge Category model', () => {
-  let testBillingChargeCategory
+  let testRecord
 
   beforeEach(async () => {
     await DatabaseHelper.clean()
 
-    testBillingChargeCategory = await BillingChargeCategoryHelper.add()
+    testRecord = await BillingChargeCategoryHelper.add()
   })
 
   describe('Basic query', () => {
     it('can successfully run a basic query', async () => {
-      const result = await BillingChargeCategoryModel.query().findById(testBillingChargeCategory.billingChargeCategoryId)
+      const result = await BillingChargeCategoryModel.query().findById(testRecord.billingChargeCategoryId)
 
       expect(result).to.be.an.instanceOf(BillingChargeCategoryModel)
-      expect(result.billingChargeCategoryId).to.equal(testBillingChargeCategory.billingChargeCategoryId)
+      expect(result.billingChargeCategoryId).to.equal(testRecord.billingChargeCategoryId)
     })
   })
 
@@ -39,7 +39,7 @@ describe('Billing Charge Category model', () => {
       let testChargeElements
 
       beforeEach(async () => {
-        const { billingChargeCategoryId } = testBillingChargeCategory
+        const { billingChargeCategoryId } = testRecord
 
         testChargeElements = []
         for (let i = 0; i < 2; i++) {
@@ -57,11 +57,11 @@ describe('Billing Charge Category model', () => {
 
       it('can eager load the charge elements', async () => {
         const result = await BillingChargeCategoryModel.query()
-          .findById(testBillingChargeCategory.billingChargeCategoryId)
+          .findById(testRecord.billingChargeCategoryId)
           .withGraphFetched('chargeElements')
 
         expect(result).to.be.instanceOf(BillingChargeCategoryModel)
-        expect(result.billingChargeCategoryId).to.equal(testBillingChargeCategory.billingChargeCategoryId)
+        expect(result.billingChargeCategoryId).to.equal(testRecord.billingChargeCategoryId)
 
         expect(result.chargeElements).to.be.an.array()
         expect(result.chargeElements[0]).to.be.an.instanceOf(ChargeElementModel)

--- a/test/models/charge-element.model.test.js
+++ b/test/models/charge-element.model.test.js
@@ -4,44 +4,133 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it } = exports.lab = Lab.script()
+const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
+// Test helpers
+const BillingChargeCategoryHelper = require('../support/helpers/billing-charge-category.helper.js')
+const BillingChargeCategoryModel = require('../../app/models/billing-charge-category.model.js')
+const ChargeElementHelper = require('../support/helpers/charge-element.helper.js')
+const ChargePurposeHelper = require('../support/helpers/charge-purpose.helper.js')
+const ChargePurposeModel = require('../../app/models/charge-purpose.model.js')
+const ChargeVersionHelper = require('../support/helpers/charge-version.helper.js')
+const ChargeVersionModel = require('../../app/models/charge-version.model.js')
+const DatabaseHelper = require('../support/helpers/database.helper.js')
+
 // Thing under test
-const ChargeElement = require('../../app/models/charge-element.model.js')
+const ChargeElementModel = require('../../app/models/charge-element.model.js')
 
 describe('Charge Element model', () => {
-  it('can successfully run a query', async () => {
-    const query = await ChargeElement.query()
+  let testRecord
 
-    expect(query).to.exist()
+  beforeEach(async () => {
+    await DatabaseHelper.clean()
+
+    testRecord = await ChargeElementHelper.add()
+  })
+
+  describe('Basic query', () => {
+    it('can successfully run a basic query', async () => {
+      const result = await ChargeElementModel.query().findById(testRecord.chargeElementId)
+
+      expect(result).to.be.an.instanceOf(ChargeElementModel)
+      expect(result.chargeElementId).to.equal(testRecord.chargeElementId)
+    })
   })
 
   describe('Relationships', () => {
-    describe('when linking to charge version', () => {
-      it('can successfully run a query', async () => {
-        const query = await ChargeElement.query()
-          .innerJoinRelated('chargeVersion')
-
-        expect(query).to.exist()
-      })
-    })
-
     describe('when linking to billing charge category', () => {
-      it('can successfully run a query', async () => {
-        const query = await ChargeElement.query()
+      let testBillingChargeCategory
+
+      beforeEach(async () => {
+        testBillingChargeCategory = await BillingChargeCategoryHelper.add()
+
+        const { billingChargeCategoryId } = testBillingChargeCategory
+        testRecord = await ChargeElementHelper.add({ billingChargeCategoryId })
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await ChargeElementModel.query()
           .innerJoinRelated('billingChargeCategory')
 
         expect(query).to.exist()
       })
+
+      it('can eager load the billing charge category', async () => {
+        const result = await ChargeElementModel.query()
+          .findById(testRecord.chargeElementId)
+          .withGraphFetched('billingChargeCategory')
+
+        expect(result).to.be.instanceOf(ChargeElementModel)
+        expect(result.chargeElementId).to.equal(testRecord.chargeElementId)
+
+        expect(result.billingChargeCategory).to.be.an.instanceOf(BillingChargeCategoryModel)
+        expect(result.billingChargeCategory).to.equal(testBillingChargeCategory)
+      })
     })
 
-    describe('when linking to charge purpose', () => {
-      it('can successfully run a query', async () => {
-        const query = await ChargeElement.query()
+    describe('when linking to charge purposes', () => {
+      let testChargePurposes
+
+      beforeEach(async () => {
+        const { chargeElementId } = testRecord
+
+        testChargePurposes = []
+        for (let i = 0; i < 2; i++) {
+          const chargePurpose = await ChargePurposeHelper.add({ description: `CP ${i}`, chargeElementId })
+          testChargePurposes.push(chargePurpose)
+        }
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await ChargeElementModel.query()
           .innerJoinRelated('chargePurposes')
 
         expect(query).to.exist()
+      })
+
+      it('can eager load the charge purposes', async () => {
+        const result = await ChargeElementModel.query()
+          .findById(testRecord.chargeElementId)
+          .withGraphFetched('chargePurposes')
+
+        expect(result).to.be.instanceOf(ChargeElementModel)
+        expect(result.chargeElementId).to.equal(testRecord.chargeElementId)
+
+        expect(result.chargePurposes).to.be.an.array()
+        expect(result.chargePurposes[0]).to.be.an.instanceOf(ChargePurposeModel)
+        expect(result.chargePurposes).to.include(testChargePurposes[0])
+        expect(result.chargePurposes).to.include(testChargePurposes[1])
+      })
+    })
+
+    describe('when linking to charge version', () => {
+      let testChargeVersion
+
+      beforeEach(async () => {
+        testChargeVersion = await ChargeVersionHelper.add()
+
+        const { chargeVersionId } = testChargeVersion
+        testRecord = await ChargeElementHelper.add({ chargeVersionId })
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await ChargeElementModel.query()
+          .innerJoinRelated('chargeVersion')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the charge version', async () => {
+        const result = await ChargeElementModel.query()
+          .findById(testRecord.chargeElementId)
+          .withGraphFetched('chargeVersion')
+
+        expect(result).to.be.instanceOf(ChargeElementModel)
+        expect(result.chargeElementId).to.equal(testRecord.chargeElementId)
+
+        expect(result.chargeVersion).to.be.an.instanceOf(ChargeVersionModel)
+        expect(result.chargeVersion).to.equal(testChargeVersion)
       })
     })
   })

--- a/test/models/charge-purpose.model.test.js
+++ b/test/models/charge-purpose.model.test.js
@@ -4,26 +4,64 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it } = exports.lab = Lab.script()
+const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
+// Test helpers
+const ChargeElementHelper = require('../support/helpers/charge-element.helper.js')
+const ChargeElementModel = require('../../app/models/charge-element.model.js')
+const ChargePurposeHelper = require('../support/helpers/charge-purpose.helper.js')
+const DatabaseHelper = require('../support/helpers/database.helper.js')
+
 // Thing under test
-const ChargePurpose = require('../../app/models/charge-purpose.model.js')
+const ChargePurposeModel = require('../../app/models/charge-purpose.model.js')
 
 describe('Charge Purpose model', () => {
-  it('can successfully run a query', async () => {
-    const query = await ChargePurpose.query()
+  let testRecord
 
-    expect(query).to.exist()
+  beforeEach(async () => {
+    await DatabaseHelper.clean()
+
+    testRecord = await ChargePurposeHelper.add()
+  })
+
+  describe('Basic query', () => {
+    it('can successfully run a basic query', async () => {
+      const result = await ChargePurposeModel.query().findById(testRecord.chargePurposeId)
+
+      expect(result).to.be.an.instanceOf(ChargePurposeModel)
+      expect(result.chargePurposeId).to.equal(testRecord.chargePurposeId)
+    })
   })
 
   describe('Relationships', () => {
     describe('when linking to charge element', () => {
-      it('can successfully run a query', async () => {
-        const query = await ChargePurpose.query()
+      let testChargeElement
+
+      beforeEach(async () => {
+        testChargeElement = await ChargeElementHelper.add()
+
+        const { chargeElementId } = testChargeElement
+        testRecord = await ChargePurposeHelper.add({ chargeElementId })
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await ChargePurposeModel.query()
           .innerJoinRelated('chargeElement')
 
         expect(query).to.exist()
+      })
+
+      it('can eager load the charge element', async () => {
+        const result = await ChargePurposeModel.query()
+          .findById(testRecord.chargePurposeId)
+          .withGraphFetched('chargeElement')
+
+        expect(result).to.be.instanceOf(ChargePurposeModel)
+        expect(result.chargePurposeId).to.equal(testRecord.chargePurposeId)
+
+        expect(result.chargeElement).to.be.an.instanceOf(ChargeElementModel)
+        expect(result.chargeElement).to.equal(testChargeElement)
       })
     })
   })

--- a/test/models/charge-version.model.test.js
+++ b/test/models/charge-version.model.test.js
@@ -4,35 +4,101 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it } = exports.lab = Lab.script()
+const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
+// Test helpers
+const ChargeElementHelper = require('../support/helpers/charge-element.helper.js')
+const ChargeElementModel = require('../../app/models/charge-element.model.js')
+const ChargeVersionHelper = require('../support/helpers/charge-version.helper.js')
+const DatabaseHelper = require('../support/helpers/database.helper.js')
+const LicenceHelper = require('../support/helpers/licence.helper.js')
+const LicenceModel = require('../../app/models/licence.model.js')
+
 // Thing under test
-const ChargeVersion = require('../../app/models/charge-version.model.js')
+const ChargeVersionModel = require('../../app/models/charge-version.model.js')
 
 describe('ChargeVersion model', () => {
-  it('can successfully run a query', async () => {
-    const query = await ChargeVersion.query()
+  let testRecord
 
-    expect(query).to.exist()
+  beforeEach(async () => {
+    await DatabaseHelper.clean()
+
+    testRecord = await ChargeVersionHelper.add()
+  })
+
+  describe('Basic query', () => {
+    it('can successfully run a basic query', async () => {
+      const result = await ChargeVersionModel.query().findById(testRecord.chargeVersionId)
+
+      expect(result).to.be.an.instanceOf(ChargeVersionModel)
+      expect(result.chargeVersionId).to.equal(testRecord.chargeVersionId)
+    })
   })
 
   describe('Relationships', () => {
     describe('when linking to licence', () => {
-      it('can successfully run a query', async () => {
-        const query = await ChargeVersion.query()
+      let testLicence
+
+      beforeEach(async () => {
+        testLicence = await LicenceHelper.add()
+
+        const { licenceId } = testLicence
+        testRecord = await ChargeVersionHelper.add({}, { licenceId })
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await ChargeVersionModel.query()
           .innerJoinRelated('licence')
 
         expect(query).to.exist()
       })
+
+      it('can eager load the licence', async () => {
+        const result = await ChargeVersionModel.query()
+          .findById(testRecord.chargeVersionId)
+          .withGraphFetched('licence')
+
+        expect(result).to.be.instanceOf(ChargeVersionModel)
+        expect(result.chargeVersionId).to.equal(testRecord.chargeVersionId)
+
+        expect(result.licence).to.be.an.instanceOf(LicenceModel)
+        expect(result.licence).to.equal(testLicence)
+      })
     })
 
-    describe('when linking to charge element', () => {
-      it('can successfully run a query', async () => {
-        const query = await ChargeVersion.query()
+    describe('when linking to charge elements', () => {
+      let testChargeElements
+
+      beforeEach(async () => {
+        const { chargeVersionId } = testRecord
+
+        testChargeElements = []
+        for (let i = 0; i < 2; i++) {
+          const chargeElement = await ChargeElementHelper.add({ description: `CE ${i}`, chargeVersionId })
+          testChargeElements.push(chargeElement)
+        }
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await ChargeVersionModel.query()
           .innerJoinRelated('chargeElements')
 
         expect(query).to.exist()
+      })
+
+      it('can eager load the charge elements', async () => {
+        const result = await ChargeVersionModel.query()
+          .findById(testRecord.chargeVersionId)
+          .withGraphFetched('chargeElements')
+
+        expect(result).to.be.instanceOf(ChargeVersionModel)
+        expect(result.chargeVersionId).to.equal(testRecord.chargeVersionId)
+
+        expect(result.chargeElements).to.be.an.array()
+        expect(result.chargeElements[0]).to.be.an.instanceOf(ChargeElementModel)
+        expect(result.chargeElements).to.include(testChargeElements[0])
+        expect(result.chargeElements).to.include(testChargeElements[1])
       })
     })
   })

--- a/test/models/event.model.test.js
+++ b/test/models/event.model.test.js
@@ -4,16 +4,31 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it } = exports.lab = Lab.script()
+const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
+// Test helpers
+const DatabaseHelper = require('../support/helpers/database.helper.js')
+const EventHelper = require('../support/helpers/event.helper.js')
+
 // Thing under test
-const Event = require('../../app/models/event.model.js')
+const EventModel = require('../../app/models/event.model.js')
 
 describe('Event model', () => {
-  it('can successfully run a query', async () => {
-    const query = await Event.query()
+  let testRecord
 
-    expect(query).to.exist()
+  beforeEach(async () => {
+    await DatabaseHelper.clean()
+
+    testRecord = await EventHelper.add()
+  })
+
+  describe('Basic query', () => {
+    it('can successfully run a basic query', async () => {
+      const result = await EventModel.query().findById(testRecord.eventId)
+
+      expect(result).to.be.an.instanceOf(EventModel)
+      expect(result.eventId).to.equal(testRecord.eventId)
+    })
   })
 })

--- a/test/models/licence.model.test.js
+++ b/test/models/licence.model.test.js
@@ -4,35 +4,101 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it } = exports.lab = Lab.script()
+const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
+// Test helpers
+const ChargeVersionHelper = require('../support/helpers/charge-version.helper.js')
+const ChargeVersionModel = require('../../app/models/charge-version.model.js')
+const DatabaseHelper = require('../support/helpers/database.helper.js')
+const LicenceHelper = require('../support/helpers/licence.helper.js')
+const RegionHelper = require('../support/helpers/region.helper.js')
+const RegionModel = require('../../app/models/region.model.js')
+
 // Thing under test
-const Licence = require('../../app/models/licence.model.js')
+const LicenceModel = require('../../app/models/licence.model.js')
 
 describe('Licence model', () => {
-  it('can successfully run a query', async () => {
-    const query = await Licence.query()
+  let testRecord
 
-    expect(query).to.exist()
+  beforeEach(async () => {
+    await DatabaseHelper.clean()
+
+    testRecord = await LicenceHelper.add()
+  })
+
+  describe('Basic query', () => {
+    it('can successfully run a basic query', async () => {
+      const result = await LicenceModel.query().findById(testRecord.licenceId)
+
+      expect(result).to.be.an.instanceOf(LicenceModel)
+      expect(result.licenceId).to.equal(testRecord.licenceId)
+    })
   })
 
   describe('Relationships', () => {
-    describe('when linking to charge versions', () => {
-      it('can successfully run a query', async () => {
-        const query = await Licence.query()
+    describe('when linking to versions', () => {
+      let testChargeVersions
+
+      beforeEach(async () => {
+        const { licenceId, licenceRef } = testRecord
+
+        testChargeVersions = []
+        for (let i = 0; i < 2; i++) {
+          const chargeVersion = await ChargeVersionHelper.add({ licenceRef }, { licenceId })
+          testChargeVersions.push(chargeVersion)
+        }
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await LicenceModel.query()
           .innerJoinRelated('chargeVersions')
 
         expect(query).to.exist()
       })
+
+      it('can eager load the charge versions', async () => {
+        const result = await LicenceModel.query()
+          .findById(testRecord.licenceId)
+          .withGraphFetched('chargeVersions')
+
+        expect(result).to.be.instanceOf(LicenceModel)
+        expect(result.licenceId).to.equal(testRecord.licenceId)
+
+        expect(result.chargeVersions).to.be.an.array()
+        expect(result.chargeVersions[0]).to.be.an.instanceOf(ChargeVersionModel)
+        expect(result.chargeVersions).to.include(testChargeVersions[0])
+        expect(result.chargeVersions).to.include(testChargeVersions[1])
+      })
     })
 
     describe('when linking to region', () => {
-      it('can successfully run a query', async () => {
-        const query = await Licence.query()
+      let testRegion
+
+      beforeEach(async () => {
+        testRegion = await RegionHelper.add()
+
+        const { regionId } = testRegion
+        testRecord = await LicenceHelper.add({ regionId })
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await LicenceModel.query()
           .innerJoinRelated('region')
 
         expect(query).to.exist()
+      })
+
+      it('can eager load the region', async () => {
+        const result = await LicenceModel.query()
+          .findById(testRecord.licenceId)
+          .withGraphFetched('region')
+
+        expect(result).to.be.instanceOf(LicenceModel)
+        expect(result.licenceId).to.equal(testRecord.licenceId)
+
+        expect(result.region).to.be.an.instanceOf(RegionModel)
+        expect(result.region).to.equal(testRegion)
       })
     })
   })

--- a/test/models/licence.model.test.js
+++ b/test/models/licence.model.test.js
@@ -37,7 +37,7 @@ describe('Licence model', () => {
   })
 
   describe('Relationships', () => {
-    describe('when linking to versions', () => {
+    describe('when linking to charge versions', () => {
       let testChargeVersions
 
       beforeEach(async () => {

--- a/test/models/region.model.test.js
+++ b/test/models/region.model.test.js
@@ -4,26 +4,106 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it } = exports.lab = Lab.script()
+const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
+// Test helpers
+const BillingBatchHelper = require('../support/helpers/billing-batch.helper.js')
+const BillingBatchModel = require('../../app/models/billing-batch.model.js')
+const DatabaseHelper = require('../support/helpers/database.helper.js')
+const LicenceHelper = require('../support/helpers/licence.helper.js')
+const LicenceModel = require('../../app/models/licence.model.js')
+const RegionHelper = require('../support/helpers/region.helper.js')
+
 // Thing under test
-const Region = require('../../app/models/region.model.js')
+const RegionModel = require('../../app/models/region.model.js')
 
 describe('Region model', () => {
-  it('can successfully run a query', async () => {
-    const result = await Region.query()
+  let testRecord
 
-    expect(result).to.exist()
+  beforeEach(async () => {
+    await DatabaseHelper.clean()
+
+    testRecord = await RegionHelper.add()
+  })
+
+  describe('Basic query', () => {
+    it('can successfully run a basic query', async () => {
+      const result = await RegionModel.query().findById(testRecord.regionId)
+
+      expect(result).to.be.an.instanceOf(RegionModel)
+      expect(result.regionId).to.equal(testRecord.regionId)
+    })
   })
 
   describe('Relationships', () => {
+    describe('when linking to billing batches', () => {
+      let testBillingBatches
+
+      beforeEach(async () => {
+        const { regionId } = testRecord
+
+        testBillingBatches = []
+        for (let i = 0; i < 2; i++) {
+          const billingBatch = await BillingBatchHelper.add({ regionId })
+          testBillingBatches.push(billingBatch)
+        }
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await RegionModel.query()
+          .innerJoinRelated('billingBatches')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the billing batches', async () => {
+        const result = await RegionModel.query()
+          .findById(testRecord.regionId)
+          .withGraphFetched('billingBatches')
+
+        expect(result).to.be.instanceOf(RegionModel)
+        expect(result.regionId).to.equal(testRecord.regionId)
+
+        expect(result.billingBatches).to.be.an.array()
+        expect(result.billingBatches[0]).to.be.an.instanceOf(BillingBatchModel)
+        expect(result.billingBatches).to.include(testBillingBatches[0])
+        expect(result.billingBatches).to.include(testBillingBatches[1])
+      })
+    })
+
     describe('when linking to licences', () => {
-      it('can successfully run a query', async () => {
-        const result = await Region.query()
+      let testLicences
+
+      beforeEach(async () => {
+        const { regionId } = testRecord
+
+        testLicences = []
+        for (let i = 0; i < 2; i++) {
+          const licence = await LicenceHelper.add({ licenceRef: `0${i}/123`, regionId })
+          testLicences.push(licence)
+        }
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await RegionModel.query()
           .innerJoinRelated('licences')
 
-        expect(result).to.exist()
+        expect(query).to.exist()
+      })
+
+      it('can eager load the licences', async () => {
+        const result = await RegionModel.query()
+          .findById(testRecord.regionId)
+          .withGraphFetched('licences')
+
+        expect(result).to.be.instanceOf(RegionModel)
+        expect(result.regionId).to.equal(testRecord.regionId)
+
+        expect(result.licences).to.be.an.array()
+        expect(result.licences[0]).to.be.an.instanceOf(LicenceModel)
+        expect(result.licences).to.include(testLicences[0])
+        expect(result.licences).to.include(testLicences[1])
       })
     })
   })


### PR DESCRIPTION
In a [previous change](https://github.com/DEFRA/water-abstraction-system/pull/70) we had to fix our Objection implementation because we realised

- our way of handling multiple schemas (using `tableName`) was [invalid](https://github.com/Vincit/objection.js/issues/85#issuecomment-185183032)
- we were using the wrong case (snake vs camel) in most places. Under the hood Knex was fine, but once we leant into Objection relationships `withGraphFetched()` was bringing back nothing

What this highlighted was our existing model tests weren't really doing anything. Sure, a query can get generated but till you run them and confirm a result you can't be sure they are working as expected.

So, this change updates our model relationship tests to insert some data and confirm we get the expected results back.