### PR TITLE
Fix bill licences with no transactions in bill run

### DIFF
--- a/app/services/bill-runs/annual/process-billing-period.service.js
+++ b/app/services/bill-runs/annual/process-billing-period.service.js
@@ -90,8 +90,6 @@ async function _createBillLicencesAndTransactions (billId, billingAccount, billR
   const allBillLicences = []
   const transactions = []
 
-  const { accountNumber } = billingAccount
-
   for (const chargeVersion of billingAccount.chargeVersions) {
     const billLicence = _findOrCreateBillLicence(allBillLicences, chargeVersion.licence, billId)
 
@@ -100,7 +98,7 @@ async function _createBillLicencesAndTransactions (billId, billingAccount, billR
       billingPeriod,
       chargeVersion,
       billRunExternalId,
-      accountNumber
+      billingAccount.accountNumber
     )
 
     if (createdTransactions.length > 0) {

--- a/app/services/bill-runs/annual/process-billing-period.service.js
+++ b/app/services/bill-runs/annual/process-billing-period.service.js
@@ -87,13 +87,13 @@ async function go (billRun, billingPeriod, billingAccounts) {
  * we have to create a new one.
  */
 async function _createBillLicencesAndTransactions (billId, billingAccount, billRunExternalId, billingPeriod) {
-  const billLicences = []
+  const allBillLicences = []
   const transactions = []
 
   const { accountNumber } = billingAccount
 
   for (const chargeVersion of billingAccount.chargeVersions) {
-    const billLicence = _findOrCreateBillLicence(billLicences, chargeVersion.licence, billId)
+    const billLicence = _findOrCreateBillLicence(allBillLicences, chargeVersion.licence, billId)
 
     const createdTransactions = await _createTransactions(
       billLicence.id,
@@ -103,8 +103,13 @@ async function _createBillLicencesAndTransactions (billId, billingAccount, billR
       accountNumber
     )
 
-    transactions.push(...createdTransactions)
+    if (createdTransactions.length > 0) {
+      billLicence.billable = true
+      transactions.push(...createdTransactions)
+    }
   }
+
+  const billLicences = _extractBillableLicences(allBillLicences)
 
   return { billLicences, transactions }
 }
@@ -122,6 +127,27 @@ async function _createTransactions (billLicenceId, billingPeriod, chargeVersion,
   const generatedTransactions = _generateTransactionData(billLicenceId, billingPeriod, chargePeriod, chargeVersion)
 
   return SendTransactionsService.go(generatedTransactions, billRunExternalId, accountNumber, chargeVersion.licence)
+}
+
+/**
+ * Intended to be used in conjunction with _createBillLicencesAndTransactions() it extracts only those bill licences
+ * where we generated transactions. This avoids us persisting a bill licence record with no transaction records.
+ *
+ * A billing account can be linked to multiple licences but not all of them may be billable. We add a flag to each
+ * one that demotes if transactions were generated. So we can easily filter the billable ones out. But we also need
+ * to remove that flag because it doesn't exist in the DB and will cause issues if we try and persist the object.
+ */
+function _extractBillableLicences (allBillLicences) {
+  const billableBillLicences = []
+
+  allBillLicences.forEach((billLicence) => {
+    const { id, billId, licenceId, licenceRef, billable } = billLicence
+    if (billable) {
+      billableBillLicences.push({ id, billId, licenceId, licenceRef })
+    }
+  })
+
+  return billableBillLicences
 }
 
 /**
@@ -160,7 +186,8 @@ function _findOrCreateBillLicence (billLicences, licence, billId) {
       id: generateUUID(),
       billId,
       licenceId,
-      licenceRef
+      licenceRef,
+      billable: false
     }
 
     billLicences.push(billLicence)


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4379

We are working to replace the legacy SROC annual billing engine with one in this project that exploits what we did with SROC supplementary billing.

The first pass of testing has highlighted a discrepancy with how many licences are being included in some bills. For example, the legacy bill run will only display 1 but the new engine will display 3.

When we looked into it we found it was because only 1 of the 3 licences had applicable transactions. Two of the licences had no billable days.

The legacy is correct in this case, we shouldn't be creating bill licence records where there were no transactions. This change fixes the annual billing engine to deal with this scenario.

> For reference the licences had no billable days because they were revoked before the abstraction period on the charge reference i.e. revoked before the charge period.