### PR TITLE
Add LicenceDocumentRoleModel from document_roles

### DIFF
--- a/app/models/address.model.js
+++ b/app/models/address.model.js
@@ -23,6 +23,14 @@ class AddressModel extends BaseModel {
           from: 'addresses.id',
           to: 'billingAccountAddresses.addressId'
         }
+      },
+      licenceDocumentRoles: {
+        relation: Model.HasManyRelation,
+        modelClass: 'licence-document-role.model',
+        join: {
+          from: 'addresses.id',
+          to: 'licenceDocumentRoles.addressId'
+        }
       }
     }
   }

--- a/app/models/company.model.js
+++ b/app/models/company.model.js
@@ -63,6 +63,14 @@ class CompanyModel extends BaseModel {
           from: 'companies.id',
           to: 'billingAccounts.companyId'
         }
+      },
+      licenceDocumentRoles: {
+        relation: Model.HasManyRelation,
+        modelClass: 'licence-document-role.model',
+        join: {
+          from: 'companies.id',
+          to: 'licenceDocumentRoles.companyId'
+        }
       }
     }
   }

--- a/app/models/contact.model.js
+++ b/app/models/contact.model.js
@@ -50,6 +50,14 @@ class ContactModel extends BaseModel {
           from: 'contacts.id',
           to: 'billingAccountAddresses.contactId'
         }
+      },
+      licenceDocumentRoles: {
+        relation: Model.HasManyRelation,
+        modelClass: 'licence-document-role.model',
+        join: {
+          from: 'contacts.id',
+          to: 'licenceDocumentRoles.contactId'
+        }
       }
     }
   }

--- a/app/models/licence-document-role.model.js
+++ b/app/models/licence-document-role.model.js
@@ -23,6 +23,14 @@ class LicenceDocumentRoleModel extends BaseModel {
           from: 'licenceDocumentRoles.licenceDocumentId',
           to: 'licenceDocuments.id'
         }
+      },
+      licenceRole: {
+        relation: Model.BelongsToOneRelation,
+        modelClass: 'licence-role.model',
+        join: {
+          from: 'licenceDocumentRoles.licenceRoleId',
+          to: 'licenceRoles.id'
+        }
       }
     }
   }

--- a/app/models/licence-document-role.model.js
+++ b/app/models/licence-document-role.model.js
@@ -5,11 +5,26 @@
  * @module LicenceDocumentRoleModel
  */
 
+const { Model } = require('objection')
+
 const BaseModel = require('./base.model.js')
 
 class LicenceDocumentRoleModel extends BaseModel {
   static get tableName () {
     return 'licenceDocumentRoles'
+  }
+
+  static get relationMappings () {
+    return {
+      licenceDocument: {
+        relation: Model.BelongsToOneRelation,
+        modelClass: 'licence-document.model',
+        join: {
+          from: 'licenceDocumentRoles.licenceDocumentId',
+          to: 'licenceDocuments.id'
+        }
+      }
+    }
   }
 }
 

--- a/app/models/licence-document-role.model.js
+++ b/app/models/licence-document-role.model.js
@@ -16,6 +16,14 @@ class LicenceDocumentRoleModel extends BaseModel {
 
   static get relationMappings () {
     return {
+      address: {
+        relation: Model.BelongsToOneRelation,
+        modelClass: 'address.model',
+        join: {
+          from: 'licenceDocumentRoles.addressId',
+          to: 'addresses.id'
+        }
+      },
       licenceDocument: {
         relation: Model.BelongsToOneRelation,
         modelClass: 'licence-document.model',

--- a/app/models/licence-document-role.model.js
+++ b/app/models/licence-document-role.model.js
@@ -32,6 +32,14 @@ class LicenceDocumentRoleModel extends BaseModel {
           to: 'companies.id'
         }
       },
+      contact: {
+        relation: Model.BelongsToOneRelation,
+        modelClass: 'contact.model',
+        join: {
+          from: 'licenceDocumentRoles.contactId',
+          to: 'contacts.id'
+        }
+      },
       licenceDocument: {
         relation: Model.BelongsToOneRelation,
         modelClass: 'licence-document.model',

--- a/app/models/licence-document-role.model.js
+++ b/app/models/licence-document-role.model.js
@@ -1,0 +1,16 @@
+'use strict'
+
+/**
+ * Model for licence_document_roles (crm_v2.document_roles)
+ * @module LicenceDocumentRoleModel
+ */
+
+const BaseModel = require('./base.model.js')
+
+class LicenceDocumentRoleModel extends BaseModel {
+  static get tableName () {
+    return 'licenceDocumentRoles'
+  }
+}
+
+module.exports = LicenceDocumentRoleModel

--- a/app/models/licence-document-role.model.js
+++ b/app/models/licence-document-role.model.js
@@ -24,6 +24,14 @@ class LicenceDocumentRoleModel extends BaseModel {
           to: 'addresses.id'
         }
       },
+      company: {
+        relation: Model.BelongsToOneRelation,
+        modelClass: 'company.model',
+        join: {
+          from: 'licenceDocumentRoles.companyId',
+          to: 'companies.id'
+        }
+      },
       licenceDocument: {
         relation: Model.BelongsToOneRelation,
         modelClass: 'licence-document.model',

--- a/app/models/licence-document.model.js
+++ b/app/models/licence-document.model.js
@@ -5,11 +5,26 @@
  * @module LicenceDocumentModel
  */
 
+const { Model } = require('objection')
+
 const BaseModel = require('./base.model.js')
 
 class LicenceDocumentModel extends BaseModel {
   static get tableName () {
     return 'licenceDocuments'
+  }
+
+  static get relationMappings () {
+    return {
+      licenceDocumentRoles: {
+        relation: Model.HasManyRelation,
+        modelClass: 'licence-document-role.model',
+        join: {
+          from: 'licenceDocuments.id',
+          to: 'licenceDocumentRoles.licenceDocumentId'
+        }
+      }
+    }
   }
 }
 

--- a/app/models/licence-role.model.js
+++ b/app/models/licence-role.model.js
@@ -5,11 +5,26 @@
  * @module LicenceRoleModel
  */
 
+const { Model } = require('objection')
+
 const BaseModel = require('./base.model.js')
 
 class LicenceRoleModel extends BaseModel {
   static get tableName () {
     return 'licenceRoles'
+  }
+
+  static get relationMappings () {
+    return {
+      licenceDocumentRoles: {
+        relation: Model.HasManyRelation,
+        modelClass: 'licence-document-role.model',
+        join: {
+          from: 'licenceRoles.id',
+          to: 'licenceDocumentRoles.licenceRoleId'
+        }
+      }
+    }
   }
 }
 

--- a/db/migrations/legacy/20240103145832_create-crm-v2-document-roles.js
+++ b/db/migrations/legacy/20240103145832_create-crm-v2-document-roles.js
@@ -1,0 +1,48 @@
+'use strict'
+
+const tableName = 'document_roles'
+
+exports.up = function (knex) {
+  return knex
+    .schema
+    .withSchema('crm_v2')
+    .createTable(tableName, (table) => {
+      // Primary Key
+      table.uuid('document_role_id').primary().defaultTo(knex.raw('gen_random_uuid()'))
+
+      // Data
+      table.uuid('document_id').notNullable()
+      table.uuid('company_id')
+      table.uuid('contact_id')
+      table.uuid('address_id')
+      table.uuid('role_id').notNullable()
+      table.date('start_date').notNullable()
+      table.date('end_date')
+      table.uuid('invoice_account_id')
+      table.boolean('is_test').notNullable().defaultTo(false)
+
+      // Legacy timestamps
+      table.timestamp('date_created').notNullable().defaultTo(knex.fn.now())
+      table.timestamp('date_updated').notNullable().defaultTo(knex.fn.now())
+
+      // Constraints
+      table.unique(['document_id', 'role_id', 'start_date'], { useConstraint: true })
+    })
+    // If it was a simple check constraint we could have used https://knexjs.org/guide/schema-builder.html#checks
+    // But because of the complexity of the constraint we have had to drop to using raw() to add the constraint after
+    // Knex has created the table.
+    .raw(`
+      ALTER TABLE crm_v2.document_roles
+      ADD CONSTRAINT company_or_invoice_account
+      CHECK (
+        ((company_id IS NOT NULL AND address_id IS NOT NULL) OR invoice_account_id IS NOT NULL)
+      );
+    `)
+}
+
+exports.down = function (knex) {
+  return knex
+    .schema
+    .withSchema('crm_v2')
+    .dropTableIfExists(tableName)
+}

--- a/db/migrations/public/20240103152905_create-licence-document-roles-view.js
+++ b/db/migrations/public/20240103152905_create-licence-document-roles-view.js
@@ -1,0 +1,31 @@
+'use strict'
+
+const viewName = 'licence_document_roles'
+
+exports.up = function (knex) {
+  return knex
+    .schema
+    .createView(viewName, (view) => {
+      // NOTE: We have commented out unused columns from the source table
+      view.as(knex('document_roles').withSchema('crm_v2').select([
+        'document_role_id AS id',
+        'document_id AS licence_document_id',
+        'company_id',
+        'contact_id',
+        'address_id',
+        'role_id AS licence_role_id',
+        // 'invoice_account_id',
+        'start_date',
+        'end_date',
+        // 'is_test',
+        'date_created AS created_at',
+        'date_updated AS updated_at'
+      ]))
+    })
+}
+
+exports.down = function (knex) {
+  return knex
+    .schema
+    .dropViewIfExists(viewName)
+}

--- a/test/models/address.model.test.js
+++ b/test/models/address.model.test.js
@@ -12,6 +12,8 @@ const AddressHelper = require('../support/helpers/address.helper.js')
 const BillingAccountAddressHelper = require('../support/helpers/billing-account-address.helper.js')
 const BillingAccountAddressModel = require('../../app/models/billing-account-address.model.js')
 const DatabaseHelper = require('../support/helpers/database.helper.js')
+const LicenceDocumentRoleHelper = require('../support/helpers/licence-document-role.helper.js')
+const LicenceDocumentRoleModel = require('../../app/models/licence-document-role.model.js')
 
 // Thing under test
 const AddressModel = require('../../app/models/address.model.js')
@@ -73,6 +75,43 @@ describe('Address model', () => {
         expect(result.billingAccountAddresses[0]).to.be.an.instanceOf(BillingAccountAddressModel)
         expect(result.billingAccountAddresses).to.include(testBillingAccountAddresses[0])
         expect(result.billingAccountAddresses).to.include(testBillingAccountAddresses[1])
+      })
+    })
+
+    describe('when linking to licence document roles', () => {
+      let testLicenceDocumentRoles
+
+      beforeEach(async () => {
+        testRecord = await AddressHelper.add()
+
+        const { id: addressId } = testRecord
+
+        testLicenceDocumentRoles = []
+        for (let i = 0; i < 2; i++) {
+          const licenceDocumentRole = await LicenceDocumentRoleHelper.add({ addressId })
+          testLicenceDocumentRoles.push(licenceDocumentRole)
+        }
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await AddressModel.query()
+          .innerJoinRelated('licenceDocumentRoles')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the licence document roles', async () => {
+        const result = await AddressModel.query()
+          .findById(testRecord.id)
+          .withGraphFetched('licenceDocumentRoles')
+
+        expect(result).to.be.instanceOf(AddressModel)
+        expect(result.id).to.equal(testRecord.id)
+
+        expect(result.licenceDocumentRoles).to.be.an.array()
+        expect(result.licenceDocumentRoles[0]).to.be.an.instanceOf(LicenceDocumentRoleModel)
+        expect(result.licenceDocumentRoles).to.include(testLicenceDocumentRoles[0])
+        expect(result.licenceDocumentRoles).to.include(testLicenceDocumentRoles[1])
       })
     })
   })

--- a/test/models/company.model.test.js
+++ b/test/models/company.model.test.js
@@ -14,6 +14,8 @@ const BillingAccountHelper = require('../support/helpers/billing-account.helper.
 const BillingAccountModel = require('../../app/models/billing-account.model.js')
 const CompanyHelper = require('../support/helpers/company.helper.js')
 const DatabaseHelper = require('../support/helpers/database.helper.js')
+const LicenceDocumentRoleHelper = require('../support/helpers/licence-document-role.helper.js')
+const LicenceDocumentRoleModel = require('../../app/models/licence-document-role.model.js')
 
 // Thing under test
 const CompanyModel = require('../../app/models/company.model.js')
@@ -111,6 +113,43 @@ describe('Company model', () => {
         expect(result.billingAccounts[0]).to.be.an.instanceOf(BillingAccountModel)
         expect(result.billingAccounts).to.include(testBillingAccounts[0])
         expect(result.billingAccounts).to.include(testBillingAccounts[1])
+      })
+    })
+
+    describe('when linking to licence document roles', () => {
+      let testLicenceDocumentRoles
+
+      beforeEach(async () => {
+        testRecord = await CompanyHelper.add()
+
+        const { id: companyId } = testRecord
+
+        testLicenceDocumentRoles = []
+        for (let i = 0; i < 2; i++) {
+          const licenceDocumentRole = await LicenceDocumentRoleHelper.add({ companyId })
+          testLicenceDocumentRoles.push(licenceDocumentRole)
+        }
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await CompanyModel.query()
+          .innerJoinRelated('licenceDocumentRoles')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the licence document roles', async () => {
+        const result = await CompanyModel.query()
+          .findById(testRecord.id)
+          .withGraphFetched('licenceDocumentRoles')
+
+        expect(result).to.be.instanceOf(CompanyModel)
+        expect(result.id).to.equal(testRecord.id)
+
+        expect(result.licenceDocumentRoles).to.be.an.array()
+        expect(result.licenceDocumentRoles[0]).to.be.an.instanceOf(LicenceDocumentRoleModel)
+        expect(result.licenceDocumentRoles).to.include(testLicenceDocumentRoles[0])
+        expect(result.licenceDocumentRoles).to.include(testLicenceDocumentRoles[1])
       })
     })
   })

--- a/test/models/contact.model.test.js
+++ b/test/models/contact.model.test.js
@@ -12,6 +12,8 @@ const BillingAccountAddressHelper = require('../support/helpers/billing-account-
 const BillingAccountAddressModel = require('../../app/models/billing-account-address.model.js')
 const ContactHelper = require('../support/helpers/contact.helper.js')
 const DatabaseHelper = require('../support/helpers/database.helper.js')
+const LicenceDocumentRoleHelper = require('../support/helpers/licence-document-role.helper.js')
+const LicenceDocumentRoleModel = require('../../app/models/licence-document-role.model.js')
 
 // Thing under test
 const ContactModel = require('../../app/models/contact.model.js')
@@ -73,6 +75,43 @@ describe('Contact model', () => {
         expect(result.billingAccountAddresses[0]).to.be.an.instanceOf(BillingAccountAddressModel)
         expect(result.billingAccountAddresses).to.include(testBillingAccountAddresses[0])
         expect(result.billingAccountAddresses).to.include(testBillingAccountAddresses[1])
+      })
+    })
+
+    describe('when linking to licence document roles', () => {
+      let testLicenceDocumentRoles
+
+      beforeEach(async () => {
+        testRecord = await ContactHelper.add()
+
+        const { id: contactId } = testRecord
+
+        testLicenceDocumentRoles = []
+        for (let i = 0; i < 2; i++) {
+          const licenceDocumentRole = await LicenceDocumentRoleHelper.add({ contactId })
+          testLicenceDocumentRoles.push(licenceDocumentRole)
+        }
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await ContactModel.query()
+          .innerJoinRelated('licenceDocumentRoles')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the licence document roles', async () => {
+        const result = await ContactModel.query()
+          .findById(testRecord.id)
+          .withGraphFetched('licenceDocumentRoles')
+
+        expect(result).to.be.instanceOf(ContactModel)
+        expect(result.id).to.equal(testRecord.id)
+
+        expect(result.licenceDocumentRoles).to.be.an.array()
+        expect(result.licenceDocumentRoles[0]).to.be.an.instanceOf(LicenceDocumentRoleModel)
+        expect(result.licenceDocumentRoles).to.include(testLicenceDocumentRoles[0])
+        expect(result.licenceDocumentRoles).to.include(testLicenceDocumentRoles[1])
       })
     })
   })

--- a/test/models/licence-document-role.model.test.js
+++ b/test/models/licence-document-role.model.test.js
@@ -1,0 +1,34 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const DatabaseHelper = require('../support/helpers/database.helper.js')
+const LicenceDocumentRoleHelper = require('../support/helpers/licence-document-role.helper.js')
+
+// Thing under test
+const LicenceDocumentRoleModel = require('../../app/models/licence-document-role.model.js')
+
+describe('Licence Document Role model', () => {
+  let testRecord
+
+  beforeEach(async () => {
+    await DatabaseHelper.clean()
+
+    testRecord = await LicenceDocumentRoleHelper.add()
+  })
+
+  describe('Basic query', () => {
+    it('can successfully run a basic query', async () => {
+      const result = await LicenceDocumentRoleModel.query().findById(testRecord.id)
+
+      expect(result).to.be.an.instanceOf(LicenceDocumentRoleModel)
+      expect(result.id).to.equal(testRecord.id)
+    })
+  })
+})

--- a/test/models/licence-document-role.model.test.js
+++ b/test/models/licence-document-role.model.test.js
@@ -12,6 +12,8 @@ const AddressHelper = require('../support/helpers/address.helper.js')
 const AddressModel = require('../../app/models/address.model.js')
 const CompanyHelper = require('../support/helpers/company.helper.js')
 const CompanyModel = require('../../app/models/company.model.js')
+const ContactHelper = require('../support/helpers/contact.helper.js')
+const ContactModel = require('../../app/models/contact.model.js')
 const DatabaseHelper = require('../support/helpers/database.helper.js')
 const LicenceDocumentHelper = require('../support/helpers/licence-document.helper.js')
 const LicenceDocumentModel = require('../../app/models/licence-document.model.js')
@@ -100,6 +102,36 @@ describe('Licence Document Role model', () => {
 
         expect(result.company).to.be.an.instanceOf(CompanyModel)
         expect(result.company).to.equal(testCompany)
+      })
+    })
+
+    describe('when linking to contact', () => {
+      let testContact
+
+      beforeEach(async () => {
+        testContact = await ContactHelper.add()
+
+        const { id: contactId } = testContact
+        testRecord = await LicenceDocumentRoleHelper.add({ contactId })
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await LicenceDocumentRoleModel.query()
+          .innerJoinRelated('contact')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the contact', async () => {
+        const result = await LicenceDocumentRoleModel.query()
+          .findById(testRecord.id)
+          .withGraphFetched('contact')
+
+        expect(result).to.be.instanceOf(LicenceDocumentRoleModel)
+        expect(result.id).to.equal(testRecord.id)
+
+        expect(result.contact).to.be.an.instanceOf(ContactModel)
+        expect(result.contact).to.equal(testContact)
       })
     })
 

--- a/test/models/licence-document-role.model.test.js
+++ b/test/models/licence-document-role.model.test.js
@@ -8,6 +8,8 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
+const AddressHelper = require('../support/helpers/address.helper.js')
+const AddressModel = require('../../app/models/address.model.js')
 const DatabaseHelper = require('../support/helpers/database.helper.js')
 const LicenceDocumentHelper = require('../support/helpers/licence-document.helper.js')
 const LicenceDocumentModel = require('../../app/models/licence-document.model.js')
@@ -39,6 +41,36 @@ describe('Licence Document Role model', () => {
   })
 
   describe('Relationships', () => {
+    describe('when linking to address', () => {
+      let testAddress
+
+      beforeEach(async () => {
+        testAddress = await AddressHelper.add()
+
+        const { id: addressId } = testAddress
+        testRecord = await LicenceDocumentRoleHelper.add({ addressId })
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await LicenceDocumentRoleModel.query()
+          .innerJoinRelated('address')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the address', async () => {
+        const result = await LicenceDocumentRoleModel.query()
+          .findById(testRecord.id)
+          .withGraphFetched('address')
+
+        expect(result).to.be.instanceOf(LicenceDocumentRoleModel)
+        expect(result.id).to.equal(testRecord.id)
+
+        expect(result.address).to.be.an.instanceOf(AddressModel)
+        expect(result.address).to.equal(testAddress)
+      })
+    })
+
     describe('when linking to licence document', () => {
       let testLicenceDocument
 

--- a/test/models/licence-document-role.model.test.js
+++ b/test/models/licence-document-role.model.test.js
@@ -10,6 +10,8 @@ const { expect } = Code
 // Test helpers
 const AddressHelper = require('../support/helpers/address.helper.js')
 const AddressModel = require('../../app/models/address.model.js')
+const CompanyHelper = require('../support/helpers/company.helper.js')
+const CompanyModel = require('../../app/models/company.model.js')
 const DatabaseHelper = require('../support/helpers/database.helper.js')
 const LicenceDocumentHelper = require('../support/helpers/licence-document.helper.js')
 const LicenceDocumentModel = require('../../app/models/licence-document.model.js')
@@ -68,6 +70,36 @@ describe('Licence Document Role model', () => {
 
         expect(result.address).to.be.an.instanceOf(AddressModel)
         expect(result.address).to.equal(testAddress)
+      })
+    })
+
+    describe('when linking to company', () => {
+      let testCompany
+
+      beforeEach(async () => {
+        testCompany = await CompanyHelper.add()
+
+        const { id: companyId } = testCompany
+        testRecord = await LicenceDocumentRoleHelper.add({ companyId })
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await LicenceDocumentRoleModel.query()
+          .innerJoinRelated('company')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the company', async () => {
+        const result = await LicenceDocumentRoleModel.query()
+          .findById(testRecord.id)
+          .withGraphFetched('company')
+
+        expect(result).to.be.instanceOf(LicenceDocumentRoleModel)
+        expect(result.id).to.equal(testRecord.id)
+
+        expect(result.company).to.be.an.instanceOf(CompanyModel)
+        expect(result.company).to.equal(testCompany)
       })
     })
 

--- a/test/models/licence-document-role.model.test.js
+++ b/test/models/licence-document-role.model.test.js
@@ -12,6 +12,8 @@ const DatabaseHelper = require('../support/helpers/database.helper.js')
 const LicenceDocumentHelper = require('../support/helpers/licence-document.helper.js')
 const LicenceDocumentModel = require('../../app/models/licence-document.model.js')
 const LicenceDocumentRoleHelper = require('../support/helpers/licence-document-role.helper.js')
+const LicenceRoleHelper = require('../support/helpers/licence-role.helper.js')
+const LicenceRoleModel = require('../../app/models/licence-role.model.js')
 
 // Thing under test
 const LicenceDocumentRoleModel = require('../../app/models/licence-document-role.model.js')
@@ -64,6 +66,36 @@ describe('Licence Document Role model', () => {
 
         expect(result.licenceDocument).to.be.an.instanceOf(LicenceDocumentModel)
         expect(result.licenceDocument).to.equal(testLicenceDocument)
+      })
+    })
+
+    describe('when linking to licence role', () => {
+      let testLicenceRole
+
+      beforeEach(async () => {
+        testLicenceRole = await LicenceRoleHelper.add()
+
+        const { id: licenceRoleId } = testLicenceRole
+        testRecord = await LicenceDocumentRoleHelper.add({ licenceRoleId })
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await LicenceDocumentRoleModel.query()
+          .innerJoinRelated('licenceRole')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the licence role', async () => {
+        const result = await LicenceDocumentRoleModel.query()
+          .findById(testRecord.id)
+          .withGraphFetched('licenceRole')
+
+        expect(result).to.be.instanceOf(LicenceDocumentRoleModel)
+        expect(result.id).to.equal(testRecord.id)
+
+        expect(result.licenceRole).to.be.an.instanceOf(LicenceRoleModel)
+        expect(result.licenceRole).to.equal(testLicenceRole)
       })
     })
   })

--- a/test/models/licence-document.model.test.js
+++ b/test/models/licence-document.model.test.js
@@ -10,6 +10,8 @@ const { expect } = Code
 // Test helpers
 const DatabaseHelper = require('../support/helpers/database.helper.js')
 const LicenceDocumentHelper = require('../support/helpers/licence-document.helper.js')
+const LicenceDocumentRoleHelper = require('../support/helpers/licence-document-role.helper.js')
+const LicenceDocumentRoleModel = require('../../app/models/licence-document-role.model.js')
 
 // Thing under test
 const LicenceDocumentModel = require('../../app/models/licence-document.model.js')
@@ -19,16 +21,57 @@ describe('Licence Document model', () => {
 
   beforeEach(async () => {
     await DatabaseHelper.clean()
-
-    testRecord = await LicenceDocumentHelper.add()
   })
 
   describe('Basic query', () => {
+    beforeEach(async () => {
+      testRecord = await LicenceDocumentHelper.add()
+    })
+
     it('can successfully run a basic query', async () => {
       const result = await LicenceDocumentModel.query().findById(testRecord.id)
 
       expect(result).to.be.an.instanceOf(LicenceDocumentModel)
       expect(result.id).to.equal(testRecord.id)
+    })
+  })
+
+  describe('Relationships', () => {
+    describe('when linking to licence document roles', () => {
+      let testLicenceDocumentRoles
+
+      beforeEach(async () => {
+        testRecord = await LicenceDocumentHelper.add()
+
+        const { id: licenceDocumentId } = testRecord
+
+        testLicenceDocumentRoles = []
+        for (let i = 0; i < 2; i++) {
+          const licenceDocumentRole = await LicenceDocumentRoleHelper.add({ licenceDocumentId })
+          testLicenceDocumentRoles.push(licenceDocumentRole)
+        }
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await LicenceDocumentModel.query()
+          .innerJoinRelated('licenceDocumentRoles')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the licence document roles', async () => {
+        const result = await LicenceDocumentModel.query()
+          .findById(testRecord.id)
+          .withGraphFetched('licenceDocumentRoles')
+
+        expect(result).to.be.instanceOf(LicenceDocumentModel)
+        expect(result.id).to.equal(testRecord.id)
+
+        expect(result.licenceDocumentRoles).to.be.an.array()
+        expect(result.licenceDocumentRoles[0]).to.be.an.instanceOf(LicenceDocumentRoleModel)
+        expect(result.licenceDocumentRoles).to.include(testLicenceDocumentRoles[0])
+        expect(result.licenceDocumentRoles).to.include(testLicenceDocumentRoles[1])
+      })
     })
   })
 })

--- a/test/models/licence-role.model.test.js
+++ b/test/models/licence-role.model.test.js
@@ -9,6 +9,8 @@ const { expect } = Code
 
 // Test helpers
 const DatabaseHelper = require('../support/helpers/database.helper.js')
+const LicenceDocumentRoleHelper = require('../support/helpers/licence-document-role.helper.js')
+const LicenceDocumentRoleModel = require('../../app/models/licence-document-role.model.js')
 const LicenceRoleHelper = require('../support/helpers/licence-role.helper.js')
 
 // Thing under test
@@ -19,16 +21,57 @@ describe('Licence Role model', () => {
 
   beforeEach(async () => {
     await DatabaseHelper.clean()
-
-    testRecord = await LicenceRoleHelper.add()
   })
 
   describe('Basic query', () => {
+    beforeEach(async () => {
+      testRecord = await LicenceRoleHelper.add()
+    })
+
     it('can successfully run a basic query', async () => {
       const result = await LicenceRoleModel.query().findById(testRecord.id)
 
       expect(result).to.be.an.instanceOf(LicenceRoleModel)
       expect(result.id).to.equal(testRecord.id)
+    })
+  })
+
+  describe('Relationships', () => {
+    describe('when linking to licence document roles', () => {
+      let testLicenceDocumentRoles
+
+      beforeEach(async () => {
+        testRecord = await LicenceRoleHelper.add()
+
+        const { id: licenceRoleId } = testRecord
+
+        testLicenceDocumentRoles = []
+        for (let i = 0; i < 2; i++) {
+          const licenceDocumentRole = await LicenceDocumentRoleHelper.add({ licenceRoleId })
+          testLicenceDocumentRoles.push(licenceDocumentRole)
+        }
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await LicenceRoleModel.query()
+          .innerJoinRelated('licenceDocumentRoles')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the licence document roles', async () => {
+        const result = await LicenceRoleModel.query()
+          .findById(testRecord.id)
+          .withGraphFetched('licenceDocumentRoles')
+
+        expect(result).to.be.instanceOf(LicenceRoleModel)
+        expect(result.id).to.equal(testRecord.id)
+
+        expect(result.licenceDocumentRoles).to.be.an.array()
+        expect(result.licenceDocumentRoles[0]).to.be.an.instanceOf(LicenceDocumentRoleModel)
+        expect(result.licenceDocumentRoles).to.include(testLicenceDocumentRoles[0])
+        expect(result.licenceDocumentRoles).to.include(testLicenceDocumentRoles[1])
+      })
     })
   })
 })

--- a/test/support/helpers/licence-document-role.helper.js
+++ b/test/support/helpers/licence-document-role.helper.js
@@ -1,0 +1,59 @@
+'use strict'
+
+/**
+ * @module LicenceDocumentHelper
+ */
+
+const { generateUUID } = require('../../../app/lib/general.lib.js')
+const LicenceDocumentRoleModel = require('../../../app/models/licence-document-role.model.js')
+
+/**
+ * Add a new licence document role
+ *
+ * If no `data` is provided, default values will be used. These are
+ *
+ * - `licenceDocumentId` - [random UUID]
+ * - `companyId` - [random UUID]
+ * - `addressId` - [random UUID]
+ * - `licenceRoleId` - [random UUID]
+ * - `startDate` - new Date('2022-01-01')
+ *
+ * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ *
+ * @returns {module:LicenceDocumentRoleModel} The instance of the newly created record
+ */
+async function add (data = {}) {
+  const insertData = defaults(data)
+
+  return LicenceDocumentRoleModel.query()
+    .insert({ ...insertData })
+    .returning('*')
+}
+
+/**
+ * Returns the defaults used
+ *
+ * It will override or append to them any data provided. Mainly used by the `add()` method, we make it available
+ * for use in tests to avoid having to duplicate values.
+ *
+ * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ */
+function defaults (data = {}) {
+  const defaults = {
+    licenceDocumentId: generateUUID(),
+    companyId: generateUUID(),
+    addressId: generateUUID(),
+    licenceRoleId: generateUUID(),
+    startDate: new Date('2022-01-01')
+  }
+
+  return {
+    ...defaults,
+    ...data
+  }
+}
+
+module.exports = {
+  add,
+  defaults
+}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4292

> This is part of a series of changes to add the ability to identify the licence holder for a licence

This change adds the migration, model, test helper and unit tests for a new `LicenceDocumentRoleModel`.

We added [LicenceDocumentModel](https://github.com/DEFRA/water-abstraction-system/pull/618). Though pointless, it's the only thing that points us to who the licence holder is. In the `crm_v2` schema it does this in `crm_v2.document_roles` which is the join table between `crm_v2.documents` and `crm_v2.roles`. `roles` is a lookup table of the 'role' a `crm_v2.contact` or `crm_c2.company` has, for example, licence holder! We added that as [LicenceRoleModel](https://github.com/DEFRA/water-abstraction-system/pull/629).

We are now on the final step which is adding the model that allows us to identify and extract the `crm_v2.document_roles` record that identifies _who_ is the current licence holder for a licence.