### PR TITLE
Update fetch charge versions service in water-abstraction-system

### DIFF
--- a/db/migrations/20230302143311_alter-water-licences.js
+++ b/db/migrations/20230302143311_alter-water-licences.js
@@ -1,0 +1,35 @@
+'use strict'
+
+const tableName = 'licences'
+
+exports.up = async function (knex) {
+  await knex
+    .schema
+    .withSchema('water')
+    .alterTable(tableName, table => {
+      table.boolean('is_water_undertaker')
+      table.jsonb('regions')
+      table.date('start_date')
+      table.date('expired_date')
+      table.date('lapsed_date')
+      table.date('revoked_date')
+      table.boolean('suspend_from_billing')
+    })
+}
+
+exports.down = async function (knex) {
+  return knex
+    .schema
+    .withSchema('water')
+    .alterTable(tableName, table => {
+      table.dropColumns(
+        'is_water_undertaker',
+        'regions',
+        'start_date',
+        'expired_date',
+        'lapsed_date',
+        'revoked_date',
+        'suspend_from_billing'
+      )
+    })
+}

--- a/test/support/helpers/water/licence.helper.js
+++ b/test/support/helpers/water/licence.helper.js
@@ -37,7 +37,8 @@ async function add (data = {}) {
 function defaults (data = {}) {
   const defaults = {
     licenceRef: '01/123',
-    regionId: 'bd114474-790f-4470-8ba4-7b0cc9c225d7'
+    regionId: 'bd114474-790f-4470-8ba4-7b0cc9c225d7',
+    regions: { historicalAreaCode: 'SAAR', regionalChargeArea: 'Southern' }
   }
 
   return {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3910

In order to process charge versions in the SROC supplementary bill run process we’ve needed to update our `FetchChargeVersionsService`.

We’ve had to include new relationships and add additional fields to the results.
- Update the service
- Update tests for the service
- Update dependent tests, for example, `SupplementaryDataService`