### PR TITLE
Update /jobs/export to be a POST request

### DIFF
--- a/app/routes/jobs.routes.js
+++ b/app/routes/jobs.routes.js
@@ -4,7 +4,7 @@ const JobsController = require('../controllers/jobs.controller.js')
 
 const routes = [
   {
-    method: 'GET',
+    method: 'POST',
     path: '/jobs/export',
     handler: JobsController.exportDb,
     options: {

--- a/test/controllers/jobs.controller.test.js
+++ b/test/controllers/jobs.controller.test.js
@@ -37,9 +37,9 @@ describe('Jobs controller', () => {
   })
 
   describe('/jobs/export', () => {
-    describe('GET', () => {
+    describe('POST', () => {
       beforeEach(() => {
-        options = { method: 'GET', url: '/jobs/export' }
+        options = { method: 'POST', url: '/jobs/export' }
       })
 
       describe('when the request succeeds', () => {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3962

For jobs that we trigger, we always use a POST request. It just helps ensure that a request was intentional and not from something trawling the site and making an inadvertent `GET` request.

We overlooked this when we added `/jobs/export` and were reminded of it again when working on [New job to add new & updated licences to workflow](https://github.com/DEFRA/water-abstraction-system/pull/903).

So, this is a bit of housekeeping to get the job in line with the others.
