### PR TITLE
Fix no credits for REPLACED charge versions

### DIFF
--- a/app/services/supplementary-billing/process-billing-period.service.js
+++ b/app/services/supplementary-billing/process-billing-period.service.js
@@ -107,11 +107,6 @@ function _buildBillingDataWithTransactions (chargeVersions, preGeneratedData, bi
   // We use reduce to build up the object as this allows us to start with an empty object and populate it with each
   // charge version.
   return chargeVersions.reduce((acc, chargeVersion) => {
-    // We only need to handle charge versions with a status of `current`
-    if (chargeVersion.status !== 'current') {
-      return acc
-    }
-
     const { billingInvoiceLicence, billingInvoice } = _retrievePreGeneratedData(
       preGeneratedData,
       chargeVersion.invoiceAccountId,
@@ -124,8 +119,12 @@ function _buildBillingDataWithTransactions (chargeVersions, preGeneratedData, bi
       acc[billingInvoiceLicenceId] = _initialBillingData(chargeVersion.licence, billingInvoice, billingInvoiceLicence)
     }
 
-    const calculatedTransactions = _generateCalculatedTransactions(billingPeriod, chargeVersion)
-    acc[billingInvoiceLicenceId].calculatedTransactions.push(...calculatedTransactions)
+    // We only need to calculate the transactions for charge versions with a status of `current` (APPROVED).
+    // We fetch the previous transactions for `superseded` (REPLACED) charge versions later in the process
+    if (chargeVersion.status === 'current') {
+      const calculatedTransactions = _generateCalculatedTransactions(billingPeriod, chargeVersion)
+      acc[billingInvoiceLicenceId].calculatedTransactions.push(...calculatedTransactions)
+    }
 
     return acc
   }, {})


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3996

We introduced an error as part of our second pass at tidying up the SROC supplementary billing code. We moved to generate all possible billing invoices and invoice licences upfront as this vastly simplified the code and meant we could fire a single query that returns many results rather than one query per invoice account ID.

What we got wrong when doing this was a check we had that looked at whether a charge version was `current` (APPROVED) or `superseded` (REPLACED). When we refactored we used it to determine whether to consider a charge version when building our billing data. It was there to decide whether to calculate transaction lines for a charge version.

The refactor meant REPLACED charge versions were being ignored which meant we were never looking back at previous transactions (which is the basis for generating credits).

This change fixes the issue and moves the check to where it should be.