### PR TITLE
Fix logging of unhandled errors

### DIFF
--- a/app/plugins/error-pages.plugin.js
+++ b/app/plugins/error-pages.plugin.js
@@ -21,8 +21,8 @@ const ErrorPagesPlugin = {
         const { response } = request
 
         // By adding `plugins: { errorPages: { plainOutput: true }}` to a route's `options:` property you can control
-        // whether we display our error handling pages or not. This is handy for API only where we would not want an
-        // error page to be returned as the response
+        // whether we display our error handling pages or not. This is handy for API only pages where we would not want
+        // an error page to be returned as the response
         const { errorPages: pluginSettings } = request.route.settings.plugins
 
         // Whether we purposely return a Boom error in our controllers or not, exceptions thrown by the controllers are
@@ -34,13 +34,7 @@ const ErrorPagesPlugin = {
             return h.view('404').code(statusCode)
           }
 
-          request.app.notifier.omfg(
-            response.message,
-            {
-              statusCode,
-              stack: response.data ? response.data.stack : response.stack
-            }
-          )
+          request.app.notifier.omfg(response.message, {}, response)
 
           return h.view('500').code(statusCode)
         }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4083

Whilst investigating an issue with an erroring SROC Supplementary bill run we observed that when the error is logged the stack trace we get isn't beneficial.

To replicate this, we altered the `InfoService` which is called by the controller on `/health/info` with this

```javascript
async function go () {
  const boomBoom = undefined
  console.log(boomBoom.boom)

  // ...
}
```

Hitting the endpoint then causes an unhandled exception to be thrown. As expected, the user is redirected to our error page. But this is what we get for the log message.

```
[08:23:49.494] ERROR (6202): Cannot read properties of undefined (reading 'boom')
statusCode: 500
stack: "TypeError: Cannot read properties of undefined (reading 'boom')\n    at Object.go (/home/repos/water-abstraction-system/app/services/health/info.service.js:28:24)\n    at index (/home/repos/water-abstraction-system/app/controllers/health/info.controller.js:11:38)\n    at exports.Manager.execute (/home/repos/water-abstraction-system/node_modules/@hapi/hapi/lib/toolkit.js:57:29)\n    at Object.internals.handler (/home/repos/water-abstraction-system/node_modules/@hapi/hapi/lib/handler.js:46:48)\n    at exports.execute (/home/repos/water-abstraction-system/node_modules/@hapi/hapi/lib/handler.js:31:36)\n    at Request._lifecycle (/home/repos/water-abstraction-system/node_modules/@hapi/hapi/lib/request.js:370:68)\n    at processTicksAndRejections (node:internal/process/task_queues:96:5)\n    at async Request._execute (/home/repos/water-abstraction-system/node_modules/@hapi/hapi/lib/request.js:280:9)"
req: {
  "id": "1692001429489:852a235f4312:6202:llalyie0:10000"
}
err: {
  "type": "Error",
  "message": "Cannot read properties of undefined (reading 'boom')",
  "stack":
      Error: Cannot read properties of undefined (reading 'boom')
          at RequestNotifierLib.omfg (/home/repos/water-abstraction-system/app/lib/base-notifier.lib.js:92:15)
          at /home/repos/water-abstraction-system/app/plugins/error-pages.plugin.js:37:32
          at exports.Manager.execute (/home/repos/water-abstraction-system/node_modules/@hapi/hapi/lib/toolkit.js:57:29)
          at Request._invoke (/home/repos/water-abstraction-system/node_modules/@hapi/hapi/lib/request.js:397:55)
          at Request._postCycle (/home/repos/water-abstraction-system/node_modules/@hapi/hapi/lib/request.js:468:86)
          at Request._reply (/home/repos/water-abstraction-system/node_modules/@hapi/hapi/lib/request.js:447:20)
          at Request._execute (/home/repos/water-abstraction-system/node_modules/@hapi/hapi/lib/request.js:281:14)
          at processTicksAndRejections (node:internal/process/task_queues:96:5)
}
```

As you can see, `InfoService` is not mentioned anywhere. This makes it hard to track down exactly where an issue arose. This change fixes the error logging to ensure the stack trace points to where the error occurred, as in this example

```
[08:44:50.463] ERROR (6238): Cannot read properties of undefined (reading 'boom')
    req: {
      "id": "1692002690453:852a235f4312:6238:llamjgdj:10000"
    }
    err: {
      "type": "TypeError",
      "message": "Cannot read properties of undefined (reading 'boom')",
      "stack":
          TypeError: Cannot read properties of undefined (reading 'boom')
              at Object.go (/home/repos/water-abstraction-system/app/services/health/info.service.js:28:24)
              at index (/home/repos/water-abstraction-system/app/controllers/health/info.controller.js:11:38)
              at exports.Manager.execute (/home/repos/water-abstraction-system/node_modules/@hapi/hapi/lib/toolkit.js:57:29)
              at Object.internals.handler (/home/repos/water-abstraction-system/node_modules/@hapi/hapi/lib/handler.js:46:48)
              at exports.execute (/home/repos/water-abstraction-system/node_modules/@hapi/hapi/lib/handler.js:31:36)
              at Request._lifecycle (/home/repos/water-abstraction-system/node_modules/@hapi/hapi/lib/request.js:370:68)
              at processTicksAndRejections (node:internal/process/task_queues:96:5)
              at async Request._execute (/home/repos/water-abstraction-system/node_modules/@hapi/hapi/lib/request.js:280:9)
      "isBoom": true,
      "isServer": true,
      "data": null,
      "output": {
        "statusCode": 500,
        "payload": {
          "statusCode": 500,
          "error": "Internal Server Error",
          "message": "An internal server error occurred"
        },
        "headers": {}
      },
      "isDeveloperError": true
    }
```