### PR TITLE
Fix licence agreement tear down again!

### DIFF
--- a/app/services/data/tear-down/water-schema.service.js
+++ b/app/services/data/tear-down/water-schema.service.js
@@ -172,6 +172,14 @@ async function _deleteAllTestData () {
 
   DELETE
   FROM
+    "water"."licence_agreements" AS "la"
+    USING "water"."licences" AS "l"
+  WHERE
+    "l"."is_test" = TRUE
+    AND "la"."licence_ref" = "l"."licence_ref";
+
+  DELETE
+  FROM
     "water"."financial_agreement_types"
   WHERE
     "is_test" = TRUE;


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4336

Ok, we've made a bit of a hash with trying to [improve the tear-down speed](https://github.com/DEFRA/water-abstraction-system/pull/671).

We realised in the rewrite we'd dropped a licence agreement DELETE statement that needed including so [fixed it](https://github.com/DEFRA/water-abstraction-system/pull/673/files).

Then we realised the tear-down was now faster but more flaky so [switched to the single query strategy](https://github.com/DEFRA/water-abstraction-system/pull/674).

Only in the switch what do you know, we lost the licence agreement DELETE statement again.

Hopefully, for the last time, we fix this!