### PR TITLE
Fix supplementary bill run errors with non-chargeable charge versions

### DIFF
--- a/app/services/supplementary-billing/fetch-charge-versions.service.js
+++ b/app/services/supplementary-billing/fetch-charge-versions.service.js
@@ -38,6 +38,7 @@ async function _fetch (regionId, billingPeriod) {
     ])
     .innerJoinRelated('licence')
     .where('scheme', 'sroc')
+    .whereNotNull('invoiceAccountId')
     .where('includeInSrocSupplementaryBilling', true)
     .where('regionId', regionId)
     .where('chargeVersions.status', 'current')

--- a/test/services/supplementary-billing/fetch-charge-versions.service.test.js
+++ b/test/services/supplementary-billing/fetch-charge-versions.service.test.js
@@ -205,6 +205,28 @@ describe('Fetch Charge Versions service', () => {
       })
     })
 
+    describe('because all the applicable charge versions have no `invoiceAccountId`', () => {
+      beforeEach(async () => {
+        billingPeriod = {
+          startDate: new Date('2022-04-01'),
+          endDate: new Date('2023-03-31')
+        }
+
+        // This creates a charge version with no `invoiceAccountId`
+        const nullInvoiceAccountIdChargeVersion = await ChargeVersionHelper.add(
+          { invoiceAccountId: null },
+          { regionId, includeInSrocSupplementaryBilling: true }
+        )
+        testRecords = [nullInvoiceAccountIdChargeVersion]
+      })
+
+      it('returns no applicable charge versions', async () => {
+        const result = await FetchChargeVersionsService.go(regionId, billingPeriod)
+
+        expect(result).to.be.empty()
+      })
+    })
+
     describe('because there are no charge versions in the billing period', () => {
       describe('as they all have start dates before the billing period', () => {
         beforeEach(async () => {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3972

We found that an sroc supplementary bill run that contains a non-chargeable charge version would immediately error. On investigation we found that we were attempting to create invoices for these charge versions, starting by destructuring the `invoiceAccountId`, causing an error.

Since we do not want to invoice these charge versions at all, we fix this by updating our db query to exclude records where `invoiceAccountId` is `null`.