### PR TITLE
View Licence customer duplicate contacts

### DIFF
--- a/app/services/licences/fetch-customer-contacts.service.js
+++ b/app/services/licences/fetch-customer-contacts.service.js
@@ -33,6 +33,7 @@ async function _fetch (licenceId) {
       'con.suffix',
       'lr.label AS communicationType'
     ])
+    .distinct()
     .from('licenceDocuments AS ld')
     .innerJoin('licences AS l', 'l.licenceRef', '=', 'ld.licenceRef')
     .innerJoin('licenceDocumentRoles AS ldr', 'ldr.licenceDocumentId', '=', 'ld.id')


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4434

Customer contacts in the Contact details tab of the view licence page is showing duplicate copies of the data.

Customer can have duplicates as in have the same name / email etc. But we are showing the same record twice.

This fix adds `select.distinct` to our fetch to resolve the issue.