### PR TITLE
Only include return submissions for the billing period

### DIFF
--- a/app/services/check/two-part.service.js
+++ b/app/services/check/two-part.service.js
@@ -119,7 +119,10 @@ async function _fetchAndApplyReturns (billingPeriod, chargeVersion) {
       })
       .withGraphFetched('versions.lines')
       .modifyGraph('versions.lines', builder => {
-        builder.where('lines.quantity', '>', 0)
+        builder
+          .where('lines.quantity', '>', 0)
+          .where('lines.startDate', '<=', billingPeriod.endDate)
+          .where('lines.endDate', '>=', billingPeriod.startDate)
       })
 
     CalculateReturnsVolumes.go(billingPeriod, chargeReference.returns)


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4151

In https://eaflood.atlassian.net/browse/WATER-4098 we started to calculate the return volumes, specifically what was inside the return’s abstraction period and what was outside.

We wondered what happens when you have a return with a ‘return period’ that crosses two billing periods?

For example, return `v1:2:3/456` has a return period of '1 Nov 2021 to 31 Oct 2022’. It reports monthly and the abstraction period is ‘1 Feb to 30 June’. The billing period the engine is considering is ‘1 Apr 2022 to 31 Mar 2023’.

The engine matches the return because it crosses over the billing period. Currently, it is then calculating all the volume submitted for the return. But this means it includes submissions for Feb and Mar 2021.

We believe it shouldn’t include those submissions. So, when calculating the inside and outside abstraction period volumes for a return, the engine needs to be updated to ignore submissions outside the billing period.

This PR will achieve this by filtering out any return lines that are outside of the billing period.