### PR TITLE
Add Contact info link to header

### DIFF
--- a/app/plugins/views.plugin.js
+++ b/app/plugins/views.plugin.js
@@ -99,7 +99,8 @@ function context (request) {
       user: request.auth.credentials?.user,
       scope: request.auth.credentials?.scope,
       permission: request.auth.credentials?.permission
-    }
+    },
+    navigationLinks: _navigationLinks(request.auth)
   }
 }
 
@@ -135,6 +136,19 @@ function prepare (config, next) {
   config.compileOptions.environment = environment
 
   return next()
+}
+
+function _navigationLinks (auth) {
+  if (!auth.isAuthenticated) {
+    return []
+  }
+
+  const links = [
+    { href: '/account/update-password', text: 'Change password' },
+    { href: '/signout', text: 'Sign out' }
+  ]
+
+  return links
 }
 
 module.exports = ViewsPlugin

--- a/app/plugins/views.plugin.js
+++ b/app/plugins/views.plugin.js
@@ -138,6 +138,19 @@ function prepare (config, next) {
   return next()
 }
 
+/**
+ * Determine which navigation links, if any to display in the top-level GOV.UK header
+ *
+ * When a user is authenticated we display a 'Change password' and 'Sign out' link in the top-level header of each page.
+ *
+ * Some users are also eligible to see a 'Contact information' link, which allows them to set their contact details
+ * which will be used when generating, for example, renewal notifications.
+ *
+ * @param {Object} auth The `auth` property added to each Hapi request by the `AuthPlugin`. It tells us whether a user
+ * is authenticated and what scopes (permissions) they have
+ *
+ * @returns {Object[]} if the user is authenticated navigation links to display in the top-level GOV.UK header
+ */
 function _navigationLinks (auth) {
   if (!auth.isAuthenticated) {
     return []

--- a/app/plugins/views.plugin.js
+++ b/app/plugins/views.plugin.js
@@ -161,6 +161,12 @@ function _navigationLinks (auth) {
     { href: '/signout', text: 'Sign out' }
   ]
 
+  const { scope } = auth.credentials
+
+  if (scope.includes('hof_notifications') || scope.includes('renewal_notifications')) {
+    links.unshift({ href: '/contact-information', text: 'Contact information' })
+  }
+
   return links
 }
 

--- a/app/views/layout.njk
+++ b/app/views/layout.njk
@@ -21,12 +21,6 @@
 {% endblock %}
 
 {% block header %}
-  {% if auth.authenticated %}
-    {% set navigationLinks = [{ href: "/account/update-password", text: "Change password" }, { href: "/signout", text: "Sign out" }] %}
-  {% else %}
-    {% set navigationLinks = [] %}
-  {% endif %}
-
   {{ govukHeader({
     homepageUrl: "#",
     containerClasses: "govuk-width-container",


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4131

In the legacy UI there is a 'Contact information' link in the header. This takes you to a screen where you enter a name, job title, email address, phone number and address. There is just an **Update** button and a note saying

> This will be visible to your public contacts

When we looked at the legacy code this is sourced from the `/external` side of the [water-abstraction-ui](https://github.com/DEFRA/water-abstraction-ui) code. If you log in as an external user you see it. We assumed it was therefore another bug and shouldn't be there.

But we've since learned it is part of the notifications flow. When a user generates, for example, a renewal notification it will pull through their details and include them on the invite. This screen is needed to populate those details.

So, it _is_ a tacked-on thing (we'd argue it should be part of the flow not some rando link in the header) but it is required. This change adds the link back in.

The only complication is the legacy code only displays it for users with a `hof_notifications` or `renewal_notifications` scope. Again, it doesn't matter if all users see this and update their details, even if no one will see them. But we also _really_ want to get our new bill run pages out to give users access to the larger bill runs. So, we replicate that feature here as well.

<details>
<summary>Screenshot of contact information</summary>

![Screenshot 2023-12-16 at 10 59 22](https://github.com/DEFRA/water-abstraction-system/assets/1789650/3f085a19-1104-4383-b220-b1a83cc7adc1)

</details>