### PR TITLE
Remove abstraction text for under query licence

### DIFF
--- a/app/presenters/bill-runs/two-part-tariff/review-licence.presenter.js
+++ b/app/presenters/bill-runs/two-part-tariff/review-licence.presenter.js
@@ -22,7 +22,7 @@ function go (matchedReturns, unmatchedReturns, chargePeriods, billRun, licenceRe
   return {
     licenceRef,
     billRunId: billRun.id,
-    status: 'Review',
+    status: 'review',
     region: billRun.region.displayName,
     matchedReturns: _prepareMatchedReturns(matchedReturns),
     unmatchedReturns: _prepareUnmatchedReturns(unmatchedReturns),

--- a/app/presenters/bill-runs/two-part-tariff/review-licence.presenter.js
+++ b/app/presenters/bill-runs/two-part-tariff/review-licence.presenter.js
@@ -40,7 +40,7 @@ function _prepareLicenceChargePeriods (chargePeriods) {
 
 function _prepareUnmatchedReturns (unmatchedReturns) {
   return unmatchedReturns.map((unmatchedReturn) => {
-    const { returnReference, status, description, purposes, allocated, quantity, startDate, endDate } = unmatchedReturn.reviewReturnResults
+    const { returnReference, status, description, purposes, quantity, startDate, endDate } = unmatchedReturn.reviewReturnResults
 
     return {
       reference: returnReference,
@@ -48,14 +48,14 @@ function _prepareUnmatchedReturns (unmatchedReturns) {
       status,
       description,
       purpose: purposes[0].tertiary.description,
-      total: `${allocated} ML / ${quantity} ML`
+      total: `${quantity} ML`
     }
   })
 }
 
 function _prepareMatchedReturns (matchedReturns) {
   return matchedReturns.map((matchedReturn) => {
-    const { returnStatus, total, allocated } = _checkStatusAndReturnTotal(matchedReturn)
+    const { returnStatus, total } = _checkStatusAndReturnTotal(matchedReturn)
     const { returnReference, description, purposes, startDate, endDate } = matchedReturn.reviewReturnResults
 
     return {
@@ -65,7 +65,7 @@ function _prepareMatchedReturns (matchedReturns) {
       description,
       purpose: purposes[0].tertiary.description,
       total,
-      allocated
+      allocated: _allocated(matchedReturn)
     }
   })
 }
@@ -73,27 +73,28 @@ function _prepareMatchedReturns (matchedReturns) {
 function _checkStatusAndReturnTotal (returnLog) {
   const { status, allocated, quantity, underQuery } = returnLog.reviewReturnResults
 
-  let allocatedStatus
   let total
   let returnStatus = underQuery ? 'query' : status
 
   if (status === 'void' || status === 'received') {
     total = '/'
-    allocatedStatus = 'Not processed'
   } else if (status === 'due') {
     returnStatus = 'overdue'
     total = '/'
-    allocatedStatus = 'Not processed'
   } else {
     total = `${allocated} ML / ${quantity} ML`
-    allocatedStatus = _allocated(quantity, allocated)
   }
 
-  return { returnStatus, total, allocated: allocatedStatus }
+  return { returnStatus, total }
 }
 
-function _allocated (quantity, allocated) {
-  if (quantity > allocated) {
+function _allocated (returnLog) {
+  const { quantity, allocated, status, underQuery } = returnLog.reviewReturnResults
+  if (underQuery) {
+    return ''
+  } else if (status === 'void' || status === 'received' || status === 'due') {
+    return 'Not processed'
+  } else if (quantity > allocated) {
     return 'Over abstraction'
   } else {
     return 'Fully allocated'

--- a/app/views/bill-runs/review-licence.njk
+++ b/app/views/bill-runs/review-licence.njk
@@ -23,7 +23,7 @@
       <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">{{pageTitle}}</h1>
 
       {# Status badge #}
-      {% if status == 'Review' %}
+      {% if status == 'review' %}
         {% set colour = "govuk-tag--blue govuk-!-font-size-16" %}
       {% else %}
         {% set colour = "govuk-tag--green govuk-!-font-size-16" %}

--- a/app/views/bill-runs/review-licence.njk
+++ b/app/views/bill-runs/review-licence.njk
@@ -23,7 +23,7 @@
       <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">{{pageTitle}}</h1>
 
       {# Status badge #}
-      {% if status == 'review' %}
+      {% if status == 'Review' %}
         {% set colour = "govuk-tag--blue govuk-!-font-size-16" %}
       {% else %}
         {% set colour = "govuk-tag--green govuk-!-font-size-16" %}

--- a/test/presenters/bill-runs/two-part-tariff/review-licence.presenter.test.js
+++ b/test/presenters/bill-runs/two-part-tariff/review-licence.presenter.test.js
@@ -10,7 +10,7 @@ const { expect } = Code
 // Thing under test
 const ReviewLicencePresenter = require('../../../../app/presenters/bill-runs/two-part-tariff/review-licence.presenter.js')
 
-describe.only('Review Licence presenter', () => {
+describe('Review Licence presenter', () => {
   describe('when there is data to be presented for review licence', () => {
     const matchedReturns = _matchingReturns()
     const unmatchedReturns = _unmatchedReturns()

--- a/test/presenters/bill-runs/two-part-tariff/review-licence.presenter.test.js
+++ b/test/presenters/bill-runs/two-part-tariff/review-licence.presenter.test.js
@@ -10,7 +10,7 @@ const { expect } = Code
 // Thing under test
 const ReviewLicencePresenter = require('../../../../app/presenters/bill-runs/two-part-tariff/review-licence.presenter.js')
 
-describe('Review Licence presenter', () => {
+describe.only('Review Licence presenter', () => {
   describe('when there is data to be presented for review licence', () => {
     const matchedReturns = _matchingReturns()
     const unmatchedReturns = _unmatchedReturns()
@@ -24,7 +24,7 @@ describe('Review Licence presenter', () => {
       expect(result).to.equal({
         licenceRef: '7/34/10/*S/0084',
         billRunId: '6620135b-0ecf-4fd4-924e-371f950c0526',
-        status: 'Review',
+        status: 'review',
         region: 'Anglian',
         matchedReturns: [
           {

--- a/test/presenters/bill-runs/two-part-tariff/review-licence.presenter.test.js
+++ b/test/presenters/bill-runs/two-part-tariff/review-licence.presenter.test.js
@@ -57,11 +57,20 @@ describe('Review Licence presenter', () => {
           {
             reference: '10042951',
             dates: '1 April 2022 to 31 March 2023',
-            status: 'query',
+            status: 'complete',
             description: 'Ormesby Broad - Point 1',
             purpose: 'Spray Irrigation - Storage',
             total: '1 ML / 10 ML',
             allocated: 'Over abstraction'
+          },
+          {
+            reference: '10042951',
+            dates: '1 April 2022 to 31 March 2023',
+            status: 'query',
+            description: 'Ormesby Broad - Point 1',
+            purpose: 'Spray Irrigation - Storage',
+            total: '0 ML / 10 ML',
+            allocated: ''
           }
         ],
         unmatchedReturns: [
@@ -71,7 +80,7 @@ describe('Review Licence presenter', () => {
             status: 'completed',
             description: 'Ormesby Broad - Point 1',
             purpose: 'Spray Irrigation - Storage',
-            total: '0 ML / 20 ML'
+            total: '20 ML'
           }
         ],
         chargePeriodDates: ['1 April 2022 to 31 March 2023']
@@ -190,7 +199,7 @@ function _matchingReturns () {
         dueDate: new Date('2023-04-28'),
         receivedDate: null,
         status: 'complete',
-        underQuery: true,
+        underQuery: false,
         nilReturn: false,
         description: 'Ormesby Broad - Point 1',
         purposes: [{
@@ -200,6 +209,32 @@ function _matchingReturns () {
         }],
         quantity: 10,
         allocated: 1,
+        abstractionOutsidePeriod: false
+      },
+      licence: {
+        licenceRef: '7/34/10/*S/0084'
+      }
+    },
+    {
+      chargePeriodStartDate: new Date('2022-04-01'),
+      chargePeriodEndDate: new Date('2023-03-31'),
+      reviewReturnResults: {
+        returnReference: '10042951',
+        startDate: new Date('2022-04-01'),
+        endDate: new Date('2023-03-31'),
+        dueDate: new Date('2023-04-28'),
+        receivedDate: null,
+        status: 'complete',
+        underQuery: true,
+        nilReturn: false,
+        description: 'Ormesby Broad - Point 1',
+        purposes: [{
+          tertiary: {
+            description: 'Spray Irrigation - Storage'
+          }
+        }],
+        quantity: 10,
+        allocated: 0,
         abstractionOutsidePeriod: false
       },
       licence: {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4191

During the testing for the review licence page in a twp part tariff bill run, it was discussed in a blocker review the text for a return that is under query. Currently if a return is under query it shows a text box stating the return is either fully abstracted or over abstracted. This is wrong as a return that is under query is not allocated on the charge element and therefore does not meet any of those definitions. This change is to remove that text box for returns under query. This change also includes content changes on the page for unmatched returns. This is since an unmatched return would not be allocated to a charge element so we are removing the allocated text field.