### PR TITLE
Add LicenceDocument relationship to LicenceModel

### DIFF
--- a/app/models/licence-document.model.js
+++ b/app/models/licence-document.model.js
@@ -16,6 +16,14 @@ class LicenceDocumentModel extends BaseModel {
 
   static get relationMappings () {
     return {
+      licence: {
+        relation: Model.BelongsToOneRelation,
+        modelClass: 'licence.model',
+        join: {
+          from: 'licenceDocuments.licenceRef',
+          to: 'licences.licenceRef'
+        }
+      },
       licenceDocumentRoles: {
         relation: Model.HasManyRelation,
         modelClass: 'licence-document-role.model',

--- a/app/models/licence-document.model.js
+++ b/app/models/licence-document.model.js
@@ -9,6 +9,22 @@ const { Model } = require('objection')
 
 const BaseModel = require('./base.model.js')
 
+/**
+ * Represents an instance of a licence document record
+ *
+ * For reference, the licence document record is a 'nothing' record! It doesn't hold anything not already stored in
+ * other licences. We only need to reference it in order to identify the companies and contacts linked to a licence, for
+ * example, who the licence holder is. That information is held in `licence_document_roles`, and `licence_documents`
+ * is the joining table between `licences` and it.
+ *
+ * We think the reason for the table being there is because of the previous teams attempts to refactor the `crm` schema.
+ * Hence, we have `crm` and `crm_v2` in the DB. The `crm` schema is heavily linked to the `permit` schema and the idea
+ * of a generic 'permit repository', which would be used to hold all sorts of permits and licences. This is also the
+ * source of the generic name 'documents' for things like a licence.
+ *
+ * So, `licence_documents` is a less detailed copy of `licences` but with a different ID. We can't have two tables
+ * called `licences`, nor can we think of a better name. So, LicenceDocument it is! ¯\_(ツ)_/¯
+ */
 class LicenceDocumentModel extends BaseModel {
   static get tableName () {
     return 'licenceDocuments'

--- a/app/models/licence.model.js
+++ b/app/models/licence.model.js
@@ -16,22 +16,6 @@ class LicenceModel extends BaseModel {
 
   static get relationMappings () {
     return {
-      chargeVersions: {
-        relation: Model.HasManyRelation,
-        modelClass: 'charge-version.model',
-        join: {
-          from: 'licences.id',
-          to: 'chargeVersions.licenceId'
-        }
-      },
-      region: {
-        relation: Model.BelongsToOneRelation,
-        modelClass: 'region.model',
-        join: {
-          from: 'licences.regionId',
-          to: 'regions.id'
-        }
-      },
       billLicences: {
         relation: Model.HasManyRelation,
         modelClass: 'bill-licence.model',
@@ -40,12 +24,12 @@ class LicenceModel extends BaseModel {
           to: 'billLicences.licenceId'
         }
       },
-      workflows: {
+      chargeVersions: {
         relation: Model.HasManyRelation,
-        modelClass: 'workflow.model',
+        modelClass: 'charge-version.model',
         join: {
           from: 'licences.id',
-          to: 'workflows.licenceId'
+          to: 'chargeVersions.licenceId'
         }
       },
       licenceDocument: {
@@ -62,6 +46,22 @@ class LicenceModel extends BaseModel {
         join: {
           from: 'licences.id',
           to: 'licenceVersions.licenceId'
+        }
+      },
+      region: {
+        relation: Model.BelongsToOneRelation,
+        modelClass: 'region.model',
+        join: {
+          from: 'licences.regionId',
+          to: 'regions.id'
+        }
+      },
+      workflows: {
+        relation: Model.HasManyRelation,
+        modelClass: 'workflow.model',
+        join: {
+          from: 'licences.id',
+          to: 'workflows.licenceId'
         }
       }
     }

--- a/app/models/licence.model.js
+++ b/app/models/licence.model.js
@@ -48,6 +48,14 @@ class LicenceModel extends BaseModel {
           to: 'workflows.licenceId'
         }
       },
+      licenceDocument: {
+        relation: Model.BelongsToOneRelation,
+        modelClass: 'licence-document.model',
+        join: {
+          from: 'licences.licenceRef',
+          to: 'licenceDocuments.licenceRef'
+        }
+      },
       licenceVersions: {
         relation: Model.HasManyRelation,
         modelClass: 'licence-version.model',

--- a/test/models/licence-document.model.test.js
+++ b/test/models/licence-document.model.test.js
@@ -9,6 +9,8 @@ const { expect } = Code
 
 // Test helpers
 const DatabaseHelper = require('../support/helpers/database.helper.js')
+const LicenceHelper = require('../support/helpers/licence.helper.js')
+const LicenceModel = require('../../app/models/licence.model.js')
 const LicenceDocumentHelper = require('../support/helpers/licence-document.helper.js')
 const LicenceDocumentRoleHelper = require('../support/helpers/licence-document-role.helper.js')
 const LicenceDocumentRoleModel = require('../../app/models/licence-document-role.model.js')
@@ -37,6 +39,36 @@ describe('Licence Document model', () => {
   })
 
   describe('Relationships', () => {
+    describe('when linking to licence', () => {
+      let testLicence
+
+      beforeEach(async () => {
+        testLicence = await LicenceHelper.add()
+
+        const { licenceRef } = testLicence
+        testRecord = await LicenceDocumentHelper.add({ licenceRef })
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await LicenceDocumentModel.query()
+          .innerJoinRelated('licence')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the licence', async () => {
+        const result = await LicenceDocumentModel.query()
+          .findById(testRecord.id)
+          .withGraphFetched('licence')
+
+        expect(result).to.be.instanceOf(LicenceDocumentModel)
+        expect(result.id).to.equal(testRecord.id)
+
+        expect(result.licence).to.be.an.instanceOf(LicenceModel)
+        expect(result.licence).to.equal(testLicence)
+      })
+    })
+
     describe('when linking to licence document roles', () => {
       let testLicenceDocumentRoles
 

--- a/test/models/licence.model.test.js
+++ b/test/models/licence.model.test.js
@@ -14,6 +14,8 @@ const ChargeVersionHelper = require('../support/helpers/charge-version.helper.js
 const ChargeVersionModel = require('../../app/models/charge-version.model.js')
 const DatabaseHelper = require('../support/helpers/database.helper.js')
 const LicenceHelper = require('../support/helpers/licence.helper.js')
+const LicenceDocumentHelper = require('../support/helpers/licence-document.helper.js')
+const LicenceDocumentModel = require('../../app/models/licence-document.model.js')
 const LicenceVersionHelper = require('../support/helpers/licence-version.helper.js')
 const LicenceVersionModel = require('../../app/models/licence-version.model.js')
 const RegionHelper = require('../support/helpers/region.helper.js')
@@ -175,6 +177,36 @@ describe('Licence model', () => {
         expect(result.workflows[0]).to.be.an.instanceOf(WorkflowModel)
         expect(result.workflows).to.include(testWorkflows[0])
         expect(result.workflows).to.include(testWorkflows[1])
+      })
+    })
+
+    describe('when linking to licence document', () => {
+      let testLicenceDocument
+
+      beforeEach(async () => {
+        testLicenceDocument = await LicenceDocumentHelper.add()
+
+        const { licenceRef } = testLicenceDocument
+        testRecord = await LicenceHelper.add({ licenceRef })
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await LicenceModel.query()
+          .innerJoinRelated('licenceDocument')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the licence document', async () => {
+        const result = await LicenceModel.query()
+          .findById(testRecord.id)
+          .withGraphFetched('licenceDocument')
+
+        expect(result).to.be.instanceOf(LicenceModel)
+        expect(result.id).to.equal(testRecord.id)
+
+        expect(result.licenceDocument).to.be.an.instanceOf(LicenceDocumentModel)
+        expect(result.licenceDocument).to.equal(testLicenceDocument)
       })
     })
 

--- a/test/models/licence.model.test.js
+++ b/test/models/licence.model.test.js
@@ -45,71 +45,6 @@ describe('Licence model', () => {
   })
 
   describe('Relationships', () => {
-    describe('when linking to charge versions', () => {
-      let testChargeVersions
-
-      beforeEach(async () => {
-        const { id, licenceRef } = testRecord
-
-        testChargeVersions = []
-        for (let i = 0; i < 2; i++) {
-          const chargeVersion = await ChargeVersionHelper.add({ licenceRef, licenceId: id })
-          testChargeVersions.push(chargeVersion)
-        }
-      })
-
-      it('can successfully run a related query', async () => {
-        const query = await LicenceModel.query()
-          .innerJoinRelated('chargeVersions')
-
-        expect(query).to.exist()
-      })
-
-      it('can eager load the charge versions', async () => {
-        const result = await LicenceModel.query()
-          .findById(testRecord.id)
-          .withGraphFetched('chargeVersions')
-
-        expect(result).to.be.instanceOf(LicenceModel)
-        expect(result.id).to.equal(testRecord.id)
-
-        expect(result.chargeVersions).to.be.an.array()
-        expect(result.chargeVersions[0]).to.be.an.instanceOf(ChargeVersionModel)
-        expect(result.chargeVersions).to.include(testChargeVersions[0])
-        expect(result.chargeVersions).to.include(testChargeVersions[1])
-      })
-    })
-
-    describe('when linking to region', () => {
-      let testRegion
-
-      beforeEach(async () => {
-        testRegion = await RegionHelper.add()
-
-        const { id: regionId } = testRegion
-        testRecord = await LicenceHelper.add({ regionId })
-      })
-
-      it('can successfully run a related query', async () => {
-        const query = await LicenceModel.query()
-          .innerJoinRelated('region')
-
-        expect(query).to.exist()
-      })
-
-      it('can eager load the region', async () => {
-        const result = await LicenceModel.query()
-          .findById(testRecord.id)
-          .withGraphFetched('region')
-
-        expect(result).to.be.instanceOf(LicenceModel)
-        expect(result.id).to.equal(testRecord.id)
-
-        expect(result.region).to.be.an.instanceOf(RegionModel)
-        expect(result.region).to.equal(testRegion)
-      })
-    })
-
     describe('when linking to bill licences', () => {
       let testBillLicences
 
@@ -145,38 +80,38 @@ describe('Licence model', () => {
       })
     })
 
-    describe('when linking to workflows', () => {
-      let testWorkflows
+    describe('when linking to charge versions', () => {
+      let testChargeVersions
 
       beforeEach(async () => {
-        const { id } = testRecord
+        const { id, licenceRef } = testRecord
 
-        testWorkflows = []
+        testChargeVersions = []
         for (let i = 0; i < 2; i++) {
-          const workflow = await WorkflowHelper.add({ licenceId: id })
-          testWorkflows.push(workflow)
+          const chargeVersion = await ChargeVersionHelper.add({ licenceRef, licenceId: id })
+          testChargeVersions.push(chargeVersion)
         }
       })
 
       it('can successfully run a related query', async () => {
         const query = await LicenceModel.query()
-          .innerJoinRelated('workflows')
+          .innerJoinRelated('chargeVersions')
 
         expect(query).to.exist()
       })
 
-      it('can eager load the workflows', async () => {
+      it('can eager load the charge versions', async () => {
         const result = await LicenceModel.query()
           .findById(testRecord.id)
-          .withGraphFetched('workflows')
+          .withGraphFetched('chargeVersions')
 
         expect(result).to.be.instanceOf(LicenceModel)
         expect(result.id).to.equal(testRecord.id)
 
-        expect(result.workflows).to.be.an.array()
-        expect(result.workflows[0]).to.be.an.instanceOf(WorkflowModel)
-        expect(result.workflows).to.include(testWorkflows[0])
-        expect(result.workflows).to.include(testWorkflows[1])
+        expect(result.chargeVersions).to.be.an.array()
+        expect(result.chargeVersions[0]).to.be.an.instanceOf(ChargeVersionModel)
+        expect(result.chargeVersions).to.include(testChargeVersions[0])
+        expect(result.chargeVersions).to.include(testChargeVersions[1])
       })
     })
 
@@ -242,6 +177,71 @@ describe('Licence model', () => {
         expect(result.licenceVersions[0]).to.be.an.instanceOf(LicenceVersionModel)
         expect(result.licenceVersions).to.include(testLicenceVersions[0])
         expect(result.licenceVersions).to.include(testLicenceVersions[1])
+      })
+    })
+
+    describe('when linking to region', () => {
+      let testRegion
+
+      beforeEach(async () => {
+        testRegion = await RegionHelper.add()
+
+        const { id: regionId } = testRegion
+        testRecord = await LicenceHelper.add({ regionId })
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await LicenceModel.query()
+          .innerJoinRelated('region')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the region', async () => {
+        const result = await LicenceModel.query()
+          .findById(testRecord.id)
+          .withGraphFetched('region')
+
+        expect(result).to.be.instanceOf(LicenceModel)
+        expect(result.id).to.equal(testRecord.id)
+
+        expect(result.region).to.be.an.instanceOf(RegionModel)
+        expect(result.region).to.equal(testRegion)
+      })
+    })
+
+    describe('when linking to workflows', () => {
+      let testWorkflows
+
+      beforeEach(async () => {
+        const { id } = testRecord
+
+        testWorkflows = []
+        for (let i = 0; i < 2; i++) {
+          const workflow = await WorkflowHelper.add({ licenceId: id })
+          testWorkflows.push(workflow)
+        }
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await LicenceModel.query()
+          .innerJoinRelated('workflows')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the workflows', async () => {
+        const result = await LicenceModel.query()
+          .findById(testRecord.id)
+          .withGraphFetched('workflows')
+
+        expect(result).to.be.instanceOf(LicenceModel)
+        expect(result.id).to.equal(testRecord.id)
+
+        expect(result.workflows).to.be.an.array()
+        expect(result.workflows[0]).to.be.an.instanceOf(WorkflowModel)
+        expect(result.workflows).to.include(testWorkflows[0])
+        expect(result.workflows).to.include(testWorkflows[1])
       })
     })
   })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4292

> This is part of a series of changes to add the ability to identify the licence holder for a licence

This change adds the migration, model, test helper and unit tests for a new `LicenceDocumentRoleModel`.

We added [LicenceDocumentModel](https://github.com/DEFRA/water-abstraction-system/pull/618). Though pointless, it's the only thing that points us to who the licence holder is. We then added [LicenceRoleModel](https://github.com/DEFRA/water-abstraction-system/pull/629) and [LicenceDocumentRoleModel](https://github.com/DEFRA/water-abstraction-system/pull/630) which in combination with `LicenceDocumentModel` will give us the licence holder.

But we intend to work with `LicenceModel` instances. `LicenceDocumentModel` is just a really, _really_ cut down copy of the licence record which the previous team added for 'reasons'. So, this last change before we can get on and identify the licence holder is to set up the relationship between `LicenceModel` and `LicenceDocumentModel`.