### PR TITLE
Fix unique constraint issue in licences-update job

### DIFF
--- a/app/services/jobs/licence-updates/fetch-licence-updates.service.js
+++ b/app/services/jobs/licence-updates/fetch-licence-updates.service.js
@@ -39,7 +39,6 @@ async function go () {
       db
         .select(1)
         .from('workflows as w')
-        .where('w.status', 'to_setup')
         .whereColumn('w.licenceVersionId', 'lv.id')
     )
     // This is only relevant for PRESROC bill runs (see WATER-3528). If a licence is linked to an in-progress PRESROC

--- a/app/services/jobs/licence-updates/fetch-licence-updates.service.js
+++ b/app/services/jobs/licence-updates/fetch-licence-updates.service.js
@@ -1,23 +1,26 @@
 'use strict'
 
 /**
- * Fetches licence versions that were created in last 2 months that have no matching `to_setup` workflow record
+ * Fetches licence versions that were created in last 2 months that have no matching workflow record
  * @module FetchLicenceUpdatesService
  */
 
 const { db } = require('../../../../db/db.js')
 
 /**
- * Fetches licence versions that were created in last two months that have no matching `to_setup` workflow record
+ * Fetches licence versions that were created in last two months that have no matching workflow record
  *
- * If a licence was created in the last two moths and doesn't have a `to_setup` record in workflow it is deemed to
- * have been 'updated.
+ * If a licence was created in the last two moths and doesn't have a `to_setup` record in workflow it is deemed to have
+ * been 'updated.
  *
  * Note, if the licence version is linked to a licence that is part of an in-progress PRESROC bill run it will be
  * excluded from the results (see {@link https://eaflood.atlassian.net/browse/WATER-3528 | WATER-3528}).
  *
- * @returns {Promise<Object[]>} The ID for each licence version created in the last 2 months without a `to_setup`
- * workflow record, plus associated licence ID and whether a charge version exists for the licence
+ * Also, if a workflow record already exists for the licence version, for example, it is already under review, it will
+ * also be excluded from the results.
+ *
+ * @returns {Promise<Object[]>} The ID for each licence version created in the last 2 months without a workflow record,
+ * plus associated licence ID and whether a charge version exists for the licence
  */
 async function go () {
   const twoMonthsAgo = _twoMonthsAgo()
@@ -34,7 +37,6 @@ async function go () {
       db.raw('EXISTS(SELECT 1 FROM public.charge_versions cv WHERE cv.licence_id = lv.licence_id) AS charge_version_exists')
     )
     .from('licenceVersions AS lv')
-    // We only care about licence versions that don't have an existing `to_setup` workflow record
     .whereNotExists(
       db
         .select(1)

--- a/test/services/jobs/licence-updates/fetch-licence-updates.service.test.js
+++ b/test/services/jobs/licence-updates/fetch-licence-updates.service.test.js
@@ -76,10 +76,10 @@ describe('Fetch Licence Updates service', () => {
       })
     })
 
-    describe("because they are already linked to 'to_setup' workflow records", () => {
+    describe('because they are already linked to a workflow records', () => {
       beforeEach(async () => {
         licenceVersion = await LicenceVersionHelper.add({ licenceId: licence.id })
-        await WorkflowHelper.add({ licenceId: licence.id, licenceVersionId: licenceVersion.id, status: 'to_setup' })
+        await WorkflowHelper.add({ licenceId: licence.id, licenceVersionId: licenceVersion.id, status: 'review' })
       })
 
       it('returns no results', async () => {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4437

We encountered an issue when we first ran this job with real data. We should have spotted that the `water.charge_version_workflows` table has a unique constraint on its `licence_version_id` field.

```sql
CREATE UNIQUE INDEX unique_licence_version_id_date_deleted_null ON water.charge_version_workflows USING btree (licence_version_id) WHERE (date_deleted IS NULL);
```

This means a licence version won't have a `to_setup` workflow record but will have a `review` workflow record. Currently, we treat that as a 'result' so try to insert a new workflow record for the updated licence.

This is causing an error. We're not familiar with charge version workflows enough to know whether removing the constraint would cause issues.

So, we just have to accept that an updated licence might appear to be in workflow, be dealt with, but then get put straight back in because now the blocking workflow record is gone so our job adds another back in for the licence.