### PR TITLE
Update new CRM_V2 models with relationships

### DIFF
--- a/app/models/crm-v2/address.model.js
+++ b/app/models/crm-v2/address.model.js
@@ -5,6 +5,8 @@
  * @module AddressModel
  */
 
+const { Model } = require('objection')
+
 const CrmV2BaseModel = require('./crm-v2-base.model.js')
 
 class AddressModel extends CrmV2BaseModel {
@@ -21,6 +23,19 @@ class AddressModel extends CrmV2BaseModel {
       { database: 'dateCreated', model: 'createdAt' },
       { database: 'dateUpdated', model: 'updatedAt' }
     ]
+  }
+
+  static get relationMappings () {
+    return {
+      invoiceAccountAddresses: {
+        relation: Model.HasManyRelation,
+        modelClass: 'invoice-account-address.model',
+        join: {
+          from: 'addresses.addressId',
+          to: 'invoiceAccountAddresses.addressId'
+        }
+      }
+    }
   }
 }
 

--- a/app/models/crm-v2/company.model.js
+++ b/app/models/crm-v2/company.model.js
@@ -5,6 +5,8 @@
  * @module CompanyModel
  */
 
+const { Model } = require('objection')
+
 const CrmV2BaseModel = require('./crm-v2-base.model.js')
 
 class CompanyModel extends CrmV2BaseModel {
@@ -21,6 +23,27 @@ class CompanyModel extends CrmV2BaseModel {
       { database: 'dateCreated', model: 'createdAt' },
       { database: 'dateUpdated', model: 'updatedAt' }
     ]
+  }
+
+  static get relationMappings () {
+    return {
+      invoiceAccounts: {
+        relation: Model.HasManyRelation,
+        modelClass: 'invoice-account.model',
+        join: {
+          from: 'companies.companyId',
+          to: 'invoiceAccounts.companyId'
+        }
+      },
+      invoiceAccountAddresses: {
+        relation: Model.HasManyRelation,
+        modelClass: 'invoice-account-address.model',
+        join: {
+          from: 'companies.companyId',
+          to: 'invoiceAccountAddresses.agentCompanyId'
+        }
+      }
+    }
   }
 }
 

--- a/app/models/crm-v2/contact.model.js
+++ b/app/models/crm-v2/contact.model.js
@@ -5,6 +5,8 @@
  * @module ContactModel
  */
 
+const { Model } = require('objection')
+
 const CrmV2BaseModel = require('./crm-v2-base.model.js')
 
 class ContactModel extends CrmV2BaseModel {
@@ -21,6 +23,19 @@ class ContactModel extends CrmV2BaseModel {
       { database: 'dateCreated', model: 'createdAt' },
       { database: 'dateUpdated', model: 'updatedAt' }
     ]
+  }
+
+  static get relationMappings () {
+    return {
+      invoiceAccountAddresses: {
+        relation: Model.HasManyRelation,
+        modelClass: 'invoice-account-address.model',
+        join: {
+          from: 'contacts.contactId',
+          to: 'invoiceAccountAddresses.contactId'
+        }
+      }
+    }
   }
 
   /**

--- a/app/models/crm-v2/invoice-account-address.model.js
+++ b/app/models/crm-v2/invoice-account-address.model.js
@@ -5,6 +5,8 @@
  * @module InvoiceAccountAddressModel
  */
 
+const { Model } = require('objection')
+
 const CrmV2BaseModel = require('./crm-v2-base.model.js')
 
 class InvoiceAccountAddressModel extends CrmV2BaseModel {
@@ -21,6 +23,43 @@ class InvoiceAccountAddressModel extends CrmV2BaseModel {
       { database: 'dateCreated', model: 'createdAt' },
       { database: 'dateUpdated', model: 'updatedAt' }
     ]
+  }
+
+  static get relationMappings () {
+    return {
+      address: {
+        relation: Model.BelongsToOneRelation,
+        modelClass: 'address.model',
+        join: {
+          from: 'invoiceAccountAddresses.addressId',
+          to: 'addresses.addressId'
+        }
+      },
+      company: {
+        relation: Model.BelongsToOneRelation,
+        modelClass: 'company.model',
+        join: {
+          from: 'invoiceAccountAddresses.agentCompanyId',
+          to: 'companies.companyId'
+        }
+      },
+      contact: {
+        relation: Model.BelongsToOneRelation,
+        modelClass: 'contact.model',
+        join: {
+          from: 'invoiceAccountAddresses.contactId',
+          to: 'contacts.contactId'
+        }
+      },
+      invoiceAccount: {
+        relation: Model.BelongsToOneRelation,
+        modelClass: 'invoice-account.model',
+        join: {
+          from: 'invoiceAccountAddresses.invoiceAccountId',
+          to: 'invoiceAccounts.invoiceAccountId'
+        }
+      }
+    }
   }
 }
 

--- a/app/models/crm-v2/invoice-account.model.js
+++ b/app/models/crm-v2/invoice-account.model.js
@@ -5,6 +5,8 @@
  * @module InvoiceAccountModel
  */
 
+const { Model } = require('objection')
+
 const CrmV2BaseModel = require('./crm-v2-base.model.js')
 
 class InvoiceAccountModel extends CrmV2BaseModel {
@@ -21,6 +23,27 @@ class InvoiceAccountModel extends CrmV2BaseModel {
       { database: 'dateCreated', model: 'createdAt' },
       { database: 'dateUpdated', model: 'updatedAt' }
     ]
+  }
+
+  static get relationMappings () {
+    return {
+      company: {
+        relation: Model.BelongsToOneRelation,
+        modelClass: 'company.model',
+        join: {
+          from: 'invoiceAccounts.companyId',
+          to: 'companies.companyId'
+        }
+      },
+      invoiceAccountAddresses: {
+        relation: Model.HasManyRelation,
+        modelClass: 'invoice-account-address.model',
+        join: {
+          from: 'invoiceAccounts.invoiceAccountId',
+          to: 'invoiceAccountAddresses.invoiceAccountId'
+        }
+      }
+    }
   }
 }
 

--- a/test/models/crm-v2/address.model.test.js
+++ b/test/models/crm-v2/address.model.test.js
@@ -10,6 +10,8 @@ const { expect } = Code
 // Test helpers
 const AddressHelper = require('../../support/helpers/crm-v2/address.helper.js')
 const DatabaseHelper = require('../../support/helpers/database.helper.js')
+const InvoiceAccountAddressHelper = require('../../support/helpers/crm-v2/invoice-account-address.helper.js')
+const InvoiceAccountAddressModel = require('../../../app/models/crm-v2/invoice-account-address.model.js')
 
 // Thing under test
 const AddressModel = require('../../../app/models/crm-v2/address.model.js')
@@ -29,6 +31,44 @@ describe('Address model', () => {
 
       expect(result).to.be.an.instanceOf(AddressModel)
       expect(result.addressId).to.equal(testRecord.addressId)
+    })
+  })
+
+  describe('Relationships', () => {
+    describe('when linking to invoice account addresses', () => {
+      let testInvoiceAccountAddresses
+
+      beforeEach(async () => {
+        testRecord = await AddressHelper.add()
+        const { addressId } = testRecord
+
+        testInvoiceAccountAddresses = []
+        for (let i = 0; i < 2; i++) {
+          const invoiceAccountAddress = await InvoiceAccountAddressHelper.add({ addressId })
+          testInvoiceAccountAddresses.push(invoiceAccountAddress)
+        }
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await AddressModel.query()
+          .innerJoinRelated('invoiceAccountAddresses')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the invoice account addresses', async () => {
+        const result = await AddressModel.query()
+          .findById(testRecord.addressId)
+          .withGraphFetched('invoiceAccountAddresses')
+
+        expect(result).to.be.instanceOf(AddressModel)
+        expect(result.addressId).to.equal(testRecord.addressId)
+
+        expect(result.invoiceAccountAddresses).to.be.an.array()
+        expect(result.invoiceAccountAddresses[0]).to.be.an.instanceOf(InvoiceAccountAddressModel)
+        expect(result.invoiceAccountAddresses).to.include(testInvoiceAccountAddresses[0])
+        expect(result.invoiceAccountAddresses).to.include(testInvoiceAccountAddresses[1])
+      })
     })
   })
 })

--- a/test/models/crm-v2/company.model.test.js
+++ b/test/models/crm-v2/company.model.test.js
@@ -10,6 +10,8 @@ const { expect } = Code
 // Test helpers
 const CompanyHelper = require('../../support/helpers/crm-v2/company.helper.js')
 const DatabaseHelper = require('../../support/helpers/database.helper.js')
+const InvoiceAccountAddressHelper = require('../../support/helpers/crm-v2/invoice-account-address.helper.js')
+const InvoiceAccountAddressModel = require('../../../app/models/crm-v2/invoice-account-address.model.js')
 
 // Thing under test
 const CompanyModel = require('../../../app/models/crm-v2/company.model.js')
@@ -29,6 +31,44 @@ describe('Company model', () => {
 
       expect(result).to.be.an.instanceOf(CompanyModel)
       expect(result.companyId).to.equal(testRecord.companyId)
+    })
+  })
+
+  describe('Relationships', () => {
+    describe('when linking to invoice account addresses', () => {
+      let testInvoiceAccountAddresses
+
+      beforeEach(async () => {
+        testRecord = await CompanyHelper.add()
+        const { companyId: agentCompanyId } = testRecord
+
+        testInvoiceAccountAddresses = []
+        for (let i = 0; i < 2; i++) {
+          const invoiceAccountAddress = await InvoiceAccountAddressHelper.add({ agentCompanyId })
+          testInvoiceAccountAddresses.push(invoiceAccountAddress)
+        }
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await CompanyModel.query()
+          .innerJoinRelated('invoiceAccountAddresses')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the invoice account addresses', async () => {
+        const result = await CompanyModel.query()
+          .findById(testRecord.companyId)
+          .withGraphFetched('invoiceAccountAddresses')
+
+        expect(result).to.be.instanceOf(CompanyModel)
+        expect(result.companyId).to.equal(testRecord.companyId)
+
+        expect(result.invoiceAccountAddresses).to.be.an.array()
+        expect(result.invoiceAccountAddresses[0]).to.be.an.instanceOf(InvoiceAccountAddressModel)
+        expect(result.invoiceAccountAddresses).to.include(testInvoiceAccountAddresses[0])
+        expect(result.invoiceAccountAddresses).to.include(testInvoiceAccountAddresses[1])
+      })
     })
   })
 })

--- a/test/models/crm-v2/contact.model.test.js
+++ b/test/models/crm-v2/contact.model.test.js
@@ -10,6 +10,8 @@ const { expect } = Code
 // Test helpers
 const ContactHelper = require('../../support/helpers/crm-v2/contact.helper.js')
 const DatabaseHelper = require('../../support/helpers/database.helper.js')
+const InvoiceAccountAddressHelper = require('../../support/helpers/crm-v2/invoice-account-address.helper.js')
+const InvoiceAccountAddressModel = require('../../../app/models/crm-v2/invoice-account-address.model.js')
 
 // Thing under test
 const ContactModel = require('../../../app/models/crm-v2/contact.model.js')
@@ -29,6 +31,44 @@ describe('Contact model', () => {
 
       expect(result).to.be.an.instanceOf(ContactModel)
       expect(result.contactId).to.equal(testRecord.contactId)
+    })
+  })
+
+  describe('Relationships', () => {
+    describe('when linking to invoice account addresses', () => {
+      let testInvoiceAccountAddresses
+
+      beforeEach(async () => {
+        testRecord = await ContactHelper.add()
+        const { contactId } = testRecord
+
+        testInvoiceAccountAddresses = []
+        for (let i = 0; i < 2; i++) {
+          const invoiceAccountAddress = await InvoiceAccountAddressHelper.add({ contactId })
+          testInvoiceAccountAddresses.push(invoiceAccountAddress)
+        }
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await ContactModel.query()
+          .innerJoinRelated('invoiceAccountAddresses')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the invoice account addresses', async () => {
+        const result = await ContactModel.query()
+          .findById(testRecord.contactId)
+          .withGraphFetched('invoiceAccountAddresses')
+
+        expect(result).to.be.instanceOf(ContactModel)
+        expect(result.contactId).to.equal(testRecord.contactId)
+
+        expect(result.invoiceAccountAddresses).to.be.an.array()
+        expect(result.invoiceAccountAddresses[0]).to.be.an.instanceOf(InvoiceAccountAddressModel)
+        expect(result.invoiceAccountAddresses).to.include(testInvoiceAccountAddresses[0])
+        expect(result.invoiceAccountAddresses).to.include(testInvoiceAccountAddresses[1])
+      })
     })
   })
 

--- a/test/models/crm-v2/invoice-account-address.model.test.js
+++ b/test/models/crm-v2/invoice-account-address.model.test.js
@@ -8,7 +8,15 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
+const AddressHelper = require('../../support/helpers/crm-v2/address.helper.js')
+const AddressModel = require('../../../app/models/crm-v2/address.model.js')
+const CompanyHelper = require('../../support/helpers/crm-v2/company.helper.js')
+const CompanyModel = require('../../../app/models/crm-v2/company.model.js')
+const ContactHelper = require('../../support/helpers/crm-v2/contact.helper.js')
+const ContactModel = require('../../../app/models/crm-v2/contact.model.js')
 const DatabaseHelper = require('../../support/helpers/database.helper.js')
+const InvoiceAccountHelper = require('../../support/helpers/crm-v2/invoice-account.helper.js')
+const InvoiceAccountModel = require('../../../app/models/crm-v2/invoice-account.model.js')
 const InvoiceAccountAddressHelper = require('../../support/helpers/crm-v2/invoice-account-address.helper.js')
 
 // Thing under test
@@ -29,6 +37,120 @@ describe('Invoice Account Address model', () => {
 
       expect(result).to.be.an.instanceOf(InvoiceAccountAddressModel)
       expect(result.invoiceAccountAddressId).to.equal(testRecord.invoiceAccountAddressId)
+    })
+  })
+
+  describe('Relationships', () => {
+    describe('when linking to address', () => {
+      let testAddress
+
+      beforeEach(async () => {
+        testAddress = await AddressHelper.add()
+        testRecord = await InvoiceAccountAddressHelper.add({ addressId: testAddress.addressId })
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await InvoiceAccountAddressModel.query()
+          .innerJoinRelated('address')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the address', async () => {
+        const result = await InvoiceAccountAddressModel.query()
+          .findById(testRecord.invoiceAccountAddressId)
+          .withGraphFetched('address')
+
+        expect(result).to.be.instanceOf(InvoiceAccountAddressModel)
+        expect(result.invoiceAccountAddressId).to.equal(testRecord.invoiceAccountAddressId)
+
+        expect(result.address).to.be.an.instanceOf(AddressModel)
+        expect(result.address).to.equal(testAddress)
+      })
+    })
+
+    describe('when linking to company', () => {
+      let testCompany
+
+      beforeEach(async () => {
+        testCompany = await CompanyHelper.add()
+        testRecord = await InvoiceAccountAddressHelper.add({ agentCompanyId: testCompany.companyId })
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await InvoiceAccountAddressModel.query()
+          .innerJoinRelated('company')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the company', async () => {
+        const result = await InvoiceAccountAddressModel.query()
+          .findById(testRecord.invoiceAccountAddressId)
+          .withGraphFetched('company')
+
+        expect(result).to.be.instanceOf(InvoiceAccountAddressModel)
+        expect(result.invoiceAccountAddressId).to.equal(testRecord.invoiceAccountAddressId)
+
+        expect(result.company).to.be.an.instanceOf(CompanyModel)
+        expect(result.company).to.equal(testCompany)
+      })
+    })
+
+    describe('when linking to contact', () => {
+      let testContact
+
+      beforeEach(async () => {
+        testContact = await ContactHelper.add()
+        testRecord = await InvoiceAccountAddressHelper.add({ contactId: testContact.contactId })
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await InvoiceAccountAddressModel.query()
+          .innerJoinRelated('contact')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the contact', async () => {
+        const result = await InvoiceAccountAddressModel.query()
+          .findById(testRecord.invoiceAccountAddressId)
+          .withGraphFetched('contact')
+
+        expect(result).to.be.instanceOf(InvoiceAccountAddressModel)
+        expect(result.invoiceAccountAddressId).to.equal(testRecord.invoiceAccountAddressId)
+
+        expect(result.contact).to.be.an.instanceOf(ContactModel)
+        expect(result.contact).to.equal(testContact)
+      })
+    })
+
+    describe('when linking to invoice account', () => {
+      let testInvoiceAccount
+
+      beforeEach(async () => {
+        testInvoiceAccount = await InvoiceAccountHelper.add()
+        testRecord = await InvoiceAccountAddressHelper.add({ invoiceAccountId: testInvoiceAccount.invoiceAccountId })
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await InvoiceAccountAddressModel.query()
+          .innerJoinRelated('invoiceAccount')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the region', async () => {
+        const result = await InvoiceAccountAddressModel.query()
+          .findById(testRecord.invoiceAccountAddressId)
+          .withGraphFetched('invoiceAccount')
+
+        expect(result).to.be.instanceOf(InvoiceAccountAddressModel)
+        expect(result.invoiceAccountAddressId).to.equal(testRecord.invoiceAccountAddressId)
+
+        expect(result.invoiceAccount).to.be.an.instanceOf(InvoiceAccountModel)
+        expect(result.invoiceAccount).to.equal(testInvoiceAccount)
+      })
     })
   })
 })

--- a/test/models/crm-v2/invoice-account.model.test.js
+++ b/test/models/crm-v2/invoice-account.model.test.js
@@ -8,8 +8,12 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
+const CompanyHelper = require('../../support/helpers/crm-v2/company.helper.js')
+const CompanyModel = require('../../../app/models/crm-v2/company.model.js')
 const DatabaseHelper = require('../../support/helpers/database.helper.js')
 const InvoiceAccountHelper = require('../../support/helpers/crm-v2/invoice-account.helper.js')
+const InvoiceAccountAddressHelper = require('../../support/helpers/crm-v2/invoice-account-address.helper.js')
+const InvoiceAccountAddressModel = require('../../../app/models/crm-v2/invoice-account-address.model.js')
 
 // Thing under test
 const InvoiceAccountModel = require('../../../app/models/crm-v2/invoice-account.model.js')
@@ -29,6 +33,72 @@ describe('Invoice Account model', () => {
 
       expect(result).to.be.an.instanceOf(InvoiceAccountModel)
       expect(result.invoiceAccountId).to.equal(testRecord.invoiceAccountId)
+    })
+  })
+
+  describe('Relationships', () => {
+    describe('when linking to company', () => {
+      let testCompany
+
+      beforeEach(async () => {
+        testCompany = await CompanyHelper.add()
+        testRecord = await InvoiceAccountHelper.add({ companyId: testCompany.companyId })
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await InvoiceAccountModel.query()
+          .innerJoinRelated('company')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the company', async () => {
+        const result = await InvoiceAccountModel.query()
+          .findById(testRecord.invoiceAccountId)
+          .withGraphFetched('company')
+
+        expect(result).to.be.instanceOf(InvoiceAccountModel)
+        expect(result.invoiceAccountId).to.equal(testRecord.invoiceAccountId)
+
+        expect(result.company).to.be.an.instanceOf(CompanyModel)
+        expect(result.company).to.equal(testCompany)
+      })
+    })
+
+    describe('when linking to invoice account addresses', () => {
+      let testInvoiceAccountAddresses
+
+      beforeEach(async () => {
+        testRecord = await InvoiceAccountHelper.add()
+        const { invoiceAccountId } = testRecord
+
+        testInvoiceAccountAddresses = []
+        for (let i = 0; i < 2; i++) {
+          const invoiceAccountAddress = await InvoiceAccountAddressHelper.add({ invoiceAccountId })
+          testInvoiceAccountAddresses.push(invoiceAccountAddress)
+        }
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await InvoiceAccountModel.query()
+          .innerJoinRelated('invoiceAccountAddresses')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the invoice account addresses', async () => {
+        const result = await InvoiceAccountModel.query()
+          .findById(testRecord.invoiceAccountId)
+          .withGraphFetched('invoiceAccountAddresses')
+
+        expect(result).to.be.instanceOf(InvoiceAccountModel)
+        expect(result.invoiceAccountId).to.equal(testRecord.invoiceAccountId)
+
+        expect(result.invoiceAccountAddresses).to.be.an.array()
+        expect(result.invoiceAccountAddresses[0]).to.be.an.instanceOf(InvoiceAccountAddressModel)
+        expect(result.invoiceAccountAddresses).to.include(testInvoiceAccountAddresses[0])
+        expect(result.invoiceAccountAddresses).to.include(testInvoiceAccountAddresses[1])
+      })
     })
   })
 })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4092

In the following PRs we added some new models for the `crm_v2` schema

- [Add CRM_V2 address model](https://github.com/DEFRA/water-abstraction-system/pull/378)
- [Add CRM_V2 contact model](https://github.com/DEFRA/water-abstraction-system/pull/379)
- [Add CRM_V2 company model](https://github.com/DEFRA/water-abstraction-system/pull/380)
- [Add CRM_V2 invoice account address model](https://github.com/DEFRA/water-abstraction-system/pull/381)

To keep the changes to a minimum we omitted the relationships between them and the existing `InvoiceAccountModel`. This change adds those relationships in.