### PR TITLE
Fix issue with dotenv in tests

### DIFF
--- a/app/server.js
+++ b/app/server.js
@@ -1,7 +1,5 @@
 'use strict'
 
-require('dotenv').config()
-
 const Hapi = require('@hapi/hapi')
 
 const AirbrakePlugin = require('./plugins/airbrake.plugin.js')

--- a/config/airbrake.config.js
+++ b/config/airbrake.config.js
@@ -5,6 +5,10 @@
  * @module AirbrakeConfig
  */
 
+// We require dotenv directly in each config file to support unit tests that depend on this this subset of config.
+// Requiring dotenv in multiple places has no effect on the app when running for real.
+require('dotenv').config()
+
 const config = {
   host: process.env.AIRBRAKE_HOST,
   projectKey: process.env.AIRBRAKE_KEY,

--- a/config/database.config.js
+++ b/config/database.config.js
@@ -5,9 +5,8 @@
  * @module DatabaseConfig
  */
 
-// Unlike the other config files we need to directly reference dotenv. It is because this config is used when we run
-// migrations. The rest of the config is only used when we run the app. `app/server.js` loads dotenv which makes it
-// available to everything else thereafter
+// We require dotenv directly in each config file to support unit tests that depend on this this subset of config.
+// Requiring dotenv in multiple places has no effect on the app when running for real.
 require('dotenv').config()
 
 const config = {

--- a/config/log.config.js
+++ b/config/log.config.js
@@ -5,6 +5,10 @@
  * @module LogConfig
  */
 
+// We require dotenv directly in each config file to support unit tests that depend on this this subset of config.
+// Requiring dotenv in multiple places has no effect on the app when running for real.
+require('dotenv').config()
+
 const config = {
   // Credit to https://stackoverflow.com/a/323546/6117745 for how to handle
   // converting the env var to a boolean

--- a/config/request.config.js
+++ b/config/request.config.js
@@ -1,5 +1,14 @@
 'use strict'
 
+/**
+ * Config values used by app/lib/request.lib.js
+ * @module RequestConfig
+ */
+
+// We require dotenv directly in each config file to support unit tests that depend on this this subset of config.
+// Requiring dotenv in multiple places has no effect on the app when running for real.
+require('dotenv').config()
+
 const config = {
   timeout: parseInt(process.env.REQUEST_TIMEOUT) || 5000,
   // Note - Why lowercase? It's just the convention for http_proxy, https_proxy

--- a/config/server.config.js
+++ b/config/server.config.js
@@ -5,6 +5,10 @@
  * @module ServerConfig
  */
 
+// We require dotenv directly in each config file to support unit tests that depend on this this subset of config.
+// Requiring dotenv in multiple places has no effect on the app when running for real.
+require('dotenv').config()
+
 const config = {
   environment: process.env.NODE_ENV || 'development',
   hapi: {

--- a/config/services.config.js
+++ b/config/services.config.js
@@ -5,6 +5,10 @@
  * @module ServicesConfig
  */
 
+// We require dotenv directly in each config file to support unit tests that depend on this this subset of config.
+// Requiring dotenv in multiple places has no effect on the app when running for real.
+require('dotenv').config()
+
 const config = {
   addressFacade: {
     url: process.env.EA_ADDRESS_FACADE_URL


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3833

In [Refactor dotenv require](https://github.com/DEFRA/water-abstraction-system/pull/10) it was identified that we were requiring [dotnev](https://github.com/motdotla/dotenv) in multiple places and ideally we should do it once, as early as possible.

It was spotted in [Move location where 'dotenv' is being required](https://github.com/DEFRA/water-abstraction-system/pull/21) that some of the tests were effected by this move, and we bumped it from `index.js` to `/app/server.js`.

We then created our first DB migrations and realised we also needed to include it in `config/database.config.js` else migrations wouldn't work.

What we now realise is that controller tests work because they require `/app/server.js` which requires **dotenv**. Also, any test that connects with the DB pulls in `config/database.config.js` so those are fine.

But when working on [Request new bill run in Charging Module API](request-new-bill-run-in-charging-module) and running tests that need `config/services.config.js` to be populated they were breaking. This is because **dotenv** is never getting `required()` so none of our env vars are getting read in.

TL;DR; there was a reason we `require('dotenv')` in all our config files in [sroc-charging-module-api ](https://github.com/DEFRA/sroc-charging-module-api); it's to make both the app _and_ tests work as expected!

This change reverts [Refactor dotenv require](https://github.com/DEFRA/water-abstraction-system/pull/10) to get everything working again.