### PR TITLE
Trigger two-part tariff annual bill run spike

### DIFF
--- a/app/controllers/bill-runs-create.controller.js
+++ b/app/controllers/bill-runs-create.controller.js
@@ -58,11 +58,11 @@ async function submitRegion (request, h) {
     })
   }
 
-  if (pageData.type.startsWith('two')) {
-    return h.redirect(`/system/bill-runs/create/${sessionId}/year`)
+  if (pageData.journeyComplete) {
+    return h.redirect('/billing/batch/list')
   }
 
-  return h.redirect('/billing/batch/list')
+  return h.redirect(`/system/bill-runs/create/${sessionId}/year`)
 }
 
 async function submitSeason (request, h) {

--- a/app/controllers/bill-runs-create.controller.js
+++ b/app/controllers/bill-runs-create.controller.js
@@ -1,0 +1,146 @@
+'use strict'
+
+/**
+ * Controller for /bill-runs/create endpoints
+ * @module BillRunsCreateController
+ */
+
+const InitiateSessionService = require('../services/bill-runs/create/initiate-session.service.js')
+const RegionService = require('../services/bill-runs/create/region.service.js')
+const TypeService = require('../services/bill-runs/create/type.service.js')
+const SeasonService = require('../services/bill-runs/create/season.service.js')
+const YearService = require('../services/bill-runs/create/year.service.js')
+const SubmitRegionService = require('../services/bill-runs/create/submit-region.service.js')
+const SubmitSeasonService = require('../services/bill-runs/create/submit-season.service.js')
+const SubmitTypeService = require('../services/bill-runs/create/submit-type.service.js')
+const SubmitYearService = require('../services/bill-runs/create/submit-year.service.js')
+
+async function create (_request, h) {
+  const session = await InitiateSessionService.go()
+
+  return h.redirect(`/system/bill-runs/create/${session.id}/type`)
+}
+
+async function region (request, h) {
+  const { sessionId } = request.params
+
+  const pageData = await RegionService.go(sessionId)
+
+  return h.view('bill-runs/create/region.njk', {
+    activeNavBar: 'bill-runs',
+    pageTitle: 'Select the region',
+    ...pageData
+  })
+}
+
+async function season (request, h) {
+  const { sessionId } = request.params
+
+  const pageData = await SeasonService.go(sessionId)
+
+  return h.view('bill-runs/create/season.njk', {
+    activeNavBar: 'bill-runs',
+    pageTitle: 'Select the season',
+    ...pageData
+  })
+}
+
+async function submitRegion (request, h) {
+  const { sessionId } = request.params
+
+  const pageData = await SubmitRegionService.go(sessionId, request.payload)
+
+  if (pageData.error) {
+    return h.view('bill-runs/create/region.njk', {
+      activeNavBar: 'bill-runs',
+      pageTitle: 'Select a region',
+      ...pageData
+    })
+  }
+
+  return h.redirect(`/system/bill-runs/create/${sessionId}/year`)
+}
+
+async function submitSeason (request, h) {
+  const { sessionId } = request.params
+
+  const pageData = await SubmitSeasonService.go(sessionId, request.payload)
+
+  if (pageData.error) {
+    return h.view('bill-runs/create/season.njk', {
+      activeNavBar: 'bill-runs',
+      pageTitle: 'Select the season',
+      ...pageData
+    })
+  }
+
+  return h.redirect('/billing/batch/list')
+}
+
+async function submitType (request, h) {
+  const { sessionId } = request.params
+
+  const pageData = await SubmitTypeService.go(sessionId, request.payload)
+
+  if (pageData.error) {
+    return h.view('bill-runs/create/type.njk', {
+      activeNavBar: 'bill-runs',
+      pageTitle: 'Select a bill run type',
+      ...pageData
+    })
+  }
+
+  return h.redirect(`/system/bill-runs/create/${sessionId}/region`)
+}
+
+async function submitYear (request, h) {
+  const { sessionId } = request.params
+
+  const pageData = await SubmitYearService.go(sessionId, request.payload)
+
+  if (pageData.error) {
+    return h.view('bill-runs/create/year.njk', {
+      activeNavBar: 'bill-runs',
+      pageTitle: 'Select the financial year',
+      ...pageData
+    })
+  }
+
+  return h.redirect(`/system/bill-runs/create/${sessionId}/season`)
+}
+
+async function type (request, h) {
+  const { sessionId } = request.params
+
+  const pageData = await TypeService.go(sessionId)
+
+  return h.view('bill-runs/create/type.njk', {
+    activeNavBar: 'bill-runs',
+    pageTitle: 'Select a bill run type',
+    ...pageData
+  })
+}
+
+async function year (request, h) {
+  const { sessionId } = request.params
+
+  const pageData = await YearService.go(sessionId)
+
+  return h.view('bill-runs/create/year.njk', {
+    activeNavBar: 'bill-runs',
+    pageTitle: 'Select the financial year',
+    ...pageData
+  })
+}
+
+module.exports = {
+  create,
+  region,
+  season,
+  submitRegion,
+  submitSeason,
+  submitType,
+  submitYear,
+  type,
+  year
+}

--- a/app/controllers/bill-runs-create.controller.js
+++ b/app/controllers/bill-runs-create.controller.js
@@ -58,7 +58,11 @@ async function submitRegion (request, h) {
     })
   }
 
-  return h.redirect(`/system/bill-runs/create/${sessionId}/year`)
+  if (pageData.type.startsWith('two')) {
+    return h.redirect(`/system/bill-runs/create/${sessionId}/year`)
+  }
+
+  return h.redirect('/billing/batch/list')
 }
 
 async function submitSeason (request, h) {

--- a/app/controllers/bill-runs-create.controller.js
+++ b/app/controllers/bill-runs-create.controller.js
@@ -5,20 +5,37 @@
  * @module BillRunsCreateController
  */
 
+const ExistsService = require('../services/bill-runs/create/exists.service.js')
 const InitiateSessionService = require('../services/bill-runs/create/initiate-session.service.js')
 const RegionService = require('../services/bill-runs/create/region.service.js')
-const TypeService = require('../services/bill-runs/create/type.service.js')
 const SeasonService = require('../services/bill-runs/create/season.service.js')
-const YearService = require('../services/bill-runs/create/year.service.js')
+const TypeService = require('../services/bill-runs/create/type.service.js')
 const SubmitRegionService = require('../services/bill-runs/create/submit-region.service.js')
 const SubmitSeasonService = require('../services/bill-runs/create/submit-season.service.js')
 const SubmitTypeService = require('../services/bill-runs/create/submit-type.service.js')
 const SubmitYearService = require('../services/bill-runs/create/submit-year.service.js')
+const YearService = require('../services/bill-runs/create/year.service.js')
 
 async function create (_request, h) {
   const session = await InitiateSessionService.go()
 
   return h.redirect(`/system/bill-runs/create/${session.id}/type`)
+}
+
+async function generate (request, h) {
+  const { sessionId } = request.params
+
+  const results = await ExistsService.go(sessionId)
+
+  if (results.pageData) {
+    return h.view('bill-runs/create/exists.njk', {
+      activeNavBar: 'bill-runs',
+      pageTitle: 'This bill run already exists',
+      ...results.pageData
+    })
+  }
+
+  return h.redirect('/billing/batch/list')
 }
 
 async function region (request, h) {
@@ -59,7 +76,7 @@ async function submitRegion (request, h) {
   }
 
   if (pageData.journeyComplete) {
-    return h.redirect('/billing/batch/list')
+    return h.redirect(`/system/bill-runs/create/${sessionId}/generate`)
   }
 
   return h.redirect(`/system/bill-runs/create/${sessionId}/year`)
@@ -78,7 +95,7 @@ async function submitSeason (request, h) {
     })
   }
 
-  return h.redirect('/billing/batch/list')
+  return h.redirect(`/system/bill-runs/create/${sessionId}/generate`)
 }
 
 async function submitType (request, h) {
@@ -111,7 +128,7 @@ async function submitYear (request, h) {
   }
 
   if (pageData.journeyComplete) {
-    return h.redirect('/billing/batch/list')
+    return h.redirect(`/system/bill-runs/create/${sessionId}/generate`)
   }
 
   return h.redirect(`/system/bill-runs/create/${sessionId}/season`)
@@ -143,6 +160,7 @@ async function year (request, h) {
 
 module.exports = {
   create,
+  generate,
   region,
   season,
   submitRegion,

--- a/app/controllers/bill-runs-create.controller.js
+++ b/app/controllers/bill-runs-create.controller.js
@@ -110,6 +110,10 @@ async function submitYear (request, h) {
     })
   }
 
+  if (pageData.journeyComplete) {
+    return h.redirect('/billing/batch/list')
+  }
+
   return h.redirect(`/system/bill-runs/create/${sessionId}/season`)
 }
 

--- a/app/lib/general.lib.js
+++ b/app/lib/general.lib.js
@@ -45,6 +45,36 @@ function calculateAndLogTimeTaken (startTime, message, data = {}) {
 }
 
 /**
+ * Determine the start and end date for the current financial year
+ *
+ * We often need to work out what the start and end date for the current financial year is. But because the financial
+ * year starts on 01-APR and finishes on 31-MAR what that year is will change dependent on the current date.
+ *
+ * @returns {Object} An object containing a `startDate` and `endDate`
+ */
+function currentFinancialYear () {
+  const currentDate = new Date()
+  const currentYear = currentDate.getFullYear()
+
+  let startYear
+  let endYear
+
+  // IMPORTANT! getMonth returns an integer (0-11). So, January is represented as 0 and December as 11. This is why
+  // we use 2 rather than 3 to refer to March
+  if (currentDate.getMonth() <= 2) {
+    // For example, if currentDate was 2022-02-15 it would fall in financial year 2021-04-01 to 2022-03-31
+    startYear = currentYear - 1
+    endYear = currentYear
+  } else {
+    // For example, if currentDate was 2022-06-15 it would fall in financial year 2022-04-01 to 2023-03-31
+    startYear = currentYear
+    endYear = currentYear + 1
+  }
+
+  return { startDate: new Date(startYear, 3, 1), endDate: new Date(endYear, 2, 31) }
+}
+
+/**
  * Returns the current time in nanoseconds. Used as part of logging how long something takes
  *
  * We often want to see how long a process takes and capture it in our logs. This can be especially useful when we
@@ -152,6 +182,7 @@ function timestampForPostgres () {
 
 module.exports = {
   calculateAndLogTimeTaken,
+  currentFinancialYear,
   currentTimeInNanoseconds,
   generateUUID,
   periodsOverlap,

--- a/app/plugins/router.plugin.js
+++ b/app/plugins/router.plugin.js
@@ -15,6 +15,7 @@ const AssetRoutes = require('../routes/assets.routes.js')
 const BillLicences = require('../routes/bill-licences.routes.js')
 const BillRoutes = require('../routes/bills.routes.js')
 const BillRunRoutes = require('../routes/bill-runs.routes.js')
+const BillRunsCreateRoutes = require('../routes/bill-runs-create.routes.js')
 const BillingAccountRoutes = require('../routes/billing-accounts.routes.js')
 const CheckRoutes = require('../routes/check.routes.js')
 const DataRoutes = require('../routes/data.routes.js')
@@ -34,6 +35,7 @@ const routes = [
   ...BillLicences,
   ...BillRoutes,
   ...BillRunRoutes,
+  ...BillRunsCreateRoutes,
   ...BillingAccountRoutes,
   ...LicenceRoutes,
   ...JobRoutes,

--- a/app/presenters/bill-runs/create/exists.presenter.js
+++ b/app/presenters/bill-runs/create/exists.presenter.js
@@ -1,0 +1,81 @@
+'use strict'
+
+/**
+ * Formats data for the `/bill-runs/create/{sessionId}/exists` page
+ * @module CancelBillRunPresenter
+ */
+
+const {
+  capitalize,
+  formatBillRunType,
+  formatChargeScheme,
+  formatFinancialYear,
+  formatLongDate
+} = require('../../base.presenter.js')
+
+/**
+ * Formats data for the `/bill-runs/create/{sessionId}/exists` page
+ *
+ * @param {module:SessionModel} session - The session instance for the create bill run journey
+ * @param {module:BillRunModel} billRun - The matching instance of `BillRunModel` to the options selected
+ *
+ * @returns {Object} - The data formatted for the view template
+ */
+function go (session, billRun) {
+  const {
+    batchType,
+    billRunNumber,
+    createdAt,
+    id,
+    region,
+    scheme,
+    status,
+    summer,
+    toFinancialYearEnding
+  } = billRun
+
+  const billRunType = formatBillRunType(batchType, scheme, summer)
+
+  return {
+    backLink: _backLink(session),
+    billRunId: id,
+    billRunNumber,
+    billRunStatus: status,
+    billRunType,
+    chargeScheme: formatChargeScheme(scheme),
+    dateCreated: formatLongDate(createdAt),
+    financialYear: formatFinancialYear(toFinancialYearEnding),
+    region: capitalize(region.displayName),
+    warningMessage: _warningMessage(billRunType, status)
+  }
+}
+
+function _backLink (session) {
+  const { type, year } = session.data
+
+  if (!type.startsWith('two_part')) {
+    return `/system/bill-runs/create/${session.id}/region`
+  }
+
+  if (['2024', '2023'].includes(year)) {
+    return `/system/bill-runs/create/${session.id}/year`
+  }
+
+  return `/system/bill-runs/create/${session.id}/season`
+}
+
+function _warningMessage (billRunType, status) {
+  if (billRunType === 'Supplementary') {
+    return 'You need to confirm or cancel this bill run before you can create a new one'
+  }
+
+  if (status !== 'sent') {
+    return 'You need to cancel this bill run before you can create a new one'
+  }
+
+  return `You can only have one ${billRunType} per region in a financial year`
+}
+
+module.exports = {
+  go
+}

--- a/app/presenters/bill-runs/create/region.presenter.js
+++ b/app/presenters/bill-runs/create/region.presenter.js
@@ -1,0 +1,26 @@
+'use strict'
+
+/**
+ * Formats data for the `/bill-runs/create/{sessionId}/region` page
+ * @module RegionPresenter
+ */
+
+/**
+ * Formats data for the `/bill-runs/create/{sessionId}/region` page
+ *
+ * @param {module:SessionModel} session - The session instance to format
+ * @param {module:RegionsModel[]} regions - UUID and display name of all regions
+ *
+ * @returns {Object} - The data formatted for the view template
+ */
+function go (session, regions) {
+  return {
+    id: session.id,
+    regions,
+    selectedRegion: session.data.region
+  }
+}
+
+module.exports = {
+  go
+}

--- a/app/presenters/bill-runs/create/season.presenter.js
+++ b/app/presenters/bill-runs/create/season.presenter.js
@@ -1,0 +1,24 @@
+'use strict'
+
+/**
+ * Formats data for the `/bill-runs/create/{sessionId}/season` page
+ * @module SeasonPresenter
+ */
+
+/**
+ * Formats data for the `/bill-runs/create/{sessionId}/season` page
+ *
+ * @param {module:SessionModel} session - The session instance to format
+ *
+ * @returns {Object} - The data formatted for the view template
+ */
+function go (session) {
+  return {
+    id: session.id,
+    selectedSeason: session.data.season
+  }
+}
+
+module.exports = {
+  go
+}

--- a/app/presenters/bill-runs/create/type.presenter.js
+++ b/app/presenters/bill-runs/create/type.presenter.js
@@ -1,0 +1,24 @@
+'use strict'
+
+/**
+ * Formats data for the `/bill-runs/create/{sessionId}/type` page
+ * @module TypePresenter
+ */
+
+/**
+ * Formats data for the `/bill-runs/create/{sessionId}/type` page
+ *
+ * @param {module:SessionModel} session - The session instance to format
+ *
+ * @returns {Object} - The data formatted for the view template
+ */
+function go (session) {
+  return {
+    id: session.id,
+    selectedType: session.data.type
+  }
+}
+
+module.exports = {
+  go
+}

--- a/app/presenters/bill-runs/create/year.presenter.js
+++ b/app/presenters/bill-runs/create/year.presenter.js
@@ -12,21 +12,11 @@
  *
  * @returns {Object} - The data formatted for the view template
  */
-function go (session, outstandingYears) {
+function go (session) {
   return {
     id: session.id,
-    years: _years(outstandingYears),
     selectedYear: session.data.year
   }
-}
-
-function _years (outstandingYears) {
-  return outstandingYears.map((outstandingYear) => {
-    return {
-      display: `${outstandingYear - 1} to ${outstandingYear}`,
-      value: outstandingYear
-    }
-  })
 }
 
 module.exports = {

--- a/app/presenters/bill-runs/create/year.presenter.js
+++ b/app/presenters/bill-runs/create/year.presenter.js
@@ -1,0 +1,34 @@
+'use strict'
+
+/**
+ * Formats data for the `/bill-runs/create/{sessionId}/year` page
+ * @module RegionPresenter
+ */
+
+/**
+ * Formats data for the `/bill-runs/create/{sessionId}/year` page
+ *
+ * @param {module:SessionModel} session - The session instance to format
+ *
+ * @returns {Object} - The data formatted for the view template
+ */
+function go (session, outstandingYears) {
+  return {
+    id: session.id,
+    years: _years(outstandingYears),
+    selectedYear: session.data.year
+  }
+}
+
+function _years (outstandingYears) {
+  return outstandingYears.map((outstandingYear) => {
+    return {
+      display: `${outstandingYear - 1} to ${outstandingYear}`,
+      value: outstandingYear
+    }
+  })
+}
+
+module.exports = {
+  go
+}

--- a/app/routes/bill-runs-create.routes.js
+++ b/app/routes/bill-runs-create.routes.js
@@ -18,6 +18,19 @@ const routes = [
   },
   {
     method: 'GET',
+    path: '/bill-runs/create/{sessionId}/generate',
+    handler: BillRunsCreateController.generate,
+    options: {
+      auth: {
+        access: {
+          scope: ['billing']
+        }
+      },
+      description: 'Attempt to generate a new bill run'
+    }
+  },
+  {
+    method: 'GET',
     path: '/bill-runs/create/{sessionId}/region',
     handler: BillRunsCreateController.region,
     options: {

--- a/app/routes/bill-runs-create.routes.js
+++ b/app/routes/bill-runs-create.routes.js
@@ -1,0 +1,125 @@
+'use strict'
+
+const BillRunsCreateController = require('../controllers/bill-runs-create.controller.js')
+
+const routes = [
+  {
+    method: 'GET',
+    path: '/bill-runs/create',
+    handler: BillRunsCreateController.create,
+    options: {
+      auth: {
+        access: {
+          scope: ['billing']
+        }
+      },
+      description: 'Create a bill run (start of journey)'
+    }
+  },
+  {
+    method: 'GET',
+    path: '/bill-runs/create/{sessionId}/region',
+    handler: BillRunsCreateController.region,
+    options: {
+      auth: {
+        access: {
+          scope: ['billing']
+        }
+      },
+      description: 'Select the region for the bill run'
+    }
+  },
+  {
+    method: 'POST',
+    path: '/bill-runs/create/{sessionId}/region',
+    handler: BillRunsCreateController.submitRegion,
+    options: {
+      auth: {
+        access: {
+          scope: ['billing']
+        }
+      },
+      description: 'Submit the region for the bill run'
+    }
+  },
+  {
+    method: 'GET',
+    path: '/bill-runs/create/{sessionId}/season',
+    handler: BillRunsCreateController.season,
+    options: {
+      auth: {
+        access: {
+          scope: ['billing']
+        }
+      },
+      description: 'Select the season for the bill run'
+    }
+  },
+  {
+    method: 'POST',
+    path: '/bill-runs/create/{sessionId}/season',
+    handler: BillRunsCreateController.submitSeason,
+    options: {
+      auth: {
+        access: {
+          scope: ['billing']
+        }
+      },
+      description: 'Submit the season for the bill run'
+    }
+  },
+  {
+    method: 'GET',
+    path: '/bill-runs/create/{sessionId}/type',
+    handler: BillRunsCreateController.type,
+    options: {
+      auth: {
+        access: {
+          scope: ['billing']
+        }
+      },
+      description: 'Select the bill run type'
+    }
+  },
+  {
+    method: 'POST',
+    path: '/bill-runs/create/{sessionId}/type',
+    handler: BillRunsCreateController.submitType,
+    options: {
+      auth: {
+        access: {
+          scope: ['billing']
+        }
+      },
+      description: 'Submit the bill run type for the bill run'
+    }
+  },
+  {
+    method: 'GET',
+    path: '/bill-runs/create/{sessionId}/year',
+    handler: BillRunsCreateController.year,
+    options: {
+      auth: {
+        access: {
+          scope: ['billing']
+        }
+      },
+      description: 'Select the financial year for the bill run'
+    }
+  },
+  {
+    method: 'POST',
+    path: '/bill-runs/create/{sessionId}/year',
+    handler: BillRunsCreateController.submitYear,
+    options: {
+      auth: {
+        access: {
+          scope: ['billing']
+        }
+      },
+      description: 'Submit the financial year for the bill run'
+    }
+  }
+]
+
+module.exports = routes

--- a/app/services/bill-runs/create/exists.service.js
+++ b/app/services/bill-runs/create/exists.service.js
@@ -1,0 +1,146 @@
+'use strict'
+
+/**
+ * Used by the `/bill-runs/create/{sessionId}/generate` page to determine if a matching bill run already exists
+ * @module BillRunsCreateExistsService
+ */
+
+const BillRunModel = require('../../../models/bill-run.model.js')
+const ExistsPresenter = require('../../../presenters/bill-runs/create/exists.presenter.js')
+const SessionModel = require('../../../models/session.model.js')
+
+const { currentFinancialYear } = require('../../../../test/support/helpers/general.helper.js')
+
+/**
+ * Determines if an existing bill run matches the one a user is trying to create
+ *
+ * Once the user completes the bill run create journey we first need to check if a matching bill run already exists.
+ *
+ * The criteria though can differ depending on the details selected. For example, you can only have 1 annual bill run
+ * per region per year. Supplementary you can have as many as you like but never more than one in process. Two-part
+ * tariff depending on the year you can have either 2 or 1.
+ *
+ * All this needs to be taken into account when determining if a 'matching' bill run exists. If it does we prepare
+ * `pageData` and the controller will redirect the user to the `/bill-runs/create/{sessionId}/exists` page. If it
+ * doesn't it will kick off generating the bill run.
+ *
+ * @param {string} id - The UUID for create bill run session record
+ *
+ * @returns {Promise<Object>} It always returns the session and the results of looking for matching bill runs plus a
+ * `pageData:` property.
+ *
+ * If no matches were found `pageData` will be `null`.
+ *
+ * If the bill run to be created is annual or two-part tariff and a match is found `pageData` will be the matching bill
+ * run's data formatted for use in the '/exists' page.
+ *
+ * If the bill run is supplementary and 2 matches are found it returns the most recent match formatted for use in the
+ * '/exists' page.
+ */
+async function go (sessionId) {
+  const session = await SessionModel.query().findById(sessionId)
+  const year = _year(session)
+  const matchResults = await _fetchMatchingBillRun(session, year)
+
+  return {
+    matchResults,
+    pageData: _pageData(session, matchResults),
+    session
+  }
+}
+
+function _pageData (session, matchResults) {
+  const { type } = session.data
+
+  // No matches so we can create the bill run
+  if (matchResults.length === 0) {
+    return null
+  }
+
+  // You can only have one SROC and PRESROC supplementary being processed at any time. If less than 2 then we can create
+  // a bill run
+  if (type === 'supplementary' && matchResults.length < 2) {
+    return null
+  }
+
+  // We have a match so format the bill run for the /exists page
+  return ExistsPresenter.go(session, matchResults[0])
+}
+
+function _applyAnnualWhereClauses (query, year) {
+  return query
+    .where('toFinancialYearEnding', year)
+    .whereNotIn('status', ['cancel', 'empty', 'error'])
+    .limit(1)
+}
+
+function _applySupplementaryWhereClauses (query) {
+  return query
+    .whereNotIn('status', ['cancel', 'empty', 'error', 'sending', 'sent'])
+}
+
+function _applyTwoPartTariffQuery (query, year, season) {
+  if (['2022', '2021'].includes(year)) {
+    query.where('summer', season === 'summer')
+  }
+
+  return query
+    .where('toFinancialYearEnding', year)
+    .whereNotIn('status', ['cancel', 'empty', 'error'])
+    .limit(1)
+}
+
+async function _fetchMatchingBillRun (session, year) {
+  const { region, season, type } = session.data
+
+  const baseQuery = BillRunModel.query()
+    .select([
+      'id',
+      'batchType',
+      'billRunNumber',
+      'createdAt',
+      'scheme',
+      'status',
+      'summer',
+      'toFinancialYearEnding'
+    ])
+    .where('regionId', region)
+    .where('batchType', type)
+
+  if (type === 'annual') {
+    _applyAnnualWhereClauses(baseQuery, year)
+  } else if (type === 'supplementary') {
+    _applySupplementaryWhereClauses(baseQuery)
+  } else {
+    _applyTwoPartTariffQuery(baseQuery, year, season)
+  }
+
+  return baseQuery
+    .orderBy([
+      { column: 'toFinancialYearEnding', order: 'desc' },
+      { column: 'createdAt', order: 'desc' }
+    ])
+    .withGraphFetched('region')
+    .modifyGraph('region', (builder) => {
+      builder.select([
+        'id',
+        'displayName'
+      ])
+    })
+}
+
+function _year (session) {
+  const { type, year } = session.data
+
+  if (year && type.startsWith('two_part')) {
+    return year
+  }
+
+  const { endDate } = currentFinancialYear()
+
+  return endDate.getFullYear()
+}
+
+module.exports = {
+  go
+}

--- a/app/services/bill-runs/create/generate.service.js
+++ b/app/services/bill-runs/create/generate.service.js
@@ -1,0 +1,49 @@
+'use strict'
+
+/**
+ * Used to generate the new bill run at the end of the create bill run journey
+ * @module BillRunsCreateGenerateService
+ */
+
+const LegacyCreateBillRunService = require('../../legacy/create-bill-run.service.js')
+const StartBillRunProcessService = require('../start-bill-run-process.service.js')
+
+async function go (user, existsServiceResults) {
+  const { matchResults, session, yearToUse } = existsServiceResults
+  const { region: regionId, type, summer } = session.data
+
+  const existingBillRun = matchResults[0]
+
+  await _triggerBillRun(regionId, type, user, yearToUse, existingBillRun)
+  await _triggerLegacyBillRun(regionId, type, user, yearToUse, summer, existingBillRun)
+
+  return session.$query().delete()
+}
+
+async function _triggerLegacyBillRun (regionId, batchType, user, year, summer, existingBillRun = null) {
+  // The one case we have to handle is where the user selected supplementary and a match was found, but it was to a
+  // PRESROC supplementary bill run. We've got to this point in the process because it is fine to trigger the SROC
+  // bill run in our engine. But we can't trigger the PRESROC one because a match already exists.
+  if (batchType === 'supplementary' && existingBillRun?.scheme === 'alcs') {
+    return null
+  }
+
+  return LegacyCreateBillRunService.go(batchType, regionId, year, user, summer)
+}
+
+async function _triggerBillRun (regionId, batchType, user, year, existingBillRun = null) {
+  const { username: userEmail } = user
+
+  // The one case we have to handle is where the user selected supplementary and a match was found, but it was to an
+  // SROC supplementary bill run. We've got to this point in the process because it is fine to trigger the PRESROC
+  // bill run in the legacy engine. But we can't trigger the SROC one because a match already exists.
+  if (batchType === 'supplementary' && existingBillRun?.scheme === 'sroc') {
+    return null
+  }
+
+  return StartBillRunProcessService.go(regionId, batchType, userEmail, year)
+}
+
+module.exports = {
+  go
+}

--- a/app/services/bill-runs/create/initiate-session.service.js
+++ b/app/services/bill-runs/create/initiate-session.service.js
@@ -1,0 +1,28 @@
+'use strict'
+
+/**
+ * Initiates the session record used for creating a new bill run
+ * @module BillRunsCreateInitiateSessionService
+ */
+
+const SessionModel = require('../../../models/session.model.js')
+
+/**
+ * Initiates the session record using for setting up a new bill run
+ *
+ * During the setup journey for a new bill run we temporarily store the data in a `SessionModel` instance. It
+ * is expected that on each page of the journey the GET will fetch the session record and use it to populate the view.
+ * When the page is submitted the session record will be updated with the next piece of data.
+ *
+ * At the end when the journey is complete the data from the session will be used to create the bill run and
+ * the session record itself deleted.
+ *
+ * @returns {Promise<module:SessionModel>} the newly created session record
+ */
+async function go () {
+  return SessionModel.query().insert({ data: {} }).returning('id')
+}
+
+module.exports = {
+  go
+}

--- a/app/services/bill-runs/create/region.service.js
+++ b/app/services/bill-runs/create/region.service.js
@@ -1,0 +1,46 @@
+'use strict'
+
+/**
+ * Orchestrates fetching and presenting the data for `/bill-runs/{sessionId}/region` page
+ * @module BillRunsCreateRegionService
+ */
+
+const RegionModel = require('../../../models/region.model.js')
+const RegionPresenter = require('../../../presenters/bill-runs/create/region.presenter.js')
+const SessionModel = require('../../../models/session.model.js')
+
+/**
+ * Orchestrates fetching and presenting the data for `/bill-runs/create/{sessionId}/region` page
+ *
+ * Supports generating the data needed for the region page in the create bill run journey. It fetches the current
+ * session record and combines it with the radio buttons and other information needed for the form.
+ *
+ * @param {string} id - The UUID for create bill run session record
+ *
+ * @returns {Promise<Object>} The view data for the region page
+ */
+async function go (sessionId) {
+  const session = await SessionModel.query().findById(sessionId)
+  const regions = await _fetchRegions()
+
+  const formattedData = RegionPresenter.go(session, regions)
+
+  return {
+    ...formattedData
+  }
+}
+
+async function _fetchRegions () {
+  return RegionModel.query()
+    .select([
+      'id',
+      'displayName'
+    ])
+    .orderBy([
+      { column: 'displayName', order: 'asc' }
+    ])
+}
+
+module.exports = {
+  go
+}

--- a/app/services/bill-runs/create/season.service.js
+++ b/app/services/bill-runs/create/season.service.js
@@ -1,0 +1,32 @@
+'use strict'
+
+/**
+ * Orchestrates fetching and presenting the data for `/bill-runs/{sessionId}/season` page
+ * @module BillRunsCreateSeasonService
+ */
+
+const SessionModel = require('../../../models/session.model.js')
+const SeasonPresenter = require('../../../presenters/bill-runs/create/season.presenter.js')
+
+/**
+ * Orchestrates fetching and presenting the data for `/bill-runs/create/{sessionId}/season` page
+ *
+ * Supports generating the data needed for the type page in the create bill run journey. It fetches the current session
+ * record and combines it with the radio buttons and other information needed for the form.
+ *
+ * @param {string} id - The UUID for create bill run session record
+ *
+ * @returns {Promise<Object>} The view data for the season page
+ */
+async function go (sessionId) {
+  const session = await SessionModel.query().findById(sessionId)
+  const formattedData = SeasonPresenter.go(session)
+
+  return {
+    ...formattedData
+  }
+}
+
+module.exports = {
+  go
+}

--- a/app/services/bill-runs/create/submit-region.service.js
+++ b/app/services/bill-runs/create/submit-region.service.js
@@ -33,7 +33,7 @@ async function go (sessionId, payload) {
   if (!validationResult) {
     await _save(session, payload)
 
-    return {}
+    return { type: session.data.type }
   }
 
   const formattedData = RegionPresenter.go(session, regions)

--- a/app/services/bill-runs/create/submit-region.service.js
+++ b/app/services/bill-runs/create/submit-region.service.js
@@ -1,0 +1,82 @@
+'use strict'
+
+/**
+ * Orchestrates validating the data for `/bill-runs/create/{sessionId}/region` page
+ * @module SubmitRegionService
+ */
+
+const RegionModel = require('../../../models/region.model.js')
+const RegionPresenter = require('../../../presenters/bill-runs/create/region.presenter.js')
+const RegionValidator = require('../../../validators/bill-runs/create/region.validator.js')
+const SessionModel = require('../../../models/session.model.js')
+
+/**
+ * Orchestrates validating the data for `/bill-runs/create/{sessionId}/region` page
+ *
+ * It first retrieves the session instance for the create bill run journey in progress.
+ *
+ * The validation result is then combined with the output of the presenter to generate the page data needed by the view.
+ * If there was a validation error the controller will re-render the page so needs this information. If all is well the
+ * controller will redirect to the next page in the journey.
+ *
+ * @param {string} sessionId - The id of the current session
+ * @param {Object} payload - The submitted form data
+ *
+ * @returns {Promise<Object>} The page data for the region page
+ */
+async function go (sessionId, payload) {
+  const session = await SessionModel.query().findById(sessionId)
+  const regions = await _fetchRegions()
+
+  const validationResult = _validate(payload, regions)
+
+  if (!validationResult) {
+    await _save(session, payload)
+
+    return {}
+  }
+
+  const formattedData = RegionPresenter.go(session, regions)
+
+  return {
+    error: validationResult,
+    ...formattedData
+  }
+}
+
+async function _fetchRegions () {
+  return RegionModel.query()
+    .select([
+      'id',
+      'displayName'
+    ])
+    .orderBy([
+      { column: 'displayName', order: 'asc' }
+    ])
+}
+
+async function _save (session, payload) {
+  const currentData = session.data
+
+  currentData.region = payload.region
+
+  return session.$query().patch({ data: currentData })
+}
+
+function _validate (payload, regions) {
+  const validation = RegionValidator.go(payload, regions)
+
+  if (!validation.error) {
+    return null
+  }
+
+  const { message } = validation.error.details[0]
+
+  return {
+    text: message
+  }
+}
+
+module.exports = {
+  go
+}

--- a/app/services/bill-runs/create/submit-region.service.js
+++ b/app/services/bill-runs/create/submit-region.service.js
@@ -33,7 +33,7 @@ async function go (sessionId, payload) {
   if (!validationResult) {
     await _save(session, payload)
 
-    return { type: session.data.type }
+    return { journeyComplete: !session.data.type.startsWith('two_part') }
   }
 
   const formattedData = RegionPresenter.go(session, regions)

--- a/app/services/bill-runs/create/submit-season.service.js
+++ b/app/services/bill-runs/create/submit-season.service.js
@@ -1,0 +1,69 @@
+'use strict'
+
+/**
+ * Orchestrates validating the data for `/bill-runs/create/{sessionId}/season` page
+ * @module SubmitSeasonService
+ */
+
+const SessionModel = require('../../../models/session.model.js')
+const SeasonPresenter = require('../../../presenters/bill-runs/create/season.presenter.js')
+const SeasonValidator = require('../../../validators/bill-runs/create/season.validator.js')
+
+/**
+ * Orchestrates validating the data for `/bill-runs/create/{sessionId}/season` page
+ *
+ * It first retrieves the session instance for the create bill run journey in progress.
+ *
+ * The validation result is then combined with the output of the presenter to generate the page data needed by the view.
+ * If there was a validation error the controller will re-render the page so needs this information. If all is well the
+ * controller will redirect to the next page in the journey.
+ *
+ * @param {string} sessionId - The id of the current session
+ * @param {Object} payload - The submitted form data
+ *
+ * @returns {Promise<Object>} The page data for the season page
+ */
+async function go (sessionId, payload) {
+  const session = await SessionModel.query().findById(sessionId)
+
+  const validationResult = _validate(payload)
+
+  if (!validationResult) {
+    await _save(session, payload)
+
+    return {}
+  }
+
+  const formattedData = SeasonPresenter.go(session)
+
+  return {
+    error: validationResult,
+    ...formattedData
+  }
+}
+
+async function _save (session, payload) {
+  const currentData = session.data
+
+  currentData.season = payload.season
+
+  return session.$query().patch({ data: currentData })
+}
+
+function _validate (payload) {
+  const validation = SeasonValidator.go(payload)
+
+  if (!validation.error) {
+    return null
+  }
+
+  const { message } = validation.error.details[0]
+
+  return {
+    text: message
+  }
+}
+
+module.exports = {
+  go
+}

--- a/app/services/bill-runs/create/submit-type.service.js
+++ b/app/services/bill-runs/create/submit-type.service.js
@@ -1,0 +1,69 @@
+'use strict'
+
+/**
+ * Orchestrates validating the data for `/bill-runs/create/{sessionId}/type` page
+ * @module SubmitTypeService
+ */
+
+const SessionModel = require('../../../models/session.model.js')
+const TypePresenter = require('../../../presenters/bill-runs/create/type.presenter.js')
+const TypeValidator = require('../../../validators/bill-runs/create/type.validator.js')
+
+/**
+ * Orchestrates validating the data for `/bill-runs/create/{sessionId}/type` page
+ *
+ * It first retrieves the session instance for the create bill run journey in progress.
+ *
+ * The validation result is then combined with the output of the presenter to generate the page data needed by the view.
+ * If there was a validation error the controller will re-render the page so needs this information. If all is well the
+ * controller will redirect to the next page in the journey.
+ *
+ * @param {string} sessionId - The id of the current session
+ * @param {Object} payload - The submitted form data
+ *
+ * @returns {Promise<Object>} The page data for the type page
+ */
+async function go (sessionId, payload) {
+  const session = await SessionModel.query().findById(sessionId)
+
+  const validationResult = _validate(payload)
+
+  if (!validationResult) {
+    await _save(session, payload)
+
+    return {}
+  }
+
+  const formattedData = TypePresenter.go(session)
+
+  return {
+    error: validationResult,
+    ...formattedData
+  }
+}
+
+async function _save (session, payload) {
+  const currentData = session.data
+
+  currentData.type = payload.type
+
+  return session.$query().patch({ data: currentData })
+}
+
+function _validate (payload) {
+  const validation = TypeValidator.go(payload)
+
+  if (!validation.error) {
+    return null
+  }
+
+  const { message } = validation.error.details[0]
+
+  return {
+    text: message
+  }
+}
+
+module.exports = {
+  go
+}

--- a/app/services/bill-runs/create/submit-year.service.js
+++ b/app/services/bill-runs/create/submit-year.service.js
@@ -25,9 +25,8 @@ const SessionModel = require('../../../models/session.model.js')
  */
 async function go (sessionId, payload) {
   const session = await SessionModel.query().findById(sessionId)
-  const years = await _fetchYears()
 
-  const validationResult = _validate(payload, years)
+  const validationResult = _validate(payload)
 
   if (!validationResult) {
     await _save(session, payload)
@@ -35,16 +34,12 @@ async function go (sessionId, payload) {
     return {}
   }
 
-  const formattedData = YearPresenter.go(session, years)
+  const formattedData = YearPresenter.go(session)
 
   return {
     error: validationResult,
     ...formattedData
   }
-}
-
-async function _fetchYears () {
-  return [2022, 2021]
 }
 
 async function _save (session, payload) {

--- a/app/services/bill-runs/create/submit-year.service.js
+++ b/app/services/bill-runs/create/submit-year.service.js
@@ -31,7 +31,7 @@ async function go (sessionId, payload) {
   if (!validationResult) {
     await _save(session, payload)
 
-    return {}
+    return { journeyComplete: ['2024', '2023'].includes(session.data.year) }
   }
 
   const formattedData = YearPresenter.go(session)

--- a/app/services/bill-runs/create/submit-year.service.js
+++ b/app/services/bill-runs/create/submit-year.service.js
@@ -1,0 +1,74 @@
+'use strict'
+
+/**
+ * Orchestrates validating the data for `/bill-runs/create/{sessionId}/year` page
+ * @module SubmitYearService
+ */
+
+const YearPresenter = require('../../../presenters/bill-runs/create/year.presenter.js')
+const YearValidator = require('../../../validators/bill-runs/create/year.validator.js')
+const SessionModel = require('../../../models/session.model.js')
+
+/**
+ * Orchestrates validating the data for `/bill-runs/create/{sessionId}/year` page
+ *
+ * It first retrieves the session instance for the create bill run journey in progress.
+ *
+ * The validation result is then combined with the output of the presenter to generate the page data needed by the view.
+ * If there was a validation error the controller will re-render the page so needs this information. If all is well the
+ * controller will redirect to the next page in the journey.
+ *
+ * @param {string} sessionId - The id of the current session
+ * @param {Object} payload - The submitted form data
+ *
+ * @returns {Promise<Object>} The page data for the year page
+ */
+async function go (sessionId, payload) {
+  const session = await SessionModel.query().findById(sessionId)
+  const years = await _fetchYears()
+
+  const validationResult = _validate(payload, years)
+
+  if (!validationResult) {
+    await _save(session, payload)
+
+    return {}
+  }
+
+  const formattedData = YearPresenter.go(session, years)
+
+  return {
+    error: validationResult,
+    ...formattedData
+  }
+}
+
+async function _fetchYears () {
+  return [2022, 2021]
+}
+
+async function _save (session, payload) {
+  const currentData = session.data
+
+  currentData.year = payload.year
+
+  return session.$query().patch({ data: currentData })
+}
+
+function _validate (payload, regions) {
+  const validation = YearValidator.go(payload, regions)
+
+  if (!validation.error) {
+    return null
+  }
+
+  const { message } = validation.error.details[0]
+
+  return {
+    text: message
+  }
+}
+
+module.exports = {
+  go
+}

--- a/app/services/bill-runs/create/type.service.js
+++ b/app/services/bill-runs/create/type.service.js
@@ -1,0 +1,32 @@
+'use strict'
+
+/**
+ * Orchestrates fetching and presenting the data for `/bill-runs/{sessionId}/type` page
+ * @module BillRunsCreateTypeService
+ */
+
+const SessionModel = require('../../../models/session.model.js')
+const TypePresenter = require('../../../presenters/bill-runs/create/type.presenter.js')
+
+/**
+ * Orchestrates fetching and presenting the data for `/bill-runs/create/{sessionId}/type` page
+ *
+ * Supports generating the data needed for the type page in the create bill run journey. It fetches the current session
+ * record and combines it with the radio buttons and other information needed for the form.
+ *
+ * @param {string} id - The UUID for create bill run session record
+ *
+ * @returns {Promise<Object>} The view data for the type page
+ */
+async function go (sessionId) {
+  const session = await SessionModel.query().findById(sessionId)
+  const formattedData = TypePresenter.go(session)
+
+  return {
+    ...formattedData
+  }
+}
+
+module.exports = {
+  go
+}

--- a/app/services/bill-runs/create/year.service.js
+++ b/app/services/bill-runs/create/year.service.js
@@ -20,17 +20,12 @@ const SessionModel = require('../../../models/session.model.js')
  */
 async function go (sessionId) {
   const session = await SessionModel.query().findById(sessionId)
-  const years = await _fetchYears()
 
-  const formattedData = YearPresenter.go(session, years)
+  const formattedData = YearPresenter.go(session)
 
   return {
     ...formattedData
   }
-}
-
-async function _fetchYears () {
-  return [2022, 2021]
 }
 
 module.exports = {

--- a/app/services/bill-runs/create/year.service.js
+++ b/app/services/bill-runs/create/year.service.js
@@ -1,0 +1,38 @@
+'use strict'
+
+/**
+ * Orchestrates fetching and presenting the data for `/bill-runs/{sessionId}/year` page
+ * @module BillRunsCreateYearService
+ */
+
+const YearPresenter = require('../../../presenters/bill-runs/create/year.presenter.js')
+const SessionModel = require('../../../models/session.model.js')
+
+/**
+ * Orchestrates fetching and presenting the data for `/bill-runs/create/{sessionId}/year` page
+ *
+ * Supports generating the data needed for the year page in the create bill run journey. It fetches the current
+ * session record and combines it with the radio buttons and other information needed for the form.
+ *
+ * @param {string} id - The UUID for create bill run session record
+ *
+ * @returns {Promise<Object>} The view data for the year page
+ */
+async function go (sessionId) {
+  const session = await SessionModel.query().findById(sessionId)
+  const years = await _fetchYears()
+
+  const formattedData = YearPresenter.go(session, years)
+
+  return {
+    ...formattedData
+  }
+}
+
+async function _fetchYears () {
+  return [2022, 2021]
+}
+
+module.exports = {
+  go
+}

--- a/app/services/legacy/create-bill-run.service.js
+++ b/app/services/legacy/create-bill-run.service.js
@@ -1,0 +1,29 @@
+'use strict'
+
+/**
+ * Connects with the Legacy APIs to refresh a bill run
+ * @module LegacyRefreshBillRunService
+ */
+
+const LegacyRequestLib = require('../../lib/legacy-request.lib.js')
+
+async function go (batchType, regionId, financialYearEnding, user, summer = false) {
+  const { id: userId, username: userEmail } = user
+
+  const path = 'billing/batches'
+  const body = {
+    batchType,
+    financialYearEnding,
+    regionId,
+    isSummer: summer,
+    userEmail
+  }
+
+  const result = await LegacyRequestLib.post('water', path, userId, true, body)
+
+  return result
+}
+
+module.exports = {
+  go
+}

--- a/app/services/legacy/refresh-bill-run.service.js
+++ b/app/services/legacy/refresh-bill-run.service.js
@@ -1,0 +1,18 @@
+'use strict'
+
+/**
+ * Connects with the Legacy APIs to refresh a bill run
+ * @module LegacyRefreshBillRunService
+ */
+
+const LegacyRequestLib = require('../../lib/legacy-request.lib.js')
+
+async function go (billRunId) {
+  const path = `billing/batches/${billRunId}/refresh`
+
+  return LegacyRequestLib.post('water', path)
+}
+
+module.exports = {
+  go
+}

--- a/app/validators/bill-runs/create/region.validator.js
+++ b/app/validators/bill-runs/create/region.validator.js
@@ -1,0 +1,39 @@
+'use strict'
+
+/**
+ * Validates data submitted for the `/bill-runs/create/{sessionId}/region` page
+ * @module BillRunsCreateRegionValidator
+ */
+
+const Joi = require('joi')
+
+/**
+ * Validates data submitted for the `/bill-runs/create/{sessionId}/region` page
+ *
+ * @param {Object} payload - The payload from the request to be validated
+ *
+ * @returns {Object} the result from calling Joi's schema.validate(). It will be an object with a `value:` property. If
+ * any errors are found the `error:` property will also exist detailing what the issues were
+ */
+function go (data, regions) {
+  const validValues = regions.map((region) => {
+    return region.id
+  })
+
+  const schema = Joi.object({
+    region: Joi.string()
+      .required()
+      .valid(...validValues)
+      .messages({
+        'any.required': 'Select the region',
+        'any.only': 'Select the region',
+        'string.empty': 'Select the region'
+      })
+  })
+
+  return schema.validate(data, { abortEarly: false })
+}
+
+module.exports = {
+  go
+}

--- a/app/validators/bill-runs/create/season.validator.js
+++ b/app/validators/bill-runs/create/season.validator.js
@@ -1,0 +1,40 @@
+'use strict'
+
+/**
+ * Validates data submitted for the `/bill-runs/create/{sessionId}/season` page
+ * @module BillRunsCreateSeasonValidator
+ */
+
+const Joi = require('joi')
+
+const VALID_VALUES = [
+  'summer',
+  'winter_all_year'
+]
+
+/**
+ * Validates data submitted for the `/bill-runs/create/{sessionId}/season` page
+ *
+ * @param {Object} payload - The payload from the request to be validated
+ *
+ * @returns {Object} the result from calling Joi's schema.validate(). It will be an object with a `value:` property. If
+ * any errors are found the `error:` property will also exist detailing what the issues were
+ */
+function go (data) {
+  const schema = Joi.object({
+    season: Joi.string()
+      .required()
+      .valid(...VALID_VALUES)
+      .messages({
+        'any.required': 'Select the season',
+        'any.only': 'Select the season',
+        'string.empty': 'Select the season'
+      })
+  })
+
+  return schema.validate(data, { abortEarly: false })
+}
+
+module.exports = {
+  go
+}

--- a/app/validators/bill-runs/create/type.validator.js
+++ b/app/validators/bill-runs/create/type.validator.js
@@ -1,0 +1,42 @@
+'use strict'
+
+/**
+ * Validates data submitted for the `/bill-runs/create/{sessionId}/type` page
+ * @module BillRunsCreateTypeValidator
+ */
+
+const Joi = require('joi')
+
+const VALID_VALUES = [
+  'annual',
+  'supplementary',
+  'two_part_tariff',
+  'two_part_tariff_supplementary'
+]
+
+/**
+ * Validates data submitted for the `/bill-runs/create/{sessionId}/type` page
+ *
+ * @param {Object} payload - The payload from the request to be validated
+ *
+ * @returns {Object} the result from calling Joi's schema.validate(). It will be an object with a `value:` property. If
+ * any errors are found the `error:` property will also exist detailing what the issues were
+ */
+function go (data) {
+  const schema = Joi.object({
+    type: Joi.string()
+      .required()
+      .valid(...VALID_VALUES)
+      .messages({
+        'any.required': 'Select a bill run type',
+        'any.only': 'Select a bill run type',
+        'string.empty': 'Select a bill run type'
+      })
+  })
+
+  return schema.validate(data, { abortEarly: false })
+}
+
+module.exports = {
+  go
+}

--- a/app/validators/bill-runs/create/year.validator.js
+++ b/app/validators/bill-runs/create/year.validator.js
@@ -1,0 +1,39 @@
+'use strict'
+
+/**
+ * Validates data submitted for the `/bill-runs/create/{sessionId}/year` page
+ * @module BillRunsCreateYearValidator
+ */
+
+const Joi = require('joi')
+
+/**
+ * Validates data submitted for the `/bill-runs/create/{sessionId}/year` page
+ *
+ * @param {Object} payload - The payload from the request to be validated
+ *
+ * @returns {Object} the result from calling Joi's schema.validate(). It will be an object with a `value:` property. If
+ * any errors are found the `error:` property will also exist detailing what the issues were
+ */
+function go (data, years) {
+  const validValues = years.map((year) => {
+    return year.toString()
+  })
+
+  const schema = Joi.object({
+    year: Joi.string()
+      .required()
+      .valid(...validValues)
+      .messages({
+        'any.required': 'Select the financial year',
+        'any.only': 'Select the financial year',
+        'string.empty': 'Select the financial year'
+      })
+  })
+
+  return schema.validate(data, { abortEarly: false })
+}
+
+module.exports = {
+  go
+}

--- a/app/validators/bill-runs/create/year.validator.js
+++ b/app/validators/bill-runs/create/year.validator.js
@@ -7,6 +7,13 @@
 
 const Joi = require('joi')
 
+const VALID_VALUES = [
+  '2024',
+  '2023',
+  '2022',
+  '2021'
+]
+
 /**
  * Validates data submitted for the `/bill-runs/create/{sessionId}/year` page
  *
@@ -15,15 +22,11 @@ const Joi = require('joi')
  * @returns {Object} the result from calling Joi's schema.validate(). It will be an object with a `value:` property. If
  * any errors are found the `error:` property will also exist detailing what the issues were
  */
-function go (data, years) {
-  const validValues = years.map((year) => {
-    return year.toString()
-  })
-
+function go (data) {
   const schema = Joi.object({
     year: Joi.string()
       .required()
-      .valid(...validValues)
+      .valid(...VALID_VALUES)
       .messages({
         'any.required': 'Select the financial year',
         'any.only': 'Select the financial year',

--- a/app/views/bill-runs/create/exists.njk
+++ b/app/views/bill-runs/create/exists.njk
@@ -1,0 +1,81 @@
+{% extends 'layout.njk' %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
+
+{% from "macros/badge.njk" import statusBadge %}
+
+{% block breadcrumbs %}
+  {# Back link #}
+  {{
+    govukBackLink({
+      text: 'Back',
+      href: backLink
+    })
+  }}
+{% endblock %}
+
+{% block content %}
+  {# Main heading #}
+  <div class="govuk-body">
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">
+      {{ pageTitle }}
+    </h1>
+  </div>
+
+  <div class="govuk-grid-row govuk-!-margin-bottom-0">
+    <div class="govuk-grid-column-full">
+
+      {{ govukWarningText({
+        text: warningMessage,
+        iconFallbackText: 'Warning'
+      }) }}
+
+      {# Status badge #}
+      <p class="govuk-body">
+        {{ statusBadge(billRunStatus) }}
+      </p>
+
+      {# Bill run meta-data #}
+      {#
+        GOV.UK summary lists only allow us to assign attributes at the top level and not to each row. This means we
+        can't assign our data-test attribute using the component. Our solution is to use the html option for each row
+        instead of text and wrap each value in a <span>. That way we can manually assign our data-test attribute to the
+        span.
+      #}
+      {{
+        govukSummaryList({
+          classes: 'govuk-summary-list--no-border',
+          attributes: {
+            'data-test': 'meta-data'
+          },
+          rows: [
+            {
+              key: { text: "Date created", classes: "meta-data__label" },
+              value: { html: '<span data-test="meta-data-created">' + dateCreated + '</span>', classes: "meta-data__value" }
+            },
+            {
+              key: { text: "Region", classes: "meta-data__label" },
+              value: { html: '<span data-test="meta-data-region">' + region + '</span>', classes: "meta-data__value" }
+            },
+            {
+              key: { text: "Bill run type", classes: "meta-data__label" },
+              value: { html: '<span data-test="meta-data-type">' + billRunType + '</span>', classes: "meta-data__value" }
+            },
+            {
+              key: { text: "Charge scheme", classes: "meta-data__label" },
+              value: { html: '<span data-test="meta-data-scheme">' + chargeScheme + '</span>', classes: "meta-data__value" }
+            },
+            {
+              key: { text: "Financial year", classes: "meta-data__label" },
+              value: { html: '<span data-test="meta-data-year">' + financialYear + '</span>', classes: "meta-data__value" }
+            }
+          ]
+        })
+      }}
+
+      <a href="/system/bill-runs/{{ billRunId }}" class="govuk-body govuk-link">Go to this bill run</a>
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/bill-runs/create/region.njk
+++ b/app/views/bill-runs/create/region.njk
@@ -1,0 +1,59 @@
+{% extends 'layout.njk' %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+
+{% block breadcrumbs %}
+  {# Back link #}
+  {{
+    govukBackLink({
+      text: 'Back',
+      href: '/system/bill-runs/create/' + id + '/type'
+    })
+  }}
+{% endblock %}
+
+{% block content %}
+  {% if error %}
+    {{ govukErrorSummary({
+      titleText: "There is a problem",
+      errorList: [
+        {
+          text: error.text,
+          href: '#region-error'
+        }
+      ]
+      }) }}
+  {% endif %}
+
+  <div class="govuk-body">
+    <form method="post">
+      {% set regionItems = [] %}
+      {% for region in regions %}
+        {% set regionItem = { text: region.displayName, value: region.id, checked: region.id == selectedRegion } %}
+
+        {# Push our item into the region items array #}
+        {% set regionItems = (regionItems.push(regionItem), regionItems) %}
+      {% endfor %}
+
+      {{ govukRadios({
+        attributes: {
+          'data-test': 'bill-run-region'
+        },
+        name: 'region',
+        errorMessage: error,
+        fieldset: {
+          legend: {
+            text: pageTitle,
+            isPageHeading: true,
+            classes: 'govuk-fieldset__legend--l govuk-!-margin-bottom-6'
+          }
+        },
+        items: regionItems
+      }) }}
+
+      {{govukButton({ text: 'Continue', preventDoubleClick: true }) }}
+    </form>
+  </div>
+{% endblock %}

--- a/app/views/bill-runs/create/season.njk
+++ b/app/views/bill-runs/create/season.njk
@@ -1,0 +1,62 @@
+{% extends 'layout.njk' %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+
+{% block breadcrumbs %}
+  {# Back link #}
+  {{
+    govukBackLink({
+      text: 'Back',
+      href: '/system/bill-runs/create/' + id + '/year'
+    })
+  }}
+{% endblock %}
+
+{% block content %}
+  {% if error %}
+    {{ govukErrorSummary({
+      titleText: 'There is a problem',
+      errorList: [
+        {
+          text: error.text,
+          href: '#season-error'
+        }
+      ]
+      }) }}
+  {% endif %}
+
+  <div class="govuk-body">
+    <form method="post">
+      {{ govukRadios({
+        attributes: {
+          'data-test': 'bill-run-year'
+        },
+        name: 'season',
+        errorMessage: error,
+        fieldset: {
+          legend: {
+            text: pageTitle,
+            isPageHeading: true,
+            classes: 'govuk-fieldset__legend--l govuk-!-margin-bottom-6'
+          }
+        },
+        items: [
+          {
+            text: 'Summer',
+            value: 'summer',
+            checked: 'summer' == selectedSeason
+          },
+          {
+            text: 'Winter and All year',
+            value: 'winter_all_year',
+            checked: 'winter_all_year' == selectedSeason
+          }
+        ]
+      }) }}
+
+      {{ govukButton({ text: 'Continue', preventDoubleClick: true }) }}
+    </form>
+  </div>
+{% endblock %}

--- a/app/views/bill-runs/create/type.njk
+++ b/app/views/bill-runs/create/type.njk
@@ -57,14 +57,6 @@
             text: 'Two-part tariff',
             value: 'two_part_tariff',
             checked: 'two_part_tariff' == selectedType
-          },
-          {
-            text: 'Two-part tariff supplementary',
-            value: 'two_part_tariff_supplementary',
-            checked: 'two_part_tariff_supplementary' == selectedType,
-            hint: {
-              text: 'Current charge scheme only'
-            }
           }
         ]
       }) }}

--- a/app/views/bill-runs/create/type.njk
+++ b/app/views/bill-runs/create/type.njk
@@ -1,0 +1,75 @@
+{% extends 'layout.njk' %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+
+{% block breadcrumbs %}
+  {# Back link #}
+  {{
+    govukBackLink({
+      text: 'Go back to bill runs',
+      href: '/billing/batch/list'
+    })
+  }}
+{% endblock %}
+
+{% block content %}
+  {% if error %}
+    {{ govukErrorSummary({
+      titleText: 'There is a problem',
+      errorList: [
+        {
+          text: error.text,
+          href: '#type-error'
+        }
+      ]
+      }) }}
+  {% endif %}
+
+  <div class="govuk-body">
+    <form method="post">
+      {{ govukRadios({
+        attributes: {
+          'data-test': 'bill-run-type'
+        },
+        name: 'type',
+        errorMessage: error,
+        fieldset: {
+          legend: {
+            text: pageTitle,
+            isPageHeading: true,
+            classes: 'govuk-fieldset__legend--l govuk-!-margin-bottom-6'
+          }
+        },
+        items: [
+          {
+            text: 'Annual',
+            value: 'annual',
+            checked: 'annual' == selectedType
+          },
+          {
+            text: 'Supplementary',
+            value: 'supplementary',
+            checked: 'supplementary' == selectedType
+          },
+          {
+            text: 'Two-part tariff',
+            value: 'two_part_tariff',
+            checked: 'two_part_tariff' == selectedType
+          },
+          {
+            text: 'Two-part tariff supplementary',
+            value: 'two_part_tariff_supplementary',
+            checked: 'two_part_tariff_supplementary' == selectedType,
+            hint: {
+              text: 'Current charge scheme only'
+            }
+          }
+        ]
+      }) }}
+
+      {{ govukButton({ text: 'Continue', preventDoubleClick: true }) }}
+    </form>
+  </div>
+{% endblock %}

--- a/app/views/bill-runs/create/year.njk
+++ b/app/views/bill-runs/create/year.njk
@@ -1,0 +1,59 @@
+{% extends 'layout.njk' %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+
+{% block breadcrumbs %}
+  {# Back link #}
+  {{
+    govukBackLink({
+      text: 'Back',
+      href: '/system/bill-runs/create/' + id + '/region'
+    })
+  }}
+{% endblock %}
+
+{% block content %}
+  {% if error %}
+    {{ govukErrorSummary({
+      titleText: "There is a problem",
+      errorList: [
+        {
+          text: error.text,
+          href: '#year-error'
+        }
+      ]
+      }) }}
+  {% endif %}
+
+  <div class="govuk-body">
+    <form method="post">
+      {% set yearItems = [] %}
+      {% for year in years %}
+        {% set yearItem = { text: year.display, value: year.value, checked: year.value == selectedYear } %}
+
+        {# Push our item into the region items array #}
+        {% set yearItems = (yearItems.push(yearItem), yearItems) %}
+      {% endfor %}
+
+      {{ govukRadios({
+        attributes: {
+          'data-test': 'bill-run-year'
+        },
+        name: 'year',
+        errorMessage: error,
+        fieldset: {
+          legend: {
+            text: pageTitle,
+            isPageHeading: true,
+            classes: 'govuk-fieldset__legend--l govuk-!-margin-bottom-6'
+          }
+        },
+        items: yearItems
+      }) }}
+
+      {{ govukButton({ text: 'Continue', preventDoubleClick: true }) }}
+    </form>
+  </div>
+{% endblock %}

--- a/app/views/bill-runs/create/year.njk
+++ b/app/views/bill-runs/create/year.njk
@@ -29,14 +29,6 @@
 
   <div class="govuk-body">
     <form method="post">
-      {% set yearItems = [] %}
-      {% for year in years %}
-        {% set yearItem = { text: year.display, value: year.value, checked: year.value == selectedYear } %}
-
-        {# Push our item into the region items array #}
-        {% set yearItems = (yearItems.push(yearItem), yearItems) %}
-      {% endfor %}
-
       {{ govukRadios({
         attributes: {
           'data-test': 'bill-run-year'
@@ -50,7 +42,28 @@
             classes: 'govuk-fieldset__legend--l govuk-!-margin-bottom-6'
           }
         },
-        items: yearItems
+        items: [
+          {
+            text: '2023 to 2024',
+            value: '2024',
+            checked: '2024' == selectedYear
+          },
+          {
+            text: '2022 to 2023',
+            value: '2023',
+            checked: '2023' == selectedYear
+          },
+          {
+            text: '2021 to 2022',
+            value: '2022',
+            checked: '2022' == selectedYear
+          },
+          {
+            text: '2020 to 2021',
+            value: '2021',
+            checked: '2021' == selectedYear
+          }
+        ]
       }) }}
 
       {{ govukButton({ text: 'Continue', preventDoubleClick: true }) }}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4375

In the legacy service, there is no clear separation between two-part tariff annual billing and two-part tariff supplementary. The previous team, for the right reasons, tried to cover it all in one. Hindsight has shown it would be better to handle them separately. This is a wish from users as well as those of us who have to build it!

This means we are going to need to _update_ the 'Create a bill run' journey to handle the changes. And if you haven't guessed from how we do things here, what this _really_ means is we get to replace the whole thing! 😁

So, we intend to use this branch to spike out a working version. We'll then break up the changes into smaller PRs for review once we know how we want to do things.