### PR TITLE
Complete Select existing return requirement page

### DIFF
--- a/app/controllers/return-requirements.controller.js
+++ b/app/controllers/return-requirements.controller.js
@@ -12,6 +12,7 @@ const AgreementsExceptionsService = require('../services/return-requirements/agr
 const CancelService = require('../services/return-requirements/cancel.service.js')
 const CheckService = require('../services/return-requirements/check.service.js')
 const DeleteNoteService = require('../services/return-requirements/delete-note.service.js')
+const ExistingService = require('../services/return-requirements/existing.service.js')
 const FrequencyCollectedService = require('../services/return-requirements/frequency-collected.service.js')
 const FrequencyReportedService = require('../services/return-requirements/frequency-reported.service.js')
 const NoReturnsRequiredService = require('../services/return-requirements/no-returns-required.service.js')
@@ -21,7 +22,6 @@ const RemoveService = require('../services/return-requirements/remove.service.js
 const ReturnsCycleService = require('../services/return-requirements/returns-cycle.service.js')
 const SelectPurposeService = require('../services/return-requirements/purpose.service.js')
 const SelectReasonService = require('../services/return-requirements/reason.service.js')
-const SessionModel = require('../models/session.model.js')
 const SetupService = require('../services/return-requirements/setup.service.js')
 const SiteDescriptionService = require('../services/return-requirements/site-description.service.js')
 const StartDateService = require('../services/return-requirements/start-date.service.js')
@@ -120,12 +120,10 @@ async function deleteNote (request, h) {
 async function existing (request, h) {
   const { sessionId } = request.params
 
-  const session = await SessionModel.query().findById(sessionId)
+  const pageData = await ExistingService.go(sessionId)
 
   return h.view('return-requirements/existing.njk', {
-    activeNavBar: 'search',
-    pageTitle: 'Select an existing return requirement from',
-    ...session
+    ...pageData
   })
 }
 

--- a/app/controllers/return-requirements.controller.js
+++ b/app/controllers/return-requirements.controller.js
@@ -30,6 +30,7 @@ const SubmitAdditionalSubmissionOptionsService = require('../services/return-req
 const SubmitAgreementsExceptions = require('../services/return-requirements/submit-agreements-exceptions.service.js')
 const SubmitCancel = require('../services/return-requirements/submit-cancel.service.js')
 const SubmitCheckService = require('../services/return-requirements/submit-check.service.js')
+const SubmitExistingService = require('../services/return-requirements/submit-existing.service.js')
 const SubmitFrequencyCollectedService = require('../services/return-requirements/submit-frequency-collected.service.js')
 const SubmitFrequencyReportedService = require('../services/return-requirements/submit-frequency-reported.service.js')
 const SubmitNoReturnsRequiredService = require('../services/return-requirements/submit-no-returns-required.service.js')
@@ -305,7 +306,13 @@ async function submitCheck (request, h) {
 }
 
 async function submitExisting (request, h) {
-  const { sessionId } = request.params
+  const { params: { sessionId }, payload } = request
+
+  const pageData = await SubmitExistingService.go(sessionId, payload)
+
+  if (pageData.error) {
+    return h.view('return-requirements/existing.njk', pageData)
+  }
 
   return h.redirect(`/system/return-requirements/${sessionId}/check`)
 }

--- a/app/presenters/return-requirements/existing.presenter.js
+++ b/app/presenters/return-requirements/existing.presenter.js
@@ -5,6 +5,9 @@
  * @module ExistingPresenter
  */
 
+const { formatLongDate } = require('../base.presenter.js')
+const { returnRequirementReasons } = require('../../lib/static-lookups.lib.js')
+
 /**
  * Formats data for the `/return-requirements/{sessionId}/existing` page
  *
@@ -16,9 +19,26 @@ function go (session) {
   const { id: sessionId, licence } = session
 
   return {
+    existingOptions: _existingOptions(licence.returnVersions),
     licenceRef: licence.licenceRef,
     sessionId
   }
+}
+
+function _existingOptions (returnVersions) {
+  return returnVersions.map((returnVersion) => {
+    const { id, reason, startDate } = returnVersion
+
+    // NOTE: because the session data is stored in a JSONB field when we get the instance from the DB the date values
+    // are in JS Date format (string). So, we have to convert it to a date before calling `formatLongDate()`
+    const dateObj = new Date(startDate)
+    const formattedStartDate = formatLongDate(dateObj)
+
+    return {
+      value: id,
+      text: reason ? `${formattedStartDate} - ${returnRequirementReasons[reason]}` : formattedStartDate
+    }
+  })
 }
 
 module.exports = {

--- a/app/presenters/return-requirements/existing.presenter.js
+++ b/app/presenters/return-requirements/existing.presenter.js
@@ -1,0 +1,26 @@
+'use strict'
+
+/**
+ * Formats data for the `/return-requirements/{sessionId}/existing` page
+ * @module ExistingPresenter
+ */
+
+/**
+ * Formats data for the `/return-requirements/{sessionId}/existing` page
+ *
+ * @param {module:SessionModel} session - The returns requirements session instance
+ *
+ * @returns {Object} The data formatted for the view template
+ */
+function go (session) {
+  const { id: sessionId, licence } = session
+
+  return {
+    licenceRef: licence.licenceRef,
+    sessionId
+  }
+}
+
+module.exports = {
+  go
+}

--- a/app/services/return-requirements/existing.service.js
+++ b/app/services/return-requirements/existing.service.js
@@ -25,7 +25,7 @@ async function go (sessionId) {
 
   return {
     activeNavBar: 'search',
-    pageTitle: 'Select an existing return requirement from',
+    pageTitle: 'Select an existing requirements for returns from',
     ...formattedData
   }
 }

--- a/app/services/return-requirements/existing.service.js
+++ b/app/services/return-requirements/existing.service.js
@@ -1,0 +1,35 @@
+'use strict'
+
+/**
+ * Orchestrates fetching and presenting the data for `/return-requirements/{sessionId}/existing` page
+ * @module ExistingService
+ */
+
+const ExistingPresenter = require('../../presenters/return-requirements/existing.presenter.js')
+const SessionModel = require('../../models/session.model.js')
+
+/**
+ * Orchestrates fetching and presenting the data for `/return-requirements/{sessionId}/existing` page
+ *
+ * Supports generating the data needed for the existing page in the return requirements setup journey. It fetches the
+ * current session record and from it determines what radio buttons to display to the user.
+ *
+ * @param {string} sessionId - The UUID of the current session
+ *
+ * @returns {Promise<Object>} The view data for the purpose page
+*/
+async function go (sessionId) {
+  const session = await SessionModel.query().findById(sessionId)
+
+  const formattedData = ExistingPresenter.go(session)
+
+  return {
+    activeNavBar: 'search',
+    pageTitle: 'Select an existing return requirement from',
+    ...formattedData
+  }
+}
+
+module.exports = {
+  go
+}

--- a/app/services/return-requirements/fetch-existing-requirements.service.js
+++ b/app/services/return-requirements/fetch-existing-requirements.service.js
@@ -1,0 +1,151 @@
+'use strict'
+
+/**
+ * Fetches existing return requirements to be copied from
+ * @module FetchExistingRequirementsService
+ */
+
+const ReturnVersionModel = require('../../models/return-version.model.js')
+
+const FREQUENCIES = {
+  day: 'daily',
+  week: 'weekly',
+  fortnight: 'fortnightly',
+  month: 'monthly',
+  quarter: 'quarterly',
+  year: 'yearly'
+}
+
+/**
+ * Fetches existing return requirements to be copied from
+ *
+ * In the returns setup journey we allow users to select the option to create new requirements by copying from them
+ * from an existing return version. This service fetches the selected return version and its requirements
+ *
+ * @param {string} returnVersionId - The UUID of the selected return version to copy requirements from
+ *
+ * @returns {Promise<Object>} The return version and its linked return requirements, plus their points and purposes
+ */
+async function go (returnVersionId) {
+  const returnVersion = await _fetch(returnVersionId)
+
+  return _transformForSetup(returnVersion)
+}
+
+async function _fetch (returnVersionId) {
+  return ReturnVersionModel.query()
+    .findById(returnVersionId)
+    .select([
+      'id'
+    ])
+    .withGraphFetched('returnRequirements')
+    .modifyGraph('returnRequirements', (builder) => {
+      builder.select([
+        'id',
+        'abstractionPeriodEndDay',
+        'abstractionPeriodEndMonth',
+        'abstractionPeriodStartDay',
+        'abstractionPeriodStartMonth',
+        'collectionFrequency',
+        'fiftySixException',
+        'gravityFill',
+        'reabstraction',
+        'reportingFrequency',
+        'siteDescription',
+        'summer',
+        'twoPartTariff'
+      ])
+    })
+    .withGraphFetched('returnRequirements.returnRequirementPoints')
+    .modifyGraph('returnRequirements.returnRequirementPoints', (builder) => {
+      builder.select([
+        'id',
+        'naldPointId'
+      ])
+    })
+    .withGraphFetched('returnRequirements.returnRequirementPurposes')
+    .modifyGraph('returnRequirements.returnRequirementPurposes', (builder) => {
+      builder.select([
+        'id',
+        'purposeId'
+      ])
+    })
+}
+
+function _transformForSetup (returnVersion) {
+  const { returnRequirements } = returnVersion
+
+  return returnRequirements.map((returnRequirement) => {
+    const {
+      abstractionPeriodEndDay,
+      abstractionPeriodEndMonth,
+      abstractionPeriodStartDay,
+      abstractionPeriodStartMonth,
+      collectionFrequency,
+      reportingFrequency,
+      returnRequirementPoints,
+      returnRequirementPurposes,
+      siteDescription,
+      summer
+    } = returnRequirement
+
+    return {
+      points: _points(returnRequirementPoints),
+      purposes: _purposes(returnRequirementPurposes),
+      returnsCycle: summer ? 'summer' : 'winter-and-all-year',
+      siteDescription,
+      abstractionPeriod: {
+        'end-abstraction-period-day': abstractionPeriodEndDay,
+        'end-abstraction-period-month': abstractionPeriodEndMonth,
+        'start-abstraction-period-day': abstractionPeriodStartDay,
+        'start-abstraction-period-month': abstractionPeriodStartMonth
+      },
+      frequencyReported: FREQUENCIES[reportingFrequency],
+      frequencyCollected: FREQUENCIES[collectionFrequency],
+      agreementsExceptions: _agreementExceptions(returnRequirement)
+    }
+  })
+}
+
+function _agreementExceptions (returnRequirement) {
+  const { fiftySixException, gravityFill, reabstraction, twoPartTariff } = returnRequirement
+  const agreementsExceptions = []
+
+  if (fiftySixException) {
+    agreementsExceptions.push('56-returns-exception')
+  }
+
+  if (gravityFill) {
+    agreementsExceptions.push('gravity-fill')
+  }
+
+  if (reabstraction) {
+    agreementsExceptions.push('transfer-re-abstraction-scheme')
+  }
+
+  if (twoPartTariff) {
+    agreementsExceptions.push('two-part-tariff')
+  }
+
+  if (agreementsExceptions.length === 0) {
+    agreementsExceptions.push('none')
+  }
+
+  return agreementsExceptions
+}
+
+function _points (returnRequirementPoints) {
+  return returnRequirementPoints.map((returnRequirementPoint) => {
+    return returnRequirementPoint.naldPointId.toString()
+  })
+}
+
+function _purposes (returnRequirementPurposes) {
+  return returnRequirementPurposes.map((returnRequirementPurpose) => {
+    return returnRequirementPurpose.purposeId
+  })
+}
+
+module.exports = {
+  go
+}

--- a/app/services/return-requirements/fetch-existing-requirements.service.js
+++ b/app/services/return-requirements/fetch-existing-requirements.service.js
@@ -32,6 +32,33 @@ async function go (returnVersionId) {
   return _transformForSetup(returnVersion)
 }
 
+function _agreementExceptions (returnRequirement) {
+  const { fiftySixException, gravityFill, reabstraction, twoPartTariff } = returnRequirement
+  const agreementsExceptions = []
+
+  if (fiftySixException) {
+    agreementsExceptions.push('56-returns-exception')
+  }
+
+  if (gravityFill) {
+    agreementsExceptions.push('gravity-fill')
+  }
+
+  if (reabstraction) {
+    agreementsExceptions.push('transfer-re-abstraction-scheme')
+  }
+
+  if (twoPartTariff) {
+    agreementsExceptions.push('two-part-tariff')
+  }
+
+  if (agreementsExceptions.length === 0) {
+    agreementsExceptions.push('none')
+  }
+
+  return agreementsExceptions
+}
+
 async function _fetch (returnVersionId) {
   return ReturnVersionModel.query()
     .findById(returnVersionId)
@@ -72,6 +99,18 @@ async function _fetch (returnVersionId) {
     })
 }
 
+function _points (returnRequirementPoints) {
+  return returnRequirementPoints.map((returnRequirementPoint) => {
+    return returnRequirementPoint.naldPointId.toString()
+  })
+}
+
+function _purposes (returnRequirementPurposes) {
+  return returnRequirementPurposes.map((returnRequirementPurpose) => {
+    return returnRequirementPurpose.purposeId
+  })
+}
+
 function _transformForSetup (returnVersion) {
   const { returnRequirements } = returnVersion
 
@@ -104,45 +143,6 @@ function _transformForSetup (returnVersion) {
       frequencyCollected: FREQUENCIES[collectionFrequency],
       agreementsExceptions: _agreementExceptions(returnRequirement)
     }
-  })
-}
-
-function _agreementExceptions (returnRequirement) {
-  const { fiftySixException, gravityFill, reabstraction, twoPartTariff } = returnRequirement
-  const agreementsExceptions = []
-
-  if (fiftySixException) {
-    agreementsExceptions.push('56-returns-exception')
-  }
-
-  if (gravityFill) {
-    agreementsExceptions.push('gravity-fill')
-  }
-
-  if (reabstraction) {
-    agreementsExceptions.push('transfer-re-abstraction-scheme')
-  }
-
-  if (twoPartTariff) {
-    agreementsExceptions.push('two-part-tariff')
-  }
-
-  if (agreementsExceptions.length === 0) {
-    agreementsExceptions.push('none')
-  }
-
-  return agreementsExceptions
-}
-
-function _points (returnRequirementPoints) {
-  return returnRequirementPoints.map((returnRequirementPoint) => {
-    return returnRequirementPoint.naldPointId.toString()
-  })
-}
-
-function _purposes (returnRequirementPurposes) {
-  return returnRequirementPurposes.map((returnRequirementPurpose) => {
-    return returnRequirementPurpose.purposeId
   })
 }
 

--- a/app/services/return-requirements/submit-existing.service.js
+++ b/app/services/return-requirements/submit-existing.service.js
@@ -1,0 +1,64 @@
+'use strict'
+
+/**
+ * Orchestrates validating the data for `/return-requirements/{sessionId}/existing` page
+ * @module SubmitExistingService
+ */
+
+const ExistingPresenter = require('../../presenters/return-requirements/existing.presenter.js')
+const ExistingValidator = require('../../validators/return-requirements/existing.validator.js')
+const SessionModel = require('../../models/session.model.js')
+
+/**
+ * Orchestrates validating the data for `/return-requirements/{sessionId}/existing` page
+ *
+ * It first retrieves the session instance for the returns requirements journey in progress.
+ *
+ * The validation result is then combined with the output of the presenter to generate the page data needed by the view.
+ * If there was a validation error the controller will re-render the page so needs this information. If all is well the
+ * controller will redirect to the next page in the journey.
+ *
+ * @param {string} sessionId - The UUID of the current session
+ * @param {Object} payload - The submitted form data
+ *
+ * @returns {Promise<Object>} If no errors an empty object else the page data for the existing page including the
+ * validation error details
+ */
+async function go (sessionId, payload) {
+  const session = await SessionModel.query().findById(sessionId)
+
+  const validationResult = _validate(payload, session)
+
+  if (!validationResult) {
+    return {}
+  }
+
+  const formattedData = ExistingPresenter.go(session)
+
+  return {
+    activeNavBar: 'search',
+    error: validationResult,
+    pageTitle: 'Select an existing requirements for returns from',
+    ...formattedData
+  }
+}
+
+function _validate (payload, session) {
+  const { licence: { returnVersions } } = session
+
+  const validation = ExistingValidator.go(payload, returnVersions)
+
+  if (!validation.error) {
+    return null
+  }
+
+  const { message } = validation.error.details[0]
+
+  return {
+    text: message
+  }
+}
+
+module.exports = {
+  go
+}

--- a/app/services/return-requirements/submit-setup.service.js
+++ b/app/services/return-requirements/submit-setup.service.js
@@ -48,17 +48,15 @@ async function go (sessionId, payload) {
 }
 
 function _redirect (setup) {
-  let endpoint
-
   if (setup === 'use-abstraction-data') {
-    endpoint = 'check'
+    return 'check'
   }
 
-  if (setup === 'set-up-manually') {
-    endpoint = 'purpose/0'
+  if (setup === 'use-existing-requirements') {
+    return 'existing'
   }
 
-  return endpoint
+  return 'purpose/0'
 }
 
 async function _save (session, payload) {

--- a/app/validators/return-requirements/existing.validator.js
+++ b/app/validators/return-requirements/existing.validator.js
@@ -1,0 +1,41 @@
+'use strict'
+
+/**
+ * Validates data submitted for the `/return-requirements/{sessionId}/existing` page
+ * @module ExistingValidator
+ */
+
+const Joi = require('joi')
+
+const errorMessage = 'Select an existing requirements for returns'
+
+/**
+ * Validates data submitted for the `/return-requirements/{sessionId}/existing` page
+ *
+ * @param {Object} payload - The payload from the request to be validated
+ *
+ * @returns {Object} the result from calling Joi's schema.validate(). It will be an object with a `value:` property. If
+ * any errors are found the `error:` property will also exist detailing what the issues were
+ */
+function go (data, returnVersions) {
+  const returnVersionIds = returnVersions.map((returnVersion) => {
+    return returnVersion.id
+  })
+
+  const schema = Joi.object({
+    existing: Joi.string()
+      .required()
+      .valid(...returnVersionIds)
+      .messages({
+        'any.required': errorMessage,
+        'any.only': errorMessage,
+        'string.empty': errorMessage
+      })
+  })
+
+  return schema.validate(data, { abortEarly: false })
+}
+
+module.exports = {
+  go
+}

--- a/app/views/return-requirements/existing.njk
+++ b/app/views/return-requirements/existing.njk
@@ -2,14 +2,12 @@
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
-{% set rootLink = "/system/return-requirements/" + id %}
-
 {% block breadcrumbs %}
   {# Back link #}
   {{
     govukBackLink({
       text: 'Back',
-      href: rootLink + "/setup"
+      href: '/system/return-requirements/' + sessionId + "/setup"
     })
   }}
 {% endblock %}
@@ -17,6 +15,7 @@
 {% block content %}
   {# Main heading #}
   <div class="govuk-body">
+    <span class="govuk-caption-l"> Licence {{ licenceRef }} </span>
     <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">{{ pageTitle }}</h1>
   </div>
 

--- a/app/views/return-requirements/existing.njk
+++ b/app/views/return-requirements/existing.njk
@@ -1,6 +1,7 @@
 {% extends 'layout.njk' %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
 
 {% block breadcrumbs %}
   {# Back link #}
@@ -14,14 +15,32 @@
 
 {% block content %}
   {# Main heading #}
-  <div class="govuk-body">
-    <span class="govuk-caption-l"> Licence {{ licenceRef }} </span>
-    <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">{{ pageTitle }}</h1>
-  </div>
+  {% set radioItems = [] %}
+  {% for existingOption in existingOptions %}
+    {% set radioItem = {
+      value: existingOption.value,
+      text: existingOption.text
+    } %}
 
-  <form method="post">
-    <div class="govuk-body">
+    {% set radioItems = (radioItems.push(radioItem), radioItems) %}
+  {% endfor %}
+
+  <div class="govuk-body">
+    <form method="post">
+      {{ govukRadios({
+        name: "existing",
+        errorMessage: error,
+        fieldset: {
+          legend: {
+            html: '<span class="govuk-caption-l">Licence ' + licenceRef + '</span>' + pageTitle,
+            isPageHeading: true,
+            classes: "govuk-fieldset__legend--l govuk-!-margin-bottom-6"
+          }
+        },
+        items: radioItems
+      }) }}
+
       {{ govukButton({ text: "Continue", preventDoubleClick: true }) }}
-    </div>
-  </form>
+    </form>
+  </div>
 {% endblock %}

--- a/app/views/return-requirements/existing.njk
+++ b/app/views/return-requirements/existing.njk
@@ -1,6 +1,7 @@
 {% extends 'layout.njk' %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 
 {% block breadcrumbs %}
@@ -14,7 +15,18 @@
 {% endblock %}
 
 {% block content %}
-  {# Main heading #}
+  {% if error %}
+    {{ govukErrorSummary({
+      titleText: "There is a problem",
+      errorList: [
+        {
+          text: error.text,
+          href: "#existing-error"
+        }
+      ]
+      }) }}
+  {% endif %}
+
   {% set radioItems = [] %}
   {% for existingOption in existingOptions %}
     {% set radioItem = {

--- a/test/controllers/return-requirements.controller.test.js
+++ b/test/controllers/return-requirements.controller.test.js
@@ -17,6 +17,7 @@ const CheckService = require('../../app/services/return-requirements/check.servi
 const DeleteNoteService = require('../../app/services/return-requirements/delete-note.service.js')
 const FrequencyCollectedService = require('../../app/services/return-requirements/frequency-collected.service.js')
 const FrequencyReportedService = require('../../app/services/return-requirements/frequency-reported.service.js')
+const ExistingService = require('../../app/services/return-requirements/existing.service.js')
 const NoReturnsRequiredService = require('../../app/services/return-requirements/no-returns-required.service.js')
 const NoteService = require('../../app/services/return-requirements/note.service.js')
 const PointsService = require('../../app/services/return-requirements/points.service.js')
@@ -309,6 +310,12 @@ describe('Return requirements controller', () => {
 
     describe('GET', () => {
       describe('when the request succeeds', () => {
+        beforeEach(async () => {
+          Sinon.stub(ExistingService, 'go').resolves({
+            id: '8702b98f-ae51-475d-8fcc-e049af8b8d38', pageTitle: 'Select an existing requirements for returns from'
+          })
+        })
+
         it('returns the page successfully', async () => {
           const response = await server.inject(_getOptions(path))
 

--- a/test/controllers/return-requirements.controller.test.js
+++ b/test/controllers/return-requirements.controller.test.js
@@ -312,7 +312,7 @@ describe('Return requirements controller', () => {
           const response = await server.inject(_getOptions(path))
 
           expect(response.statusCode).to.equal(200)
-          expect(response.payload).to.contain('Select an existing return requirement from')
+          expect(response.payload).to.contain('Select an existing requirements for returns from')
         })
       })
     })

--- a/test/controllers/return-requirements.controller.test.js
+++ b/test/controllers/return-requirements.controller.test.js
@@ -29,6 +29,7 @@ const SiteDescriptionService = require('../../app/services/return-requirements/s
 const StartDateService = require('../../app/services/return-requirements/start-date.service.js')
 const SubmitAbstractionPeriod = require('../../app/services/return-requirements/submit-abstraction-period.service.js')
 const SubmitAgreementsExceptions = require('../../app/services/return-requirements/submit-agreements-exceptions.service.js')
+const SubmitExistingService = require('../../app/services/return-requirements/submit-existing.service.js')
 const SubmitFrequencyCollectedService = require('../../app/services/return-requirements/submit-frequency-collected.service.js')
 const SubmitFrequencyReportedService = require('../../app/services/return-requirements/submit-frequency-reported.service.js')
 const SubmitPointsService = require('../../app/services/return-requirements/submit-points.service.js')
@@ -313,6 +314,36 @@ describe('Return requirements controller', () => {
 
           expect(response.statusCode).to.equal(200)
           expect(response.payload).to.contain('Select an existing requirements for returns from')
+        })
+      })
+    })
+
+    describe('POST', () => {
+      describe('when the request succeeds', () => {
+        describe('and the validation fails', () => {
+          beforeEach(async () => {
+            Sinon.stub(SubmitExistingService, 'go').resolves({ error: {} })
+          })
+
+          it('returns the page successfully with the error summary banner', async () => {
+            const response = await server.inject(_postOptions(path))
+
+            expect(response.statusCode).to.equal(200)
+            expect(response.payload).to.contain('There is a problem')
+          })
+        })
+
+        describe('and the validation succeeds', () => {
+          beforeEach(async () => {
+            Sinon.stub(SubmitExistingService, 'go').resolves({})
+          })
+
+          it('redirects to /system/return-requirements/{sessionId}/check', async () => {
+            const response = await server.inject(_postOptions(path))
+
+            expect(response.statusCode).to.equal(302)
+            expect(response.headers.location).to.equal('/system/return-requirements/' + sessionId + '/check')
+          })
         })
       })
     })

--- a/test/presenters/return-requirements/existing.presenter.test.js
+++ b/test/presenters/return-requirements/existing.presenter.test.js
@@ -41,8 +41,38 @@ describe('Return Requirements - Existing presenter', () => {
       const result = ExistingPresenter.go(session)
 
       expect(result).to.equal({
+        existingOptions: [{ value: '60b5d10d-1372-4fb2-b222-bfac81da69ab', text: '1 January 2023' }],
         licenceRef: '01/ABC',
         sessionId: '61e07498-f309-4829-96a9-72084a54996d'
+      })
+    })
+  })
+
+  describe('the "existingOptions" property', () => {
+    describe('when the return versions do not contain a "reason"', () => {
+      it('returns the version ID as the option value and just the start date as the option text', () => {
+        const result = ExistingPresenter.go(session)
+
+        expect(result.existingOptions).to.equal([
+          { value: '60b5d10d-1372-4fb2-b222-bfac81da69ab', text: '1 January 2023' }
+        ])
+      })
+    })
+
+    describe('when the return versions contain a "reason"', () => {
+      beforeEach(() => {
+        session.licence.returnVersions.unshift({
+          id: '22ecef19-3a13-44a0-a55e-8f4d34dd59a5', reason: 'major-change', startDate: '2024-05-07T00:00:00.000Z'
+        })
+      })
+
+      it('returns the version ID as the option value and the start date and reason as the option text', () => {
+        const result = ExistingPresenter.go(session)
+
+        expect(result.existingOptions).to.equal([
+          { value: '22ecef19-3a13-44a0-a55e-8f4d34dd59a5', text: '7 May 2024 - Major change' },
+          { value: '60b5d10d-1372-4fb2-b222-bfac81da69ab', text: '1 January 2023' }
+        ])
       })
     })
   })

--- a/test/presenters/return-requirements/existing.presenter.test.js
+++ b/test/presenters/return-requirements/existing.presenter.test.js
@@ -1,0 +1,49 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Thing under test
+const ExistingPresenter = require('../../../app/presenters/return-requirements/existing.presenter.js')
+
+describe('Return Requirements - Existing presenter', () => {
+  let session
+
+  beforeEach(() => {
+    session = {
+      id: '61e07498-f309-4829-96a9-72084a54996d',
+      checkPageVisited: false,
+      licence: {
+        id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
+        currentVersionStartDate: '2023-01-01T00:00:00.000Z',
+        endDate: null,
+        licenceRef: '01/ABC',
+        licenceHolder: 'Turbo Kid',
+        returnVersions: [{
+          id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
+          startDate: '2023-01-01T00:00:00.000Z',
+          reason: null
+        }],
+        startDate: '2022-04-01T00:00:00.000Z'
+      },
+      journey: 'returns-required',
+      requirements: [{}],
+      startDateOptions: 'licenceStartDate'
+    }
+  })
+
+  describe('when provided with a session', () => {
+    it('correctly presents the data', () => {
+      const result = ExistingPresenter.go(session)
+
+      expect(result).to.equal({
+        licenceRef: '01/ABC',
+        sessionId: '61e07498-f309-4829-96a9-72084a54996d'
+      })
+    })
+  })
+})

--- a/test/services/return-requirements/existing.service.test.js
+++ b/test/services/return-requirements/existing.service.test.js
@@ -1,0 +1,62 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const DatabaseSupport = require('../../support/database.js')
+const SessionHelper = require('../../support/helpers/session.helper.js')
+
+// Thing under test
+const ExistingService = require('../../../app/services/return-requirements/existing.service.js')
+
+describe('Return Requirements - Existing service', () => {
+  let session
+
+  beforeEach(async () => {
+    await DatabaseSupport.clean()
+    session = await SessionHelper.add({
+      data: {
+        checkPageVisited: false,
+        licence: {
+          id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
+          currentVersionStartDate: '2023-01-01T00:00:00.000Z',
+          endDate: null,
+          licenceRef: '01/ABC',
+          licenceHolder: 'Turbo Kid',
+          returnVersions: [{
+            id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
+            startDate: '2023-01-01T00:00:00.000Z',
+            reason: null
+          }],
+          startDate: '2022-04-01T00:00:00.000Z'
+        },
+        journey: 'returns-required',
+        requirements: [{}],
+        startDateOptions: 'licenceStartDate'
+      }
+    })
+  })
+
+  describe('when called', () => {
+    it('fetches the current setup session record', async () => {
+      const result = await ExistingService.go(session.id)
+
+      expect(result.sessionId).to.equal(session.id)
+    })
+
+    it('returns page data for the view', async () => {
+      const result = await ExistingService.go(session.id)
+
+      expect(result).to.equal({
+        activeNavBar: 'search',
+        pageTitle: 'Select an existing return requirement from',
+        licenceRef: '01/ABC'
+      }, { skip: ['sessionId'] })
+    })
+  })
+})

--- a/test/services/return-requirements/existing.service.test.js
+++ b/test/services/return-requirements/existing.service.test.js
@@ -54,7 +54,7 @@ describe('Return Requirements - Existing service', () => {
 
       expect(result).to.equal({
         activeNavBar: 'search',
-        pageTitle: 'Select an existing return requirement from',
+        pageTitle: 'Select an existing requirements for returns from',
         existingOptions: [{ value: '60b5d10d-1372-4fb2-b222-bfac81da69ab', text: '1 January 2023' }],
         licenceRef: '01/ABC'
       }, { skip: ['sessionId'] })

--- a/test/services/return-requirements/existing.service.test.js
+++ b/test/services/return-requirements/existing.service.test.js
@@ -55,6 +55,7 @@ describe('Return Requirements - Existing service', () => {
       expect(result).to.equal({
         activeNavBar: 'search',
         pageTitle: 'Select an existing return requirement from',
+        existingOptions: [{ value: '60b5d10d-1372-4fb2-b222-bfac81da69ab', text: '1 January 2023' }],
         licenceRef: '01/ABC'
       }, { skip: ['sessionId'] })
     })

--- a/test/services/return-requirements/fetch-existing-requirements.service.test.js
+++ b/test/services/return-requirements/fetch-existing-requirements.service.test.js
@@ -1,0 +1,71 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const DatabaseSupport = require('../../support/database.js')
+const RequirementsForReturnsSeed = require('../../support/seeders/requirements-for-returns.seeder.js')
+
+// Thing under test
+const FetchExistingRequirementsService = require('../../../app/services/return-requirements/fetch-existing-requirements.service.js')
+
+describe('Return Requirements - Fetch Existing Requirements service', () => {
+  let returnVersion
+
+  beforeEach(async () => {
+    await DatabaseSupport.clean()
+  })
+
+  describe('when a matching return version exists', () => {
+    beforeEach(async () => {
+      returnVersion = await RequirementsForReturnsSeed.seed()
+    })
+
+    it('returns the details of the its return requirements transformed for use in the journey', async () => {
+      const result = await FetchExistingRequirementsService.go(returnVersion.id)
+
+      expect(result).to.equal([
+        {
+          points: ['1234'],
+          purposes: ['1a1a68cc-b1f5-43db-8d1a-3452425bcc68'],
+          returnsCycle: 'winter-and-all-year',
+          siteDescription: 'FIRST BOREHOLE AT AVALON',
+          abstractionPeriod: {
+            'end-abstraction-period-day': 31,
+            'end-abstraction-period-month': 3,
+            'start-abstraction-period-day': 1,
+            'start-abstraction-period-month': 4
+          },
+          frequencyReported: 'weekly',
+          frequencyCollected: 'weekly',
+          agreementsExceptions: ['none']
+        },
+        {
+          points: ['4321'],
+          purposes: ['91bac151-1c95-4ae5-b0bb-490980396e24'],
+          returnsCycle: 'summer',
+          siteDescription: 'SECOND BOREHOLE AT AVALON',
+          abstractionPeriod: {
+            'end-abstraction-period-day': 31,
+            'end-abstraction-period-month': 3,
+            'start-abstraction-period-day': 1,
+            'start-abstraction-period-month': 4
+          },
+          frequencyReported: 'monthly',
+          frequencyCollected: 'weekly',
+          agreementsExceptions: [
+            '56-returns-exception',
+            'gravity-fill',
+            'transfer-re-abstraction-scheme',
+            'two-part-tariff'
+          ]
+        }
+      ])
+    })
+  })
+})

--- a/test/services/return-requirements/submit-existing.service.test.js
+++ b/test/services/return-requirements/submit-existing.service.test.js
@@ -1,0 +1,90 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const DatabaseSupport = require('../../support/database.js')
+const SessionHelper = require('../../support/helpers/session.helper.js')
+
+// Thing under test
+const SubmitExistingService = require('../../../app/services/return-requirements/submit-existing.service.js')
+
+describe('Return Requirements - Submit Existing service', () => {
+  let payload
+  let session
+  let sessionData
+
+  beforeEach(async () => {
+    await DatabaseSupport.clean()
+
+    sessionData = {
+      data: {
+        checkPageVisited: false,
+        licence: {
+          id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
+          currentVersionStartDate: '2023-01-01T00:00:00.000Z',
+          endDate: null,
+          licenceRef: '01/ABC',
+          licenceHolder: 'Turbo Kid',
+          returnVersions: [{
+            id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
+            startDate: '2023-01-01T00:00:00.000Z',
+            reason: null
+          }],
+          startDate: '2022-04-01T00:00:00.000Z'
+        },
+        journey: 'returns-required',
+        requirements: [{}],
+        startDateOptions: 'licenceStartDate'
+      }
+    }
+
+    session = await SessionHelper.add(sessionData)
+  })
+
+  describe('when called', () => {
+    describe('with a valid payload', () => {
+      beforeEach(() => {
+        payload = {
+          existing: '60b5d10d-1372-4fb2-b222-bfac81da69ab'
+        }
+      })
+
+      it('returns the correct details the controller needs to redirect the journey', async () => {
+        const result = await SubmitExistingService.go(session.id, payload)
+
+        expect(result).to.equal({})
+      })
+    })
+
+    describe('with an invalid payload', () => {
+      beforeEach(() => {
+        payload = {}
+      })
+
+      it('returns page data for the view', async () => {
+        const result = await SubmitExistingService.go(session.id, payload)
+
+        expect(result).to.equal({
+          activeNavBar: 'search',
+          pageTitle: 'Select an existing requirements for returns from',
+          existingOptions: [{ value: '60b5d10d-1372-4fb2-b222-bfac81da69ab', text: '1 January 2023' }],
+          licenceRef: '01/ABC'
+        }, { skip: ['sessionId', 'error'] })
+      })
+
+      describe('because the user has not submitted anything', () => {
+        it('includes an error for the input element', async () => {
+          const result = await SubmitExistingService.go(session.id, payload)
+
+          expect(result.error).to.equal({ text: 'Select an existing requirements for returns' })
+        })
+      })
+    })
+  })
+})

--- a/test/services/return-requirements/submit-setup.service.test.js
+++ b/test/services/return-requirements/submit-setup.service.test.js
@@ -69,6 +69,20 @@ describe('Return Requirements - Submit Setup service', () => {
         })
       })
 
+      describe('and the user has selected to copy an existing requirement', () => {
+        beforeEach(() => {
+          payload = {
+            setup: 'use-existing-requirements'
+          }
+        })
+
+        it('returns the route for the select an existing requirement page', async () => {
+          const result = await SubmitSetupService.go(session.id, payload)
+
+          expect(result.redirect).to.equal('existing')
+        })
+      })
+
       describe('and the user has selected to setup the requirement manually', () => {
         beforeEach(() => {
           payload = {

--- a/test/support/seeders/requirements-for-returns.seeder.js
+++ b/test/support/seeders/requirements-for-returns.seeder.js
@@ -1,0 +1,86 @@
+'use strict'
+
+/**
+ * @module RequirementsForReturnsSeeder
+ */
+
+const ReturnRequirementPointHelper = require('../helpers/return-requirement-point.helper.js')
+const ReturnRequirementPurposeHelper = require('../helpers/return-requirement-purpose.helper.js')
+const ReturnRequirementHelper = require('../helpers/return-requirement.helper.js')
+const ReturnVersionHelper = require('../helpers/return-version.helper.js')
+
+/**
+ * Add a complete 'requirements for returns' record, including return version, requirements, points and purposes
+ *
+ * Was built to support the testing of `FetchExistingRequirementsService` but can be used in any scenario where a
+ * complete 'requirements for returns' record is needed.
+ *
+ * It creates the parent return version then two return requirement records. To each it adds a return requirement point
+ * and purpose record.
+ *
+ * The first requirement has a winter returns cycle. reports weekly, and has no agreements. The second has a summer
+ * returns cycle, reports monthly, and has _all_ the agreements!
+ *
+ * Because of this it can be useful to test presenters and services that need to transform the data.
+ *
+ * @param {String} [licenceId] - The UUID of the licence to link the return version to
+ *
+ * @returns a 'complete' `ReturnVersionModel` instance with two return requirements, each containing a point and a
+ * purpose
+ */
+async function seed (licenceId = '1c68cd37-84af-46a4-b3ce-1fc625fcbf37') {
+  // Create a return version to which we'll link multiple return requirements
+  const returnVersion = await ReturnVersionHelper.add({ licenceId })
+
+  // Create the first requirement record
+  let returnRequirement = await _returnRequirement(
+    returnVersion.id,
+    'week',
+    false,
+    1234,
+    '1a1a68cc-b1f5-43db-8d1a-3452425bcc68',
+    false
+  )
+  returnVersion.returnRequirements = [returnRequirement]
+
+  // Create the second requirement record
+  returnRequirement = await _returnRequirement(
+    returnVersion.id,
+    'month',
+    true,
+    4321,
+    '91bac151-1c95-4ae5-b0bb-490980396e24',
+    true
+  )
+  returnVersion.returnRequirements.push(returnRequirement)
+
+  return returnVersion
+}
+
+async function _returnRequirement (returnVersionId, reportingFrequency, summer, naldPointId, purposeId, agreements) {
+  const returnRequirement = await ReturnRequirementHelper.add({
+    collectionFrequency: 'week',
+    fiftySixException: agreements,
+    gravityFill: agreements,
+    reabstraction: agreements,
+    reportingFrequency,
+    returnVersionId,
+    siteDescription: summer ? 'SECOND BOREHOLE AT AVALON' : 'FIRST BOREHOLE AT AVALON',
+    summer,
+    twoPartTariff: agreements
+  })
+
+  const { id: returnRequirementId } = returnRequirement
+
+  const point = await ReturnRequirementPointHelper.add({ naldPointId, returnRequirementId })
+  returnRequirement.returnRequirementPoints = [point]
+
+  const purpose = await ReturnRequirementPurposeHelper.add({ purposeId, returnRequirementId })
+  returnRequirement.returnRequirementPurposes = [purpose]
+
+  return returnRequirement
+}
+
+module.exports = {
+  seed
+}

--- a/test/validators/return-requirements/existing.validator.test.js
+++ b/test/validators/return-requirements/existing.validator.test.js
@@ -1,0 +1,53 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Thing under test
+const ExistingValidator = require('../../../app/validators/return-requirements/existing.validator.js')
+
+describe('Existing validator', () => {
+  const returnVersions = [
+    {
+      id: '60b5d10d-1372-4fb2-b222-bfac81da69ab', reason: null, startDate: '2023-01-01T00:00:00.000Z'
+    },
+    {
+      id: '22ecef19-3a13-44a0-a55e-8f4d34dd59a5', reason: 'major-change', startDate: '2024-05-07T00:00:00.000Z'
+    }
+  ]
+
+  describe('when valid data is provided', () => {
+    it('confirms the data is valid', () => {
+      const result = ExistingValidator.go({ existing: '60b5d10d-1372-4fb2-b222-bfac81da69ab' }, returnVersions)
+
+      expect(result.value).to.exist()
+      expect(result.error).not.to.exist()
+    })
+  })
+
+  describe('when valid data is provided', () => {
+    describe('because no "existing version" is given', () => {
+      it('fails validation', () => {
+        const result = ExistingValidator.go({ existing: '' }, returnVersions)
+
+        expect(result.value).to.exist()
+        expect(result.error).to.exist()
+        expect(result.error.details[0].message).to.equal('Select an existing requirements for returns')
+      })
+    })
+
+    describe('because an unknown "reason" is given', () => {
+      it('fails validation', () => {
+        const result = ExistingValidator.go({ existing: 'be1f32a8-599f-4622-ada7-9dd885f5fc80' }, returnVersions)
+
+        expect(result.value).to.exist()
+        expect(result.error).to.exist()
+        expect(result.error.details[0].message).to.equal('Select an existing requirements for returns')
+      })
+    })
+  })
+})


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4283

> Part of the work to replace NALD for handling return requirements

We want to be able to offer users the option to copy data from an existing return requirement when setting up a new one. We [made the option available](https://github.com/DEFRA/water-abstraction-system/pull/1081) in the `/setup` page.

When a user selects this option they'll be taken to the `Select an existing return requirement from` page. This change is about completing that page and the feature.

- add the controls to the page. These will be dynamically generated based on the licences current return versions
- add validation to the page
- retrieve the requirements for the selected return version and populate the session with them

Once the page has completed it's work the user will be redirected to the `/check` page where they can see the results of their action.