### PR TITLE
Handle soft deleted workflow in supp. billing

### DIFF
--- a/app/services/supplementary-billing/fetch-charge-versions.service.js
+++ b/app/services/supplementary-billing/fetch-charge-versions.service.js
@@ -47,6 +47,7 @@ async function _fetch (regionId, billingPeriod) {
       ChargeVersionWorkflow.query()
         .select(1)
         .whereColumn('chargeVersions.licenceId', 'chargeVersionWorkflows.licenceId')
+        .whereNull('chargeVersionWorkflows.dateDeleted')
     )
     .orderBy([
       { column: 'chargeVersions.invoiceAccountId' },

--- a/test/services/supplementary-billing/fetch-charge-versions.service.test.js
+++ b/test/services/supplementary-billing/fetch-charge-versions.service.test.js
@@ -55,7 +55,7 @@ describe('Fetch Charge Versions service', () => {
         includeInSrocSupplementaryBilling: true,
         includeInSupplementaryBilling: 'yes'
       })
-      const licenceId = licence.licenceId
+      const { licenceId } = licence
       changeReason = await ChangeReasonHelper.add({ triggersMinimumCharge: true })
 
       // This creates a 'current' SROC charge version


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3999

In [Licences in Workflow should not be considered](https://github.com/DEFRA/water-abstraction-system/pull/176) we changed our `FetchChargeVersionsService` to exclude any charge version that was in the `charge_version_workflows` table. It was identified as a requirement that anything in 'workflow' should not be considered for billing.

When we tested we saw that when adding a charge version, for example, a `charge_version_workflow` record is created. Once the charge version gets approved the workflow record gets deleted. This is the same behaviour we have noted elsewhere.

But, during UAT it was noted there were licences (charge versions) not being picked up for supplementary billing which when checking the workflow screen were not displayed. Some digging found the reason.

Workflow records have a 'status'; `to_setup` or `review` (there is also `changes_requested` but we've not seen evidence of its use). We don't understand _how_ the `to_set_up` records get added (probably during the import process). But `review` appears when you add a new charge version.

After some testing, we've found that if you click the 'Set up' link on the entry in a licence's charge versions, it changes the workflow's status from `to_setup` to `review`. When your charge version gets approved the workflow record gets deleted.

But, this is where our work has come undone! If you click the 'Remove' link all the service does is update the workflow's `date_deleted` column. It doesn't delete the record 😮😩

We don't know why they are handled differently. But we must account for these 'soft-deleted' workflow records in `FetchChargeVersionsService`.

<details>
<summary>Screenshot of setup entry</summary>

![Screenshot 2023-05-05 at 11 50 37](https://user-images.githubusercontent.com/1789650/236442109-38454936-2ad2-4606-ac5c-1397017ff2f6.png)

</details>