### PR TITLE
Fix issue using Array.at() - Node is to old

### DIFF
--- a/app/services/supplementary-billing/new-billing-batch.service.js
+++ b/app/services/supplementary-billing/new-billing-batch.service.js
@@ -24,8 +24,8 @@ async function go (regionId, userEmail) {
 
 function _financialYearEndings (billingPeriods) {
   return {
-    fromFinancialYearEnding: billingPeriods.at(-1).endDate.getFullYear(),
-    toFinancialYearEnding: billingPeriods.at(0).endDate.getFullYear()
+    fromFinancialYearEnding: billingPeriods[billingPeriods.length - 1].endDate.getFullYear(),
+    toFinancialYearEnding: billingPeriods[0].endDate.getFullYear()
   }
 }
 

--- a/app/services/supplementary-billing/process-billing-batch.service.js
+++ b/app/services/supplementary-billing/process-billing-batch.service.js
@@ -10,7 +10,7 @@ const ProcessBillingPeriodService = require('./process-billing-period.service.js
 const UnflagUnbilledLicencesService = require('./unflag-unbilled-licences.service.js')
 
 async function go (billingBatch, billingPeriods) {
-  const currentBillingPeriod = billingPeriods.at(-1)
+  const currentBillingPeriod = billingPeriods[billingPeriods.length - 1]
   const { billingBatchId } = billingBatch
 
   try {


### PR DESCRIPTION
It was reported that SROC supplementary bill runs were not running in our `dev` environment. But we could run them locally and our CI seemed fine.

We managed to track down the issue to it not being available on the version of Node we are running in AWS. There we are running v14, locally we are running v16.

We decided to 'look ahead' so that when we do upgrade all will be fine. But clearly, this is an example of that coming to bite us in the 🍑!

So, this change reverts the use of `at()` for a more traditional approach. We'll tackle the disparity in Node versions separately.