### PR TITLE
Restructure models by type and scheme

### DIFF
--- a/app/models/base.model.js
+++ b/app/models/base.model.js
@@ -5,7 +5,7 @@
  * @module BaseModel
  */
 
-const { Model, QueryBuilder } = require('objection')
+const { Model } = require('objection')
 
 const { db } = require('../../db/db.js')
 
@@ -16,42 +16,26 @@ Model.knex(db)
 
 class BaseModel extends Model {
   /**
-   * An objective property we override to tell it where to search for models for relationships
+   * Array of paths to search for models used in relationships
    *
-   * When setting a relationship in a model we have to provide a reference to the related model. As we need to set the
-   * relationship on both sides this leads to
+   * This is an objective property we override. When setting a relationship in a model we have to provide a reference
+   * to the related model. As we need to set the relationship on both sides this leads to
    * {@link https://vincit.github.io/objection.js/guide/relations.html#require-loops|require-loops}. We can avoid this
    * by having the model tell Objection where to search for models for relationships. In the relationship declaration we
    * can then just use a string value
    *
    * ```
-   *  // ...
-   *  relation: Model.ManyToManyRelation,
-        modelClass: 'charge_version.model',
-      // ...
-      ```
-
-      We don't want to do this in every model so set it in the `BaseModel` as Objection recommends.
+   * // ...
+   * relation: Model.ManyToManyRelation,
+   * modelClass: 'charge_version.model',
+   * // ...
+   * ```
+   *
+   * We don't want to do this in every model so set it in the `BaseModel` as Objection recommends.
    */
   static get modelPaths () {
     return [__dirname]
   }
-
-  static get defaultSchema () {
-    return 'water'
-  }
 }
-
-class DefaultSchemaQueryBuilder extends QueryBuilder {
-  constructor (modelClass) {
-    super(modelClass)
-    if (modelClass.defaultSchema) {
-      this.withSchema(modelClass.defaultSchema)
-    }
-  }
-}
-
-Model.QueryBuilder = DefaultSchemaQueryBuilder
-Model.RelatedQueryBuilder = DefaultSchemaQueryBuilder
 
 module.exports = BaseModel

--- a/app/models/legacy-base.model.js
+++ b/app/models/legacy-base.model.js
@@ -1,0 +1,77 @@
+'use strict'
+
+/**
+ * Base class for all models based on tables in the legacy schemas
+ * @module LegacyBaseModel
+ */
+
+const { QueryBuilder } = require('objection')
+const path = require('path')
+
+const BaseModel = require('./base.model.js')
+
+class LegacyBaseModel extends BaseModel {
+  /**
+   * Array of paths to search for models used in relationships
+   *
+   * > See `modelPaths()` in `BaseModel` for more details on this getter
+   *
+   * We override the one provided in `BaseModel` to include our legacy folders.
+   *
+   * @returns {Array} array of paths to search for related models
+   */
+  static get modelPaths () {
+    const currentPath = __dirname
+    return [
+      currentPath,
+      path.join(currentPath, 'water')
+    ]
+  }
+
+  /**
+   * Returns a custom `QueryBuilder` which supports declaring the schema to use when connecting to the DB
+   *
+   * See `schema()` for further details.
+   *
+   * @returns {Object} a custom Objection `QueryBuilder`
+   */
+  static get QueryBuilder () {
+    return SchemaQueryBuilder
+  }
+
+  /**
+   * Name of the database schema a model belongs to
+   *
+   * All the legacy repos talk to the same PostgreSQL DB server but split their data using
+   * {@link https://www.postgresql.org/docs/current/ddl-schemas.html schemas}. Objection.js however assumes you are
+   * using the **public** schema which is the default in PostgreSQL if you don't specify one.
+   *
+   * So, when Objection is working with our legacy models it needs to know what schemas they belong to. There is no
+   * out-of-the-box support for specifying this. But the maintainer behind Objection.js suggested this solution in
+   * {@link https://github.com/Vincit/objection.js/issues/85#issuecomment-185183032 an issue} (which we've tweaked
+   * slightly).
+   *
+   * You extend Objection's QueryBuilder (see `SchemaQueryBuilder`) and call Knex's `withSchema()` within it (Knex
+   * _does_ understand schemas). It expects the Model generating the query to have a custom getter `schema` which
+   * returns the schema name. You then override the getter `QueryBuilder` in your model and return your
+   * {@link https://vincit.github.io/objection.js/recipes/custom-query-builder.html custom QueryBuilder}. This is then
+   * used to build any queries, for example, `MyModel.query.find()` ensuring the schema name is declared and our data
+   * layer knows where to find the data.
+   *
+   * > In this base model model we throw an exception to ensure any child classes override this getter.
+   *
+   * @returns {string} the schema name, for example, 'water'
+   */
+  static get schema () {
+    throw new Error('defaultSchema() not implemented in child class')
+  }
+}
+
+class SchemaQueryBuilder extends QueryBuilder {
+  constructor (modelClass) {
+    super(modelClass)
+    this.withSchema(modelClass.schema)
+  }
+}
+
+module.exports = LegacyBaseModel

--- a/app/models/water/billing-batch.model.js
+++ b/app/models/water/billing-batch.model.js
@@ -7,7 +7,7 @@
 
 const { Model } = require('objection')
 
-const BaseModel = require('./base.model.js')
+const BaseModel = require('../base.model.js')
 
 class BillingBatchModel extends BaseModel {
   static get tableName () {

--- a/app/models/water/billing-batch.model.js
+++ b/app/models/water/billing-batch.model.js
@@ -7,9 +7,9 @@
 
 const { Model } = require('objection')
 
-const BaseModel = require('../base.model.js')
+const WaterBaseModel = require('./water-base.model.js')
 
-class BillingBatchModel extends BaseModel {
+class BillingBatchModel extends WaterBaseModel {
   static get tableName () {
     return 'billingBatches'
   }

--- a/app/models/water/billing-charge-category.model.js
+++ b/app/models/water/billing-charge-category.model.js
@@ -7,9 +7,9 @@
 
 const { Model } = require('objection')
 
-const BaseModel = require('../base.model.js')
+const WaterBaseModel = require('./water-base.model.js')
 
-class BillingChargeCategoryModel extends BaseModel {
+class BillingChargeCategoryModel extends WaterBaseModel {
   static get tableName () {
     return 'billingChargeCategories'
   }

--- a/app/models/water/billing-charge-category.model.js
+++ b/app/models/water/billing-charge-category.model.js
@@ -7,7 +7,7 @@
 
 const { Model } = require('objection')
 
-const BaseModel = require('./base.model.js')
+const BaseModel = require('../base.model.js')
 
 class BillingChargeCategoryModel extends BaseModel {
   static get tableName () {

--- a/app/models/water/charge-element.model.js
+++ b/app/models/water/charge-element.model.js
@@ -7,7 +7,7 @@
 
 const { Model } = require('objection')
 
-const BaseModel = require('./base.model.js')
+const BaseModel = require('../base.model.js')
 
 class ChargeElementModel extends BaseModel {
   static get tableName () {

--- a/app/models/water/charge-element.model.js
+++ b/app/models/water/charge-element.model.js
@@ -7,9 +7,9 @@
 
 const { Model } = require('objection')
 
-const BaseModel = require('../base.model.js')
+const WaterBaseModel = require('./water-base.model.js')
 
-class ChargeElementModel extends BaseModel {
+class ChargeElementModel extends WaterBaseModel {
   static get tableName () {
     return 'chargeElements'
   }

--- a/app/models/water/charge-purpose.model.js
+++ b/app/models/water/charge-purpose.model.js
@@ -7,9 +7,9 @@
 
 const { Model } = require('objection')
 
-const BaseModel = require('../base.model.js')
+const WaterBaseModel = require('./water-base.model.js')
 
-class ChargePurposeModel extends BaseModel {
+class ChargePurposeModel extends WaterBaseModel {
   static get tableName () {
     return 'chargePurposes'
   }

--- a/app/models/water/charge-purpose.model.js
+++ b/app/models/water/charge-purpose.model.js
@@ -7,7 +7,7 @@
 
 const { Model } = require('objection')
 
-const BaseModel = require('./base.model.js')
+const BaseModel = require('../base.model.js')
 
 class ChargePurposeModel extends BaseModel {
   static get tableName () {

--- a/app/models/water/charge-version.model.js
+++ b/app/models/water/charge-version.model.js
@@ -7,9 +7,9 @@
 
 const { Model } = require('objection')
 
-const BaseModel = require('../base.model.js')
+const WaterBaseModel = require('./water-base.model.js')
 
-class ChargeVersionModel extends BaseModel {
+class ChargeVersionModel extends WaterBaseModel {
   static get tableName () {
     return 'chargeVersions'
   }

--- a/app/models/water/charge-version.model.js
+++ b/app/models/water/charge-version.model.js
@@ -7,7 +7,7 @@
 
 const { Model } = require('objection')
 
-const BaseModel = require('./base.model.js')
+const BaseModel = require('../base.model.js')
 
 class ChargeVersionModel extends BaseModel {
   static get tableName () {

--- a/app/models/water/event.model.js
+++ b/app/models/water/event.model.js
@@ -5,9 +5,9 @@
  * @module EventModel
  */
 
-const BaseModel = require('../base.model.js')
+const WaterBaseModel = require('./water-base.model.js')
 
-class EventModel extends BaseModel {
+class EventModel extends WaterBaseModel {
   static get tableName () {
     return 'events'
   }

--- a/app/models/water/event.model.js
+++ b/app/models/water/event.model.js
@@ -5,7 +5,7 @@
  * @module EventModel
  */
 
-const BaseModel = require('./base.model.js')
+const BaseModel = require('../base.model.js')
 
 class EventModel extends BaseModel {
   static get tableName () {

--- a/app/models/water/licence.model.js
+++ b/app/models/water/licence.model.js
@@ -7,7 +7,7 @@
 
 const { Model } = require('objection')
 
-const BaseModel = require('./base.model.js')
+const BaseModel = require('../base.model.js')
 
 class LicenceModel extends BaseModel {
   static get tableName () {

--- a/app/models/water/licence.model.js
+++ b/app/models/water/licence.model.js
@@ -7,9 +7,9 @@
 
 const { Model } = require('objection')
 
-const BaseModel = require('../base.model.js')
+const WaterBaseModel = require('./water-base.model.js')
 
-class LicenceModel extends BaseModel {
+class LicenceModel extends WaterBaseModel {
   static get tableName () {
     return 'licences'
   }

--- a/app/models/water/region.model.js
+++ b/app/models/water/region.model.js
@@ -7,9 +7,9 @@
 
 const { Model } = require('objection')
 
-const BaseModel = require('../base.model.js')
+const WaterBaseModel = require('./water-base.model.js')
 
-class RegionModel extends BaseModel {
+class RegionModel extends WaterBaseModel {
   static get tableName () {
     return 'regions'
   }

--- a/app/models/water/region.model.js
+++ b/app/models/water/region.model.js
@@ -7,7 +7,7 @@
 
 const { Model } = require('objection')
 
-const BaseModel = require('./base.model.js')
+const BaseModel = require('../base.model.js')
 
 class RegionModel extends BaseModel {
   static get tableName () {

--- a/app/models/water/water-base.model.js
+++ b/app/models/water/water-base.model.js
@@ -1,0 +1,16 @@
+'use strict'
+
+/**
+ * Base class for all models based on the legacy 'water' schema
+ * @module WaterBaseModel
+ */
+
+const LegacyBaseModel = require('../legacy-base.model.js')
+
+class WaterBaseModel extends LegacyBaseModel {
+  static get schema () {
+    return 'water'
+  }
+}
+
+module.exports = WaterBaseModel

--- a/app/services/charge-module-token.service.js
+++ b/app/services/charge-module-token.service.js
@@ -10,7 +10,6 @@ const RequestLib = require('../lib/request.lib.js')
 const servicesConfig = require('../../config/services.config.js')
 
 async function go () {
-  console.log(`--> ${servicesConfig.chargingModule.token.url}`)
   const url = new URL('/oauth2/token', servicesConfig.chargingModule.token.url)
 
   const result = await RequestLib.post(url.href, _options())

--- a/app/services/charge-module-token.service.js
+++ b/app/services/charge-module-token.service.js
@@ -10,6 +10,7 @@ const RequestLib = require('../lib/request.lib.js')
 const servicesConfig = require('../../config/services.config.js')
 
 async function go () {
+  console.log(`--> ${servicesConfig.chargingModule.token.url}`)
   const url = new URL('/oauth2/token', servicesConfig.chargingModule.token.url)
 
   const result = await RequestLib.post(url.href, _options())

--- a/app/services/supplementary-billing/create-billing-batch-event.service.js
+++ b/app/services/supplementary-billing/create-billing-batch-event.service.js
@@ -6,7 +6,7 @@
  */
 
 const CreateBillingBatchEventPresenter = require('../../presenters/supplementary-billing/create-billing-batch-event.presenter.js')
-const EventModel = require('../../models/event.model.js')
+const EventModel = require('../../models/water/event.model.js')
 
 /**
  * Create an event for when a new bill run is initialised

--- a/app/services/supplementary-billing/create-billing-batch.service.js
+++ b/app/services/supplementary-billing/create-billing-batch.service.js
@@ -5,7 +5,7 @@
  * @module CreateBillingBatchService
  */
 
-const BillingBatchModel = require('../../models/billing-batch.model.js')
+const BillingBatchModel = require('../../models/water/billing-batch.model.js')
 
 /**
  * Create a new billing batch

--- a/app/services/supplementary-billing/fetch-charge-versions.service.js
+++ b/app/services/supplementary-billing/fetch-charge-versions.service.js
@@ -5,7 +5,7 @@
  * @module FetchChargeVersionsService
  */
 
-const ChargeVersion = require('../../models/charge-version.model.js')
+const ChargeVersion = require('../../models/water/charge-version.model.js')
 
 /**
  * Fetch all SROC charge versions linked to licences flagged for supplementary billing that are in the period being

--- a/app/services/supplementary-billing/fetch-licences.service.js
+++ b/app/services/supplementary-billing/fetch-licences.service.js
@@ -5,7 +5,7 @@
  * @module FetchLicencesService
  */
 
-const LicenceModel = require('../../models/licence.model.js')
+const LicenceModel = require('../../models/water/licence.model.js')
 
 /**
  * Fetches licences flagged for supplementary billing that are linked to the selected region

--- a/app/services/supplementary-billing/fetch-region.service.js
+++ b/app/services/supplementary-billing/fetch-region.service.js
@@ -5,7 +5,7 @@
  * @module FetchRegionService
  */
 
-const RegionModel = require('../../models/region.model.js')
+const RegionModel = require('../../models/water/region.model.js')
 
 /**
  * Fetches the region with the matching NALD Region ID

--- a/test/models/legacy-base.model.test.js
+++ b/test/models/legacy-base.model.test.js
@@ -1,0 +1,35 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Thing under test
+const LegacyBaseModel = require('../../app/models/legacy-base.model.js')
+
+describe('Legacy Base model', () => {
+  describe('.schema()', () => {
+    describe('when the getter is not overridden', () => {
+      class BadModel extends LegacyBaseModel {}
+
+      it('throws an error when called', () => {
+        expect(() => BadModel.query()).to.throw()
+      })
+    })
+
+    describe('when the getter is overridden', () => {
+      class GoodModel extends LegacyBaseModel {
+        static get schema () {
+          return 'water'
+        }
+      }
+
+      it('does not throw an error when called', () => {
+        expect(() => GoodModel.query()).not.to.throw()
+      })
+    })
+  })
+})

--- a/test/models/water/billing-batch.model.test.js
+++ b/test/models/water/billing-batch.model.test.js
@@ -8,13 +8,13 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const BillingBatchHelper = require('../support/helpers/billing-batch.helper.js')
-const DatabaseHelper = require('../support/helpers/database.helper.js')
-const RegionHelper = require('../support/helpers/region.helper.js')
-const RegionModel = require('../../app/models/region.model.js')
+const BillingBatchHelper = require('../../support/helpers/water/billing-batch.helper.js')
+const DatabaseHelper = require('../../support/helpers/database.helper.js')
+const RegionHelper = require('../../support/helpers/water/region.helper.js')
+const RegionModel = require('../../../app/models/water/region.model.js')
 
 // Thing under test
-const BillingBatchModel = require('../../app/models/billing-batch.model.js')
+const BillingBatchModel = require('../../../app/models/water/billing-batch.model.js')
 
 describe('Billing Batch model', () => {
   let testRecord

--- a/test/models/water/billing-charge-category.model.test.js
+++ b/test/models/water/billing-charge-category.model.test.js
@@ -8,13 +8,13 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const BillingChargeCategoryHelper = require('../support/helpers/billing-charge-category.helper.js')
-const ChargeElementHelper = require('../support/helpers/charge-element.helper.js')
-const ChargeElementModel = require('../../app/models/charge-element.model.js')
-const DatabaseHelper = require('../support/helpers/database.helper.js')
+const BillingChargeCategoryHelper = require('../../support/helpers/water/billing-charge-category.helper.js')
+const ChargeElementHelper = require('../../support/helpers/water/charge-element.helper.js')
+const ChargeElementModel = require('../../../app/models/water/charge-element.model.js')
+const DatabaseHelper = require('../../support/helpers/database.helper.js')
 
 // Thing under test
-const BillingChargeCategoryModel = require('../../app/models/billing-charge-category.model.js')
+const BillingChargeCategoryModel = require('../../../app/models/water/billing-charge-category.model.js')
 
 describe('Billing Charge Category model', () => {
   let testRecord

--- a/test/models/water/charge-element.model.test.js
+++ b/test/models/water/charge-element.model.test.js
@@ -8,17 +8,17 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const BillingChargeCategoryHelper = require('../support/helpers/billing-charge-category.helper.js')
-const BillingChargeCategoryModel = require('../../app/models/billing-charge-category.model.js')
-const ChargeElementHelper = require('../support/helpers/charge-element.helper.js')
-const ChargePurposeHelper = require('../support/helpers/charge-purpose.helper.js')
-const ChargePurposeModel = require('../../app/models/charge-purpose.model.js')
-const ChargeVersionHelper = require('../support/helpers/charge-version.helper.js')
-const ChargeVersionModel = require('../../app/models/charge-version.model.js')
-const DatabaseHelper = require('../support/helpers/database.helper.js')
+const BillingChargeCategoryHelper = require('../../support/helpers/water/billing-charge-category.helper.js')
+const BillingChargeCategoryModel = require('../../../app/models/water/billing-charge-category.model.js')
+const ChargeElementHelper = require('../../support/helpers/water/charge-element.helper.js')
+const ChargePurposeHelper = require('../../support/helpers/water/charge-purpose.helper.js')
+const ChargePurposeModel = require('../../../app/models/water/charge-purpose.model.js')
+const ChargeVersionHelper = require('../../support/helpers/water/charge-version.helper.js')
+const ChargeVersionModel = require('../../../app/models/water/charge-version.model.js')
+const DatabaseHelper = require('../../support/helpers/database.helper.js')
 
 // Thing under test
-const ChargeElementModel = require('../../app/models/charge-element.model.js')
+const ChargeElementModel = require('../../../app/models/water/charge-element.model.js')
 
 describe('Charge Element model', () => {
   let testRecord

--- a/test/models/water/charge-purpose.model.test.js
+++ b/test/models/water/charge-purpose.model.test.js
@@ -8,13 +8,13 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const ChargeElementHelper = require('../support/helpers/charge-element.helper.js')
-const ChargeElementModel = require('../../app/models/charge-element.model.js')
-const ChargePurposeHelper = require('../support/helpers/charge-purpose.helper.js')
-const DatabaseHelper = require('../support/helpers/database.helper.js')
+const ChargeElementHelper = require('../../support/helpers/water/charge-element.helper.js')
+const ChargeElementModel = require('../../../app/models/water/charge-element.model.js')
+const ChargePurposeHelper = require('../../support/helpers/water/charge-purpose.helper.js')
+const DatabaseHelper = require('../../support/helpers/database.helper.js')
 
 // Thing under test
-const ChargePurposeModel = require('../../app/models/charge-purpose.model.js')
+const ChargePurposeModel = require('../../../app/models/water/charge-purpose.model.js')
 
 describe('Charge Purpose model', () => {
   let testRecord

--- a/test/models/water/charge-version.model.test.js
+++ b/test/models/water/charge-version.model.test.js
@@ -8,15 +8,15 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const ChargeElementHelper = require('../support/helpers/charge-element.helper.js')
-const ChargeElementModel = require('../../app/models/charge-element.model.js')
-const ChargeVersionHelper = require('../support/helpers/charge-version.helper.js')
-const DatabaseHelper = require('../support/helpers/database.helper.js')
-const LicenceHelper = require('../support/helpers/licence.helper.js')
-const LicenceModel = require('../../app/models/licence.model.js')
+const ChargeElementHelper = require('../../support/helpers/water/charge-element.helper.js')
+const ChargeElementModel = require('../../../app/models/water/charge-element.model.js')
+const ChargeVersionHelper = require('../../support/helpers/water/charge-version.helper.js')
+const DatabaseHelper = require('../../support/helpers/database.helper.js')
+const LicenceHelper = require('../../support/helpers/water/licence.helper.js')
+const LicenceModel = require('../../../app/models/water/licence.model.js')
 
 // Thing under test
-const ChargeVersionModel = require('../../app/models/charge-version.model.js')
+const ChargeVersionModel = require('../../../app/models/water/charge-version.model.js')
 
 describe('ChargeVersion model', () => {
   let testRecord

--- a/test/models/water/event.model.test.js
+++ b/test/models/water/event.model.test.js
@@ -8,11 +8,11 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const DatabaseHelper = require('../support/helpers/database.helper.js')
-const EventHelper = require('../support/helpers/event.helper.js')
+const DatabaseHelper = require('../../support/helpers/database.helper.js')
+const EventHelper = require('../../support/helpers/water/event.helper.js')
 
 // Thing under test
-const EventModel = require('../../app/models/event.model.js')
+const EventModel = require('../../../app/models/water/event.model.js')
 
 describe('Event model', () => {
   let testRecord

--- a/test/models/water/licence.model.test.js
+++ b/test/models/water/licence.model.test.js
@@ -8,15 +8,15 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const ChargeVersionHelper = require('../support/helpers/charge-version.helper.js')
-const ChargeVersionModel = require('../../app/models/charge-version.model.js')
-const DatabaseHelper = require('../support/helpers/database.helper.js')
-const LicenceHelper = require('../support/helpers/licence.helper.js')
-const RegionHelper = require('../support/helpers/region.helper.js')
-const RegionModel = require('../../app/models/region.model.js')
+const ChargeVersionHelper = require('../../support/helpers/water/charge-version.helper.js')
+const ChargeVersionModel = require('../../../app/models/water/charge-version.model.js')
+const DatabaseHelper = require('../../support/helpers/database.helper.js')
+const LicenceHelper = require('../../support/helpers/water/licence.helper.js')
+const RegionHelper = require('../../support/helpers/water/region.helper.js')
+const RegionModel = require('../../../app/models/water/region.model.js')
 
 // Thing under test
-const LicenceModel = require('../../app/models/licence.model.js')
+const LicenceModel = require('../../../app/models/water/licence.model.js')
 
 describe('Licence model', () => {
   let testRecord

--- a/test/models/water/region.model.test.js
+++ b/test/models/water/region.model.test.js
@@ -8,15 +8,15 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const BillingBatchHelper = require('../support/helpers/billing-batch.helper.js')
-const BillingBatchModel = require('../../app/models/billing-batch.model.js')
-const DatabaseHelper = require('../support/helpers/database.helper.js')
-const LicenceHelper = require('../support/helpers/licence.helper.js')
-const LicenceModel = require('../../app/models/licence.model.js')
-const RegionHelper = require('../support/helpers/region.helper.js')
+const BillingBatchHelper = require('../../support/helpers/water/billing-batch.helper.js')
+const BillingBatchModel = require('../../../app/models/water/billing-batch.model.js')
+const DatabaseHelper = require('../../support/helpers/database.helper.js')
+const LicenceHelper = require('../../support/helpers/water/licence.helper.js')
+const LicenceModel = require('../../../app/models/water/licence.model.js')
+const RegionHelper = require('../../support/helpers/water/region.helper.js')
 
 // Thing under test
-const RegionModel = require('../../app/models/region.model.js')
+const RegionModel = require('../../../app/models/water/region.model.js')
 
 describe('Region model', () => {
   let testRecord

--- a/test/presenters/supplementary-billing/create-billing-batch-event.presenter.test.js
+++ b/test/presenters/supplementary-billing/create-billing-batch-event.presenter.test.js
@@ -8,10 +8,10 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const BillingBatchHelper = require('../../support/helpers/billing-batch.helper.js')
-const BillingBatchModel = require('../../../app/models/billing-batch.model.js')
+const BillingBatchHelper = require('../../support/helpers/water/billing-batch.helper.js')
+const BillingBatchModel = require('../../../app/models/water/billing-batch.model.js')
 const DatabaseHelper = require('../../support/helpers/database.helper.js')
-const RegionHelper = require('../../support/helpers/region.helper.js')
+const RegionHelper = require('../../support/helpers/water/region.helper.js')
 
 // Thing under test
 const CreateBillingBatchEventPresenter = require('../../../app/presenters/supplementary-billing/create-billing-batch-event.presenter.js')

--- a/test/services/supplementary-billing/create-billing-batch-event.service.test.js
+++ b/test/services/supplementary-billing/create-billing-batch-event.service.test.js
@@ -8,11 +8,11 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const BillingBatchHelper = require('../../support/helpers/billing-batch.helper.js')
-const BillingBatchModel = require('../../../app/models/billing-batch.model.js')
+const BillingBatchHelper = require('../../support/helpers/water/billing-batch.helper.js')
+const BillingBatchModel = require('../../../app/models/water/billing-batch.model.js')
 const DatabaseHelper = require('../../support/helpers/database.helper.js')
-const EventModel = require('../../../app/models/event.model.js')
-const RegionHelper = require('../../support/helpers/region.helper.js')
+const EventModel = require('../../../app/models/water/event.model.js')
+const RegionHelper = require('../../support/helpers/water/region.helper.js')
 
 // Thing under test
 const CreateBillingBatchEventService = require('../../../app/services/supplementary-billing/create-billing-batch-event.service.js')

--- a/test/services/supplementary-billing/create-billing-batch.service.test.js
+++ b/test/services/supplementary-billing/create-billing-batch.service.test.js
@@ -8,10 +8,10 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const BillingBatchModel = require('../../../app/models/billing-batch.model.js')
+const BillingBatchModel = require('../../../app/models/water/billing-batch.model.js')
 const DatabaseHelper = require('../../support/helpers/database.helper.js')
-const RegionHelper = require('../../support/helpers/region.helper.js')
-const RegionModel = require('../../../app/models/region.model.js')
+const RegionHelper = require('../../support/helpers/water/region.helper.js')
+const RegionModel = require('../../../app/models/water/region.model.js')
 
 // Thing under test
 const CreateBillingBatchService = require('../../../app/services/supplementary-billing/create-billing-batch.service.js')

--- a/test/services/supplementary-billing/fetch-charge-versions.service.test.js
+++ b/test/services/supplementary-billing/fetch-charge-versions.service.test.js
@@ -8,12 +8,12 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const BillingChargeCategoryHelper = require('../../support/helpers/billing-charge-category.helper.js')
-const ChargeElementHelper = require('../../support/helpers/charge-element.helper.js')
-const ChargePurposeHelper = require('../../support/helpers/charge-purpose.helper.js')
-const ChargeVersionHelper = require('../../support/helpers/charge-version.helper.js')
+const BillingChargeCategoryHelper = require('../../support/helpers/water/billing-charge-category.helper.js')
+const ChargeElementHelper = require('../../support/helpers/water/charge-element.helper.js')
+const ChargePurposeHelper = require('../../support/helpers/water/charge-purpose.helper.js')
+const ChargeVersionHelper = require('../../support/helpers/water/charge-version.helper.js')
 const DatabaseHelper = require('../../support/helpers/database.helper.js')
-const LicenceHelper = require('../../support/helpers/licence.helper.js')
+const LicenceHelper = require('../../support/helpers/water/licence.helper.js')
 
 // Thing under test
 const FetchChargeVersionsService = require('../../../app/services/supplementary-billing/fetch-charge-versions.service.js')

--- a/test/services/supplementary-billing/fetch-licences.service.test.js
+++ b/test/services/supplementary-billing/fetch-licences.service.test.js
@@ -8,9 +8,9 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const ChargeVersionHelper = require('../../support/helpers/charge-version.helper.js')
+const ChargeVersionHelper = require('../../support/helpers/water/charge-version.helper.js')
 const DatabaseHelper = require('../../support/helpers/database.helper.js')
-const LicenceHelper = require('../../support/helpers/licence.helper.js')
+const LicenceHelper = require('../../support/helpers/water/licence.helper.js')
 
 // Thing under test
 const FetchLicencesService = require('../../../app/services/supplementary-billing/fetch-licences.service.js')

--- a/test/services/supplementary-billing/fetch-region.service.test.js
+++ b/test/services/supplementary-billing/fetch-region.service.test.js
@@ -9,7 +9,7 @@ const { expect } = Code
 
 // Test helpers
 const DatabaseHelper = require('../../support/helpers/database.helper.js')
-const RegionHelper = require('../../support/helpers/region.helper.js')
+const RegionHelper = require('../../support/helpers/water/region.helper.js')
 
 // Thing under test
 const FetchRegionService = require('../../../app/services/supplementary-billing/fetch-region.service.js')

--- a/test/services/supplementary-billing/initiate-billing-batch.service.test.js
+++ b/test/services/supplementary-billing/initiate-billing-batch.service.test.js
@@ -9,10 +9,10 @@ const { describe, it, beforeEach, afterEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const BillingBatchModel = require('../../../app/models/billing-batch.model.js')
+const BillingBatchModel = require('../../../app/models/water/billing-batch.model.js')
 const DatabaseHelper = require('../../support/helpers/database.helper.js')
-const EventModel = require('../../../app/models/event.model.js')
-const RegionHelper = require('../../support/helpers/region.helper.js')
+const EventModel = require('../../../app/models/water/event.model.js')
+const RegionHelper = require('../../support/helpers/water/region.helper.js')
 
 // Things we need to stub
 const BillingPeriodService = require('../../../app/services/supplementary-billing/billing-period.service.js')

--- a/test/support/helpers/water/billing-batch.helper.js
+++ b/test/support/helpers/water/billing-batch.helper.js
@@ -1,33 +1,38 @@
 'use strict'
 
 /**
- * @module LicenceHelper
+ * @module BillingBatchHelper
  */
 
-const LicenceModel = require('../../../app/models/licence.model.js')
+const BillingBatchModel = require('../../../../app/models/water/billing-batch.model.js')
 
 /**
- * Add a new licence
+ * Add a new billing batch
  *
  * If no `data` is provided, default values will be used. These are
  *
- * - `licenceRef` - 01/123
  * - `regionId` - bd114474-790f-4470-8ba4-7b0cc9c225d7
+ * - `batchType` - supplementary
+ * - `fromFinancialYearEnding` - 2023
+ * - `toFinancialYearEnding` - 2023
+ * - `status` - processing
+ * - `scheme` - sroc
+ * - `source` - wrls
  *
  * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
  *
- * @returns {module:LicenceModel} The instance of the newly created record
+ * @returns {module:BillingBatchModel} The instance of the newly created record
  */
-async function add (data = {}) {
+function add (data = {}) {
   const insertData = defaults(data)
 
-  return LicenceModel.query()
+  return BillingBatchModel.query()
     .insert({ ...insertData })
     .returning('*')
 }
 
 /**
- * Returns the defaults used when creating a new licence
+ * Returns the defaults used when creating a new billing batch
  *
  * It will override or append to them any data provided. Mainly used by the `add()` method, we make it available
  * for use in tests to avoid having to duplicate values.
@@ -36,8 +41,13 @@ async function add (data = {}) {
  */
 function defaults (data = {}) {
   const defaults = {
-    licenceRef: '01/123',
-    regionId: 'bd114474-790f-4470-8ba4-7b0cc9c225d7'
+    regionId: 'bd114474-790f-4470-8ba4-7b0cc9c225d7',
+    batchType: 'supplementary',
+    fromFinancialYearEnding: 2023,
+    toFinancialYearEnding: 2023,
+    status: 'processing',
+    scheme: 'sroc',
+    source: 'wrls'
   }
 
   return {

--- a/test/support/helpers/water/billing-charge-category.helper.js
+++ b/test/support/helpers/water/billing-charge-category.helper.js
@@ -4,7 +4,7 @@
  * @module BillingChargeCategoryHelper
  */
 
-const BillingChargeCategoryModel = require('../../../app/models/billing-charge-category.model.js')
+const BillingChargeCategoryModel = require('../../../../app/models/water/billing-charge-category.model.js')
 
 /**
  * Add a new billing charge category

--- a/test/support/helpers/water/charge-element.helper.js
+++ b/test/support/helpers/water/charge-element.helper.js
@@ -4,7 +4,7 @@
  * @module ChargeElementHelper
  */
 
-const ChargeElementModel = require('../../../app/models/charge-element.model.js')
+const ChargeElementModel = require('../../../../app/models/water/charge-element.model.js')
 
 /**
  * Add a new charge element

--- a/test/support/helpers/water/charge-purpose.helper.js
+++ b/test/support/helpers/water/charge-purpose.helper.js
@@ -4,7 +4,7 @@
  * @module ChargePurposeHelper
  */
 
-const ChargePurposeModel = require('../../../app/models/charge-purpose.model.js')
+const ChargePurposeModel = require('../../../../app/models/water/charge-purpose.model.js')
 
 /**
  * Add a new charge purpose

--- a/test/support/helpers/water/charge-version.helper.js
+++ b/test/support/helpers/water/charge-version.helper.js
@@ -4,7 +4,7 @@
  * @module ChargeVersionHelper
  */
 
-const ChargeVersionModel = require('../../../app/models/charge-version.model.js')
+const ChargeVersionModel = require('../../../../app/models/water/charge-version.model.js')
 const LicenceHelper = require('./licence.helper.js')
 
 /**

--- a/test/support/helpers/water/event.helper.js
+++ b/test/support/helpers/water/event.helper.js
@@ -4,7 +4,7 @@
  * @module EventHelper
  */
 
-const EventModel = require('../../../app/models/event.model.js')
+const EventModel = require('../../../../app/models/water/event.model.js')
 
 /**
  * Add a new event

--- a/test/support/helpers/water/licence.helper.js
+++ b/test/support/helpers/water/licence.helper.js
@@ -1,38 +1,33 @@
 'use strict'
 
 /**
- * @module BillingBatchHelper
+ * @module LicenceHelper
  */
 
-const BillingBatchModel = require('../../../app/models/billing-batch.model.js')
+const LicenceModel = require('../../../../app/models/water/licence.model.js')
 
 /**
- * Add a new billing batch
+ * Add a new licence
  *
  * If no `data` is provided, default values will be used. These are
  *
+ * - `licenceRef` - 01/123
  * - `regionId` - bd114474-790f-4470-8ba4-7b0cc9c225d7
- * - `batchType` - supplementary
- * - `fromFinancialYearEnding` - 2023
- * - `toFinancialYearEnding` - 2023
- * - `status` - processing
- * - `scheme` - sroc
- * - `source` - wrls
  *
  * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
  *
- * @returns {module:BillingBatchModel} The instance of the newly created record
+ * @returns {module:LicenceModel} The instance of the newly created record
  */
-function add (data = {}) {
+async function add (data = {}) {
   const insertData = defaults(data)
 
-  return BillingBatchModel.query()
+  return LicenceModel.query()
     .insert({ ...insertData })
     .returning('*')
 }
 
 /**
- * Returns the defaults used when creating a new billing batch
+ * Returns the defaults used when creating a new licence
  *
  * It will override or append to them any data provided. Mainly used by the `add()` method, we make it available
  * for use in tests to avoid having to duplicate values.
@@ -41,13 +36,8 @@ function add (data = {}) {
  */
 function defaults (data = {}) {
   const defaults = {
-    regionId: 'bd114474-790f-4470-8ba4-7b0cc9c225d7',
-    batchType: 'supplementary',
-    fromFinancialYearEnding: 2023,
-    toFinancialYearEnding: 2023,
-    status: 'processing',
-    scheme: 'sroc',
-    source: 'wrls'
+    licenceRef: '01/123',
+    regionId: 'bd114474-790f-4470-8ba4-7b0cc9c225d7'
   }
 
   return {

--- a/test/support/helpers/water/region.helper.js
+++ b/test/support/helpers/water/region.helper.js
@@ -4,7 +4,7 @@
  * @module RegionHelper
  */
 
-const RegionModel = require('../../../app/models/region.model.js')
+const RegionModel = require('../../../../app/models/water/region.model.js')
 
 /**
  * Add a new region


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/69

Our next step in refactoring the models to deal with legacy issues is to identify them by type and scheme. Admittedly, we know we are just dealing with one type (legacy) and scheme (water). But more will be coming and this helps set the groundwork for implementing base classes that allow us to start hiding some of the issues with the existing DB.

So, we move the existing models into a new `models/water` folder and we add a new `LegacyModel` which all our existing classes will inherit from.