### PR TITLE
Fix isNewLicence null violation for prev. trans.

### DIFF
--- a/app/services/supplementary-billing/fetch-previous-billing-transactions.service.js
+++ b/app/services/supplementary-billing/fetch-previous-billing-transactions.service.js
@@ -135,6 +135,7 @@ async function _fetch (licenceId, invoiceAccountId, financialYearEnding) {
       'bt.chargeCategoryDescription',
       'bt.isSupportedSource',
       'bt.supportedSourceName',
+      'bt.isNewLicence',
       'bt.isWaterCompanyCharge',
       'bt.isWinterOnly',
       'bt.purposes',


### PR DESCRIPTION
We had an issue reported that we were able to replicate locally. It looks like when we try to persist `billing_transactions` 'en masse' using Objection.js it behaves slightly differently than when inserting them in one by one.

In our latest changes, where we now wait till we have generated _all_ the transactions for a billing period before persisting them a new issue has come to light.

```
...
null value in column \"is_new_licence\" of relation \"billing_transactions\" violates not-null constraint"
...
```

After some debugging, we found that our generated transactions were ok. It was any previous transactions we had fetched and were trying to persist as credits. We weren't fetching `isNewLicence` because we were depending on it defaults to false. It seems we must now fetch the property and ensure it is in the object when trying to persist them en masse.
