### PR TITLE
Fix bill total in single licence bill page

### DIFF
--- a/app/presenters/bill-licences/view-bill-licence.presenter.js
+++ b/app/presenters/bill-licences/view-bill-licence.presenter.js
@@ -2,7 +2,7 @@
 
 /**
  * Formats data for a bill licence including its transactions into what is needed for the bill-licence page
- * @module BillLicencesTransactionsPresenter
+ * @module ViewBillLicencePresenter
  */
 
 const { formatMoney } = require('../base.presenter.js')
@@ -36,8 +36,8 @@ function go (billLicence) {
     licenceRef,
     scheme: bill.billRun.scheme,
     tableCaption: _tableCaption(transactions),
-    total,
-    transactions: _transactions(transactions)
+    transactions: _transactions(transactions),
+    transactionsTotal: total
   }
 }
 

--- a/app/presenters/bills/bill.presenter.js
+++ b/app/presenters/bills/bill.presenter.js
@@ -25,6 +25,7 @@ function go (bill, billingAccount) {
     billRunNumber: billRun.billRunNumber,
     billRunStatus: billRun.status,
     billRunType: _billRunType(billRun),
+    billTotal: _billTotal(bill.netAmount, bill.isCredit),
     chargeScheme: _scheme(billRun),
     contactName: _contactName(billingAccount),
     credit: bill.isCredit,
@@ -36,7 +37,6 @@ function go (bill, billingAccount) {
     financialYear: _financialYear(bill),
     flaggedForReissue: bill.isFlaggedForRebilling,
     region: capitalize(billRun.region.displayName),
-    total: _total(bill.netAmount, bill.isCredit),
     transactionFile: billRun.transactionFileReference
   }
 
@@ -148,7 +148,7 @@ function _scheme (billRun) {
   return 'Old'
 }
 
-function _total (valueInPence, credit) {
+function _billTotal (valueInPence, credit) {
   const valueAsMoney = formatMoney(valueInPence)
 
   if (credit) {

--- a/app/views/bill-licences/view-presroc.njk
+++ b/app/views/bill-licences/view-presroc.njk
@@ -271,7 +271,7 @@
           colspan: tableHeaders | length - 1
         },
         {
-          text: total,
+          text: transactionsTotal,
           format: 'numeric',
           classes: 'govuk-table__cell--total govuk-!-font-weight-bold',
           attributes: { 'data-test': 'total' }

--- a/app/views/bill-licences/view-sroc.njk
+++ b/app/views/bill-licences/view-sroc.njk
@@ -266,7 +266,7 @@
           colspan: tableHeaders | length - 1
         },
         {
-          text: total,
+          text: transactionsTotal,
           format: 'numeric',
           classes: 'govuk-table__cell--total govuk-!-font-weight-bold',
           attributes: { 'data-test': 'total' }

--- a/app/views/bills/view-multi-licence.njk
+++ b/app/views/bills/view-multi-licence.njk
@@ -109,7 +109,7 @@
   <div class="govuk-grid-row govuk-!-margin-bottom-3">
     <div class="govuk-grid-column-one-half">
       <h2>
-        <span class="govuk-body govuk-!-font-weight-bold govuk-!-font-size-80" data-test="bill-total">{{ total }}</span><br>
+        <span class="govuk-body govuk-!-font-weight-bold govuk-!-font-size-80" data-test="bill-total">{{ billTotal }}</span><br>
         <span class="govuk-body govuk-!-font-weight-bold govuk-!-font-size-24">Total</span>
       </h2>
       {% if deminimis %}

--- a/app/views/bills/view-single-licence-presroc.njk
+++ b/app/views/bills/view-single-licence-presroc.njk
@@ -409,7 +409,7 @@
           colspan: tableHeaders | length - 1
         },
         {
-          text: total,
+          text: transactionsTotal,
           format: 'numeric',
           classes: 'govuk-table__cell--total govuk-!-font-weight-bold',
           attributes: { 'data-test': 'total' }

--- a/app/views/bills/view-single-licence-presroc.njk
+++ b/app/views/bills/view-single-licence-presroc.njk
@@ -109,7 +109,7 @@
   <div class="govuk-grid-row govuk-!-margin-bottom-3">
     <div class="govuk-grid-column-one-half">
       <h2>
-        <span class="govuk-body govuk-!-font-weight-bold govuk-!-font-size-80" data-test="bill-total">{{ total }}</span><br>
+        <span class="govuk-body govuk-!-font-weight-bold govuk-!-font-size-80" data-test="bill-total">{{ billTotal }}</span><br>
         <span class="govuk-body govuk-!-font-weight-bold govuk-!-font-size-24">Total</span>
       </h2>
       {% if deminimis %}

--- a/app/views/bills/view-single-licence-sroc.njk
+++ b/app/views/bills/view-single-licence-sroc.njk
@@ -109,7 +109,7 @@
   <div class="govuk-grid-row govuk-!-margin-bottom-3">
     <div class="govuk-grid-column-one-half">
       <h2>
-        <span class="govuk-body govuk-!-font-weight-bold govuk-!-font-size-80" data-test="bill-total">{{ total }}</span><br>
+        <span class="govuk-body govuk-!-font-weight-bold govuk-!-font-size-80" data-test="bill-total">{{ billTotal }}</span><br>
         <span class="govuk-body govuk-!-font-weight-bold govuk-!-font-size-24">Total</span>
       </h2>
       {% if deminimis %}

--- a/app/views/bills/view-single-licence-sroc.njk
+++ b/app/views/bills/view-single-licence-sroc.njk
@@ -404,7 +404,7 @@
           colspan: tableHeaders | length - 1
         },
         {
-          text: total,
+          text: transactionsTotal,
           format: 'numeric',
           classes: 'govuk-table__cell--total govuk-!-font-weight-bold',
           attributes: { 'data-test': 'total' }

--- a/test/presenters/bill-licences/view-bill-licence.presenter.test.js
+++ b/test/presenters/bill-licences/view-bill-licence.presenter.test.js
@@ -94,13 +94,13 @@ describe('View Bill Licence presenter', () => {
           licenceRef: 'WA/055/0017/013',
           scheme: 'alcs',
           tableCaption: '4 transactions',
-          total: '£288.37',
           transactions: [
             { chargeType: 'standard' },
             { chargeType: 'standard' },
             { chargeType: 'compensation' },
             { chargeType: 'minimum_charge' }
-          ]
+          ],
+          transactionsTotal: '£288.37'
         })
       })
     })
@@ -130,13 +130,13 @@ describe('View Bill Licence presenter', () => {
           licenceRef: 'WA/055/0017/013',
           scheme: 'alcs',
           tableCaption: '4 transactions',
-          total: '-£288.37',
           transactions: [
             { chargeType: 'standard' },
             { chargeType: 'standard' },
             { chargeType: 'compensation' },
             { chargeType: 'minimum_charge' }
-          ]
+          ],
+          transactionsTotal: '-£288.37'
         })
       })
     })

--- a/test/presenters/bills/bill.presenter.test.js
+++ b/test/presenters/bills/bill.presenter.test.js
@@ -37,6 +37,7 @@ describe('Bill presenter', () => {
         billRunNumber: 10003,
         billRunStatus: 'sent',
         billRunType: 'Annual',
+        billTotal: '£213,178.00',
         chargeScheme: 'Current',
         contactName: null,
         credit: false,
@@ -48,7 +49,6 @@ describe('Bill presenter', () => {
         financialYear: '2022 to 2023',
         flaggedForReissue: false,
         region: 'South West',
-        total: '£213,178.00',
         transactionFile: 'nalei50002t'
       })
     })
@@ -147,6 +147,28 @@ describe('Bill presenter', () => {
               expect(result.billRunType).to.equal('Two-part tariff summer')
             })
           })
+        })
+      })
+    })
+
+    describe("the 'billTotal' property", () => {
+      describe('when the bill is a debit', () => {
+        it('returns just the bill total formatted as money', () => {
+          const result = BillPresenter.go(bill, billingAccount)
+
+          expect(result.billTotal).to.equal('£213,178.00')
+        })
+      })
+
+      describe('when the bill is a credit', () => {
+        beforeEach(() => {
+          bill.isCredit = true
+        })
+
+        it("returns the bill total formatted as money plus 'credit' as a suffix", () => {
+          const result = BillPresenter.go(bill, billingAccount)
+
+          expect(result.billTotal).to.equal('£213,178.00 credit')
         })
       })
     })
@@ -339,28 +361,6 @@ describe('Bill presenter', () => {
         const result = BillPresenter.go(bill, billingAccount)
 
         expect(result.region).to.equal('South West')
-      })
-    })
-
-    describe("the 'total' property", () => {
-      describe('when the bill is a debit', () => {
-        it('returns just the bill total formatted as money', () => {
-          const result = BillPresenter.go(bill, billingAccount)
-
-          expect(result.total).to.equal('£213,178.00')
-        })
-      })
-
-      describe('when the bill is a credit', () => {
-        beforeEach(() => {
-          bill.isCredit = true
-        })
-
-        it("returns the bill total formatted as money plus 'credit' as a suffix", () => {
-          const result = BillPresenter.go(bill, billingAccount)
-
-          expect(result.total).to.equal('£213,178.00 credit')
-        })
       })
     })
   })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4132

An issue was found with how credits were displayed that we sorted; [Fix display of credit transactions in bill views](https://github.com/DEFRA/water-abstraction-system/pull/522). Or we thought we did. 😩

The bill information has a total which needs to be `£100.00 credit`. The transactions table beneath also has a total but it needs to display `-£100.00`.

To build the single licence bill view we combine the output from `BillPresenter` with `ViewBillLicencePresenter`. It just so happens that both return a `total:` property. 🤦

This means one is overriding the other leading to an issue on the single licence bill page. This change fixes it.