### PR TITLE
Update badge macro to support 2pt

### DIFF
--- a/app/presenters/bill-runs/two-part-tariff/review-bill-run.presenter.js
+++ b/app/presenters/bill-runs/two-part-tariff/review-bill-run.presenter.js
@@ -69,7 +69,9 @@ function _prepareLicences (licences) {
       id: licence.licenceId,
       licenceRef: licence.licenceRef,
       licenceHolder: licence.licenceHolder,
-      status: licence.status,
+      // Note: to use the badge macro in the view the status for 'ready' needs to be changed to 'reviewReady' as ready
+      // already exists in the macro with a different colour
+      status: licence.status === 'ready' ? 'reviewReady' : licence.status,
       issue: _getIssueOnLicence(licence.issues)
     })
   }

--- a/app/presenters/bill-runs/two-part-tariff/review-licence.presenter.js
+++ b/app/presenters/bill-runs/two-part-tariff/review-licence.presenter.js
@@ -23,6 +23,8 @@ function go (billRun, licence) {
     licence: {
       licenceId: licence[0].licenceId,
       licenceRef: licence[0].licenceRef,
+      // Note: to use the badge macro in the view the status for 'ready' needs to be changed to 'reviewReady' as ready
+      // already exists in the macro with a different colour
       status: licence[0].status === 'ready' ? 'reviewReady' : licence[0].status,
       licenceHolder: licence[0].licenceHolder
     },
@@ -83,6 +85,8 @@ function _chargeElementDetails (reviewChargeReference, chargePeriod) {
 
     return {
       elementNumber,
+      // Note: to use the badge macro in the view the status for 'ready' needs to be changed to 'reviewReady' as ready
+      // already exists in the macro with a different colour
       elementStatus: reviewChargeElement.status === 'ready' ? 'reviewReady' : reviewChargeElement.status,
       elementDescription: reviewChargeElement.chargeElement.description,
       dates,

--- a/app/presenters/bill-runs/two-part-tariff/review-licence.presenter.js
+++ b/app/presenters/bill-runs/two-part-tariff/review-licence.presenter.js
@@ -23,7 +23,7 @@ function go (billRun, licence) {
     licence: {
       licenceId: licence[0].licenceId,
       licenceRef: licence[0].licenceRef,
-      status: licence[0].status,
+      status: licence[0].status === 'ready' ? 'reviewReady' : licence[0].status,
       licenceHolder: licence[0].licenceHolder
     },
     matchedReturns: _matchedReturns(licence[0].reviewReturns),
@@ -83,7 +83,7 @@ function _chargeElementDetails (reviewChargeReference, chargePeriod) {
 
     return {
       elementNumber,
-      elementStatus: reviewChargeElement.status,
+      elementStatus: reviewChargeElement.status === 'ready' ? 'reviewReady' : reviewChargeElement.status,
       elementDescription: reviewChargeElement.chargeElement.description,
       dates,
       issues,

--- a/app/views/bill-runs/review-licence.njk
+++ b/app/views/bill-runs/review-licence.njk
@@ -4,7 +4,8 @@
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
-{% from "macros/badge.njk" import badge %}
+{% from "macros/badge.njk" import statusBadge %}
+
 
 
 {% block breadcrumbs %}
@@ -25,17 +26,8 @@
       <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">{{pageTitle}}</h1>
 
       {# Status badge #}
-      {% if licence.status == 'review' %}
-        {% set colour = "govuk-tag--blue govuk-!-font-size-16" %}
-      {% else %}
-        {% set colour = "govuk-tag--green govuk-!-font-size-16" %}
-      {% endif %}
-
       <p class="govuk-body">
-        {{govukTag({
-          text: licence.status,
-          classes: colour
-        })}}
+        {{ statusBadge(licence.status) }}
       </p>
     </div>
   </div>
@@ -83,15 +75,10 @@
     {% for return in matchedReturns %}
       {% set matchedReturnIndex = loop.index0 %}
 
-      {% if return.returnStatus == 'overdue' or return.returnStatus == 'query' %}
-        {% set colour = "govuk-tag--red"%}
-        {% set returnLink = "/return/internal?returnId=" + return.returnId %}
-      {% elif return.status == 'void' %}
-        {% set colour = "govuk-tag--grey" %}
-        {% set returnLink = "/return/internal?returnId=" + return.returnId %}
+      {% if return.status == 'completed' %}
+        {% set returnLink = "/returns/return?id=" + return.returnId %}
       {% else %}
-        {% set colour = "govuk-tag--green" %}
-        {% set returnLink = "/returns/return?id=" + return.returnId%}
+        {% set returnLink = "/return/internal?returnId=" + return.returnId%}
       {% endif %}
 
       {% set action %}
@@ -107,10 +94,7 @@
       {% endset %}
 
       {% set statusTag %}
-        {{govukTag({
-          text: return.returnStatus,
-          classes: colour + ' govuk-!-font-size-14'
-        })}}
+        {{ statusBadge(return.returnStatus) }}
       {% endset %}
 
       {% set issues = '' %}
@@ -176,16 +160,14 @@
     {% for return in unmatchedReturns %}
       {% set unmatchedReturnIndex = loop.index0 %}
 
-      {% if return.returnStatus == 'overdue' or return.returnStatus == 'query' %}
-        {% set colour = "govuk-tag--red"%}
-      {% elif return.status == 'void' %}
-        {% set colour = "govuk-tag--grey" %}
+      {% if return.status == 'completed' %}
+        {% set returnLink = "/returns/return?id=" + return.returnId %}
       {% else %}
-        {% set colour = "govuk-tag--green" %}
+        {% set returnLink = "/return/internal?returnId=" + return.returnId%}
       {% endif %}
 
       {% set action %}
-        <a class="govuk-link" href="/licences/{{ licence.licenceId }}#returns">{{ return.reference }}<span class="govuk-visually-hidden"></a>
+        <a class="govuk-link" href="{{returnLink}}">{{ return.reference }}<span class="govuk-visually-hidden"></a>
         <div>{{return.dates}}</div>
       {% endset %}
 
@@ -197,10 +179,7 @@
       {% endset %}
 
       {% set statusTag %}
-        {{govukTag({
-          text: return.returnStatus,
-          classes: colour + ' govuk-!-font-size-14'
-        })}}
+        {{ statusBadge(return.returnStatus) }}
       {% endset %}
 
       {% set issues = '' %}
@@ -349,21 +328,12 @@
                   {% set chargeElementIndex = loop.index0 %}
                     {% set elementRows = [] %}
 
-                    {# Status badge #}
-                    {% if chargeElement.elementStatus == 'review' %}
-                      {% set elementColour = "govuk-tag--blue govuk-!-font-size-16" %}
-                    {% else %}
-                      {% set elementColour = "govuk-tag--green govuk-!-font-size-16" %}
-                    {% endif %}
-
                     <div class="govuk-!-margin-top-6">
                       <div class="tag-wrapper">
                         <span class="govuk-body govuk-!-font-weight-regular">{{chargeElement.elementNumber}}</span>
                         <span class="tag-element">
-                          {{govukTag({
-                            text: chargeElement.elementStatus,
-                            classes: elementColour
-                          })}}
+                          {# Status badge #}
+                          {{ statusBadge(chargeElement.elementStatus) }}
                         </span>
                         <h3 class="govuk-heading-s govuk-!-margin-bottom-1">{{chargeElement.elementDescription}}
                           <div>

--- a/app/views/bill-runs/review.njk
+++ b/app/views/bill-runs/review.njk
@@ -9,6 +9,7 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/tag/macro.njk" import govukTag %}
+{% from "macros/badge.njk" import statusBadge %}
 
 {% block breadcrumbs %}
   {# Back link #}
@@ -263,17 +264,9 @@
   {% set tableRows = [] %}
     {% if preparedLicences.length > 0 %}
       {% for licence in preparedLicences %}
-        {% if licence.status == 'review' %}
-          {% set colour = "govuk-tag--blue" %}
-        {% else %}
-          {% set colour = "govuk-tag--green" %}
-        {% endif %}
 
         {% set statusTag %}
-          {{govukTag({
-            text: licence.status,
-            classes: colour
-          })}}
+          {{ statusBadge(licence.status) }}
         {% endset %}
 
         {% set action %}

--- a/app/views/macros/badge.njk
+++ b/app/views/macros/badge.njk
@@ -16,6 +16,14 @@
     {% set text = 'ready' %}
   {% elif type === '2ptReview' %}
     {% set classes = "govuk-tag--blue" %}
+  {% elif type === 'completed' %}
+    {% set classes = "govuk-tag--green govuk-!-font-size-14"%}
+  {% elif type === 'void' %}
+    {% set classes = "govuk-tag--grey govuk-!-font-size-14"  %}
+  {% elif type === 'overdue' %}
+    {% set classes = "govuk-tag--red govuk-!-font-size-14" %}
+  {% elif type === 'received' %}
+    {% set classes = "govuk-tag--blue govuk-!-font-size-14" %}
   {% else %}
     {% set classes = "govuk-tag--blue govuk-!-font-size-27" %}
   {% endif %}
@@ -42,6 +50,15 @@
     {% set badgeType = '2ptReady' %}
   {% elif status === 'review' %}
     {% set badgeType = '2ptReview' %}
+  {# two-part tariff return statuses #}
+  {% elif status === 'completed' %}
+    {% set badgeType = 'completed' %}
+  {% elif status === 'void' %}
+    {% set badgeType = 'void' %}
+  {% elif status === 'overdue' or status === 'query' %}
+    {% set badgeType = 'overdue' %}
+  {% elif status === 'received' %}
+    {% set badgeType = 'received' %}
   {% endif %}
 
   {{ badge(status, badgeType) }}

--- a/app/views/macros/badge.njk
+++ b/app/views/macros/badge.njk
@@ -11,9 +11,11 @@
     {% set classes = "govuk-tag--orange govuk-!-font-size-27" %}
   {% elif type === 'success' %}
     {% set classes = "govuk-tag--green govuk-!-font-size-27" %}
-  {% elif type === 'reviewReady' %}
-    {% set classes = "govuk-tag--green govuk-!-font-size-27" %}
+  {% elif type === '2ptReady' %}
+    {% set classes = "govuk-tag--green" %}
     {% set text = 'ready' %}
+  {% elif type === '2ptReview' %}
+    {% set classes = "govuk-tag--blue" %}
   {% else %}
     {% set classes = "govuk-tag--blue govuk-!-font-size-27" %}
   {% endif %}
@@ -27,7 +29,7 @@
 {% endmacro %}
 
 {% macro statusBadge(status) %}
-  {% if status === 'ready' or status === 'review' %}
+  {% if status === 'ready' %}
     {% set badgeType = 'info' %}
   {% elif status === 'sent' %}
     {% set badgeType = 'success' %}
@@ -37,7 +39,9 @@
     {% set badgeType = 'error' %}
   {# two part tariff review screens have a green `ready` status hence this is called `reviewReady`#}
   {% elif status === 'reviewReady' %}
-    {% set badgeType = 'reviewReady' %}
+    {% set badgeType = '2ptReady' %}
+  {% elif status === 'review' %}
+    {% set badgeType = '2ptReview' %}
   {% endif %}
 
   {{ badge(status, badgeType) }}

--- a/app/views/macros/badge.njk
+++ b/app/views/macros/badge.njk
@@ -11,6 +11,9 @@
     {% set classes = "govuk-tag--orange govuk-!-font-size-27" %}
   {% elif type === 'success' %}
     {% set classes = "govuk-tag--green govuk-!-font-size-27" %}
+  {% elif type === 'reviewReady' %}
+    {% set classes = "govuk-tag--green govuk-!-font-size-27" %}
+    {% set text = 'ready' %}
   {% else %}
     {% set classes = "govuk-tag--blue govuk-!-font-size-27" %}
   {% endif %}
@@ -24,7 +27,7 @@
 {% endmacro %}
 
 {% macro statusBadge(status) %}
-  {% if status === 'ready' %}
+  {% if status === 'ready' or status === 'review' %}
     {% set badgeType = 'info' %}
   {% elif status === 'sent' %}
     {% set badgeType = 'success' %}
@@ -32,6 +35,9 @@
     {% set badgeType = 'inactive' %}
   {% elif status === 'error' %}
     {% set badgeType = 'error' %}
+  {# two part tariff review screens have a green `ready` status hence this is called `reviewReady`#}
+  {% elif status === 'reviewReady' %}
+    {% set badgeType = 'reviewReady' %}
   {% endif %}
 
   {{ badge(status, badgeType) }}

--- a/test/presenters/bill-runs/two-part-tariff/review-bill-run.presenter.test.js
+++ b/test/presenters/bill-runs/two-part-tariff/review-bill-run.presenter.test.js
@@ -53,14 +53,14 @@ describe('Review Bill Run presenter', () => {
               id: 'cc4bbb18-0d6a-4254-ac2c-7409de814d7e',
               licenceRef: '1/11/11/*11/1111',
               licenceHolder: 'Big Farm Ltd',
-              status: 'ready',
+              status: 'reviewReady',
               issue: ''
             },
             {
               id: '395bdc01-605b-44f5-9d90-5836cc013799',
               licenceRef: '2/22/22/*S2/2222',
               licenceHolder: 'Bob Bobbles',
-              status: 'ready',
+              status: 'reviewReady',
               issue: 'Abstraction outside period'
             },
             {

--- a/test/presenters/bill-runs/two-part-tariff/review-licence.presenter.test.js
+++ b/test/presenters/bill-runs/two-part-tariff/review-licence.presenter.test.js
@@ -24,7 +24,7 @@ describe('Review Licence presenter', () => {
         licence: {
           licenceId: '786f0d83-eaf7-43c3-9de5-ec59e3de05ee',
           licenceRef: '01/49/80/4608',
-          status: 'ready',
+          status: 'reviewReady',
           licenceHolder: 'Licence Holder Ltd'
         },
         matchedReturns: [
@@ -68,7 +68,7 @@ describe('Review Licence presenter', () => {
                 chargeElements: [
                   {
                     elementNumber: 'Element 1 of 1',
-                    elementStatus: 'ready',
+                    elementStatus: 'reviewReady',
                     elementDescription: 'Trickle Irrigation - Direct',
                     dates: ['1 April 2022 to 5 June 2022'],
                     issues: [''],


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4370

As part of the ongoing work building the two-part tariff bill run pages, this PR is to adapt the badge macro to support the two-part tariff review statuses and update the pages that use badges.