### PR TITLE
Add first route to bill run setup journey

### DIFF
--- a/app/controllers/bill-runs-setup.controller.js
+++ b/app/controllers/bill-runs-setup.controller.js
@@ -1,0 +1,18 @@
+'use strict'
+
+/**
+ * Controller for /bill-runs/create endpoints
+ * @module BillRunsCreateController
+ */
+
+const InitiateSessionService = require('../services/bill-runs/setup/initiate-session.service.js')
+
+async function setup (_request, h) {
+  const session = await InitiateSessionService.go()
+
+  return h.redirect(`/system/bill-runs/setup/${session.id}/type`)
+}
+
+module.exports = {
+  setup
+}

--- a/app/plugins/router.plugin.js
+++ b/app/plugins/router.plugin.js
@@ -15,6 +15,7 @@ const AssetRoutes = require('../routes/assets.routes.js')
 const BillLicences = require('../routes/bill-licences.routes.js')
 const BillRoutes = require('../routes/bills.routes.js')
 const BillRunRoutes = require('../routes/bill-runs.routes.js')
+const BillRunSetupRoutes = require('../routes/bill-runs-setup.routes.js')
 const BillingAccountRoutes = require('../routes/billing-accounts.routes.js')
 const CheckRoutes = require('../routes/check.routes.js')
 const DataRoutes = require('../routes/data.routes.js')
@@ -34,6 +35,7 @@ const routes = [
   ...BillLicences,
   ...BillRoutes,
   ...BillRunRoutes,
+  ...BillRunSetupRoutes,
   ...BillingAccountRoutes,
   ...LicenceRoutes,
   ...JobRoutes,

--- a/app/routes/bill-runs-setup.routes.js
+++ b/app/routes/bill-runs-setup.routes.js
@@ -1,0 +1,21 @@
+'use strict'
+
+const BillRunsSetupController = require('../controllers/bill-runs-setup.controller.js')
+
+const routes = [
+  {
+    method: 'GET',
+    path: '/bill-runs/setup',
+    handler: BillRunsSetupController.setup,
+    options: {
+      auth: {
+        access: {
+          scope: ['billing']
+        }
+      },
+      description: 'Create a bill run (start of journey)'
+    }
+  }
+]
+
+module.exports = routes

--- a/app/services/bill-runs/setup/initiate-session.service.js
+++ b/app/services/bill-runs/setup/initiate-session.service.js
@@ -1,0 +1,30 @@
+'use strict'
+
+/**
+ * Initiates the session record used for setting up a new bill run
+ * @module InitiateSessionService
+ */
+
+const SessionModel = require('../../../models/session.model.js')
+
+/**
+ * Initiates the session record using for setting up a new bill run
+ *
+ * During the setup journey for a new bill run we temporarily store the data in a `SessionModel` instance. It
+ * is expected that on each page of the journey the GET will fetch the session record and use it to populate the view.
+ * When the page is submitted the session record will be updated with the next piece of data.
+ *
+ * At the end when the journey is complete the data from the session will be used to create the bill run and
+ * the session record itself deleted.
+ *
+ * @returns {Promise<module:SessionModel>} the newly created session record
+ */
+async function go () {
+  // NOTE: data defaults to {} when a new record is created. But Objection.js throws a 'The query is empty' if we pass
+  // nothing into `insert()`.
+  return SessionModel.query().insert({ data: {} }).returning('id')
+}
+
+module.exports = {
+  go
+}

--- a/test/controllers/bill-runs-setup.controller.test.js
+++ b/test/controllers/bill-runs-setup.controller.test.js
@@ -1,0 +1,65 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { describe, it, beforeEach, afterEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Things we need to stub
+const InitiateSessionService = require('../../app/services/bill-runs/setup/initiate-session.service.js')
+
+// For running our service
+const { init } = require('../../app/server.js')
+
+describe('Bill Runs Setup controller', () => {
+  let server
+
+  // Create server before each test
+  beforeEach(async () => {
+    server = await init()
+
+    // We silence any calls to server.logger.error made in the plugin to try and keep the test output as clean as
+    // possible
+    Sinon.stub(server.logger, 'error')
+
+    // We silence sending a notification to our Errbit instance using Airbrake
+    Sinon.stub(server.app.airbrake, 'notify').resolvesThis()
+  })
+
+  afterEach(() => {
+    Sinon.restore()
+  })
+
+  describe('GET /bill-runs/setup', () => {
+    const session = { id: 'e009b394-8405-4358-86af-1a9eb31298a5', data: {} }
+
+    let options
+
+    beforeEach(async () => {
+      options = {
+        method: 'GET',
+        url: '/bill-runs/setup',
+        auth: {
+          strategy: 'session',
+          credentials: { scope: ['billing'] }
+        }
+      }
+    })
+
+    describe('when a request is valid', () => {
+      beforeEach(async () => {
+        Sinon.stub(InitiateSessionService, 'go').resolves(session)
+      })
+
+      it('redirects to select bill run type page', async () => {
+        const response = await server.inject(options)
+
+        expect(response.statusCode).to.equal(302)
+        expect(response.headers.location).to.equal(`/system/bill-runs/setup/${session.id}/type`)
+      })
+    })
+  })
+})

--- a/test/services/bill-runs/setup/initialise-session.service.test.js
+++ b/test/services/bill-runs/setup/initialise-session.service.test.js
@@ -1,0 +1,31 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const DatabaseSupport = require('../../../support/database.js')
+const SessionModel = require('../../../../app/models/session.model.js')
+
+// Thing under test
+const InitiateSessionService = require('../../../../app/services/bill-runs/setup/initiate-session.service.js')
+
+describe('Bill Run Initiate Session service', () => {
+  beforeEach(async () => {
+    await DatabaseSupport.clean()
+  })
+
+  describe('when called', () => {
+    it('creates a new session record with an empty data property', async () => {
+      const result = await InitiateSessionService.go()
+
+      const matchingSession = await SessionModel.query().findById(result.id)
+
+      expect(matchingSession.data).to.equal({})
+    })
+  })
+})


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4375

> Part of a series of changes related to replacing the create bill run journey to incorporate changes for two-part tariff

The first thing to note is we are referring to the journey to create a bill run as setting up a bill run i.e. 'setup'. Though the big green button on the UI page says 'Create' we consider creating a bill run to be more the actual creation of the bill run record and then all the subsequent bills and transactions.

Before you can get there you have to 'setup' what kind of bill run you want to create. Hence, our name for choice for the path that will sit under bill runs; `/bill-runs/setup/`.

This change is the first route in the journey. This is where we will create the session record that will be used to record the choices a user makes when setting up a bill run. It will then redirect to the first page in the journey (coming in a subsequent change!)