### PR TITLE
Flag bill runs as errored on CHA failure

### DIFF
--- a/test/services/supplementary-billing/initiate-billing-batch.service.test.js
+++ b/test/services/supplementary-billing/initiate-billing-batch.service.test.js
@@ -90,22 +90,43 @@ describe('Initiate Billing Batch service', () => {
 
   describe('when initiating a billing batch fails', () => {
     describe('because a bill run could not be created in the Charging Module', () => {
-      beforeEach(() => {
-        Sinon.stub(ChargingModuleCreateBillRunService, 'go').resolves({
-          succeeded: false,
-          response: {
-            statusCode: 403,
-            error: 'Forbidden',
-            message: "Unauthorised for regime 'wrls'"
-          }
+      describe('and the error includes a message', () => {
+        beforeEach(() => {
+          Sinon.stub(ChargingModuleCreateBillRunService, 'go').resolves({
+            succeeded: false,
+            response: {
+              statusCode: 403,
+              error: 'Forbidden',
+              message: "Unauthorised for regime 'wrls'"
+            }
+          })
+        })
+
+        it('rejects with an appropriate error', async () => {
+          const err = await expect(InitiateBillingBatchService.go(validatedRequestData)).to.reject()
+
+          expect(err).to.be.an.error()
+          expect(err.message).to.equal("403 Forbidden - Unauthorised for regime 'wrls'")
         })
       })
 
-      it('rejects with an appropriate error', async () => {
-        const err = await expect(InitiateBillingBatchService.go(validatedRequestData)).to.reject()
+      describe('and the error does not include a message', () => {
+        beforeEach(() => {
+          Sinon.stub(ChargingModuleCreateBillRunService, 'go').resolves({
+            succeeded: false,
+            response: {
+              statusCode: 403,
+              error: 'Forbidden'
+            }
+          })
+        })
 
-        expect(err).to.be.an.error()
-        expect(err.message).to.equal("403 Forbidden - Unauthorised for regime 'wrls'")
+        it('rejects with an appropriate error', async () => {
+          const err = await expect(InitiateBillingBatchService.go(validatedRequestData)).to.reject()
+
+          expect(err).to.be.an.error()
+          expect(err.message).to.equal('403 Forbidden')
+        })
       })
     })
 
@@ -119,25 +140,6 @@ describe('Initiate Billing Batch service', () => {
 
         expect(err).to.be.an.error()
         expect(err.message).to.equal(`Batch already live for region ${validatedRequestData.region}`)
-      })
-    })
-
-    describe('and the error doesn\'t include a message', () => {
-      beforeEach(() => {
-        Sinon.stub(ChargingModuleCreateBillRunService, 'go').resolves({
-          succeeded: false,
-          response: {
-            statusCode: 403,
-            error: 'Forbidden'
-          }
-        })
-      })
-
-      it('rejects with an appropriate error', async () => {
-        const err = await expect(InitiateBillingBatchService.go(validatedRequestData)).to.reject()
-
-        expect(err).to.be.an.error()
-        expect(err.message).to.equal('403 Forbidden')
       })
     })
   })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3833

If we fail to create the bill run in the [Charging Module API](https://github.com/DEFRA/sroc-charging-module-api) we are currently handling the error. We ensure the app doesn't fall over, the issue gets logged and a `5xx` is returned to the client.

What we are not doing is updating the `billing_batch` we created with a status of error. This means as far as the UI is concerned it's **QUEUED** waiting to be processed.

This change updates the `billing_batch` record if the request to the CHA fails so that it correctly shows as errored in the UI.