### PR TITLE
Support new queued bill run status

### DIFF
--- a/app/services/supplementary-billing/create-billing-batch.service.js
+++ b/app/services/supplementary-billing/create-billing-batch.service.js
@@ -26,7 +26,7 @@ async function go (regionId, billingPeriod, batchType = 'supplementary', scheme 
       batchType,
       fromFinancialYearEnding: billingPeriod.endDate.getFullYear(),
       toFinancialYearEnding: billingPeriod.endDate.getFullYear(),
-      status: 'processing',
+      status: 'queued',
       scheme,
       source,
       externalId

--- a/test/services/supplementary-billing/create-billing-batch.service.test.js
+++ b/test/services/supplementary-billing/create-billing-batch.service.test.js
@@ -32,7 +32,7 @@ describe('Create Billing Batch service', () => {
 
       expect(result).to.be.an.instanceOf(BillingBatchModel)
 
-      expect(result.status).to.equal('processing')
+      expect(result.status).to.equal('queued')
       expect(result.fromFinancialYearEnding).to.equal(2023)
       expect(result.toFinancialYearEnding).to.equal(2023)
       expect(result.batchType).to.equal('supplementary')
@@ -56,7 +56,7 @@ describe('Create Billing Batch service', () => {
 
       expect(result).to.be.an.instanceOf(BillingBatchModel)
 
-      expect(result.status).to.equal('processing')
+      expect(result.status).to.equal('queued')
       expect(result.fromFinancialYearEnding).to.equal(2023)
       expect(result.toFinancialYearEnding).to.equal(2023)
       expect(result.batchType).to.equal(batchType)

--- a/test/services/supplementary-billing/initiate-billing-batch.service.test.js
+++ b/test/services/supplementary-billing/initiate-billing-batch.service.test.js
@@ -82,7 +82,7 @@ describe('Initiate Billing Batch service', () => {
       expect(result.region).to.equal(billingBatch.regionId)
       expect(result.scheme).to.equal('sroc')
       expect(result.batchType).to.equal('supplementary')
-      expect(result.status).to.equal('processing')
+      expect(result.status).to.equal('queued')
     })
   })
 

--- a/test/support/helpers/water/billing-batch.helper.js
+++ b/test/support/helpers/water/billing-batch.helper.js
@@ -15,7 +15,7 @@ const BillingBatchModel = require('../../../../app/models/water/billing-batch.mo
  * - `batchType` - supplementary
  * - `fromFinancialYearEnding` - 2023
  * - `toFinancialYearEnding` - 2023
- * - `status` - processing
+ * - `status` - queued
  * - `scheme` - sroc
  * - `source` - wrls
  *
@@ -45,7 +45,7 @@ function defaults (data = {}) {
     batchType: 'supplementary',
     fromFinancialYearEnding: 2023,
     toFinancialYearEnding: 2023,
-    status: 'processing',
+    status: 'queued',
     scheme: 'sroc',
     source: 'wrls'
   }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3877

When a supplementary bill run is started, we'll be creating both a PRESROC and SROC one at the same time.

The PRESROC one will then begin `processing` (labelled as BUILDING in the UI) whilst the SROC one is `queued` waiting to be processed.

At the moment though, all we can do is initialise the SROC bill run with a status of `processing` as that is all that is available to us. In the UI this will give the impression both are building when they're not.

We've added a new `queued` status to [water-abstraction-service](https://github.com/DEFRA/water-abstraction-service/pull/1965) and support for it in [water-abstraction-ui](https://github.com/DEFRA/water-abstraction-ui/pull/2271). This change updates changes the default status we apply to new bill runs to be `queued`.