### PR TITLE
Fix missing bill run number in batch

### DIFF
--- a/app/services/supplementary-billing/initiate-billing-batch.service.js
+++ b/app/services/supplementary-billing/initiate-billing-batch.service.js
@@ -55,6 +55,7 @@ function _billingBatchOptions (type, scheme, chargingModuleResult) {
 
   if (chargingModuleResult.succeeded) {
     options.externalId = chargingModuleResult.response.body.billRun.id
+    options.billRunNumber = chargingModuleResult.response.body.billRun.billRunNumber
 
     return options
   }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3906

We spotted during testing that the success page after confirming an SROC supplementary bill run displayed an `undefined` (This is in the [water-abstraction-ui](https://github.com/DEFRA/water-abstraction-ui)). What it should have been showing was the bill run number.

This comes from the [Charging Module API](https://github.com/DEFRA/sroc-charging-module-api) in the response after creating the bill run. We found the legacy code saves this but we've overlooked it in our version.

This change fixes this oversight.

<details>
<summary>Screenshot of error</summary>

![Screenshot 2023-03-01 at 14 41 01](https://user-images.githubusercontent.com/1789650/222686780-0333c482-9170-407f-b20e-a88232d5020d.png)

</details>