### PR TITLE
update back links to use new return-requirement pattern

### DIFF
--- a/app/controllers/return-requirements.controller.js
+++ b/app/controllers/return-requirements.controller.js
@@ -80,13 +80,8 @@ async function saveReturnsCheckYourAnswers (request, h) {
 }
 
 async function requirementsApproved (request, h) {
-  const { sessionId } = request.params
-
-  const session = await SessionModel.query().findById(sessionId)
-
   return h.view('return-requirements/requirements-approved.njk', {
-    activeNavBar: 'search',
-    ...session
+    activeNavBar: 'search'
   })
 }
 
@@ -106,7 +101,7 @@ async function saveNoReturnsRequired (request, h) {
 
   const session = await SessionModel.query().findById(sessionId)
 
-  return h.redirect(`/system/return-requirements/${session.id}/no-returns-check-your-answers`)
+  return h.redirect(`/system/return-requirements/${session.id}/no-return-check-your-answers`)
 }
 
 async function noReturnsCheckYourAnswers (request, h) {

--- a/app/routes/return-requirement.routes.js
+++ b/app/routes/return-requirement.routes.js
@@ -101,7 +101,7 @@ const routes = [
     }
   }, {
     method: 'GET',
-    path: '/return-requirements/{sessionId}/requirements-approved',
+    path: '/return-requirements/requirements-approved',
     handler: ReturnRequirementsController.requirementsApproved,
     options: {
       auth: {

--- a/app/views/return-requirements/add-a-note.njk
+++ b/app/views/return-requirements/add-a-note.njk
@@ -2,7 +2,7 @@
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
-{% set rootLink = "/system/licences/" + licenceId %}
+{% set rootLink = "/system/return-requirements/" + id %}
 {% block breadcrumbs %}
   {# Back link #}
   {{

--- a/app/views/return-requirements/no-return-check-your-answers.njk
+++ b/app/views/return-requirements/no-return-check-your-answers.njk
@@ -2,7 +2,7 @@
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
-{% set rootLink = "/system/licences/" + licenceId %}
+{% set rootLink = "/system/return-requirements/" + id %}
 {% block breadcrumbs %}
   {# Back link #}
   {{

--- a/app/views/return-requirements/no-returns-required.njk
+++ b/app/views/return-requirements/no-returns-required.njk
@@ -2,7 +2,7 @@
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
-{% set rootLink = "/system/licences/" + licenceId %}
+{% set rootLink = "/system/return-requirements/" + id %}
 {% block breadcrumbs %}
   {# Back link #}
   {{

--- a/app/views/return-requirements/reason.njk
+++ b/app/views/return-requirements/reason.njk
@@ -3,13 +3,13 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% set title = "Select the reason for the return requirement" %}
-{% set rootLink = "/system/licences/" + licenceId %}
+{% set rootLink = "/system/return-requirements/" + id %}
 
 {% block breadcrumbs %}
   {# Back link #}
   {{
     govukBackLink({
-      text: 'back',
+      text: 'Back',
       href: rootLink + "/"
     })
   }}

--- a/app/views/return-requirements/returns-check-your-answers.njk
+++ b/app/views/return-requirements/returns-check-your-answers.njk
@@ -2,7 +2,7 @@
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
-{% set rootLink = "/system/licences/" + licenceId %}
+{% set rootLink = "/system/return-requirements/" + id %}
 {% block breadcrumbs %}
   {# Back link #}
   {{

--- a/app/views/return-requirements/returns-how-do-you-want.njk
+++ b/app/views/return-requirements/returns-how-do-you-want.njk
@@ -1,17 +1,17 @@
 {% extends 'layout.njk' %}
-{# {% from "govuk/components/back-link/macro.njk" import govukBackLink %} #}
-{# {% from "govuk/components/button/macro.njk" import govukButton %} #}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
 
-{# {% set rootLink = "/system/licences/" + licenceId %} #}
+{% set rootLink = "/system/return-requirements/" + id %}
 
 {% block breadcrumbs %}
   {# Back link #}
-  {# {{
+  {{
     govukBackLink({
-      text: 'back',
+      text: 'Back',
       href: rootLink + "/reason"
     })
-  }} #}
+  }}
 {% endblock %}
 
 {% block content %}
@@ -20,9 +20,9 @@
     <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">How do you want to set up the return requirement?</h1>
   </div>
 
-  {# <form method="post">
+  <form method="post">
     <div class="govuk-body">
       {{ govukButton({ text: "Continue" }) }}
     </div>
-  </form> #}
+  </form>
 {% endblock %}

--- a/app/views/return-requirements/select-return-start-date.njk
+++ b/app/views/return-requirements/select-return-start-date.njk
@@ -2,7 +2,7 @@
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
-{% set rootLink = "/system/licences/" + licenceId %}
+{% set rootLink = "/system/return-requirements/" + id %}
 {% block breadcrumbs %}
   {# Back link #}
   {{

--- a/test/controllers/return-requirements.controller.test.js
+++ b/test/controllers/return-requirements.controller.test.js
@@ -112,10 +112,10 @@ describe('Return requirements controller', () => {
     })
   })
 
-  describe('GET /return-requirements/{sessionId}/requirements-approved', () => {
+  describe('GET /return-requirements/requirements-approved', () => {
     const options = {
       method: 'GET',
-      url: '/return-requirements/64924759-8142-4a08-9d1e-1e902cd9d316/requirements-approved',
+      url: '/return-requirements/requirements-approved',
       auth: {
         strategy: 'session',
         credentials: { scope: ['billing'] }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4248

Testing noticed that the back links were still pointing at the old /licence/ style urls. 

Updated all the njk files to use the new return-requirement url pattern.