### PR TITLE
SROC Supplementary flag not cleared for 'non-chargeable' licence

### DIFF
--- a/app/services/supplementary-billing/fetch-charge-versions.service.js
+++ b/app/services/supplementary-billing/fetch-charge-versions.service.js
@@ -115,6 +115,14 @@ async function _fetch (regionId, billingPeriod) {
   return uncleansedChargeVersions
 }
 
+/**
+ * Extract the `licence_id`s from the charge versions before removing charge versions that have no `invoice_account_id`
+ *
+ * When a licence is made "non-chargeable" the supplementary billing flag gets set and a charge version created that has
+ * no `invoice_account_id`. For the purpose of billing we are not interested in charge versions with no
+ * `invoice_account_id` as these will not be charged. We are however interested in the associated licences to ensure
+ * that "non-chargeable" licences have thier supplementary billing flag un-set.
+ */
 function _extractLicencesAndCleanseChargeVersions (uncleansedChargeVersions) {
   const licenceIdsForPeriod = []
   const chargeVersions = []

--- a/app/services/supplementary-billing/fetch-charge-versions.service.js
+++ b/app/services/supplementary-billing/fetch-charge-versions.service.js
@@ -121,7 +121,7 @@ async function _fetch (regionId, billingPeriod) {
  * When a licence is made "non-chargeable" the supplementary billing flag gets set and a charge version created that has
  * no `invoice_account_id`. For the purpose of billing we are not interested in charge versions with no
  * `invoice_account_id` as these will not be charged. We are however interested in the associated licences to ensure
- * that "non-chargeable" licences have thier supplementary billing flag un-set.
+ * that "non-chargeable" licences have their supplementary billing flag un-set.
  */
 function _extractLicencesAndCleanseChargeVersions (uncleansedChargeVersions) {
   const licenceIdsForPeriod = []

--- a/test/services/supplementary-billing/fetch-charge-versions.service.test.js
+++ b/test/services/supplementary-billing/fetch-charge-versions.service.test.js
@@ -244,7 +244,7 @@ describe('Fetch Charge Versions service', () => {
         testRecords = [srocDraftChargeVersion]
       })
 
-      it('returns no applicable charge versions', async () => {
+      it('returns no applicable licenceIds or charge versions', async () => {
         const result = await FetchChargeVersionsService.go(regionId, billingPeriod)
 
         expect(result.chargeVersions).to.be.empty()
@@ -269,7 +269,7 @@ describe('Fetch Charge Versions service', () => {
         testRecords = [alcsChargeVersion]
       })
 
-      it('returns no applicable charge versions', async () => {
+      it('returns no applicable licenceIds or charge versions', async () => {
         const result = await FetchChargeVersionsService.go(regionId, billingPeriod)
 
         expect(result.chargeVersions).to.be.empty()
@@ -327,7 +327,7 @@ describe('Fetch Charge Versions service', () => {
           testRecords = [srocChargeVersion]
         })
 
-        it('returns no applicable charge versions', async () => {
+        it('returns no applicable licenceIds or charge versions', async () => {
           const result = await FetchChargeVersionsService.go(regionId, billingPeriod)
 
           expect(result.chargeVersions).to.be.empty()
@@ -355,7 +355,7 @@ describe('Fetch Charge Versions service', () => {
           testRecords = [srocChargeVersion]
         })
 
-        it('returns no applicable charge versions', async () => {
+        it('returns no applicable licenceIds or charge versions', async () => {
           const result = await FetchChargeVersionsService.go(regionId, billingPeriod)
 
           expect(result.chargeVersions).to.be.empty()
@@ -381,7 +381,7 @@ describe('Fetch Charge Versions service', () => {
         testRecords = [otherRegionChargeVersion]
       })
 
-      it('returns no applicable charge versions', async () => {
+      it('returns no applicable licenceIds or charge versions', async () => {
         const result = await FetchChargeVersionsService.go(regionId, billingPeriod)
 
         expect(result.chargeVersions).to.be.empty()
@@ -407,7 +407,7 @@ describe('Fetch Charge Versions service', () => {
         testRecords = [chargeVersion]
       })
 
-      it('returns no applicable charge versions', async () => {
+      it('returns no applicable licenceIds or charge versions', async () => {
         const result = await FetchChargeVersionsService.go(regionId, billingPeriod)
 
         expect(result.chargeVersions).to.be.empty()

--- a/test/services/supplementary-billing/fetch-charge-versions.service.test.js
+++ b/test/services/supplementary-billing/fetch-charge-versions.service.test.js
@@ -113,37 +113,46 @@ describe('Fetch Charge Versions service', () => {
       it('returns the SROC charge versions that are applicable', async () => {
         const result = await FetchChargeVersionsService.go(regionId, billingPeriod)
 
-        expect(result).to.have.length(3)
-        expect(result[0].chargeVersionId).to.equal(testRecords[0].chargeVersionId)
-        expect(result[1].chargeVersionId).to.equal(testRecords[1].chargeVersionId)
-        expect(result[2].chargeVersionId).to.equal(testRecords[2].chargeVersionId)
+        expect(result.chargeVersions).to.have.length(3)
+        expect(result.chargeVersions[0].chargeVersionId).to.equal(testRecords[0].chargeVersionId)
+        expect(result.chargeVersions[1].chargeVersionId).to.equal(testRecords[1].chargeVersionId)
+        expect(result.chargeVersions[2].chargeVersionId).to.equal(testRecords[2].chargeVersionId)
+      })
+
+      it('returns the licenceIds from SROC charge versions that are applicable', async () => {
+        const result = await FetchChargeVersionsService.go(regionId, billingPeriod)
+
+        expect(result.licenceIdsForPeriod).to.have.length(3)
+        expect(result.licenceIdsForPeriod[0]).to.equal(licence.licenceId)
+        expect(result.licenceIdsForPeriod[1]).to.equal(licence.licenceId)
+        expect(result.licenceIdsForPeriod[2]).to.equal(licence.licenceId)
       })
     })
 
     it("returns both 'current' and 'superseded' SROC charge versions that are applicable", async () => {
       const result = await FetchChargeVersionsService.go(regionId, billingPeriod)
 
-      expect(result).to.have.length(3)
-      expect(result[0].chargeVersionId).to.equal(testRecords[0].chargeVersionId)
-      expect(result[1].chargeVersionId).to.equal(testRecords[1].chargeVersionId)
-      expect(result[2].chargeVersionId).to.equal(testRecords[2].chargeVersionId)
+      expect(result.chargeVersions).to.have.length(3)
+      expect(result.chargeVersions[0].chargeVersionId).to.equal(testRecords[0].chargeVersionId)
+      expect(result.chargeVersions[1].chargeVersionId).to.equal(testRecords[1].chargeVersionId)
+      expect(result.chargeVersions[2].chargeVersionId).to.equal(testRecords[2].chargeVersionId)
     })
 
     it('includes the related licence and region', async () => {
       const result = await FetchChargeVersionsService.go(regionId, billingPeriod)
 
-      expect(result[0].licence.licenceRef).to.equal(licenceDefaults.licenceRef)
-      expect(result[0].licence.isWaterUndertaker).to.equal(true)
-      expect(result[0].licence.historicalAreaCode).to.equal(licenceDefaults.regions.historicalAreaCode)
-      expect(result[0].licence.regionalChargeArea).to.equal(licenceDefaults.regions.regionalChargeArea)
-      expect(result[0].licence.region.regionId).to.equal(regionId)
-      expect(result[0].licence.region.chargeRegionId).to.equal(region.chargeRegionId)
+      expect(result.chargeVersions[0].licence.licenceRef).to.equal(licenceDefaults.licenceRef)
+      expect(result.chargeVersions[0].licence.isWaterUndertaker).to.equal(true)
+      expect(result.chargeVersions[0].licence.historicalAreaCode).to.equal(licenceDefaults.regions.historicalAreaCode)
+      expect(result.chargeVersions[0].licence.regionalChargeArea).to.equal(licenceDefaults.regions.regionalChargeArea)
+      expect(result.chargeVersions[0].licence.region.regionId).to.equal(regionId)
+      expect(result.chargeVersions[0].licence.region.chargeRegionId).to.equal(region.chargeRegionId)
     })
 
     it('includes the related change reason', async () => {
       const result = await FetchChargeVersionsService.go(regionId, billingPeriod)
 
-      expect(result[0].changeReason.triggersMinimumCharge).to.equal(changeReason.triggersMinimumCharge)
+      expect(result.chargeVersions[0].changeReason.triggersMinimumCharge).to.equal(changeReason.triggersMinimumCharge)
     })
 
     it('includes the related charge elements, billing charge category and charge purposes', async () => {
@@ -191,8 +200,8 @@ describe('Fetch Charge Versions service', () => {
         }]
       }
 
-      expect(result[0].chargeElements[0]).to.equal(expectedResult2024)
-      expect(result[1].chargeElements[0]).to.equal(expectedResult2023)
+      expect(result.chargeVersions[0].chargeElements[0]).to.equal(expectedResult2024)
+      expect(result.chargeVersions[1].chargeElements[0]).to.equal(expectedResult2023)
     })
   })
 
@@ -210,10 +219,11 @@ describe('Fetch Charge Versions service', () => {
         testRecords = [srocChargeVersion]
       })
 
-      it('returns no applicable charge versions', async () => {
+      it('returns no applicable licenceIds or charge versions', async () => {
         const result = await FetchChargeVersionsService.go(regionId, billingPeriod)
 
-        expect(result).to.be.empty()
+        expect(result.chargeVersions).to.be.empty()
+        expect(result.licenceIdsForPeriod).to.be.empty()
       })
     })
 
@@ -237,7 +247,8 @@ describe('Fetch Charge Versions service', () => {
       it('returns no applicable charge versions', async () => {
         const result = await FetchChargeVersionsService.go(regionId, billingPeriod)
 
-        expect(result).to.be.empty()
+        expect(result.chargeVersions).to.be.empty()
+        expect(result.licenceIdsForPeriod).to.be.empty()
       })
     })
 
@@ -261,31 +272,37 @@ describe('Fetch Charge Versions service', () => {
       it('returns no applicable charge versions', async () => {
         const result = await FetchChargeVersionsService.go(regionId, billingPeriod)
 
-        expect(result).to.be.empty()
+        expect(result.chargeVersions).to.be.empty()
+        expect(result.licenceIdsForPeriod).to.be.empty()
       })
     })
 
     describe('because none of them have an `invoiceAccountId`', () => {
+      let licenceId
       beforeEach(async () => {
         billingPeriod = {
           startDate: new Date('2022-04-01'),
           endDate: new Date('2023-03-31')
         }
 
-        const { licenceId } = await LicenceHelper.add({
+        const licence = await LicenceHelper.add({
           regionId,
           includeInSrocSupplementaryBilling: true
         })
+
+        licenceId = licence.licenceId
 
         // This creates a charge version with no `invoiceAccountId`
         const nullInvoiceAccountIdChargeVersion = await ChargeVersionHelper.add({ invoiceAccountId: null, licenceId })
         testRecords = [nullInvoiceAccountIdChargeVersion]
       })
 
-      it('returns no applicable charge versions', async () => {
+      it('returns the licenceId but no applicable charge versions', async () => {
         const result = await FetchChargeVersionsService.go(regionId, billingPeriod)
 
-        expect(result).to.be.empty()
+        expect(result.chargeVersions).to.be.empty()
+        expect(result.licenceIdsForPeriod).to.have.length(1)
+        expect(result.licenceIdsForPeriod[0]).to.equal(licenceId)
       })
     })
 
@@ -313,7 +330,8 @@ describe('Fetch Charge Versions service', () => {
         it('returns no applicable charge versions', async () => {
           const result = await FetchChargeVersionsService.go(regionId, billingPeriod)
 
-          expect(result).to.be.empty()
+          expect(result.chargeVersions).to.be.empty()
+          expect(result.licenceIdsForPeriod).to.be.empty()
         })
       })
 
@@ -340,7 +358,8 @@ describe('Fetch Charge Versions service', () => {
         it('returns no applicable charge versions', async () => {
           const result = await FetchChargeVersionsService.go(regionId, billingPeriod)
 
-          expect(result).to.be.empty()
+          expect(result.chargeVersions).to.be.empty()
+          expect(result.licenceIdsForPeriod).to.be.empty()
         })
       })
     })
@@ -365,7 +384,8 @@ describe('Fetch Charge Versions service', () => {
       it('returns no applicable charge versions', async () => {
         const result = await FetchChargeVersionsService.go(regionId, billingPeriod)
 
-        expect(result).to.be.empty()
+        expect(result.chargeVersions).to.be.empty()
+        expect(result.licenceIdsForPeriod).to.be.empty()
       })
     })
 
@@ -390,7 +410,8 @@ describe('Fetch Charge Versions service', () => {
       it('returns no applicable charge versions', async () => {
         const result = await FetchChargeVersionsService.go(regionId, billingPeriod)
 
-        expect(result).to.be.empty()
+        expect(result.chargeVersions).to.be.empty()
+        expect(result.licenceIdsForPeriod).to.be.empty()
       })
     })
   })

--- a/test/services/supplementary-billing/process-billing-batch.service.test.js
+++ b/test/services/supplementary-billing/process-billing-batch.service.test.js
@@ -60,7 +60,7 @@ describe('Process billing batch service', () => {
 
   describe('when the service is called', () => {
     beforeEach(() => {
-      Sinon.stub(FetchChargeVersionsService, 'go').resolves([])
+      Sinon.stub(FetchChargeVersionsService, 'go').resolves({ chargeVersions: [], licenceIdsForPeriod: [] })
       Sinon.stub(UnflagUnbilledLicencesService, 'go')
     })
 
@@ -157,7 +157,7 @@ describe('Process billing batch service', () => {
         beforeEach(() => {
           thrownError = new BillingBatchError(new Error(), BillingBatchModel.errorCodes.failedToPrepareTransactions)
 
-          Sinon.stub(FetchChargeVersionsService, 'go').resolves([])
+          Sinon.stub(FetchChargeVersionsService, 'go').resolves({ chargeVersions: [], licenceIdsForPeriod: [] })
           Sinon.stub(ProcessBillingPeriodService, 'go').rejects(thrownError)
         })
 
@@ -190,7 +190,7 @@ describe('Process billing batch service', () => {
       beforeEach(() => {
         thrownError = new Error('ERROR')
 
-        Sinon.stub(FetchChargeVersionsService, 'go').resolves([])
+        Sinon.stub(FetchChargeVersionsService, 'go').resolves({ chargeVersions: [], licenceIdsForPeriod: [] })
         Sinon.stub(ProcessBillingPeriodService, 'go').resolves(false)
         Sinon.stub(UnflagUnbilledLicencesService, 'go').rejects(thrownError)
       })

--- a/test/services/supplementary-billing/process-billing-period.service.test.js
+++ b/test/services/supplementary-billing/process-billing-period.service.test.js
@@ -94,7 +94,8 @@ describe('Process billing period service', () => {
             abstractionPeriodEndMonth: 3
           })
 
-          chargeVersions = await FetchChargeVersionsService.go(licence.regionId, billingPeriod)
+          const chargeVersionData = await FetchChargeVersionsService.go(licence.regionId, billingPeriod)
+          chargeVersions = chargeVersionData.chargeVersions
 
           const sentTransactions = [{
             billingTransactionId: '9b092372-1a26-436a-bf1f-b5eb3f9aca44',
@@ -168,7 +169,8 @@ describe('Process billing period service', () => {
               abstractionPeriodEndMonth: 5
             })
 
-            chargeVersions = await FetchChargeVersionsService.go(licence.regionId, billingPeriod)
+            const chargeVersionData = await FetchChargeVersionsService.go(licence.regionId, billingPeriod)
+            chargeVersions = chargeVersionData.chargeVersions
           })
 
           describe('and there are no previous billed transactions', () => {
@@ -227,7 +229,8 @@ describe('Process billing period service', () => {
       )
       await ChargePurposeHelper.add({ chargeElementId })
 
-      chargeVersions = await FetchChargeVersionsService.go(licence.regionId, billingPeriod)
+      const chargeVersionData = await FetchChargeVersionsService.go(licence.regionId, billingPeriod)
+      chargeVersions = chargeVersionData.chargeVersions
     })
 
     describe('because generating the calculated transactions fails', () => {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4041

It has been found in QA that when a licence has no other SROC charge versions and is made 'non-chargeable', this correctly sets the SROC supplementary billing flag on the licence. However, the problem is that when a bill run that includes this licence is created, the SROC supplementary billing flag is not un-set for it.

This issue is being caused because when a licence is made “non-chargeable” it creates a charge version without any charge elements, but also without an `invoice_account_id`.

Our `fetch-charge-versions` service only fetches charge versions which have an `invoice_account_id`. This in effect means that if a licence only has the “non-chargeable” charge version associated with it. That licence will never be looked at, since the licence ID is extracted from the results of the fetch-charge-versions service. As the licence is never included by the SROC supplementary service the flag is never un-set.

This PR fixes that issue by initially fetching the charge versions with no `invoice_account_id`, rather than filtering them out in the query as was done previously.

The `licence_id`s are then extracted from the results of this query before finally stripping out the charge versions that have no `invoice_account_id`.