### PR TITLE
Add review badge, rename existing and call it tag!

### DIFF
--- a/app/views/bill-licences/remove.njk
+++ b/app/views/bill-licences/remove.njk
@@ -5,7 +5,7 @@
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 
-{% from "macros/badge.njk" import statusBadge %}
+{% from "macros/bill-run-status-tag.njk" import statusTag %}
 
 {% block breadcrumbs %}
   {# Back link #}
@@ -32,9 +32,9 @@
   <div class="govuk-grid-row govuk-!-margin-bottom-0">
     <div class="govuk-grid-column-full">
 
-      {# Status badge #}
+      {# Status tag #}
       <p class="govuk-body">
-        {{ statusBadge(billRunStatus) }}
+        {{ statusTag(billRunStatus) }}
       </p>
 
       {# Bill run meta-data #}

--- a/app/views/bill-runs/cancel.njk
+++ b/app/views/bill-runs/cancel.njk
@@ -3,7 +3,7 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 
-{% from "macros/badge.njk" import statusBadge %}
+{% from "macros/bill-run-status-tag.njk" import statusTag %}
 
 {% block breadcrumbs %}
   {# Back link #}
@@ -26,9 +26,9 @@
   <div class="govuk-grid-row govuk-!-margin-bottom-0">
     <div class="govuk-grid-column-full">
 
-      {# Status badge #}
+      {# Status tag #}
       <p class="govuk-body">
-        {{ statusBadge(billRunStatus) }}
+        {{ statusTag(billRunStatus) }}
       </p>
 
       {# Bill run meta-data #}

--- a/app/views/bill-runs/empty.njk
+++ b/app/views/bill-runs/empty.njk
@@ -4,7 +4,7 @@
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 
-{% from "macros/badge.njk" import statusBadge %}
+{% from "macros/bill-run-status-tag.njk" import statusTag %}
 
 {% block breadcrumbs %}
   {# Back link #}
@@ -38,9 +38,9 @@
   <div class="govuk-grid-row govuk-!-margin-bottom-0">
     <div class="govuk-grid-column-full">
 
-      {# Status badge #}
+      {# Status tag #}
       <p class="govuk-body">
-        {{ statusBadge(billRunStatus) }}
+        {{ statusTag(billRunStatus) }}
       </p>
 
       {# Bill run meta-data #}

--- a/app/views/bill-runs/errored.njk
+++ b/app/views/bill-runs/errored.njk
@@ -4,7 +4,7 @@
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 
-{% from "macros/badge.njk" import statusBadge %}
+{% from "macros/bill-run-status-tag.njk" import statusTag %}
 
 {% block breadcrumbs %}
   {# Back link #}
@@ -38,9 +38,9 @@
   <div class="govuk-grid-row govuk-!-margin-bottom-0">
     <div class="govuk-grid-column-full">
 
-      {# Status badge #}
+      {# Status tag #}
       <p class="govuk-body">
-        {{ statusBadge(billRunStatus) }}
+        {{ statusTag(billRunStatus) }}
       </p>
 
       {# Bill run meta-data #}

--- a/app/views/bill-runs/review-licence.njk
+++ b/app/views/bill-runs/review-licence.njk
@@ -4,7 +4,7 @@
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
-{% from "macros/badge.njk" import badge %}
+{% from "macros/review-status-tag.njk" import statusTag %}
 
 
 {% block breadcrumbs %}
@@ -24,18 +24,8 @@
       <span class="govuk-caption-l">{{region}} two-part tariff bill run</span>
       <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">{{pageTitle}}</h1>
 
-      {# Status badge #}
-      {% if licence.status == 'review' %}
-        {% set colour = "govuk-tag--blue govuk-!-font-size-16" %}
-      {% else %}
-        {% set colour = "govuk-tag--green govuk-!-font-size-16" %}
-      {% endif %}
-
       <p class="govuk-body">
-        {{govukTag({
-          text: licence.status,
-          classes: colour
-        })}}
+        {{ statusTag(licence.status) }}
       </p>
     </div>
   </div>
@@ -106,11 +96,8 @@
           {{ return.description }}
       {% endset %}
 
-      {% set statusTag %}
-        {{govukTag({
-          text: return.returnStatus,
-          classes: colour + ' govuk-!-font-size-14'
-        })}}
+      {% set tag %}
+        {{ statusTag(return.returnStatus) }}
       {% endset %}
 
       {% set issues = '' %}
@@ -130,7 +117,7 @@
           attributes: { 'data-test': 'matched-return-summary' + matchedReturnIndex }
           },
         {
-          html: statusTag,
+          html: tag,
           classes: 'govuk-body-s',
           attributes: { 'data-test': 'matched-return-status' + matchedReturnIndex }
         },
@@ -349,21 +336,11 @@
                   {% set chargeElementIndex = loop.index0 %}
                     {% set elementRows = [] %}
 
-                    {# Status badge #}
-                    {% if chargeElement.elementStatus == 'review' %}
-                      {% set elementColour = "govuk-tag--blue govuk-!-font-size-16" %}
-                    {% else %}
-                      {% set elementColour = "govuk-tag--green govuk-!-font-size-16" %}
-                    {% endif %}
-
                     <div class="govuk-!-margin-top-6">
                       <div class="tag-wrapper">
                         <span class="govuk-body govuk-!-font-weight-regular">{{chargeElement.elementNumber}}</span>
                         <span class="tag-element">
-                          {{govukTag({
-                            text: chargeElement.elementStatus,
-                            classes: elementColour
-                          })}}
+                          {{ statusTag(chargeElement.elementStatus) }}
                         </span>
                         <h3 class="govuk-heading-s govuk-!-margin-bottom-1">{{chargeElement.elementDescription}}
                           <div>

--- a/app/views/bill-runs/review-licence.njk
+++ b/app/views/bill-runs/review-licence.njk
@@ -1,11 +1,9 @@
 {% extends 'layout.njk' %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
-{% from "govuk/components/tag/macro.njk" import govukTag %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 {% from "macros/review-status-tag.njk" import statusTag %}
-
 
 {% block breadcrumbs %}
   {# Back link #}
@@ -74,13 +72,10 @@
       {% set matchedReturnIndex = loop.index0 %}
 
       {% if return.returnStatus == 'overdue' or return.returnStatus == 'query' %}
-        {% set colour = "govuk-tag--red"%}
         {% set returnLink = "/return/internal?returnId=" + return.returnId %}
       {% elif return.status == 'void' %}
-        {% set colour = "govuk-tag--grey" %}
         {% set returnLink = "/return/internal?returnId=" + return.returnId %}
       {% else %}
-        {% set colour = "govuk-tag--green" %}
         {% set returnLink = "/returns/return?id=" + return.returnId%}
       {% endif %}
 
@@ -163,14 +158,6 @@
     {% for return in unmatchedReturns %}
       {% set unmatchedReturnIndex = loop.index0 %}
 
-      {% if return.returnStatus == 'overdue' or return.returnStatus == 'query' %}
-        {% set colour = "govuk-tag--red"%}
-      {% elif return.status == 'void' %}
-        {% set colour = "govuk-tag--grey" %}
-      {% else %}
-        {% set colour = "govuk-tag--green" %}
-      {% endif %}
-
       {% set action %}
         <a class="govuk-link" href="/licences/{{ licence.licenceId }}#returns">{{ return.reference }}<span class="govuk-visually-hidden"></a>
         <div>{{return.dates}}</div>
@@ -183,11 +170,8 @@
           {{ return.description }}
       {% endset %}
 
-      {% set statusTag %}
-        {{govukTag({
-          text: return.returnStatus,
-          classes: colour + ' govuk-!-font-size-14'
-        })}}
+      {% set tag %}
+        {{ statusTag(return.returnStatus) }}
       {% endset %}
 
       {% set issues = '' %}
@@ -207,7 +191,7 @@
           attributes: { 'data-test': 'unmatched-return-summary' + unmatchedReturnIndex }
         },
         {
-          html: statusTag,
+          html: tag,
           classes: 'govuk-body-s',
           attributes: { 'data-test': 'unmatched-return-status' + unmatchedReturnIndex }
         },

--- a/app/views/bill-runs/review.njk
+++ b/app/views/bill-runs/review.njk
@@ -8,7 +8,9 @@
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
-{% from "govuk/components/tag/macro.njk" import govukTag %}
+
+{% from "macros/bill-run-status-tag.njk" import statusTag as billRunStatusTag %}
+{% from "macros/review-status-tag.njk" import statusTag as reviewStatusTag %}
 
 {% block breadcrumbs %}
   {# Back link #}
@@ -25,18 +27,8 @@
       <span class="govuk-caption-l">{{ region }} {{ billRunType }} bill run</span>
       <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">{{ pageTitle }}</h1>
 
-      {# Status badge #}
-      {% if status == 'review' %}
-        {% set colour = "govuk-tag--blue govuk-!-font-size-27" %}
-      {% else %}
-        {% set colour = "govuk-tag--green govuk-!-font-size-27" %}
-      {% endif %}
-
       <p class="govuk-body">
-        {{ govukTag({
-          text: status,
-          classes: colour
-        }) }}
+        {{ billRunStatusTag(status) }}
       </p>
 
       {# Bill run meta-data #}
@@ -263,17 +255,8 @@
   {% set tableRows = [] %}
     {% if preparedLicences.length > 0 %}
       {% for licence in preparedLicences %}
-        {% if licence.status == 'review' %}
-          {% set colour = "govuk-tag--blue" %}
-        {% else %}
-          {% set colour = "govuk-tag--green" %}
-        {% endif %}
-
         {% set statusTag %}
-          {{govukTag({
-            text: licence.status,
-            classes: colour
-          })}}
+          {{ reviewStatusTag(licence.status) }}
         {% endset %}
 
         {% set action %}

--- a/app/views/bill-runs/send.njk
+++ b/app/views/bill-runs/send.njk
@@ -3,7 +3,7 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 
-{% from "macros/badge.njk" import statusBadge %}
+{% from "macros/bill-run-status-tag.njk" import statusTag %}
 
 {% block breadcrumbs %}
   {# Back link #}
@@ -26,9 +26,9 @@
   <div class="govuk-grid-row govuk-!-margin-bottom-0">
     <div class="govuk-grid-column-full">
 
-      {# Status badge #}
+      {# Status tag #}
       <p class="govuk-body">
-        {{ statusBadge(billRunStatus) }}
+        {{ statusTag(billRunStatus) }}
       </p>
 
       {# Bill run meta-data #}

--- a/app/views/bill-runs/setup/create.njk
+++ b/app/views/bill-runs/setup/create.njk
@@ -4,7 +4,7 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 
-{% from "macros/badge.njk" import statusBadge %}
+{% from "macros/bill-run-status-tag.njk" import statusTag %}
 
 {% block breadcrumbs %}
   {# Back link #}
@@ -32,9 +32,9 @@
         iconFallbackText: 'Warning'
       }) }}
 
-      {# Status badge #}
+      {# Status tag #}
       <p class="govuk-body">
-        {{ statusBadge(billRunStatus) }}
+        {{ statusTag(billRunStatus) }}
       </p>
 
       {# Bill run meta-data #}

--- a/app/views/bill-runs/view.njk
+++ b/app/views/bill-runs/view.njk
@@ -5,7 +5,7 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
 
-{% from "macros/badge.njk" import statusBadge %}
+{% from "macros/bill-run-status-tag.njk" import statusTag %}
 
 {% block breadcrumbs %}
   {# Back link #}
@@ -28,9 +28,9 @@
   <div class="govuk-grid-row govuk-!-margin-bottom-0">
     <div class="govuk-grid-column-full">
 
-      {# Status badge #}
+      {# Status tag #}
       <p class="govuk-body">
-        {{ statusBadge(billRunStatus) }}
+        {{ statusTag(billRunStatus) }}
       </p>
 
       {# Bill run meta-data #}

--- a/app/views/bills/remove.njk
+++ b/app/views/bills/remove.njk
@@ -5,7 +5,7 @@
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 
-{% from "macros/badge.njk" import statusBadge %}
+{% from "macros/bill-run-status-tag.njk" import statusTag %}
 
 {% block breadcrumbs %}
   {# Back link #}
@@ -32,9 +32,9 @@
   <div class="govuk-grid-row govuk-!-margin-bottom-0">
     <div class="govuk-grid-column-full">
 
-      {# Status badge #}
+      {# Status tag #}
       <p class="govuk-body">
-        {{ statusBadge(billRunStatus) }}
+        {{ statusTag(billRunStatus) }}
       </p>
 
       {# Bill run meta-data #}

--- a/app/views/bills/view-multi-licence.njk
+++ b/app/views/bills/view-multi-licence.njk
@@ -6,7 +6,7 @@
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 
-{% from "macros/badge.njk" import statusBadge %}
+{% from "macros/bill-run-status-tag.njk" import statusTag %}
 
 {% block breadcrumbs %}
   {# Back link #}
@@ -29,9 +29,9 @@
   <div class="govuk-grid-row govuk-!-margin-bottom-0">
     <div class="govuk-grid-column-full">
 
-      {# Status badge #}
+      {# Status tag #}
       <p class="govuk-body">
-        {{ statusBadge(billRunStatus) }}
+        {{ statusTag(billRunStatus) }}
       </p>
 
       {# Bill meta-data #}

--- a/app/views/bills/view-single-licence-presroc.njk
+++ b/app/views/bills/view-single-licence-presroc.njk
@@ -6,7 +6,7 @@
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 
-{% from "macros/badge.njk" import statusBadge %}
+{% from "macros/bill-run-status-tag.njk" import statusTag %}
 
 {% block breadcrumbs %}
   {# Back link #}
@@ -29,9 +29,9 @@
   <div class="govuk-grid-row govuk-!-margin-bottom-0">
     <div class="govuk-grid-column-full">
 
-      {# Status badge #}
+      {# Status tag #}
       <p class="govuk-body">
-        {{ statusBadge(billRunStatus) }}
+        {{ statusTag(billRunStatus) }}
       </p>
 
       {# Bill meta-data #}

--- a/app/views/bills/view-single-licence-sroc.njk
+++ b/app/views/bills/view-single-licence-sroc.njk
@@ -6,7 +6,7 @@
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 
-{% from "macros/badge.njk" import statusBadge %}
+{% from "macros/bill-run-status-tag.njk" import statusTag %}
 
 {% block breadcrumbs %}
   {# Back link #}
@@ -29,9 +29,9 @@
   <div class="govuk-grid-row govuk-!-margin-bottom-0">
     <div class="govuk-grid-column-full">
 
-      {# Status badge #}
+      {# Status tag #}
       <p class="govuk-body">
-        {{ statusBadge(billRunStatus) }}
+        {{ statusTag(billRunStatus) }}
       </p>
 
       {# Bill meta-data #}

--- a/app/views/macros/bill-run-status-tag.njk
+++ b/app/views/macros/bill-run-status-tag.njk
@@ -1,40 +1,24 @@
 {% from "govuk/components/tag/macro.njk" import govukTag %}
 
-{% macro tag(text, type) %}
-  {% if type === 'error' %}
-    {% set classes = "govuk-tag--red govuk-!-font-size-27" %}
-  {% elif type === 'inactive' %}
-    {% set classes = "govuk-tag--grey govuk-!-font-size-27" %}
-  {% elif type === 'info' %}
+{% macro statusTag(status) %}
+  {% if status === 'ready' %}
     {% set classes = "govuk-tag--blue govuk-!-font-size-27" %}
-  {% elif type === 'warning' %}
-    {% set classes = "govuk-tag--orange govuk-!-font-size-27" %}
-  {% elif type === 'success' %}
+  {% elif status === 'review' %}
+    {% set classes = "govuk-tag--blue govuk-!-font-size-27" %}
+  {% elif status === 'sent' %}
     {% set classes = "govuk-tag--green govuk-!-font-size-27" %}
+  {% elif status === 'empty' %}
+    {% set classes = "govuk-tag--grey govuk-!-font-size-27" %}
+  {% elif status === 'error' %}
+    {% set classes = "govuk-tag--red govuk-!-font-size-27" %}
   {% else %}
     {% set classes = "govuk-tag--blue govuk-!-font-size-27" %}
   {% endif %}
 
   {{
     govukTag({
-      text: text,
+      text: status,
       classes: classes
     })
   }}
-{% endmacro %}
-
-{% macro statusTag(status) %}
-  {% if status === 'ready' %}
-    {% set tagType = 'info' %}
-  {% elif status === 'review' %}
-    {% set tagType = 'info' %}
-  {% elif status === 'sent' %}
-    {% set tagType = 'success' %}
-  {% elif status === 'empty' %}
-    {% set tagType = 'inactive' %}
-  {% elif status === 'error' %}
-    {% set tagType = 'error' %}
-  {% endif %}
-
-  {{ tag(status, tagType) }}
 {% endmacro %}

--- a/app/views/macros/bill-run-status-tag.njk
+++ b/app/views/macros/bill-run-status-tag.njk
@@ -1,6 +1,6 @@
 {% from "govuk/components/tag/macro.njk" import govukTag %}
 
-{% macro badge(text, type) %}
+{% macro tag(text, type) %}
   {% if type === 'error' %}
     {% set classes = "govuk-tag--red govuk-!-font-size-27" %}
   {% elif type === 'inactive' %}
@@ -23,16 +23,16 @@
   }}
 {% endmacro %}
 
-{% macro statusBadge(status) %}
+{% macro statusTag(status) %}
   {% if status === 'ready' %}
-    {% set badgeType = 'info' %}
+    {% set tagType = 'info' %}
   {% elif status === 'sent' %}
-    {% set badgeType = 'success' %}
+    {% set tagType = 'success' %}
   {% elif status === 'empty' %}
-    {% set badgeType = 'inactive' %}
+    {% set tagType = 'inactive' %}
   {% elif status === 'error' %}
-    {% set badgeType = 'error' %}
+    {% set tagType = 'error' %}
   {% endif %}
 
-  {{ badge(status, badgeType) }}
+  {{ tag(status, tagType) }}
 {% endmacro %}

--- a/app/views/macros/bill-run-status-tag.njk
+++ b/app/views/macros/bill-run-status-tag.njk
@@ -26,6 +26,8 @@
 {% macro statusTag(status) %}
   {% if status === 'ready' %}
     {% set tagType = 'info' %}
+  {% elif status === 'review' %}
+    {% set tagType = 'info' %}
   {% elif status === 'sent' %}
     {% set tagType = 'success' %}
   {% elif status === 'empty' %}

--- a/app/views/macros/review-status-tag.njk
+++ b/app/views/macros/review-status-tag.njk
@@ -1,0 +1,28 @@
+{% from "govuk/components/tag/macro.njk" import govukTag %}
+
+{% macro statusTag(status) %}
+  {% if status === 'ready' %}
+    {% set classes = "govuk-tag--green" %}
+  {% elif status === 'review' %}
+    {% set classes = "govuk-tag--blue" %}
+  {% elif status === 'completed' %}
+    {% set classes = "govuk-tag--green govuk-!-font-size-14" %}
+  {% elif status === 'overdue' %}
+    {% set classes = "govuk-tag--red govuk-!-font-size-14" %}
+  {% elif status === 'query' %}
+    {% set classes = "govuk-tag--red govuk-!-font-size-14" %}
+  {% elif status === 'received' %}
+    {% set classes = "govuk-tag--blue govuk-!-font-size-14" %}
+  {% elif status === 'void' %}
+    {% set classes = "govuk-tag--grey govuk-!-font-size-14" %}
+  {% else %}
+    {% set classes = "govuk-tag--blue govuk-!-font-size-14" %}
+  {% endif %}
+
+  {{
+    govukTag({
+      text: status,
+      classes: classes
+    })
+  }}
+{% endmacro %}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4370

A long time back we created a macro for displaying 'badges' for bill runs. These are [GOV.UK tag components](https://design-system.service.gov.uk/components/tag/) and indicate the status of a bill run.

We have to display them in so many places it is the only thing to justify having a macro so far.

In the work we are doing building the review two-part tariff matches and allocations views we again need badges for statuses.

Great! We have a 'badge' macro. Only there are differences. `ready` for bill runs should be displayed as blue. In the review screens it needs to be green. Also, the badges need to be different sizes for the two contexts.

We had it in mind to [expand the existing functionality](https://github.com/DEFRA/water-abstraction-system/pull/882) but that was what made it clear we needed two different badges for the 2 contexts.

This means the existing `badge.njk` macro should also be given a more explicit name.

Then the final change; stop calling these blooming things badges. They're tags!