### PR TITLE
Add support for versioning the repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "rollback:db:test": "NODE_ENV=test knex migrate:rollback --all",
     "lint": "standard",
     "test": "lab --silent-skips --shuffle",
-    "postinstall": "npm run build"
+    "postinstall": "npm run build",
+    "version": "npx --yes auto-changelog -p --commit-limit false && git add CHANGELOG.md"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
As a team, we have a documented release process [that includes bumping the version of the repo](https://github.com/DEFRA/water-abstraction-team/blob/main/releasing/sign_off.md#bump-version).

We use [npm version](https://docs.npmjs.com/cli/v9/commands/npm-version) to do this and use a post-version hook to generate our CHANGELOG. We've just spotted that this repo doesn't have that hook so this change adds it in.