### PR TITLE
Standardise how we test the length of an array

### DIFF
--- a/test/services/check/supplementary-data.service.test.js
+++ b/test/services/check/supplementary-data.service.test.js
@@ -40,7 +40,7 @@ describe('Supplementary service', () => {
     it('always includes the current billing period', async () => {
       const result = await SupplementaryDataService.go(naldRegionId)
 
-      expect(result.billingPeriods.length).to.equal(1)
+      expect(result.billingPeriods).to.have.length(1)
       expect(result.billingPeriods[0]).to.equal(currentBillingPeriod)
     })
   })
@@ -62,7 +62,7 @@ describe('Supplementary service', () => {
       it('returns the matching charge versions', async () => {
         const result = await SupplementaryDataService.go(naldRegionId)
 
-        expect(result.chargeVersions.length).to.equal(1)
+        expect(result.chargeVersions).to.have.length(1)
         expect(result.chargeVersions[0].chargeVersionId).to.equal(testRecords[0].chargeVersionId)
       })
     })

--- a/test/services/supplementary-billing/billing-period.service.test.js
+++ b/test/services/supplementary-billing/billing-period.service.test.js
@@ -35,7 +35,7 @@ describe('Billing Period service', () => {
     it('returns the expected date range', () => {
       const result = BillingPeriodService.go()
 
-      expect(result.length).to.equal(1)
+      expect(result).to.have.length(1)
       expect(result[0]).to.equal(expectedResult)
     })
   })
@@ -54,7 +54,7 @@ describe('Billing Period service', () => {
     it('returns the expected date range', () => {
       const result = BillingPeriodService.go()
 
-      expect(result.length).to.equal(1)
+      expect(result).to.have.length(1)
       expect(result[0]).to.equal(expectedResult)
     })
   })
@@ -75,7 +75,7 @@ describe('Billing Period service', () => {
     it('returns the expected date range', () => {
       const result = BillingPeriodService.go()
 
-      expect(result.length).to.equal(1)
+      expect(result).to.have.length(1)
       expect(result[0]).to.equal(expectedResult)
     })
   })

--- a/test/services/supplementary-billing/fetch-charge-versions.service.test.js
+++ b/test/services/supplementary-billing/fetch-charge-versions.service.test.js
@@ -86,7 +86,7 @@ describe('Fetch Charge Versions service', () => {
     it("returns only the 'current' SROC charge versions that are applicable", async () => {
       const result = await FetchChargeVersionsService.go(regionId, billingPeriod)
 
-      expect(result.length).to.equal(1)
+      expect(result).to.have.length(1)
       expect(result[0].chargeVersionId).to.equal(testRecords[0].chargeVersionId)
     })
 
@@ -131,7 +131,7 @@ describe('Fetch Charge Versions service', () => {
         }]
       }
 
-      expect(result.length).to.equal(1)
+      expect(result).to.have.length(1)
       expect(result[0].chargeVersionId).to.equal(testRecords[0].chargeVersionId)
       expect(result[0].chargeElements[0]).to.equal(expectedResult)
     })
@@ -154,7 +154,7 @@ describe('Fetch Charge Versions service', () => {
       it('returns no applicable charge versions', async () => {
         const result = await FetchChargeVersionsService.go(regionId, billingPeriod)
 
-        expect(result.length).to.equal(0)
+        expect(result).to.have.length(0)
       })
     })
 
@@ -179,7 +179,7 @@ describe('Fetch Charge Versions service', () => {
       it('returns no applicable charge versions', async () => {
         const result = await FetchChargeVersionsService.go(regionId, billingPeriod)
 
-        expect(result.length).to.equal(0)
+        expect(result).to.have.length(0)
       })
     })
 
@@ -201,7 +201,7 @@ describe('Fetch Charge Versions service', () => {
       it('returns no applicable charge versions', async () => {
         const result = await FetchChargeVersionsService.go(regionId, billingPeriod)
 
-        expect(result.length).to.equal(0)
+        expect(result).to.have.length(0)
       })
     })
 
@@ -225,7 +225,7 @@ describe('Fetch Charge Versions service', () => {
         it('returns no applicable charge versions', async () => {
           const result = await FetchChargeVersionsService.go(regionId, billingPeriod)
 
-          expect(result.length).to.equal(0)
+          expect(result).to.have.length(0)
         })
       })
 
@@ -248,7 +248,7 @@ describe('Fetch Charge Versions service', () => {
         it('returns no applicable charge versions', async () => {
           const result = await FetchChargeVersionsService.go(regionId, billingPeriod)
 
-          expect(result.length).to.equal(0)
+          expect(result).to.have.length(0)
         })
       })
     })
@@ -274,7 +274,7 @@ describe('Fetch Charge Versions service', () => {
       it('returns no applicable charge versions', async () => {
         const result = await FetchChargeVersionsService.go(regionId, billingPeriod)
 
-        expect(result.length).to.equal(0)
+        expect(result).to.have.length(0)
       })
     })
 
@@ -300,7 +300,7 @@ describe('Fetch Charge Versions service', () => {
       it('returns no applicable charge versions', async () => {
         const result = await FetchChargeVersionsService.go(regionId, billingPeriod)
 
-        expect(result.length).to.equal(0)
+        expect(result).to.have.length(0)
       })
     })
   })

--- a/test/services/supplementary-billing/fetch-charge-versions.service.test.js
+++ b/test/services/supplementary-billing/fetch-charge-versions.service.test.js
@@ -154,7 +154,7 @@ describe('Fetch Charge Versions service', () => {
       it('returns no applicable charge versions', async () => {
         const result = await FetchChargeVersionsService.go(regionId, billingPeriod)
 
-        expect(result).to.have.length(0)
+        expect(result).to.be.empty()
       })
     })
 
@@ -179,7 +179,7 @@ describe('Fetch Charge Versions service', () => {
       it('returns no applicable charge versions', async () => {
         const result = await FetchChargeVersionsService.go(regionId, billingPeriod)
 
-        expect(result).to.have.length(0)
+        expect(result).to.be.empty()
       })
     })
 
@@ -201,7 +201,7 @@ describe('Fetch Charge Versions service', () => {
       it('returns no applicable charge versions', async () => {
         const result = await FetchChargeVersionsService.go(regionId, billingPeriod)
 
-        expect(result).to.have.length(0)
+        expect(result).to.be.empty()
       })
     })
 
@@ -225,7 +225,7 @@ describe('Fetch Charge Versions service', () => {
         it('returns no applicable charge versions', async () => {
           const result = await FetchChargeVersionsService.go(regionId, billingPeriod)
 
-          expect(result).to.have.length(0)
+          expect(result).to.be.empty()
         })
       })
 
@@ -248,7 +248,7 @@ describe('Fetch Charge Versions service', () => {
         it('returns no applicable charge versions', async () => {
           const result = await FetchChargeVersionsService.go(regionId, billingPeriod)
 
-          expect(result).to.have.length(0)
+          expect(result).to.be.empty()
         })
       })
     })
@@ -274,7 +274,7 @@ describe('Fetch Charge Versions service', () => {
       it('returns no applicable charge versions', async () => {
         const result = await FetchChargeVersionsService.go(regionId, billingPeriod)
 
-        expect(result).to.have.length(0)
+        expect(result).to.be.empty()
       })
     })
 
@@ -300,7 +300,7 @@ describe('Fetch Charge Versions service', () => {
       it('returns no applicable charge versions', async () => {
         const result = await FetchChargeVersionsService.go(regionId, billingPeriod)
 
-        expect(result).to.have.length(0)
+        expect(result).to.be.empty()
       })
     })
   })

--- a/test/services/supplementary-billing/fetch-replaced-charge-versions.service.test.js
+++ b/test/services/supplementary-billing/fetch-replaced-charge-versions.service.test.js
@@ -67,7 +67,7 @@ describe('Fetch Replaced Charge Versions service', () => {
     it("returns only the 'superseded' SROC charge versions that are applicable", async () => {
       const result = await FetchReplacedChargeVersionsService.go(regionId, billingPeriod, billingBatchId)
 
-      expect(result.length).to.equal(1)
+      expect(result).to.have.length(1)
       expect(result[0].chargeVersionId).to.equal(testRecords[1].chargeVersionId)
     })
 
@@ -103,7 +103,7 @@ describe('Fetch Replaced Charge Versions service', () => {
       it('returns no applicable charge versions', async () => {
         const result = await FetchReplacedChargeVersionsService.go(regionId, billingPeriod, billingBatchId)
 
-        expect(result.length).to.equal(0)
+        expect(result).to.have.length(0)
       })
     })
 
@@ -128,7 +128,7 @@ describe('Fetch Replaced Charge Versions service', () => {
       it('returns no applicable charge versions', async () => {
         const result = await FetchReplacedChargeVersionsService.go(regionId, billingPeriod, billingBatchId)
 
-        expect(result.length).to.equal(0)
+        expect(result).to.have.length(0)
       })
     })
 
@@ -150,7 +150,7 @@ describe('Fetch Replaced Charge Versions service', () => {
       it('returns no applicable charge versions', async () => {
         const result = await FetchReplacedChargeVersionsService.go(regionId, billingPeriod, billingBatchId)
 
-        expect(result.length).to.equal(0)
+        expect(result).to.have.length(0)
       })
     })
 
@@ -174,7 +174,7 @@ describe('Fetch Replaced Charge Versions service', () => {
         it('returns no applicable charge versions', async () => {
           const result = await FetchReplacedChargeVersionsService.go(regionId, billingPeriod, billingBatchId)
 
-          expect(result.length).to.equal(0)
+          expect(result).to.have.length(0)
         })
       })
 
@@ -197,7 +197,7 @@ describe('Fetch Replaced Charge Versions service', () => {
         it('returns no applicable charge versions', async () => {
           const result = await FetchReplacedChargeVersionsService.go(regionId, billingPeriod, billingBatchId)
 
-          expect(result.length).to.equal(0)
+          expect(result).to.have.length(0)
         })
       })
     })
@@ -223,7 +223,7 @@ describe('Fetch Replaced Charge Versions service', () => {
       it('returns no applicable charge versions', async () => {
         const result = await FetchReplacedChargeVersionsService.go(regionId, billingPeriod, billingBatchId)
 
-        expect(result.length).to.equal(0)
+        expect(result).to.have.length(0)
       })
     })
 
@@ -249,7 +249,7 @@ describe('Fetch Replaced Charge Versions service', () => {
       it('returns no applicable charge versions', async () => {
         const result = await FetchReplacedChargeVersionsService.go(regionId, billingPeriod, billingBatchId)
 
-        expect(result.length).to.equal(0)
+        expect(result).to.have.length(0)
       })
     })
 
@@ -276,7 +276,7 @@ describe('Fetch Replaced Charge Versions service', () => {
       it('returns no applicable charge versions', async () => {
         const result = await FetchReplacedChargeVersionsService.go(regionId, billingPeriod, billingBatchId)
 
-        expect(result.length).to.equal(0)
+        expect(result).to.have.length(0)
       })
     })
   })

--- a/test/services/supplementary-billing/fetch-replaced-charge-versions.service.test.js
+++ b/test/services/supplementary-billing/fetch-replaced-charge-versions.service.test.js
@@ -103,7 +103,7 @@ describe('Fetch Replaced Charge Versions service', () => {
       it('returns no applicable charge versions', async () => {
         const result = await FetchReplacedChargeVersionsService.go(regionId, billingPeriod, billingBatchId)
 
-        expect(result).to.have.length(0)
+        expect(result).to.be.empty()
       })
     })
 
@@ -128,7 +128,7 @@ describe('Fetch Replaced Charge Versions service', () => {
       it('returns no applicable charge versions', async () => {
         const result = await FetchReplacedChargeVersionsService.go(regionId, billingPeriod, billingBatchId)
 
-        expect(result).to.have.length(0)
+        expect(result).to.be.empty()
       })
     })
 
@@ -150,7 +150,7 @@ describe('Fetch Replaced Charge Versions service', () => {
       it('returns no applicable charge versions', async () => {
         const result = await FetchReplacedChargeVersionsService.go(regionId, billingPeriod, billingBatchId)
 
-        expect(result).to.have.length(0)
+        expect(result).to.be.empty()
       })
     })
 
@@ -174,7 +174,7 @@ describe('Fetch Replaced Charge Versions service', () => {
         it('returns no applicable charge versions', async () => {
           const result = await FetchReplacedChargeVersionsService.go(regionId, billingPeriod, billingBatchId)
 
-          expect(result).to.have.length(0)
+          expect(result).to.be.empty()
         })
       })
 
@@ -197,7 +197,7 @@ describe('Fetch Replaced Charge Versions service', () => {
         it('returns no applicable charge versions', async () => {
           const result = await FetchReplacedChargeVersionsService.go(regionId, billingPeriod, billingBatchId)
 
-          expect(result).to.have.length(0)
+          expect(result).to.be.empty()
         })
       })
     })
@@ -223,7 +223,7 @@ describe('Fetch Replaced Charge Versions service', () => {
       it('returns no applicable charge versions', async () => {
         const result = await FetchReplacedChargeVersionsService.go(regionId, billingPeriod, billingBatchId)
 
-        expect(result).to.have.length(0)
+        expect(result).to.be.empty()
       })
     })
 
@@ -249,7 +249,7 @@ describe('Fetch Replaced Charge Versions service', () => {
       it('returns no applicable charge versions', async () => {
         const result = await FetchReplacedChargeVersionsService.go(regionId, billingPeriod, billingBatchId)
 
-        expect(result).to.have.length(0)
+        expect(result).to.be.empty()
       })
     })
 
@@ -276,7 +276,7 @@ describe('Fetch Replaced Charge Versions service', () => {
       it('returns no applicable charge versions', async () => {
         const result = await FetchReplacedChargeVersionsService.go(regionId, billingPeriod, billingBatchId)
 
-        expect(result).to.have.length(0)
+        expect(result).to.be.empty()
       })
     })
   })

--- a/test/services/supplementary-billing/process-billing-transactions.service.test.js
+++ b/test/services/supplementary-billing/process-billing-transactions.service.test.js
@@ -164,7 +164,7 @@ describe('Process billing batch service', () => {
               billingPeriod
             )
 
-            expect(result).to.have.length(0)
+            expect(result).to.be.empty()
           })
         })
 

--- a/test/services/supplementary-billing/process-billing-transactions.service.test.js
+++ b/test/services/supplementary-billing/process-billing-transactions.service.test.js
@@ -123,7 +123,7 @@ describe('Process billing batch service', () => {
               billingPeriod
             )
 
-            expect(result.length).to.equal(1)
+            expect(result).to.have.length(1)
             expect(result[0]).to.equal(calculatedTransactions[2])
           })
         })
@@ -143,7 +143,7 @@ describe('Process billing batch service', () => {
               billingPeriod
             )
 
-            expect(result.length).to.equal(2)
+            expect(result).to.have.length(2)
             expect(result[0].purposes).to.equal('CALCULATED_TRANSACTION_3')
             expect(result[1].purposes).to.equal('I_WILL_NOT_BE_REMOVED')
           })
@@ -164,7 +164,7 @@ describe('Process billing batch service', () => {
               billingPeriod
             )
 
-            expect(result.length).to.equal(0)
+            expect(result).to.have.length(0)
           })
         })
 
@@ -183,7 +183,7 @@ describe('Process billing batch service', () => {
               billingPeriod
             )
 
-            expect(result.length).to.equal(2)
+            expect(result).to.have.length(2)
 
             // NOTE: We know the text says 'I_WILL_BE_REMOVED' but in this scenario they won't be!
             expect(result[0].purposes).to.equal('I_WILL_BE_REMOVED_1')
@@ -206,7 +206,7 @@ describe('Process billing batch service', () => {
           billingPeriod
         )
 
-        expect(result.length).to.equal(3)
+        expect(result).to.have.length(3)
         expect(result[0].purposes).to.equal('CALCULATED_TRANSACTION_1')
         expect(result[1].purposes).to.equal('CALCULATED_TRANSACTION_2')
         expect(result[2].purposes).to.equal('CALCULATED_TRANSACTION_3')

--- a/test/services/supplementary-billing/process-previous-billing-transactions.service.test.js
+++ b/test/services/supplementary-billing/process-previous-billing-transactions.service.test.js
@@ -51,7 +51,7 @@ describe('Process previous billing transactions service', () => {
           billingPeriod
         )
 
-        expect(result.length).to.equal(1)
+        expect(result).to.have.length(1)
         expect(result[0].billingTransactionId).not.to.equal(previousTransaction.billingTransactionId)
         expect(result[0].isCredit).not.to.equal(previousTransaction.isCredit)
       })

--- a/test/services/supplementary-billing/reverse-billing-transactions.service.test.js
+++ b/test/services/supplementary-billing/reverse-billing-transactions.service.test.js
@@ -30,7 +30,7 @@ describe('Reverse Billing Transactions service', () => {
     it('returns reversing transactions', () => {
       const result = ReverseBillingTransactionsService.go(transactions, billingInvoiceLicence)
 
-      expect(result.length).to.equal(transactions.length)
+      expect(result).to.have.length(transactions.length)
 
       expect(result[0].invoiceAccountId).not.to.exist()
       expect(result[0].invoiceAccountNumber).not.to.exist()


### PR DESCRIPTION
In our unit tests we had been checking the length of an array using the method `expect(result.length).to.equal(1)`. However our preferred way to test the length of an array is `expect(result).to.have.length(1)`.

This PR updates all unit tests to use the `expect(result).to.have.length(1)` method to test the length of an array.