### PR TITLE
Migrate confirm remove licence from bill run page

### DIFF
--- a/app/controllers/bill-licences.controller.js
+++ b/app/controllers/bill-licences.controller.js
@@ -5,7 +5,19 @@
  * @module BillLicencesController
  */
 
+const RemoveBillLicenceService = require('../services/bill-licences/remove-bill-licence.service.js')
 const ViewBillLicenceService = require('../services/bill-licences/view-bill-licence.service.js')
+
+async function remove (request, h) {
+  const { id } = request.params
+
+  const pageData = await RemoveBillLicenceService.go(id)
+
+  return h.view('bill-licences/remove.njk', {
+    activeNavBar: 'bill-runs',
+    ...pageData
+  })
+}
 
 async function view (request, h) {
   const { id } = request.params
@@ -22,5 +34,6 @@ async function view (request, h) {
 }
 
 module.exports = {
+  remove,
   view
 }

--- a/app/controllers/bill-licences.controller.js
+++ b/app/controllers/bill-licences.controller.js
@@ -5,7 +5,10 @@
  * @module BillLicencesController
  */
 
+const Boom = require('@hapi/boom')
+
 const RemoveBillLicenceService = require('../services/bill-licences/remove-bill-licence.service.js')
+const SubmitRemoveBillLicenceService = require('../services/bill-licences/submit-remove-bill-licence.service.js')
 const ViewBillLicenceService = require('../services/bill-licences/view-bill-licence.service.js')
 
 async function remove (request, h) {
@@ -17,6 +20,18 @@ async function remove (request, h) {
     activeNavBar: 'bill-runs',
     ...pageData
   })
+}
+
+async function submitRemove (request, h) {
+  const { id } = request.params
+
+  try {
+    const redirectPath = await SubmitRemoveBillLicenceService.go(id, request.auth.credentials.user)
+
+    return h.redirect(redirectPath)
+  } catch (error) {
+    return Boom.badImplementation(error.message)
+  }
 }
 
 async function view (request, h) {
@@ -35,5 +50,6 @@ async function view (request, h) {
 
 module.exports = {
   remove,
+  submitRemove,
   view
 }

--- a/app/presenters/bill-licences/remove-bill-licence.presenter.js
+++ b/app/presenters/bill-licences/remove-bill-licence.presenter.js
@@ -1,0 +1,103 @@
+'use strict'
+
+/**
+ * Formats data for the confirm remove a bill licence page
+ * @module RemoveBillLicencePresenter
+ */
+
+const {
+  capitalize,
+  formatBillRunType,
+  formatChargeScheme,
+  formatFinancialYear,
+  formatLongDate,
+  formatMoney
+} = require('../base.presenter.js')
+
+/**
+ * Formats data for the confirm remove a bill licence page
+ *
+ * @param {module:BillLicenceModel} bilLicence - an instance of `BillLicenceModel` with associated billing data
+ *
+ * @returns {Object} - the prepared bill licence summary data to be passed to the confirm remove a bill licence page
+ */
+function go (billLicence) {
+  const { id: billLicenceId, bill, licenceRef, transactions } = billLicence
+
+  const {
+    billRunNumber,
+    billRunStatus,
+    billRunType,
+    chargeScheme,
+    dateCreated,
+    financialYear,
+    region
+  } = _billRunSummary(bill.billRun)
+
+  return {
+    accountName: _accountName(bill.billingAccount),
+    accountNumber: bill.billingAccount.accountNumber,
+    billLicenceId,
+    billRunNumber,
+    billRunStatus,
+    billRunType,
+    chargeScheme,
+    dateCreated,
+    financialYear,
+    licenceRef,
+    pageTitle: _pageTitle(licenceRef),
+    region,
+    transactionsTotal: _total(transactions)
+  }
+}
+
+function _accountName (billingAccount) {
+  const accountAddress = billingAccount.billingAccountAddresses[0]
+
+  if (accountAddress.company) {
+    return accountAddress.company.name
+  }
+
+  return billingAccount.company.name
+}
+
+function _billRunSummary (billRun) {
+  const {
+    batchType,
+    billRunNumber,
+    createdAt,
+    region,
+    scheme,
+    status,
+    summer,
+    toFinancialYearEnding
+  } = billRun
+
+  return {
+    billRunNumber,
+    billRunStatus: status,
+    billRunType: formatBillRunType(batchType, scheme, summer),
+    chargeScheme: formatChargeScheme(scheme),
+    dateCreated: formatLongDate(createdAt),
+    financialYear: formatFinancialYear(toFinancialYearEnding),
+    region: capitalize(region.displayName)
+  }
+}
+
+function _pageTitle (licenceRef) {
+  return `You're about to remove ${licenceRef} from the bill run`
+}
+
+function _total (transactions) {
+  const transactionTotal = transactions.reduce((total, transaction) => {
+    total += transaction.netAmount
+
+    return total
+  }, 0)
+
+  return formatMoney(transactionTotal, true)
+}
+
+module.exports = {
+  go
+}

--- a/app/routes/bill-licences.routes.js
+++ b/app/routes/bill-licences.routes.js
@@ -28,6 +28,19 @@ const routes = [
         }
       }
     }
+  },
+  {
+    method: 'POST',
+    path: '/bill-licences/{id}/remove',
+    options: {
+      handler: BillLicencesController.submitRemove,
+      description: 'Submit confirm licence should be removed from bill run',
+      auth: {
+        access: {
+          scope: ['billing']
+        }
+      }
+    }
   }
 ]
 

--- a/app/routes/bill-licences.routes.js
+++ b/app/routes/bill-licences.routes.js
@@ -15,6 +15,19 @@ const routes = [
         }
       }
     }
+  },
+  {
+    method: 'GET',
+    path: '/bill-licences/{id}/remove',
+    options: {
+      handler: BillLicencesController.remove,
+      description: 'Confirm licence should be removed from bill run page',
+      auth: {
+        access: {
+          scope: ['billing']
+        }
+      }
+    }
   }
 ]
 

--- a/app/services/bill-licences/fetch-bill-licence-summary.service.js
+++ b/app/services/bill-licences/fetch-bill-licence-summary.service.js
@@ -1,0 +1,124 @@
+'use strict'
+
+/**
+ * Fetches data for the remove bill licence page which summarises the bill run and billing details for the licence
+ * @module FetchBillLicenceService
+ */
+
+const BillLicenceModel = require('../../models/bill-licence.model.js')
+
+/**
+ * Fetches data for the remove bill licence page which summarises the bill run and billing details for the licence
+ *
+ * Was built to provide the data needed for the '/bill-licences/{id}/remove' page. We have to display the 'name' for
+ * the billing account on the page. But this gets complex depending on whether there is a current billing account
+ * address record, and if so does it have just a contact, or an agent company link.
+ *
+ * This is why the Objection query, though not complex does involve a number of `withGraphFetched()` calls.
+ *
+ * @param {string} billLicenceId - The UUID for the bill licence to fetch a summary of
+ *
+ * @returns {Promise<Object>} the matching instance of BillLicenceModel plus the linked bill, billing account and bill
+ * run. Also all transactions linked to the bill licence so we can work out the total for the licence
+ */
+async function go (billLicenceId) {
+  return _fetchBillLicence(billLicenceId)
+}
+
+async function _fetchBillLicence (billLicenceId) {
+  const results = await BillLicenceModel.query()
+    .findById(billLicenceId)
+    .select([
+      'id',
+      'licenceId',
+      'licenceRef'
+    ])
+    .withGraphFetched('bill')
+    .modifyGraph('bill', (builder) => {
+      builder.select([
+        'id',
+        'accountNumber'
+      ])
+    })
+    .withGraphFetched('bill.billingAccount')
+    .modifyGraph('bill.billingAccount', (builder) => {
+      builder.select([
+        'id',
+        'accountNumber'
+      ])
+    })
+    .withGraphFetched('bill.billingAccount.company')
+    .modifyGraph('bill.billingAccount.company', (builder) => {
+      builder.select([
+        'id',
+        'name',
+        'type'
+      ])
+    })
+    .withGraphFetched('bill.billingAccount.billingAccountAddresses')
+    // The current billing account address is denoted by the fact it is the only one with a null end date
+    .modifyGraph('bill.billingAccount.billingAccountAddresses', (builder) => {
+      builder
+        .select([
+          'id'
+        ])
+        .whereNull('endDate')
+    })
+    .withGraphFetched('bill.billingAccount.billingAccountAddresses.company')
+    .modifyGraph('bill.billingAccount.billingAccountAddresses.company', (builder) => {
+      builder.select([
+        'id',
+        'name',
+        'type'
+      ])
+    })
+    .withGraphFetched('bill.billingAccount.billingAccountAddresses.contact')
+    .modifyGraph('bill.billingAccount.billingAccountAddresses.contact', (builder) => {
+      builder.select([
+        'id',
+        'contactType',
+        'dataSource',
+        'department',
+        'firstName',
+        'initials',
+        'lastName',
+        'middleInitials',
+        'salutation',
+        'suffix'
+      ])
+    })
+    .withGraphFetched('bill.billRun')
+    .modifyGraph('bill.billRun', (builder) => {
+      builder.select([
+        'id',
+        'batchType',
+        'billRunNumber',
+        'createdAt',
+        'scheme',
+        'source',
+        'status',
+        'toFinancialYearEnding'
+      ])
+    })
+    .withGraphFetched('bill.billRun.region')
+    .modifyGraph('bill.billRun.region', (builder) => {
+      builder.select([
+        'id',
+        'displayName'
+      ])
+    })
+    .withGraphFetched('transactions')
+    .modifyGraph('transactions', (builder) => {
+      builder.select([
+        'id',
+        'credit',
+        'netAmount'
+      ])
+    })
+
+  return results
+}
+
+module.exports = {
+  go
+}

--- a/app/services/bill-licences/remove-bill-licence.service.js
+++ b/app/services/bill-licences/remove-bill-licence.service.js
@@ -1,0 +1,27 @@
+'use strict'
+
+/**
+ * Orchestrates fetching and presenting the data needed for the remove bill licence page
+ * @module RemoveBillLicenceService
+ */
+
+const FetchBillLicenceSummaryService = require('./fetch-bill-licence-summary.service.js')
+const RemoveBillLicencePresenter = require('../../presenters/bill-licences/remove-bill-licence.presenter.js')
+
+/**
+ * Orchestrates fetching and presenting the data needed for the remove bill licence page
+ *
+ * @param {string} billLicenceId - The UUID for the bill licence to remove
+ *
+ * @returns {Promise<Object>} a formatted representation of the bill licence, its bill, billing account and the bill run
+ * it is linked to for the remove bill licence page
+ */
+async function go (billLicenceId) {
+  const billLicence = await FetchBillLicenceSummaryService.go(billLicenceId)
+
+  return RemoveBillLicencePresenter.go(billLicence)
+}
+
+module.exports = {
+  go
+}

--- a/app/services/bill-licences/submit-remove-bill-licence.service.js
+++ b/app/services/bill-licences/submit-remove-bill-licence.service.js
@@ -1,0 +1,44 @@
+'use strict'
+
+/**
+ * Orchestrates the removing of a bill licence from a bill run
+ * @module SubmitRemoveBillLicenceService
+ */
+
+const BillLicenceModel = require('../../models/bill-licence.model.js')
+const LegacyDeleteBillLicenceRequest = require('../../requests/legacy/delete-bill-licence.request.js')
+
+/**
+ * Orchestrates the removing of a bill licence from a bill run
+ *
+ * @param {string} billLicenceId - UUID of the bill licence to be removed
+ * @param {Object} user - Instance of `UserModel` that represents the user making the request
+ *
+ * @returns {Promise<string>} Returns the redirect path the controller needs
+ */
+async function go (billLicenceId, user) {
+  const { bill } = await _fetchBillLicence(billLicenceId)
+
+  await LegacyDeleteBillLicenceRequest.send(billLicenceId, user)
+
+  return `/billing/batch/${bill.billRunId}/processing?invoiceId=${bill.id}`
+}
+
+async function _fetchBillLicence (billLicenceId) {
+  return BillLicenceModel.query()
+    .findById(billLicenceId)
+    .select([
+      'id'
+    ])
+    .withGraphFetched('bill')
+    .modifyGraph('bill', (builder) => {
+      builder.select([
+        'id',
+        'billRunId'
+      ])
+    })
+}
+
+module.exports = {
+  go
+}

--- a/app/views/bill-licences/remove.njk
+++ b/app/views/bill-licences/remove.njk
@@ -1,0 +1,106 @@
+{% extends 'layout.njk' %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+
+{% from "macros/badge.njk" import statusBadge %}
+
+{% block breadcrumbs %}
+  {# Back link #}
+  {{
+    govukBackLink({
+      text: 'Go back to transactions for ' + licenceRef,
+      href: '/system/bill-licences/' + billLicenceId
+    })
+  }}
+{% endblock %}
+
+{% block content %}
+  {# Main heading #}
+  <div class="govuk-body">
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">
+      <span class="govuk-caption-l">Bill run {{ billRunNumber }}</span>{{ pageTitle }}
+    </h1>
+
+    {{ govukInsetText({
+      text: 'The licence will go into the next supplementary bill run.'
+    }) }}
+  </div>
+
+  <div class="govuk-grid-row govuk-!-margin-bottom-0">
+    <div class="govuk-grid-column-full">
+
+      {# Status badge #}
+      <p class="govuk-body">
+        {{ statusBadge(billRunStatus) }}
+      </p>
+
+      {# Bill run meta-data #}
+      {#
+        GOV.UK summary lists only allow us to assign attributes at the top level and not to each row. This means we
+        can't assign our data-test attribute using the component. Our solution is to use the html option for each row
+        instead of text and wrap each value in a <span>. That way we can manually assign our data-test attribute to the
+        span.
+      #}
+      {{
+        govukSummaryList({
+          classes: 'govuk-summary-list--no-border',
+          attributes: {
+            'data-test': 'bill-run-meta-data'
+          },
+          rows: [
+            {
+              key: { text: "Date created", classes: "meta-data__label" },
+              value: { html: '<span data-test="meta-data-created">' + dateCreated + '</span>', classes: "meta-data__value" }
+            },
+            {
+              key: { text: "Region", classes: "meta-data__label" },
+              value: { html: '<span data-test="meta-data-region">' + region + '</span>', classes: "meta-data__value" }
+            },
+            {
+              key: { text: "Bill run type", classes: "meta-data__label" },
+              value: { html: '<span data-test="meta-data-type">' + billRunType + '</span>', classes: "meta-data__value" }
+            },
+            {
+              key: { text: "Charge scheme", classes: "meta-data__label" },
+              value: { html: '<span data-test="meta-data-scheme">' + chargeScheme + '</span>', classes: "meta-data__value" }
+            },
+            {
+              key: { text: "Financial year", classes: "meta-data__label" },
+              value: { html: '<span data-test="meta-data-year">' + financialYear + '</span>', classes: "meta-data__value" }
+            }
+          ]
+        })
+      }}
+
+      {{
+        govukSummaryList({
+          classes: 'govuk-summary-list--no-border',
+          attributes: {
+            'data-test': 'bill-licence-meta-data'
+          },
+          rows: [
+            {
+              key: { text: "Billing account", classes: "meta-data__label" },
+              value: { html: '<span data-test="bill-licence-meta-data-billing-account">' + accountNumber + '</span>', classes: "meta-data__value" }
+            },
+            {
+              key: { text: "Bill for", classes: "meta-data__label" },
+              value: { html: '<span data-test="bill-licence-meta-data-bill-for">' + accountName + '</span>', classes: "meta-data__value" }
+            },
+            {
+              key: { text: "Total", classes: "meta-data__label" },
+              value: { html: '<span data-test="bill-licence-meta-data-total">' + transactionsTotal + '</span>', classes: "meta-data__value" }
+            }
+          ]
+        })
+      }}
+
+      <form method="post">
+        {{ govukButton({ text: "Remove this licence" }) }}
+      </form>
+    </div>
+  </div>
+{% endblock %}

--- a/test/controllers/bill-licences.controller.test.js
+++ b/test/controllers/bill-licences.controller.test.js
@@ -10,6 +10,7 @@ const { expect } = Code
 
 // Things we need to stub
 const RemoveBillLicenceService = require('../../app/services/bill-licences/remove-bill-licence.service.js')
+const SubmitRemoveBillLicenceService = require('../../app/services/bill-licences/submit-remove-bill-licence.service.js')
 const ViewBillLicenceService = require('../../app/services/bill-licences/view-bill-licence.service.js')
 
 // For running our service
@@ -94,6 +95,25 @@ describe('Bill Licences controller', () => {
           expect(response.statusCode).to.equal(200)
           expect(response.payload).to.contain('about to remove AT/SROC/SUPB/02 from the bill run')
         })
+      })
+    })
+
+    describe('POST', () => {
+      beforeEach(() => {
+        options = _options('POST', 'remove')
+
+        Sinon.stub(SubmitRemoveBillLicenceService, 'go').resolves(
+          '/billing/batch/c04ea618-d1ad-494b-bdc4-1bfa670876d0/processing?invoiceId=9a87e3ee-038e-4e58-99f2-1081292a7710'
+        )
+      })
+
+      it('redirects to the legacy processing bill run page', async () => {
+        const response = await server.inject(options)
+
+        expect(response.statusCode).to.equal(302)
+        expect(response.headers.location).to.equal(
+          '/billing/batch/c04ea618-d1ad-494b-bdc4-1bfa670876d0/processing?invoiceId=9a87e3ee-038e-4e58-99f2-1081292a7710'
+        )
       })
     })
   })

--- a/test/presenters/bill-licences/remove-bill-licence.presenter.test.js
+++ b/test/presenters/bill-licences/remove-bill-licence.presenter.test.js
@@ -1,0 +1,153 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { describe, it, beforeEach, afterEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Thing under test
+const RemoveBillLicencePresenter = require('../../../app/presenters/bill-licences/remove-bill-licence.presenter.js')
+
+describe('Remove Bill Licence presenter', () => {
+  let billLicence
+
+  afterEach(() => {
+    Sinon.restore()
+  })
+
+  describe('when provided with a populated bill licence', () => {
+    beforeEach(() => {
+      billLicence = _billLicenceSummary()
+    })
+
+    it('correctly presents the data', () => {
+      const result = RemoveBillLicencePresenter.go(billLicence)
+
+      expect(result).to.equal({
+        accountName: 'Example Trading Ltd',
+        accountNumber: 'T65757520A',
+        billLicenceId: billLicence.id,
+        billRunNumber: 10010,
+        billRunStatus: 'ready',
+        billRunType: 'Supplementary',
+        chargeScheme: 'Current',
+        dateCreated: '1 November 2023',
+        financialYear: '2023 to 2024',
+        licenceRef: 'WA/055/0017/013',
+        pageTitle: "You're about to remove WA/055/0017/013 from the bill run",
+        region: 'Stormlands',
+        transactionsTotal: '£288.37'
+      })
+    })
+
+    describe("the 'accountName' property", () => {
+      describe('when the billing account is not linked to an agent', () => {
+        it('returns the name of the company linked to the billing account', () => {
+          const result = RemoveBillLicencePresenter.go(billLicence)
+
+          expect(result.accountName).to.equal('Example Trading Ltd')
+        })
+      })
+
+      describe('when the billing account is linked to an agent', () => {
+        beforeEach(() => {
+          billLicence.bill.billingAccount.billingAccountAddresses[0].company = {
+            companyId: 'b0d35412-f76c-44ca-9d63-c6350337e03d',
+            type: 'person',
+            name: 'Alan Broke'
+          }
+        })
+
+        it('returns the name of the agent company', () => {
+          const result = RemoveBillLicencePresenter.go(billLicence)
+
+          expect(result.accountName).to.equal('Alan Broke')
+        })
+      })
+    })
+
+    describe("the 'pageTitle' property", () => {
+      it('returns the licence reference as part of the title', () => {
+        const result = RemoveBillLicencePresenter.go(billLicence)
+
+        expect(result.pageTitle).to.equal("You're about to remove WA/055/0017/013 from the bill run")
+      })
+    })
+  })
+})
+
+function _billLicenceSummary () {
+  return {
+    id: 'a4fbaa27-a91c-4328-a1b8-774ade11027b',
+    licenceId: '2eaa831d-7bd6-4b0a-aaf1-3aacafec6bf2',
+    licenceRef: 'WA/055/0017/013',
+    bill: {
+      id: '5a5b313b-e707-490a-a693-799339941e4f',
+      accountNumber: 'T65757520A',
+      billingAccount: {
+        id: 'e2b35a4a-7368-425f-9990-faa23efc0a25',
+        accountNumber: 'T65757520A',
+        company: {
+          id: '3b60ddd0-654f-4012-a349-000aab3e49c3',
+          name: 'Example Trading Ltd',
+          type: 'organisation'
+        },
+        billingAccountAddresses: [{
+          id: '1d440029-745a-47ec-a43e-9f4a36014126',
+          company: null,
+          contact: {
+            id: '95ba53be-543f-415b-90b1-08f58f63ff74',
+            contactType: 'person',
+            dataSource: 'wrls',
+            department: null,
+            firstName: 'Amara',
+            initials: null,
+            lastName: 'Gupta',
+            middleInitials: null,
+            salutation: null,
+            suffix: null
+          }
+        }]
+      },
+      billRun: {
+        id: '0e61c36f-f22f-4534-8247-b73a97f551b5',
+        batchType: 'supplementary',
+        billRunNumber: 10010,
+        createdAt: new Date('2023-11-01'),
+        scheme: 'sroc',
+        source: 'wrls',
+        status: 'ready',
+        toFinancialYearEnding: 2024,
+        region: {
+          id: '4ad8ce03-48a8-447e-bce2-3c317d0aeaf6',
+          displayName: 'Stormlands'
+        }
+      }
+    },
+    transactions: [
+      {
+        id: '5858e36f-5a8e-4f5c-84b3-cbca26624d67',
+        credit: false,
+        netAmount: 29837
+      },
+      {
+        id: '5858e36f-5a8e-4f5c-84b3-cbca26624d67',
+        credit: true,
+        netAmount: -1000
+      },
+      {
+        id: '14d6d530-7f07-4e4b-ac17-b8ade9f5b21a',
+        credit: false,
+        netAmount: 0
+      },
+      {
+        id: '23f43d51-8880-4e30-89da-40231cb8dea2',
+        credit: false,
+        netAmount: 0
+      }
+    ]
+  }
+}

--- a/test/services/bill-licences/fetch-bill-licence-summary.service.test.js
+++ b/test/services/bill-licences/fetch-bill-licence-summary.service.test.js
@@ -1,0 +1,149 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const BillingAccountHelper = require('../../support/helpers/billing-account.helper.js')
+const BillingAccountAddressHelper = require('../../support/helpers/billing-account-address.helper.js')
+const BillHelper = require('../../support/helpers/bill.helper.js')
+const BillLicenceHelper = require('../../support/helpers/bill-licence.helper.js')
+const BillRunHelper = require('../../support/helpers/bill-run.helper.js')
+const CompanyHelper = require('../../support/helpers/company.helper.js')
+const ContactHelper = require('../../support/helpers/contact.helper.js')
+const DatabaseSupport = require('../../support/database.js')
+const RegionHelper = require('../../support/helpers/region.helper.js')
+const TransactionHelper = require('../../support/helpers/transaction.helper.js')
+
+// Thing under test
+const FetchBillLicenceSummaryService = require('../../../app/services/bill-licences/fetch-bill-licence-summary.service.js')
+
+describe('Fetch Bill Licence Summary service', () => {
+  let agentCompanyId
+  let billId
+  let billingAccountId
+  let billingAccountAddressId
+  let billLicence
+  let billRunId
+  let companyId
+  let contactId
+  let regionId
+  let transactionId
+
+  beforeEach(async () => {
+    await DatabaseSupport.clean()
+
+    const company = await CompanyHelper.add()
+    companyId = company.id
+
+    const billingAccount = await BillingAccountHelper.add({ accountNumber: 'T65757520A', companyId })
+    billingAccountId = billingAccount.id
+
+    const agentCompany = await CompanyHelper.add({ name: 'Agent Company Ltd' })
+    agentCompanyId = agentCompany.id
+
+    const contact = await ContactHelper.add()
+    contactId = contact.id
+
+    const billingAccountAddress = await BillingAccountAddressHelper.add({
+      billingAccountId, companyId: agentCompanyId, contactId, endDate: null
+    })
+    billingAccountAddressId = billingAccountAddress.id
+
+    const region = await RegionHelper.add({ displayName: 'Stormlands' })
+    regionId = region.id
+
+    const billRun = await BillRunHelper.add({
+      billRunNumber: 1075, createdAt: new Date('2023-05-01'), status: 'ready', regionId
+    })
+    billRunId = billRun.id
+
+    const bill = await BillHelper.add({ accountNumber: 'T65757520A', billingAccountId, billRunId })
+    billId = bill.id
+
+    billLicence = await BillLicenceHelper.add({ billId, licenceRef: '01/86/26/9400' })
+
+    const transaction = await TransactionHelper.add({ billLicenceId: billLicence.id, netAmount: 1000.10 })
+    transactionId = transaction.id
+  })
+
+  describe('when a bill licence with a matching ID exists', () => {
+    it('will fetch the data use in the remove bill licence page', async () => {
+      const result = await FetchBillLicenceSummaryService.go(billLicence.id)
+
+      // // NOTE: Transactions would not ordinarily be empty. But the format of the transactions will differ depending on
+      // // scheme so we get into that in later tests.
+      expect(result).to.equal({
+        id: billLicence.id,
+        licenceId: billLicence.licenceId,
+        licenceRef: '01/86/26/9400',
+        bill: {
+          id: billId,
+          accountNumber: 'T65757520A',
+          billingAccount: {
+            id: billingAccountId,
+            accountNumber: 'T65757520A',
+            company: {
+              id: companyId,
+              name: 'Example Trading Ltd',
+              type: 'organisation'
+            },
+            billingAccountAddresses: [{
+              id: billingAccountAddressId,
+              company: {
+                id: agentCompanyId,
+                name: 'Agent Company Ltd',
+                type: 'organisation'
+              },
+              contact: {
+                id: contactId,
+                contactType: 'person',
+                dataSource: 'wrls',
+                department: null,
+                firstName: 'Amara',
+                initials: null,
+                lastName: 'Gupta',
+                middleInitials: null,
+                salutation: null,
+                suffix: null
+              }
+            }]
+          },
+          billRun: {
+            id: billRunId,
+            batchType: 'supplementary',
+            billRunNumber: 1075,
+            createdAt: new Date('2023-05-01'),
+            scheme: 'sroc',
+            source: 'wrls',
+            status: 'ready',
+            toFinancialYearEnding: 2023,
+            region: {
+              id: regionId,
+              displayName: 'Stormlands'
+            }
+          }
+        },
+        transactions: [
+          {
+            id: transactionId,
+            credit: false,
+            netAmount: 1000.10
+          }
+        ]
+      })
+    })
+  })
+
+  describe('when a bill licence with a matching ID does not exist', () => {
+    it('returns no result', async () => {
+      const result = await FetchBillLicenceSummaryService.go('93112100-152b-4860-abea-2adee11dcd69')
+
+      expect(result).to.be.undefined()
+    })
+  })
+})

--- a/test/services/bill-licences/remove-bill-licence.service.test.js
+++ b/test/services/bill-licences/remove-bill-licence.service.test.js
@@ -1,0 +1,122 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { describe, it, beforeEach, afterEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Things we need to stub
+const FetchBillLicenceSummaryService = require('../../../app/services/bill-licences/fetch-bill-licence-summary.service.js')
+
+// Thing under test
+const RemoveBillLicenceService = require('../../../app/services/bill-licences/remove-bill-licence.service.js')
+
+describe('Remove Bill Licence service', () => {
+  const testId = 'a4fbaa27-a91c-4328-a1b8-774ade11027b'
+
+  beforeEach(() => {
+    Sinon.stub(FetchBillLicenceSummaryService, 'go').resolves(_billLicenceSummary())
+  })
+
+  afterEach(() => {
+    Sinon.restore()
+  })
+
+  describe('when called', () => {
+    it('returns page data for the view', async () => {
+      const result = await RemoveBillLicenceService.go(testId)
+
+      expect(result).to.equal({
+        accountName: 'Example Trading Ltd',
+        accountNumber: 'T65757520A',
+        billLicenceId: testId,
+        billRunNumber: 10010,
+        billRunStatus: 'ready',
+        billRunType: 'Supplementary',
+        chargeScheme: 'Current',
+        dateCreated: '1 November 2023',
+        financialYear: '2023 to 2024',
+        licenceRef: 'WA/055/0017/013',
+        pageTitle: "You're about to remove WA/055/0017/013 from the bill run",
+        region: 'Stormlands',
+        transactionsTotal: '£288.37'
+      })
+    })
+  })
+})
+
+function _billLicenceSummary () {
+  return {
+    id: 'a4fbaa27-a91c-4328-a1b8-774ade11027b',
+    licenceId: '2eaa831d-7bd6-4b0a-aaf1-3aacafec6bf2',
+    licenceRef: 'WA/055/0017/013',
+    bill: {
+      id: '5a5b313b-e707-490a-a693-799339941e4f',
+      accountNumber: 'T65757520A',
+      billingAccount: {
+        id: 'e2b35a4a-7368-425f-9990-faa23efc0a25',
+        accountNumber: 'T65757520A',
+        company: {
+          id: '3b60ddd0-654f-4012-a349-000aab3e49c3',
+          name: 'Example Trading Ltd',
+          type: 'organisation'
+        },
+        billingAccountAddresses: [{
+          id: '1d440029-745a-47ec-a43e-9f4a36014126',
+          company: null,
+          contact: {
+            id: '95ba53be-543f-415b-90b1-08f58f63ff74',
+            contactType: 'person',
+            dataSource: 'wrls',
+            department: null,
+            firstName: 'Amara',
+            initials: null,
+            lastName: 'Gupta',
+            middleInitials: null,
+            salutation: null,
+            suffix: null
+          }
+        }]
+      },
+      billRun: {
+        id: '0e61c36f-f22f-4534-8247-b73a97f551b5',
+        batchType: 'supplementary',
+        billRunNumber: 10010,
+        createdAt: new Date('2023-11-01'),
+        scheme: 'sroc',
+        source: 'wrls',
+        status: 'ready',
+        toFinancialYearEnding: 2024,
+        region: {
+          id: '4ad8ce03-48a8-447e-bce2-3c317d0aeaf6',
+          displayName: 'Stormlands'
+        }
+      }
+    },
+    transactions: [
+      {
+        id: '5858e36f-5a8e-4f5c-84b3-cbca26624d67',
+        credit: false,
+        netAmount: 29837
+      },
+      {
+        id: '5858e36f-5a8e-4f5c-84b3-cbca26624d67',
+        credit: true,
+        netAmount: -1000
+      },
+      {
+        id: '14d6d530-7f07-4e4b-ac17-b8ade9f5b21a',
+        credit: false,
+        netAmount: 0
+      },
+      {
+        id: '23f43d51-8880-4e30-89da-40231cb8dea2',
+        credit: false,
+        netAmount: 0
+      }
+    ]
+  }
+}

--- a/test/services/bill-licences/submit-remove-bill-licence.service.test.js
+++ b/test/services/bill-licences/submit-remove-bill-licence.service.test.js
@@ -1,0 +1,55 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { describe, it, beforeEach, afterEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const BillHelper = require('../../support/helpers/bill.helper.js')
+const BillLicenceHelper = require('../../support/helpers/bill-licence.helper.js')
+const DatabaseSupport = require('../../support/database.js')
+
+// Things we need to stub
+const LegacyDeleteBillLicenceRequest = require('../../../app/requests/legacy/delete-bill-licence.request.js')
+
+// Thing under test
+const SubmitRemoveBillLicenceService = require('../../../app/services/bill-licences/submit-remove-bill-licence.service.js')
+
+describe('Submit Remove Bill Licence service', () => {
+  const user = { id: '0aa9dcaa-9a26-4a77-97ab-c17db54d38a1', useremail: 'carol.shaw@atari.com' }
+
+  let bill
+  let billLicence
+  let legacyDeleteBillLicenceRequestStub
+
+  beforeEach(async () => {
+    await DatabaseSupport.clean()
+
+    bill = await BillHelper.add()
+    billLicence = await BillLicenceHelper.add({ billId: bill.id })
+
+    legacyDeleteBillLicenceRequestStub = Sinon.stub(LegacyDeleteBillLicenceRequest, 'send').resolves()
+  })
+
+  afterEach(() => {
+    Sinon.restore()
+  })
+
+  describe('when called', () => {
+    it('sends a request to the legacy service to delete the bill licence', async () => {
+      await SubmitRemoveBillLicenceService.go(billLicence.id, user)
+
+      expect(legacyDeleteBillLicenceRequestStub.called).to.be.true()
+    })
+
+    it('returns the path to the legacy bill run processing page with invoice ID option', async () => {
+      const result = await SubmitRemoveBillLicenceService.go(billLicence.id, user)
+
+      expect(result).to.equal(`/billing/batch/${bill.billRunId}/processing?invoiceId=${bill.id}`)
+    })
+  })
+})

--- a/test/support/helpers/contact.helper.js
+++ b/test/support/helpers/contact.helper.js
@@ -12,7 +12,7 @@ const ContactModel = require('../../../app/models/contact.model.js')
  * If no `data` is provided, default values will be used. These are
  *
  * - `firstName` - Amara
- * - `surname` - Gupta
+ * - `lastName` - Gupta
  * - `dataSource` - wrls
  * - `contactType` - person
  * - `email` - amara.gupta@example.com


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4410

> Part of a series of changes to add support for removing a bill licence back into the billing views

We're not ready to implement removing a bill licence from a bill run as it depends on sending requests to the [Charging Module API](https://github.com/DEFRA/sroc-charging-module-api) and running the legacy refresh job to update everything on our side.

But we can migrate the confirmation page a user sees when removing a licence. Not only is that one less thing in the legacy code but we can also update the view to be consistent with others we've done like

- [Migrate view errored bill run page](https://github.com/DEFRA/water-abstraction-system/pull/785)
- [Migrate view empty bill run page](https://github.com/DEFRA/water-abstraction-system/pull/783)
- [Add cancel bill run page](https://github.com/DEFRA/water-abstraction-system/pull/780)

With this in place, we can then fix our billing views and make the [Remove licence button](https://github.com/DEFRA/water-abstraction-system/pull/824) visible again!

![Screenshot 2024-03-16 at 14 37 10](https://github.com/DEFRA/water-abstraction-system/assets/1789650/6dfa6bad-1273-48da-a7ee-d8516e682c45)

