### PR TITLE
Two-part tariff review pages housekeeping

### DIFF
--- a/app/services/bill-runs/two-part-tariff/fetch-review-charge-reference.service.js
+++ b/app/services/bill-runs/two-part-tariff/fetch-review-charge-reference.service.js
@@ -30,7 +30,6 @@ async function _fetchBillRun (billRunId) {
     .findById(billRunId)
     .select(
       'id',
-      'fromFinancialYearEnding',
       'toFinancialYearEnding')
 }
 

--- a/app/views/bill-runs/amend-adjustment-factor.njk
+++ b/app/views/bill-runs/amend-adjustment-factor.njk
@@ -96,7 +96,7 @@
           errorMessage: error.chargeAdjustmentElement
         }) }}
 
-        {{ govukButton({ text: 'Confirm' }) }}
+        {{ govukButton({ text: 'Confirm', preventDoubleClick: true }) }}
       </form>
     </div>
   </div>

--- a/app/views/bill-runs/amend-billable-returns.njk
+++ b/app/views/bill-runs/amend-billable-returns.njk
@@ -98,7 +98,7 @@
       {# Hidden input for authorised volume #}
       <input type="hidden" name="authorisedVolume" value="{{ authorisedQuantity }}">
 
-      {{ govukButton({ text: 'Confirm' }) }}
+      {{ govukButton({ text: 'Confirm', preventDoubleClick: true }) }}
     </form>
   </div>
 {% endblock %}

--- a/app/views/bill-runs/match-details.njk
+++ b/app/views/bill-runs/match-details.njk
@@ -106,7 +106,8 @@
       {{ govukButton({
         text: "Edit the billable returns",
         href: "/system/bill-runs/" + billRunId + "/review/" + licenceId + "/match-details/" + chargeElement.chargeElementId + "/amend-billable-returns",
-        classes: "govuk-button--secondary"
+        classes: "govuk-button--secondary",
+        preventDoubleClick: true
       }) }}
     </div>
   </div>

--- a/test/services/bill-runs/two-part-tariff/amend-adjustment-factor.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/amend-adjustment-factor.service.test.js
@@ -51,7 +51,6 @@ describe('Amend Adjustment Factor Service', () => {
 function _billRun () {
   return {
     id: 'cc4bbb18-0d6a-4254-ac2c-7409de814d7e',
-    fromFinancialYearEnding: 2023,
     toFinancialYearEnding: 2023
   }
 }

--- a/test/services/bill-runs/two-part-tariff/charge-reference-details.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/charge-reference-details.service.test.js
@@ -54,7 +54,6 @@ describe('Charge Reference Details Service', () => {
 function _billRun () {
   return {
     id: 'cc4bbb18-0d6a-4254-ac2c-7409de814d7e',
-    fromFinancialYearEnding: 2023,
     toFinancialYearEnding: 2023
   }
 }

--- a/test/services/bill-runs/two-part-tariff/fetch-review-charge-reference.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/fetch-review-charge-reference.service.test.js
@@ -67,7 +67,6 @@ describe('Fetch Review Charge Reference service', () => {
 
         expect(result.billRun).to.equal({
           id: billRun.id,
-          fromFinancialYearEnding: billRun.fromFinancialYearEnding,
           toFinancialYearEnding: billRun.toFinancialYearEnding
         })
       })


### PR DESCRIPTION
During work on one of the final [two-part tariff review pages,](https://github.com/DEFRA/water-abstraction-system/pull/1037) it was pointed out there are a few inconsistency's in some of the pages code. 
This PR is for updating all the buttons on the two-part tariff review pages to have the preventDoubleClick attributes set as true. This is currently done on some pages but not all.
This PR is also removing an unnecessary 'fromFinanicalYearEnding' property that it being fetched on one of our fetch services. The property isn't used once it's been fetched so it makes sense to remove it. 