### PR TITLE
Add View Licence Bills page

### DIFF
--- a/app/controllers/licences.controller.js
+++ b/app/controllers/licences.controller.js
@@ -10,6 +10,8 @@ const ViewLicenceBillsService = require('../services/licences/view-licence-bills
 const ViewLicenceReturnsService = require('../services/licences/view-licence-returns.service')
 const ViewLicenceSummaryService = require('../services/licences/view-licence-summary.service')
 
+
+const ViewLicencePage = 'licences/view.njk'
 async function noReturnsRequired (request, h) {
   const { id } = request.params
 
@@ -31,7 +33,7 @@ async function viewBills (request, h) {
 
   const data = await ViewLicenceBillsService.go(id, auth, page)
 
-  return h.view('licences/view.njk', {
+  return h.view(ViewLicencePage, {
     ...data
   })
 }
@@ -41,7 +43,7 @@ async function viewSummary (request, h) {
 
   const data = await ViewLicenceSummaryService.go(id, auth)
 
-  return h.view('licences/view.njk', {
+  return h.view(ViewLicencePage, {
     ...data
   })
 }
@@ -51,7 +53,7 @@ async function viewReturns (request, h) {
 
   const data = await ViewLicenceReturnsService.go(id, auth, page)
 
-  return h.view('licences/view.njk', {
+  return h.view(ViewLicencePage, {
     ...data
   })
 }

--- a/app/controllers/licences.controller.js
+++ b/app/controllers/licences.controller.js
@@ -6,6 +6,7 @@
  */
 
 const InitiateReturnRequirementSessionService = require('../services/return-requirements/initiate-return-requirement-session.service.js')
+const ViewLicenceBillsService = require('../services/licences/view-licence-bills.service')
 const ViewLicenceReturnsService = require('../services/licences/view-licence-returns.service')
 const ViewLicenceSummaryService = require('../services/licences/view-licence-summary.service')
 
@@ -25,13 +26,22 @@ async function returnsRequired (request, h) {
   return h.redirect(`/system/return-requirements/${session.id}/start-date`)
 }
 
+async function viewBills (request, h) {
+  const { params: { id }, auth, query: { page = 1 } } = request
+
+  const data = await ViewLicenceBillsService.go(id, auth, page)
+
+  return h.view('licences/view.njk', {
+    ...data
+  })
+}
+
 async function viewSummary (request, h) {
   const { params: { id }, auth } = request
 
   const data = await ViewLicenceSummaryService.go(id, auth)
 
   return h.view('licences/view.njk', {
-    activeNavBar: 'search',
     ...data
   })
 }
@@ -42,7 +52,6 @@ async function viewReturns (request, h) {
   const data = await ViewLicenceReturnsService.go(id, auth, page)
 
   return h.view('licences/view.njk', {
-    activeNavBar: 'search',
     ...data
   })
 }
@@ -51,5 +60,6 @@ module.exports = {
   noReturnsRequired,
   returnsRequired,
   viewReturns,
-  viewSummary
+  viewSummary,
+  viewBills
 }

--- a/app/controllers/licences.controller.js
+++ b/app/controllers/licences.controller.js
@@ -10,7 +10,6 @@ const ViewLicenceBillsService = require('../services/licences/view-licence-bills
 const ViewLicenceReturnsService = require('../services/licences/view-licence-returns.service')
 const ViewLicenceSummaryService = require('../services/licences/view-licence-summary.service')
 
-
 const ViewLicencePage = 'licences/view.njk'
 
 async function noReturnsRequired (request, h) {

--- a/app/controllers/licences.controller.js
+++ b/app/controllers/licences.controller.js
@@ -12,6 +12,7 @@ const ViewLicenceSummaryService = require('../services/licences/view-licence-sum
 
 
 const ViewLicencePage = 'licences/view.njk'
+
 async function noReturnsRequired (request, h) {
   const { id } = request.params
 
@@ -61,7 +62,7 @@ async function viewReturns (request, h) {
 module.exports = {
   noReturnsRequired,
   returnsRequired,
+  viewBills,
   viewReturns,
-  viewSummary,
-  viewBills
+  viewSummary
 }

--- a/app/presenters/licences/view-licence-bills.presenter.js
+++ b/app/presenters/licences/view-licence-bills.presenter.js
@@ -31,7 +31,7 @@ function _formatBillsToTableRow (bills) {
       billNumber: bill.invoiceNumber,
       dateCreated: formatLongDate(new Date(bill.createdAt)),
       account: bill.accountNumber,
-      runType: bill.batchType,
+      runType: bill.billRun.batchType,
       financialYear: bill.financialYearEnding,
       total: _formatCurrencyToGBP(bill.netAmount),
       accountId: bill.billingAccountId,

--- a/app/presenters/licences/view-licence-bills.presenter.js
+++ b/app/presenters/licences/view-licence-bills.presenter.js
@@ -1,0 +1,21 @@
+'use strict'
+
+/**
+ * Formats data for the `/licences/{id}/bills` view licence bill page
+ * @module ViewLicenceBillsPresenter
+ */
+
+/**
+ * Formats data for the `/licences/{id}/bills` view licence bill page
+ *
+ * @returns {Object} The data formatted for the view template
+ */
+function go (billsData) {
+  return {
+    activeTab: 'bills'
+  }
+}
+
+module.exports = {
+  go
+}

--- a/app/presenters/licences/view-licence-bills.presenter.js
+++ b/app/presenters/licences/view-licence-bills.presenter.js
@@ -5,15 +5,39 @@
  * @module ViewLicenceBillsPresenter
  */
 
+const { formatLongDate } = require('../base.presenter')
+
 /**
  * Formats data for the `/licences/{id}/bills` view licence bill page
  *
  * @returns {Object} The data formatted for the view template
  */
-function go (billsData) {
+function go (bills) {
   return {
-    activeTab: 'bills'
+    activeTab: 'bills',
+    bills: _formatBillsToTableRow(bills)
   }
+}
+
+function _formatCurrencyToGBP (amount) {
+  return amount.toLocaleString('en-gb', {
+    style: 'currency',
+    currency: 'GBP'
+  })
+}
+function _formatBillsToTableRow (bills) {
+  return bills.map((bill) => {
+    return {
+      billNumber: bill.invoiceNumber,
+      dateCreated: formatLongDate(new Date(bill.createdAt)),
+      account: bill.accountNumber,
+      runType: bill.batchType,
+      financialYear: bill.financialYearEnding,
+      total: _formatCurrencyToGBP(bill.netAmount),
+      accountId: bill.billingAccountId,
+      id: bill.id
+    }
+  })
 }
 
 module.exports = {

--- a/app/presenters/licences/view-licence-bills.presenter.js
+++ b/app/presenters/licences/view-licence-bills.presenter.js
@@ -5,7 +5,7 @@
  * @module ViewLicenceBillsPresenter
  */
 
-const { formatLongDate } = require('../base.presenter')
+const { formatLongDate, formatMoney } = require('../base.presenter')
 
 /**
  * Formats data for the `/licences/{id}/bills` view licence bill page
@@ -19,21 +19,15 @@ function go (bills) {
   }
 }
 
-function _formatCurrencyToGBP (amount) {
-  return amount.toLocaleString('en-gb', {
-    style: 'currency',
-    currency: 'GBP'
-  })
-}
 function _formatBillsToTableRow (bills) {
   return bills.map((bill) => {
     return {
       billNumber: bill.invoiceNumber,
       dateCreated: formatLongDate(new Date(bill.createdAt)),
       account: bill.accountNumber,
-      runType: bill.billRun.batchType,
+      runType: bill.billRun?.batchType,
       financialYear: bill.financialYearEnding,
-      total: _formatCurrencyToGBP(bill.netAmount),
+      total: formatMoney(bill.netAmount),
       accountId: bill.billingAccountId,
       id: bill.id
     }

--- a/app/presenters/licences/view-licence-bills.presenter.js
+++ b/app/presenters/licences/view-licence-bills.presenter.js
@@ -25,7 +25,7 @@ function _formatBillsToTableRow (bills) {
       billNumber: bill.invoiceNumber,
       dateCreated: formatLongDate(new Date(bill.createdAt)),
       account: bill.accountNumber,
-      runType: bill.billRun?.batchType,
+      runType: bill.billRun.batchType,
       financialYear: bill.financialYearEnding,
       total: formatMoney(bill.netAmount),
       accountId: bill.billingAccountId,

--- a/app/presenters/licences/view-licence.presenter.js
+++ b/app/presenters/licences/view-licence.presenter.js
@@ -33,7 +33,8 @@ function go (licence, auth) {
     pageTitle: `Licence ${licenceRef}`,
     registeredTo,
     roles: _authRoles(auth),
-    warning: _generateWarningMessage(ends)
+    warning: _generateWarningMessage(ends),
+    activeNavBar: 'search'
   }
 }
 

--- a/app/routes/licence.routes.js
+++ b/app/routes/licence.routes.js
@@ -8,6 +8,11 @@ const routes = [
     path: '/licences/{id}/bills',
     handler: LicencesController.viewBills,
     options: {
+      auth: {
+        access: {
+          scope: ['billing']
+        }
+      },
       description: 'View a licence bills page'
     }
   },

--- a/app/routes/licence.routes.js
+++ b/app/routes/licence.routes.js
@@ -5,6 +5,14 @@ const LicencesController = require('../controllers/licences.controller.js')
 const routes = [
   {
     method: 'GET',
+    path: '/licences/{id}/bills',
+    handler: LicencesController.viewBills,
+    options: {
+      description: 'View a licence bills page'
+    }
+  },
+  {
+    method: 'GET',
     path: '/licences/{id}/summary',
     handler: LicencesController.viewSummary,
     options: {

--- a/app/services/licences/fetch-licence-bills.service.js
+++ b/app/services/licences/fetch-licence-bills.service.js
@@ -5,7 +5,6 @@
  * @module FetchLicenceBillsService
  */
 
-const LicenceModel = require('../../models/licence.model')
 const BillLicenceModel = require('../../models/bill-licence.model')
 const BillModel = require('../../models/bill.model')
 
@@ -25,16 +24,9 @@ async function go (licenceId, page) {
 }
 
 async function _fetch (licenceId, page) {
-  const licence = await LicenceModel.query()
-    .findById(licenceId)
-    .select([
-      'id',
-      'licenceRef'
-    ])
-
   const billLicences = await BillLicenceModel.query()
     .select('*')
-    .where('billLicences.licence_ref', licence.licenceRef)
+    .where('billLicences.licence_id', licenceId)
     .page(page - 1, DatabaseConfig.defaultPageSize)
 
   const billIds = JSON.parse(JSON.stringify(billLicences)).results.map(b => b.billId)

--- a/app/services/licences/fetch-licence-bills.service.js
+++ b/app/services/licences/fetch-licence-bills.service.js
@@ -5,7 +5,6 @@
  * @module FetchLicenceBillsService
  */
 
-const BillLicenceModel = require('../../models/bill-licence.model')
 const BillModel = require('../../models/bill.model')
 
 const DatabaseConfig = require('../../../config/database.config')
@@ -32,7 +31,7 @@ async function _fetch (licenceId, page) {
       'bills.financialYearEnding',
       'bills.netAmount',
       'bills.billingAccountId',
-      'bills.createdAt',
+      'bills.createdAt'
     ])
     .innerJoinRelated('billLicences')
     .where('billLicences.licence_id', licenceId)

--- a/app/services/licences/fetch-licence-bills.service.js
+++ b/app/services/licences/fetch-licence-bills.service.js
@@ -42,7 +42,10 @@ async function _fetch (licenceId, page) {
   return BillModel.query()
     .findByIds(billIds)
     .select('*')
-    // .where('bills.billing_account_id', billLicence.billId)
+    .withGraphFetched('billRun')
+    .modifyGraph('billRun', (builder) => {
+      builder.select(['batchType'])
+    })
     .orderBy([
       { column: 'created_at', order: 'desc' }
     ])

--- a/app/services/licences/fetch-licence-bills.service.js
+++ b/app/services/licences/fetch-licence-bills.service.js
@@ -1,7 +1,7 @@
 'use strict'
 
 /**
- * Fetches all return logs for a licence which is needed for the view '/licences/{id}/returns` page
+ * Fetches all return logs for a licence which is needed for the view '/licences/{id}/bills` page
  * @module FetchLicenceBillsService
  */
 
@@ -14,7 +14,7 @@ const DatabaseConfig = require('../../../config/database.config')
  *
  * @param {string} licenceId - The UUID for the licence to fetch
  *
- * @returns {Promise<Object>} the data needed to populate the view licence page's returns tab
+ * @returns {Promise<Object>} the data needed to populate the view licence page's bills tab
  */
 async function go (licenceId, page) {
   const { results, total } = await _fetch(licenceId, page)

--- a/app/services/licences/fetch-licence-bills.service.js
+++ b/app/services/licences/fetch-licence-bills.service.js
@@ -1,0 +1,54 @@
+'use strict'
+
+/**
+ * Fetches all return logs for a licence which is needed for the view '/licences/{id}/returns` page
+ * @module FetchLicenceBillsService
+ */
+
+const LicenceModel = require('../../models/licence.model')
+const BillLicenceModel = require('../../models/bill-licence.model')
+const BillModel = require('../../models/bill.model')
+
+const DatabaseConfig = require('../../../config/database.config')
+
+/**
+ * Fetches all bills for a licence which is needed for the view '/licences/{id}/bills` page
+ *
+ * @param {string} licenceId - The UUID for the licence to fetch
+ *
+ * @returns {Promise<Object>} the data needed to populate the view licence page's returns tab
+ */
+async function go (licenceId, page) {
+  const { results, total } = await _fetch(licenceId, page)
+
+  return { bills: JSON.parse(JSON.stringify(results)), pagination: { total } }
+}
+
+async function _fetch (licenceId, page) {
+  const licence = await LicenceModel.query()
+    .findById(licenceId)
+    .select([
+      'id',
+      'licenceRef'
+    ])
+
+  const billLicences = await BillLicenceModel.query()
+    .select('*')
+    .where('billLicences.licence_ref', licence.licenceRef)
+    .page(page - 1, DatabaseConfig.defaultPageSize)
+
+  const billIds = JSON.parse(JSON.stringify(billLicences)).results.map(b => b.billId)
+
+  return BillModel.query()
+    .findByIds(billIds)
+    .select('*')
+    // .where('bills.billing_account_id', billLicence.billId)
+    .orderBy([
+      { column: 'created_at', order: 'desc' }
+    ])
+    .page(page - 1, DatabaseConfig.defaultPageSize)
+}
+
+module.exports = {
+  go
+}

--- a/app/services/licences/view-licence-bills.service.js
+++ b/app/services/licences/view-licence-bills.service.js
@@ -23,7 +23,7 @@ async function go (licenceId, auth, page) {
   const billsData = await FetchLicenceBillsService.go(licenceId, page)
   const pageData = ViewLicenceBillsPresenter.go(billsData.bills)
 
-  const pagination = PaginatorPresenter.go(100, Number(page), `/system/licences/${licenceId}/bills`)
+  const pagination = PaginatorPresenter.go(billsData.pagination.total, Number(page), `/system/licences/${licenceId}/bills`)
 
   return {
     ...commonData,

--- a/app/services/licences/view-licence-bills.service.js
+++ b/app/services/licences/view-licence-bills.service.js
@@ -8,6 +8,7 @@
 const FetchLicenceBillsService = require('./fetch-licence-bills.service')
 const ViewLicenceService = require('./view-licence.service')
 const ViewLicenceBillsPresenter = require('../../presenters/licences/view-licence-bills.presenter')
+const PaginatorPresenter = require('../../presenters/paginator.presenter')
 
 /**
  * Orchestrates fetching and presenting the data needed for the licence summary page
@@ -16,16 +17,18 @@ const ViewLicenceBillsPresenter = require('../../presenters/licences/view-licenc
  *
  * @returns {Promise<Object>} an object representing the `pageData` needed by the licence summary template.
  */
-async function go (licenceId, auth) {
+async function go (licenceId, auth, page) {
   const commonData = await ViewLicenceService.go(licenceId, auth)
 
-  const billsData = await FetchLicenceBillsService.go(licenceId, 1)
+  const billsData = await FetchLicenceBillsService.go(licenceId, page)
   const pageData = ViewLicenceBillsPresenter.go(billsData.bills)
+
+  const pagination = PaginatorPresenter.go(100, Number(page), `/system/licences/${licenceId}/bills`)
 
   return {
     ...commonData,
     ...pageData,
-    pagination: { total: 1 }
+    pagination
   }
 }
 

--- a/app/services/licences/view-licence-bills.service.js
+++ b/app/services/licences/view-licence-bills.service.js
@@ -25,7 +25,7 @@ async function go (licenceId, auth) {
   return {
     ...commonData,
     ...pageData,
-    pagination: { total: 1 },
+    pagination: { total: 1 }
   }
 }
 

--- a/app/services/licences/view-licence-bills.service.js
+++ b/app/services/licences/view-licence-bills.service.js
@@ -6,8 +6,8 @@
  */
 
 const FetchLicenceBillsService = require('./fetch-licence-bills.service')
-const ViewLicenceService = require('./view-licence.service')
 const ViewLicenceBillsPresenter = require('../../presenters/licences/view-licence-bills.presenter')
+const ViewLicenceService = require('./view-licence.service')
 const PaginatorPresenter = require('../../presenters/paginator.presenter')
 
 /**

--- a/app/services/licences/view-licence-bills.service.js
+++ b/app/services/licences/view-licence-bills.service.js
@@ -1,0 +1,31 @@
+'use strict'
+
+/**
+ * Orchestrates fetching and presenting the data needed for the licence summary page
+ * @module ViewLicenceBillsService
+ */
+
+const ViewLicenceService = require('./view-licence.service')
+const ViewLicenceBillsPresenter = require('../../presenters/licences/view-licence-bills.presenter')
+
+/**
+ * Orchestrates fetching and presenting the data needed for the licence summary page
+ *
+ * @param {string} licenceId - The UUID of the licence
+ *
+ * @returns {Promise<Object>} an object representing the `pageData` needed by the licence summary template.
+ */
+async function go (licenceId, auth) {
+  const commonData = await ViewLicenceService.go(licenceId, auth)
+
+  const pageData = ViewLicenceBillsPresenter.go()
+
+  return {
+    ...commonData,
+    ...pageData
+  }
+}
+
+module.exports = {
+  go
+}

--- a/app/services/licences/view-licence-bills.service.js
+++ b/app/services/licences/view-licence-bills.service.js
@@ -5,6 +5,7 @@
  * @module ViewLicenceBillsService
  */
 
+const FetchLicenceBillsService = require('./fetch-licence-bills.service')
 const ViewLicenceService = require('./view-licence.service')
 const ViewLicenceBillsPresenter = require('../../presenters/licences/view-licence-bills.presenter')
 
@@ -18,11 +19,13 @@ const ViewLicenceBillsPresenter = require('../../presenters/licences/view-licenc
 async function go (licenceId, auth) {
   const commonData = await ViewLicenceService.go(licenceId, auth)
 
-  const pageData = ViewLicenceBillsPresenter.go()
+  const billsData = await FetchLicenceBillsService.go(licenceId, 1)
+  const pageData = ViewLicenceBillsPresenter.go(billsData.bills)
 
   return {
     ...commonData,
-    ...pageData
+    ...pageData,
+    pagination: { total: 1 },
   }
 }
 

--- a/app/views/licences/tabs/bills.njk
+++ b/app/views/licences/tabs/bills.njk
@@ -1,0 +1,9 @@
+<table class="govuk-table">
+  <h2 class="govuk-heading-l">Bills</h2>
+  {% if bills %}
+
+  {% else %}
+    <p>No bills sent for this licence.</p>
+  {% endif %}
+</table>
+

--- a/app/views/licences/tabs/bills.njk
+++ b/app/views/licences/tabs/bills.njk
@@ -1,7 +1,46 @@
 <table class="govuk-table">
   <h2 class="govuk-heading-l">Bills</h2>
   {% if bills %}
-
+    <table class="govuk-table">
+      <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th class="govuk-table__header" scope="col">Bill number</th>
+        <th class="govuk-table__header" scope="col">Date created</th>
+        <th class="govuk-table__header" scope="col">Billing account</th>
+        <th class="govuk-table__header" scope="col">Bill run type</th>
+        <th class="govuk-table__header govuk-table__header--numeric" scope="col">Financial year</th>
+        <th class="govuk-table__header govuk-table__header--numeric" scope="col">Bill total</th>
+      </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+      {% for bill in bills %}
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell" scope="row">
+            <a href="/system/bills/{{ bill.id }}">
+              {{ bill.billNumber }}
+            </a>
+          </td>
+          <td class="govuk-table__cell">
+            {{ bill.dateCreated }}
+          </td>
+          <td class="govuk-table__cell">
+            <a href="/billing-accounts/{{ bill.accountId }}">
+              {{ bill.account }}
+            </a>
+          </td>
+          <td class="govuk-table__cell">
+            {{ bill.runType }}
+          </td>
+          <td class="govuk-table__cell govuk-table__cell--numeric">
+            {{ bill.financialYear }}
+          </td>
+          <td class="govuk-table__cell govuk-table__cell--numeric">
+            {{ bill.total }}
+          </td>
+        </tr>
+      {% endfor %}
+      </tbody>
+    </table>
   {% else %}
     <p>No bills sent for this licence.</p>
   {% endif %}

--- a/app/views/licences/tabs/bills.njk
+++ b/app/views/licences/tabs/bills.njk
@@ -1,3 +1,5 @@
+{% from "govuk/components/pagination/macro.njk" import govukPagination %}
+
 <table class="govuk-table">
   <h2 class="govuk-heading-l">Bills</h2>
   {% if bills %}
@@ -45,4 +47,9 @@
     <p>No bills sent for this licence.</p>
   {% endif %}
 </table>
+
+{% if bills and pagination.numberOfPages > 1 %}
+  {{ govukPagination(pagination.component) }}
+{% endif %}
+
 

--- a/app/views/licences/tabs/bills.njk
+++ b/app/views/licences/tabs/bills.njk
@@ -29,7 +29,7 @@
             </a>
           </td>
           <td class="govuk-table__cell">
-            {{ bill.runType }}
+            {{ bill.runType | title }}
           </td>
           <td class="govuk-table__cell govuk-table__cell--numeric">
             {{ bill.financialYear }}

--- a/app/views/licences/view.njk
+++ b/app/views/licences/view.njk
@@ -82,6 +82,9 @@
       {% if activeTab === 'returns' %}
         {% include "licences/tabs/returns.njk" %}
       {% endif %}
+      {% if activeTab === 'bills' %}
+        {% include "licences/tabs/bills.njk" %}
+      {% endif %}
     </div>
   </div>
 {% endblock %}

--- a/test/controllers/licences.controller.test.js
+++ b/test/controllers/licences.controller.test.js
@@ -184,7 +184,7 @@ describe('Licences controller', () => {
     })
     describe('when a request is valid and has no bills', () => {
       beforeEach(async () => {
-        Sinon.stub(ViewLicenceBillsService, 'go').resolves({ activeTab: 'bills'})
+        Sinon.stub(ViewLicenceBillsService, 'go').resolves({ activeTab: 'bills' })
       })
 
       it('returns the page successfully', async () => {
@@ -198,63 +198,63 @@ describe('Licences controller', () => {
       })
     })
   })
-})
 
-describe('GET /licences/{id}/summary', () => {
-  beforeEach(async () => {
-    options = {
-      method: 'GET',
-      url: '/licences/7861814c-ca19-43f2-be11-3c612f0d744b/summary',
-      auth: {
-        strategy: 'session',
-        credentials: { scope: [] }
-      }
-    }
-  })
-
-  describe('when a request is valid', () => {
+  describe('GET /licences/{id}/summary', () => {
     beforeEach(async () => {
-      Sinon.stub(ViewLicenceSummaryService, 'go').resolves(_viewLicenceSummary())
-    })
-
-    it('returns the page successfully', async () => {
-      const response = await server.inject(options)
-
-      expect(response.statusCode).to.equal(200)
-      expect(response.payload).to.contain('Summary')
-      expect(response.payload).to.contain('Effective from')
-      expect(response.payload).to.contain('End date')
-    })
-  })
-})
-
-describe('GET /licences/{id}/returns', () => {
-  beforeEach(async () => {
-    options = {
-      method: 'GET',
-      url: '/licences/7861814c-ca19-43f2-be11-3c612f0d744b/returns',
-      auth: {
-        strategy: 'session',
-        credentials: { scope: ['billing'] }
+      options = {
+        method: 'GET',
+        url: '/licences/7861814c-ca19-43f2-be11-3c612f0d744b/summary',
+        auth: {
+          strategy: 'session',
+          credentials: { scope: [] }
+        }
       }
-    }
-  })
-
-  describe('when a request is valid and has returns', () => {
-    beforeEach(async () => {
-      Sinon.stub(ViewLicenceReturnsService, 'go').resolves(_viewLicenceReturns())
     })
 
-    it('returns the page successfully', async () => {
-      const response = await server.inject(options)
+    describe('when a request is valid', () => {
+      beforeEach(async () => {
+        Sinon.stub(ViewLicenceSummaryService, 'go').resolves(_viewLicenceSummary())
+      })
 
-      expect(response.statusCode).to.equal(200)
-      expect(response.payload).to.contain('Returns')
-      //  Check the table titles
-      expect(response.payload).to.contain('Return reference and dates')
-      expect(response.payload).to.contain('Purpose and description')
-      expect(response.payload).to.contain('Due date')
-      expect(response.payload).to.contain('Status')
+      it('returns the page successfully', async () => {
+        const response = await server.inject(options)
+
+        expect(response.statusCode).to.equal(200)
+        expect(response.payload).to.contain('Summary')
+        expect(response.payload).to.contain('Effective from')
+        expect(response.payload).to.contain('End date')
+      })
+    })
+  })
+
+  describe('GET /licences/{id}/returns', () => {
+    beforeEach(async () => {
+      options = {
+        method: 'GET',
+        url: '/licences/7861814c-ca19-43f2-be11-3c612f0d744b/returns',
+        auth: {
+          strategy: 'session',
+          credentials: { scope: ['billing'] }
+        }
+      }
+    })
+
+    describe('when a request is valid and has returns', () => {
+      beforeEach(async () => {
+        Sinon.stub(ViewLicenceReturnsService, 'go').resolves(_viewLicenceReturns())
+      })
+
+      it('returns the page successfully', async () => {
+        const response = await server.inject(options)
+
+        expect(response.statusCode).to.equal(200)
+        expect(response.payload).to.contain('Returns')
+        //  Check the table titles
+        expect(response.payload).to.contain('Return reference and dates')
+        expect(response.payload).to.contain('Purpose and description')
+        expect(response.payload).to.contain('Due date')
+        expect(response.payload).to.contain('Status')
+      })
     })
   })
 })

--- a/test/controllers/licences.controller.test.js
+++ b/test/controllers/licences.controller.test.js
@@ -159,7 +159,7 @@ describe('Licences controller', () => {
         url: '/licences/7861814c-ca19-43f2-be11-3c612f0d744b/bills',
         auth: {
           strategy: 'session',
-          credentials: { scope: [] }
+          credentials: { scope: ['billing'] }
         }
       }
     })

--- a/test/controllers/licences.controller.test.js
+++ b/test/controllers/licences.controller.test.js
@@ -13,6 +13,7 @@ const Boom = require('@hapi/boom')
 
 // Things we need to stub
 const InitiateReturnRequirementSessionService = require('../../app/services/return-requirements/initiate-return-requirement-session.service.js')
+const ViewLicenceBillsService = require('../../app/services/licences/view-licence-bills.service')
 const ViewLicenceSummaryService = require('../../app/services/licences/view-licence-summary.service')
 const ViewLicenceReturnsService = require('../../app/services/licences/view-licence-returns.service')
 
@@ -151,6 +152,35 @@ describe('Licences controller', () => {
     })
   })
 
+  describe('GET /licences/{id}/bills', () => {
+    beforeEach(async () => {
+      options = {
+        method: 'GET',
+        url: '/licences/7861814c-ca19-43f2-be11-3c612f0d744b/bills',
+        auth: {
+          strategy: 'session',
+          credentials: { scope: [] }
+        }
+      }
+    })
+
+    describe('when a request is valid and has bills', () => {
+      beforeEach(async () => {
+        Sinon.stub(ViewLicenceBillsService, 'go').resolves(_viewLicenceBills())
+      })
+
+      it('returns the page successfully', async () => {
+        const response = await server.inject(options)
+
+        expect(response.statusCode).to.equal(200)
+        expect(response.payload).to.contain('Bills')
+        //  Check the table titles
+        expect(response.payload).to.contain('Bills')
+        expect(response.payload).to.contain('No bills sent for this licence.')
+      })
+    })
+  })
+
   describe('GET /licences/{id}/summary', () => {
     beforeEach(async () => {
       options = {
@@ -221,6 +251,13 @@ describe('Licences controller', () => {
     })
   })
 })
+
+function _viewLicenceBills () {
+  return {
+    activeTab: 'bills'
+    // bills: []
+  }
+}
 
 function _viewLicenceReturns () {
   return {

--- a/test/controllers/licences.controller.test.js
+++ b/test/controllers/licences.controller.test.js
@@ -175,87 +175,94 @@ describe('Licences controller', () => {
         expect(response.statusCode).to.equal(200)
         expect(response.payload).to.contain('Bills')
         //  Check the table titles
+        expect(response.payload).to.contain('Bill number')
+        expect(response.payload).to.contain('Date created')
+        expect(response.payload).to.contain('Billing account')
+        expect(response.payload).to.contain('Bill run type')
+        expect(response.payload).to.contain('Bill total')
+      })
+    })
+    describe('when a request is valid and has no bills', () => {
+      beforeEach(async () => {
+        Sinon.stub(ViewLicenceBillsService, 'go').resolves({ activeTab: 'bills'})
+      })
+
+      it('returns the page successfully', async () => {
+        const response = await server.inject(options)
+
+        expect(response.statusCode).to.equal(200)
+        expect(response.payload).to.contain('Bills')
+        //  Check the table titles
         expect(response.payload).to.contain('Bills')
         expect(response.payload).to.contain('No bills sent for this licence.')
       })
     })
   })
+})
 
-  describe('GET /licences/{id}/summary', () => {
-    beforeEach(async () => {
-      options = {
-        method: 'GET',
-        url: '/licences/7861814c-ca19-43f2-be11-3c612f0d744b/summary',
-        auth: {
-          strategy: 'session',
-          credentials: { scope: [] }
-        }
-      }
-    })
-
-    describe('when a request is valid', () => {
-      beforeEach(async () => {
-        Sinon.stub(ViewLicenceSummaryService, 'go').resolves(_viewLicenceSummary())
-      })
-
-      it('returns the page successfully', async () => {
-        const response = await server.inject(options)
-
-        expect(response.statusCode).to.equal(200)
-        expect(response.payload).to.contain('Summary')
-        expect(response.payload).to.contain('Effective from')
-        expect(response.payload).to.contain('End date')
-      })
-    })
-
-    function _viewLicenceSummary () {
-      return {
-        id: '7861814c-ca19-43f2-be11-3c612f0d744b',
-        licenceRef: '01/130/R01',
-        region: 'Southern',
-        startDate: '1 November 2022',
-        endDate: '1 November 2032',
-        activeTab: 'summary'
+describe('GET /licences/{id}/summary', () => {
+  beforeEach(async () => {
+    options = {
+      method: 'GET',
+      url: '/licences/7861814c-ca19-43f2-be11-3c612f0d744b/summary',
+      auth: {
+        strategy: 'session',
+        credentials: { scope: [] }
       }
     }
   })
 
-  describe('GET /licences/{id}/returns', () => {
+  describe('when a request is valid', () => {
     beforeEach(async () => {
-      options = {
-        method: 'GET',
-        url: '/licences/7861814c-ca19-43f2-be11-3c612f0d744b/returns',
-        auth: {
-          strategy: 'session',
-          credentials: { scope: ['billing'] }
-        }
-      }
+      Sinon.stub(ViewLicenceSummaryService, 'go').resolves(_viewLicenceSummary())
     })
 
-    describe('when a request is valid and has returns', () => {
-      beforeEach(async () => {
-        Sinon.stub(ViewLicenceReturnsService, 'go').resolves(_viewLicenceReturns())
-      })
+    it('returns the page successfully', async () => {
+      const response = await server.inject(options)
 
-      it('returns the page successfully', async () => {
-        const response = await server.inject(options)
+      expect(response.statusCode).to.equal(200)
+      expect(response.payload).to.contain('Summary')
+      expect(response.payload).to.contain('Effective from')
+      expect(response.payload).to.contain('End date')
+    })
+  })
+})
 
-        expect(response.statusCode).to.equal(200)
-        expect(response.payload).to.contain('Returns')
-        //  Check the table titles
-        expect(response.payload).to.contain('Return reference and dates')
-        expect(response.payload).to.contain('Purpose and description')
-        expect(response.payload).to.contain('Due date')
-        expect(response.payload).to.contain('Status')
-      })
+describe('GET /licences/{id}/returns', () => {
+  beforeEach(async () => {
+    options = {
+      method: 'GET',
+      url: '/licences/7861814c-ca19-43f2-be11-3c612f0d744b/returns',
+      auth: {
+        strategy: 'session',
+        credentials: { scope: ['billing'] }
+      }
+    }
+  })
+
+  describe('when a request is valid and has returns', () => {
+    beforeEach(async () => {
+      Sinon.stub(ViewLicenceReturnsService, 'go').resolves(_viewLicenceReturns())
+    })
+
+    it('returns the page successfully', async () => {
+      const response = await server.inject(options)
+
+      expect(response.statusCode).to.equal(200)
+      expect(response.payload).to.contain('Returns')
+      //  Check the table titles
+      expect(response.payload).to.contain('Return reference and dates')
+      expect(response.payload).to.contain('Purpose and description')
+      expect(response.payload).to.contain('Due date')
+      expect(response.payload).to.contain('Status')
     })
   })
 })
 
 function _viewLicenceBills () {
   return {
-    activeTab: 'bills'
-    // bills: []
+    activeTab: 'bills',
+    bills: []
   }
 }
 
@@ -263,5 +270,16 @@ function _viewLicenceReturns () {
   return {
     activeTab: 'returns',
     returns: [{}]
+  }
+}
+
+function _viewLicenceSummary () {
+  return {
+    id: '7861814c-ca19-43f2-be11-3c612f0d744b',
+    licenceRef: '01/130/R01',
+    region: 'Southern',
+    startDate: '1 November 2022',
+    endDate: '1 November 2032',
+    activeTab: 'summary'
   }
 }

--- a/test/presenters/licences/view-licence-bills-presenter.test.js
+++ b/test/presenters/licences/view-licence-bills-presenter.test.js
@@ -29,6 +29,11 @@ describe('View Licence Bills presenter', () => {
         }]
       })
     })
+    it('correctly formats the created date to convention', () => {
+      const result = ViewLicenceBillsPresenter.go(_bills())
+      expect(result.bills[0].dateCreated).to.equal('1 January 2020')
+    })
+
     it('correctly formats the currency to UK standard', () => {
       const result = ViewLicenceBillsPresenter.go(_bills())
       expect(result.bills[0].total).to.equal('£1,234,567.89')
@@ -38,13 +43,13 @@ describe('View Licence Bills presenter', () => {
 
 function _bills () {
   return [{
-    invoiceNumber: 'inv123',
-    createdAt: new Date('2020-01-01'),
     accountNumber: 'acc123',
-    financialYearEnding: '2021',
-    netAmount: 123456789,
+    billRun: { batchType: 'annual' },
     billingAccountId: 'bicc1233',
+    createdAt: new Date('2020-01-01'),
+    financialYearEnding: '2021',
     id: 'id123',
-    billRun: { batchType: 'annual' }
+    invoiceNumber: 'inv123',
+    netAmount: 123456789
   }]
 }

--- a/test/presenters/licences/view-licence-bills-presenter.test.js
+++ b/test/presenters/licences/view-licence-bills-presenter.test.js
@@ -16,12 +16,35 @@ describe('View Licence Bills presenter', () => {
       const result = ViewLicenceBillsPresenter.go(_bills())
 
       expect(result).to.equal({
-        activeTab: 'bills'
+        activeTab: 'bills',
+        bills: [{
+          account: 'acc123',
+          accountId: 'bicc1233',
+          billNumber: 'inv123',
+          dateCreated: '1 January 2020',
+          financialYear: '2021',
+          id: 'id123',
+          runType: 'Annual',
+          total: '£123,456,789.00'
+        }]
       })
+    })
+    it('correctly formats the currency to UK standard', () => {
+      const result = ViewLicenceBillsPresenter.go(_bills())
+      expect(result.bills[0].total).to.equal('£123,456,789.00')
     })
   })
 })
 
 function _bills () {
-  return {}
+  return [{
+    invoiceNumber: 'inv123',
+    createdAt: new Date('2020-01-01'),
+    accountNumber: 'acc123',
+    batchType: 'Annual',
+    financialYearEnding: '2021',
+    netAmount: 123456789,
+    billingAccountId: 'bicc1233',
+    id: 'id123'
+  }]
 }

--- a/test/presenters/licences/view-licence-bills-presenter.test.js
+++ b/test/presenters/licences/view-licence-bills-presenter.test.js
@@ -1,0 +1,33 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Thing under test
+const ViewLicenceBillsPresenter = require('../../../app/presenters/licences/view-licence-bills.presenter')
+
+describe('View Licence Bills presenter', () => {
+  let auth
+
+  beforeEach(() => {
+    auth = undefined
+  })
+
+  describe('when provided with a bills data', () => {
+    it('correctly presents the data', () => {
+      const result = ViewLicenceBillsPresenter.go(_bills())
+
+      expect(result).to.equal({
+        activeTab: 'bills'
+      })
+    })
+  })
+})
+
+function _bills () {
+  return {}
+}

--- a/test/presenters/licences/view-licence-bills-presenter.test.js
+++ b/test/presenters/licences/view-licence-bills-presenter.test.js
@@ -24,14 +24,14 @@ describe('View Licence Bills presenter', () => {
           dateCreated: '1 January 2020',
           financialYear: '2021',
           id: 'id123',
-          runType: 'Annual',
-          total: '£123,456,789.00'
+          runType: 'annual',
+          total: '£1,234,567.89'
         }]
       })
     })
     it('correctly formats the currency to UK standard', () => {
       const result = ViewLicenceBillsPresenter.go(_bills())
-      expect(result.bills[0].total).to.equal('£123,456,789.00')
+      expect(result.bills[0].total).to.equal('£1,234,567.89')
     })
   })
 })
@@ -41,10 +41,10 @@ function _bills () {
     invoiceNumber: 'inv123',
     createdAt: new Date('2020-01-01'),
     accountNumber: 'acc123',
-    batchType: 'Annual',
     financialYearEnding: '2021',
     netAmount: 123456789,
     billingAccountId: 'bicc1233',
-    id: 'id123'
+    id: 'id123',
+    billRun: { batchType: 'annual' }
   }]
 }

--- a/test/presenters/licences/view-licence-bills-presenter.test.js
+++ b/test/presenters/licences/view-licence-bills-presenter.test.js
@@ -4,19 +4,13 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { describe, it } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Thing under test
 const ViewLicenceBillsPresenter = require('../../../app/presenters/licences/view-licence-bills.presenter')
 
 describe('View Licence Bills presenter', () => {
-  let auth
-
-  beforeEach(() => {
-    auth = undefined
-  })
-
   describe('when provided with a bills data', () => {
     it('correctly presents the data', () => {
       const result = ViewLicenceBillsPresenter.go(_bills())

--- a/test/presenters/licences/view-licence-presenter.test.js
+++ b/test/presenters/licences/view-licence-presenter.test.js
@@ -24,6 +24,7 @@ describe('View Licence presenter', () => {
       const result = ViewLicencePresenter.go(licence)
 
       expect(result).to.equal({
+        activeNavBar: 'search',
         licenceId: 'f1288f6c-8503-4dc1-b114-75c408a14bd0',
         licenceName: 'Unregistered licence',
         licenceRef: '01/123',

--- a/test/services/licences/fetch-licence-bills.service.test.js
+++ b/test/services/licences/fetch-licence-bills.service.test.js
@@ -1,0 +1,73 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const DatabaseSupport = require('../../support/database.js')
+const BillLicenceHelper = require('../../support/helpers/bill-licence.helper')
+const BillHelper = require('../../support/helpers/bill.helper')
+const BillRunHelper = require('../../support/helpers/bill-run.helper')
+
+// Thing under test
+const FetchLicenceBillService = require('../../../app/services/licences/fetch-licence-bills.service')
+
+describe('Fetch licence bills service', () => {
+  beforeEach(async () => {
+    await DatabaseSupport.clean()
+  })
+
+  describe('when the licence has bills', () => {
+    const createdDate = new Date('2022-01-01')
+
+    const licenceId = '96d97293-1a62-4ad0-bcb6-24f68a203e6b'
+    const billId = '72988ec1-9fb2-4b87-b0a0-3c0be628a72c'
+    const billingAccountId = '0ba3b707-72ee-4296-b177-a19afff10688'
+
+    beforeEach(async () => {
+      await BillLicenceHelper.add({
+        licenceId,
+        billId
+      })
+
+      await BillRunHelper.add({ batchType: 'annual' })
+
+      await BillHelper.add(
+        {
+          id: billId,
+          invoiceNumber: '123',
+          accountNumber: 'T21404193A',
+          netAmount: 12345,
+          billingAccountId,
+          createdAt: createdDate
+        })
+      // Add an extra record to ensure the bill is retrieved by the license id
+      await BillHelper.add()
+    })
+
+    it('returns results', async () => {
+      const result = await FetchLicenceBillService.go(licenceId, 1)
+
+      expect(result.pagination).to.equal({
+        total: 1
+      })
+
+      expect(result.bills).to.equal(
+        [{
+          accountNumber: 'T21404193A',
+          billRun: null,
+          billingAccountId,
+          createdAt: createdDate,
+          financialYearEnding: 2023,
+          id: billId,
+          invoiceNumber: '123',
+          netAmount: 12345
+        }]
+      )
+    })
+  })
+})

--- a/test/services/licences/view-licence-bills.service.test.js
+++ b/test/services/licences/view-licence-bills.service.test.js
@@ -62,6 +62,6 @@ function _billsPresenter () {
 function _billsFetchService () {
   return {
     bills: [],
-    pagination: { total: 1 },
+    pagination: { total: 1 }
   }
 }

--- a/test/services/licences/view-licence-bills.service.test.js
+++ b/test/services/licences/view-licence-bills.service.test.js
@@ -10,6 +10,7 @@ const { expect } = Code
 
 // Things we need to stub
 const FetchLicenceBillsService = require('../../../app/services/licences/fetch-licence-bills.service')
+const PaginatorPresenter = require('../../../app/presenters/paginator.presenter')
 const ViewLicenceService = require('../../../app/services/licences/view-licence.service')
 const ViewLicenceBillsPresenter = require('../../../app/presenters/licences/view-licence-bills.presenter')
 
@@ -17,11 +18,14 @@ const ViewLicenceBillsPresenter = require('../../../app/presenters/licences/view
 const ViewLicenceBillsService = require('../../../app/services/licences/view-licence-bills.service')
 
 describe('View Licence service bills', () => {
-  const testId = '2c80bd22-a005-4cf4-a2a2-73812a9861de'
   const auth = {}
+  const page = 1
+  const pagination = { page }
+  const testId = '2c80bd22-a005-4cf4-a2a2-73812a9861de'
 
   beforeEach(() => {
     Sinon.stub(FetchLicenceBillsService, 'go').returns(_billsFetchService())
+    Sinon.stub(PaginatorPresenter, 'go').returns(pagination)
     Sinon.stub(ViewLicenceBillsPresenter, 'go').returns(_billsPresenter())
     Sinon.stub(ViewLicenceService, 'go').resolves(_licence())
   })
@@ -39,9 +43,7 @@ describe('View Licence service bills', () => {
           activeTab: 'bills',
           bills: [],
           licenceName: 'fake licence',
-          pagination: {
-            total: 1
-          }
+          pagination: { page: 1 }
         })
       })
     })

--- a/test/services/licences/view-licence-bills.service.test.js
+++ b/test/services/licences/view-licence-bills.service.test.js
@@ -9,17 +9,19 @@ const { describe, it, beforeEach, afterEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Things we need to stub
+const FetchLicenceBillsService = require('../../../app/services/licences/fetch-licence-bills.service')
 const ViewLicenceService = require('../../../app/services/licences/view-licence.service')
 const ViewLicenceBillsPresenter = require('../../../app/presenters/licences/view-licence-bills.presenter')
 
 // Thing under test
 const ViewLicenceBillsService = require('../../../app/services/licences/view-licence-bills.service')
 
-describe('View Licence service returns', () => {
+describe('View Licence service bills', () => {
   const testId = '2c80bd22-a005-4cf4-a2a2-73812a9861de'
   const auth = {}
 
   beforeEach(() => {
+    Sinon.stub(FetchLicenceBillsService, 'go').returns(_billsFetchService())
     Sinon.stub(ViewLicenceBillsPresenter, 'go').returns(_billsPresenter())
     Sinon.stub(ViewLicenceService, 'go').resolves(_licence())
   })
@@ -30,13 +32,16 @@ describe('View Licence service returns', () => {
 
   describe('when a bill', () => {
     describe('and it has no optional fields', () => {
-      it('will return all the mandatory data and default values for use in the licence returns page', async () => {
+      it('will return all the mandatory data and default values for use in the licence bills page', async () => {
         const result = await ViewLicenceBillsService.go(testId, auth)
 
         expect(result).to.equal({
-          licenceName: 'fake licence',
+          activeTab: 'bills',
           bills: [],
-          activeTab: 'bills'
+          licenceName: 'fake licence',
+          pagination: {
+            total: 1
+          }
         })
       })
     })
@@ -51,5 +56,12 @@ function _billsPresenter () {
   return {
     bills: [],
     activeTab: 'bills'
+  }
+}
+
+function _billsFetchService () {
+  return {
+    bills: [],
+    pagination: { total: 1 },
   }
 }

--- a/test/services/licences/view-licence-bills.service.test.js
+++ b/test/services/licences/view-licence-bills.service.test.js
@@ -28,7 +28,7 @@ describe('View Licence service returns', () => {
     Sinon.restore()
   })
 
-  describe.only('when a bill', () => {
+  describe('when a bill', () => {
     describe('and it has no optional fields', () => {
       it('will return all the mandatory data and default values for use in the licence returns page', async () => {
         const result = await ViewLicenceBillsService.go(testId, auth)

--- a/test/services/licences/view-licence-bills.service.test.js
+++ b/test/services/licences/view-licence-bills.service.test.js
@@ -1,0 +1,55 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { describe, it, beforeEach, afterEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Things we need to stub
+const ViewLicenceService = require('../../../app/services/licences/view-licence.service')
+const ViewLicenceBillsPresenter = require('../../../app/presenters/licences/view-licence-bills.presenter')
+
+// Thing under test
+const ViewLicenceBillsService = require('../../../app/services/licences/view-licence-bills.service')
+
+describe('View Licence service returns', () => {
+  const testId = '2c80bd22-a005-4cf4-a2a2-73812a9861de'
+  const auth = {}
+
+  beforeEach(() => {
+    Sinon.stub(ViewLicenceBillsPresenter, 'go').returns(_billsPresenter())
+    Sinon.stub(ViewLicenceService, 'go').resolves(_licence())
+  })
+
+  afterEach(() => {
+    Sinon.restore()
+  })
+
+  describe.only('when a bill', () => {
+    describe('and it has no optional fields', () => {
+      it('will return all the mandatory data and default values for use in the licence returns page', async () => {
+        const result = await ViewLicenceBillsService.go(testId, auth)
+
+        expect(result).to.equal({
+          licenceName: 'fake licence',
+          bills: [],
+          activeTab: 'bills'
+        })
+      })
+    })
+  })
+})
+
+function _licence () {
+  return { licenceName: 'fake licence' }
+}
+
+function _billsPresenter () {
+  return {
+    bills: [],
+    activeTab: 'bills'
+  }
+}

--- a/test/services/licences/view-licence.service.test.js
+++ b/test/services/licences/view-licence.service.test.js
@@ -46,6 +46,7 @@ describe('View Licence service', () => {
         const result = await ViewLicenceService.go(testId)
 
         expect(result).to.equal({
+          activeNavBar: 'search',
           licenceId: '2c80bd22-a005-4cf4-a2a2-73812a9861de',
           licenceName: 'Unregistered licence',
           licenceRef: '01/130/R01',

--- a/test/support/helpers/bill-licence.helper.js
+++ b/test/support/helpers/bill-licence.helper.js
@@ -41,7 +41,7 @@ function defaults (data = {}) {
   const defaults = {
     billId: generateUUID(),
     licenceRef: LicenceHelper.generateLicenceRef(),
-    licenceId: generateUUID()
+    licenceId: data.licenceId || generateUUID()
   }
 
   return {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4316

The existing service handling view licence is slow because it loads all the data for the tabs in one render. Work has been done previously to refactor the summary page to load only the summary information.

This change will introduce a bills controller, service and presenter to handle the view licence bills page.

This will share the same view as the summary page and load the same 'common data' established in [previous work](#957).