### PR TITLE
Add warning text to view licence page

### DIFF
--- a/app/controllers/licences.controller.js
+++ b/app/controllers/licences.controller.js
@@ -28,7 +28,6 @@ async function view (request, h) {
   const { id } = request.params
 
   const data = await ViewLicenceService.go(id)
-  console.log(data)
 
   return h.view('licences/view.njk', {
     activeNavBar: 'search',

--- a/app/controllers/licences.controller.js
+++ b/app/controllers/licences.controller.js
@@ -28,6 +28,7 @@ async function view (request, h) {
   const { id } = request.params
 
   const data = await ViewLicenceService.go(id)
+  console.log(data)
 
   return h.view('licences/view.njk', {
     activeNavBar: 'search',

--- a/app/presenters/licences/view-licence.presenter.js
+++ b/app/presenters/licences/view-licence.presenter.js
@@ -15,28 +15,110 @@ const { formatLongDate } = require('../base.presenter.js')
  * @returns {Object} The data formatted for the view template
  */
 function go (licence) {
-  const { expiredDate, id, licenceRef, region, startDate } = licence
+  const { expiredDate, id, lapsedDate, licenceRef, region, revokedDate, startDate } = licence
+  const warning = _generateWarningMessage(expiredDate, lapsedDate, revokedDate)
 
   return {
     id,
     endDate: _endDate(expiredDate),
     licenceRef,
     region: region.displayName,
-    startDate: formatLongDate(startDate)
+    startDate: formatLongDate(startDate),
+    warning
   }
 }
 
 /**
- * Formats the expired date of the licence as the end date for the view
+ * Compares two end dates and chooses the correct one to return
+ *
+ * @param {date} firstEndDate - The first date to compare
+ *
+ * @param {date} secondEndDate - The second date to compare
  *
  * @module ViewLicencePresenter
  */
+function _compareEndDates (firstEndDate, secondEndDate) {
+  if (firstEndDate.date.getTime() === secondEndDate.date.getTime()) {
+    if (firstEndDate.name === 'revoked') return firstEndDate
+    if (secondEndDate.name === 'revoked') return secondEndDate
+    if (firstEndDate.name === 'lapsed') return firstEndDate
+  } else if (firstEndDate.date < secondEndDate.date) {
+    return firstEndDate
+  }
+  return secondEndDate
+}
+
+/**
+  * Formats the expired date of the licence as the end date for the view
+  *
+  * @param {date} expiredDate - The expired date to be formatted if it is in the past
+  *
+  * @module ViewLicencePresenter
+*/
 function _endDate (expiredDate) {
   if (!expiredDate || expiredDate < Date.now()) {
     return null
   }
 
   return formatLongDate(expiredDate)
+}
+
+/**
+ * When given up to three possible end dates for a licence this function will determine the correct one to show
+ * and return it formatted in the standard way
+ *
+ * @module ViewLicencePresenter
+ *
+ * @param {date} expiredDate - The expired date or null if not present
+ *
+ * @param {date} lapsedDate - The lapsed date or null if not present
+ *
+ * @param {date} revokedDate - The revoked date or null if not present
+ *
+ * @returns {string} The warning message formatted for the view template
+ */
+function _generateWarningMessage (expiredDate, lapsedDate, revokedDate) {
+  const endDates = []
+
+  if (lapsedDate) {
+    endDates.push({
+      name: 'lapsed',
+      message: `This licence lapsed on ${formatLongDate(lapsedDate)}`,
+      date: lapsedDate
+    })
+  }
+
+  if (expiredDate) {
+    endDates.push({
+      name: 'expired',
+      message: `This licence expired on ${formatLongDate(expiredDate)}`,
+      date: expiredDate
+    })
+  }
+
+  if (revokedDate) {
+    endDates.push({
+      name: 'revoked',
+      message: `This licence was revoked on ${formatLongDate(revokedDate)}`,
+      date: revokedDate
+    })
+  }
+
+  if (endDates.length === 0) {
+    return null
+  }
+
+  if (endDates.length === 1) {
+    return endDates[0].message
+  }
+
+  if (endDates.length > 1) {
+    return endDates.reduce((result, endDate) => {
+      return _compareEndDates(result, endDate)
+    }).message
+  }
+
+  return null
 }
 
 module.exports = {

--- a/app/presenters/licences/view-licence.presenter.js
+++ b/app/presenters/licences/view-licence.presenter.js
@@ -28,15 +28,6 @@ function go (licence) {
   }
 }
 
-/**
- * Compares two end dates and chooses the correct one to return
- *
- * @param {date} firstEndDate - The first date to compare
- *
- * @param {date} secondEndDate - The second date to compare
- *
- * @module ViewLicencePresenter
- */
 function _compareEndDates (firstEndDate, secondEndDate) {
   if (firstEndDate.date.getTime() === secondEndDate.date.getTime()) {
     if (firstEndDate.name === 'revoked') return firstEndDate
@@ -48,13 +39,6 @@ function _compareEndDates (firstEndDate, secondEndDate) {
   return secondEndDate
 }
 
-/**
-  * Formats the expired date of the licence as the end date for the view
-  *
-  * @param {date} expiredDate - The expired date to be formatted if it is in the past
-  *
-  * @module ViewLicencePresenter
-*/
 function _endDate (expiredDate) {
   if (!expiredDate || expiredDate < Date.now()) {
     return null
@@ -63,20 +47,6 @@ function _endDate (expiredDate) {
   return formatLongDate(expiredDate)
 }
 
-/**
- * When given up to three possible end dates for a licence this function will determine the correct one to show
- * and return it formatted in the standard way
- *
- * @module ViewLicencePresenter
- *
- * @param {date} expiredDate - The expired date or null if not present
- *
- * @param {date} lapsedDate - The lapsed date or null if not present
- *
- * @param {date} revokedDate - The revoked date or null if not present
- *
- * @returns {string} The warning message formatted for the view template
- */
 function _generateWarningMessage (expiredDate, lapsedDate, revokedDate) {
   const endDates = []
 
@@ -112,13 +82,11 @@ function _generateWarningMessage (expiredDate, lapsedDate, revokedDate) {
     return endDates[0].message
   }
 
-  if (endDates.length > 1) {
-    return endDates.reduce((result, endDate) => {
-      return _compareEndDates(result, endDate)
-    }).message
-  }
+  const earliestPriorityEndDate = endDates.reduce((result, endDate) => {
+    return _compareEndDates(result, endDate)
+  })
 
-  return null
+  return earliestPriorityEndDate.message
 }
 
 module.exports = {

--- a/app/views/licences/view.njk
+++ b/app/views/licences/view.njk
@@ -1,6 +1,7 @@
 {% extends 'layout.njk' %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/tabs/macro.njk" import govukTabs %}
+{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 
 {% block breadcrumbs %}
   {{
@@ -31,7 +32,13 @@
 {% endset %}
 
 {% block content %}
-  <h1 class="govuk-heading-l">Licence Number {{ licenceRef }}</h1>
+  {% if warning %}
+    {{ govukWarningText({
+      text: warning,
+      iconFallbackText: "Warning"
+    }) }}
+  {% endif %}
+  <h1 class="govuk-heading-l">Licence number {{ licenceRef }}</h1>
 
   {{ govukTabs({
     items: [

--- a/test/services/licences/view-licence.service.test.js
+++ b/test/services/licences/view-licence.service.test.js
@@ -14,7 +14,7 @@ const FetchLicenceService = require('../../../app/services/licences/fetch-licenc
 // Thing under test
 const ViewLicenceService = require('../../../app/services/licences/view-licence.service.js')
 
-describe.only('View Licence service', () => {
+describe('View Licence service', () => {
   const testId = '2c80bd22-a005-4cf4-a2a2-73812a9861de'
   let fetchLicenceResult
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4325

As part of the work to migrate the summary page from the old UI to the new one we need to display a warning when a licence has been revoke, expired or lapsed.