### PR TITLE
Add relationship between bill and billing account

### DIFF
--- a/app/models/bill.model.js
+++ b/app/models/bill.model.js
@@ -16,6 +16,14 @@ class BillModel extends BaseModel {
 
   static get relationMappings () {
     return {
+      billingAccount: {
+        relation: Model.BelongsToOneRelation,
+        modelClass: 'billing-account.model',
+        join: {
+          from: 'bills.billingAccountId',
+          to: 'billingAccounts.id'
+        }
+      },
       billRun: {
         relation: Model.BelongsToOneRelation,
         modelClass: 'bill-run.model',

--- a/app/models/billing-account.model.js
+++ b/app/models/billing-account.model.js
@@ -24,6 +24,14 @@ class BillingAccountModel extends BaseModel {
           to: 'billingAccountAddresses.billingAccountId'
         }
       },
+      bills: {
+        relation: Model.HasManyRelation,
+        modelClass: 'bill.model',
+        join: {
+          from: 'billingAccounts.id',
+          to: 'bills.billingAccountId'
+        }
+      },
       chargeVersions: {
         relation: Model.HasManyRelation,
         modelClass: 'charge-version.model',

--- a/test/models/bill.model.test.js
+++ b/test/models/bill.model.test.js
@@ -8,8 +8,10 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const BillRunModel = require('../../app/models/bill-run.model.js')
 const BillHelper = require('../support/helpers/bill.helper.js')
+const BillingAccountHelper = require('../support/helpers/billing-account.helper.js')
+const BillingAccountModel = require('../../app/models/billing-account.model.js')
+const BillRunModel = require('../../app/models/bill-run.model.js')
 const BillLicenceHelper = require('../support/helpers/bill-licence.helper.js')
 const BillLicenceModel = require('../../app/models/bill-licence.model.js')
 const BillRunHelper = require('../support/helpers/bill-run.helper.js')
@@ -39,6 +41,36 @@ describe('Bill model', () => {
   })
 
   describe('Relationships', () => {
+    describe('when linking to billing account', () => {
+      let testBillingAccount
+
+      beforeEach(async () => {
+        testBillingAccount = await BillingAccountHelper.add()
+
+        const { id: billingAccountId } = testBillingAccount
+        testRecord = await BillHelper.add({ billingAccountId })
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await BillModel.query()
+          .innerJoinRelated('billingAccount')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the billing account', async () => {
+        const result = await BillModel.query()
+          .findById(testRecord.id)
+          .withGraphFetched('billingAccount')
+
+        expect(result).to.be.instanceOf(BillModel)
+        expect(result.id).to.equal(testRecord.id)
+
+        expect(result.billingAccount).to.be.an.instanceOf(BillingAccountModel)
+        expect(result.billingAccount).to.equal(testBillingAccount)
+      })
+    })
+
     describe('when linking to bill run', () => {
       let testBillRun
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4410

> Part of a series of changes to add support for removing a bill licence back into the billing views

We're not ready to implement removing a bill licence from a bill run as it depends on sending requests to the [Charging Module API](https://github.com/DEFRA/sroc-charging-module-api) and running the legacy refresh job to update everything on our side.

But we can migrate the confirmation page a user sees when removing a licence. Before we get there though we need to add a relationship that has always existed but only thanks to us switching to view-based models is available to use.

This updates the `BillModel` and `BillingAccountModel` with relationships that join them We will then be able to extract both bill run, bill and bill licence information in a single [Objection.js query](https://vincit.github.io/objection.js/).