### PR TITLE
Add CRM_V2 contact model

### DIFF
--- a/app/models/crm-v2/contact.model.js
+++ b/app/models/crm-v2/contact.model.js
@@ -1,0 +1,91 @@
+'use strict'
+
+/**
+ * Model for contacts
+ * @module ContactModel
+ */
+
+const CrmV2BaseModel = require('./crm-v2-base.model.js')
+
+class ContactModel extends CrmV2BaseModel {
+  static get tableName () {
+    return 'contacts'
+  }
+
+  static get idColumn () {
+    return 'contactId'
+  }
+
+  static get translations () {
+    return [
+      { database: 'dateCreated', model: 'createdAt' },
+      { database: 'dateUpdated', model: 'updatedAt' }
+    ]
+  }
+
+  /**
+   * Returns the name for the contact derived from its various parts
+   *
+   * We have 2 sources for contact data; the import from NALD and those directly entered into the service. For reasons
+   * only the previous team will know we have not been consistent across them. What fields are populated depends on
+   * the data source. Added to that 'contacts' entered via the service are used to hold both departments and people.
+   *
+   * We have to send a derived name when sending customer changes to the Charging Module API as it accepts only a
+   * single `customerName` value. What we have implemented here replicates what the legacy code was doing to derive
+   * what that name should be.
+   *
+   * Along the way we learnt the following about `crm_v2.contacts`
+   *
+   * ### NALD
+   * - `contactType` is always null
+   * - `department` is always null
+   * - `middleInitials` is always null
+   * - `suffix` is always null
+   * - `lastName` is always set
+   * - `externalId` is always set
+   *
+   * ### WRLS
+   * - `contactType` is always set
+   * - `initials` is always null
+   * - `externalId` is always null
+   * - if `middleInitials` is set then `firstName` is always set
+   * - a 'person' always has `firstName` and `lastName` set
+   * - a 'person' can have `department` populated
+   * - a 'department' will only have `department` populated
+   * - as of 2023-08-01 there were 6 contacts with `suffix` populated out of 42,827 (1,621 WRLS)
+   *
+   * @returns {String} The name for the contact derived from its various parts
+   */
+  $name () {
+    if (this.contactType === 'department') {
+      return this.department
+    }
+
+    const initials = this._determineInitials()
+
+    const allNameParts = [
+      this.salutation,
+      initials || this.firstName, // if we have initials use them else use firstName
+      this.lastName,
+      this.suffix
+    ]
+
+    const onlyPopulatedNameParts = allNameParts.filter((item) => item)
+
+    return onlyPopulatedNameParts.join(' ')
+  }
+
+  _determineInitials () {
+    if (this.initials) {
+      return this.initials
+    }
+
+    if (this.middleInitials) {
+      return `${this.firstName.slice(0, 1)} ${this.middleInitials}`
+    }
+
+    return null
+  }
+}
+
+module.exports = ContactModel

--- a/db/migrations/20230820170600_create-crm-v2-contacts.js
+++ b/db/migrations/20230820170600_create-crm-v2-contacts.js
@@ -1,0 +1,40 @@
+'use strict'
+
+const tableName = 'contacts'
+
+exports.up = function (knex) {
+  return knex
+    .schema
+    .withSchema('crm_v2')
+    .createTable(tableName, (table) => {
+      // Primary Key
+      table.uuid('contact_id').primary().defaultTo(knex.raw('gen_random_uuid()'))
+
+      // Data
+      table.string('salutation')
+      table.string('first_name')
+      table.string('middle_initials')
+      table.string('last_name')
+      table.string('external_id')
+      table.string('initials')
+      table.boolean('is_test').notNullable().defaultTo(false)
+      table.string('data_source').notNullable()
+      table.string('contact_type')
+      table.string('suffix')
+      table.string('department')
+      table.string('last_hash')
+      table.string('current_hash')
+      table.string('email')
+
+      // Legacy timestamps
+      table.timestamp('date_created').notNullable().defaultTo(knex.fn.now())
+      table.timestamp('date_updated').notNullable().defaultTo(knex.fn.now())
+    })
+}
+
+exports.down = function (knex) {
+  return knex
+    .schema
+    .withSchema('crm_v2')
+    .dropTableIfExists(tableName)
+}

--- a/test/models/crm-v2/contact.model.test.js
+++ b/test/models/crm-v2/contact.model.test.js
@@ -1,0 +1,229 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const ContactHelper = require('../../support/helpers/crm-v2/contact.helper.js')
+const DatabaseHelper = require('../../support/helpers/database.helper.js')
+
+// Thing under test
+const ContactModel = require('../../../app/models/crm-v2/contact.model.js')
+
+describe('Contact model', () => {
+  let testRecord
+
+  beforeEach(async () => {
+    await DatabaseHelper.clean()
+
+    testRecord = await ContactHelper.add()
+  })
+
+  describe('Basic query', () => {
+    it('can successfully run a basic query', async () => {
+      const result = await ContactModel.query().findById(testRecord.contactId)
+
+      expect(result).to.be.an.instanceOf(ContactModel)
+      expect(result.contactId).to.equal(testRecord.contactId)
+    })
+  })
+
+  // NOTE: The test data we generate in these tests is in accordance with how a contact record could be populated. For
+  // example, if the data source is 'wrls' and the contact type is 'person', then first name and last name is always
+  // populated. We don't test what would happen if last name wasn't because analysis of the data confirms this would
+  // never happen. See the method's documentation for more details.
+  describe('$name', () => {
+    let contactRecord
+
+    beforeEach(() => {
+      contactRecord = {
+        contactType: null,
+        dataSource: null,
+        department: null,
+        firstName: null,
+        initials: null,
+        lastName: null,
+        middleInitials: null,
+        salutation: null,
+        suffix: null
+      }
+    })
+
+    describe('when the contact was imported in NALD', () => {
+      beforeEach(() => {
+        contactRecord.dataSource = 'nald'
+      })
+
+      describe("and has a last name of 'Villar'", () => {
+        beforeEach(() => {
+          contactRecord.lastName = 'Villar'
+        })
+
+        it("returns 'Villar'", () => {
+          testRecord = ContactModel.fromJson(contactRecord)
+
+          expect(testRecord.$name()).to.equal('Villar')
+        })
+
+        describe("and the salutation 'Mrs'", () => {
+          beforeEach(() => {
+            contactRecord.salutation = 'Mrs'
+          })
+
+          it("returns 'Mrs Villar'", () => {
+            testRecord = ContactModel.fromJson(contactRecord)
+
+            expect(testRecord.$name()).to.equal('Mrs Villar')
+          })
+
+          describe("and the initial 'J'", () => {
+            beforeEach(() => {
+              contactRecord.initials = 'J'
+            })
+
+            it("returns 'Mrs J Villar'", () => {
+              testRecord = ContactModel.fromJson(contactRecord)
+
+              expect(testRecord.$name()).to.equal('Mrs J Villar')
+            })
+          })
+        })
+
+        describe("and a first name of 'Margherita'", () => {
+          beforeEach(() => {
+            contactRecord.firstName = 'Margherita'
+          })
+
+          it("returns 'Margherita Villar'", () => {
+            testRecord = ContactModel.fromJson(contactRecord)
+
+            expect(testRecord.$name()).to.equal('Margherita Villar')
+          })
+
+          describe("and the salutation 'Mrs'", () => {
+            beforeEach(() => {
+              contactRecord.salutation = 'Mrs'
+            })
+
+            it("returns 'Mrs Margherita Villar'", () => {
+              testRecord = ContactModel.fromJson(contactRecord)
+
+              expect(testRecord.$name()).to.equal('Mrs Margherita Villar')
+            })
+
+            describe("and the initial 'J'", () => {
+              beforeEach(() => {
+                contactRecord.initials = 'J'
+              })
+
+              it("returns 'Mrs J Villar'", () => {
+                testRecord = ContactModel.fromJson(contactRecord)
+
+                expect(testRecord.$name()).to.equal('Mrs J Villar')
+              })
+            })
+          })
+        })
+      })
+    })
+
+    describe('when the contact was entered into WRLS', () => {
+      beforeEach(() => {
+        contactRecord.dataSource = 'wrls'
+      })
+
+      describe("and it is a department named 'Humanoid Risk Assessment'", () => {
+        beforeEach(() => {
+          contactRecord.contactType = 'department'
+          contactRecord.department = 'Humanoid Risk Assessment'
+        })
+
+        it("returns 'Humanoid Risk Assessment'", () => {
+          testRecord = ContactModel.fromJson(contactRecord)
+
+          expect(testRecord.$name()).to.equal('Humanoid Risk Assessment')
+        })
+      })
+
+      describe("and it is a 'person'", () => {
+        beforeEach(() => {
+          contactRecord.contactType = 'person'
+          contactRecord.firstName = 'Vincent'
+          contactRecord.lastName = 'Anderson'
+        })
+
+        describe("with the name 'Vincent Anderson'", () => {
+          it("returns 'Vincent Anderson'", () => {
+            testRecord = ContactModel.fromJson(contactRecord)
+
+            expect(testRecord.$name()).to.equal('Vincent Anderson')
+          })
+        })
+
+        describe("and the salutation 'Mr'", () => {
+          beforeEach(() => {
+            contactRecord.salutation = 'Mr'
+          })
+
+          it("returns 'Mr Vincent Anderson'", () => {
+            testRecord = ContactModel.fromJson(contactRecord)
+
+            expect(testRecord.$name()).to.equal('Mr Vincent Anderson')
+          })
+
+          describe("and the middle initial 'P'", () => {
+            beforeEach(() => {
+              contactRecord.middleInitials = 'P'
+            })
+
+            it("returns 'Mr V P Anderson'", () => {
+              testRecord = ContactModel.fromJson(contactRecord)
+
+              expect(testRecord.$name()).to.equal('Mr V P Anderson')
+            })
+
+            describe("and the suffix 'MBE'", () => {
+              beforeEach(() => {
+                contactRecord.suffix = 'MBE'
+              })
+
+              it("returns 'Mr V P Anderson MBE'", () => {
+                testRecord = ContactModel.fromJson(contactRecord)
+
+                expect(testRecord.$name()).to.equal('Mr V P Anderson MBE')
+              })
+            })
+          })
+        })
+
+        describe("and the middle initial 'P'", () => {
+          beforeEach(() => {
+            contactRecord.middleInitials = 'P'
+          })
+
+          it("returns 'V P Anderson'", () => {
+            testRecord = ContactModel.fromJson(contactRecord)
+
+            expect(testRecord.$name()).to.equal('V P Anderson')
+          })
+
+          describe("and the suffix 'MBE'", () => {
+            beforeEach(() => {
+              contactRecord.suffix = 'MBE'
+            })
+
+            it("returns 'V P Anderson MBE'", () => {
+              testRecord = ContactModel.fromJson(contactRecord)
+
+              expect(testRecord.$name()).to.equal('V P Anderson MBE')
+            })
+          })
+        })
+      })
+    })
+  })
+})

--- a/test/support/helpers/crm-v2/contact.helper.js
+++ b/test/support/helpers/crm-v2/contact.helper.js
@@ -1,0 +1,58 @@
+'use strict'
+
+/**
+ * @module ContactHelper
+ */
+
+const ContactModel = require('../../../../app/models/crm-v2/contact.model.js')
+
+/**
+ * Add a new contact
+ *
+ * If no `data` is provided, default values will be used. These are
+ *
+ * - `firstName` - Amara
+ * - `surname` - Gupta
+ * - `dataSource` - wrls
+ * - `contactType` - person
+ * - `email` - amara.gupta@example.com
+ *
+ * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ *
+ * @returns {module:ContactModel} The instance of the newly created record
+ */
+function add (data = {}) {
+  const insertData = defaults(data)
+
+  return ContactModel.query()
+    .insert({ ...insertData })
+    .returning('*')
+}
+
+/**
+ * Returns the defaults used when creating a new contact
+ *
+ * It will override or append to them any data provided. Mainly used by the `add()` method, we make it available
+ * for use in tests to avoid having to duplicate values.
+ *
+ * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ */
+function defaults (data = {}) {
+  const defaults = {
+    firstName: 'Amara',
+    lastName: 'Gupta',
+    dataSource: 'wrls',
+    contactType: 'person',
+    email: 'amara.gupta@example.com'
+  }
+
+  return {
+    ...defaults,
+    ...data
+  }
+}
+
+module.exports = {
+  add,
+  defaults
+}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4092

We are building a new endpoint to handle changing the address for a billing account.

We'll get into why we need to build a new endpoint when we start adding the code for it. But there are a series of changes we need to make in preparation.

The first of these was [Add automatic payload cleaning](https://github.com/DEFRA/water-abstraction-system/pull/375). The next set of changes is adding the models we'll need to interact with the `crm_v2` schema.

The `contact` model includes some additional functionality to return the 'name' to use. Unfortunately, both the source NALD system and our existing legacy service have chosen to go all in on breaking apart a person's name. What's even better (!) is they do it in different ways!!

We'll eventually be trying to replicate existing functionality that currently has a bug in it. It depends on being able to generate a name. So, even though we do not agree with splitting apart names and capturing unnecessary details like titles and suffixes, we've had to implement our own version of what the legacy code was doing.

> For reference, the [GOV.UK Design system](https://design-system.service.gov.uk/patterns/names/) encourages you not to do what we currently do. You should also look at [Personal names around the world (W3C)](https://www.w3.org/International/questions/qa-personal-names) and [Falsehoods about names (Kalzumeus)](http://www.kalzumeus.com/2010/06/17/falsehoods-programmers-believe-about-names/) to understand why any pattern other than 'Name:' is bad!