### PR TITLE
Add new /billing-accounts endpoint

### DIFF
--- a/app/controllers/billing-accounts.controller.js
+++ b/app/controllers/billing-accounts.controller.js
@@ -1,0 +1,14 @@
+'use strict'
+
+/**
+ * Controller for /billing-accounts endpoints
+ * @module BillingAccountsController
+ */
+
+async function changeAddress (_request, h) {
+  return h.response().code(201)
+}
+
+module.exports = {
+  changeAddress
+}

--- a/app/plugins/router.plugin.js
+++ b/app/plugins/router.plugin.js
@@ -13,6 +13,7 @@
 
 const AssetRoutes = require('../routes/assets.routes.js')
 const BillRunRoutes = require('../routes/bill-runs.routes')
+const BillingAccountRoutes = require('../routes/billing-accounts.routes')
 const CheckRoutes = require('../routes/check.routes')
 const DataRoutes = require('../routes/data.routes.js')
 const FilterRoutesService = require('../services/plugins/filter-routes.service.js')
@@ -26,6 +27,7 @@ const routes = [
   ...AssetRoutes,
   ...HealthRoutes,
   ...BillRunRoutes,
+  ...BillingAccountRoutes,
   ...CheckRoutes,
   ...DataRoutes
 ]

--- a/app/routes/billing-accounts.routes.js
+++ b/app/routes/billing-accounts.routes.js
@@ -1,0 +1,19 @@
+'use strict'
+
+const BillingAccountsController = require('../controllers/billing-accounts.controller.js')
+
+const routes = [
+  {
+    method: 'POST',
+    path: '/billing-accounts/{invoiceAccountId}/change-address',
+    handler: BillingAccountsController.changeAddress,
+    options: {
+      description: 'Used updating a billing account with a new address',
+      app: {
+        plainOutput: true
+      }
+    }
+  }
+]
+
+module.exports = routes

--- a/test/controllers/billing-accounts.controller.test.js
+++ b/test/controllers/billing-accounts.controller.test.js
@@ -1,0 +1,47 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { describe, it, beforeEach, afterEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// For running our service
+const { init } = require('../../app/server.js')
+
+describe('Billing Accounts controller', () => {
+  let server
+
+  // Create server before each test
+  beforeEach(async () => {
+    server = await init()
+
+    // We silence any calls to server.logger.error made in the plugin to try and keep the test output as clean as
+    // possible
+    Sinon.stub(server.logger, 'error')
+
+    // We silence sending a notification to our Errbit instance using Airbrake
+    Sinon.stub(server.app.airbrake, 'notify').resolvesThis()
+  })
+
+  afterEach(() => {
+    Sinon.restore()
+  })
+
+  describe('POST /bill-runs', () => {
+    const options = {
+      method: 'POST',
+      url: '/billing-accounts/7fa2f044-b29e-483a-99b6-e16db0db0f58/change-address'
+    }
+
+    describe('when the request succeeds', () => {
+      it('returns a 201 status', async () => {
+        const response = await server.inject(options)
+
+        expect(response.statusCode).to.equal(201)
+      })
+    })
+  })
+})


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4092

We have an issue with the legacy system around billing accounts. When a user creates a new one the [Charging Module API](https://github.com/DEFRA/sroc-charging-module-api) needs to know about it. This is because it manages the 'customer changes' file that gets passed to SSCL and the SOP system. The data imported from the file is used when generating invoices from the billing runs we generate.

This process is working fine. The issue is when a billing account gets updated. This is triggered by finding the existing account and opting to 'Change the Address'. During the journey you can also change the company and contact linked to the 'billing account' but the problem is with the address.

Though the system updates the address fine, it is sending the old address through to the Charging Module. We had to do some digging through the old code to figure out what is going on. We believe we know what the issue is but the fact we are uncertain speaks to just how complex the previous team have made this.

For example, the data is collected by the [water-abstraction-ui](https://github.com/DEFRA/water-abstraction-ui) which at the end of the journey submits it to the [water-abstraction-service](https://github.com/DEFRA/water-abstraction-service). That service works out whether it is dealing with an update or a new account (both are sent to the same endpoint). It then orchestrates the update to the database by making calls to endpoints in the [water-abstraction-tactical-crm](https://github.com/DEFRA/water-abstraction-tactical-crm). The bit we loved was the **tactical-crm** will make http calls _to itself_ to get some of those updates applied! This is because it uses [hapi-pg-rest-api](https://github.com/DEFRA/hapi-pg-rest-api), a custom package that generates a REST endpoint for a PostgreSQL table.

That covers updating the record in our DB. The update to the Charging Module APi is done differently. Instead of sending the request and dealing with the response directly, a job is created and added to the [BullMQ message queue](https://docs.bullmq.io/).

When the job is picked up and processed it grabs the latest address and uses that when generating the request to the Charging Module API. On the face of it this should all work. But we have been able to repeatedly (though not consistently) demonstrate that the query it uses to return the 'current' address linked to the billing account is returning the old one. The process that updates the database applies an `end_date` to the `invoice_account_address` record. This is how the system marks addresses as no longer 'current'. But when the BullMQ job is being processed it's finding that update hasn't happened so is picking the old address.

We believe it's a timing issue between the 2 processes.

So, why are we in this repo? We had to wade through the code base of 3 separate apps plus a custom package to understand what was going on. Added to that the 2 parts to this process; updating the DB and letting the Charging Module API know, are handled completely differently. Plus, you need knowledge of the BullMQ framework to understand how that second part is done. _All of this_ is being done just to

- add a record in the DB
- update another one
- send a HTTP `POST` request to an external API

By the way, we're omitting the various custom controller generators, object manipulators, shared HTTP request modules, etc, we assume built to make stuff generic but which mean there is a whole other level of complexity to each step. Add to that the haphazard and inconsistent way they have been applied.

We could keep digging and testing, and 'fix' the existing legacy code. But examples like this are why we have this repo and are migrating as much as we can as fast as we can.

So, we have decided to re-implement this function within **water-abstraction-system**. The previous PR's were some initial prep work. Adding the endpoint is the first step in moving changing a billing account address here.