### PR TITLE
Fix issue allocating return volume

### DIFF
--- a/app/services/check/allocate-returns-volumes.service.js
+++ b/app/services/check/allocate-returns-volumes.service.js
@@ -20,7 +20,7 @@ function go (chargeReference) {
           // Calculate how much is left to allocated to the ChargeElement from the return
           let volumeLeftToAllocate = chargeElement.authorisedAnnualQuantity - chargeElement.billableAnnualQuantity
           // Check for the case that the return does not cover the full allocation
-          if (returnVolumeInMegalitres < volumeLeftToAllocate) {
+          if (returnVolumeInMegalitres <= volumeLeftToAllocate) {
             volumeLeftToAllocate = returnVolumeInMegalitres
           }
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4127

A issue has been spotted in the PR which deals with allocating the Returns volumes to the Charge Elements which was merged in https://github.com/DEFRA/water-abstraction-system/pull/436

The issue is that if the return volume exactly matches the `authorisedAnnualQuantity` the volume isn't allocated to that Charge Elelment. This PR will fix that bug.