### PR TITLE
Set abstraction and monitoring captions to always be plural

### DIFF
--- a/app/presenters/licences/view-licence.presenter.js
+++ b/app/presenters/licences/view-licence.presenter.js
@@ -43,7 +43,7 @@ function go (licence, licenceAbstractionConditions) {
   }
 
   const abstractionDetails = _parseAbstractionsAndSourceOfSupply(permitLicence)
-  const monitoringStationDetails = _generateMonitoringStation(licenceGaugingStations)
+  const monitoringStations = _generateMonitoringStation(licenceGaugingStations)
 
   const abstractionConditionDetails = _abstractionConditionDetails(licenceAbstractionConditions)
 
@@ -62,8 +62,7 @@ function go (licence, licenceAbstractionConditions) {
     licenceHolder: _generateLicenceHolder(licenceHolder),
     licenceName,
     licenceRef,
-    monitoringStationCaption: monitoringStationDetails.monitoringStationCaption,
-    monitoringStations: monitoringStationDetails.monitoringStations,
+    monitoringStations,
     pageTitle: `Licence ${licenceRef}`,
     purposes,
     region: region.displayName,
@@ -108,12 +107,8 @@ function _abstractionAmountDetails (purpose) {
 function _abstractionConditionDetails (licenceAbstractionConditions) {
   const { conditions, numberOfConditions } = licenceAbstractionConditions
 
-  const conditionText = numberOfConditions === 1 ? 'condition' : 'conditions'
-
   return {
-    caption: `Abstraction ${conditionText}`,
     conditions,
-    linkText: `View details of the abstraction ${conditionText}`,
     numberOfConditions
   }
 }
@@ -156,14 +151,7 @@ function _generateMonitoringStation (stations) {
     monitoringStations = Array.from(new Set(jsonArray)).map(JSON.parse)
   }
 
-  const monitoringStationCaption = monitoringStations.length > 1
-    ? 'Monitoring stations'
-    : 'Monitoring station'
-
-  return {
-    monitoringStationCaption,
-    monitoringStations
-  }
+  return monitoringStations
 }
 
 function _generatePurposes (licenceVersions) {

--- a/app/views/licences/tabs/summary.njk
+++ b/app/views/licences/tabs/summary.njk
@@ -91,7 +91,7 @@
     {% endif %}
 
     <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">{{ monitoringStationCaption }}</dt>
+        <dt class="govuk-summary-list__key">Monitoring stations</dt>
         <dd class="govuk-summary-list__value">
             {% if monitoringStations.length > 0 %}
                 <ul class="govuk-list govuk-!-margin-bottom-0">
@@ -111,7 +111,7 @@
     </div>
 
     <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">{{ abstractionConditionDetails.caption }}</dt>
+        <dt class="govuk-summary-list__key">Abstraction conditions</dt>
         <dd class="govuk-summary-list__value">
             <div>
                 {% if abstractionConditionDetails.numberOfConditions > 5 %}
@@ -126,7 +126,7 @@
                     {{ abstractionConditionDetails.conditions[0] }}
                 {% endif %}
             </div>
-            <a href="/licences/{{ documentId }}/conditions">{{ abstractionConditionDetails.linkText }}</a>
+            <a href="/licences/{{ documentId }}/conditions">View details of the abstraction conditions</a>
         </dd>
     </div>
 

--- a/test/presenters/licences/view-licence.presenter.test.js
+++ b/test/presenters/licences/view-licence.presenter.test.js
@@ -26,9 +26,7 @@ describe('View Licence presenter', () => {
       expect(result).to.equal({
         id: 'f1288f6c-8503-4dc1-b114-75c408a14bd0',
         abstractionConditionDetails: {
-          caption: 'Abstraction conditions',
           conditions: ['Derogation clause', 'General conditions', 'Non standard quantities'],
-          linkText: 'View details of the abstraction conditions',
           numberOfConditions: 4
         },
         abstractionPeriods: null,
@@ -43,7 +41,6 @@ describe('View Licence presenter', () => {
         licenceHolder: 'Unregistered licence',
         licenceName: 'Unregistered licence',
         licenceRef: '01/123',
-        monitoringStationCaption: 'Monitoring station',
         monitoringStations: [{
           gaugingStationId: 'ac075651-4781-4e24-a684-b943b98607ca',
           label: 'MEVAGISSEY FIRE STATION'
@@ -71,9 +68,7 @@ describe('View Licence presenter', () => {
           const result = ViewLicencePresenter.go(licence, licenceAbstractionConditions)
 
           expect(result.abstractionConditionDetails).to.equal({
-            caption: 'Abstraction conditions',
             conditions: ['Derogation clause', 'General conditions'],
-            linkText: 'View details of the abstraction conditions',
             numberOfConditions: 2
           })
         })
@@ -89,9 +84,7 @@ describe('View Licence presenter', () => {
           const result = ViewLicencePresenter.go(licence, licenceAbstractionConditions)
 
           expect(result.abstractionConditionDetails).to.equal({
-            caption: 'Abstraction conditions',
             conditions: ['Derogation clause'],
-            linkText: 'View details of the abstraction conditions',
             numberOfConditions: 2
           })
         })
@@ -108,12 +101,7 @@ describe('View Licence presenter', () => {
         const result = ViewLicencePresenter.go(licence, licenceAbstractionConditions)
 
         expect(result.abstractionConditionDetails).to.equal({
-          caption: 'Abstraction condition',
           conditions: ['Derogation clause'],
-          linkText: 'View details of the abstraction condition',
-          // NOTE: We set this to 2 on purpose as a reminder. A licence could have two purposes but the same condition
-          // applied to both. In number terms the licence has 2 conditions applied to it but from a UI point of view we
-          // display a distinct list of them
           numberOfConditions: 1
         })
       })
@@ -130,9 +118,7 @@ describe('View Licence presenter', () => {
         const result = ViewLicencePresenter.go(licence, licenceAbstractionConditions)
 
         expect(result.abstractionConditionDetails).to.equal({
-          caption: 'Abstraction conditions',
           conditions: [],
-          linkText: 'View details of the abstraction conditions',
           numberOfConditions: 0
         })
       })
@@ -354,10 +340,9 @@ describe('View Licence presenter', () => {
         licence.licenceGaugingStations = []
       })
 
-      it('will return the a singular caption and an empty array of monitoring station details', async () => {
+      it('will return an empty array of monitoring station details', async () => {
         const result = await ViewLicencePresenter.go(licence, licenceAbstractionConditions)
 
-        expect(result.monitoringStationCaption).to.equal('Monitoring station')
         expect(result.monitoringStations).to.equal([])
       })
     })
@@ -367,19 +352,17 @@ describe('View Licence presenter', () => {
         licence.licenceGaugingStations = null
       })
 
-      it('will return the a singular caption and an empty array of monitoring station details', async () => {
+      it('will return an empty array of monitoring station details', async () => {
         const result = await ViewLicencePresenter.go(licence, licenceAbstractionConditions)
 
-        expect(result.monitoringStationCaption).to.equal('Monitoring station')
         expect(result.monitoringStations).to.equal([])
       })
     })
 
     describe('when the licence has a gauging station', () => {
-      it('will return the a singular caption and an array populated with monitoring station details', async () => {
+      it('will return an array populated with monitoring station details', async () => {
         const result = await ViewLicencePresenter.go(licence, licenceAbstractionConditions)
 
-        expect(result.monitoringStationCaption).to.equal('Monitoring station')
         expect(result.monitoringStations).to.equal([{
           gaugingStationId: 'ac075651-4781-4e24-a684-b943b98607ca',
           label: 'MEVAGISSEY FIRE STATION'
@@ -398,10 +381,9 @@ describe('View Licence presenter', () => {
         }]
       })
 
-      it('will return the a plural caption and an array populated with multiple monitoring station details', async () => {
+      it('will return an array populated with multiple monitoring station details', async () => {
         const result = await ViewLicencePresenter.go(licence, licenceAbstractionConditions)
 
-        expect(result.monitoringStationCaption).to.equal('Monitoring stations')
         expect(result.monitoringStations).to.equal([{
           gaugingStationId: 'ac075651-4781-4e24-a684-b943b98607ca',
           label: 'MEVAGISSEY FIRE STATION'

--- a/test/services/licences/view-licence.service.test.js
+++ b/test/services/licences/view-licence.service.test.js
@@ -47,9 +47,7 @@ describe('View Licence service', () => {
 
         expect(result).to.equal({
           abstractionConditionDetails: {
-            caption: 'Abstraction conditions',
             conditions: [],
-            linkText: 'View details of the abstraction conditions',
             numberOfConditions: 0
           },
           abstractionPeriods: null,
@@ -67,7 +65,6 @@ describe('View Licence service', () => {
           licenceHolder: 'Unregistered licence',
           licenceName: 'Unregistered licence',
           licenceRef: '01/130/R01',
-          monitoringStationCaption: 'Monitoring station',
           monitoringStations: [],
           pageTitle: 'Licence 01/130/R01',
           purposes: null,


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4332

As part of the testing for this ticket we had a discussion around the pluralisation of the label names. It was getting confusing around when to use the s or not. After discussing it with the design team it was agreed to keep both labels plural.