### PR TITLE
Create `crm_v2` schema views

### DIFF
--- a/db/migrations/public/20231128140249_create-billing-accounts-view.js
+++ b/db/migrations/public/20231128140249_create-billing-accounts-view.js
@@ -1,0 +1,29 @@
+'use strict'
+
+const viewName = 'billing_accounts'
+
+exports.up = function (knex) {
+  return knex
+    .schema
+    .createView(viewName, (view) => {
+      // NOTE: We have commented out unused columns from the source table
+      view.as(knex('invoice_accounts').withSchema('crm_v2').select([
+        'invoice_accounts.invoice_account_id AS id',
+        'invoice_accounts.company_id',
+        'invoice_accounts.invoice_account_number AS account_number',
+        // 'invoice_accounts.start_date', // is populated but is never displayed in the UI or used
+        // 'invoice_accounts.end_date', // is null for all records
+        // 'invoice_accounts.is_test', // we ignore this legacy test column in tables
+        'invoice_accounts.last_transaction_file_reference AS last_transaction_file',
+        'invoice_accounts.date_last_transaction_file_reference_updated AS last_transaction_file_created_at',
+        'invoice_accounts.date_created AS created_at',
+        'invoice_accounts.date_updated AS updated_at'
+      ]))
+    })
+}
+
+exports.down = function (knex) {
+  return knex
+    .schema
+    .dropViewIfExists(viewName)
+}

--- a/db/migrations/public/20231128141428_create-billing-account-addresses-view.js
+++ b/db/migrations/public/20231128141428_create-billing-account-addresses-view.js
@@ -1,0 +1,29 @@
+'use strict'
+
+const viewName = 'billing_account_addresses'
+
+exports.up = function (knex) {
+  return knex
+    .schema
+    .createView(viewName, (view) => {
+      // NOTE: We have commented out unused columns from the source table
+      view.as(knex('invoice_account_addresses').withSchema('crm_v2').select([
+        'invoice_account_addresses.invoice_account_address_id AS id',
+        'invoice_account_addresses.invoice_account_id AS billing_account_id',
+        'invoice_account_addresses.address_id',
+        'invoice_account_addresses.start_date',
+        'invoice_account_addresses.end_date',
+        // 'invoice_account_addresses.is_test', // we ignore this legacy test column in tables
+        'invoice_account_addresses.agent_company_id AS company_id',
+        'invoice_account_addresses.contact_id',
+        'invoice_account_addresses.date_created AS created_at',
+        'invoice_account_addresses.date_updated AS updated_at'
+      ]))
+    })
+}
+
+exports.down = function (knex) {
+  return knex
+    .schema
+    .dropViewIfExists(viewName)
+}

--- a/db/migrations/public/20231128142558_create-addresses-view.js
+++ b/db/migrations/public/20231128142558_create-addresses-view.js
@@ -1,0 +1,36 @@
+'use strict'
+
+const viewName = 'addresses'
+
+exports.up = function (knex) {
+  return knex
+    .schema
+    .createView(viewName, (view) => {
+      // NOTE: We have commented out unused columns from the source table
+      view.as(knex('addresses').withSchema('crm_v2').select([
+        'addresses.address_id AS id',
+        'addresses.address_1',
+        'addresses.address_2',
+        'addresses.address_3',
+        'addresses.address_4',
+        'addresses.town AS address_5',
+        'addresses.county AS address_6',
+        'addresses.postcode',
+        'addresses.country',
+        // 'addresses.external_id', // is populated for addresses migrated from NALD but not actually used
+        // 'addresses.is_test', // we ignore this legacy test column in tables
+        'addresses.data_source',
+        'addresses.uprn',
+        // 'addresses.last_hash', // is populated but is only used by the legacy import process
+        // 'addresses.current_hash', // is populated but is only used by the legacy import process
+        'addresses.date_created AS created_at',
+        'addresses.date_updated AS updated_at'
+      ]))
+    })
+}
+
+exports.down = function (knex) {
+  return knex
+    .schema
+    .dropViewIfExists(viewName)
+}

--- a/db/migrations/public/20231128143653_create-companies-view.js
+++ b/db/migrations/public/20231128143653_create-companies-view.js
@@ -1,0 +1,30 @@
+'use strict'
+
+const viewName = 'companies'
+
+exports.up = function (knex) {
+  return knex
+    .schema
+    .createView(viewName, (view) => {
+      // NOTE: We have commented out unused columns from the source table
+      view.as(knex('companies').withSchema('crm_v2').select([
+        'companies.company_id AS id',
+        'companies.name',
+        'companies.type',
+        'companies.company_number',
+        // 'companies.external_id', // is populated for companies migrated from NALD but not actually used
+        // 'companies.is_test', // we ignore this legacy test column in tables
+        'companies.organisation_type',
+        // 'companies.last_hash', // is populated but is only used by the legacy import process
+        // 'companies.current_hash', // is populated but is only used by the legacy import process
+        'companies.date_created AS created_at',
+        'companies.date_updated AS updated_at'
+      ]))
+    })
+}
+
+exports.down = function (knex) {
+  return knex
+    .schema
+    .dropViewIfExists(viewName)
+}

--- a/db/migrations/public/20231128143937_create-contacts-view.js
+++ b/db/migrations/public/20231128143937_create-contacts-view.js
@@ -1,0 +1,36 @@
+'use strict'
+
+const viewName = 'contacts'
+
+exports.up = function (knex) {
+  return knex
+    .schema
+    .createView(viewName, (view) => {
+      // NOTE: We have commented out unused columns from the source table
+      view.as(knex('contacts').withSchema('crm_v2').select([
+        'contacts.contact_id AS id',
+        'contacts.salutation',
+        'contacts.first_name',
+        'contacts.middle_initials',
+        'contacts.last_name',
+        // 'contacts.external_id', // is populated for contacts migrated from NALD but not actually used
+        'contacts.initials',
+        // 'contacts.is_test', // we ignore this legacy test column in tables
+        'contacts.data_source',
+        'contacts.contact_type',
+        'contacts.suffix',
+        'contacts.department',
+        // 'contacts.last_hash', // is populated but is only used by the legacy import process
+        // 'contacts.current_hash', // is populated but is only used by the legacy import process
+        'contacts.email',
+        'contacts.date_created AS created_at',
+        'contacts.date_updated AS updated_at'
+      ]))
+    })
+}
+
+exports.down = function (knex) {
+  return knex
+    .schema
+    .dropViewIfExists(viewName)
+}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4057

As part of the work we have been doing on two-part tariff we are going to be creating all our new tables in the default `public` schema.

We have also decided that when there is a legacy table that we are still going to need we will create a [View](https://www.postgresql.org/docs/current/sql-createview.html) of it in the `public` schema. This allows us to correct any issues with naming conventions, strip out unused fields, and join entities that are currently sat in different schemas. The first example of this approach was done in PR #531 .

This change adds the migrations needed to create views for the tables we are currently using from `crm_v2` schema.

> We'll follow this up with new models and test helpers in another change. The final step is then to refactor the existing code to use the new models and delete the old legacy ones.