### PR TITLE
Make requests to the CHA more resilient

### DIFF
--- a/app/lib/charging-module-request.lib.js
+++ b/app/lib/charging-module-request.lib.js
@@ -6,6 +6,8 @@
  */
 
 const RequestLib = require('./request.lib.js')
+
+const requestConfig = require('../../config/request.config.js')
 const servicesConfig = require('../../config/services.config.js')
 
 /**
@@ -95,6 +97,9 @@ function _requestOptions (accessToken, body) {
       authorization: `Bearer ${accessToken}`
     },
     responseType: 'json',
+    timeout: {
+      request: requestConfig.chargingModuleTimeout
+    },
     json: body
   }
 }

--- a/app/lib/request.lib.js
+++ b/app/lib/request.lib.js
@@ -44,10 +44,12 @@ function defaultOptions () {
     retry: {
       // The default is also 2 retries before erroring. We specify it to make this fact visible
       limit: 2,
-      // We ensure that the only network errors Got retries are timeout errors
+      // We ensure that the only network errors Got retries are timeout and econnreset errors. Both can be a result of
+      // the other side being overloaded which can happen when we are trying to send high volumes of requests, for
+      // example, when creating a bill run
       errorCodes: ['ECONNRESET', 'ETIMEDOUT'],
-      // By default, Got does not retry PATCH and POST requests. As we only retry timeouts there is no risk in retrying
-      // our PATCH and POST requests. So, we set methods to be Got's defaults plus 'PATCH' and 'POST'
+      // By default, Got does not retry PATCH and POST requests. As we only retry certain errors there is no risk in
+      // retrying our PATCH and POST requests. So, we set the methods to be Got's defaults plus 'PATCH' and 'POST'
       methods: ['GET', 'PATCH', 'POST', 'PUT', 'HEAD', 'DELETE', 'OPTIONS', 'TRACE'],
       // We set statusCodes as an empty array to ensure that 4xx, 5xx etc. errors are not retried
       statusCodes: []

--- a/app/lib/request.lib.js
+++ b/app/lib/request.lib.js
@@ -45,7 +45,7 @@ function defaultOptions () {
       // The default is also 2 retries before erroring. We specify it to make this fact visible
       limit: 2,
       // We ensure that the only network errors Got retries are timeout errors
-      errorCodes: ['ETIMEDOUT'],
+      errorCodes: ['ECONNRESET', 'ETIMEDOUT'],
       // By default, Got does not retry PATCH and POST requests. As we only retry timeouts there is no risk in retrying
       // our PATCH and POST requests. So, we set methods to be Got's defaults plus 'PATCH' and 'POST'
       methods: ['GET', 'PATCH', 'POST', 'PUT', 'HEAD', 'DELETE', 'OPTIONS', 'TRACE'],

--- a/config/request.config.js
+++ b/config/request.config.js
@@ -11,6 +11,10 @@ require('dotenv').config()
 
 const config = {
   timeout: parseInt(process.env.REQUEST_TIMEOUT) || 5000,
+  // Generating a bill run can require us to fire 1000's of requests at the charging module in a burst. Obviously, this
+  // can put the API under pressure so requests can take longer to complete. To avoid a slow request causing the whole
+  // bill run to error we give the CHA a little more wiggle-room to handle things
+  chargingModuleTimeout: parseInt(process.env.CHA_REQUEST_TIMEOUT) || 20000,
   // Note - Why lowercase? It's just the convention for http_proxy, https_proxy
   // and no_proxy. ¯\_(ツ)_/¯ https://unix.stackexchange.com/a/212972
   httpProxy: process.env.http_proxy

--- a/test/lib/charging-module-request.lib.test.js
+++ b/test/lib/charging-module-request.lib.test.js
@@ -9,6 +9,7 @@ const { describe, it, before, beforeEach, after, afterEach } = exports.lab = Lab
 const { expect } = Code
 
 // Things we need to stub
+const requestConfig = require('../../config/request.config.js')
 const RequestLib = require('../../app/lib/request.lib.js')
 
 // Thing under test
@@ -30,6 +31,13 @@ describe('ChargingModuleRequestLib', () => {
         expiresIn: 3600
       })
     }
+  })
+
+  beforeEach(() => {
+    // Set the timeout value to 1234ms for these tests. We don't trigger a timeout but we do test that the module
+    // uses it when making a request to the charging module, rather than the default request timeout config value
+    Sinon.replace(requestConfig, 'chargingModuleTimeout', 1234)
+    Sinon.replace(requestConfig, 'timeout', 1000)
   })
 
   afterEach(() => {
@@ -61,6 +69,14 @@ describe('ChargingModuleRequestLib', () => {
 
         expect(requestArgs[0]).to.endWith('TEST_ROUTE')
         expect(requestArgs[1].headers).to.include({ authorization: 'Bearer ACCESS_TOKEN' })
+      })
+
+      it('uses the charging module timeout', async () => {
+        await ChargingModuleRequestLib.get(testRoute)
+
+        const requestArgs = RequestLib.get.firstCall.args
+
+        expect(requestArgs[1].timeout).to.equal({ request: 1234 })
       })
 
       it('returns a `true` success status', async () => {
@@ -155,6 +171,14 @@ describe('ChargingModuleRequestLib', () => {
         expect(requestArgs[1].headers).to.include({ authorization: 'Bearer ACCESS_TOKEN' })
       })
 
+      it('uses the charging module timeout', async () => {
+        await ChargingModuleRequestLib.patch(testRoute)
+
+        const requestArgs = RequestLib.patch.firstCall.args
+
+        expect(requestArgs[1].timeout).to.equal({ request: 1234 })
+      })
+
       it('returns a `true` success status', async () => {
         const result = await ChargingModuleRequestLib.patch(testRoute)
 
@@ -246,6 +270,14 @@ describe('ChargingModuleRequestLib', () => {
         expect(requestArgs[0]).to.endWith('TEST_ROUTE')
         expect(requestArgs[1].headers).to.include({ authorization: 'Bearer ACCESS_TOKEN' })
         expect(requestArgs[1].json).to.equal({ test: 'yes' })
+      })
+
+      it('uses the charging module timeout', async () => {
+        await ChargingModuleRequestLib.post(testRoute)
+
+        const requestArgs = RequestLib.post.firstCall.args
+
+        expect(requestArgs[1].timeout).to.equal({ request: 1234 })
       })
 
       it('returns a `true` success status', async () => {

--- a/test/lib/request.lib.test.js
+++ b/test/lib/request.lib.test.js
@@ -112,9 +112,7 @@ describe('RequestLib', () => {
       })
 
       describe('because there was a network issue', () => {
-        // Because of the retries Lab will timeout (by default tests have 2 seconds to finish). So, we have to override
-        // the timeout for this specific test to all it to complete
-        describe('and all retries fail', { timeout: 5000 }, () => {
+        describe('and all retries fail', () => {
           beforeEach(async () => {
             Nock(testDomain)
               .get(() => true)
@@ -159,9 +157,7 @@ describe('RequestLib', () => {
           })
         })
 
-        // Because of the retries Lab will timeout (by default tests have 2 seconds to finish). So, we have to override
-        // the timeout for this specific test to all it to complete
-        describe('and a retry succeeds', { timeout: 5000 }, () => {
+        describe('and a retry succeeds', () => {
           beforeEach(async () => {
             // The first response will error, the second response will return OK
             Nock(testDomain)
@@ -214,10 +210,23 @@ describe('RequestLib', () => {
           })
 
           it('logs when a retry has happened', async () => {
-            await RequestLib.get(testDomain)
+            await RequestLib.get(testDomain, { retry: shortBackoffLimitRetryOptions })
 
             expect(notifierStub.omg.callCount).to.equal(2)
             expect(notifierStub.omg.alwaysCalledWith('Retrying HTTP request')).to.be.true()
+          })
+
+          it('logs and records the error', async () => {
+            await RequestLib.get(testDomain, { retry: shortBackoffLimitRetryOptions })
+
+            const logDataArg = notifierStub.omfg.args[0][1]
+
+            expect(notifierStub.omfg.calledWith('GET request errored')).to.be.true()
+            expect(logDataArg.method).to.equal('GET')
+            expect(logDataArg.url).to.equal('http://example.com')
+            expect(logDataArg.additionalOptions).to.exist()
+            expect(logDataArg.result.succeeded).to.be.false()
+            expect(logDataArg.result.response).to.be.an.error()
           })
 
           describe('the result it returns', () => {
@@ -249,7 +258,7 @@ describe('RequestLib', () => {
           })
 
           it('logs when a retry has happened', async () => {
-            await RequestLib.get(testDomain)
+            await RequestLib.get(testDomain, { retry: shortBackoffLimitRetryOptions })
 
             expect(notifierStub.omg.callCount).to.equal(1)
             expect(notifierStub.omg.alwaysCalledWith('Retrying HTTP request')).to.be.true()
@@ -371,9 +380,7 @@ describe('RequestLib', () => {
       })
 
       describe('because there was a network issue', () => {
-        // Because of the retries Lab will timeout (by default tests have 2 seconds to finish). So, we have to override
-        // the timeout for this specific test to all it to complete
-        describe('and all retries fail', { timeout: 5000 }, () => {
+        describe('and all retries fail', () => {
           beforeEach(async () => {
             Nock(testDomain)
               .patch(() => true)
@@ -418,9 +425,7 @@ describe('RequestLib', () => {
           })
         })
 
-        // Because of the retries Lab will timeout (by default tests have 2 seconds to finish). So, we have to override
-        // the timeout for this specific test to all it to complete
-        describe('and a retry succeeds', { timeout: 5000 }, () => {
+        describe('and a retry succeeds', () => {
           beforeEach(async () => {
             // The first response will error, the second response will return OK
             Nock(testDomain)
@@ -473,10 +478,23 @@ describe('RequestLib', () => {
           })
 
           it('logs when a retry has happened', async () => {
-            await RequestLib.patch(testDomain)
+            await RequestLib.patch(testDomain, { retry: shortBackoffLimitRetryOptions })
 
             expect(notifierStub.omg.callCount).to.equal(2)
             expect(notifierStub.omg.alwaysCalledWith('Retrying HTTP request')).to.be.true()
+          })
+
+          it('logs and records the error', async () => {
+            await RequestLib.patch(testDomain, { retry: shortBackoffLimitRetryOptions })
+
+            const logDataArg = notifierStub.omfg.args[0][1]
+
+            expect(notifierStub.omfg.calledWith('PATCH request errored')).to.be.true()
+            expect(logDataArg.method).to.equal('PATCH')
+            expect(logDataArg.url).to.equal('http://example.com')
+            expect(logDataArg.additionalOptions).to.exist()
+            expect(logDataArg.result.succeeded).to.be.false()
+            expect(logDataArg.result.response).to.be.an.error()
           })
 
           describe('the result it returns', () => {
@@ -508,7 +526,7 @@ describe('RequestLib', () => {
           })
 
           it('logs when a retry has happened', async () => {
-            await RequestLib.patch(testDomain)
+            await RequestLib.patch(testDomain, { retry: shortBackoffLimitRetryOptions })
 
             expect(notifierStub.omg.callCount).to.equal(1)
             expect(notifierStub.omg.alwaysCalledWith('Retrying HTTP request')).to.be.true()
@@ -630,9 +648,7 @@ describe('RequestLib', () => {
       })
 
       describe('because there was a network issue', () => {
-        // Because of the retries Lab will timeout (by default tests have 2 seconds to finish). So, we have to override
-        // the timeout for this specific test to all it to complete
-        describe('and all retries fail', { timeout: 5000 }, () => {
+        describe('and all retries fail', () => {
           beforeEach(async () => {
             Nock(testDomain)
               .post(() => true)
@@ -677,9 +693,7 @@ describe('RequestLib', () => {
           })
         })
 
-        // Because of the retries Lab will timeout (by default tests have 2 seconds to finish). So, we have to override
-        // the timeout for this specific test to all it to complete
-        describe('and a retry succeeds', { timeout: 5000 }, () => {
+        describe('and a retry succeeds', () => {
           beforeEach(async () => {
             // The first response will error, the second response will return OK
             Nock(testDomain)
@@ -732,10 +746,23 @@ describe('RequestLib', () => {
           })
 
           it('logs when a retry has happened', async () => {
-            await RequestLib.post(testDomain)
+            await RequestLib.post(testDomain, { retry: shortBackoffLimitRetryOptions })
 
             expect(notifierStub.omg.callCount).to.equal(2)
             expect(notifierStub.omg.alwaysCalledWith('Retrying HTTP request')).to.be.true()
+          })
+
+          it('logs and records the error', async () => {
+            await RequestLib.post(testDomain, { retry: shortBackoffLimitRetryOptions })
+
+            const logDataArg = notifierStub.omfg.args[0][1]
+
+            expect(notifierStub.omfg.calledWith('POST request errored')).to.be.true()
+            expect(logDataArg.method).to.equal('POST')
+            expect(logDataArg.url).to.equal('http://example.com')
+            expect(logDataArg.additionalOptions).to.exist()
+            expect(logDataArg.result.succeeded).to.be.false()
+            expect(logDataArg.result.response).to.be.an.error()
           })
 
           describe('the result it returns', () => {
@@ -767,7 +794,7 @@ describe('RequestLib', () => {
           })
 
           it('logs when a retry has happened', async () => {
-            await RequestLib.post(testDomain)
+            await RequestLib.post(testDomain, { retry: shortBackoffLimitRetryOptions })
 
             expect(notifierStub.omg.callCount).to.equal(1)
             expect(notifierStub.omg.alwaysCalledWith('Retrying HTTP request')).to.be.true()


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4365

As part of looking at re-implementing the SROC annual billing engine in this project, we found a solution that allows us to process bills in parallel (will be added in later commits!) However, the more we do the more strain this puts on the [Charging Module API](https://github.com/DEFRA/sroc-charging-module-api) to the point we start seeing timeouts and `ECONNRESET` errors.

With just a few tweaks on our side, we could increase our tolerance of these errors. There is still a point where we are pushing it too hard. But the more throughput we get, the faster we can complete the bill run process.

So, this change does the following.

- **Double the default timeout we set for web requests just for the charging module.** We don't just double the timeout for all web requests. Some impact the experience of the end-user and they shouldn't be made to watch a page spinning for longer than necessary
- **Retry `ECONNRESET` errors.** We learnt this can happen when an API is under pressure. It doesn't mean the Charging Module can't handle the next attempt so it is safe to try these again.