### PR TITLE
Move legacy refresh requests to module

### DIFF
--- a/app/requests/charging-module/generate-bill-run.request.js
+++ b/app/requests/charging-module/generate-bill-run.request.js
@@ -8,17 +8,17 @@
 const ChargingModuleRequest = require('../charging-module.request.js')
 
 /**
- * Delete a bill run in the Charging Module API
+ * Generate a bill run in the Charging Module API
  *
- * See {@link https://defra.github.io/sroc-charging-module-api-docs/#/bill-run/DeleteBillRun | CHA API docs} for more
+ * See {@link https://defra.github.io/sroc-charging-module-api-docs/#/bill-run/GenerateBillRun | CHA API docs} for more
  * details
  *
  * @param {string} billRunId - UUID of the Charging Module API bill run to generate
  *
  * @returns {Promise<Object>} The result of the request; whether it succeeded and the response or error returned
  */
-async function send (billingRunId) {
-  const path = `v3/wrls/bill-runs/${billingRunId}/generate`
+async function send (billRunId) {
+  const path = `v3/wrls/bill-runs/${billRunId}/generate`
   const result = await ChargingModuleRequest.patch(path)
 
   return result

--- a/app/requests/legacy/refresh-bill-run.request.js
+++ b/app/requests/legacy/refresh-bill-run.request.js
@@ -1,0 +1,33 @@
+'use strict'
+
+/**
+ * Connects with the water-abstraction-service to refresh a bill run
+ * @module RefreshBillRunRequest
+ */
+
+const LegacyRequest = require('../legacy.request.js')
+
+/**
+ * Send a request to the legacy water-abstraction-service to refresh a bill run
+ *
+ * After the Charging Module API has
+ * {@link https://defra.github.io/sroc-charging-module-api-docs/#/bill-run/GenerateBillRun | generated} a bill run we
+ * need to update the data on our side with the calculated bill totals plus any additional transactions the CHA has
+ * deemed necessary.
+ *
+ * This is handled by the legacy service so we need to send a request in order to start the process.
+ *
+ * @param {string} billRunId - UUID of the bill run to refresh
+ *
+ * @returns {Promise<Object>} The result of the request; whether it succeeded and the response or error returned
+ */
+async function send (billRunId) {
+  const path = `billing/batches/${billRunId}/refresh`
+  const result = await LegacyRequest.post('water', path)
+
+  return result
+}
+
+module.exports = {
+  send
+}

--- a/app/services/bill-runs/annual/process-bill-run.service.js
+++ b/app/services/bill-runs/annual/process-bill-run.service.js
@@ -10,7 +10,7 @@ const BillRunError = require('../../../errors/bill-run.error.js')
 const ChargingModuleGenerateBillRunRequest = require('../../../requests/charging-module/generate-bill-run.request.js')
 const FetchBillingAccountsService = require('./fetch-billing-accounts.service.js')
 const { calculateAndLogTimeTaken } = require('../../../lib/general.lib.js')
-const LegacyRequest = require('../../../requests/legacy.request.js')
+const LegacyRefreshBillRunRequest = require('../../../requests/legacy/refresh-bill-run.request.js')
 const ProcessBillingPeriodService = require('./process-billing-period.service.js')
 const HandleErroredBillRunService = require('../handle-errored-bill-run.service.js')
 
@@ -80,7 +80,7 @@ async function _finaliseBillRun (billRun, billRunPopulated) {
   // the debit and credit amounts, and adds any additional transactions needed, for example, minimum charge
   await ChargingModuleGenerateBillRunRequest.send(billRun.externalId)
 
-  await LegacyRequest.post('water', `billing/batches/${billRun.id}/refresh`)
+  await LegacyRefreshBillRunRequest.send(billRun.id)
 }
 
 async function _processBillingPeriod (billingPeriod, billRun) {

--- a/app/services/bill-runs/supplementary/process-bill-run.service.js
+++ b/app/services/bill-runs/supplementary/process-bill-run.service.js
@@ -11,7 +11,7 @@ const ChargingModuleGenerateBillRunRequest = require('../../../requests/charging
 const FetchChargeVersionsService = require('./fetch-charge-versions.service.js')
 const { calculateAndLogTimeTaken, currentTimeInNanoseconds } = require('../../../lib/general.lib.js')
 const HandleErroredBillRunService = require('../handle-errored-bill-run.service.js')
-const LegacyRequest = require('../../../requests/legacy.request.js')
+const LegacyRefreshBillRunRequest = require('../../../requests/legacy/refresh-bill-run.request.js')
 const ProcessBillingPeriodService = require('./process-billing-period.service.js')
 const ReissueBillsService = require('./reissue-bills.service.js')
 const UnflagUnbilledLicencesService = require('./unflag-unbilled-licences.service.js')
@@ -116,7 +116,7 @@ async function _finaliseBillRun (billRun, accumulatedLicenceIds, resultsOfProces
   // the debit and credit amounts, and adds any additional transactions needed, for example, minimum charge
   await ChargingModuleGenerateBillRunRequest.send(billRun.externalId)
 
-  await LegacyRequest.post('water', `billing/batches/${billRun.id}/refresh`)
+  await LegacyRefreshBillRunRequest.send(billRun.id)
 }
 
 function _logError (billRun, error) {

--- a/test/requests/legacy/refresh-bill-run.request.test.js
+++ b/test/requests/legacy/refresh-bill-run.request.test.js
@@ -1,0 +1,104 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { describe, it, beforeEach, afterEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Things we need to stub
+const LegacyRequest = require('../../../app/requests/legacy.request.js')
+
+// Thing under test
+const RefreshBillRunRequest = require('../../../app/requests/legacy/refresh-bill-run.request.js')
+
+describe('Legacy Refresh Bill Run request', () => {
+  const billRunId = '2bbbe459-966e-4026-b5d2-2f10867bdddd'
+
+  afterEach(() => {
+    Sinon.restore()
+  })
+
+  describe('when the request can refresh a bill run', () => {
+    beforeEach(async () => {
+      Sinon.stub(LegacyRequest, 'post').resolves({
+        succeeded: true,
+        response: {
+          statusCode: 200,
+          body: null
+        }
+      })
+    })
+
+    it('returns a `true` success status', async () => {
+      const result = await RefreshBillRunRequest.send(billRunId)
+
+      expect(result.succeeded).to.be.true()
+    })
+
+    it('returns a 200 - ok', async () => {
+      const result = await RefreshBillRunRequest.send(billRunId)
+
+      expect(result.response.statusCode).to.equal(200)
+      expect(result.response.body).to.be.null()
+    })
+  })
+
+  describe('when the request cannot refresh a bill run', () => {
+    describe('because the request did not return a 2xx/3xx response', () => {
+      beforeEach(async () => {
+        Sinon.stub(LegacyRequest, 'post').resolves({
+          succeeded: false,
+          response: {
+            statusCode: 401,
+            body: {
+              statusCode: 401,
+              error: 'Unauthorized',
+              message: 'Invalid JWT: Token format not valid',
+              attributes: { error: 'Invalid JWT: Token format not valid' }
+            }
+          }
+        })
+      })
+
+      it('returns a `false` success status', async () => {
+        const result = await RefreshBillRunRequest.send(billRunId)
+
+        expect(result.succeeded).to.be.false()
+      })
+
+      it('returns the error in the `response`', async () => {
+        const result = await RefreshBillRunRequest.send(billRunId)
+
+        expect(result.response.body.statusCode).to.equal(401)
+        expect(result.response.body.error).to.equal('Unauthorized')
+        expect(result.response.body.message).to.equal('Invalid JWT: Token format not valid')
+      })
+    })
+
+    describe('because the request attempt returned an error, for example, TimeoutError', () => {
+      beforeEach(async () => {
+        Sinon.stub(LegacyRequest, 'post').resolves({
+          succeeded: false,
+          response: new Error("Timeout awaiting 'request' for 5000ms")
+        })
+      })
+
+      it('returns a `false` success status', async () => {
+        const result = await RefreshBillRunRequest.send(billRunId)
+
+        expect(result.succeeded).to.be.false()
+      })
+
+      it('returns the error in the `response`', async () => {
+        const result = await RefreshBillRunRequest.send(billRunId)
+
+        expect(result.response.statusCode).not.to.exist()
+        expect(result.response.body).not.to.exist()
+        expect(result.response.message).to.equal("Timeout awaiting 'request' for 5000ms")
+      })
+    })
+  })
+})

--- a/test/services/bill-runs/annual/process-bill-run.service.test.js
+++ b/test/services/bill-runs/annual/process-bill-run.service.test.js
@@ -18,7 +18,7 @@ const { determineCurrentFinancialYear } = require('../../../../app/lib/general.l
 const ChargingModuleGenerateRequest = require('../../../../app/requests/charging-module/generate-bill-run.request.js')
 const FetchBillingAccountsService = require('../../../../app/services/bill-runs/annual/fetch-billing-accounts.service.js')
 const HandleErroredBillRunService = require('../../../../app/services/bill-runs/handle-errored-bill-run.service.js')
-const LegacyRequest = require('../../../../app/requests/legacy.request.js')
+const LegacyRefreshBillRunRequest = require('../../../../app/requests/legacy/refresh-bill-run.request.js')
 const ProcessBillingPeriodService = require('../../../../app/services/bill-runs/annual/process-billing-period.service.js')
 
 // Thing under test
@@ -66,11 +66,11 @@ describe('Annual Process Bill Run service', () => {
 
     describe('and something is billed', () => {
       let chargingModuleGenerateRequestStub
-      let legacyRequestStub
+      let legacyRefreshBillRunRequestStub
 
       beforeEach(() => {
         chargingModuleGenerateRequestStub = Sinon.stub(ChargingModuleGenerateRequest, 'send')
-        legacyRequestStub = Sinon.stub(LegacyRequest, 'post')
+        legacyRefreshBillRunRequestStub = Sinon.stub(LegacyRefreshBillRunRequest, 'send')
 
         Sinon.stub(ProcessBillingPeriodService, 'go').resolves(true)
       })
@@ -92,7 +92,7 @@ describe('Annual Process Bill Run service', () => {
       it('tells the legacy service to start its refresh job', async () => {
         await ProcessBillRunService.go(billRun, [billingPeriod])
 
-        expect(legacyRequestStub.called).to.be.true()
+        expect(legacyRefreshBillRunRequestStub.called).to.be.true()
       })
     })
   })

--- a/test/services/bill-runs/supplementary/process-bill-run.service.test.js
+++ b/test/services/bill-runs/supplementary/process-bill-run.service.test.js
@@ -19,7 +19,7 @@ const ChargingModuleGenerateBillRunRequest = require('../../../../app/requests/c
 const FeatureFlagsConfig = require('../../../../config/feature-flags.config.js')
 const FetchChargeVersionsService = require('../../../../app/services/bill-runs/supplementary/fetch-charge-versions.service.js')
 const HandleErroredBillRunService = require('../../../../app/services/bill-runs/handle-errored-bill-run.service.js')
-const LegacyRequest = require('../../../../app/requests/legacy.request.js')
+const LegacyRefreshBillRunRequest = require('../../../../app/requests/legacy/refresh-bill-run.request.js')
 const ProcessBillingPeriodService = require('../../../../app/services/bill-runs/supplementary/process-billing-period.service.js')
 const ReissueBillsService = require('../../../../app/services/bill-runs/supplementary/reissue-bills.service.js')
 const UnflagUnbilledLicencesService = require('../../../../app/services/bill-runs/supplementary/unflag-unbilled-licences.service.js')
@@ -36,7 +36,7 @@ describe('Supplementary Process Bill Run service', () => {
   let billRun
   let chargingModuleGenerateBillRunRequestStub
   let handleErroredBillRunStub
-  let legacyRequestStub
+  let legacyRefreshBillRunRequestStub
   let notifierStub
 
   beforeEach(async () => {
@@ -46,7 +46,7 @@ describe('Supplementary Process Bill Run service', () => {
 
     handleErroredBillRunStub = Sinon.stub(HandleErroredBillRunService, 'go')
     chargingModuleGenerateBillRunRequestStub = Sinon.stub(ChargingModuleGenerateBillRunRequest, 'send')
-    legacyRequestStub = Sinon.stub(LegacyRequest, 'post')
+    legacyRefreshBillRunRequestStub = Sinon.stub(LegacyRefreshBillRunRequest, 'send')
 
     // The service depends on GlobalNotifier to have been set. This happens in app/plugins/global-notifier.plugin.js
     // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
@@ -126,7 +126,7 @@ describe('Supplementary Process Bill Run service', () => {
       it('tells the legacy service to start its refresh job', async () => {
         await SupplementaryProcessBillRunService.go(billRun, billingPeriods)
 
-        expect(legacyRequestStub.called).to.be.true()
+        expect(legacyRefreshBillRunRequestStub.called).to.be.true()
       })
 
       it('it logs the time taken', async () => {

--- a/test/services/bill-runs/supplementary/reissue-bills.service.test.js
+++ b/test/services/bill-runs/supplementary/reissue-bills.service.test.js
@@ -19,7 +19,6 @@ const TransactionHelper = require('../../../support/helpers/transaction.helper.j
 const TransactionModel = require('../../../../app/models/transaction.model.js')
 
 // Things we need to stub
-const LegacyRequest = require('../../../../app/requests/legacy.request.js')
 const FetchBillsToBeReissuedService = require('../../../../app/services/bill-runs/supplementary/fetch-bills-to-be-reissued.service.js')
 const ReissueBillService = require('../../../../app/services/bill-runs/supplementary/reissue-bill.service.js')
 
@@ -34,8 +33,6 @@ describe('Reissue Bills service', () => {
 
   beforeEach(async () => {
     await DatabaseSupport.clean()
-
-    Sinon.stub(LegacyRequest, 'post')
 
     // The service depends on GlobalNotifier to have been set. This happens in app/plugins/global-notifier.plugin.js
     // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4375

> Part of a series of changes related to replacing the create bill run journey to incorporate changes for two-part tariff

In [Migrate Charging Module services to *.request.js](https://github.com/DEFRA/water-abstraction-system/pull/797) we made structural changes to where the code that sends requests to 3rd party apps sits. This was in preparation for this change. For each request type, we send to the [Charging Module API](https://github.com/DEFRA/sroc-charging-mdoule-api) we have a module. This removes duplication, centralises how that type of request is made and makes the intent clearer.

But for legacy requests, we're just using `Legacy.request.js` directly. We want a consistent pattern for how these things are done, especially as we are on the cusp of adding a new legacy request type. So, having moved the Charging Module requests to the pattern we want to adopt, it is now time to move how we send requests to the Legacy apps to refresh a bill run.