### PR TITLE
Create migration script, model, helper and unit tests for `licence_versions`

### DIFF
--- a/app/models/water/licence-version.model.js
+++ b/app/models/water/licence-version.model.js
@@ -1,0 +1,42 @@
+'use strict'
+
+/**
+ * Model for licenceVersions
+ * @module LicenceVersionModel
+ */
+
+const { Model } = require('objection')
+
+const WaterBaseModel = require('./water-base.model.js')
+
+class LicenceVersionModel extends WaterBaseModel {
+  static get tableName () {
+    return 'licenceVersions'
+  }
+
+  static get idColumn () {
+    return 'licenceVersionId'
+  }
+
+  static get translations () {
+    return [
+      { database: 'dateCreated', model: 'createdAt' },
+      { database: 'dateUpdated', model: 'updatedAt' }
+    ]
+  }
+
+  static get relationMappings () {
+    return {
+      licence: {
+        relation: Model.BelongsToOneRelation,
+        modelClass: 'licence.model',
+        join: {
+          from: 'licenceVersions.licenceId',
+          to: 'licences.licenceId'
+        }
+      }
+    }
+  }
+}
+
+module.exports = LicenceVersionModel

--- a/app/models/water/licence.model.js
+++ b/app/models/water/licence.model.js
@@ -58,6 +58,14 @@ class LicenceModel extends WaterBaseModel {
           from: 'licences.licenceId',
           to: 'chargeVersionWorkflows.licenceId'
         }
+      },
+      licenceVersions: {
+        relation: Model.HasManyRelation,
+        modelClass: 'licence-version.model',
+        join: {
+          from: 'licences.licenceId',
+          to: 'licenceVersions.licenceId'
+        }
       }
     }
   }

--- a/db/migrations/20231009155523_create-water-licence-versions.js
+++ b/db/migrations/20231009155523_create-water-licence-versions.js
@@ -1,0 +1,34 @@
+'use strict'
+
+const tableName = 'licence_versions'
+
+exports.up = function (knex) {
+  return knex
+    .schema
+    .withSchema('water')
+    .createTable(tableName, (table) => {
+      // Primary Key
+      table.uuid('licence_version_id').primary().defaultTo(knex.raw('gen_random_uuid()'))
+
+      // Data
+      table.uuid('licence_id').notNullable()
+      table.integer('issue').notNullable()
+      table.integer('increment').notNullable()
+      table.string('status').notNullable()
+      table.date('start_date').notNullable()
+      table.date('end_date')
+      table.string('external_id').notNullable()
+      table.boolean('is_test').notNullable().defaultTo(false)
+
+      // Legacy timestamps
+      table.timestamp('date_created', { useTz: false }).notNullable()
+      table.timestamp('date_updated', { useTz: false }).notNullable()
+    })
+}
+
+exports.down = function (knex) {
+  return knex
+    .schema
+    .withSchema('water')
+    .dropTableIfExists(tableName)
+}

--- a/test/models/water/licence-version.model.test.js
+++ b/test/models/water/licence-version.model.test.js
@@ -1,0 +1,68 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const DatabaseHelper = require('../../support/helpers/database.helper.js')
+const LicenceHelper = require('../../support/helpers/water/licence.helper.js')
+const LicenceModel = require('../../../app/models/water/licence.model.js')
+const LicenceVersionHelper = require('../../support/helpers/water/licence-version.helper.js')
+
+// Thing under test
+const LicenceVersionModel = require('../../../app/models/water/licence-version.model.js')
+
+describe('Licence Version model', () => {
+  let testRecord
+
+  beforeEach(async () => {
+    await DatabaseHelper.clean()
+
+    testRecord = await LicenceVersionHelper.add()
+  })
+
+  describe('Basic query', () => {
+    it('can successfully run a basic query', async () => {
+      const result = await LicenceVersionModel.query().findById(testRecord.licenceVersionId)
+
+      expect(result).to.be.an.instanceOf(LicenceVersionModel)
+      expect(result.licenceVersionId).to.equal(testRecord.licenceVersionId)
+    })
+  })
+
+  describe('Relationships', () => {
+    describe('when linking to licence', () => {
+      let testLicence
+
+      beforeEach(async () => {
+        testLicence = await LicenceHelper.add()
+
+        const { licenceId } = testLicence
+        testRecord = await LicenceVersionHelper.add({ licenceId })
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await LicenceVersionModel.query()
+          .innerJoinRelated('licence')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the licence', async () => {
+        const result = await LicenceVersionModel.query()
+          .findById(testRecord.licenceVersionId)
+          .withGraphFetched('licence')
+
+        expect(result).to.be.instanceOf(LicenceVersionModel)
+        expect(result.licenceVersionId).to.equal(testRecord.licenceVersionId)
+
+        expect(result.licence).to.be.an.instanceOf(LicenceModel)
+        expect(result.licence).to.equal(testLicence)
+      })
+    })
+  })
+})

--- a/test/models/water/licence.model.test.js
+++ b/test/models/water/licence.model.test.js
@@ -14,6 +14,8 @@ const ChargeVersionHelper = require('../../support/helpers/water/charge-version.
 const ChargeVersionModel = require('../../../app/models/water/charge-version.model.js')
 const DatabaseHelper = require('../../support/helpers/database.helper.js')
 const LicenceHelper = require('../../support/helpers/water/licence.helper.js')
+const LicenceVersionHelper = require('../../support/helpers/water/licence-version.helper.js')
+const LicenceVersionModel = require('../../../app/models/water/licence-version.model.js')
 const RegionHelper = require('../../support/helpers/water/region.helper.js')
 const RegionModel = require('../../../app/models/water/region.model.js')
 const WorkflowHelper = require('../../support/helpers/water/workflow.helper.js')
@@ -173,6 +175,41 @@ describe('Licence model', () => {
         expect(result.workflows[0]).to.be.an.instanceOf(WorkflowModel)
         expect(result.workflows).to.include(testWorkflows[0])
         expect(result.workflows).to.include(testWorkflows[1])
+      })
+    })
+
+    describe('when linking to licence versions', () => {
+      let testLicenceVersions
+
+      beforeEach(async () => {
+        const { licenceId } = testRecord
+
+        testLicenceVersions = []
+        for (let i = 0; i < 2; i++) {
+          const licenceVersion = await LicenceVersionHelper.add({ licenceId })
+          testLicenceVersions.push(licenceVersion)
+        }
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await LicenceModel.query()
+          .innerJoinRelated('licenceVersions')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the licence versions', async () => {
+        const result = await LicenceModel.query()
+          .findById(testRecord.licenceId)
+          .withGraphFetched('licenceVersions')
+
+        expect(result).to.be.instanceOf(LicenceModel)
+        expect(result.licenceId).to.equal(testRecord.licenceId)
+
+        expect(result.licenceVersions).to.be.an.array()
+        expect(result.licenceVersions[0]).to.be.an.instanceOf(LicenceVersionModel)
+        expect(result.licenceVersions).to.include(testLicenceVersions[0])
+        expect(result.licenceVersions).to.include(testLicenceVersions[1])
       })
     })
   })

--- a/test/support/helpers/water/licence-version.helper.js
+++ b/test/support/helpers/water/licence-version.helper.js
@@ -4,7 +4,7 @@
  * @module LicenceVersionHelper
  */
 
-const { generateUUID } = require('../../../../app/lib/general.lib.js')
+const { generateUUID, timestampForPostgres } = require('../../../../app/lib/general.lib.js')
 const LicenceVersionModel = require('../../../../app/models/water/licence-version.model.js')
 
 /**
@@ -42,6 +42,8 @@ async function add (data = {}) {
  * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
  */
 function defaults (data = {}) {
+  const timestamp = timestampForPostgres()
+
   const defaults = {
     licenceId: generateUUID(),
     issue: 1,
@@ -49,8 +51,8 @@ function defaults (data = {}) {
     status: 'current',
     startDate: new Date('2022-01-01'),
     externalId: '9:99999:1:0',
-    createdAt: new Date(),
-    updatedAt: new Date()
+    createdAt: timestamp,
+    updatedAt: timestamp
   }
 
   return {

--- a/test/support/helpers/water/licence-version.helper.js
+++ b/test/support/helpers/water/licence-version.helper.js
@@ -23,7 +23,7 @@ const LicenceVersionModel = require('../../../../app/models/water/licence-versio
  *
  * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
  *
- * @returns {module:LicenceModel} The instance of the newly created record
+ * @returns {module:LicenceVersionModel} The instance of the newly created record
  */
 async function add (data = {}) {
   const insertData = defaults(data)

--- a/test/support/helpers/water/licence-version.helper.js
+++ b/test/support/helpers/water/licence-version.helper.js
@@ -5,6 +5,7 @@
  */
 
 const { generateUUID, timestampForPostgres } = require('../../../../app/lib/general.lib.js')
+const { randomInteger } = require('../general.helper.js')
 const LicenceVersionModel = require('../../../../app/models/water/licence-version.model.js')
 
 /**
@@ -50,7 +51,7 @@ function defaults (data = {}) {
     increment: 0,
     status: 'current',
     startDate: new Date('2022-01-01'),
-    externalId: '9:99999:1:0',
+    externalId: `9:${randomInteger(10000, 99999)}:1:0`,
     createdAt: timestamp,
     updatedAt: timestamp
   }

--- a/test/support/helpers/water/licence-version.helper.js
+++ b/test/support/helpers/water/licence-version.helper.js
@@ -18,7 +18,7 @@ const LicenceVersionModel = require('../../../../app/models/water/licence-versio
  * - `increment` - 0
  * - `status` - 'current'
  * - `startDate` - new Date('2022-01-01')
- * - `externalId` - '9:99999:1:0'
+ * - `externalId` - [randomly generated - 9:99999:1:0]
  * - `createdAt` - new Date()
  * - `updatedAt` - new Date()
  *

--- a/test/support/helpers/water/licence-version.helper.js
+++ b/test/support/helpers/water/licence-version.helper.js
@@ -1,0 +1,65 @@
+'use strict'
+
+/**
+ * @module LicenceVersionHelper
+ */
+
+const { generateUUID } = require('../../../../app/lib/general.lib.js')
+const LicenceVersionModel = require('../../../../app/models/water/licence-version.model.js')
+
+/**
+ * Add a new licence version
+ *
+ * If no `data` is provided, default values will be used. These are
+ *
+ * - `licenceId` - [random UUID]
+ * - `issue` - 1
+ * - `increment` - 0
+ * - `status` - 'current'
+ * - `startDate` - new Date('2022-01-01')
+ * - `externalId` - '9:99999:1:0'
+ * - `createdAt` - new Date()
+ * - `updatedAt` - new Date()
+ *
+ * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ *
+ * @returns {module:LicenceModel} The instance of the newly created record
+ */
+async function add (data = {}) {
+  const insertData = defaults(data)
+
+  return LicenceVersionModel.query()
+    .insert({ ...insertData })
+    .returning('*')
+}
+
+/**
+ * Returns the defaults used when creating a new licence version
+ *
+ * It will override or append to them any data provided. Mainly used by the `add()` method, we make it available
+ * for use in tests to avoid having to duplicate values.
+ *
+ * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ */
+function defaults (data = {}) {
+  const defaults = {
+    licenceId: generateUUID(),
+    issue: 1,
+    increment: 0,
+    status: 'current',
+    startDate: new Date('2022-01-01'),
+    externalId: '9:99999:1:0',
+    createdAt: new Date(),
+    updatedAt: new Date()
+  }
+
+  return {
+    ...defaults,
+    ...data
+  }
+}
+
+module.exports = {
+  add,
+  defaults
+}

--- a/test/support/helpers/water/licence-version.helper.js
+++ b/test/support/helpers/water/licence-version.helper.js
@@ -34,7 +34,7 @@ async function add (data = {}) {
 }
 
 /**
- * Returns the defaults used when creating a new licence version
+ * Returns the defaults used
  *
  * It will override or append to them any data provided. Mainly used by the `add()` method, we make it available
  * for use in tests to avoid having to duplicate values.


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3486

Whilst working on the unit tests for the enhancement in this PR https://github.com/DEFRA/water-abstraction-system/pull/443 it was found that we would need the migration script, model, helper and unit tests for table `licence_versions`.

These will be created in this PR.