### PR TITLE
Determine returns matching status for licence

### DIFF
--- a/app/services/check/friendly-response.service.js
+++ b/app/services/check/friendly-response.service.js
@@ -24,12 +24,13 @@ function go (billingPeriod, matchedChargeVersions) {
 
 function _formatFriendlyLicences (licences, matchedChargeVersions) {
   matchedChargeVersions.forEach((matchedChargeVersion) => {
-    const { licenceId, licenceRef, chargeVersions } = matchedChargeVersion
+    const { licenceId, licenceRef, chargeVersions, returnsStatuses, returnsReady } = matchedChargeVersion
 
     const friendlyLicence = {
       id: licenceId,
       licenceRef,
-      returnsStatuses: chargeVersions[0].returnStatuses,
+      returnsStatuses,
+      returnsReady,
       chargeInformations: []
     }
 

--- a/app/services/check/two-part.service.js
+++ b/app/services/check/two-part.service.js
@@ -124,16 +124,16 @@ async function _fetchAndApplyReturns (billingPeriod, chargeVersion) {
     cumulativeReturnStatuses.push(...chargeElementReturnStatuses)
   }
 
-  chargeVersion.returnStatuses = [...new Set(cumulativeReturnStatuses)]
+  chargeVersion.returnsStatuses = [...new Set(cumulativeReturnStatuses)]
 
   if (
-    chargeVersion.returnStatuses.includes('received', 'void') |
+    chargeVersion.returnsStatuses.includes('received', 'void') |
     returnsUnderQuery |
-    chargeVersion.returnStatuses.length === 0
+    chargeVersion.returnsStatuses.length === 0
   ) {
-    chargeVersion.returnsMatchingStatus = 'error'
+    chargeVersion.returnsReady = false
   } else {
-    chargeVersion.returnsMatchingStatus = 'ready'
+    chargeVersion.returnsReady = true
   }
 }
 
@@ -155,22 +155,22 @@ function _matchChargeVersions (chargeVersions) {
       return chargeVersion.licenceId === uniqueLicenceId
     })
 
-    const chargeVersionreturnStatuses = []
-    let returnsMatchingStatus = 'error'
+    const chargeVersionReturnsStatuses = []
+    let returnsReady = false
 
     for (const matchedChargeVersion of matchedChargeVersions) {
-      chargeVersionreturnStatuses.push(...matchedChargeVersion.returnStatuses)
+      chargeVersionReturnsStatuses.push(...matchedChargeVersion.returnsStatuses)
 
-      if (matchedChargeVersion.returnsMatchingStatus === 'ready') {
-        returnsMatchingStatus = 'ready'
+      if (matchedChargeVersion.returnsReady) {
+        returnsReady = true
       }
     }
 
     return {
       licenceId: uniqueLicenceId,
       licenceRef: matchedChargeVersions[0].licenceRef,
-      returnsMatchingStatus,
-      returnStatuses: [...new Set(chargeVersionreturnStatuses)],
+      returnsReady,
+      returnsStatuses: [...new Set(chargeVersionReturnsStatuses)],
       chargeVersions: matchedChargeVersions
     }
   })

--- a/app/services/check/two-part.service.js
+++ b/app/services/check/two-part.service.js
@@ -126,10 +126,14 @@ async function _fetchAndApplyReturns (billingPeriod, chargeVersion) {
 
   chargeVersion.returnStatuses = [...new Set(cumulativeReturnStatuses)]
 
-  if (chargeVersion.returnStatuses.includes('completed', 'due') && !returnsUnderQuery) {
-    chargeVersion.returnsMatchingStatus = 'ready'
-  } else {
+  if (
+    chargeVersion.returnStatuses.includes('received', 'void') |
+    returnsUnderQuery |
+    chargeVersion.returnStatuses.length === 0
+  ) {
     chargeVersion.returnsMatchingStatus = 'error'
+  } else {
+    chargeVersion.returnsMatchingStatus = 'ready'
   }
 }
 

--- a/app/services/check/two-part.service.js
+++ b/app/services/check/two-part.service.js
@@ -151,9 +151,22 @@ function _matchChargeVersions (chargeVersions) {
       return chargeVersion.licenceId === uniqueLicenceId
     })
 
+    const chargeVersionreturnStatuses = []
+    let returnsMatchingStatus = 'error'
+
+    for (const matchedChargeVersion of matchedChargeVersions) {
+      chargeVersionreturnStatuses.push(...matchedChargeVersion.returnStatuses)
+
+      if (matchedChargeVersion.returnsMatchingStatus === 'ready') {
+        returnsMatchingStatus = 'ready'
+      }
+    }
+
     return {
       licenceId: uniqueLicenceId,
       licenceRef: matchedChargeVersions[0].licenceRef,
+      returnsMatchingStatus,
+      returnStatuses: [...new Set(chargeVersionreturnStatuses)],
       chargeVersions: matchedChargeVersions
     }
   })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4079

This PR will add a new `returnsMatchingStatus` data item to the Two Part Tariff algorithms output. This is calculated as follows:
- No matching returns then mark as `error`
- A return status is `UNDER QUERY` then mark as `error` (this is a boolean in the `returns` table)
- A return status is `NOT KEYED` then mark as `error` (assumption made this is the `received` status in the `returns` table)
- A return status is `DUE` then  mark as `ready`
- A return status is `COMPLETE` then mark as `ready`

There is also a possible return status of `void`, this will also mark as `error`.