### PR TITLE
Clean up temporary files

### DIFF
--- a/app/services/db-export/delete-file.service.js
+++ b/app/services/db-export/delete-file.service.js
@@ -12,7 +12,7 @@ const fs = require('fs')
  * @param {String} filePath The file path that we want to delete
  */
 async function go (filePath) {
-  await fs.unlinkSync(filePath)
+  fs.unlinkSync(filePath)
 }
 
 module.exports = {

--- a/app/services/db-export/delete-file.service.js
+++ b/app/services/db-export/delete-file.service.js
@@ -1,0 +1,20 @@
+'use strict'
+
+/**
+ * @module DeleteFileService
+ */
+
+const fs = require('fs')
+
+/**
+ * Deleting a file
+ *
+ * @param {String} filePath The file path that we want to delete
+ */
+async function go (filePath) {
+  await fs.unlinkSync(filePath)
+}
+
+module.exports = {
+  go
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "@hapi/code": "^9.0.2",
         "@hapi/hoek": "^11.0.2",
         "@hapi/lab": "^25.0.1",
+        "mock-fs": "^5.2.0",
         "nock": "^13.2.9",
         "pino-pretty": "^9.1.1",
         "proxyquire": "^2.1.3",
@@ -5591,6 +5592,15 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/mock-fs": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-5.2.0.tgz",
+      "integrity": "sha512-2dF2R6YMSZbpip1V1WHKGLNjr/k48uQClqMVb5H3MOvwc9qhYis3/IWbj02qIg/Y8MDXKFF4c5v0rxx2o6xTZw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/module-not-found-error": {
@@ -11750,6 +11760,12 @@
       "requires": {
         "pkg-up": "3.x.x"
       }
+    },
+    "mock-fs": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-5.2.0.tgz",
+      "integrity": "sha512-2dF2R6YMSZbpip1V1WHKGLNjr/k48uQClqMVb5H3MOvwc9qhYis3/IWbj02qIg/Y8MDXKFF4c5v0rxx2o6xTZw==",
+      "dev": true
     },
     "module-not-found-error": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@hapi/code": "^9.0.2",
     "@hapi/hoek": "^11.0.2",
     "@hapi/lab": "^25.0.1",
+    "mock-fs": "^5.2.0",
     "nock": "^13.2.9",
     "pino-pretty": "^9.1.1",
     "proxyquire": "^2.1.3",

--- a/test/services/db-export/compress-files.service.test.js
+++ b/test/services/db-export/compress-files.service.test.js
@@ -12,7 +12,7 @@ const { expect } = Code
 const fs = require('fs')
 
 // Thing under test
-const CompressFilesService = require('../../../app/services/db-export/compress-files.service')
+const CompressFilesService = require('../../../app/services/db-export/compress-files.service.js')
 
 describe('Compress files service', () => {
   let notifierStub

--- a/test/services/db-export/convert-to-csv.service.test.js
+++ b/test/services/db-export/convert-to-csv.service.test.js
@@ -8,7 +8,7 @@ const { describe, it } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Thing under test
-const ConvertToCSVService = require('../../../app/services/db-export/convert-to-csv.service')
+const ConvertToCSVService = require('../../../app/services/db-export/convert-to-csv.service.js')
 
 /**
  * billingChargeCategoriesTable has all data types we are testing for

--- a/test/services/db-export/delete-file.service.test.js
+++ b/test/services/db-export/delete-file.service.test.js
@@ -1,0 +1,54 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach, afterEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const fs = require('fs')
+const path = require('path')
+const mockFs = require('mock-fs')
+
+// Thing under test
+const DeleteFileService = require('../../../app/services/db-export/delete-file.service.js')
+
+describe('Delete File service', () => {
+  let filenameWithPath
+
+  beforeEach(() => {
+    filenameWithPath = path.join('testFolder', 'testFile')
+
+    mockFs({
+      testFolder: {
+        testFile: 'test content'
+      }
+    })
+  })
+
+  afterEach(() => {
+    mockFs.restore()
+  })
+
+  describe('When a valid file is specified', () => {
+    it('deletes the file', async () => {
+      await DeleteFileService.go(filenameWithPath)
+
+      const fileExists = fs.existsSync(filenameWithPath)
+      expect(fileExists).to.be.false()
+    })
+  })
+
+  describe('When an error occurs', () => {
+    it('throws an error', async () => {
+      const fakeFile = 'FAKE_FILE'
+
+      const result = await expect(DeleteFileService.go(fakeFile)).to.reject()
+
+      expect(result).to.be.an.error()
+      expect(result.message).to.equal(`ENOENT: no such file or directory, unlink '${fakeFile}'`)
+    })
+  })
+})

--- a/test/services/db-export/export-data-files.service.test.js
+++ b/test/services/db-export/export-data-files.service.test.js
@@ -13,7 +13,7 @@ const fs = require('fs')
 const path = require('path')
 
 // Thing under test
-const ExportDataFilesService = require('../../../app/services/db-export/export-data-files.service')
+const ExportDataFilesService = require('../../../app/services/db-export/export-data-files.service.js')
 
 const csvHeader = [
   '"billingChargeCategoryId"',

--- a/test/services/db-export/send-to-s3-bucket.service.test.js
+++ b/test/services/db-export/send-to-s3-bucket.service.test.js
@@ -15,7 +15,7 @@ const path = require('path')
 const { S3Client, PutObjectCommand } = require('@aws-sdk/client-s3')
 
 // Thing under test
-const SendToS3BucketService = require('../../../app/services/db-export/send-to-s3-bucket.service')
+const SendToS3BucketService = require('../../../app/services/db-export/send-to-s3-bucket.service.js')
 
 describe('Send to S3 bucket service', () => {
   let s3Stub


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3967

This pull request is just a small part of a larger project that involves exporting all our database schemas, converting them into CSV files, and uploading them to our Amazon S3 bucket. This PR's primary focus is cleaning up the files that have been temporarily created to upload to the bucket. To expedite the export process and see the output sooner, we are using a vertical slicing approach, rather than a horizontal one, which means exporting a single table at a time from each schema.