### PR TITLE
Remove unnecessary async

### DIFF
--- a/app/controllers/root.controller.js
+++ b/app/controllers/root.controller.js
@@ -5,7 +5,7 @@
  * @module RootController
  */
 
-async function index (_request, _h) {
+function index (_request, _h) {
   return { status: 'alive' }
 }
 module.exports = {


### PR DESCRIPTION
While working on updating all repos `/status` endpoints to only return a static response I noticed that the controller for this endpoint is `async` when it doesn't need to be. I've therefore removed the `async` from the function that returns the static response.