### PR TITLE
Add new fetch billing account service

### DIFF
--- a/app/models/crm-v2/invoice-account-address.model.js
+++ b/app/models/crm-v2/invoice-account-address.model.js
@@ -35,7 +35,7 @@ class InvoiceAccountAddressModel extends CrmV2BaseModel {
           to: 'addresses.addressId'
         }
       },
-      company: {
+      agentCompany: {
         relation: Model.BelongsToOneRelation,
         modelClass: 'company.model',
         join: {

--- a/app/services/bills/fetch-billing-account.service.js
+++ b/app/services/bills/fetch-billing-account.service.js
@@ -1,0 +1,75 @@
+'use strict'
+
+/**
+ * Fetches the billing account and associated details for a given invoice account ID
+ * @module FetchBillingAccountService
+ */
+
+const InvoiceAccount = require('../../models/crm-v2/invoice-account.model.js')
+
+async function go (id) {
+  return _fetch(id)
+}
+
+async function _fetch (id) {
+  const result = InvoiceAccount.query()
+    .findById(id)
+    .select([
+      'invoiceAccountId',
+      'invoiceAccountNumber'
+    ])
+    .withGraphFetched('company')
+    .modifyGraph('company', (builder) => {
+      builder.select([
+        'company_id',
+        'type',
+        'name'
+      ])
+    })
+    .withGraphFetched('invoiceAccountAddresses')
+    .modifyGraph('invoiceAccountAddresses', (builder) => {
+      builder.whereNull('endDate')
+    })
+    .withGraphFetched('invoiceAccountAddresses.address')
+    .modifyGraph('invoiceAccountAddresses.address', (builder) => {
+      builder.select([
+        'addressId',
+        'address1',
+        'address2',
+        'address3',
+        'address4',
+        'town',
+        'county',
+        'postcode',
+        'country'
+      ])
+    })
+    .withGraphFetched('invoiceAccountAddresses.agentCompany')
+    .modifyGraph('invoiceAccountAddresses.agentCompany', (builder) => {
+      builder.select([
+        'companyId',
+        'type',
+        'name'
+      ])
+    })
+    .withGraphFetched('invoiceAccountAddresses.contact')
+    .modifyGraph('invoiceAccountAddresses.contact', (builder) => {
+      builder.select([
+        'contactId',
+        'firstName',
+        'middleInitials',
+        'lastName',
+        'initials',
+        'dataSource',
+        'contactType',
+        'suffix',
+        'department'
+      ])
+    })
+
+  return result
+}
+
+module.exports = {
+  go
+}

--- a/app/services/bills/fetch-billing-account.service.js
+++ b/app/services/bills/fetch-billing-account.service.js
@@ -7,6 +7,13 @@
 
 const InvoiceAccount = require('../../models/crm-v2/invoice-account.model.js')
 
+/**
+ * Fetch the matching Billing account plus the current account address record linked to it
+ *
+ * @param {string} id The UUID for the billing account to fetch
+ *
+ * @returns the matching instance of BillModel including linked company and just the current account address record
+ */
 async function go (id) {
   return _fetch(id)
 }
@@ -27,6 +34,7 @@ async function _fetch (id) {
       ])
     })
     .withGraphFetched('invoiceAccountAddresses')
+    // The current invoice account address is denoted by the fact it is the only one with a null end date
     .modifyGraph('invoiceAccountAddresses', (builder) => {
       builder.whereNull('endDate')
     })

--- a/test/models/crm-v2/invoice-account-address.model.test.js
+++ b/test/models/crm-v2/invoice-account-address.model.test.js
@@ -71,7 +71,7 @@ describe('Invoice Account Address model', () => {
       })
     })
 
-    describe('when linking to company', () => {
+    describe('when linking to company (agent)', () => {
       let testCompany
 
       beforeEach(async () => {
@@ -81,21 +81,21 @@ describe('Invoice Account Address model', () => {
 
       it('can successfully run a related query', async () => {
         const query = await InvoiceAccountAddressModel.query()
-          .innerJoinRelated('company')
+          .innerJoinRelated('agentCompany')
 
         expect(query).to.exist()
       })
 
-      it('can eager load the company', async () => {
+      it('can eager load the agent company', async () => {
         const result = await InvoiceAccountAddressModel.query()
           .findById(testRecord.invoiceAccountAddressId)
-          .withGraphFetched('company')
+          .withGraphFetched('agentCompany')
 
         expect(result).to.be.instanceOf(InvoiceAccountAddressModel)
         expect(result.invoiceAccountAddressId).to.equal(testRecord.invoiceAccountAddressId)
 
-        expect(result.company).to.be.an.instanceOf(CompanyModel)
-        expect(result.company).to.equal(testCompany)
+        expect(result.agentCompany).to.be.an.instanceOf(CompanyModel)
+        expect(result.agentCompany).to.equal(testCompany)
       })
     })
 

--- a/test/services/bills/fetch-billing-account.service.test.js
+++ b/test/services/bills/fetch-billing-account.service.test.js
@@ -23,7 +23,7 @@ const InvoiceAccountAddressModel = require('../../../app/models/crm-v2/invoice-a
 // Thing under test
 const FetchBillingAccountService = require('../../../app/services/bills/fetch-billing-account.service.js')
 
-describe('Fetch Charge Versions service', () => {
+describe('Fetch Billing Account service', () => {
   let linkedCompany
   let testBillingAccount
 

--- a/test/services/bills/fetch-billing-account.service.test.js
+++ b/test/services/bills/fetch-billing-account.service.test.js
@@ -1,0 +1,148 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const AddressHelper = require('../../support/helpers/crm-v2/address.helper.js')
+const AddressModel = require('../../../app/models/crm-v2/address.model.js')
+const CompanyHelper = require('../../support/helpers/crm-v2/company.helper.js')
+const CompanyModel = require('../../../app/models/crm-v2/company.model.js')
+const ContactHelper = require('../../support/helpers/crm-v2/contact.helper.js')
+const ContactModel = require('../../../app/models/crm-v2/contact.model.js')
+const DatabaseHelper = require('../../support/helpers/database.helper.js')
+const InvoiceAccountHelper = require('../../support/helpers/crm-v2/invoice-account.helper.js')
+const InvoiceAccountModel = require('../../../app/models/crm-v2/invoice-account.model.js')
+const InvoiceAccountAddressHelper = require('../../support/helpers/crm-v2/invoice-account-address.helper.js')
+const InvoiceAccountAddressModel = require('../../../app/models/crm-v2/invoice-account-address.model.js')
+
+// Thing under test
+const FetchBillingAccountService = require('../../../app/services/bills/fetch-billing-account.service.js')
+
+describe('Fetch Charge Versions service', () => {
+  let linkedCompany
+  let testBillingAccount
+
+  beforeEach(async () => {
+    await DatabaseHelper.clean()
+
+    linkedCompany = await CompanyHelper.add()
+
+    testBillingAccount = await InvoiceAccountHelper.add({ companyId: linkedCompany.companyId })
+  })
+
+  describe('when a billing account with a matching ID exists', () => {
+    describe('and that has multiple invoice account addresses', () => {
+      let linkedAddress
+
+      beforeEach(async () => {
+        const { invoiceAccountId } = testBillingAccount
+
+        linkedAddress = await AddressHelper.add()
+        const { addressId } = linkedAddress
+
+        await Promise.all([
+          InvoiceAccountAddressHelper.add({ invoiceAccountId, addressId, endDate: new Date('2023-09-18') }),
+          InvoiceAccountAddressHelper.add({ invoiceAccountId, addressId, startDate: new Date('2023-09-19') })
+        ])
+      })
+
+      it('only returns the current one', async () => {
+        const result = await FetchBillingAccountService.go(testBillingAccount.invoiceAccountId)
+
+        expect(result.invoiceAccountId).to.equal(testBillingAccount.invoiceAccountId)
+        expect(result).to.be.an.instanceOf(InvoiceAccountModel)
+
+        expect(result.invoiceAccountAddresses).to.have.length(1)
+        expect(result.invoiceAccountAddresses[0].endDate).to.be.null()
+        expect(result.invoiceAccountAddresses[0]).to.be.an.instanceof(InvoiceAccountAddressModel)
+      })
+
+      // All account address records are linked to an address
+      it('returns details for the linked address', async () => {
+        const result = await FetchBillingAccountService.go(testBillingAccount.invoiceAccountId)
+
+        expect(result.invoiceAccountId).to.equal(testBillingAccount.invoiceAccountId)
+        expect(result).to.be.an.instanceOf(InvoiceAccountModel)
+
+        const returnedAddress = result.invoiceAccountAddresses[0].address
+
+        expect(returnedAddress.addressId).to.equal(linkedAddress.addressId)
+        expect(returnedAddress).to.be.an.instanceof(AddressModel)
+      })
+    })
+
+    // Agent company is optional in the account address record
+    describe('and the current invoice account address has an agent company', () => {
+      let linkedAgentCompany
+
+      beforeEach(async () => {
+        const { invoiceAccountId } = testBillingAccount
+        linkedAgentCompany = await CompanyHelper.add()
+
+        await InvoiceAccountAddressHelper.add({ invoiceAccountId, agentCompanyId: linkedAgentCompany.companyId })
+      })
+
+      it('returns details for the linked agent company', async () => {
+        const result = await FetchBillingAccountService.go(testBillingAccount.invoiceAccountId)
+
+        expect(result.invoiceAccountId).to.equal(testBillingAccount.invoiceAccountId)
+        expect(result).to.be.an.instanceOf(InvoiceAccountModel)
+
+        const returnedAgentCompany = result.invoiceAccountAddresses[0].agentCompany
+
+        expect(returnedAgentCompany.companyId).to.equal(linkedAgentCompany.companyId)
+        expect(returnedAgentCompany).to.be.an.instanceof(CompanyModel)
+      })
+    })
+
+    // Contact is optional in the account addresss record
+    describe('and the current invoice account address has a contact', () => {
+      let linkedContact
+
+      beforeEach(async () => {
+        const { invoiceAccountId } = testBillingAccount
+        linkedContact = await ContactHelper.add()
+
+        await InvoiceAccountAddressHelper.add({ invoiceAccountId, contactId: linkedContact.contactId })
+      })
+
+      it('returns details for the linked contact', async () => {
+        const result = await FetchBillingAccountService.go(testBillingAccount.invoiceAccountId)
+
+        expect(result.invoiceAccountId).to.equal(testBillingAccount.invoiceAccountId)
+        expect(result).to.be.an.instanceOf(InvoiceAccountModel)
+
+        const returnedContact = result.invoiceAccountAddresses[0].contact
+
+        expect(returnedContact.contactId).to.equal(linkedContact.contactId)
+        expect(returnedContact).to.be.an.instanceof(ContactModel)
+      })
+    })
+
+    // All billing account records have a linked company
+    it('returns details for the linked company', async () => {
+      const result = await FetchBillingAccountService.go(testBillingAccount.invoiceAccountId)
+
+      expect(result.invoiceAccountId).to.equal(testBillingAccount.invoiceAccountId)
+      expect(result).to.be.an.instanceOf(InvoiceAccountModel)
+
+      const returnedCompany = result.company
+
+      expect(returnedCompany.contactId).to.equal(returnedCompany.companyId)
+      expect(returnedCompany).to.be.an.instanceof(CompanyModel)
+    })
+  })
+
+  describe('when a billing account with a matching ID does not exist', () => {
+    it('returns no results', async () => {
+      const result = await FetchBillingAccountService.go('87049159-eb97-4378-8e23-04ec2d1de41e')
+
+      expect(result).to.be.undefined()
+    })
+  })
+})


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4155

We are building our first proper page which will replace the bill summary page the [water-abstraction-ui](https://github.com/DEFRA/water-abstraction-ui) currently provides. Rather than try to show all licences _and_ all their transactions for a bill on one page we'll instead list the licences. Users can then see the transaction details by selecting a licence.

We've already made several other changes to support this. This change adds a new service we need to fetch details about the billing account for displaying on the page.