### PR TITLE
Fix bug introduced when fixing merge conflicts

### DIFF
--- a/app/controllers/bill-runs.controller.js
+++ b/app/controllers/bill-runs.controller.js
@@ -67,7 +67,7 @@ async function cancel (request, h) {
 async function chargeReferenceDetails (request, h) {
   const { id: billRunId, licenceId, reviewChargeReferenceId } = request.params
 
-  const pageData = await ChargeReferenceDetailsService.go(billRunId, licenceId, reviewChargeReferenceId)
+  const pageData = await ChargeReferenceDetailsService.go(billRunId, licenceId, reviewChargeReferenceId, request.yar)
 
   return h.view('bill-runs/charge-reference-details.njk', {
     pageTitle: 'Charge reference details',


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4439

Whilst sorting out some merge conflicts in this PR https://github.com/DEFRA/water-abstraction-system/pull/987 a bug was introduced. The bug was caused by `yar` no longer being sent to the `charge-reference-details` service.

This PR fixes that issue.