### PR TITLE
Fix licence status button text

### DIFF
--- a/app/views/bill-runs/review-licence.njk
+++ b/app/views/bill-runs/review-licence.njk
@@ -62,7 +62,7 @@
 
   {# Change status #}
   {% if licence.status === 'ready' %}
-    {% set statusButtonText = 'Put licence into Review' %}
+    {% set statusButtonText = 'Put licence into review' %}
     {% set statusButtonValue = 'review' %}
     {% set statusButtonClass = "govuk-button--secondary" %}
   {% else %}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4371

It has been spotted during QA that the button text on the button that flips the licence status is incorrect. The text is currently `Put licence into Review` when it should be `Put licence into review`.

This PR fixes the button text