### PR TITLE
Add creating the bill run to end of setup journey

### DIFF
--- a/app/controllers/bill-runs-setup.controller.js
+++ b/app/controllers/bill-runs-setup.controller.js
@@ -5,6 +5,9 @@
  * @module BillRunsSetupController
  */
 
+const Boom = require('@hapi/boom')
+
+const CreateService = require('../services/bill-runs/setup/create.service.js')
 const ExistsService = require('../services/bill-runs/setup/exists.service.js')
 const InitiateSessionService = require('../services/bill-runs/setup/initiate-session.service.js')
 const RegionService = require('../services/bill-runs/setup/region.service.js')
@@ -31,7 +34,14 @@ async function create (request, h) {
     })
   }
 
-  return h.redirect('/billing/batch/list')
+  // If we get here then we are go for launch!
+  try {
+    await CreateService.go(request.auth.credentials.user, results)
+
+    return h.redirect('/billing/batch/list')
+  } catch (error) {
+    return Boom.badImplementation(error.message)
+  }
 }
 
 async function region (request, h) {

--- a/app/services/bill-runs/setup/create.service.js
+++ b/app/services/bill-runs/setup/create.service.js
@@ -1,0 +1,79 @@
+'use strict'
+
+/**
+ * Used to create the new bill run at the end of the setup bill run journey
+ * @module CreateService
+ */
+
+const LegacyCreateBillRunRequest = require('../../../requests/legacy/create-bill-run.request.js')
+const StartBillRunProcessService = require('../start-bill-run-process.service.js')
+
+/**
+ * Used to create the new bill run at the end of the setup bill run journey
+ *
+ * The service needs to determine if it is triggering a bill run in this app, the legacy app or both. The service
+ * is intended to work in tandem with the `ExistsService`. It assumes that service has been called in order to block
+ * calls to this one for bill runs that the two engines will reject because they already exist.
+ *
+ * Once the bill runs have been triggered it finishes by deleting the setup session. Control is handed back to the
+ * controller whilst the engines create and being building the bill runs.
+ *
+ * @param {Object} user - Instance of `UserModel` that represents the user making the request
+ * @param {Object} existsResults - Results of `ExistsService` returned in the controller and passed on to this service
+ *
+ * @returns {Promise} A promise is returned but it does not resolve to anything we expect the caller to use
+ */
+async function go (user, existsResults) {
+  const { matchResults, session, yearToUse } = existsResults
+  const { region: regionId, type, summer } = session.data
+
+  const existingBillRun = matchResults[0]
+
+  await _triggerBillRun(regionId, type, user, yearToUse, existingBillRun)
+  await _triggerLegacyBillRun(regionId, type, user, yearToUse, summer, existingBillRun)
+
+  return session.$query().delete()
+}
+
+async function _triggerBillRun (regionId, batchType, user, year, existingBillRun = null) {
+  const { username: userEmail } = user
+
+  // The one case we have to handle is where the user selected supplementary and a match was found, but it was to an
+  // SROC supplementary bill run. We've got to this point in the process because it is fine to trigger the PRESROC
+  // bill run in the legacy engine. But we can't trigger the SROC one because a match already exists.
+  if (batchType === 'supplementary' && existingBillRun?.scheme === 'sroc') {
+    return null
+  }
+
+  // We do not bother to send requests for PRESROC 2PT bill runs to our engine
+  if (batchType === 'two_part_tariff' && ['2021', '2022'].includes(year)) {
+    return null
+  }
+
+  return StartBillRunProcessService.go(regionId, batchType, userEmail, year)
+}
+
+async function _triggerLegacyBillRun (regionId, batchType, user, year, summer, existingBillRun = null) {
+  // The legacy service no longer handles annual billing
+  if (batchType === 'annual') {
+    return null
+  }
+
+  // The one case we have to handle is where the user selected supplementary and a match was found, but it was to a
+  // PRESROC supplementary bill run. We've got to this point in the process because it is fine to trigger the SROC
+  // bill run in our engine. But we can't trigger the PRESROC one because a match already exists.
+  if (batchType === 'supplementary' && existingBillRun?.scheme === 'alcs') {
+    return null
+  }
+
+  // We do not bother to send requests for SROC 2PT bill runs to the legacy service
+  if (batchType === 'two_part_tariff' && ['2024', '2023'].includes(year)) {
+    return null
+  }
+
+  return LegacyCreateBillRunRequest.go(batchType, regionId, year, user, summer)
+}
+
+module.exports = {
+  go
+}

--- a/app/services/bill-runs/setup/create.service.js
+++ b/app/services/bill-runs/setup/create.service.js
@@ -46,7 +46,7 @@ async function _triggerBillRun (regionId, batchType, user, year, existingBillRun
   }
 
   // We do not bother to send requests for PRESROC 2PT bill runs to our engine
-  if (batchType === 'two_part_tariff' && ['2021', '2022'].includes(year)) {
+  if (batchType === 'two_part_tariff' && [2021, 2022].includes(year)) {
     return null
   }
 
@@ -67,11 +67,11 @@ async function _triggerLegacyBillRun (regionId, batchType, user, year, summer, e
   }
 
   // We do not bother to send requests for SROC 2PT bill runs to the legacy service
-  if (batchType === 'two_part_tariff' && ['2024', '2023'].includes(year)) {
+  if (batchType === 'two_part_tariff' && [2024, 2023].includes(year)) {
     return null
   }
 
-  return LegacyCreateBillRunRequest.go(batchType, regionId, year, user, summer)
+  return LegacyCreateBillRunRequest.send(batchType, regionId, year, user, summer)
 }
 
 module.exports = {

--- a/app/services/bill-runs/setup/exists.service.js
+++ b/app/services/bill-runs/setup/exists.service.js
@@ -55,7 +55,7 @@ function _determineYear (session) {
   const { type, year } = session.data
 
   if (year && type.startsWith('two_part')) {
-    return year
+    return Number(year)
   }
 
   const { endDate } = determineCurrentFinancialYear()

--- a/test/controllers/bill-runs-setup.controller.test.js
+++ b/test/controllers/bill-runs-setup.controller.test.js
@@ -9,6 +9,7 @@ const { describe, it, beforeEach, afterEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Things we need to stub
+const CreateService = require('../../app/services/bill-runs/setup/create.service.js')
 const ExistsService = require('../../app/services/bill-runs/setup/exists.service.js')
 const InitiateSessionService = require('../../app/services/bill-runs/setup/initiate-session.service.js')
 const RegionService = require('../../app/services/bill-runs/setup/region.service.js')
@@ -101,6 +102,7 @@ describe('Bill Runs Setup controller', () => {
               session: { id: 'e009b394-8405-4358-86af-1a9eb31298a5' },
               yearToUse: 2024
             })
+            Sinon.stub(CreateService, 'go').resolves()
           })
 
           it('redirects to the bill runs page', async () => {

--- a/test/services/bill-runs/setup/create.service.test.js
+++ b/test/services/bill-runs/setup/create.service.test.js
@@ -1,0 +1,168 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { describe, it, beforeEach, afterEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const DatabaseSupport = require('../../../support/database.js')
+const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModel = require('../../../../app/models/session.model.js')
+
+// Things we need to stub
+const LegacyCreateBillRunRequest = require('../../../../app/requests/legacy/create-bill-run.request.js')
+const StartBillRunProcessService = require('../../../../app/services/bill-runs/start-bill-run-process.service.js')
+
+// Thing under test
+const CreateService = require('../../../../app/services/bill-runs/setup/create.service.js')
+
+describe('Bill Runs Setup Create service', () => {
+  const user = { useremail: 'carol.shaw@atari.com' }
+
+  let existsResults
+  let legacyCreateBillRunRequestStub
+  let session
+  let startBillRunProcessServiceStub
+
+  beforeEach(async () => {
+    await DatabaseSupport.clean()
+
+    legacyCreateBillRunRequestStub = Sinon.stub(LegacyCreateBillRunRequest, 'send')
+    startBillRunProcessServiceStub = Sinon.stub(StartBillRunProcessService, 'go')
+  })
+
+  afterEach(() => {
+    Sinon.restore()
+  })
+
+  describe('when called and the bill runs have been triggered', () => {
+    beforeEach(async () => {
+      session = await SessionHelper.add({
+        data: { region: '19a027c6-4aad-47d3-80e3-3917a4579a5b', type: 'annual' }
+      })
+
+      existsResults = { matchResults: [], session, yearToUse: 2024 }
+    })
+
+    it('deletes the setup session', async () => {
+      await CreateService.go(user, existsResults)
+
+      const findSessionResults = await SessionModel.query().where('id', session.id)
+
+      expect(findSessionResults).to.be.empty()
+    })
+  })
+
+  describe('when the user wishes to create an annual bill run', () => {
+    beforeEach(async () => {
+      session = await SessionHelper.add({
+        data: { region: '19a027c6-4aad-47d3-80e3-3917a4579a5b', type: 'annual' }
+      })
+
+      existsResults = { matchResults: [], session, yearToUse: 2024 }
+    })
+
+    it('only triggers our bill run process', async () => {
+      await CreateService.go(user, existsResults)
+
+      expect(legacyCreateBillRunRequestStub.called).to.be.false()
+      expect(startBillRunProcessServiceStub.called).to.be.true()
+    })
+  })
+
+  describe('when the user wishes to create a supplementary bill run', () => {
+    beforeEach(async () => {
+      session = await SessionHelper.add({
+        data: { region: '19a027c6-4aad-47d3-80e3-3917a4579a5b', type: 'supplementary' }
+      })
+    })
+
+    describe('and there were no matching bill runs', () => {
+      beforeEach(async () => {
+        existsResults = { matchResults: [], session, yearToUse: 2024 }
+      })
+
+      it('triggers both our and the legacy bill run processes', async () => {
+        await CreateService.go(user, existsResults)
+
+        expect(legacyCreateBillRunRequestStub.called).to.be.true()
+        expect(startBillRunProcessServiceStub.called).to.be.true()
+      })
+    })
+
+    describe('and there is a matching PRESROC bill run', () => {
+      beforeEach(async () => {
+        existsResults = { matchResults: [{ scheme: 'alcs' }], session, yearToUse: 2024 }
+      })
+
+      it('only triggers our bill run process', async () => {
+        await CreateService.go(user, existsResults)
+
+        expect(legacyCreateBillRunRequestStub.called).to.be.false()
+        expect(startBillRunProcessServiceStub.called).to.be.true()
+      })
+    })
+
+    describe('and there is a matching SROC bill run', () => {
+      beforeEach(async () => {
+        existsResults = { matchResults: [{ scheme: 'sroc' }], session, yearToUse: 2024 }
+      })
+
+      it('only triggers the legacy bill run process', async () => {
+        await CreateService.go(user, existsResults)
+
+        expect(legacyCreateBillRunRequestStub.called).to.be.true()
+        expect(startBillRunProcessServiceStub.called).to.be.false()
+      })
+    })
+  })
+
+  describe('when the user wishes to create a two-part tariff bill run', () => {
+    describe('in a PRESROC year', () => {
+      beforeEach(async () => {
+        session = await SessionHelper.add({
+          data: {
+            region: '19a027c6-4aad-47d3-80e3-3917a4579a5b',
+            type: 'two_part_tariff',
+            year: 2022,
+            season: 'summer'
+          }
+        })
+
+        existsResults = { matchResults: [], session, yearToUse: 2022 }
+      })
+
+      it('only triggers the legacy bill run process', async () => {
+        await CreateService.go(user, existsResults)
+
+        expect(legacyCreateBillRunRequestStub.called).to.be.true()
+        expect(startBillRunProcessServiceStub.called).to.be.false()
+      })
+    })
+
+    describe('in an SROC year', () => {
+      beforeEach(async () => {
+        session = await SessionHelper.add({
+          data: {
+            region: '19a027c6-4aad-47d3-80e3-3917a4579a5b',
+            type: 'two_part_tariff',
+            year: 2023
+          }
+        })
+
+        existsResults = { matchResults: [], session, yearToUse: 2023 }
+      })
+
+      it('only triggers our bill run process', async () => {
+        await CreateService.go(user, existsResults)
+
+        expect(legacyCreateBillRunRequestStub.called).to.be.false()
+        expect(startBillRunProcessServiceStub.called).to.be.true()
+      })
+    })
+  })
+})

--- a/test/services/bill-runs/setup/exists.service.test.js
+++ b/test/services/bill-runs/setup/exists.service.test.js
@@ -60,7 +60,7 @@ describe('Bill Runs Setup Exists service', () => {
           expect(matchResults).to.be.empty()
           expect(pageData).to.be.null()
           expect(session).to.equal(session)
-          expect(yearToUse).to.equal(session.data.year)
+          expect(yearToUse).to.equal(2022)
         })
       })
 
@@ -87,7 +87,7 @@ describe('Bill Runs Setup Exists service', () => {
           expect(matchResults[0].id).to.equal('dfbbc7ac-b15b-483a-afcf-a7c01ac377d1')
           expect(pageData.billRunId).to.be.equal('dfbbc7ac-b15b-483a-afcf-a7c01ac377d1')
           expect(session).to.equal(session)
-          expect(yearToUse).to.equal(session.data.year)
+          expect(yearToUse).to.equal(2022)
         })
       })
     })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4375

> Part of a series of changes related to replacing the create bill run journey to incorporate changes for two-part tariff

At the end of the bill run setup journey, after checking if [an existing bill run matches the options selected](https://github.com/DEFRA/water-abstraction-system/pull/810) we create the bill run.

This can involve calling one of our bill run services, sending a request to the legacy [water-abstraction-service](https://github/DEFRA/water-abstraction-service), or both. We need to add the service that handles this to complete the migration of the bill run setup journey.