### PR TITLE
Add phase banner to our page layout

### DIFF
--- a/app/views/layout.njk
+++ b/app/views/layout.njk
@@ -1,4 +1,5 @@
 {% extends "govuk/template.njk" %}
+{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
 
 {% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}
 
@@ -33,6 +34,17 @@
     serviceUrl: "/",
     navigation: navigationLinks
   }) }}
+{% endblock %}
+
+{% block beforeContent %}
+  {{
+    govukPhaseBanner({
+      tag: {
+        text: "Beta"
+      },
+      html: 'This is a new service - your <a class="govuk-link" href="/feedback">feedback</a> will help us to improve it.'
+    })
+  }}
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4155

We thought the [nav bar for internal users](https://github.com/DEFRA/water-abstraction-system/pull/478) would be the final piece. But we have since confirmed with our designer that until we know otherwise, we should also be including the [phase banner](https://design-system.service.gov.uk/components/phase-banner/) even though this is an internal app.

So, this change adds the banner to our layout. It will be displayed always, no matter if someone is authenticated or not.