### PR TITLE
Exclude ended licences in two-part tariff matching

### DIFF
--- a/app/services/bill-runs/two-part-tariff/fetch-charge-versions.service.js
+++ b/app/services/bill-runs/two-part-tariff/fetch-charge-versions.service.js
@@ -21,6 +21,7 @@ const Workflow = require('../../../models/workflow.model.js')
  * - be linked to a licence with is linked to the selected region
  * - have a start date before the end of the billing period
  * - not be linked to a licence in the workflow
+ * - not be linked to a licence that 'ended' before the billing period
  * - have a status of current
  * - be linked to a charge reference that is marked as two-part-tariff
  *
@@ -43,10 +44,26 @@ async function _fetch (regionCode, billingPeriod) {
       'chargeVersions.endDate',
       'chargeVersions.status'
     ])
+    .innerJoinRelated('licence')
     .where('chargeVersions.scheme', 'sroc')
     .where('chargeVersions.startDate', '<=', billingPeriod.endDate)
     .where('chargeVersions.status', 'current')
     .where('chargeVersions.regionCode', regionCode)
+    .where((builder) => {
+      builder
+        .whereNull('licence.expiredDate')
+        .orWhere('licence.expiredDate', '>=', billingPeriod.startDate)
+    })
+    .where((builder) => {
+      builder
+        .whereNull('licence.lapsedDate')
+        .orWhere('licence.lapsedDate', '>=', billingPeriod.startDate)
+    })
+    .where((builder) => {
+      builder
+        .whereNull('licence.revokedDate')
+        .orWhere('licence.revokedDate', '>=', billingPeriod.startDate)
+    })
     .whereNotExists(
       Workflow.query()
         .select(1)

--- a/test/services/bill-runs/two-part-tariff/fetch-charge-versions.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/fetch-charge-versions.service.test.js
@@ -42,7 +42,7 @@ describe('Fetch Charge Versions service', () => {
     const region = await RegionHelper.add({ naldRegionId: regionCode })
     regionId = region.id
 
-    await LicenceHelper.add({ id: licenceId, licenceRef, regionId })
+    await LicenceHelper.add({ id: licenceId, licenceRef, regionId, expiredDate: new Date('2024-05-01') })
   })
 
   describe('when there are applicable charge versions', () => {
@@ -108,7 +108,7 @@ describe('Fetch Charge Versions service', () => {
           id: 'cee9ff5f-813a-49c7-ba04-c65cfecf67dd',
           licenceRef: '01/128',
           startDate: new Date('2022-01-01'),
-          expiredDate: null,
+          expiredDate: new Date('2024-05-01'),
           lapsedDate: null,
           revokedDate: null
         },

--- a/test/services/bill-runs/two-part-tariff/fetch-charge-versions.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/fetch-charge-versions.service.test.js
@@ -277,7 +277,16 @@ describe('Fetch Charge Versions service', () => {
 
     describe('because the licence ended (expired, lapsed or revoked) before the billing period', () => {
       beforeEach(async () => {
-        const licence = await LicenceHelper.add({ licenceRef, regionId, expiredDate: new Date('2019-05-01') })
+        // NOTE: To make things spicy (!) we have the licence expire _after_ the billing period starts but revoked
+        // before it. Where The licence has dates in more than one of these fields, it is considered ended on the
+        // earliest of them (we have found real examples that confirm this is possible)
+        const licence = await LicenceHelper.add({
+          licenceRef,
+          regionId,
+          expiredDate: new Date('2019-05-01'),
+          revokedDate: new Date('2022-06-01')
+        })
+
         const { id: chargeVersionId } = await ChargeVersionHelper.add(
           { licenceId: licence.id, licenceRef, regionCode }
         )

--- a/test/services/bill-runs/two-part-tariff/fetch-charge-versions.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/fetch-charge-versions.service.test.js
@@ -274,5 +274,28 @@ describe('Fetch Charge Versions service', () => {
         expect(results).to.be.empty()
       })
     })
+
+    describe('because the licence ended (expired, lapsed or revoked) before the billing period', () => {
+      beforeEach(async () => {
+        const licence = await LicenceHelper.add({ licenceRef, regionId, expiredDate: new Date('2019-05-01') })
+        const { id: chargeVersionId } = await ChargeVersionHelper.add(
+          { licenceId: licence.id, licenceRef, regionCode }
+        )
+
+        await ChargeReferenceHelper.add({
+          chargeVersionId,
+          chargeCategoryId,
+          adjustments: { s127: true }
+        })
+
+        await WorkflowHelper.add({ licenceId })
+      })
+
+      it('returns no records', async () => {
+        const results = await FetchChargeVersionsService.go(regionId, billingPeriod)
+
+        expect(results).to.be.empty()
+      })
+    })
   })
 })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4057

When a two-part tariff bill run is triggered one of the first steps is fetching all the charge versions and their relevant licences that are applicable (same region and cross over the billing period).

A scenario we encountered when testing was a licence that had a 'current' charge version with a start date of 2022-04-01 but the licence was marked as lapsed in 2009.

When processed by our engine it resulted in a blank charge period, which then caused a whole bunch more errors. Initially, we made changes to cater for this scenario but having spoken with our SMEs they have agreed that ended licences can be excluded completely.

So, this change updates `FetchChargeVersionsService` to exclude ended (lapsed, expired or revoked) licences.