### PR TITLE
Fix 2PT volume allocation

### DIFF
--- a/app/services/bill-runs/two-part-tariff/allocate-returns-to-charge-element.service.js
+++ b/app/services/bill-runs/two-part-tariff/allocate-returns-to-charge-element.service.js
@@ -35,18 +35,17 @@ function go (chargeElement, matchingReturns, chargePeriod, chargeReference) {
 function _allocateReturns (chargeElement, matchedReturn, chargePeriod, chargeReference, i, matchedLines) {
   matchedLines.forEach((matchedLine) => {
     const chargeElementRemainingAllocation = chargeElement.authorisedAnnualQuantity - chargeElement.allocatedQuantity
+    const chargeReferenceRemainingAllocation = chargeReference.volume - chargeReference.allocatedQuantity
 
-    if (chargeElementRemainingAllocation > 0) {
+    const remainingAllocation = Math.min(chargeElementRemainingAllocation, chargeReferenceRemainingAllocation)
+
+    if (remainingAllocation > 0) {
       let qtyToAllocate
 
       // If what remains to allocate on the charge reference/element is actually less than the `matchedLine.unallocated`
       // we set `qtyToAllocate` to what remains. Else the `qtyToAllocate` is equal to the `matchedLine.unallocated`.
-      const chargeReferenceRemainingAllocation = chargeReference.volume - chargeReference.allocatedQuantity
-
-      if (matchedLine.unallocated > chargeReferenceRemainingAllocation) {
-        qtyToAllocate = chargeReferenceRemainingAllocation
-      } else if (matchedLine.unallocated > chargeElementRemainingAllocation) {
-        qtyToAllocate = chargeElementRemainingAllocation
+      if (matchedLine.unallocated > remainingAllocation) {
+        qtyToAllocate = remainingAllocation
       } else {
         qtyToAllocate = matchedLine.unallocated
       }

--- a/test/services/bill-runs/two-part-tariff/allocate-returns-to-charge-element.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/allocate-returns-to-charge-element.service.test.js
@@ -174,7 +174,7 @@ describe('Allocate Returns to Charge Element Service', () => {
           expect(chargeElement.returnLogs[0].allocatedQuantity).to.equal(3)
         })
 
-        it('allocates 10 from the return log', () => {
+        it('allocates 3 from the return log', () => {
           const { chargeElement, chargeReference, matchingReturns } = testData
 
           AllocateReturnsToChargeElementService.go(chargeElement, matchingReturns, chargePeriod, chargeReference)

--- a/test/services/bill-runs/two-part-tariff/allocate-returns-to-charge-element.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/allocate-returns-to-charge-element.service.test.js
@@ -10,7 +10,7 @@ const { expect } = Code
 // Thing under test
 const AllocateReturnsToChargeElementService = require('../../../../app/services/bill-runs/two-part-tariff/allocate-returns-to-charge-element.service.js')
 
-describe.only('Allocate Returns to Charge Element Service', () => {
+describe('Allocate Returns to Charge Element Service', () => {
   describe('when there are records to process', () => {
     const chargePeriod = {
       startDate: new Date('2022-04-01'),

--- a/test/services/bill-runs/two-part-tariff/allocate-returns-to-charge-element.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/allocate-returns-to-charge-element.service.test.js
@@ -145,9 +145,10 @@ describe('Allocate Returns to Charge Element Service', () => {
       })
 
       // NOTE It was found during testing that if the individual return line volumes are greater than the charge
-      // reference authorised volume, which in turn is greater than the element authorised volume. That the element was
-      // being over allocated. In this scenario 3.5 would have been allocated to the element. This scenario has
-      // therefore been created to test that this does not happen.
+      // reference authorised volume, which in turn is greater than the element authorised volume, that the element was
+      // being over allocated. We should only be allocating to the lower volume. In this scenario 3.5 would have been
+      // allocated to the element rather than the correct volume of 3. This scenario has therefore been created to test
+      // that this does not happen.
       describe('with a reference authorised to 3.5, element to 3, matched to a return with line volumes of 4', () => {
         beforeEach(() => {
           testData = _generateTestData()


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4377

It was found during testing that if the individual return line volumes are greater than the charge reference authorised volume, which in turn is greater than the element authorised volume. That the element was being over-allocated.

This PR fixes this issue and creates a new unit test to check for it as it wasn't being picked up previously.