### PR TITLE
View licence communications remove alert

### DIFF
--- a/app/presenters/licences/communications.presenter.js
+++ b/app/presenters/licences/communications.presenter.js
@@ -32,19 +32,19 @@ function _communications (communications) {
 
 function _type (communication) {
   return {
-    alert: _typeAlert(communication),
-    label: communication.event.metadata.name,
+    label: _typeLabel(communication),
     sentVia: `sent ${formatLongDate(new Date(communication.event.createdAt))} via ${communication.messageType}`,
     pdf: communication.messageRef.includes('pdf')
   }
 }
 
-function _typeAlert (communication) {
+function _typeLabel (communication) {
   if (communication.event.metadata.name === 'Water abstraction alert') {
-    return `${sentenceCase(communication.event.metadata.options.sendingAlertType)}`
+    return `${sentenceCase(communication.event.metadata.options.sendingAlertType)}` +
+      ` - ${communication.event.metadata.name}`
   }
 
-  return null
+  return communication.event.metadata.name
 }
 
 module.exports = {

--- a/app/views/licences/tabs/communications.njk
+++ b/app/views/licences/tabs/communications.njk
@@ -25,7 +25,6 @@
             <span class="govuk-visually-hidden"> {{ communication.type.sentVia }} </span>
           {% else %}
             <a href="/licences/{{ documentId }}/communications/{{ communication.id }}" class="govuk-link">
-              {{ communication.type.alert }}
               {{ communication.type.label }}
               <span class="govuk-visually-hidden"> {{ communication.type.sentVia }} </span>
             </a>

--- a/test/presenters/licences/communications.presenter.test.js
+++ b/test/presenters/licences/communications.presenter.test.js
@@ -44,7 +44,6 @@ describe('Communications presenter', () => {
           sender: 'admin-internal@wrls.gov.uk',
           sent: '15 May 2024',
           type: {
-            alert: null,
             label: 'Returns: invitation',
             pdf: false,
             sentVia: 'sent 15 May 2024 via letter'
@@ -64,7 +63,6 @@ describe('Communications presenter', () => {
           const result = CommunicationsPresenter.go(communications)
 
           expect(result.communications[0].type).to.equal({
-            alert: null,
             label: 'Returns: invitation',
             pdf: true,
             sentVia: 'sent 15 May 2024 via letter'
@@ -77,7 +75,6 @@ describe('Communications presenter', () => {
           const result = CommunicationsPresenter.go(communications)
 
           expect(result.communications[0].type).to.equal({
-            alert: null,
             label: 'Returns: invitation',
             pdf: false,
             sentVia: 'sent 15 May 2024 via letter'
@@ -103,15 +100,14 @@ describe('Communications presenter', () => {
     describe("when the communication is a 'Water abstraction alert'", () => {
       beforeEach(() => {
         communications[0].event.metadata.name = 'Water abstraction alert'
-        communications[0].event.metadata.options.sendingAlertType = 'test - Water abstraction alert'
+        communications[0].event.metadata.options.sendingAlertType = 'test'
       })
 
       it('returns the type object with an alert text', () => {
         const result = CommunicationsPresenter.go(communications)
 
         expect(result.communications[0].type).to.equal({
-          alert: 'Test - water abstraction alert',
-          label: 'Water abstraction alert',
+          label: 'Test - Water abstraction alert',
           pdf: false,
           sentVia: 'sent 15 May 2024 via letter'
         })


### PR DESCRIPTION
The implementation of alert was not understood from the old system implementation.

This change removes the idea of an alert and a label and merges them together to simplify the view and presenter.

The outcome should be the label is returned unless the sendingAlertType is Water abstraction alert the it should append ' - Water abstraction alert' to the end of the alert type.

For example - Stop - Water abstraction alert