### PR TITLE
Fix download link in view bill run page

### DIFF
--- a/app/views/bill-runs/view.njk
+++ b/app/views/bill-runs/view.njk
@@ -145,7 +145,7 @@
     govukButton({
       classes: "govuk-button--secondary",
       text: "Download this bill run",
-      href: cancelBillRunLink
+      href: downloadBillRunLink
     })
   }}
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4223

Somehow we've mucked up the download a bill run link in the view bill run page. We've clearly copied & pasted a link we generated for the cancel button and used it for the download bill run button.

This change fixes the issue.