### PR TITLE
View licence contact details title format

### DIFF
--- a/app/views/licences/tabs/contact-details.njk
+++ b/app/views/licences/tabs/contact-details.njk
@@ -1,4 +1,4 @@
-<h2 class="govuk-heading-l">Contact Details</h2>
+<h2 class="govuk-heading-l">Contact details</h2>
 
 {% if customerId %}
   <p><a href='/customer/{{ customerId }}/#contacts'>Go to customer contacts</a></p>

--- a/test/controllers/licences.controller.test.js
+++ b/test/controllers/licences.controller.test.js
@@ -221,7 +221,7 @@ describe('Licences controller', () => {
         const response = await server.inject(options)
 
         expect(response.statusCode).to.equal(200)
-        expect(response.payload).to.contain('Contact Details')
+        expect(response.payload).to.contain('Contact details')
         // Table row titles
         expect(response.payload).to.contain('Name')
         expect(response.payload).to.contain('Communication type')
@@ -242,7 +242,7 @@ describe('Licences controller', () => {
         const response = await server.inject(options)
 
         expect(response.statusCode).to.equal(200)
-        expect(response.payload).to.contain('Contact Details')
+        expect(response.payload).to.contain('Contact details')
         expect(response.payload).to.contain('No contacts found.')
       })
     })


### PR DESCRIPTION
The page should show Contact details not Contact Details.

The mistake was a capital d.