### PR TITLE
Include charge category in 2PT matching results

### DIFF
--- a/app/services/check/two-part.service.js
+++ b/app/services/check/two-part.service.js
@@ -54,7 +54,7 @@ async function _fetchChargeVersions (billingPeriod, naldRegionId) {
       builder.whereJsonPath('chargeElements.adjustments', '$.s127', '=', true)
     })
     .withGraphFetched('chargeElements.billingChargeCategory')
-    .modifyGraph('chargeElements.billingChargeCategory', builder => {
+    .modifyGraph('chargeElements.billingChargeCategory', (builder) => {
       builder.select([
         'reference',
         'shortDescription'

--- a/app/services/check/two-part.service.js
+++ b/app/services/check/two-part.service.js
@@ -53,6 +53,13 @@ async function _fetchChargeVersions (billingPeriod, naldRegionId) {
     .modifyGraph('chargeVersions.chargeElements', (builder) => {
       builder.whereJsonPath('chargeElements.adjustments', '$.s127', '=', true)
     })
+    .withGraphFetched('chargeElements.billingChargeCategory')
+    .modifyGraph('chargeElements.billingChargeCategory', builder => {
+      builder.select([
+        'reference',
+        'shortDescription'
+      ])
+    })
     .withGraphFetched('chargeElements.chargePurposes.purposesUse')
 
   return chargeVersions


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4046

One thing we are struggling with when checking the results from the endpoint is we cannot see the charge category, for example, **4.6.24**.

This change updates the 2PT matching service to fetch the linked record so we can include it in the results.