### PR TITLE
Alter and add migration for amendAllocated column two-part tariff review

### DIFF
--- a/db/migrations/public/20240503155022_alter-review-charge-elements-column-type.js
+++ b/db/migrations/public/20240503155022_alter-review-charge-elements-column-type.js
@@ -14,6 +14,6 @@ exports.down = async function (knex) {
   return knex
     .schema
     .alterTable(tableName, (table) => {
-      table.decimal('amended_allocated')
+      table.decimal('amended_allocated').alter()
     })
 }

--- a/db/migrations/public/20240503155022_alter-review-charge-elements-column-type.js
+++ b/db/migrations/public/20240503155022_alter-review-charge-elements-column-type.js
@@ -6,7 +6,7 @@ exports.up = async function (knex) {
   return knex
     .schema
     .alterTable(tableName, (table) => {
-      table.decimal('calculated')
+      table.decimal('amended_allocated', null, null).defaultTo(0)
     })
 }
 
@@ -14,6 +14,6 @@ exports.down = async function (knex) {
   return knex
     .schema
     .alterTable(tableName, (table) => {
-      table.dropColumn('calculated')
+      table.decimal('amended_allocated')
     })
 }

--- a/db/migrations/public/20240503155022_alter-review-charge-elements-column-type.js
+++ b/db/migrations/public/20240503155022_alter-review-charge-elements-column-type.js
@@ -6,7 +6,7 @@ exports.up = async function (knex) {
   return knex
     .schema
     .alterTable(tableName, (table) => {
-      table.decimal('amended_allocated', null, null).defaultTo(0)
+      table.decimal('amended_allocated', null, null).defaultTo(0).alter()
     })
 }
 


### PR DESCRIPTION
Oppsie, I messed up! 
During testing for the two-part tariff review screens, it was noted that some of the data for a charge element allocated volume wasn't persisting correctly. This is due to the table's column not being the correct data type. 
The initial migration for the creation of the column calculated (now called amended_allocated) was on April 17th. 
The column wasn't created properly and needed to be amended so that the decimal points weren't getting cut off. 
Having checked the commit history in the repo there were no tags at the time, so rather than create a new migration, I went and edited the original migration instead. 

This is where my oppsie happened. 

The edited migration commit happened on the 17th (before the repo got tagged for release) however due to the length of PR I was working on, the actual PR itself didn't get merged until the 24th. The repo got tagged for a release between this on the 19th. This means the initial migration has been run on production and the edited version of the migration will not work for updating the column data type. 

This PR reverts the migration file to its original state and adds a new migration that can be run to update the column data type. *facepalm*

<img src="https://media4.giphy.com/media/HfFccPJv7a9k4/giphy.gif"/>