### PR TITLE
Update page header with user links

### DIFF
--- a/app/routes/health.routes.js
+++ b/app/routes/health.routes.js
@@ -34,7 +34,14 @@ const routes = [
     path: '/health/info',
     handler: HealthController.info,
     options: {
-      auth: false,
+      auth: {
+        // NOTE: this means any request credentials are attempted authentication, but if the credentials are invalid,
+        // the request proceeds regardless of the authentication error. We do this so we can display the change
+        // password and sign out links in the header _if_ the user is authenticated. But you don't need to be
+        // authenticated to see this page. So, if you have no creds or you are running with an expired cookie we don't
+        // care, you'll just not see the links.
+        mode: 'try'
+      },
       description: 'Used by the delivery team to confirm we can connect to our other apps and services. It also ' +
       'returns us the version and commit hash for each one.'
     }

--- a/app/views/layout.njk
+++ b/app/views/layout.njk
@@ -20,11 +20,13 @@
 {% endblock %}
 
 {% block header %}
+  {% set navigationLinks = [{ href: "/account/update-password", text: "Change password" }, { href: "/signout", text: "Sign out" }] %}
   {{ govukHeader({
     homepageUrl: "#",
     containerClasses: "govuk-width-container",
     serviceName: "Manage your water abstraction or impoundment licence",
-    serviceUrl: "#"
+    serviceUrl: "/",
+    navigation: navigationLinks
   }) }}
 {% endblock %}
 

--- a/app/views/layout.njk
+++ b/app/views/layout.njk
@@ -20,7 +20,12 @@
 {% endblock %}
 
 {% block header %}
-  {% set navigationLinks = ([{ href: "/account/update-password", text: "Change password" }, { href: "/signout", text: "Sign out" }] if auth.authenticated else [] ) %}
+  {% if auth.authenticated %}
+    {% set navigationLinks = [{ href: "/account/update-password", text: "Change password" }, { href: "/signout", text: "Sign out" }] %}
+  {% else %}
+    {% set navigationLinks = [] %}
+  {% endif %}
+
   {{ govukHeader({
     homepageUrl: "#",
     containerClasses: "govuk-width-container",

--- a/app/views/layout.njk
+++ b/app/views/layout.njk
@@ -20,7 +20,7 @@
 {% endblock %}
 
 {% block header %}
-  {% set navigationLinks = [{ href: "/account/update-password", text: "Change password" }, { href: "/signout", text: "Sign out" }] %}
+  {% set navigationLinks = ([{ href: "/account/update-password", text: "Change password" }, { href: "/signout", text: "Sign out" }] if auth.authenticated else [] ) %}
   {{ govukHeader({
     homepageUrl: "#",
     containerClasses: "govuk-width-container",


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4155

We are building our first proper page which will replace something the [water-abstraction-ui](https://github.com/DEFRA/water-abstraction-ui) currently handles.

But before we get into the meat of it we need to update our header to include links specific to the user. These are

- **Change password**
- **Sign out**

> The legacy UI also displays **Contact information** but this is because it doesn't differentiate the internal and external sites. This link should only be shown to external users.

The complexity is we should only show them to authenticated users. So, in this change, we are going to use `/health/info` as a test! If an authenticated user happens to request the page we'll show the links. Else not.

Essentially, we're working out a way to do this that will hopefully work as we add more and more pages.

<details>
<summary>Screenshot of links</summary>

![Screenshot 2023-10-19 at 19 19 53](https://github.com/DEFRA/water-abstraction-system/assets/1789650/3146760e-4451-40c4-8f1d-76bbaf1e07e4)

</details>