### PR TITLE
Spike for two-part tariff annual billing

### DIFF
--- a/app/controllers/bill-runs.controller.js
+++ b/app/controllers/bill-runs.controller.js
@@ -14,6 +14,7 @@ const CalculateChargeService = require('../services/bill-runs/two-part-tariff/ca
 const CancelBillRunService = require('../services/bill-runs/cancel-bill-run.service.js')
 const ChargeReferenceDetailsService = require('../services/bill-runs/two-part-tariff/charge-reference-details.service.js')
 const CreateBillRunValidator = require('../validators/create-bill-run.validator.js')
+const GenerateBillRunService = require('../services/bill-runs/two-part-tariff/generate-bill-run.service.js')
 const IndexBillRunsService = require('../services/bill-runs/index-bill-runs.service.js')
 const MatchDetailsService = require('../services/bill-runs/two-part-tariff/match-details.service.js')
 const RemoveBillRunLicenceService = require('../services/bill-runs/two-part-tariff/remove-bill-run-licence.service.js')
@@ -295,6 +296,21 @@ async function submitSend (request, h) {
   }
 }
 
+async function twoPartTariff (request, h) {
+  const { id } = request.params
+
+  try {
+    // NOTE: What we are awaiting here is for the GenerateBillRunService to update the status of the bill run to
+    // `processing'.
+    await GenerateBillRunService.go(id)
+
+    // Redirect to the bill runs page
+    return h.redirect('/system/bill-runs')
+  } catch (error) {
+    return Boom.badImplementation(error.message)
+  }
+}
+
 async function view (request, h) {
   const { id } = request.params
 
@@ -328,5 +344,6 @@ module.exports = {
   submitRemoveLicence,
   submitReviewLicence,
   submitSend,
+  twoPartTariff,
   view
 }

--- a/app/models/charge-element.model.js
+++ b/app/models/charge-element.model.js
@@ -31,6 +31,14 @@ class ChargeElementModel extends BaseModel {
           from: 'chargeElements.purposeId',
           to: 'purposes.id'
         }
+      },
+      reviewChargeElements: {
+        relation: Model.HasManyRelation,
+        modelClass: 'review-charge-element.model',
+        join: {
+          from: 'chargeElements.id',
+          to: 'reviewChargeElements.chargeElementId'
+        }
       }
     }
   }

--- a/app/models/charge-reference.model.js
+++ b/app/models/charge-reference.model.js
@@ -56,6 +56,14 @@ class ChargeReferenceModel extends BaseModel {
           to: 'purposes.id'
         }
       },
+      reviewChargeReferences: {
+        relation: Model.HasManyRelation,
+        modelClass: 'review-charge-reference.model',
+        join: {
+          from: 'chargeReferences.id',
+          to: 'reviewChargeReferences.chargeReferenceId'
+        }
+      },
       transactions: {
         relation: Model.HasManyRelation,
         modelClass: 'transaction.model',

--- a/app/models/charge-version.model.js
+++ b/app/models/charge-version.model.js
@@ -55,6 +55,14 @@ class ChargeVersionModel extends BaseModel {
           from: 'chargeVersions.id',
           to: 'chargeReferences.chargeVersionId'
         }
+      },
+      reviewChargeVersions: {
+        relation: Model.HasManyRelation,
+        modelClass: 'review-charge-version.model',
+        join: {
+          from: 'chargeVersions.id',
+          to: 'reviewChargeVersions.chargeVersionId'
+        }
       }
     }
   }

--- a/app/presenters/bill-runs/two-part-tariff/review-bill-run.presenter.js
+++ b/app/presenters/bill-runs/two-part-tariff/review-bill-run.presenter.js
@@ -75,6 +75,7 @@ function _prepareLicences (licences) {
 
 function _prepareBillRun (billRun, preparedLicences) {
   return {
+    billRunId: billRun.id,
     region: billRun.region.displayName,
     status: billRun.status,
     dateCreated: formatLongDate(billRun.createdAt),

--- a/app/routes/bill-runs.routes.js
+++ b/app/routes/bill-runs.routes.js
@@ -269,6 +269,18 @@ const routes = [
         }
       }
     }
+  },
+  {
+    method: 'GET',
+    path: '/bill-runs/{id}/two-part-tariff',
+    handler: BillRunsController.twoPartTariff,
+    options: {
+      auth: {
+        access: {
+          scope: ['billing']
+        }
+      }
+    }
   }
 ]
 

--- a/app/services/bill-runs/two-part-tariff/fetch-billing-accounts.service.js
+++ b/app/services/bill-runs/two-part-tariff/fetch-billing-accounts.service.js
@@ -1,0 +1,143 @@
+'use strict'
+
+const { ref } = require('objection')
+
+const BillingAccountModel = require('../../../models/billing-account.model.js')
+const ChargeVersionModel = require('../../../models/charge-version.model.js')
+
+async function go (billRunId) {
+  return BillingAccountModel.query()
+    .select([
+      'billingAccounts.id',
+      'billingAccounts.accountNumber'
+    ])
+    .whereExists(_whereBillingAccountExistsClause(billRunId))
+    .orderBy([
+      { column: 'billingAccounts.accountNumber' }
+    ])
+    .withGraphFetched('chargeVersions')
+    .modifyGraph('chargeVersions', (builder) => {
+      builder
+        .select([
+          'chargeVersions.id',
+          'chargeVersions.scheme',
+          'chargeVersions.startDate',
+          'chargeVersions.endDate',
+          'chargeVersions.billingAccountId',
+          'chargeVersions.status'
+        ])
+        .innerJoin('reviewChargeVersions', 'reviewChargeVersions.chargeVersionId', 'chargeVersions.id')
+        .innerJoin('reviewLicences', 'reviewLicences.id', 'reviewChargeVersions.reviewLicenceId')
+        .where('reviewLicences.billRunId', billRunId)
+        .orderBy([
+          { column: 'licenceId', order: 'ASC' },
+          { column: 'startDate', order: 'ASC' }
+        ])
+    })
+    .withGraphFetched('chargeVersions.licence')
+    .modifyGraph('chargeVersions.licence', (builder) => {
+      builder.select([
+        'id',
+        'licenceRef',
+        'waterUndertaker',
+        ref('licences.regions:historicalAreaCode').castText().as('historicalAreaCode'),
+        ref('licences.regions:regionalChargeArea').castText().as('regionalChargeArea'),
+        'startDate',
+        'expiredDate',
+        'lapsedDate',
+        'revokedDate'
+      ])
+    })
+    .withGraphFetched('chargeVersions.licence.region')
+    .modifyGraph('chargeVersions.licence.region', (builder) => {
+      builder.select([
+        'id',
+        'chargeRegionId'
+      ])
+    })
+    .withGraphFetched('chargeVersions.changeReason')
+    .modifyGraph('chargeVersions.changeReason', (builder) => {
+      builder.select([
+        'id',
+        'triggersMinimumCharge'
+      ])
+    })
+    .withGraphFetched('chargeVersions.chargeReferences')
+    .modifyGraph('chargeVersions.chargeReferences', (builder) => {
+      builder.select([
+        'chargeReferences.id',
+        'chargeReferences.source',
+        'chargeReferences.loss',
+        'chargeReferences.volume',
+        'chargeReferences.adjustments',
+        'chargeReferences.additionalCharges',
+        'chargeReferences.description'
+      ])
+        .innerJoin('reviewChargeReferences', 'reviewChargeReferences.chargeReferenceId', 'chargeReferences.id')
+        .innerJoin('reviewChargeVersions', 'reviewChargeVersions.id', 'reviewChargeReferences.reviewChargeVersionId')
+        .innerJoin('reviewLicences', 'reviewLicences.id', 'reviewChargeVersions.reviewLicenceId')
+        .where('reviewLicences.billRunId', billRunId)
+    })
+    .withGraphFetched('chargeVersions.chargeReferences.reviewChargeReferences')
+    .modifyGraph('chargeVersions.chargeReferences.reviewChargeReferences', (builder) => {
+      builder.select([
+        'reviewChargeReferences.id',
+        'reviewChargeReferences.amendedAggregate',
+        'reviewChargeReferences.amendedChargeAdjustment',
+        'reviewChargeReferences.amendedAuthorisedVolume'
+      ])
+        .innerJoin('reviewChargeVersions', 'reviewChargeVersions.id', 'reviewChargeReferences.reviewChargeVersionId')
+        .innerJoin('reviewLicences', 'reviewLicences.id', 'reviewChargeVersions.reviewLicenceId')
+        .where('reviewLicences.billRunId', billRunId)
+    })
+    .withGraphFetched('chargeVersions.chargeReferences.chargeCategory')
+    .modifyGraph('chargeVersions.chargeReferences.chargeCategory', (builder) => {
+      builder.select([
+        'id',
+        'reference',
+        'shortDescription'
+      ])
+    })
+    .withGraphFetched('chargeVersions.chargeReferences.chargeElements')
+    .modifyGraph('chargeVersions.chargeReferences.chargeElements', (builder) => {
+      builder.select([
+        'chargeElements.id',
+        'chargeElements.abstractionPeriodStartDay',
+        'chargeElements.abstractionPeriodStartMonth',
+        'chargeElements.abstractionPeriodEndDay',
+        'chargeElements.abstractionPeriodEndMonth'
+      ])
+        .innerJoin('reviewChargeElements', 'reviewChargeElements.chargeElementId', 'chargeElements.id')
+        .innerJoin('reviewChargeReferences', 'reviewChargeReferences.id', 'reviewChargeElements.reviewChargeReferenceId')
+        .innerJoin('reviewChargeVersions', 'reviewChargeVersions.id', 'reviewChargeReferences.reviewChargeVersionId')
+        .innerJoin('reviewLicences', 'reviewLicences.id', 'reviewChargeVersions.reviewLicenceId')
+        .where('reviewLicences.billRunId', billRunId)
+    })
+    .withGraphFetched('chargeVersions.chargeReferences.chargeElements.reviewChargeElements')
+    .modifyGraph('chargeVersions.chargeReferences.chargeElements.reviewChargeElements', (builder) => {
+      builder.select([
+        'reviewChargeElements.id',
+        'reviewChargeElements.amendedAllocated'
+      ])
+        .innerJoin('reviewChargeReferences', 'reviewChargeReferences.id', 'reviewChargeElements.reviewChargeReferenceId')
+        .innerJoin('reviewChargeVersions', 'reviewChargeVersions.id', 'reviewChargeReferences.reviewChargeVersionId')
+        .innerJoin('reviewLicences', 'reviewLicences.id', 'reviewChargeVersions.reviewLicenceId')
+        .where('reviewLicences.billRunId', billRunId)
+    })
+}
+
+function _whereBillingAccountExistsClause (billRunId) {
+  const query = ChargeVersionModel.query().select(1)
+
+  query
+    .innerJoin('reviewChargeVersions', 'reviewChargeVersions.chargeVersionId', 'chargeVersions.id')
+    .innerJoin('reviewLicences', 'reviewLicences.id', 'reviewChargeVersions.reviewLicenceId')
+    .whereColumn('chargeVersions.billingAccountId', 'billingAccounts.id')
+    .where('reviewLicences.billRunId', billRunId)
+
+  return query
+}
+
+module.exports = {
+  go
+}

--- a/app/services/bill-runs/two-part-tariff/generate-bill-run.service.js
+++ b/app/services/bill-runs/two-part-tariff/generate-bill-run.service.js
@@ -1,0 +1,118 @@
+'use strict'
+
+const BillRunError = require('../../../errors/bill-run.error.js')
+const BillRunModel = require('../../../models/bill-run.model.js')
+const ChargingModuleGenerateBillRunRequest = require('../../../requests/charging-module/generate-bill-run.request.js')
+const ExpandedError = require('../../../errors/expanded.error.js')
+const {
+  calculateAndLogTimeTaken,
+  currentTimeInNanoseconds,
+  timestampForPostgres
+} = require('../../../lib/general.lib.js')
+const FetchBillingAccountsService = require('./fetch-billing-accounts.service.js')
+const HandleErroredBillRunService = require('../handle-errored-bill-run.service.js')
+const LegacyRefreshBillRunRequest = require('../../../requests/legacy/refresh-bill-run.request.js')
+const ProcessBillingPeriodService = require('./process-billing-period.service.js')
+
+async function go (billRunId) {
+  const billRun = await _fetchBillRun(billRunId)
+
+  if (billRun.status !== 'review') {
+    throw new ExpandedError('Cannot process a two-part tariff bill run that is not in review', { billRunId })
+  }
+
+  await _updateStatus(billRunId, 'processing')
+
+  _generateBillRun(billRun)
+}
+
+async function _fetchBillingAccounts (billRunId) {
+  try {
+    // We don't just `return FetchBillingDataService.go()` as we need to call HandleErroredBillRunService if it
+    // fails
+    const billingAccounts = await FetchBillingAccountsService.go(billRunId)
+
+    return billingAccounts
+  } catch (error) {
+    // We know we're saying we failed to process charge versions. But we're stuck with the legacy error codes and this
+    // is the closest one related to what stage we're at in the process
+    throw new BillRunError(error, BillRunModel.errorCodes.failedToProcessChargeVersions)
+  }
+}
+
+async function _fetchBillRun (billRunId) {
+  return BillRunModel.query()
+    .findById(billRunId)
+    .select([
+      'id',
+      'batchType',
+      'createdAt',
+      'externalId',
+      'regionId',
+      'scheme',
+      'status',
+      'toFinancialYearEnding'
+    ])
+}
+
+async function _finaliseBillRun (billRun, billRunPopulated) {
+  // If there are no bill licences then the bill run is considered empty. We just need to set the status to indicate
+  // this in the UI
+  if (!billRunPopulated) {
+    await _updateStatus(billRun.id, 'empty')
+
+    return
+  }
+
+  // We now need to tell the Charging Module to run its generate process. This is where the Charging module finalises
+  // the debit and credit amounts, and adds any additional transactions needed, for example, minimum charge
+  await ChargingModuleGenerateBillRunRequest.send(billRun.externalId)
+
+  await LegacyRefreshBillRunRequest.send(billRun.id)
+}
+
+async function _generateBillRun (billRun) {
+  const { id: billRunId } = billRun
+
+  try {
+    const startTime = currentTimeInNanoseconds()
+
+    const billingPeriod = _billingPeriod(billRun)
+
+    await _processBillingPeriod(billingPeriod, billRun)
+
+    calculateAndLogTimeTaken(startTime, 'Process bill run complete', { billRunId })
+  } catch (error) {
+    await HandleErroredBillRunService.go(billRunId, error.code)
+    global.GlobalNotifier.omfg('Bill run process errored', { billRun }, error)
+  }
+}
+
+async function _processBillingPeriod (billingPeriod, billRun) {
+  const { id: billRunId } = billRun
+
+  const billingAccounts = await _fetchBillingAccounts(billRunId)
+
+  const billRunPopulated = await ProcessBillingPeriodService.go(billRun, billingPeriod, billingAccounts)
+
+  await _finaliseBillRun(billRun, billRunPopulated)
+}
+
+async function _updateStatus (billRunId, status) {
+  return BillRunModel.query()
+    .findById(billRunId)
+    .patch({ status, updatedAt: timestampForPostgres() })
+}
+
+function _billingPeriod (billRun) {
+  const { toFinancialYearEnding } = billRun
+
+  return {
+    startDate: new Date(`${toFinancialYearEnding - 1}-04-01`),
+    endDate: new Date(`${toFinancialYearEnding}-03-31`)
+  }
+}
+
+module.exports = {
+  go
+}

--- a/app/services/bill-runs/two-part-tariff/generate-transaction.service.js
+++ b/app/services/bill-runs/two-part-tariff/generate-transaction.service.js
@@ -1,0 +1,103 @@
+'use strict'
+
+/**
+ * Generate transaction data from the the charge reference and other information passed in
+ * @module GenerateTransactionService
+ */
+
+const { generateUUID } = require('../../../lib/general.lib.js')
+
+function go (billLicenceId, chargeReference, chargePeriod, newLicence, waterUndertaker) {
+  const billableQuantity = _billableQuantity(chargeReference.chargeElements)
+
+  return _standardTransaction(
+    billLicenceId,
+    billableQuantity,
+    chargeReference,
+    chargePeriod,
+    newLicence,
+    waterUndertaker
+  )
+}
+
+function _billableQuantity (chargeElements) {
+  return chargeElements.reduce((total, chargeElement) => {
+    total += chargeElement.reviewChargeElements[0].amendedAllocated
+
+    return total
+  }, 0)
+}
+
+function _description (chargeReference) {
+  // If the value is false, undefined, null or simply doesn't exist we return the standard description
+  if (!chargeReference.adjustments.s127) {
+    return `Water abstraction charge: ${chargeReference.description}`
+  }
+
+  return `Two-part tariff basic water abstraction charge: ${chargeReference.description}`
+}
+
+/**
+ * Returns a json representation of all charge elements in a charge reference
+ */
+function _generateElements (chargeReference) {
+  const jsonChargeElements = chargeReference.chargeElements.map((chargeElement) => {
+    delete chargeElement.reviewChargeElements
+
+    return chargeElement.toJSON()
+  })
+
+  return JSON.stringify(jsonChargeElements)
+}
+
+/**
+ * Generates a standard transaction based on the supplied data, along with some default fields (eg. status)
+ */
+function _standardTransaction (
+  billLicenceId,
+  billableQuantity,
+  chargeReference,
+  chargePeriod,
+  newLicence,
+  waterUndertaker
+) {
+  return {
+    id: generateUUID(),
+    billLicenceId,
+    authorisedDays: 0,
+    billableDays: 0,
+    newLicence,
+    waterUndertaker,
+    chargeReferenceId: chargeReference.id,
+    startDate: chargePeriod.startDate,
+    endDate: chargePeriod.endDate,
+    source: chargeReference.source,
+    season: 'all year',
+    loss: chargeReference.loss,
+    credit: false,
+    chargeType: 'standard',
+    authorisedQuantity: chargeReference.reviewChargeReferences[0].amendedAuthorisedVolume,
+    billableQuantity,
+    status: 'candidate',
+    description: _description(chargeReference),
+    volume: chargeReference.volume,
+    section126Factor: Number(chargeReference.adjustments.s126) || 1,
+    section127Agreement: !!chargeReference.adjustments.s127,
+    section130Agreement: !!chargeReference.adjustments.s130,
+    secondPartCharge: true,
+    scheme: 'sroc',
+    aggregateFactor: chargeReference.reviewChargeReferences[0].amendedAggregate,
+    adjustmentFactor: chargeReference.reviewChargeReferences[0].amendedChargeAdjustment,
+    chargeCategoryCode: chargeReference.chargeCategory.reference,
+    chargeCategoryDescription: chargeReference.chargeCategory.shortDescription,
+    supportedSource: !!chargeReference.additionalCharges?.supportedSource?.name,
+    supportedSourceName: chargeReference.additionalCharges?.supportedSource?.name || null,
+    waterCompanyCharge: !!chargeReference.additionalCharges?.isSupplyPublicWater,
+    winterOnly: !!chargeReference.adjustments.winter,
+    purposes: _generateElements(chargeReference)
+  }
+}
+
+module.exports = {
+  go
+}

--- a/app/services/bill-runs/two-part-tariff/process-billing-period.service.js
+++ b/app/services/bill-runs/two-part-tariff/process-billing-period.service.js
@@ -1,0 +1,191 @@
+'use strict'
+
+/**
+ * Process the billing accounts for a given billing period and creates their annual bills
+ * @module ProcessBillingPeriodService
+ */
+
+const BillRunError = require('../../../errors/bill-run.error.js')
+const BillRunModel = require('../../../models/bill-run.model.js')
+const BillModel = require('../../../models/bill.model.js')
+const BillLicenceModel = require('../../../models/bill-licence.model.js')
+const DetermineChargePeriodService = require('../determine-charge-period.service.js')
+const DetermineMinimumChargeService = require('../determine-minimum-charge.service.js')
+const { generateUUID } = require('../../../lib/general.lib.js')
+const GenerateTransactionService = require('./generate-transaction.service.js')
+const SendTransactionsService = require('../send-transactions.service.js')
+const TransactionModel = require('../../../models/transaction.model.js')
+
+const BillingConfig = require('../../../../config/billing.config.js')
+
+/**
+ * Process the billing accounts for a given billing period and creates their annual bills
+ *
+ * @param {module:BillRunModel} billRun - The newly created bill run we need to process
+ * @param {Object} billingPeriod - An object representing the financial year the bills will be for
+ * @param {module:BillingAccountModel[]} billingAccounts - The billing accounts to create bills for
+ *
+ * @returns {Promise<Boolean>} true if the bill run is not empty (there are transactions to bill) else false
+ */
+async function go (billRun, billingPeriod, billingAccounts) {
+  let billRunIsPopulated = false
+
+  if (billingAccounts.length === 0) {
+    return billRunIsPopulated
+  }
+
+  const batchSize = BillingConfig.annual.batchSize
+  const billingAccountsCount = billingAccounts.length
+
+  for (let i = 0; i < billingAccountsCount; i += batchSize) {
+    const accountsToProcess = billingAccounts.slice(i, i + batchSize)
+
+    const processes = accountsToProcess.map((accountToProcess) => {
+      return _processBillingAccount(accountToProcess, billRun, billingPeriod)
+    })
+
+    const results = await Promise.all(processes)
+    if (!billRunIsPopulated) {
+      billRunIsPopulated = results.some((result) => {
+        return result
+      })
+    }
+  }
+
+  return billRunIsPopulated
+}
+
+async function _createBillLicencesAndTransactions (billId, billingAccount, billRunExternalId, billingPeriod) {
+  const allBillLicences = []
+  const transactions = []
+
+  for (const chargeVersion of billingAccount.chargeVersions) {
+    const billLicence = _findOrCreateBillLicence(allBillLicences, chargeVersion.licence, billId)
+
+    const createdTransactions = await _createTransactions(
+      billLicence.id,
+      billingPeriod,
+      chargeVersion,
+      billRunExternalId,
+      billingAccount.accountNumber
+    )
+
+    if (createdTransactions.length > 0) {
+      billLicence.billable = true
+      transactions.push(...createdTransactions)
+    }
+  }
+
+  const billLicences = _extractBillableLicences(allBillLicences)
+
+  return { billLicences, transactions }
+}
+
+async function _createTransactions (billLicenceId, billingPeriod, chargeVersion, billRunExternalId, accountNumber) {
+  const chargePeriod = DetermineChargePeriodService.go(chargeVersion, billingPeriod)
+
+  if (!chargePeriod.startDate) {
+    return []
+  }
+
+  const generatedTransactions = _generateTransactionData(billLicenceId, chargePeriod, chargeVersion)
+
+  return SendTransactionsService.go(generatedTransactions, billRunExternalId, accountNumber, chargeVersion.licence)
+}
+
+function _extractBillableLicences (allBillLicences) {
+  const billableBillLicences = []
+
+  allBillLicences.forEach((billLicence) => {
+    const { id, billId, licenceId, licenceRef, billable } = billLicence
+    if (billable) {
+      billableBillLicences.push({ id, billId, licenceId, licenceRef })
+    }
+  })
+
+  return billableBillLicences
+}
+
+function _findOrCreateBillLicence (billLicences, licence, billId) {
+  const { id: licenceId, licenceRef } = licence
+
+  let billLicence = billLicences.find((existingBillLicence) => {
+    return existingBillLicence.licenceId === licenceId
+  })
+
+  if (!billLicence) {
+    billLicence = {
+      id: generateUUID(),
+      billId,
+      licenceId,
+      licenceRef,
+      billable: false
+    }
+
+    billLicences.push(billLicence)
+  }
+
+  return billLicence
+}
+
+function _generateTransactionData (billLicenceId, chargePeriod, chargeVersion) {
+  try {
+    const firstChargeOnNewLicence = DetermineMinimumChargeService.go(chargeVersion, chargePeriod)
+
+    const transactions = []
+
+    chargeVersion.chargeReferences.forEach((chargeReference) => {
+      const transaction = GenerateTransactionService.go(
+        billLicenceId,
+        chargeReference,
+        chargePeriod,
+        firstChargeOnNewLicence,
+        chargeVersion.licence.waterUndertaker
+      )
+
+      transactions.push(transaction)
+    })
+
+    return transactions
+  } catch (error) {
+    throw new BillRunError(error, BillRunModel.errorCodes.failedToPrepareTransactions)
+  }
+}
+
+async function _processBillingAccount (billingAccount, billRun, billingPeriod) {
+  const { id: billingAccountId, accountNumber } = billingAccount
+  const { id: billRunId, externalId: billRunExternalId } = billRun
+
+  const bill = {
+    id: generateUUID(),
+    accountNumber,
+    address: {}, // Address is set to an empty object for SROC billing invoices
+    billingAccountId,
+    billRunId,
+    credit: false,
+    financialYearEnding: billingPeriod.endDate.getFullYear()
+  }
+
+  const billData = await _createBillLicencesAndTransactions(bill.id, billingAccount, billRunExternalId, billingPeriod)
+
+  const { billLicences, transactions } = billData
+
+  // No transactions were generated so there is nothing to bill. Do not persist anything!
+  if (transactions.length === 0) {
+    return false
+  }
+
+  return _persistBillData(bill, billLicences, transactions)
+}
+
+async function _persistBillData (bill, billLicences, transactions) {
+  await BillModel.query().insert(bill)
+  await BillLicenceModel.query().insert(billLicences)
+  await TransactionModel.query().insert(transactions)
+
+  return true
+}
+
+module.exports = {
+  go
+}

--- a/app/services/bill-runs/two-part-tariff/send-transactions.service.js
+++ b/app/services/bill-runs/two-part-tariff/send-transactions.service.js
@@ -1,0 +1,37 @@
+'use strict'
+
+/**
+ * Sends transactions to the Charging Module
+ * @module SendTransactionsService
+ */
+
+const BillRunError = require('../../../errors/bill-run.error.js')
+const BillRunModel = require('../../../models/bill-run.model.js')
+const ChargingModuleCreateTransactionPresenter = require('../../../presenters/charging-module/create-transaction.presenter.js')
+const { generateUUID } = require('../../../lib/general.lib.js')
+
+async function go (transactions, billRunExternalId, accountNumber, licence) {
+  const sendRequests = transactions.map((transaction) => {
+    return _sendTransactionToChargingModule(transaction, billRunExternalId, accountNumber, licence)
+  })
+
+  return Promise.all(sendRequests)
+}
+
+async function _sendTransactionToChargingModule (transaction, billRunExternalId, accountNumber, licence) {
+  try {
+    const chargingModuleRequest = ChargingModuleCreateTransactionPresenter.go(transaction, accountNumber, licence)
+    // console.log('🚀 ~ _sendTransactionToChargingModule ~ chargingModuleRequest:', chargingModuleRequest)
+
+    transaction.status = 'charge_created'
+    transaction.externalId = generateUUID()
+
+    return transaction
+  } catch (error) {
+    throw new BillRunError(error, BillRunModel.errorCodes.failedToCreateCharge)
+  }
+}
+
+module.exports = {
+  go
+}

--- a/app/views/bill-runs/review.njk
+++ b/app/views/bill-runs/review.njk
@@ -117,6 +117,14 @@
 
   {# Cancel bill run button #}
   <section class="govuk-!-margin-bottom-9">
+    {% if numberOfLicencesToReview === 0 %}
+      {{ govukButton({
+        classes: "govuk-!-margin-right-1 govuk-!-margin-bottom-0",
+        text: "Continue bill run",
+        href: "/system/bill-runs/" + billRunId  + "/two-part-tariff",
+        preventDoubleClick: true
+      }) }}
+    {% endif %}
     {{ govukButton({
       classes: "govuk-button--secondary govuk-!-margin-bottom-0",
       text: "Cancel bill run",

--- a/test/models/charge-element.model.test.js
+++ b/test/models/charge-element.model.test.js
@@ -14,6 +14,8 @@ const ChargeReferenceModel = require('../../app/models/charge-reference.model.js
 const DatabaseSupport = require('../support/database.js')
 const PurposeModel = require('../../app/models/purpose.model.js')
 const PurposeHelper = require('../support/helpers/purpose.helper.js')
+const ReviewChargeElementModel = require('../../app/models/review-charge-element.model.js')
+const ReviewChargeElementHelper = require('../support/helpers/review-charge-element.helper.js')
 
 // Thing under test
 const ChargeElementModel = require('../../app/models/charge-element.model.js')
@@ -23,11 +25,13 @@ describe('Charge Element model', () => {
 
   beforeEach(async () => {
     await DatabaseSupport.clean()
-
-    testRecord = await ChargeElementHelper.add()
   })
 
   describe('Basic query', () => {
+    beforeEach(async () => {
+      testRecord = await ChargeElementHelper.add()
+    })
+
     it('can successfully run a basic query', async () => {
       const result = await ChargeElementModel.query().findById(testRecord.id)
 
@@ -94,6 +98,41 @@ describe('Charge Element model', () => {
 
         expect(result.purpose).to.be.an.instanceOf(PurposeModel)
         expect(result.purpose).to.equal(testPurpose)
+      })
+    })
+
+    describe('when linking to review charge elements', () => {
+      let testReviewChargeElements
+
+      beforeEach(async () => {
+        testRecord = await ChargeElementHelper.add()
+
+        testReviewChargeElements = []
+        for (let i = 0; i < 2; i++) {
+          const reviewChargeElement = await ReviewChargeElementHelper.add({ chargeElementId: testRecord.id })
+          testReviewChargeElements.push(reviewChargeElement)
+        }
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await ChargeElementModel.query()
+          .innerJoinRelated('reviewChargeElements')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the review charge elements', async () => {
+        const result = await ChargeElementModel.query()
+          .findById(testRecord.id)
+          .withGraphFetched('reviewChargeElements')
+
+        expect(result).to.be.instanceOf(ChargeElementModel)
+        expect(result.id).to.equal(testRecord.id)
+
+        expect(result.reviewChargeElements).to.be.an.array()
+        expect(result.reviewChargeElements[0]).to.be.an.instanceOf(ReviewChargeElementModel)
+        expect(result.reviewChargeElements).to.include(testReviewChargeElements[0])
+        expect(result.reviewChargeElements).to.include(testReviewChargeElements[1])
       })
     })
   })

--- a/test/models/charge-version.model.test.js
+++ b/test/models/charge-version.model.test.js
@@ -20,6 +20,8 @@ const ChargeVersionHelper = require('../support/helpers/charge-version.helper.js
 const DatabaseSupport = require('../support/database.js')
 const LicenceHelper = require('../support/helpers/licence.helper.js')
 const LicenceModel = require('../../app/models/licence.model.js')
+const ReviewChargeVersionHelper = require('../support/helpers/review-charge-version.helper.js')
+const ReviewChargeVersionModel = require('../../app/models/review-charge-version.model.js')
 
 // Thing under test
 const ChargeVersionModel = require('../../app/models/charge-version.model.js')
@@ -29,11 +31,13 @@ describe('Charge Version model', () => {
 
   beforeEach(async () => {
     await DatabaseSupport.clean()
-
-    testRecord = await ChargeVersionHelper.add()
   })
 
   describe('Basic query', () => {
+    beforeEach(async () => {
+      testRecord = await ChargeVersionHelper.add()
+    })
+
     it('can successfully run a basic query', async () => {
       const result = await ChargeVersionModel.query().findById(testRecord.id)
 
@@ -77,11 +81,11 @@ describe('Charge Version model', () => {
       let testBillRunChargeVersionYears
 
       beforeEach(async () => {
-        const { id: chargeVersionId } = testRecord
+        testRecord = await ChargeVersionHelper.add()
 
         testBillRunChargeVersionYears = []
         for (let i = 0; i < 2; i++) {
-          const billRunChargeVersionYear = await BillRunChargeVersionYearHelper.add({ chargeVersionId })
+          const billRunChargeVersionYear = await BillRunChargeVersionYearHelper.add({ chargeVersionId: testRecord.id })
           testBillRunChargeVersionYears.push(billRunChargeVersionYear)
         }
       })
@@ -172,11 +176,11 @@ describe('Charge Version model', () => {
       let testChargeReferences
 
       beforeEach(async () => {
-        const { id } = testRecord
+        testRecord = await ChargeVersionHelper.add()
 
         testChargeReferences = []
         for (let i = 0; i < 2; i++) {
-          const chargeReference = await ChargeReferenceHelper.add({ description: `CE ${i}`, chargeVersionId: id })
+          const chargeReference = await ChargeReferenceHelper.add({ description: `CE ${i}`, chargeVersionId: testRecord.id })
           testChargeReferences.push(chargeReference)
         }
       })
@@ -200,6 +204,41 @@ describe('Charge Version model', () => {
         expect(result.chargeReferences[0]).to.be.an.instanceOf(ChargeReferenceModel)
         expect(result.chargeReferences).to.include(testChargeReferences[0])
         expect(result.chargeReferences).to.include(testChargeReferences[1])
+      })
+    })
+
+    describe('when linking to review charge versions', () => {
+      let testReviewChargeVersions
+
+      beforeEach(async () => {
+        testRecord = await ChargeVersionHelper.add()
+
+        testReviewChargeVersions = []
+        for (let i = 0; i < 2; i++) {
+          const reviewChargeVersion = await ReviewChargeVersionHelper.add({ chargeVersionId: testRecord.id })
+          testReviewChargeVersions.push(reviewChargeVersion)
+        }
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await ChargeVersionModel.query()
+          .innerJoinRelated('reviewChargeVersions')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the review charge versions', async () => {
+        const result = await ChargeVersionModel.query()
+          .findById(testRecord.id)
+          .withGraphFetched('reviewChargeVersions')
+
+        expect(result).to.be.instanceOf(ChargeVersionModel)
+        expect(result.id).to.equal(testRecord.id)
+
+        expect(result.reviewChargeVersions).to.be.an.array()
+        expect(result.reviewChargeVersions[0]).to.be.an.instanceOf(ReviewChargeVersionModel)
+        expect(result.reviewChargeVersions).to.include(testReviewChargeVersions[0])
+        expect(result.reviewChargeVersions).to.include(testReviewChargeVersions[1])
       })
     })
   })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4383

We've built the first part of the two-part tariff annual billing process: matching and allocating. Once users have reviewed the results and made any changes, we need to generate the actual bills.

We'e previously done that with SROC annual and supplementary and we know we can make use of a lot of it. But two-part tariff is different in that we already know which licences to include and key details need to come from the review results not the charging information.

So, this is a spike; hack together a 'working' billing engine that generates the bills using the review data.

We never intend to merge this change. But we'll use it to direct and inform the changes we do need to make.