### PR TITLE
Create `ChargingModuleRequestLib`

### DIFF
--- a/.labrc.js
+++ b/.labrc.js
@@ -18,6 +18,8 @@ module.exports = {
     'GLOBAL_AGENT','ROARR',
     // GlobalNotifier is added by us a global in a server plugin. It's how we make logging available anywhere in the app
     // whilst avoiding having to pass it around
-    'GlobalNotifier'
+    'GlobalNotifier',
+    // HapiServerMethods is added by us in a server plugin to allow us to access server methods globally.
+    'HapiServerMethods'
   ].join(',')
 }

--- a/app/lib/charging-module-request.lib.js
+++ b/app/lib/charging-module-request.lib.js
@@ -1,0 +1,78 @@
+'use strict'
+
+/**
+ * Use for making http requests to other services
+ * @module ChargingModuleRequestLib
+ */
+
+const ChargingModuleTokenService = require('../services/charging-module/token.service.js')
+const RequestLib = require('./request.lib.js')
+const servicesConfig = require('../../config/services.config.js')
+
+/**
+ *
+ * @param {string} route The route that you wish to connect to
+ * @returns {Object} The result of the request; whether it succeeded and the response or error returned
+ */
+async function get (route) {
+  const url = new URL(route, servicesConfig.chargingModule.url)
+  const authentication = await ChargingModuleTokenService.go()
+  const options = _getOptions(authentication)
+
+  const result = await RequestLib.get(url.href, options)
+
+  return _parseResult(result)
+}
+
+/**
+ *
+ * @param {string} route The route that you wish to connect to
+ * @param {Object} additionalOptions Append to or replace the options passed to Got when making the request
+ * @returns {Object} The result of the request; whether it succeeded and the response or error returned
+ */
+async function post (route, additionalOptions = {}) {
+  const url = new URL(route, servicesConfig.chargingModule.url)
+  const authentication = await ChargingModuleTokenService.go()
+  const options = _postOptions(authentication, additionalOptions)
+
+  const result = await RequestLib.post(url.href, options)
+
+  return _parseResult(result)
+}
+
+function _getOptions (authentication) {
+  return {
+    headers: {
+      authorization: `Bearer ${authentication.accessToken}`
+    }
+  }
+}
+
+function _postOptions (authentication, additionalOptions) {
+  return {
+    headers: {
+      authorization: `Bearer ${authentication.accessToken}`
+    },
+    json: additionalOptions
+  }
+}
+
+function _parseResult (result) {
+  let response = result.response
+
+  // If the request got a response from the Charging Module we will have a response body. If the request errored, for
+  // example a timeout because the Charging Module is down, response will be the instance of the error thrown by Got.
+  if (response.body) {
+    response = JSON.parse(response.body)
+  }
+
+  return {
+    succeeded: result.succeeded,
+    response
+  }
+}
+
+module.exports = {
+  get,
+  post
+}

--- a/app/lib/charging-module-request.lib.js
+++ b/app/lib/charging-module-request.lib.js
@@ -45,18 +45,19 @@ async function post (route, body = {}) {
 async function _sendRequest (route, method, body = {}) {
   const url = new URL(route, servicesConfig.chargingModule.url)
   const authentication = await ChargingModuleTokenService.go()
+  const options = _requestOptions(authentication.accessToken, body)
 
-  const result = await method(url.href, {
-    headers: _authorizationHeader(authentication.accessToken),
-    json: body
-  })
+  const result = await method(url.href, options)
 
   return result
 }
 
-function _authorizationHeader (accessToken) {
+function _requestOptions (accessToken, body) {
   return {
-    authorization: `Bearer ${accessToken}`
+    headers: {
+      authorization: `Bearer ${accessToken}`
+    },
+    json: body
   }
 }
 

--- a/app/lib/charging-module-request.lib.js
+++ b/app/lib/charging-module-request.lib.js
@@ -1,7 +1,7 @@
 'use strict'
 
 /**
- * Use for making http requests to other services
+ * Use for making http requests to the Charging Module
  * @module ChargingModuleRequestLib
  */
 
@@ -11,8 +11,11 @@ const servicesConfig = require('../../config/services.config.js')
 /**
  * Sends a GET request to the Charging Module for the provided route
  *
- * @param {string} route The route that you wish to connect to
- * @returns {Object} The result of the request; whether it succeeded and the response or error returned
+ * @param {string} route The route to send the request to
+ *
+ * @returns {Object} result An object representing the result of the request
+ * @returns {boolean} result.succeeded Whether the request was successful
+ * @returns {Object} result.response The Charging Module response if successful; or the error response if not
  */
 async function get (route) {
   const result = await _sendRequest(route, RequestLib.get)
@@ -23,9 +26,12 @@ async function get (route) {
 /**
  * Sends a POST request to the Charging Module for the provided route
  *
- * @param {string} route The route that you wish to connect to
- * @param {Object} body Body of the request which will be sent to the route as json
- * @returns {Object} The result of the request; whether it succeeded and the response or error returned
+ * @param {string} route The route to send the request to
+ * @param {Object} [body] The body of the request
+ *
+ * @returns {Object} result An object representing the result of the request
+ * @returns {boolean} result.succeeded Whether the request was successful
+ * @returns {Object} result.response The Charging Module response if successful; or the error response if not
  */
 async function post (route, body = {}) {
   const result = await _sendRequest(route, RequestLib.post, body)
@@ -36,10 +42,11 @@ async function post (route, body = {}) {
 /**
  * Sends a request to the Charging Module to the provided using the provided RequestLib method
  *
- * @param {string} route
+ * @param {string} route The route that you wish to connect to
  * @param {Object} method An instance of a RequestLib method which will be used to send the request
  * @param {Object} [body] Optional body to be sent to the route as json
- * @returns
+ *
+ * @returns {Object} The result of the request passed back from RequestLib
  */
 async function _sendRequest (route, method, body = {}) {
   const url = new URL(route, servicesConfig.chargingModule.url)
@@ -60,6 +67,9 @@ function _requestOptions (accessToken, body) {
   }
 }
 
+/**
+ * Parses the response from RequestLib. If the response contains a body then we convert it from JSON to an object.
+ */
 function _parseResult (result) {
   let response = result.response
 

--- a/app/lib/charging-module-request.lib.js
+++ b/app/lib/charging-module-request.lib.js
@@ -5,7 +5,6 @@
  * @module ChargingModuleRequestLib
  */
 
-const ChargingModuleTokenService = require('../services/charging-module/token.service.js')
 const RequestLib = require('./request.lib.js')
 const servicesConfig = require('../../config/services.config.js')
 
@@ -44,7 +43,7 @@ async function post (route, body = {}) {
  */
 async function _sendRequest (route, method, body = {}) {
   const url = new URL(route, servicesConfig.chargingModule.url)
-  const authentication = await ChargingModuleTokenService.go()
+  const authentication = await global.HapiServerMethods.getChargingModuleToken()
   const options = _requestOptions(authentication.accessToken, body)
 
   const result = await method(url.href, options)

--- a/app/lib/charging-module-request.lib.js
+++ b/app/lib/charging-module-request.lib.js
@@ -47,9 +47,7 @@ async function _sendRequest (route, method, body = {}) {
   const authentication = await ChargingModuleTokenService.go()
 
   const result = await method(url.href, {
-    headers: {
-      ..._authorizationHeader(authentication.accessToken)
-    },
+    headers: _authorizationHeader(authentication.accessToken),
     json: body
   })
 

--- a/app/plugins/global-hapi-server-methods.plugin.js
+++ b/app/plugins/global-hapi-server-methods.plugin.js
@@ -2,6 +2,11 @@
 
 /**
  * Plugin to add Hapi server methods to the global object
+ *
+ * The advantage of server methods is that their output can be cached. From our tests we have seen that accessing them
+ * via `server.methods` and `global.HapiServerMethods` makes use of the same cache. Nevertheless, for consistency we
+ * should only access them via `global.HapiServerMethods` even when the server object is available to us.
+ *
  * @module GlobalHapiServerMethods
  */
 

--- a/app/plugins/global-hapi-server-methods.plugin.js
+++ b/app/plugins/global-hapi-server-methods.plugin.js
@@ -1,0 +1,15 @@
+'use strict'
+
+/**
+ * Plugin to add Hapi server methods to the global object
+ * @module GlobalHapiServerMethods
+ */
+
+const GlobalHapiServerMethods = {
+  name: 'global-hapi-server-methods',
+  register: (server, _options) => {
+    global.HapiServerMethods = server.methods
+  }
+}
+
+module.exports = GlobalHapiServerMethods

--- a/app/server.js
+++ b/app/server.js
@@ -6,6 +6,7 @@ const AirbrakePlugin = require('./plugins/airbrake.plugin.js')
 const BlippPlugin = require('./plugins/blipp.plugin.js')
 const ChargingModuleTokenCachePlugin = require('./plugins/charging-module-token-cache.plugin.js')
 const ErrorPagesPlugin = require('./plugins/error-pages.plugin.js')
+const GlobalHapiServerMethodsPlugin = require('./plugins/global-hapi-server-methods.plugin.js')
 const GlobalNotifierPlugin = require('./plugins/global-notifier.plugin.js')
 const HapiPinoPlugin = require('./plugins/hapi-pino.plugin.js')
 const RequestNotifierPlugin = require('./plugins/request-notifier.plugin.js')
@@ -27,6 +28,7 @@ const registerPlugins = async (server) => {
   await server.register(ErrorPagesPlugin)
   await server.register(RequestNotifierPlugin)
   await server.register(ViewsPlugin)
+  await server.register(GlobalHapiServerMethodsPlugin)
 
   // Register non-production plugins
   if (ServerConfig.environment === 'development') {

--- a/test/lib/charging-module-request.lib.test.js
+++ b/test/lib/charging-module-request.lib.test.js
@@ -32,26 +32,26 @@ describe.only('ChargingModuleRequestLib', () => {
   describe('#get', () => {
     let result
 
-    beforeEach(async () => {
-      Sinon.stub(RequestLib, 'get').resolves({
-        succeeded: true,
-        response: {
-          statusCode: 200,
-          body: '{"testObject": {"test": "yes"}}'
-        }
+    describe('when the request succeeds', () => {
+      beforeEach(async () => {
+        Sinon.stub(RequestLib, 'get').resolves({
+          succeeded: true,
+          response: {
+            statusCode: 200,
+            body: '{"testObject": {"test": "yes"}}'
+          }
+        })
+
+        result = await ChargingModuleRequestLib.get(testRoute)
       })
 
-      result = await ChargingModuleRequestLib.get(testRoute)
-    })
+      it('calls the Charging Module with the required options', async () => {
+        const requestArgs = RequestLib.get.firstCall.args
 
-    it('calls the Charging Module with the required options', async () => {
-      const requestArgs = RequestLib.get.firstCall.args
+        expect(requestArgs[0]).to.endWith('/TEST_ROUTE')
+        expect(requestArgs[1].headers).to.include({ authorization: 'Bearer ACCESS_TOKEN' })
+      })
 
-      expect(requestArgs[0]).to.endWith('/TEST_ROUTE')
-      expect(requestArgs[1].headers).to.include({ authorization: 'Bearer ACCESS_TOKEN' })
-    })
-
-    describe('when the request succeeds', () => {
       it('returns a `true` success status', async () => {
         expect(result.succeeded).to.be.true()
       })
@@ -60,6 +60,30 @@ describe.only('ChargingModuleRequestLib', () => {
         const { response } = result
 
         expect(response.testObject.test).to.equal('yes')
+      })
+    })
+
+    describe('when the request fails', () => {
+      beforeEach(async () => {
+        Sinon.stub(RequestLib, 'get').resolves({
+          succeeded: false,
+          response: {
+            statusCode: 400,
+            testError: 'TEST_ERROR'
+          }
+        })
+
+        result = await ChargingModuleRequestLib.get(testRoute)
+      })
+
+      it('returns a `false` success status', async () => {
+        expect(result.succeeded).to.be.false()
+      })
+
+      it('returns the error response', async () => {
+        const { response } = result
+
+        expect(response.testError).to.equal('TEST_ERROR')
       })
     })
   })
@@ -67,27 +91,27 @@ describe.only('ChargingModuleRequestLib', () => {
   describe('#post', () => {
     let result
 
-    beforeEach(async () => {
-      Sinon.stub(RequestLib, 'post').resolves({
-        succeeded: true,
-        response: {
-          statusCode: 200,
-          body: '{"testObject": {"test": "yes"}}'
-        }
+    describe('when the request succeeds', () => {
+      beforeEach(async () => {
+        Sinon.stub(RequestLib, 'post').resolves({
+          succeeded: true,
+          response: {
+            statusCode: 200,
+            body: '{"testObject": {"test": "yes"}}'
+          }
+        })
+
+        result = await ChargingModuleRequestLib.post(testRoute, { test: true })
       })
 
-      result = await ChargingModuleRequestLib.post(testRoute, { test: true })
-    })
+      it('calls the Charging Module with the required options', async () => {
+        const requestArgs = RequestLib.post.firstCall.args
 
-    it('calls the Charging Module with the required options', async () => {
-      const requestArgs = RequestLib.post.firstCall.args
+        expect(requestArgs[0]).to.endWith('/TEST_ROUTE')
+        expect(requestArgs[1].headers).to.include({ authorization: 'Bearer ACCESS_TOKEN' })
+        expect(requestArgs[1].json).to.include({ test: true })
+      })
 
-      expect(requestArgs[0]).to.endWith('/TEST_ROUTE')
-      expect(requestArgs[1].headers).to.include({ authorization: 'Bearer ACCESS_TOKEN' })
-      expect(requestArgs[1].json).to.include({ test: true })
-    })
-
-    describe('when the request succeeds', () => {
       it('returns a `true` success status', async () => {
         expect(result.succeeded).to.be.true()
       })
@@ -96,6 +120,30 @@ describe.only('ChargingModuleRequestLib', () => {
         const { response } = result
 
         expect(response.testObject.test).to.equal('yes')
+      })
+    })
+
+    describe('when the request fails', () => {
+      beforeEach(async () => {
+        Sinon.stub(RequestLib, 'post').resolves({
+          succeeded: false,
+          response: {
+            statusCode: 400,
+            testError: 'TEST_ERROR'
+          }
+        })
+
+        result = await ChargingModuleRequestLib.post(testRoute, { test: true })
+      })
+
+      it('returns a `false` success status', async () => {
+        expect(result.succeeded).to.be.false()
+      })
+
+      it('returns the error response', async () => {
+        const { response } = result
+
+        expect(response.testError).to.equal('TEST_ERROR')
       })
     })
   })

--- a/test/lib/charging-module-request.lib.test.js
+++ b/test/lib/charging-module-request.lib.test.js
@@ -5,11 +5,10 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, beforeEach, afterEach } = exports.lab = Lab.script()
+const { describe, it, before, beforeEach, after, afterEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Things we need to stub
-const ChargingModuleTokenService = require('../../app/services/charging-module/token.service.js')
 const RequestLib = require('../../app/lib/request.lib.js')
 
 // Thing under test
@@ -18,15 +17,23 @@ const ChargingModuleRequestLib = require('../../app/lib/charging-module-request.
 describe.only('ChargingModuleRequestLib', () => {
   const testRoute = 'TEST_ROUTE'
 
-  beforeEach(async () => {
-    Sinon.stub(ChargingModuleTokenService, 'go').resolves({
-      accessToken: 'ACCESS_TOKEN',
-      expiresIn: 3600
-    })
+  before(async () => {
+    // ChargingModuleRequestLib makes use of the getChargingModuleToken() server method, which we therefore need to stub
+    global.HapiServerMethods = {
+      getChargingModuleToken: Sinon.stub().resolves({
+        accessToken: 'ACCESS_TOKEN',
+        expiresIn: 3600
+      })
+    }
   })
 
   afterEach(() => {
     Sinon.restore()
+  })
+
+  after(() => {
+    // Tidy up our global server methods stub once done
+    delete global.HapiServerMethods
   })
 
   describe('#get', () => {

--- a/test/lib/charging-module-request.lib.test.js
+++ b/test/lib/charging-module-request.lib.test.js
@@ -1,0 +1,102 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { describe, it, beforeEach, afterEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Things we need to stub
+const ChargingModuleTokenService = require('../../app/services/charging-module/token.service.js')
+const RequestLib = require('../../app/lib/request.lib.js')
+
+// Thing under test
+const ChargingModuleRequestLib = require('../../app/lib/charging-module-request.lib.js')
+
+describe.only('ChargingModuleRequestLib', () => {
+  const testRoute = 'TEST_ROUTE'
+
+  beforeEach(async () => {
+    Sinon.stub(ChargingModuleTokenService, 'go').resolves({
+      accessToken: 'ACCESS_TOKEN',
+      expiresIn: 3600
+    })
+  })
+
+  afterEach(() => {
+    Sinon.restore()
+  })
+
+  describe('#get', () => {
+    let result
+
+    beforeEach(async () => {
+      Sinon.stub(RequestLib, 'get').resolves({
+        succeeded: true,
+        response: {
+          statusCode: 200,
+          body: '{"testObject": {"test": "yes"}}'
+        }
+      })
+
+      result = await ChargingModuleRequestLib.get(testRoute)
+    })
+
+    it('calls the Charging Module with the required options', async () => {
+      const requestArgs = RequestLib.get.firstCall.args
+
+      expect(requestArgs[0]).to.endWith('/TEST_ROUTE')
+      expect(requestArgs[1].headers).to.include({ authorization: 'Bearer ACCESS_TOKEN' })
+    })
+
+    describe('when the request succeeds', () => {
+      it('returns a `true` success status', async () => {
+        expect(result.succeeded).to.be.true()
+      })
+
+      it('returns the response as an object', async () => {
+        const { response } = result
+
+        expect(response.testObject.test).to.equal('yes')
+      })
+    })
+  })
+
+  describe('#post', () => {
+    let result
+
+    beforeEach(async () => {
+      Sinon.stub(RequestLib, 'post').resolves({
+        succeeded: true,
+        response: {
+          statusCode: 200,
+          body: '{"testObject": {"test": "yes"}}'
+        }
+      })
+
+      result = await ChargingModuleRequestLib.post(testRoute, { test: true })
+    })
+
+    it('calls the Charging Module with the required options', async () => {
+      const requestArgs = RequestLib.post.firstCall.args
+
+      expect(requestArgs[0]).to.endWith('/TEST_ROUTE')
+      expect(requestArgs[1].headers).to.include({ authorization: 'Bearer ACCESS_TOKEN' })
+      expect(requestArgs[1].json).to.include({ test: true })
+    })
+
+    describe('when the request succeeds', () => {
+      it('returns a `true` success status', async () => {
+        expect(result.succeeded).to.be.true()
+      })
+
+      it('returns the response as an object', async () => {
+        const { response } = result
+
+        expect(response.testObject.test).to.equal('yes')
+      })
+    })
+  })
+})

--- a/test/lib/charging-module-request.lib.test.js
+++ b/test/lib/charging-module-request.lib.test.js
@@ -14,7 +14,7 @@ const RequestLib = require('../../app/lib/request.lib.js')
 // Thing under test
 const ChargingModuleRequestLib = require('../../app/lib/charging-module-request.lib.js')
 
-describe.only('ChargingModuleRequestLib', () => {
+describe('ChargingModuleRequestLib', () => {
   const testRoute = 'TEST_ROUTE'
 
   before(async () => {

--- a/test/lib/charging-module-request.lib.test.js
+++ b/test/lib/charging-module-request.lib.test.js
@@ -19,6 +19,7 @@ describe('ChargingModuleRequestLib', () => {
 
   before(async () => {
     // ChargingModuleRequestLib makes use of the getChargingModuleToken() server method, which we therefore need to stub
+    // Note that we only need to do this once as it is unaffected by the Sinon.restore() in our afterEach()
     global.HapiServerMethods = {
       getChargingModuleToken: Sinon.stub().resolves({
         accessToken: 'ACCESS_TOKEN',


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3903

Currently we have `RequestLib` which we use to make requests to external services. Having developed code which sends requests to the Charging Module we can see that there will be things we need to do which will be common to all CM requests -- for example, obtaining an access token, formatting the response in a particular way, etc.

Before we go any further with developing more services which send requests to the CM we want to create a general `ChargingModuleRequestLib` which will do all of this for us, allowing our services to concentrate on what they actually need to do and not all the stuff surrounding the requests.

This PR implements `ChargingModuleRequestLib` and two initial methods, `get` and `post`.

As part of this, we want to access our server method `getChargingModuleToken()` to ensure that Cognito tokens are cached for all requests. In order to do this without passing the `server` object around from one service to another, we introduce a new `GlobalHapiServerMethodsPlugin`, which adds the Hapi server methods object to the global object, allowing us to access them from anywhere; this means we can get a token by calling `global.HapiServerMethods.getChargingModuleToken()`. In testing we confirmed that calling this and calling `server.methods.getChargingModuleToken()` gives the same token; however, for consistency we intend to use `global.HapiServerMethods.getChargingModuleToken()` at all times.

Note that existing code which sends requests to the CM will be updated in a separate PR.