### PR TITLE
Create `fetch-licences` service

### DIFF
--- a/app/services/bill-runs/two-part-tariff/fetch-licences.service.js
+++ b/app/services/bill-runs/two-part-tariff/fetch-licences.service.js
@@ -1,0 +1,64 @@
+'use strict'
+
+/**
+ * Fetches 2PT Licences for the matching region and billing period
+ * @module FetchLicencesService
+ */
+
+const FetchChargeVersionsService = require('./fetch-charge-versions.service.js')
+
+/**
+ *
+ * @param {*} regionId
+ * @param {*} billingPeriod
+ *
+ * @returns
+ */
+async function go (regionId, billingPeriod) {
+  const chargeVersions = await FetchChargeVersionsService.go(regionId, billingPeriod)
+
+  const uniqueLicenceIds = _extractUniqueLicenceIds(chargeVersions)
+
+  return _groupByLicence(chargeVersions, uniqueLicenceIds)
+}
+
+function _extractUniqueLicenceIds (chargeVersions) {
+  const allLicenceIds = chargeVersions.map((chargeVersion) => {
+    return chargeVersion.licence.id
+  })
+
+  return [...new Set(allLicenceIds)]
+}
+
+function _groupByLicence (chargeVersions, uniqueLicenceIds) {
+  // NOTE: We could have initialized licences as an empty array and pushed each new object. But for a big region
+  // the number of licences we might be dealing will be in the hundreds, possibly thousands. In these cases we get a
+  // performance bump if we create the array sized to our needs first, rather than asking Node to resize the array on
+  // each loop. Only applicable here though! Don't go doing this for every new array you declare ;-)
+  const licences = Array(uniqueLicenceIds.length).fill(undefined)
+
+  for (let i = 0; i < uniqueLicenceIds.length; i++) {
+    const licenceId = uniqueLicenceIds[i]
+    const matchedChargeVersions = chargeVersions.filter((chargeVersion) => {
+      return chargeVersion.licence.id === licenceId
+    })
+
+    const { licenceRef, startDate, expiredDate, lapsedDate, revokedDate } = matchedChargeVersions[0].licence
+
+    licences[i] = {
+      licenceId,
+      licenceRef,
+      startDate,
+      expiredDate,
+      lapsedDate,
+      revokedDate,
+      chargeVersions: matchedChargeVersions
+    }
+  }
+
+  return licences
+}
+
+module.exports = {
+  go
+}

--- a/app/services/bill-runs/two-part-tariff/fetch-licences.service.js
+++ b/app/services/bill-runs/two-part-tariff/fetch-licences.service.js
@@ -11,10 +11,10 @@ const FetchChargeVersionsService = require('./fetch-charge-versions.service.js')
  * Fetches 2PT Licences for the matching region and billing period plus the charge versions associated with them grouped
  * by licence
  *
- * @param {*} regionId UUID of the region being billed that the licences must be linked to
- * @param {*} billingPeriod Object with a `startDate` and `endDate` property representing the period being billed
+ * @param {String} regionId UUID of the region being billed that the licences must be linked to
+ * @param {Object} billingPeriod Object with a `startDate` and `endDate` property representing the period being billed
  *
- * @returns {Object} Contains an array of unique licence IDs and array of charge versions to be processed
+ * @returns {Object[]} the licences to be matched, each containing an array of charge versions applicable for two-part tariff
  */
 async function go (regionId, billingPeriod) {
   const chargeVersions = await FetchChargeVersionsService.go(regionId, billingPeriod)

--- a/app/services/bill-runs/two-part-tariff/fetch-licences.service.js
+++ b/app/services/bill-runs/two-part-tariff/fetch-licences.service.js
@@ -48,7 +48,7 @@ function _groupByLicence (chargeVersions, uniqueLicenceIds) {
     const { licenceRef, startDate, expiredDate, lapsedDate, revokedDate } = matchedChargeVersions[0].licence
 
     licences[i] = {
-      licenceId,
+      id: licenceId,
       licenceRef,
       startDate,
       expiredDate,

--- a/app/services/bill-runs/two-part-tariff/fetch-licences.service.js
+++ b/app/services/bill-runs/two-part-tariff/fetch-licences.service.js
@@ -8,11 +8,13 @@
 const FetchChargeVersionsService = require('./fetch-charge-versions.service.js')
 
 /**
+ * Fetches 2PT Licences for the matching region and billing period plus the charge versions associated with them grouped
+ * by licence
  *
- * @param {*} regionId
- * @param {*} billingPeriod
+ * @param {*} regionId UUID of the region being billed that the licences must be linked to
+ * @param {*} billingPeriod Object with a `startDate` and `endDate` property representing the period being billed
  *
- * @returns
+ * @returns {Object} Contains an array of unique licence IDs and array of charge versions to be processed
  */
 async function go (regionId, billingPeriod) {
   const chargeVersions = await FetchChargeVersionsService.go(regionId, billingPeriod)

--- a/test/services/bill-runs/two-part-tariff/fetch-licences.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/fetch-licences.service.test.js
@@ -54,7 +54,7 @@ describe('Fetch Licences service', () => {
         const result = await FetchLicencesService.go(regionId, billingPeriod)
 
         expect(result).to.have.length(1)
-        expect(result[0].licenceId).to.equal(licenceOne.id)
+        expect(result[0].id).to.equal(licenceOne.id)
         expect(result[0].licenceRef).to.equal(licenceOne.licenceRef)
         expect(result[0].startDate).to.equal(licenceOne.startDate)
         expect(result[0].expiredDate).to.equal(licenceOne.expiredDate)
@@ -112,8 +112,8 @@ describe('Fetch Licences service', () => {
         const result = await FetchLicencesService.go(regionId, billingPeriod)
 
         expect(result).to.have.length(2)
-        expect(result[0].licenceId).to.equal(licenceOne.id)
-        expect(result[1].licenceId).to.equal(licenceTwo.id)
+        expect(result[0].id).to.equal(licenceOne.id)
+        expect(result[1].id).to.equal(licenceTwo.id)
 
         expect(result[0].chargeVersions).to.have.length(2)
         expect(result[0].chargeVersions[0].id).to.equal('9407b74d-816c-44a2-9926-73a89a9da985')

--- a/test/services/bill-runs/two-part-tariff/fetch-licences.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/fetch-licences.service.test.js
@@ -70,40 +70,6 @@ describe('Fetch Licences service', () => {
       })
     })
 
-    describe('and there is a single licence linked to two charge versions', () => {
-      beforeEach(() => {
-        Sinon.stub(FetchChargeVersionsService, 'go').resolves(
-          [
-            {
-              id: '9407b74d-816c-44a2-9926-73a89a9da985',
-              startDate: '2022-10-01T00:00:00.000Z',
-              endDate: null,
-              status: 'current',
-              licence: licenceOne
-            },
-            {
-              id: 'cbab5668-21db-4fe5-9af8-9bb823d9294f',
-              startDate: '2022-04-01T00:00:00.000Z',
-              endDate: '2022-09-30T00:00:00.000Z',
-              status: 'current',
-              licence: licenceOne
-            }
-          ]
-        )
-      })
-
-      it('will fetch the data, format it and group the charge versions by the licence', async () => {
-        const result = await FetchLicencesService.go(regionId, billingPeriod)
-
-        expect(result).to.have.length(1)
-        expect(result[0].licenceId).to.equal(licenceOne.id)
-
-        expect(result[0].chargeVersions).to.have.length(2)
-        expect(result[0].chargeVersions[0].id).to.equal('9407b74d-816c-44a2-9926-73a89a9da985')
-        expect(result[0].chargeVersions[1].id).to.equal('cbab5668-21db-4fe5-9af8-9bb823d9294f')
-      })
-    })
-
     describe('and there are two licences linked to three charge versions', () => {
       const licenceTwo = {
         id: 'd561be9a-ddbb-4442-a361-757a4d1ef46c',

--- a/test/services/bill-runs/two-part-tariff/fetch-licences.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/fetch-licences.service.test.js
@@ -1,0 +1,147 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { describe, it, beforeEach, afterEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Things we need to stub
+const FetchChargeVersionsService = require('../../../../app/services/bill-runs/two-part-tariff/fetch-charge-versions.service.js')
+
+// Thing under test
+const FetchLicencesService = require('../../../../app/services/bill-runs/two-part-tariff/fetch-licences.service.js')
+
+describe('Fetch Licences service', () => {
+  const testId = '64924759-8142-4a08-9d1e-1e902cd9d316'
+
+  afterEach(() => {
+    Sinon.restore()
+  })
+
+  describe('when a bill with a matching ID exists', () => {
+    describe('and it is linked to multiple licences', () => {
+      beforeEach(() => {
+        Sinon.stub(FetchChargeVersionsService, 'go').resolves(
+          {
+            bill: {
+              billingInvoiceId: 'a102d2b4-d0d5-4b26-82e2-d74a66e2cdc3',
+              invoiceAccountId: '34183769-40d8-4d23-8bbb-f28e4d00c737'
+            },
+            licenceSummaries: [
+              { billingInvoiceLicenceId: '82c106dd-ee90-4566-b06b-a66d9e56b4b1' },
+              { billingInvoiceLicenceId: '5bf9a7f0-c769-486d-a685-f032799e42d9' }
+            ]
+          }
+        )
+
+        Sinon.stub(ViewBillPresenter, 'go').returns({
+          billingAccountId: '34183769-40d8-4d23-8bbb-f28e4d00c737'
+        })
+
+        Sinon.stub(ViewLicenceSummariesPresenter, 'go').returns(
+          {
+            billLicences: [
+              {
+                id: 'e37320ba-10c8-4954-8bc4-6982e56ded41',
+                reference: '01/735',
+                total: '£6,222.18'
+              },
+              {
+                id: '127377ea-24ea-4578-8b96-ef9a8625a313',
+                reference: '01/466',
+                total: '£7,066.55'
+              }
+            ],
+            tableCaption: '3 licences'
+          }
+        )
+      })
+
+      it('will fetch the data and format it using the bill and licence summaries presenters', async () => {
+        const result = await ViewBillService.go(testId)
+
+        expect(result).to.equal({
+          billingAccountId: '34183769-40d8-4d23-8bbb-f28e4d00c737',
+          billLicences: [
+            {
+              id: 'e37320ba-10c8-4954-8bc4-6982e56ded41',
+              reference: '01/735',
+              total: '£6,222.18'
+            },
+            {
+              id: '127377ea-24ea-4578-8b96-ef9a8625a313',
+              reference: '01/466',
+              total: '£7,066.55'
+            }
+          ],
+          tableCaption: '3 licences'
+        })
+      })
+    })
+
+    describe('and it is linked to a single licence', () => {
+      beforeEach(() => {
+        Sinon.stub(FetchBillService, 'go').resolves(
+          {
+            bill: {
+              billingInvoiceId: 'a102d2b4-d0d5-4b26-82e2-d74a66e2cdc3',
+              invoiceAccountId: '34183769-40d8-4d23-8bbb-f28e4d00c737'
+            },
+            licenceSummaries: [
+              { billingInvoiceLicenceId: '82c106dd-ee90-4566-b06b-a66d9e56b4b1' }
+            ]
+          }
+        )
+
+        Sinon.stub(ViewBillPresenter, 'go').returns({
+          billingAccountId: '34183769-40d8-4d23-8bbb-f28e4d00c737'
+        })
+
+        Sinon.stub(ViewBillLicencePresenter, 'go').returns(
+          {
+            tableCaption: '2 transactions',
+            transactions: [
+              { chargeType: 'standard' },
+              { chargeType: 'compensation' }
+            ]
+          }
+        )
+      })
+
+      it('will fetch the data and format it using the bill and view bill licence presenters', async () => {
+        const result = await ViewBillService.go(testId)
+
+        expect(result).to.equal({
+          billingAccountId: '34183769-40d8-4d23-8bbb-f28e4d00c737',
+          tableCaption: '2 transactions',
+          transactions: [
+            { chargeType: 'standard' },
+            { chargeType: 'compensation' }
+          ]
+        })
+      })
+    })
+  })
+
+  describe('when a bill with a matching ID does not exist', () => {
+    beforeEach(() => {
+      Sinon.stub(FetchBillService, 'go').resolves(
+        {
+          bill: undefined,
+          licenceSummaries: []
+        }
+      )
+
+      Sinon.stub(FetchBillingAccountService, 'go').resolves(undefined)
+    })
+
+    it('throws an exception', async () => {
+      await expect(ViewBillService.go('testId'))
+        .to
+        .reject()
+    })
+  })
+})


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4188

As part of the work we have been doing, we've been hacking away at a branch in a mob to build the two-part-tariff service. As a result of this, we have some refactoring to do to tidy up the work we have done in our mob. We are keeping track of the refactoring to do in this issue https://github.com/DEFRA/water-abstraction-team/issues/105.

This PR will extract the `fetch-licences` service out of our hacky branch https://github.com/DEFRA/water-abstraction-system/pull/458 and into its own PR along with the unit tests.