### PR TITLE
Fix -billableDays 4 out of period charge versions

### DIFF
--- a/app/services/supplementary-billing/process-billing-period.service.js
+++ b/app/services/supplementary-billing/process-billing-period.service.js
@@ -192,6 +192,11 @@ function _generateCalculatedTransactions (billingPeriod, chargeVersion) {
   try {
     const financialYearEnding = billingPeriod.endDate.getFullYear()
     const chargePeriod = DetermineChargePeriodService.go(chargeVersion, financialYearEnding)
+
+    if (!chargePeriod.startDate) {
+      return []
+    }
+
     const isNewLicence = DetermineMinimumChargeService.go(chargeVersion, financialYearEnding)
     const isWaterUndertaker = chargeVersion.licence.isWaterUndertaker
 

--- a/test/services/supplementary-billing/determine-charge-period.service.test.js
+++ b/test/services/supplementary-billing/determine-charge-period.service.test.js
@@ -202,7 +202,7 @@ describe('Determine charge period service', () => {
     })
   })
 
-  describe.only('neither period overlaps', () => {
+  describe('neither period overlaps', () => {
     describe('because the charge version start date is after the financial period', () => {
       beforeEach(() => {
         chargeVersion = {

--- a/test/services/supplementary-billing/determine-charge-period.service.test.js
+++ b/test/services/supplementary-billing/determine-charge-period.service.test.js
@@ -202,7 +202,7 @@ describe('Determine charge period service', () => {
     })
   })
 
-  describe('neither period overlaps', () => {
+  describe.only('neither period overlaps', () => {
     describe('because the charge version start date is after the financial period', () => {
       beforeEach(() => {
         chargeVersion = {
@@ -211,8 +211,11 @@ describe('Determine charge period service', () => {
         }
       })
 
-      it('throws an error', () => {
-        expect(() => DetermineChargePeriodService.go(chargeVersion, financialYear.yearEnding)).to.throw()
+      it('returns null values for the dates', () => {
+        const result = DetermineChargePeriodService.go(chargeVersion, financialYear.yearEnding)
+
+        expect(result.startDate).to.be.null()
+        expect(result.endDate).to.be.null()
       })
     })
 
@@ -220,12 +223,16 @@ describe('Determine charge period service', () => {
       beforeEach(() => {
         chargeVersion = {
           startDate: new Date('2021-05-01'),
-          endDate: new Date('2021-05-31')
+          endDate: new Date('2021-05-31'),
+          licence: { startDate: new Date('2018-01-01') }
         }
       })
 
-      it('throws an error', () => {
-        expect(() => DetermineChargePeriodService.go(chargeVersion, financialYear.yearEnding)).to.throw()
+      it('returns null values for the dates', () => {
+        const result = DetermineChargePeriodService.go(chargeVersion, financialYear.yearEnding)
+
+        expect(result.startDate).to.be.null()
+        expect(result.endDate).to.be.null()
       })
     })
   })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4044

In [Fix supp. billing not crediting old accounts](https://github.com/DEFRA/water-abstraction-system/pull/280) as sought to resolve a problem in multi-year billing that saw debits raised in a period not being credited.

Imagine a charge version that starts 2022-04-01 with no end date. The first bill run would generate a debit for both 2023-24 and 2022-23. Should we add a new charge version that starts 2022-06-01 the service will automatically add an end date to the first one (2022-05-31).

Our engine on the second run, when fetching the charge versions for 2023-24 would now skip the first charge version because it's outside the billing period. But by skipping it we overlook checking for any previous transactions to credit, which we need to do in this case.

We fixed it by simply removing the end date clause in `FetchChargeVersionsService`. Now to be included a charge version just needs to start before the billing period end date (2024-03-31).

We got lucky when we ran the fix against the scenario that identified this problem. A lot of complexity comes from working out just when a charge version is 'chargeable' and whether their abstraction period overlaps this. In the original scenario, all things aligned to calculate zero billable days.

Further testing by our QA found a scenario where the bill run always errored. Essentially, we were calculating negative billable days and trying to send it to the charging module API, which was rejecting it.

As part of the original fix, we'd removed a check in our `DetermineChargePeriodService` that said the charge version's end date couldn't be before the billing period's start date. We had to as we were now fetching charge versions where this was the case.

In the new scenario, there was a charge version for 2022-09-07 to 2022-11-30 which when processed in 2023-204 was determining a charge period of

- **start date** 2023-04-01
- **end date** 2022-11-30

End date before the start date was causing a problem further down the process hence us trying to send a negative billable days value to the charging module.

This change puts back the check we removed in `DetermineChargePeriodService`, and now use it to tell us if the charge version and billing period are incompatible. And if they are, instead of throwing an error we return a result that says, “Don't bother calculating this one”.

We skip unnecessary processing and avoid trying to send an invalid transaction to the Charging Module API.