### PR TITLE
Add check your answers page  for return required journey

### DIFF
--- a/app/controllers/licences.controller.js
+++ b/app/controllers/licences.controller.js
@@ -41,9 +41,19 @@ async function noReturnsCheckYourAnswers (request, h) {
   })
 }
 
+async function returnsCheckYourAnswers (request, h) {
+  const { id } = request.params
+
+  return h.view('return-requirements/returns-check-your-answers.njk', {
+    activeNavBar: 'search',
+    licenceId: id
+  })
+}
+
 module.exports = {
   noReturnsCheckYourAnswers,
   noReturnsRequired,
   requirementsApproved,
+  returnsCheckYourAnswers,
   selectReturnStartDate
 }

--- a/app/routes/licence.routes.js
+++ b/app/routes/licence.routes.js
@@ -51,6 +51,18 @@ const routes = [
       },
       description: 'Returns requirements approved'
     }
+  }, {
+    method: 'GET',
+    path: '/licences/{id}/returns-check-your-answers',
+    handler: LicencesController.returnsCheckYourAnswers,
+    options: {
+      auth: {
+        access: {
+          scope: ['billing']
+        }
+      },
+      description: 'Returns check your answers page'
+    }
   }
 ]
 

--- a/app/views/return-requirements/returns-check-your-answers.njk
+++ b/app/views/return-requirements/returns-check-your-answers.njk
@@ -1,0 +1,25 @@
+{% extends 'layout.njk' %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% set rootLink = "/licences/" + licenceId %}
+{% block breadcrumbs %}
+  {# Back link #}
+  {{
+    govukBackLink({
+      text: 'back',
+      href: rootLink + "/how-do-you-want-to-return"
+    })
+  }}
+{% endblock %}
+
+{% block content %}
+  {# Main heading #}
+  <div class="govuk-body">
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">Check your answers</h1>
+  </div>
+
+  <div class="govuk-body">
+    {{ govukButton({ text: "Approve returns requirements" }) }}
+  </div>
+{% endblock %}

--- a/test/controllers/licences.controller.test.js
+++ b/test/controllers/licences.controller.test.js
@@ -111,4 +111,24 @@ describe('Licences controller', () => {
       })
     })
   })
+
+  describe('GET /licences/{id}/returns-check-your-answers', () => {
+    const options = {
+      method: 'GET',
+      url: '/licences/64924759-8142-4a08-9d1e-1e902cd9d316/returns-check-your-answers',
+      auth: {
+        strategy: 'session',
+        credentials: { scope: ['billing'] }
+      }
+    }
+
+    describe('when the request succeeds', () => {
+      it('returns the page successfully', async () => {
+        const response = await server.inject(options)
+
+        expect(response.statusCode).to.equal(200)
+        expect(response.payload).to.contain('Check your answers')
+      })
+    })
+  })
 })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4256

We are starting work on adding support for setting up return requirements within the service. A return requirement sets out how a licensee is expected to submit their returns, for example, daily, weekly or monthly, by what date, and using what unit of measure.

This is the fifth page in the return requirements setup journey when 'a return is required' is selected.

This is just a stub page and controls and validation will come later.