### PR TITLE
Alter `return_logs` view

### DIFF
--- a/app/services/bill-runs/two-part-tariff/fetch-return-logs-for-licence.service.js
+++ b/app/services/bill-runs/two-part-tariff/fetch-return-logs-for-licence.service.js
@@ -26,7 +26,7 @@ async function _fetch (licenceRef, billingPeriod) {
   const returnLogs = await ReturnLogModel.query()
     .select([
       'id',
-      'returnRequirement',
+      'returnReference',
       ref('metadata:description').castText().as('description'),
       'startDate',
       'endDate',
@@ -47,7 +47,7 @@ async function _fetch (licenceRef, billingPeriod) {
     .where('endDate', '>=', billingPeriod.startDate)
     .whereJsonPath('metadata', '$.isTwoPartTariff', '=', true)
     .orderBy('startDate', 'ASC')
-    .orderBy('returnRequirement', 'ASC')
+    .orderBy('returnReference', 'ASC')
     .withGraphFetched('returnSubmissions')
     .modifyGraph('returnSubmissions', builder => {
       builder

--- a/app/services/bill-runs/two-part-tariff/persist-allocated-licence-to-results.service.js
+++ b/app/services/bill-runs/two-part-tariff/persist-allocated-licence-to-results.service.js
@@ -141,7 +141,7 @@ async function _persistReviewResult (
 async function _persistReviewReturnResult (returnLog) {
   const data = {
     returnId: returnLog.id,
-    returnReference: returnLog.returnRequirement,
+    returnReference: returnLog.returnReference,
     startDate: returnLog.startDate,
     endDate: returnLog.endDate,
     dueDate: returnLog.dueDate,

--- a/app/services/check/scenario-formatter.service.js
+++ b/app/services/check/scenario-formatter.service.js
@@ -169,7 +169,7 @@ function _formatReturnLogs (returnLogs) {
   return returnLogs.map((returnLog, index) => {
     const {
       id,
-      returnRequirement: requirement,
+      returnReference: reference,
       description,
       startDate,
       endDate,
@@ -213,7 +213,7 @@ function _formatReturnLogs (returnLogs) {
     return {
       simpleId,
       id,
-      requirement,
+      reference,
       status,
       description,
       starts: startDate.toLocaleDateString('en-GB'),

--- a/db/migrations/public/20240301151323_alter-return-logs-view.js
+++ b/db/migrations/public/20240301151323_alter-return-logs-view.js
@@ -1,0 +1,63 @@
+'use strict'
+
+const viewName = 'return_logs'
+
+exports.up = function (knex) {
+  return knex
+    .schema
+    .dropViewIfExists(viewName)
+    .createView(viewName, (view) => {
+      // NOTE: We have commented out unused columns from the source table
+      view.as(knex('returns').withSchema('returns').select([
+        'return_id AS id',
+        // 'regime', // always 'water'
+        // 'licence_type', // always 'abstraction'
+        'licence_ref',
+        'start_date',
+        'end_date',
+        'returns_frequency',
+        'status',
+        // 'source', // always 'NALD'
+        'metadata',
+        'received_date',
+        'return_requirement as return_reference',
+        'due_date',
+        'under_query',
+        // 'under_query_comment',
+        // 'is_test',
+        // 'return_cycle_id' // is populated but links to a table that does not appear to be used
+        'created_at',
+        'updated_at'
+      ]))
+    })
+}
+
+exports.down = function (knex) {
+  return knex
+    .schema
+    .dropViewIfExists(viewName)
+    .createView(viewName, (view) => {
+      // NOTE: We have commented out unused columns from the source table
+      view.as(knex('returns').withSchema('returns').select([
+        'return_id AS id',
+        // 'regime', // always 'water'
+        // 'licence_type', // always 'abstraction'
+        'licence_ref',
+        'start_date',
+        'end_date',
+        'returns_frequency',
+        'status',
+        // 'source', // always 'NALD'
+        'metadata',
+        'received_date',
+        'return_requirement',
+        'due_date',
+        'under_query',
+        // 'under_query_comment',
+        // 'is_test',
+        // 'return_cycle_id' // is populated but links to a table that does not appear to be used
+        'created_at',
+        'updated_at'
+      ]))
+    })
+}

--- a/test/services/bill-runs/two-part-tariff/match-and-allocate.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/match-and-allocate.service.test.js
@@ -153,7 +153,7 @@ function _generateMatchingReturnsData () {
   return [
     {
       id: 'v1:1:5/31/14/*S/0116A:10021668:2022-04-01:2023-03-31',
-      returnRequirement: '10021668',
+      returnReference: '10021668',
       description: 'DRAINS ETC-DEEPING FEN AND OTHER LINKED SITES',
       startDate: new Date('2022-04-01'),
       endDate: new Date('2023-03-31'),

--- a/test/services/bill-runs/two-part-tariff/persist-allocated-licence-to-results.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/persist-allocated-licence-to-results.service.test.js
@@ -60,7 +60,7 @@ describe('Persist Allocated Licence to Results service', () => {
         )
 
         expect(result[0].reviewReturnResults.returnId).to.equal(testLicence.returnLogs[0].id)
-        expect(result[0].reviewReturnResults.returnReference).to.equal(testLicence.returnLogs[0].returnRequirement)
+        expect(result[0].reviewReturnResults.returnReference).to.equal(testLicence.returnLogs[0].returnReference)
         expect(result[0].reviewReturnResults.startDate).to.equal(testLicence.returnLogs[0].startDate)
         expect(result[0].reviewReturnResults.endDate).to.equal(testLicence.returnLogs[0].endDate)
         expect(result[0].reviewReturnResults.dueDate).to.equal(testLicence.returnLogs[0].dueDate)
@@ -106,7 +106,7 @@ describe('Persist Allocated Licence to Results service', () => {
         expect(result[0].reviewChargeElementResults).to.be.null()
 
         expect(result[0].reviewReturnResults.returnId).to.equal(testLicence.returnLogs[0].id)
-        expect(result[0].reviewReturnResults.returnReference).to.equal(testLicence.returnLogs[0].returnRequirement)
+        expect(result[0].reviewReturnResults.returnReference).to.equal(testLicence.returnLogs[0].returnReference)
         expect(result[0].reviewReturnResults.startDate).to.equal(testLicence.returnLogs[0].startDate)
         expect(result[0].reviewReturnResults.endDate).to.equal(testLicence.returnLogs[0].endDate)
         expect(result[0].reviewReturnResults.dueDate).to.equal(testLicence.returnLogs[0].dueDate)
@@ -202,7 +202,7 @@ function _generateData (aggregate = null, returnMatched = true) {
     returnLogs: [
       {
         id: returnId,
-        returnRequirement: '10021668',
+        returnReference: '10021668',
         description: 'DRAINS ETC-DEEPING FEN AND OTHER LINKED SITES',
         startDate: new Date('2022-04-01'),
         endDate: new Date('2023-03-31'),

--- a/test/services/bill-runs/two-part-tariff/prepare-return-logs.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/prepare-return-logs.service.test.js
@@ -44,7 +44,7 @@ describe('Prepare Return Logs Service', () => {
 
           expect(licence.returnLogs[0]).to.equal({
             id: 'v1:1:01/977:14959864:2022-04-01:2023-03-31',
-            returnRequirement: '14959864',
+            returnReference: '14959864',
             description: 'The Description',
             startDate: new Date('2022-04-01'),
             endDate: new Date('2023-03-31'),
@@ -226,7 +226,7 @@ function _testLicence () {
 function _testReturnLog () {
   return {
     id: 'v1:1:01/977:14959864:2022-04-01:2023-03-31',
-    returnRequirement: '14959864',
+    returnReference: '14959864',
     description: 'The Description',
     startDate: new Date('2022-04-01T00:00:00.000Z'),
     endDate: new Date('2023-03-31T00:00:00.000Z'),

--- a/test/support/helpers/return-log.helper.js
+++ b/test/support/helpers/return-log.helper.js
@@ -14,14 +14,14 @@ const ReturnLogModel = require('../../../app/models/return-log.model.js')
  *
  * If no `data` is provided, default values will be used. These are
  *
- * - `id` - v1:1:[the generated licenceRef]:[the generated returnRequirement]:2022-04-01:2023-03-31
+ * - `id` - v1:1:[the generated licenceRef]:[the generated returnReference]:2022-04-01:2023-03-31
  * - `createdAt` - new Date()
  * - `dueDate` - 2023-04-28
  * - `endDate` - 2023-03-31
  * - `licenceRef` - [randomly generated - 1/23/45/76/3672]
  * - `metadata` - {}
  * - `receivedDate` - 2023-04-12
- * - `returnRequirement` - [randomly generated - 10000321]
+ * - `returnReference` - [randomly generated - 10000321]
  * - `returnsFrequency` - month
  * - `startDate` - 2022-04-01
  * - `status` - completed
@@ -49,18 +49,18 @@ function add (data = {}) {
  */
 function defaults (data = {}) {
   const licenceRef = data.licenceRef ? data.licenceRef : generateLicenceRef()
-  const returnRequirement = data.returnRequirement ? data.returnRequirement : randomInteger(10000000, 19999999)
+  const returnReference = data.returnReference ? data.returnReference : randomInteger(10000000, 19999999)
   const timestamp = timestampForPostgres()
 
   const defaults = {
-    id: generateReturnLogId('2022-04-01', '2023-03-31', 1, licenceRef, returnRequirement),
+    id: generateReturnLogId('2022-04-01', '2023-03-31', 1, licenceRef, returnReference),
     createdAt: timestamp,
     dueDate: new Date('2023-04-28'),
     endDate: new Date('2023-03-31'),
     licenceRef,
     metadata: {},
     receivedDate: new Date('2023-04-12'),
-    returnRequirement,
+    returnReference,
     returnsFrequency: 'month',
     startDate: new Date('2022-04-01'),
     status: 'completed',
@@ -78,17 +78,17 @@ function generateReturnLogId (
   endDate = '2023-03-31',
   version = 1,
   licenceRef,
-  returnRequirement
+  returnReference
 ) {
   if (!licenceRef) {
     licenceRef = generateLicenceRef()
   }
 
-  if (!returnRequirement) {
-    returnRequirement = randomInteger(10000000, 19999999)
+  if (!returnReference) {
+    returnReference = randomInteger(10000000, 19999999)
   }
 
-  return `v${version}:1:${licenceRef}:${returnRequirement}:${startDate}:${endDate}`
+  return `v${version}:1:${licenceRef}:${returnReference}:${startDate}:${endDate}`
 }
 
 module.exports = {

--- a/test/support/helpers/review-return-result.helper.js
+++ b/test/support/helpers/review-return-result.helper.js
@@ -16,7 +16,7 @@ const ReviewReturnResultModel = require('../../../app/models/review-return-resul
  * If no `data` is provided, default values will be used. These are
  *
  * - `id` - [random UUID]
- * - `returnId` - v1:1:[the generated licenceRef]:[the generated returnRequirement]:2022-04-01:2023-03-31
+ * - `returnId` - v1:1:[the generated licenceRef]:[the generated returnReference]:2022-04-01:2023-03-31
  * - `returnReference` - `10031343`
  * - `startDate` - 2022-04-01
  * - `endDate` - 2022-05-06
@@ -53,11 +53,11 @@ function add (data = {}) {
  */
 function defaults (data = {}) {
   const licenceRef = data.licenceRef ? data.licenceRef : generateLicenceRef()
-  const returnRequirement = data.returnRequirement ? data.returnRequirement : randomInteger(10000000, 19999999)
+  const returnReference = data.returnReference ? data.returnReference : randomInteger(10000000, 19999999)
 
   const defaults = {
     id: generateUUID(),
-    returnId: generateReturnLogId('2022-04-01', '2023-03-31', 1, licenceRef, returnRequirement),
+    returnId: generateReturnLogId('2022-04-01', '2023-03-31', 1, licenceRef, returnReference),
     returnReference: '10031343',
     startDate: new Date('2022-04-01'),
     endDate: new Date('2022-05-06'),


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4378

Whilst working on two-part tariff we have noticed that the column in the `return_log` view called `return_requirement` is called "Return reference" in the service.

We are therefore going to rename the `return_requirement` column in the view to `return_reference` so that it is the same as in the service.