### PR TITLE
Rename bill presenters to match convention

### DIFF
--- a/app/presenters/bill-licences/view-bill-licence.presenter.js
+++ b/app/presenters/bill-licences/view-bill-licence.presenter.js
@@ -6,9 +6,9 @@
  */
 
 const { formatMoney } = require('../base.presenter.js')
-const CompensationChargeTransactionPresenter = require('./compensation-charge-transaction.presenter.js')
-const MinimumChargeTransactionPresenter = require('./minimum-charge-transaction.presenter.js')
-const StandardChargeTransactionPresenter = require('./standard-charge-transaction.presenter.js')
+const ViewCompensationChargeTransactionPresenter = require('./view-compensation-charge-transaction.presenter.js')
+const ViewMinimumChargeTransactionPresenter = require('./view-minimum-charge-transaction.presenter.js')
+const ViewStandardChargeTransactionPresenter = require('./view-standard-charge-transaction.presenter.js')
 
 /**
  * Formats data for a bill licence including its transactions into what is needed for the bill-licence page
@@ -85,14 +85,14 @@ function _transactions (transactions) {
     const { chargeType } = transaction
 
     if (chargeType === 'minimum_charge') {
-      return MinimumChargeTransactionPresenter.go(transaction)
+      return ViewMinimumChargeTransactionPresenter.go(transaction)
     }
 
     if (chargeType === 'compensation') {
-      return CompensationChargeTransactionPresenter.go(transaction)
+      return ViewCompensationChargeTransactionPresenter.go(transaction)
     }
 
-    return StandardChargeTransactionPresenter.go(transaction)
+    return ViewStandardChargeTransactionPresenter.go(transaction)
   })
 }
 

--- a/app/presenters/bill-licences/view-compensation-charge-transaction.presenter.js
+++ b/app/presenters/bill-licences/view-compensation-charge-transaction.presenter.js
@@ -2,7 +2,7 @@
 
 /**
  * Formats data for a compensation charge transaction for the bill-licence page
- * @module CompensationChargeTransactionPresenter
+ * @module ViewCompensationChargeTransactionPresenter
  */
 
 const { formatLongDate, formatMoney } = require('../base.presenter.js')

--- a/app/presenters/bill-licences/view-minimum-charge-transaction.presenter.js
+++ b/app/presenters/bill-licences/view-minimum-charge-transaction.presenter.js
@@ -2,7 +2,7 @@
 
 /**
  * Formats data for minimum charge transaction for the bill-licence page
- * @module MinimumChargeTransactionPresenter
+ * @module ViewMinimumChargeTransactionPresenter
  */
 
 const { formatMoney } = require('../base.presenter.js')

--- a/app/presenters/bill-licences/view-standard-charge-transaction.presenter.js
+++ b/app/presenters/bill-licences/view-standard-charge-transaction.presenter.js
@@ -2,7 +2,7 @@
 
 /**
  * Formats data for a standard charge transaction for the bill-licence page
- * @module StandardChargeTransactionPresenter
+ * @module ViewStandardChargeTransactionPresenter
  */
 
 const {

--- a/app/presenters/bills/view-bill.presenter.js
+++ b/app/presenters/bills/view-bill.presenter.js
@@ -2,7 +2,7 @@
 
 /**
  * Formats bill data ready for presenting in the single licence bill and multi licence bill pages
- * @module BillPresenter
+ * @module ViewBillPresenter
  */
 
 const {

--- a/app/presenters/bills/view-licence-summaries.presenter.js
+++ b/app/presenters/bills/view-licence-summaries.presenter.js
@@ -2,7 +2,7 @@
 
 /**
  * Formats summary data of licences connected to a bill for the multi-licence bill page
- * @module LicenceSummariesPresenter
+ * @module ViewLicenceSummariesPresenter
  */
 
 const { formatMoney } = require('../base.presenter.js')

--- a/app/services/bills/view-bill.service.js
+++ b/app/services/bills/view-bill.service.js
@@ -5,12 +5,12 @@
  * @module ViewBillService
  */
 
-const BillPresenter = require('../../presenters/bills/bill.presenter.js')
 const FetchBillingAccountService = require('./fetch-billing-account.service.js')
 const FetchBillLicence = require('../bill-licences/fetch-bill-licence.service.js')
 const FetchBillService = require('./fetch-bill-service.js')
-const LicenceSummariesPresenter = require('../../presenters/bills/licence-summaries.presenter.js')
+const ViewBillPresenter = require('../../presenters/bills/view-bill.presenter.js')
 const ViewBillLicencePresenter = require('../../presenters/bill-licences/view-bill-licence.presenter.js')
+const ViewLicenceSummariesPresenter = require('../../presenters/bills/view-licence-summaries.presenter.js')
 
 /**
  * Orchestrates fetching and presenting the data needed for one of the view bill templates
@@ -35,13 +35,13 @@ async function go (id) {
 
   // Irrespective of of how many licences are linked to the bill, the templates always need formatted bill and billing
   // account data
-  const billAndBillingAccountData = BillPresenter.go(bill, billingAccount)
+  const billAndBillingAccountData = ViewBillPresenter.go(bill, billingAccount)
 
   let additionalData = {}
 
   // If we have multiple licences we need to provide formatted licence summary data for the multi licence bill template
   if (licenceSummaries.length > 1) {
-    additionalData = LicenceSummariesPresenter.go(licenceSummaries)
+    additionalData = ViewLicenceSummariesPresenter.go(licenceSummaries)
   } else {
     // Else we need to provide we need to provide bill licence data for the single licence bill templates
     // (ViewBillLicencePresenter handles both PRESROC and SROC)

--- a/test/presenters/bill-licences/view-bill-licence.presenter.test.js
+++ b/test/presenters/bill-licences/view-bill-licence.presenter.test.js
@@ -9,9 +9,9 @@ const { describe, it, beforeEach, afterEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Things we need to stub
-const CompensationChargeTransactionPresenter = require('../../../app/presenters/bill-licences/compensation-charge-transaction.presenter.js')
-const MinimumChargeTransactionPresenter = require('../../../app/presenters/bill-licences/minimum-charge-transaction.presenter.js')
-const StandardChargeTransactionPresenter = require('../../../app/presenters/bill-licences/standard-charge-transaction.presenter.js')
+const ViewCompensationChargeTransactionPresenter = require('../../../app/presenters/bill-licences/view-compensation-charge-transaction.presenter.js')
+const ViewMinimumChargeTransactionPresenter = require('../../../app/presenters/bill-licences/view-minimum-charge-transaction.presenter.js')
+const ViewStandardChargeTransactionPresenter = require('../../../app/presenters/bill-licences/view-standard-charge-transaction.presenter.js')
 
 // Thing under test
 const ViewBillLicencePresenter = require('../../../app/presenters/bill-licences/view-bill-licence.presenter.js')
@@ -27,9 +27,9 @@ describe('View Bill Licence presenter', () => {
     beforeEach(() => {
       billLicence = _testBillLicence()
 
-      Sinon.stub(CompensationChargeTransactionPresenter, 'go').returns({ chargeType: 'compensation' })
-      Sinon.stub(MinimumChargeTransactionPresenter, 'go').returns({ chargeType: 'minimum_charge' })
-      Sinon.stub(StandardChargeTransactionPresenter, 'go').returns({ chargeType: 'standard' })
+      Sinon.stub(ViewCompensationChargeTransactionPresenter, 'go').returns({ chargeType: 'compensation' })
+      Sinon.stub(ViewMinimumChargeTransactionPresenter, 'go').returns({ chargeType: 'minimum_charge' })
+      Sinon.stub(ViewStandardChargeTransactionPresenter, 'go').returns({ chargeType: 'standard' })
     })
 
     describe("the 'displayCreditDebitTotals' property", () => {

--- a/test/presenters/bill-licences/view-compensation-charge-transaction.presenter.test.js
+++ b/test/presenters/bill-licences/view-compensation-charge-transaction.presenter.test.js
@@ -8,9 +8,9 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Thing under test
-const CompensationChargeTransactionPresenter = require('../../../app/presenters/bill-licences/compensation-charge-transaction.presenter.js')
+const ViewCompensationChargeTransactionPresenter = require('../../../app/presenters/bill-licences/view-compensation-charge-transaction.presenter.js')
 
-describe('Compensation Charge Transaction presenter', () => {
+describe('View Compensation Charge Transaction presenter', () => {
   let transaction
 
   describe('when provided with a compensation charge transaction', () => {
@@ -35,7 +35,7 @@ describe('Compensation Charge Transaction presenter', () => {
       })
 
       it('returns the credit property populated and the debit empty', () => {
-        const result = CompensationChargeTransactionPresenter.go(transaction)
+        const result = ViewCompensationChargeTransactionPresenter.go(transaction)
 
         expect(result.creditAmount).to.equal('£214.74')
         expect(result.debitAmount).to.equal('')
@@ -48,7 +48,7 @@ describe('Compensation Charge Transaction presenter', () => {
       })
 
       it('returns the debit property populated and the credit empty', () => {
-        const result = CompensationChargeTransactionPresenter.go(transaction)
+        const result = ViewCompensationChargeTransactionPresenter.go(transaction)
 
         expect(result.creditAmount).to.equal('')
         expect(result.debitAmount).to.equal('£214.74')
@@ -57,7 +57,7 @@ describe('Compensation Charge Transaction presenter', () => {
 
     describe('that is for SROC', () => {
       it('correctly presents the data', () => {
-        const result = CompensationChargeTransactionPresenter.go(transaction)
+        const result = ViewCompensationChargeTransactionPresenter.go(transaction)
 
         expect(result).to.equal({
           billableDays: '153/214',
@@ -83,7 +83,7 @@ describe('Compensation Charge Transaction presenter', () => {
           })
 
           it("returns 'Two-part tariff'", () => {
-            const result = CompensationChargeTransactionPresenter.go(transaction)
+            const result = ViewCompensationChargeTransactionPresenter.go(transaction)
 
             expect(result.agreement).to.equal('Two-part tariff')
           })
@@ -91,7 +91,7 @@ describe('Compensation Charge Transaction presenter', () => {
 
         describe('when the transaction is not two-part tariff', () => {
           it('returns null', () => {
-            const result = CompensationChargeTransactionPresenter.go(transaction)
+            const result = ViewCompensationChargeTransactionPresenter.go(transaction)
 
             expect(result.agreement).to.be.null()
           })
@@ -99,7 +99,7 @@ describe('Compensation Charge Transaction presenter', () => {
       })
 
       it('correctly presents the data', () => {
-        const result = CompensationChargeTransactionPresenter.go(transaction)
+        const result = ViewCompensationChargeTransactionPresenter.go(transaction)
 
         expect(result).to.equal({
           agreement: null,

--- a/test/presenters/bill-licences/view-minimum-charge-transaction.presenter.test.js
+++ b/test/presenters/bill-licences/view-minimum-charge-transaction.presenter.test.js
@@ -8,9 +8,9 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Thing under test
-const MinimumChargeTransactionPresenter = require('../../../app/presenters/bill-licences/minimum-charge-transaction.presenter.js')
+const ViewMinimumChargeTransactionPresenter = require('../../../app/presenters/bill-licences/view-minimum-charge-transaction.presenter.js')
 
-describe('Minimum Charge Transaction presenter', () => {
+describe('View Minimum Charge Transaction presenter', () => {
   let transaction
 
   describe('when provided with a minimum charge transaction', () => {
@@ -27,7 +27,7 @@ describe('Minimum Charge Transaction presenter', () => {
       })
 
       it('returns the credit property populated and the debit empty', () => {
-        const result = MinimumChargeTransactionPresenter.go(transaction)
+        const result = ViewMinimumChargeTransactionPresenter.go(transaction)
 
         expect(result.creditAmount).to.equal('£24.01')
         expect(result.debitAmount).to.equal('')
@@ -40,7 +40,7 @@ describe('Minimum Charge Transaction presenter', () => {
       })
 
       it('returns the debit property populated and the credit empty', () => {
-        const result = MinimumChargeTransactionPresenter.go(transaction)
+        const result = ViewMinimumChargeTransactionPresenter.go(transaction)
 
         expect(result.creditAmount).to.equal('')
         expect(result.debitAmount).to.equal('£24.01')
@@ -48,7 +48,7 @@ describe('Minimum Charge Transaction presenter', () => {
     })
 
     it('correctly presents the data', () => {
-      const result = MinimumChargeTransactionPresenter.go(transaction)
+      const result = ViewMinimumChargeTransactionPresenter.go(transaction)
 
       expect(result).to.equal({
         billableDays: '',

--- a/test/presenters/bill-licences/view-standard-charge-transaction.presenter.test.js
+++ b/test/presenters/bill-licences/view-standard-charge-transaction.presenter.test.js
@@ -8,9 +8,9 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Thing under test
-const StandardChargeTransactionPresenter = require('../../../app/presenters/bill-licences/standard-charge-transaction.presenter.js')
+const ViewStandardChargeTransactionPresenter = require('../../../app/presenters/bill-licences/view-standard-charge-transaction.presenter.js')
 
-describe('Standard Charge Transaction presenter', () => {
+describe('View Standard Charge Transaction presenter', () => {
   let transaction
 
   describe('when provided with an SROC standard charge transaction', () => {
@@ -24,7 +24,7 @@ describe('Standard Charge Transaction presenter', () => {
       })
 
       it('returns the credit and debit properties correctly', () => {
-        const result = StandardChargeTransactionPresenter.go(transaction)
+        const result = ViewStandardChargeTransactionPresenter.go(transaction)
 
         expect(result.creditAmount).to.equal('£1,162.00')
         expect(result.debitAmount).to.equal('')
@@ -37,7 +37,7 @@ describe('Standard Charge Transaction presenter', () => {
       })
 
       it('returns the credit and debit properties correctly', () => {
-        const result = StandardChargeTransactionPresenter.go(transaction)
+        const result = ViewStandardChargeTransactionPresenter.go(transaction)
 
         expect(result.creditAmount).to.equal('')
         expect(result.debitAmount).to.equal('£1,162.00')
@@ -57,7 +57,7 @@ describe('Standard Charge Transaction presenter', () => {
           })
 
           it("returns 'Supported source Candover (£-145.67)'", () => {
-            const result = StandardChargeTransactionPresenter.go(transaction)
+            const result = ViewStandardChargeTransactionPresenter.go(transaction)
 
             expect(result.additionalCharges).to.equal('Supported source Candover (£-145.67)')
           })
@@ -69,7 +69,7 @@ describe('Standard Charge Transaction presenter', () => {
           })
 
           it("returns 'Supported source Candover (£145.67)'", () => {
-            const result = StandardChargeTransactionPresenter.go(transaction)
+            const result = ViewStandardChargeTransactionPresenter.go(transaction)
 
             expect(result.additionalCharges).to.equal('Supported source Candover (£145.67)')
           })
@@ -82,7 +82,7 @@ describe('Standard Charge Transaction presenter', () => {
         })
 
         it("returns 'Public Water Supply'", () => {
-          const result = StandardChargeTransactionPresenter.go(transaction)
+          const result = ViewStandardChargeTransactionPresenter.go(transaction)
 
           expect(result.additionalCharges).to.equal('Public Water Supply')
         })
@@ -96,7 +96,7 @@ describe('Standard Charge Transaction presenter', () => {
         })
 
         it("returns 'Public Water Supply'", () => {
-          const result = StandardChargeTransactionPresenter.go(transaction)
+          const result = ViewStandardChargeTransactionPresenter.go(transaction)
 
           expect(result.additionalCharges).to.equal('Supported source Candover (£145.67), Public Water Supply')
         })
@@ -110,7 +110,7 @@ describe('Standard Charge Transaction presenter', () => {
         })
 
         it("returns 'Aggregate factor (0.75)'", () => {
-          const result = StandardChargeTransactionPresenter.go(transaction)
+          const result = ViewStandardChargeTransactionPresenter.go(transaction)
 
           expect(result.adjustments).to.equal('Aggregate factor (0.75)')
         })
@@ -122,7 +122,7 @@ describe('Standard Charge Transaction presenter', () => {
         })
 
         it("returns 'Adjustment factor (0.75)'", () => {
-          const result = StandardChargeTransactionPresenter.go(transaction)
+          const result = ViewStandardChargeTransactionPresenter.go(transaction)
 
           expect(result.adjustments).to.equal('Adjustment factor (0.75)')
         })
@@ -134,7 +134,7 @@ describe('Standard Charge Transaction presenter', () => {
         })
 
         it("returns 'Abatement factor (0.75)'", () => {
-          const result = StandardChargeTransactionPresenter.go(transaction)
+          const result = ViewStandardChargeTransactionPresenter.go(transaction)
 
           expect(result.adjustments).to.equal('Abatement factor (0.75)')
         })
@@ -146,7 +146,7 @@ describe('Standard Charge Transaction presenter', () => {
         })
 
         it("returns 'Two-part tariff (0.5)'", () => {
-          const result = StandardChargeTransactionPresenter.go(transaction)
+          const result = ViewStandardChargeTransactionPresenter.go(transaction)
 
           expect(result.adjustments).to.equal('Two-part tariff (0.5)')
         })
@@ -158,7 +158,7 @@ describe('Standard Charge Transaction presenter', () => {
         })
 
         it("returns 'Canal and River Trust (0.5)'", () => {
-          const result = StandardChargeTransactionPresenter.go(transaction)
+          const result = ViewStandardChargeTransactionPresenter.go(transaction)
 
           expect(result.adjustments).to.equal('Canal and River Trust (0.5)')
         })
@@ -170,7 +170,7 @@ describe('Standard Charge Transaction presenter', () => {
         })
 
         it("returns 'Winter discount (0.5)'", () => {
-          const result = StandardChargeTransactionPresenter.go(transaction)
+          const result = ViewStandardChargeTransactionPresenter.go(transaction)
 
           expect(result.adjustments).to.equal('Winter discount (0.5)')
         })
@@ -184,7 +184,7 @@ describe('Standard Charge Transaction presenter', () => {
         })
 
         it('returns the adjustment descriptions combined', () => {
-          const result = StandardChargeTransactionPresenter.go(transaction)
+          const result = ViewStandardChargeTransactionPresenter.go(transaction)
 
           expect(result.adjustments).to.equal('Adjustment factor (0.75), Two-part tariff (0.5), Winter discount (0.5)')
         })
@@ -193,7 +193,7 @@ describe('Standard Charge Transaction presenter', () => {
 
     describe("'chargeElements' property", () => {
       it('returns the purpose, abstraction period and volume for each element linked via the charge reference', () => {
-        const result = StandardChargeTransactionPresenter.go(transaction)
+        const result = ViewStandardChargeTransactionPresenter.go(transaction)
 
         expect(result.chargeElements).to.equal([
           {
@@ -212,14 +212,14 @@ describe('Standard Charge Transaction presenter', () => {
 
     describe("'chargeReference' property", () => {
       it("returns the charge category combined with the base line charge '4.5.13 (£11.62)'", () => {
-        const result = StandardChargeTransactionPresenter.go(transaction)
+        const result = ViewStandardChargeTransactionPresenter.go(transaction)
 
         expect(result.chargeReference).to.equal('4.5.13 (£11.62)')
       })
     })
 
     it('correctly presents the data', () => {
-      const result = StandardChargeTransactionPresenter.go(transaction)
+      const result = ViewStandardChargeTransactionPresenter.go(transaction)
 
       expect(result).to.equal({
         additionalCharges: '',
@@ -260,7 +260,7 @@ describe('Standard Charge Transaction presenter', () => {
       })
 
       it('returns the credit property populated and the debit empty', () => {
-        const result = StandardChargeTransactionPresenter.go(transaction)
+        const result = ViewStandardChargeTransactionPresenter.go(transaction)
 
         expect(result.creditAmount).to.equal('£1,162.00')
         expect(result.debitAmount).to.equal('')
@@ -273,7 +273,7 @@ describe('Standard Charge Transaction presenter', () => {
       })
 
       it('returns the debit property populated and the credit empty', () => {
-        const result = StandardChargeTransactionPresenter.go(transaction)
+        const result = ViewStandardChargeTransactionPresenter.go(transaction)
 
         expect(result.creditAmount).to.equal('')
         expect(result.debitAmount).to.equal('£1,162.00')
@@ -287,7 +287,7 @@ describe('Standard Charge Transaction presenter', () => {
         })
 
         it("returns 'Two-part tariff'", () => {
-          const result = StandardChargeTransactionPresenter.go(transaction)
+          const result = ViewStandardChargeTransactionPresenter.go(transaction)
 
           expect(result.agreement).to.equal('Two-part tariff')
         })
@@ -299,7 +299,7 @@ describe('Standard Charge Transaction presenter', () => {
         })
 
         it('returns null', () => {
-          const result = StandardChargeTransactionPresenter.go(transaction)
+          const result = ViewStandardChargeTransactionPresenter.go(transaction)
 
           expect(result.agreement).to.be.null()
         })
@@ -308,7 +308,7 @@ describe('Standard Charge Transaction presenter', () => {
 
     describe("the 'chargeElement' property", () => {
       it('returns the purpose, abstraction period, source, season and loss for the transaction', () => {
-        const result = StandardChargeTransactionPresenter.go(transaction)
+        const result = ViewStandardChargeTransactionPresenter.go(transaction)
 
         expect(result.chargeElement).to.equal({
           purpose: 'Trickle Irrigation - Direct',
@@ -321,7 +321,7 @@ describe('Standard Charge Transaction presenter', () => {
     })
 
     it('correctly presents the data', () => {
-      const result = StandardChargeTransactionPresenter.go(transaction)
+      const result = ViewStandardChargeTransactionPresenter.go(transaction)
 
       expect(result).to.equal({
         agreement: null,

--- a/test/presenters/bills/view-bill.presenter.test.js
+++ b/test/presenters/bills/view-bill.presenter.test.js
@@ -11,9 +11,9 @@ const { expect } = Code
 const ContactModel = require('../../../app/models/crm-v2/contact.model.js')
 
 // Thing under test
-const BillPresenter = require('../../../app/presenters/bills/bill.presenter.js')
+const ViewBillPresenter = require('../../../app/presenters/bills/view-bill.presenter.js')
 
-describe('Bill presenter', () => {
+describe('View Bill presenter', () => {
   let bill
   let billingAccount
 
@@ -24,7 +24,7 @@ describe('Bill presenter', () => {
     })
 
     it('correctly presents the data', () => {
-      const result = BillPresenter.go(bill, billingAccount)
+      const result = ViewBillPresenter.go(bill, billingAccount)
 
       expect(result).to.equal({
         accountName: 'Wessex Water Services Ltd',
@@ -56,7 +56,7 @@ describe('Bill presenter', () => {
     describe("the 'accountName' property", () => {
       describe('when the billing account is not linked to an agent', () => {
         it('returns the name of the company linked to the billing account', () => {
-          const result = BillPresenter.go(bill, billingAccount)
+          const result = ViewBillPresenter.go(bill, billingAccount)
 
           expect(result.accountName).to.equal('Wessex Water Services Ltd')
         })
@@ -72,7 +72,7 @@ describe('Bill presenter', () => {
         })
 
         it('returns the name of the agent company', () => {
-          const result = BillPresenter.go(bill, billingAccount)
+          const result = ViewBillPresenter.go(bill, billingAccount)
 
           expect(result.accountName).to.equal('Alan Broke')
         })
@@ -82,7 +82,7 @@ describe('Bill presenter', () => {
     describe("the 'addressLines' property", () => {
       describe('when the billing account address contains blank elements', () => {
         it('returns an array of only the set elements', () => {
-          const result = BillPresenter.go(bill, billingAccount)
+          const result = ViewBillPresenter.go(bill, billingAccount)
 
           expect(result.addressLines).to.equal(['86 Oxford Road', 'WOOTTON', 'COURTENAY', 'TA24 8NX'])
         })
@@ -92,7 +92,7 @@ describe('Bill presenter', () => {
     describe("the 'billRunType' property", () => {
       describe('when the bill run is annual', () => {
         it('returns Annual', () => {
-          const result = BillPresenter.go(bill, billingAccount)
+          const result = ViewBillPresenter.go(bill, billingAccount)
 
           expect(result.billRunType).to.equal('Annual')
         })
@@ -104,7 +104,7 @@ describe('Bill presenter', () => {
         })
 
         it('returns Supplementary', () => {
-          const result = BillPresenter.go(bill, billingAccount)
+          const result = ViewBillPresenter.go(bill, billingAccount)
 
           expect(result.billRunType).to.equal('Supplementary')
         })
@@ -117,7 +117,7 @@ describe('Bill presenter', () => {
 
         describe('and the scheme is sroc', () => {
           it('returns Supplementary', () => {
-            const result = BillPresenter.go(bill, billingAccount)
+            const result = ViewBillPresenter.go(bill, billingAccount)
 
             expect(result.billRunType).to.equal('Two-part tariff')
           })
@@ -130,7 +130,7 @@ describe('Bill presenter', () => {
 
           describe('and it is not summer only', () => {
             it('returns Supplementary', () => {
-              const result = BillPresenter.go(bill, billingAccount)
+              const result = ViewBillPresenter.go(bill, billingAccount)
 
               expect(result.billRunType).to.equal('Two-part tariff winter and all year')
             })
@@ -142,7 +142,7 @@ describe('Bill presenter', () => {
             })
 
             it('returns Supplementary', () => {
-              const result = BillPresenter.go(bill, billingAccount)
+              const result = ViewBillPresenter.go(bill, billingAccount)
 
               expect(result.billRunType).to.equal('Two-part tariff summer')
             })
@@ -154,7 +154,7 @@ describe('Bill presenter', () => {
     describe("the 'billTotal' property", () => {
       describe('when the bill is a debit', () => {
         it('returns just the bill total formatted as money', () => {
-          const result = BillPresenter.go(bill, billingAccount)
+          const result = ViewBillPresenter.go(bill, billingAccount)
 
           expect(result.billTotal).to.equal('£213,178.00')
         })
@@ -166,7 +166,7 @@ describe('Bill presenter', () => {
         })
 
         it("returns the bill total formatted as money plus 'credit' as a suffix", () => {
-          const result = BillPresenter.go(bill, billingAccount)
+          const result = ViewBillPresenter.go(bill, billingAccount)
 
           expect(result.billTotal).to.equal('£213,178.00 credit')
         })
@@ -176,7 +176,7 @@ describe('Bill presenter', () => {
     describe("the 'chargeScheme' property", () => {
       describe('when the bill run is sroc', () => {
         it('returns Current', () => {
-          const result = BillPresenter.go(bill, billingAccount)
+          const result = ViewBillPresenter.go(bill, billingAccount)
 
           expect(result.chargeScheme).to.equal('Current')
         })
@@ -188,7 +188,7 @@ describe('Bill presenter', () => {
         })
 
         it('returns Old', () => {
-          const result = BillPresenter.go(bill, billingAccount)
+          const result = ViewBillPresenter.go(bill, billingAccount)
 
           expect(result.chargeScheme).to.equal('Old')
         })
@@ -198,7 +198,7 @@ describe('Bill presenter', () => {
     describe("the 'contactName' property", () => {
       describe('when the billing account is linked not linked to a contact', () => {
         it('returns null', () => {
-          const result = BillPresenter.go(bill, billingAccount)
+          const result = ViewBillPresenter.go(bill, billingAccount)
 
           expect(result.contactName).to.be.null()
         })
@@ -223,7 +223,7 @@ describe('Bill presenter', () => {
         })
 
         it('returns the properly formatted contact name', () => {
-          const result = BillPresenter.go(bill, billingAccount)
+          const result = ViewBillPresenter.go(bill, billingAccount)
 
           expect(result.contactName).to.equal('Mrs M J Villar MBE')
         })
@@ -233,7 +233,7 @@ describe('Bill presenter', () => {
     describe("the 'creditsTotal' property", () => {
       describe('when the bill run was created in WRLS', () => {
         it("returns the 'creditNoteValue' of the bill (£0.00)", () => {
-          const result = BillPresenter.go(bill, billingAccount)
+          const result = ViewBillPresenter.go(bill, billingAccount)
 
           expect(result.creditsTotal).to.equal('£0.00')
         })
@@ -246,7 +246,7 @@ describe('Bill presenter', () => {
 
         describe("and 'netAmount' on the bill is 21317800", () => {
           it('returns £0.00', () => {
-            const result = BillPresenter.go(bill, billingAccount)
+            const result = ViewBillPresenter.go(bill, billingAccount)
 
             expect(result.creditsTotal).to.equal('£0.00')
           })
@@ -258,7 +258,7 @@ describe('Bill presenter', () => {
           })
 
           it('returns £213,178.00', () => {
-            const result = BillPresenter.go(bill, billingAccount)
+            const result = ViewBillPresenter.go(bill, billingAccount)
 
             expect(result.creditsTotal).to.equal('£213,178.00')
           })
@@ -270,7 +270,7 @@ describe('Bill presenter', () => {
           })
 
           it('returns £0.00', () => {
-            const result = BillPresenter.go(bill, billingAccount)
+            const result = ViewBillPresenter.go(bill, billingAccount)
 
             expect(result.creditsTotal).to.equal('£0.00')
           })
@@ -281,7 +281,7 @@ describe('Bill presenter', () => {
     describe("the 'debitsTotal' property", () => {
       describe('when the bill run was created in WRLS', () => {
         it("returns the 'invoiceValue' of the bill (£213,178.00)", () => {
-          const result = BillPresenter.go(bill, billingAccount)
+          const result = ViewBillPresenter.go(bill, billingAccount)
 
           expect(result.debitsTotal).to.equal('£213,178.00')
         })
@@ -294,7 +294,7 @@ describe('Bill presenter', () => {
 
         describe("and 'netAmount' on the bill is 21317800", () => {
           it('returns £213,178.00', () => {
-            const result = BillPresenter.go(bill, billingAccount)
+            const result = ViewBillPresenter.go(bill, billingAccount)
 
             expect(result.debitsTotal).to.equal('£213,178.00')
           })
@@ -306,7 +306,7 @@ describe('Bill presenter', () => {
           })
 
           it('returns £0.00', () => {
-            const result = BillPresenter.go(bill, billingAccount)
+            const result = ViewBillPresenter.go(bill, billingAccount)
 
             expect(result.debitsTotal).to.equal('£0.00')
           })
@@ -318,7 +318,7 @@ describe('Bill presenter', () => {
           })
 
           it('returns £0.00', () => {
-            const result = BillPresenter.go(bill, billingAccount)
+            const result = ViewBillPresenter.go(bill, billingAccount)
 
             expect(result.debitsTotal).to.equal('£0.00')
           })
@@ -329,7 +329,7 @@ describe('Bill presenter', () => {
     describe("the 'displayCreditDebitTotals' property", () => {
       describe('when the bill run is not supplementary', () => {
         it('returns false', () => {
-          const result = BillPresenter.go(bill, billingAccount)
+          const result = ViewBillPresenter.go(bill, billingAccount)
 
           expect(result.displayCreditDebitTotals).to.be.false()
         })
@@ -341,7 +341,7 @@ describe('Bill presenter', () => {
         })
 
         it('returns true', () => {
-          const result = BillPresenter.go(bill, billingAccount)
+          const result = ViewBillPresenter.go(bill, billingAccount)
 
           expect(result.displayCreditDebitTotals).to.be.true()
         })
@@ -350,7 +350,7 @@ describe('Bill presenter', () => {
 
     describe("the 'financialYear' property", () => {
       it('returns the bill run start and end financial year', () => {
-        const result = BillPresenter.go(bill, billingAccount)
+        const result = ViewBillPresenter.go(bill, billingAccount)
 
         expect(result.financialYear).to.equal('2022 to 2023')
       })
@@ -358,7 +358,7 @@ describe('Bill presenter', () => {
 
     describe("the 'region' property", () => {
       it("returns the bill run's region display name capitalized", () => {
-        const result = BillPresenter.go(bill, billingAccount)
+        const result = ViewBillPresenter.go(bill, billingAccount)
 
         expect(result.region).to.equal('South West')
       })

--- a/test/presenters/bills/view-licence-summaries.presenter.test.js
+++ b/test/presenters/bills/view-licence-summaries.presenter.test.js
@@ -8,9 +8,9 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Thing under test
-const LicenceSummariesPresenter = require('../../../app/presenters/bills/licence-summaries.presenter.js')
+const ViewLicenceSummariesPresenter = require('../../../app/presenters/bills/view-licence-summaries.presenter.js')
 
-describe('Licence Summaries presenter', () => {
+describe('View Licence Summaries presenter', () => {
   let licenceSummaries
 
   describe('when provided with a populated licence summaries', () => {
@@ -19,7 +19,7 @@ describe('Licence Summaries presenter', () => {
     })
 
     it('correctly presents the data', () => {
-      const result = LicenceSummariesPresenter.go(licenceSummaries)
+      const result = ViewLicenceSummariesPresenter.go(licenceSummaries)
 
       expect(result).to.equal({
         billLicences: [
@@ -52,7 +52,7 @@ describe('Licence Summaries presenter', () => {
         })
 
         it('returns the count and caption singular', () => {
-          const result = LicenceSummariesPresenter.go(singularLicenceSummary)
+          const result = ViewLicenceSummariesPresenter.go(singularLicenceSummary)
 
           expect(result.tableCaption).to.equal('1 licence')
         })
@@ -60,7 +60,7 @@ describe('Licence Summaries presenter', () => {
 
       describe('when there are multiple licence summaries', () => {
         it('returns the count and caption pluralised', () => {
-          const result = LicenceSummariesPresenter.go(licenceSummaries)
+          const result = ViewLicenceSummariesPresenter.go(licenceSummaries)
 
           expect(result.tableCaption).to.equal('3 licences')
         })

--- a/test/services/bills/view-bill.service.test.js
+++ b/test/services/bills/view-bill.service.test.js
@@ -9,10 +9,10 @@ const { describe, it, beforeEach, afterEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Things we need to stub
-const BillPresenter = require('../../../app/presenters/bills/bill.presenter.js')
 const FetchBillingAccountService = require('../../../app/services/bills/fetch-billing-account.service.js')
 const FetchBillService = require('../../../app/services/bills/fetch-bill-service.js')
-const LicenceSummariesPresenter = require('../../../app/presenters/bills/licence-summaries.presenter.js')
+const ViewBillPresenter = require('../../../app/presenters/bills/view-bill.presenter.js')
+const ViewLicenceSummariesPresenter = require('../../../app/presenters/bills/view-licence-summaries.presenter.js')
 const ViewBillLicencePresenter = require('../../../app/presenters/bill-licences/view-bill-licence.presenter.js')
 
 // Thing under test
@@ -41,11 +41,11 @@ describe('View Bill service', () => {
           }
         )
 
-        Sinon.stub(BillPresenter, 'go').returns({
+        Sinon.stub(ViewBillPresenter, 'go').returns({
           billingAccountId: '34183769-40d8-4d23-8bbb-f28e4d00c737'
         })
 
-        Sinon.stub(LicenceSummariesPresenter, 'go').returns(
+        Sinon.stub(ViewLicenceSummariesPresenter, 'go').returns(
           {
             billLicences: [
               {
@@ -100,7 +100,7 @@ describe('View Bill service', () => {
           }
         )
 
-        Sinon.stub(BillPresenter, 'go').returns({
+        Sinon.stub(ViewBillPresenter, 'go').returns({
           billingAccountId: '34183769-40d8-4d23-8bbb-f28e4d00c737'
         })
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4131

We've realised that the presenters we built to support the new view bill, and bill licence pages don't follow the convention we've been following. Principally, we start with an adjective. For example, `view` or `create`. We do this to give new maintainers a sense of what context the presenter is used in.

So, this is a housekeeping change to rename the presenters and bring them in line.