### PR TITLE
Add new page for add a note

### DIFF
--- a/app/controllers/licences.controller.js
+++ b/app/controllers/licences.controller.js
@@ -50,7 +50,17 @@ async function returnsCheckYourAnswers (request, h) {
   })
 }
 
+async function addANote (request, h) {
+  const { id } = request.params
+
+  return h.view('return-requirements/add-a-note.njk', {
+    activeNavBar: 'search',
+    licenceId: id
+  })
+}
+
 module.exports = {
+  addANote,
   noReturnsCheckYourAnswers,
   noReturnsRequired,
   requirementsApproved,

--- a/app/routes/licence.routes.js
+++ b/app/routes/licence.routes.js
@@ -63,6 +63,18 @@ const routes = [
       },
       description: 'Returns check your answers page'
     }
+  }, {
+    method: 'GET',
+    path: '/licences/{id}/add-a-note',
+    handler: LicencesController.addANote,
+    options: {
+      auth: {
+        access: {
+          scope: ['billing']
+        }
+      },
+      description: 'Returns add a note page'
+    }
   }
 ]
 

--- a/app/views/return-requirements/add-a-note.njk
+++ b/app/views/return-requirements/add-a-note.njk
@@ -1,0 +1,25 @@
+{% extends 'layout.njk' %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% set rootLink = "/licences/" + licenceId %}
+{% block breadcrumbs %}
+  {# Back link #}
+  {{
+    govukBackLink({
+      text: 'back',
+      href: rootLink + "/returns-check-your-answers"
+    })
+  }}
+{% endblock %}
+
+{% block content %}
+  {# Main heading #}
+  <div class="govuk-body">
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">Add a note</h1>
+  </div>
+
+  <div class="govuk-body">
+    {{ govukButton({ text: "Confirm" }) }}
+  </div>
+{% endblock %}

--- a/test/controllers/licences.controller.test.js
+++ b/test/controllers/licences.controller.test.js
@@ -131,4 +131,24 @@ describe('Licences controller', () => {
       })
     })
   })
+
+  describe('GET /licences/{id}/add-a-note', () => {
+    const options = {
+      method: 'GET',
+      url: '/licences/64924759-8142-4a08-9d1e-1e902cd9d316/add-a-note',
+      auth: {
+        strategy: 'session',
+        credentials: { scope: ['billing'] }
+      }
+    }
+
+    describe('when the request succeeds', () => {
+      it('returns the page successfully', async () => {
+        const response = await server.inject(options)
+
+        expect(response.statusCode).to.equal(200)
+        expect(response.payload).to.contain('Add a note')
+      })
+    })
+  })
 })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4260

We are starting work on adding support for setting up return requirements within the service. A return requirement sets out how a licensee is expected to submit their returns, for example, daily, weekly or monthly, by what date, and using what unit of measure.

This is a page for adding a note to a return requirement.

This is just a stub page and controls and validation will come later.