### PR TITLE
Licences in Workflow should not be considered

### DIFF
--- a/app/models/water/charge-version-workflow.model.js
+++ b/app/models/water/charge-version-workflow.model.js
@@ -1,0 +1,42 @@
+'use strict'
+
+/**
+ * Model for chargeVersionWorkflows
+ * @module ChargeVersionWorkflowModel
+ */
+
+const { Model } = require('objection')
+
+const WaterBaseModel = require('./water-base.model.js')
+
+class ChargeVersionWorkflowModel extends WaterBaseModel {
+  static get tableName () {
+    return 'chargeVersionWorkflows'
+  }
+
+  static get idColumn () {
+    return 'chargeVersionWorkflowId'
+  }
+
+  static get translations () {
+    return [
+      { database: 'dateCreated', model: 'createdAt' },
+      { database: 'dateUpdated', model: 'updatedAt' }
+    ]
+  }
+
+  static get relationMappings () {
+    return {
+      licence: {
+        relation: Model.BelongsToOneRelation,
+        modelClass: 'licence.model',
+        join: {
+          from: 'chargeVersionWorkflows.licenceId',
+          to: 'licences.licenceId'
+        }
+      }
+    }
+  }
+}
+
+module.exports = ChargeVersionWorkflowModel

--- a/app/models/water/licence.model.js
+++ b/app/models/water/licence.model.js
@@ -50,6 +50,14 @@ class LicenceModel extends WaterBaseModel {
           from: 'licences.licenceId',
           to: 'billingInvoiceLicences.licenceId'
         }
+      },
+      chargeVersionWorkflows: {
+        relation: Model.HasManyRelation,
+        modelClass: 'charge-version-workflow.model',
+        join: {
+          from: 'licences.licenceId',
+          to: 'chargeVersionWorkflows.licenceId'
+        }
       }
     }
   }

--- a/app/services/supplementary-billing/fetch-charge-versions.service.js
+++ b/app/services/supplementary-billing/fetch-charge-versions.service.js
@@ -43,7 +43,11 @@ async function _fetch (regionId, billingPeriod) {
     .where('chargeVersions.status', 'current')
     .where('chargeVersions.startDate', '>=', billingPeriod.startDate)
     .where('chargeVersions.startDate', '<=', billingPeriod.endDate)
-    .whereNotExists(ChargeVersionWorkflow.query().select(1).whereColumn('chargeVersions.licenceId', 'chargeVersionWorkflows.licenceId'))
+    .whereNotExists(
+      ChargeVersionWorkflow.query()
+        .select(1)
+        .whereColumn('chargeVersions.licenceId', 'chargeVersionWorkflows.licenceId')
+    )
     .orderBy([
       { column: 'chargeVersions.invoiceAccountId' },
       { column: 'chargeVersions.licenceId' }

--- a/app/services/supplementary-billing/fetch-charge-versions.service.js
+++ b/app/services/supplementary-billing/fetch-charge-versions.service.js
@@ -7,6 +7,7 @@ const { ref } = require('objection')
  */
 
 const ChargeVersion = require('../../models/water/charge-version.model.js')
+const ChargeVersionWorkflow = require('../../models/water/charge-version-workflow.model.js')
 
 /**
  * Fetch all SROC charge versions linked to licences flagged for supplementary billing that are in the period being
@@ -42,6 +43,7 @@ async function _fetch (regionId, billingPeriod) {
     .where('chargeVersions.status', 'current')
     .where('chargeVersions.startDate', '>=', billingPeriod.startDate)
     .where('chargeVersions.startDate', '<=', billingPeriod.endDate)
+    .whereNotExists(ChargeVersionWorkflow.query().select(1).whereColumn('chargeVersions.licenceId', 'chargeVersionWorkflows.licenceId'))
     .orderBy([
       { column: 'chargeVersions.invoiceAccountId' },
       { column: 'chargeVersions.licenceId' }

--- a/db/migrations/20230327095020_create-charge-version-workflows.js
+++ b/db/migrations/20230327095020_create-charge-version-workflows.js
@@ -1,0 +1,33 @@
+'use strict'
+
+const tableName = 'charge_version_workflows'
+
+exports.up = async function (knex) {
+  await knex
+    .schema
+    .withSchema('water')
+    .createTable(tableName, table => {
+      // Primary Key
+      table.uuid('charge_version_workflow_id').primary().defaultTo(knex.raw('gen_random_uuid()'))
+
+      // Data
+      table.uuid('licence_id').notNullable()
+      table.jsonb('created_by')
+      table.string('approver_comments')
+      table.string('status')
+      table.jsonb('data')
+      table.uuid('licence_version_id')
+      table.timestamp('date_deleted', { useTz: false })
+
+      // Legacy timestamps
+      table.timestamp('date_created', { useTz: false }).notNullable()
+      table.timestamp('date_updated', { useTz: false })
+    })
+}
+
+exports.down = function (knex) {
+  return knex
+    .schema
+    .withSchema('water')
+    .dropTableIfExists(tableName)
+}

--- a/test/models/water/charge-version-workflow.model.test.js
+++ b/test/models/water/charge-version-workflow.model.test.js
@@ -1,0 +1,68 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const ChargeVersionWorkflowHelper = require('../../support/helpers/water/charge-version-workflow.helper.js')
+const DatabaseHelper = require('../../support/helpers/database.helper.js')
+const LicenceHelper = require('../../support/helpers/water/licence.helper.js')
+const LicenceModel = require('../../../app/models/water/licence.model.js')
+
+// Thing under test
+const ChargeVersionWorkflowModel = require('../../../app/models/water/charge-version-workflow.model.js')
+
+describe('Charge Version Workflow model', () => {
+  let testRecord
+
+  beforeEach(async () => {
+    await DatabaseHelper.clean()
+
+    testRecord = await ChargeVersionWorkflowHelper.add()
+  })
+
+  describe('Basic query', () => {
+    it('can successfully run a basic query', async () => {
+      const result = await ChargeVersionWorkflowModel.query().findById(testRecord.chargeVersionWorkflowId)
+
+      expect(result).to.be.an.instanceOf(ChargeVersionWorkflowModel)
+      expect(result.chargeVersionWorkflowId).to.equal(testRecord.chargeVersionWorkflowId)
+    })
+  })
+
+  describe('Relationships', () => {
+    describe('when linking to licence', () => {
+      let testLicence
+
+      beforeEach(async () => {
+        testLicence = await LicenceHelper.add()
+
+        const { licenceId } = testLicence
+        testRecord = await ChargeVersionWorkflowHelper.add({ licenceId })
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await ChargeVersionWorkflowModel.query()
+          .innerJoinRelated('licence')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the licence', async () => {
+        const result = await ChargeVersionWorkflowModel.query()
+          .findById(testRecord.chargeVersionWorkflowId)
+          .withGraphFetched('licence')
+
+        expect(result).to.be.instanceOf(ChargeVersionWorkflowModel)
+        expect(result.chargeVersionWorkflowId).to.equal(testRecord.chargeVersionWorkflowId)
+
+        expect(result.licence).to.be.an.instanceOf(LicenceModel)
+        expect(result.licence).to.equal(testLicence)
+      })
+    })
+  })
+})

--- a/test/models/water/licence.model.test.js
+++ b/test/models/water/licence.model.test.js
@@ -141,7 +141,7 @@ describe('Licence model', () => {
       })
     })
 
-    describe.only('when linking to charge version workflows', () => {
+    describe('when linking to charge version workflows', () => {
       let testChargeVersionWorkflows
 
       beforeEach(async () => {

--- a/test/models/water/licence.model.test.js
+++ b/test/models/water/licence.model.test.js
@@ -12,6 +12,8 @@ const BillingInvoiceLicenceHelper = require('../../support/helpers/water/billing
 const BillingInvoiceLicenceModel = require('../../../app/models/water/billing-invoice-licence.model.js')
 const ChargeVersionHelper = require('../../support/helpers/water/charge-version.helper.js')
 const ChargeVersionModel = require('../../../app/models/water/charge-version.model.js')
+const ChargeVersionWorkflowHelper = require('../../support/helpers/water/charge-version-workflow.helper.js')
+const ChargeVersionWorkflowModel = require('../../../app/models/water/charge-version-workflow.model.js')
 const DatabaseHelper = require('../../support/helpers/database.helper.js')
 const LicenceHelper = require('../../support/helpers/water/licence.helper.js')
 const RegionHelper = require('../../support/helpers/water/region.helper.js')
@@ -136,6 +138,41 @@ describe('Licence model', () => {
         expect(result.billingInvoiceLicences[0]).to.be.an.instanceOf(BillingInvoiceLicenceModel)
         expect(result.billingInvoiceLicences).to.include(testBillingInvoiceLicences[0])
         expect(result.billingInvoiceLicences).to.include(testBillingInvoiceLicences[1])
+      })
+    })
+
+    describe.only('when linking to charge version workflows', () => {
+      let testChargeVersionWorkflows
+
+      beforeEach(async () => {
+        const { licenceId } = testRecord
+
+        testChargeVersionWorkflows = []
+        for (let i = 0; i < 2; i++) {
+          const chargeVersionWorkflow = await ChargeVersionWorkflowHelper.add({ licenceId })
+          testChargeVersionWorkflows.push(chargeVersionWorkflow)
+        }
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await LicenceModel.query()
+          .innerJoinRelated('chargeVersionWorkflows')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the charge version workflows', async () => {
+        const result = await LicenceModel.query()
+          .findById(testRecord.licenceId)
+          .withGraphFetched('chargeVersionWorkflows')
+
+        expect(result).to.be.instanceOf(LicenceModel)
+        expect(result.licenceId).to.equal(testRecord.licenceId)
+
+        expect(result.chargeVersionWorkflows).to.be.an.array()
+        expect(result.chargeVersionWorkflows[0]).to.be.an.instanceOf(ChargeVersionWorkflowModel)
+        expect(result.chargeVersionWorkflows).to.include(testChargeVersionWorkflows[0])
+        expect(result.chargeVersionWorkflows).to.include(testChargeVersionWorkflows[1])
       })
     })
   })

--- a/test/services/supplementary-billing/fetch-charge-versions.service.test.js
+++ b/test/services/supplementary-billing/fetch-charge-versions.service.test.js
@@ -13,6 +13,7 @@ const ChargeElementHelper = require('../../support/helpers/water/charge-element.
 const ChargePurposeHelper = require('../../support/helpers/water/charge-purpose.helper.js')
 const ChangeReasonHelper = require('../../support/helpers/water/change-reason.helper.js')
 const ChargeVersionHelper = require('../../support/helpers/water/charge-version.helper.js')
+const ChargeVersionWorkflowHelper = require('../../support/helpers/water/charge-version-workflow.helper.js')
 const DatabaseHelper = require('../../support/helpers/database.helper.js')
 const LicenceHelper = require('../../support/helpers/water/licence.helper.js')
 const RegionHelper = require('../../support/helpers/water/region.helper.js')
@@ -268,6 +269,32 @@ describe('Fetch Charge Versions service', () => {
           }
         )
         testRecords = [otherRegionChargeVersion]
+      })
+
+      it('returns no applicable charge versions', async () => {
+        const result = await FetchChargeVersionsService.go(regionId, billingPeriod)
+
+        expect(result.length).to.equal(0)
+      })
+    })
+
+    describe.only('because the licence is in workflow', () => {
+      beforeEach(async () => {
+        billingPeriod = {
+          startDate: new Date('2022-04-01'),
+          endDate: new Date('2023-03-31')
+        }
+
+        const chargeVersion = await ChargeVersionHelper.add(
+          {},
+          {
+            includeInSupplementaryBilling: 'yes',
+            regionId
+          }
+        )
+        await ChargeVersionWorkflowHelper.add({ licenceId: chargeVersion.licenceId })
+
+        testRecords = [chargeVersion]
       })
 
       it('returns no applicable charge versions', async () => {

--- a/test/services/supplementary-billing/fetch-charge-versions.service.test.js
+++ b/test/services/supplementary-billing/fetch-charge-versions.service.test.js
@@ -278,7 +278,7 @@ describe('Fetch Charge Versions service', () => {
       })
     })
 
-    describe.only('because the licence is in workflow', () => {
+    describe('because the licence is in workflow', () => {
       beforeEach(async () => {
         billingPeriod = {
           startDate: new Date('2022-04-01'),

--- a/test/support/helpers/water/charge-version-workflow.helper.js
+++ b/test/support/helpers/water/charge-version-workflow.helper.js
@@ -1,0 +1,56 @@
+'use strict'
+
+/**
+ * @module ChargeVersionWorkflowHelper
+ */
+
+const ChargeVersionWorkflowModel = require('../../../../app/models/water/charge-version-workflow.model.js')
+
+/**
+ * Add a new charge version workflow
+ *
+ * If no `data` is provided, default values will be used. These are
+ *
+ * - `licenceId` - 1acfbded-9cd4-4933-8e98-04cd9e92d884
+ * - `status` - to_setup - Other possible values are: changes_requested & review
+ * - `data` - { chargeVersion: null },
+ * - `createdAt` - 2022-02-23
+ *
+ * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ *
+ * @returns {module:ChangeReasonModel} The instance of the newly created record
+ */
+function add (data = {}) {
+  const insertData = defaults(data)
+
+  return ChargeVersionWorkflowModel.query()
+    .insert({ ...insertData })
+    .returning('*')
+}
+
+/**
+ * Returns the defaults used when creating a new charge version workflow
+ *
+ * It will override or append to them any data provided. Mainly used by the `add()` method, we make it available
+ * for use in tests to avoid having to duplicate values.
+ *
+ * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ */
+function defaults (data = {}) {
+  const defaults = {
+    licenceId: '1acfbded-9cd4-4933-8e98-04cd9e92d884',
+    status: 'to_setup',
+    data: { chargeVersion: null },
+    createdAt: new Date()
+  }
+
+  return {
+    ...defaults,
+    ...data
+  }
+}
+
+module.exports = {
+  add,
+  defaults
+}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3949

Prevent licences that appear in the `charge_versions_workflow` table from being included in the bill run.

If a licence is in the workflow for any reason it is a business requirement that it is not included in supplementary billing.

This change insures that any charge versions linked to a licence that is in workflow are not included in a supplementary bill run.