### PR TITLE
Do not unflag all SROC supplementary

### DIFF
--- a/app/services/bill-runs/supplementary/process-bill-run.service.js
+++ b/app/services/bill-runs/supplementary/process-bill-run.service.js
@@ -100,7 +100,7 @@ async function _finaliseBillRun (billRun, accumulatedLicenceIds, resultsOfProces
   // .findByIds() so we spread it into an array
   const allLicenceIds = [...new Set(accumulatedLicenceIds)]
 
-  await UnflagUnbilledLicencesService.go(billRun.id, allLicenceIds)
+  await UnflagUnbilledLicencesService.go(billRun, allLicenceIds)
 
   // We set `isPopulated` to `true` if at least one processing result was truthy
   const isPopulated = resultsOfProcessing.some(result => result)

--- a/app/services/bill-runs/supplementary/unflag-billed-licences.service.js
+++ b/app/services/bill-runs/supplementary/unflag-billed-licences.service.js
@@ -56,10 +56,11 @@ async function _updateOldScheme (billRun) {
  * SROC
  */
 async function _updateCurrentScheme (billRun) {
-  const { id: billRunId } = billRun
+  const { id: billRunId, createdAt } = billRun
 
   return LicenceModel.query()
     .patch({ includeInSrocBilling: false })
+    .where('updatedAt', '<=', createdAt)
     .whereExists(
       LicenceModel.relatedQuery('billLicences')
         .join('bills', 'bills.id', 'billLicences.billId')

--- a/app/services/bill-runs/supplementary/unflag-billed-licences.service.js
+++ b/app/services/bill-runs/supplementary/unflag-billed-licences.service.js
@@ -65,6 +65,10 @@ async function _updateCurrentScheme (billRun) {
         .join('bills', 'bills.id', 'billLicences.billId')
         .where('bills.billRunId', billRunId)
     )
+    .whereNotExists(
+      LicenceModel.relatedQuery('workflows')
+        .whereNull('workflows.deletedAt')
+    )
 }
 
 module.exports = {

--- a/app/services/bill-runs/supplementary/unflag-billed-licences.service.js
+++ b/app/services/bill-runs/supplementary/unflag-billed-licences.service.js
@@ -72,14 +72,14 @@ async function _updateCurrentScheme (billRun) {
   return LicenceModel.query()
     .patch({ includeInSrocBilling: false })
     .where('updatedAt', '<=', createdAt)
+    .whereNotExists(
+      LicenceModel.relatedQuery('workflows')
+        .whereNull('workflows.deletedAt')
+    )
     .whereExists(
       LicenceModel.relatedQuery('billLicences')
         .join('bills', 'bills.id', 'billLicences.billId')
         .where('bills.billRunId', billRunId)
-    )
-    .whereNotExists(
-      LicenceModel.relatedQuery('workflows')
-        .whereNull('workflows.deletedAt')
     )
 }
 

--- a/app/services/bill-runs/supplementary/unflag-billed-licences.service.js
+++ b/app/services/bill-runs/supplementary/unflag-billed-licences.service.js
@@ -12,14 +12,25 @@ const LicenceModel = require('../../../models/licence.model.js')
  *
  * Our `SubmitSendBillRunService` supports both SROC and PRESROC bill runs. But how they unflag bill runs is different.
  *
- * In SROC we have the `UnflagUnbilledLicencesService` which deals with licences that didn't result in a bill being
- * created during the generation process. This means when the bill run is finally sent any licences linked to the bill
- * can be confidently unflagged.
+ * The PRESROC process doesn't restrict to licences in the bill run. This is because they don't deal with licences that
+ * were processed but resulted in no bill in their engine. So, they are forced to consider all flagged licences when the
+ * bill run gets 'sent'.
  *
- * The legacy PRESROC process doesn't deal with licences that result in no bills created during the generation process.
- * This means it has to rely on comparing the dates when the licences were last updated and the created date of the bill
- * run. Any licences updated before the bill run was created that are flagged for supplementary billing get their
- * flags removed.
+ * In SROC we have the `UnflagUnbilledLicencesService` which deals with licences that didn't result in a bill being
+ * created during the generation process.
+ *
+ * Other than that both queries have to deal with the same scenarios of when _not_ to unflag
+ *
+ * - licences in workflow
+ * - licences updated after the bill run was created
+ *
+ * Essentially, in both cases a user or the import process might have made a change that resulted in the bill run
+ * getting flagged. This change will not have been considered as part of the current bill run so needs to be evaluated
+ * in the next supplementary bill run. If we remove the flag this won't happen.
+ *
+ * There is a risk we leave the flag on a licence that was updated for a reason that didn't need it to be included in
+ * the next supplementary bill run. But if that is the case no bill will be created and the licence will get unflagged
+ * then.
  *
  * @param {module:BillRunModel} billRun - Instance of the bill run being sent
  *

--- a/app/services/bill-runs/supplementary/unflag-unbilled-licences.service.js
+++ b/app/services/bill-runs/supplementary/unflag-unbilled-licences.service.js
@@ -41,17 +41,17 @@ async function go (billRun, allLicenceIds) {
 
   const result = await LicenceModel.query()
     .patch({ includeInSrocBilling: false })
-    .whereIn('id', allLicenceIds)
+    .where('updatedAt', '<=', createdAt)
+    .whereNotExists(
+      LicenceModel.relatedQuery('workflows')
+        .whereNull('workflows.deletedAt')
+    )
     .whereNotExists(
       LicenceModel.relatedQuery('billLicences')
         .join('bills', 'bills.id', '=', 'billLicences.billId')
         .where('bills.billRunId', '=', billRunId)
     )
-    .whereNotExists(
-      LicenceModel.relatedQuery('workflows')
-        .whereNull('workflows.deletedAt')
-    )
-    .where('updatedAt', '<=', createdAt)
+    .whereIn('id', allLicenceIds)
 
   return result
 }

--- a/app/services/bill-runs/supplementary/unflag-unbilled-licences.service.js
+++ b/app/services/bill-runs/supplementary/unflag-unbilled-licences.service.js
@@ -11,25 +11,30 @@ const LicenceModel = require('../../../models/licence.model.js')
  * Unflag any licences that were not billed as part of a bill run
  *
  * Some licences will not result in an invoice (`billing_invoice_licence`) being created. For example, you could add a
- * new charge version that does nothing but change the description of the previous one. In isolation, this would
- * result in an `EMPTY` bill run. If others are being processed at the same time, it would just mean no records are
- * added to the bill run for this licence.
+ * new charge version that does nothing but change the description of the previous one. In isolation, this would result
+ * in an `EMPTY` bill run. If others are being processed at the same time, it would just mean no records are added to
+ * the bill run for this licence.
  *
  * If this is the case, we can remove the 'Include in SROC Supplementary Billing' flag from the licence now. Even if the
  * bill run gets cancelled and re-run later the result will be the same.
  *
- * What it also means is we can be accurate with which licences get unflagged when the bill run is finally **SENT**. In
- * the old logic they simply unflag any licence in a region where `date_updated` is less than the bill run's created
- * date. But we know this is flawed because a licence can be updated after a bill run is created, for example the NALD
- * import process updates them all. If this happens the flag remains on.
+ * What it also means is we can be accurate with which licences get unflagged when the bill run is finally **SENT**. The
+ * PRESROC process doesn't restrict to licences in the bill run. This is because they don't deal with licences that were
+ * processed but resulted in no bill in their engine. So, they are forced to consider all flagged licences when the bill
+ * run gets 'sent'.
  *
- * The query we run during the **SEND** process unflags only those which are linked to the bill run being sent. We can
- * do this because we know this service has handled anything that was unbilled and not represented.
+ * There are two scenarios of when _not_ to unflag an unbilled licence
  *
- * @param {String} billRunId The ID of the bill run being processed
- * @param {String[]} allLicenceIds All licence IDs being processed in the bill run
+ * - if the licence is in workflow
+ * - if the licence was updated after the bill run was created
  *
- * @returns {Promise<Number>} count of records updated
+ * Unlike `UnflagBilledLicencesService` the chances of these events happening between bill run creation and this service
+ * running are slim. But we feel it prudent to still check plus it keeps the services consistent.
+ *
+ * @param {String} billRunId - The UUID of the bill run being processed
+ * @param {String[]} allLicenceIds - All licence UUIDs being processed in the bill run
+ *
+ * @returns {Promise<Number>} Resolves to the count of records updated
  */
 async function go (billRunId, allLicenceIds) {
   const result = await LicenceModel.query()

--- a/app/services/bill-runs/supplementary/unflag-unbilled-licences.service.js
+++ b/app/services/bill-runs/supplementary/unflag-unbilled-licences.service.js
@@ -45,6 +45,10 @@ async function go (billRunId, allLicenceIds) {
         .join('bills', 'bills.id', '=', 'billLicences.billId')
         .where('bills.billRunId', '=', billRunId)
     )
+    .whereNotExists(
+      LicenceModel.relatedQuery('workflows')
+        .whereNull('workflows.deletedAt')
+    )
 
   return result
 }

--- a/app/services/bill-runs/supplementary/unflag-unbilled-licences.service.js
+++ b/app/services/bill-runs/supplementary/unflag-unbilled-licences.service.js
@@ -31,12 +31,14 @@ const LicenceModel = require('../../../models/licence.model.js')
  * Unlike `UnflagBilledLicencesService` the chances of these events happening between bill run creation and this service
  * running are slim. But we feel it prudent to still check plus it keeps the services consistent.
  *
- * @param {String} billRunId - The UUID of the bill run being processed
+ * @param {module:BillRunModel} billRun - Instance of the bill run being processed
  * @param {String[]} allLicenceIds - All licence UUIDs being processed in the bill run
  *
  * @returns {Promise<Number>} Resolves to the count of records updated
  */
-async function go (billRunId, allLicenceIds) {
+async function go (billRun, allLicenceIds) {
+  const { id: billRunId, createdAt } = billRun
+
   const result = await LicenceModel.query()
     .patch({ includeInSrocBilling: false })
     .whereIn('id', allLicenceIds)
@@ -49,6 +51,7 @@ async function go (billRunId, allLicenceIds) {
       LicenceModel.relatedQuery('workflows')
         .whereNull('workflows.deletedAt')
     )
+    .where('updatedAt', '<=', createdAt)
 
   return result
 }

--- a/test/services/bill-runs/supplementary/unflag-billed-licences.service.test.js
+++ b/test/services/bill-runs/supplementary/unflag-billed-licences.service.test.js
@@ -88,6 +88,8 @@ describe('Unflag Billed Licences service', () => {
     let licenceInBillRun
 
     beforeEach(async () => {
+      licenceInBillRun = await LicenceHelper.add({ includeInSrocBilling: true })
+
       licenceNotInBillRun = await LicenceHelper.add({ includeInSrocBilling: true })
 
       licenceInBillRunAndWorkflow = await LicenceHelper.add({ includeInSrocBilling: true })
@@ -96,8 +98,6 @@ describe('Unflag Billed Licences service', () => {
       licenceInBillRunAndFlaggedAfterBillRunCreated = await LicenceHelper.add({
         includeInSrocBilling: true, updatedAt: new Date('2099-01-01')
       })
-
-      licenceInBillRun = await LicenceHelper.add({ includeInSrocBilling: true })
 
       billRun = {
         id: 'fa5b8225-b616-4057-a268-1927c2f3eef1',

--- a/test/services/bill-runs/supplementary/unflag-billed-licences.service.test.js
+++ b/test/services/bill-runs/supplementary/unflag-billed-licences.service.test.js
@@ -58,7 +58,7 @@ describe('Unflag Billed Licences service', () => {
       }
     })
 
-    it('unflags those in the same region, not in workflow, and that were last updated before the bill bun was created', async () => {
+    it('unflags those in the same region, not in workflow, and that were last updated before the bill run was created', async () => {
       await UnflagBilledLicencesService.go(billRun)
 
       let licenceBeingChecked
@@ -83,9 +83,22 @@ describe('Unflag Billed Licences service', () => {
 
   describe('when there are licences flagged for SROC supplementary billing', () => {
     let licenceNotInBillRun
+    let licenceInBillRunAndWorkflow
+    let licenceInBillRunAndFlaggedAfterBillRunCreated
     let licenceInBillRun
 
     beforeEach(async () => {
+      licenceNotInBillRun = await LicenceHelper.add({ includeInSrocBilling: true })
+
+      licenceInBillRunAndWorkflow = await LicenceHelper.add({ includeInSrocBilling: true })
+      await WorkflowHelper.add({ licenceId: licenceInBillRunAndWorkflow.id, deletedAt: null })
+
+      licenceInBillRunAndFlaggedAfterBillRunCreated = await LicenceHelper.add({
+        includeInSrocBilling: true, updatedAt: new Date('2099-01-01')
+      })
+
+      licenceInBillRun = await LicenceHelper.add({ includeInSrocBilling: true })
+
       billRun = {
         id: 'fa5b8225-b616-4057-a268-1927c2f3eef1',
         createdAt: new Date(),
@@ -93,14 +106,13 @@ describe('Unflag Billed Licences service', () => {
         scheme: 'sroc'
       }
 
-      licenceNotInBillRun = await LicenceHelper.add({ includeInSrocBilling: true })
-      licenceInBillRun = await LicenceHelper.add({ includeInSrocBilling: true })
-
       const { id: billId } = await BillHelper.add({ billRunId: billRun.id })
+      await BillLicenceHelper.add({ billId, licenceId: licenceInBillRunAndWorkflow.id })
+      await BillLicenceHelper.add({ billId, licenceId: licenceInBillRunAndFlaggedAfterBillRunCreated.id })
       await BillLicenceHelper.add({ billId, licenceId: licenceInBillRun.id })
     })
 
-    it('unflags only those licences in the bill run)', async () => {
+    it('unflags only those licences in the bill run that are not in workflow, and that were last updated before the bill run was created)', async () => {
       await UnflagBilledLicencesService.go(billRun)
 
       let licenceBeingChecked
@@ -109,7 +121,15 @@ describe('Unflag Billed Licences service', () => {
       licenceBeingChecked = await licenceNotInBillRun.$query()
       expect(licenceBeingChecked.includeInSrocBilling).to.be.true()
 
-      // Finally check the licence in the bill run has been unflagged
+      // Check licence in bill run but also in workflow still flagged
+      licenceBeingChecked = await licenceInBillRunAndWorkflow.$query()
+      expect(licenceBeingChecked.includeInSrocBilling).to.be.true()
+
+      // Check licence in bill run but updated after bill run was created (e.g. charge version approved) still flagged
+      licenceBeingChecked = await licenceInBillRunAndFlaggedAfterBillRunCreated.$query()
+      expect(licenceBeingChecked.includeInSrocBilling).to.be.true()
+
+      // Finally check the licence in the bill run with no other issues has been unflagged
       licenceBeingChecked = await licenceInBillRun.$query()
       expect(licenceBeingChecked.includeInSrocBilling).to.be.false()
     })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4390

We recently [Migrate legacy send bill run functionality](https://github.com/DEFRA/water-abstraction-system/pull/771) to our system.

The PR details the reasons why (😱🤬) but suffice to say we are now responsible for the final stages of a bill run.

We then spotted that we'd overlooked dealing with unflagging licences that were flagged for supplementary billing. That got sorted in [Fix supplementary flags not clearing after 'send'](https://github.com/DEFRA/water-abstraction-system/pull/849).

But then we started discussing the differences between the legacy approach (which we had to recreate) and our approach. We realised there are scenarios we are not covering.

1. User makes a change that flags a licence for supplementary billing
2. User generates a supplementary bill run
3. User then makes another change (adds a new charge version) which is waiting to be approved
4. User sends the bill run

Currently, we'd remove the flag when the licence needs to be included in the next one. Also, if in step 3 they added a new charge version and then approved it, we'd have no workflow record to hang off. We'd be removing the flag when again the licence needs to be in the next supplementary bill run.

This applies to licences the engine determines are unbilled (these get unflagged during bill run creation) and those that were billed (dealt with when the bill run gets sent).

So, this change adds some of that legacy logic to our services to cover these scenarios.