### PR TITLE
Fix cancel back link to PRESROC 2pt review

### DIFF
--- a/app/presenters/bill-runs/cancel-bill-run.presenter.js
+++ b/app/presenters/bill-runs/cancel-bill-run.presenter.js
@@ -34,7 +34,7 @@ function go (billRun) {
   } = billRun
 
   return {
-    backLink: _backLink(id, status),
+    backLink: _backLink(id, scheme, status),
     billRunId: id,
     billRunNumber,
     billRunStatus: status,
@@ -46,8 +46,12 @@ function go (billRun) {
   }
 }
 
-function _backLink (id, status) {
+function _backLink (id, scheme, status) {
   if (status === 'review') {
+    if (scheme === 'alcs') {
+      return `/billing/batch/${id}/two-part-tariff-review`
+    }
+
     return `/system/bill-runs/${id}/review`
   }
 

--- a/app/views/bill-runs/cancel.njk
+++ b/app/views/bill-runs/cancel.njk
@@ -1,9 +1,7 @@
 {% extends 'layout.njk' %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
-{% from "govuk/components/details/macro.njk" import govukDetails %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
-{% from "govuk/components/table/macro.njk" import govukTable %}
 
 {% from "macros/badge.njk" import statusBadge %}
 

--- a/test/presenters/bill-runs/cancel-bill-run.presenter.test.js
+++ b/test/presenters/bill-runs/cancel-bill-run.presenter.test.js
@@ -40,10 +40,24 @@ describe('Cancel Bill Run presenter', () => {
           billRun.status = 'review'
         })
 
-        it('returns a link to the review page', () => {
-          const result = CancelBillRunPresenter.go(billRun)
+        describe('and the scheme is SROC', () => {
+          it('returns a link to the SROC review page', () => {
+            const result = CancelBillRunPresenter.go(billRun)
 
-          expect(result.backLink).to.equal('/system/bill-runs/420e948f-1992-437e-8a47-74c0066cb017/review')
+            expect(result.backLink).to.equal('/system/bill-runs/420e948f-1992-437e-8a47-74c0066cb017/review')
+          })
+        })
+
+        describe('and the scheme is PRESROC', () => {
+          beforeEach(() => {
+            billRun.scheme = 'alcs'
+          })
+
+          it('returns a link to the PRESROC review page', () => {
+            const result = CancelBillRunPresenter.go(billRun)
+
+            expect(result.backLink).to.equal('/billing/batch/420e948f-1992-437e-8a47-74c0066cb017/two-part-tariff-review')
+          })
         })
       })
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4387

To make cancelling bill runs more visible in the service we needed to re-implement the cancel bill run feature. Because we've also replaced all the legacy bill run pages we didn't think we'd need to deal with any legacy views.

That was until we spotted that the PRESROC two-part tariff review page is still alive and kicking in the service! You can cancel a bill run from that page so we must support going back to it in our confirm cancel bill run page.

This change makes that so.