### PR TITLE
Fix DetermineFinancialEndYearService

### DIFF
--- a/app/services/bill-runs/setup/determine-financial-year-end.service.js
+++ b/app/services/bill-runs/setup/determine-financial-year-end.service.js
@@ -55,6 +55,7 @@ async function _determineSupplementaryEndYear (regionId, currentFinancialYearEnd
       'toFinancialYearEnding'
     ])
     .where('regionId', regionId)
+    .where('batchType', 'annual')
     .where('status', 'sent')
     // NOTE: We would never have an annual bill run with a toFinancialYearEnding greater than the current one in a
     // 'real' environment. But we often manipulate bill run dates whilst testing to move annual bill runs out of the

--- a/test/services/bill-runs/setup/determine-financial-year-end.service.test.js
+++ b/test/services/bill-runs/setup/determine-financial-year-end.service.test.js
@@ -108,6 +108,23 @@ describe('Bill Runs Setup Determine Financial Year End service', () => {
       })
     })
 
+    describe("and the last 'sent' bill run is not an annual", () => {
+      beforeEach(async () => {
+        await BillRunHelper.add({
+          batchType: 'two_part_tariff', regionId, status: 'sent', toFinancialYearEnding: currentFinancialYearEnd
+        })
+        await BillRunHelper.add({
+          batchType: 'annual', regionId, status: 'sent', toFinancialYearEnding: currentFinancialYearEnd - 1
+        })
+      })
+
+      it("ignores the other bill run and returns the financial year end of the first matching 'sent' annual", async () => {
+        const result = await DetermineFinancialYearEndService.go(regionId, 'supplementary')
+
+        expect(result).to.equal(currentFinancialYearEnd - 1)
+      })
+    })
+
     // NOTE: This would never happen in a 'real' environment. All regions have 'sent' annual bill runs so a result
     // would always be found
     describe("and there is no 'sent' annual bill run for the same region", () => {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4403

In [Bump supplementary end year if no annual bill run](https://github.com/DEFRA/water-abstraction-system/pull/875) we amended our billing engine for supplementary. We made it possible for users to generate supplementary bill runs in years where no annual has yet been created and sent.

Previously, the Billing & Data team would have to put a block on creating bill runs until the annuals were generated. This is because supplementary takes into account previous transactions whereas annual doesn't. Without the change creating a supplementary followed by an annual bill run would result in the customer getting charged twice.

We now determine when the last annual bill run was sent and use its financial end year as the end year for the supplementary bill run. Annual created in this billing period? Then the supplementary will start there and work back 5 years. If the last sent annual was for the previous billing period the supplementary will start _there_ and work back 5 years.

So, what's the problem? In this explanation, we keep referring to the last sent 'annual' bill run. But we've just spotted the logic which looks for the last sent bill run does not include batch type in the `where()` clause. Theoretically, we could create a two-part tariff bill run, send it and that would then match our query!

This change corrects the query we use to find the last sent annual bill run for a region.