### PR TITLE
Fix reissuing ALCS invoice bug

### DIFF
--- a/app/services/billing/supplementary/fetch-invoices-to-be-reissued.service.js
+++ b/app/services/billing/supplementary/fetch-invoices-to-be-reissued.service.js
@@ -8,7 +8,7 @@
 const BillingInvoiceModel = require('../../../models/water/billing-invoice.model.js')
 
 /**
- * Takes a region and fetches billing invoices in that region marked for reissuing, along with their transactions
+ * Takes a region and fetches sroc billing invoices in that region marked for reissuing, along with their transactions
  *
  * @param {String} regionId The uuid of the region
  *
@@ -28,6 +28,7 @@ async function go (regionId) {
       .where('isFlaggedForRebilling', true)
       .joinRelated('billingBatch')
       .where('billingBatch.regionId', regionId)
+      .where('billingBatch.scheme', 'sroc')
       .withGraphFetched('billingInvoiceLicences.billingTransactions')
       .modifyGraph('billingInvoiceLicences', (builder) => {
         builder.select(

--- a/test/services/billing/supplementary/fetch-invoices-to-be-reissued.service.test.js
+++ b/test/services/billing/supplementary/fetch-invoices-to-be-reissued.service.test.js
@@ -101,6 +101,7 @@ describe('Fetch Invoices To Be Reissued service', () => {
         const result = await FetchInvoicesToBeReissuedService.go(billingBatch.regionId)
 
         expect(result).to.have.length(1)
+        expect(result[0].billingInvoiceId).to.equal(billingInvoice.billingInvoiceId)
       })
     })
   })

--- a/test/services/billing/supplementary/fetch-invoices-to-be-reissued.service.test.js
+++ b/test/services/billing/supplementary/fetch-invoices-to-be-reissued.service.test.js
@@ -22,7 +22,6 @@ const FetchInvoicesToBeReissuedService = require('../../../../app/services/billi
 describe('Fetch Invoices To Be Reissued service', () => {
   let billingBatch
   let billingInvoice
-  let alcsBillingInvoice
 
   beforeEach(async () => {
     await DatabaseHelper.clean()
@@ -31,15 +30,6 @@ describe('Fetch Invoices To Be Reissued service', () => {
     billingInvoice = await BillingInvoiceHelper.add({ billingBatchId: billingBatch.billingBatchId })
     const { billingInvoiceLicenceId } = await BillingInvoiceLicenceHelper.add({ billingInvoiceId: billingInvoice.billingInvoiceId })
     await BillingTransactionHelper.add({ billingInvoiceLicenceId })
-
-    // Set up a separate billing batch which we will manually patch to be alcs
-    const alcsBillingBatch = await BillingBatchHelper.add()
-    alcsBillingInvoice = await BillingInvoiceHelper.add({ billingBatchId: alcsBillingBatch.billingBatchId })
-    const { billingInvoiceLicenceId: alcsBillingInvoiceLicenceId } = await BillingInvoiceLicenceHelper.add({
-      billingInvoiceId: alcsBillingInvoice.billingInvoiceId
-    })
-    await BillingTransactionHelper.add({ billingInvoiceLicenceId: alcsBillingInvoiceLicenceId })
-    await alcsBillingBatch.$query().patch({ scheme: 'alcs' })
   })
 
   describe('when there are no billing invoices to be reissued', () => {
@@ -94,7 +84,15 @@ describe('Fetch Invoices To Be Reissued service', () => {
 
     describe('and there are alcs billing invoices to be reissued', () => {
       beforeEach(async () => {
-        await alcsBillingInvoice.$query().patch({ isFlaggedForRebilling: true })
+        const alcsBillingBatch = await BillingBatchHelper.add({ scheme: 'alcs' })
+        const alcsBillingInvoice = await BillingInvoiceHelper.add({
+          billingBatchId: alcsBillingBatch.billingBatchId,
+          isFlaggedForRebilling: true
+        })
+        const { billingInvoiceLicenceId: alcsBillingInvoiceLicenceId } = await BillingInvoiceLicenceHelper.add({
+          billingInvoiceId: alcsBillingInvoice.billingInvoiceId
+        })
+        await BillingTransactionHelper.add({ billingInvoiceLicenceId: alcsBillingInvoiceLicenceId })
       })
 
       it('returns only sroc billing invoices', async () => {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4036

Reissuing was confirmed working in our local environments but was continuing to fail in `dev`. When we checked the logs we realised that it was failing because it was fetching alcs invoices that were awaiting reissuing as well as sroc ones! This then causes an error to come back from the CM as it won't reissue an alcs invoice onto an sroc bill run.

We resolve this by updating `FetchInvoicesToBeReissuedService` to only fetch invoices linked to an sroc billing batch.