### PR TITLE
Add purpose description on two-part tariff licence review page

### DIFF
--- a/app/presenters/bill-runs/two-part-tariff/review-licence.presenter.js
+++ b/app/presenters/bill-runs/two-part-tariff/review-licence.presenter.js
@@ -95,6 +95,7 @@ function _chargeElementDetails (reviewChargeReference, chargePeriod) {
       elementStatus: reviewChargeElement.status,
       elementDescription: reviewChargeElement.chargeElement.description,
       dates: _prepareChargeElementDates(reviewChargeElement.chargeElement, chargePeriod),
+      purpose: reviewChargeElement.chargeElement.purpose.description,
       issues: reviewChargeElement.issues.length > 0 ? reviewChargeElement.issues.split(', ') : [''],
       billableReturns: `${reviewChargeElement.amendedAllocated} ML / ${reviewChargeElement.chargeElement.authorisedAnnualQuantity} ML`,
       returnVolume: _prepareReturnVolume(reviewChargeElement)

--- a/app/services/bill-runs/two-part-tariff/fetch-review-licence-results.service.js
+++ b/app/services/bill-runs/two-part-tariff/fetch-review-licence-results.service.js
@@ -103,9 +103,8 @@ async function _fetchReviewLicence (licenceId, billRunId) {
       ])
     })
     .withGraphFetched('reviewChargeVersions.reviewChargeReferences.reviewChargeElements.chargeElement.purpose')
-    .modifyGraph('chargeReferences.chargeElements.purpose', (builder) => {
-      builder
-        .select(['description'])
+    .modifyGraph('reviewChargeVersions.reviewChargeReferences.reviewChargeElements.chargeElement.purpose', (builder) => {
+      builder.select(['description'])
     })
     .withGraphFetched('reviewChargeVersions.reviewChargeReferences.reviewChargeElements.reviewReturns')
 }

--- a/app/services/bill-runs/two-part-tariff/fetch-review-licence-results.service.js
+++ b/app/services/bill-runs/two-part-tariff/fetch-review-licence-results.service.js
@@ -102,6 +102,11 @@ async function _fetchReviewLicence (licenceId, billRunId) {
         'authorisedAnnualQuantity'
       ])
     })
+    .withGraphFetched('reviewChargeVersions.reviewChargeReferences.reviewChargeElements.chargeElement.purpose')
+    .modifyGraph('chargeReferences.chargeElements.purpose', (builder) => {
+      builder
+        .select(['description'])
+    })
     .withGraphFetched('reviewChargeVersions.reviewChargeReferences.reviewChargeElements.reviewReturns')
 }
 

--- a/app/views/bill-runs/review-licence.njk
+++ b/app/views/bill-runs/review-licence.njk
@@ -396,6 +396,7 @@
                             <div data-test="element-dates-{{ chargeElementIndex }}">{{ chargeElementDate }}</div>
                           {% endfor %}
                         </div>
+                        {{ chargeElement.purpose }}
                       </h3>
 
                       {% set issues = '' %}

--- a/test/presenters/bill-runs/two-part-tariff/review-licence.presenter.test.js
+++ b/test/presenters/bill-runs/two-part-tariff/review-licence.presenter.test.js
@@ -93,6 +93,7 @@ describe('Review Licence presenter', () => {
                     elementStatus: 'ready',
                     elementDescription: 'Trickle Irrigation - Direct',
                     dates: ['1 April 2022 to 5 June 2022'],
+                    purpose: 'Make-up or top up water',
                     issues: [''],
                     billableReturns: '0 ML / 200 ML',
                     returnVolume: ['0 ML (10031343)'],
@@ -350,7 +351,10 @@ function _licenceData () {
             abstractionPeriodStartMonth: 4,
             abstractionPeriodEndDay: 31,
             abstractionPeriodEndMonth: 3,
-            authorisedAnnualQuantity: 200
+            authorisedAnnualQuantity: 200,
+            purpose: {
+              description: 'Make-up or top up water'
+            }
           },
           reviewReturns: [{
             id: '2264f443-5c16-4ca9-8522-f63e2d4e38be',

--- a/test/services/bill-runs/two-part-tariff/fetch-review-licence-results.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/fetch-review-licence-results.service.test.js
@@ -15,6 +15,7 @@ const ChargeReferenceHelper = require('../../../support/helpers/charge-reference
 const ChargeVersionHelper = require('../../../support/helpers/charge-version.helper.js')
 const DatabaseSupport = require('../../../support/database.js')
 const LicenceHelper = require('../../../support/helpers/licence.helper.js')
+const PurposeHelper = require('../../../support/helpers/purpose.helper.js')
 const RegionHelper = require('../../../support/helpers/region.helper.js')
 const ReturnLogHelper = require('../../../support/helpers/return-log.helper.js')
 const ReviewChargeVersionHelper = require('../../../support/helpers/review-charge-version.helper.js')
@@ -59,6 +60,7 @@ describe('Fetch Review Licence Results Service', () => {
       let reviewChargeElement
       let returnLog
       let reviewReturn
+      let purpose
 
       beforeEach(async () => {
         licence = await LicenceHelper.add()
@@ -76,7 +78,8 @@ describe('Fetch Review Licence Results Service', () => {
           chargeReferenceId: chargeReference.id
         })
 
-        chargeElement = await ChargeElementHelper.add({ chargeReferenceId: chargeReference.id })
+        purpose = await PurposeHelper.add()
+        chargeElement = await ChargeElementHelper.add({ chargeReferenceId: chargeReference.id, purposeId: purpose.id })
         reviewChargeElement = await ReviewChargeElementHelper.add({
           reviewChargeReferenceId: reviewChargeReference.id,
           chargeElementId: chargeElement.id
@@ -198,7 +201,10 @@ describe('Fetch Review Licence Results Service', () => {
                   abstractionPeriodStartMonth: chargeElement.abstractionPeriodStartMonth,
                   abstractionPeriodEndDay: chargeElement.abstractionPeriodEndDay,
                   abstractionPeriodEndMonth: chargeElement.abstractionPeriodEndMonth,
-                  authorisedAnnualQuantity: chargeElement.authorisedAnnualQuantity
+                  authorisedAnnualQuantity: chargeElement.authorisedAnnualQuantity,
+                  purpose: {
+                    description: purpose.description
+                  }
                 },
                 reviewReturns: [{
                   id: reviewReturn.id,

--- a/test/services/bill-runs/two-part-tariff/review-licence.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/review-licence.service.test.js
@@ -163,7 +163,10 @@ function _fetchReviewLicenceResults () {
               abstractionPeriodStartMonth: 4,
               abstractionPeriodEndDay: 31,
               abstractionPeriodEndMonth: 3,
-              authorisedAnnualQuantity: 200
+              authorisedAnnualQuantity: 200,
+              purpose: {
+                description: 'Spray irrigation - direct'
+              }
             },
             reviewReturns: [{
               id: '2264f443-5c16-4ca9-8522-f63e2d4e38be',


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4513

During testing for the two-part tariff review screens by the billing and data team, it was noted that adding the purpose to the end of the charge elements description, along with abstraction period dates, would simplify the review process. This PR aims to include the charge element's purpose text on the licence review page.