### PR TITLE
Filter Licences by Licence Holder Name on the 2PT Review Licences Page

### DIFF
--- a/app/controllers/bill-runs.controller.js
+++ b/app/controllers/bill-runs.controller.js
@@ -46,8 +46,7 @@ async function create (request, h) {
 
 async function review (request, h) {
   const { id } = request.params
-
-  const pageData = await ReviewBillRunService.go(id)
+  const pageData = await ReviewBillRunService.go(id, request.payload)
 
   return h.view('bill-runs/review.njk', {
     pageTitle: 'Review licences',

--- a/app/models/bill-run.model.js
+++ b/app/models/bill-run.model.js
@@ -16,12 +16,12 @@ class BillRunModel extends BaseModel {
 
   static get relationMappings () {
     return {
-      region: {
-        relation: Model.BelongsToOneRelation,
-        modelClass: 'region.model',
+      billRunVolumes: {
+        relation: Model.HasManyRelation,
+        modelClass: 'bill-run-volume.model',
         join: {
-          from: 'billRuns.regionId',
-          to: 'regions.id'
+          from: 'billRuns.id',
+          to: 'billRunVolumes.billRunId'
         }
       },
       bills: {
@@ -32,12 +32,20 @@ class BillRunModel extends BaseModel {
           to: 'bills.billRunId'
         }
       },
-      billRunVolumes: {
+      region: {
+        relation: Model.BelongsToOneRelation,
+        modelClass: 'region.model',
+        join: {
+          from: 'billRuns.regionId',
+          to: 'regions.id'
+        }
+      },
+      reviewLicences: {
         relation: Model.HasManyRelation,
-        modelClass: 'bill-run-volume.model',
+        modelClass: 'review-licence.model',
         join: {
           from: 'billRuns.id',
-          to: 'billRunVolumes.billRunId'
+          to: 'reviewLicences.billRunId'
         }
       }
     }

--- a/app/models/review-licence.model.js
+++ b/app/models/review-licence.model.js
@@ -16,6 +16,14 @@ class ReviewLicenceModel extends BaseModel {
 
   static get relationMappings () {
     return {
+      billRun: {
+        relation: Model.BelongsToOneRelation,
+        modelClass: 'bill-run.model',
+        join: {
+          from: 'reviewLicences.billRunId',
+          to: 'billRuns.id'
+        }
+      },
       licence: {
         relation: Model.BelongsToOneRelation,
         modelClass: 'licence.model',

--- a/app/presenters/bill-runs/two-part-tariff/review-bill-run.presenter.js
+++ b/app/presenters/bill-runs/two-part-tariff/review-bill-run.presenter.js
@@ -10,10 +10,11 @@ const { formatLongDate } = require('../../base.presenter.js')
 /**
  * Prepares and processes bill run and licence data for presentation
  *
- * @param {module:BillRunModel} billRun the data from the bill run
- * @param {module:LicenceModel} licences the licences data asociated with the bill run
+ * @param {module:BillRunModel} billRun The data from the bill run
+ * @param {module:LicenceModel} licences The licences data asociated with the bill run
+ * @param {String} filterLicenceHolder The string that the licence holder is to be filtered on if any
  *
- * @returns {Object} the prepared bill run and licence data to be passed to the review page
+ * @returns {Object} The prepared bill run and licence data to be passed to the review page
  */
 function go (billRun, licences, filterLicenceHolder) {
   const { licencesToReviewCount, preparedLicences } = _prepareLicences(licences)

--- a/app/presenters/bill-runs/two-part-tariff/review-bill-run.presenter.js
+++ b/app/presenters/bill-runs/two-part-tariff/review-bill-run.presenter.js
@@ -15,12 +15,18 @@ const { formatLongDate } = require('../../base.presenter.js')
  *
  * @returns {Object} the prepared bill run and licence data to be passed to the review page
  */
-function go (billRun, licences) {
+function go (billRun, licences, filterLicenceHolder) {
   const { licencesToReviewCount, preparedLicences } = _prepareLicences(licences)
 
   const preparedBillRun = _prepareBillRun(billRun, preparedLicences, licencesToReviewCount)
+  const filterData = { openFilter: false }
 
-  return { ...preparedBillRun, preparedLicences }
+  if (filterLicenceHolder) {
+    filterData.openFilter = true
+    filterData.licenceHolder = filterLicenceHolder
+  }
+
+  return { ...preparedBillRun, preparedLicences, filterData }
 }
 
 function _prepareLicences (licences) {

--- a/app/presenters/bill-runs/two-part-tariff/review-bill-run.presenter.js
+++ b/app/presenters/bill-runs/two-part-tariff/review-bill-run.presenter.js
@@ -17,9 +17,6 @@ const { formatLongDate } = require('../../base.presenter.js')
  * @returns {Object} The prepared bill run and licence data to be passed to the review page
  */
 function go (billRun, licences, filterLicenceHolder) {
-  console.log('🚀 ~ go ~ billRun:', billRun)
-  console.log('🚀 ~ go ~ licences:', licences)
-  console.log('🚀 ~ go ~ filterLicenceHolder:', filterLicenceHolder)
   const { licencesToReviewCount, preparedLicences } = _prepareLicences(licences)
 
   const preparedBillRun = _prepareBillRun(billRun, preparedLicences, licencesToReviewCount)

--- a/app/presenters/bill-runs/two-part-tariff/review-bill-run.presenter.js
+++ b/app/presenters/bill-runs/two-part-tariff/review-bill-run.presenter.js
@@ -17,9 +17,9 @@ const { formatLongDate } = require('../../base.presenter.js')
  * @returns {Object} The prepared bill run and licence data to be passed to the review page
  */
 function go (billRun, licences, filterLicenceHolder) {
-  const { licencesToReviewCount, preparedLicences } = _prepareLicences(licences)
+  const { numberOfLicencesToReview, preparedLicences } = _prepareLicences(licences)
 
-  const preparedBillRun = _prepareBillRun(billRun, preparedLicences, licencesToReviewCount)
+  const preparedBillRun = _prepareBillRun(billRun, preparedLicences, numberOfLicencesToReview)
   const filterData = { openFilter: false }
 
   if (filterLicenceHolder) {
@@ -31,12 +31,12 @@ function go (billRun, licences, filterLicenceHolder) {
 }
 
 function _prepareLicences (licences) {
-  let licencesToReviewCount = 0
+  let numberOfLicencesToReview = 0
   const preparedLicences = []
 
   for (const licence of licences) {
     if (licence.status === 'review') {
-      licencesToReviewCount++
+      numberOfLicencesToReview++
     }
 
     preparedLicences.push({
@@ -48,10 +48,10 @@ function _prepareLicences (licences) {
     })
   }
 
-  return { preparedLicences, licencesToReviewCount }
+  return { preparedLicences, numberOfLicencesToReview }
 }
 
-function _prepareBillRun (billRun, preparedLicences, licencesToReviewCount) {
+function _prepareBillRun (billRun, preparedLicences, numberOfLicencesToReview) {
   return {
     region: billRun.region.displayName,
     status: billRun.status,
@@ -59,7 +59,7 @@ function _prepareBillRun (billRun, preparedLicences, licencesToReviewCount) {
     financialYear: _financialYear(billRun.toFinancialYearEnding),
     billRunType: 'two-part tariff',
     numberOfLicencesDisplayed: preparedLicences.length,
-    licencesToReviewCount,
+    numberOfLicencesToReview,
     totalNumberOfLicences: billRun.reviewLicences[0].totalNumberOfLicences
   }
 }

--- a/app/presenters/bill-runs/two-part-tariff/review-bill-run.presenter.js
+++ b/app/presenters/bill-runs/two-part-tariff/review-bill-run.presenter.js
@@ -51,15 +51,16 @@ function _prepareLicences (licences) {
   return { preparedLicences, licencesToReviewCount }
 }
 
-function _prepareBillRun (billRun, billRunLicences, licencesToReviewCount) {
+function _prepareBillRun (billRun, preparedLicences, licencesToReviewCount) {
   return {
     region: billRun.region.displayName,
     status: billRun.status,
     dateCreated: formatLongDate(billRun.createdAt),
     financialYear: _financialYear(billRun.toFinancialYearEnding),
     billRunType: 'two-part tariff',
-    numberOfLicences: billRunLicences.length,
-    licencesToReviewCount
+    numberOfLicencesDisplayed: preparedLicences.length,
+    licencesToReviewCount,
+    totalNumberOfLicences: billRun.reviewLicences[0].totalNumberOfLicences
   }
 }
 

--- a/app/presenters/bill-runs/two-part-tariff/review-bill-run.presenter.js
+++ b/app/presenters/bill-runs/two-part-tariff/review-bill-run.presenter.js
@@ -17,6 +17,9 @@ const { formatLongDate } = require('../../base.presenter.js')
  * @returns {Object} The prepared bill run and licence data to be passed to the review page
  */
 function go (billRun, licences, filterLicenceHolder) {
+  console.log('🚀 ~ go ~ billRun:', billRun)
+  console.log('🚀 ~ go ~ licences:', licences)
+  console.log('🚀 ~ go ~ filterLicenceHolder:', filterLicenceHolder)
   const { licencesToReviewCount, preparedLicences } = _prepareLicences(licences)
 
   const preparedBillRun = _prepareBillRun(billRun, preparedLicences, licencesToReviewCount)
@@ -72,12 +75,11 @@ function _financialYear (financialYearEnding) {
 }
 
 function _getIssueOnLicence (issues) {
-  if (issues.length > 1) {
+  // if there is more than one issue the issues will be seperated by a comma
+  if (issues.includes(',')) {
     return 'Multiple Issues'
-  } else if (issues.length === 1) {
-    return issues[0]
   } else {
-    return ''
+    return issues
   }
 }
 

--- a/app/presenters/bill-runs/two-part-tariff/review-bill-run.presenter.js
+++ b/app/presenters/bill-runs/two-part-tariff/review-bill-run.presenter.js
@@ -75,9 +75,9 @@ function _getIssueOnLicence (issues) {
   // if there is more than one issue the issues will be seperated by a comma
   if (issues.includes(',')) {
     return 'Multiple Issues'
-  } else {
-    return issues
   }
+
+  return issues
 }
 
 module.exports = {

--- a/app/routes/bill-runs.routes.js
+++ b/app/routes/bill-runs.routes.js
@@ -72,6 +72,19 @@ const routes = [
     }
   },
   {
+    method: 'POST',
+    path: '/bill-runs/{id}/review',
+    handler: BillRunsController.review,
+    options: {
+      auth: {
+        access: {
+          scope: ['billing']
+        }
+      },
+      description: 'POST request recieved when filtering applied to Review two-part tariff match and allocation results'
+    }
+  },
+  {
     method: 'GET',
     path: '/bill-runs/{id}/review/{licenceId}',
     handler: BillRunsController.reviewLicence,

--- a/app/routes/bill-runs.routes.js
+++ b/app/routes/bill-runs.routes.js
@@ -81,7 +81,7 @@ const routes = [
           scope: ['billing']
         }
       },
-      description: 'POST request recieved when filtering applied to Review two-part tariff match and allocation results'
+      description: 'POST request recieved when filtering applied to review two-part tariff match and allocation results'
     }
   },
   {

--- a/app/services/bill-runs/two-part-tariff/fetch-bill-run-licences.service.js
+++ b/app/services/bill-runs/two-part-tariff/fetch-bill-run-licences.service.js
@@ -25,7 +25,6 @@ async function go (id, payload) {
   const filterLicenceHolder = payload?.filterLicenceHolder
 
   const billRun = await _fetchBillRun(id)
-  console.log('🚀 ~ go ~ billRun:', billRun)
   const licences = await _fetchBillRunLicences(id, filterLicenceHolder)
 
   return { billRun, licences, filterLicenceHolder }

--- a/app/services/bill-runs/two-part-tariff/fetch-bill-run-licences.service.js
+++ b/app/services/bill-runs/two-part-tariff/fetch-bill-run-licences.service.js
@@ -15,8 +15,11 @@ const ReviewLicenceModel = require('../../../models/review-licence.model.js')
  * ref.
  *
  * @param {String} id The UUID for the bill run
+ * @param {Object} payload The `request.payload` containing the filter data. This only contains data when there is a
+ * POST request, which only occurs when a filter is applied to the results.
  *
- * @returns {Promise<Object>} an object containing the billRun data and an array of licences for the bill run
+ * @returns {Promise<Object>} An object containing the billRun data and an array of licences for the bill run. Also
+ * included is any data that has been used to filter the results
  */
 async function go (id, payload) {
   const filterLicenceHolder = payload?.filterLicenceHolder

--- a/app/services/bill-runs/two-part-tariff/fetch-bill-run-licences.service.js
+++ b/app/services/bill-runs/two-part-tariff/fetch-bill-run-licences.service.js
@@ -25,6 +25,7 @@ async function go (id, payload) {
   const filterLicenceHolder = payload?.filterLicenceHolder
 
   const billRun = await _fetchBillRun(id)
+  console.log('🚀 ~ go ~ billRun:', billRun)
   const licences = await _fetchBillRunLicences(id, filterLicenceHolder)
 
   return { billRun, licences, filterLicenceHolder }
@@ -33,19 +34,24 @@ async function go (id, payload) {
 async function _fetchBillRun (id) {
   return BillRunModel.query()
     .findById(id)
-    .select([
+    .select(
       'id',
       'createdAt',
       'status',
       'toFinancialYearEnding',
       'batchType'
-    ])
+    )
     .withGraphFetched('region')
     .modifyGraph('region', (builder) => {
-      builder.select([
+      builder.select(
         'id',
         'displayName'
-      ])
+      )
+    })
+    .withGraphFetched('reviewLicences')
+    .modifyGraph('reviewLicences', (builder) => {
+      builder.count('licenceId as totalNumberOfLicences')
+        .groupBy('billRunId')
     })
 }
 

--- a/app/services/bill-runs/two-part-tariff/fetch-bill-run-licences.service.js
+++ b/app/services/bill-runs/two-part-tariff/fetch-bill-run-licences.service.js
@@ -33,19 +33,10 @@ async function go (id, payload) {
 async function _fetchBillRun (id) {
   return BillRunModel.query()
     .findById(id)
-    .select(
-      'id',
-      'createdAt',
-      'status',
-      'toFinancialYearEnding',
-      'batchType'
-    )
+    .select('id', 'createdAt', 'status', 'toFinancialYearEnding', 'batchType')
     .withGraphFetched('region')
     .modifyGraph('region', (builder) => {
-      builder.select(
-        'id',
-        'displayName'
-      )
+      builder.select('id', 'displayName')
     })
     .withGraphFetched('reviewLicences')
     .modifyGraph('reviewLicences', (builder) => {

--- a/app/services/bill-runs/two-part-tariff/fetch-bill-run-licences.service.js
+++ b/app/services/bill-runs/two-part-tariff/fetch-bill-run-licences.service.js
@@ -18,17 +18,13 @@ const ReviewLicenceModel = require('../../../models/review-licence.model.js')
  *
  * @returns {Promise<Object>} an object containing the billRun data and an array of licences for the bill run
  */
-async function go (id) {
+async function go (id, payload) {
+  const licenceHolder = payload?.licenceHolder
+
   const billRun = await _fetchBillRun(id)
-  const licences = await _fetchBillRunLicences(id)
+  const licences = await _fetchBillRunLicences(id, licenceHolder)
 
   return { billRun, licences }
-}
-
-async function _fetchBillRunLicences (id) {
-  return ReviewLicenceModel.query()
-    .where('billRunId', id)
-    .orderBy('status', 'desc')
 }
 
 async function _fetchBillRun (id) {
@@ -48,6 +44,18 @@ async function _fetchBillRun (id) {
         'displayName'
       ])
     })
+}
+
+async function _fetchBillRunLicences (id, licenceHolder) {
+  const reviewLicenceQuery = ReviewLicenceModel.query()
+    .where('billRunId', id)
+    .orderBy('status', 'desc')
+
+  if (licenceHolder) {
+    reviewLicenceQuery.whereILike('licenceHolder', `%${licenceHolder}%`)
+  }
+
+  return reviewLicenceQuery
 }
 
 module.exports = {

--- a/app/services/bill-runs/two-part-tariff/fetch-bill-run-licences.service.js
+++ b/app/services/bill-runs/two-part-tariff/fetch-bill-run-licences.service.js
@@ -19,12 +19,12 @@ const ReviewLicenceModel = require('../../../models/review-licence.model.js')
  * @returns {Promise<Object>} an object containing the billRun data and an array of licences for the bill run
  */
 async function go (id, payload) {
-  const licenceHolder = payload?.licenceHolder
+  const filterLicenceHolder = payload?.filterLicenceHolder
 
   const billRun = await _fetchBillRun(id)
-  const licences = await _fetchBillRunLicences(id, licenceHolder)
+  const licences = await _fetchBillRunLicences(id, filterLicenceHolder)
 
-  return { billRun, licences }
+  return { billRun, licences, filterLicenceHolder }
 }
 
 async function _fetchBillRun (id) {
@@ -46,13 +46,13 @@ async function _fetchBillRun (id) {
     })
 }
 
-async function _fetchBillRunLicences (id, licenceHolder) {
+async function _fetchBillRunLicences (id, filterLicenceHolder) {
   const reviewLicenceQuery = ReviewLicenceModel.query()
     .where('billRunId', id)
     .orderBy('status', 'desc')
 
-  if (licenceHolder) {
-    reviewLicenceQuery.whereILike('licenceHolder', `%${licenceHolder}%`)
+  if (filterLicenceHolder) {
+    reviewLicenceQuery.whereILike('licenceHolder', `%${filterLicenceHolder}%`)
   }
 
   return reviewLicenceQuery

--- a/app/services/bill-runs/two-part-tariff/review-bill-run.service.js
+++ b/app/services/bill-runs/two-part-tariff/review-bill-run.service.js
@@ -16,8 +16,8 @@ const ReviewBillRunPresenter = require('../../../presenters/bill-runs/two-part-t
  * @returns {Promise<Object>} an object representing the `pageData` needed by the review bill run template. It contains details of
  * the bill run and the licences linked to it.
  */
-async function go (id) {
-  const { billRun, licences } = await FetchBillRunLicencesService.go(id)
+async function go (id, payload = null) {
+  const { billRun, licences } = await FetchBillRunLicencesService.go(id, payload)
 
   const pageData = ReviewBillRunPresenter.go(billRun, licences)
 

--- a/app/services/bill-runs/two-part-tariff/review-bill-run.service.js
+++ b/app/services/bill-runs/two-part-tariff/review-bill-run.service.js
@@ -17,9 +17,9 @@ const ReviewBillRunPresenter = require('../../../presenters/bill-runs/two-part-t
  * the bill run and the licences linked to it.
  */
 async function go (id, payload = null) {
-  const { billRun, licences } = await FetchBillRunLicencesService.go(id, payload)
+  const { billRun, licences, filterLicenceHolder } = await FetchBillRunLicencesService.go(id, payload)
 
-  const pageData = ReviewBillRunPresenter.go(billRun, licences)
+  const pageData = ReviewBillRunPresenter.go(billRun, licences, filterLicenceHolder)
 
   return pageData
 }

--- a/app/services/bill-runs/two-part-tariff/review-bill-run.service.js
+++ b/app/services/bill-runs/two-part-tariff/review-bill-run.service.js
@@ -11,10 +11,12 @@ const ReviewBillRunPresenter = require('../../../presenters/bill-runs/two-part-t
 /**
  * Orchestrates fetching and presenting the data needed for the review bill run page
  *
- * @param {string} id The UUID for the bill run to review
+ * @param {String} id The UUID for the bill run to review
+ * @param {Object} payload The `request.payload` containing the filter data. This is only passed to the service when
+ * there is a POST request, which only occurs when a filter is applied to the results.
  *
- * @returns {Promise<Object>} an object representing the `pageData` needed by the review bill run template. It contains details of
- * the bill run and the licences linked to it.
+ * @returns {Promise<Object>} An object representing the `pageData` needed by the review bill run template. It contains
+ * details of the bill run and the licences linked to it as well as any data that has been used to filter the results.
  */
 async function go (id, payload = null) {
   const { billRun, licences, filterLicenceHolder } = await FetchBillRunLicencesService.go(id, payload)

--- a/app/views/bill-runs/review.njk
+++ b/app/views/bill-runs/review.njk
@@ -134,7 +134,8 @@
         },
         classes: "govuk-input--width-20",
         id: "licenceHolder",
-        name: "licenceHolder"
+        name: "licenceHolder",
+        value: filter.licenceHolder
       }) }}
 
       <div class="govuk-button-group">
@@ -155,7 +156,8 @@
   {{ govukDetails({
     summaryText: "Filter licences",
     html: filtersForm | safe,
-    classes: "govuk-!-margin-bottom-2"
+    classes: "govuk-!-margin-bottom-2",
+    open: openFilter
   }) }}
 
   {# Generate the row data for the table #}

--- a/app/views/bill-runs/review.njk
+++ b/app/views/bill-runs/review.njk
@@ -13,12 +13,10 @@
 
 {% block breadcrumbs %}
   {# Back link #}
-  {{
-    govukBackLink({
+  {{ govukBackLink({
       text: 'Go back to bill runs',
       href: '/billing/batch/list'
-    })
-  }}
+  }) }}
 {% endblock %}
 
 {% block content %}
@@ -36,10 +34,10 @@
       {% endif %}
 
       <p class="govuk-body">
-        {{govukTag({
+        {{ govukTag({
           text: status,
           classes: colour
-        })}}
+        }) }}
       </p>
 
       {# Bill run meta-data #}
@@ -122,6 +120,43 @@
       href: 'cancel'
     }) }}
   </section>
+
+
+  {% set filtersForm %}
+    <h2 class="govuk-heading-m govuk-!-margin-bottom-3">Filter by</h2>
+
+    <form  method="post" novalidate action="review">
+      {{ govukInput({
+        label: {
+          text: "Licence holder",
+          classes: "govuk-label--s",
+          isPageHeading: false
+        },
+        classes: "govuk-input--width-20",
+        id: "licenceHolder",
+        name: "licenceHolder"
+      }) }}
+
+      <div class="govuk-button-group">
+        {{ govukButton({
+          text: "Apply filters"
+        }) }}
+
+        {{ govukButton({
+          text: "Clear filters",
+          classes: "govuk-button--secondary ",
+          name: "clearFilters",
+          type: "reset"
+        }) }}
+      </div>
+    </form>
+  {% endset %}
+
+  {{ govukDetails({
+    summaryText: "Filter licences",
+    html: filtersForm | safe,
+    classes: "govuk-!-margin-bottom-2"
+  }) }}
 
   {# Generate the row data for the table #}
   {% set tableRows = [] %}

--- a/app/views/bill-runs/review.njk
+++ b/app/views/bill-runs/review.njk
@@ -192,9 +192,16 @@
       {% endfor %}
     {% endif %}
 
+  {# Sets the caption to be used in the table below #}
+  {% if totalNumberOfLicences > numberOfLicencesDisplayed %}
+    {% set caption = "Showing " + numberOfLicencesDisplayed + " of " + totalNumberOfLicences + " licences" %}
+  {% else %}
+    {% set caption = "Showing all " + totalNumberOfLicences + " licences" %}
+  {% endif %}
+
   {# Table displaying details of the licences in the bill run. These results take into account any filter that is set #}
   {{ govukTable({
-    caption: "Showing all " + numberOfLicences + " licences",
+    caption: caption,
     captionClasses: "govuk-table__caption--s govuk-!-margin-bottom-2",
     firstCellIsHeader: false,
     head: [

--- a/app/views/bill-runs/review.njk
+++ b/app/views/bill-runs/review.njk
@@ -100,10 +100,10 @@
   </div>
 
   {# Dynamic message either telling the user they have issues to deal with or that they can generate bills #}
-  {% if licencesToReviewCount > 0 %}
+  {% if numberOfLicencesToReview > 0 %}
     <section class="govuk-!-margin-bottom-9">
       {{ govukInsetText({
-        text: 'You need to review ' + licencesToReviewCount + ' licences with returns data issues. You can then continue and send the bill run.'
+        text: 'You need to review ' + numberOfLicencesToReview + ' licences with returns data issues. You can then continue and send the bill run.'
       }) }}
     </section>
   {% else %}

--- a/app/views/bill-runs/review.njk
+++ b/app/views/bill-runs/review.njk
@@ -116,8 +116,8 @@
   <section class="govuk-!-margin-bottom-9">
     {{ govukButton({
       classes: "govuk-button--secondary govuk-!-margin-bottom-0",
-      text: 'Cancel bill run',
-      href: 'cancel'
+      text: "Cancel bill run",
+      href: "cancel"
     }) }}
   </section>
 
@@ -133,9 +133,9 @@
           isPageHeading: false
         },
         classes: "govuk-input--width-20",
-        id: "licenceHolder",
-        name: "licenceHolder",
-        value: filter.licenceHolder
+        id: "filterLicenceHolder",
+        name: "filterLicenceHolder",
+        value: filterData.licenceHolder
       }) }}
 
       <div class="govuk-button-group">
@@ -147,7 +147,8 @@
           text: "Clear filters",
           classes: "govuk-button--secondary ",
           name: "clearFilters",
-          type: "reset"
+          type: "reset",
+          href: "review"
         }) }}
       </div>
     </form>
@@ -157,7 +158,7 @@
     summaryText: "Filter licences",
     html: filtersForm | safe,
     classes: "govuk-!-margin-bottom-2",
-    open: openFilter
+    open: filterData.openFilter
   }) }}
 
   {# Generate the row data for the table #}

--- a/test/controllers/bill-runs.controller.test.js
+++ b/test/controllers/bill-runs.controller.test.js
@@ -448,7 +448,7 @@ function _reviewBillRunData () {
     financialYear: '2021 to 2022',
     billRunType: 'two-part tariff',
     numberOfLicencesDisplayed: 2,
-    licencesToReviewCount: 1,
+    numberOfLicencesToReview: 1,
     totalNumberOfLicences: 2,
     preparedLicences: [
       {

--- a/test/models/bill-run.model.test.js
+++ b/test/models/bill-run.model.test.js
@@ -16,6 +16,8 @@ const BillRunVolumeModel = require('../../app/models/bill-run-volume.model.js')
 const DatabaseSupport = require('../support/database.js')
 const RegionHelper = require('../support/helpers/region.helper.js')
 const RegionModel = require('../../app/models/region.model.js')
+const ReviewLicenceHelper = require('../support/helpers/review-licence.helper.js')
+const ReviewLicenceModel = require('../../app/models/review-licence.model.js')
 
 // Thing under test
 const BillRunModel = require('../../app/models/bill-run.model.js')
@@ -138,6 +140,42 @@ describe('Bill Run model', () => {
         expect(result.billRunVolumes[0]).to.be.an.instanceOf(BillRunVolumeModel)
         expect(result.billRunVolumes).to.include(testBillRunVolumes[0])
         expect(result.billRunVolumes).to.include(testBillRunVolumes[1])
+      })
+    })
+
+    describe('when linking to review Licences', () => {
+      let testReviewLicences
+
+      beforeEach(async () => {
+        testRecord = await BillRunHelper.add()
+        const { id } = testRecord
+
+        testReviewLicences = []
+        for (let i = 0; i < 2; i++) {
+          const reviewLicence = await ReviewLicenceHelper.add({ billRunId: id })
+          testReviewLicences.push(reviewLicence)
+        }
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await BillRunModel.query()
+          .innerJoinRelated('reviewLicences')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the review licences', async () => {
+        const result = await BillRunModel.query()
+          .findById(testRecord.id)
+          .withGraphFetched('reviewLicences')
+
+        expect(result).to.be.instanceOf(BillRunModel)
+        expect(result.id).to.equal(testRecord.id)
+
+        expect(result.reviewLicences).to.be.an.array()
+        expect(result.reviewLicences[0]).to.be.an.instanceOf(ReviewLicenceModel)
+        expect(result.reviewLicences).to.include(testReviewLicences[0])
+        expect(result.reviewLicences).to.include(testReviewLicences[1])
       })
     })
   })

--- a/test/models/review-licence.model.test.js
+++ b/test/models/review-licence.model.test.js
@@ -9,6 +9,8 @@ const { expect } = Code
 
 // Test helpers
 const DatabaseSupport = require('../support/database.js')
+const BillRunHelper = require('../support/helpers/bill-run.helper.js')
+const BillRunModel = require('../../app/models/bill-run.model.js')
 const LicenceHelper = require('../support/helpers/licence.helper.js')
 const LicenceModel = require('../../app/models/licence.model.js')
 const ReviewChargeVersionHelper = require('../support/helpers/review-charge-version.helper.js')
@@ -41,7 +43,36 @@ describe('Review Licence model', () => {
   })
 
   describe('Relationships', () => {
-    describe('when linking to licence', () => {
+    describe('when linking to a bill run', () => {
+      let testBillRun
+
+      beforeEach(async () => {
+        testBillRun = await BillRunHelper.add()
+
+        testRecord = await ReviewLicenceHelper.add({ billRunId: testBillRun.id })
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await ReviewLicenceModel.query()
+          .innerJoinRelated('billRun')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the bill run', async () => {
+        const result = await ReviewLicenceModel.query()
+          .findById(testRecord.id)
+          .withGraphFetched('billRun')
+
+        expect(result).to.be.instanceOf(ReviewLicenceModel)
+        expect(result.id).to.equal(testRecord.id)
+
+        expect(result.billRun).to.be.instanceOf(BillRunModel)
+        expect(result.billRun).to.equal(testBillRun)
+      })
+    })
+
+    describe('when linking to a licence', () => {
       let testLicence
 
       beforeEach(async () => {

--- a/test/presenters/bill-runs/two-part-tariff/review-bill-run.presenter.test.js
+++ b/test/presenters/bill-runs/two-part-tariff/review-bill-run.presenter.test.js
@@ -24,8 +24,9 @@ describe('Review Bill Run presenter', () => {
         dateCreated: '17 January 2024',
         financialYear: '2022 to 2023',
         billRunType: 'two-part tariff',
-        numberOfLicences: 3,
+        numberOfLicencesDisplayed: 3,
         licencesToReviewCount: 1,
+        totalNumberOfLicences: 3,
         preparedLicences: [
           {
             id: 'cc4bbb18-0d6a-4254-ac2c-7409de814d7e',
@@ -48,7 +49,19 @@ describe('Review Bill Run presenter', () => {
             status: 'review',
             issue: 'Multiple Issues'
           }
-        ]
+        ],
+        filterData: { openFilter: false }
+      })
+    })
+
+    describe('and a filter has been applied', () => {
+      const filterLicenceHolder = 'big farm'
+
+      it('correctly presents the data', () => {
+        const result = ReviewBillRunPresenter.go(testBillRun, testLicences, filterLicenceHolder)
+
+        expect(result.filterData.openFilter).to.equal(true)
+        expect(result.filterData.licenceHolder).to.equal(filterLicenceHolder)
       })
     })
   })
@@ -63,7 +76,8 @@ function _testBillRun () {
     batchType: 'two_part_tariff',
     region: {
       displayName: 'Southern (Test replica)'
-    }
+    },
+    reviewLicences: [{ totalNumberOfLicences: 3 }]
   }
 }
 
@@ -74,7 +88,7 @@ function _testLicences () {
       licenceId: 'cc4bbb18-0d6a-4254-ac2c-7409de814d7e',
       licenceRef: '1/11/11/*11/1111',
       licenceHolder: 'Big Farm Ltd',
-      issues: [],
+      issues: '',
       status: 'ready'
     },
     // Licence with a single issue
@@ -82,7 +96,7 @@ function _testLicences () {
       licenceId: '395bdc01-605b-44f5-9d90-5836cc013799',
       licenceRef: '2/22/22/*S2/2222',
       licenceHolder: 'Bob Bobbles',
-      issues: ['Abstraction outside period'],
+      issues: 'Abstraction outside period',
       status: 'ready'
     },
     // Licence with multiple issues
@@ -90,11 +104,7 @@ function _testLicences () {
       licenceId: 'fdae33da-9195-4b97-976a-9791bc4f6b66',
       licenceRef: '3/33/33/*3/3333',
       licenceHolder: 'Farmer Palmer',
-      issues: [
-        'Abstraction outside period',
-        'Over abstraction',
-        'Overlap of charge dates'
-      ],
+      issues: 'Abstraction outside period, Over abstraction, Overlap of charge dates',
       status: 'review'
     }
   ]

--- a/test/presenters/bill-runs/two-part-tariff/review-bill-run.presenter.test.js
+++ b/test/presenters/bill-runs/two-part-tariff/review-bill-run.presenter.test.js
@@ -25,7 +25,7 @@ describe('Review Bill Run presenter', () => {
         financialYear: '2022 to 2023',
         billRunType: 'two-part tariff',
         numberOfLicencesDisplayed: 3,
-        licencesToReviewCount: 1,
+        numberOfLicencesToReview: 1,
         totalNumberOfLicences: 3,
         preparedLicences: [
           {

--- a/test/services/bill-runs/two-part-tariff/fetch-bill-run-licences.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/fetch-bill-run-licences.service.test.js
@@ -32,10 +32,18 @@ describe('Fetch Bill Run Licences service', () => {
 
     describe('and there are licences in the bill run', () => {
       let testLicenceReady
+      let testLicenceReview
 
       beforeEach(async () => {
-        testLicenceReady = await ReviewLicenceHelper.add({ billRunId: billRun.id })
-        await ReviewLicenceHelper.add({ billRunId: billRun.id, status: 'review' })
+        testLicenceReady = await ReviewLicenceHelper.add({
+          billRunId: billRun.id,
+          licenceHolder: 'Ready Licence Holder Ltd'
+        })
+        testLicenceReview = await ReviewLicenceHelper.add({
+          billRunId: billRun.id,
+          licenceHolder: 'Review Licence Holder Ltd',
+          status: 'review'
+        })
       })
 
       it('returns details of the bill run and the licences in it', async () => {
@@ -47,11 +55,17 @@ describe('Fetch Bill Run Licences service', () => {
         expect(result.billRun.toFinancialYearEnding).to.equal(billRun.toFinancialYearEnding)
         expect(result.billRun.batchType).to.equal(billRun.batchType)
         expect(result.billRun.region.displayName).to.equal(region.displayName)
+        expect(result.billRun.reviewLicences[0].totalNumberOfLicences).to.equal(2)
 
         expect(result.licences).to.have.length(2)
+        expect(result.licences[0].licenceId).to.equal(testLicenceReview.licenceId)
+        expect(result.licences[0].licenceHolder).to.equal('Review Licence Holder Ltd')
+        expect(result.licences[0].licenceRef).to.equal(testLicenceReview.licenceRef)
         expect(result.licences[1].licenceId).to.equal(testLicenceReady.licenceId)
-        expect(result.licences[1].licenceHolder).to.equal('Licence Holder Ltd')
+        expect(result.licences[1].licenceHolder).to.equal('Ready Licence Holder Ltd')
         expect(result.licences[1].licenceRef).to.equal(testLicenceReady.licenceRef)
+
+        expect(result.filterLicenceHolder).to.be.undefined()
       })
 
       it("orders the licence by 'review status'", async () => {
@@ -59,6 +73,39 @@ describe('Fetch Bill Run Licences service', () => {
 
         expect(result.licences[0].status).to.equal('review')
         expect(result.licences[1].status).to.equal('ready')
+      })
+
+      describe('and a filter has been applied to the licence holder', () => {
+        let payload
+
+        beforeEach(async () => {
+          payload = { filterLicenceHolder: 'ready licence' }
+        })
+
+        it('returns details of the bill run and the licences in it', async () => {
+          const result = await FetchBillRunLicencesService.go(billRun.id, payload)
+
+          expect(result.billRun.id).to.equal(billRun.id)
+          expect(result.billRun.createdAt).to.equal(billRun.createdAt)
+          expect(result.billRun.status).to.equal(billRun.status)
+          expect(result.billRun.toFinancialYearEnding).to.equal(billRun.toFinancialYearEnding)
+          expect(result.billRun.batchType).to.equal(billRun.batchType)
+          expect(result.billRun.region.displayName).to.equal(region.displayName)
+          expect(result.billRun.reviewLicences[0].totalNumberOfLicences).to.equal(2)
+
+          expect(result.licences).to.have.length(1)
+          expect(result.licences[0].licenceId).to.equal(testLicenceReady.licenceId)
+          expect(result.licences[0].licenceHolder).to.equal('Ready Licence Holder Ltd')
+          expect(result.licences[0].licenceRef).to.equal(testLicenceReady.licenceRef)
+
+          expect(result.filterLicenceHolder).to.equal('ready licence')
+        })
+
+        it("orders the licence by 'review status'", async () => {
+          const result = await FetchBillRunLicencesService.go(billRun.id, payload)
+
+          expect(result.licences[0].status).to.equal('ready')
+        })
       })
     })
   })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4190

Add the functionality to be able to filter on the two-part tariff review screen by licence holder name.