### PR TITLE
Add DELETE support to LegacyRequest

### DIFF
--- a/app/requests/legacy.request.js
+++ b/app/requests/legacy.request.js
@@ -59,6 +59,23 @@ const services = {
 }
 
 /**
+ * Sends a DELETE request to the legacy service for the provided path
+ *
+ * @param {string} serviceName - Name of the legacy service to call (background, crm, external, idm, import, internal,
+ * permits, reporting, returns or water)
+ * @param {string} path - The path to send the request to (do not include the starting /)
+ * @param {string} [userId] - If the legacy endpoint needs to check a user's authorisation their ID to be added as a
+ * header. Defaults to null
+ * @param {boolean} [apiRequest] - Whether the request is to the service's API endpoints (JSON response) or web (HTML
+ * response). Defaults to true
+ *
+ * @returns {Promise<Object>} An object representing the result of the request
+ */
+async function deleteRequest (serviceName, path, userId = null, apiRequest = true) {
+  return _sendRequest(BaseRequest.delete, serviceName, path, userId, apiRequest)
+}
+
+/**
  * Sends a GET request to the legacy service for the provided path
  *
  * @param {string} serviceName - Name of the legacy service to call (background, crm, external, idm, import, internal,
@@ -177,6 +194,7 @@ function _parseResult (result) {
 }
 
 module.exports = {
+  delete: deleteRequest,
   get,
   post
 }

--- a/test/requests/legacy.request.test.js
+++ b/test/requests/legacy.request.test.js
@@ -95,19 +95,19 @@ describe('Legacy Request', () => {
       })
 
       it('returns a `false` success status', async () => {
-        const result = await LegacyRequest.delete('water', testPath)
+        const result = await LegacyRequest.delete('import', testPath)
 
         expect(result.succeeded).to.be.false()
       })
 
       it('returns the error response', async () => {
-        const result = await LegacyRequest.delete('water', testPath)
+        const result = await LegacyRequest.delete('import', testPath)
 
         expect(result.response.body.message).to.equal('Not Found')
       })
 
       it('returns the status code', async () => {
-        const result = await LegacyRequest.delete('water', testPath)
+        const result = await LegacyRequest.delete('import', testPath)
 
         expect(result.response.statusCode).to.equal(404)
       })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4410

> Part of a series of changes to add support for removing a bill licence back into the billing views

We're not ready to implement removing a bill licence from a bill run as it depends on sending requests to the [Charging Module API](https://github.com/DEFRA/sroc-charging-module-api) and running the legacy refresh job to update everything on our side.

But to trigger all that we need to send a DELETE request to [water-abstraction-service](https://github.com/DEFRA/water-abstraction-service). We've yet to add support for that to `LegacyRequest` hence this change.