### PR TITLE
feat: add notification banner to license view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,3 @@ app/public/build
 
 # ignore husky config
 .husky/
-
-.idea/
-.webstorm/

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ app/public/build
 
 # ignore husky config
 .husky/
+
+.idea/
+.webstorm/

--- a/app/presenters/licences/view-licence.presenter.js
+++ b/app/presenters/licences/view-licence.presenter.js
@@ -20,6 +20,8 @@ function go (licence, licenceAbstractionConditions) {
     ends,
     expiredDate,
     id,
+    includeInPresrocBilling,
+    includeInSrocBilling,
     licenceDocumentHeader,
     licenceGaugingStations,
     licenceHolder,
@@ -29,9 +31,7 @@ function go (licence, licenceAbstractionConditions) {
     permitLicence,
     region,
     registeredTo,
-    startDate,
-    includeInPresrocBilling,
-    includeInSrocBilling
+    startDate
   } = licence
 
   const abstractionPeriods = _generateAbstractionPeriods(licenceVersions)
@@ -50,28 +50,28 @@ function go (licence, licenceAbstractionConditions) {
   const abstractionConditionDetails = _abstractionConditionDetails(licenceAbstractionConditions)
 
   return {
-    id,
     abstractionConditionDetails,
     abstractionPeriods,
     abstractionPeriodsAndPurposesLinkText,
+    abstractionPointLinkText: abstractionDetails.pointLinkText,
     abstractionPoints: abstractionDetails.points,
     abstractionPointsCaption: abstractionDetails.pointsCaption,
-    abstractionPointLinkText: abstractionDetails.pointLinkText,
     abstractionQuantities: abstractionDetails.quantities,
     documentId: licenceDocumentHeader.id,
     endDate: _endDate(expiredDate),
+    id,
     licenceHolder: _generateLicenceHolder(licenceHolder),
     licenceName,
     licenceRef,
     monitoringStations,
+    notification: _determineNotificationBanner(includeInPresrocBilling, includeInSrocBilling),
     pageTitle: `Licence ${licenceRef}`,
     purposes,
     region: region.displayName,
     registeredTo,
     sourceOfSupply: abstractionDetails.sourceOfSupply,
     startDate: formatLongDate(startDate),
-    warning: _generateWarningMessage(ends),
-    notification: _calculateNotificationBanner(includeInPresrocBilling, includeInSrocBilling)
+    warning: _generateWarningMessage(ends)
   }
 }
 
@@ -107,20 +107,21 @@ function _abstractionConditionDetails (licenceAbstractionConditions) {
   }
 }
 
-function _calculateNotificationBanner (includeInPresrocBilling, includeInSrocBilling) {
-  let notification
+function _determineNotificationBanner (includeInPresrocBilling, includeInSrocBilling) {
   const baseMessage = 'This license has been marked for the next supplementary bill run'
 
   if (includeInPresrocBilling === 'yes' && includeInSrocBilling === true) {
-    notification = baseMessage + 's for the current and old charge schemes.'
-  } else if (includeInPresrocBilling === 'yes') {
-    notification = baseMessage + ' for the old charge scheme.'
-  } else if (includeInSrocBilling === true) {
-    notification = baseMessage + '.'
-  } else {
-    notification = null
+    return baseMessage + 's for the current and old charge schemes.'
   }
-  return notification
+  if (includeInPresrocBilling === 'yes') {
+    return baseMessage + ' for the old charge scheme.'
+  }
+
+  if (includeInSrocBilling === true) {
+    return baseMessage + '.'
+  }
+
+  return null
 }
 
 function _endDate (expiredDate) {

--- a/app/presenters/licences/view-licence.presenter.js
+++ b/app/presenters/licences/view-licence.presenter.js
@@ -29,7 +29,9 @@ function go (licence, licenceAbstractionConditions) {
     permitLicence,
     region,
     registeredTo,
-    startDate
+    startDate,
+    includeInPresrocBilling,
+    includeInSrocBilling
   } = licence
 
   const abstractionPeriods = _generateAbstractionPeriods(licenceVersions)
@@ -68,7 +70,8 @@ function go (licence, licenceAbstractionConditions) {
     registeredTo,
     sourceOfSupply: abstractionDetails.sourceOfSupply,
     startDate: formatLongDate(startDate),
-    warning: _generateWarningMessage(ends)
+    warning: _generateWarningMessage(ends),
+    notification: _calculateNotificationBanner(includeInPresrocBilling, includeInSrocBilling)
   }
 }
 
@@ -102,6 +105,19 @@ function _abstractionConditionDetails (licenceAbstractionConditions) {
     conditions,
     numberOfConditions
   }
+}
+
+function _calculateNotificationBanner (includeInPresrocBilling, includeInSrocBilling ) {
+  let notification = null
+  const baseMessage = 'This license has been marked for the next supplementary bill run'
+  if (includeInPresrocBilling === 'yes' && includeInSrocBilling === true) {
+    notification = baseMessage + 's for the current and old charge schemes.'
+  } else if (includeInPresrocBilling === 'yes') {
+    notification = baseMessage  + ' for the old charge scheme'
+  } else if (includeInSrocBilling === true) {
+    notification = baseMessage + '.'
+  }
+  return notification
 }
 
 function _endDate (expiredDate) {

--- a/app/presenters/licences/view-licence.presenter.js
+++ b/app/presenters/licences/view-licence.presenter.js
@@ -107,13 +107,13 @@ function _abstractionConditionDetails (licenceAbstractionConditions) {
   }
 }
 
-function _calculateNotificationBanner (includeInPresrocBilling, includeInSrocBilling ) {
+function _calculateNotificationBanner (includeInPresrocBilling, includeInSrocBilling) {
   let notification = null
   const baseMessage = 'This license has been marked for the next supplementary bill run'
   if (includeInPresrocBilling === 'yes' && includeInSrocBilling === true) {
     notification = baseMessage + 's for the current and old charge schemes.'
   } else if (includeInPresrocBilling === 'yes') {
-    notification = baseMessage  + ' for the old charge scheme'
+    notification = baseMessage + ' for the old charge scheme.'
   } else if (includeInSrocBilling === true) {
     notification = baseMessage + '.'
   }

--- a/app/presenters/licences/view-licence.presenter.js
+++ b/app/presenters/licences/view-licence.presenter.js
@@ -108,14 +108,17 @@ function _abstractionConditionDetails (licenceAbstractionConditions) {
 }
 
 function _calculateNotificationBanner (includeInPresrocBilling, includeInSrocBilling) {
-  let notification = null
+  let notification
   const baseMessage = 'This license has been marked for the next supplementary bill run'
+
   if (includeInPresrocBilling === 'yes' && includeInSrocBilling === true) {
     notification = baseMessage + 's for the current and old charge schemes.'
   } else if (includeInPresrocBilling === 'yes') {
     notification = baseMessage + ' for the old charge scheme.'
   } else if (includeInSrocBilling === true) {
     notification = baseMessage + '.'
+  } else {
+    notification = null
   }
   return notification
 }

--- a/app/services/licences/fetch-licence.service.js
+++ b/app/services/licences/fetch-licence.service.js
@@ -47,7 +47,10 @@ async function _fetchLicence (id) {
       'lapsedDate',
       'licenceRef',
       'revokedDate',
-      'startDate'
+      'startDate',
+      'include_in_presroc_billing',
+      'include_in_sroc_billing'
+
     ])
     .withGraphFetched('region')
     .modifyGraph('region', (builder) => {

--- a/app/services/licences/fetch-licence.service.js
+++ b/app/services/licences/fetch-licence.service.js
@@ -44,13 +44,12 @@ async function _fetchLicence (id) {
     .select([
       'expiredDate',
       'id',
+      'include_in_presroc_billing',
+      'include_in_sroc_billing',
       'lapsedDate',
       'licenceRef',
       'revokedDate',
-      'startDate',
-      'include_in_presroc_billing',
-      'include_in_sroc_billing'
-
+      'startDate'
     ])
     .withGraphFetched('region')
     .modifyGraph('region', (builder) => {

--- a/app/views/licences/view.njk
+++ b/app/views/licences/view.njk
@@ -2,6 +2,7 @@
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/tabs/macro.njk" import govukTabs %}
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 
 {% block breadcrumbs %}
   {{
@@ -37,6 +38,19 @@
       text: warning,
       iconFallbackText: "Warning"
     }) }}
+  {% endif %}
+
+  {% if notification %}
+    <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+      <div class="govuk-notification-banner__header">
+        <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+          Important
+        </h2>
+      </div>
+      <div class="govuk-notification-banner__content">
+     <strong> {{ notification }} </strong>
+      </div>
+    </div>
   {% endif %}
 
   <span class="govuk-caption-l">{{ licenceName }}</span>

--- a/app/views/licences/view.njk
+++ b/app/views/licences/view.njk
@@ -1,8 +1,8 @@
 {% extends 'layout.njk' %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 {% from "govuk/components/tabs/macro.njk" import govukTabs %}
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
-{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 
 {% block breadcrumbs %}
   {{
@@ -41,16 +41,11 @@
   {% endif %}
 
   {% if notification %}
-    <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
-      <div class="govuk-notification-banner__header">
-        <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
-          Important
-        </h2>
-      </div>
-      <div class="govuk-notification-banner__content">
-     <strong> {{ notification }} </strong>
-      </div>
-    </div>
+    {% if notification %}
+      {{ govukNotificationBanner({
+        html: '<strong>' + notification + '</strong>'
+      }) }}
+    {% endif %}
   {% endif %}
 
   <span class="govuk-caption-l">{{ licenceName }}</span>

--- a/test/presenters/licences/view-licence.presenter.test.js
+++ b/test/presenters/licences/view-licence.presenter.test.js
@@ -1075,7 +1075,7 @@ describe('View Licence presenter', () => {
     })
   })
   describe("the 'notification' property", () => {
-    describe('when the licence will not be in the next supplementary bill', () => {
+    describe('when the licence will not be in the next supplementary bill run', () => {
       it('returns NULL', () => {
         const result = ViewLicencePresenter.go(licence, licenceAbstractionConditions)
 
@@ -1083,7 +1083,7 @@ describe('View Licence presenter', () => {
       })
     })
 
-    describe('when the licence will be in the next supplementary bill (PRESROC)', () => {
+    describe('when the licence will be in the next supplementary bill run (PRESROC)', () => {
       beforeEach(() => {
         licence.includeInPresrocBilling = 'yes'
       })
@@ -1095,7 +1095,7 @@ describe('View Licence presenter', () => {
       })
     })
 
-    describe('when the licence will be in the next supplementary bill (SROC)', () => {
+    describe('when the licence will be in the next supplementary bill run (SROC)', () => {
       beforeEach(() => {
         licence.includeInSrocBilling = true
       })
@@ -1107,7 +1107,7 @@ describe('View Licence presenter', () => {
       })
     })
 
-    describe('when the licence will be in the next supplementary bill (SROC & PRESROC)', () => {
+    describe('when the licence will be in the next supplementary bill run (SROC & PRESROC)', () => {
       beforeEach(() => {
         licence.includeInSrocBilling = true
         licence.includeInPresrocBilling = 'yes'

--- a/test/presenters/licences/view-licence.presenter.test.js
+++ b/test/presenters/licences/view-licence.presenter.test.js
@@ -1074,6 +1074,52 @@ describe('View Licence presenter', () => {
       })
     })
   })
+  describe("the 'notification' property", () => {
+    describe('when the licence will not be in the next supplementary bill', () => {
+      it('returns NULL', () => {
+        const result = ViewLicencePresenter.go(licence, licenceAbstractionConditions)
+
+        expect(result.notification).to.be.null()
+      })
+    })
+
+    describe('when the licence will be in the next supplementary bill (PRESROC)', () => {
+      beforeEach(() => {
+        licence.includeInPresrocBilling = 'yes'
+      })
+
+      it('returns the notification for PRESROC', () => {
+        const result = ViewLicencePresenter.go(licence, licenceAbstractionConditions)
+
+        expect(result.notification).to.equal('This license has been marked for the next supplementary bill run for the old charge scheme.')
+      })
+    })
+
+    describe('when the licence will be in the next supplementary bill (SROC)', () => {
+      beforeEach(() => {
+        licence.includeInSrocBilling = true
+      })
+
+      it('returns the notification for SROC', () => {
+        const result = ViewLicencePresenter.go(licence, licenceAbstractionConditions)
+
+        expect(result.notification).to.equal('This license has been marked for the next supplementary bill run.')
+      })
+    })
+
+    describe('when the licence will be in the next supplementary bill (SROC & PRESROC)', () => {
+      beforeEach(() => {
+        licence.includeInSrocBilling = true
+        licence.includeInPresrocBilling = 'yes'
+      })
+
+      it('returns the notification for SROC & PRESROC)', () => {
+        const result = ViewLicencePresenter.go(licence, licenceAbstractionConditions)
+
+        expect(result.notification).to.equal('This license has been marked for the next supplementary bill runs for the current and old charge schemes.')
+      })
+    })
+  })
 })
 
 function _abstractionConditions () {

--- a/test/presenters/licences/view-licence.presenter.test.js
+++ b/test/presenters/licences/view-licence.presenter.test.js
@@ -45,6 +45,7 @@ describe('View Licence presenter', () => {
           label: 'MEVAGISSEY FIRE STATION'
         }],
         pageTitle: 'Licence 01/123',
+        notification: null,
         purposes: null,
         registeredTo: null,
         region: 'Narnia',

--- a/test/services/licences/fetch-licence.service.test.js
+++ b/test/services/licences/fetch-licence.service.test.js
@@ -44,7 +44,9 @@ describe('Fetch licence service', () => {
         expiredDate: null,
         lapsedDate: null,
         regionId: region.id,
-        revokedDate: null
+        revokedDate: null,
+        include_in_presroc_billing: 'yes',
+        include_in_sroc_billing: true
       })
 
       // Create 2 licence versions so we can test the service only gets the 'current' version
@@ -81,6 +83,8 @@ describe('Fetch licence service', () => {
       expect(result.revokedDate).to.equal(null)
       expect(result.permitLicence).to.equal(null)
       expect(result.licenceGaugingStations).to.equal([])
+      expect(result.includeInPresrocBilling).to.equal('yes')
+      expect(result.includeInSrocBilling).to.be.true()
     })
   })
 

--- a/test/services/licences/view-licence.service.test.js
+++ b/test/services/licences/view-licence.service.test.js
@@ -66,6 +66,7 @@ describe('View Licence service', () => {
           licenceRef: '01/130/R01',
           monitoringStations: [],
           pageTitle: 'Licence 01/130/R01',
+          notification: null,
           purposes: null,
           region: 'South West',
           registeredTo: null,


### PR DESCRIPTION
Add a notification banner, if the license will be in the next supplementary bull run. 

PRESROC notification 

![Screenshot 2024-04-25 at 15 16 49](https://github.com/DEFRA/water-abstraction-system/assets/58443816/ff143cce-0ff7-4740-9235-923d313fabff)

SROC notification
![Screenshot 2024-04-25 at 15 21 11](https://github.com/DEFRA/water-abstraction-system/assets/58443816/68d8a80f-5087-4967-bde2-66dafce06a15)

Both charge scheme notifications
![Screenshot 2024-04-25 at 15 21 56](https://github.com/DEFRA/water-abstraction-system/assets/58443816/1f7ba333-cdae-472b-8ff6-3af4eb2c722b)
