### PR TITLE
Add back in our check endpoint

### DIFF
--- a/app/controllers/check/check.controller.js
+++ b/app/controllers/check/check.controller.js
@@ -5,8 +5,18 @@
  * @module CheckController
  */
 
-async function twoPart (_request, h) {
-  return h.response().code(204)
+const Boom = require('@hapi/boom')
+
+const TwoPartService = require('../../services/check/two-part.service.js')
+
+async function twoPart (request, h) {
+  try {
+    const result = await TwoPartService.go(request.params.naldRegionId)
+
+    return h.response(result).code(200)
+  } catch (error) {
+    return Boom.badImplementation(error.message)
+  }
 }
 
 module.exports = {

--- a/app/controllers/check/check.controller.js
+++ b/app/controllers/check/check.controller.js
@@ -7,11 +7,11 @@
 
 const Boom = require('@hapi/boom')
 
-const TwoPartService = require('../../services/check/two-part.service.js')
+const CheckTwoPartService = require('../../services/check/two-part.service.js')
 
 async function twoPart (request, h) {
   try {
-    const result = await TwoPartService.go(request.params.naldRegionId)
+    const result = await CheckTwoPartService.go(request.params.naldRegionId)
 
     return h.response(result).code(200)
   } catch (error) {

--- a/app/controllers/check/check.controller.js
+++ b/app/controllers/check/check.controller.js
@@ -1,0 +1,14 @@
+'use strict'
+
+/**
+ * Controller for /check endpoints
+ * @module CheckController
+ */
+
+async function twoPart (_request, h) {
+  return h.response().code(204)
+}
+
+module.exports = {
+  twoPart
+}

--- a/app/plugins/router.plugin.js
+++ b/app/plugins/router.plugin.js
@@ -13,6 +13,7 @@
 
 const AssetRoutes = require('../routes/assets.routes.js')
 const BillRunRoutes = require('../routes/bill-runs.routes')
+const CheckRoutes = require('../routes/check.routes')
 const DataRoutes = require('../routes/data.routes.js')
 const FilterRoutesService = require('../services/plugins/filter-routes.service.js')
 const HealthRoutes = require('../routes/health.routes.js')
@@ -25,6 +26,7 @@ const routes = [
   ...AssetRoutes,
   ...HealthRoutes,
   ...BillRunRoutes,
+  ...CheckRoutes,
   ...DataRoutes
 ]
 

--- a/app/routes/check.routes.js
+++ b/app/routes/check.routes.js
@@ -1,0 +1,17 @@
+'use strict'
+
+const CheckController = require('../controllers/check/check.controller.js')
+
+const routes = [
+  {
+    method: 'POST',
+    path: '/check/two-part',
+    handler: CheckController.twoPart,
+    options: {
+      description: 'Used by the delivery team to check the SROC 2PT billing logic',
+      app: { excludeFromProd: true }
+    }
+  }
+]
+
+module.exports = routes

--- a/app/routes/check.routes.js
+++ b/app/routes/check.routes.js
@@ -4,8 +4,8 @@ const CheckController = require('../controllers/check/check.controller.js')
 
 const routes = [
   {
-    method: 'POST',
-    path: '/check/two-part',
+    method: 'GET',
+    path: '/check/two-part/{naldRegionId}',
     handler: CheckController.twoPart,
     options: {
       description: 'Used by the delivery team to check the SROC 2PT billing logic',

--- a/app/services/check/two-part.service.js
+++ b/app/services/check/two-part.service.js
@@ -1,0 +1,20 @@
+'use strict'
+
+/**
+ * Used to test the Two-part tariff matching logic
+ * @module SupplementaryDataService
+ */
+
+const FetchRegionService = require('../billing/supplementary/fetch-region.service.js')
+
+async function go (naldRegionId) {
+  const region = await FetchRegionService.go(naldRegionId)
+
+  return {
+    regionName: region.name
+  }
+}
+
+module.exports = {
+  go
+}

--- a/test/controllers/check/check.controller.test.js
+++ b/test/controllers/check/check.controller.test.js
@@ -8,6 +8,9 @@ const Sinon = require('sinon')
 const { describe, it, beforeEach, afterEach } = exports.lab = Lab.script()
 const { expect } = Code
 
+// Things we need to stub
+const TwoPartService = require('../../../app/services/check/two-part.service.js')
+
 // For running our service
 const { init } = require('../../../app/server.js')
 
@@ -30,17 +33,38 @@ describe('Check controller', () => {
     Sinon.restore()
   })
 
-  describe('POST /check/two-part', () => {
+  describe('GET /check/two-part', () => {
     const options = {
-      method: 'POST',
-      url: '/check/two-part'
+      method: 'GET',
+      url: '/check/two-part/9'
     }
 
     describe('when the request succeeds', () => {
+      beforeEach(async () => {
+        Sinon.stub(TwoPartService, 'go').resolves({ regionName: 'Fantasia' })
+      })
+
       it('displays the correct message', async () => {
         const response = await server.inject(options)
 
-        expect(response.statusCode).to.equal(204)
+        const responsePayload = JSON.parse(response.payload)
+
+        expect(response.statusCode).to.equal(200)
+        expect(responsePayload).to.equal({ regionName: 'Fantasia' })
+      })
+    })
+
+    describe('when the request fails', () => {
+      describe('because the TwoPartService errors', () => {
+        beforeEach(async () => {
+          Sinon.stub(TwoPartService, 'go').rejects()
+        })
+
+        it('returns a 500 status', async () => {
+          const response = await server.inject(options)
+
+          expect(response.statusCode).to.equal(500)
+        })
       })
     })
   })

--- a/test/controllers/check/check.controller.test.js
+++ b/test/controllers/check/check.controller.test.js
@@ -1,0 +1,47 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { describe, it, beforeEach, afterEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// For running our service
+const { init } = require('../../../app/server.js')
+
+describe('Check controller', () => {
+  let server
+
+  beforeEach(async () => {
+    // Create server before each test
+    server = await init()
+
+    // We silence any calls to server.logger.error made in the plugin to try and keep the test output as clean as
+    // possible
+    Sinon.stub(server.logger, 'error')
+
+    // We silence sending a notification to our Errbit instance using Airbrake
+    Sinon.stub(server.app.airbrake, 'notify').resolvesThis()
+  })
+
+  afterEach(() => {
+    Sinon.restore()
+  })
+
+  describe('POST /check/two-part', () => {
+    const options = {
+      method: 'POST',
+      url: '/check/two-part'
+    }
+
+    describe('when the request succeeds', () => {
+      it('displays the correct message', async () => {
+        const response = await server.inject(options)
+
+        expect(response.statusCode).to.equal(204)
+      })
+    })
+  })
+})


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4038

Way back when we first started the work on SROC Supplementary billing we [started with a `/test` endpoint](https://github.com/DEFRA/water-abstraction-system/pull/13). We used this as a means of triggering our billing engine and exposing the results, until such time as we were ready to integrate it into the process for real.

We're about ready to start developing the next bill run type, which is two-part tariff (2PT) and we want to do the same again. Over time we learnt things were much less confusing if the endpoint was actually `/check` (testing `TestService` in the `test/services/test` folder - need we say more!)

So, this change adds the endpoint back into the repo. We can then start iterating our 2PT engine, verifying the results along the way.