### PR TITLE
Fix `idm-group-roles` migration

### DIFF
--- a/db/migrations/20230824092452_create-idm-group-roles.js
+++ b/db/migrations/20230824092452_create-idm-group-roles.js
@@ -8,7 +8,7 @@ exports.up = function (knex) {
     .withSchema('idm')
     .createTable(tableName, (table) => {
       // Primary Key
-      table.string('user_id').primary().notNullable()
+      table.string('group_role_id').primary().notNullable()
 
       // Data
       table.string('group_id').notNullable()


### PR DESCRIPTION
A post-merge review of the `idm` schema spotted that the `idm-group-roles` migration contained an incorrect column name. This PR amends the migration (which is yet to be deployed and therefore still considered by us to be editable) to fix this.