### PR TITLE
Update allocation engine to handle overdue returns

### DIFF
--- a/app/services/bill-runs/two-part-tariff/allocate-returns-to-charge-element.service.js
+++ b/app/services/bill-runs/two-part-tariff/allocate-returns-to-charge-element.service.js
@@ -58,7 +58,6 @@ function _allocateReturns (chargeElement, matchedReturn, chargePeriod, chargeRef
 
       chargeElement.allocatedQuantity += qtyToAllocate
       chargeElement.returnLogs[i].allocatedQuantity += qtyToAllocate
-
       matchedLine.unallocated -= qtyToAllocate
       matchedReturn.allocatedQuantity += qtyToAllocate
       chargeReference.allocatedQuantity += qtyToAllocate
@@ -81,7 +80,6 @@ function _allocateDueReturns (chargeElement, matchedReturn, chargeReference, i) 
 
     chargeElement.allocatedQuantity += qtyToAllocate
     chargeElement.returnLogs[i].allocatedQuantity += qtyToAllocate
-
     matchedReturn.allocatedQuantity += qtyToAllocate
     chargeReference.allocatedQuantity += qtyToAllocate
   }
@@ -106,11 +104,7 @@ function _fullyAllocated (chargeElement, chargeReference) {
   }
 
   // Finally, we can only allocate to the charge element if there is unallocated volume left!
-  if (chargeElement.allocatedQuantity >= chargeElement.authorisedAnnualQuantity) {
-    return true
-  }
-
-  return false
+  return (chargeElement.allocatedQuantity >= chargeElement.authorisedAnnualQuantity)
 }
 
 function _matchLines (chargeElement, returnSubmissionLines) {

--- a/app/services/bill-runs/two-part-tariff/allocate-returns-to-charge-element.service.js
+++ b/app/services/bill-runs/two-part-tariff/allocate-returns-to-charge-element.service.js
@@ -36,17 +36,18 @@ function _allocateReturns (chargeElement, matchedReturn, chargePeriod, chargeRef
   matchedLines.forEach((matchedLine) => {
     const chargeElementRemainingAllocation = chargeElement.authorisedAnnualQuantity - chargeElement.allocatedQuantity
     if (chargeElementRemainingAllocation > 0) {
-      // We default how much to allocate to what is unallocated on the line i.e. remaining >= line.unallocated
-      let qtyToAllocate = matchedLine.unallocated
+      let qtyToAllocate
 
-      // If what remains is actually less than the line we instead set qtyToAllocate to what remains. We check this
-      // on both the chargeReference and the element
+      // If what remains to allocate on the charge reference/element is actually less than the `matchedLine.unallocated`
+      // we set `qtyToAllocate` to what remains. Else the `qtyToAllocate` is equal to the `matchedLine.unallocated`.
       const chargeReferenceRemainingAllocation = chargeReference.volume - chargeReference.allocatedQuantity
 
-      if (qtyToAllocate > chargeReferenceRemainingAllocation) {
+      if (matchedLine.unallocated > chargeReferenceRemainingAllocation) {
         qtyToAllocate = chargeReferenceRemainingAllocation
-      } else if (chargeElementRemainingAllocation < matchedLine.unallocated) {
+      } else if (matchedLine.unallocated > chargeElementRemainingAllocation) {
         qtyToAllocate = chargeElementRemainingAllocation
+      } else {
+        qtyToAllocate = matchedLine.unallocated
       }
 
       // We do this check to prevent overwriting the value with false once it's been set to true as it only requires

--- a/app/services/bill-runs/two-part-tariff/allocate-returns-to-charge-element.service.js
+++ b/app/services/bill-runs/two-part-tariff/allocate-returns-to-charge-element.service.js
@@ -97,6 +97,21 @@ function _chargeDatesOverlap (matchedLine, chargePeriod) {
   return (lineStartDate < chargePeriodStartDate && lineEndDate > chargePeriodStartDate)
 }
 
+function _fullyAllocated (chargeElement, chargeReference) {
+  // We can only allocate up to the authorised volume on the charge reference, even if there is charge elements
+  // unallocated and returns to be allocated
+  if (chargeReference.allocatedQuantity >= chargeReference.volume) {
+    return true
+  }
+
+  // Finally, we can only allocate to the charge element if there is unallocated volume left!
+  if (chargeElement.allocatedQuantity >= chargeElement.authorisedAnnualQuantity) {
+    return true
+  }
+
+  return false
+}
+
 function _matchLines (chargeElement, returnSubmissionLines) {
   return returnSubmissionLines.filter((returnSubmissionLine) => {
     if (returnSubmissionLine.unallocated === 0) {
@@ -115,14 +130,8 @@ function _processCompletedReturns (chargeElement, matchingReturns, chargePeriod,
       return
     }
 
-    // We can only allocate up to the authorised volume on the charge reference, even if there is charge elements
-    // unallocated and returns to be allocated
-    if (chargeReference.allocatedQuantity >= chargeReference.volume) {
-      return
-    }
-
-    // Finally, we can only allocate to the charge element if there is unallocated volume left!
-    if (chargeElement.allocatedQuantity >= chargeElement.authorisedAnnualQuantity) {
+    // If the element/reference is fully allocated there is no further processing to do for the return
+    if (_fullyAllocated(chargeElement, chargeReference)) {
       return
     }
 
@@ -141,14 +150,8 @@ function _processDueReturns (chargeElement, matchingReturns, chargeReference) {
       return
     }
 
-    // We can only allocate up to the authorised volume on the charge reference, even if there is charge elements
-    // unallocated and returns to be allocated
-    if (chargeReference.allocatedQuantity >= chargeReference.volume) {
-      return
-    }
-
-    // Finally, we can only allocate to the charge element if there is unallocated volume left!
-    if (chargeElement.allocatedQuantity >= chargeElement.authorisedAnnualQuantity) {
+    // If the element/reference is fully allocated there is no further processing to do for the return
+    if (_fullyAllocated(chargeElement, chargeReference)) {
       return
     }
 

--- a/app/services/bill-runs/two-part-tariff/allocate-returns-to-charge-element.service.js
+++ b/app/services/bill-runs/two-part-tariff/allocate-returns-to-charge-element.service.js
@@ -34,8 +34,8 @@ function go (chargeElement, matchingReturns, chargePeriod, chargeReference) {
 
 function _allocateReturns (chargeElement, matchedReturn, chargePeriod, chargeReference, i, matchedLines) {
   matchedLines.forEach((matchedLine) => {
-    const remainingAllocation = chargeElement.authorisedAnnualQuantity - chargeElement.allocatedQuantity
-    if (remainingAllocation > 0) {
+    const chargeElementRemainingAllocation = chargeElement.authorisedAnnualQuantity - chargeElement.allocatedQuantity
+    if (chargeElementRemainingAllocation > 0) {
       // We default how much to allocate to what is unallocated on the line i.e. remaining >= line.unallocated
       let qtyToAllocate = matchedLine.unallocated
 
@@ -45,8 +45,8 @@ function _allocateReturns (chargeElement, matchedReturn, chargePeriod, chargeRef
 
       if (qtyToAllocate > chargeReferenceRemainingAllocation) {
         qtyToAllocate = chargeReferenceRemainingAllocation
-      } else if (remainingAllocation < matchedLine.unallocated) {
-        qtyToAllocate = remainingAllocation
+      } else if (chargeElementRemainingAllocation < matchedLine.unallocated) {
+        qtyToAllocate = chargeElementRemainingAllocation
       }
 
       // We do this check to prevent overwriting the value with false once it's been set to true as it only requires

--- a/app/services/bill-runs/two-part-tariff/allocate-returns-to-charge-element.service.js
+++ b/app/services/bill-runs/two-part-tariff/allocate-returns-to-charge-element.service.js
@@ -10,7 +10,7 @@ const { periodsOverlap } = require('../../../lib/general.lib.js')
 /**
  * For a chargeElement with matching returns any abstracted volume recorded on the return log will be allocated to the
  * charge element up to a maximum of the charge elements authorised volume, or the remaining authorised volume on the
- * charge reference, whichever is lower. If any "due" returns are are matched to a charge element, that element will
+ * charge reference, whichever is lower. If any "due" returns are matched to a charge element, that element will
  * have it's allocated volume increased to the authorised annual quantity or the references authorised annual quantity,
  * whichever is lower.
  *

--- a/app/services/bill-runs/two-part-tariff/determine-bill-run-issues.service.js
+++ b/app/services/bill-runs/two-part-tariff/determine-bill-run-issues.service.js
@@ -122,7 +122,7 @@ function _notProcessed (issues, licenceReviewResults) {
 
 function _noReturnsReceived (issues, licenceReviewResults) {
   const noReturnsReceived = licenceReviewResults.some((licenceReviewResult) => {
-    return licenceReviewResult.reviewReturnResults?.status === 'due' || licenceReviewResult.reviewReturnResults?.status === 'overdue'
+    return licenceReviewResult.reviewReturnResults?.status === 'due'
   })
 
   if (noReturnsReceived) {

--- a/test/services/bill-runs/two-part-tariff/allocate-returns-to-charge-element.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/allocate-returns-to-charge-element.service.test.js
@@ -325,6 +325,38 @@ describe('Allocate Returns to Charge Element Service', () => {
             expect(matchingReturns[0].allocatedQuantity).to.equal(22)
           })
         })
+
+        describe('and reference/element has been fully allocated from another return', () => {
+          beforeEach(() => {
+            testData.chargeReference.allocatedQuantity = 32
+            testData.chargeElement.allocatedQuantity = 32
+          })
+
+          it('the fully allocated amount of 32 to the charge reference is unaltered by the due return', () => {
+            const { chargeElement, chargeReference, matchingReturns } = testData
+
+            AllocateReturnsToChargeElementService.go(chargeElement, matchingReturns, chargePeriod, chargeReference)
+
+            expect(chargeReference.allocatedQuantity).to.equal(32)
+          })
+
+          it('the fully allocated amount of 32 to the charge element is unaltered by the due return', () => {
+            const { chargeElement, chargeReference, matchingReturns } = testData
+
+            AllocateReturnsToChargeElementService.go(chargeElement, matchingReturns, chargePeriod, chargeReference)
+
+            expect(chargeElement.allocatedQuantity).to.equal(32)
+            expect(chargeElement.returnLogs[0].allocatedQuantity).to.equal(0)
+          })
+
+          it('allocates 0 from the return log', () => {
+            const { chargeElement, chargeReference, matchingReturns } = testData
+
+            AllocateReturnsToChargeElementService.go(chargeElement, matchingReturns, chargePeriod, chargeReference)
+
+            expect(matchingReturns[0].allocatedQuantity).to.equal(0)
+          })
+        })
       })
 
       describe('with a charge reference authorised up to 32, element authorised to 10, matched to a due return', () => {

--- a/test/services/bill-runs/two-part-tariff/allocate-returns-to-charge-element.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/allocate-returns-to-charge-element.service.test.js
@@ -19,251 +19,384 @@ describe('Allocate Returns to Charge Element Service', () => {
 
     let testData
 
-    describe('with a charge reference/element authorised upto 32, matched to a return with a quantity of 32', () => {
+    describe('and the return status is completed', () => {
       beforeEach(() => {
         testData = _generateTestData()
       })
 
-      it('correctly allocates 32 to the charge reference', () => {
-        const { chargeElement, chargeReference, matchingReturns } = testData
+      describe('with a charge reference/element authorised up to 32, matched to a return with a quantity of 32', () => {
+        it('allocates 32 to the charge reference', () => {
+          const { chargeElement, chargeReference, matchingReturns } = testData
 
-        AllocateReturnsToChargeElementService.go(chargeElement, matchingReturns, chargePeriod, chargeReference)
+          AllocateReturnsToChargeElementService.go(chargeElement, matchingReturns, chargePeriod, chargeReference)
 
-        expect(chargeReference.allocatedQuantity).to.equal(32)
+          expect(chargeReference.allocatedQuantity).to.equal(32)
+        })
+
+        it('allocates 32 to the charge element and adds chargeDatesOverlap property as `false`', () => {
+          const { chargeElement, chargeReference, matchingReturns } = testData
+
+          AllocateReturnsToChargeElementService.go(chargeElement, matchingReturns, chargePeriod, chargeReference)
+
+          expect(chargeElement.allocatedQuantity).to.equal(32)
+          expect(chargeElement.returnLogs[0].allocatedQuantity).to.equal(32)
+          expect(chargeElement.chargeDatesOverlap).to.be.false()
+        })
+
+        it('allocates all 32 from the return log', () => {
+          const { chargeElement, chargeReference, matchingReturns } = testData
+
+          AllocateReturnsToChargeElementService.go(chargeElement, matchingReturns, chargePeriod, chargeReference)
+
+          expect(matchingReturns[0].allocatedQuantity).to.equal(32)
+          expect(matchingReturns[0].returnSubmissions[0].returnSubmissionLines[0].unallocated).to.equal(0)
+          expect(matchingReturns[0].returnSubmissions[0].returnSubmissionLines[1].unallocated).to.equal(0)
+          expect(matchingReturns[0].returnSubmissions[0].returnSubmissionLines[2].unallocated).to.equal(0)
+          expect(matchingReturns[0].returnSubmissions[0].returnSubmissionLines[3].unallocated).to.equal(0)
+          expect(matchingReturns[0].returnSubmissions[0].returnSubmissionLines[4].unallocated).to.equal(0)
+          expect(matchingReturns[0].returnSubmissions[0].returnSubmissionLines[5].unallocated).to.equal(0)
+          expect(matchingReturns[0].returnSubmissions[0].returnSubmissionLines[6].unallocated).to.equal(0)
+          expect(matchingReturns[0].returnSubmissions[0].returnSubmissionLines[7].unallocated).to.equal(0)
+        })
       })
 
-      it('correctly allocates 32 to the charge element and adds chargeDatesOverlap property as `false`', () => {
-        const { chargeElement, chargeReference, matchingReturns } = testData
+      describe('with a charge reference authorised up to 10, matched to a return with a quantity of 32', () => {
+        beforeEach(() => {
+          testData = _generateTestData()
+          testData.chargeReference.volume = 10
+        })
 
-        AllocateReturnsToChargeElementService.go(chargeElement, matchingReturns, chargePeriod, chargeReference)
+        it('allocates 10 to the charge reference', () => {
+          const { chargeElement, chargeReference, matchingReturns } = testData
 
-        expect(chargeElement.allocatedQuantity).to.equal(32)
-        expect(chargeElement.returnLogs[0].allocatedQuantity).to.equal(32)
-        expect(chargeElement.chargeDatesOverlap).to.be.false()
+          AllocateReturnsToChargeElementService.go(chargeElement, matchingReturns, chargePeriod, chargeReference)
+
+          expect(chargeReference.volume).to.equal(10)
+          expect(chargeReference.allocatedQuantity).to.equal(10)
+        })
+
+        it('allocates 10 to the charge element', () => {
+          const { chargeElement, chargeReference, matchingReturns } = testData
+
+          AllocateReturnsToChargeElementService.go(chargeElement, matchingReturns, chargePeriod, chargeReference)
+
+          expect(chargeElement.authorisedAnnualQuantity).to.equal(32)
+          expect(chargeElement.allocatedQuantity).to.equal(10)
+          expect(chargeElement.returnLogs[0].allocatedQuantity).to.equal(10)
+        })
+
+        it('allocates 10 from the return log', () => {
+          const { chargeElement, chargeReference, matchingReturns } = testData
+
+          AllocateReturnsToChargeElementService.go(chargeElement, matchingReturns, chargePeriod, chargeReference)
+
+          expect(matchingReturns[0].allocatedQuantity).to.equal(10)
+          expect(matchingReturns[0].returnSubmissions[0].returnSubmissionLines[0].unallocated).to.equal(0)
+          expect(matchingReturns[0].returnSubmissions[0].returnSubmissionLines[1].unallocated).to.equal(0)
+          expect(matchingReturns[0].returnSubmissions[0].returnSubmissionLines[2].unallocated).to.equal(2)
+          expect(matchingReturns[0].returnSubmissions[0].returnSubmissionLines[3].unallocated).to.equal(4)
+          expect(matchingReturns[0].returnSubmissions[0].returnSubmissionLines[4].unallocated).to.equal(4)
+          expect(matchingReturns[0].returnSubmissions[0].returnSubmissionLines[5].unallocated).to.equal(4)
+          expect(matchingReturns[0].returnSubmissions[0].returnSubmissionLines[6].unallocated).to.equal(4)
+          expect(matchingReturns[0].returnSubmissions[0].returnSubmissionLines[7].unallocated).to.equal(4)
+        })
       })
 
-      it('correctly allocates all 32 from the return log', () => {
-        const { chargeElement, chargeReference, matchingReturns } = testData
+      describe('with a charge element authorised up to 10, matched to a return with a quantity of 32', () => {
+        beforeEach(() => {
+          testData = _generateTestData()
+          testData.chargeElement.authorisedAnnualQuantity = 10
+        })
 
-        AllocateReturnsToChargeElementService.go(chargeElement, matchingReturns, chargePeriod, chargeReference)
+        it('allocates 10 to the charge reference', () => {
+          const { chargeElement, chargeReference, matchingReturns } = testData
 
-        expect(matchingReturns[0].allocatedQuantity).to.equal(32)
-        expect(matchingReturns[0].returnSubmissions[0].returnSubmissionLines[0].unallocated).to.equal(0)
-        expect(matchingReturns[0].returnSubmissions[0].returnSubmissionLines[1].unallocated).to.equal(0)
-        expect(matchingReturns[0].returnSubmissions[0].returnSubmissionLines[2].unallocated).to.equal(0)
-        expect(matchingReturns[0].returnSubmissions[0].returnSubmissionLines[3].unallocated).to.equal(0)
-        expect(matchingReturns[0].returnSubmissions[0].returnSubmissionLines[4].unallocated).to.equal(0)
-        expect(matchingReturns[0].returnSubmissions[0].returnSubmissionLines[5].unallocated).to.equal(0)
-        expect(matchingReturns[0].returnSubmissions[0].returnSubmissionLines[6].unallocated).to.equal(0)
-        expect(matchingReturns[0].returnSubmissions[0].returnSubmissionLines[7].unallocated).to.equal(0)
+          AllocateReturnsToChargeElementService.go(chargeElement, matchingReturns, chargePeriod, chargeReference)
+
+          expect(chargeReference.volume).to.equal(32)
+          expect(chargeReference.allocatedQuantity).to.equal(10)
+        })
+
+        it('allocates 10 to the charge element', () => {
+          const { chargeElement, chargeReference, matchingReturns } = testData
+
+          AllocateReturnsToChargeElementService.go(chargeElement, matchingReturns, chargePeriod, chargeReference)
+
+          expect(chargeElement.authorisedAnnualQuantity).to.equal(10)
+          expect(chargeElement.allocatedQuantity).to.equal(10)
+          expect(chargeElement.returnLogs[0].allocatedQuantity).to.equal(10)
+        })
+
+        it('allocates 10 from the return log', () => {
+          const { chargeElement, chargeReference, matchingReturns } = testData
+
+          AllocateReturnsToChargeElementService.go(chargeElement, matchingReturns, chargePeriod, chargeReference)
+
+          expect(matchingReturns[0].allocatedQuantity).to.equal(10)
+          expect(matchingReturns[0].returnSubmissions[0].returnSubmissionLines[0].unallocated).to.equal(0)
+          expect(matchingReturns[0].returnSubmissions[0].returnSubmissionLines[1].unallocated).to.equal(0)
+          expect(matchingReturns[0].returnSubmissions[0].returnSubmissionLines[2].unallocated).to.equal(2)
+          expect(matchingReturns[0].returnSubmissions[0].returnSubmissionLines[3].unallocated).to.equal(4)
+          expect(matchingReturns[0].returnSubmissions[0].returnSubmissionLines[4].unallocated).to.equal(4)
+          expect(matchingReturns[0].returnSubmissions[0].returnSubmissionLines[5].unallocated).to.equal(4)
+          expect(matchingReturns[0].returnSubmissions[0].returnSubmissionLines[6].unallocated).to.equal(4)
+          expect(matchingReturns[0].returnSubmissions[0].returnSubmissionLines[7].unallocated).to.equal(4)
+        })
+      })
+
+      describe('with a `returnSubmissionLine` outside of the `chargePeriod`', () => {
+        beforeEach(() => {
+          testData = _generateTestData()
+          testData.matchingReturns[0].returnSubmissions[0].returnSubmissionLines[0].startDate = new Date('2022-03-01')
+          testData.matchingReturns[0].returnSubmissions[0].returnSubmissionLines[0].endDate = new Date('2022-03-30')
+        })
+
+        it('allocates 28 to the charge reference', () => {
+          const { chargeElement, chargeReference, matchingReturns } = testData
+
+          AllocateReturnsToChargeElementService.go(chargeElement, matchingReturns, chargePeriod, chargeReference)
+
+          expect(chargeReference.allocatedQuantity).to.equal(28)
+        })
+
+        it('allocates 28 to the charge element', () => {
+          const { chargeElement, chargeReference, matchingReturns } = testData
+
+          AllocateReturnsToChargeElementService.go(chargeElement, matchingReturns, chargePeriod, chargeReference)
+
+          expect(chargeElement.allocatedQuantity).to.equal(28)
+          expect(chargeElement.returnLogs[0].allocatedQuantity).to.equal(28)
+        })
+
+        it('does not include the line outside of the charge period and allocates 28 from the return log', () => {
+          const { chargeElement, chargeReference, matchingReturns } = testData
+
+          AllocateReturnsToChargeElementService.go(chargeElement, matchingReturns, chargePeriod, chargeReference)
+
+          expect(matchingReturns[0].allocatedQuantity).to.equal(28)
+          expect(matchingReturns[0].returnSubmissions[0].returnSubmissionLines[0].unallocated).to.equal(4)
+          expect(matchingReturns[0].returnSubmissions[0].returnSubmissionLines[1].unallocated).to.equal(0)
+          expect(matchingReturns[0].returnSubmissions[0].returnSubmissionLines[2].unallocated).to.equal(0)
+          expect(matchingReturns[0].returnSubmissions[0].returnSubmissionLines[3].unallocated).to.equal(0)
+          expect(matchingReturns[0].returnSubmissions[0].returnSubmissionLines[4].unallocated).to.equal(0)
+          expect(matchingReturns[0].returnSubmissions[0].returnSubmissionLines[5].unallocated).to.equal(0)
+          expect(matchingReturns[0].returnSubmissions[0].returnSubmissionLines[6].unallocated).to.equal(0)
+          expect(matchingReturns[0].returnSubmissions[0].returnSubmissionLines[7].unallocated).to.equal(0)
+        })
+      })
+
+      describe('with a `returnSubmissionLine` with a `startDate` outside the charge period but endDate within', () => {
+        beforeEach(() => {
+          testData = _generateTestData()
+          testData.matchingReturns[0].returnSubmissions[0].returnSubmissionLines[0].startDate = new Date('2022-03-01')
+          testData.matchingReturns[0].returnSubmissions[0].returnSubmissionLines[0].endDate = new Date('2022-04-30')
+        })
+
+        it('allocates 32 to the charge element and sets `chargeDatesOverlap` to true', () => {
+          const { chargeElement, chargeReference, matchingReturns } = testData
+
+          AllocateReturnsToChargeElementService.go(chargeElement, matchingReturns, chargePeriod, chargeReference)
+
+          expect(chargeElement.allocatedQuantity).to.equal(32)
+          expect(chargeElement.returnLogs[0].allocatedQuantity).to.equal(32)
+          expect(chargeElement.chargeDatesOverlap).to.be.true()
+        })
+      })
+
+      describe('with a `returnSubmissionLine` with a `endDate` outside the charge period but startDate within', () => {
+        beforeEach(() => {
+          testData = _generateTestData()
+          testData.matchingReturns[0].returnSubmissions[0].returnSubmissionLines[7].startDate = new Date('2023-03-01')
+          testData.matchingReturns[0].returnSubmissions[0].returnSubmissionLines[7].endDate = new Date('2023-04-31')
+        })
+
+        it('allocates 32 to the charge element and sets `chargeDatesOverlap` to true', () => {
+          const { chargeElement, chargeReference, matchingReturns } = testData
+
+          AllocateReturnsToChargeElementService.go(chargeElement, matchingReturns, chargePeriod, chargeReference)
+
+          expect(chargeElement.allocatedQuantity).to.equal(32)
+          expect(chargeElement.returnLogs[0].allocatedQuantity).to.equal(32)
+          expect(chargeElement.chargeDatesOverlap).to.be.true()
+        })
+      })
+
+      describe('with a return that has issues', () => {
+        beforeEach(() => {
+          testData = _generateTestData()
+          testData.matchingReturns[0].issues = true
+        })
+
+        it('does not allocate anything from the return log', () => {
+          const { chargeElement, chargeReference, matchingReturns } = testData
+
+          AllocateReturnsToChargeElementService.go(chargeElement, matchingReturns, chargePeriod, chargeReference)
+
+          expect(chargeReference.allocatedQuantity).to.equal(0)
+
+          expect(chargeElement.allocatedQuantity).to.equal(0)
+          expect(chargeElement.returnLogs[0].allocatedQuantity).to.equal(0)
+
+          expect(matchingReturns[0].allocatedQuantity).to.equal(0)
+          expect(matchingReturns[0].returnSubmissions[0].returnSubmissionLines[0].unallocated).to.equal(4)
+        })
+      })
+
+      describe('with a nil return that has no `returnSubmissionLines`', () => {
+        beforeEach(() => {
+          testData = _generateTestData()
+          testData.matchingReturns[0].returnSubmissions[0].returnSubmissionLines = []
+        })
+
+        it('does not allocate anything from the return log', () => {
+          const { chargeElement, chargeReference, matchingReturns } = testData
+
+          AllocateReturnsToChargeElementService.go(chargeElement, matchingReturns, chargePeriod, chargeReference)
+
+          expect(chargeReference.allocatedQuantity).to.equal(0)
+
+          expect(chargeElement.allocatedQuantity).to.equal(0)
+          expect(chargeElement.returnLogs[0].allocatedQuantity).to.equal(0)
+
+          expect(matchingReturns[0].allocatedQuantity).to.equal(0)
+        })
       })
     })
 
-    describe('with a charge reference authorised upto 10, matched to a return with a quantity of 32', () => {
+    describe('and the return status is due', () => {
       beforeEach(() => {
-        testData = _generateTestData()
-        testData.chargeReference.volume = 10
+        testData = _generateTestData('due')
       })
 
-      it('correctly allocates 10 to the charge reference', () => {
-        const { chargeElement, chargeReference, matchingReturns } = testData
+      describe('with a charge reference/element authorised up to 32, matched to a due return', () => {
+        it('fully allocates up to authorised amount of 32 to the charge reference', () => {
+          const { chargeElement, chargeReference, matchingReturns } = testData
 
-        AllocateReturnsToChargeElementService.go(chargeElement, matchingReturns, chargePeriod, chargeReference)
+          AllocateReturnsToChargeElementService.go(chargeElement, matchingReturns, chargePeriod, chargeReference)
 
-        expect(chargeReference.volume).to.equal(10)
-        expect(chargeReference.allocatedQuantity).to.equal(10)
+          expect(chargeReference.allocatedQuantity).to.equal(32)
+        })
+
+        it('fully allocates up to authorised amount of 32 to the charge element', () => {
+          const { chargeElement, chargeReference, matchingReturns } = testData
+
+          AllocateReturnsToChargeElementService.go(chargeElement, matchingReturns, chargePeriod, chargeReference)
+
+          expect(chargeElement.allocatedQuantity).to.equal(32)
+          expect(chargeElement.returnLogs[0].allocatedQuantity).to.equal(32)
+        })
+
+        it('allocates 32 from the return log', () => {
+          const { chargeElement, chargeReference, matchingReturns } = testData
+
+          AllocateReturnsToChargeElementService.go(chargeElement, matchingReturns, chargePeriod, chargeReference)
+
+          expect(matchingReturns[0].allocatedQuantity).to.equal(32)
+        })
+
+        describe('and 10 has already been allocated to the reference/element from another return', () => {
+          beforeEach(() => {
+            testData.chargeReference.allocatedQuantity = 10
+            testData.chargeElement.allocatedQuantity = 10
+          })
+
+          it('fully allocates up to authorised amount of 32 to the charge reference', () => {
+            const { chargeElement, chargeReference, matchingReturns } = testData
+
+            AllocateReturnsToChargeElementService.go(chargeElement, matchingReturns, chargePeriod, chargeReference)
+
+            expect(chargeReference.allocatedQuantity).to.equal(32)
+          })
+
+          it('fully allocates up to authorised amount of 32 to the charge element', () => {
+            const { chargeElement, chargeReference, matchingReturns } = testData
+
+            AllocateReturnsToChargeElementService.go(chargeElement, matchingReturns, chargePeriod, chargeReference)
+
+            expect(chargeElement.allocatedQuantity).to.equal(32)
+            expect(chargeElement.returnLogs[0].allocatedQuantity).to.equal(22)
+          })
+
+          it('allocates 22 from the return log', () => {
+            const { chargeElement, chargeReference, matchingReturns } = testData
+
+            AllocateReturnsToChargeElementService.go(chargeElement, matchingReturns, chargePeriod, chargeReference)
+
+            expect(matchingReturns[0].allocatedQuantity).to.equal(22)
+          })
+        })
       })
 
-      it('correctly allocates 10 to the charge element', () => {
-        const { chargeElement, chargeReference, matchingReturns } = testData
+      describe('with a charge reference authorised up to 32, element authorised to 10, matched to a due return', () => {
+        beforeEach(() => {
+          testData.chargeElement.authorisedAnnualQuantity = 10
+        })
 
-        AllocateReturnsToChargeElementService.go(chargeElement, matchingReturns, chargePeriod, chargeReference)
+        it('allocates the charge elements authorised amount of 10 to the charge reference', () => {
+          const { chargeElement, chargeReference, matchingReturns } = testData
 
-        expect(chargeElement.authorisedAnnualQuantity).to.equal(32)
-        expect(chargeElement.allocatedQuantity).to.equal(10)
-        expect(chargeElement.returnLogs[0].allocatedQuantity).to.equal(10)
+          AllocateReturnsToChargeElementService.go(chargeElement, matchingReturns, chargePeriod, chargeReference)
+
+          expect(chargeReference.volume).to.equal(32)
+          expect(chargeReference.allocatedQuantity).to.equal(10)
+        })
+
+        it('fully allocates up to authorised amount of 10 to the charge element', () => {
+          const { chargeElement, chargeReference, matchingReturns } = testData
+
+          AllocateReturnsToChargeElementService.go(chargeElement, matchingReturns, chargePeriod, chargeReference)
+
+          expect(chargeElement.authorisedAnnualQuantity).to.equal(10)
+          expect(chargeElement.allocatedQuantity).to.equal(10)
+          expect(chargeElement.returnLogs[0].allocatedQuantity).to.equal(10)
+        })
+
+        it('allocates 10 from the return log', () => {
+          const { chargeElement, chargeReference, matchingReturns } = testData
+
+          AllocateReturnsToChargeElementService.go(chargeElement, matchingReturns, chargePeriod, chargeReference)
+
+          expect(matchingReturns[0].allocatedQuantity).to.equal(10)
+        })
       })
 
-      it('correctly allocates 10 from the return log', () => {
-        const { chargeElement, chargeReference, matchingReturns } = testData
+      describe('with a charge reference authorised up to 10, element authorised to 32, matched to a due return', () => {
+        beforeEach(() => {
+          testData.chargeReference.volume = 10
+        })
 
-        AllocateReturnsToChargeElementService.go(chargeElement, matchingReturns, chargePeriod, chargeReference)
+        it('fully allocates up to authorised amount of 10 to the charge reference', () => {
+          const { chargeElement, chargeReference, matchingReturns } = testData
 
-        expect(matchingReturns[0].allocatedQuantity).to.equal(10)
-        expect(matchingReturns[0].returnSubmissions[0].returnSubmissionLines[0].unallocated).to.equal(0)
-        expect(matchingReturns[0].returnSubmissions[0].returnSubmissionLines[1].unallocated).to.equal(0)
-        expect(matchingReturns[0].returnSubmissions[0].returnSubmissionLines[2].unallocated).to.equal(2)
-        expect(matchingReturns[0].returnSubmissions[0].returnSubmissionLines[3].unallocated).to.equal(4)
-        expect(matchingReturns[0].returnSubmissions[0].returnSubmissionLines[4].unallocated).to.equal(4)
-        expect(matchingReturns[0].returnSubmissions[0].returnSubmissionLines[5].unallocated).to.equal(4)
-        expect(matchingReturns[0].returnSubmissions[0].returnSubmissionLines[6].unallocated).to.equal(4)
-        expect(matchingReturns[0].returnSubmissions[0].returnSubmissionLines[7].unallocated).to.equal(4)
-      })
-    })
+          AllocateReturnsToChargeElementService.go(chargeElement, matchingReturns, chargePeriod, chargeReference)
 
-    describe('with a charge element authorised upto 10, matched to a return with a quantity of 32', () => {
-      beforeEach(() => {
-        testData = _generateTestData()
-        testData.chargeElement.authorisedAnnualQuantity = 10
-      })
+          expect(chargeReference.volume).to.equal(10)
+          expect(chargeReference.allocatedQuantity).to.equal(10)
+        })
 
-      it('correctly allocates 10 to the charge reference', () => {
-        const { chargeElement, chargeReference, matchingReturns } = testData
+        it('allocates the charge references authorised amount of 10 to the charge element', () => {
+          const { chargeElement, chargeReference, matchingReturns } = testData
 
-        AllocateReturnsToChargeElementService.go(chargeElement, matchingReturns, chargePeriod, chargeReference)
+          AllocateReturnsToChargeElementService.go(chargeElement, matchingReturns, chargePeriod, chargeReference)
 
-        expect(chargeReference.volume).to.equal(32)
-        expect(chargeReference.allocatedQuantity).to.equal(10)
-      })
+          expect(chargeElement.authorisedAnnualQuantity).to.equal(32)
+          expect(chargeElement.allocatedQuantity).to.equal(10)
+          expect(chargeElement.returnLogs[0].allocatedQuantity).to.equal(10)
+        })
 
-      it('correctly allocates 10 to the charge element', () => {
-        const { chargeElement, chargeReference, matchingReturns } = testData
+        it('allocates 10 from the return log', () => {
+          const { chargeElement, chargeReference, matchingReturns } = testData
 
-        AllocateReturnsToChargeElementService.go(chargeElement, matchingReturns, chargePeriod, chargeReference)
+          AllocateReturnsToChargeElementService.go(chargeElement, matchingReturns, chargePeriod, chargeReference)
 
-        expect(chargeElement.authorisedAnnualQuantity).to.equal(10)
-        expect(chargeElement.allocatedQuantity).to.equal(10)
-        expect(chargeElement.returnLogs[0].allocatedQuantity).to.equal(10)
-      })
-
-      it('correctly allocates 10 from the return log', () => {
-        const { chargeElement, chargeReference, matchingReturns } = testData
-
-        AllocateReturnsToChargeElementService.go(chargeElement, matchingReturns, chargePeriod, chargeReference)
-
-        expect(matchingReturns[0].allocatedQuantity).to.equal(10)
-        expect(matchingReturns[0].returnSubmissions[0].returnSubmissionLines[0].unallocated).to.equal(0)
-        expect(matchingReturns[0].returnSubmissions[0].returnSubmissionLines[1].unallocated).to.equal(0)
-        expect(matchingReturns[0].returnSubmissions[0].returnSubmissionLines[2].unallocated).to.equal(2)
-        expect(matchingReturns[0].returnSubmissions[0].returnSubmissionLines[3].unallocated).to.equal(4)
-        expect(matchingReturns[0].returnSubmissions[0].returnSubmissionLines[4].unallocated).to.equal(4)
-        expect(matchingReturns[0].returnSubmissions[0].returnSubmissionLines[5].unallocated).to.equal(4)
-        expect(matchingReturns[0].returnSubmissions[0].returnSubmissionLines[6].unallocated).to.equal(4)
-        expect(matchingReturns[0].returnSubmissions[0].returnSubmissionLines[7].unallocated).to.equal(4)
-      })
-    })
-
-    describe('with a `returnSubmissionLine` outside of the `chargePeriod`', () => {
-      beforeEach(() => {
-        testData = _generateTestData()
-        testData.matchingReturns[0].returnSubmissions[0].returnSubmissionLines[0].startDate = new Date('2022-03-01')
-        testData.matchingReturns[0].returnSubmissions[0].returnSubmissionLines[0].endDate = new Date('2022-03-30')
-      })
-
-      it('correctly allocates 28 to the charge reference', () => {
-        const { chargeElement, chargeReference, matchingReturns } = testData
-
-        AllocateReturnsToChargeElementService.go(chargeElement, matchingReturns, chargePeriod, chargeReference)
-
-        expect(chargeReference.allocatedQuantity).to.equal(28)
-      })
-
-      it('correctly allocates 28 to the charge element', () => {
-        const { chargeElement, chargeReference, matchingReturns } = testData
-
-        AllocateReturnsToChargeElementService.go(chargeElement, matchingReturns, chargePeriod, chargeReference)
-
-        expect(chargeElement.allocatedQuantity).to.equal(28)
-        expect(chargeElement.returnLogs[0].allocatedQuantity).to.equal(28)
-      })
-
-      it('does not include the line outside of the charge period and allocates 28 from the return log', () => {
-        const { chargeElement, chargeReference, matchingReturns } = testData
-
-        AllocateReturnsToChargeElementService.go(chargeElement, matchingReturns, chargePeriod, chargeReference)
-
-        expect(matchingReturns[0].allocatedQuantity).to.equal(28)
-        expect(matchingReturns[0].returnSubmissions[0].returnSubmissionLines[0].unallocated).to.equal(4)
-        expect(matchingReturns[0].returnSubmissions[0].returnSubmissionLines[1].unallocated).to.equal(0)
-        expect(matchingReturns[0].returnSubmissions[0].returnSubmissionLines[2].unallocated).to.equal(0)
-        expect(matchingReturns[0].returnSubmissions[0].returnSubmissionLines[3].unallocated).to.equal(0)
-        expect(matchingReturns[0].returnSubmissions[0].returnSubmissionLines[4].unallocated).to.equal(0)
-        expect(matchingReturns[0].returnSubmissions[0].returnSubmissionLines[5].unallocated).to.equal(0)
-        expect(matchingReturns[0].returnSubmissions[0].returnSubmissionLines[6].unallocated).to.equal(0)
-        expect(matchingReturns[0].returnSubmissions[0].returnSubmissionLines[7].unallocated).to.equal(0)
-      })
-    })
-
-    describe('with a `returnSubmissionLine` with a `startDate` outside the charge period but endDate within', () => {
-      beforeEach(() => {
-        testData = _generateTestData()
-        testData.matchingReturns[0].returnSubmissions[0].returnSubmissionLines[0].startDate = new Date('2022-03-01')
-        testData.matchingReturns[0].returnSubmissions[0].returnSubmissionLines[0].endDate = new Date('2022-04-30')
-      })
-
-      it('correctly allocates 32 to the charge element and sets `chargeDatesOverlap` to true', () => {
-        const { chargeElement, chargeReference, matchingReturns } = testData
-
-        AllocateReturnsToChargeElementService.go(chargeElement, matchingReturns, chargePeriod, chargeReference)
-
-        expect(chargeElement.allocatedQuantity).to.equal(32)
-        expect(chargeElement.returnLogs[0].allocatedQuantity).to.equal(32)
-        expect(chargeElement.chargeDatesOverlap).to.be.true()
-      })
-    })
-
-    describe('with a `returnSubmissionLine` with a `endDate` outside the charge period but startDate within', () => {
-      beforeEach(() => {
-        testData = _generateTestData()
-        testData.matchingReturns[0].returnSubmissions[0].returnSubmissionLines[7].startDate = new Date('2023-03-01')
-        testData.matchingReturns[0].returnSubmissions[0].returnSubmissionLines[7].endDate = new Date('2023-04-31')
-      })
-
-      it('correctly allocates 32 to the charge element and sets `chargeDatesOverlap` to true', () => {
-        const { chargeElement, chargeReference, matchingReturns } = testData
-
-        AllocateReturnsToChargeElementService.go(chargeElement, matchingReturns, chargePeriod, chargeReference)
-
-        expect(chargeElement.allocatedQuantity).to.equal(32)
-        expect(chargeElement.returnLogs[0].allocatedQuantity).to.equal(32)
-        expect(chargeElement.chargeDatesOverlap).to.be.true()
-      })
-    })
-
-    describe('with a return that has issues', () => {
-      beforeEach(() => {
-        testData = _generateTestData()
-        testData.matchingReturns[0].issues = true
-      })
-
-      it('does not allocate anything from the return log', () => {
-        const { chargeElement, chargeReference, matchingReturns } = testData
-
-        AllocateReturnsToChargeElementService.go(chargeElement, matchingReturns, chargePeriod, chargeReference)
-
-        expect(chargeReference.allocatedQuantity).to.equal(0)
-
-        expect(chargeElement.allocatedQuantity).to.equal(0)
-        expect(chargeElement.returnLogs[0].allocatedQuantity).to.equal(0)
-
-        expect(matchingReturns[0].allocatedQuantity).to.equal(0)
-        expect(matchingReturns[0].returnSubmissions[0].returnSubmissionLines[0].unallocated).to.equal(4)
-      })
-    })
-
-    describe('with a nil return that has no `returnSubmissionLines`', () => {
-      beforeEach(() => {
-        testData = _generateTestData()
-        testData.matchingReturns[0].returnSubmissions[0].returnSubmissionLines = []
-      })
-
-      it('does not allocate anything from the return log', () => {
-        const { chargeElement, chargeReference, matchingReturns } = testData
-
-        AllocateReturnsToChargeElementService.go(chargeElement, matchingReturns, chargePeriod, chargeReference)
-
-        expect(chargeReference.allocatedQuantity).to.equal(0)
-
-        expect(chargeElement.allocatedQuantity).to.equal(0)
-        expect(chargeElement.returnLogs[0].allocatedQuantity).to.equal(0)
-
-        expect(matchingReturns[0].allocatedQuantity).to.equal(0)
+          expect(matchingReturns[0].allocatedQuantity).to.equal(10)
+        })
       })
     })
   })
 })
 
-function _generateTestData () {
+function _generateTestData (returnStatus = 'complete') {
   // Data not required for the tests has been excluded from the generated data
   const chargeElement = {
     authorisedAnnualQuantity: 32,
@@ -290,56 +423,60 @@ function _generateTestData () {
     allocatedQuantity: 0
   }
 
+  const returnSubmissions = [
+    {
+      returnSubmissionLines: [
+        {
+          startDate: new Date('2022-04-01'),
+          endDate: new Date('2022-04-30'),
+          unallocated: 4
+        },
+        {
+          startDate: new Date('2022-05-01'),
+          endDate: new Date('2022-05-31'),
+          unallocated: 4
+        },
+        {
+          startDate: new Date('2022-06-01'),
+          endDate: new Date('2022-06-30'),
+          unallocated: 4
+        },
+        {
+          startDate: new Date('2022-07-01'),
+          endDate: new Date('2022-07-31'),
+          unallocated: 4
+        },
+        {
+          startDate: new Date('2022-08-01'),
+          endDate: new Date('2022-08-31'),
+          unallocated: 4
+        },
+        {
+          startDate: new Date('2022-09-01'),
+          endDate: new Date('2022-09-30'),
+          unallocated: 4
+        },
+        {
+          startDate: new Date('2022-10-01'),
+          endDate: new Date('2022-10-31'),
+          unallocated: 4
+        },
+        {
+          startDate: new Date('2023-03-01'),
+          endDate: new Date('2023-03-31'),
+          unallocated: 4
+        }
+      ]
+    }
+  ]
+
+  // If a returns status isn't `complete` it won't have any return submission lines and the `issues` will be `true`
   const matchingReturns = [
     {
-      returnSubmissions: [
-        {
-          returnSubmissionLines: [
-            {
-              startDate: new Date('2022-04-01'),
-              endDate: new Date('2022-04-30'),
-              unallocated: 4
-            },
-            {
-              startDate: new Date('2022-05-01'),
-              endDate: new Date('2022-05-31'),
-              unallocated: 4
-            },
-            {
-              startDate: new Date('2022-06-01'),
-              endDate: new Date('2022-06-30'),
-              unallocated: 4
-            },
-            {
-              startDate: new Date('2022-07-01'),
-              endDate: new Date('2022-07-31'),
-              unallocated: 4
-            },
-            {
-              startDate: new Date('2022-08-01'),
-              endDate: new Date('2022-08-31'),
-              unallocated: 4
-            },
-            {
-              startDate: new Date('2022-09-01'),
-              endDate: new Date('2022-09-30'),
-              unallocated: 4
-            },
-            {
-              startDate: new Date('2022-10-01'),
-              endDate: new Date('2022-10-31'),
-              unallocated: 4
-            },
-            {
-              startDate: new Date('2023-03-01'),
-              endDate: new Date('2023-03-31'),
-              unallocated: 4
-            }
-          ]
-        }
-      ],
+      returnSubmissions: returnStatus === 'complete' ? returnSubmissions : [],
       allocatedQuantity: 0,
-      issues: false
+      issues: returnStatus !== 'complete',
+      status: returnStatus
     }
   ]
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4377

Update the match & allocation engine to ‘allocate’ overdue returns.

The complication is the engine is built on matching return submission lines to charge elements by comparing the line’s start and end dates to a charge element’s calculated abstraction dates (amongst a host of other parameters).

So where there is a licence with an overdue return that has been matched to an element. The engine needs to ensure that the customer is charged the authorised amount for that element.

The engine is to be updated so that after all completed returns have had their volumes allocated. If there are any overdue returns, the engine will attempt to match those to a charge element. If matched the engine will then bump the volume allocated to that element up to its authorised volume.