### PR TITLE
Add licence ref. and holder to rtn. req. session

### DIFF
--- a/app/controllers/licences.controller.js
+++ b/app/controllers/licences.controller.js
@@ -10,9 +10,9 @@ const InitiateReturnRequirementSessionService = require('../services/return-requ
 async function noReturnsRequired (request, h) {
   const { id } = request.params
 
-  const sessionId = await InitiateReturnRequirementSessionService.go(id)
+  const session = await InitiateReturnRequirementSessionService.go(id)
 
-  return h.redirect(`/system/return-requirements/${sessionId}/select-return-start-date`)
+  return h.redirect(`/system/return-requirements/${session.id}/select-return-start-date`)
 }
 
 module.exports = {

--- a/app/controllers/licences.controller.js
+++ b/app/controllers/licences.controller.js
@@ -5,19 +5,14 @@
  * @module LicencesController
  */
 
-const SessionModel = require('../models/session.model.js')
+const InitiateReturnRequirementSessionService = require('../services/return-requirements/initiate-return-requirement-session.service.js')
 
 async function noReturnsRequired (request, h) {
   const { id } = request.params
 
-  const data = { licenceId: id }
-  const session = await SessionModel.query()
-    .insert({
-      data
-    })
-    .returning('*')
+  const sessionId = await InitiateReturnRequirementSessionService.go(id)
 
-  return h.redirect(`/system/return-requirements/${session.id}/select-return-start-date`)
+  return h.redirect(`/system/return-requirements/${sessionId}/select-return-start-date`)
 }
 
 module.exports = {

--- a/app/services/return-requirements/initiate-return-requirement-session.service.js
+++ b/app/services/return-requirements/initiate-return-requirement-session.service.js
@@ -22,16 +22,14 @@ const SessionModel = require('../../models/session.model.js')
  *
  * @param {String} licenceId - the ID of the licence the return requirement will be created for
  *
- * @returns {String} the ID of the newly created session record
+ * @returns {module:SessionModel} the newly created session record
  */
 async function go (licenceId) {
   const licence = await _fetchLicence(licenceId)
 
   const data = _data(licence)
 
-  const sessionId = await _createSession(data)
-
-  return sessionId
+  return _createSession(data)
 }
 
 async function _createSession (data) {
@@ -41,7 +39,7 @@ async function _createSession (data) {
     })
     .returning('*')
 
-  return session.id
+  return session
 }
 
 function _data (licence) {

--- a/app/services/return-requirements/initiate-return-requirement-session.service.js
+++ b/app/services/return-requirements/initiate-return-requirement-session.service.js
@@ -28,6 +28,7 @@ async function go (licenceId) {
   const licence = await _fetchLicence(licenceId)
 
   const data = _data(licence)
+  console.log('🚀 ~ file: initiate-return-requirement-session.service.js:31 ~ go ~ data:', data)
 
   const sessionId = await _createSession(data)
 
@@ -77,7 +78,7 @@ async function _fetchLicence (licenceId) {
         ])
         .innerJoinRelated('licenceRole')
         .where('licenceRole.name', 'licenceHolder')
-        .orderBy('licenceDocumentRoles.createdAt', 'desc')
+        .orderBy('licenceDocumentRoles.startDate', 'desc')
     })
     .withGraphFetched('licenceDocument.licenceDocumentRoles.company')
     .modifyGraph('licenceDocument.licenceDocumentRoles.company', (builder) => {
@@ -112,7 +113,7 @@ async function _fetchLicence (licenceId) {
 
 function _licenceHolder (licenceDocument) {
   // Extract the company and contact from the last licenceDocumentRole created. _fetchLicence() ensures in the case
-  // that there is more than one that they are ordered by their created date
+  // that there is more than one that they are ordered by their start date (DESC)
   const { company, contact } = licenceDocument.licenceDocumentRoles[0]
 
   if (contact) {

--- a/app/services/return-requirements/initiate-return-requirement-session.service.js
+++ b/app/services/return-requirements/initiate-return-requirement-session.service.js
@@ -5,6 +5,7 @@
  * @module InitiateReturnRequirementSessionService
  */
 
+const LicenceModel = require('../../../app/models/licence.model.js')
 const SessionModel = require('../../models/session.model.js')
 
 /**
@@ -40,8 +41,13 @@ async function _createSession (data) {
 }
 
 async function _licenceDetails (licenceId) {
+  const licence = await LicenceModel.query()
+    .findById(licenceId)
+    .select('licenceRef')
+
   return {
-    licenceId
+    licenceId,
+    licenceRef: licence.licenceRef
   }
 }
 

--- a/app/services/return-requirements/initiate-return-requirement-session.service.js
+++ b/app/services/return-requirements/initiate-return-requirement-session.service.js
@@ -21,7 +21,7 @@ const SessionModel = require('../../models/session.model.js')
  *
  * @param {String} licenceId - the ID of the licence the return requirement will be created for
  *
- * @returns {StringId} the ID of the newly created session record
+ * @returns {String} the ID of the newly created session record
  */
 async function go (licenceId) {
   const licence = await _fetchLicence(licenceId)

--- a/app/services/return-requirements/initiate-return-requirement-session.service.js
+++ b/app/services/return-requirements/initiate-return-requirement-session.service.js
@@ -7,7 +7,6 @@
 
 const Boom = require('@hapi/boom')
 
-const { db } = require('../../../db/db.js')
 const LicenceModel = require('../../../app/models/licence.model.js')
 const SessionModel = require('../../models/session.model.js')
 
@@ -27,11 +26,8 @@ const SessionModel = require('../../models/session.model.js')
  */
 async function go (licenceId) {
   const licence = await _fetchLicence(licenceId)
-  console.log('🚀 ~ file: initiate-return-requirement-session.service.js:30 ~ go:', licence)
-  console.log('🚀 ~ file: initiate-return-requirement-session.service.js:31 ~ go:', licence.licenceDocument)
 
   const data = _data(licence)
-  console.log('🚀 ~ file: initiate-return-requirement-session.service.js:34 ~ go ~ data:', data)
 
   const sessionId = await _createSession(data)
 
@@ -115,8 +111,8 @@ async function _fetchLicence (licenceId) {
 }
 
 function _licenceHolder (licenceDocument) {
-  // Extract the company and contact from the last licenceDocumentRole created. fetchLicence() ensures in the case that
-  // there is more than one that they are ordered by their created date
+  // Extract the company and contact from the last licenceDocumentRole created. _fetchLicence() ensures in the case
+  // that there is more than one that they are ordered by their created date
   const { company, contact } = licenceDocument.licenceDocumentRoles[0]
 
   if (contact) {

--- a/app/services/return-requirements/initiate-return-requirement-session.service.js
+++ b/app/services/return-requirements/initiate-return-requirement-session.service.js
@@ -1,0 +1,43 @@
+'use strict'
+
+/**
+ * Initiates the session record used for setting up a new return requirement
+ * @module InitiateReturnRequirementSessionService
+ */
+
+const SessionModel = require('../../models/session.model.js')
+
+/**
+ * Initiates the session record using for setting up a new return requirement
+ *
+ * During the setup journey for a new return requirement we temporarily store the data in a `SessionModel` instance. It
+ * is expected that on each page of the journey the GET will fetch the session record and use it to populate the view.
+ * When the page is submitted the session record will be updated with the next piece of data.
+ *
+ * At the end when the journey is complete the data from the session will be used to create the return requirement and
+ * the session record itself deleted.
+ *
+ * @param {String} licenceId - the ID of the licence the return requirement will be created for
+ *
+ * @returns {StringId} the ID of the newly created session record
+ */
+async function go (licenceId) {
+  const data = { licenceId }
+  const sessionId = await _createSession(data)
+
+  return sessionId
+}
+
+async function _createSession (data) {
+  const session = await SessionModel.query()
+    .insert({
+      data
+    })
+    .returning('*')
+
+  return session.id
+}
+
+module.exports = {
+  go
+}

--- a/app/services/return-requirements/initiate-return-requirement-session.service.js
+++ b/app/services/return-requirements/initiate-return-requirement-session.service.js
@@ -22,7 +22,8 @@ const SessionModel = require('../../models/session.model.js')
  * @returns {StringId} the ID of the newly created session record
  */
 async function go (licenceId) {
-  const data = { licenceId }
+  const data = { licence: await _licenceDetails(licenceId) }
+
   const sessionId = await _createSession(data)
 
   return sessionId
@@ -36,6 +37,12 @@ async function _createSession (data) {
     .returning('*')
 
   return session.id
+}
+
+async function _licenceDetails (licenceId) {
+  return {
+    licenceId
+  }
 }
 
 module.exports = {

--- a/app/services/return-requirements/initiate-return-requirement-session.service.js
+++ b/app/services/return-requirements/initiate-return-requirement-session.service.js
@@ -28,7 +28,6 @@ async function go (licenceId) {
   const licence = await _fetchLicence(licenceId)
 
   const data = _data(licence)
-  console.log('🚀 ~ file: initiate-return-requirement-session.service.js:31 ~ go ~ data:', data)
 
   const sessionId = await _createSession(data)
 

--- a/test/controllers/licences.controller.test.js
+++ b/test/controllers/licences.controller.test.js
@@ -77,6 +77,19 @@ describe('Licences controller', () => {
           expect(response.payload).to.contain('Page not found')
         })
       })
+
+      describe('because the initialise session service errors', () => {
+        beforeEach(async () => {
+          Sinon.stub(InitiateReturnRequirementSessionService, 'go').rejects()
+        })
+
+        it('returns a 200 and there is a problem with the service page', async () => {
+          const response = await server.inject(options)
+
+          expect(response.statusCode).to.equal(200)
+          expect(response.payload).to.contain('Sorry, there is a problem with the service')
+        })
+      })
     })
   })
 })

--- a/test/controllers/licences.controller.test.js
+++ b/test/controllers/licences.controller.test.js
@@ -38,7 +38,7 @@ describe('Licences controller', () => {
   })
 
   describe('GET /licences/{id}/no-returns-required', () => {
-    const sessionId = '1c265420-6a5e-4a4c-94e4-196d7799ed01'
+    const session = { id: '1c265420-6a5e-4a4c-94e4-196d7799ed01' }
 
     beforeEach(async () => {
       options = {
@@ -53,14 +53,14 @@ describe('Licences controller', () => {
 
     describe('when a request is valid', () => {
       beforeEach(async () => {
-        Sinon.stub(InitiateReturnRequirementSessionService, 'go').resolves(sessionId)
+        Sinon.stub(InitiateReturnRequirementSessionService, 'go').resolves(session)
       })
 
       it('redirects to select return start date page', async () => {
         const response = await server.inject(options)
 
         expect(response.statusCode).to.equal(302)
-        expect(response.headers.location).to.equal(`/system/return-requirements/${sessionId}/select-return-start-date`)
+        expect(response.headers.location).to.equal(`/system/return-requirements/${session.id}/select-return-start-date`)
       })
     })
 

--- a/test/controllers/licences.controller.test.js
+++ b/test/controllers/licences.controller.test.js
@@ -9,11 +9,13 @@ const { describe, it, beforeEach, afterEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Things we need to stub
+const InitiateReturnRequirementSessionService = require('../../app/services/return-requirements/initiate-return-requirement-session.service.js')
 
 // For running our service
 const { init } = require('../../app/server.js')
 
 describe('Licences controller', () => {
+  let options
   let server
 
   beforeEach(async () => {
@@ -33,20 +35,27 @@ describe('Licences controller', () => {
   })
 
   describe('GET /licences/{id}/no-returns-required', () => {
-    const options = {
-      method: 'GET',
-      url: '/licences/64924759-8142-4a08-9d1e-1e902cd9d316/no-returns-required',
-      auth: {
-        strategy: 'session',
-        credentials: { scope: ['billing'] }
-      }
-    }
+    const sessionId = '1c265420-6a5e-4a4c-94e4-196d7799ed01'
 
-    describe('when the request succeeds', () => {
-      it('creates a record in the sessions table and redirects to no retuns required reason page', async () => {
+    describe('when a request is valid', () => {
+      beforeEach(async () => {
+        options = {
+          method: 'GET',
+          url: '/licences/64924759-8142-4a08-9d1e-1e902cd9d316/no-returns-required',
+          auth: {
+            strategy: 'session',
+            credentials: { scope: ['billing'] }
+          }
+        }
+
+        Sinon.stub(InitiateReturnRequirementSessionService, 'go').resolves(sessionId)
+      })
+
+      it('redirects to select return start date page', async () => {
         const response = await server.inject(options)
 
         expect(response.statusCode).to.equal(302)
+        expect(response.headers.location).to.equal(`/system/return-requirements/${sessionId}/select-return-start-date`)
       })
     })
   })

--- a/test/services/return-requirements/initiate-return-requirement-session.service.test.js
+++ b/test/services/return-requirements/initiate-return-requirement-session.service.test.js
@@ -44,8 +44,8 @@ describe('Initiate Return Requirement Session service', () => {
         licenceRoles.holder = await LicenceRoleHelper.add()
 
         // Create a company and contact record
-        company = await CompanyHelper.add()
-        contact = await ContactHelper.add()
+        company = await CompanyHelper.add({ name: 'Licence Holder Ltd' })
+        contact = await ContactHelper.add({ firstName: 'Luce', lastName: 'Holder' })
 
         // We have to create a licence document to link our licence record to (eventually!) the company or contact
         // record that is the 'licence holder'
@@ -69,7 +69,7 @@ describe('Initiate Return Requirement Session service', () => {
           })
         })
 
-        it('creates a new session record containing details of the licence and licence holder', async () => {
+        it('creates a new session record containing details of the licence and licence holder (company)', async () => {
           const result = await InitiateReturnRequirementSessionService.go(licence.id)
 
           const session = await SessionModel.query().findById(result)
@@ -77,6 +77,30 @@ describe('Initiate Return Requirement Session service', () => {
 
           expect(data.licence.id).to.equal(licence.id)
           expect(data.licence.licenceRef).to.equal(licence.licenceRef)
+          expect(data.licence.licenceHolder).to.equal('Licence Holder Ltd')
+        })
+      })
+
+      describe('and the licence holder is a contact', () => {
+        beforeEach(async () => {
+          // Create the licence document role record that _is_ linked to the licence holder records
+          await LicenceDocumentRoleHelper.add({
+            licenceDocumentId: licenceDocument.id,
+            licenceRoleId: licenceRoles.holder.id,
+            companyId: company.id,
+            contactId: contact.id
+          })
+        })
+
+        it('creates a new session record containing details of the licence and licence holder (contact)', async () => {
+          const result = await InitiateReturnRequirementSessionService.go(licence.id)
+
+          const session = await SessionModel.query().findById(result)
+          const { data } = session
+
+          expect(data.licence.id).to.equal(licence.id)
+          expect(data.licence.licenceRef).to.equal(licence.licenceRef)
+          expect(data.licence.licenceHolder).to.equal('Luce Holder')
         })
       })
     })

--- a/test/services/return-requirements/initiate-return-requirement-session.service.test.js
+++ b/test/services/return-requirements/initiate-return-requirement-session.service.test.js
@@ -20,21 +20,36 @@ describe('Initiate Return Requirement Session service', () => {
 
   beforeEach(async () => {
     await DatabaseHelper.clean()
+
+    licence = await LicenceHelper.add()
   })
 
   describe('when called', () => {
-    beforeEach(async () => {
-      licence = await LicenceHelper.add()
+    describe('and the licence exists', () => {
+      it('creates a new session record containing details of the licence', async () => {
+        const result = await InitiateReturnRequirementSessionService.go(licence.id)
+
+        const session = await SessionModel.query().findById(result)
+        const { data } = session
+
+        expect(data.licence.id).to.equal(licence.id)
+        expect(data.licence.licenceRef).to.equal(licence.licenceRef)
+      })
     })
 
-    it('creates a new session record containing details of the licence', async () => {
-      const result = await InitiateReturnRequirementSessionService.go(licence.id)
+    describe('but the licence does not exist', () => {
+      it('throws a Boom not found error', async () => {
+        const error = await expect(InitiateReturnRequirementSessionService.go('e456e538-4d55-4552-84f7-6a7636eb1945')).to.reject()
 
-      const session = await SessionModel.query().findById(result)
-      const { data } = session
+        expect(error.isBoom).to.be.true()
+        expect(error.data).to.equal({ id: 'e456e538-4d55-4552-84f7-6a7636eb1945' })
 
-      expect(data.licence.licenceId).to.equal(licence.id)
-      expect(data.licence.licenceRef).to.equal(licence.licenceRef)
+        const { statusCode, error: errorType, message } = error.output.payload
+
+        expect(statusCode).to.equal(404)
+        expect(errorType).to.equal('Not Found')
+        expect(message).to.equal('Licence for new return requirement not found')
+      })
     })
   })
 })

--- a/test/services/return-requirements/initiate-return-requirement-session.service.test.js
+++ b/test/services/return-requirements/initiate-return-requirement-session.service.test.js
@@ -9,26 +9,32 @@ const { expect } = Code
 
 // Test helpers
 const DatabaseHelper = require('../../support/helpers/database.helper.js')
+const LicenceHelper = require('../../support/helpers/licence.helper.js')
 const SessionModel = require('../../../app/models/session.model.js')
 
 // Thing under test
 const InitiateReturnRequirementSessionService = require('../../../app/services/return-requirements/initiate-return-requirement-session.service.js')
 
 describe('Initiate Return Requirement Session service', () => {
-  const licenceId = '3267ad26-eecc-4b04-bdd9-174239f3c0d2'
+  let licence
 
   beforeEach(async () => {
     await DatabaseHelper.clean()
   })
 
   describe('when called', () => {
+    beforeEach(async () => {
+      licence = await LicenceHelper.add()
+    })
+
     it('creates a new session record containing details of the licence', async () => {
-      const result = await InitiateReturnRequirementSessionService.go(licenceId)
+      const result = await InitiateReturnRequirementSessionService.go(licence.id)
 
       const session = await SessionModel.query().findById(result)
-      const { licence } = session.data
+      const { data } = session
 
-      expect(licence.licenceId).to.equal(licenceId)
+      expect(data.licence.licenceId).to.equal(licence.id)
+      expect(data.licence.licenceRef).to.equal(licence.licenceRef)
     })
   })
 })

--- a/test/services/return-requirements/initiate-return-requirement-session.service.test.js
+++ b/test/services/return-requirements/initiate-return-requirement-session.service.test.js
@@ -1,0 +1,34 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const DatabaseHelper = require('../../support/helpers/database.helper.js')
+const SessionModel = require('../../../app/models/session.model.js')
+
+// Thing under test
+const InitiateReturnRequirementSessionService = require('../../../app/services/return-requirements/initiate-return-requirement-session.service.js')
+
+describe('Initiate Return Requirement Session service', () => {
+  const licenceId = '3267ad26-eecc-4b04-bdd9-174239f3c0d2'
+
+  beforeEach(async () => {
+    await DatabaseHelper.clean()
+  })
+
+  describe('when called', () => {
+    it('creates a new session record containing details of the licence', async () => {
+      const result = await InitiateReturnRequirementSessionService.go(licenceId)
+
+      const newSession = await SessionModel.query().findById(result)
+
+      expect(newSession).to.exist()
+      expect(newSession.data.licenceId).to.equal(licenceId)
+    })
+  })
+})

--- a/test/services/return-requirements/initiate-return-requirement-session.service.test.js
+++ b/test/services/return-requirements/initiate-return-requirement-session.service.test.js
@@ -25,10 +25,10 @@ describe('Initiate Return Requirement Session service', () => {
     it('creates a new session record containing details of the licence', async () => {
       const result = await InitiateReturnRequirementSessionService.go(licenceId)
 
-      const newSession = await SessionModel.query().findById(result)
+      const session = await SessionModel.query().findById(result)
+      const { licence } = session.data
 
-      expect(newSession).to.exist()
-      expect(newSession.data.licenceId).to.equal(licenceId)
+      expect(licence.licenceId).to.equal(licenceId)
     })
   })
 })

--- a/test/services/return-requirements/initiate-return-requirement-session.service.test.js
+++ b/test/services/return-requirements/initiate-return-requirement-session.service.test.js
@@ -15,7 +15,6 @@ const LicenceHelper = require('../../support/helpers/licence.helper.js')
 const LicenceDocumentHelper = require('../../support/helpers/licence-document.helper.js')
 const LicenceDocumentRoleHelper = require('../../support/helpers/licence-document-role.helper.js')
 const LicenceRoleHelper = require('../../support/helpers/licence-role.helper.js')
-const SessionModel = require('../../../app/models/session.model.js')
 
 // Thing under test
 const InitiateReturnRequirementSessionService = require('../../../app/services/return-requirements/initiate-return-requirement-session.service.js')
@@ -83,8 +82,7 @@ describe('Initiate Return Requirement Session service', () => {
         it('creates a new session record containing details of the licence and licence holder (company)', async () => {
           const result = await InitiateReturnRequirementSessionService.go(licence.id)
 
-          const session = await SessionModel.query().findById(result)
-          const { data } = session
+          const { data } = result
 
           expect(data.licence.id).to.equal(licence.id)
           expect(data.licence.licenceRef).to.equal(licence.licenceRef)
@@ -109,8 +107,7 @@ describe('Initiate Return Requirement Session service', () => {
         it('creates a new session record containing details of the licence and licence holder (contact)', async () => {
           const result = await InitiateReturnRequirementSessionService.go(licence.id)
 
-          const session = await SessionModel.query().findById(result)
-          const { data } = session
+          const { data } = result
 
           expect(data.licence.id).to.equal(licence.id)
           expect(data.licence.licenceRef).to.equal(licence.licenceRef)


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4261

In WATER-4292 we added a much of models (`LicenceDocument`, `LicenceRole` and `LicenceDocumentRole`) in preparation for identifying the current licence holder for a licence. We need the licence reference on every page of the return requirement setup journey because the page design has it as a caption alongside the page title.

Rather than the number on each page, it would be better to just grab the information once, and add it to the 'session' record the journey is using. But as we also need the licence holder ready for the check answers page we may as well grab that at the same time.

So, this change refactors the `LicencesController` to use a new `InitiateReturnRequirementSessionService` that will handle fetching this licence data and instantiating the initial  `SessionModel` instance. Subsequent controller handlers will then be able to access this data when they fetch the session record.