### PR TITLE
Fix and improve acceptance testing attributes

### DIFF
--- a/app/views/bill-runs/view.njk
+++ b/app/views/bill-runs/view.njk
@@ -38,7 +38,7 @@
         {{ badge(billRunStatus, badgeType) }}
       </p>
 
-      {# Bill meta-data #}
+      {# Bill run meta-data #}
       {#
         GOV.UK summary lists only allow us to assign attributes at the top level and not to each row. This means we
         can't assign our data-test attribute using the component. Our solution is to use the html option for each row

--- a/app/views/bill-runs/view.njk
+++ b/app/views/bill-runs/view.njk
@@ -38,7 +38,13 @@
         {{ badge(billRunStatus, badgeType) }}
       </p>
 
-      {# Bill run meta-data #}
+      {# Bill meta-data #}
+      {#
+        GOV.UK summary lists only allow us to assign attributes at the top level and not to each row. This means we
+        can't assign our data-test attribute using the component. Our solution is to use the html option for each row
+        instead of text and wrap each value in a <span>. That way we can manually assign our data-test attribute to the
+        span.
+      #}
       {{
         govukSummaryList({
           classes: 'govuk-summary-list--no-border',
@@ -48,31 +54,31 @@
           rows: [
             {
               key: { text: "Date created", classes: "meta-data__label" },
-              value: { text: dateCreated, classes: "meta-data__value" }
+              value: { html: '<span data-test="meta-data-created">' + dateCreated + '</span>', classes: "meta-data__value" }
             },
             {
               key: { text: "Region", classes: "meta-data__label" },
-              value: { text: region, classes: "meta-data__value" }
+              value: { html: '<span data-test="meta-data-region">' + region + '</span>', classes: "meta-data__value" }
             },
             {
               key: { text: "Bill run type", classes: "meta-data__label" },
-              value: { text: billRunType, classes: "meta-data__value" }
+              value: { html: '<span data-test="meta-data-type">' + billRunType + '</span>', classes: "meta-data__value" }
             },
             {
               key: { text: "Charge scheme", classes: "meta-data__label" },
-              value: { text: chargeScheme, classes: "meta-data__value" }
+              value: { html: '<span data-test="meta-data-scheme">' + chargeScheme + '</span>', classes: "meta-data__value" }
             },
             {
               key: { text: "Financial year", classes: "meta-data__label" },
-              value: { text: financialYear, classes: "meta-data__value" }
-            } if financialYear,
+              value: { html: '<span data-test="meta-data-year">' + financialYear + '</span>', classes: "meta-data__value" }
+            },
             {
               key: { text: "Transaction file", classes: "meta-data__label" },
-              value: { text: transactionFile, classes: "meta-data__value" }
+              value: { html: '<span data-test="meta-data-file">' + transactionFile + '</span>', classes: "meta-data__value" }
             } if transactionFile,
             {
               key: { text: "Bill number", classes: "meta-data__label" },
-              value: { text: billNumber, classes: "meta-data__value" }
+              value: { html: '<span data-test="meta-data-number">' + billNumber + '</span>', classes: "meta-data__value" }
             } if billNumber
           ]
         })

--- a/app/views/bill-runs/view.njk
+++ b/app/views/bill-runs/view.njk
@@ -233,7 +233,7 @@
       {% set tableRow = [
         {
           text: bill.accountNumber,
-          attributes: { 'data-test': 'account-number' + rowIndex }
+          attributes: { 'data-test': 'account-number-' + rowIndex }
         },
         {
           text: bill.billingContact,

--- a/app/views/bill-runs/view.njk
+++ b/app/views/bill-runs/view.njk
@@ -251,7 +251,7 @@
           {
             text: bill.financialYear,
             format: 'numeric',
-            attributes: { 'data-test': 'financial-year' + rowIndex }
+            attributes: { 'data-test': 'financial-year-' + rowIndex }
           }
         ), tableRow) %}
       {% endif %}

--- a/app/views/bills/view-multi-licence.njk
+++ b/app/views/bills/view-multi-licence.njk
@@ -140,7 +140,7 @@
       </div>
       <div class="govuk-grid-column-one-half">
         <h2>
-          <span class="govuk-body govuk-!-font-weight-bold govuk-!-font-size-48" data-test="credits-total">{{ debitsTotal }}</span><br>
+          <span class="govuk-body govuk-!-font-weight-bold govuk-!-font-size-48" data-test="debits-total">{{ debitsTotal }}</span><br>
           <span class="govuk-body govuk-!-font-weight-bold govuk-!-font-size-24">Debits</span>
         </h2>
       </div>

--- a/app/views/bills/view-multi-licence.njk
+++ b/app/views/bills/view-multi-licence.njk
@@ -40,6 +40,12 @@
       </p>
 
       {# Bill meta-data #}
+      {#
+        GOV.UK summary lists only allow us to assign attributes at the top level and not to each row. This means we
+        can't assign our data-test attribute using the component. Our solution is to use the html option for each row
+        instead of text and wrap each value in a <span>. That way we can manually assign our data-test attribute to the
+        span.
+      #}
       {{
         govukSummaryList({
           classes: 'govuk-summary-list--no-border',
@@ -49,31 +55,31 @@
           rows: [
             {
               key: { text: "Date created", classes: "meta-data__label" },
-              value: { text: dateCreated, classes: "meta-data__value" }
+              value: { html: '<span data-test="meta-data-created">' + dateCreated + '</span>', classes: "meta-data__value" }
             },
             {
               key: { text: "Region", classes: "meta-data__label" },
-              value: { text: region, classes: "meta-data__value" }
+              value: { html: '<span data-test="meta-data-region">' + region + '</span>', classes: "meta-data__value" }
             },
             {
               key: { text: "Bill run type", classes: "meta-data__label" },
-              value: { text: billRunType, classes: "meta-data__value" }
+              value: { html: '<span data-test="meta-data-type">' + billRunType + '</span>', classes: "meta-data__value" }
             },
             {
               key: { text: "Charge scheme", classes: "meta-data__label" },
-              value: { text: chargeScheme, classes: "meta-data__value" }
+              value: { html: '<span data-test="meta-data-scheme">' + chargeScheme + '</span>', classes: "meta-data__value" }
             },
             {
               key: { text: "Financial year", classes: "meta-data__label" },
-              value: { text: financialYear, classes: "meta-data__value" }
+              value: { html: '<span data-test="meta-data-year">' + financialYear + '</span>', classes: "meta-data__value" }
             },
             {
               key: { text: "Transaction file", classes: "meta-data__label" },
-              value: { text: transactionFile, classes: "meta-data__value" }
+              value: { html: '<span data-test="meta-data-file">' + transactionFile + '</span>', classes: "meta-data__value" }
             } if transactionFile,
             {
               key: { text: "Bill number", classes: "meta-data__label" },
-              value: { text: billNumber, classes: "meta-data__value" }
+              value: { html: '<span data-test="meta-data-number">' + billNumber + '</span>', classes: "meta-data__value" }
             } if billNumber
           ]
         })

--- a/app/views/bills/view-single-licence-presroc.njk
+++ b/app/views/bills/view-single-licence-presroc.njk
@@ -140,7 +140,7 @@
       </div>
       <div class="govuk-grid-column-one-half">
         <h2>
-          <span class="govuk-body govuk-!-font-weight-bold govuk-!-font-size-48" data-test="credits-total">{{ debitsTotal }}</span><br>
+          <span class="govuk-body govuk-!-font-weight-bold govuk-!-font-size-48" data-test="debits-total">{{ debitsTotal }}</span><br>
           <span class="govuk-body govuk-!-font-weight-bold govuk-!-font-size-24">Debits</span>
         </h2>
       </div>

--- a/app/views/bills/view-single-licence-presroc.njk
+++ b/app/views/bills/view-single-licence-presroc.njk
@@ -40,6 +40,12 @@
       </p>
 
       {# Bill meta-data #}
+      {#
+        GOV.UK summary lists only allow us to assign attributes at the top level and not to each row. This means we
+        can't assign our data-test attribute using the component. Our solution is to use the html option for each row
+        instead of text and wrap each value in a <span>. That way we can manually assign our data-test attribute to the
+        span.
+      #}
       {{
         govukSummaryList({
           classes: 'govuk-summary-list--no-border',
@@ -49,31 +55,31 @@
           rows: [
             {
               key: { text: "Date created", classes: "meta-data__label" },
-              value: { text: dateCreated, classes: "meta-data__value" }
+              value: { html: '<span data-test="meta-data-created">' + dateCreated + '</span>', classes: "meta-data__value" }
             },
             {
               key: { text: "Region", classes: "meta-data__label" },
-              value: { text: region, classes: "meta-data__value" }
+              value: { html: '<span data-test="meta-data-region">' + region + '</span>', classes: "meta-data__value" }
             },
             {
               key: { text: "Bill run type", classes: "meta-data__label" },
-              value: { text: billRunType, classes: "meta-data__value" }
+              value: { html: '<span data-test="meta-data-type">' + billRunType + '</span>', classes: "meta-data__value" }
             },
             {
               key: { text: "Charge scheme", classes: "meta-data__label" },
-              value: { text: chargeScheme, classes: "meta-data__value" }
+              value: { html: '<span data-test="meta-data-scheme">' + chargeScheme + '</span>', classes: "meta-data__value" }
             },
             {
               key: { text: "Financial year", classes: "meta-data__label" },
-              value: { text: financialYear, classes: "meta-data__value" }
+              value: { html: '<span data-test="meta-data-year">' + financialYear + '</span>', classes: "meta-data__value" }
             },
             {
               key: { text: "Transaction file", classes: "meta-data__label" },
-              value: { text: transactionFile, classes: "meta-data__value" }
+              value: { html: '<span data-test="meta-data-file">' + transactionFile + '</span>', classes: "meta-data__value" }
             } if transactionFile,
             {
               key: { text: "Bill number", classes: "meta-data__label" },
-              value: { text: billNumber, classes: "meta-data__value" }
+              value: { html: '<span data-test="meta-data-number">' + billNumber + '</span>', classes: "meta-data__value" }
             } if billNumber
           ]
         })

--- a/app/views/bills/view-single-licence-presroc.njk
+++ b/app/views/bills/view-single-licence-presroc.njk
@@ -378,7 +378,7 @@
             text: creditTotal,
             format: 'numeric',
             classes: 'govuk-!-font-weight-bold',
-            attributes: { 'data-test': 'credits-total' }
+            attributes: { 'data-test': 'transactions-credits-total' }
           },
           {
             text: '',
@@ -395,7 +395,7 @@
             text: debitTotal,
             format: 'numeric',
             classes: 'govuk-!-font-weight-bold',
-            attributes: { 'data-test': 'debits-total' }
+            attributes: { 'data-test': 'transactions-debits-total' }
           }
         ] %}
 

--- a/app/views/bills/view-single-licence-sroc.njk
+++ b/app/views/bills/view-single-licence-sroc.njk
@@ -140,7 +140,7 @@
       </div>
       <div class="govuk-grid-column-one-half">
         <h2>
-          <span class="govuk-body govuk-!-font-weight-bold govuk-!-font-size-48" data-test="credits-total">{{ debitsTotal }}</span><br>
+          <span class="govuk-body govuk-!-font-weight-bold govuk-!-font-size-48" data-test="debits-total">{{ debitsTotal }}</span><br>
           <span class="govuk-body govuk-!-font-weight-bold govuk-!-font-size-24">Debits</span>
         </h2>
       </div>

--- a/app/views/bills/view-single-licence-sroc.njk
+++ b/app/views/bills/view-single-licence-sroc.njk
@@ -40,6 +40,12 @@
       </p>
 
       {# Bill meta-data #}
+      {#
+        GOV.UK summary lists only allow us to assign attributes at the top level and not to each row. This means we
+        can't assign our data-test attribute using the component. Our solution is to use the html option for each row
+        instead of text and wrap each value in a <span>. That way we can manually assign our data-test attribute to the
+        span.
+      #}
       {{
         govukSummaryList({
           classes: 'govuk-summary-list--no-border',
@@ -49,31 +55,31 @@
           rows: [
             {
               key: { text: "Date created", classes: "meta-data__label" },
-              value: { text: dateCreated, classes: "meta-data__value" }
+              value: { html: '<span data-test="meta-data-created">' + dateCreated + '</span>', classes: "meta-data__value" }
             },
             {
               key: { text: "Region", classes: "meta-data__label" },
-              value: { text: region, classes: "meta-data__value" }
+              value: { html: '<span data-test="meta-data-region">' + region + '</span>', classes: "meta-data__value" }
             },
             {
               key: { text: "Bill run type", classes: "meta-data__label" },
-              value: { text: billRunType, classes: "meta-data__value" }
+              value: { html: '<span data-test="meta-data-type">' + billRunType + '</span>', classes: "meta-data__value" }
             },
             {
               key: { text: "Charge scheme", classes: "meta-data__label" },
-              value: { text: chargeScheme, classes: "meta-data__value" }
+              value: { html: '<span data-test="meta-data-scheme">' + chargeScheme + '</span>', classes: "meta-data__value" }
             },
             {
               key: { text: "Financial year", classes: "meta-data__label" },
-              value: { text: financialYear, classes: "meta-data__value" }
+              value: { html: '<span data-test="meta-data-year">' + financialYear + '</span>', classes: "meta-data__value" }
             },
             {
               key: { text: "Transaction file", classes: "meta-data__label" },
-              value: { text: transactionFile, classes: "meta-data__value" }
+              value: { html: '<span data-test="meta-data-file">' + transactionFile + '</span>', classes: "meta-data__value" }
             } if transactionFile,
             {
               key: { text: "Bill number", classes: "meta-data__label" },
-              value: { text: billNumber, classes: "meta-data__value" }
+              value: { html: '<span data-test="meta-data-number">' + billNumber + '</span>', classes: "meta-data__value" }
             } if billNumber
           ]
         })

--- a/app/views/bills/view-single-licence-sroc.njk
+++ b/app/views/bills/view-single-licence-sroc.njk
@@ -373,7 +373,7 @@
             text: creditTotal,
             format: 'numeric',
             classes: 'govuk-!-font-weight-bold',
-            attributes: { 'data-test': 'credits-total' }
+            attributes: { 'data-test': 'transactions-credits-total' }
           },
           {
             text: '',
@@ -390,7 +390,7 @@
             text: debitTotal,
             format: 'numeric',
             classes: 'govuk-!-font-weight-bold',
-            attributes: { 'data-test': 'debits-total' }
+            attributes: { 'data-test': 'transactions-debits-total' }
           }
         ] %}
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4336

In WATER-4070 we logged that the Billing & Data team struggled because they could not access the larger bill runs. The service would appear to be busy for a while and then eventually error.

We figured out it was simply that the service could not return all the data needed using the current design, which listed out all the transactions in a bill run. We also knew the data could be collected in a more performant way.

So, we ended up rebuilding the whole journey of viewing a bill run, the bills in it and the transaction details.

This also allowed us to add attributes to elements likely referenced in our acceptance tests. A [recognised best practice in selecting elements in tests](https://docs.cypress.io/guides/references/best-practices#Selecting-Elements) is to avoid brittle, complex selectors and to use `data-*` attributes instead.

> For reference we have opted for `data-test` as our convention

The legacy pages had none of this, and often didn't even bother with IDs. This means a common battle with the acceptance tests we inherited is finding suitable selectors for the elements we needed.

We now need to [update those tests we broke](https://github.com/DEFRA/water-abstraction-acceptance-tests/pull/78) because of our new pages. Doing this has allowed us to spot a few places where we've made mistakes and others where `data-test` would help. This change is us making those tweaks to the billing templates.
