### PR TITLE
Create licence holder seeder

### DIFF
--- a/test/services/return-requirements/initiate-return-requirement-session.service.test.js
+++ b/test/services/return-requirements/initiate-return-requirement-session.service.test.js
@@ -8,13 +8,10 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const CompanyHelper = require('../../support/helpers/company.helper.js')
 const DatabaseHelper = require('../../support/helpers/database.helper.js')
 const LicenceHelper = require('../../support/helpers/licence.helper.js')
-const LicenceDocumentHelper = require('../../support/helpers/licence-document.helper.js')
-const LicenceDocumentRoleHelper = require('../../support/helpers/licence-document-role.helper.js')
-const LicenceRoleHelper = require('../../support/helpers/licence-role.helper.js')
 const LicenceVersionHelper = require('../../support/helpers/licence-version.helper.js')
+const LicenceHolderSeeder = require('../../support/seeders/licence-holder.seeder.js')
 
 // Thing under test
 const InitiateReturnRequirementSessionService = require('../../../app/services/return-requirements/initiate-return-requirement-session.service.js')
@@ -42,23 +39,8 @@ describe('Initiate Return Requirement Session service', () => {
           licenceId: licence.id, startDate: new Date('2022-05-01')
         })
 
-        // Create a licence role (the default is licenceHolder)
-        const licenceRole = await LicenceRoleHelper.add()
-
-        // Create a company record
-        const company = await CompanyHelper.add({ name: 'Licence Holder Ltd' })
-
-        // We have to create a licence document to link our licence record to (eventually!) the company or contact
-        // record that is the 'licence holder'
-        const licenceDocument = await LicenceDocumentHelper.add({ licenceRef: licence.licenceRef })
-
-        // Create the licence document role record that _is_ linked to the correct licence holder record
-        await LicenceDocumentRoleHelper.add({
-          licenceDocumentId: licenceDocument.id,
-          licenceRoleId: licenceRole.id,
-          companyId: company.id,
-          startDate: new Date('2022-08-01')
-        })
+        // Create a licence holder for the licence with the default name 'Licence Holder Ltd'
+        await LicenceHolderSeeder.seed(licence.licenceRef)
 
         journey = 'returns-required'
       })

--- a/test/support/seeders/licence-holder.seeder.js
+++ b/test/support/seeders/licence-holder.seeder.js
@@ -1,0 +1,40 @@
+'use strict'
+
+/**
+ * @module LicenceHolderSeeder
+ */
+
+const CompanyHelper = require('../helpers/company.helper.js')
+const LicenceDocumentHelper = require('../helpers/licence-document.helper.js')
+const LicenceDocumentRoleHelper = require('../helpers/licence-document-role.helper.js')
+const LicenceRoleHelper = require('../helpers/licence-role.helper.js')
+
+/**
+ * Adds a company to the provided licence that is set up to be the licence holder
+ *
+ * @param {String} licenceRef The licence reference that the company will be the licence holder for
+ * @param {String} name The name of the company that will be the licence holder
+ */
+async function seed (licenceRef, name = 'Licence Holder Ltd') {
+  // Create a licence role (the default is licenceHolder)
+  const licenceRole = await LicenceRoleHelper.add()
+
+  // Create a company record
+  const company = await CompanyHelper.add({ name })
+
+  // We have to create a licence document to link our licence record to (eventually!) the company or contact record that
+  // is the 'licence holder'
+  const licenceDocument = await LicenceDocumentHelper.add({ licenceRef })
+
+  // Create the licence document role record that _is_ linked to the correct licence holder record
+  await LicenceDocumentRoleHelper.add({
+    licenceDocumentId: licenceDocument.id,
+    licenceRoleId: licenceRole.id,
+    companyId: company.id,
+    startDate: new Date('2022-04-01')
+  })
+}
+
+module.exports = {
+  seed
+}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4188

Whilst carrying out testing there have been multiple instances where we need to create data for a licence holder. This isn't a simple process and involves creating records in 4 tables in the DB.

We have therefore created a "seeder" which when passed a licence reference will create the records required for a licence holder.