### PR TITLE
Add eslint rule to enforce file extenstions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,7 +9,8 @@ module.exports = {
       ignoreStrings: true,
       ignoreTemplateLiterals: true,
       ignoreUrls: true
-    }]
+    }],
+    'import/extensions': ['error', 'always']
   }
 }
 


### PR DESCRIPTION
Reference to the coding_convention - https://github.com/DEFRA/water-abstraction-team/blob/main/coding_conventions.md#add-the-js-extension

When linking to an internal module in our require() statements always include the *.js extension.

```
// Good
const RequestLib = require('../lib/request.lib.js')

// Bad
const RequestLib = require('../lib/request.lib')
```

We know 😝 that you don't have to and that generally the convention is not to. But we still hold out hope that one day we'll switch our main repo from CommonJS to ES6 modules. The extension is required when using import and the work of migrating is made easier if the existing require() statements already include it.