### PR TITLE
Migrate view errored bill run page

### DIFF
--- a/app/presenters/bill-runs/empty-bill-run-presenter.js
+++ b/app/presenters/bill-runs/empty-bill-run-presenter.js
@@ -19,7 +19,7 @@ const {
  *
  * @param {module:BillRunModel} billRun - an instance of `BillRunModel`
  *
- * @returns {Object} - the prepared bill run data to be passed to the cancel bill run confirmation page
+ * @returns {Object} - the prepared bill run data to be passed to the empty bill run page
  */
 function go (billRun) {
   const {

--- a/app/presenters/bill-runs/errored-bill-run-presenter.js
+++ b/app/presenters/bill-runs/errored-bill-run-presenter.js
@@ -1,0 +1,52 @@
+'use strict'
+
+/**
+ * Formats the bill run data ready for presenting in the errored bill run page
+ * @module ErroredBillRunPresenter
+ */
+
+const {
+  capitalize,
+  generateBillRunTitle,
+  formatBillRunType,
+  formatChargeScheme,
+  formatFinancialYear,
+  formatLongDate
+} = require('../base.presenter.js')
+
+/**
+ * Prepares and processes bill run data for presentation
+ *
+ * @param {module:BillRunModel} billRun - an instance of `BillRunModel`
+ *
+ * @returns {Object} - the prepared bill run data to be passed to the errored bill run page
+ */
+function go (billRun) {
+  const {
+    batchType,
+    billRunNumber,
+    createdAt,
+    id,
+    region,
+    scheme,
+    status,
+    summer,
+    toFinancialYearEnding
+  } = billRun
+
+  return {
+    billRunId: id,
+    billRunNumber,
+    billRunStatus: status,
+    billRunType: formatBillRunType(batchType, scheme, summer),
+    chargeScheme: formatChargeScheme(scheme),
+    dateCreated: formatLongDate(createdAt),
+    financialYear: formatFinancialYear(toFinancialYearEnding),
+    pageTitle: generateBillRunTitle(region.displayName, batchType, scheme, summer),
+    region: capitalize(region.displayName)
+  }
+}
+
+module.exports = {
+  go
+}

--- a/app/presenters/bill-runs/errored-bill-run-presenter.js
+++ b/app/presenters/bill-runs/errored-bill-run-presenter.js
@@ -26,6 +26,7 @@ function go (billRun) {
     batchType,
     billRunNumber,
     createdAt,
+    errorCode,
     id,
     region,
     scheme,
@@ -41,10 +42,35 @@ function go (billRun) {
     billRunType: formatBillRunType(batchType, scheme, summer),
     chargeScheme: formatChargeScheme(scheme),
     dateCreated: formatLongDate(createdAt),
+    errorMessage: _errorMessage(errorCode),
     financialYear: formatFinancialYear(toFinancialYearEnding),
     pageTitle: generateBillRunTitle(region.displayName, batchType, scheme, summer),
     region: capitalize(region.displayName)
   }
+}
+
+function _errorMessage (errorCode) {
+  const errors = [
+    { code: 10, message: 'Error when populating the charge versions.' },
+    { code: 20, message: 'Error when processing the charge versions.' },
+    { code: 30, message: 'Error when preparing the transactions.' },
+    { code: 40, message: 'Error when requesting or processing a transaction charge.' },
+    { code: 50, message: 'Error when creating the Charging Module bill run.' },
+    { code: 60, message: 'Error when deleting an invoice.' },
+    { code: 70, message: 'Error when processing two-part tariff.' },
+    { code: 80, message: 'Error when getting the Charging Module bill run summary.' },
+    { code: 90, message: 'Error when re-billing a bill run.' }
+  ]
+
+  const matchingError = errors.find((error) => {
+    return error.code === errorCode
+  })
+
+  if (matchingError) {
+    return matchingError.message
+  }
+
+  return 'No error code was assigned. We have no further information at this time.'
 }
 
 module.exports = {

--- a/app/services/bill-runs/fetch-bill-run.service.js
+++ b/app/services/bill-runs/fetch-bill-run.service.js
@@ -38,6 +38,7 @@ async function _fetchBillRun (id) {
       'createdAt',
       'creditNoteCount',
       'creditNoteValue',
+      'errorCode',
       'invoiceCount',
       'invoiceValue',
       'summer',

--- a/app/services/bill-runs/view-bill-run.service.js
+++ b/app/services/bill-runs/view-bill-run.service.js
@@ -6,6 +6,7 @@
  */
 
 const EmptyBillRunPresenter = require('../../presenters/bill-runs/empty-bill-run-presenter.js')
+const ErroredBillRunPresenter = require('../../presenters/bill-runs/errored-bill-run-presenter.js')
 const ViewBillRunPresenter = require('../../presenters/bill-runs/view-bill-run.presenter.js')
 const ViewBillSummariesPresenter = require('../../presenters/bill-runs/view-bill-summaries.presenter.js')
 const FetchBillRunService = require('./fetch-bill-run.service.js')
@@ -33,6 +34,13 @@ function _pageData (fetchResult) {
     return {
       view: 'bill-runs/empty.njk',
       ...EmptyBillRunPresenter.go(billRun)
+    }
+  }
+
+  if (billRun.status === 'error') {
+    return {
+      view: 'bill-runs/errored.njk',
+      ...ErroredBillRunPresenter.go(billRun)
     }
   }
 

--- a/app/views/bill-runs/errored.njk
+++ b/app/views/bill-runs/errored.njk
@@ -1,0 +1,93 @@
+{% extends 'layout.njk' %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+
+{% from "macros/badge.njk" import statusBadge %}
+
+{% block breadcrumbs %}
+  {# Back link #}
+  {{
+    govukBackLink({
+      text: 'Go back to bill runs',
+      href: '/billing/batch/list'
+    })
+  }}
+{% endblock %}
+
+{% block content %}
+  {# Error notification #}
+  {{
+    govukErrorSummary({
+      titleText: "There is a problem",
+      errorList: [{
+        text: errorMessage
+      }],
+      attributes: { 'data-test': 'error-notification' }
+    })
+  }}
+
+  {# Main heading #}
+  <div class="govuk-body">
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">
+      <span class="govuk-caption-l">Bill run {{ billRunNumber }}</span>{{ pageTitle }}
+    </h1>
+  </div>
+
+  <div class="govuk-grid-row govuk-!-margin-bottom-0">
+    <div class="govuk-grid-column-full">
+
+      {# Status badge #}
+      <p class="govuk-body">
+        {{ statusBadge(billRunStatus) }}
+      </p>
+
+      {# Bill run meta-data #}
+      {#
+        GOV.UK summary lists only allow us to assign attributes at the top level and not to each row. This means we
+        can't assign our data-test attribute using the component. Our solution is to use the html option for each row
+        instead of text and wrap each value in a <span>. That way we can manually assign our data-test attribute to the
+        span.
+      #}
+      {{
+        govukSummaryList({
+          classes: 'govuk-summary-list--no-border',
+          attributes: {
+            'data-test': 'meta-data'
+          },
+          rows: [
+            {
+              key: { text: "Date created", classes: "meta-data__label" },
+              value: { html: '<span data-test="meta-data-created">' + dateCreated + '</span>', classes: "meta-data__value" }
+            },
+            {
+              key: { text: "Region", classes: "meta-data__label" },
+              value: { html: '<span data-test="meta-data-region">' + region + '</span>', classes: "meta-data__value" }
+            },
+            {
+              key: { text: "Bill run type", classes: "meta-data__label" },
+              value: { html: '<span data-test="meta-data-type">' + billRunType + '</span>', classes: "meta-data__value" }
+            },
+            {
+              key: { text: "Charge scheme", classes: "meta-data__label" },
+              value: { html: '<span data-test="meta-data-scheme">' + chargeScheme + '</span>', classes: "meta-data__value" }
+            },
+            {
+              key: { text: "Financial year", classes: "meta-data__label" },
+              value: { html: '<span data-test="meta-data-year">' + financialYear + '</span>', classes: "meta-data__value" }
+            }
+          ]
+        })
+      }}
+
+      {{
+        govukButton({
+          classes: "govuk-button--secondary",
+          text: "Cancel bill run",
+          href: '/system/bill-runs/' + billRunId + '/cancel'
+        })
+      }}
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/macros/badge.njk
+++ b/app/views/macros/badge.njk
@@ -30,6 +30,8 @@
     {% set badgeType = 'success' %}
   {% elif status === 'empty' %}
     {% set badgeType = 'inactive' %}
+  {% elif status === 'error' %}
+    {% set badgeType = 'error' %}
   {% endif %}
 
   {{ badge(status, badgeType) }}

--- a/test/presenters/bill-runs/errored-bill-run.presenter.test.js
+++ b/test/presenters/bill-runs/errored-bill-run.presenter.test.js
@@ -1,0 +1,54 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Thing under test
+const ErroredBillRunPresenter = require('../../../app/presenters/bill-runs/errored-bill-run-presenter.js')
+
+describe('Errored Bill Run presenter', () => {
+  let billRun
+
+  describe('when provided with a populated bill run', () => {
+    beforeEach(() => {
+      billRun = _testBillRun()
+    })
+
+    it('correctly presents the data', () => {
+      const result = ErroredBillRunPresenter.go(billRun)
+
+      expect(result).to.equal({
+        billRunId: '420e948f-1992-437e-8a47-74c0066cb017',
+        billRunNumber: 10010,
+        billRunStatus: 'error',
+        billRunType: 'Supplementary',
+        chargeScheme: 'Current',
+        dateCreated: '1 November 2023',
+        financialYear: '2023 to 2024',
+        pageTitle: 'Wales supplementary',
+        region: 'Wales'
+      })
+    })
+  })
+})
+
+function _testBillRun () {
+  return {
+    id: '420e948f-1992-437e-8a47-74c0066cb017',
+    batchType: 'supplementary',
+    billRunNumber: 10010,
+    summer: false,
+    scheme: 'sroc',
+    status: 'error',
+    toFinancialYearEnding: 2024,
+    createdAt: new Date('2023-11-01'),
+    region: {
+      id: 'f6c4699f-9a80-419a-82e7-f785ece727e1',
+      displayName: 'Wales'
+    }
+  }
+}

--- a/test/presenters/bill-runs/errored-bill-run.presenter.test.js
+++ b/test/presenters/bill-runs/errored-bill-run.presenter.test.js
@@ -28,9 +28,36 @@ describe('Errored Bill Run presenter', () => {
         billRunType: 'Supplementary',
         chargeScheme: 'Current',
         dateCreated: '1 November 2023',
+        errorMessage: 'Error when preparing the transactions.',
         financialYear: '2023 to 2024',
         pageTitle: 'Wales supplementary',
         region: 'Wales'
+      })
+    })
+
+    describe("the 'errorMessage' property", () => {
+      describe('when the bill run has an error code', () => {
+        beforeEach(() => {
+          billRun.errorCode = 80
+        })
+
+        it('returns the matching error message', () => {
+          const result = ErroredBillRunPresenter.go(billRun)
+
+          expect(result.errorMessage).to.equal('Error when getting the Charging Module bill run summary.')
+        })
+      })
+
+      describe('when the bill run does not have an error code', () => {
+        beforeEach(() => {
+          billRun.errorCode = null
+        })
+
+        it('returns the generic error message', () => {
+          const result = ErroredBillRunPresenter.go(billRun)
+
+          expect(result.errorMessage).to.equal('No error code was assigned. We have no further information at this time.')
+        })
       })
     })
   })
@@ -41,11 +68,12 @@ function _testBillRun () {
     id: '420e948f-1992-437e-8a47-74c0066cb017',
     batchType: 'supplementary',
     billRunNumber: 10010,
-    summer: false,
+    createdAt: new Date('2023-11-01'),
+    errorCode: 30,
     scheme: 'sroc',
     status: 'error',
+    summer: false,
     toFinancialYearEnding: 2024,
-    createdAt: new Date('2023-11-01'),
     region: {
       id: 'f6c4699f-9a80-419a-82e7-f785ece727e1',
       displayName: 'Wales'

--- a/test/services/bill-runs/view-bill-run.service.test.js
+++ b/test/services/bill-runs/view-bill-run.service.test.js
@@ -31,7 +31,7 @@ describe('View Bill Run service', () => {
         Sinon.stub(FetchBillRunService, 'go').resolves(fetchBillRunResult)
       })
 
-      it('will fetch the data and format it for use in the view bill run page', async () => {
+      it('will fetch the data and format it for use in the empty bill run page', async () => {
         const result = await ViewBillRunService.go(testId)
 
         expect(result).to.equal({
@@ -45,6 +45,33 @@ describe('View Bill Run service', () => {
           pageTitle: 'South West annual',
           region: 'South West',
           view: 'bill-runs/empty.njk'
+        })
+      })
+    })
+
+    describe("and it has a status of 'errored'", () => {
+      beforeEach(() => {
+        fetchBillRunResult = _singleGroupBillRun()
+        fetchBillRunResult.billRun.status = 'error'
+
+        Sinon.stub(FetchBillRunService, 'go').resolves(fetchBillRunResult)
+      })
+
+      it('will fetch the data and format it for use in the errored bill run page', async () => {
+        const result = await ViewBillRunService.go(testId)
+
+        expect(result).to.equal({
+          billRunId: '2c80bd22-a005-4cf4-a2a2-73812a9861de',
+          billRunNumber: 10003,
+          billRunStatus: 'error',
+          billRunType: 'Annual',
+          chargeScheme: 'Current',
+          dateCreated: '7 March 2023',
+          errorMessage: 'No error code was assigned. We have no further information at this time.',
+          financialYear: '2022 to 2023',
+          pageTitle: 'South West annual',
+          region: 'South West',
+          view: 'bill-runs/errored.njk'
         })
       })
     })
@@ -189,6 +216,7 @@ function _multipleGroupBillRun () {
       billRunNumber: 10003,
       creditNoteCount: 0,
       creditNoteValue: 0,
+      errorCode: null,
       invoiceCount: 2,
       invoiceValue: 21327500,
       summer: false,
@@ -219,6 +247,7 @@ function _singleGroupBillRun () {
       billRunNumber: 10003,
       creditNoteCount: 0,
       creditNoteValue: 0,
+      errorCode: null,
       invoiceCount: 1,
       invoiceValue: 9700,
       summer: false,


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4396

This change migrates the handling of viewing an errored bill run from the legacy [water-abstraction-ui](https://github.com/DEFRA/water-abstraction-ui) to this project.

Because we've migrated the cancelling of a bill run to this project (WATER-4387) we need to update the legacy pages with a cancel button to point to it.

Or, as we choose to do, we replace them with our own!

This change deals with when the bill run has a status of `error` and the page that gets shown.