### PR TITLE
Improve reissuing error logging

### DIFF
--- a/app/services/billing/supplementary/reissue-invoice.service.js
+++ b/app/services/billing/supplementary/reissue-invoice.service.js
@@ -136,7 +136,7 @@ async function _pauseUntilNotPending (billingBatchExternalId) {
     if (!result.succeeded) {
       const error = new ExpandedError(
         'Charging Module reissue request failed',
-        { billingBatchExternalId }
+        { billingBatchExternalId, responseBody: result.response.body }
       )
 
       throw error
@@ -280,7 +280,11 @@ async function _sendReissueRequest (billingBatchExternalId, invoiceExternalId) {
   if (!result.succeeded) {
     const error = new ExpandedError(
       'Charging Module reissue request failed',
-      { billingBatchExternalId, invoiceExternalId }
+      {
+        billingBatchExternalId,
+        invoiceExternalId,
+        responseBody: result.response.body
+      }
     )
 
     throw error
@@ -298,7 +302,11 @@ async function _sendViewInvoiceRequest (billingBatch, reissueInvoiceId) {
   if (!result.succeeded) {
     const error = new ExpandedError(
       'Charging Module view invoice request failed',
-      { billingBatchExternalId: billingBatch.externalId, reissueInvoiceExternalId: reissueInvoiceId }
+      {
+        billingBatchExternalId: billingBatch.externalId,
+        reissueInvoiceExternalId: reissueInvoiceId,
+        responseBody: result.response.body
+      }
     )
 
     throw error

--- a/test/services/billing/supplementary/reissue-invoice.service.test.js
+++ b/test/services/billing/supplementary/reissue-invoice.service.test.js
@@ -254,7 +254,14 @@ describe('Reissue invoice service', () => {
       beforeEach(() => {
         ChargingModuleReissueInvoiceService.go.restore()
         Sinon.stub(ChargingModuleReissueInvoiceService, 'go').resolves({
-          succeeded: false, response: { body: 'RESPONSE_BODY' }
+          succeeded: false,
+          response: {
+            body: {
+              error: 'Conflict',
+              message: 'Invoice 2274cd48-2a61-4b73-a9c0-bc5696c5218d has already been rebilled.',
+              statusCode: 409
+            }
+          }
         })
       })
 
@@ -263,12 +270,19 @@ describe('Reissue invoice service', () => {
           .to.reject(Error, 'Charging Module reissue request failed')
       })
 
-      it('includes the billing batch and source invoice external ids and CM response body', async () => {
+      it('includes the billing batch and source invoice external ids', async () => {
         const errorResult = await expect(ReissueInvoiceService.go(sourceInvoice, reissueBillingBatch)).to.reject()
 
         expect(errorResult.billingBatchExternalId).to.equal(reissueBillingBatch.externalId)
         expect(errorResult.invoiceExternalId).to.equal(sourceInvoice.externalId)
-        expect(errorResult.responseBody).to.equal('RESPONSE_BODY')
+      })
+
+      it('includes the Charging Module response body', async () => {
+        const errorResult = await expect(ReissueInvoiceService.go(sourceInvoice, reissueBillingBatch)).to.reject()
+
+        expect(errorResult.responseBody.error).to.equal('Conflict')
+        expect(errorResult.responseBody.message).to.equal('Invoice 2274cd48-2a61-4b73-a9c0-bc5696c5218d has already been rebilled.')
+        expect(errorResult.responseBody.statusCode).to.equal(409)
       })
     })
 
@@ -276,7 +290,14 @@ describe('Reissue invoice service', () => {
       beforeEach(() => {
         ChargingModuleViewInvoiceService.go.restore()
         Sinon.stub(ChargingModuleViewInvoiceService, 'go').resolves({
-          succeeded: false, response: { body: 'RESPONSE_BODY' }
+          succeeded: false,
+          response: {
+            body: {
+              error: 'Conflict',
+              message: 'Invoice 2274cd48-2a61-4b73-a9c0-bc5696c5218d has already been rebilled.',
+              statusCode: 409
+            }
+          }
         })
       })
 
@@ -285,14 +306,21 @@ describe('Reissue invoice service', () => {
           .to.reject(Error, 'Charging Module view invoice request failed')
       })
 
-      it('includes the billing batch and reissue invoice external ids and CM response body', async () => {
+      it('includes the billing batch and reissue invoice external ids', async () => {
         const errorResult = await expect(ReissueInvoiceService.go(sourceInvoice, reissueBillingBatch)).to.reject()
 
         expect(errorResult.billingBatchExternalId).to.equal(reissueBillingBatch.externalId)
         // The error will be thrown on the first iteration over the invoices so we hardcode the check for the first
         // element's id
         expect(errorResult.reissueInvoiceExternalId).to.equal(CHARGING_MODULE_REISSUE_INVOICE_RESPONSE.invoices[0].id)
-        expect(errorResult.responseBody).to.equal('RESPONSE_BODY')
+      })
+
+      it('includes the Charging Module response body', async () => {
+        const errorResult = await expect(ReissueInvoiceService.go(sourceInvoice, reissueBillingBatch)).to.reject()
+
+        expect(errorResult.responseBody.error).to.equal('Conflict')
+        expect(errorResult.responseBody.message).to.equal('Invoice 2274cd48-2a61-4b73-a9c0-bc5696c5218d has already been rebilled.')
+        expect(errorResult.responseBody.statusCode).to.equal(409)
       })
     })
   })

--- a/test/services/billing/supplementary/reissue-invoice.service.test.js
+++ b/test/services/billing/supplementary/reissue-invoice.service.test.js
@@ -253,7 +253,9 @@ describe('Reissue invoice service', () => {
     describe('when sending the reissue request', () => {
       beforeEach(() => {
         ChargingModuleReissueInvoiceService.go.restore()
-        Sinon.stub(ChargingModuleReissueInvoiceService, 'go').resolves({ succeeded: false })
+        Sinon.stub(ChargingModuleReissueInvoiceService, 'go').resolves({
+          succeeded: false, response: { body: 'RESPONSE_BODY' }
+        })
       })
 
       it('throws an error', async () => {
@@ -261,18 +263,21 @@ describe('Reissue invoice service', () => {
           .to.reject(Error, 'Charging Module reissue request failed')
       })
 
-      it('includes the billing batch and source invoice external ids', async () => {
+      it('includes the billing batch and source invoice external ids and CM response body', async () => {
         const errorResult = await expect(ReissueInvoiceService.go(sourceInvoice, reissueBillingBatch)).to.reject()
 
         expect(errorResult.billingBatchExternalId).to.equal(reissueBillingBatch.externalId)
         expect(errorResult.invoiceExternalId).to.equal(sourceInvoice.externalId)
+        expect(errorResult.responseBody).to.equal('RESPONSE_BODY')
       })
     })
 
     describe('when viewing an invoice', () => {
       beforeEach(() => {
         ChargingModuleViewInvoiceService.go.restore()
-        Sinon.stub(ChargingModuleViewInvoiceService, 'go').resolves({ succeeded: false })
+        Sinon.stub(ChargingModuleViewInvoiceService, 'go').resolves({
+          succeeded: false, response: { body: 'RESPONSE_BODY' }
+        })
       })
 
       it('throws an error', async () => {
@@ -280,13 +285,14 @@ describe('Reissue invoice service', () => {
           .to.reject(Error, 'Charging Module view invoice request failed')
       })
 
-      it('includes the billing batch and reissue invoice external ids', async () => {
+      it('includes the billing batch and reissue invoice external ids and CM response body', async () => {
         const errorResult = await expect(ReissueInvoiceService.go(sourceInvoice, reissueBillingBatch)).to.reject()
 
         expect(errorResult.billingBatchExternalId).to.equal(reissueBillingBatch.externalId)
         // The error will be thrown on the first iteration over the invoices so we hardcode the check for the first
         // element's id
         expect(errorResult.reissueInvoiceExternalId).to.equal(CHARGING_MODULE_REISSUE_INVOICE_RESPONSE.invoices[0].id)
+        expect(errorResult.responseBody).to.equal('RESPONSE_BODY')
       })
     })
   })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4036

We found that checking the logs for reissuing errors caused by the Charging Module returning an error response wasn't as straightforward as it could be; instead of having all the info logged in one error, we had to find the separately-logged CM error response to see why the request errored. This change adds the response body to our logged error (as `responseBody`) so we don't need to go hunting for the reason for the error (eg. "Invoice has already been rebilled").