### PR TITLE
Remove returns requirements button on check page

### DIFF
--- a/app/controllers/return-requirements.controller.js
+++ b/app/controllers/return-requirements.controller.js
@@ -396,7 +396,7 @@ async function submitReason (request, h) {
 async function submitRemove (request, h) {
   const { requirementIndex, sessionId } = request.params
 
-  await SubmitRemoveService.go(sessionId, requirementIndex)
+  await SubmitRemoveService.go(sessionId, requirementIndex, request.yar)
 
   return h.redirect(`/system/return-requirements/${sessionId}/check`)
 }

--- a/app/services/return-requirements/submit-remove.service.js
+++ b/app/services/return-requirements/submit-remove.service.js
@@ -17,8 +17,15 @@ const SessionModel = require('../../models/session.model.js')
  *
  * @returns {Promise} the promise returned is not intended to resolve to any particular value
  */
-async function go (sessionId, requirementIndex) {
+async function go (sessionId, requirementIndex, yar) {
   const session = await SessionModel.query().findById(sessionId)
+
+  const notification = {
+    title: 'Removed',
+    text: 'Requirement removed'
+  }
+
+  yar.flash('notification', notification)
 
   return _removeRequirementFromSession(session, requirementIndex)
 }

--- a/app/services/return-requirements/submit-remove.service.js
+++ b/app/services/return-requirements/submit-remove.service.js
@@ -14,6 +14,8 @@ const SessionModel = require('../../models/session.model.js')
  * is deleted from the session in the database.
  *
  * @param {string} sessionId - The UUID for the return requirement setup session record
+ * @param {number} requirementIndex - The index of the requirement being removed
+ * @param {Object} yar - The Hapi `request.yar` session manager passed on by the controller
  *
  * @returns {Promise} the promise returned is not intended to resolve to any particular value
  */

--- a/app/views/return-requirements/check.njk
+++ b/app/views/return-requirements/check.njk
@@ -113,7 +113,7 @@
         {# Set an easier to use index #}
         {% set rowIndex = loop.index0 %}
         <div>
-          <h3>{{requirement.siteDescription}}</h3>
+          <h3 class="govuk-body">{{requirement.siteDescription}}</h3>
           {{ govukButton({
             text: "Remove requirement",
             classes: "govuk-button--warning",

--- a/app/views/return-requirements/check.njk
+++ b/app/views/return-requirements/check.njk
@@ -114,7 +114,12 @@
         {% set rowIndex = loop.index0 %}
         <div>
           <h3>{{requirement.siteDescription}}</h3>
-          <p>Remove {{rowIndex}} </p>
+          {{ govukButton({
+            text: "Remove requirement",
+            classes: "govuk-button--warning",
+            preventDoubleClick: true,
+            href: "/system/return-requirements/" + sessionId + "/remove/" + rowIndex
+          }) }}
         </div>
       {% endfor %}
     </div>

--- a/test/services/return-requirements/submit-remove.service.test.js
+++ b/test/services/return-requirements/submit-remove.service.test.js
@@ -15,7 +15,7 @@ const SessionHelper = require('../../support/helpers/session.helper.js')
 // Thing under test
 const SubmitRemoveService = require('../../../app/services/return-requirements/submit-remove.service.js')
 
-describe.only('Return Requirements - Submit Remove service', () => {
+describe('Return Requirements - Submit Remove service', () => {
   const requirementIndex = 0
 
   let session

--- a/test/services/return-requirements/submit-remove.service.test.js
+++ b/test/services/return-requirements/submit-remove.service.test.js
@@ -3,6 +3,7 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
+const Sinon = require('sinon')
 
 const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
@@ -14,10 +15,11 @@ const SessionHelper = require('../../support/helpers/session.helper.js')
 // Thing under test
 const SubmitRemoveService = require('../../../app/services/return-requirements/submit-remove.service.js')
 
-describe('Return Requirements - Submit Remove service', () => {
+describe.only('Return Requirements - Submit Remove service', () => {
   const requirementIndex = 0
 
   let session
+  let yarStub
 
   beforeEach(async () => {
     await DatabaseSupport.clean()
@@ -60,15 +62,28 @@ describe('Return Requirements - Submit Remove service', () => {
         reason: 'major-change'
       }
     })
+
+    yarStub = {
+      flash: Sinon.stub()
+    }
   })
 
   describe('when a user submits the return requirements to be removed', () => {
     it('deletes the selected requirement from the session data', async () => {
-      await SubmitRemoveService.go(session.id, requirementIndex)
+      await SubmitRemoveService.go(session.id, requirementIndex, yarStub)
 
       const refreshedSession = await session.$query()
 
       expect(refreshedSession.requirements[requirementIndex]).not.to.exist()
+    })
+
+    it("sets the notification message to 'Requirements removed'", async () => {
+      await SubmitRemoveService.go(session.id, requirementIndex, yarStub)
+
+      const [flashType, notification] = yarStub.flash.args[0]
+
+      expect(flashType).to.equal('notification')
+      expect(notification).to.equal({ title: 'Removed', text: 'Requirement removed' })
     })
   })
 })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4304

When setting up a requirement for returns, a user can now add multiple requirements. As a result of being able to add more requirements, errors can occur where unwanted requirements have been added to a return.

Users need the flexibility to remove a single requirement on the check page without having to cancel the entire return through the [Cancel these return requirements](https://eaflood.atlassian.net/browse/WATER-4302) button. Users must also be notified of the removed requirement when redirected to the check page.

This PR expands on [Remove these return requirements](https://eaflood.atlassian.net/browse/WATER-4304 ) and implements a button to redirect users to the remove page where requirements can be removed one by one. Yar notifications are also added in this PR to notify users of a successfully removed requirement.