### PR TITLE
Move the calculate & log time feature to lib

### DIFF
--- a/app/lib/general.lib.js
+++ b/app/lib/general.lib.js
@@ -75,6 +75,30 @@ function periodsOverlap (referencePeriods, checkPeriods) {
 }
 
 /**
+ * Returns the current time in nanoseconds. Used as part of logging how long something takes
+ *
+ * We often want to see how long a process takes and capture it in our logs. This can be especially useful when we
+ * have a process that involves talking to an external one. By capturing the time it takes our process to complete
+ * we can deal with any challenges about the performance of our process VS the total time taken.
+ *
+ * To do that you need to record the time when the process starts and the time when the process ends and then work out
+ * the duration. Doing that with JavaScript time constructs though gets very messy and we want to avoid bringing in
+ * 3rd party packages for just this one thing.
+ *
+ * Unfortunately, we cannot find the original source but a 'neat' way of doing it is to use
+ * {@link https://nodejs.org/api/process.html#processhrtimebigint | process.hrtime.bigint()} which returns
+ * "the current high-resolution real time in nanoseconds".
+ *
+ * Do the same at the end and take one from the other, and you then have the duration in nanoseconds which you can
+ * easily convert into something more readable.
+ *
+ * @returns {bigint} the current time in nanoseconds
+ */
+function startTime () {
+  return process.hrtime.bigint()
+}
+
+/**
  * Returns the current date and time as an ISO string
  *
  * We can't use Date.now() because Javascript returns the time since the epoch in milliseconds, whereas a PostgreSQL
@@ -92,5 +116,6 @@ function timestampForPostgres () {
 module.exports = {
   generateUUID,
   periodsOverlap,
+  startTime,
   timestampForPostgres
 }

--- a/app/lib/general.lib.js
+++ b/app/lib/general.lib.js
@@ -29,7 +29,7 @@ const { randomUUID } = require('crypto')
  * @param {string} message - the message to log
  * @param {Object} [data] - additional data to include with the log output
  */
-function calculateAndLogTime (startTime, message, data = {}) {
+function calculateAndLogTimeTaken (startTime, message, data = {}) {
   const endTime = process.hrtime.bigint()
   const timeTakenNs = endTime - startTime
   const timeTakenMs = timeTakenNs / 1000000n
@@ -149,7 +149,7 @@ function timestampForPostgres () {
 }
 
 module.exports = {
-  calculateAndLogTime,
+  calculateAndLogTimeTaken,
   currentTimeInNanoseconds,
   generateUUID,
   periodsOverlap,

--- a/app/lib/general.lib.js
+++ b/app/lib/general.lib.js
@@ -8,6 +8,30 @@
 const { randomUUID } = require('crypto')
 
 /**
+ * Returns the current time in nanoseconds. Used as part of logging how long something takes
+ *
+ * We often want to see how long a process takes and capture it in our logs. This can be especially useful when we
+ * have a process that involves talking to an external one. By capturing the time it takes our process to complete
+ * we can deal with any challenges about the performance of our process VS the total time taken.
+ *
+ * To do that you need to record the time when the process starts and the time when the process ends and then work out
+ * the duration. Doing that with JavaScript time constructs though gets very messy and we want to avoid bringing in
+ * 3rd party packages for just this one thing.
+ *
+ * Unfortunately, we cannot find the original source but a 'neat' way of doing it is to use
+ * {@link https://nodejs.org/api/process.html#processhrtimebigint | process.hrtime.bigint()} which returns
+ * "the current high-resolution real time in nanoseconds".
+ *
+ * Do the same at the end and take one from the other, and you then have the duration in nanoseconds which you can
+ * easily convert into something more readable.
+ *
+ * @returns {bigint} the current time in nanoseconds
+ */
+function currentTimeInNanoseconds () {
+  return process.hrtime.bigint()
+}
+
+/**
  * Generate a Universally Unique Identifier (UUID)
  *
  * The service uses these as the IDs for most records in the DB. Most tables will automatically generate them when
@@ -75,30 +99,6 @@ function periodsOverlap (referencePeriods, checkPeriods) {
 }
 
 /**
- * Returns the current time in nanoseconds. Used as part of logging how long something takes
- *
- * We often want to see how long a process takes and capture it in our logs. This can be especially useful when we
- * have a process that involves talking to an external one. By capturing the time it takes our process to complete
- * we can deal with any challenges about the performance of our process VS the total time taken.
- *
- * To do that you need to record the time when the process starts and the time when the process ends and then work out
- * the duration. Doing that with JavaScript time constructs though gets very messy and we want to avoid bringing in
- * 3rd party packages for just this one thing.
- *
- * Unfortunately, we cannot find the original source but a 'neat' way of doing it is to use
- * {@link https://nodejs.org/api/process.html#processhrtimebigint | process.hrtime.bigint()} which returns
- * "the current high-resolution real time in nanoseconds".
- *
- * Do the same at the end and take one from the other, and you then have the duration in nanoseconds which you can
- * easily convert into something more readable.
- *
- * @returns {bigint} the current time in nanoseconds
- */
-function startTime () {
-  return process.hrtime.bigint()
-}
-
-/**
  * Returns the current date and time as an ISO string
  *
  * We can't use Date.now() because Javascript returns the time since the epoch in milliseconds, whereas a PostgreSQL
@@ -114,8 +114,8 @@ function timestampForPostgres () {
 }
 
 module.exports = {
+  currentTimeInNanoseconds,
   generateUUID,
   periodsOverlap,
-  startTime,
   timestampForPostgres
 }

--- a/app/lib/general.lib.js
+++ b/app/lib/general.lib.js
@@ -30,8 +30,6 @@ const { randomUUID } = require('crypto')
  * @param {Object} [data] - additional data to include with the log output
  */
 function calculateAndLogTimeTaken (startTime, message, data = {}) {
-  console.log('🚀 ~ calculateAndLogTimeTaken ~ data:', data)
-  console.log('🚀 ~ calculateAndLogTimeTaken ~ message:', message)
   const endTime = process.hrtime.bigint()
   const timeTakenNs = endTime - startTime
   const timeTakenMs = timeTakenNs / 1000000n

--- a/app/lib/general.lib.js
+++ b/app/lib/general.lib.js
@@ -30,7 +30,7 @@ const { randomUUID } = require('crypto')
  * @param {Object} [data] - additional data to include with the log output
  */
 function calculateAndLogTimeTaken (startTime, message, data = {}) {
-  const endTime = process.hrtime.bigint()
+  const endTime = currentTimeInNanoseconds()
   const timeTakenNs = endTime - startTime
   const timeTakenMs = timeTakenNs / 1000000n
   const timeTakenSs = timeTakenMs / 1000n

--- a/app/lib/general.lib.js
+++ b/app/lib/general.lib.js
@@ -23,7 +23,7 @@ const { randomUUID } = require('crypto')
  * "the current high-resolution real time in nanoseconds".
  *
  * Assuming a process recorded the start time using `currentTimeInNanoseconds()` when passed to this helper it will
- * work out the time taken in nanoseconds, convert that to milliseconds and output it as a log message.
+ * work out the time taken in nanoseconds, convert that to milliseconds and seconds and output it as a log message.
  *
  * @param {bigint} startTime - the time the process started in nanoseconds
  * @param {string} message - the message to log
@@ -33,9 +33,11 @@ function calculateAndLogTimeTaken (startTime, message, data = {}) {
   const endTime = process.hrtime.bigint()
   const timeTakenNs = endTime - startTime
   const timeTakenMs = timeTakenNs / 1000000n
+  const timeTakenSs = timeTakenMs / 1000
 
   const logData = {
     timeTakenMs,
+    timeTakenSs,
     ...data
   }
 

--- a/app/lib/general.lib.js
+++ b/app/lib/general.lib.js
@@ -30,10 +30,12 @@ const { randomUUID } = require('crypto')
  * @param {Object} [data] - additional data to include with the log output
  */
 function calculateAndLogTimeTaken (startTime, message, data = {}) {
+  console.log('🚀 ~ calculateAndLogTimeTaken ~ data:', data)
+  console.log('🚀 ~ calculateAndLogTimeTaken ~ message:', message)
   const endTime = process.hrtime.bigint()
   const timeTakenNs = endTime - startTime
   const timeTakenMs = timeTakenNs / 1000000n
-  const timeTakenSs = timeTakenMs / 1000
+  const timeTakenSs = timeTakenMs / 1000n
 
   const logData = {
     timeTakenMs,

--- a/app/lib/general.lib.js
+++ b/app/lib/general.lib.js
@@ -8,6 +8,41 @@
 const { randomUUID } = require('crypto')
 
 /**
+ * Calculates and logs the time taken in milliseconds between the provided `startTime` and the current time
+ *
+ * We often want to see how long a process takes and capture it in our logs. This can be especially useful when we
+ * have a process that involves talking to an external one. By capturing the time it takes our process to complete
+ * we can deal with any challenges about the performance of our process VS the total time taken.
+ *
+ * To do that you need to record the time when the process starts and the time when the process ends and then work out
+ * the duration. Doing that with JavaScript time constructs though gets very messy and we want to avoid bringing in
+ * 3rd party packages for just this one thing.
+ *
+ * Unfortunately, we cannot find the original source but a 'neat' way of doing it is to use
+ * {@link https://nodejs.org/api/process.html#processhrtimebigint | process.hrtime.bigint()} which returns
+ * "the current high-resolution real time in nanoseconds".
+ *
+ * Assuming a process recorded the start time using `currentTimeInNanoseconds()` when passed to this helper it will
+ * work out the time taken in nanoseconds, convert that to milliseconds and output it as a log message.
+ *
+ * @param {bigint} startTime - the time the process started in nanoseconds
+ * @param {string} message - the message to log
+ * @param {Object} [data] - additional data to include with the log output
+ */
+function calculateAndLogTime (startTime, message, data = {}) {
+  const endTime = process.hrtime.bigint()
+  const timeTakenNs = endTime - startTime
+  const timeTakenMs = timeTakenNs / 1000000n
+
+  const logData = {
+    timeTakenMs,
+    ...data
+  }
+
+  global.GlobalNotifier.omg(message, logData)
+}
+
+/**
  * Returns the current time in nanoseconds. Used as part of logging how long something takes
  *
  * We often want to see how long a process takes and capture it in our logs. This can be especially useful when we
@@ -114,6 +149,7 @@ function timestampForPostgres () {
 }
 
 module.exports = {
+  calculateAndLogTime,
   currentTimeInNanoseconds,
   generateUUID,
   periodsOverlap,

--- a/app/services/bill-runs/supplementary/process-bill-run.service.js
+++ b/app/services/bill-runs/supplementary/process-bill-run.service.js
@@ -9,7 +9,7 @@ const BillRunModel = require('../../../models/bill-run.model.js')
 const BillRunError = require('../../../errors/bill-run.error.js')
 const ChargingModuleGenerateService = require('../../charging-module/generate-bill-run.service.js')
 const FetchChargeVersionsService = require('./fetch-charge-versions.service.js')
-const { currentTimeInNanoseconds } = require('../../../lib/general.lib.js')
+const { calculateAndLogTime, currentTimeInNanoseconds } = require('../../../lib/general.lib.js')
 const HandleErroredBillRunService = require('./handle-errored-bill-run.service.js')
 const LegacyRequestLib = require('../../../lib/legacy-request.lib.js')
 const ProcessBillingPeriodService = require('./process-billing-period.service.js')
@@ -37,7 +37,7 @@ async function go (billRun, billingPeriods) {
 
     await _processBillingPeriods(billingPeriods, billRun, resultOfReissuing)
 
-    _calculateAndLogTime(billRunId, startTime)
+    calculateAndLogTime(startTime, 'Process bill run complete', { billRunId, type: 'supplementary' })
   } catch (error) {
     await HandleErroredBillRunService.go(billRunId, error.code)
     _logError(billRun, error)
@@ -76,24 +76,6 @@ async function _reissueBills (billRun) {
   const result = await ReissueBillsService.go(billRun)
 
   return result
-}
-
-/**
-  * Log the time taken to process the bill run
-  *
-  * If `notifier` is not set then it will do nothing. If it is set this will get the current time and then calculate the
-  * difference from `startTime`. This and the `billRunId` are then used to generate a log message.
-  *
-  * @param {string} billRunId Id of the bill run currently being 'processed'
-  * @param {BigInt} startTime The time the generate process kicked off. It is expected to be the result of a call to
-  * `process.hrtime.bigint()`
-  */
-function _calculateAndLogTime (billRunId, startTime) {
-  const endTime = process.hrtime.bigint()
-  const timeTakenNs = endTime - startTime
-  const timeTakenMs = timeTakenNs / 1000000n
-
-  global.GlobalNotifier.omg('Process bill run complete', { billRunId, timeTakenMs })
 }
 
 async function _fetchChargeVersions (billRun, billingPeriod) {

--- a/app/services/bill-runs/supplementary/process-bill-run.service.js
+++ b/app/services/bill-runs/supplementary/process-bill-run.service.js
@@ -9,6 +9,7 @@ const BillRunModel = require('../../../models/bill-run.model.js')
 const BillRunError = require('../../../errors/bill-run.error.js')
 const ChargingModuleGenerateService = require('../../charging-module/generate-bill-run.service.js')
 const FetchChargeVersionsService = require('./fetch-charge-versions.service.js')
+const { currentTimeInNanoseconds } = require('../../../lib/general.lib.js')
 const HandleErroredBillRunService = require('./handle-errored-bill-run.service.js')
 const LegacyRequestLib = require('../../../lib/legacy-request.lib.js')
 const ProcessBillingPeriodService = require('./process-billing-period.service.js')
@@ -28,7 +29,7 @@ async function go (billRun, billingPeriods) {
   const { id: billRunId } = billRun
 
   try {
-    const startTime = process.hrtime.bigint()
+    const startTime = currentTimeInNanoseconds()
 
     await _updateStatus(billRunId, 'processing')
 

--- a/app/services/bill-runs/supplementary/process-bill-run.service.js
+++ b/app/services/bill-runs/supplementary/process-bill-run.service.js
@@ -9,7 +9,7 @@ const BillRunModel = require('../../../models/bill-run.model.js')
 const BillRunError = require('../../../errors/bill-run.error.js')
 const ChargingModuleGenerateService = require('../../charging-module/generate-bill-run.service.js')
 const FetchChargeVersionsService = require('./fetch-charge-versions.service.js')
-const { calculateAndLogTime, currentTimeInNanoseconds } = require('../../../lib/general.lib.js')
+const { calculateAndLogTimeTaken, currentTimeInNanoseconds } = require('../../../lib/general.lib.js')
 const HandleErroredBillRunService = require('./handle-errored-bill-run.service.js')
 const LegacyRequestLib = require('../../../lib/legacy-request.lib.js')
 const ProcessBillingPeriodService = require('./process-billing-period.service.js')
@@ -37,7 +37,7 @@ async function go (billRun, billingPeriods) {
 
     await _processBillingPeriods(billingPeriods, billRun, resultOfReissuing)
 
-    calculateAndLogTime(startTime, 'Process bill run complete', { billRunId, type: 'supplementary' })
+    calculateAndLogTimeTaken(startTime, 'Process bill run complete', { billRunId, type: 'supplementary' })
   } catch (error) {
     await HandleErroredBillRunService.go(billRunId, error.code)
     _logError(billRun, error)

--- a/app/services/bill-runs/two-part-tariff/match-and-allocate.service.js
+++ b/app/services/bill-runs/two-part-tariff/match-and-allocate.service.js
@@ -5,6 +5,7 @@
 
 const AllocateReturnsToChargeElementService = require('./allocate-returns-to-charge-element.service.js')
 const FetchLicencesService = require('./fetch-licences.service.js')
+const { currentTimeInNanoseconds } = require('../../../lib/general.lib.js')
 const MatchReturnsToChargeElementService = require('./match-returns-to-charge-element.service.js')
 const PrepareChargeVersionService = require('./prepare-charge-version.service.js')
 const PrepareReturnLogsService = require('./prepare-return-logs.service.js')
@@ -26,7 +27,7 @@ const PersistAllocatedLicenceToResultsService = require('./persist-allocated-lic
  * @returns {Array} - An array of processed licences associated with the bill run
  */
 async function go (billRun, billingPeriods) {
-  const startTime = process.hrtime.bigint()
+  const startTime = currentTimeInNanoseconds()
 
   const licences = await FetchLicencesService.go(billRun.regionId, billingPeriods[0])
 

--- a/app/services/bill-runs/two-part-tariff/match-and-allocate.service.js
+++ b/app/services/bill-runs/two-part-tariff/match-and-allocate.service.js
@@ -5,7 +5,7 @@
 
 const AllocateReturnsToChargeElementService = require('./allocate-returns-to-charge-element.service.js')
 const FetchLicencesService = require('./fetch-licences.service.js')
-const { calculateAndLogTime, currentTimeInNanoseconds } = require('../../../lib/general.lib.js')
+const { calculateAndLogTimeTaken, currentTimeInNanoseconds } = require('../../../lib/general.lib.js')
 const MatchReturnsToChargeElementService = require('./match-returns-to-charge-element.service.js')
 const PrepareChargeVersionService = require('./prepare-charge-version.service.js')
 const PrepareReturnLogsService = require('./prepare-return-logs.service.js')
@@ -35,7 +35,7 @@ async function go (billRun, billingPeriods) {
     await _process(licences, billingPeriods, billRun)
   }
 
-  calculateAndLogTime(startTime, 'Two part tariff matching complete', { billRunId: billRun.id })
+  calculateAndLogTimeTaken(startTime, 'Two part tariff matching complete', { billRunId: billRun.id })
 
   return licences
 }

--- a/app/services/bill-runs/two-part-tariff/match-and-allocate.service.js
+++ b/app/services/bill-runs/two-part-tariff/match-and-allocate.service.js
@@ -5,7 +5,7 @@
 
 const AllocateReturnsToChargeElementService = require('./allocate-returns-to-charge-element.service.js')
 const FetchLicencesService = require('./fetch-licences.service.js')
-const { currentTimeInNanoseconds } = require('../../../lib/general.lib.js')
+const { calculateAndLogTime, currentTimeInNanoseconds } = require('../../../lib/general.lib.js')
 const MatchReturnsToChargeElementService = require('./match-returns-to-charge-element.service.js')
 const PrepareChargeVersionService = require('./prepare-charge-version.service.js')
 const PrepareReturnLogsService = require('./prepare-return-logs.service.js')
@@ -35,17 +35,9 @@ async function go (billRun, billingPeriods) {
     await _process(licences, billingPeriods, billRun)
   }
 
-  _calculateAndLogTime(startTime)
+  calculateAndLogTime(startTime, 'Two part tariff matching complete', { billRunId: billRun.id })
 
   return licences
-}
-
-function _calculateAndLogTime (startTime) {
-  const endTime = process.hrtime.bigint()
-  const timeTakenNs = endTime - startTime
-  const timeTakenMs = timeTakenNs / 1000000n
-
-  global.GlobalNotifier.omg('Two part tariff matching complete', { timeTakenMs })
 }
 
 async function _process (licences, billingPeriods, billRun) {

--- a/app/services/data/tear-down/tear-down.service.js
+++ b/app/services/data/tear-down/tear-down.service.js
@@ -6,13 +6,14 @@
  */
 
 const CrmSchemaService = require('./crm-schema.service.js')
+const { currentTimeInNanoseconds } = require('../../../../app/lib/general.lib.js')
 const IdmSchemaService = require('./idm-schema.service.js')
 const PermitSchemaService = require('./permit-schema.service.js')
 const ReturnsSchemaService = require('./returns-schema.service.js')
 const WaterSchemaService = require('./water-schema.service.js')
 
 async function go () {
-  const startTime = process.hrtime.bigint()
+  const startTime = currentTimeInNanoseconds()
 
   await Promise.all([
     CrmSchemaService.go(),

--- a/app/services/data/tear-down/tear-down.service.js
+++ b/app/services/data/tear-down/tear-down.service.js
@@ -6,7 +6,7 @@
  */
 
 const CrmSchemaService = require('./crm-schema.service.js')
-const { calculateAndLogTime, currentTimeInNanoseconds } = require('../../../../app/lib/general.lib.js')
+const { calculateAndLogTimeTaken, currentTimeInNanoseconds } = require('../../../../app/lib/general.lib.js')
 const IdmSchemaService = require('./idm-schema.service.js')
 const PermitSchemaService = require('./permit-schema.service.js')
 const ReturnsSchemaService = require('./returns-schema.service.js')
@@ -23,7 +23,7 @@ async function go () {
     WaterSchemaService.go()
   ])
 
-  calculateAndLogTime(startTime, 'Tear down complete')
+  calculateAndLogTimeTaken(startTime, 'Tear down complete')
 }
 
 module.exports = {

--- a/app/services/data/tear-down/tear-down.service.js
+++ b/app/services/data/tear-down/tear-down.service.js
@@ -6,7 +6,7 @@
  */
 
 const CrmSchemaService = require('./crm-schema.service.js')
-const { currentTimeInNanoseconds } = require('../../../../app/lib/general.lib.js')
+const { calculateAndLogTime, currentTimeInNanoseconds } = require('../../../../app/lib/general.lib.js')
 const IdmSchemaService = require('./idm-schema.service.js')
 const PermitSchemaService = require('./permit-schema.service.js')
 const ReturnsSchemaService = require('./returns-schema.service.js')
@@ -23,15 +23,7 @@ async function go () {
     WaterSchemaService.go()
   ])
 
-  _calculateAndLogTime(startTime)
-}
-
-function _calculateAndLogTime (startTime) {
-  const endTime = process.hrtime.bigint()
-  const timeTakenNs = endTime - startTime
-  const timeTakenMs = timeTakenNs / 1000000n
-
-  global.GlobalNotifier.omg('Tear down complete', { timeTakenMs })
+  calculateAndLogTime(startTime, 'Tear down complete')
 }
 
 module.exports = {

--- a/app/services/jobs/export/export.service.js
+++ b/app/services/jobs/export/export.service.js
@@ -5,6 +5,7 @@
  * @module DbExportService
  */
 
+const { currentTimeInNanoseconds } = require('../../../lib/general.lib.js')
 const SchemaExportService = require('./schema-export.service.js')
 
 /**
@@ -12,7 +13,7 @@ const SchemaExportService = require('./schema-export.service.js')
  */
 async function go () {
   // Mark the start time for later logging
-  const startTime = process.hrtime.bigint()
+  const startTime = currentTimeInNanoseconds()
 
   const schemaNames = ['water', 'returns', 'crm', 'crm_v2', 'idm', 'permit']
 

--- a/app/services/jobs/export/export.service.js
+++ b/app/services/jobs/export/export.service.js
@@ -5,7 +5,7 @@
  * @module DbExportService
  */
 
-const { currentTimeInNanoseconds } = require('../../../lib/general.lib.js')
+const { calculateAndLogTime, currentTimeInNanoseconds } = require('../../../lib/general.lib.js')
 const SchemaExportService = require('./schema-export.service.js')
 
 /**
@@ -22,15 +22,7 @@ async function go () {
   }
 
   // Log how long the process took
-  _calculateAndLogTime(startTime)
-}
-
-function _calculateAndLogTime (startTime) {
-  const endTime = process.hrtime.bigint()
-  const timeTakenNs = endTime - startTime
-  const timeTakenMs = timeTakenNs / 1000000n
-
-  global.GlobalNotifier.omg('DB export complete', { timeTakenMs })
+  calculateAndLogTime(startTime, 'DB export complete')
 }
 
 module.exports = {

--- a/app/services/jobs/export/export.service.js
+++ b/app/services/jobs/export/export.service.js
@@ -5,7 +5,7 @@
  * @module DbExportService
  */
 
-const { calculateAndLogTime, currentTimeInNanoseconds } = require('../../../lib/general.lib.js')
+const { calculateAndLogTimeTaken, currentTimeInNanoseconds } = require('../../../lib/general.lib.js')
 const SchemaExportService = require('./schema-export.service.js')
 
 /**
@@ -22,7 +22,7 @@ async function go () {
   }
 
   // Log how long the process took
-  calculateAndLogTime(startTime, 'DB export complete')
+  calculateAndLogTimeTaken(startTime, 'DB export complete')
 }
 
 module.exports = {

--- a/test/lib/general.lib.test.js
+++ b/test/lib/general.lib.test.js
@@ -32,7 +32,7 @@ describe('RequestLib', () => {
     })
 
     describe('when no additional data is provided', () => {
-      it('logs the message and time taken in milliseconds', () => {
+      it('logs the message and time taken in milliseconds and seconds', () => {
         GeneralLib.calculateAndLogTimeTaken(startTime, 'I am the test with no data')
 
         const logDataArg = notifierStub.omg.args[0][1]
@@ -41,12 +41,13 @@ describe('RequestLib', () => {
           notifierStub.omg.calledWith('I am the test with no data')
         ).to.be.true()
         expect(logDataArg.timeTakenMs).to.exist()
+        expect(logDataArg.timeTakenSs).to.exist()
         expect(logDataArg.name).not.to.exist()
       })
     })
 
     describe('when additional data is provided', () => {
-      it('logs the message and time taken in milliseconds as well as the additional data', () => {
+      it('logs the message and time taken in milliseconds and seconds as well as the additional data', () => {
         GeneralLib.calculateAndLogTime(startTime, 'I am the test with data', { name: 'Foo Bar' })
 
         const logDataArg = notifierStub.omg.args[0][1]

--- a/test/lib/general.lib.test.js
+++ b/test/lib/general.lib.test.js
@@ -16,7 +16,7 @@ describe('RequestLib', () => {
     Sinon.restore()
   })
 
-  describe('#calculateAndLogTime', () => {
+  describe('#calculateAndLogTimeTaken', () => {
     let notifierStub
     let startTime
 
@@ -33,7 +33,7 @@ describe('RequestLib', () => {
 
     describe('when no additional data is provided', () => {
       it('logs the message and time taken in milliseconds', () => {
-        GeneralLib.calculateAndLogTime(startTime, 'I am the test with no data')
+        GeneralLib.calculateAndLogTimeTaken(startTime, 'I am the test with no data')
 
         const logDataArg = notifierStub.omg.args[0][1]
 

--- a/test/lib/general.lib.test.js
+++ b/test/lib/general.lib.test.js
@@ -11,7 +11,7 @@ const { expect } = Code
 // Thing under test
 const GeneralLib = require('../../app/lib/general.lib.js')
 
-describe('RequestLib', () => {
+describe('GeneralLib', () => {
   afterEach(() => {
     Sinon.restore()
   })
@@ -48,7 +48,7 @@ describe('RequestLib', () => {
 
     describe('when additional data is provided', () => {
       it('logs the message and time taken in milliseconds and seconds as well as the additional data', () => {
-        GeneralLib.calculateAndLogTime(startTime, 'I am the test with data', { name: 'Foo Bar' })
+        GeneralLib.calculateAndLogTimeTaken(startTime, 'I am the test with data', { name: 'Foo Bar' })
 
         const logDataArg = notifierStub.omg.args[0][1]
 

--- a/test/lib/general.lib.test.js
+++ b/test/lib/general.lib.test.js
@@ -12,6 +12,21 @@ const { expect } = Code
 const GeneralLib = require('../../app/lib/general.lib.js')
 
 describe('RequestLib', () => {
+  describe('#currentTimeInNanoseconds', () => {
+    let timeBeforeTest
+
+    beforeEach(() => {
+      timeBeforeTest = process.hrtime.bigint()
+    })
+
+    it('returns the current date and time as an ISO string', () => {
+      const result = GeneralLib.currentTimeInNanoseconds()
+
+      expect(typeof result).to.equal('bigint')
+      expect(result).to.be.greaterThan(timeBeforeTest)
+    })
+  })
+
   describe('#generateUUID', () => {
     // NOTE: generateUUID() only calls crypto.randomUUID(); it does nothing else. So, there is nothing really to test
     // and certainly, testing the UUID is really unique is beyond the scope of this project! But this test at least
@@ -149,21 +164,6 @@ describe('RequestLib', () => {
 
         expect(result).to.equal(true)
       })
-    })
-  })
-
-  describe('#startTime', () => {
-    let timeBeforeTest
-
-    beforeEach(() => {
-      timeBeforeTest = process.hrtime.bigint()
-    })
-
-    it('returns the current date and time as an ISO string', () => {
-      const result = GeneralLib.startTime()
-
-      expect(typeof result).to.equal('bigint')
-      expect(result).to.be.greaterThan(timeBeforeTest)
     })
   })
 

--- a/test/lib/general.lib.test.js
+++ b/test/lib/general.lib.test.js
@@ -27,6 +27,21 @@ describe('RequestLib', () => {
     })
   })
 
+  describe('#startTime', () => {
+    let timeBeforeTest
+
+    beforeEach(() => {
+      timeBeforeTest = process.hrtime.bigint()
+    })
+
+    it('returns the current date and time as an ISO string', () => {
+      const result = GeneralLib.startTime()
+
+      expect(typeof result).to.equal('bigint')
+      expect(result).to.be.greaterThan(timeBeforeTest)
+    })
+  })
+
   describe('#timestampForPostgres', () => {
     let clock
     let testDate

--- a/test/lib/general.lib.test.js
+++ b/test/lib/general.lib.test.js
@@ -27,43 +27,6 @@ describe('RequestLib', () => {
     })
   })
 
-  describe('#startTime', () => {
-    let timeBeforeTest
-
-    beforeEach(() => {
-      timeBeforeTest = process.hrtime.bigint()
-    })
-
-    it('returns the current date and time as an ISO string', () => {
-      const result = GeneralLib.startTime()
-
-      expect(typeof result).to.equal('bigint')
-      expect(result).to.be.greaterThan(timeBeforeTest)
-    })
-  })
-
-  describe('#timestampForPostgres', () => {
-    let clock
-    let testDate
-
-    beforeEach(() => {
-      testDate = new Date(2015, 9, 21, 20, 31, 57)
-
-      clock = Sinon.useFakeTimers(testDate)
-    })
-
-    afterEach(() => {
-      clock.restore()
-      Sinon.restore()
-    })
-
-    it('returns the current date and time as an ISO string', () => {
-      const result = GeneralLib.timestampForPostgres()
-
-      expect(result).to.equal('2015-10-21T20:31:57.000Z')
-    })
-  })
-
   describe('#periodsOverlap', () => {
     let referencePeriod
     let checkPeriod
@@ -186,6 +149,43 @@ describe('RequestLib', () => {
 
         expect(result).to.equal(true)
       })
+    })
+  })
+
+  describe('#startTime', () => {
+    let timeBeforeTest
+
+    beforeEach(() => {
+      timeBeforeTest = process.hrtime.bigint()
+    })
+
+    it('returns the current date and time as an ISO string', () => {
+      const result = GeneralLib.startTime()
+
+      expect(typeof result).to.equal('bigint')
+      expect(result).to.be.greaterThan(timeBeforeTest)
+    })
+  })
+
+  describe('#timestampForPostgres', () => {
+    let clock
+    let testDate
+
+    beforeEach(() => {
+      testDate = new Date(2015, 9, 21, 20, 31, 57)
+
+      clock = Sinon.useFakeTimers(testDate)
+    })
+
+    afterEach(() => {
+      clock.restore()
+      Sinon.restore()
+    })
+
+    it('returns the current date and time as an ISO string', () => {
+      const result = GeneralLib.timestampForPostgres()
+
+      expect(result).to.equal('2015-10-21T20:31:57.000Z')
     })
   })
 })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4345

We're about to start working on rebuilding the SROC annual bill run engine in this project. To do that we'll be referencing the existing supplementary billing code a lot.

One of the first things we want to bring across is the ability to record how long it takes to generate the bill run. You'll see this in several places in our project; a function will initialise a variable called `startTime` and when the work is complete pass it to a function called `_calculateAndLogTime()` which will output a message that includes the time taken.

You'll see this in so many places that it is time to say 'Enough is enough!'

This change moves that functionality to the `lib/` and then updates the project to reuse it rather than duplicating `_calculateAndLogTime()` all over the place.