### PR TITLE
Fix supp. billing not crediting old accounts

### DIFF
--- a/app/services/supplementary-billing/determine-charge-period.service.js
+++ b/app/services/supplementary-billing/determine-charge-period.service.js
@@ -23,7 +23,7 @@ function go (chargeVersion, financialYearEnding) {
   const financialYearStartDate = new Date(financialYearEnding - 1, 3, 1)
   const financialYearEndDate = new Date(financialYearEnding, 2, 31)
 
-  if (_periodIsInvalid(chargeVersion, financialYearStartDate, financialYearEndDate)) {
+  if (_periodIsInvalid(chargeVersion, financialYearEndDate)) {
     throw new Error(`Charge version is outside billing period ${financialYearEnding}`)
   }
 
@@ -50,6 +50,7 @@ function go (chargeVersion, financialYearEnding) {
   }
 }
 
+// TODO: Update documentation
 /**
  * Determine if the charge version starts after or ends before the billing period
  *
@@ -57,16 +58,12 @@ function go (chargeVersion, financialYearEnding) {
  * nonsense and all possible scenarios are covered in our tests 😁
  *
  * @param {Object} chargeVersion chargeVersion being billed
- * @param {Date} financialYearStartDate billing period (financial year) start date
  * @param {Date} financialYearEndDate billing period (financial year) end date
  *
  * @returns {boolean} true if invalid else false
  */
-function _periodIsInvalid (chargeVersion, financialYearStartDate, financialYearEndDate) {
-  const chargeVersionStartsAfterFinancialYear = chargeVersion.startDate > financialYearEndDate
-  const chargeVersionEndsBeforeFinancialYear = chargeVersion.endDate && chargeVersion.endDate < financialYearStartDate
-
-  return chargeVersionStartsAfterFinancialYear || chargeVersionEndsBeforeFinancialYear
+function _periodIsInvalid (chargeVersion, financialYearEndDate) {
+  return chargeVersion.startDate > financialYearEndDate
 }
 
 module.exports = {

--- a/app/services/supplementary-billing/determine-charge-period.service.js
+++ b/app/services/supplementary-billing/determine-charge-period.service.js
@@ -50,12 +50,19 @@ function go (chargeVersion, financialYearEnding) {
   }
 }
 
-// TODO: Update documentation
 /**
- * Determine if the charge version starts after or ends before the billing period
+ * Determine if the charge version is valid for the billing period billing period
  *
- * We never expect a charge version outside the financial period but we do this just to ensure we never return
- * nonsense and all possible scenarios are covered in our tests 😁
+ * With having to support multi-year charging the only way a charge version could be invalid is when it's start date
+ * is after the billing period.
+ *
+ * Any that start before _might_ be valid. For example, assume the billing period is 2023-24
+ *
+ * - a charge version that starts on 2023-04-01 is valid
+ * - a charge version that starts on 2022-04-01 is valid (with no end date it applies to 2023-24)
+ * - a charge version that starts on 2022-04-01 and ends on 2022-06-01 is valid (the charge period will be determined
+ *   as outside the billing period. But we still need to process these charge versions in case they have any previous
+ *   transactions that need crediting)
  *
  * @param {Object} chargeVersion chargeVersion being billed
  * @param {Date} financialYearEndDate billing period (financial year) end date

--- a/app/services/supplementary-billing/fetch-charge-versions.service.js
+++ b/app/services/supplementary-billing/fetch-charge-versions.service.js
@@ -11,39 +11,46 @@ const ChargeVersion = require('../../models/water/charge-version.model.js')
 const ChargeVersionWorkflow = require('../../models/water/charge-version-workflow.model.js')
 
 /**
- * Fetch all SROC charge versions linked to licences flagged for supplementary billing that are in the period being
- * billed
+ * Fetch all SROC charge versions to be processed as part of supplementary billing
+ *
+ * To be selected for billing charge versions must
+ *
+ * - be linked to a licence flagged for supplementary billing
+ * - be linked to a licence which is linked to the selected region
+ * - have the scheme 'sroc'
+ * - have a start date before the end of the billing period
+ * - not have a status of draft
+ * - not be linked to a licence in the workflow
+ *
+ * From this initial result we extract an array of unique licence IDs and then remove any that are non-chargeable (we
+ * need to know about them in order to unset the licence's supplementary billing flag).
  *
  * @param {String} regionId UUID of the region being billed that the licences must be linked to
  * @param {Object} billingPeriod Object with a `startDate` and `endDate` property representing the period being billed
  *
- * @returns {Object[]} An array of matching charge versions
+ * @returns {Object} Contains an array of unique licence IDs and array of charge versions to be processed
  */
 async function go (regionId, billingPeriod) {
-  const uncleansedChargeVersions = await _fetch(regionId, billingPeriod)
+  const allChargeVersions = await _fetch(regionId, billingPeriod)
 
-  return _extractLicencesAndCleanseChargeVersions(uncleansedChargeVersions)
+  return _extractLicenceIdsThenRemoveNonChargeableChargeVersions(allChargeVersions)
 }
 
 async function _fetch (regionId, billingPeriod) {
-  const uncleansedChargeVersions = await ChargeVersion.query()
+  const allChargeVersions = await ChargeVersion.query()
     .select([
-      'chargeVersionId',
-      'scheme',
+      'chargeVersions.chargeVersionId',
+      'chargeVersions.scheme',
       'chargeVersions.startDate',
       'chargeVersions.endDate',
-      'invoiceAccountId',
-      'status'
+      'chargeVersions.invoiceAccountId',
+      'chargeVersions.status'
     ])
     .innerJoinRelated('licence')
-    .where('includeInSrocSupplementaryBilling', true)
-    .where('regionId', regionId)
+    .where('licences.includeInSrocSupplementaryBilling', true)
+    .where('licences.regionId', regionId)
     .where('chargeVersions.scheme', 'sroc')
     .where('chargeVersions.startDate', '<=', billingPeriod.endDate)
-    .where(builder => {
-      builder.whereNull('chargeVersions.endDate')
-        .orWhere('chargeVersions.endDate', '>=', billingPeriod.startDate)
-    })
     .whereNot('chargeVersions.status', 'draft')
     .whereNotExists(
       ChargeVersionWorkflow.query()
@@ -112,22 +119,21 @@ async function _fetch (regionId, billingPeriod) {
       ])
     })
 
-  return uncleansedChargeVersions
+  return allChargeVersions
 }
 
 /**
- * Extract the `licence_id`s from the charge versions before removing charge versions that have no `invoice_account_id`
+ * Extract the `licenceId`s from all the charge versions before removing non-chargeable charge versions
  *
  * When a licence is made "non-chargeable" the supplementary billing flag gets set and a charge version created that has
- * no `invoice_account_id`. For the purpose of billing we are not interested in charge versions with no
- * `invoice_account_id` as these will not be charged. We are however interested in the associated licences to ensure
- * that "non-chargeable" licences have their supplementary billing flag un-set.
+ * no `invoice_account_id`. For the purpose of billing we are not interested in non-chargeable charge versions. We are
+ * interested in the associated licences to ensure that their supplementary billing flag is unset.
  */
-function _extractLicencesAndCleanseChargeVersions (uncleansedChargeVersions) {
+function _extractLicenceIdsThenRemoveNonChargeableChargeVersions (allChargeVersions) {
   const licenceIdsForPeriod = []
   const chargeVersions = []
 
-  for (const chargeVersion of uncleansedChargeVersions) {
+  for (const chargeVersion of allChargeVersions) {
     licenceIdsForPeriod.push(chargeVersion.licence.licenceId)
 
     if (chargeVersion.invoiceAccountId) {

--- a/app/services/supplementary-billing/fetch-charge-versions.service.js
+++ b/app/services/supplementary-billing/fetch-charge-versions.service.js
@@ -39,16 +39,16 @@ async function go (regionId, billingPeriod) {
 async function _fetch (regionId, billingPeriod) {
   const allChargeVersions = await ChargeVersion.query()
     .select([
-      'chargeVersions.chargeVersionId',
-      'chargeVersions.scheme',
+      'chargeVersionId',
+      'scheme',
       'chargeVersions.startDate',
       'chargeVersions.endDate',
-      'chargeVersions.invoiceAccountId',
-      'chargeVersions.status'
+      'invoiceAccountId',
+      'status'
     ])
     .innerJoinRelated('licence')
-    .where('licences.includeInSrocSupplementaryBilling', true)
-    .where('licences.regionId', regionId)
+    .where('includeInSrocSupplementaryBilling', true)
+    .where('regionId', regionId)
     .where('chargeVersions.scheme', 'sroc')
     .where('chargeVersions.startDate', '<=', billingPeriod.endDate)
     .whereNot('chargeVersions.status', 'draft')


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4044

Assume the following scenario. A charge version is added to a licence starting on 1 April 2022 against invoice account **INVAC001**. The licence is flagged for supplementary billing which is run during the 2023-2024 billing period.

This will will generate 2 bills for **INVAC001**; one in 2024 and one in 2023 ([multi-year billing!](https://github.com/DEFRA/water-abstraction-system/pull/228))

Then another charge version is added starting on 1 June 2022 against invoice account **INVAC002**. Again the licence is flagged for supplementary billing which is run during the 2023-2024 billing period.

What should happen is

- 2024
  - **INVAC001** receives a whole year credit
  - **INVAC002** receives a whole year debit
- 2023
  - **INVAC001** receives a part-year credit and debit
  - **INVAC002** receives a part-year debit

So, 4 bills in total which result in a £0 bill run.

What is happening is no credit is generated for **INVAC001** in 2024. The reason is `FetchChargeVersionsService` was written to exclude charge versions which start and finish outside the billing period being processed. But that exclusion means we never check them for previous transactions, which in this scenario would result in **INVAC001's** debit being found so a credit is generated.

This change resolves the issue by removing the clause in our query which excludes charge versions that end before the billing period start date. To support this we also need to amend the `_periodIsInvalid()` in `DetermineChargePeriodService`.

> Note - removal of this clause means we might pick up charge versions that don't need to be processed at all. We did manage to implement an Objection.js query that used a [UNION](https://www.w3schools.com/sql/sql_union.asp) to prevent this. But it made `FetchChargeVersionsService` vastly more complex purely for a negligible performance bump.