### PR TITLE
Update bill run setup journey to use new session

### DIFF
--- a/app/presenters/bill-runs/setup/create.presenter.js
+++ b/app/presenters/bill-runs/setup/create.presenter.js
@@ -54,7 +54,7 @@ function go (session, billRun) {
 }
 
 function _backLink (session) {
-  const { type, year } = session.data
+  const { type, year } = session
 
   if (!type.startsWith('two_part')) {
     return `/system/bill-runs/setup/${session.id}/region`

--- a/app/presenters/bill-runs/setup/region.presenter.js
+++ b/app/presenters/bill-runs/setup/region.presenter.js
@@ -17,7 +17,7 @@ function go (session, regions) {
   return {
     sessionId: session.id,
     regions,
-    selectedRegion: session.data.region ? session.data.region : null
+    selectedRegion: session.region ? session.region : null
   }
 }
 

--- a/app/presenters/bill-runs/setup/season.presenter.js
+++ b/app/presenters/bill-runs/setup/season.presenter.js
@@ -15,7 +15,7 @@
 function go (session) {
   return {
     sessionId: session.id,
-    selectedSeason: session.data.season ? session.data.season : null
+    selectedSeason: session.season ? session.season : null
   }
 }
 

--- a/app/presenters/bill-runs/setup/type.presenter.js
+++ b/app/presenters/bill-runs/setup/type.presenter.js
@@ -15,7 +15,7 @@
 function go (session) {
   return {
     sessionId: session.id,
-    selectedType: session.data.type ? session.data.type : null
+    selectedType: session.type ? session.type : null
   }
 }
 

--- a/app/presenters/bill-runs/setup/year.presenter.js
+++ b/app/presenters/bill-runs/setup/year.presenter.js
@@ -15,7 +15,7 @@
 function go (session) {
   return {
     sessionId: session.id,
-    selectedYear: session.data.year ? session.data.year : null
+    selectedYear: session.year ? session.year : null
   }
 }
 

--- a/app/services/bill-runs/setup/create.service.js
+++ b/app/services/bill-runs/setup/create.service.js
@@ -25,7 +25,7 @@ const StartBillRunProcessService = require('../start-bill-run-process.service.js
  */
 async function go (user, existsResults) {
   const { matchResults, session, yearToUse } = existsResults
-  const { region: regionId, type, summer } = session.data
+  const { region: regionId, type, summer } = session
 
   const existingBillRun = matchResults[0]
 

--- a/app/services/bill-runs/setup/exists.service.js
+++ b/app/services/bill-runs/setup/exists.service.js
@@ -38,7 +38,7 @@ const SessionModel = require('../../../models/session.model.js')
 async function go (sessionId) {
   const session = await SessionModel.query().findById(sessionId)
 
-  const { region, type, year } = session.data
+  const { region, type, year } = session
   const yearToUse = await DetermineFinancialYearEndService.go(region, type, year)
 
   const matchResults = await _fetchMatchingBillRun(session, yearToUse)
@@ -54,13 +54,13 @@ async function go (sessionId) {
 }
 
 async function _fetchMatchingBillRun (session, year) {
-  const { region, season, type } = session.data
+  const { region, season, type } = session
 
   return DetermineBlockingBillRunService.go(region, type, year, season)
 }
 
 function _pageData (session, matchResults) {
-  const { type } = session.data
+  const { type } = session
 
   // No matches so we can create the bill run
   if (matchResults.length === 0) {

--- a/app/services/bill-runs/setup/submit-region.service.js
+++ b/app/services/bill-runs/setup/submit-region.service.js
@@ -40,7 +40,7 @@ async function go (sessionId, payload) {
     await _save(session, payload)
 
     // The journey is complete (we don't need any details) if the bill run type is not 2PT
-    return { setupComplete: !session.data.type.startsWith('two_part') }
+    return { setupComplete: !session.type.startsWith('two_part') }
   }
 
   const formattedData = RegionPresenter.go(session, regions)
@@ -52,7 +52,7 @@ async function go (sessionId, payload) {
 }
 
 async function _save (session, payload) {
-  const currentData = session.data
+  const currentData = session
 
   currentData.region = payload.region
 

--- a/app/services/bill-runs/setup/submit-season.service.js
+++ b/app/services/bill-runs/setup/submit-season.service.js
@@ -48,11 +48,9 @@ async function go (sessionId, payload) {
 }
 
 async function _save (session, payload) {
-  const currentData = session.data
+  session.season = payload.season
 
-  currentData.season = payload.season
-
-  return session.$query().patch({ data: currentData })
+  return session.$update()
 }
 
 function _validate (payload) {

--- a/app/services/bill-runs/setup/submit-type.service.js
+++ b/app/services/bill-runs/setup/submit-type.service.js
@@ -48,11 +48,9 @@ async function go (sessionId, payload) {
 }
 
 async function _save (session, payload) {
-  const currentData = session.data
+  session.type = payload.type
 
-  currentData.type = payload.type
-
-  return session.$query().patch({ data: currentData })
+  return session.$update()
 }
 
 function _validate (payload) {

--- a/app/services/bill-runs/setup/submit-year.service.js
+++ b/app/services/bill-runs/setup/submit-year.service.js
@@ -37,7 +37,7 @@ async function go (sessionId, payload) {
   if (!validationResult) {
     await _save(session, payload)
 
-    return { setupComplete: ['2024', '2023'].includes(session.data.year) }
+    return { setupComplete: ['2024', '2023'].includes(session.year) }
   }
 
   const formattedData = YearPresenter.go(session)
@@ -49,11 +49,9 @@ async function go (sessionId, payload) {
 }
 
 async function _save (session, payload) {
-  const currentData = session.data
+  session.year = payload.year
 
-  currentData.year = payload.year
-
-  return session.$query().patch({ data: currentData })
+  return session.$update()
 }
 
 function _validate (payload, regions) {

--- a/test/presenters/bill-runs/setup/create.presenter.test.js
+++ b/test/presenters/bill-runs/setup/create.presenter.test.js
@@ -18,7 +18,7 @@ describe('Bill Runs Setup Create presenter', () => {
     beforeEach(() => {
       session = {
         id: '98ad3a1f-8e4f-490a-be05-0aece6755466',
-        data: { type: 'annual' }
+        type: 'annual'
       }
 
       matchingBillRun = {
@@ -55,7 +55,7 @@ describe('Bill Runs Setup Create presenter', () => {
     describe("the 'backLink' property", () => {
       describe("when the selected bill run type is not 'two_part_tariff'", () => {
         beforeEach(() => {
-          session.data.type = 'supplementary'
+          session.type = 'supplementary'
         })
 
         it('returns a link to the region page', () => {
@@ -67,12 +67,12 @@ describe('Bill Runs Setup Create presenter', () => {
 
       describe("when the selected bill run type is 'two_part_tariff'", () => {
         beforeEach(() => {
-          session.data.type = 'two_part_tariff'
+          session.type = 'two_part_tariff'
         })
 
         describe('and the selected financial year is in the SROC period', () => {
           beforeEach(() => {
-            session.data.year = '2023'
+            session.year = '2023'
           })
 
           it('returns a link to the financial year page', () => {
@@ -84,7 +84,7 @@ describe('Bill Runs Setup Create presenter', () => {
 
         describe('and the selected financial year is in the PRESROC period', () => {
           beforeEach(() => {
-            session.data.year = '2022'
+            session.year = '2022'
           })
 
           it('returns a link to the season page', () => {

--- a/test/presenters/bill-runs/setup/region.presenter.test.js
+++ b/test/presenters/bill-runs/setup/region.presenter.test.js
@@ -41,7 +41,7 @@ describe('Bill Runs Setup Region presenter', () => {
 
     describe('where the user has previously selected a bill run region', () => {
       beforeEach(() => {
-        session.data.region = 'Stormlands'
+        session.region = 'Stormlands'
       })
 
       it('correctly presents the data', () => {

--- a/test/presenters/bill-runs/setup/season.presenter.test.js
+++ b/test/presenters/bill-runs/setup/season.presenter.test.js
@@ -34,7 +34,7 @@ describe('Bill Runs Setup Season presenter', () => {
 
     describe('where the user has previously selected a season', () => {
       beforeEach(() => {
-        session.data.season = 'summer'
+        session.season = 'summer'
       })
 
       it('correctly presents the data', () => {

--- a/test/presenters/bill-runs/setup/type.presenter.test.js
+++ b/test/presenters/bill-runs/setup/type.presenter.test.js
@@ -34,7 +34,7 @@ describe('Bill Runs Setup Type presenter', () => {
 
     describe('where the user has previously selected a bill run type', () => {
       beforeEach(() => {
-        session.data.type = 'annual'
+        session.type = 'annual'
       })
 
       it('correctly presents the data', () => {

--- a/test/presenters/bill-runs/setup/year.presenter.test.js
+++ b/test/presenters/bill-runs/setup/year.presenter.test.js
@@ -34,7 +34,7 @@ describe('Bill Runs Setup Year presenter', () => {
 
     describe('where the user has previously selected a financial year', () => {
       beforeEach(() => {
-        session.data.year = 2022
+        session.year = 2022
       })
 
       it('correctly presents the data', () => {

--- a/test/services/bill-runs/setup/create.service.test.js
+++ b/test/services/bill-runs/setup/create.service.test.js
@@ -44,6 +44,10 @@ describe('Bill Runs Setup Create service', () => {
       session = await SessionHelper.add({
         data: { region: '19a027c6-4aad-47d3-80e3-3917a4579a5b', type: 'annual' }
       })
+      // NOTE: We make these additional $afterFind() calls to trigger the hook that would have been called when the
+      // create service queries for the session. The hook elevates properties from `data` onto the session instance
+      // itself. Without this the tests fail though the service works fine.
+      session.$afterFind()
 
       existsResults = { matchResults: [], session, yearToUse: 2024 }
     })
@@ -62,6 +66,7 @@ describe('Bill Runs Setup Create service', () => {
       session = await SessionHelper.add({
         data: { region: '19a027c6-4aad-47d3-80e3-3917a4579a5b', type: 'annual' }
       })
+      session.$afterFind()
 
       existsResults = { matchResults: [], session, yearToUse: 2024 }
     })
@@ -84,6 +89,7 @@ describe('Bill Runs Setup Create service', () => {
       session = await SessionHelper.add({
         data: { region: '19a027c6-4aad-47d3-80e3-3917a4579a5b', type: 'supplementary' }
       })
+      session.$afterFind()
     })
 
     describe('and there were no matching bill runs', () => {
@@ -147,6 +153,7 @@ describe('Bill Runs Setup Create service', () => {
             season: 'summer'
           }
         })
+        session.$afterFind()
 
         existsResults = { matchResults: [], session, yearToUse: 2022 }
       })
@@ -168,6 +175,7 @@ describe('Bill Runs Setup Create service', () => {
             year: 2023
           }
         })
+        session.$afterFind()
 
         existsResults = { matchResults: [], session, yearToUse: 2023 }
       })

--- a/test/services/bill-runs/setup/submit-region.service.test.js
+++ b/test/services/bill-runs/setup/submit-region.service.test.js
@@ -58,7 +58,7 @@ describe('Bill Runs Setup Submit Region service', () => {
 
           const refreshedSession = await session.$query()
 
-          expect(refreshedSession.data.region).to.equal('19a027c6-4aad-47d3-80e3-3917a4579a5b')
+          expect(refreshedSession.region).to.equal('19a027c6-4aad-47d3-80e3-3917a4579a5b')
           expect(result.setupComplete).to.be.true()
         })
       })
@@ -73,7 +73,7 @@ describe('Bill Runs Setup Submit Region service', () => {
 
           const refreshedSession = await session.$query()
 
-          expect(refreshedSession.data.region).to.equal('19a027c6-4aad-47d3-80e3-3917a4579a5b')
+          expect(refreshedSession.region).to.equal('19a027c6-4aad-47d3-80e3-3917a4579a5b')
           expect(result.setupComplete).to.be.false()
         })
       })

--- a/test/services/bill-runs/setup/submit-season.service.test.js
+++ b/test/services/bill-runs/setup/submit-season.service.test.js
@@ -37,7 +37,7 @@ describe('Bill Runs Setup Submit Season service', () => {
 
         const refreshedSession = await session.$query()
 
-        expect(refreshedSession.data.season).to.equal('summer')
+        expect(refreshedSession.season).to.equal('summer')
       })
 
       it('returns an empty object (no page data is needed for a redirect)', async () => {

--- a/test/services/bill-runs/setup/submit-type.service.test.js
+++ b/test/services/bill-runs/setup/submit-type.service.test.js
@@ -37,7 +37,7 @@ describe('Bill Runs Setup Submit Type service', () => {
 
         const refreshedSession = await session.$query()
 
-        expect(refreshedSession.data.type).to.equal('annual')
+        expect(refreshedSession.type).to.equal('annual')
       })
 
       it('returns an empty object (no page data is needed for a redirect)', async () => {

--- a/test/services/bill-runs/setup/submit-year.service.test.js
+++ b/test/services/bill-runs/setup/submit-year.service.test.js
@@ -38,7 +38,7 @@ describe('Bill Runs Setup Submit Year service', () => {
 
           const refreshedSession = await session.$query()
 
-          expect(refreshedSession.data.year).to.equal('2023')
+          expect(refreshedSession.year).to.equal('2023')
           expect(result.setupComplete).to.be.true()
         })
       })
@@ -55,7 +55,7 @@ describe('Bill Runs Setup Submit Year service', () => {
 
           const refreshedSession = await session.$query()
 
-          expect(refreshedSession.data.year).to.equal('2022')
+          expect(refreshedSession.year).to.equal('2022')
           expect(result.setupComplete).to.be.false()
         })
       })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4463

We created our `SessionModel` and its backing table out of the need to be able to store data temporarily, for example, when a user is following a journey to create a new return requirement.

After using it in our bill run setup and return requirement journeys we spotted there were some improvements we could make. So, we [Enhanced the SessionModel to expose and update data](https://github.com/DEFRA/water-abstraction-system/pull/981).

The next step is to update the existing journeys to take advantage of these enhancements.

In this change, we update the bill run setup journey. We'll update the return requirements journey in the next change.