### PR TITLE
Fix unsent bills displaying in licence bills tab

### DIFF
--- a/app/services/licences/fetch-licence-bills.service.js
+++ b/app/services/licences/fetch-licence-bills.service.js
@@ -37,7 +37,9 @@ async function _fetch (licenceId, page) {
       'bills.netAmount'
     ])
     .innerJoinRelated('billLicences')
+    .innerJoin('billRuns', 'billRuns.id', 'bills.billRunId')
     .where('billLicences.licence_id', licenceId)
+    .where('billRuns.status', 'sent')
     .withGraphFetched('billRun')
     .modifyGraph('billRun', (builder) => {
       builder.select(['batchType'])

--- a/app/services/licences/fetch-licence-bills.service.js
+++ b/app/services/licences/fetch-licence-bills.service.js
@@ -5,9 +5,9 @@
  * @module FetchLicenceBillsService
  */
 
-const BillModel = require('../../models/bill.model')
+const BillModel = require('../../models/bill.model.js')
 
-const DatabaseConfig = require('../../../config/database.config')
+const DatabaseConfig = require('../../../config/database.config.js')
 
 /**
  * Fetches all bills for a licence which is needed for the view '/licences/{id}/bills` page

--- a/test/services/licences/fetch-licence-bills.service.test.js
+++ b/test/services/licences/fetch-licence-bills.service.test.js
@@ -9,12 +9,12 @@ const { expect } = Code
 
 // Test helpers
 const DatabaseSupport = require('../../support/database.js')
-const BillLicenceHelper = require('../../support/helpers/bill-licence.helper')
-const BillHelper = require('../../support/helpers/bill.helper')
-const BillRunHelper = require('../../support/helpers/bill-run.helper')
+const BillLicenceHelper = require('../../support/helpers/bill-licence.helper.js')
+const BillHelper = require('../../support/helpers/bill.helper.js')
+const BillRunHelper = require('../../support/helpers/bill-run.helper.js')
 
 // Thing under test
-const FetchLicenceBillService = require('../../../app/services/licences/fetch-licence-bills.service')
+const FetchLicenceBillService = require('../../../app/services/licences/fetch-licence-bills.service.js')
 
 describe('Fetch licence bills service', () => {
   beforeEach(async () => {

--- a/test/services/licences/fetch-licence-bills.service.test.js
+++ b/test/services/licences/fetch-licence-bills.service.test.js
@@ -34,48 +34,82 @@ describe('Fetch Licence Bills service', () => {
         licenceId,
         billId
       })
-
-      await BillRunHelper.add({ id: billRunId })
-
-      await BillHelper.add(
-        {
-          id: billId,
-          billRunId,
-          invoiceNumber: '123',
-          accountNumber: 'T21404193A',
-          netAmount: 12345,
-          billingAccountId,
-          createdAt: createdDate
-        })
-
-      // Add an extra bill linked to the same bill run to test only bills for the licence are retrieved
-      await BillHelper.add({ billRunId })
     })
 
-    it('returns results', async () => {
-      const result = await FetchLicenceBillService.go(licenceId, 1)
+    describe("and they are linked to a 'sent' bill run", () => {
+      beforeEach(async () => {
+        await BillRunHelper.add({ id: billRunId, status: 'sent' })
 
-      expect(result.pagination).to.equal({
-        total: 1
+        await BillHelper.add(
+          {
+            id: billId,
+            billRunId,
+            invoiceNumber: '123',
+            accountNumber: 'T21404193A',
+            netAmount: 12345,
+            billingAccountId,
+            createdAt: createdDate
+          })
+
+        // Add an extra bill linked to the same bill run to test only bills for the licence are retrieved
+        await BillHelper.add({ billRunId })
       })
 
-      expect(result.bills).to.equal(
-        [{
-          accountNumber: 'T21404193A',
-          billRun: {
-            batchType: 'supplementary'
-          },
-          billingAccountId,
-          createdAt: createdDate,
-          credit: null,
-          deminimis: false,
-          financialYearEnding: 2023,
-          id: billId,
-          invoiceNumber: '123',
-          legacyId: null,
-          netAmount: 12345
-        }]
-      )
+      it('returns results', async () => {
+        const result = await FetchLicenceBillService.go(licenceId, 1)
+
+        expect(result.pagination).to.equal({
+          total: 1
+        })
+
+        expect(result.bills).to.equal(
+          [{
+            accountNumber: 'T21404193A',
+            billRun: {
+              batchType: 'supplementary'
+            },
+            billingAccountId,
+            createdAt: createdDate,
+            credit: null,
+            deminimis: false,
+            financialYearEnding: 2023,
+            id: billId,
+            invoiceNumber: '123',
+            legacyId: null,
+            netAmount: 12345
+          }]
+        )
+      })
+    })
+
+    describe("but they are not linked to a 'sent' bill run", () => {
+      beforeEach(async () => {
+        await BillRunHelper.add({ id: billRunId })
+
+        await BillHelper.add(
+          {
+            id: billId,
+            billRunId,
+            invoiceNumber: '123',
+            accountNumber: 'T21404193A',
+            netAmount: 12345,
+            billingAccountId,
+            createdAt: createdDate
+          })
+
+        // Add an extra bill linked to the same bill run to test only bills for the licence are retrieved
+        await BillHelper.add({ billRunId })
+      })
+
+      it('returns no results', async () => {
+        const result = await FetchLicenceBillService.go(licenceId, 1)
+
+        expect(result.pagination).to.equal({
+          total: 0
+        })
+
+        expect(result.bills).to.be.empty()
+      })
     })
   })
 })

--- a/test/services/licences/fetch-licence-bills.service.test.js
+++ b/test/services/licences/fetch-licence-bills.service.test.js
@@ -17,18 +17,17 @@ const BillRunHelper = require('../../support/helpers/bill-run.helper.js')
 const FetchLicenceBillService = require('../../../app/services/licences/fetch-licence-bills.service.js')
 
 describe('Fetch Licence Bills service', () => {
+  const billId = '72988ec1-9fb2-4b87-b0a0-3c0be628a72c'
+  const billingAccountId = '0ba3b707-72ee-4296-b177-a19afff10688'
+  const billRunId = 'd40004d5-a99b-40a7-adf2-22d36d5b20b5'
+  const createdDate = new Date('2022-01-01')
+  const licenceId = '96d97293-1a62-4ad0-bcb6-24f68a203e6b'
+
   beforeEach(async () => {
     await DatabaseSupport.clean()
   })
 
   describe('when the licence has bills', () => {
-    const createdDate = new Date('2022-01-01')
-
-    const licenceId = '96d97293-1a62-4ad0-bcb6-24f68a203e6b'
-    const billId = '72988ec1-9fb2-4b87-b0a0-3c0be628a72c'
-    const billingAccountId = '0ba3b707-72ee-4296-b177-a19afff10688'
-    const billRunId = 'd40004d5-a99b-40a7-adf2-22d36d5b20b5'
-
     beforeEach(async () => {
       await BillLicenceHelper.add({
         licenceId,
@@ -110,6 +109,24 @@ describe('Fetch Licence Bills service', () => {
 
         expect(result.bills).to.be.empty()
       })
+    })
+  })
+
+  describe('when the licence has no bills', () => {
+    beforeEach(async () => {
+      await BillRunHelper.add({ id: billRunId, status: 'sent' })
+      await BillHelper.add({ id: billId, billRunId })
+      await BillLicenceHelper.add({ billId })
+    })
+
+    it('returns no results', async () => {
+      const result = await FetchLicenceBillService.go(licenceId, 1)
+
+      expect(result.pagination).to.equal({
+        total: 0
+      })
+
+      expect(result.bills).to.be.empty()
     })
   })
 })

--- a/test/services/licences/fetch-licence-bills.service.test.js
+++ b/test/services/licences/fetch-licence-bills.service.test.js
@@ -11,7 +11,6 @@ const { expect } = Code
 const DatabaseSupport = require('../../support/database.js')
 const BillLicenceHelper = require('../../support/helpers/bill-licence.helper.js')
 const BillHelper = require('../../support/helpers/bill.helper.js')
-const BillRunHelper = require('../../support/helpers/bill-run.helper.js')
 
 // Thing under test
 const FetchLicenceBillService = require('../../../app/services/licences/fetch-licence-bills.service.js')
@@ -33,8 +32,6 @@ describe('Fetch Licence Bills service', () => {
         licenceId,
         billId
       })
-
-      await BillRunHelper.add({ batchType: 'annual' })
 
       await BillHelper.add(
         {

--- a/test/services/licences/fetch-licence-bills.service.test.js
+++ b/test/services/licences/fetch-licence-bills.service.test.js
@@ -11,6 +11,7 @@ const { expect } = Code
 const DatabaseSupport = require('../../support/database.js')
 const BillLicenceHelper = require('../../support/helpers/bill-licence.helper.js')
 const BillHelper = require('../../support/helpers/bill.helper.js')
+const BillRunHelper = require('../../support/helpers/bill-run.helper.js')
 
 // Thing under test
 const FetchLicenceBillService = require('../../../app/services/licences/fetch-licence-bills.service.js')
@@ -26,6 +27,7 @@ describe('Fetch Licence Bills service', () => {
     const licenceId = '96d97293-1a62-4ad0-bcb6-24f68a203e6b'
     const billId = '72988ec1-9fb2-4b87-b0a0-3c0be628a72c'
     const billingAccountId = '0ba3b707-72ee-4296-b177-a19afff10688'
+    const billRunId = 'd40004d5-a99b-40a7-adf2-22d36d5b20b5'
 
     beforeEach(async () => {
       await BillLicenceHelper.add({
@@ -33,17 +35,21 @@ describe('Fetch Licence Bills service', () => {
         billId
       })
 
+      await BillRunHelper.add({ id: billRunId })
+
       await BillHelper.add(
         {
           id: billId,
+          billRunId,
           invoiceNumber: '123',
           accountNumber: 'T21404193A',
           netAmount: 12345,
           billingAccountId,
           createdAt: createdDate
         })
-      // Add an extra record to ensure the bill is retrieved by the license id
-      await BillHelper.add()
+
+      // Add an extra bill linked to the same bill run to test only bills for the licence are retrieved
+      await BillHelper.add({ billRunId })
     })
 
     it('returns results', async () => {
@@ -56,7 +62,9 @@ describe('Fetch Licence Bills service', () => {
       expect(result.bills).to.equal(
         [{
           accountNumber: 'T21404193A',
-          billRun: null,
+          billRun: {
+            batchType: 'supplementary'
+          },
           billingAccountId,
           createdAt: createdDate,
           credit: null,

--- a/test/services/licences/fetch-licence-bills.service.test.js
+++ b/test/services/licences/fetch-licence-bills.service.test.js
@@ -16,7 +16,7 @@ const BillRunHelper = require('../../support/helpers/bill-run.helper.js')
 // Thing under test
 const FetchLicenceBillService = require('../../../app/services/licences/fetch-licence-bills.service.js')
 
-describe('Fetch licence bills service', () => {
+describe('Fetch Licence Bills service', () => {
   beforeEach(async () => {
     await DatabaseSupport.clean()
   })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4316

In [Add View Licence Bills page](https://github.com/DEFRA/water-abstraction-system/pull/986) we added support for displaying the bills linked to a licence in the view licence page's 'Bills' tab.

Only we didn't spot that it should only be 'sent' bills.

This change updates the relevant fetch service to ensure the bills we get back are only those with a status of 'sent'.