### PR TITLE
Add new acceptance test data loader

### DIFF
--- a/app/controllers/data.controller.js
+++ b/app/controllers/data.controller.js
@@ -5,6 +5,7 @@
  * @module DataController
  */
 
+const LoadService = require('../services/data/load/load.service.js')
 const SeedService = require('../services/data/seed/seed.service.js')
 const SubmitDeduplicateService = require('../services/data/deduplicate/submit-deduplicate.service.js')
 const TearDownService = require('../services/data/tear-down/tear-down.service.js')
@@ -14,6 +15,12 @@ async function deduplicate (_request, h) {
     pageTitle: 'De-duplicate a licence',
     activeNavBar: 'search'
   })
+}
+
+async function load (request, h) {
+  const result = await LoadService.go(request.payload)
+
+  return h.response(result).code(200)
 }
 
 async function seed (_request, h) {
@@ -44,6 +51,7 @@ async function tearDown (_request, h) {
 
 module.exports = {
   deduplicate,
+  load,
   seed,
   submitDeduplicate,
   tearDown

--- a/app/routes/data.routes.js
+++ b/app/routes/data.routes.js
@@ -31,6 +31,19 @@ const routes = [
   },
   {
     method: 'POST',
+    path: '/data/load',
+    handler: DataController.load,
+    options: {
+      app: {
+        excludeFromProd: true,
+        plainOutput: true
+      },
+      auth: false,
+      description: 'Used to load test data in the database'
+    }
+  },
+  {
+    method: 'POST',
     path: '/data/seed',
     handler: DataController.seed,
     options: {

--- a/app/services/data/load/load.service.js
+++ b/app/services/data/load/load.service.js
@@ -5,6 +5,125 @@
  * @module LoadService
  */
 
+const { db } = require('../../../../db/db.js')
+
+const ExpandedError = require('../../../errors/expanded.error.js')
+
+const AddressHelper = require('../../../../test/support/helpers/address.helper.js')
+const BillLicenceHelper = require('../../../../test/support/helpers/bill-licence.helper.js')
+const BillRunChargeVersionYearHelper = require('../../../../test/support/helpers/bill-run-charge-version-year.helper.js')
+const BillRunVolumeHelper = require('../../../../test/support/helpers/bill-run-volume.helper.js')
+const BillRunHelper = require('../../../../test/support/helpers/bill-run.helper.js')
+const BillHelper = require('../../../../test/support/helpers/bill.helper.js')
+const BillingAccountAddressHelper = require('../../../../test/support/helpers/billing-account-address.helper.js')
+const BillingAccountHelper = require('../../../../test/support/helpers/billing-account.helper.js')
+const ChangeReasonHelper = require('../../../../test/support/helpers/change-reason.helper.js')
+const ChargeCategoryHelper = require('../../../../test/support/helpers/charge-category.helper.js')
+const ChargeElementHelper = require('../../../../test/support/helpers/charge-element.helper.js')
+const ChargeReferenceHelper = require('../../../../test/support/helpers/charge-reference.helper.js')
+const ChargeVersionHelper = require('../../../../test/support/helpers/charge-version.helper.js')
+const CompanyContactHelper = require('../../../../test/support/helpers/company-contact.helper.js')
+const CompanyHelper = require('../../../../test/support/helpers/company.helper.js')
+const ContactHelper = require('../../../../test/support/helpers/contact.helper.js')
+const EventHelper = require('../../../../test/support/helpers/event.helper.js')
+const FinancialAgreementHelper = require('../../../../test/support/helpers/financial-agreement.helper.js')
+const GaugingStationHelper = require('../../../../test/support/helpers/gauging-station.helper.js')
+const GroupRoleHelper = require('../../../../test/support/helpers/group-role.helper.js')
+const GroupHelper = require('../../../../test/support/helpers/group.helper.js')
+const LicenceAgreementHelper = require('../../../../test/support/helpers/licence-agreement.helper.js')
+const LicenceDocumentHeaderHelper = require('../../../../test/support/helpers/licence-document-header.helper.js')
+const LicenceDocumentRoleHelper = require('../../../../test/support/helpers/licence-document-role.helper.js')
+const LicenceDocumentHelper = require('../../../../test/support/helpers/licence-document.helper.js')
+const LicenceEntityRoleHelper = require('../../../../test/support/helpers/licence-entity-role.helper.js')
+const LicenceEntityHelper = require('../../../../test/support/helpers/licence-entity.helper.js')
+const LicenceGaugingStationHelper = require('../../../../test/support/helpers/licence-gauging-station.helper.js')
+const LicenceRoleHelper = require('../../../../test/support/helpers/licence-role.helper.js')
+const LicenceVersionPurposeConditionTypeHelper = require('../../../../test/support/helpers/licence-version-purpose-condition-type.helper.js')
+const LicenceVersionPurposeConditionHelper = require('../../../../test/support/helpers/licence-version-purpose-condition.helper.js')
+const LicenceVersionPurposeHelper = require('../../../../test/support/helpers/licence-version-purpose.helper.js')
+const LicenceVersionHelper = require('../../../../test/support/helpers/licence-version.helper.js')
+const LicenceHelper = require('../../../../test/support/helpers/licence.helper.js')
+const PermitLicenceHelper = require('../../../../test/support/helpers/permit-licence.helper.js')
+const PurposeHelper = require('../../../../test/support/helpers/purpose.helper.js')
+const RegionHelper = require('../../../../test/support/helpers/region.helper.js')
+const ReturnLogHelper = require('../../../../test/support/helpers/return-log.helper.js')
+const ReturnSubmissionLineHelper = require('../../../../test/support/helpers/return-submission-line.helper.js')
+const ReturnSubmissionHelper = require('../../../../test/support/helpers/return-submission.helper.js')
+const ReviewChargeElementReturnHelper = require('../../../../test/support/helpers/review-charge-element-return.helper.js')
+const ReviewChargeElementHelper = require('../../../../test/support/helpers/review-charge-element.helper.js')
+const ReviewChargeReferenceHelper = require('../../../../test/support/helpers/review-charge-reference.helper.js')
+const ReviewChargeVersionHelper = require('../../../../test/support/helpers/review-charge-version.helper.js')
+const ReviewLicenceHelper = require('../../../../test/support/helpers/review-licence.helper.js')
+const ReviewReturnHelper = require('../../../../test/support/helpers/review-return.helper.js')
+const RoleHelper = require('../../../../test/support/helpers/role.helper.js')
+const ScheduledNotificationHelper = require('../../../../test/support/helpers/scheduled-notification.helper.js')
+const SessionHelper = require('../../../../test/support/helpers/session.helper.js')
+const TransactionHelper = require('../../../../test/support/helpers/transaction.helper.js')
+const UserGroupHelper = require('../../../../test/support/helpers/user-group.helper.js')
+const UserRoleHelper = require('../../../../test/support/helpers/user-role.helper.js')
+const UserHelper = require('../../../../test/support/helpers/user.helper.js')
+const WorkflowHelper = require('../../../../test/support/helpers/workflow.helper.js')
+
+// The entities defined in the payload need to match the properties of this object else you'll get an error. The loader
+// uses the matched value to determine which helper to use to 'load' the entity instance, and whether we can flag it
+// as `is_test`.
+const LOAD_HELPERS = {
+  addresses: { helper: AddressHelper, test: true, legacy: { schema: 'crm_v2', table: 'addresses', id: 'address_id' } },
+  billLicences: { helper: BillLicenceHelper, test: false },
+  billRunChargeVersionYears: { helper: BillRunChargeVersionYearHelper, test: false },
+  billRunVolumes: { helper: BillRunVolumeHelper, test: false },
+  billRuns: { helper: BillRunHelper, test: false },
+  bills: { helper: BillHelper, test: false },
+  billingAccountAddresses: { helper: BillingAccountAddressHelper, test: true, legacy: { schema: 'crm_v2', table: 'invoice_account_addresses', id: 'invoice_account_address_id' } },
+  billingAccounts: { helper: BillingAccountHelper, test: true, legacy: { schema: 'crm_v2', table: 'invoice_accounts', id: 'invoice_account_id' } },
+  changeReasons: { helper: ChangeReasonHelper, test: false },
+  chargeCategories: { helper: ChargeCategoryHelper, test: true, legacy: { schema: 'water', table: 'billing_charge_categories', id: 'billing_charge_category_id' } },
+  chargeElements: { helper: ChargeElementHelper, test: true, legacy: { schema: 'water', table: 'charge_purposes', id: 'charge_purpose_id' } },
+  chargeReferences: { helper: ChargeReferenceHelper, test: true, legacy: { schema: 'water', table: 'charge_elements', id: 'charge_element_id' } },
+  chargeVersions: { helper: ChargeVersionHelper, test: true, legacy: { schema: 'water', table: 'charge_versions', id: 'charge_version_id' } },
+  companyContacts: { helper: CompanyContactHelper, test: true, legacy: { schema: 'crm_v2', table: 'company_contacts', id: 'company_contact_id' } },
+  companies: { helper: CompanyHelper, test: true, legacy: { schema: 'crm_v2', table: 'companies', id: 'company_id' } },
+  contacts: { helper: ContactHelper, test: true, legacy: { schema: 'crm_v2', table: 'contacts', id: 'contact_id' } },
+  events: { helper: EventHelper, test: false },
+  financialAgreements: { helper: FinancialAgreementHelper, test: true, legacy: { schema: 'water', table: 'financial_agreement_types', id: 'financial_agreement_type_id' } },
+  gaugingStations: { helper: GaugingStationHelper, test: true, legacy: { schema: 'water', table: 'gauging_stations', id: 'gauging_station_id' } },
+  groupRoles: { helper: GroupRoleHelper, test: false },
+  groups: { helper: GroupHelper, test: false },
+  licenceAgreements: { helper: LicenceAgreementHelper, test: true, legacy: { schema: 'water', table: 'licence_agreements', id: 'licence_agreement_id' } },
+  licenceDocumentHeaders: { helper: LicenceDocumentHeaderHelper, test: false },
+  licenceDocumentRoles: { helper: LicenceDocumentRoleHelper, test: true, legacy: { schema: 'crm_v2', table: 'document_roles', id: 'document_role_id' } },
+  licenceDocuments: { helper: LicenceDocumentHelper, test: true, legacy: { schema: 'crm_v2', table: 'documents', id: 'document_id' } },
+  licenceEntityRoles: { helper: LicenceEntityRoleHelper, test: false },
+  licenceEntities: { helper: LicenceEntityHelper, test: false },
+  licenceGaugingStations: { helper: LicenceGaugingStationHelper, test: true, legacy: { schema: 'water', table: 'licence_gauging_stations', id: 'licence_gauging_station_id' } },
+  licenceRoles: { helper: LicenceRoleHelper, test: false },
+  licenceVersionPurposeConditionTypes: { helper: LicenceVersionPurposeConditionTypeHelper, test: false },
+  licenceVersionPurposeConditions: { helper: LicenceVersionPurposeConditionHelper, test: false },
+  licenceVersionPurposes: { helper: LicenceVersionPurposeHelper, test: true, legacy: { schema: 'water', table: 'licence_version_purposes', id: 'licence_version_purpose_id' } },
+  licenceVersions: { helper: LicenceVersionHelper, test: true, legacy: { schema: 'water', table: 'licence_versions', id: 'licence_version_id' } },
+  licences: { helper: LicenceHelper, test: true, legacy: { schema: 'water', table: 'licences', id: 'licence_id' } },
+  permitLicences: { helper: PermitLicenceHelper, test: false },
+  purposes: { helper: PurposeHelper, test: true, legacy: { schema: 'water', table: 'purposes_uses', id: 'purpose_use_id' } },
+  regions: { helper: RegionHelper, test: true, legacy: { schema: 'water', table: 'regions', id: 'region_id' } },
+  returnLogs: { helper: ReturnLogHelper, test: true, legacy: { schema: 'returns', table: 'returns', id: 'return_id' } },
+  returnSubmissionLines: { helper: ReturnSubmissionLineHelper, test: false },
+  returnSubmissions: { helper: ReturnSubmissionHelper, test: false },
+  reviewChargeElementReturns: { helper: ReviewChargeElementReturnHelper, test: false },
+  reviewChargeElements: { helper: ReviewChargeElementHelper, test: false },
+  reviewChargeReferences: { helper: ReviewChargeReferenceHelper, test: false },
+  reviewChargeVersions: { helper: ReviewChargeVersionHelper, test: false },
+  reviewLicences: { helper: ReviewLicenceHelper, test: false },
+  reviewReturns: { helper: ReviewReturnHelper, test: false },
+  roles: { helper: RoleHelper, test: false },
+  scheduledNotifications: { helper: ScheduledNotificationHelper },
+  sessions: { helper: SessionHelper, test: false },
+  transactions: { helper: TransactionHelper, test: false },
+  userGroups: { helper: UserGroupHelper, test: false },
+  userRoles: { helper: UserRoleHelper, test: false },
+  users: { helper: UserHelper, test: false },
+  workflows: { helper: WorkflowHelper, test: false }
+}
+
 /**
  * Loads the entities requested by our acceptance tests when `/data/load` is called into the DB using the helpers
  *
@@ -90,7 +209,124 @@
  * ```
  */
 async function go (payload) {
-  return {}
+  // Instantiate a result object to which we'll record the ID's generated/used
+  const result = {}
+
+  if (!payload) {
+    return result
+  }
+
+  // From the payload grab the entities to load; regions, licences, chargeVersions etc
+  const entityKeys = Object.keys(payload)
+
+  for (const entityKey of entityKeys) {
+    result[entityKey] = []
+
+    // Extract the next entity to load, for example licences: [{}, {}]
+    const entity = payload[entityKey]
+
+    // Then iterate through the entity's instances to be created
+    for (const instance of entity) {
+      // Apply any lookups defined in the instance
+      await _applyLookups(instance)
+
+      // Select the appropriate helper for the entity
+      const loadHelper = _helper(entityKey)
+
+      // Then create (load) the instance into the DB
+      const { id } = await loadHelper.helper.add(instance)
+
+      // Check if we need to apply our 'fudge' solution for setting `is_test` flags
+      if (loadHelper.test) {
+        await _applyTestFlag(loadHelper.legacy, id)
+      }
+
+      // Finally record the ID either generated or used in the result
+      result[entityKey].push(id)
+    }
+  }
+
+  return result
+}
+
+/**
+ * A lookup is where we need to grab an existing value from the DB. For example, looking up the ID of the charge
+ * category to use in a charge reference we are trying to load.
+ *
+ * In this example the instance needs to lookup the ID for the `crm.entity` record whose `entity_type` is `'regime'`.
+ *
+ * ```json
+ *   "licenceDocumentHeaders": [
+ *     {
+ *       "id": "282b226e-c47b-4dcc-bbb0-94648fb6b242",
+ *       "regimeEntityId": {
+ *         "schema": "crm",
+ *         "table": "entity",
+ *         "lookup": "entityType",
+ *         "value": "regime",
+ *         "select": "entityId"
+ *       }
+ *     }
+ *   ]
+ * ```
+ *
+ * We grab all the keys for the instance, then iterate through all its properties. In this example when we get to
+ * `instance.regimeEntityId` we'll confirm it is an object with a `schema:` property. We then replace the value of
+ * `instance.regimeEntityId` with the result of a query based on the details provided. In this case `SELECT entity_id
+ * FROM crm.entity WHERE entity_type = 'regime'`.
+ */
+async function _applyLookups (instance) {
+  const keys = Object.keys(instance)
+
+  for (const key of keys) {
+    if (instance[key].schema) {
+      const { schema, table, lookup, value, select } = instance[key]
+
+      instance[key] = await _selector(schema, table, select, lookup, value)
+    }
+  }
+}
+
+/**
+ * Set the `is_test` flag on a record post-insert
+ *
+ * We don't believe in the idea of an `is_test` flag. All data in a non-prod environment can be considered test data. It
+ * is easier to create unit tests and build stuff if you know that everything can be wiped and re-seeded.
+ *
+ * So, when we created our views of the legacy tables we purposefully commented out the `is_test` field from all of
+ * them. We optimistically hoped to have a solution for test data that wouldn't depend on them.
+ *
+ * We'll we now have this solution to load test data. What we don't have yet is sufficient data to load. Meantime, our
+ * tests depend on using the `/data/tear-down` to wipe stuff and it depends on `is_test` flags.
+ *
+ * So, this is a 'fudge' to avoid having to go back and re-create loads of views just to include the flag. The constant
+ * `LOAD_HELPERS` identifies those entities that have a `is_test` field. When we load one that does we trigger this
+ * function to update the flag on the source table. Then when `/data/tear-down` runs it will know to clear it.
+ */
+async function _applyTestFlag (legacy, id) {
+  const { schema, table, id: tableId } = legacy
+
+  return db(table).withSchema(schema).update('is_test', true).where(tableId, id)
+}
+
+function _helper (entityKey) {
+  const loadHelper = LOAD_HELPERS[entityKey]
+
+  if (!loadHelper) {
+    throw new ExpandedError('Unknown entity to load', { entityKey })
+  }
+
+  return loadHelper
+}
+
+async function _selector (schema, table, select, where, value) {
+  const result = await db
+    .withSchema(schema)
+    .first(select)
+    .from(table)
+    .where(where, value)
+
+  return result[select]
 }
 
 module.exports = {

--- a/app/services/data/load/load.service.js
+++ b/app/services/data/load/load.service.js
@@ -1,0 +1,98 @@
+'use strict'
+
+/**
+ * Loads the entities requested by our acceptance tests when `/data/load` is called into the DB using the helpers
+ * @module LoadService
+ */
+
+/**
+ * Loads the entities requested by our acceptance tests when `/data/load` is called into the DB using the helpers
+ *
+ * Takes arrays of entities from the payload and using our test helpers creates associated records in the DB. For
+ * example, given the following payload a new 'region' record will be created using the `RegionHelper`, and a 'licence'
+ * using the `LicenceHelper`.
+ *
+ * ```json
+ * {
+ *   "regions": [
+ *     {
+ *       "id": "d0a4123d-1e19-480d-9dd4-f70f3387c4b9",
+ *       "chargeRegionId": "S",
+ *       "naldRegionId": 9,
+ *       "displayName": "Test Region",
+ *       "name": "Test Region"
+ *     }
+ *   ],
+ *   "licences": [
+ *     {
+ *       "id": "f8702a6a-f61d-4b0a-9af3-9a53768ee516",
+ *       "licenceRef": "AT/TEST/01",
+ *       "regionId": "d0a4123d-1e19-480d-9dd4-f70f3387c4b9",
+ *       "regions": {
+ *         "historicalAreaCode": "SAAR",
+ *         "regionalChargeArea": "Southern"
+ *       },
+ *       "startDate": "2022-04-01",
+ *       "waterUndertaker": true
+ *     }
+ *   ]
+ * }
+ * ```
+ *
+ * The IDs have been defined in the payload to make it possible to link the new licence to the new region.
+ *
+ * > Order matters!
+ *
+ * This is only possible because the region is defined in the payload _before_ the licence. If they were the other way
+ * round an error would be thrown when inserting the licence due to a foreign key constraint that requires the
+ * referenced region to exist.
+ *
+ * The values for each entity instance are passed to the associated helper. Like the unit tests, it is on the caller
+ * to override any defaults the helper will use. As this is intended to support acceptance testing it is likely you will
+ * need to define real values instead of leaving the helper generate the data.
+ *
+ * ### Looking up an ID (or value)
+ *
+ * Some records link to lookup values that already exist, for example charge categories and purposes. The problem is
+ * the IDs will be different in every environment. It is not possible to set the ID in the fixture. For these you can
+ * tell the loader to 'lookup' the ID (or value - it is up to you).
+ *
+ * In this example we need to lookup the ID for the `crm.entity` record whose `entity_type` is `'regime'`.
+ *
+ * ```json
+ *   "licenceDocumentHeaders": [
+ *     {
+ *       "id": "282b226e-c47b-4dcc-bbb0-94648fb6b242",
+ *       "regimeEntityId": {
+ *         "schema": "crm",
+ *         "table": "entity",
+ *         "lookup": "entityType",
+ *         "value": "regime",
+ *         "select": "entityId"
+ *       }
+ *     }
+ *   ]
+ * ```
+ *
+ * The result of the lookup will be used as the value for `regimeEntityId` when it is passed to the
+ * `LicenceDocumentHeaderHelper`. You _must_ provide all elements for the query. Transformed to SQL this would be
+ * `SELECT entity_id FROM crm.entity WHERE entity_type = 'regime'`.
+ *
+ * @param {Object} payload - the body from the request containing the entities to be created
+ *
+ * @returns {Promise<Object>} for each entity type passed in an array of ID's for the records created, for example
+ *
+ * ```javascript
+ * {
+ *   regions: ['d0a4123d-1e19-480d-9dd4-f70f3387c4b9'],
+ *   licences: ['f8702a6a-f61d-4b0a-9af3-9a53768ee516']
+ * }
+ * ```
+ */
+async function go (payload) {
+  return {}
+}
+
+module.exports = {
+  go
+}

--- a/test/controllers/data.controller.test.js
+++ b/test/controllers/data.controller.test.js
@@ -9,6 +9,7 @@ const { describe, it, beforeEach, afterEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Things we need to stub
+const LoadService = require('../../app/services/data/load/load.service.js')
 const SeedService = require('../../app/services/data/seed/seed.service.js')
 const SubmitDeduplicateService = require('../../app/services/data/deduplicate/submit-deduplicate.service.js')
 const TearDownService = require('../../app/services/data/tear-down/tear-down.service.js')
@@ -103,6 +104,44 @@ describe('Data controller', () => {
           expect(response.statusCode).to.equal(200)
           expect(response.payload).to.contain('There is a problem')
           expect(response.payload).to.contain('Enter a licence reference to de-dupe')
+        })
+      })
+    })
+  })
+
+  describe('/data/load', () => {
+    describe('POST', () => {
+      const options = {
+        method: 'POST',
+        url: '/data/load'
+      }
+
+      describe('when the request succeeds', () => {
+        beforeEach(async () => {
+          Sinon.stub(LoadService, 'go').resolves({
+            regions: ['d0a4123d-1e19-480d-9dd4-f70f3387c4b9']
+          })
+        })
+
+        it('returns a 200 status and the results', async () => {
+          const response = await server.inject(options)
+
+          expect(response.statusCode).to.equal(200)
+          expect(response.payload).to.equal('{"regions":["d0a4123d-1e19-480d-9dd4-f70f3387c4b9"]}')
+        })
+      })
+
+      describe('when the request fails', () => {
+        describe('because the LoadService errors', () => {
+          beforeEach(async () => {
+            Sinon.stub(LoadService, 'go').rejects()
+          })
+
+          it('returns a 500 status', async () => {
+            const response = await server.inject(options)
+
+            expect(response.statusCode).to.equal(500)
+          })
         })
       })
     })

--- a/test/services/data/load/load.service.test.js
+++ b/test/services/data/load/load.service.test.js
@@ -8,7 +8,13 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const DatabaseSupport = require('../../support/database.js')
+const BillRunModel = require('../../../../app/models/bill-run.model.js')
+const { db } = require('../../../../db/db.js')
+const DatabaseSupport = require('../../../support/database.js')
+const ExpandedError = require('../../../../app/errors/expanded.error.js')
+const ChargeCategoryHelper = require('../../../support/helpers/charge-category.helper.js')
+const ChargeReferenceModel = require('../../../../app/models/charge-reference.model.js')
+const RegionModel = require('../../../../app/models/region.model.js')
 
 // Thing under test
 const LoadService = require('../../../../app/services/data/load/load.service.js')
@@ -21,25 +27,104 @@ describe('Load service', () => {
   })
 
   describe('when the service is called', () => {
-    describe('with an valid payload', () => {
-      it('returns the generated IDs', async () => {
+    describe('with a valid payload', () => {
+      beforeEach(() => {
+        payload = {
+          regions: [
+            {
+              id: 'd0a4123d-1e19-480d-9dd4-f70f3387c4b9',
+              chargeRegionId: 'S',
+              naldRegionId: 9,
+              displayName: 'Test Region',
+              name: 'Test Region'
+            }
+          ],
+          billRuns: [
+            {
+              regionId: 'd0a4123d-1e19-480d-9dd4-f70f3387c4b9',
+              scheme: 'sroc',
+              status: 'sent'
+            }
+          ]
+        }
+      })
+
+      it('loads the entities into the DB', async () => {
+        const { billRuns } = await LoadService.go(payload)
+
+        const region = await RegionModel.query().findById('d0a4123d-1e19-480d-9dd4-f70f3387c4b9')
+        expect(region.displayName).to.equal('Test Region')
+
+        const billRun = await BillRunModel.query().findById(billRuns[0])
+        expect(billRun.regionId).to.equal('d0a4123d-1e19-480d-9dd4-f70f3387c4b9')
+        expect(billRun.status).to.equal('sent')
+      })
+
+      it('returns the generated and used IDs for the entities', async () => {
         const result = await LoadService.go(payload)
 
-        expect(result).to.equal({})
+        expect(result.regions).to.exist()
+        expect(result.regions).not.to.be.empty()
+
+        expect(result.billRuns).to.exist()
+        expect(result.billRuns).not.to.be.empty()
+      })
+
+      describe('that includes an entity instance with a lookup', () => {
+        let chargeCategoryId
+
+        beforeEach(async () => {
+          const { id } = await ChargeCategoryHelper.add({ reference: '4.2.1' })
+          chargeCategoryId = id
+
+          payload = {
+            chargeReferences: [
+              {
+                id: 'fa3c73d0-0459-41f0-b6cf-0e0758775ca4',
+                chargeVersionId: '8e5626ee-5e4c-48f6-a668-471d35997e2c',
+                description: 'SROC Charge Reference 01',
+                chargeCategoryId: { schema: 'public', table: 'chargeCategories', lookup: 'reference', value: '4.2.1', select: 'id' }
+              }
+            ]
+          }
+        })
+
+        it('transforms the lookup into the queried value', async () => {
+          await LoadService.go(payload)
+
+          const chargeReference = await ChargeReferenceModel.query().findById('fa3c73d0-0459-41f0-b6cf-0e0758775ca4')
+
+          expect(chargeReference.chargeCategoryId).to.equal(chargeCategoryId)
+        })
+      })
+
+      describe('that includes an entity with an "is_test" field', () => {
+        it('sets the "is_test" flag on the entity instance as part of loading it', async () => {
+          const result = await LoadService.go(payload)
+
+          const region = await db('regions').withSchema('water').first('isTest').where('regionId', result.regions[0])
+
+          expect(region.isTest).to.be.true()
+        })
       })
     })
 
     describe('with an invalid payload', () => {
-      it('returns the generated IDs', async () => {
-        await expect(LoadService.go(payload))
-          .to
-          .reject()
+      beforeEach(() => {
+        payload = { cats: [{ id: '72991007-3be7-4cd1-98b4-9ed54547e8c7', name: 'Tom' }] }
+      })
+
+      it('throws an exception', async () => {
+        const result = await expect(LoadService.go(payload)).to.reject()
+
+        expect(result).to.be.instanceOf(ExpandedError)
+        expect(result.entityKey).to.equal('cats')
       })
     })
 
     describe('with an empty payload', () => {
-      it('returns the generated IDs', async () => {
-        const result = await LoadService.go(payload)
+      it('returns an empty result', async () => {
+        const result = await LoadService.go(null)
 
         expect(result).to.equal({})
       })

--- a/test/services/data/load/load.service.test.js
+++ b/test/services/data/load/load.service.test.js
@@ -1,0 +1,48 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const DatabaseSupport = require('../../support/database.js')
+
+// Thing under test
+const LoadService = require('../../../../app/services/data/load/load.service.js')
+
+describe('Load service', () => {
+  let payload
+
+  beforeEach(async () => {
+    await DatabaseSupport.clean()
+  })
+
+  describe('when the service is called', () => {
+    describe('with an valid payload', () => {
+      it('returns the generated IDs', async () => {
+        const result = await LoadService.go(payload)
+
+        expect(result).to.equal({})
+      })
+    })
+
+    describe('with an invalid payload', () => {
+      it('returns the generated IDs', async () => {
+        await expect(LoadService.go(payload))
+          .to
+          .reject()
+      })
+    })
+
+    describe('with an empty payload', () => {
+      it('returns the generated IDs', async () => {
+        const result = await LoadService.go(payload)
+
+        expect(result).to.equal({})
+      })
+    })
+  })
+})


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3981

The [water-abstraction-service](https://gitub.com/DEFRA/water-abstraction-service) has a mechanism for seeding data for testing that relies on loading in YAML fixture files, sort of. Some content comes from these, but other stuff is hard-coded into the 'loaders'.

The legacy solution depends heavily on using placeholders to define references between the entities. The benefit is that you can add things in any order, and it's easier to see `x` links to `y`. The downside is that the loaders are very complex as they try to ensure the records are created in the right order, and the right placeholders in the YAML fixtures are updated. You also have to 'know' how they work because they can be inconsistent. For example, sometimes it will handle setting a lookup value, other times you have to create a 'test' lookup value and then reference it. This has led to occasions where a fixture is trying to load in a lookup value that already exists.

Finally, there is some undocumented functionality where certain placeholders are not references but instructions to generate dynamic data. All together, it is more than 7,000 lines of code, including 5,000 lines of YAML and 1,500 lines of JavaScript. To top it off, it often falls over for no discernible reason.

Long story short, we're going to replace it with something simpler yet more flexible!

Our new solution is going to be based on the hard work we've already invested in making our test helpers. We use these to quickly create meaningful records in the DB which we can then write unit tests against. So, why not reuse them to do the same for our acceptance tests!?

This change adds a new endpoint; `/data/load`. Our [water-abstraction-acceptance-tests](https://github.com/DEFRA/water-abstraction-acceptance-tests) will send a JSON payload that defines what entities it wants created and with what properties.

```json
{
  "regions": [
    {
      "id": "d0a4123d-1e19-480d-9dd4-f70f3387c4b9",
      "chargeRegionId": "S",
      "naldRegionId": 9,
      "displayName": "Test Region",
      "name": "Test Region"
    }
  ],
  "licences": [
    {
      "id": "f8702a6a-f61d-4b0a-9af3-9a53768ee516",
      "licenceRef": "AT/TEST/01",
      "regionId": "d0a4123d-1e19-480d-9dd4-f70f3387c4b9",
      "regions": {
        "historicalAreaCode": "SAAR",
        "regionalChargeArea": "Southern"
      },
      "startDate": "2022-04-01",
      "waterUndertaker": true
    }
  ],
  "licenceDocumentHeaders": [
    {
      "id": "282b226e-c47b-4dcc-bbb0-94648fb6b242",
      "regimeEntityId": {
        "schema": "crm",
        "table": "entity",
        "lookup": "entityType",
        "value": "regime",
        "select": "entityId"
      }
    }
  ],
}
```

As you can see we've eschewed clever referencing. Instead, when you create the fixture in **water-abstraction-acceptance-tests** you specify the ID's directly. For this to work, the order of the entities matter. The loader we are adding will process the JSON payload from top to bottom. For example, the region in this payload will be created first. Then when the licence is created its foreign key constraint won't error because the region it is referencing exists.

Obviously, with defined ID's you cannot load the same fixture without first having called `/data/tear-down` to delete any existing test data. But this is the same requirement for the legacy solution.

One problem that needed to be overcome was getting the ID's for lookup values. For example, we need to load a charge reference that is linked to the charge category `4.2.1`. The categories exist in a lookup table, and the charge references table has a foreign key constraint. So, we _must_ link to something that exists in that table. The problem is the ID's are generated when the table is created and populated as part of the migrations. That means they will be different across all environments. For this situation, rather than setting a value you can set an object.

```json
  "regimeEntityId": {
    "schema": "crm",
    "table": "entity",
    "lookup": "entityType",
    "value": "regime",
    "select": "entityId"
  }
```

This is the one 'clever' thing our loader does. It will use the information in the object to query the DB and extract the value requested. This will then be used when the entity is passed to the helper's `.add()` method.

That's it. Essentially we're doing the same thing we do in our unit tests. Passing values to our helpers and letting them deal with creating the records. Only the request is coming via a web request.