### PR TITLE
Remove unused frontend macros from cancel view

### DIFF
--- a/app/views/bill-runs/cancel.njk
+++ b/app/views/bill-runs/cancel.njk
@@ -1,9 +1,7 @@
 {% extends 'layout.njk' %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
-{% from "govuk/components/details/macro.njk" import govukDetails %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
-{% from "govuk/components/table/macro.njk" import govukTable %}
 
 {% from "macros/badge.njk" import statusBadge %}
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4387

We spotted a little too late that the `app/views/bill-runs/cancel.njk` view is importing macros it is not using. We know this was because of a copy and paste and doesn't break anything.

Still, we don't like to make a habit of importing things and then not using them.