### PR TITLE
Add user to CreateBillRunValidator

### DIFF
--- a/app/validators/bill-runs/create-bill-run.validator.js
+++ b/app/validators/bill-runs/create-bill-run.validator.js
@@ -14,8 +14,8 @@ function go (data) {
     type: Joi.string().valid('supplementary').required(),
     scheme: Joi.string().valid('sroc').required(),
     region: Joi.string().guid().required(),
-    previousBillRunId: Joi.string().guid().optional(),
-    user: Joi.string().email().required()
+    user: Joi.string().email().required(),
+    previousBillRunId: Joi.string().guid().optional()
   })
 
   return schema.validate(data)

--- a/app/validators/bill-runs/create-bill-run.validator.js
+++ b/app/validators/bill-runs/create-bill-run.validator.js
@@ -14,7 +14,8 @@ function go (data) {
     type: Joi.string().valid('supplementary').required(),
     scheme: Joi.string().valid('sroc').required(),
     region: Joi.string().guid().required(),
-    previousBillRunId: Joi.string().guid().optional()
+    previousBillRunId: Joi.string().guid().optional(),
+    user: Joi.string().email().required()
   })
 
   return schema.validate(data)

--- a/test/controllers/bill-runs.controller.test.js
+++ b/test/controllers/bill-runs.controller.test.js
@@ -27,7 +27,8 @@ describe('Bill Runs controller:', () => {
           payload: {
             type: 'supplementary',
             scheme: 'sroc',
-            region: '07ae7f3a-2677-4102-b352-cc006828948c'
+            region: '07ae7f3a-2677-4102-b352-cc006828948c',
+            user: 'test.user@defra.gov.uk'
           }
         }
 
@@ -47,7 +48,8 @@ describe('Bill Runs controller:', () => {
           payload: {
             type: 'supplementary',
             scheme: 'INVALID',
-            region: '07ae7f3a-2677-4102-b352-cc006828948c'
+            region: '07ae7f3a-2677-4102-b352-cc006828948c',
+            user: 'test.user@defra.gov.uk'
           }
         }
 

--- a/test/validators/bill-runs/create-bill-run.validator.js
+++ b/test/validators/bill-runs/create-bill-run.validator.js
@@ -17,7 +17,8 @@ describe('Create Bill Run validator', () => {
         type: 'supplementary',
         scheme: 'sroc',
         region: '07ae7f3a-2677-4102-b352-cc006828948c',
-        previousBillRunId: '28a5fc2e-bdc9-4b48-96e7-5ee7b2f5d603'
+        previousBillRunId: '28a5fc2e-bdc9-4b48-96e7-5ee7b2f5d603',
+        user: 'test.user@defra.gov.uk'
       }
 
       const result = await CreateBillRunValidator.go(validData)
@@ -26,7 +27,8 @@ describe('Create Bill Run validator', () => {
         type: 'supplementary',
         scheme: 'sroc',
         region: '07ae7f3a-2677-4102-b352-cc006828948c',
-        previousBillRunId: '28a5fc2e-bdc9-4b48-96e7-5ee7b2f5d603'
+        previousBillRunId: '28a5fc2e-bdc9-4b48-96e7-5ee7b2f5d603',
+        user: 'test.user@defra.gov.uk'
       })
     })
 
@@ -35,7 +37,8 @@ describe('Create Bill Run validator', () => {
         const validData = {
           type: 'supplementary',
           scheme: 'sroc',
-          region: '07ae7f3a-2677-4102-b352-cc006828948c'
+          region: '07ae7f3a-2677-4102-b352-cc006828948c',
+          user: 'test.user@defra.gov.uk'
         }
 
         const result = await CreateBillRunValidator.go(validData)
@@ -43,7 +46,8 @@ describe('Create Bill Run validator', () => {
         expect(result.value).to.equal({
           type: 'supplementary',
           scheme: 'sroc',
-          region: '07ae7f3a-2677-4102-b352-cc006828948c'
+          region: '07ae7f3a-2677-4102-b352-cc006828948c',
+          user: 'test.user@defra.gov.uk'
         })
       })
     })
@@ -54,7 +58,8 @@ describe('Create Bill Run validator', () => {
       it('returns an error', async () => {
         const invalidData = {
           scheme: 'sroc',
-          region: '07ae7f3a-2677-4102-b352-cc006828948c'
+          region: '07ae7f3a-2677-4102-b352-cc006828948c',
+          user: 'test.user@defra.gov.uk'
         }
 
         const result = await CreateBillRunValidator.go(invalidData)
@@ -67,7 +72,8 @@ describe('Create Bill Run validator', () => {
       it('returns an error', async () => {
         const invalidData = {
           type: 'supplementary',
-          region: '07ae7f3a-2677-4102-b352-cc006828948c'
+          region: '07ae7f3a-2677-4102-b352-cc006828948c',
+          user: 'test.user@defra.gov.uk'
         }
 
         const result = await CreateBillRunValidator.go(invalidData)
@@ -80,7 +86,22 @@ describe('Create Bill Run validator', () => {
       it('returns an error', async () => {
         const invalidData = {
           type: 'supplementary',
-          scheme: 'sroc'
+          scheme: 'sroc',
+          user: 'test.user@defra.gov.uk'
+        }
+
+        const result = await CreateBillRunValidator.go(invalidData)
+
+        expect(result.error).to.not.be.empty()
+      })
+    })
+
+    describe('because `user` is missing', () => {
+      it('returns an error', async () => {
+        const invalidData = {
+          type: 'supplementary',
+          scheme: 'sroc',
+          region: '07ae7f3a-2677-4102-b352-cc006828948c'
         }
 
         const result = await CreateBillRunValidator.go(invalidData)
@@ -93,7 +114,9 @@ describe('Create Bill Run validator', () => {
       it('returns an error', async () => {
         const invalidData = {
           type: 'INVALID',
-          scheme: 'sroc'
+          scheme: 'sroc',
+          region: '07ae7f3a-2677-4102-b352-cc006828948c',
+          user: 'test.user@defra.gov.uk'
         }
 
         const result = await CreateBillRunValidator.go(invalidData)
@@ -106,7 +129,9 @@ describe('Create Bill Run validator', () => {
       it('returns an error', async () => {
         const invalidData = {
           type: 'supplementary',
-          scheme: 'INVALID'
+          scheme: 'INVALID',
+          region: '07ae7f3a-2677-4102-b352-cc006828948c',
+          user: 'test.user@defra.gov.uk'
         }
 
         const result = await CreateBillRunValidator.go(invalidData)
@@ -120,7 +145,23 @@ describe('Create Bill Run validator', () => {
         const invalidData = {
           type: 'supplementary',
           scheme: 'sroc',
-          region: 'INVALID'
+          region: 'INVALID',
+          user: 'test.user@defra.gov.uk'
+        }
+
+        const result = await CreateBillRunValidator.go(invalidData)
+
+        expect(result.error).to.not.be.empty()
+      })
+    })
+
+    describe('because `user` has an invalid value', () => {
+      it('returns an error', async () => {
+        const invalidData = {
+          type: 'supplementary',
+          scheme: 'sroc',
+          region: '07ae7f3a-2677-4102-b352-cc006828948c',
+          user: 'INVALID'
         }
 
         const result = await CreateBillRunValidator.go(invalidData)

--- a/test/validators/bill-runs/create-bill-run.validator.js
+++ b/test/validators/bill-runs/create-bill-run.validator.js
@@ -17,8 +17,8 @@ describe('Create Bill Run validator', () => {
         type: 'supplementary',
         scheme: 'sroc',
         region: '07ae7f3a-2677-4102-b352-cc006828948c',
-        previousBillRunId: '28a5fc2e-bdc9-4b48-96e7-5ee7b2f5d603',
-        user: 'test.user@defra.gov.uk'
+        user: 'test.user@defra.gov.uk',
+        previousBillRunId: '28a5fc2e-bdc9-4b48-96e7-5ee7b2f5d603'
       }
 
       const result = await CreateBillRunValidator.go(validData)
@@ -27,8 +27,8 @@ describe('Create Bill Run validator', () => {
         type: 'supplementary',
         scheme: 'sroc',
         region: '07ae7f3a-2677-4102-b352-cc006828948c',
-        previousBillRunId: '28a5fc2e-bdc9-4b48-96e7-5ee7b2f5d603',
-        user: 'test.user@defra.gov.uk'
+        user: 'test.user@defra.gov.uk',
+        previousBillRunId: '28a5fc2e-bdc9-4b48-96e7-5ee7b2f5d603'
       })
     })
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3854

As part of initialising a new bill run, we create an 'event' record. It requires the `issuer` field to be populated with the email address of the user requesting the new bill run.

So, we'll need to include the current user's email as part of our request. This change updates the validator to include it.