### PR TITLE
Alter 2PT Review Licences filter behaviour

### DIFF
--- a/app/controllers/bill-runs.controller.js
+++ b/app/controllers/bill-runs.controller.js
@@ -227,7 +227,7 @@ async function submitRemoveLicence (request, h) {
 async function submitReview (request, h) {
   const { id } = request.params
 
-  await SubmitReviewBillRunService.go(request.payload, request.yar)
+  await SubmitReviewBillRunService.go(id, request.payload, request.yar)
 
   return h.redirect(`/system/bill-runs/${id}/review`)
 }

--- a/app/services/bill-runs/two-part-tariff/review-bill-run.service.js
+++ b/app/services/bill-runs/two-part-tariff/review-bill-run.service.js
@@ -20,7 +20,7 @@ const ReviewBillRunPresenter = require('../../../presenters/bill-runs/two-part-t
  * details of the bill run and the licences linked to it as well as any data that has been used to filter the results.
  */
 async function go (id, page, yar) {
-  const { filterIssues, filterLicenceHolder, filterLicenceStatus } = _getFilters(yar)
+  const { filterIssues, filterLicenceHolder, filterLicenceStatus } = _getFilters(id, yar)
 
   const selectedPageNumber = page ? Number(page) : 1
 
@@ -49,8 +49,8 @@ async function go (id, page, yar) {
   return { bannerMessage, ...pageData, pageTitle, pagination }
 }
 
-function _getFilters (yar) {
-  const filters = yar.get('reviewFilters')
+function _getFilters (id, yar) {
+  const filters = yar.get(`review-${id}`)
 
   const filterIssues = filters?.filterIssues
   const filterLicenceHolder = filters?.filterLicenceHolder

--- a/app/services/bill-runs/two-part-tariff/submit-review-bill-run.service.js
+++ b/app/services/bill-runs/two-part-tariff/submit-review-bill-run.service.js
@@ -8,19 +8,20 @@
 /**
  * Updates the session cookie with the filter data needed for the two-part tariff review bill run page
  *
+ * @param {String} billRunId - The UUID of the bill run
  * @param {Object} payload The `request.payload` containing the filter data.
  * @param {Object} yar - The Hapi `request.yar` session manager passed on by the controller
  */
-async function go (payload, yar) {
+async function go (billRunId, payload, yar) {
   const clearFilters = payload?.clearFilters
   const filterIssues = payload?.filterIssues
   const filterLicenceHolder = payload?.filterLicenceHolder
   const filterLicenceStatus = payload?.filterLicenceStatus
 
   if (clearFilters) {
-    yar.clear('reviewFilters')
+    yar.clear(`review-${billRunId}`)
   } else {
-    yar.set('reviewFilters', {
+    yar.set(`review-${billRunId}`, {
       filterIssues,
       filterLicenceHolder,
       filterLicenceStatus

--- a/test/services/bill-runs/two-part-tariff/submit-review-bill-run.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/submit-review-bill-run.service.test.js
@@ -12,6 +12,7 @@ const { expect } = Code
 const SubmitReviewBillRunService = require('../../../../app/services/bill-runs/two-part-tariff/submit-review-bill-run.service.js')
 
 describe('Submit Review Bill Run Service', () => {
+  const billRunId = '27dad88a-6b3c-438b-a25f-f1483e7e12a0'
   let yarStub
 
   beforeEach(() => {
@@ -30,10 +31,11 @@ describe('Submit Review Bill Run Service', () => {
     }
 
     it('will set the cookie with the filter data', async () => {
-      await SubmitReviewBillRunService.go(payload, yarStub)
+      await SubmitReviewBillRunService.go(billRunId, payload, yarStub)
 
       expect(yarStub.clear.called).to.be.false()
       expect(yarStub.set.called).to.be.true()
+      expect(yarStub.set.args[0][0]).to.equal('review-27dad88a-6b3c-438b-a25f-f1483e7e12a0')
       expect(yarStub.set.args[0][1]).to.equal(payload)
     })
   })
@@ -42,9 +44,10 @@ describe('Submit Review Bill Run Service', () => {
     const payload = { clearFilters: 'reset' }
 
     it('will clear the filter data from the cookie', async () => {
-      await SubmitReviewBillRunService.go(payload, yarStub)
+      await SubmitReviewBillRunService.go(billRunId, payload, yarStub)
 
       expect(yarStub.clear.called).to.be.true()
+      expect(yarStub.clear.args[0][0]).to.equal('review-27dad88a-6b3c-438b-a25f-f1483e7e12a0')
       expect(yarStub.set.called).to.be.false()
     })
   })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4462

Currently, the filter data that is held in the cookie for the "Review Licences" page will persist each time the user accesses the page, regardless of which 2PT bill run they are reviewing.

This is not desirable behaviour. So in this PR the identifier for the cookie data will now include the `billRunId` to which it relates so it only persists data for the bill run the user set the filter on.