### PR TITLE
Cancel a 2PT Bill Run from the Review Licences Screen

### DIFF
--- a/app/views/bill-runs/review.njk
+++ b/app/views/bill-runs/review.njk
@@ -114,6 +114,15 @@
     </section>
   {% endif %}
 
+  {# Cancel bill run button #}
+  <section class="govuk-!-margin-bottom-9">
+    {{ govukButton({
+      classes: "govuk-button--secondary govuk-!-margin-bottom-0",
+      text: 'Cancel bill run',
+      href: 'cancel'
+    }) }}
+  </section>
+
   {# Generate the row data for the table #}
   {% set tableRows = [] %}
     {% if preparedLicences.length > 0 %}
@@ -132,7 +141,7 @@
         {% endset %}
 
         {% set action %}
-        <a class="govuk-link" href="review/{{ licence.id }}">{{ licence.licenceRef }}<span class="govuk-visually-hidden">View licence matching for licence {{ licence.licenceRef }} </a>
+          <a class="govuk-link" href="review/{{ licence.id }}">{{ licence.licenceRef }}<span class="govuk-visually-hidden">View licence matching for licence {{ licence.licenceRef }} </a>
         {% endset %}
 
       {% set tableRow = [


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4189

Add a "Cancel bill run" button to the "Review licences" screen which was built in a previous PR https://github.com/DEFRA/water-abstraction-system/pull/663

On clicking the cancel button the user is taken to a confirmation screen displaying the header details of the bill run and a confirmation button to cancel the bill run.

Upon clicking the confirmation button the bill run should be deleted from the Charging Module & database, along with the data that has been persisted following the matching process.

All the code with the exception of adding the "Cancel" button to the review screen has been done in another PR https://github.com/DEFRA/water-abstraction-system/pull/780 

Therefore this PR is to just add the button to the "Review licences" screen.