### PR TITLE
Fix return req. frequency fields in view

### DIFF
--- a/db/migrations/legacy/20221108007024_water-return-requirements.js
+++ b/db/migrations/legacy/20221108007024_water-return-requirements.js
@@ -28,6 +28,7 @@ exports.up = function (knex) {
       table.boolean('reabstraction').notNullable().defaultTo(false)
       table.boolean('two_part_tariff').notNullable().defaultTo(false)
       table.boolean('fifty_six_exception').notNullable().defaultTo(false)
+      table.text('reporting_frequency').notNullable().defaultTo('day')
 
       // Legacy timestamps
       table.timestamp('date_created', { useTz: false }).notNullable().defaultTo(knex.fn.now())

--- a/db/migrations/public/20240606104018_create-return-requirements-view.js
+++ b/db/migrations/public/20240606104018_create-return-requirements-view.js
@@ -19,6 +19,7 @@ exports.up = function (knex) {
         'site_description',
         'legacy_id',
         'external_id',
+        'reporting_frequency',
         'collection_frequency',
         'gravity_fill',
         'reabstraction',


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4473

We recently extended the import of return requirements from NALD to include the frequency with which returns need to be collected. We thought with this and `returns_frequency` we would have the data we need to support the return requirements setup journey.

However, we now realise we made an incorrect assumption about what `returns_frequency` represents. We thought it was the reporting frequency; however it turns out NALD has 3 frequency levels.

- Return to agency (`ARTC_RET_FREQ_CODE`)
- Recording (`ARTC_REC_FREQ_CODE`)
- Collection (`ARTC_CODE`)

Because we assumed `ARTC_RET_FREQ_CODE` was reporting, we were importing `ARTC_REC_FREQ_CODE` as collection. Now we know it should have been

- `ARTC_REC_FREQ_CODE` is reporting frequency
- `ARTC_CODE` is collection frequency

We don't want to touch `ARTC_RET_FREQ_CODE` because we're still not 100% sure that nothing in the legacy code is using these tables. So, we have made changes to [water-abstraction-service](https://github.com/DEFRA/water-abstraction-service/pull/2556) and [water-abstraction-import](https://github.com/DEFRA/water-abstraction-import/pull/947) to add a new `reporting_frequency` field to `water.return_requirements`.

This change corrects the migrations we wrote (because they are not yet live) for return requirements to include the new field.