### PR TITLE
Add capitalize() method to base presenter

### DIFF
--- a/app/presenters/base.presenter.js
+++ b/app/presenters/base.presenter.js
@@ -1,6 +1,25 @@
 'use strict'
 
 /**
+ * Capitalize the first letter of each word in a string
+ *
+ * Will work for strings containing multiple words or only one.
+ *
+ * @param {string} value The string to capitalize
+ */
+function capitalize (value) {
+  const words = value.split(' ')
+  const capitalizedWords = []
+
+  words.forEach((word) => {
+    const capitalizedWord = word.charAt(0).toUpperCase() + word.slice(1)
+    capitalizedWords.push(capitalizedWord)
+  })
+
+  return capitalizedWords.join(' ')
+}
+
+/**
  * Converts a number which represents pence into pounds by dividing it by 100
  *
  * This is such a simply calculation it could be done in place. But by having it as a named method we make it clear
@@ -123,6 +142,7 @@ function leftPadZeroes (number, length) {
 }
 
 module.exports = {
+  capitalize,
   convertPenceToPounds,
   formatAbstractionDate,
   formatAbstractionPeriod,

--- a/app/presenters/base.presenter.js
+++ b/app/presenters/base.presenter.js
@@ -6,6 +6,8 @@
  * Will work for strings containing multiple words or only one.
  *
  * @param {string} value The string to capitalize
+ *
+ * @returns {string} The capitalized string
  */
 function capitalize (value) {
   const words = value.split(' ')

--- a/test/presenters/base.presenter.test.js
+++ b/test/presenters/base.presenter.test.js
@@ -11,6 +11,58 @@ const { expect } = Code
 const BasePresenter = require('../../app/presenters/base.presenter.js')
 
 describe('Base presenter', () => {
+  describe('#capitalize()', () => {
+    let valueToCapitalize
+
+    describe('when the value is a single word', () => {
+      beforeEach(() => {
+        valueToCapitalize = 'high'
+      })
+
+      it('correctly returns the value capitalized, for example, High', async () => {
+        const result = BasePresenter.capitalize(valueToCapitalize)
+
+        expect(result).to.equal('High')
+      })
+    })
+
+    describe('when the value is multiple words', () => {
+      beforeEach(() => {
+        valueToCapitalize = 'spray irrigation'
+      })
+
+      it('correctly returns the value capitalized, for example, Spray Irrigation', async () => {
+        const result = BasePresenter.capitalize(valueToCapitalize)
+
+        expect(result).to.equal('Spray Irrigation')
+      })
+    })
+
+    describe('when the value contains a symbol', () => {
+      beforeEach(() => {
+        valueToCapitalize = 'spray irrigation - direct'
+      })
+
+      it('correctly returns the value capitalized, for example, Spray Irrigation - Direct', async () => {
+        const result = BasePresenter.capitalize(valueToCapitalize)
+
+        expect(result).to.equal('Spray Irrigation - Direct')
+      })
+    })
+
+    describe('when the value is all capitals', () => {
+      beforeEach(() => {
+        valueToCapitalize = 'SPRAY IRRIGATION'
+      })
+
+      it('correctly returns the value unchanged, for example, SPRAY IRRIGATION', async () => {
+        const result = BasePresenter.capitalize(valueToCapitalize)
+
+        expect(result).to.equal('SPRAY IRRIGATION')
+      })
+    })
+  })
+
   describe('#convertPenceToPounds()', () => {
     let valueInPence
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4152

We are currently working on the SROC two-part tariff bill. The first step of the process in the UI is to review how the returns have been matched. Our superstar design team are working on an improved design for the returns review screen but to do that they need data.

This led us to start [Implement mock return review](https://github.com/DEFRA/water-abstraction-system/pull/447). A requirement that came out of that was the ability to capitalize certain values, for example, loss is recorded in the DB as `high` but when presenting it we want to see `High`.

As we start to build views and 'present' the data for them we're going to need this in more and more cases.

So, this change adds a `capitalize()` method to our base presenter.