### PR TITLE
Fix 2PT query

### DIFF
--- a/app/services/check/two-part.service.js
+++ b/app/services/check/two-part.service.js
@@ -20,7 +20,7 @@ async function go (naldRegionId) {
     .where('chargeVersions.regionCode', naldRegionId)
     .where('chargeVersions.scheme', 'sroc')
     .where('chargeVersions.startDate', '<=', billingPeriod.endDate)
-    .where('chargeVersions:chargeElements.isSection127AgreementEnabled', true)
+    .whereJsonPath('chargeVersions:chargeElements.adjustments', '$.s127', '=', true)
     .whereNot('chargeVersions.status', 'draft')
     .withGraphFetched('chargeVersions.chargeElements.chargePurposes')
 


### PR DESCRIPTION
The query was checking the `chargeElements.isSection127AgreementEnabled` column to see if the charge version was a 2 Part Tarrif. This was the incorrect column, we should have been using the `chargeVersions:chargeElements.adjustments` column. This PR fixes that issue.