### PR TITLE
Add Charging Module generate bill run service

### DIFF
--- a/app/services/charging-module/generate-bill-run.service.js
+++ b/app/services/charging-module/generate-bill-run.service.js
@@ -1,0 +1,19 @@
+'use strict'
+
+/**
+ * Connects with the Charging Module to generate a bill run
+ * @module ChargingModuleGenerateBillRunService
+ */
+
+const ChargingModuleRequestLib = require('../../lib/charging-module-request.lib.js')
+
+async function go (billingRunId) {
+  const path = `v3/wrls/bill-runs/${billingRunId}/generate`
+  const result = await ChargingModuleRequestLib.patch(path)
+
+  return result
+}
+
+module.exports = {
+  go
+}

--- a/test/services/charging-module/generate-bill-run.service.test.js
+++ b/test/services/charging-module/generate-bill-run.service.test.js
@@ -1,0 +1,112 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { describe, it, beforeEach, afterEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Things we need to stub
+const ChargingModuleRequestLib = require('../../../app/lib/charging-module-request.lib.js')
+
+// Thing under test
+const ChargingModuleGenerateBillRunService = require('../../../app/services/charging-module/generate-bill-run.service.js')
+
+describe('Charge module generate bill run service', () => {
+  const billRunId = '2bbbe459-966e-4026-b5d2-2f10867bdddd'
+
+  afterEach(() => {
+    Sinon.restore()
+  })
+
+  describe('when the service can generate a bill run', () => {
+    beforeEach(async () => {
+      Sinon.stub(ChargingModuleRequestLib, 'patch').resolves({
+        succeeded: true,
+        response: {
+          info: {
+            gitCommit: '273604040a47e0977b0579a0fef0f09726d95e39',
+            dockerTag: 'ghcr.io/defra/sroc-charging-module-api:v0.19.0'
+          },
+          statusCode: 204,
+          body: null
+        }
+      })
+    })
+
+    it('returns a `true` success status', async () => {
+      const result = await ChargingModuleGenerateBillRunService.go(billRunId)
+
+      expect(result.succeeded).to.be.true()
+    })
+
+    it('returns a 204 - no content', async () => {
+      const result = await ChargingModuleGenerateBillRunService.go(billRunId)
+
+      expect(result.response.statusCode).to.equal(204)
+      expect(result.response.body).to.be.null()
+    })
+  })
+
+  describe('when the service cannot create a transaction', () => {
+    describe('because the request did not return a 2xx/3xx response', () => {
+      beforeEach(async () => {
+        Sinon.stub(ChargingModuleRequestLib, 'patch').resolves({
+          succeeded: false,
+          response: {
+            info: {
+              gitCommit: '273604040a47e0977b0579a0fef0f09726d95e39',
+              dockerTag: 'ghcr.io/defra/sroc-charging-module-api:v0.19.0'
+            },
+            statusCode: 401,
+            body: {
+              statusCode: 401,
+              error: 'Unauthorized',
+              message: 'Invalid JWT: Token format not valid',
+              attributes: { error: 'Invalid JWT: Token format not valid' }
+            }
+          }
+        })
+      })
+
+      it('returns a `false` success status', async () => {
+        const result = await ChargingModuleGenerateBillRunService.go(billRunId)
+
+        expect(result.succeeded).to.be.false()
+      })
+
+      it('returns the error in the `response`', async () => {
+        const result = await ChargingModuleGenerateBillRunService.go(billRunId)
+
+        expect(result.response.body.statusCode).to.equal(401)
+        expect(result.response.body.error).to.equal('Unauthorized')
+        expect(result.response.body.message).to.equal('Invalid JWT: Token format not valid')
+      })
+    })
+
+    describe('because the request attempt returned an error, for example, TimeoutError', () => {
+      beforeEach(async () => {
+        Sinon.stub(ChargingModuleRequestLib, 'patch').resolves({
+          succeeded: false,
+          response: new Error("Timeout awaiting 'request' for 5000ms")
+        })
+      })
+
+      it('returns a `false` success status', async () => {
+        const result = await ChargingModuleGenerateBillRunService.go(billRunId)
+
+        expect(result.succeeded).to.be.false()
+      })
+
+      it('returns the error in the `response`', async () => {
+        const result = await ChargingModuleGenerateBillRunService.go(billRunId)
+
+        expect(result.response.statusCode).not.to.exist()
+        expect(result.response.body).not.to.exist()
+        expect(result.response.message).to.equal("Timeout awaiting 'request' for 5000ms")
+      })
+    })
+  })
+})


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3906
https://eaflood.atlassian.net/browse/WATER-3917

Once all the transactions have been added to the Charging Module bill run it needs to be [generated](https://defra.github.io/sroc-charging-module-api-docs/#/bill-run/GenerateBillRun). This is where it confirms the final values and calculates any additional transaction lines needed.

So, in this change, we add app/services/charging-module/generate-bill-run.service.js which will handle calling the `/generate` endpoint in the [sroc-charging-module-api](https://github.com/DEFRA/sroc-charging-module-api).