### PR TITLE
Fix annual billing not excluding workflow licences

### DIFF
--- a/app/services/bill-runs/annual/fetch-billing-accounts.service.js
+++ b/app/services/bill-runs/annual/fetch-billing-accounts.service.js
@@ -133,14 +133,14 @@ async function _fetchNew (regionId, billingPeriod) {
  *
  * So, we have moved the 'WHERE' clause to its own function that we can then reuse.
  *
- * @param {module:QueryBuilder} builder - an instance of the Objection QueryBuilder being generated
+ * @param {module:QueryBuilder} query - an instance of the Objection QueryBuilder being generated
  * @param {string} regionId - UUID of the region being billed that the licences must be linked to
  * @param {Object} billingPeriod - Object with a `startDate` and `endDate` property representing the period being billed
  *
  * @returns {module:QueryBuilder} the builder instance passed in with the additional `where` clauses added
  */
-function _whereClauseForChargeVersions (builder, regionId, billingPeriod) {
-  return builder
+function _whereClauseForChargeVersions (query, regionId, billingPeriod) {
+  return query
     .innerJoinRelated('licence')
     .where('licence.regionId', regionId)
     .where('chargeVersions.scheme', 'sroc')
@@ -180,12 +180,12 @@ function _whereClauseForChargeVersions (builder, regionId, billingPeriod) {
  * considered is done here by combining a `select(1)` with our `_whereClauseForChargeVersions()` function.
  */
 function _whereExistsClause (regionId, billingPeriod) {
-  let builder = ChargeVersionModel.query().select(1)
+  let query = ChargeVersionModel.query().select(1)
 
-  builder = _whereClauseForChargeVersions(builder, regionId, billingPeriod)
-  builder.whereColumn('chargeVersions.billingAccountId', 'billingAccounts.id')
+  query = _whereClauseForChargeVersions(query, regionId, billingPeriod)
+  query.whereColumn('chargeVersions.billingAccountId', 'billingAccounts.id')
 
-  return builder
+  return query
 }
 
 module.exports = {

--- a/app/services/bill-runs/annual/fetch-billing-accounts.service.js
+++ b/app/services/bill-runs/annual/fetch-billing-accounts.service.js
@@ -42,11 +42,6 @@ async function _fetchNew (regionId, billingPeriod) {
       'billingAccounts.id',
       'billingAccounts.accountNumber'
     ])
-    // NOTE: The WHERE EXISTS clause is a beast of a query in its own right so moved it to a function and have it return
-    // the QueryBuilder instance `whereExists()` can use.
-    // Bill runs are formed of 'bills' which are a 1-to-1 with billing accounts. But whether a billing account should
-    // be included is _all_ based on the charge versions they are linked to. So, all the work of filtering what will be
-    // considered is done there.
     .whereExists(_whereExistsClause(regionId, billingPeriod))
     .orderBy([
       { column: 'billingAccounts.accountNumber' }
@@ -55,25 +50,20 @@ async function _fetchNew (regionId, billingPeriod) {
     .modifyGraph('chargeVersions', (builder) => {
       builder
         .select([
-          'id',
-          'scheme',
-          'startDate',
-          'endDate',
-          'billingAccountId',
-          'status'
+          'chargeVersions.id',
+          'chargeVersions.scheme',
+          'chargeVersions.startDate',
+          'chargeVersions.endDate',
+          'chargeVersions.billingAccountId',
+          'chargeVersions.status'
         ])
-        .where('scheme', 'sroc')
-        .where('startDate', '<=', billingPeriod.endDate)
-        .where('status', 'current')
-        .where(() => {
-          builder
-            .whereNull('endDate')
-            .orWhere('endDate', '>=', billingPeriod.startDate)
-        })
-        .orderBy([
-          { column: 'licenceId', order: 'ASC' },
-          { column: 'startDate', order: 'ASC' }
-        ])
+
+      _whereClauseForChargeVersions(builder, regionId, billingPeriod)
+
+      builder.orderBy([
+        { column: 'licenceId', order: 'ASC' },
+        { column: 'startDate', order: 'ASC' }
+      ])
     })
     .withGraphFetched('chargeVersions.licence')
     .modifyGraph('chargeVersions.licence', (builder) => {
@@ -135,12 +125,24 @@ async function _fetchNew (regionId, billingPeriod) {
     })
 }
 
-function _whereExistsClause (regionId, billingPeriod) {
-  return ChargeVersionModel.query()
-    .select(1)
+/**
+ * Where clause to use when fetching charge versions within the main query
+ *
+ * We have to filter the applicable charge versions for a number of reasons and need to do it twice; once when
+ * determining which billing accounts to fetch and again, when grabbing their related charge versions.
+ *
+ * So, we have moved the 'WHERE' clause to its own function that we can then reuse.
+ *
+ * @param {module:QueryBuilder} builder - an instance of the Objection QueryBuilder being generated
+ * @param {string} regionId - UUID of the region being billed that the licences must be linked to
+ * @param {Object} billingPeriod - Object with a `startDate` and `endDate` property representing the period being billed
+ *
+ * @returns {module:QueryBuilder} the builder instance passed in with the additional `where` clauses added
+ */
+function _whereClauseForChargeVersions (builder, regionId, billingPeriod) {
+  return builder
     .innerJoinRelated('licence')
     .where('licence.regionId', regionId)
-    .whereColumn('chargeVersions.billingAccountId', 'billingAccounts.id')
     .where('chargeVersions.scheme', 'sroc')
     .where('chargeVersions.startDate', '<=', billingPeriod.endDate)
     .where('chargeVersions.status', 'current')
@@ -170,6 +172,20 @@ function _whereExistsClause (regionId, billingPeriod) {
         .whereColumn('chargeVersions.licenceId', 'workflows.licenceId')
         .whereNull('workflows.deletedAt')
     )
+}
+
+/**
+ * Bill runs are formed of 'bills' which are a 1-to-1 with billing accounts. But whether a billing account should
+ * be included is _all_ based on the charge versions they are linked to. So, all the work of filtering what will be
+ * considered is done here by combining a `select(1)` with our `_whereClauseForChargeVersions()` function.
+ */
+function _whereExistsClause (regionId, billingPeriod) {
+  let builder = ChargeVersionModel.query().select(1)
+
+  builder = _whereClauseForChargeVersions(builder, regionId, billingPeriod)
+  builder.whereColumn('chargeVersions.billingAccountId', 'billingAccounts.id')
+
+  return builder
 }
 
 module.exports = {

--- a/test/services/bill-runs/annual/fetch-billing-accounts.service.test.js
+++ b/test/services/bill-runs/annual/fetch-billing-accounts.service.test.js
@@ -246,7 +246,7 @@ describe('Fetch Billing Accounts service', () => {
     describe('because they are all linked to licences in workflow', () => {
       beforeEach(async () => {
         await ChargeVersionHelper.add({ billingAccountId, licenceId })
-        await WorkflowHelper.add({ licenceId })
+        await WorkflowHelper.add({ licenceId: '2f4b66a9-5992-4302-9707-bfb3ea1606c5' })
       })
 
       it('returns empty results', async () => {

--- a/test/services/bill-runs/annual/fetch-billing-accounts.service.test.js
+++ b/test/services/bill-runs/annual/fetch-billing-accounts.service.test.js
@@ -246,7 +246,7 @@ describe('Fetch Billing Accounts service', () => {
     describe('because they are all linked to licences in workflow', () => {
       beforeEach(async () => {
         await ChargeVersionHelper.add({ billingAccountId, licenceId })
-        await WorkflowHelper.add({ licenceId: '2f4b66a9-5992-4302-9707-bfb3ea1606c5' })
+        await WorkflowHelper.add({ licenceId })
       })
 
       it('returns empty results', async () => {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4379

We are working to replace the legacy SROC annual billing engine with one in this project that exploits what we did with SROC supplementary billing.

The first pass of testing has highlighted a discrepancy with the bill amounts. When we looked into it we found the new engine was still including licences that have records in workflow as part of the calculation.

Our new engine is only returning billing accounts that have applicable charge versions. What we failed to do was then filter again the charge versions returned for each billing account.

The scenario we found was a billing account linked to 2 licences, one of which was in workflow. The billing account was included because it has a charge version linked to a licence that isn't in workflow.

But then we fetched for the billing account _all_ the charge versions including the one linked to a licence in workflow.

We should be doing the same filtering in both places. This fix ensures that.