### PR TITLE
Ensure blank line b4 function return statements

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,7 +9,11 @@ module.exports = {
       ignoreStrings: true,
       ignoreTemplateLiterals: true,
       ignoreUrls: true
-    }]
+    }],
+    '@stylistic/js/padding-line-between-statements': [
+      'error',
+      { blankLine: 'always', prev: '*', next: 'return' }
+    ]
   }
 }
 

--- a/app/controllers/return-requirements.controller.js
+++ b/app/controllers/return-requirements.controller.js
@@ -210,6 +210,7 @@ async function startDate (request, h) {
   const { sessionId } = request.params
 
   const pageData = await StartDateService.go(sessionId)
+
   return h.view('return-requirements/start-date.njk', {
     ...pageData
   })

--- a/app/presenters/bill-runs/create-bill-run-event.presenter.js
+++ b/app/presenters/bill-runs/create-bill-run-event.presenter.js
@@ -23,6 +23,7 @@ function go (billRun) {
     status,
     toFinancialYearEnding
   } = billRun
+
   return {
     batch: {
       id,

--- a/app/presenters/bill-runs/two-part-tariff/charge-reference-details.presenter.js
+++ b/app/presenters/bill-runs/two-part-tariff/charge-reference-details.presenter.js
@@ -98,6 +98,7 @@ function _prepareDate (startDate, endDate) {
 function _totalBillableReturns (reviewChargeElements) {
   return reviewChargeElements.reduce((total, reviewChargeElement) => {
     total += reviewChargeElement.amendedAllocated
+
     return total
   }, 0)
 }

--- a/app/presenters/licences/view-licence-summary.presenter.js
+++ b/app/presenters/licences/view-licence-summary.presenter.js
@@ -148,6 +148,7 @@ function _generateAbstractionPeriods (licenceVersions) {
   const formattedAbstactionPeriods = licenceVersions[0].licenceVersionPurposes.map((purpose) => {
     const startDate = formatAbstractionDate(purpose.abstractionPeriodStartDay, purpose.abstractionPeriodStartMonth)
     const endDate = formatAbstractionDate(purpose.abstractionPeriodEndDay, purpose.abstractionPeriodEndMonth)
+
     return `${startDate} to ${endDate}`
   })
 

--- a/app/services/bill-runs/annual/process-bill-run.service.js
+++ b/app/services/bill-runs/annual/process-bill-run.service.js
@@ -73,6 +73,7 @@ async function _finaliseBillRun (billRun, billRunPopulated) {
   // this in the UI
   if (!billRunPopulated) {
     await _updateStatus(billRun.id, 'empty')
+
     return
   }
 

--- a/app/services/bill-runs/calculate-authorised-and-billable-days.service.js
+++ b/app/services/bill-runs/calculate-authorised-and-billable-days.service.js
@@ -146,6 +146,7 @@ function _consolidateAndCalculate (referencePeriod, abstractionsPeriods) {
 
   const totalDays = consolidatedAbstractionPeriods.reduce((acc, abstractionPeriod) => {
     const abstractionOverlapPeriod = _calculateAbstractionOverlapPeriod(referencePeriod, abstractionPeriod)
+
     return acc + _calculateDays(abstractionOverlapPeriod)
   }, 0)
 

--- a/app/services/bill-runs/supplementary/pre-generate-billing-data.service.js
+++ b/app/services/bill-runs/supplementary/pre-generate-billing-data.service.js
@@ -100,6 +100,7 @@ function _billLicenceKey (billId, licenceId) {
 function _preGenerateBills (billingAccounts, billRunId, billingPeriod) {
   const keyedBills = billingAccounts.reduce((acc, billingAccount) => {
     const { id: billingAccountId, accountNumber } = billingAccount
+
     // Note that the array of billing accounts will already have been deduped so we don't need to check whether a
     // bill licence already exists in the object before generating one
     return {

--- a/app/services/bill-runs/supplementary/process-bill-run.service.js
+++ b/app/services/bill-runs/supplementary/process-bill-run.service.js
@@ -88,6 +88,7 @@ async function _finaliseBillRun (billRun, accumulatedLicenceIds, resultsOfProces
   // this in the UI
   if (!isPopulated) {
     await _updateStatus(billRun.id, 'empty')
+
     return
   }
 

--- a/app/services/bill-runs/two-part-tariff/submit-review-licence.service.js
+++ b/app/services/bill-runs/two-part-tariff/submit-review-licence.service.js
@@ -39,11 +39,13 @@ function _bannerMessage (yar, parsedPayload) {
 
   if (status) {
     yar.flash('banner', `Licence changed to ${status}.`)
+
     return
   }
 
   if (progress) {
     yar.flash('banner', 'This licence has been marked.')
+
     return
   }
 

--- a/app/services/health/fetch-system-info.service.js
+++ b/app/services/health/fetch-system-info.service.js
@@ -29,6 +29,7 @@ async function go () {
 async function _getCommitHash () {
   try {
     const { stdout, stderr } = await exec('git rev-parse HEAD')
+
     return stderr ? `ERROR: ${stderr}` : stdout.replace('\n', '')
   } catch (error) {
     return `ERROR: ${error.message}`

--- a/app/services/health/info.service.js
+++ b/app/services/health/info.service.js
@@ -134,6 +134,7 @@ async function _getRedisConnectivityData () {
 async function _getVirusScannerData () {
   try {
     const { stdout, stderr } = await exec('clamdscan --version')
+
     return stderr ? `ERROR: ${stderr}` : stdout
   } catch (error) {
     return `ERROR: ${error.message}`

--- a/app/services/idm/fetch-user-roles-and-groups.service.js
+++ b/app/services/idm/fetch-user-roles-and-groups.service.js
@@ -72,6 +72,7 @@ function _extractRolesFromGroups (groups) {
   return groups.flatMap((group) => {
     const { roles } = group
     delete group.roles
+
     return roles
   })
 }

--- a/app/services/licences/fetch-licence.service.js
+++ b/app/services/licences/fetch-licence.service.js
@@ -54,6 +54,7 @@ async function _fetchLicence (id) {
       ])
     })
     .modify('registeredToAndLicenceName')
+
   return result
 }
 

--- a/app/services/return-requirements/check-licence-ended.service.js
+++ b/app/services/return-requirements/check-licence-ended.service.js
@@ -23,6 +23,7 @@ const LicenceModel = require('../../models/licence.model.js')
 async function go (id) {
   const licence = await _fetchLicence(id)
   const licenceEnded = _licenceEnded(licence)
+
   return licenceEnded
 }
 

--- a/app/validators/return-requirements/start-date.validator.js
+++ b/app/validators/return-requirements/start-date.validator.js
@@ -36,6 +36,7 @@ function go (payload, licenceStartDate, licenceEndDate) {
 
   if (selectedOption === 'anotherStartDate') {
     payload.fullDate = _fullDate(payload)
+
     return _validateAnotherStartDate(payload, licenceStartDate, licenceEndDate)
   }
 


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/115

This has been an unwritten convention we often pick up in the PRs of those new to the team. We like to see a blank line before the `return` statement in a function. We believe it helps make the code easier to follow and understand.

```javascript
// Bad
function rubbishNameGenerator () {
  const firstName = 'John'
  const lastName = 'Doe'
  return `${firstName} ${lastName}`
}

// Good
function rubbishNameGenerator () {
  const firstName = 'John'
  const lastName = 'Doe'

  return `${firstName} ${lastName}`
}
```

But we don't want to see it all the time!

```javascript
// Bad
function rubbishNameGeneratorV2 (useAlternate = false) {
  if (useAlternate) {

    return 'Jane Doe'
  }

  return 'John Doe'
}

// Good
function rubbishNameGeneratorV2 (useAlternate = false) {
  if (useAlternate) {
    return 'Jane Doe'
  }

  return 'John Doe'
}
```

We weren't sure we could make ESLint see the difference but it turns out we can! So, this change enables and adds an initial configuration for the rule [padding-line-between-statements](https://eslint.style/rules/js/padding-line-between-statements).

> We expect to expand the config to cover some more unwritten conventions regarding white space in our code. But those will come separately!