### PR TITLE
Add missing links to page footer

### DIFF
--- a/app/views/layout.njk
+++ b/app/views/layout.njk
@@ -34,6 +34,27 @@
   <h1 class="govuk-heading-xl">Default page template</h1>
 {% endblock %}
 
+{% block footer %}
+  {{ govukFooter({
+    meta: {
+      items: [
+        {
+          href: "/cookies",
+          text: "Cookies"
+        },
+        {
+          href: "/privacy-policy",
+          text: "Privacy"
+        },
+        {
+          href: "/accessibility",
+          text: "Accessibility"
+        }
+      ]
+    }
+  }) }}
+{% endblock %}
+
 {% block bodyEnd %}
   {# Run JavaScript at end of the <body>, to avoid blocking the initial render. #}
   <script src="{{ assetPath }}/all.js"></script>


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4155

We are building our first proper page which will replace something the [water-abstraction-ui](https://github.com/DEFRA/water-abstraction-ui) currently handles.

But before we get into the meat of it we've spotted that the footer is missing links to our cookies, privacy and accessibility pages.

This change rectifies that.

<details>
<summary>Screenshot of links</summary>

<img width="986" alt="Screenshot 2023-10-19 at 19 02 04" src="https://github.com/DEFRA/water-abstraction-system/assets/1789650/40b40c36-4705-4984-b239-05d521b3a148">

</details>