### PR TITLE
Exclude long strings from ESLint max-len rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,7 +5,10 @@ module.exports = {
   ],
   rules: {
     '@stylistic/js/max-len': ['error', {
-      code: 120
+      code: 120,
+      ignoreStrings: true,
+      ignoreTemplateLiterals: true,
+      ignoreUrls: true
     }]
   }
 }


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/115

Whilst we should be making every effort to keep lines shorter than 120 characters the intent of the rule is to stop folks from stringing together complex one-liners.

Sometimes we need to include long pieces of text, build strings from verbose variable names or reference URLS that will cause us to exceed the limit.

We don't want to make them more complex just for the sake of a linter. So, we add this config to exclude these lines of these types from the rule.