### PR TITLE
Fix all max-len ESLint rule infractions

### DIFF
--- a/app/controllers/bill-runs.controller.js
+++ b/app/controllers/bill-runs.controller.js
@@ -150,7 +150,13 @@ async function send (request, h) {
 async function submitAmendedBillableReturns (request, h) {
   const { id: billRunId, licenceId, reviewChargeElementId } = request.params
 
-  const pageData = await SubmitAmendedBillableReturnsService.go(billRunId, licenceId, reviewChargeElementId, request.payload, request.yar)
+  const pageData = await SubmitAmendedBillableReturnsService.go(
+    billRunId,
+    licenceId,
+    reviewChargeElementId,
+    request.payload,
+    request.yar
+  )
 
   if (pageData.error) {
     return h.view('bill-runs/amend-billable-returns.njk', pageData)

--- a/app/lib/base-notifier.lib.js
+++ b/app/lib/base-notifier.lib.js
@@ -41,8 +41,8 @@ class BaseNotifierLib {
    * The message will be added as an `INFO` level log message.
    *
    * @param {string} message Message to add to the log (INFO)
-   * @param {Object} [data={}] An object containing any values to be logged, for example, a bill run ID to be included with
-   *  the log message. Defaults to an empty object
+   * @param {Object} [data={}] An object containing any values to be logged, for example, a bill run ID to be included
+   *  with the log message. Defaults to an empty object
    */
   omg (message, data = {}) {
     this._logger.info(this._formatLogPacket(data), message)

--- a/app/models/licence-entity-role.model.js
+++ b/app/models/licence-entity-role.model.js
@@ -12,9 +12,9 @@ const BaseModel = require('./base.model.js')
 /**
  * Represents an instance of a licence entity role record
  *
- * For reference, the licence entity role record is related to functionality that was added when the service was first built.
- * It sits in the old `crm` schema and was not migrated to `crm_v2` as part of the previous team's efforts to replace
- * the old legacy CRM setup.
+ * For reference, the licence entity role record is related to functionality that was added when the service was first
+ * built. It sits in the old `crm` schema and was not migrated to `crm_v2` as part of the previous team's efforts to
+ * replace the old legacy CRM setup.
  *
  * Currently, the only reason we need it is to identify if a licence has a 'registered user'. You'll see this
  * highlighted when you view a licence.

--- a/app/plugins/hapi-pino.plugin.js
+++ b/app/plugins/hapi-pino.plugin.js
@@ -23,8 +23,8 @@ const HapiPinoPlugin = () => {
     options: {
       // Include our test configuration
       ...HapiPinoLogInTestService.go(LogConfig.logInTest),
-      // When not in the production environment we want a 'pretty' version of the JSON to make it easier to grok what has
-      // happened
+      // When not in the production environment we want a 'pretty' version of the JSON to make it easier to grok what
+      // has happened
       transport: process.env.NODE_ENV !== 'production' ? { target: 'pino-pretty', options: { colorize: true } } : undefined,
       // Redact Authorization headers, see https://getpino.io/#/docs/redaction
       redact: ['req.headers.authorization'],

--- a/app/services/bill-licences/fetch-bill-licence.service.js
+++ b/app/services/bill-licences/fetch-bill-licence.service.js
@@ -16,8 +16,8 @@ const BillLicenceModel = require('../../models/bill-licence.model.js')
  *
  * @param {string} id The UUID for the bill licence to fetch
  *
- * @returns {Promise<Object>} the matching instance of BillLicenceModel plus the linked bill and bill run. Also all transactions
- * linked to the bill licence and their linked charge reference details
+ * @returns {Promise<Object>} the matching instance of BillLicenceModel plus the linked bill and bill run. Also all
+ * transactions linked to the bill licence and their linked charge reference details
  */
 async function go (id) {
   return _fetchBillLicence(id)

--- a/app/services/bill-licences/view-bill-licence.service.js
+++ b/app/services/bill-licences/view-bill-licence.service.js
@@ -13,8 +13,8 @@ const ViewBillLicencePresenter = require('../../presenters/bill-licences/view-bi
  *
  * @param {string} id The UUID for the bill licence to view
  *
- * @returns {Promise<Object>} a formatted representation of the bill licence and its transactions for use in the bill licence
- * view page
+ * @returns {Promise<Object>} a formatted representation of the bill licence and its transactions for use in the bill
+ * licence view page
  */
 async function go (id) {
   const billLicence = await FetchBillLicenceService.go(id)

--- a/app/services/bill-runs/determine-billing-periods.service.js
+++ b/app/services/bill-runs/determine-billing-periods.service.js
@@ -17,14 +17,14 @@ const SROC_FIRST_FIN_YEAR_END = 2023
 /**
  * Determine the billing periods needed when generating a bill run
  *
- * Using the `financialYearEnding` provided we first determine the financial start and end date for that financial year. If
- * no `financialYearEnding` is provided we use the current financial year.
+ * Using the `financialYearEnding` provided we first determine the financial start and end date for that financial year.
+ * If no `financialYearEnding` is provided we use the current financial year.
  *
  * If the bill run type is 'annual' or 'two_part_tariff' we just return that billing period.
  *
- * If the bill run type is 'supplementary' we then need to calculate a range of up to 6 billing periods back to 2022-2023.
- * The service supports corrections and changes being made to charge version information in the current financial year
- * plus 5. We limit this to 2022-2023 as that is the first SROC year (and we don't handle PRESROC!)
+ * If the bill run type is 'supplementary' we then need to calculate a range of up to 6 billing periods back to
+ * 2022-2023. The service supports corrections and changes being made to charge version information in the current
+ * financial year plus 5. We limit this to 2022-2023 as that is the first SROC year (and we don't handle PRESROC!)
  *
  * Our 3 billing engines then use these periods to generate the bill run.
  *

--- a/app/services/bill-runs/fetch-bill-run.service.js
+++ b/app/services/bill-runs/fetch-bill-run.service.js
@@ -15,8 +15,8 @@ const { db } = require('../../../db/db.js')
  *
  * @param {string} id The UUID for the bill run to fetch
  *
- * @returns {Promise<Object>} the matching instance of BillRunModel plus a summary (Billing account number and contact, licence,
- * numbers, financial year and total net amount) for each bill linked to the bill run
+ * @returns {Promise<Object>} the matching instance of BillRunModel plus a summary (Billing account number and contact,
+ * licence, numbers, financial year and total net amount) for each bill linked to the bill run
  */
 async function go (id) {
   const billRun = await _fetchBillRun(id)

--- a/app/services/bill-runs/start-bill-run-process.service.js
+++ b/app/services/bill-runs/start-bill-run-process.service.js
@@ -41,7 +41,8 @@ function _financialYearEndings (billingPeriods) {
 }
 
 function _processBillRun (billRun, billingPeriods) {
-  // We do not `await` the bill run being processed so we can leave it to run in the background while we return an immediate response
+  // We do not `await` the bill run being processed so we can leave it to run in the background while we return an
+  // immediate response
   switch (billRun.batchType) {
     case 'annual':
       AnnualProcessBillRunService.go(billRun, billingPeriods)

--- a/app/services/bill-runs/two-part-tariff/allocate-returns-to-charge-element.service.js
+++ b/app/services/bill-runs/two-part-tariff/allocate-returns-to-charge-element.service.js
@@ -136,7 +136,8 @@ function _checkReturnForIssues (matchedReturn) {
     return true
   }
 
-  if (matchedReturn.returnSubmissions.length === 0 || matchedReturn.returnSubmissions[0].returnSubmissionLines.length === 0) {
+  if (matchedReturn.returnSubmissions.length === 0 ||
+    matchedReturn.returnSubmissions[0].returnSubmissionLines.length === 0) {
     return true
   }
 

--- a/app/services/bill-runs/two-part-tariff/fetch-licences.service.js
+++ b/app/services/bill-runs/two-part-tariff/fetch-licences.service.js
@@ -14,7 +14,8 @@ const FetchChargeVersionsService = require('./fetch-charge-versions.service.js')
  * @param {String} regionId UUID of the region being billed that the licences must be linked to
  * @param {Object} billingPeriod Object with a `startDate` and `endDate` property representing the period being billed
  *
- * @returns {Promise<Object[]>} the licences to be matched, each containing an array of charge versions applicable for two-part tariff
+ * @returns {Promise<Object[]>} the licences to be matched, each containing an array of charge versions applicable for
+ * two-part tariff
  */
 async function go (regionId, billingPeriod) {
   const chargeVersions = await FetchChargeVersionsService.go(regionId, billingPeriod)

--- a/app/services/bill-runs/two-part-tariff/fetch-return-logs-for-licence.service.js
+++ b/app/services/bill-runs/two-part-tariff/fetch-return-logs-for-licence.service.js
@@ -41,7 +41,8 @@ async function _fetch (licenceRef, billingPeriod) {
       ref('metadata:purposes').as('purposes')
     ])
     .where('licenceRef', licenceRef)
-    // water-abstraction-service filters out old return logs in this way: see `src/lib/services/returns/api-connector.js`
+    // water-abstraction-service filters out old return logs in this way: see
+    // `src/lib/services/returns/api-connector.js`
     .where('startDate', '>=', '2008-04-01')
     .where('endDate', '>=', billingPeriod.startDate)
     .where('endDate', '<=', billingPeriod.endDate)

--- a/app/services/bill-runs/view-bill-run.service.js
+++ b/app/services/bill-runs/view-bill-run.service.js
@@ -16,8 +16,8 @@ const FetchBillRunService = require('./fetch-bill-run.service.js')
  *
  * @param {string} id The UUID for the bill run to view
  *
- * @returns {Promise<Object>} an object representing the `pageData` needed by the view bill run template. It contains details of
- * the bill run and the bills linked to it plus the page title.
+ * @returns {Promise<Object>} an object representing the `pageData` needed by the view bill run template. It contains
+ * details of the bill run and the bills linked to it plus the page title.
  */
 async function go (id) {
   const result = await FetchBillRunService.go(id)

--- a/app/services/billing-accounts/change-address.service.js
+++ b/app/services/billing-accounts/change-address.service.js
@@ -18,9 +18,9 @@ const SendCustomerChangeService = require('./send-customer-change.service.js')
  * Within the service an internal user can 'Change the address' of a billing account. That is what the button says but
  * they can also change or set the agent company and the contact along with the address.
  *
- * Behind the scenes a new `billing_account_address` record is created that links to the `addresses`,
- * `companies` and `contacts` records. It will also be linked to the `billing_account` which
- * represents the billing account being amended.
+ * Behind the scenes a new `billing_account_address` record is created that links to the `addresses`, `companies` and
+ * `contacts` records. It will also be linked to the `billing_account` which represents the billing account being
+ * amended.
  *
  * It won't have an end date, which marks it as the 'current' address. The previous `billing_account_address` will get
  * its `end_date` updated. The legacy service then knows that address is no longer current.
@@ -49,7 +49,8 @@ const SendCustomerChangeService = require('./send-customer-change.service.js')
  * @param {Object} [agentCompany] The validated agent company details
  * @param {Object} [contact] The validated contact details
  *
- * @returns {Promise<Object>} contains a copy of the persisted address, agent company and contact if they were also changed
+ * @returns {Promise<Object>} contains a copy of the persisted address, agent company and contact if they were also
+ * changed
  */
 async function go (billingAccountId, address, agentCompany = {}, contact = {}) {
   const billingAccount = await _fetchBillingAccount(billingAccountId)
@@ -105,9 +106,9 @@ async function _fetchBillingAccount (billingAccountId) {
  * instances.
  *
  * We attempt to persist the address, company and contact model instances first because we need their IDs in order to
- * create the new `billing_account_addresses` record. When we create that record we also need to apply an end date
- * to any existing billing account addresses with a null end date. This is how the service determines which address
- * details are current (end date is null).
+ * create the new `billing_account_addresses` record. When we create that record we also need to apply an end date to
+ * any existing billing account addresses with a null end date. This is how the service determines which address details
+ * are current (end date is null).
  *
  * The object we return has all 3 entities whether they were persisted or not. This gets passed back to the UI via the
  * controller and is what it needs to then be able to redirect the user to the correct page.
@@ -118,8 +119,8 @@ async function _fetchBillingAccount (billingAccountId) {
  * @param {module:CompanyModel} company the new agent company to be persisted (not expected to be populated)
  * @param {module:ContactModel} contact the new contact to be persisted (not expected to be populated)
  *
- * @returns {Promise<Object>} a single object that contains the persisted billingAccountAddress, plus address, agent company and
- * contact
+ * @returns {Promise<Object>} a single object that contains the persisted billingAccountAddress, plus address, agent
+ * company and contact
  */
 async function _persist (timestamp, billingAccount, address, company, contact) {
   const persistedData = {}

--- a/app/services/bills/fetch-bill-service.js
+++ b/app/services/bills/fetch-bill-service.js
@@ -15,8 +15,8 @@ const { db } = require('../../../db/db.js')
  *
  * @param {string} id The UUID for the bill to fetch
  *
- * @returns {Promise<Object>} the matching instance of BillModel plus a summary (ID, reference, and total net amount) for each
- * licence linked to the bill
+ * @returns {Promise<Object>} the matching instance of BillModel plus a summary (ID, reference, and total net amount)
+ * for each licence linked to the bill
  */
 async function go (id) {
   const bill = await _fetchBill(id)

--- a/app/services/bills/view-bill.service.js
+++ b/app/services/bills/view-bill.service.js
@@ -15,19 +15,19 @@ const ViewLicenceSummariesPresenter = require('../../presenters/bills/view-licen
 /**
  * Orchestrates fetching and presenting the data needed for one of the view bill templates
  *
- * When viewing a bill we are required to return a different template depending on whether the bill is linked to one
- * or multiple licences.
+ * When viewing a bill we are required to return a different template depending on whether the bill is linked to one or
+ * multiple licences.
  *
- * All templates depend on the same bill and billing account data. We show the same thing at the top of the page. But
- * if the bill has multiple licences we show a table that summarises them so depend on `LicenceSummariesPresenter`.
+ * All templates depend on the same bill and billing account data. We show the same thing at the top of the page. But if
+ * the bill has multiple licences we show a table that summarises them so depend on `LicenceSummariesPresenter`.
  *
- * Else when there is just 1 licence we show all the transactions details instead (saving the user an extra click!).
- * For this we need to fetch the bill licence and use `ViewBillLicencePresenter` to generate the data.
+ * Else when there is just 1 licence we show all the transactions details instead (saving the user an extra click!). For
+ * this we need to fetch the bill licence and use `ViewBillLicencePresenter` to generate the data.
  *
  * @param {string} id The UUID for the bill to view
  *
- * @returns {Promise<Object>} a formatted representation of the bill, its bill run and billing account plus summaries for all
- * the licences linked to the bill for use in the bill view page
+ * @returns {Promise<Object>} a formatted representation of the bill, its bill run and billing account plus summaries
+ * for all the licences linked to the bill for use in the bill view page
  */
 async function go (id) {
   const { bill, licenceSummaries } = await FetchBillService.go(id)

--- a/app/services/jobs/export/fetch-table.service.js
+++ b/app/services/jobs/export/fetch-table.service.js
@@ -8,7 +8,9 @@
 const { db } = require('../../../../db/db.js')
 
 /**
- * Retrieves headers, a knex query for the table rows and the table name from the table in the db, and returns them as an object
+ * Retrieves headers, a knex query for the table rows and the table name from the table in the db, and returns them as
+ * an object
+ *
  * @param {String} tableName The name of the table to retrieve
  * @param {string} schemaName The schema that the table belongs to
  *

--- a/app/services/return-requirements/site-description.service.js
+++ b/app/services/return-requirements/site-description.service.js
@@ -11,8 +11,8 @@ const SiteDescriptionPresenter = require('../../presenters/return-requirements/s
 /**
  * Orchestrates fetching and presenting the data for `/return-requirements/{sessionId}/site-description` page
  *
- * Supports generating the data needed for the site description page in the return requirements setup journey. It fetches the
- * current session record and combines it with the date fields and other information needed for the form.
+ * Supports generating the data needed for the site description page in the return requirements setup journey. It
+ * fetches the current session record and combines it with the date fields and other information needed for the form.
  *
  * @param {string} sessionId - The UUID of the current session
  * @param {string} requirementIndex - The index of the requirement being added or changed

--- a/test/models/licence-version-purpose-condition.model.test.js
+++ b/test/models/licence-version-purpose-condition.model.test.js
@@ -60,7 +60,8 @@ describe('Licence Version Purposes model', () => {
         expect(result).to.be.instanceOf(LicenceVersionPurposeConditionModel)
         expect(result.id).to.equal(testRecord.id)
 
-        expect(result.licenceVersionPurposeConditionTypes[0]).to.be.an.instanceOf(LicenceVersionPurposeConditionTypeModel)
+        expect(result.licenceVersionPurposeConditionTypes[0])
+          .to.be.an.instanceOf(LicenceVersionPurposeConditionTypeModel)
         expect(result.licenceVersionPurposeConditionTypes[0].id).to.equal(testLicenceVersionPurposeConditionType.id)
       })
     })

--- a/test/services/bill-licences/fetch-bill-licence-summary.service.test.js
+++ b/test/services/bill-licences/fetch-bill-licence-summary.service.test.js
@@ -75,8 +75,8 @@ describe('Fetch Bill Licence Summary service', () => {
     it('will fetch the data use in the remove bill licence page', async () => {
       const result = await FetchBillLicenceSummaryService.go(billLicence.id)
 
-      // // NOTE: Transactions would not ordinarily be empty. But the format of the transactions will differ depending on
-      // // scheme so we get into that in later tests.
+      // NOTE: Transactions would not ordinarily be empty. But the format of the transactions will differ depending on
+      // scheme so we get into that in later tests.
       expect(result).to.equal({
         id: billLicence.id,
         licenceId: billLicence.licenceId,

--- a/test/services/bill-runs/create-bill-run.service.test.js
+++ b/test/services/bill-runs/create-bill-run.service.test.js
@@ -55,7 +55,11 @@ describe('Create Bill Run service', () => {
     const errorCode = 50
 
     it('returns the new bill run instance containing the provided values', async () => {
-      const result = await CreateBillRunService.go(region.id, financialYearEndings, { batchType, scheme, source, externalId, status, errorCode })
+      const result = await CreateBillRunService.go(
+        region.id,
+        financialYearEndings,
+        { batchType, scheme, source, externalId, status, errorCode }
+      )
 
       expect(result).to.be.an.instanceOf(BillRunModel)
 

--- a/test/services/bill-runs/supplementary/fetch-previous-transactions.service.test.js
+++ b/test/services/bill-runs/supplementary/fetch-previous-transactions.service.test.js
@@ -73,7 +73,11 @@ describe('Fetch Previous Transactions service', () => {
             })
 
             it('returns no results', async () => {
-              const results = await FetchPreviousTransactionsService.go(billingAccountId, licenceId, financialYearEnding)
+              const results = await FetchPreviousTransactionsService.go(
+                billingAccountId,
+                licenceId,
+                financialYearEnding
+              )
 
               expect(results).to.be.empty()
             })
@@ -90,7 +94,11 @@ describe('Fetch Previous Transactions service', () => {
             })
 
             it('returns the debits', async () => {
-              const results = await FetchPreviousTransactionsService.go(billingAccountId, licenceId, financialYearEnding)
+              const results = await FetchPreviousTransactionsService.go(
+                billingAccountId,
+                licenceId,
+                financialYearEnding
+              )
 
               expect(results).to.have.length(1)
               expect(results[0].credit).to.be.false()
@@ -116,7 +124,11 @@ describe('Fetch Previous Transactions service', () => {
             })
 
             it('returns only the follow up debit', async () => {
-              const results = await FetchPreviousTransactionsService.go(billingAccountId, licenceId, financialYearEnding)
+              const results = await FetchPreviousTransactionsService.go(
+                billingAccountId,
+                licenceId,
+                financialYearEnding
+              )
 
               expect(results).to.have.length(1)
               expect(results[0].credit).to.be.false()
@@ -135,7 +147,11 @@ describe('Fetch Previous Transactions service', () => {
             })
 
             it('returns both debits', async () => {
-              const results = await FetchPreviousTransactionsService.go(billingAccountId, licenceId, financialYearEnding)
+              const results = await FetchPreviousTransactionsService.go(
+                billingAccountId,
+                licenceId,
+                financialYearEnding
+              )
 
               expect(results).to.have.length(2)
               expect(results.every((transaction) => !transaction.credit)).to.be.true()

--- a/test/services/bill-runs/supplementary/pre-generate-billing-data.service.test.js
+++ b/test/services/bill-runs/supplementary/pre-generate-billing-data.service.test.js
@@ -89,14 +89,21 @@ describe('Pre-generate billing data service', () => {
 
     describe('returns an object with a billLicences property', () => {
       it('has one key per combination of bill id and licence id', async () => {
-        const { billLicences: result } = await PreGenerateBillingDataService.go(chargeVersions, billRunId, billingPeriod)
+        const { billLicences: result } = await PreGenerateBillingDataService.go(
+          chargeVersions,
+          billRunId,
+          billingPeriod
+        )
 
         const keys = Object.entries(result)
         expect(keys).to.have.length(3)
       })
 
       it('is keyed with the bill id and licence id', async () => {
-        const { billLicences: result } = await PreGenerateBillingDataService.go(chargeVersions, billRunId, billingPeriod)
+        const { billLicences: result } = await PreGenerateBillingDataService.go(
+          chargeVersions,
+          billRunId,
+          billingPeriod)
 
         const entries = Object.entries(result)
 
@@ -106,7 +113,11 @@ describe('Pre-generate billing data service', () => {
       })
 
       it('has the correct data for each key', async () => {
-        const { billLicences: result } = await PreGenerateBillingDataService.go(chargeVersions, billRunId, billingPeriod)
+        const { billLicences: result } = await PreGenerateBillingDataService.go(
+          chargeVersions,
+          billRunId,
+          billingPeriod
+        )
 
         const entries = Object.entries(result)
 

--- a/test/services/bill-runs/two-part-tariff/fetch-match-details.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/fetch-match-details.service.test.js
@@ -48,10 +48,14 @@ describe('Fetch Match Details service', () => {
       beforeEach(async () => {
         reviewChargeVersion = await ReviewChargeVersionHelper.add()
         chargeReference = await ChargeReferenceHelper.add()
-        reviewChargeReference = await ReviewChargeReferenceHelper.add({ reviewChargeVersionId: reviewChargeVersion.id, chargeReferenceId: chargeReference.id })
+        reviewChargeReference = await ReviewChargeReferenceHelper.add(
+          { reviewChargeVersionId: reviewChargeVersion.id, chargeReferenceId: chargeReference.id }
+        )
 
         chargeElement = await ChargeElementHelper.add({ chargeReferenceId: reviewChargeReference.chargeReferenceId })
-        reviewChargeElement = await ReviewChargeElementHelper.add({ reviewChargeReferenceId: reviewChargeReference.id, chargeElementId: chargeElement.id })
+        reviewChargeElement = await ReviewChargeElementHelper.add(
+          { reviewChargeReferenceId: reviewChargeReference.id, chargeElementId: chargeElement.id }
+        )
       })
 
       describe('that has a matching return', () => {

--- a/test/services/bill-runs/two-part-tariff/submit-amended-billable-returns.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/submit-amended-billable-returns.service.test.js
@@ -106,7 +106,13 @@ describe('Submit Amended Billable Returns Service', () => {
         })
 
         it('returns the page data for the view', async () => {
-          const result = await SubmitAmendedBillableReturnsService.go(billRunId, licenceId, reviewChargeElement.id, payload, yarStub)
+          const result = await SubmitAmendedBillableReturnsService.go(
+            billRunId,
+            licenceId,
+            reviewChargeElement.id,
+            payload,
+            yarStub
+          )
 
           expect(result).to.equal({
             activeNavBar: 'search',
@@ -131,7 +137,13 @@ describe('Submit Amended Billable Returns Service', () => {
         })
 
         it('returns page data with an error for the radio form element', async () => {
-          const result = await SubmitAmendedBillableReturnsService.go(billRunId, licenceId, reviewChargeElement.id, payload, yarStub)
+          const result = await SubmitAmendedBillableReturnsService.go(
+            billRunId,
+            licenceId,
+            reviewChargeElement.id,
+            payload,
+            yarStub
+          )
 
           expect(result.error).to.equal({
             message: 'Select the billable quantity',
@@ -151,7 +163,13 @@ describe('Submit Amended Billable Returns Service', () => {
         })
 
         it('returns the page data for the view', async () => {
-          const result = await SubmitAmendedBillableReturnsService.go(billRunId, licenceId, reviewChargeElement.id, payload, yarStub)
+          const result = await SubmitAmendedBillableReturnsService.go(
+            billRunId,
+            licenceId,
+            reviewChargeElement.id,
+            payload,
+            yarStub
+          )
 
           expect(result).to.equal({
             activeNavBar: 'search',
@@ -176,7 +194,13 @@ describe('Submit Amended Billable Returns Service', () => {
         })
 
         it('returns page data with an error for the custom quantity input form element', async () => {
-          const result = await SubmitAmendedBillableReturnsService.go(billRunId, licenceId, reviewChargeElement.id, payload, yarStub)
+          const result = await SubmitAmendedBillableReturnsService.go(
+            billRunId,
+            licenceId,
+            reviewChargeElement.id,
+            payload,
+            yarStub
+          )
 
           expect(result.error).to.equal({
             message: 'The quantity must be a number',


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/115

In [Exclude long strings from ESLint max-len rule](https://github.com/DEFRA/water-abstraction-system/pull/992) we updated our ESLint [max-len](https://eslint.style/rules/js/max-len) to exclude long strings or template literals from being flagged as issues.

That reduced the noise (there were lots of infractions!) and helped us see long lines of logic that should be refactored.

This fixes all the remaining `max-len` infractions.