### PR TITLE
Update validation msg for ret. req. copy existing

### DIFF
--- a/app/validators/return-requirements/existing.validator.js
+++ b/app/validators/return-requirements/existing.validator.js
@@ -7,7 +7,7 @@
 
 const Joi = require('joi')
 
-const errorMessage = 'Use previous requirements for returns'
+const errorMessage = 'Select a previous requirements for returns'
 
 /**
  * Validates data submitted for the `/return-requirements/{sessionId}/existing` page

--- a/test/services/return-requirements/submit-existing.service.test.js
+++ b/test/services/return-requirements/submit-existing.service.test.js
@@ -100,7 +100,7 @@ describe('Return Requirements - Submit Existing service', () => {
         it('includes an error for the input element', async () => {
           const result = await SubmitExistingService.go(session.id, payload)
 
-          expect(result.error).to.equal({ text: 'Use previous requirements for returns' })
+          expect(result.error).to.equal({ text: 'Select a previous requirements for returns' })
         })
       })
     })

--- a/test/validators/return-requirements/existing.validator.test.js
+++ b/test/validators/return-requirements/existing.validator.test.js
@@ -36,7 +36,7 @@ describe('Existing validator', () => {
 
         expect(result.value).to.exist()
         expect(result.error).to.exist()
-        expect(result.error.details[0].message).to.equal('Use previous requirements for returns')
+        expect(result.error.details[0].message).to.equal('Select a previous requirements for returns')
       })
     })
 
@@ -46,7 +46,7 @@ describe('Existing validator', () => {
 
         expect(result.value).to.exist()
         expect(result.error).to.exist()
-        expect(result.error.details[0].message).to.equal('Use previous requirements for returns')
+        expect(result.error.details[0].message).to.equal('Select a previous requirements for returns')
       })
     })
   })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4283

> Part of the work to replace NALD for handling return requirements

In [Complete Select existing return requirement page](https://github.com/DEFRA/water-abstraction-system/pull/895) we added the controls and logic to enable a user to copy the return requirements from an existing return version into the session.

The H1 title we used though was though to be wrong. So, we [Correct copy existing return req. page title](https://github.com/DEFRA/water-abstraction-system/pull/1092). When we did that, we also updated the validation message as all our current messages just replay the H1 title.

Again, however, this was thought to be incorrect. Our UAT team has decided the message we should show when an option is not selected is **Select a previous requirements for returns**.

This is that change.