### PR TITLE
Add legacy create bill run request

### DIFF
--- a/app/requests/legacy/create-bill-run.request.js
+++ b/app/requests/legacy/create-bill-run.request.js
@@ -1,0 +1,40 @@
+'use strict'
+
+/**
+ * Connects with the water-abstraction-service to create a bill run
+ * @module CreateBillRunRequest
+ */
+
+const LegacyRequest = require('../legacy.request.js')
+
+/**
+ * Send a request to the legacy water-abstraction-service to create a bill run
+ *
+ * @param {string} batchType - the type of bill run the legacy service needs to create. We only expect this to be
+ * sending `supplementary` and `two_part_tariff` as annual is now handled by us.
+ * @param {string} regionID - UUID of the region the bill run is for
+ * @param {number} financialYearEnding - The end year for the financial year to be generated
+ * @param {module:UserModel} user - Instance representing the user that originated the request
+ * @param {boolean} [summer] - Only relates to two-part tariff. In PRESROC 2PT bill runs were split by summer or winter
+ * and all-year. This tells the legacy engine which kind of 2PT bill run to generate
+ *
+ * @returns {Promise<Object>} The result of the request; whether it succeeded and the response or error returned
+ */
+async function send (batchType, regionId, financialYearEnding, user, summer = false) {
+  const { id: userId, username: userEmail } = user
+
+  const path = 'billing/batches'
+  const body = {
+    batchType,
+    financialYearEnding,
+    regionId,
+    isSummer: summer,
+    userEmail
+  }
+
+  return LegacyRequest.post('water', path, userId, true, body)
+}
+
+module.exports = {
+  send
+}

--- a/test/requests/legacy/create-bill-run.request.test.js
+++ b/test/requests/legacy/create-bill-run.request.test.js
@@ -1,0 +1,108 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { describe, it, beforeEach, afterEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Things we need to stub
+const LegacyRequest = require('../../../app/requests/legacy.request.js')
+
+// Thing under test
+const CreateBillRunRequest = require('../../../app/requests/legacy/create-bill-run.request.js')
+
+describe('Legacy Create Bill Run request', () => {
+  const batchType = 'two_part_tariff'
+  const regionId = '8feaf2c1-f7cd-47f1-93b9-0d2218d20d56'
+  const financialYearEnding = 2024
+  const user = { id: '1c4ce580-9053-4531-ba23-d0cf0caf0562', username: 'carol.shaw@atari.com' }
+  const summer = true
+
+  afterEach(() => {
+    Sinon.restore()
+  })
+
+  describe('when the request can create a bill run', () => {
+    beforeEach(async () => {
+      Sinon.stub(LegacyRequest, 'post').resolves({
+        succeeded: true,
+        response: {
+          statusCode: 200,
+          body: null
+        }
+      })
+    })
+
+    it('returns a `true` success status', async () => {
+      const result = await CreateBillRunRequest.send(batchType, regionId, financialYearEnding, user, summer)
+
+      expect(result.succeeded).to.be.true()
+    })
+
+    it('returns a 200 - ok', async () => {
+      const result = await CreateBillRunRequest.send(batchType, regionId, financialYearEnding, user, summer)
+
+      expect(result.response.statusCode).to.equal(200)
+      expect(result.response.body).to.be.null()
+    })
+  })
+
+  describe('when the request cannot create a bill run', () => {
+    describe('because the request did not return a 2xx/3xx response', () => {
+      beforeEach(async () => {
+        Sinon.stub(LegacyRequest, 'post').resolves({
+          succeeded: false,
+          response: {
+            statusCode: 401,
+            body: {
+              statusCode: 401,
+              error: 'Unauthorized',
+              message: 'Invalid JWT: Token format not valid',
+              attributes: { error: 'Invalid JWT: Token format not valid' }
+            }
+          }
+        })
+      })
+
+      it('returns a `false` success status', async () => {
+        const result = await CreateBillRunRequest.send(batchType, regionId, financialYearEnding, user, summer)
+
+        expect(result.succeeded).to.be.false()
+      })
+
+      it('returns the error in the `response`', async () => {
+        const result = await CreateBillRunRequest.send(batchType, regionId, financialYearEnding, user, summer)
+
+        expect(result.response.body.statusCode).to.equal(401)
+        expect(result.response.body.error).to.equal('Unauthorized')
+        expect(result.response.body.message).to.equal('Invalid JWT: Token format not valid')
+      })
+    })
+
+    describe('because the request attempt returned an error, for example, TimeoutError', () => {
+      beforeEach(async () => {
+        Sinon.stub(LegacyRequest, 'post').resolves({
+          succeeded: false,
+          response: new Error("Timeout awaiting 'request' for 5000ms")
+        })
+      })
+
+      it('returns a `false` success status', async () => {
+        const result = await CreateBillRunRequest.send(batchType, regionId, financialYearEnding, user, summer)
+
+        expect(result.succeeded).to.be.false()
+      })
+
+      it('returns the error in the `response`', async () => {
+        const result = await CreateBillRunRequest.send(batchType, regionId, financialYearEnding, user, summer)
+
+        expect(result.response.statusCode).not.to.exist()
+        expect(result.response.body).not.to.exist()
+        expect(result.response.message).to.equal("Timeout awaiting 'request' for 5000ms")
+      })
+    })
+  })
+})


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4375

> Part of a series of changes related to replacing the create bill run journey to incorporate changes for two-part tariff

By taking over the create bill run journey we also take over responsibility for triggering bill runs. This means in both our app and the legacy app. Currently, [water-abstraction-ui](https://github.com/DEFRA/water-abstraction-ui) does that by sending a `POST` request to both apps. We'll be able to trigger any SROC bill run directly but still need to send a `POST` request for any PRESROC bill runs.

This change adds a new legacy `CreateBillRunRequest` to do exactly that.