### PR TITLE
Fix licence set up route guard

### DIFF
--- a/app/presenters/licences/set-up.presenter.js
+++ b/app/presenters/licences/set-up.presenter.js
@@ -8,7 +8,6 @@
 const { formatLongDate } = require('../base.presenter.js')
 
 const roles = {
-  billing: 'billing',
   workflowEditor: 'charge_version_workflow_editor',
   workflowReviewer: 'charge_version_workflow_reviewer'
 }

--- a/app/routes/licence.routes.js
+++ b/app/routes/licence.routes.js
@@ -39,7 +39,7 @@ const routes = [
     options: {
       auth: {
         access: {
-          scope: ['billing']
+          scope: ['view_charge_versions']
         }
       },
       description: 'View a licence set up page'

--- a/test/controllers/licences.controller.test.js
+++ b/test/controllers/licences.controller.test.js
@@ -304,7 +304,7 @@ describe('Licences controller', () => {
         url: '/licences/7861814c-ca19-43f2-be11-3c612f0d744b/set-up',
         auth: {
           strategy: 'session',
-          credentials: { scope: ['billing'] }
+          credentials: { scope: ['view_charge_versions'] }
         }
       }
     })


### PR DESCRIPTION
A user needs the view_charge_versions permission to view the licence set up page (previously charge information)