### PR TITLE
Fix validation messages for two-part tariff billable returns page

### DIFF
--- a/app/services/bill-runs/two-part-tariff/submit-amended-billable-returns.service.js
+++ b/app/services/bill-runs/two-part-tariff/submit-amended-billable-returns.service.js
@@ -21,7 +21,7 @@ const ReviewChargeElementModel = require('../../../models/review-charge-element.
  * @returns {Promise<Object>} The updated value for the billable returns
  */
 async function go (billRunId, licenceId, reviewChargeElementId, payload) {
-  const validationResult = await _validate(payload)
+  const validationResult = _validate(payload)
 
   if (!validationResult) {
     await _persistAmendedBillableReturns(reviewChargeElementId, payload)

--- a/app/services/bill-runs/two-part-tariff/submit-amended-billable-returns.service.js
+++ b/app/services/bill-runs/two-part-tariff/submit-amended-billable-returns.service.js
@@ -5,8 +5,9 @@
  * @module SubmitAmendedBillableReturnsService
 */
 
-const AmendBillableReturnsService = require('../../../services/bill-runs/two-part-tariff/amend-billable-returns.service.js')
+const AmendBillableReturnsPresenter = require('../../../presenters/bill-runs/two-part-tariff/amend-billable-returns.presenter.js')
 const BillableReturnsValidator = require('../../../validators/bill-runs/two-part-tariff/billable-returns.validator.js')
+const FetchMatchDetailsService = require('./fetch-match-details.service.js')
 const ReviewChargeElementModel = require('../../../models/review-charge-element.model.js')
 
 /**
@@ -28,13 +29,16 @@ async function go (billRunId, licenceId, reviewChargeElementId, payload) {
     return { error: null }
   }
 
-  const pageData = await AmendBillableReturnsService.go(billRunId, licenceId, reviewChargeElementId)
+  const { billRun, reviewChargeElement } = await FetchMatchDetailsService.go(billRunId, reviewChargeElementId)
+  const pageData = AmendBillableReturnsPresenter.go(billRun, reviewChargeElement, licenceId)
 
   return {
     activeNavBar: 'search',
     pageTitle: 'Set the billable returns quantity for this bill run',
     error: validationResult,
-    ...pageData
+    ...pageData,
+    customQuantitySelected: payload['quantity-options'] === 'customQuantity',
+    customQuantityValue: payload.customQuantity
   }
 }
 

--- a/app/services/bill-runs/two-part-tariff/submit-amended-billable-returns.service.js
+++ b/app/services/bill-runs/two-part-tariff/submit-amended-billable-returns.service.js
@@ -36,9 +36,9 @@ async function go (billRunId, licenceId, reviewChargeElementId, payload) {
     activeNavBar: 'search',
     pageTitle: 'Set the billable returns quantity for this bill run',
     error: validationResult,
-    ...pageData,
     customQuantitySelected: payload['quantity-options'] === 'customQuantity',
-    customQuantityValue: payload.customQuantity
+    customQuantityValue: payload.customQuantity,
+    ...pageData
   }
 }
 

--- a/app/services/bill-runs/two-part-tariff/submit-amended-billable-returns.service.js
+++ b/app/services/bill-runs/two-part-tariff/submit-amended-billable-returns.service.js
@@ -59,18 +59,13 @@ function _validate (payload) {
 
   const { message } = validation.error.details[0]
 
-  if (payload['quantity-options'] === 'customQuantity') {
-    return {
-      message,
-      radioFormElement: null,
-      customQuantityInputFormElement: { text: message }
-    }
-  }
+  const radioFormElement = payload['quantity-options'] === 'customQuantity' ? null : { text: message }
+  const customQuantityInputFormElement = payload['quantity-options'] === 'customQuantity' ? { text: message } : null
 
   return {
     message,
-    radioFormElement: { text: message },
-    customQuantityInputFormElement: null
+    radioFormElement,
+    customQuantityInputFormElement
   }
 }
 

--- a/app/validators/bill-runs/two-part-tariff/billable-returns.validator.js
+++ b/app/validators/bill-runs/two-part-tariff/billable-returns.validator.js
@@ -49,12 +49,12 @@ function customValidation (customQuantity, helpers) {
   return helpers.message({ custom: 'The quantity must contain no more than 6 decimal places' })
 }
 
-function _validateCustomQuantity (customQuantity, authorisedAnnualQuantity) {
+function _validateCustomQuantity (customQuantity, authorisedVolume) {
   const schema = Joi.object({
     customQuantity: Joi
       .number()
       .min(0)
-      .max(authorisedAnnualQuantity)
+      .max(authorisedVolume)
       .required()
       .messages({
         'number.unsafe': 'The quantity must be a number',

--- a/app/validators/bill-runs/two-part-tariff/billable-returns.validator.js
+++ b/app/validators/bill-runs/two-part-tariff/billable-returns.validator.js
@@ -24,7 +24,7 @@ function go (payload) {
   const { 'quantity-options': selectedOption } = payload
 
   if (selectedOption === 'customQuantity') {
-    return _validateCustomQuantity(payload.customQuantity)
+    return _validateCustomQuantity(payload.customQuantity, Number(payload.authorisedVolume))
   }
 
   return _validateAuthorisedQuantity(selectedOption)
@@ -46,17 +46,22 @@ function customValidation (customQuantity, helpers) {
     return customQuantity
   }
 
-  return helpers.message({ custom: 'You must enter less than 6 decimal places' })
+  return helpers.message({ custom: 'The quantity must contain no more than 6 decimal places' })
 }
 
-function _validateCustomQuantity (customQuantity) {
+function _validateCustomQuantity (customQuantity, authorisedAnnualQuantity) {
   const schema = Joi.object({
     customQuantity: Joi
       .number()
+      .min(0)
+      .max(authorisedAnnualQuantity)
       .required()
       .messages({
-        'number.base': 'You must enter a number',
-        'any.required': 'You must enter a custom quantity'
+        'number.unsafe': 'The quantity must be a number',
+        'number.base': 'The quantity must be a number',
+        'number.min': 'The quantity must be zero or higher',
+        'number.max': 'The quantity must be the same as or less than the authorised amount',
+        'any.required': 'Enter the billable quantity'
       })
   })
 
@@ -79,7 +84,7 @@ function _validateAuthorisedQuantity (selectedOption) {
       .number()
       .required()
       .messages({
-        'any.required': 'You must choose or enter a value'
+        'any.required': 'Select the billable quantity'
       })
   })
 

--- a/app/validators/bill-runs/two-part-tariff/billable-returns.validator.js
+++ b/app/validators/bill-runs/two-part-tariff/billable-returns.validator.js
@@ -12,7 +12,7 @@ const Joi = require('joi')
  * Validates data submitted for the `/bill-runs/{billRunId}/review/{licenceId}/match-details/{reviewChargeElementId}
  * /amend-billable-returns` page
  *
- * When editing the charge elements billable volume the user must either chose the existing authorised volume or enter
+ * When editing the charge elements billable volume the user must either choose the existing authorised volume or enter
  * there own custom volume. The validation happening here is to ensure that a user selects either option and if its the
  * custom one, that they enter a number above 0 but below the authorised volume and that the number is less than 6
  * decimal places.

--- a/app/validators/bill-runs/two-part-tariff/billable-returns.validator.js
+++ b/app/validators/bill-runs/two-part-tariff/billable-returns.validator.js
@@ -14,7 +14,8 @@ const Joi = require('joi')
  *
  * When editing the charge elements billable volume the user must either chose the existing authorised volume or enter
  * there own custom volume. The validation happening here is to ensure that a user selects either option and if its the
- * custom one, that they enter a number and that the number is less than 6 decimal places.
+ * custom one, that they enter a number above 0 but below the authorised volume and that the number is less than 6
+ * decimal places.
  * @param {Object} payload - The payload from the request to be validated
  *
  * @returns {Object} the result from calling Joi's schema.validate(). It will be an object with a `value:` property. If

--- a/app/views/bill-runs/amend-billable-returns.njk
+++ b/app/views/bill-runs/amend-billable-returns.njk
@@ -16,11 +16,16 @@
 {% endblock %}
 
 {% set quantityInputHTML %}
+  {% if error.customQuantityInputFormElement %}
+    {% set errorClass = 'govuk-input--error' %}
+  {% endif %}
+
   {{ govukInput({
     id: "custom-quantity-input",
     name: "customQuantity",
     errorMessage: error.customQuantityInputFormElement,
-    classes: "govuk-!-width-one-third",
+    classes: "govuk-!-width-one-third " + errorClass,
+    value: customQuantityValue,
     label: {
       text: "Billable returns quantity"
     },
@@ -64,6 +69,7 @@
     <form method="post">
       {{ govukRadios({
           name: 'quantity-options',
+          errorMessage: error.radioFormElement,
           fieldset: {
             legend: {
               html: '<span class="govuk-caption-l">' + chargeElement.description + ' ' +  chargeElement.dates + '</span>' + 'Set the billable returns quantity for this bill run' + secondHeader,
@@ -75,8 +81,7 @@
             {
               id: 'authorised-quantity',
               value: chargeElement.authorisedQuantity,
-              html: 'Authorised ' + chargeElement.authorisedQuantity + 'ML',
-              checked: authorisedQuantitySelected
+              html: 'Authorised ' + chargeElement.authorisedQuantity + 'ML'
             },
             {
               id: 'custom-quantity',
@@ -89,6 +94,9 @@
             }
           ]
         }) }}
+
+      {# Hidden input for authorised volume #}
+      <input type="hidden" name="authorisedVolume" value="{{ chargeElement.authorisedQuantity }}">
 
       {{ govukButton({ text: 'Confirm' }) }}
     </form>

--- a/test/services/bill-runs/two-part-tariff/submit-amended-billable-returns.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/submit-amended-billable-returns.service.test.js
@@ -14,7 +14,8 @@ const ReviewChargeElementHelper = require('../../../support/helpers/review-charg
 const ReviewChargeElementModel = require('../../../../app/models/review-charge-element.model.js')
 
 // Things we need to stub
-const AmendBillableReturnsService = require('../../../../app/services/bill-runs/two-part-tariff/amend-billable-returns.service.js')
+const FetchMatchDetailsService = require('../../../../app/services/bill-runs/two-part-tariff/fetch-match-details.service.js')
+const AmendBillableReturnsPresenter = require('../../../../app/presenters/bill-runs/two-part-tariff/amend-billable-returns.presenter.js')
 
 // Thing under test
 const SubmitAmendedBillableReturnsService = require('../../../../app/services/bill-runs/two-part-tariff/submit-amended-billable-returns.service.js')
@@ -39,7 +40,8 @@ describe('Submit Amended Billable Returns Service', () => {
     describe('with a valid payload for quantityOptions', () => {
       beforeEach(async () => {
         payload = {
-          'quantity-options': 10
+          'quantity-options': 10,
+          authorisedVolume: 11
         }
       })
 
@@ -56,7 +58,8 @@ describe('Submit Amended Billable Returns Service', () => {
       beforeEach(async () => {
         payload = {
           'quantity-options': 'customQuantity',
-          customQuantity: 20
+          customQuantity: 20,
+          authorisedVolume: 25
         }
       })
 
@@ -70,11 +73,15 @@ describe('Submit Amended Billable Returns Service', () => {
     })
 
     describe('with an invalid payload', () => {
+      beforeEach(() => {
+        Sinon.stub(FetchMatchDetailsService, 'go').resolves({ billRun: 'bill run', reviewChargeElement: 'charge element' })
+        Sinon.stub(AmendBillableReturnsPresenter, 'go').returns(_amendBillableReturnsData())
+      })
       describe('because the user did not select anything', () => {
         beforeEach(async () => {
-          payload = {}
-
-          Sinon.stub(AmendBillableReturnsService, 'go').resolves(_amendBillableReturnsData())
+          payload = {
+            authorisedVolume: 11
+          }
         })
 
         it('returns the page data for the view', async () => {
@@ -96,7 +103,9 @@ describe('Submit Amended Billable Returns Service', () => {
             chargeVersion: {
               chargePeriod: '1 April 2022 to 5 June 2022'
             },
-            licenceId: '5aa8e752-1a5c-4b01-9112-d92a543b70d1'
+            licenceId: '5aa8e752-1a5c-4b01-9112-d92a543b70d1',
+            customQuantitySelected: false,
+            customQuantityValue: undefined
           }, { skip: ['error'] })
         })
 
@@ -104,8 +113,8 @@ describe('Submit Amended Billable Returns Service', () => {
           const result = await SubmitAmendedBillableReturnsService.go(billRunId, licenceId, reviewChargeElement.id, payload)
 
           expect(result.error).to.equal({
-            message: 'You must choose or enter a value',
-            radioFormElement: { text: 'You must choose or enter a value' },
+            message: 'Select the billable quantity',
+            radioFormElement: { text: 'Select the billable quantity' },
             customQuantityInputFormElement: null
           })
         })
@@ -115,10 +124,9 @@ describe('Submit Amended Billable Returns Service', () => {
         beforeEach(async () => {
           payload = {
             'quantity-options': 'customQuantity',
-            customQuantity: 'Hello world'
+            customQuantity: 'Hello world',
+            authorisedVolume: 11
           }
-
-          Sinon.stub(AmendBillableReturnsService, 'go').resolves(_amendBillableReturnsData())
         })
 
         it('returns the page data for the view', async () => {
@@ -140,7 +148,9 @@ describe('Submit Amended Billable Returns Service', () => {
             chargeVersion: {
               chargePeriod: '1 April 2022 to 5 June 2022'
             },
-            licenceId: '5aa8e752-1a5c-4b01-9112-d92a543b70d1'
+            licenceId: '5aa8e752-1a5c-4b01-9112-d92a543b70d1',
+            customQuantitySelected: true,
+            customQuantityValue: 'Hello world'
           }, { skip: ['error'] })
         })
 
@@ -148,9 +158,9 @@ describe('Submit Amended Billable Returns Service', () => {
           const result = await SubmitAmendedBillableReturnsService.go(billRunId, licenceId, reviewChargeElement.id, payload)
 
           expect(result.error).to.equal({
-            message: 'You must enter a number',
+            message: 'The quantity must be a number',
             radioFormElement: null,
-            customQuantityInputFormElement: { text: 'You must enter a number' }
+            customQuantityInputFormElement: { text: 'The quantity must be a number' }
           })
         })
       })

--- a/test/validators/bill-runs/two-part-tariff/billable-returns.validator.test.js
+++ b/test/validators/bill-runs/two-part-tariff/billable-returns.validator.test.js
@@ -29,7 +29,7 @@ describe('Billable Returns validator', () => {
       })
     })
 
-    describe('because the user entered a valid volume (less than the authorised volume but greater than 0', () => {
+    describe('because the user entered a valid volume (less than the authorised volume but greater than 0)', () => {
       beforeEach(() => {
         payload = {
           'quantity-options': 'customQuantity',

--- a/test/validators/bill-runs/two-part-tariff/billable-returns.validator.test.js
+++ b/test/validators/bill-runs/two-part-tariff/billable-returns.validator.test.js
@@ -17,7 +17,8 @@ describe('Billable Returns validator', () => {
     describe('because the user selected the authorised volume option', () => {
       beforeEach(() => {
         payload = {
-          'quantity-options': '25'
+          'quantity-options': 25,
+          authorisedVolume: 30
         }
       })
 
@@ -28,11 +29,12 @@ describe('Billable Returns validator', () => {
       })
     })
 
-    describe('because the user entered a valid volume', () => {
+    describe('because the user entered a valid volume (less than the authorised volume but greater than 0', () => {
       beforeEach(() => {
         payload = {
           'quantity-options': 'customQuantity',
-          customQuantity: '123456'
+          customQuantity: 12,
+          authorisedVolume: 30
         }
       })
 
@@ -47,28 +49,33 @@ describe('Billable Returns validator', () => {
   describe('when an invalid payload is provided', () => {
     describe('because the user did not select an option', () => {
       beforeEach(() => {
-        payload = {}
+        payload = {
+          authorisedVolume: 30
+        }
       })
 
-      it("fails the validation with the message 'You must choose or enter a value'", () => {
+      it("fails the validation with the message 'Select the billable quantity'", () => {
         const result = BillableReturnsValidator.go(payload)
 
         expect(result.error).to.exist()
-        expect(result.error.details[0].message).to.equal('You must choose or enter a value')
+        expect(result.error.details[0].message).to.equal('Select the billable quantity')
       })
     })
 
     describe('because the user selected to enter a custom quantity', () => {
       describe('but entered no value', () => {
         beforeEach(() => {
-          payload = { 'quantity-options': 'customQuantity' }
+          payload = {
+            'quantity-options': 'customQuantity',
+            authorisedVolume: 25
+          }
         })
 
-        it("fails validation with the message 'You must enter a custom quantity'", () => {
+        it("fails validation with the message 'Enter the billable quantity'", () => {
           const result = BillableReturnsValidator.go(payload)
 
           expect(result.error).to.exist()
-          expect(result.error.details[0].message).to.equal('You must enter a custom quantity')
+          expect(result.error.details[0].message).to.equal('Enter the billable quantity')
         })
       })
 
@@ -76,15 +83,16 @@ describe('Billable Returns validator', () => {
         beforeEach(() => {
           payload = {
             'quantity-options': 'customQuantity',
-            customQuantity: 'Hello world'
+            customQuantity: 'Hello world',
+            authorisedVolume: 25
           }
         })
 
-        it("fails validation with the message 'You must enter a number'", () => {
+        it("fails validation with the message 'The quantity must be a number'", () => {
           const result = BillableReturnsValidator.go(payload)
 
           expect(result.error).to.exist()
-          expect(result.error.details[0].message).to.equal('You must enter a number')
+          expect(result.error.details[0].message).to.equal('The quantity must be a number')
         })
       })
 
@@ -92,15 +100,50 @@ describe('Billable Returns validator', () => {
         beforeEach(() => {
           payload = {
             'quantity-options': 'customQuantity',
-            customQuantity: '12.3456789'
+            customQuantity: 12.3456789,
+            authorisedVolume: 25
           }
         })
 
-        it("fails validation with the message 'You must enter less than 6 decimal places'", () => {
+        it("fails validation with the message 'The quantity must contain no more than 6 decimal places'", () => {
           const result = BillableReturnsValidator.go(payload)
 
           expect(result.error).to.exist()
-          expect(result.error.details[0].message).to.equal('You must enter less than 6 decimal places')
+          expect(result.error.details[0].message).to.equal('The quantity must contain no more than 6 decimal places')
+        })
+      })
+
+      describe('but entered a number less than 0', () => {
+        beforeEach(() => {
+          payload = {
+            'quantity-options': 'customQuantity',
+            customQuantity: -0.1,
+            authorisedVolume: 25
+          }
+        })
+
+        it("fails validation with the message 'The quantity must be zero or higher'", () => {
+          const result = BillableReturnsValidator.go(payload)
+
+          expect(result.error).to.exist()
+          expect(result.error.details[0].message).to.equal('The quantity must be zero or higher')
+        })
+      })
+
+      describe('but entered a number greater than the authorised annual quantity', () => {
+        beforeEach(() => {
+          payload = {
+            'quantity-options': 'customQuantity',
+            customQuantity: 40,
+            authorisedVolume: 25
+          }
+        })
+
+        it("fails validation with the message 'The quantity must be the same as or less than the authorised amount'", () => {
+          const result = BillableReturnsValidator.go(payload)
+
+          expect(result.error).to.exist()
+          expect(result.error.details[0].message).to.equal('The quantity must be the same as or less than the authorised amount')
         })
       })
     })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4370

During testing for the above ticket, it was found that a new validation was needed for the custom quantity that a user can enter. This quantity can not be greater than the authorised quantity on the charge element. This PR is to add this validation and to amend the original validation messages to update them as per the design team's request.