### PR TITLE
Fix bill licence supp source decimal in wrong place

### DIFF
--- a/app/presenters/bill-licences/view-standard-charge-transaction.presenter.js
+++ b/app/presenters/bill-licences/view-standard-charge-transaction.presenter.js
@@ -200,12 +200,14 @@ function _srocContent (transaction) {
     volume
   } = transaction
 
-  // NOTE: The baseline charge is returned in pounds not pence. This is different to all other values we have to deal
-  // with. So, we have to convert the value before passing it to our formatter as it expects the value to be in pence.
+  // NOTE: These charges are returned from the Rules Service (via the Charging Module API) in pounds not pence. This is
+  // different to all other values we have to deal with. So, we have to convert the values before passing them to our
+  // formatter as it expects the values to be in pence.
   const baselineChargeInPence = baselineCharge * 100
+  const supportedSourceChargeInPence = supportedSourceCharge * 100
 
   return {
-    additionalCharges: _additionalCharges(credit, waterCompanyCharge, supportedSourceCharge, supportedSourceName),
+    additionalCharges: _additionalCharges(credit, waterCompanyCharge, supportedSourceChargeInPence, supportedSourceName),
     adjustments: _adjustments(
       adjustmentFactor,
       aggregateFactor,

--- a/app/presenters/bill-licences/view-standard-charge-transaction.presenter.js
+++ b/app/presenters/bill-licences/view-standard-charge-transaction.presenter.js
@@ -127,10 +127,7 @@ function _chargeElements (chargeElements) {
 }
 
 function _chargeReference (baselineCharge, chargeCategoryCode) {
-  // NOTE: The baseline charge is returned in pounds not pence. This is different to all other values we have to deal
-  // with. So, we have to convert the value before passing it to the formatter as it expects the value to be in pence.
-  const baselineChargeInPence = baselineCharge * 100
-  return `${chargeCategoryCode} (£${formatPounds(baselineChargeInPence)})`
+  return `${chargeCategoryCode} (£${formatPounds(baselineCharge)})`
 }
 
 function _presrocContent (transaction) {
@@ -203,6 +200,10 @@ function _srocContent (transaction) {
     volume
   } = transaction
 
+  // NOTE: The baseline charge is returned in pounds not pence. This is different to all other values we have to deal
+  // with. So, we have to convert the value before passing it to our formatter as it expects the value to be in pence.
+  const baselineChargeInPence = baselineCharge * 100
+
   return {
     additionalCharges: _additionalCharges(credit, waterCompanyCharge, supportedSourceCharge, supportedSourceName),
     adjustments: _adjustments(
@@ -217,7 +218,7 @@ function _srocContent (transaction) {
     chargeCategoryDescription,
     chargeElements: _chargeElements(chargeReference.chargeElements),
     chargePeriod: `${formatLongDate(startDate)} to ${formatLongDate(endDate)}`,
-    chargeReference: _chargeReference(baselineCharge, chargeCategoryCode),
+    chargeReference: _chargeReference(baselineChargeInPence, chargeCategoryCode),
     chargeType,
     creditAmount: credit ? formatMoney(netAmount) : '',
     debitAmount: credit ? '' : formatMoney(netAmount),

--- a/test/presenters/bill-licences/view-standard-charge-transaction.presenter.test.js
+++ b/test/presenters/bill-licences/view-standard-charge-transaction.presenter.test.js
@@ -56,10 +56,10 @@ describe('View Standard Charge Transaction presenter', () => {
             transaction.credit = true
           })
 
-          it("returns 'Supported source Candover (£-145.67)'", () => {
+          it("returns 'Supported source Candover (£-14567.00)'", () => {
             const result = ViewStandardChargeTransactionPresenter.go(transaction)
 
-            expect(result.additionalCharges).to.equal('Supported source Candover (£-145.67)')
+            expect(result.additionalCharges).to.equal('Supported source Candover (£-14567.00)')
           })
         })
 
@@ -68,10 +68,10 @@ describe('View Standard Charge Transaction presenter', () => {
             transaction.credit = false
           })
 
-          it("returns 'Supported source Candover (£145.67)'", () => {
+          it("returns 'Supported source Candover (£14567.00)'", () => {
             const result = ViewStandardChargeTransactionPresenter.go(transaction)
 
-            expect(result.additionalCharges).to.equal('Supported source Candover (£145.67)')
+            expect(result.additionalCharges).to.equal('Supported source Candover (£14567.00)')
           })
         })
       })
@@ -98,7 +98,7 @@ describe('View Standard Charge Transaction presenter', () => {
         it("returns 'Public Water Supply'", () => {
           const result = ViewStandardChargeTransactionPresenter.go(transaction)
 
-          expect(result.additionalCharges).to.equal('Supported source Candover (£145.67), Public Water Supply')
+          expect(result.additionalCharges).to.equal('Supported source Candover (£14567.00), Public Water Supply')
         })
       })
     })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4358

Back again! (see [Fix bill licence charge ref decimal in wrong place](https://github.com/DEFRA/water-abstraction-system/pull/713))

The Billing & Data team have also spotted that the value shown against a supported source in the `/bill-licences` view has the decimal in the wrong place.

Both the charge reference charge (baseline charge) and Supported source charge are extracted out of the JSON blob the Charging Module service captures from the Rules Service and returns in its response.

Looks like the Rules service returns these in pounds, unlike all other values that are in pence.

This change fixes the issue for supported source charge (and fingers crossed that's it!)

> Screenshot of incorrect value

![Screenshot 2024-02-07 at 13 31 48](https://github.com/DEFRA/water-abstraction-system/assets/1789650/6f2da39e-e385-45e2-add1-f41d450849a0)
