### PR TITLE
Fix FetchLiveBillRunsService

### DIFF
--- a/app/services/bill-runs/fetch-live-bill-runs.service.js
+++ b/app/services/bill-runs/fetch-live-bill-runs.service.js
@@ -82,7 +82,6 @@ function _matchLiveBillRuns (liveBillRuns, financialYearEnding, supplementary) {
     // Regardless of bill run type if the years match we have a matching live bill run
     if (liveBillRun.toFinancialYearEnding === financialYearEnding) {
       matches.push(liveBillRun)
-      break
     }
 
     // If the bill run we are checking for is supplementary we also need to check if there is a match for the last year

--- a/app/services/bill-runs/fetch-live-bill-runs.service.js
+++ b/app/services/bill-runs/fetch-live-bill-runs.service.js
@@ -79,16 +79,16 @@ function _matchLiveBillRuns (liveBillRuns, financialYearEnding, supplementary) {
   const matches = []
 
   for (const liveBillRun of liveBillRuns) {
-    // If it's not supplementary we are looking on behalf of annual or 2PT. This means as soon as we have a match we
-    // can break the loop and return the result
-    if (!supplementary && liveBillRun.toFinancialYearEnding === financialYearEnding) {
+    // Regardless of bill run type if the years match we have a matching live bill run
+    if (liveBillRun.toFinancialYearEnding === financialYearEnding) {
       matches.push(liveBillRun)
       break
     }
 
-    // Because of the check above this will only be applied to supplementary bill runs. This is where we check the
-    // live bill run against both the specified financial year ending and the last year of PRESROC 2022
-    if (liveBillRun.toFinancialYearEnding === financialYearEnding || liveBillRun.toFinancialYearEnding === LAST_PRESROC_YEAR) {
+    // If the bill run we are checking for is supplementary we also need to check if there is a match for the last year
+    // of PRESROC. This won't necessarily block the bill run from being created. But it will help the calling service
+    // determine whether to ping the legacy app or not to create a PRESROC bill run
+    if (supplementary && liveBillRun.toFinancialYearEnding === LAST_PRESROC_YEAR) {
       matches.push(liveBillRun)
     }
   }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4375

We migrated the create bill run process from the legacy service as part of applying updates to support changes for two-part tariff.

One of the things we had to mirror was how it checks for matching or live bill runs at the end of the journey. In testing, we've found there is a scenario our unit tests and therefore the code didn't cover.

> There is _only_ a PRESROC bill run that is `READY` with a financial end year of 2022. You are trying to create an annual bill run for the current financial year (2024).

With that scenario the first test is this and the result would be false.

```javascript
  if (!supplementary && liveBillRun.toFinancialYearEnding === financialYearEnding) {
    matches.push(liveBillRun)
    break
  }
```

Our mistake is to assume only supplementary bill runs would get past this point. So, the next test is passing causing a match to be returned when it shouldn't.

```javascript
  // Because of the check above this will only be applied to supplementary bill runs. This is where we check the
  // live bill run against both the specified financial year ending and the last year of PRESROC 2022
  if (liveBillRun.toFinancialYearEnding === financialYearEnding || liveBillRun.toFinancialYearEnding === LAST_PRESROC_YEAR) {
    matches.push(liveBillRun)
  }
```

This change updates the unit tests to include this scenario and then fixes the flaw in our logic.