### PR TITLE
Fix FetchMatchingBillRunService for PRESROC 2PT

### DIFF
--- a/app/services/bill-runs/fetch-matching-bill-run.service.js
+++ b/app/services/bill-runs/fetch-matching-bill-run.service.js
@@ -70,7 +70,7 @@ function _applySupplementaryWhereClauses (query) {
 }
 
 function _applyTwoPartTariffWhereClauses (query, financialYearEnding, summer) {
-  if (['2022', '2021'].includes(financialYearEnding)) {
+  if (financialYearEnding <= 2022) {
     query.where('summer', summer)
   }
 

--- a/app/services/bill-runs/fetch-matching-bill-run.service.js
+++ b/app/services/bill-runs/fetch-matching-bill-run.service.js
@@ -52,7 +52,7 @@ async function go (regionId, batchType, financialYearEnding, summer = false) {
     .where('regionId', regionId)
     .where('batchType', batchType)
 
-  _applyWhereClauses(baseQuery, batchType, summer, financialYearEnding)
+  _applyWhereClauses(baseQuery, batchType, financialYearEnding, summer)
 
   return _fetch(baseQuery)
 }
@@ -80,7 +80,7 @@ function _applyTwoPartTariffWhereClauses (query, financialYearEnding, summer) {
     .limit(1)
 }
 
-function _applyWhereClauses (baseQuery, batchType, summer, financialYearEnding) {
+function _applyWhereClauses (baseQuery, batchType, financialYearEnding, summer) {
   if (batchType === 'annual') {
     _applyAnnualWhereClauses(baseQuery, financialYearEnding)
   } else if (batchType === 'supplementary') {

--- a/app/services/bill-runs/fetch-matching-bill-run.service.js
+++ b/app/services/bill-runs/fetch-matching-bill-run.service.js
@@ -7,6 +7,8 @@
 
 const BillRunModel = require('../../models/bill-run.model.js')
 
+const LAST_PRESROC_YEAR = 2022
+
 /**
  * Fetch bill run(s) that match the options provided
  *
@@ -70,7 +72,7 @@ function _applySupplementaryWhereClauses (query) {
 }
 
 function _applyTwoPartTariffWhereClauses (query, financialYearEnding, summer) {
-  if (financialYearEnding <= 2022) {
+  if (financialYearEnding <= LAST_PRESROC_YEAR) {
     query.where('summer', summer)
   }
 

--- a/app/services/bill-runs/fetch-matching-bill-run.service.js
+++ b/app/services/bill-runs/fetch-matching-bill-run.service.js
@@ -2,7 +2,7 @@
 
 /**
  * Fetch bill run(s) that match the options provided
- * @module ExistsService
+ * @module FetchMatchingBillRunService
  */
 
 const BillRunModel = require('../../models/bill-run.model.js')

--- a/test/services/bill-runs/fetch-matching-bill-run.service.test.js
+++ b/test/services/bill-runs/fetch-matching-bill-run.service.test.js
@@ -89,36 +89,37 @@ describe('Fetch Matching Bill Run service', () => {
         })
 
         describe('and the financial year is in the PRESROC period', () => {
-          describe("and 'summer' is set to false", () => {
-            describe('and a bill run for the same financial year exists', () => {
-              beforeEach(async () => {
-                const billRun = await BillRunHelper.add({
-                  regionId, batchType: 'two_part_tariff', status: 'sent', toFinancialYearEnding: 2022, summer: false
-                })
-                matchingBillRunId = billRun.id
-              })
+          let matchingSummerBillRunId
+          let matchingWinterBillRunId
 
-              it('returns the matching bill run', async () => {
-                const results = await FetchMatchingBillRunService.go(regionId, 'two_part_tariff', 2022, false)
-
-                expect(results[0].id).to.equal(matchingBillRunId)
-              })
+          beforeEach(async () => {
+            let billRun = await BillRunHelper.add({
+              regionId, batchType: 'two_part_tariff', status: 'sent', toFinancialYearEnding: 2022, summer: true
             })
+            matchingSummerBillRunId = billRun.id
+
+            billRun = await BillRunHelper.add({
+              regionId, batchType: 'two_part_tariff', status: 'sent', toFinancialYearEnding: 2022, summer: false
+            })
+            matchingWinterBillRunId = billRun.id
           })
 
           describe("and 'summer' is set to true", () => {
             describe('and a bill run for the same financial year exists', () => {
-              beforeEach(async () => {
-                const billRun = await BillRunHelper.add({
-                  regionId, batchType: 'two_part_tariff', status: 'sent', toFinancialYearEnding: 2022, summer: true
-                })
-                matchingBillRunId = billRun.id
-              })
-
               it('returns the matching bill run', async () => {
                 const results = await FetchMatchingBillRunService.go(regionId, 'two_part_tariff', 2022, true)
 
-                expect(results[0].id).to.equal(matchingBillRunId)
+                expect(results[0].id).to.equal(matchingSummerBillRunId)
+              })
+            })
+          })
+
+          describe("and 'summer' is set to false", () => {
+            describe('and a bill run for the same financial year exists', () => {
+              it('returns the matching bill run', async () => {
+                const results = await FetchMatchingBillRunService.go(regionId, 'two_part_tariff', 2022, false)
+
+                expect(results[0].id).to.equal(matchingWinterBillRunId)
               })
             })
           })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4375

In testing, it was found that when you complete the journey to set up a PRESROC two-part tariff bill run and select 'winter and all year' as the season you get a match for the summer 2PT bill run in that year returned.

After investigating the issue it's not that we are matching the wrong season but that we are not filtering by season at all. If in the environment where the tests were being run the winter 2PT had been created last then it would always be the result returned first.

The flaw is a result of initially passing in the values selected in the UI raw, and then switching to transformed values. We always get values back from the UI as strings and this is what we are matching financial year against to determine if we need to apply the season clause to our query. But at some point in our development, we changed that to a number, which means it now never matches.

```javascript
  // financialYearEnding is 2022 not '2022'!
  if (['2022', '2021'].includes(financialYearEnding)) {
    query.where('summer', summer)
  }
```

This change fixes the issue.