### PR TITLE
Compress billing-charge-categories export

### DIFF
--- a/app/services/db-export/compress-files.service.js
+++ b/app/services/db-export/compress-files.service.js
@@ -1,7 +1,7 @@
 'use strict'
 
 /**
- * Given the path of a file to compress it
+ * Compresses a file at a specified path using gzip
  * @module CompressFilesService
  */
 
@@ -33,9 +33,9 @@ async function go (filePath) {
 async function compressFile (filePath) {
   if (fs.existsSync(filePath)) {
     const readStream = fs.createReadStream(filePath)
-    const newFileName = filePath + '.gz'
-    const writeStream = fs.createWriteStream(newFileName)
+    const writeStream = fs.createWriteStream(`${filePath}.gz`)
     const compress = zlib.createGzip()
+
     const pipe = promisify(pipeline)
 
     await pipe(readStream, compress, writeStream)

--- a/app/services/db-export/compress-files.service.js
+++ b/app/services/db-export/compress-files.service.js
@@ -5,7 +5,7 @@
  * @module CompressFilesService
  */
 
-const fs = require('fs')
+const fs = require('node:fs')
 const { pipeline } = require('node:stream')
 const { promisify } = require('node:util')
 const zlib = require('node:zlib')
@@ -18,30 +18,26 @@ const zlib = require('node:zlib')
  * @returns {Boolean} True if the file is compressed successfully and false if not
  */
 async function go (filePath) {
-  try {
-    await compressFile(filePath)
-    global.GlobalNotifier.omg(`${filePath} successfully compressed to gzip.`)
-
-    return true
-  } catch (error) {
+  if (!fs.existsSync(filePath)) {
     global.GlobalNotifier.omfg(`ERROR: ${filePath} did not successfully compress to gzip.`)
 
     return false
   }
+
+  await _compressFile(filePath)
+  global.GlobalNotifier.omg(`${filePath} successfully compressed to gzip.`)
+
+  return true
 }
 
-async function compressFile (filePath) {
-  if (fs.existsSync(filePath)) {
-    const readStream = fs.createReadStream(filePath)
-    const writeStream = fs.createWriteStream(`${filePath}.gz`)
-    const compress = zlib.createGzip()
+async function _compressFile (filePath) {
+  const readStream = fs.createReadStream(filePath)
+  const writeStream = fs.createWriteStream(`${filePath}.gz`)
+  const compress = zlib.createGzip()
 
-    const pipe = promisify(pipeline)
+  const pipe = promisify(pipeline)
 
-    await pipe(readStream, compress, writeStream)
-  } else {
-    throw new Error('File to compress does not exist')
-  }
+  await pipe(readStream, compress, writeStream)
 }
 
 module.exports = {

--- a/app/services/db-export/compress-files.service.js
+++ b/app/services/db-export/compress-files.service.js
@@ -1,0 +1,49 @@
+'use strict'
+
+/**
+ * Given the path of a file to compress it
+ * @module CompressFilesService
+ */
+
+const fs = require('fs')
+const { pipeline } = require('node:stream')
+const { promisify } = require('node:util')
+const zlib = require('node:zlib')
+
+/**
+ * Compresses a file using gzip and writes the compressed data to a new file with a '.gz' extension
+ *
+ * @param {String} filePath A string containing the file path that will be compressed
+ *
+ * @returns {Boolean} True if the file is compressed successfully and false if not
+ */
+async function go (filePath) {
+  try {
+    await compressFile(filePath)
+    global.GlobalNotifier.omg(`${filePath} successfully compressed to gzip.`)
+
+    return true
+  } catch (error) {
+    global.GlobalNotifier.omfg(`ERROR: ${filePath} did not successfully compress to gzip.`)
+
+    return false
+  }
+}
+
+async function compressFile (filePath) {
+  if (fs.existsSync(filePath)) {
+    const readStream = fs.createReadStream(filePath)
+    const newFileName = filePath + '.gz'
+    const writeStream = fs.createWriteStream(newFileName)
+    const compress = zlib.createGzip()
+    const pipe = promisify(pipeline)
+
+    await pipe(readStream, compress, writeStream)
+  } else {
+    throw new Error('File to compress does not exist')
+  }
+}
+
+module.exports = {
+  go
+}

--- a/app/services/db-export/export-data-files.service.js
+++ b/app/services/db-export/export-data-files.service.js
@@ -19,11 +19,13 @@ const os = require('os')
  * @returns {Boolean} True if the file is written successfully and false if not
  */
 async function go (tableConvertedToCsv, tableName) {
+  const filePath = _filenameWithPath(tableName)
+
   try {
-    await fs.writeFile(_filenameWithPath(tableName), tableConvertedToCsv)
+    await fs.writeFile(filePath, tableConvertedToCsv)
     global.GlobalNotifier.omg(`${tableName} exported successfully`)
 
-    return _filenameWithPath(tableName)
+    return filePath
   } catch (error) {
     global.GlobalNotifier.omfg(`${tableName} Export request errored`, error)
 

--- a/app/services/db-export/export-data-files.service.js
+++ b/app/services/db-export/export-data-files.service.js
@@ -23,7 +23,7 @@ async function go (tableConvertedToCsv, tableName) {
     await fs.writeFile(_filenameWithPath(tableName), tableConvertedToCsv)
     global.GlobalNotifier.omg(`${tableName} exported successfully`)
 
-    return true
+    return _filenameWithPath(tableName)
   } catch (error) {
     global.GlobalNotifier.omfg(`${tableName} Export request errored`, error)
 

--- a/test/fixtures/compress-files.service.csv
+++ b/test/fixtures/compress-files.service.csv
@@ -1,0 +1,2 @@
+"billingChargeCategoryId"
+"20146cdc-9b40-4769-aa78-b51c17080d56"

--- a/test/services/db-export/compress-files.service.test.js
+++ b/test/services/db-export/compress-files.service.test.js
@@ -1,0 +1,63 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { describe, it, beforeEach, afterEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const fs = require('fs')
+
+// Thing under test
+const CompressFilesService = require('../../../app/services/db-export/compress-files.service')
+
+describe('Compress files service', () => {
+  let notifierStub
+  let filePath
+
+  beforeEach(() => {
+    notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
+    global.GlobalNotifier = notifierStub
+  })
+
+  afterEach(() => {
+    Sinon.restore()
+    delete global.GlobalNotifier
+  })
+
+  describe('when successful', () => {
+    beforeEach(() => {
+      filePath = 'test/fixtures/compress-files.service.csv'
+    })
+
+    afterEach(() => {
+      // Delete the new file
+      fs.unlinkSync(`${filePath}.gz`)
+    })
+
+    it('compresses the csv file to a .gz file', async () => {
+      const result = await CompressFilesService.go(filePath)
+
+      expect(result).to.equal(true)
+      expect(fs.existsSync(`${filePath}.gz`)).to.equal(true)
+      expect(notifierStub.omg.calledWith(`${filePath} successfully compressed to gzip.`)).to.be.true()
+    })
+  })
+
+  describe('when unsuccessful because the CSV file does not exist', () => {
+    beforeEach(() => {
+      filePath = ''
+    })
+
+    it('returns an error', async () => {
+      const result = await CompressFilesService.go(filePath)
+
+      expect(result).to.equal(false)
+      expect(fs.existsSync((`${filePath}.gz`))).to.equal(false)
+      expect(notifierStub.omfg.calledWith(`ERROR: ${filePath} did not successfully compress to gzip.`)).to.be.true()
+    })
+  })
+})

--- a/test/services/db-export/export-data-files.service.test.js
+++ b/test/services/db-export/export-data-files.service.test.js
@@ -81,7 +81,7 @@ describe('Export data files service', () => {
       const returnedResult = await ExportDataFilesService.go(data, tableName)
 
       expect(fs.existsSync(filePath)).to.equal(true)
-      expect(returnedResult).to.equal(true)
+      expect(returnedResult).to.equal('/tmp/billing_charge_categories.csv')
       expect(notifierStub.omg.calledWith('billing_charge_categories exported successfully')).to.be.true()
     })
   })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3965

This pull request is just a small part of a larger project that involves exporting all our database schemas, converting them into CSV files, and uploading them to our Amazon S3 bucket. This PR's primary focus is compressing the billing charge categories table that we have already converted and exported to a CSV file. To expedite the export process and see the output sooner, we are using a vertical slicing approach, rather than a horizontal one, which means exporting a single table at a time from each schema.