### PR TITLE
Move currentFinancialYear() from test

### DIFF
--- a/app/lib/general.lib.js
+++ b/app/lib/general.lib.js
@@ -45,36 +45,6 @@ function calculateAndLogTimeTaken (startTime, message, data = {}) {
 }
 
 /**
- * Determine the start and end date for the current financial year
- *
- * We often need to work out what the start and end date for the current financial year is. But because the financial
- * year starts on 01-APR and finishes on 31-MAR what that year is will change dependent on the current date.
- *
- * @returns {Object} An object containing a `startDate` and `endDate`
- */
-function currentFinancialYear () {
-  const currentDate = new Date()
-  const currentYear = currentDate.getFullYear()
-
-  let startYear
-  let endYear
-
-  // IMPORTANT! getMonth returns an integer (0-11). So, January is represented as 0 and December as 11. This is why
-  // we use 2 rather than 3 to refer to March
-  if (currentDate.getMonth() <= 2) {
-    // For example, if currentDate was 2022-02-15 it would fall in financial year 2021-04-01 to 2022-03-31
-    startYear = currentYear - 1
-    endYear = currentYear
-  } else {
-    // For example, if currentDate was 2022-06-15 it would fall in financial year 2022-04-01 to 2023-03-31
-    startYear = currentYear
-    endYear = currentYear + 1
-  }
-
-  return { startDate: new Date(startYear, 3, 1), endDate: new Date(endYear, 2, 31) }
-}
-
-/**
  * Returns the current time in nanoseconds. Used as part of logging how long something takes
  *
  * We often want to see how long a process takes and capture it in our logs. This can be especially useful when we
@@ -96,6 +66,36 @@ function currentFinancialYear () {
  */
 function currentTimeInNanoseconds () {
   return process.hrtime.bigint()
+}
+
+/**
+ * Determine the start and end date for the current financial year
+ *
+ * We often need to work out what the start and end date for the current financial year is. But because the financial
+ * year starts on 01-APR and finishes on 31-MAR what that year is will change dependent on the current date.
+ *
+ * @returns {Object} An object containing a `startDate` and `endDate`
+ */
+function determineCurrentFinancialYear () {
+  const currentDate = new Date()
+  const currentYear = currentDate.getFullYear()
+
+  let startYear
+  let endYear
+
+  // IMPORTANT! getMonth returns an integer (0-11). So, January is represented as 0 and December as 11. This is why
+  // we use 2 rather than 3 to refer to March
+  if (currentDate.getMonth() <= 2) {
+    // For example, if currentDate was 2022-02-15 it would fall in financial year 2021-04-01 to 2022-03-31
+    startYear = currentYear - 1
+    endYear = currentYear
+  } else {
+    // For example, if currentDate was 2022-06-15 it would fall in financial year 2022-04-01 to 2023-03-31
+    startYear = currentYear
+    endYear = currentYear + 1
+  }
+
+  return { startDate: new Date(startYear, 3, 1), endDate: new Date(endYear, 2, 31) }
 }
 
 /**
@@ -182,8 +182,8 @@ function timestampForPostgres () {
 
 module.exports = {
   calculateAndLogTimeTaken,
-  currentFinancialYear,
   currentTimeInNanoseconds,
+  determineCurrentFinancialYear,
   generateUUID,
   periodsOverlap,
   timestampForPostgres

--- a/app/lib/general.lib.js
+++ b/app/lib/general.lib.js
@@ -45,6 +45,36 @@ function calculateAndLogTimeTaken (startTime, message, data = {}) {
 }
 
 /**
+ * Determine the start and end date for the current financial year
+ *
+ * We often need to work out what the start and end date for the current financial year is. But because the financial
+ * year starts on 01-APR and finishes on 31-MAR what that year is will change dependent on the current date.
+ *
+ * @returns {Object} An object containing a `startDate` and `endDate`
+ */
+function currentFinancialYear () {
+  const currentDate = new Date()
+  const currentYear = currentDate.getFullYear()
+
+  let startYear
+  let endYear
+
+  // IMPORTANT! getMonth returns an integer (0-11). So, January is represented as 0 and December as 11. This is why
+  // we use 2 rather than 3 to refer to March
+  if (currentDate.getMonth() <= 2) {
+    // For example, if currentDate was 2022-02-15 it would fall in financial year 2021-04-01 to 2022-03-31
+    startYear = currentYear - 1
+    endYear = currentYear
+  } else {
+    // For example, if currentDate was 2022-06-15 it would fall in financial year 2022-04-01 to 2023-03-31
+    startYear = currentYear
+    endYear = currentYear + 1
+  }
+
+  return { startDate: new Date(startYear, 3, 1), endDate: new Date(endYear, 2, 31) }
+}
+
+/**
  * Returns the current time in nanoseconds. Used as part of logging how long something takes
  *
  * We often want to see how long a process takes and capture it in our logs. This can be especially useful when we
@@ -152,6 +182,7 @@ function timestampForPostgres () {
 
 module.exports = {
   calculateAndLogTimeTaken,
+  currentFinancialYear,
   currentTimeInNanoseconds,
   generateUUID,
   periodsOverlap,

--- a/test/lib/general.lib.test.js
+++ b/test/lib/general.lib.test.js
@@ -61,6 +61,47 @@ describe('GeneralLib', () => {
     })
   })
 
+  describe('#currentFinancialYear', () => {
+    let clock
+    let testDate
+
+    afterEach(() => {
+      clock.restore()
+    })
+
+    describe('when the current financial year is 2023 to 2024', () => {
+      describe('and the current date is between April and December', () => {
+        beforeEach(() => {
+          testDate = new Date(2023, 7, 21, 20, 31, 57)
+
+          clock = Sinon.useFakeTimers(testDate)
+        })
+
+        it('returns the correct start and end dates for the financial year', () => {
+          const result = GeneralLib.currentFinancialYear()
+
+          expect(result.startDate).to.equal(new Date('2023-04-01'))
+          expect(result.endDate).to.equal(new Date('2024-03-31'))
+        })
+      })
+
+      describe('and the current date is between January and March', () => {
+        beforeEach(() => {
+          testDate = new Date(2024, 2, 21, 20, 31, 57)
+
+          clock = Sinon.useFakeTimers(testDate)
+        })
+
+        it('returns the correct start and end dates for the financial year', () => {
+          const result = GeneralLib.currentFinancialYear()
+
+          expect(result.startDate).to.equal(new Date('2023-04-01'))
+          expect(result.endDate).to.equal(new Date('2024-03-31'))
+        })
+      })
+    })
+  })
+
   describe('#currentTimeInNanoseconds', () => {
     let timeBeforeTest
 

--- a/test/lib/general.lib.test.js
+++ b/test/lib/general.lib.test.js
@@ -61,7 +61,22 @@ describe('GeneralLib', () => {
     })
   })
 
-  describe('#currentFinancialYear', () => {
+  describe('#currentTimeInNanoseconds', () => {
+    let timeBeforeTest
+
+    beforeEach(() => {
+      timeBeforeTest = process.hrtime.bigint()
+    })
+
+    it('returns the current date and time as an ISO string', () => {
+      const result = GeneralLib.currentTimeInNanoseconds()
+
+      expect(typeof result).to.equal('bigint')
+      expect(result).to.be.greaterThan(timeBeforeTest)
+    })
+  })
+
+  describe('#determineCurrentFinancialYear', () => {
     let clock
     let testDate
 
@@ -78,7 +93,7 @@ describe('GeneralLib', () => {
         })
 
         it('returns the correct start and end dates for the financial year', () => {
-          const result = GeneralLib.currentFinancialYear()
+          const result = GeneralLib.determineCurrentFinancialYear()
 
           expect(result.startDate).to.equal(new Date('2023-04-01'))
           expect(result.endDate).to.equal(new Date('2024-03-31'))
@@ -93,27 +108,12 @@ describe('GeneralLib', () => {
         })
 
         it('returns the correct start and end dates for the financial year', () => {
-          const result = GeneralLib.currentFinancialYear()
+          const result = GeneralLib.determineCurrentFinancialYear()
 
           expect(result.startDate).to.equal(new Date('2023-04-01'))
           expect(result.endDate).to.equal(new Date('2024-03-31'))
         })
       })
-    })
-  })
-
-  describe('#currentTimeInNanoseconds', () => {
-    let timeBeforeTest
-
-    beforeEach(() => {
-      timeBeforeTest = process.hrtime.bigint()
-    })
-
-    it('returns the current date and time as an ISO string', () => {
-      const result = GeneralLib.currentTimeInNanoseconds()
-
-      expect(typeof result).to.equal('bigint')
-      expect(result).to.be.greaterThan(timeBeforeTest)
     })
   })
 

--- a/test/services/bill-runs/annual/fetch-billing-accounts.service.test.js
+++ b/test/services/bill-runs/annual/fetch-billing-accounts.service.test.js
@@ -20,13 +20,13 @@ const DatabaseHelper = require('../../../support/helpers/database.helper.js')
 const LicenceHelper = require('../../../support/helpers/licence.helper.js')
 const RegionHelper = require('../../../support/helpers/region.helper.js')
 
-const { currentFinancialYear } = require('../../../../app/lib/general.lib.js')
+const { determineCurrentFinancialYear } = require('../../../../app/lib/general.lib.js')
 
 // Thing under test
 const FetchBillingAccountsService = require('../../../../app/services/bill-runs/annual/fetch-billing-accounts.service.js')
 
 describe('Fetch Billing Accounts service', () => {
-  const billingPeriod = currentFinancialYear()
+  const billingPeriod = determineCurrentFinancialYear()
 
   let billingAccount
   let billingAccountId

--- a/test/services/bill-runs/annual/fetch-billing-accounts.service.test.js
+++ b/test/services/bill-runs/annual/fetch-billing-accounts.service.test.js
@@ -20,7 +20,7 @@ const DatabaseHelper = require('../../../support/helpers/database.helper.js')
 const LicenceHelper = require('../../../support/helpers/licence.helper.js')
 const RegionHelper = require('../../../support/helpers/region.helper.js')
 
-const { currentFinancialYear } = require('../../../support/helpers/general.helper.js')
+const { currentFinancialYear } = require('../../../../app/lib/general.lib.js')
 
 // Thing under test
 const FetchBillingAccountsService = require('../../../../app/services/bill-runs/annual/fetch-billing-accounts.service.js')

--- a/test/services/bill-runs/annual/process-bill-run.service.test.js
+++ b/test/services/bill-runs/annual/process-bill-run.service.test.js
@@ -12,7 +12,7 @@ const { expect } = Code
 const BillRunError = require('../../../../app/errors/bill-run.error.js')
 const BillRunHelper = require('../../../support/helpers/bill-run.helper.js')
 const BillRunModel = require('../../../../app/models/bill-run.model.js')
-const { currentFinancialYear } = require('../../../support/helpers/general.helper.js')
+const { currentFinancialYear } = require('../../../../app/lib/general.lib.js')
 
 // Things we need to stub
 const ChargingModuleGenerateService = require('../../../../app/services/charging-module/generate-bill-run.service.js')

--- a/test/services/bill-runs/annual/process-bill-run.service.test.js
+++ b/test/services/bill-runs/annual/process-bill-run.service.test.js
@@ -12,7 +12,7 @@ const { expect } = Code
 const BillRunError = require('../../../../app/errors/bill-run.error.js')
 const BillRunHelper = require('../../../support/helpers/bill-run.helper.js')
 const BillRunModel = require('../../../../app/models/bill-run.model.js')
-const { currentFinancialYear } = require('../../../../app/lib/general.lib.js')
+const { determineCurrentFinancialYear } = require('../../../../app/lib/general.lib.js')
 
 // Things we need to stub
 const ChargingModuleGenerateService = require('../../../../app/services/charging-module/generate-bill-run.service.js')
@@ -25,7 +25,7 @@ const ProcessBillingPeriodService = require('../../../../app/services/bill-runs/
 const ProcessBillRunService = require('../../../../app/services/bill-runs/annual/process-bill-run.service.js')
 
 describe('Annual Process Bill Run service', () => {
-  const billingPeriod = currentFinancialYear()
+  const billingPeriod = determineCurrentFinancialYear()
 
   let billRun
   let notifierStub

--- a/test/services/bill-runs/annual/process-billing-period.service.test.js
+++ b/test/services/bill-runs/annual/process-billing-period.service.test.js
@@ -11,7 +11,7 @@ const { expect } = Code
 // Test helpers
 const DatabaseHelper = require('../../../support/helpers/database.helper.js')
 const { generateUUID } = require('../../../../app/lib/general.lib.js')
-const { currentFinancialYear } = require('../../../../app/lib/general.lib.js')
+const { determineCurrentFinancialYear } = require('../../../../app/lib/general.lib.js')
 
 // Things we need to stub
 const BillModel = require('../../../../app/models/bill.model.js')
@@ -24,7 +24,7 @@ const GenerateTransactionsService = require('../../../../app/services/bill-runs/
 const ProcessBillingPeriodService = require('../../../../app/services/bill-runs/annual/process-billing-period.service.js')
 
 describe('Annual Process billing period service', () => {
-  const billingPeriod = currentFinancialYear()
+  const billingPeriod = determineCurrentFinancialYear()
   const billRun = {
     id: '8e0d4c8b-e9fe-4238-8f3e-dfca743316ef',
     externalId: 'f6e052f5-37f9-43f3-a649-ff6398cec1a3'

--- a/test/services/bill-runs/annual/process-billing-period.service.test.js
+++ b/test/services/bill-runs/annual/process-billing-period.service.test.js
@@ -11,7 +11,7 @@ const { expect } = Code
 // Test helpers
 const DatabaseHelper = require('../../../support/helpers/database.helper.js')
 const { generateUUID } = require('../../../../app/lib/general.lib.js')
-const { currentFinancialYear } = require('../../../support/helpers/general.helper.js')
+const { currentFinancialYear } = require('../../../../app/lib/general.lib.js')
 
 // Things we need to stub
 const BillModel = require('../../../../app/models/bill.model.js')

--- a/test/services/bill-runs/check-live-bill-run.service.test.js
+++ b/test/services/bill-runs/check-live-bill-run.service.test.js
@@ -10,13 +10,13 @@ const { expect } = Code
 // Test helpers
 const BillRunHelper = require('../../support/helpers/bill-run.helper.js')
 const DatabaseHelper = require('../../support/helpers/database.helper.js')
-const { currentFinancialYear } = require('../../../app/lib/general.lib.js')
+const { determineCurrentFinancialYear } = require('../../../app/lib/general.lib.js')
 
 // Thing under test
 const CheckLiveBillRunService = require('../../../app/services/bill-runs/check-live-bill-run.service.js')
 
 describe('Check Live Bill Run service', () => {
-  const billingPeriod = currentFinancialYear()
+  const billingPeriod = determineCurrentFinancialYear()
   const regionId = '6ec2f8b5-70e2-4abf-8ba9-026971d9de52'
   const toFinancialYearEnding = billingPeriod.endDate.getFullYear()
 

--- a/test/services/bill-runs/check-live-bill-run.service.test.js
+++ b/test/services/bill-runs/check-live-bill-run.service.test.js
@@ -10,7 +10,7 @@ const { expect } = Code
 // Test helpers
 const BillRunHelper = require('../../support/helpers/bill-run.helper.js')
 const DatabaseHelper = require('../../support/helpers/database.helper.js')
-const { currentFinancialYear } = require('../../support/helpers/general.helper.js')
+const { currentFinancialYear } = require('../../../app/lib/general.lib.js')
 
 // Thing under test
 const CheckLiveBillRunService = require('../../../app/services/bill-runs/check-live-bill-run.service.js')

--- a/test/support/helpers/general.helper.js
+++ b/test/support/helpers/general.helper.js
@@ -6,37 +6,6 @@
  */
 
 /**
- * Determine the start and end date for the current financial year
- *
- * For testing purposes we often need to work out what the start and end date for the current financial year is. But
- * because the financial year starts on 01-APR and finishes on 31-MAR what that year is will change dependent on the
- * current date.
- *
- * @returns {Object} An object containing a `startDate` and `endDate`
- */
-function currentFinancialYear () {
-  const currentDate = new Date()
-  const currentYear = currentDate.getFullYear()
-
-  let startYear
-  let endYear
-
-  // IMPORTANT! getMonth returns an integer (0-11). So, January is represented as 0 and December as 11. This is why
-  // we use 2 rather than 3 to refer to March
-  if (currentDate.getMonth() <= 2) {
-    // For example, if currentDate was 2022-02-15 it would fall in financial year 2021-04-01 to 2022-03-31
-    startYear = currentYear - 1
-    endYear = currentYear
-  } else {
-    // For example, if currentDate was 2022-06-15 it would fall in financial year 2022-04-01 to 2023-03-31
-    startYear = currentYear
-    endYear = currentYear + 1
-  }
-
-  return { startDate: new Date(startYear, 3, 1), endDate: new Date(endYear, 2, 31) }
-}
-
-/**
  * Generate a random integer within a range (inclusive)
  *
  * @param {Number} min lowest number (integer) in the range (inclusive)
@@ -51,6 +20,5 @@ function randomInteger (min, max) {
 }
 
 module.exports = {
-  currentFinancialYear,
   randomInteger
 }

--- a/test/support/helpers/transaction.helper.js
+++ b/test/support/helpers/transaction.helper.js
@@ -5,7 +5,7 @@
  */
 
 const { generateChargeReference } = require('./charge-category.helper.js')
-const { currentFinancialYear } = require('../../../app/lib/general.lib.js')
+const { determineCurrentFinancialYear } = require('../../../app/lib/general.lib.js')
 const { generateUUID } = require('../../../app/lib/general.lib.js')
 const TransactionModel = require('../../../app/models/transaction.model.js')
 
@@ -58,7 +58,7 @@ function add (data = {}) {
  * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
  */
 function defaults (data = {}) {
-  const { startDate, endDate } = currentFinancialYear()
+  const { startDate, endDate } = determineCurrentFinancialYear()
 
   const defaults = {
     adjustmentFactor: 1,

--- a/test/support/helpers/transaction.helper.js
+++ b/test/support/helpers/transaction.helper.js
@@ -5,7 +5,7 @@
  */
 
 const { generateChargeReference } = require('./charge-category.helper.js')
-const { currentFinancialYear } = require('../helpers/general.helper.js')
+const { currentFinancialYear } = require('../../../app/lib/general.lib.js')
 const { generateUUID } = require('../../../app/lib/general.lib.js')
 const TransactionModel = require('../../../app/models/transaction.model.js')
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4375

> Part of a series of changes related to replacing the create bill run journey to incorporate changes for two-part tariff

We create a function for testing that can determine what the current financial year is. We now need that function in the main code. So, this change moves it from the test helper to `GeneralLib`.