### PR TITLE
Display public water supply charge in bill licence

### DIFF
--- a/app/presenters/bill-licences/view-standard-charge-transaction.presenter.js
+++ b/app/presenters/bill-licences/view-standard-charge-transaction.presenter.js
@@ -31,17 +31,21 @@ function go (transaction) {
   return _presrocContent(transaction)
 }
 
-function _additionalCharges (waterCompanyCharge, supportedSourceCharge, supportedSourceName) {
+function _additionalCharges (
+  waterCompanyCharge, waterCompanyChargeValue, supportedSourceChargeValue, supportedSourceName
+) {
   const charges = []
 
   if (supportedSourceName) {
-    const chargeInPounds = formatPounds(supportedSourceCharge)
+    const chargeInPounds = formatPounds(supportedSourceChargeValue)
 
     charges.push(`Supported source ${supportedSourceName} (£${chargeInPounds})`)
   }
 
   if (waterCompanyCharge) {
-    charges.push('Public Water Supply')
+    const chargeInPounds = formatPounds(waterCompanyChargeValue)
+
+    charges.push(`Public Water Supply (£${chargeInPounds})`)
   }
 
   return charges.join(', ')
@@ -183,26 +187,30 @@ function _srocContent (transaction) {
     description,
     endDate,
     credit,
-    waterCompanyCharge,
-    winterOnly,
     netAmount,
     section126Factor,
     section127Agreement,
     section130Agreement,
     startDate,
-    supportedSourceCharge,
+    supportedSourceChargeValue,
     supportedSourceName,
-    volume
+    volume,
+    waterCompanyCharge,
+    waterCompanyChargeValue,
+    winterOnly
   } = transaction
 
   // NOTE: These charges are returned from the Rules Service (via the Charging Module API) in pounds not pence. This is
   // different to all other values we have to deal with. So, we have to convert the values before passing them to our
   // formatter as it expects the values to be in pence.
   const baselineChargeInPence = baselineCharge * 100
-  const supportedSourceChargeInPence = supportedSourceCharge * 100
+  const supportedSourceChargeInPence = supportedSourceChargeValue * 100
+  const waterCompanyChargeInPence = waterCompanyChargeValue * 100
 
   return {
-    additionalCharges: _additionalCharges(waterCompanyCharge, supportedSourceChargeInPence, supportedSourceName),
+    additionalCharges: _additionalCharges(
+      waterCompanyCharge, waterCompanyChargeInPence, supportedSourceChargeInPence, supportedSourceName
+    ),
     adjustments: _adjustments(
       adjustmentFactor,
       aggregateFactor,

--- a/app/services/bill-licences/fetch-bill-licence.service.js
+++ b/app/services/bill-licences/fetch-bill-licence.service.js
@@ -79,7 +79,8 @@ async function _fetchBillLicence (id) {
         ref('abstractionPeriod:startMonth').castInt().as('abstractionPeriodStartMonth'),
         ref('abstractionPeriod:endDay').castInt().as('abstractionPeriodEndDay'),
         ref('abstractionPeriod:endMonth').castInt().as('abstractionPeriodEndMonth'),
-        ref('grossValuesCalculated:supportedSourceCharge').castInt().as('supportedSourceCharge')
+        ref('grossValuesCalculated:supportedSourceCharge').castInt().as('supportedSourceChargeValue'),
+        ref('grossValuesCalculated:waterCompanyCharge').castInt().as('waterCompanyChargeValue')
       ])
         .orderBy([
           { column: 'chargeCategoryCode', order: 'desc' },

--- a/test/presenters/bill-licences/view-standard-charge-transaction.presenter.test.js
+++ b/test/presenters/bill-licences/view-standard-charge-transaction.presenter.test.js
@@ -48,7 +48,7 @@ describe('View Standard Charge Transaction presenter', () => {
       describe('when supported source is set', () => {
         beforeEach(() => {
           transaction.supportedSourceName = 'Candover'
-          transaction.supportedSourceCharge = '14567'
+          transaction.supportedSourceChargeValue = '14567'
         })
 
         it("returns 'Supported source Candover (£14567.00)'", () => {
@@ -61,26 +61,28 @@ describe('View Standard Charge Transaction presenter', () => {
       describe('when is a water company charge is true', () => {
         beforeEach(() => {
           transaction.waterCompanyCharge = true
+          transaction.waterCompanyChargeValue = '2498'
         })
 
-        it("returns 'Public Water Supply'", () => {
+        it("returns 'Public Water Supply (£2498.00)'", () => {
           const result = ViewStandardChargeTransactionPresenter.go(transaction)
 
-          expect(result.additionalCharges).to.equal('Public Water Supply')
+          expect(result.additionalCharges).to.equal('Public Water Supply (£2498.00)')
         })
       })
 
       describe('when both supported source and is a water company charge are set', () => {
         beforeEach(() => {
           transaction.supportedSourceName = 'Candover'
-          transaction.supportedSourceCharge = '14567'
+          transaction.supportedSourceChargeValue = '14567'
           transaction.waterCompanyCharge = true
+          transaction.waterCompanyChargeValue = '2498'
         })
 
-        it("returns 'Public Water Supply'", () => {
+        it("returns 'Supported source Candover (£14567.00), Public Water Supply (£2498.00)'", () => {
           const result = ViewStandardChargeTransactionPresenter.go(transaction)
 
-          expect(result.additionalCharges).to.equal('Supported source Candover (£14567.00), Public Water Supply')
+          expect(result.additionalCharges).to.equal('Supported source Candover (£14567.00), Public Water Supply (£2498.00)')
         })
       })
     })
@@ -382,7 +384,8 @@ function _srocTransaction () {
     section130Agreement: 'false',
     supportedSourceName: null,
     baselineCharge: 1162,
-    supportedSourceCharge: 0
+    supportedSourceChargeValue: 0,
+    waterCompanyChargeValue: 0
   }
 
   transaction.chargeReference.chargeElements = [


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4392

When you view a bill licence we display the transactions for that licence in the current bill. If there are any additional charges there is a section that appears that will list these out.

Billing & Data have highlighted that when the additional charge is 'Supported source' we handily show the charge in brackets afterwards. If the charge is 'Public water supply' we don't.

This change makes it so!