### PR TITLE
Determine licence start date 4 returns reqs setup

### DIFF
--- a/app/services/return-requirements/initiate-return-requirement-session.service.js
+++ b/app/services/return-requirements/initiate-return-requirement-session.service.js
@@ -38,7 +38,7 @@ async function _createSession (data) {
     .insert({
       data
     })
-    .returning('*')
+    .returning('id')
 
   return session
 }

--- a/test/services/return-requirements/initiate-return-requirement-session.service.test.js
+++ b/test/services/return-requirements/initiate-return-requirement-session.service.test.js
@@ -15,6 +15,7 @@ const LicenceHelper = require('../../support/helpers/licence.helper.js')
 const LicenceDocumentHelper = require('../../support/helpers/licence-document.helper.js')
 const LicenceDocumentRoleHelper = require('../../support/helpers/licence-document-role.helper.js')
 const LicenceRoleHelper = require('../../support/helpers/licence-role.helper.js')
+const LicenceVersionHelper = require('../../support/helpers/licence-version.helper.js')
 
 // Thing under test
 const InitiateReturnRequirementSessionService = require('../../../app/services/return-requirements/initiate-return-requirement-session.service.js')
@@ -37,6 +38,14 @@ describe('Initiate Return Requirement Session service', () => {
 
       beforeEach(async () => {
         licence = await LicenceHelper.add()
+
+        // Create 2 licence versions so we can test the service only gets the 'current' version
+        await LicenceVersionHelper.add({
+          licenceId: licence.id, startDate: new Date('2021-10-11'), status: 'superseded'
+        })
+        await LicenceVersionHelper.add({
+          licenceId: licence.id, startDate: new Date('2022-05-01')
+        })
 
         // Create 2 licence roles so we can test the service only gets the licence document role record that is for
         // 'licence holder'
@@ -92,6 +101,14 @@ describe('Initiate Return Requirement Session service', () => {
           expect(data.licence.licenceHolder).to.equal('Licence Holder Ltd')
         })
 
+        it("creates a new session record containing the licence's 'current' start date", async () => {
+          const result = await InitiateReturnRequirementSessionService.go(licence.id, journey)
+
+          const { data } = result
+
+          expect(data.licence.startDate).to.equal(new Date('2022-05-01'))
+        })
+
         it('creates a new session record containing the journey passed in', async () => {
           const result = await InitiateReturnRequirementSessionService.go(licence.id, journey)
 
@@ -125,6 +142,14 @@ describe('Initiate Return Requirement Session service', () => {
           expect(data.licence.id).to.equal(licence.id)
           expect(data.licence.licenceRef).to.equal(licence.licenceRef)
           expect(data.licence.licenceHolder).to.equal('Luce Holder')
+        })
+
+        it("creates a new session record containing the licence's 'current' start date", async () => {
+          const result = await InitiateReturnRequirementSessionService.go(licence.id, journey)
+
+          const { data } = result
+
+          expect(data.licence.startDate).to.equal(new Date('2022-05-01'))
         })
 
         it('creates a new session record containing the journey passed in', async () => {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4261

> This change supports the return requirements setup work

Tickets WATER-4263 and WATER-4266 cover adding controls and validation to the start date page in the set-up journeys (returns required and not required).

Users will be offered the choice to choose an existing start date or enter one manually. The existing start date needs to come from the current licence version record.

So, this change adds functionality to the `InitiateReturnRequirementSessionService` to add the start date to the session for use later in the page.