### PR TITLE
Update two-part tariff review pages to add Cypress data test attributes

### DIFF
--- a/app/views/bill-runs/review-licence.njk
+++ b/app/views/bill-runs/review-licence.njk
@@ -438,7 +438,7 @@
                             text: 'Return volume'
                           },
                           value: {
-                            html: '<div data-test="charge-element-return volumes-' + chargeElementIndex + '">' + returnVolumes + '</div>'
+                            html: '<div data-test="charge-element-return-volumes-' + chargeElementIndex + '">' + returnVolumes + '</div>'
                           }
                         }]
                       %}

--- a/app/views/bill-runs/review.njk
+++ b/app/views/bill-runs/review.njk
@@ -159,57 +159,68 @@
           {
             value: "abs-outside-period",
             text: "Abstraction outside period",
-            checked: filter.issues.absOutsidePeriod
+            checked: filter.issues.absOutsidePeriod,
+            attributes: { 'data-test': 'abs-outside-period' }
           },
           {
             value: "aggregate-factor",
             text: "Aggregate",
-            checked: filter.issues.aggregateFactor
+            checked: filter.issues.aggregateFactor,
+            attributes: { 'data-test': 'aggregate-factor' }
           },
           {
             value: "checking-query",
             text: "Checking query",
-            checked: filter.issues.checkingQuery
+            checked: filter.issues.checkingQuery,
+            attributes: { 'data-test': 'checking-query' }
           },
           {
             value: "no-returns-received",
             text: "No returns received",
-            checked: filter.issues.noReturnsReceived
+            checked: filter.issues.noReturnsReceived,
+            attributes: { 'data-test': 'no-returns-received' }
           },
           {
             value: "over-abstraction",
             text: "Over abstraction",
-            checked: filter.issues.overAbstraction
+            checked: filter.issues.overAbstraction,
+            attributes: { 'data-test': 'over-abstraction' }
           },
           {
             value: "overlap-of-charge-dates",
             text: "Overlap of charge dates",
-            checked: filter.issues.overlapOfChargeDates
+            checked: filter.issues.overlapOfChargeDates,
+            attributes: { 'data-test': 'overlap-of-charge-dates' }
           },
           {
             value: "returns-received-not-processed",
             text: "Returns received but not processed",
-            checked: filter.issues.returnsReceivedNotProcessed
+            checked: filter.issues.returnsReceivedNotProcessed,
+            attributes: { 'data-test': 'returns-received-not-processed' }
           },
           {
             value: "returns-late",
             text: "Returns received late",
-            checked: filter.issues.returnsLate
+            checked: filter.issues.returnsLate,
+            attributes: { 'data-test': 'returns-late' }
           },
           {
             value: "return-split-over-refs",
             text: "Return split over charge references",
-            checked: filter.issues.returnSplitOverRefs
+            checked: filter.issues.returnSplitOverRefs,
+            attributes: { 'data-test': 'return-split-over-refs' }
           },
           {
             value: "some-returns-not-received",
             text: "Some returns IDs not received",
-            checked: filter.issues.someReturnsNotReceived
+            checked: filter.issues.someReturnsNotReceived,
+            attributes: { 'data-test': 'some-returns-not-received' }
           },
           {
             value: "unable-to-match-return",
             text: "Unable to match return",
-            checked: filter.issues.unableToMatchReturn
+            checked: filter.issues.unableToMatchReturn,
+            attributes: { 'data-test': 'unable-to-match-return' }
           }
         ]
       }) }}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4450

We've finished building all the pages for the two-part tariff review and are now working on the acceptance tests. While writing these tests, we found a few places where the data test attribute on the view needs to be updated to make it clearer and easier to find in the acceptance tests file.