### PR TITLE
Add missing CRM_V2 table constraints

### DIFF
--- a/db/migrations/20230904125928_alter-crm-v2-addresses.js
+++ b/db/migrations/20230904125928_alter-crm-v2-addresses.js
@@ -1,0 +1,21 @@
+'use strict'
+
+const tableName = 'addresses'
+
+exports.up = function (knex) {
+  return knex
+    .schema
+    .withSchema('crm_v2')
+    .alterTable(tableName, (table) => {
+      table.unique('uprn', { useConstraint: true })
+    })
+}
+
+exports.down = function (knex) {
+  return knex
+    .schema
+    .withSchema('crm_v2')
+    .alterTable(tableName, (table) => {
+      table.dropUnique('uprn')
+    })
+}

--- a/db/migrations/20230904140538_alter-crm-v2-companies.js
+++ b/db/migrations/20230904140538_alter-crm-v2-companies.js
@@ -1,0 +1,21 @@
+'use strict'
+
+const tableName = 'companies'
+
+exports.up = function (knex) {
+  return knex
+    .schema
+    .withSchema('crm_v2')
+    .alterTable(tableName, (table) => {
+      table.unique('company_number', { useConstraint: true })
+    })
+}
+
+exports.down = function (knex) {
+  return knex
+    .schema
+    .withSchema('crm_v2')
+    .alterTable(tableName, (table) => {
+      table.dropUnique('company_number')
+    })
+}

--- a/db/migrations/20230904140845_alter-crm-v2-invoice-account-addresses.js
+++ b/db/migrations/20230904140845_alter-crm-v2-invoice-account-addresses.js
@@ -1,0 +1,21 @@
+'use strict'
+
+const tableName = 'invoice_account_addresses'
+
+exports.up = function (knex) {
+  return knex
+    .schema
+    .withSchema('crm_v2')
+    .alterTable(tableName, (table) => {
+      table.unique(['invoice_account_id', 'start_date'], { useConstraint: true })
+    })
+}
+
+exports.down = function (knex) {
+  return knex
+    .schema
+    .withSchema('crm_v2')
+    .alterTable(tableName, (table) => {
+      table.dropUnique(['invoice_account_id', 'start_date'])
+    })
+}

--- a/test/models/crm-v2/address.model.test.js
+++ b/test/models/crm-v2/address.model.test.js
@@ -21,11 +21,13 @@ describe('Address model', () => {
 
   beforeEach(async () => {
     await DatabaseHelper.clean()
-
-    testRecord = await AddressHelper.add()
   })
 
   describe('Basic query', () => {
+    beforeEach(async () => {
+      testRecord = await AddressHelper.add()
+    })
+
     it('can successfully run a basic query', async () => {
       const result = await AddressModel.query().findById(testRecord.addressId)
 
@@ -44,7 +46,10 @@ describe('Address model', () => {
 
         testInvoiceAccountAddresses = []
         for (let i = 0; i < 2; i++) {
-          const invoiceAccountAddress = await InvoiceAccountAddressHelper.add({ addressId })
+          // NOTE: A constraint in the invoice_account_addresses table means you cannot have 2 records with the same
+          // invoiceAccountId and start date
+          const startDate = i === 0 ? new Date(2023, 8, 4) : new Date(2023, 8, 3)
+          const invoiceAccountAddress = await InvoiceAccountAddressHelper.add({ startDate, addressId })
           testInvoiceAccountAddresses.push(invoiceAccountAddress)
         }
       })

--- a/test/models/crm-v2/company.model.test.js
+++ b/test/models/crm-v2/company.model.test.js
@@ -21,11 +21,13 @@ describe('Company model', () => {
 
   beforeEach(async () => {
     await DatabaseHelper.clean()
-
-    testRecord = await CompanyHelper.add()
   })
 
   describe('Basic query', () => {
+    beforeEach(async () => {
+      testRecord = await CompanyHelper.add()
+    })
+
     it('can successfully run a basic query', async () => {
       const result = await CompanyModel.query().findById(testRecord.companyId)
 
@@ -44,7 +46,10 @@ describe('Company model', () => {
 
         testInvoiceAccountAddresses = []
         for (let i = 0; i < 2; i++) {
-          const invoiceAccountAddress = await InvoiceAccountAddressHelper.add({ agentCompanyId })
+          // NOTE: A constraint in the invoice_account_addresses table means you cannot have 2 records with the same
+          // invoiceAccountId and start date
+          const startDate = i === 0 ? new Date(2023, 8, 4) : new Date(2023, 8, 3)
+          const invoiceAccountAddress = await InvoiceAccountAddressHelper.add({ startDate, agentCompanyId })
           testInvoiceAccountAddresses.push(invoiceAccountAddress)
         }
       })

--- a/test/models/crm-v2/contact.model.test.js
+++ b/test/models/crm-v2/contact.model.test.js
@@ -21,11 +21,13 @@ describe('Contact model', () => {
 
   beforeEach(async () => {
     await DatabaseHelper.clean()
-
-    testRecord = await ContactHelper.add()
   })
 
   describe('Basic query', () => {
+    beforeEach(async () => {
+      testRecord = await ContactHelper.add()
+    })
+
     it('can successfully run a basic query', async () => {
       const result = await ContactModel.query().findById(testRecord.contactId)
 
@@ -44,7 +46,10 @@ describe('Contact model', () => {
 
         testInvoiceAccountAddresses = []
         for (let i = 0; i < 2; i++) {
-          const invoiceAccountAddress = await InvoiceAccountAddressHelper.add({ contactId })
+          // NOTE: A constraint in the invoice_account_addresses table means you cannot have 2 records with the same
+          // invoiceAccountId and start date
+          const startDate = i === 0 ? new Date(2023, 8, 4) : new Date(2023, 8, 3)
+          const invoiceAccountAddress = await InvoiceAccountAddressHelper.add({ startDate, contactId })
           testInvoiceAccountAddresses.push(invoiceAccountAddress)
         }
       })

--- a/test/models/crm-v2/invoice-account-address.model.test.js
+++ b/test/models/crm-v2/invoice-account-address.model.test.js
@@ -27,11 +27,13 @@ describe('Invoice Account Address model', () => {
 
   beforeEach(async () => {
     await DatabaseHelper.clean()
-
-    testRecord = await InvoiceAccountAddressHelper.add()
   })
 
   describe('Basic query', () => {
+    beforeEach(async () => {
+      testRecord = await InvoiceAccountAddressHelper.add()
+    })
+
     it('can successfully run a basic query', async () => {
       const result = await InvoiceAccountAddressModel.query().findById(testRecord.invoiceAccountAddressId)
 

--- a/test/models/crm-v2/invoice-account.model.test.js
+++ b/test/models/crm-v2/invoice-account.model.test.js
@@ -23,11 +23,13 @@ describe('Invoice Account model', () => {
 
   beforeEach(async () => {
     await DatabaseHelper.clean()
-
-    testRecord = await InvoiceAccountHelper.add()
   })
 
   describe('Basic query', () => {
+    beforeEach(async () => {
+      testRecord = await InvoiceAccountHelper.add()
+    })
+
     it('can successfully run a basic query', async () => {
       const result = await InvoiceAccountModel.query().findById(testRecord.invoiceAccountId)
 
@@ -74,7 +76,10 @@ describe('Invoice Account model', () => {
 
         testInvoiceAccountAddresses = []
         for (let i = 0; i < 2; i++) {
-          const invoiceAccountAddress = await InvoiceAccountAddressHelper.add({ invoiceAccountId })
+          // NOTE: A constraint in the invoice_account_addresses table means you cannot have 2 records with the same
+          // invoiceAccountId and start date
+          const startDate = i === 0 ? new Date(2023, 8, 4) : new Date(2023, 8, 3)
+          const invoiceAccountAddress = await InvoiceAccountAddressHelper.add({ startDate, invoiceAccountId })
           testInvoiceAccountAddresses.push(invoiceAccountAddress)
         }
       })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4092

We are migrating the change billing account address functionality from the legacy code to this project. In our test DB, we previously added migrations to recreate the CRM_V2 tables `addresses`, `companies` and `invoice_account_addresses`. But to keep things simple we usually don't bother with constraints as unless we really need them, we prefer to avoid using them.

Well, in the [new Billing Account change address service](https://github.com/DEFRA/water-abstraction-system/pull/400) we're adding we do! 🤦 We depend on the constraints to raise [ON CONFLICT errors](https://www.postgresql.org/docs/current/sql-insert.html#SQL-ON-CONFLICT) for our logic to work.

So, in order to test our new service we need to add the missing constraints to our migrations. We're doing that change separately because [Add new Billing Account change address service](https://github.com/DEFRA/water-abstraction-system/pull/400) is already pretty big 😬.