### PR TITLE
Fix missing page titles from 500 and 404

### DIFF
--- a/app/views/404.njk
+++ b/app/views/404.njk
@@ -1,5 +1,7 @@
 {% extends 'layout.njk' %}
 
+{% set pageTitle = 'Page not found' %}
+
 {% block content %}
   <div class="govuk-width-container">
     <div class="govuk-main-wrapper">

--- a/app/views/500.njk
+++ b/app/views/500.njk
@@ -1,5 +1,7 @@
 {% extends 'layout.njk' %}
 
+{% set pageTitle = 'Sorry, there is a problem with the service' %}
+
 {% block content %}
   <div class="govuk-width-container">
     <div class="govuk-main-wrapper">


### PR DESCRIPTION
We spotted this whilst working on another feature that our error pages do not have titles. This impacts how the browser labels things like tabs. Basically, they should have them!

This change adds the missing titles to the views.

![Screenshot 2024-03-12 at 10 45 49](https://github.com/DEFRA/water-abstraction-system/assets/1789650/6316bc19-1c32-4568-82f4-c3b97b29f879)

> Broken on the left, fixed on the right