### PR TITLE
Fix view licence summary for incomplete licences

### DIFF
--- a/app/presenters/licences/view-licence-summary.presenter.js
+++ b/app/presenters/licences/view-licence-summary.presenter.js
@@ -5,7 +5,7 @@
  * @module ViewLicenceSummaryPresenter
  */
 
-const { formatLongDate, formatAbstractionDate } = require('../base.presenter')
+const { formatLongDate, formatAbstractionDate } = require('../base.presenter.js')
 const { generateAbstractionPointDetail } = require('../../lib/general.lib.js')
 
 /**

--- a/app/presenters/licences/view-licence-summary.presenter.js
+++ b/app/presenters/licences/view-licence-summary.presenter.js
@@ -175,7 +175,7 @@ function _generatePurposes (licenceVersions) {
 
 function _parseAbstractionsAndSourceOfSupply (permitLicence) {
   if (!permitLicence ||
-    permitLicence?.purposes === undefined ||
+    !permitLicence.purposes ||
     permitLicence.purposes.length === 0 ||
     permitLicence.purposes[0]?.purposePoints === undefined ||
     permitLicence.purposes[0]?.purposePoints.length === 0

--- a/app/presenters/licences/view-licence-summary.presenter.js
+++ b/app/presenters/licences/view-licence-summary.presenter.js
@@ -120,14 +120,14 @@ function _generateAbstractionPeriods (licenceVersions) {
     return null
   }
 
-  const formattedAbstactionPeriods = licenceVersions[0].licenceVersionPurposes.map((purpose) => {
+  const formattedAbstractionPeriods = licenceVersions[0].licenceVersionPurposes.map((purpose) => {
     const startDate = formatAbstractionDate(purpose.abstractionPeriodStartDay, purpose.abstractionPeriodStartMonth)
     const endDate = formatAbstractionDate(purpose.abstractionPeriodEndDay, purpose.abstractionPeriodEndMonth)
 
     return `${startDate} to ${endDate}`
   })
 
-  const uniqueAbstractionPeriods = [...new Set(formattedAbstactionPeriods)]
+  const uniqueAbstractionPeriods = [...new Set(formattedAbstractionPeriods)]
 
   return {
     caption: uniqueAbstractionPeriods.length > 1 ? 'Periods of abstraction' : 'Period of abstraction',

--- a/app/services/licences/fetch-licence-abstraction-conditions.service.js
+++ b/app/services/licences/fetch-licence-abstraction-conditions.service.js
@@ -32,7 +32,20 @@ const LicenceVersionPurposeModel = require('../../models/licence-version-purpose
  * to and the total count of conditions for the licence version.
  */
 async function go (licenceVersionId) {
-  const results = await LicenceVersionPurposeModel.query()
+  const results = await _fetch(licenceVersionId)
+
+  return _processResults(results)
+}
+
+function _fetch (licenceVersionId) {
+  // NOTE: We have found in testing that there are incomplete licences in the DB, for example, with no licence versions.
+  // If we are dealing with such a licence licenceVersionId will be undefined. As this service knows how to format the
+  // results for downstream services we handle it here rather than in the calling service.
+  if (!licenceVersionId) {
+    return []
+  }
+
+  return LicenceVersionPurposeModel.query()
     .distinct([
       'licenceVersionPurposes.purposeId',
       'licenceVersionPurposeConditionTypes.displayTitle'
@@ -43,8 +56,6 @@ async function go (licenceVersionId) {
     .orderBy([
       { column: 'licenceVersionPurposeConditionTypes.displayTitle', order: 'asc' }
     ])
-
-  return _processResults(results)
 }
 
 function _processResults (results) {

--- a/app/services/licences/view-licence-summary.service.js
+++ b/app/services/licences/view-licence-summary.service.js
@@ -25,9 +25,9 @@ async function go (licenceId, auth) {
 
   const currentLicenceVersionId = summaryLicenceData?.licenceVersions[0]?.id
 
-  const licenceAbstractionConditions = await FetchLicenceAbstractionConditionsService.go(currentLicenceVersionId)
+  const abstractionConditions = await FetchLicenceAbstractionConditionsService.go(currentLicenceVersionId)
 
-  const pageData = ViewLicenceSummaryPresenter.go(summaryLicenceData, licenceAbstractionConditions)
+  const pageData = ViewLicenceSummaryPresenter.go(summaryLicenceData, abstractionConditions)
 
   return {
     ...pageData,

--- a/app/services/licences/view-licence-summary.service.js
+++ b/app/services/licences/view-licence-summary.service.js
@@ -6,9 +6,9 @@
  */
 
 const FetchLicenceAbstractionConditionsService = require('./fetch-licence-abstraction-conditions.service.js')
-const FetchLicenceSummaryService = require('./fetch-licence-summary.service')
-const ViewLicenceSummaryPresenter = require('../../presenters/licences/view-licence-summary.presenter')
-const ViewLicenceService = require('./view-licence.service')
+const FetchLicenceSummaryService = require('./fetch-licence-summary.service.js')
+const ViewLicenceSummaryPresenter = require('../../presenters/licences/view-licence-summary.presenter.js')
+const ViewLicenceService = require('./view-licence.service.js')
 
 /**
  * Orchestrates fetching and presenting the data needed for the licence summary page

--- a/app/services/licences/view-licence-summary.service.js
+++ b/app/services/licences/view-licence-summary.service.js
@@ -14,6 +14,7 @@ const ViewLicenceService = require('./view-licence.service.js')
  * Orchestrates fetching and presenting the data needed for the licence summary page
  *
  * @param {string} licenceId - The UUID of the licence
+ * @param {object} auth - The auth object taken from `request.auth` containing user details
  *
  * @returns {Promise<Object>} an object representing the `pageData` needed by the licence summary template.
  */

--- a/test/presenters/licences/view-licence-summary.presenter.test.js
+++ b/test/presenters/licences/view-licence-summary.presenter.test.js
@@ -8,7 +8,7 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Thing under test
-const ViewLicenceSummaryPresenter = require('../../../app/presenters/licences/view-licence-summary.presenter')
+const ViewLicenceSummaryPresenter = require('../../../app/presenters/licences/view-licence-summary.presenter.js')
 
 describe('View Licence Summary presenter', () => {
   let licenceAbstractionConditions

--- a/test/services/licences/fetch-licence-abstraction-conditions.service.test.js
+++ b/test/services/licences/fetch-licence-abstraction-conditions.service.test.js
@@ -89,4 +89,14 @@ describe('Fetch Licence Abstraction Conditions service', () => {
       expect(result.numberOfConditions).to.equal(0)
     })
   })
+
+  describe('when an undefined licence version ID is passed in', () => {
+    it('returns an empty array of conditions, purpose IDs and 0 for the number of conditions', async () => {
+      const result = await FetchLicenceAbstractionConditionsService.go(undefined)
+
+      expect(result.conditions).to.be.empty()
+      expect(result.purposeIds).to.be.empty()
+      expect(result.numberOfConditions).to.equal(0)
+    })
+  })
 })

--- a/test/services/licences/view-licence-summary.service.test.js
+++ b/test/services/licences/view-licence-summary.service.test.js
@@ -13,10 +13,10 @@ const LicenceModel = require('../../../app/models/licence.model.js')
 
 // Things we need to stub
 const FetchLicenceAbstractionConditionsService = require('../../../app/services/licences/fetch-licence-abstraction-conditions.service.js')
-const FetchLicenceSummaryService = require('../../../app/services/licences/fetch-licence-summary.service')
-const ViewLicenceService = require('../../../app/services/licences/view-licence.service')
+const FetchLicenceSummaryService = require('../../../app/services/licences/fetch-licence-summary.service.js')
+const ViewLicenceService = require('../../../app/services/licences/view-licence.service.js')
 // Thing under test
-const ViewLicenceSummaryService = require('../../../app/services/licences/view-licence-summary.service')
+const ViewLicenceSummaryService = require('../../../app/services/licences/view-licence-summary.service.js')
 
 describe('View Licence service summary', () => {
   const testId = '2c80bd22-a005-4cf4-a2a2-73812a9861de'


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4322

In testing, we have found licences that have incomplete information. For example, `28/39/29/0048C` has no contacts, not even a licence holder, nor any licence version records.

The data doesn't appear to exist in the NALD extract we receive, so we have nothing we can use to fill in the missing pieces. But we don't want our licence summary to break when a user searches for the licence and then clicks through.

So, these changes ensure the page _shouldn't_ error when a user selects one of these incomplete licences.