### PR TITLE
Fix check two-part tariff region endpoint

### DIFF
--- a/app/services/check/two-part.service.js
+++ b/app/services/check/two-part.service.js
@@ -57,8 +57,10 @@ function _billingPeriod () {
 async function _determineRegionId (identifier, type) {
   if (type === 'region') {
     const region = await RegionModel.query()
-      .select('identifier')
+      .select('id')
       .where('naldRegionId', identifier)
+      .limit(1)
+      .first()
 
     return region.id
   }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4057

When we were updating the existing check endpoint to include changes made to support the alternate version of the matching and allocating engine (see [Update 2PT check endpoint with alternate changes](https://github.com/DEFRA/water-abstraction-system/pull/582)) we confirmed our working by constantly pinging the `/check/two-part-licence/{licenceId}` endpoint.

We overlooked checking `/check/two-part/{naldRegionId}` (in our defence this is a hack endpoint!) If we had we would have found that it is broken.

This change fixes it.