### PR TITLE
Charge periods shown on bills in supplementary billing show all year

### DIFF
--- a/app/presenters/charging-module/create-transaction.presenter.js
+++ b/app/presenters/charging-module/create-transaction.presenter.js
@@ -12,9 +12,9 @@ const { formatChargingModuleDate } = require('../base.presenter.js')
  *
  * @returns {Object} an object to be used as the body in a Charging Module POST transaction request
  */
-function go (transaction, billingPeriod, invoiceAccountNumber, licence) {
-  const periodStart = formatChargingModuleDate(billingPeriod.startDate)
-  const periodEnd = formatChargingModuleDate(billingPeriod.endDate)
+function go (transaction, invoiceAccountNumber, licence) {
+  const periodStart = formatChargingModuleDate(transaction.startDate)
+  const periodEnd = formatChargingModuleDate(transaction.endDate)
 
   return {
     clientId: transaction.billingTransactionId,

--- a/app/services/billing/supplementary/process-billing-period.service.js
+++ b/app/services/billing/supplementary/process-billing-period.service.js
@@ -66,8 +66,7 @@ async function _buildDataToPersist (billingData, billingPeriod, billRunExternalI
         currentBillingData.bill,
         currentBillingData.billLicence,
         billRunExternalId,
-        cleansedTransactions,
-        billingPeriod
+        cleansedTransactions
       )
 
       dataToPersist.transactions.push(...transactions)

--- a/app/services/billing/supplementary/send-transactions.service.js
+++ b/app/services/billing/supplementary/send-transactions.service.js
@@ -24,14 +24,13 @@ const ChargingModuleCreateTransactionPresenter = require('../../../presenters/ch
  *
  * @returns {Object[]} Array of transactions which have been sent to the Charging Module
  */
-async function go (licence, bill, billLicence, billRunExternalId, transactions, billingPeriod) {
+async function go (licence, bill, billLicence, billRunExternalId, transactions) {
   try {
     const sentTransactions = []
 
     for (const transaction of transactions) {
       const chargingModuleResponse = await _sendTransactionToChargingModule(
         transaction,
-        billingPeriod,
         bill,
         licence,
         billRunExternalId
@@ -48,10 +47,9 @@ async function go (licence, bill, billLicence, billRunExternalId, transactions, 
   }
 }
 
-async function _sendTransactionToChargingModule (transaction, billingPeriod, bill, licence, billRunExternalId) {
+async function _sendTransactionToChargingModule (transaction, bill, licence, billRunExternalId) {
   const chargingModuleRequest = ChargingModuleCreateTransactionPresenter.go(
     transaction,
-    billingPeriod,
     bill.invoiceAccountNumber,
     licence
   )

--- a/test/presenters/charging-module/create-transaction.presenter.test.js
+++ b/test/presenters/charging-module/create-transaction.presenter.test.js
@@ -19,10 +19,6 @@ const TransactionHelper = require('../../support/helpers/water/transaction.helpe
 const CreateTransactionPresenter = require('../../../app/presenters/charging-module/create-transaction.presenter.js')
 
 describe('Charging Module Create Transaction presenter', () => {
-  const billingPeriod = {
-    startDate: new Date('2022-04-01'),
-    endDate: new Date('2023-03-31')
-  }
   const invoiceAccountNumber = 'A51542397A'
 
   let transaction
@@ -69,10 +65,12 @@ describe('Charging Module Create Transaction presenter', () => {
       transaction.chargeCategoryCode = '4.5.6'
       transaction.section127Agreement = false
       transaction.section130Agreement = false
+      transaction.startDate = new Date('2022-04-01')
+      transaction.endDate = new Date('2023-03-31')
     })
 
     it('correctly presents the data', () => {
-      const result = CreateTransactionPresenter.go(transaction, billingPeriod, invoiceAccountNumber, licence)
+      const result = CreateTransactionPresenter.go(transaction, invoiceAccountNumber, licence)
 
       expect(result.clientId).to.equal(transaction.billingTransactionId)
       expect(result.ruleset).to.equal('sroc')


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4179

It has been reported by a customer that the charge period shown on a recent supplementary bill they received showed the whole financial year as a charge period, rather than the dates related to the charge versions and financial years.

The data passed to the charge module for supplementary appears to be using the financial year dates in all circumstances, when it should be using the charge period dates as shown on the transaction screen.

This PR will fix that issue by passing the correct dates to the CM.