### PR TITLE
Fix adjustment factors link

### DIFF
--- a/app/presenters/bill-runs/two-part-tariff/charge-reference-details.presenter.js
+++ b/app/presenters/bill-runs/two-part-tariff/charge-reference-details.presenter.js
@@ -57,33 +57,52 @@ function _additionalCharges (chargeReference) {
 }
 
 function _adjustments (reviewChargeReference) {
+  const {
+    aggregate,
+    amendedAggregate,
+    chargeAdjustment,
+    amendedChargeAdjustment,
+    abatementAgreement,
+    winterDiscount,
+    twoPartTariffAgreement,
+    canalAndRiverTrustAgreement
+  } = reviewChargeReference
+
   const adjustments = []
   let hasAggregateOrChargeFactor = false
 
-  if (reviewChargeReference.amendedAggregate !== 1) {
-    adjustments.push(`Aggregate factor (${reviewChargeReference.amendedAggregate})`)
+  if (amendedAggregate !== 1) {
+    adjustments.push(`Aggregate factor (${amendedAggregate})`)
     hasAggregateOrChargeFactor = true
   }
 
-  if (reviewChargeReference.amendedChargeAdjustment !== 1) {
-    adjustments.push(`Charge adjustment (${reviewChargeReference.amendedChargeAdjustment})`)
+  if (amendedChargeAdjustment !== 1) {
+    adjustments.push(`Charge adjustment (${amendedChargeAdjustment})`)
     hasAggregateOrChargeFactor = true
   }
 
-  if (reviewChargeReference.abatementAgreement !== 1) {
-    adjustments.push(`Abatement agreement (${reviewChargeReference.abatementAgreement})`)
+  if (abatementAgreement !== 1) {
+    adjustments.push(`Abatement agreement (${abatementAgreement})`)
   }
 
-  if (reviewChargeReference.winterDiscount) {
+  if (winterDiscount) {
     adjustments.push('Winter discount')
   }
 
-  if (reviewChargeReference.twoPartTariffAgreement) {
+  if (twoPartTariffAgreement) {
     adjustments.push('Two part tariff agreement')
   }
 
-  if (reviewChargeReference.canalAndRiverTrustAgreement) {
+  if (canalAndRiverTrustAgreement) {
     adjustments.push('Canal and River trust agreement')
+  }
+
+  if (aggregate !== amendedAggregate) {
+    hasAggregateOrChargeFactor = true
+  }
+
+  if (chargeAdjustment !== amendedChargeAdjustment) {
+    hasAggregateOrChargeFactor = true
   }
 
   return { adjustments, hasAggregateOrChargeFactor }

--- a/app/presenters/bill-runs/two-part-tariff/charge-reference-details.presenter.js
+++ b/app/presenters/bill-runs/two-part-tariff/charge-reference-details.presenter.js
@@ -97,11 +97,7 @@ function _adjustments (reviewChargeReference) {
     adjustments.push('Canal and River trust agreement')
   }
 
-  if (aggregate !== amendedAggregate) {
-    hasAggregateOrChargeFactor = true
-  }
-
-  if (chargeAdjustment !== amendedChargeAdjustment) {
+  if (aggregate !== amendedAggregate || chargeAdjustment !== amendedChargeAdjustment) {
     hasAggregateOrChargeFactor = true
   }
 

--- a/test/presenters/bill-runs/two-part-tariff/charge-reference-details.presenter.test.js
+++ b/test/presenters/bill-runs/two-part-tariff/charge-reference-details.presenter.test.js
@@ -78,6 +78,7 @@ describe('Charge Reference Details presenter', () => {
       describe('when the charge reference has a charge adjustment factor', () => {
         beforeEach(() => {
           reviewChargeReference.amendedChargeAdjustment = 0.7
+          reviewChargeReference.chargeAdjustment = 0.7
         })
 
         it('adds the charge adjustment factor to the adjustments property', () => {

--- a/test/presenters/bill-runs/two-part-tariff/charge-reference-details.presenter.test.js
+++ b/test/presenters/bill-runs/two-part-tariff/charge-reference-details.presenter.test.js
@@ -46,6 +46,7 @@ describe('Charge Reference Details presenter', () => {
       describe('when the charge reference has an aggregate factor', () => {
         beforeEach(() => {
           reviewChargeReference.amendedAggregate = 0.5
+          reviewChargeReference.aggregate = 0.5
         })
 
         it('adds the aggregate factor to the adjustments property', () => {
@@ -58,6 +59,19 @@ describe('Charge Reference Details presenter', () => {
           const result = ChargeReferenceDetailsPresenter.go(billRun, reviewChargeReference, licenceId)
 
           expect(result.hasAggregateOrChargeFactor).to.equal(true)
+        })
+
+        describe('when the source aggregate factor is different to the amendedAggregate factor', () => {
+          beforeEach(() => {
+            reviewChargeReference.aggregate = 0.5
+            reviewChargeReference.amendedAggregate = 1
+          })
+
+          it("sets the 'hasAggregateOrChargeFactor' property to true", () => {
+            const result = ChargeReferenceDetailsPresenter.go(billRun, reviewChargeReference, licenceId)
+
+            expect(result.hasAggregateOrChargeFactor).to.equal(true)
+          })
         })
       })
 
@@ -76,6 +90,19 @@ describe('Charge Reference Details presenter', () => {
           const result = ChargeReferenceDetailsPresenter.go(billRun, reviewChargeReference, licenceId)
 
           expect(result.hasAggregateOrChargeFactor).to.equal(true)
+        })
+
+        describe('when the source charge adjustment factor is different to the amendedChargeAdjustment factor', () => {
+          beforeEach(() => {
+            reviewChargeReference.chargeAdjustment = 0.5
+            reviewChargeReference.amendedChargeAdjustment = 1
+          })
+
+          it("sets the 'hasAggregateOrChargeFactor' property to true", () => {
+            const result = ChargeReferenceDetailsPresenter.go(billRun, reviewChargeReference, licenceId)
+
+            expect(result.hasAggregateOrChargeFactor).to.equal(true)
+          })
         })
       })
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4439

During the testing for the above ticket it was noted that if an adjustment factor is removed from a licence on the set adjustment factor page, then the link is removed from the charge reference details page after. This is incorrect as the link should always stay if a charge factor was present initially. This PR adds in the functionally for the link to always be present if a charge factor was initially on the licence.