### PR TITLE
Fix pagination text in 2PT review screen

### DIFF
--- a/app/presenters/paginator.presenter.js
+++ b/app/presenters/paginator.presenter.js
@@ -106,13 +106,13 @@ const COMPLEX_END_PAGINATOR = 'end'
  * @param {number} selectedPageNumber - the page of results selected for viewing
  * @param {string} path - the URL path the paginator should use, for example, `'/system/bill-runs'`
  *
- * @returns {Object} if no pagination is needed just the `numberOfPages: 1` is returned else a `component:` property is
+ * @returns {Object} if no pagination is needed just the `numberOfPages` is returned else a `component:` property is
  * also included that can be directly passed to the `govukPagination()` in the view.
  */
 function go (numberOfRecords, selectedPageNumber, path) {
   const numberOfPages = Math.ceil(numberOfRecords / DatabaseConfig.defaultPageSize)
 
-  if (numberOfPages === 1) {
+  if (numberOfPages < 2) {
     return { numberOfPages }
   }
 

--- a/app/services/bill-runs/two-part-tariff/review-bill-run.service.js
+++ b/app/services/bill-runs/two-part-tariff/review-bill-run.service.js
@@ -60,7 +60,7 @@ function _getFilters (id, yar) {
 }
 
 function _pageTitle (numberOfPages, selectedPageNumber) {
-  if (numberOfPages === 1) {
+  if (numberOfPages < 2) {
     return 'Review licences'
   }
 

--- a/test/services/bill-runs/two-part-tariff/review-bill-run.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/review-bill-run.service.test.js
@@ -251,4 +251,51 @@ describe('Review Bill Run Service', () => {
       })
     })
   })
+
+  describe('when there are no pages of results after a filter is applied', () => {
+    const bannerMessage = undefined
+    const presenterStubData = {
+      preparedBillRun: 'bill run data',
+      preparedLicences: 'licence data',
+      filter: {
+        issues: undefined,
+        licenceHolder: 'Unknown Licence Holder',
+        licenceStatus: undefined,
+        openFilter: true
+      }
+    }
+    const yarGetStubData = {
+      filterIssues: undefined,
+      filterLicenceHolderNumber: 'Unknown Licence Holder',
+      filterLicenceStatus: undefined
+    }
+
+    beforeEach(() => {
+      page = undefined
+
+      Sinon.stub(FetchBillRunLicencesService, 'go').resolves({
+        billRun: 'bill data',
+        licences: { results: 'licence data', total: 0 }
+      })
+
+      Sinon.stub(ReviewBillRunPresenter, 'go').returns(presenterStubData)
+
+      yarStub = { flash: Sinon.stub().returns([]), get: Sinon.stub().returns(yarGetStubData) }
+    })
+
+    it('will fetch the data for the review page and return it once formatted by the presenter', async () => {
+      const result = await ReviewBillRunService.go(billRunId, page, yarStub)
+
+      expect(result.bannerMessage).to.equal(bannerMessage)
+      expect(result.preparedBillRun).to.equal(presenterStubData.preparedBillRun)
+      expect(result.preparedLicences).to.equal(presenterStubData.preparedLicences)
+      expect(result.filter).to.equal(presenterStubData.filter)
+      expect(result.pageTitle).to.equal('Review licences')
+      expect(result.pagination.numberOfPages).to.equal(0)
+      expect(result.pagination.component).not.to.exist()
+
+      expect(FetchBillRunLicencesService.go.called).to.be.true()
+      expect(ReviewBillRunPresenter.go.called).to.be.true()
+    })
+  })
 })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4515

During testing it has been found that in the two-part tariff review screen. If a filter is applied to the results resulting in no records being returned, the title is displayed as "Review licences (page 1 of 0)". The pagination is incorrectly being displayed in the title. The pagination should only be displayed if more than 1 page of data exists.

This issue is caused by the logic used to determine if the pagination should be displayed. Currently it is not displayed if the number of pages equals 1. This needs to be updated so that it is not displayed if the number of pages is less than 2.

This PR will fix that issue.