### PR TITLE
Add purpose primary and secondary models

### DIFF
--- a/app/models/licence-version-purpose.model.js
+++ b/app/models/licence-version-purpose.model.js
@@ -39,6 +39,14 @@ class LicenceVersionPurposeModel extends BaseModel {
           from: 'licenceVersionPurposes.purposeId',
           to: 'purposes.id'
         }
+      },
+      secondaryPurpose: {
+        relation: Model.BelongsToOneRelation,
+        modelClass: 'secondary-purpose.model.js',
+        join: {
+          from: 'licenceVersionPurposes.secondaryPurposeId',
+          to: 'secondaryPurposes.id'
+        }
       }
     }
   }

--- a/app/models/licence-version-purpose.model.js
+++ b/app/models/licence-version-purpose.model.js
@@ -24,6 +24,14 @@ class LicenceVersionPurposeModel extends BaseModel {
           to: 'licenceVersions.id'
         }
       },
+      primaryPurpose: {
+        relation: Model.BelongsToOneRelation,
+        modelClass: 'primary-purpose.model.js',
+        join: {
+          from: 'licenceVersionPurposes.primaryPurposeId',
+          to: 'primaryPurposes.id'
+        }
+      },
       purpose: {
         relation: Model.BelongsToOneRelation,
         modelClass: 'purpose.model.js',

--- a/app/models/licence-version-purpose.model.js
+++ b/app/models/licence-version-purpose.model.js
@@ -50,6 +50,77 @@ class LicenceVersionPurposeModel extends BaseModel {
       }
     }
   }
+
+  /**
+   * Modifiers allow us to reuse logic in queries, eg. select the licence version purpose and all related purposes to
+   * determine if the purpose is electricity generation.
+   *
+   * return LicenceVersionPurposeModel.query()
+   *   .findById(licenceVersionPurposeId)
+   *   .modify('allPurposes')
+   *
+   * See {@link https://vincit.github.io/objection.js/recipes/modifiers.html | Modifiers} for more details
+   */
+  static get modifiers () {
+    return {
+      /**
+       * allPurposes modifier fetches the purpose plus primary and secondary purposes. Built to support determining if
+       * the overall purpose is electricity generation or spray irrigation with two-part tariff. These are needed to
+       * determine what frequency returns should be collected and reported by the licensee.
+       */
+      allPurposes (query) {
+        query
+          .withGraphFetched('purpose')
+          .modifyGraph('purpose', (builder) => {
+            builder.select([
+              'id',
+              'legacyId',
+              'twoPartTariff'
+            ])
+          })
+          .withGraphFetched('primaryPurpose')
+          .modifyGraph('primaryPurpose', (builder) => {
+            builder.select([
+              'id',
+              'legacyId'
+            ])
+          })
+          .withGraphFetched('secondaryPurpose')
+          .modifyGraph('secondaryPurpose', (builder) => {
+            builder.select([
+              'id',
+              'legacyId'
+            ])
+          })
+      }
+    }
+  }
+
+  /**
+   * Determine if the overall purpose is for electricity generation
+   *
+   * If the primary purpose is P (Production Of Energy), the secondary purpose is ELC (Electricity) and purpose is
+   * either 200 (Heat Pump) or 240 (Hydroelectric Power Generation) then the overall purpose is deemed to be electricity
+   * generation.
+   *
+   * This information is used when we have to generate return requirements from the current abstraction data and
+   * determine what collection and reporting frequency to use.
+   *
+   * @returns {Boolean} true if the overall purpose is electricity generation (P-ELC-240 or P-ELC-200) else false
+   */
+  $electricityGeneration () {
+    if (this.primaryPurpose.legacyId !== 'P') {
+      return false
+    }
+
+    if (this.secondaryPurpose.legacyId !== 'ELC') {
+      return false
+    }
+
+    const electricityGenerationPurposes = ['200', '240']
+
+    return electricityGenerationPurposes.includes(this.purpose.legacyId)
+  }
 }
 
 module.exports = LicenceVersionPurposeModel

--- a/app/models/primary-purpose.model.js
+++ b/app/models/primary-purpose.model.js
@@ -5,11 +5,34 @@
  * @module PrimaryPurposeModel
  */
 
+const { Model } = require('objection')
+
 const BaseModel = require('./base.model.js')
 
 class PrimaryPurposeModel extends BaseModel {
   static get tableName () {
     return 'primaryPurposes'
+  }
+
+  static get relationMappings () {
+    return {
+      licenceVersionPurposes: {
+        relation: Model.HasManyRelation,
+        modelClass: 'licence-version-purpose.model',
+        join: {
+          from: 'primaryPurposes.id',
+          to: 'licenceVersionPurposes.primaryPurposeId'
+        }
+      },
+      returnRequirementPurposes: {
+        relation: Model.HasManyRelation,
+        modelClass: 'return-requirement-purpose.model',
+        join: {
+          from: 'primaryPurposes.id',
+          to: 'returnRequirementPurposes.primaryPurposeId'
+        }
+      }
+    }
   }
 }
 

--- a/app/models/primary-purpose.model.js
+++ b/app/models/primary-purpose.model.js
@@ -1,0 +1,16 @@
+'use strict'
+
+/**
+ * Model for primary_purposes (water.purposes_primary)
+ * @module PrimaryPurposeModel
+ */
+
+const BaseModel = require('./base.model.js')
+
+class PrimaryPurposeModel extends BaseModel {
+  static get tableName () {
+    return 'primaryPurposes'
+  }
+}
+
+module.exports = PrimaryPurposeModel

--- a/app/models/return-requirement-purpose.model.js
+++ b/app/models/return-requirement-purpose.model.js
@@ -39,6 +39,14 @@ class ReturnRequirementPurposeModel extends BaseModel {
           from: 'returnRequirementPurposes.returnRequirementId',
           to: 'returnRequirements.id'
         }
+      },
+      secondaryPurpose: {
+        relation: Model.BelongsToOneRelation,
+        modelClass: 'secondary-purpose.model.js',
+        join: {
+          from: 'returnRequirementPurposes.secondaryPurposeId',
+          to: 'secondaryPurposes.id'
+        }
       }
     }
   }

--- a/app/models/return-requirement-purpose.model.js
+++ b/app/models/return-requirement-purpose.model.js
@@ -16,6 +16,14 @@ class ReturnRequirementPurposeModel extends BaseModel {
 
   static get relationMappings () {
     return {
+      primaryPurpose: {
+        relation: Model.BelongsToOneRelation,
+        modelClass: 'primary-purpose.model.js',
+        join: {
+          from: 'returnRequirementPurposes.primaryPurposeId',
+          to: 'primaryPurposes.id'
+        }
+      },
       purpose: {
         relation: Model.BelongsToOneRelation,
         modelClass: 'purpose.model',

--- a/app/models/secondary-purpose.model.js
+++ b/app/models/secondary-purpose.model.js
@@ -5,11 +5,34 @@
  * @module SecondaryPurposeModel
  */
 
+const { Model } = require('objection')
+
 const BaseModel = require('./base.model.js')
 
 class SecondaryPurposeModel extends BaseModel {
   static get tableName () {
     return 'secondaryPurposes'
+  }
+
+  static get relationMappings () {
+    return {
+      licenceVersionPurposes: {
+        relation: Model.HasManyRelation,
+        modelClass: 'licence-version-purpose.model',
+        join: {
+          from: 'secondaryPurposes.id',
+          to: 'licenceVersionPurposes.secondaryPurposeId'
+        }
+      },
+      returnRequirementPurposes: {
+        relation: Model.HasManyRelation,
+        modelClass: 'return-requirement-purpose.model',
+        join: {
+          from: 'secondaryPurposes.id',
+          to: 'returnRequirementPurposes.secondaryPurposeId'
+        }
+      }
+    }
   }
 }
 

--- a/app/models/secondary-purpose.model.js
+++ b/app/models/secondary-purpose.model.js
@@ -1,0 +1,16 @@
+'use strict'
+
+/**
+ * Model for secondary_purposes (water.purposes_secondary)
+ * @module SecondaryPurposeModel
+ */
+
+const BaseModel = require('./base.model.js')
+
+class SecondaryPurposeModel extends BaseModel {
+  static get tableName () {
+    return 'secondaryPurposes'
+  }
+}
+
+module.exports = SecondaryPurposeModel

--- a/db/migrations/legacy/20221108007035_water-purposes-primary.js
+++ b/db/migrations/legacy/20221108007035_water-purposes-primary.js
@@ -1,0 +1,32 @@
+'use strict'
+
+const tableName = 'purposes_primary'
+
+exports.up = function (knex) {
+  return knex
+    .schema
+    .withSchema('water')
+    .createTable(tableName, (table) => {
+      // Primary Key
+      table.uuid('purpose_primary_id').primary().defaultTo(knex.raw('gen_random_uuid()'))
+
+      // Data
+      table.string('legacy_id').notNullable()
+      table.string('description').notNullable()
+      table.boolean('is_test')
+
+      // Legacy timestamps
+      table.timestamp('date_created', { useTz: false }).notNullable().defaultTo(knex.fn.now())
+      table.timestamp('date_updated', { useTz: false }).notNullable().defaultTo(knex.fn.now())
+
+      // Constraints
+      table.unique(['legacy_id'], { useConstraint: true })
+    })
+}
+
+exports.down = function (knex) {
+  return knex
+    .schema
+    .withSchema('water')
+    .dropTableIfExists(tableName)
+}

--- a/db/migrations/legacy/20221108007036_water-purposes-secondary.js
+++ b/db/migrations/legacy/20221108007036_water-purposes-secondary.js
@@ -1,0 +1,32 @@
+'use strict'
+
+const tableName = 'purposes_secondary'
+
+exports.up = function (knex) {
+  return knex
+    .schema
+    .withSchema('water')
+    .createTable(tableName, (table) => {
+      // Primary Key
+      table.uuid('purpose_secondary_id').primary().defaultTo(knex.raw('gen_random_uuid()'))
+
+      // Data
+      table.string('legacy_id').notNullable()
+      table.string('description').notNullable()
+      table.boolean('is_test')
+
+      // Legacy timestamps
+      table.timestamp('date_created', { useTz: false }).notNullable().defaultTo(knex.fn.now())
+      table.timestamp('date_updated', { useTz: false }).notNullable().defaultTo(knex.fn.now())
+
+      // Constraints
+      table.unique(['legacy_id'], { useConstraint: true })
+    })
+}
+
+exports.down = function (knex) {
+  return knex
+    .schema
+    .withSchema('water')
+    .dropTableIfExists(tableName)
+}

--- a/db/migrations/public/20240611200155_create-primary-purposes-view.js
+++ b/db/migrations/public/20240611200155_create-primary-purposes-view.js
@@ -1,0 +1,25 @@
+'use strict'
+
+const viewName = 'primary_purposes'
+
+exports.up = function (knex) {
+  return knex
+    .schema
+    .createView(viewName, (view) => {
+      // NOTE: We have commented out unused columns from the source table
+      view.as(knex('purposes_primary').withSchema('water').select([
+        'purpose_primary_id AS id',
+        'legacy_id',
+        'description',
+        // 'is_test',
+        'date_created AS created_at',
+        'date_updated AS updated_at'
+      ]))
+    })
+}
+
+exports.down = function (knex) {
+  return knex
+    .schema
+    .dropViewIfExists(viewName)
+}

--- a/db/migrations/public/20240611200206_create-secondary-purposes-view.js
+++ b/db/migrations/public/20240611200206_create-secondary-purposes-view.js
@@ -1,0 +1,25 @@
+'use strict'
+
+const viewName = 'secondary_purposes'
+
+exports.up = function (knex) {
+  return knex
+    .schema
+    .createView(viewName, (view) => {
+      // NOTE: We have commented out unused columns from the source table
+      view.as(knex('purposes_secondary').withSchema('water').select([
+        'purpose_secondary_id AS id',
+        'legacy_id',
+        'description',
+        // 'is_test',
+        'date_created AS created_at',
+        'date_updated AS updated_at'
+      ]))
+    })
+}
+
+exports.down = function (knex) {
+  return knex
+    .schema
+    .dropViewIfExists(viewName)
+}

--- a/db/migrations/public/20240611200226_alter-licence-version-purposes-view.js
+++ b/db/migrations/public/20240611200226_alter-licence-version-purposes-view.js
@@ -1,0 +1,59 @@
+'use strict'
+
+const viewName = 'licence_version_purposes'
+
+exports.up = function (knex) {
+  return knex
+    .schema
+    .dropViewIfExists(viewName)
+    .createView(viewName, (view) => {
+      // NOTE: We have commented out unused columns from the source table
+      view.as(knex('licence_version_purposes').withSchema('water').select([
+        'licence_version_purpose_id AS id',
+        'licence_version_id',
+        'purpose_primary_id AS primary_purpose_id',
+        'purpose_secondary_id AS secondary_purpose_id',
+        'purpose_use_id AS purpose_id',
+        'abstraction_period_start_day',
+        'abstraction_period_start_month',
+        'abstraction_period_end_day',
+        'abstraction_period_end_month',
+        'time_limited_start_date',
+        'time_limited_end_date',
+        'notes',
+        'annual_quantity',
+        'external_id',
+        // 'is_test ',
+        'date_created AS created_at',
+        'date_updated AS updated_at'
+      ]))
+    })
+}
+
+exports.down = function (knex) {
+  return knex
+    .schema
+    .dropViewIfExists(viewName)
+    .createView(viewName, (view) => {
+      // NOTE: We have commented out unused columns from the source table
+      view.as(knex('licence_version_purposes').withSchema('water').select([
+        'licence_version_purpose_id AS id',
+        'licence_version_id',
+        'purpose_primary_id',
+        'purpose_secondary_id',
+        'purpose_use_id AS purpose_id',
+        'abstraction_period_start_day',
+        'abstraction_period_start_month',
+        'abstraction_period_end_day',
+        'abstraction_period_end_month',
+        'time_limited_start_date',
+        'time_limited_end_date',
+        'notes',
+        'annual_quantity',
+        'external_id',
+        // 'is_test ',
+        'date_created AS created_at',
+        'date_updated AS updated_at'
+      ]))
+    })
+}

--- a/db/migrations/public/20240611215502_alter-return-requirement-purposes-view.js
+++ b/db/migrations/public/20240611215502_alter-return-requirement-purposes-view.js
@@ -1,0 +1,41 @@
+'use strict'
+
+const viewName = 'return_requirement_purposes'
+
+exports.up = function (knex) {
+  return knex
+    .schema
+    .dropViewIfExists(viewName)
+    .createView(viewName, (view) => {
+      view.as(knex('return_requirement_purposes').withSchema('water').select([
+        'return_requirement_purpose_id AS id',
+        'return_requirement_id',
+        'purpose_primary_id AS primary_purpose_id',
+        'purpose_secondary_id AS secondary_purpose_id',
+        'purpose_use_id AS purpose_id',
+        'purpose_alias AS alias',
+        'external_id',
+        'date_created AS created_at',
+        'date_updated AS updated_at'
+      ]))
+    })
+}
+
+exports.down = function (knex) {
+  return knex
+    .schema
+    .dropViewIfExists(viewName)
+    .createView(viewName, (view) => {
+      view.as(knex('return_requirement_purposes').withSchema('water').select([
+        'return_requirement_purpose_id AS id',
+        'return_requirement_id',
+        'purpose_primary_id',
+        'purpose_secondary_id',
+        'purpose_use_id AS purpose_id',
+        'purpose_alias AS alias',
+        'external_id',
+        'date_created AS created_at',
+        'date_updated AS updated_at'
+      ]))
+    })
+}

--- a/test/models/licence-version-purpose.model.test.js
+++ b/test/models/licence-version-purpose.model.test.js
@@ -14,6 +14,8 @@ const LicenceVersionHelper = require('../support/helpers/licence-version.helper.
 const LicenceVersionPurposeHelper = require('../support/helpers/licence-version-purpose.helper.js')
 const PrimaryPurposeHelper = require('../support/helpers/primary-purpose.helper.js')
 const PrimaryPurposeModel = require('../../app/models/primary-purpose.model.js')
+const PurposeHelper = require('../support/helpers/purpose.helper.js')
+const PurposeModel = require('../../app/models/purpose.model.js')
 const SecondaryPurposeHelper = require('../support/helpers/secondary-purpose.helper.js')
 const SecondaryPurposeModel = require('../../app/models/secondary-purpose.model.js')
 
@@ -98,6 +100,36 @@ describe('Licence Version Purposes model', () => {
 
         expect(result.primaryPurpose).to.be.an.instanceOf(PrimaryPurposeModel)
         expect(result.primaryPurpose.id).to.equal(testPrimaryPurpose.id)
+      })
+    })
+
+    describe('when linking to purpose', () => {
+      let testPurpose
+
+      beforeEach(async () => {
+        testPurpose = await PurposeHelper.add()
+
+        const { id: purposeId } = testPurpose
+        testRecord = await LicenceVersionPurposeHelper.add({ purposeId })
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await LicenceVersionPurposeModel.query()
+          .innerJoinRelated('purpose')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the purpose', async () => {
+        const result = await LicenceVersionPurposeModel.query()
+          .findById(testRecord.id)
+          .withGraphFetched('purpose')
+
+        expect(result).to.be.instanceOf(LicenceVersionPurposeModel)
+        expect(result.id).to.equal(testRecord.id)
+
+        expect(result.purpose).to.be.an.instanceOf(PurposeModel)
+        expect(result.purpose.id).to.equal(testPurpose.id)
       })
     })
 

--- a/test/models/licence-version-purpose.model.test.js
+++ b/test/models/licence-version-purpose.model.test.js
@@ -217,11 +217,13 @@ describe('Licence Version Purposes model', () => {
 
     describe('but the secondary purpose is not "ELC" (Electricity)', () => {
       beforeEach(async () => {
-        await LicenceVersionPurposeHelper.add({
+        const licenceVersionPurpose = await LicenceVersionPurposeHelper.add({
           primaryPurposeId: validPrimaryPurpose.id,
           secondaryPurposeId: invalidSecondaryPurpose.id,
           purposeId: validPurpose.id
         })
+
+        testRecord = await LicenceVersionPurposeModel.query().findById(licenceVersionPurpose.id).modify('allPurposes')
       })
 
       it('returns false', () => {
@@ -233,11 +235,13 @@ describe('Licence Version Purposes model', () => {
 
     describe('but the purpose is not "200" or "240"', () => {
       beforeEach(async () => {
-        await LicenceVersionPurposeHelper.add({
+        const licenceVersionPurpose = await LicenceVersionPurposeHelper.add({
           primaryPurposeId: validPrimaryPurpose.id,
           secondaryPurposeId: validSecondaryPurpose.id,
           purposeId: invalidPurpose.id
         })
+
+        testRecord = await LicenceVersionPurposeModel.query().findById(licenceVersionPurpose.id).modify('allPurposes')
       })
 
       it('returns false', () => {
@@ -249,11 +253,13 @@ describe('Licence Version Purposes model', () => {
 
     describe('and the purpose plus primary and secondary purpose are all electricity generating', () => {
       beforeEach(async () => {
-        await LicenceVersionPurposeHelper.add({
+        const licenceVersionPurpose = await LicenceVersionPurposeHelper.add({
           primaryPurposeId: validPrimaryPurpose.id,
           secondaryPurposeId: validSecondaryPurpose.id,
           purposeId: validPurpose.id
         })
+
+        testRecord = await LicenceVersionPurposeModel.query().findById(licenceVersionPurpose.id).modify('allPurposes')
       })
 
       it('returns true', () => {

--- a/test/models/licence-version-purpose.model.test.js
+++ b/test/models/licence-version-purpose.model.test.js
@@ -14,6 +14,8 @@ const LicenceVersionHelper = require('../support/helpers/licence-version.helper.
 const LicenceVersionPurposeHelper = require('../support/helpers/licence-version-purpose.helper.js')
 const PrimaryPurposeHelper = require('../support/helpers/primary-purpose.helper.js')
 const PrimaryPurposeModel = require('../../app/models/primary-purpose.model.js')
+const SecondaryPurposeHelper = require('../support/helpers/secondary-purpose.helper.js')
+const SecondaryPurposeModel = require('../../app/models/secondary-purpose.model.js')
 
 // Thing under test
 const LicenceVersionPurposeModel = require('../../app/models/licence-version-purpose.model.js')
@@ -96,6 +98,36 @@ describe('Licence Version Purposes model', () => {
 
         expect(result.primaryPurpose).to.be.an.instanceOf(PrimaryPurposeModel)
         expect(result.primaryPurpose.id).to.equal(testPrimaryPurpose.id)
+      })
+    })
+
+    describe('when linking to secondary purpose', () => {
+      let testSecondaryPurpose
+
+      beforeEach(async () => {
+        testSecondaryPurpose = await SecondaryPurposeHelper.add()
+
+        const { id: secondaryPurposeId } = testSecondaryPurpose
+        testRecord = await LicenceVersionPurposeHelper.add({ secondaryPurposeId })
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await LicenceVersionPurposeModel.query()
+          .innerJoinRelated('secondaryPurpose')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the secondary purpose', async () => {
+        const result = await LicenceVersionPurposeModel.query()
+          .findById(testRecord.id)
+          .withGraphFetched('secondaryPurpose')
+
+        expect(result).to.be.instanceOf(LicenceVersionPurposeModel)
+        expect(result.id).to.equal(testRecord.id)
+
+        expect(result.secondaryPurpose).to.be.an.instanceOf(SecondaryPurposeModel)
+        expect(result.secondaryPurpose.id).to.equal(testSecondaryPurpose.id)
       })
     })
   })

--- a/test/models/licence-version-purpose.model.test.js
+++ b/test/models/licence-version-purpose.model.test.js
@@ -11,7 +11,9 @@ const { expect } = Code
 const DatabaseSupport = require('../support/database.js')
 const LicenceVersionModel = require('../../app/models/licence-version.model.js')
 const LicenceVersionHelper = require('../support/helpers/licence-version.helper.js')
-const LicenceVersionPurposesHelper = require('../support/helpers/licence-version-purpose.helper.js')
+const LicenceVersionPurposeHelper = require('../support/helpers/licence-version-purpose.helper.js')
+const PrimaryPurposeHelper = require('../support/helpers/primary-purpose.helper.js')
+const PrimaryPurposeModel = require('../../app/models/primary-purpose.model.js')
 
 // Thing under test
 const LicenceVersionPurposeModel = require('../../app/models/licence-version-purpose.model.js')
@@ -21,11 +23,13 @@ describe('Licence Version Purposes model', () => {
 
   beforeEach(async () => {
     await DatabaseSupport.clean()
-
-    testRecord = await LicenceVersionPurposesHelper.add()
   })
 
   describe('Basic query', () => {
+    beforeEach(async () => {
+      testRecord = await LicenceVersionPurposeHelper.add()
+    })
+
     it('can successfully run a basic query', async () => {
       const result = await LicenceVersionPurposeModel.query().findById(testRecord.id)
 
@@ -35,14 +39,14 @@ describe('Licence Version Purposes model', () => {
   })
 
   describe('Relationships', () => {
-    describe('when linking to licence version purposes', () => {
+    describe('when linking to licence version', () => {
       let testLicenceVersion
 
       beforeEach(async () => {
         testLicenceVersion = await LicenceVersionHelper.add()
 
         const { id } = testLicenceVersion
-        testRecord = await LicenceVersionPurposesHelper.add({ licenceVersionId: id })
+        testRecord = await LicenceVersionPurposeHelper.add({ licenceVersionId: id })
       })
 
       it('can successfully run a related query', async () => {
@@ -62,6 +66,36 @@ describe('Licence Version Purposes model', () => {
 
         expect(result.licenceVersion).to.be.an.instanceOf(LicenceVersionModel)
         expect(result.licenceVersion.id).to.equal(testLicenceVersion.id)
+      })
+    })
+
+    describe('when linking to primary purpose', () => {
+      let testPrimaryPurpose
+
+      beforeEach(async () => {
+        testPrimaryPurpose = await PrimaryPurposeHelper.add()
+
+        const { id: primaryPurposeId } = testPrimaryPurpose
+        testRecord = await LicenceVersionPurposeHelper.add({ primaryPurposeId })
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await LicenceVersionPurposeModel.query()
+          .innerJoinRelated('primaryPurpose')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the primary purpose', async () => {
+        const result = await LicenceVersionPurposeModel.query()
+          .findById(testRecord.id)
+          .withGraphFetched('primaryPurpose')
+
+        expect(result).to.be.instanceOf(LicenceVersionPurposeModel)
+        expect(result.id).to.equal(testRecord.id)
+
+        expect(result.primaryPurpose).to.be.an.instanceOf(PrimaryPurposeModel)
+        expect(result.primaryPurpose.id).to.equal(testPrimaryPurpose.id)
       })
     })
   })

--- a/test/models/primary-purpose.model.test.js
+++ b/test/models/primary-purpose.model.test.js
@@ -9,7 +9,11 @@ const { expect } = Code
 
 // Test helpers
 const DatabaseSupport = require('../support/database.js')
+const LicenceVersionPurposeHelper = require('../support/helpers/licence-version-purpose.helper.js')
+const LicenceVersionPurposeModel = require('../../app/models/licence-version-purpose.model.js')
 const PrimaryPurposeHelper = require('../support/helpers/primary-purpose.helper.js')
+const ReturnRequirementPurposeHelper = require('../support/helpers/return-requirement-purpose.helper.js')
+const ReturnRequirementPurposeModel = require('../../app/models/return-requirement-purpose.model.js')
 
 // Thing under test
 const PrimaryPurposeModel = require('../../app/models/primary-purpose.model.js')
@@ -31,6 +35,82 @@ describe('Primary Purpose model', () => {
 
       expect(result).to.be.an.instanceOf(PrimaryPurposeModel)
       expect(result.id).to.equal(testRecord.id)
+    })
+  })
+
+  describe('Relationships', () => {
+    describe('when linking to licence version purposes', () => {
+      let testLicenceVersionPurposes
+
+      beforeEach(async () => {
+        testRecord = await PrimaryPurposeHelper.add()
+
+        testLicenceVersionPurposes = []
+        for (let i = 0; i < 2; i++) {
+          const licenceVersionPurpose = await LicenceVersionPurposeHelper.add({
+            notes: `TEST licence Version purpose ${i}`, primaryPurposeId: testRecord.id
+          })
+          testLicenceVersionPurposes.push(licenceVersionPurpose)
+        }
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await PrimaryPurposeModel.query()
+          .innerJoinRelated('licenceVersionPurposes')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the bill licences', async () => {
+        const result = await PrimaryPurposeModel.query()
+          .findById(testRecord.id)
+          .withGraphFetched('licenceVersionPurposes')
+
+        expect(result).to.be.instanceOf(PrimaryPurposeModel)
+        expect(result.id).to.equal(testRecord.id)
+
+        expect(result.licenceVersionPurposes).to.be.an.array()
+        expect(result.licenceVersionPurposes[0]).to.be.an.instanceOf(LicenceVersionPurposeModel)
+        expect(result.licenceVersionPurposes).to.include(testLicenceVersionPurposes[0])
+        expect(result.licenceVersionPurposes).to.include(testLicenceVersionPurposes[1])
+      })
+    })
+
+    describe('when linking to return requirement purposes', () => {
+      let testReturnRequirementPurposes
+
+      beforeEach(async () => {
+        testRecord = await PrimaryPurposeHelper.add()
+
+        testReturnRequirementPurposes = []
+        for (let i = 0; i < 2; i++) {
+          const returnRequirementPurpose = await ReturnRequirementPurposeHelper.add({
+            alias: `TEST return requirement purpose ${i}`, primaryPurposeId: testRecord.id
+          })
+          testReturnRequirementPurposes.push(returnRequirementPurpose)
+        }
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await PrimaryPurposeModel.query()
+          .innerJoinRelated('returnRequirementPurposes')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the bill licences', async () => {
+        const result = await PrimaryPurposeModel.query()
+          .findById(testRecord.id)
+          .withGraphFetched('returnRequirementPurposes')
+
+        expect(result).to.be.instanceOf(PrimaryPurposeModel)
+        expect(result.id).to.equal(testRecord.id)
+
+        expect(result.returnRequirementPurposes).to.be.an.array()
+        expect(result.returnRequirementPurposes[0]).to.be.an.instanceOf(ReturnRequirementPurposeModel)
+        expect(result.returnRequirementPurposes).to.include(testReturnRequirementPurposes[0])
+        expect(result.returnRequirementPurposes).to.include(testReturnRequirementPurposes[1])
+      })
     })
   })
 })

--- a/test/models/primary-purpose.model.test.js
+++ b/test/models/primary-purpose.model.test.js
@@ -1,0 +1,36 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const DatabaseSupport = require('../support/database.js')
+const PrimaryPurposeHelper = require('../support/helpers/primary-purpose.helper.js')
+
+// Thing under test
+const PrimaryPurposeModel = require('../../app/models/primary-purpose.model.js')
+
+describe('Primary Purpose model', () => {
+  let testRecord
+
+  beforeEach(async () => {
+    await DatabaseSupport.clean()
+  })
+
+  describe('Basic query', () => {
+    beforeEach(async () => {
+      testRecord = await PrimaryPurposeHelper.add()
+    })
+
+    it('can successfully run a basic query', async () => {
+      const result = await PrimaryPurposeModel.query().findById(testRecord.id)
+
+      expect(result).to.be.an.instanceOf(PrimaryPurposeModel)
+      expect(result.id).to.equal(testRecord.id)
+    })
+  })
+})

--- a/test/models/return-requirement-purpose.model.test.js
+++ b/test/models/return-requirement-purpose.model.test.js
@@ -16,6 +16,8 @@ const PurposeHelper = require('../support/helpers/purpose.helper.js')
 const ReturnRequirementHelper = require('../support/helpers/return-requirement.helper.js')
 const ReturnRequirementModel = require('../../app/models/return-requirement.model.js')
 const ReturnRequirementPurposeHelper = require('../support/helpers/return-requirement-purpose.helper.js')
+const SecondaryPurposeHelper = require('../support/helpers/secondary-purpose.helper.js')
+const SecondaryPurposeModel = require('../../app/models/secondary-purpose.model.js')
 
 // Thing under test
 const ReturnRequirementPurposeModel = require('../../app/models/return-requirement-purpose.model.js')
@@ -129,6 +131,36 @@ describe('Return Requirement Purpose model', () => {
         expect(result.returnRequirement).to.be.an.instanceOf(ReturnRequirementModel)
         expect(result.returnRequirement).to.equal(testReturnRequirement)
       })
+    })
+  })
+
+  describe('when linking to secondary purpose', () => {
+    let testSecondaryPurpose
+
+    beforeEach(async () => {
+      testSecondaryPurpose = await SecondaryPurposeHelper.add()
+
+      const { id: secondaryPurposeId } = testSecondaryPurpose
+      testRecord = await ReturnRequirementPurposeHelper.add({ secondaryPurposeId })
+    })
+
+    it('can successfully run a related query', async () => {
+      const query = await ReturnRequirementPurposeModel.query()
+        .innerJoinRelated('secondaryPurpose')
+
+      expect(query).to.exist()
+    })
+
+    it('can eager load the secondary purpose', async () => {
+      const result = await ReturnRequirementPurposeModel.query()
+        .findById(testRecord.id)
+        .withGraphFetched('secondaryPurpose')
+
+      expect(result).to.be.instanceOf(ReturnRequirementPurposeModel)
+      expect(result.id).to.equal(testRecord.id)
+
+      expect(result.secondaryPurpose).to.be.an.instanceOf(SecondaryPurposeModel)
+      expect(result.secondaryPurpose.id).to.equal(testSecondaryPurpose.id)
     })
   })
 })

--- a/test/models/return-requirement-purpose.model.test.js
+++ b/test/models/return-requirement-purpose.model.test.js
@@ -9,6 +9,8 @@ const { expect } = Code
 
 // Test helpers
 const DatabaseSupport = require('../support/database.js')
+const PrimaryPurposeHelper = require('../support/helpers/primary-purpose.helper.js')
+const PrimaryPurposeModel = require('../../app/models/primary-purpose.model.js')
 const PurposeModel = require('../../app/models/purpose.model.js')
 const PurposeHelper = require('../support/helpers/purpose.helper.js')
 const ReturnRequirementHelper = require('../support/helpers/return-requirement.helper.js')
@@ -39,6 +41,36 @@ describe('Return Requirement Purpose model', () => {
   })
 
   describe('Relationships', () => {
+    describe('when linking to primary purpose', () => {
+      let testPrimaryPurpose
+
+      beforeEach(async () => {
+        testPrimaryPurpose = await PrimaryPurposeHelper.add()
+
+        const { id: primaryPurposeId } = testPrimaryPurpose
+        testRecord = await ReturnRequirementPurposeHelper.add({ primaryPurposeId })
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await ReturnRequirementPurposeModel.query()
+          .innerJoinRelated('primaryPurpose')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the primary purpose', async () => {
+        const result = await ReturnRequirementPurposeModel.query()
+          .findById(testRecord.id)
+          .withGraphFetched('primaryPurpose')
+
+        expect(result).to.be.instanceOf(ReturnRequirementPurposeModel)
+        expect(result.id).to.equal(testRecord.id)
+
+        expect(result.primaryPurpose).to.be.an.instanceOf(PrimaryPurposeModel)
+        expect(result.primaryPurpose.id).to.equal(testPrimaryPurpose.id)
+      })
+    })
+
     describe('when linking to purpose', () => {
       let testPurpose
 
@@ -56,7 +88,7 @@ describe('Return Requirement Purpose model', () => {
         expect(query).to.exist()
       })
 
-      it('can eager load the purposes use', async () => {
+      it('can eager load the purpose', async () => {
         const result = await ReturnRequirementPurposeModel.query()
           .findById(testRecord.id)
           .withGraphFetched('purpose')

--- a/test/models/secondary-purpose.model.test.js
+++ b/test/models/secondary-purpose.model.test.js
@@ -1,0 +1,36 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const DatabaseSupport = require('../support/database.js')
+const SecondaryPurposeHelper = require('../support/helpers/secondary-purpose.helper.js')
+
+// Thing under test
+const SecondaryPurposeModel = require('../../app/models/secondary-purpose.model.js')
+
+describe('Secondary Purpose model', () => {
+  let testRecord
+
+  beforeEach(async () => {
+    await DatabaseSupport.clean()
+  })
+
+  describe('Basic query', () => {
+    beforeEach(async () => {
+      testRecord = await SecondaryPurposeHelper.add()
+    })
+
+    it('can successfully run a basic query', async () => {
+      const result = await SecondaryPurposeModel.query().findById(testRecord.id)
+
+      expect(result).to.be.an.instanceOf(SecondaryPurposeModel)
+      expect(result.id).to.equal(testRecord.id)
+    })
+  })
+})

--- a/test/models/secondary-purpose.model.test.js
+++ b/test/models/secondary-purpose.model.test.js
@@ -9,6 +9,10 @@ const { expect } = Code
 
 // Test helpers
 const DatabaseSupport = require('../support/database.js')
+const LicenceVersionPurposeHelper = require('../support/helpers/licence-version-purpose.helper.js')
+const LicenceVersionPurposeModel = require('../../app/models/licence-version-purpose.model.js')
+const ReturnRequirementPurposeHelper = require('../support/helpers/return-requirement-purpose.helper.js')
+const ReturnRequirementPurposeModel = require('../../app/models/return-requirement-purpose.model.js')
 const SecondaryPurposeHelper = require('../support/helpers/secondary-purpose.helper.js')
 
 // Thing under test
@@ -31,6 +35,82 @@ describe('Secondary Purpose model', () => {
 
       expect(result).to.be.an.instanceOf(SecondaryPurposeModel)
       expect(result.id).to.equal(testRecord.id)
+    })
+  })
+
+  describe('Relationships', () => {
+    describe('when linking to licence version purposes', () => {
+      let testLicenceVersionPurposes
+
+      beforeEach(async () => {
+        testRecord = await SecondaryPurposeHelper.add()
+
+        testLicenceVersionPurposes = []
+        for (let i = 0; i < 2; i++) {
+          const licenceVersionPurpose = await LicenceVersionPurposeHelper.add({
+            notes: `TEST licence Version purpose ${i}`, secondaryPurposeId: testRecord.id
+          })
+          testLicenceVersionPurposes.push(licenceVersionPurpose)
+        }
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await SecondaryPurposeModel.query()
+          .innerJoinRelated('licenceVersionPurposes')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the bill licences', async () => {
+        const result = await SecondaryPurposeModel.query()
+          .findById(testRecord.id)
+          .withGraphFetched('licenceVersionPurposes')
+
+        expect(result).to.be.instanceOf(SecondaryPurposeModel)
+        expect(result.id).to.equal(testRecord.id)
+
+        expect(result.licenceVersionPurposes).to.be.an.array()
+        expect(result.licenceVersionPurposes[0]).to.be.an.instanceOf(LicenceVersionPurposeModel)
+        expect(result.licenceVersionPurposes).to.include(testLicenceVersionPurposes[0])
+        expect(result.licenceVersionPurposes).to.include(testLicenceVersionPurposes[1])
+      })
+    })
+
+    describe('when linking to return requirement purposes', () => {
+      let testReturnRequirementPurposes
+
+      beforeEach(async () => {
+        testRecord = await SecondaryPurposeHelper.add()
+
+        testReturnRequirementPurposes = []
+        for (let i = 0; i < 2; i++) {
+          const returnRequirementPurpose = await ReturnRequirementPurposeHelper.add({
+            alias: `TEST return requirement purpose ${i}`, secondaryPurposeId: testRecord.id
+          })
+          testReturnRequirementPurposes.push(returnRequirementPurpose)
+        }
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await SecondaryPurposeModel.query()
+          .innerJoinRelated('returnRequirementPurposes')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the bill licences', async () => {
+        const result = await SecondaryPurposeModel.query()
+          .findById(testRecord.id)
+          .withGraphFetched('returnRequirementPurposes')
+
+        expect(result).to.be.instanceOf(SecondaryPurposeModel)
+        expect(result.id).to.equal(testRecord.id)
+
+        expect(result.returnRequirementPurposes).to.be.an.array()
+        expect(result.returnRequirementPurposes[0]).to.be.an.instanceOf(ReturnRequirementPurposeModel)
+        expect(result.returnRequirementPurposes).to.include(testReturnRequirementPurposes[0])
+        expect(result.returnRequirementPurposes).to.include(testReturnRequirementPurposes[1])
+      })
     })
   })
 })

--- a/test/support/helpers/licence-version-purpose.helper.js
+++ b/test/support/helpers/licence-version-purpose.helper.js
@@ -15,8 +15,8 @@ const { randomInteger } = require('../general.js')
  *
  * - `licenceVersionPurposeId` - [random UUID]
  * - `licenceVersionId` - [random UUID]
- * - `purposePrimaryId` - [random UUID]
- * - `purposeSecondaryId` - [random UUID]
+ * - `primaryPurposeId` - [random UUID]
+ * - `secondaryPurposeId` - [random UUID]
  * - `purposeUseId` - [random UUID]
  * - `abstractionPeriodStartDay` - [1]
  * - `abstractionPeriodStartMonth` - [1]
@@ -58,8 +58,8 @@ function defaults (data = {}) {
     updatedAt: timestamp,
     externalId: `9:${randomInteger(10000, 99999)}:1:0`,
     licenceVersionId: generateUUID(),
-    purposePrimaryId: generateUUID(),
-    purposeSecondaryId: generateUUID(),
+    primaryPurposeId: generateUUID(),
+    secondaryPurposeId: generateUUID(),
     purposeId: generateUUID()
   }
 

--- a/test/support/helpers/primary-purpose.helper.js
+++ b/test/support/helpers/primary-purpose.helper.js
@@ -1,0 +1,72 @@
+'use strict'
+
+/**
+ * @module PurposeHelper
+ */
+
+const PrimaryPurposeModel = require('../../../app/models/primary-purpose.model.js')
+const { randomInteger } = require('../general.js')
+
+// NOTE: Taken from water.purposes_primary
+const PRIMARY_PURPOSES = [
+  { code: 'A', description: 'Agriculture' },
+  { code: 'E', description: 'Environmental' },
+  { code: 'I', description: 'Industrial, Commercial And Public Services' },
+  { code: 'M', description: 'Amenity' },
+  { code: 'P', description: 'Production Of Energy' },
+  { code: 'W', description: 'Water Supply' },
+  { code: 'X', description: 'Impounding' },
+  { code: 'C', description: 'Crown And Government' }
+]
+
+/**
+ * Add a new primary purpose
+ *
+ * If no `data` is provided, default values will be used. These are
+ *
+ * - `legacyId` - [randomly selected - A]
+ * - `description` - [randomly selected - Agriculture]
+ *
+ * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ *
+ * @returns {Promise<module:PurposeModel>} The instance of the newly created record
+ */
+function add (data = {}) {
+  const insertData = defaults(data)
+
+  return PrimaryPurposeModel.query()
+    .insert({ ...insertData })
+    .returning('*')
+}
+
+/**
+ * Returns the defaults used
+ *
+ * It will override or append to them any data provided. Mainly used by the `add()` method, we make it available
+ * for use in tests to avoid having to duplicate values.
+ *
+ * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ */
+function defaults (data = {}) {
+  const { code, description } = generatePrimaryPurpose()
+
+  const defaults = {
+    legacyId: data.legacyId ? data.legacyId : code,
+    description: data.description ? data.description : description
+  }
+
+  return {
+    ...defaults,
+    ...data
+  }
+}
+
+function generatePrimaryPurpose () {
+  return PRIMARY_PURPOSES[randomInteger(0, 7)]
+}
+
+module.exports = {
+  add,
+  defaults,
+  generatePrimaryPurpose
+}

--- a/test/support/helpers/return-requirement-purpose.helper.js
+++ b/test/support/helpers/return-requirement-purpose.helper.js
@@ -6,7 +6,9 @@
 
 const { generateUUID } = require('../../../app/lib/general.lib.js')
 const { randomInteger } = require('../general.js')
+const { generatePrimaryPurpose } = require('./primary-purpose.helper.js')
 const { generatePurposeCode } = require('./purpose.helper.js')
+const { generateSecondaryPurpose } = require('./secondary-purpose.helper.js')
 const ReturnRequirementPurposeModel = require('../../../app/models/return-requirement-purpose.model.js')
 
 /**
@@ -58,17 +60,11 @@ function defaults (data = {}) {
 }
 
 function _generatePrimaryCode () {
-  // NOTE: Taken from water.purposes_primary
-  const codes = ['A', 'E', 'I', 'M', 'P', 'W', 'X', 'C']
-
-  return codes[randomInteger(0, 7)]
+  return generatePrimaryPurpose().code
 }
 
 function _generateSecondaryCode () {
-  // NOTE: This is only a subset. There 63 of these codes that could be used. Taken from water.purposes_secondary
-  const codes = ['AGR', 'AQF', 'AQP', 'BRW', 'BUS', 'CHE', 'CON', 'CRN', 'DAR', 'ELC', 'EXT', 'FAD', 'FOR', 'GOF']
-
-  return codes[randomInteger(0, 13)]
+  return generateSecondaryPurpose().code
 }
 
 module.exports = {

--- a/test/support/helpers/return-requirement-purpose.helper.js
+++ b/test/support/helpers/return-requirement-purpose.helper.js
@@ -18,8 +18,8 @@ const ReturnRequirementPurposeModel = require('../../../app/models/return-requir
  *
  * - `externalId` - [randomly generated - 9:99999:A:AGR:400]
  * - `purposeId` - [random UUID]
- * - `purposePrimaryId` - [random UUID]
- * - `purposeSecondaryId` - [random UUID]
+ * - `primaryPurposeId` - [random UUID]
+ * - `secondaryPurposeId` - [random UUID]
  * - `returnRequirementId` - [random UUID]
  *
  * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
@@ -48,8 +48,8 @@ function defaults (data = {}) {
   const defaults = {
     externalId,
     purposeId: generateUUID(),
-    purposePrimaryId: generateUUID(),
-    purposeSecondaryId: generateUUID(),
+    primaryPurposeId: generateUUID(),
+    secondaryPurposeId: generateUUID(),
     returnRequirementId: generateUUID()
   }
 

--- a/test/support/helpers/secondary-purpose.helper.js
+++ b/test/support/helpers/secondary-purpose.helper.js
@@ -1,0 +1,84 @@
+'use strict'
+
+/**
+ * @module PurposeHelper
+ */
+
+const SecondaryPurposeModel = require('../../../app/models/secondary-purpose.model.js')
+const { randomInteger } = require('../general.js')
+
+// NOTE: This is only a subset. There 63 of these codes that could be used. Taken from water.purposes_secondary
+const SECONDARY_PURPOSES = [
+  { code: 'AGR', description: 'General Agriculture' },
+  { code: 'AQF', description: 'Aquaculture Fish' },
+  { code: 'AQP', description: 'Aquaculture Plant' },
+  { code: 'BRW', description: 'Breweries/Wine' },
+  { code: 'BUS', description: 'Business Parks' },
+  { code: 'CHE', description: 'Chemicals' },
+  { code: 'CON', description: 'Construction' },
+  { code: 'CRN', description: 'Crown And Government' },
+  { code: 'DAR', description: 'Dairies' },
+  { code: 'ELC', description: 'Electricity' },
+  { code: 'EXT', description: 'Extractive' },
+  { code: 'FAD', description: 'Food & Drink' },
+  { code: 'FOR', description: 'Forestry' },
+  { code: 'GOF', description: 'Golf Courses' },
+  { code: 'HOL', description: 'Holiday Sites, Camp Sites & Tourist Attractions' },
+  { code: 'HOS', description: 'Hospitals' },
+  { code: 'PAD', description: 'Public Administration' },
+  { code: 'PAP', description: 'Paper And Printing' },
+  { code: 'PET', description: 'Petrochemicals' },
+  { code: 'PRI', description: 'Private Non-Industrial' }
+]
+
+/**
+ * Add a new secondary purpose
+ *
+ * If no `data` is provided, default values will be used. These are
+ *
+ * - `legacyId` - [randomly selected - AGR]
+ * - `description` - [randomly selected - General Agriculture]
+ *
+ * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ *
+ * @returns {Promise<module:PurposeModel>} The instance of the newly created record
+ */
+function add (data = {}) {
+  const insertData = defaults(data)
+
+  return SecondaryPurposeModel.query()
+    .insert({ ...insertData })
+    .returning('*')
+}
+
+/**
+ * Returns the defaults used
+ *
+ * It will override or append to them any data provided. Mainly used by the `add()` method, we make it available
+ * for use in tests to avoid having to duplicate values.
+ *
+ * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ */
+function defaults (data = {}) {
+  const { code, description } = generateSecondaryPurpose()
+
+  const defaults = {
+    legacyId: data.legacyId ? data.legacyId : code,
+    description: data.description ? data.description : description
+  }
+
+  return {
+    ...defaults,
+    ...data
+  }
+}
+
+function generateSecondaryPurpose () {
+  return SECONDARY_PURPOSES[randomInteger(0, 7)]
+}
+
+module.exports = {
+  add,
+  defaults,
+  generateSecondaryPurpose
+}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4442

> Part of the work to replace NALD for handling return requirements

We want to be able to offer users the option to generate return requirements from the licence's abstraction data. On the `/setup` page, they can select this option and the service is expected to generate return requirements using the source abstraction data against the licence. The other options are to copy existing return requirements or set them up manually.

When you setup a return requirement you have to specify the frequency (daily, weekly or monthly) meter readings need to be collected and reported.

- collected - visit the meter and record the reading
- reported - when submitting the readings how they are to be provided

Generally they are the same, but there are scenarios where we may ask for readings to be collected more frequently than they are reported.

In order to generate the requirements automatically, we need to determine what frequencies to use based on the licence's abstraction data. A specific scenario is licences for the purpose of electricity generation; P-ELC-200 and P-ELC-240.

- `P` is the 'purpose primary' code
- `ELC` is the 'purpose secondary' code
- `200` is the 'purpose' legacy ID

We record all 3 against a `LicenceVersionPurpose` but currently the only one that exists as a model is 'purpose'. To support this work, we also need to know what the primary and secondary purposes on a `LicenceVersionPurposeModel` are.

So, this change adds the migrations, helpers and models for `PurposePrimary` and `PurposeSecondary` and sets up the relationships between them and `LicenceVersionPurposeModel`.

It then adds a modifier to `LicenceVersionPurpose` to automate fetching them, along with a custom model instance method that can be used to determine if a `LicenceVersionPurposeModel` is for the purpose of electricity generation.