### PR TITLE
Fix missing fields in bill runs view

### DIFF
--- a/db/migrations/public/20231215174532_alter-bill-runs-view.js
+++ b/db/migrations/public/20231215174532_alter-bill-runs-view.js
@@ -1,0 +1,68 @@
+'use strict'
+
+const viewName = 'bill_runs'
+
+exports.up = function (knex) {
+  return knex
+    .schema
+    .dropView(viewName)
+    .createView(viewName, (view) => {
+      view.as(knex('billing_batches').withSchema('water').select([
+        'billing_batch_id AS id',
+        'region_id',
+        'batch_type',
+        'from_financial_year_ending',
+        'to_financial_year_ending',
+        'status',
+        'invoice_count',
+        'credit_note_count',
+        'net_total',
+        'bill_run_number',
+        'error_code',
+        'external_id',
+        'is_summer AS summer',
+        'source',
+        'legacy_id',
+        'metadata',
+        'invoice_value',
+        'credit_note_value',
+        'transaction_file_reference',
+        'scheme',
+        'date_created AS created_at',
+        'date_updated AS updated_at'
+      ]))
+    })
+}
+
+exports.down = function (knex) {
+  return knex
+    .schema
+    .dropView(viewName)
+    .createView(viewName, (view) => {
+      // NOTE: We have commented out unused columns from the source table
+      view.as(knex('billing_batches').withSchema('water').select([
+        'billing_batch_id AS id',
+        'region_id',
+        'batch_type',
+        'from_financial_year_ending',
+        'to_financial_year_ending',
+        'status',
+        'invoice_count AS bill_count',
+        'credit_note_count',
+        'net_total',
+        'bill_run_number',
+        // 'error_code',
+        'external_id',
+        'is_summer AS summer',
+        'source',
+        'legacy_id',
+        'metadata',
+        'invoice_value',
+        'credit_note_value',
+        'transaction_file_reference',
+        'scheme',
+        'date_created AS created_at',
+        'date_updated AS updated_at'
+      ]))
+    })
+}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4057

As part of the work we have been doing on two-part tariff, we will create all our new tables in the default `public` schema.

We have also decided that when there is a legacy table that we are still going to need we will create a [View](https://www.postgresql.org/docs/current/sql-createview.html) of it in the `public` schema. This allows us to correct any issues with naming conventions, strip out unused fields, and join entities currently sat in different schemas. The first example of this approach was done in PR #531 .

In [Create water schema views](https://github.com/DEFRA/water-abstraction-system/pull/551) we created the view for `water.billing_batches` and dropped a column we thought wasn't needed and renamed one we thought was wrong.

We use `errorCode:` in our codebase during supplementary billing if a bill run fails so it is needed. And `invoiceCount` refers to the number of debit (positive value) bills in a bill run, not the total number. 'Invoice' rather than 'Debit' is used throughout the UI. So, we need to revert the name change.

> Note - when it comes to views you have to drop and recreate them. Unlike tables, you cannot alter columns individually
