### PR TITLE
Fix tear-down service

### DIFF
--- a/app/services/data/tear-down/water-schema.service.js
+++ b/app/services/data/tear-down/water-schema.service.js
@@ -69,9 +69,12 @@ async function _deleteBilling () {
     .whereIn('billingBatchId', billingBatchIds)
     .del()
 
+  // Just deleting the `biilingBatches` based on the `billingBatchIds` does not always remove all test records so the
+  // Test Region is used to identify the records for deletion
   await db
-    .from('water.billingBatches')
-    .whereIn('billingBatchId', billingBatchIds)
+    .from('water.billingBatches as bb')
+    .innerJoin('water.regions as r', 'bb.regionId', 'r.regionId')
+    .where('r.isTest', true)
     .del()
 }
 


### PR DESCRIPTION
The creation of a new Cypress acceptance test in https://github.com/DEFRA/water-abstraction-acceptance-tests/pull/59 has uncovered an issue in the current tear-down service which is causing it to fail with the following error: `ERROR (429): delete from "water"."regions" where "is_test" = $1 - update or delete on table "regions" violates foreign key constraint "billing_batches_region_id_fkey" on table "billing_batches"`.

This PR will resolve this issue by making sure the appropriate record is removed from `billing_batches` table which is causing this foreign key constraint violation.