### PR TITLE
Migrate view bill runs page from legacy UI

### DIFF
--- a/app/controllers/bill-runs-setup.controller.js
+++ b/app/controllers/bill-runs-setup.controller.js
@@ -38,7 +38,7 @@ async function create (request, h) {
   try {
     await CreateService.go(request.auth.credentials.user, results)
 
-    return h.redirect('/billing/batch/list')
+    return h.redirect('/system/bill-runs')
   } catch (error) {
     return Boom.badImplementation(error.message)
   }

--- a/app/controllers/bill-runs.controller.js
+++ b/app/controllers/bill-runs.controller.js
@@ -9,6 +9,7 @@ const Boom = require('@hapi/boom')
 
 const CancelBillRunService = require('../services/bill-runs/cancel-bill-run.service.js')
 const CreateBillRunValidator = require('../validators/create-bill-run.validator.js')
+const IndexBillRunsService = require('../services/bill-runs/index-bill-runs.service.js')
 const MatchDetailsService = require('../services/bill-runs/two-part-tariff/match-details.service.js')
 const ReviewBillRunService = require('../services/bill-runs/two-part-tariff/review-bill-run.service.js')
 const ReviewLicenceService = require('../services/bill-runs/two-part-tariff/review-licence.service.js')
@@ -45,6 +46,17 @@ async function create (request, h) {
   } catch (error) {
     return Boom.badImplementation(error.message)
   }
+}
+
+async function index (request, h) {
+  const { page } = request.query
+
+  const pageData = await IndexBillRunsService.go(page)
+
+  return h.view('bill-runs/index.njk', {
+    activeNavBar: 'bill-runs',
+    ...pageData
+  })
 }
 
 async function matchDetails (request, h) {
@@ -137,6 +149,7 @@ async function view (request, h) {
 module.exports = {
   cancel,
   create,
+  index,
   matchDetails,
   review,
   reviewLicence,

--- a/app/controllers/bill-runs.controller.js
+++ b/app/controllers/bill-runs.controller.js
@@ -114,7 +114,7 @@ async function submitCancel (request, h) {
     // `cancel'.
     await SubmitCancelBillRunService.go(id)
 
-    return h.redirect('/billing/batch/list')
+    return h.redirect('/system/bill-runs')
   } catch (error) {
     return Boom.badImplementation(error.message)
   }

--- a/app/presenters/bill-runs/index-bill-runs.presenter.js
+++ b/app/presenters/bill-runs/index-bill-runs.presenter.js
@@ -52,6 +52,10 @@ function go (billRuns) {
 }
 
 function _link (billRunId, status) {
+  if (status === 'cancel') {
+    return null
+  }
+
   if (status === 'review') {
     return `/system/bill-runs/${billRunId}/review`
   }

--- a/app/presenters/bill-runs/index-bill-runs.presenter.js
+++ b/app/presenters/bill-runs/index-bill-runs.presenter.js
@@ -34,8 +34,6 @@ function go (billRuns) {
       status
     } = billRun
 
-    const type = formatBillRunType(batchType, scheme, summer)
-
     return {
       id,
       createdAt: formatLongDate(createdAt),
@@ -46,7 +44,7 @@ function go (billRuns) {
       scheme,
       status,
       total: formatMoney(netTotal, true),
-      type
+      type: formatBillRunType(batchType, scheme, summer)
     }
   })
 }

--- a/app/presenters/bill-runs/index-bill-runs.presenter.js
+++ b/app/presenters/bill-runs/index-bill-runs.presenter.js
@@ -1,0 +1,64 @@
+'use strict'
+
+/**
+ * Formats the summary data for each bill run for use in the /bill-runs page
+ * @module IndexBillRunsPresenter
+ */
+
+const {
+  capitalize,
+  formatBillRunType,
+  formatLongDate,
+  formatMoney
+} = require('../base.presenter.js')
+
+/**
+ * Formats the summary data for each bill run for use in the /bill-runs page
+ *
+ * @param {module:BillRunModel[]} billRuns - The bill runs containing the data to be summarised for the view
+ *
+ * @returns {Object[]} Each bill run summary formatted for use in the `index.njk` template for `/bill-runs`
+ */
+function go (billRuns) {
+  return billRuns.map((billRun) => {
+    const {
+      batchType,
+      billRunNumber,
+      createdAt,
+      id,
+      netTotal,
+      numberOfBills,
+      region,
+      scheme,
+      summer,
+      status
+    } = billRun
+
+    const type = formatBillRunType(batchType, scheme, summer)
+
+    return {
+      id,
+      createdAt: formatLongDate(createdAt),
+      link: _link(id, status),
+      number: billRunNumber,
+      numberOfBills,
+      region: capitalize(region),
+      scheme,
+      status,
+      total: formatMoney(netTotal, true),
+      type
+    }
+  })
+}
+
+function _link (billRunId, status) {
+  if (status === 'review') {
+    return `/system/bill-runs/${billRunId}/review`
+  }
+
+  return `/system/bill-runs/${billRunId}`
+}
+
+module.exports = {
+  go
+}

--- a/app/routes/bill-runs.routes.js
+++ b/app/routes/bill-runs.routes.js
@@ -4,6 +4,19 @@ const BillRunsController = require('../controllers/bill-runs.controller.js')
 
 const routes = [
   {
+    method: 'GET',
+    path: '/bill-runs',
+    handler: BillRunsController.index,
+    options: {
+      auth: {
+        access: {
+          scope: ['billing']
+        }
+      },
+      description: 'List all bill runs'
+    }
+  },
+  {
     method: 'POST',
     path: '/bill-runs',
     handler: BillRunsController.create,

--- a/app/services/bill-runs/index-bill-runs.service.js
+++ b/app/services/bill-runs/index-bill-runs.service.js
@@ -1,0 +1,63 @@
+'use strict'
+
+/**
+ * Orchestrates fetching and presenting the data needed for the /bill-runs page
+ * @module IndexBillRunsService
+ */
+
+const CheckBusyBillRunsService = require('./check-busy-bill-runs.service.js')
+const FetchBillRunsService = require('./fetch-bill-runs.service.js')
+const IndexBillRunsPresenter = require('../../presenters/bill-runs/index-bill-runs.presenter.js')
+const PaginatorPresenter = require('../../presenters/paginator.presenter.js')
+
+/**
+ * Orchestrates fetching and presenting the data needed for the /bill-runs page
+ *
+ * @param {string} page - the page number of bill runs to be viewed
+ *
+ * @returns {Promise<Object>} an object representing the `pageData` needed by the index bill run template. It contains
+ * summary details for each bill run for the page selected, for the templates pagination control, the title and the
+ * status of busy bill runs
+ */
+async function go (page) {
+  const selectedPageNumber = _selectedPageNumber(page)
+
+  // We expect the FetchBillRunsService to take longer to complete than CheckBusyBillRunsService. But running them
+  // together means we are only waiting as long as it takes rather than the combined time to run both queries
+  const [fetchedBillRunResult, busyResult] = await Promise.all([
+    FetchBillRunsService.go(selectedPageNumber),
+    CheckBusyBillRunsService.go()
+  ])
+
+  const billRuns = IndexBillRunsPresenter.go(fetchedBillRunResult.results)
+  const pagination = PaginatorPresenter.go(fetchedBillRunResult.total, selectedPageNumber)
+
+  const pageTitle = _pageTitle(pagination.numberOfPages, selectedPageNumber)
+
+  return {
+    billRuns,
+    busy: busyResult,
+    pageTitle,
+    pagination
+  }
+}
+
+function _pageTitle (numberOfPages, selectedPageNumber) {
+  if (numberOfPages === 1) {
+    return 'Bill runs'
+  }
+
+  return `Bill runs (page ${selectedPageNumber} of ${numberOfPages})`
+}
+
+function _selectedPageNumber (page) {
+  if (!page) {
+    return 1
+  }
+
+  return Number(page)
+}
+
+module.exports = {
+  go
+}

--- a/app/services/bill-runs/index-bill-runs.service.js
+++ b/app/services/bill-runs/index-bill-runs.service.js
@@ -16,14 +16,15 @@ const PaginatorPresenter = require('../../presenters/paginator.presenter.js')
  * @param {string} page - the page number of bill runs to be viewed
  *
  * @returns {Promise<Object>} an object representing the `pageData` needed by the index bill run template. It contains
- * summary details for each bill run for the page selected, for the templates pagination control, the title and the
- * status of busy bill runs
+ * summary details for each bill run for the page selected, the template's pagination control, the title and the
+ * status of any busy bill runs
  */
 async function go (page) {
   const selectedPageNumber = _selectedPageNumber(page)
 
   // We expect the FetchBillRunsService to take longer to complete than CheckBusyBillRunsService. But running them
-  // together means we are only waiting as long as it takes rather than the combined time to run both queries
+  // together means we are only waiting as long as it takes FetchBillRunsService to complete rather than their combined
+  // time
   const [fetchedBillRunResult, busyResult] = await Promise.all([
     FetchBillRunsService.go(selectedPageNumber),
     CheckBusyBillRunsService.go()

--- a/app/services/bill-runs/index-bill-runs.service.js
+++ b/app/services/bill-runs/index-bill-runs.service.js
@@ -31,7 +31,7 @@ async function go (page) {
   ])
 
   const billRuns = IndexBillRunsPresenter.go(fetchedBillRunResult.results)
-  const pagination = PaginatorPresenter.go(fetchedBillRunResult.total, selectedPageNumber)
+  const pagination = PaginatorPresenter.go(fetchedBillRunResult.total, selectedPageNumber, '/system/bill-runs')
 
   const pageTitle = _pageTitle(pagination.numberOfPages, selectedPageNumber)
 

--- a/app/views/bill-runs/empty.njk
+++ b/app/views/bill-runs/empty.njk
@@ -11,7 +11,7 @@
   {{
     govukBackLink({
       text: 'Go back to bill runs',
-      href: '/billing/batch/list'
+      href: '/system/bill-runs'
     })
   }}
 {% endblock %}

--- a/app/views/bill-runs/errored.njk
+++ b/app/views/bill-runs/errored.njk
@@ -11,7 +11,7 @@
   {{
     govukBackLink({
       text: 'Go back to bill runs',
-      href: '/billing/batch/list'
+      href: '/system/bill-runs'
     })
   }}
 {% endblock %}

--- a/app/views/bill-runs/index.njk
+++ b/app/views/bill-runs/index.njk
@@ -1,0 +1,132 @@
+{% extends 'layout.njk' %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
+{% from "govuk/components/pagination/macro.njk" import govukPagination %}
+{% from "govuk/components/table/macro.njk" import govukTable %}
+
+{% from "macros/bill-run-status-tag.njk" import statusTag %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      {# Bill runs busy banner #}
+      {% if busy == 'both' %}
+        {{ govukNotificationBanner({
+            html: '<p class="govuk-notification-banner__heading">Bill runs are currently busy building and cancelling.</p>
+              <p class="govuk-body">Please wait for these bill runs to finish before creating another one.</p>'
+        }) }}
+      {% elif busy == 'building' %}
+        {{ govukNotificationBanner({
+            html: '<p class="govuk-notification-banner__heading">A bill run is currently building.</p>
+              <p class="govuk-body">Please wait for this bill run to finish building before creating another one.</p>'
+        }) }}
+      {% elif busy == 'cancelling' %}
+        {{ govukNotificationBanner({
+            html: '<p class="govuk-notification-banner__heading">A bill run is currently cancelling.</p>
+              <p class="govuk-body">Please wait for this bill run to finish cancelling before creating another one.</p>'
+        }) }}
+      {% endif %}
+
+      <h1 class="govuk-heading-xl">Bill runs</h1>
+
+      <p class="govuk-body">Create a supplementary, annual or two-part tariff bill run.</p>
+
+      {{ govukButton({
+        text: "Create a bill run",
+        href: "/system/bill-runs/setup"
+      }) }}
+
+      <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+
+    </div>
+  </div>
+
+  <div class="govuk-grid-row govuk-!-margin-bottom-9">
+    <div class="govuk-grid-column-full">
+      {# Results #}
+      {% if billRuns|length == 0 %}
+        <p>No bill runs found.</p>
+      {% else %}
+        <h2 class="govuk-heading-l govuk-!-margin-top-6">View a bill run</h2>
+
+        <p class="govuk-body">Select date to see the details of a bill run.</p>
+
+        {% set tableRows = [] %}
+        {% for billRun in billRuns %}
+          {# Set an easier to use index #}
+          {% set rowIndex = loop.index0 %}
+
+
+          {# Generate the link to view the bill run #}
+          {% set viewLink %}
+            <a class="govuk-link" href="{{ billRun.link }}">{{ billRun.createdAt }} <span class="govuk-visually-hidden">View bill run {{ billRun.number }}</span></a>
+            {% if billRun.scheme == 'alcs' %}
+              <div class="govuk-body-s govuk-!-margin-0">Old charge scheme</div>
+            {% endif %}
+          {% endset %}
+
+          {% set billRunStatusTag %}
+            {{ statusTag(billRun.status, true) }}
+          {% endset %}
+
+          {% set tableRow = [
+            {
+              html: viewLink,
+              attributes: { 'data-test': 'date-created-' + rowIndex }
+            },
+            {
+              text: billRun.region,
+              attributes: { 'data-test': 'region-' + rowIndex }
+            },
+            {
+              text: billRun.type,
+              attributes: { 'data-test': 'bill-run-type-' + rowIndex }
+            },
+            {
+              text: billRun.number,
+              attributes: { 'data-test': 'bill-run-number-' + rowIndex },
+              format: 'numeric'
+            },
+            {
+              text: billRun.numberOfBills,
+              attributes: { 'data-test': 'number-of-bills-' + rowIndex },
+              format: 'numeric'
+            },
+            {
+              text: billRun.total,
+              attributes: { 'data-test': 'bill-run-total-' + rowIndex },
+              format: 'numeric'
+            },
+            {
+              html: billRunStatusTag,
+              attributes: { 'data-test': 'bill-run-status-' + rowIndex },
+              format: 'numeric'
+            }
+          ] %}
+
+          {# Push our row into the table rows array #}
+          {% set tableRows = (tableRows.push(tableRow), tableRows) %}
+        {% endfor %}
+
+        {{ govukTable({
+            firstCellIsHeader: false,
+            attributes: { 'data-test': 'bill-runs'},
+            head: [
+              { text: 'Date' },
+              { text: 'Region' },
+              { text: 'Run type' },
+              { text: 'Number', format: 'numeric' },
+              { text: 'Bills', format: 'numeric' },
+              { text: 'Values', format: 'numeric' },
+              { text: 'Status', format: 'numeric' }
+            ],
+            rows: tableRows
+        }) }}
+
+        {% if pagination.numberOfPages > 1  %}
+          {{ govukPagination(pagination.component) }}
+        {% endif %}
+      {% endif %}
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/bill-runs/index.njk
+++ b/app/views/bill-runs/index.njk
@@ -57,9 +57,15 @@
           {% set rowIndex = loop.index0 %}
 
 
-          {# Generate the link to view the bill run #}
+          {# Link to view the bill run #}
           {% set viewLink %}
-            <a class="govuk-link" href="{{ billRun.link }}">{{ billRun.createdAt }} <span class="govuk-visually-hidden">View bill run {{ billRun.number }}</span></a>
+            {# If the link is null it is because the bill run is cancelling so we do not want to display a link #}
+            {% if billRun.link %}
+              <a class="govuk-link" href="{{ billRun.link }}">{{ billRun.createdAt }} <span class="govuk-visually-hidden">View bill run {{ billRun.number }}</span></a>
+            {% else %}
+              {{ billRun.createdAt }}
+            {% endif %}
+
             {% if billRun.scheme == 'alcs' %}
               <div class="govuk-body-s govuk-!-margin-0">Old charge scheme</div>
             {% endif %}

--- a/app/views/bill-runs/review.njk
+++ b/app/views/bill-runs/review.njk
@@ -16,7 +16,7 @@
   {# Back link #}
   {{ govukBackLink({
       text: 'Go back to bill runs',
-      href: '/billing/batch/list'
+      href: '/system/bill-runs'
   }) }}
 {% endblock %}
 

--- a/app/views/bill-runs/setup/type.njk
+++ b/app/views/bill-runs/setup/type.njk
@@ -9,7 +9,7 @@
   {{
     govukBackLink({
       text: 'Go back to bill runs',
-      href: '/billing/batch/list'
+      href: '/system/bill-runs'
     })
   }}
 {% endblock %}

--- a/app/views/bill-runs/view.njk
+++ b/app/views/bill-runs/view.njk
@@ -12,7 +12,7 @@
   {{
     govukBackLink({
       text: 'Go back to bill runs',
-      href: '/billing/batch/list'
+      href: '/system/bill-runs'
     })
   }}
 {% endblock %}

--- a/app/views/includes/nav-bar.njk
+++ b/app/views/includes/nav-bar.njk
@@ -9,7 +9,7 @@
       </li>
     {% if auth.permission.billRuns %}
       <li class="navbar__item">
-        <a class="navbar__link govuk-link--no-visited-state {{ 'navbar__link--active' if activeNavBar === 'bill-runs' }}" href="/billing/batch/list" id="nav-bill-runs">
+        <a class="navbar__link govuk-link--no-visited-state {{ 'navbar__link--active' if activeNavBar === 'bill-runs' }}" href="/system/bill-runs" id="nav-bill-runs">
           Bill runs
         </a>
       </li>

--- a/app/views/macros/bill-run-status-tag.njk
+++ b/app/views/macros/bill-run-status-tag.njk
@@ -1,24 +1,30 @@
 {% from "govuk/components/tag/macro.njk" import govukTag %}
 
-{% macro statusTag(status) %}
+{% macro statusTag(status, inline=false) %}
   {% if status === 'ready' %}
-    {% set classes = "govuk-tag--blue govuk-!-font-size-27" %}
+    {% set color = "govuk-tag--blue" %}
   {% elif status === 'review' %}
-    {% set classes = "govuk-tag--blue govuk-!-font-size-27" %}
+    {% set color = "govuk-tag--blue" %}
   {% elif status === 'sent' %}
-    {% set classes = "govuk-tag--green govuk-!-font-size-27" %}
+    {% set color = "govuk-tag--green" %}
   {% elif status === 'empty' %}
-    {% set classes = "govuk-tag--grey govuk-!-font-size-27" %}
+    {% set color = "govuk-tag--grey" %}
   {% elif status === 'error' %}
-    {% set classes = "govuk-tag--red govuk-!-font-size-27" %}
+    {% set color = "govuk-tag--red" %}
   {% else %}
-    {% set classes = "govuk-tag--blue govuk-!-font-size-27" %}
+    {% set color = "govuk-tag--blue" %}
+  {% endif %}
+
+  {% if inline %}
+    {% set fontSize = "" %}
+  {% else %}
+    {% set fontSize = "govuk-!-font-size-27" %}
   {% endif %}
 
   {{
     govukTag({
       text: status,
-      classes: classes
+      classes: color + ' ' + fontSize
     })
   }}
 {% endmacro %}

--- a/app/views/macros/bill-run-status-tag.njk
+++ b/app/views/macros/bill-run-status-tag.njk
@@ -9,6 +9,8 @@
     {% set color = "govuk-tag--green" %}
   {% elif status === 'empty' %}
     {% set color = "govuk-tag--grey" %}
+  {% elif status === 'cancel' %}
+    {% set color = "govuk-tag--orange" %}
   {% elif status === 'error' %}
     {% set color = "govuk-tag--red" %}
   {% else %}

--- a/test/controllers/bill-runs-setup.controller.test.js
+++ b/test/controllers/bill-runs-setup.controller.test.js
@@ -112,7 +112,7 @@ describe('Bill Runs Setup controller', () => {
             const response = await server.inject(options)
 
             expect(response.statusCode).to.equal(302)
-            expect(response.headers.location).to.equal('/billing/batch/list')
+            expect(response.headers.location).to.equal('/system/bill-runs')
           })
         })
       })

--- a/test/controllers/bill-runs.controller.test.js
+++ b/test/controllers/bill-runs.controller.test.js
@@ -11,6 +11,7 @@ const { expect } = Code
 // Things we need to stub
 const Boom = require('@hapi/boom')
 const CancelBillRunService = require('../../app/services/bill-runs/cancel-bill-run.service.js')
+const IndexBillRunsService = require('../../app/services/bill-runs/index-bill-runs.service.js')
 const ReviewLicenceService = require('../../app/services/bill-runs/two-part-tariff/review-licence.service.js')
 const ReviewBillRunService = require('../../app/services/bill-runs/two-part-tariff/review-bill-run.service.js')
 const SendBillRunService = require('../../app/services/bill-runs/send-bill-run.service.js')
@@ -44,6 +45,61 @@ describe('Bill Runs controller', () => {
   })
 
   describe('/bill-runs', () => {
+    describe('GET', () => {
+      beforeEach(async () => {
+        options = {
+          method: 'GET',
+          url: '/bill-runs?page=2',
+          auth: {
+            strategy: 'session',
+            credentials: { scope: ['billing'] }
+          }
+        }
+      })
+
+      describe('when the request succeeds', () => {
+        beforeEach(async () => {
+          Sinon.stub(IndexBillRunsService, 'go').resolves({
+            billRuns: [{
+              id: '31fec553-f2de-40cf-a8d7-a5fb65f5761b',
+              createdAt: '1 January 2024',
+              link: '/system/bill-runs/31fec553-f2de-40cf-a8d7-a5fb65f5761b',
+              number: 1002,
+              numberOfBills: 7,
+              region: 'Avalon',
+              scheme: 'sroc',
+              status: 'ready',
+              total: '£200.00',
+              type: 'Supplementary'
+            }],
+            busy: 'none',
+            pageTitle: 'Bill runs (page 2 of 30)',
+            pagination: {
+              numberOfPages: 30,
+              component: {
+                previous: { href: '/system/bill-runs?page=1' },
+                next: { href: '/system/bill-runs?page=3' },
+                items: [
+                  { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs?page=1', current: false },
+                  { number: 2, visuallyHiddenText: 'Page 2', href: '/system/bill-runs?page=2', current: true },
+                  { number: 3, visuallyHiddenText: 'Page 3', href: '/system/bill-runs?page=3', current: false }
+                ]
+              }
+            }
+          })
+        })
+
+        it('returns the page successfully', async () => {
+          const response = await server.inject(options)
+
+          expect(response.statusCode).to.equal(200)
+          expect(response.payload).to.contain('Bill runs (page 2 of 30)')
+          expect(response.payload).to.contain('Previous')
+          expect(response.payload).to.contain('Next')
+        })
+      })
+    })
+
     describe('POST', () => {
       beforeEach(() => {
         options = _options('POST')

--- a/test/controllers/bill-runs.controller.test.js
+++ b/test/controllers/bill-runs.controller.test.js
@@ -247,7 +247,7 @@ describe('Bill Runs controller', () => {
           const response = await server.inject(options)
 
           expect(response.statusCode).to.equal(302)
-          expect(response.headers.location).to.equal('/billing/batch/list')
+          expect(response.headers.location).to.equal('/system/bill-runs')
         })
       })
 

--- a/test/presenters/bill-runs/index.bill-runs.presenter.test.js
+++ b/test/presenters/bill-runs/index.bill-runs.presenter.test.js
@@ -50,11 +50,26 @@ describe('Index Bill Runs presenter', () => {
     })
 
     describe("the 'link' property", () => {
-      it('generates the href needed to link to the bill run', () => {
-        const results = IndexBillRunsPresenter.go(billRuns)
+      describe("when a bill run has the status 'review'", () => {
+        beforeEach(() => {
+          billRuns[0].status = 'review'
+        })
 
-        expect(results[0].link).to.equal('/system/bill-runs/31fec553-f2de-40cf-a8d7-a5fb65f5761b')
-        expect(results[1].link).to.equal('/system/bill-runs/dfdde4c9-9a0e-440d-b297-7143903c6734')
+        it('generates the href needed to link to the bill run review', () => {
+          const results = IndexBillRunsPresenter.go(billRuns)
+
+          expect(results[0].link).to.equal('/system/bill-runs/31fec553-f2de-40cf-a8d7-a5fb65f5761b/review')
+          expect(results[1].link).to.equal('/system/bill-runs/dfdde4c9-9a0e-440d-b297-7143903c6734')
+        })
+      })
+
+      describe("when a bill run does not have the status 'review'", () => {
+        it('generates the href needed to link to the bill run', () => {
+          const results = IndexBillRunsPresenter.go(billRuns)
+
+          expect(results[0].link).to.equal('/system/bill-runs/31fec553-f2de-40cf-a8d7-a5fb65f5761b')
+          expect(results[1].link).to.equal('/system/bill-runs/dfdde4c9-9a0e-440d-b297-7143903c6734')
+        })
       })
     })
   })

--- a/test/presenters/bill-runs/index.bill-runs.presenter.test.js
+++ b/test/presenters/bill-runs/index.bill-runs.presenter.test.js
@@ -63,6 +63,19 @@ describe('Index Bill Runs presenter', () => {
         })
       })
 
+      describe("when a bill run has the status 'cancel'", () => {
+        beforeEach(() => {
+          billRuns[0].status = 'cancel'
+        })
+
+        it('does not generate a href (returns null)', () => {
+          const results = IndexBillRunsPresenter.go(billRuns)
+
+          expect(results[0].link).to.be.null()
+          expect(results[1].link).to.equal('/system/bill-runs/dfdde4c9-9a0e-440d-b297-7143903c6734')
+        })
+      })
+
       describe("when a bill run does not have the status 'review'", () => {
         it('generates the href needed to link to the bill run', () => {
           const results = IndexBillRunsPresenter.go(billRuns)

--- a/test/presenters/bill-runs/index.bill-runs.presenter.test.js
+++ b/test/presenters/bill-runs/index.bill-runs.presenter.test.js
@@ -1,0 +1,90 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Thing under test
+const IndexBillRunsPresenter = require('../../../app/presenters/bill-runs/index-bill-runs.presenter.js')
+
+describe('Index Bill Runs presenter', () => {
+  let billRuns
+
+  describe('when provided with a populated bill run', () => {
+    beforeEach(() => {
+      billRuns = _billRuns()
+    })
+
+    it('correctly presents the data', () => {
+      const results = IndexBillRunsPresenter.go(billRuns)
+
+      expect(results).to.equal([
+        {
+          id: '31fec553-f2de-40cf-a8d7-a5fb65f5761b',
+          createdAt: '1 January 2024',
+          link: '/system/bill-runs/31fec553-f2de-40cf-a8d7-a5fb65f5761b',
+          number: 1002,
+          numberOfBills: 7,
+          region: 'Avalon',
+          scheme: 'sroc',
+          status: 'ready',
+          total: '£200.00',
+          type: 'Supplementary'
+        },
+        {
+          id: 'dfdde4c9-9a0e-440d-b297-7143903c6734',
+          createdAt: '1 October 2023',
+          link: '/system/bill-runs/dfdde4c9-9a0e-440d-b297-7143903c6734',
+          number: 1001,
+          numberOfBills: 15,
+          region: 'Albion',
+          scheme: 'sroc',
+          status: 'sent',
+          total: '£300.00',
+          type: 'Supplementary'
+        }
+      ])
+    })
+
+    describe("the 'link' property", () => {
+      it('generates the href needed to link to the bill run', () => {
+        const results = IndexBillRunsPresenter.go(billRuns)
+
+        expect(results[0].link).to.equal('/system/bill-runs/31fec553-f2de-40cf-a8d7-a5fb65f5761b')
+        expect(results[1].link).to.equal('/system/bill-runs/dfdde4c9-9a0e-440d-b297-7143903c6734')
+      })
+    })
+  })
+})
+
+function _billRuns () {
+  return [
+    {
+      id: '31fec553-f2de-40cf-a8d7-a5fb65f5761b',
+      batchType: 'supplementary',
+      billRunNumber: 1002,
+      createdAt: new Date('2024-01-01'),
+      netTotal: 20000,
+      scheme: 'sroc',
+      status: 'ready',
+      summer: false,
+      numberOfBills: 7,
+      region: 'Avalon'
+    },
+    {
+      id: 'dfdde4c9-9a0e-440d-b297-7143903c6734',
+      batchType: 'supplementary',
+      billRunNumber: 1001,
+      createdAt: new Date('2023-10-01'),
+      netTotal: 30000,
+      scheme: 'sroc',
+      status: 'sent',
+      summer: false,
+      numberOfBills: 15,
+      region: 'Albion'
+    }
+  ]
+}

--- a/test/services/bill-runs/index-bill-runs.service.test.js
+++ b/test/services/bill-runs/index-bill-runs.service.test.js
@@ -1,0 +1,136 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { describe, it, beforeEach, afterEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Things we need to stub
+const CheckBusyBillRunsService = require('../../../app/services/bill-runs/check-busy-bill-runs.service.js')
+const FetchBillRunsService = require('../../../app/services/bill-runs/fetch-bill-runs.service.js')
+
+// Thing under test
+const IndexBillRunsService = require('../../../app/services/bill-runs/index-bill-runs.service.js')
+
+describe('Index Bill Runs service', () => {
+  let page
+
+  beforeEach(() => {
+    // It doesn't matter for these tests what busy state the service returns, only that it returns one.
+    Sinon.stub(CheckBusyBillRunsService, 'go').resolves('none')
+  })
+
+  afterEach(() => {
+    Sinon.restore()
+  })
+
+  describe('when there is only one page of results', () => {
+    beforeEach(() => {
+      Sinon.stub(FetchBillRunsService, 'go').resolves({
+        results: _fetchedBillRuns(),
+        total: 2
+      })
+    })
+
+    it("returns all bill runs, the state of 'busy' bill runs, the title without page info and no pagination component for the view", async () => {
+      const result = await IndexBillRunsService.go(page)
+
+      expect(result.billRuns).to.have.length(2)
+      expect(result.busy).to.equal('none')
+      expect(result.pageTitle).to.equal('Bill runs')
+      expect(result.pagination.component).not.to.exist()
+    })
+  })
+
+  describe('when there are multiple pages of results', () => {
+    describe('and no page is selected', () => {
+      beforeEach(() => {
+        Sinon.stub(FetchBillRunsService, 'go').resolves({
+          results: _fetchedBillRuns(),
+          total: 70
+        })
+      })
+
+      it("returns the first page of bill runs, the state of 'busy' bill runs, the title with page info and a pagination component for the view", async () => {
+        const result = await IndexBillRunsService.go(page)
+
+        expect(result.billRuns).to.have.length(2)
+        expect(result.busy).to.equal('none')
+        expect(result.pageTitle).to.equal('Bill runs (page 1 of 3)')
+        expect(result.pagination.component).to.exist()
+      })
+    })
+
+    describe("and a page other than 'page 1' with bill runs is selected", () => {
+      beforeEach(() => {
+        page = 2
+
+        Sinon.stub(FetchBillRunsService, 'go').resolves({
+          results: _fetchedBillRuns(),
+          total: 70
+        })
+      })
+
+      it("returns the page of bill runs, the state of 'busy' bill runs, the title with page info and a pagination component for the view", async () => {
+        const result = await IndexBillRunsService.go(page)
+
+        expect(result.billRuns).to.have.length(2)
+        expect(result.busy).to.equal('none')
+        expect(result.pageTitle).to.equal('Bill runs (page 2 of 3)')
+        expect(result.pagination.component).to.exist()
+      })
+    })
+
+    describe('and a page without bill runs is selected', () => {
+      beforeEach(() => {
+        page = 3
+
+        Sinon.stub(FetchBillRunsService, 'go').resolves({
+          results: [],
+          total: 70
+        })
+      })
+
+      it("returns no bill runs, the state of 'busy' bill runs, the title with page info and a pagination component for the view", async () => {
+        const result = await IndexBillRunsService.go(page)
+
+        expect(result.billRuns).to.be.empty()
+        expect(result.busy).to.equal('none')
+        expect(result.pageTitle).to.equal('Bill runs (page 3 of 3)')
+        expect(result.pagination.component).to.exist()
+      })
+    })
+  })
+})
+
+function _fetchedBillRuns () {
+  return [
+    {
+      id: '31fec553-f2de-40cf-a8d7-a5fb65f5761b',
+      batchType: 'supplementary',
+      billRunNumber: 1002,
+      createdAt: new Date('2024-01-01'),
+      netTotal: 20000,
+      scheme: 'sroc',
+      status: 'ready',
+      summer: false,
+      numberOfBills: 7,
+      region: 'Avalon'
+    },
+    {
+      id: 'dfdde4c9-9a0e-440d-b297-7143903c6734',
+      batchType: 'supplementary',
+      billRunNumber: 1001,
+      createdAt: new Date('2023-10-01'),
+      netTotal: 30000,
+      scheme: 'sroc',
+      status: 'sent',
+      summer: false,
+      numberOfBills: 15,
+      region: 'Albion'
+    }
+  ]
+}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4445

> Part of a series of changes to migrate the legacy view bill runs page into this project

This is the final step in migrating the legacy view bill runs page to this project. We dealt with the support services we need in previous changes. Now we need to add

- the route
- the controller handler
- the orchestration service
- the view template

We also update the menu to point to it and not the legacy `/billing/batch/list`. Worth noting (because this is the first) we use the convention of naming the handler and subsequent files `index` to reflect they deal with displaying a list of bill runs, not a single one.

![Screenshot 2024-04-22 at 22 50 51](https://github.com/DEFRA/water-abstraction-system/assets/1789650/c7258cfa-f73d-4658-9983-6693fcf2db0b)
