### PR TITLE
Fix no error in logs for process billing batch

### DIFF
--- a/app/services/supplementary-billing/process-billing-batch.service.js
+++ b/app/services/supplementary-billing/process-billing-batch.service.js
@@ -81,7 +81,7 @@ async function go (billingBatch, billingPeriod) {
     // Log how long the process took
     _calculateAndLogTime(billingBatchId, startTime)
   } catch (error) {
-    global.GlobalNotifier.omfg('Billing Batch process errored', { billingBatch, error })
+    _logError(billingBatch, error)
   }
 }
 
@@ -259,6 +259,19 @@ function _generateCalculatedTransactions (billingPeriod, chargeVersion, billingB
 
     throw error
   }
+}
+
+function _logError (billingBatch, error) {
+  global.GlobalNotifier.omfg(
+    'Billing Batch process errored',
+    {
+      billingBatch,
+      error: {
+        name: error.name,
+        message: error.message,
+        stack: error.stack
+      }
+    })
 }
 
 async function _updateStatus (billingBatchId, status) {

--- a/test/services/supplementary-billing/process-billing-batch.service.test.js
+++ b/test/services/supplementary-billing/process-billing-batch.service.test.js
@@ -117,7 +117,11 @@ describe('Process billing batch service', () => {
 
       expect(notifierStub.omfg.calledWith('Billing Batch process errored')).to.be.true()
       expect(logDataArg.billingBatch).to.equal(billingBatch)
-      expect(logDataArg.error).to.equal(expectedError)
+      expect(logDataArg.error).to.equal({
+        name: expectedError.name,
+        message: expectedError.message,
+        stack: expectedError.stack
+      })
     })
   })
 


### PR DESCRIPTION
We've noticed when working on the `ProcessBillingBatchService` that when we get an error our logging mechanism doesn't seem to show it. We can see the error in Errbit and the billing batch instance appears in both(Errbit and the logs). But the error is always shown as `error: {}` in our logs.

Having traced it through we're confident that we are generating an object that contains the information. Debugging `GlobalNotifierLib._formatLogPacket()` confirms we see both the billing batch and the error instance. So, we conclude that the information gets dropped by [pino](https://github.com/pinojs/pino) when it attempts to output it as JSON. Perhaps it doesn't parse so **pino** quietly drops it?

Whatever the reason, we have to try and resolve the issue. What we have found is that if we extract the properties of the error and forward them as a new object then everything outputs as intended.

```
[07:56:51.450] ERROR (2801):
    message: "Billing Batch process errored"
    billingBatch: {
      "regionId": "adca5dd3-114d-4477-8cdd-684081429f4b",
      "fromFinancialYearEnding": 2023,
      "toFinancialYearEnding": 2023,
      "batchType": "supplementary",
      "scheme": "sroc",
      "source": "wrls",
      "externalId": "707e14e4-701c-4479-8c4f-c3eb03068983",
      "status": "queued",
      "errorCode": null,
      "billRunNumber": 10193,
      "billingBatchId": "b609cc45-a7d0-4be6-a24e-92832b0089b3",
      "invoiceCount": null,
      "creditNoteCount": null,
      "netTotal": null,
      "isSummer": false,
      "legacyId": null,
      "metadata": null,
      "invoiceValue": null,
      "creditNoteValue": null,
      "transactionFileReference": null,
      "createdAt": "2023-03-30T07:56:51.339Z",
      "updatedAt": "2023-03-30T07:56:51.339Z",
      "region": {
        "regionId": "adca5dd3-114d-4477-8cdd-684081429f4b",
        "chargeRegionId": "E",
        "naldRegionId": 5,
        "name": "South West",
        "displayName": "South West",
        "isTest": false,
        "createdAt": "2022-06-15T10:41:37.635Z",
        "updatedAt": "2022-06-15T10:41:37.635Z"
      }
    }
    error: {
      "name": "TypeError",
      "message": "Cannot read properties of null (reading 'licenceId')",
      "stack":
          TypeError: Cannot read properties of null (reading 'licenceId')
              at Object.go (/home/repos/water-abstraction-system/app/services/supplementary-billing/fetch-previous-billing-transactions.service.js:12:27)
              at _fetchPreviousTransactions (/home/repos/water-abstraction-system/app/services/supplementary-billing/process-billing-transactions.service.js:60:70)
              at Object.go (/home/repos/water-abstraction-system/app/services/supplementary-billing/process-billing-transactions.service.js:7:38)
              at _finaliseCurrentInvoiceLicence (/home/repos/water-abstraction-system/app/services/supplementary-billing/process-billing-batch.service.js:193:74)
              at Object.go (/home/repos/water-abstraction-system/app/services/supplementary-billing/process-billing-batch.service.js:77:11)
              at processTicksAndRejections (node:internal/process/task_queues:96:5)
    }
```