### PR TITLE
Supplementary bill run doesn't credit old account correctly

### DIFF
--- a/app/services/supplementary-billing/determine-charge-period.service.js
+++ b/app/services/supplementary-billing/determine-charge-period.service.js
@@ -63,8 +63,14 @@ function go (chargeVersion, financialYearEnding) {
  * @returns {boolean} true if invalid else false
  */
 function _periodIsInvalid (chargeVersion, financialYearStartDate, financialYearEndDate) {
+  // `chargeVersionEndToCheck` added because if a licence was charged in 2024 FY but then later ended in the 2023 FY due
+  // to a Billing contact change. When the supplementary is re-run, the charge made to the original contact in 2024
+  // would not be taken into account, as the endDate on the CV would be prior to the start of the 2024 FY. So we need to
+  // take into account when the CV was last billed up to so credits can be made to the original contact if required.
+  const chargeVersionEndToCheck = chargeVersion.billedUptoDate ? chargeVersion.billedUptoDate : chargeVersion.endDate
+
   const chargeVersionStartsAfterFinancialYear = chargeVersion.startDate > financialYearEndDate
-  const chargeVersionEndsBeforeFinancialYear = chargeVersion.endDate && chargeVersion.endDate < financialYearStartDate
+  const chargeVersionEndsBeforeFinancialYear = chargeVersion.endDate && chargeVersionEndToCheck < financialYearStartDate
 
   return chargeVersionStartsAfterFinancialYear || chargeVersionEndsBeforeFinancialYear
 }

--- a/app/services/supplementary-billing/determine-charge-period.service.js
+++ b/app/services/supplementary-billing/determine-charge-period.service.js
@@ -63,14 +63,14 @@ function go (chargeVersion, financialYearEnding) {
  * @returns {boolean} true if invalid else false
  */
 function _periodIsInvalid (chargeVersion, financialYearStartDate, financialYearEndDate) {
-  // `chargeVersionEndToCheck` added because if a licence was charged in 2024 FY but then later ended in the 2023 FY due
-  // to a Billing contact change. When the supplementary is re-run, the charge made to the original contact in 2024
-  // would not be taken into account, as the endDate on the CV would be prior to the start of the 2024 FY. So we need to
-  // take into account when the CV was last billed up to so credits can be made to the original contact if required.
-  const chargeVersionEndToCheck = chargeVersion.billedUptoDate ? chargeVersion.billedUptoDate : chargeVersion.endDate
+  // `billedUptoOrEndDate` added because if a licence was charged in 2024 FY but then later ended in the 2023 FY due to
+  // a Billing contact change. When the supplementary is re-run, the charge made to the original contact in 2024 would
+  // not be taken into account, as the endDate on the CV would be prior to the start of the 2024 FY. So we need to take
+  // into account when the CV was last billed up to so credits can be made to the original contact if required.
+  const billedUptoOrEndDate = chargeVersion.billedUptoDate ? chargeVersion.billedUptoDate : chargeVersion.endDate
 
   const chargeVersionStartsAfterFinancialYear = chargeVersion.startDate > financialYearEndDate
-  const chargeVersionEndsBeforeFinancialYear = chargeVersion.endDate && chargeVersionEndToCheck < financialYearStartDate
+  const chargeVersionEndsBeforeFinancialYear = chargeVersion.endDate && billedUptoOrEndDate < financialYearStartDate
 
   return chargeVersionStartsAfterFinancialYear || chargeVersionEndsBeforeFinancialYear
 }

--- a/app/services/supplementary-billing/fetch-charge-versions.service.js
+++ b/app/services/supplementary-billing/fetch-charge-versions.service.js
@@ -32,6 +32,7 @@ async function _fetch (regionId, billingPeriod) {
       'scheme',
       'chargeVersions.startDate',
       'chargeVersions.endDate',
+      'chargeVersions.billedUptoDate',
       'invoiceAccountId',
       'status'
     ])
@@ -43,6 +44,7 @@ async function _fetch (regionId, billingPeriod) {
     .where(builder => {
       builder.whereNull('chargeVersions.endDate')
         .orWhere('chargeVersions.endDate', '>=', billingPeriod.startDate)
+        .orWhere('chargeVersions.billedUptoDate', '>=', billingPeriod.startDate)
     })
     .whereNot('chargeVersions.status', 'draft')
     .whereNotExists(


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4044

An issue was found when a Charge Version was charged in the 2024 FY but later superseded in the 2023 FY due to a Billing contact change. When the supplementary billing is re-run, the charge made to the original contact in 2024 is not being considered as the endDate of the Charge Version is before the start of the 2024 FY. This means that the Charge Version is not picked up, resulting in previous charges against the replaced invoice account being ignored rather than credited.