### PR TITLE
Content change on set adjustment factors page 2pt

### DIFF
--- a/app/presenters/bill-runs/two-part-tariff/amend-adjustment-factor.presenter.js
+++ b/app/presenters/bill-runs/two-part-tariff/amend-adjustment-factor.presenter.js
@@ -28,8 +28,8 @@ function go (billRun, reviewChargeReference, licenceId) {
     chargeReference: {
       id: reviewChargeReference.id,
       description: reviewChargeReference.chargeReference.chargeCategory.shortDescription,
-      aggregateFactor: reviewChargeReference.amendedAggregate,
-      chargeAdjustment: reviewChargeReference.amendedChargeAdjustment,
+      aggregateFactor: reviewChargeReference.amendedAggregate === 0 ? '0' : reviewChargeReference.amendedAggregate,
+      chargeAdjustment: reviewChargeReference.amendedChargeAdjustment === 0 ? '0' : reviewChargeReference.amendedChargeAdjustment,
       otherAdjustments: _otherAdjustments(reviewChargeReference)
     }
   }

--- a/app/views/bill-runs/amend-adjustment-factor.njk
+++ b/app/views/bill-runs/amend-adjustment-factor.njk
@@ -74,7 +74,7 @@
       <form method="post">
         {{ govukInput({
           label: {
-            text: "Aggregate factor (optional)",
+            text: "Aggregate factor",
             classes: "govuk-label"
           },
           id: "amended-aggregate-factor",
@@ -86,7 +86,7 @@
 
         {{ govukInput({
           label: {
-            text: "Charge adjustment (optional)",
+            text: "Charge adjustment",
             classes: "govuk-label"
           },
           id: "amended-charge-adjustment",

--- a/test/controllers/bill-runs.controller.test.js
+++ b/test/controllers/bill-runs.controller.test.js
@@ -500,7 +500,7 @@ describe('Bill Runs controller', () => {
           expect(response.statusCode).to.equal(200)
           expect(response.payload).to.contain('High loss, non-tidal, restricted water, greater than 85 up to and including 120 ML/yr')
           expect(response.payload).to.contain('Set the adjustment factors')
-          expect(response.payload).to.contain('Aggregate factor (optional)')
+          expect(response.payload).to.contain('Aggregate factor')
         })
       })
     })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4439

During the testing for the above ticket, it was decided that a content change was necessary on the set adjustment factors page. This PR is removing the 'optional' text from the page. The PR is also fixing a small bug, where if a user enters 0 for the adjustment factors (unlikely) the 0 will not appear pre-populated on the input boxes if they were to go back to the page again.