### PR TITLE
Fix determine billing periods

### DIFF
--- a/app/services/bill-runs/setup/create.service.js
+++ b/app/services/bill-runs/setup/create.service.js
@@ -50,7 +50,15 @@ async function _triggerBillRun (regionId, batchType, user, year, existingBillRun
     return null
   }
 
-  return StartBillRunProcessService.go(regionId, batchType, userEmail, year)
+  // TODO: We do want to send the year through. However, the billing engine was written initially for supplementary
+  // then extended for annual and soon to be amended again for two-part tariff. 2PT has a short term requirement to
+  // handle a year being provided by the user but once a back log of bill runs has been completed this will no longer
+  // be the case (it will work like the other and just use the current year). Providing a year breaks supplementary
+  // and isn't the intended expectation for annual. So, until we update our billing engine (soon to be because of
+  // WATER-4403) we trigger the start of the process in the same way the legacy create bill run process would.
+  const yearForBillRun = batchType === 'two_part_tariff' ? year : null
+
+  return StartBillRunProcessService.go(regionId, batchType, userEmail, yearForBillRun)
 }
 
 async function _triggerLegacyBillRun (regionId, batchType, user, year, summer, existingBillRun = null) {

--- a/test/services/bill-runs/determine-billing-periods.service.test.js
+++ b/test/services/bill-runs/determine-billing-periods.service.test.js
@@ -21,52 +21,118 @@ describe('Billing Periods service', () => {
     Sinon.restore()
   })
 
-  describe('when the date is in 2022 and falls within the 2022 financial year', () => {
-    beforeEach(() => {
-      testDate = new Date('2022-04-01')
-      expectedResult = {
-        startDate: new Date('2022-04-01'),
-        endDate: new Date('2023-03-31')
-      }
+  describe('when no financial year is provided', () => {
+    describe('and the date is in 2022 and falls within the 2022 financial year', () => {
+      beforeEach(() => {
+        testDate = new Date('2022-04-01')
+        expectedResult = {
+          startDate: new Date('2022-04-01'),
+          endDate: new Date('2023-03-31')
+        }
 
-      clock = Sinon.useFakeTimers(testDate)
+        clock = Sinon.useFakeTimers(testDate)
+      })
+
+      it('returns the expected date range', () => {
+        const result = DetermineBillingPeriodsService.go()
+
+        expect(result).to.have.length(1)
+        expect(result[0]).to.equal(expectedResult)
+      })
     })
 
-    it('returns the expected date range', () => {
-      const result = DetermineBillingPeriodsService.go()
+    describe('and the date is in 2023 and falls within the 2022 financial year', () => {
+      beforeEach(() => {
+        testDate = new Date('2023-03-01')
+        expectedResult = {
+          startDate: new Date('2022-04-01'),
+          endDate: new Date('2023-03-31')
+        }
 
-      expect(result).to.have.length(1)
-      expect(result[0]).to.equal(expectedResult)
+        clock = Sinon.useFakeTimers(testDate)
+      })
+
+      it('returns the expected date range', () => {
+        const result = DetermineBillingPeriodsService.go()
+
+        expect(result).to.have.length(1)
+        expect(result[0]).to.equal(expectedResult)
+      })
+    })
+
+    describe('and the date is in 2023 and falls within the 2023 financial year', () => {
+      beforeEach(() => {
+        testDate = new Date('2023-10-10')
+        expectedResult = [
+          {
+            startDate: new Date('2023-04-01'),
+            endDate: new Date('2024-03-31')
+          },
+          {
+            startDate: new Date('2022-04-01'),
+            endDate: new Date('2023-03-31')
+          }
+        ]
+
+        clock = Sinon.useFakeTimers(testDate)
+      })
+
+      it('returns the expected date range', () => {
+        const result = DetermineBillingPeriodsService.go()
+
+        expect(result).to.have.length(2)
+        expect(result).to.equal(expectedResult)
+      })
+    })
+
+    describe('and the date is in 2030 and falls within the 2030 financial year', () => {
+      beforeEach(() => {
+        testDate = new Date('2030-10-10')
+        expectedResult = [
+          {
+            startDate: new Date('2030-04-01'),
+            endDate: new Date('2031-03-31')
+          },
+          {
+            startDate: new Date('2029-04-01'),
+            endDate: new Date('2030-03-31')
+          },
+          {
+            startDate: new Date('2028-04-01'),
+            endDate: new Date('2029-03-31')
+          },
+          {
+            startDate: new Date('2027-04-01'),
+            endDate: new Date('2028-03-31')
+          },
+          {
+            startDate: new Date('2026-04-01'),
+            endDate: new Date('2027-03-31')
+          },
+          {
+            startDate: new Date('2025-04-01'),
+            endDate: new Date('2026-03-31')
+          }
+        ]
+
+        clock = Sinon.useFakeTimers(testDate)
+      })
+
+      it('returns the expected date range', () => {
+        const result = DetermineBillingPeriodsService.go()
+
+        expect(result).to.have.length(6)
+        expect(result).to.equal(expectedResult)
+      })
     })
   })
 
-  describe('when the date is in 2023 and falls within the 2022 financial year', () => {
-    beforeEach(() => {
-      testDate = new Date('2023-03-01')
-      expectedResult = {
-        startDate: new Date('2022-04-01'),
-        endDate: new Date('2023-03-31')
-      }
+  describe('when the `financialYearEnding` of 2023 is passed to the service', () => {
+    const financialYearEnding = 2023
 
-      clock = Sinon.useFakeTimers(testDate)
-    })
-
-    it('returns the expected date range', () => {
-      const result = DetermineBillingPeriodsService.go()
-
-      expect(result).to.have.length(1)
-      expect(result[0]).to.equal(expectedResult)
-    })
-  })
-
-  describe('when the date is in 2023 and falls within the 2023 financial year', () => {
     beforeEach(() => {
       testDate = new Date('2023-10-10')
       expectedResult = [
-        {
-          startDate: new Date('2023-04-01'),
-          endDate: new Date('2024-03-31')
-        },
         {
           startDate: new Date('2022-04-01'),
           endDate: new Date('2023-03-31')
@@ -77,70 +143,9 @@ describe('Billing Periods service', () => {
     })
 
     it('returns the expected date range', () => {
-      const result = DetermineBillingPeriodsService.go()
+      const result = DetermineBillingPeriodsService.go(financialYearEnding)
 
-      expect(result).to.have.length(2)
-      expect(result).to.equal(expectedResult)
-    })
-
-    describe('when the `financialYearEnding` of 2023 is passed to the service', () => {
-      const financialYearEnding = 2023
-
-      beforeEach(() => {
-        expectedResult = [
-          {
-            startDate: new Date('2022-04-01'),
-            endDate: new Date('2023-03-31')
-          }
-        ]
-      })
-
-      it('returns the expected date range', () => {
-        const result = DetermineBillingPeriodsService.go(financialYearEnding)
-
-        expect(result).to.have.length(1)
-        expect(result).to.equal(expectedResult)
-      })
-    })
-  })
-
-  describe('when the date is in 2030 and falls within the 2030 financial year', () => {
-    beforeEach(() => {
-      testDate = new Date('2030-10-10')
-      expectedResult = [
-        {
-          startDate: new Date('2030-04-01'),
-          endDate: new Date('2031-03-31')
-        },
-        {
-          startDate: new Date('2029-04-01'),
-          endDate: new Date('2030-03-31')
-        },
-        {
-          startDate: new Date('2028-04-01'),
-          endDate: new Date('2029-03-31')
-        },
-        {
-          startDate: new Date('2027-04-01'),
-          endDate: new Date('2028-03-31')
-        },
-        {
-          startDate: new Date('2026-04-01'),
-          endDate: new Date('2027-03-31')
-        },
-        {
-          startDate: new Date('2025-04-01'),
-          endDate: new Date('2026-03-31')
-        }
-      ]
-
-      clock = Sinon.useFakeTimers(testDate)
-    })
-
-    it('returns the expected date range', () => {
-      const result = DetermineBillingPeriodsService.go()
-
-      expect(result).to.have.length(6)
+      expect(result).to.have.length(1)
       expect(result).to.equal(expectedResult)
     })
   })

--- a/test/services/bill-runs/determine-billing-periods.service.test.js
+++ b/test/services/bill-runs/determine-billing-periods.service.test.js
@@ -127,22 +127,22 @@ describe('Billing Periods service', () => {
     })
   })
 
-  describe('when the `financialYearEnding` of 2023 is passed to the service', () => {
-    const financialYearEnding = 2023
+  describe('when a financial year is provided', () => {
+    const financialYearEnding = 2025
 
     beforeEach(() => {
-      testDate = new Date('2023-10-10')
+      testDate = new Date('2024-10-10')
       expectedResult = [
         {
-          startDate: new Date('2022-04-01'),
-          endDate: new Date('2023-03-31')
+          startDate: new Date('2024-04-01'),
+          endDate: new Date('2025-03-31')
         }
       ]
 
       clock = Sinon.useFakeTimers(testDate)
     })
 
-    it('returns the expected date range', () => {
+    it('only returns the billing period for that financial year', () => {
       const result = DetermineBillingPeriodsService.go(financialYearEnding)
 
       expect(result).to.have.length(1)

--- a/test/services/bill-runs/setup/create.service.test.js
+++ b/test/services/bill-runs/setup/create.service.test.js
@@ -66,7 +66,7 @@ describe('Bill Runs Setup Create service', () => {
       existsResults = { matchResults: [], session, yearToUse: 2024 }
     })
 
-    it.only('only triggers our bill run process', async () => {
+    it('only triggers our bill run process', async () => {
       await CreateService.go(user, existsResults)
 
       expect(legacyCreateBillRunRequestStub.called).to.be.false()
@@ -178,7 +178,7 @@ describe('Bill Runs Setup Create service', () => {
         expect(legacyCreateBillRunRequestStub.called).to.be.false()
         expect(startBillRunProcessServiceStub.calledWith(
           '19a027c6-4aad-47d3-80e3-3917a4579a5b',
-          'supplementary',
+          'two_part_tariff',
           'carol.shaw@atari.com',
           2023)
         ).to.be.true()

--- a/test/services/bill-runs/setup/create.service.test.js
+++ b/test/services/bill-runs/setup/create.service.test.js
@@ -21,7 +21,7 @@ const StartBillRunProcessService = require('../../../../app/services/bill-runs/s
 const CreateService = require('../../../../app/services/bill-runs/setup/create.service.js')
 
 describe('Bill Runs Setup Create service', () => {
-  const user = { useremail: 'carol.shaw@atari.com' }
+  const user = { username: 'carol.shaw@atari.com' }
 
   let existsResults
   let legacyCreateBillRunRequestStub
@@ -66,11 +66,16 @@ describe('Bill Runs Setup Create service', () => {
       existsResults = { matchResults: [], session, yearToUse: 2024 }
     })
 
-    it('only triggers our bill run process', async () => {
+    it.only('only triggers our bill run process', async () => {
       await CreateService.go(user, existsResults)
 
       expect(legacyCreateBillRunRequestStub.called).to.be.false()
-      expect(startBillRunProcessServiceStub.called).to.be.true()
+      expect(startBillRunProcessServiceStub.calledWith(
+        '19a027c6-4aad-47d3-80e3-3917a4579a5b',
+        'annual',
+        'carol.shaw@atari.com',
+        null)
+      ).to.be.true()
     })
   })
 
@@ -90,7 +95,12 @@ describe('Bill Runs Setup Create service', () => {
         await CreateService.go(user, existsResults)
 
         expect(legacyCreateBillRunRequestStub.called).to.be.true()
-        expect(startBillRunProcessServiceStub.called).to.be.true()
+        expect(startBillRunProcessServiceStub.calledWith(
+          '19a027c6-4aad-47d3-80e3-3917a4579a5b',
+          'supplementary',
+          'carol.shaw@atari.com',
+          null)
+        ).to.be.true()
       })
     })
 
@@ -103,7 +113,12 @@ describe('Bill Runs Setup Create service', () => {
         await CreateService.go(user, existsResults)
 
         expect(legacyCreateBillRunRequestStub.called).to.be.false()
-        expect(startBillRunProcessServiceStub.called).to.be.true()
+        expect(startBillRunProcessServiceStub.calledWith(
+          '19a027c6-4aad-47d3-80e3-3917a4579a5b',
+          'supplementary',
+          'carol.shaw@atari.com',
+          null)
+        ).to.be.true()
       })
     })
 
@@ -161,7 +176,12 @@ describe('Bill Runs Setup Create service', () => {
         await CreateService.go(user, existsResults)
 
         expect(legacyCreateBillRunRequestStub.called).to.be.false()
-        expect(startBillRunProcessServiceStub.called).to.be.true()
+        expect(startBillRunProcessServiceStub.calledWith(
+          '19a027c6-4aad-47d3-80e3-3917a4579a5b',
+          'supplementary',
+          'carol.shaw@atari.com',
+          2023)
+        ).to.be.true()
       })
     })
   })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4375

To implement changes to support new two-part tariff bill run options we needed to update the create bill run journey. We took advantage of this to migrate the functionality into [water-abstraction-system](https://github.com/DEFRA/water-abstraction-system).

In our new journey to determine if there are any live bill runs that would block a new bill run from proceeding, we have to determine the financial end year for the proposed bill run. We do this in `app/services/bill-runs/setup/exists.service.js`.

Having determined the year we pass this into our existing `StartBillRunProcessService` for consistency.

What we had overlooked was that if the year is set it will then pass that on to `DetermineBillingPeriodsService` which, if provided with a financial year will _only_ generate a billing period for that year. This breaks supplementary billing which for SROC needs multiple billing periods to be determined.

We'll be revisiting `DetermineBillingPeriodsService` soon as part of our work to [Exclude Financial Year from Supplementary Billing where Annual Bill has not been run for region & year](https://eaflood.atlassian.net/browse/WATER-4403). But for now, we just need to get supplementary billing working again.