### PR TITLE
Fix missing backlink in view bill page

### DIFF
--- a/app/views/layout.njk
+++ b/app/views/layout.njk
@@ -48,6 +48,10 @@
   {% if auth.authenticated %}
     {% include "includes/nav-bar.njk" %}
   {% endif %}
+
+  {# Place holder section for things like back links or breadcrumbs #}
+  {% block breadcrumbs %}
+  {% endblock %}
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4155

We missed a change needed in the main `layout.njk` template needed to support views with backlinks like the new view bill page.