### PR TITLE
Support both return requirements set up journeys

### DIFF
--- a/app/controllers/licences.controller.js
+++ b/app/controllers/licences.controller.js
@@ -10,7 +10,7 @@ const InitiateReturnRequirementSessionService = require('../services/return-requ
 async function noReturnsRequired (request, h) {
   const { id } = request.params
 
-  const session = await InitiateReturnRequirementSessionService.go(id)
+  const session = await InitiateReturnRequirementSessionService.go(id, 'no-returns-required')
 
   return h.redirect(`/system/return-requirements/${session.id}/start-date`)
 }
@@ -18,7 +18,7 @@ async function noReturnsRequired (request, h) {
 async function returnsRequired (request, h) {
   const { id } = request.params
 
-  const session = await InitiateReturnRequirementSessionService.go(id)
+  const session = await InitiateReturnRequirementSessionService.go(id, 'returns-required')
 
   return h.redirect(`/system/return-requirements/${session.id}/start-date`)
 }

--- a/app/controllers/licences.controller.js
+++ b/app/controllers/licences.controller.js
@@ -15,6 +15,15 @@ async function noReturnsRequired (request, h) {
   return h.redirect(`/system/return-requirements/${session.id}/start-date`)
 }
 
+async function returnsRequired (request, h) {
+  const { id } = request.params
+
+  const session = await InitiateReturnRequirementSessionService.go(id)
+
+  return h.redirect(`/system/return-requirements/${session.id}/start-date`)
+}
+
 module.exports = {
-  noReturnsRequired
+  noReturnsRequired,
+  returnsRequired
 }

--- a/app/routes/licence.routes.js
+++ b/app/routes/licence.routes.js
@@ -13,7 +13,20 @@ const routes = [
           scope: ['billing']
         }
       },
-      description: 'Review two-part tariff match and allocation results'
+      description: 'Start no returns required set up journey (return-requirements)'
+    }
+  },
+  {
+    method: 'GET',
+    path: '/licences/{id}/returns-required',
+    handler: LicencesController.returnsRequired,
+    options: {
+      auth: {
+        access: {
+          scope: ['billing']
+        }
+      },
+      description: 'Start returns required set up journey (return-requirements)'
     }
   }
 ]

--- a/app/services/return-requirements/initiate-return-requirement-session.service.js
+++ b/app/services/return-requirements/initiate-return-requirement-session.service.js
@@ -21,13 +21,14 @@ const SessionModel = require('../../models/session.model.js')
  * the session record itself deleted.
  *
  * @param {String} licenceId - the ID of the licence the return requirement will be created for
+ * @param {String} journey - whether the set up journey needed is 'no-returns-required' or 'returns-required'
  *
  * @returns {module:SessionModel} the newly created session record
  */
-async function go (licenceId) {
+async function go (licenceId, journey) {
   const licence = await _fetchLicence(licenceId)
 
-  const data = _data(licence)
+  const data = _data(licence, journey)
 
   return _createSession(data)
 }
@@ -42,7 +43,7 @@ async function _createSession (data) {
   return session
 }
 
-function _data (licence) {
+function _data (licence, journey) {
   const { id, licenceRef, licenceDocument } = licence
 
   return {
@@ -50,7 +51,8 @@ function _data (licence) {
       id,
       licenceRef,
       licenceHolder: _licenceHolder(licenceDocument)
-    }
+    },
+    journey
   }
 }
 

--- a/test/controllers/licences.controller.test.js
+++ b/test/controllers/licences.controller.test.js
@@ -92,4 +92,60 @@ describe('Licences controller', () => {
       })
     })
   })
+
+  describe('GET /licences/{id}/returns-required', () => {
+    const session = { id: '1c265420-6a5e-4a4c-94e4-196d7799ed01' }
+
+    beforeEach(async () => {
+      options = {
+        method: 'GET',
+        url: '/licences/64924759-8142-4a08-9d1e-1e902cd9d316/returns-required',
+        auth: {
+          strategy: 'session',
+          credentials: { scope: ['billing'] }
+        }
+      }
+    })
+
+    describe('when a request is valid', () => {
+      beforeEach(async () => {
+        Sinon.stub(InitiateReturnRequirementSessionService, 'go').resolves(session)
+      })
+
+      it('redirects to select return start date page', async () => {
+        const response = await server.inject(options)
+
+        expect(response.statusCode).to.equal(302)
+        expect(response.headers.location).to.equal(`/system/return-requirements/${session.id}/start-date`)
+      })
+    })
+
+    describe('when a request is invalid', () => {
+      describe('because the licence ID is unrecognised', () => {
+        beforeEach(async () => {
+          Sinon.stub(InitiateReturnRequirementSessionService, 'go').rejects(Boom.notFound())
+        })
+
+        it('returns a 404 and page not found', async () => {
+          const response = await server.inject(options)
+
+          expect(response.statusCode).to.equal(404)
+          expect(response.payload).to.contain('Page not found')
+        })
+      })
+
+      describe('because the initialise session service errors', () => {
+        beforeEach(async () => {
+          Sinon.stub(InitiateReturnRequirementSessionService, 'go').rejects()
+        })
+
+        it('returns a 200 and there is a problem with the service page', async () => {
+          const response = await server.inject(options)
+
+          expect(response.statusCode).to.equal(200)
+          expect(response.payload).to.contain('Sorry, there is a problem with the service')
+        })
+      })
+    })
+  })
 })

--- a/test/services/return-requirements/initiate-return-requirement-session.service.test.js
+++ b/test/services/return-requirements/initiate-return-requirement-session.service.test.js
@@ -20,6 +20,7 @@ const LicenceRoleHelper = require('../../support/helpers/licence-role.helper.js'
 const InitiateReturnRequirementSessionService = require('../../../app/services/return-requirements/initiate-return-requirement-session.service.js')
 
 describe('Initiate Return Requirement Session service', () => {
+  let journey
   let licence
 
   beforeEach(async () => {
@@ -77,16 +78,26 @@ describe('Initiate Return Requirement Session service', () => {
             companyId: company.id,
             startDate: new Date('2022-08-01')
           })
+
+          journey = 'returns-required'
         })
 
         it('creates a new session record containing details of the licence and licence holder (company)', async () => {
-          const result = await InitiateReturnRequirementSessionService.go(licence.id)
+          const result = await InitiateReturnRequirementSessionService.go(licence.id, journey)
 
           const { data } = result
 
           expect(data.licence.id).to.equal(licence.id)
           expect(data.licence.licenceRef).to.equal(licence.licenceRef)
           expect(data.licence.licenceHolder).to.equal('Licence Holder Ltd')
+        })
+
+        it('creates a new session record containing the journey passed in', async () => {
+          const result = await InitiateReturnRequirementSessionService.go(licence.id, journey)
+
+          const { data } = result
+
+          expect(data.journey).to.equal(journey)
         })
       })
 
@@ -102,10 +113,12 @@ describe('Initiate Return Requirement Session service', () => {
             contactId: contact.id,
             startDate: new Date('2022-08-01')
           })
+
+          journey = 'no-returns-required'
         })
 
         it('creates a new session record containing details of the licence and licence holder (contact)', async () => {
-          const result = await InitiateReturnRequirementSessionService.go(licence.id)
+          const result = await InitiateReturnRequirementSessionService.go(licence.id, journey)
 
           const { data } = result
 
@@ -113,12 +126,20 @@ describe('Initiate Return Requirement Session service', () => {
           expect(data.licence.licenceRef).to.equal(licence.licenceRef)
           expect(data.licence.licenceHolder).to.equal('Luce Holder')
         })
+
+        it('creates a new session record containing the journey passed in', async () => {
+          const result = await InitiateReturnRequirementSessionService.go(licence.id, journey)
+
+          const { data } = result
+
+          expect(data.journey).to.equal(journey)
+        })
       })
     })
 
     describe('but the licence does not exist', () => {
       it('throws a Boom not found error', async () => {
-        const error = await expect(InitiateReturnRequirementSessionService.go('e456e538-4d55-4552-84f7-6a7636eb1945')).to.reject()
+        const error = await expect(InitiateReturnRequirementSessionService.go('e456e538-4d55-4552-84f7-6a7636eb1945', 'journey')).to.reject()
 
         expect(error.isBoom).to.be.true()
         expect(error.data).to.equal({ id: 'e456e538-4d55-4552-84f7-6a7636eb1945' })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4261

The return requirement setup journey is backed by a `SessionModel` instance that is used to store the values a user enters as well as helpful info like the licence ID and reference. But at the moment we are only creating it for the 'no returns required' journey. We need the session to be initialised for both journeys to develop and test all the pages needed.

So, this change adds a new endpoint to `/licences` that will do the same thing as `LicencesController.noReturnsRequired()`. Only both handlers will now pass a value that denotes the journey type to the `InitiateReturnRequirementSessionService` so it can store it in the session for future reference.