### PR TITLE
Add bill runs setup financial year page to journey

### DIFF
--- a/app/controllers/bill-runs-setup.controller.js
+++ b/app/controllers/bill-runs-setup.controller.js
@@ -9,6 +9,7 @@ const InitiateSessionService = require('../services/bill-runs/setup/initiate-ses
 const RegionService = require('../services/bill-runs/setup/region.service.js')
 const SubmitRegionService = require('../services/bill-runs/setup/submit-region.service.js')
 const SubmitTypeService = require('../services/bill-runs/setup/submit-type.service.js')
+const SubmitYearService = require('../services/bill-runs/setup/submit-year.service.js')
 const TypeService = require('../services/bill-runs/setup/type.service.js')
 const YearService = require('../services/bill-runs/setup/year.service.js')
 
@@ -66,6 +67,26 @@ async function submitType (request, h) {
   return h.redirect(`/system/bill-runs/setup/${sessionId}/region`)
 }
 
+async function submitYear (request, h) {
+  const { sessionId } = request.params
+
+  const pageData = await SubmitYearService.go(sessionId, request.payload)
+
+  if (pageData.error) {
+    return h.view('bill-runs/setup/year.njk', {
+      activeNavBar: 'bill-runs',
+      pageTitle: 'Select the financial year',
+      ...pageData
+    })
+  }
+
+  if (pageData.setupComplete) {
+    return h.redirect(`/system/bill-runs/setup/${sessionId}/generate`)
+  }
+
+  return h.redirect(`/system/bill-runs/setup/${sessionId}/season`)
+}
+
 async function type (request, h) {
   const { sessionId } = request.params
 
@@ -95,6 +116,7 @@ module.exports = {
   setup,
   submitRegion,
   submitType,
+  submitYear,
   type,
   year
 }

--- a/app/controllers/bill-runs-setup.controller.js
+++ b/app/controllers/bill-runs-setup.controller.js
@@ -10,6 +10,7 @@ const RegionService = require('../services/bill-runs/setup/region.service.js')
 const SubmitRegionService = require('../services/bill-runs/setup/submit-region.service.js')
 const SubmitTypeService = require('../services/bill-runs/setup/submit-type.service.js')
 const TypeService = require('../services/bill-runs/setup/type.service.js')
+const YearService = require('../services/bill-runs/setup/year.service.js')
 
 async function region (request, h) {
   const { sessionId } = request.params
@@ -77,10 +78,23 @@ async function type (request, h) {
   })
 }
 
+async function year (request, h) {
+  const { sessionId } = request.params
+
+  const pageData = await YearService.go(sessionId)
+
+  return h.view('bill-runs/setup/year.njk', {
+    activeNavBar: 'bill-runs',
+    pageTitle: 'Select the financial year',
+    ...pageData
+  })
+}
+
 module.exports = {
   region,
   setup,
   submitRegion,
   submitType,
-  type
+  type,
+  year
 }

--- a/app/presenters/bill-runs/setup/year.presenter.js
+++ b/app/presenters/bill-runs/setup/year.presenter.js
@@ -1,0 +1,24 @@
+'use strict'
+
+/**
+ * Formats data for the `/bill-runs/setup/{sessionId}/year` page
+ * @module RegionPresenter
+ */
+
+/**
+ * Formats data for the `/bill-runs/setup/{sessionId}/year` page
+ *
+ * @param {module:SessionModel} session - The session instance to format
+ *
+ * @returns {Object} - The data formatted for the view template
+ */
+function go (session) {
+  return {
+    sessionId: session.id,
+    selectedYear: session.data.year ? session.data.year : null
+  }
+}
+
+module.exports = {
+  go
+}

--- a/app/routes/bill-runs-setup.routes.js
+++ b/app/routes/bill-runs-setup.routes.js
@@ -80,6 +80,19 @@ const routes = [
       },
       description: 'Select the financial year for the bill run'
     }
+  },
+  {
+    method: 'POST',
+    path: '/bill-runs/setup/{sessionId}/year',
+    handler: BillRunsSetupController.submitYear,
+    options: {
+      auth: {
+        access: {
+          scope: ['billing']
+        }
+      },
+      description: 'Submit the financial year for the bill run'
+    }
   }
 ]
 

--- a/app/routes/bill-runs-setup.routes.js
+++ b/app/routes/bill-runs-setup.routes.js
@@ -67,6 +67,19 @@ const routes = [
       },
       description: 'Submit the bill run type for the bill run'
     }
+  },
+  {
+    method: 'GET',
+    path: '/bill-runs/setup/{sessionId}/year',
+    handler: BillRunsSetupController.year,
+    options: {
+      auth: {
+        access: {
+          scope: ['billing']
+        }
+      },
+      description: 'Select the financial year for the bill run'
+    }
   }
 ]
 

--- a/app/services/bill-runs/setup/region.service.js
+++ b/app/services/bill-runs/setup/region.service.js
@@ -13,7 +13,7 @@ const SessionModel = require('../../../models/session.model.js')
  * Orchestrates fetching and presenting the data for `/bill-runs/setup/{sessionId}/region` page
  *
  * Supports generating the data needed for the region page in the setup bill run journey. It fetches the current
- * session record and combines it with the radio buttons and other information needed for the form.
+ * session record and formats the data needed for the form.
  *
  * @param {string} sessionId - The UUID for setup bill run session record
  *

--- a/app/services/bill-runs/setup/submit-year.service.js
+++ b/app/services/bill-runs/setup/submit-year.service.js
@@ -1,0 +1,75 @@
+'use strict'
+
+/**
+ * Handles the user submission for the `/bill-runs/setup/{sessionId}/year` page
+ * @module SubmitYearService
+ */
+
+const SessionModel = require('../../../models/session.model.js')
+const YearPresenter = require('../../../presenters/bill-runs/setup/year.presenter.js')
+const YearValidator = require('../../../validators/bill-runs/setup/year.validator.js')
+
+/**
+ * Handles the user submission for the `/bill-runs/setup/{sessionId}/year` page
+ *
+ * It first retrieves the session instance for the setup bill run journey in progress. It then validates the payload of
+ * the submitted request.
+ *
+ * If there is no validation error it will save the selected value to the session then return an object with a
+ * `setupComplete:` property. If the year is not PRESROC this will be true. Else it will be false. The fact the property
+ * exists will tell the controller the submission was successful. Whether the property `setupComplete:` is true or false
+ * will be used to determine which page to direct the user to next.
+ *
+ * If there is a validation error it is combined with the output of the presenter to generate the page data needed to
+ * re-render the view with an error message.
+ *
+ * @param {string} sessionId - The UUID of the current session
+ * @param {Object} payload - The submitted form data
+ *
+ * @returns {Promise<Object>} An object with a `setupComplete:` property if there are no errors else the page data for
+ * the year page including the validation error details
+ */
+async function go (sessionId, payload) {
+  const session = await SessionModel.query().findById(sessionId)
+
+  const validationResult = _validate(payload)
+
+  if (!validationResult) {
+    await _save(session, payload)
+
+    return { setupComplete: ['2024', '2023'].includes(session.data.year) }
+  }
+
+  const formattedData = YearPresenter.go(session)
+
+  return {
+    error: validationResult,
+    ...formattedData
+  }
+}
+
+async function _save (session, payload) {
+  const currentData = session.data
+
+  currentData.year = payload.year
+
+  return session.$query().patch({ data: currentData })
+}
+
+function _validate (payload, regions) {
+  const validation = YearValidator.go(payload, regions)
+
+  if (!validation.error) {
+    return null
+  }
+
+  const { message } = validation.error.details[0]
+
+  return {
+    text: message
+  }
+}
+
+module.exports = {
+  go
+}

--- a/app/services/bill-runs/setup/type.service.js
+++ b/app/services/bill-runs/setup/type.service.js
@@ -11,8 +11,8 @@ const TypePresenter = require('../../../presenters/bill-runs/setup/type.presente
 /**
  * Orchestrates fetching and presenting the data for `/bill-runs/setup/{sessionId}/type` page
  *
- * Supports generating the data needed for the type page in the setup bill run journey. It fetches the current session
- * record and combines it with the radio buttons and other information needed for the form.
+ * Supports generating the data needed for the type page in the setup bill run journey. It fetches the current
+ * session record and formats the data needed for the form.
  *
  * @param {string} sessionId - The UUID for setup bill run session record
  *

--- a/app/services/bill-runs/setup/year.service.js
+++ b/app/services/bill-runs/setup/year.service.js
@@ -1,0 +1,32 @@
+'use strict'
+
+/**
+ * Orchestrates fetching and presenting the data for `/bill-runs/setup/{sessionId}/year` page
+ * @module YearService
+ */
+
+const YearPresenter = require('../../../presenters/bill-runs/setup/year.presenter.js')
+const SessionModel = require('../../../models/session.model.js')
+
+/**
+ * Orchestrates fetching and presenting the data for `/bill-runs/setup/{sessionId}/year` page
+ *
+ * Supports generating the data needed for the year page in the setup bill run journey. It fetches the current
+ * session record and formats the data needed for the form.
+ *
+ * @param {string} sessionId - The UUID for setup bill run session record
+ *
+ * @returns {Promise<Object>} The view data for the year page
+ */
+async function go (sessionId) {
+  const session = await SessionModel.query().findById(sessionId)
+  const formattedData = YearPresenter.go(session)
+
+  return {
+    ...formattedData
+  }
+}
+
+module.exports = {
+  go
+}

--- a/app/validators/bill-runs/setup/year.validator.js
+++ b/app/validators/bill-runs/setup/year.validator.js
@@ -1,0 +1,42 @@
+'use strict'
+
+/**
+ * Validates data submitted for the `/bill-runs/setup/{sessionId}/year` page
+ * @module YearValidator
+ */
+
+const Joi = require('joi')
+
+const VALID_VALUES = [
+  '2024',
+  '2023',
+  '2022',
+  '2021'
+]
+
+/**
+ * Validates data submitted for the `/bill-runs/setup/{sessionId}/year` page
+ *
+ * @param {Object} payload - The payload from the request to be validated
+ *
+ * @returns {Object} the result from calling Joi's schema.validate(). It will be an object with a `value:` property. If
+ * any errors are found the `error:` property will also exist detailing what the issues were
+ */
+function go (data) {
+  const schema = Joi.object({
+    year: Joi.string()
+      .required()
+      .valid(...VALID_VALUES)
+      .messages({
+        'any.required': 'Select the financial year',
+        'any.only': 'Select the financial year',
+        'string.empty': 'Select the financial year'
+      })
+  })
+
+  return schema.validate(data, { abortEarly: false })
+}
+
+module.exports = {
+  go
+}

--- a/app/views/bill-runs/setup/year.njk
+++ b/app/views/bill-runs/setup/year.njk
@@ -1,0 +1,72 @@
+{% extends 'layout.njk' %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+
+{% block breadcrumbs %}
+  {# Back link #}
+  {{
+    govukBackLink({
+      text: 'Back',
+      href: '/system/bill-runs/setup/' + sessionId + '/region'
+    })
+  }}
+{% endblock %}
+
+{% block content %}
+  {% if error %}
+    {{ govukErrorSummary({
+      titleText: "There is a problem",
+      errorList: [
+        {
+          text: error.text,
+          href: '#year-error'
+        }
+      ]
+      }) }}
+  {% endif %}
+
+  <div class="govuk-body">
+    <form method="post">
+      {{ govukRadios({
+        attributes: {
+          'data-test': 'bill-run-year'
+        },
+        name: 'year',
+        errorMessage: error,
+        fieldset: {
+          legend: {
+            text: pageTitle,
+            isPageHeading: true,
+            classes: 'govuk-fieldset__legend--l govuk-!-margin-bottom-6'
+          }
+        },
+        items: [
+          {
+            text: '2023 to 2024',
+            value: '2024',
+            checked: '2024' == selectedYear
+          },
+          {
+            text: '2022 to 2023',
+            value: '2023',
+            checked: '2023' == selectedYear
+          },
+          {
+            text: '2021 to 2022',
+            value: '2022',
+            checked: '2022' == selectedYear
+          },
+          {
+            text: '2020 to 2021',
+            value: '2021',
+            checked: '2021' == selectedYear
+          }
+        ]
+      }) }}
+
+      {{ govukButton({ text: 'Continue', preventDoubleClick: true }) }}
+    </form>
+  </div>
+{% endblock %}

--- a/test/controllers/bill-runs-setup.controller.test.js
+++ b/test/controllers/bill-runs-setup.controller.test.js
@@ -14,6 +14,7 @@ const RegionService = require('../../app/services/bill-runs/setup/region.service
 const SubmitRegionService = require('../../app/services/bill-runs/setup/submit-region.service.js')
 const SubmitTypeService = require('../../app/services/bill-runs/setup/submit-type.service.js')
 const TypeService = require('../../app/services/bill-runs/setup/type.service.js')
+const YearService = require('../../app/services/bill-runs/setup/year.service.js')
 
 // For running our service
 const { init } = require('../../app/server.js')
@@ -197,6 +198,28 @@ describe('Bill Runs Setup controller', () => {
           expect(response.statusCode).to.equal(200)
           expect(response.payload).to.contain('Select a bill run type')
           expect(response.payload).to.contain('There is a problem')
+        })
+      })
+    })
+  })
+
+  describe('/bill-runs/setup/{sessionId}/year', () => {
+    describe('GET', () => {
+      beforeEach(async () => {
+        options = _getOptions('year')
+
+        Sinon.stub(YearService, 'go').resolves({
+          sessionId: 'e009b394-8405-4358-86af-1a9eb31298a5',
+          selectedYear: null
+        })
+      })
+
+      describe('when the request succeeds', () => {
+        it('returns the page successfully', async () => {
+          const response = await server.inject(options)
+
+          expect(response.statusCode).to.equal(200)
+          expect(response.payload).to.contain('Select the financial year')
         })
       })
     })

--- a/test/presenters/bill-runs/setup/year.presenter.test.js
+++ b/test/presenters/bill-runs/setup/year.presenter.test.js
@@ -1,0 +1,50 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Thing under test
+const YearPresenter = require('../../../../app/presenters/bill-runs/setup/year.presenter.js')
+
+describe('Bill Runs Setup Year presenter', () => {
+  let session
+
+  describe('when provided with a bill run setup session record', () => {
+    beforeEach(() => {
+      session = {
+        id: '98ad3a1f-8e4f-490a-be05-0aece6755466',
+        data: {}
+      }
+    })
+
+    describe('where the user has not previously selected a financial year', () => {
+      it('correctly presents the data', () => {
+        const result = YearPresenter.go(session)
+
+        expect(result).to.equal({
+          sessionId: '98ad3a1f-8e4f-490a-be05-0aece6755466',
+          selectedYear: null
+        })
+      })
+    })
+
+    describe('where the user has previously selected a financial year', () => {
+      beforeEach(() => {
+        session.data.year = 2022
+      })
+
+      it('correctly presents the data', () => {
+        const result = YearPresenter.go(session)
+
+        expect(result).to.equal({
+          sessionId: '98ad3a1f-8e4f-490a-be05-0aece6755466',
+          selectedYear: 2022
+        })
+      })
+    })
+  })
+})

--- a/test/services/bill-runs/setup/submit-region.service.test.js
+++ b/test/services/bill-runs/setup/submit-region.service.test.js
@@ -18,7 +18,7 @@ const FetchRegionsService = require('../../../../app/services/bill-runs/setup/fe
 // Thing under test
 const SubmitRegionService = require('../../../../app/services/bill-runs/setup/submit-region.service.js')
 
-describe('Submit No Returns Required service', () => {
+describe('Bill Runs Setup Submit Region service', () => {
   const regions = [
     { id: 'e21b987c-7a5f-4eb3-a794-e4aae4a96a28', displayName: 'Riverlands' },
     { id: '19a027c6-4aad-47d3-80e3-3917a4579a5b', displayName: 'Stormlands' },

--- a/test/services/bill-runs/setup/submit-type.service.test.js
+++ b/test/services/bill-runs/setup/submit-type.service.test.js
@@ -14,7 +14,7 @@ const SessionHelper = require('../../../support/helpers/session.helper.js')
 // Thing under test
 const SubmitTypeService = require('../../../../app/services/bill-runs/setup/submit-type.service.js')
 
-describe('Submit No Returns Required service', () => {
+describe('Bill Runs Setup Submit Type service', () => {
   let payload
   let session
 

--- a/test/services/bill-runs/setup/submit-year.service.test.js
+++ b/test/services/bill-runs/setup/submit-year.service.test.js
@@ -1,0 +1,84 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const DatabaseSupport = require('../../../support/database.js')
+const SessionHelper = require('../../../support/helpers/session.helper.js')
+
+// Thing under test
+const SubmitYearService = require('../../../../app/services/bill-runs/setup/submit-year.service.js')
+
+describe('Bill Runs Setup Submit Year service', () => {
+  let payload
+  let session
+
+  beforeEach(async () => {
+    await DatabaseSupport.clean()
+
+    session = await SessionHelper.add({ data: {} })
+  })
+
+  describe('when called', () => {
+    describe('with a valid payload', () => {
+      describe('and the year is in the SROC period', () => {
+        beforeEach(() => {
+          payload = {
+            year: '2023'
+          }
+        })
+
+        it('saves the submitted value and returns an object confirming setup is complete', async () => {
+          const result = await SubmitYearService.go(session.id, payload)
+
+          const refreshedSession = await session.$query()
+
+          expect(refreshedSession.data.year).to.equal('2023')
+          expect(result.setupComplete).to.be.true()
+        })
+      })
+
+      describe('and the year is in the PRESROC period', () => {
+        beforeEach(() => {
+          payload = {
+            year: '2022'
+          }
+        })
+
+        it('saves the submitted value and returns an object confirming setup is not complete', async () => {
+          const result = await SubmitYearService.go(session.id, payload)
+
+          const refreshedSession = await session.$query()
+
+          expect(refreshedSession.data.year).to.equal('2022')
+          expect(result.setupComplete).to.be.false()
+        })
+      })
+    })
+
+    describe('with an invalid payload', () => {
+      describe('because the user has not selected anything', () => {
+        beforeEach(async () => {
+          payload = {}
+        })
+
+        it('returns page data needed to re-render the view including the validation error', async () => {
+          const result = await SubmitYearService.go(session.id, payload)
+
+          expect(result).to.equal({
+            sessionId: session.id,
+            selectedYear: null,
+            error: {
+              text: 'Select the financial year'
+            }
+          })
+        })
+      })
+    })
+  })
+})

--- a/test/services/bill-runs/setup/year.service.test.js
+++ b/test/services/bill-runs/setup/year.service.test.js
@@ -1,0 +1,36 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const DatabaseSupport = require('../../../support/database.js')
+const SessionHelper = require('../../../support/helpers/session.helper.js')
+
+// Thing under test
+const YearService = require('../../../../app/services/bill-runs/setup/year.service.js')
+
+describe('Bill Runs Setup Year service', () => {
+  let session
+
+  beforeEach(async () => {
+    await DatabaseSupport.clean()
+
+    session = await SessionHelper.add({ data: { year: 2024 } })
+  })
+
+  describe('when called', () => {
+    it('returns page data for the view', async () => {
+      const result = await YearService.go(session.id)
+
+      expect(result).to.equal({
+        sessionId: session.id,
+        selectedYear: 2024
+      })
+    })
+  })
+})

--- a/test/validators/bill-runs/setup/year.validator.test.js
+++ b/test/validators/bill-runs/setup/year.validator.test.js
@@ -1,0 +1,44 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Thing under test
+const YearValidator = require('../../../../app/validators/bill-runs/setup/year.validator.js')
+
+describe('Bill Runs Setup Year validator', () => {
+  describe('when valid data is provided', () => {
+    it('confirms the data is valid', () => {
+      const result = YearValidator.go({ year: '2022' })
+
+      expect(result.value).to.exist()
+      expect(result.error).not.to.exist()
+    })
+  })
+
+  describe('when invalid data is provided', () => {
+    describe("because no 'year' is given", () => {
+      it('fails validation', () => {
+        const result = YearValidator.go({ year: '' })
+
+        expect(result.value).to.exist()
+        expect(result.error).to.exist()
+        expect(result.error.details[0].message).to.equal('Select the financial year')
+      })
+    })
+
+    describe("because an unknown 'year' is given", () => {
+      it('fails validation', () => {
+        const result = YearValidator.go({ year: '2020' })
+
+        expect(result.value).to.exist()
+        expect(result.error).to.exist()
+        expect(result.error.details[0].message).to.equal('Select the financial year')
+      })
+    })
+  })
+})


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4375

> Part of a series of changes related to replacing the create bill run journey to incorporate changes for two-part tariff

This adds the third page to the setup bill run journey; select the financial year. This like [Add bill runs setup region page to journey](https://github.com/DEFRA/water-abstraction-system/pull/804) has the complexity of having to direct the user to different pages depending on the year chosen.

The page only applies to two-part tariff bill runs and is only intended to be temporary. Two-part tariff bill runs were held during COVID then the SROC ones have been delayed whilst we build an SROC 2PT billing engine. This means we have a backlog so users need to be able to select the year they wish to create the bill run for. Normally, the current financial year would automatically be determined in the same way as annual bill runs. The years shown are determined by those with outstanding two-part tariff bill runs.

Once the backlog of bill runs is cleared this page can be dropped from the journey.