### PR TITLE
Fix permissions for licence summary

### DIFF
--- a/app/routes/licence.routes.js
+++ b/app/routes/licence.routes.js
@@ -8,11 +8,6 @@ const routes = [
     path: '/licences/{id}/summary',
     handler: LicencesController.viewSummary,
     options: {
-      auth: {
-        access: {
-          scope: ['billing']
-        }
-      },
       description: 'View a licence page'
     }
   }, {

--- a/test/controllers/licences.controller.test.js
+++ b/test/controllers/licences.controller.test.js
@@ -157,7 +157,7 @@ describe('Licences controller', () => {
         url: '/licences/7861814c-ca19-43f2-be11-3c612f0d744b/summary',
         auth: {
           strategy: 'session',
-          credentials: { scope: ['billing'] }
+          credentials: { scope: [] }
         }
       }
     })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4432
https://eaflood.atlassian.net/browse/WATER-4457

What tabs a user sees on the view licence page needs to be determined based on their permissions. Everyone should be able to see

- Summary
- Contact Details
- Returns
- Communications

Any one in the National Permitting Service also needs to be able to see 'Charge Information'. The only team with access to 'Bills' is Billing & Data.

WATER-4432 got all that working but we overlooked something when we update the 'tech' to allow us to load tabs in isolation ( WATER-4457 ). Each tab will now have its own endpoint which means we also need to take into account the `scope` we assign to those routes.

Those tabs that all users should be able to see need to have no `scope` to make them work. But back when we initially started hacking our version of the page we just copy & pasted an existing route which had the 'billing' scope assigned. This means only a Billing & Data user can get to our licence page!

This change fixes the issue by removing the scope from the licence summary endpoint (the one endpoint we have built at this time!)

> Note - this just removes the permission. It doesn't mean an unauthenticated user can now access the endpoint.