### PR TITLE
Implement mock return review

### DIFF
--- a/app/presenters/data/mock-returns-review.presenter.js
+++ b/app/presenters/data/mock-returns-review.presenter.js
@@ -1,0 +1,142 @@
+'use strict'
+
+/**
+ * Formats the response for the GET `/data/mock/{returns-review}` endpoint
+ * @module MockReturnsReviewPresenter
+ */
+
+const { capitalize, formatAbstractionPeriod, formatLongDate } = require('../base.presenter.js')
+
+const ISSUE_DESCRIPTIONS = {
+  10: 'No returns received',
+  20: 'Checking query',
+  30: 'Returns received but not processed',
+  40: 'Some returns IDs not received',
+  50: 'Returns received late',
+  60: 'Over abstraction',
+  70: 'No returns received',
+  80: 'Too early to bill',
+  90: 'Overlap of charge dates',
+  100: 'No matching charge element'
+}
+
+function go (billRunInfo, reviewDataByLicence) {
+  const response = {
+    ..._transformBillRunInfo(billRunInfo),
+    counts: {
+      errored: 0,
+      ready: 0
+    },
+    erroredLicences: [],
+    readyLicences: []
+  }
+
+  reviewDataByLicence.forEach((licence) => {
+    const twoPartTariffStatuses = []
+
+    licence.returnsEdited = licence.returnsEdited ? 'Yes' : ''
+
+    licence.financialYears.forEach((financialYear) => {
+      financialYear.chargeElements = []
+
+      financialYear.resultsMatchedByFinancialYear.forEach((result) => {
+        if (result.twoPartTariffStatus) {
+          twoPartTariffStatuses.push(result.twoPartTariffStatus)
+        }
+
+        financialYear.chargeElements.push(_transformResultToChargeElement(result))
+      })
+      delete financialYear.resultsMatchedByFinancialYear
+    })
+
+    licence.issue = _determineLicenceIssue(twoPartTariffStatuses)
+
+    if (licence.errored) {
+      response.counts.errored += 1
+      response.erroredLicences.push(licence)
+    } else {
+      response.counts.ready += 1
+      response.readyLicences.push(licence)
+    }
+  })
+
+  return response
+}
+
+function _determineLicenceIssue (twoPartTariffStatuses) {
+  if (twoPartTariffStatuses.length === 0) {
+    return ''
+  }
+
+  const uniqueStatuses = [...new Set(twoPartTariffStatuses)]
+
+  if (uniqueStatuses.length === 1) {
+    return _twoPartTariffStatusDescription(uniqueStatuses[0])
+  }
+
+  return 'Multiple errors'
+}
+
+function _transformBillRunInfo (billRunInfo) {
+  const { billingBatchId, billRunNumber, dateCreated, batchType, scheme, regionName } = billRunInfo
+
+  return {
+    billingBatchId,
+    billRunNumber,
+    dateCreated: formatLongDate(dateCreated),
+    region: capitalize(regionName),
+    billRunType: capitalize(batchType),
+    chargeScheme: scheme === 'sroc' ? 'Current' : 'Old'
+  }
+}
+
+function _transformResultToChargeElement (result) {
+  const {
+    calculatedVolume,
+    description,
+    invoiceAccountNumber,
+    loss,
+    purpose,
+    source,
+    season,
+    twoPartTariffStatus,
+    volume,
+    abstractionPeriodEndDay: endDay,
+    abstractionPeriodEndMonth: endMonth,
+    abstractionPeriodStartDay: startDay,
+    abstractionPeriodStartMonth: startMonth,
+    authorisedAnnualQuantity: authorisedQty,
+    billableAnnualQuantity: billableQty
+  } = result
+
+  return {
+    issue: _twoPartTariffStatusDescription(twoPartTariffStatus),
+    billableReturns: `${volume}Ml`,
+    reportedReturns: `${calculatedVolume}Ml`,
+    edited: volume !== calculatedVolume,
+    billingAccount: invoiceAccountNumber,
+    purpose: capitalize(purpose),
+    description,
+    chargePeriod: '',
+    abstractionPeriod: formatAbstractionPeriod(startDay, startMonth, endDay, endMonth),
+    authorisedQuantity: authorisedQty ? `${authorisedQty}Ml authorised` : 'Authorised not set',
+    billableQuantity: billableQty ? `${authorisedQty}Ml billable` : 'Billable not set',
+    source: capitalize(source),
+    season: capitalize(season),
+    loss: capitalize(loss)
+  }
+}
+
+function _twoPartTariffStatusDescription (statusCode) {
+  const description = ISSUE_DESCRIPTIONS[statusCode]
+
+  if (description) {
+    return description
+  }
+
+  return null
+}
+
+module.exports = {
+  go
+}

--- a/app/services/data/mock/generate-returns-review.service.js
+++ b/app/services/data/mock/generate-returns-review.service.js
@@ -5,24 +5,33 @@
  * @module GenerateReturnsReviewService
  */
 
-const BillRunVolumeModel = require('../../../../app/models/water/bill-run-volume.model.js')
 const { db } = require('../../../../db/db.js')
 
 const GenerateMockDataService = require('./generate-mock-data.service.js')
+const MockReturnsReviewPresenter = require('../../../presenters/data/mock-returns-review.presenter.js')
 
 async function go (id) {
-  const billRunVolumes = await _fetchBillRunVolumes(id)
+  const reviewData = await _fetchReviewData(id)
 
-  if (!billRunVolumes) {
+  if (!reviewData) {
     throw new Error('No matching bill run exists')
   }
 
-  return _response(billRunVolumes)
+  const billRunInfo = _extractBillRunInfo(reviewData[0])
+  const transformedReviewData = _transformToBeLicenceBased(reviewData)
+
+  return _response(billRunInfo, transformedReviewData)
 }
 
-async function _fetchBillRunVolumes (id) {
+async function _fetchReviewData (id) {
   return db
     .select(
+      'bb.billing_batch_id',
+      'bb.bill_run_number',
+      'bb.date_created',
+      'bb.batch_type',
+      'bb.scheme',
+      'r.name AS region_name',
       'cv.licence_id',
       'cv.licence_ref',
       'cv.invoice_account_id',
@@ -31,96 +40,121 @@ async function _fetchBillRunVolumes (id) {
       'bv.calculated_volume',
       'bv.volume',
       'bv.two_part_tariff_status',
-      'bv.two_part_tariff_error'
+      'bv.two_part_tariff_error',
+      'ce.description',
+      'ce.source',
+      'ce.season',
+      'ce.loss',
+      'ce.authorised_annual_quantity',
+      'ce.abstraction_period_start_day',
+      'ce.abstraction_period_start_month',
+      'ce.abstraction_period_end_day',
+      'ce.abstraction_period_end_month',
+      'ce.billable_annual_quantity',
+      'pu.description AS purpose'
     )
-    .from('water.billing_volumes AS bv')
+    .from('water.billing_batches AS bb')
+    .innerJoin('water.regions AS r', 'r.region_id', 'bb.region_id')
+    .innerJoin('water.billing_volumes AS bv', 'bv.billing_batch_id', 'bb.billing_batch_id')
     .innerJoin('water.charge_elements AS ce', 'ce.charge_element_id', 'bv.charge_element_id')
     .innerJoin('water.charge_versions AS cv', 'cv.charge_version_id', 'ce.charge_version_id')
     .innerJoin('crm_v2.invoice_accounts AS ia', 'ia.invoice_account_id', 'cv.invoice_account_id')
+    .innerJoin('water.purposes_uses AS pu', 'pu.purpose_use_id', 'ce.purpose_use_id')
     .where({
-      'bv.billing_batch_id': id
+      'bb.billing_batch_id': id
     })
     .orderBy('cv.licence_ref', 'bv.financial_year')
 }
 
-function _transformToBeLicenceBased (billRunVolumes) {
-  const allLicenceIds = billRunVolumes.map((billRunVolume) => {
-    return billRunVolume.licenceId
+function _extractBillRunInfo (reviewDataResult) {
+  const { billingBatchId, billRunNumber, dateCreated, batchType, scheme, regionName } = reviewDataResult
+
+  return {
+    billingBatchId,
+    billRunNumber,
+    dateCreated,
+    batchType,
+    scheme,
+    regionName
+  }
+}
+
+function _uniqueLicenceIds (allResults) {
+  const allLicenceIds = allResults.map((result) => {
+    return result.licenceId
   })
 
   const uniqueLicenceIds = [...new Set(allLicenceIds)]
+  uniqueLicenceIds.sort()
 
-  const licences = []
+  return uniqueLicenceIds
+}
 
-  uniqueLicenceIds.forEach((licenceId) => {
-    const volumesMatchedByLicence = billRunVolumes.filter((billRunVolume) => {
-      return billRunVolume.licenceId === licenceId
+function _uniqueFinanceYears (resultsMatchedByLicence) {
+  const allMatchedFinancialYears = resultsMatchedByLicence.map((result) => {
+    return result.financialYear
+  })
+
+  const uniqueFinancialYears = [...new Set(allMatchedFinancialYears)]
+  uniqueFinancialYears.sort()
+
+  return uniqueFinancialYears
+}
+
+function _generateLicence (licenceId, resultsMatchedByLicence) {
+  const { licenceRef } = resultsMatchedByLicence[0]
+
+  const errored = resultsMatchedByLicence.some((result) => {
+    return result.twoPartTariffError
+  })
+
+  const returnsEdited = resultsMatchedByLicence.some((result) => {
+    return result.volume !== result.calculatedVolume
+  })
+
+  return {
+    licenceId,
+    licenceReference: licenceRef,
+    billingContact: GenerateMockDataService.go().name,
+    issue: '',
+    errored,
+    returnsEdited,
+    financialYears: []
+  }
+}
+
+function _transformToBeLicenceBased (reviewData) {
+  const uniqueLicenceIds = _uniqueLicenceIds(reviewData)
+
+  return uniqueLicenceIds.map((licenceId) => {
+    const resultsMatchedByLicence = reviewData.filter((result) => {
+      return result.licenceId === licenceId
     })
-    const { licenceRef } = volumesMatchedByLicence[0]
 
-    const allMatchedFinancialYears = volumesMatchedByLicence.map((billRunVolume) => {
-      return billRunVolume.financialYear
-    })
+    const licence = _generateLicence(licenceId, resultsMatchedByLicence)
 
-    const uniqueFinancialYears = [...new Set(allMatchedFinancialYears)]
-    uniqueFinancialYears.sort()
-
-    const financialYears = []
+    const uniqueFinancialYears = _uniqueFinanceYears(resultsMatchedByLicence)
 
     uniqueFinancialYears.forEach((uniqueFinancialYear) => {
-      const volumesMatchedByFinancialYear = volumesMatchedByLicence.filter((billRunVolume) => {
-        return billRunVolume.financialYear === uniqueFinancialYear
-      })
-
-      const volumes = volumesMatchedByFinancialYear.map((billRunVolume) => {
-        const { invoiceAccountId, invoiceAccountNumber, calculatedVolume, volume, twoPartTariffStatus, twoPartTariffError } = billRunVolume
-        return {
-          invoiceAccountId,
-          invoiceAccountNumber,
-          reportedReturns: calculatedVolume,
-          billableReturns: volume,
-          twoPartTariffStatus,
-          twoPartTariffError,
-          issue: _twoPartTariffStatus(twoPartTariffStatus)
-        }
+      const resultsMatchedByFinancialYear = resultsMatchedByLicence.filter((result) => {
+        return result.financialYear === uniqueFinancialYear
       })
 
       const financialYear = {
         financialStartYear: uniqueFinancialYear - 1,
         financialEndYear: uniqueFinancialYear,
-        volumes
+        resultsMatchedByFinancialYear
       }
 
-      financialYears.push(financialYear)
+      licence.financialYears.push(financialYear)
     })
 
-    const licence = {
-      licenceId,
-      licenceReference: licenceRef,
-      billingContact: GenerateMockDataService.go().name,
-      financialYears
-    }
-
-    licences.push(licence)
+    return licence
   })
-
-  return licences
 }
 
-function _twoPartTariffStatus (statusCode) {
-  const index = Object.values(BillRunVolumeModel.twoPartTariffStatuses).findIndex((value) => {
-    return value === statusCode
-  })
-
-  if (index !== -1) {
-    return Object.keys(BillRunVolumeModel.twoPartTariffStatuses)[index]
-  }
-
-  return null
-}
-
-function _response (mockedReturnReviewData) {
-  return _transformToBeLicenceBased(mockedReturnReviewData)
+function _response (billRunInfo, reviewData) {
+  return MockReturnsReviewPresenter.go(billRunInfo, reviewData)
 }
 
 module.exports = {

--- a/app/services/data/mock/generate-returns-review.service.js
+++ b/app/services/data/mock/generate-returns-review.service.js
@@ -1,17 +1,126 @@
 'use strict'
 
+/**
+ * Generates mock returns review based on a real one
+ * @module GenerateReturnsReviewService
+ */
+
+const BillRunVolumeModel = require('../../../../app/models/water/bill-run-volume.model.js')
+const { db } = require('../../../../db/db.js')
+
+const GenerateMockDataService = require('./generate-mock-data.service.js')
+
 async function go (id) {
-  const mockedReturnReviewData = {
-    id: '83a67627-f523-4a0b-8875-24e990d1c89c',
-    name: 'boo',
-    otherId: id
+  const billRunVolumes = await _fetchBillRunVolumes(id)
+
+  if (!billRunVolumes) {
+    throw new Error('No matching bill run exists')
   }
 
-  return _response(mockedReturnReviewData)
+  return _response(billRunVolumes)
+}
+
+async function _fetchBillRunVolumes (id) {
+  return db
+    .select(
+      'cv.licence_id',
+      'cv.licence_ref',
+      'cv.invoice_account_id',
+      'ia.invoice_account_number',
+      'bv.financial_year',
+      'bv.calculated_volume',
+      'bv.volume',
+      'bv.two_part_tariff_status',
+      'bv.two_part_tariff_error'
+    )
+    .from('water.billing_volumes AS bv')
+    .innerJoin('water.charge_elements AS ce', 'ce.charge_element_id', 'bv.charge_element_id')
+    .innerJoin('water.charge_versions AS cv', 'cv.charge_version_id', 'ce.charge_version_id')
+    .innerJoin('crm_v2.invoice_accounts AS ia', 'ia.invoice_account_id', 'cv.invoice_account_id')
+    .where({
+      'bv.billing_batch_id': id
+    })
+    .orderBy('cv.licence_ref', 'bv.financial_year')
+}
+
+function _transformToBeLicenceBased (billRunVolumes) {
+  const allLicenceIds = billRunVolumes.map((billRunVolume) => {
+    return billRunVolume.licenceId
+  })
+
+  const uniqueLicenceIds = [...new Set(allLicenceIds)]
+
+  const licences = []
+
+  uniqueLicenceIds.forEach((licenceId) => {
+    const volumesMatchedByLicence = billRunVolumes.filter((billRunVolume) => {
+      return billRunVolume.licenceId === licenceId
+    })
+    const { licenceRef } = volumesMatchedByLicence[0]
+
+    const allMatchedFinancialYears = volumesMatchedByLicence.map((billRunVolume) => {
+      return billRunVolume.financialYear
+    })
+
+    const uniqueFinancialYears = [...new Set(allMatchedFinancialYears)]
+    uniqueFinancialYears.sort()
+
+    const financialYears = []
+
+    uniqueFinancialYears.forEach((uniqueFinancialYear) => {
+      const volumesMatchedByFinancialYear = volumesMatchedByLicence.filter((billRunVolume) => {
+        return billRunVolume.financialYear === uniqueFinancialYear
+      })
+
+      const volumes = volumesMatchedByFinancialYear.map((billRunVolume) => {
+        const { invoiceAccountId, invoiceAccountNumber, calculatedVolume, volume, twoPartTariffStatus, twoPartTariffError } = billRunVolume
+        return {
+          invoiceAccountId,
+          invoiceAccountNumber,
+          reportedReturns: calculatedVolume,
+          billableReturns: volume,
+          twoPartTariffStatus,
+          twoPartTariffError,
+          issue: _twoPartTariffStatus(twoPartTariffStatus)
+        }
+      })
+
+      const financialYear = {
+        financialStartYear: uniqueFinancialYear - 1,
+        financialEndYear: uniqueFinancialYear,
+        volumes
+      }
+
+      financialYears.push(financialYear)
+    })
+
+    const licence = {
+      licenceId,
+      licenceReference: licenceRef,
+      billingContact: GenerateMockDataService.go().name,
+      financialYears
+    }
+
+    licences.push(licence)
+  })
+
+  return licences
+}
+
+function _twoPartTariffStatus (statusCode) {
+  const index = Object.values(BillRunVolumeModel.twoPartTariffStatuses).findIndex((value) => {
+    return value === statusCode
+  })
+
+  if (index !== -1) {
+    return Object.keys(BillRunVolumeModel.twoPartTariffStatuses)[index]
+  }
+
+  return null
 }
 
 function _response (mockedReturnReviewData) {
-  return mockedReturnReviewData
+  return _transformToBeLicenceBased(mockedReturnReviewData)
 }
 
 module.exports = {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4152

We are currently working on the SROC two-part tariff bill. The first step of the process in the UI is to review how the returns have been matched. Our superstar design team are working on an improved design for the returns review screen but to do that they need data.

Enter our mock data service!

We previously [Create endpoint to generate fake data](https://github.com/DEFRA/water-abstraction-system/pull/347) which was focused on a bill run. The design team would love it if we could do the same for the data the current returns review page uses.

This change completes the work started in [Add new bill run volume model](https://github.com/DEFRA/water-abstraction-system/pull/440) to take an existing 2PT bill run and generate mock returns review data from it.