### PR TITLE
Fix supplementary flags not clearing after 'send'

### DIFF
--- a/app/services/bill-runs/submit-send-bill-run.service.js
+++ b/app/services/bill-runs/submit-send-bill-run.service.js
@@ -11,6 +11,7 @@ const ExpandedError = require('../../errors/expanded.error.js')
 const { calculateAndLogTimeTaken, timestampForPostgres } = require('../../lib/general.lib.js')
 const ChargingModuleSendBillRunRequest = require('../../requests/charging-module/send-bill-run.request.js')
 const ChargingModuleViewBillRunRequest = require('../../requests/charging-module/view-bill-run.request.js')
+const UnflagBilledLicencesService = require('./supplementary/unflag-billed-licences.service.js')
 
 /**
  * Orchestrates the sending of a bill run
@@ -55,7 +56,10 @@ async function _fetchBillRun (id) {
     .findById(id)
     .select([
       'id',
+      'createdAt',
       'externalId',
+      'regionId',
+      'scheme',
       'status'
     ])
 }
@@ -87,6 +91,8 @@ async function _sendBillRun (billRun) {
   await _updateInvoiceData(externalBillRun)
 
   await _updateBillRunData(billRun, externalBillRun)
+
+  await UnflagBilledLicencesService.go(billRun)
 
   calculateAndLogTimeTaken(startTime, 'Send bill run complete', { billRunId })
 }

--- a/app/services/bill-runs/supplementary/unflag-billed-licences.service.js
+++ b/app/services/bill-runs/supplementary/unflag-billed-licences.service.js
@@ -1,0 +1,72 @@
+'use strict'
+
+/**
+ * Unflag all licences in a bill run that resulted in a billing invoice (they are billed)
+ * @module UnflagUnbilledLicencesService
+ */
+
+const LicenceModel = require('../../../models/licence.model.js')
+
+/**
+ * Unflag any licences that were billed as part of a bill run
+ *
+ * Our `SubmitSendBillRunService` supports both SROC and PRESROC bill runs. But how they unflag bill runs is different.
+ *
+ * In SROC we have the `UnflagUnbilledLicencesService` which deals with licences that didn't result in a bill being
+ * created during the generation process. This means when the bill run is finally sent any licences linked to the bill
+ * can be confidently unflagged.
+ *
+ * The legacy PRESROC process doesn't deal with licences that result in no bills created during the generation process.
+ * This means it has to rely on comparing the dates when the licences were last updated and the created date of the bill
+ * run. Any licences updated before the bill run was created that are flagged for supplementary billing get their
+ * flags removed.
+ *
+ * @param {module:BillRunModel} billRun - Instance of the bill run being sent
+ *
+ * @returns {Promise<Number>} Resolves to the count of records updated
+ */
+async function go (billRun) {
+  const { scheme } = billRun
+
+  if (scheme === 'sroc') {
+    return _updateCurrentScheme(billRun)
+  }
+
+  return _updateOldScheme(billRun)
+}
+
+/**
+ * PRESROC
+ */
+async function _updateOldScheme (billRun) {
+  const { createdAt, regionId } = billRun
+
+  return LicenceModel.query()
+    .patch({ includeInPresrocBilling: 'no' })
+    .where('updatedAt', '<=', createdAt)
+    .where('regionId', regionId)
+    .where('includeInPresrocBilling', 'yes')
+    .whereNotExists(
+      LicenceModel.relatedQuery('workflows')
+        .whereNull('workflows.deletedAt')
+    )
+}
+
+/**
+ * SROC
+ */
+async function _updateCurrentScheme (billRun) {
+  const { id: billRunId } = billRun
+
+  return LicenceModel.query()
+    .patch({ includeInSrocBilling: false })
+    .whereExists(
+      LicenceModel.relatedQuery('billLicences')
+        .join('bills', 'bills.id', 'billLicences.billId')
+        .where('bills.billRunId', billRunId)
+    )
+}
+
+module.exports = {
+  go
+}

--- a/test/services/bill-runs/supplementary/unflag-billed-licences.service.test.js
+++ b/test/services/bill-runs/supplementary/unflag-billed-licences.service.test.js
@@ -1,0 +1,117 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const BillHelper = require('../../../support/helpers/bill.helper.js')
+const BillLicenceHelper = require('../../../support/helpers/bill-licence.helper.js')
+const LicenceHelper = require('../../../support/helpers/licence.helper.js')
+const DatabaseSupport = require('../../../support/database.js')
+const WorkflowHelper = require('../../../support/helpers/workflow.helper.js')
+
+// Thing under test
+const UnflagBilledLicencesService = require('../../../../app/services/bill-runs/supplementary/unflag-billed-licences.service.js')
+
+describe('Unflag Billed Licences service', () => {
+  const regionId = 'bef4204f-c9af-47e1-aa57-9632ec4634af'
+
+  let billRun
+
+  beforeEach(async () => {
+    await DatabaseSupport.clean()
+  })
+
+  describe('when there are licences flagged for PRESROC supplementary billing', () => {
+    let licenceNotInRegion
+    let licenceInWorkflow
+    let licenceFlaggedAfterBillRunCreated
+    let licenceFlaggedBeforeBillRunCreated
+
+    beforeEach(async () => {
+      const updatedAt = new Date('2024-02-02')
+
+      licenceNotInRegion = await LicenceHelper.add({
+        includeInPresrocBilling: 'yes', regionId: 'aa1504ba-211a-4851-ac2b-fd0e1e882067', updatedAt
+      })
+      licenceInWorkflow = await LicenceHelper.add({
+        includeInPresrocBilling: 'yes', regionId, updatedAt
+      })
+      await WorkflowHelper.add({ licenceId: licenceInWorkflow.id, deletedAt: null })
+
+      licenceFlaggedAfterBillRunCreated = await LicenceHelper.add({
+        includeInPresrocBilling: 'yes', regionId, updatedAt: new Date('2099-01-01')
+      })
+      licenceFlaggedBeforeBillRunCreated = await LicenceHelper.add({
+        includeInPresrocBilling: 'yes', regionId, updatedAt
+      })
+
+      billRun = {
+        id: 'fa5b8225-b616-4057-a268-1927c2f3eef1',
+        createdAt: new Date('2024-02-03'),
+        regionId,
+        scheme: 'alcs'
+      }
+    })
+
+    it('unflags those in the same region, not in workflow, and that were last updated before the bill bun was created', async () => {
+      await UnflagBilledLicencesService.go(billRun)
+
+      let licenceBeingChecked
+
+      // Check licence not in region still flagged
+      licenceBeingChecked = await licenceNotInRegion.$query()
+      expect(licenceBeingChecked.includeInPresrocBilling).to.equal('yes')
+
+      // Check licence in workflow still flagged
+      licenceBeingChecked = await licenceInWorkflow.$query()
+      expect(licenceBeingChecked.includeInPresrocBilling).to.equal('yes')
+
+      // Check licence flagged (updated) after the bill run was created
+      licenceBeingChecked = await licenceFlaggedAfterBillRunCreated.$query()
+      expect(licenceBeingChecked.includeInPresrocBilling).to.equal('yes')
+
+      // Finally check the licence which matches the query has been unflagged
+      licenceBeingChecked = await licenceFlaggedBeforeBillRunCreated.$query()
+      expect(licenceBeingChecked.includeInPresrocBilling).to.equal('no')
+    })
+  })
+
+  describe('when there are licences flagged for SROC supplementary billing', () => {
+    let licenceNotInBillRun
+    let licenceInBillRun
+
+    beforeEach(async () => {
+      billRun = {
+        id: 'fa5b8225-b616-4057-a268-1927c2f3eef1',
+        createdAt: new Date(),
+        regionId,
+        scheme: 'sroc'
+      }
+
+      licenceNotInBillRun = await LicenceHelper.add({ includeInSrocBilling: true })
+      licenceInBillRun = await LicenceHelper.add({ includeInSrocBilling: true })
+
+      const { id: billId } = await BillHelper.add({ billRunId: billRun.id })
+      await BillLicenceHelper.add({ billId, licenceId: licenceInBillRun.id })
+    })
+
+    it('unflags only those licences in the bill run)', async () => {
+      await UnflagBilledLicencesService.go(billRun)
+
+      let licenceBeingChecked
+
+      // Check licence not in bill run still flagged
+      licenceBeingChecked = await licenceNotInBillRun.$query()
+      expect(licenceBeingChecked.includeInSrocBilling).to.be.true()
+
+      // Finally check the licence in the bill run has been unflagged
+      licenceBeingChecked = await licenceInBillRun.$query()
+      expect(licenceBeingChecked.includeInSrocBilling).to.be.false()
+    })
+  })
+})


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4390

We recently [Migrate legacy send bill run functionality](https://github.com/DEFRA/water-abstraction-system/pull/771) to our system.

The PR details the reasons why (😱🤬) but suffice to say we are now responsible for the final stages of a bill run.

We've been putting the change through its paces and our ever-vigilant QA team has spotted something.

Once a supplementary bill run is sent the supplementary billing flags on the licences in the bill are supposed to be cleared. But this isn't happening in our version.

After double-checking we've found where the legacy code was doing this. We need to replicate this behaviour in our version!