### PR TITLE
Update empty requirements for returns message

### DIFF
--- a/app/views/licences/tabs/set-up.njk
+++ b/app/views/licences/tabs/set-up.njk
@@ -11,11 +11,11 @@
 {% endmacro %}
 
 <h2 class="govuk-heading-l">Licence set up</h2>
-
+k
   <h3 class="govuk-heading-m"> Requirements for returns </h3>
 
   {% if returnVersions.length == 0 %}
-    <p class="govuk-body"> No requirements for returns for this licence.</p>
+    <p class="govuk-body"> No requirements for returns have been set up for this licence.</p>
   {% else %}
     {% set returnVersionsTableRows = [] %}
 

--- a/app/views/licences/tabs/set-up.njk
+++ b/app/views/licences/tabs/set-up.njk
@@ -11,7 +11,6 @@
 {% endmacro %}
 
 <h2 class="govuk-heading-l">Licence set up</h2>
-k
   <h3 class="govuk-heading-m"> Requirements for returns </h3>
 
   {% if returnVersions.length == 0 %}

--- a/test/controllers/licences.controller.test.js
+++ b/test/controllers/licences.controller.test.js
@@ -363,7 +363,7 @@ describe('Licences controller', () => {
         expect(response.statusCode).to.equal(200)
         expect(response.payload).to.contain('Licence set up')
         expect(response.payload).to.contain('Requirements for returns')
-        expect(response.payload).to.contain('No requirements for returns for this licence.')
+        expect(response.payload).to.contain('No requirements for returns have been set up for this licence.')
         expect(response.payload).to.contain('Charge information')
         expect(response.payload).to.contain('No charge information for this licence.')
         expect(response.payload).to.contain('Agreements')


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4407

The message shown in the licence set up page should be: "No requirements for returns have been set up for this licence."