### PR TITLE
Move two-part tariff review routes to own folder

### DIFF
--- a/app/controllers/bill-runs.controller.js
+++ b/app/controllers/bill-runs.controller.js
@@ -9,8 +9,6 @@ const Boom = require('@hapi/boom')
 
 const CancelBillRunService = require('../services/bill-runs/cancel-bill-run.service.js')
 const CreateBillRunValidator = require('../validators/create-bill-run.validator.js')
-const ReviewBillRunService = require('../services/bill-runs/two-part-tariff/review-bill-run.service.js')
-const ReviewLicenceService = require('../services/bill-runs/two-part-tariff/review-licence.service.js')
 const SendBillRunService = require('../services/bill-runs/send-bill-run.service.js')
 const StartBillRunProcessService = require('../services/bill-runs/start-bill-run-process.service.js')
 const SubmitCancelBillRunService = require('../services/bill-runs/submit-cancel-bill-run.service.js')
@@ -46,17 +44,6 @@ async function create (request, h) {
   }
 }
 
-async function review (request, h) {
-  const { id } = request.params
-  const pageData = await ReviewBillRunService.go(id, request.payload)
-
-  return h.view('bill-runs/review.njk', {
-    pageTitle: 'Review licences',
-    activeNavBar: 'bill-runs',
-    ...pageData
-  })
-}
-
 async function send (request, h) {
   const { id } = request.params
 
@@ -64,18 +51,6 @@ async function send (request, h) {
 
   return h.view('bill-runs/send.njk', {
     pageTitle: "You're about to send this bill run",
-    activeNavBar: 'bill-runs',
-    ...pageData
-  })
-}
-
-async function reviewLicence (request, h) {
-  const { id: billRunId, licenceId } = request.params
-
-  const pageData = await ReviewLicenceService.go(billRunId, licenceId)
-
-  return h.view('bill-runs/review-licence.njk', {
-    pageTitle: `Licence ${pageData.licence.licenceRef}`,
     activeNavBar: 'bill-runs',
     ...pageData
   })
@@ -124,8 +99,6 @@ async function view (request, h) {
 module.exports = {
   cancel,
   create,
-  review,
-  reviewLicence,
   send,
   submitCancel,
   submitSend,

--- a/app/controllers/reviews.controller.js
+++ b/app/controllers/reviews.controller.js
@@ -1,0 +1,37 @@
+'use strict'
+
+/**
+ * Controller for /reviews endpoints
+ * @module ReviewsController
+ */
+
+const ReviewBillRunService = require('../services/bill-runs/two-part-tariff/review-bill-run.service.js')
+const ReviewLicenceService = require('../services/bill-runs/two-part-tariff/review-licence.service.js')
+
+async function view (request, h) {
+  const { id } = request.params
+  const pageData = await ReviewBillRunService.go(id, request.payload)
+
+  return h.view('bill-runs/review.njk', {
+    pageTitle: 'Review licences',
+    activeNavBar: 'bill-runs',
+    ...pageData
+  })
+}
+
+async function viewLicence (request, h) {
+  const { id: billRunId, licenceId } = request.params
+
+  const pageData = await ReviewLicenceService.go(billRunId, licenceId)
+
+  return h.view('bill-runs/review-licence.njk', {
+    pageTitle: `Licence ${pageData.licence.licenceRef}`,
+    activeNavBar: 'bill-runs',
+    ...pageData
+  })
+}
+
+module.exports = {
+  view,
+  viewLicence
+}

--- a/app/plugins/router.plugin.js
+++ b/app/plugins/router.plugin.js
@@ -24,6 +24,7 @@ const HealthRoutes = require('../routes/health.routes.js')
 const JobRoutes = require('../routes/jobs.routes.js')
 const LicenceRoutes = require('../routes/licence.routes.js')
 const ReturnRequirementRoutes = require('../routes/return-requirement.routes.js')
+const ReviewsRoutes = require('../routes/reviews.routes.js')
 const RootRoutes = require('../routes/root.routes.js')
 
 const AirbrakeConfig = require('../../config/airbrake.config.js')
@@ -40,6 +41,7 @@ const routes = [
   ...LicenceRoutes,
   ...JobRoutes,
   ...ReturnRequirementRoutes,
+  ...ReviewsRoutes,
   ...CheckRoutes,
   ...DataRoutes
 ]

--- a/app/routes/bill-runs.routes.js
+++ b/app/routes/bill-runs.routes.js
@@ -60,45 +60,6 @@ const routes = [
   },
   {
     method: 'GET',
-    path: '/bill-runs/{id}/review',
-    handler: BillRunsController.review,
-    options: {
-      auth: {
-        access: {
-          scope: ['billing']
-        }
-      },
-      description: 'Review two-part tariff match and allocation results'
-    }
-  },
-  {
-    method: 'POST',
-    path: '/bill-runs/{id}/review',
-    handler: BillRunsController.review,
-    options: {
-      auth: {
-        access: {
-          scope: ['billing']
-        }
-      },
-      description: 'POST request recieved when filtering applied to review two-part tariff match and allocation results'
-    }
-  },
-  {
-    method: 'GET',
-    path: '/bill-runs/{id}/review/{licenceId}',
-    handler: BillRunsController.reviewLicence,
-    options: {
-      auth: {
-        access: {
-          scope: ['billing']
-        }
-      },
-      description: 'Review a two-part tariff licence'
-    }
-  },
-  {
-    method: 'GET',
     path: '/bill-runs/{id}/send',
     handler: BillRunsController.send,
     options: {

--- a/app/routes/reviews.routes.js
+++ b/app/routes/reviews.routes.js
@@ -1,0 +1,47 @@
+'use strict'
+
+const ReviewsController = require('../controllers/reviews.controller.js')
+
+const routes = [
+  {
+    method: 'GET',
+    path: '/reviews/{billRunId}',
+    handler: ReviewsController.view,
+    options: {
+      auth: {
+        access: {
+          scope: ['billing']
+        }
+      },
+      description: 'Review two-part tariff match and allocation results'
+    }
+  },
+  {
+    method: 'POST',
+    path: '/reviews/{billRunId}',
+    handler: ReviewsController.view,
+    options: {
+      auth: {
+        access: {
+          scope: ['billing']
+        }
+      },
+      description: 'POST request received when filtering applied to review two-part tariff match and allocation results'
+    }
+  },
+  {
+    method: 'GET',
+    path: '/reviews/{billRunId}/licences/{licenceId}',
+    handler: ReviewsController.viewLicence,
+    options: {
+      auth: {
+        access: {
+          scope: ['billing']
+        }
+      },
+      description: 'Review a two-part tariff licence'
+    }
+  }
+]
+
+module.exports = routes


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4057

Before a two-part tariff bill run is ready to be billed users first have to review the results of the matching and allocation. Because the review is connected to the bill run process we started by having these routes be part of `/bill-runs`. But this means we are adding more and more services into `app/services/bill-runs/two-part-tariff` that are solely to review the results. It is making it harder to see what is billing engine-related and what is just for the review views.

So, before this gets any more confusing we are going to move all two-part tariff review-related routes to a new `/review` root URL. We can then move all services, presenters etc to their own matching `/review` folder. This will then separate our review logic from the billing logic.