### PR TITLE
Remove multiple issues showing as review status on two-part tariff pages

### DIFF
--- a/app/services/bill-runs/two-part-tariff/determine-licence-issues.service.js
+++ b/app/services/bill-runs/two-part-tariff/determine-licence-issues.service.js
@@ -14,12 +14,12 @@ const { twoPartTariffReviewIssues } = require('../../../lib/static-lookups.lib.j
  * elements linked to the licence.
  *
  * But the review screens in the UI work from the context of a licence and the main page needs to show whether a licence
- * has any issues and whether it is in 'review'. Only when a user clicks through to look at a the results for a licence
+ * has any issues and whether it is in 'review'. Only when a user clicks through to look at the results for a licence
  * will they see which of its returns and charge elements have the issues.
  *
- * If only one issue is found we still assign it to the licence (an the charge element or return in question) for later
+ * If only one issue is found we still assign it to the licence (and the charge element or return in question) for later
  * persisting in a `ReviewLicence` record. We also check the issue against a list of those that will flag the licence
- * for review. Should a licence have multiple issues we flag it for review regardless.
+ * for review.
  *
  * > No result is returned. The issues are directly assigned to the licence and its relevant properties
  *
@@ -63,13 +63,13 @@ function _determineLicenceStatus (allElementIssues, allReturnIssues) {
   const allLicenceIssues = [...allElementIssues, ...allReturnIssues]
   const reviewStatuses = _getReviewStatuses()
 
-  // If a licence has more than one issue, or has 1 issue that is in the `REVIEW_STATUSES` array the licence status is
+  // If a licence has 1 issue that is in the `REVIEW_STATUSES` array the licence status is
   // set to 'Review' otherwise its 'Ready'
-  if (allLicenceIssues.length > 1 || reviewStatuses.includes(allLicenceIssues[0])) {
-    return 'review'
-  } else {
-    return 'ready'
-  }
+  const hasReviewIssue = allLicenceIssues.some((issue) => {
+    return reviewStatuses.includes(issue)
+  })
+
+  return hasReviewIssue ? 'review' : 'ready'
 }
 
 function _determineReturnLogsIssues (returnLogs, licence) {

--- a/test/services/bill-runs/two-part-tariff/determine-licence-issues.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/determine-licence-issues.service.test.js
@@ -14,7 +14,60 @@ describe('Determine Licence Issues Service', () => {
   describe('when given a licence', () => {
     let licence
 
-    describe('that has multiple issues', () => {
+    describe('that has multiple "ready" issues', () => {
+      beforeEach(() => {
+        licence = _generateMultipleReadyIssuesLicenceData()
+      })
+
+      describe('on the licence', () => {
+        it('sets "issues" to a comma separated unique list in alphabetical order of the issues found', () => {
+          DetermineLicenceIssuesService.go(licence)
+
+          expect(licence.issues).to.equal([
+            'Abstraction outside period',
+            'No returns received',
+            'Over abstraction',
+            'Returns received late',
+            'Some returns not received'
+          ])
+        })
+
+        it('sets the status of the licence to "ready"', () => {
+          DetermineLicenceIssuesService.go(licence)
+
+          expect(licence.status).to.equal('ready')
+        })
+      })
+    })
+
+    describe('that has multiple "review" issues', () => {
+      beforeEach(() => {
+        licence = _generateMultipleReviewIssuesLicenceData()
+      })
+
+      describe('on the licence', () => {
+        it('sets "issues" to a comma separated unique list in alphabetical order of the issues found', () => {
+          DetermineLicenceIssuesService.go(licence)
+
+          expect(licence.issues).to.equal([
+            'Aggregate',
+            'Checking query',
+            'Overlap of charge dates',
+            'Return split over charge references',
+            'Returns received but not processed',
+            'Unable to match return'
+          ])
+        })
+
+        it('sets the status of the licence to "review"', () => {
+          DetermineLicenceIssuesService.go(licence)
+
+          expect(licence.status).to.equal('review')
+        })
+      })
+    })
+
+    describe('that has multiple "ready" and "review" issues', () => {
       beforeEach(() => {
         licence = _generateMultipleIssuesLicenceData()
       })
@@ -301,6 +354,118 @@ function _generateMultipleIssuesLicenceData () {
         quantity: 0,
         allocatedQuantity: 0,
         receivedDate: null,
+        dueDate: new Date('2024 01 01')
+      },
+      {
+        id: '91011',
+        abstractionOutsidePeriod: false,
+        underQuery: false,
+        status: 'received',
+        quantity: 0,
+        allocatedQuantity: 0,
+        receivedDate: new Date('2024 01 01'),
+        dueDate: new Date('2024 01 01')
+      }
+    ]
+  }
+}
+
+function _generateMultipleReadyIssuesLicenceData () {
+  return {
+    chargeVersions: [
+      {
+        chargeReferences: [
+          {
+            aggregate: 1,
+            chargeElements: [
+              {
+                chargeDatesOverlap: false,
+                returnLogs: [
+                  {
+                    returnId: '1234'
+                  },
+                  {
+                    returnId: '5678'
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    returnLogs: [
+      {
+        id: '1234',
+        abstractionOutsidePeriod: true,
+        underQuery: false,
+        status: 'completed',
+        quantity: 1,
+        allocatedQuantity: 0,
+        receivedDate: new Date('2024 02 01'),
+        dueDate: new Date('2024 01 01')
+      },
+      {
+        id: '5678',
+        abstractionOutsidePeriod: false,
+        underQuery: false,
+        status: 'due',
+        quantity: 0,
+        allocatedQuantity: 0,
+        receivedDate: null,
+        dueDate: new Date('2024 01 01')
+      }
+    ]
+  }
+}
+
+function _generateMultipleReviewIssuesLicenceData () {
+  return {
+    chargeVersions: [
+      {
+        chargeReferences: [
+          {
+            aggregate: 1.25,
+            chargeElements: [
+              {
+                chargeDatesOverlap: true,
+                returnLogs: [
+                  {
+                    returnId: '1234'
+                  }
+                ]
+              },
+              {
+                chargeDatesOverlap: false,
+                returnLogs: []
+              }
+            ]
+          },
+          {
+            aggregate: 1.25,
+            chargeElements: [
+              {
+                chargeDatesOverlap: false,
+                returnLogs: [
+                  {
+                    returnId: '1234'
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    returnLogs: [
+      {
+        id: '1234',
+        abstractionOutsidePeriod: false,
+        underQuery: true,
+        status: 'completed',
+        quantity: 0,
+        allocatedQuantity: 0,
+        receivedDate: new Date('2024 01 01'),
         dueDate: new Date('2024 01 01')
       },
       {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4517

During testing for the two-part tariff review screens by the billing and data team, it was noted that if a licence had multiple issues (even if they were all of a 'ready' status) the licence would be marked as a 'review' status. The point of the statuses was to make issues visible to users and direct them if action was needed. If a licence has two issues, both of a 'ready' status, then it doesn't have any action for the team to complete. This PR changes the logic to remove multiple issues flagging as a review status.