### PR TITLE
Create fetch billing invoice licence service

### DIFF
--- a/app/services/supplementary-billing/fetch-billing-invoice-licence.service.js
+++ b/app/services/supplementary-billing/fetch-billing-invoice-licence.service.js
@@ -39,7 +39,7 @@ async function go (foundBillingInvoiceLicenceIds, licenceId, financialYearEnding
   const billingInvoiceLicenceData = await _fetch(licenceId, financialYearEnding)
 
   billingInvoiceLicence = {
-    billingInvoiceLicenceId: billingInvoiceLicenceData.billingInvoiceLicenceId,
+    billingInvoiceLicenceId: billingInvoiceLicenceData[0].billingInvoiceLicenceId,
     licenceId,
     financialYearEnding
   }

--- a/app/services/supplementary-billing/fetch-billing-invoice-licence.service.js
+++ b/app/services/supplementary-billing/fetch-billing-invoice-licence.service.js
@@ -1,0 +1,81 @@
+'use strict'
+
+/**
+ * Fetches a billingInvoiceLicenceId for a the last 'sent' billrun if one exists
+ * @module FetchBillingInvoiceLicenceService
+ */
+
+const { db } = require('../../../db/db.js')
+
+/**
+ * Return either a new billing invoice licence object to use to find the transactions or an existing one if it exists
+ *
+ * This first checks whether a billing invoice licence with the same licence ID & financial year exists in
+ * `foundBillingInvoiceLicenceIds`. The calling service is expected to provide and keep track of this variable between
+ * between calls. If it does, it returns that instance along with the original array unchanged.
+ *
+ * If it doesn't, we generate a new instance and create a new array, based on the one provided plus our new instance.
+ * We then return the instance and the new array as the result.
+ *
+ * For context, this is all to avoid searching for `billing_invoice_licence` records unnecessarily.
+ *
+ * @param {Object[]} foundBillingInvoiceLicenceIds An array of previously generated billing invoice licence objects
+ * @param {*} licenceId UUID of the licence the billing invoice licence is linked to
+ * @param {*} financialYearEnding The financial year ending of the related billing invoice
+ *
+ * @returns {Object} A result object containing either the found or generated billing invoice licence object, and an
+ * array of generated billing invoices which includes the one being returned
+ */
+async function go (foundBillingInvoiceLicenceIds, licenceId, financialYearEnding) {
+  let billingInvoiceLicence = _existing(foundBillingInvoiceLicenceIds, licenceId, financialYearEnding)
+
+  if (billingInvoiceLicence) {
+    return {
+      billingInvoiceLicence,
+      billingInvoiceLicences: foundBillingInvoiceLicenceIds
+    }
+  }
+
+  const billingInvoiceLicenceData = await _fetch(licenceId, financialYearEnding)
+
+  billingInvoiceLicence = {
+    billingInvoiceLicenceId: billingInvoiceLicenceData.billingInvoiceLicenceId,
+    licenceId,
+    financialYearEnding
+  }
+  const updatedBillingInvoiceLicences = [...foundBillingInvoiceLicenceIds, billingInvoiceLicence]
+
+  return {
+    billingInvoiceLicence,
+    billingInvoiceLicences: updatedBillingInvoiceLicences
+  }
+}
+
+function _existing (foundBillingInvoiceLicenceIds, licenceId, financialYearEnding) {
+  return foundBillingInvoiceLicenceIds.find((invoiceLicences) => {
+    return licenceId === invoiceLicences.licenceId && financialYearEnding === invoiceLicences.financialYearEnding
+  })
+}
+
+async function _fetch (licenceId, financialYearEnding) {
+  const result = db
+    .select('bil.billingInvoiceLicenceId')
+    .max('bil.date_created as latest_date_created')
+    .from('water.billingInvoiceLicences as bil')
+    .innerJoin('water.licences as l', 'bil.licenceId', 'l.licenceId')
+    .innerJoin('water.billingInvoices as bi', 'bil.billingInvoiceId', 'bi.billingInvoiceId')
+    .innerJoin('water.billingBatches as bb', 'bi.billingBatchId', 'bb.billingBatchId')
+    .where({
+      'bi.financialYearEnding': financialYearEnding,
+      'bb.status': 'sent',
+      'bb.scheme': 'sroc',
+      'l.licenceId': licenceId
+    })
+    .groupBy('bil.billingInvoiceLicenceId')
+
+  return result
+}
+
+module.exports = {
+  go
+}

--- a/app/services/supplementary-billing/fetch-billing-invoice-licence.service.js
+++ b/app/services/supplementary-billing/fetch-billing-invoice-licence.service.js
@@ -1,30 +1,30 @@
 'use strict'
 
 /**
- * Fetches a billingInvoiceLicenceId for a the last 'sent' billrun if one exists
+ * Fetches the transactions for a the last 'sent' billrun if one exists
  * @module FetchBillingInvoiceLicenceService
  */
 
 const { db } = require('../../../db/db.js')
 
 /**
- * Return either a new billing invoice licence object to use to find the transactions or an existing one if it exists
+ * Return either a new billing transaction object to use or an existing one if it exists
  *
- * This first checks whether a billing invoice licence with the same licence ID & financial year exists in
- * `foundBillingInvoiceLicenceIds`. The calling service is expected to provide and keep track of this variable between
+ * This first checks whether billing transactions for the same licence ID & financial year exists in
+ * `foundBillingTransactions`. The calling service is expected to provide and keep track of this variable between
  * between calls. If it does, it returns that instance along with the original array unchanged.
  *
  * If it doesn't, we generate a new instance and create a new array, based on the one provided plus our new instance.
  * We then return the instance and the new array as the result.
  *
- * For context, this is all to avoid searching for `billing_invoice_licence` records unnecessarily.
+ * For context, this is all to avoid searching for `billing_transaction` records unnecessarily.
  *
- * @param {Object[]} foundBillingInvoiceLicenceIds An array of previously generated billing invoice licence objects
+ * @param {Object[]} foundBillingTransactions An array of previously generated billing transaction objects
  * @param {*} licenceId UUID of the licence the billing invoice licence is linked to
  * @param {*} financialYearEnding The financial year ending of the related billing invoice
  *
- * @returns {Object} A result object containing either the found or generated billing invoice licence object, and an
- * array of generated billing invoices which includes the one being returned
+ * @returns {Object} A result object containing either the found or generated billing transaction object, and an
+ * array of generated billing transactions which includes the one being returned
  */
 async function go (foundBillingTransactions, licenceId, financialYearEnding) {
   let billingTransaction = _existing(foundBillingTransactions, licenceId, financialYearEnding)

--- a/app/services/supplementary-billing/fetch-billing-invoice-licence.service.js
+++ b/app/services/supplementary-billing/fetch-billing-invoice-licence.service.js
@@ -59,7 +59,37 @@ function _existing (foundBillingTransactions, licenceId, financialYearEnding) {
 
 async function _fetch (licenceId, financialYearEnding) {
   const result = db
-    .select('bt.*')
+    .select(
+      'authorisedDays',
+      'billableDays',
+      'isWaterUndertaker',
+      'chargeElementId',
+      'startDate',
+      'endDate',
+      'source',
+      'season',
+      'loss',
+      'isCredit',
+      'chargeType',
+      'authorisedQuantity',
+      'billableQuantity',
+      'description',
+      'volume',
+      'section126Factor',
+      'section127Agreement',
+      'section130Agreement',
+      'isTwoPartSecondPartCharge',
+      'scheme',
+      'aggregateFactor',
+      'adjustmentFactor',
+      'chargeCategoryCode',
+      'chargeCategoryDescription',
+      'isSupportedSource',
+      'supportedSourceName',
+      'isWaterCompanyCharge',
+      'isWinterOnly',
+      'purposes'
+    )
     .from('water.billingTransactions as bt')
     .innerJoin(
       db


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3936

When we generate a supplementary bill run we are required to reverse the previous one. Essentially, when a licence is flagged for supplementary billing, for whatever reason, we reverse any previous bill runs and generate a new one.

With the exception of Annual billing, because we know any previous supplementary bill run will have reversed the one that came before, any new runs also just need to focus on the ones previous to them.

So, for each charge version `FetchChargeVersionsService` returns we'll need to identify if they are linked to a previous `billing_batch`. From there we'll need to locate the transactions and use them to generate new ones, which reverse what was previously done.

This PR creates the `FetchBillingInvoiceLicenceService` which accepts a `licenceId` and `financialYearEnding`. If it has been previously billed it returns the `billingInvoiceLicenceId` from the last time the licence was billed. The `billingInvoiceLicenceId` can then be used to retrieve the last set of transactions for the licence from the `billing_transactions` table.