### PR TITLE
Show correct text in textarea in Add Note page

### DIFF
--- a/app/services/return-requirements/submit-add-note.service.js
+++ b/app/services/return-requirements/submit-add-note.service.js
@@ -35,13 +35,13 @@ async function go (sessionId, payload, user) {
     }
   }
 
-  const formattedData = AddNotePresenter.go(session)
+  const submittedSessionData = _submittedSessionData(session, payload)
 
   return {
     activeNavBar: 'search',
     error: validationResult,
     pageTitle: 'Add a note',
-    ...formattedData
+    ...submittedSessionData
   }
 }
 
@@ -54,6 +54,12 @@ async function _save (session, payload, user) {
   }
 
   return session.$query().patch({ data: currentData })
+}
+
+function _submittedSessionData (session, payload) {
+  session.data.note = payload.note ? payload.note : null
+
+  return AddNotePresenter.go(session)
 }
 
 function _validate (payload) {


### PR DESCRIPTION
This amend allows the user to see the correct data in the textarea when they return to a page or submit. 
This ensures that we don't show session data where payload data should be.