### PR TITLE
Getting table names from schema

### DIFF
--- a/app/services/db-export/fetch-table-names.service.js
+++ b/app/services/db-export/fetch-table-names.service.js
@@ -12,10 +12,12 @@ const { db } = require('../../../db/db.js')
  * @param schemaName The name of the schema from which to fetch the
  * table names
  *
- * @returns {Array} An array containing the table names for the specified schema
+ * @returns {String[]} Table names for the specified schema
  */
 async function go (schemaName) {
   const tableData = await _fetchTableNames(schemaName)
+
+  // tableData has information we do not need
   const tableNames = _pluckTableNames(tableData.rows)
 
   if (tableNames.length === 0) {
@@ -25,14 +27,6 @@ async function go (schemaName) {
   return tableNames
 }
 
-/**
- * fetchTableNames is connecting the the db and querying the schema for its information
- *
- * @param {*} schemaName The name of the schema from which we want to retrieve the table names
- *
- * @returns {Array} An array of objects containing both the table names and
- * additional information that is not relevant to our needs
- */
 async function _fetchTableNames (schemaName) {
   const query = `
       SELECT table_name

--- a/app/services/db-export/fetch-table-names.service.js
+++ b/app/services/db-export/fetch-table-names.service.js
@@ -1,16 +1,16 @@
 'use strict'
 
-/** Fetches all the table names from a given schema
+/**
+ * Fetches all the table names from a given schema
  * @module FetchTableNames
  */
 
 const { db } = require('../../../db/db.js')
 
 /**
- * Retrieves the table names for a specific schema by making a database call
+ * Retrieves the table names for a specific schema
  *
- * @param schemaName The name of the schema from which to fetch the
- * table names
+ * @param schemaName The name of the schema from which to fetch the table names
  *
  * @returns {String[]} Table names for the specified schema
  */

--- a/app/services/db-export/fetch-table-names.service.js
+++ b/app/services/db-export/fetch-table-names.service.js
@@ -1,0 +1,50 @@
+'use strict'
+
+/** Fetches all the table names from a given schema
+ * @module FetchTableNames
+ */
+
+const { db } = require('../../../db/db.js')
+
+/**
+ * Retrieves the table names for a specific schema by making a database call
+ *
+ * @param schemaName The name of the schema from which to fetch the
+ * table names
+ *
+ * @returns {Array} An array containing the table names for the specified schema
+ */
+async function go (schemaName) {
+  const tableData = await _fetchTableNames(schemaName)
+
+  const tableNames = _pluckTableNames(tableData.rows)
+
+  return tableNames
+}
+
+/**
+ * fetchTableNames is connecting the the db and querying the schema for its information
+ *
+ * @param {*} schemaName The name of the schema from which we want to retrieve the table names
+ *
+ * @returns {Array} An array of objects containing both the table names and
+ * additional information that is not relevant to our needs
+ */
+async function _fetchTableNames (schemaName) {
+  const query = `
+      SELECT table_name
+      FROM information_schema.tables
+      WHERE table_schema = '${schemaName}'
+        AND table_type = 'BASE TABLE';
+    `
+
+  return await db.raw(query)
+}
+
+function _pluckTableNames (tableData) {
+  return tableData.map(obj => obj.table_name)
+}
+
+module.exports = {
+  go
+}

--- a/app/services/db-export/fetch-table-names.service.js
+++ b/app/services/db-export/fetch-table-names.service.js
@@ -16,8 +16,11 @@ const { db } = require('../../../db/db.js')
  */
 async function go (schemaName) {
   const tableData = await _fetchTableNames(schemaName)
-
   const tableNames = _pluckTableNames(tableData.rows)
+
+  if (tableNames.length === 0) {
+    throw new Error('Error: Unable to fetch table names')
+  }
 
   return tableNames
 }

--- a/test/services/db-export/fetch-table-names.service.test.js
+++ b/test/services/db-export/fetch-table-names.service.test.js
@@ -31,7 +31,9 @@ describe('Fetch table names', () => {
     it('returns a list of the schemas table names', async () => {
       const result = await FetchTableNames.go('water')
 
-      expect(result).to.equal(listOfTableNames)
+      expect(result).to.include('billing_charge_categories')
+      expect(result).to.include('charge_purposes')
+      expect(result).to.include('billing_batches')
     })
   })
 

--- a/test/services/db-export/fetch-table-names.service.test.js
+++ b/test/services/db-export/fetch-table-names.service.test.js
@@ -26,7 +26,7 @@ const listOfTableNames = [
   'billing_charge_categories'
 ]
 
-describe.only('Fetch table names', () => {
+describe('Fetch table names', () => {
   describe('when given a schema name', () => {
     it('returns a list of the schemas table names', async () => {
       const result = await FetchTableNames.go('water')
@@ -36,10 +36,11 @@ describe.only('Fetch table names', () => {
   })
 
   describe('when not given a schema name', () => {
-    it('returns an empty array', async () => {
-      const result = await FetchTableNames.go()
+    it('throws an error', async () => {
+      const result = await expect(FetchTableNames.go()).to.reject()
 
-      expect(result).to.be.empty()
+      expect(result).to.be.an.error()
+      expect(result.message).to.equal('Error: Unable to fetch table names')
     })
   })
 })

--- a/test/services/db-export/fetch-table-names.service.test.js
+++ b/test/services/db-export/fetch-table-names.service.test.js
@@ -1,0 +1,45 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Thing under test
+const FetchTableNames = require('../../../app/services/db-export/fetch-table-names.service')
+
+const listOfTableNames = [
+  'charge_versions',
+  'billing_batches',
+  'licences',
+  'charge_elements',
+  'charge_version_workflows',
+  'change_reasons',
+  'regions',
+  'billing_invoice_licences',
+  'billing_transactions',
+  'charge_purposes',
+  'billing_invoices',
+  'events',
+  'billing_charge_categories'
+]
+
+describe.only('Fetch table names', () => {
+  describe('when given a schema name', () => {
+    it('returns a list of the schemas table names', async () => {
+      const result = await FetchTableNames.go('water')
+
+      expect(result).to.equal(listOfTableNames)
+    })
+  })
+
+  describe('when not given a schema name', () => {
+    it('returns an empty array', async () => {
+      const result = await FetchTableNames.go()
+
+      expect(result).to.be.empty()
+    })
+  })
+})

--- a/test/services/db-export/fetch-table-names.service.test.js
+++ b/test/services/db-export/fetch-table-names.service.test.js
@@ -10,22 +10,6 @@ const { expect } = Code
 // Thing under test
 const FetchTableNames = require('../../../app/services/db-export/fetch-table-names.service')
 
-const listOfTableNames = [
-  'charge_versions',
-  'billing_batches',
-  'licences',
-  'charge_elements',
-  'charge_version_workflows',
-  'change_reasons',
-  'regions',
-  'billing_invoice_licences',
-  'billing_transactions',
-  'charge_purposes',
-  'billing_invoices',
-  'events',
-  'billing_charge_categories'
-]
-
 describe('Fetch table names', () => {
   describe('when given a schema name', () => {
     it('returns a list of the schemas table names', async () => {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4017

This pull request is just a small part of a larger project that involves exporting all our database schemas, converting them into CSV files, and uploading them to our Amazon S3 bucket. This PR's primary focus is to get the table names from the database using only the schema name provided. To expedite the export process and see the output sooner, we are using a vertical slicing approach, rather than a horizontal one, which means exporting a single table at a time from each schema.