### PR TITLE
Handle errors in ProcessBillingBatchService

### DIFF
--- a/app/services/supplementary-billing/handle-errored-billing-batch.service.js
+++ b/app/services/supplementary-billing/handle-errored-billing-batch.service.js
@@ -1,0 +1,34 @@
+'use strict'
+
+/**
+ * Handles an errored billing batch (setting status etc.)
+ * @module HandleErroredBillingBatchService
+ */
+
+const BillingBatchModel = require('../../models/water/billing-batch.model.js')
+
+/**
+ * Sets the status of the specified billing batch to `error`, and logs an error if this can't be done.
+ *
+ * We keep this in a separate service so we don't need to worry about multiple/nested try-catch blocks in cases where a
+ * billing batch fails and setting its status to error also fails.
+ *
+ * @param {string} billingBatchId UUID of the billing batch to be marked with `error` status
+ */
+async function go (billingBatchId) {
+  try {
+    await _updateStatus(billingBatchId)
+  } catch (error) {
+    global.GlobalNotifier.omfg('Failed to set error status on billing batch', { error, billingBatchId })
+  }
+}
+
+async function _updateStatus (billingBatchId) {
+  await BillingBatchModel.query()
+    .findById(billingBatchId)
+    .patch({ status: 'error' })
+}
+
+module.exports = {
+  go
+}

--- a/app/services/supplementary-billing/process-billing-batch.service.js
+++ b/app/services/supplementary-billing/process-billing-batch.service.js
@@ -84,6 +84,8 @@ async function go (billingBatch, billingPeriod) {
 
     await _finaliseBillingBatch(billingBatch, generatedInvoices, generatedInvoiceLicences)
   } catch (error) {
+    await _updateStatus(billingBatchId, 'error')
+
     global.GlobalNotifier.omfg('Billing Batch process errored', { billingBatch, error })
   }
 }

--- a/app/services/supplementary-billing/process-billing-batch.service.js
+++ b/app/services/supplementary-billing/process-billing-batch.service.js
@@ -18,6 +18,7 @@ const FetchChargeVersionsService = require('./fetch-charge-versions.service.js')
 const GenerateBillingTransactionsService = require('./generate-billing-transactions.service.js')
 const GenerateBillingInvoiceService = require('./generate-billing-invoice.service.js')
 const GenerateBillingInvoiceLicenceService = require('./generate-billing-invoice-licence.service.js')
+const HandleErroredBillingBatchService = require('./handle-errored-billing-batch.service.js')
 const LegacyRequestLib = require('../../lib/legacy-request.lib.js')
 
 /**
@@ -84,7 +85,7 @@ async function go (billingBatch, billingPeriod) {
 
     await _finaliseBillingBatch(billingBatch, generatedInvoices, generatedInvoiceLicences)
   } catch (error) {
-    await _updateStatus(billingBatchId, 'error')
+    await HandleErroredBillingBatchService.go(billingBatchId)
 
     global.GlobalNotifier.omfg('Billing Batch process errored', { billingBatch, error })
   }

--- a/app/services/supplementary-billing/process-billing-batch.service.js
+++ b/app/services/supplementary-billing/process-billing-batch.service.js
@@ -139,7 +139,6 @@ async function _createTransactionLines (
 
       const chargingModuleResponse = await ChargingModuleCreateTransactionService.go(billingBatch.externalId, chargingModuleRequest)
 
-      // TODO: Handle a failed request
       transaction.status = 'charge_created'
       transaction.externalId = chargingModuleResponse.response.body.transaction.id
       transaction.billingInvoiceLicenceId = billingInvoiceLicence.billingInvoiceLicenceId

--- a/test/services/supplementary-billing/handle-errored-billing-batch.service.test.js
+++ b/test/services/supplementary-billing/handle-errored-billing-batch.service.test.js
@@ -1,0 +1,84 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { describe, it, beforeEach, afterEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const BillingBatchHelper = require('../../support/helpers/water/billing-batch.helper.js')
+
+// Thing under test
+const HandleErroredBillingBatchService = require('../../../app/services/supplementary-billing/handle-errored-billing-batch.service.js')
+
+describe('Handle Errored Billing Batch service', () => {
+  let billingBatch
+  let notifierStub
+
+  beforeEach(async () => {
+    // RequestLib depends on the GlobalNotifier to have been set. This happens in app/plugins/global-notifier.plugin.js
+    // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
+    // test we recreate the condition by setting it directly with our own stub
+    notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
+    global.GlobalNotifier = notifierStub
+
+    billingBatch = await BillingBatchHelper.add()
+  })
+
+  afterEach(() => {
+    Sinon.restore()
+  })
+
+  describe('when the service is called successfully', () => {
+    it('sets the billing batch status to `error`', async () => {
+      await HandleErroredBillingBatchService.go(billingBatch.billingBatchId)
+
+      const result = await billingBatch.$query()
+
+      expect(result.status).to.equal('error')
+    })
+
+    describe('when no error code is passed', () => {
+      it('doesn\'t set an error code', async () => {
+        await HandleErroredBillingBatchService.go(billingBatch.billingBatchId)
+
+        const result = await billingBatch.$query()
+
+        expect(result.errorCode).to.be.null()
+      })
+    })
+
+    describe('when an error code is passed', () => {
+      it('does set an error code', async () => {
+        await HandleErroredBillingBatchService.go(billingBatch.billingBatchId, 40)
+
+        const result = await billingBatch.$query()
+
+        expect(result.errorCode).to.equal(40)
+      })
+    })
+  })
+
+  describe('when the service is called unsuccessfully', () => {
+    describe('because patching the billing batch fails', () => {
+      it('handles the error', async () => {
+        await expect(HandleErroredBillingBatchService.go(billingBatch.billingBatchId, 'INVALID_ERROR_CODE')).not.to.reject()
+      })
+
+      it('logs an error', async () => {
+        // Note that we would not normally pass a string as an error code but we do this here to force the patch to fail
+        // in lieu of a working method of stubbing Objection
+        await HandleErroredBillingBatchService.go(billingBatch.billingBatchId, 'INVALID_ERROR_CODE')
+
+        const logDataArg = notifierStub.omfg.firstCall.args[1]
+
+        expect(notifierStub.omfg.calledWith('Failed to set error status on billing batch')).to.be.true()
+        expect(logDataArg.billingBatchId).to.equal(billingBatch.billingBatchId)
+        expect(logDataArg.errorCode).to.equal('INVALID_ERROR_CODE')
+      })
+    })
+  })
+})

--- a/test/services/supplementary-billing/process-billing-batch.service.test.js
+++ b/test/services/supplementary-billing/process-billing-batch.service.test.js
@@ -30,7 +30,7 @@ const HandleErroredBillingBatchService = require('../../../app/services/suppleme
 // Thing under test
 const ProcessBillingBatchService = require('../../../app/services/supplementary-billing/process-billing-batch.service.js')
 
-describe.only('Process billing batch service', () => {
+describe('Process billing batch service', () => {
   const billingPeriod = {
     startDate: new Date('2022-04-01'),
     endDate: new Date('2023-03-31')

--- a/test/services/supplementary-billing/process-billing-batch.service.test.js
+++ b/test/services/supplementary-billing/process-billing-batch.service.test.js
@@ -12,30 +12,43 @@ const { expect } = Code
 const BillingBatchHelper = require('../../support/helpers/water/billing-batch.helper.js')
 const DatabaseHelper = require('../../support/helpers/database.helper.js')
 
+// Things we need to stub
+const FetchChargeVersionsService = require('../../../app/services/supplementary-billing/fetch-charge-versions.service.js')
+
 // Thing under test
 const ProcessBillingBatchService = require('../../../app/services/supplementary-billing/process-billing-batch.service.js')
 
-describe.skip('Process billing batch service', () => {
+describe('Process billing batch service', () => {
   const billingPeriod = {
     startDate: new Date('2022-04-01'),
     endDate: new Date('2023-03-31')
   }
+
   let billingBatch
+  let notifierStub
 
   beforeEach(async () => {
     await DatabaseHelper.clean()
+
+    // RequestLib depends on the GlobalNotifier to have been set. This happens in app/plugins/global-notifier.plugin.js
+    // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
+    // test we recreate the condition by setting it directly with our own stub
+    notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
+    global.GlobalNotifier = notifierStub
   })
 
   afterEach(() => {
     Sinon.restore()
   })
 
-  describe('when the service is called', () => {
+  describe('when the service errors', () => {
     beforeEach(async () => {
       billingBatch = await BillingBatchHelper.add()
+
+      Sinon.stub(FetchChargeVersionsService, 'go').rejects()
     })
 
-    it('does something temporarily as it is just a placeholder at the moment', async () => {
+    it('handles the error', async () => {
       await expect(ProcessBillingBatchService.go(billingBatch, billingPeriod)).not.to.reject()
     })
   })

--- a/test/services/supplementary-billing/process-billing-batch.service.test.js
+++ b/test/services/supplementary-billing/process-billing-batch.service.test.js
@@ -10,6 +10,7 @@ const { expect } = Code
 
 // Test helpers
 const BillingBatchHelper = require('../../support/helpers/water/billing-batch.helper.js')
+const DatabaseHelper = require('../../support/helpers/database.helper.js')
 
 // Thing under test
 const ProcessBillingBatchService = require('../../../app/services/supplementary-billing/process-billing-batch.service.js')
@@ -20,6 +21,10 @@ describe.skip('Process billing batch service', () => {
     endDate: new Date('2023-03-31')
   }
   let billingBatch
+
+  beforeEach(async () => {
+    await DatabaseHelper.clean()
+  })
 
   afterEach(() => {
     Sinon.restore()

--- a/test/services/supplementary-billing/process-billing-batch.service.test.js
+++ b/test/services/supplementary-billing/process-billing-batch.service.test.js
@@ -10,10 +10,22 @@ const { expect } = Code
 
 // Test helpers
 const BillingBatchHelper = require('../../support/helpers/water/billing-batch.helper.js')
+const BillingBatchModel = require('../../../app/models/water/billing-batch.model.js')
+const BillingChargeCategoryHelper = require('../../support/helpers/water/billing-charge-category.helper.js')
+const ChangeReasonHelper = require('../../support/helpers/water/change-reason.helper.js')
+const ChargeElementHelper = require('../../support/helpers/water/charge-element.helper.js')
+const ChargePurposeHelper = require('../../support/helpers/water/charge-purpose.helper.js')
+const ChargeVersionHelper = require('../../support/helpers/water/charge-version.helper.js')
+const InvoiceAccountHelper = require('../../support/helpers/crm-v2/invoice-account.helper.js')
+const LicenceHelper = require('../../support/helpers/water/licence.helper.js')
 const DatabaseHelper = require('../../support/helpers/database.helper.js')
+const RegionHelper = require('../../support/helpers/water/region.helper.js')
 
 // Things we need to stub
+const ChargingModuleCreateTransactionService = require('../../../app/services/charging-module/create-transaction.service.js')
 const FetchChargeVersionsService = require('../../../app/services/supplementary-billing/fetch-charge-versions.service.js')
+const GenerateBillingTransactionsService = require('../../../app/services/supplementary-billing/generate-billing-transactions.service.js')
+const HandleErroredBillingBatchService = require('../../../app/services/supplementary-billing/handle-errored-billing-batch.service.js')
 
 // Thing under test
 const ProcessBillingBatchService = require('../../../app/services/supplementary-billing/process-billing-batch.service.js')
@@ -25,16 +37,30 @@ describe.only('Process billing batch service', () => {
   }
 
   let billingBatch
+  let handleErroredBillingBatchStub
   let notifierStub
 
   beforeEach(async () => {
     await DatabaseHelper.clean()
+
+    const { regionId } = await RegionHelper.add()
+    const { licenceId } = await LicenceHelper.add({ includeInSupplementaryBilling: 'yes', regionId })
+    const { changeReasonId } = await ChangeReasonHelper.add()
+    const { invoiceAccountId } = await InvoiceAccountHelper.add()
+    const { chargeVersionId } = await ChargeVersionHelper.add({ changeReasonId, invoiceAccountId }, { licenceId })
+    const { billingChargeCategoryId } = await BillingChargeCategoryHelper.add()
+    const { chargeElementId } = await ChargeElementHelper.add({ billingChargeCategoryId, chargeVersionId })
+    await ChargePurposeHelper.add({ chargeElementId })
+
+    billingBatch = await BillingBatchHelper.add({ regionId })
 
     // RequestLib depends on the GlobalNotifier to have been set. This happens in app/plugins/global-notifier.plugin.js
     // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
     // test we recreate the condition by setting it directly with our own stub
     notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
     global.GlobalNotifier = notifierStub
+
+    handleErroredBillingBatchStub = Sinon.stub(HandleErroredBillingBatchService, 'go')
   })
 
   afterEach(() => {
@@ -44,9 +70,7 @@ describe.only('Process billing batch service', () => {
   describe('when the service errors', () => {
     const expectedError = new Error('ERROR')
 
-    beforeEach(async () => {
-      billingBatch = await BillingBatchHelper.add()
-
+    beforeEach(() => {
       Sinon.stub(FetchChargeVersionsService, 'go').rejects(expectedError)
     })
 
@@ -54,12 +78,12 @@ describe.only('Process billing batch service', () => {
       await expect(ProcessBillingBatchService.go(billingBatch, billingPeriod)).not.to.reject()
     })
 
-    it('sets the billing batch status to `error`', async () => {
+    it('calls HandleErroredBillingBatchService with the billing batch id', async () => {
       await ProcessBillingBatchService.go(billingBatch, billingPeriod)
 
-      const refreshedBillingBatch = await billingBatch.$query()
+      const handlerArgs = handleErroredBillingBatchStub.firstCall.args
 
-      expect(refreshedBillingBatch.status).to.equal('error')
+      expect(handlerArgs[0]).to.equal(billingBatch.billingBatchId)
     })
 
     it('logs the error', async () => {
@@ -70,6 +94,48 @@ describe.only('Process billing batch service', () => {
       expect(notifierStub.omfg.calledWith('Billing Batch process errored')).to.be.true()
       expect(logDataArg.billingBatch).to.equal(billingBatch)
       expect(logDataArg.error).to.equal(expectedError)
+    })
+  })
+
+  describe('when attempting to fetch the charge versions fails', () => {
+    beforeEach(() => {
+      Sinon.stub(FetchChargeVersionsService, 'go').rejects()
+    })
+
+    it('sets the appropriate error code', async () => {
+      await ProcessBillingBatchService.go(billingBatch, billingPeriod)
+
+      const handlerArgs = handleErroredBillingBatchStub.firstCall.args
+
+      expect(handlerArgs[1]).to.equal(BillingBatchModel.errorCodes.failedToProcessChargeVersions)
+    })
+  })
+
+  describe('when attempting to generate the transaction lines fails', () => {
+    beforeEach(() => {
+      Sinon.stub(GenerateBillingTransactionsService, 'go').throws()
+    })
+
+    it('sets the appropriate error code', async () => {
+      await ProcessBillingBatchService.go(billingBatch, billingPeriod)
+
+      const handlerArgs = handleErroredBillingBatchStub.firstCall.args
+
+      expect(handlerArgs[1]).to.equal(BillingBatchModel.errorCodes.failedToPrepareTransactions)
+    })
+  })
+
+  describe('when attempting to create the transaction lines fails', () => {
+    beforeEach(() => {
+      Sinon.stub(ChargingModuleCreateTransactionService, 'go').rejects()
+    })
+
+    it('sets the appropriate error code', async () => {
+      await ProcessBillingBatchService.go(billingBatch, billingPeriod)
+
+      const handlerArgs = handleErroredBillingBatchStub.firstCall.args
+
+      expect(handlerArgs[1]).to.equal(BillingBatchModel.errorCodes.failedToCreateCharge)
     })
   })
 })

--- a/test/services/supplementary-billing/process-billing-batch.service.test.js
+++ b/test/services/supplementary-billing/process-billing-batch.service.test.js
@@ -18,7 +18,7 @@ const FetchChargeVersionsService = require('../../../app/services/supplementary-
 // Thing under test
 const ProcessBillingBatchService = require('../../../app/services/supplementary-billing/process-billing-batch.service.js')
 
-describe('Process billing batch service', () => {
+describe.only('Process billing batch service', () => {
   const billingPeriod = {
     startDate: new Date('2022-04-01'),
     endDate: new Date('2023-03-31')
@@ -42,14 +42,34 @@ describe('Process billing batch service', () => {
   })
 
   describe('when the service errors', () => {
+    const expectedError = new Error('ERROR')
+
     beforeEach(async () => {
       billingBatch = await BillingBatchHelper.add()
 
-      Sinon.stub(FetchChargeVersionsService, 'go').rejects()
+      Sinon.stub(FetchChargeVersionsService, 'go').rejects(expectedError)
     })
 
     it('handles the error', async () => {
       await expect(ProcessBillingBatchService.go(billingBatch, billingPeriod)).not.to.reject()
+    })
+
+    it('sets the billing batch status to `error`', async () => {
+      await ProcessBillingBatchService.go(billingBatch, billingPeriod)
+
+      const refreshedBillingBatch = await billingBatch.$query()
+
+      expect(refreshedBillingBatch.status).to.equal('error')
+    })
+
+    it('logs the error', async () => {
+      await ProcessBillingBatchService.go(billingBatch, billingPeriod)
+
+      const logDataArg = notifierStub.omfg.firstCall.args[1]
+
+      expect(notifierStub.omfg.calledWith('Billing Batch process errored')).to.be.true()
+      expect(logDataArg.billingBatch).to.equal(billingBatch)
+      expect(logDataArg.error).to.equal(expectedError)
     })
   })
 })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3924

Should an error occur during the supplementary bill run process it brings down the service. We're not handling the exception and because we moved the process to the background in our bill runs controller, there is nothing to deal with it when thrown.

So, we need to protect the service from _any_ errors during the process, to prevent the service from going down. But we also need to mimic the legacy service and use an 'error code' to provide extra information about the error. We've already used this concept with [Create error bill run when CM fails](https://github.com/DEFRA/water-abstraction-system/pull/104) where we apply a code to the `billing_batch` record which the UI then uses to indicate what happened to the user.

This change deals with both; ensuring we handle any exceptions raised and where possible, setting a relevant error code when updating the `billing_batch` status to 'errored'.