### PR TITLE
Add new Minimum Charge Transaction presenter

### DIFF
--- a/app/presenters/bill-licences/minimum-charge-transaction.presenter.js
+++ b/app/presenters/bill-licences/minimum-charge-transaction.presenter.js
@@ -1,0 +1,37 @@
+'use strict'
+
+/**
+ * Formats data for minimum charge transaction for the bill-licence page
+ * @module MinimumChargeTransactionPresenter
+ */
+
+const { formatMoney } = require('../base.presenter.js')
+
+/**
+ * Formats data for minimum charge transaction for the bill-licence page
+ *
+ * @param {module:TransactionModel} transaction an instance of `TransactionModel` that represents a minimum charge
+ * transaction
+ *
+ * @returns {Object} a formatted representation of the transaction specifically for the bill-licence page
+ */
+function go (transaction) {
+  const {
+    chargeType,
+    isCredit,
+    netAmount
+  } = transaction
+
+  return {
+    billableDays: '',
+    chargeType,
+    creditAmount: isCredit ? formatMoney(netAmount) : '',
+    debitAmount: isCredit ? '' : formatMoney(netAmount),
+    description: 'Minimum charge',
+    quantity: ''
+  }
+}
+
+module.exports = {
+  go
+}

--- a/test/presenters/bill-licences/minimum-charge-transaction.presenter.test.js
+++ b/test/presenters/bill-licences/minimum-charge-transaction.presenter.test.js
@@ -1,0 +1,63 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Thing under test
+const MinimumChargeTransactionPresenter = require('../../../app/presenters/bill-licences/minimum-charge-transaction.presenter.js')
+
+describe('Minimum Charge Transaction presenter', () => {
+  let transaction
+
+  describe('when provided with a minimum charge transaction', () => {
+    beforeEach(() => {
+      transaction = {
+        chargeType: 'minimum_charge',
+        netAmount: 2401
+      }
+    })
+
+    describe('that is a credit', () => {
+      beforeEach(() => {
+        transaction.isCredit = true
+      })
+
+      it('returns the credit property populated and the debit empty', () => {
+        const result = MinimumChargeTransactionPresenter.go(transaction)
+
+        expect(result.creditAmount).to.equal('£24.01')
+        expect(result.debitAmount).to.equal('')
+      })
+    })
+
+    describe('that is a debit', () => {
+      beforeEach(() => {
+        transaction.isCredit = false
+      })
+
+      it('returns the debit property populated and the credit empty', () => {
+        const result = MinimumChargeTransactionPresenter.go(transaction)
+
+        expect(result.creditAmount).to.equal('')
+        expect(result.debitAmount).to.equal('£24.01')
+      })
+    })
+
+    it('correctly presents the data', () => {
+      const result = MinimumChargeTransactionPresenter.go(transaction)
+
+      expect(result).to.equal({
+        billableDays: '',
+        chargeType: 'minimum_charge',
+        creditAmount: '',
+        debitAmount: '£24.01',
+        description: 'Minimum charge',
+        quantity: ''
+      })
+    })
+  })
+})


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4156

Related to WATER-4155 and the work to replace the legacy bill page with our own we're now starting to build the page it will link to; a view of the bill licence and all its transactions.

This adds a presenter that given a `TransactionModel` instance whose charge type is `minimum_charge` will return an object containing formatted details about the transaction.

The presenter doesn't need to make any distinction between PRESROC and SROC transactions as they are both displayed in the same way.