### PR TITLE
Do not create SROC bill run if one already exists

### DIFF
--- a/app/services/supplementary-billing/check-live-bill-run.service.js
+++ b/app/services/supplementary-billing/check-live-bill-run.service.js
@@ -1,0 +1,26 @@
+'use strict'
+
+/**
+ * Checks whether a "live" bill run exists for the specified region, scheme, type and financial year
+ * @module CheckLiveBillRunService
+ */
+
+/**
+ * Check whether a "live" bill run exists for the specified region, scheme, type and financial year
+ *
+ * We define "live" as having the status `processing`, `ready` or `review`
+ *
+ * @param {*} region
+ * @param {*} scheme
+ * @param {*} type
+ * @param {*} financialYeara
+ *
+ * @returns {Boolean} Whether a "live" bill run exists
+ */
+async function go (region, scheme, type, financialYear) {
+  return true
+}
+
+module.exports = {
+  go
+}

--- a/app/services/supplementary-billing/check-live-bill-run.service.js
+++ b/app/services/supplementary-billing/check-live-bill-run.service.js
@@ -5,20 +5,32 @@
  * @module CheckLiveBillRunService
  */
 
+const BillingBatchModel = require('../../models/water/billing-batch.model.js')
+
+const LIVE_STATUSES = ['processing', 'ready', 'review']
+
 /**
  * Check whether a "live" bill run exists for the specified region, scheme, type and financial year
  *
  * We define "live" as having the status `processing`, `ready` or `review`
  *
- * @param {*} region
- * @param {*} scheme
- * @param {*} type
- * @param {*} financialYeara
+ * @param {*} regionId The id of the region to be checked
+ * @param {*} financialYear The financial year to be checked
  *
  * @returns {Boolean} Whether a "live" bill run exists
  */
-async function go (region, scheme, type, financialYear) {
-  return true
+async function go (regionId, financialYear) {
+  const numberOfLiveBillRuns = await BillingBatchModel.query()
+    .where({
+      regionId,
+      toFinancialYearEnding: financialYear,
+      scheme: 'sroc',
+      batchType: 'supplementary'
+    })
+    .whereIn('status', LIVE_STATUSES)
+    .resultSize()
+
+  return numberOfLiveBillRuns !== 0
 }
 
 module.exports = {

--- a/app/services/supplementary-billing/check-live-bill-run.service.js
+++ b/app/services/supplementary-billing/check-live-bill-run.service.js
@@ -21,6 +21,7 @@ const LIVE_STATUSES = ['processing', 'ready', 'review', 'queued']
  */
 async function go (regionId, financialYear) {
   const numberOfLiveBillRuns = await BillingBatchModel.query()
+    .select('billing_batch_id')
     .where({
       regionId,
       toFinancialYearEnding: financialYear,

--- a/app/services/supplementary-billing/check-live-bill-run.service.js
+++ b/app/services/supplementary-billing/check-live-bill-run.service.js
@@ -7,12 +7,12 @@
 
 const BillingBatchModel = require('../../models/water/billing-batch.model.js')
 
-const LIVE_STATUSES = ['processing', 'ready', 'review']
+const LIVE_STATUSES = ['processing', 'ready', 'review', 'queued']
 
 /**
  * Check whether a "live" bill run exists for the specified region, scheme, type and financial year
  *
- * We define "live" as having the status `processing`, `ready` or `review`
+ * We define "live" as having the status `processing`, `ready`, `review` or `queued`
  *
  * @param {*} regionId The id of the region to be checked
  * @param {*} financialYear The financial year to be checked

--- a/app/services/supplementary-billing/initiate-billing-batch.service.js
+++ b/app/services/supplementary-billing/initiate-billing-batch.service.js
@@ -33,7 +33,7 @@ async function go (billRunRequestData) {
   const liveBillRunExists = await CheckLiveBillRunService.go(region, financialYear)
 
   if (liveBillRunExists) {
-    throw Error()
+    throw Error(`Batch already live for region ${region}`)
   }
 
   const chargingModuleBillRun = await ChargingModuleCreateBillRunService.go(region, 'sroc')

--- a/app/services/supplementary-billing/initiate-billing-batch.service.js
+++ b/app/services/supplementary-billing/initiate-billing-batch.service.js
@@ -7,6 +7,7 @@
 
 const BillingPeriodService = require('./billing-period.service.js')
 const ChargingModuleCreateBillRunService = require('../charging-module/create-bill-run.service.js')
+const CheckLiveBillRunService = require('./check-live-bill-run.service.js')
 const CreateBillingBatchPresenter = require('../../presenters/supplementary-billing/create-billing-batch.presenter.js')
 const CreateBillingBatchService = require('./create-billing-batch.service.js')
 const CreateBillingBatchEventService = require('./create-billing-batch-event.service.js')
@@ -27,6 +28,13 @@ async function go (billRunRequestData) {
   const billingPeriod = BillingPeriodService.go()[0]
 
   const { region, scheme, type, user } = billRunRequestData
+
+  const financialYear = billingPeriod.endDate.getFullYear()
+  const liveBillRunExists = await CheckLiveBillRunService.go(region, financialYear)
+
+  if (liveBillRunExists) {
+    throw Error()
+  }
 
   const chargingModuleBillRun = await ChargingModuleCreateBillRunService.go(region, 'sroc')
 

--- a/test/services/supplementary-billing/check-live-bill-run.service.test.js
+++ b/test/services/supplementary-billing/check-live-bill-run.service.test.js
@@ -15,7 +15,7 @@ const DatabaseHelper = require('../../support/helpers/database.helper.js')
 const CheckLiveBillRunService = require('../../../app/services/supplementary-billing/check-live-bill-run.service.js')
 
 describe('Check Live Bill Run service', () => {
-  let billRunRegion
+  let billRun
 
   beforeEach(async () => {
     await DatabaseHelper.clean()
@@ -24,12 +24,11 @@ describe('Check Live Bill Run service', () => {
   describe('when an sroc supplementary bill run exists for this region and financial year', () => {
     describe('with a status considered to be "live"', () => {
       beforeEach(async () => {
-        const billRun = await BillingBatchHelper.add()
-        billRunRegion = billRun.regionId
+        billRun = await BillingBatchHelper.add()
       })
 
       it('returns `true`', async () => {
-        const result = await CheckLiveBillRunService.go(billRunRegion, 2023)
+        const result = await CheckLiveBillRunService.go(billRun.regionId, 2023)
 
         expect(result).to.be.true()
       })
@@ -37,12 +36,11 @@ describe('Check Live Bill Run service', () => {
 
     describe('with a status not considered to be "live"', () => {
       beforeEach(async () => {
-        const billRun = await BillingBatchHelper.add({ status: 'sent' })
-        billRunRegion = billRun.regionId
+        billRun = await BillingBatchHelper.add({ status: 'sent' })
       })
 
       it('returns `false`', async () => {
-        const result = await CheckLiveBillRunService.go(billRunRegion, 2023)
+        const result = await CheckLiveBillRunService.go(billRun.regionId, 2023)
 
         expect(result).to.be.false()
       })
@@ -51,12 +49,11 @@ describe('Check Live Bill Run service', () => {
 
   describe('when an sroc supplementary bill run does not exist for this region and financial year', () => {
     beforeEach(async () => {
-      const billRun = await BillingBatchHelper.add({ fromFinancialYearEnding: 2024, toFinancialYearEnding: 2024 })
-      billRunRegion = billRun.regionId
+      billRun = await BillingBatchHelper.add({ fromFinancialYearEnding: 2024, toFinancialYearEnding: 2024 })
     })
 
     it('returns `false`', async () => {
-      const result = await CheckLiveBillRunService.go(billRunRegion, 2023)
+      const result = await CheckLiveBillRunService.go(billRun.regionId, 2023)
 
       expect(result).to.be.false()
     })

--- a/test/services/supplementary-billing/check-live-bill-run.service.test.js
+++ b/test/services/supplementary-billing/check-live-bill-run.service.test.js
@@ -1,0 +1,64 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const BillingBatchHelper = require('../../support/helpers/water/billing-batch.helper.js')
+const DatabaseHelper = require('../../support/helpers/database.helper.js')
+
+// Thing under test
+const CheckLiveBillRunService = require('../../../app/services/supplementary-billing/check-live-bill-run.service.js')
+
+describe.only('Check Live Bill Run service', () => {
+  let billRunRegion
+
+  beforeEach(async () => {
+    await DatabaseHelper.clean()
+  })
+
+  describe('when an sroc supplementary bill run exists for this region and financial year', () => {
+    describe('with a status considered to be "live"', () => {
+      beforeEach(async () => {
+        const billRun = await BillingBatchHelper.add()
+        billRunRegion = billRun.regionId
+      })
+
+      it('returns `true`', async () => {
+        const result = await CheckLiveBillRunService.go(billRunRegion, 'sroc', 'supplementary', 2023)
+
+        expect(result).to.be.true()
+      })
+    })
+
+    describe('with a status not considered to be "live"', () => {
+      beforeEach(async () => {
+        const billRun = await BillingBatchHelper.add({ status: 'sent' })
+        billRunRegion = billRun.regionId
+      })
+
+      it('returns `false`', async () => {
+        const result = await CheckLiveBillRunService.go(billRunRegion, 'sroc', 'supplementary', 2023)
+
+        expect(result).to.be.false()
+      })
+    })
+  })
+
+  describe('when an sroc supplementary bill run does not exist for this region and financial year', () => {
+    beforeEach(async () => {
+      const billRun = await BillingBatchHelper.add({ fromFinancialYearEnding: 2024, toFinancialYearEnding: 2024 })
+      billRunRegion = billRun.regionId
+    })
+
+    it('returns `false`', async () => {
+      const result = await CheckLiveBillRunService.go(billRunRegion, 'sroc', 'supplementary', 2023)
+
+      expect(result).to.be.false()
+    })
+  })
+})

--- a/test/services/supplementary-billing/check-live-bill-run.service.test.js
+++ b/test/services/supplementary-billing/check-live-bill-run.service.test.js
@@ -14,7 +14,7 @@ const DatabaseHelper = require('../../support/helpers/database.helper.js')
 // Thing under test
 const CheckLiveBillRunService = require('../../../app/services/supplementary-billing/check-live-bill-run.service.js')
 
-describe.only('Check Live Bill Run service', () => {
+describe('Check Live Bill Run service', () => {
   let billRunRegion
 
   beforeEach(async () => {
@@ -29,7 +29,7 @@ describe.only('Check Live Bill Run service', () => {
       })
 
       it('returns `true`', async () => {
-        const result = await CheckLiveBillRunService.go(billRunRegion, 'sroc', 'supplementary', 2023)
+        const result = await CheckLiveBillRunService.go(billRunRegion, 2023)
 
         expect(result).to.be.true()
       })
@@ -42,7 +42,7 @@ describe.only('Check Live Bill Run service', () => {
       })
 
       it('returns `false`', async () => {
-        const result = await CheckLiveBillRunService.go(billRunRegion, 'sroc', 'supplementary', 2023)
+        const result = await CheckLiveBillRunService.go(billRunRegion, 2023)
 
         expect(result).to.be.false()
       })
@@ -56,7 +56,7 @@ describe.only('Check Live Bill Run service', () => {
     })
 
     it('returns `false`', async () => {
-      const result = await CheckLiveBillRunService.go(billRunRegion, 'sroc', 'supplementary', 2023)
+      const result = await CheckLiveBillRunService.go(billRunRegion, 2023)
 
       expect(result).to.be.false()
     })

--- a/test/services/supplementary-billing/initiate-billing-batch.service.test.js
+++ b/test/services/supplementary-billing/initiate-billing-batch.service.test.js
@@ -111,8 +111,7 @@ describe.only('Initiate Billing Batch service', () => {
 
     describe('because a bill run already exists for this region and financial year', () => {
       beforeEach(() => {
-        CheckLiveBillRunService.go.restore()
-        Sinon.stub(CheckLiveBillRunService, 'go').resolves(true)
+        CheckLiveBillRunService.go.resolves(true)
       })
 
       it('rejects with an appropriate error', async () => {

--- a/test/services/supplementary-billing/initiate-billing-batch.service.test.js
+++ b/test/services/supplementary-billing/initiate-billing-batch.service.test.js
@@ -17,11 +17,12 @@ const RegionHelper = require('../../support/helpers/water/region.helper.js')
 // Things we need to stub
 const BillingPeriodService = require('../../../app/services/supplementary-billing/billing-period.service.js')
 const ChargingModuleCreateBillRunService = require('../../../app/services/charging-module/create-bill-run.service.js')
+const CheckLiveBillRunService = require('../../../app/services/supplementary-billing/check-live-bill-run.service.js')
 
 // Thing under test
 const InitiateBillingBatchService = require('../../../app//services/supplementary-billing/initiate-billing-batch.service.js')
 
-describe('Initiate Billing Batch service', () => {
+describe.only('Initiate Billing Batch service', () => {
   const currentBillingPeriod = {
     startDate: new Date('2022-04-01'),
     endDate: new Date('2023-03-31')
@@ -40,6 +41,7 @@ describe('Initiate Billing Batch service', () => {
     }
 
     Sinon.stub(BillingPeriodService, 'go').returns([currentBillingPeriod])
+    Sinon.stub(CheckLiveBillRunService, 'go').resolves(false)
   })
 
   afterEach(() => {
@@ -104,6 +106,19 @@ describe('Initiate Billing Batch service', () => {
 
         expect(err).to.be.an.error()
         expect(err.message).to.equal("403 Forbidden - Unauthorised for regime 'wrls'")
+      })
+    })
+
+    describe('because a bill run already exists for this region and financial year', () => {
+      beforeEach(() => {
+        CheckLiveBillRunService.go.restore()
+        Sinon.stub(CheckLiveBillRunService, 'go').resolves(true)
+      })
+
+      it('rejects with an appropriate error', async () => {
+        const err = await expect(InitiateBillingBatchService.go(validatedRequestData)).to.reject()
+
+        expect(err).to.be.an.error()
       })
     })
 

--- a/test/services/supplementary-billing/initiate-billing-batch.service.test.js
+++ b/test/services/supplementary-billing/initiate-billing-batch.service.test.js
@@ -22,7 +22,7 @@ const CheckLiveBillRunService = require('../../../app/services/supplementary-bil
 // Thing under test
 const InitiateBillingBatchService = require('../../../app//services/supplementary-billing/initiate-billing-batch.service.js')
 
-describe.only('Initiate Billing Batch service', () => {
+describe('Initiate Billing Batch service', () => {
   const currentBillingPeriod = {
     startDate: new Date('2022-04-01'),
     endDate: new Date('2023-03-31')
@@ -118,6 +118,7 @@ describe.only('Initiate Billing Batch service', () => {
         const err = await expect(InitiateBillingBatchService.go(validatedRequestData)).to.reject()
 
         expect(err).to.be.an.error()
+        expect(err.message).to.equal(`Batch already live for region ${validatedRequestData.region}`)
       })
     })
 

--- a/test/services/supplementary-billing/initiate-billing-batch.service.test.js
+++ b/test/services/supplementary-billing/initiate-billing-batch.service.test.js
@@ -107,7 +107,7 @@ describe('Initiate Billing Batch service', () => {
       })
     })
 
-    describe('and the error doesn\'t include a messge', () => {
+    describe('and the error doesn\'t include a message', () => {
       beforeEach(() => {
         Sinon.stub(ChargingModuleCreateBillRunService, 'go').resolves({
           succeeded: false,


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3875

The legacy system will not create a presroc bill run if one exists that is "live" (ie. has a status of `processing`, `ready` or `review`) with the same region, financial year and type. The same logic needs to be implemented for sroc supplementary bill runs (adding our new `queued` status to the list of statuses we consider to be "live").

We do this by creating `CheckLiveBillRunService`, which takes a region id and financial year and returns a boolean to indicate whether there are any "live" bill runs. We then call this from `InitiateBillingBatchService` and throw an error if it returns `true`. Note that we give the error the same message that the `water-abstraction-service` has but we don't format it as a `409` error.