### PR TITLE
Fix No returns required missing notification banner

### DIFF
--- a/app/controllers/return-requirements.controller.js
+++ b/app/controllers/return-requirements.controller.js
@@ -350,9 +350,9 @@ async function submitFrequencyReported (request, h) {
 }
 
 async function submitNoReturnsRequired (request, h) {
-  const { sessionId } = request.params
+  const { params: { sessionId }, payload, yar } = request
 
-  const pageData = await SubmitNoReturnsRequiredService.go(sessionId, request.payload)
+  const pageData = await SubmitNoReturnsRequiredService.go(sessionId, payload, yar)
 
   if (pageData.error) {
     return h.view('return-requirements/no-returns-required.njk', pageData)

--- a/app/services/return-requirements/submit-no-returns-required.service.js
+++ b/app/services/return-requirements/submit-no-returns-required.service.js
@@ -8,6 +8,7 @@
 const NoReturnsRequiredPresenter = require('../../presenters/return-requirements/no-returns-required.presenter.js')
 const NoReturnsRequiredValidator = require('../../validators/return-requirements/no-returns-required.validator.js')
 const SessionModel = require('../../models/session.model.js')
+const GeneralLib = require('../../lib/general.lib')
 
 /**
  * Orchestrates validating the data for `/return-requirements/{sessionId}/no-returns-required` page
@@ -20,15 +21,20 @@ const SessionModel = require('../../models/session.model.js')
  *
  * @param {string} sessionId - The id of the current session
  * @param {Object} payload - The submitted form data
+ * @param {Object} yar - The Hapi `request.yar` session manager passed on by the controller
  *
  * @returns {Promise<Object>} The page data for the no returns required page
  */
-async function go (sessionId, payload) {
+async function go (sessionId, payload, yar) {
   const session = await SessionModel.query().findById(sessionId)
   const validationResult = _validate(payload)
 
   if (!validationResult) {
     await _save(session, payload)
+
+    if (session.checkPageVisited) {
+      GeneralLib.flashNotification(yar)
+    }
 
     return {
       checkPageVisited: session.checkPageVisited,

--- a/test/controllers/return-requirements.controller.test.js
+++ b/test/controllers/return-requirements.controller.test.js
@@ -33,6 +33,7 @@ const SubmitAgreementsExceptions = require('../../app/services/return-requiremen
 const SubmitExistingService = require('../../app/services/return-requirements/submit-existing.service.js')
 const SubmitFrequencyCollectedService = require('../../app/services/return-requirements/submit-frequency-collected.service.js')
 const SubmitFrequencyReportedService = require('../../app/services/return-requirements/submit-frequency-reported.service.js')
+const SubmitNoReturnsRequiredService = require('../../app/services/return-requirements/submit-no-returns-required.service.js')
 const SubmitPointsService = require('../../app/services/return-requirements/submit-points.service.js')
 const SubmitPurposeService = require('../../app/services/return-requirements/submit-purpose.service.js')
 const SubmitReasonService = require('../../app/services/return-requirements/submit-reason.service.js')
@@ -499,6 +500,36 @@ describe('Return requirements controller', () => {
           const response = await server.inject(_getOptions(path))
           expect(response.statusCode).to.equal(200)
           expect(response.payload).to.contain('Why are no returns required?')
+        })
+      })
+    })
+
+    describe('POST', () => {
+      describe('when the request succeeds', () => {
+        describe('and the validation passes', () => {
+          beforeEach(async () => {
+            Sinon.stub(SubmitNoReturnsRequiredService, 'go').resolves({ })
+          })
+
+          it('redirects to /system/return-requirements/{sessionId}/check', async () => {
+            const response = await server.inject(_postOptions(path))
+
+            expect(response.statusCode).to.equal(302)
+            expect(response.headers.location).to.equal('/system/return-requirements/' + sessionId + '/check')
+          })
+        })
+
+        describe('and the validation fails', () => {
+          beforeEach(async () => {
+            Sinon.stub(SubmitNoReturnsRequiredService, 'go').resolves({ error: {} })
+          })
+
+          it('returns the page successfully with the error summary banner', async () => {
+            const response = await server.inject(_postOptions(path))
+
+            expect(response.statusCode).to.equal(200)
+            expect(response.payload).to.contain('There is a problem')
+          })
         })
       })
     })

--- a/test/services/licences/view-licence-set-up.service.test.js
+++ b/test/services/licences/view-licence-set-up.service.test.js
@@ -9,6 +9,7 @@ const { describe, it, beforeEach, afterEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Things we need to stub
+const FeatureFlagsConfig = require('../../../config/feature-flags.config.js')
 const FetchAgreementsService = require('../../../app/services/licences/fetch-agreements.service.js')
 const FetchChargeVersionsService = require('../../../app/services/licences/fetch-charge-versions.service.js')
 const FetchReturnVersionsService = require('../../../app/services/licences/fetch-return-versions.service.js')
@@ -24,6 +25,8 @@ describe('View Licence Set Up service', () => {
   let auth = {}
 
   beforeEach(() => {
+    Sinon.stub(FeatureFlagsConfig, 'enableRequirementsForReturns').value(false)
+
     Sinon.stub(FetchAgreementsService, 'go').returns([
       {
         id: '123',


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4386

> Part of the work to replace NALD for handling return requirements

When a user changes the reason for a no-returns requirement, a flash notification should be displayed on the requirements check page highlighting that an update has been made.

The other pages were done in [Add flash notification when changes occur on returns Requirements](https://github.com/DEFRA/water-abstraction-system/pull/1079) but this one was missed.