### PR TITLE
Consider Revoked, Expired, Lapsed licences dates when calculating charges

### DIFF
--- a/app/services/supplementary-billing/determine-charge-period.service.js
+++ b/app/services/supplementary-billing/determine-charge-period.service.js
@@ -27,12 +27,25 @@ function go (chargeVersion, financialYearEnding) {
     throw new Error(`Charge version is outside billing period ${financialYearEnding}`)
   }
 
-  const chargeVersionStartDate = chargeVersion.startDate
-  const latestStartDateTimestamp = Math.max(financialYearStartDate, chargeVersionStartDate)
+  const latestStartDateTimestamp = Math.max(
+    financialYearStartDate,
+    chargeVersion.startDate,
+    chargeVersion.licence.startDate
+  )
 
-  // If the charge version has no end date then use the financial year end date instead
+  // If the end date is null then use the financial year end date instead as Math.min() will count nulls as 0
   const chargeVersionEndDate = chargeVersion.endDate || financialYearEndDate
-  const earliestEndDateTimestamp = Math.min(financialYearEndDate, chargeVersionEndDate)
+  const licenceExpiredDate = chargeVersion.licence.expiredDate || financialYearEndDate
+  const licencelapsedDate = chargeVersion.licence.lapsedDate || financialYearEndDate
+  const licencerevokedDate = chargeVersion.licence.revokedDate || financialYearEndDate
+
+  const earliestEndDateTimestamp = Math.min(
+    financialYearEndDate,
+    chargeVersionEndDate,
+    licenceExpiredDate,
+    licencelapsedDate,
+    licencerevokedDate
+  )
 
   return {
     startDate: new Date(latestStartDateTimestamp),

--- a/app/services/supplementary-billing/fetch-charge-versions.service.js
+++ b/app/services/supplementary-billing/fetch-charge-versions.service.js
@@ -59,7 +59,11 @@ async function _fetch (regionId, billingPeriod) {
         'licenceRef',
         'isWaterUndertaker',
         ref('licences.regions:historicalAreaCode').castText().as('historicalAreaCode'),
-        ref('licences.regions:regionalChargeArea').castText().as('regionalChargeArea')
+        ref('licences.regions:regionalChargeArea').castText().as('regionalChargeArea'),
+        'startDate',
+        'expiredDate',
+        'lapsedDate',
+        'revokedDate'
       ])
     })
     .withGraphFetched('licence.region')

--- a/test/services/supplementary-billing/determine-charge-period.service.test.js
+++ b/test/services/supplementary-billing/determine-charge-period.service.test.js
@@ -117,7 +117,7 @@ describe('Determine charge period service', () => {
       })
     })
 
-    describe('and the licence start date is inside the financial period', () => {
+    describe('and the licence start date is after the charge versions and inside the financial period', () => {
       beforeEach(() => {
         chargeVersion.licence = { startDate: new Date('2022-08-31') }
       })

--- a/test/services/supplementary-billing/determine-charge-period.service.test.js
+++ b/test/services/supplementary-billing/determine-charge-period.service.test.js
@@ -122,7 +122,7 @@ describe('Determine charge period service', () => {
         chargeVersion.licence = { startDate: new Date('2022-08-31') }
       })
 
-      it('returns the licence start and charge version end date', () => {
+      it('returns the licence start and financial end date', () => {
         const result = DetermineChargePeriodService.go(chargeVersion, financialYear.yearEnding)
 
         expect(result.startDate).to.equal(chargeVersion.licence.startDate)
@@ -135,7 +135,7 @@ describe('Determine charge period service', () => {
         chargeVersion.licence = { startDate: new Date('2022-01-01'), revokedDate: new Date('2022-08-01') }
       })
 
-      it('returns the financial year start and licence revoked end date', () => {
+      it('returns the financial start and licence revoked end date', () => {
         const result = DetermineChargePeriodService.go(chargeVersion, financialYear.yearEnding)
 
         expect(result.startDate).to.equal(financialYear.startDate)
@@ -148,7 +148,7 @@ describe('Determine charge period service', () => {
         chargeVersion.licence = { startDate: new Date('2022-01-01'), lapsedDate: new Date('2022-08-31') }
       })
 
-      it('returns the financial year start and licence lapsed end date', () => {
+      it('returns the financial start and licence lapsed end date', () => {
         const result = DetermineChargePeriodService.go(chargeVersion, financialYear.yearEnding)
 
         expect(result.startDate).to.equal(financialYear.startDate)
@@ -161,7 +161,7 @@ describe('Determine charge period service', () => {
         chargeVersion.licence = { startDate: new Date('2022-01-01'), expiredDate: new Date('2022-07-01') }
       })
 
-      it('returns the financial year start and licence expired end date', () => {
+      it('returns the financial start and licence expired end date', () => {
         const result = DetermineChargePeriodService.go(chargeVersion, financialYear.yearEnding)
 
         expect(result.startDate).to.equal(financialYear.startDate)

--- a/test/services/supplementary-billing/determine-charge-period.service.test.js
+++ b/test/services/supplementary-billing/determine-charge-period.service.test.js
@@ -22,7 +22,8 @@ describe('Determine charge period service', () => {
     beforeEach(() => {
       chargeVersion = {
         startDate: new Date('2022-05-01'),
-        endDate: null
+        endDate: null,
+        licence: { startDate: new Date('2022-01-01') }
       }
     })
 
@@ -53,7 +54,8 @@ describe('Determine charge period service', () => {
     beforeEach(() => {
       chargeVersion = {
         startDate: new Date('2022-02-01'),
-        endDate: null
+        endDate: null,
+        licence: { startDate: new Date('2022-01-01') }
       }
     })
 
@@ -90,6 +92,7 @@ describe('Determine charge period service', () => {
 
     describe('and the charge version has an end date that is inside the financial period', () => {
       beforeEach(() => {
+        chargeVersion.licence = { startDate: new Date('2022-01-01') }
         chargeVersion.endDate = new Date('2022-05-31')
       })
 
@@ -102,11 +105,67 @@ describe('Determine charge period service', () => {
     })
 
     describe('and the charge version does not have an end date', () => {
+      beforeEach(() => {
+        chargeVersion.licence = { startDate: new Date('2022-01-01') }
+      })
+
       it('returns the financial start and end dates', () => {
         const result = DetermineChargePeriodService.go(chargeVersion, financialYear.yearEnding)
 
         expect(result.startDate).to.equal(financialYear.startDate)
         expect(result.endDate).to.equal(financialYear.endDate)
+      })
+    })
+
+    describe('and the licence start date is inside the financial period', () => {
+      beforeEach(() => {
+        chargeVersion.licence = { startDate: new Date('2022-08-31') }
+      })
+
+      it('returns the licence start and charge version end date', () => {
+        const result = DetermineChargePeriodService.go(chargeVersion, financialYear.yearEnding)
+
+        expect(result.startDate).to.equal(chargeVersion.licence.startDate)
+        expect(result.endDate).to.equal(financialYear.endDate)
+      })
+    })
+
+    describe('and the licence revoked date is inside the financial period', () => {
+      beforeEach(() => {
+        chargeVersion.licence = { startDate: new Date('2022-01-01'), revokedDate: new Date('2022-08-01') }
+      })
+
+      it('returns the financial year start and licence revoked end date', () => {
+        const result = DetermineChargePeriodService.go(chargeVersion, financialYear.yearEnding)
+
+        expect(result.startDate).to.equal(financialYear.startDate)
+        expect(result.endDate).to.equal(chargeVersion.licence.revokedDate)
+      })
+    })
+
+    describe('and the licence lapsed date is inside the financial period', () => {
+      beforeEach(() => {
+        chargeVersion.licence = { startDate: new Date('2022-01-01'), lapsedDate: new Date('2022-08-31') }
+      })
+
+      it('returns the financial year start and licence lapsed end date', () => {
+        const result = DetermineChargePeriodService.go(chargeVersion, financialYear.yearEnding)
+
+        expect(result.startDate).to.equal(financialYear.startDate)
+        expect(result.endDate).to.equal(chargeVersion.licence.lapsedDate)
+      })
+    })
+
+    describe('and the licence expired date is inside the financial period', () => {
+      beforeEach(() => {
+        chargeVersion.licence = { startDate: new Date('2022-01-01'), expiredDate: new Date('2022-07-01') }
+      })
+
+      it('returns the financial year start and licence expired end date', () => {
+        const result = DetermineChargePeriodService.go(chargeVersion, financialYear.yearEnding)
+
+        expect(result.startDate).to.equal(financialYear.startDate)
+        expect(result.endDate).to.equal(chargeVersion.licence.expiredDate)
       })
     })
   })
@@ -115,7 +174,8 @@ describe('Determine charge period service', () => {
     beforeEach(() => {
       chargeVersion = {
         startDate: new Date('2022-05-01'),
-        endDate: null
+        endDate: null,
+        licence: { startDate: new Date('2022-01-01') }
       }
     })
 

--- a/test/services/supplementary-billing/determine-minimum-charge.service.test.js
+++ b/test/services/supplementary-billing/determine-minimum-charge.service.test.js
@@ -32,6 +32,7 @@ describe('Determine minimum charge service', () => {
           changeReasonId: changeReason.changeReasonId
         })
         chargeVersion.changeReason = changeReason
+        chargeVersion.licence = { startDate: new Date('2022-01-01') }
       })
 
       it('returns true', async () => {
@@ -49,6 +50,7 @@ describe('Determine minimum charge service', () => {
           changeReasonId: changeReason.changeReasonId
         })
         chargeVersion.changeReason = changeReason
+        chargeVersion.licence = { startDate: new Date('2022-01-01') }
       })
 
       it('returns false', async () => {
@@ -67,6 +69,7 @@ describe('Determine minimum charge service', () => {
         changeReasonId: changeReason.changeReasonId
       })
       chargeVersion.changeReason = changeReason
+      chargeVersion.licence = { startDate: new Date('2022-01-01') }
     })
 
     it('returns false', async () => {

--- a/test/services/supplementary-billing/fetch-charge-versions.service.test.js
+++ b/test/services/supplementary-billing/fetch-charge-versions.service.test.js
@@ -249,7 +249,7 @@ describe('Fetch Charge Versions service', () => {
           // This creates an SROC charge version with a start date before the billing period. This would have been
           // picked up by a previous bill run
           const alcsChargeVersion = await ChargeVersionHelper.add(
-            { startDate: new Date(2022, 2, 31), licenceId } // 2022-03-01 - Months are zero indexed :-)
+            { startDate: new Date('2022-03-01'), licenceId }
           )
           testRecords = [alcsChargeVersion]
         })
@@ -276,7 +276,7 @@ describe('Fetch Charge Versions service', () => {
           // This creates an SROC charge version with a start date after the billing period. This will be picked in
           // next years bill runs
           const alcsChargeVersion = await ChargeVersionHelper.add(
-            { startDate: new Date(2023, 3, 1), licenceId } // 2023-04-01 - Months are zero indexed :-)
+            { startDate: new Date('2023-04-01'), licenceId }
           )
           testRecords = [alcsChargeVersion]
         })

--- a/test/support/helpers/water/licence.helper.js
+++ b/test/support/helpers/water/licence.helper.js
@@ -13,6 +13,8 @@ const LicenceModel = require('../../../../app/models/water/licence.model.js')
  *
  * - `licenceRef` - 01/123
  * - `regionId` - bd114474-790f-4470-8ba4-7b0cc9c225d7
+ * - `regions` - { historicalAreaCode: 'SAAR', regionalChargeArea: 'Southern' }
+ * - `startDate` - new Date('2022-01-01')
  *
  * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
  *
@@ -38,7 +40,8 @@ function defaults (data = {}) {
   const defaults = {
     licenceRef: '01/123',
     regionId: 'bd114474-790f-4470-8ba4-7b0cc9c225d7',
-    regions: { historicalAreaCode: 'SAAR', regionalChargeArea: 'Southern' }
+    regions: { historicalAreaCode: 'SAAR', regionalChargeArea: 'Southern' },
+    startDate: new Date('2022-01-01')
   }
 
   return {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3987

When a licence is expired/lapsed/revoked before the end of a charge version, the supplementary billing process needs to consider these dates as part of the billable days calculation.