### PR TITLE
Add friendly formatting to two-part tariff endpoint

### DIFF
--- a/app/controllers/check/check.controller.js
+++ b/app/controllers/check/check.controller.js
@@ -11,7 +11,7 @@ const CheckTwoPartService = require('../../services/check/two-part.service.js')
 
 async function twoPart (request, h) {
   try {
-    const result = await CheckTwoPartService.go(request.params.naldRegionId)
+    const result = await CheckTwoPartService.go(request.params.naldRegionId, request.params.format)
 
     return h.response(result).code(200)
   } catch (error) {

--- a/app/routes/check.routes.js
+++ b/app/routes/check.routes.js
@@ -5,7 +5,7 @@ const CheckController = require('../controllers/check/check.controller.js')
 const routes = [
   {
     method: 'GET',
-    path: '/check/two-part/{naldRegionId}',
+    path: '/check/two-part/{naldRegionId}/{format?}',
     handler: CheckController.twoPart,
     options: {
       description: 'Used by the delivery team to check the SROC 2PT billing logic',

--- a/app/services/check/two-part.service.js
+++ b/app/services/check/two-part.service.js
@@ -12,7 +12,7 @@ const ChargeVersionModel = require('../../models/water/charge-version.model.js')
 const DetermineBillingPeriodsService = require('../billing/determine-billing-periods.service.js')
 const ReturnModel = require('../../models/returns/return.model.js')
 
-async function go (naldRegionId) {
+async function go (naldRegionId, format = 'friendly') {
   const billingPeriods = DetermineBillingPeriodsService.go()
 
   const billingPeriod = billingPeriods[1]
@@ -23,7 +23,16 @@ async function go (naldRegionId) {
     await _fetchAndApplyReturns(billingPeriod, chargeVersion)
   }
 
-  return _response(chargeVersions)
+  const matchedChargeVersions = _matchChargeVersions(chargeVersions)
+
+  switch (format) {
+    case 'friendly':
+      return _friendlyResponse(matchedChargeVersions)
+    case 'raw':
+      return matchedChargeVersions
+    default:
+      return { error: `Unknown format type ${format}` }
+  }
 }
 
 async function _fetchChargeVersions (billingPeriod, naldRegionId) {
@@ -95,7 +104,7 @@ function _extractPurposeUseLegacyIds (chargeElement) {
   })
 }
 
-function _response (chargeVersions) {
+function _matchChargeVersions (chargeVersions) {
   const allLicenceIds = chargeVersions.map((chargeVersion) => {
     return chargeVersion.licenceId
   })
@@ -113,6 +122,10 @@ function _response (chargeVersions) {
       chargeVersions: matchedChargeVersions
     }
   })
+}
+
+function _friendlyResponse (_matchedChargeVersions) {
+  return { hello: 'world' }
 }
 
 module.exports = {

--- a/app/services/check/two-part.service.js
+++ b/app/services/check/two-part.service.js
@@ -32,7 +32,7 @@ async function go (naldRegionId, format = 'friendly') {
       return matchedChargeVersions
     default:
       // TODO: consider throwing a Boom error here
-      return { error: `Unknown format type ${format}` }
+      return { error: `Invalid format ${format}` }
   }
 }
 

--- a/app/services/check/two-part.service.js
+++ b/app/services/check/two-part.service.js
@@ -31,6 +31,7 @@ async function go (naldRegionId, format = 'friendly') {
     case 'raw':
       return matchedChargeVersions
     default:
+      // TODO: consider throwing a Boom error here
       return { error: `Unknown format type ${format}` }
   }
 }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4046

We update our two-part tariff endpoint to output data in a friendlier format, optionally allowing us to view the raw data if specified.

The endpoint is still `/check/two-part/{region}` but it now takes an optional `/{format}` path parameter, eg `/check/two-part/1/raw`. We default to `friendly` output if nothing is specified, which is currently a simple `{ "hello": "world" }` response but will ultimately be in a format similar to the UI. `raw` format simply shows the end result of the db queries and matching without any further changes. Any other format value returns an error response.