### PR TITLE
Fix reissuing bugs

### DIFF
--- a/app/models/water/billing-transaction.model.js
+++ b/app/models/water/billing-transaction.model.js
@@ -45,6 +45,16 @@ class BillingTransactionModel extends WaterBaseModel {
       }
     }
   }
+
+  // Defining which fields contain json allows us to insert an object without needing to stringify it first
+  static get jsonAttributes () {
+    return [
+      'abstractionPeriod',
+      'grossValuesCalculated',
+      'metadata',
+      'purposes'
+    ]
+  }
 }
 
 module.exports = BillingTransactionModel

--- a/app/services/billing/supplementary/fetch-invoices-to-be-reissued.service.js
+++ b/app/services/billing/supplementary/fetch-invoices-to-be-reissued.service.js
@@ -18,6 +18,7 @@ async function go (regionId) {
   try {
     const result = await BillingInvoiceModel.query()
       .select(
+        'billingInvoiceId',
         'billingInvoices.externalId',
         'invoiceAccountId',
         'invoiceAccountNumber',

--- a/app/services/billing/supplementary/fetch-invoices-to-be-reissued.service.js
+++ b/app/services/billing/supplementary/fetch-invoices-to-be-reissued.service.js
@@ -20,6 +20,7 @@ async function go (regionId) {
       .select(
         'billingInvoiceId',
         'billingInvoices.externalId',
+        'financialYearEnding',
         'invoiceAccountId',
         'invoiceAccountNumber',
         'originalBillingInvoiceId'

--- a/app/services/billing/supplementary/process-billing-batch.service.js
+++ b/app/services/billing/supplementary/process-billing-batch.service.js
@@ -36,7 +36,7 @@ async function go (billingBatch, billingPeriods) {
 
     const resultOfReissuing = await _reissueInvoices(billingBatch)
 
-    await _processBillingPeriods(billingPeriods, billingBatch, billingBatchId, resultOfReissuing)
+    await _processBillingPeriods(billingPeriods, billingBatch, resultOfReissuing)
 
     _calculateAndLogTime(billingBatchId, startTime)
   } catch (error) {
@@ -45,7 +45,7 @@ async function go (billingBatch, billingPeriods) {
   }
 }
 
-async function _processBillingPeriods (billingPeriods, billingBatch, billingBatchId, resultOfReissuing) {
+async function _processBillingPeriods (billingPeriods, billingBatch, resultOfReissuing) {
   const accumulatedLicenceIds = []
 
   // We use `results` to check if any db changes have been made (which is indicated by a billing period being processed

--- a/app/services/billing/supplementary/reissue-invoice.service.js
+++ b/app/services/billing/supplementary/reissue-invoice.service.js
@@ -121,7 +121,6 @@ async function go (sourceInvoice, reissueBillingBatch) {
  * `pending`, at which point it returns.
  */
 async function _pauseUntilNotPending (billingBatchExternalId) {
-  // TODO: Do more complete unit testing for this
   let status
 
   do {
@@ -129,7 +128,7 @@ async function _pauseUntilNotPending (billingBatchExternalId) {
     // bombarding the CM with requests
     if (status) {
       // Create a new promise that resolves after 1000ms and wait until it's resolved before continuing
-      await new Promise(resolve => setTimeout(resolve, 1000))
+      await new Promise((resolve) => setTimeout(resolve, 1000))
     }
 
     const result = await ChargingModuleBillRunStatusService.go(billingBatchExternalId)

--- a/app/services/billing/supplementary/reissue-invoice.service.js
+++ b/app/services/billing/supplementary/reissue-invoice.service.js
@@ -246,7 +246,7 @@ async function _sendReissueRequest (billingBatchExternalId, invoiceExternalId) {
   }
 
   // The CM returns a few bits of info but we only need the id
-  return result.response.invoices.map((invoice) => {
+  return result.response.body.invoices.map((invoice) => {
     return invoice.id
   })
 }
@@ -263,7 +263,7 @@ async function _sendViewInvoiceRequest (billingBatch, reissueInvoiceId) {
     throw error
   }
 
-  return result.response.invoice
+  return result.response.body.invoice
 }
 
 module.exports = {

--- a/app/services/billing/supplementary/reissue-invoice.service.js
+++ b/app/services/billing/supplementary/reissue-invoice.service.js
@@ -164,9 +164,11 @@ function _generateTransaction (chargingModuleReissueTransaction, sourceTransacti
   }
 }
 
-// The Charging Module always returns a positive value for net amount whereas our db has a positive amount for debits
-// and a negative value for credits. We therefore use the CM charge value and credit flag to determine whether our net
-// amount should be positive or negative
+/**
+ * The Charging Module always returns a positive value for net amount whereas our db has a positive amount for debits
+ * and a negative value for credits. We therefore use the CM charge value and credit flag to determine whether our net
+ * amount should be positive or negative
+ */
 function _determineSignOfNetAmount (chargeValue, credit) {
   return credit ? -chargeValue : chargeValue
 }

--- a/app/services/charging-module/bill-run-status.service.js
+++ b/app/services/charging-module/bill-run-status.service.js
@@ -1,0 +1,29 @@
+'use strict'
+
+/**
+ * Sends a request to the Charging Module to view a bill run's status and returns the result
+ * @module ChargingModuleBillRunStatusService
+ */
+
+const ChargingModuleRequestLib = require('../../lib/charging-module-request.lib.js')
+
+/**
+ * Sends a request to the Charging Module to view a bill run's status and returns the result
+ *
+ * @param {string} billingBatchId The UUID of the bill run to view the status of. Note that this is the Charging
+ * Module's UUID, ie. what we call the "external ID"
+ *
+ * @returns {Object} result An object representing the result of the request
+ * @returns {boolean} result.succeeded Whether the request was successful
+ * @returns {Object} result.response Details of the bill run status if successful; or the error response if not
+ */
+async function go (billingBatchId) {
+  const path = `v3/wrls/bill-runs/${billingBatchId}/status`
+  const result = await ChargingModuleRequestLib.get(path)
+
+  return result
+}
+
+module.exports = {
+  go
+}

--- a/test/models/water/billing-transaction.model.test.js
+++ b/test/models/water/billing-transaction.model.test.js
@@ -110,5 +110,22 @@ describe('Billing Transaction model', () => {
         })
       ).to.not.reject()
     })
+
+    it('returns an object from a json field regardless of whether the inserted object was stringified first', async () => {
+      const objectTransaction = await BillingTransactionModel.query().insert({
+        ...BillingTransactionHelper.defaults(),
+        purposes: [{ test: 'TEST' }]
+      })
+      const stringifyTransaction = await BillingTransactionModel.query().insert({
+        ...BillingTransactionHelper.defaults(),
+        purposes: JSON.stringify([{ test: 'TEST' }])
+      })
+
+      const objectResult = await BillingTransactionModel.query().findById(objectTransaction.billingTransactionId)
+      const stringifyResult = await BillingTransactionModel.query().findById(stringifyTransaction.billingTransactionId)
+
+      expect(objectResult.purposes).to.equal([{ test: 'TEST' }])
+      expect(stringifyResult.purposes).to.equal([{ test: 'TEST' }])
+    })
   })
 })

--- a/test/models/water/billing-transaction.model.test.js
+++ b/test/models/water/billing-transaction.model.test.js
@@ -97,4 +97,18 @@ describe('Billing Transaction model', () => {
       })
     })
   })
+
+  describe('Inserting', () => {
+    // Objection doesn't normally allow us to insert an object directly into a json field unless we stringify it first.
+    // However if we define jsonAttributes in our model with the json fields then we don't need to stringify the object.
+    // This test is therefore to check whether jsonAttributes is correctly working.
+    it('can insert an object directly into a json field', async () => {
+      await expect(
+        BillingTransactionModel.query().insert({
+          ...BillingTransactionHelper.defaults(),
+          purposes: [{ test: 'TEST' }]
+        })
+      ).to.not.reject()
+    })
+  })
 })

--- a/test/services/billing/supplementary/fetch-invoices-to-be-reissued.service.test.js
+++ b/test/services/billing/supplementary/fetch-invoices-to-be-reissued.service.test.js
@@ -60,6 +60,7 @@ describe('Fetch Invoices To Be Reissued service', () => {
       expect(result).to.only.include([
         'billingInvoiceId',
         'externalId',
+        'financialYearEnding',
         'invoiceAccountId',
         'invoiceAccountNumber',
         'billingInvoiceLicences',

--- a/test/services/billing/supplementary/fetch-invoices-to-be-reissued.service.test.js
+++ b/test/services/billing/supplementary/fetch-invoices-to-be-reissued.service.test.js
@@ -58,6 +58,7 @@ describe('Fetch Invoices To Be Reissued service', () => {
       const result = Object.keys(billingInvoice[0])
 
       expect(result).to.only.include([
+        'billingInvoiceId',
         'externalId',
         'invoiceAccountId',
         'invoiceAccountNumber',

--- a/test/services/billing/supplementary/reissue-invoice.service.test.js
+++ b/test/services/billing/supplementary/reissue-invoice.service.test.js
@@ -60,7 +60,7 @@ const CHARGING_MODULE_VIEW_INVOICE_CREDIT_RESPONSE = {
   }
 }
 
-const CHARING_MODULE_VIEW_INVOICE_REISSUE_RESPONSE = {
+const CHARGING_MODULE_VIEW_INVOICE_REISSUE_RESPONSE = {
   invoice: {
     id: CHARGING_MODULE_REISSUE_INVOICE_RESPONSE.invoices[1].id,
     billRunId: ORIGINAL_BILLING_BATCH_EXTERNAL_ID,
@@ -83,7 +83,6 @@ const CHARING_MODULE_VIEW_INVOICE_REISSUE_RESPONSE = {
       }
     ]
   }
-
 }
 
 describe('Reissue invoice service', () => {
@@ -99,19 +98,19 @@ describe('Reissue invoice service', () => {
       .withArgs(reissueBillingBatch.externalId, INVOICE_EXTERNAL_ID)
       .resolves({
         succeeded: true,
-        response: CHARGING_MODULE_REISSUE_INVOICE_RESPONSE
+        response: { body: CHARGING_MODULE_REISSUE_INVOICE_RESPONSE }
       })
 
     Sinon.stub(ChargingModuleViewInvoiceService, 'go')
       .withArgs(reissueBillingBatch.externalId, CHARGING_MODULE_VIEW_INVOICE_CREDIT_RESPONSE.invoice.id)
       .resolves({
         succeeded: true,
-        response: CHARGING_MODULE_VIEW_INVOICE_CREDIT_RESPONSE
+        response: { body: CHARGING_MODULE_VIEW_INVOICE_CREDIT_RESPONSE }
       })
-      .withArgs(reissueBillingBatch.externalId, CHARING_MODULE_VIEW_INVOICE_REISSUE_RESPONSE.invoice.id)
+      .withArgs(reissueBillingBatch.externalId, CHARGING_MODULE_VIEW_INVOICE_REISSUE_RESPONSE.invoice.id)
       .resolves({
         succeeded: true,
-        response: CHARING_MODULE_VIEW_INVOICE_REISSUE_RESPONSE
+        response: { body: CHARGING_MODULE_VIEW_INVOICE_REISSUE_RESPONSE }
       })
 
     sourceInvoice = await BillingInvoiceHelper.add({

--- a/test/services/billing/supplementary/reissue-invoice.service.test.js
+++ b/test/services/billing/supplementary/reissue-invoice.service.test.js
@@ -143,12 +143,14 @@ describe('Reissue invoice service', () => {
 
     await BillingTransactionHelper.add({
       billingInvoiceLicenceId: sourceInvoiceLicences[0].billingInvoiceLicenceId,
-      externalId: INVOICE_LICENCE_1_TRANSACTION_ID
+      externalId: INVOICE_LICENCE_1_TRANSACTION_ID,
+      purposes: { test: 'TEST' }
     })
 
     await BillingTransactionHelper.add({
       billingInvoiceLicenceId: sourceInvoiceLicences[1].billingInvoiceLicenceId,
-      externalId: INVOICE_LICENCE_2_TRANSACTION_ID
+      externalId: INVOICE_LICENCE_2_TRANSACTION_ID,
+      purposes: { test: 'TEST' }
     })
 
     // Refresh sourceInvoice to include billing invoice licences and transactions, as expected by the service

--- a/test/services/billing/supplementary/reissue-invoice.service.test.js
+++ b/test/services/billing/supplementary/reissue-invoice.service.test.js
@@ -17,6 +17,7 @@ const BillingTransactionHelper = require('../../../support/helpers/water/billing
 const DatabaseHelper = require('../../../support/helpers/database.helper.js')
 
 // Things we need to stub
+const ChargingModuleBillRunStatusService = require('../../../../app/services/charging-module/bill-run-status.service.js')
 const ChargingModuleReissueInvoiceService = require('../../../../app/services/charging-module/reissue-invoice.service.js')
 const ChargingModuleViewInvoiceService = require('../../../../app/services/charging-module/view-invoice.service.js')
 
@@ -112,6 +113,15 @@ describe('Reissue invoice service', () => {
         succeeded: true,
         response: { body: CHARGING_MODULE_VIEW_INVOICE_REISSUE_RESPONSE }
       })
+
+    Sinon.stub(ChargingModuleBillRunStatusService, 'go').resolves({
+      succeeded: true,
+      response: {
+        body: {
+          status: 'initialised'
+        }
+      }
+    })
 
     sourceInvoice = await BillingInvoiceHelper.add({
       externalId: INVOICE_EXTERNAL_ID,

--- a/test/services/billing/supplementary/reissue-invoices.service.test.js
+++ b/test/services/billing/supplementary/reissue-invoices.service.test.js
@@ -74,7 +74,16 @@ describe('Reissue invoices service', () => {
         Sinon.stub(ReissueInvoiceService, 'go').resolves({
           billingInvoices: [BillingInvoiceModel.fromJson(BillingInvoiceHelper.defaults())],
           billingInvoiceLicences: [BillingInvoiceLicenceModel.fromJson(BillingInvoiceLicenceHelper.defaults())],
-          billingTransactions: [BillingTransactionModel.fromJson(BillingTransactionHelper.defaults())]
+          billingTransactions: [BillingTransactionModel.fromJson({
+            ...BillingTransactionHelper.defaults(),
+            purposes: [{
+              chargePurposeId: '01adfc33-4ba9-4215-bbe0-97014730991b',
+              abstractionPeriodEndDay: 31,
+              abstractionPeriodEndMonth: 3,
+              abstractionPeriodStartDay: 1,
+              abstractionPeriodStartMonth: 4
+            }]
+          })]
         })
       })
 

--- a/test/services/charging-module/bill-run-status.service.test.js
+++ b/test/services/charging-module/bill-run-status.service.test.js
@@ -1,0 +1,114 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { describe, it, beforeEach, afterEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Things we need to stub
+const ChargingModuleRequestLib = require('../../../app/lib/charging-module-request.lib.js')
+
+// Thing under test
+const ChargingModuleBillRunStatusService = require('../../../app/services/charging-module/bill-run-status.service.js')
+
+describe('Charging Module bill run status service', () => {
+  const billingBatchId = '2bbbe459-966e-4026-b5d2-2f10867bdddd'
+  const transactionData = { billingTransactionId: '2395429b-e703-43bc-8522-ce3f67507ffa' }
+
+  afterEach(() => {
+    Sinon.restore()
+  })
+
+  describe('when the service can get a bill run status', () => {
+    beforeEach(async () => {
+      Sinon.stub(ChargingModuleRequestLib, 'get').resolves({
+        succeeded: true,
+        response: {
+          info: {
+            gitCommit: '273604040a47e0977b0579a0fef0f09726d95e39',
+            dockerTag: 'ghcr.io/defra/sroc-charging-module-api:v0.19.0'
+          },
+          statusCode: 200,
+          body: {
+            status: 'initialised'
+          }
+        }
+      })
+    })
+
+    it('returns a `true` success status', async () => {
+      const result = await ChargingModuleBillRunStatusService.go(billingBatchId, transactionData)
+
+      expect(result.succeeded).to.be.true()
+    })
+
+    it('returns the bill run status in the `response`', async () => {
+      const result = await ChargingModuleBillRunStatusService.go(billingBatchId, transactionData)
+
+      expect(result.response.body.status).to.equal('initialised')
+    })
+  })
+
+  describe('when the service cannot create a transaction', () => {
+    describe('because the request did not return a 2xx/3xx response', () => {
+      beforeEach(async () => {
+        Sinon.stub(ChargingModuleRequestLib, 'get').resolves({
+          succeeded: false,
+          response: {
+            info: {
+              gitCommit: '273604040a47e0977b0579a0fef0f09726d95e39',
+              dockerTag: 'ghcr.io/defra/sroc-charging-module-api:v0.19.0'
+            },
+            statusCode: 401,
+            body: {
+              statusCode: 401,
+              error: 'Unauthorized',
+              message: 'Invalid JWT: Token format not valid',
+              attributes: { error: 'Invalid JWT: Token format not valid' }
+            }
+          }
+        })
+      })
+
+      it('returns a `false` success status', async () => {
+        const result = await ChargingModuleBillRunStatusService.go(billingBatchId, transactionData)
+
+        expect(result.succeeded).to.be.false()
+      })
+
+      it('returns the error in the `response`', async () => {
+        const result = await ChargingModuleBillRunStatusService.go(billingBatchId, transactionData)
+
+        expect(result.response.body.statusCode).to.equal(401)
+        expect(result.response.body.error).to.equal('Unauthorized')
+        expect(result.response.body.message).to.equal('Invalid JWT: Token format not valid')
+      })
+    })
+
+    describe('because the request attempt returned an error, for example, TimeoutError', () => {
+      beforeEach(async () => {
+        Sinon.stub(ChargingModuleRequestLib, 'get').resolves({
+          succeeded: false,
+          response: new Error("Timeout awaiting 'request' for 5000ms")
+        })
+      })
+
+      it('returns a `false` success status', async () => {
+        const result = await ChargingModuleBillRunStatusService.go(billingBatchId, transactionData)
+
+        expect(result.succeeded).to.be.false()
+      })
+
+      it('returns the error in the `response`', async () => {
+        const result = await ChargingModuleBillRunStatusService.go(billingBatchId, transactionData)
+
+        expect(result.response.statusCode).not.to.exist()
+        expect(result.response.body).not.to.exist()
+        expect(result.response.message).to.equal("Timeout awaiting 'request' for 5000ms")
+      })
+    })
+  })
+})


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4036

Reissuing failed QA. The following fixes have therefore been applied:

- After sending the reissue request to the CM, we wait for the bill run status to leave `pending` before proceeding;
- We ensure the correct data is being passed back from the CM;
- We pull some additional fields from the db for invoices to ensure the records are completed;
- We found that inserting transactions where some data is in object format would fail. This is because even though the field's datatype is `jsonb`, Objection expects us to stringify the data first. We initially explored doing this, however we found that Objection allows us to define JSON fields in the model (by adding a `jsonAttributes` getter) which means it will stringify the data for us if needed. We therefore update `BillingTransactionModel` to make use of this.