### PR TITLE
Add LicenceEntityRoleModel

### DIFF
--- a/app/models/licence-entity-role.model.js
+++ b/app/models/licence-entity-role.model.js
@@ -5,6 +5,8 @@
  * @module LicenceEntityRoleModel
  */
 
+const { Model } = require('objection')
+
 const BaseModel = require('./base.model.js')
 
 /**
@@ -22,6 +24,19 @@ const BaseModel = require('./base.model.js')
 class LicenceEntityRoleModel extends BaseModel {
   static get tableName () {
     return 'licenceEntityRoles'
+  }
+
+  static get relationMappings () {
+    return {
+      licenceEntity: {
+        relation: Model.BelongsToOneRelation,
+        modelClass: 'licence-entity.model',
+        join: {
+          from: 'licenceEntityRoles.licenceEntityId',
+          to: 'licenceEntities.id'
+        }
+      }
+    }
   }
 }
 

--- a/app/models/licence-entity-role.model.js
+++ b/app/models/licence-entity-role.model.js
@@ -28,6 +28,14 @@ class LicenceEntityRoleModel extends BaseModel {
 
   static get relationMappings () {
     return {
+      companyEntity: {
+        relation: Model.BelongsToOneRelation,
+        modelClass: 'licence-entity.model',
+        join: {
+          from: 'licenceEntityRoles.companyEntityId',
+          to: 'licenceEntities.id'
+        }
+      },
       licenceEntity: {
         relation: Model.BelongsToOneRelation,
         modelClass: 'licence-entity.model',

--- a/app/models/licence-entity-role.model.js
+++ b/app/models/licence-entity-role.model.js
@@ -1,0 +1,28 @@
+'use strict'
+
+/**
+ * Model for licence_entity_roles (crm.entity_roles)
+ * @module LicenceEntityRoleModel
+ */
+
+const BaseModel = require('./base.model.js')
+
+/**
+ * Represents an instance of a licence entity role record
+ *
+ * For reference, the licence entity role record is related to functionality that was added when the service was first built.
+ * It sits in the old `crm` schema and was not migrated to `crm_v2` as part of the previous team's efforts to replace
+ * the old legacy CRM setup.
+ *
+ * Currently, the only reason we need it is to identify if a licence has a 'registered user'. You'll see this
+ * highlighted when you view a licence.
+ *
+ * From it we can identify the 'entity' which has the role of primary user.
+ */
+class LicenceEntityRoleModel extends BaseModel {
+  static get tableName () {
+    return 'licenceEntityRoles'
+  }
+}
+
+module.exports = LicenceEntityRoleModel

--- a/app/models/licence-entity-role.model.js
+++ b/app/models/licence-entity-role.model.js
@@ -35,6 +35,14 @@ class LicenceEntityRoleModel extends BaseModel {
           from: 'licenceEntityRoles.licenceEntityId',
           to: 'licenceEntities.id'
         }
+      },
+      regimeEntity: {
+        relation: Model.BelongsToOneRelation,
+        modelClass: 'licence-entity.model',
+        join: {
+          from: 'licenceEntityRoles.regimeEntityId',
+          to: 'licenceEntities.id'
+        }
       }
     }
   }

--- a/app/models/licence-entity.model.js
+++ b/app/models/licence-entity.model.js
@@ -5,6 +5,8 @@
  * @module LicenceEntityModel
  */
 
+const { Model } = require('objection')
+
 const BaseModel = require('./base.model.js')
 
 /**
@@ -30,6 +32,19 @@ const BaseModel = require('./base.model.js')
 class LicenceEntityModel extends BaseModel {
   static get tableName () {
     return 'licenceEntities'
+  }
+
+  static get relationMappings () {
+    return {
+      licenceEntityRoles: {
+        relation: Model.HasManyRelation,
+        modelClass: 'licence-entity-role.model',
+        join: {
+          from: 'licenceEntities.id',
+          to: 'licenceEntityRoles.licenceEntityId'
+        }
+      }
+    }
   }
 }
 

--- a/db/migrations/legacy/20240127115605_create-crm-entity.js
+++ b/db/migrations/legacy/20240127115605_create-crm-entity.js
@@ -8,7 +8,7 @@ exports.up = function (knex) {
     .withSchema('crm')
     .createTable(tableName, (table) => {
       // Primary Key
-      table.uuid('entity_id').primary().defaultTo(knex.raw('gen_random_uuid()'))
+      table.string('entity_id').primary()
 
       // Data
       table.string('entity_nm').notNullable()

--- a/db/migrations/legacy/20240127132301_create-crm-entity-roles.js
+++ b/db/migrations/legacy/20240127132301_create-crm-entity-roles.js
@@ -1,0 +1,44 @@
+'use strict'
+
+const tableName = 'entity_roles'
+
+exports.up = function (knex) {
+  return knex
+    .schema
+    .withSchema('crm')
+    .createTable(tableName, (table) => {
+      // Primary Key
+      table.string('entity_role_id').primary()
+
+      // Data
+      table.string('entity_id')
+      table.string('role')
+      table.string('regime_entity_id')
+      table.string('company_entity_id')
+      table.string('created_by')
+
+      // Legacy timestamps
+      // NOTE: They are not automatically set and there are large numbers of records where these fields are null!
+      table.timestamp('created_at').defaultTo(knex.fn.now())
+    })
+    // If it was a simple check constraint we could have used https://knexjs.org/guide/schema-builder.html#checks
+    // But because of the complexity of the constraint we have had to drop to using raw() to add the constraint after
+    // Knex has created the table.
+    .raw(`
+      CREATE UNIQUE INDEX unique_role
+      ON crm.entity_roles USING btree (
+        entity_id,
+        COALESCE(regime_entity_id, '00000000-0000-0000-0000-000000000000'::character varying),
+        company_entity_id,
+        role
+      );
+    `)
+}
+
+exports.down = function (knex) {
+  return knex
+    .schema
+    .withSchema('crm')
+    .dropTableIfExists(tableName)
+    .drop
+}

--- a/db/migrations/public/20240127134739_create-licence-entity-roles-view.js
+++ b/db/migrations/public/20240127134739_create-licence-entity-roles-view.js
@@ -1,0 +1,29 @@
+'use strict'
+
+const viewName = 'licence_entity_roles'
+
+exports.up = function (knex) {
+  return knex
+    .schema
+    .createView(viewName, (view) => {
+      view.as(knex('entity_roles').withSchema('crm').select([
+        'entity_role_id AS id',
+        'entity_id AS licence_entity_id',
+        'role',
+        // This could be ignored as it is always set to the same ID. But that id comes from a single record in the
+        // crm.entity table which has the `entity_type` regime. So, for the purposes of testing we just have to live
+        // with always populating it even though we don't care about it.
+        'regime_entity_id',
+        'company_entity_id',
+        // NOTE: Can be a UUID to another entity or the email address of the user or NULL
+        'created_by',
+        'created_at'
+      ]))
+    })
+}
+
+exports.down = function (knex) {
+  return knex
+    .schema
+    .dropViewIfExists(viewName)
+}

--- a/test/models/licence-entity-role.model.test.js
+++ b/test/models/licence-entity-role.model.test.js
@@ -1,0 +1,36 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const DatabaseHelper = require('../support/helpers/database.helper.js')
+const LicenceEntityRoleHelper = require('../support/helpers/licence-entity-role.helper.js')
+
+// Thing under test
+const LicenceEntityRoleModel = require('../../app/models/licence-entity-role.model.js')
+
+describe('Licence Entity Role model', () => {
+  let testRecord
+
+  beforeEach(async () => {
+    await DatabaseHelper.clean()
+  })
+
+  describe('Basic query', () => {
+    beforeEach(async () => {
+      testRecord = await LicenceEntityRoleHelper.add()
+    })
+
+    it('can successfully run a basic query', async () => {
+      const result = await LicenceEntityRoleModel.query().findById(testRecord.id)
+
+      expect(result).to.be.an.instanceOf(LicenceEntityRoleModel)
+      expect(result.id).to.equal(testRecord.id)
+    })
+  })
+})

--- a/test/models/licence-entity-role.model.test.js
+++ b/test/models/licence-entity-role.model.test.js
@@ -37,6 +37,36 @@ describe('Licence Entity Role model', () => {
   })
 
   describe('Relationships', () => {
+    describe('when linking to company entity', () => {
+      let testCompanyEntity
+
+      beforeEach(async () => {
+        testCompanyEntity = await LicenceEntityHelper.add({ type: 'company' })
+
+        const { id: companyEntityId } = testCompanyEntity
+        testRecord = await LicenceEntityRoleHelper.add({ companyEntityId })
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await LicenceEntityRoleModel.query()
+          .innerJoinRelated('companyEntity')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the company entity', async () => {
+        const result = await LicenceEntityRoleModel.query()
+          .findById(testRecord.id)
+          .withGraphFetched('companyEntity')
+
+        expect(result).to.be.instanceOf(LicenceEntityRoleModel)
+        expect(result.id).to.equal(testRecord.id)
+
+        expect(result.companyEntity).to.be.an.instanceOf(LicenceEntityModel)
+        expect(result.companyEntity).to.equal(testCompanyEntity)
+      })
+    })
+
     describe('when linking to licence entity', () => {
       let testLicenceEntity
 

--- a/test/models/licence-entity-role.model.test.js
+++ b/test/models/licence-entity-role.model.test.js
@@ -9,6 +9,8 @@ const { expect } = Code
 
 // Test helpers
 const DatabaseHelper = require('../support/helpers/database.helper.js')
+const LicenceEntityHelper = require('../support/helpers/licence-entity.helper.js')
+const LicenceEntityModel = require('../../app/models/licence-entity.model.js')
 const LicenceEntityRoleHelper = require('../support/helpers/licence-entity-role.helper.js')
 
 // Thing under test
@@ -31,6 +33,38 @@ describe('Licence Entity Role model', () => {
 
       expect(result).to.be.an.instanceOf(LicenceEntityRoleModel)
       expect(result.id).to.equal(testRecord.id)
+    })
+  })
+
+  describe('Relationships', () => {
+    describe('when linking to licence entity', () => {
+      let testLicenceEntity
+
+      beforeEach(async () => {
+        testLicenceEntity = await LicenceEntityHelper.add()
+
+        const { id: licenceEntityId } = testLicenceEntity
+        testRecord = await LicenceEntityRoleHelper.add({ licenceEntityId })
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await LicenceEntityRoleModel.query()
+          .innerJoinRelated('licenceEntity')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the licence entity', async () => {
+        const result = await LicenceEntityRoleModel.query()
+          .findById(testRecord.id)
+          .withGraphFetched('licenceEntity')
+
+        expect(result).to.be.instanceOf(LicenceEntityRoleModel)
+        expect(result.id).to.equal(testRecord.id)
+
+        expect(result.licenceEntity).to.be.an.instanceOf(LicenceEntityModel)
+        expect(result.licenceEntity).to.equal(testLicenceEntity)
+      })
     })
   })
 })

--- a/test/models/licence-entity-role.model.test.js
+++ b/test/models/licence-entity-role.model.test.js
@@ -66,5 +66,35 @@ describe('Licence Entity Role model', () => {
         expect(result.licenceEntity).to.equal(testLicenceEntity)
       })
     })
+
+    describe('when linking to regime entity', () => {
+      let testRegimeEntity
+
+      beforeEach(async () => {
+        testRegimeEntity = await LicenceEntityHelper.add({ type: 'regime' })
+
+        const { id: regimeEntityId } = testRegimeEntity
+        testRecord = await LicenceEntityRoleHelper.add({ regimeEntityId })
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await LicenceEntityRoleModel.query()
+          .innerJoinRelated('regimeEntity')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the regime entity', async () => {
+        const result = await LicenceEntityRoleModel.query()
+          .findById(testRecord.id)
+          .withGraphFetched('regimeEntity')
+
+        expect(result).to.be.instanceOf(LicenceEntityRoleModel)
+        expect(result.id).to.equal(testRecord.id)
+
+        expect(result.regimeEntity).to.be.an.instanceOf(LicenceEntityModel)
+        expect(result.regimeEntity).to.equal(testRegimeEntity)
+      })
+    })
   })
 })

--- a/test/models/licence-entity.model.test.js
+++ b/test/models/licence-entity.model.test.js
@@ -10,6 +10,8 @@ const { expect } = Code
 // Test helpers
 const DatabaseHelper = require('../support/helpers/database.helper.js')
 const LicenceEntityHelper = require('../support/helpers/licence-entity.helper.js')
+const LicenceEntityRoleHelper = require('../support/helpers/licence-entity-role.helper.js')
+const LicenceEntityRoleModel = require('../../app/models/licence-entity-role.model.js')
 
 // Thing under test
 const LicenceEntityModel = require('../../app/models/licence-entity.model.js')
@@ -31,6 +33,45 @@ describe('Licence Entity model', () => {
 
       expect(result).to.be.an.instanceOf(LicenceEntityModel)
       expect(result.id).to.equal(testRecord.id)
+    })
+  })
+
+  describe('Relationships', () => {
+    describe('when linking to licence entity roles', () => {
+      let testLicenceEntityRoles
+
+      beforeEach(async () => {
+        testRecord = await LicenceEntityHelper.add()
+
+        const { id: licenceEntityId } = testRecord
+
+        testLicenceEntityRoles = []
+        for (let i = 0; i < 2; i++) {
+          const licenceEntityRole = await LicenceEntityRoleHelper.add({ licenceEntityId })
+          testLicenceEntityRoles.push(licenceEntityRole)
+        }
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await LicenceEntityModel.query()
+          .innerJoinRelated('licenceEntityRoles')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the licence entity roles', async () => {
+        const result = await LicenceEntityModel.query()
+          .findById(testRecord.id)
+          .withGraphFetched('licenceEntityRoles')
+
+        expect(result).to.be.instanceOf(LicenceEntityModel)
+        expect(result.id).to.equal(testRecord.id)
+
+        expect(result.licenceEntityRoles).to.be.an.array()
+        expect(result.licenceEntityRoles[0]).to.be.an.instanceOf(LicenceEntityRoleModel)
+        expect(result.licenceEntityRoles).to.include(testLicenceEntityRoles[0])
+        expect(result.licenceEntityRoles).to.include(testLicenceEntityRoles[1])
+      })
     })
   })
 })

--- a/test/models/licence-entity.model.test.js
+++ b/test/models/licence-entity.model.test.js
@@ -14,7 +14,7 @@ const LicenceEntityHelper = require('../support/helpers/licence-entity.helper.js
 // Thing under test
 const LicenceEntityModel = require('../../app/models/licence-entity.model.js')
 
-describe('Licence Role model', () => {
+describe('Licence Entity model', () => {
   let testRecord
 
   beforeEach(async () => {

--- a/test/support/helpers/licence-entity-role.helper.js
+++ b/test/support/helpers/licence-entity-role.helper.js
@@ -1,0 +1,59 @@
+'use strict'
+
+/**
+ * @module LicenceEntityRoleHelper
+ */
+
+const { generateUUID } = require('../../../app/lib/general.lib.js')
+const LicenceEntityRoleModel = require('../../../app/models/licence-entity-role.model.js')
+
+/**
+ * Add a new licence entity role
+ *
+ * If no `data` is provided, default values will be used. These are
+ *
+ * - `id` - [random UUID]
+ * - `licenceEntityId` - [random UUID]
+ * - `role` - primary_user
+ * - `regimeEntityId` - [random UUID]
+ * - `companyEntityId` - [random UUID]
+ *
+ * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ *
+ * @returns {module:LicenceEntityRoleModel} The instance of the newly created record
+ */
+async function add (data = {}) {
+  const insertData = defaults(data)
+
+  return LicenceEntityRoleModel.query()
+    .insert({ ...insertData })
+    .returning('*')
+}
+
+/**
+ * Returns the defaults used
+ *
+ * It will override or append to them any data provided. Mainly used by the `add()` method, we make it available
+ * for use in tests to avoid having to duplicate values.
+ *
+ * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ */
+function defaults (data = {}) {
+  const defaults = {
+    id: generateUUID(),
+    licenceEntityId: generateUUID(),
+    role: 'primary_user',
+    regimeEntityId: generateUUID(),
+    companyEntityId: generateUUID()
+  }
+
+  return {
+    ...defaults,
+    ...data
+  }
+}
+
+module.exports = {
+  add,
+  defaults
+}

--- a/test/support/helpers/licence-entity.helper.js
+++ b/test/support/helpers/licence-entity.helper.js
@@ -4,6 +4,7 @@
  * @module LicenceEntityHelper
  */
 
+const { generateUUID } = require('../../../app/lib/general.lib.js')
 const LicenceEntityModel = require('../../../app/models/licence-entity.model.js')
 
 /**
@@ -11,6 +12,7 @@ const LicenceEntityModel = require('../../../app/models/licence-entity.model.js'
  *
  * If no `data` is provided, default values will be used. These are
  *
+ * - `id` - [random UUID]
  * - `name` - Grace Hopper
  * - `type` - individual
  *
@@ -36,6 +38,7 @@ async function add (data = {}) {
  */
 function defaults (data = {}) {
   const defaults = {
+    id: generateUUID(),
     name: 'Grace Hopper',
     type: 'Licence Holder'
   }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4324

> This is part of a series of changes to allow us to replace the legacy view licence page

When viewing a licence using the [legacy water-abstraction-ui](https://github.com/DEFRA/water-abstraction-ui) the page will display information on who the registered user is.

The registered is an external user who has declared that they manage the licence via the external UI. They are not the licence holder, just the person declared to be responsible for managing it.

Unfortunately, this functionality dates from the very start of the service and the data is in one of the oldest legacy schemas; `crm`. It seems this was one of the things which the previous team never managed to migrate to `crm_v2`, their intended better CRM structure.

We are expected to show this information in the licence view so we need to create some new models. The first of these was  [LicenceEntityModel](https://github.com/DEFRA/water-abstraction-system/pull/690), which is based on `crm.entity` and just holds a name and type.

The second is `LicenceEntityRoleModel`, which is based on `crm.entity_roles`. It appears to just be a joining table between `crm.entity` and `crm.roles`. But we need it because it identifies which `crm.entity` has the role of 'primary_user'.