### PR TITLE
Update test helpers to use Objection

### DIFF
--- a/app/services/supplementary-billing/create-billing-batch.service.js
+++ b/app/services/supplementary-billing/create-billing-batch.service.js
@@ -18,10 +18,10 @@ const BillingBatchModel = require('../../models/billing-batch.model.js')
 async function go (regionId, billingPeriod) {
   const billingBatch = await BillingBatchModel.query()
     .insert({
-      region_id: regionId,
-      batch_type: 'supplementary',
-      from_financial_year_ending: billingPeriod.endDate.getFullYear(),
-      to_financial_year_ending: billingPeriod.endDate.getFullYear(),
+      regionId,
+      batchType: 'supplementary',
+      fromFinancialYearEnding: billingPeriod.endDate.getFullYear(),
+      toFinancialYearEnding: billingPeriod.endDate.getFullYear(),
       status: 'processing',
       scheme: 'sroc'
     })

--- a/app/services/supplementary-billing/fetch-licences.service.js
+++ b/app/services/supplementary-billing/fetch-licences.service.js
@@ -25,10 +25,10 @@ async function go (region) {
 
 async function _fetch (region) {
   const result = await LicenceModel.query()
-    .distinctOn('licence_id')
+    .distinctOn('licenceId')
     .innerJoinRelated('chargeVersions')
-    .where('region_id', region.regionId)
-    .where('include_in_supplementary_billing', 'yes')
+    .where('regionId', region.regionId)
+    .where('includeInSupplementaryBilling', 'yes')
     .where('chargeVersions.scheme', 'sroc')
 
   return result

--- a/app/services/supplementary-billing/fetch-region.service.js
+++ b/app/services/supplementary-billing/fetch-region.service.js
@@ -26,7 +26,7 @@ async function go (naldRegionId) {
 
 async function _fetch (naldRegionId) {
   const result = await RegionModel.query()
-    .where('nald_region_id', naldRegionId)
+    .where('naldRegionId', naldRegionId)
     .first()
 
   return result

--- a/test/services/supplementary-billing/fetch-charge-versions.service.test.js
+++ b/test/services/supplementary-billing/fetch-charge-versions.service.test.js
@@ -16,7 +16,7 @@ const LicenceHelper = require('../../support/helpers/licence.helper.js')
 const FetchChargeVersionsService = require('../../../app/services/supplementary-billing/fetch-charge-versions.service.js')
 
 describe('Fetch Charge Versions service', () => {
-  const { region_id: regionId } = LicenceHelper.defaults()
+  const { regionId } = LicenceHelper.defaults()
   let testRecords
   let billingPeriod
 
@@ -34,13 +34,13 @@ describe('Fetch Charge Versions service', () => {
       // This creates an SROC charge version linked to a licence marked for supplementary billing
       const srocChargeVersion = await ChargeVersionHelper.add(
         {},
-        { include_in_supplementary_billing: 'yes' }
+        { includeInSupplementaryBilling: 'yes' }
       )
 
       // This creates an ALCS (presroc) charge version linked to a licence marked for supplementary billing
       const alcsChargeVersion = await ChargeVersionHelper.add(
         { scheme: 'alcs' },
-        { include_in_supplementary_billing: 'yes' }
+        { includeInSupplementaryBilling: 'yes' }
       )
 
       testRecords = [srocChargeVersion, alcsChargeVersion]
@@ -50,12 +50,12 @@ describe('Fetch Charge Versions service', () => {
       const result = await FetchChargeVersionsService.go(regionId, billingPeriod)
 
       expect(result.length).to.equal(1)
-      expect(result[0].charge_version_id).to.equal(testRecords[0].charge_version_id)
+      expect(result[0].chargeVersionId).to.equal(testRecords[0].chargeVersionId)
     })
   })
 
   describe('when there are no licences to be included in supplementary billing', () => {
-    describe("because none of them are marked 'include_in_supplementary_billing'", () => {
+    describe("because none of them are marked 'includeInSupplementaryBilling'", () => {
       beforeEach(async () => {
         billingPeriod = {
           startDate: new Date('2022-04-01'),
@@ -85,7 +85,7 @@ describe('Fetch Charge Versions service', () => {
         // This creates an ALCS (presroc) charge version linked to a licence marked for supplementary billing
         const alcsChargeVersion = await ChargeVersionHelper.add(
           { scheme: 'alcs' },
-          { include_in_supplementary_billing: 'yes' }
+          { includeInSupplementaryBilling: 'yes' }
         )
         testRecords = [alcsChargeVersion]
       })
@@ -108,8 +108,8 @@ describe('Fetch Charge Versions service', () => {
           // This creates an SROC charge version with a start date before the billing period. This would have been
           // picked up by a previous bill run
           const alcsChargeVersion = await ChargeVersionHelper.add(
-            { start_date: new Date(2022, 2, 31) }, // 2022-03-01 - Months are zero indexed :-)
-            { include_in_supplementary_billing: 'yes' }
+            { startDate: new Date(2022, 2, 31) }, // 2022-03-01 - Months are zero indexed :-)
+            { includeInSupplementaryBilling: 'yes' }
           )
           testRecords = [alcsChargeVersion]
         })
@@ -131,8 +131,8 @@ describe('Fetch Charge Versions service', () => {
           // This creates an SROC charge version with a start date after the billing period. This will be picked in
           // next years bill runs
           const alcsChargeVersion = await ChargeVersionHelper.add(
-            { start_date: new Date(2023, 3, 1) }, // 2023-04-01 - Months are zero indexed :-)
-            { include_in_supplementary_billing: 'yes' }
+            { startDate: new Date(2023, 3, 1) }, // 2023-04-01 - Months are zero indexed :-)
+            { includeInSupplementaryBilling: 'yes' }
           )
           testRecords = [alcsChargeVersion]
         })
@@ -156,8 +156,8 @@ describe('Fetch Charge Versions service', () => {
         const otherRegionChargeVersion = await ChargeVersionHelper.add(
           {},
           {
-            include_in_supplementary_billing: 'yes',
-            region_id: 'e117b501-e3c1-4337-ad35-21c60ed9ad73'
+            includeInSupplementaryBilling: 'yes',
+            regionId: 'e117b501-e3c1-4337-ad35-21c60ed9ad73'
           }
         )
         testRecords = [otherRegionChargeVersion]

--- a/test/services/supplementary-billing/fetch-licences.service.test.js
+++ b/test/services/supplementary-billing/fetch-licences.service.test.js
@@ -16,8 +16,8 @@ const LicenceHelper = require('../../support/helpers/licence.helper.js')
 const FetchLicencesService = require('../../../app/services/supplementary-billing/fetch-licences.service.js')
 
 describe('Fetch Licences service', () => {
-  const region = { regionId: LicenceHelper.defaults().region_id }
-  let testRecords
+  const region = { regionId: LicenceHelper.defaults().regionId }
+  let testLicence
 
   beforeEach(async () => {
     await DatabaseHelper.clean()
@@ -26,33 +26,33 @@ describe('Fetch Licences service', () => {
   describe('when there are licences for the matching region', () => {
     describe('that are flagged to be included in supplementary billing', () => {
       beforeEach(async () => {
-        testRecords = await LicenceHelper.add({ include_in_supplementary_billing: 'yes' })
+        testLicence = await LicenceHelper.add({ includeInSupplementaryBilling: 'yes' })
       })
 
       describe('and that have an SROC charge version', () => {
         beforeEach(async () => {
-          await ChargeVersionHelper.add({}, testRecords[0])
+          await ChargeVersionHelper.add({}, testLicence)
         })
 
         it('returns results', async () => {
           const result = await FetchLicencesService.go(region)
 
           expect(result.length).to.equal(1)
-          expect(result[0].licenceId).to.equal(testRecords[0].licenceId)
+          expect(result[0].licenceId).to.equal(testLicence.licenceId)
         })
       })
 
       describe('and that have multiple SROC charge versions', () => {
         beforeEach(async () => {
-          await ChargeVersionHelper.add({}, testRecords[0])
-          await ChargeVersionHelper.add({}, testRecords[0])
+          await ChargeVersionHelper.add({}, testLicence)
+          await ChargeVersionHelper.add({}, testLicence)
         })
 
         it('returns a licence only once in the results', async () => {
           const result = await FetchLicencesService.go(region)
 
           expect(result.length).to.equal(1)
-          expect(result[0].licenceId).to.equal(testRecords[0].licenceId)
+          expect(result[0].licenceId).to.equal(testLicence.licenceId)
         })
       })
 
@@ -67,7 +67,7 @@ describe('Fetch Licences service', () => {
 
     describe('that are not flagged to be included in supplementary billing', () => {
       beforeEach(async () => {
-        LicenceHelper.add()
+        await LicenceHelper.add()
       })
 
       it('returns no results', async () => {
@@ -80,7 +80,7 @@ describe('Fetch Licences service', () => {
 
   describe('when there are no licences for the matching region', () => {
     beforeEach(async () => {
-      LicenceHelper.add({ region_id: '000446bd-182a-4340-be6b-d719855ace1a' })
+      await LicenceHelper.add({ regionId: '000446bd-182a-4340-be6b-d719855ace1a' })
     })
 
     it('returns no results', async () => {

--- a/test/services/supplementary-billing/fetch-region.service.test.js
+++ b/test/services/supplementary-billing/fetch-region.service.test.js
@@ -16,7 +16,7 @@ const FetchRegionService = require('../../../app/services/supplementary-billing/
 
 describe('Fetch Region service', () => {
   const naldRegionId = 9
-  let testRecords
+  let testRegion
 
   beforeEach(async () => {
     await DatabaseHelper.clean()
@@ -24,19 +24,19 @@ describe('Fetch Region service', () => {
 
   describe('when there is a region with a matching NALD region id', () => {
     beforeEach(async () => {
-      testRecords = await RegionHelper.add()
+      testRegion = await RegionHelper.add()
     })
 
     it('returns results', async () => {
       const result = await FetchRegionService.go(naldRegionId)
 
-      expect(result.regionId).to.equal(testRecords[0].regionId)
+      expect(result.regionId).to.equal(testRegion.regionId)
     })
   })
 
   describe('when there is no region with a matching NALD region id', () => {
     beforeEach(async () => {
-      RegionHelper.add({ nald_region_id: 99 })
+      RegionHelper.add({ naldRegionId: 99 })
     })
 
     it('returns no results', async () => {

--- a/test/support/helpers/billing-batch.helper.js
+++ b/test/support/helpers/billing-batch.helper.js
@@ -4,32 +4,30 @@
  * @module BillingBatchHelper
  */
 
-const { db } = require('../../../db/db.js')
+const BillingBatchModel = require('../../../app/models/billing-batch.model.js')
 
 /**
  * Add a new billing batch
  *
  * If no `data` is provided, default values will be used. These are
  *
- * - `region_id` - bd114474-790f-4470-8ba4-7b0cc9c225d7
- * - `batch_type` - supplementary
- * - `from_financial_year_ending` - 2023
- * - `to_financial_year_ending` - 2023
+ * - `regionId` - bd114474-790f-4470-8ba4-7b0cc9c225d7
+ * - `batchType` - supplementary
+ * - `fromFinancialYearEnding` - 2023
+ * - `toFinancialYearEnding` - 2023
  * - `status` - processing
  * - `scheme` - sroc
  *
  * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
  *
- * @returns {string} The ID of the newly created record
+ * @returns {module:BillingBatchModel} The instance of the newly created record
  */
-async function add (data = {}) {
+function add (data = {}) {
   const insertData = defaults(data)
 
-  const result = await db.table('water.billing_batches')
-    .insert(insertData)
-    .returning('billing_batch_id')
-
-  return result
+  return BillingBatchModel.query()
+    .insert({ ...insertData })
+    .returning('*')
 }
 
 /**
@@ -42,10 +40,10 @@ async function add (data = {}) {
  */
 function defaults (data = {}) {
   const defaults = {
-    region_id: 'bd114474-790f-4470-8ba4-7b0cc9c225d7',
-    batch_type: 'supplementary',
-    from_financial_year_ending: 2023,
-    to_financial_year_ending: 2023,
+    regionId: 'bd114474-790f-4470-8ba4-7b0cc9c225d7',
+    batchType: 'supplementary',
+    fromFinancialYearEnding: 2023,
+    toFinancialYearEnding: 2023,
     status: 'processing',
     scheme: 'sroc'
   }

--- a/test/support/helpers/billing-batch.helper.js
+++ b/test/support/helpers/billing-batch.helper.js
@@ -55,5 +55,6 @@ function defaults (data = {}) {
 }
 
 module.exports = {
-  add
+  add,
+  defaults
 }

--- a/test/support/helpers/billing-charge-category.helper.js
+++ b/test/support/helpers/billing-charge-category.helper.js
@@ -4,7 +4,7 @@
  * @module BillingChargeCategoryHelper
  */
 
-const { db } = require('../../../db/db.js')
+const BillingChargeCategoryModel = require('../../../app/models/billing-charge-category.model.js')
 
 /**
  * Add a new billing charge category
@@ -12,28 +12,26 @@ const { db } = require('../../../db/db.js')
  * If no `data` is provided, default values will be used. These are
  *
  * - `reference` - 4.4.5
- * - `subsistence_charge` - 12000
+ * - `subsistenceCharge` - 12000
  * - `description` - Low loss non-tidal abstraction of restricted water up to and including 5,000 megalitres a year, where a Tier 1 model applies.
- * - `short_description` - Low loss, non-tidal, restricted water, up to and including 5,000 ML/yr, Tier 1 model
- * - `is_tidal` - false
- * - `loss_factor` - low
- * - `model_tier` - tier 1
- * - `is_restricted_source` - true
- * - `min_volume` - 0
- * - `max_volume` - 5000
+ * - `shortDescription` - Low loss, non-tidal, restricted water, up to and including 5,000 ML/yr, Tier 1 model
+ * - `isTidal` - false
+ * - `lossFactor` - low
+ * - `modelTier` - tier 1
+ * - `isRestrictedSource` - true
+ * - `minVolume` - 0
+ * - `maxVolume` - 5000
  *
  * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
  *
- * @returns {string} The ID of the newly created record
+ * @returns {module:BillingChargeCategoryModel} The instance of the newly created record
  */
-async function add (data = {}) {
+function add (data = {}) {
   const insertData = defaults(data)
 
-  const result = await db.table('water.billing_charge_categories')
-    .insert(insertData)
-    .returning('billing_charge_category_id')
-
-  return result
+  return BillingChargeCategoryModel.query()
+    .insertData({ ...insertData })
+    .returning('*')
 }
 
 /**
@@ -47,15 +45,15 @@ async function add (data = {}) {
 function defaults (data = {}) {
   const defaults = {
     reference: '4.4.5',
-    subsistence_charge: 12000,
+    subsistenceCharge: 12000,
     description: 'Low loss non-tidal abstraction of restricted water up to and including 5,000 megalitres a year, where a Tier 1 model applies.',
-    short_description: 'Low loss, non-tidal, restricted water, up to and including 5,000 ML/yr, Tier 1 model',
-    is_tidal: false,
-    loss_factor: 'low',
-    model_tier: 'tier 1',
-    is_restricted_source: true,
-    min_volume: 0,
-    max_volume: 5000
+    shortDescription: 'Low loss, non-tidal, restricted water, up to and including 5,000 ML/yr, Tier 1 model',
+    isTidal: false,
+    lossFactor: 'low',
+    modelTier: 'tier 1',
+    isRestrictedSource: true,
+    minVolume: 0,
+    maxVolume: 5000
   }
 
   return {

--- a/test/support/helpers/billing-charge-category.helper.js
+++ b/test/support/helpers/billing-charge-category.helper.js
@@ -63,5 +63,6 @@ function defaults (data = {}) {
 }
 
 module.exports = {
-  add
+  add,
+  defaults
 }

--- a/test/support/helpers/charge-element.helper.js
+++ b/test/support/helpers/charge-element.helper.js
@@ -69,5 +69,6 @@ function defaults (data = {}) {
 }
 
 module.exports = {
-  add
+  add,
+  defaults
 }

--- a/test/support/helpers/charge-element.helper.js
+++ b/test/support/helpers/charge-element.helper.js
@@ -4,39 +4,37 @@
  * @module ChargeElementHelper
  */
 
-const { db } = require('../../../db/db.js')
+const ChargeElementModel = require('../../../app/models/charge-element.model.js')
 
 /**
  * Add a new charge element
  *
  * If no `data` is provided, default values will be used. These are
  *
- * - `charge_version_id` - b033e8d1-3ad4-4782-930b-c1e10cb9110e
+ * - `chargeVersionId` - b033e8d1-3ad4-4782-930b-c1e10cb9110e
  * - `source` - non-tidal
  * - `loss` - low
  * - `description` - Mineral washing
- * - `is_section_127_agreement_enabled` - true
+ * - `isSection127AgreementEnabled` - true
  * - `scheme` - sroc
- * - `is_restricted_source` - true
- * - `water_model` - no model
+ * - `isRestrictedSource` - true
+ * - `waterModel` - no model
  * - `volume` - 6.819
- * - `billing_charge_category_id` - cd9ca44d-2ddb-4d5d-ac62-79883176bdec
- * - `additional_charges` - { isSupplyPublicWater: true }
+ * - `billingChargeCategoryId` - cd9ca44d-2ddb-4d5d-ac62-79883176bdec
+ * - `additionalCharges` - { isSupplyPublicWater: true }
  * - `adjustments` - { s126: null, s127: false, s130: false, charge: null, winter: false, aggregate: 0.562114443 }
- * - `eiuc_region` - Anglian
+ * - `eiucRegion` - Anglian
  *
  * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
  *
- * @returns {string} The ID of the newly created record
+ * @returns {module:ChargeElementModel} The instance of the newly created record
  */
-async function add (data = {}) {
+function add (data = {}) {
   const insertData = defaults(data)
 
-  const result = await db.table('water.charge_elements')
-    .insert(insertData)
-    .returning('charge_element_id')
-
-  return result
+  return ChargeElementModel.query()
+    .insert({ ...insertData })
+    .returning('*')
 }
 
 /**
@@ -49,19 +47,19 @@ async function add (data = {}) {
  */
 function defaults (data = {}) {
   const defaults = {
-    charge_version_id: 'b033e8d1-3ad4-4782-930b-c1e10cb9110e',
+    chargeVersionId: 'b033e8d1-3ad4-4782-930b-c1e10cb9110e',
     source: 'non-tidal',
     loss: 'low',
     description: 'Mineral washing',
-    is_section_127_agreement_enabled: true,
+    isSection127AgreementEnabled: true,
     scheme: 'sroc',
-    is_restricted_source: true,
-    water_model: 'no model',
+    isRestrictedSource: true,
+    waterModel: 'no model',
     volume: 6.819,
-    billing_charge_category_id: 'cd9ca44d-2ddb-4d5d-ac62-79883176bdec',
-    additional_charges: { isSupplyPublicWater: true },
+    billingChargeCategoryId: 'cd9ca44d-2ddb-4d5d-ac62-79883176bdec',
+    additionalCharges: { isSupplyPublicWater: true },
     adjustments: { s126: null, s127: false, s130: false, charge: null, winter: false, aggregate: 0.562114443 },
-    eiuc_region: 'Anglian'
+    eiucRegion: 'Anglian'
   }
 
   return {

--- a/test/support/helpers/charge-purpose.helper.js
+++ b/test/support/helpers/charge-purpose.helper.js
@@ -4,42 +4,40 @@
  * @module ChargePurposeHelper
  */
 
-const { db } = require('../../../db/db.js')
+const ChargePurposeModel = require('../../../app/models/charge-purpose.model.js')
 
 /**
  * Add a new charge purpose
  *
  * If no `data` is provided, default values will be used. These are
  *
- * - `charge_element_id` - 090f42a0-7718-453e-bc6a-d57ef8d65417
- * - `abstraction_period_start_day` - 1
- * - `abstraction_period_start_month` - 4
- * - `abstraction_period_end_day` - 31
- * - `abstraction_period_end_month` - 3
- * - `authorised_annual_quantity` - 200
+ * - `chargeElementId` - 090f42a0-7718-453e-bc6a-d57ef8d65417
+ * - `abstractionPeriodStartDay` - 1
+ * - `abstractionPeriodStartMonth` - 4
+ * - `abstractionPeriodEndDay` - 31
+ * - `abstractionPeriodEndMonth` - 3
+ * - `authorisedAnnualQuantity` - 200
  * - `loss` - low
- * - `factors_overridden` - true
- * - `billable_annual_quantity` - 4.55
- * - `time_limited_start_date` - 2022-04-01
- * - `time_limited_end_date` - 2030-03-30
+ * - `factorsOverridden` - true
+ * - `billableAnnualQuantity` - 4.55
+ * - `timeLimitedStartDate` - 2022-04-01
+ * - `timeLimitedEndDate` - 2030-03-30
  * - `description` - Trickle Irrigation - Direct
- * - `purpose_primary_id` - 383ab43e-6d0b-4be0-b5d2-4226f333f1d7
- * - `purpose_secondary_id` - 0e92d79a-f17f-4364-955f-443360ebddb2
- * - `purpose_use_id` - cc9f412c-22c6-483a-93b0-b955a3a644dc
- * - `is_section_127_agreement_enabled` - true
+ * - `purposePrimaryId` - 383ab43e-6d0b-4be0-b5d2-4226f333f1d7
+ * - `purposeSecondaryId` - 0e92d79a-f17f-4364-955f-443360ebddb2
+ * - `purposeUseId` - cc9f412c-22c6-483a-93b0-b955a3a644dc
+ * - `isSection127AgreementEnabled` - true
  *
  * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
  *
- * @returns {string} The ID of the newly created record
+ * @returns {module:ChargePurposeModel} The instance of the newly created record
  */
-async function add (data = {}) {
+function add (data = {}) {
   const insertData = defaults(data)
 
-  const result = await db.table('water.charge_purposes')
-    .insert(insertData)
-    .returning('charge_purpose_id')
-
-  return result
+  return ChargePurposeModel.query()
+    .insert({ ...insertData })
+    .returning('*')
 }
 
 /**
@@ -52,22 +50,22 @@ async function add (data = {}) {
  */
 function defaults (data = {}) {
   const defaults = {
-    charge_element_id: '090f42a0-7718-453e-bc6a-d57ef8d65417',
-    abstraction_period_start_day: 1,
-    abstraction_period_start_month: 4,
-    abstraction_period_end_day: 31,
-    abstraction_period_end_month: 3,
-    authorised_annual_quantity: 200,
+    chargeElementId: '090f42a0-7718-453e-bc6a-d57ef8d65417',
+    abstractionPeriodStartDay: 1,
+    abstractionPeriodStartMonth: 4,
+    abstractionPeriodEndDay: 31,
+    abstractionPeriodEndMonth: 3,
+    authorisedAnnualQuantity: 200,
     loss: 'low',
-    factors_overridden: true,
-    billable_annual_quantity: 4.55,
-    time_limited_start_date: '2022-04-01',
-    time_limited_end_date: '2030-03-30',
+    factorsOverridden: true,
+    billableAnnualQuantity: 4.55,
+    timeLimitedStartDate: '2022-04-01',
+    timeLimitedEndDate: '2030-03-30',
     description: 'Trickle Irrigation - Direct',
-    purpose_primary_id: '383ab43e-6d0b-4be0-b5d2-4226f333f1d7',
-    purpose_secondary_id: '0e92d79a-f17f-4364-955f-443360ebddb2',
-    purpose_use_id: 'cc9f412c-22c6-483a-93b0-b955a3a644dc',
-    is_section_127_agreement_enabled: true
+    purposePrimaryId: '383ab43e-6d0b-4be0-b5d2-4226f333f1d7',
+    purposeSecondaryId: '0e92d79a-f17f-4364-955f-443360ebddb2',
+    purposeUseId: 'cc9f412c-22c6-483a-93b0-b955a3a644dc',
+    isSection127AgreementEnabled: true
   }
 
   return {

--- a/test/support/helpers/charge-purpose.helper.js
+++ b/test/support/helpers/charge-purpose.helper.js
@@ -75,5 +75,6 @@ function defaults (data = {}) {
 }
 
 module.exports = {
-  add
+  add,
+  defaults
 }

--- a/test/support/helpers/event.helper.js
+++ b/test/support/helpers/event.helper.js
@@ -4,7 +4,7 @@
  * @module EventHelper
  */
 
-const { db } = require('../../../db/db.js')
+const EventModel = require('../../../app/models/event.model.js')
 
 /**
  * Add a new event
@@ -27,16 +27,14 @@ const { db } = require('../../../db/db.js')
  *
  * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
  *
- * @returns {string} The newly created event record
+ * @returns {module:EventModel} The instance of the newly created record
  */
-async function add (data = {}) {
+function add (data = {}) {
   const insertData = defaults(data)
 
-  const result = await db.table('water.events')
-    .insert(insertData)
+  return EventModel.query()
+    .insert({ ...insertData })
     .returning('*')
-
-  return result
 }
 
 /**

--- a/test/support/helpers/event.helper.js
+++ b/test/support/helpers/event.helper.js
@@ -70,5 +70,6 @@ function defaults (data = {}) {
 }
 
 module.exports = {
-  add
+  add,
+  defaults
 }

--- a/test/support/helpers/licence.helper.js
+++ b/test/support/helpers/licence.helper.js
@@ -4,28 +4,26 @@
  * @module LicenceHelper
  */
 
-const { db } = require('../../../db/db.js')
+const LicenceModel = require('../../../app/models/licence.model.js')
 
 /**
  * Add a new licence
  *
  * If no `data` is provided, default values will be used. These are
  *
- * - `licence_ref` - 01/123
- * - `region_id` - bd114474-790f-4470-8ba4-7b0cc9c225d7
+ * - `licenceRef` - 01/123
+ * - `regionId` - bd114474-790f-4470-8ba4-7b0cc9c225d7
  *
  * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
  *
- * @returns {string} The ID of the newly created record
+ * @returns {module:LicenceModel} The instance of the newly created record
  */
 async function add (data = {}) {
   const insertData = defaults(data)
 
-  const result = await db.table('water.licences')
-    .insert(insertData)
-    .returning('licence_id')
-
-  return result
+  return LicenceModel.query()
+    .insert({ ...insertData })
+    .returning('*')
 }
 
 /**
@@ -38,8 +36,8 @@ async function add (data = {}) {
  */
 function defaults (data = {}) {
   const defaults = {
-    licence_ref: '01/123',
-    region_id: 'bd114474-790f-4470-8ba4-7b0cc9c225d7'
+    licenceRef: '01/123',
+    regionId: 'bd114474-790f-4470-8ba4-7b0cc9c225d7'
   }
 
   return {

--- a/test/support/helpers/region.helper.js
+++ b/test/support/helpers/region.helper.js
@@ -4,28 +4,26 @@
  * @module RegionHelper
  */
 
-const { db } = require('../../../db/db.js')
+const RegionModel = require('../../../app/models/region.model.js')
 
 /**
  * Add a new region
  *
  * If no `data` is provided, default values will be used. These are
  *
- * - `charge_region_id` - S
- * - `nald_region_id` - 9
+ * - `chargeRegionId` - S
+ * - `naldRegionId` - 9
  *
  * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
  *
- * @returns {string} The ID of the newly created record
+ * @returns {module:RegionModel} The instance of the newly created record
  */
-async function add (data = {}) {
+function add (data = {}) {
   const insertData = defaults(data)
 
-  const result = await db.table('water.regions')
-    .insert(insertData)
-    .returning('region_id')
-
-  return result
+  return RegionModel.query()
+    .insert({ ...insertData })
+    .returning('*')
 }
 
 /**
@@ -38,8 +36,8 @@ async function add (data = {}) {
  */
 function defaults (data = {}) {
   const defaults = {
-    charge_region_id: 'S',
-    nald_region_id: 9
+    chargeRegionId: 'S',
+    naldRegionId: 9
   }
 
   return {


### PR DESCRIPTION
> This is in support of [Improve model tests](https://github.com/DEFRA/water-abstraction-system/pull/71)

Currently, our test helpers create records using Knex directly. This is a result of the initial helpers being added before we implemented [Objection.js](https://vincit.github.io/objection.js/).

We want to expand some of our tests plus there is an argument to be consistent in how we interact with the tables in our DB. So, this change updates the helpers to do things via Objection and fixes any tests we break as a result.