### PR TITLE
remove back link from check your answer pages

### DIFF
--- a/app/views/return-requirements/no-return-check-your-answers.njk
+++ b/app/views/return-requirements/no-return-check-your-answers.njk
@@ -1,17 +1,5 @@
 {% extends 'layout.njk' %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
-
-{% set rootLink = "/system/return-requirements/" + id %}
-{% block breadcrumbs %}
-  {# Back link #}
-  {{
-    govukBackLink({
-      text: 'Back',
-      href: rootLink + "/select-return-start-date"
-    })
-  }}
-{% endblock %}
 
 {% block content %}
   {# Main heading #}

--- a/app/views/return-requirements/returns-check-your-answers.njk
+++ b/app/views/return-requirements/returns-check-your-answers.njk
@@ -1,17 +1,5 @@
 {% extends 'layout.njk' %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
-
-{% set rootLink = "/system/return-requirements/" + id %}
-{% block breadcrumbs %}
-  {# Back link #}
-  {{
-    govukBackLink({
-      text: 'Back',
-      href: rootLink + "/how-do-you-want-to-return"
-    })
-  }}
-{% endblock %}
 
 {% block content %}
   {# Main heading #}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4250

Shabbir pointed out that the check your answer pages shouldn't have back links on the as per the design on the screen shots so removing them.