### PR TITLE
Fix bill run status badge in bill runs page

### DIFF
--- a/app/presenters/bill-runs/index-bill-runs.presenter.js
+++ b/app/presenters/bill-runs/index-bill-runs.presenter.js
@@ -42,7 +42,7 @@ function go (billRuns) {
       numberOfBills,
       region: capitalize(region),
       scheme,
-      status,
+      status: status === 'cancel' ? 'cancelling' : status,
       total: formatMoney(netTotal, true),
       type: formatBillRunType(batchType, scheme, summer)
     }

--- a/app/views/macros/bill-run-status-tag.njk
+++ b/app/views/macros/bill-run-status-tag.njk
@@ -11,6 +11,8 @@
     {% set color = "govuk-tag--grey" %}
   {% elif status === 'cancel' %}
     {% set color = "govuk-tag--orange" %}
+  {% elif status === 'cancelling' %}
+    {% set color = "govuk-tag--orange" %}
   {% elif status === 'error' %}
     {% set color = "govuk-tag--red" %}
   {% else %}

--- a/test/presenters/bill-runs/index.bill-runs.presenter.test.js
+++ b/test/presenters/bill-runs/index.bill-runs.presenter.test.js
@@ -85,6 +85,29 @@ describe('Index Bill Runs presenter', () => {
         })
       })
     })
+
+    describe("the 'status' property", () => {
+      describe("when a bill run has the status 'cancel'", () => {
+        beforeEach(() => {
+          billRuns[0].status = 'cancel'
+        })
+
+        it("returns 'cancelling' for the status", () => {
+          const results = IndexBillRunsPresenter.go(billRuns)
+
+          expect(results[0].status).to.equal('cancelling')
+        })
+      })
+
+      describe("when a bill run has a status other than 'cancel'", () => {
+        it('returns whatever the bill run status was', () => {
+          const results = IndexBillRunsPresenter.go(billRuns)
+
+          expect(results[0].status).to.equal(billRuns[0].status)
+          expect(results[1].status).to.equal(billRuns[1].status)
+        })
+      })
+    })
   })
 })
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4445

Spotted by our vigilant QA team that we had overlooked bill runs with a status of `'cancel'` and need their tag to display as 'cancelling' on the page.

This change fixes the issue.

![Screenshot 2024-04-26 at 10 36 39](https://github.com/DEFRA/water-abstraction-system/assets/1789650/e32989be-3734-469b-8a38-dcc1f1c53326)
