### PR TITLE
Add the returns cycle text to the returns requirements check page

### DIFF
--- a/app/presenters/return-requirements/check/returns-requirements.presenter.js
+++ b/app/presenters/return-requirements/check/returns-requirements.presenter.js
@@ -54,18 +54,6 @@ function _requirements (requirements, purposes, points) {
   return completedRequirements
 }
 
-function _returnsCycle (returnsCycle) {
-  if (returnsCycle === 'summer') {
-    return 'Summer'
-  }
-
-  if (returnsCycle === 'winter-and-all-year') {
-    return 'Winter and all year'
-  }
-
-  return ''
-}
-
 function _mapPurposes (requirementPurposes, purposes) {
   return requirementPurposes.map((requirementPurpose) => {
     const matchedPurpose = purposes.find((purpose) => {

--- a/app/presenters/return-requirements/check/returns-requirements.presenter.js
+++ b/app/presenters/return-requirements/check/returns-requirements.presenter.js
@@ -84,7 +84,7 @@ function _mapRequirement (requirement, index, purposes, points) {
     index,
     points: _mapPoints(requirement.points, points),
     purposes: _mapPurposes(requirement.purposes, purposes),
-    returnsCycle: _returnsCycle(requirement.returnsCycle),
+    returnsCycle: requirement.returnsCycle === 'summer' ? 'Summer' : 'Winter and all year',
     siteDescription: requirement.siteDescription
   }
 }

--- a/app/presenters/return-requirements/check/returns-requirements.presenter.js
+++ b/app/presenters/return-requirements/check/returns-requirements.presenter.js
@@ -64,12 +64,25 @@ function _mapPurposes (requirementPurposes, purposes) {
   })
 }
 
+function _mapReturnCycle (returnsCycle) {
+  if (returnsCycle === 'summer') {
+    return 'Summer'
+  }
+
+  if (returnsCycle === 'winter-and-all-year') {
+    return 'Winter and all year'
+  }
+
+  return ''
+}
+
 function _mapRequirement (requirement, index, purposes, points) {
   return {
     abstractionPeriod: _abstractionPeriod(requirement.abstractionPeriod),
     frequencyCollected: requirement.frequencyCollected,
     frequencyReported: requirement.frequencyReported,
     index,
+    returnsCycle: _mapReturnCycle(requirement.returnsCycle),
     points: _mapPoints(requirement.points, points),
     purposes: _mapPurposes(requirement.purposes, purposes),
     siteDescription: requirement.siteDescription
@@ -77,7 +90,6 @@ function _mapRequirement (requirement, index, purposes, points) {
 }
 
 function _mapPoints (requirementPoints, points) {
-
   return requirementPoints.map((point) => {
     const matchedPoint = points.find((pid) => { return pid.ID === point })
 

--- a/app/presenters/return-requirements/check/returns-requirements.presenter.js
+++ b/app/presenters/return-requirements/check/returns-requirements.presenter.js
@@ -64,7 +64,7 @@ function _mapPurposes (requirementPurposes, purposes) {
   })
 }
 
-function _mapReturnCycle (returnsCycle) {
+function _returnsCycle (returnsCycle) {
   if (returnsCycle === 'summer') {
     return 'Summer'
   }
@@ -82,7 +82,7 @@ function _mapRequirement (requirement, index, purposes, points) {
     frequencyCollected: requirement.frequencyCollected,
     frequencyReported: requirement.frequencyReported,
     index,
-    returnsCycle: _mapReturnCycle(requirement.returnsCycle),
+    returnsCycle: _returnsCycle(requirement.returnsCycle),
     points: _mapPoints(requirement.points, points),
     purposes: _mapPurposes(requirement.purposes, purposes),
     siteDescription: requirement.siteDescription

--- a/app/presenters/return-requirements/check/returns-requirements.presenter.js
+++ b/app/presenters/return-requirements/check/returns-requirements.presenter.js
@@ -54,16 +54,6 @@ function _requirements (requirements, purposes, points) {
   return completedRequirements
 }
 
-function _mapPurposes (requirementPurposes, purposes) {
-  return requirementPurposes.map((requirementPurpose) => {
-    const matchedPurpose = purposes.find((purpose) => {
-      return purpose.id === requirementPurpose
-    })
-
-    return matchedPurpose.description
-  })
-}
-
 function _returnsCycle (returnsCycle) {
   if (returnsCycle === 'summer') {
     return 'Summer'
@@ -76,15 +66,25 @@ function _returnsCycle (returnsCycle) {
   return ''
 }
 
+function _mapPurposes (requirementPurposes, purposes) {
+  return requirementPurposes.map((requirementPurpose) => {
+    const matchedPurpose = purposes.find((purpose) => {
+      return purpose.id === requirementPurpose
+    })
+
+    return matchedPurpose.description
+  })
+}
+
 function _mapRequirement (requirement, index, purposes, points) {
   return {
     abstractionPeriod: _abstractionPeriod(requirement.abstractionPeriod),
     frequencyCollected: requirement.frequencyCollected,
     frequencyReported: requirement.frequencyReported,
     index,
-    returnsCycle: _returnsCycle(requirement.returnsCycle),
     points: _mapPoints(requirement.points, points),
     purposes: _mapPurposes(requirement.purposes, purposes),
+    returnsCycle: _returnsCycle(requirement.returnsCycle),
     siteDescription: requirement.siteDescription
   }
 }

--- a/app/views/return-requirements/check.njk
+++ b/app/views/return-requirements/check.njk
@@ -181,7 +181,7 @@
                     text: "Returns cycle"
                   },
                   value: {
-                    html: "requirement.returnsCycle"
+                    text: requirement.returnsCycle
                   },
                   actions: {
                     items: [

--- a/test/presenters/return-requirements/check/returns-requirements.presenter.test.js
+++ b/test/presenters/return-requirements/check/returns-requirements.presenter.test.js
@@ -128,10 +128,12 @@ describe('Return Requirements presenter', () => {
             expect(result.requirements[0].returnsCycle).to.equal('Summer')
           })
         })
+
         describe('Winter and all year', () => {
           beforeEach(() => {
             requirements = [{ ...requirement, returnsCycle: 'winter-and-all-year' }]
           })
+
           it('should return the text for a Winter and all year return cycle', () => {
             const result = ReturnRequirementsPresenter.go(requirements, purposes, points, journey)
 

--- a/test/presenters/return-requirements/check/returns-requirements.presenter.test.js
+++ b/test/presenters/return-requirements/check/returns-requirements.presenter.test.js
@@ -79,6 +79,7 @@ describe('Return Requirements presenter', () => {
           purposes: [
             'A singular purpose'
           ],
+          returnsCycle: 'Summer',
           siteDescription: 'A place in the sun'
         }]
       })
@@ -101,6 +102,7 @@ describe('Return Requirements presenter', () => {
           purposes: [
             'A singular purpose'
           ],
+          returnsCycle: 'Summer',
           siteDescription: 'A place in the sun'
         }
         ])
@@ -116,6 +118,26 @@ describe('Return Requirements presenter', () => {
         const result = ReturnRequirementsPresenter.go(requirements, purposes, points, journey)
 
         expect(result.requirements[0].points).to.equal(['At National Grid Reference TQ 1234 1234 (Test local name)'])
+      })
+
+      describe('and the return cycle is', () => {
+        describe('Summer', () => {
+          it('should return the text for a summer return cycle', () => {
+            const result = ReturnRequirementsPresenter.go(requirements, purposes, points, journey)
+
+            expect(result.requirements[0].returnsCycle).to.equal('Summer')
+          })
+        })
+        describe('Winter and all year', () => {
+          beforeEach(() => {
+            requirements = [{ ...requirement, returnsCycle: 'winter-and-all-year' }]
+          })
+          it('should return the text for a Winter and all year return cycle', () => {
+            const result = ReturnRequirementsPresenter.go(requirements, purposes, points, journey)
+
+            expect(result.requirements[0].returnsCycle).to.equal('Winter and all year')
+          })
+        })
       })
     })
 

--- a/test/services/return-requirements/check/returns-requirements.service.test.js
+++ b/test/services/return-requirements/check/returns-requirements.service.test.js
@@ -83,6 +83,7 @@ describe('Return Requirements service', () => {
           purposes: [
             'Spray Irrigation - Storage'
           ],
+          returnsCycle: 'Summer',
           siteDescription: 'A place in the sun'
         }],
         returnsRequired: true


### PR DESCRIPTION
Due to the estimated complexity of adding fetch services for purposes, points and other display items. We have broken down the complex display items into their own branches of work.

https://eaflood.atlassian.net/browse/WATER-4386

This branch will add returns cycles to the return requirement summary card. As of this commit there is only 'summer' and 'winter and all year' returns cycles

Previous work done here - #1019