### PR TITLE
Add LicenceVersionModel from water.licence_versions

### DIFF
--- a/db/migrations/legacy/20240111085159_create-water-licence-versions.js
+++ b/db/migrations/legacy/20240111085159_create-water-licence-versions.js
@@ -1,0 +1,37 @@
+'use strict'
+
+const tableName = 'licence_versions'
+
+exports.up = function (knex) {
+  return knex
+    .schema
+    .withSchema('water')
+    .createTable(tableName, (table) => {
+      // Primary Key
+      table.uuid('licence_version_id').primary().defaultTo(knex.raw('gen_random_uuid()'))
+
+      // Data
+      table.uuid('licence_id').notNullable()
+      table.integer('issue').notNullable()
+      table.integer('increment').notNullable()
+      table.string('status').notNullable()
+      table.date('start_date').notNullable()
+      table.date('end_date')
+      table.string('external_id').notNullable()
+      table.boolean('is_test').notNullable().defaultTo(false)
+
+      // Legacy timestamps
+      table.timestamp('date_created').notNullable()
+      table.timestamp('date_updated').notNullable()
+
+      // Constraints
+      table.unique(['external_id'], { useConstraint: true })
+    })
+}
+
+exports.down = function (knex) {
+  return knex
+    .schema
+    .withSchema('water')
+    .dropTableIfExists(tableName)
+}

--- a/db/migrations/public/20240111085846_create-licence-versions-view.js
+++ b/db/migrations/public/20240111085846_create-licence-versions-view.js
@@ -1,0 +1,30 @@
+'use strict'
+
+const viewName = 'licence_versions'
+
+exports.up = function (knex) {
+  return knex
+    .schema
+    .createView(viewName, (view) => {
+      // NOTE: We have commented out unused columns from the source table
+      view.as(knex('licence_versions').withSchema('water').select([
+        'licence_version_id AS id',
+        'licence_id',
+        'issue',
+        'increment',
+        'status',
+        'start_date',
+        'end_date',
+        'external_id',
+        // 'is_test',
+        'date_created AS created_at',
+        'date_updated AS updated_at'
+      ]))
+    })
+}
+
+exports.down = function (knex) {
+  return knex
+    .schema
+    .dropViewIfExists(viewName)
+}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4261

> This change supports the return requirements setup work

Tickets WATER-4263 and WATER-4266 cover adding controls and validation to the start date page in the set-up journeys (returns required and not required).

Users will be offered the choice to choose an existing start date or enter one manually. The existing start date needs to come from the current licence version record.

So, as a first step to enabling, we need to add the `LicenceVersionModel` to our project and link it to `LicenceModel`.