### PR TITLE
Add Charging Module Delete Bill Run Service

### DIFF
--- a/app/lib/charging-module-request.lib.js
+++ b/app/lib/charging-module-request.lib.js
@@ -11,6 +11,23 @@ const requestConfig = require('../../config/request.config.js')
 const servicesConfig = require('../../config/services.config.js')
 
 /**
+ * Sends a DELETE request to the Charging Module for the provided path
+ *
+ * > Note: This function has been called `deleteRequest` here rather than `delete` as `delete` is a reserved word.
+ *
+ * @param {string} path - The path to send the request to (do not include the starting /)
+ *
+ * @returns {Promise<Object>} An object representing the result of the request
+ * @returns {boolean} result.succeeded Whether the request was successful
+ * @returns {Object} result.response The Charging Module response if successful or the error response if not
+ */
+async function deleteRequest (path) {
+  const result = await _sendRequest(path, RequestLib.delete)
+
+  return _parseResult(result)
+}
+
+/**
  * Sends a GET request to the Charging Module for the provided route
  *
  * @param {string} path The route to send the request to (do not include the starting /)
@@ -132,6 +149,7 @@ function _parseResult (result) {
 }
 
 module.exports = {
+  delete: deleteRequest,
   get,
   patch,
   post

--- a/app/lib/charging-module-request.lib.js
+++ b/app/lib/charging-module-request.lib.js
@@ -30,7 +30,7 @@ async function deleteRequest (path) {
 /**
  * Sends a GET request to the Charging Module for the provided route
  *
- * @param {string} path The route to send the request to (do not include the starting /)
+ * @param {string} path - The route to send the request to (do not include the starting /)
  *
  * @returns {Promise<Object>} result An object representing the result of the request
  * @returns {boolean} result.succeeded Whether the request was successful
@@ -45,7 +45,7 @@ async function get (path) {
 /**
  * Sends a PATCH request to the Charging Module for the provided path
  *
- * @param {string} path The path to send the request to (do not include the starting /)
+ * @param {string} path - The path to send the request to (do not include the starting /)
  *
  * @returns {Promise<Object>} result An object representing the result of the request
  * @returns {boolean} result.succeeded Whether the request was successful
@@ -60,8 +60,8 @@ async function patch (path) {
 /**
  * Sends a POST request to the Charging Module for the provided path
  *
- * @param {string} path The path to send the request to (do not include the starting /)
- * @param {Object} [body] The body of the request
+ * @param {string} path - The path to send the request to (do not include the starting /)
+ * @param {Object} [body] - The body of the request
  *
  * @returns {Promise<Object>} result An object representing the result of the request
  * @returns {boolean} result.succeeded Whether the request was successful
@@ -76,9 +76,9 @@ async function post (path, body = {}) {
 /**
  * Sends a request to the Charging Module using the provided RequestLib method
  *
- * @param {string} path The path that you wish to connect to (do not include the starting /)
- * @param {Object} method An instance of a RequestLib method which will be used to send the request
- * @param {Object} [body] Optional body to be sent to the route as json
+ * @param {string} path - The path that you wish to connect to (do not include the starting /)
+ * @param {Object} method - An instance of a RequestLib method which will be used to send the request
+ * @param {Object} [body] - Optional body to be sent to the route as json
  *
  * @returns {Promise<Object>} The result of the request passed back from RequestLib
  */
@@ -124,7 +124,7 @@ function _requestOptions (accessToken, body) {
 /**
  * Parses the charging module response returned from RequestLib
  *
- * @param {Object} result The result object returned by RequestLib
+ * @param {Object} result - The result object returned by RequestLib
  *
  * @returns {Object} If result was not an error, a parsed version of the response
  */

--- a/app/services/charging-module/delete-bill-run.service.js
+++ b/app/services/charging-module/delete-bill-run.service.js
@@ -1,0 +1,29 @@
+'use strict'
+
+/**
+ * Connects with the Charging Module to delete a new bill run
+ * @module ChargingModuleDeleteBillRunService
+ */
+
+const ChargingModuleRequestLib = require('../../lib/charging-module-request.lib.js')
+
+/**
+ * Delete a bill run in the Charging Module API
+ *
+ * See {@link https://defra.github.io/sroc-charging-module-api-docs/#/bill-run/DeleteBillRun | CHA API docs} for more
+ * details
+ *
+ * @param {string} billRunId - UUID of the charging module API bill run to delete
+ *
+ * @returns {Promise<Object>} The result of the request; whether it succeeded and the response or error returned
+ */
+async function go (billRunId) {
+  const path = `v3/wrls/bill-runs/${billRunId}`
+  const result = await ChargingModuleRequestLib.delete(path)
+
+  return result
+}
+
+module.exports = {
+  go
+}

--- a/test/lib/charging-module-request.lib.test.js
+++ b/test/lib/charging-module-request.lib.test.js
@@ -49,6 +49,106 @@ describe('ChargingModuleRequestLib', () => {
     delete global.HapiServerMethods
   })
 
+  describe('#delete', () => {
+    describe('when the request succeeds', () => {
+      beforeEach(async () => {
+        Sinon.stub(RequestLib, 'delete').resolves({
+          succeeded: true,
+          response: {
+            headers,
+            statusCode: 204,
+            body: {}
+          }
+        })
+      })
+
+      it('calls the Charging Module with the required options', async () => {
+        await ChargingModuleRequestLib.delete(testRoute)
+
+        const requestArgs = RequestLib.delete.firstCall.args
+
+        expect(requestArgs[0]).to.endWith('TEST_ROUTE')
+        expect(requestArgs[1].headers).to.include({ authorization: 'Bearer ACCESS_TOKEN' })
+      })
+
+      it('uses the charging module timeout', async () => {
+        await ChargingModuleRequestLib.delete(testRoute)
+
+        const requestArgs = RequestLib.delete.firstCall.args
+
+        expect(requestArgs[1].timeout).to.equal({ request: 1234 })
+      })
+
+      it('returns a `true` success status', async () => {
+        const result = await ChargingModuleRequestLib.delete(testRoute)
+
+        expect(result.succeeded).to.be.true()
+      })
+
+      it('returns the response body as an object', async () => {
+        const result = await ChargingModuleRequestLib.delete(testRoute)
+
+        expect(result.response.body).to.equal({})
+      })
+
+      it('returns the status code', async () => {
+        const result = await ChargingModuleRequestLib.delete(testRoute)
+
+        expect(result.response.statusCode).to.equal(204)
+      })
+
+      it('returns the information about the running Charging Module API', async () => {
+        const result = await ChargingModuleRequestLib.delete(testRoute)
+
+        expect(result.response.info).to.equal({
+          gitCommit: '273604040a47e0977b0579a0fef0f09726d95e39',
+          dockerTag: 'ghcr.io/defra/sroc-charging-module-api:v0.19.0'
+        })
+      })
+    })
+
+    describe('when the request fails', () => {
+      beforeEach(async () => {
+        Sinon.stub(RequestLib, 'delete').resolves({
+          succeeded: false,
+          response: {
+            headers,
+            statusCode: 404,
+            statusMessage: 'Not Found',
+            body: { statusCode: 404, error: 'Not Found', message: 'Not Found' }
+          }
+        })
+      })
+
+      it('returns a `false` success status', async () => {
+        const result = await ChargingModuleRequestLib.delete(testRoute)
+
+        expect(result.succeeded).to.be.false()
+      })
+
+      it('returns the error response', async () => {
+        const result = await ChargingModuleRequestLib.delete(testRoute)
+
+        expect(result.response.body.message).to.equal('Not Found')
+      })
+
+      it('returns the status code', async () => {
+        const result = await ChargingModuleRequestLib.delete(testRoute)
+
+        expect(result.response.statusCode).to.equal(404)
+      })
+
+      it('returns the information about the running Charging Module API', async () => {
+        const result = await ChargingModuleRequestLib.delete(testRoute)
+
+        expect(result.response.info).to.equal({
+          gitCommit: '273604040a47e0977b0579a0fef0f09726d95e39',
+          dockerTag: 'ghcr.io/defra/sroc-charging-module-api:v0.19.0'
+        })
+      })
+    })
+  })
+
   describe('#get', () => {
     describe('when the request succeeds', () => {
       beforeEach(async () => {

--- a/test/services/charging-module/bill-run-status.service.test.js
+++ b/test/services/charging-module/bill-run-status.service.test.js
@@ -14,7 +14,7 @@ const ChargingModuleRequestLib = require('../../../app/lib/charging-module-reque
 // Thing under test
 const ChargingModuleBillRunStatusService = require('../../../app/services/charging-module/bill-run-status.service.js')
 
-describe('Charging Module bill run status service', () => {
+describe('Charging Module Bill Run Status service', () => {
   const billRunId = '2bbbe459-966e-4026-b5d2-2f10867bdddd'
   const transactionData = { billingTransactionId: '2395429b-e703-43bc-8522-ce3f67507ffa' }
 
@@ -52,7 +52,7 @@ describe('Charging Module bill run status service', () => {
     })
   })
 
-  describe('when the service cannot create a transaction', () => {
+  describe('when the service cannot get a bill run status', () => {
     describe('because the request did not return a 2xx/3xx response', () => {
       beforeEach(async () => {
         Sinon.stub(ChargingModuleRequestLib, 'get').resolves({

--- a/test/services/charging-module/create-bill-run.service.test.js
+++ b/test/services/charging-module/create-bill-run.service.test.js
@@ -18,7 +18,7 @@ const ChargingModuleRequestLib = require('../../../app/lib/charging-module-reque
 // Thing under test
 const ChargingModuleCreateBillRunService = require('../../../app/services/charging-module/create-bill-run.service.js')
 
-describe('Charge module create bill run service', () => {
+describe('Charging Module Create Bill Run service', () => {
   let testRegion
 
   beforeEach(async () => {

--- a/test/services/charging-module/create-customer-change.service.test.js
+++ b/test/services/charging-module/create-customer-change.service.test.js
@@ -14,7 +14,7 @@ const ChargingModuleRequestLib = require('../../../app/lib/charging-module-reque
 // Thing under test
 const ChargingModuleCreateCustomerChangeService = require('../../../app/services/charging-module/create-customer-change.service.js')
 
-describe('Charging module create customer change service', () => {
+describe('Charging Module Create Customer Change service', () => {
   const requestData = {
     region: 'B',
     customerReference: 'B88891136A',

--- a/test/services/charging-module/create-transaction.service.test.js
+++ b/test/services/charging-module/create-transaction.service.test.js
@@ -14,7 +14,7 @@ const ChargingModuleRequestLib = require('../../../app/lib/charging-module-reque
 // Thing under test
 const ChargingModuleCreateTransactionService = require('../../../app/services/charging-module/create-transaction.service.js')
 
-describe('Charge module create transaction service', () => {
+describe('Charging Module Create Transaction service', () => {
   const billRunId = '2bbbe459-966e-4026-b5d2-2f10867bdddd'
   const transactionData = { billingTransactionId: '2395429b-e703-43bc-8522-ce3f67507ffa' }
 

--- a/test/services/charging-module/delete-bill-run.service.test.js
+++ b/test/services/charging-module/delete-bill-run.service.test.js
@@ -1,0 +1,112 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { describe, it, beforeEach, afterEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Things we need to stub
+const ChargingModuleRequestLib = require('../../../app/lib/charging-module-request.lib.js')
+
+// Thing under test
+const ChargingModuleDeleteBillRunService = require('../../../app/services/charging-module/delete-bill-run.service.js')
+
+describe('Charging Module Delete Bill Run service', () => {
+  const billRunId = '2bbbe459-966e-4026-b5d2-2f10867bdddd'
+
+  afterEach(() => {
+    Sinon.restore()
+  })
+
+  describe('when the service can delete a bill run', () => {
+    beforeEach(async () => {
+      Sinon.stub(ChargingModuleRequestLib, 'delete').resolves({
+        succeeded: true,
+        response: {
+          info: {
+            gitCommit: '273604040a47e0977b0579a0fef0f09726d95e39',
+            dockerTag: 'ghcr.io/defra/sroc-charging-module-api:v0.19.0'
+          },
+          statusCode: 204,
+          body: null
+        }
+      })
+    })
+
+    it('returns a `true` success status', async () => {
+      const result = await ChargingModuleDeleteBillRunService.go(billRunId)
+
+      expect(result.succeeded).to.be.true()
+    })
+
+    it('returns a 204 - no content', async () => {
+      const result = await ChargingModuleDeleteBillRunService.go(billRunId)
+
+      expect(result.response.statusCode).to.equal(204)
+      expect(result.response.body).to.be.null()
+    })
+  })
+
+  describe('when the service cannot delete a bill run', () => {
+    describe('because the request did not return a 2xx/3xx response', () => {
+      beforeEach(async () => {
+        Sinon.stub(ChargingModuleRequestLib, 'delete').resolves({
+          succeeded: false,
+          response: {
+            info: {
+              gitCommit: '273604040a47e0977b0579a0fef0f09726d95e39',
+              dockerTag: 'ghcr.io/defra/sroc-charging-module-api:v0.19.0'
+            },
+            statusCode: 401,
+            body: {
+              statusCode: 401,
+              error: 'Unauthorized',
+              message: 'Invalid JWT: Token format not valid',
+              attributes: { error: 'Invalid JWT: Token format not valid' }
+            }
+          }
+        })
+      })
+
+      it('returns a `false` success status', async () => {
+        const result = await ChargingModuleDeleteBillRunService.go(billRunId)
+
+        expect(result.succeeded).to.be.false()
+      })
+
+      it('returns the error in the `response`', async () => {
+        const result = await ChargingModuleDeleteBillRunService.go(billRunId)
+
+        expect(result.response.body.statusCode).to.equal(401)
+        expect(result.response.body.error).to.equal('Unauthorized')
+        expect(result.response.body.message).to.equal('Invalid JWT: Token format not valid')
+      })
+    })
+
+    describe('because the request attempt returned an error, for example, TimeoutError', () => {
+      beforeEach(async () => {
+        Sinon.stub(ChargingModuleRequestLib, 'delete').resolves({
+          succeeded: false,
+          response: new Error("Timeout awaiting 'request' for 5000ms")
+        })
+      })
+
+      it('returns a `false` success status', async () => {
+        const result = await ChargingModuleDeleteBillRunService.go(billRunId)
+
+        expect(result.succeeded).to.be.false()
+      })
+
+      it('returns the error in the `response`', async () => {
+        const result = await ChargingModuleDeleteBillRunService.go(billRunId)
+
+        expect(result.response.statusCode).not.to.exist()
+        expect(result.response.body).not.to.exist()
+        expect(result.response.message).to.equal("Timeout awaiting 'request' for 5000ms")
+      })
+    })
+  })
+})

--- a/test/services/charging-module/generate-bill-run.service.test.js
+++ b/test/services/charging-module/generate-bill-run.service.test.js
@@ -14,7 +14,7 @@ const ChargingModuleRequestLib = require('../../../app/lib/charging-module-reque
 // Thing under test
 const ChargingModuleGenerateBillRunService = require('../../../app/services/charging-module/generate-bill-run.service.js')
 
-describe('Charge module generate bill run service', () => {
+describe('Charging Module Generate Bill Run service', () => {
   const billRunId = '2bbbe459-966e-4026-b5d2-2f10867bdddd'
 
   afterEach(() => {
@@ -50,7 +50,7 @@ describe('Charge module generate bill run service', () => {
     })
   })
 
-  describe('when the service cannot create a transaction', () => {
+  describe('when the service cannot generate a bill run', () => {
     describe('because the request did not return a 2xx/3xx response', () => {
       beforeEach(async () => {
         Sinon.stub(ChargingModuleRequestLib, 'patch').resolves({

--- a/test/services/charging-module/reissue-bill.service.test.js
+++ b/test/services/charging-module/reissue-bill.service.test.js
@@ -71,7 +71,7 @@ describe('Charging Module Reissue Bill service', () => {
     })
   })
 
-  describe('when the service cannot create a bill run', () => {
+  describe('when the service cannot reissue a bill run', () => {
     describe('because the request did not return a 2xx/3xx response', () => {
       beforeEach(async () => {
         Sinon.stub(ChargingModuleRequestLib, 'patch').resolves({

--- a/test/services/charging-module/token.service.test.js
+++ b/test/services/charging-module/token.service.test.js
@@ -14,7 +14,7 @@ const RequestLib = require('../../../app/lib/request.lib.js')
 // Thing under test
 const ChargingModuleTokenService = require('../../../app/services/charging-module/token.service.js')
 
-describe('Charging module token service', () => {
+describe('Charging Module Token service', () => {
   afterEach(() => {
     Sinon.restore()
   })

--- a/test/services/charging-module/view-bill.service.test.js
+++ b/test/services/charging-module/view-bill.service.test.js
@@ -64,7 +64,7 @@ describe('Charging Module View Bill service', () => {
     })
   })
 
-  describe('when the service cannot create a bill run', () => {
+  describe('when the service cannot view a bill run', () => {
     describe('because the request did not return a 2xx/3xx response', () => {
       beforeEach(async () => {
         Sinon.stub(ChargingModuleRequestLib, 'get').resolves({


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4387

We need to add this to support our work to improve how bill runs are cancelled. Basically, replace the crummy legacy one!

When you cancel a bill run you need to send a [DELETE request](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/DELETE) to the [Charging Module API](https://github.com/DEFRA/sroc-charging-module-api) to tell it to delete its copy.

Following our existing pattern we wrap interactions with the Charging Module in specific services. That way any calls to the ChargingModule can be centrally managed. It also makes it easier to stub the CHA in our tests.

This change adds a new `ChargingModuleDeleteBillRunService`.