### PR TITLE
Add View Licence communications

### DIFF
--- a/app/controllers/licences.controller.js
+++ b/app/controllers/licences.controller.js
@@ -7,6 +7,7 @@
 
 const InitiateSessionService = require('../services/return-requirements/initiate-session.service.js')
 const ViewLicenceBillsService = require('../services/licences/view-licence-bills.service.js')
+const ViewLicenceCommunicationsService = require('../services/licences/view-licence-communications.service.js')
 const ViewLicenceContactDetailsService = require('../services/licences/view-licence-contact-details.service.js')
 const ViewLicenceReturnsService = require('../services/licences/view-licence-returns.service.js')
 const ViewLicenceSummaryService = require('../services/licences/view-licence-summary.service.js')
@@ -33,6 +34,16 @@ async function viewBills (request, h) {
   const { params: { id }, auth, query: { page = 1 } } = request
 
   const data = await ViewLicenceBillsService.go(id, auth, page)
+
+  return h.view(ViewLicencePage, {
+    ...data
+  })
+}
+
+async function viewCommunications (request, h) {
+  const { params: { id }, auth, query: { page = 1 } } = request
+
+  const data = await ViewLicenceCommunicationsService.go(id, auth, page)
 
   return h.view(ViewLicencePage, {
     ...data
@@ -73,6 +84,7 @@ module.exports = {
   noReturnsRequired,
   returnsRequired,
   viewBills,
+  viewCommunications,
   viewContacts,
   viewReturns,
   viewSummary

--- a/app/presenters/licences/communications.presenter.js
+++ b/app/presenters/licences/communications.presenter.js
@@ -1,0 +1,29 @@
+'use strict'
+
+/**
+ * Formats data for the `/licences/{id}/communications` view licence communications page
+ * @module CommunicationsPresenter
+ */
+
+/**
+ * Formats data for the `/licences/{id}/communications` view licence communications page
+ *
+ * @returns {Object} The data formatted for the view template
+ */
+function go (communications) {
+  return {
+    communications: _communications(communications)
+  }
+}
+
+function _communications (communications) {
+  return communications.map((communication) => {
+    return {
+      ...communication
+    }
+  })
+}
+
+module.exports = {
+  go
+}

--- a/app/presenters/licences/communications.presenter.js
+++ b/app/presenters/licences/communications.presenter.js
@@ -21,8 +21,8 @@ function go (communications) {
 function _communications (communications) {
   return communications.map((communication) => {
     return {
-      sender: communication.issuer,
-      sent: formatLongDate(communication.createdAt)
+      sender: communication.event.issuer,
+      sent: formatLongDate(communication.event.createdAt)
     }
   })
 }

--- a/app/presenters/licences/communications.presenter.js
+++ b/app/presenters/licences/communications.presenter.js
@@ -36,7 +36,7 @@ function _type (communication) {
   return {
     alert: _typeAlert(communication),
     label: communication.event.metadata.name,
-    sentVia: `sent ${formatLongDate(communication.event.createdAt)} via ${communication.messageType}`,
+    sentVia: `sent ${formatLongDate(new Date(communication.event.createdAt))} via ${communication.messageType}`,
     pdf: communication.messageRef.includes('pdf')
   }
 }
@@ -47,7 +47,7 @@ function _communications (communications) {
       id: communication.id,
       type: _type(communication),
       sender: communication.event.issuer,
-      sent: formatLongDate(communication.event.createdAt),
+      sent: formatLongDate(new Date(communication.event.createdAt)),
       method: _sentenceCase(communication.messageType)
     }
   })

--- a/app/presenters/licences/communications.presenter.js
+++ b/app/presenters/licences/communications.presenter.js
@@ -18,11 +18,25 @@ function go (communications) {
   }
 }
 
+function _type (communication) {
+//   {#          {% if message.isPdf %}
+//     {{ message.event.metadata.name }}
+//     <span class="govuk-visually-hidden"> sent {{ message.event.created | date }} via {{ message.messageType }}</span>
+//   {% else %}
+//     <a href="/licences/{{ documentId }}/communications/{{ message.id }}">
+//       {{ message.event.metadata.options.sendingAlertType | sentenceCase + ' - ' if message.event.metadata.name == 'Water abstraction alert' else '' }}
+//       {{ message.event.metadata.name }}
+//       <span class="govuk-visually-hidden"> sent {{ message.event.created | date }} via {{ message.messageType }}</span>
+//     </a>
+//   {% endif %}#}
+}
+
 function _communications (communications) {
   return communications.map((communication) => {
     return {
       sender: communication.event.issuer,
-      sent: formatLongDate(communication.event.createdAt)
+      sent: formatLongDate(communication.event.createdAt),
+      method: communication.messageType.toLowerCase()
     }
   })
 }

--- a/app/presenters/licences/communications.presenter.js
+++ b/app/presenters/licences/communications.presenter.js
@@ -5,7 +5,7 @@
  * @module CommunicationsPresenter
  */
 
-const { formatLongDate } = require('../base.presenter.js')
+const { formatLongDate, sentenceCase } = require('../base.presenter.js')
 
 /**
  * Formats data for the `/licences/{id}/communications` view licence communications page
@@ -25,18 +25,9 @@ function _communications (communications) {
       type: _type(communication),
       sender: communication.event.issuer,
       sent: formatLongDate(new Date(communication.event.createdAt)),
-      method: _sentenceCase(communication.messageType)
+      method: sentenceCase(communication.messageType)
     }
   })
-}
-
-function _titleCase (text = '') {
-  return text.charAt(0).toUpperCase() + text.slice(1)
-}
-function _sentenceCase (text = '') {
-  const sentence = text.toLowerCase()
-
-  return _titleCase(sentence)
 }
 
 function _type (communication) {
@@ -50,7 +41,7 @@ function _type (communication) {
 
 function _typeAlert (communication) {
   if (communication.event.metadata.name === 'Water abstraction alert') {
-    return `${_sentenceCase(communication.event.metadata.options.sendingAlertType)} - Water abstraction alert`
+    return `${sentenceCase(communication.event.metadata.options.sendingAlertType)} - Water abstraction alert`
   }
 
   return null

--- a/app/presenters/licences/communications.presenter.js
+++ b/app/presenters/licences/communications.presenter.js
@@ -5,6 +5,8 @@
  * @module CommunicationsPresenter
  */
 
+const { formatLongDate } = require('../base.presenter.js')
+
 /**
  * Formats data for the `/licences/{id}/communications` view licence communications page
  *
@@ -19,7 +21,8 @@ function go (communications) {
 function _communications (communications) {
   return communications.map((communication) => {
     return {
-      ...communication
+      sender: communication.issuer,
+      sent: formatLongDate(communication.createdAt)
     }
   })
 }

--- a/app/presenters/licences/communications.presenter.js
+++ b/app/presenters/licences/communications.presenter.js
@@ -18,18 +18,22 @@ function go (communications) {
   }
 }
 
+function _communications (communications) {
+  return communications.map((communication) => {
+    return {
+      id: communication.id,
+      type: _type(communication),
+      sender: communication.event.issuer,
+      sent: formatLongDate(new Date(communication.event.createdAt)),
+      method: _sentenceCase(communication.messageType)
+    }
+  })
+}
+
 function _sentenceCase (text = '') {
   const sentence = text.toLowerCase()
 
   return sentence.charAt(0).toUpperCase() + sentence.slice(1)
-}
-
-function _typeAlert (communication) {
-  if (communication.event.metadata.name === 'Water abstraction alert') {
-    return `${_sentenceCase(communication.event.metadata.options.sendingAlertType)} - Water abstraction alert`
-  }
-
-  return null
 }
 
 function _type (communication) {
@@ -41,16 +45,12 @@ function _type (communication) {
   }
 }
 
-function _communications (communications) {
-  return communications.map((communication) => {
-    return {
-      id: communication.id,
-      type: _type(communication),
-      sender: communication.event.issuer,
-      sent: formatLongDate(new Date(communication.event.createdAt)),
-      method: _sentenceCase(communication.messageType)
-    }
-  })
+function _typeAlert (communication) {
+  if (communication.event.metadata.name === 'Water abstraction alert') {
+    return `${_sentenceCase(communication.event.metadata.options.sendingAlertType)} - Water abstraction alert`
+  }
+
+  return null
 }
 
 module.exports = {

--- a/app/presenters/licences/communications.presenter.js
+++ b/app/presenters/licences/communications.presenter.js
@@ -18,25 +18,37 @@ function go (communications) {
   }
 }
 
+function _sentenceCase (text = '') {
+  const sentence = text.toLowerCase()
+
+  return sentence.charAt(0).toUpperCase() + sentence.slice(1)
+}
+
+function _typeAlert (communication) {
+  if (communication.event.metadata.name === 'Water abstraction alert') {
+    return `${_sentenceCase(communication.event.metadata.options.sendingAlertType)} - Water abstraction alert`
+  }
+
+  return null
+}
+
 function _type (communication) {
-//   {#          {% if message.isPdf %}
-//     {{ message.event.metadata.name }}
-//     <span class="govuk-visually-hidden"> sent {{ message.event.created | date }} via {{ message.messageType }}</span>
-//   {% else %}
-//     <a href="/licences/{{ documentId }}/communications/{{ message.id }}">
-//       {{ message.event.metadata.options.sendingAlertType | sentenceCase + ' - ' if message.event.metadata.name == 'Water abstraction alert' else '' }}
-//       {{ message.event.metadata.name }}
-//       <span class="govuk-visually-hidden"> sent {{ message.event.created | date }} via {{ message.messageType }}</span>
-//     </a>
-//   {% endif %}#}
+  return {
+    alert: _typeAlert(communication),
+    label: communication.event.metadata.name,
+    sentVia: `sent ${formatLongDate(communication.event.createdAt)} via ${communication.messageType}`,
+    pdf: communication.messageRef.includes('pdf')
+  }
 }
 
 function _communications (communications) {
   return communications.map((communication) => {
     return {
+      id: communication.id,
+      type: _type(communication),
       sender: communication.event.issuer,
       sent: formatLongDate(communication.event.createdAt),
-      method: communication.messageType.toLowerCase()
+      method: _sentenceCase(communication.messageType)
     }
   })
 }

--- a/app/presenters/licences/communications.presenter.js
+++ b/app/presenters/licences/communications.presenter.js
@@ -30,10 +30,13 @@ function _communications (communications) {
   })
 }
 
+function _titleCase (text = '') {
+  return text.charAt(0).toUpperCase() + text.slice(1)
+}
 function _sentenceCase (text = '') {
   const sentence = text.toLowerCase()
 
-  return sentence.charAt(0).toUpperCase() + sentence.slice(1)
+  return _titleCase(sentence)
 }
 
 function _type (communication) {

--- a/app/presenters/licences/view-licence.presenter.js
+++ b/app/presenters/licences/view-licence.presenter.js
@@ -17,12 +17,13 @@ const { formatLongDate } = require('../base.presenter.js')
 function go (licence, auth) {
   const {
     ends,
+    id,
     includeInPresrocBilling,
     includeInSrocBilling,
+    licenceDocumentHeader,
     licenceName,
     licenceRef,
-    registeredTo,
-    id
+    registeredTo
   } = licence
 
   return {
@@ -34,7 +35,8 @@ function go (licence, auth) {
     registeredTo,
     roles: _authRoles(auth),
     warning: _generateWarningMessage(ends),
-    activeNavBar: 'search'
+    activeNavBar: 'search',
+    documentId: licenceDocumentHeader.id
   }
 }
 

--- a/app/routes/licence.routes.js
+++ b/app/routes/licence.routes.js
@@ -18,6 +18,14 @@ const routes = [
   },
   {
     method: 'GET',
+    path: '/licences/{id}/communications',
+    handler: LicencesController.viewCommunications,
+    options: {
+      description: 'View a licence communications page'
+    }
+  },
+  {
+    method: 'GET',
     path: '/licences/{id}/contact-details',
     handler: LicencesController.viewContacts,
     options: {

--- a/app/services/licences/fetch-communications.service.js
+++ b/app/services/licences/fetch-communications.service.js
@@ -43,7 +43,7 @@ async function _fetch (licenceRef, page) {
         'subtype',
         'status',
         'issuer'
-      ]).where('licences', '@>', `["${licenceRef}"]`)
+      ])
     })
     .page(page - 1, DatabaseConfig.defaultPageSize)
     .orderBy('send_after', 'desc')

--- a/app/services/licences/fetch-communications.service.js
+++ b/app/services/licences/fetch-communications.service.js
@@ -28,7 +28,8 @@ async function _fetch (licenceRef, page) {
   const data = await ScheduledNotificationModel.query()
     .select([
       'id',
-      'messageType'
+      'messageType',
+      'messageRef'
     ])
     .where('licences', '@>', `["${licenceRef}"]`)
     .whereNotNull('eventId')

--- a/app/services/licences/fetch-communications.service.js
+++ b/app/services/licences/fetch-communications.service.js
@@ -5,6 +5,9 @@
  * @module FetchCommunicationsService
  */
 
+const EventModel = require('../../models/event.model.js')
+const DatabaseConfig = require('../../../config/database.config.js')
+
 /**
  * Fetch the matching licence and return data needed for the view licence communications page
  *
@@ -14,14 +17,26 @@
  *
  * @returns {Promise<Object>} the data needed to populate the view licence page's communications tab
  */
-async function go (licenceId, page) {
-  const { results, total } = await _fetch(licenceId, page)
+async function go (licenceRef, page) {
+  const { results, total } = await _fetch(licenceRef, page)
 
   return { communications: results, pagination: { total } }
 }
 
-async function _fetch (licenceId, page) {
-  return { results: [], total: 0 }
+async function _fetch (licenceRef, page) {
+  const data = await EventModel.query()
+    .select([
+      'created_at',
+      'metadata',
+      'type',
+      'subtype',
+      'status',
+      'issuer'
+    ])
+    .where('licences', '@>', `["${licenceRef}"]`)
+    .page(page - 1, DatabaseConfig.defaultPageSize)
+
+  return data
 }
 
 module.exports = {

--- a/app/services/licences/fetch-communications.service.js
+++ b/app/services/licences/fetch-communications.service.js
@@ -6,6 +6,7 @@
  */
 
 const EventModel = require('../../models/event.model.js')
+const ScheduledNotificationModel = require('../../models/scheduled-notification.model.js')
 const DatabaseConfig = require('../../../config/database.config.js')
 
 /**
@@ -24,16 +25,20 @@ async function go (licenceRef, page) {
 }
 
 async function _fetch (licenceRef, page) {
-  const data = await EventModel.query()
-    .select([
-      'created_at',
-      'metadata',
-      'type',
-      'subtype',
-      'status',
-      'issuer'
-    ])
+  const data = await ScheduledNotificationModel.query()
     .where('licences', '@>', `["${licenceRef}"]`)
+    .whereNotNull('eventId')
+    .withGraphFetched('event')
+    .modifyGraph('event', (builder) => {
+      builder.select([
+        'created_at',
+        'metadata',
+        'type',
+        'subtype',
+        'status',
+        'issuer'
+      ]).where('licences', '@>', `["${licenceRef}"]`)
+    })
     .page(page - 1, DatabaseConfig.defaultPageSize)
 
   return data

--- a/app/services/licences/fetch-communications.service.js
+++ b/app/services/licences/fetch-communications.service.js
@@ -6,6 +6,7 @@
  */
 
 const ScheduledNotificationModel = require('../../models/scheduled-notification.model.js')
+
 const DatabaseConfig = require('../../../config/database.config.js')
 
 /**

--- a/app/services/licences/fetch-communications.service.js
+++ b/app/services/licences/fetch-communications.service.js
@@ -24,7 +24,7 @@ async function go (licenceRef, page) {
 }
 
 async function _fetch (licenceRef, page) {
-  const data = await ScheduledNotificationModel.query()
+  return ScheduledNotificationModel.query()
     .select([
       'id',
       'messageType',
@@ -46,8 +46,6 @@ async function _fetch (licenceRef, page) {
     })
     .page(page - 1, DatabaseConfig.defaultPageSize)
     .orderBy('send_after', 'desc')
-
-  return data
 }
 
 module.exports = {

--- a/app/services/licences/fetch-communications.service.js
+++ b/app/services/licences/fetch-communications.service.js
@@ -26,6 +26,10 @@ async function go (licenceRef, page) {
 
 async function _fetch (licenceRef, page) {
   const data = await ScheduledNotificationModel.query()
+    .select([
+      'id',
+      'messageType'
+    ])
     .where('licences', '@>', `["${licenceRef}"]`)
     .whereNotNull('eventId')
     .withGraphFetched('event')

--- a/app/services/licences/fetch-communications.service.js
+++ b/app/services/licences/fetch-communications.service.js
@@ -5,7 +5,6 @@
  * @module FetchCommunicationsService
  */
 
-const EventModel = require('../../models/event.model.js')
 const ScheduledNotificationModel = require('../../models/scheduled-notification.model.js')
 const DatabaseConfig = require('../../../config/database.config.js')
 
@@ -32,7 +31,8 @@ async function _fetch (licenceRef, page) {
       'messageRef'
     ])
     .where('licences', '@>', `["${licenceRef}"]`)
-    .whereNotNull('eventId')
+    .andWhere('notify_status', 'in', ['delivered', 'received'])
+    .andWhere('eventId', 'is not', null)
     .withGraphFetched('event')
     .modifyGraph('event', (builder) => {
       builder.select([
@@ -45,6 +45,7 @@ async function _fetch (licenceRef, page) {
       ]).where('licences', '@>', `["${licenceRef}"]`)
     })
     .page(page - 1, DatabaseConfig.defaultPageSize)
+    .orderBy('send_after', 'desc')
 
   return data
 }

--- a/app/services/licences/fetch-communications.service.js
+++ b/app/services/licences/fetch-communications.service.js
@@ -1,0 +1,29 @@
+'use strict'
+
+/**
+ * Fetches data needed for the view '/licences/{id}/communications` page
+ * @module FetchCommunicationsService
+ */
+
+/**
+ * Fetch the matching licence and return data needed for the view licence communications page
+ *
+ * Was built to provide the data needed for the '/licences/{id}/communications' page
+ *
+ * @param {string} licenceId The UUID for the licence to fetch
+ *
+ * @returns {Promise<Object>} the data needed to populate the view licence page's communications tab
+ */
+async function go (licenceId, page) {
+  const { results, total } = await _fetch(licenceId, page)
+
+  return { communications: results, pagination: { total } }
+}
+
+async function _fetch (licenceId, page) {
+  return { results: [], total: 0 }
+}
+
+module.exports = {
+  go
+}

--- a/app/services/licences/fetch-communications.service.js
+++ b/app/services/licences/fetch-communications.service.js
@@ -37,7 +37,7 @@ async function _fetch (licenceRef, page) {
     .withGraphFetched('event')
     .modifyGraph('event', (builder) => {
       builder.select([
-        'created_at',
+        'createdAt',
         'metadata',
         'type',
         'subtype',
@@ -46,7 +46,7 @@ async function _fetch (licenceRef, page) {
       ])
     })
     .page(page - 1, DatabaseConfig.defaultPageSize)
-    .orderBy('send_after', 'desc')
+    .orderBy('sendAfter', 'desc')
 }
 
 module.exports = {

--- a/app/services/licences/view-licence-communications.service.js
+++ b/app/services/licences/view-licence-communications.service.js
@@ -1,0 +1,30 @@
+'use strict'
+
+/**
+ * Orchestrates fetching and presenting the data needed for the view licence communications tab
+ * @module ViewLicenceCommunicationsService
+ */
+
+const ViewLicenceService = require('./view-licence.service.js')
+
+/**
+ * Orchestrates fetching and presenting the data needed for the licence communications page
+ *
+ * @param {string} licenceId - The UUID of the licence
+ * @param {Object} auth - The auth object taken from `request.auth` containing user details
+ *
+ * @returns {Promise<Object>} an object representing the `pageData` needed by the licence communication template.
+ */
+async function go (licenceId, auth) {
+  const commonData = await ViewLicenceService.go(licenceId, auth)
+
+  return {
+    activeTab: 'communications',
+    ...commonData,
+    communications: []
+  }
+}
+
+module.exports = {
+  go
+}

--- a/app/services/licences/view-licence-communications.service.js
+++ b/app/services/licences/view-licence-communications.service.js
@@ -20,7 +20,7 @@ const CommunicationsPresenter = require('../../presenters/licences/communication
 async function go (licenceId, auth, page) {
   const commonData = await ViewLicenceService.go(licenceId, auth)
 
-  const communications = await FetchCommunicationsService.go(licenceId, page)
+  const communications = await FetchCommunicationsService.go(commonData.licenceRef, page)
   const communicationsData = CommunicationsPresenter.go(communications.communications)
 
   return {

--- a/app/services/licences/view-licence-communications.service.js
+++ b/app/services/licences/view-licence-communications.service.js
@@ -5,9 +5,10 @@
  * @module ViewLicenceCommunicationsService
  */
 
-const ViewLicenceService = require('./view-licence.service.js')
-const FetchCommunicationsService = require('./fetch-communications.service.js')
 const CommunicationsPresenter = require('../../presenters/licences/communications.presenter.js')
+const FetchCommunicationsService = require('./fetch-communications.service.js')
+const PaginatorPresenter = require('../../presenters/paginator.presenter.js')
+const ViewLicenceService = require('./view-licence.service.js')
 
 /**
  * Orchestrates fetching and presenting the data needed for the licence communications page
@@ -23,10 +24,13 @@ async function go (licenceId, auth, page) {
   const communications = await FetchCommunicationsService.go(commonData.licenceRef, page)
   const communicationsData = CommunicationsPresenter.go(communications.communications)
 
+  const pagination = PaginatorPresenter.go(communications.pagination.total, Number(page), `/system/licences/${licenceId}/communications`)
+
   return {
     activeTab: 'communications',
     ...commonData,
-    ...communicationsData
+    ...communicationsData,
+    pagination
   }
 }
 

--- a/app/services/licences/view-licence-communications.service.js
+++ b/app/services/licences/view-licence-communications.service.js
@@ -6,6 +6,8 @@
  */
 
 const ViewLicenceService = require('./view-licence.service.js')
+const FetchCommunicationsService = require('./fetch-communications.service.js')
+const CommunicationsPresenter = require('../../presenters/licences/communications.presenter.js')
 
 /**
  * Orchestrates fetching and presenting the data needed for the licence communications page
@@ -15,13 +17,16 @@ const ViewLicenceService = require('./view-licence.service.js')
  *
  * @returns {Promise<Object>} an object representing the `pageData` needed by the licence communication template.
  */
-async function go (licenceId, auth) {
+async function go (licenceId, auth, page) {
   const commonData = await ViewLicenceService.go(licenceId, auth)
+
+  const communications = await FetchCommunicationsService.go(licenceId, page)
+  const communicationsData = CommunicationsPresenter.go(communications.communications)
 
   return {
     activeTab: 'communications',
     ...commonData,
-    communications: []
+    ...communicationsData
   }
 }
 

--- a/app/views/licences/tabs/communications.njk
+++ b/app/views/licences/tabs/communications.njk
@@ -17,10 +17,10 @@
     <tbody class="govuk-table__body">
     {% for communication in communications %}
       <tr class="govuk-table__row">
-        <td class="govuk-table__cell">{{ communication.Type }}</td>
-        <td class="govuk-table__cell">{{ communication.Sent }}</td>
-        <td class="govuk-table__cell">{{ communication.Sender }}</td>
-        <td class="govuk-table__cell">{{ communication.Method }}</td>
+        <td class="govuk-table__cell">{{ communication.type }}</td>
+        <td class="govuk-table__cell">{{ communication.sent }}</td>
+        <td class="govuk-table__cell">{{ communication.sender }}</td>
+        <td class="govuk-table__cell">{{ communication.method }}</td>
       </tr>
     {% endfor %}
     </tbody>

--- a/app/views/licences/tabs/communications.njk
+++ b/app/views/licences/tabs/communications.njk
@@ -1,0 +1,28 @@
+<h2 class="govuk-heading-l">Communications</h2>
+
+{% if communications.length == 0 %}
+  <p> No communications for this licence. </p>
+{% endif %}
+
+{% if communications.length > 0 %}
+  <table class="govuk-table">
+    <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header govuk-!-width-one-third">Type</th>
+      <th scope="col" class="govuk-table__header govuk-!-width-one-third">Sent</th>
+      <th scope="col" class="govuk-table__header govuk-!-width-one-third">Sender</th>
+      <th scope="col" class="govuk-table__header govuk-!-width-one-third">Method</th>
+    </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+    {% for communication in communications %}
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell">{{ communication.Type }}</td>
+        <td class="govuk-table__cell">{{ communication.Sent }}</td>
+        <td class="govuk-table__cell">{{ communication.Sender }}</td>
+        <td class="govuk-table__cell">{{ communication.Method }}</td>
+      </tr>
+    {% endfor %}
+    </tbody>
+  </table>
+{% endif %}

--- a/app/views/licences/tabs/communications.njk
+++ b/app/views/licences/tabs/communications.njk
@@ -33,7 +33,7 @@
         </td>
         <td class="govuk-table__cell">{{ communication.sent }}</td>
         <td class="govuk-table__cell">{{ communication.sender }}</td>
-        <td class="govuk-table__cell">{{ communication.method | title }}</td>
+        <td class="govuk-table__cell">{{ communication.method }}</td>
       </tr>
     {% endfor %}
     </tbody>

--- a/app/views/licences/tabs/communications.njk
+++ b/app/views/licences/tabs/communications.njk
@@ -1,3 +1,5 @@
+{% from "govuk/components/pagination/macro.njk" import govukPagination %}
+
 <h2 class="govuk-heading-l">Communications</h2>
 
 {% if communications.length == 0 %}
@@ -36,4 +38,8 @@
     {% endfor %}
     </tbody>
   </table>
+{% endif %}
+
+{% if communications.length > 0 and pagination.numberOfPages > 1 %}
+  {{ govukPagination(pagination.component) }}
 {% endif %}

--- a/app/views/licences/tabs/communications.njk
+++ b/app/views/licences/tabs/communications.njk
@@ -8,38 +8,26 @@
   <table class="govuk-table">
     <thead class="govuk-table__head">
     <tr class="govuk-table__row">
-      <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Type</th>
-      <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Sent</th>
-      <th scope="col" class="govuk-table__header govuk-!-width-one-half">Sender</th>
-      <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Method</th>
+      <th scope="col" class="govuk-table__header">Type</th>
+      <th scope="col" class="govuk-table__header">Sent</th>
+      <th scope="col" class="govuk-table__header">Sender</th>
+      <th scope="col" class="govuk-table__header">Method</th>
     </tr>
     </thead>
     <tbody class="govuk-table__body">
     {% for communication in communications %}
       <tr class="govuk-table__row">
         <td class="govuk-table__cell">
-
           {% if communication.type.pdf %}
             <p class="govuk-body govuk-!-margin-bottom-0"> {{ communication.type.label }} </p>
             <span class="govuk-visually-hidden"> {{ communication.type.sentVia }} </span>
           {% else %}
-            <a href="/licences/{{ documentId }}/communications/{{ communication.id }}">
-              <p class="govuk-body govuk-!-margin-bottom-0"> {{ communication.type.alert }} </p>
-              <p class="govuk-body govuk-!-margin-bottom-0"> {{ communication.type.label }} </p>
+            <a href="/licences/{{ documentId }}/communications/{{ communication.id }}" class="govuk-link">
+              {{ communication.type.alert }}
+              {{ communication.type.label }}
               <span class="govuk-visually-hidden"> {{ communication.type.sentVia }} </span>
             </a>
           {% endif %}
-
-          {#          {% if message.isPdf %}
-    {{ message.event.metadata.name }}
-    <span class="govuk-visually-hidden"> sent {{ message.event.created | date }} via {{ message.messageType }}</span>
-  {% else %}
-    <a href="/licences/{{ documentId }}/communications/{{ message.id }}">
-      {{ message.event.metadata.options.sendingAlertType | sentenceCase + ' - ' if message.event.metadata.name == 'Water abstraction alert' else '' }}
-      {{ message.event.metadata.name }}
-      <span class="govuk-visually-hidden"> sent {{ message.event.created | date }} via {{ message.messageType }}</span>
-    </a>
-  {% endif %} #}
         </td>
         <td class="govuk-table__cell">{{ communication.sent }}</td>
         <td class="govuk-table__cell">{{ communication.sender }}</td>

--- a/app/views/licences/tabs/communications.njk
+++ b/app/views/licences/tabs/communications.njk
@@ -17,9 +17,20 @@
     <tbody class="govuk-table__body">
     {% for communication in communications %}
       <tr class="govuk-table__row">
-        <td class="govuk-table__cell">{{ communication.type }}
+        <td class="govuk-table__cell">
 
-{#          {% if message.isPdf %}
+          {% if communication.type.pdf %}
+            <p class="govuk-body govuk-!-margin-bottom-0"> {{ communication.type.label }} </p>
+            <span class="govuk-visually-hidden"> {{ communication.type.sentVia }} </span>
+          {% else %}
+            <a href="/licences/{{ documentId }}/communications/{{ communication.id }}">
+              <p class="govuk-body govuk-!-margin-bottom-0"> {{ communication.type.alert }} </p>
+              <p class="govuk-body govuk-!-margin-bottom-0"> {{ communication.type.label }} </p>
+              <span class="govuk-visually-hidden"> {{ communication.type.sentVia }} </span>
+            </a>
+          {% endif %}
+
+          {#          {% if message.isPdf %}
     {{ message.event.metadata.name }}
     <span class="govuk-visually-hidden"> sent {{ message.event.created | date }} via {{ message.messageType }}</span>
   {% else %}
@@ -28,11 +39,11 @@
       {{ message.event.metadata.name }}
       <span class="govuk-visually-hidden"> sent {{ message.event.created | date }} via {{ message.messageType }}</span>
     </a>
-  {% endif %}#}
+  {% endif %} #}
         </td>
         <td class="govuk-table__cell">{{ communication.sent }}</td>
         <td class="govuk-table__cell">{{ communication.sender }}</td>
-        <td class="govuk-table__cell">{{ communication.method | title}}</td>
+        <td class="govuk-table__cell">{{ communication.method | title }}</td>
       </tr>
     {% endfor %}
     </tbody>

--- a/app/views/licences/tabs/communications.njk
+++ b/app/views/licences/tabs/communications.njk
@@ -8,19 +8,31 @@
   <table class="govuk-table">
     <thead class="govuk-table__head">
     <tr class="govuk-table__row">
-      <th scope="col" class="govuk-table__header govuk-!-width-one-third">Type</th>
-      <th scope="col" class="govuk-table__header govuk-!-width-one-third">Sent</th>
-      <th scope="col" class="govuk-table__header govuk-!-width-one-third">Sender</th>
-      <th scope="col" class="govuk-table__header govuk-!-width-one-third">Method</th>
+      <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Type</th>
+      <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Sent</th>
+      <th scope="col" class="govuk-table__header govuk-!-width-one-half">Sender</th>
+      <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Method</th>
     </tr>
     </thead>
     <tbody class="govuk-table__body">
     {% for communication in communications %}
       <tr class="govuk-table__row">
-        <td class="govuk-table__cell">{{ communication.type }}</td>
+        <td class="govuk-table__cell">{{ communication.type }}
+
+{#          {% if message.isPdf %}
+    {{ message.event.metadata.name }}
+    <span class="govuk-visually-hidden"> sent {{ message.event.created | date }} via {{ message.messageType }}</span>
+  {% else %}
+    <a href="/licences/{{ documentId }}/communications/{{ message.id }}">
+      {{ message.event.metadata.options.sendingAlertType | sentenceCase + ' - ' if message.event.metadata.name == 'Water abstraction alert' else '' }}
+      {{ message.event.metadata.name }}
+      <span class="govuk-visually-hidden"> sent {{ message.event.created | date }} via {{ message.messageType }}</span>
+    </a>
+  {% endif %}#}
+        </td>
         <td class="govuk-table__cell">{{ communication.sent }}</td>
         <td class="govuk-table__cell">{{ communication.sender }}</td>
-        <td class="govuk-table__cell">{{ communication.method }}</td>
+        <td class="govuk-table__cell">{{ communication.method | title}}</td>
       </tr>
     {% endfor %}
     </tbody>

--- a/app/views/licences/view.njk
+++ b/app/views/licences/view.njk
@@ -85,6 +85,9 @@
       {% if activeTab === 'returns' %}
         {% include "licences/tabs/returns.njk" %}
       {% endif %}
+      {% if activeTab === 'communications' %}
+        {% include "licences/tabs/communications.njk" %}
+      {% endif %}
       {% if activeTab === 'bills' %}
         {% include "licences/tabs/bills.njk" %}
       {% endif %}

--- a/db/migrations/public/20240516044126_alter-scheduled-notification-add-message-ref-column.js
+++ b/db/migrations/public/20240516044126_alter-scheduled-notification-add-message-ref-column.js
@@ -1,0 +1,43 @@
+'use strict'
+
+const viewName = 'scheduled_notification'
+
+exports.up = async function (knex) {
+  return knex
+    .schema
+    .dropViewIfExists(viewName)
+    .createView(viewName, (view) => {
+      // NOTE: We have commented out unused columns from the source table
+      view.as(knex('scheduled_notification').withSchema('water').select([
+        'scheduled_notification.date_created AS created_at',
+        'scheduled_notification.event_id',
+        'scheduled_notification.id',
+        'scheduled_notification.licences',
+        'scheduled_notification.message_type',
+        'scheduled_notification.message_ref',
+        'scheduled_notification.notify_status',
+        'scheduled_notification.send_after',
+        'scheduled_notification.status'
+
+        // 'scheduled_notification.company_entity_id',
+        // 'scheduled_notification.individual_entity_id',
+        // 'scheduled_notification.job_id',
+        // 'scheduled_notification.log',
+        // 'scheduled_notification.medium',
+        // 'scheduled_notification.metadata',
+        // 'scheduled_notification.next_status_check',
+        // 'scheduled_notification.notification_type',
+        // 'scheduled_notification.notify_id',
+        // 'scheduled_notification.personalisation',
+        // 'scheduled_notification.plaintext',
+        // 'scheduled_notification.recipient',
+        // 'scheduled_notification.status_checks'
+      ]))
+    })
+}
+
+exports.down = async function (knex) {
+  return knex
+    .schema
+    .dropViewIfExists(viewName)
+}

--- a/test/controllers/licences.controller.test.js
+++ b/test/controllers/licences.controller.test.js
@@ -13,10 +13,11 @@ const Boom = require('@hapi/boom')
 
 // Things we need to stub
 const InitiateSessionService = require('../../app/services/return-requirements/initiate-session.service.js')
-const ViewLicenceBillsService = require('../../app/services/licences/view-licence-bills.service')
-const ViewLicenceContactDetailsService = require('../../app/services/licences/view-licence-contact-details.service')
-const ViewLicenceSummaryService = require('../../app/services/licences/view-licence-summary.service')
-const ViewLicenceReturnsService = require('../../app/services/licences/view-licence-returns.service')
+const ViewLicenceBillsService = require('../../app/services/licences/view-licence-bills.service.js')
+const ViewLicenceCommunicationsService = require('../../app/services/licences/view-licence-communications.service.js')
+const ViewLicenceContactDetailsService = require('../../app/services/licences/view-licence-contact-details.service.js')
+const ViewLicenceReturnsService = require('../../app/services/licences/view-licence-returns.service.js')
+const ViewLicenceSummaryService = require('../../app/services/licences/view-licence-summary.service.js')
 
 // For running our service
 const { init } = require('../../app/server.js')
@@ -200,6 +201,53 @@ describe('Licences controller', () => {
     })
   })
 
+  describe('GET /licences/{id}/communications', () => {
+    beforeEach(async () => {
+      options = {
+        method: 'GET',
+        url: '/licences/7861814c-ca19-43f2-be11-3c612f0d744b/communications',
+        auth: {
+          strategy: 'session',
+          credentials: { scope: [] }
+        }
+      }
+    })
+
+    describe('when a request is valid and has communications', () => {
+      beforeEach(async () => {
+        Sinon.stub(ViewLicenceCommunicationsService, 'go').resolves(_viewLicenceCommunications())
+      })
+
+      it('returns the page successfully', async () => {
+        const response = await server.inject(options)
+
+        expect(response.statusCode).to.equal(200)
+        expect(response.payload).to.contain('Communications')
+        expect(response.payload).to.contain('Type')
+        expect(response.payload).to.contain('Sent')
+        expect(response.payload).to.contain('Sender')
+        expect(response.payload).to.contain('Method')
+      })
+    })
+
+    describe('when a request is valid and does not have communications', () => {
+      beforeEach(async () => {
+        Sinon.stub(ViewLicenceCommunicationsService, 'go').resolves({
+          activeTab: 'communications',
+          communications: []
+        })
+      })
+
+      it('returns the page successfully', async () => {
+        const response = await server.inject(options)
+
+        expect(response.statusCode).to.equal(200)
+        expect(response.payload).to.contain('Communications')
+        expect(response.payload).to.contain('No communications for this licence.')
+      })
+    })
+  })
+
   describe('GET /licences/{id}/contact-details', () => {
     beforeEach(async () => {
       options = {
@@ -330,6 +378,13 @@ function _viewLicenceBills () {
   return {
     activeTab: 'bills',
     bills: [{ id: 'bills-id' }]
+  }
+}
+
+function _viewLicenceCommunications () {
+  return {
+    activeTab: 'communications',
+    communications: [{ type: 'paper return', sent: 'date', sender: 'admin@email.com', method: 'letter' }]
   }
 }
 

--- a/test/presenters/licences/communications.presenter.test.js
+++ b/test/presenters/licences/communications.presenter.test.js
@@ -1,0 +1,29 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Thing under test
+const CommunicationsPresenter = require('../../../app/presenters/licences/communications.presenter.js')
+
+describe('Communications presenter', () => {
+  let communications
+
+  beforeEach(() => {
+    communications = []
+  })
+
+  describe('when provided with populated communications data', () => {
+    it('correctly presents the data', () => {
+      const result = CommunicationsPresenter.go(communications)
+
+      expect(result).to.equal({
+        communications: []
+      })
+    })
+  })
+})

--- a/test/presenters/licences/communications.presenter.test.js
+++ b/test/presenters/licences/communications.presenter.test.js
@@ -104,6 +104,7 @@ describe('Communications presenter', () => {
         communications[0].event.metadata.name = 'Water abstraction alert'
         communications[0].event.metadata.options.sendingAlertType = 'test'
       })
+
       it('returns the type object with an alert text', () => {
         const result = CommunicationsPresenter.go(communications)
 

--- a/test/presenters/licences/communications.presenter.test.js
+++ b/test/presenters/licences/communications.presenter.test.js
@@ -53,11 +53,13 @@ describe('Communications presenter', () => {
         ]
       })
     })
-    
+
     describe("the 'messageRef' property", () => {
       describe('when the message ref contains pdf', () => {
-        it('returns that communication type', () => {
+        beforeEach(() => {
           communications[0].messageRef = 'pdf.return_form'
+        })
+        it('returns that communication type', () => {
           const result = CommunicationsPresenter.go(communications)
 
           expect(result.communications[0].type).to.equal({
@@ -84,9 +86,11 @@ describe('Communications presenter', () => {
     })
 
     describe("the 'messageType' property", () => {
+      beforeEach(() => {
+        communications[0].messageType = 'i AM in senTence case'
+      })
       describe('when the message type is present', () => {
         it('returns the method key in sentence case', () => {
-          communications[0].messageType = 'i AM in senTence case'
           const result = CommunicationsPresenter.go(communications)
 
           expect(result.communications[0].method).to.equal('I am in sentence case')
@@ -95,9 +99,11 @@ describe('Communications presenter', () => {
     })
 
     describe("when the communication is a 'Water abstraction alert'", () => {
-      it('returns the type object with an alert text', () => {
+      beforeEach(() => {
         communications[0].event.metadata.name = 'Water abstraction alert'
         communications[0].event.metadata.options.sendingAlertType = 'test'
+      })
+      it('returns the type object with an alert text', () => {
         const result = CommunicationsPresenter.go(communications)
 
         expect(result.communications[0].type).to.equal({

--- a/test/presenters/licences/communications.presenter.test.js
+++ b/test/presenters/licences/communications.presenter.test.js
@@ -68,6 +68,7 @@ describe('Communications presenter', () => {
           })
         })
       })
+
       describe('when the message ref does not contain pdf', () => {
         it('returns that communication type', () => {
           const result = CommunicationsPresenter.go(communications)

--- a/test/presenters/licences/communications.presenter.test.js
+++ b/test/presenters/licences/communications.presenter.test.js
@@ -91,5 +91,20 @@ describe('Communications presenter', () => {
         })
       })
     })
+
+    describe('when the communication is a \'Water abstraction alert\' ', () => {
+      it('returns the type object with an alert text', () => {
+        communications[0].event.metadata.name = 'Water abstraction alert'
+        communications[0].event.metadata.options.sendingAlertType = 'test'
+        const result = CommunicationsPresenter.go(communications)
+
+        expect(result.communications[0].type).to.equal({
+          alert: 'Test - Water abstraction alert',
+          label: 'Water abstraction alert',
+          pdf: false,
+          sentVia: 'sent 15 May 2024 via letter'
+        })
+      })
+    })
   })
 })

--- a/test/presenters/licences/communications.presenter.test.js
+++ b/test/presenters/licences/communications.presenter.test.js
@@ -93,7 +93,7 @@ describe('Communications presenter', () => {
       })
     })
 
-    describe('when the communication is a \'Water abstraction alert\' ', () => {
+    describe("when the communication is a 'Water abstraction alert'", () => {
       it('returns the type object with an alert text', () => {
         communications[0].event.metadata.name = 'Water abstraction alert'
         communications[0].event.metadata.options.sendingAlertType = 'test'

--- a/test/presenters/licences/communications.presenter.test.js
+++ b/test/presenters/licences/communications.presenter.test.js
@@ -53,7 +53,8 @@ describe('Communications presenter', () => {
         ]
       })
     })
-    describe('the \'messageRef\' property', () => {
+    
+    describe("the 'messageRef' property", () => {
       describe('when the message ref contains pdf', () => {
         it('returns that communication type', () => {
           communications[0].messageRef = 'pdf.return_form'

--- a/test/presenters/licences/communications.presenter.test.js
+++ b/test/presenters/licences/communications.presenter.test.js
@@ -10,11 +10,27 @@ const { expect } = Code
 // Thing under test
 const CommunicationsPresenter = require('../../../app/presenters/licences/communications.presenter.js')
 
-describe('Communications presenter', () => {
+describe.only('Communications presenter', () => {
   let communications
 
   beforeEach(() => {
-    communications = []
+    communications = [{
+      id: '3ce7d0b6-610f-4cb2-9d4c-9761db797141',
+      messageType: 'letter',
+      messageRef: 'returns_invitation_licence_holder_letter',
+      event: {
+        createdAt: '2024-05-15T10:27:15.000Z',
+        metadata: {
+          name: 'Returns: invitation',
+          options: {
+          }
+        },
+        type: 'notification',
+        subtype: 'returnInvitation',
+        status: 'processed',
+        issuer: 'admin-internal@wrls.gov.uk'
+      }
+    }]
   })
 
   describe('when provided with populated communications data', () => {
@@ -22,7 +38,57 @@ describe('Communications presenter', () => {
       const result = CommunicationsPresenter.go(communications)
 
       expect(result).to.equal({
-        communications: []
+        communications: [{
+          id: '3ce7d0b6-610f-4cb2-9d4c-9761db797141',
+          method: 'Letter',
+          sender: 'admin-internal@wrls.gov.uk',
+          sent: '15 May 2024',
+          type: {
+            alert: null,
+            label: 'Returns: invitation',
+            pdf: false,
+            sentVia: 'sent 15 May 2024 via letter'
+          }
+        }
+        ]
+      })
+    })
+    describe('the \'messageRef\' property', () => {
+      describe('when the message ref contains pdf', () => {
+        it('returns that communication type', () => {
+          communications[0].messageRef = 'pdf.return_form'
+          const result = CommunicationsPresenter.go(communications)
+
+          expect(result.communications[0].type).to.equal({
+            alert: null,
+            label: 'Returns: invitation',
+            pdf: true,
+            sentVia: 'sent 15 May 2024 via letter'
+          })
+        })
+      })
+      describe('when the message ref does not contain pdf', () => {
+        it('returns that communication type', () => {
+          const result = CommunicationsPresenter.go(communications)
+
+          expect(result.communications[0].type).to.equal({
+            alert: null,
+            label: 'Returns: invitation',
+            pdf: false,
+            sentVia: 'sent 15 May 2024 via letter'
+          })
+        })
+      })
+    })
+
+    describe('the \'messageType\' property', () => {
+      describe('when the message type is present', () => {
+        it('returns the method key in sentence case', () => {
+          communications[0].messageType = 'i AM in senTence case'
+          const result = CommunicationsPresenter.go(communications)
+
+          expect(result.communications[0].method).to.equal('I am in sentence case')
+        })
       })
     })
   })

--- a/test/presenters/licences/communications.presenter.test.js
+++ b/test/presenters/licences/communications.presenter.test.js
@@ -59,6 +59,7 @@ describe('Communications presenter', () => {
         beforeEach(() => {
           communications[0].messageRef = 'pdf.return_form'
         })
+
         it('returns that communication type', () => {
           const result = CommunicationsPresenter.go(communications)
 

--- a/test/presenters/licences/communications.presenter.test.js
+++ b/test/presenters/licences/communications.presenter.test.js
@@ -10,7 +10,7 @@ const { expect } = Code
 // Thing under test
 const CommunicationsPresenter = require('../../../app/presenters/licences/communications.presenter.js')
 
-describe.only('Communications presenter', () => {
+describe('Communications presenter', () => {
   let communications
 
   beforeEach(() => {

--- a/test/presenters/licences/communications.presenter.test.js
+++ b/test/presenters/licences/communications.presenter.test.js
@@ -90,6 +90,7 @@ describe('Communications presenter', () => {
       beforeEach(() => {
         communications[0].messageType = 'i AM in senTence case'
       })
+
       describe('when the message type is present', () => {
         it('returns the method key in sentence case', () => {
           const result = CommunicationsPresenter.go(communications)

--- a/test/presenters/licences/communications.presenter.test.js
+++ b/test/presenters/licences/communications.presenter.test.js
@@ -82,7 +82,7 @@ describe('Communications presenter', () => {
       })
     })
 
-    describe('the \'messageType\' property', () => {
+    describe("the 'messageType' property", () => {
       describe('when the message type is present', () => {
         it('returns the method key in sentence case', () => {
           communications[0].messageType = 'i AM in senTence case'

--- a/test/presenters/licences/view-licence-presenter.test.js
+++ b/test/presenters/licences/view-licence-presenter.test.js
@@ -25,6 +25,7 @@ describe('View Licence presenter', () => {
 
       expect(result).to.equal({
         activeNavBar: 'search',
+        documentId: '28665d16-eba3-4c9a-aa55-7ab671b0c4fb',
         licenceId: 'f1288f6c-8503-4dc1-b114-75c408a14bd0',
         licenceName: 'Unregistered licence',
         licenceRef: '01/123',
@@ -32,8 +33,7 @@ describe('View Licence presenter', () => {
         pageTitle: 'Licence 01/123',
         registeredTo: null,
         roles: null,
-        warning: null,
-        documentId: '28665d16-eba3-4c9a-aa55-7ab671b0c4fb'
+        warning: null
       })
     })
   })

--- a/test/presenters/licences/view-licence-presenter.test.js
+++ b/test/presenters/licences/view-licence-presenter.test.js
@@ -8,7 +8,7 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Thing under test
-const ViewLicencePresenter = require('../../../app/presenters/licences/view-licence.presenter')
+const ViewLicencePresenter = require('../../../app/presenters/licences/view-licence.presenter.js')
 
 describe('View Licence presenter', () => {
   let licence
@@ -32,7 +32,8 @@ describe('View Licence presenter', () => {
         pageTitle: 'Licence 01/123',
         registeredTo: null,
         roles: null,
-        warning: null
+        warning: null,
+        documentId: '28665d16-eba3-4c9a-aa55-7ab671b0c4fb'
       })
     })
   })

--- a/test/services/licences/fetch-communications.service.test.js
+++ b/test/services/licences/fetch-communications.service.test.js
@@ -34,8 +34,6 @@ describe('Fetch Communications service', () => {
   })
 
   describe('when the licence has communications', () => {
-    beforeEach(async () => {
-    })
 
     it('returns the matching communication', async () => {
       const result = await FetchCommunicationsService.go(licenceRef)

--- a/test/services/licences/fetch-communications.service.test.js
+++ b/test/services/licences/fetch-communications.service.test.js
@@ -37,7 +37,7 @@ describe('Fetch Communications service', () => {
     beforeEach(async () => {
     })
 
-    it('returns the matching licence customer contacts', async () => {
+    it('returns the matching communication', async () => {
       const result = await FetchCommunicationsService.go(licenceRef)
 
       expect(result.pagination).to.equal({

--- a/test/services/licences/fetch-communications.service.test.js
+++ b/test/services/licences/fetch-communications.service.test.js
@@ -1,0 +1,34 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const DatabaseSupport = require('../../support/database.js')
+
+// Thing under test
+const FetchCommunicationsService =
+  require('../../../app/services/licences/fetch-communications.service.js')
+
+describe('Fetch Communications service', () => {
+  let licenceId
+
+  beforeEach(async () => {
+    await DatabaseSupport.clean()
+  })
+
+  describe('when the licence has communications', () => {
+    beforeEach(async () => {
+    })
+
+    it('returns the matching licence customer contacts', async () => {
+      const results = await FetchCommunicationsService.go(licenceId)
+
+      expect(results).to.equal([])
+    })
+  })
+})

--- a/test/services/licences/fetch-communications.service.test.js
+++ b/test/services/licences/fetch-communications.service.test.js
@@ -28,7 +28,7 @@ describe('Fetch Communications service', () => {
     it('returns the matching licence customer contacts', async () => {
       const results = await FetchCommunicationsService.go(licenceId)
 
-      expect(results).to.equal([])
+      expect(results).to.equal({ communications: [], pagination: { total: 0 } })
     })
   })
 })

--- a/test/services/licences/fetch-communications.service.test.js
+++ b/test/services/licences/fetch-communications.service.test.js
@@ -62,7 +62,7 @@ describe('Fetch Communications service', () => {
         total: 0
       })
 
-      expect(result.communications).to.equal([])
+      expect(result.communications).to.be.empty()
     })
   })
 })

--- a/test/services/licences/fetch-communications.service.test.js
+++ b/test/services/licences/fetch-communications.service.test.js
@@ -54,8 +54,6 @@ describe('Fetch Communications service', () => {
   })
 
   describe('when the licence has no communications', () => {
-    beforeEach(async () => {
-    })
 
     it('returns no communications', async () => {
       const result = await FetchCommunicationsService.go()

--- a/test/services/licences/fetch-communications.service.test.js
+++ b/test/services/licences/fetch-communications.service.test.js
@@ -59,7 +59,7 @@ describe('Fetch Communications service', () => {
     beforeEach(async () => {
     })
 
-    it('returns the matching licence customer contacts', async () => {
+    it('returns no communications', async () => {
       const result = await FetchCommunicationsService.go()
 
       expect(result.pagination).to.equal({

--- a/test/services/licences/fetch-communications.service.test.js
+++ b/test/services/licences/fetch-communications.service.test.js
@@ -16,7 +16,7 @@ const ScheduledNotificationModel = require('../../support/helpers/scheduled-noti
 const FetchCommunicationsService =
   require('../../../app/services/licences/fetch-communications.service.js')
 
-describe.only('Fetch Communications service', () => {
+describe('Fetch Communications service', () => {
   const licenceRef = '01/01'
 
   let testRecord

--- a/test/services/licences/fetch-communications.service.test.js
+++ b/test/services/licences/fetch-communications.service.test.js
@@ -56,7 +56,7 @@ describe('Fetch Communications service', () => {
   describe('when the licence has no communications', () => {
 
     it('returns no communications', async () => {
-      const result = await FetchCommunicationsService.go()
+      const result = await FetchCommunicationsService.go('01/02')
 
       expect(result.pagination).to.equal({
         total: 0

--- a/test/services/licences/view-licence-communications.service.test.js
+++ b/test/services/licences/view-licence-communications.service.test.js
@@ -10,6 +10,7 @@ const { expect } = Code
 
 // Things we need to stub
 const FetchCommunicationsService = require('../../../app/services/licences/fetch-communications.service.js')
+const PaginatorPresenter = require('../../../app/presenters/paginator.presenter.js')
 const ViewLicenceService = require('../../../app/services/licences/view-licence.service.js')
 
 // Thing under test
@@ -18,10 +19,12 @@ const ViewLicenceCommunicationsService = require('../../../app/services/licences
 describe('View Licence Communications service', () => {
   const auth = {}
   const page = 1
+  const pagination = { page }
   const testId = '2c80bd22-a005-4cf4-a2a2-73812a9861de'
 
   beforeEach(() => {
     Sinon.stub(ViewLicenceService, 'go').resolves({ licenceName: 'fake licence' })
+    Sinon.stub(PaginatorPresenter, 'go').returns(pagination)
     Sinon.stub(FetchCommunicationsService, 'go').resolves({
       communications: [],
       pagination: { total: 1 }
@@ -39,7 +42,10 @@ describe('View Licence Communications service', () => {
       expect(result).to.equal({
         activeTab: 'communications',
         communications: [],
-        licenceName: 'fake licence'
+        licenceName: 'fake licence',
+        pagination: {
+          page: 1
+        }
       })
     })
   })

--- a/test/services/licences/view-licence-communications.service.test.js
+++ b/test/services/licences/view-licence-communications.service.test.js
@@ -9,6 +9,7 @@ const { describe, it, beforeEach, afterEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Things we need to stub
+const FetchCommunicationsService = require('../../../app/services/licences/fetch-communications.service.js')
 const ViewLicenceService = require('../../../app/services/licences/view-licence.service.js')
 
 // Thing under test
@@ -16,10 +17,15 @@ const ViewLicenceCommunicationsService = require('../../../app/services/licences
 
 describe('View Licence Communications service', () => {
   const auth = {}
+  const page = 1
   const testId = '2c80bd22-a005-4cf4-a2a2-73812a9861de'
 
   beforeEach(() => {
     Sinon.stub(ViewLicenceService, 'go').resolves({ licenceName: 'fake licence' })
+    Sinon.stub(FetchCommunicationsService, 'go').resolves({
+      communications: [],
+      pagination: { total: 1 }
+    })
   })
 
   afterEach(() => {
@@ -28,7 +34,7 @@ describe('View Licence Communications service', () => {
 
   describe('when called', () => {
     it('returns page data for the view', async () => {
-      const result = await ViewLicenceCommunicationsService.go(testId, auth)
+      const result = await ViewLicenceCommunicationsService.go(testId, auth, page)
 
       expect(result).to.equal({
         activeTab: 'communications',

--- a/test/services/licences/view-licence-communications.service.test.js
+++ b/test/services/licences/view-licence-communications.service.test.js
@@ -1,0 +1,40 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { describe, it, beforeEach, afterEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Things we need to stub
+const ViewLicenceService = require('../../../app/services/licences/view-licence.service.js')
+
+// Thing under test
+const ViewLicenceCommunicationsService = require('../../../app/services/licences/view-licence-communications.service.js')
+
+describe('View Licence Communications service', () => {
+  const auth = {}
+  const testId = '2c80bd22-a005-4cf4-a2a2-73812a9861de'
+
+  beforeEach(() => {
+    Sinon.stub(ViewLicenceService, 'go').resolves({ licenceName: 'fake licence' })
+  })
+
+  afterEach(() => {
+    Sinon.restore()
+  })
+
+  describe('when called', () => {
+    it('returns page data for the view', async () => {
+      const result = await ViewLicenceCommunicationsService.go(testId, auth)
+
+      expect(result).to.equal({
+        activeTab: 'communications',
+        communications: [],
+        licenceName: 'fake licence'
+      })
+    })
+  })
+})

--- a/test/services/licences/view-licence.service.test.js
+++ b/test/services/licences/view-licence.service.test.js
@@ -47,6 +47,7 @@ describe('View Licence service', () => {
 
         expect(result).to.equal({
           activeNavBar: 'search',
+          documentId: '28665d16-eba3-4c9a-aa55-7ab671b0c4fb',
           licenceId: '2c80bd22-a005-4cf4-a2a2-73812a9861de',
           licenceName: 'Unregistered licence',
           licenceRef: '01/130/R01',
@@ -158,6 +159,7 @@ function _testLicence () {
     licenceRef: '01/130/R01',
     licenceName: 'Unregistered licence',
     registeredTo: null,
-    startDate: new Date('2013-03-07')
+    startDate: new Date('2013-03-07'),
+    licenceDocumentHeader: { id: '28665d16-eba3-4c9a-aa55-7ab671b0c4fb' }
   })
 }

--- a/test/support/helpers/scheduled-notification.helper.js
+++ b/test/support/helpers/scheduled-notification.helper.js
@@ -37,7 +37,8 @@ function add (data = {}) {
  */
 function defaults (data = {}) {
   const defaults = {
-    eventId: generateUUID()
+    eventId: generateUUID(),
+    notifyStatus: 'delivered'
   }
 
   return {

--- a/test/support/helpers/scheduled-notification.helper.js
+++ b/test/support/helpers/scheduled-notification.helper.js
@@ -14,6 +14,7 @@ const { generateUUID } = require('../../../app/lib/general.lib.js')
  *
  * - `id` - [random UUID]
  * - `event_id` - [random UUID]
+ * - 'notify_status': 'delivered'
  *
  * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
  *


### PR DESCRIPTION

https://eaflood.atlassian.net/browse/WATER-4315

The existing service handling view licence is slow because it loads all the data for the tabs in one render. Work has been done previously to refactor the summary page to load only the summary information.

This change will add a communications controller, service and presenter to handle the communications tab data introducing a customer contacts presenter and fetch service.

This will share the same view as the summary page and load the same 'common data' established in previous work.