### PR TITLE
Return to Check Your Answers after making a change

### DIFF
--- a/app/controllers/return-requirements.controller.js
+++ b/app/controllers/return-requirements.controller.js
@@ -204,6 +204,10 @@ async function submitAbstractionPeriod (request, h) {
     return h.view('return-requirements/abstraction-period.njk', pageData)
   }
 
+  if (pageData.checkYourAnswersVisited) {
+    return h.redirect(`/system/return-requirements/${sessionId}/check-your-answers`)
+  }
+
   return h.redirect(`/system/return-requirements/${sessionId}/returns-cycle`)
 }
 
@@ -227,6 +231,10 @@ async function submitAgreementsExceptions (request, h) {
 
   if (pageData.error) {
     return h.view('return-requirements/agreements-exceptions.njk', pageData)
+  }
+
+  if (pageData.checkYourAnswersVisited) {
+    return h.redirect(`/system/return-requirements/${sessionId}/check-your-answers`)
   }
 
   return h.redirect(`/system/return-requirements/${sessionId}/check-your-answers`)
@@ -254,6 +262,10 @@ async function submitFrequencyCollected (request, h) {
     return h.view('return-requirements/frequency-collected.njk', pageData)
   }
 
+  if (pageData.checkYourAnswersVisited) {
+    return h.redirect(`/system/return-requirements/${sessionId}/check-your-answers`)
+  }
+
   return h.redirect(`/system/return-requirements/${sessionId}/frequency-reported`)
 }
 
@@ -264,6 +276,10 @@ async function submitFrequencyReported (request, h) {
 
   if (pageData.error) {
     return h.view('return-requirements/frequency-reported.njk', pageData)
+  }
+
+  if (pageData.checkYourAnswersVisited) {
+    return h.redirect(`/system/return-requirements/${sessionId}/check-your-answers`)
   }
 
   return h.redirect(`/system/return-requirements/${sessionId}/agreements-exceptions`)
@@ -290,6 +306,10 @@ async function submitPoints (request, h) {
     return h.view('return-requirements/points.njk', pageData)
   }
 
+  if (pageData.checkYourAnswersVisited) {
+    return h.redirect(`/system/return-requirements/${sessionId}/check-your-answers`)
+  }
+
   return h.redirect(`/system/return-requirements/${sessionId}/abstraction-period`)
 }
 
@@ -300,6 +320,10 @@ async function submitPurpose (request, h) {
 
   if (pageData.error) {
     return h.view('return-requirements/purpose.njk', pageData)
+  }
+
+  if (pageData.checkYourAnswersVisited) {
+    return h.redirect(`/system/return-requirements/${sessionId}/check-your-answers`)
   }
 
   return h.redirect(`/system/return-requirements/${sessionId}/points`)
@@ -330,6 +354,10 @@ async function submitReturnsCycle (request, h) {
     return h.view('return-requirements/returns-cycle.njk', pageData)
   }
 
+  if (pageData.checkYourAnswersVisited) {
+    return h.redirect(`/system/return-requirements/${sessionId}/check-your-answers`)
+  }
+
   return h.redirect(`/system/return-requirements/${sessionId}/site-description`)
 }
 
@@ -352,6 +380,10 @@ async function submitSiteDescription (request, h) {
 
   if (pageData.error) {
     return h.view('return-requirements/site-description.njk', pageData)
+  }
+
+  if (pageData.checkYourAnswersVisited) {
+    return h.redirect(`/system/return-requirements/${sessionId}/check-your-answers`)
   }
 
   return h.redirect(`/system/return-requirements/${sessionId}/frequency-collected`)

--- a/app/services/return-requirements/submit-abstraction-period.service.js
+++ b/app/services/return-requirements/submit-abstraction-period.service.js
@@ -31,13 +31,16 @@ async function go (sessionId, payload) {
   if (!validationResult) {
     await _save(session, payload)
 
-    return {}
+    return {
+      checkYourAnswersVisited: session.data.checkYourAnswersVisited
+    }
   }
 
   const submittedSessionData = _submittedSessionData(session, payload)
 
   return {
     activeNavBar: 'search',
+    checkYourAnswersVisited: session.data.checkYourAnswersVisited,
     error: validationResult,
     pageTitle: 'Enter the abstraction period for the requirements for returns',
     ...submittedSessionData

--- a/app/services/return-requirements/submit-agreements-exceptions.service.js
+++ b/app/services/return-requirements/submit-agreements-exceptions.service.js
@@ -33,13 +33,16 @@ async function go (sessionId, payload) {
   if (!validationResult) {
     await _save(session, payload)
 
-    return {}
+    return {
+      checkYourAnswersVisited: session.data.checkYourAnswersVisited
+    }
   }
 
   const formattedData = AgreementsExceptionsPresenter.go(session, payload)
 
   return {
     activeNavBar: 'search',
+    checkYourAnswersVisited: session.data.checkYourAnswersVisited,
     error: validationResult,
     pageTitle: 'Select agreements and exceptions for the requirements for returns',
     ...formattedData

--- a/app/services/return-requirements/submit-frequency-collected.service.js
+++ b/app/services/return-requirements/submit-frequency-collected.service.js
@@ -31,13 +31,16 @@ async function go (sessionId, payload) {
   if (!validationResult) {
     await _save(session, payload)
 
-    return {}
+    return {
+      checkYourAnswersVisited: session.data.checkYourAnswersVisited
+    }
   }
 
   const formattedData = FrequencyCollectedPresenter.go(session)
 
   return {
     activeNavBar: 'search',
+    checkYourAnswersVisited: session.data.checkYourAnswersVisited,
     error: validationResult,
     pageTitle: 'Select how often readings or volumes are collected',
     ...formattedData

--- a/app/services/return-requirements/submit-frequency-reported.service.js
+++ b/app/services/return-requirements/submit-frequency-reported.service.js
@@ -31,13 +31,16 @@ async function go (sessionId, payload) {
   if (!validationResult) {
     await _save(session, payload)
 
-    return {}
+    return {
+      checkYourAnswersVisited: session.data.checkYourAnswersVisited
+    }
   }
 
   const formattedData = FrequencyReportedPresenter.go(session)
 
   return {
     activeNavBar: 'search',
+    checkYourAnswersVisited: session.data.checkYourAnswersVisited,
     error: validationResult,
     pageTitle: 'Select how often readings or volumes are reported',
     ...formattedData

--- a/app/services/return-requirements/submit-points.service.js
+++ b/app/services/return-requirements/submit-points.service.js
@@ -34,7 +34,9 @@ async function go (sessionId, payload) {
   if (!validationResult) {
     await _save(session, payload)
 
-    return {}
+    return {
+      checkYourAnswersVisited: session.data.checkYourAnswersVisited
+    }
   }
 
   const pointsData = await FetchPointsService.go(session.data.licence.id)
@@ -42,6 +44,7 @@ async function go (sessionId, payload) {
 
   return {
     activeNavBar: 'search',
+    checkYourAnswersVisited: session.data.checkYourAnswersVisited,
     error: validationResult,
     pageTitle: 'Select the points for the requirements for returns',
     ...formattedData

--- a/app/services/return-requirements/submit-purpose.service.js
+++ b/app/services/return-requirements/submit-purpose.service.js
@@ -34,7 +34,9 @@ async function go (sessionId, payload) {
   if (!validationResult) {
     await _save(session, payload)
 
-    return {}
+    return {
+      checkYourAnswersVisited: session.data.checkYourAnswersVisited
+    }
   }
 
   const purposesData = await FetchPurposesService.go(session.data.licence.id)
@@ -42,6 +44,7 @@ async function go (sessionId, payload) {
 
   return {
     activeNavBar: 'search',
+    checkYourAnswersVisited: session.data.checkYourAnswersVisited,
     error: validationResult,
     pageTitle: 'Select the purpose for the requirements for returns',
     ...formattedData

--- a/app/services/return-requirements/submit-returns-cycle.service.js
+++ b/app/services/return-requirements/submit-returns-cycle.service.js
@@ -31,13 +31,16 @@ async function go (sessionId, payload) {
   if (!validationResult) {
     await _save(session, payload)
 
-    return {}
+    return {
+      checkYourAnswersVisited: session.data.checkYourAnswersVisited
+    }
   }
 
   const formattedData = ReturnsCyclePresenter.go(session)
 
   return {
     activeNavBar: 'search',
+    checkYourAnswersVisited: session.data.checkYourAnswersVisited,
     error: validationResult,
     pageTitle: 'Select the returns cycle for the requirements for returns',
     ...formattedData

--- a/app/services/return-requirements/submit-site-description.service.js
+++ b/app/services/return-requirements/submit-site-description.service.js
@@ -31,13 +31,16 @@ async function go (sessionId, payload) {
   if (!validationResult) {
     await _save(session, payload)
 
-    return {}
+    return {
+      checkYourAnswersVisited: session.data.checkYourAnswersVisited
+    }
   }
 
   const submittedSessionData = _submittedSessionData(session, payload)
 
   return {
     activeNavBar: 'search',
+    checkYourAnswersVisited: session.data.checkYourAnswersVisited,
     error: validationResult,
     pageTitle: 'Enter a site description for the requirements for returns',
     ...submittedSessionData

--- a/test/services/return-requirements/submit-abstraction-period.service.test.js
+++ b/test/services/return-requirements/submit-abstraction-period.service.test.js
@@ -23,6 +23,7 @@ describe('Submit Abstraction Period service', () => {
 
     session = await SessionHelper.add({
       data: {
+        checkYourAnswersVisited: false,
         licence: {
           id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
           currentVersionStartDate: '2023-01-01T00:00:00.000Z',
@@ -60,10 +61,12 @@ describe('Submit Abstraction Period service', () => {
         })
       })
 
-      it('returns an empty object (no page data needed for a redirect)', async () => {
+      it('returns the checkYourAnswersVisited property (no page data needed for a redirect)', async () => {
         const result = await SubmitAbstractionPeriodService.go(session.id, payload)
 
-        expect(result).to.equal({})
+        expect(result).to.equal({
+          checkYourAnswersVisited: false
+        })
       })
     })
 
@@ -85,6 +88,7 @@ describe('Submit Abstraction Period service', () => {
           expect(result).to.equal({
             abstractionPeriod: null,
             activeNavBar: 'search',
+            checkYourAnswersVisited: false,
             error: null,
             pageTitle: 'Enter the abstraction period for the requirements for returns',
             id: 'aeb46f58-3431-42af-8724-361a7779becf',
@@ -126,6 +130,7 @@ describe('Submit Abstraction Period service', () => {
 
           expect(result).to.equal({
             activeNavBar: 'search',
+            checkYourAnswersVisited: false,
             error: null,
             pageTitle: 'Enter the abstraction period for the requirements for returns',
             id: 'aeb46f58-3431-42af-8724-361a7779becf',
@@ -173,6 +178,7 @@ describe('Submit Abstraction Period service', () => {
 
           expect(result).to.equal({
             activeNavBar: 'search',
+            checkYourAnswersVisited: false,
             error: null,
             pageTitle: 'Enter the abstraction period for the requirements for returns',
             id: 'aeb46f58-3431-42af-8724-361a7779becf',
@@ -220,6 +226,7 @@ describe('Submit Abstraction Period service', () => {
 
           expect(result).to.equal({
             activeNavBar: 'search',
+            checkYourAnswersVisited: false,
             error: null,
             pageTitle: 'Enter the abstraction period for the requirements for returns',
             id: 'aeb46f58-3431-42af-8724-361a7779becf',
@@ -267,6 +274,7 @@ describe('Submit Abstraction Period service', () => {
 
           expect(result).to.equal({
             activeNavBar: 'search',
+            checkYourAnswersVisited: false,
             error: null,
             pageTitle: 'Enter the abstraction period for the requirements for returns',
             id: 'aeb46f58-3431-42af-8724-361a7779becf',
@@ -314,6 +322,7 @@ describe('Submit Abstraction Period service', () => {
 
           expect(result).to.equal({
             activeNavBar: 'search',
+            checkYourAnswersVisited: false,
             error: null,
             pageTitle: 'Enter the abstraction period for the requirements for returns',
             id: 'aeb46f58-3431-42af-8724-361a7779becf',

--- a/test/services/return-requirements/submit-agreements-exceptions.service.test.js
+++ b/test/services/return-requirements/submit-agreements-exceptions.service.test.js
@@ -23,6 +23,7 @@ describe('Submit Agreements and Exceptions service', () => {
 
     session = await SessionHelper.add({
       data: {
+        checkYourAnswersVisited: false,
         licence: {
           id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
           currentVersionStartDate: '2023-01-01T00:00:00.000Z',
@@ -60,10 +61,12 @@ describe('Submit Agreements and Exceptions service', () => {
         ])
       })
 
-      it('returns an empty object (no page data needed for a redirect)', async () => {
+      it('returns the checkYourAnswersVisited property (no page data needed for a redirect)', async () => {
         const result = await SubmitAgreementsExceptionsService.go(session.id, payload)
 
-        expect(result).to.equal({})
+        expect(result).to.equal({
+          checkYourAnswersVisited: false
+        })
       })
     })
   })
@@ -85,6 +88,7 @@ describe('Submit Agreements and Exceptions service', () => {
 
         expect(result).to.equal({
           activeNavBar: 'search',
+          checkYourAnswersVisited: false,
           error: null,
           pageTitle: 'Select agreements and exceptions for the requirements for returns',
           id: 'aeb46f58-3431-42af-8724-361a7779becf',

--- a/test/services/return-requirements/submit-frequency-collected.service.test.js
+++ b/test/services/return-requirements/submit-frequency-collected.service.test.js
@@ -23,6 +23,7 @@ describe('Submit Frequency Collected service', () => {
 
     session = await SessionHelper.add({
       data: {
+        checkYourAnswersVisited: false,
         licence: {
           id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
           currentVersionStartDate: '2023-01-01T00:00:00.000Z',
@@ -52,10 +53,12 @@ describe('Submit Frequency Collected service', () => {
         expect(refreshedSession.data.frequencyCollected).to.equal('weekly')
       })
 
-      it('returns an empty object (no page data needed for a redirect)', async () => {
+      it('returns the checkYourAnswersVisited property (no page data needed for a redirect)', async () => {
         const result = await SubmitFrequencyCollectedService.go(session.id, payload)
 
-        expect(result).to.equal({})
+        expect(result).to.equal({
+          checkYourAnswersVisited: false
+        })
       })
     })
 
@@ -76,6 +79,7 @@ describe('Submit Frequency Collected service', () => {
 
           expect(result).to.equal({
             activeNavBar: 'search',
+            checkYourAnswersVisited: false,
             licenceId: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
             licenceRef: '01/ABC',
             pageTitle: 'Select how often readings or volumes are collected',

--- a/test/services/return-requirements/submit-frequency-reported.service.test.js
+++ b/test/services/return-requirements/submit-frequency-reported.service.test.js
@@ -23,6 +23,7 @@ describe('Submit Frequency Reported service', () => {
 
     session = await SessionHelper.add({
       data: {
+        checkYourAnswersVisited: false,
         licence: {
           id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
           currentVersionStartDate: '2023-01-01T00:00:00.000Z',
@@ -52,10 +53,12 @@ describe('Submit Frequency Reported service', () => {
         expect(refreshedSession.data.frequencyReported).to.equal('weekly')
       })
 
-      it('returns an empty object (no page data needed for a redirect)', async () => {
+      it('returns the checkYourAnswersVisited property (no page data needed for a redirect)', async () => {
         const result = await SubmitFrequencyReportedService.go(session.id, payload)
 
-        expect(result).to.equal({})
+        expect(result).to.equal({
+          checkYourAnswersVisited: false
+        })
       })
     })
 
@@ -76,6 +79,7 @@ describe('Submit Frequency Reported service', () => {
 
           expect(result).to.equal({
             activeNavBar: 'search',
+            checkYourAnswersVisited: false,
             licenceId: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
             licenceRef: '01/ABC',
             pageTitle: 'Select how often readings or volumes are reported',

--- a/test/services/return-requirements/submit-points.service.test.js
+++ b/test/services/return-requirements/submit-points.service.test.js
@@ -28,6 +28,7 @@ describe('Submit Points service', () => {
 
     session = await SessionHelper.add({
       data: {
+        checkYourAnswersVisited: false,
         licence: {
           id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
           currentVersionStartDate: '2023-01-01T00:00:00.000Z',
@@ -69,10 +70,12 @@ describe('Submit Points service', () => {
         ])
       })
 
-      it('returns an empty object (no page data needed for a redirect)', async () => {
+      it('returns the checkYourAnswersVisited property (no page data needed for a redirect)', async () => {
         const result = await SubmitPointsService.go(session.id, payload)
 
-        expect(result).to.equal({})
+        expect(result).to.equal({
+          checkYourAnswersVisited: false
+        })
       })
     })
   })
@@ -96,6 +99,7 @@ describe('Submit Points service', () => {
 
         expect(result).to.equal({
           activeNavBar: 'search',
+          checkYourAnswersVisited: false,
           pageTitle: 'Select the points for the requirements for returns',
           licenceId: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
           licenceRef: '01/ABC',

--- a/test/services/return-requirements/submit-purpose.service.test.js
+++ b/test/services/return-requirements/submit-purpose.service.test.js
@@ -28,6 +28,7 @@ describe('Submit Purpose service', () => {
 
     session = await SessionHelper.add({
       data: {
+        checkYourAnswersVisited: false,
         licence: {
           id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
           currentVersionStartDate: '2023-01-01T00:00:00.000Z',
@@ -71,10 +72,12 @@ describe('Submit Purpose service', () => {
         expect(refreshedSession.data.purposes).to.equal(['Potable Water Supply - Direct'])
       })
 
-      it('returns an empty object (no page data needed for a redirect)', async () => {
+      it('returns the checkYourAnswersVisited property (no page data needed for a redirect)', async () => {
         const result = await SubmitPurposeService.go(session.id, payload)
 
-        expect(result).to.equal({})
+        expect(result).to.equal({
+          checkYourAnswersVisited: false
+        })
       })
     })
 
@@ -102,6 +105,7 @@ describe('Submit Purpose service', () => {
 
           expect(result).to.equal({
             activeNavBar: 'search',
+            checkYourAnswersVisited: false,
             pageTitle: 'Select the purpose for the requirements for returns',
             licenceId: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
             licenceRef: '01/ABC',

--- a/test/services/return-requirements/submit-returns-cycle.service.test.js
+++ b/test/services/return-requirements/submit-returns-cycle.service.test.js
@@ -23,6 +23,7 @@ describe('Submit Returns Cycle service', () => {
 
     session = await SessionHelper.add({
       data: {
+        checkYourAnswersVisited: false,
         licence: {
           id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
           currentVersionStartDate: '2023-01-01T00:00:00.000Z',
@@ -52,10 +53,12 @@ describe('Submit Returns Cycle service', () => {
         expect(refreshedSession.data.returnsCycle).to.equal('summer')
       })
 
-      it('returns an empty object (no page data needed for a redirect)', async () => {
+      it('returns the checkYourAnswersVisited property (no page data needed for a redirect)', async () => {
         const result = await SubmitReturnsCycleService.go(session.id, payload)
 
-        expect(result).to.equal({})
+        expect(result).to.equal({
+          checkYourAnswersVisited: false
+        })
       })
     })
 
@@ -76,6 +79,7 @@ describe('Submit Returns Cycle service', () => {
 
           expect(result).to.equal({
             activeNavBar: 'search',
+            checkYourAnswersVisited: false,
             licenceId: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
             licenceRef: '01/ABC',
             pageTitle: 'Select the returns cycle for the requirements for returns',

--- a/test/services/return-requirements/submit-site-description.service.test.js
+++ b/test/services/return-requirements/submit-site-description.service.test.js
@@ -23,6 +23,7 @@ describe('Submit Site Description service', () => {
 
     session = await SessionHelper.add({
       data: {
+        checkYourAnswersVisited: false,
         licence: {
           id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
           currentVersionStartDate: '2023-01-01T00:00:00.000Z',
@@ -52,10 +53,12 @@ describe('Submit Site Description service', () => {
         expect(refreshedSession.data.siteDescription).to.equal('This is a valid return requirement description')
       })
 
-      it('returns an empty object (no page data needed for a redirect)', async () => {
+      it('returns the checkYourAnswersVisited property (no page data needed for a redirect)', async () => {
         const result = await SubmitSiteDescriptionService.go(session.id, payload)
 
-        expect(result).to.equal({})
+        expect(result).to.equal({
+          checkYourAnswersVisited: false
+        })
       })
     })
 
@@ -76,6 +79,7 @@ describe('Submit Site Description service', () => {
 
           expect(result).to.equal({
             activeNavBar: 'search',
+            checkYourAnswersVisited: false,
             pageTitle: 'Enter a site description for the requirements for returns',
             licenceId: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
             licenceRef: '01/ABC',
@@ -110,6 +114,7 @@ describe('Submit Site Description service', () => {
 
           expect(result).to.equal({
             activeNavBar: 'search',
+            checkYourAnswersVisited: false,
             pageTitle: 'Enter a site description for the requirements for returns',
             licenceId: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
             licenceRef: '01/ABC',
@@ -147,6 +152,7 @@ describe('Submit Site Description service', () => {
 
           expect(result).to.equal({
             activeNavBar: 'search',
+            checkYourAnswersVisited: false,
             pageTitle: 'Enter a site description for the requirements for returns',
             licenceId: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
             licenceRef: '01/ABC',


### PR DESCRIPTION
This is a PR focused on adding the ability to return to the Check Your Answers page after updating a previously submitted page in the return requirements journey.

When a user reaches the Check Your Answers page at the end of the return requirements journey, they are given the ability to update previously entered options. After making a change, users should be navigated back to the Check Your Answers page instead of continuing through the already completed journey.