### PR TITLE
Start processing the billing batch from Initiate

### DIFF
--- a/app/services/supplementary-billing/initiate-billing-batch.service.js
+++ b/app/services/supplementary-billing/initiate-billing-batch.service.js
@@ -12,6 +12,7 @@ const CheckLiveBillRunService = require('./check-live-bill-run.service.js')
 const CreateBillingBatchPresenter = require('../../presenters/supplementary-billing/create-billing-batch.presenter.js')
 const CreateBillingBatchService = require('./create-billing-batch.service.js')
 const CreateBillingBatchEventService = require('./create-billing-batch-event.service.js')
+const ProcessBillingBatchService = require('./process-billing-batch.service.js')
 
 /**
  * Initiate a new billing batch
@@ -43,6 +44,8 @@ async function go (billRunRequestData) {
   const billingBatch = await CreateBillingBatchService.go(region, billingPeriod, billingBatchOptions)
 
   await CreateBillingBatchEventService.go(billingBatch, user)
+
+  ProcessBillingBatchService.go(billingBatch, billingPeriod)
 
   return _response(billingBatch)
 }

--- a/app/services/supplementary-billing/process-billing-batch.service.js
+++ b/app/services/supplementary-billing/process-billing-batch.service.js
@@ -1,0 +1,28 @@
+'use strict'
+
+/**
+ * Processes a new billing batch
+ * @module InitiateBillingBatchService
+ */
+
+const ChargingModuleRequestLib = require('../../lib/charging-module-request.lib.js')
+
+/**
+ * Creates the invoices and transactions in both WRLS and the Charging Module API
+ *
+ * TODO: Currently a placeholder service. Proper implementation is coming
+ *
+ * @param {module:BillingBatchModel} billingBatch The newly created bill batch we need to process
+ * @param {Object} billingPeriod an object representing the financial year the transaction is for
+ */
+async function go (billingBatch, billingPeriod) {
+  // TODO: Remove this call. We'e just using this to demonstrate that we can make asynchronous calls and perform
+  // actions in here all whilst the InitiateBillingBatchService (which calls this service) has moved on and responded
+  // to the original request
+  const result = await ChargingModuleRequestLib.get('status')
+  console.log(result, billingBatch, billingPeriod)
+}
+
+module.exports = {
+  go
+}

--- a/test/services/supplementary-billing/initiate-billing-batch.service.test.js
+++ b/test/services/supplementary-billing/initiate-billing-batch.service.test.js
@@ -18,6 +18,7 @@ const RegionHelper = require('../../support/helpers/water/region.helper.js')
 const BillingPeriodService = require('../../../app/services/supplementary-billing/billing-period.service.js')
 const ChargingModuleCreateBillRunService = require('../../../app/services/charging-module/create-bill-run.service.js')
 const CheckLiveBillRunService = require('../../../app/services/supplementary-billing/check-live-bill-run.service.js')
+const ProcessBillingBatchService = require('../../../app/services/supplementary-billing/process-billing-batch.service.js')
 
 // Thing under test
 const InitiateBillingBatchService = require('../../../app//services/supplementary-billing/initiate-billing-batch.service.js')
@@ -42,6 +43,10 @@ describe('Initiate Billing Batch service', () => {
 
     Sinon.stub(BillingPeriodService, 'go').returns([currentBillingPeriod])
     Sinon.stub(CheckLiveBillRunService, 'go').resolves(false)
+
+    // The InitiateBillingBatch service does not await the call to the ProcessBillingBatchService. It is intended to
+    // kick of the process and then move on. This is why we simply stub it in the tests.
+    Sinon.stub(ProcessBillingBatchService, 'go')
   })
 
   afterEach(() => {

--- a/test/services/supplementary-billing/process-billing-batch.service.test.js
+++ b/test/services/supplementary-billing/process-billing-batch.service.test.js
@@ -1,0 +1,54 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { describe, it, beforeEach, afterEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const BillingBatchHelper = require('../../support/helpers/water/billing-batch.helper.js')
+
+// Things we need to stub
+const ChargingModuleRequestLib = require('../../../app/lib/charging-module-request.lib.js')
+
+// Thing under test
+const ProcessBillingBatchService = require('../../../app/services/supplementary-billing/process-billing-batch.service.js')
+
+describe('Process billing batch service', () => {
+  const billingPeriod = {
+    startDate: new Date('2022-04-01'),
+    endDate: new Date('2023-03-31')
+  }
+  let billingBatch
+
+  afterEach(() => {
+    Sinon.restore()
+  })
+
+  describe('when the service is called', () => {
+    beforeEach(async () => {
+      billingBatch = await BillingBatchHelper.add()
+
+      Sinon.stub(ChargingModuleRequestLib, 'get').resolves({
+        succeeded: true,
+        response: {
+          info: {
+            gitCommit: '273604040a47e0977b0579a0fef0f09726d95e39',
+            dockerTag: 'ghcr.io/defra/sroc-charging-module-api:v0.19.0'
+          },
+          statusCode: 200,
+          body: {
+            status: 'alive'
+          }
+        }
+      })
+    })
+
+    it('does something temporarily as it is just a placeholder at the moment', async () => {
+      await expect(ProcessBillingBatchService.go(billingBatch, billingPeriod)).not.to.reject()
+    })
+  })
+})


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3906
https://eaflood.atlassian.net/browse/WATER-3929

Our `InitiateBillingBatchService` handles creating the initial WRLS and Charging Module bill runs. It then returns information about both to the [water-abstraction-service](https://github.com/DEFRA/water-abstraction-service) which makes the create bill run request.

Using the same design as the [charging-module-api](https://github.com/DEFRA/sroc-charging-module-api), our intent is to perform a small action like this, and then return the result in less than a second. As the processing of the billing batch will take more than a second, this must happen in the background and _not_ be something a user is left waiting for.

But we still need to kick it off and as the `InitiateBillingBatchService` has all the data we need to do that this change updates the service to call a new `ProcessBillingBatchService`.

> Note: `ProcessBillingBatchService` will just be a placeholder for now; it'll do something to prove the design works and we'll update it later.