### PR TITLE
Add bill runs setup season page to journey

### DIFF
--- a/app/controllers/bill-runs-setup.controller.js
+++ b/app/controllers/bill-runs-setup.controller.js
@@ -7,6 +7,7 @@
 
 const InitiateSessionService = require('../services/bill-runs/setup/initiate-session.service.js')
 const RegionService = require('../services/bill-runs/setup/region.service.js')
+const SeasonService = require('../services/bill-runs/setup/season.service.js')
 const SubmitRegionService = require('../services/bill-runs/setup/submit-region.service.js')
 const SubmitTypeService = require('../services/bill-runs/setup/submit-type.service.js')
 const SubmitYearService = require('../services/bill-runs/setup/submit-year.service.js')
@@ -21,6 +22,18 @@ async function region (request, h) {
   return h.view('bill-runs/setup/region.njk', {
     activeNavBar: 'bill-runs',
     pageTitle: 'Select the region',
+    ...pageData
+  })
+}
+
+async function season (request, h) {
+  const { sessionId } = request.params
+
+  const pageData = await SeasonService.go(sessionId)
+
+  return h.view('bill-runs/setup/season.njk', {
+    activeNavBar: 'bill-runs',
+    pageTitle: 'Select the season',
     ...pageData
   })
 }
@@ -113,6 +126,7 @@ async function year (request, h) {
 
 module.exports = {
   region,
+  season,
   setup,
   submitRegion,
   submitType,

--- a/app/controllers/bill-runs-setup.controller.js
+++ b/app/controllers/bill-runs-setup.controller.js
@@ -9,6 +9,7 @@ const InitiateSessionService = require('../services/bill-runs/setup/initiate-ses
 const RegionService = require('../services/bill-runs/setup/region.service.js')
 const SeasonService = require('../services/bill-runs/setup/season.service.js')
 const SubmitRegionService = require('../services/bill-runs/setup/submit-region.service.js')
+const SubmitSeasonService = require('../services/bill-runs/setup/submit-season.service.js')
 const SubmitTypeService = require('../services/bill-runs/setup/submit-type.service.js')
 const SubmitYearService = require('../services/bill-runs/setup/submit-year.service.js')
 const TypeService = require('../services/bill-runs/setup/type.service.js')
@@ -62,6 +63,22 @@ async function submitRegion (request, h) {
   }
 
   return h.redirect(`/system/bill-runs/setup/${sessionId}/year`)
+}
+
+async function submitSeason (request, h) {
+  const { sessionId } = request.params
+
+  const pageData = await SubmitSeasonService.go(sessionId, request.payload)
+
+  if (pageData.error) {
+    return h.view('bill-runs/setup/season.njk', {
+      activeNavBar: 'bill-runs',
+      pageTitle: 'Select the season',
+      ...pageData
+    })
+  }
+
+  return h.redirect(`/system/bill-runs/setup/${sessionId}/generate`)
 }
 
 async function submitType (request, h) {
@@ -129,6 +146,7 @@ module.exports = {
   season,
   setup,
   submitRegion,
+  submitSeason,
   submitType,
   submitYear,
   type,

--- a/app/presenters/bill-runs/setup/season.presenter.js
+++ b/app/presenters/bill-runs/setup/season.presenter.js
@@ -1,0 +1,24 @@
+'use strict'
+
+/**
+ * Formats data for the `/bill-runs/setup/{sessionId}/season` page
+ * @module SeasonPresenter
+ */
+
+/**
+ * Formats data for the `/bill-runs/setup/{sessionId}/season` page
+ *
+ * @param {module:SessionModel} session - The session instance to format
+ *
+ * @returns {Object} - The data formatted for the view template
+ */
+function go (session) {
+  return {
+    sessionId: session.id,
+    selectedSeason: session.data.season ? session.data.season : null
+  }
+}
+
+module.exports = {
+  go
+}

--- a/app/routes/bill-runs-setup.routes.js
+++ b/app/routes/bill-runs-setup.routes.js
@@ -31,6 +31,19 @@ const routes = [
   },
   {
     method: 'GET',
+    path: '/bill-runs/setup/{sessionId}/season',
+    handler: BillRunsSetupController.season,
+    options: {
+      auth: {
+        access: {
+          scope: ['billing']
+        }
+      },
+      description: 'Select the season for the bill run'
+    }
+  },
+  {
+    method: 'GET',
     path: '/bill-runs/setup',
     handler: BillRunsSetupController.setup,
     options: {

--- a/app/routes/bill-runs-setup.routes.js
+++ b/app/routes/bill-runs-setup.routes.js
@@ -43,6 +43,19 @@ const routes = [
     }
   },
   {
+    method: 'POST',
+    path: '/bill-runs/setup/{sessionId}/season',
+    handler: BillRunsSetupController.submitSeason,
+    options: {
+      auth: {
+        access: {
+          scope: ['billing']
+        }
+      },
+      description: 'Submit the season for the bill run'
+    }
+  },
+  {
     method: 'GET',
     path: '/bill-runs/setup',
     handler: BillRunsSetupController.setup,

--- a/app/services/bill-runs/setup/season.service.js
+++ b/app/services/bill-runs/setup/season.service.js
@@ -1,0 +1,32 @@
+'use strict'
+
+/**
+ * Orchestrates fetching and presenting the data for `/bill-runs/setup/{sessionId}/season` page
+ * @module BillRunsCreateSeasonService
+ */
+
+const SessionModel = require('../../../models/session.model.js')
+const SeasonPresenter = require('../../../presenters/bill-runs/setup/season.presenter.js')
+
+/**
+ * Orchestrates fetching and presenting the data for `/bill-runs/setup/{sessionId}/season` page
+ *
+ * Supports generating the data needed for the type page in the create bill run journey. It fetches the current
+ * session record and formats the data needed for the form.
+ *
+ * @param {string} sessionId - The UUID for setup bill run session record
+ *
+ * @returns {Promise<Object>} The view data for the season page
+ */
+async function go (sessionId) {
+  const session = await SessionModel.query().findById(sessionId)
+  const formattedData = SeasonPresenter.go(session)
+
+  return {
+    ...formattedData
+  }
+}
+
+module.exports = {
+  go
+}

--- a/app/services/bill-runs/setup/submit-region.service.js
+++ b/app/services/bill-runs/setup/submit-region.service.js
@@ -1,7 +1,7 @@
 'use strict'
 
 /**
- * Orchestrates validating the data for `/bill-runs/setup/{sessionId}/region` page
+ * Handles the user submission for the `/bill-runs/setup/{sessionId}/region` page
  * @module SubmitRegionService
  */
 
@@ -11,7 +11,7 @@ const RegionValidator = require('../../../validators/bill-runs/setup/region.vali
 const SessionModel = require('../../../models/session.model.js')
 
 /**
- * Orchestrates validating the data for `/bill-runs/setup/{sessionId}/region` page
+ * Handles the user submission for the `/bill-runs/setup/{sessionId}/region` page
  *
  * It first retrieves the session instance for the setup bill run journey in progress. It then validates the payload of
  * the submitted request.

--- a/app/services/bill-runs/setup/submit-season.service.js
+++ b/app/services/bill-runs/setup/submit-season.service.js
@@ -1,0 +1,74 @@
+'use strict'
+
+/**
+ * Handles the user submission for the `/bill-runs/setup/{sessionId}/type` page
+ * @module SubmitSeasonService
+ */
+
+const SessionModel = require('../../../models/session.model.js')
+const SeasonPresenter = require('../../../presenters/bill-runs/setup/season.presenter.js')
+const SeasonValidator = require('../../../validators/bill-runs/setup/season.validator.js')
+
+/**
+ * Handles the user submission for the `/bill-runs/setup/{sessionId}/type` page
+ *
+ * It first retrieves the session instance for the setup bill run journey in progress. It then validates the payload of
+ * the submitted request.
+ *
+ * If there is no validation error it will save the selected value to the session then return an empty object. This will
+ * indicate to the controller that the submission was successful triggering it to redirect to the next page in the
+ * journey.
+ *
+ * If there is a validation error it is combined with the output of the presenter to generate the page data needed to
+ * re-render the view with an error message.
+ *
+ * @param {string} sessionId - The UUID of the current session
+ * @param {Object} payload - The submitted form data
+ *
+ * @returns {Promise<Object>} An empty object if there are no errors else the page data for the type page including the
+ * validation error details
+ */
+async function go (sessionId, payload) {
+  const session = await SessionModel.query().findById(sessionId)
+
+  const validationResult = _validate(payload)
+
+  if (!validationResult) {
+    await _save(session, payload)
+
+    return {}
+  }
+
+  const formattedData = SeasonPresenter.go(session)
+
+  return {
+    error: validationResult,
+    ...formattedData
+  }
+}
+
+async function _save (session, payload) {
+  const currentData = session.data
+
+  currentData.season = payload.season
+
+  return session.$query().patch({ data: currentData })
+}
+
+function _validate (payload) {
+  const validation = SeasonValidator.go(payload)
+
+  if (!validation.error) {
+    return null
+  }
+
+  const { message } = validation.error.details[0]
+
+  return {
+    text: message
+  }
+}
+
+module.exports = {
+  go
+}

--- a/app/validators/bill-runs/setup/season.validator.js
+++ b/app/validators/bill-runs/setup/season.validator.js
@@ -1,0 +1,40 @@
+'use strict'
+
+/**
+ * Validates data submitted for the `/bill-runs/setup/{sessionId}/season` page
+ * @module SeasonValidator
+ */
+
+const Joi = require('joi')
+
+const VALID_VALUES = [
+  'summer',
+  'winter_all_year'
+]
+
+/**
+ * Validates data submitted for the `/bill-runs/setup/{sessionId}/season` page
+ *
+ * @param {Object} payload - The payload from the request to be validated
+ *
+ * @returns {Object} the result from calling Joi's schema.validate(). It will be an object with a `value:` property. If
+ * any errors are found the `error:` property will also exist detailing what the issues were
+ */
+function go (data) {
+  const schema = Joi.object({
+    season: Joi.string()
+      .required()
+      .valid(...VALID_VALUES)
+      .messages({
+        'any.required': 'Select the season',
+        'any.only': 'Select the season',
+        'string.empty': 'Select the season'
+      })
+  })
+
+  return schema.validate(data, { abortEarly: false })
+}
+
+module.exports = {
+  go
+}

--- a/app/views/bill-runs/setup/season.njk
+++ b/app/views/bill-runs/setup/season.njk
@@ -1,0 +1,62 @@
+{% extends 'layout.njk' %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+
+{% block breadcrumbs %}
+  {# Back link #}
+  {{
+    govukBackLink({
+      text: 'Back',
+      href: '/system/bill-runs/setup/' + sessionId + '/year'
+    })
+  }}
+{% endblock %}
+
+{% block content %}
+  {% if error %}
+    {{ govukErrorSummary({
+      titleText: 'There is a problem',
+      errorList: [
+        {
+          text: error.text,
+          href: '#season-error'
+        }
+      ]
+      }) }}
+  {% endif %}
+
+  <div class="govuk-body">
+    <form method="post">
+      {{ govukRadios({
+        attributes: {
+          'data-test': 'bill-run-season'
+        },
+        name: 'season',
+        errorMessage: error,
+        fieldset: {
+          legend: {
+            text: pageTitle,
+            isPageHeading: true,
+            classes: 'govuk-fieldset__legend--l govuk-!-margin-bottom-6'
+          }
+        },
+        items: [
+          {
+            text: 'Summer',
+            value: 'summer',
+            checked: 'summer' == selectedSeason
+          },
+          {
+            text: 'Winter and All year',
+            value: 'winter_all_year',
+            checked: 'winter_all_year' == selectedSeason
+          }
+        ]
+      }) }}
+
+      {{ govukButton({ text: 'Continue', preventDoubleClick: true }) }}
+    </form>
+  </div>
+{% endblock %}

--- a/test/controllers/bill-runs-setup.controller.test.js
+++ b/test/controllers/bill-runs-setup.controller.test.js
@@ -13,6 +13,7 @@ const InitiateSessionService = require('../../app/services/bill-runs/setup/initi
 const RegionService = require('../../app/services/bill-runs/setup/region.service.js')
 const SeasonService = require('../../app/services/bill-runs/setup/season.service.js')
 const SubmitRegionService = require('../../app/services/bill-runs/setup/submit-region.service.js')
+const SubmitSeasonService = require('../../app/services/bill-runs/setup/submit-season.service.js')
 const SubmitTypeService = require('../../app/services/bill-runs/setup/submit-type.service.js')
 const SubmitYearService = require('../../app/services/bill-runs/setup/submit-year.service.js')
 const TypeService = require('../../app/services/bill-runs/setup/type.service.js')
@@ -60,28 +61,6 @@ describe('Bill Runs Setup controller', () => {
 
           expect(response.statusCode).to.equal(302)
           expect(response.headers.location).to.equal(`/system/bill-runs/setup/${session.id}/type`)
-        })
-      })
-    })
-  })
-
-  describe('/bill-runs/setup/{sessionId}/season', () => {
-    describe('GET', () => {
-      beforeEach(async () => {
-        options = _getOptions('season')
-
-        Sinon.stub(SeasonService, 'go').resolves({
-          sessionId: 'e009b394-8405-4358-86af-1a9eb31298a5',
-          selectedSeason: null
-        })
-      })
-
-      describe('when the request succeeds', () => {
-        it('returns the page successfully', async () => {
-          const response = await server.inject(options)
-
-          expect(response.statusCode).to.equal(200)
-          expect(response.payload).to.contain('Select the season')
         })
       })
     })
@@ -162,6 +141,65 @@ describe('Bill Runs Setup controller', () => {
 
           expect(response.statusCode).to.equal(200)
           expect(response.payload).to.contain('Select a region')
+          expect(response.payload).to.contain('There is a problem')
+        })
+      })
+    })
+  })
+
+  describe('/bill-runs/setup/{sessionId}/season', () => {
+    describe('GET', () => {
+      beforeEach(async () => {
+        options = _getOptions('season')
+
+        Sinon.stub(SeasonService, 'go').resolves({
+          sessionId: 'e009b394-8405-4358-86af-1a9eb31298a5',
+          selectedSeason: null
+        })
+      })
+
+      describe('when the request succeeds', () => {
+        it('returns the page successfully', async () => {
+          const response = await server.inject(options)
+
+          expect(response.statusCode).to.equal(200)
+          expect(response.payload).to.contain('Select the season')
+        })
+      })
+    })
+
+    describe('POST', () => {
+      describe('when a request is valid', () => {
+        beforeEach(async () => {
+          options = _postOptions('season', { season: 'summer' })
+
+          Sinon.stub(SubmitSeasonService, 'go').resolves({})
+        })
+
+        it('redirects to the generate bill run endpoint', async () => {
+          const response = await server.inject(options)
+
+          expect(response.statusCode).to.equal(302)
+          expect(response.headers.location).to.equal('/system/bill-runs/setup/e009b394-8405-4358-86af-1a9eb31298a5/generate')
+        })
+      })
+
+      describe('when a request is invalid', () => {
+        beforeEach(async () => {
+          options = _postOptions('season', { type: '' })
+
+          Sinon.stub(SubmitSeasonService, 'go').resolves({
+            sessionId: 'e009b394-8405-4358-86af-1a9eb31298a5',
+            selectedSeason: null,
+            error: { text: 'Select the season' }
+          })
+        })
+
+        it('re-renders the page with an error message', async () => {
+          const response = await server.inject(options)
+
+          expect(response.statusCode).to.equal(200)
+          expect(response.payload).to.contain('Select the season')
           expect(response.payload).to.contain('There is a problem')
         })
       })

--- a/test/controllers/bill-runs-setup.controller.test.js
+++ b/test/controllers/bill-runs-setup.controller.test.js
@@ -11,6 +11,7 @@ const { expect } = Code
 // Things we need to stub
 const InitiateSessionService = require('../../app/services/bill-runs/setup/initiate-session.service.js')
 const RegionService = require('../../app/services/bill-runs/setup/region.service.js')
+const SeasonService = require('../../app/services/bill-runs/setup/season.service.js')
 const SubmitRegionService = require('../../app/services/bill-runs/setup/submit-region.service.js')
 const SubmitTypeService = require('../../app/services/bill-runs/setup/submit-type.service.js')
 const SubmitYearService = require('../../app/services/bill-runs/setup/submit-year.service.js')
@@ -59,6 +60,28 @@ describe('Bill Runs Setup controller', () => {
 
           expect(response.statusCode).to.equal(302)
           expect(response.headers.location).to.equal(`/system/bill-runs/setup/${session.id}/type`)
+        })
+      })
+    })
+  })
+
+  describe('/bill-runs/setup/{sessionId}/season', () => {
+    describe('GET', () => {
+      beforeEach(async () => {
+        options = _getOptions('season')
+
+        Sinon.stub(SeasonService, 'go').resolves({
+          sessionId: 'e009b394-8405-4358-86af-1a9eb31298a5',
+          selectedSeason: null
+        })
+      })
+
+      describe('when the request succeeds', () => {
+        it('returns the page successfully', async () => {
+          const response = await server.inject(options)
+
+          expect(response.statusCode).to.equal(200)
+          expect(response.payload).to.contain('Select the season')
         })
       })
     })

--- a/test/presenters/bill-runs/setup/season.presenter.test.js
+++ b/test/presenters/bill-runs/setup/season.presenter.test.js
@@ -1,0 +1,50 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Thing under test
+const SeasonPresenter = require('../../../../app/presenters/bill-runs/setup/season.presenter.js')
+
+describe('Bill Runs Setup Season presenter', () => {
+  let session
+
+  describe('when provided with a bill run setup session record', () => {
+    beforeEach(() => {
+      session = {
+        id: '98ad3a1f-8e4f-490a-be05-0aece6755466',
+        data: {}
+      }
+    })
+
+    describe('where the user has not previously selected a season', () => {
+      it('correctly presents the data', () => {
+        const result = SeasonPresenter.go(session)
+
+        expect(result).to.equal({
+          sessionId: '98ad3a1f-8e4f-490a-be05-0aece6755466',
+          selectedSeason: null
+        })
+      })
+    })
+
+    describe('where the user has previously selected a season', () => {
+      beforeEach(() => {
+        session.data.season = 'summer'
+      })
+
+      it('correctly presents the data', () => {
+        const result = SeasonPresenter.go(session)
+
+        expect(result).to.equal({
+          sessionId: '98ad3a1f-8e4f-490a-be05-0aece6755466',
+          selectedSeason: 'summer'
+        })
+      })
+    })
+  })
+})

--- a/test/services/bill-runs/setup/season.service.test.js
+++ b/test/services/bill-runs/setup/season.service.test.js
@@ -1,0 +1,36 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const DatabaseSupport = require('../../../support/database.js')
+const SessionHelper = require('../../../support/helpers/session.helper.js')
+
+// Thing under test
+const SeasonService = require('../../../../app/services/bill-runs/setup/season.service.js')
+
+describe('Bill Runs Setup Type service', () => {
+  let session
+
+  beforeEach(async () => {
+    await DatabaseSupport.clean()
+
+    session = await SessionHelper.add({ data: { season: 'summer' } })
+  })
+
+  describe('when called', () => {
+    it('returns page data for the view', async () => {
+      const result = await SeasonService.go(session.id)
+
+      expect(result).to.equal({
+        sessionId: session.id,
+        selectedSeason: 'summer'
+      })
+    })
+  })
+})

--- a/test/services/bill-runs/setup/submit-season.service.test.js
+++ b/test/services/bill-runs/setup/submit-season.service.test.js
@@ -1,0 +1,70 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const DatabaseSupport = require('../../../support/database.js')
+const SessionHelper = require('../../../support/helpers/session.helper.js')
+
+// Thing under test
+const SubmitSeasonService = require('../../../../app/services/bill-runs/setup/submit-season.service.js')
+
+describe('Bill Runs Setup Submit Season service', () => {
+  let payload
+  let session
+
+  beforeEach(async () => {
+    await DatabaseSupport.clean()
+
+    session = await SessionHelper.add({ data: {} })
+  })
+
+  describe('when called', () => {
+    describe('with a valid payload', () => {
+      beforeEach(() => {
+        payload = {
+          season: 'summer'
+        }
+      })
+
+      it('saves the submitted value', async () => {
+        await SubmitSeasonService.go(session.id, payload)
+
+        const refreshedSession = await session.$query()
+
+        expect(refreshedSession.data.season).to.equal('summer')
+      })
+
+      it('returns an empty object (no page data is needed for a redirect)', async () => {
+        const result = await SubmitSeasonService.go(session.id, payload)
+
+        expect(result).to.equal({})
+      })
+    })
+
+    describe('with an invalid payload', () => {
+      describe('because the user has not selected anything', () => {
+        beforeEach(() => {
+          payload = {}
+        })
+
+        it('returns page data needed to re-render the view including the validation error', async () => {
+          const result = await SubmitSeasonService.go(session.id, payload)
+
+          expect(result).to.equal({
+            sessionId: session.id,
+            selectedSeason: null,
+            error: {
+              text: 'Select the season'
+            }
+          })
+        })
+      })
+    })
+  })
+})

--- a/test/validators/bill-runs/setup/season.validator.test.js
+++ b/test/validators/bill-runs/setup/season.validator.test.js
@@ -1,0 +1,44 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Thing under test
+const SeasonValidator = require('../../../../app/validators/bill-runs/setup/season.validator.js')
+
+describe('Bill Runs Setup Season validator', () => {
+  describe('when valid data is provided', () => {
+    it('confirms the data is valid', () => {
+      const result = SeasonValidator.go({ season: 'summer' })
+
+      expect(result.value).to.exist()
+      expect(result.error).not.to.exist()
+    })
+  })
+
+  describe('when invalid data is provided', () => {
+    describe("because no 'season' is given", () => {
+      it('fails validation', () => {
+        const result = SeasonValidator.go({ season: '' })
+
+        expect(result.value).to.exist()
+        expect(result.error).to.exist()
+        expect(result.error.details[0].message).to.equal('Select the season')
+      })
+    })
+
+    describe("because an unknown 'season' is given", () => {
+      it('fails validation', () => {
+        const result = SeasonValidator.go({ type: 'spring' })
+
+        expect(result.value).to.exist()
+        expect(result.error).to.exist()
+        expect(result.error.details[0].message).to.equal('Select the season')
+      })
+    })
+  })
+})


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4375

> Part of a series of changes related to replacing the create bill run journey to incorporate changes for two-part tariff

This adds the fourth and final page to the setup bill run journey; select the season. This like [Add bill runs setup financial year page to journey](https://github.com/DEFRA/water-abstraction-system/pull/805) is only needed temporarily.

Two-part tariff bill runs were held during COVID then the SROC ones have been delayed whilst we build an SROC 2PT billing engine. This means we have a backlog so users need to be able to select the year they wish to create the bill run for.

If they select a PRESROC year they then need to pick the season. Under PRESROC two-part tariff bill runs were based on whether a licence's abstraction was in summer, or winter and all-year. We need to know what season they wish to generate so we can tell the legacy engine.

Once the backlogged PRESROC two-part tariff bill runs are dealt with this page will become redundant. Once all the backlogged two-part tariff bill runs have been dealt with both `/year` and `/season` can be dropped from the journey altogether.