### PR TITLE
Fix broken PRESROC review bill run links

### DIFF
--- a/app/presenters/bill-runs/index-bill-runs.presenter.js
+++ b/app/presenters/bill-runs/index-bill-runs.presenter.js
@@ -37,7 +37,7 @@ function go (billRuns) {
     return {
       id,
       createdAt: formatLongDate(createdAt),
-      link: _link(id, status),
+      link: _link(id, status, scheme),
       number: billRunNumber,
       numberOfBills,
       region: capitalize(region),
@@ -49,12 +49,17 @@ function go (billRuns) {
   })
 }
 
-function _link (billRunId, status) {
+function _link (billRunId, status, scheme) {
   if (['cancel', 'processing', 'queued', 'sending'].includes(status)) {
     return null
   }
 
   if (status === 'review') {
+    // Old PRESROC bill runs
+    if (scheme === 'alcs') {
+      return `/billing/batch/${billRunId}/two-part-tariff-review`
+    }
+
     return `/system/bill-runs/${billRunId}/review`
   }
 

--- a/test/presenters/bill-runs/index-bill-runs.presenter.test.js
+++ b/test/presenters/bill-runs/index-bill-runs.presenter.test.js
@@ -125,11 +125,26 @@ describe('Index Bill Runs presenter', () => {
           billRuns[0].status = 'review'
         })
 
-        it('generates the href needed to link to the bill run review', () => {
-          const results = IndexBillRunsPresenter.go(billRuns)
+        describe("and is for the 'PRESROC' charge scheme", () => {
+          beforeEach(() => {
+            billRuns[0].scheme = 'alcs'
+          })
 
-          expect(results[0].link).to.equal('/system/bill-runs/31fec553-f2de-40cf-a8d7-a5fb65f5761b/review')
-          expect(results[1].link).to.equal('/system/bill-runs/dfdde4c9-9a0e-440d-b297-7143903c6734')
+          it('generates the href needed to link to the old bill run review', () => {
+            const results = IndexBillRunsPresenter.go(billRuns)
+
+            expect(results[0].link).to.equal('/billing/batch/31fec553-f2de-40cf-a8d7-a5fb65f5761b/two-part-tariff-review')
+            expect(results[1].link).to.equal('/system/bill-runs/dfdde4c9-9a0e-440d-b297-7143903c6734')
+          })
+        })
+
+        describe("and is for the 'SROC' charge scheme", () => {
+          it('generates the href needed to link to bill run review', () => {
+            const results = IndexBillRunsPresenter.go(billRuns)
+
+            expect(results[0].link).to.equal('/system/bill-runs/31fec553-f2de-40cf-a8d7-a5fb65f5761b/review')
+            expect(results[1].link).to.equal('/system/bill-runs/dfdde4c9-9a0e-440d-b297-7143903c6734')
+          })
         })
       })
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4445

In [Migrate view bill runs page from legacy UI](https://github.com/DEFRA/water-abstraction-system/pull/925) we were able to implement a new version of the bill runs page!

However, our QA team have spotted that the links to PRESROC bill runs that are in `review` are broken. The links we generate are for our review page when they should be for the legacy one.

This change fixes the issue.