### PR TITLE
Move licence end date logic to model

### DIFF
--- a/app/presenters/licences/view-licence.presenter.js
+++ b/app/presenters/licences/view-licence.presenter.js
@@ -15,8 +15,8 @@ const { formatLongDate } = require('../base.presenter.js')
  * @returns {Object} The data formatted for the view template
  */
 function go (licence) {
-  const { expiredDate, id, lapsedDate, licenceRef, region, revokedDate, startDate } = licence
-  const warning = _generateWarningMessage(expiredDate, lapsedDate, revokedDate)
+  const { expiredDate, id, licenceRef, region, startDate } = licence
+  const warning = _generateWarningMessage(licence)
 
   return {
     id,
@@ -28,17 +28,6 @@ function go (licence) {
   }
 }
 
-function _compareEndDates (firstEndDate, secondEndDate) {
-  if (firstEndDate.date.getTime() === secondEndDate.date.getTime()) {
-    if (firstEndDate.name === 'revoked') return firstEndDate
-    if (secondEndDate.name === 'revoked') return secondEndDate
-    if (firstEndDate.name === 'lapsed') return firstEndDate
-  } else if (firstEndDate.date < secondEndDate.date) {
-    return firstEndDate
-  }
-  return secondEndDate
-}
-
 function _endDate (expiredDate) {
   if (!expiredDate || expiredDate < Date.now()) {
     return null
@@ -47,46 +36,24 @@ function _endDate (expiredDate) {
   return formatLongDate(expiredDate)
 }
 
-function _generateWarningMessage (expiredDate, lapsedDate, revokedDate) {
-  const endDates = []
+function _generateWarningMessage (licence) {
+  const ends = licence.$ends()
 
-  if (lapsedDate) {
-    endDates.push({
-      name: 'lapsed',
-      message: `This licence lapsed on ${formatLongDate(lapsedDate)}`,
-      date: lapsedDate
-    })
-  }
-
-  if (expiredDate) {
-    endDates.push({
-      name: 'expired',
-      message: `This licence expired on ${formatLongDate(expiredDate)}`,
-      date: expiredDate
-    })
-  }
-
-  if (revokedDate) {
-    endDates.push({
-      name: 'revoked',
-      message: `This licence was revoked on ${formatLongDate(revokedDate)}`,
-      date: revokedDate
-    })
-  }
-
-  if (endDates.length === 0) {
+  if (!ends) {
     return null
   }
 
-  if (endDates.length === 1) {
-    return endDates[0].message
+  const { date, reason } = ends
+
+  if (reason === 'revoked') {
+    return `This licence was revoked on ${formatLongDate(date)}`
   }
 
-  const earliestPriorityEndDate = endDates.reduce((result, endDate) => {
-    return _compareEndDates(result, endDate)
-  })
+  if (reason === 'lapsed') {
+    return `This licence lapsed on ${formatLongDate(date)}`
+  }
 
-  return earliestPriorityEndDate.message
+  return `This licence expired on ${formatLongDate(date)}`
 }
 
 module.exports = {

--- a/app/presenters/licences/view-licence.presenter.js
+++ b/app/presenters/licences/view-licence.presenter.js
@@ -44,6 +44,11 @@ function _generateWarningMessage (licence) {
   }
 
   const { date, reason } = ends
+  const today = new Date()
+
+  if (date > today) {
+    return null
+  }
 
   if (reason === 'revoked') {
     return `This licence was revoked on ${formatLongDate(date)}`

--- a/app/services/return-requirements/initiate-return-requirement-session.service.js
+++ b/app/services/return-requirements/initiate-return-requirement-session.service.js
@@ -49,6 +49,7 @@ function _data (licence, journey) {
   return {
     licence: {
       id,
+      ends: licence.$ends(),
       licenceRef,
       licenceHolder: _licenceHolder(licenceDocument),
       startDate: _startDate(licenceVersions)
@@ -62,7 +63,10 @@ async function _fetchLicence (licenceId) {
     .findById(licenceId)
     .select([
       'id',
-      'licenceRef'
+      'expiredDate',
+      'lapsedDate',
+      'licenceRef',
+      'revokedDate'
     ])
     .withGraphFetched('licenceVersions')
     .modifyGraph('licenceVersions', (builder) => {

--- a/test/models/licence.model.test.js
+++ b/test/models/licence.model.test.js
@@ -277,4 +277,189 @@ describe('Licence model', () => {
       })
     })
   })
+
+  describe('$ends', () => {
+    let expiredDate
+    let lapsedDate
+    let revokedDate
+
+    describe('when no end dates are set', () => {
+      it('returns null', () => {
+        testRecord = LicenceModel.fromJson({})
+
+        expect(testRecord.$ends()).to.be.null()
+      })
+    })
+
+    describe('when all the end dates are null', () => {
+      beforeEach(() => {
+        expiredDate = null
+        lapsedDate = null
+        revokedDate = null
+      })
+
+      it('returns null', () => {
+        testRecord = LicenceModel.fromJson({ expiredDate, lapsedDate, revokedDate })
+
+        expect(testRecord.$ends()).to.be.null()
+      })
+    })
+
+    describe('when only the revoked date is set', () => {
+      beforeEach(() => {
+        revokedDate = new Date('2023-03-07')
+      })
+
+      it("returns 'revoked' as the reason and '2023-03-07' as the date", () => {
+        const result = LicenceModel.fromJson({ revokedDate }).$ends()
+
+        expect(result).to.equal({ date: new Date('2023-03-07'), priority: 1, reason: 'revoked' })
+      })
+    })
+
+    describe('when only the lapsed date is set', () => {
+      beforeEach(() => {
+        lapsedDate = new Date('2023-03-08')
+      })
+
+      it("returns 'lapsed' as the reason and '2023-03-08' as the date", () => {
+        const result = LicenceModel.fromJson({ lapsedDate }).$ends()
+
+        expect(result).to.equal({ date: new Date('2023-03-08'), priority: 2, reason: 'lapsed' })
+      })
+    })
+
+    describe('when only the expired date is set', () => {
+      beforeEach(() => {
+        expiredDate = new Date('2023-03-09')
+      })
+
+      it("returns 'lapsed' as the reason and '2023-03-09' as the date", () => {
+        const result = LicenceModel.fromJson({ expiredDate }).$ends()
+
+        expect(result).to.equal({ date: new Date('2023-03-09'), priority: 3, reason: 'expired' })
+      })
+    })
+
+    describe('when two dates are set', () => {
+      describe('that have different dates', () => {
+        beforeEach(() => {
+          expiredDate = new Date('2023-03-09')
+          lapsedDate = new Date('2023-03-08')
+        })
+
+        it('returns the one with the earliest date', () => {
+          const result = LicenceModel.fromJson({ expiredDate, lapsedDate }).$ends()
+
+          expect(result).to.equal({ date: new Date('2023-03-08'), priority: 2, reason: 'lapsed' })
+        })
+      })
+
+      describe('that have the same date', () => {
+        beforeEach(() => {
+          expiredDate = new Date('2023-03-09')
+          lapsedDate = new Date('2023-03-09')
+          revokedDate = new Date('2023-03-09')
+        })
+
+        describe("and they are 'lapsed' and 'expired'", () => {
+          it("returns 'lapsed' as the end date", () => {
+            const result = LicenceModel.fromJson({ expiredDate, lapsedDate }).$ends()
+
+            expect(result).to.equal({ date: new Date('2023-03-09'), priority: 2, reason: 'lapsed' })
+          })
+        })
+
+        describe("and they are 'lapsed' and 'revoked'", () => {
+          it("returns 'revoked' as the end date", () => {
+            const result = LicenceModel.fromJson({ lapsedDate, revokedDate }).$ends()
+
+            expect(result).to.equal({ date: new Date('2023-03-09'), priority: 1, reason: 'revoked' })
+          })
+        })
+
+        describe("and they are 'expired' and 'revoked'", () => {
+          it("returns 'revoked' as the end date", () => {
+            const result = LicenceModel.fromJson({ expiredDate, revokedDate }).$ends()
+
+            expect(result).to.equal({ date: new Date('2023-03-09'), priority: 1, reason: 'revoked' })
+          })
+        })
+      })
+    })
+
+    describe('when all dates are set', () => {
+      describe('and all have different dates', () => {
+        beforeEach(() => {
+          expiredDate = new Date('2023-03-09')
+          lapsedDate = new Date('2023-03-08')
+          revokedDate = new Date('2023-03-07')
+        })
+
+        it('returns the one with the earliest date', () => {
+          const result = LicenceModel.fromJson({ expiredDate, lapsedDate, revokedDate }).$ends()
+
+          expect(result).to.equal({ date: new Date('2023-03-07'), priority: 1, reason: 'revoked' })
+        })
+      })
+
+      describe('and two have the same earliest date', () => {
+        describe("and they are 'lapsed' and 'expired'", () => {
+          beforeEach(() => {
+            expiredDate = new Date('2023-03-09')
+            lapsedDate = new Date('2023-03-09')
+            revokedDate = new Date('2023-03-10')
+          })
+
+          it("returns 'lapsed' as the end date", () => {
+            const result = LicenceModel.fromJson({ expiredDate, lapsedDate, revokedDate }).$ends()
+
+            expect(result).to.equal({ date: new Date('2023-03-09'), priority: 2, reason: 'lapsed' })
+          })
+        })
+
+        describe("and they are 'lapsed' and 'revoked'", () => {
+          beforeEach(() => {
+            expiredDate = new Date('2023-03-10')
+            lapsedDate = new Date('2023-03-09')
+            revokedDate = new Date('2023-03-09')
+          })
+
+          it("returns 'revoked' as the end date", () => {
+            const result = LicenceModel.fromJson({ expiredDate, lapsedDate, revokedDate }).$ends()
+
+            expect(result).to.equal({ date: new Date('2023-03-09'), priority: 1, reason: 'revoked' })
+          })
+        })
+
+        describe("and they are 'expired' and 'revoked'", () => {
+          beforeEach(() => {
+            expiredDate = new Date('2023-03-09')
+            lapsedDate = new Date('2023-03-10')
+            revokedDate = new Date('2023-03-09')
+          })
+
+          it("returns 'revoked' as the end date", () => {
+            const result = LicenceModel.fromJson({ expiredDate, lapsedDate, revokedDate }).$ends()
+
+            expect(result).to.equal({ date: new Date('2023-03-09'), priority: 1, reason: 'revoked' })
+          })
+        })
+      })
+
+      describe('and all have the same date', () => {
+        beforeEach(() => {
+          expiredDate = new Date('2023-03-09')
+          lapsedDate = new Date('2023-03-09')
+          revokedDate = new Date('2023-03-09')
+        })
+
+        it("returns 'revoked' as the end date", () => {
+          const result = LicenceModel.fromJson({ lapsedDate, revokedDate }).$ends()
+
+          expect(result).to.equal({ date: new Date('2023-03-09'), priority: 1, reason: 'revoked' })
+        })
+      })
+    })
+  })
 })

--- a/test/services/licences/view-licence.service.test.js
+++ b/test/services/licences/view-licence.service.test.js
@@ -39,244 +39,82 @@ describe('View Licence service', () => {
       })
     })
 
-    describe('and it has an expired date, revoked date and lapsed date all in the past on the same day', () => {
+    describe("and it did 'end' in the past", () => {
       beforeEach(() => {
         fetchLicenceResult = _testLicence()
-        fetchLicenceResult.expiredDate = new Date('2023-03-07')
-        fetchLicenceResult.lapsedDate = new Date('2023-03-07')
-        fetchLicenceResult.revokedDate = new Date('2023-03-07')
-        Sinon.stub(FetchLicenceService, 'go').resolves(fetchLicenceResult)
       })
 
-      it('will return the data and format it for use in the licence summary page', async () => {
-        const result = await ViewLicenceService.go(testId)
+      describe('because it was revoked', () => {
+        beforeEach(() => {
+          fetchLicenceResult.revokedDate = new Date('2023-03-07')
+          Sinon.stub(FetchLicenceService, 'go').resolves(fetchLicenceResult)
+        })
 
-        expect(result.warning).to.equal('This licence was revoked on 7 March 2023')
+        it('will include the revoked warning message for use in the view licence page', async () => {
+          const result = await ViewLicenceService.go(testId)
+
+          expect(result.warning).to.equal('This licence was revoked on 7 March 2023')
+        })
+      })
+
+      describe('because it was lapsed', () => {
+        beforeEach(() => {
+          fetchLicenceResult.lapsedDate = new Date('2023-03-07')
+          Sinon.stub(FetchLicenceService, 'go').resolves(fetchLicenceResult)
+        })
+
+        it('will include the lapsed warning message for use in the view licence page', async () => {
+          const result = await ViewLicenceService.go(testId)
+
+          expect(result.warning).to.equal('This licence lapsed on 7 March 2023')
+        })
+      })
+
+      describe('because it was expired', () => {
+        beforeEach(() => {
+          fetchLicenceResult.expiredDate = new Date('2023-03-07')
+          Sinon.stub(FetchLicenceService, 'go').resolves(fetchLicenceResult)
+        })
+
+        it('will include the expired warning message for use in the view licence page', async () => {
+          const result = await ViewLicenceService.go(testId)
+
+          expect(result.warning).to.equal('This licence expired on 7 March 2023')
+        })
       })
     })
 
-    describe('and it has no expired date but revoked and lapsed dates are in the past on the same day', () => {
+    describe("and it did 'ends' today", () => {
       beforeEach(() => {
         fetchLicenceResult = _testLicence()
-        fetchLicenceResult.lapsedDate = new Date('2023-03-07')
-        fetchLicenceResult.revokedDate = new Date('2023-03-07')
+        fetchLicenceResult.revokedDate = new Date()
         Sinon.stub(FetchLicenceService, 'go').resolves(fetchLicenceResult)
       })
 
-      it('will return the data and format it for use in the licence summary page', async () => {
+      it('will include a warning message for use in the view licence page', async () => {
         const result = await ViewLicenceService.go(testId)
 
-        expect(result.warning).to.equal('This licence was revoked on 7 March 2023')
+        expect(result.warning).to.startWith('This licence was revoked on')
       })
     })
 
-    describe('and it has no lapsed date but expired and revoked dates are in the past on the same day', () => {
+    describe("and it did 'ends' in the future", () => {
       beforeEach(() => {
         fetchLicenceResult = _testLicence()
-        fetchLicenceResult.expiredDate = new Date('2023-03-07')
-        fetchLicenceResult.revokedDate = new Date('2023-03-07')
+
+        // Set the 'end' date to tomorrow
+        const today = new Date()
+        // 86400000 is one day in milliseconds
+        const tomorrow = new Date(today.getTime() + 86400000)
+        fetchLicenceResult.revokedDate = tomorrow
+
         Sinon.stub(FetchLicenceService, 'go').resolves(fetchLicenceResult)
       })
 
-      it('will return the data and format it for use in the licence summary page', async () => {
+      it('will include a warning message for use in the view licence page', async () => {
         const result = await ViewLicenceService.go(testId)
 
-        expect(result.warning).to.equal('This licence was revoked on 7 March 2023')
-      })
-    })
-
-    describe('and it has no revoked date but expired and lapsed dates are in the past on the same day', () => {
-      beforeEach(() => {
-        fetchLicenceResult = _testLicence()
-        fetchLicenceResult.expiredDate = new Date('2023-03-07')
-        fetchLicenceResult.lapsedDate = new Date('2023-03-07')
-        Sinon.stub(FetchLicenceService, 'go').resolves(fetchLicenceResult)
-      })
-
-      it('will return the data and format it for use in the licence summary page', async () => {
-        const result = await ViewLicenceService.go(testId)
-
-        expect(result.warning).to.equal('This licence lapsed on 7 March 2023')
-      })
-    })
-
-    describe('and it only has an expired date', () => {
-      beforeEach(() => {
-        fetchLicenceResult = _testLicence()
-        fetchLicenceResult.expiredDate = new Date('2023-03-07')
-        Sinon.stub(FetchLicenceService, 'go').resolves(fetchLicenceResult)
-      })
-
-      it('will return the data and format it for use in the licence summary page', async () => {
-        const result = await ViewLicenceService.go(testId)
-
-        expect(result.warning).to.equal('This licence expired on 7 March 2023')
-      })
-    })
-
-    describe('and it only has a lapsed date', () => {
-      beforeEach(() => {
-        fetchLicenceResult = _testLicence()
-        fetchLicenceResult.lapsedDate = new Date('2023-03-07')
-        Sinon.stub(FetchLicenceService, 'go').resolves(fetchLicenceResult)
-      })
-
-      it('will return the data and format it for use in the licence summary page', async () => {
-        const result = await ViewLicenceService.go(testId)
-
-        expect(result.warning).to.equal('This licence lapsed on 7 March 2023')
-      })
-    })
-
-    describe('and it only has a revoked date', () => {
-      beforeEach(() => {
-        fetchLicenceResult = _testLicence()
-        fetchLicenceResult.revokedDate = new Date('2023-03-07')
-        Sinon.stub(FetchLicenceService, 'go').resolves(fetchLicenceResult)
-      })
-
-      it('will return the data and format it for use in the licence summary page', async () => {
-        const result = await ViewLicenceService.go(testId)
-
-        expect(result.warning).to.equal('This licence was revoked on 7 March 2023')
-      })
-    })
-
-    describe('and it has an expired and revoked date with expired being earlier', () => {
-      beforeEach(() => {
-        fetchLicenceResult = _testLicence()
-        fetchLicenceResult.revokedDate = new Date('2023-03-07')
-        fetchLicenceResult.expiredDate = new Date('2023-02-07')
-        Sinon.stub(FetchLicenceService, 'go').resolves(fetchLicenceResult)
-      })
-
-      it('will return the data and format it for use in the licence summary page', async () => {
-        const result = await ViewLicenceService.go(testId)
-
-        expect(result.warning).to.equal('This licence expired on 7 February 2023')
-      })
-    })
-
-    describe('and it has an expired and lapsed date with expired being earlier', () => {
-      beforeEach(() => {
-        fetchLicenceResult = _testLicence()
-        fetchLicenceResult.expiredDate = new Date('2023-02-07')
-        fetchLicenceResult.lapsedDate = new Date('2023-03-07')
-        Sinon.stub(FetchLicenceService, 'go').resolves(fetchLicenceResult)
-      })
-
-      it('will return the data and format it for use in the licence summary page', async () => {
-        const result = await ViewLicenceService.go(testId)
-
-        expect(result.warning).to.equal('This licence expired on 7 February 2023')
-      })
-    })
-
-    describe('and it has an expired and lapsed date with lapsed being earlier', () => {
-      beforeEach(() => {
-        fetchLicenceResult = _testLicence()
-        fetchLicenceResult.expiredDate = new Date('2023-03-07')
-        fetchLicenceResult.lapsedDate = new Date('2023-02-07')
-        Sinon.stub(FetchLicenceService, 'go').resolves(fetchLicenceResult)
-      })
-
-      it('will return the data and format it for use in the licence summary page', async () => {
-        const result = await ViewLicenceService.go(testId)
-
-        expect(result.warning).to.equal('This licence lapsed on 7 February 2023')
-      })
-    })
-
-    describe('and it has an expired and revoked date with revoked being earlier', () => {
-      beforeEach(() => {
-        fetchLicenceResult = _testLicence()
-        fetchLicenceResult.expiredDate = new Date('2023-03-07')
-        fetchLicenceResult.revokedDate = new Date('2023-02-07')
-        Sinon.stub(FetchLicenceService, 'go').resolves(fetchLicenceResult)
-      })
-
-      it('will return the data and format it for use in the licence summary page', async () => {
-        const result = await ViewLicenceService.go(testId)
-
-        expect(result.warning).to.equal('This licence was revoked on 7 February 2023')
-      })
-    })
-
-    describe('and it has a revoked and lapsed date with lapsed being earlier', () => {
-      beforeEach(() => {
-        fetchLicenceResult = _testLicence()
-        fetchLicenceResult.lapsedDate = new Date('2023-02-07')
-        fetchLicenceResult.revokedDate = new Date('2023-03-07')
-        Sinon.stub(FetchLicenceService, 'go').resolves(fetchLicenceResult)
-      })
-
-      it('will return the data and format it for use in the licence summary page', async () => {
-        const result = await ViewLicenceService.go(testId)
-
-        expect(result.warning).to.equal('This licence lapsed on 7 February 2023')
-      })
-    })
-
-    describe('and it has a revoked and lapsed date with revoked being earlier', () => {
-      beforeEach(() => {
-        fetchLicenceResult = _testLicence()
-        fetchLicenceResult.revokedDate = new Date('2023-02-07')
-        fetchLicenceResult.lapsedDate = new Date('2023-03-07')
-        Sinon.stub(FetchLicenceService, 'go').resolves(fetchLicenceResult)
-      })
-
-      it('will return the data and format it for use in the licence summary page', async () => {
-        const result = await ViewLicenceService.go(testId)
-
-        expect(result.warning).to.equal('This licence was revoked on 7 February 2023')
-      })
-    })
-
-    describe('and it has a revoked, expired and lapsed date with revoked being earlier', () => {
-      beforeEach(() => {
-        fetchLicenceResult = _testLicence()
-        fetchLicenceResult.revokedDate = new Date('2023-02-07')
-        fetchLicenceResult.lapsedDate = new Date('2023-03-07')
-        fetchLicenceResult.expiredDate = new Date('2023-03-07')
-        Sinon.stub(FetchLicenceService, 'go').resolves(fetchLicenceResult)
-      })
-
-      it('will return the data and format it for use in the licence summary page', async () => {
-        const result = await ViewLicenceService.go(testId)
-
-        expect(result.warning).to.equal('This licence was revoked on 7 February 2023')
-      })
-    })
-
-    describe('and it has a revoked, expired and lapsed date with expired being earlier', () => {
-      beforeEach(() => {
-        fetchLicenceResult = _testLicence()
-        fetchLicenceResult.revokedDate = new Date('2023-03-07')
-        fetchLicenceResult.lapsedDate = new Date('2023-03-07')
-        fetchLicenceResult.expiredDate = new Date('2023-02-07')
-        Sinon.stub(FetchLicenceService, 'go').resolves(fetchLicenceResult)
-      })
-
-      it('will return the data and format it for use in the licence summary page', async () => {
-        const result = await ViewLicenceService.go(testId)
-
-        expect(result.warning).to.equal('This licence expired on 7 February 2023')
-      })
-    })
-
-    describe('and it has a revoked, expired and lapsed date with lapsed being earlier', () => {
-      beforeEach(() => {
-        fetchLicenceResult = _testLicence()
-        fetchLicenceResult.revokedDate = new Date('2023-03-07')
-        fetchLicenceResult.lapsedDate = new Date('2023-02-07')
-        fetchLicenceResult.expiredDate = new Date('2023-03-07')
-        Sinon.stub(FetchLicenceService, 'go').resolves(fetchLicenceResult)
-      })
-
-      it('will return the data and format it for use in the licence summary page', async () => {
-        const result = await ViewLicenceService.go(testId)
-
-        expect(result.warning).to.equal('This licence lapsed on 7 February 2023')
+        expect(result.warning).to.be.null()
       })
     })
   })

--- a/test/services/licences/view-licence.service.test.js
+++ b/test/services/licences/view-licence.service.test.js
@@ -8,6 +8,9 @@ const Sinon = require('sinon')
 const { describe, it, beforeEach, afterEach } = exports.lab = Lab.script()
 const { expect } = Code
 
+// Test helpers
+const LicenceModel = require('../../../app/models/licence.model.js')
+
 // Things we need to stub
 const FetchLicenceService = require('../../../app/services/licences/fetch-licence.service.js')
 
@@ -25,7 +28,7 @@ describe('View Licence service', () => {
   describe('when a licence with a matching ID exists', () => {
     describe('and it does not have an expired, lapsed, or revoke date', () => {
       beforeEach(() => {
-        fetchLicenceResult = _licenceData()
+        fetchLicenceResult = _testLicence()
         Sinon.stub(FetchLicenceService, 'go').resolves(fetchLicenceResult)
       })
 
@@ -38,7 +41,7 @@ describe('View Licence service', () => {
 
     describe('and it has an expired date, revoked date and lapsed date all in the past on the same day', () => {
       beforeEach(() => {
-        fetchLicenceResult = _licenceData()
+        fetchLicenceResult = _testLicence()
         fetchLicenceResult.expiredDate = new Date('2023-03-07')
         fetchLicenceResult.lapsedDate = new Date('2023-03-07')
         fetchLicenceResult.revokedDate = new Date('2023-03-07')
@@ -54,7 +57,7 @@ describe('View Licence service', () => {
 
     describe('and it has no expired date but revoked and lapsed dates are in the past on the same day', () => {
       beforeEach(() => {
-        fetchLicenceResult = _licenceData()
+        fetchLicenceResult = _testLicence()
         fetchLicenceResult.lapsedDate = new Date('2023-03-07')
         fetchLicenceResult.revokedDate = new Date('2023-03-07')
         Sinon.stub(FetchLicenceService, 'go').resolves(fetchLicenceResult)
@@ -69,7 +72,7 @@ describe('View Licence service', () => {
 
     describe('and it has no lapsed date but expired and revoked dates are in the past on the same day', () => {
       beforeEach(() => {
-        fetchLicenceResult = _licenceData()
+        fetchLicenceResult = _testLicence()
         fetchLicenceResult.expiredDate = new Date('2023-03-07')
         fetchLicenceResult.revokedDate = new Date('2023-03-07')
         Sinon.stub(FetchLicenceService, 'go').resolves(fetchLicenceResult)
@@ -84,7 +87,7 @@ describe('View Licence service', () => {
 
     describe('and it has no revoked date but expired and lapsed dates are in the past on the same day', () => {
       beforeEach(() => {
-        fetchLicenceResult = _licenceData()
+        fetchLicenceResult = _testLicence()
         fetchLicenceResult.expiredDate = new Date('2023-03-07')
         fetchLicenceResult.lapsedDate = new Date('2023-03-07')
         Sinon.stub(FetchLicenceService, 'go').resolves(fetchLicenceResult)
@@ -99,7 +102,7 @@ describe('View Licence service', () => {
 
     describe('and it only has an expired date', () => {
       beforeEach(() => {
-        fetchLicenceResult = _licenceData()
+        fetchLicenceResult = _testLicence()
         fetchLicenceResult.expiredDate = new Date('2023-03-07')
         Sinon.stub(FetchLicenceService, 'go').resolves(fetchLicenceResult)
       })
@@ -113,7 +116,7 @@ describe('View Licence service', () => {
 
     describe('and it only has a lapsed date', () => {
       beforeEach(() => {
-        fetchLicenceResult = _licenceData()
+        fetchLicenceResult = _testLicence()
         fetchLicenceResult.lapsedDate = new Date('2023-03-07')
         Sinon.stub(FetchLicenceService, 'go').resolves(fetchLicenceResult)
       })
@@ -127,7 +130,7 @@ describe('View Licence service', () => {
 
     describe('and it only has a revoked date', () => {
       beforeEach(() => {
-        fetchLicenceResult = _licenceData()
+        fetchLicenceResult = _testLicence()
         fetchLicenceResult.revokedDate = new Date('2023-03-07')
         Sinon.stub(FetchLicenceService, 'go').resolves(fetchLicenceResult)
       })
@@ -141,7 +144,7 @@ describe('View Licence service', () => {
 
     describe('and it has an expired and revoked date with expired being earlier', () => {
       beforeEach(() => {
-        fetchLicenceResult = _licenceData()
+        fetchLicenceResult = _testLicence()
         fetchLicenceResult.revokedDate = new Date('2023-03-07')
         fetchLicenceResult.expiredDate = new Date('2023-02-07')
         Sinon.stub(FetchLicenceService, 'go').resolves(fetchLicenceResult)
@@ -156,7 +159,7 @@ describe('View Licence service', () => {
 
     describe('and it has an expired and lapsed date with expired being earlier', () => {
       beforeEach(() => {
-        fetchLicenceResult = _licenceData()
+        fetchLicenceResult = _testLicence()
         fetchLicenceResult.expiredDate = new Date('2023-02-07')
         fetchLicenceResult.lapsedDate = new Date('2023-03-07')
         Sinon.stub(FetchLicenceService, 'go').resolves(fetchLicenceResult)
@@ -171,7 +174,7 @@ describe('View Licence service', () => {
 
     describe('and it has an expired and lapsed date with lapsed being earlier', () => {
       beforeEach(() => {
-        fetchLicenceResult = _licenceData()
+        fetchLicenceResult = _testLicence()
         fetchLicenceResult.expiredDate = new Date('2023-03-07')
         fetchLicenceResult.lapsedDate = new Date('2023-02-07')
         Sinon.stub(FetchLicenceService, 'go').resolves(fetchLicenceResult)
@@ -186,7 +189,7 @@ describe('View Licence service', () => {
 
     describe('and it has an expired and revoked date with revoked being earlier', () => {
       beforeEach(() => {
-        fetchLicenceResult = _licenceData()
+        fetchLicenceResult = _testLicence()
         fetchLicenceResult.expiredDate = new Date('2023-03-07')
         fetchLicenceResult.revokedDate = new Date('2023-02-07')
         Sinon.stub(FetchLicenceService, 'go').resolves(fetchLicenceResult)
@@ -201,7 +204,7 @@ describe('View Licence service', () => {
 
     describe('and it has a revoked and lapsed date with lapsed being earlier', () => {
       beforeEach(() => {
-        fetchLicenceResult = _licenceData()
+        fetchLicenceResult = _testLicence()
         fetchLicenceResult.lapsedDate = new Date('2023-02-07')
         fetchLicenceResult.revokedDate = new Date('2023-03-07')
         Sinon.stub(FetchLicenceService, 'go').resolves(fetchLicenceResult)
@@ -216,7 +219,7 @@ describe('View Licence service', () => {
 
     describe('and it has a revoked and lapsed date with revoked being earlier', () => {
       beforeEach(() => {
-        fetchLicenceResult = _licenceData()
+        fetchLicenceResult = _testLicence()
         fetchLicenceResult.revokedDate = new Date('2023-02-07')
         fetchLicenceResult.lapsedDate = new Date('2023-03-07')
         Sinon.stub(FetchLicenceService, 'go').resolves(fetchLicenceResult)
@@ -231,7 +234,7 @@ describe('View Licence service', () => {
 
     describe('and it has a revoked, expired and lapsed date with revoked being earlier', () => {
       beforeEach(() => {
-        fetchLicenceResult = _licenceData()
+        fetchLicenceResult = _testLicence()
         fetchLicenceResult.revokedDate = new Date('2023-02-07')
         fetchLicenceResult.lapsedDate = new Date('2023-03-07')
         fetchLicenceResult.expiredDate = new Date('2023-03-07')
@@ -247,7 +250,7 @@ describe('View Licence service', () => {
 
     describe('and it has a revoked, expired and lapsed date with expired being earlier', () => {
       beforeEach(() => {
-        fetchLicenceResult = _licenceData()
+        fetchLicenceResult = _testLicence()
         fetchLicenceResult.revokedDate = new Date('2023-03-07')
         fetchLicenceResult.lapsedDate = new Date('2023-03-07')
         fetchLicenceResult.expiredDate = new Date('2023-02-07')
@@ -263,7 +266,7 @@ describe('View Licence service', () => {
 
     describe('and it has a revoked, expired and lapsed date with lapsed being earlier', () => {
       beforeEach(() => {
-        fetchLicenceResult = _licenceData()
+        fetchLicenceResult = _testLicence()
         fetchLicenceResult.revokedDate = new Date('2023-03-07')
         fetchLicenceResult.lapsedDate = new Date('2023-02-07')
         fetchLicenceResult.expiredDate = new Date('2023-03-07')
@@ -279,8 +282,8 @@ describe('View Licence service', () => {
   })
 })
 
-function _licenceData () {
-  return {
+function _testLicence () {
+  return LicenceModel.fromJson({
     id: '2c80bd22-a005-4cf4-a2a2-73812a9861de',
     licenceRef: '01/130/R01',
     region: {
@@ -288,5 +291,5 @@ function _licenceData () {
       displayName: 'South West'
     },
     startDate: new Date('2013-03-07')
-  }
+  })
 }

--- a/test/services/return-requirements/initiate-return-requirement-session.service.test.js
+++ b/test/services/return-requirements/initiate-return-requirement-session.service.test.js
@@ -37,7 +37,9 @@ describe('Initiate Return Requirement Session service', () => {
       let licenceDocument
 
       beforeEach(async () => {
-        licence = await LicenceHelper.add()
+        // Create the licence record with an 'end' date so we can confirm the session gets populated with the licence's
+        // 'ends' information
+        licence = await LicenceHelper.add({ expiredDate: new Date('2024-08-10') })
 
         // Create 2 licence versions so we can test the service only gets the 'current' version
         await LicenceVersionHelper.add({
@@ -97,6 +99,7 @@ describe('Initiate Return Requirement Session service', () => {
           const { data } = result
 
           expect(data.licence.id).to.equal(licence.id)
+          expect(data.licence.ends).to.equal({ date: new Date('2024-08-10'), priority: 3, reason: 'expired' })
           expect(data.licence.licenceRef).to.equal(licence.licenceRef)
           expect(data.licence.licenceHolder).to.equal('Licence Holder Ltd')
         })
@@ -140,6 +143,7 @@ describe('Initiate Return Requirement Session service', () => {
           const { data } = result
 
           expect(data.licence.id).to.equal(licence.id)
+          expect(data.licence.ends).to.equal({ date: new Date('2024-08-10'), priority: 3, reason: 'expired' })
           expect(data.licence.licenceRef).to.equal(licence.licenceRef)
           expect(data.licence.licenceHolder).to.equal('Luce Holder')
         })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4325
https://eaflood.atlassian.net/browse/WATER-4263

We have had two tickets come through that both need to determine if and when a licence 'ends'.

A licence can 'end' for 3 reasons:

- because it is _revoked_
- because it is _lapsed_
- because it is _expired_

The previous delivery team chose to encode these as 3 separate date fields on the licence record. So, if a field is populated it means the licence 'ends' for that reason on that day. But it's not that simple! 😁

More than one of these fields may be populated. For example, a licence was due to expire on 2023-08-10 but was then revoked on 2022-04-27. So, to determine the reason you need to select the _earliest_ date.

But there's more! 😲

We have examples where 2 of the fields might be populated with the same date (and 1 licence where all 3 have the same date!) So, how do you determine the 'end' reason then? If more than one date field is populated and they hold the earliest date value then we select based on priority; revoked -> lapsed -> expired.

Both tickets are connected to PRs that have to handle all or some of this logic.

- [Returns required journey - Select start date page iteration 2 (1 of 7)](https://github.com/DEFRA/water-abstraction-system/pull/646)
- [Add warning text to view licence page](https://github.com/DEFRA/water-abstraction-system/pull/670)

Both PRs will also have to write numerous tests to check the right date is being used, and we have a strong suspicion we are already doing something similar in supplementary billing and that we'll need the 'end' in future tickets.

So, enough is enough! This refactoring change moves the logic to the model, specifically, as a [custom Objection.js instance method](https://vincit.github.io/objection.js/api/model/instance-methods.html). This is something we've done in a [previous project](https://github.com/DEFRA/sroc-charging-module-api) and in this project to determine a `ContactModel`s name.

We can then remove the duplication both in logic and unit tests.

This change updates the model, adds the new tests, and then refactors existing usages to use the model's `$ends()` method.
