### PR TITLE
Actually remove server.dependency from auth plugin

### DIFF
--- a/app/plugins/auth.plugin.js
+++ b/app/plugins/auth.plugin.js
@@ -36,22 +36,19 @@ const TWO_HOURS_IN_MS = 2 * 60 * 60 * 1000
 const AuthPlugin = {
   name: 'authentication',
   register: async (server, _options) => {
-    // We wait for @hapi/cookie to be registered before setting up the authentication strategy
-    server.dependency('@hapi/cookie', async (server) => {
-      server.auth.strategy('session', 'cookie', {
-        cookie: {
-          name: 'sid',
-          password: AuthenticationConfig.password,
-          isSecure: false,
-          isSameSite: 'Lax',
-          ttl: TWO_HOURS_IN_MS,
-          isHttpOnly: true
-        },
-        redirectTo: '/signin',
-        validate: async (_request, session) => {
-          return AuthService.go(session.userId)
-        }
-      })
+    server.auth.strategy('session', 'cookie', {
+      cookie: {
+        name: 'sid',
+        password: AuthenticationConfig.password,
+        isSecure: false,
+        isSameSite: 'Lax',
+        ttl: TWO_HOURS_IN_MS,
+        isHttpOnly: true
+      },
+      redirectTo: '/signin',
+      validate: async (_request, session) => {
+        return AuthService.go(session.userId)
+      }
     })
   }
 }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4085

Doh! Forgot to do this in [Fix and rename Authentication plugin](https://github.com/DEFRA/water-abstraction-system/pull/464).

It's not working for us and we need to remove it to enable the default auth strategy to work.