### PR TITLE
Ensure strict mode directive in all files

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,7 +3,7 @@
 module.exports = {
   extends: 'standard', // Maintain Standard.js rules
   parserOptions: {
-    sourceType: 'commonjs'
+    sourceType: 'script'
   },
   plugins: [
     '@stylistic/js'

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,17 +1,23 @@
+'use strict'
+
 module.exports = {
   extends: 'standard', // Maintain Standard.js rules
+  parserOptions: {
+    sourceType: 'commonjs'
+  },
   plugins: [
     '@stylistic/js'
   ],
   rules: {
+    'import/extensions': ['error', 'always'],
+    strict: ['error', 'global'],
     '@stylistic/js/arrow-parens': ['error', 'always'],
     '@stylistic/js/max-len': ['error', {
       code: 120,
       ignoreStrings: true,
       ignoreTemplateLiterals: true,
       ignoreUrls: true
-    }],
-    'import/extensions': ['error', 'always']
+    }]
   }
 }
 


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/115

It is currently an unwritten convention (we are [working on](https://github.com/DEFRA/water-abstraction-team/pull/117) fixing that!) to add 'use strict' to the top of all our files. Why?

> JavaScript's strict mode is a way to opt in to a restricted variant of JavaScript, thereby implicitly opting-out of "sloppy mode".
> [MSDN docs - Strict mode](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode)

When the alternate mode is named 'sloppy', would you want to use it!?

The docs do provide some further explanation of what declaring strict mode means

> Strict mode makes several changes to normal JavaScript semantics:
>
> 1. Eliminates some JavaScript silent errors by changing them to throw errors.
> 2. Fixes mistakes that make it difficult for JavaScript engines to perform optimizations: strict mode code can sometimes be made to run faster than identical code that's not strict mode.
> 3. Prohibits some syntax likely to be defined in future versions of ECMAScript.

For these reasons, this change updates our ESLint rules to ensure we do this.