### PR TITLE
Handle return descriptions with double spaces

### DIFF
--- a/app/services/check/friendly-response.service.js
+++ b/app/services/check/friendly-response.service.js
@@ -241,8 +241,11 @@ function _titleCaseAllWords (stringToBeTitleCased) {
   const lowercaseWords = stringToBeTitleCased.toLowerCase().split(' ')
 
   const titleCaseWords = lowercaseWords.reduce((words, lowercaseWord) => {
-    const titleCasedWord = `${lowercaseWord[0].toUpperCase()}${lowercaseWord.slice(1)}`
-    words.push(titleCasedWord)
+    // If stringToBeTitleCased contains a double space it will cause the title casing to crash
+    if (!lowercaseWord.trim() === '') {
+      const titleCasedWord = `${lowercaseWord[0].toUpperCase()}${lowercaseWord.slice(1)}`
+      words.push(titleCasedWord)
+    }
 
     return words
   }, [])


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4046

When testing the returns matching and using the 'friendly' output an error was reported. After some investigation we tracked the issue to a return with a description that included a double space. It was causing the `_titleCaseAllWords()` function to implode.

This change updates the function to handle this scenario.