### PR TITLE
Tweak data tear-down

### DIFF
--- a/app/services/data/tear-down/crm-schema.service.js
+++ b/app/services/data/tear-down/crm-schema.service.js
@@ -17,6 +17,15 @@ async function go () {
   await _deleteTestData('crm_v2.addresses')
   await _deleteDocuments()
   await _deleteTestData('crm_v2.contacts')
+
+  await _deleteCompanies()
+}
+
+async function _deleteCompanies () {
+  await db
+    .from('crm_v2.companies')
+    .whereLike('name', 'Big Farm Co Ltd%')
+    .del()
 }
 
 async function _deleteEntities () {
@@ -30,6 +39,7 @@ async function _deleteEntities () {
     .whereLike('entityNm', 'acceptance-test.%')
     .orWhereLike('entityNm', '%@example.com')
     .orWhereLike('entityNm', 'regression.tests.%')
+    .orWhereLike('entityNm', 'Big Farm Co Ltd%')
     .orWhere('source', 'acceptance-test-setup')
     .del()
 }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4138
https://eaflood.atlassian.net/browse/WATER-4077

When running the [water-abstraction-acceptance-tests](https://github.com/DEFRA/) recently, we encountered an issue where tests fail because 2 'Big Farm Co Ltd 01' companies are returned when searching for an existing company record. One is a test record, the other is from a previous test.

Because the one created in a previous test is not flagged as `is_test` it remains even after running the tear-down. So, we need to tweak the tear-down process for the `crm_v2.companies` table.