### PR TITLE
Fix bill total wrapping when a credit

### DIFF
--- a/app/views/bills/view-multi-licence.njk
+++ b/app/views/bills/view-multi-licence.njk
@@ -107,7 +107,7 @@
 
   {# Bill total #}
   <div class="govuk-grid-row govuk-!-margin-bottom-3">
-    <div class="govuk-grid-column-one-half">
+    <div class="govuk-grid-column-two-thirds">
       <h2>
         <span class="govuk-body govuk-!-font-weight-bold govuk-!-font-size-80" data-test="bill-total">{{ billTotal }}</span><br>
         <span class="govuk-body govuk-!-font-weight-bold govuk-!-font-size-24">Total</span>

--- a/app/views/bills/view-single-licence-presroc.njk
+++ b/app/views/bills/view-single-licence-presroc.njk
@@ -107,7 +107,7 @@
 
   {# Bill total #}
   <div class="govuk-grid-row govuk-!-margin-bottom-3">
-    <div class="govuk-grid-column-one-half">
+    <div class="govuk-grid-column-two-thirds">
       <h2>
         <span class="govuk-body govuk-!-font-weight-bold govuk-!-font-size-80" data-test="bill-total">{{ billTotal }}</span><br>
         <span class="govuk-body govuk-!-font-weight-bold govuk-!-font-size-24">Total</span>

--- a/app/views/bills/view-single-licence-sroc.njk
+++ b/app/views/bills/view-single-licence-sroc.njk
@@ -107,7 +107,7 @@
 
   {# Bill total #}
   <div class="govuk-grid-row govuk-!-margin-bottom-3">
-    <div class="govuk-grid-column-one-half">
+    <div class="govuk-grid-column-two-thirds">
       <h2>
         <span class="govuk-body govuk-!-font-weight-bold govuk-!-font-size-80" data-test="bill-total">{{ billTotal }}</span><br>
         <span class="govuk-body govuk-!-font-weight-bold govuk-!-font-size-24">Total</span>


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4131

We have found when the value of a credit gets beyond a few pounds that the current view will wrap it even though there appears to be plenty of space.

So, in this change, we tweak the [GDS layout class](https://design-system.service.gov.uk/styles/layout/#common-layouts) being used to give us a little extra space. The value will still wrap if it's _really_ large. But in most cases now it should be on one line.

## Before

![Screenshot 2023-11-14 at 23 37 36](https://github.com/DEFRA/water-abstraction-system/assets/1789650/75a38d43-aee8-4f8a-81fb-fc05571911b0)

## After

![Screenshot 2023-11-14 at 23 37 58](https://github.com/DEFRA/water-abstraction-system/assets/1789650/636a59ab-9d29-43ba-9d1a-e5b86940b0a4)
