### PR TITLE
Add sentence case function & rename capitalize 

### DIFF
--- a/app/presenters/base.presenter.js
+++ b/app/presenters/base.presenter.js
@@ -226,6 +226,21 @@ function leftPadZeroes (number, length) {
 }
 
 /**
+ * Convert a string to sentence case by lowercasing all characters then capitalizing the first letter
+ *
+ * Will work for strings containing multiple words or only one.
+ *
+ * @param {string} value - The string to title case
+ *
+ * @returns {string} The title cased string
+ */
+function sentenceCase (value) {
+  const sentence = value.toLowerCase()
+
+  return sentence.charAt(0).toUpperCase() + sentence.slice(1)
+}
+
+/**
  * Convert a string to title case by capitalizing the first letter of each word
  *
  * Will work for strings containing multiple words or only one.
@@ -260,5 +275,6 @@ module.exports = {
   formatMoney,
   formatPounds,
   leftPadZeroes,
+  sentenceCase,
   titleCase
 }

--- a/app/presenters/base.presenter.js
+++ b/app/presenters/base.presenter.js
@@ -1,27 +1,6 @@
 'use strict'
 
 /**
- * Capitalize the first letter of each word in a string
- *
- * Will work for strings containing multiple words or only one.
- *
- * @param {string} value The string to capitalize
- *
- * @returns {string} The capitalized string
- */
-function capitalize (value) {
-  const words = value.split(' ')
-  const capitalizedWords = []
-
-  words.forEach((word) => {
-    const capitalizedWord = word.charAt(0).toUpperCase() + word.slice(1)
-    capitalizedWords.push(capitalizedWord)
-  })
-
-  return capitalizedWords.join(' ')
-}
-
-/**
  * Converts a number which represents pence into pounds by dividing it by 100
  *
  * This is such a simply calculation it could be done in place. But by having it as a named method we make it clear
@@ -52,7 +31,7 @@ function convertPenceToPounds (value) {
 function generateBillRunTitle (regionName, batchType, scheme, summer) {
   const billRunType = formatBillRunType(batchType, scheme, summer)
 
-  return `${capitalize(regionName)} ${billRunType.toLowerCase()}`
+  return `${titleCase(regionName)} ${billRunType.toLowerCase()}`
 }
 
 /**
@@ -99,7 +78,7 @@ function formatAbstractionPeriod (startDay, startMonth, endDay, endMonth) {
  */
 function formatBillRunType (batchType, scheme, summer) {
   if (batchType !== 'two_part_tariff') {
-    return capitalize(batchType)
+    return titleCase(batchType)
   }
 
   if (scheme === 'sroc') {
@@ -246,8 +225,28 @@ function leftPadZeroes (number, length) {
     .padStart(length, '0')
 }
 
+/**
+ * Convert a string to title case by capitalizing the first letter of each word
+ *
+ * Will work for strings containing multiple words or only one.
+ *
+ * @param {string} value - The string to title case
+ *
+ * @returns {string} The title cased string
+ */
+function titleCase (value) {
+  const words = value.split(' ')
+  const titleCasedWords = []
+
+  words.forEach((word) => {
+    const titleCasedWord = word.charAt(0).toUpperCase() + word.slice(1)
+    titleCasedWords.push(titleCasedWord)
+  })
+
+  return titleCasedWords.join(' ')
+}
+
 module.exports = {
-  capitalize,
   convertPenceToPounds,
   generateBillRunTitle,
   formatAbstractionDate,
@@ -260,5 +259,6 @@ module.exports = {
   formatLongDateTime,
   formatMoney,
   formatPounds,
-  leftPadZeroes
+  leftPadZeroes,
+  titleCase
 }

--- a/app/presenters/bill-licences/remove-bill-licence.presenter.js
+++ b/app/presenters/bill-licences/remove-bill-licence.presenter.js
@@ -6,12 +6,12 @@
  */
 
 const {
-  capitalize,
   formatBillRunType,
   formatChargeScheme,
   formatFinancialYear,
   formatLongDate,
-  formatMoney
+  formatMoney,
+  titleCase
 } = require('../base.presenter.js')
 
 /**
@@ -80,7 +80,7 @@ function _billRunSummary (billRun) {
     chargeScheme: formatChargeScheme(scheme),
     dateCreated: formatLongDate(createdAt),
     financialYear: formatFinancialYear(toFinancialYearEnding),
-    region: capitalize(region.displayName)
+    region: titleCase(region.displayName)
   }
 }
 

--- a/app/presenters/bill-licences/view-standard-charge-transaction.presenter.js
+++ b/app/presenters/bill-licences/view-standard-charge-transaction.presenter.js
@@ -6,11 +6,11 @@
  */
 
 const {
-  capitalize,
   formatAbstractionPeriod,
   formatLongDate,
   formatMoney,
-  formatPounds
+  formatPounds,
+  titleCase
 } = require('../base.presenter.js')
 
 /**
@@ -102,9 +102,9 @@ function _chargeElement (purpose, startDay, startMonth, endDay, endMonth, source
   return {
     purpose: purpose.description,
     abstractionPeriod: formatAbstractionPeriod(startDay, startMonth, endDay, endMonth),
-    source: capitalize(source),
-    season: capitalize(season),
-    loss: capitalize(loss)
+    source: titleCase(source),
+    season: titleCase(season),
+    loss: titleCase(loss)
   }
 }
 

--- a/app/presenters/bill-runs/cancel-bill-run.presenter.js
+++ b/app/presenters/bill-runs/cancel-bill-run.presenter.js
@@ -6,11 +6,11 @@
  */
 
 const {
-  capitalize,
   formatBillRunType,
   formatChargeScheme,
   formatFinancialYear,
-  formatLongDate
+  formatLongDate,
+  titleCase
 } = require('../base.presenter.js')
 
 /**
@@ -42,7 +42,7 @@ function go (billRun) {
     chargeScheme: formatChargeScheme(scheme),
     dateCreated: formatLongDate(createdAt),
     financialYear: formatFinancialYear(toFinancialYearEnding),
-    region: capitalize(region.displayName)
+    region: titleCase(region.displayName)
   }
 }
 

--- a/app/presenters/bill-runs/empty-bill-run-presenter.js
+++ b/app/presenters/bill-runs/empty-bill-run-presenter.js
@@ -6,12 +6,12 @@
  */
 
 const {
-  capitalize,
   generateBillRunTitle,
   formatBillRunType,
   formatChargeScheme,
   formatFinancialYear,
-  formatLongDate
+  formatLongDate,
+  titleCase
 } = require('../base.presenter.js')
 
 /**
@@ -43,7 +43,7 @@ function go (billRun) {
     dateCreated: formatLongDate(createdAt),
     financialYear: formatFinancialYear(toFinancialYearEnding),
     pageTitle: generateBillRunTitle(region.displayName, batchType, scheme, summer),
-    region: capitalize(region.displayName)
+    region: titleCase(region.displayName)
   }
 }
 

--- a/app/presenters/bill-runs/errored-bill-run-presenter.js
+++ b/app/presenters/bill-runs/errored-bill-run-presenter.js
@@ -6,12 +6,12 @@
  */
 
 const {
-  capitalize,
   generateBillRunTitle,
   formatBillRunType,
   formatChargeScheme,
   formatFinancialYear,
-  formatLongDate
+  formatLongDate,
+  titleCase
 } = require('../base.presenter.js')
 
 /**
@@ -45,7 +45,7 @@ function go (billRun) {
     errorMessage: _errorMessage(errorCode),
     financialYear: formatFinancialYear(toFinancialYearEnding),
     pageTitle: generateBillRunTitle(region.displayName, batchType, scheme, summer),
-    region: capitalize(region.displayName)
+    region: titleCase(region.displayName)
   }
 }
 

--- a/app/presenters/bill-runs/index-bill-runs.presenter.js
+++ b/app/presenters/bill-runs/index-bill-runs.presenter.js
@@ -6,10 +6,10 @@
  */
 
 const {
-  capitalize,
   formatBillRunType,
   formatLongDate,
-  formatMoney
+  formatMoney,
+  titleCase
 } = require('../base.presenter.js')
 
 /**
@@ -40,7 +40,7 @@ function go (billRuns) {
       link: _link(id, status, scheme),
       number: billRunNumber,
       numberOfBills,
-      region: capitalize(region),
+      region: titleCase(region),
       scheme,
       status,
       total: formatMoney(netTotal, true),

--- a/app/presenters/bill-runs/send-bill-run.presenter.js
+++ b/app/presenters/bill-runs/send-bill-run.presenter.js
@@ -6,11 +6,11 @@
  */
 
 const {
-  capitalize,
   formatBillRunType,
   formatChargeScheme,
   formatFinancialYear,
-  formatLongDate
+  formatLongDate,
+  titleCase
 } = require('../base.presenter.js')
 
 /**
@@ -41,7 +41,7 @@ function go (billRun) {
     chargeScheme: formatChargeScheme(scheme),
     dateCreated: formatLongDate(createdAt),
     financialYear: formatFinancialYear(toFinancialYearEnding),
-    region: capitalize(region.displayName)
+    region: titleCase(region.displayName)
   }
 }
 

--- a/app/presenters/bill-runs/setup/create.presenter.js
+++ b/app/presenters/bill-runs/setup/create.presenter.js
@@ -6,11 +6,11 @@
  */
 
 const {
-  capitalize,
   formatBillRunType,
   formatChargeScheme,
   formatFinancialYear,
-  formatLongDate
+  formatLongDate,
+  titleCase
 } = require('../../base.presenter.js')
 
 const LAST_PRESROC_YEAR = 2022
@@ -48,7 +48,7 @@ function go (session, billRun) {
     chargeScheme: formatChargeScheme(scheme),
     dateCreated: formatLongDate(createdAt),
     financialYear: formatFinancialYear(toFinancialYearEnding),
-    region: capitalize(region.displayName),
+    region: titleCase(region.displayName),
     warningMessage: _warningMessage(billRunType, status)
   }
 }

--- a/app/presenters/bill-runs/view-bill-run.presenter.js
+++ b/app/presenters/bill-runs/view-bill-run.presenter.js
@@ -6,13 +6,13 @@
  */
 
 const {
-  capitalize,
   generateBillRunTitle,
   formatBillRunType,
   formatChargeScheme,
   formatFinancialYear,
   formatLongDate,
-  formatMoney
+  formatMoney,
+  titleCase
 } = require('../base.presenter.js')
 
 function go (billRun, billSummaries) {
@@ -52,7 +52,7 @@ function go (billRun, billSummaries) {
     displayCreditDebitTotals: _displayCreditDebitTotals(billRun),
     financialYear: formatFinancialYear(toFinancialYearEnding),
     pageTitle: generateBillRunTitle(region.displayName, batchType, scheme, summer),
-    region: capitalize(region.displayName),
+    region: titleCase(region.displayName),
     transactionFile: transactionFileReference
   }
 }

--- a/app/presenters/bills/remove-bill.presenter.js
+++ b/app/presenters/bills/remove-bill.presenter.js
@@ -6,12 +6,12 @@
  */
 
 const {
-  capitalize,
   formatBillRunType,
   formatChargeScheme,
   formatFinancialYear,
   formatLongDate,
-  formatMoney
+  formatMoney,
+  titleCase
 } = require('../base.presenter.js')
 
 /**
@@ -86,7 +86,7 @@ function _billRunSummary (billRun) {
     chargeScheme: formatChargeScheme(scheme),
     dateCreated: formatLongDate(createdAt),
     financialYear: formatFinancialYear(toFinancialYearEnding),
-    region: capitalize(region.displayName)
+    region: titleCase(region.displayName)
   }
 }
 

--- a/app/presenters/bills/view-bill.presenter.js
+++ b/app/presenters/bills/view-bill.presenter.js
@@ -6,9 +6,9 @@
  */
 
 const {
-  capitalize,
   formatLongDate,
-  formatMoney
+  formatMoney,
+  titleCase
 } = require('../base.presenter.js')
 
 function go (bill, billingAccount) {
@@ -36,7 +36,7 @@ function go (bill, billingAccount) {
     displayCreditDebitTotals: _displayCreditDebitTotals(billRun),
     financialYear: _financialYear(bill),
     flaggedForReissue: bill.flaggedForRebilling,
-    region: capitalize(billRun.region.displayName),
+    region: titleCase(billRun.region.displayName),
     transactionFile: billRun.transactionFileReference
   }
 
@@ -76,7 +76,7 @@ function _billRunType (billRun) {
   const { batchType, summer, scheme } = billRun
 
   if (batchType !== 'two_part_tariff') {
-    return capitalize(batchType)
+    return titleCase(batchType)
   }
 
   if (scheme === 'sroc') {

--- a/test/presenters/base.presenter.test.js
+++ b/test/presenters/base.presenter.test.js
@@ -11,58 +11,6 @@ const { expect } = Code
 const BasePresenter = require('../../app/presenters/base.presenter.js')
 
 describe('Base presenter', () => {
-  describe('#titleCase()', () => {
-    let valueToCapitalize
-
-    describe('when the value is a single word', () => {
-      beforeEach(() => {
-        valueToCapitalize = 'high'
-      })
-
-      it('correctly returns the value in title case, for example, High', async () => {
-        const result = BasePresenter.titleCase(valueToCapitalize)
-
-        expect(result).to.equal('High')
-      })
-    })
-
-    describe('when the value is multiple words', () => {
-      beforeEach(() => {
-        valueToCapitalize = 'spray irrigation'
-      })
-
-      it('correctly returns the value in title case, for example, Spray Irrigation', async () => {
-        const result = BasePresenter.titleCase(valueToCapitalize)
-
-        expect(result).to.equal('Spray Irrigation')
-      })
-    })
-
-    describe('when the value contains a symbol', () => {
-      beforeEach(() => {
-        valueToCapitalize = 'spray irrigation - direct'
-      })
-
-      it('correctly returns the value in title case, for example, Spray Irrigation - Direct', async () => {
-        const result = BasePresenter.titleCase(valueToCapitalize)
-
-        expect(result).to.equal('Spray Irrigation - Direct')
-      })
-    })
-
-    describe('when the value is all capitals', () => {
-      beforeEach(() => {
-        valueToCapitalize = 'SPRAY IRRIGATION'
-      })
-
-      it('correctly returns the value unchanged, for example, SPRAY IRRIGATION', async () => {
-        const result = BasePresenter.titleCase(valueToCapitalize)
-
-        expect(result).to.equal('SPRAY IRRIGATION')
-      })
-    })
-  })
-
   describe('#convertPenceToPounds()', () => {
     let valueInPence
 
@@ -357,6 +305,58 @@ describe('Base presenter', () => {
       const result = BasePresenter.leftPadZeroes(number, 7)
 
       expect(result).to.equal('0000123')
+    })
+  })
+
+  describe('#titleCase()', () => {
+    let valueToTitleCase
+
+    describe('when the value is a single word', () => {
+      beforeEach(() => {
+        valueToTitleCase = 'high'
+      })
+
+      it('correctly returns the value in title case, for example, High', async () => {
+        const result = BasePresenter.titleCase(valueToTitleCase)
+
+        expect(result).to.equal('High')
+      })
+    })
+
+    describe('when the value is multiple words', () => {
+      beforeEach(() => {
+        valueToTitleCase = 'spray irrigation'
+      })
+
+      it('correctly returns the value in title case, for example, Spray Irrigation', async () => {
+        const result = BasePresenter.titleCase(valueToTitleCase)
+
+        expect(result).to.equal('Spray Irrigation')
+      })
+    })
+
+    describe('when the value contains a symbol', () => {
+      beforeEach(() => {
+        valueToTitleCase = 'spray irrigation - direct'
+      })
+
+      it('correctly returns the value in title case, for example, Spray Irrigation - Direct', async () => {
+        const result = BasePresenter.titleCase(valueToTitleCase)
+
+        expect(result).to.equal('Spray Irrigation - Direct')
+      })
+    })
+
+    describe('when the value is all capitals', () => {
+      beforeEach(() => {
+        valueToTitleCase = 'SPRAY IRRIGATION'
+      })
+
+      it('correctly returns the value unchanged, for example, SPRAY IRRIGATION', async () => {
+        const result = BasePresenter.titleCase(valueToTitleCase)
+
+        expect(result).to.equal('SPRAY IRRIGATION')
+      })
     })
   })
 })

--- a/test/presenters/base.presenter.test.js
+++ b/test/presenters/base.presenter.test.js
@@ -308,6 +308,58 @@ describe('Base presenter', () => {
     })
   })
 
+  describe('#sentenceCase()', () => {
+    let valueToSentenceCase
+
+    describe('when the value is a single word', () => {
+      beforeEach(() => {
+        valueToSentenceCase = 'high'
+      })
+
+      it('correctly returns the value in sentence case, for example, High', async () => {
+        const result = BasePresenter.sentenceCase(valueToSentenceCase)
+
+        expect(result).to.equal('High')
+      })
+    })
+
+    describe('when the value is multiple words', () => {
+      beforeEach(() => {
+        valueToSentenceCase = 'spray irrigation'
+      })
+
+      it('correctly returns the value in sentence case, for example, Spray irrigation', async () => {
+        const result = BasePresenter.sentenceCase(valueToSentenceCase)
+
+        expect(result).to.equal('Spray irrigation')
+      })
+    })
+
+    describe('when the value contains a symbol', () => {
+      beforeEach(() => {
+        valueToSentenceCase = 'spray irrigation - direct'
+      })
+
+      it('correctly returns the value in sentence case, for example, Spray irrigation - direct', async () => {
+        const result = BasePresenter.sentenceCase(valueToSentenceCase)
+
+        expect(result).to.equal('Spray irrigation - direct')
+      })
+    })
+
+    describe('when the value is all capitals', () => {
+      beforeEach(() => {
+        valueToSentenceCase = 'SPRAY IRRIGATION'
+      })
+
+      it('correctly returns the value in sentence case, for example, Spray irrigation', async () => {
+        const result = BasePresenter.sentenceCase(valueToSentenceCase)
+
+        expect(result).to.equal('Spray irrigation')
+      })
+    })
+  })
+
   describe('#titleCase()', () => {
     let valueToTitleCase
 

--- a/test/presenters/base.presenter.test.js
+++ b/test/presenters/base.presenter.test.js
@@ -11,7 +11,7 @@ const { expect } = Code
 const BasePresenter = require('../../app/presenters/base.presenter.js')
 
 describe('Base presenter', () => {
-  describe('#capitalize()', () => {
+  describe('#titleCase()', () => {
     let valueToCapitalize
 
     describe('when the value is a single word', () => {
@@ -19,8 +19,8 @@ describe('Base presenter', () => {
         valueToCapitalize = 'high'
       })
 
-      it('correctly returns the value capitalized, for example, High', async () => {
-        const result = BasePresenter.capitalize(valueToCapitalize)
+      it('correctly returns the value in title case, for example, High', async () => {
+        const result = BasePresenter.titleCase(valueToCapitalize)
 
         expect(result).to.equal('High')
       })
@@ -31,8 +31,8 @@ describe('Base presenter', () => {
         valueToCapitalize = 'spray irrigation'
       })
 
-      it('correctly returns the value capitalized, for example, Spray Irrigation', async () => {
-        const result = BasePresenter.capitalize(valueToCapitalize)
+      it('correctly returns the value in title case, for example, Spray Irrigation', async () => {
+        const result = BasePresenter.titleCase(valueToCapitalize)
 
         expect(result).to.equal('Spray Irrigation')
       })
@@ -43,8 +43,8 @@ describe('Base presenter', () => {
         valueToCapitalize = 'spray irrigation - direct'
       })
 
-      it('correctly returns the value capitalized, for example, Spray Irrigation - Direct', async () => {
-        const result = BasePresenter.capitalize(valueToCapitalize)
+      it('correctly returns the value in title case, for example, Spray Irrigation - Direct', async () => {
+        const result = BasePresenter.titleCase(valueToCapitalize)
 
         expect(result).to.equal('Spray Irrigation - Direct')
       })
@@ -56,7 +56,7 @@ describe('Base presenter', () => {
       })
 
       it('correctly returns the value unchanged, for example, SPRAY IRRIGATION', async () => {
-        const result = BasePresenter.capitalize(valueToCapitalize)
+        const result = BasePresenter.titleCase(valueToCapitalize)
 
         expect(result).to.equal('SPRAY IRRIGATION')
       })

--- a/test/presenters/bills/view-bill.presenter.test.js
+++ b/test/presenters/bills/view-bill.presenter.test.js
@@ -357,7 +357,7 @@ describe('View Bill presenter', () => {
     })
 
     describe("the 'region' property", () => {
-      it("returns the bill run's region display name capitalized", () => {
+      it("returns the bill run's region display name in title case", () => {
         const result = ViewBillPresenter.go(bill, billingAccount)
 
         expect(result.region).to.equal('South West')


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4315

As part of our work to re-create the communications tab in the view licence page, we needed to display some text from the DB in [Sentence case](https://titlecaseconverter.com/blog/sentence-case-vs-title-case/). At the same time, we also needed to capitalize the first character of a word. The superstar @jonathangoulding solved both of these problems in [their change](https://github.com/DEFRA/water-abstraction-system/pull/1020).

But wait! We already have a `capitalize()` method in the base presenter. We were ready to suggest the change when we realised it wouldn't solve the sentence case issue.

Eeek! We need to keep the sentence case solution, but it relies on the title case method @jonathangoulding added.

This change is to sort things out so we can solve the problems in that change. Our reasoning is that if we have a `sentenceCase()` solution, its ideal home is with similar functions in the base presenter. But it also highlighted that the world refers to what we are currently doing in `capitalize()` as 'title case'.

So, we rename it as part of this change.