### PR TITLE
Fix message text in two-part tariff review screen

### DIFF
--- a/app/views/bill-runs/review.njk
+++ b/app/views/bill-runs/review.njk
@@ -101,19 +101,21 @@
   </div>
 
   {# Dynamic message either telling the user they have issues to deal with or that they can generate bills #}
-  {% if numberOfLicencesToReview > 0 %}
-    <section class="govuk-!-margin-bottom-9">
-      {{ govukInsetText({
-        html: '<span data-test="licences-to-review">You need to review ' + numberOfLicencesToReview + ' licences with returns data issues. You can then continue and send the bill run.</span>'
-      }) }}
-    </section>
-  {% else %}
-    <section class="govuk-!-margin-bottom-9">
-      {{ govukInsetText({
-        html: '<span data-test="licences-to-review">You have resolved all returns data issues. Continue to generate bills.</span>'
-      }) }}
-    </section>
-  {% endif %}
+  <section class="govuk-!-margin-bottom-9">
+    {% if numberOfLicencesToReview === 1 %}
+        {{ govukInsetText({
+          html: '<span data-test="licences-to-review">You need to review ' + numberOfLicencesToReview + ' licence with returns data issues. You can then continue and send the bill run.</span>'
+        }) }}
+    {% elif numberOfLicencesToReview > 1 %}
+        {{ govukInsetText({
+          html: '<span data-test="licences-to-review">You need to review ' + numberOfLicencesToReview + ' licences with returns data issues. You can then continue and send the bill run.</span>'
+        }) }}
+    {% else %}
+        {{ govukInsetText({
+          html: '<span data-test="licences-to-review">You have resolved all returns data issues. Continue to generate bills.</span>'
+        }) }}
+    {% endif %}
+  </section>
 
   {# Cancel bill run button #}
   <section class="govuk-!-margin-bottom-9">


### PR DESCRIPTION
On the Review screen when there are licences in review we show a message letting users know how many there are. Currently when there is only 1 licence in review the text displays as `1 licences` whereas it should be singular and display `1 licence`.

This PR corrects that text.