### PR TITLE
Add ability to search by Licence Number in 2 Part Tariff Review

### DIFF
--- a/app/presenters/bill-runs/two-part-tariff/review-bill-run.presenter.js
+++ b/app/presenters/bill-runs/two-part-tariff/review-bill-run.presenter.js
@@ -14,24 +14,24 @@ const { formatLongDate } = require('../../base.presenter.js')
  * @param {{Object[]}} filterIssues An array of issues to filter the results by. This will only contain data when
  * there is a POST request, which only occurs when a filter is applied to the results. NOTE: if there is only a single
  * issue this will be a string, not an array
- * @param {String} filterLicenceHolder The licence holder to filter the results by. This will only contain data when
- * there is a POST request, which only occurs when a filter is applied to the results.
+ * @param {String} filterLicenceHolderNumber The licence holder or licence number to filter the results by. This will
+ * only contain data when there is a POST request, which only occurs when a filter is applied to the results.
  * @param {String} filterLicenceStatus The status of the licence to filter the results by. This also only contains data
  * when there is a POST request.
  * @param {module:LicenceModel} licences The licences data associated with the bill run
  *
  * @returns {Object} The prepared bill run,licence and filter data to be passed to the review page
  */
-function go (billRun, filterIssues, filterLicenceHolder, filterLicenceStatus, licences) {
+function go (billRun, filterIssues, filterLicenceHolderNumber, filterLicenceStatus, licences) {
   const preparedLicences = _prepareLicences(licences)
 
   const preparedBillRun = _prepareBillRun(billRun, preparedLicences)
 
   const issues = filterIssues ? _prepareIssues(filterIssues) : filterIssues
 
-  const filter = { issues, licenceHolder: filterLicenceHolder, licenceStatus: filterLicenceStatus }
+  const filter = { issues, licenceHolderNumber: filterLicenceHolderNumber, licenceStatus: filterLicenceStatus }
   // this opens the filter on the page if any filter data has been received so the user can see the applied filters
-  filter.openFilter = (filterIssues || filterLicenceHolder || filterLicenceStatus) !== undefined
+  filter.openFilter = (filterIssues || filterLicenceHolderNumber || filterLicenceStatus) !== undefined
 
   return { ...preparedBillRun, preparedLicences, filter }
 }

--- a/app/services/bill-runs/two-part-tariff/fetch-bill-run-licences.service.js
+++ b/app/services/bill-runs/two-part-tariff/fetch-bill-run-licences.service.js
@@ -43,7 +43,12 @@ function _applyFilters (reviewLicenceQuery, filterIssues, filterLicenceHolderNum
   }
 
   if (filterLicenceHolderNumber) {
-    reviewLicenceQuery.whereILike('licenceHolder', `%${filterLicenceHolderNumber}%`)
+    // reviewLicenceQuery.whereILike('licenceHolder', `%${filterLicenceHolderNumber}%`)
+    reviewLicenceQuery.where((builder) => {
+      builder
+        .whereILike('licenceHolder', `%${filterLicenceHolderNumber}%`)
+        .orWhereLike('licenceRef', `%${filterLicenceHolderNumber}%`)
+    })
   }
 
   if (filterLicenceStatus) {

--- a/app/services/bill-runs/two-part-tariff/fetch-bill-run-licences.service.js
+++ b/app/services/bill-runs/two-part-tariff/fetch-bill-run-licences.service.js
@@ -21,8 +21,8 @@ const DatabaseConfig = require('../../../../config/database.config.js')
  * @param {{Object[]}} filterIssues An array of issues to filter the results by. This will only contain data when
  * there is a POST request, which only occurs when a filter is applied to the results. NOTE: if there is only a single
  * issue this will be a string, not an array
- * @param {String} filterLicenceHolder The licence holder to filter the results by. This will only contain data when
- * there is a POST request, which only occurs when a filter is applied to the results.
+ * @param {String} filterLicenceHolderNumber The licence holder or licence number to filter the results by. This will
+ * only contain data when there is a POST request, which only occurs when a filter is applied to the results.
  * @param {String} filterLicenceStatus The status of the licence to filter the results by. This also only contains data
  * when there is a POST request.
  * @param {number} page - the page number of licences to be viewed
@@ -30,20 +30,20 @@ const DatabaseConfig = require('../../../../config/database.config.js')
  * @returns {Promise<Object>} An object containing the billRun data and an array of licences for the bill run that match
  * the selected 'page in the data. Also included is any data that has been used to filter the results
  */
-async function go (id, filterIssues, filterLicenceHolder, filterLicenceStatus, page) {
+async function go (id, filterIssues, filterLicenceHolderNumber, filterLicenceStatus, page) {
   const billRun = await _fetchBillRun(id)
-  const licences = await _fetchBillRunLicences(id, filterIssues, filterLicenceHolder, filterLicenceStatus, page)
+  const licences = await _fetchBillRunLicences(id, filterIssues, filterLicenceHolderNumber, filterLicenceStatus, page)
 
   return { billRun, licences }
 }
 
-function _applyFilters (reviewLicenceQuery, filterIssues, filterLicenceHolder, filterLicenceStatus) {
+function _applyFilters (reviewLicenceQuery, filterIssues, filterLicenceHolderNumber, filterLicenceStatus) {
   if (filterIssues) {
     _filterIssues(filterIssues, reviewLicenceQuery)
   }
 
-  if (filterLicenceHolder) {
-    reviewLicenceQuery.whereILike('licenceHolder', `%${filterLicenceHolder}%`)
+  if (filterLicenceHolderNumber) {
+    reviewLicenceQuery.whereILike('licenceHolder', `%${filterLicenceHolderNumber}%`)
   }
 
   if (filterLicenceStatus) {
@@ -67,7 +67,7 @@ async function _fetchBillRun (id) {
     })
 }
 
-async function _fetchBillRunLicences (id, filterIssues, filterLicenceHolder, filterLicenceStatus, page = 1) {
+async function _fetchBillRunLicences (id, filterIssues, filterLicenceHolderNumber, filterLicenceStatus, page = 1) {
   const reviewLicenceQuery = ReviewLicenceModel.query()
     .select('licenceId', 'licenceRef', 'licenceHolder', 'issues', 'progress', 'status')
     .where('billRunId', id)
@@ -77,7 +77,7 @@ async function _fetchBillRunLicences (id, filterIssues, filterLicenceHolder, fil
     ])
     .page(page - 1, DatabaseConfig.defaultPageSize)
 
-  _applyFilters(reviewLicenceQuery, filterIssues, filterLicenceHolder, filterLicenceStatus)
+  _applyFilters(reviewLicenceQuery, filterIssues, filterLicenceHolderNumber, filterLicenceStatus)
 
   return reviewLicenceQuery
 }

--- a/app/services/bill-runs/two-part-tariff/fetch-bill-run-licences.service.js
+++ b/app/services/bill-runs/two-part-tariff/fetch-bill-run-licences.service.js
@@ -43,11 +43,10 @@ function _applyFilters (reviewLicenceQuery, filterIssues, filterLicenceHolderNum
   }
 
   if (filterLicenceHolderNumber) {
-    // reviewLicenceQuery.whereILike('licenceHolder', `%${filterLicenceHolderNumber}%`)
     reviewLicenceQuery.where((builder) => {
       builder
         .whereILike('licenceHolder', `%${filterLicenceHolderNumber}%`)
-        .orWhereLike('licenceRef', `%${filterLicenceHolderNumber}%`)
+        .orWhereILike('licenceRef', `%${filterLicenceHolderNumber}%`)
     })
   }
 

--- a/app/services/bill-runs/two-part-tariff/review-bill-run.service.js
+++ b/app/services/bill-runs/two-part-tariff/review-bill-run.service.js
@@ -20,14 +20,14 @@ const ReviewBillRunPresenter = require('../../../presenters/bill-runs/two-part-t
  * details of the bill run and the licences linked to it as well as any data that has been used to filter the results.
  */
 async function go (id, page, yar) {
-  const { filterIssues, filterLicenceHolder, filterLicenceStatus } = _getFilters(id, yar)
+  const { filterIssues, filterLicenceHolderNumber, filterLicenceStatus } = _getFilters(id, yar)
 
   const selectedPageNumber = page ? Number(page) : 1
 
   const { billRun, licences } = await FetchBillRunLicencesService.go(
     id,
     filterIssues,
-    filterLicenceHolder,
+    filterLicenceHolderNumber,
     filterLicenceStatus,
     selectedPageNumber
   )
@@ -37,7 +37,7 @@ async function go (id, page, yar) {
   const pageData = ReviewBillRunPresenter.go(
     billRun,
     filterIssues,
-    filterLicenceHolder,
+    filterLicenceHolderNumber,
     filterLicenceStatus,
     licences.results
   )
@@ -53,10 +53,10 @@ function _getFilters (id, yar) {
   const filters = yar.get(`review-${id}`)
 
   const filterIssues = filters?.filterIssues
-  const filterLicenceHolder = filters?.filterLicenceHolder
+  const filterLicenceHolderNumber = filters?.filterLicenceHolderNumber
   const filterLicenceStatus = filters?.filterLicenceStatus
 
-  return { filterIssues, filterLicenceHolder, filterLicenceStatus }
+  return { filterIssues, filterLicenceHolderNumber, filterLicenceStatus }
 }
 
 function _pageTitle (numberOfPages, selectedPageNumber) {

--- a/app/services/bill-runs/two-part-tariff/submit-review-bill-run.service.js
+++ b/app/services/bill-runs/two-part-tariff/submit-review-bill-run.service.js
@@ -15,7 +15,7 @@
 async function go (billRunId, payload, yar) {
   const clearFilters = payload?.clearFilters
   const filterIssues = payload?.filterIssues
-  const filterLicenceHolder = payload?.filterLicenceHolder
+  const filterLicenceHolderNumber = payload?.filterLicenceHolderNumber
   const filterLicenceStatus = payload?.filterLicenceStatus
 
   if (clearFilters) {
@@ -23,7 +23,7 @@ async function go (billRunId, payload, yar) {
   } else {
     yar.set(`review-${billRunId}`, {
       filterIssues,
-      filterLicenceHolder,
+      filterLicenceHolderNumber,
       filterLicenceStatus
     })
   }

--- a/app/views/bill-runs/review.njk
+++ b/app/views/bill-runs/review.njk
@@ -131,17 +131,17 @@
     <h2 class="govuk-heading-m govuk-!-margin-bottom-3">Filter by</h2>
 
     <form  method="post" action="review">
-      {# Filter by licence holder #}
+      {# Filter by licence holder or licence number #}
       {{ govukInput({
         label: {
-          text: "Licence holder",
+          text: "Licence holder or number",
           classes: "govuk-label--s",
           isPageHeading: false
         },
         classes: "govuk-input--width-20",
-        id: "filter-licence-holder",
-        name: "filterLicenceHolder",
-        value: filter.licenceHolder
+        id: "filter-licence-holder-number",
+        name: "filterLicenceHolderNumber",
+        value: filter.licenceHolderNumber
       }) }}
 
       {# Filter by licence issues #}

--- a/test/presenters/bill-runs/two-part-tariff/review-bill-run.presenter.test.js
+++ b/test/presenters/bill-runs/two-part-tariff/review-bill-run.presenter.test.js
@@ -13,7 +13,7 @@ const ReviewBillRunPresenter = require('../../../../app/presenters/bill-runs/two
 describe('Review Bill Run presenter', () => {
   describe('when there is data to be presented for review', () => {
     let filterIssues
-    let filterLicenceHolder
+    let filterLicenceHolderNumber
     let filterLicenceStatus
     let testBillRun
     let testLicences
@@ -26,7 +26,7 @@ describe('Review Bill Run presenter', () => {
     describe('and no filter has been applied', () => {
       beforeEach(() => {
         filterIssues = undefined
-        filterLicenceHolder = undefined
+        filterLicenceHolderNumber = undefined
         filterLicenceStatus = undefined
       })
 
@@ -34,7 +34,7 @@ describe('Review Bill Run presenter', () => {
         const result = ReviewBillRunPresenter.go(
           testBillRun,
           filterIssues,
-          filterLicenceHolder,
+          filterLicenceHolderNumber,
           filterLicenceStatus,
           testLicences
         )
@@ -76,7 +76,7 @@ describe('Review Bill Run presenter', () => {
           ],
           filter: {
             issues: undefined,
-            licenceHolder: undefined,
+            licenceHolderNumber: undefined,
             licenceStatus: undefined,
             openFilter: false
           }
@@ -87,7 +87,7 @@ describe('Review Bill Run presenter', () => {
     describe('and filters have been applied', () => {
       beforeEach(() => {
         filterIssues = ['abs-outside-period', 'over-abstraction']
-        filterLicenceHolder = 'bob'
+        filterLicenceHolderNumber = 'bob'
         filterLicenceStatus = 'ready'
       })
 
@@ -95,13 +95,13 @@ describe('Review Bill Run presenter', () => {
         const result = ReviewBillRunPresenter.go(
           testBillRun,
           filterIssues,
-          filterLicenceHolder,
+          filterLicenceHolderNumber,
           filterLicenceStatus,
           testLicences
         )
 
         expect(result.filter.openFilter).to.equal(true)
-        expect(result.filter.licenceHolder).to.equal(filterLicenceHolder)
+        expect(result.filter.licenceHolderNumber).to.equal(filterLicenceHolderNumber)
         expect(result.filter.licenceStatus).to.equal(filterLicenceStatus)
         expect(result.filter.issues).to.equal({
           absOutsidePeriod: true,

--- a/test/services/bill-runs/two-part-tariff/fetch-bill-run-licences.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/fetch-bill-run-licences.service.test.js
@@ -175,6 +175,41 @@ describe('Fetch Bill Run Licences service', () => {
         })
       })
 
+      describe('and a filter has been applied to the licence number', () => {
+        beforeEach(() => {
+          filterIssues = undefined
+          filterLicenceHolderNumber = '02/200'
+          filterLicenceStatus = undefined
+        })
+
+        it('returns details of the bill run and the licences that match the filter', async () => {
+          const result = await FetchBillRunLicencesService.go(
+            billRun.id,
+            filterIssues,
+            filterLicenceHolderNumber,
+            filterLicenceStatus,
+            page
+          )
+
+          expect(result.billRun.id).to.equal(billRun.id)
+          expect(result.billRun.createdAt).to.equal(billRun.createdAt)
+          expect(result.billRun.status).to.equal(billRun.status)
+          expect(result.billRun.toFinancialYearEnding).to.equal(billRun.toFinancialYearEnding)
+          expect(result.billRun.batchType).to.equal(billRun.batchType)
+          expect(result.billRun.region.displayName).to.equal(region.displayName)
+          expect(result.billRun.reviewLicences[0].totalNumberOfLicences).to.equal(2)
+          expect(result.billRun.reviewLicences[0].numberOfLicencesToReview).to.equal(1)
+
+          expect(result.licences.total).to.equal(1)
+          expect(result.licences.results).to.have.length(1)
+          expect(result.licences.results[0].licenceId).to.equal(testLicenceReview.licenceId)
+          expect(result.licences.results[0].licenceHolder).to.equal('Review Licence Holder Ltd')
+          expect(result.licences.results[0].licenceRef).to.equal('02/200')
+          expect(result.licences.results[0].issues).to.equal('Over abstraction, Returns received but not processed')
+          expect(result.licences.results[0].status).to.equal('review')
+        })
+      })
+
       describe('and a filter has been applied to the licence status', () => {
         beforeEach(() => {
           filterIssues = undefined

--- a/test/services/bill-runs/two-part-tariff/fetch-bill-run-licences.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/fetch-bill-run-licences.service.test.js
@@ -20,7 +20,7 @@ const FetchBillRunLicencesService = require('../../../../app/services/bill-runs/
 
 describe('Fetch Bill Run Licences service', () => {
   let filterIssues
-  let filterLicenceHolder
+  let filterLicenceHolderNumber
   let filterLicenceStatus
   let page
   let testLicenceReady
@@ -62,7 +62,7 @@ describe('Fetch Bill Run Licences service', () => {
       beforeEach(async () => {
         // no filters are being applied so these are undefined
         filterIssues = undefined
-        filterLicenceHolder = undefined
+        filterLicenceHolderNumber = undefined
         filterLicenceStatus = undefined
 
         page = undefined
@@ -74,7 +74,7 @@ describe('Fetch Bill Run Licences service', () => {
         const result = await FetchBillRunLicencesService.go(
           billRun.id,
           filterIssues,
-          filterLicenceHolder,
+          filterLicenceHolderNumber,
           filterLicenceStatus,
           page
         )
@@ -106,7 +106,7 @@ describe('Fetch Bill Run Licences service', () => {
         const result = await FetchBillRunLicencesService.go(
           billRun.id,
           filterIssues,
-          filterLicenceHolder,
+          filterLicenceHolderNumber,
           filterLicenceStatus,
           page
         )
@@ -130,7 +130,7 @@ describe('Fetch Bill Run Licences service', () => {
           const result = await FetchBillRunLicencesService.go(
             billRun.id,
             filterIssues,
-            filterLicenceHolder,
+            filterLicenceHolderNumber,
             filterLicenceStatus,
             page
           )
@@ -143,7 +143,7 @@ describe('Fetch Bill Run Licences service', () => {
       describe('and a filter has been applied to the licence holder', () => {
         beforeEach(() => {
           filterIssues = undefined
-          filterLicenceHolder = 'ready licence'
+          filterLicenceHolderNumber = 'ready licence'
           filterLicenceStatus = undefined
         })
 
@@ -151,7 +151,7 @@ describe('Fetch Bill Run Licences service', () => {
           const result = await FetchBillRunLicencesService.go(
             billRun.id,
             filterIssues,
-            filterLicenceHolder,
+            filterLicenceHolderNumber,
             filterLicenceStatus,
             page
           )
@@ -178,7 +178,7 @@ describe('Fetch Bill Run Licences service', () => {
       describe('and a filter has been applied to the licence status', () => {
         beforeEach(() => {
           filterIssues = undefined
-          filterLicenceHolder = undefined
+          filterLicenceHolderNumber = undefined
           filterLicenceStatus = 'review'
         })
 
@@ -186,7 +186,7 @@ describe('Fetch Bill Run Licences service', () => {
           const result = await FetchBillRunLicencesService.go(
             billRun.id,
             filterIssues,
-            filterLicenceHolder,
+            filterLicenceHolderNumber,
             filterLicenceStatus,
             page
           )
@@ -213,7 +213,7 @@ describe('Fetch Bill Run Licences service', () => {
       describe('and a single filter has been applied to the licence issues', () => {
         beforeEach(() => {
           filterIssues = 'over-abstraction'
-          filterLicenceHolder = undefined
+          filterLicenceHolderNumber = undefined
           filterLicenceStatus = undefined
         })
 
@@ -221,7 +221,7 @@ describe('Fetch Bill Run Licences service', () => {
           const result = await FetchBillRunLicencesService.go(
             billRun.id,
             filterIssues,
-            filterLicenceHolder,
+            filterLicenceHolderNumber,
             filterLicenceStatus,
             page
           )
@@ -248,7 +248,7 @@ describe('Fetch Bill Run Licences service', () => {
       describe('and multiple filters have been applied to the licence issues', () => {
         beforeEach(() => {
           filterIssues = ['abs-outside-period', 'returns-received-not-processed', 'returns-late']
-          filterLicenceHolder = undefined
+          filterLicenceHolderNumber = undefined
           filterLicenceStatus = undefined
         })
 
@@ -256,7 +256,7 @@ describe('Fetch Bill Run Licences service', () => {
           const result = await FetchBillRunLicencesService.go(
             billRun.id,
             filterIssues,
-            filterLicenceHolder,
+            filterLicenceHolderNumber,
             filterLicenceStatus,
             page
           )
@@ -288,7 +288,7 @@ describe('Fetch Bill Run Licences service', () => {
       describe('and filters have been applied that will return no results', () => {
         beforeEach(() => {
           filterIssues = undefined
-          filterLicenceHolder = 'ready licence'
+          filterLicenceHolderNumber = 'ready licence'
           filterLicenceStatus = 'review'
         })
 
@@ -296,7 +296,7 @@ describe('Fetch Bill Run Licences service', () => {
           const result = await FetchBillRunLicencesService.go(
             billRun.id,
             filterIssues,
-            filterLicenceHolder,
+            filterLicenceHolderNumber,
             filterLicenceStatus,
             page
           )
@@ -319,7 +319,7 @@ describe('Fetch Bill Run Licences service', () => {
       beforeEach(async () => {
         // no filters are being applied so these are undefined
         filterIssues = undefined
-        filterLicenceHolder = undefined
+        filterLicenceHolderNumber = undefined
         filterLicenceStatus = undefined
 
         // Set the default page size to 1 so the 2 records fit on 2 pages
@@ -335,7 +335,7 @@ describe('Fetch Bill Run Licences service', () => {
           const result = await FetchBillRunLicencesService.go(
             billRun.id,
             filterIssues,
-            filterLicenceHolder,
+            filterLicenceHolderNumber,
             filterLicenceStatus,
             page
           )
@@ -368,7 +368,7 @@ describe('Fetch Bill Run Licences service', () => {
           const result = await FetchBillRunLicencesService.go(
             billRun.id,
             filterIssues,
-            filterLicenceHolder,
+            filterLicenceHolderNumber,
             filterLicenceStatus,
             page
           )
@@ -401,7 +401,7 @@ describe('Fetch Bill Run Licences service', () => {
           const result = await FetchBillRunLicencesService.go(
             billRun.id,
             filterIssues,
-            filterLicenceHolder,
+            filterLicenceHolderNumber,
             filterLicenceStatus,
             page
           )
@@ -427,7 +427,7 @@ describe('Fetch Bill Run Licences service', () => {
 
     beforeEach(() => {
       filterIssues = undefined
-      filterLicenceHolder = undefined
+      filterLicenceHolderNumber = undefined
       filterLicenceStatus = undefined
       invalidBillRunId = '56db85ed-767f-4c83-8174-5ad9c80fd00d'
       page = undefined
@@ -437,7 +437,7 @@ describe('Fetch Bill Run Licences service', () => {
       const result = await FetchBillRunLicencesService.go(
         invalidBillRunId,
         filterIssues,
-        filterLicenceHolder,
+        filterLicenceHolderNumber,
         filterLicenceStatus,
         page
       )

--- a/test/services/bill-runs/two-part-tariff/review-bill-run.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/review-bill-run.service.test.js
@@ -104,7 +104,7 @@ describe('Review Bill Run Service', () => {
       }
       const yarGetStubData = {
         filterIssues: ['abs-outside-period', 'aggregate-factor'],
-        filterLicenceHolder: 'A Licence Holder Ltd',
+        filterLicenceHolderNumber: 'A Licence Holder Ltd',
         filterLicenceStatus: 'review'
       }
 
@@ -156,7 +156,7 @@ describe('Review Bill Run Service', () => {
       }
       const yarGetStubData = {
         filterIssues: ['abs-outside-period', 'aggregate-factor'],
-        filterLicenceHolder: 'A Licence Holder Ltd',
+        filterLicenceHolderNumber: 'A Licence Holder Ltd',
         filterLicenceStatus: 'review'
       }
 

--- a/test/services/bill-runs/two-part-tariff/submit-review-bill-run.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/submit-review-bill-run.service.test.js
@@ -26,7 +26,7 @@ describe('Submit Review Bill Run Service', () => {
   describe('when called with the filters applied', () => {
     const payload = {
       filterIssues: ['abs-outside-period', 'aggregate-factor'],
-      filterLicenceHolder: 'A Licence Holder Ltd',
+      filterLicenceHolderNumber: 'A Licence Holder Ltd',
       filterLicenceStatus: 'review'
     }
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4515

The pagination can make it difficult to find a specific licence in the review so the business has requested the ability to search by Licence Number.

Currently the user is only able to search by Licence Holder Name. This change is going to allow a search on either Licence Holder Name or Licence Number from the same text field (similar to the main search bar).