### PR TITLE
Add defra-user-id header to legacy requests

### DIFF
--- a/test/lib/legacy-request.lib.test.js
+++ b/test/lib/legacy-request.lib.test.js
@@ -180,7 +180,7 @@ describe('LegacyRequestLib', () => {
       it('can add the defra-user-id header', async () => {
         await LegacyRequestLib.post('import', testPath, 1234, false, requestBody)
 
-        const requestArgs = RequestLib.get.firstCall.args
+        const requestArgs = RequestLib.post.firstCall.args
 
         expect(requestArgs[1].headers['defra-internal-user-id']).to.equal(1234)
       })

--- a/test/lib/legacy-request.lib.test.js
+++ b/test/lib/legacy-request.lib.test.js
@@ -68,7 +68,7 @@ describe('LegacyRequestLib', () => {
       })
 
       it('can handle none API requests', async () => {
-        await LegacyRequestLib.get('import', testPath, false)
+        await LegacyRequestLib.get('import', testPath, null, false)
 
         const requestArgs = RequestLib.get.firstCall.args
 
@@ -131,7 +131,7 @@ describe('LegacyRequestLib', () => {
       })
 
       it('calls the legacy service with the required options', async () => {
-        await LegacyRequestLib.post('import', testPath, true, requestBody)
+        await LegacyRequestLib.post('import', testPath, null, true, requestBody)
 
         const requestArgs = RequestLib.post.firstCall.args
 
@@ -143,26 +143,26 @@ describe('LegacyRequestLib', () => {
       })
 
       it('returns a `true` success status', async () => {
-        const result = await LegacyRequestLib.post('import', testPath, true, requestBody)
+        const result = await LegacyRequestLib.post('import', testPath, null, true, requestBody)
 
         expect(result.succeeded).to.be.true()
       })
 
       it('returns the response body as an object', async () => {
-        const result = await LegacyRequestLib.post('import', testPath, true, requestBody)
+        const result = await LegacyRequestLib.post('import', testPath, null, true, requestBody)
 
         expect(result.response.body.version).to.equal('3.1.2')
         expect(result.response.body.commit).to.equal('70708cff586cc410c11af25cf8fd296f987d7f36')
       })
 
       it('returns the status code', async () => {
-        const result = await LegacyRequestLib.post('import', testPath, true, requestBody)
+        const result = await LegacyRequestLib.post('import', testPath, null, true, requestBody)
 
         expect(result.response.statusCode).to.equal(200)
       })
 
       it('can handle none API requests', async () => {
-        await LegacyRequestLib.post('import', testPath, false, requestBody)
+        await LegacyRequestLib.post('import', testPath, null, false, requestBody)
 
         const requestArgs = RequestLib.post.firstCall.args
 
@@ -183,19 +183,19 @@ describe('LegacyRequestLib', () => {
       })
 
       it('returns a `false` success status', async () => {
-        const result = await LegacyRequestLib.post('import', testPath, true, requestBody)
+        const result = await LegacyRequestLib.post('import', testPath, null, true, requestBody)
 
         expect(result.succeeded).to.be.false()
       })
 
       it('returns the error response', async () => {
-        const result = await LegacyRequestLib.post('import', testPath, true, requestBody)
+        const result = await LegacyRequestLib.post('import', testPath, null, true, requestBody)
 
         expect(result.response.body.message).to.equal('Not Found')
       })
 
       it('returns the status code', async () => {
-        const result = await LegacyRequestLib.post('import', testPath, true, requestBody)
+        const result = await LegacyRequestLib.post('import', testPath, null, true, requestBody)
 
         expect(result.response.statusCode).to.equal(404)
       })
@@ -203,7 +203,7 @@ describe('LegacyRequestLib', () => {
 
     describe('when the request is to an unknown legacy service', () => {
       it('throws an error', async () => {
-        await expect(LegacyRequestLib.post('foobar', testPath, true, requestBody))
+        await expect(LegacyRequestLib.post('foobar', testPath, null, true, requestBody))
           .to
           .reject(Error, 'Request to unknown legacy service foobar')
       })

--- a/test/lib/legacy-request.lib.test.js
+++ b/test/lib/legacy-request.lib.test.js
@@ -74,6 +74,14 @@ describe('LegacyRequestLib', () => {
 
         expect(requestArgs[1].prefixUrl).to.equal(servicesConfig.import.url)
       })
+
+      it('can add the defra-user-id header', async () => {
+        await LegacyRequestLib.get('import', testPath, 1234, false)
+
+        const requestArgs = RequestLib.get.firstCall.args
+
+        expect(requestArgs[1].headers['defra-internal-user-id']).to.equal(1234)
+      })
     })
 
     describe('when the request fails', () => {
@@ -167,6 +175,14 @@ describe('LegacyRequestLib', () => {
         const requestArgs = RequestLib.post.firstCall.args
 
         expect(requestArgs[1].prefixUrl).to.equal(servicesConfig.import.url)
+      })
+
+      it('can add the defra-user-id header', async () => {
+        await LegacyRequestLib.post('import', testPath, 1234, false, requestBody)
+
+        const requestArgs = RequestLib.get.firstCall.args
+
+        expect(requestArgs[1].headers['defra-internal-user-id']).to.equal(1234)
       })
     })
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4375

> Part of a series of changes related to replacing the create bill run journey to incorporate changes for two-part tariff

If we are to take over the create bill run journey it means _we_ are now responsible for triggering legacy bill runs rather than vice versa. That means we need to trigger the [water-abstraction-service](https://github.com/DEFRA/water-abstraction-service) `POST /water/1.0/billing/batches` endpoint.

Simple, we thought! We already have `LegacyRequestLib` that adds support for talking to the other services from our project. That was until we kept getting `403` errors. After some digging, we found the cause.

Just like in our project and [water-abstraction-ui](https://github.com/DEFRA/water-abstraction-ui) some of the internal legacy services also have an authorization strategy that applies [scope](https://hapi.dev/api/?v=21.3.3#-routeoptionsauthaccessscope) to their routes. We authenticate with them using the shared JWT token the previous team left behind. But that is not enough for those routes which have, for example, 'billing' configured as their authorization scope.

They expect the legacy UI to also let them know who the user is behind the request being made so they can confirm they have authorization to do that 'thing'. As this has already been checked by the UI it is pointless and wasteful. But it is what it is!

**water-abstraction-service** for example appears to have a couple of strategies; decoding the user email from the JWT token being one of them. But we suspect this was abandoned in favour of adding the user's `userId` as a header in the request.

If the header exists, the downstream service will extract the ID from it, make a call to [water-abstraction-tactical-idm](https://github.com/DEFRA/water-abstraction-tactical-idm) and then confirm the user and their scope. If they match the request is accepted.

All this means we need to update our `LegacyRequestLib` to support adding the `defra-internal-user-id` header to requests that need it.