### PR TITLE
Fix issues with reissue post The Great Rename

### DIFF
--- a/app/services/bill-runs/supplementary/reissue-bill.service.js
+++ b/app/services/bill-runs/supplementary/reissue-bill.service.js
@@ -235,8 +235,16 @@ function _retrieveOrGenerateBill (dataToReturn, sourceBill, reissueBillRun, char
   }
 
   const translatedChargingModuleInvoice = _mapChargingModuleInvoice(chargingModuleReissueInvoice)
+
+  // GenerateBillService expects a BillingAccount instance and was built for supplementary billing. We only have the
+  // Bill object. So, we create a 'billing account' from its data that GenerateBillService can then use.
+  const billingAccount = {
+    id: sourceBill.billingAccountId,
+    accountNumber: sourceBill.accountNumber
+  }
+
   const generatedBill = GenerateBillService.go(
-    sourceBill,
+    billingAccount,
     reissueBillRun.id,
     sourceBill.financialYearEnding
   )
@@ -267,7 +275,14 @@ function _retrieveOrGenerateBillLicence (dataToReturn, sourceBill, billingId, so
     return existingBillLicence
   }
 
-  const newBillLicence = GenerateBillLicenceService.go(billingId, sourceBillLicence)
+  // GenerateBillLicenceService expects a Licence object and was built for supplementary billing. We only have the
+  // BillLicence object. So, we create a 'licence' from its data that GenerateBillLicenceService can then use.
+  const licence = {
+    id: sourceBillLicence.licenceId,
+    licenceRef: sourceBillLicence.licenceRef
+  }
+
+  const newBillLicence = GenerateBillLicenceService.go(billingId, licence)
 
   dataToReturn.billLicences.push(newBillLicence)
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4336

Whilst working on updating our acceptance tests due to changes in the view bill run and view bill screens we found even after accounting for the changes, the SROC reissue test still failed.

After investigation, we were able to identify changes made during the [The Great Rename](https://github.com/DEFRA/water-abstraction-system/pull/416) had broken the reissue engine.

Before the rename the reissue engine depended on shared fields between records. For example, a `water.billing_invoice` and a `crm_v2.invoice_account` shared the same fields; `invoice_account_id` and `invoice_account_number`.

So, you could pass an instance of both to a service like `GenerateBillService` and as far as it is concerned it is dealing with a 'billing account' instance because it has the `invoice_account_id` and `invoice_account_number` properties it expects.

```javascript
const billingInvoice = {
  billingInvoiceId: 'e1b40699-3b57-422c-96c3-3732e86312fc',
  invoiceAccountId: '53c85d8c-d5fc-48db-9c59-aa36995c0e4b',
  invoiceAccountNumber: 'A00000002A'
}

const invoiceAccount = {
  invoiceAccountId: '53c85d8c-d5fc-48db-9c59-aa36995c0e4b',
  invoiceAccountNumber: 'A00000002A'
}
```

Post the rename this is no longer the case. Now we have the following

```javascript
const billingInvoice = {
  id: 'e1b40699-3b57-422c-96c3-3732e86312fc',
  invoiceAccountId: '53c85d8c-d5fc-48db-9c59-aa36995c0e4b',
  invoiceAccountNumber: 'A00000002A'
}

const invoiceAccount = {
  id: '53c85d8c-d5fc-48db-9c59-aa36995c0e4b',
  invoiceAccountNumber: 'A00000002A'
}
```

> We use field names before the great rename to help explain the issue. But this is not what they are in the code anymore.

It's `invoiceAccountId` on the billing invoice and just `id` on the invoice account. `GenerateBillService` can no longer be given both types of instances and expect to get the same result.

So, this fixes the issue by generating objects that represent what `GenerateBillService` and `GenerateBillLicenceService` expect.