### PR TITLE
Fix dupe bill. invoice licence in process service

### DIFF
--- a/app/services/supplementary-billing/create-billing-invoice-licence.service.js
+++ b/app/services/supplementary-billing/create-billing-invoice-licence.service.js
@@ -17,6 +17,17 @@ const BillingInvoiceLicenceModel = require('../../models/water/billing-invoice-l
  * @returns {Object} The newly-created billing invoice licence record
  */
 async function go (billingInvoice, licence) {
+  // TODO: REFACTOR THIS TO UPSERT INSTEAD OF RETRIEVE AND RETURN EXISTING
+  const retrievedBillingInvoiceLicence = await BillingInvoiceLicenceModel.query()
+    .where('billingInvoiceId', billingInvoice.billingInvoiceId)
+    .where('licenceId', licence.licenceId)
+    .limit(1)
+    .first()
+
+  if (retrievedBillingInvoiceLicence) {
+    return retrievedBillingInvoiceLicence
+  }
+
   const billingInvoiceLicence = await BillingInvoiceLicenceModel.query()
     .insert({
       billingInvoiceId: billingInvoice.billingInvoiceId,

--- a/test/services/supplementary-billing/create-billing-invoice-licence.service.test.js
+++ b/test/services/supplementary-billing/create-billing-invoice-licence.service.test.js
@@ -17,19 +17,17 @@ const DatabaseHelper = require('../../support/helpers/database.helper.js')
 const CreateBillingInvoiceLicenceService = require('../../../app/services/supplementary-billing/create-billing-invoice-licence.service.js')
 
 describe('Create Billing Invoice Licence service', () => {
+  let billingInvoice
+  let licence
+
   beforeEach(async () => {
     await DatabaseHelper.clean()
+
+    billingInvoice = await BillingBatchHelper.add()
+    licence = await LicenceHelper.add()
   })
 
-  describe('when a BillingBatchModel instance is provided', () => {
-    let billingInvoice
-    let licence
-
-    beforeEach(async () => {
-      billingInvoice = await BillingBatchHelper.add()
-      licence = await LicenceHelper.add()
-    })
-
+  describe('when no existing billing invoice licence exists', () => {
     it('returns the new billing invoice licence instance', async () => {
       const result = await CreateBillingInvoiceLicenceService.go(billingInvoice, licence)
 
@@ -38,6 +36,15 @@ describe('Create Billing Invoice Licence service', () => {
       expect(result.billingInvoiceId).to.equal(billingInvoice.billingInvoiceId)
       expect(result.licenceRef).to.equal(licence.licenceRef)
       expect(result.licenceId).to.equal(licence.licenceId)
+    })
+  })
+
+  describe('when an existing billing invoice licence exists', () => {
+    it('returns an existing billing invoice licence instance containing the correct data', async () => {
+      const result1 = await CreateBillingInvoiceLicenceService.go(billingInvoice, licence)
+      const result2 = await CreateBillingInvoiceLicenceService.go(billingInvoice, licence)
+
+      expect(result1.billingInvoiceLicenceId).to.equal(result2.billingInvoiceLicenceId)
     })
   })
 })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3906

Found in testing where we have a licence with multiple charge versions for the same invoice account we are handling reusing the billing invoice. But we are always trying to create a new billing invoice licence when we should be reusing them (when the Billing Invoice ID and licence ID are the same).

So, this change updates the `app/services/supplementary-billing/create-billing-invoice-licence.service.js` to work in the same way as `app/services/supplementary-billing/create-billing-invoice.service.js`, fetching the existing billing invoice licence record if it exists else creating a new one.