### PR TITLE
Fix bill licence charge ref decimal in wrong place

### DIFF
--- a/app/presenters/bill-licences/view-standard-charge-transaction.presenter.js
+++ b/app/presenters/bill-licences/view-standard-charge-transaction.presenter.js
@@ -127,7 +127,10 @@ function _chargeElements (chargeElements) {
 }
 
 function _chargeReference (baselineCharge, chargeCategoryCode) {
-  return `${chargeCategoryCode} (£${formatPounds(baselineCharge)})`
+  // NOTE: The baseline charge is returned in pounds not pence. This is different to all other values we have to deal
+  // with. So, we have to convert the value before passing it to the formatter as it expects the value to be in pence.
+  const baselineChargeInPence = baselineCharge * 100
+  return `${chargeCategoryCode} (£${formatPounds(baselineChargeInPence)})`
 }
 
 function _presrocContent (transaction) {

--- a/test/presenters/bill-licences/view-standard-charge-transaction.presenter.test.js
+++ b/test/presenters/bill-licences/view-standard-charge-transaction.presenter.test.js
@@ -211,10 +211,10 @@ describe('View Standard Charge Transaction presenter', () => {
     })
 
     describe("'chargeReference' property", () => {
-      it("returns the charge category combined with the base line charge '4.5.13 (£11.62)'", () => {
+      it("returns the charge category combined with the base line charge '4.5.13 (£1162.00)'", () => {
         const result = ViewStandardChargeTransactionPresenter.go(transaction)
 
-        expect(result.chargeReference).to.equal('4.5.13 (£11.62)')
+        expect(result.chargeReference).to.equal('4.5.13 (£1162.00)')
       })
     })
 
@@ -239,7 +239,7 @@ describe('View Standard Charge Transaction presenter', () => {
           }
         ],
         chargePeriod: '1 April 2023 to 31 March 2024',
-        chargeReference: '4.5.13 (£11.62)',
+        chargeReference: '4.5.13 (£1162.00)',
         chargeType: 'standard',
         creditAmount: '',
         debitAmount: '£1,162.00',


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4358

It has been spotted by the Billing & Data team that the value shown against a charge reference in the `/bill-licences` view has the decimal in the wrong place. For example, charge reference 4.6.10 should display a value of `£609.00` but instead is `£6.09`.

This change fixes the issue.

> Screenshot of incorrect value</summary>

![water-4358_new](https://github.com/DEFRA/water-abstraction-system/assets/1789650/d8d83ac5-6b1c-4107-8548-9311f3ffeddc)

