### PR TITLE
Add new Compensation Charge Transaction presenter

### DIFF
--- a/app/presenters/bill-licences/compensation-charge-transaction.presenter.js
+++ b/app/presenters/bill-licences/compensation-charge-transaction.presenter.js
@@ -1,0 +1,86 @@
+'use strict'
+
+/**
+ * Formats data for a compensation charge transaction for the bill-licence page
+ * @module CompensationChargeTransactionPresenter
+ */
+
+const { formatLongDate, formatMoney } = require('../base.presenter.js')
+
+/**
+ * Formats data for a compensation charge transaction for the bill-licence page
+ *
+ * The format of the object the presenter returns will differ depending on the scheme the transaction is for.
+ *
+ * @param {module:TransactionModel} transaction an instance of `TransactionModel` that represents a compensation charge
+ * transaction
+ *
+ * @returns {Object} a formatted representation of the transaction specifically for the bill-licence page
+ */
+function go (transaction) {
+  if (transaction.scheme === 'sroc') {
+    return _srocContent(transaction)
+  }
+
+  return _presrocContent(transaction)
+}
+
+function _agreement (section127Agreement) {
+  if (section127Agreement) {
+    return 'Two-part tariff'
+  }
+
+  return null
+}
+
+function _presrocContent (transaction) {
+  const {
+    authorisedDays,
+    billableDays,
+    chargeType,
+    endDate,
+    isCredit,
+    netAmount,
+    section127Agreement,
+    startDate,
+    volume
+  } = transaction
+
+  return {
+    agreement: _agreement(section127Agreement),
+    billableDays: `${billableDays}/${authorisedDays}`,
+    chargePeriod: `${formatLongDate(startDate)} to ${formatLongDate(endDate)}`,
+    chargeType,
+    creditAmount: isCredit ? formatMoney(netAmount) : '',
+    debitAmount: isCredit ? '' : formatMoney(netAmount),
+    description: 'Compensation charge',
+    quantity: `${volume}ML`
+  }
+}
+
+function _srocContent (transaction) {
+  const {
+    authorisedDays,
+    billableDays,
+    chargeType,
+    endDate,
+    isCredit,
+    netAmount,
+    startDate,
+    volume
+  } = transaction
+
+  return {
+    billableDays: `${billableDays}/${authorisedDays}`,
+    chargePeriod: `${formatLongDate(startDate)} to ${formatLongDate(endDate)}`,
+    chargeType,
+    creditAmount: isCredit ? formatMoney(netAmount) : '',
+    debitAmount: isCredit ? '' : formatMoney(netAmount),
+    description: 'Compensation charge',
+    quantity: `${volume}ML`
+  }
+}
+
+module.exports = {
+  go
+}

--- a/test/presenters/bill-licences/compensation-charge-transaction.presenter.test.js
+++ b/test/presenters/bill-licences/compensation-charge-transaction.presenter.test.js
@@ -1,0 +1,117 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Thing under test
+const CompensationChargeTransactionPresenter = require('../../../app/presenters/bill-licences/compensation-charge-transaction.presenter.js')
+
+describe('Compensation Charge Transaction presenter', () => {
+  let transaction
+
+  describe('when provided with a compensation charge transaction', () => {
+    beforeEach(() => {
+      transaction = {
+        authorisedDays: 214,
+        billableDays: 153,
+        chargeType: 'compensation',
+        endDate: new Date('2024-03-31'),
+        isCredit: false,
+        netAmount: 21474,
+        scheme: 'sroc',
+        section127Agreement: false,
+        startDate: new Date('2023-04-01'),
+        volume: 100
+      }
+    })
+
+    describe('that is a credit', () => {
+      beforeEach(() => {
+        transaction.isCredit = true
+      })
+
+      it('returns the credit property populated and the debit empty', () => {
+        const result = CompensationChargeTransactionPresenter.go(transaction)
+
+        expect(result.creditAmount).to.equal('£214.74')
+        expect(result.debitAmount).to.equal('')
+      })
+    })
+
+    describe('that is a debit', () => {
+      beforeEach(() => {
+        transaction.isCredit = false
+      })
+
+      it('returns the debit property populated and the credit empty', () => {
+        const result = CompensationChargeTransactionPresenter.go(transaction)
+
+        expect(result.creditAmount).to.equal('')
+        expect(result.debitAmount).to.equal('£214.74')
+      })
+    })
+
+    describe('that is for SROC', () => {
+      it('correctly presents the data', () => {
+        const result = CompensationChargeTransactionPresenter.go(transaction)
+
+        expect(result).to.equal({
+          billableDays: '153/214',
+          chargePeriod: '1 April 2023 to 31 March 2024',
+          chargeType: 'compensation',
+          creditAmount: '',
+          debitAmount: '£214.74',
+          description: 'Compensation charge',
+          quantity: '100ML'
+        })
+      })
+    })
+
+    describe('that is for PRESROC', () => {
+      beforeEach(() => {
+        transaction.scheme = 'alcs'
+      })
+
+      describe("the 'agreement' property", () => {
+        describe('when the transaction is two-part tariff', () => {
+          beforeEach(() => {
+            transaction.section127Agreement = true
+          })
+
+          it("returns 'Two-part tariff'", () => {
+            const result = CompensationChargeTransactionPresenter.go(transaction)
+
+            expect(result.agreement).to.equal('Two-part tariff')
+          })
+        })
+
+        describe('when the transaction is not two-part tariff', () => {
+          it('returns null', () => {
+            const result = CompensationChargeTransactionPresenter.go(transaction)
+
+            expect(result.agreement).to.be.null()
+          })
+        })
+      })
+
+      it('correctly presents the data', () => {
+        const result = CompensationChargeTransactionPresenter.go(transaction)
+
+        expect(result).to.equal({
+          agreement: null,
+          billableDays: '153/214',
+          chargePeriod: '1 April 2023 to 31 March 2024',
+          chargeType: 'compensation',
+          creditAmount: '',
+          debitAmount: '£214.74',
+          description: 'Compensation charge',
+          quantity: '100ML'
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4156

Related to WATER-4155 and the work to replace the legacy bill page with our own we're now starting to build the page it will link to; a view of the bill licence and all its transactions.

This adds a presenter that given a `TransactionModel` instance whose charge type is `compensation` will return an object containing formatted details about the transaction.

The presenter handles both PRESROC and SROC transactions, altering the format of the output slightly by what needs to be displayed on the page when the transaction is displayed.