### PR TITLE
Fix badge for empty status

### DIFF
--- a/app/views/bill-runs/cancel.njk
+++ b/app/views/bill-runs/cancel.njk
@@ -5,7 +5,7 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
 
-{% from "macros/badge.njk" import badge %}
+{% from "macros/badge.njk" import statusBadge %}
 
 {% block breadcrumbs %}
   {# Back link #}
@@ -29,13 +29,8 @@
     <div class="govuk-grid-column-full">
 
       {# Status badge #}
-      {% if billRunStatus === 'ready' %}
-        {% set badgeType = 'info' %}
-      {% elif billRunStatus === 'sent' %}
-        {% set badgeType = 'success' %}
-      {% endif %}
       <p class="govuk-body">
-        {{ badge(billRunStatus, badgeType) }}
+        {{ statusBadge(billRunStatus) }}
       </p>
 
       {# Bill run meta-data #}

--- a/app/views/bill-runs/empty.njk
+++ b/app/views/bill-runs/empty.njk
@@ -4,7 +4,7 @@
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 
-{% from "macros/badge.njk" import badge %}
+{% from "macros/badge.njk" import statusBadge %}
 
 {% block breadcrumbs %}
   {# Back link #}
@@ -39,13 +39,8 @@
     <div class="govuk-grid-column-full">
 
       {# Status badge #}
-      {% if billRunStatus === 'ready' %}
-        {% set badgeType = 'info' %}
-      {% elif billRunStatus === 'sent' %}
-        {% set badgeType = 'success' %}
-      {% endif %}
       <p class="govuk-body">
-        {{ badge(billRunStatus, badgeType) }}
+        {{ statusBadge(billRunStatus) }}
       </p>
 
       {# Bill run meta-data #}

--- a/app/views/bill-runs/view.njk
+++ b/app/views/bill-runs/view.njk
@@ -5,7 +5,7 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
 
-{% from "macros/badge.njk" import badge %}
+{% from "macros/badge.njk" import statusBadge %}
 
 {% block breadcrumbs %}
   {# Back link #}
@@ -29,13 +29,8 @@
     <div class="govuk-grid-column-full">
 
       {# Status badge #}
-      {% if billRunStatus === 'ready' %}
-        {% set badgeType = 'info' %}
-      {% elif billRunStatus === 'sent' %}
-        {% set badgeType = 'success' %}
-      {% endif %}
       <p class="govuk-body">
-        {{ badge(billRunStatus, badgeType) }}
+        {{ statusBadge(billRunStatus) }}
       </p>
 
       {# Bill run meta-data #}

--- a/app/views/bills/view-multi-licence.njk
+++ b/app/views/bills/view-multi-licence.njk
@@ -6,7 +6,7 @@
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 
-{% from "macros/badge.njk" import badge %}
+{% from "macros/badge.njk" import statusBadge %}
 
 {% block breadcrumbs %}
   {# Back link #}
@@ -30,13 +30,8 @@
     <div class="govuk-grid-column-full">
 
       {# Status badge #}
-      {% if billRunStatus === 'ready' %}
-        {% set badgeType = 'info' %}
-      {% elif billRunStatus === 'sent' %}
-        {% set badgeType = 'success' %}
-      {% endif %}
       <p class="govuk-body">
-        {{ badge(billRunStatus, badgeType) }}
+        {{ statusBadge(billRunStatus) }}
       </p>
 
       {# Bill meta-data #}

--- a/app/views/bills/view-single-licence-presroc.njk
+++ b/app/views/bills/view-single-licence-presroc.njk
@@ -6,7 +6,7 @@
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 
-{% from "macros/badge.njk" import badge %}
+{% from "macros/badge.njk" import statusBadge %}
 
 {% block breadcrumbs %}
   {# Back link #}
@@ -30,13 +30,8 @@
     <div class="govuk-grid-column-full">
 
       {# Status badge #}
-      {% if billRunStatus === 'ready' %}
-        {% set badgeType = 'info' %}
-      {% elif billRunStatus === 'sent' %}
-        {% set badgeType = 'success' %}
-      {% endif %}
       <p class="govuk-body">
-        {{ badge(billRunStatus, badgeType) }}
+        {{ statusBadge(billRunStatus) }}
       </p>
 
       {# Bill meta-data #}

--- a/app/views/bills/view-single-licence-sroc.njk
+++ b/app/views/bills/view-single-licence-sroc.njk
@@ -6,7 +6,7 @@
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 
-{% from "macros/badge.njk" import badge %}
+{% from "macros/badge.njk" import statusBadge %}
 
 {% block breadcrumbs %}
   {# Back link #}
@@ -30,13 +30,8 @@
     <div class="govuk-grid-column-full">
 
       {# Status badge #}
-      {% if billRunStatus === 'ready' %}
-        {% set badgeType = 'info' %}
-      {% elif billRunStatus === 'sent' %}
-        {% set badgeType = 'success' %}
-      {% endif %}
       <p class="govuk-body">
-        {{ badge(billRunStatus, badgeType) }}
+        {{ statusBadge(billRunStatus) }}
       </p>
 
       {# Bill meta-data #}

--- a/app/views/macros/badge.njk
+++ b/app/views/macros/badge.njk
@@ -22,3 +22,15 @@
     })
   }}
 {% endmacro %}
+
+{% macro statusBadge(status) %}
+  {% if status === 'ready' %}
+    {% set badgeType = 'info' %}
+  {% elif status === 'sent' %}
+    {% set badgeType = 'success' %}
+  {% elif status === 'empty' %}
+    {% set badgeType = 'inactive' %}
+  {% endif %}
+
+  {{ badge(status, badgeType) }}
+{% endmacro %}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4396

Unfortunately, we only spotted after [migrating the view empty bill run page](https://github.com/DEFRA/water-abstraction-system/pull/783) from the legacy service to this one that the status badge was wrong.

It should be styled as a grey badge (inactive) but we were displaying it as blue (info). Fixing it required adding an if/else check into 2 views which made us re-think how we were doing the bill run status badges.

So, in this change we fix the badge for `empty` and along the way, we add a new `statusBadge()` macro that moves the logic of converting bill run status into badge type to one place.