### PR TITLE
Make test helpers consistent

### DIFF
--- a/test/models/water/billing-invoice-licence.model.test.js
+++ b/test/models/water/billing-invoice-licence.model.test.js
@@ -20,7 +20,7 @@ const LicenceModel = require('../../../app/models/water/licence.model.js')
 // Thing under test
 const BillingInvoiceLicenceModel = require('../../../app/models/water/billing-invoice-licence.model.js')
 
-describe('Billing Invoice Licence model', () => {
+describe.only('Billing Invoice Licence model', () => {
   let testRecord
 
   beforeEach(async () => {
@@ -46,7 +46,7 @@ describe('Billing Invoice Licence model', () => {
         testBillingInvoice = await BillingInvoiceHelper.add()
 
         const { billingInvoiceId } = testBillingInvoice
-        testRecord = await BillingInvoiceLicenceHelper.add({}, {}, { billingInvoiceId })
+        testRecord = await BillingInvoiceLicenceHelper.add({ billingInvoiceId })
       })
 
       it('can successfully run a related query', async () => {
@@ -112,7 +112,7 @@ describe('Billing Invoice Licence model', () => {
         testLicence = await LicenceHelper.add()
 
         const { licenceId } = testLicence
-        testRecord = await BillingInvoiceLicenceHelper.add({}, { licenceId })
+        testRecord = await BillingInvoiceLicenceHelper.add({ licenceId })
       })
 
       it('can successfully run a related query', async () => {

--- a/test/models/water/billing-invoice.model.test.js
+++ b/test/models/water/billing-invoice.model.test.js
@@ -76,7 +76,7 @@ describe('Billing Invoice model', () => {
 
         testBillingInvoiceLicences = []
         for (let i = 0; i < 2; i++) {
-          const billingInvoiceLicence = await BillingInvoiceLicenceHelper.add({}, {}, { billingInvoiceId })
+          const billingInvoiceLicence = await BillingInvoiceLicenceHelper.add({ billingInvoiceId })
           testBillingInvoiceLicences.push(billingInvoiceLicence)
         }
       })

--- a/test/models/water/licence.model.test.js
+++ b/test/models/water/licence.model.test.js
@@ -114,7 +114,7 @@ describe('Licence model', () => {
 
         testBillingInvoiceLicences = []
         for (let i = 0; i < 2; i++) {
-          const billingInvoiceLicence = await BillingInvoiceLicenceHelper.add({ licenceRef }, { licenceId })
+          const billingInvoiceLicence = await BillingInvoiceLicenceHelper.add({ licenceRef, licenceId })
           testBillingInvoiceLicences.push(billingInvoiceLicence)
         }
       })

--- a/test/services/supplementary-billing/fetch-previous-billing-transactions.service.test.js
+++ b/test/services/supplementary-billing/fetch-previous-billing-transactions.service.test.js
@@ -173,11 +173,7 @@ describe('Fetch Previous Billing Transactions service', () => {
 async function _createBillingBatchInvoiceAndLicence (invoiceAccountId, licenceId) {
   const { billingBatchId } = await BillingBatchHelper.add({ status: 'sent' })
   const { billingInvoiceId } = await BillingInvoiceHelper.add({ invoiceAccountId }, { billingBatchId })
-  const { billingInvoiceLicenceId } = await BillingInvoiceLicenceHelper.add(
-    {},
-    { licenceId },
-    { billingInvoiceId }
-  )
+  const { billingInvoiceLicenceId } = await BillingInvoiceLicenceHelper.add({ billingInvoiceId, licenceId })
 
   return billingInvoiceLicenceId
 }

--- a/test/support/helpers/water/billing-invoice-licence.helper.js
+++ b/test/support/helpers/water/billing-invoice-licence.helper.js
@@ -4,58 +4,27 @@
  * @module BillingInvoiceLicenceHelper
  */
 
-const BillingInvoiceHelper = require('./billing-invoice.helper.js')
 const BillingInvoiceLicenceModel = require('../../../../app/models/water/billing-invoice-licence.model.js')
-const LicenceHelper = require('./licence.helper.js')
 
 /**
  * Add a new billing invoice licence
  *
- * A billing invoice licence is always linked to a licence and a billing invoice. So, creating a billing invoice licence will automatically
- * create a new licence, a new billing invoice and handle linking them together by `licenceId` & `billingInvoiceId`.
- *
  * If no `data` is provided, default values will be used. These are
  *
+ * - `billingInvoiceId` - 45f08fe4-5b8b-4cf7-aaf0-5a07534e1357
  * - `licenceRef` - 01/123
- *
- * See `LicenceHelper` for the licence defaults
- * See `BillingInvoiceHelper` for the billing invoice defaults
+ * - `licenceId` - 2eb0623e-30c6-4bf4-9598-2d60a8366c7d
  *
  * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
- * @param {Object} [licence] Any licence data you want to use instead of the defaults used here or in the database
- * @param {Object} [billingInvoice] Any billing invoice data you want to use instead of the defaults used here or in the database
  *
  * @returns {module:BillingInvoiceLicenceModel} The instance of the newly created record
  */
-async function add (data = {}, licence = {}, billingInvoice = {}) {
-  const licenceId = await _licenceId(licence)
-  const billingInvoiceId = await _billingInvoiceId(billingInvoice)
-
-  const insertData = defaults({ ...data, licenceId, billingInvoiceId })
+async function add (data = {}) {
+  const insertData = defaults(data)
 
   return BillingInvoiceLicenceModel.query()
     .insert({ ...insertData })
     .returning('*')
-}
-
-async function _licenceId (providedLicence) {
-  if (providedLicence?.licenceId) {
-    return providedLicence.licenceId
-  }
-
-  const licence = await LicenceHelper.add(providedLicence)
-
-  return licence.licenceId
-}
-
-async function _billingInvoiceId (providedBillingInvoice) {
-  if (providedBillingInvoice?.billingInvoiceId) {
-    return providedBillingInvoice.billingInvoiceId
-  }
-
-  const billingInvoice = await BillingInvoiceHelper.add(providedBillingInvoice)
-
-  return billingInvoice.billingInvoiceId
 }
 
 /**
@@ -68,7 +37,9 @@ async function _billingInvoiceId (providedBillingInvoice) {
  */
 function defaults (data = {}) {
   const defaults = {
-    licenceRef: '01/123'
+    billingInvoiceId: '45f08fe4-5b8b-4cf7-aaf0-5a07534e1357',
+    licenceRef: '01/123',
+    licenceId: '2eb0623e-30c6-4bf4-9598-2d60a8366c7d'
   }
 
   return {


### PR DESCRIPTION
To support our unit testing we have a convention of creating ‘helpers’ that create the data we need to test our code.

Often data is related, for example, a `ChargeVersion` is linked to a `Licence` record. When we first built the helpers we copied the model used by [sroc-charging-module-api](https://github.com/DEFRA/sroc-charging-module-api), which will create linked data records automatically.

But as time went on, we realised the complexity of the WRLS data schema was making this pattern unworkable so we stopped. But our initial data helpers still follow that pattern. This has caused us to waste time or get confused at times when working on SROC supplementary billing.

So, before we start the next phase of work, we need to update the original helpers to stop creating linked records and update existing tests accordingly.