### PR TITLE
Add new CHA create customer change service

### DIFF
--- a/app/services/charging-module/create-customer-change.service.js
+++ b/app/services/charging-module/create-customer-change.service.js
@@ -1,0 +1,29 @@
+'use strict'
+
+/**
+ * Connects with the Charging Module to create a new customer change
+ * @module ChargingModuleCreateCustomerChangeService
+ */
+
+const ChargingModuleRequestLib = require('../../lib/charging-module-request.lib.js')
+
+/**
+ * Sends a request to the Charging Module to create a new customer change and returns the result
+ *
+ * {@link https://defra.github.io/sroc-charging-module-api-docs/#/customer/CreateCustomerChange | API docs}
+ *
+ * @param {Object} requestData The data that will be sent in the POST request
+ *
+ * @returns {Object} result An object representing the result of the request
+ * @returns {boolean} result.succeeded Whether the customer change request was successful
+ * @returns {Object} result.response Just a 201 status code if successful; or the error response if not
+ */
+async function go (requestData) {
+  const result = await ChargingModuleRequestLib.post('v3/wrls/customer-changes', requestData)
+
+  return result
+}
+
+module.exports = {
+  go
+}

--- a/test/services/charging-module/create-customer-change.service.test.js
+++ b/test/services/charging-module/create-customer-change.service.test.js
@@ -1,0 +1,115 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { describe, it, beforeEach, afterEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Things we need to stub
+const ChargingModuleRequestLib = require('../../../app/lib/charging-module-request.lib.js')
+
+// Thing under test
+const ChargingModuleCreateCustomerChangeService = require('../../../app/services/charging-module/create-customer-change.service.js')
+
+describe('Charging module create customer change service', () => {
+  const requestData = {
+    region: 'B',
+    customerReference: 'B88891136A',
+    customerName: 'SCP ESTATE LIMITED',
+    addressLine1: 'FAO Mr V P Anderson MBE',
+    addressLine2: 'ENVIRONMENT AGENCY',
+    addressLine3: 'HORIZON HOUSE',
+    addressLine4: 'DEANERY ROAD',
+    addressLine5: 'BRISTOL',
+    addressLine6: 'United Kingdom',
+    postcode: 'BS1 5AH'
+  }
+
+  afterEach(() => {
+    Sinon.restore()
+  })
+
+  describe('when the service can create a customer change', () => {
+    beforeEach(async () => {
+      Sinon.stub(ChargingModuleRequestLib, 'post').resolves({
+        succeeded: true,
+        response: {
+          info: {
+            gitCommit: '273604040a47e0977b0579a0fef0f09726d95e39',
+            dockerTag: 'ghcr.io/defra/sroc-charging-module-api:v0.19.0'
+          },
+          statusCode: 201
+        }
+      })
+    })
+
+    it('returns a `true` success status', async () => {
+      const result = await ChargingModuleCreateCustomerChangeService.go(requestData)
+
+      expect(result.succeeded).to.be.true()
+    })
+  })
+
+  describe('when the service cannot create a customer change', () => {
+    describe('because the request did not return a 2xx/3xx response', () => {
+      beforeEach(async () => {
+        Sinon.stub(ChargingModuleRequestLib, 'post').resolves({
+          succeeded: false,
+          response: {
+            info: {
+              gitCommit: '273604040a47e0977b0579a0fef0f09726d95e39',
+              dockerTag: 'ghcr.io/defra/sroc-charging-module-api:v0.19.0'
+            },
+            statusCode: 401,
+            body: {
+              statusCode: 401,
+              error: 'Unauthorized',
+              message: 'Invalid JWT: Token format not valid',
+              attributes: { error: 'Invalid JWT: Token format not valid' }
+            }
+          }
+        })
+      })
+
+      it('returns a `false` success status', async () => {
+        const result = await ChargingModuleCreateCustomerChangeService.go(requestData)
+
+        expect(result.succeeded).to.be.false()
+      })
+
+      it('returns the error in the `response`', async () => {
+        const result = await ChargingModuleCreateCustomerChangeService.go(requestData)
+
+        expect(result.response.body.statusCode).to.equal(401)
+        expect(result.response.body.error).to.equal('Unauthorized')
+        expect(result.response.body.message).to.equal('Invalid JWT: Token format not valid')
+      })
+    })
+
+    describe('because the request attempt returned an error, for example, TimeoutError', () => {
+      beforeEach(async () => {
+        Sinon.stub(ChargingModuleRequestLib, 'post').resolves({
+          succeeded: false,
+          response: new Error("Timeout awaiting 'request' for 5000ms")
+        })
+      })
+
+      it('returns a `false` success status', async () => {
+        const result = await ChargingModuleCreateCustomerChangeService.go(requestData)
+
+        expect(result.succeeded).to.be.false()
+      })
+
+      it('returns the error in the `response`', async () => {
+        const result = await ChargingModuleCreateCustomerChangeService.go(requestData)
+
+        expect(result.response.statusCode).not.to.exist()
+        expect(result.response.body).not.to.exist()
+        expect(result.response.message).to.equal("Timeout awaiting 'request' for 5000ms")
+      })
+    })
+  })
+})


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4092

We are working on migrating the change billing account address functionality from the legacy code to this project. A key part of this is being able to tell the [Charging Module API](https://github.com/DEFRA/sroc-charging-module-api) about the change!

This change adds a new Charging Module service which handles sending the request. Admittedly it is doing very little. However, adding it as a distinct service keeps it consistent with how we are handling requests to the Charging Module.