### PR TITLE
View licence communication alert

### DIFF
--- a/app/presenters/licences/communications.presenter.js
+++ b/app/presenters/licences/communications.presenter.js
@@ -41,7 +41,7 @@ function _type (communication) {
 
 function _typeAlert (communication) {
   if (communication.event.metadata.name === 'Water abstraction alert') {
-    return `${sentenceCase(communication.event.metadata.options.sendingAlertType)} - Water abstraction alert`
+    return `${sentenceCase(communication.event.metadata.options.sendingAlertType)}`
   }
 
   return null

--- a/test/presenters/licences/communications.presenter.test.js
+++ b/test/presenters/licences/communications.presenter.test.js
@@ -103,14 +103,14 @@ describe('Communications presenter', () => {
     describe("when the communication is a 'Water abstraction alert'", () => {
       beforeEach(() => {
         communications[0].event.metadata.name = 'Water abstraction alert'
-        communications[0].event.metadata.options.sendingAlertType = 'test'
+        communications[0].event.metadata.options.sendingAlertType = 'test - Water abstraction alert'
       })
 
       it('returns the type object with an alert text', () => {
         const result = CommunicationsPresenter.go(communications)
 
         expect(result.communications[0].type).to.equal({
-          alert: 'Test - Water abstraction alert',
+          alert: 'Test - water abstraction alert',
           label: 'Water abstraction alert',
           pdf: false,
           sentVia: 'sent 15 May 2024 via letter'


### PR DESCRIPTION
The Water abstraction alert metadata contains the label required to show the alert type and the required 'Water abstraction alert' additional label.

This has been tested and verified in the test env with all alert types