### PR TITLE
Reverse previous SROC billing batches in supplementary bill run process

### DIFF
--- a/app/services/supplementary-billing/fetch-previous-billing-transactions.service.js
+++ b/app/services/supplementary-billing/fetch-previous-billing-transactions.service.js
@@ -1,7 +1,8 @@
 'use strict'
 
 /**
- * Fetches the previously billed transactions that match the invoice, licence and year provided
+ * Fetches the previously billed transactions that match the invoice, licence and year provided, removing any debits
+ * which are cancelled out by previous credits.
  * @module FetchPreviousBillingTransactionsService
  */
 
@@ -17,6 +18,11 @@ async function go (billingInvoice, billingInvoiceLicence, financialYearEnding) {
   return _cleanse(billingTransactions)
 }
 
+/**
+ * Cleanse the billing transactions by cancelling out matching pairs of debits and credits, and return the remaining
+ * debits. We judge a pair of credits and debits to be matching if they have the same number of billable days and the
+ * same charge type.
+ */
 function _cleanse (billingTransactions) {
   const credits = billingTransactions.filter((transaction) => transaction.isCredit)
   const debits = billingTransactions.filter((transaction) => !transaction.isCredit)


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3936

When we generate a supplementary bill run, we must reverse the previous ones in the same financial period. Essentially, when a licence is flagged for supplementary billing, for whatever reason, we reverse any previous bill runs and generate a new one.

This marks a change to our previous approach where only the last bill run was reversed. This is due to a scenario being found during testing which needed more than just the last bill run to be reversed. We therefore needed to change how we do this.

The way we decided to approach this is to get all credits and debits then remove any debits which have a matching credit, based on the value of billable days and the charge type. The debits that remain are the ones that we will then turn into credits in order to reverse the previous batches.