### PR TITLE
Add submit cancel bill run endpoint

### DIFF
--- a/app/controllers/bill-runs.controller.js
+++ b/app/controllers/bill-runs.controller.js
@@ -9,10 +9,11 @@ const Boom = require('@hapi/boom')
 
 const CancelBillRunService = require('../services/bill-runs/cancel-bill-run.service.js')
 const CreateBillRunValidator = require('../validators/create-bill-run.validator.js')
-const StartBillRunProcessService = require('../services/bill-runs/start-bill-run-process.service.js')
-const ViewBillRunService = require('../services/bill-runs/view-bill-run.service.js')
 const ReviewBillRunService = require('../services/bill-runs/two-part-tariff/review-bill-run.service.js')
 const ReviewLicenceService = require('../services/bill-runs/two-part-tariff/review-licence.service.js')
+const StartBillRunProcessService = require('../services/bill-runs/start-bill-run-process.service.js')
+const SubmitCancelBillRunService = require('../services/bill-runs/submit-cancel-bill-run.service.js')
+const ViewBillRunService = require('../services/bill-runs/view-bill-run.service.js')
 
 async function cancel (request, h) {
   const { id } = request.params
@@ -67,6 +68,26 @@ async function reviewLicence (request, h) {
   })
 }
 
+async function submitCancel (request, h) {
+  const { id } = request.params
+
+  try {
+    // NOTE: What we are awaiting here is for the SubmitCancelBillRunService to update the status of the bill run to
+    // `cancel'. If the bill run run is deemed small enough, we'll also wait for the cancelling to complete before
+    // we redirect. This avoids users always having to refresh the bill runs page to get rid of bill runs that have
+    // finished cancelling 1 second after the request is submitted.
+    //
+    // But for larger bill runs, especially annual, after the bill run status has been updated control will be returned
+    // to here and the cancel process will then happen in the background. Because of this if we didn't wrap the call
+    // in a try/catch and the process errored, we'd get an unhandled exception which will bring the service down!
+    await SubmitCancelBillRunService.go(id)
+
+    return h.redirect('/billing/batch/list')
+  } catch (error) {
+    return Boom.badImplementation(error.message)
+  }
+}
+
 async function view (request, h) {
   const { id } = request.params
 
@@ -97,5 +118,6 @@ module.exports = {
   create,
   review,
   reviewLicence,
+  submitCancel,
   view
 }

--- a/app/controllers/bill-runs.controller.js
+++ b/app/controllers/bill-runs.controller.js
@@ -31,7 +31,7 @@ async function create (request, h) {
   const validatedData = CreateBillRunValidator.go(request.payload)
 
   if (validatedData.error) {
-    return _formattedValidationError(validatedData.error)
+    return Boom.badRequest(validatedData.error.details[0].message)
   }
 
   try {
@@ -40,7 +40,7 @@ async function create (request, h) {
 
     return h.response(result).code(200)
   } catch (error) {
-    return _formattedInitiateBillRunError(error)
+    return Boom.badImplementation(error.message)
   }
 }
 
@@ -97,20 +97,6 @@ async function view (request, h) {
     activeNavBar: 'bill-runs',
     ...pageData
   })
-}
-
-/**
- * Takes an error from a validator and returns a suitable Boom error
-*/
-function _formattedValidationError (error) {
-  return Boom.badRequest(error.details[0].message)
-}
-
-/**
- * Takes an error thrown during operation and returns a suitable Boom error
- */
-function _formattedInitiateBillRunError (error) {
-  return Boom.badImplementation(error.message)
 }
 
 module.exports = {

--- a/app/routes/bill-runs.routes.js
+++ b/app/routes/bill-runs.routes.js
@@ -46,6 +46,19 @@ const routes = [
     }
   },
   {
+    method: 'POST',
+    path: '/bill-runs/{id}/cancel',
+    handler: BillRunsController.submitCancel,
+    options: {
+      auth: {
+        access: {
+          scope: ['billing']
+        }
+      },
+      description: 'Submit bill run cancellation'
+    }
+  },
+  {
     method: 'GET',
     path: '/bill-runs/{id}/review',
     handler: BillRunsController.review,

--- a/app/services/bill-runs/submit-cancel-bill-run.service.js
+++ b/app/services/bill-runs/submit-cancel-bill-run.service.js
@@ -1,0 +1,218 @@
+'use strict'
+
+/**
+ * Orchestrates the cancelling of a bill run
+ * @module SubmitCancelBillRunService
+ */
+
+const BillModel = require('../../models/bill.model.js')
+const BillLicenceModel = require('../../models/bill-licence.model.js')
+const BillRunModel = require('../../models/bill-run.model.js')
+const BillRunChargeVersionYearModel = require('../../models/bill-run-charge-version-year.model.js')
+const BillRunVolumeModel = require('../../models/bill-run-volume.model.js')
+const { db } = require('../../../db/db.js')
+const ChargingModuleDeleteBillRunService = require('../charging-module/delete-bill-run.service.js')
+const { calculateAndLogTimeTaken, timestampForPostgres } = require('../../lib/general.lib.js')
+const ReviewChargeElementResultModel = require('../../models/review-charge-element-result.model.js')
+const ReviewResultModel = require('../../models/review-result.model.js')
+const ReviewReturnResultModel = require('../../models/review-return-result.model.js')
+
+/**
+ * Orchestrates the cancelling of a bill run
+ *
+ * After checking that the bill run has a status that can be cancelled (sending and sent bill runs cannot be cancelled)
+ * we set the status of the bill run to `cancel`. At this point we return control to the controller so that it can
+ * redirect the user to the bill runs page.
+ *
+ * Meantime now in the background, we send a request to the Charging Module API to delete the bill run there. Then we
+ * delete all details of the bill run from our tables.
+ *
+ * Where possible we do these in parallel to speed up the process. We also are not to fussed about errors. For example,
+ * if the CHA returns an error we don't stop the process as an orphaned CHA bill run won't impact us.
+ *
+ * The final thing worth noting that due to the number of constraints placed on the legacy tables deleting records can
+ * take some time. For example, an Anglian annual bill run in production will take more than 30 mins to delete
+ * everything.
+ *
+ * @param {string} billRunId  - UUID of the bill run to be cancelled
+ *
+ * @returns {Promise} the promise returned is not intended to resolve to any particular value
+ */
+async function go (billRunId) {
+  const billRun = await _fetchBillRun(billRunId)
+
+  const cannotBeDeleted = _cannotBeDeleted(billRun.status)
+  if (cannotBeDeleted) {
+    return
+  }
+
+  await _updateStatusToCancel(billRunId)
+
+  _cancelBillRun(billRun)
+}
+
+async function _cancelBillRun (billRun) {
+  const startTime = process.hrtime.bigint()
+
+  const { id: billRunId, externalId } = billRun
+
+  // Within the scope of this method we await all 3 processes to complete and then log the time taken. For a small
+  // supplementary bill run the request to the charge module might be the one that takes the longest. In the case of
+  // an annual bill run it will be removing the bill run. Either way, all 3 processes can be run in parallel as none of
+  // them have a dependence on the other
+  await Promise.all([
+    // If the Charging Module errors whilst doing this it shouldn't block us carrying on with deleting the bill run on
+    // our side. It just means the the CHA will be storing an 'orphaned' bill run that will never get sent.
+    ChargingModuleDeleteBillRunService.go(externalId),
+    // We can be deleting these records whilst getting on with deleting the other things. But should it fail we'll just
+    // be left with orphaned review results. As long as it's an incidental occurrence this wouldn't be a problem.
+    _removeReviewResults(billRunId),
+    // Finally we get on with deleting the billing records which in some cases (Anglian annual bill run) can take more
+    // than 30 mins!
+    _removeBillingRecords(billRunId)
+  ])
+
+  calculateAndLogTimeTaken(startTime, 'Cancel bill run complete', { billRunId })
+}
+
+function _cannotBeDeleted (status) {
+  // NOTE: We have intentionally left 'cancel' out of the list of statuses. Arguably, you shouldn't be able to cancel
+  // a bill run that is already being cancelled!
+  //
+  // But we know that there are existing 'stuck' cancelling bill runs at the time this gets shipped. Plus should an
+  // error cause any future cancelling bill runs this will give us a 'backdoor' means of trying to remove them again.
+  //
+  // Because our version of cancel bill run redirects the user to the bill runs page as soon as the status is set it
+  // is only by intention that someone could get back to the cancel bill run page. But it is this we intend to exploit
+  // to clear up existing stuck bill runs and deal with any of our own in future!
+  const invalidStatusesForDeleting = ['sending', 'sent']
+
+  return invalidStatusesForDeleting.includes(status)
+}
+
+/**
+ * This service handles the POST request from the confirm cancel bill run page. We _could_ have included the the
+ * externalId as a hidden field in the form and included it in the request. This would give the impression we could
+ * avoid a query to the DB.
+ *
+ * But we need to ensure no one exploits the `POST /bill-runs/{id}/cancel` endpoint to try and delete a 'sent' bill
+ * run. So, we always have to fetch the bill run to check its status is not one that prevents us deleting it.
+ */
+async function _fetchBillRun (id) {
+  return BillRunModel.query()
+    .findById(id)
+    .select([
+      'id',
+      'externalId',
+      'status'
+    ])
+}
+
+/**
+ * These deals with all the tables that may be populated for a bill run. Because we have to deal with bills created
+ * using the legacy engine and the new engine there will be times where a table won't have any records. But as this
+ * won't effect the outcome we dispense with checking the scheme or type and just get on with clearing all tables to
+ * keep the process simpler.
+ *
+ * Some tables have to be cleared before others because of foreign key constraints the previous team added. Those along
+ * with other constraints are why clearing the billing tables can take more than 30 mins!!
+ *
+ * Transactions have to be deleted before bill licences. Bill licences have to be cleared before bills. Bills, batch
+ * charge version years, and bill run volumes have to be cleared before we can delete the bill run. But we can do
+ * those in parallel.
+ */
+async function _removeBillingRecords (billRunId) {
+  try {
+    // NOTE: This needs to run first but is also typically the one that takes the longest to complete. In production
+    // deleting the transactions for an Anglian annual bill run can take more than 30 mins!!
+    await _removeBillRunTransactions(billRunId)
+
+    await _removeBillLicences(billRunId)
+
+    await Promise.all([
+      _removeBills(billRunId),
+      _removeBillRunChargeVersionYears(billRunId),
+      _removeBillRunVolumes(billRunId)
+    ])
+
+    // We can now finally delete the bill run record
+    await BillRunModel.query().deleteById(billRunId)
+  } catch (error) {
+    global.GlobalNotifier.omfg('Failed to remove billing records', { billRunId }, error)
+  }
+}
+
+async function _removeBills (billRunId) {
+  return BillModel.query().delete().where('billRunId', billRunId)
+}
+
+async function _removeBillLicences (billRunId) {
+  return BillLicenceModel.query()
+    .delete()
+    .whereExists(BillLicenceModel.relatedQuery('bill').where('bill.billRunId', billRunId))
+}
+
+async function _removeBillRunChargeVersionYears (billRunId) {
+  return BillRunChargeVersionYearModel.query().delete().where('billRunId', billRunId)
+}
+
+/**
+ * We've opted to do this particular query using knex raw rather than via the Objection models due to the need for
+ * multiple joins.
+ */
+async function _removeBillRunTransactions (billRunId) {
+  return db.raw(`
+    DELETE FROM water.billing_transactions WHERE billing_transaction_id IN (
+      SELECT bt.billing_transaction_id FROM water.billing_transactions bt
+      INNER JOIN water.billing_invoice_licences bil ON bil.billing_invoice_licence_id = bt.billing_invoice_licence_id
+      INNER JOIN water.billing_invoices bi ON bi.billing_invoice_id = bil.billing_invoice_id
+      WHERE
+        bi.billing_batch_id = ?
+    );
+  `, billRunId
+  )
+}
+
+async function _removeBillRunVolumes (billRunId) {
+  return BillRunVolumeModel.query().delete().where('billRunId', billRunId)
+}
+
+/**
+ * We always call this function as part of cancelling a bill run. However, there will only be records if the bill run
+ * is an SROC tw-part tariff bill run in 'review'.
+ */
+async function _removeReviewResults (billRunId) {
+  try {
+    const deleteChargeElementsProcess = ReviewChargeElementResultModel.query()
+      .delete()
+      .whereExists(ReviewChargeElementResultModel
+        .relatedQuery('reviewResults')
+        .where('reviewResults.billRunId', billRunId)
+      )
+
+    const deleteReturnsProcess = ReviewReturnResultModel.query()
+      .delete()
+      .whereExists(ReviewReturnResultModel
+        .relatedQuery('reviewResults')
+        .where('reviewResults.billRunId', billRunId)
+      )
+
+    // To help performance we allow both these processes to run in parallel. Because their where clause depends on
+    // `review_results` we have to wait for them to complete before we proceed.
+    await Promise.all([deleteChargeElementsProcess, deleteReturnsProcess])
+
+    return ReviewResultModel.query().delete().where('billRunId', billRunId)
+  } catch (error) {
+    global.GlobalNotifier.omfg('Failed to remove review results', { billRunId }, error)
+  }
+}
+
+async function _updateStatusToCancel (billRunId) {
+  return BillRunModel.query()
+    .findById(billRunId)
+    .patch({ status: 'cancel', updatedAt: timestampForPostgres() })
+}
+
+module.exports = {
+  go
+}

--- a/test/services/bill-runs/submit-cancel-bill-run.service.test.js
+++ b/test/services/bill-runs/submit-cancel-bill-run.service.test.js
@@ -1,0 +1,152 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { describe, it, beforeEach, afterEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const { setTimeout } = require('timers/promises')
+
+const BillHelper = require('../../support/helpers/bill.helper.js')
+const BillModel = require('../../../app/models/bill.model.js')
+const BillLicenceHelper = require('../../support/helpers/bill-licence.helper.js')
+const BillLicenceModel = require('../../../app/models/bill-licence.model.js')
+const BillRunHelper = require('../../support/helpers/bill-run.helper.js')
+const BillRunModel = require('../../../app/models/bill-run.model.js')
+const BillRunChargeVersionYearHelper = require('../../support/helpers/bill-run-charge-version-year.helper.js')
+const BillRunChargeVersionYearModel = require('../../../app/models/bill-run-charge-version-year.model.js')
+const BillRunVolumeHelper = require('../../support/helpers/bill-run-volume.helper.js')
+const BillRunVolumeModel = require('../../../app/models/bill-run-volume.model.js')
+const DatabaseHelper = require('../../support/helpers/database.helper.js')
+const ReviewChargeElementResultHelper = require('../../support/helpers/review-charge-element-result.helper.js')
+const ReviewChargeElementResultModel = require('../../../app/models/review-charge-element-result.model.js')
+const ReviewResultHelper = require('../../support/helpers/review-result.helper.js')
+const ReviewResultModel = require('../../../app/models/review-result.model.js')
+const ReviewReturnResultHelper = require('../../support/helpers/review-return-result.helper.js')
+const ReviewReturnResultModel = require('../../../app/models/review-return-result.model.js')
+const TransactionHelper = require('../../support/helpers/transaction.helper.js')
+const TransactionModel = require('../../../app/models/transaction.model.js')
+
+// Things we need to stub
+const ChargingModuleDeleteBillRunService = require('../../../app/services/charging-module/delete-bill-run.service.js')
+
+// Thing under test
+const SubmitCancelBillBunService = require('../../../app/services/bill-runs/submit-cancel-bill-run.service.js')
+
+describe('Submit Cancel Bill Run service', () => {
+  let chargingModuleDeleteBillRunServiceStub
+  let notifierStub
+
+  beforeEach(async () => {
+    await DatabaseHelper.clean()
+
+    chargingModuleDeleteBillRunServiceStub = Sinon.stub(ChargingModuleDeleteBillRunService, 'go')
+  })
+
+  afterEach(() => {
+    Sinon.restore()
+  })
+
+  describe('when the bill run exists', () => {
+    let billRun
+
+    describe('and can be deleted', () => {
+      beforeEach(async () => {
+        billRun = await BillRunHelper.add({ status: 'ready' })
+
+        const { id: billRunId } = billRun
+
+        // Add records to all the tables the service deletes from
+        const { id: reviewChargeElementResultId } = await ReviewChargeElementResultHelper.add()
+        const { id: reviewReturnResultId } = await ReviewReturnResultHelper.add()
+        await ReviewResultHelper.add({ billRunId, reviewChargeElementResultId, reviewReturnResultId })
+        await BillRunChargeVersionYearHelper.add({ billRunId })
+        await BillRunVolumeHelper.add({ billRunId })
+        const { id: billId } = await BillHelper.add({ billRunId })
+        const { id: billLicenceId } = await BillLicenceHelper.add({ billId })
+        await TransactionHelper.add({ billLicenceId })
+
+        chargingModuleDeleteBillRunServiceStub.resolves()
+
+        // The service depends on GlobalNotifier to have been set. This happens in app/plugins/global-notifier.plugin.js
+        // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
+        // test we recreate the condition by setting it directly with our own stub
+        notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
+        global.GlobalNotifier = notifierStub
+      })
+
+      it('sends a request to the Charging Module API to delete its copy', async () => {
+        await SubmitCancelBillBunService.go(billRun.id)
+
+        // NOTE: introducing a delay in the test is not ideal. But the service is written such that the deletion happens
+        // in the background and is not awaited. We want to confirm the tables have been cleared. But the only way to do
+        // so is to give the background process time to complete.
+        await setTimeout(500)
+
+        expect(chargingModuleDeleteBillRunServiceStub.called).to.be.true()
+      })
+
+      it('deletes any two-part tariff review data', async () => {
+        await SubmitCancelBillBunService.go(billRun.id)
+
+        await setTimeout(500)
+
+        const reviewChargeElementResultCount = await ReviewChargeElementResultModel.query().select('id').resultSize()
+        const reviewResultCount = await ReviewResultModel.query().select('id').resultSize()
+        const reviewReturnResultCount = await ReviewReturnResultModel.query().select('id').resultSize()
+
+        expect(reviewChargeElementResultCount).to.equal(0)
+        expect(reviewResultCount).to.equal(0)
+        expect(reviewReturnResultCount).to.equal(0)
+      })
+
+      it('deletes any billing data data', async () => {
+        await SubmitCancelBillBunService.go(billRun.id)
+
+        await setTimeout(500)
+
+        const billRunChargeVersionYearCount = await BillRunChargeVersionYearModel.query().select('id').resultSize()
+        const billRunVolumeCount = await BillRunVolumeModel.query().select('id').resultSize()
+        const transactionCount = await TransactionModel.query().select('id').resultSize()
+        const billLicenceCount = await BillLicenceModel.query().select('id').resultSize()
+        const billCount = await BillModel.query().select('id').resultSize()
+        const billRunCount = await BillRunModel.query().select('id').resultSize()
+
+        expect(billRunChargeVersionYearCount).to.equal(0)
+        expect(billRunVolumeCount).to.equal(0)
+        expect(transactionCount).to.equal(0)
+        expect(billLicenceCount).to.equal(0)
+        expect(billCount).to.equal(0)
+        expect(billRunCount).to.equal(0)
+      })
+    })
+
+    describe('but cannot be deleted because of its status', () => {
+      beforeEach(async () => {
+        billRun = await BillRunHelper.add({ status: 'sent' })
+      })
+
+      it('does nothing', async () => {
+        await SubmitCancelBillBunService.go(billRun.id)
+
+        const refreshedBillRun = await billRun.$query()
+
+        expect(refreshedBillRun).to.exist()
+        expect(refreshedBillRun.status).to.equal('sent')
+        expect(chargingModuleDeleteBillRunServiceStub.called).to.be.false()
+      })
+    })
+  })
+
+  describe('when the bill run does not exist', () => {
+    it('throws as error', async () => {
+      await expect(SubmitCancelBillBunService.go('testId'))
+        .to
+        .reject()
+    })
+  })
+})


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4387

We need to add this to support our work to improve how bill runs are cancelled. Basically, replace the crummy legacy one!

In [Add cancel bill run page](https://github.com/DEFRA/water-abstraction-system/pull/780) we add the page where the user confirms they want to cancel (delete) the bill run.

This final step implements the service that will do the cancelling and the endpoint to trigger it.

Unlike the legacy version when we cancel a bill run, we'll

- immediately update the bill run status to `cancel`
- redirect the user to the bill runs page
- continue the process of cancelling the bill run in the background

This way the user should never see a timeout waiting for a bill run to cancel ever again. It also puts the service into a state where we can start to display to users that a bill run is in the process of being cancelled, the end goal of WATER-4387.