### PR TITLE
Clear the SROC Supp Billing flag when billrun empty

### DIFF
--- a/app/services/supplementary-billing/process-billing-batch.service.js
+++ b/app/services/supplementary-billing/process-billing-batch.service.js
@@ -20,6 +20,7 @@ const GenerateBillingInvoiceService = require('./generate-billing-invoice.servic
 const GenerateBillingInvoiceLicenceService = require('./generate-billing-invoice-licence.service.js')
 const HandleErroredBillingBatchService = require('./handle-errored-billing-batch.service.js')
 const LegacyRequestLib = require('../../lib/legacy-request.lib.js')
+const LicenceModel = require('../../models/water/licence.model.js')
 const ProcessBillingTransactionsService = require('./process-billing-transactions.service.js')
 
 /**
@@ -76,7 +77,7 @@ async function go (billingBatch, billingPeriod) {
     }
     await _finaliseCurrentInvoiceLicence(currentBillingData, billingPeriod, billingBatch)
 
-    await _finaliseBillingBatch(billingBatch, currentBillingData.isEmpty)
+    await _finaliseBillingBatch(billingBatch, chargeVersions, currentBillingData.isEmpty)
 
     // Log how long the process took
     _calculateAndLogTime(billingBatchId, startTime)
@@ -167,11 +168,12 @@ async function _fetchChargeVersions (billingBatch, billingPeriod) {
   }
 }
 
-async function _finaliseBillingBatch (billingBatch, isEmpty) {
+async function _finaliseBillingBatch (billingBatch, chargeVersions, isEmpty) {
   try {
     // The bill run is considered empty. We just need to set the status to indicate this in the UI
     if (isEmpty) {
       await _updateStatus(billingBatch.billingBatchId, 'empty')
+      await _setSuppBillingFlagsToFalse(chargeVersions)
 
       return
     }
@@ -290,6 +292,16 @@ async function _updateStatus (billingBatchId, status) {
 
     throw error
   }
+}
+
+async function _setSuppBillingFlagsToFalse (chargeVersions) {
+  const licenceIds = chargeVersions.map((chargeVersion) => {
+    return chargeVersion.licence.licenceId
+  })
+
+  await LicenceModel.query()
+    .whereIn('licenceId', licenceIds)
+    .patch({ includeInSrocSupplementaryBilling: false })
 }
 
 module.exports = {

--- a/test/services/supplementary-billing/process-billing-batch.service.test.js
+++ b/test/services/supplementary-billing/process-billing-batch.service.test.js
@@ -18,6 +18,7 @@ const ChargePurposeHelper = require('../../support/helpers/water/charge-purpose.
 const ChargeVersionHelper = require('../../support/helpers/water/charge-version.helper.js')
 const InvoiceAccountHelper = require('../../support/helpers/crm-v2/invoice-account.helper.js')
 const LicenceHelper = require('../../support/helpers/water/licence.helper.js')
+const LicenceModel = require('../../../app/models/water/licence.model.js')
 const DatabaseHelper = require('../../support/helpers/database.helper.js')
 const RegionHelper = require('../../support/helpers/water/region.helper.js')
 
@@ -129,6 +130,14 @@ describe('Process billing batch service', () => {
             const result = await BillingBatchModel.query().findById(billingBatch.billingBatchId)
 
             expect(result.status).to.equal('empty')
+          })
+
+          it('sets the includeInSrocSupplementaryBilling flag to false', async () => {
+            await ProcessBillingBatchService.go(billingBatch, billingPeriod)
+
+            const result = await LicenceModel.query().findById(licence.licenceId)
+
+            expect(result.includeInSrocSupplementaryBilling).to.equal(false)
           })
         })
       })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3948

The `include_in_sroc_supplementary_billing` flag on the licence was not set to `false` following a successful bill run if the bill run was empty.

This PR ensures that the flag is set to false if the bill run is empty.