### PR TITLE
Add Annual ProcessBillingPeriodService

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,6 +56,9 @@ REDIS_PORT=6379
 REDIS_PASSWORD=
 REDIS_DISABLE_TLS=false
 
+# Billing config
+BILLING_ANNUAL_BATCH_SIZE=5
+
 # Cookie secret for authenticating requests coming via the UI. Note that the value should be the same as `COOKIE_SECRET`
 # on the UI side
 COOKIE_SECRET=

--- a/app/services/bill-runs/annual/process-billing-period.service.js
+++ b/app/services/bill-runs/annual/process-billing-period.service.js
@@ -151,8 +151,8 @@ async function _createTransactions (billLicenceId, billingPeriod, chargeVersion,
 function _findOrCreateBillLicence (billLicences, licence, billId) {
   const { id: licenceId, licenceRef } = licence
 
-  let billLicence = billLicences.find((billLicence) => {
-    return billLicence.licenceId === licenceId
+  let billLicence = billLicences.find((existingBillLicence) => {
+    return existingBillLicence.licenceId === licenceId
   })
 
   if (!billLicence) {

--- a/app/services/bill-runs/annual/process-billing-period.service.js
+++ b/app/services/bill-runs/annual/process-billing-period.service.js
@@ -1,0 +1,253 @@
+'use strict'
+
+/**
+ * Process the billing accounts for a given billing period and creates their annual bills
+ * @module ProcessBillingPeriodService
+ */
+
+const BillRunError = require('../../../errors/bill-run.error.js')
+const BillRunModel = require('../../../models/bill-run.model.js')
+const BillModel = require('../../../models/bill.model.js')
+const BillLicenceModel = require('../../../models/bill-licence.model.js')
+const DetermineChargePeriodService = require('../determine-charge-period.service.js')
+const DetermineMinimumChargeService = require('../determine-minimum-charge.service.js')
+const { generateUUID } = require('../../../lib/general.lib.js')
+const GenerateTransactionsService = require('../generate-transactions.service.js')
+const SendTransactionsService = require('../send-transactions.service.js')
+const TransactionModel = require('../../../models/transaction.model.js')
+
+const BillingConfig = require('../../../../config/billing.config.js')
+
+/**
+ * Process the billing accounts for a given billing period and creates their annual bills
+ *
+ * @param {module:BillRunModel} billRun - The newly created bill run we need to process
+ * @param {Object} billingPeriod - An object representing the financial year the bills will be for
+ * @param {module:BillingAccountModel[]} billingAccounts - The billing accounts to create bills for
+ *
+ * @returns {Promise<Boolean>} true if the bill run is not empty (there are transactions to bill) else false
+ */
+async function go (billRun, billingPeriod, billingAccounts) {
+  let billRunIsPopulated = false
+
+  if (billingAccounts.length === 0) {
+    return billRunIsPopulated
+  }
+
+  // We set the batch size and number of billing accounts here rather than determine them for every iteration of the
+  // loop. It's a very minor node towards performance.
+  const batchSize = BillingConfig.annual.batchSize
+  const billingAccountsCount = billingAccounts.length
+
+  // Loop through the billing accounts to be processed by the size of the batch. For example, if we have 100 billing
+  // accounts to process and the batch size is 10, we'll make 10 iterations of the loop
+  for (let i = 0; i < billingAccountsCount; i += batchSize) {
+    // Use slice(start, end) to extract the next batch of billing accounts to process. For example, if we have 100
+    // billing accounts, a batch size of 10 then
+    //
+    // - 1st pass: slice(0, 10) will return billingAccounts[0] to billingAccounts[9]
+    // - 2nd pass: slice(10, 20) will return billingAccounts[10] to billingAccounts[19]
+    //
+    // Both the start and end params are zero-based indexes for the array being sliced. The bit that might confuse is
+    // end is not inclusive!
+    const accountsToProcess = billingAccounts.slice(i, i + batchSize)
+
+    // NOTE: we purposefully loop through each billing account in the batch without awaiting them to be processed. This
+    // is for performance purposes. If our batch size is 10 we'll start processing one after the other. We then wait for
+    // all 10 to complete. The overall process time will only be that of the one that takes the longest. If we await
+    // instead the overall time will be the sum of the time to process each one.
+    const processes = accountsToProcess.map((accountToProcess) => {
+      return _processBillingAccount(accountToProcess, billRun, billingPeriod)
+    })
+
+    // _processBillingAccount() will return true (bill was created) else false (no bill created) for each billing
+    // account processed. Promise.all() will return these results as an array. Only one of them has to be true for us to
+    // mark the bill run as populated. The complication is we're not doing this once but multiple times as we iterate
+    // the billing accounts. As soon as we have flagged the bill run as populated we can stop checking. And TBH, unlike
+    // supplementary it is extremely unlikely an annual bill run would generate no bills. But we play it safe and don't
+    // make that assumption.
+    const results = await Promise.all(processes)
+    if (!billRunIsPopulated) {
+      billRunIsPopulated = results.some((result) => result)
+    }
+  }
+
+  return billRunIsPopulated
+}
+
+/**
+ * Create the bill licence and transaction records for a bill
+ *
+ * For each billing account we need to create a bill (1-to-1). Linked to the bill will be multiple charge versions
+ * which is what we actually use to calculate a bill. A charge version can have multiple charge references and for each
+ * one we need to generate a transaction line.
+ *
+ * The complication is we group transactions by licence (via the bill licence) not charge version. So, as we iterate
+ * the charge versions we have to determine if its for a licence that we have already generated a bill licence for, or
+ * we have to create a new one.
+ */
+async function _createBillLicencesAndTransactions (billId, billingAccount, billRunExternalId, billingPeriod) {
+  const billLicences = []
+  const transactions = []
+
+  const { accountNumber } = billingAccount
+
+  for (const chargeVersion of billingAccount.chargeVersions) {
+    const billLicence = _findOrCreateBillLicence(billLicences, chargeVersion.licence, billId)
+
+    const createdTransactions = await _createTransactions(
+      billLicence.id,
+      billingPeriod,
+      chargeVersion,
+      billRunExternalId,
+      accountNumber
+    )
+
+    transactions.push(...createdTransactions)
+  }
+
+  return { billLicences, transactions }
+}
+
+/**
+ * Handles generating the transaction data for a given charge version and then sending it to the Charging Module API.
+ */
+async function _createTransactions (billLicenceId, billingPeriod, chargeVersion, billRunExternalId, accountNumber) {
+  const chargePeriod = DetermineChargePeriodService.go(chargeVersion, billingPeriod)
+
+  if (!chargePeriod.startDate) {
+    return []
+  }
+
+  const generatedTransactions = _generateTransactionData(billLicenceId, billingPeriod, chargePeriod, chargeVersion)
+
+  return SendTransactionsService.go(generatedTransactions, billRunExternalId, accountNumber, chargeVersion.licence)
+}
+
+/**
+ * Use to either find or create the bill licence for a given bill (billing account) and licence
+ *
+ * For each billing account being processed the engine will create a bill. But the transactions within a bill are
+ * grouped by licence because the details of the licence will effect the charge against the transactions.
+ *
+ * So, transactions are linked to a bill by a 'bill licence' record. Things are further complicated by the fact we don't
+ * directly work with the licences against a billing account. The link is via charge versions, and more than one charge
+ * version can link to the same licence.
+ *
+ * > The information needed for billing is held in charge versions and their associated records. A licence will have at
+ * > least one of these but may have more should changes have been made, for example, a change in the amount that can be
+ * > abstracted. It's the charge version that is directly linked to the billing account, not the licence.
+ *
+ * Because we're processing the charge versions for a billing account the same licence might appear more than once. This
+ * means we need to find the existing bill licence record or if one doesn't exist create it.
+ *
+ * @param {*} billLicences - The existing bill licences created for the bill being generated
+ * @param {*} licence - the licence we're looking for an against bill licence record
+ * @param {*} billId - the ID of the bill we're creating
+ *
+ * @return {Object} returns either an existing bill licence we previously created or a new one for the licence and bill
+ * being generated
+ */
+function _findOrCreateBillLicence (billLicences, licence, billId) {
+  const { id: licenceId, licenceRef } = licence
+
+  let billLicence = billLicences.find((billLicence) => {
+    return billLicence.licenceId === licenceId
+  })
+
+  if (!billLicence) {
+    billLicence = {
+      id: generateUUID(),
+      billId,
+      licenceId,
+      licenceRef
+    }
+
+    billLicences.push(billLicence)
+  }
+
+  return billLicence
+}
+
+/**
+ * Generate the transaction data for a charge version
+ *
+ * What we generate is two-fold. For each charge reference linked to the charge version we have to generate a
+ * transaction record. One of the things we need to know is if the charge version is the first charge on a new licence.
+ * This information needs to be passed to the Charging Module API as it affects the calculation.
+ *
+ * And if the charge version is linked to a licence _not_ flagged as a 'water undertaker' (water company) we are also
+ * required to generate a second 'compensation' transaction.
+ *
+ * This function iterates the charge references and combines the transactions generated into a 'flat' array of all
+ * the transactions for the charge version and returns it.
+ */
+function _generateTransactionData (billLicenceId, billingPeriod, chargePeriod, chargeVersion) {
+  try {
+    const firstChargeOnNewLicence = DetermineMinimumChargeService.go(chargeVersion, chargePeriod)
+
+    // We use flatMap as GenerateTransactionsService returns an array of transactions (depending on if a compensation
+    // transaction is also created) and we
+    const transactions = chargeVersion.chargeReferences.flatMap((chargeReference) => {
+      return GenerateTransactionsService.go(
+        billLicenceId,
+        chargeReference,
+        billingPeriod,
+        chargePeriod,
+        firstChargeOnNewLicence,
+        chargeVersion.licence.waterUndertaker
+      )
+    })
+
+    return transactions
+  } catch (error) {
+    throw new BillRunError(error, BillRunModel.errorCodes.failedToPrepareTransactions)
+  }
+}
+
+/**
+ * Processes the billing account
+ *
+ * We create a bill object that will eventually be persisted for the billing account. We then call
+ * `_createBillLicencesAndTransactions()` which handles generating the bill licences and transactions that will form
+ * our bill.
+ *
+ * Once everything has been generated we persist the results to the DB.
+ */
+async function _processBillingAccount (billingAccount, billRun, billingPeriod) {
+  const { id: billingAccountId, accountNumber } = billingAccount
+  const { id: billRunId, externalId: billRunExternalId } = billRun
+
+  const bill = {
+    id: generateUUID(),
+    accountNumber,
+    address: {}, // Address is set to an empty object for SROC billing invoices
+    billingAccountId,
+    billRunId,
+    credit: false,
+    financialYearEnding: billingPeriod.endDate.getFullYear()
+  }
+
+  const billData = await _createBillLicencesAndTransactions(bill.id, billingAccount, billRunExternalId, billingPeriod)
+
+  const { billLicences, transactions } = billData
+
+  // No transactions were generated so there is nothing to bill. Do not persist anything!
+  if (transactions.length === 0) {
+    return false
+  }
+
+  return _persistBillData(bill, billLicences, transactions)
+}
+
+async function _persistBillData (bill, billLicences, transactions) {
+  await BillModel.query().insert(bill)
+  await BillLicenceModel.query().insert(billLicences)
+  await TransactionModel.query().insert(transactions)
+
+  return true
+}
+
+module.exports = {
+  go
+}

--- a/config/billing.config.js
+++ b/config/billing.config.js
@@ -1,0 +1,18 @@
+'use strict'
+
+/**
+ * Config values used by app/services/bill-runs/ engines
+ * @module BillingConfig
+ */
+
+// We require dotenv directly in each config file to support unit tests that depend on this this subset of config.
+// Requiring dotenv in multiple places has no effect on the app when running for real.
+require('dotenv').config()
+
+const config = {
+  annual: {
+    batchSize: parseInt(process.env.BILLING_ANNUAL_BATCH_SIZE) || 5
+  }
+}
+
+module.exports = config

--- a/test/services/bill-runs/annual/process-billing-period.service.test.js
+++ b/test/services/bill-runs/annual/process-billing-period.service.test.js
@@ -1,0 +1,215 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { describe, it, beforeEach, afterEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const DatabaseHelper = require('../../../support/helpers/database.helper.js')
+const { generateUUID } = require('../../../../app/lib/general.lib.js')
+const { currentFinancialYear } = require('../../../support/helpers/general.helper.js')
+
+// Things we need to stub
+const BillRunError = require('../../../../app/errors/bill-run.error.js')
+const BillRunModel = require('../../../../app/models/bill-run.model.js')
+const ChargingModuleCreateTransactionService = require('../../../../app/services/charging-module/create-transaction.service.js')
+const GenerateTransactionsService = require('../../../../app/services/bill-runs/generate-transactions.service.js')
+
+// Thing under test
+const ProcessBillingPeriodService = require('../../../../app/services/bill-runs/annual/process-billing-period.service.js')
+
+describe('Annual Process billing period service', () => {
+  const billingPeriod = currentFinancialYear()
+  const billRun = {
+    id: '8e0d4c8b-e9fe-4238-8f3e-dfca743316ef',
+    externalId: 'f6e052f5-37f9-43f3-a649-ff6398cec1a3'
+  }
+
+  let billingAccount
+  let chargingModuleCreateTransactionServiceStub
+
+  beforeEach(async () => {
+    // NOTE: Although we don't rely on the helpers to create the data we pass into the service it does persist the
+    // results. If we don't clean the DB it causes the tests to fail because of unique constraints on the legacy tables.
+    await DatabaseHelper.clean()
+
+    chargingModuleCreateTransactionServiceStub = Sinon.stub(ChargingModuleCreateTransactionService, 'go')
+  })
+
+  afterEach(() => {
+    Sinon.restore()
+  })
+
+  describe('when the service is called', () => {
+    describe('and there are no billing accounts to process', () => {
+      it('returns false (bill run is empty)', async () => {
+        const result = await ProcessBillingPeriodService.go(billRun, billingPeriod, [])
+
+        expect(result).to.be.false()
+      })
+    })
+
+    describe('and there are billing accounts to process', () => {
+      describe('and they are billable', () => {
+        beforeEach(async () => {
+          billingAccount = _testBillingAccount()
+
+          // We want to ensure there is coverage of the functionality that finds an existing bill licence or creates a
+          // new one when processing a billing account. To to that we need a billing account with 2 charge versions
+          // linked to the same licence
+          billingAccount.chargeVersions = [_testChargeVersion(billingAccount.id), _testChargeVersion(billingAccount.id)]
+
+          chargingModuleCreateTransactionServiceStub.onFirstCall().resolves({
+            ..._chargingModuleResponse('7e752fa6-a19c-4779-b28c-6e536f028795')
+          })
+          chargingModuleCreateTransactionServiceStub.onSecondCall().resolves({
+            ..._chargingModuleResponse('a2086da4-e3b6-4b83-afe1-0e2e5255efaf')
+          })
+        })
+
+        it('returns true (bill run is not empty)', async () => {
+          const result = await ProcessBillingPeriodService.go(billRun, billingPeriod, [billingAccount])
+
+          expect(result).to.be.true()
+        })
+      })
+
+      describe('but they are not billable', () => {
+        beforeEach(async () => {
+          billingAccount = _testBillingAccount()
+          const chargeVersion = _testChargeVersion(billingAccount.id)
+
+          // We update the billing account's charge information so that the engine calculates a charge period that
+          // starts after the abstraction period i.e. nothing to bill
+          chargeVersion.startDate = new Date(billingPeriod.endDate.getFullYear(), 7, 1)
+          chargeVersion.chargeReferences[0].chargeElements[0].abstractionPeriodEndMonth = 5
+
+          billingAccount.chargeVersions = [chargeVersion]
+        })
+
+        it('returns false (bill run is empty)', async () => {
+          const result = await ProcessBillingPeriodService.go(billRun, billingPeriod, [billingAccount])
+
+          expect(result).to.be.false()
+        })
+      })
+    })
+  })
+
+  describe('when the service errors', () => {
+    beforeEach(async () => {
+      billingAccount = _testBillingAccount()
+      billingAccount.chargeVersions = [_testChargeVersion(billingAccount.id)]
+    })
+
+    describe('because generating the calculated transactions fails', () => {
+      beforeEach(async () => {
+        Sinon.stub(GenerateTransactionsService, 'go').throws()
+      })
+
+      it('throws a BillRunError with the correct code', async () => {
+        const error = await expect(ProcessBillingPeriodService.go(billRun, billingPeriod, [billingAccount]))
+          .to
+          .reject()
+
+        expect(error).to.be.an.instanceOf(BillRunError)
+        expect(error.code).to.equal(BillRunModel.errorCodes.failedToPrepareTransactions)
+      })
+    })
+
+    describe('because sending the transactions fails', () => {
+      beforeEach(async () => {
+        chargingModuleCreateTransactionServiceStub.rejects()
+      })
+
+      it('throws a BillRunError with the correct code', async () => {
+        const error = await expect(ProcessBillingPeriodService.go(billRun, billingPeriod, [billingAccount]))
+          .to
+          .reject()
+
+        expect(error).to.be.an.instanceOf(BillRunError)
+        expect(error.code).to.equal(BillRunModel.errorCodes.failedToCreateCharge)
+      })
+    })
+  })
+})
+
+function _chargingModuleResponse (transactionId) {
+  return {
+    succeeded: true,
+    response: {
+      body: { transaction: { id: transactionId } }
+    }
+  }
+}
+
+function _testBillingAccount () {
+  return {
+    id: '973a5852-9c06-4c14-b1e2-d32b88d3e878',
+    accountNumber: 'T71117364A'
+  }
+}
+
+function _testChargeVersion (billingAccountId) {
+  return {
+    id: generateUUID(),
+    scheme: 'sroc',
+    startDate: new Date('2022-04-01'),
+    endDate: null,
+    billingAccountId,
+    status: 'current',
+    licence: {
+      id: '1b605a4e-a065-4b17-80eb-47179b99a4e8',
+      licenceRef: '01/684',
+      waterUndertaker: true,
+      historicalAreaCode: 'SAAR',
+      regionalChargeArea: 'Southern',
+      startDate: new Date('2022-01-01'),
+      expiredDate: null,
+      lapsedDate: null,
+      revokedDate: null,
+      region: {
+        id: '03d3a38b-0213-43eb-9ab4-d83f26d3b111',
+        chargeRegionId: 'A'
+      }
+    },
+    changeReason: {
+      id: '9107791e-b4b2-481c-b768-fb66d0b5d22e',
+      triggersMinimumCharge: false
+    },
+    chargeReferences: [
+      {
+        id: generateUUID(),
+        source: 'non-tidal',
+        loss: 'low',
+        volume: '6.819',
+        adjustments: {
+          s126: null, s127: false, s130: false, charge: null, winter: false, aggregate: '0.562114443'
+        },
+        additionalCharges: { isSupplyPublicWater: true },
+        description: 'Mineral washing',
+        chargeCategory: {
+          id: 'cc4a66da-efdb-4882-b18a-daf000131349',
+          reference: '4.4.1',
+          shortDescription: 'Low loss, non-tidal, up to and including 5,000 ML/yr'
+        },
+        chargeElements: [
+          {
+            id: generateUUID(),
+            abstractionPeriodStartDay: 1,
+            abstractionPeriodStartMonth: 4,
+            abstractionPeriodEndDay: 31,
+            abstractionPeriodEndMonth: 10,
+            // NOTE: We are faking an Objection model which comes with a toJSON() method that gets called as part
+            // of processing the billing account.
+            toJSON: () => { return '{}' }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/test/services/bill-runs/supplementary/process-billing-period.service.test.js
+++ b/test/services/bill-runs/supplementary/process-billing-period.service.test.js
@@ -31,7 +31,7 @@ const SendTransactionsService = require('../../../../app/services/bill-runs/send
 // Thing under test
 const ProcessBillingPeriodService = require('../../../../app/services/bill-runs/supplementary/process-billing-period.service.js')
 
-describe('Process billing period service', () => {
+describe('Supplementary Process billing period service', () => {
   const billingPeriod = {
     startDate: new Date('2022-04-01'),
     endDate: new Date('2023-03-31')


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4365

> For context this came out of us working on re-implementing the SROC annual bill run using what we've learnt and components from our supplementary billing engine.

The main component of our supplementary billing engine is its `ProcessBillingPeriodService`. But it has to deal with generating bills across 6 years as well as checking what has previously been billed and comparing that with what is due to be billed.

Fortunately, the annual billing engine doesn't have any of these additional complications. Which means we can't reuse what we built for supplementary billing.

So, this adds a `ProcessBillingPeriodService` for annual billing which will be responsible for processing the billing accounts to bill and creating their bills, generating the transactions and sending them to the [Charging Module API](https://github.com/DEFRA/sroc-charging-module-api).

Once in place, we can hook up the create bill request to this engine and start auditing if what we've built is correct.