### PR TITLE
Refactor CreateBillingBatchService

### DIFF
--- a/app/services/supplementary-billing/create-billing-batch.service.js
+++ b/app/services/supplementary-billing/create-billing-batch.service.js
@@ -10,22 +10,27 @@ const BillingBatchModel = require('../../models/billing-batch.model.js')
 /**
  * Create a new billing batch
  *
- * @param {Object} [regionId] The region_id for the selected region
- * @param {Object} [billingPeriod] The billing period in the format { startDate: 2022-04-01, endDate: 2023-03-31 }
+ * @param {Object} regionId The regionId for the selected region
+ * @param {Object} billingPeriod The billing period in the format { startDate: 2022-04-01, endDate: 2023-03-31 }
+ * @param {string} [batchType=supplementary] The type of billing batch to create. Defaults to 'supplementary'
+ * @param {string} [scheme=sroc] The applicable charging scheme. Defaults to 'sroc'
+ * @param {string} [source=wrls] Where the billing batch originated from. Records imported from NALD have the source 'nald'. Those created in the service use 'wrls'. Defaults to 'wrls'
  *
- * @returns {Object} The newly created billing batch record
+ * @returns {module:BillingBatchModel} The newly created billing batch instance with the `.region` property populated
  */
-async function go (regionId, billingPeriod) {
+async function go (regionId, billingPeriod, batchType = 'supplementary', scheme = 'sroc', source = 'wrls') {
   const billingBatch = await BillingBatchModel.query()
     .insert({
       regionId,
-      batchType: 'supplementary',
+      batchType,
       fromFinancialYearEnding: billingPeriod.endDate.getFullYear(),
       toFinancialYearEnding: billingPeriod.endDate.getFullYear(),
       status: 'processing',
-      scheme: 'sroc'
+      scheme,
+      source
     })
     .returning('*')
+    .withGraphFetched('region')
 
   return billingBatch
 }

--- a/test/services/supplementary-billing/create-billing-batch.service.test.js
+++ b/test/services/supplementary-billing/create-billing-batch.service.test.js
@@ -16,7 +16,7 @@ const RegionModel = require('../../../app/models/region.model.js')
 // Thing under test
 const CreateBillingBatchService = require('../../../app/services/supplementary-billing/create-billing-batch.service.js')
 
-describe.only('Create Billing Batch service', () => {
+describe('Create Billing Batch service', () => {
   const billingPeriod = { startDate: new Date('2022-04-01'), endDate: new Date('2023-03-31') }
   let region
 

--- a/test/services/supplementary-billing/create-billing-batch.service.test.js
+++ b/test/services/supplementary-billing/create-billing-batch.service.test.js
@@ -8,24 +8,61 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
+const BillingBatchModel = require('../../../app/models/billing-batch.model.js')
 const DatabaseHelper = require('../../support/helpers/database.helper.js')
+const RegionHelper = require('../../support/helpers/region.helper.js')
+const RegionModel = require('../../../app/models/region.model.js')
 
 // Thing under test
 const CreateBillingBatchService = require('../../../app/services/supplementary-billing/create-billing-batch.service.js')
 
-describe('Create Billing Batch service', () => {
-  const regionId = '6ac6cd43-af79-492a-9b82-15a70411c906'
+describe.only('Create Billing Batch service', () => {
   const billingPeriod = { startDate: new Date('2022-04-01'), endDate: new Date('2023-03-31') }
+  let region
 
   beforeEach(async () => {
     await DatabaseHelper.clean()
+
+    region = await RegionHelper.add()
   })
 
-  it('creates a billing batch record', async () => {
-    const result = await CreateBillingBatchService.go(regionId, billingPeriod)
+  describe('when the defaults are not overridden', () => {
+    it('returns the new billing batch instance containing the defaults', async () => {
+      const result = await CreateBillingBatchService.go(region.regionId, billingPeriod)
 
-    expect(result.regionId).to.equal(regionId)
-    expect(result.fromFinancialYearEnding).to.equal(2023)
-    expect(result.toFinancialYearEnding).to.equal(2023)
+      expect(result).to.be.an.instanceOf(BillingBatchModel)
+
+      expect(result.status).to.equal('processing')
+      expect(result.fromFinancialYearEnding).to.equal(2023)
+      expect(result.toFinancialYearEnding).to.equal(2023)
+      expect(result.batchType).to.equal('supplementary')
+      expect(result.scheme).to.equal('sroc')
+      expect(result.source).to.equal('wrls')
+
+      expect(result.region).to.be.an.instanceOf(RegionModel)
+      expect(result.region.regionId).to.equal(region.regionId)
+    })
+  })
+
+  describe('when the defaults are overridden', () => {
+    const batchType = 'annual'
+    const scheme = 'wrls'
+    const source = 'nald'
+
+    it('returns the new billing batch instance containing the provided values', async () => {
+      const result = await CreateBillingBatchService.go(region.regionId, billingPeriod, batchType, scheme, source)
+
+      expect(result).to.be.an.instanceOf(BillingBatchModel)
+
+      expect(result.status).to.equal('processing')
+      expect(result.fromFinancialYearEnding).to.equal(2023)
+      expect(result.toFinancialYearEnding).to.equal(2023)
+      expect(result.batchType).to.equal(batchType)
+      expect(result.scheme).to.equal(scheme)
+      expect(result.source).to.equal(source)
+
+      expect(result.region).to.be.an.instanceOf(RegionModel)
+      expect(result.region.regionId).to.equal(region.regionId)
+    })
   })
 })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3854

To support our work on adding an endpoint that will allow us to create a new SROC bill run we need to refactor the existing `CreateBillingBatchService` a little bit!

Some of the stuff it's currently defaulting we're now going to pass in. We also need it to bring back the instance with `.region` populated. This is to support creating the 'new' billing batch event record.