### PR TITLE
Use yar for Review licence flash notifications

### DIFF
--- a/app/controllers/bill-runs.controller.js
+++ b/app/controllers/bill-runs.controller.js
@@ -100,7 +100,7 @@ async function review (request, h) {
 async function reviewLicence (request, h) {
   const { id: billRunId, licenceId } = request.params
 
-  const pageData = await ReviewLicenceService.go(billRunId, licenceId)
+  const pageData = await ReviewLicenceService.go(billRunId, licenceId, request.yar)
 
   return h.view('bill-runs/review-licence.njk', {
     pageTitle: `Licence ${pageData.licence.licenceRef}`,
@@ -150,13 +150,9 @@ async function submitCancel (request, h) {
 async function submitReviewLicence (request, h) {
   const { id: billRunId, licenceId } = request.params
 
-  const pageData = await SubmitReviewLicenceService.go(billRunId, licenceId, request.payload)
+  await SubmitReviewLicenceService.go(billRunId, licenceId, request.payload, request.yar)
 
-  return h.view('bill-runs/review-licence.njk', {
-    pageTitle: `Licence ${pageData.licence.licenceRef}`,
-    activeNavBar: 'bill-runs',
-    ...pageData
-  })
+  return h.redirect(`/system/bill-runs/${billRunId}/review/${licenceId}`)
 }
 
 async function submitSend (request, h) {

--- a/app/presenters/bill-runs/two-part-tariff/review-licence.presenter.js
+++ b/app/presenters/bill-runs/two-part-tariff/review-licence.presenter.js
@@ -9,20 +9,14 @@ const DetermineAbstractionPeriodService = require('../../../services/bill-runs/d
 const { formatLongDate } = require('../../base.presenter.js')
 
 /**
- * Prepares and processes bill run and review licence data for presentation
+ * Formats the review licence data ready for presenting in the review licence page
  *
- * @param {module:BillRunModel} billRun the data from the bill run
- * @param {module:ReviewLicenceModel} licence the data from review licence
- * @param {String} licenceStatus will contain the string 'ready' or 'review' if the licence review status button has
- * been clicked, otherwise it will be null. It is used to determine the message displayed by the 'Licence updated'
- * banner, if any
- * @param {String} markProgress will contain the string 'mark' or 'unmark' if the mark/unmark progress button has been
- * clicked, otherwise it will be null. It is used to determine the message displayed by the 'Licence updated'
- * banner, if any
+ * @param {module:BillRunModel} billRun - the data from the bill run
+ * @param {module:ReviewLicenceModel} licence - the data from review licence
  *
  * @returns {Object} the prepared bill run and licence data to be passed to the review licence page
  */
-function go (billRun, licence, licenceStatus, markProgress) {
+function go (billRun, licence) {
   return {
     billRunId: billRun.id,
     region: billRun.region.displayName,
@@ -34,7 +28,6 @@ function go (billRun, licence, licenceStatus, markProgress) {
       progress: licence[0].progress
     },
     elementsInReview: licence[0].hasReviewStatus,
-    licenceUpdatedMessage: _licenceUpdatedMessage(licenceStatus, markProgress),
     matchedReturns: _matchedReturns(licence[0].reviewReturns),
     unmatchedReturns: _unmatchedReturns(licence[0].reviewReturns),
     chargeData: _prepareChargeData(licence, billRun)
@@ -141,20 +134,6 @@ function _financialYear (financialYearEnding) {
   const endYear = financialYearEnding
 
   return `${startYear} to ${endYear}`
-}
-
-function _licenceUpdatedMessage (licenceStatus, markProgress) {
-  if (licenceStatus === 'ready') {
-    return 'Licence changed to ready.'
-  } else if (licenceStatus === 'review') {
-    return 'Licence changed to review.'
-  } else if (markProgress === 'mark') {
-    return 'This licence has been marked.'
-  } else if (markProgress === 'unmark') {
-    return 'The progress mark for this licence has been removed.'
-  } else {
-    return null
-  }
 }
 
 function _matchedReturns (returnLogs) {

--- a/app/services/bill-runs/two-part-tariff/review-licence.service.js
+++ b/app/services/bill-runs/two-part-tariff/review-licence.service.js
@@ -9,20 +9,25 @@ const FetchReviewLicenceResultsService = require('./fetch-review-licence-results
 const ReviewLicencePresenter = require('../../../presenters/bill-runs/two-part-tariff/review-licence.presenter.js')
 
 /**
- * Orchestrated fetching and presenting the data needed for the licence review page
+ * Orchestrates fetching and presenting the data needed for the licence review page in a two-part tariff bill run
  *
- * @param {module:BillRunModel} billRunId The UUID for the bill run
- * @param {module:LicenceModel} licenceId The UUID of the licence that is being reviewed
+ * @param {module:BillRunModel} billRunId - The UUID for the bill run
+ * @param {module:LicenceModel} licenceId - The UUID of the licence that is being reviewed
+ * @param {Object} sessionManager - The Hapi `request.yar` session manager passed on by the controller
  *
  * @returns {Promise<Object>} the 'pageData' needed for the review licence page. It contains the licence, bill run,
  * matched and unmatched returns and the licence charge data
  */
-async function go (billRunId, licenceId) {
+async function go (billRunId, licenceId, yar) {
   const { billRun, licence } = await FetchReviewLicenceResultsService.go(billRunId, licenceId)
 
+  const [bannerMessage] = yar.flash('banner')
   const pageData = ReviewLicencePresenter.go(billRun, licence)
 
-  return pageData
+  return {
+    bannerMessage,
+    ...pageData
+  }
 }
 
 module.exports = {

--- a/app/services/bill-runs/two-part-tariff/submit-review-licence.service.js
+++ b/app/services/bill-runs/two-part-tariff/submit-review-licence.service.js
@@ -1,62 +1,77 @@
 'use strict'
 
 /**
- * Orchestrates fetching and presenting the data needed for the licence review page in a two-part tariff bill run
- * @module ReviewLicenceService
+ * Handles updating a review licence record when the progress or status buttons are clicked
+ * @module SubmitReviewLicenceService
  */
 
-const FetchReviewLicenceResultsService = require('./fetch-review-licence-results.service.js')
 const ReviewLicenceModel = require('../../../models/review-licence.model.js')
-const ReviewLicencePresenter = require('../../../presenters/bill-runs/two-part-tariff/review-licence.presenter.js')
 
 /**
- * Orchestrated fetching and presenting the data needed for the licence review page
+ * Handles updating a review licence record when the progress or status buttons are clicked
  *
- * @param {module:BillRunModel} billRunId The UUID for the bill run
- * @param {module:LicenceModel} licenceId The UUID of the licence that is being reviewed
- * @param {Object} payload The `request.payload` containing the `marKProgress` data. This is only passed to the service
- * when there is a POST request, which only occurs when the 'Mark progress' button is clicked.
+ * The progress button in the two-part tariff review licence screen toggles whether a licence is 'in-progress' or not.
  *
- * @returns {Object} an object representing the 'pageData' needed to review the individual licence. It contains the
- * licence, bill run, matched and unmatched returns and the licence charge data
+ * The status button toggles whether a licence is 'ready' or in 'review'.
+ *
+ * We update the `ReviewLicenceModel` record and set a `flash()` message in the session so that when the request is
+ * redirected to the `GET` it knows to display a notification banner to confirm that the progress or status has changed
+ * to the user.
+ *
+ * @param {module:BillRunModel} billRunId - The UUID for the bill run
+ * @param {module:LicenceModel} licenceId - The UUID of the licence that is being reviewed
+ * @param {Object} payload - The Hapi `request.payload` object passed on by the controller
+ * @param {Object} yar - The Hapi `request.yar` session manager passed on by the controller
+ *
+ * @returns {Promise<Object>} resolves to the result of the update query. Not intended to be used
  */
-async function go (billRunId, licenceId, payload) {
-  const licenceStatus = payload?.licenceStatus
-  const markProgress = payload?.marKProgress
+async function go (billRunId, licenceId, payload, yar) {
+  const parsedPayload = _parsePayload(payload)
 
-  if (payload) {
-    await _processPayload(billRunId, licenceId, licenceStatus, markProgress)
-  }
+  // NOTE: The YarPlugin decorates the Hapi request object with a yar property. Yar is a session manager
+  _bannerMessage(yar, parsedPayload)
 
-  const { billRun, licence } = await FetchReviewLicenceResultsService.go(billRunId, licenceId)
-
-  const pageData = ReviewLicencePresenter.go(billRun, licence, licenceStatus, markProgress)
-
-  return pageData
+  return _update(billRunId, licenceId, parsedPayload)
 }
 
-async function _processPayload (billRunId, licenceId, licenceStatus, markProgress) {
-  if (licenceStatus === 'ready' || licenceStatus === 'review') {
-    await _updateStatus(billRunId, licenceId, licenceStatus)
+function _bannerMessage (yar, parsedPayload) {
+  const { progress, status } = parsedPayload
+
+  if (status) {
+    yar.flash('banner', `Licence changed to ${status}.`)
+    return
   }
 
-  if (markProgress === 'mark' || markProgress === 'unmark') {
-    await _updateProgress(billRunId, licenceId, markProgress)
+  if (progress) {
+    yar.flash('banner', 'This licence has been marked.')
+    return
+  }
+
+  yar.flash('banner', 'The progress mark for this licence has been removed.')
+}
+
+function _parsePayload (payload) {
+  const markProgress = payload.marKProgress ?? null
+  const licenceStatus = payload.licenceStatus ?? null
+
+  return {
+    progress: markProgress === 'mark',
+    status: licenceStatus
   }
 }
 
-async function _updateProgress (billRunId, licenceId, marKProgress) {
-  const progress = marKProgress === 'mark'
+async function _update (billRunId, licenceId, parsedPayload) {
+  const { progress, status } = parsedPayload
+  const patch = {}
 
-  await ReviewLicenceModel.query()
-    .patch({ progress })
-    .where('billRunId', billRunId)
-    .andWhere('licenceId', licenceId)
-}
+  if (status) {
+    patch.status = status
+  } else {
+    patch.progress = progress
+  }
 
-async function _updateStatus (billRunId, licenceId, licenceStatus) {
-  await ReviewLicenceModel.query()
-    .patch({ status: licenceStatus })
+  return ReviewLicenceModel.query()
+    .patch(patch)
     .where('billRunId', billRunId)
     .andWhere('licenceId', licenceId)
 }

--- a/app/services/bill-runs/two-part-tariff/submit-review-licence.service.js
+++ b/app/services/bill-runs/two-part-tariff/submit-review-licence.service.js
@@ -51,8 +51,8 @@ function _bannerMessage (yar, parsedPayload) {
 }
 
 function _parsePayload (payload) {
-  const markProgress = payload.marKProgress ?? null
-  const licenceStatus = payload.licenceStatus ?? null
+  const markProgress = payload['mark-progress'] ?? null
+  const licenceStatus = payload['licence-status'] ?? null
 
   return {
     progress: markProgress === 'mark',

--- a/app/views/bill-runs/review-licence.njk
+++ b/app/views/bill-runs/review-licence.njk
@@ -21,10 +21,10 @@
 
 {% block content %}
   {# Licence updated banner #}
-  {% if licenceUpdatedMessage %}
+  {% if bannerMessage %}
     {{ govukNotificationBanner({
       titleText: 'Licence updated',
-      text: licenceUpdatedMessage
+      text: bannerMessage
     }) }}
   {% endif %}
 

--- a/app/views/bill-runs/review-licence.njk
+++ b/app/views/bill-runs/review-licence.njk
@@ -86,7 +86,7 @@
       text: statusButtonText,
       classes: statusButtonClass,
       preventDoubleClick: true,
-      name: "licenceStatus",
+      name: "licence-status",
       value: statusButtonValue
     }) }}
 
@@ -94,7 +94,7 @@
       text: progressButtonText,
       classes: "govuk-button--secondary",
       preventDoubleClick: true,
-      name: "marKProgress",
+      name: "mark-progress",
       value: progressButtonValue
     }) }}
     </div>

--- a/test/controllers/bill-runs.controller.test.js
+++ b/test/controllers/bill-runs.controller.test.js
@@ -374,16 +374,14 @@ describe('Bill Runs controller', () => {
 
       describe('when a request is valid', () => {
         beforeEach(() => {
-          Sinon.stub(SubmitReviewLicenceService, 'go').resolves(_licenceReviewData())
+          Sinon.stub(SubmitReviewLicenceService, 'go').resolves()
         })
 
-        it('returns a 200 response', async () => {
+        it('redirects to the review licence page', async () => {
           const response = await server.inject(options)
 
-          expect(response.statusCode).to.equal(200)
-          expect(response.payload).to.contain('1/11/10/*S/0084')
-          expect(response.payload).to.contain('two-part tariff')
-          expect(response.payload).to.contain('Test Road. Points 1 and 2.')
+          expect(response.statusCode).to.equal(302)
+          expect(response.headers.location).to.equal('/system/bill-runs/97db1a27-8308-4aba-b463-8a6af2558b28/review/cc4bbb18-0d6a-4254-ac2c-7409de814d7e')
         })
       })
     })

--- a/test/presenters/bill-runs/two-part-tariff/review-licence.presenter.test.js
+++ b/test/presenters/bill-runs/two-part-tariff/review-licence.presenter.test.js
@@ -13,19 +13,15 @@ const ReviewLicencePresenter = require('../../../../app/presenters/bill-runs/two
 describe('Review Licence presenter', () => {
   let billRun
   let licence
-  let licenceStatus
-  let markProgress
 
   describe('when there is data to be presented for the review licence page', () => {
     beforeEach(() => {
       billRun = _billRun()
       licence = _licenceData()
-      licenceStatus = undefined
-      markProgress = undefined
     })
 
     it('correctly presents the data', async () => {
-      const result = ReviewLicencePresenter.go(billRun, licence, licenceStatus, markProgress)
+      const result = ReviewLicencePresenter.go(billRun, licence)
 
       expect(result).to.equal({
         billRunId: '6620135b-0ecf-4fd4-924e-371f950c0526',
@@ -37,7 +33,6 @@ describe('Review Licence presenter', () => {
           status: 'ready',
           licenceHolder: 'Licence Holder Ltd'
         },
-        licenceUpdatedMessage: null,
         elementsInReview: false,
         matchedReturns: [
           {
@@ -185,66 +180,6 @@ describe('Review Licence presenter', () => {
           expect(result.matchedReturns[0].returnStatus).to.equal('query')
         })
       })
-    })
-  })
-
-  describe('when there is data to be presented and the user has clicked the "Confirm licence is ready" button', () => {
-    beforeEach(() => {
-      billRun = _billRun()
-      licence = _licenceData()
-      licenceStatus = 'ready'
-      markProgress = undefined
-    })
-
-    it('correctly returns the text for the "Licence updated" notification banner', async () => {
-      const result = ReviewLicencePresenter.go(billRun, licence, licenceStatus, markProgress)
-
-      expect(result.licenceUpdatedMessage).to.equal('Licence changed to ready.')
-    })
-  })
-
-  describe('when there is data to be presented and the user has clicked the "Put licence into Review" button', () => {
-    beforeEach(() => {
-      billRun = _billRun()
-      licence = _licenceData()
-      licenceStatus = 'review'
-      markProgress = undefined
-    })
-
-    it('correctly returns the text for the "Licence updated" notification banner', async () => {
-      const result = ReviewLicencePresenter.go(billRun, licence, licenceStatus, markProgress)
-
-      expect(result.licenceUpdatedMessage).to.equal('Licence changed to review.')
-    })
-  })
-
-  describe('when there is data to be presented and the user has clicked the "Mark progress" button', () => {
-    beforeEach(() => {
-      billRun = _billRun()
-      licence = _licenceData()
-      licenceStatus = undefined
-      markProgress = 'mark'
-    })
-
-    it('correctly returns the text for the "Licence updated" notification banner', async () => {
-      const result = ReviewLicencePresenter.go(billRun, licence, licenceStatus, markProgress)
-
-      expect(result.licenceUpdatedMessage).to.equal('This licence has been marked.')
-    })
-  })
-
-  describe('when there is data to be presented and the user has clicked the "Remove progress mark" button', () => {
-    beforeEach(() => {
-      billRun = _billRun()
-      licence = _licenceData()
-      licenceStatus = undefined
-      markProgress = 'unmark'
-    })
-
-    it('correctly returns the text for the "Licence updated" notification banner', async () => {
-      const result = ReviewLicencePresenter.go(billRun, licence, licenceStatus, markProgress)
-
-      expect(result.licenceUpdatedMessage).to.equal('The progress mark for this licence has been removed.')
     })
   })
 })

--- a/test/services/bill-runs/two-part-tariff/review-licence.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/review-licence.service.test.js
@@ -18,8 +18,12 @@ describe('Review Licence Service', () => {
   const billRunId = '2c80bd22-a005-4cf4-a2a2-73812a9861de'
   const licenceId = '082f528e-4ae4-4f41-ba64-b740a0a210ff'
 
+  let yarStub
+
   beforeEach(async () => {
     Sinon.stub(FetchReviewLicenceResultsService, 'go').resolves(_fetchReviewLicenceResults())
+
+    yarStub = { flash: Sinon.stub().returns(['This licence has been marked.']) }
   })
 
   afterEach(() => {
@@ -28,10 +32,12 @@ describe('Review Licence Service', () => {
 
   describe('when called', () => {
     it('returns page data for the view', async () => {
-      const result = await ReviewLicenceService.go(billRunId, licenceId)
+      const result = await ReviewLicenceService.go(billRunId, licenceId, yarStub)
 
-      // NOTE: The service just regurgitates what the ReviewLicencePresenter returns. So, we don't diligently check
-      // each property of the result because we know this will have been covered by the ReviewLicencePresenter
+      expect(result.bannerMessage).to.equal('This licence has been marked.')
+
+      // NOTE: The service mainly just regurgitates what the ReviewLicencePresenter returns. So, we don't diligently
+      // check each property of the result because we know this will have been covered by the ReviewLicencePresenter
       expect(result.billRunId).to.equal('6620135b-0ecf-4fd4-924e-371f950c0526')
       expect(result.region).to.equal('Anglian')
       expect(result.licence.licenceId).to.equal('786f0d83-eaf7-43c3-9de5-ec59e3de05ee')

--- a/test/services/bill-runs/two-part-tariff/review-licence.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/review-licence.service.test.js
@@ -41,7 +41,6 @@ describe('Review Licence Service', () => {
       expect(result.billRunId).to.equal('6620135b-0ecf-4fd4-924e-371f950c0526')
       expect(result.region).to.equal('Anglian')
       expect(result.licence.licenceId).to.equal('786f0d83-eaf7-43c3-9de5-ec59e3de05ee')
-      expect(result.licenceUpdatedMessage).to.be.null()
       expect(result.matchedReturns[0].returnId).to.equal('v1:1:01/60/28/3437:17061181:2022-04-01:2023-03-31')
       expect(result.unmatchedReturns[0].returnId).to.equal('v2:1:01/60/28/3437:17061181:2022-04-01:2023-03-31')
       expect(result.chargeData[0].financialYear).to.equal('2022 to 2023')

--- a/test/services/bill-runs/two-part-tariff/submit-review-licence.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/submit-review-licence.service.test.js
@@ -36,7 +36,7 @@ describe('Submit Review Licence Service', () => {
   describe('when called by the status button', () => {
     describe("to set the review licence status to 'review'", () => {
       beforeEach(async () => {
-        payload = { licenceStatus: 'review' }
+        payload = { 'licence-status': 'review' }
 
         reviewLicence = await ReviewLicenceHelper.add({ billRunId, licenceId, status: 'ready' })
       })
@@ -61,7 +61,7 @@ describe('Submit Review Licence Service', () => {
 
     describe("to set the review licence status to 'ready'", () => {
       beforeEach(async () => {
-        payload = { licenceStatus: 'ready' }
+        payload = { 'licence-status': 'ready' }
 
         reviewLicence = await ReviewLicenceHelper.add({ billRunId, licenceId, status: 'review' })
       })
@@ -88,7 +88,7 @@ describe('Submit Review Licence Service', () => {
   describe('when called by the progress button', () => {
     describe('to mark the licence as in progress', () => {
       beforeEach(async () => {
-        payload = { marKProgress: 'mark' }
+        payload = { 'mark-progress': 'mark' }
 
         reviewLicence = await ReviewLicenceHelper.add({ billRunId, licenceId, progress: false })
       })
@@ -113,7 +113,7 @@ describe('Submit Review Licence Service', () => {
 
     describe('to remove the progress mark from the licence', () => {
       beforeEach(async () => {
-        payload = { marKProgress: 'unmark' }
+        payload = { 'mark-progress': 'unmark' }
 
         reviewLicence = await ReviewLicenceHelper.add({ billRunId, licenceId, progress: true })
       })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4447

We recently added [Hapi yar session manager to the project](https://github.com/DEFRA/water-abstraction-system/pull/926). This was specifically to support flash notification banners (ones that appear on the first GET request but then disappear).

The Review licence screen has a number of these already. Ones for when you toggle the progress and others for toggling the status. These have been achieved by breaking the [post-redirect-get pattern](https://www.geeksforgeeks.org/post-redirect-get-prg-design-pattern/) and responding directly to the POST request.

As a first step we [refactored `ReviewLicenceService`](https://github.com/DEFRA/water-abstraction-system/pull/928) into two; `ReviewLicenceService` and `SubmitReviewLicenceService`.

We can now complete the process. This change updates `SubmitReviewLicenceService` to use **yar** and have the associated controller redirect rather than respond.