### PR TITLE
Fix typo with remove button in remove requirements

### DIFF
--- a/app/views/return-requirements/remove.njk
+++ b/app/views/return-requirements/remove.njk
@@ -24,7 +24,7 @@
       <p class="govuk-body govuk-!-font-weight-bold govuk-!-font-size-27"> {{ returnRequirement }}</p>
 
       <p class="govuk-!-margin-bottom-7"></p>
-      {{ govukButton({ text: "Confirm cancel" }) }}
+      {{ govukButton({ text: "Remove" }) }}
     </div>
   </form>
 {% endblock %}

--- a/app/views/return-requirements/remove.njk
+++ b/app/views/return-requirements/remove.njk
@@ -24,7 +24,10 @@
       <p class="govuk-body govuk-!-font-weight-bold govuk-!-font-size-27"> {{ returnRequirement }}</p>
 
       <p class="govuk-!-margin-bottom-7"></p>
-      {{ govukButton({ text: "Remove" }) }}
+      {{ govukButton({
+        text: "Remove",
+        preventDoubleClick: true
+      }) }}
     </div>
   </form>
 {% endblock %}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4304

Noticed a typo with the button on the remove page of the return requirements
journey. Button should be labelled "Remove" instead of "Confirm Cancel".

This PR is focused on fixing that typo.