### PR TITLE
Fix handling of Charging Module errors

### DIFF
--- a/app/services/charging-module/create-bill-run.service.js
+++ b/app/services/charging-module/create-bill-run.service.js
@@ -56,16 +56,15 @@ async function _getChargeRegionId (regionId) {
 }
 
 function _parseResult (result) {
-  // Simply return the result as-is if we were unsuccessful
-  if (!result.succeeded) {
-    return result
-  }
-
   const parsedBody = JSON.parse(result.response.body)
 
+  // If the request succeeded then we return the bill run in the response; otherwise, we simply return the entire body
+  // as this includes the status code and error messages
+  const response = result.succeeded ? parsedBody.billRun : parsedBody
+
   return {
-    succeeded: true,
-    response: parsedBody.billRun
+    succeeded: result.succeeded,
+    response
   }
 }
 

--- a/app/services/supplementary-billing/initiate-billing-batch.service.js
+++ b/app/services/supplementary-billing/initiate-billing-batch.service.js
@@ -32,7 +32,15 @@ async function go (billRunRequestData) {
 
   // A failed response will be due to a failed `RequestLib` request so format an error message accordingly and throw it
   if (!chargingModuleBillRun.succeeded) {
-    throw Error(`${chargingModuleBillRun.response.statusCode} - ${chargingModuleBillRun.response.message}`)
+    // We always get the status code and error
+    const errorHead = `${chargingModuleBillRun.response.statusCode} ${chargingModuleBillRun.response.error}`
+
+    // We should always get an additional error messge but if not then simply throw the status code and error
+    if (!chargingModuleBillRun.response.message) {
+      throw Error(errorHead)
+    }
+
+    throw Error(errorHead + ` - ${chargingModuleBillRun.response.message}`)
   }
 
   const billingBatch = await CreateBillingBatchService.go(region, billingPeriod, type, scheme, undefined, chargingModuleBillRun.response.id)

--- a/test/services/charging-module/create-bill-run.service.test.js
+++ b/test/services/charging-module/create-bill-run.service.test.js
@@ -78,9 +78,9 @@ describe('Charge module create bill run service', () => {
       Sinon.stub(RequestLib, 'post').resolves({
         succeeded: false,
         response: {
-          statusCode: 403,
-          error: 'Forbidden',
-          message: "Unauthorised for regime 'wrls'"
+          // For consistency we include the status code in the response but note that it is also returned in the body
+          statusCode: 401,
+          body: '{"statusCode":401,"error":"Unauthorized","message":"Invalid JWT: Token format not valid","attributes":{"error":"Invalid JWT: Token format not valid"}}'
         }
       })
 
@@ -94,9 +94,9 @@ describe('Charge module create bill run service', () => {
     it('returns the error in the `response`', async () => {
       const { response } = result
 
-      expect(response.statusCode).to.equal(403)
-      expect(response.error).to.equal('Forbidden')
-      expect(response.message).to.equal("Unauthorised for regime 'wrls'")
+      expect(response.statusCode).to.equal(401)
+      expect(response.error).to.equal('Unauthorized')
+      expect(response.message).to.equal('Invalid JWT: Token format not valid')
     })
   })
 })

--- a/test/services/supplementary-billing/initiate-billing-batch.service.test.js
+++ b/test/services/supplementary-billing/initiate-billing-batch.service.test.js
@@ -103,7 +103,26 @@ describe('Initiate Billing Batch service', () => {
         const err = await expect(InitiateBillingBatchService.go(validatedRequestData)).to.reject()
 
         expect(err).to.be.an.error()
-        expect(err.message).to.equal("403 - Unauthorised for regime 'wrls'")
+        expect(err.message).to.equal("403 Forbidden - Unauthorised for regime 'wrls'")
+      })
+    })
+
+    describe('and the error doesn\'t include a messge', () => {
+      beforeEach(() => {
+        Sinon.stub(ChargingModuleCreateBillRunService, 'go').resolves({
+          succeeded: false,
+          response: {
+            statusCode: 403,
+            error: 'Forbidden'
+          }
+        })
+      })
+
+      it('rejects with an appropriate error', async () => {
+        const err = await expect(InitiateBillingBatchService.go(validatedRequestData)).to.reject()
+
+        expect(err).to.be.an.error()
+        expect(err.message).to.equal('403 Forbidden')
       })
     })
   })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3833

While diagnosing an issue with Charging Module authorisation, we realised that we weren't correctly passing back any error messages it returned.

It turned out the format that errors come back in didn't quite match what we expected -- while the status code and status error (eg. `401` and `Unauthorized`) are returned as part of the response, the error message we want to display (eg. `Invalid JWT`) is returned in the response body in JSON format (which also contains the status code and error).

We therefore update how `CreateBillRunService` returns these errors by parsing the body, and in the event of an unsuccessful request we return it as-is in the response (whereas a successful request still extracts the `billRun` object from the body and returns that as the response). This gives us the status code and status error along with any returned error message.

We then amend how `InitiateBillingBatchService` formats these errors. We previously intended errors to be thrown as:
```
401 Invalid JWT
```
We now throw them as:
```
401 Unauthorized - Invalid JWT
```
(ie. status code, status error, and returned error message)

We expect to receive a message in the event of an error but if no message was returned we throw:
```
401 Unauthorized
```