### PR TITLE
Fix licence ends before billing period

### DIFF
--- a/app/services/supplementary-billing/determine-charge-period.service.js
+++ b/app/services/supplementary-billing/determine-charge-period.service.js
@@ -8,8 +8,8 @@
 /**
  * Returns a charge period, which is an object comprising `startDate` and `endDate`
  *
- * The charge period is determined as the overlap between the charge version and licence's, and the billing period. So,
- * to determine the charge period we look for
+ * The charge period is determined as the overlap between the charge version and licence's start and end dates, and the
+ * billing period. So, to determine the charge period we look for
  *
  * - the latest start date amongst the charge version, licence and billing period
  * - the earliest end date amongst the charge version, licence and billing period
@@ -27,8 +27,8 @@
  * This is to cover scenarios where a charge version with a start date in 2022-23 would have resulted in a debit in both
  * 2022-23 and 2023-24. Then a new charge version is added that starts in 2022-23. The old one is still valid, but the
  * 2023-24 debit for it needs to be credited. We only know to do that by fetching it when running the
- * `ProcessBillingPeriodService` for 2023-24 so `ProcessBillingTransactionsService` will fetch the previous
- * transactions for it.
+ * `ProcessBillingPeriodService` for 2023-24 so `ProcessBillingTransactionsService` will fetch the previous transactions
+ * for it.
  *
  * Add to that licences that end before the charge version or billing period and you get scenarios where the start and
  * end date are incompatible

--- a/app/services/supplementary-billing/determine-charge-period.service.js
+++ b/app/services/supplementary-billing/determine-charge-period.service.js
@@ -54,18 +54,18 @@
  * @returns {Object} The start and end date of the calculated charge period
  */
 function go (chargeVersion, financialYearEnding) {
-  const financialYearStartDate = new Date(financialYearEnding - 1, 3, 1)
-  const financialYearEndDate = new Date(financialYearEnding, 2, 31)
+  const billingPeriodStartDate = new Date(financialYearEnding - 1, 3, 1)
+  const billingPeriodEndDate = new Date(financialYearEnding, 2, 31)
 
   const latestStartDateTimestamp = Math.max(
-    financialYearStartDate,
+    billingPeriodStartDate,
     chargeVersion.startDate,
     chargeVersion.licence.startDate
   )
 
   // We use .filter() to remove any null timestamps, as Math.min() assumes a value of `0` for these
   const endDateTimestamps = [
-    financialYearEndDate,
+    billingPeriodEndDate,
     chargeVersion.endDate,
     chargeVersion.licence.expiredDate,
     chargeVersion.licence.lapsedDate,
@@ -77,7 +77,7 @@ function go (chargeVersion, financialYearEnding) {
   const startDate = new Date(latestStartDateTimestamp)
   const endDate = new Date(earliestEndDateTimestamp)
 
-  if (_periodIsIncompatible(startDate, endDate, financialYearStartDate, financialYearEndDate)) {
+  if (_periodIsIncompatible(startDate, endDate, billingPeriodStartDate, billingPeriodEndDate)) {
     return {
       startDate: null,
       endDate: null
@@ -90,11 +90,11 @@ function go (chargeVersion, financialYearEnding) {
   }
 }
 
-function _periodIsIncompatible (startDate, endDate, financialYearStartDate, financialYearEndDate) {
-  const startsAfterFinancialYear = startDate > financialYearEndDate
-  const endsBeforeFinancialYear = endDate < financialYearStartDate
+function _periodIsIncompatible (startDate, endDate, billingPeriodStartDate, billingPeriodEndDate) {
+  const startsAfterBillingPeriod = startDate > billingPeriodEndDate
+  const endsBeforeBillingPeriod = endDate < billingPeriodStartDate
 
-  return startsAfterFinancialYear || endsBeforeFinancialYear
+  return startsAfterBillingPeriod || endsBeforeBillingPeriod
 }
 
 module.exports = {

--- a/app/services/supplementary-billing/determine-charge-period.service.js
+++ b/app/services/supplementary-billing/determine-charge-period.service.js
@@ -23,13 +23,6 @@ function go (chargeVersion, financialYearEnding) {
   const financialYearStartDate = new Date(financialYearEnding - 1, 3, 1)
   const financialYearEndDate = new Date(financialYearEnding, 2, 31)
 
-  if (_periodIsIncompatible(chargeVersion, financialYearStartDate, financialYearEndDate)) {
-    return {
-      startDate: null,
-      endDate: null
-    }
-  }
-
   const latestStartDateTimestamp = Math.max(
     financialYearStartDate,
     chargeVersion.startDate,
@@ -47,9 +40,19 @@ function go (chargeVersion, financialYearEnding) {
 
   const earliestEndDateTimestamp = Math.min(...endDateTimestamps)
 
+  const startDate = new Date(latestStartDateTimestamp)
+  const endDate = new Date(earliestEndDateTimestamp)
+
+  if (_periodIsIncompatible(startDate, endDate, financialYearStartDate, financialYearEndDate)) {
+    return {
+      startDate: null,
+      endDate: null
+    }
+  }
+
   return {
-    startDate: new Date(latestStartDateTimestamp),
-    endDate: new Date(earliestEndDateTimestamp)
+    startDate,
+    endDate
   }
 }
 
@@ -89,11 +92,11 @@ function go (chargeVersion, financialYearEnding) {
  *
  * @returns {boolean} true if invalid else false
  */
-function _periodIsIncompatible (chargeVersion, financialYearStartDate, financialYearEndDate) {
-  const chargeVersionStartsAfterFinancialYear = chargeVersion.startDate > financialYearEndDate
-  const chargeVersionEndsBeforeFinancialYear = chargeVersion.endDate && (chargeVersion.endDate < financialYearStartDate)
+function _periodIsIncompatible (startDate, endDate, financialYearStartDate, financialYearEndDate) {
+  const startsAfterFinancialYear = startDate > financialYearEndDate
+  const endsBeforeFinancialYear = endDate < financialYearStartDate
 
-  return chargeVersionStartsAfterFinancialYear || chargeVersionEndsBeforeFinancialYear
+  return startsAfterFinancialYear || endsBeforeFinancialYear
 }
 
 module.exports = {

--- a/app/services/supplementary-billing/determine-charge-period.service.js
+++ b/app/services/supplementary-billing/determine-charge-period.service.js
@@ -45,6 +45,12 @@
  * - end dates: charge version not set, Licence 2023-01-11, Billing period 2024-03-31
  * - result: **incompatible!** start date 2023-04-01 to end date 2023-01-11
  *
+ * ### An expired licence
+ *
+ * - start dates: charge version 2023-10-01, Licence 2017-10-14, Billing period 2023-04-01
+ * - end dates: charge version not set, Licence 2023-08-11, Billing period 2024-03-31
+ * - result: **incompatible!** start date 2023-10-01 to end date 2023-08-01
+ *
  * When this happens we return an Object with `null` start and end dates. Calling services then know there is no valid
  * charge period and to avoid trying to calculate any billable days.
  *
@@ -90,8 +96,9 @@ function go (chargeVersion, billingPeriod) {
 function _periodIsIncompatible (startDate, endDate, billingPeriod) {
   const startsAfterBillingPeriod = startDate > billingPeriod.endDate
   const endsBeforeBillingPeriod = endDate < billingPeriod.startDate
+  const startsAfterItEnds = startDate > endDate
 
-  return startsAfterBillingPeriod || endsBeforeBillingPeriod
+  return startsAfterBillingPeriod || endsBeforeBillingPeriod || startsAfterItEnds
 }
 
 module.exports = {

--- a/app/services/supplementary-billing/determine-charge-period.service.js
+++ b/app/services/supplementary-billing/determine-charge-period.service.js
@@ -77,26 +77,25 @@ function go (chargeVersion, billingPeriod) {
 
   const earliestEndDateTimestamp = Math.min(...endDateTimestamps)
 
-  const startDate = new Date(latestStartDateTimestamp)
-  const endDate = new Date(earliestEndDateTimestamp)
+  const chargePeriod = {
+    startDate: new Date(latestStartDateTimestamp),
+    endDate: new Date(earliestEndDateTimestamp)
+  }
 
-  if (_periodIsIncompatible(startDate, endDate, billingPeriod)) {
+  if (_periodIsIncompatible(chargePeriod, billingPeriod)) {
     return {
       startDate: null,
       endDate: null
     }
   }
 
-  return {
-    startDate,
-    endDate
-  }
+  return chargePeriod
 }
 
-function _periodIsIncompatible (startDate, endDate, billingPeriod) {
-  const startsAfterBillingPeriod = startDate > billingPeriod.endDate
-  const endsBeforeBillingPeriod = endDate < billingPeriod.startDate
-  const startsAfterItEnds = startDate > endDate
+function _periodIsIncompatible (chargePeriod, billingPeriod) {
+  const startsAfterBillingPeriod = chargePeriod.startDate > billingPeriod.endDate
+  const endsBeforeBillingPeriod = chargePeriod.endDate < billingPeriod.startDate
+  const startsAfterItEnds = chargePeriod.startDate > chargePeriod.endDate
 
   return startsAfterBillingPeriod || endsBeforeBillingPeriod || startsAfterItEnds
 }

--- a/app/services/supplementary-billing/determine-minimum-charge.service.js
+++ b/app/services/supplementary-billing/determine-minimum-charge.service.js
@@ -5,8 +5,6 @@
  * @module DetermineMinimumChargeService
  */
 
-const DetermineChargePeriodService = require('./determine-charge-period.service.js')
-
 /**
  * Checks if minimum charge applies to a charge version for the given billing period
  *
@@ -16,12 +14,11 @@ const DetermineChargePeriodService = require('./determine-charge-period.service.
  * If either of those tests is false then the service will return false.
  *
  * @param {module:ChargeVersionModel} chargeVersion The charge version being checked for minimum charge
- * @param {Number} financialYearEnding The year the financial billing period ends
+ * @param {Object} chargePeriod Object with a `startDate` and `endDate` property representing the chargeable period
  *
  * @returns {Boolean} true if minimum charge applies else false
  */
-function go (chargeVersion, financialYearEnding) {
-  const chargePeriod = DetermineChargePeriodService.go(chargeVersion, financialYearEnding)
+function go (chargeVersion, chargePeriod) {
   const chargePeriodStartTimestamp = chargePeriod.startDate.getTime()
   const chargeVersionStartTimestamp = chargeVersion.startDate.getTime()
 

--- a/app/services/supplementary-billing/process-billing-period.service.js
+++ b/app/services/supplementary-billing/process-billing-period.service.js
@@ -190,14 +190,13 @@ async function _cleanseTransactions (currentBillingData, billingPeriod) {
 
 function _generateCalculatedTransactions (billingPeriod, chargeVersion) {
   try {
-    const financialYearEnding = billingPeriod.endDate.getFullYear()
     const chargePeriod = DetermineChargePeriodService.go(chargeVersion, billingPeriod)
 
     if (!chargePeriod.startDate) {
       return []
     }
 
-    const isNewLicence = DetermineMinimumChargeService.go(chargeVersion, financialYearEnding)
+    const isNewLicence = DetermineMinimumChargeService.go(chargeVersion, chargePeriod)
     const isWaterUndertaker = chargeVersion.licence.isWaterUndertaker
 
     // We use flatMap as GenerateBillingTransactionsService returns an array of transactions

--- a/app/services/supplementary-billing/process-billing-period.service.js
+++ b/app/services/supplementary-billing/process-billing-period.service.js
@@ -191,7 +191,7 @@ async function _cleanseTransactions (currentBillingData, billingPeriod) {
 function _generateCalculatedTransactions (billingPeriod, chargeVersion) {
   try {
     const financialYearEnding = billingPeriod.endDate.getFullYear()
-    const chargePeriod = DetermineChargePeriodService.go(chargeVersion, financialYearEnding)
+    const chargePeriod = DetermineChargePeriodService.go(chargeVersion, billingPeriod)
 
     if (!chargePeriod.startDate) {
       return []

--- a/test/services/supplementary-billing/determine-charge-period.service.test.js
+++ b/test/services/supplementary-billing/determine-charge-period.service.test.js
@@ -261,7 +261,6 @@ describe('Determine charge period service', () => {
 
         it('returns null values for the dates', () => {
           const result = DetermineChargePeriodService.go(chargeVersion, billingPeriod)
-          console.log('🚀 ~ file: determine-charge-period.service.test.js:264 ~ it ~ result:', result)
 
           expect(result.startDate).to.be.null()
           expect(result.endDate).to.be.null()

--- a/test/services/supplementary-billing/determine-charge-period.service.test.js
+++ b/test/services/supplementary-billing/determine-charge-period.service.test.js
@@ -17,85 +17,17 @@ describe('Determine charge period service', () => {
   }
   let chargeVersion
 
-  describe('charge version starts inside the billing period', () => {
-    beforeEach(() => {
-      chargeVersion = {
-        startDate: new Date('2023-05-01'),
-        endDate: null,
-        licence: { startDate: new Date('2023-01-01') }
-      }
-    })
-
-    describe('and the charge version has an end date', () => {
+  describe('the charge version starts before the billing period', () => {
+    describe('and has an end date that is inside the billing period', () => {
       beforeEach(() => {
-        chargeVersion.endDate = new Date('2023-05-31')
+        chargeVersion = {
+          startDate: new Date('2022-04-01'),
+          endDate: new Date('2023-05-31'),
+          licence: { startDate: new Date('2017-01-01') }
+        }
       })
 
-      it('returns the charge version start and end dates', () => {
-        const result = DetermineChargePeriodService.go(chargeVersion, billingPeriod)
-
-        expect(result.startDate).to.equal(chargeVersion.startDate)
-        expect(result.endDate).to.equal(chargeVersion.endDate)
-      })
-    })
-
-    describe('and the charge version does not have an end date', () => {
-      it('returns the charge version start date and billing period end date', () => {
-        const result = DetermineChargePeriodService.go(chargeVersion, billingPeriod)
-
-        expect(result.startDate).to.equal(chargeVersion.startDate)
-        expect(result.endDate).to.equal(billingPeriod.endDate)
-      })
-    })
-  })
-
-  describe('billing period starts inside the charge version', () => {
-    beforeEach(() => {
-      chargeVersion = {
-        startDate: new Date('2023-02-01'),
-        endDate: null,
-        licence: { startDate: new Date('2023-01-01') }
-      }
-    })
-
-    describe('and the charge version has an end date', () => {
-      beforeEach(() => {
-        chargeVersion.endDate = new Date('2024-05-31')
-      })
-
-      it('returns the billing period start and end dates', () => {
-        const result = DetermineChargePeriodService.go(chargeVersion, billingPeriod)
-
-        expect(result.startDate).to.equal(billingPeriod.startDate)
-        expect(result.endDate).to.equal(billingPeriod.endDate)
-      })
-    })
-
-    describe('and the charge version does not have an end date', () => {
-      it('returns the billing period start and end dates', () => {
-        const result = DetermineChargePeriodService.go(chargeVersion, billingPeriod)
-
-        expect(result.startDate).to.equal(billingPeriod.startDate)
-        expect(result.endDate).to.equal(billingPeriod.endDate)
-      })
-    })
-  })
-
-  describe('charge version starts before the billing period', () => {
-    beforeEach(() => {
-      chargeVersion = {
-        startDate: new Date('2023-02-01'),
-        endDate: null
-      }
-    })
-
-    describe('and the charge version has an end date that is inside the billing period', () => {
-      beforeEach(() => {
-        chargeVersion.licence = { startDate: new Date('2023-01-01') }
-        chargeVersion.endDate = new Date('2023-05-31')
-      })
-
-      it('returns the billing period start and charge version end date', () => {
+      it('returns the billing period start and charge version end dates', () => {
         const result = DetermineChargePeriodService.go(chargeVersion, billingPeriod)
 
         expect(result.startDate).to.equal(billingPeriod.startDate)
@@ -103,9 +35,13 @@ describe('Determine charge period service', () => {
       })
     })
 
-    describe('and the charge version does not have an end date', () => {
+    describe('and does not have an end date', () => {
       beforeEach(() => {
-        chargeVersion.licence = { startDate: new Date('2023-01-01') }
+        chargeVersion = {
+          startDate: new Date('2022-04-01'),
+          endDate: null,
+          licence: { startDate: new Date('2017-01-01') }
+        }
       })
 
       it('returns the billing period start and end dates', () => {
@@ -116,12 +52,33 @@ describe('Determine charge period service', () => {
       })
     })
 
-    describe('and the licence start date is after the charge versions and inside the billing period', () => {
+    describe('and has an end date that is after the billing period', () => {
       beforeEach(() => {
-        chargeVersion.licence = { startDate: new Date('2023-08-31') }
+        chargeVersion = {
+          startDate: new Date('2022-04-01'),
+          endDate: new Date('2024-05-31'),
+          licence: { startDate: new Date('2017-01-01') }
+        }
       })
 
-      it('returns the licence start and billing period end date', () => {
+      it('returns the billing period start and end dates', () => {
+        const result = DetermineChargePeriodService.go(chargeVersion, billingPeriod)
+
+        expect(result.startDate).to.equal(billingPeriod.startDate)
+        expect(result.endDate).to.equal(billingPeriod.endDate)
+      })
+    })
+
+    describe("and the licence start date is after the charge version's and inside the billing period", () => {
+      beforeEach(() => {
+        chargeVersion = {
+          startDate: new Date('2023-03-01'),
+          endDate: null,
+          licence: { startDate: new Date('2023-05-01') }
+        }
+      })
+
+      it('returns the licence start and billing period end dates', () => {
         const result = DetermineChargePeriodService.go(chargeVersion, billingPeriod)
 
         expect(result.startDate).to.equal(chargeVersion.licence.startDate)
@@ -132,7 +89,11 @@ describe('Determine charge period service', () => {
     describe('and the licence revoked date', () => {
       describe('is inside the billing period', () => {
         beforeEach(() => {
-          chargeVersion.licence = { startDate: new Date('2023-01-01'), revokedDate: new Date('2023-08-01') }
+          chargeVersion = {
+            startDate: new Date('2022-04-01'),
+            endDate: null,
+            licence: { startDate: new Date('2023-01-01'), revokedDate: new Date('2023-08-01') }
+          }
         })
 
         it('returns the billing period start and licence revoked end date', () => {
@@ -145,7 +106,11 @@ describe('Determine charge period service', () => {
 
       describe('is before the billing period', () => {
         beforeEach(() => {
-          chargeVersion.licence = { startDate: new Date('2023-01-01'), revokedDate: new Date('2023-02-01') }
+          chargeVersion = {
+            startDate: new Date('2022-04-01'),
+            endDate: null,
+            licence: { startDate: new Date('2023-01-01'), revokedDate: new Date('2023-02-01') }
+          }
         })
 
         it('returns null values for the dates', () => {
@@ -160,7 +125,11 @@ describe('Determine charge period service', () => {
     describe('and the licence lapsed date', () => {
       describe('is inside the billing period', () => {
         beforeEach(() => {
-          chargeVersion.licence = { startDate: new Date('2023-01-01'), lapsedDate: new Date('2023-08-31') }
+          chargeVersion = {
+            startDate: new Date('2022-04-01'),
+            endDate: null,
+            licence: { startDate: new Date('2023-01-01'), lapsedDate: new Date('2023-08-01') }
+          }
         })
 
         it('returns the billing period start and licence lapsed end date', () => {
@@ -173,7 +142,11 @@ describe('Determine charge period service', () => {
 
       describe('is before the billing period', () => {
         beforeEach(() => {
-          chargeVersion.licence = { startDate: new Date('2023-01-01'), lapsedDate: new Date('2023-02-31') }
+          chargeVersion = {
+            startDate: new Date('2022-04-01'),
+            endDate: null,
+            licence: { startDate: new Date('2023-01-01'), lapsedDate: new Date('2023-02-01') }
+          }
         })
 
         it('returns null values for the dates', () => {
@@ -188,7 +161,11 @@ describe('Determine charge period service', () => {
     describe('and the licence expired date', () => {
       describe('is inside the billing period', () => {
         beforeEach(() => {
-          chargeVersion.licence = { startDate: new Date('2023-01-01'), expiredDate: new Date('2023-07-01') }
+          chargeVersion = {
+            startDate: new Date('2022-04-01'),
+            endDate: null,
+            licence: { startDate: new Date('2023-01-01'), expiredDate: new Date('2023-08-01') }
+          }
         })
 
         it('returns the billing period start and licence expired end date', () => {
@@ -201,7 +178,11 @@ describe('Determine charge period service', () => {
 
       describe('is before the billing period', () => {
         beforeEach(() => {
-          chargeVersion.licence = { startDate: new Date('2023-01-01'), lapsedDate: new Date('2023-02-31') }
+          chargeVersion = {
+            startDate: new Date('2022-04-01'),
+            endDate: null,
+            licence: { startDate: new Date('2023-01-01'), lapsedDate: new Date('2023-02-01') }
+          }
         })
 
         it('returns null values for the dates', () => {
@@ -214,30 +195,53 @@ describe('Determine charge period service', () => {
     })
   })
 
-  describe('billing period starts before the charge version', () => {
-    beforeEach(() => {
-      chargeVersion = {
-        startDate: new Date('2023-05-01'),
-        endDate: null,
-        licence: { startDate: new Date('2023-01-01') }
-      }
+  describe('the charge version starts inside the billing period', () => {
+    describe('and has an end date', () => {
+      describe('that is inside the billing period', () => {
+        beforeEach(() => {
+          chargeVersion = {
+            startDate: new Date('2023-05-01'),
+            endDate: new Date('2023-05-31'),
+            licence: { startDate: new Date('2023-01-01') }
+          }
+        })
+
+        it('returns the charge version start and end dates', () => {
+          const result = DetermineChargePeriodService.go(chargeVersion, billingPeriod)
+
+          expect(result.startDate).to.equal(chargeVersion.startDate)
+          expect(result.endDate).to.equal(chargeVersion.endDate)
+        })
+      })
+
+      describe('that is after the billing period', () => {
+        beforeEach(() => {
+          chargeVersion = {
+            startDate: new Date('2023-05-01'),
+            endDate: new Date('2024-05-31'),
+            licence: { startDate: new Date('2023-01-01') }
+          }
+        })
+
+        it('returns the charge version start and billing period end dates', () => {
+          const result = DetermineChargePeriodService.go(chargeVersion, billingPeriod)
+
+          expect(result.startDate).to.equal(chargeVersion.startDate)
+          expect(result.endDate).to.equal(billingPeriod.endDate)
+        })
+      })
     })
 
-    describe('and the charge version has an end date that is outside the billing period', () => {
+    describe('and does not have an end date', () => {
       beforeEach(() => {
-        chargeVersion.endDate = new Date('2024-05-31')
+        chargeVersion = {
+          startDate: new Date('2023-05-01'),
+          endDate: null,
+          licence: { startDate: new Date('2023-01-01') }
+        }
       })
 
-      it('returns the charge version start date and billing period end date', () => {
-        const result = DetermineChargePeriodService.go(chargeVersion, billingPeriod)
-
-        expect(result.startDate).to.equal(chargeVersion.startDate)
-        expect(result.endDate).to.equal(billingPeriod.endDate)
-      })
-    })
-
-    describe('and the charge version does not have an end date', () => {
-      it('returns the charge version start date and billing period end date', () => {
+      it('returns the charge version start and billing period end dates', () => {
         const result = DetermineChargePeriodService.go(chargeVersion, billingPeriod)
 
         expect(result.startDate).to.equal(chargeVersion.startDate)
@@ -246,39 +250,20 @@ describe('Determine charge period service', () => {
     })
   })
 
-  describe('neither period overlaps', () => {
-    describe('because the charge version start date is after the billing period', () => {
-      beforeEach(() => {
-        chargeVersion = {
-          startDate: new Date('2024-05-01'),
-          endDate: null,
-          licence: { startDate: new Date('2018-01-01') }
-        }
-      })
-
-      it('returns null values for the dates', () => {
-        const result = DetermineChargePeriodService.go(chargeVersion, billingPeriod)
-
-        expect(result.startDate).to.be.null()
-        expect(result.endDate).to.be.null()
-      })
+  describe('the charge version starts after the billing period', () => {
+    beforeEach(() => {
+      chargeVersion = {
+        startDate: new Date('2024-05-01'),
+        endDate: null,
+        licence: { startDate: new Date('2018-01-01') }
+      }
     })
 
-    describe('because the charge version end date is before the billing period', () => {
-      beforeEach(() => {
-        chargeVersion = {
-          startDate: new Date('2022-05-01'),
-          endDate: new Date('2022-05-31'),
-          licence: { startDate: new Date('2018-01-01') }
-        }
-      })
+    it('returns null values for the dates', () => {
+      const result = DetermineChargePeriodService.go(chargeVersion, billingPeriod)
 
-      it('returns null values for the dates', () => {
-        const result = DetermineChargePeriodService.go(chargeVersion, billingPeriod)
-
-        expect(result.startDate).to.be.null()
-        expect(result.endDate).to.be.null()
-      })
+      expect(result.startDate).to.be.null()
+      expect(result.endDate).to.be.null()
     })
   })
 })

--- a/test/services/supplementary-billing/determine-charge-period.service.test.js
+++ b/test/services/supplementary-billing/determine-charge-period.service.test.js
@@ -12,24 +12,24 @@ const DetermineChargePeriodService = require('../../../app/services/supplementar
 
 describe('Determine charge period service', () => {
   const financialYear = {
-    startDate: new Date('2022-04-01'),
-    endDate: new Date('2023-03-31'),
-    yearEnding: 2023
+    startDate: new Date('2023-04-01'),
+    endDate: new Date('2024-03-31'),
+    yearEnding: 2024
   }
   let chargeVersion
 
   describe('charge version starts inside the financial period', () => {
     beforeEach(() => {
       chargeVersion = {
-        startDate: new Date('2022-05-01'),
+        startDate: new Date('2023-05-01'),
         endDate: null,
-        licence: { startDate: new Date('2022-01-01') }
+        licence: { startDate: new Date('2023-01-01') }
       }
     })
 
     describe('and the charge version has an end date', () => {
       beforeEach(() => {
-        chargeVersion.endDate = new Date('2022-05-31')
+        chargeVersion.endDate = new Date('2023-05-31')
       })
 
       it('returns the charge version start and end dates', () => {
@@ -53,15 +53,15 @@ describe('Determine charge period service', () => {
   describe('financial period starts inside the charge version', () => {
     beforeEach(() => {
       chargeVersion = {
-        startDate: new Date('2022-02-01'),
+        startDate: new Date('2023-02-01'),
         endDate: null,
-        licence: { startDate: new Date('2022-01-01') }
+        licence: { startDate: new Date('2023-01-01') }
       }
     })
 
     describe('and the charge version has an end date', () => {
       beforeEach(() => {
-        chargeVersion.endDate = new Date('2023-05-31')
+        chargeVersion.endDate = new Date('2024-05-31')
       })
 
       it('returns the financial start and end dates', () => {
@@ -85,15 +85,15 @@ describe('Determine charge period service', () => {
   describe('charge version starts before the financial period', () => {
     beforeEach(() => {
       chargeVersion = {
-        startDate: new Date('2022-02-01'),
+        startDate: new Date('2023-02-01'),
         endDate: null
       }
     })
 
     describe('and the charge version has an end date that is inside the financial period', () => {
       beforeEach(() => {
-        chargeVersion.licence = { startDate: new Date('2022-01-01') }
-        chargeVersion.endDate = new Date('2022-05-31')
+        chargeVersion.licence = { startDate: new Date('2023-01-01') }
+        chargeVersion.endDate = new Date('2023-05-31')
       })
 
       it('returns the financial start and charge version end date', () => {
@@ -106,7 +106,7 @@ describe('Determine charge period service', () => {
 
     describe('and the charge version does not have an end date', () => {
       beforeEach(() => {
-        chargeVersion.licence = { startDate: new Date('2022-01-01') }
+        chargeVersion.licence = { startDate: new Date('2023-01-01') }
       })
 
       it('returns the financial start and end dates', () => {
@@ -119,7 +119,7 @@ describe('Determine charge period service', () => {
 
     describe('and the licence start date is after the charge versions and inside the financial period', () => {
       beforeEach(() => {
-        chargeVersion.licence = { startDate: new Date('2022-08-31') }
+        chargeVersion.licence = { startDate: new Date('2023-08-31') }
       })
 
       it('returns the licence start and financial end date', () => {
@@ -132,7 +132,7 @@ describe('Determine charge period service', () => {
 
     describe('and the licence revoked date is inside the financial period', () => {
       beforeEach(() => {
-        chargeVersion.licence = { startDate: new Date('2022-01-01'), revokedDate: new Date('2022-08-01') }
+        chargeVersion.licence = { startDate: new Date('2023-01-01'), revokedDate: new Date('2023-08-01') }
       })
 
       it('returns the financial start and licence revoked end date', () => {
@@ -145,7 +145,7 @@ describe('Determine charge period service', () => {
 
     describe('and the licence lapsed date is inside the financial period', () => {
       beforeEach(() => {
-        chargeVersion.licence = { startDate: new Date('2022-01-01'), lapsedDate: new Date('2022-08-31') }
+        chargeVersion.licence = { startDate: new Date('2023-01-01'), lapsedDate: new Date('2023-08-31') }
       })
 
       it('returns the financial start and licence lapsed end date', () => {
@@ -158,7 +158,7 @@ describe('Determine charge period service', () => {
 
     describe('and the licence expired date is inside the financial period', () => {
       beforeEach(() => {
-        chargeVersion.licence = { startDate: new Date('2022-01-01'), expiredDate: new Date('2022-07-01') }
+        chargeVersion.licence = { startDate: new Date('2023-01-01'), expiredDate: new Date('2023-07-01') }
       })
 
       it('returns the financial start and licence expired end date', () => {
@@ -173,15 +173,15 @@ describe('Determine charge period service', () => {
   describe('financial period starts before the charge version', () => {
     beforeEach(() => {
       chargeVersion = {
-        startDate: new Date('2022-05-01'),
+        startDate: new Date('2023-05-01'),
         endDate: null,
-        licence: { startDate: new Date('2022-01-01') }
+        licence: { startDate: new Date('2023-01-01') }
       }
     })
 
     describe('and the charge version has an end date that is outside the financial period', () => {
       beforeEach(() => {
-        chargeVersion.endDate = new Date('2023-05-31')
+        chargeVersion.endDate = new Date('2024-05-31')
       })
 
       it('returns the charge version start date and financial period end date', () => {
@@ -206,7 +206,7 @@ describe('Determine charge period service', () => {
     describe('because the charge version start date is after the financial period', () => {
       beforeEach(() => {
         chargeVersion = {
-          startDate: new Date('2023-05-01'),
+          startDate: new Date('2024-05-01'),
           endDate: null
         }
       })
@@ -222,8 +222,8 @@ describe('Determine charge period service', () => {
     describe('because the charge version end date is before the financial period', () => {
       beforeEach(() => {
         chargeVersion = {
-          startDate: new Date('2021-05-01'),
-          endDate: new Date('2021-05-31'),
+          startDate: new Date('2022-05-01'),
+          endDate: new Date('2022-05-31'),
           licence: { startDate: new Date('2018-01-01') }
         }
       })

--- a/test/services/supplementary-billing/determine-charge-period.service.test.js
+++ b/test/services/supplementary-billing/determine-charge-period.service.test.js
@@ -252,7 +252,8 @@ describe('Determine charge period service', () => {
       beforeEach(() => {
         chargeVersion = {
           startDate: new Date('2024-05-01'),
-          endDate: null
+          endDate: null,
+          licence: { startDate: new Date('2018-01-01') }
         }
       })
 

--- a/test/services/supplementary-billing/determine-charge-period.service.test.js
+++ b/test/services/supplementary-billing/determine-charge-period.service.test.js
@@ -248,6 +248,26 @@ describe('Determine charge period service', () => {
         expect(result.endDate).to.equal(billingPeriod.endDate)
       })
     })
+
+    describe('and the licence expired date', () => {
+      describe("is inside the billing period before the charge version's start date", () => {
+        beforeEach(() => {
+          chargeVersion = {
+            startDate: new Date('2023-10-01'),
+            endDate: null,
+            licence: { startDate: new Date('2023-01-01'), expiredDate: new Date('2023-06-01') }
+          }
+        })
+
+        it('returns null values for the dates', () => {
+          const result = DetermineChargePeriodService.go(chargeVersion, billingPeriod)
+          console.log('🚀 ~ file: determine-charge-period.service.test.js:264 ~ it ~ result:', result)
+
+          expect(result.startDate).to.be.null()
+          expect(result.endDate).to.be.null()
+        })
+      })
+    })
   })
 
   describe('the charge version starts after the billing period', () => {

--- a/test/services/supplementary-billing/determine-charge-period.service.test.js
+++ b/test/services/supplementary-billing/determine-charge-period.service.test.js
@@ -130,42 +130,87 @@ describe('Determine charge period service', () => {
       })
     })
 
-    describe('and the licence revoked date is inside the financial period', () => {
-      beforeEach(() => {
-        chargeVersion.licence = { startDate: new Date('2023-01-01'), revokedDate: new Date('2023-08-01') }
+    describe('and the licence revoked date', () => {
+      describe('is inside the financial period', () => {
+        beforeEach(() => {
+          chargeVersion.licence = { startDate: new Date('2023-01-01'), revokedDate: new Date('2023-08-01') }
+        })
+
+        it('returns the financial start and licence revoked end date', () => {
+          const result = DetermineChargePeriodService.go(chargeVersion, financialYear.yearEnding)
+
+          expect(result.startDate).to.equal(financialYear.startDate)
+          expect(result.endDate).to.equal(chargeVersion.licence.revokedDate)
+        })
       })
 
-      it('returns the financial start and licence revoked end date', () => {
-        const result = DetermineChargePeriodService.go(chargeVersion, financialYear.yearEnding)
+      describe('is before the financial period', () => {
+        beforeEach(() => {
+          chargeVersion.licence = { startDate: new Date('2023-01-01'), revokedDate: new Date('2023-02-01') }
+        })
 
-        expect(result.startDate).to.equal(financialYear.startDate)
-        expect(result.endDate).to.equal(chargeVersion.licence.revokedDate)
+        it('returns null values for the dates', () => {
+          const result = DetermineChargePeriodService.go(chargeVersion, financialYear.yearEnding)
+
+          expect(result.startDate).to.be.null()
+          expect(result.endDate).to.be.null()
+        })
       })
     })
 
-    describe('and the licence lapsed date is inside the financial period', () => {
-      beforeEach(() => {
-        chargeVersion.licence = { startDate: new Date('2023-01-01'), lapsedDate: new Date('2023-08-31') }
+    describe('and the licence lapsed date', () => {
+      describe('is inside the financial period', () => {
+        beforeEach(() => {
+          chargeVersion.licence = { startDate: new Date('2023-01-01'), lapsedDate: new Date('2023-08-31') }
+        })
+
+        it('returns the financial start and licence lapsed end date', () => {
+          const result = DetermineChargePeriodService.go(chargeVersion, financialYear.yearEnding)
+
+          expect(result.startDate).to.equal(financialYear.startDate)
+          expect(result.endDate).to.equal(chargeVersion.licence.lapsedDate)
+        })
       })
 
-      it('returns the financial start and licence lapsed end date', () => {
-        const result = DetermineChargePeriodService.go(chargeVersion, financialYear.yearEnding)
+      describe('is before the financial period', () => {
+        beforeEach(() => {
+          chargeVersion.licence = { startDate: new Date('2023-01-01'), lapsedDate: new Date('2023-02-31') }
+        })
 
-        expect(result.startDate).to.equal(financialYear.startDate)
-        expect(result.endDate).to.equal(chargeVersion.licence.lapsedDate)
+        it('returns null values for the dates', () => {
+          const result = DetermineChargePeriodService.go(chargeVersion, financialYear.yearEnding)
+
+          expect(result.startDate).to.be.null()
+          expect(result.endDate).to.be.null()
+        })
       })
     })
 
-    describe('and the licence expired date is inside the financial period', () => {
-      beforeEach(() => {
-        chargeVersion.licence = { startDate: new Date('2023-01-01'), expiredDate: new Date('2023-07-01') }
+    describe('and the licence expired date', () => {
+      describe('is inside the financial period', () => {
+        beforeEach(() => {
+          chargeVersion.licence = { startDate: new Date('2023-01-01'), expiredDate: new Date('2023-07-01') }
+        })
+
+        it('returns the financial start and licence expired end date', () => {
+          const result = DetermineChargePeriodService.go(chargeVersion, financialYear.yearEnding)
+
+          expect(result.startDate).to.equal(financialYear.startDate)
+          expect(result.endDate).to.equal(chargeVersion.licence.expiredDate)
+        })
       })
 
-      it('returns the financial start and licence expired end date', () => {
-        const result = DetermineChargePeriodService.go(chargeVersion, financialYear.yearEnding)
+      describe('is before the financial period', () => {
+        beforeEach(() => {
+          chargeVersion.licence = { startDate: new Date('2023-01-01'), lapsedDate: new Date('2023-02-31') }
+        })
 
-        expect(result.startDate).to.equal(financialYear.startDate)
-        expect(result.endDate).to.equal(chargeVersion.licence.expiredDate)
+        it('returns null values for the dates', () => {
+          const result = DetermineChargePeriodService.go(chargeVersion, financialYear.yearEnding)
+
+          expect(result.startDate).to.be.null()
+          expect(result.endDate).to.be.null()
+        })
       })
     })
   })

--- a/test/services/supplementary-billing/determine-charge-period.service.test.js
+++ b/test/services/supplementary-billing/determine-charge-period.service.test.js
@@ -11,10 +11,9 @@ const { expect } = Code
 const DetermineChargePeriodService = require('../../../app/services/supplementary-billing/determine-charge-period.service.js')
 
 describe('Determine charge period service', () => {
-  const financialYear = {
+  const billingPeriod = {
     startDate: new Date('2023-04-01'),
-    endDate: new Date('2024-03-31'),
-    yearEnding: 2024
+    endDate: new Date('2024-03-31')
   }
   let chargeVersion
 
@@ -33,7 +32,7 @@ describe('Determine charge period service', () => {
       })
 
       it('returns the charge version start and end dates', () => {
-        const result = DetermineChargePeriodService.go(chargeVersion, financialYear.yearEnding)
+        const result = DetermineChargePeriodService.go(chargeVersion, billingPeriod)
 
         expect(result.startDate).to.equal(chargeVersion.startDate)
         expect(result.endDate).to.equal(chargeVersion.endDate)
@@ -42,10 +41,10 @@ describe('Determine charge period service', () => {
 
     describe('and the charge version does not have an end date', () => {
       it('returns the charge version start date and financial year end date', () => {
-        const result = DetermineChargePeriodService.go(chargeVersion, financialYear.yearEnding)
+        const result = DetermineChargePeriodService.go(chargeVersion, billingPeriod)
 
         expect(result.startDate).to.equal(chargeVersion.startDate)
-        expect(result.endDate).to.equal(financialYear.endDate)
+        expect(result.endDate).to.equal(billingPeriod.endDate)
       })
     })
   })
@@ -65,19 +64,19 @@ describe('Determine charge period service', () => {
       })
 
       it('returns the financial start and end dates', () => {
-        const result = DetermineChargePeriodService.go(chargeVersion, financialYear.yearEnding)
+        const result = DetermineChargePeriodService.go(chargeVersion, billingPeriod)
 
-        expect(result.startDate).to.equal(financialYear.startDate)
-        expect(result.endDate).to.equal(financialYear.endDate)
+        expect(result.startDate).to.equal(billingPeriod.startDate)
+        expect(result.endDate).to.equal(billingPeriod.endDate)
       })
     })
 
     describe('and the charge version does not have an end date', () => {
       it('returns the financial start and end dates', () => {
-        const result = DetermineChargePeriodService.go(chargeVersion, financialYear.yearEnding)
+        const result = DetermineChargePeriodService.go(chargeVersion, billingPeriod)
 
-        expect(result.startDate).to.equal(financialYear.startDate)
-        expect(result.endDate).to.equal(financialYear.endDate)
+        expect(result.startDate).to.equal(billingPeriod.startDate)
+        expect(result.endDate).to.equal(billingPeriod.endDate)
       })
     })
   })
@@ -97,9 +96,9 @@ describe('Determine charge period service', () => {
       })
 
       it('returns the financial start and charge version end date', () => {
-        const result = DetermineChargePeriodService.go(chargeVersion, financialYear.yearEnding)
+        const result = DetermineChargePeriodService.go(chargeVersion, billingPeriod)
 
-        expect(result.startDate).to.equal(financialYear.startDate)
+        expect(result.startDate).to.equal(billingPeriod.startDate)
         expect(result.endDate).to.equal(chargeVersion.endDate)
       })
     })
@@ -110,10 +109,10 @@ describe('Determine charge period service', () => {
       })
 
       it('returns the financial start and end dates', () => {
-        const result = DetermineChargePeriodService.go(chargeVersion, financialYear.yearEnding)
+        const result = DetermineChargePeriodService.go(chargeVersion, billingPeriod)
 
-        expect(result.startDate).to.equal(financialYear.startDate)
-        expect(result.endDate).to.equal(financialYear.endDate)
+        expect(result.startDate).to.equal(billingPeriod.startDate)
+        expect(result.endDate).to.equal(billingPeriod.endDate)
       })
     })
 
@@ -123,10 +122,10 @@ describe('Determine charge period service', () => {
       })
 
       it('returns the licence start and financial end date', () => {
-        const result = DetermineChargePeriodService.go(chargeVersion, financialYear.yearEnding)
+        const result = DetermineChargePeriodService.go(chargeVersion, billingPeriod)
 
         expect(result.startDate).to.equal(chargeVersion.licence.startDate)
-        expect(result.endDate).to.equal(financialYear.endDate)
+        expect(result.endDate).to.equal(billingPeriod.endDate)
       })
     })
 
@@ -137,9 +136,9 @@ describe('Determine charge period service', () => {
         })
 
         it('returns the financial start and licence revoked end date', () => {
-          const result = DetermineChargePeriodService.go(chargeVersion, financialYear.yearEnding)
+          const result = DetermineChargePeriodService.go(chargeVersion, billingPeriod)
 
-          expect(result.startDate).to.equal(financialYear.startDate)
+          expect(result.startDate).to.equal(billingPeriod.startDate)
           expect(result.endDate).to.equal(chargeVersion.licence.revokedDate)
         })
       })
@@ -150,7 +149,7 @@ describe('Determine charge period service', () => {
         })
 
         it('returns null values for the dates', () => {
-          const result = DetermineChargePeriodService.go(chargeVersion, financialYear.yearEnding)
+          const result = DetermineChargePeriodService.go(chargeVersion, billingPeriod)
 
           expect(result.startDate).to.be.null()
           expect(result.endDate).to.be.null()
@@ -165,9 +164,9 @@ describe('Determine charge period service', () => {
         })
 
         it('returns the financial start and licence lapsed end date', () => {
-          const result = DetermineChargePeriodService.go(chargeVersion, financialYear.yearEnding)
+          const result = DetermineChargePeriodService.go(chargeVersion, billingPeriod)
 
-          expect(result.startDate).to.equal(financialYear.startDate)
+          expect(result.startDate).to.equal(billingPeriod.startDate)
           expect(result.endDate).to.equal(chargeVersion.licence.lapsedDate)
         })
       })
@@ -178,7 +177,7 @@ describe('Determine charge period service', () => {
         })
 
         it('returns null values for the dates', () => {
-          const result = DetermineChargePeriodService.go(chargeVersion, financialYear.yearEnding)
+          const result = DetermineChargePeriodService.go(chargeVersion, billingPeriod)
 
           expect(result.startDate).to.be.null()
           expect(result.endDate).to.be.null()
@@ -193,9 +192,9 @@ describe('Determine charge period service', () => {
         })
 
         it('returns the financial start and licence expired end date', () => {
-          const result = DetermineChargePeriodService.go(chargeVersion, financialYear.yearEnding)
+          const result = DetermineChargePeriodService.go(chargeVersion, billingPeriod)
 
-          expect(result.startDate).to.equal(financialYear.startDate)
+          expect(result.startDate).to.equal(billingPeriod.startDate)
           expect(result.endDate).to.equal(chargeVersion.licence.expiredDate)
         })
       })
@@ -206,7 +205,7 @@ describe('Determine charge period service', () => {
         })
 
         it('returns null values for the dates', () => {
-          const result = DetermineChargePeriodService.go(chargeVersion, financialYear.yearEnding)
+          const result = DetermineChargePeriodService.go(chargeVersion, billingPeriod)
 
           expect(result.startDate).to.be.null()
           expect(result.endDate).to.be.null()
@@ -230,19 +229,19 @@ describe('Determine charge period service', () => {
       })
 
       it('returns the charge version start date and financial period end date', () => {
-        const result = DetermineChargePeriodService.go(chargeVersion, financialYear.yearEnding)
+        const result = DetermineChargePeriodService.go(chargeVersion, billingPeriod)
 
         expect(result.startDate).to.equal(chargeVersion.startDate)
-        expect(result.endDate).to.equal(financialYear.endDate)
+        expect(result.endDate).to.equal(billingPeriod.endDate)
       })
     })
 
     describe('and the charge version does not have an end date', () => {
       it('returns the charge version start date and financial period end date', () => {
-        const result = DetermineChargePeriodService.go(chargeVersion, financialYear.yearEnding)
+        const result = DetermineChargePeriodService.go(chargeVersion, billingPeriod)
 
         expect(result.startDate).to.equal(chargeVersion.startDate)
-        expect(result.endDate).to.equal(financialYear.endDate)
+        expect(result.endDate).to.equal(billingPeriod.endDate)
       })
     })
   })
@@ -258,7 +257,7 @@ describe('Determine charge period service', () => {
       })
 
       it('returns null values for the dates', () => {
-        const result = DetermineChargePeriodService.go(chargeVersion, financialYear.yearEnding)
+        const result = DetermineChargePeriodService.go(chargeVersion, billingPeriod)
 
         expect(result.startDate).to.be.null()
         expect(result.endDate).to.be.null()
@@ -275,7 +274,7 @@ describe('Determine charge period service', () => {
       })
 
       it('returns null values for the dates', () => {
-        const result = DetermineChargePeriodService.go(chargeVersion, financialYear.yearEnding)
+        const result = DetermineChargePeriodService.go(chargeVersion, billingPeriod)
 
         expect(result.startDate).to.be.null()
         expect(result.endDate).to.be.null()

--- a/test/services/supplementary-billing/determine-charge-period.service.test.js
+++ b/test/services/supplementary-billing/determine-charge-period.service.test.js
@@ -17,7 +17,7 @@ describe('Determine charge period service', () => {
   }
   let chargeVersion
 
-  describe('charge version starts inside the financial period', () => {
+  describe('charge version starts inside the billing period', () => {
     beforeEach(() => {
       chargeVersion = {
         startDate: new Date('2023-05-01'),
@@ -40,7 +40,7 @@ describe('Determine charge period service', () => {
     })
 
     describe('and the charge version does not have an end date', () => {
-      it('returns the charge version start date and financial year end date', () => {
+      it('returns the charge version start date and billing period end date', () => {
         const result = DetermineChargePeriodService.go(chargeVersion, billingPeriod)
 
         expect(result.startDate).to.equal(chargeVersion.startDate)
@@ -49,7 +49,7 @@ describe('Determine charge period service', () => {
     })
   })
 
-  describe('financial period starts inside the charge version', () => {
+  describe('billing period starts inside the charge version', () => {
     beforeEach(() => {
       chargeVersion = {
         startDate: new Date('2023-02-01'),
@@ -63,7 +63,7 @@ describe('Determine charge period service', () => {
         chargeVersion.endDate = new Date('2024-05-31')
       })
 
-      it('returns the financial start and end dates', () => {
+      it('returns the billing period start and end dates', () => {
         const result = DetermineChargePeriodService.go(chargeVersion, billingPeriod)
 
         expect(result.startDate).to.equal(billingPeriod.startDate)
@@ -72,7 +72,7 @@ describe('Determine charge period service', () => {
     })
 
     describe('and the charge version does not have an end date', () => {
-      it('returns the financial start and end dates', () => {
+      it('returns the billing period start and end dates', () => {
         const result = DetermineChargePeriodService.go(chargeVersion, billingPeriod)
 
         expect(result.startDate).to.equal(billingPeriod.startDate)
@@ -81,7 +81,7 @@ describe('Determine charge period service', () => {
     })
   })
 
-  describe('charge version starts before the financial period', () => {
+  describe('charge version starts before the billing period', () => {
     beforeEach(() => {
       chargeVersion = {
         startDate: new Date('2023-02-01'),
@@ -89,13 +89,13 @@ describe('Determine charge period service', () => {
       }
     })
 
-    describe('and the charge version has an end date that is inside the financial period', () => {
+    describe('and the charge version has an end date that is inside the billing period', () => {
       beforeEach(() => {
         chargeVersion.licence = { startDate: new Date('2023-01-01') }
         chargeVersion.endDate = new Date('2023-05-31')
       })
 
-      it('returns the financial start and charge version end date', () => {
+      it('returns the billing period start and charge version end date', () => {
         const result = DetermineChargePeriodService.go(chargeVersion, billingPeriod)
 
         expect(result.startDate).to.equal(billingPeriod.startDate)
@@ -108,7 +108,7 @@ describe('Determine charge period service', () => {
         chargeVersion.licence = { startDate: new Date('2023-01-01') }
       })
 
-      it('returns the financial start and end dates', () => {
+      it('returns the billing period start and end dates', () => {
         const result = DetermineChargePeriodService.go(chargeVersion, billingPeriod)
 
         expect(result.startDate).to.equal(billingPeriod.startDate)
@@ -116,12 +116,12 @@ describe('Determine charge period service', () => {
       })
     })
 
-    describe('and the licence start date is after the charge versions and inside the financial period', () => {
+    describe('and the licence start date is after the charge versions and inside the billing period', () => {
       beforeEach(() => {
         chargeVersion.licence = { startDate: new Date('2023-08-31') }
       })
 
-      it('returns the licence start and financial end date', () => {
+      it('returns the licence start and billing period end date', () => {
         const result = DetermineChargePeriodService.go(chargeVersion, billingPeriod)
 
         expect(result.startDate).to.equal(chargeVersion.licence.startDate)
@@ -130,12 +130,12 @@ describe('Determine charge period service', () => {
     })
 
     describe('and the licence revoked date', () => {
-      describe('is inside the financial period', () => {
+      describe('is inside the billing period', () => {
         beforeEach(() => {
           chargeVersion.licence = { startDate: new Date('2023-01-01'), revokedDate: new Date('2023-08-01') }
         })
 
-        it('returns the financial start and licence revoked end date', () => {
+        it('returns the billing period start and licence revoked end date', () => {
           const result = DetermineChargePeriodService.go(chargeVersion, billingPeriod)
 
           expect(result.startDate).to.equal(billingPeriod.startDate)
@@ -143,7 +143,7 @@ describe('Determine charge period service', () => {
         })
       })
 
-      describe('is before the financial period', () => {
+      describe('is before the billing period', () => {
         beforeEach(() => {
           chargeVersion.licence = { startDate: new Date('2023-01-01'), revokedDate: new Date('2023-02-01') }
         })
@@ -158,12 +158,12 @@ describe('Determine charge period service', () => {
     })
 
     describe('and the licence lapsed date', () => {
-      describe('is inside the financial period', () => {
+      describe('is inside the billing period', () => {
         beforeEach(() => {
           chargeVersion.licence = { startDate: new Date('2023-01-01'), lapsedDate: new Date('2023-08-31') }
         })
 
-        it('returns the financial start and licence lapsed end date', () => {
+        it('returns the billing period start and licence lapsed end date', () => {
           const result = DetermineChargePeriodService.go(chargeVersion, billingPeriod)
 
           expect(result.startDate).to.equal(billingPeriod.startDate)
@@ -171,7 +171,7 @@ describe('Determine charge period service', () => {
         })
       })
 
-      describe('is before the financial period', () => {
+      describe('is before the billing period', () => {
         beforeEach(() => {
           chargeVersion.licence = { startDate: new Date('2023-01-01'), lapsedDate: new Date('2023-02-31') }
         })
@@ -186,12 +186,12 @@ describe('Determine charge period service', () => {
     })
 
     describe('and the licence expired date', () => {
-      describe('is inside the financial period', () => {
+      describe('is inside the billing period', () => {
         beforeEach(() => {
           chargeVersion.licence = { startDate: new Date('2023-01-01'), expiredDate: new Date('2023-07-01') }
         })
 
-        it('returns the financial start and licence expired end date', () => {
+        it('returns the billing period start and licence expired end date', () => {
           const result = DetermineChargePeriodService.go(chargeVersion, billingPeriod)
 
           expect(result.startDate).to.equal(billingPeriod.startDate)
@@ -199,7 +199,7 @@ describe('Determine charge period service', () => {
         })
       })
 
-      describe('is before the financial period', () => {
+      describe('is before the billing period', () => {
         beforeEach(() => {
           chargeVersion.licence = { startDate: new Date('2023-01-01'), lapsedDate: new Date('2023-02-31') }
         })
@@ -214,7 +214,7 @@ describe('Determine charge period service', () => {
     })
   })
 
-  describe('financial period starts before the charge version', () => {
+  describe('billing period starts before the charge version', () => {
     beforeEach(() => {
       chargeVersion = {
         startDate: new Date('2023-05-01'),
@@ -223,12 +223,12 @@ describe('Determine charge period service', () => {
       }
     })
 
-    describe('and the charge version has an end date that is outside the financial period', () => {
+    describe('and the charge version has an end date that is outside the billing period', () => {
       beforeEach(() => {
         chargeVersion.endDate = new Date('2024-05-31')
       })
 
-      it('returns the charge version start date and financial period end date', () => {
+      it('returns the charge version start date and billing period end date', () => {
         const result = DetermineChargePeriodService.go(chargeVersion, billingPeriod)
 
         expect(result.startDate).to.equal(chargeVersion.startDate)
@@ -237,7 +237,7 @@ describe('Determine charge period service', () => {
     })
 
     describe('and the charge version does not have an end date', () => {
-      it('returns the charge version start date and financial period end date', () => {
+      it('returns the charge version start date and billing period end date', () => {
         const result = DetermineChargePeriodService.go(chargeVersion, billingPeriod)
 
         expect(result.startDate).to.equal(chargeVersion.startDate)
@@ -247,7 +247,7 @@ describe('Determine charge period service', () => {
   })
 
   describe('neither period overlaps', () => {
-    describe('because the charge version start date is after the financial period', () => {
+    describe('because the charge version start date is after the billing period', () => {
       beforeEach(() => {
         chargeVersion = {
           startDate: new Date('2024-05-01'),
@@ -264,7 +264,7 @@ describe('Determine charge period service', () => {
       })
     })
 
-    describe('because the charge version end date is before the financial period', () => {
+    describe('because the charge version end date is before the billing period', () => {
       beforeEach(() => {
         chargeVersion = {
           startDate: new Date('2022-05-01'),

--- a/test/services/supplementary-billing/determine-minimum-charge.service.test.js
+++ b/test/services/supplementary-billing/determine-minimum-charge.service.test.js
@@ -16,7 +16,10 @@ const DatabaseHelper = require('../../support/helpers/database.helper.js')
 const DetermineMinimumChargeService = require('../../../app/services/supplementary-billing/determine-minimum-charge.service.js')
 
 describe('Determine minimum charge service', () => {
-  const financialYearEnding = 2023
+  const chargePeriod = {
+    startDate: new Date('2023-04-01'),
+    endDate: new Date('2024-03-31')
+  }
   let chargeVersion
 
   afterEach(async () => {
@@ -28,7 +31,7 @@ describe('Determine minimum charge service', () => {
       beforeEach(async () => {
         const changeReason = await ChangeReasonHelper.add({ triggersMinimumCharge: true })
         chargeVersion = await ChargeVersionHelper.add({
-          startDate: new Date('2022-05-01'),
+          startDate: new Date('2023-04-01'),
           changeReasonId: changeReason.changeReasonId
         })
         chargeVersion.changeReason = changeReason
@@ -36,7 +39,7 @@ describe('Determine minimum charge service', () => {
       })
 
       it('returns true', async () => {
-        const result = DetermineMinimumChargeService.go(chargeVersion, financialYearEnding)
+        const result = DetermineMinimumChargeService.go(chargeVersion, chargePeriod)
 
         expect(result).to.be.true()
       })
@@ -54,7 +57,7 @@ describe('Determine minimum charge service', () => {
       })
 
       it('returns false', async () => {
-        const result = DetermineMinimumChargeService.go(chargeVersion, financialYearEnding)
+        const result = DetermineMinimumChargeService.go(chargeVersion, chargePeriod)
 
         expect(result).to.be.false()
       })
@@ -73,7 +76,7 @@ describe('Determine minimum charge service', () => {
     })
 
     it('returns false', async () => {
-      const result = DetermineMinimumChargeService.go(chargeVersion, financialYearEnding)
+      const result = DetermineMinimumChargeService.go(chargeVersion, chargePeriod)
 
       expect(result).to.be.false()
     })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4044

We recently implemented a [fix to stop calculating negative billable days for out-of-period charge versions](https://github.com/DEFRA/water-abstraction-system/pull/286).

For each billable period (financial year) we have to look at all charge versions that start before the period ends. This is to catch those which were previously debited in the period but recent changes now cause them to end before it.

We've since spotted another scenario that causes a charge period to be returned where the start date is after the end date. A charge version that starts before the billable period but is linked to a licence that ended before the billable period results in an invalid charge period

- charge version start date 2022-04-01
- licence revoked date 2023-01-11
- billable period start date 2023-04-01
- billable period end date 2024-03-31

Our current `_periodIsIncompatible()` check would determine whether the charge version has a compatible period. So, the service would grab the latest start date; billable period start date. Next, it would grab the earliest end date; the licence revoked date.

The result is a charge period that results in negative billable days

```javascript
  return {
    startDate: new Date('2023-04-01'),
    endDate: new Date('2023-01-11')
  }
```

This change moves the `_periodIsIncompatible()` check to after we've determined the start and end dates. This should mean no matter the reason for determining a start date after the end date, the service will see it is incompatible and return the null result needed to stop `ProcessBillingPeriodService` from trying to calculate billable days.

---

As part of these changes, we spotted that

- `DetermineChargePeriodService` was working out the billing period when it was readily available to pass in
- `DetermineMinimumChargeService` was using `DetermineChargePeriodService` to work out the charge period when again, it was readily available to pass in
- Tests for `DetermineChargePeriodService` had become duplicated

This cleanup was done as part of this change.