### PR TITLE
Add `system` to new status page

### DIFF
--- a/app/services/health/fetch-system-info.service.js
+++ b/app/services/health/fetch-system-info.service.js
@@ -18,8 +18,11 @@ const { version } = require('../../../package.json')
  */
 async function go () {
   return {
+    name: 'System',
+    serviceName: 'system',
     version,
-    commit: await _getCommitHash()
+    commit: await _getCommitHash(),
+    jobs: []
   }
 }
 

--- a/app/services/health/fetch-system-info.service.js
+++ b/app/services/health/fetch-system-info.service.js
@@ -1,7 +1,7 @@
 'use strict'
 
 /**
- * Returns the version and commit hash for the `system` repo
+ * Returns information about the `system` repo in the format required by the info service
  * @module FetchSystemInfoService
  */
 
@@ -12,9 +12,9 @@ const exec = util.promisify(require('child_process').exec)
 const { version } = require('../../../package.json')
 
 /**
- * Returns the version and commit hash for the `system` repo
+ * Returns information about the `system` repo in the format required by the info service
  *
- * @returns {Object} An object containing the `version` & `commit`
+ * @returns {Object} An object containing the `name`, `serviceName`, `version`, `commit` & `jobs`
  */
 async function go () {
   return {

--- a/app/services/health/fetch-system-info.service.js
+++ b/app/services/health/fetch-system-info.service.js
@@ -1,0 +1,37 @@
+'use strict'
+
+/**
+ * Returns the version and commit hash for the `system` repo
+ * @module FetchSystemInfoService
+ */
+
+// We use promisify to wrap exec in a promise. This allows us to await it without resorting to using callbacks.
+const util = require('util')
+const exec = util.promisify(require('child_process').exec)
+
+const { version } = require('../../../package.json')
+
+/**
+ * Returns the version and commit hash for the `system` repo
+ *
+ * @returns {Object} An object containing the `version` & `commit`
+ */
+async function go () {
+  return {
+    version,
+    commit: await _getCommitHash()
+  }
+}
+
+async function _getCommitHash () {
+  try {
+    const { stdout, stderr } = await exec('git rev-parse HEAD')
+    return stderr ? `ERROR: ${stderr}` : stdout.replace('\n', '')
+  } catch (error) {
+    return `ERROR: ${error.message}`
+  }
+}
+
+module.exports = {
+  go
+}

--- a/test/services/health/fetch-system-info.service.test.js
+++ b/test/services/health/fetch-system-info.service.test.js
@@ -17,7 +17,10 @@ describe('Fetch System Info service', () => {
   it('returns the systems version and commit hash', async () => {
     const result = await FetchSystemInfoService.go()
 
+    expect(result.name).to.equal('System')
+    expect(result.serviceName).to.equal('system')
     expect(result.version).to.equal(version)
     expect(result.commit).to.exist()
+    expect(result.jobs).to.have.length(0)
   })
 })

--- a/test/services/health/fetch-system-info.service.test.js
+++ b/test/services/health/fetch-system-info.service.test.js
@@ -1,0 +1,23 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const { version } = require('../../../package.json')
+
+// Thing under test
+const FetchSystemInfoService = require('../../../app/services/health/fetch-system-info.service.js')
+
+describe.only('Fetch System Info service', () => {
+  it('returns the systems version and commit hash', async () => {
+    const result = await FetchSystemInfoService.go()
+
+    expect(result.version).to.equal(version)
+    expect(result.commit).to.exist()
+  })
+})

--- a/test/services/health/fetch-system-info.service.test.js
+++ b/test/services/health/fetch-system-info.service.test.js
@@ -13,7 +13,7 @@ const { version } = require('../../../package.json')
 // Thing under test
 const FetchSystemInfoService = require('../../../app/services/health/fetch-system-info.service.js')
 
-describe.only('Fetch System Info service', () => {
+describe('Fetch System Info service', () => {
   it('returns the systems version and commit hash', async () => {
     const result = await FetchSystemInfoService.go()
 

--- a/test/services/health/info.service.test.js
+++ b/test/services/health/info.service.test.js
@@ -14,8 +14,8 @@ const servicesConfig = require('../../../config/services.config.js')
 
 // Things we need to stub
 const ChargingModuleRequestLib = require('../../../app/lib/charging-module-request.lib.js')
-const CreateRedisClient = require('../../../app/services/health/create-redis-client.service.js')
-const FetchImportJobs = require('../../../app/services/health/fetch-import-jobs.service.js')
+const CreateRedisClientService = require('../../../app/services/health/create-redis-client.service.js')
+const FetchImportJobsService = require('../../../app/services/health/fetch-import-jobs.service.js')
 const LegacyRequestLib = require('../../../app/lib/legacy-request.lib.js')
 const RequestLib = require('../../../app/lib/request.lib.js')
 
@@ -65,10 +65,10 @@ describe('Info service', () => {
 
   beforeEach(() => {
     chargingModuleRequestLibStub = Sinon.stub(ChargingModuleRequestLib, 'get')
-    fetchImportJobsStub = Sinon.stub(FetchImportJobs, 'go')
+    fetchImportJobsStub = Sinon.stub(FetchImportJobsService, 'go')
     legacyRequestLibStub = Sinon.stub(LegacyRequestLib, 'get')
     requestLibStub = Sinon.stub(RequestLib, 'get')
-    redisStub = Sinon.stub(CreateRedisClient, 'go')
+    redisStub = Sinon.stub(CreateRedisClientService, 'go')
 
     // These requests will remain unchanged throughout the tests. We do alter the ones to the AddressFacade and the
     // water-api (foreground-service) though, which is why they are defined separately in each test.

--- a/test/services/health/info.service.test.js
+++ b/test/services/health/info.service.test.js
@@ -126,7 +126,7 @@ describe('Info service', () => {
         'virusScannerData', 'redisConnectivityData', 'addressFacadeData', 'chargingModuleData', 'appData'
       ])
 
-      expect(result.appData).to.have.length(10)
+      expect(result.appData).to.have.length(11)
       expect(result.appData[0].name).to.equal('Import')
       expect(result.appData[0].serviceName).to.equal('import')
       expect(result.appData[0].version).to.equal('9.0.99')
@@ -189,7 +189,7 @@ describe('Info service', () => {
         expect(result).to.include([
           'virusScannerData', 'redisConnectivityData', 'addressFacadeData', 'chargingModuleData', 'appData'
         ])
-        expect(result.appData).to.have.length(10)
+        expect(result.appData).to.have.length(11)
         expect(result.appData[0].version).to.equal('9.0.99')
         expect(result.appData[0].jobs).to.have.length(2)
 
@@ -232,7 +232,7 @@ describe('Info service', () => {
         expect(result).to.include([
           'virusScannerData', 'redisConnectivityData', 'addressFacadeData', 'chargingModuleData', 'appData'
         ])
-        expect(result.appData).to.have.length(10)
+        expect(result.appData).to.have.length(11)
         expect(result.appData[0].version).to.equal('9.0.99')
         expect(result.appData[0].jobs).to.have.length(2)
 
@@ -259,7 +259,7 @@ describe('Info service', () => {
         expect(result).to.include([
           'virusScannerData', 'redisConnectivityData', 'addressFacadeData', 'chargingModuleData', 'appData'
         ])
-        expect(result.appData).to.have.length(10)
+        expect(result.appData).to.have.length(11)
         expect(result.appData[0].version).to.equal('9.0.99')
         expect(result.appData[0].jobs).to.have.length(2)
 
@@ -301,7 +301,7 @@ describe('Info service', () => {
         expect(result).to.include([
           'virusScannerData', 'redisConnectivityData', 'addressFacadeData', 'chargingModuleData', 'appData'
         ])
-        expect(result.appData).to.have.length(10)
+        expect(result.appData).to.have.length(11)
         expect(result.appData[0].version).to.equal('9.0.99')
         expect(result.appData[0].jobs).to.have.length(0)
 
@@ -321,7 +321,7 @@ describe('Info service', () => {
         expect(result).to.include([
           'virusScannerData', 'redisConnectivityData', 'addressFacadeData', 'chargingModuleData', 'appData'
         ])
-        expect(result.appData).to.have.length(10)
+        expect(result.appData).to.have.length(11)
         expect(result.appData[0].version).to.equal('9.0.99')
         expect(result.appData[0].jobs).to.have.length(0)
 
@@ -365,7 +365,7 @@ describe('Info service', () => {
         expect(result).to.include([
           'virusScannerData', 'redisConnectivityData', 'addressFacadeData', 'chargingModuleData', 'appData'
         ])
-        expect(result.appData).to.have.length(10)
+        expect(result.appData).to.have.length(11)
         expect(result.appData[0].version).to.equal('9.0.99')
         expect(result.appData[0].jobs).to.have.length(2)
 
@@ -392,7 +392,7 @@ describe('Info service', () => {
         expect(result).to.include([
           'virusScannerData', 'redisConnectivityData', 'addressFacadeData', 'chargingModuleData', 'appData'
         ])
-        expect(result.appData).to.have.length(10)
+        expect(result.appData).to.have.length(11)
         expect(result.appData[0].version).to.equal('9.0.99')
         expect(result.appData[0].jobs).to.have.length(2)
 


### PR DESCRIPTION
The new `health/info` page does not contain the Version & Commit hash for the system repo. This PR will add those details.