### PR TITLE
Correct copy existing return req. page title

### DIFF
--- a/app/services/return-requirements/existing.service.js
+++ b/app/services/return-requirements/existing.service.js
@@ -25,7 +25,7 @@ async function go (sessionId) {
 
   return {
     activeNavBar: 'search',
-    pageTitle: 'Select an existing requirements for returns from',
+    pageTitle: 'Use previous requirements for returns',
     ...formattedData
   }
 }

--- a/app/services/return-requirements/submit-existing.service.js
+++ b/app/services/return-requirements/submit-existing.service.js
@@ -44,7 +44,7 @@ async function go (sessionId, payload) {
   return {
     activeNavBar: 'search',
     error: validationResult,
-    pageTitle: 'Select an existing requirements for returns from',
+    pageTitle: 'Use previous requirements for returns',
     ...formattedData
   }
 }

--- a/app/validators/return-requirements/existing.validator.js
+++ b/app/validators/return-requirements/existing.validator.js
@@ -7,7 +7,7 @@
 
 const Joi = require('joi')
 
-const errorMessage = 'Select an existing requirements for returns'
+const errorMessage = 'Use previous requirements for returns'
 
 /**
  * Validates data submitted for the `/return-requirements/{sessionId}/existing` page

--- a/app/views/return-requirements/existing.njk
+++ b/app/views/return-requirements/existing.njk
@@ -49,6 +49,9 @@
             classes: "govuk-fieldset__legend--l govuk-!-margin-bottom-6"
           }
         },
+        hint: {
+          text: "Select which requirements you want to use for this return."
+        },
         items: radioItems
       }) }}
 

--- a/test/controllers/return-requirements.controller.test.js
+++ b/test/controllers/return-requirements.controller.test.js
@@ -312,7 +312,7 @@ describe('Return requirements controller', () => {
       describe('when the request succeeds', () => {
         beforeEach(async () => {
           Sinon.stub(ExistingService, 'go').resolves({
-            id: '8702b98f-ae51-475d-8fcc-e049af8b8d38', pageTitle: 'Select an existing requirements for returns from'
+            id: '8702b98f-ae51-475d-8fcc-e049af8b8d38', pageTitle: 'Use previous requirements for returns'
           })
         })
 
@@ -320,7 +320,7 @@ describe('Return requirements controller', () => {
           const response = await server.inject(_getOptions(path))
 
           expect(response.statusCode).to.equal(200)
-          expect(response.payload).to.contain('Select an existing requirements for returns from')
+          expect(response.payload).to.contain('Use previous requirements for returns')
         })
       })
     })

--- a/test/services/return-requirements/existing.service.test.js
+++ b/test/services/return-requirements/existing.service.test.js
@@ -54,7 +54,7 @@ describe('Return Requirements - Existing service', () => {
 
       expect(result).to.equal({
         activeNavBar: 'search',
-        pageTitle: 'Select an existing requirements for returns from',
+        pageTitle: 'Use previous requirements for returns',
         existingOptions: [{ value: '60b5d10d-1372-4fb2-b222-bfac81da69ab', text: '1 January 2023' }],
         licenceRef: '01/ABC'
       }, { skip: ['sessionId'] })

--- a/test/services/return-requirements/submit-existing.service.test.js
+++ b/test/services/return-requirements/submit-existing.service.test.js
@@ -90,7 +90,7 @@ describe('Return Requirements - Submit Existing service', () => {
 
         expect(result).to.equal({
           activeNavBar: 'search',
-          pageTitle: 'Select an existing requirements for returns from',
+          pageTitle: 'Use previous requirements for returns',
           existingOptions: [{ value: '60b5d10d-1372-4fb2-b222-bfac81da69ab', text: '1 January 2023' }],
           licenceRef: '01/ABC'
         }, { skip: ['sessionId', 'error'] })
@@ -100,7 +100,7 @@ describe('Return Requirements - Submit Existing service', () => {
         it('includes an error for the input element', async () => {
           const result = await SubmitExistingService.go(session.id, payload)
 
-          expect(result.error).to.equal({ text: 'Select an existing requirements for returns' })
+          expect(result.error).to.equal({ text: 'Use previous requirements for returns' })
         })
       })
     })

--- a/test/validators/return-requirements/existing.validator.test.js
+++ b/test/validators/return-requirements/existing.validator.test.js
@@ -36,7 +36,7 @@ describe('Existing validator', () => {
 
         expect(result.value).to.exist()
         expect(result.error).to.exist()
-        expect(result.error.details[0].message).to.equal('Select an existing requirements for returns')
+        expect(result.error.details[0].message).to.equal('Use previous requirements for returns')
       })
     })
 
@@ -46,7 +46,7 @@ describe('Existing validator', () => {
 
         expect(result.value).to.exist()
         expect(result.error).to.exist()
-        expect(result.error.details[0].message).to.equal('Select an existing requirements for returns')
+        expect(result.error.details[0].message).to.equal('Use previous requirements for returns')
       })
     })
   })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4283

> Part of the work to replace NALD for handling return requirements

We want to be able to offer users the option to copy data from an existing return requirement when setting up a new one. We [made the option available](https://github.com/DEFRA/water-abstraction-system/pull/1081) in the `/setup` page.

We then did the actual work of allowing users to select the return requirements to copy and saving them to the session in [Complete Select existing return requirement page](https://github.com/DEFRA/water-abstraction-system/pull/895).

But we've since learned that the title we used for the page is not right. This change corrects it.

![Screenshot 2024-06-12 at 11 45 47](https://github.com/DEFRA/water-abstraction-system/assets/1789650/41fd0a3f-4b76-4677-89d2-4ada50e67d83)
