### PR TITLE
Fix error in match & allocate service crashing app

### DIFF
--- a/app/services/bill-runs/two-part-tariff/determine-licence-issues.service.js
+++ b/app/services/bill-runs/two-part-tariff/determine-licence-issues.service.js
@@ -12,7 +12,7 @@ const { twoPartTariffReviewIssues } = require('../../../lib/static-lookups.lib.j
  *
  * @param {module:LicenceModel} licence - the two-part tariff licence included in the bill run
  */
-async function go (licence) {
+function go (licence) {
   const { returnLogs: licenceReturnLogs, chargeVersions } = licence
 
   const allReturnIssues = _determineReturnLogsIssues(licenceReturnLogs, licence)

--- a/app/services/bill-runs/two-part-tariff/match-and-allocate.service.js
+++ b/app/services/bill-runs/two-part-tariff/match-and-allocate.service.js
@@ -39,7 +39,7 @@ async function go (billRun, billingPeriod) {
 }
 
 async function _process (licences, billingPeriod, billRun) {
-  licences.forEach(async (licence) => {
+  for (const licence of licences) {
     await PrepareReturnLogsService.go(licence, billingPeriod)
 
     const { chargeVersions, returnLogs } = licence
@@ -67,9 +67,9 @@ async function _process (licences, billingPeriod, billRun) {
       })
     })
 
-    await DetermineLicenceIssuesService.go(licence)
+    DetermineLicenceIssuesService.go(licence)
     await PersistAllocatedLicenceToResultsService.go(billRun.id, licence)
-  })
+  }
 }
 
 module.exports = {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4375

Spotted whilst working on [Fix licence issues failing to insert for review](https://github.com/DEFRA/water-abstraction-system/pull/867). When `PersistAllocatedLicenceToResultsService` errored trying to insert a record it was causing an uncaught exception that was crashing the app.

After investigating the issue we have spotted it is because `MatchAndAllocateService` is using a `forEach()` to call asynchronous code.

- [Using async/await in a forEach loop (you can't)](https://blog.devgenius.io/using-async-await-in-a-foreach-loop-you-cant-c174b31999bd)
- [Do not use forEach with async-await](https://gist.github.com/joeytwiddle/37d2085425c049629b80956d3c618971)

If we switch to a `for...of` loop instead any errors thrown within the loop, even from `PersistAllocatedLicenceToResultsService` get caught as expected by the top level `try/catch` in `ProcessBillRun` and the bill run marked as errored.

Also, whilst looking into this we spotted that `DetermineLicenceIssuesService` has been made `async` even though it is doing nothing asynchronous. We use this opportunity to fix that as well.