### PR TITLE
Adding multiple return requirements to the session

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,17 +1,23 @@
+'use strict'
+
 module.exports = {
   extends: 'standard', // Maintain Standard.js rules
+  parserOptions: {
+    sourceType: 'script'
+  },
   plugins: [
     '@stylistic/js'
   ],
   rules: {
+    'import/extensions': ['error', 'always'],
+    strict: ['error', 'global'],
     '@stylistic/js/arrow-parens': ['error', 'always'],
     '@stylistic/js/max-len': ['error', {
       code: 120,
       ignoreStrings: true,
       ignoreTemplateLiterals: true,
       ignoreUrls: true
-    }],
-    'import/extensions': ['error', 'always']
+    }]
   }
 }
 

--- a/app/controllers/return-requirements.controller.js
+++ b/app/controllers/return-requirements.controller.js
@@ -6,6 +6,7 @@
  */
 
 const AbstractionPeriodService = require('../services/return-requirements/abstraction-period.service.js')
+const AddService = require('../services/return-requirements/add.service.js')
 const AgreementsExceptionsService = require('../services/return-requirements/agreements-exceptions.service.js')
 const CancelService = require('../services/return-requirements/cancel.service.js')
 const CheckService = require('../services/return-requirements/check.service.js')
@@ -46,6 +47,14 @@ async function abstractionPeriod (request, h) {
   return h.view('return-requirements/abstraction-period.njk', {
     ...pageData
   })
+}
+
+async function add (request, h) {
+  const { sessionId } = request.params
+
+  const requirementIndex = await AddService.go(sessionId)
+
+  return h.redirect(`/system/return-requirements/${sessionId}/purpose/${requirementIndex}`)
 }
 
 async function agreementsExceptions (request, h) {
@@ -437,6 +446,7 @@ async function submitStartDate (request, h) {
 
 module.exports = {
   abstractionPeriod,
+  add,
   agreementsExceptions,
   approved,
   cancel,

--- a/app/presenters/return-requirements/check.presenter.js
+++ b/app/presenters/return-requirements/check.presenter.js
@@ -40,6 +40,9 @@ function _requirements (session) {
 
   for (const requirement of requirements) {
     const { siteDescription, agreementsExceptions } = requirement
+
+    // NOTE: We determine a requirement is complete because agreement exceptions is populated and it is the last step in
+    // the journey
     if (agreementsExceptions) {
       completedRequirements.push({ siteDescription })
     }

--- a/app/presenters/return-requirements/check.presenter.js
+++ b/app/presenters/return-requirements/check.presenter.js
@@ -18,6 +18,7 @@ function go (session) {
     pageTitle: `Check the return requirements for ${licence.licenceHolder}`,
     reason: returnRequirementReasons[reason],
     reasonLink: _reasonLink(sessionId, journey),
+    requirements: _requirements(session),
     sessionId,
     startDate: _startDate(session),
     userEmail: note ? note.userEmail : 'No notes added'
@@ -30,6 +31,21 @@ function _reasonLink (sessionId, journey) {
   }
 
   return `/system/return-requirements/${sessionId}/no-returns-required`
+}
+
+function _requirements (session) {
+  const { requirements } = session
+
+  const completedRequirements = []
+
+  for (const requirement of requirements) {
+    const { siteDescription, agreementsExceptions } = requirement
+    if (agreementsExceptions) {
+      completedRequirements.push({ siteDescription })
+    }
+  }
+
+  return completedRequirements
 }
 
 function _startDate (session) {

--- a/app/presenters/return-requirements/purpose.presenter.js
+++ b/app/presenters/return-requirements/purpose.presenter.js
@@ -31,6 +31,15 @@ function go (session, requirementIndex, purposesData) {
 function _backLink (session) {
   const { checkPageVisited, id, requirements } = session
 
+  // NOTE: Purpose is the first page in the manual setup journey. So, when a user first comes through, we want to allow
+  // them to go back to `/setup`. Once they've got to the `/check` page they may return because they clicked the
+  // 'Change' link for the purpose. When this happens, `checkPageVisited` will be true and 'Back' needs to take them
+  // back there.
+  //
+  // But if they click 'Add requirement' on the `/check` page they'll also be directed here. When that happens
+  // `checkPageVisited` will have been reset to false to allow the user to progress through the setup journey. In this
+  // scenario 'Back' also needs to take them back to `/check`. Hence, the logic is different in this presenter when
+  // compared with the other setup pages.
   if (checkPageVisited || requirements.length > 1) {
     return `/system/return-requirements/${id}/check`
   }

--- a/app/presenters/return-requirements/purpose.presenter.js
+++ b/app/presenters/return-requirements/purpose.presenter.js
@@ -29,9 +29,9 @@ function go (session, requirementIndex, purposesData) {
 }
 
 function _backLink (session) {
-  const { checkPageVisited, id } = session
+  const { checkPageVisited, id, requirements } = session
 
-  if (checkPageVisited) {
+  if (checkPageVisited || requirements.length > 1) {
     return `/system/return-requirements/${id}/check`
   }
 

--- a/app/routes/return-requirement.routes.js
+++ b/app/routes/return-requirement.routes.js
@@ -30,6 +30,20 @@ const routes = [
     }
   },
   {
+    method: 'POST',
+    path: '/return-requirements/{sessionId}/add',
+    handler: ReturnRequirementsController.add,
+    options: {
+      auth: {
+        access: {
+          scope: ['billing']
+        }
+      },
+      description: 'Submit the abstraction period for the return requirement'
+    }
+
+  },
+  {
     method: 'GET',
     path: '/return-requirements/{sessionId}/agreements-exceptions/{requirementIndex}',
     handler: ReturnRequirementsController.agreementsExceptions,

--- a/app/routes/return-requirement.routes.js
+++ b/app/routes/return-requirement.routes.js
@@ -39,7 +39,7 @@ const routes = [
           scope: ['billing']
         }
       },
-      description: 'Submit the abstraction period for the return requirement'
+      description: 'Adds another object to the requirements array in the session'
     }
 
   },

--- a/app/services/return-requirements/add.service.js
+++ b/app/services/return-requirements/add.service.js
@@ -14,6 +14,7 @@ const SessionModel = require('../../models/session.model.js')
  * requirement' button.
  *
  * @param {string} sessionId - The UUID of the current session
+ *
  * @returns {number} - The index of the new requirement. Needed by the setup pages so they know which requirement to
  * display and update
 */

--- a/app/services/return-requirements/add.service.js
+++ b/app/services/return-requirements/add.service.js
@@ -1,21 +1,22 @@
 'use strict'
 
 /**
- * Orchestrates adding an empty object to requirements array to the setup session record.
+ * Orchestrates adding an empty object to the requirements array in the session
  * @module AddService
- */
+*/
 
 const SessionModel = require('../../models/session.model.js')
 
 /**
- * Orchestrates adding an empty object to requirements array to the setup session record.
+ * Orchestrates adding an empty object to the requirements array in the session
  *
- * Supports adding another object to the requirements array in the session when a user hits the add requirements button.
- * It also returns the index of the object added to add the new returns requirements data.
+ * Supports adding another object to the requirements array in the session when a user hits the 'Add another
+ * requirement' button.
  *
  * @param {string} sessionId - The UUID of the current session
- * @returns {number} - The index of the object in the requirements array
- */
+ * @returns {number} - The index of the new requirement. Needed by the setup pages so they know which requirement to
+ * display and update
+*/
 async function go (sessionId) {
   const session = await SessionModel.query().findById(sessionId)
 

--- a/app/services/return-requirements/add.service.js
+++ b/app/services/return-requirements/add.service.js
@@ -1,12 +1,21 @@
 'use strict'
 
 /**
- * Orchestrates adding object to requirements array
+ * Orchestrates adding an empty object to requirements array to the setup session record.
  * @module AddService
  */
 
 const SessionModel = require('../../models/session.model.js')
 
+/**
+ * Orchestrates adding an empty object to requirements array to the setup session record.
+ *
+ * Supports adding another object to the requirements array in the session when a user hits the add requirements button.
+ * It also returns the index of the object added to add the new returns requirements data.
+ *
+ * @param {string} sessionId - The UUID of the current session
+ * @returns {number} - The index of the object in the requirements array
+ */
 async function go (sessionId) {
   const session = await SessionModel.query().findById(sessionId)
 

--- a/app/services/return-requirements/add.service.js
+++ b/app/services/return-requirements/add.service.js
@@ -1,0 +1,27 @@
+'use strict'
+
+/**
+ * Orchestrates adding object to requirements array
+ * @module AddService
+ */
+
+const SessionModel = require('../../models/session.model.js')
+
+async function go (sessionId) {
+  const session = await SessionModel.query().findById(sessionId)
+
+  await _save(session)
+
+  return session.requirements.length - 1
+}
+
+async function _save (session) {
+  session.requirements.push({})
+
+  session.checkPageVisited = false
+
+  return session.$update()
+}
+module.exports = {
+  go
+}

--- a/app/views/return-requirements/check.njk
+++ b/app/views/return-requirements/check.njk
@@ -99,6 +99,28 @@
       <hr class="govuk-section-break  govuk-!-margin-bottom-2 govuk-section-break--visible">
     </div>
 
+    {% if journey == 'returns-required' %}
+      <div class="govuk-!-margin-bottom-9">
+        <h2 class="govuk-heading-l govuk-!-margin-bottom-4" >Requirements for returns</h2>
+        <form method= "post" action= "/system/return-requirements/{{sessionId}}/add">
+          {{ govukButton({
+            text: "Add another requirement",
+            classes: "govuk-button--secondary",
+            preventDoubleClick: true
+          }) }}
+        </form>
+
+        {% for requirement in requirements %}
+          {# Set an easier to use index #}
+          {% set rowIndex = loop.index0 %}
+          <div>
+            <h3>{{requirement.siteDescription}}</h3>
+            <p>Remove {{rowIndex}} </p>
+          </div>
+        {% endfor %}
+      </div>
+    {% endif %}
+
     <div class="govuk-body">
       {% if journey == 'no-returns-required' %}
         <h3 class="govuk-heading-m">Returns are not required for this licence</h3>

--- a/app/views/return-requirements/check.njk
+++ b/app/views/return-requirements/check.njk
@@ -19,108 +19,108 @@
     </h1>
   </div>
 
-  <form method="post">
-    <div class="govuk-!-margin-bottom-9">
-      <hr class="govuk-section-break  govuk-!-margin-bottom-2 govuk-section-break--visible">
-      {{ govukSummaryList({
-        classes: 'govuk-!-margin-bottom-2',
-        rows: [
-          {
-            classes: 'govuk-summary-list govuk-summary-list__row--no-border',
-            key: {
-              text: "Start date"
-            },
-            value: {
-              text: startDate
-            },
-            actions: {
-              items: [
-                {
-                  href: "/system/return-requirements/" + sessionId + "/start-date",
-                  text: "Change",
-                  visuallyHiddenText: "the start date for the return requirement"
-                }
-              ]
-            }
+  <div class="govuk-!-margin-bottom-9">
+    <hr class="govuk-section-break  govuk-!-margin-bottom-2 govuk-section-break--visible">
+    {{ govukSummaryList({
+      classes: 'govuk-!-margin-bottom-2',
+      rows: [
+        {
+          classes: 'govuk-summary-list govuk-summary-list__row--no-border',
+          key: {
+            text: "Start date"
           },
-          {
-            classes: 'govuk-summary-list govuk-summary-list__row--no-border',
-            key: {
-              text: "Reason"
-            },
-            value: {
-              text: reason
-            },
-            actions: {
-              items: [
-                {
-                  href: reasonLink,
-                  text: "Change",
-                  visuallyHiddenText: "the reason for the return requirement"
-                }
-              ]
-            }
+          value: {
+            text: startDate
+          },
+          actions: {
+            items: [
+              {
+                href: "/system/return-requirements/" + sessionId + "/start-date",
+                text: "Change",
+                visuallyHiddenText: "the start date for the return requirement"
+              }
+            ]
           }
-        ]
-      }) }}
-      <hr class="govuk-section-break  govuk-!-margin-bottom-2 govuk-section-break--visible">
-    </div>
+        },
+        {
+          classes: 'govuk-summary-list govuk-summary-list__row--no-border',
+          key: {
+            text: "Reason"
+          },
+          value: {
+            text: reason
+          },
+          actions: {
+            items: [
+              {
+                href: reasonLink,
+                text: "Change",
+                visuallyHiddenText: "the reason for the return requirement"
+              }
+            ]
+          }
+        }
+      ]
+    }) }}
+    <hr class="govuk-section-break  govuk-!-margin-bottom-2 govuk-section-break--visible">
+  </div>
 
+  <div class="govuk-!-margin-bottom-9">
+    <h2 class="govuk-heading-l govuk-!-margin-bottom-4" >Notes</h2>
+    <hr class="govuk-section-break  govuk-!-margin-bottom-2 govuk-section-break--visible">
+    {{ govukSummaryList({
+      classes: 'govuk-!-margin-bottom-2',
+      rows: [
+        {
+          classes: 'govuk-summary-list govuk-summary-list__row--no-border',
+          key: {
+            text: userEmail,
+            classes: "govuk-body govuk-!-font-weight-regular"
+          },
+          value: {
+            text: note | escape | nl2br
+          },
+          actions: {
+            items: [
+              {
+                href: "note",
+                text: "Change" if note else "Add a note"
+              },
+              {
+                href: "delete-note",
+                text: "Delete"
+              } if note
+            ]
+          }
+        }
+      ]
+    }) }}
+    <hr class="govuk-section-break  govuk-!-margin-bottom-2 govuk-section-break--visible">
+  </div>
+
+  {% if journey == 'returns-required' %}
     <div class="govuk-!-margin-bottom-9">
-      <h2 class="govuk-heading-l govuk-!-margin-bottom-4" >Notes</h2>
-      <hr class="govuk-section-break  govuk-!-margin-bottom-2 govuk-section-break--visible">
-      {{ govukSummaryList({
-        classes: 'govuk-!-margin-bottom-2',
-        rows: [
-          {
-            classes: 'govuk-summary-list govuk-summary-list__row--no-border',
-            key: {
-              text: userEmail,
-              classes: "govuk-body govuk-!-font-weight-regular"
-            },
-            value: {
-              text: note | escape | nl2br
-            },
-            actions: {
-              items: [
-                {
-                  href: "note",
-                  text: "Change" if note else "Add a note"
-                },
-                {
-                  href: "delete-note",
-                  text: "Delete"
-                } if note
-              ]
-            }
-          }
-        ]
-      }) }}
-      <hr class="govuk-section-break  govuk-!-margin-bottom-2 govuk-section-break--visible">
+      <h2 class="govuk-heading-l govuk-!-margin-bottom-4" >Requirements for returns</h2>
+      <form method= "post" action= "/system/return-requirements/{{sessionId}}/add">
+        {{ govukButton({
+          text: "Add another requirement",
+          classes: "govuk-button--secondary",
+          preventDoubleClick: true
+        }) }}
+      </form>
+
+      {% for requirement in requirements %}
+        {# Set an easier to use index #}
+        {% set rowIndex = loop.index0 %}
+        <div>
+          <h3>{{requirement.siteDescription}}</h3>
+          <p>Remove {{rowIndex}} </p>
+        </div>
+      {% endfor %}
     </div>
+  {% endif %}
 
-    {% if journey == 'returns-required' %}
-      <div class="govuk-!-margin-bottom-9">
-        <h2 class="govuk-heading-l govuk-!-margin-bottom-4" >Requirements for returns</h2>
-        <form method= "post" action= "/system/return-requirements/{{sessionId}}/add">
-          {{ govukButton({
-            text: "Add another requirement",
-            classes: "govuk-button--secondary",
-            preventDoubleClick: true
-          }) }}
-        </form>
-
-        {% for requirement in requirements %}
-          {# Set an easier to use index #}
-          {% set rowIndex = loop.index0 %}
-          <div>
-            <h3>{{requirement.siteDescription}}</h3>
-            <p>Remove {{rowIndex}} </p>
-          </div>
-        {% endfor %}
-      </div>
-    {% endif %}
-
+  <form method="post">
     <div class="govuk-body">
       {% if journey == 'no-returns-required' %}
         <h3 class="govuk-heading-m">Returns are not required for this licence</h3>

--- a/test/presenters/return-requirements/check.presenter.test.js
+++ b/test/presenters/return-requirements/check.presenter.test.js
@@ -43,6 +43,7 @@ describe('Return Requirements - Check presenter', () => {
         pageTitle: 'Check the return requirements for Turbo Kid',
         reason: 'Major change',
         reasonLink: '/system/return-requirements/61e07498-f309-4829-96a9-72084a54996d/reason',
+        requirements: [],
         sessionId: '61e07498-f309-4829-96a9-72084a54996d',
         startDate: '1 January 2023',
         userEmail: 'No notes added'

--- a/test/services/return-requirements/add.service.test.js
+++ b/test/services/return-requirements/add.service.test.js
@@ -49,7 +49,7 @@ describe('Return Requirements - Add service', () => {
       expect(refreshedSession.data.requirements).to.equal([{}, {}])
     })
 
-    it('returns the index of the the new requirement', async () => {
+    it('returns the index of the new requirement', async () => {
       const result = await AddService.go(session.id)
 
       expect(result).to.equal(1)

--- a/test/services/return-requirements/add.service.test.js
+++ b/test/services/return-requirements/add.service.test.js
@@ -48,5 +48,11 @@ describe('Return Requirements - Add service', () => {
       expect(refreshedSession.data.requirements.length).to.equal(2)
       expect(refreshedSession.data.requirements).to.equal([{}, {}])
     })
+
+    it('returns the index of the the new requirement', async () => {
+      const result = await AddService.go(session.id)
+
+      expect(result).to.equal(1)
+    })
   })
 })

--- a/test/services/return-requirements/add.service.test.js
+++ b/test/services/return-requirements/add.service.test.js
@@ -1,0 +1,52 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const DatabaseSupport = require('../../support/database.js')
+const SessionHelper = require('../../support/helpers/session.helper.js')
+
+// Thing under test
+const AddService = require('../../../app/services/return-requirements/add.service.js')
+
+describe('Return Requirements - Add service', () => {
+  let session
+
+  beforeEach(async () => {
+    await DatabaseSupport.clean()
+
+    session = await SessionHelper.add({
+      data: {
+        checkPageVisited: false,
+        licence: {
+          id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
+          currentVersionStartDate: '2023-01-01T00:00:00.000Z',
+          endDate: null,
+          licenceRef: '01/ABC',
+          licenceHolder: 'Turbo Kid',
+          startDate: '2022-04-01T00:00:00.000Z'
+        },
+        journey: 'returns-required',
+        requirements: [{}],
+        startDateOptions: 'licenceStartDate',
+        reason: 'major-change'
+      }
+    })
+  })
+
+  describe('when called', () => {
+    it('adds another empty object to the requirement array in the current setup session record', async () => {
+      await AddService.go(session.id)
+
+      const refreshedSession = await session.$query()
+
+      expect(refreshedSession.data.requirements.length).to.equal(2)
+      expect(refreshedSession.data.requirements).to.equal([{}, {}])
+    })
+  })
+})

--- a/test/services/return-requirements/check.service.test.js
+++ b/test/services/return-requirements/check.service.test.js
@@ -66,6 +66,7 @@ describe('Return Requirements - Check service', () => {
         pageTitle: 'Check the return requirements for Turbo Kid',
         reason: 'Major change',
         reasonLink: `/system/return-requirements/${session.id}/reason`,
+        requirements: [],
         startDate: '1 January 2023',
         userEmail: 'No notes added'
       }, { skip: ['sessionId'] })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4386

When setting up 'requirements for returns', a user can set up multiple requirements (it's why we call it '_requirements_ for returns' not '_requirement_ for returns'!

Unfortunately, the wording for this feature isn't helpful to us dev's. So, when a user opts to setup a new 'requirements for returns' we actually create a _return version_. Against that we'll record the start date, reason, a note (optional) and any additional agreements.

Under that must be _at least_ 1 return requirement. Against that we record details like the purpose, point, site description etc.

But users need flexibility. For example, suppose a licence is granted to abstract water for 2 different purposes. We may require separate returns for each purpose. In this case, we only need 1 return version, for example, 'new licence'. But we need 2 separate return requirements in order to detail the 2 different return submissions we'll expect.

In [Add support for multiple rtn. reqs. plus tidy up](https://github.com/DEFRA/water-abstraction-system/pull/977) we updated the session handling and journey to support working with multiple return requirements.

This change is allows users to add and additional requirements to the session and set them up once they have reached the `/check` page in the journey. When a user clicks the add button, they'll be redirected to the `/purpose/{new requirements index}` page after we've inserted a new blank requirement in the session.