### PR TITLE
Amend bill count in bill run view for zero-value

### DIFF
--- a/app/presenters/bill-runs/view-bill-run.presenter.js
+++ b/app/presenters/bill-runs/view-bill-run.presenter.js
@@ -34,7 +34,7 @@ function go (billRun, billRunSummaries) {
   const regionName = capitalize(region.displayName)
 
   return {
-    billsCount: _billsCount(creditNoteCount, invoiceCount, billRunType),
+    billsCount: _billsCount(creditNoteCount, invoiceCount, billRunType, billRunSummaries),
     billRunId: id,
     billRunNumber,
     billRunStatus: status,
@@ -54,14 +54,30 @@ function go (billRun, billRunSummaries) {
   }
 }
 
-function _billsCount (creditsCount, debitsCount, billRunType) {
+function _billsCount (creditsCount, debitsCount, billRunType, billRunSummaries) {
   const total = creditsCount + debitsCount
 
+  // NOTE: A bill run wouldn't exist if there was just a single zero value bill on it. So, we can safely assume if the
+  // total is 1 it's not for a zero value bill and we can immediately return.
   if (total === 1) {
     return `1 ${billRunType} bill`
   }
 
-  return `${total} ${billRunType} bills`
+  const zeroValueBills = billRunSummaries.filter((billRunSummary) => {
+    return billRunSummary.netAmount === 0
+  })
+
+  const numberOfZeroValueBills = zeroValueBills.length
+
+  if (numberOfZeroValueBills === 0) {
+    return `${total} ${billRunType} bills`
+  }
+
+  if (numberOfZeroValueBills === 1) {
+    return `${total} ${billRunType} bills and 1 zero value bill`
+  }
+
+  return `${total} ${billRunType} bills and ${numberOfZeroValueBills} zero value bills`
 }
 
 function _billRunTotal (valueInPence) {

--- a/app/presenters/bill-runs/view-bill-run.presenter.js
+++ b/app/presenters/bill-runs/view-bill-run.presenter.js
@@ -11,7 +11,7 @@ const {
   formatMoney
 } = require('../base.presenter.js')
 
-function go (billRun, billRunSummaries) {
+function go (billRun, billSummaries) {
   const {
     batchType,
     billRunNumber,
@@ -34,7 +34,7 @@ function go (billRun, billRunSummaries) {
   const regionName = capitalize(region.displayName)
 
   return {
-    billsCount: _billsCount(creditNoteCount, invoiceCount, billRunType, billRunSummaries),
+    billsCount: _billsCount(creditNoteCount, invoiceCount, billRunType, billSummaries),
     billRunId: id,
     billRunNumber,
     billRunStatus: status,
@@ -54,7 +54,7 @@ function go (billRun, billRunSummaries) {
   }
 }
 
-function _billsCount (creditsCount, debitsCount, billRunType, billRunSummaries) {
+function _billsCount (creditsCount, debitsCount, billRunType, billSummaries) {
   const total = creditsCount + debitsCount
 
   // NOTE: A bill run wouldn't exist if there was just a single zero value bill on it. So, we can safely assume if the
@@ -63,8 +63,8 @@ function _billsCount (creditsCount, debitsCount, billRunType, billRunSummaries) 
     return `1 ${billRunType} bill`
   }
 
-  const zeroValueBills = billRunSummaries.filter((billRunSummary) => {
-    return billRunSummary.netAmount === 0
+  const zeroValueBills = billSummaries.filter((billSummary) => {
+    return billSummary.netAmount === 0
   })
 
   const numberOfZeroValueBills = zeroValueBills.length

--- a/app/presenters/bill-runs/view-bill-run.presenter.js
+++ b/app/presenters/bill-runs/view-bill-run.presenter.js
@@ -11,7 +11,7 @@ const {
   formatMoney
 } = require('../base.presenter.js')
 
-function go (billRun) {
+function go (billRun, billRunSummaries) {
   const {
     batchType,
     billRunNumber,

--- a/app/presenters/bill-runs/view-bill-run.presenter.js
+++ b/app/presenters/bill-runs/view-bill-run.presenter.js
@@ -63,11 +63,13 @@ function _billsCount (creditsCount, debitsCount, billRunType, billSummaries) {
     return `1 ${billRunType} bill`
   }
 
-  const zeroValueBills = billSummaries.filter((billSummary) => {
-    return billSummary.netAmount === 0
-  })
+  const numberOfZeroValueBills = billSummaries.reduce((count, billSummary) => {
+    if (billSummary.netAmount === 0) {
+      count += 1
+    }
 
-  const numberOfZeroValueBills = zeroValueBills.length
+    return count
+  }, 0)
 
   if (numberOfZeroValueBills === 0) {
     return `${total} ${billRunType} bills`

--- a/app/services/bill-runs/view-bill-run.service.js
+++ b/app/services/bill-runs/view-bill-run.service.js
@@ -20,7 +20,7 @@ const FetchBillRunService = require('./fetch-bill-run.service.js')
 async function go (id) {
   const result = await FetchBillRunService.go(id)
 
-  const billRun = ViewBillRunPresenter.go(result.billRun)
+  const billRun = ViewBillRunPresenter.go(result.billRun, result.billSummaries)
   const billGroups = ViewBillSummariesPresenter.go(result.billSummaries)
 
   return {

--- a/test/presenters/bill-runs/view-bill-run.presenter.test.js
+++ b/test/presenters/bill-runs/view-bill-run.presenter.test.js
@@ -44,7 +44,7 @@ describe.only('View Bill Run presenter', () => {
       })
     })
 
-    describe("the 'billsCount' property", () => {
+    describe.only("the 'billsCount' property", () => {
       describe('when the sum of the invoice and credit count is 1', () => {
         beforeEach(() => {
           billRun.creditNoteCount = 0
@@ -52,26 +52,75 @@ describe.only('View Bill Run presenter', () => {
         })
 
         describe('and there are no zero-value bills', () => {
-          it('returns the sum plus the bill run type as singular (1 Supplementary bill)', () => {
+          it('returns 1 plus the bill run type as singular (1 Supplementary bill)', () => {
             const result = ViewBillRunPresenter.go(billRun, billRunSummaries)
 
             expect(result.billsCount).to.equal('1 Supplementary bill')
+          })
+        })
+
+        describe('and there is 1 zero-value bill', () => {
+          beforeEach(() => {
+            billRunSummaries[0].netAmount = 0
+          })
+
+          it('returns 1 plus the bill run type and zero-value as singular (1 Supplementary bill and 1 zero value bill)', () => {
+            const result = ViewBillRunPresenter.go(billRun, billRunSummaries)
+
+            expect(result.billsCount).to.equal('1 Supplementary bill and 1 zero value bill')
+          })
+        })
+
+        describe('and there are multiple zero-value bills', () => {
+          beforeEach(() => {
+            billRunSummaries[0].netAmount = 0
+            billRunSummaries[1].netAmount = 0
+          })
+
+          it('returns 1 plus the bill run type as singular but zero-value pluralised (1 Supplementary bill and 2 zero value bills)', () => {
+            const result = ViewBillRunPresenter.go(billRun, billRunSummaries)
+
+            expect(result.billsCount).to.equal('1 Supplementary bill and 2 zero value bills')
           })
         })
       })
 
       describe('when the sum of the invoice and credit count is more than 1', () => {
         beforeEach(() => {
-          billRun.batchType = 'annual'
           billRun.creditNoteCount = 5
           billRun.invoiceCount = 7
         })
 
         describe('and there are no zero-value bills', () => {
-          it('returns the sum plus the bill run type pluralised (12 Annual bills)', () => {
+          it('returns the sum plus the bill run type pluralised (12 Supplementary bills)', () => {
             const result = ViewBillRunPresenter.go(billRun, billRunSummaries)
 
-            expect(result.billsCount).to.equal('12 Annual bills')
+            expect(result.billsCount).to.equal('12 Supplementary bills')
+          })
+        })
+
+        describe('and there is 1 zero-value bill', () => {
+          beforeEach(() => {
+            billRunSummaries[0].netAmount = 0
+          })
+
+          it('returns the sum plus the bill run type pluralised and zero-value as singular (12 Supplementary bills and 1 zero value bill)', () => {
+            const result = ViewBillRunPresenter.go(billRun, billRunSummaries)
+
+            expect(result.billsCount).to.equal('12 Supplementary bills and 1 zero value bill')
+          })
+        })
+
+        describe('and there are multiple zero-value bills', () => {
+          beforeEach(() => {
+            billRunSummaries[0].netAmount = 0
+            billRunSummaries[1].netAmount = 0
+          })
+
+          it('returns the sum plus the bill run type and zero-value pluralised (12 Supplementary bills and 2 zero value bills)', () => {
+            const result = ViewBillRunPresenter.go(billRun, billRunSummaries)
+
+            expect(result.billsCount).to.equal('1 Supplementary bill and 2 zero value bills')
           })
         })
       })
@@ -323,6 +372,17 @@ function _testBillSummaries () {
       agentName: 'Geordie Leforge',
       allLicences: '17/53/001/G/782',
       waterCompany: false
+    },
+    {
+      id: '64924759-8142-4a08-9d1e-1e902cd9d316',
+      billingAccountId: 'ee3f5562-26ad-4d58-9b59-5c388a13d7d0',
+      accountNumber: 'E22288888A',
+      netAmount: 21317800,
+      financialYearEnding: 2023,
+      companyName: 'Acme Water Services Ltd',
+      agentName: null,
+      allLicences: '17/53/001/A/101,17/53/002/B/205,17/53/002/C/308',
+      waterCompany: true
     }
   ]
 }

--- a/test/presenters/bill-runs/view-bill-run.presenter.test.js
+++ b/test/presenters/bill-runs/view-bill-run.presenter.test.js
@@ -51,7 +51,7 @@ describe.only('View Bill Run presenter', () => {
           billRun.invoiceCount = 1
         })
 
-        describe('and there are no zero-value bills', () => {
+        describe('and there are no zero value bills', () => {
           it('returns 1 plus the bill run type as singular (1 Supplementary bill)', () => {
             const result = ViewBillRunPresenter.go(billRun, billRunSummaries)
 
@@ -59,25 +59,25 @@ describe.only('View Bill Run presenter', () => {
           })
         })
 
-        describe('and there is 1 zero-value bill', () => {
+        describe('and there is 1 zero value bill', () => {
           beforeEach(() => {
             billRunSummaries[0].netAmount = 0
           })
 
-          it('returns 1 plus the bill run type and zero-value as singular (1 Supplementary bill and 1 zero value bill)', () => {
+          it('returns 1 plus the bill run type and zero value as singular (1 Supplementary bill and 1 zero value bill)', () => {
             const result = ViewBillRunPresenter.go(billRun, billRunSummaries)
 
             expect(result.billsCount).to.equal('1 Supplementary bill and 1 zero value bill')
           })
         })
 
-        describe('and there are multiple zero-value bills', () => {
+        describe('and there are multiple zero value bills', () => {
           beforeEach(() => {
             billRunSummaries[0].netAmount = 0
             billRunSummaries[1].netAmount = 0
           })
 
-          it('returns 1 plus the bill run type as singular but zero-value pluralised (1 Supplementary bill and 2 zero value bills)', () => {
+          it('returns 1 plus the bill run type as singular but zero value pluralised (1 Supplementary bill and 2 zero value bills)', () => {
             const result = ViewBillRunPresenter.go(billRun, billRunSummaries)
 
             expect(result.billsCount).to.equal('1 Supplementary bill and 2 zero value bills')
@@ -91,7 +91,7 @@ describe.only('View Bill Run presenter', () => {
           billRun.invoiceCount = 7
         })
 
-        describe('and there are no zero-value bills', () => {
+        describe('and there are no zero value bills', () => {
           it('returns the sum plus the bill run type pluralised (12 Supplementary bills)', () => {
             const result = ViewBillRunPresenter.go(billRun, billRunSummaries)
 
@@ -99,25 +99,25 @@ describe.only('View Bill Run presenter', () => {
           })
         })
 
-        describe('and there is 1 zero-value bill', () => {
+        describe('and there is 1 zero value bill', () => {
           beforeEach(() => {
             billRunSummaries[0].netAmount = 0
           })
 
-          it('returns the sum plus the bill run type pluralised and zero-value as singular (12 Supplementary bills and 1 zero value bill)', () => {
+          it('returns the sum plus the bill run type pluralised and zero value as singular (12 Supplementary bills and 1 zero value bill)', () => {
             const result = ViewBillRunPresenter.go(billRun, billRunSummaries)
 
             expect(result.billsCount).to.equal('12 Supplementary bills and 1 zero value bill')
           })
         })
 
-        describe('and there are multiple zero-value bills', () => {
+        describe('and there are multiple zero value bills', () => {
           beforeEach(() => {
             billRunSummaries[0].netAmount = 0
             billRunSummaries[1].netAmount = 0
           })
 
-          it('returns the sum plus the bill run type and zero-value pluralised (12 Supplementary bills and 2 zero value bills)', () => {
+          it('returns the sum plus the bill run type and zero value pluralised (12 Supplementary bills and 2 zero value bills)', () => {
             const result = ViewBillRunPresenter.go(billRun, billRunSummaries)
 
             expect(result.billsCount).to.equal('1 Supplementary bill and 2 zero value bills')

--- a/test/presenters/bill-runs/view-bill-run.presenter.test.js
+++ b/test/presenters/bill-runs/view-bill-run.presenter.test.js
@@ -12,14 +12,16 @@ const ViewBillRunPresenter = require('../../../app/presenters/bill-runs/view-bil
 
 describe('View Bill Run presenter', () => {
   let billRun
+  let billRunSummaries
 
   describe('when provided with a populated bill run', () => {
     beforeEach(() => {
       billRun = _testBillRun()
+      billRunSummaries = _testBillSummaries()
     })
 
     it('correctly presents the data', () => {
-      const result = ViewBillRunPresenter.go(billRun)
+      const result = ViewBillRunPresenter.go(billRun, billRunSummaries)
 
       expect(result).to.equal({
         billsCount: '8 Supplementary bills',
@@ -50,7 +52,7 @@ describe('View Bill Run presenter', () => {
         })
 
         it('returns to sum plus the bill run type as singular (1 Supplementary bill)', () => {
-          const result = ViewBillRunPresenter.go(billRun)
+          const result = ViewBillRunPresenter.go(billRun, billRunSummaries)
 
           expect(result.billsCount).to.equal('1 Supplementary bill')
         })
@@ -64,7 +66,7 @@ describe('View Bill Run presenter', () => {
         })
 
         it('returns to sum plus the bill run type pluralised (12 Annual bills)', () => {
-          const result = ViewBillRunPresenter.go(billRun)
+          const result = ViewBillRunPresenter.go(billRun, billRunSummaries)
 
           expect(result.billsCount).to.equal('12 Annual bills')
         })
@@ -74,7 +76,7 @@ describe('View Bill Run presenter', () => {
     describe("the 'billRunTotal' property", () => {
       describe('when the net total is greater than 0', () => {
         it('returns the value converted to pounds, formatted as money and showing as a debit (£707.00)', () => {
-          const result = ViewBillRunPresenter.go(billRun)
+          const result = ViewBillRunPresenter.go(billRun, billRunSummaries)
 
           expect(result.billRunTotal).to.equal('£707.00')
         })
@@ -86,7 +88,7 @@ describe('View Bill Run presenter', () => {
         })
 
         it('returns the value converted to pounds, formatted as money and showing as a debit (£0.00)', () => {
-          const result = ViewBillRunPresenter.go(billRun)
+          const result = ViewBillRunPresenter.go(billRun, billRunSummaries)
 
           expect(result.billRunTotal).to.equal('£0.00')
         })
@@ -98,7 +100,7 @@ describe('View Bill Run presenter', () => {
         })
 
         it('returns the value converted to pounds, formatted as money and showing as a credit (£707.00 credit)', () => {
-          const result = ViewBillRunPresenter.go(billRun)
+          const result = ViewBillRunPresenter.go(billRun, billRunSummaries)
 
           expect(result.billRunTotal).to.equal('£707.00 credit')
         })
@@ -112,7 +114,7 @@ describe('View Bill Run presenter', () => {
         })
 
         it('returns Annual', () => {
-          const result = ViewBillRunPresenter.go(billRun)
+          const result = ViewBillRunPresenter.go(billRun, billRunSummaries)
 
           expect(result.billRunType).to.equal('Annual')
         })
@@ -120,7 +122,7 @@ describe('View Bill Run presenter', () => {
 
       describe('when the bill run is supplementary', () => {
         it('returns Supplementary', () => {
-          const result = ViewBillRunPresenter.go(billRun)
+          const result = ViewBillRunPresenter.go(billRun, billRunSummaries)
 
           expect(result.billRunType).to.equal('Supplementary')
         })
@@ -133,7 +135,7 @@ describe('View Bill Run presenter', () => {
 
         describe('and the scheme is sroc', () => {
           it('returns Supplementary', () => {
-            const result = ViewBillRunPresenter.go(billRun)
+            const result = ViewBillRunPresenter.go(billRun, billRunSummaries)
 
             expect(result.billRunType).to.equal('Two-part tariff')
           })
@@ -146,7 +148,7 @@ describe('View Bill Run presenter', () => {
 
           describe('and it is not summer only', () => {
             it('returns Supplementary', () => {
-              const result = ViewBillRunPresenter.go(billRun)
+              const result = ViewBillRunPresenter.go(billRun, billRunSummaries)
 
               expect(result.billRunType).to.equal('Two-part tariff winter and all year')
             })
@@ -158,7 +160,7 @@ describe('View Bill Run presenter', () => {
             })
 
             it('returns Supplementary', () => {
-              const result = ViewBillRunPresenter.go(billRun)
+              const result = ViewBillRunPresenter.go(billRun, billRunSummaries)
 
               expect(result.billRunType).to.equal('Two-part tariff summer')
             })
@@ -170,7 +172,7 @@ describe('View Bill Run presenter', () => {
     describe("the 'chargeScheme' property", () => {
       describe('when the bill run is sroc', () => {
         it('returns Current', () => {
-          const result = ViewBillRunPresenter.go(billRun)
+          const result = ViewBillRunPresenter.go(billRun, billRunSummaries)
 
           expect(result.chargeScheme).to.equal('Current')
         })
@@ -182,7 +184,7 @@ describe('View Bill Run presenter', () => {
         })
 
         it('returns Old', () => {
-          const result = ViewBillRunPresenter.go(billRun)
+          const result = ViewBillRunPresenter.go(billRun, billRunSummaries)
 
           expect(result.chargeScheme).to.equal('Old')
         })
@@ -196,7 +198,7 @@ describe('View Bill Run presenter', () => {
         })
 
         it('returns the count singular (1 credit note)', () => {
-          const result = ViewBillRunPresenter.go(billRun)
+          const result = ViewBillRunPresenter.go(billRun, billRunSummaries)
 
           expect(result.creditsCount).to.equal('1 credit note')
         })
@@ -204,7 +206,7 @@ describe('View Bill Run presenter', () => {
 
       describe('when there are multiple credit notes', () => {
         it('returns the count pluralised (2 credit notes)', () => {
-          const result = ViewBillRunPresenter.go(billRun)
+          const result = ViewBillRunPresenter.go(billRun, billRunSummaries)
 
           expect(result.creditsCount).to.equal('2 credit notes')
         })
@@ -218,7 +220,7 @@ describe('View Bill Run presenter', () => {
         })
 
         it('returns the count singular (1 invoice)', () => {
-          const result = ViewBillRunPresenter.go(billRun)
+          const result = ViewBillRunPresenter.go(billRun, billRunSummaries)
 
           expect(result.debitsCount).to.equal('1 invoice')
         })
@@ -226,7 +228,7 @@ describe('View Bill Run presenter', () => {
 
       describe('when there are multiple invoices', () => {
         it('returns the count pluralised (6 invoices)', () => {
-          const result = ViewBillRunPresenter.go(billRun)
+          const result = ViewBillRunPresenter.go(billRun, billRunSummaries)
 
           expect(result.debitsCount).to.equal('6 invoices')
         })
@@ -240,7 +242,7 @@ describe('View Bill Run presenter', () => {
         })
 
         it('returns false', () => {
-          const result = ViewBillRunPresenter.go(billRun)
+          const result = ViewBillRunPresenter.go(billRun, billRunSummaries)
 
           expect(result.displayCreditDebitTotals).to.be.false()
         })
@@ -248,7 +250,7 @@ describe('View Bill Run presenter', () => {
 
       describe('when the bill run is supplementary', () => {
         it('returns true', () => {
-          const result = ViewBillRunPresenter.go(billRun)
+          const result = ViewBillRunPresenter.go(billRun, billRunSummaries)
 
           expect(result.displayCreditDebitTotals).to.be.true()
         })
@@ -257,7 +259,7 @@ describe('View Bill Run presenter', () => {
 
     describe("the 'financialYear' property", () => {
       it('returns the to and from financial year (2023 to 2024)', () => {
-        const result = ViewBillRunPresenter.go(billRun)
+        const result = ViewBillRunPresenter.go(billRun, billRunSummaries)
 
         expect(result.financialYear).to.equal('2023 to 2024')
       })
@@ -265,7 +267,7 @@ describe('View Bill Run presenter', () => {
 
     describe("the 'pageTitle' property", () => {
       it('returns the region name and bill run type (Wales supplementary)', () => {
-        const result = ViewBillRunPresenter.go(billRun)
+        const result = ViewBillRunPresenter.go(billRun, billRunSummaries)
 
         expect(result.pageTitle).to.equal('Wales supplementary')
       })
@@ -273,7 +275,7 @@ describe('View Bill Run presenter', () => {
 
     describe("the 'region' property", () => {
       it("returns the bill run's region display name capitalized (Wales)", () => {
-        const result = ViewBillRunPresenter.go(billRun)
+        const result = ViewBillRunPresenter.go(billRun, billRunSummaries)
 
         expect(result.region).to.equal('Wales')
       })
@@ -303,4 +305,20 @@ function _testBillRun () {
       displayName: 'Wales'
     }
   }
+}
+
+function _testBillSummaries () {
+  return [
+    {
+      id: '7c8a248c-b71e-463c-bea8-bc5e0a5d95e2',
+      billingAccountId: 'e8bd9fe1-47eb-42f2-a507-786bccd35aee',
+      accountNumber: 'E11101999A',
+      netAmount: -9700,
+      financialYearEnding: 2023,
+      companyName: 'H M Scotty & Daughter',
+      agentName: 'Geordie Leforge',
+      allLicences: '17/53/001/G/782',
+      waterCompany: false
+    }
+  ]
 }

--- a/test/presenters/bill-runs/view-bill-run.presenter.test.js
+++ b/test/presenters/bill-runs/view-bill-run.presenter.test.js
@@ -51,10 +51,12 @@ describe('View Bill Run presenter', () => {
           billRun.invoiceCount = 1
         })
 
-        it('returns to sum plus the bill run type as singular (1 Supplementary bill)', () => {
-          const result = ViewBillRunPresenter.go(billRun, billRunSummaries)
+        describe('and there are no zero-value bills', () => {
+          it('returns to sum plus the bill run type as singular (1 Supplementary bill)', () => {
+            const result = ViewBillRunPresenter.go(billRun, billRunSummaries)
 
-          expect(result.billsCount).to.equal('1 Supplementary bill')
+            expect(result.billsCount).to.equal('1 Supplementary bill')
+          })
         })
       })
 
@@ -65,10 +67,12 @@ describe('View Bill Run presenter', () => {
           billRun.invoiceCount = 7
         })
 
-        it('returns to sum plus the bill run type pluralised (12 Annual bills)', () => {
-          const result = ViewBillRunPresenter.go(billRun, billRunSummaries)
+        describe('and there are no zero-value bills', () => {
+          it('returns to sum plus the bill run type pluralised (12 Annual bills)', () => {
+            const result = ViewBillRunPresenter.go(billRun, billRunSummaries)
 
-          expect(result.billsCount).to.equal('12 Annual bills')
+            expect(result.billsCount).to.equal('12 Annual bills')
+          })
         })
       })
     })

--- a/test/presenters/bill-runs/view-bill-run.presenter.test.js
+++ b/test/presenters/bill-runs/view-bill-run.presenter.test.js
@@ -10,7 +10,7 @@ const { expect } = Code
 // Thing under test
 const ViewBillRunPresenter = require('../../../app/presenters/bill-runs/view-bill-run.presenter.js')
 
-describe.only('View Bill Run presenter', () => {
+describe('View Bill Run presenter', () => {
   let billRun
   let billRunSummaries
 
@@ -44,44 +44,19 @@ describe.only('View Bill Run presenter', () => {
       })
     })
 
-    describe.only("the 'billsCount' property", () => {
+    describe("the 'billsCount' property", () => {
+      // NOTE: We have no tests for zero value bills in this scenario because a bill run won't exist if it just contains
+      // a single zero value bill. So, if there is only one bill it must be a credit or an invoice
       describe('when the sum of the invoice and credit count is 1', () => {
         beforeEach(() => {
           billRun.creditNoteCount = 0
           billRun.invoiceCount = 1
         })
 
-        describe('and there are no zero value bills', () => {
-          it('returns 1 plus the bill run type as singular (1 Supplementary bill)', () => {
-            const result = ViewBillRunPresenter.go(billRun, billRunSummaries)
+        it('returns 1 plus the bill run type as singular (1 Supplementary bill)', () => {
+          const result = ViewBillRunPresenter.go(billRun, billRunSummaries)
 
-            expect(result.billsCount).to.equal('1 Supplementary bill')
-          })
-        })
-
-        describe('and there is 1 zero value bill', () => {
-          beforeEach(() => {
-            billRunSummaries[0].netAmount = 0
-          })
-
-          it('returns 1 plus the bill run type and zero value as singular (1 Supplementary bill and 1 zero value bill)', () => {
-            const result = ViewBillRunPresenter.go(billRun, billRunSummaries)
-
-            expect(result.billsCount).to.equal('1 Supplementary bill and 1 zero value bill')
-          })
-        })
-
-        describe('and there are multiple zero value bills', () => {
-          beforeEach(() => {
-            billRunSummaries[0].netAmount = 0
-            billRunSummaries[1].netAmount = 0
-          })
-
-          it('returns 1 plus the bill run type as singular but zero value pluralised (1 Supplementary bill and 2 zero value bills)', () => {
-            const result = ViewBillRunPresenter.go(billRun, billRunSummaries)
-
-            expect(result.billsCount).to.equal('1 Supplementary bill and 2 zero value bills')
-          })
+          expect(result.billsCount).to.equal('1 Supplementary bill')
         })
       })
 
@@ -120,7 +95,7 @@ describe.only('View Bill Run presenter', () => {
           it('returns the sum plus the bill run type and zero value pluralised (12 Supplementary bills and 2 zero value bills)', () => {
             const result = ViewBillRunPresenter.go(billRun, billRunSummaries)
 
-            expect(result.billsCount).to.equal('1 Supplementary bill and 2 zero value bills')
+            expect(result.billsCount).to.equal('12 Supplementary bills and 2 zero value bills')
           })
         })
       })

--- a/test/presenters/bill-runs/view-bill-run.presenter.test.js
+++ b/test/presenters/bill-runs/view-bill-run.presenter.test.js
@@ -12,16 +12,16 @@ const ViewBillRunPresenter = require('../../../app/presenters/bill-runs/view-bil
 
 describe('View Bill Run presenter', () => {
   let billRun
-  let billRunSummaries
+  let billSummaries
 
   describe('when provided with a populated bill run', () => {
     beforeEach(() => {
       billRun = _testBillRun()
-      billRunSummaries = _testBillSummaries()
+      billSummaries = _testBillSummaries()
     })
 
     it('correctly presents the data', () => {
-      const result = ViewBillRunPresenter.go(billRun, billRunSummaries)
+      const result = ViewBillRunPresenter.go(billRun, billSummaries)
 
       expect(result).to.equal({
         billsCount: '8 Supplementary bills',
@@ -54,7 +54,7 @@ describe('View Bill Run presenter', () => {
         })
 
         it('returns 1 plus the bill run type as singular (1 Supplementary bill)', () => {
-          const result = ViewBillRunPresenter.go(billRun, billRunSummaries)
+          const result = ViewBillRunPresenter.go(billRun, billSummaries)
 
           expect(result.billsCount).to.equal('1 Supplementary bill')
         })
@@ -68,7 +68,7 @@ describe('View Bill Run presenter', () => {
 
         describe('and there are no zero value bills', () => {
           it('returns the sum plus the bill run type pluralised (12 Supplementary bills)', () => {
-            const result = ViewBillRunPresenter.go(billRun, billRunSummaries)
+            const result = ViewBillRunPresenter.go(billRun, billSummaries)
 
             expect(result.billsCount).to.equal('12 Supplementary bills')
           })
@@ -76,11 +76,11 @@ describe('View Bill Run presenter', () => {
 
         describe('and there is 1 zero value bill', () => {
           beforeEach(() => {
-            billRunSummaries[0].netAmount = 0
+            billSummaries[0].netAmount = 0
           })
 
           it('returns the sum plus the bill run type pluralised and zero value as singular (12 Supplementary bills and 1 zero value bill)', () => {
-            const result = ViewBillRunPresenter.go(billRun, billRunSummaries)
+            const result = ViewBillRunPresenter.go(billRun, billSummaries)
 
             expect(result.billsCount).to.equal('12 Supplementary bills and 1 zero value bill')
           })
@@ -88,12 +88,12 @@ describe('View Bill Run presenter', () => {
 
         describe('and there are multiple zero value bills', () => {
           beforeEach(() => {
-            billRunSummaries[0].netAmount = 0
-            billRunSummaries[1].netAmount = 0
+            billSummaries[0].netAmount = 0
+            billSummaries[1].netAmount = 0
           })
 
           it('returns the sum plus the bill run type and zero value pluralised (12 Supplementary bills and 2 zero value bills)', () => {
-            const result = ViewBillRunPresenter.go(billRun, billRunSummaries)
+            const result = ViewBillRunPresenter.go(billRun, billSummaries)
 
             expect(result.billsCount).to.equal('12 Supplementary bills and 2 zero value bills')
           })
@@ -104,7 +104,7 @@ describe('View Bill Run presenter', () => {
     describe("the 'billRunTotal' property", () => {
       describe('when the net total is greater than 0', () => {
         it('returns the value converted to pounds, formatted as money and showing as a debit (£707.00)', () => {
-          const result = ViewBillRunPresenter.go(billRun, billRunSummaries)
+          const result = ViewBillRunPresenter.go(billRun, billSummaries)
 
           expect(result.billRunTotal).to.equal('£707.00')
         })
@@ -116,7 +116,7 @@ describe('View Bill Run presenter', () => {
         })
 
         it('returns the value converted to pounds, formatted as money and showing as a debit (£0.00)', () => {
-          const result = ViewBillRunPresenter.go(billRun, billRunSummaries)
+          const result = ViewBillRunPresenter.go(billRun, billSummaries)
 
           expect(result.billRunTotal).to.equal('£0.00')
         })
@@ -128,7 +128,7 @@ describe('View Bill Run presenter', () => {
         })
 
         it('returns the value converted to pounds, formatted as money and showing as a credit (£707.00 credit)', () => {
-          const result = ViewBillRunPresenter.go(billRun, billRunSummaries)
+          const result = ViewBillRunPresenter.go(billRun, billSummaries)
 
           expect(result.billRunTotal).to.equal('£707.00 credit')
         })
@@ -142,7 +142,7 @@ describe('View Bill Run presenter', () => {
         })
 
         it('returns Annual', () => {
-          const result = ViewBillRunPresenter.go(billRun, billRunSummaries)
+          const result = ViewBillRunPresenter.go(billRun, billSummaries)
 
           expect(result.billRunType).to.equal('Annual')
         })
@@ -150,7 +150,7 @@ describe('View Bill Run presenter', () => {
 
       describe('when the bill run is supplementary', () => {
         it('returns Supplementary', () => {
-          const result = ViewBillRunPresenter.go(billRun, billRunSummaries)
+          const result = ViewBillRunPresenter.go(billRun, billSummaries)
 
           expect(result.billRunType).to.equal('Supplementary')
         })
@@ -163,7 +163,7 @@ describe('View Bill Run presenter', () => {
 
         describe('and the scheme is sroc', () => {
           it('returns Supplementary', () => {
-            const result = ViewBillRunPresenter.go(billRun, billRunSummaries)
+            const result = ViewBillRunPresenter.go(billRun, billSummaries)
 
             expect(result.billRunType).to.equal('Two-part tariff')
           })
@@ -176,7 +176,7 @@ describe('View Bill Run presenter', () => {
 
           describe('and it is not summer only', () => {
             it('returns Supplementary', () => {
-              const result = ViewBillRunPresenter.go(billRun, billRunSummaries)
+              const result = ViewBillRunPresenter.go(billRun, billSummaries)
 
               expect(result.billRunType).to.equal('Two-part tariff winter and all year')
             })
@@ -188,7 +188,7 @@ describe('View Bill Run presenter', () => {
             })
 
             it('returns Supplementary', () => {
-              const result = ViewBillRunPresenter.go(billRun, billRunSummaries)
+              const result = ViewBillRunPresenter.go(billRun, billSummaries)
 
               expect(result.billRunType).to.equal('Two-part tariff summer')
             })
@@ -200,7 +200,7 @@ describe('View Bill Run presenter', () => {
     describe("the 'chargeScheme' property", () => {
       describe('when the bill run is sroc', () => {
         it('returns Current', () => {
-          const result = ViewBillRunPresenter.go(billRun, billRunSummaries)
+          const result = ViewBillRunPresenter.go(billRun, billSummaries)
 
           expect(result.chargeScheme).to.equal('Current')
         })
@@ -212,7 +212,7 @@ describe('View Bill Run presenter', () => {
         })
 
         it('returns Old', () => {
-          const result = ViewBillRunPresenter.go(billRun, billRunSummaries)
+          const result = ViewBillRunPresenter.go(billRun, billSummaries)
 
           expect(result.chargeScheme).to.equal('Old')
         })
@@ -226,7 +226,7 @@ describe('View Bill Run presenter', () => {
         })
 
         it('returns the count singular (1 credit note)', () => {
-          const result = ViewBillRunPresenter.go(billRun, billRunSummaries)
+          const result = ViewBillRunPresenter.go(billRun, billSummaries)
 
           expect(result.creditsCount).to.equal('1 credit note')
         })
@@ -234,7 +234,7 @@ describe('View Bill Run presenter', () => {
 
       describe('when there are multiple credit notes', () => {
         it('returns the count pluralised (2 credit notes)', () => {
-          const result = ViewBillRunPresenter.go(billRun, billRunSummaries)
+          const result = ViewBillRunPresenter.go(billRun, billSummaries)
 
           expect(result.creditsCount).to.equal('2 credit notes')
         })
@@ -248,7 +248,7 @@ describe('View Bill Run presenter', () => {
         })
 
         it('returns the count singular (1 invoice)', () => {
-          const result = ViewBillRunPresenter.go(billRun, billRunSummaries)
+          const result = ViewBillRunPresenter.go(billRun, billSummaries)
 
           expect(result.debitsCount).to.equal('1 invoice')
         })
@@ -256,7 +256,7 @@ describe('View Bill Run presenter', () => {
 
       describe('when there are multiple invoices', () => {
         it('returns the count pluralised (6 invoices)', () => {
-          const result = ViewBillRunPresenter.go(billRun, billRunSummaries)
+          const result = ViewBillRunPresenter.go(billRun, billSummaries)
 
           expect(result.debitsCount).to.equal('6 invoices')
         })
@@ -270,7 +270,7 @@ describe('View Bill Run presenter', () => {
         })
 
         it('returns false', () => {
-          const result = ViewBillRunPresenter.go(billRun, billRunSummaries)
+          const result = ViewBillRunPresenter.go(billRun, billSummaries)
 
           expect(result.displayCreditDebitTotals).to.be.false()
         })
@@ -278,7 +278,7 @@ describe('View Bill Run presenter', () => {
 
       describe('when the bill run is supplementary', () => {
         it('returns true', () => {
-          const result = ViewBillRunPresenter.go(billRun, billRunSummaries)
+          const result = ViewBillRunPresenter.go(billRun, billSummaries)
 
           expect(result.displayCreditDebitTotals).to.be.true()
         })
@@ -287,7 +287,7 @@ describe('View Bill Run presenter', () => {
 
     describe("the 'financialYear' property", () => {
       it('returns the to and from financial year (2023 to 2024)', () => {
-        const result = ViewBillRunPresenter.go(billRun, billRunSummaries)
+        const result = ViewBillRunPresenter.go(billRun, billSummaries)
 
         expect(result.financialYear).to.equal('2023 to 2024')
       })
@@ -295,7 +295,7 @@ describe('View Bill Run presenter', () => {
 
     describe("the 'pageTitle' property", () => {
       it('returns the region name and bill run type (Wales supplementary)', () => {
-        const result = ViewBillRunPresenter.go(billRun, billRunSummaries)
+        const result = ViewBillRunPresenter.go(billRun, billSummaries)
 
         expect(result.pageTitle).to.equal('Wales supplementary')
       })
@@ -303,7 +303,7 @@ describe('View Bill Run presenter', () => {
 
     describe("the 'region' property", () => {
       it("returns the bill run's region display name capitalized (Wales)", () => {
-        const result = ViewBillRunPresenter.go(billRun, billRunSummaries)
+        const result = ViewBillRunPresenter.go(billRun, billSummaries)
 
         expect(result.region).to.equal('Wales')
       })

--- a/test/presenters/bill-runs/view-bill-run.presenter.test.js
+++ b/test/presenters/bill-runs/view-bill-run.presenter.test.js
@@ -10,7 +10,7 @@ const { expect } = Code
 // Thing under test
 const ViewBillRunPresenter = require('../../../app/presenters/bill-runs/view-bill-run.presenter.js')
 
-describe('View Bill Run presenter', () => {
+describe.only('View Bill Run presenter', () => {
   let billRun
   let billRunSummaries
 
@@ -52,7 +52,7 @@ describe('View Bill Run presenter', () => {
         })
 
         describe('and there are no zero-value bills', () => {
-          it('returns to sum plus the bill run type as singular (1 Supplementary bill)', () => {
+          it('returns the sum plus the bill run type as singular (1 Supplementary bill)', () => {
             const result = ViewBillRunPresenter.go(billRun, billRunSummaries)
 
             expect(result.billsCount).to.equal('1 Supplementary bill')
@@ -68,7 +68,7 @@ describe('View Bill Run presenter', () => {
         })
 
         describe('and there are no zero-value bills', () => {
-          it('returns to sum plus the bill run type pluralised (12 Annual bills)', () => {
+          it('returns the sum plus the bill run type pluralised (12 Annual bills)', () => {
             const result = ViewBillRunPresenter.go(billRun, billRunSummaries)
 
             expect(result.billsCount).to.equal('12 Annual bills')


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4223

In testing of the new bill run view we've built a scenario was found where the count of bills we show didn't match with the number of bills on the page.

For example, the bill run had 6 credit notes and 4 invoices so we displayed "10 Supplementary bills" as the caption. But when you counted the bills listed there were 11.

We double-checked what the legacy UI was doing with this bill run and found it also displayed 6 credits and 4 invoices. But its caption was "11 supplementary bills".

Neither looks right!

After digging in we found the extra bill is a 'zero-value' bill (where the credit and debit lines have value but they cancel each other out). These don't get sent to SSCL so are not included in the credit note and invoice count.

After consultation with users, they don't want these to be included in the credit note or invoice count as this will mess up their reconciliation process. But they would like the total count to be correct. The agreed solution is that when a bill run contains zero-value bills we should extend the caption, for example, "10 Supplementary bills and 1 zero value bill".

This change implements that solution.