### PR TITLE
Fix the returns and bills empty message

### DIFF
--- a/app/views/licences/tabs/bills.njk
+++ b/app/views/licences/tabs/bills.njk
@@ -2,7 +2,7 @@
 
 <table class="govuk-table">
   <h2 class="govuk-heading-l">Bills</h2>
-  {% if bills %}
+  {% if bills.length > 0 %}
     <table class="govuk-table">
       <thead class="govuk-table__head">
       <tr class="govuk-table__row">

--- a/app/views/licences/tabs/returns.njk
+++ b/app/views/licences/tabs/returns.njk
@@ -21,7 +21,7 @@
 
 <table class="govuk-table">
   <h2 class="govuk-heading-l">Returns</h2>
-  {% if returns %}
+  {% if returns.length > 0 %}
     <thead class="govuk-table__head">
     <tr class="govuk-table__row">
       <th scope="col" class="govuk-table__header">Return reference and dates</th>

--- a/test/controllers/licences.controller.test.js
+++ b/test/controllers/licences.controller.test.js
@@ -184,7 +184,7 @@ describe('Licences controller', () => {
     })
     describe('when a request is valid and has no bills', () => {
       beforeEach(async () => {
-        Sinon.stub(ViewLicenceBillsService, 'go').resolves({ activeTab: 'bills' })
+        Sinon.stub(ViewLicenceBillsService, 'go').resolves({ activeTab: 'bills', bills: [] })
       })
 
       it('returns the page successfully', async () => {
@@ -256,20 +256,38 @@ describe('Licences controller', () => {
         expect(response.payload).to.contain('Status')
       })
     })
+
+    describe('when a request is valid and has NO returns', () => {
+      beforeEach(async () => {
+        Sinon.stub(ViewLicenceReturnsService, 'go').resolves({
+          activeTab: 'returns',
+          returns: []
+        })
+      })
+
+      it('returns the page successfully', async () => {
+        const response = await server.inject(options)
+
+        expect(response.statusCode).to.equal(200)
+        expect(response.payload).to.contain('Returns')
+        //  Check the table titles
+        expect(response.payload).to.contain('No returns found')
+      })
+    })
   })
 })
 
 function _viewLicenceBills () {
   return {
     activeTab: 'bills',
-    bills: []
+    bills: [{ id: 'bills-id' }]
   }
 }
 
 function _viewLicenceReturns () {
   return {
     activeTab: 'returns',
-    returns: [{}]
+    returns: [{ id: 'returns-id' }]
   }
 }
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4444

An assumption was made previously that the returned value would be null when there were no bills/ returns. This was an over site, and it would obviously always be an array.

This fix will check the array is > 0 to determine when to show the table or the empty message.