### PR TITLE
Return `aggregate` as a float

### DIFF
--- a/app/services/bill-runs/two-part-tariff/fetch-charge-versions.service.js
+++ b/app/services/bill-runs/two-part-tariff/fetch-charge-versions.service.js
@@ -80,7 +80,7 @@ async function _fetch (regionCode, billingPeriod) {
         .select([
           'id',
           'description',
-          ref('chargeReferences.adjustments:aggregate').as('aggregate'),
+          ref('chargeReferences.adjustments:aggregate').castFloat().as('aggregate'),
           ref('chargeReferences.adjustments:s127').castText().as('s127')
         ])
         .whereJsonPath('chargeReferences.adjustments', '$.s127', '=', true)


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4188

During QA it has been spotted that the value for the `aggregate` is being returned as a string rather than a float, as this is how it is stored in the JSONB field in the database.

In this PR the `aggregate` value will be converted to a float in the `fetch-charge-versions` service by using `castFloat` in the Objection query.