### PR TITLE
Add auto-merge GitHub workflow

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,14 @@
+name: auto-merge
+
+on:
+  pull_request:
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ahmadnassri/action-dependabot-auto-merge@v2
+        with:
+          target: minor
+          github-token: ${{ secrets.AUTO_MERGE }}


### PR DESCRIPTION
We currently have to maintain Dependabot updates across 11 repos for the Water Abstraction Service.

All we do when checking a Dependabot update is confirm it hasn't broken CI. We then approve and merge.

We are not really adding any value to the process. So, to reduce the maintenance load on the team we have agreed that any Depedabot update that passes our CI build can be automatically merged.

This adds [Dependabot Auto Merge](https://github.com/marketplace/actions/dependabot-auto-merge) to the repo which is a GitHub action that should handle this for us.