### PR TITLE
Get Return Status as part of Matching Algorithm

### DIFF
--- a/app/services/check/two-part.service.js
+++ b/app/services/check/two-part.service.js
@@ -91,14 +91,17 @@ async function _fetchAndApplyReturns (billingPeriod, chargeVersion) {
 
   for (const chargeElement of chargeElements) {
     const { chargePurposes } = chargeElement
+
     for (const chargePurpose of chargePurposes) {
       const legacyId = chargePurpose.purposesUse.legacyId
+
       chargePurpose.returns = await ReturnModel.query()
         .select([
           'returnId',
           'returnRequirement',
           'startDate',
           'endDate',
+          'status',
           'metadata'
         ])
         .where('licenceRef', licenceRef)
@@ -108,6 +111,10 @@ async function _fetchAndApplyReturns (billingPeriod, chargeVersion) {
         .where('endDate', '>=', billingPeriod.startDate)
         .whereJsonPath('metadata', '$.isTwoPartTariff', '=', true)
         .where(ref('metadata:purposes[0].tertiary.code').castInt(), legacyId)
+
+      chargePurpose.returnStatus = chargePurpose.returns.map((matchedReturn) => {
+        return matchedReturn.status
+      })
     }
   }
 }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4081

As a billing and data user, I need the status of the returns to be assessed.

Once the charge element is matched to a return, the next step is to assess the status of the return, so that the relevant volumes and status can be recorded or error recorded.

This PR adds a new `returnStatus` array to the `chargePurpose` object displaying the status of the returns matched to that purpose via the `legacyId`.