### PR TITLE
Fix fetching returns for two part tariff

### DIFF
--- a/app/services/bill-runs/two-part-tariff/fetch-return-logs-for-licence.service.js
+++ b/app/services/bill-runs/two-part-tariff/fetch-return-logs-for-licence.service.js
@@ -43,8 +43,8 @@ async function _fetch (licenceRef, billingPeriod) {
     .where('licenceRef', licenceRef)
     // water-abstraction-service filters out old return logs in this way: see `src/lib/services/returns/api-connector.js`
     .where('startDate', '>=', '2008-04-01')
-    .where('startDate', '<=', billingPeriod.endDate)
     .where('endDate', '>=', billingPeriod.startDate)
+    .where('endDate', '<=', billingPeriod.endDate)
     .whereJsonPath('metadata', '$.isTwoPartTariff', '=', true)
     .orderBy('startDate', 'ASC')
     .orderBy('returnReference', 'ASC')

--- a/test/services/bill-runs/two-part-tariff/fetch-return-logs-for-licence.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/fetch-return-logs-for-licence.service.test.js
@@ -147,7 +147,7 @@ describe('Fetch Return Logs for Licence service', () => {
       })
     })
 
-    describe('where the return logs start date is outside the billing period', () => {
+    describe('where the return logs start date is outside the billing period but the end date is inside', () => {
       beforeEach(async () => {
         await ReturnLogHelper.add({
           startDate: new Date('2022-01-01'),
@@ -189,7 +189,7 @@ describe('Fetch Return Logs for Licence service', () => {
       })
     })
 
-    describe('because the return logs end date is outside the billing period', () => {
+    describe('because the return logs start date is inside the billing period but end date is outside', () => {
       beforeEach(async () => {
         returnLogRecord = await ReturnLogHelper.add({
           startDate: new Date('2023-01-01'),

--- a/test/services/bill-runs/two-part-tariff/fetch-return-logs-for-licence.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/fetch-return-logs-for-licence.service.test.js
@@ -146,14 +146,54 @@ describe('Fetch Return Logs for Licence service', () => {
         expect(result[0].returnSubmissions[0].returnSubmissionLines).to.have.length(0)
       })
     })
+
+    describe('where the return logs start date is outside the billing period', () => {
+      beforeEach(async () => {
+        await ReturnLogHelper.add({
+          startDate: new Date('2022-01-01'),
+          endDate: new Date('2022-12-31')
+        })
+        const { id } = returnLogRecord
+
+        await ReturnSubmissionHelper.add({ returnLogId: id })
+      })
+
+      it('returns the return log and return submission lines that are applicable', async () => {
+        const { licenceRef } = returnLogRecord
+        const result = await FetchReturnLogsForLicenceService.go(licenceRef, billingPeriod)
+
+        expect(result).to.have.length(1)
+        expect(result[0].id).to.equal(returnLogRecord.id)
+        expect(result[0].description).to.equal('The Description')
+      })
+    })
   })
 
   describe('when there are NO valid return logs that should be considered', () => {
-    describe('because the return log is outside the billing period', () => {
+    describe('because the return log is fully outside the billing period', () => {
       beforeEach(async () => {
         returnLogRecord = await ReturnLogHelper.add({
           startDate: new Date('2023-04-01'),
           endDate: new Date('2024-03-31')
+        })
+        const { id } = returnLogRecord
+
+        await ReturnSubmissionHelper.add({ returnLogId: id })
+      })
+
+      it('returns no records', async () => {
+        const { licenceRef } = returnLogRecord
+        const result = await FetchReturnLogsForLicenceService.go(licenceRef, billingPeriod)
+
+        expect(result).to.have.length(0)
+      })
+    })
+
+    describe('because the return logs end date is outside the billing period', () => {
+      beforeEach(async () => {
+        returnLogRecord = await ReturnLogHelper.add({
+          startDate: new Date('2023-01-01'),
+          endDate: new Date('2023-12-31')
         })
         const { id } = returnLogRecord
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4188

As part of the ongoing testing for the two-part tariff engine, it was found that there were too many returns matching a charge element. The returns were spread over two years (all within the financial year but starting and finishing outside). This wasn't a bug in the code but rather an A|C that wasn't fleshed out properly. The team don't want returns to be pulled in if the end date of the return is outside the financial year. This PR is to update the fetching query to adjust the start and end dates that the returns can be picked from.