### PR TITLE
Fix licence 2 licence gauging station relationship

### DIFF
--- a/app/models/licence-gauging-station.model.js
+++ b/app/models/licence-gauging-station.model.js
@@ -16,8 +16,8 @@ class LicenceGaugingStationModel extends BaseModel {
 
   static get relationMappings () {
     return {
-      licenceGaugingStations: {
-        relation: Model.HasManyRelation,
+      gaugingStation: {
+        relation: Model.BelongsToOneRelation,
         modelClass: 'gauging-station.model',
         join: {
           from: 'licenceGaugingStations.gaugingStationId',

--- a/app/models/licence-gauging-station.model.js
+++ b/app/models/licence-gauging-station.model.js
@@ -23,6 +23,14 @@ class LicenceGaugingStationModel extends BaseModel {
           from: 'licenceGaugingStations.gaugingStationId',
           to: 'gaugingStations.id'
         }
+      },
+      licence: {
+        relation: Model.BelongsToOneRelation,
+        modelClass: 'licence.model',
+        join: {
+          from: 'licenceGaugingStations.licenceId',
+          to: 'licences.id'
+        }
       }
     }
   }

--- a/app/models/licence.model.js
+++ b/app/models/licence.model.js
@@ -32,18 +32,6 @@ class LicenceModel extends BaseModel {
           to: 'chargeVersions.licenceId'
         }
       },
-      gaugingStations: {
-        relation: Model.ManyToManyRelation,
-        modelClass: 'gauging-station.model',
-        join: {
-          from: 'licences.id',
-          through: {
-            from: 'licenceGaugingStations.licenceId',
-            to: 'licenceGaugingStations.gaugingStationId'
-          },
-          to: 'gaugingStations.id'
-        }
-      },
       licenceAgreements: {
         relation: Model.HasManyRelation,
         modelClass: 'licence-agreement.model',
@@ -69,15 +57,11 @@ class LicenceModel extends BaseModel {
         }
       },
       licenceGaugingStations: {
-        relation: Model.ManyToManyRelation,
-        modelClass: 'gauging-station.model',
+        relation: Model.HasManyRelation,
+        modelClass: 'licence-gauging-station.model',
         join: {
           from: 'licences.id',
-          through: {
-            from: 'licenceGaugingStations.licenceId',
-            to: 'licenceGaugingStations.gaugingStationId'
-          },
-          to: 'gaugingStations.id'
+          to: 'licenceGaugingStations.licenceId'
         }
       },
       licenceVersions: {

--- a/app/models/licence.model.js
+++ b/app/models/licence.model.js
@@ -32,6 +32,18 @@ class LicenceModel extends BaseModel {
           to: 'chargeVersions.licenceId'
         }
       },
+      gaugingStations: {
+        relation: Model.ManyToManyRelation,
+        modelClass: 'gauging-station.model',
+        join: {
+          from: 'licences.id',
+          through: {
+            from: 'licenceGaugingStations.licenceId',
+            to: 'licenceGaugingStations.gaugingStationId'
+          },
+          to: 'gaugingStations.id'
+        }
+      },
       licenceAgreements: {
         relation: Model.HasManyRelation,
         modelClass: 'licence-agreement.model',

--- a/app/presenters/licences/view-licence-summary.presenter.js
+++ b/app/presenters/licences/view-licence-summary.presenter.js
@@ -50,7 +50,7 @@ function _abstractionWrapper (licenceAbstractionConditions, licenceVersions, pur
   const abstractionPeriods = _generateAbstractionPeriods(licenceVersions)
   let abstractionPeriodsAndPurposesLinkText = null
 
-  if (abstractionPeriods && purposes) {
+  if (abstractionPeriods) {
     const abstractionPeriodsLabel = abstractionPeriods.uniqueAbstractionPeriods.length > 1 ? 'periods' : 'period'
     const purposesLabel = purposes.data.length > 1 ? 'purposes' : 'purpose'
     abstractionPeriodsAndPurposesLinkText = `View details of your ${purposesLabel}, ${abstractionPeriodsLabel} and amounts`
@@ -112,11 +112,7 @@ function _endDate (expiredDate) {
 }
 
 function _generateAbstractionPeriods (licenceVersions) {
-  if (!licenceVersions ||
-    licenceVersions.length === 0 ||
-    licenceVersions[0]?.licenceVersionPurposes === undefined ||
-    licenceVersions[0]?.licenceVersionPurposes?.length === 0
-  ) {
+  if (licenceVersions.length === 0 || licenceVersions[0].licenceVersionPurposes.length === 0) {
     return null
   }
 
@@ -143,26 +139,19 @@ function _generateLicenceHolder (licenceHolder) {
   return licenceHolder
 }
 
-function _generateMonitoringStation (stations) {
-  let monitoringStations = []
-  if (stations && stations.length !== undefined) {
-    const jsonArray = stations.map(JSON.stringify)
-    monitoringStations = Array.from(new Set(jsonArray)).map(JSON.parse)
-  }
-
-  return monitoringStations
+function _generateMonitoringStation (licenceGaugingStations) {
+  return licenceGaugingStations.map((licenceGaugingStation) => {
+    return licenceGaugingStation.gaugingStation
+  })
 }
 
 function _generatePurposes (licenceVersions) {
-  if (!licenceVersions ||
-    licenceVersions.length === 0 ||
-    licenceVersions[0]?.purposes === undefined ||
-    licenceVersions[0]?.purposes?.length === 0
-  ) {
+  if (licenceVersions.length === 0 || licenceVersions[0].licenceVersionPurposes.length === 0) {
     return null
   }
-  const allPurposeDescriptions = licenceVersions[0].purposes.map((item) => {
-    return item.description
+
+  const allPurposeDescriptions = licenceVersions[0].licenceVersionPurposes.map((licenceVersionPurpose) => {
+    return licenceVersionPurpose.purpose.description
   })
 
   const uniquePurposes = [...new Set(allPurposeDescriptions)]

--- a/app/views/licences/tabs/summary.njk
+++ b/app/views/licences/tabs/summary.njk
@@ -4,149 +4,153 @@
 <h2 class="govuk-heading-l">Summary</h2>
 
 <dl class="govuk-summary-list">
-<div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">Licence Holder</dt>
-        <dd class="govuk-summary-list__value">
-            <span class="govuk-form-group">{{ licenceHolder }}</span>
-            <a class="govuk-form-group" href="/licences/{{ documentId }}/contact">View licence contact details</a>
-        </dd>
-    </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">Licence Holder</dt>
+    <dd class="govuk-summary-list__value">
+      <span class="govuk-form-group">{{ licenceHolder }}</span>
+      <a class="govuk-form-group" href="/licences/{{ documentId }}/contact">View licence contact details</a>
+    </dd>
+  </div>
+
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">Effective from</dt>
+    <dd class="govuk-summary-list__value">{{ startDate }}</dd>
+  </div>
+
+  {% if endDate %}
     <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">Effective from</dt>
-        <dd class="govuk-summary-list__value">{{ startDate }}</dd>
+      <dt class="govuk-summary-list__key">End date</dt>
+      <dd class="govuk-summary-list__value">{{ endDate }}</dd>
     </div>
-    {% if endDate %}
-        <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">End date</dt>
-            <dd class="govuk-summary-list__value">{{ endDate }}</dd>
-        </div>
-    {% endif %}
+  {% endif %}
 
+  {% if sourceOfSupply %}
     <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">Source of supply</dt>
-        <dd class="govuk-summary-list__value">{{ sourceOfSupply }}</dd>
+      <dt class="govuk-summary-list__key">Source of supply</dt>
+      <dd class="govuk-summary-list__value">{{ sourceOfSupply }}</dd>
     </div>
+  {% endif %}
 
-    {% if purposes %}
-        <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">{{ purposes.caption }}</dt>
-            <dd class="govuk-summary-list__value">
-                {% if purposes.data.length > 5 %}
-                    There are {{ purposes.data.length }} purposes
-                {% elseif purposes.data.length > 1 %}
-                    <ul class="govuk-list">
-                        {% for purpose in purposes.data %}
-                            <li>{{ purpose }}</li>
-                        {% endfor %}
-                    </ul>
-                {% else %}
-                    {{ purposes.data[0] }}
-                {% endif %}
-            </dd>
-        </div>
-    {% endif %}
-
-    {% if abstractionPeriods %}
-        <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">{{ abstractionPeriods.caption }}</dt>
-            <dd class="govuk-summary-list__value">
-                <div>
-                    {% if abstractionPeriods.uniqueAbstractionPeriods.length > 5 %}
-                        There are {{ abstractionPeriods.uniqueAbstractionPeriods.length }} periods of abstraction
-                    {% elseif abstractionPeriods.uniqueAbstractionPeriods.length > 1 %}
-                        <ul class="govuk-list govuk-!-margin-bottom-0">
-                            {% for abstractionPeriod in abstractionPeriods.uniqueAbstractionPeriods %}
-                                <li>{{ abstractionPeriod }}</li>
-                            {% endfor %}
-                        </ul>
-                    {% else %}
-                        {{ abstractionPeriods.uniqueAbstractionPeriods[0] }}
-                    {% endif %}
-                </div>
-                <a href="/licences/{{ documentId }}/purposes">{{ abstractionPeriodsAndPurposesLinkText }}</a>
-            </dd>
-        </div>
-    {% endif %}
-
-    {% if abstractionPoints %}
-        <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">{{ abstractionPointsCaption }}</dt>
-            <dd class="govuk-summary-list__value">
-                <div>
-                    {% if abstractionPoints.length > 5 %}
-                        There are {{ abstractionPoints.length }} abstraction points
-                    {% elseif abstractionPoints.length > 1 %}
-                        <ul class="govuk-list govuk-!-margin-bottom-0">
-                            {% for abstractionPoint in abstractionPoints %}
-                                <li>{{ abstractionPoint }}</li>
-                            {% endfor %}
-                        </ul>
-                    {% else %}
-                        {{ abstractionPoints[0] }}
-                    {% endif %}
-                </div>
-                <a href="/licences/{{ documentId }}/points">{{ abstractionPointLinkText }}</a>
-            </dd>
-        </div>
-    {% endif %}
-
+  {% if purposes %}
     <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">Monitoring stations</dt>
-        <dd class="govuk-summary-list__value">
-            {% if monitoringStations.length > 0 %}
-                <ul class="govuk-list govuk-!-margin-bottom-0">
-                    {% for monitoringStation in monitoringStations %}
-                        <li>
-                            <a href="/monitoring-stations/{{ monitoringStation.id }}">{{ monitoringStation.label }}</a>
-                        </li>
-                    {% endfor %}
-                </ul>
-            {% else %}
-                <span class="govuk-form-group govuk-!-margin-bottom-0">
-                    This licence is not tagged with a station
-                </span>
-                <a href="/licences">Search for a monitoring station and tag this licence</a>
-            {% endif %}
-        </dd>
+      <dt class="govuk-summary-list__key">{{ purposes.caption }}</dt>
+      <dd class="govuk-summary-list__value">
+        {% if purposes.data.length > 5 %}
+          There are {{ purposes.data.length }} purposes
+        {% elseif purposes.data.length > 1 %}
+          <ul class="govuk-list">
+            {% for purpose in purposes.data %}
+              <li>{{ purpose }}</li>
+            {% endfor %}
+          </ul>
+        {% else %}
+          {{ purposes.data[0] }}
+        {% endif %}
+      </dd>
     </div>
+  {% endif %}
 
+  {% if abstractionPeriods %}
     <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">Abstraction conditions</dt>
-        <dd class="govuk-summary-list__value">
-            <div>
-                {% if abstractionConditionDetails.numberOfConditions > 5 %}
-                    There are {{ abstractionConditionDetails.numberOfConditions }} abstraction conditions
-                {% elif abstractionConditionDetails.numberOfConditions > 1 %}
-                    <ul class="govuk-list govuk-!-margin-bottom-0">
-                        {% for condition in abstractionConditionDetails.conditions %}
-                            <li>{{ condition }}</li>
-                        {% endfor %}
-                    </ul>
-                {% else %}
-                    {{ abstractionConditionDetails.conditions[0] }}
-                {% endif %}
-            </div>
-            <a href="/licences/{{ documentId }}/conditions">View details of the abstraction conditions</a>
-        </dd>
-    </div>
-
-    {% if abstractionQuantities %}
-        <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">Abstraction amounts</dt>
-            <dd class="govuk-summary-list__value">
-                <ul class="govuk-list govuk-!-margin-bottom-0">
-                    {% for quantity in abstractionQuantities %}
-                        <li>{{ quantity }}</li>
-                    {% endfor %}
-                </ul>
-            </dd>
+      <dt class="govuk-summary-list__key">{{ abstractionPeriods.caption }}</dt>
+      <dd class="govuk-summary-list__value">
+        <div>
+          {% if abstractionPeriods.uniqueAbstractionPeriods.length > 5 %}
+            There are {{ abstractionPeriods.uniqueAbstractionPeriods.length }} periods of abstraction
+          {% elseif abstractionPeriods.uniqueAbstractionPeriods.length > 1 %}
+            <ul class="govuk-list govuk-!-margin-bottom-0">
+              {% for abstractionPeriod in abstractionPeriods.uniqueAbstractionPeriods %}
+                <li>{{ abstractionPeriod }}</li>
+              {% endfor %}
+            </ul>
+          {% else %}
+            {{ abstractionPeriods.uniqueAbstractionPeriods[0] }}
+          {% endif %}
         </div>
-    {% endif %}
-
-    <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">Billing region</dt>
-        <dd class="govuk-summary-list__value">{{ region }}</dd>
+        <a href="/licences/{{ documentId }}/purposes">{{ abstractionPeriodsAndPurposesLinkText }}</a>
+      </dd>
     </div>
+  {% endif %}
+
+  {% if abstractionPoints %}
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">{{ abstractionPointsCaption }}</dt>
+      <dd class="govuk-summary-list__value">
+        <div>
+          {% if abstractionPoints.length > 5 %}
+            There are {{ abstractionPoints.length }} abstraction points
+          {% elseif abstractionPoints.length > 1 %}
+            <ul class="govuk-list govuk-!-margin-bottom-0">
+              {% for abstractionPoint in abstractionPoints %}
+                <li>{{ abstractionPoint }}</li>
+              {% endfor %}
+            </ul>
+          {% else %}
+            {{ abstractionPoints[0] }}
+          {% endif %}
+        </div>
+        <a href="/licences/{{ documentId }}/points">{{ abstractionPointLinkText }}</a>
+      </dd>
+    </div>
+  {% endif %}
+
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">Monitoring stations</dt>
+    <dd class="govuk-summary-list__value">
+      {% if monitoringStations.length > 0 %}
+        <ul class="govuk-list govuk-!-margin-bottom-0">
+          {% for monitoringStation in monitoringStations %}
+            <li>
+              <a href="/monitoring-stations/{{ monitoringStation.id }}">{{ monitoringStation.label }}</a>
+            </li>
+          {% endfor %}
+        </ul>
+      {% else %}
+        <span class="govuk-form-group govuk-!-margin-bottom-0">
+          This licence is not tagged with a station
+        </span>
+        <a href="/licences">Search for a monitoring station and tag this licence</a>
+      {% endif %}
+    </dd>
+  </div>
+
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">Abstraction conditions</dt>
+    <dd class="govuk-summary-list__value">
+      <div>
+        {% if abstractionConditionDetails.numberOfConditions > 5 %}
+          There are {{ abstractionConditionDetails.numberOfConditions }} abstraction conditions
+        {% elif abstractionConditionDetails.numberOfConditions > 1 %}
+          <ul class="govuk-list govuk-!-margin-bottom-0">
+            {% for condition in abstractionConditionDetails.conditions %}
+              <li>{{ condition }}</li>
+            {% endfor %}
+          </ul>
+        {% else %}
+          {{ abstractionConditionDetails.conditions[0] }}
+        {% endif %}
+      </div>
+      <a href="/licences/{{ documentId }}/conditions">View details of the abstraction conditions</a>
+    </dd>
+  </div>
+
+  {% if abstractionQuantities %}
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">Abstraction amounts</dt>
+      <dd class="govuk-summary-list__value">
+        <ul class="govuk-list govuk-!-margin-bottom-0">
+          {% for quantity in abstractionQuantities %}
+            <li>{{ quantity }}</li>
+          {% endfor %}
+        </ul>
+      </dd>
+    </div>
+  {% endif %}
+
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">Billing region</dt>
+    <dd class="govuk-summary-list__value">{{ region }}</dd>
+  </div>
 </dl>
 
 <div class="govuk-grid-row">
@@ -160,19 +164,19 @@
     }) }}
 
     <details class="govuk-details">
-        <summary class="govuk-details__summary">
-            <span class="govuk-details__summary-text">Is your licence information correct?</span>
-        </summary>
-        <div class="govuk-details__text">
-            <p>
-                To help us improve our new service, please let us know if you find any errors in the licence
-                information we are showing you. You can contact us by:
-            </p>
-            <p>Email: <a href="mailto:enquiries@environment-agency.gov.uk">enquiries@environment-agency.gov.uk</a></p>
-            <p>Telephone: <a href="tel:03708506506">03708 506 506</a></p>
-            <p>Telephone from outside the UK: <a href="tel:+441142825312">+44 114 282 5312</a></p>
-            <p>You can call us from 8am to 6pm, Monday to Friday.</p>
-        </div>
+      <summary class="govuk-details__summary">
+        <span class="govuk-details__summary-text">Is your licence information correct?</span>
+      </summary>
+      <div class="govuk-details__text">
+        <p>
+          To help us improve our new service, please let us know if you find any errors in the licence
+          information we are showing you. You can contact us by:
+        </p>
+        <p>Email: <a href="mailto:enquiries@environment-agency.gov.uk">enquiries@environment-agency.gov.uk</a></p>
+        <p>Telephone: <a href="tel:03708506506">03708 506 506</a></p>
+        <p>Telephone from outside the UK: <a href="tel:+441142825312">+44 114 282 5312</a></p>
+        <p>You can call us from 8am to 6pm, Monday to Friday.</p>
+      </div>
     </details>
   </div>
 </div>

--- a/db/migrations/legacy/20221108007026_water-gauging-stations.js
+++ b/db/migrations/legacy/20221108007026_water-gauging-stations.js
@@ -8,15 +8,15 @@ exports.up = function (knex) {
     .withSchema('water')
     .createTable(tableName, (table) => {
       // Primary Key
-      table.uuid('gauging_station_id').primary()
+      table.uuid('gauging_station_id').primary().defaultTo(knex.raw('gen_random_uuid()'))
 
       // Data
       table.string('label').notNullable()
-      table.decimal('lat').notNullable()
-      table.decimal('long').notNullable()
+      table.decimal('lat')
+      table.decimal('long')
       table.integer('easting')
       table.integer('northing')
-      table.string('grid_reference').notNullable()
+      table.string('grid_reference')
       table.string('catchment_name')
       table.string('river_name')
       table.string('wiski_id')
@@ -24,11 +24,14 @@ exports.up = function (knex) {
       table.string('status')
       table.jsonb('metadata')
       table.uuid('hydrology_station_id').notNullable()
-      table.boolean('is_test')
+      table.boolean('is_test').defaultTo(false)
 
       // Legacy timestamps
-      table.timestamp('date_created', { useTz: false }).notNullable().defaultTo(knex.fn.now())
-      table.timestamp('date_updated', { useTz: false }).notNullable().defaultTo(knex.fn.now())
+      table.timestamp('date_created', { useTz: false })
+      table.timestamp('date_updated', { useTz: false })
+
+      // Constraints
+      table.unique(['hydrology_station_id'], { useConstraint: true })
     })
 }
 

--- a/db/migrations/legacy/20221108007027_water-licence-gauging-stations.js
+++ b/db/migrations/legacy/20221108007027_water-licence-gauging-stations.js
@@ -8,13 +8,13 @@ exports.up = function (knex) {
     .withSchema('water')
     .createTable(tableName, (table) => {
       // Primary Key
-      table.uuid('licence_gauging_station_id').primary()
+      table.uuid('licence_gauging_station_id').primary().defaultTo(knex.raw('gen_random_uuid()'))
 
       // Data
       table.uuid('licence_id').notNullable()
       table.uuid('gauging_station_id').notNullable()
       table.string('source').notNullable()
-      table.uuid('licence_version_purpose_condition_id').notNullable()
+      table.uuid('licence_version_purpose_condition_id')
       table.smallint('abstraction_period_start_day')
       table.smallint('abstraction_period_start_month')
       table.smallint('abstraction_period_end_day')
@@ -22,15 +22,15 @@ exports.up = function (knex) {
       table.string('restriction_type').notNullable()
       table.string('threshold_unit').notNullable()
       table.decimal('threshold_value').notNullable()
-      table.string('status').notNullable()
+      table.string('status').notNullable().defaultTo('resume')
       table.timestamp('date_status_updated', { useTz: false })
       table.timestamp('date_deleted', { useTz: false })
-      table.string('alert_type').notNullable()
-      table.boolean('is_test')
+      table.string('alert_type').notNullable().default('reduce')
+      table.boolean('is_test').defaultTo(false)
 
       // Legacy timestamps
-      table.timestamp('date_created', { useTz: false }).notNullable().defaultTo(knex.fn.now())
-      table.timestamp('date_updated', { useTz: false }).notNullable().defaultTo(knex.fn.now())
+      table.timestamp('date_created', { useTz: false }).notNullable()
+      table.timestamp('date_updated', { useTz: false }).notNullable()
     })
 }
 

--- a/db/migrations/public/20240613152012_alter-licence-gauging-stations.js
+++ b/db/migrations/public/20240613152012_alter-licence-gauging-stations.js
@@ -1,0 +1,62 @@
+'use strict'
+
+const viewName = 'licence_gauging_stations'
+
+exports.up = function (knex) {
+  return knex
+    .schema
+    .dropViewIfExists(viewName)
+    .createView(viewName, (view) => {
+      // NOTE: We have commented out unused columns from the source table
+      view.as(knex('licence_gauging_stations').withSchema('water').select([
+        'licence_gauging_station_id AS id',
+        'licence_id',
+        'gauging_station_id',
+        'source',
+        'licence_version_purpose_condition_id',
+        'abstraction_period_start_day',
+        'abstraction_period_start_month ',
+        'abstraction_period_end_day',
+        'abstraction_period_end_month',
+        'restriction_type',
+        'threshold_unit',
+        'threshold_value',
+        'status',
+        'date_status_updated AS status_updated_at',
+        'date_deleted AS deleted_at',
+        'alert_type',
+        // 'is_test',
+        'date_created AS created_at',
+        'date_updated AS updated_at'
+      ]))
+    })
+}
+
+exports.down = function (knex) {
+  return knex
+    .schema
+    .dropViewIfExists(viewName)
+    .createView(viewName, (view) => {
+      view.as(knex('licence_gauging_stations').withSchema('water').select([
+        'licence_gauging_station_id AS id',
+        'licence_id',
+        'gauging_station_id',
+        'source',
+        'licence_version_purpose_condition_id',
+        'abstraction_period_start_day',
+        'abstraction_period_start_month ',
+        'abstraction_period_end_day',
+        'abstraction_period_end_month',
+        'restriction_type',
+        'threshold_unit',
+        'threshold_value',
+        'status',
+        'date_status_updated',
+        'date_deleted',
+        'alert_type',
+        // 'is_test',
+        'date_created AS created_at',
+        'date_updated AS updated_at'
+      ]))
+    })
+}

--- a/test/models/gauging-station.model.test.js
+++ b/test/models/gauging-station.model.test.js
@@ -1,0 +1,77 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const DatabaseSupport = require('../support/database.js')
+const GaugingStationHelper = require('../support/helpers/gauging-station.helper.js')
+const LicenceGaugingStationHelper = require('../support/helpers/licence-gauging-station.helper.js')
+const LicenceGaugingStationModel = require('../../app/models/licence-gauging-station.model.js')
+
+// Thing under test
+const GaugingStationModel = require('../../app/models/gauging-station.model.js')
+
+describe('Gauging Station model', () => {
+  let testRecord
+
+  beforeEach(async () => {
+    await DatabaseSupport.clean()
+  })
+
+  describe('Basic query', () => {
+    beforeEach(async () => {
+      testRecord = await GaugingStationHelper.add()
+    })
+
+    it('can successfully run a basic query', async () => {
+      const result = await GaugingStationModel.query().findById(testRecord.id)
+
+      expect(result).to.be.an.instanceOf(GaugingStationModel)
+      expect(result.id).to.equal(testRecord.id)
+    })
+  })
+
+  describe('Relationships', () => {
+    describe('when linking to licence gauging stations', () => {
+      let testLicenceGaugingStations
+
+      beforeEach(async () => {
+        testRecord = await GaugingStationHelper.add()
+
+        testLicenceGaugingStations = []
+        for (let i = 0; i < 2; i++) {
+          const licenceGaugingStation = await LicenceGaugingStationHelper.add(
+            { gaugingStationId: testRecord.id }
+          )
+          testLicenceGaugingStations.push(licenceGaugingStation)
+        }
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await GaugingStationModel.query()
+          .innerJoinRelated('licenceGaugingStations')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the licence gauging stations', async () => {
+        const result = await GaugingStationModel.query()
+          .findById(testRecord.id)
+          .withGraphFetched('licenceGaugingStations')
+
+        expect(result).to.be.instanceOf(GaugingStationModel)
+        expect(result.id).to.equal(testRecord.id)
+
+        expect(result.licenceGaugingStations).to.be.an.array()
+        expect(result.licenceGaugingStations[0]).to.be.an.instanceOf(LicenceGaugingStationModel)
+        expect(result.licenceGaugingStations).to.include(testLicenceGaugingStations[0])
+        expect(result.licenceGaugingStations).to.include(testLicenceGaugingStations[1])
+      })
+    })
+  })
+})

--- a/test/models/licence-gauging-station.model.test.js
+++ b/test/models/licence-gauging-station.model.test.js
@@ -1,0 +1,102 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const DatabaseSupport = require('../support/database.js')
+const GaugingStationHelper = require('../support/helpers/gauging-station.helper.js')
+const GaugingStationModel = require('../../app/models/gauging-station.model.js')
+const LicenceGaugingStationHelper = require('../support/helpers/licence-gauging-station.helper.js')
+const LicenceHelper = require('../support/helpers/licence.helper.js')
+const LicenceModel = require('../../app/models/licence.model.js')
+
+// Thing under test
+const LicenceGaugingStationModel = require('../../app/models/licence-gauging-station.model.js')
+
+describe('Licence Gauging Station model', () => {
+  let testRecord
+
+  beforeEach(async () => {
+    await DatabaseSupport.clean()
+  })
+
+  describe('Basic query', () => {
+    beforeEach(async () => {
+      testRecord = await LicenceGaugingStationHelper.add()
+    })
+
+    it('can successfully run a basic query', async () => {
+      const result = await LicenceGaugingStationModel.query().findById(testRecord.id)
+
+      expect(result).to.be.an.instanceOf(LicenceGaugingStationModel)
+      expect(result.id).to.equal(testRecord.id)
+    })
+  })
+
+  describe('Relationships', () => {
+    describe('when linking to gauging station', () => {
+      let testGaugingStation
+
+      beforeEach(async () => {
+        testGaugingStation = await GaugingStationHelper.add()
+
+        const { id: gaugingStationId } = testGaugingStation
+        testRecord = await LicenceGaugingStationHelper.add({ gaugingStationId })
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await LicenceGaugingStationModel.query()
+          .innerJoinRelated('gaugingStation')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the gauging station', async () => {
+        const result = await LicenceGaugingStationModel.query()
+          .findById(testRecord.id)
+          .withGraphFetched('gaugingStation')
+
+        expect(result).to.be.instanceOf(LicenceGaugingStationModel)
+        expect(result.id).to.equal(testRecord.id)
+
+        expect(result.gaugingStation).to.be.an.instanceOf(GaugingStationModel)
+        expect(result.gaugingStation).to.equal(testGaugingStation)
+      })
+    })
+
+    describe('when linking to licence', () => {
+      let testLicence
+
+      beforeEach(async () => {
+        testLicence = await LicenceHelper.add()
+
+        const { id: licenceId } = testLicence
+        testRecord = await LicenceGaugingStationHelper.add({ licenceId })
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await LicenceGaugingStationModel.query()
+          .innerJoinRelated('licence')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the licence', async () => {
+        const result = await LicenceGaugingStationModel.query()
+          .findById(testRecord.id)
+          .withGraphFetched('licence')
+
+        expect(result).to.be.instanceOf(LicenceGaugingStationModel)
+        expect(result.id).to.equal(testRecord.id)
+
+        expect(result.licence).to.be.an.instanceOf(LicenceModel)
+        expect(result.licence).to.equal(testLicence)
+      })
+    })
+  })
+})

--- a/test/models/licence.model.test.js
+++ b/test/models/licence.model.test.js
@@ -15,6 +15,8 @@ const ChargeVersionModel = require('../../app/models/charge-version.model.js')
 const CompanyHelper = require('../support/helpers/company.helper.js')
 const ContactHelper = require('../support/helpers/contact.helper.js')
 const DatabaseSupport = require('../support/database.js')
+const GaugingStationHelper = require('../support/helpers/gauging-station.helper.js')
+const GaugingStationModel = require('../../app/models/gauging-station.model.js')
 const LicenceAgreementHelper = require('../support/helpers/licence-agreement.helper.js')
 const LicenceAgreementModel = require('../../app/models/licence-agreement.model.js')
 const LicenceHelper = require('../support/helpers/licence.helper.js')
@@ -23,6 +25,7 @@ const LicenceDocumentModel = require('../../app/models/licence-document.model.js
 const LicenceDocumentHeaderHelper = require('../support/helpers/licence-document-header.helper.js')
 const LicenceDocumentHeaderModel = require('../../app/models/licence-document-header.model.js')
 const LicenceDocumentRoleHelper = require('../support/helpers/licence-document-role.helper.js')
+const LicenceGaugingStationHelper = require('../support/helpers/licence-gauging-station.helper.js')
 const LicenceRoleHelper = require('../support/helpers/licence-role.helper.js')
 const LicenceVersionHelper = require('../support/helpers/licence-version.helper.js')
 const LicenceVersionModel = require('../../app/models/licence-version.model.js')
@@ -127,6 +130,39 @@ describe('Licence model', () => {
         expect(result.chargeVersions[0]).to.be.an.instanceOf(ChargeVersionModel)
         expect(result.chargeVersions).to.include(testChargeVersions[0])
         expect(result.chargeVersions).to.include(testChargeVersions[1])
+      })
+    })
+
+    describe('when linking through licence gauging stations to gauging stations', () => {
+      let gaugingStation
+
+      beforeEach(async () => {
+        testRecord = await LicenceHelper.add()
+        gaugingStation = await GaugingStationHelper.add()
+
+        await LicenceGaugingStationHelper.add({
+          licenceId: testRecord.id,
+          gaugingStationId: gaugingStation.id
+        })
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await LicenceModel.query()
+          .innerJoinRelated('gaugingStations')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the gauging stations', async () => {
+        const result = await LicenceModel.query()
+          .findById(testRecord.id)
+          .withGraphFetched('gaugingStations')
+
+        expect(result).to.be.instanceOf(LicenceModel)
+        expect(result.id).to.equal(testRecord.id)
+
+        expect(result.gaugingStations[0]).to.be.an.instanceOf(GaugingStationModel)
+        expect(result.gaugingStations).to.equal([gaugingStation])
       })
     })
 

--- a/test/presenters/licences/view-licence-summary.presenter.test.js
+++ b/test/presenters/licences/view-licence-summary.presenter.test.js
@@ -28,8 +28,11 @@ describe('View Licence Summary presenter', () => {
           conditions: ['Derogation clause', 'General conditions', 'Non standard quantities'],
           numberOfConditions: 4
         },
-        abstractionPeriods: null,
-        abstractionPeriodsAndPurposesLinkText: null,
+        abstractionPeriods: {
+          caption: 'Periods of abstraction',
+          uniqueAbstractionPeriods: ['1 April to 31 October', '1 November to 31 March']
+        },
+        abstractionPeriodsAndPurposesLinkText: 'View details of your purposes, periods and amounts',
         abstractionPointLinkText: 'View details of the abstraction point',
         abstractionPoints: ['At National Grid Reference TL 23198 88603'],
         abstractionPointsCaption: 'Point of abstraction',
@@ -40,11 +43,14 @@ describe('View Licence Summary presenter', () => {
         id: 'f1288f6c-8503-4dc1-b114-75c408a14bd0',
         licenceHolder: 'Unregistered licence',
         monitoringStations: [{
-          gaugingStationId: 'ac075651-4781-4e24-a684-b943b98607ca',
+          id: 'ac075651-4781-4e24-a684-b943b98607ca',
           label: 'MEVAGISSEY FIRE STATION'
         }],
-        purposes: null,
-        region: 'Narnia',
+        purposes: {
+          caption: 'Purposes',
+          data: ['Spray Irrigation - Storage', 'Spray Irrigation - Direct']
+        },
+        region: 'Avalon',
         sourceOfSupply: 'SURFACE WATER SOURCE OF SUPPLY',
         startDate: '1 April 2019'
       })
@@ -120,9 +126,191 @@ describe('View Licence Summary presenter', () => {
     })
   })
 
+  describe('the "abstractionPeriods" property', () => {
+    describe('when there is no "current" licence version', () => {
+      beforeEach(() => {
+        licence.licenceVersions = []
+      })
+
+      it('returns null', () => {
+        const result = ViewLicenceSummaryPresenter.go(licence, licenceAbstractionConditions)
+
+        expect(result.abstractionPeriods).to.equal(null)
+      })
+    })
+
+    describe('when there is a "current" licence version', () => {
+      describe('but no licence version purposes linked to it', () => {
+        beforeEach(() => {
+          licence.licenceVersions[0].licenceVersionPurposes = []
+        })
+
+        it('returns null', () => {
+          const result = ViewLicenceSummaryPresenter.go(licence, licenceAbstractionConditions)
+
+          expect(result.abstractionPeriods).to.equal(null)
+        })
+      })
+
+      describe('and a single licence version purpose linked to it', () => {
+        beforeEach(() => {
+          licence.licenceVersions[0].licenceVersionPurposes.pop()
+          licence.licenceVersions[0].licenceVersionPurposes.pop()
+        })
+
+        it('returns the singular version of the caption and period formatted for display', () => {
+          const result = ViewLicenceSummaryPresenter.go(licence, licenceAbstractionConditions)
+
+          expect(result.abstractionPeriods).to.equal({
+            caption: 'Period of abstraction',
+            uniqueAbstractionPeriods: ['1 April to 31 October']
+          })
+        })
+      })
+
+      describe('and multiple licence version purposes linked to it', () => {
+        describe('that all have different abstraction periods', () => {
+          beforeEach(() => {
+            licence.licenceVersions[0].licenceVersionPurposes.pop()
+          })
+
+          it('returns the plural version of the caption and periods formatted for display', () => {
+            const result = ViewLicenceSummaryPresenter.go(licence, licenceAbstractionConditions)
+
+            expect(result.abstractionPeriods).to.equal({
+              caption: 'Periods of abstraction',
+              uniqueAbstractionPeriods: ['1 April to 31 October', '1 November to 31 March']
+            })
+          })
+        })
+
+        describe('that have some abstraction periods that are the same', () => {
+          it('returns the plural version of the caption and the unique periods formatted for display', () => {
+            const result = ViewLicenceSummaryPresenter.go(licence, licenceAbstractionConditions)
+
+            expect(result.abstractionPeriods).to.equal({
+              caption: 'Periods of abstraction',
+              uniqueAbstractionPeriods: ['1 April to 31 October', '1 November to 31 March']
+            })
+          })
+        })
+      })
+    })
+  })
+
+  describe('the "abstractionPeriodsAndPurposesLinkText" property', () => {
+    describe('when there is no "current" licence version', () => {
+      beforeEach(() => {
+        licence.licenceVersions = []
+      })
+
+      it('returns null', () => {
+        const result = ViewLicenceSummaryPresenter.go(licence, licenceAbstractionConditions)
+
+        expect(result.abstractionPeriodsAndPurposesLinkText).to.equal(null)
+      })
+    })
+
+    describe('when there is a "current" licence version', () => {
+      describe('but no licence version purposes linked to it', () => {
+        beforeEach(() => {
+          licence.licenceVersions[0].licenceVersionPurposes = []
+        })
+
+        it('returns null', () => {
+          const result = ViewLicenceSummaryPresenter.go(licence, licenceAbstractionConditions)
+
+          expect(result.abstractionPeriodsAndPurposesLinkText).to.equal(null)
+        })
+      })
+
+      describe('and a single licence version purpose linked to it', () => {
+        beforeEach(() => {
+          licence.licenceVersions[0].licenceVersionPurposes.pop()
+          licence.licenceVersions[0].licenceVersionPurposes.pop()
+        })
+
+        it('returns the singular version of the link (period and purpose)', () => {
+          const result = ViewLicenceSummaryPresenter.go(licence, licenceAbstractionConditions)
+
+          expect(result.abstractionPeriodsAndPurposesLinkText)
+            .to
+            .equal('View details of your purpose, period and amounts')
+        })
+      })
+
+      describe('and multiple licence version purposes linked to it', () => {
+        describe('that all have different abstraction periods', () => {
+          describe('but the same purpose', () => {
+            beforeEach(() => {
+              licence.licenceVersions[0].licenceVersionPurposes.pop()
+            })
+
+            it('returns a mixed version of the link (periods and purpose)', () => {
+              const result = ViewLicenceSummaryPresenter.go(licence, licenceAbstractionConditions)
+
+              expect(result.abstractionPeriodsAndPurposesLinkText)
+                .to
+                .equal('View details of your purpose, periods and amounts')
+            })
+          })
+
+          describe('and different purposes', () => {
+            beforeEach(() => {
+              licence.licenceVersions[0].licenceVersionPurposes.pop()
+              licence.licenceVersions[0].licenceVersionPurposes[1].purpose = {
+                id: 'd1fc1c6f-bff0-4da2-a41a-033f151fddc7', description: 'Spray Irrigation - Direct'
+              }
+            })
+
+            it('returns the plural version of the link (periods and purposes)', () => {
+              const result = ViewLicenceSummaryPresenter.go(licence, licenceAbstractionConditions)
+
+              expect(result.abstractionPeriodsAndPurposesLinkText)
+                .to
+                .equal('View details of your purposes, periods and amounts')
+            })
+          })
+        })
+
+        describe('that all have the same abstraction period', () => {
+          beforeEach(() => {
+            licence.licenceVersions[0].licenceVersionPurposes.splice(1, 1)
+          })
+
+          describe('and the same purpose', () => {
+            beforeEach(() => {
+              licence.licenceVersions[0].licenceVersionPurposes[1].purpose = {
+                id: '0316229a-e76d-4785-bc2c-65075a1a8f50', description: 'Spray Irrigation - Storage'
+              }
+            })
+
+            it('returns the singular version of the link (period and purpose)', () => {
+              const result = ViewLicenceSummaryPresenter.go(licence, licenceAbstractionConditions)
+
+              expect(result.abstractionPeriodsAndPurposesLinkText)
+                .to
+                .equal('View details of your purpose, period and amounts')
+            })
+          })
+
+          describe('but different purposes', () => {
+            it('returns a mixed version of the link (period and purposes)', () => {
+              const result = ViewLicenceSummaryPresenter.go(licence, licenceAbstractionConditions)
+
+              expect(result.abstractionPeriodsAndPurposesLinkText)
+                .to
+                .equal('View details of your purposes, period and amounts')
+            })
+          })
+        })
+      })
+    })
+  })
+
   describe('the "endDate" property', () => {
     describe('when the licence expired date is null', () => {
-      it('returns NULL', () => {
+      it('returns null', () => {
         const result = ViewLicenceSummaryPresenter.go(licence, licenceAbstractionConditions)
 
         expect(result.endDate).to.be.null()
@@ -140,7 +328,7 @@ describe('View Licence Summary presenter', () => {
         licence.expiredDate = today
       })
 
-      it('returns NULL', () => {
+      it('returns null', () => {
         const result = ViewLicenceSummaryPresenter.go(licence, licenceAbstractionConditions)
 
         expect(result.endDate).to.be.null()
@@ -182,162 +370,13 @@ describe('View Licence Summary presenter', () => {
     })
   })
 
-  describe('the "licenceVersionPurposes" property', () => {
-    describe('when there are no licenceVersions', () => {
-      it('returns null', () => {
-        const result = ViewLicenceSummaryPresenter.go(licence, licenceAbstractionConditions)
-
-        expect(result.abstractionPeriods).to.equal(null)
-        expect(result.abstractionPeriodsAndPurposesLinkText).to.equal(null)
-      })
-    })
-
-    describe('when there are no licenceVersions so an empty array is returned', () => {
-      beforeEach(() => {
-        licence.licenceVersions = []
-      })
-
-      it('returns null', () => {
-        const result = ViewLicenceSummaryPresenter.go(licence, licenceAbstractionConditions)
-
-        expect(result.abstractionPeriods).to.equal(null)
-        expect(result.abstractionPeriodsAndPurposesLinkText).to.equal(null)
-      })
-    })
-
-    describe('when the licenceVersionPurposes has no abstraction period and one purpose', () => {
-      beforeEach(() => {
-        licence.licenceVersions = [{
-          purposes: [{
-            description: 'Spray Irrigation - Storage'
-          }],
-          licenceVersionPurposes: []
-        }]
-      })
-
-      it('returns null', () => {
-        const result = ViewLicenceSummaryPresenter.go(licence, licenceAbstractionConditions)
-
-        expect(result.abstractionPeriods).to.equal(null)
-      })
-    })
-
-    describe('when the licenceVersionPurposes has one abstraction period and one purpose', () => {
-      beforeEach(() => {
-        licence.licenceVersions = [{
-          purposes: [{
-            description: 'Spray Irrigation - Storage'
-          }],
-          licenceVersionPurposes: [{
-            abstractionPeriodStartDay: 1,
-            abstractionPeriodStartMonth: 1,
-            abstractionPeriodEndDay: 28,
-            abstractionPeriodEndMonth: 2
-          }]
-        }]
-      })
-
-      it('returns an object with a caption and an array with one abstraction period', () => {
-        const result = ViewLicenceSummaryPresenter.go(licence, licenceAbstractionConditions)
-
-        expect(result.abstractionPeriods).to.equal({
-          caption: 'Period of abstraction',
-          uniqueAbstractionPeriods: ['1 January to 28 February']
-        })
-      })
-    })
-
-    describe('when the licenceVersions has more than one abstraction period of the same range', () => {
-      beforeEach(() => {
-        licence.licenceVersions = [{
-          licenceVersionPurposes: [{
-            abstractionPeriodStartDay: 1,
-            abstractionPeriodStartMonth: 1,
-            abstractionPeriodEndDay: 28,
-            abstractionPeriodEndMonth: 2
-          }, {
-            abstractionPeriodStartDay: 1,
-            abstractionPeriodStartMonth: 1,
-            abstractionPeriodEndDay: 28,
-            abstractionPeriodEndMonth: 2
-          }]
-        }]
-      })
-
-      it('returns an object with a caption and an array with one abstraction period', () => {
-        const result = ViewLicenceSummaryPresenter.go(licence, licenceAbstractionConditions)
-
-        expect(result.abstractionPeriods).to.equal({
-          caption: 'Period of abstraction',
-          uniqueAbstractionPeriods: ['1 January to 28 February']
-        })
-      })
-    })
-
-    describe('when the licenceVersions has more than one abstraction period and purposes of different types', () => {
-      beforeEach(() => {
-        licence.licenceVersions = [{
-          purposes: [{
-            description: 'Spray Irrigation - Storage'
-          }, {
-            description: 'Make-Up Or Top Up Water'
-          }],
-          licenceVersionPurposes: [{
-            abstractionPeriodStartDay: 1,
-            abstractionPeriodStartMonth: 1,
-            abstractionPeriodEndDay: 28,
-            abstractionPeriodEndMonth: 2
-          }, {
-            abstractionPeriodStartDay: 1,
-            abstractionPeriodStartMonth: 3,
-            abstractionPeriodEndDay: 28,
-            abstractionPeriodEndMonth: 4
-          }]
-        }]
-      })
-
-      it('returns an object with a caption and an array with two purposes', () => {
-        const result = ViewLicenceSummaryPresenter.go(licence, licenceAbstractionConditions)
-
-        expect(result.abstractionPeriods).to.equal({
-          caption: 'Periods of abstraction',
-          uniqueAbstractionPeriods: ['1 January to 28 February', '1 March to 28 April']
-        })
-      })
-    })
-  })
-
   describe('the "monitoringStations" property', () => {
-    describe('when the licenceGaugingStations property is not an array', () => {
-      beforeEach(() => {
-        licence.licenceGaugingStations = {}
-      })
-
-      it('will return an empty array of monitoring station details', async () => {
-        const result = await ViewLicenceSummaryPresenter.go(licence, licenceAbstractionConditions)
-
-        expect(result.monitoringStations).to.equal([])
-      })
-    })
-
     describe('when the licence has no gauging stations', () => {
       beforeEach(() => {
         licence.licenceGaugingStations = []
       })
 
-      it('will return an empty array of monitoring station details', async () => {
-        const result = await ViewLicenceSummaryPresenter.go(licence, licenceAbstractionConditions)
-
-        expect(result.monitoringStations).to.equal([])
-      })
-    })
-
-    describe('when the licence has a null "licenceGaugingStations" property', () => {
-      beforeEach(() => {
-        licence.licenceGaugingStations = null
-      })
-
-      it('will return an empty array of monitoring station details', async () => {
+      it('will return an empty array', async () => {
         const result = await ViewLicenceSummaryPresenter.go(licence, licenceAbstractionConditions)
 
         expect(result.monitoringStations).to.equal([])
@@ -345,11 +384,11 @@ describe('View Licence Summary presenter', () => {
     })
 
     describe('when the licence has a gauging station', () => {
-      it('will return an array populated with monitoring station details', async () => {
+      it('will return any array with the monitoring station details', async () => {
         const result = await ViewLicenceSummaryPresenter.go(licence, licenceAbstractionConditions)
 
         expect(result.monitoringStations).to.equal([{
-          gaugingStationId: 'ac075651-4781-4e24-a684-b943b98607ca',
+          id: 'ac075651-4781-4e24-a684-b943b98607ca',
           label: 'MEVAGISSEY FIRE STATION'
         }])
       })
@@ -357,39 +396,34 @@ describe('View Licence Summary presenter', () => {
 
     describe('when the licence has multiple gauging stations', () => {
       beforeEach(() => {
-        licence.licenceGaugingStations = [{
-          gaugingStationId: 'ac075651-4781-4e24-a684-b943b98607ca',
-          label: 'MEVAGISSEY FIRE STATION'
-        }, {
-          gaugingStationId: 'ac075651-4781-4e24-a684-b943b98607cb',
-          label: 'AVALON FIRE STATION'
-        }]
+        licence.licenceGaugingStations.push({
+          id: '13f7504d-2750-4dd9-94dd-929e99e900a0',
+          gaugingStation: {
+            id: '4a6493b0-1d8d-429f-a7a0-3a6541d5ff1f',
+            label: 'AVALON FIRE STATION'
+          }
+        })
       })
 
-      it('will return an array populated with multiple monitoring station details', async () => {
+      it('will return any array with the monitoring station details', async () => {
         const result = await ViewLicenceSummaryPresenter.go(licence, licenceAbstractionConditions)
 
-        expect(result.monitoringStations).to.equal([{
-          gaugingStationId: 'ac075651-4781-4e24-a684-b943b98607ca',
-          label: 'MEVAGISSEY FIRE STATION'
-        }, {
-          gaugingStationId: 'ac075651-4781-4e24-a684-b943b98607cb',
-          label: 'AVALON FIRE STATION'
-        }])
+        expect(result.monitoringStations).to.equal([
+          {
+            id: 'ac075651-4781-4e24-a684-b943b98607ca',
+            label: 'MEVAGISSEY FIRE STATION'
+          },
+          {
+            id: '4a6493b0-1d8d-429f-a7a0-3a6541d5ff1f',
+            label: 'AVALON FIRE STATION'
+          }
+        ])
       })
     })
   })
 
   describe('the "purposes" property', () => {
-    describe('when there are no licenceVersions', () => {
-      it('returns null', () => {
-        const result = ViewLicenceSummaryPresenter.go(licence, licenceAbstractionConditions)
-
-        expect(result.purposes).to.equal(null)
-      })
-    })
-
-    describe('when there is an empty licenceVersions array', () => {
+    describe('when there is no "current" licence version', () => {
       beforeEach(() => {
         licence.licenceVersions = []
       })
@@ -401,83 +435,66 @@ describe('View Licence Summary presenter', () => {
       })
     })
 
-    describe('when there is an empty licenceVersions purposes array', () => {
-      beforeEach(() => {
-        licence.licenceVersions = [{
-          purposes: []
-        }]
-      })
+    describe('when there is a "current" licence version', () => {
+      describe('but no licence version purposes linked to it', () => {
+        beforeEach(() => {
+          licence.licenceVersions[0].licenceVersionPurposes = []
+        })
 
-      it('returns null', () => {
-        const result = ViewLicenceSummaryPresenter.go(licence, licenceAbstractionConditions)
+        it('returns null', () => {
+          const result = ViewLicenceSummaryPresenter.go(licence, licenceAbstractionConditions)
 
-        expect(result.purposes).to.equal(null)
-      })
-    })
-
-    describe('when the licenceVersions has one purpose', () => {
-      beforeEach(() => {
-        licence.licenceVersions = [{
-          purposes: [{
-            description: 'Spray Irrigation - Storage'
-          }]
-        }]
-      })
-
-      it('returns an object with a caption and an array with one purpose', () => {
-        const result = ViewLicenceSummaryPresenter.go(licence, licenceAbstractionConditions)
-
-        expect(result.purposes).to.equal({
-          caption: 'Purpose',
-          data: ['Spray Irrigation - Storage']
+          expect(result.purposes).to.equal(null)
         })
       })
-    })
 
-    describe('when the licenceVersions has more than one purpose of the same type', () => {
-      beforeEach(() => {
-        licence.licenceVersions = [{
-          purposes: [{
-            description: 'Spray Irrigation - Storage'
-          }, {
-            description: 'Spray Irrigation - Storage'
-          }]
-        }]
-      })
+      describe('and a single licence version purpose linked to it', () => {
+        beforeEach(() => {
+          licence.licenceVersions[0].licenceVersionPurposes.pop()
+          licence.licenceVersions[0].licenceVersionPurposes.pop()
+        })
 
-      it('returns an object with a caption and an array with one entry', () => {
-        const result = ViewLicenceSummaryPresenter.go(licence, licenceAbstractionConditions)
+        it('returns the singular version of the caption and the purpose descriptions', () => {
+          const result = ViewLicenceSummaryPresenter.go(licence, licenceAbstractionConditions)
 
-        expect(result.purposes).to.equal({
-          caption: 'Purpose',
-          data: ['Spray Irrigation - Storage']
+          expect(result.purposes).to.equal({
+            caption: 'Purpose',
+            data: ['Spray Irrigation - Storage']
+          })
         })
       })
-    })
 
-    describe('when the licenceVersions has more than one purpose of different types', () => {
-      beforeEach(() => {
-        licence.licenceVersions = [{
-          purposes: [{
-            description: 'Spray Irrigation - Storage'
-          }, {
-            description: 'Make-Up Or Top Up Water'
-          }]
-        }]
-      })
+      describe('and multiple licence version purposes linked to it', () => {
+        describe('that all have different purposes', () => {
+          beforeEach(() => {
+            licence.licenceVersions[0].licenceVersionPurposes.splice(1, 1)
+          })
 
-      it('returns an object with a caption and an array with two entries', () => {
-        const result = ViewLicenceSummaryPresenter.go(licence, licenceAbstractionConditions)
+          it('returns the plural version of the caption and all purpose descriptions', () => {
+            const result = ViewLicenceSummaryPresenter.go(licence, licenceAbstractionConditions)
 
-        expect(result.purposes).to.equal({
-          caption: 'Purposes',
-          data: ['Spray Irrigation - Storage', 'Make-Up Or Top Up Water']
+            expect(result.purposes).to.equal({
+              caption: 'Purposes',
+              data: ['Spray Irrigation - Storage', 'Spray Irrigation - Direct']
+            })
+          })
+        })
+
+        describe('that have some abstraction purposes that are the same', () => {
+          it('returns the plural version of the captions and the unique purpose descriptions', () => {
+            const result = ViewLicenceSummaryPresenter.go(licence, licenceAbstractionConditions)
+
+            expect(result.purposes).to.equal({
+              caption: 'Purposes',
+              data: ['Spray Irrigation - Storage', 'Spray Irrigation - Direct']
+            })
+          })
         })
       })
     })
   })
 
-  describe('the "purposes" property', () => {
+  describe('the "sourceOfSupply" property', () => {
     describe('and it has a source of supply', () => {
       it('will return the source of supply for use in the licence summary page', async () => {
         const result = await ViewLicenceSummaryPresenter.go(licence, licenceAbstractionConditions)
@@ -980,16 +997,12 @@ function _abstractionConditions () {
 function _licence () {
   return {
     id: 'f1288f6c-8503-4dc1-b114-75c408a14bd0',
-    ends: null,
     expiredDate: null,
-    licenceDocumentHeader: { id: '28665d16-eba3-4c9a-aa55-7ab671b0c4fb' },
-    licenceGaugingStations: [{
-      gaugingStationId: 'ac075651-4781-4e24-a684-b943b98607ca',
-      label: 'MEVAGISSEY FIRE STATION'
-    }],
-    licenceHolder: null,
-    licenceName: 'Unregistered licence',
-    licenceRef: '01/123',
+    startDate: new Date('2019-04-01'),
+    region: {
+      id: '740375f0-5add-4335-8ed5-b21b55b4a228',
+      displayName: 'Avalon'
+    },
     permitLicence: {
       purposes: [{
         ANNUAL_QTY: 'null',
@@ -1008,8 +1021,44 @@ function _licence () {
         }]
       }]
     },
-    region: { displayName: 'Narnia' },
-    registeredTo: null,
-    startDate: new Date('2019-04-01')
+    licenceVersions: [{
+      id: 'ac9a8a56-c9ae-43d0-a003-296b4aa7481d',
+      licenceVersionPurposes: [
+        {
+          id: '7f5e0838-d87a-4c2e-8e9b-09d6814b9ec4',
+          abstractionPeriodStartDay: 1,
+          abstractionPeriodStartMonth: 4,
+          abstractionPeriodEndDay: 31,
+          abstractionPeriodEndMonth: 10,
+          purpose: { id: '0316229a-e76d-4785-bc2c-65075a1a8f50', description: 'Spray Irrigation - Storage' }
+        },
+        {
+          id: 'da6cbb9b-edcb-4b5b-8d3a-fab22ce6ee8b',
+          abstractionPeriodStartDay: 1,
+          abstractionPeriodStartMonth: 11,
+          abstractionPeriodEndDay: 31,
+          abstractionPeriodEndMonth: 3,
+          purpose: { id: '0316229a-e76d-4785-bc2c-65075a1a8f50', description: 'Spray Irrigation - Storage' }
+        },
+        {
+          id: 'f68ed9a0-4a2b-42da-8f5b-c5c897113121',
+          abstractionPeriodStartDay: 1,
+          abstractionPeriodStartMonth: 4,
+          abstractionPeriodEndDay: 31,
+          abstractionPeriodEndMonth: 10,
+          purpose: { id: 'd1fc1c6f-bff0-4da2-a41a-033f151fddc7', description: 'Spray Irrigation - Direct' }
+        }
+      ]
+    }],
+    licenceGaugingStations: [{
+      id: 'f775f2cf-9b7c-4f1e-bb6f-6e81b34b1a8d',
+      gaugingStation: {
+        id: 'ac075651-4781-4e24-a684-b943b98607ca',
+        label: 'MEVAGISSEY FIRE STATION'
+      }
+    }],
+    licenceDocument: {},
+    licenceDocumentHeader: { id: '28665d16-eba3-4c9a-aa55-7ab671b0c4fb' },
+    licenceHolder: null
   }
 }

--- a/test/services/licences/fetch-licence-summary.service.test.js
+++ b/test/services/licences/fetch-licence-summary.service.test.js
@@ -8,17 +8,13 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const CompanyHelper = require('../../support/helpers/company.helper.js')
 const DatabaseSupport = require('../../support/database.js')
 const GaugingStationHelper = require('../../support/helpers/gauging-station.helper.js')
 const LicenceEntityHelper = require('../../support/helpers/licence-entity.helper.js')
 const LicenceEntityRoleHelper = require('../../support/helpers/licence-entity-role.helper.js')
 const LicenceHelper = require('../../support/helpers/licence.helper.js')
 const LicenceDocumentHeaderHelper = require('../../support/helpers/licence-document-header.helper.js')
-const LicenceDocumentHelper = require('../../support/helpers/licence-document.helper.js')
-const LicenceDocumentRoleHelper = require('../../support/helpers/licence-document-role.helper.js')
 const LicenceGaugingStationHelper = require('../../support/helpers/licence-gauging-station.helper.js')
-const LicenceRoleHelper = require('../../support/helpers/licence-role.helper.js')
 const LicenceHolderSeeder = require('../../support/seeders/licence-holder.seeder.js')
 const LicenceVersionHelper = require('../../support/helpers/licence-version.helper.js')
 const LicenceVersionPurposeHelper = require('../../support/helpers/licence-version-purpose.helper.js')
@@ -30,135 +26,138 @@ const RegionHelper = require('../../support/helpers/region.helper.js')
 const FetchLicenceSummaryService = require('../../../app/services/licences/fetch-licence-summary.service.js')
 
 describe('Fetch Licence Summary service', () => {
+  let gaugingStation
   let licence
+  let licenceDocumentHeader
+  let licenceGaugingStation
+  let licenceHolderSeed
+  let licenceVersion
+  let licenceVersionPurpose
+  let permitLicence
+  let purpose
+  let region
 
   beforeEach(async () => {
     await DatabaseSupport.clean()
-  })
 
-  describe('when there is no optional data in the model', () => {
-    beforeEach(async () => {
-      const region = await RegionHelper.add()
+    region = await RegionHelper.add()
 
-      licence = await LicenceHelper.add({
-        expiredDate: null,
-        lapsedDate: null,
-        regionId: region.id
-      })
-
-      // Create 2 licence versions so we can test the service only gets the 'current' version
-      await LicenceVersionHelper.add({
-        licenceId: licence.id, startDate: new Date('2021-10-11'), status: 'superseded'
-      })
-      const licenceVersion = await LicenceVersionHelper.add({
-        licenceId: licence.id, startDate: new Date('2022-05-01')
-      })
-
-      const purpose = await PurposeHelper.add()
-      await LicenceVersionPurposeHelper.add({
-        licenceVersionId: licenceVersion.id,
-        purposeId: purpose.id
-      })
-
-      // Create a licence holder for the licence with the default name 'Licence Holder Ltd'
-      await LicenceHolderSeeder.seed(licence.licenceRef)
+    licence = await LicenceHelper.add({
+      expiredDate: null,
+      lapsedDate: null,
+      regionId: region.id
     })
 
-    it('returns results', async () => {
-      const result = await FetchLicenceSummaryService.go(licence.id)
-
-      expect(result.id).to.equal(licence.id)
-      expect(result.expiredDate).to.equal(null)
-      expect(result.licenceHolder).to.equal('Licence Holder Ltd')
-      expect(result.licenceVersions[0].purposes[0].description).to.equal('Spray Irrigation - Storage')
-      expect(result.region.displayName).to.equal('Avalon')
-      expect(result.permitLicence).to.equal(null)
-      expect(result.licenceGaugingStations).to.equal([])
+    // Create 2 licence versions so we can test the service only gets the 'current' version
+    await LicenceVersionHelper.add({
+      licenceId: licence.id, startDate: new Date('2021-10-11'), status: 'superseded'
     })
-  })
+    licenceVersion = await LicenceVersionHelper.add({
+      licenceId: licence.id, startDate: new Date('2022-05-01')
+    })
 
-  describe('when there is optional data in the model', () => {
-    beforeEach(async () => {
-      const region = await RegionHelper.add()
+    purpose = await PurposeHelper.add()
 
-      licence = await LicenceHelper.add({
-        expiredDate: null,
-        lapsedDate: null,
-        regionId: region.id
-      })
+    licenceVersionPurpose = await LicenceVersionPurposeHelper.add({
+      licenceVersionId: licenceVersion.id,
+      purposeId: purpose.id
+    })
 
-      // Create 2 licence versions so we can test the service only gets the 'current' version
-      await LicenceVersionHelper.add({
-        licenceId: licence.id, startDate: new Date('2021-10-11'), status: 'superseded'
-      })
-      const licenceVersion = await LicenceVersionHelper.add({
-        licenceId: licence.id, startDate: new Date('2022-05-01')
-      })
+    licenceHolderSeed = await LicenceHolderSeeder.seed(licence.licenceRef)
 
-      const purpose = await PurposeHelper.add()
-      await LicenceVersionPurposeHelper.add({
-        licenceVersionId: licenceVersion.id,
-        purposeId: purpose.id
-      })
+    licenceDocumentHeader = await LicenceDocumentHeaderHelper.add({
+      companyEntityId: licenceHolderSeed.companyId,
+      licenceName: 'Licence Holder Ltd',
+      licenceRef: licence.licenceRef
+    })
+    const { id: licenceEntityId } = await LicenceEntityHelper.add()
 
-      await PermitLicenceHelper.add({
-        licenceRef: licence.licenceRef,
-        licenceDataValue: {
-          data: {
-            current_version: {
-              purposes: [{
-                purposePoints: [{ point_source: { NAME: 'Ground water' } }]
-              }]
-            }
+    await LicenceEntityRoleHelper.add({ companyEntityId: licenceHolderSeed.companyId, licenceEntityId })
+
+    permitLicence = await PermitLicenceHelper.add({
+      licenceRef: licence.licenceRef,
+      licenceDataValue: {
+        data: {
+          current_version: {
+            purposes: [{
+              purposePoints: [{ point_source: { NAME: 'Ground water' } }]
+            }]
           }
         }
-      })
-
-      const licenceRole = await LicenceRoleHelper.add()
-      const licenceName = 'Test Company Ltd'
-      const companyEntityId = 'c960a4a1-94f9-4c05-9db1-a70ce5d08738'
-      const licenceRef = licence.licenceRef
-
-      const company = await CompanyHelper.add({ name: licenceName })
-
-      const licenceDocument = await LicenceDocumentHelper.add({ licenceRef })
-
-      await LicenceDocumentHeaderHelper.add({ companyEntityId, licenceName, licenceRef })
-      const { id: licenceEntityId } = await LicenceEntityHelper.add()
-
-      await LicenceEntityRoleHelper.add({ companyEntityId, licenceEntityId })
-
-      await LicenceDocumentRoleHelper.add({
-        licenceDocumentId: licenceDocument.id,
-        licenceRoleId: licenceRole.id,
-        companyId: company.id,
-        startDate: new Date('2022-04-01')
-      })
-
-      const gaugingStation = await GaugingStationHelper.add({
-        id: 'ac075651-4781-4e24-a684-b943b98607ca'
-      })
-      await LicenceGaugingStationHelper.add({
-        gaugingStationId: gaugingStation.id,
-        licenceId: licence.id
-      })
+      }
     })
 
+    gaugingStation = await GaugingStationHelper.add()
+
+    licenceGaugingStation = await LicenceGaugingStationHelper.add({
+      gaugingStationId: gaugingStation.id,
+      licenceId: licence.id
+    })
+  })
+
+  describe('when called', () => {
     it('returns results', async () => {
       const result = await FetchLicenceSummaryService.go(licence.id)
 
-      expect(result.id).to.equal(licence.id)
-      expect(result.expiredDate).to.equal(null)
-      expect(result.licenceHolder).to.equal('Test Company Ltd')
-      expect(result.licenceVersions[0].purposes[0].description).to.equal('Spray Irrigation - Storage')
-      expect(result.region.displayName).to.equal('Avalon')
-      expect(result.permitLicence.purposes).to.equal([{
-        purposePoints: [{ point_source: { NAME: 'Ground water' } }]
-      }])
-      expect(result.licenceGaugingStations).to.equal([{
-        id: 'ac075651-4781-4e24-a684-b943b98607ca',
-        label: 'MEVAGISSEY FIRE STATION'
-      }])
+      expect(result).to.equal({
+        id: licence.id,
+        expiredDate: null,
+        startDate: new Date('2022-01-01'),
+        region: {
+          id: region.id,
+          displayName: 'Avalon'
+        },
+        permitLicence: {
+          id: permitLicence.id,
+          purposes: [{
+            purposePoints: [{
+              point_source: { NAME: 'Ground water' }
+            }]
+          }]
+        },
+        licenceVersions: [
+          {
+            id: licenceVersion.id,
+            licenceVersionPurposes: [{
+              id: licenceVersionPurpose.id,
+              abstractionPeriodStartDay: 1,
+              abstractionPeriodStartMonth: 1,
+              abstractionPeriodEndDay: 31,
+              abstractionPeriodEndMonth: 3,
+              purpose: {
+                id: purpose.id,
+                description: 'Spray Irrigation - Storage'
+              }
+            }]
+          }
+        ],
+        licenceGaugingStations: [{
+          id: licenceGaugingStation.id,
+          gaugingStation: {
+            id: gaugingStation.id,
+            label: 'MEVAGISSEY FIRE STATION'
+          }
+        }],
+        licenceDocument: {
+          id: licenceHolderSeed.licenceDocumentId,
+          licenceDocumentRoles: [{
+            id: licenceHolderSeed.id,
+            contact: null,
+            company: {
+              id: licenceHolderSeed.companyId,
+              name: 'Licence Holder Ltd',
+              type: 'organisation'
+            }
+          }]
+        },
+        licenceDocumentHeader: {
+          id: licenceDocumentHeader.id,
+          licenceName: 'Licence Holder Ltd',
+          registeredTo: 'grace.hopper@example.com',
+          role: 'primary_user'
+        },
+        licenceHolder: 'Licence Holder Ltd'
+      })
     })
   })
 })

--- a/test/services/licences/fetch-licence-summary.service.test.js
+++ b/test/services/licences/fetch-licence-summary.service.test.js
@@ -27,9 +27,9 @@ const PermitLicenceHelper = require('../../support/helpers/permit-licence.helper
 const RegionHelper = require('../../support/helpers/region.helper.js')
 
 // Thing under test
-const FetchLicenceSummaryService = require('../../../app/services/licences/fetch-licence-summary.service')
+const FetchLicenceSummaryService = require('../../../app/services/licences/fetch-licence-summary.service.js')
 
-describe('Fetch licence summary service', () => {
+describe('Fetch Licence Summary service', () => {
   let licence
 
   beforeEach(async () => {

--- a/test/services/licences/view-licence-summary.service.test.js
+++ b/test/services/licences/view-licence-summary.service.test.js
@@ -54,22 +54,23 @@ describe('View Licence service summary', () => {
           abstractionPeriods: null,
           abstractionPeriodsAndPurposesLinkText: null,
           abstractionPointLinkText: 'View details of the abstraction point',
-          abstractionPoints: [
-            'At National Grid Reference TL 23198 88603'
-          ],
+          abstractionPoints: ['At National Grid Reference TL 23198 88603'],
           abstractionPointsCaption: 'Point of abstraction',
           abstractionQuantities: null,
           activeTab: 'summary',
-          documentId: '40306a46-d4ce-4874-9c9e-30ab6469b3fe',
+          documentId: '28665d16-eba3-4c9a-aa55-7ab671b0c4fb',
           endDate: null,
-          id: '2c80bd22-a005-4cf4-a2a2-73812a9861de',
+          id: 'f1288f6c-8503-4dc1-b114-75c408a14bd0',
           licenceHolder: 'Unregistered licence',
+          monitoringStations: [{
+            id: 'ac075651-4781-4e24-a684-b943b98607ca',
+            label: 'MEVAGISSEY FIRE STATION'
+          }],
           licenceName: 'fake licence',
-          monitoringStations: [],
           purposes: null,
-          region: 'South West',
+          region: 'Avalon',
           sourceOfSupply: 'SURFACE WATER SOURCE OF SUPPLY',
-          startDate: '7 March 2013'
+          startDate: '1 April 2019'
         })
       })
     })
@@ -106,13 +107,13 @@ describe('View Licence service summary', () => {
 
 function _testLicence () {
   return LicenceModel.fromJson({
-    id: '2c80bd22-a005-4cf4-a2a2-73812a9861de',
-    licenceDocumentHeader: {
-      id: '40306a46-d4ce-4874-9c9e-30ab6469b3fe'
+    id: 'f1288f6c-8503-4dc1-b114-75c408a14bd0',
+    expiredDate: null,
+    startDate: new Date('2019-04-01'),
+    region: {
+      id: '740375f0-5add-4335-8ed5-b21b55b4a228',
+      displayName: 'Avalon'
     },
-    licenceRef: '01/130/R01',
-    licenceName: 'Unregistered licence',
-    licenceVersions: [],
     permitLicence: {
       purposes: [{
         ANNUAL_QTY: 'null',
@@ -131,11 +132,16 @@ function _testLicence () {
         }]
       }]
     },
-    region: {
-      id: 'adca5dd3-114d-4477-8cdd-684081429f4b',
-      displayName: 'South West'
-    },
-    registeredTo: null,
-    startDate: new Date('2013-03-07')
+    licenceVersions: [],
+    licenceGaugingStations: [{
+      id: 'f775f2cf-9b7c-4f1e-bb6f-6e81b34b1a8d',
+      gaugingStation: {
+        id: 'ac075651-4781-4e24-a684-b943b98607ca',
+        label: 'MEVAGISSEY FIRE STATION'
+      }
+    }],
+    licenceDocument: {},
+    licenceDocumentHeader: { id: '28665d16-eba3-4c9a-aa55-7ab671b0c4fb' },
+    licenceHolder: null
   })
 }

--- a/test/support/helpers/gauging-station.helper.js
+++ b/test/support/helpers/gauging-station.helper.js
@@ -12,12 +12,11 @@ const GaugingStationModel = require('../../../app/models/gauging-station.model.j
  *
  * If no `data` is provided, default values will be used. These are
  *
- * - `gauging_station_id` - [random UUID]
- * - `hydrology_station_id` - [random UUID]
- * - `lat` - [decimal]
- * - `long` - [decimal]
- * - `grid_reference` - [string]
- * - `label` - [string]
+ * - `hydrologyStationId` - [random UUID]
+ * - `lat` - 52.04436
+ * - `long` - -0.15477
+ * - `gridReference` - TL2664640047
+ * - `label` - MEVAGISSEY FIRE STATION
  *
  * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
  *
@@ -41,7 +40,6 @@ async function add (data = {}) {
  */
 function defaults (data = {}) {
   const defaults = {
-    id: generateUUID(),
     hydrologyStationId: generateUUID(),
     lat: 52.04436,
     long: -0.15477,

--- a/test/support/helpers/licence-gauging-station.helper.js
+++ b/test/support/helpers/licence-gauging-station.helper.js
@@ -12,15 +12,14 @@ const LicenceGaugingStationModel = require('../../../app/models/licence-gauging-
  *
  * If no `data` is provided, default values will be used. These are
  *
- * - `licence_gauging_station_id` - [random UUID]
- * - `licence_id` - [random UUID]
- * - `licence_version_purpose_condition_id` - [random UUID]
- * - `source` - [string]
- * - `restriction_type` - [string]
- * - `threshold_unit` - [string]
- * - `threshold_value` - [string]
- * - `status` - [string]
- * - `alert_type` -[string]
+ * - `gaugingStationId` - [random UUID]
+ * - `licenceId` - [random UUID]
+ * - `restrictionType` - flow
+ * - `source` - wrls
+ * - `thresholdUnit` - m3/s
+ * - `thresholdValue` - 100
+ * - `createdAt` - Date.now()
+ * - `updatedAt` - Date.now()
  *
  * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
  *
@@ -44,15 +43,19 @@ async function add (data = {}) {
  */
 function defaults (data = {}) {
   const defaults = {
-    id: generateUUID(),
+    gaugingStationId: generateUUID(),
     licenceId: generateUUID(),
-    licenceVersionPurposeConditionId: generateUUID(),
-    source: 'wrls',
     restrictionType: 'flow',
+    source: 'wrls',
     thresholdUnit: 'm3/s',
-    thresholdValue: '100',
-    status: 'resume',
-    alertType: 'stop'
+    thresholdValue: 100,
+    // INFO: The table does not have a default for the createAt and updatedAt columns. But they are set as 'not
+    // nullable'! So, we need to ensure we set them when creating a new record. Also, we can't use Date.now() because
+    // Javascript returns the time since the epoch in milliseconds, whereas a PostgreSQL timestamp field can only hold
+    // the seconds since the epoch. Pass it an ISO string though ('2023-01-05T08:37:05.575Z') and PostgreSQL can do the
+    // conversion https://stackoverflow.com/a/61912776/6117745
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString()
   }
 
   return {

--- a/test/support/seeders/licence-holder.seeder.js
+++ b/test/support/seeders/licence-holder.seeder.js
@@ -12,8 +12,11 @@ const LicenceRoleHelper = require('../helpers/licence-role.helper.js')
 /**
  * Adds a company to the provided licence that is set up to be the licence holder
  *
- * @param {String} licenceRef The licence reference that the company will be the licence holder for
- * @param {String} name The name of the company that will be the licence holder
+ * @param {String} licenceRef - The licence reference that the company will be the licence holder for
+ * @param {String} [name] - The name of the company that will be the licence holder
+ *
+ * @returns {Promise<module:LicenceDocumentRoleHelper>} the licence document role which will link through to all the
+ * entities that make up the licence holder
  */
 async function seed (licenceRef, name = 'Licence Holder Ltd') {
   // Create a licence role (the default is licenceHolder)
@@ -27,7 +30,7 @@ async function seed (licenceRef, name = 'Licence Holder Ltd') {
   const licenceDocument = await LicenceDocumentHelper.add({ licenceRef })
 
   // Create the licence document role record that _is_ linked to the correct licence holder record
-  await LicenceDocumentRoleHelper.add({
+  return LicenceDocumentRoleHelper.add({
     licenceDocumentId: licenceDocument.id,
     licenceRoleId: licenceRole.id,
     companyId: company.id,


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4331

## Where we started!

The `LicenceGaugingStationModel` was added in [Display monitoring stations in view licence page summary tab](https://github.com/DEFRA/water-abstraction-system/pull/773) as part of our work to replace the legacy view licence page.

`water.licence_gauging_stations` links licences to gauging stations. When we get these, we'll typically setup the relationship, for example, as `licences` links to `gauging_stations` _through_ `licence_gauging_stations`.

That was what we did in this case. Only we named the relationship `licenceGaugingStations`. This is incorrect because if we did do an [Objection.js withGraphFetched()](https://vincit.github.io/objection.js/api/query-builder/eager-methods.html#withgraphfetched) we'd get `GaugingStationModel`s back, _not_ `LicenceGaugingStationModel`s.

But in this case, `water.licence_gauging_stations` also contains details about the abstraction periods that apply and the certain metrics (though, to be honest, we don't know why we record them!) We'll want that information as well at some point, so a _through_ relationship is not really appropriate.

Also, we never added any tests for the relationship!

## Where we finished!

Digging into this relationship and correcting it then meant needing to make changes to `FetchLicenceSummaryService`. But that brought to light that the fetch query was doing things in a way that could be simplified with knock-on effects for the presenter.

Then in the presenter tests, we saw that there wasn't a test that covered a full response, and we'd split them based on the properties passed in and not what we get out.

We also found that a number of these models didn't have unit tests themselves. Finally, the migration scripts didn't match up to what is actually in the real DB.

SO, this became a major tidy up of fetching and presenting a licence for the view summary. There is still more we think can be done. But we've drawn a line at this point 😁.