### PR TITLE
Add disinfect plugin to sanitize payloads

### DIFF
--- a/app/plugins/disinfect.plugin.js
+++ b/app/plugins/disinfect.plugin.js
@@ -1,0 +1,19 @@
+'use strict'
+
+/**
+ * Plugin that handles 'cleaning' payloads of empty or null properties, extraneous whitespace and any malicious content
+ * @module AirbrakePlugin
+ */
+
+const Disinfect = require('disinfect')
+
+const DisinfectPlugin = {
+  plugin: Disinfect,
+  options: {
+    deleteEmpty: true,
+    deleteWhitespace: true,
+    disinfectPayload: true
+  }
+}
+
+module.exports = DisinfectPlugin

--- a/app/server.js
+++ b/app/server.js
@@ -5,6 +5,7 @@ const Hapi = require('@hapi/hapi')
 const AirbrakePlugin = require('./plugins/airbrake.plugin.js')
 const BlippPlugin = require('./plugins/blipp.plugin.js')
 const ChargingModuleTokenCachePlugin = require('./plugins/charging-module-token-cache.plugin.js')
+const DisinfectPlugin = require('./plugins/disinfect.plugin.js')
 const ErrorPagesPlugin = require('./plugins/error-pages.plugin.js')
 const GlobalHapiServerMethodsPlugin = require('./plugins/global-hapi-server-methods.plugin.js')
 const GlobalNotifierPlugin = require('./plugins/global-notifier.plugin.js')
@@ -29,6 +30,7 @@ const registerPlugins = async (server) => {
   await server.register(RequestNotifierPlugin)
   await server.register(ViewsPlugin)
   await server.register(GlobalHapiServerMethodsPlugin)
+  await server.register(DisinfectPlugin)
 
   // Register non-production plugins
   if (ServerConfig.environment === 'development') {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@hapi/vision": "^7.0.2",
         "bcryptjs": "^2.4.3",
         "blipp": "^4.0.2",
+        "disinfect": "^2.0.0",
         "dotenv": "^16.3.1",
         "got": "^12.5.3",
         "govuk-frontend": "^4.7.0",
@@ -2855,6 +2856,11 @@
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
     },
+    "node_modules/async": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
+      "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -3460,6 +3466,25 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/disinfect": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/disinfect/-/disinfect-2.0.0.tgz",
+      "integrity": "sha512-qPQ7fdOBEqBiHJWx7Hc53z2/GKiC6YjOfmG4+rhBKbVqgHYo7qrrn2UygCNU31xOKBeSOmUpZWfvjsEplM6jHw==",
+      "dependencies": {
+        "@hapi/hoek": "^10.0.1",
+        "async": "^3.2.4",
+        "joi": "^17.7.0",
+        "sanitizer": "^0.1.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/disinfect/node_modules/@hapi/hoek": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-10.0.1.tgz",
+      "integrity": "sha512-CvlW7jmOhWzuqOqiJQ3rQVLMcREh0eel4IBnxDx2FAcK8g7qoJRQK4L1CPBASoCY6y8e6zuCy3f2g+HWdkzcMw=="
     },
     "node_modules/doctrine": {
       "version": "3.0.0",
@@ -6893,6 +6918,11 @@
         "node": ">=10"
       }
     },
+    "node_modules/sanitizer": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/sanitizer/-/sanitizer-0.1.3.tgz",
+      "integrity": "sha512-j05vL56tR90rsYqm9ZD05v6K4HI7t4yMDEvvU0x4f+IADXM9Jx1x9mzatxOs5drJq6dGhugxDW99mcPvXVLl+Q=="
+    },
     "node_modules/sass": {
       "version": "1.66.1",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.66.1.tgz",
@@ -10043,6 +10073,11 @@
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
     },
+    "async": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
+      "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
+    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -10470,6 +10505,24 @@
       "dev": true,
       "requires": {
         "path-type": "^4.0.0"
+      }
+    },
+    "disinfect": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/disinfect/-/disinfect-2.0.0.tgz",
+      "integrity": "sha512-qPQ7fdOBEqBiHJWx7Hc53z2/GKiC6YjOfmG4+rhBKbVqgHYo7qrrn2UygCNU31xOKBeSOmUpZWfvjsEplM6jHw==",
+      "requires": {
+        "@hapi/hoek": "^10.0.1",
+        "async": "^3.2.4",
+        "joi": "^17.7.0",
+        "sanitizer": "^0.1.3"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "10.0.1",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-10.0.1.tgz",
+          "integrity": "sha512-CvlW7jmOhWzuqOqiJQ3rQVLMcREh0eel4IBnxDx2FAcK8g7qoJRQK4L1CPBASoCY6y8e6zuCy3f2g+HWdkzcMw=="
+        }
       }
     },
     "doctrine": {
@@ -12939,6 +12992,11 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.0.tgz",
       "integrity": "sha512-eehKHKpab6E741ud7ZIMcXhKcP6TSIezPkNZhy5U8xC6+VvrRdUA2tMgxGxaGl4cz7c2Ew5+mg5+wNB16KQqrA=="
+    },
+    "sanitizer": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/sanitizer/-/sanitizer-0.1.3.tgz",
+      "integrity": "sha512-j05vL56tR90rsYqm9ZD05v6K4HI7t4yMDEvvU0x4f+IADXM9Jx1x9mzatxOs5drJq6dGhugxDW99mcPvXVLl+Q=="
     },
     "sass": {
       "version": "1.66.1",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@hapi/vision": "^7.0.2",
     "bcryptjs": "^2.4.3",
     "blipp": "^4.0.2",
+    "disinfect": "^2.0.0",
     "dotenv": "^16.3.1",
     "got": "^12.5.3",
     "govuk-frontend": "^4.7.0",


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4092

We really should have added this when working on supplementary billing. But now we are building a new endpoint to handle changing the address for a billing account we really need it.

We'll get into why we need to build a new endpoint when we start adding the code for it. But there are a series of changes we need to make in preparation.

The first of these is to implement automatic payload cleaning. This is something we did in the [Charging Module API](https://github.com/DEFRA/sroc-charging-module-api). By cleaning payloads automatically when they come in, we avoid polluting the [Joi](https://joi.dev/) schemas and our controllers with lots of calls to `trim()` or checks to see if something is `null` or `undefined`.

By cleaning we mean removing empty, null or undefined properties and then removing extraneous whitespace from the values left. It also includes sanitizing values to protect us from things like [cross-site scripting](https://owasp.org/www-community/attacks/xss/).

With this in place, controllers can get on and use `request.payload` without having to do any of these other checks.

In the **Charging Module** we rolled our own using [sanitizer](https://github.com/theSmaw/Caja-HTML-Sanitizer) to handle the dodgy stuff. @Jozzey pointed out [disinfect](https://github.com/genediazjr/disinfect) as an alternate. The fact it's been updated in the last 8 years already puts it ahead. But it can also do some of the work we were doing, dropping empty or null properties from the payload. The one thing it doesn't do is remove extraneous whitespace from values.

So, this change implements **Disinfect** along with a custom `payloadSanitizer` to get us the same result.