### PR TITLE
Add auth & user details to view context by default

### DIFF
--- a/app/plugins/views.plugin.js
+++ b/app/plugins/views.plugin.js
@@ -27,9 +27,12 @@ const ViewsPlugin = {
       }
     },
     context,
+    // the root file path used to resolve and load the templates identified when calling h.view()
     path: '../views',
+    // a base path used as prefix for `path:`
     relativeTo: __dirname,
-    isCached: ServerConfig.environment !== 'development' // Disable caching if we're running in dev
+    // Only enable caching of templates if we are running in production
+    isCached: ServerConfig.environment === 'production'
   }
 }
 

--- a/app/plugins/views.plugin.js
+++ b/app/plugins/views.plugin.js
@@ -81,6 +81,8 @@ function compile (template, options) {
  * Vision will combine the 'context' (data) we pass in with the `params`, `payload`, `query` and `pre` values from the
  * `request` plus the output of this function and pass that through to the template. Nice!
  *
+ * > Credit to https://www.solarwinter.net/hapi-vision-and-who-am-i/ for highlighting we could do this
+ *
  * @param {Object} request Instance of a Hapi {@link https://hapi.dev/api/?v=21.3.2#request Request}
  *
  * @returns {Object} the global context for all templates

--- a/app/plugins/views.plugin.js
+++ b/app/plugins/views.plugin.js
@@ -12,13 +12,14 @@
 
 const path = require('path')
 const Nunjucks = require('nunjucks')
+const Vision = require('@hapi/vision')
 
 const pkg = require('../../package.json')
 
 const ServerConfig = require('../../config/server.config.js')
 
 const ViewsPlugin = {
-  plugin: require('@hapi/vision'),
+  plugin: Vision,
   options: {
     engines: {
       // The 'engine' is the file extension this applies to; in this case, .njk

--- a/app/plugins/views.plugin.js
+++ b/app/plugins/views.plugin.js
@@ -14,8 +14,6 @@ const path = require('path')
 const Nunjucks = require('nunjucks')
 const Vision = require('@hapi/vision')
 
-const pkg = require('../../package.json')
-
 const ServerConfig = require('../../config/server.config.js')
 
 const ViewsPlugin = {
@@ -36,7 +34,6 @@ const ViewsPlugin = {
     // layout.njk as the path to get static assets like client-side javascript. These are added to or overridden in the
     // h.view() call in a controller.
     context: {
-      appVersion: pkg.version,
       assetPath: '/assets'
     }
   }

--- a/app/plugins/views.plugin.js
+++ b/app/plugins/views.plugin.js
@@ -17,8 +17,6 @@ const pkg = require('../../package.json')
 
 const ServerConfig = require('../../config/server.config.js')
 
-const SERVICE_NAME = 'Manage your water abstraction or impoundment licence'
-
 const ViewsPlugin = {
   plugin: require('@hapi/vision'),
   options: {
@@ -51,9 +49,7 @@ const ViewsPlugin = {
     // h.view() call in a controller.
     context: {
       appVersion: pkg.version,
-      assetPath: '/assets',
-      serviceName: SERVICE_NAME,
-      pageTitle: `${SERVICE_NAME} - GOV.UK`
+      assetPath: '/assets'
     }
   }
 }

--- a/app/views/layout.njk
+++ b/app/views/layout.njk
@@ -21,7 +21,7 @@
   {{ govukHeader({
     homepageUrl: "#",
     containerClasses: "govuk-width-container",
-    serviceName: serviceName,
+    serviceName: "Manage your water abstraction or impoundment licence",
     serviceUrl: "#"
   }) }}
 {% endblock %}

--- a/app/views/layout.njk
+++ b/app/views/layout.njk
@@ -1,5 +1,7 @@
 {% extends "govuk/template.njk" %}
 
+{% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}
+
 {% block head %}
   <!--[if !IE 8]><!-->
     <link href="{{ assetPath }}/stylesheets/application.css" rel="stylesheet" />
@@ -24,10 +26,6 @@
     serviceName: "Manage your water abstraction or impoundment licence",
     serviceUrl: "#"
   }) }}
-{% endblock %}
-
-{% block pageTitle %}
-  {{ pageTitle }}
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4155

When working on [Update page header with user links](https://github.com/DEFRA/water-abstraction-system/pull/474) we hit a blocker.

The header needs to display links but only if a user is authenticated (logged in). So, we need to pass this information into the 'context' used when compiling (rendering) a view.

Commonly, what you will see in controllers that return views is something like this

```javascript
  // NOTE: naming the object which contains the data collated by the controller `pageData` is a convention we use
  return h.view('info.njk', {
    pageTitle: 'Info',
    ...pageData
  })
```

The first arg is the path to the Nunjucks template to be rendered. The second is the 'context' containing the data the template will use.

We could have just done the following.

```javascript
  const pageData = { authenticated: request.auth.isAuthenticated, user: request.auth.credentials?.user }

  return h.view('info.njk', {
    pageTitle: 'Info',
    ...pageData
  })
```

If we did that though we'd need to do it in _every_ controller that returns a view. A better solution is to include it in the global context which is always passed in via the engine.

```javascript
  // app/plugins/views.plugin.js
  plugin: require('@hapi/vision'),
  options: {
    engines: {
      // The 'engine' is the file extension this applies to; in this case, .njk
      njk: {
        compile: (src, options) => {
          const template = nunjucks.compile(src, options.environment)
          return context => template.render(context)
        },
  // ...
```

Prior to this change, the context is a static object also found in `app/plugins/views.plugin.js`.

```javascript
  context: {
    appVersion: pkg.version,
    assetPath: '/assets',
    serviceName: SERVICE_NAME,
    pageTitle: `${SERVICE_NAME} - GOV.UK`
  }
```

This change replaces that with a function that will generate the global context including auth details found in the request each time a view is rendered. Whilst we're at it we'll update the plugin to match our conventions rather than being a straight copy of the **Vision's** example.