### PR TITLE
Add timing to 2PT matching service

### DIFF
--- a/app/services/check/two-part.service.js
+++ b/app/services/check/two-part.service.js
@@ -13,6 +13,8 @@ const DetermineBillingPeriodsService = require('../billing/determine-billing-per
 const ReturnModel = require('../../models/returns/return.model.js')
 
 async function go (naldRegionId, format = 'friendly') {
+  const startTime = process.hrtime.bigint()
+
   const billingPeriods = DetermineBillingPeriodsService.go()
 
   const billingPeriod = billingPeriods[1]
@@ -24,6 +26,8 @@ async function go (naldRegionId, format = 'friendly') {
   }
 
   const matchedChargeVersions = _matchChargeVersions(chargeVersions)
+
+  _calculateAndLogTime(startTime)
 
   switch (format) {
     case 'friendly':
@@ -127,6 +131,14 @@ function _matchChargeVersions (chargeVersions) {
 
 function _friendlyResponse (_matchedChargeVersions) {
   return { hello: 'world' }
+}
+
+function _calculateAndLogTime (startTime) {
+  const endTime = process.hrtime.bigint()
+  const timeTakenNs = endTime - startTime
+  const timeTakenMs = timeTakenNs / 1000000n
+
+  global.GlobalNotifier.omg('Two part tariff matching complete', { timeTakenMs })
 }
 
 module.exports = {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4046

We believe we have the matching algorithm to a point that covers all examples we have been asked to meet so far. We're also confident it will meet any new ones thrown at us!

So, if and when we do make changes we want to make sure we retain its current performance (5 secs to match _all_ 2PT licences in Anglian; approximately 2,000).

To help us do that we are adding timing to the `TwoPartService` so we can keep an eye on it in the logs as we make further changes.