### PR TITLE
Add PATCH support to our request lib modules

### DIFF
--- a/app/lib/charging-module-request.lib.js
+++ b/app/lib/charging-module-request.lib.js
@@ -24,6 +24,21 @@ async function get (path) {
 }
 
 /**
+ * Sends a PATCH request to the Charging Module for the provided route
+ *
+ * @param {string} path The route to send the request to (do not include the starting /)
+ *
+ * @returns {Object} result An object representing the result of the request
+ * @returns {boolean} result.succeeded Whether the request was successful
+ * @returns {Object} result.response The Charging Module response if successful or the error response if not
+ */
+async function patch (path) {
+  const result = await _sendRequest(path, RequestLib.patch)
+
+  return _parseResult(result)
+}
+
+/**
  * Sends a POST request to the Charging Module for the provided route
  *
  * @param {string} path The path to send the request to (do not include the starting /)
@@ -113,5 +128,6 @@ function _parseResult (result) {
 
 module.exports = {
   get,
+  patch,
   post
 }

--- a/app/lib/request.lib.js
+++ b/app/lib/request.lib.js
@@ -34,6 +34,10 @@ async function get (url, additionalOptions = {}) {
   return await _sendRequest('get', url, additionalOptions)
 }
 
+async function patch (url, additionalOptions = {}) {
+  return await _sendRequest('patch', url, additionalOptions)
+}
+
 async function post (url, additionalOptions = {}) {
   return await _sendRequest('post', url, additionalOptions)
 }
@@ -162,5 +166,6 @@ function _requestOptions (additionalOptions) {
 
 module.exports = {
   get,
+  patch,
   post
 }

--- a/app/lib/request.lib.js
+++ b/app/lib/request.lib.js
@@ -147,9 +147,9 @@ function _requestOptions (additionalOptions) {
     retry: {
       // We ensure that the only network errors Got retries are timeout errors
       errorCodes: ['ETIMEDOUT'],
-      // By default, Got does not retry POST requests. As we only retry timeouts there is no risk in retrying POST
-      // requests. So, we set methods to be Got's defaults plus 'POST'
-      methods: ['GET', 'POST', 'PUT', 'HEAD', 'DELETE', 'OPTIONS', 'TRACE'],
+      // By default, Got does not retry PATCH and POST requests. As we only retry timeouts there is no risk in retrying
+      // our PATCH and POST requests. So, we set methods to be Got's defaults plus 'PATCH' and 'POST'
+      methods: ['GET', 'PATCH', 'POST', 'PUT', 'HEAD', 'DELETE', 'OPTIONS', 'TRACE'],
       // We set statusCodes as an empty array to ensure that 4xx, 5xx etc. errors are not retried
       statusCodes: []
     },

--- a/test/lib/charging-module-request.lib.test.js
+++ b/test/lib/charging-module-request.lib.test.js
@@ -121,6 +121,86 @@ describe('ChargingModuleRequestLib', () => {
     })
   })
 
+  describe('#patch', () => {
+    let result
+
+    describe('when the request succeeds', () => {
+      beforeEach(async () => {
+        Sinon.stub(RequestLib, 'patch').resolves({
+          succeeded: true,
+          response: {
+            headers,
+            statusCode: 204,
+            body: {}
+          }
+        })
+
+        result = await ChargingModuleRequestLib.patch(testRoute)
+      })
+
+      it('calls the Charging Module with the required options', async () => {
+        const requestArgs = RequestLib.patch.firstCall.args
+
+        expect(requestArgs[0]).to.endWith('TEST_ROUTE')
+        expect(requestArgs[1].headers).to.include({ authorization: 'Bearer ACCESS_TOKEN' })
+      })
+
+      it('returns a `true` success status', async () => {
+        expect(result.succeeded).to.be.true()
+      })
+
+      it('returns the response body as an object', async () => {
+        expect(result.response.body).to.equal({})
+      })
+
+      it('returns the status code', async () => {
+        expect(result.response.statusCode).to.equal(204)
+      })
+
+      it('returns the information about the running Charging Module API', async () => {
+        expect(result.response.info).to.equal({
+          gitCommit: '273604040a47e0977b0579a0fef0f09726d95e39',
+          dockerTag: 'ghcr.io/defra/sroc-charging-module-api:v0.19.0'
+        })
+      })
+    })
+
+    describe('when the request fails', () => {
+      beforeEach(async () => {
+        Sinon.stub(RequestLib, 'patch').resolves({
+          succeeded: false,
+          response: {
+            headers,
+            statusCode: 404,
+            statusMessage: 'Not Found',
+            body: { statusCode: 404, error: 'Not Found', message: 'Not Found' }
+          }
+        })
+
+        result = await ChargingModuleRequestLib.patch(testRoute)
+      })
+
+      it('returns a `false` success status', async () => {
+        expect(result.succeeded).to.be.false()
+      })
+
+      it('returns the error response', async () => {
+        expect(result.response.body.message).to.equal('Not Found')
+      })
+
+      it('returns the status code', async () => {
+        expect(result.response.statusCode).to.equal(404)
+      })
+
+      it('returns the information about the running Charging Module API', async () => {
+        expect(result.response.info).to.equal({
+          gitCommit: '273604040a47e0977b0579a0fef0f09726d95e39',
+          dockerTag: 'ghcr.io/defra/sroc-charging-module-api:v0.19.0'
+        })
+      })
+    })
+  })
+
   describe('#post', () => {
     let result
 

--- a/test/lib/charging-module-request.lib.test.js
+++ b/test/lib/charging-module-request.lib.test.js
@@ -42,8 +42,6 @@ describe('ChargingModuleRequestLib', () => {
   })
 
   describe('#get', () => {
-    let result
-
     describe('when the request succeeds', () => {
       beforeEach(async () => {
         Sinon.stub(RequestLib, 'get').resolves({
@@ -54,11 +52,11 @@ describe('ChargingModuleRequestLib', () => {
             body: { testObject: { test: 'yes' } }
           }
         })
-
-        result = await ChargingModuleRequestLib.get(testRoute)
       })
 
       it('calls the Charging Module with the required options', async () => {
+        await ChargingModuleRequestLib.get(testRoute)
+
         const requestArgs = RequestLib.get.firstCall.args
 
         expect(requestArgs[0]).to.endWith('TEST_ROUTE')
@@ -66,18 +64,26 @@ describe('ChargingModuleRequestLib', () => {
       })
 
       it('returns a `true` success status', async () => {
+        const result = await ChargingModuleRequestLib.get(testRoute)
+
         expect(result.succeeded).to.be.true()
       })
 
       it('returns the response body as an object', async () => {
+        const result = await ChargingModuleRequestLib.get(testRoute)
+
         expect(result.response.body.testObject.test).to.equal('yes')
       })
 
       it('returns the status code', async () => {
+        const result = await ChargingModuleRequestLib.get(testRoute)
+
         expect(result.response.statusCode).to.equal(200)
       })
 
       it('returns the information about the running Charging Module API', async () => {
+        const result = await ChargingModuleRequestLib.get(testRoute)
+
         expect(result.response.info).to.equal({
           gitCommit: '273604040a47e0977b0579a0fef0f09726d95e39',
           dockerTag: 'ghcr.io/defra/sroc-charging-module-api:v0.19.0'
@@ -96,23 +102,29 @@ describe('ChargingModuleRequestLib', () => {
             body: { statusCode: 404, error: 'Not Found', message: 'Not Found' }
           }
         })
-
-        result = await ChargingModuleRequestLib.get(testRoute)
       })
 
       it('returns a `false` success status', async () => {
+        const result = await ChargingModuleRequestLib.get(testRoute)
+
         expect(result.succeeded).to.be.false()
       })
 
       it('returns the error response', async () => {
+        const result = await ChargingModuleRequestLib.get(testRoute)
+
         expect(result.response.body.message).to.equal('Not Found')
       })
 
       it('returns the status code', async () => {
+        const result = await ChargingModuleRequestLib.get(testRoute)
+
         expect(result.response.statusCode).to.equal(404)
       })
 
       it('returns the information about the running Charging Module API', async () => {
+        const result = await ChargingModuleRequestLib.get(testRoute)
+
         expect(result.response.info).to.equal({
           gitCommit: '273604040a47e0977b0579a0fef0f09726d95e39',
           dockerTag: 'ghcr.io/defra/sroc-charging-module-api:v0.19.0'
@@ -122,8 +134,6 @@ describe('ChargingModuleRequestLib', () => {
   })
 
   describe('#patch', () => {
-    let result
-
     describe('when the request succeeds', () => {
       beforeEach(async () => {
         Sinon.stub(RequestLib, 'patch').resolves({
@@ -134,11 +144,11 @@ describe('ChargingModuleRequestLib', () => {
             body: {}
           }
         })
-
-        result = await ChargingModuleRequestLib.patch(testRoute)
       })
 
       it('calls the Charging Module with the required options', async () => {
+        await ChargingModuleRequestLib.patch(testRoute)
+
         const requestArgs = RequestLib.patch.firstCall.args
 
         expect(requestArgs[0]).to.endWith('TEST_ROUTE')
@@ -146,18 +156,26 @@ describe('ChargingModuleRequestLib', () => {
       })
 
       it('returns a `true` success status', async () => {
+        const result = await ChargingModuleRequestLib.patch(testRoute)
+
         expect(result.succeeded).to.be.true()
       })
 
       it('returns the response body as an object', async () => {
+        const result = await ChargingModuleRequestLib.patch(testRoute)
+
         expect(result.response.body).to.equal({})
       })
 
       it('returns the status code', async () => {
+        const result = await ChargingModuleRequestLib.patch(testRoute)
+
         expect(result.response.statusCode).to.equal(204)
       })
 
       it('returns the information about the running Charging Module API', async () => {
+        const result = await ChargingModuleRequestLib.patch(testRoute)
+
         expect(result.response.info).to.equal({
           gitCommit: '273604040a47e0977b0579a0fef0f09726d95e39',
           dockerTag: 'ghcr.io/defra/sroc-charging-module-api:v0.19.0'
@@ -176,23 +194,29 @@ describe('ChargingModuleRequestLib', () => {
             body: { statusCode: 404, error: 'Not Found', message: 'Not Found' }
           }
         })
-
-        result = await ChargingModuleRequestLib.patch(testRoute)
       })
 
       it('returns a `false` success status', async () => {
+        const result = await ChargingModuleRequestLib.patch(testRoute)
+
         expect(result.succeeded).to.be.false()
       })
 
       it('returns the error response', async () => {
+        const result = await ChargingModuleRequestLib.patch(testRoute)
+
         expect(result.response.body.message).to.equal('Not Found')
       })
 
       it('returns the status code', async () => {
+        const result = await ChargingModuleRequestLib.patch(testRoute)
+
         expect(result.response.statusCode).to.equal(404)
       })
 
       it('returns the information about the running Charging Module API', async () => {
+        const result = await ChargingModuleRequestLib.patch(testRoute)
+
         expect(result.response.info).to.equal({
           gitCommit: '273604040a47e0977b0579a0fef0f09726d95e39',
           dockerTag: 'ghcr.io/defra/sroc-charging-module-api:v0.19.0'
@@ -202,8 +226,6 @@ describe('ChargingModuleRequestLib', () => {
   })
 
   describe('#post', () => {
-    let result
-
     describe('when the request succeeds', () => {
       beforeEach(async () => {
         Sinon.stub(RequestLib, 'post').resolves({
@@ -214,11 +236,11 @@ describe('ChargingModuleRequestLib', () => {
             body: { testObject: { test: 'yes' } }
           }
         })
-
-        result = await ChargingModuleRequestLib.post(testRoute, { test: 'yes' })
       })
 
       it('calls the Charging Module with the required options', async () => {
+        await ChargingModuleRequestLib.post(testRoute, { test: 'yes' })
+
         const requestArgs = RequestLib.post.firstCall.args
 
         expect(requestArgs[0]).to.endWith('TEST_ROUTE')
@@ -227,18 +249,26 @@ describe('ChargingModuleRequestLib', () => {
       })
 
       it('returns a `true` success status', async () => {
+        const result = await ChargingModuleRequestLib.post(testRoute, { test: 'yes' })
+
         expect(result.succeeded).to.be.true()
       })
 
       it('returns the response body as an object', async () => {
+        const result = await ChargingModuleRequestLib.post(testRoute, { test: 'yes' })
+
         expect(result.response.body.testObject.test).to.equal('yes')
       })
 
       it('returns the status code', async () => {
+        const result = await ChargingModuleRequestLib.post(testRoute, { test: 'yes' })
+
         expect(result.response.statusCode).to.equal(200)
       })
 
       it('returns the information about the running Charging Module API', async () => {
+        const result = await ChargingModuleRequestLib.post(testRoute, { test: 'yes' })
+
         expect(result.response.info).to.equal({
           gitCommit: '273604040a47e0977b0579a0fef0f09726d95e39',
           dockerTag: 'ghcr.io/defra/sroc-charging-module-api:v0.19.0'
@@ -257,23 +287,29 @@ describe('ChargingModuleRequestLib', () => {
             body: { statusCode: 404, error: 'Not Found', message: 'Not Found' }
           }
         })
-
-        result = await ChargingModuleRequestLib.post(testRoute, { test: true })
       })
 
       it('returns a `false` success status', async () => {
+        const result = await ChargingModuleRequestLib.post(testRoute, { test: 'yes' })
+
         expect(result.succeeded).to.be.false()
       })
 
       it('returns the error response', async () => {
+        const result = await ChargingModuleRequestLib.post(testRoute, { test: 'yes' })
+
         expect(result.response.body.message).to.equal('Not Found')
       })
 
       it('returns the status code', async () => {
+        const result = await ChargingModuleRequestLib.post(testRoute, { test: 'yes' })
+
         expect(result.response.statusCode).to.equal(404)
       })
 
       it('returns the information about the running Charging Module API', async () => {
+        const result = await ChargingModuleRequestLib.post(testRoute, { test: 'yes' })
+
         expect(result.response.info).to.equal({
           gitCommit: '273604040a47e0977b0579a0fef0f09726d95e39',
           dockerTag: 'ghcr.io/defra/sroc-charging-module-api:v0.19.0'

--- a/test/lib/request.lib.test.js
+++ b/test/lib/request.lib.test.js
@@ -228,6 +228,201 @@ describe('RequestLib', () => {
     })
   })
 
+  describe('#patch()', () => {
+    describe('When a request succeeds', () => {
+      beforeEach(() => {
+        Nock(testDomain).patch('/').reply(200, { data: 'hello world' })
+      })
+
+      describe('the result it returns', () => {
+        it("has a 'succeeded' property marked as true", async () => {
+          const result = await RequestLib.patch(testDomain)
+
+          expect(result.succeeded).to.be.true()
+        })
+
+        it("has a 'response' property containing the web response", async () => {
+          const result = await RequestLib.patch(testDomain)
+
+          expect(result.response).to.exist()
+          expect(result.response.statusCode).to.equal(200)
+          expect(result.response.body).to.equal('{"data":"hello world"}')
+        })
+      })
+    })
+
+    describe('When a request fails', () => {
+      describe('because the response was a 500', () => {
+        beforeEach(() => {
+          Nock(testDomain).patch('/').reply(500, { data: 'hello world' })
+        })
+
+        it('logs the failure', async () => {
+          await RequestLib.patch(testDomain)
+
+          const logDataArg = notifierStub.omg.args[0][1]
+
+          expect(notifierStub.omg.calledWith('PATCH request failed')).to.be.true()
+          expect(logDataArg.method).to.equal('PATCH')
+          expect(logDataArg.url).to.equal('http://example.com')
+          expect(logDataArg.additionalOptions).to.equal({})
+          expect(logDataArg.result.succeeded).to.be.false()
+          expect(logDataArg.result.response).to.equal({
+            statusCode: 500,
+            body: '{"data":"hello world"}'
+          })
+        })
+
+        describe('the result it returns', () => {
+          it("has a 'succeeded' property marked as false", async () => {
+            const result = await RequestLib.patch(testDomain)
+
+            expect(result.succeeded).to.be.false()
+          })
+
+          it("has a 'response' property containing the web response", async () => {
+            const result = await RequestLib.patch(testDomain)
+
+            expect(result.response).to.exist()
+            expect(result.response.statusCode).to.equal(500)
+            expect(result.response.body).to.equal('{"data":"hello world"}')
+          })
+        })
+      })
+
+      describe('because there was a network issue', () => {
+        beforeEach(() => {
+          Nock(testDomain).patch('/').replyWithError({ code: 'ECONNRESET' })
+        })
+
+        it('logs and records the error', async () => {
+          await RequestLib.patch(testDomain)
+
+          const logDataArg = notifierStub.omfg.args[0][1]
+
+          expect(notifierStub.omfg.calledWith('PATCH request errored')).to.be.true()
+          expect(logDataArg.method).to.equal('PATCH')
+          expect(logDataArg.url).to.equal('http://example.com')
+          expect(logDataArg.additionalOptions).to.equal({})
+          expect(logDataArg.result.succeeded).to.be.false()
+          expect(logDataArg.result.response).to.be.an.error()
+        })
+
+        describe('the result it returns', () => {
+          it("has a 'succeeded' property marked as false", async () => {
+            const result = await RequestLib.patch(testDomain)
+
+            expect(result.succeeded).to.be.false()
+          })
+
+          it("has a 'response' property containing the error", async () => {
+            const result = await RequestLib.patch(testDomain)
+
+            expect(result.response).to.exist()
+            expect(result.response).to.be.an.error()
+            expect(result.response.code).to.equal('ECONNRESET')
+          })
+        })
+      })
+
+      describe('because request timed out', () => {
+        beforeEach(async () => {
+          // Set the timeout value to 50ms for these tests
+          Sinon.replace(requestConfig, 'timeout', 50)
+        })
+
+        // Because of the fake delay in this test, Lab will timeout (by default tests have 2 seconds to finish). So, we
+        // have to override the timeout for this specific test to all it to complete
+        describe('and all retries fail', { timeout: 5000 }, () => {
+          beforeEach(async () => {
+            Nock(testDomain)
+              .patch(() => true)
+              .delay(100)
+              .reply(200, { data: 'hello world' })
+              .persist()
+          })
+
+          describe('the result it returns', () => {
+            it("has a 'succeeded' property marked as false", async () => {
+              const result = await RequestLib.patch(testDomain)
+
+              expect(result.succeeded).to.be.false()
+            })
+
+            it("has a 'response' property containing the error", async () => {
+              const result = await RequestLib.patch(testDomain)
+
+              expect(result.response).to.exist()
+              expect(result.response).to.be.an.error()
+              expect(result.response.code).to.equal('ETIMEDOUT')
+            })
+          })
+        })
+
+        describe('and a retry succeeds', () => {
+          beforeEach(async () => {
+            // The first response will time out, the second response will return OK
+            Nock(testDomain)
+              .patch(() => true)
+              .delay(100)
+              .reply(200, { data: 'hello world' })
+              .patch(() => true)
+              .reply(200, { data: 'delayed hello world' })
+          })
+
+          describe('the result it returns', () => {
+            it("has a 'succeeded' property marked as true", async () => {
+              const result = await RequestLib.patch(testDomain)
+
+              expect(result.succeeded).to.be.true()
+            })
+
+            it("has a 'response' property containing the web response", async () => {
+              const result = await RequestLib.patch(testDomain)
+
+              expect(result.response).to.exist()
+              expect(result.response.statusCode).to.equal(200)
+              expect(result.response.body).to.equal('{"data":"delayed hello world"}')
+            })
+          })
+        })
+      })
+    })
+
+    describe('When I provide additional options', () => {
+      describe('and they expand the default options', () => {
+        beforeEach(() => {
+          Nock(testDomain).patch('/').reply(200, { data: 'hello world' })
+        })
+
+        it('adds them to the options used when making the request', async () => {
+          // We tell Got to return the response as json rather than text. We can confirm the option has been applied by
+          // checking the result.response.body below.
+          const options = { responseType: 'json' }
+          const result = await RequestLib.patch(testDomain, options)
+
+          expect(result.succeeded).to.be.true()
+          expect(result.response.body).to.equal({ data: 'hello world' })
+        })
+      })
+
+      describe('and they replace a default option', () => {
+        beforeEach(() => {
+          Nock(testDomain).patch('/').reply(500)
+        })
+
+        it('uses them in the options used when making the request', async () => {
+          // We tell Got throw an error if the response is not 2xx or 3xx
+          const options = { throwHttpErrors: true }
+          const result = await RequestLib.patch(testDomain, options)
+
+          expect(result.succeeded).to.be.false()
+          expect(result.response).to.be.an.error()
+        })
+      })
+    })
+  })
+
   describe('#post()', () => {
     describe('When a request succeeds', () => {
       beforeEach(() => {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3906
https://eaflood.atlassian.net/browse/WATER-3919

In order to call the [/generate](https://defra.github.io/sroc-charging-module-api-docs/#/bill-run/GenerateBillRun) bill run endpoint in the Charging Module API we need to be able to make `PATCH` HTTP requests.

This change adds the functionality to `app/lib/request.lib.js` and `app/lib/charging-module-request.lib.js`.

---

**Housekeeping**

It is a personal preference that has become a convention in our tests. Executing the thing under test should be done within the test rather than a `before()` block.

It's our opinion when this isn't done you lose sight of what a test is testing as you add more and more unit tests. It does mean you get some duplication. But we think it makes for more readable code.

As we were adding new tests to `test/lib/charging-module-request.lib.test.js` we spotted this deviation and corrected it as part of this change.