### PR TITLE
Add LicenceRoleModel from crm_v2.roles

### DIFF
--- a/app/models/licence-role.model.js
+++ b/app/models/licence-role.model.js
@@ -1,0 +1,16 @@
+'use strict'
+
+/**
+ * Model for licence_roles (crm_v2.roles)
+ * @module LicenceRoleModel
+ */
+
+const BaseModel = require('./base.model.js')
+
+class LicenceRoleModel extends BaseModel {
+  static get tableName () {
+    return 'licenceRoles'
+  }
+}
+
+module.exports = LicenceRoleModel

--- a/db/migrations/legacy/20240103123926_create-crm-v2-roles.js
+++ b/db/migrations/legacy/20240103123926_create-crm-v2-roles.js
@@ -1,0 +1,28 @@
+'use strict'
+
+const tableName = 'roles'
+
+exports.up = function (knex) {
+  return knex
+    .schema
+    .withSchema('crm_v2')
+    .createTable(tableName, (table) => {
+      // Primary Key
+      table.uuid('role_id').primary().defaultTo(knex.raw('gen_random_uuid()'))
+
+      // Data
+      table.string('name').notNullable()
+      table.string('label')
+
+      // Legacy timestamps
+      table.timestamp('date_created').notNullable().defaultTo(knex.fn.now())
+      table.timestamp('date_updated').notNullable().defaultTo(knex.fn.now())
+    })
+}
+
+exports.down = function (knex) {
+  return knex
+    .schema
+    .withSchema('crm_v2')
+    .dropTableIfExists(tableName)
+}

--- a/db/migrations/public/20240103124409_create-licence-roles-view.js
+++ b/db/migrations/public/20240103124409_create-licence-roles-view.js
@@ -1,0 +1,23 @@
+'use strict'
+
+const viewName = 'licence_roles'
+
+exports.up = function (knex) {
+  return knex
+    .schema
+    .createView(viewName, (view) => {
+      view.as(knex('roles').withSchema('crm_v2').select([
+        'role_id AS id',
+        'name',
+        'label',
+        'date_created AS created_at',
+        'date_updated AS updated_at'
+      ]))
+    })
+}
+
+exports.down = function (knex) {
+  return knex
+    .schema
+    .dropViewIfExists(viewName)
+}

--- a/test/models/licence-role.model.test.js
+++ b/test/models/licence-role.model.test.js
@@ -1,0 +1,34 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const DatabaseHelper = require('../support/helpers/database.helper.js')
+const LicenceRoleHelper = require('../support/helpers/licence-role.helper.js')
+
+// Thing under test
+const LicenceRoleModel = require('../../app/models/licence-role.model.js')
+
+describe('Licence Role model', () => {
+  let testRecord
+
+  beforeEach(async () => {
+    await DatabaseHelper.clean()
+
+    testRecord = await LicenceRoleHelper.add()
+  })
+
+  describe('Basic query', () => {
+    it('can successfully run a basic query', async () => {
+      const result = await LicenceRoleModel.query().findById(testRecord.id)
+
+      expect(result).to.be.an.instanceOf(LicenceRoleModel)
+      expect(result.id).to.equal(testRecord.id)
+    })
+  })
+})

--- a/test/support/helpers/licence-role.helper.js
+++ b/test/support/helpers/licence-role.helper.js
@@ -1,0 +1,52 @@
+'use strict'
+
+/**
+ * @module LicenceRoleHelper
+ */
+
+const LicenceRoleModel = require('../../../app/models/licence-role.model.js')
+
+/**
+ * Add a new licence role
+ *
+ * If no `data` is provided, default values will be used. These are
+ *
+ * - `name` - licenceHolder
+ * - `label` - Licence Holder
+ *
+ * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ *
+ * @returns {module:LicenceRoleModel} The instance of the newly created record
+ */
+async function add (data = {}) {
+  const insertData = defaults(data)
+
+  return LicenceRoleModel.query()
+    .insert({ ...insertData })
+    .returning('*')
+}
+
+/**
+ * Returns the defaults used
+ *
+ * It will override or append to them any data provided. Mainly used by the `add()` method, we make it available
+ * for use in tests to avoid having to duplicate values.
+ *
+ * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ */
+function defaults (data = {}) {
+  const defaults = {
+    name: 'licenceHolder',
+    label: 'Licence Holder'
+  }
+
+  return {
+    ...defaults,
+    ...data
+  }
+}
+
+module.exports = {
+  add,
+  defaults
+}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4292

> This is part of a series of changes to add the ability to identify the licence holder for a licence

This change adds the migration, model, test helper and unit tests for a new `LicenceRoleModel`.

We've already added [LicenceDocumentModel](https://github.com/DEFRA/water-abstraction-system/pull/618). Though pointless, it's the only thing that points us to who the licence holder is. In the `crm_v2` schema it does this in `crm_v2.document_roles` which is the join table between `crm_v2.documents` and `crm_v2.roles`. `roles` is a lookup table of the 'role' a `crm_v2.contact` or `crm_c2.company` has, for example, licence holder!

So, our next step is to create a model for 'roles' so we can then get on and join them in a future model. Our first blocker though is we can't use the name `roles` and that is already taken (`RoleModel` is used for the lookup table of user roles). Hence, we're creating a new `LicenceRoleModel` in this change! 😁