### PR TITLE
Generate Billing Invoice Licence record for SROC

### DIFF
--- a/app/services/supplementary-billing/create-billing-invoice-licence.service.js
+++ b/app/services/supplementary-billing/create-billing-invoice-licence.service.js
@@ -1,0 +1,34 @@
+'use strict'
+
+/**
+ * Creates a billing invoice licence record
+ *
+ * @module CreateBillingInvoiceLicenceService
+ */
+
+const BillingInvoiceLicenceModel = require('../../models/water/billing-invoice-licence.model.js')
+
+/**
+ * Create a billing invoice licence record for the provided billing invoice and licence
+ *
+ * @param {module:BillingInvoiceModel} billingInvoice An instance of `BillingInvoiceModel`
+ * @param {module:licenceModel} licence An instance of `LicenceModel`
+ *
+ * @returns {Object} The newly-created billing invoice licence record
+ */
+async function go (billingInvoice, licence) {
+  const event = await BillingInvoiceLicenceModel.query()
+    .insert({
+      billingInvoiceId: billingInvoice.billingInvoiceId,
+      licenceRef: licence.licenceRef,
+      licenceId: licence.licenceId
+
+    })
+    .returning('*')
+
+  return event
+}
+
+module.exports = {
+  go
+}

--- a/app/services/supplementary-billing/create-billing-invoice-licence.service.js
+++ b/app/services/supplementary-billing/create-billing-invoice-licence.service.js
@@ -22,7 +22,6 @@ async function go (billingInvoice, licence) {
       billingInvoiceId: billingInvoice.billingInvoiceId,
       licenceRef: licence.licenceRef,
       licenceId: licence.licenceId
-
     })
     .returning('*')
 

--- a/test/services/supplementary-billing/create-billing-invoice-licence.service.test.js
+++ b/test/services/supplementary-billing/create-billing-invoice-licence.service.test.js
@@ -16,7 +16,7 @@ const DatabaseHelper = require('../../support/helpers/database.helper.js')
 // Thing under test
 const CreateBillingInvoiceLicenceService = require('../../../app/services/supplementary-billing/create-billing-invoice-licence.service.js')
 
-describe.only('Create Billing Invoice Licence service', () => {
+describe('Create Billing Invoice Licence service', () => {
   beforeEach(async () => {
     await DatabaseHelper.clean()
   })

--- a/test/services/supplementary-billing/create-billing-invoice-licence.service.test.js
+++ b/test/services/supplementary-billing/create-billing-invoice-licence.service.test.js
@@ -1,0 +1,43 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const BillingBatchHelper = require('../../support/helpers/water/billing-invoice.helper.js')
+const BillingInvoiceLicenceModel = require('../../../app/models/water/billing-invoice-licence.model.js')
+const LicenceHelper = require('../../support/helpers/water/licence.helper.js')
+const DatabaseHelper = require('../../support/helpers/database.helper.js')
+
+// Thing under test
+const CreateBillingInvoiceLicenceService = require('../../../app/services/supplementary-billing/create-billing-invoice-licence.service.js')
+
+describe.only('Create Billing Invoice Licence service', () => {
+  beforeEach(async () => {
+    await DatabaseHelper.clean()
+  })
+
+  describe('when a BillingBatchModel instance is provided', () => {
+    let billingInvoice
+    let licence
+
+    beforeEach(async () => {
+      billingInvoice = await BillingBatchHelper.add()
+      licence = await LicenceHelper.add()
+    })
+
+    it('creates an event record', async () => {
+      const result = await CreateBillingInvoiceLicenceService.go(billingInvoice, licence)
+
+      expect(result).to.be.an.instanceOf(BillingInvoiceLicenceModel)
+
+      expect(result.billingInvoiceId).to.equal(billingInvoice.billingInvoiceId)
+      expect(result.licenceRef).to.equal(licence.licenceRef)
+      expect(result.licenceId).to.equal(licence.licenceId)
+    })
+  })
+})

--- a/test/services/supplementary-billing/create-billing-invoice-licence.service.test.js
+++ b/test/services/supplementary-billing/create-billing-invoice-licence.service.test.js
@@ -30,7 +30,7 @@ describe('Create Billing Invoice Licence service', () => {
       licence = await LicenceHelper.add()
     })
 
-    it('creates an event record', async () => {
+    it('returns the new billing invoice licence instance', async () => {
       const result = await CreateBillingInvoiceLicenceService.go(billingInvoice, licence)
 
       expect(result).to.be.an.instanceOf(BillingInvoiceLicenceModel)


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3897

In order to 'piggy-back' onto the existing functions in the legacy service for reviewing, confirming, sending, viewing, deleting a bill run etc we need to create the same base database records as it does for a Bill run. As part of this we need to generate`billing_invoice_licence` entities, which link billing invoices with licences. We already have this entity so this PR implements `CreateBillingInvoiceLicenceService` which can create these.