### PR TITLE
Fix response handling for Charging Module requests

### DIFF
--- a/app/lib/charging-module-request.lib.js
+++ b/app/lib/charging-module-request.lib.js
@@ -64,7 +64,7 @@ function _requestOptions (accessToken, body) {
       authorization: `Bearer ${accessToken}`
     },
     responseType: 'json',
-    body: JSON.stringify(body)
+    json: body
   }
 }
 

--- a/app/lib/charging-module-request.lib.js
+++ b/app/lib/charging-module-request.lib.js
@@ -72,12 +72,16 @@ function _requestOptions (accessToken, body) {
  * Parses the response from RequestLib. If the response contains a body then we convert it from JSON to an object.
  */
 function _parseResult (result) {
-  const { statusCode, body } = result.response
+  const { body, headers, statusCode } = result.response
 
   if (body) {
     return {
       succeeded: result.succeeded,
       response: {
+        info: {
+          gitCommit: headers['x-cma-git-commit'],
+          dockerTag: headers['x-cma-docker-tag']
+        },
         statusCode,
         body
       }

--- a/app/lib/charging-module-request.lib.js
+++ b/app/lib/charging-module-request.lib.js
@@ -11,14 +11,14 @@ const servicesConfig = require('../../config/services.config.js')
 /**
  * Sends a GET request to the Charging Module for the provided route
  *
- * @param {string} route The route to send the request to
+ * @param {string} path The route to send the request to (do not include the starting /)
  *
  * @returns {Object} result An object representing the result of the request
  * @returns {boolean} result.succeeded Whether the request was successful
  * @returns {Object} result.response The Charging Module response if successful or the error response if not
  */
-async function get (route) {
-  const result = await _sendRequest(route, RequestLib.get)
+async function get (path) {
+  const result = await _sendRequest(path, RequestLib.get)
 
   return _parseResult(result)
 }
@@ -26,15 +26,15 @@ async function get (route) {
 /**
  * Sends a POST request to the Charging Module for the provided route
  *
- * @param {string} route The route to send the request to
+ * @param {string} path The path to send the request to (do not include the starting /)
  * @param {Object} [body] The body of the request
  *
  * @returns {Object} result An object representing the result of the request
  * @returns {boolean} result.succeeded Whether the request was successful
  * @returns {Object} result.response The Charging Module response if successful or the error response if not.
  */
-async function post (route, body = {}) {
-  const result = await _sendRequest(route, RequestLib.post, body)
+async function post (path, body = {}) {
+  const result = await _sendRequest(path, RequestLib.post, body)
 
   return _parseResult(result)
 }
@@ -42,18 +42,17 @@ async function post (route, body = {}) {
 /**
  * Sends a request to the Charging Module to the provided using the provided RequestLib method
  *
- * @param {string} route The route that you wish to connect to
+ * @param {string} path The path that you wish to connect to (do not include the starting /)
  * @param {Object} method An instance of a RequestLib method which will be used to send the request
  * @param {Object} [body] Optional body to be sent to the route as json
  *
  * @returns {Object} The result of the request passed back from RequestLib
  */
-async function _sendRequest (route, method, body) {
-  const url = new URL(route, servicesConfig.chargingModule.url)
+async function _sendRequest (path, method, body) {
   const authentication = await global.HapiServerMethods.getChargingModuleToken()
   const options = _requestOptions(authentication.accessToken, body)
 
-  const result = await method(url.href, options)
+  const result = await method(path, options)
 
   return result
 }
@@ -61,9 +60,13 @@ async function _sendRequest (route, method, body) {
 /**
  * Additional options that will be added to the default options used by RequestLib
  *
- * We use it to set the authorization header with the AWS Cognito token on our requests, the body (which is always
- * a JSON object) for our POST requests and the option to tell Got that we expect JSON responses. This means Got will
- * automatically handle parsing the response to a JSON object for us.
+ * We use it to set
+ *
+ * - the base charging module URL for all requests
+ * - the authorization header with the AWS Cognito token on our requests
+ * - the body (which is always a JSON object) for our POST requests
+ * - the option to tell Got that we expect JSON responses. This means Got will automatically handle parsing the
+ *   response to a JSON object for us
  *
  * @param {string} accessToken
  * @param {Object} body
@@ -72,6 +75,7 @@ async function _sendRequest (route, method, body) {
  */
 function _requestOptions (accessToken, body) {
   return {
+    prefixUrl: servicesConfig.chargingModule.url,
     headers: {
       authorization: `Bearer ${accessToken}`
     },

--- a/app/lib/charging-module-request.lib.js
+++ b/app/lib/charging-module-request.lib.js
@@ -15,7 +15,7 @@ const servicesConfig = require('../../config/services.config.js')
  *
  * @returns {Object} result An object representing the result of the request
  * @returns {boolean} result.succeeded Whether the request was successful
- * @returns {Object} result.response The Charging Module response if successful or the error response if not.
+ * @returns {Object} result.response The Charging Module response if successful or the error response if not
  */
 async function get (route) {
   const result = await _sendRequest(route, RequestLib.get)
@@ -69,7 +69,11 @@ function _requestOptions (accessToken, body) {
 }
 
 /**
- * Parses the response from RequestLib. If the response contains a body then we convert it from JSON to an object.
+ * Parses the charging module response returned from RequestLib
+ *
+ * @param {Object} result The result object returned by RequestLib
+ *
+ * @returns {Object} If result was not an error, a parsed version of the response
  */
 function _parseResult (result) {
   const { body, headers, statusCode } = result.response

--- a/app/lib/charging-module-request.lib.js
+++ b/app/lib/charging-module-request.lib.js
@@ -63,6 +63,7 @@ function _requestOptions (accessToken, body) {
     headers: {
       authorization: `Bearer ${accessToken}`
     },
+    responseType: 'json',
     body: JSON.stringify(body)
   }
 }
@@ -71,18 +72,19 @@ function _requestOptions (accessToken, body) {
  * Parses the response from RequestLib. If the response contains a body then we convert it from JSON to an object.
  */
 function _parseResult (result) {
-  const { response } = result
+  const { statusCode, body } = result.response
 
-  // If the request got a response from the Charging Module we will have a response body in JSON format. In this
-  // scenario, we overwrite it with a parsed object.
-  if (response.body) {
-    response.body = JSON.parse(response.body)
+  if (body) {
+    return {
+      succeeded: result.succeeded,
+      response: {
+        statusCode,
+        body
+      }
+    }
   }
 
-  return {
-    succeeded: result.succeeded,
-    response
-  }
+  return result
 }
 
 module.exports = {

--- a/app/lib/charging-module-request.lib.js
+++ b/app/lib/charging-module-request.lib.js
@@ -58,6 +58,18 @@ async function _sendRequest (route, method, body) {
   return result
 }
 
+/**
+ * Additional options that will be added to the default options used by RequestLib
+ *
+ * We use it to set the authorization header with the AWS Cognito token on our requests, the body (which is always
+ * a JSON object) for our POST requests and the option to tell Got that we expect JSON responses. This means Got will
+ * automatically handle parsing the response to a JSON object for us.
+ *
+ * @param {string} accessToken
+ * @param {Object} body
+ *
+ * @returns Charging Module API specific options to be passed to RequestLib
+ */
 function _requestOptions (accessToken, body) {
   return {
     headers: {

--- a/app/services/charging-module/create-bill-run.service.js
+++ b/app/services/charging-module/create-bill-run.service.js
@@ -21,7 +21,7 @@ const ChargingModuleRequestLib = require('../../lib/charging-module-request.lib.
 async function go (regionId, ruleset) {
   const region = await _getChargeRegionId(regionId)
 
-  const result = await ChargingModuleRequestLib.post('/v3/wrls/bill-runs', { region, ruleset })
+  const result = await ChargingModuleRequestLib.post('v3/wrls/bill-runs', { region, ruleset })
 
   return result
 }

--- a/app/services/health/info.service.js
+++ b/app/services/health/info.service.js
@@ -83,7 +83,7 @@ async function _getChargingModuleData () {
   const result = await ChargingModuleRequestLib.get('/status')
 
   if (result.succeeded) {
-    return result.response.headers['x-cma-docker-tag']
+    return result.response.info.dockerTag
   }
 
   return _parseFailedRequestResult(result)

--- a/app/services/health/info.service.js
+++ b/app/services/health/info.service.js
@@ -80,7 +80,8 @@ async function _getAddressFacadeData () {
 }
 
 async function _getChargingModuleData () {
-  const result = await ChargingModuleRequestLib.get('/status')
+  const result = await ChargingModuleRequestLib.get('status')
+  await ChargingModuleRequestLib.post('v3/wrls/bill-runs', { region: 'A', ruleset: 'sroc' })
 
   if (result.succeeded) {
     return result.response.info.dockerTag

--- a/app/services/health/info.service.js
+++ b/app/services/health/info.service.js
@@ -81,7 +81,6 @@ async function _getAddressFacadeData () {
 
 async function _getChargingModuleData () {
   const result = await ChargingModuleRequestLib.get('status')
-  await ChargingModuleRequestLib.post('v3/wrls/bill-runs', { region: 'A', ruleset: 'sroc' })
 
   if (result.succeeded) {
     return result.response.info.dockerTag

--- a/app/services/supplementary-billing/initiate-billing-batch.service.js
+++ b/app/services/supplementary-billing/initiate-billing-batch.service.js
@@ -37,9 +37,9 @@ async function go (billRunRequestData) {
     throw Error(`Batch already live for region ${region}`)
   }
 
-  const chargingModuleBillRun = await ChargingModuleCreateBillRunService.go(region, 'sroc')
+  const chargingModuleResult = await ChargingModuleCreateBillRunService.go(region, 'sroc')
 
-  const billingBatchOptions = _billingBatchOptions(type, scheme, chargingModuleBillRun)
+  const billingBatchOptions = _billingBatchOptions(type, scheme, chargingModuleResult)
   const billingBatch = await CreateBillingBatchService.go(region, billingPeriod, billingBatchOptions)
 
   await CreateBillingBatchEventService.go(billingBatch, user)
@@ -47,14 +47,14 @@ async function go (billRunRequestData) {
   return _response(billingBatch)
 }
 
-function _billingBatchOptions (type, scheme, chargingModuleBillRun) {
+function _billingBatchOptions (type, scheme, chargingModuleResult) {
   const options = {
     scheme,
     batchType: type,
-    externalId: chargingModuleBillRun.response.id
+    externalId: chargingModuleResult.response.body.billRun.id
   }
 
-  if (!chargingModuleBillRun.succeeded) {
+  if (!chargingModuleResult.succeeded) {
     options.status = 'error'
     options.errorCode = BillingBatchModel.errorCodes.failedToCreateBillRun
   }

--- a/app/services/supplementary-billing/initiate-billing-batch.service.js
+++ b/app/services/supplementary-billing/initiate-billing-batch.service.js
@@ -50,14 +50,17 @@ async function go (billRunRequestData) {
 function _billingBatchOptions (type, scheme, chargingModuleResult) {
   const options = {
     scheme,
-    batchType: type,
-    externalId: chargingModuleResult.response.body.billRun.id
+    batchType: type
   }
 
-  if (!chargingModuleResult.succeeded) {
-    options.status = 'error'
-    options.errorCode = BillingBatchModel.errorCodes.failedToCreateBillRun
+  if (chargingModuleResult.succeeded) {
+    options.externalId = chargingModuleResult.response.body.billRun.id
+
+    return options
   }
+
+  options.status = 'error'
+  options.errorCode = BillingBatchModel.errorCodes.failedToCreateBillRun
 
   return options
 }

--- a/test/lib/charging-module-request.lib.test.js
+++ b/test/lib/charging-module-request.lib.test.js
@@ -15,6 +15,10 @@ const RequestLib = require('../../app/lib/request.lib.js')
 const ChargingModuleRequestLib = require('../../app/lib/charging-module-request.lib.js')
 
 describe('ChargingModuleRequestLib', () => {
+  const headers = {
+    'x-cma-git-commit': '273604040a47e0977b0579a0fef0f09726d95e39',
+    'x-cma-docker-tag': 'ghcr.io/defra/sroc-charging-module-api:v0.19.0'
+  }
   const testRoute = 'TEST_ROUTE'
 
   before(async () => {
@@ -45,8 +49,9 @@ describe('ChargingModuleRequestLib', () => {
         Sinon.stub(RequestLib, 'get').resolves({
           succeeded: true,
           response: {
+            headers,
             statusCode: 200,
-            body: '{"testObject": {"test": "yes"}}'
+            body: { testObject: { test: 'yes' } }
           }
         })
 
@@ -56,7 +61,7 @@ describe('ChargingModuleRequestLib', () => {
       it('calls the Charging Module with the required options', async () => {
         const requestArgs = RequestLib.get.firstCall.args
 
-        expect(requestArgs[0]).to.endWith('/TEST_ROUTE')
+        expect(requestArgs[0]).to.endWith('TEST_ROUTE')
         expect(requestArgs[1].headers).to.include({ authorization: 'Bearer ACCESS_TOKEN' })
       })
 
@@ -67,6 +72,17 @@ describe('ChargingModuleRequestLib', () => {
       it('returns the response body as an object', async () => {
         expect(result.response.body.testObject.test).to.equal('yes')
       })
+
+      it('returns the status code', async () => {
+        expect(result.response.statusCode).to.equal(200)
+      })
+
+      it('returns the information about the running Charging Module API', async () => {
+        expect(result.response.info).to.equal({
+          gitCommit: '273604040a47e0977b0579a0fef0f09726d95e39',
+          dockerTag: 'ghcr.io/defra/sroc-charging-module-api:v0.19.0'
+        })
+      })
     })
 
     describe('when the request fails', () => {
@@ -74,9 +90,10 @@ describe('ChargingModuleRequestLib', () => {
         Sinon.stub(RequestLib, 'get').resolves({
           succeeded: false,
           response: {
+            headers,
             statusCode: 404,
             statusMessage: 'Not Found',
-            body: '{"statusCode":404,"error":"Not Found","message":"Not Found"}'
+            body: { statusCode: 404, error: 'Not Found', message: 'Not Found' }
           }
         })
 
@@ -88,7 +105,18 @@ describe('ChargingModuleRequestLib', () => {
       })
 
       it('returns the error response', async () => {
-        expect(result.response.statusMessage).to.equal('Not Found')
+        expect(result.response.body.message).to.equal('Not Found')
+      })
+
+      it('returns the status code', async () => {
+        expect(result.response.statusCode).to.equal(404)
+      })
+
+      it('returns the information about the running Charging Module API', async () => {
+        expect(result.response.info).to.equal({
+          gitCommit: '273604040a47e0977b0579a0fef0f09726d95e39',
+          dockerTag: 'ghcr.io/defra/sroc-charging-module-api:v0.19.0'
+        })
       })
     })
   })
@@ -101,9 +129,9 @@ describe('ChargingModuleRequestLib', () => {
         Sinon.stub(RequestLib, 'post').resolves({
           succeeded: true,
           response: {
+            headers,
             statusCode: 200,
-            statusMessage: 'OK',
-            body: '{"testObject": {"test":"yes"}}'
+            body: { testObject: { test: 'yes' } }
           }
         })
 
@@ -113,9 +141,9 @@ describe('ChargingModuleRequestLib', () => {
       it('calls the Charging Module with the required options', async () => {
         const requestArgs = RequestLib.post.firstCall.args
 
-        expect(requestArgs[0]).to.endWith('/TEST_ROUTE')
+        expect(requestArgs[0]).to.endWith('TEST_ROUTE')
         expect(requestArgs[1].headers).to.include({ authorization: 'Bearer ACCESS_TOKEN' })
-        expect(requestArgs[1].body).to.equal('{"test":"yes"}')
+        expect(requestArgs[1].json).to.equal({ test: 'yes' })
       })
 
       it('returns a `true` success status', async () => {
@@ -125,6 +153,17 @@ describe('ChargingModuleRequestLib', () => {
       it('returns the response body as an object', async () => {
         expect(result.response.body.testObject.test).to.equal('yes')
       })
+
+      it('returns the status code', async () => {
+        expect(result.response.statusCode).to.equal(200)
+      })
+
+      it('returns the information about the running Charging Module API', async () => {
+        expect(result.response.info).to.equal({
+          gitCommit: '273604040a47e0977b0579a0fef0f09726d95e39',
+          dockerTag: 'ghcr.io/defra/sroc-charging-module-api:v0.19.0'
+        })
+      })
     })
 
     describe('when the request fails', () => {
@@ -132,9 +171,10 @@ describe('ChargingModuleRequestLib', () => {
         Sinon.stub(RequestLib, 'post').resolves({
           succeeded: false,
           response: {
+            headers,
             statusCode: 404,
             statusMessage: 'Not Found',
-            body: '{"statusCode":404,"error":"Not Found","message":"Not Found"}'
+            body: { statusCode: 404, error: 'Not Found', message: 'Not Found' }
           }
         })
 
@@ -146,7 +186,18 @@ describe('ChargingModuleRequestLib', () => {
       })
 
       it('returns the error response', async () => {
-        expect(result.response.statusMessage).to.equal('Not Found')
+        expect(result.response.body.message).to.equal('Not Found')
+      })
+
+      it('returns the status code', async () => {
+        expect(result.response.statusCode).to.equal(404)
+      })
+
+      it('returns the information about the running Charging Module API', async () => {
+        expect(result.response.info).to.equal({
+          gitCommit: '273604040a47e0977b0579a0fef0f09726d95e39',
+          dockerTag: 'ghcr.io/defra/sroc-charging-module-api:v0.19.0'
+        })
       })
     })
   })

--- a/test/services/charging-module/create-bill-run.service.test.js
+++ b/test/services/charging-module/create-bill-run.service.test.js
@@ -37,6 +37,11 @@ describe('Charge module create bill run service', () => {
       Sinon.stub(ChargingModuleRequestLib, 'post').resolves({
         succeeded: true,
         response: {
+          info: {
+            gitCommit: '273604040a47e0977b0579a0fef0f09726d95e39',
+            dockerTag: 'ghcr.io/defra/sroc-charging-module-api:v0.19.0'
+          },
+          statusCode: 200,
           body: {
             billRun: {
               id: '2bbbe459-966e-4026-b5d2-2f10867bdddd',
@@ -67,6 +72,11 @@ describe('Charge module create bill run service', () => {
         Sinon.stub(ChargingModuleRequestLib, 'post').resolves({
           succeeded: false,
           response: {
+            info: {
+              gitCommit: '273604040a47e0977b0579a0fef0f09726d95e39',
+              dockerTag: 'ghcr.io/defra/sroc-charging-module-api:v0.19.0'
+            },
+            statusCode: 401,
             body: {
               statusCode: 401,
               error: 'Unauthorized',

--- a/test/services/health/info.service.test.js
+++ b/test/services/health/info.service.test.js
@@ -28,9 +28,9 @@ describe('Info service', () => {
       succeeded: true,
       response: {
         statusCode: 200,
-        headers: {
-          'x-cma-git-commit': '273604040a47e0977b0579a0fef0f09726d95e39',
-          'x-cma-docker-tag': 'ghcr.io/defra/sroc-charging-module-api:v9.99.9'
+        info: {
+          gitCommit: '273604040a47e0977b0579a0fef0f09726d95e39',
+          dockerTag: 'ghcr.io/defra/sroc-charging-module-api:v0.19.0'
         }
       }
     },
@@ -73,7 +73,7 @@ describe('Info service', () => {
 
     chargingModuleRequestLibStub = Sinon.stub(ChargingModuleRequestLib, 'get')
     chargingModuleRequestLibStub
-      .withArgs('/status')
+      .withArgs('status')
       .resolves(goodRequestResults.chargingModule)
   })
 

--- a/test/services/supplementary-billing/initiate-billing-batch.service.test.js
+++ b/test/services/supplementary-billing/initiate-billing-batch.service.test.js
@@ -53,8 +53,17 @@ describe('Initiate Billing Batch service', () => {
       Sinon.stub(ChargingModuleCreateBillRunService, 'go').resolves({
         succeeded: true,
         response: {
-          id: '2bbbe459-966e-4026-b5d2-2f10867bdddd',
-          billRunNumber: 10004
+          info: {
+            gitCommit: '273604040a47e0977b0579a0fef0f09726d95e39',
+            dockerTag: 'ghcr.io/defra/sroc-charging-module-api:v0.19.0'
+          },
+          statusCode: 200,
+          body: {
+            billRun: {
+              id: '2bbbe459-966e-4026-b5d2-2f10867bdddd',
+              billRunNumber: 10004
+            }
+          }
         }
       })
     })
@@ -95,9 +104,16 @@ describe('Initiate Billing Batch service', () => {
         Sinon.stub(ChargingModuleCreateBillRunService, 'go').resolves({
           succeeded: false,
           response: {
+            info: {
+              gitCommit: '273604040a47e0977b0579a0fef0f09726d95e39',
+              dockerTag: 'ghcr.io/defra/sroc-charging-module-api:v0.19.0'
+            },
             statusCode: 403,
-            error: 'Forbidden',
-            message: "Unauthorised for regime 'wrls'"
+            body: {
+              statusCode: 403,
+              error: 'Forbidden',
+              message: "Unauthorised for regime 'wrls'"
+            }
           }
         })
       })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3906

We've spotted that we're not being consistent with our response handling of requests to the [sroc-charging-module-api](https://github.com/DEFRA/sroc-charging-module-api).

We'd done some refactoring in [Refactor to use ChargingModuleRequestLib](https://github.com/DEFRA/water-abstraction-system/pull/130) to the `_parseResult()` function of `app/lib/charging-module-request.lib.js`.

The result was a calling service would receive something like

```javascript
{
  succeeded: true,
  response: {
    body: {
      billRun: {
        id: ...,
        billRunNumber: ...
      }
    },
    statusCode: ...
  }
}
```

This started blowing up when we started work on the [Spike - Create a complete debit only SROC bill run](https://github.com/DEFRA/water-abstraction-system/pull/133). This was because `app/services/supplementary-billing/initiate-billing-batch.service.js` was trying to access the result as below

```javascript
const options = {
  scheme,
  batchType: type,
  externalId: chargingModuleBillRun.response.id
}
```

To resolve this we came to the conclusion that, exceptions aside, what we want from [Got](https://github.com/sindresorhus/got) is the response body as is, plus the status code. That's it. This applies to `2xx/3xx` and `4xx/5xx` responses.

This change updates `app/lib/charging-module-request.lib.js` to ensure this.

We could have done it in `app/lib/request.lib.js` but we will be using **Got** options that may not be applicable in all cases. So, by doing it at the `charging-module-request.lib.js` level we retain flexibility in how we make requests should we need it.