### PR TITLE
Stop showing supp source charge as negative

### DIFF
--- a/app/presenters/bill-licences/view-standard-charge-transaction.presenter.js
+++ b/app/presenters/bill-licences/view-standard-charge-transaction.presenter.js
@@ -35,12 +35,7 @@ function _additionalCharges (credit, waterCompanyCharge, supportedSourceCharge, 
   const charges = []
 
   if (supportedSourceName) {
-    let chargeInPounds = 0
-    if (credit) {
-      chargeInPounds = formatPounds(supportedSourceCharge * -1)
-    } else {
-      chargeInPounds = formatPounds(supportedSourceCharge)
-    }
+    const chargeInPounds = formatPounds(supportedSourceCharge)
 
     charges.push(`Supported source ${supportedSourceName} (£${chargeInPounds})`)
   }

--- a/app/presenters/bill-licences/view-standard-charge-transaction.presenter.js
+++ b/app/presenters/bill-licences/view-standard-charge-transaction.presenter.js
@@ -31,7 +31,7 @@ function go (transaction) {
   return _presrocContent(transaction)
 }
 
-function _additionalCharges (credit, waterCompanyCharge, supportedSourceCharge, supportedSourceName) {
+function _additionalCharges (waterCompanyCharge, supportedSourceCharge, supportedSourceName) {
   const charges = []
 
   if (supportedSourceName) {
@@ -202,7 +202,7 @@ function _srocContent (transaction) {
   const supportedSourceChargeInPence = supportedSourceCharge * 100
 
   return {
-    additionalCharges: _additionalCharges(credit, waterCompanyCharge, supportedSourceChargeInPence, supportedSourceName),
+    additionalCharges: _additionalCharges(waterCompanyCharge, supportedSourceChargeInPence, supportedSourceName),
     adjustments: _adjustments(
       adjustmentFactor,
       aggregateFactor,

--- a/test/presenters/bill-licences/view-standard-charge-transaction.presenter.test.js
+++ b/test/presenters/bill-licences/view-standard-charge-transaction.presenter.test.js
@@ -51,28 +51,10 @@ describe('View Standard Charge Transaction presenter', () => {
           transaction.supportedSourceCharge = '14567'
         })
 
-        describe('and the transaction is a credit', () => {
-          beforeEach(() => {
-            transaction.credit = true
-          })
+        it("returns 'Supported source Candover (£14567.00)'", () => {
+          const result = ViewStandardChargeTransactionPresenter.go(transaction)
 
-          it("returns 'Supported source Candover (£-14567.00)'", () => {
-            const result = ViewStandardChargeTransactionPresenter.go(transaction)
-
-            expect(result.additionalCharges).to.equal('Supported source Candover (£-14567.00)')
-          })
-        })
-
-        describe('and the transaction is a debit', () => {
-          beforeEach(() => {
-            transaction.credit = false
-          })
-
-          it("returns 'Supported source Candover (£14567.00)'", () => {
-            const result = ViewStandardChargeTransactionPresenter.go(transaction)
-
-            expect(result.additionalCharges).to.equal('Supported source Candover (£14567.00)')
-          })
+          expect(result.additionalCharges).to.equal('Supported source Candover (£14567.00)')
         })
       })
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4363

We've just dealt with [Fix bill licence supp source decimal in wrong place](https://github.com/DEFRA/water-abstraction-system/pull/714). This caused us to take a closer look at how the supported source charge is displayed in the new views.

Our eagle-eyed testers spotted we were showing the value as a negative if the transaction itself is a credit and whether this is correct. When we double-checked the legacy view we found it's not! 🤦

This change fixes the display so the supported source charge is always displayed as a positive.

> Screenshot of supported source charge showing with the negative sign

![water-4363_new](https://github.com/DEFRA/water-abstraction-system/assets/1789650/bfdef66b-db0c-4c88-89ce-5388d69e5bfc)
