### PR TITLE
Amend charge versions fetched for SROC supplementary

### DIFF
--- a/app/services/supplementary-billing/fetch-charge-versions.service.js
+++ b/app/services/supplementary-billing/fetch-charge-versions.service.js
@@ -39,6 +39,7 @@ async function _fetch (regionId, billingPeriod) {
     .where('scheme', 'sroc')
     .where('includeInSupplementaryBilling', 'yes')
     .where('regionId', regionId)
+    .where('chargeVersions.status', 'current')
     .where('chargeVersions.startDate', '>=', billingPeriod.startDate)
     .where('chargeVersions.startDate', '<=', billingPeriod.endDate)
     .withGraphFetched('licence')

--- a/db/migrations/20230310181716_alter-charge-versions.js
+++ b/db/migrations/20230310181716_alter-charge-versions.js
@@ -1,0 +1,23 @@
+'use strict'
+
+const tableName = 'charge_versions'
+
+exports.up = async function (knex) {
+  await knex
+    .schema
+    .withSchema('water')
+    .alterTable(tableName, table => {
+      table.string('status')
+    })
+}
+
+exports.down = async function (knex) {
+  return knex
+    .schema
+    .withSchema('water')
+    .alterTable(tableName, table => {
+      table.dropColumns(
+        'status'
+      )
+    })
+}

--- a/test/support/helpers/water/charge-version.helper.js
+++ b/test/support/helpers/water/charge-version.helper.js
@@ -19,6 +19,7 @@ const LicenceHelper = require('./licence.helper.js')
  * - `scheme` - sroc
  * - `startDate` - 2022-04-01
  * - `invoiceAccountId` - 01931031-4680-4950-87d6-50f8fe784f6d
+ * - `status` - current
  *
  * See `LicenceHelper` for the licence defaults
  *
@@ -60,7 +61,8 @@ function defaults (data = {}) {
     licenceRef: '01/123',
     scheme: 'sroc',
     startDate: new Date('2022-04-01'),
-    invoiceAccountId: '01931031-4680-4950-87d6-50f8fe784f6d'
+    invoiceAccountId: '01931031-4680-4950-87d6-50f8fe784f6d',
+    status: 'current'
   }
 
   return {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3935

Initial tests of the SROC supplementary bill run process immediately identified charge versions were being included in the bill run that shouldn't be.

The current query is based on WATER-3826, the story that originally defined which charge versions to base the bill run on. It just said

- charge versions linked to a licence flagged for supplementary billing
- that are applicable to the financial year being billed
- where the charge version is linked to a licence that matches the selected region

And by inference, the charge version is for the SROC scheme.

The change we have been asked to make is to further filter the charge versions to only those that show as `APPROVED` in the [water-abstraction-ui](https://github.com/DEFRA/water-abstraction-ui).

After some digging we found the `water.charge_versions` table uses a custom data type for the `status` column. The only permitted values are

- **current**
- **draft**
- **superseded**

We also checked the UI code and found `repos/water-abstraction-ui/src/shared/view/nunjucks/filters/charge-version-badge.js` that handles determining which badge to display based on the charge version status.

```javascript
//  Map the backend statuses to the desired front-end labels from acceptance criteria.
//  Statuses are: 'Draft', 'Review', 'Change Request', 'Approved', 'Replaced' - We will also keep invalid to accomodate errors and edge cases. TT 2020-08-28
const displayedTextTransformer = {
  current: 'approved',
  draft: 'draft',
  approved: 'approved',
  replaced: 'replaced',
  superseded: 'replaced',
  invalid: 'invalid',
  review: 'review',
  changes_requested: 'change request',
  to_setup: 'to set up'
}
```

It looks like there were a lot more statuses at one point. But the TL;DR; is `APPROVED` equates to `current`.

So, this change updates `FetchChargeVersionsService` to only return charge versions where the status is `current`.