### PR TITLE
Hack for supplementary billing being late

### DIFF
--- a/app/services/supplementary-billing/billing-period.service.js
+++ b/app/services/supplementary-billing/billing-period.service.js
@@ -8,7 +8,8 @@
 /**
  * Returns the billing periods needed when generating a supplementary bill run
  *
- * **IMPORANT!** This service currently only handles SROC billing periods and only the 'current year'
+ * **MORE IMPORTANT!** This service has been hacked to only return 2022-23
+ * **IMPORTANT!** This service currently only handles SROC billing periods and only the 'current year'
  *
  * Using the current date at the time the service is called, it calculates the billing periods to use. We permit
  * changes to charge versions to be retroactively applied up to 5 years. So, a bill run generated in 2022 would need
@@ -20,34 +21,45 @@
  * @returns {Object[]} an array of billing periods each containing a `startDate` and `endDate`.
  */
 function go () {
-  const currentDate = new Date()
-  const currentYear = currentDate.getFullYear()
-
-  // 01-APR to 31-MAR
-  const financialPeriod = {
-    start: { day: 1, month: 3 },
-    end: { day: 31, month: 2 }
-  }
-
-  let startYear
-  let endYear
-
-  // IMPORANT! getMonth returns an integer (0-11). So, January is represented as 0 and December as 11. This is why
-  // financialPeriod.end.month is 2 rather than 3, even though we mean March
-  if (currentDate.getMonth() <= financialPeriod.end.month) {
-    // For example, if currentDate was 2022-02-15 it would fall in financial year 2021-04-01 to 2022-03-31
-    startYear = currentYear - 1
-    endYear = currentYear
-  } else {
-    // For example, if currentDate was 2022-06-15 it would fall in financial year 2022-04-01 to 2023-03-31
-    startYear = currentYear
-    endYear = currentYear + 1
-  }
-
+  // TODO: We have hardcoded the billing period this service returns to be 2022-23 the first year SROC went live. This
+  // is because we were unable to get SROC supplementary billing shipped in 2022-23. Without this being hard coded and
+  // with multi-year support being the _next_ feature there would be no way to generate any supplementary bill runs for
+  // 2022-23.
+  //
+  // This will need removing and the code below uncommented and updated to handle multiple billing periods.
   return [{
-    startDate: new Date(startYear, financialPeriod.start.month, financialPeriod.start.day),
-    endDate: new Date(endYear, financialPeriod.end.month, financialPeriod.end.day)
+    startDate: new Date(2022, 3, 1),
+    endDate: new Date(2023, 2, 31)
   }]
+
+  // const currentDate = new Date()
+  // const currentYear = currentDate.getFullYear()
+
+  // // 01-APR to 31-MAR
+  // const financialPeriod = {
+  //   start: { day: 1, month: 3 },
+  //   end: { day: 31, month: 2 }
+  // }
+
+  // let startYear
+  // let endYear
+
+  // // IMPORTANT! getMonth returns an integer (0-11). So, January is represented as 0 and December as 11. This is why
+  // // financialPeriod.end.month is 2 rather than 3, even though we mean March
+  // if (currentDate.getMonth() <= financialPeriod.end.month) {
+  //   // For example, if currentDate was 2022-02-15 it would fall in financial year 2021-04-01 to 2022-03-31
+  //   startYear = currentYear - 1
+  //   endYear = currentYear
+  // } else {
+  //   // For example, if currentDate was 2022-06-15 it would fall in financial year 2022-04-01 to 2023-03-31
+  //   startYear = currentYear
+  //   endYear = currentYear + 1
+  // }
+
+  // return [{
+  //   startDate: new Date(startYear, financialPeriod.start.month, financialPeriod.start.day),
+  //   endDate: new Date(endYear, financialPeriod.end.month, financialPeriod.end.day)
+  // }]
 }
 
 module.exports = {

--- a/test/services/supplementary-billing/billing-period.service.test.js
+++ b/test/services/supplementary-billing/billing-period.service.test.js
@@ -59,7 +59,9 @@ describe('Billing Period service', () => {
     })
   })
 
-  describe('when the date is in 2023 and falls within the 2023 financial year', () => {
+  // TODO: See notes in app/services/supplementary-billing/billing-period.service.js for reasons why this is skipped
+  // and needs to be unskipped someday!
+  describe.skip('when the date is in 2023 and falls within the 2023 financial year', () => {
     beforeEach(async () => {
       testDate = new Date('2023-10-10')
       expectedResult = {


### PR DESCRIPTION
SROC supplementary billing was always intended to be shipped for use in the financial year 2022-23. We know at some point it will need to go back and look at previous years, as the PRE-SROC legacy version already does. But when we started this functionality was going to be added later.

So, we wrote the current functionality to look at the current financial year. That's a great idea when it's October 2022 and you aim to be done by Christmas! Fast forward to now, we're still plugging away and finding scenarios we've not covered or not handled (because we didn't know BTW). This means we've fallen into the financial year 2023-24!

😱😱😱😱😱

As a hack, to allow us to ship supplementary billing and get the 2022-23 bills out and then move to multi-year billing we're hard-coding the `BillingPeriodService` to always return 2022-23 (the first year of SROC's existence).