### PR TITLE
Two-part tariff review pages - Removing validation

### DIFF
--- a/app/validators/bill-runs/two-part-tariff/adjustment-factor.validator.js
+++ b/app/validators/bill-runs/two-part-tariff/adjustment-factor.validator.js
@@ -16,7 +16,7 @@ const Joi = require('joi')
  * pre-populated with the current value for both. The user must overwrite this value with there own value to amend the
  * adjustments.
  * The validation happening here is to ensure that the adjustments have been entered. Both have a
- * minimum value of 0 and a maximum value of 1, and they both get validated to either 2 or 15 decimal places.
+ * minimum value of 0 and they both get validated to either 2 or 15 decimal places.
  *
  * @param {Object} payload - The payload from the request to be validated
  * @param {Number} maxNumberOfDecimals - The maximum number of decimal places the factor can be validated to
@@ -54,13 +54,11 @@ function _validate (quantity, maxNumberOfDecimals, validationType) {
     quantity: Joi
       .number()
       .min(0)
-      .max(1)
       .required()
       .messages({
         'number.base': `The ${validationType} factor must be a number`,
         'number.unsafe': `The ${validationType} factor must be a number`,
         'number.min': `The ${validationType} factor must be greater than 0`,
-        'number.max': `The ${validationType} factor must be equal to or less than 1`,
         'any.required': `Enter a ${validationType} factor`
       })
   })

--- a/app/validators/bill-runs/two-part-tariff/authorised-volume.validator.js
+++ b/app/validators/bill-runs/two-part-tariff/authorised-volume.validator.js
@@ -15,7 +15,7 @@ const Joi = require('joi')
  * When editing the authorised volume on the charge reference, the user input box is pre-populated with the current
  * value. The user must overwrite this value with there own value to amend the authorised volume.
  * The validation happening here is to ensure that the volume has been entered, it has a maximum 6 decimal places and
- * is more than either the totalBillableReturns or the minVolume (whichever is more) and greater than the maxVolume.
+ * is more than the totalBillableReturns.
  *
  * @param {Object} payload - The payload from the request to be validated
  *
@@ -23,12 +23,9 @@ const Joi = require('joi')
  * any errors are found the `error:` property will also exist detailing what the issues were
  */
 function go (payload) {
-  const { authorisedVolume, totalBillableReturns, minVolume, maxVolume } = payload
+  const { authorisedVolume, totalBillableReturns } = payload
 
-  const minValue = Number(Math.max(totalBillableReturns, minVolume))
-  const maxValue = Number(maxVolume)
-
-  const validation = _validate(authorisedVolume, minValue, maxValue)
+  const validation = _validate(authorisedVolume, Number(totalBillableReturns))
 
   // The first check we are doing is validating that a number has been inputted within the correct range. If it has
   // then we can move onto next validating the number of decimal places
@@ -62,18 +59,16 @@ function _customValidation (quantity, helpers) {
   })
 }
 
-function _validate (authorisedVolume, minValue, maxValue) {
+function _validate (authorisedVolume, totalBillableReturns) {
   const schema = Joi.object({
     authorisedVolume: Joi
       .number()
-      .min(minValue)
-      .max(maxValue)
+      .min(totalBillableReturns)
       .required()
       .messages({
         'number.base': 'The authorised volume must be a number',
         'number.unsafe': 'The authorised volume must be a number or fewer than 17 digits long',
-        'number.min': `The authorised volume must be greater than ${minValue}`,
-        'number.max': `The authorised volume must be equal to or less than ${maxValue}`,
+        'number.min': `The authorised volume must be greater than ${totalBillableReturns}`,
         'any.required': 'Enter an authorised volume'
       })
   })

--- a/app/views/bill-runs/amend-authorised-volume.njk
+++ b/app/views/bill-runs/amend-authorised-volume.njk
@@ -67,8 +67,6 @@
 
         {# Hidden input for authorised volume #}
         <input type="hidden" name="totalBillableReturns" value="{{ chargeReference.totalBillableReturns }}">
-        <input type="hidden" name="minVolume" value="{{ chargeCategory.minVolume }}">
-        <input type="hidden" name="maxVolume" value="{{ chargeCategory.maxVolume }}">
 
         {{ govukButton({ text: 'Confirm', preventDoubleClick: true }) }}
       </form>

--- a/test/validators/bill-runs/two-part-tariff/adjustment-factor.validator.test.js
+++ b/test/validators/bill-runs/two-part-tariff/adjustment-factor.validator.test.js
@@ -106,23 +106,6 @@ describe('Adjustment Factor validator', () => {
       })
     })
 
-    describe('because the user entered a value greater than 1', () => {
-      beforeEach(() => {
-        payload = {
-          amendedAggregateFactor: 1.1
-        }
-
-        validationType = 'aggregate'
-      })
-
-      it('fails the validation with the message "The aggregate factor must be equal to or less than 1"', () => {
-        const result = AdjustmentFactorValidator.go(payload.amendedAggregateFactor, maxNumberOfDecimals, validationType)
-
-        expect(result.error).to.exist()
-        expect(result.error.details[0].message).to.equal('The aggregate factor must be equal to or less than 1')
-      })
-    })
-
     describe('because the user entered a value less than 0', () => {
       beforeEach(() => {
         payload = {
@@ -188,23 +171,6 @@ describe('Adjustment Factor validator', () => {
 
         expect(result.error).to.exist()
         expect(result.error.details[0].message).to.equal('The charge factor must not have more than 15 decimal places')
-      })
-    })
-
-    describe('because the user entered a value greater than 1', () => {
-      beforeEach(() => {
-        payload = {
-          amendedChargeFactor: 1.1
-        }
-
-        validationType = 'charge'
-      })
-
-      it('fails the validation with the message "The charge factor must be equal to or less than 1"', () => {
-        const result = AdjustmentFactorValidator.go(payload.amendedChargeFactor, maxNumberOfDecimals, validationType)
-
-        expect(result.error).to.exist()
-        expect(result.error.details[0].message).to.equal('The charge factor must be equal to or less than 1')
       })
     })
 

--- a/test/validators/bill-runs/two-part-tariff/authorised-volume.validator.test.js
+++ b/test/validators/bill-runs/two-part-tariff/authorised-volume.validator.test.js
@@ -18,9 +18,7 @@ describe('Authorised Volume validator', () => {
       beforeEach(() => {
         payload = {
           authorisedVolume: '10',
-          totalBillableReturns: '5',
-          minVolume: '5',
-          maxVolume: '20'
+          totalBillableReturns: '5'
         }
       })
 
@@ -36,9 +34,7 @@ describe('Authorised Volume validator', () => {
     describe('because the user did not enter an authorised volume', () => {
       beforeEach(() => {
         payload = {
-          totalBillableReturns: '5',
-          minVolume: '5',
-          maxVolume: '20'
+          totalBillableReturns: '5'
         }
       })
 
@@ -54,9 +50,7 @@ describe('Authorised Volume validator', () => {
       beforeEach(() => {
         payload = {
           authorisedVolume: 'Hello World',
-          totalBillableReturns: '5',
-          minVolume: '5',
-          maxVolume: '20'
+          totalBillableReturns: '5'
         }
       })
 
@@ -72,9 +66,7 @@ describe('Authorised Volume validator', () => {
       beforeEach(() => {
         payload = {
           authorisedVolume: '5',
-          totalBillableReturns: '6',
-          minVolume: '5',
-          maxVolume: '20'
+          totalBillableReturns: '6'
         }
       })
 
@@ -83,42 +75,6 @@ describe('Authorised Volume validator', () => {
 
         expect(result.error).to.exist()
         expect(result.error.details[0].message).to.equal('The authorised volume must be greater than 6')
-      })
-    })
-
-    describe('because the user entered a number less than the minVolume', () => {
-      beforeEach(() => {
-        payload = {
-          authorisedVolume: '5',
-          totalBillableReturns: '5',
-          minVolume: '6',
-          maxVolume: '20'
-        }
-      })
-
-      it('fails the validation with the message "The authorised volume must be greater than 6"', () => {
-        const result = AuthorisedVolumeValidator.go(payload)
-
-        expect(result.error).to.exist()
-        expect(result.error.details[0].message).to.equal('The authorised volume must be greater than 6')
-      })
-    })
-
-    describe('because the user entered a number greater than the max volume', () => {
-      beforeEach(() => {
-        payload = {
-          authorisedVolume: '25',
-          totalBillableReturns: '5',
-          minVolume: '6',
-          maxVolume: '20'
-        }
-      })
-
-      it('fails the validation with the message "The authorised volume must be equal to or less than 20"', () => {
-        const result = AuthorisedVolumeValidator.go(payload)
-
-        expect(result.error).to.exist()
-        expect(result.error.details[0].message).to.equal('The authorised volume must be equal to or less than 20')
       })
     })
 
@@ -126,9 +82,7 @@ describe('Authorised Volume validator', () => {
       beforeEach(() => {
         payload = {
           authorisedVolume: '15.1234567',
-          totalBillableReturns: '5',
-          minVolume: '6',
-          maxVolume: '20'
+          totalBillableReturns: '5'
         }
       })
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4497

During the testing for the two-part tariff review pages, it was found that some of the validation on the amend pages where too restrictive. The volumes or adjustments entered both had minimum and maximum values set. The billing and data team after testing the engine found these to be too restrictive and they needed the ability to go higher than the max amount. This PR removes the validation for the range that a user can enter.