### PR TITLE
Create `idm` migrations for authentication plugin

### DIFF
--- a/db/migrations/20230823150507_create-idm-schema.js
+++ b/db/migrations/20230823150507_create-idm-schema.js
@@ -1,0 +1,13 @@
+'use strict'
+
+exports.up = function (knex) {
+  return knex.raw(`
+    CREATE SCHEMA IF NOT EXISTS "idm";
+  `)
+}
+
+exports.down = function (knex) {
+  return knex.raw(`
+    DROP SCHEMA IF EXISTS "idm";
+  `)
+}

--- a/db/migrations/20230823150600_create-idm-users.js
+++ b/db/migrations/20230823150600_create-idm-users.js
@@ -1,0 +1,39 @@
+'use strict'
+
+const tableName = 'users'
+
+exports.up = function (knex) {
+  return knex
+    .schema
+    .withSchema('idm')
+    .createTable(tableName, (table) => {
+      // Primary Key
+      table.integer('user_id').primary().notNullable()
+
+      // Data
+      table.string('user_name').notNullable()
+      table.string('password').notNullable()
+      table.jsonb('user_data')
+      table.string('reset_guid')
+      table.bigint('reset_required')
+
+      table.timestamp('last_login')
+      table.bigint('bad_logins')
+      table.string('application')
+      table.jsonb('role')
+      table.string('external_id')
+      table.timestamp('reset_guid_date_created')
+      table.boolean('enabled').notNullable().defaultTo(true)
+
+      // Legacy timestamps
+      table.timestamp('date_created', { useTz: false }).notNullable().defaultTo(knex.fn.now())
+      table.timestamp('date_updated', { useTz: false }).notNullable().defaultTo(knex.fn.now())
+    })
+}
+
+exports.down = function (knex) {
+  return knex
+    .schema
+    .withSchema('idm')
+    .dropTableIfExists(tableName)
+}

--- a/db/migrations/20230824092452_create-idm-group-roles.js
+++ b/db/migrations/20230824092452_create-idm-group-roles.js
@@ -1,0 +1,28 @@
+'use strict'
+
+const tableName = 'group_roles'
+
+exports.up = function (knex) {
+  return knex
+    .schema
+    .withSchema('idm')
+    .createTable(tableName, (table) => {
+      // Primary Key
+      table.string('user_id').primary().notNullable()
+
+      // Data
+      table.string('group_id').notNullable()
+      table.string('role_id').notNullable()
+
+      // Legacy timestamps
+      table.timestamp('date_created', { useTz: false }).notNullable().defaultTo(knex.fn.now())
+      table.timestamp('date_updated', { useTz: false }).notNullable().defaultTo(knex.fn.now())
+    })
+}
+
+exports.down = function (knex) {
+  return knex
+    .schema
+    .withSchema('idm')
+    .dropTableIfExists(tableName)
+}

--- a/db/migrations/20230824092657_create-idm-groups.js
+++ b/db/migrations/20230824092657_create-idm-groups.js
@@ -1,0 +1,29 @@
+'use strict'
+
+const tableName = 'groups'
+
+exports.up = function (knex) {
+  return knex
+    .schema
+    .withSchema('idm')
+    .createTable(tableName, (table) => {
+      // Primary Key
+      table.string('group_id').primary().notNullable()
+
+      // Data
+      table.string('application')
+      table.string('group').notNullable()
+      table.string('description').notNullable()
+
+      // Legacy timestamps
+      table.timestamp('date_created', { useTz: false }).notNullable().defaultTo(knex.fn.now())
+      table.timestamp('date_updated', { useTz: false }).notNullable().defaultTo(knex.fn.now())
+    })
+}
+
+exports.down = function (knex) {
+  return knex
+    .schema
+    .withSchema('idm')
+    .dropTableIfExists(tableName)
+}

--- a/db/migrations/20230824092939_create-idm-roles.js
+++ b/db/migrations/20230824092939_create-idm-roles.js
@@ -1,0 +1,29 @@
+'use strict'
+
+const tableName = 'roles'
+
+exports.up = function (knex) {
+  return knex
+    .schema
+    .withSchema('idm')
+    .createTable(tableName, (table) => {
+      // Primary Key
+      table.integer('role_id').primary()
+
+      // Data
+      table.string('application')
+      table.string('role').notNullable()
+      table.string('description').notNullable()
+
+      // Legacy timestamps
+      table.timestamp('date_created', { useTz: false }).notNullable().defaultTo(knex.fn.now())
+      table.timestamp('date_updated', { useTz: false }).notNullable().defaultTo(knex.fn.now())
+    })
+}
+
+exports.down = function (knex) {
+  return knex
+    .schema
+    .withSchema('idm')
+    .dropTableIfExists(tableName)
+}

--- a/db/migrations/20230824093122_create-idm-user-groups.js
+++ b/db/migrations/20230824093122_create-idm-user-groups.js
@@ -1,0 +1,28 @@
+'use strict'
+
+const tableName = 'user_groups'
+
+exports.up = function (knex) {
+  return knex
+    .schema
+    .withSchema('idm')
+    .createTable(tableName, (table) => {
+      // Primary Key
+      table.string('user_group_id').primary().notNullable()
+
+      // Data
+      table.integer('user_id').notNullable()
+      table.string('group_id').notNullable()
+
+      // Legacy timestamps
+      table.timestamp('date_created', { useTz: false }).notNullable().defaultTo(knex.fn.now())
+      table.timestamp('date_updated', { useTz: false }).notNullable().defaultTo(knex.fn.now())
+    })
+}
+
+exports.down = function (knex) {
+  return knex
+    .schema
+    .withSchema('idm')
+    .dropTableIfExists(tableName)
+}

--- a/db/migrations/20230824142221_create-idm-user-roles.js
+++ b/db/migrations/20230824142221_create-idm-user-roles.js
@@ -1,0 +1,28 @@
+'use strict'
+
+const tableName = 'user_roles'
+
+exports.up = function (knex) {
+  return knex
+    .schema
+    .withSchema('idm')
+    .createTable(tableName, (table) => {
+      // Primary Key
+      table.string('user_role_id').primary().notNullable()
+
+      // Data
+      table.integer('user_id').notNullable()
+      table.string('role_id').notNullable()
+
+      // Legacy timestamps
+      table.timestamp('date_created', { useTz: false }).notNullable().defaultTo(knex.fn.now())
+      table.timestamp('date_updated', { useTz: false }).notNullable().defaultTo(knex.fn.now())
+    })
+}
+
+exports.down = function (knex) {
+  return knex
+    .schema
+    .withSchema('idm')
+    .dropTableIfExists(tableName)
+}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4085

In anticipation of developing our [authentication plugin](https://github.com/DEFRA/water-abstraction-system/pull/351) we create migrations to set up our test db with the `idm` schema and required tables.