### PR TITLE
Change where the allocated Return volume is held

### DIFF
--- a/app/services/check/allocate-returns-volumes.service.js
+++ b/app/services/check/allocate-returns-volumes.service.js
@@ -13,18 +13,21 @@ function go (chargeReference) {
     returnVolumeInMegalitres = returnData.volumes.total / 1000
     // Loop through each charge element
     chargeReference.chargeElements.forEach((chargeElement) => {
+      if (!chargeElement.allocatedReturnVolume) {
+        chargeElement.allocatedReturnVolume = 0
+      }
       // Check the chargeElement is not already fully allocated
-      if (chargeElement.billableAnnualQuantity < chargeElement.authorisedAnnualQuantity) {
+      if (chargeElement.allocatedReturnVolume < chargeElement.authorisedAnnualQuantity) {
         // Check if the return's purpose and abstraction period match the charge element
         if (_matchReturnToElement(returnData.metadata, chargeElement)) {
           // Calculate how much is left to allocated to the ChargeElement from the return
-          let volumeLeftToAllocate = chargeElement.authorisedAnnualQuantity - chargeElement.billableAnnualQuantity
+          let volumeLeftToAllocate = chargeElement.authorisedAnnualQuantity - chargeElement.allocatedReturnVolume
           // Check for the case that the return does not cover the full allocation
           if (returnVolumeInMegalitres < volumeLeftToAllocate) {
             volumeLeftToAllocate = returnVolumeInMegalitres
           }
 
-          chargeElement.billableAnnualQuantity += volumeLeftToAllocate
+          chargeElement.allocatedReturnVolume += volumeLeftToAllocate
           returnVolumeInMegalitres -= volumeLeftToAllocate
         }
       }

--- a/app/services/check/friendly-response.service.js
+++ b/app/services/check/friendly-response.service.js
@@ -107,8 +107,8 @@ function _formatFriendlyChargeReferences (friendlyChargeReferences, chargeRefere
 function _formatFriendlyChargeElements (friendlyChargeElements, chargeElements) {
   chargeElements.forEach((chargeElement) => {
     const {
+      allocatedReturnVolume,
       authorisedAnnualQuantity,
-      billableAnnualQuantity,
       chargePurposeId,
       description,
       isSection127AgreementEnabled,
@@ -126,7 +126,7 @@ function _formatFriendlyChargeElements (friendlyChargeElements, chargeElements) 
       description,
       abstractionPeriod: formatAbstractionPeriod(startDay, startMonth, endDay, endMonth),
       authorisedAnnualQuantity,
-      billableAnnualQuantity,
+      allocatedReturnVolume,
       timeLimit: _formatTimeLimit(timeLimitedStartDate, timeLimitedEndDate),
       loss
     }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4127

In a previous PR https://github.com/DEFRA/water-abstraction-system/pull/436 which dealt with allocating the Return volumes to Charge Elements. It was assumed that the `billableAnnualQuantity` data item could be used to hold the Return volumes allocated to a Charge Element. However, in very few cases, this could already contain data which will cause the Return volume allocation process to not work properly.

Therefore this PR will create a new data item on the Charge Element called `allocatedReturnVolume` that will be used to hold any Return volumes allocated to a particular Charge Element.