### PR TITLE
Fix missing bill in view bill run screen

### DIFF
--- a/app/services/bill-runs/fetch-bill-run.service.js
+++ b/app/services/bill-runs/fetch-bill-run.service.js
@@ -108,7 +108,7 @@ async function _fetchBillSummaries (id) {
     .from('bills AS bi')
     .innerJoin('billing_accounts AS ia', 'ia.id', 'bi.billing_account_id')
     .innerJoin('companies AS c', 'c.id', 'ia.company_id')
-    .innerJoin(
+    .leftJoin(
       'billing_account_addresses AS iaa',
       function () {
         this.on('iaa.billing_account_id', '=', 'ia.id').andOnNull('iaa.end_date')

--- a/app/services/bill-runs/fetch-bill-run.service.js
+++ b/app/services/bill-runs/fetch-bill-run.service.js
@@ -108,7 +108,7 @@ async function _fetchBillSummaries (id) {
     .from('bills AS bi')
     .innerJoin('billing_accounts AS ia', 'ia.id', 'bi.billing_account_id')
     .innerJoin('companies AS c', 'c.id', 'ia.company_id')
-    .leftJoin(
+    .innerJoin(
       'billing_account_addresses AS iaa',
       function () {
         this.on('iaa.billing_account_id', '=', 'ia.id').andOnNull('iaa.end_date')

--- a/test/services/bill-runs/fetch-bill-run.service.test.js
+++ b/test/services/bill-runs/fetch-bill-run.service.test.js
@@ -69,14 +69,10 @@ describe('Fetch Bill Run service', () => {
     // We don't care about the address in our service. But it's a required field when creating a BillingAccountAddress
     const address = await AddressHelper.add()
 
-    // Create a BillingAccountAddress for each BillingAccount we created. On the second one we set the optional agent
+    // Create a BillingAccountAddress for just one BillingAccount. This is to cater for billing accounts that don't
+    // have BillingAccountAddress record (something we found in testing!) For the one we create set the optional agent
     // company we prepared earlier
     await Promise.all([
-      BillingAccountAddressHelper.add({
-        billingAccountId: linkedBillingAccounts[0].id,
-        addressId: address.id
-
-      }),
       BillingAccountAddressHelper.add({
         billingAccountId: linkedBillingAccounts[1].id,
         addressId: address.id,

--- a/test/services/bill-runs/fetch-bill-run.service.test.js
+++ b/test/services/bill-runs/fetch-bill-run.service.test.js
@@ -74,6 +74,10 @@ describe('Fetch Bill Run service', () => {
     // company we prepared earlier
     await Promise.all([
       BillingAccountAddressHelper.add({
+        billingAccountId: linkedBillingAccounts[0].id,
+        addressId: address.id
+      }),
+      BillingAccountAddressHelper.add({
         billingAccountId: linkedBillingAccounts[1].id,
         addressId: address.id,
         companyId: linkedCompanies[2].id


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4223

We are replacing the legacy bill run view with one we have developed in this project. During testing, it was found that there are examples of bill runs where a bill is missing from the view. When we checked the legacy version the bill was present so this is an issue just in our version of the page.

This change fixes the feature to ensure all bills are displayed in the view as expected.