### PR TITLE
Identify Licences for 2 Part Tariff Annual Billing (SROC)

### DIFF
--- a/app/services/check/two-part.service.js
+++ b/app/services/check/two-part.service.js
@@ -5,14 +5,26 @@
  * @module SupplementaryDataService
  */
 
+const ChargeVersion = require('../../models/water/charge-version.model.js')
+const DetermineBillingPeriodsService = require('../billing/determine-billing-periods.service.js')
 const FetchRegionService = require('../billing/fetch-region.service.js')
 
 async function go (naldRegionId) {
   const region = await FetchRegionService.go(naldRegionId)
+  const billingPeriods = DetermineBillingPeriodsService.go()
 
-  return {
-    regionName: region.name
-  }
+  const billingPeriod = billingPeriods[1]
+
+  const licenceRefs = await ChargeVersion.query()
+    .select('licenceRef')
+    .innerJoinRelated('chargeElements')
+    .where('regionCode', naldRegionId)
+    .where('chargeVersions.scheme', 'sroc')
+    .where('startDate', '<=', billingPeriod.endDate)
+    .where('isSection127AgreementEnabled', true)
+    .whereNot('status', 'draft')
+
+  return [region.name, billingPeriods[1], licenceRefs]
 }
 
 module.exports = {

--- a/app/services/check/two-part.service.js
+++ b/app/services/check/two-part.service.js
@@ -24,7 +24,7 @@ async function go (naldRegionId) {
     .where('isSection127AgreementEnabled', true)
     .whereNot('status', 'draft')
 
-  return [region.name, billingPeriods[1], licenceRefs]
+  return [region.name, billingPeriod, licenceRefs]
 }
 
 module.exports = {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4038

2 Part Tariff Billing is split over 2 Annual events, the 1st part is based on Authorised volumes linked to Spray or Trickle irrigation, where a 2 part tariff agreement is present and provides a 50% discount on those elements as part of the Annual Billing process.

The first step in the process that this PR will cover is to identify the licences that need to be included in the bill run.   This should be any licence within the chosen region which has a valid charge version within the previous year where the 2PT indicator at Charge Reference level is set to yes.  ie If the Bill run triggered is for FY 22/23 then the charge version must be valid in the FY 21/22.