### PR TITLE
Add missing title in view licence page

### DIFF
--- a/app/presenters/licences/view-licence.presenter.js
+++ b/app/presenters/licences/view-licence.presenter.js
@@ -22,6 +22,7 @@ function go (licence) {
     id,
     endDate: _endDate(expiredDate),
     licenceRef,
+    pageTitle: `Licence ${licenceRef}`,
     region: region.displayName,
     startDate: formatLongDate(startDate),
     warning

--- a/test/presenters/licences/view-licence.presenter.test.js
+++ b/test/presenters/licences/view-licence.presenter.test.js
@@ -1,0 +1,136 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const LicenceModel = require('../../../app/models/licence.model.js')
+
+// Thing under test
+const ViewLicencePresenter = require('../../../app/presenters/licences/view-licence.presenter.js')
+
+describe('View Licence presenter', () => {
+  let licence
+
+  beforeEach(() => {
+    licence = LicenceModel.fromJson({
+      id: 'f1288f6c-8503-4dc1-b114-75c408a14bd0',
+      expiredDate: null,
+      licenceRef: '01/123',
+      region: { displayName: 'Narnia' },
+      startDate: new Date('2019-04-01')
+    })
+  })
+
+  describe('when provided with a populated licence', () => {
+    it('correctly presents the data', () => {
+      const result = ViewLicencePresenter.go(licence)
+
+      expect(result).to.equal({
+        id: 'f1288f6c-8503-4dc1-b114-75c408a14bd0',
+        endDate: null,
+        licenceRef: '01/123',
+        pageTitle: 'Licence 01/123',
+        region: 'Narnia',
+        startDate: '1 April 2019',
+        warning: null
+      })
+    })
+
+    describe("the 'endDate' property", () => {
+      describe('when the licence expired date is null', () => {
+        it('returns NULL', () => {
+          const result = ViewLicencePresenter.go(licence)
+
+          expect(result.endDate).to.be.null()
+        })
+      })
+
+      describe('when the licence expired date is set to a date less than or equal to today', () => {
+        beforeEach(() => {
+          licence.expiredDate = new Date()
+        })
+
+        it('returns NULL', () => {
+          const result = ViewLicencePresenter.go(licence)
+
+          expect(result.endDate).to.be.null()
+        })
+      })
+
+      describe('when the licence expired date is set to a date greater than today (2099-04-01)', () => {
+        beforeEach(() => {
+          licence.expiredDate = new Date('2099-04-01')
+        })
+
+        it("returns '1 April 2099'", () => {
+          const result = ViewLicencePresenter.go(licence)
+
+          expect(result.endDate).to.equal('1 April 2099')
+        })
+      })
+    })
+
+    describe("the 'warning' property", () => {
+      describe('when the licence does not have an end date (expired, lapsed or revoked)', () => {
+        it('returns NULL', () => {
+          const result = ViewLicencePresenter.go(licence)
+
+          expect(result.warning).to.be.null()
+        })
+      })
+
+      describe('when the licence does have an end date but it is in the future (expired, lapsed or revoked)', () => {
+        beforeEach(() => {
+          licence.expiredDate = new Date('2099-04-01')
+        })
+
+        it('returns NULL', () => {
+          const result = ViewLicencePresenter.go(licence)
+
+          expect(result.warning).to.be.null()
+        })
+      })
+
+      describe('when the licence expired today or in the past (2019-04-01)', () => {
+        beforeEach(() => {
+          licence.expiredDate = new Date('2019-04-01')
+        })
+
+        it("returns 'This licence expired on 1 April 2019'", () => {
+          const result = ViewLicencePresenter.go(licence)
+
+          expect(result.warning).to.equal('This licence expired on 1 April 2019')
+        })
+      })
+
+      describe('when the licence lapsed today or in the past (2019-04-01)', () => {
+        beforeEach(() => {
+          licence.lapsedDate = new Date('2019-04-01')
+        })
+
+        it("returns 'This licence lapsed on 1 April 2019'", () => {
+          const result = ViewLicencePresenter.go(licence)
+
+          expect(result.warning).to.equal('This licence lapsed on 1 April 2019')
+        })
+      })
+
+      describe('when the licence was revoked today or in the past (2019-04-01)', () => {
+        beforeEach(() => {
+          licence.revokedDate = new Date('2019-04-01')
+        })
+
+        it("returns 'This licence was revoked on 1 April 2019'", () => {
+          const result = ViewLicencePresenter.go(licence)
+
+          expect(result.warning).to.equal('This licence was revoked on 1 April 2019')
+        })
+      })
+    })
+  })
+})

--- a/test/presenters/licences/view-licence.presenter.test.js
+++ b/test/presenters/licences/view-licence.presenter.test.js
@@ -52,7 +52,13 @@ describe('View Licence presenter', () => {
 
       describe('when the licence expired date is set to a date less than or equal to today', () => {
         beforeEach(() => {
-          licence.expiredDate = new Date()
+          // NOTE: The date we get back from the DB is without time. If we just assigned new Date() to expiredDate
+          // there is a chance the test could fail depending on how quickly this is compared to the logic in the
+          // presenter
+          const today = new Date()
+          today.setHours(0, 0, 0, 0)
+
+          licence.expiredDate = today
         })
 
         it('returns NULL', () => {

--- a/test/services/bill-runs/view-bill-run.service.test.js
+++ b/test/services/bill-runs/view-bill-run.service.test.js
@@ -91,7 +91,6 @@ describe('View Bill Run service', () => {
 
       it('will fetch the data and format it for use in the view bill run page', async () => {
         const result = await ViewBillRunService.go(testId)
-        console.log('🚀 ~ file: view-bill-run.service.test.js:55 ~ it ~ result:', result)
 
         expect(result).to.equal({
           billsCount: '1 Annual bill',

--- a/test/services/licences/view-licence.service.test.js
+++ b/test/services/licences/view-licence.service.test.js
@@ -41,6 +41,7 @@ describe('View Licence service', () => {
           endDate: null,
           licenceHolder: 'Unregistered licence',
           licenceRef: '01/130/R01',
+          pageTitle: 'Licence 01/130/R01',
           region: 'South West',
           startDate: '7 March 2013',
           warning: null


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4322

Whilst working on [Add registered user modifier to LicenceModel](https://github.com/DEFRA/water-abstraction-system/pull/693) we spotted that the new view licence page is missing its title.

As part of this, we identified that there was no direct unit test for the `ViewLicencePresenter`, so we also added that.
