### PR TITLE
Handle unauthorized errors plus return safe codes

### DIFF
--- a/app/services/plugins/error-pages.service.js
+++ b/app/services/plugins/error-pages.service.js
@@ -36,6 +36,8 @@ function _logError (statusCode, request) {
 
   if (statusCode === 404) {
     global.GlobalNotifier.omg('Page not found', { path: request.path })
+  } else if (statusCode === 403) {
+    global.GlobalNotifier.omg('Not authorised', { path: request.path })
   } else if (response.isBoom) {
     global.GlobalNotifier.omfg(response.message, {}, response)
   }
@@ -45,6 +47,12 @@ function _statusCode (request) {
   const { response } = request
 
   if (response.isBoom) {
+    const { statusCode } = response.output
+
+    if ([404, 403].includes(statusCode)) {
+      return 404
+    }
+
     return response.output.statusCode
   }
 

--- a/test/services/plugins/error-pages.service.test.js
+++ b/test/services/plugins/error-pages.service.test.js
@@ -60,12 +60,6 @@ describe('Error pages service', () => {
       }
     })
 
-    it('returns the correct status code', () => {
-      const result = ErrorPagesService.go(request)
-
-      expect(result.statusCode).to.equal(boom500Response.output.statusCode)
-    })
-
     it('logs an error', () => {
       ErrorPagesService.go(request)
 
@@ -82,6 +76,12 @@ describe('Error pages service', () => {
 
         expect(result.stopResponse).to.be.false()
       })
+
+      it('returns the original status code', () => {
+        const result = ErrorPagesService.go(request)
+
+        expect(result.statusCode).to.equal(500)
+      })
     })
 
     describe('and the route is not configured for plain output (redirect to error page)', () => {
@@ -89,6 +89,12 @@ describe('Error pages service', () => {
         const result = ErrorPagesService.go(request)
 
         expect(result.stopResponse).to.be.true()
+      })
+
+      it("returns a 'safe' status code", () => {
+        const result = ErrorPagesService.go(request)
+
+        expect(result.statusCode).to.equal(200)
       })
     })
   })

--- a/test/services/plugins/error-pages.service.test.js
+++ b/test/services/plugins/error-pages.service.test.js
@@ -148,12 +148,6 @@ describe('Error pages service', () => {
       }
     })
 
-    it('returns the correct status code', () => {
-      const result = ErrorPagesService.go(request)
-
-      expect(result.statusCode).to.equal(404)
-    })
-
     it('logs a message', () => {
       ErrorPagesService.go(request)
 
@@ -170,6 +164,12 @@ describe('Error pages service', () => {
 
         expect(result.stopResponse).to.be.false()
       })
+
+      it('returns the original status code', () => {
+        const result = ErrorPagesService.go(request)
+
+        expect(result.statusCode).to.equal(403)
+      })
     })
 
     describe('and the route is not configured (redirect to error page)', () => {
@@ -181,6 +181,12 @@ describe('Error pages service', () => {
         const result = ErrorPagesService.go(request)
 
         expect(result.stopResponse).to.be.true()
+      })
+
+      it("returns a 'safe' status code", () => {
+        const result = ErrorPagesService.go(request)
+
+        expect(result.statusCode).to.equal(404)
       })
     })
   })

--- a/test/services/plugins/error-pages.service.test.js
+++ b/test/services/plugins/error-pages.service.test.js
@@ -103,7 +103,7 @@ describe('Error pages service', () => {
     beforeEach(() => {
       request = {
         response: boom404Response,
-        route: { settings: { app: { plainOutput: true } } },
+        route: { settings: { } },
         path
       }
     })
@@ -111,7 +111,7 @@ describe('Error pages service', () => {
     it('returns the correct status code', () => {
       const result = ErrorPagesService.go(request)
 
-      expect(result.statusCode).to.equal(boom404Response.output.statusCode)
+      expect(result.statusCode).to.equal(404)
     })
 
     it('logs a message', () => {
@@ -133,10 +133,6 @@ describe('Error pages service', () => {
     })
 
     describe('and the route is not configured (redirect to error page)', () => {
-      beforeEach(() => {
-        request.route = { settings: { } }
-      })
-
       it('tells the plugin to stop the response and redirect to an error page', () => {
         const result = ErrorPagesService.go(request)
 
@@ -149,7 +145,7 @@ describe('Error pages service', () => {
     beforeEach(() => {
       request = {
         response: boom403Response,
-        route: { settings: { app: { plainOutput: true } } },
+        route: { settings: { } },
         path
       }
     })
@@ -179,10 +175,6 @@ describe('Error pages service', () => {
     })
 
     describe('and the route is not configured (redirect to error page)', () => {
-      beforeEach(() => {
-        request.route = { settings: { } }
-      })
-
       it('tells the plugin to stop the response and redirect to an error page', () => {
         const result = ErrorPagesService.go(request)
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4085
https://eaflood.atlassian.net/browse/WATER-4155

The final step of our pass-through authentication story is dealing with unauthorized requests. This is where Hapi will compare the scope defined in the credentials our `AuthPlugin` sets to what is in the route config. If they don't match Hapi will through an error with a [403 Forbidden](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403) code.

When this happens our `ErrorsPlugin` will pick up the response and using `ErrorPagesService` determine if it should be redirected to an error page. Before this change, our logic would have deduced a [500 Internal Server Error](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) and show the page for that.

Clearly, that's wrong but the solution is a little more complex. If you assume we don't render links to things a user cannot access, the request must have been manufactured i.e. directly entered into the browser. If we respond with a `403` and a nice 'You are not authorised' page we would be confirming the thing someone is trying to access exists, they just don't have the authority to. Similar to handling [user enumeration attacks](https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/03-Identity_Management_Testing/04-Testing_for_Account_Enumeration_and_Guessable_User_Account) we don't want to do that. Instead, it is [recommended to return a 404](https://www.rfc-editor.org/rfc/rfc9110.html#name-403-forbidden).

So, we need to amend our error handling logic to check for `403` errors but ensure we respond with `404` instead.

Finally, whilst we are messing with the logic, we will also deal with the fact that returning a `500` means the user never sees our error page. This is because the service is behind a [F5 Silverline Managed Web Application Firewall (WAF)](https://aws.amazon.com/marketplace/pp/prodview-7ge77z55kayes) which blocks `5xx` responses and returns its own error page. (It does this to prevent apps from leaking info because of unhandled errors.)