### PR TITLE
Add check your answers page (return requirements)

### DIFF
--- a/app/controllers/licences.controller.js
+++ b/app/controllers/licences.controller.js
@@ -23,7 +23,7 @@ async function selectReturnStartDate (request, h) {
   })
 }
 
-async function noReturnCheckYourAnswers (request, h) {
+async function noReturnsCheckYourAnswers (request, h) {
   const { id } = request.params
 
   return h.view('return-requirements/no-return-check-your-answers.njk', {
@@ -33,7 +33,7 @@ async function noReturnCheckYourAnswers (request, h) {
 }
 
 module.exports = {
+  noReturnsCheckYourAnswers,
   noReturnsRequired,
-  selectReturnStartDate,
-  noReturnCheckYourAnswers
+  selectReturnStartDate
 }

--- a/app/controllers/licences.controller.js
+++ b/app/controllers/licences.controller.js
@@ -23,7 +23,17 @@ async function selectReturnStartDate (request, h) {
   })
 }
 
+async function noReturnCheckYourAnswers (request, h) {
+  const { id } = request.params
+
+  return h.view('return-requirements/no-return-check-your-answers.njk', {
+    activeNavBar: 'search',
+    licenceId: id
+  })
+}
+
 module.exports = {
   noReturnsRequired,
-  selectReturnStartDate
+  selectReturnStartDate,
+  noReturnCheckYourAnswers
 }

--- a/app/routes/licence.routes.js
+++ b/app/routes/licence.routes.js
@@ -30,7 +30,7 @@ const routes = [
   }, {
     method: 'GET',
     path: '/licences/{id}/no-return-check-your-answers',
-    handler: LicencesController.noReturnCheckYourAnswers,
+    handler: LicencesController.noReturnsCheckYourAnswers,
     options: {
       auth: {
         access: {

--- a/app/routes/licence.routes.js
+++ b/app/routes/licence.routes.js
@@ -27,6 +27,18 @@ const routes = [
       },
       description: 'Select the start date of the return'
     }
+  }, {
+    method: 'GET',
+    path: '/licences/{id}/no-return-check-your-answers',
+    handler: LicencesController.noReturnCheckYourAnswers,
+    options: {
+      auth: {
+        access: {
+          scope: ['billing']
+        }
+      },
+      description: 'No return check your answers page'
+    }
   }
 ]
 

--- a/app/views/return-requirements/no-return-check-your-answers.njk
+++ b/app/views/return-requirements/no-return-check-your-answers.njk
@@ -7,7 +7,7 @@
   {{
     govukBackLink({
       text: 'back',
-      href: "/licences/" + licenceId + "/no-returns-required"
+      href: "/licences/" + licenceId + "/select-return-start-date"
     })
   }}
 {% endblock %}
@@ -15,10 +15,10 @@
 {% block content %}
   {# Main heading #}
   <div class="govuk-body">
-    <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">Select the start date for the return requirement</h1>
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">Check your answers</h1>
   </div>
 
   <div class="govuk-body">
-    {{ govukButton({ text: "Continue" }) }}
+    {{ govukButton({ text: "Approve returns requirements" }) }}
   </div>
 {% endblock %}

--- a/app/views/return-requirements/no-return-check-your-answers.njk
+++ b/app/views/return-requirements/no-return-check-your-answers.njk
@@ -2,12 +2,13 @@
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
+{% set rootLink = "/licences/" + licenceId %}
 {% block breadcrumbs %}
   {# Back link #}
   {{
     govukBackLink({
       text: 'back',
-      href: "/licences/" + licenceId + "/select-return-start-date"
+      href: rootLink + "/select-return-start-date"
     })
   }}
 {% endblock %}

--- a/app/views/return-requirements/select-return-start-date.njk
+++ b/app/views/return-requirements/select-return-start-date.njk
@@ -2,12 +2,13 @@
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
+{% set rootLink = "/licences/" + licenceId %}
 {% block breadcrumbs %}
   {# Back link #}
   {{
     govukBackLink({
       text: 'back',
-      href: "/licences/" + licenceId + "/no-returns-required"
+      href: rootLink + "/no-returns-required"
     })
   }}
 {% endblock %}

--- a/test/controllers/licences.controller.test.js
+++ b/test/controllers/licences.controller.test.js
@@ -71,4 +71,24 @@ describe('Licences controller', () => {
       })
     })
   })
+
+  describe('GET /licences/{id}/no-return-check-your-answers', () => {
+    const options = {
+      method: 'GET',
+      url: '/licences/64924759-8142-4a08-9d1e-1e902cd9d316/no-return-check-your-answers',
+      auth: {
+        strategy: 'session',
+        credentials: { scope: ['billing'] }
+      }
+    }
+
+    describe('when the request succeeds', () => {
+      it('returns the page successfully', async () => {
+        const response = await server.inject(options)
+
+        expect(response.statusCode).to.equal(200)
+        expect(response.payload).to.contain('Check your answers')
+      })
+    })
+  })
 })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4250

We are starting work on adding support for setting up return requirements within the service. A return requirement sets out how a licensee is expected to submit their returns, for example, daily, weekly or monthly, by what date, and using what unit of measure.

This is the third page in the return requirements setup journey when 'no returns required' is selected.

This is just a stub page and controls and validation will come later.