### PR TITLE
Enhance the SessionModel to expose and update data

### DIFF
--- a/app/models/session.model.js
+++ b/app/models/session.model.js
@@ -9,6 +9,11 @@ const BaseModel = require('./base.model.js')
 
 /**
  * Used for managing temporary session data, for example, during set up journeys
+ *
+ * > IMPORTANT! Do use the following properties in `data:`; `id`, `createdAt` or `updatedAt`.
+ * >
+ * > This model includes functionality to elevate the properties of `data` onto the instance when fetched. But if `data`
+ * > contains these properties they will override the existing properties of the session instance.
  */
 class SessionModel extends BaseModel {
   static get tableName () {

--- a/app/models/session.model.js
+++ b/app/models/session.model.js
@@ -7,6 +7,9 @@
 
 const BaseModel = require('./base.model.js')
 
+/**
+ * Used for managing temporary session data, for example, during set up journeys
+ */
 class SessionModel extends BaseModel {
   static get tableName () {
     return 'sessions'
@@ -17,6 +20,60 @@ class SessionModel extends BaseModel {
     return [
       'data'
     ]
+  }
+
+  /**
+   * Called after a session instance is fetched. It elevates the properties of `data` to the top level of the instance
+   *
+   * > We do not expect modules to call this function directly. It is a named hook for use with Objection.js
+   *
+   * The session table, excluding `id` and the timestamps, only contains one field; `data`. It is a JSONB field so
+   * it is flexible enough to hold whatever data an individual needs.
+   *
+   * To improve working with the session and avoid callers having to do _everything_ via `session.data` we use this
+   * `$afterFind()` hook to elevate the properties of `.data` to the top level of the instance.
+   *
+   * So, if `session.data` contained `{ reason: 'major-change' }` after a caller fetched the session instance they would
+   * be able to call and update `session.reason` instead.
+   *
+   * We think this makes working with the `SessionModel` the same as working with the normal, structured model
+   * instances.
+   *
+   * @param {Object} _queryContext - Objection.js query context which we do not use
+   */
+  $afterFind (_queryContext) {
+    for (const [key, value] of Object.entries(this.data)) {
+      this[key] = value
+    }
+  }
+
+  /**
+   * Update the session instance's `data` property with the current properties of the instance
+   *
+   * Added to avoid callers having to repeatedly implement this pattern.
+   *
+   * ```javascript
+   * const currentData = session.data
+   * currentData.reason = payload.reason
+   * await session.$query().patch({ data: currentData })
+   * ```
+   *
+   * Now callers can just do the following.
+   *
+   * ```javascript
+   * session.reason = payload.reason
+   * session.$update()
+   * ```
+   *
+   * Ignoring `id` and the timestamps, this method extracts all the other properties on the instance into an object
+   * then calls `patch({ data: currentData })`, saving calling modules the trouble!
+   *
+   * @returns {Promise<Number>} - the number of affected rows. In our case this will always be 1!
+   */
+  async $update () {
+    const { id, createdAt, data, updatedAt, ...currentData } = this
+
+    return this.$query().patch({ data: currentData })
   }
 }
 

--- a/test/models/session.model.test.js
+++ b/test/models/session.model.test.js
@@ -34,4 +34,92 @@ describe('Session model', () => {
       expect(result.data).to.equal({})
     })
   })
+
+  // NOTE: this is an Objection.js hook and not intended to be called directly
+  describe('$afterFind', () => {
+    describe("when 'data' is empty", () => {
+      beforeEach(async () => {
+        testRecord = await SessionHelper.add()
+      })
+
+      it('adds nothing to the session instance properties', async () => {
+        const result = await SessionModel.query().findById(testRecord.id)
+
+        expect(Object.keys(result)).to.equal(['id', 'data', 'createdAt', 'updatedAt'])
+      })
+    })
+
+    describe("when 'data' is populated", () => {
+      beforeEach(async () => {
+        testRecord = await SessionHelper.add({
+          data: {
+            licence: {
+              licenceRef: '01/123/01',
+              startDate: new Date('2017-05-07')
+            },
+            purposes: ['foo', 'bar'],
+            reason: 'major-change'
+          }
+        })
+      })
+
+      it('adds its properties to the session instance properties', async () => {
+        const result = await SessionModel.query().findById(testRecord.id)
+
+        expect(Object.keys(result)).to.equal(['id', 'data', 'createdAt', 'updatedAt', 'reason', 'licence', 'purposes'])
+
+        expect(result.licence).to.equal({ licenceRef: '01/123/01', startDate: '2017-05-07T00:00:00.000Z' })
+        expect(result.purposes).to.equal(['foo', 'bar'])
+        expect(result.reason).to.equal('major-change')
+      })
+    })
+  })
+
+  describe('$update', () => {
+    let recordToUpdate
+
+    describe('when the session has an existing property that was updated', () => {
+      beforeEach(async () => {
+        testRecord = await SessionHelper.add({ data: { reason: 'major-change' } })
+
+        recordToUpdate = await SessionModel.query().findById(testRecord.id)
+        recordToUpdate.reason = 'minor-change'
+      })
+
+      it("is updated in the 'data' field when 'update()' is called", async () => {
+        const result = await recordToUpdate.$update()
+
+        // NOTE: We do not expect it to be used. But Objection.js patch() returns a count of records effected so we also
+        // return that as a result. As we are patching the instance this should only ever be 1
+        expect(result).to.equal(1)
+
+        const refreshedInstance = await SessionModel.query().findById(testRecord.id)
+
+        expect(refreshedInstance.data).to.equal({ reason: 'minor-change' })
+        expect(refreshedInstance.reason).to.equal('minor-change')
+      })
+    })
+
+    describe('when a new property is set on the session', () => {
+      beforeEach(async () => {
+        testRecord = await SessionHelper.add()
+
+        recordToUpdate = await SessionModel.query().findById(testRecord.id)
+        recordToUpdate.reason = 'new-licence'
+      })
+
+      it("is set in the 'data' field when 'update()' is called", async () => {
+        const result = await recordToUpdate.$update()
+
+        // NOTE: We do not expect it to be used. But Objection.js patch() returns a count of records effected so we also
+        // return that as a result. As we are patching the instance this should only ever be 1
+        expect(result).to.equal(1)
+
+        const refreshedInstance = await SessionModel.query().findById(testRecord.id)
+
+        expect(refreshedInstance.data).to.equal({ reason: 'new-licence' })
+        expect(refreshedInstance.reason).to.equal('new-licence')
+      })
+    })
+  })
 })

--- a/test/models/session.model.test.js
+++ b/test/models/session.model.test.js
@@ -121,5 +121,27 @@ describe('Session model', () => {
         expect(refreshedInstance.reason).to.equal('new-licence')
       })
     })
+
+    describe('when the session has an existing property that was deleted', () => {
+      beforeEach(async () => {
+        testRecord = await SessionHelper.add({ data: { reason: 'name-or-address-change' } })
+
+        recordToUpdate = await SessionModel.query().findById(testRecord.id)
+        delete recordToUpdate.reason
+      })
+
+      it("removed from the 'data' field when 'update()' is called", async () => {
+        const result = await recordToUpdate.$update()
+
+        // NOTE: We do not expect it to be used. But Objection.js patch() returns a count of records effected so we also
+        // return that as a result. As we are patching the instance this should only ever be 1
+        expect(result).to.equal(1)
+
+        const refreshedInstance = await SessionModel.query().findById(testRecord.id)
+
+        expect(refreshedInstance.data).to.equal({})
+        expect(refreshedInstance.reason).not.to.exist()
+      })
+    })
   })
 })

--- a/test/services/return-requirements/check-your-answers.service.test.js
+++ b/test/services/return-requirements/check-your-answers.service.test.js
@@ -18,7 +18,6 @@ const SessionModel = require('../../../app/models/session.model.js')
 
 const sessionData = {
   data: {
-    id: 'f1288f6c-8503-4dc1-b114-75c408a14bd0',
     checkYourAnswersVisited: false,
     licence: {
       endDate: null,

--- a/test/services/return-requirements/delete-note.service.test.js
+++ b/test/services/return-requirements/delete-note.service.test.js
@@ -18,7 +18,6 @@ const DeleteNoteService = require('../../../app/services/return-requirements/del
 describe('Delete Note service', () => {
   const sessionData = {
     data: {
-      id: 'f1288f6c-8503-4dc1-b114-75c408a14bd0',
       checkYourAnswersVisited: true,
       licence: {
         endDate: null,


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4463

We created our `SessionModel` and its backing table out of the need to be able to store data temporarily, for example, when a user is following a journey to create a new return requirement.

We don't want to use cookies, because their size is limited, and they have a habit of sticking around and polluting new sessions. The 'proper' way is with a server-side session cookie backed by Redis. But we're trying to simplify our service not embed the existing complexity.

We have PostgreSQL, reading and writing to it is fast enough and scalable enough for our use case so why not use it!?

So, that is what we did. We made it simple and flexible by having just one property, `data`, which is a JSONB field so can hold whatever data we need to support whatever journey.

Currently, it's used in the bill run and return requirements set-up journeys and will no doubt be used for more in the future.

What we have seen though are some common patterns and duplications emerging. The services we've created to support these journeys are

- fetching the session
- extracting the properties they need via the `session.data` instance
- saving changes by first extracting a copy of the existing `data` property, updating it, then calling `patch({ data: currentData })` on the instance

With these changes, we intend to make things a little slicker!

Using the [Objection.js $afterFind() hook](https://vincit.github.io/objection.js/api/model/instance-methods.html#afterfind) we can automatically elevate the properties in `data` to the top-level. This means we can use, for example, `session.siteDescription` instead of `session.data.siteDescription`. It also means new properties can be added at the top level. No more forgetting to add `data` and wondering why it isn't working!

When it comes to updating, we can simplify things for callers. We can move the work of updating the value of `data` into the model itself. If we have a session instance, which we do in all our current `Submit` services. Having set your new property, for example, `session.reason = 'major-change'`, you can then just call `session.update()`. The model will handle ensuring the new property you set is applied to `data` along with all its existing values. It works the same for properties that already existed, which were elevated to the top level during the find and then updated. `update()` will ensure the new value is saved.