### PR TITLE
Update notes for contact and company CRM_V2 models

### DIFF
--- a/app/models/crm-v2/company.model.js
+++ b/app/models/crm-v2/company.model.js
@@ -9,6 +9,38 @@ const { Model } = require('objection')
 
 const CrmV2BaseModel = require('./crm-v2-base.model.js')
 
+/**
+ * Objection model that represents a `company` in the `crm_v2.companies` table
+ *
+ * ### Notes
+ *
+ * There is no `dataSource` field in the table. But anything that has `externalId` populated can be assumed to have been
+ * imported from NALD and everything else directly entered into WRLS.
+ *
+ * For all records `name` and `type` are set
+ *
+ * When the source is 'nald'
+ *
+ * - `companyNumber` is always null
+ * - `organisationType` is always null
+ * - `lastHash` is always set
+ * - `currentHash` is always set
+ * - `externalId` is always set
+ *
+ * When the source is 'wrls'
+ *
+ * - `lastHash` is always null
+ * - `currentHash` is always null
+ * - `externalId` is always null
+ * - if `type` is 'organisation' then `companyNumber` is always set
+ * - if `type` is 'organisation' then `organisationType` can be null or set
+ * - if `type` is 'person' then `companyNumber` is always null
+ * - if `type` is 'person' then `organisationType` is always null
+ * - as of 2023-08-01 there were 28 companies with `type` set to 'organisation'
+ *
+ * We currently do not know how `organisationType` gets populated!
+ *
+ */
 class CompanyModel extends CrmV2BaseModel {
   static get tableName () {
     return 'companies'

--- a/app/models/crm-v2/contact.model.js
+++ b/app/models/crm-v2/contact.model.js
@@ -9,6 +9,34 @@ const { Model } = require('objection')
 
 const CrmV2BaseModel = require('./crm-v2-base.model.js')
 
+/**
+ * Objection model that represents a `contact` in the `crm_v2.contacts` table
+ *
+ * ### Notes
+ *
+ * Whilst working with this table we have learnt the following;
+ *
+ * When the `dataSource` is 'nald'
+ *
+ * - `contactType` is always null
+ * - `department` is always null
+ * - `middleInitials` is always null
+ * - `suffix` is always null
+ * - `lastName` is always set
+ * - `externalId` is always set
+ *
+ * When the `dataSource` is 'wrls'
+ *
+ * - `contactType` is always set
+ * - `initials` is always null
+ * - `externalId` is always null
+ * - if `middleInitials` is set then `firstName` is always set
+ * - a 'person' always has `firstName` and `lastName` set
+ * - a 'person' can have `department` populated
+ * - a 'department' will only have `department` populated
+ * - as of 2023-08-01 there were 6 contacts with `suffix` populated out of 42,827 (1,621 WRLS)
+ *
+ */
 class ContactModel extends CrmV2BaseModel {
   static get tableName () {
     return 'contacts'
@@ -48,26 +76,6 @@ class ContactModel extends CrmV2BaseModel {
    * We have to send a derived name when sending customer changes to the Charging Module API as it accepts only a
    * single `customerName` value. What we have implemented here replicates what the legacy code was doing to derive
    * what that name should be.
-   *
-   * Along the way we learnt the following about `crm_v2.contacts`
-   *
-   * ### NALD
-   * - `contactType` is always null
-   * - `department` is always null
-   * - `middleInitials` is always null
-   * - `suffix` is always null
-   * - `lastName` is always set
-   * - `externalId` is always set
-   *
-   * ### WRLS
-   * - `contactType` is always set
-   * - `initials` is always null
-   * - `externalId` is always null
-   * - if `middleInitials` is set then `firstName` is always set
-   * - a 'person' always has `firstName` and `lastName` set
-   * - a 'person' can have `department` populated
-   * - a 'department' will only have `department` populated
-   * - as of 2023-08-01 there were 6 contacts with `suffix` populated out of 42,827 (1,621 WRLS)
    *
    * @returns {String} The name for the contact derived from its various parts
    */


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4092

We are working on migrating the change billing account address functionality from the legacy code to this project. Whilst working on persisting the company data we learnt some details about how the previous team stored data in the `crm_v2.companies` table depending on the source.

We wanted to add these notes for future reference, which made us revisit how we did something similar in the `ContactModel`.

So, this change is just about updating our notes in the models to be consistent.