### PR TITLE
Add CRM_V2 invoice account address model

### DIFF
--- a/app/models/crm-v2/invoice-account-address.model.js
+++ b/app/models/crm-v2/invoice-account-address.model.js
@@ -1,0 +1,27 @@
+'use strict'
+
+/**
+ * Model for invoiceAccountAddresses
+ * @module InvoiceAccountAddressModel
+ */
+
+const CrmV2BaseModel = require('./crm-v2-base.model.js')
+
+class InvoiceAccountAddressModel extends CrmV2BaseModel {
+  static get tableName () {
+    return 'invoiceAccountAddresses'
+  }
+
+  static get idColumn () {
+    return 'invoiceAccountAddressId'
+  }
+
+  static get translations () {
+    return [
+      { database: 'dateCreated', model: 'createdAt' },
+      { database: 'dateUpdated', model: 'updatedAt' }
+    ]
+  }
+}
+
+module.exports = InvoiceAccountAddressModel

--- a/db/migrations/20230818155314_create-crm-v2-invoice-account-addressses.js
+++ b/db/migrations/20230818155314_create-crm-v2-invoice-account-addressses.js
@@ -1,0 +1,33 @@
+'use strict'
+
+const tableName = 'invoice_account_addresses'
+
+exports.up = function (knex) {
+  return knex
+    .schema
+    .withSchema('crm_v2')
+    .createTable(tableName, (table) => {
+      // Primary Key
+      table.uuid('invoice_account_address_id').primary().defaultTo(knex.raw('gen_random_uuid()'))
+
+      // Data
+      table.uuid('invoice_account_id').notNullable()
+      table.uuid('address_id').notNullable()
+      table.date('start_date').notNullable()
+      table.date('end_date')
+      table.boolean('is_test').notNullable().defaultTo(false)
+      table.uuid('agent_company_id')
+      table.uuid('contact_id')
+
+      // Legacy timestamps
+      table.timestamp('date_created').notNullable().defaultTo(knex.fn.now())
+      table.timestamp('date_updated').notNullable().defaultTo(knex.fn.now())
+    })
+}
+
+exports.down = function (knex) {
+  return knex
+    .schema
+    .withSchema('crm_v2')
+    .dropTableIfExists(tableName)
+}

--- a/test/models/crm-v2/invoice-account-address.model.test.js
+++ b/test/models/crm-v2/invoice-account-address.model.test.js
@@ -1,0 +1,34 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const DatabaseHelper = require('../../support/helpers/database.helper.js')
+const InvoiceAccountAddressHelper = require('../../support/helpers/crm-v2/invoice-account-address.helper.js')
+
+// Thing under test
+const InvoiceAccountAddressModel = require('../../../app/models/crm-v2/invoice-account-address.model.js')
+
+describe('Invoice Account Address model', () => {
+  let testRecord
+
+  beforeEach(async () => {
+    await DatabaseHelper.clean()
+
+    testRecord = await InvoiceAccountAddressHelper.add()
+  })
+
+  describe('Basic query', () => {
+    it('can successfully run a basic query', async () => {
+      const result = await InvoiceAccountAddressModel.query().findById(testRecord.invoiceAccountAddressId)
+
+      expect(result).to.be.an.instanceOf(InvoiceAccountAddressModel)
+      expect(result.invoiceAccountAddressId).to.equal(testRecord.invoiceAccountAddressId)
+    })
+  })
+})

--- a/test/support/helpers/crm-v2/invoice-account-address.helper.js
+++ b/test/support/helpers/crm-v2/invoice-account-address.helper.js
@@ -1,0 +1,54 @@
+'use strict'
+
+/**
+ * @module InvoiceAccountAddressHelper
+ */
+
+const InvoiceAccountAddressModel = require('../../../../app/models/crm-v2/invoice-account-address.model.js')
+
+/**
+ * Add a new invoice account address
+ *
+ * If no `data` is provided, default values will be used. These are
+ *
+ * - `invoiceAccountId` - b16efa32-9271-4333-aecf-b9358ba42892
+ * - `addressId` - 9570acde-752e-456a-a895-7b46a3c923a3
+ * - `startDate` - 2023-08-18
+ *
+ * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ *
+ * @returns {module:InvoiceAccountAddressModel} The instance of the newly created record
+ */
+function add (data = {}) {
+  const insertData = defaults(data)
+
+  return InvoiceAccountAddressModel.query()
+    .insert({ ...insertData })
+    .returning('*')
+}
+
+/**
+ * Returns the defaults used when creating a new invoice account address
+ *
+ * It will override or append to them any data provided. Mainly used by the `add()` method, we make it available
+ * for use in tests to avoid having to duplicate values.
+ *
+ * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ */
+function defaults (data = {}) {
+  const defaults = {
+    invoiceAccountId: 'b16efa32-9271-4333-aecf-b9358ba42892',
+    addressId: '9570acde-752e-456a-a895-7b46a3c923a3',
+    startDate: new Date(2023, 9, 18)
+  }
+
+  return {
+    ...defaults,
+    ...data
+  }
+}
+
+module.exports = {
+  add,
+  defaults
+}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4092

We are building a new endpoint to handle changing the address for a billing account.

We'll get into why we need to build a new endpoint when we start adding the code for it. But there are a series of changes we need to make in preparation.

The first of these was [Add automatic payload cleaning](https://github.com/DEFRA/water-abstraction-system/pull/375). The next set of changes is adding the models we'll need to interact with the `crm_v2` schema.