### PR TITLE
Add Base Presenter module

### DIFF
--- a/app/presenters/base.presenter.js
+++ b/app/presenters/base.presenter.js
@@ -1,0 +1,42 @@
+'use strict'
+
+/**
+ * Converts a date into the format required by output files, eg 25/03/2021 becomes 25-MAR-2021
+ *
+ * @param {Date} date The date value to format to a string
+ *
+ * @returns {string} The date formatted as a 'DD-MMM-YYYY' string
+ */
+function formatDate (date) {
+  // The output date format of methods such as toLocaleString() are based on the Unicode CLDR which is subject to
+  // change and cannot be relied on to be consistent: https://github.com/nodejs/node/issues/42030. We therefore
+  // generate the formatted date ourselves.
+  const unpaddedDay = date.getDate()
+  const day = leftPadZeroes(unpaddedDay, 2)
+
+  const monthStrings = ['JAN', 'FEB', 'MAR', 'APR', 'MAY', 'JUN', 'JUL', 'AUG', 'SEP', 'OCT', 'NOV', 'DEC']
+  const month = monthStrings[date.getMonth()]
+
+  const year = date.getFullYear()
+
+  return `${day}-${month}-${year}`
+}
+
+/**
+ * Pads a number to a given length with leading zeroes and returns the result as a string
+ *
+ * @param {Number} number The number to be padded
+ * @param {Number} length How many characters in length the final string should be
+ *
+ * @returns {string} The number padded with zeros to the specified length
+ */
+function leftPadZeroes (number, length) {
+  return number
+    .toString()
+    .padStart(length, '0')
+}
+
+module.exports = {
+  formatDate,
+  leftPadZeroes
+}

--- a/test/presenters/base.presenter.test.js
+++ b/test/presenters/base.presenter.test.js
@@ -1,0 +1,48 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Thing under test
+const BasePresenter = require('../../app/presenters/base.presenter.js')
+
+describe('Base presenter', () => {
+  describe('#formatDate()', () => {
+    it('correctly formats dates', async () => {
+      // We check an array of dates, one for each month, to ensure that every month is formatted correctly
+      const results = [
+        new Date('2021-01-01T14:41:10.511Z'),
+        new Date('2021-02-01T14:41:10.511Z'),
+        new Date('2021-03-01T14:41:10.511Z'),
+        new Date('2021-04-01T14:41:10.511Z'),
+        new Date('2021-05-01T14:41:10.511Z'),
+        new Date('2021-06-01T14:41:10.511Z'),
+        new Date('2021-07-12T14:41:10.511Z'),
+        new Date('2021-08-12T14:41:10.511Z'),
+        new Date('2021-09-12T14:41:10.511Z'),
+        new Date('2021-10-12T14:41:10.511Z'),
+        new Date('2021-11-12T14:41:10.511Z'),
+        new Date('2021-12-12T14:41:10.511Z')
+      ].map(date => BasePresenter.formatDate(date))
+
+      expect(results).to.equal([
+        '01-JAN-2021',
+        '01-FEB-2021',
+        '01-MAR-2021',
+        '01-APR-2021',
+        '01-MAY-2021',
+        '01-JUN-2021',
+        '12-JUL-2021',
+        '12-AUG-2021',
+        '12-SEP-2021',
+        '12-OCT-2021',
+        '12-NOV-2021',
+        '12-DEC-2021'
+      ])
+    })
+  })
+})

--- a/test/presenters/base.presenter.test.js
+++ b/test/presenters/base.presenter.test.js
@@ -10,7 +10,7 @@ const { expect } = Code
 // Thing under test
 const BasePresenter = require('../../app/presenters/base.presenter.js')
 
-describe('Base presenter', () => {
+describe.only('Base presenter', () => {
   describe('#formatDate()', () => {
     it('correctly formats dates', async () => {
       // We check an array of dates, one for each month, to ensure that every month is formatted correctly
@@ -43,6 +43,15 @@ describe('Base presenter', () => {
         '12-NOV-2021',
         '12-DEC-2021'
       ])
+    })
+  })
+
+  describe('#leftPadZeroes()', () => {
+    it('correctly pads numbers', async () => {
+      const number = 123
+      const result = BasePresenter.leftPadZeroes(number, 7)
+
+      expect(result).to.equal('0000123')
     })
   })
 })

--- a/test/presenters/base.presenter.test.js
+++ b/test/presenters/base.presenter.test.js
@@ -10,7 +10,7 @@ const { expect } = Code
 // Thing under test
 const BasePresenter = require('../../app/presenters/base.presenter.js')
 
-describe.only('Base presenter', () => {
+describe('Base presenter', () => {
   describe('#formatDate()', () => {
     it('correctly formats dates', async () => {
       // We check an array of dates, one for each month, to ensure that every month is formatted correctly


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3906
https://eaflood.atlassian.net/browse/WATER-3925

In the [sroc-charging-module-api](https://github.com/DEFRA/sroc-charging-module-api) project all our 'presenters' inherited from a `base.presenter.js`. It contained handy util methods, for example, `formatDate()` which formats a date as a `DD-MMM-YYYY` string.

Turns out, we need exactly that when preparing the transaction data to be sent to the charging module API! So, we add a `base.presenter.js` module for the first time. We'll bring over some of what we have in the **sroc-charging-module-api** as it has `formatDate()` and `leftPadZeroes()` which is what we need right now.

One thing to note is the **sroc-charging-module-api** was built mainly from [classes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes). We wanted to align more with JavaScript conventions for this project so have stuck to modules. That means our presenters won't inherit the base. Instead, those that need it can just `require()` it and its functions. We've stuck with the name 'base' though as it's our convention for a base object that is intended to be used by related objects.