### PR TITLE
Bump supplementary end year if no annual bill run

### DIFF
--- a/app/services/bill-runs/setup/determine-financial-year-end.service.js
+++ b/app/services/bill-runs/setup/determine-financial-year-end.service.js
@@ -1,0 +1,73 @@
+'use strict'
+
+/**
+ * Determine the financial end year to use for a new bill run
+ * @module DetermineFinancialEndYearService
+ */
+
+const BillRunModel = require('../../../models/bill-run.model.js')
+const { determineCurrentFinancialYear } = require('../../../lib/general.lib.js')
+
+/**
+ * Determine the financial year to use for a new bill run
+ *
+ * Used by the `ExistsService` when determining what financial end year to use for a bill run.
+ *
+ * In the case of annual it is simply the current financial year end.
+ *
+ * For two-part tariff it is the year selected by the user.
+ *
+ * Supplementary billing is more complicated. Generally, it also is the current financial year end. But we want our
+ * users to be able to create supplementary bill runs all year round. However, when the financial year switches over if
+ * the annual bill run for a region has not been run a supplementary will cause problems.
+ *
+ * Annual bill runs do not take into account what has been billed that year. They just work through the valid charge
+ * versions for the region and financial year, generate the transactions and send them to the Charging Module API to
+ * create a charge and a bill run.
+ *
+ * Because of this if a supplementary is created _before_ the annual customers will get charged twice. So, to avoid this
+ * when a user is attempting to create a supplementary bill run we have to determine when the last 'sent' annual bill
+ * run was. If its end year matches the current year we do nothing.
+ *
+ * If it doesn't, we 'bump' the financial end year to back to the year of the last annual bill run.
+ *
+ * @returns {Promise<Number>} The financial end year to use for selected bill run type and region
+ */
+async function go (regionId, billRunType, year = null) {
+  const currentFinancialYear = determineCurrentFinancialYear()
+  const currentFinancialYearEnd = currentFinancialYear.endDate.getFullYear()
+
+  if (billRunType === 'supplementary') {
+    return _determineSupplementaryEndYear(regionId, currentFinancialYearEnd)
+  }
+
+  if (year && billRunType.startsWith('two_part')) {
+    return Number(year)
+  }
+
+  return currentFinancialYearEnd
+}
+
+async function _determineSupplementaryEndYear (regionId, currentFinancialYearEnd) {
+  const billRun = await BillRunModel.query()
+    .select([
+      'id',
+      'toFinancialYearEnding'
+    ])
+    .where('regionId', regionId)
+    .where('status', 'sent')
+    // NOTE: We would never have an annual bill run with a toFinancialYearEnding greater than the current one in a
+    // 'real' environment. But we often manipulate bill run dates whilst testing to move annual bill runs out of the
+    // way. We would hate to break this ability so we have logic to only look at sent annual bill runs with an end year
+    // less than or equal to the current financial end year
+    .where('toFinancialYearEnding', '<=', currentFinancialYearEnd)
+    .orderBy('toFinancialYearEnding', 'desc')
+    .limit(1)
+    .first()
+
+  return billRun.toFinancialYearEnding
+}
+
+module.exports = {
+  go
+}

--- a/test/services/bill-runs/setup/determine-financial-year-end.service.test.js
+++ b/test/services/bill-runs/setup/determine-financial-year-end.service.test.js
@@ -1,0 +1,128 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const BillRunHelper = require('../../../support/helpers/bill-run.helper.js')
+const DatabaseSupport = require('../../../support/database.js')
+const { determineCurrentFinancialYear } = require('../../../../app/lib/general.lib.js')
+const RegionHelper = require('../../../support/helpers/region.helper.js')
+
+// Thing under test
+const DetermineFinancialYearEndService = require('../../../../app/services/bill-runs/setup/determine-financial-year-end.service.js')
+
+describe('Bill Runs Setup Determine Financial Year End service', () => {
+  const currentFinancialYear = determineCurrentFinancialYear()
+
+  let currentFinancialYearEnd
+  let regionId
+
+  beforeEach(async () => {
+    await DatabaseSupport.clean()
+
+    currentFinancialYearEnd = currentFinancialYear.endDate.getFullYear()
+
+    const region = await RegionHelper.add()
+    regionId = region.id
+  })
+
+  describe('when called for an annual bill run', () => {
+    it('returns the current financial year end', async () => {
+      const result = await DetermineFinancialYearEndService.go(regionId, 'annual')
+
+      expect(result).to.equal(currentFinancialYearEnd)
+    })
+  })
+
+  describe('when called for a two-part tariff bill run', () => {
+    describe("and 'year' is not provided", () => {
+      it('returns the current financial year end', async () => {
+        const result = await DetermineFinancialYearEndService.go(regionId, 'two_part_tariff')
+
+        expect(result).to.equal(currentFinancialYearEnd)
+      })
+    })
+
+    describe("and 'year' is provided", () => {
+      it('returns the year provided', async () => {
+        const result = await DetermineFinancialYearEndService.go(regionId, 'two_part_tariff', 2023)
+
+        expect(result).to.equal(2023)
+      })
+    })
+  })
+
+  describe('when called for an supplementary bill run', () => {
+    describe("and the last 'sent' annual bill run is in the current financial year", () => {
+      beforeEach(async () => {
+        await BillRunHelper.add({
+          batchType: 'annual', regionId, status: 'sent', toFinancialYearEnding: currentFinancialYearEnd
+        })
+      })
+
+      it('returns the current financial year end', async () => {
+        const result = await DetermineFinancialYearEndService.go(regionId, 'supplementary')
+
+        expect(result).to.equal(currentFinancialYearEnd)
+      })
+    })
+
+    describe("and the last 'sent' annual bill run is in the previous financial year", () => {
+      beforeEach(async () => {
+        await BillRunHelper.add({
+          batchType: 'annual', regionId, status: 'sent', toFinancialYearEnding: currentFinancialYearEnd - 1
+        })
+      })
+
+      it('returns the current financial year end', async () => {
+        const result = await DetermineFinancialYearEndService.go(regionId, 'supplementary')
+
+        expect(result).to.equal(currentFinancialYearEnd - 1)
+      })
+    })
+
+    // NOTE: This would never happen in a 'real' environment. But we often manipulate bill run dates whilst testing
+    // to move annual bill runs out of the way. We would hate to break this ability so we have logic to only look at
+    // sent annual bill runs with an end year less than or equal to the current financial end year
+    describe("and the last 'sent' annual bill run is in the next financial year", () => {
+      beforeEach(async () => {
+        await Promise.all([
+          BillRunHelper.add({
+            batchType: 'annual', regionId, status: 'sent', toFinancialYearEnding: currentFinancialYearEnd
+          }),
+          BillRunHelper.add({
+            batchType: 'annual', regionId, status: 'sent', toFinancialYearEnding: currentFinancialYearEnd + 1
+          })
+        ])
+      })
+
+      it('returns the financial year end of the bill run in the current year', async () => {
+        const result = await DetermineFinancialYearEndService.go(regionId, 'supplementary')
+
+        expect(result).to.equal(currentFinancialYearEnd)
+      })
+    })
+
+    // NOTE: This would never happen in a 'real' environment. All regions have 'sent' annual bill runs so a result
+    // would always be found
+    describe("and there is no 'sent' annual bill run for the same region", () => {
+      beforeEach(async () => {
+        await BillRunHelper.add({
+          batchType: 'annual',
+          regionId: '576fde36-c19f-4e20-b852-7328d20d2aa0',
+          status: 'sent',
+          toFinancialYearEnding: currentFinancialYearEnd
+        })
+      })
+
+      it('throws an error', async () => {
+        await expect(DetermineFinancialYearEndService.go(regionId, 'supplementary')).to.reject()
+      })
+    })
+  })
+})

--- a/test/services/bill-runs/setup/determine-financial-year-end.service.test.js
+++ b/test/services/bill-runs/setup/determine-financial-year-end.service.test.js
@@ -79,7 +79,7 @@ describe('Bill Runs Setup Determine Financial Year End service', () => {
         })
       })
 
-      it('returns the current financial year end', async () => {
+      it('returns the previous financial year end', async () => {
         const result = await DetermineFinancialYearEndService.go(regionId, 'supplementary')
 
         expect(result).to.equal(currentFinancialYearEnd - 1)

--- a/test/services/bill-runs/setup/exists.service.test.js
+++ b/test/services/bill-runs/setup/exists.service.test.js
@@ -15,6 +15,7 @@ const SessionHelper = require('../../../support/helpers/session.helper.js')
 
 // Things we need to stub
 const DetermineBlockingBillRunService = require('../../../../app/services/bill-runs/determine-blocking-bill-run.service.js')
+const DetermineFinancialYearEndService = require('../../../../app/services/bill-runs/setup/determine-financial-year-end.service.js')
 
 // Thing under test
 const ExistsService = require('../../../../app/services/bill-runs/setup/exists.service.js')
@@ -45,6 +46,8 @@ describe('Bill Runs Setup Exists service', () => {
             season: 'summer'
           }
         })
+
+        Sinon.stub(DetermineFinancialYearEndService, 'go').resolves(2022)
       })
 
       describe('and no matching bill runs exist', () => {
@@ -105,6 +108,8 @@ describe('Bill Runs Setup Exists service', () => {
             season: 'summer'
           }
         })
+
+        Sinon.stub(DetermineFinancialYearEndService, 'go').resolves(currentFinancialEndYear)
       })
 
       describe('and no matching bill runs exist', () => {
@@ -165,6 +170,8 @@ describe('Bill Runs Setup Exists service', () => {
             season: 'summer'
           }
         })
+
+        Sinon.stub(DetermineFinancialYearEndService, 'go').resolves(currentFinancialEndYear)
       })
 
       describe('and no matching bill runs exist', () => {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4403

We want our Billing & Data team to be able to generate supplementary bill runs all year round. However, at the moment they have to enforce a manual 'stop' on them until annual bill runs are completed. This is because of the 2 ways the engine operates.

Annual just bills for the current charge versions. It doesn't look at replaced charge versions or what was previously billed. supplementary does do these things. So, if the order is 'Annual -> Supplementary' then the bill will be correct. For example, supplementary calculates a debit of £100 for a charge version (the licence was flagged for 'reasons'!) but sees the £100 debit from the annual bill. They cancel each other out so the customer sees nothing.

If the order was `Supplementary -> Annual` though, annual doesn't look back at previous transactions. It would generate another debit to the customer for £100 leading to them being billed twice.

We could guarantee annual bills were raised on April 1 we wouldn't have a problem. However, the additional work that goes into preparing them and validating what the engine generates, means it can take some time. That leaves a window where a supplementary could be raised and the charges for a customer get messed up.

This has always been the case and billing & data have just had to deal with it by not generating supplementary. But that causes problems because bills start backing up that could be sent out.

So, this year we intend to solve the problem. We will amend our supplementary billing engine to check if an annual bill run for the same region has been raised in the current billing period. If it has we'll carry on as usual. If it hasn't, we'll move the financial year end back to the first year where one was raised. This will allow B&D to crack on with supplementary bills, at least for previous years and prevent charging data from being messed up.

The first step was to refactor [Refactor DetermineBillingPeriods to use type](https://github.com/DEFRA/water-abstraction-system/pull/864). It can then use this information to generate the billing periods accordingly, rather than always from the current billing period.

Now that service will work appropriately if given a type and year we can implement determining _what_ that year is.