### PR TITLE
Update 2PT /check endpoint with latest services

### DIFF
--- a/app/services/check/scenario-formatter.service.js
+++ b/app/services/check/scenario-formatter.service.js
@@ -92,9 +92,10 @@ function _formatChargeElementMatchedReturns (matchedReturns, formattedReturns) {
   return matchedReturns.map((matchedReturn) => {
     const {
       id,
-      allocatedQuantity,
-      lines
+      allocatedQuantity
     } = matchedReturn
+
+    const lines = matchedReturn.lines ? matchedReturn.lines : []
 
     const matchingReturn = formattedReturns.find((formattedReturn) => formattedReturn.id === matchedReturn.id)
     lines.forEach((line) => {

--- a/app/services/check/scenario-formatter.service.js
+++ b/app/services/check/scenario-formatter.service.js
@@ -90,14 +90,9 @@ function _formatChargeElements (chargeElements, formattedReturns, chargeReferenc
 
 function _formatChargeElementMatchedReturns (matchedReturns, formattedReturns) {
   return matchedReturns.map((matchedReturn) => {
-    const {
-      id,
-      allocatedQuantity
-    } = matchedReturn
-
     const lines = matchedReturn.lines ? matchedReturn.lines : []
 
-    const matchingReturn = formattedReturns.find((formattedReturn) => formattedReturn.id === matchedReturn.id)
+    const matchingReturn = formattedReturns.find((formattedReturn) => formattedReturn.id === matchedReturn.returnId)
     lines.forEach((line) => {
       line.matchingLine = matchingReturn.lines.find((matchingReturnLine) => {
         return matchingReturnLine.id === line.id
@@ -114,8 +109,8 @@ function _formatChargeElementMatchedReturns (matchedReturns, formattedReturns) {
 
     return {
       simpleId: matchingReturn.simpleId,
-      id,
-      allocatedQuantity,
+      id: matchedReturn.returnId,
+      allocatedQuantity: matchedReturn.allocatedQuantity,
       lines: formattedLines
     }
   })

--- a/app/services/check/stand-ins.service.js
+++ b/app/services/check/stand-ins.service.js
@@ -1,40 +1,84 @@
 'use strict'
 
 /**
- * Not a real service! Contains stand-ins for services currently being built as part of the two-part tariff refactoring
+ * Not a real service! Contains stand-ins for services we've had to tweak to support the check endpoint
  * @module CheckController
  */
 
-const DetermineAbstractionPeriodService = require('../bill-runs/determine-abstraction-periods.service.js')
-const DetermineChargePeriodService = require('../bill-runs/determine-charge-period.service.js')
-const FetchReturnLogsForLicenceService = require('../bill-runs/two-part-tariff/fetch-return-logs-for-licence.service.js')
 const { periodsOverlap } = require('../../lib/general.lib.js')
 
 // =====================================================================================================================
 // AllocateReturnsToLicenceService stand-in code
-// Delete when real service is merged
+// An exact copy of the real service. Only change is to capture which lines were allocated to an element. Something
+// we don't care about in the real engine but it's really useful when validating the engine.
 
-const allocateReturnsToLicencesService = {
+const AllocateReturnsToChargeElementService = {
   go: _allocateReturnsToLicences
 }
 
-function _allocateReturnsToLicences (licences) {
-  licences.forEach((licence) => {
-    const { chargeVersions, returnLogs } = licence
+function _allocateReturnsToLicences (chargeElement, matchingReturns, chargePeriod, chargeReference) {
+  matchingReturns.forEach((matchedReturn, i) => {
+    // We don't allocate returns with issues
+    if (matchedReturn.issues) {
+      return
+    }
 
-    chargeVersions.forEach((chargeVersion) => {
-      const { chargeReferences } = chargeVersion
+    // We can only allocate up to the authorised volume on the charge reference, even if there is charge elements
+    // unallocated and returns to be allocated
+    if (chargeReference.allocatedQuantity >= chargeReference.volume) {
+      return
+    }
 
-      chargeReferences.forEach((chargeReference) => {
-        chargeReference.allocatedQuantity = 0
+    // Finally, we can only allocate to the charge element if there is unallocated volume left!
+    if (chargeElement.allocatedQuantity >= chargeElement.authorisedAnnualQuantity) {
+      return
+    }
 
-        const { chargeElements } = chargeReference
+    const matchedLines = _matchLines(chargeElement, matchedReturn.returnSubmissions[0].returnSubmissionLines)
 
-        chargeElements.forEach((chargeElement) => {
-          _matchAndAllocate(chargeElement, returnLogs, chargeVersion.chargePeriod, chargeReference)
-        })
-      })
-    })
+    if (matchedLines.length > 0) {
+      _allocateReturns(chargeElement, matchedReturn, chargePeriod, chargeReference, i, matchedLines)
+    }
+  })
+}
+
+function _allocateReturns (chargeElement, matchedReturn, chargePeriod, chargeReference, i, matchedLines) {
+  matchedLines.forEach((matchedLine) => {
+    const remainingAllocation = chargeElement.authorisedAnnualQuantity - chargeElement.allocatedQuantity
+    if (remainingAllocation > 0) {
+      // We default how much to allocate to what is unallocated on the line i.e. remaining >= line.unallocated
+      let qtyToAllocate = matchedLine.unallocated
+
+      // If what remains is actually less than the line we instead set qtyToAllocate to what remains. We check this
+      // on both the chargeReference and the element
+      const chargeReferenceRemainingAllocation = chargeReference.volume - chargeReference.allocatedQuantity
+
+      if (qtyToAllocate > chargeReferenceRemainingAllocation) {
+        qtyToAllocate = chargeReferenceRemainingAllocation
+      } else if (remainingAllocation < matchedLine.unallocated) {
+        qtyToAllocate = remainingAllocation
+      }
+
+      // We do this check to prevent overwriting the value with false once it's been set to true as it only requires
+      // a single `matchedLine` to overlap the charge period
+      if (!chargeElement.chargeDatesOverlap) {
+        chargeElement.chargeDatesOverlap = _chargeDatesOverlap(matchedLine, chargePeriod)
+      }
+
+      chargeElement.allocatedQuantity += qtyToAllocate
+      chargeElement.returnLogs[i].allocatedQuantity += qtyToAllocate
+
+      // NOTE: This is the only change from the real service. It is here to support the check endpoint
+      if (!chargeElement.returnLogs[i].lines) {
+        chargeElement.returnLogs[i].lines = [{ id: matchedLine.id, allocated: qtyToAllocate }]
+      } else {
+        chargeElement.returnLogs[i].lines.push({ id: matchedLine.id, allocated: qtyToAllocate })
+      }
+
+      matchedLine.unallocated -= qtyToAllocate
+      matchedReturn.allocatedQuantity += qtyToAllocate
+      chargeReference.allocatedQuantity += qtyToAllocate
+    }
   })
 }
 
@@ -46,89 +90,7 @@ function _chargeDatesOverlap (matchedLine, chargePeriod) {
     return true
   }
 
-  if (lineStartDate < chargePeriodStartDate && lineEndDate > chargePeriodStartDate) {
-    return true
-  }
-
-  return false
-}
-
-function _checkReturnForIssues (returnRecord) {
-  if (returnRecord.nilReturn) {
-    return true
-  }
-
-  if (returnRecord.underQuery) {
-    return true
-  }
-
-  if (returnRecord.status !== 'completed') {
-    return true
-  }
-
-  if (returnRecord.returnSubmissions.length === 0 || returnRecord.returnSubmissions[0].returnSubmissionLines.length === 0) {
-    return true
-  }
-
-  return false
-}
-
-function _matchAndAllocate (chargeElement, returnLogs, chargePeriod, chargeReference) {
-  const matchedReturns = _matchReturns(chargeElement, returnLogs)
-
-  if (matchedReturns.length === 0) {
-    return
-  }
-
-  matchedReturns.forEach((matchedReturn) => {
-    const matchedReturnResult = {
-      id: matchedReturn.id,
-      allocatedQuantity: 0,
-      lines: []
-    }
-
-    chargeElement.returnLogs.push(matchedReturnResult)
-    matchedReturn.matched = true
-
-    if (chargeElement.allocatedQuantity < chargeElement.authorisedAnnualQuantity && chargeReference.allocatedQuantity < chargeReference.volume) {
-      if (_checkReturnForIssues(matchedReturn)) {
-        return
-      }
-
-      const matchedLines = _matchLines(chargeElement, matchedReturn.returnSubmissions[0].returnSubmissionLines)
-
-      if (matchedLines.length === 0) {
-        return
-      }
-
-      matchedLines.forEach((matchedLine) => {
-        const remainingAllocation = chargeElement.authorisedAnnualQuantity - chargeElement.allocatedQuantity
-        if (remainingAllocation > 0) {
-          // We default how much to allocate to what is unallocated on the line i.e. remaining >= line.unallocated
-          let qtyToAllocate = matchedLine.unallocated
-
-          // If what remains is actually less than the line we instead set qtyToAllocate to what remains. We check this
-          // on both the chargeReference and the element
-          const chargeReferenceRemainingAllocation = chargeReference.volume - chargeReference.allocatedQuantity
-
-          if (qtyToAllocate > chargeReferenceRemainingAllocation) {
-            qtyToAllocate = chargeReferenceRemainingAllocation
-          } else if (remainingAllocation < matchedLine.unallocated) {
-            qtyToAllocate = remainingAllocation
-          }
-
-          chargeElement.chargeDatesOverlap = _chargeDatesOverlap(matchedLine, chargePeriod)
-          chargeElement.allocatedQuantity += qtyToAllocate
-          matchedReturnResult.allocatedQuantity += qtyToAllocate
-
-          matchedLine.unallocated -= qtyToAllocate
-          matchedReturn.allocatedQuantity += qtyToAllocate
-          chargeReference.allocatedQuantity += qtyToAllocate
-          matchedReturnResult.lines.push({ id: matchedLine.id, allocated: qtyToAllocate })
-        }
-      })
-    }
-  })
+  return (lineStartDate < chargePeriodStartDate && lineEndDate > chargePeriodStartDate)
 }
 
 function _matchLines (chargeElement, returnSubmissionLines) {
@@ -142,133 +104,6 @@ function _matchLines (chargeElement, returnSubmissionLines) {
   })
 }
 
-function _matchReturns (chargeElement, returnLogs) {
-  const elementCode = chargeElement.purpose.legacyId
-  const elementPeriods = chargeElement.abstractionPeriods
-
-  return returnLogs.filter((record) => {
-    const returnPeriods = record.abstractionPeriods
-
-    const matchFound = record.purposes.some((purpose) => {
-      return purpose.tertiary.code === elementCode
-    })
-
-    if (!matchFound) {
-      return false
-    }
-
-    return periodsOverlap(elementPeriods, returnPeriods)
-  })
-}
-
-// =====================================================================================================================
-// PrepareLicencesForAllocationService stand-in code
-// Delete when real service is merged
-const prepareLicencesForAllocationService = {
-  go: _prepareLicencesForAllocation
-}
-
-async function _prepareLicencesForAllocation (licences, billingPeriod) {
-  for (const licence of licences) {
-    licence.returnLogs = await FetchReturnLogsForLicenceService.go(licence.licenceRef, billingPeriod)
-
-    const { chargeVersions, returnLogs } = licence
-
-    _prepReturnsForMatching(returnLogs, billingPeriod)
-
-    chargeVersions.forEach((chargeVersion) => {
-      const { chargeReferences } = chargeVersion
-
-      _sortChargeReferencesBySubsistenceCharge(chargeReferences)
-      chargeVersion.chargePeriod = DetermineChargePeriodService.go(chargeVersion, billingPeriod)
-
-      chargeReferences.forEach((chargeReference) => {
-        const { chargeElements } = chargeReference
-
-        _prepChargeElementsForMatching(chargeElements, chargeVersion.chargePeriod)
-      })
-    })
-  }
-}
-
-function _abstractionOutsidePeriod (returnAbstractionPeriods, returnLine) {
-  const { startDate, endDate } = returnLine
-
-  return !periodsOverlap(returnAbstractionPeriods, [{ startDate, endDate }])
-}
-
-function _prepChargeElementsForMatching (chargeElements, chargePeriod) {
-  chargeElements.forEach((chargeElement) => {
-    const {
-      abstractionPeriodStartDay,
-      abstractionPeriodStartMonth,
-      abstractionPeriodEndDay,
-      abstractionPeriodEndMonth
-    } = chargeElement
-
-    const abstractionPeriods = DetermineAbstractionPeriodService.go(
-      chargePeriod,
-      abstractionPeriodStartDay,
-      abstractionPeriodStartMonth,
-      abstractionPeriodEndDay,
-      abstractionPeriodEndMonth
-    )
-
-    chargeElement.returnLogs = []
-    chargeElement.allocatedQuantity = 0
-    chargeElement.abstractionPeriods = abstractionPeriods
-  })
-}
-
-function _prepReturnsForMatching (returnLogs, billingPeriod) {
-  returnLogs.forEach((returnLog) => {
-    const { periodStartDay, periodStartMonth, periodEndDay, periodEndMonth, returnSubmissions } = returnLog
-    const abstractionPeriods = DetermineAbstractionPeriodService.go(
-      billingPeriod,
-      periodStartDay,
-      periodStartMonth,
-      periodEndDay,
-      periodEndMonth
-    )
-
-    let quantity = 0
-    let abstractionOutsidePeriod = false
-
-    returnSubmissions[0]?.returnSubmissionLines.forEach((returnSubmissionLine) => {
-      if (!abstractionOutsidePeriod) {
-        abstractionOutsidePeriod = _abstractionOutsidePeriod(abstractionPeriods, returnSubmissionLine)
-      }
-      returnSubmissionLine.unallocated = returnSubmissionLine.quantity / 1000
-      quantity += returnSubmissionLine.unallocated
-    })
-
-    returnLog.nilReturn = returnSubmissions[0]?.nilReturn ?? false
-    returnLog.quantity = quantity
-    returnLog.allocatedQuantity = 0
-    returnLog.abstractionPeriods = abstractionPeriods
-    returnLog.abstractionOutsidePeriod = abstractionOutsidePeriod
-    returnLog.matched = false
-  })
-}
-
-function _sortChargeReferencesBySubsistenceCharge (chargeReferences) {
-  return chargeReferences.sort((firstChargeReference, secondChargeReference) => {
-    const { subsistenceCharge: subsistenceChargeFirst } = firstChargeReference.chargeCategory
-    const { subsistenceCharge: subsistenceChargeSecond } = secondChargeReference.chargeCategory
-
-    if (subsistenceChargeFirst > subsistenceChargeSecond) {
-      return -1
-    }
-
-    if (subsistenceChargeFirst < subsistenceChargeSecond) {
-      return 1
-    }
-
-    return 0
-  })
-}
-
 module.exports = {
-  allocateReturnsToLicencesService,
-  prepareLicencesForAllocationService
+  AllocateReturnsToChargeElementService
 }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4339

This follows on from [Update 2PT check endpoint with alternate changes](https://github.com/DEFRA/water-abstraction-system/pull/582) where we applied the services we refactored out of our 2PT spike branch to the `/check` endpoint.

The final set of services has now been refactored and added to `main`, so we can update the stand-ins service.

We can also update the `TwoPartService` to use the new way of working, iterating all licences in one place and passing each licence to the new services.

---

We can drop the `PrepareLicences` from stand-ins and use the real one. However, when verifying the results we find it useful to see which lines were allocated to which elements. This is not something we care about when generating the review results for real.

The problem is this can only happen deep inside the allocation process. We don't want to add toggles to the production service just for this. We're on the cusp of having the pages ready to go at which point we expect the `/check` endpoint to become defunct.

So, for now, we just copy the real `AllocateReturnsToChargeElementService` into our stand-ins and add the tweak which captures which lines were allocated to it.