### PR TITLE
Handle no charge versions in ProcessBillingBatch

### DIFF
--- a/app/services/supplementary-billing/process-billing-batch.service.js
+++ b/app/services/supplementary-billing/process-billing-batch.service.js
@@ -190,6 +190,12 @@ async function _finaliseBillingBatch (billingBatch, isEmpty) {
 
 async function _finaliseCurrentInvoiceLicence (currentBillingData, billingPeriod, billingBatch) {
   try {
+    // Guard clause which is most likely to hit in the event that no charge versions were 'fetched' to be billed in the
+    // first place
+    if (!currentBillingData.billingInvoice) {
+      return
+    }
+
     const cleansedTransactions = await ProcessBillingTransactionsService.go(
       currentBillingData.calculatedTransactions,
       currentBillingData.billingInvoice,

--- a/test/services/supplementary-billing/process-billing-batch.service.test.js
+++ b/test/services/supplementary-billing/process-billing-batch.service.test.js
@@ -69,6 +69,20 @@ describe.only('Process billing batch service', () => {
   })
 
   describe('when the service is called', () => {
+    describe('and there are no charge versions to process', () => {
+      beforeEach(() => {
+        Sinon.stub(FetchChargeVersionsService, 'go').resolves([])
+      })
+
+      it('sets the Billing Batch status to empty', async () => {
+        await ProcessBillingBatchService.go(billingBatch, billingPeriod)
+
+        const result = await BillingBatchModel.query().findById(billingBatch.billingBatchId)
+
+        expect(result.status).to.equal('empty')
+      })
+    })
+
     beforeEach(() => {
       Sinon.stub(ChargingModuleCreateTransactionService, 'go').resolves({
         succeeded: true,

--- a/test/services/supplementary-billing/process-billing-batch.service.test.js
+++ b/test/services/supplementary-billing/process-billing-batch.service.test.js
@@ -49,7 +49,7 @@ describe('Process billing batch service', () => {
     await DatabaseHelper.clean()
 
     const { regionId } = await RegionHelper.add()
-    licence = await LicenceHelper.add({ includeInSupplementaryBilling: 'yes', regionId })
+    licence = await LicenceHelper.add({ includeInSrocSupplementaryBilling: true, regionId })
     changeReason = await ChangeReasonHelper.add()
     invoiceAccount = await InvoiceAccountHelper.add()
     billingChargeCategory = await BillingChargeCategoryHelper.add()

--- a/test/services/supplementary-billing/process-billing-transactions.service.test.js
+++ b/test/services/supplementary-billing/process-billing-transactions.service.test.js
@@ -167,6 +167,29 @@ describe('Process billing batch service', () => {
             expect(result.length).to.equal(0)
           })
         })
+
+        describe('are empty', () => {
+          beforeEach(() => {
+            previousTransactions = [allPreviousTransactions[0], allPreviousTransactions[1]]
+
+            Sinon.stub(FetchPreviousBillingTransactionsService, 'go').resolves(previousTransactions)
+          })
+
+          it('returns only the previous transactions', async () => {
+            const result = await ProcessBillingTransactionsService.go(
+              [],
+              billingInvoice,
+              billingInvoiceLicence,
+              billingPeriod
+            )
+
+            expect(result.length).to.equal(2)
+
+            // NOTE: We know the text says 'I_WILL_BE_REMOVED' but in this scenario they won't be!
+            expect(result[0].purposes).to.equal('I_WILL_BE_REMOVED_1')
+            expect(result[1].purposes).to.equal('I_WILL_BE_REMOVED_2')
+          })
+        })
       })
     })
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3952
https://eaflood.atlassian.net/browse/WATER-3803

To be honest, this change started as our first effort to add unit test coverage for the `ProcessBillingBatchService`. So, for example, our unit test error coverage now covers the changes we made including reversing the previous billing batch.

Whilst working on them we realised we were not handling no charge versions being returned at all. So, we put in protection against this issue. Nice!

Only our QA has come across this issue in testing and needs it resolved so they can continue their work.

Hence, we're derailing the original intent of this PR and getting the fix to handle no charge versions returned (plus tests! 😬)
