### PR TITLE
`ProcessBillingBatchService` refactor - pre-generate invoice licences

### DIFF
--- a/app/services/supplementary-billing/generate-billing-invoice-licence.service.js
+++ b/app/services/supplementary-billing/generate-billing-invoice-licence.service.js
@@ -8,38 +8,15 @@
 const { randomUUID } = require('crypto')
 
 /**
- * Return either a new billing invoice licence object ready for persisting or an existing one if it exists
+ * Return a billing invoice licence object ready for persisting
  *
- * This first checks whether the billing invoice id and licence id of `currentBillingInvoiceLicence` match the ones
- * passed to this service. If they do, we return that instance.
- *
- * If they don't, we generate a new instance and return it.
- *
- * For context, this is all to avoid creating `billing_invoice` and `billing_invoice_licence` records unnecessarily. The
- * legacy service will create them first, then determine if there are any transactions to be billed. If there aren't, it
- * then has to go back and delete the records it created.
- *
- * Our intent is to only call the DB when we have records that need persisting. So, we start at the transaction level
- * and only persist `billing_invoice` and `billing_invoice_licence` records that are linked to billable transactions.
- * But to persist the billing transactions we need the foreign keys. So, we generate our billing invoice and billing
- * licence data in memory along with ID's, and use this service to provide the right record when persisting the
- * transaction.
- *
- * @param {module:billingInvoiceLicence} currentBillingInvoiceLicence A billing invoice licence object
  * @param {String} billingInvoiceId UUID of the billing invoice this billing invoice licence will be linked to if
  *  persisted
  * @param {module:LicenceModel} licence The licence this billing invoice licence will be linked to
  *
  * @returns {Object} The current or newly-generated billing invoice licence object
  */
-function go (currentBillingInvoiceLicence, billingInvoiceId, licence) {
-  if (
-    currentBillingInvoiceLicence?.billingInvoiceId === billingInvoiceId &&
-    currentBillingInvoiceLicence?.licenceId === licence.licenceId
-  ) {
-    return currentBillingInvoiceLicence
-  }
-
+function go (billingInvoiceId, licence) {
   const billingInvoiceLicence = {
     billingInvoiceId,
     billingInvoiceLicenceId: randomUUID({ disableEntropyCache: true }),

--- a/app/services/supplementary-billing/process-billing-batch.service.js
+++ b/app/services/supplementary-billing/process-billing-batch.service.js
@@ -133,7 +133,8 @@ function _preGenerateBillingInvoiceLicences (chargeVersions, billingInvoices, bi
 
       const key = _billingInvoiceLicenceKey(billingInvoiceId, licence.licenceId)
 
-      // If the key already exists in our object then we don't need to generate another billing invoice licence for it
+      // The charge versions may contain a combination of billing invoice and licence multiple times, so we check to see
+      // if this combination has already had a billing invoice licence generated for it and return early if so
       if (acc.key) {
         return acc
       }
@@ -169,6 +170,8 @@ function _billingInvoiceLicenceKey (billingInvoiceId, licenceId) {
 function _preGenerateBillingInvoices (invoiceAccounts, billingBatchId, billingPeriod) {
   try {
     const keyedBillingInvoices = invoiceAccounts.reduce((acc, invoiceAccount) => {
+      // Note that the array of invoice accounts will already have been deduped so we don't need to check whether a
+      // billing invoice licence already exists in the object before generating one
       return {
         ...acc,
         [invoiceAccount.invoiceAccountId]: GenerateBillingInvoiceService.go(

--- a/app/services/supplementary-billing/process-billing-batch.service.js
+++ b/app/services/supplementary-billing/process-billing-batch.service.js
@@ -52,13 +52,11 @@ async function go (billingBatch, billingPeriod) {
     const chargeVersions = await _fetchChargeVersions(billingBatch, billingPeriod)
     const invoiceAccounts = await _fetchInvoiceAccounts(chargeVersions, billingBatchId)
 
-    // Pre-generate our required data
-    const billingInvoices = _generateBillingInvoices(invoiceAccounts, billingBatchId, billingPeriod)
-    const billingInvoiceLicences = _generateBillingInvoiceLicences(chargeVersions, billingInvoices, billingBatch)
+    const billingInvoices = _preGenerateBillingInvoices(invoiceAccounts, billingBatchId, billingPeriod)
+    const billingInvoiceLicences = _preGenerateBillingInvoiceLicences(chargeVersions, billingInvoices, billingBatch)
 
     for (const chargeVersion of chargeVersions) {
-      // Retrieve our previously-generated data
-      const { billingInvoiceLicence, billingInvoice } = _retrieveGeneratedData(
+      const { billingInvoiceLicence, billingInvoice } = _retrievePreGeneratedData(
         chargeVersion,
         billingInvoices,
         billingInvoiceLicences
@@ -91,7 +89,7 @@ async function go (billingBatch, billingPeriod) {
   }
 }
 
-function _retrieveGeneratedData (chargeVersion, billingInvoices, billingInvoiceLicences) {
+function _retrievePreGeneratedData (chargeVersion, billingInvoices, billingInvoiceLicences) {
   const billingInvoice = billingInvoices[chargeVersion.invoiceAccountId]
 
   const billingInvoiceLicenceKey = _billingInvoiceLicenceKey(
@@ -115,7 +113,7 @@ async function _fetchInvoiceAccounts (chargeVersions, billingBatchId) {
   }
 }
 
-function _generateBillingInvoiceLicences (chargeVersions, billingInvoices, billingBatch) {
+function _preGenerateBillingInvoiceLicences (chargeVersions, billingInvoices, billingBatch) {
   try {
     const billingInvoiceLicences = chargeVersions.map((chargeVersion) => {
       const { licence } = chargeVersion
@@ -152,7 +150,7 @@ function _billingInvoiceLicenceKey (billingInvoiceId, licenceId) {
   return `${billingInvoiceId}-${licenceId}`
 }
 
-function _generateBillingInvoices (invoiceAccounts, billingBatchId, billingPeriod) {
+function _preGenerateBillingInvoices (invoiceAccounts, billingBatchId, billingPeriod) {
   try {
     const billingInvoices = invoiceAccounts.map((invoiceAccount) => {
       return GenerateBillingInvoiceService.go(

--- a/app/services/supplementary-billing/process-billing-batch.service.js
+++ b/app/services/supplementary-billing/process-billing-batch.service.js
@@ -50,10 +50,10 @@ async function go (billingBatch, billingPeriod) {
     await _updateStatus(billingBatchId, 'processing')
 
     const chargeVersions = await _fetchChargeVersions(billingBatch, billingPeriod)
-    const invoiceAccounts = await _fetchInvoiceAccounts(chargeVersions, billingBatch.billingBatchId)
+    const invoiceAccounts = await _fetchInvoiceAccounts(chargeVersions, billingBatchId)
 
     // Pre-generate our required data
-    const billingInvoices = _generateBillingInvoices(invoiceAccounts, billingBatch.billingBatchId, billingPeriod)
+    const billingInvoices = _generateBillingInvoices(invoiceAccounts, billingBatchId, billingPeriod)
     const billingInvoiceLicences = _generateBillingInvoiceLicences(chargeVersions, billingInvoices, billingBatch)
 
     for (const chargeVersion of chargeVersions) {

--- a/app/services/supplementary-billing/process-billing-batch.service.js
+++ b/app/services/supplementary-billing/process-billing-batch.service.js
@@ -52,7 +52,7 @@ async function go (billingBatch, billingPeriod) {
     const chargeVersions = await _fetchChargeVersions(billingBatch, billingPeriod)
     const invoiceAccounts = await _fetchInvoiceAccounts(chargeVersions, billingBatch.billingBatchId)
 
-    // Pre-generate our required data.
+    // Pre-generate our required data
     const billingInvoices = _generateBillingInvoices(invoiceAccounts, billingBatch.billingBatchId, billingPeriod)
     const billingInvoiceLicences = _generateBillingInvoiceLicences(chargeVersions, billingInvoices, billingBatch)
 
@@ -121,10 +121,7 @@ function _generateBillingInvoiceLicences (chargeVersions, billingInvoices, billi
       const { licence } = chargeVersion
       const { billingInvoiceId } = billingInvoices[chargeVersion.invoiceAccountId]
 
-      // TODO: We pass {} as the first argument as we always want GenerateBillingInvoiceLicenceService to generate us a
-      // billing invoice licence. Once we've confirmed we're happy with our revised approach we will remove this
-      // functionality from the service.
-      return GenerateBillingInvoiceLicenceService.go({}, billingInvoiceId, licence)
+      return GenerateBillingInvoiceLicenceService.go(billingInvoiceId, licence)
     })
 
     // We create a keyed object from the array so we can quickly retrieve the required billing invoice licence later. This

--- a/test/services/supplementary-billing/generate-billing-invoice-licence.service.test.js
+++ b/test/services/supplementary-billing/generate-billing-invoice-licence.service.test.js
@@ -18,68 +18,22 @@ describe('Generate billing invoice licence service', () => {
 
   const billingInvoiceId = 'f4fb6257-c50f-46ea-80b0-7533423d6efd'
 
-  let currentBillingInvoiceLicence
   let expectedResult
 
-  describe('when `currentBillingInvoiceLicence` is null', () => {
+  describe('when called', () => {
     beforeEach(() => {
-      currentBillingInvoiceLicence = null
-      expectedResult = _billingInvoiceLicenceGenerator(billingInvoiceId, licence)
+      expectedResult = {
+        billingInvoiceLicenceId: 'fa0c763e-3976-42df-ae2c-e93a954701dd',
+        billingInvoiceId,
+        licenceRef: licence.licenceRef,
+        licenceId: licence.licenceId
+      }
     })
 
     it('returns a new billing invoice licence with the provided values', () => {
-      const result = GenerateBillingInvoiceLicenceService.go(currentBillingInvoiceLicence, billingInvoiceId, licence)
+      const result = GenerateBillingInvoiceLicenceService.go(billingInvoiceId, licence)
 
       expect(result).to.equal(expectedResult, { skip: 'billingInvoiceLicenceId' })
     })
   })
-
-  describe('when `currentBillingInvoiceLicence` is set', () => {
-    beforeEach(() => {
-      currentBillingInvoiceLicence = _billingInvoiceLicenceGenerator(billingInvoiceId, licence)
-    })
-
-    describe('and the billing invoice id matches', () => {
-      describe('as well as the licence', () => {
-        it('returns the `currentBillingInvoiceLicence`', async () => {
-          const result = GenerateBillingInvoiceLicenceService.go(currentBillingInvoiceLicence, billingInvoiceId, licence)
-
-          expect(result).to.equal(currentBillingInvoiceLicence)
-        })
-      })
-
-      describe('but the licence does not', () => {
-        const otherLicence = { licenceId: 'e6c07787-b367-408d-a2f8-a5313cfcef32', licenceRef: 'ABC1' }
-
-        it('returns a new billing invoice licence with the provided values', () => {
-          const result = GenerateBillingInvoiceLicenceService.go(currentBillingInvoiceLicence, billingInvoiceId, otherLicence)
-
-          expect(result).not.to.equal(currentBillingInvoiceLicence)
-          expect(result.billingInvoiceId).to.equal(billingInvoiceId)
-          expect(result.licenceId).to.equal(otherLicence.licenceId)
-        })
-      })
-    })
-
-    describe('but the billing invoice id does not match', () => {
-      const otherBillingInvoiceId = 'fc9c4a2f-819d-4b31-9bcc-39c795660602'
-
-      it('returns a new billing invoice licence with the provided values', () => {
-        const result = GenerateBillingInvoiceLicenceService.go(currentBillingInvoiceLicence, otherBillingInvoiceId, licence)
-
-        expect(result).not.to.equal(currentBillingInvoiceLicence)
-        expect(result.billingInvoiceId).to.equal(otherBillingInvoiceId)
-        expect(result.licenceId).to.equal(licence.licenceId)
-      })
-    })
-  })
 })
-
-function _billingInvoiceLicenceGenerator (billingInvoiceId, licence) {
-  return {
-    billingInvoiceLicenceId: 'fa0c763e-3976-42df-ae2c-e93a954701dd',
-    billingInvoiceId,
-    licenceRef: licence.licenceRef,
-    licenceId: licence.licenceId
-  }
-}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3996

In order to fix a bug introduced by our refactoring, we moved to pre-generating all required billing invoices prior to entering the main charge version processing loop. Having done this, we think it would be a good idea to also pre-generate the required invoice licences.

This PR also introduces further optimisations to the pre-generation of the billing invoices, reducing the number of times we need to iterate in order to produce the object containing the generated billing invoices.