### PR TITLE
Add LicenceDocumentModel from crm_v2.documents

### DIFF
--- a/app/models/licence-document.model.js
+++ b/app/models/licence-document.model.js
@@ -1,0 +1,16 @@
+'use strict'
+
+/**
+ * Model for licence_documents (crm_v2.documents)
+ * @module LicenceDocumentModel
+ */
+
+const BaseModel = require('./base.model.js')
+
+class LicenceDocumentModel extends BaseModel {
+  static get tableName () {
+    return 'licenceDocuments'
+  }
+}
+
+module.exports = LicenceDocumentModel

--- a/db/migrations/legacy/20231221145235_create-crm-v2-documents.js
+++ b/db/migrations/legacy/20231221145235_create-crm-v2-documents.js
@@ -1,0 +1,36 @@
+'use strict'
+
+const tableName = 'documents'
+
+exports.up = function (knex) {
+  return knex
+    .schema
+    .withSchema('crm_v2')
+    .createTable(tableName, (table) => {
+      // Primary Key
+      table.uuid('document_id').primary().defaultTo(knex.raw('gen_random_uuid()'))
+
+      // Data
+      table.string('regime').notNullable().defaultTo('water')
+      table.string('document_type').notNullable().defaultTo('abstraction_licence')
+      table.string('document_ref').notNullable()
+      table.date('start_date').notNullable()
+      table.date('end_date')
+      table.string('external_id')
+      table.boolean('is_test').notNullable().defaultTo(false)
+      table.timestamp('date_deleted')
+
+      // Legacy timestamps
+      table.timestamp('date_created').notNullable().defaultTo(knex.fn.now())
+      table.timestamp('date_updated').notNullable().defaultTo(knex.fn.now())
+
+      table.unique(['regime', 'document_type', 'document_ref'], { useConstraint: true })
+    })
+}
+
+exports.down = function (knex) {
+  return knex
+    .schema
+    .withSchema('crm_v2')
+    .dropTableIfExists(tableName)
+}

--- a/db/migrations/public/20231221144424_create-licence-documents-view.js
+++ b/db/migrations/public/20231221144424_create-licence-documents-view.js
@@ -1,0 +1,29 @@
+'use strict'
+
+const viewName = 'licence_documents'
+
+exports.up = function (knex) {
+  return knex
+    .schema
+    .createView(viewName, (view) => {
+      // NOTE: We have commented out unused columns from the source table
+      view.as(knex('documents').withSchema('crm_v2').select([
+        'document_id AS id',
+        // 'regime',
+        // 'document_type',
+        'document_ref AS licence_ref',
+        'start_date',
+        'end_date',
+        // 'is_test',
+        'date_deleted AS deleted_at',
+        'date_created AS created_at',
+        'date_updated AS updated_at'
+      ]))
+    })
+}
+
+exports.down = function (knex) {
+  return knex
+    .schema
+    .dropViewIfExists(viewName)
+}

--- a/test/models/licence-document.model.test.js
+++ b/test/models/licence-document.model.test.js
@@ -1,0 +1,34 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const DatabaseHelper = require('../support/helpers/database.helper.js')
+const LicenceDocumentHelper = require('../support/helpers/licence-document.helper.js')
+
+// Thing under test
+const LicenceDocumentModel = require('../../app/models/licence-document.model.js')
+
+describe.only('Licence Document model', () => {
+  let testRecord
+
+  beforeEach(async () => {
+    await DatabaseHelper.clean()
+
+    testRecord = await LicenceDocumentHelper.add()
+  })
+
+  describe('Basic query', () => {
+    it('can successfully run a basic query', async () => {
+      const result = await LicenceDocumentModel.query().findById(testRecord.id)
+
+      expect(result).to.be.an.instanceOf(LicenceDocumentModel)
+      expect(result.id).to.equal(testRecord.id)
+    })
+  })
+})

--- a/test/models/licence-document.model.test.js
+++ b/test/models/licence-document.model.test.js
@@ -14,7 +14,7 @@ const LicenceDocumentHelper = require('../support/helpers/licence-document.helpe
 // Thing under test
 const LicenceDocumentModel = require('../../app/models/licence-document.model.js')
 
-describe.only('Licence Document model', () => {
+describe('Licence Document model', () => {
   let testRecord
 
   beforeEach(async () => {

--- a/test/support/helpers/licence-document.helper.js
+++ b/test/support/helpers/licence-document.helper.js
@@ -1,0 +1,53 @@
+'use strict'
+
+/**
+ * @module LicenceDocumentHelper
+ */
+
+const { generateLicenceRef } = require('./licence.helper.js')
+const LicenceDocumentModel = require('../../../app/models/licence-document.model.js')
+
+/**
+ * Add a new licence document
+ *
+ * If no `data` is provided, default values will be used. These are
+ *
+ * - `licenceRef` - [randomly generated - 01/123]
+ * - `startDate` - new Date('2022-01-01')
+ *
+ * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ *
+ * @returns {module:LicenceDocumentModel} The instance of the newly created record
+ */
+async function add (data = {}) {
+  const insertData = defaults(data)
+
+  return LicenceDocumentModel.query()
+    .insert({ ...insertData })
+    .returning('*')
+}
+
+/**
+ * Returns the defaults used when creating a new licence
+ *
+ * It will override or append to them any data provided. Mainly used by the `add()` method, we make it available
+ * for use in tests to avoid having to duplicate values.
+ *
+ * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ */
+function defaults (data = {}) {
+  const defaults = {
+    licenceRef: generateLicenceRef(),
+    startDate: new Date('2022-01-01')
+  }
+
+  return {
+    ...defaults,
+    ...data
+  }
+}
+
+module.exports = {
+  add,
+  defaults
+}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4292

> This is part of a series of changes to add the ability to identify the licence holder for a licence

This change adds the migration, model, test helper and unit tests for a new `LicenceDocumentModel`.

TBH, it is a pointless model! This seems to be a bridge between the `water.licences` table we now have and the `crm.document` that was created back when the idea was to have a generic 'repository' for all types of documents, not just water abstraction licences. We know the schema `crm_v2` is the result of an incomplete attempt to move away from that idea. But for whatever reason, rather than link the `water.licences` records directly to contact and company information instead the previous team stuck with the concept of a 'document'

So, we need to add this model to then be able to identify the relevant `crm_v2.document_roles` records we need, to find the current licence holder! 🥳😩