### PR TITLE
Use absolute paths for relations in legacy models

### DIFF
--- a/app/models/legacy-base.model.js
+++ b/app/models/legacy-base.model.js
@@ -23,7 +23,6 @@ class LegacyBaseModel extends BaseModel {
   static get modelPaths () {
     const currentPath = __dirname
     return [
-      currentPath,
       path.join(currentPath, 'returns'),
       path.join(currentPath, 'water'),
       path.join(currentPath, 'crm-v2'),


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4057

As part of the work we have been doing on two-part tariff we are going to be creating all our new tables in the default `public` schema.

We have also decided that when there is a legacy table that we are still going to need we will create a [View](https://www.postgresql.org/docs/current/sql-createview.html) of it in the `public` schema. This allows us to correct any issues with naming conventions, strip out unused fields, and join entities that are currently sat in different schemas. The first example of this approach was done in PR #531 .

Whilst we transition from the models based directly on the tables to ones on our new views we'll have 2 of everything; 2 `BillRunModel`, `AddressModel`, etc. We didn't think this would be a problem but our initial attempts to create the new models have exposed an issue.

Because we are not able to take advantage of ESM modules, when you specify a relationship between models you have to provide a path. Handily, [Objection.js](https://vincit.github.io/objection.js/) has a solution where you provide a base class and specify a `modelPaths` property.

```javascript
  static get modelPaths () {
    return [__dirname]
  }
```

Because we put our legacy models in folders to help make it clear which schemas they came from, we needed to extend this further in the `LegacyBaseModel`.

```javascript
  static get modelPaths () {
    const currentPath = __dirname
    return [
      currentPath,
      path.join(currentPath, 'returns'),
      path.join(currentPath, 'water'),
      path.join(currentPath, 'crm-v2'),
      path.join(currentPath, 'idm')
    ]
  }
```

The issue is when Objection is trying to work out the relationships in a legacy model, it is seeing both models. This is causing relationships to break and unit tests to fail. Fortunately, the fix is simple. We just need to stop including the path to the new models in the `LegacyBaseModel`. Then, when Objection comes to deal with a relationship the only models it is seeing are the legacy ones. The same goes for the new models, because they only extend `BaseModel` they only know of the ones in the root of `src/models`.