### PR TITLE
Include volume in FetchChargeVersionsService

### DIFF
--- a/app/services/bill-runs/two-part-tariff/fetch-charge-versions.service.js
+++ b/app/services/bill-runs/two-part-tariff/fetch-charge-versions.service.js
@@ -79,6 +79,7 @@ async function _fetch (regionCode, billingPeriod) {
       builder
         .select([
           'id',
+          'volume',
           'description',
           ref('chargeReferences.adjustments:aggregate').castFloat().as('aggregate'),
           ref('chargeReferences.adjustments:s127').castText().as('s127')

--- a/test/services/bill-runs/two-part-tariff/fetch-charge-versions.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/fetch-charge-versions.service.test.js
@@ -181,7 +181,7 @@ describe('Fetch Charge Versions service', () => {
     describe("because the status is not 'current'", () => {
       beforeEach(async () => {
         const { id: chargeVersionId } = await ChargeVersionHelper.add(
-          { startDate: new Date('2023-04-01'), licenceId, licenceRef, regionCode, status: 'superseded' }
+          { licenceId, licenceRef, regionCode, status: 'superseded' }
         )
 
         await ChargeReferenceHelper.add({
@@ -201,7 +201,7 @@ describe('Fetch Charge Versions service', () => {
     describe('because the region is different', () => {
       beforeEach(async () => {
         const { id: chargeVersionId } = await ChargeVersionHelper.add(
-          { startDate: new Date('2023-04-01'), licenceId, licenceRef, regionCode: 9 }
+          { licenceId, licenceRef, regionCode: 9 }
         )
 
         await ChargeReferenceHelper.add({
@@ -221,7 +221,7 @@ describe('Fetch Charge Versions service', () => {
     describe('because the licence is linked to a workflow', () => {
       beforeEach(async () => {
         const { id: chargeVersionId } = await ChargeVersionHelper.add(
-          { startDate: new Date('2023-04-01'), licenceId, licenceRef, regionCode }
+          { licenceId, licenceRef, regionCode }
         )
 
         await ChargeReferenceHelper.add({

--- a/test/services/bill-runs/two-part-tariff/fetch-charge-versions.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/fetch-charge-versions.service.test.js
@@ -26,9 +26,10 @@ describe('Fetch Charge Versions service', () => {
     endDate: new Date('2023-03-31')
   }
   const regionCode = 5
+  const licenceId = 'cee9ff5f-813a-49c7-ba04-c65cfecf67dd'
+  const licenceRef = '01/128'
 
   let chargeCategoryId
-  let licence
   let regionId
 
   beforeEach(async () => {
@@ -40,15 +41,13 @@ describe('Fetch Charge Versions service', () => {
     const region = await RegionHelper.add({ naldRegionId: regionCode })
     regionId = region.id
 
-    licence = await LicenceHelper.add({ regionId })
+    await LicenceHelper.add({ id: licenceId, licenceRef, regionId })
   })
 
   describe('when there are applicable charge versions', () => {
     let chargeVersionId
 
     beforeEach(async () => {
-      const { id: licenceId, licenceRef } = licence
-
       const chargeVersion = await ChargeVersionHelper.add(
         { startDate: new Date('2022-04-01'), licenceId, licenceRef, regionCode }
       )
@@ -84,8 +83,8 @@ describe('Fetch Charge Versions service', () => {
         endDate: null,
         status: 'current',
         licence: {
-          id: licence.id,
-          licenceRef: licence.licenceRef,
+          id: 'cee9ff5f-813a-49c7-ba04-c65cfecf67dd',
+          licenceRef: '01/128',
           startDate: new Date('2022-01-01'),
           expiredDate: null,
           lapsedDate: null,
@@ -141,8 +140,6 @@ describe('Fetch Charge Versions service', () => {
   describe('when there are no applicable charge versions', () => {
     describe("because the scheme is 'presroc'", () => {
       beforeEach(async () => {
-        const { id: licenceId, licenceRef } = licence
-
         await ChargeVersionHelper.add(
           { scheme: 'alcs', licenceId, licenceRef, regionCode: 5 }
         )
@@ -157,8 +154,6 @@ describe('Fetch Charge Versions service', () => {
 
     describe('because the start date is after the billing period ends', () => {
       beforeEach(async () => {
-        const { id: licenceId, licenceRef } = licence
-
         const { id: chargeVersionId } = await ChargeVersionHelper.add(
           { startDate: new Date('2023-04-01'), licenceId, licenceRef, regionCode }
         )
@@ -179,8 +174,6 @@ describe('Fetch Charge Versions service', () => {
 
     describe("because the status is not 'current'", () => {
       beforeEach(async () => {
-        const { id: licenceId, licenceRef } = licence
-
         const { id: chargeVersionId } = await ChargeVersionHelper.add(
           { startDate: new Date('2023-04-01'), licenceId, licenceRef, regionCode, status: 'superseded' }
         )
@@ -201,8 +194,6 @@ describe('Fetch Charge Versions service', () => {
 
     describe('because the region is different', () => {
       beforeEach(async () => {
-        const { id: licenceId, licenceRef } = licence
-
         const { id: chargeVersionId } = await ChargeVersionHelper.add(
           { startDate: new Date('2023-04-01'), licenceId, licenceRef, regionCode: 9 }
         )
@@ -223,8 +214,6 @@ describe('Fetch Charge Versions service', () => {
 
     describe('because the licence is linked to a workflow', () => {
       beforeEach(async () => {
-        const { id: licenceId, licenceRef } = licence
-
         const { id: chargeVersionId } = await ChargeVersionHelper.add(
           { startDate: new Date('2023-04-01'), licenceId, licenceRef, regionCode }
         )
@@ -235,7 +224,7 @@ describe('Fetch Charge Versions service', () => {
           adjustments: { s127: true }
         })
 
-        await WorkflowHelper.add({ licenceId: licence.id })
+        await WorkflowHelper.add({ licenceId })
       })
 
       it('returns no records', async () => {

--- a/test/services/bill-runs/two-part-tariff/fetch-charge-versions.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/fetch-charge-versions.service.test.js
@@ -127,43 +127,6 @@ describe('Fetch Charge Versions service', () => {
     })
 
     describe('and the start date', () => {
-      describe('is before the billing period end', () => {
-        let testRecordsInDate
-        let inDateChargeReference
-        let inDateChargeElement
-
-        beforeEach(async () => {
-          const { id: licenceId, licenceRef } = licence
-
-          const inDateChargeVersion = await ChargeVersionHelper.add(
-            { startDate: new Date('2022-04-01'), licenceId, licenceRef, regionCode }
-          )
-
-          inDateChargeReference = await ChargeReferenceHelper.add({
-            chargeVersionId: inDateChargeVersion.id,
-            chargeCategoryId,
-            adjustments: { s127: true, aggregate: 0.562114443 }
-          })
-
-          inDateChargeElement = await ChargeElementHelper.add({
-            chargeReferenceId: inDateChargeReference.id
-          })
-
-          testRecordsInDate = [
-            inDateChargeVersion,
-            inDateChargeReference,
-            inDateChargeElement
-          ]
-        })
-
-        it('returns the charge versions that are applicable', async () => {
-          const results = await FetchChargeVersionsService.go(regionId, billingPeriod)
-
-          expect(results).to.have.length(1)
-          expect(results[0].id).to.include(testRecordsInDate[0].id)
-        })
-      })
-
       describe('is after the billing period end', () => {
         let notInDateChargeReference
 

--- a/test/services/bill-runs/two-part-tariff/fetch-charge-versions.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/fetch-charge-versions.service.test.js
@@ -36,7 +36,7 @@ describe('Fetch Charge Versions service', () => {
   beforeEach(async () => {
     await DatabaseHelper.clean()
 
-    const chargeCategory = await ChargeCategoryHelper.add()
+    const chargeCategory = await ChargeCategoryHelper.add({ reference: '4.3.41' })
     chargeCategoryId = chargeCategory.id
 
     const region = await RegionHelper.add({ naldRegionId: regionCode })
@@ -101,7 +101,11 @@ describe('Fetch Charge Versions service', () => {
           description: 'Mineral washing',
           aggregate: 0.562114443,
           s127: 'true',
-          chargeCategory: null,
+          chargeCategory: {
+            reference: '4.3.41',
+            shortDescription: 'Low loss, non-tidal, restricted water, up to and including 5,000 ML/yr, Tier 1 model',
+            subsistenceCharge: 12000
+          },
           chargeElements: [
             {
               id: 'dab91d76-6778-417f-8f2d-9124a270e926',

--- a/test/services/bill-runs/two-part-tariff/fetch-charge-versions.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/fetch-charge-versions.service.test.js
@@ -28,14 +28,13 @@ describe('Fetch Charge Versions service', () => {
     }
 
     let licence
-    let region
     let regionId
     let testRecords
 
     beforeEach(async () => {
       await DatabaseHelper.clean()
 
-      region = await RegionHelper.add({ naldRegionId: 5 })
+      const region = await RegionHelper.add({ naldRegionId: 5 })
       regionId = region.id
 
       licence = await LicenceHelper.add({ regionId })

--- a/test/services/bill-runs/two-part-tariff/fetch-charge-versions.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/fetch-charge-versions.service.test.js
@@ -36,7 +36,7 @@ describe('Fetch Charge Versions service', () => {
   beforeEach(async () => {
     await DatabaseHelper.clean()
 
-    const chargeCategory = ChargeCategoryHelper.add()
+    const chargeCategory = await ChargeCategoryHelper.add()
     chargeCategoryId = chargeCategory.id
 
     const region = await RegionHelper.add({ naldRegionId: regionCode })

--- a/test/services/bill-runs/two-part-tariff/fetch-charge-versions.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/fetch-charge-versions.service.test.js
@@ -127,7 +127,7 @@ describe('Fetch Charge Versions service', () => {
         )
       })
 
-      it('doesnt return the charge version', async () => {
+      it('does not return the charge version', async () => {
         const results = await FetchChargeVersionsService.go(regionId, billingPeriod)
 
         expect(results).to.have.length(0)
@@ -248,7 +248,7 @@ describe('Fetch Charge Versions service', () => {
       })
     })
 
-    describe('and the charge version doesnt have a status of current', () => {
+    describe('and the charge version does not have a status of current', () => {
       let chargeCategory
       let notCurrentChargeReference
 
@@ -345,7 +345,7 @@ describe('Fetch Charge Versions service', () => {
         })
       })
 
-      describe('doesnt have the same region code', () => {
+      describe('does not have the same region code', () => {
         let differentRegionChargeReference
 
         beforeEach(async () => {

--- a/test/services/bill-runs/two-part-tariff/fetch-charge-versions.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/fetch-charge-versions.service.test.js
@@ -81,12 +81,12 @@ describe('Fetch Charge Versions service', () => {
       // Second charge version to test ordering
       const otherLicence = await LicenceHelper.add({ licenceRef: '01/130', regionId })
       const chargeVersion = await ChargeVersionHelper.add(
-        { startDate: new Date('2022-04-01'), licenceId: otherLicence.id, licenceRef: '01/130', regionCode }
+        { licenceId: otherLicence.id, licenceRef: '01/130', regionCode }
       )
       const chargeReference = await ChargeReferenceHelper.add({
         chargeVersionId: chargeVersion.id,
         chargeCategoryId,
-        adjustments: { s127: true, aggregate: 0.562114443 }
+        adjustments: { s127: true }
       })
       await ChargeElementHelper.add({
         chargeReferenceId: chargeReference.id,

--- a/test/services/bill-runs/two-part-tariff/fetch-charge-versions.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/fetch-charge-versions.service.test.js
@@ -21,28 +21,28 @@ const RegionHelper = require('../../../support/helpers/region.helper.js')
 const FetchChargeVersionsService = require('../../../../app/services/bill-runs/two-part-tariff/fetch-charge-versions.service')
 
 describe('Fetch Charge Versions service', () => {
+  const billingPeriod = {
+    startDate: new Date('2022-04-01'),
+    endDate: new Date('2023-03-31')
+  }
+
+  let chargeCategoryId
+  let licence
+  let regionId
+
+  beforeEach(async () => {
+    await DatabaseHelper.clean()
+
+    const chargeCategory = ChargeCategoryHelper.add()
+    chargeCategoryId = chargeCategory.id
+
+    const region = await RegionHelper.add({ naldRegionId: 5 })
+    regionId = region.id
+
+    licence = await LicenceHelper.add({ regionId })
+  })
+
   describe('when there are charge versions', () => {
-    const billingPeriod = {
-      startDate: new Date('2022-04-01'),
-      endDate: new Date('2023-03-31')
-    }
-
-    let chargeCategoryId
-    let licence
-    let regionId
-
-    beforeEach(async () => {
-      await DatabaseHelper.clean()
-
-      const chargeCategory = ChargeCategoryHelper.add()
-      chargeCategoryId = chargeCategory.id
-
-      const region = await RegionHelper.add({ naldRegionId: 5 })
-      regionId = region.id
-
-      licence = await LicenceHelper.add({ regionId })
-    })
-
     describe('and the scheme is SROC', () => {
       let chargeVersionId
 

--- a/test/services/bill-runs/two-part-tariff/fetch-charge-versions.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/fetch-charge-versions.service.test.js
@@ -27,9 +27,9 @@ describe('Fetch Charge Versions service', () => {
       endDate: new Date('2023-03-31')
     }
 
+    let licence
     let region
     let regionId
-    let licence
     let testRecords
 
     beforeEach(async () => {

--- a/test/services/bill-runs/two-part-tariff/fetch-charge-versions.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/fetch-charge-versions.service.test.js
@@ -45,13 +45,12 @@ describe('Fetch Charge Versions service', () => {
   })
 
   describe('when there are applicable charge versions', () => {
-    let chargeVersionId
+    const chargeVersionId = '2c2f0ab5-4f73-416e-b3f8-5ed19d81bd59'
 
     beforeEach(async () => {
-      const chargeVersion = await ChargeVersionHelper.add(
-        { startDate: new Date('2022-04-01'), licenceId, licenceRef, regionCode }
+      await ChargeVersionHelper.add(
+        { id: chargeVersionId, startDate: new Date('2022-04-01'), licenceId, licenceRef, regionCode }
       )
-      chargeVersionId = chargeVersion.id
 
       const { id: chargeReferenceId } = await ChargeReferenceHelper.add({
         id: 'a86837fa-cf25-42fe-8216-ea8c2d2c939d',
@@ -78,7 +77,7 @@ describe('Fetch Charge Versions service', () => {
 
       expect(results).to.have.length(1)
       expect(results[0]).to.equal({
-        id: chargeVersionId,
+        id: '2c2f0ab5-4f73-416e-b3f8-5ed19d81bd59',
         startDate: new Date('2022-04-01'),
         endDate: null,
         status: 'current',

--- a/test/services/bill-runs/two-part-tariff/fetch-charge-versions.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/fetch-charge-versions.service.test.js
@@ -239,15 +239,6 @@ describe('Fetch Charge Versions service', () => {
         })
       })
 
-      describe('has the same region code', () => {
-        it('returns the charge versions that are applicable', async () => {
-          const results = await FetchChargeVersionsService.go(regionId, billingPeriod)
-
-          expect(results).to.have.length(1)
-          expect(results[0].id).to.include(testRecordsSameRegion[0].id)
-        })
-      })
-
       describe('does not have the same region code', () => {
         let differentRegionChargeReference
 

--- a/test/services/bill-runs/two-part-tariff/fetch-charge-versions.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/fetch-charge-versions.service.test.js
@@ -194,43 +194,6 @@ describe('Fetch Charge Versions service', () => {
       })
     })
 
-    describe('and the charge version has a status of current', () => {
-      let testRecordsCurrent
-      let currentChargeReference
-      let currentChargeElement
-
-      beforeEach(async () => {
-        const { id: licenceId, licenceRef } = licence
-
-        const currentChargeVersion = await ChargeVersionHelper.add(
-          { startDate: new Date('2022-04-01'), licenceId, licenceRef, regionCode }
-        )
-
-        currentChargeReference = await ChargeReferenceHelper.add({
-          chargeVersionId: currentChargeVersion.id,
-          chargeCategoryId,
-          adjustments: { s127: true, aggregate: 0.562114443 }
-        })
-
-        currentChargeElement = await ChargeElementHelper.add({
-          chargeReferenceId: currentChargeReference.id
-        })
-
-        testRecordsCurrent = [
-          currentChargeVersion,
-          currentChargeReference,
-          currentChargeElement
-        ]
-      })
-
-      it('returns the charge versions that are applicable', async () => {
-        const results = await FetchChargeVersionsService.go(regionId, billingPeriod)
-
-        expect(results).to.have.length(1)
-        expect(results[0].id).to.include(testRecordsCurrent[0].id)
-      })
-    })
-
     describe('and the charge version does not have a status of current', () => {
       let notCurrentChargeReference
 

--- a/test/services/bill-runs/two-part-tariff/fetch-charge-versions.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/fetch-charge-versions.service.test.js
@@ -25,6 +25,7 @@ describe('Fetch Charge Versions service', () => {
     startDate: new Date('2022-04-01'),
     endDate: new Date('2023-03-31')
   }
+  const regionCode = 5
 
   let chargeCategoryId
   let licence
@@ -36,7 +37,7 @@ describe('Fetch Charge Versions service', () => {
     const chargeCategory = ChargeCategoryHelper.add()
     chargeCategoryId = chargeCategory.id
 
-    const region = await RegionHelper.add({ naldRegionId: 5 })
+    const region = await RegionHelper.add({ naldRegionId: regionCode })
     regionId = region.id
 
     licence = await LicenceHelper.add({ regionId })
@@ -49,7 +50,7 @@ describe('Fetch Charge Versions service', () => {
       const { id: licenceId, licenceRef } = licence
 
       const chargeVersion = await ChargeVersionHelper.add(
-        { startDate: new Date('2022-04-01'), licenceId, licenceRef, regionCode: 5 }
+        { startDate: new Date('2022-04-01'), licenceId, licenceRef, regionCode }
       )
       chargeVersionId = chargeVersion.id
 
@@ -159,7 +160,7 @@ describe('Fetch Charge Versions service', () => {
         const { id: licenceId, licenceRef } = licence
 
         const { id: chargeVersionId } = await ChargeVersionHelper.add(
-          { startDate: new Date('2023-04-01'), licenceId, licenceRef, regionCode: 5 }
+          { startDate: new Date('2023-04-01'), licenceId, licenceRef, regionCode }
         )
 
         await ChargeReferenceHelper.add({
@@ -181,7 +182,7 @@ describe('Fetch Charge Versions service', () => {
         const { id: licenceId, licenceRef } = licence
 
         const { id: chargeVersionId } = await ChargeVersionHelper.add(
-          { startDate: new Date('2023-04-01'), licenceId, licenceRef, regionCode: 5, status: 'superseded' }
+          { startDate: new Date('2023-04-01'), licenceId, licenceRef, regionCode, status: 'superseded' }
         )
 
         await ChargeReferenceHelper.add({
@@ -225,7 +226,7 @@ describe('Fetch Charge Versions service', () => {
         const { id: licenceId, licenceRef } = licence
 
         const { id: chargeVersionId } = await ChargeVersionHelper.add(
-          { startDate: new Date('2023-04-01'), licenceId, licenceRef, regionCode: 5 }
+          { startDate: new Date('2023-04-01'), licenceId, licenceRef, regionCode }
         )
 
         await ChargeReferenceHelper.add({

--- a/test/services/bill-runs/two-part-tariff/fetch-charge-versions.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/fetch-charge-versions.service.test.js
@@ -27,12 +27,16 @@ describe('Fetch Charge Versions service', () => {
       endDate: new Date('2023-03-31')
     }
 
+    let chargeCategoryId
     let licence
     let regionId
     let testRecords
 
     beforeEach(async () => {
       await DatabaseHelper.clean()
+
+      const chargeCategory = ChargeCategoryHelper.add()
+      chargeCategoryId = chargeCategory.id
 
       const region = await RegionHelper.add({ naldRegionId: 5 })
       regionId = region.id
@@ -41,7 +45,6 @@ describe('Fetch Charge Versions service', () => {
     })
 
     describe('and the scheme is SROC', () => {
-      let chargeCategory
       let srocChargeReference
       let srocChargeElement
 
@@ -52,11 +55,9 @@ describe('Fetch Charge Versions service', () => {
           { startDate: new Date('2022-04-01'), licenceId, licenceRef, regionCode: 5 }
         )
 
-        chargeCategory = ChargeCategoryHelper.add()
-
         srocChargeReference = await ChargeReferenceHelper.add({
           chargeVersionId: srocChargeVersion.id,
-          chargeCategoryId: chargeCategory.id,
+          chargeCategoryId,
           adjustments: { s127: true, aggregate: 0.562114443 }
         })
 
@@ -135,7 +136,6 @@ describe('Fetch Charge Versions service', () => {
     describe('and the start date', () => {
       describe('is before the billing period end', () => {
         let testRecordsInDate
-        let chargeCategory
         let inDateChargeReference
         let inDateChargeElement
 
@@ -146,11 +146,9 @@ describe('Fetch Charge Versions service', () => {
             { startDate: new Date('2022-04-01'), licenceId, licenceRef, regionCode: 5 }
           )
 
-          chargeCategory = ChargeCategoryHelper.add()
-
           inDateChargeReference = await ChargeReferenceHelper.add({
             chargeVersionId: inDateChargeVersion.id,
-            chargeCategoryId: chargeCategory.id,
+            chargeCategoryId,
             adjustments: { s127: true, aggregate: 0.562114443 }
           })
 
@@ -174,7 +172,6 @@ describe('Fetch Charge Versions service', () => {
       })
 
       describe('is after the billing period end', () => {
-        let chargeCategory
         let notInDateChargeReference
 
         beforeEach(async () => {
@@ -184,11 +181,9 @@ describe('Fetch Charge Versions service', () => {
             { startDate: new Date('2023-04-01'), licenceId, licenceRef, regionCode: 5 }
           )
 
-          chargeCategory = ChargeCategoryHelper.add()
-
           notInDateChargeReference = await ChargeReferenceHelper.add({
             chargeVersionId: notInDateChargeVersion.id,
-            chargeCategoryId: chargeCategory.id,
+            chargeCategoryId,
             adjustments: { s127: true, aggregate: 0.562114443 }
           })
 
@@ -208,7 +203,6 @@ describe('Fetch Charge Versions service', () => {
 
     describe('and the charge version has a status of current', () => {
       let testRecordsCurrent
-      let chargeCategory
       let currentChargeReference
       let currentChargeElement
 
@@ -219,11 +213,9 @@ describe('Fetch Charge Versions service', () => {
           { startDate: new Date('2022-04-01'), licenceId, licenceRef, regionCode: 5 }
         )
 
-        chargeCategory = ChargeCategoryHelper.add()
-
         currentChargeReference = await ChargeReferenceHelper.add({
           chargeVersionId: currentChargeVersion.id,
-          chargeCategoryId: chargeCategory.id,
+          chargeCategoryId,
           adjustments: { s127: true, aggregate: 0.562114443 }
         })
 
@@ -247,7 +239,6 @@ describe('Fetch Charge Versions service', () => {
     })
 
     describe('and the charge version does not have a status of current', () => {
-      let chargeCategory
       let notCurrentChargeReference
 
       beforeEach(async () => {
@@ -257,11 +248,9 @@ describe('Fetch Charge Versions service', () => {
           { status: 'superseded', licenceId, licenceRef, regionCode: 5 }
         )
 
-        chargeCategory = ChargeCategoryHelper.add()
-
         notCurrentChargeReference = await ChargeReferenceHelper.add({
           chargeVersionId: notCurrentChargeVersion.id,
-          chargeCategoryId: chargeCategory.id,
+          chargeCategoryId,
           adjustments: { s127: true, aggregate: 0.562114443 }
         })
 
@@ -279,7 +268,6 @@ describe('Fetch Charge Versions service', () => {
 
     describe('and the licence associated with it', () => {
       let testRecordsSameRegion
-      let chargeCategory
       let sameRegionChargeReference
       let sameRegionChargeElement
 
@@ -290,11 +278,9 @@ describe('Fetch Charge Versions service', () => {
           { startDate: new Date('2022-04-01'), licenceId, licenceRef, regionCode: 5 }
         )
 
-        chargeCategory = ChargeCategoryHelper.add()
-
         sameRegionChargeReference = await ChargeReferenceHelper.add({
           chargeVersionId: sameRegionChargeVersion.id,
-          chargeCategoryId: chargeCategory.id,
+          chargeCategoryId,
           adjustments: { s127: true, aggregate: 0.562114443 }
         })
 
@@ -353,11 +339,9 @@ describe('Fetch Charge Versions service', () => {
             { startDate: new Date('2022-04-01'), licenceId, licenceRef, regionCode: 4 }
           )
 
-          chargeCategory = ChargeCategoryHelper.add()
-
           differentRegionChargeReference = await ChargeReferenceHelper.add({
             chargeVersionId: differentRegionChargeVersion.id,
-            chargeCategoryId: chargeCategory.id,
+            chargeCategoryId,
             adjustments: { s127: true, aggregate: 0.562114443 }
           })
 
@@ -379,7 +363,6 @@ describe('Fetch Charge Versions service', () => {
       let secondSrocChargeElement
       let firstSrocChargeElement
       let firstSrocChargeReference
-      let chargeCategory
 
       beforeEach(async () => {
         const { id: licenceId, licenceRef } = licence
@@ -388,11 +371,9 @@ describe('Fetch Charge Versions service', () => {
           { startDate: new Date('2022-04-01'), licenceId, licenceRef, regionCode: 5 }
         )
 
-        chargeCategory = ChargeCategoryHelper.add()
-
         firstSrocChargeReference = await ChargeReferenceHelper.add({
           chargeVersionId: srocChargeVersion.id,
-          chargeCategoryId: chargeCategory.id,
+          chargeCategoryId,
           adjustments: { s127: true, aggregate: 0.562114443 }
         })
 

--- a/test/services/bill-runs/two-part-tariff/fetch-charge-versions.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/fetch-charge-versions.service.test.js
@@ -102,19 +102,19 @@ describe('Fetch Charge Versions service', () => {
           }]
         }
 
-        const result = await FetchChargeVersionsService.go(regionId, billingPeriod)
+        const results = await FetchChargeVersionsService.go(regionId, billingPeriod)
 
-        expect(result).to.have.length(1)
-        expect(result[0].id).to.equal(testRecords[0].id)
-        expect(result[0].status).to.equal('current')
-        expect(result[0].licence).to.equal(expectedLicence)
-        expect(result[0].chargeReferences[0]).to.equal(expectedChargeReferenceAndElement)
+        expect(results).to.have.length(1)
+        expect(results[0].id).to.equal(testRecords[0].id)
+        expect(results[0].status).to.equal('current')
+        expect(results[0].licence).to.equal(expectedLicence)
+        expect(results[0].chargeReferences[0]).to.equal(expectedChargeReferenceAndElement)
       })
 
       it('returns charge versions with correct ordering based on licence reference', async () => {
-        const result = await FetchChargeVersionsService.go(regionId, billingPeriod)
+        const results = await FetchChargeVersionsService.go(regionId, billingPeriod)
 
-        expect(result).to.have.length(1)
+        expect(results).to.have.length(1)
       })
     })
 
@@ -128,9 +128,9 @@ describe('Fetch Charge Versions service', () => {
       })
 
       it('doesnt return the charge version', async () => {
-        const result = await FetchChargeVersionsService.go(regionId, billingPeriod)
+        const results = await FetchChargeVersionsService.go(regionId, billingPeriod)
 
-        expect(result).to.have.length(0)
+        expect(results).to.have.length(0)
       })
     })
 
@@ -168,10 +168,10 @@ describe('Fetch Charge Versions service', () => {
         })
 
         it('returns the charge versions that are applicable', async () => {
-          const result = await FetchChargeVersionsService.go(regionId, billingPeriod)
+          const results = await FetchChargeVersionsService.go(regionId, billingPeriod)
 
-          expect(result).to.have.length(1)
-          expect(result[0].id).to.include(testRecordsInDate[0].id)
+          expect(results).to.have.length(1)
+          expect(results[0].id).to.include(testRecordsInDate[0].id)
         })
       })
 
@@ -200,10 +200,10 @@ describe('Fetch Charge Versions service', () => {
         })
 
         it('returns the charge versions that are applicable', async () => {
-          const result = await FetchChargeVersionsService.go(regionId, billingPeriod)
+          const results = await FetchChargeVersionsService.go(regionId, billingPeriod)
 
-          expect(result).to.have.length(0)
-          expect(result).to.equal([])
+          expect(results).to.have.length(0)
+          expect(results).to.equal([])
         })
       })
     })
@@ -241,10 +241,10 @@ describe('Fetch Charge Versions service', () => {
       })
 
       it('returns the charge versions that are applicable', async () => {
-        const result = await FetchChargeVersionsService.go(regionId, billingPeriod)
+        const results = await FetchChargeVersionsService.go(regionId, billingPeriod)
 
-        expect(result).to.have.length(1)
-        expect(result[0].id).to.include(testRecordsCurrent[0].id)
+        expect(results).to.have.length(1)
+        expect(results[0].id).to.include(testRecordsCurrent[0].id)
       })
     })
 
@@ -273,9 +273,9 @@ describe('Fetch Charge Versions service', () => {
       })
 
       it('returns the charge versions that are applicable', async () => {
-        const result = await FetchChargeVersionsService.go(regionId, billingPeriod)
+        const results = await FetchChargeVersionsService.go(regionId, billingPeriod)
 
-        expect(result).to.have.length(0)
+        expect(results).to.have.length(0)
       })
     })
 
@@ -317,9 +317,9 @@ describe('Fetch Charge Versions service', () => {
         })
 
         it('does not return the related charge versions', async () => {
-          const result = await FetchChargeVersionsService.go(regionId, billingPeriod)
+          const results = await FetchChargeVersionsService.go(regionId, billingPeriod)
 
-          expect(result).to.equal([])
+          expect(results).to.equal([])
         })
       })
 
@@ -329,19 +329,19 @@ describe('Fetch Charge Versions service', () => {
         })
 
         it('returns the charge versions that are applicable', async () => {
-          const result = await FetchChargeVersionsService.go(regionId, billingPeriod)
+          const results = await FetchChargeVersionsService.go(regionId, billingPeriod)
 
-          expect(result).to.have.length(1)
-          expect(result[0].id).to.include(testRecordsSameRegion[0].id)
+          expect(results).to.have.length(1)
+          expect(results[0].id).to.include(testRecordsSameRegion[0].id)
         })
       })
 
       describe('has the same region code', () => {
         it('returns the charge versions that are applicable', async () => {
-          const result = await FetchChargeVersionsService.go(regionId, billingPeriod)
+          const results = await FetchChargeVersionsService.go(regionId, billingPeriod)
 
-          expect(result).to.have.length(1)
-          expect(result[0].id).to.include(testRecordsSameRegion[0].id)
+          expect(results).to.have.length(1)
+          expect(results[0].id).to.include(testRecordsSameRegion[0].id)
         })
       })
 
@@ -409,10 +409,10 @@ describe('Fetch Charge Versions service', () => {
       })
 
       it('returns the charge elements with correct ordering based on authorised annual quantity', async () => {
-        const result = await FetchChargeVersionsService.go(regionId, billingPeriod)
+        const results = await FetchChargeVersionsService.go(regionId, billingPeriod)
 
-        expect(result[0].chargeReferences[0].chargeElements[0].authorisedAnnualQuantity).to.equal(secondSrocChargeElement.authorisedAnnualQuantity)
-        expect(result[0].chargeReferences[0].chargeElements[1].authorisedAnnualQuantity).to.equal(firstSrocChargeElement.authorisedAnnualQuantity)
+        expect(results[0].chargeReferences[0].chargeElements[0].authorisedAnnualQuantity).to.equal(secondSrocChargeElement.authorisedAnnualQuantity)
+        expect(results[0].chargeReferences[0].chargeElements[1].authorisedAnnualQuantity).to.equal(firstSrocChargeElement.authorisedAnnualQuantity)
       })
     })
   })

--- a/test/services/bill-runs/two-part-tariff/fetch-charge-versions.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/fetch-charge-versions.service.test.js
@@ -15,6 +15,7 @@ const ChargeVersionHelper = require('../../../support/helpers/charge-version.hel
 const WorkflowHelper = require('../../../support/helpers/workflow.helper.js')
 const DatabaseHelper = require('../../../support/helpers/database.helper.js')
 const LicenceHelper = require('../../../support/helpers/licence.helper.js')
+const PurposeHelper = require('../../../support/helpers/purpose.helper.js')
 const RegionHelper = require('../../../support/helpers/region.helper.js')
 
 // Thing under test
@@ -59,16 +60,21 @@ describe('Fetch Charge Versions service', () => {
         adjustments: { s127: true, aggregate: 0.562114443 }
       })
 
+      const purposeId = '4f300bf3-9d6d-44a2-ac76-ce3c02e7e81b'
+      await PurposeHelper.add({ id: purposeId, legacyId: '420' })
+
       await ChargeElementHelper.add({
         id: '1a966bd1-dbce-499d-ae94-b1d6ab72f0b2',
         chargeReferenceId,
-        authorisedAnnualQuantity: 100
+        authorisedAnnualQuantity: 100,
+        purposeId
       })
 
       await ChargeElementHelper.add({
         id: 'dab91d76-6778-417f-8f2d-9124a270e926',
         chargeReferenceId,
-        authorisedAnnualQuantity: 200
+        authorisedAnnualQuantity: 200,
+        purposeId
       })
     })
 
@@ -105,7 +111,11 @@ describe('Fetch Charge Versions service', () => {
               abstractionPeriodEndDay: 31,
               abstractionPeriodEndMonth: 3,
               authorisedAnnualQuantity: 200,
-              purpose: null
+              purpose: {
+                id: '4f300bf3-9d6d-44a2-ac76-ce3c02e7e81b',
+                legacyId: '420',
+                description: 'Spray Irrigation - Storage'
+              }
             },
             {
               id: '1a966bd1-dbce-499d-ae94-b1d6ab72f0b2',
@@ -115,7 +125,11 @@ describe('Fetch Charge Versions service', () => {
               abstractionPeriodEndDay: 31,
               abstractionPeriodEndMonth: 3,
               authorisedAnnualQuantity: 100,
-              purpose: null
+              purpose: {
+                id: '4f300bf3-9d6d-44a2-ac76-ce3c02e7e81b',
+                legacyId: '420',
+                description: 'Spray Irrigation - Storage'
+              }
             }
           ]
         }]

--- a/test/services/bill-runs/two-part-tariff/fetch-charge-versions.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/fetch-charge-versions.service.test.js
@@ -22,22 +22,21 @@ const FetchChargeVersionsService = require('../../../../app/services/bill-runs/t
 
 describe('Fetch Charge Versions service', () => {
   describe('when there are charge versions', () => {
+    const billingPeriod = {
+      startDate: new Date('2022-04-01'),
+      endDate: new Date('2023-03-31')
+    }
+
     let region
     let regionId
     let licence
     let testRecords
-    let billingPeriod
 
     beforeEach(async () => {
       await DatabaseHelper.clean()
 
       region = await RegionHelper.add({ naldRegionId: 5 })
       regionId = region.id
-
-      billingPeriod = {
-        startDate: new Date('2022-04-01'),
-        endDate: new Date('2023-03-31')
-      }
 
       licence = await LicenceHelper.add({ regionId })
     })

--- a/test/services/bill-runs/two-part-tariff/fetch-charge-versions.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/fetch-charge-versions.service.test.js
@@ -140,9 +140,15 @@ describe('Fetch Charge Versions service', () => {
   describe('when there are no applicable charge versions', () => {
     describe("because the scheme is 'presroc'", () => {
       beforeEach(async () => {
-        await ChargeVersionHelper.add(
+        const { id: chargeVersionId } = await ChargeVersionHelper.add(
           { scheme: 'alcs', licenceId, licenceRef, regionCode: 5 }
         )
+
+        await ChargeReferenceHelper.add({
+          chargeVersionId,
+          chargeCategoryId,
+          adjustments: { s127: true }
+        })
       })
 
       it('returns no records', async () => {

--- a/test/services/bill-runs/two-part-tariff/fetch-charge-versions.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/fetch-charge-versions.service.test.js
@@ -85,6 +85,7 @@ describe('Fetch Charge Versions service', () => {
 
         const expectedChargeReferenceAndElement = {
           id: srocChargeReference.id,
+          volume: 6.82,
           description: srocChargeReference.description,
           aggregate: 0.562114443,
           s127: 'true',

--- a/test/services/bill-runs/two-part-tariff/fetch-charge-versions.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/fetch-charge-versions.service.test.js
@@ -50,7 +50,7 @@ describe('Fetch Charge Versions service', () => {
 
     beforeEach(async () => {
       await ChargeVersionHelper.add(
-        { id: chargeVersionId, startDate: new Date('2022-04-01'), licenceId, licenceRef, regionCode }
+        { id: chargeVersionId, licenceId, licenceRef, regionCode }
       )
 
       const { id: chargeReferenceId } = await ChargeReferenceHelper.add({

--- a/test/services/bill-runs/two-part-tariff/fetch-charge-versions.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/fetch-charge-versions.service.test.js
@@ -150,7 +150,7 @@ describe('Fetch Charge Versions service', () => {
 
           inDateChargeReference = await ChargeReferenceHelper.add({
             chargeVersionId: inDateChargeVersion.id,
-            billingChargeCategoryId: chargeCategory.id,
+            chargeCategoryId: chargeCategory.id,
             adjustments: { s127: true, aggregate: 0.562114443 }
           })
 
@@ -188,7 +188,7 @@ describe('Fetch Charge Versions service', () => {
 
           notInDateChargeReference = await ChargeReferenceHelper.add({
             chargeVersionId: notInDateChargeVersion.id,
-            billingChargeCategoryId: chargeCategory.id,
+            chargeCategoryId: chargeCategory.id,
             adjustments: { s127: true, aggregate: 0.562114443 }
           })
 
@@ -223,7 +223,7 @@ describe('Fetch Charge Versions service', () => {
 
         currentChargeReference = await ChargeReferenceHelper.add({
           chargeVersionId: currentChargeVersion.id,
-          billingChargeCategoryId: chargeCategory.id,
+          chargeCategoryId: chargeCategory.id,
           adjustments: { s127: true, aggregate: 0.562114443 }
         })
 
@@ -261,7 +261,7 @@ describe('Fetch Charge Versions service', () => {
 
         notCurrentChargeReference = await ChargeReferenceHelper.add({
           chargeVersionId: notCurrentChargeVersion.id,
-          billingChargeCategoryId: chargeCategory.id,
+          chargeCategoryId: chargeCategory.id,
           adjustments: { s127: true, aggregate: 0.562114443 }
         })
 
@@ -294,7 +294,7 @@ describe('Fetch Charge Versions service', () => {
 
         sameRegionChargeReference = await ChargeReferenceHelper.add({
           chargeVersionId: sameRegionChargeVersion.id,
-          billingChargeCategoryId: chargeCategory.id,
+          chargeCategoryId: chargeCategory.id,
           adjustments: { s127: true, aggregate: 0.562114443 }
         })
 
@@ -357,7 +357,7 @@ describe('Fetch Charge Versions service', () => {
 
           differentRegionChargeReference = await ChargeReferenceHelper.add({
             chargeVersionId: differentRegionChargeVersion.id,
-            billingChargeCategoryId: chargeCategory.id,
+            chargeCategoryId: chargeCategory.id,
             adjustments: { s127: true, aggregate: 0.562114443 }
           })
 
@@ -392,7 +392,7 @@ describe('Fetch Charge Versions service', () => {
 
         firstSrocChargeReference = await ChargeReferenceHelper.add({
           chargeVersionId: srocChargeVersion.id,
-          billingChargeCategoryId: chargeCategory.id,
+          chargeCategoryId: chargeCategory.id,
           adjustments: { s127: true, aggregate: 0.562114443 }
         })
 

--- a/test/services/bill-runs/two-part-tariff/fetch-charge-versions.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/fetch-charge-versions.service.test.js
@@ -161,7 +161,7 @@ describe('Fetch Charge Versions service', () => {
         await ChargeReferenceHelper.add({
           chargeVersionId,
           chargeCategoryId,
-          adjustments: { s127: true, aggregate: 0.562114443 }
+          adjustments: { s127: true }
         })
       })
 

--- a/test/services/bill-runs/two-part-tariff/fetch-charge-versions.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/fetch-charge-versions.service.test.js
@@ -157,7 +157,7 @@ describe('Fetch Charge Versions service', () => {
       })
     })
 
-    it('returns the charge versions order by licence reference', async () => {
+    it('returns the charge versions ordered by licence reference', async () => {
       const results = await FetchChargeVersionsService.go(regionId, billingPeriod)
 
       expect(results[0].licence.licenceRef).to.equal('01/128')

--- a/test/services/bill-runs/two-part-tariff/fetch-charge-versions.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/fetch-charge-versions.service.test.js
@@ -25,6 +25,7 @@ describe('Fetch Charge Versions service', () => {
     startDate: new Date('2022-04-01'),
     endDate: new Date('2023-03-31')
   }
+  const regionCode = 5
 
   let chargeCategoryId
   let licence
@@ -36,7 +37,7 @@ describe('Fetch Charge Versions service', () => {
     const chargeCategory = ChargeCategoryHelper.add()
     chargeCategoryId = chargeCategory.id
 
-    const region = await RegionHelper.add({ naldRegionId: 5 })
+    const region = await RegionHelper.add({ naldRegionId: regionCode })
     regionId = region.id
 
     licence = await LicenceHelper.add({ regionId })
@@ -50,7 +51,7 @@ describe('Fetch Charge Versions service', () => {
         const { id: licenceId, licenceRef } = licence
 
         const chargeVersion = await ChargeVersionHelper.add(
-          { startDate: new Date('2022-04-01'), licenceId, licenceRef, regionCode: 5 }
+          { startDate: new Date('2022-04-01'), licenceId, licenceRef, regionCode }
         )
         chargeVersionId = chargeVersion.id
 
@@ -114,7 +115,7 @@ describe('Fetch Charge Versions service', () => {
         const { id: licenceId, licenceRef } = licence
 
         await ChargeVersionHelper.add(
-          { scheme: 'alcs', licenceId, licenceRef, regionCode: 5 }
+          { scheme: 'alcs', licenceId, licenceRef, regionCode }
         )
       })
 
@@ -135,7 +136,7 @@ describe('Fetch Charge Versions service', () => {
           const { id: licenceId, licenceRef } = licence
 
           const inDateChargeVersion = await ChargeVersionHelper.add(
-            { startDate: new Date('2022-04-01'), licenceId, licenceRef, regionCode: 5 }
+            { startDate: new Date('2022-04-01'), licenceId, licenceRef, regionCode }
           )
 
           inDateChargeReference = await ChargeReferenceHelper.add({
@@ -170,7 +171,7 @@ describe('Fetch Charge Versions service', () => {
           const { id: licenceId, licenceRef } = licence
 
           const notInDateChargeVersion = await ChargeVersionHelper.add(
-            { startDate: new Date('2023-04-01'), licenceId, licenceRef, regionCode: 5 }
+            { startDate: new Date('2023-04-01'), licenceId, licenceRef, regionCode }
           )
 
           notInDateChargeReference = await ChargeReferenceHelper.add({
@@ -202,7 +203,7 @@ describe('Fetch Charge Versions service', () => {
         const { id: licenceId, licenceRef } = licence
 
         const currentChargeVersion = await ChargeVersionHelper.add(
-          { startDate: new Date('2022-04-01'), licenceId, licenceRef, regionCode: 5 }
+          { startDate: new Date('2022-04-01'), licenceId, licenceRef, regionCode }
         )
 
         currentChargeReference = await ChargeReferenceHelper.add({
@@ -237,7 +238,7 @@ describe('Fetch Charge Versions service', () => {
         const { id: licenceId, licenceRef } = licence
 
         const notCurrentChargeVersion = await ChargeVersionHelper.add(
-          { status: 'superseded', licenceId, licenceRef, regionCode: 5 }
+          { status: 'superseded', licenceId, licenceRef, regionCode }
         )
 
         notCurrentChargeReference = await ChargeReferenceHelper.add({
@@ -267,7 +268,7 @@ describe('Fetch Charge Versions service', () => {
         const { id: licenceId, licenceRef } = licence
 
         const sameRegionChargeVersion = await ChargeVersionHelper.add(
-          { startDate: new Date('2022-04-01'), licenceId, licenceRef, regionCode: 5 }
+          { startDate: new Date('2022-04-01'), licenceId, licenceRef, regionCode }
         )
 
         sameRegionChargeReference = await ChargeReferenceHelper.add({
@@ -360,7 +361,7 @@ describe('Fetch Charge Versions service', () => {
         const { id: licenceId, licenceRef } = licence
 
         const srocChargeVersion = await ChargeVersionHelper.add(
-          { startDate: new Date('2022-04-01'), licenceId, licenceRef, regionCode: 5 }
+          { startDate: new Date('2022-04-01'), licenceId, licenceRef, regionCode }
         )
 
         firstSrocChargeReference = await ChargeReferenceHelper.add({


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4057

This is related to our work building a new SROC two-part tariff matching and allocating engine.

We've been asked to make a change to the engine. Now when it allocates returns to charge elements it should take into account the authorised volume of the charge reference the charge element is under.

For example, if we had the following scenario

- `CR01 - authorised 100`
  - `CE01 - authorised 75`
  - `CE02 - authorised 75`
- `RT01 - submitted 150`

The original understanding was that we would be able to allocate all 150ML across the 2 charge elements. Now, when the total allocation across all charge elements within a charge reference reaches the charge references authorised we have to stop. So, the result would be

- `CR01 - authorised 100`
  - `CE01 - authorised 75 / allocated 75`
  - `CE02 - authorised 75 / allocated 25`
- `RT01 - submitted 150 / allocated 100`

To be able to do this we need to know what the authorised volume of the charge reference is. So, this change adds to what we get back when calling `FetchChargeVersionsService`.