### PR TITLE
Fix licence set up charge information buttons

### DIFF
--- a/app/presenters/licences/set-up.presenter.js
+++ b/app/presenters/licences/set-up.presenter.js
@@ -80,7 +80,7 @@ function _endsSixYearsAgo (endDate) {
   const sixYearsFromYesterday = new Date(yesterday.getTime())
   sixYearsFromYesterday.setFullYear(yesterday.getFullYear() - sixYears)
 
-  return endDate < sixYearsFromYesterday
+  return endDate.date < sixYearsFromYesterday
 }
 
 function _status (status) {

--- a/test/presenters/licences/set-up.presenter.test.js
+++ b/test/presenters/licences/set-up.presenter.test.js
@@ -257,7 +257,9 @@ describe('Licence Set Up presenter', () => {
         sixYearsAndOneDayAgo.setDate(sixYearsAndOneDayAgo.getDate() - 1)
         sixYearsAndOneDayAgo.setFullYear(sixYearsAndOneDayAgo.getFullYear() - 6)
 
-        commonData.ends = sixYearsAndOneDayAgo
+        commonData.ends = {
+          date: sixYearsAndOneDayAgo
+        }
 
         chargeVersions = []
         workflows = [{ ...workflow }]


### PR DESCRIPTION
When a licence is more than 6 years the charge information buttons should not show.

The endDate key on the licence was not a date but an object. This changes fixes the  _endsSixYearsAgo function by checking the date key on the endDate object.