### PR TITLE
Handle returns without alias in friendly response

### DIFF
--- a/app/services/check/friendly-response.service.js
+++ b/app/services/check/friendly-response.service.js
@@ -147,7 +147,7 @@ function _formatFriendlyReturns (returns, matchedReturns) {
     const friendlyReturn = {
       id: returnId,
       siteDescription: _titleCaseAllWords(metadata.description),
-      purpose: _titleCaseAllWords(metadata.purposes[0].alias),
+      purpose: _formatPurpose(metadata.purposes[0]),
       returnPeriod: `${formatLongDate(startDate)} to ${formatLongDate(endDate)}`,
       abstractionPeriod: formatAbstractionPeriod(periodStartDay, periodStartMonth, periodEndDay, periodEndMonth),
       twoPartTariff: metadata.isTwoPartTariff,
@@ -212,17 +212,12 @@ function _formatAdjustments (adjustments) {
   return friendlyAdjustments
 }
 
-function _titleCaseAllWords (stringToBeTitleCased) {
-  const lowercaseWords = stringToBeTitleCased.toLowerCase().split(' ')
+function _formatPurpose (purpose) {
+  if (purpose.alias) {
+    return _titleCaseAllWords(purpose.alias)
+  }
 
-  const titleCaseWords = lowercaseWords.reduce((words, lowercaseWord) => {
-    const titleCasedWord = `${lowercaseWord[0].toUpperCase()}${lowercaseWord.slice(1)}`
-    words.push(titleCasedWord)
-
-    return words
-  }, [])
-
-  return titleCaseWords.join(' ')
+  return _titleCaseAllWords(purpose.tertiary.description)
 }
 
 function _formatTimeLimit (startDate, endDate) {
@@ -239,6 +234,19 @@ function _formatWaterAvailability (isRestrictedSource) {
   }
 
   return 'Available'
+}
+
+function _titleCaseAllWords (stringToBeTitleCased) {
+  const lowercaseWords = stringToBeTitleCased.toLowerCase().split(' ')
+
+  const titleCaseWords = lowercaseWords.reduce((words, lowercaseWord) => {
+    const titleCasedWord = `${lowercaseWord[0].toUpperCase()}${lowercaseWord.slice(1)}`
+    words.push(titleCasedWord)
+
+    return words
+  }, [])
+
+  return titleCaseWords.join(' ')
 }
 
 module.exports = {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4046

We found in testing that some return records do not have an alias which we assumed all did. After checking what the UI does in these cases we found it just displays the description against the `nald.purposes[0].tertiary` object in the `metadata` as a fallback.

This updates the 'friendly' response to handle it.