### PR TITLE
Fix bump supp. end year if no annual bill run

### DIFF
--- a/app/services/bill-runs/setup/create.service.js
+++ b/app/services/bill-runs/setup/create.service.js
@@ -50,15 +50,7 @@ async function _triggerBillRun (regionId, batchType, user, year, existingBillRun
     return null
   }
 
-  // TODO: We do want to send the year through. However, the billing engine was written initially for supplementary
-  // then extended for annual and soon to be amended again for two-part tariff. 2PT has a short term requirement to
-  // handle a year being provided by the user but once a back log of bill runs has been completed this will no longer
-  // be the case (it will work like the other and just use the current year). Providing a year breaks supplementary
-  // and isn't the intended expectation for annual. So, until we update our billing engine (soon to be because of
-  // WATER-4403) we trigger the start of the process in the same way the legacy create bill run process would.
-  const yearForBillRun = batchType === 'two_part_tariff' ? year : null
-
-  return StartBillRunProcessService.go(regionId, batchType, userEmail, yearForBillRun)
+  return StartBillRunProcessService.go(regionId, batchType, userEmail, year)
 }
 
 async function _triggerLegacyBillRun (regionId, batchType, user, year, summer, existingBillRun = null) {

--- a/test/services/bill-runs/setup/create.service.test.js
+++ b/test/services/bill-runs/setup/create.service.test.js
@@ -74,7 +74,7 @@ describe('Bill Runs Setup Create service', () => {
         '19a027c6-4aad-47d3-80e3-3917a4579a5b',
         'annual',
         'carol.shaw@atari.com',
-        null)
+        2024)
       ).to.be.true()
     })
   })
@@ -99,7 +99,7 @@ describe('Bill Runs Setup Create service', () => {
           '19a027c6-4aad-47d3-80e3-3917a4579a5b',
           'supplementary',
           'carol.shaw@atari.com',
-          null)
+          2024)
         ).to.be.true()
       })
     })
@@ -117,7 +117,7 @@ describe('Bill Runs Setup Create service', () => {
           '19a027c6-4aad-47d3-80e3-3917a4579a5b',
           'supplementary',
           'carol.shaw@atari.com',
-          null)
+          2024)
         ).to.be.true()
       })
     })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4403

In [Bump supplementary end year if no annual bill run](https://github.com/DEFRA/water-abstraction-system/pull/875) we added logic that would mean when creating a new supplementary bill run the engine could tell if an annual bill run existed for the same year and region.

If one doesn't it will make a mess of the billing for customers if the supplementary happened before the annual. But we don't want to block users from working. So, instead, we bump the financial end year to use back to the same as the last 'sent' annual bill run for that region.

We even [Refactor DetermineBillingPeriods to use type](https://github.com/DEFRA/water-abstraction-system/pull/864) so it would know to use the calculated year when determining the billing periods for the supplementary bill run.

What we forgot to do was remove a [temporary fix](https://github.com/DEFRA/water-abstraction-system/pull/859) we'd added until this work can be completed.

This means the year we've calculated is being dropped and not passed to `DetermineBillingPeriods`. This change fixes that!