### PR TITLE
Fix bill run exists page for bill runs in review

### DIFF
--- a/app/presenters/bill-runs/setup/create.presenter.js
+++ b/app/presenters/bill-runs/setup/create.presenter.js
@@ -13,6 +13,8 @@ const {
   formatLongDate
 } = require('../../base.presenter.js')
 
+const LAST_PRESROC_YEAR = 2022
+
 /**
  * Formats data for the `/bill-runs/setup/{sessionId}/create` page
  *
@@ -39,6 +41,7 @@ function go (session, billRun) {
   return {
     backLink: _backLink(session),
     billRunId: id,
+    billRunLink: _billRunLink(billRun),
     billRunNumber,
     billRunStatus: status,
     billRunType,
@@ -62,6 +65,20 @@ function _backLink (session) {
   }
 
   return `/system/bill-runs/setup/${session.id}/season`
+}
+
+function _billRunLink (billRun) {
+  const { id: billRunId, status, toFinancialYearEnding } = billRun
+
+  if (status !== 'review') {
+    return `/system/bill-runs/${billRunId}`
+  }
+
+  if (toFinancialYearEnding > LAST_PRESROC_YEAR) {
+    return `/system/bill-runs/${billRunId}/review`
+  }
+
+  return `/billing/batch/${billRunId}/two-part-tariff-review`
 }
 
 function _warningMessage (billRunType, status) {

--- a/app/views/bill-runs/setup/create.njk
+++ b/app/views/bill-runs/setup/create.njk
@@ -75,7 +75,7 @@
         })
       }}
 
-      <a href="/system/bill-runs/{{ billRunId }}" class="govuk-body govuk-link">Go to this bill run</a>
+      <a href="{{ billRunLink }}" class="govuk-body govuk-link">Go to this bill run</a>
     </div>
   </div>
 {% endblock %}

--- a/test/controllers/bill-runs-setup.controller.test.js
+++ b/test/controllers/bill-runs-setup.controller.test.js
@@ -79,7 +79,10 @@ describe('Bill Runs Setup controller', () => {
           beforeEach(() => {
             Sinon.stub(ExistsService, 'go').resolves({
               matchResults: [{ id: '81e97369-e744-44c9-ad2e-75e8e632e61c' }],
-              pageData: { billRunId: '81e97369-e744-44c9-ad2e-75e8e632e61c' },
+              pageData: {
+                billRunId: '81e97369-e744-44c9-ad2e-75e8e632e61c',
+                billRunLink: '/system/bill-runs/81e97369-e744-44c9-ad2e-75e8e632e61c'
+              },
               session: { id: 'e009b394-8405-4358-86af-1a9eb31298a5' },
               yearToUse: 2024
             })

--- a/test/presenters/bill-runs/setup/create.presenter.test.js
+++ b/test/presenters/bill-runs/setup/create.presenter.test.js
@@ -40,6 +40,7 @@ describe('Bill Runs Setup Create presenter', () => {
       expect(result).to.equal({
         backLink: '/system/bill-runs/setup/98ad3a1f-8e4f-490a-be05-0aece6755466/region',
         billRunId: 'c0608545-9870-4605-a407-5ff49f8a5182',
+        billRunLink: '/system/bill-runs/c0608545-9870-4605-a407-5ff49f8a5182',
         billRunNumber: 12345,
         billRunStatus: 'sent',
         billRunType: 'Annual',
@@ -90,6 +91,43 @@ describe('Bill Runs Setup Create presenter', () => {
             const result = CreatePresenter.go(session, matchingBillRun)
 
             expect(result.backLink).to.equal('/system/bill-runs/setup/98ad3a1f-8e4f-490a-be05-0aece6755466/season')
+          })
+        })
+      })
+    })
+
+    describe("the 'billRunLink' property", () => {
+      describe("when the matching bill run's status is not 'review'", () => {
+        it('returns a link to the bill run page', () => {
+          const result = CreatePresenter.go(session, matchingBillRun)
+
+          expect(result.billRunLink).to.equal('/system/bill-runs/c0608545-9870-4605-a407-5ff49f8a5182')
+        })
+      })
+
+      describe("when the matching bill run's status is 'review'", () => {
+        beforeEach(() => {
+          matchingBillRun.batchType = 'two_part_tariff'
+          matchingBillRun.status = 'review'
+        })
+
+        describe("and the matching bill run's financial year is in the SROC period", () => {
+          it('returns a link to the SROC review page', () => {
+            const result = CreatePresenter.go(session, matchingBillRun)
+
+            expect(result.billRunLink).to.equal('/system/bill-runs/c0608545-9870-4605-a407-5ff49f8a5182/review')
+          })
+        })
+
+        describe("and the matching bill run's financial year is in the PRESROC period", () => {
+          beforeEach(() => {
+            matchingBillRun.toFinancialYearEnding = '2022'
+          })
+
+          it('returns a link to the PRESROC review page', () => {
+            const result = CreatePresenter.go(session, matchingBillRun)
+
+            expect(result.billRunLink).to.equal('/billing/batch/c0608545-9870-4605-a407-5ff49f8a5182/two-part-tariff-review')
           })
         })
       })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4375

We recently migrated the setup bill run journey into this project which meant we also needed to migrate the page which displays when an existing bill run is found.

In testing, we have spotted an issue with the page. If the match is a two-part tariff bill run in review, the 'Go to bill run' link takes them to the view bill run page. This means the user just sees an empty bill run when they should be seeing the appropriate review page.

This change fixes the issue.