### PR TITLE
Fix broken process billing period unit test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,13 +65,13 @@ jobs:
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of sonarcloud analysis
 
-      # Before we do anything, check we haven't accidentally left any `describe.only()` or `it.only(` statements in the
-      # tests
-      #
-      # Reworking of https://stackoverflow.com/a/21788642/6117745
-      - name: Temporary tag check
-        run: |
-          ! grep -R 'describe.only(\|it.only(' test
+      # # Before we do anything, check we haven't accidentally left any `describe.only()` or `it.only(` statements in the
+      # # tests
+      # #
+      # # Reworking of https://stackoverflow.com/a/21788642/6117745
+      # - name: Temporary tag check
+      #   run: |
+      #     ! grep -R 'describe.only(\|it.only(' test
 
       # Our projects use .nvmrc files to specify the node version to use. We can read and then output it as the result
       # this step. Subsequent steps can then access the value

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,13 +65,13 @@ jobs:
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of sonarcloud analysis
 
-      # # Before we do anything, check we haven't accidentally left any `describe.only()` or `it.only(` statements in the
-      # # tests
-      # #
-      # # Reworking of https://stackoverflow.com/a/21788642/6117745
-      # - name: Temporary tag check
-      #   run: |
-      #     ! grep -R 'describe.only(\|it.only(' test
+      # Before we do anything, check we haven't accidentally left any `describe.only()` or `it.only(` statements in the
+      # tests
+      #
+      # Reworking of https://stackoverflow.com/a/21788642/6117745
+      - name: Temporary tag check
+        run: |
+          ! grep -R 'describe.only(\|it.only(' test
 
       # Our projects use .nvmrc files to specify the node version to use. We can read and then output it as the result
       # this step. Subsequent steps can then access the value

--- a/test/services/billing/supplementary/process-billing-period.service.test.js
+++ b/test/services/billing/supplementary/process-billing-period.service.test.js
@@ -209,7 +209,7 @@ describe.only('Process billing period service', () => {
               chargeVersions = chargeVersionData.chargeVersions
             })
 
-            it.only('returns false (bill run is empty)', async () => {
+            it('returns false (bill run is empty)', async () => {
               const result = await ProcessBillingPeriodService.go(billingBatch, billingPeriod, chargeVersions)
 
               expect(result).to.be.false()

--- a/test/services/billing/supplementary/process-billing-period.service.test.js
+++ b/test/services/billing/supplementary/process-billing-period.service.test.js
@@ -31,7 +31,7 @@ const SendBillingTransactionsService = require('../../../../app/services/billing
 // Thing under test
 const ProcessBillingPeriodService = require('../../../../app/services/billing/supplementary/process-billing-period.service.js')
 
-describe.only('Process billing period service', () => {
+describe('Process billing period service', () => {
   const billingPeriod = {
     startDate: new Date('2022-04-01'),
     endDate: new Date('2023-03-31')

--- a/test/services/billing/supplementary/process-billing-period.service.test.js
+++ b/test/services/billing/supplementary/process-billing-period.service.test.js
@@ -204,6 +204,9 @@ describe.only('Process billing period service', () => {
                 abstractionPeriodEndDay: 31,
                 abstractionPeriodEndMonth: 3
               })
+
+              const chargeVersionData = await FetchChargeVersionsService.go(licence.regionId, billingPeriod)
+              chargeVersions = chargeVersionData.chargeVersions
             })
 
             it.only('returns false (bill run is empty)', async () => {

--- a/test/services/billing/supplementary/process-billing-period.service.test.js
+++ b/test/services/billing/supplementary/process-billing-period.service.test.js
@@ -31,7 +31,7 @@ const SendBillingTransactionsService = require('../../../../app/services/billing
 // Thing under test
 const ProcessBillingPeriodService = require('../../../../app/services/billing/supplementary/process-billing-period.service.js')
 
-describe('Process billing period service', () => {
+describe.only('Process billing period service', () => {
   const billingPeriod = {
     startDate: new Date('2022-04-01'),
     endDate: new Date('2023-03-31')
@@ -206,7 +206,7 @@ describe('Process billing period service', () => {
               })
             })
 
-            it('returns false (bill run is empty)', async () => {
+            it.only('returns false (bill run is empty)', async () => {
               const result = await ProcessBillingPeriodService.go(billingBatch, billingPeriod, chargeVersions)
 
               expect(result).to.be.false()


### PR DESCRIPTION
We have found a unit test when run in isolation that breaks.

```
Process billing period service
  when the service is called
    and there are charge versions to process
      but none of them are billable
        because the charge version status is `superseded`
          and there are no previously billed transactions
            ✔ 326) returns false (bill run is empty) (5 ms)
```

It is just a copy & paste error. The `beforeEach()` block being used is missing a couple of lines of code that were overlooked when the block was copied.

Because `chargeVersions` is declared outside this test, as long as other tests run it is getting populated. But if the test is run in isolation it never gets set hence the error.