### PR TITLE
Add new view bill licence endpoint and template

### DIFF
--- a/app/controllers/bill-licences.controller.js
+++ b/app/controllers/bill-licences.controller.js
@@ -1,0 +1,26 @@
+'use strict'
+
+/**
+ * Controller for /bill-licences endpoints
+ * @module BillLicencesController
+ */
+
+const ViewBillLicenceService = require('../services/bill-licences/view-bill-licence.service.js')
+
+async function view (request, h) {
+  const { id } = request.params
+
+  const pageData = await ViewBillLicenceService.go(id)
+
+  const view = pageData.scheme === 'sroc' ? 'view-sroc.njk' : 'view-presroc.njk'
+
+  return h.view(`bill-licences/${view}`, {
+    pageTitle: `Transactions for ${pageData.licenceRef}`,
+    activeNavBar: 'bill-runs',
+    ...pageData
+  })
+}
+
+module.exports = {
+  view
+}

--- a/app/plugins/router.plugin.js
+++ b/app/plugins/router.plugin.js
@@ -12,6 +12,7 @@
  */
 
 const AssetRoutes = require('../routes/assets.routes.js')
+const BillLicences = require('../routes/bill-licences.routes.js')
 const BillRoutes = require('../routes/bills.routes.js')
 const BillRunRoutes = require('../routes/bill-runs.routes.js')
 const BillingAccountRoutes = require('../routes/billing-accounts.routes.js')
@@ -28,6 +29,7 @@ const routes = [
   ...RootRoutes,
   ...AssetRoutes,
   ...HealthRoutes,
+  ...BillLicences,
   ...BillRoutes,
   ...BillRunRoutes,
   ...BillingAccountRoutes,

--- a/app/routes/bill-licences.routes.js
+++ b/app/routes/bill-licences.routes.js
@@ -1,0 +1,21 @@
+'use strict'
+
+const BillLicencesController = require('../controllers/bill-licences.controller.js')
+
+const routes = [
+  {
+    method: 'GET',
+    path: '/bill-licences/{id}',
+    options: {
+      handler: BillLicencesController.view,
+      description: "Used to view a bill licence and it's transactions",
+      auth: {
+        access: {
+          scope: ['billing']
+        }
+      }
+    }
+  }
+]
+
+module.exports = routes

--- a/app/views/bill-licences/view-presroc.njk
+++ b/app/views/bill-licences/view-presroc.njk
@@ -1,0 +1,296 @@
+{% extends 'layout.njk' %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/table/macro.njk" import govukTable %}
+
+{% block breadcrumbs %}
+  {# Back link #}
+  {{
+    govukBackLink({
+      text: "Back",
+      href: "/system/bills/" + billingInvoiceId
+    })
+  }}
+{% endblock %}
+
+{% block content %}
+  {# Main heading #}
+  <div class="govuk-body">
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">
+      <span class="govuk-caption-l" data-test="pre-header">Billing account {{ accountNumber }}</span>{{ pageTitle }}
+    </h1>
+  </div>
+
+  <div class="govuk-grid-row govuk-!-margin-bottom-0">
+    <div class="govuk-grid-column-full">
+      <section>
+        <div class="govuk-button-group">
+          <a class="govuk-link" href="/licences/{{ licenceId }}">View licence summary</a>
+        </div>
+      </section>
+    </div>
+  </div>
+
+  {# Transactions table #}
+  <div class="govuk-grid-row govuk-!-margin-bottom-0">
+    <div class="govuk-grid-column-full">
+      {# Determine headers (credit column is only shown for supplementary bill runs created in WRLS) #}
+      {% if displayCreditDebitTotals %}
+        {% set tableHeaders = [
+          { text: 'Transaction detail' },
+          { text: 'Billable days', format: 'numeric' },
+          { text: 'Quantity', format: 'numeric' },
+          { text: 'Credit', format: 'numeric' },
+          { text: 'Debit', format: 'numeric' }
+        ] %}
+      {% else %}
+        {% set tableHeaders = [
+          { text: 'Transaction detail' },
+          { text: 'Billable days', format: 'numeric' },
+          { text: 'Quantity', format: 'numeric' },
+          { text: 'Debit', format: 'numeric' }
+        ] %}
+      {% endif %}
+
+      {% set tableRows = [] %}
+
+      {% for transaction in transactions %}
+        {# Set an easier to use index. Also means we can refer to it inside our elementDetail loop #}
+        {% set rowIndex = loop.index0 %}
+
+        {#
+          Determine the transaction detail cell contents. Depending on the transaction's charge type this goes from
+          simple to very messy! This is because we embed a lot of data in the cell which is layed out more like a part
+          of the UI.
+
+          All transaction types including minimum charge display a description. Compensation charge we also show the
+          charge period. Standard charges we show all that plus element details, further complicated by whether the
+          transaction is sroc or presroc.
+        #}
+        {% set detailDescription %}
+          <span data-test="description-{{ rowIndex }}">{{ transaction.description }}</span>
+        {% endset %}
+
+        {% if transaction.chargeType === 'compensation' %}
+          {% set detailChargeInfo %}
+            <p class="govuk-body-s"><br>
+              <span data-test="charge-period-{{ rowIndex }}"><strong>Charge period:</strong> {{ transaction.chargePeriod }}</span>
+              {% if transaction.agreement %}
+                <br><span data-test="agreement-{{ rowIndex }}"><strong>Agreement:</strong> {{ transaction.agreement }}</span>
+              {% endif %}
+            </p>
+          {% endset %}
+        {% else %}
+          {% set detailChargeInfo %}
+            <p class="govuk-body-s"><br>
+              <span data-test="charge-period-{{ rowIndex }}"><strong>Charge period:</strong> {{ transaction.chargePeriod }}</span>
+              {% if transaction.agreement %}
+                <br><span data-test="agreement-{{ rowIndex }}"><strong>Agreement:</strong> {{ transaction.agreement }}</span>
+              {% endif %}
+          {% endset %}
+
+          {# Charge element details section #}
+          {% set elementDetail %}
+            <details class="govuk-details govuk-!-margin-bottom-0 govuk-!-font-size-16" data-module="govuk-details">
+              <summary class="govuk-details__summary">
+                <span class="govuk-details__summary-text">Charge element details</span>
+              </summary>
+              <div class="govuk-details__text">
+                {#
+                  GOV.UK summary lists only allow us to assign attributes at the top level and not to each row. This
+                  means we can't assign our data-test attribute using the componenent. Our solution is to use the
+                  html option for each row instead of text and wrap each value in a <span>. That way we can manually
+                  assign our data-test attribute to the span.
+                #}
+                {% set chargeElementPurpose %}
+                  <span data-test="charge-element-purpose-{{ rowIndex }}">{{ transaction.chargeElement.purpose }}</span>
+                {% endset %}
+                {% set chargeElementAbstractionPeriod %}
+                  <span data-test="charge-element-period-{{ rowIndex }}">{{ transaction.chargeElement.abstractionPeriod }}</span>
+                {% endset %}
+                {% set chargeElementSource %}
+                  <span data-test="charge-element-source-{{ rowIndex }}">{{ transaction.chargeElement.source }}</span>
+                {% endset %}
+                {% set chargeElementSeason %}
+                  <span data-test="charge-element-season-{{ rowIndex }}">{{ transaction.chargeElement.season }}</span>
+                {% endset %}
+                {% set chargeElementLoss %}
+                  <span data-test="charge-element-loss-{{ rowIndex }}">{{ transaction.chargeElement.loss }}</span>
+                {% endset %}
+                {{
+                  govukSummaryList({
+                    classes: ' govuk-summary-list--no-border govuk-!-font-size-16 govuk-!-margin-bottom-0',
+                    attributes: { 'data-test': 'charge-element-' + rowIndex },
+                    rows: [
+                      {
+                        key: {
+                          text: "Purpose",
+                          classes: "meta-data__label govuk-!-font-weight-bold widthOverride"
+                          },
+                        value: {
+                          html: chargeElementPurpose,
+                          classes: "meta-data__value "
+                        }
+                      },
+                      {
+                        key: {
+                          text: "Abstraction period",
+                          classes: "meta-data__label govuk-!-font-weight-bold"
+                        },
+                        value: {
+                          html: chargeElementAbstractionPeriod,
+                          classes: "meta-data__value "
+                        }
+                      },
+                      {
+                        key: {
+                          text: "Source",
+                          classes: "meta-data__label govuk-!-font-weight-bold"
+                        },
+                        value: {
+                          html: chargeElementSource,
+                          classes: "meta-data__value "
+                        }
+                      },
+                      {
+                        key: {
+                          text: "Season",
+                          classes: "meta-data__label govuk-!-font-weight-bold"
+                        },
+                        value: {
+                          html: chargeElementSeason,
+                          classes: "meta-data__value "
+                        }
+                      },
+                      {
+                        key: {
+                          text: "Loss",
+                          classes: "meta-data__label govuk-!-font-weight-bold"
+                        },
+                        value: {
+                          html: chargeElementLoss,
+                          classes: "meta-data__value "
+                        }
+                      }
+                    ]
+                    })
+                }}
+              </div>
+            </details>
+          {% endset %}
+
+          {% set detailChargeInfo = detailChargeInfo + '</p>' + elementDetail %}
+        {% endif %}
+
+        {# Create the transaction row and set the first 3 columns; Transaction detail, Billable days and Quantity #}
+        {% set transactionRow = [
+          {
+            html: detailDescription + detailChargeInfo,
+            attributes: { 'data-test': 'details-' + loop.index0 }
+          },
+          {
+            text: transaction.billableDays,
+            format: 'numeric',
+            attributes: { 'data-test': 'billable-days-' + loop.index0 }
+          },
+          {
+            text: transaction.quantity,
+            format: 'numeric',
+            attributes: { 'data-test': 'quantity-' + loop.index0 }
+          }
+        ] %}
+
+        {# Credit column - we only add it for supplementary bills created in WRLS #}
+        {% if displayCreditDebitTotals %}
+          {% set transactionRow = (transactionRow.push(
+            {
+              text: transaction.creditAmount,
+              format: 'numeric',
+              attributes: { 'data-test': 'credit-' + loop.index0 }
+            }
+          ), transactionRow) %}
+        {% endif %}
+
+        {# Debit column - always added but must be done after the dynamic credit column to match the header order #}
+        {% set transactionRow = (transactionRow.push(
+          {
+            text: transaction.debitAmount,
+            format: 'numeric',
+            attributes: { 'data-test': 'debit-' + loop.index0 }
+          }
+        ), transactionRow) %}
+
+        {% set tableRows = (tableRows.push(transactionRow), tableRows) %}
+      {% endfor %}
+
+      {# Determine if credit and debit total rows should be added #}
+      {% if displayCreditDebitTotals %}
+        {% set creditRow = [
+          {
+            text: 'Credits total',
+            colspan: 3
+          },
+          {
+            text: creditTotal,
+            format: 'numeric',
+            classes: 'govuk-!-font-weight-bold',
+            attributes: { 'data-test': 'credits-total' }
+          },
+          {
+            text: '',
+            format: 'numeric'
+          }
+        ] %}
+
+        {% set debitRow = [
+          {
+            text: 'Debits total',
+            colspan: 4
+          },
+          {
+            text: debitTotal,
+            format: 'numeric',
+            classes: 'govuk-!-font-weight-bold',
+            attributes: { 'data-test': 'debits-total' }
+          }
+        ] %}
+
+        {% set tableRows = (tableRows.push(creditRow), tableRows) %}
+        {% set tableRows = (tableRows.push(debitRow), tableRows) %}
+      {% endif %}
+
+      {#
+        Add the Total row. This always gets added and uses a custom class to add a thicker dividing line.
+
+        To get the colspan correct we get the length of the tableHeaders array using a Nunjucks built in filter.
+      #}
+      {% set totalRow = [
+        {
+          text: 'Total',
+          classes: 'govuk-table__cell--total',
+          colspan: tableHeaders | length - 1
+        },
+        {
+          text: total,
+          format: 'numeric',
+          classes: 'govuk-table__cell--total govuk-!-font-weight-bold',
+          attributes: { 'data-test': 'total' }
+        }
+      ] %}
+      {% set tableRows = (tableRows.push(totalRow), tableRows) %}
+
+
+      {# Finally, add the table to the page! #}
+      {{
+        govukTable({
+          caption: tableCaption,
+          captionClasses: "govuk-table__caption--m govuk-!-margin-bottom-0",
+          firstCellIsHeader: true,
+          attributes: { 'data-test': 'transactions' },
+          head: tableHeaders,
+          rows: tableRows
+        })
+      }}
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/bill-licences/view-sroc.njk
+++ b/app/views/bill-licences/view-sroc.njk
@@ -1,0 +1,291 @@
+{% extends 'layout.njk' %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/table/macro.njk" import govukTable %}
+
+{% block breadcrumbs %}
+  {# Back link #}
+  {{
+    govukBackLink({
+      text: "Back",
+      href: "/system/bills/" + billingInvoiceId
+    })
+  }}
+{% endblock %}
+
+{% block content %}
+  {# Main heading #}
+  <div class="govuk-body">
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">
+      <span class="govuk-caption-l" data-test="pre-header">Billing account {{ accountNumber }}</span>{{ pageTitle }}
+    </h1>
+  </div>
+
+  <div class="govuk-grid-row govuk-!-margin-bottom-0">
+    <div class="govuk-grid-column-full">
+      <section>
+        <div class="govuk-button-group">
+          <a class="govuk-link" href="/licences/{{ licenceId }}">View licence summary</a>
+        </div>
+      </section>
+    </div>
+  </div>
+
+  {# Transactions table #}
+  <div class="govuk-grid-row govuk-!-margin-bottom-0">
+    <div class="govuk-grid-column-full">
+      {# Determine headers (credit column is only shown for supplementary bill runs created in WRLS) #}
+      {% if displayCreditDebitTotals %}
+        {% set tableHeaders = [
+          { text: 'Transaction detail' },
+          { text: 'Billable days', format: 'numeric' },
+          { text: 'Quantity', format: 'numeric' },
+          { text: 'Credit', format: 'numeric' },
+          { text: 'Debit', format: 'numeric' }
+        ] %}
+      {% else %}
+        {% set tableHeaders = [
+          { text: 'Transaction detail' },
+          { text: 'Billable days', format: 'numeric' },
+          { text: 'Quantity', format: 'numeric' },
+          { text: 'Debit', format: 'numeric' }
+        ] %}
+      {% endif %}
+
+      {% set tableRows = [] %}
+
+      {% for transaction in transactions %}
+        {# Set an easier to use index. Also means we can refer to it inside our elementDetail loop #}
+        {% set rowIndex = loop.index0 %}
+
+        {#
+          Determine the transaction detail cell contents. Depending on the transaction's charge type this goes from
+          simple to very messy! This is because we embed a lot of data in the cell which is layed out more like a part
+          of the UI.
+
+          All transaction types including minimum charge display a description. Compensation charge we also show the
+          charge period. Standard charges we show all that plus element details, further complicated by whether the
+          transaction is sroc or presroc.
+        #}
+        {% set detailDescription %}
+          <span data-test="description-{{ rowIndex }}">{{ transaction.description }}</span>
+        {% endset %}
+
+        {% if transaction.chargeType === 'compensation' %}
+          {% set detailChargeInfo %}
+            <p class="govuk-body-s"><br>
+              <span data-test="charge-period-{{ rowIndex }}"><strong>Charge period:</strong> {{ transaction.chargePeriod }}</span>
+            </p>
+          {% endset %}
+        {% else %}
+          {% set detailChargeInfo %}
+            <p class="govuk-body-s"><br>
+              <span data-test="charge-period-{{ rowIndex }}"><strong>Charge period:</strong> {{ transaction.chargePeriod }}</span><br>
+              <span data-test="charge-reference-{{ rowIndex }}"><strong>Charge reference:</strong> {{ transaction.chargeReference }}</span><br>
+              <span data-test="category-description-{{ rowIndex }}"><strong>Charge description:</strong> {{ transaction.chargeCategoryDescription }}</span>
+          {% endset %}
+
+          {# Only show additional charges if we have any #}
+          {% if transaction.additionalCharges %}
+            {% set additionalChargesDetail %}
+                <br><br>
+                <span data-test="additional-charges-{{ rowIndex }}"><strong>Additional charges:</strong> {{ transaction.additionalCharges }}</span>
+            {% endset %}
+          {% endif %}
+
+          {# Only show adjustments if we have any #}
+          {% if transaction.adjustments %}
+            {% set adjustmentsDetail %}
+              <br><br>
+              <span data-test="adjustments-{{ rowIndex }}"><strong>Adjustments:</strong> {{ transaction.adjustments }}</span>
+            {% endset %}
+          {% endif %}
+
+          {# Charge element details section #}
+          {% set elementDetail %}
+            <details class="govuk-details govuk-!-margin-bottom-0 govuk-!-font-size-16" data-module="govuk-details">
+              <summary class="govuk-details__summary">
+                <span class="govuk-details__summary-text">Charge element details</span>
+              </summary>
+              <div class="govuk-details__text">
+                {#
+                  In SROC a reference (which is what the transaction links to) can have multiple elements. So, we need
+                  to be able to display a summary list for each one.
+                #}
+                {% for chargeElement in transaction.chargeElements %}
+                  {# Again, set an easier to reference loop index, this time for the charge elements loop #}
+                  {% set elementIndex = loop.index0 %}
+
+                  {#
+                    GOV.UK summary lists only allow us to assign attributes at the top level and not to each row. This
+                    means we can't assign our data-test attribute using the componenent. Our solution is to use the
+                    html option for each row instead of text and wrap each value in a <span>. That way we can manually
+                    assign our data-test attribute to the span.
+                  #}
+                  {% set chargeElementPurpose %}
+                    <span data-test="charge-element-purpose-{{ rowIndex }}-{{ elementIndex }}">{{ chargeElement.purpose }}</span>
+                  {% endset %}
+                  {% set chargeElementAbstractionPeriod %}
+                    <span data-test="charge-element-period-{{ rowIndex }}-{{ elementIndex }}">{{ chargeElement.abstractionPeriod }}</span>
+                  {% endset %}
+                  {% set chargeElementVolume %}
+                    <span data-test="charge-element-volume-{{ rowIndex }}-{{ elementIndex }}">{{ chargeElement.volume }}</span>
+                  {% endset %}
+                  {{
+                    govukSummaryList({
+                      classes: ' govuk-summary-list--no-border govuk-!-font-size-16 govuk-!-margin-bottom-0',
+                      attributes: { 'data-test': 'charge-element-' + rowIndex + '-' + elementIndex },
+                      rows: [
+                        {
+                          key: {
+                            text: "Purpose",
+                            classes: "meta-data__label govuk-!-font-weight-bold widthOverride"
+                            },
+                          value: {
+                            html: chargeElementPurpose,
+                            classes: "meta-data__value "
+                          }
+                        },
+                        {
+                          key: {
+                            text: "Abstraction period",
+                            classes: "meta-data__label govuk-!-font-weight-bold"
+                          },
+                          value: {
+                            html: chargeElementAbstractionPeriod,
+                            classes: "meta-data__value "
+                          }
+                        },
+                        {
+                          key: {
+                            text: "Volume",
+                            classes: "meta-data__label govuk-!-font-weight-bold"
+                          },
+                          value: {
+                            html: chargeElementVolume,
+                            classes: "meta-data__value "
+                          }
+                        }
+                      ]
+                      })
+                  }}
+                {% endfor %}
+              </div>
+            </details>
+          {% endset %}
+
+          {% set detailChargeInfo = detailChargeInfo + additionalChargesDetail + adjustmentsDetail + '</p>' + elementDetail %}
+        {% endif %}
+
+        {# Create the transaction row and set the first 3 columns; Transaction detail, Billable days and Quantity #}
+        {% set transactionRow = [
+          {
+            html: detailDescription + detailChargeInfo,
+            attributes: { 'data-test': 'details-' + rowIndex }
+          },
+          {
+            text: transaction.billableDays,
+            format: 'numeric',
+            attributes: { 'data-test': 'billable-days-' + rowIndex }
+          },
+          {
+            text: transaction.quantity,
+            format: 'numeric',
+            attributes: { 'data-test': 'quantity-' + rowIndex }
+          }
+        ] %}
+
+        {# Credit column - we only add it for supplementary bills created in WRLS #}
+        {% if displayCreditDebitTotals %}
+          {% set transactionRow = (transactionRow.push(
+            {
+              text: transaction.creditAmount,
+              format: 'numeric',
+              attributes: { 'data-test': 'credit-' + rowIndex }
+            }
+          ), transactionRow) %}
+        {% endif %}
+
+        {# Debit column - always added but must be done after the dynamic credit column to match the header order #}
+        {% set transactionRow = (transactionRow.push(
+          {
+            text: transaction.debitAmount,
+            format: 'numeric',
+            attributes: { 'data-test': 'debit-' + rowIndex }
+          }
+        ), transactionRow) %}
+
+        {% set tableRows = (tableRows.push(transactionRow), tableRows) %}
+      {% endfor %}
+
+      {# Determine if credit and debit total rows should be added #}
+      {% if displayCreditDebitTotals %}
+        {% set creditRow = [
+          {
+            text: 'Credits total',
+            colspan: 3
+          },
+          {
+            text: creditTotal,
+            format: 'numeric',
+            classes: 'govuk-!-font-weight-bold',
+            attributes: { 'data-test': 'credits-total' }
+          },
+          {
+            text: '',
+            format: 'numeric'
+          }
+        ] %}
+
+        {% set debitRow = [
+          {
+            text: 'Debits total',
+            colspan: 4
+          },
+          {
+            text: debitTotal,
+            format: 'numeric',
+            classes: 'govuk-!-font-weight-bold',
+            attributes: { 'data-test': 'debits-total' }
+          }
+        ] %}
+
+        {% set tableRows = (tableRows.push(creditRow), tableRows) %}
+        {% set tableRows = (tableRows.push(debitRow), tableRows) %}
+      {% endif %}
+
+      {#
+        Add the Total row. This always gets added and uses a custom class to add a thicker dividing line.
+
+        To get the colspan correct we get the length of the tableHeaders array using a Nunjucks built in filter.
+      #}
+      {% set totalRow = [
+        {
+          text: 'Total',
+          classes: 'govuk-table__cell--total',
+          colspan: tableHeaders | length - 1
+        },
+        {
+          text: total,
+          format: 'numeric',
+          classes: 'govuk-table__cell--total govuk-!-font-weight-bold',
+          attributes: { 'data-test': 'total' }
+        }
+      ] %}
+      {% set tableRows = (tableRows.push(totalRow), tableRows) %}
+
+
+      {# Finally, add the table to the page! #}
+      {{
+        govukTable({
+          caption: tableCaption,
+          captionClasses: "govuk-table__caption--m govuk-!-margin-bottom-0",
+          firstCellIsHeader: true,
+          attributes: { 'data-test': 'transactions' },
+          head: tableHeaders,
+          rows: tableRows
+        })
+      }}
+    </div>
+  </div>
+{% endblock %}

--- a/test/controllers/bill-licences.controller.test.js
+++ b/test/controllers/bill-licences.controller.test.js
@@ -1,0 +1,168 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { describe, it, beforeEach, afterEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Things we need to stub
+const ViewBillLicenceService = require('../../app/services/bill-licences/view-bill-licence.service.js')
+
+// For running our service
+const { init } = require('../../app/server.js')
+
+describe('Bill Licences controller', () => {
+  let server
+
+  beforeEach(async () => {
+    // Create server before each test
+    server = await init()
+
+    // We silence any calls to server.logger.error made in the plugin to try and keep the test output as clean as
+    // possible
+    Sinon.stub(server.logger, 'error')
+
+    // We silence sending a notification to our Errbit instance using Airbrake
+    Sinon.stub(server.app.airbrake, 'notify').resolvesThis()
+  })
+
+  afterEach(() => {
+    Sinon.restore()
+  })
+
+  describe('GET /bill-licences', () => {
+    const options = {
+      method: 'GET',
+      url: '/bill-licences/64924759-8142-4a08-9d1e-1e902cd9d316',
+      auth: {
+        strategy: 'session',
+        credentials: { scope: ['billing'] }
+      }
+    }
+
+    describe('when the request succeeds', () => {
+      describe('and is for a PRESROC bill licence', () => {
+        beforeEach(async () => {
+          Sinon.stub(ViewBillLicenceService, 'go').resolves(_presrocPageData())
+        })
+
+        it('returns the page successfully', async () => {
+          const response = await server.inject(options)
+
+          expect(response.statusCode).to.equal(200)
+          expect(response.payload).to.contain('Transactions for WA/055/0017/999')
+
+          // Only the presroc view has this data attribute tag
+          expect(response.payload).to.contain('data-test="charge-element-season-0"')
+        })
+      })
+
+      describe('and is for an SROC bill licence', () => {
+        beforeEach(async () => {
+          Sinon.stub(ViewBillLicenceService, 'go').resolves(_srocPageData())
+        })
+
+        it('returns the page successfully', async () => {
+          const response = await server.inject(options)
+
+          expect(response.statusCode).to.equal(200)
+          expect(response.payload).to.contain('Transactions for 03/28/72/0099/1')
+
+          // Only the SROC view has this data attribute tag
+          expect(response.payload).to.contain('data-test="charge-reference-0"')
+        })
+      })
+    })
+  })
+})
+
+function _presrocPageData () {
+  return {
+    accountNumber: 'W99999999A',
+    billingInvoiceId: '5a5b313b-e707-490a-a693-799339941e4f',
+    creditTotal: '£0.00',
+    debitTotal: '£100.37',
+    displayCreditDebitTotals: true,
+    licenceId: '2eaa831d-7bd6-4b0a-aaf1-3aacafec6bf2',
+    licenceRef: 'WA/055/0017/999',
+    scheme: 'alcs',
+    tableCaption: '2 transactions',
+    total: '£100.37',
+    transactions: [
+      {
+        agreement: null,
+        billableDays: '123/123',
+        chargeElement: {
+          purpose: 'Spray Irrigation - Direct',
+          abstractionPeriod: '1 May to 31 August',
+          source: 'Unsupported',
+          season: 'Summer',
+          loss: 'High'
+        },
+        chargePeriod: '1 April 2021 to 31 March 2022',
+        chargeType: 'standard',
+        creditAmount: '',
+        debitAmount: '£100.37',
+        description: 'River Watery at Jenny Barrow, Whitchurch',
+        quantity: '12ML'
+      },
+      {
+        agreement: null,
+        billableDays: '123/123',
+        chargePeriod: '1 April 2021 to 31 March 2022',
+        chargeType: 'compensation',
+        creditAmount: '',
+        debitAmount: '£0.00',
+        description: 'Compensation charge',
+        quantity: '12ML'
+      }
+    ]
+  }
+}
+
+function _srocPageData () {
+  return {
+    accountNumber: 'B99990099A',
+    billingInvoiceId: '13822096-1118-404c-81a4-fdbe5fb73d8f',
+    creditTotal: '£0.00',
+    debitTotal: '£1,253.00',
+    displayCreditDebitTotals: true,
+    licenceId: 'a7a60a47-6d13-41ca-96f7-ea890f9c08e8',
+    licenceRef: '03/28/72/0099/1',
+    scheme: 'sroc',
+    tableCaption: '2 transactions',
+    total: '£1,253.00',
+    transactions: [
+      {
+        additionalCharges: '',
+        adjustments: 'Two-part tariff (0.5)',
+        billableDays: '214/214',
+        chargeCategoryDescription: 'High loss, non-tidal, restricted water, greater than 120 up to and including 220 ML/yr, Tier 1 model',
+        chargeElements: [{
+          purpose: 'Trickle Irrigation - Direct',
+          abstractionPeriod: '1 April to 31 October',
+          volume: '150ML'
+        }],
+        chargePeriod: '1 April 2023 to 31 March 2024',
+        chargeReference: '4.6.29 (£35.74)',
+        chargeType: 'standard',
+        creditAmount: '',
+        debitAmount: '£1,787.00',
+        description: 'Two-part tariff basic water abstraction charge: Borehole at Muckton - Sussex',
+        quantity: '150ML'
+      },
+      {
+        billableDays: '214/214',
+        chargePeriod: '1 April 2023 to 31 March 2024',
+        chargeType: 'compensation',
+        creditAmount: '',
+        debitAmount: '£0.00',
+        description: 'Compensation charge',
+        quantity: '150ML'
+      }
+    ]
+  }
+}

--- a/test/controllers/bills.controller.test.js
+++ b/test/controllers/bills.controller.test.js
@@ -14,7 +14,7 @@ const ViewBillService = require('../../app/services/bills/view-bill.service.js')
 // For running our service
 const { init } = require('../../app/server.js')
 
-describe('Health controller', () => {
+describe('Bills controller', () => {
   let server
 
   beforeEach(async () => {
@@ -33,7 +33,7 @@ describe('Health controller', () => {
     Sinon.restore()
   })
 
-  describe('GET /data/export', () => {
+  describe('GET /bills', () => {
     const options = {
       method: 'GET',
       url: '/bills/64924759-8142-4a08-9d1e-1e902cd9d316',


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4156

Related to WATER-4155 and the work to replace the legacy bill page with our own we're now able to add the page it will link to; a view of the bill licence and all its transactions.

We've already made several other changes to support this. With the addition of [Add view bill licence service](https://github.com/DEFRA/water-abstraction-system/pull/509) we can make the final change; creating the endpoint and adding the view template.