### PR TITLE
Return instead of await requests

### DIFF
--- a/app/requests/charging-module/create-customer-change.request.js
+++ b/app/requests/charging-module/create-customer-change.request.js
@@ -18,9 +18,9 @@ const ChargingModuleRequest = require('../charging-module.request.js')
  * @returns {Promise<Object>} The result of the request; whether it succeeded and the response or error returned
  */
 async function send (customerChangeData) {
-  const result = await ChargingModuleRequest.post('v3/wrls/customer-changes', customerChangeData)
+  const path = 'v3/wrls/customer-changes'
 
-  return result
+  return ChargingModuleRequest.post(path, customerChangeData)
 }
 
 module.exports = {

--- a/app/requests/charging-module/create-transaction.request.js
+++ b/app/requests/charging-module/create-transaction.request.js
@@ -20,9 +20,8 @@ const ChargingModuleRequest = require('../charging-module.request.js')
  */
 async function send (billRunId, transactionData) {
   const path = `v3/wrls/bill-runs/${billRunId}/transactions`
-  const result = await ChargingModuleRequest.post(path, transactionData)
 
-  return result
+  return ChargingModuleRequest.post(path, transactionData)
 }
 
 module.exports = {

--- a/app/requests/charging-module/delete-bill-run.request.js
+++ b/app/requests/charging-module/delete-bill-run.request.js
@@ -19,9 +19,8 @@ const ChargingModuleRequest = require('../charging-module.request.js')
  */
 async function send (billRunId) {
   const path = `v3/wrls/bill-runs/${billRunId}`
-  const result = await ChargingModuleRequest.delete(path)
 
-  return result
+  return ChargingModuleRequest.delete(path)
 }
 
 module.exports = {

--- a/app/requests/charging-module/generate-bill-run.request.js
+++ b/app/requests/charging-module/generate-bill-run.request.js
@@ -19,9 +19,8 @@ const ChargingModuleRequest = require('../charging-module.request.js')
  */
 async function send (billRunId) {
   const path = `v3/wrls/bill-runs/${billRunId}/generate`
-  const result = await ChargingModuleRequest.patch(path)
 
-  return result
+  return ChargingModuleRequest.patch(path)
 }
 
 module.exports = {

--- a/app/requests/charging-module/reissue-bill.request.js
+++ b/app/requests/charging-module/reissue-bill.request.js
@@ -22,9 +22,8 @@ const ChargingModuleRequest = require('../charging-module.request.js')
 */
 async function send (billRunId, billId) {
   const path = `v3/wrls/bill-runs/${billRunId}/invoices/${billId}/rebill`
-  const result = await ChargingModuleRequest.patch(path)
 
-  return result
+  return ChargingModuleRequest.patch(path)
 }
 
 module.exports = {

--- a/app/requests/charging-module/view-bill-run-status.request.js
+++ b/app/requests/charging-module/view-bill-run-status.request.js
@@ -19,9 +19,8 @@ const ChargingModuleRequest = require('../charging-module.request.js')
  */
 async function send (billRunId) {
   const path = `v3/wrls/bill-runs/${billRunId}/status`
-  const result = await ChargingModuleRequest.get(path)
 
-  return result
+  return ChargingModuleRequest.get(path)
 }
 
 module.exports = {

--- a/app/requests/charging-module/view-bill.request.js
+++ b/app/requests/charging-module/view-bill.request.js
@@ -20,9 +20,8 @@ const ChargingModuleRequest = require('../charging-module.request.js')
 */
 async function send (billRunId, billId) {
   const path = `v3/wrls/bill-runs/${billRunId}/invoices/${billId}`
-  const result = await ChargingModuleRequest.get(path)
 
-  return result
+  return ChargingModuleRequest.get(path)
 }
 
 module.exports = {

--- a/app/requests/legacy/refresh-bill-run.request.js
+++ b/app/requests/legacy/refresh-bill-run.request.js
@@ -23,9 +23,8 @@ const LegacyRequest = require('../legacy.request.js')
  */
 async function send (billRunId) {
   const path = `billing/batches/${billRunId}/refresh`
-  const result = await LegacyRequest.post('water', path)
 
-  return result
+  return LegacyRequest.post('water', path)
 }
 
 module.exports = {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4375

> Part of a series of changes related to replacing the create bill run journey to incorporate changes for two-part tariff

The code that calls these requests should have the option to decide whether the request needs to be awaited or not. If we return directly rather than `const results await` they have that option.

This updates the requests to return rather than await the result. There will be no impact on the code because it is already awaiting these requests when they are used.