### PR TITLE
Fix missing schema from DatabaseHelper

### DIFF
--- a/test/support/helpers/database.helper.js
+++ b/test/support/helpers/database.helper.js
@@ -19,7 +19,7 @@ const { db } = require('../../../db/db.js')
  * identity columns. For example, if a table relies on an incrementing ID the query will reset that to 1.
  */
 async function clean () {
-  const schemas = ['crm_v2', 'water', 'returns']
+  const schemas = ['crm_v2', 'idm', 'water', 'returns']
 
   for (const schema of schemas) {
     const tables = await _tableNames(schema)


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4085

We are always doing this! 🤦

In [Create idm migrations for authentication plugin](https://github.com/DEFRA/water-abstraction-system/pull/384) we added migrations to create the `idm` schema and some tables. But we forgot to include the schema in our DatabaseHelper. Doh!