### PR TITLE
Fix QA issues found with the review adjustment factors validation

### DIFF
--- a/app/services/bill-runs/two-part-tariff/submit-amended-adjustment-factor.service.js
+++ b/app/services/bill-runs/two-part-tariff/submit-amended-adjustment-factor.service.js
@@ -63,7 +63,7 @@ async function _persistAmendedAdjustmentFactor (reviewChargeReferenceId, payload
 }
 
 function _validate (payload) {
-  const maxDecimalsForAggregateValue = 2
+  const maxDecimalsForAggregateValue = 15
   const maxDecimalsForChargeAdjustmentValue = 15
 
   const aggregateValidation = AdjustmentFactorValidator.go(

--- a/app/validators/bill-runs/two-part-tariff/adjustment-factor.validator.js
+++ b/app/validators/bill-runs/two-part-tariff/adjustment-factor.validator.js
@@ -45,7 +45,7 @@ function _customValidation (quantity, helpers, maxNumberOfDecimals, validationTy
   }
 
   return helpers.message({
-    custom: `The ${validationType} must contain no more than ${maxNumberOfDecimals} decimal places`
+    custom: `The ${validationType} factor must not have more than ${maxNumberOfDecimals} decimal places`
   })
 }
 
@@ -60,7 +60,7 @@ function _validate (quantity, maxNumberOfDecimals, validationType) {
         'number.base': `The ${validationType} factor must be a number`,
         'number.unsafe': `The ${validationType} factor must be a number`,
         'number.min': `The ${validationType} factor must be greater than 0`,
-        'number.max': `The ${validationType} factor must be less than 1`,
+        'number.max': `The ${validationType} factor must be equal to or less than 1`,
         'any.required': `Enter a ${validationType} factor`
       })
   })

--- a/test/validators/bill-runs/two-part-tariff/adjustment-factor.validator.test.js
+++ b/test/validators/bill-runs/two-part-tariff/adjustment-factor.validator.test.js
@@ -11,8 +11,9 @@ const { expect } = Code
 const AdjustmentFactorValidator = require('../../../../app/validators/bill-runs/two-part-tariff/adjustment-factor.validator.js')
 
 describe('Adjustment Factor validator', () => {
+  const maxNumberOfDecimals = 15
+
   let payload
-  let maxNumberOfDecimals
   let validationType
 
   describe('when a valid payload is provided', () => {
@@ -22,7 +23,6 @@ describe('Adjustment Factor validator', () => {
           amendedAggregateFactor: 0.5
         }
 
-        maxNumberOfDecimals = 2
         validationType = 'aggregate'
       })
 
@@ -39,12 +39,15 @@ describe('Adjustment Factor validator', () => {
           amendedChargeAdjustment: 0.5
         }
 
-        maxNumberOfDecimals = 15
         validationType = 'charge'
       })
 
       it('confirms the payload is valid', () => {
-        const result = AdjustmentFactorValidator.go(payload.amendedChargeAdjustment, maxNumberOfDecimals, validationType)
+        const result = AdjustmentFactorValidator.go(
+          payload.amendedChargeAdjustment,
+          maxNumberOfDecimals,
+          validationType
+        )
 
         expect(result.error).not.to.exist()
       })
@@ -56,7 +59,6 @@ describe('Adjustment Factor validator', () => {
       beforeEach(() => {
         payload = undefined
 
-        maxNumberOfDecimals = 2
         validationType = 'aggregate'
       })
 
@@ -74,7 +76,6 @@ describe('Adjustment Factor validator', () => {
           amendedAggregateFactor: 'Hello World'
         }
 
-        maxNumberOfDecimals = 2
         validationType = 'aggregate'
       })
 
@@ -89,18 +90,19 @@ describe('Adjustment Factor validator', () => {
     describe('because the user entered too many decimal places', () => {
       beforeEach(() => {
         payload = {
-          amendedAggregateFactor: 0.555
+          amendedAggregateFactor: 0.1234567890123456
         }
 
-        maxNumberOfDecimals = 2
         validationType = 'aggregate'
       })
 
-      it("fails the validation with the message 'The aggregate must contain no more than 2 decimal places'", () => {
+      it("fails the validation with the message 'The aggregate factor must not have more than 15 decimal places'", () => {
         const result = AdjustmentFactorValidator.go(payload.amendedAggregateFactor, maxNumberOfDecimals, validationType)
 
         expect(result.error).to.exist()
-        expect(result.error.details[0].message).to.equal('The aggregate must contain no more than 2 decimal places')
+        expect(result.error.details[0].message).to.equal(
+          'The aggregate factor must not have more than 15 decimal places'
+        )
       })
     })
 
@@ -110,15 +112,14 @@ describe('Adjustment Factor validator', () => {
           amendedAggregateFactor: 1.1
         }
 
-        maxNumberOfDecimals = 2
         validationType = 'aggregate'
       })
 
-      it("fails the validation with the message 'The aggregate factor must be less than 1'", () => {
+      it("fails the validation with the message 'The aggregate factor must be equal to or less than 1'", () => {
         const result = AdjustmentFactorValidator.go(payload.amendedAggregateFactor, maxNumberOfDecimals, validationType)
 
         expect(result.error).to.exist()
-        expect(result.error.details[0].message).to.equal('The aggregate factor must be less than 1')
+        expect(result.error.details[0].message).to.equal('The aggregate factor must be equal to or less than 1')
       })
     })
 
@@ -128,7 +129,6 @@ describe('Adjustment Factor validator', () => {
           amendedAggregateFactor: -1
         }
 
-        maxNumberOfDecimals = 2
         validationType = 'aggregate'
       })
 
@@ -146,7 +146,6 @@ describe('Adjustment Factor validator', () => {
       beforeEach(() => {
         payload = undefined
 
-        maxNumberOfDecimals = 15
         validationType = 'charge'
       })
 
@@ -164,7 +163,6 @@ describe('Adjustment Factor validator', () => {
           amendedChargeFactor: 'Hello World'
         }
 
-        maxNumberOfDecimals = 15
         validationType = 'charge'
       })
 
@@ -182,15 +180,14 @@ describe('Adjustment Factor validator', () => {
           amendedChargeFactor: 0.5555555555555555
         }
 
-        maxNumberOfDecimals = 15
         validationType = 'charge'
       })
 
-      it("fails the validation with the message 'The charge must contain no more than 2 decimal places'", () => {
+      it("fails the validation with the message 'The charge factor must not have more than 15 decimal places'", () => {
         const result = AdjustmentFactorValidator.go(payload.amendedChargeFactor, maxNumberOfDecimals, validationType)
 
         expect(result.error).to.exist()
-        expect(result.error.details[0].message).to.equal('The charge must contain no more than 15 decimal places')
+        expect(result.error.details[0].message).to.equal('The charge factor must not have more than 15 decimal places')
       })
     })
 
@@ -200,15 +197,14 @@ describe('Adjustment Factor validator', () => {
           amendedChargeFactor: 1.1
         }
 
-        maxNumberOfDecimals = 15
         validationType = 'charge'
       })
 
-      it("fails the validation with the message 'The charge factor must be less than 1'", () => {
+      it("fails the validation with the message 'The charge factor must be equal to or less than 1'", () => {
         const result = AdjustmentFactorValidator.go(payload.amendedChargeFactor, maxNumberOfDecimals, validationType)
 
         expect(result.error).to.exist()
-        expect(result.error.details[0].message).to.equal('The charge factor must be less than 1')
+        expect(result.error.details[0].message).to.equal('The charge factor must be equal to or less than 1')
       })
     })
 
@@ -218,7 +214,6 @@ describe('Adjustment Factor validator', () => {
           amendedChargeFactor: -1
         }
 
-        maxNumberOfDecimals = 15
         validationType = 'charge'
       })
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4439

During QA it was found that the error message for when a factor greater than 1 is entered was incorrect in the ticket & subsequently on the page. It used to read "factor must be less than 1".  When it should have read "factor must be equal to or less than 1".

Also the ticket originally specified that the Charge Adjustment should be validated to 2DP. This was incorrect, it should be validated to 15DP like the Aggregate factor.

These two issues will be corrected in this ticket.