### PR TITLE
Ensure use of block body for arrow functions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,6 +13,7 @@ module.exports = {
     'import/extensions': ['error', 'always'],
     strict: ['error', 'global'],
     '@stylistic/js/arrow-parens': ['error', 'always'],
+    '@stylistic/js/implicit-arrow-linebreak': ['off'],
     '@stylistic/js/max-len': ['error', {
       code: 120,
       ignoreStrings: true,

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,6 +9,7 @@ module.exports = {
     '@stylistic/js'
   ],
   rules: {
+    'arrow-body-style': ['error', 'always'],
     'import/extensions': ['error', 'always'],
     strict: ['error', 'global'],
     '@stylistic/js/arrow-parens': ['error', 'always'],

--- a/app/lib/legacy-db-snake-case-mappers.lib.js
+++ b/app/lib/legacy-db-snake-case-mappers.lib.js
@@ -36,8 +36,12 @@ const { camelCase, knexIdentifierMappers, snakeCase } = require('objection/lib/u
  */
 function legacyDbSnakeCaseMappers (opt = {}) {
   return knexIdentifierMappers({
-    parse: (str) => _legacyCamelCase(str, opt),
-    format: (str) => _legacySnakeCase(str, opt)
+    parse: (str) => {
+      return _legacyCamelCase(str, opt)
+    },
+    format: (str) => {
+      return _legacySnakeCase(str, opt)
+    }
   })
 }
 

--- a/app/models/contact.model.js
+++ b/app/models/contact.model.js
@@ -89,7 +89,9 @@ class ContactModel extends BaseModel {
       this.suffix
     ]
 
-    const onlyPopulatedNameParts = allNameParts.filter((item) => item)
+    const onlyPopulatedNameParts = allNameParts.filter((item) => {
+      return item
+    })
 
     return onlyPopulatedNameParts.join(' ')
   }

--- a/app/models/licence.model.js
+++ b/app/models/licence.model.js
@@ -221,7 +221,9 @@ class LicenceModel extends BaseModel {
       { date: this.expiredDate, priority: 3, reason: 'expired' }
     ]
 
-    const filteredDates = endDates.filter((endDate) => endDate.date)
+    const filteredDates = endDates.filter((endDate) => {
+      return endDate.date
+    })
 
     if (filteredDates.length === 0) {
       return null

--- a/app/presenters/bills/view-bill.presenter.js
+++ b/app/presenters/bills/view-bill.presenter.js
@@ -67,7 +67,9 @@ function _addressLines (billingAccount) {
     address.country
   ]
 
-  return addressParts.filter((part) => part)
+  return addressParts.filter((part) => {
+    return part
+  })
 }
 
 function _billRunType (billRun) {

--- a/app/services/bill-runs/annual/process-billing-period.service.js
+++ b/app/services/bill-runs/annual/process-billing-period.service.js
@@ -68,7 +68,9 @@ async function go (billRun, billingPeriod, billingAccounts) {
     // make that assumption.
     const results = await Promise.all(processes)
     if (!billRunIsPopulated) {
-      billRunIsPopulated = results.some((result) => result)
+      billRunIsPopulated = results.some((result) => {
+        return result
+      })
     }
   }
 

--- a/app/services/bill-runs/determine-charge-period.service.js
+++ b/app/services/bill-runs/determine-charge-period.service.js
@@ -73,7 +73,9 @@ function go (chargeVersion, billingPeriod) {
     chargeVersion.licence.expiredDate,
     chargeVersion.licence.lapsedDate,
     chargeVersion.licence.revokedDate
-  ].filter((timestamp) => timestamp)
+  ].filter((timestamp) => {
+    return timestamp
+  })
 
   const earliestEndDateTimestamp = Math.min(...endDateTimestamps)
 

--- a/app/services/bill-runs/reissue/reissue-bill.service.js
+++ b/app/services/bill-runs/reissue/reissue-bill.service.js
@@ -147,7 +147,9 @@ async function _pauseUntilNotPending (billRunExternalId) {
     // bombarding the CM with requests
     if (status) {
       // Create a new promise that resolves after 1000ms and wait until it's resolved before continuing
-      await new Promise((resolve) => setTimeout(resolve, 1000))
+      await new Promise((resolve) => {
+        return setTimeout(resolve, 1000)
+      })
     }
 
     const result = await ChargingModuleViewBillRunStatusRequest.send(billRunExternalId)

--- a/app/services/bill-runs/supplementary/fetch-previous-transactions.service.js
+++ b/app/services/bill-runs/supplementary/fetch-previous-transactions.service.js
@@ -32,8 +32,12 @@ async function go (billingAccountId, licenceId, financialYearEnding) {
  * to know only about debits that have not been credited.
  */
 function _cleanse (transactions) {
-  const credits = transactions.filter((transaction) => transaction.credit)
-  const debits = transactions.filter((transaction) => !transaction.credit)
+  const credits = transactions.filter((transaction) => {
+    return transaction.credit
+  })
+  const debits = transactions.filter((transaction) => {
+    return !transaction.credit
+  })
 
   credits.forEach((credit) => {
     const debitIndex = debits.findIndex((debit) => {

--- a/app/services/bill-runs/supplementary/process-bill-run.service.js
+++ b/app/services/bill-runs/supplementary/process-bill-run.service.js
@@ -82,7 +82,9 @@ async function _finaliseBillRun (billRun, accumulatedLicenceIds, resultsOfProces
   await UnflagUnbilledLicencesService.go(billRun, allLicenceIds)
 
   // We set `isPopulated` to `true` if at least one processing result was truthy
-  const isPopulated = resultsOfProcessing.some((result) => result)
+  const isPopulated = resultsOfProcessing.some((result) => {
+    return result
+  })
 
   // If there are no bill licences then the bill run is considered empty. We just need to set the status to indicate
   // this in the UI

--- a/app/services/health/fetch-import-jobs.service.js
+++ b/app/services/health/fetch-import-jobs.service.js
@@ -45,11 +45,11 @@ async function go () {
         .from('water_import.job')
         .whereIn('state', ['failed', 'completed', 'active', 'created'])
         .whereIn('name', PGBOSS_JOBS_ARRAY)
-        .where((builder) =>
-          builder
+        .where((builder) => {
+          return builder
             .where('createdon', '>', currentDateMinusOneDay)
             .orWhere('completedon', '>', currentDateMinusOneDay)
-        )
+        })
         .unionAll(
           db
             .select(
@@ -60,11 +60,11 @@ async function go () {
             .from('water_import.archive')
             .whereIn('state', ['failed', 'completed', 'active', 'created'])
             .whereIn('name', PGBOSS_JOBS_ARRAY)
-            .where((builder) =>
-              builder
+            .where((builder) => {
+              return builder
                 .where('createdon', '>', currentDateMinusOneDay)
                 .orWhere('completedon', '>', currentDateMinusOneDay)
-            )
+            })
         ))
         .as('jobs')
     )

--- a/app/services/jobs/export/fetch-table-names.service.js
+++ b/app/services/jobs/export/fetch-table-names.service.js
@@ -39,7 +39,9 @@ async function _fetchTableNames (schemaName) {
 }
 
 function _pluckTableNames (tableData) {
-  return tableData.map((obj) => obj.table_name)
+  return tableData.map((obj) => {
+    return obj.table_name
+  })
 }
 
 module.exports = {

--- a/app/services/plugins/filter-routes.service.js
+++ b/app/services/plugins/filter-routes.service.js
@@ -42,7 +42,9 @@ function _protectedEnvironment (environment) {
 }
 
 function _filteredRoutes (routes) {
-  return routes.filter((route) => !route?.options?.app?.excludeFromProd)
+  return routes.filter((route) => {
+    return !route?.options?.app?.excludeFromProd
+  })
 }
 
 module.exports = {

--- a/db/seeds/01-users.js
+++ b/db/seeds/01-users.js
@@ -97,7 +97,9 @@ async function _insertUsersWhereNotExists (knex) {
 }
 
 async function _insertUserGroupsWhereNotExists (knex) {
-  const seedUsersWithGroups = seedUsers.filter((seedData) => seedData.group)
+  const seedUsersWithGroups = seedUsers.filter((seedData) => {
+    return seedData.group
+  })
 
   for (const seedUser of seedUsersWithGroups) {
     const existingUserGroup = await knex('idm.userGroups')
@@ -121,11 +123,15 @@ async function _updateSeedUsersWithUserIdAndGroupId (knex) {
   const groups = await _groups(knex)
 
   seedUsers.forEach((seedUser) => {
-    const user = users.find(({ userName }) => userName === seedUser.userName)
+    const user = users.find(({ userName }) => {
+      return userName === seedUser.userName
+    })
     seedUser.userId = user.userId
 
     if (seedUser.group) {
-      const userGroup = groups.find(({ group }) => group === seedUser.group)
+      const userGroup = groups.find(({ group }) => {
+        return group === seedUser.group
+      })
       seedUser.groupId = userGroup.groupId
     }
   })

--- a/test/lib/boom-notifier.lib.test.js
+++ b/test/lib/boom-notifier.lib.test.js
@@ -32,7 +32,9 @@ describe('BoomNotifierLib class', () => {
     it('throws a Boom error with the correct message and data', async () => {
       const testNotifier = new BoomNotifierLib(id, pinoFake, airbrakeFake)
 
-      expect(() => testNotifier.omfg(message, data)).to.throw(Error, { message, data })
+      expect(() => {
+        return testNotifier.omfg(message, data)
+      }).to.throw(Error, { message, data })
     })
   })
 })

--- a/test/lib/global-notifier.lib.test.js
+++ b/test/lib/global-notifier.lib.test.js
@@ -33,13 +33,17 @@ describe('GlobalNotifierLib class', () => {
   describe('#constructor', () => {
     describe("when the 'logger' argument is not provided", () => {
       it('throws an error', () => {
-        expect(() => new GlobalNotifierLib(null, airbrakeFake)).to.throw()
+        expect(() => {
+          return new GlobalNotifierLib(null, airbrakeFake)
+        }).to.throw()
       })
     })
 
     describe("when the 'notifier' argument is not provided", () => {
       it('throws an error', () => {
-        expect(() => new GlobalNotifierLib(pinoFake)).to.throw()
+        expect(() => {
+          return new GlobalNotifierLib(pinoFake)
+        }).to.throw()
       })
     })
   })

--- a/test/presenters/base.presenter.test.js
+++ b/test/presenters/base.presenter.test.js
@@ -222,7 +222,9 @@ describe('Base presenter', () => {
         new Date('2021-10-12T14:41:10.511Z'),
         new Date('2021-11-12T14:41:10.511Z'),
         new Date('2021-12-12T14:41:10.511Z')
-      ].map((date) => BasePresenter.formatChargingModuleDate(date))
+      ].map((date) => {
+        return BasePresenter.formatChargingModuleDate(date)
+      })
 
       expect(results).to.equal([
         '01-JAN-2021',

--- a/test/requests/base.request.test.js
+++ b/test/requests/base.request.test.js
@@ -115,7 +115,9 @@ describe('Base Request', () => {
         describe('and all retries fail', () => {
           beforeEach(async () => {
             Nock(testDomain)
-              .delete(() => true)
+              .delete(() => {
+                return true
+              })
               .replyWithError({ code: 'ECONNRESET' })
               .persist()
           })
@@ -161,9 +163,13 @@ describe('Base Request', () => {
           beforeEach(async () => {
             // The first response will error, the second response will return OK
             Nock(testDomain)
-              .delete(() => true)
+              .delete(() => {
+                return true
+              })
               .replyWithError({ code: 'ECONNRESET' })
-              .delete(() => true)
+              .delete(() => {
+                return true
+              })
               .reply(200, { data: 'econnreset hello world' })
           })
 
@@ -203,7 +209,9 @@ describe('Base Request', () => {
         describe('and all retries fail', { timeout: 5000 }, () => {
           beforeEach(async () => {
             Nock(testDomain)
-              .delete(() => true)
+              .delete(() => {
+                return true
+              })
               .delay(100)
               .reply(200, { data: 'hello world' })
               .persist()
@@ -250,10 +258,14 @@ describe('Base Request', () => {
           beforeEach(async () => {
             // The first response will time out, the second response will return OK
             Nock(testDomain)
-              .delete(() => true)
+              .delete(() => {
+                return true
+              })
               .delay(100)
               .reply(200, { data: 'hello world' })
-              .delete(() => true)
+              .delete(() => {
+                return true
+              })
               .reply(200, { data: 'delayed hello world' })
           })
 
@@ -383,7 +395,9 @@ describe('Base Request', () => {
         describe('and all retries fail', () => {
           beforeEach(async () => {
             Nock(testDomain)
-              .get(() => true)
+              .get(() => {
+                return true
+              })
               .replyWithError({ code: 'ECONNRESET' })
               .persist()
           })
@@ -429,9 +443,13 @@ describe('Base Request', () => {
           beforeEach(async () => {
             // The first response will error, the second response will return OK
             Nock(testDomain)
-              .get(() => true)
+              .get(() => {
+                return true
+              })
               .replyWithError({ code: 'ECONNRESET' })
-              .get(() => true)
+              .get(() => {
+                return true
+              })
               .reply(200, { data: 'econnreset hello world' })
           })
 
@@ -471,7 +489,9 @@ describe('Base Request', () => {
         describe('and all retries fail', { timeout: 5000 }, () => {
           beforeEach(async () => {
             Nock(testDomain)
-              .get(() => true)
+              .get(() => {
+                return true
+              })
               .delay(100)
               .reply(200, { data: 'hello world' })
               .persist()
@@ -518,10 +538,14 @@ describe('Base Request', () => {
           beforeEach(async () => {
             // The first response will time out, the second response will return OK
             Nock(testDomain)
-              .get(() => true)
+              .get(() => {
+                return true
+              })
               .delay(100)
               .reply(200, { data: 'hello world' })
-              .get(() => true)
+              .get(() => {
+                return true
+              })
               .reply(200, { data: 'delayed hello world' })
           })
 
@@ -651,7 +675,9 @@ describe('Base Request', () => {
         describe('and all retries fail', () => {
           beforeEach(async () => {
             Nock(testDomain)
-              .patch(() => true)
+              .patch(() => {
+                return true
+              })
               .replyWithError({ code: 'ECONNRESET' })
               .persist()
           })
@@ -697,9 +723,13 @@ describe('Base Request', () => {
           beforeEach(async () => {
             // The first response will error, the second response will return OK
             Nock(testDomain)
-              .patch(() => true)
+              .patch(() => {
+                return true
+              })
               .replyWithError({ code: 'ECONNRESET' })
-              .patch(() => true)
+              .patch(() => {
+                return true
+              })
               .reply(200, { data: 'econnreset hello world' })
           })
 
@@ -739,7 +769,9 @@ describe('Base Request', () => {
         describe('and all retries fail', { timeout: 5000 }, () => {
           beforeEach(async () => {
             Nock(testDomain)
-              .patch(() => true)
+              .patch(() => {
+                return true
+              })
               .delay(100)
               .reply(200, { data: 'hello world' })
               .persist()
@@ -786,10 +818,14 @@ describe('Base Request', () => {
           beforeEach(async () => {
             // The first response will time out, the second response will return OK
             Nock(testDomain)
-              .patch(() => true)
+              .patch(() => {
+                return true
+              })
               .delay(100)
               .reply(200, { data: 'hello world' })
-              .patch(() => true)
+              .patch(() => {
+                return true
+              })
               .reply(200, { data: 'delayed hello world' })
           })
 
@@ -919,7 +955,9 @@ describe('Base Request', () => {
         describe('and all retries fail', () => {
           beforeEach(async () => {
             Nock(testDomain)
-              .post(() => true)
+              .post(() => {
+                return true
+              })
               .replyWithError({ code: 'ECONNRESET' })
               .persist()
           })
@@ -965,9 +1003,13 @@ describe('Base Request', () => {
           beforeEach(async () => {
             // The first response will error, the second response will return OK
             Nock(testDomain)
-              .post(() => true)
+              .post(() => {
+                return true
+              })
               .replyWithError({ code: 'ECONNRESET' })
-              .post(() => true)
+              .post(() => {
+                return true
+              })
               .reply(200, { data: 'econnreset hello world' })
           })
 
@@ -1007,7 +1049,9 @@ describe('Base Request', () => {
         describe('and all retries fail', { timeout: 5000 }, () => {
           beforeEach(async () => {
             Nock(testDomain)
-              .post(() => true)
+              .post(() => {
+                return true
+              })
               .delay(100)
               .reply(200, { data: 'hello world' })
               .persist()
@@ -1054,10 +1098,14 @@ describe('Base Request', () => {
           beforeEach(async () => {
             // The first response will time out, the second response will return OK
             Nock(testDomain)
-              .post(() => true)
+              .post(() => {
+                return true
+              })
               .delay(100)
               .reply(200, { data: 'hello world' })
-              .post(() => true)
+              .post(() => {
+                return true
+              })
               .reply(200, { data: 'delayed hello world' })
           })
 

--- a/test/services/bill-runs/reissue/reissue-bill.service.test.js
+++ b/test/services/bill-runs/reissue/reissue-bill.service.test.js
@@ -206,7 +206,9 @@ describe('Reissue Bill service', () => {
       it('negative for credits', async () => {
         const result = await ReissueBillService.go(sourceBill, reissueBillRun)
 
-        const credits = result.transactions.filter((transaction) => transaction.credit)
+        const credits = result.transactions.filter((transaction) => {
+          return transaction.credit
+        })
 
         credits.forEach((transaction) => {
           expect(transaction.netAmount).to.be.below(0)
@@ -216,7 +218,9 @@ describe('Reissue Bill service', () => {
       it('positive for debits', async () => {
         const result = await ReissueBillService.go(sourceBill, reissueBillRun)
 
-        const debits = result.transactions.filter((transaction) => !transaction.credit)
+        const debits = result.transactions.filter((transaction) => {
+          return !transaction.credit
+        })
 
         debits.forEach((transaction) => {
           expect(transaction.netAmount).to.be.above(0)

--- a/test/services/bill-runs/supplementary/fetch-previous-transactions.service.test.js
+++ b/test/services/bill-runs/supplementary/fetch-previous-transactions.service.test.js
@@ -154,8 +154,12 @@ describe('Fetch Previous Transactions service', () => {
               )
 
               expect(results).to.have.length(2)
-              expect(results.every((transaction) => !transaction.credit)).to.be.true()
-              expect(results.find((transaction) => transaction.description === 'follow up')).to.exist()
+              expect(results.every((transaction) => {
+                return !transaction.credit
+              })).to.be.true()
+              expect(results.find((transaction) => {
+                return transaction.description === 'follow up'
+              })).to.exist()
             })
           })
         })

--- a/test/services/health/info.service.test.js
+++ b/test/services/health/info.service.test.js
@@ -115,7 +115,11 @@ describe('Info service', () => {
           stdout: 'ClamAV 9.99.9/26685/Mon Oct 10 08:00:01 2022\n',
           stderror: null
         })
-      const utilStub = { promisify: Sinon.stub().callsFake(() => execStub) }
+      const utilStub = {
+        promisify: Sinon.stub().callsFake(() => {
+          return execStub
+        })
+      }
       InfoService = Proxyquire('../../../app/services/health/info.service', { util: utilStub })
     })
 
@@ -171,7 +175,11 @@ describe('Info service', () => {
           stdout: 'ClamAV 9.99.9/26685/Mon Oct 10 08:00:01 2022\n',
           stderror: null
         })
-      const utilStub = { promisify: Sinon.stub().callsFake(() => execStub) }
+      const utilStub = {
+        promisify: Sinon.stub().callsFake(() => {
+          return execStub
+        })
+      }
       InfoService = Proxyquire('../../../app/services/health/info.service', { util: utilStub })
     })
 
@@ -222,7 +230,11 @@ describe('Info service', () => {
             stdout: null,
             stderr: 'Could not connect to clamd'
           })
-        const utilStub = { promisify: Sinon.stub().callsFake(() => execStub) }
+        const utilStub = {
+          promisify: Sinon.stub().callsFake(() => {
+            return execStub
+          })
+        }
         InfoService = Proxyquire('../../../app/services/health/info.service', { util: utilStub })
       })
 
@@ -249,7 +261,11 @@ describe('Info service', () => {
           .stub()
           .withArgs('clamdscan --version')
           .throwsException(new Error('ClamAV check went boom'))
-        const utilStub = { promisify: Sinon.stub().callsFake(() => execStub) }
+        const utilStub = {
+          promisify: Sinon.stub().callsFake(() => {
+            return execStub
+          })
+        }
         InfoService = Proxyquire('../../../app/services/health/info.service', { util: utilStub })
       })
 
@@ -286,7 +302,11 @@ describe('Info service', () => {
           stdout: 'ClamAV 9.99.9/26685/Mon Oct 10 08:00:01 2022\n',
           stderror: null
         })
-      const utilStub = { promisify: Sinon.stub().callsFake(() => execStub) }
+      const utilStub = {
+        promisify: Sinon.stub().callsFake(() => {
+          return execStub
+        })
+      }
       InfoService = Proxyquire('../../../app/services/health/info.service', { util: utilStub })
     })
 
@@ -343,7 +363,11 @@ describe('Info service', () => {
           stdout: 'ClamAV 9.99.9/26685/Mon Oct 10 08:00:01 2022\n',
           stderror: null
         })
-      const utilStub = { promisify: Sinon.stub().callsFake(() => execStub) }
+      const utilStub = {
+        promisify: Sinon.stub().callsFake(() => {
+          return execStub
+        })
+      }
       InfoService = Proxyquire('../../../app/services/health/info.service', { util: utilStub })
 
       redisStub.returns({ ping: Sinon.stub().resolves(), disconnect: Sinon.stub().resolves() })

--- a/test/services/idm/fetch-user-roles-and-groups.service.test.js
+++ b/test/services/idm/fetch-user-roles-and-groups.service.test.js
@@ -57,7 +57,9 @@ describe('Fetch User Roles And Groups service', () => {
     it("returns the user's roles", async () => {
       const result = await FetchUserRolesAndGroupsService.go(testUser.id)
 
-      const roles = result.roles.map((role) => role.role)
+      const roles = result.roles.map((role) => {
+        return role.role
+      })
 
       expect(roles).to.have.length(2)
       expect(roles).to.only.include(['role_for_user', 'role_for_group'])
@@ -66,7 +68,9 @@ describe('Fetch User Roles And Groups service', () => {
     it("returns the user's groups", async () => {
       const result = await FetchUserRolesAndGroupsService.go(testUser.id)
 
-      const groups = result.groups.map((group) => group.group)
+      const groups = result.groups.map((group) => {
+        return group.group
+      })
 
       expect(groups).to.have.length(1)
       expect(groups).to.equal(['wirs'])
@@ -80,7 +84,9 @@ describe('Fetch User Roles And Groups service', () => {
       it('returns only one instance of the role', async () => {
         const result = await FetchUserRolesAndGroupsService.go(testUser.id)
 
-        const roles = result.roles.map((role) => role.role)
+        const roles = result.roles.map((role) => {
+          return role.role
+        })
 
         expect(roles).to.have.length(2)
         expect(roles).to.only.include(['role_for_user', 'role_for_group'])


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/115

Just like [parens in arrow functions](https://github.com/DEFRA/water-abstraction-system/pull/1004) how you write an [arrow function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions) can differ.

```javascript
const materials = [
  'Hydrogen',
  'Helium',
  'Lithium',
  'Beryllium'
]

// Block body
materials.forEach((material) => {
  console.log(`${material} - ${material.length}`)
})

// Concise body
materials.forEach((material) => console.log(`${material} - ${material.length}`))
```

The _block-body_ version can be applied in all cases. But like with parens where devs will often drop the parens when there is only 1 param, they'll use _concise_ for simple arrow functions and _block-body_ for the rest.

To us though, the argument is the same. For those new or inexperienced with JavaScript, this inconsistency can be confusing and a blocker to progressing with the language. The more we can do to keep the code base simple and consistent, the easier new folks will find working with it.

So, this change enables [the rule in ESLint](https://eslint.org/docs/latest/rules/arrow-body-style) that requires all arrow functions to use the block-body.

---

The [ESLint stylistic plugin](https://eslint.style/) we use has a related rule; [https://eslint.style/rules/js/implicit-arrow-linebreak#when-not-to-use-it](https://eslint.style/rules/js/implicit-arrow-linebreak#when-not-to-use-it) which suggests it should not be used when `arrow-body-style` is set to 'always'. This is why it is disabled as part of this change.