### PR TITLE
Unflag all processed licences not in bill run

### DIFF
--- a/app/services/supplementary-billing/process-billing-batch.service.js
+++ b/app/services/supplementary-billing/process-billing-batch.service.js
@@ -21,8 +21,8 @@ const GenerateBillingInvoiceService = require('./generate-billing-invoice.servic
 const GenerateBillingInvoiceLicenceService = require('./generate-billing-invoice-licence.service.js')
 const HandleErroredBillingBatchService = require('./handle-errored-billing-batch.service.js')
 const LegacyRequestLib = require('../../lib/legacy-request.lib.js')
-const LicenceModel = require('../../models/water/licence.model.js')
 const ProcessBillingTransactionsService = require('./process-billing-transactions.service.js')
+const UnflagUnbilledLicencesService = require('./unflag-unbilled-licences.service.js')
 
 /**
  * Creates the invoices and transactions in both WRLS and the Charging Module API
@@ -258,10 +258,11 @@ async function _fetchChargeVersions (billingBatch, billingPeriod) {
 
 async function _finaliseBillingBatch (billingBatch, chargeVersions, isEmpty) {
   try {
+    await UnflagUnbilledLicencesService.go(billingBatch.billingBatchId, chargeVersions)
+
     // The bill run is considered empty. We just need to set the status to indicate this in the UI
     if (isEmpty) {
       await _updateStatus(billingBatch.billingBatchId, 'empty')
-      await _setSuppBillingFlagsToFalse(chargeVersions)
 
       return
     }
@@ -374,16 +375,6 @@ async function _updateStatus (billingBatchId, status) {
 
     throw error
   }
-}
-
-async function _setSuppBillingFlagsToFalse (chargeVersions) {
-  const licenceIds = chargeVersions.map((chargeVersion) => {
-    return chargeVersion.licence.licenceId
-  })
-
-  await LicenceModel.query()
-    .whereIn('licenceId', licenceIds)
-    .patch({ includeInSrocSupplementaryBilling: false })
 }
 
 module.exports = {

--- a/app/services/supplementary-billing/unflag-unbilled-licences.service.js
+++ b/app/services/supplementary-billing/unflag-unbilled-licences.service.js
@@ -1,0 +1,59 @@
+'use strict'
+
+/**
+ * Unflag all licences in a bill run that did not result in a billing invoice (they are unbilled)
+ * @module UnflagUnbilledLicencesService
+ */
+
+const LicenceModel = require('../../models/water/licence.model.js')
+
+/**
+ * Unflag any licences that were not billed as part of a bill run
+ *
+ * Some licences will not result in an invoice (`billing_invoice_licence`) being created. For example, you could add a
+ * new charge version that does nothing but change the description of the previous one. In isolation, this would result
+ * in an `EMPTY` bill run. If others are being processed at the same time, it would just mean no records are added to
+ * the bill run for this licence.
+ *
+ * If this is the case, we can remove the 'Include in SROC Supplementary Billing' flag from the licence now. Even if
+ * the bill run gets cancelled and re-run later the result will be the same.
+ *
+ * What it also means is we can be accurate with which licences get unflagged when the bill run is finally **SENT**. In
+ * the old logic they simply unflag any licence in a region where `date_updated` is less than the bill run's
+ * created date. But we know this is flawed because a licence can be updated after a bill run is created, for example
+ * the NALD import process updates them all. If this happens the flag remains on.
+ *
+ * The query we run during the **SEND** process unflags only those which are linked to the bill run being sent. We can
+ * do this because we know this service has handled anything that was unbilled and not represented.
+ *
+ * @param {*} billingBatchId The ID of the bill run (billing batch) being processed
+ * @param {module:ChargeVersionModel[]} chargeVersions All charge versions being processed in the bill run
+ * @returns {Number} count of records updated
+ */
+async function go (billingBatchId, chargeVersions) {
+  const allLicenceIds = _extractUniqueLicenceIds(chargeVersions)
+  allLicenceIds.push('310f05c0-98d9-4e70-9857-71e5106e7559')
+
+  return LicenceModel.query()
+    .patch({ includeInSrocSupplementaryBilling: false })
+    .whereIn('licenceId', allLicenceIds)
+    .whereNotExists(
+      LicenceModel.relatedQuery('billingInvoiceLicences')
+        .join('billingInvoices', 'billingInvoices.billingInvoiceId', '=', 'billingInvoiceLicences.billingInvoiceId')
+        .where('billingInvoices.billingBatchId', '=', billingBatchId)
+    )
+}
+
+function _extractUniqueLicenceIds (chargeVersions) {
+  const allLicenceIds = chargeVersions.map((chargeVersion) => {
+    return chargeVersion.licence.licenceId
+  })
+
+  // Creating a new set from allLicenceIds gives us just the unique ids. Objection does not accept sets in
+  // .findByIds() so we spread it into an array
+  return [...new Set(allLicenceIds)]
+}
+
+module.exports = {
+  go
+}

--- a/app/services/supplementary-billing/unflag-unbilled-licences.service.js
+++ b/app/services/supplementary-billing/unflag-unbilled-licences.service.js
@@ -32,7 +32,6 @@ const LicenceModel = require('../../models/water/licence.model.js')
  */
 async function go (billingBatchId, chargeVersions) {
   const allLicenceIds = _extractUniqueLicenceIds(chargeVersions)
-  allLicenceIds.push('310f05c0-98d9-4e70-9857-71e5106e7559')
 
   return LicenceModel.query()
     .patch({ includeInSrocSupplementaryBilling: false })

--- a/test/services/supplementary-billing/unflag-unbilled-licences.service.test.js
+++ b/test/services/supplementary-billing/unflag-unbilled-licences.service.test.js
@@ -1,0 +1,83 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const BillingInvoiceHelper = require('../../support/helpers/water/billing-invoice.helper.js')
+const BillingInvoiceLicenceHelper = require('../../support/helpers/water/billing-invoice-licence.helper.js')
+const LicenceHelper = require('../../support/helpers/water/licence.helper.js')
+const LicenceModel = require('../../../app/models/water/licence.model.js')
+const DatabaseHelper = require('../../support/helpers/database.helper.js')
+
+// Thing under test
+const UnflagUnbilledLicencesService = require('../../../app/services/supplementary-billing/unflag-unbilled-licences.service.js')
+
+describe('Unflag unbilled licences service', () => {
+  const billingBatchId = '42e7a42b-8a9a-42b4-b527-2baaedf952f2'
+
+  beforeEach(async () => {
+    await DatabaseHelper.clean()
+  })
+
+  describe('when there are licences flagged for SROC supplementary billing', () => {
+    let chargeVersions
+    const licences = {
+      notInBillRun: null,
+      notBilledInBillRun: null,
+      billedInBillRun: null
+    }
+
+    beforeEach(async () => {
+      licences.notInBillRun = await LicenceHelper.add({ includeInSrocSupplementaryBilling: true })
+      licences.notBilledInBillRun = await LicenceHelper.add({ includeInSrocSupplementaryBilling: true })
+      licences.billedInBillRun = await LicenceHelper.add({ includeInSrocSupplementaryBilling: true })
+
+      chargeVersions = [
+        { licence: { licenceId: licences.notBilledInBillRun.licenceId } },
+        { licence: { licenceId: licences.billedInBillRun.licenceId } }
+      ]
+    })
+
+    describe('those licences in the current bill run', () => {
+      describe('which were not billed', () => {
+        it('are unflagged (include_in_sroc_supplementary_billing set to false)', async () => {
+          await UnflagUnbilledLicencesService.go(billingBatchId, chargeVersions)
+
+          const licenceToBeChecked = await LicenceModel.query().findById(licences.notBilledInBillRun.licenceId)
+
+          expect(licenceToBeChecked.includeInSrocSupplementaryBilling).to.be.false()
+        })
+      })
+
+      describe('which were billed', () => {
+        beforeEach(async () => {
+          const { billingInvoiceId } = await BillingInvoiceHelper.add({ billingBatchId })
+          await BillingInvoiceLicenceHelper.add({ billingInvoiceId, licenceId: licences.billedInBillRun.licenceId })
+        })
+
+        it('are left flagged (include_in_sroc_supplementary_billing still true)', async () => {
+          await UnflagUnbilledLicencesService.go(billingBatchId, chargeVersions)
+
+          const licenceToBeChecked = await LicenceModel.query().findById(licences.billedInBillRun.licenceId)
+
+          expect(licenceToBeChecked.includeInSrocSupplementaryBilling).to.be.true()
+        })
+      })
+    })
+
+    describe('those licences not in the current bill run', () => {
+      it('leaves flagged (include_in_sroc_supplementary_billing still true)', async () => {
+        await UnflagUnbilledLicencesService.go(billingBatchId, chargeVersions)
+
+        const licenceToBeChecked = await LicenceModel.query().findById(licences.notInBillRun.licenceId)
+
+        expect(licenceToBeChecked.includeInSrocSupplementaryBilling).to.be.true()
+      })
+    })
+  })
+})


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4007

> This came about dues to an issue found during UAT of SROC supplementary billing

The issue was that when the SROC bill run was sent licences that were processed in the bill run retained a 'include in SROC supplementary billing' flag. This means the licence will be processed again in the next supplementary bill run.

We've had trouble replicating the issue. So, we went back to the logic to see if that can shine any light.

***The current logic***

At the very end of the **send** process the legacy code will fire off this query

```sql
update water.licences l
  set include_in_sroc_supplementary_billing = :to
  where l.date_updated <= :batchCreatedDate
    and l.region_id = :regionId
    and l.licence_id not in (select licence_id from water.charge_version_workflows where date_deleted is null)
    and l.include_in_sroc_supplementary_billing = :from
```

This is the original query used for PRESROC which we copied and tweaked for SROC. Most folks on the team assumed we unflagged only those licences included in the bill run. But that's not the case.

The problem is a licence when processed may result in no need for a `billing_invoice` to be generated. Because of the queueing architecture in the legacy code at the point this query is run, you've lost which licences never made it into the billing_batch. This is why the legacy code has defaulted to unsetting the flag for any licence last updated prior to the billing_batch (bill run) being created.

***The problem***

Should a licence record get updated after the bill run is created, the query won't include it. We've not been able to pin down how this happens. But our primary suspect is the import process, which seems to update all licence records at approximately the same time.

***The fix***

We're updating our system repo's billing engine to unflag any licences that have been processed but didn't result in a `billing_invoice` record being created. Should the bill run get cancelled and re-generated it won't matter these are no longer flagged as the result will be the same.

With this in place, we can then update the query we're asking the legacy code to fire to be much more intelligent. It can use the `billing_invoice_licence` records linked to the bill run to identify precisely which licences were processed and part of the bill run. It won't matter when they got updated.

With both steps in place, the new SROC supplementary process will only unflag those licences processed during the bill run.