### PR TITLE
Add change_reason model to water-abstraction-system

### DIFF
--- a/app/models/water/change-reason.model.js
+++ b/app/models/water/change-reason.model.js
@@ -1,0 +1,42 @@
+'use strict'
+
+/**
+ * Model for changeReasons
+ * @module ChangeReasonModel
+ */
+
+const { Model } = require('objection')
+
+const WaterBaseModel = require('./water-base.model.js')
+
+class ChangeReasonModel extends WaterBaseModel {
+  static get tableName () {
+    return 'changeReasons'
+  }
+
+  static get idColumn () {
+    return 'changeReasonId'
+  }
+
+  static get translations () {
+    return [
+      { database: 'dateCreated', model: 'createdAt' },
+      { database: 'dateUpdated', model: 'updatedAt' }
+    ]
+  }
+
+  static get relationMappings () {
+    return {
+      chargeVersions: {
+        relation: Model.HasManyRelation,
+        modelClass: 'charge-version.model',
+        join: {
+          from: 'changeReasons.changeReasonId',
+          to: 'chargeVersions.changeReasonId'
+        }
+      }
+    }
+  }
+}
+
+module.exports = ChangeReasonModel

--- a/app/models/water/charge-version.model.js
+++ b/app/models/water/charge-version.model.js
@@ -35,6 +35,14 @@ class ChargeVersionModel extends WaterBaseModel {
           to: 'licences.licenceId'
         }
       },
+      changeReason: {
+        relation: Model.BelongsToOneRelation,
+        modelClass: 'change-reason.model',
+        join: {
+          from: 'chargeVersions.changeReasonId',
+          to: 'changeReasons.changeReasonId'
+        }
+      },
       chargeElements: {
         relation: Model.HasManyRelation,
         modelClass: 'charge-element.model',

--- a/db/migrations/20230302110453_create-water-change-reasons.js
+++ b/db/migrations/20230302110453_create-water-change-reasons.js
@@ -1,0 +1,30 @@
+'use strict'
+
+const tableName = 'change_reasons'
+
+exports.up = async function (knex) {
+  await knex
+    .schema
+    .withSchema('water')
+    .createTable(tableName, table => {
+      // Primary Key
+      table.uuid('change_reason_id').primary().defaultTo(knex.raw('gen_random_uuid()'))
+
+      // Data
+      table.string('description').notNullable()
+      table.boolean('triggers_minimum_charge').notNullable().defaultTo(false)
+      table.string('type').notNullable()
+      table.boolean('is_enabled_for_new_charge_versions').notNullable()
+
+      // Legacy timestamps
+      table.timestamp('date_created', { useTz: false }).notNullable()
+      table.timestamp('date_updated', { useTz: false })
+    })
+}
+
+exports.down = function (knex) {
+  return knex
+    .schema
+    .withSchema('water')
+    .dropTableIfExists(tableName)
+}

--- a/db/migrations/20230302110745_alter-water-charge-versions.js
+++ b/db/migrations/20230302110745_alter-water-charge-versions.js
@@ -1,0 +1,23 @@
+'use strict'
+
+const tableName = 'charge_versions'
+
+exports.up = async function (knex) {
+  await knex
+    .schema
+    .withSchema('water')
+    .alterTable(tableName, table => {
+      table.uuid('change_reason_id')
+    })
+}
+
+exports.down = async function (knex) {
+  return knex
+    .schema
+    .withSchema('water')
+    .alterTable(tableName, table => {
+      table.dropColumns(
+        'change_reason_id'
+      )
+    })
+}

--- a/test/models/water/change-reason.model.test.js
+++ b/test/models/water/change-reason.model.test.js
@@ -1,0 +1,73 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const ChangeReasonHelper = require('../../support/helpers/water/change-reason.helper.js')
+const ChargeVersionHelper = require('../../support/helpers/water/charge-version.helper.js')
+const ChargeVersionModel = require('../../../app/models/water/charge-version.model.js')
+const DatabaseHelper = require('../../support/helpers/database.helper.js')
+
+// Thing under test
+const ChangeReasonModel = require('../../../app/models/water/change-reason.model.js')
+
+describe('Change Reason model', () => {
+  let testRecord
+
+  beforeEach(async () => {
+    await DatabaseHelper.clean()
+
+    testRecord = await ChangeReasonHelper.add()
+  })
+
+  describe('Basic query', () => {
+    it('can successfully run a basic query', async () => {
+      const result = await ChangeReasonModel.query().findById(testRecord.changeReasonId)
+
+      expect(result).to.be.an.instanceOf(ChangeReasonModel)
+      expect(result.changeReasonId).to.equal(testRecord.changeReasonId)
+    })
+  })
+
+  describe('Relationships', () => {
+    describe('when linking to charge versions', () => {
+      let testChargeVersions
+
+      beforeEach(async () => {
+        const { changeReasonId } = testRecord
+
+        testChargeVersions = []
+        for (let i = 0; i < 2; i++) {
+          const chargeVersion = await ChargeVersionHelper.add({ changeReasonId })
+          testChargeVersions.push(chargeVersion)
+        }
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await ChangeReasonModel.query()
+          .innerJoinRelated('chargeVersions')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the charge versions', async () => {
+        const result = await ChangeReasonModel.query()
+          .findById(testRecord.changeReasonId)
+          .withGraphFetched('chargeVersions')
+
+        expect(result).to.be.instanceOf(ChangeReasonModel)
+        expect(result.changeReasonId).to.equal(testRecord.changeReasonId)
+
+        expect(result.chargeVersions).to.be.an.array()
+        expect(result.chargeVersions[0]).to.be.an.instanceOf(ChargeVersionModel)
+        expect(result.chargeVersions).to.include(testChargeVersions[0])
+        expect(result.chargeVersions).to.include(testChargeVersions[1])
+      })
+    })
+  })
+})

--- a/test/models/water/charge-version.model.test.js
+++ b/test/models/water/charge-version.model.test.js
@@ -8,6 +8,8 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
+const ChangeReasonHelper = require('../../support/helpers/water/change-reason.helper.js')
+const ChangeReasonModel = require('../../../app/models/water/change-reason.model.js')
 const ChargeElementHelper = require('../../support/helpers/water/charge-element.helper.js')
 const ChargeElementModel = require('../../../app/models/water/charge-element.model.js')
 const ChargeVersionHelper = require('../../support/helpers/water/charge-version.helper.js')
@@ -64,6 +66,36 @@ describe('ChargeVersion model', () => {
 
         expect(result.licence).to.be.an.instanceOf(LicenceModel)
         expect(result.licence).to.equal(testLicence)
+      })
+    })
+
+    describe('when linking to change reason', () => {
+      let testChangeReason
+
+      beforeEach(async () => {
+        testChangeReason = await ChangeReasonHelper.add()
+
+        const { changeReasonId } = testChangeReason
+        testRecord = await ChargeVersionHelper.add({ changeReasonId })
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await ChargeVersionModel.query()
+          .innerJoinRelated('changeReason')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the change reason', async () => {
+        const result = await ChargeVersionModel.query()
+          .findById(testRecord.chargeVersionId)
+          .withGraphFetched('changeReason')
+
+        expect(result).to.be.instanceOf(ChargeVersionModel)
+        expect(result.chargeVersionId).to.equal(testRecord.chargeVersionId)
+
+        expect(result.changeReason).to.be.an.instanceOf(ChangeReasonModel)
+        expect(result.changeReason).to.equal(testChangeReason)
       })
     })
 

--- a/test/support/helpers/water/change-reason.helper.js
+++ b/test/support/helpers/water/change-reason.helper.js
@@ -1,0 +1,56 @@
+'use strict'
+
+/**
+ * @module ChangeReasonHelper
+ */
+
+const ChangeReasonModel = require('../../../../app/models/water/change-reason.model.js')
+
+/**
+ * Add a new change reason
+ *
+ * If no `data` is provided, default values will be used. These are
+ *
+ * - `description` - Strategic review of charges (SRoC)
+ * - `type` - new_chargeable_charge_version
+ * - `isEnabledForNewChargeVersions` - true,
+ * - `createdAt` - 2022-02-23
+ *
+ * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ *
+ * @returns {module:ChangeReasonModel} The instance of the newly created record
+ */
+function add (data = {}) {
+  const insertData = defaults(data)
+
+  return ChangeReasonModel.query()
+    .insert({ ...insertData })
+    .returning('*')
+}
+
+/**
+ * Returns the defaults used when creating a new charge purpose
+ *
+ * It will override or append to them any data provided. Mainly used by the `add()` method, we make it available
+ * for use in tests to avoid having to duplicate values.
+ *
+ * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ */
+function defaults (data = {}) {
+  const defaults = {
+    description: 'Strategic review of charges (SRoC)',
+    type: 'new_chargeable_charge_version',
+    isEnabledForNewChargeVersions: true,
+    createdAt: new Date('2022-02-23')
+  }
+
+  return {
+    ...defaults,
+    ...data
+  }
+}
+
+module.exports = {
+  add,
+  defaults
+}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3908

`change_reason` is linked to a charge version record. We have identified it is used to determine if the change triggers a minimum charge.

- add the model
- update relationships
- add unit tests for model
- update charge version model unit tests
- add test helper