### PR TITLE
Fix duplicated abstraction points for return requirements points page

### DIFF
--- a/app/presenters/return-requirements/points.presenter.js
+++ b/app/presenters/return-requirements/points.presenter.js
@@ -47,7 +47,9 @@ function _licencePoints (pointsData, payload) {
     abstractionPoints.push(_generateAbstractionContent(pointDetail))
   })
 
-  return abstractionPoints
+  const uniqueAbstractionPoints = [...new Set(abstractionPoints)]
+
+  return uniqueAbstractionPoints
 }
 
 function _generateAbstractionContent (pointDetails) {

--- a/test/presenters/return-requirements/points.presenter.test.js
+++ b/test/presenters/return-requirements/points.presenter.test.js
@@ -10,7 +10,7 @@ const { expect } = Code
 // Thing under test
 const PointsPresenter = require('../../../app/presenters/return-requirements/points.presenter.js')
 
-describe.only('Select Points presenter', () => {
+describe('Select Points presenter', () => {
   let session
   let pointsData
 

--- a/test/presenters/return-requirements/points.presenter.test.js
+++ b/test/presenters/return-requirements/points.presenter.test.js
@@ -10,7 +10,7 @@ const { expect } = Code
 // Thing under test
 const PointsPresenter = require('../../../app/presenters/return-requirements/points.presenter.js')
 
-describe('Select Points presenter', () => {
+describe.only('Select Points presenter', () => {
   let session
   let pointsData
 
@@ -30,6 +30,21 @@ describe('Select Points presenter', () => {
     }
 
     pointsData = [{
+      NGR1_EAST: '69212',
+      NGR2_EAST: 'null',
+      NGR3_EAST: 'null',
+      NGR4_EAST: 'null',
+      LOCAL_NAME: 'RIVER MEDWAY AT YALDING INTAKE',
+      NGR1_NORTH: '50394',
+      NGR1_SHEET: 'TQ',
+      NGR2_NORTH: 'null',
+      NGR2_SHEET: 'null',
+      NGR3_NORTH: 'null',
+      NGR3_SHEET: 'null',
+      NGR4_NORTH: 'null',
+      NGR4_SHEET: 'null'
+    },
+    {
       NGR1_EAST: '69212',
       NGR2_EAST: 'null',
       NGR3_EAST: 'null',


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4295

https://github.com/DEFRA/water-abstraction-system/pull/833

This was a ticket that was thought to have been completed, but upon QA testing by Ven, some licences seem to have duplicated 'abstraction points'. There was a previous check within the code preventing this but it was removed as no duplicating 'point_details' were encountered at that time.

This PR will be focused on preventing duplicating abstraction points being present within the list of checkbox points on the return requirements points page.