### PR TITLE
Create new presenter to format a date

### DIFF
--- a/app/presenters/base.presenter.js
+++ b/app/presenters/base.presenter.js
@@ -91,7 +91,7 @@ function formatLongDateTime (date) {
   return date.toLocaleDateString(
     'en-GB',
     { year: 'numeric', month: 'long', day: 'numeric', hour: '2-digit', minute: '2-digit', second: '2-digit' }
-    )
+  )
 }
 
 /**

--- a/app/presenters/base.presenter.js
+++ b/app/presenters/base.presenter.js
@@ -81,6 +81,20 @@ function formatLongDate (date) {
 }
 
 /**
+ * Formats a date into a human readable day, month, year and time string, for example, '12 September 2021 at 21:43:44'
+ *
+ * @param {Date} date The date to be formatted
+ *
+ * @returns {string} The date formatted as a 'DD MMMM YYYY at HH:MM:SS' string
+ */
+function formatLongDateTime (date) {
+  return date.toLocaleDateString(
+    'en-GB',
+    { year: 'numeric', month: 'long', day: 'numeric', hour: '2-digit', minute: '2-digit', second: '2-digit' }
+    )
+}
+
+/**
  * Formats a number which represents a value in pounds as a money string, for example, 1149 as '1149.00'
  *
  * @param {Number} value The value to display as currency. Assumed to be in pounds
@@ -114,6 +128,7 @@ module.exports = {
   formatAbstractionPeriod,
   formatChargingModuleDate,
   formatLongDate,
+  formatLongDateTime,
   formatNumberAsMoney,
   leftPadZeroes
 }

--- a/test/presenters/base.presenter.test.js
+++ b/test/presenters/base.presenter.test.js
@@ -106,6 +106,14 @@ describe('Base presenter', () => {
     })
   })
 
+  describe('#formatLongDateTime()', () => {
+    it('correctly formats the given date, for example, 12 September 2021 at 14:41:10', async () => {
+      const result = BasePresenter.formatLongDateTime(new Date('2021-09-12T14:41:10.511Z'))
+
+      expect(result).to.equal('12 September 2021 at 14:41:10')
+    })
+  })
+
   describe('#formatNumberAsMoney()', () => {
     const valueInPence = 1149.5
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4099

The update to the `health/info` page in PR https://github.com/DEFRA/water-abstraction-system/pull/376 requires a date to be formatted as a `DD MMMM YYYY at HH:MM:SS` string.

We have not converted a date to this format before so a new presenter is being created to ensure consistency should this format be required again.