### PR TITLE
Redirect rtns reqs start-date to correct journey

### DIFF
--- a/app/controllers/return-requirements.controller.js
+++ b/app/controllers/return-requirements.controller.js
@@ -275,6 +275,12 @@ async function submitSiteDescription (request, h) {
 async function submitStartDate (request, h) {
   const { sessionId } = request.params
 
+  const session = await SessionModel.query().findById(sessionId)
+
+  if (session.data.journey === 'returns-required') {
+    return h.redirect(`/system/return-requirements/${sessionId}/reason`)
+  }
+
   return h.redirect(`/system/return-requirements/${sessionId}/no-returns-required`)
 }
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4261

Having added [support for the returns requirements set up journey session object to store which journey was selected](https://github.com/DEFRA/water-abstraction-system/pull/648) (returns required or no returns required) it means we can now do things like enable the `/start-date` page to redirect to the correct next page. At the moment it only supports the no-returns required journey which means those testing the journey need to manually manipulate the URL.

We're about to begin work on [adding the controls and validation](https://github.com/DEFRA/water-abstraction-system/pull/646) for `/start-date` page in the returns requirements set-up journey. So, we expect this change to be updated as part of that. But till that is complete this change will allow our QA team to get on with checking other pages.