### PR TITLE
Update rtn. req. setup journey to use new session

### DIFF
--- a/app/controllers/return-requirements.controller.js
+++ b/app/controllers/return-requirements.controller.js
@@ -402,6 +402,7 @@ async function submitStartDate (request, h) {
   const { sessionId } = request.params
 
   const pageData = await SubmitStartDateService.go(sessionId, request.payload)
+  console.log('🚀 ~ submitStartDate ~ pageData:', pageData)
 
   if (pageData.error) {
     return h.view('return-requirements/start-date.njk', pageData)

--- a/app/presenters/return-requirements/abstraction-period.presenter.js
+++ b/app/presenters/return-requirements/abstraction-period.presenter.js
@@ -14,10 +14,10 @@
  */
 function go (session) {
   const data = {
-    abstractionPeriod: session.data.abstractionPeriod ? session.data.abstractionPeriod : null,
+    abstractionPeriod: session.abstractionPeriod ? session.abstractionPeriod : null,
     id: session.id,
-    licenceId: session.data.licence.id,
-    licenceRef: session.data.licence.licenceRef
+    licenceId: session.licence.id,
+    licenceRef: session.licence.licenceRef
   }
 
   return data

--- a/app/presenters/return-requirements/agreements-exceptions.presenter.js
+++ b/app/presenters/return-requirements/agreements-exceptions.presenter.js
@@ -16,9 +16,9 @@
 function go (session) {
   const data = {
     id: session.id,
-    licenceId: session.data.licence.id,
-    licenceRef: session.data.licence.licenceRef,
-    agreementsExceptions: session.data.agreementsExceptions ? session.data.agreementsExceptions : ''
+    licenceId: session.licence.id,
+    licenceRef: session.licence.licenceRef,
+    agreementsExceptions: session.agreementsExceptions ? session.agreementsExceptions : ''
   }
 
   return data

--- a/app/presenters/return-requirements/check-your-answers.presenter.js
+++ b/app/presenters/return-requirements/check-your-answers.presenter.js
@@ -10,27 +10,27 @@ const { formatLongDate } = require('../base.presenter.js')
 function go (session) {
   const data = {
     id: session.id,
-    journey: session.data.journey,
-    licenceRef: session.data.licence.licenceRef,
-    note: session.data.note ? session.data.note.content : '',
-    reason: session.data.reason,
-    startDate: _startDate(session.data),
-    userEmail: session.data.note ? session.data.note.userEmail : 'No notes added'
+    journey: session.journey,
+    licenceRef: session.licence.licenceRef,
+    note: session.note ? session.note.content : '',
+    reason: session.reason,
+    startDate: _startDate(session),
+    userEmail: session.note ? session.note.userEmail : 'No notes added'
   }
 
   return data
 }
 
-function _startDate (sessionData) {
-  const selectedOption = sessionData.startDateOptions
+function _startDate (session) {
+  const selectedOption = session.startDateOptions
   let date
 
   if (selectedOption === 'licenceStartDate') {
-    date = new Date(sessionData.licence.currentVersionStartDate)
+    date = new Date(session.licence.currentVersionStartDate)
   } else {
-    const day = sessionData.startDateDay
-    const month = sessionData.startDateMonth
-    const year = sessionData.startDateYear
+    const day = session.startDateDay
+    const month = session.startDateMonth
+    const year = session.startDateYear
 
     date = new Date(`${year}-${month}-${day}`)
   }

--- a/app/presenters/return-requirements/frequency-collected.presenter.js
+++ b/app/presenters/return-requirements/frequency-collected.presenter.js
@@ -16,9 +16,9 @@
 function go (session) {
   const data = {
     id: session.id,
-    licenceId: session.data.licence.id,
-    licenceRef: session.data.licence.licenceRef,
-    frequencyCollected: session.data.frequencyCollected ? session.data.frequencyCollected : null
+    licenceId: session.licence.id,
+    licenceRef: session.licence.licenceRef,
+    frequencyCollected: session.frequencyCollected ? session.frequencyCollected : null
   }
 
   return data

--- a/app/presenters/return-requirements/frequency-reported.presenter.js
+++ b/app/presenters/return-requirements/frequency-reported.presenter.js
@@ -16,9 +16,9 @@
 function go (session) {
   const data = {
     id: session.id,
-    licenceId: session.data.licence.id,
-    licenceRef: session.data.licence.licenceRef,
-    frequencyReported: session.data.frequencyReported ? session.data.frequencyReported : null
+    licenceId: session.licence.id,
+    licenceRef: session.licence.licenceRef,
+    frequencyReported: session.frequencyReported ? session.frequencyReported : null
   }
 
   return data

--- a/app/presenters/return-requirements/no-returns-required.presenter.js
+++ b/app/presenters/return-requirements/no-returns-required.presenter.js
@@ -7,9 +7,9 @@
 
 function go (session) {
   const data = {
-    selectedOption: session.data.reason || null,
+    selectedOption: session.reason || null,
     id: session.id,
-    licenceRef: session.data.licence.licenceRef
+    licenceRef: session.licence.licenceRef
   }
 
   return data

--- a/app/presenters/return-requirements/note.presenter.js
+++ b/app/presenters/return-requirements/note.presenter.js
@@ -6,11 +6,11 @@
  */
 
 function go (session) {
-  const { id, data: { note } } = session
+  const { id, note } = session
 
   const data = {
     id,
-    licenceRef: session.data.licence.licenceRef,
+    licenceRef: session.licence.licenceRef,
     note: note ? note.content : ''
   }
 

--- a/app/presenters/return-requirements/points.presenter.js
+++ b/app/presenters/return-requirements/points.presenter.js
@@ -16,10 +16,10 @@
 function go (session, pointsData) {
   const data = {
     id: session.id,
-    licenceId: session.data.licence.id,
-    licenceRef: session.data.licence.licenceRef,
+    licenceId: session.licence.id,
+    licenceRef: session.licence.licenceRef,
     licencePoints: _licencePoints(pointsData),
-    selectedPoints: session.data.points ? session.data.points.join(',') : ''
+    selectedPoints: session.points ? session.points.join(',') : ''
   }
 
   return data

--- a/app/presenters/return-requirements/purpose.presenter.js
+++ b/app/presenters/return-requirements/purpose.presenter.js
@@ -17,10 +17,10 @@
 function go (session, purposesData) {
   const data = {
     id: session.id,
-    licenceId: session.data.licence.id,
-    licenceRef: session.data.licence.licenceRef,
+    licenceId: session.licence.id,
+    licenceRef: session.licence.licenceRef,
     licencePurposes: purposesData,
-    selectedPurposes: session.data.purposes ? session.data.purposes.join(',') : ''
+    selectedPurposes: session.purposes ? session.purposes.join(',') : ''
   }
 
   return data

--- a/app/presenters/return-requirements/reason.presenter.js
+++ b/app/presenters/return-requirements/reason.presenter.js
@@ -8,8 +8,8 @@
 function go (session) {
   const data = {
     id: session.id,
-    licenceRef: session.data.licence.licenceRef,
-    reason: session.data.reason ? session.data.reason : null
+    licenceRef: session.licence.licenceRef,
+    reason: session.reason ? session.reason : null
   }
 
   return data

--- a/app/presenters/return-requirements/returns-cycle.presenter.js
+++ b/app/presenters/return-requirements/returns-cycle.presenter.js
@@ -16,9 +16,9 @@
 function go (session) {
   const data = {
     id: session.id,
-    licenceId: session.data.licence.id,
-    licenceRef: session.data.licence.licenceRef,
-    returnsCycle: session.data.returnsCycle ? session.data.returnsCycle : null
+    licenceId: session.licence.id,
+    licenceRef: session.licence.licenceRef,
+    returnsCycle: session.returnsCycle ? session.returnsCycle : null
   }
 
   return data

--- a/app/presenters/return-requirements/setup.presenter.js
+++ b/app/presenters/return-requirements/setup.presenter.js
@@ -8,8 +8,8 @@
 function go (session) {
   const data = {
     id: session.id,
-    licenceRef: session.data.licence.licenceRef,
-    setup: session.data.setup ? session.data.setup : null
+    licenceRef: session.licence.licenceRef,
+    setup: session.setup ? session.setup : null
   }
 
   return data

--- a/app/presenters/return-requirements/site-description.presenter.js
+++ b/app/presenters/return-requirements/site-description.presenter.js
@@ -16,9 +16,9 @@
 function go (session) {
   const data = {
     id: session.id,
-    licenceId: session.data.licence.id,
-    licenceRef: session.data.licence.licenceRef,
-    siteDescription: session.data.siteDescription ? session.data.siteDescription : null
+    licenceId: session.licence.id,
+    licenceRef: session.licence.licenceRef,
+    siteDescription: session.siteDescription ? session.siteDescription : null
   }
 
   return data

--- a/app/presenters/return-requirements/start-date.presenter.js
+++ b/app/presenters/return-requirements/start-date.presenter.js
@@ -18,10 +18,10 @@ const { formatLongDate } = require('../base.presenter.js')
 function go (session) {
   const data = {
     id: session.id,
-    licenceId: session.data.licence.id,
-    licenceRef: session.data.licence.licenceRef,
-    licenceVersionStartDate: _licenceVersionStartDate(session.data.licence.currentVersionStartDate),
-    ..._transformSession(session.data)
+    licenceId: session.licence.id,
+    licenceRef: session.licence.licenceRef,
+    licenceVersionStartDate: _licenceVersionStartDate(session.licence.currentVersionStartDate),
+    ..._transformSession(session)
   }
 
   return data
@@ -36,13 +36,13 @@ function _licenceVersionStartDate (date) {
   return formattedDate
 }
 
-function _transformSession (sessionData) {
+function _transformSession (session) {
   // NOTE: 'startDateOptions' is the session value that tells us whether the user selected the licence version start
   // date or another date radio button.
   // If it is not set then either its because the presenter has been called from `StartDateService` and it's the first
   // load. Else its been called by `SubmitStartDateService` but the user hasn't selected a radio button.
   // Either way, we use it to tell us whether there is anything in the session worth transforming.
-  const selectedOption = sessionData.startDateOptions
+  const selectedOption = session.startDateOptions
 
   if (!selectedOption) {
     return {
@@ -54,9 +54,9 @@ function _transformSession (sessionData) {
   }
 
   return {
-    anotherStartDateDay: sessionData.startDateDay,
-    anotherStartDateMonth: sessionData.startDateMonth,
-    anotherStartDateYear: sessionData.startDateYear,
+    anotherStartDateDay: session.startDateDay,
+    anotherStartDateMonth: session.startDateMonth,
+    anotherStartDateYear: session.startDateYear,
     selectedOption
   }
 }

--- a/app/services/return-requirements/check-your-answers.service.js
+++ b/app/services/return-requirements/check-your-answers.service.js
@@ -27,20 +27,16 @@ async function go (sessionId, yar) {
   return {
     activeNavBar: 'search',
     notification,
-    licenceRef: session.data.licence.licenceRef,
-    pageTitle: `Check the return requirements for ${session.data.licence.licenceHolder}`,
+    licenceRef: session.licence.licenceRef,
+    pageTitle: `Check the return requirements for ${session.licence.licenceHolder}`,
     ...formattedData
   }
 }
 
 async function _checkYourAnswersVisited (session) {
-  const currentData = session.data
+  session.checkYourAnswersVisited = true
 
-  currentData.checkYourAnswersVisited = true
-  await session.$query().patch({ data: currentData })
-
-  const updatedSession = await SessionModel.query().findById(session.id)
-  return updatedSession
+  return session.$update()
 }
 
 module.exports = {

--- a/app/services/return-requirements/delete-note.service.js
+++ b/app/services/return-requirements/delete-note.service.js
@@ -31,11 +31,9 @@ async function go (sessionId, yar) {
 }
 
 async function _save (session) {
-  const currentData = session.data
+  delete session.note
 
-  delete currentData.note
-
-  return session.$query().patch({ data: currentData })
+  return session.$update()
 }
 
 module.exports = {

--- a/app/services/return-requirements/no-returns-required.service.js
+++ b/app/services/return-requirements/no-returns-required.service.js
@@ -23,7 +23,7 @@ async function go (sessionId) {
 
   return {
     activeNavBar: 'search',
-    checkYourAnswersVisited: session.data.checkYourAnswersVisited,
+    checkYourAnswersVisited: session.checkYourAnswersVisited,
     pageTitle: 'Why are no returns required?',
     ...formattedData
   }

--- a/app/services/return-requirements/note.service.js
+++ b/app/services/return-requirements/note.service.js
@@ -23,7 +23,7 @@ async function go (sessionId) {
 
   return {
     activeNavBar: 'search',
-    checkYourAnswersVisited: session.data.checkYourAnswersVisited,
+    checkYourAnswersVisited: session.checkYourAnswersVisited,
     pageTitle: 'Add a note',
     ...formattedData
   }

--- a/app/services/return-requirements/points.service.js
+++ b/app/services/return-requirements/points.service.js
@@ -21,7 +21,7 @@ const SessionModel = require('../../models/session.model.js')
 */
 async function go (sessionId) {
   const session = await SessionModel.query().findById(sessionId)
-  const pointsData = await FetchPointsService.go(session.data.licence.id)
+  const pointsData = await FetchPointsService.go(session.licence.id)
 
   const formattedData = PointsPresenter.go(session, pointsData)
 

--- a/app/services/return-requirements/purpose.service.js
+++ b/app/services/return-requirements/purpose.service.js
@@ -21,7 +21,7 @@ const SessionModel = require('../../models/session.model.js')
 */
 async function go (sessionId) {
   const session = await SessionModel.query().findById(sessionId)
-  const purposesData = await FetchPurposesService.go(session.data.licence.id)
+  const purposesData = await FetchPurposesService.go(session.licence.id)
 
   const formattedData = SelectPurposePresenter.go(session, purposesData)
 

--- a/app/services/return-requirements/reason.service.js
+++ b/app/services/return-requirements/reason.service.js
@@ -23,7 +23,7 @@ async function go (sessionId) {
 
   return {
     activeNavBar: 'search',
-    checkYourAnswersVisited: session.data.checkYourAnswersVisited,
+    checkYourAnswersVisited: session.checkYourAnswersVisited,
     pageTitle: 'Select the reason for the requirements for returns',
     ...formattedData
   }

--- a/app/services/return-requirements/start-date.service.js
+++ b/app/services/return-requirements/start-date.service.js
@@ -24,7 +24,7 @@ async function go (sessionId) {
 
   return {
     activeNavBar: 'search',
-    checkYourAnswersVisited: session.data.checkYourAnswersVisited,
+    checkYourAnswersVisited: session.checkYourAnswersVisited,
     pageTitle: 'Select the start date for the requirements for returns',
     ...formattedData
   }

--- a/app/services/return-requirements/submit-abstraction-period.service.js
+++ b/app/services/return-requirements/submit-abstraction-period.service.js
@@ -32,7 +32,7 @@ async function go (sessionId, payload) {
     await _save(session, payload)
 
     return {
-      checkYourAnswersVisited: session.data.checkYourAnswersVisited
+      checkYourAnswersVisited: session.checkYourAnswersVisited
     }
   }
 
@@ -40,7 +40,7 @@ async function go (sessionId, payload) {
 
   return {
     activeNavBar: 'search',
-    checkYourAnswersVisited: session.data.checkYourAnswersVisited,
+    checkYourAnswersVisited: session.checkYourAnswersVisited,
     error: validationResult,
     pageTitle: 'Enter the abstraction period for the requirements for returns',
     ...submittedSessionData
@@ -48,11 +48,9 @@ async function go (sessionId, payload) {
 }
 
 async function _save (session, payload) {
-  const currentData = session.data
+  session.abstractionPeriod = payload
 
-  currentData.abstractionPeriod = payload
-
-  return session.$query().patch({ data: currentData })
+  return session.$update()
 }
 
 /**
@@ -60,7 +58,7 @@ async function _save (session, payload) {
  * the user, payload will be an empty object.
  */
 function _submittedSessionData (session, payload) {
-  session.data.abstractionPeriod = Object.keys(payload).length > 0 ? payload : null
+  session.abstractionPeriod = Object.keys(payload).length > 0 ? payload : null
 
   return AbstractionPeriodPresenter.go(session)
 }

--- a/app/services/return-requirements/submit-agreements-exceptions.service.js
+++ b/app/services/return-requirements/submit-agreements-exceptions.service.js
@@ -34,7 +34,7 @@ async function go (sessionId, payload) {
     await _save(session, payload)
 
     return {
-      checkYourAnswersVisited: session.data.checkYourAnswersVisited
+      checkYourAnswersVisited: session.checkYourAnswersVisited
     }
   }
 
@@ -42,7 +42,7 @@ async function go (sessionId, payload) {
 
   return {
     activeNavBar: 'search',
-    checkYourAnswersVisited: session.data.checkYourAnswersVisited,
+    checkYourAnswersVisited: session.checkYourAnswersVisited,
     error: validationResult,
     pageTitle: 'Select agreements and exceptions for the requirements for returns',
     ...formattedData
@@ -61,11 +61,9 @@ function _handleOneOptionSelected (payload) {
 }
 
 async function _save (session, payload) {
-  const currentData = session.data
+  session.agreementsExceptions = payload.agreementsExceptions
 
-  currentData.agreementsExceptions = payload.agreementsExceptions
-
-  return session.$query().patch({ data: currentData })
+  return session.$update()
 }
 
 function _validate (payload) {

--- a/app/services/return-requirements/submit-check-your-answers.service.js
+++ b/app/services/return-requirements/submit-check-your-answers.service.js
@@ -26,9 +26,9 @@ const SessionModel = require('../../models/session.model.js')
 async function go (sessionId) {
   const session = await SessionModel.query().findById(sessionId)
 
-  await _validateLicence(session.data.licence.id)
+  await _validateLicence(session.licence.id)
 
-  return session.data.licence.id
+  return session.licence.id
 }
 
 async function _validateLicence (licenceId) {

--- a/app/services/return-requirements/submit-frequency-collected.service.js
+++ b/app/services/return-requirements/submit-frequency-collected.service.js
@@ -32,7 +32,7 @@ async function go (sessionId, payload) {
     await _save(session, payload)
 
     return {
-      checkYourAnswersVisited: session.data.checkYourAnswersVisited
+      checkYourAnswersVisited: session.checkYourAnswersVisited
     }
   }
 
@@ -40,7 +40,7 @@ async function go (sessionId, payload) {
 
   return {
     activeNavBar: 'search',
-    checkYourAnswersVisited: session.data.checkYourAnswersVisited,
+    checkYourAnswersVisited: session.checkYourAnswersVisited,
     error: validationResult,
     pageTitle: 'Select how often readings or volumes are collected',
     ...formattedData
@@ -48,11 +48,9 @@ async function go (sessionId, payload) {
 }
 
 async function _save (session, payload) {
-  const currentData = session.data
+  session.frequencyCollected = payload.frequencyCollected
 
-  currentData.frequencyCollected = payload.frequencyCollected
-
-  return session.$query().patch({ data: currentData })
+  return session.$update()
 }
 
 function _validate (payload) {

--- a/app/services/return-requirements/submit-frequency-reported.service.js
+++ b/app/services/return-requirements/submit-frequency-reported.service.js
@@ -32,7 +32,7 @@ async function go (sessionId, payload) {
     await _save(session, payload)
 
     return {
-      checkYourAnswersVisited: session.data.checkYourAnswersVisited
+      checkYourAnswersVisited: session.checkYourAnswersVisited
     }
   }
 
@@ -40,7 +40,7 @@ async function go (sessionId, payload) {
 
   return {
     activeNavBar: 'search',
-    checkYourAnswersVisited: session.data.checkYourAnswersVisited,
+    checkYourAnswersVisited: session.checkYourAnswersVisited,
     error: validationResult,
     pageTitle: 'Select how often readings or volumes are reported',
     ...formattedData
@@ -48,11 +48,9 @@ async function go (sessionId, payload) {
 }
 
 async function _save (session, payload) {
-  const currentData = session.data
+  session.frequencyReported = payload.frequencyReported
 
-  currentData.frequencyReported = payload.frequencyReported
-
-  return session.$query().patch({ data: currentData })
+  return session.$update()
 }
 
 function _validate (payload) {

--- a/app/services/return-requirements/submit-no-returns-required.service.js
+++ b/app/services/return-requirements/submit-no-returns-required.service.js
@@ -31,8 +31,8 @@ async function go (sessionId, payload) {
     await _save(session, payload)
 
     return {
-      checkYourAnswersVisited: session.data.checkYourAnswersVisited,
-      journey: session.data.journey
+      checkYourAnswersVisited: session.checkYourAnswersVisited,
+      journey: session.journey
     }
   }
 
@@ -40,7 +40,7 @@ async function go (sessionId, payload) {
 
   return {
     activeNavBar: 'search',
-    checkYourAnswersVisited: session.data.checkYourAnswersVisited,
+    checkYourAnswersVisited: session.checkYourAnswersVisited,
     error: validationResult,
     pageTitle: 'Why are no returns required?',
     selectedOption: null,
@@ -49,11 +49,9 @@ async function go (sessionId, payload) {
 }
 
 async function _save (session, payload) {
-  const currentData = session.data
+  session.reason = payload.reason
 
-  currentData.reason = payload.reason
-
-  return session.$query().patch({ data: currentData })
+  return session.$update()
 }
 
 function _validate (payload) {

--- a/app/services/return-requirements/submit-note.service.js
+++ b/app/services/return-requirements/submit-note.service.js
@@ -38,7 +38,7 @@ async function go (sessionId, payload, user, yar) {
     }
 
     return {
-      journey: session.data.journey
+      journey: session.journey
     }
   }
 
@@ -74,18 +74,16 @@ function _notification (session, newNote) {
 }
 
 async function _save (session, payload, user) {
-  const currentData = session.data
-
-  currentData.note = {
+  session.note = {
     content: payload.note,
     userEmail: user.username
   }
 
-  return session.$query().patch({ data: currentData })
+  return session.$update()
 }
 
 function _submittedSessionData (session, payload) {
-  session.data.note = payload.note ? payload.note : null
+  session.note = payload.note ? payload.note : null
 
   return NotePresenter.go(session)
 }

--- a/app/services/return-requirements/submit-points.service.js
+++ b/app/services/return-requirements/submit-points.service.js
@@ -35,16 +35,16 @@ async function go (sessionId, payload) {
     await _save(session, payload)
 
     return {
-      checkYourAnswersVisited: session.data.checkYourAnswersVisited
+      checkYourAnswersVisited: session.checkYourAnswersVisited
     }
   }
 
-  const pointsData = await FetchPointsService.go(session.data.licence.id)
+  const pointsData = await FetchPointsService.go(session.licence.id)
   const formattedData = PointsPresenter.go(session, pointsData)
 
   return {
     activeNavBar: 'search',
-    checkYourAnswersVisited: session.data.checkYourAnswersVisited,
+    checkYourAnswersVisited: session.checkYourAnswersVisited,
     error: validationResult,
     pageTitle: 'Select the points for the requirements for returns',
     ...formattedData
@@ -63,11 +63,9 @@ function _handleOneOptionSelected (payload) {
 }
 
 async function _save (session, payload) {
-  const currentData = session.data
+  session.points = payload.points
 
-  currentData.points = payload.points
-
-  return session.$query().patch({ data: currentData })
+  return session.$update()
 }
 
 function _validate (payload) {

--- a/app/services/return-requirements/submit-purpose.service.js
+++ b/app/services/return-requirements/submit-purpose.service.js
@@ -35,16 +35,16 @@ async function go (sessionId, payload) {
     await _save(session, payload)
 
     return {
-      checkYourAnswersVisited: session.data.checkYourAnswersVisited
+      checkYourAnswersVisited: session.checkYourAnswersVisited
     }
   }
 
-  const purposesData = await FetchPurposesService.go(session.data.licence.id)
+  const purposesData = await FetchPurposesService.go(session.licence.id)
   const formattedData = PurposePresenter.go(session, purposesData)
 
   return {
     activeNavBar: 'search',
-    checkYourAnswersVisited: session.data.checkYourAnswersVisited,
+    checkYourAnswersVisited: session.checkYourAnswersVisited,
     error: validationResult,
     pageTitle: 'Select the purpose for the requirements for returns',
     ...formattedData
@@ -63,11 +63,9 @@ function _handleOneOptionSelected (payload) {
 }
 
 async function _save (session, payload) {
-  const currentData = session.data
+  session.purposes = payload.purposes
 
-  currentData.purposes = payload.purposes
-
-  return session.$query().patch({ data: currentData })
+  return session.$update()
 }
 
 function _validate (payload) {

--- a/app/services/return-requirements/submit-reason.service.js
+++ b/app/services/return-requirements/submit-reason.service.js
@@ -32,7 +32,7 @@ async function go (sessionId, payload) {
     await _save(session, payload)
 
     return {
-      checkYourAnswersVisited: session.data.checkYourAnswersVisited
+      checkYourAnswersVisited: session.checkYourAnswersVisited
     }
   }
 
@@ -40,7 +40,7 @@ async function go (sessionId, payload) {
 
   return {
     activeNavBar: 'search',
-    checkYourAnswersVisited: session.data.checkYourAnswersVisited,
+    checkYourAnswersVisited: session.checkYourAnswersVisited,
     error: validationResult,
     pageTitle: 'Select the reason for the requirements for returns',
     ...formattedData
@@ -48,11 +48,9 @@ async function go (sessionId, payload) {
 }
 
 async function _save (session, payload) {
-  const currentData = session.data
+  session.reason = payload.reason
 
-  currentData.reason = payload.reason
-
-  return session.$query().patch({ data: currentData })
+  return session.$update()
 }
 
 function _validate (payload) {

--- a/app/services/return-requirements/submit-returns-cycle.service.js
+++ b/app/services/return-requirements/submit-returns-cycle.service.js
@@ -32,7 +32,7 @@ async function go (sessionId, payload) {
     await _save(session, payload)
 
     return {
-      checkYourAnswersVisited: session.data.checkYourAnswersVisited
+      checkYourAnswersVisited: session.checkYourAnswersVisited
     }
   }
 
@@ -40,7 +40,7 @@ async function go (sessionId, payload) {
 
   return {
     activeNavBar: 'search',
-    checkYourAnswersVisited: session.data.checkYourAnswersVisited,
+    checkYourAnswersVisited: session.checkYourAnswersVisited,
     error: validationResult,
     pageTitle: 'Select the returns cycle for the requirements for returns',
     ...formattedData
@@ -48,11 +48,9 @@ async function go (sessionId, payload) {
 }
 
 async function _save (session, payload) {
-  const currentData = session.data
+  session.returnsCycle = payload.returnsCycle
 
-  currentData.returnsCycle = payload.returnsCycle
-
-  return session.$query().patch({ data: currentData })
+  return session.$update()
 }
 
 function _validate (payload) {

--- a/app/services/return-requirements/submit-setup.service.js
+++ b/app/services/return-requirements/submit-setup.service.js
@@ -61,11 +61,9 @@ function _redirect (setup) {
 }
 
 async function _save (session, payload) {
-  const currentData = session.data
+  session.setup = payload.setup
 
-  currentData.setup = payload.setup
-
-  return session.$query().patch({ data: currentData })
+  return session.$update()
 }
 
 function _validate (payload) {

--- a/app/services/return-requirements/submit-site-description.service.js
+++ b/app/services/return-requirements/submit-site-description.service.js
@@ -32,7 +32,7 @@ async function go (sessionId, payload) {
     await _save(session, payload)
 
     return {
-      checkYourAnswersVisited: session.data.checkYourAnswersVisited
+      checkYourAnswersVisited: session.checkYourAnswersVisited
     }
   }
 
@@ -40,7 +40,7 @@ async function go (sessionId, payload) {
 
   return {
     activeNavBar: 'search',
-    checkYourAnswersVisited: session.data.checkYourAnswersVisited,
+    checkYourAnswersVisited: session.checkYourAnswersVisited,
     error: validationResult,
     pageTitle: 'Enter a site description for the requirements for returns',
     ...submittedSessionData
@@ -48,11 +48,9 @@ async function go (sessionId, payload) {
 }
 
 async function _save (session, payload) {
-  const currentData = session.data
+  session.siteDescription = payload.siteDescription
 
-  currentData.siteDescription = payload.siteDescription
-
-  return session.$query().patch({ data: currentData })
+  return session.$update()
 }
 
 /**
@@ -60,7 +58,7 @@ async function _save (session, payload) {
  * the user, payload will be an empty object.
  */
 function _submittedSessionData (session, payload) {
-  session.data.siteDescription = payload.siteDescription ? payload.siteDescription : null
+  session.siteDescription = payload.siteDescription ? payload.siteDescription : null
 
   return SiteDescriptionPresenter.go(session)
 }

--- a/app/services/return-requirements/submit-start-date.service.js
+++ b/app/services/return-requirements/submit-start-date.service.js
@@ -27,15 +27,15 @@ const StartDateValidator = require('../../validators/return-requirements/start-d
 async function go (sessionId, payload) {
   const session = await SessionModel.query().findById(sessionId)
 
-  const { endDate, startDate } = session.data.licence
+  const { endDate, startDate } = session.licence
   const validationResult = _validate(payload, startDate, endDate)
 
   if (!validationResult) {
     await _save(session, payload)
 
     return {
-      checkYourAnswersVisited: session.data.checkYourAnswersVisited,
-      journey: session.data.journey
+      checkYourAnswersVisited: session.checkYourAnswersVisited,
+      journey: session.journey
     }
   }
 
@@ -43,34 +43,33 @@ async function go (sessionId, payload) {
 
   return {
     activeNavBar: 'search',
-    checkYourAnswersVisited: session.data.checkYourAnswersVisited,
+    checkYourAnswersVisited: session.checkYourAnswersVisited,
     error: validationResult,
-    journey: session.data.journey,
+    journey: session.journey,
     pageTitle: 'Select the start date for the requirements for returns',
     ...submittedSessionData
   }
 }
 
 async function _save (session, payload) {
-  const currentData = session.data
   const selectedOption = payload['start-date-options']
 
-  currentData.startDateOptions = selectedOption
+  session.startDateOptions = selectedOption
 
   if (selectedOption === 'anotherStartDate') {
-    currentData.startDateDay = payload['start-date-day']
-    currentData.startDateMonth = payload['start-date-month']
-    currentData.startDateYear = payload['start-date-year']
+    session.startDateDay = payload['start-date-day']
+    session.startDateMonth = payload['start-date-month']
+    session.startDateYear = payload['start-date-year']
   }
 
-  return session.$query().patch({ data: currentData })
+  return session.$update()
 }
 
 function _submittedSessionData (session, payload) {
-  session.data.startDateDay = payload['start-date-day'] ? payload['start-date-day'] : null
-  session.data.startDateMonth = payload['start-date-month'] ? payload['start-date-month'] : null
-  session.data.startDateYear = payload['start-date-year'] ? payload['start-date-year'] : null
-  session.data.startDateOptions = payload['start-date-options'] ? payload['start-date-options'] : null
+  session.startDateDay = payload['start-date-day'] ? payload['start-date-day'] : null
+  session.startDateMonth = payload['start-date-month'] ? payload['start-date-month'] : null
+  session.startDateYear = payload['start-date-year'] ? payload['start-date-year'] : null
+  session.startDateOptions = payload['start-date-options'] ? payload['start-date-options'] : null
 
   return StartDatePresenter.go(session, payload)
 }

--- a/test/presenters/return-requirements/abstraction-period.presenter.test.js
+++ b/test/presenters/return-requirements/abstraction-period.presenter.test.js
@@ -16,22 +16,20 @@ describe('Abstraction Period presenter', () => {
   beforeEach(() => {
     session = {
       id: '61e07498-f309-4829-96a9-72084a54996d',
-      data: {
-        licence: {
-          id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
-          currentVersionStartDate: '2023-01-01T00:00:00.000Z',
-          endDate: null,
-          licenceRef: '01/ABC',
-          licenceHolder: 'Turbo Kid',
-          startDate: '2022-04-01T00:00:00.000Z'
-        }
+      licence: {
+        id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
+        currentVersionStartDate: '2023-01-01T00:00:00.000Z',
+        endDate: null,
+        licenceRef: '01/ABC',
+        licenceHolder: 'Turbo Kid',
+        startDate: '2022-04-01T00:00:00.000Z'
       }
     }
   })
 
   describe('when provided with a session where abstraction period is populated', () => {
     beforeEach(() => {
-      session.data.abstractionPeriod = {
+      session.abstractionPeriod = {
         'start-abstraction-period-day': '07',
         'start-abstraction-period-month': '12',
         'end-abstraction-period-day': '22',

--- a/test/presenters/return-requirements/agreements-exceptions.presenter.test.js
+++ b/test/presenters/return-requirements/agreements-exceptions.presenter.test.js
@@ -18,15 +18,13 @@ describe('Agreements Exceptions presenter', () => {
       beforeEach(() => {
         session = {
           id: '61e07498-f309-4829-96a9-72084a54996d',
-          data: {
-            licence: {
-              id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
-              currentVersionStartDate: '2023-01-01T00:00:00.000Z',
-              endDate: null,
-              licenceRef: '01/ABC',
-              licenceHolder: 'Turbo Kid',
-              startDate: '2022-04-01T00:00:00.000Z'
-            }
+          licence: {
+            id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
+            currentVersionStartDate: '2023-01-01T00:00:00.000Z',
+            endDate: null,
+            licenceRef: '01/ABC',
+            licenceHolder: 'Turbo Kid',
+            startDate: '2022-04-01T00:00:00.000Z'
           }
         }
       })
@@ -47,17 +45,15 @@ describe('Agreements Exceptions presenter', () => {
       beforeEach(() => {
         session = {
           id: '61e07498-f309-4829-96a9-72084a54996d',
-          data: {
-            licence: {
-              id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
-              currentVersionStartDate: '2023-01-01T00:00:00.000Z',
-              endDate: null,
-              licenceRef: '01/ABC',
-              licenceHolder: 'Turbo Kid',
-              startDate: '2022-04-01T00:00:00.000Z'
-            },
-            agreementsExceptions: 'gravity-fill'
-          }
+          licence: {
+            id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
+            currentVersionStartDate: '2023-01-01T00:00:00.000Z',
+            endDate: null,
+            licenceRef: '01/ABC',
+            licenceHolder: 'Turbo Kid',
+            startDate: '2022-04-01T00:00:00.000Z'
+          },
+          agreementsExceptions: 'gravity-fill'
         }
       })
 

--- a/test/presenters/return-requirements/check-your-answers.presenter.test.js
+++ b/test/presenters/return-requirements/check-your-answers.presenter.test.js
@@ -16,23 +16,21 @@ describe('Check Your Answers presenter', () => {
   beforeEach(() => {
     session = {
       id: 'f1288f6c-8503-4dc1-b114-75c408a14bd0',
-      data: {
-        licence: {
-          currentVersionStartDate: '2023-01-01T00:00:00.000Z',
-          id: 'ea53bfc6-740d-46c5-9558-fc8cabfc6c1f',
-          licenceRef: '01/123',
-          licenceHolder: 'Astro Boy'
+      licence: {
+        currentVersionStartDate: '2023-01-01T00:00:00.000Z',
+        id: 'ea53bfc6-740d-46c5-9558-fc8cabfc6c1f',
+        licenceRef: '01/123',
+        licenceHolder: 'Astro Boy'
 
-        },
-        journey: 'no-returns-required',
-        note: {
-          content: 'Note attached to requirement',
-          status: 'Added',
-          userEmail: 'carol.shaw@atari.com'
-        },
-        reason: 'returns-exception',
-        startDateOptions: 'licenceStartDate'
-      }
+      },
+      journey: 'no-returns-required',
+      note: {
+        content: 'Note attached to requirement',
+        status: 'Added',
+        userEmail: 'carol.shaw@atari.com'
+      },
+      reason: 'returns-exception',
+      startDateOptions: 'licenceStartDate'
     }
   })
 
@@ -63,7 +61,7 @@ describe('Check Your Answers presenter', () => {
 
     describe('when there is no note', () => {
       beforeEach(() => {
-        delete session.data.note
+        delete session.note
       })
 
       it('returns an empty string', () => {
@@ -77,11 +75,11 @@ describe('Check Your Answers presenter', () => {
   describe("the 'startDate' property", () => {
     describe("when the user selected the option 'anotherStartDate'", () => {
       beforeEach(() => {
-        session.data.startDateOptions = 'anotherStartDate'
+        session.startDateOptions = 'anotherStartDate'
 
-        session.data.startDateDay = '07'
-        session.data.startDateMonth = '03'
-        session.data.startDateYear = '2009'
+        session.startDateDay = '07'
+        session.startDateMonth = '03'
+        session.startDateYear = '2009'
       })
 
       it('returns the start day, month and year entered combined as a date', () => {
@@ -111,7 +109,7 @@ describe('Check Your Answers presenter', () => {
 
     describe('when there is no note', () => {
       beforeEach(() => {
-        delete session.data.note
+        delete session.note
       })
 
       it("returns 'No notes added'", () => {

--- a/test/presenters/return-requirements/frequency-collected.presenter.test.js
+++ b/test/presenters/return-requirements/frequency-collected.presenter.test.js
@@ -18,15 +18,13 @@ describe('Frequency Collected presenter', () => {
       beforeEach(() => {
         session = {
           id: '61e07498-f309-4829-96a9-72084a54996d',
-          data: {
-            licence: {
-              id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
-              currentVersionStartDate: '2023-01-01T00:00:00.000Z',
-              endDate: null,
-              licenceRef: '01/ABC',
-              licenceHolder: 'Turbo Kid',
-              startDate: '2022-04-01T00:00:00.000Z'
-            }
+          licence: {
+            id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
+            currentVersionStartDate: '2023-01-01T00:00:00.000Z',
+            endDate: null,
+            licenceRef: '01/ABC',
+            licenceHolder: 'Turbo Kid',
+            startDate: '2022-04-01T00:00:00.000Z'
           }
         }
       })
@@ -47,17 +45,15 @@ describe('Frequency Collected presenter', () => {
       beforeEach(() => {
         session = {
           id: '61e07498-f309-4829-96a9-72084a54996d',
-          data: {
-            licence: {
-              id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
-              currentVersionStartDate: '2023-01-01T00:00:00.000Z',
-              endDate: null,
-              licenceRef: '01/ABC',
-              licenceHolder: 'Turbo Kid',
-              startDate: '2022-04-01T00:00:00.000Z'
-            },
-            frequencyCollected: 'weekly'
-          }
+          licence: {
+            id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
+            currentVersionStartDate: '2023-01-01T00:00:00.000Z',
+            endDate: null,
+            licenceRef: '01/ABC',
+            licenceHolder: 'Turbo Kid',
+            startDate: '2022-04-01T00:00:00.000Z'
+          },
+          frequencyCollected: 'weekly'
         }
       })
 

--- a/test/presenters/return-requirements/frequency-reported.presenter.test.js
+++ b/test/presenters/return-requirements/frequency-reported.presenter.test.js
@@ -18,15 +18,13 @@ describe('Frequency Reported presenter', () => {
       beforeEach(() => {
         session = {
           id: '61e07498-f309-4829-96a9-72084a54996d',
-          data: {
-            licence: {
-              id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
-              currentVersionStartDate: '2023-01-01T00:00:00.000Z',
-              endDate: null,
-              licenceRef: '01/ABC',
-              licenceHolder: 'Turbo Kid',
-              startDate: '2022-04-01T00:00:00.000Z'
-            }
+          licence: {
+            id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
+            currentVersionStartDate: '2023-01-01T00:00:00.000Z',
+            endDate: null,
+            licenceRef: '01/ABC',
+            licenceHolder: 'Turbo Kid',
+            startDate: '2022-04-01T00:00:00.000Z'
           }
         }
       })
@@ -47,17 +45,15 @@ describe('Frequency Reported presenter', () => {
       beforeEach(() => {
         session = {
           id: '61e07498-f309-4829-96a9-72084a54996d',
-          data: {
-            licence: {
-              id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
-              currentVersionStartDate: '2023-01-01T00:00:00.000Z',
-              endDate: null,
-              licenceRef: '01/ABC',
-              licenceHolder: 'Turbo Kid',
-              startDate: '2022-04-01T00:00:00.000Z'
-            },
-            frequencyReported: 'weekly'
-          }
+          licence: {
+            id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
+            currentVersionStartDate: '2023-01-01T00:00:00.000Z',
+            endDate: null,
+            licenceRef: '01/ABC',
+            licenceHolder: 'Turbo Kid',
+            startDate: '2022-04-01T00:00:00.000Z'
+          },
+          frequencyReported: 'weekly'
         }
       })
 

--- a/test/presenters/return-requirements/no-returns-required.presenter.test.js
+++ b/test/presenters/return-requirements/no-returns-required.presenter.test.js
@@ -16,14 +16,12 @@ describe('No Returns Required presenter', () => {
   beforeEach(() => {
     session = {
       id: 'f1288f6c-8503-4dc1-b114-75c408a14bd0',
-      data: {
-        licence: {
-          id: 'ea53bfc6-740d-46c5-9558-fc8cabfc6c1f',
-          licenceRef: '01/123',
-          licenceHolder: 'Jane Doe'
-        },
-        reason: 'transfer-licence'
-      }
+      licence: {
+        id: 'ea53bfc6-740d-46c5-9558-fc8cabfc6c1f',
+        licenceRef: '01/123',
+        licenceHolder: 'Jane Doe'
+      },
+      reason: 'transfer-licence'
     }
   })
 

--- a/test/presenters/return-requirements/note.presenter.test.js
+++ b/test/presenters/return-requirements/note.presenter.test.js
@@ -16,13 +16,10 @@ describe('Note presenter', () => {
   beforeEach(() => {
     session = {
       id: 'f1288f6c-8503-4dc1-b114-75c408a14bd0',
-      data: {
-        licence: {
-          id: 'ea53bfc6-740d-46c5-9558-fc8cabfc6c1f',
-          licenceRef: '01/123',
-          licenceHolder: 'Jane Doe'
-        },
-        note: ''
+      licence: {
+        id: 'ea53bfc6-740d-46c5-9558-fc8cabfc6c1f',
+        licenceRef: '01/123',
+        licenceHolder: 'Jane Doe'
       }
     }
   })
@@ -42,7 +39,7 @@ describe('Note presenter', () => {
   describe("the 'note' property", () => {
     describe('when there is a note', () => {
       beforeEach(() => {
-        session.data.note = {
+        session.note = {
           content: 'Note attached to return requirement',
           userEmail: 'carol.shaw@atari.com'
         }

--- a/test/presenters/return-requirements/points.presenter.test.js
+++ b/test/presenters/return-requirements/points.presenter.test.js
@@ -24,15 +24,13 @@ describe('Points presenter', () => {
       beforeEach(() => {
         session = {
           id: '61e07498-f309-4829-96a9-72084a54996d',
-          data: {
-            licence: {
-              id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
-              currentVersionStartDate: '2023-01-01T00:00:00.000Z',
-              endDate: null,
-              licenceRef: '01/ABC',
-              licenceHolder: 'Turbo Kid',
-              startDate: '2022-04-01T00:00:00.000Z'
-            }
+          licence: {
+            id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
+            currentVersionStartDate: '2023-01-01T00:00:00.000Z',
+            endDate: null,
+            licenceRef: '01/ABC',
+            licenceHolder: 'Turbo Kid',
+            startDate: '2022-04-01T00:00:00.000Z'
           }
         }
       })
@@ -57,17 +55,15 @@ describe('Points presenter', () => {
       beforeEach(() => {
         session = {
           id: '61e07498-f309-4829-96a9-72084a54996d',
-          data: {
-            licence: {
-              id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
-              currentVersionStartDate: '2023-01-01T00:00:00.000Z',
-              endDate: null,
-              licenceRef: '01/ABC',
-              licenceHolder: 'Turbo Kid',
-              startDate: '2022-04-01T00:00:00.000Z'
-            },
-            points: ['At National Grid Reference TQ 68083 33604 (BEWL WATER RESERVOIR)']
-          }
+          licence: {
+            id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
+            currentVersionStartDate: '2023-01-01T00:00:00.000Z',
+            endDate: null,
+            licenceRef: '01/ABC',
+            licenceHolder: 'Turbo Kid',
+            startDate: '2022-04-01T00:00:00.000Z'
+          },
+          points: ['At National Grid Reference TQ 68083 33604 (BEWL WATER RESERVOIR)']
         }
       })
 

--- a/test/presenters/return-requirements/purpose.presenter.test.js
+++ b/test/presenters/return-requirements/purpose.presenter.test.js
@@ -26,15 +26,13 @@ describe('Purpose presenter', () => {
     describe('and no purposes in session data', () => {
       const session = {
         id: '61e07498-f309-4829-96a9-72084a54996d',
-        data: {
-          licence: {
-            id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
-            currentVersionStartDate: '2023-01-01T00:00:00.000Z',
-            endDate: null,
-            licenceRef: '01/ABC',
-            licenceHolder: 'Turbo Kid',
-            startDate: '2022-04-01T00:00:00.000Z'
-          }
+        licence: {
+          id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
+          currentVersionStartDate: '2023-01-01T00:00:00.000Z',
+          endDate: null,
+          licenceRef: '01/ABC',
+          licenceHolder: 'Turbo Kid',
+          startDate: '2022-04-01T00:00:00.000Z'
         }
       }
 
@@ -59,17 +57,15 @@ describe('Purpose presenter', () => {
     describe('and with purposes in session data', () => {
       const session = {
         id: '61e07498-f309-4829-96a9-72084a54996d',
-        data: {
-          licence: {
-            id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
-            currentVersionStartDate: '2023-01-01T00:00:00.000Z',
-            endDate: null,
-            licenceRef: '01/ABC',
-            licenceHolder: 'Turbo Kid',
-            startDate: '2022-04-01T00:00:00.000Z'
-          },
-          purposes: ['Heat Pump', 'Horticultural Watering']
-        }
+        licence: {
+          id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
+          currentVersionStartDate: '2023-01-01T00:00:00.000Z',
+          endDate: null,
+          licenceRef: '01/ABC',
+          licenceHolder: 'Turbo Kid',
+          startDate: '2022-04-01T00:00:00.000Z'
+        },
+        purposes: ['Heat Pump', 'Horticultural Watering']
       }
 
       it('correctly presents the data', () => {

--- a/test/presenters/return-requirements/reason.presenter.test.js
+++ b/test/presenters/return-requirements/reason.presenter.test.js
@@ -16,12 +16,10 @@ describe('Select Reason presenter', () => {
   beforeEach(() => {
     session = {
       id: 'f1288f6c-8503-4dc1-b114-75c408a14bd0',
-      data: {
-        licence: {
-          id: 'ea53bfc6-740d-46c5-9558-fc8cabfc6c1f',
-          licenceRef: '01/123',
-          licenceHolder: 'Jane Doe'
-        }
+      licence: {
+        id: 'ea53bfc6-740d-46c5-9558-fc8cabfc6c1f',
+        licenceRef: '01/123',
+        licenceHolder: 'Jane Doe'
       }
     }
   })

--- a/test/presenters/return-requirements/returns-cycle.presenter.test.js
+++ b/test/presenters/return-requirements/returns-cycle.presenter.test.js
@@ -18,15 +18,13 @@ describe('Returns Cycle presenter', () => {
       beforeEach(() => {
         session = {
           id: '61e07498-f309-4829-96a9-72084a54996d',
-          data: {
-            licence: {
-              id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
-              currentVersionStartDate: '2023-01-01T00:00:00.000Z',
-              endDate: null,
-              licenceRef: '01/ABC',
-              licenceHolder: 'Turbo Kid',
-              startDate: '2022-04-01T00:00:00.000Z'
-            }
+          licence: {
+            id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
+            currentVersionStartDate: '2023-01-01T00:00:00.000Z',
+            endDate: null,
+            licenceRef: '01/ABC',
+            licenceHolder: 'Turbo Kid',
+            startDate: '2022-04-01T00:00:00.000Z'
           }
         }
       })
@@ -47,17 +45,15 @@ describe('Returns Cycle presenter', () => {
       beforeEach(() => {
         session = {
           id: '61e07498-f309-4829-96a9-72084a54996d',
-          data: {
-            licence: {
-              id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
-              currentVersionStartDate: '2023-01-01T00:00:00.000Z',
-              endDate: null,
-              licenceRef: '01/ABC',
-              licenceHolder: 'Turbo Kid',
-              startDate: '2022-04-01T00:00:00.000Z'
-            },
-            returnsCycle: 'summer'
-          }
+          licence: {
+            id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
+            currentVersionStartDate: '2023-01-01T00:00:00.000Z',
+            endDate: null,
+            licenceRef: '01/ABC',
+            licenceHolder: 'Turbo Kid',
+            startDate: '2022-04-01T00:00:00.000Z'
+          },
+          returnsCycle: 'summer'
         }
       })
 

--- a/test/presenters/return-requirements/setup.presenter.test.js
+++ b/test/presenters/return-requirements/setup.presenter.test.js
@@ -16,12 +16,10 @@ describe('Setup presenter', () => {
   beforeEach(() => {
     session = {
       id: 'f1288f6c-8503-4dc1-b114-75c408a14bd0',
-      data: {
-        licence: {
-          id: 'ea53bfc6-740d-46c5-9558-fc8cabfc6c1f',
-          licenceRef: '01/123',
-          licenceHolder: 'Astro Boy'
-        }
+      licence: {
+        id: 'ea53bfc6-740d-46c5-9558-fc8cabfc6c1f',
+        licenceRef: '01/123',
+        licenceHolder: 'Astro Boy'
       }
     }
   })

--- a/test/presenters/return-requirements/site-description.presenter.test.js
+++ b/test/presenters/return-requirements/site-description.presenter.test.js
@@ -18,15 +18,13 @@ describe('Site Description presenter', () => {
       beforeEach(() => {
         session = {
           id: '61e07498-f309-4829-96a9-72084a54996d',
-          data: {
-            licence: {
-              id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
-              currentVersionStartDate: '2023-01-01T00:00:00.000Z',
-              endDate: null,
-              licenceRef: '01/ABC',
-              licenceHolder: 'Turbo Kid',
-              startDate: '2022-04-01T00:00:00.000Z'
-            }
+          licence: {
+            id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
+            currentVersionStartDate: '2023-01-01T00:00:00.000Z',
+            endDate: null,
+            licenceRef: '01/ABC',
+            licenceHolder: 'Turbo Kid',
+            startDate: '2022-04-01T00:00:00.000Z'
           }
         }
       })
@@ -53,17 +51,15 @@ describe('Site Description presenter', () => {
 
         session = {
           id: '61e07498-f309-4829-96a9-72084a54996d',
-          data: {
-            licence: {
-              id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
-              currentVersionStartDate: '2023-01-01T00:00:00.000Z',
-              endDate: null,
-              licenceRef: '01/ABC',
-              licenceHolder: 'Turbo Kid',
-              startDate: '2022-04-01T00:00:00.000Z'
-            },
-            siteDescription: 'This is a valid return requirement description'
-          }
+          licence: {
+            id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
+            currentVersionStartDate: '2023-01-01T00:00:00.000Z',
+            endDate: null,
+            licenceRef: '01/ABC',
+            licenceHolder: 'Turbo Kid',
+            startDate: '2022-04-01T00:00:00.000Z'
+          },
+          siteDescription: 'This is a valid return requirement description'
         }
       })
 

--- a/test/presenters/return-requirements/start-date.presenter.test.js
+++ b/test/presenters/return-requirements/start-date.presenter.test.js
@@ -17,17 +17,15 @@ describe('Start Date presenter', () => {
     beforeEach(async () => {
       session = {
         id: 'd3fr4-f3ad-4cb6-a058-78abc4w4t3r',
-        data: {
-          licence: {
-            id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
-            currentVersionStartDate: '2023-01-01T00:00:00.000Z',
-            endDate: null,
-            licenceRef: '01/ABC',
-            licenceHolder: 'Turbo Kid',
-            startDate: '2023-11-126T00:00:00.000Z'
-          },
-          selectedOption: null
-        }
+        licence: {
+          id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
+          currentVersionStartDate: '2023-01-01T00:00:00.000Z',
+          endDate: null,
+          licenceRef: '01/ABC',
+          licenceHolder: 'Turbo Kid',
+          startDate: '2023-11-126T00:00:00.000Z'
+        },
+        selectedOption: null
       }
     })
 
@@ -53,20 +51,18 @@ describe('Start Date presenter', () => {
     beforeEach(async () => {
       session = {
         id: 'd3fr4-f3ad-4cb6-a058-78abc4w4t3r',
-        data: {
-          licence: {
-            id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
-            currentVersionStartDate: '2023-01-01T00:00:00.000Z',
-            endDate: null,
-            licenceRef: '01/ABC',
-            licenceHolder: 'Turbo Kid',
-            startDate: '2023-11-126T00:00:00.000Z'
-          },
-          startDateDay: '26',
-          startDateMonth: '11',
-          startDateYear: '2023',
-          startDateOptions: 'anotherStartDate'
-        }
+        licence: {
+          id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
+          currentVersionStartDate: '2023-01-01T00:00:00.000Z',
+          endDate: null,
+          licenceRef: '01/ABC',
+          licenceHolder: 'Turbo Kid',
+          startDate: '2023-11-126T00:00:00.000Z'
+        },
+        startDateDay: '26',
+        startDateMonth: '11',
+        startDateYear: '2023',
+        startDateOptions: 'anotherStartDate'
       }
     })
 

--- a/test/services/return-requirements/check-your-answers.service.test.js
+++ b/test/services/return-requirements/check-your-answers.service.test.js
@@ -79,7 +79,7 @@ describe('Check Your Answers service', () => {
       await CheckYourAnswersService.go(session.id, yarStub)
       const updatedSession = await SessionModel.query().findById(session.id)
 
-      expect(updatedSession.data.checkYourAnswersVisited).to.be.true()
+      expect(updatedSession.checkYourAnswersVisited).to.be.true()
     })
   })
 })

--- a/test/services/return-requirements/delete-note.service.test.js
+++ b/test/services/return-requirements/delete-note.service.test.js
@@ -55,7 +55,7 @@ describe('Delete Note service', () => {
 
     const refreshedSession = await session.$query()
 
-    expect(refreshedSession.data.note).to.be.undefined()
+    expect(refreshedSession.note).to.be.undefined()
   })
 
   it("sets the notification message to 'Removed'", async () => {

--- a/test/services/return-requirements/submit-abstraction-period.service.test.js
+++ b/test/services/return-requirements/submit-abstraction-period.service.test.js
@@ -53,7 +53,7 @@ describe('Submit Abstraction Period service', () => {
 
         const refreshedSession = await session.$query()
 
-        expect(refreshedSession.data.abstractionPeriod).to.equal({
+        expect(refreshedSession.abstractionPeriod).to.equal({
           'end-abstraction-period-day': '02',
           'start-abstraction-period-day': '01',
           'end-abstraction-period-month': '7',

--- a/test/services/return-requirements/submit-agreements-exceptions.service.test.js
+++ b/test/services/return-requirements/submit-agreements-exceptions.service.test.js
@@ -54,7 +54,7 @@ describe('Submit Agreements and Exceptions service', () => {
 
         const refreshedSession = await session.$query()
 
-        expect(refreshedSession.data.agreementsExceptions).to.equal([
+        expect(refreshedSession.agreementsExceptions).to.equal([
           'gravity-fill',
           'two-part-tariff',
           '56-returns-exception'

--- a/test/services/return-requirements/submit-check-your-answers.service.test.js
+++ b/test/services/return-requirements/submit-check-your-answers.service.test.js
@@ -42,6 +42,7 @@ describe('Submit Check Your Answers service', () => {
 
     it('returns a valid licence', async () => {
       const result = await SubmitCheckYourAnswersService.go(sessionId)
+
       expect(result).to.equal(session.data.licence.id)
     })
   })
@@ -53,6 +54,7 @@ describe('Submit Check Your Answers service', () => {
 
     it('throws an error', async () => {
       const response = await expect(SubmitCheckYourAnswersService.go(sessionId)).to.reject()
+
       expect(response).to.be.an.instanceOf(ExpandedError)
       expect(response.message).to.equal('Invalid licence for return requirements')
     })

--- a/test/services/return-requirements/submit-frequency-collected.service.test.js
+++ b/test/services/return-requirements/submit-frequency-collected.service.test.js
@@ -50,7 +50,7 @@ describe('Submit Frequency Collected service', () => {
 
         const refreshedSession = await session.$query()
 
-        expect(refreshedSession.data.frequencyCollected).to.equal('weekly')
+        expect(refreshedSession.frequencyCollected).to.equal('weekly')
       })
 
       it('returns the checkYourAnswersVisited property (no page data needed for a redirect)', async () => {

--- a/test/services/return-requirements/submit-frequency-reported.service.test.js
+++ b/test/services/return-requirements/submit-frequency-reported.service.test.js
@@ -50,7 +50,7 @@ describe('Submit Frequency Reported service', () => {
 
         const refreshedSession = await session.$query()
 
-        expect(refreshedSession.data.frequencyReported).to.equal('weekly')
+        expect(refreshedSession.frequencyReported).to.equal('weekly')
       })
 
       it('returns the checkYourAnswersVisited property (no page data needed for a redirect)', async () => {

--- a/test/services/return-requirements/submit-no-returns-required.service.test.js
+++ b/test/services/return-requirements/submit-no-returns-required.service.test.js
@@ -52,7 +52,7 @@ describe('Submit No Returns Required service', () => {
 
         const refreshedSession = await session.$query()
 
-        expect(refreshedSession.data.reason).to.equal('abstraction-below-100-cubic-metres-per-day')
+        expect(refreshedSession.reason).to.equal('abstraction-below-100-cubic-metres-per-day')
       })
 
       it('returns the journey to redirect the page', async () => {

--- a/test/services/return-requirements/submit-note.service.test.js
+++ b/test/services/return-requirements/submit-note.service.test.js
@@ -61,7 +61,7 @@ describe('Submit Note service', () => {
 
           const refreshedSession = await session.$query()
 
-          expect(refreshedSession.data.note).to.equal({
+          expect(refreshedSession.note).to.equal({
             content: 'A note related to return requirement',
             userEmail: 'carol.shaw@atari.com'
           })

--- a/test/services/return-requirements/submit-points.service.test.js
+++ b/test/services/return-requirements/submit-points.service.test.js
@@ -65,7 +65,7 @@ describe('Submit Points service', () => {
 
         const refreshedSession = await session.$query()
 
-        expect(refreshedSession.data.points).to.equal([
+        expect(refreshedSession.points).to.equal([
           'At National Grid Reference TQ 69212 50394 (RIVER MEDWAY AT YALDING INTAKE)'
         ])
       })

--- a/test/services/return-requirements/submit-purpose.service.test.js
+++ b/test/services/return-requirements/submit-purpose.service.test.js
@@ -69,7 +69,7 @@ describe('Submit Purpose service', () => {
 
         const refreshedSession = await session.$query()
 
-        expect(refreshedSession.data.purposes).to.equal(['Potable Water Supply - Direct'])
+        expect(refreshedSession.purposes).to.equal(['Potable Water Supply - Direct'])
       })
 
       it('returns the checkYourAnswersVisited property (no page data needed for a redirect)', async () => {

--- a/test/services/return-requirements/submit-reason.service.test.js
+++ b/test/services/return-requirements/submit-reason.service.test.js
@@ -51,7 +51,7 @@ describe('Submit Reason service', () => {
 
         const refreshedSession = await session.$query()
 
-        expect(refreshedSession.data.returnsRequired).to.equal('new-licence')
+        expect(refreshedSession.returnsRequired).to.equal('new-licence')
       })
 
       it('returns page data for the journey', async () => {

--- a/test/services/return-requirements/submit-returns-cycle.service.test.js
+++ b/test/services/return-requirements/submit-returns-cycle.service.test.js
@@ -50,7 +50,7 @@ describe('Submit Returns Cycle service', () => {
 
         const refreshedSession = await session.$query()
 
-        expect(refreshedSession.data.returnsCycle).to.equal('summer')
+        expect(refreshedSession.returnsCycle).to.equal('summer')
       })
 
       it('returns the checkYourAnswersVisited property (no page data needed for a redirect)', async () => {

--- a/test/services/return-requirements/submit-site-description.service.test.js
+++ b/test/services/return-requirements/submit-site-description.service.test.js
@@ -50,7 +50,7 @@ describe('Submit Site Description service', () => {
 
         const refreshedSession = await session.$query()
 
-        expect(refreshedSession.data.siteDescription).to.equal('This is a valid return requirement description')
+        expect(refreshedSession.siteDescription).to.equal('This is a valid return requirement description')
       })
 
       it('returns the checkYourAnswersVisited property (no page data needed for a redirect)', async () => {

--- a/test/services/return-requirements/submit-start-date.service.test.js
+++ b/test/services/return-requirements/submit-start-date.service.test.js
@@ -51,7 +51,7 @@ describe('Submit Start Date service', () => {
 
         const refreshedSession = await session.$query()
 
-        expect(refreshedSession.data.startDateOptions).to.equal('licenceStartDate')
+        expect(refreshedSession.startDateOptions).to.equal('licenceStartDate')
       })
 
       it('returns the correct journey for the no-returns-required journey', async () => {
@@ -77,10 +77,10 @@ describe('Submit Start Date service', () => {
 
         const refreshedSession = await session.$query()
 
-        expect(refreshedSession.data.startDateOptions).to.equal('anotherStartDate')
-        expect(refreshedSession.data.startDateDay).to.equal('26')
-        expect(refreshedSession.data.startDateMonth).to.equal('11')
-        expect(refreshedSession.data.startDateYear).to.equal('2023')
+        expect(refreshedSession.startDateOptions).to.equal('anotherStartDate')
+        expect(refreshedSession.startDateDay).to.equal('26')
+        expect(refreshedSession.startDateMonth).to.equal('11')
+        expect(refreshedSession.startDateYear).to.equal('2023')
       })
 
       it('returns the correct journey for the no returns required journey', async () => {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4463

We created our `SessionModel` and its backing table out of the need to be able to store data temporarily, for example, when a user is following a journey to create a new return requirement.

After using it in our bill run setup and return requirement journeys we spotted there were some improvements we could make. So, we [Enhanced the SessionModel to expose and update data](https://github.com/DEFRA/water-abstraction-system/pull/981).

The next step is to update the existing journeys to take advantage of these enhancements.

In this change, we update the return requirement setup journey.