### PR TITLE
Fix CHA CreateBillRunService result parsing

### DIFF
--- a/app/services/charging-module/create-bill-run.service.js
+++ b/app/services/charging-module/create-bill-run.service.js
@@ -60,8 +60,8 @@ function _parseResult (result) {
 
   // If the request got a response from the Charging Module we will have a response body. If the request errored, for
   // example a timeout because the Charging Module is down, response will be the instance of the error thrown by Got.
-  if (result.response.body) {
-    const parsedBody = JSON.parse(result.response.body)
+  if (response.body) {
+    const parsedBody = JSON.parse(response.body)
     response = result.succeeded ? parsedBody.billRun : parsedBody
   }
 

--- a/app/services/charging-module/create-bill-run.service.js
+++ b/app/services/charging-module/create-bill-run.service.js
@@ -63,8 +63,6 @@ function _parseResult (result) {
   if (result.response.body) {
     const parsedBody = JSON.parse(result.response.body)
     response = result.succeeded ? parsedBody.billRun : parsedBody
-  } else {
-    response = result.response
   }
 
   return {

--- a/app/services/charging-module/create-bill-run.service.js
+++ b/app/services/charging-module/create-bill-run.service.js
@@ -56,11 +56,16 @@ async function _getChargeRegionId (regionId) {
 }
 
 function _parseResult (result) {
-  const parsedBody = JSON.parse(result.response.body)
+  let response = result.response
 
-  // If the request succeeded then we return the bill run in the response; otherwise, we simply return the entire body
-  // as this includes the status code and error messages
-  const response = result.succeeded ? parsedBody.billRun : parsedBody
+  // If the request got a response from the Charging Module we will have a response body. If the request errored, for
+  // example a timeout because the Charging Module is down, response will be the instance of the error thrown by Got.
+  if (result.response.body) {
+    const parsedBody = JSON.parse(result.response.body)
+    response = result.succeeded ? parsedBody.billRun : parsedBody
+  } else {
+    response = result.response
+  }
 
   return {
     succeeded: result.succeeded,


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3833

Found when working on [Add GlobalNotifier to the app](https://github.com/DEFRA/water-abstraction-system/pull/100). If we get an error response from the [SROC Charging Module API](https://github.com/DEFRA/sroc-charging-module-api) we are able to parse the result without issue. This is because it will have a JSON body.

But if **Got** throws an exception, which it will do if it fails to get a response, for example, when the request times out then `result.response` won't have a `body` property.

This is causing the `_parseResult()` method to throw an error; `Unexpected token u in JSON at position 0`.

This change updates `_parseResult()` in `CreateBillRunService` to be able to handle both scenarios.