### PR TITLE
Ensure parens used in all arrow functions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,6 +4,7 @@ module.exports = {
     '@stylistic/js'
   ],
   rules: {
+    '@stylistic/js/arrow-parens': ['error', 'always'],
     '@stylistic/js/max-len': ['error', {
       code: 120,
       ignoreStrings: true,

--- a/app/lib/base-notifier.lib.js
+++ b/app/lib/base-notifier.lib.js
@@ -103,7 +103,7 @@ class BaseNotifierLib {
           this._logger.error(notice.error, `${this.constructor.name} - Airbrake failed`)
         }
       })
-      .catch(err => {
+      .catch((err) => {
         this._logger.error(err, `${this.constructor.name} - Airbrake errored`)
       })
   }

--- a/app/plugins/airbrake.plugin.js
+++ b/app/plugins/airbrake.plugin.js
@@ -43,12 +43,12 @@ const AirbrakePlugin = {
             url: request.url.href
           }
         })
-        .then(notice => {
+        .then((notice) => {
           if (!notice.id) {
             server.logger.error({ message: `Airbrake notification failed: ${notice.error}`, error: notice.error })
           }
         })
-        .catch(error => {
+        .catch((error) => {
           server.logger.error({ message: `Airbrake notification errored: ${error}`, error })
         })
     })

--- a/app/server.js
+++ b/app/server.js
@@ -61,7 +61,7 @@ const start = async () => {
   return server
 }
 
-process.on('unhandledRejection', err => {
+process.on('unhandledRejection', (err) => {
   console.log(err)
   process.exit(1)
 })

--- a/app/services/bill-runs/supplementary/fetch-billing-accounts.service.js
+++ b/app/services/bill-runs/supplementary/fetch-billing-accounts.service.js
@@ -42,7 +42,7 @@ function _fetch (uniqueBillingAccountIds) {
 }
 
 function _makeObjects (models) {
-  return models.map(model => {
+  return models.map((model) => {
     return model.toJSON()
   })
 }

--- a/app/services/bill-runs/supplementary/fetch-charge-versions.service.js
+++ b/app/services/bill-runs/supplementary/fetch-charge-versions.service.js
@@ -63,7 +63,7 @@ async function _fetch (regionId, billingPeriod) {
       { column: 'chargeVersions.licenceId' }
     ])
     .withGraphFetched('licence')
-    .modifyGraph('licence', builder => {
+    .modifyGraph('licence', (builder) => {
       builder.select([
         'id',
         'licenceRef',
@@ -77,20 +77,20 @@ async function _fetch (regionId, billingPeriod) {
       ])
     })
     .withGraphFetched('licence.region')
-    .modifyGraph('licence.region', builder => {
+    .modifyGraph('licence.region', (builder) => {
       builder.select([
         'id',
         'chargeRegionId'
       ])
     })
     .withGraphFetched('changeReason')
-    .modifyGraph('changeReason', builder => {
+    .modifyGraph('changeReason', (builder) => {
       builder.select([
         'triggersMinimumCharge'
       ])
     })
     .withGraphFetched('chargeReferences')
-    .modifyGraph('chargeReferences', builder => {
+    .modifyGraph('chargeReferences', (builder) => {
       builder.select([
         'id',
         'source',
@@ -102,14 +102,14 @@ async function _fetch (regionId, billingPeriod) {
       ])
     })
     .withGraphFetched('chargeReferences.chargeCategory')
-    .modifyGraph('chargeReferences.chargeCategory', builder => {
+    .modifyGraph('chargeReferences.chargeCategory', (builder) => {
       builder.select([
         'reference',
         'shortDescription'
       ])
     })
     .withGraphFetched('chargeReferences.chargeElements')
-    .modifyGraph('chargeReferences.chargeElements', builder => {
+    .modifyGraph('chargeReferences.chargeElements', (builder) => {
       builder.select([
         'id',
         'abstractionPeriodStartDay',

--- a/app/services/bill-runs/supplementary/process-bill-run.service.js
+++ b/app/services/bill-runs/supplementary/process-bill-run.service.js
@@ -82,7 +82,7 @@ async function _finaliseBillRun (billRun, accumulatedLicenceIds, resultsOfProces
   await UnflagUnbilledLicencesService.go(billRun, allLicenceIds)
 
   // We set `isPopulated` to `true` if at least one processing result was truthy
-  const isPopulated = resultsOfProcessing.some(result => result)
+  const isPopulated = resultsOfProcessing.some((result) => result)
 
   // If there are no bill licences then the bill run is considered empty. We just need to set the status to indicate
   // this in the UI

--- a/app/services/bill-runs/two-part-tariff/fetch-return-logs-for-licence.service.js
+++ b/app/services/bill-runs/two-part-tariff/fetch-return-logs-for-licence.service.js
@@ -50,7 +50,7 @@ async function _fetch (licenceRef, billingPeriod) {
     .orderBy('startDate', 'ASC')
     .orderBy('returnReference', 'ASC')
     .withGraphFetched('returnSubmissions')
-    .modifyGraph('returnSubmissions', builder => {
+    .modifyGraph('returnSubmissions', (builder) => {
       builder
         .select([
           'id',
@@ -59,7 +59,7 @@ async function _fetch (licenceRef, billingPeriod) {
         .where('returnSubmissions.current', true)
     })
     .withGraphFetched('returnSubmissions.returnSubmissionLines')
-    .modifyGraph('returnSubmissions.returnSubmissionLines', builder => {
+    .modifyGraph('returnSubmissions.returnSubmissionLines', (builder) => {
       builder
         .select([
           'id',

--- a/app/services/health/info.service.js
+++ b/app/services/health/info.service.js
@@ -141,7 +141,7 @@ async function _getVirusScannerData () {
 }
 
 function _mapArrayToTextCells (rows) {
-  return rows.map(row => {
+  return rows.map((row) => {
     return [
       ...[{ text: row.name }],
       ...[{ text: row.completedCount }],

--- a/app/services/jobs/export/fetch-table-names.service.js
+++ b/app/services/jobs/export/fetch-table-names.service.js
@@ -39,7 +39,7 @@ async function _fetchTableNames (schemaName) {
 }
 
 function _pluckTableNames (tableData) {
-  return tableData.map(obj => obj.table_name)
+  return tableData.map((obj) => obj.table_name)
 }
 
 module.exports = {

--- a/db/wipe.database.js
+++ b/db/wipe.database.js
@@ -33,7 +33,7 @@ async function wipeDatabase () {
   console.log(`${dbConfig.connection.database} database wiped`)
 
   process.exit()
-})().catch(error => {
+})().catch((error) => {
   console.error(`Could not wipe ${dbConfig.connection.database}: ${error.message}`)
 
   process.exit(1)

--- a/test/presenters/base.presenter.test.js
+++ b/test/presenters/base.presenter.test.js
@@ -222,7 +222,7 @@ describe('Base presenter', () => {
         new Date('2021-10-12T14:41:10.511Z'),
         new Date('2021-11-12T14:41:10.511Z'),
         new Date('2021-12-12T14:41:10.511Z')
-      ].map(date => BasePresenter.formatChargingModuleDate(date))
+      ].map((date) => BasePresenter.formatChargingModuleDate(date))
 
       expect(results).to.equal([
         '01-JAN-2021',

--- a/test/presenters/charging-module/create-transaction.presenter.test.js
+++ b/test/presenters/charging-module/create-transaction.presenter.test.js
@@ -49,7 +49,7 @@ describe('Charging Module Create Transaction presenter', () => {
           ref('licences.regions:regionalChargeArea').castText().as('regionalChargeArea')
         ])
         .withGraphFetched('region')
-        .modifyGraph('licence.region', builder => {
+        .modifyGraph('licence.region', (builder) => {
           builder.select([
             'id',
             'chargeRegionId'

--- a/test/services/bill-runs/reissue/reissue-bill.service.test.js
+++ b/test/services/bill-runs/reissue/reissue-bill.service.test.js
@@ -206,7 +206,7 @@ describe('Reissue Bill service', () => {
       it('negative for credits', async () => {
         const result = await ReissueBillService.go(sourceBill, reissueBillRun)
 
-        const credits = result.transactions.filter(transaction => transaction.credit)
+        const credits = result.transactions.filter((transaction) => transaction.credit)
 
         credits.forEach((transaction) => {
           expect(transaction.netAmount).to.be.below(0)
@@ -216,7 +216,7 @@ describe('Reissue Bill service', () => {
       it('positive for debits', async () => {
         const result = await ReissueBillService.go(sourceBill, reissueBillRun)
 
-        const debits = result.transactions.filter(transaction => !transaction.credit)
+        const debits = result.transactions.filter((transaction) => !transaction.credit)
 
         debits.forEach((transaction) => {
           expect(transaction.netAmount).to.be.above(0)

--- a/test/services/idm/fetch-user-roles-and-groups.service.test.js
+++ b/test/services/idm/fetch-user-roles-and-groups.service.test.js
@@ -57,7 +57,7 @@ describe('Fetch User Roles And Groups service', () => {
     it("returns the user's roles", async () => {
       const result = await FetchUserRolesAndGroupsService.go(testUser.id)
 
-      const roles = result.roles.map(role => role.role)
+      const roles = result.roles.map((role) => role.role)
 
       expect(roles).to.have.length(2)
       expect(roles).to.only.include(['role_for_user', 'role_for_group'])
@@ -66,7 +66,7 @@ describe('Fetch User Roles And Groups service', () => {
     it("returns the user's groups", async () => {
       const result = await FetchUserRolesAndGroupsService.go(testUser.id)
 
-      const groups = result.groups.map(group => group.group)
+      const groups = result.groups.map((group) => group.group)
 
       expect(groups).to.have.length(1)
       expect(groups).to.equal(['wirs'])
@@ -80,7 +80,7 @@ describe('Fetch User Roles And Groups service', () => {
       it('returns only one instance of the role', async () => {
         const result = await FetchUserRolesAndGroupsService.go(testUser.id)
 
-        const roles = result.roles.map(role => role.role)
+        const roles = result.roles.map((role) => role.role)
 
         expect(roles).to.have.length(2)
         expect(roles).to.only.include(['role_for_user', 'role_for_group'])


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/115

We have a written convention that [all arrow functions should wrap params in parens even when there is only one](https://github.com/DEFRA/water-abstraction-team/blob/main/coding_conventions.md#arrow-functions).

We think code is clearer to follow and understand when it is _consistent_. JavaScript will allow you to skip adding them when there is only one param to an arrow function. But we think this inconsistency is not helpful to those new to the language or the team.

So, it is our convention to _always_ add parens. Now we are using ESLint we can make the tool highlight when this is missed rather than relying on reviewers.