### PR TITLE
Add bill runs setup type page to journey

### DIFF
--- a/app/controllers/bill-runs-setup.controller.js
+++ b/app/controllers/bill-runs-setup.controller.js
@@ -1,17 +1,34 @@
 'use strict'
 
 /**
- * Controller for /bill-runs/create endpoints
- * @module BillRunsCreateController
+ * Controller for /bill-runs/setup endpoints
+ * @module BillRunsSetupController
  */
 
 const InitiateSessionService = require('../services/bill-runs/setup/initiate-session.service.js')
+const SubmitTypeService = require('../services/bill-runs/setup/submit-type.service.js')
 const TypeService = require('../services/bill-runs/setup/type.service.js')
 
 async function setup (_request, h) {
   const session = await InitiateSessionService.go()
 
   return h.redirect(`/system/bill-runs/setup/${session.id}/type`)
+}
+
+async function submitType (request, h) {
+  const { sessionId } = request.params
+
+  const pageData = await SubmitTypeService.go(sessionId, request.payload)
+
+  if (pageData.error) {
+    return h.view('bill-runs/setup/type.njk', {
+      activeNavBar: 'bill-runs',
+      pageTitle: 'Select a bill run type',
+      ...pageData
+    })
+  }
+
+  return h.redirect(`/system/bill-runs/setup/${sessionId}/region`)
 }
 
 async function type (request, h) {
@@ -28,5 +45,6 @@ async function type (request, h) {
 
 module.exports = {
   setup,
+  submitType,
   type
 }

--- a/app/controllers/bill-runs-setup.controller.js
+++ b/app/controllers/bill-runs-setup.controller.js
@@ -6,6 +6,7 @@
  */
 
 const InitiateSessionService = require('../services/bill-runs/setup/initiate-session.service.js')
+const TypeService = require('../services/bill-runs/setup/type.service.js')
 
 async function setup (_request, h) {
   const session = await InitiateSessionService.go()
@@ -13,6 +14,19 @@ async function setup (_request, h) {
   return h.redirect(`/system/bill-runs/setup/${session.id}/type`)
 }
 
+async function type (request, h) {
+  const { sessionId } = request.params
+
+  const pageData = await TypeService.go(sessionId)
+
+  return h.view('bill-runs/setup/type.njk', {
+    activeNavBar: 'bill-runs',
+    pageTitle: 'Select a bill run type',
+    ...pageData
+  })
+}
+
 module.exports = {
-  setup
+  setup,
+  type
 }

--- a/app/presenters/bill-runs/setup/type.presenter.js
+++ b/app/presenters/bill-runs/setup/type.presenter.js
@@ -1,0 +1,24 @@
+'use strict'
+
+/**
+ * Formats data for the `/bill-runs/setup/{sessionId}/type` page
+ * @module TypePresenter
+ */
+
+/**
+ * Formats data for the `/bill-runs/setup/{sessionId}/type` page
+ *
+ * @param {module:SessionModel} session - The session instance to format
+ *
+ * @returns {Object} - The data formatted for the view template
+ */
+function go (session) {
+  return {
+    sessionId: session.id,
+    selectedType: session.data.type ? session.data.type : null
+  }
+}
+
+module.exports = {
+  go
+}

--- a/app/routes/bill-runs-setup.routes.js
+++ b/app/routes/bill-runs-setup.routes.js
@@ -28,6 +28,19 @@ const routes = [
       },
       description: 'Select the bill run type'
     }
+  },
+  {
+    method: 'POST',
+    path: '/bill-runs/setup/{sessionId}/type',
+    handler: BillRunsSetupController.submitType,
+    options: {
+      auth: {
+        access: {
+          scope: ['billing']
+        }
+      },
+      description: 'Submit the bill run type for the bill run'
+    }
   }
 ]
 

--- a/app/routes/bill-runs-setup.routes.js
+++ b/app/routes/bill-runs-setup.routes.js
@@ -15,6 +15,19 @@ const routes = [
       },
       description: 'Create a bill run (start of journey)'
     }
+  },
+  {
+    method: 'GET',
+    path: '/bill-runs/setup/{sessionId}/type',
+    handler: BillRunsSetupController.type,
+    options: {
+      auth: {
+        access: {
+          scope: ['billing']
+        }
+      },
+      description: 'Select the bill run type'
+    }
   }
 ]
 

--- a/app/services/bill-runs/setup/submit-type.service.js
+++ b/app/services/bill-runs/setup/submit-type.service.js
@@ -1,0 +1,74 @@
+'use strict'
+
+/**
+ * Handles the user submission for the `/bill-runs/setup/{sessionId}/type` page
+ * @module SubmitTypeService
+ */
+
+const SessionModel = require('../../../models/session.model.js')
+const TypePresenter = require('../../../presenters/bill-runs/setup/type.presenter.js')
+const TypeValidator = require('../../../validators/bill-runs/setup/type.validator.js')
+
+/**
+ * Handles the user submission for the `/bill-runs/setup/{sessionId}/type` page
+ *
+ * It first retrieves the session instance for the setup bill run journey in progress. It then validates the payload of
+ * the submitted request.
+ *
+ * If there is validation error it will save the selected value to the session then return an empty object. This will
+ * indicate to the controller that the submission was successful triggering it to redirect to the next page in the
+ * journey.
+ *
+ * If there is a validation error it is combined with the output of the presenter to generate the page data needed to
+ * re-render the view with an error message.
+ *
+ * @param {string} sessionId - The UUID of the current session
+ * @param {Object} payload - The submitted form data
+ *
+ * @returns {Promise<Object>} An empty object if there are no errors else the page data for the type page including the
+ * validation error details
+ */
+async function go (sessionId, payload) {
+  const session = await SessionModel.query().findById(sessionId)
+
+  const validationResult = _validate(payload)
+
+  if (!validationResult) {
+    await _save(session, payload)
+
+    return {}
+  }
+
+  const formattedData = TypePresenter.go(session)
+
+  return {
+    error: validationResult,
+    ...formattedData
+  }
+}
+
+async function _save (session, payload) {
+  const currentData = session.data
+
+  currentData.type = payload.type
+
+  return session.$query().patch({ data: currentData })
+}
+
+function _validate (payload) {
+  const validation = TypeValidator.go(payload)
+
+  if (!validation.error) {
+    return null
+  }
+
+  const { message } = validation.error.details[0]
+
+  return {
+    text: message
+  }
+}
+
+module.exports = {
+  go
+}

--- a/app/services/bill-runs/setup/type.service.js
+++ b/app/services/bill-runs/setup/type.service.js
@@ -1,0 +1,32 @@
+'use strict'
+
+/**
+ * Orchestrates fetching and presenting the data for `/bill-runs/setup/{sessionId}/type` page
+ * @module TypeService
+ */
+
+const SessionModel = require('../../../models/session.model.js')
+const TypePresenter = require('../../../presenters/bill-runs/setup/type.presenter.js')
+
+/**
+ * Orchestrates fetching and presenting the data for `/bill-runs/setup/{sessionId}/type` page
+ *
+ * Supports generating the data needed for the type page in the setup bill run journey. It fetches the current session
+ * record and combines it with the radio buttons and other information needed for the form.
+ *
+ * @param {string} sessionId - The UUID for setup bill run session record
+ *
+ * @returns {Promise<Object>} The view data for the type page
+ */
+async function go (sessionId) {
+  const session = await SessionModel.query().findById(sessionId)
+  const formattedData = TypePresenter.go(session)
+
+  return {
+    ...formattedData
+  }
+}
+
+module.exports = {
+  go
+}

--- a/app/validators/bill-runs/setup/type.validator.js
+++ b/app/validators/bill-runs/setup/type.validator.js
@@ -10,8 +10,7 @@ const Joi = require('joi')
 const VALID_VALUES = [
   'annual',
   'supplementary',
-  'two_part_tariff',
-  'two_part_tariff_supplementary'
+  'two_part_tariff'
 ]
 
 /**

--- a/app/validators/bill-runs/setup/type.validator.js
+++ b/app/validators/bill-runs/setup/type.validator.js
@@ -1,0 +1,42 @@
+'use strict'
+
+/**
+ * Validates data submitted for the `/bill-runs/setup/{sessionId}/type` page
+ * @module TypeValidator
+ */
+
+const Joi = require('joi')
+
+const VALID_VALUES = [
+  'annual',
+  'supplementary',
+  'two_part_tariff',
+  'two_part_tariff_supplementary'
+]
+
+/**
+ * Validates data submitted for the `/bill-runs/setup/{sessionId}/type` page
+ *
+ * @param {Object} payload - The payload from the request to be validated
+ *
+ * @returns {Object} the result from calling Joi's schema.validate(). It will be an object with a `value:` property. If
+ * any errors are found the `error:` property will also exist detailing what the issues were
+ */
+function go (data) {
+  const schema = Joi.object({
+    type: Joi.string()
+      .required()
+      .valid(...VALID_VALUES)
+      .messages({
+        'any.required': 'Select a bill run type',
+        'any.only': 'Select a bill run type',
+        'string.empty': 'Select a bill run type'
+      })
+  })
+
+  return schema.validate(data, { abortEarly: false })
+}
+
+module.exports = {
+  go
+}

--- a/app/views/bill-runs/setup/type.njk
+++ b/app/views/bill-runs/setup/type.njk
@@ -1,0 +1,67 @@
+{% extends 'layout.njk' %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+
+{% block breadcrumbs %}
+  {# Back link #}
+  {{
+    govukBackLink({
+      text: 'Go back to bill runs',
+      href: '/billing/batch/list'
+    })
+  }}
+{% endblock %}
+
+{% block content %}
+  {% if error %}
+    {{ govukErrorSummary({
+      titleText: 'There is a problem',
+      errorList: [
+        {
+          text: error.text,
+          href: '#type-error'
+        }
+      ]
+      }) }}
+  {% endif %}
+
+  <div class="govuk-body">
+    <form method="post">
+      {{ govukRadios({
+        attributes: {
+          'data-test': 'bill-run-type'
+        },
+        name: 'type',
+        errorMessage: error,
+        fieldset: {
+          legend: {
+            text: pageTitle,
+            isPageHeading: true,
+            classes: 'govuk-fieldset__legend--l govuk-!-margin-bottom-6'
+          }
+        },
+        items: [
+          {
+            text: 'Annual',
+            value: 'annual',
+            checked: 'annual' == selectedType
+          },
+          {
+            text: 'Supplementary',
+            value: 'supplementary',
+            checked: 'supplementary' == selectedType
+          },
+          {
+            text: 'Two-part tariff',
+            value: 'two_part_tariff',
+            checked: 'two_part_tariff' == selectedType
+          }
+        ]
+      }) }}
+
+      {{ govukButton({ text: 'Continue', preventDoubleClick: true }) }}
+    </form>
+  </div>
+{% endblock %}

--- a/test/controllers/bill-runs-setup.controller.test.js
+++ b/test/controllers/bill-runs-setup.controller.test.js
@@ -10,11 +10,13 @@ const { expect } = Code
 
 // Things we need to stub
 const InitiateSessionService = require('../../app/services/bill-runs/setup/initiate-session.service.js')
+const TypeService = require('../../app/services/bill-runs/setup/type.service.js')
 
 // For running our service
 const { init } = require('../../app/server.js')
 
 describe('Bill Runs Setup controller', () => {
+  let options
   let server
 
   // Create server before each test
@@ -35,8 +37,6 @@ describe('Bill Runs Setup controller', () => {
 
   describe('GET /bill-runs/setup', () => {
     const session = { id: 'e009b394-8405-4358-86af-1a9eb31298a5', data: {} }
-
-    let options
 
     beforeEach(async () => {
       options = {
@@ -62,4 +62,32 @@ describe('Bill Runs Setup controller', () => {
       })
     })
   })
+
+  describe('GET /bill-runs/setup/{sessionId}/type', () => {
+    beforeEach(async () => {
+      options = _options('type')
+
+      Sinon.stub(TypeService, 'go').resolves({ sessionId: '8702b98f-ae51-475d-8fcc-e049af8b8d38', selectedType: null })
+    })
+
+    describe('when the request succeeds', () => {
+      it('returns the page successfully', async () => {
+        const response = await server.inject(options)
+
+        expect(response.statusCode).to.equal(200)
+        expect(response.payload).to.contain('Select a bill run type')
+      })
+    })
+  })
 })
+
+function _options (path) {
+  return {
+    method: 'GET',
+    url: `/bill-runs/setup/e009b394-8405-4358-86af-1a9eb31298a5/${path}`,
+    auth: {
+      strategy: 'session',
+      credentials: { scope: ['billing'] }
+    }
+  }
+}

--- a/test/presenters/bill-runs/setup/type.presenter.test.js
+++ b/test/presenters/bill-runs/setup/type.presenter.test.js
@@ -1,0 +1,50 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Thing under test
+const TypePresenter = require('../../../../app/presenters/bill-runs/setup/type.presenter.js')
+
+describe('Bill Runs Setup Type presenter', () => {
+  let session
+
+  describe('when provided with a bill run setup session record', () => {
+    beforeEach(() => {
+      session = {
+        id: '98ad3a1f-8e4f-490a-be05-0aece6755466',
+        data: {}
+      }
+    })
+
+    describe('where the user has not previously selected a bill run type', () => {
+      it('correctly presents the data', () => {
+        const result = TypePresenter.go(session)
+
+        expect(result).to.equal({
+          sessionId: '98ad3a1f-8e4f-490a-be05-0aece6755466',
+          selectedType: null
+        })
+      })
+    })
+
+    describe('where the user has previously selected a bill run type', () => {
+      beforeEach(() => {
+        session.data.type = 'annual'
+      })
+
+      it('correctly presents the data', () => {
+        const result = TypePresenter.go(session)
+
+        expect(result).to.equal({
+          sessionId: '98ad3a1f-8e4f-490a-be05-0aece6755466',
+          selectedType: 'annual'
+        })
+      })
+    })
+  })
+})

--- a/test/services/bill-runs/setup/submit-type.service.test.js
+++ b/test/services/bill-runs/setup/submit-type.service.test.js
@@ -1,0 +1,70 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const DatabaseSupport = require('../../../support/database.js')
+const SessionHelper = require('../../../support/helpers/session.helper.js')
+
+// Thing under test
+const SubmitTypeService = require('../../../../app/services/bill-runs/setup/submit-type.service.js')
+
+describe('Submit No Returns Required service', () => {
+  let payload
+  let session
+
+  beforeEach(async () => {
+    await DatabaseSupport.clean()
+
+    session = await SessionHelper.add({ data: {} })
+  })
+
+  describe('when called', () => {
+    describe('with a valid payload', () => {
+      beforeEach(() => {
+        payload = {
+          type: 'annual'
+        }
+      })
+
+      it('saves the submitted value', async () => {
+        await SubmitTypeService.go(session.id, payload)
+
+        const refreshedSession = await session.$query()
+
+        expect(refreshedSession.data.type).to.equal('annual')
+      })
+
+      it('returns an empty object (no page data is needed for a redirect)', async () => {
+        const result = await SubmitTypeService.go(session.id, payload)
+
+        expect(result).to.equal({})
+      })
+    })
+
+    describe('with an invalid payload', () => {
+      describe('because the user has not selected anything', () => {
+        beforeEach(() => {
+          payload = {}
+        })
+
+        it('returns page data needed to re-render the view including the validation error', async () => {
+          const result = await SubmitTypeService.go(session.id, payload)
+
+          expect(result).to.equal({
+            sessionId: session.id,
+            selectedType: null,
+            error: {
+              text: 'Select a bill run type'
+            }
+          })
+        })
+      })
+    })
+  })
+})

--- a/test/services/bill-runs/setup/type.service.test.js
+++ b/test/services/bill-runs/setup/type.service.test.js
@@ -1,0 +1,36 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const DatabaseSupport = require('../../../support/database.js')
+const SessionHelper = require('../../../support/helpers/session.helper.js')
+
+// Thing under test
+const TypeService = require('../../../../app/services/bill-runs/setup/type.service.js')
+
+describe('Bill Runs Setup Type service', () => {
+  let session
+
+  beforeEach(async () => {
+    await DatabaseSupport.clean()
+
+    session = await SessionHelper.add({ data: { type: 'annual' } })
+  })
+
+  describe('when called', () => {
+    it('returns page data for the view', async () => {
+      const result = await TypeService.go(session.id)
+
+      expect(result).to.equal({
+        sessionId: session.id,
+        selectedType: 'annual'
+      })
+    })
+  })
+})

--- a/test/validators/bill-runs/setup/type.validator.test.js
+++ b/test/validators/bill-runs/setup/type.validator.test.js
@@ -1,0 +1,44 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Thing under test
+const TypeValidator = require('../../../../app/validators/bill-runs/setup/type.validator.js')
+
+describe('Bill Runs Setup Type validator', () => {
+  describe('when valid data is provided', () => {
+    it('confirms the data is valid', () => {
+      const result = TypeValidator.go({ type: 'annual' })
+
+      expect(result.value).to.exist()
+      expect(result.error).not.to.exist()
+    })
+  })
+
+  describe('when invalid data is provided', () => {
+    describe("because no 'reason' is given", () => {
+      it('fails validation', () => {
+        const result = TypeValidator.go({ type: '' })
+
+        expect(result.value).to.exist()
+        expect(result.error).to.exist()
+        expect(result.error.details[0].message).to.equal('Select a bill run type')
+      })
+    })
+
+    describe("because an unknown 'reason' is given", () => {
+      it('fails validation', () => {
+        const result = TypeValidator.go({ type: 'free_one' })
+
+        expect(result.value).to.exist()
+        expect(result.error).to.exist()
+        expect(result.error.details[0].message).to.equal('Select a bill run type')
+      })
+    })
+  })
+})


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4375

> Part of a series of changes related to replacing the create bill run journey to incorporate changes for two-part tariff

Having [Add first route to bill run setup journey](https://github.com/DEFRA/water-abstraction-system/pull/801) we can now add our first page which is where the user selects what bill run type they wish to create.

It is planned in the future that there will be 4; annual, supplementary, two-part tariff and two-part tariff supplementary. Until we have implemented two-part tariff supplementary though it is just the first 3 options.

![Screenshot 2024-03-11 at 09 21 40](https://github.com/DEFRA/water-abstraction-system/assets/1789650/784614b6-aa24-4f33-89e4-8f1bf5e6d4d0)
