### PR TITLE
Add no returns required page (return requirements)

### DIFF
--- a/app/controllers/licences.controller.js
+++ b/app/controllers/licences.controller.js
@@ -5,8 +5,13 @@
  * @module LicencesController
  */
 
-async function noReturnsRequired (_request, h) {
-  return h.response().code(200)
+async function noReturnsRequired (request, h) {
+  const { id } = request.params
+
+  return h.view('return-requirements/no-returns-required.njk', {
+    activeNavBar: 'search',
+    licenceId: id
+  })
 }
 
 async function selectReturnStartDate (request, h) {

--- a/app/views/return-requirements/no-returns-required.njk
+++ b/app/views/return-requirements/no-returns-required.njk
@@ -1,0 +1,24 @@
+{% extends 'layout.njk' %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% block breadcrumbs %}
+  {# Back link #}
+  {{
+    govukBackLink({
+      text: 'back',
+      href: "/licences/" + licenceId
+    })
+  }}
+{% endblock %}
+
+{% block content %}
+  {# Main heading #}
+  <div class="govuk-body">
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">Why are no returns required?</h1>
+  </div>
+
+  <div class="govuk-body">
+    {{ govukButton({ text: "Continue" }) }}
+  </div>
+{% endblock %}

--- a/test/controllers/licences.controller.test.js
+++ b/test/controllers/licences.controller.test.js
@@ -13,7 +13,7 @@ const { expect } = Code
 // For running our service
 const { init } = require('../../app/server.js')
 
-describe('Liicences controller', () => {
+describe('Licences controller', () => {
   let server
 
   beforeEach(async () => {
@@ -48,6 +48,26 @@ describe('Liicences controller', () => {
 
         expect(response.statusCode).to.equal(200)
         expect(response.payload).to.contain('Select the start date for the return requirement')
+      })
+    })
+  })
+
+  describe('GET /licences/{id}/no-returns-required', () => {
+    const options = {
+      method: 'GET',
+      url: '/licences/64924759-8142-4a08-9d1e-1e902cd9d316/no-returns-required',
+      auth: {
+        strategy: 'session',
+        credentials: { scope: ['billing'] }
+      }
+    }
+
+    describe('when the request succeeds', () => {
+      it('returns the page successfully', async () => {
+        const response = await server.inject(options)
+
+        expect(response.statusCode).to.equal(200)
+        expect(response.payload).to.contain('Why are no returns required?')
       })
     })
   })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4248

We are starting work on adding support for setting up return requirements within the service. A return requirement sets out how a licensee is expected to submit their returns, for example, daily, weekly or monthly, by what date, and using what unit of measure.

This is the very first page in the return requirements setup journey when 'no returns required' is selected.

This is just a stub page and controls and validation will come later.