### PR TITLE
Add Legacy DeleteBillLicenceRequest

### DIFF
--- a/app/requests/legacy/delete-bill-licence.request.js
+++ b/app/requests/legacy/delete-bill-licence.request.js
@@ -1,0 +1,36 @@
+'use strict'
+
+/**
+ * Connects with the water-abstraction-service to delete a bill licence
+ * @module DeleteBillLicenceRequest
+ */
+
+const LegacyRequest = require('../legacy.request.js')
+
+/**
+ * Send a request to the legacy water-abstraction-service to delete a bill licence
+ *
+ * Users can remove a licence from a bill run. This requires sending a request to the charging module, then after it has
+ * regenerated the bill run refreshing the data on our side.
+ *
+ * Currently, this is all handled by the water-abstraction-service and we're not ready to migrate this until we have
+ * migrated the refresh functionality (needed by a number of operations)
+ *
+ * So, as this is handled by the legacy service we need to send the request to it once a user confirms they wish to
+ * remove the licence.
+ *
+ * @param {string} billLicenceId - UUID of the bill licence to be removed
+ * @param {module:UserModel} user - Instance representing the user that originated the request
+ *
+ * @returns {Promise<Object>} The result of the request; whether it succeeded and the response or error returned
+ */
+async function send (billLicenceId, user) {
+  const { id: userId } = user
+  const path = `billing/invoice-licences/${billLicenceId}`
+
+  return LegacyRequest.delete('water', path, userId)
+}
+
+module.exports = {
+  send
+}

--- a/test/requests/legacy/delete-bill-licence.request.test.js
+++ b/test/requests/legacy/delete-bill-licence.request.test.js
@@ -1,0 +1,105 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { describe, it, beforeEach, afterEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Things we need to stub
+const LegacyRequest = require('../../../app/requests/legacy.request.js')
+
+// Thing under test
+const DeleteBillLicenceRequest = require('../../../app/requests/legacy/delete-bill-licence.request.js')
+
+describe('Legacy Delete Bill Licence request', () => {
+  const billLicenceId = '8feaf2c1-f7cd-47f1-93b9-0d2218d20d56'
+  const user = { id: '1c4ce580-9053-4531-ba23-d0cf0caf0562', username: 'carol.shaw@atari.com' }
+
+  afterEach(() => {
+    Sinon.restore()
+  })
+
+  describe('when the request can delete a bill licence', () => {
+    beforeEach(async () => {
+      Sinon.stub(LegacyRequest, 'delete').resolves({
+        succeeded: true,
+        response: {
+          statusCode: 204,
+          body: null
+        }
+      })
+    })
+
+    it('returns a `true` success status', async () => {
+      const result = await DeleteBillLicenceRequest.send(billLicenceId, user)
+
+      expect(result.succeeded).to.be.true()
+    })
+
+    it('returns a 204 - ok', async () => {
+      const result = await DeleteBillLicenceRequest.send(billLicenceId, user)
+
+      expect(result.response.statusCode).to.equal(204)
+      expect(result.response.body).to.be.null()
+    })
+  })
+
+  describe('when the request cannot delete a bill licence', () => {
+    describe('because the request did not return a 2xx/3xx response', () => {
+      beforeEach(async () => {
+        Sinon.stub(LegacyRequest, 'delete').resolves({
+          succeeded: false,
+          response: {
+            statusCode: 401,
+            body: {
+              statusCode: 401,
+              error: 'Unauthorized',
+              message: 'Invalid JWT: Token format not valid',
+              attributes: { error: 'Invalid JWT: Token format not valid' }
+            }
+          }
+        })
+      })
+
+      it('returns a `false` success status', async () => {
+        const result = await DeleteBillLicenceRequest.send(billLicenceId, user)
+
+        expect(result.succeeded).to.be.false()
+      })
+
+      it('returns the error in the `response`', async () => {
+        const result = await DeleteBillLicenceRequest.send(billLicenceId, user)
+
+        expect(result.response.body.statusCode).to.equal(401)
+        expect(result.response.body.error).to.equal('Unauthorized')
+        expect(result.response.body.message).to.equal('Invalid JWT: Token format not valid')
+      })
+    })
+
+    describe('because the request attempt returned an error, for example, TimeoutError', () => {
+      beforeEach(async () => {
+        Sinon.stub(LegacyRequest, 'delete').resolves({
+          succeeded: false,
+          response: new Error("Timeout awaiting 'request' for 5000ms")
+        })
+      })
+
+      it('returns a `false` success status', async () => {
+        const result = await DeleteBillLicenceRequest.send(billLicenceId, user)
+
+        expect(result.succeeded).to.be.false()
+      })
+
+      it('returns the error in the `response`', async () => {
+        const result = await DeleteBillLicenceRequest.send(billLicenceId, user)
+
+        expect(result.response.statusCode).not.to.exist()
+        expect(result.response.body).not.to.exist()
+        expect(result.response.message).to.equal("Timeout awaiting 'request' for 5000ms")
+      })
+    })
+  })
+})


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4410

> Part of a series of changes to add support for removing a bill licence back into the billing views

We're not ready to implement removing a bill licence from a bill run as it depends on sending requests to the [Charging Module API](https://github.com/DEFRA/sroc-charging-module-api) and running the legacy refresh job to update everything on our side.

But to trigger all that we need to send a DELETE request to [water-abstraction-service](https://github.com/DEFRA/water-abstraction-service). This adds the legacy request that will deal with sending that request.