### PR TITLE
Fix comparison Section 126 factor in supp. billing

### DIFF
--- a/app/services/supplementary-billing/generate-billing-transactions.service.js
+++ b/app/services/supplementary-billing/generate-billing-transactions.service.js
@@ -147,15 +147,15 @@ function _standardTransaction (
     status: 'candidate',
     description: _description(chargeElement),
     volume: chargeElement.volume,
-    section126Factor: chargeElement.adjustments.s126 || 1,
+    section126Factor: Number(chargeElement.adjustments.s126) || 1,
     section127Agreement: !!chargeElement.adjustments.s127,
     section130Agreement: !!chargeElement.adjustments.s130,
     // NOTE: We do not currently support two part tariff bill runs. We set this to false until we implement that
     // functionality and understand what determines the flag
     isTwoPartSecondPartCharge: false,
     scheme: 'sroc',
-    aggregateFactor: chargeElement.adjustments.aggregate || 1,
-    adjustmentFactor: chargeElement.adjustments.charge || 1,
+    aggregateFactor: Number(chargeElement.adjustments.aggregate) || 1,
+    adjustmentFactor: Number(chargeElement.adjustments.charge) || 1,
     chargeCategoryCode: chargeElement.billingChargeCategory.reference,
     chargeCategoryDescription: chargeElement.billingChargeCategory.shortDescription,
     isSupportedSource: !!chargeElement.additionalCharges?.supportedSource?.name,

--- a/test/support/helpers/water/charge-element.helper.js
+++ b/test/support/helpers/water/charge-element.helper.js
@@ -62,7 +62,7 @@ function defaults (data = {}) {
     volume: 6.819,
     billingChargeCategoryId: 'cd9ca44d-2ddb-4d5d-ac62-79883176bdec',
     additionalCharges: { isSupplyPublicWater: true },
-    adjustments: { s126: null, s127: false, s130: false, charge: null, winter: false, aggregate: 0.562114443 },
+    adjustments: { s126: null, s127: false, s130: false, charge: null, winter: false, aggregate: '0.562114443' },
     eiucRegion: 'Anglian',
     abstractionPeriodStartDay: 1,
     abstractionPeriodStartMonth: 1,


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4010

We found another scenario where the bill run always added credit and debit for the charge version on each bill run.

The scenario was a new charge version was added which applied an abatement agreement (section 126 factor). The bill run gets run and sent.

Another minor change is then made. No new debit and credit are needed. But when the engine grabs the previous debit, flips it to credit and compares it against the calculated line it finds they don't match.

This results in a debit and credit for the same amount appearing each time when they should be cancelled out and not appear at all.

We tracked the problem down to the `charge_element` holding all the values as strings inside a JSONB field (`adjustments`). But when they get persisted to the `billing_transactions` table they are properly stored as a number.

This is the same issue as [Fix including unnecessary supp. billing trans.](https://github.com/DEFRA/water-abstraction-system/pull/210) only in reverse. Thanks, legacy code!

This change ensures when it comes to the comparison of `section126Factor` both previous and calculated and looking at the same data type.