### PR TITLE
Refactor DetermineBillingPeriods to use type

### DIFF
--- a/app/services/bill-runs/setup/create.service.js
+++ b/app/services/bill-runs/setup/create.service.js
@@ -50,15 +50,7 @@ async function _triggerBillRun (regionId, batchType, user, year, existingBillRun
     return null
   }
 
-  // TODO: We do want to send the year through. However, the billing engine was written initially for supplementary
-  // then extended for annual and soon to be amended again for two-part tariff. 2PT has a short term requirement to
-  // handle a year being provided by the user but once a back log of bill runs has been completed this will no longer
-  // be the case (it will work like the other and just use the current year). Providing a year breaks supplementary
-  // and isn't the intended expectation for annual. So, until we update our billing engine (soon to be because of
-  // WATER-4403) we trigger the start of the process in the same way the legacy create bill run process would.
-  const yearForBillRun = batchType === 'two_part_tariff' ? year : null
-
-  return StartBillRunProcessService.go(regionId, batchType, userEmail, yearForBillRun)
+  return StartBillRunProcessService.go(regionId, batchType, userEmail, year)
 }
 
 async function _triggerLegacyBillRun (regionId, batchType, user, year, summer, existingBillRun = null) {

--- a/app/services/bill-runs/start-bill-run-process.service.js
+++ b/app/services/bill-runs/start-bill-run-process.service.js
@@ -23,7 +23,7 @@ const TwoPartTariffProcessBillRunService = require('./two-part-tariff/process-bi
  * @returns {Promise<Object>} Object that will be the JSON response returned to the client
  */
 async function go (regionId, batchType, userEmail, financialYearEnding) {
-  const billingPeriods = DetermineBillingPeriodsService.go(financialYearEnding)
+  const billingPeriods = DetermineBillingPeriodsService.go(batchType, financialYearEnding)
   const financialYearEndings = _financialYearEndings(billingPeriods)
 
   const billRun = await InitiateBillRunService.go(financialYearEndings, regionId, batchType, userEmail)

--- a/test/services/bill-runs/determine-billing-periods.service.test.js
+++ b/test/services/bill-runs/determine-billing-periods.service.test.js
@@ -8,86 +8,213 @@ const Sinon = require('sinon')
 const { describe, it, beforeEach, afterEach } = exports.lab = Lab.script()
 const { expect } = Code
 
+// Test helpers
+const { determineCurrentFinancialYear } = require('../../../app/lib/general.lib.js')
+
 // Thing under test
 const DetermineBillingPeriodsService = require('../../../app/services/bill-runs/determine-billing-periods.service.js')
 
-describe('Billing Periods service', () => {
+describe('Determine Billing Periods service', () => {
+  const currentFinancialYear = determineCurrentFinancialYear()
+
+  let billRunType
   let clock
   let expectedResult
+  let financialYearEnding
   let testDate
 
   afterEach(() => {
-    clock.restore()
     Sinon.restore()
   })
 
-  describe('when no financial year is provided', () => {
-    describe('and the date is in 2022 and falls within the 2022 financial year', () => {
+  describe("when the bill run type is 'annual'", () => {
+    beforeEach(() => {
+      billRunType = 'annual'
+    })
+
+    describe('and no financial year ending is provided', () => {
+      it('returns a single billing period for the current financial year', () => {
+        const result = DetermineBillingPeriodsService.go(billRunType)
+
+        expect(result).to.have.length(1)
+        expect(result[0]).to.equal(currentFinancialYear)
+      })
+    })
+
+    describe("and the financial year ending '2023' is provided", () => {
       beforeEach(() => {
-        testDate = new Date('2022-04-01')
+        financialYearEnding = 2023
+
         expectedResult = {
           startDate: new Date('2022-04-01'),
           endDate: new Date('2023-03-31')
         }
-
-        clock = Sinon.useFakeTimers(testDate)
       })
 
-      it('returns the expected date range', () => {
-        const result = DetermineBillingPeriodsService.go()
+      it('returns a single billing period for that financial year', () => {
+        const result = DetermineBillingPeriodsService.go(billRunType, financialYearEnding)
 
         expect(result).to.have.length(1)
         expect(result[0]).to.equal(expectedResult)
       })
     })
+  })
 
-    describe('and the date is in 2023 and falls within the 2022 financial year', () => {
+  describe("when the bill run type is 'two_part_tariff'", () => {
+    beforeEach(() => {
+      billRunType = 'two_part_tariff'
+    })
+
+    describe('and no financial year ending is provided', () => {
+      it('returns a single billing period for the current financial year', () => {
+        const result = DetermineBillingPeriodsService.go(billRunType)
+
+        expect(result).to.have.length(1)
+        expect(result[0]).to.equal(currentFinancialYear)
+      })
+    })
+
+    describe("and the financial year ending '2023' is provided", () => {
       beforeEach(() => {
-        testDate = new Date('2023-03-01')
+        financialYearEnding = 2023
+
         expectedResult = {
           startDate: new Date('2022-04-01'),
           endDate: new Date('2023-03-31')
         }
-
-        clock = Sinon.useFakeTimers(testDate)
       })
 
-      it('returns the expected date range', () => {
-        const result = DetermineBillingPeriodsService.go()
+      it('returns a single billing period for that financial year', () => {
+        const result = DetermineBillingPeriodsService.go(billRunType, financialYearEnding)
 
         expect(result).to.have.length(1)
         expect(result[0]).to.equal(expectedResult)
       })
     })
+  })
 
-    describe('and the date is in 2023 and falls within the 2023 financial year', () => {
+  describe("when the bill run type is 'supplementary'", () => {
+    beforeEach(() => {
+      billRunType = 'supplementary'
+    })
+
+    afterEach(() => {
+      clock.restore()
+    })
+
+    describe("and today's date is 2022-05-01 (in start year of financial year)", () => {
       beforeEach(() => {
-        testDate = new Date('2023-10-10')
-        expectedResult = [
-          {
-            startDate: new Date('2023-04-01'),
-            endDate: new Date('2024-03-31')
-          },
-          {
+        testDate = new Date('2022-05-01')
+        clock = Sinon.useFakeTimers(testDate)
+
+        expectedResult = {
+          startDate: new Date('2022-04-01'),
+          endDate: new Date('2023-03-31')
+        }
+      })
+
+      describe('and no financial year ending is provided', () => {
+        it("returns a single billing period for the 'current' financial year", () => {
+          const result = DetermineBillingPeriodsService.go(billRunType)
+
+          expect(result).to.have.length(1)
+          expect(result[0]).to.equal(expectedResult)
+        })
+      })
+
+      // NOTE: This scenario would never happen, i.e. that we'd get a request to generate an SROC supplementary for a
+      // PRESROC financial year. But it demonstrates the service will only generate billing periods that start in the
+      // first year of SROC
+      describe("and the financial year ending '2021' is provided", () => {
+        beforeEach(() => {
+          financialYearEnding = 2021
+        })
+
+        it('returns no billing periods', () => {
+          const result = DetermineBillingPeriodsService.go(billRunType, financialYearEnding)
+
+          expect(result).to.be.empty()
+        })
+      })
+
+      describe("and the financial year ending '2023' is provided", () => {
+        beforeEach(() => {
+          financialYearEnding = 2023
+
+          expectedResult = {
             startDate: new Date('2022-04-01'),
             endDate: new Date('2023-03-31')
           }
-        ]
+        })
 
-        clock = Sinon.useFakeTimers(testDate)
-      })
+        it('returns a single billing period for that financial year', () => {
+          const result = DetermineBillingPeriodsService.go(billRunType, financialYearEnding)
 
-      it('returns the expected date range', () => {
-        const result = DetermineBillingPeriodsService.go()
-
-        expect(result).to.have.length(2)
-        expect(result).to.equal(expectedResult)
+          expect(result).to.have.length(1)
+          expect(result[0]).to.equal(expectedResult)
+        })
       })
     })
 
-    describe('and the date is in 2030 and falls within the 2030 financial year', () => {
+    describe("and today's date is 2023-02-01 (in end year of financial year)", () => {
       beforeEach(() => {
-        testDate = new Date('2030-10-10')
+        testDate = new Date('2023-02-01')
+        clock = Sinon.useFakeTimers(testDate)
+
+        expectedResult = {
+          startDate: new Date('2022-04-01'),
+          endDate: new Date('2023-03-31')
+        }
+      })
+
+      describe('and no financial year ending is provided', () => {
+        it("returns a single billing period for the 'current' financial year", () => {
+          const result = DetermineBillingPeriodsService.go(billRunType)
+
+          expect(result).to.have.length(1)
+          expect(result[0]).to.equal(expectedResult)
+        })
+      })
+
+      // NOTE: This scenario would never happen, i.e. that we'd get a request to generate an SROC supplementary for a
+      // PRESROC financial year. But it demonstrates the service will only generate billing periods that start in the
+      // first year of SROC
+      describe("and the financial year ending '2021' is provided", () => {
+        beforeEach(() => {
+          financialYearEnding = 2021
+        })
+
+        it('returns no billing periods', () => {
+          const result = DetermineBillingPeriodsService.go(billRunType, financialYearEnding)
+
+          expect(result).to.be.empty()
+        })
+      })
+
+      describe("and the financial year ending '2023' is provided", () => {
+        beforeEach(() => {
+          financialYearEnding = 2023
+
+          expectedResult = {
+            startDate: new Date('2022-04-01'),
+            endDate: new Date('2023-03-31')
+          }
+        })
+
+        it('returns a single billing period for that financial year', () => {
+          const result = DetermineBillingPeriodsService.go(billRunType, financialYearEnding)
+
+          expect(result).to.have.length(1)
+          expect(result[0]).to.equal(expectedResult)
+        })
+      })
+    })
+
+    describe("and today's date is 2030-05-01 (more than 5 years from first SROC year end)", () => {
+      beforeEach(() => {
+        testDate = new Date('2030-05-01')
+        clock = Sinon.useFakeTimers(testDate)
+
         expectedResult = [
           {
             startDate: new Date('2030-04-01'),
@@ -114,39 +241,176 @@ describe('Billing Periods service', () => {
             endDate: new Date('2026-03-31')
           }
         ]
-
-        clock = Sinon.useFakeTimers(testDate)
       })
 
-      it('returns the expected date range', () => {
-        const result = DetermineBillingPeriodsService.go()
+      describe('and no financial year ending is provided', () => {
+        it("returns 6 billing periods starting with the 'current' financial year and working back", () => {
+          const result = DetermineBillingPeriodsService.go(billRunType)
 
-        expect(result).to.have.length(6)
-        expect(result).to.equal(expectedResult)
+          expect(result).to.have.length(6)
+          expect(result).to.equal(expectedResult)
+        })
+      })
+
+      describe("and the financial year ending '2026' is provided", () => {
+        beforeEach(() => {
+          financialYearEnding = 2026
+
+          expectedResult = [
+            {
+              startDate: new Date('2025-04-01'),
+              endDate: new Date('2026-03-31')
+            },
+            {
+              startDate: new Date('2024-04-01'),
+              endDate: new Date('2025-03-31')
+            },
+            {
+              startDate: new Date('2023-04-01'),
+              endDate: new Date('2024-03-31')
+            },
+            {
+              startDate: new Date('2022-04-01'),
+              endDate: new Date('2023-03-31')
+            }
+          ]
+        })
+
+        it('returns 4 billing periods starting with that financial year and working back to last SROC year', () => {
+          const result = DetermineBillingPeriodsService.go(billRunType, financialYearEnding)
+
+          expect(result).to.have.length(4)
+          expect(result).to.equal(expectedResult)
+        })
       })
     })
   })
 
-  describe('when a financial year is provided', () => {
-    const financialYearEnding = 2025
+  //   describe('and the date is in 2022 and falls within the 2022 financial year', () => {
+  //     beforeEach(() => {
+  //
+  //       expectedResult = {
+  //         startDate: new Date('2022-04-01'),
+  //         endDate: new Date('2023-03-31')
+  //       }
 
-    beforeEach(() => {
-      testDate = new Date('2024-10-10')
-      expectedResult = [
-        {
-          startDate: new Date('2024-04-01'),
-          endDate: new Date('2025-03-31')
-        }
-      ]
+  //       clock = Sinon.useFakeTimers(testDate)
+  //     })
 
-      clock = Sinon.useFakeTimers(testDate)
-    })
+  //     it('returns the expected date range', () => {
+  //       const result = DetermineBillingPeriodsService.go()
 
-    it('only returns the billing period for that financial year', () => {
-      const result = DetermineBillingPeriodsService.go(financialYearEnding)
+  //       expect(result).to.have.length(1)
+  //       expect(result[0]).to.equal(expectedResult)
+  //     })
+  //   })
 
-      expect(result).to.have.length(1)
-      expect(result).to.equal(expectedResult)
-    })
-  })
+  //   describe('and the date is in 2023 and falls within the 2022 financial year', () => {
+  //     beforeEach(() => {
+  //       testDate = new Date('2023-03-01')
+  //       expectedResult = {
+  //         startDate: new Date('2022-04-01'),
+  //         endDate: new Date('2023-03-31')
+  //       }
+
+  //       clock = Sinon.useFakeTimers(testDate)
+  //     })
+
+  //     it('returns the expected date range', () => {
+  //       const result = DetermineBillingPeriodsService.go()
+
+  //       expect(result).to.have.length(1)
+  //       expect(result[0]).to.equal(expectedResult)
+  //     })
+  //   })
+
+  //   describe('and the date is in 2023 and falls within the 2023 financial year', () => {
+  //     beforeEach(() => {
+  //       testDate = new Date('2023-10-10')
+  //       expectedResult = [
+  //         {
+  //           startDate: new Date('2023-04-01'),
+  //           endDate: new Date('2024-03-31')
+  //         },
+  //         {
+  //           startDate: new Date('2022-04-01'),
+  //           endDate: new Date('2023-03-31')
+  //         }
+  //       ]
+
+  //       clock = Sinon.useFakeTimers(testDate)
+  //     })
+
+  //     it('returns the expected date range', () => {
+  //       const result = DetermineBillingPeriodsService.go()
+
+  //       expect(result).to.have.length(2)
+  //       expect(result).to.equal(expectedResult)
+  //     })
+  //   })
+
+  //   describe('and the date is in 2030 and falls within the 2030 financial year', () => {
+  //     beforeEach(() => {
+  //       testDate = new Date('2030-10-10')
+  //       expectedResult = [
+  //         {
+  //           startDate: new Date('2030-04-01'),
+  //           endDate: new Date('2031-03-31')
+  //         },
+  //         {
+  //           startDate: new Date('2029-04-01'),
+  //           endDate: new Date('2030-03-31')
+  //         },
+  //         {
+  //           startDate: new Date('2028-04-01'),
+  //           endDate: new Date('2029-03-31')
+  //         },
+  //         {
+  //           startDate: new Date('2027-04-01'),
+  //           endDate: new Date('2028-03-31')
+  //         },
+  //         {
+  //           startDate: new Date('2026-04-01'),
+  //           endDate: new Date('2027-03-31')
+  //         },
+  //         {
+  //           startDate: new Date('2025-04-01'),
+  //           endDate: new Date('2026-03-31')
+  //         }
+  //       ]
+
+  //       clock = Sinon.useFakeTimers(testDate)
+  //     })
+
+  //     it('returns the expected date range', () => {
+  //       const result = DetermineBillingPeriodsService.go()
+
+  //       expect(result).to.have.length(6)
+  //       expect(result).to.equal(expectedResult)
+  //     })
+  //   })
+  // })
+
+  // describe('when a financial year is provided', () => {
+  //   const financialYearEnding = 2025
+
+  //   beforeEach(() => {
+  //     testDate = new Date('2024-10-10')
+  //     expectedResult = [
+  //       {
+  //         startDate: new Date('2024-04-01'),
+  //         endDate: new Date('2025-03-31')
+  //       }
+  //     ]
+
+  //     clock = Sinon.useFakeTimers(testDate)
+  //   })
+
+  //   it('only returns the billing period for that financial year', () => {
+  //     const result = DetermineBillingPeriodsService.go(financialYearEnding)
+
+  //     expect(result).to.have.length(1)
+  //     expect(result).to.equal(expectedResult)
+  //   })
+  // })
 })

--- a/test/services/bill-runs/setup/create.service.test.js
+++ b/test/services/bill-runs/setup/create.service.test.js
@@ -74,7 +74,7 @@ describe('Bill Runs Setup Create service', () => {
         '19a027c6-4aad-47d3-80e3-3917a4579a5b',
         'annual',
         'carol.shaw@atari.com',
-        null)
+        2024)
       ).to.be.true()
     })
   })
@@ -99,7 +99,7 @@ describe('Bill Runs Setup Create service', () => {
           '19a027c6-4aad-47d3-80e3-3917a4579a5b',
           'supplementary',
           'carol.shaw@atari.com',
-          null)
+          2024)
         ).to.be.true()
       })
     })
@@ -117,7 +117,7 @@ describe('Bill Runs Setup Create service', () => {
           '19a027c6-4aad-47d3-80e3-3917a4579a5b',
           'supplementary',
           'carol.shaw@atari.com',
-          null)
+          2024)
         ).to.be.true()
       })
     })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4403

We want our Billing & Data team to be able to generate supplementary bill runs all year round. However, at the moment they have to enforce a manual 'stop' on them until annual bill runs are completed. This is because of the 2 ways the engine operates.

Annual just bills for the current charge versions. It doesn't look at replaced charge versions or what was previously billed. supplementary does do these things. So, if the order is 'Annual -> Supplementary' then the bill will be correct. For example, supplementary calculates a debit of £100 for a charge version (the licence was flagged for 'reasons'!) but sees the £100 debit from the annual bill. They cancel each other out so the customer sees nothing.

If the order was `Supplementary -> Annual` though, annual doesn't look back at previous transactions. It would generate another debit to the customer for £100 leading to them being billed twice.

We could guarantee annual bills were raised on April 1 we wouldn't have a problem. However, the additional work that goes into preparing them and validating what the engine generates, means it can take some time. That leaves a window where a supplementary could be raised and the charges for a customer get messed up.

This has always been the case and billing & data have just had to deal with it by not generating supplementary. But that causes problems because bills start backing up that could be sent out.

So, this year we intend to solve the problem. We will amend our supplementary billing engine to check if an annual bill run for the same region has been raised in the current billing period. If it has we'll carry on as usual. If it hasn't, we'll move the financial year end back to the first year where one was raised. This will allow B&D to crack on with supplementary bills, at least for previous years and prevent charging data from being messed up.

The first step to achieving this is to refactor `DetermineBillingPeriods` to expect a `year` and a `billRunType`. It can then use this information to generate the billing periods accordingly, rather than always from the current billing period.

> How we determine the financial end year for a supplementary bill run will come in later changes.