### PR TITLE
Add prefix to 2PT billing transaction descriptions

### DIFF
--- a/app/services/supplementary-billing/generate-billing-transactions.service.js
+++ b/app/services/supplementary-billing/generate-billing-transactions.service.js
@@ -77,6 +77,15 @@ function _compensationTransaction (billingTransactionId, standardTransaction) {
   }
 }
 
+function _description (chargeElement) {
+  // If the value is false, undefined, null or simply doesn't exist we return the standard description
+  if (!chargeElement.adjustments.s127) {
+    return `Water abstraction charge: ${chargeElement.description}`
+  }
+
+  return `Two-part tariff basic water abstraction charge: ${chargeElement.description}`
+}
+
 /**
  * Return a unique UUID to be used as an ID
  *
@@ -136,7 +145,7 @@ function _standardTransaction (
     authorisedQuantity: chargeElement.volume,
     billableQuantity: chargeElement.volume,
     status: 'candidate',
-    description: `Water abstraction charge: ${chargeElement.description}`,
+    description: _description(chargeElement),
     volume: chargeElement.volume,
     section126Factor: chargeElement.adjustments.s126 || 1,
     section127Agreement: !!chargeElement.adjustments.s127,

--- a/test/services/supplementary-billing/generate-billing-transactions.service.test.js
+++ b/test/services/supplementary-billing/generate-billing-transactions.service.test.js
@@ -172,15 +172,15 @@ describe('Generate billing transactions service', () => {
         isNewLicence = true
       })
 
-      it('returns `isNewLicence` as true on both transaction lines in the result', () => {
+      it('returns `isNewLicence` as true in the results', () => {
         const result = GenerateBillingTransactionsService.go(chargeElement, billingPeriod, chargePeriod, isNewLicence, isWaterUndertaker)
 
         expect(result[0].isNewLicence).to.be.true()
       })
     })
 
-    describe('returns `isNewLicence` as false on both transaction lines in the result', () => {
-      it('returns the expected data', () => {
+    describe('and is not a new licence', () => {
+      it('returns `isNewLicence` as false in the results', () => {
         const result = GenerateBillingTransactionsService.go(chargeElement, billingPeriod, chargePeriod, isNewLicence, isWaterUndertaker)
 
         expect(result[0].isNewLicence).to.be.false()

--- a/test/services/supplementary-billing/generate-billing-transactions.service.test.js
+++ b/test/services/supplementary-billing/generate-billing-transactions.service.test.js
@@ -100,12 +100,12 @@ describe('Generate billing transactions service', () => {
       })
 
       it('returns an array of one transaction containing the expected data', () => {
-        const result = GenerateBillingTransactionsService.go(chargeElement, billingPeriod, chargePeriod, isNewLicence, isWaterUndertaker)
+        const results = GenerateBillingTransactionsService.go(chargeElement, billingPeriod, chargePeriod, isNewLicence, isWaterUndertaker)
 
         // Should only return the 'standard' charge transaction line
-        expect(result).to.have.length(1)
+        expect(results).to.have.length(1)
         // We skip checking 'purposes' as we test this elsewhere
-        expect(result[0]).to.equal(
+        expect(results[0]).to.equal(
           {
             ...expectedStandardChargeResult,
             isWaterUndertaker
@@ -115,9 +115,9 @@ describe('Generate billing transactions service', () => {
       })
 
       it('returns the charge purpose as JSON in the transaction line `purposes` property', () => {
-        const result = GenerateBillingTransactionsService.go(chargeElement, billingPeriod, chargePeriod, isNewLicence, isWaterUndertaker)
+        const results = GenerateBillingTransactionsService.go(chargeElement, billingPeriod, chargePeriod, isNewLicence, isWaterUndertaker)
 
-        const parsedPurposes = JSON.parse(result[0].purposes)
+        const parsedPurposes = JSON.parse(results[0].purposes)
 
         expect(parsedPurposes[0].chargePurposeId).to.equal(chargePurpose.chargePurposeId)
       })
@@ -125,12 +125,12 @@ describe('Generate billing transactions service', () => {
 
     describe('and is not a water undertaker', () => {
       it('returns an array of two transactions containing the expected data', () => {
-        const result = GenerateBillingTransactionsService.go(chargeElement, billingPeriod, chargePeriod, isNewLicence, isWaterUndertaker)
+        const results = GenerateBillingTransactionsService.go(chargeElement, billingPeriod, chargePeriod, isNewLicence, isWaterUndertaker)
 
         // Should return both a 'standard' charge and 'compensation' charge transaction line
-        expect(result).to.have.length(2)
+        expect(results).to.have.length(2)
         // We skip checking 'purposes' as we test this elsewhere
-        expect(result[0]).to.equal(
+        expect(results[0]).to.equal(
           {
             ...expectedStandardChargeResult,
             isWaterUndertaker
@@ -140,9 +140,9 @@ describe('Generate billing transactions service', () => {
       })
 
       it('returns a second compensation charge transaction', () => {
-        const result = GenerateBillingTransactionsService.go(chargeElement, billingPeriod, chargePeriod, isNewLicence, isWaterUndertaker)
+        const results = GenerateBillingTransactionsService.go(chargeElement, billingPeriod, chargePeriod, isNewLicence, isWaterUndertaker)
 
-        expect(result[1]).to.equal(
+        expect(results[1]).to.equal(
           {
             ...expectedStandardChargeResult,
             isWaterUndertaker,
@@ -154,10 +154,10 @@ describe('Generate billing transactions service', () => {
       })
 
       it('returns the charge purpose as JSON in both transaction lines `purposes` property', () => {
-        const result = GenerateBillingTransactionsService.go(chargeElement, billingPeriod, chargePeriod, isNewLicence, isWaterUndertaker)
+        const results = GenerateBillingTransactionsService.go(chargeElement, billingPeriod, chargePeriod, isNewLicence, isWaterUndertaker)
 
-        const parsedStandardPurposes = JSON.parse(result[0].purposes)
-        const parsedCompensationPurposes = JSON.parse(result[1].purposes)
+        const parsedStandardPurposes = JSON.parse(results[0].purposes)
+        const parsedCompensationPurposes = JSON.parse(results[1].purposes)
 
         expect(parsedStandardPurposes[0].chargePurposeId).to.equal(chargePurpose.chargePurposeId)
         expect(parsedCompensationPurposes[0].chargePurposeId).to.equal(chargePurpose.chargePurposeId)
@@ -173,26 +173,26 @@ describe('Generate billing transactions service', () => {
       })
 
       it('returns `isNewLicence` as true in the results', () => {
-        const result = GenerateBillingTransactionsService.go(chargeElement, billingPeriod, chargePeriod, isNewLicence, isWaterUndertaker)
+        const results = GenerateBillingTransactionsService.go(chargeElement, billingPeriod, chargePeriod, isNewLicence, isWaterUndertaker)
 
-        expect(result[0].isNewLicence).to.be.true()
+        expect(results[0].isNewLicence).to.be.true()
       })
     })
 
     describe('and is not a new licence', () => {
       it('returns `isNewLicence` as false in the results', () => {
-        const result = GenerateBillingTransactionsService.go(chargeElement, billingPeriod, chargePeriod, isNewLicence, isWaterUndertaker)
+        const results = GenerateBillingTransactionsService.go(chargeElement, billingPeriod, chargePeriod, isNewLicence, isWaterUndertaker)
 
-        expect(result[0].isNewLicence).to.be.false()
+        expect(results[0].isNewLicence).to.be.false()
       })
     })
 
     describe('and a two-part tariff agreement (section 127)', () => {
       describe('has not applied', () => {
         it('returns the standard description', () => {
-          const result = GenerateBillingTransactionsService.go(chargeElement, billingPeriod, chargePeriod, isNewLicence, isWaterUndertaker)
+          const results = GenerateBillingTransactionsService.go(chargeElement, billingPeriod, chargePeriod, isNewLicence, isWaterUndertaker)
 
-          expect(result[0].description).to.equal(`Water abstraction charge: ${chargeElement.description}`)
+          expect(results[0].description).to.equal(`Water abstraction charge: ${chargeElement.description}`)
         })
       })
 
@@ -202,9 +202,9 @@ describe('Generate billing transactions service', () => {
         })
 
         it('returns the two-part tariff prefixed description', () => {
-          const result = GenerateBillingTransactionsService.go(chargeElement, billingPeriod, chargePeriod, isNewLicence, isWaterUndertaker)
+          const results = GenerateBillingTransactionsService.go(chargeElement, billingPeriod, chargePeriod, isNewLicence, isWaterUndertaker)
 
-          expect(result[0].description).to.equal(`Two-part tariff basic water abstraction charge: ${chargeElement.description}`)
+          expect(results[0].description).to.equal(`Two-part tariff basic water abstraction charge: ${chargeElement.description}`)
         })
       })
     })
@@ -221,9 +221,9 @@ describe('Generate billing transactions service', () => {
     })
 
     it('returns an empty array', () => {
-      const result = GenerateBillingTransactionsService.go(chargeElement, billingPeriod, chargePeriod, isNewLicence, isWaterUndertaker)
+      const results = GenerateBillingTransactionsService.go(chargeElement, billingPeriod, chargePeriod, isNewLicence, isWaterUndertaker)
 
-      expect(result).to.be.empty()
+      expect(results).to.be.empty()
     })
   })
 })

--- a/test/services/supplementary-billing/generate-billing-transactions.service.test.js
+++ b/test/services/supplementary-billing/generate-billing-transactions.service.test.js
@@ -194,6 +194,32 @@ describe('Generate billing transactions service', () => {
         expect(result[0].isNewLicence).to.be.false()
       })
     })
+
+    describe('and a two-part tariff agreement (section 127)', () => {
+      beforeEach(() => {
+        isWaterUndertaker = false
+      })
+
+      describe('has not applied', () => {
+        it('returns the standard description', () => {
+          const result = GenerateBillingTransactionsService.go(chargeElement, billingPeriod, chargePeriod, isNewLicence, isWaterUndertaker)
+
+          expect(result[0].description).to.equal(`Water abstraction charge: ${chargeElement.description}`)
+        })
+      })
+
+      describe('has been applied', () => {
+        beforeEach(() => {
+          chargeElement.adjustments.s127 = true
+        })
+
+        it('returns the two-part tariff prefixed description', () => {
+          const result = GenerateBillingTransactionsService.go(chargeElement, billingPeriod, chargePeriod, isNewLicence, isWaterUndertaker)
+
+          expect(result[0].description).to.equal(`Two-part tariff basic water abstraction charge: ${chargeElement.description}`)
+        })
+      })
+    })
   })
 
   describe('when a charge element does not have billable days', () => {

--- a/test/services/supplementary-billing/generate-billing-transactions.service.test.js
+++ b/test/services/supplementary-billing/generate-billing-transactions.service.test.js
@@ -56,6 +56,7 @@ describe('Generate billing transactions service', () => {
         startDate: new Date('2022-04-01'),
         endDate: new Date('2022-10-31')
       }
+      isWaterUndertaker = false
       isNewLicence = false
 
       expectedStandardChargeResult = {
@@ -123,10 +124,6 @@ describe('Generate billing transactions service', () => {
     })
 
     describe('and is not a water undertaker', () => {
-      beforeEach(() => {
-        isWaterUndertaker = false
-      })
-
       it('returns an array of two transactions containing the expected data', () => {
         const result = GenerateBillingTransactionsService.go(chargeElement, billingPeriod, chargePeriod, isNewLicence, isWaterUndertaker)
 
@@ -172,7 +169,6 @@ describe('Generate billing transactions service', () => {
     // worth adding unit tests for, if only to document it as something that the service expects
     describe('and is a new licence', () => {
       beforeEach(() => {
-        isWaterUndertaker = false
         isNewLicence = true
       })
 
@@ -184,10 +180,6 @@ describe('Generate billing transactions service', () => {
     })
 
     describe('returns `isNewLicence` as false on both transaction lines in the result', () => {
-      beforeEach(() => {
-        isWaterUndertaker = false
-      })
-
       it('returns the expected data', () => {
         const result = GenerateBillingTransactionsService.go(chargeElement, billingPeriod, chargePeriod, isNewLicence, isWaterUndertaker)
 
@@ -196,10 +188,6 @@ describe('Generate billing transactions service', () => {
     })
 
     describe('and a two-part tariff agreement (section 127)', () => {
-      beforeEach(() => {
-        isWaterUndertaker = false
-      })
-
       describe('has not applied', () => {
         it('returns the standard description', () => {
           const result = GenerateBillingTransactionsService.go(chargeElement, billingPeriod, chargePeriod, isNewLicence, isWaterUndertaker)
@@ -228,8 +216,6 @@ describe('Generate billing transactions service', () => {
         startDate: new Date('2022-04-01'),
         endDate: new Date('2022-10-31')
       }
-      isNewLicence = false
-      isWaterUndertaker = false
 
       Sinon.stub(CalculateAuthorisedAndBillableDaysServiceService, 'go').returns({ authorisedDays: 365, billableDays: 0 })
     })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4006

It has been highlighted in testing that users expect to see a different description for any billing transactions linked to a charge version with a two-part tariff agreement in place.

For example, a standard description would be

> Water abstraction charge: Spray Irrigation at Baygrove Upcot Oldent

If the charge version has a two-part tariff agreement it should be

> Two-part tariff basic water abstraction charge: Spray Irrigation at Baygrove Upcot Oldent

This change makes that happen.

N.B. For reference, the legacy code handles this in `src/modules/billing/services/charge-processor-service/transactions-processor.js`

```javascript
return chargeElement.adjustments.s127
  ? `Two-part tariff basic water abstraction charge: ${chargeElement.description}`
  : `Water abstraction charge: ${chargeElement.description}`
```