### PR TITLE
Fix incorrect cleanse of previous transactions

### DIFF
--- a/test/services/supplementary-billing/fetch-previous-billing-transactions.service.test.js
+++ b/test/services/supplementary-billing/fetch-previous-billing-transactions.service.test.js
@@ -46,87 +46,138 @@ describe('Fetch Previous Billing Transactions service', () => {
       })
 
       it('returns results', async () => {
-        const result = await FetchPreviousBillingTransactionsService.go(
+        const results = await FetchPreviousBillingTransactionsService.go(
           { invoiceAccountId },
           { licenceId },
           financialYearEnding
         )
 
-        expect(result).to.have.length(1)
+        expect(results).to.have.length(1)
+        expect(results[0].isCredit).to.be.false()
       })
 
-      describe('followed by another run which credits the previous', () => {
+      describe('followed by another bill run for the same licence and invoice account', () => {
+        let followUpBillingInvoiceLicenceId
+
         beforeEach(async () => {
-          const billingInvoiceLicenceId = await _createBillingBatchInvoiceAndLicence(invoiceAccountId, licenceId)
-          await BillingTransactionHelper.add({ billingInvoiceLicenceId, isCredit: true })
+          followUpBillingInvoiceLicenceId = await _createBillingBatchInvoiceAndLicence(invoiceAccountId, licenceId)
         })
 
-        it('returns no results', async () => {
-          const result = await FetchPreviousBillingTransactionsService.go(
-            { invoiceAccountId },
-            { licenceId },
-            financialYearEnding
-          )
+        describe('which only contains a credit', () => {
+          describe("that matches the first bill run's debit", () => {
+            beforeEach(async () => {
+              await BillingTransactionHelper.add({
+                billingInvoiceLicenceId: followUpBillingInvoiceLicenceId,
+                isCredit: true
+              })
+            })
 
-          expect(result).to.be.empty()
-        })
-      })
+            it('returns no results', async () => {
+              const results = await FetchPreviousBillingTransactionsService.go(
+                { invoiceAccountId },
+                { licenceId },
+                financialYearEnding
+              )
 
-      describe('followed by more runs with equal credits and debits', () => {
-        beforeEach(async () => {
-          const creditsBillingInvoiceLicenceId = await _createBillingBatchInvoiceAndLicence(invoiceAccountId, licenceId)
-          await BillingTransactionHelper.add({
-            billingInvoiceLicenceId: creditsBillingInvoiceLicenceId,
-            isCredit: true
-          })
-          await BillingTransactionHelper.add({
-            billingInvoiceLicenceId: creditsBillingInvoiceLicenceId,
-            isCredit: true
+              expect(results).to.be.empty()
+            })
           })
 
-          const debitBillingInvoiceLicenceId = await _createBillingBatchInvoiceAndLicence(invoiceAccountId, licenceId)
-          await BillingTransactionHelper.add({ billingInvoiceLicenceId: debitBillingInvoiceLicenceId })
+          describe("that does not match the first bill run's debit", () => {
+            describe('because the billable days are different', () => {
+              beforeEach(async () => {
+                await BillingTransactionHelper.add({
+                  billingInvoiceLicenceId: followUpBillingInvoiceLicenceId,
+                  billableDays: 30,
+                  isCredit: true
+                })
+              })
+
+              it('returns the debits', async () => {
+                const results = await FetchPreviousBillingTransactionsService.go(
+                  { invoiceAccountId },
+                  { licenceId },
+                  financialYearEnding
+                )
+
+                expect(results).to.have.length(1)
+                expect(results[0].isCredit).to.be.false()
+              })
+            })
+
+            describe('because the charge type is different', () => {
+              beforeEach(async () => {
+                await BillingTransactionHelper.add({
+                  billingInvoiceLicenceId: followUpBillingInvoiceLicenceId,
+                  chargeType: 'compensation',
+                  isCredit: true
+                })
+              })
+
+              it('returns the debits', async () => {
+                const results = await FetchPreviousBillingTransactionsService.go(
+                  { invoiceAccountId },
+                  { licenceId },
+                  financialYearEnding
+                )
+
+                expect(results).to.have.length(1)
+                expect(results[0].isCredit).to.be.false()
+              })
+            })
+          })
         })
 
-        it('returns no results', async () => {
-          const result = await FetchPreviousBillingTransactionsService.go(
-            { invoiceAccountId },
-            { licenceId },
-            financialYearEnding
-          )
-
-          expect(result).to.be.empty()
-        })
-      })
-
-      describe('followed by more runs with unequal credits and debits', () => {
-        beforeEach(async () => {
-          const unmatchedBillingInvoiceLicenceId = await _createBillingBatchInvoiceAndLicence(
-            invoiceAccountId,
-            licenceId
-          )
-          await BillingTransactionHelper.add({
-            billingInvoiceLicenceId: unmatchedBillingInvoiceLicenceId,
-            billableDays: 30,
-            isCredit: true
+        describe('which contains a debit', () => {
+          beforeEach(async () => {
+            await BillingTransactionHelper.add({
+              billingInvoiceLicenceId: followUpBillingInvoiceLicenceId,
+              description: 'follow up'
+            })
           })
 
-          const matchedBillingInvoiceLicenceId = await _createBillingBatchInvoiceAndLicence(invoiceAccountId, licenceId)
-          await BillingTransactionHelper.add({
-            billingInvoiceLicenceId: matchedBillingInvoiceLicenceId,
-            isCredit: true
+          describe("and a credit that matches the first bill run's debit", () => {
+            beforeEach(async () => {
+              await BillingTransactionHelper.add({
+                billingInvoiceLicenceId: followUpBillingInvoiceLicenceId,
+                isCredit: true
+              })
+            })
+
+            it('returns only the follow up debit', async () => {
+              const results = await FetchPreviousBillingTransactionsService.go(
+                { invoiceAccountId },
+                { licenceId },
+                financialYearEnding
+              )
+
+              expect(results).to.have.length(1)
+              expect(results[0].isCredit).to.be.false()
+              expect(results[0].description).to.equal('follow up')
+            })
           })
-          await BillingTransactionHelper.add({ billingInvoiceLicenceId: matchedBillingInvoiceLicenceId })
-        })
 
-        it('returns results', async () => {
-          const result = await FetchPreviousBillingTransactionsService.go(
-            { invoiceAccountId },
-            { licenceId },
-            financialYearEnding
-          )
+          describe("and a credit that does not match the first bill run's debit", () => {
+            beforeEach(async () => {
+              await BillingTransactionHelper.add({
+                billingInvoiceLicenceId: followUpBillingInvoiceLicenceId,
+                billableDays: 30,
+                isCredit: true
+              })
+            })
 
-          expect(result).to.have.length(1)
+            it('returns both debits', async () => {
+              const results = await FetchPreviousBillingTransactionsService.go(
+                { invoiceAccountId },
+                { licenceId },
+                financialYearEnding
+              )
+
+              expect(results).to.have.length(2)
+              expect(results.every((transaction) => !transaction.isCredit)).to.be.true()
+              expect(results.find((transaction) => transaction.description === 'follow up')).to.exist()
+            })
+          })
         })
       })
     })
@@ -138,13 +189,13 @@ describe('Fetch Previous Billing Transactions service', () => {
       })
 
       it('returns no results', async () => {
-        const result = await FetchPreviousBillingTransactionsService.go(
+        const results = await FetchPreviousBillingTransactionsService.go(
           { invoiceAccountId },
           { licenceId },
           financialYearEnding
         )
 
-        expect(result).to.be.empty()
+        expect(results).to.be.empty()
       })
     })
 
@@ -158,13 +209,13 @@ describe('Fetch Previous Billing Transactions service', () => {
       })
 
       it('returns no results', async () => {
-        const result = await FetchPreviousBillingTransactionsService.go(
+        const results = await FetchPreviousBillingTransactionsService.go(
           { invoiceAccountId },
           { licenceId },
           financialYearEnding
         )
 
-        expect(result).to.be.empty()
+        expect(results).to.be.empty()
       })
     })
   })

--- a/test/services/supplementary-billing/fetch-previous-billing-transactions.service.test.js
+++ b/test/services/supplementary-billing/fetch-previous-billing-transactions.service.test.js
@@ -125,6 +125,216 @@ describe('Fetch Previous Billing Transactions service', () => {
                 expect(results[0].isCredit).to.be.false()
               })
             })
+
+            describe('because the charge category code is different', () => {
+              beforeEach(async () => {
+                await BillingTransactionHelper.add({
+                  billingInvoiceLicenceId: followUpBillingInvoiceLicenceId,
+                  chargeCategoryCode: '4.3.2',
+                  isCredit: true
+                })
+              })
+
+              it('returns the debits', async () => {
+                const results = await FetchPreviousBillingTransactionsService.go(
+                  { invoiceAccountId },
+                  { licenceId },
+                  financialYearEnding
+                )
+
+                expect(results).to.have.length(1)
+                expect(results[0].isCredit).to.be.false()
+              })
+            })
+
+            describe('because the abatement agreement (section 126) is different', () => {
+              beforeEach(async () => {
+                await BillingTransactionHelper.add({
+                  billingInvoiceLicenceId: followUpBillingInvoiceLicenceId,
+                  section126Factor: 0.5,
+                  isCredit: true
+                })
+              })
+
+              it('returns the debits', async () => {
+                const results = await FetchPreviousBillingTransactionsService.go(
+                  { invoiceAccountId },
+                  { licenceId },
+                  financialYearEnding
+                )
+
+                expect(results).to.have.length(1)
+                expect(results[0].isCredit).to.be.false()
+              })
+            })
+
+            describe('because the two-part tariff agreement (section 127) is different', () => {
+              beforeEach(async () => {
+                await BillingTransactionHelper.add({
+                  billingInvoiceLicenceId: followUpBillingInvoiceLicenceId,
+                  section127Agreement: true,
+                  isCredit: true
+                })
+              })
+
+              it('returns the debits', async () => {
+                const results = await FetchPreviousBillingTransactionsService.go(
+                  { invoiceAccountId },
+                  { licenceId },
+                  financialYearEnding
+                )
+
+                expect(results).to.have.length(1)
+                expect(results[0].isCredit).to.be.false()
+              })
+            })
+
+            describe('because the canal and river trust agreement (section 130) is different', () => {
+              beforeEach(async () => {
+                await BillingTransactionHelper.add({
+                  billingInvoiceLicenceId: followUpBillingInvoiceLicenceId,
+                  section130Agreement: true,
+                  isCredit: true
+                })
+              })
+
+              it('returns the debits', async () => {
+                const results = await FetchPreviousBillingTransactionsService.go(
+                  { invoiceAccountId },
+                  { licenceId },
+                  financialYearEnding
+                )
+
+                expect(results).to.have.length(1)
+                expect(results[0].isCredit).to.be.false()
+              })
+            })
+
+            describe('because the aggregate is different', () => {
+              beforeEach(async () => {
+                await BillingTransactionHelper.add({
+                  billingInvoiceLicenceId: followUpBillingInvoiceLicenceId,
+                  aggregateFactor: 0.5,
+                  isCredit: true
+                })
+              })
+
+              it('returns the debits', async () => {
+                const results = await FetchPreviousBillingTransactionsService.go(
+                  { invoiceAccountId },
+                  { licenceId },
+                  financialYearEnding
+                )
+
+                expect(results).to.have.length(1)
+                expect(results[0].isCredit).to.be.false()
+              })
+            })
+
+            describe('because the charge adjustment is different', () => {
+              beforeEach(async () => {
+                await BillingTransactionHelper.add({
+                  billingInvoiceLicenceId: followUpBillingInvoiceLicenceId,
+                  adjustmentFactor: 0.5,
+                  isCredit: true
+                })
+              })
+
+              it('returns the debits', async () => {
+                const results = await FetchPreviousBillingTransactionsService.go(
+                  { invoiceAccountId },
+                  { licenceId },
+                  financialYearEnding
+                )
+
+                expect(results).to.have.length(1)
+                expect(results[0].isCredit).to.be.false()
+              })
+            })
+
+            describe('because the winter discount is different', () => {
+              beforeEach(async () => {
+                await BillingTransactionHelper.add({
+                  billingInvoiceLicenceId: followUpBillingInvoiceLicenceId,
+                  isWinterOnly: true,
+                  isCredit: true
+                })
+              })
+
+              it('returns the debits', async () => {
+                const results = await FetchPreviousBillingTransactionsService.go(
+                  { invoiceAccountId },
+                  { licenceId },
+                  financialYearEnding
+                )
+
+                expect(results).to.have.length(1)
+                expect(results[0].isCredit).to.be.false()
+              })
+            })
+
+            describe('because the supported source differs (additional charge) is different', () => {
+              beforeEach(async () => {
+                await BillingTransactionHelper.add({
+                  billingInvoiceLicenceId: followUpBillingInvoiceLicenceId,
+                  isSupportedSource: true,
+                  isCredit: true
+                })
+              })
+
+              it('returns the debits', async () => {
+                const results = await FetchPreviousBillingTransactionsService.go(
+                  { invoiceAccountId },
+                  { licenceId },
+                  financialYearEnding
+                )
+
+                expect(results).to.have.length(1)
+                expect(results[0].isCredit).to.be.false()
+              })
+            })
+
+            describe('because the supported source name differs (additional charge) is different', () => {
+              beforeEach(async () => {
+                await BillingTransactionHelper.add({
+                  billingInvoiceLicenceId: followUpBillingInvoiceLicenceId,
+                  supportedSourceName: 'source name',
+                  isCredit: true
+                })
+              })
+
+              it('returns the debits', async () => {
+                const results = await FetchPreviousBillingTransactionsService.go(
+                  { invoiceAccountId },
+                  { licenceId },
+                  financialYearEnding
+                )
+
+                expect(results).to.have.length(1)
+                expect(results[0].isCredit).to.be.false()
+              })
+            })
+
+            describe('because the water company flag differs (additional charge) is different', () => {
+              beforeEach(async () => {
+                await BillingTransactionHelper.add({
+                  billingInvoiceLicenceId: followUpBillingInvoiceLicenceId,
+                  isWaterCompanyCharge: true,
+                  isCredit: true
+                })
+              })
+
+              it('returns the debits', async () => {
+                const results = await FetchPreviousBillingTransactionsService.go(
+                  { invoiceAccountId },
+                  { licenceId },
+                  financialYearEnding
+                )
+
+                expect(results).to.have.length(1)
+                expect(results[0].isCredit).to.be.false()
+              })
+            })
           })
         })
 


### PR DESCRIPTION
> https://eaflood.atlassian.net/browse/WATER-4005

We have found another issue in UAT for the SROC supplementary billing. When fetching previous billing transactions we compare the debits against the credits and 'cleanse' any that match. This is how we determine if there is anything previous to be credited in the new bill run because they will be the debits that didn't match anything.

But we have found in testing there is a scenario where there is a debit to be credited but we're letting the _wrong_ debit billing transactions through. This is because we are only comparing charge type and number of billable days. We need to be looking at a number of other properties.

To explain the issue, we've put together this example.

## Before the fix

### Bill run 1

So, imagine we have licence `01/123/456` and linked to it is 1 new SROC charge version with no additional agreements.

> For the purposes of this the abstraction period is all year and the charge reference is the same for each charge version. Also, the charge version ID below ascends in the order they are added. But we list them in the tables in the order the UI will display them.

|ID   |Add. agreements?|Start|End  |Status  |
|-----|----------------|-----|-----|--------|
|CHG01|-               |01/04|-    |APPROVED|

The annual bill run was generated resulting in

|ID   |Charge Version|Add. agreements?|Billable days|Debit or Credit?|Amount|
|-----|--------------|----------------|-------------|----------------|------|
|TRN01|CHG01         |-               |365          |Debit           |1000  |

### Bill run 2

Then, a new charge version with an additional agreement is added which replaces `CHG01`.

|ID   |Add. agreements?|Start|End  |Status  |
|-----|----------------|-----|-----|--------|
|CHG02|Winter discount |01/04|-    |APPROVED|
|CHG01|-               |01/04|-    |REPLACED|

A supplementary bill run is generated resulting in

|ID   |Charge Version|Add. agreements?|Billable days|Debit or Credit?|Amount|
|-----|--------------|----------------|-------------|----------------|------|
|TRN02|CHG01         |-               |365          |Credit          |1000  |
|TRN03|CHG02         |Winter discount |365          |Debit           |500   |

### Bill run 3

Then, another charge version is added which replaces `CHG02` (the reason doesn't matter).

|ID   |Add. agreements?|Start|End  |Status  |
|-----|----------------|-----|-----|--------|
|CHG03|Winter discount |01/04|-    |APPROVED|
|CHG02|Winter discount |01/04|-    |REPLACED|
|CHG01|-               |01/04|-    |REPLACED|

A supplementary bill run is generated. Depending on the order in which `FetchPreviousBillingTransactionsService` recieves the transactions from the DB we could get one of 2 bill runs (first correct, second incorrect).

|ID   |Charge Version|Add. agreements?|Billable days|Debit or Credit?|Amount|
|-----|--------------|----------------|-------------|----------------|------|
|TRN04|CHG02         |Winter discount |365          |Credit          |500   |
|TRN05|CHG03         |Winter discount |365          |Debit           |500   |

or

|ID   |Charge Version|Add. agreements?|Billable days|Debit or Credit?|Amount|
|-----|--------------|----------------|-------------|----------------|------|
|TRN04|CHG01         |-               |365          |Credit          |1000  |
|TRN05|CHG03         |Winter discount |365          |Debit           |500   |

If the service received the transactions in this order it would result in the second bill run.

|ID   |Charge Version|Add. agreements?|Billable days|Debit or Credit?|Amount|
|-----|--------------|----------------|-------------|----------------|------|
|TRN03|CHG02         |Winter discount |365          |Debit           |500   |
|TRN01|CHG01         |-               |365          |Debit           |1000  |
|TRN02|CHG01         |-               |365          |Credit          |1000  |

This is because `FetchPreviousBillingTransactionsService` splits the results into debits and credits, then compares the 2. Prior to this change we only compared billable days (and charge type but that is irrelevant to the issue). So, our £500 winter discount-based debit (`TRN03`) would be cancelled by the £1000 no agreement-based credit (`TRN02`).

This would leave our supplementary billing engine to think `TRN01`, the £1000 debit needs to be credited.

## The fix

By comparing other properties, including agreements as well as the billable days the correct credit will be cancelled out by the correct debit.