### PR TITLE
Add view bill licence service

### DIFF
--- a/app/services/bill-licences/view-bill-licence.service.js
+++ b/app/services/bill-licences/view-bill-licence.service.js
@@ -1,0 +1,27 @@
+'use strict'
+
+/**
+ * Orchestrates fetching and presenting the data needed for the view bill licence page
+ * @module ViewBillLicenceService
+ */
+
+const FetchBillLicenceService = require('./fetch-bill-licence.service.js')
+const ViewBillLicencePresenter = require('../../presenters/bill-licences/view-bill-licence.presenter.js')
+
+/**
+ * Orchestrates fetching and presenting the data needed for the view bill licence page
+ *
+ * @param {string} id The UUID for the bill licence to view
+ *
+ * @returns {Object} a formatted representation of the bill licence and its transactions for use in the bill licence
+ * view page
+ */
+async function go (id) {
+  const billLicence = await FetchBillLicenceService.go(id)
+
+  return ViewBillLicencePresenter.go(billLicence)
+}
+
+module.exports = {
+  go
+}

--- a/test/services/bill-licences/view-bill-licence.service.test.js
+++ b/test/services/bill-licences/view-bill-licence.service.test.js
@@ -1,0 +1,54 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { describe, it, beforeEach, afterEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Things we need to stub
+const FetchBillLicenceService = require('../../../app/services/bill-licences/fetch-bill-licence.service.js')
+const ViewBillLicencePresenter = require('../../../app/presenters/bill-licences/view-bill-licence.presenter.js')
+
+// Thing under test
+const ViewBillLicenceService = require('../../../app/services/bill-licences/view-bill-licence.service.js')
+
+describe('View Bill Licence service', () => {
+  const testId = '1ac20440-fddc-4835-97ea-95c702cb9430'
+
+  let fetchBillLicenceSpy
+
+  afterEach(() => {
+    Sinon.restore()
+  })
+
+  describe('when a bill licence with a matching ID exists', () => {
+    beforeEach(() => {
+      fetchBillLicenceSpy = Sinon.spy(FetchBillLicenceService, 'go')
+
+      Sinon.stub(ViewBillLicencePresenter, 'go').returns({
+        billingInvoiceLicenceId: '1ac20440-fddc-4835-97ea-95c702cb9430'
+      })
+    })
+
+    it('will fetch the data and format it using the bill licence services', async () => {
+      const result = await ViewBillLicenceService.go(testId)
+
+      expect(result).to.equal({
+        billingInvoiceLicenceId: '1ac20440-fddc-4835-97ea-95c702cb9430'
+      })
+
+      expect(fetchBillLicenceSpy.calledOnceWith(testId)).to.be.true()
+    })
+  })
+
+  describe('when a bill with a matching ID does not exist', () => {
+    it('throws an exception', async () => {
+      await expect(ViewBillLicenceService.go('testId'))
+        .to
+        .reject()
+    })
+  })
+})


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4156

Related to WATER-4155 and the work to replace the legacy bill page with our own we're now starting to build the page it will link to; a view of the bill licence and all its transactions.

We've already made several other changes to support this. This change adds a new service that orchestrates fetching the information needed ([Add new fetch bill licence service](https://github.com/DEFRA/water-abstraction-system/pull/501)), passing it through to a presenter ([Add View bill licence presenter](https://github.com/DEFRA/water-abstraction-system/pull/508)) and returning the result.