### PR TITLE
Amend 2PT friendly response following changes

### DIFF
--- a/app/services/check/friendly-response.service.js
+++ b/app/services/check/friendly-response.service.js
@@ -66,6 +66,7 @@ function _formatFriendlyChargeReferences (chargeReferences, chargeElements) {
       eiucRegion,
       isRestrictedSource,
       loss,
+      returns,
       source,
       volume,
       waterModel
@@ -89,9 +90,11 @@ function _formatFriendlyChargeReferences (chargeReferences, chargeElements) {
       eiucRegion,
       additionalCharges: formattedAdditionalCharges,
       adjustments: formattedAdjustments,
-      chargeElements: []
+      chargeElements: [],
+      returns: []
     }
 
+    _formatFriendlyReturns(friendlyChargeReference.returns, returns)
     _formatFriendlyChargeElements(friendlyChargeReference.chargeElements, chargePurposes)
 
     chargeReferences.push(friendlyChargeReference)
@@ -130,9 +133,6 @@ function _formatFriendlyChargeElements (chargeElements, chargePurposes) {
 
     friendlyChargeElement.legacyId = purposesUse.legacyId
     friendlyChargeElement.returnStatuses = returnStatus
-    friendlyChargeElement.returns = []
-
-    _formatFriendlyReturns(friendlyChargeElement.returns, chargePurpose.returns)
 
     chargeElements.push(friendlyChargeElement)
   })

--- a/app/services/check/friendly-response.service.js
+++ b/app/services/check/friendly-response.service.js
@@ -9,6 +9,7 @@ const { formatAbstractionPeriod, formatLongDate } = require('../../presenters/ba
 
 function go (billingPeriod, matchedChargeVersions) {
   const response = {
+    note: 'This response aims to match the UI. Note this means the entity names and structure DO NOT match what is in the DB.',
     billingPeriod: {
       startDate: formatLongDate(billingPeriod.startDate),
       endDate: formatLongDate(billingPeriod.endDate)

--- a/app/services/check/friendly-response.service.js
+++ b/app/services/check/friendly-response.service.js
@@ -28,6 +28,7 @@ function _formatFriendlyLicences (licences, matchedChargeVersions) {
     const friendlyLicence = {
       id: licenceId,
       licenceRef,
+      returnsStatuses: chargeVersions[0].returnStatuses,
       chargeInformations: []
     }
 
@@ -110,7 +111,6 @@ function _formatFriendlyChargeElements (chargeElements, chargePurposes) {
       isSection127AgreementEnabled,
       loss,
       purposesUse,
-      returnStatus,
       timeLimitedStartDate,
       timeLimitedEndDate,
       abstractionPeriodEndDay: endDay,
@@ -132,7 +132,6 @@ function _formatFriendlyChargeElements (chargeElements, chargePurposes) {
     }
 
     friendlyChargeElement.legacyId = purposesUse.legacyId
-    friendlyChargeElement.returnStatuses = returnStatus
 
     chargeElements.push(friendlyChargeElement)
   })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4081

After the changes made in [Get Return Status as part of Matching Algorithm](https://github.com/DEFRA/water-abstraction-system/pull/360) we need to update the 'friendly' response the two-part tariff `/check` endpoint returns.

Namely, matched returns have been moved back to be assigned against the matching charge element (charge reference in the friendly response). And the return statuses are now a distinct array of statuses for all returns matched within a charge version (charge information).