### PR TITLE
Fix invalid GOT POST reg. to create CHA bill run

### DIFF
--- a/app/services/charging-module/create-bill-run.service.js
+++ b/app/services/charging-module/create-bill-run.service.js
@@ -39,7 +39,7 @@ async function _options (regionId, ruleset, authentication) {
     headers: {
       authorization: `Bearer ${authentication.accessToken}`
     },
-    body: {
+    json: {
       region,
       ruleset
     }

--- a/test/services/charging-module/create-bill-run.service.test.js
+++ b/test/services/charging-module/create-bill-run.service.test.js
@@ -56,7 +56,7 @@ describe('Charge module create bill run service', () => {
 
       expect(requestArgs[0]).to.endWith('/wrls/bill-runs')
       expect(requestArgs[1].headers).to.include({ authorization: 'Bearer ACCESS_TOKEN' })
-      expect(requestArgs[1].body).to.include({ region: testRegion.chargeRegionId, ruleset: 'sroc' })
+      expect(requestArgs[1].json).to.include({ region: testRegion.chargeRegionId, ruleset: 'sroc' })
     })
 
     it('returns a `true` success status', async () => {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3833

When we deployed the latest version of the repo with the new [Request new bill run in Charging Module API](https://github.com/DEFRA/water-abstraction-system/pull/83) we kept getting a `500` error returned by the service.

The root error was

```text
Error: undefined - Expected value which is `predicate returns truthy for any value`, received values of types `Object`.
6|system  |               at _formattedInitiateBillingBatchError (/home/repos/water-abstraction-system/app/controllers/bill-runs/bill-runs.controller.js:40:15)
6|system  |               at create (/home/repos/water-abstraction-system/app/controllers/bill-runs/bill-runs.controller.js:25:12)
6|system  |               at processTicksAndRejections (node:internal/process/task_queues:96:5)
6|system  |               at async exports.Manager.execute (/home/repos/water-abstraction-system/node_modules/@hapi/hapi/lib/toolkit.js:60:28)
6|system  |               at async Object.internals.handler (/home/repos/water-abstraction-system/node_modules/@hapi/hapi/lib/handler.js:46:20)
6|system  |               at async exports.execute (/home/repos/water-abstraction-system/node_modules/@hapi/hapi/lib/handler.js:31:20)
6|system  |               at async Request._lifecycle (/home/repos/water-abstraction-system/node_modules/@hapi/hapi/lib/request.js:370:32)
6|system  |               at async Request._execute (/home/repos/water-abstraction-system/node_modules/@hapi/hapi/lib/request.js:280:9)
```

After some research, we found mention of this error in a couple of [Got](https://github.com/sindresorhus/got) related issues

- [Throw more useful errors for request validation](https://github.com/sindresorhus/got/issues/1257)
- [Enhance assert error messages](https://github.com/sindresorhus/is/issues/107#issuecomment-1144196069)

Basically, we were passing in an invalid property for one of the options. In our case we were passing `body: {}` when it should have been `json: {}`.

So, just a simple tweak but it gets the thing working!