### PR TITLE
Redirect to check-your-answers from reason page

### DIFF
--- a/app/controllers/return-requirements.controller.js
+++ b/app/controllers/return-requirements.controller.js
@@ -308,6 +308,10 @@ async function submitReason (request, h) {
     return h.view('return-requirements/reason.njk', pageData)
   }
 
+  if (pageData.checkYourAnswersVisited) {
+    return h.redirect(`/system/return-requirements/${sessionId}/check-your-answers`)
+  }
+
   return h.redirect(`/system/return-requirements/${sessionId}/setup`)
 }
 

--- a/app/services/return-requirements/submit-reason.service.js
+++ b/app/services/return-requirements/submit-reason.service.js
@@ -31,13 +31,16 @@ async function go (sessionId, payload) {
   if (!validationResult) {
     await _save(session, payload)
 
-    return {}
+    return {
+      checkYourAnswersVisited: session.data.checkYourAnswersVisited
+    }
   }
 
   const formattedData = ReasonPresenter.go(session, payload)
 
   return {
     activeNavBar: 'search',
+    checkYourAnswersVisited: session.data.checkYourAnswersVisited,
     error: validationResult,
     pageTitle: 'Select the reason for the return requirement',
     ...formattedData

--- a/app/views/return-requirements/reason.njk
+++ b/app/views/return-requirements/reason.njk
@@ -6,10 +6,14 @@
 
 {% block breadcrumbs %}
   {# Back link #}
+  {% set backLink %}
+    /system/return-requirements/{{ id }}/{{ 'check-your-answers' if checkYourAnswersVisited else 'start-date' }}
+  {% endset %}
+
   {{
     govukBackLink({
       text: 'Back',
-      href: '/system/return-requirements/' + id + '/start-date'
+      href: backLink
     })
   }}
 {% endblock %}

--- a/test/services/return-requirements/submit-reason.service.test.js
+++ b/test/services/return-requirements/submit-reason.service.test.js
@@ -23,6 +23,7 @@ describe('Submit Reason service', () => {
 
     session = await SessionHelper.add({
       data: {
+        checkYourAnswersVisited: false,
         licence: {
           id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
           currentVersionStartDate: '2023-01-01T00:00:00.000Z',
@@ -58,6 +59,7 @@ describe('Submit Reason service', () => {
 
         expect(result).to.equal({
           activeNavBar: 'search',
+          checkYourAnswersVisited: false,
           pageTitle: 'Select the reason for the return requirement',
           licenceRef: '01/ABC'
         }, { skip: ['id', 'error'] })
@@ -81,6 +83,7 @@ describe('Submit Reason service', () => {
 
           expect(result).to.equal({
             activeNavBar: 'search',
+            checkYourAnswersVisited: false,
             pageTitle: 'Select the reason for the return requirement',
             licenceRef: '01/ABC'
           }, { skip: ['id', 'error'] })


### PR DESCRIPTION
This change will ensure that the reason page redirects back to check-your-answers if the user came from there.