### PR TITLE
Handle create annual bill run requests

### DIFF
--- a/app/lib/static-lookups.lib.js
+++ b/app/lib/static-lookups.lib.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const billRunTypes = [
+  'annual',
   'supplementary',
   'two_part_tariff'
 ]

--- a/app/services/bill-runs/annual/process-bill-run.service.js
+++ b/app/services/bill-runs/annual/process-bill-run.service.js
@@ -1,0 +1,17 @@
+'use strict'
+
+/**
+ * Process a given annual bill run for the given billing periods
+ * @module ProcessBillRunService
+ */
+
+/**
+ * Functionality not yet implemented
+ */
+async function go (billRun, _billingPeriods) {
+  global.GlobalNotifier.omg(`Annual not implemented: Cannot process ${billRun.id}`)
+}
+
+module.exports = {
+  go
+}

--- a/app/services/bill-runs/start-bill-run-process.service.js
+++ b/app/services/bill-runs/start-bill-run-process.service.js
@@ -5,6 +5,7 @@
  * @module StartBillRunProcessService
  */
 
+const AnnualProcessBillRunService = require('./annual/process-bill-run.service.js')
 const DetermineBillingPeriodsService = require('./determine-billing-periods.service.js')
 const CreateBillRunPresenter = require('../../presenters/bill-runs/create-bill-run.presenter.js')
 const InitiateBillRunService = require('./initiate-bill-run.service.js')
@@ -42,6 +43,9 @@ function _financialYearEndings (billingPeriods) {
 function _processBillRun (billRun, billingPeriods) {
   // We do not `await` the bill run being processed so we can leave it to run in the background while we return an immediate response
   switch (billRun.batchType) {
+    case 'annual':
+      AnnualProcessBillRunService.go(billRun, billingPeriods)
+      break
     case 'supplementary':
       SupplementaryProcessBillRunService.go(billRun, billingPeriods)
       break

--- a/test/services/bill-runs/annual/process-bill-run.service.test.js
+++ b/test/services/bill-runs/annual/process-bill-run.service.test.js
@@ -11,7 +11,7 @@ const { expect } = Code
 // Thing under test
 const AnnualProcessBillRunService = require('../../../../app/services/bill-runs/annual/process-bill-run.service.js')
 
-describe.only('Annual Process Bill Run service', () => {
+describe('Annual Process Bill Run service', () => {
   let notifierStub
 
   beforeEach(() => {

--- a/test/services/bill-runs/annual/process-bill-run.service.test.js
+++ b/test/services/bill-runs/annual/process-bill-run.service.test.js
@@ -1,0 +1,34 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Thing under test
+const AnnualProcessBillRunService = require('../../../../app/services/bill-runs/annual/process-bill-run.service.js')
+
+describe.only('Annual Process Bill Run service', () => {
+  let notifierStub
+
+  beforeEach(() => {
+    // RequestLib depends on the GlobalNotifier to have been set. This happens in app/plugins/global-notifier.plugin.js
+    // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
+    // test we recreate the condition by setting it directly with our own stub
+    notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
+    global.GlobalNotifier = notifierStub
+  })
+
+  describe('when the service is called', () => {
+    it('logs the attempt to process the annual bill run', async () => {
+      await AnnualProcessBillRunService.go({ id: 'd913e2c1-2442-4c87-8642-d88670dad8e4' })
+
+      expect(
+        notifierStub.omg.calledWith('Annual not implemented: Cannot process d913e2c1-2442-4c87-8642-d88670dad8e4')
+      ).to.be.true()
+    })
+  })
+})


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4347

The system already handles create bill run requests. But only for supplementary and two-part tariff bill runs. We need to amend our logic to also handle requests to create annual bill runs.

There is still plenty of work to do processing and generating the bill run. But this change will at least get the bill run record created and set to a state of `QUEUED` if only so we can confirm our [changes to the legacy UI to trigger it](https://github.com/DEFRA/water-abstraction-ui/pull/2503) are working.