### PR TITLE
Add charging model to review model relationships

### DIFF
--- a/app/models/charge-element.model.js
+++ b/app/models/charge-element.model.js
@@ -31,6 +31,14 @@ class ChargeElementModel extends BaseModel {
           from: 'chargeElements.purposeId',
           to: 'purposes.id'
         }
+      },
+      reviewChargeElements: {
+        relation: Model.HasManyRelation,
+        modelClass: 'review-charge-element.model',
+        join: {
+          from: 'chargeElements.id',
+          to: 'reviewChargeElements.chargeElementId'
+        }
       }
     }
   }

--- a/app/models/charge-reference.model.js
+++ b/app/models/charge-reference.model.js
@@ -24,14 +24,6 @@ class ChargeReferenceModel extends BaseModel {
           to: 'billRunVolumes.chargeReferenceId'
         }
       },
-      chargeVersion: {
-        relation: Model.BelongsToOneRelation,
-        modelClass: 'charge-version.model',
-        join: {
-          from: 'chargeReferences.chargeVersionId',
-          to: 'chargeVersions.id'
-        }
-      },
       chargeCategory: {
         relation: Model.BelongsToOneRelation,
         modelClass: 'charge-category.model',
@@ -46,6 +38,14 @@ class ChargeReferenceModel extends BaseModel {
         join: {
           from: 'chargeReferences.id',
           to: 'chargeElements.chargeReferenceId'
+        }
+      },
+      chargeVersion: {
+        relation: Model.BelongsToOneRelation,
+        modelClass: 'charge-version.model',
+        join: {
+          from: 'chargeReferences.chargeVersionId',
+          to: 'chargeVersions.id'
         }
       },
       purpose: {

--- a/app/models/charge-reference.model.js
+++ b/app/models/charge-reference.model.js
@@ -56,6 +56,14 @@ class ChargeReferenceModel extends BaseModel {
           to: 'purposes.id'
         }
       },
+      reviewChargeReferences: {
+        relation: Model.HasManyRelation,
+        modelClass: 'review-charge-reference.model',
+        join: {
+          from: 'chargeReferences.id',
+          to: 'reviewChargeReferences.chargeReferenceId'
+        }
+      },
       transactions: {
         relation: Model.HasManyRelation,
         modelClass: 'transaction.model',

--- a/app/models/charge-version.model.js
+++ b/app/models/charge-version.model.js
@@ -55,6 +55,14 @@ class ChargeVersionModel extends BaseModel {
           from: 'chargeVersions.licenceId',
           to: 'licences.id'
         }
+      },
+      reviewChargeVersions: {
+        relation: Model.HasManyRelation,
+        modelClass: 'review-charge-version.model',
+        join: {
+          from: 'chargeVersions.id',
+          to: 'reviewChargeVersions.chargeVersionId'
+        }
       }
     }
   }

--- a/app/models/charge-version.model.js
+++ b/app/models/charge-version.model.js
@@ -32,14 +32,6 @@ class ChargeVersionModel extends BaseModel {
           to: 'billRunChargeVersionYears.chargeVersionId'
         }
       },
-      licence: {
-        relation: Model.BelongsToOneRelation,
-        modelClass: 'licence.model',
-        join: {
-          from: 'chargeVersions.licenceId',
-          to: 'licences.id'
-        }
-      },
       changeReason: {
         relation: Model.BelongsToOneRelation,
         modelClass: 'change-reason.model',
@@ -54,6 +46,14 @@ class ChargeVersionModel extends BaseModel {
         join: {
           from: 'chargeVersions.id',
           to: 'chargeReferences.chargeVersionId'
+        }
+      },
+      licence: {
+        relation: Model.BelongsToOneRelation,
+        modelClass: 'licence.model',
+        join: {
+          from: 'chargeVersions.licenceId',
+          to: 'licences.id'
         }
       }
     }

--- a/test/models/charge-element.model.test.js
+++ b/test/models/charge-element.model.test.js
@@ -23,11 +23,13 @@ describe('Charge Element model', () => {
 
   beforeEach(async () => {
     await DatabaseSupport.clean()
-
-    testRecord = await ChargeElementHelper.add()
   })
 
   describe('Basic query', () => {
+    beforeEach(async () => {
+      testRecord = await ChargeElementHelper.add()
+    })
+
     it('can successfully run a basic query', async () => {
       const result = await ChargeElementModel.query().findById(testRecord.id)
 

--- a/test/models/charge-element.model.test.js
+++ b/test/models/charge-element.model.test.js
@@ -14,6 +14,8 @@ const ChargeReferenceModel = require('../../app/models/charge-reference.model.js
 const DatabaseSupport = require('../support/database.js')
 const PurposeModel = require('../../app/models/purpose.model.js')
 const PurposeHelper = require('../support/helpers/purpose.helper.js')
+const ReviewChargeElementModel = require('../../app/models/review-charge-element.model.js')
+const ReviewChargeElementHelper = require('../support/helpers/review-charge-element.helper.js')
 
 // Thing under test
 const ChargeElementModel = require('../../app/models/charge-element.model.js')
@@ -96,6 +98,41 @@ describe('Charge Element model', () => {
 
         expect(result.purpose).to.be.an.instanceOf(PurposeModel)
         expect(result.purpose).to.equal(testPurpose)
+      })
+    })
+
+    describe('when linking to review charge elements', () => {
+      let testReviewChargeElements
+
+      beforeEach(async () => {
+        testRecord = await ChargeElementHelper.add()
+
+        testReviewChargeElements = []
+        for (let i = 0; i < 2; i++) {
+          const reviewChargeElement = await ReviewChargeElementHelper.add({ chargeElementId: testRecord.id })
+          testReviewChargeElements.push(reviewChargeElement)
+        }
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await ChargeElementModel.query()
+          .innerJoinRelated('reviewChargeElements')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the review charge elements', async () => {
+        const result = await ChargeElementModel.query()
+          .findById(testRecord.id)
+          .withGraphFetched('reviewChargeElements')
+
+        expect(result).to.be.instanceOf(ChargeElementModel)
+        expect(result.id).to.equal(testRecord.id)
+
+        expect(result.reviewChargeElements).to.be.an.array()
+        expect(result.reviewChargeElements[0]).to.be.an.instanceOf(ReviewChargeElementModel)
+        expect(result.reviewChargeElements).to.include(testReviewChargeElements[0])
+        expect(result.reviewChargeElements).to.include(testReviewChargeElements[1])
       })
     })
   })

--- a/test/models/charge-reference.model.test.js
+++ b/test/models/charge-reference.model.test.js
@@ -148,6 +148,36 @@ describe('Charge Reference model', () => {
       })
     })
 
+    describe('when linking to charge version', () => {
+      let testChargeVersion
+
+      beforeEach(async () => {
+        testChargeVersion = await ChargeVersionHelper.add()
+
+        const { id: chargeVersionId } = testChargeVersion
+        testRecord = await ChargeReferenceHelper.add({ chargeVersionId })
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await ChargeReferenceModel.query()
+          .innerJoinRelated('chargeVersion')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the charge version', async () => {
+        const result = await ChargeReferenceModel.query()
+          .findById(testRecord.id)
+          .withGraphFetched('chargeVersion')
+
+        expect(result).to.be.instanceOf(ChargeReferenceModel)
+        expect(result.id).to.equal(testRecord.id)
+
+        expect(result.chargeVersion).to.be.an.instanceOf(ChargeVersionModel)
+        expect(result.chargeVersion).to.equal(testChargeVersion)
+      })
+    })
+
     describe('when linking to purpose', () => {
       let testPurpose
 
@@ -210,36 +240,6 @@ describe('Charge Reference model', () => {
         expect(result.transactions[0]).to.be.an.instanceOf(TransactionModel)
         expect(result.transactions).to.include(testTransactions[0])
         expect(result.transactions).to.include(testTransactions[1])
-      })
-    })
-
-    describe('when linking to charge version', () => {
-      let testChargeVersion
-
-      beforeEach(async () => {
-        testChargeVersion = await ChargeVersionHelper.add()
-
-        const { id: chargeVersionId } = testChargeVersion
-        testRecord = await ChargeReferenceHelper.add({ chargeVersionId })
-      })
-
-      it('can successfully run a related query', async () => {
-        const query = await ChargeReferenceModel.query()
-          .innerJoinRelated('chargeVersion')
-
-        expect(query).to.exist()
-      })
-
-      it('can eager load the charge version', async () => {
-        const result = await ChargeReferenceModel.query()
-          .findById(testRecord.id)
-          .withGraphFetched('chargeVersion')
-
-        expect(result).to.be.instanceOf(ChargeReferenceModel)
-        expect(result.id).to.equal(testRecord.id)
-
-        expect(result.chargeVersion).to.be.an.instanceOf(ChargeVersionModel)
-        expect(result.chargeVersion).to.equal(testChargeVersion)
       })
     })
   })

--- a/test/models/charge-reference.model.test.js
+++ b/test/models/charge-reference.model.test.js
@@ -31,11 +31,13 @@ describe('Charge Reference model', () => {
 
   beforeEach(async () => {
     await DatabaseSupport.clean()
-
-    testRecord = await ChargeReferenceHelper.add()
   })
 
   describe('Basic query', () => {
+    beforeEach(async () => {
+      testRecord = await ChargeReferenceHelper.add()
+    })
+
     it('can successfully run a basic query', async () => {
       const result = await ChargeReferenceModel.query().findById(testRecord.id)
 
@@ -115,11 +117,11 @@ describe('Charge Reference model', () => {
       let testChargeElements
 
       beforeEach(async () => {
-        const { id } = testRecord
+        testRecord = await ChargeReferenceHelper.add()
 
         testChargeElements = []
         for (let i = 0; i < 2; i++) {
-          const chargeElement = await ChargeElementHelper.add({ description: `CP ${i}`, chargeReferenceId: id })
+          const chargeElement = await ChargeElementHelper.add({ chargeReferenceId: testRecord.id })
           testChargeElements.push(chargeElement)
         }
       })
@@ -180,11 +182,11 @@ describe('Charge Reference model', () => {
       let testTransactions
 
       beforeEach(async () => {
-        const { id } = testRecord
+        testRecord = await ChargeReferenceHelper.add()
 
         testTransactions = []
         for (let i = 0; i < 2; i++) {
-          const transaction = await TransactionHelper.add({ description: `TEST TRANSACTION ${i}`, chargeReferenceId: id })
+          const transaction = await TransactionHelper.add({ chargeReferenceId: testRecord.id })
           testTransactions.push(transaction)
         }
       })

--- a/test/models/charge-reference.model.test.js
+++ b/test/models/charge-reference.model.test.js
@@ -20,6 +20,8 @@ const ChargeVersionModel = require('../../app/models/charge-version.model.js')
 const DatabaseSupport = require('../support/database.js')
 const PurposeModel = require('../../app/models/purpose.model.js')
 const PurposeHelper = require('../support/helpers/purpose.helper.js')
+const ReviewChargeReferenceModel = require('../../app/models/review-charge-reference.model.js')
+const ReviewChargeReferenceHelper = require('../support/helpers/review-charge-reference.helper.js')
 const TransactionHelper = require('../support/helpers/transaction.helper.js')
 const TransactionModel = require('../../app/models/transaction.model.js')
 
@@ -205,6 +207,41 @@ describe('Charge Reference model', () => {
 
         expect(result.purpose).to.be.an.instanceOf(PurposeModel)
         expect(result.purpose).to.equal(testPurpose)
+      })
+    })
+
+    describe('when linking to review charge references', () => {
+      let testReviewChargeReferences
+
+      beforeEach(async () => {
+        testRecord = await ChargeReferenceHelper.add()
+
+        testReviewChargeReferences = []
+        for (let i = 0; i < 2; i++) {
+          const reviewChargeReference = await ReviewChargeReferenceHelper.add({ chargeReferenceId: testRecord.id })
+          testReviewChargeReferences.push(reviewChargeReference)
+        }
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await ChargeReferenceModel.query()
+          .innerJoinRelated('reviewChargeReferences')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the review charge references', async () => {
+        const result = await ChargeReferenceModel.query()
+          .findById(testRecord.id)
+          .withGraphFetched('reviewChargeReferences')
+
+        expect(result).to.be.instanceOf(ChargeReferenceModel)
+        expect(result.id).to.equal(testRecord.id)
+
+        expect(result.reviewChargeReferences).to.be.an.array()
+        expect(result.reviewChargeReferences[0]).to.be.an.instanceOf(ReviewChargeReferenceModel)
+        expect(result.reviewChargeReferences).to.include(testReviewChargeReferences[0])
+        expect(result.reviewChargeReferences).to.include(testReviewChargeReferences[1])
       })
     })
 

--- a/test/models/charge-version.model.test.js
+++ b/test/models/charge-version.model.test.js
@@ -20,6 +20,8 @@ const ChargeVersionHelper = require('../support/helpers/charge-version.helper.js
 const DatabaseSupport = require('../support/database.js')
 const LicenceHelper = require('../support/helpers/licence.helper.js')
 const LicenceModel = require('../../app/models/licence.model.js')
+const ReviewChargeVersionHelper = require('../support/helpers/review-charge-version.helper.js')
+const ReviewChargeVersionModel = require('../../app/models/review-charge-version.model.js')
 
 // Thing under test
 const ChargeVersionModel = require('../../app/models/charge-version.model.js')
@@ -202,6 +204,41 @@ describe('Charge Version model', () => {
 
         expect(result.licence).to.be.an.instanceOf(LicenceModel)
         expect(result.licence).to.equal(testLicence)
+      })
+    })
+
+    describe('when linking to review charge versions', () => {
+      let testReviewChargeVersions
+
+      beforeEach(async () => {
+        testRecord = await ChargeVersionHelper.add()
+
+        testReviewChargeVersions = []
+        for (let i = 0; i < 2; i++) {
+          const reviewChargeVersion = await ReviewChargeVersionHelper.add({ chargeVersionId: testRecord.id })
+          testReviewChargeVersions.push(reviewChargeVersion)
+        }
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await ChargeVersionModel.query()
+          .innerJoinRelated('reviewChargeVersions')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the review charge versions', async () => {
+        const result = await ChargeVersionModel.query()
+          .findById(testRecord.id)
+          .withGraphFetched('reviewChargeVersions')
+
+        expect(result).to.be.instanceOf(ChargeVersionModel)
+        expect(result.id).to.equal(testRecord.id)
+
+        expect(result.reviewChargeVersions).to.be.an.array()
+        expect(result.reviewChargeVersions[0]).to.be.an.instanceOf(ReviewChargeVersionModel)
+        expect(result.reviewChargeVersions).to.include(testReviewChargeVersions[0])
+        expect(result.reviewChargeVersions).to.include(testReviewChargeVersions[1])
       })
     })
   })

--- a/test/models/charge-version.model.test.js
+++ b/test/models/charge-version.model.test.js
@@ -29,11 +29,13 @@ describe('Charge Version model', () => {
 
   beforeEach(async () => {
     await DatabaseSupport.clean()
-
-    testRecord = await ChargeVersionHelper.add()
   })
 
   describe('Basic query', () => {
+    beforeEach(async () => {
+      testRecord = await ChargeVersionHelper.add()
+    })
+
     it('can successfully run a basic query', async () => {
       const result = await ChargeVersionModel.query().findById(testRecord.id)
 
@@ -77,11 +79,11 @@ describe('Charge Version model', () => {
       let testBillRunChargeVersionYears
 
       beforeEach(async () => {
-        const { id: chargeVersionId } = testRecord
+        testRecord = await ChargeVersionHelper.add()
 
         testBillRunChargeVersionYears = []
         for (let i = 0; i < 2; i++) {
-          const billRunChargeVersionYear = await BillRunChargeVersionYearHelper.add({ chargeVersionId })
+          const billRunChargeVersionYear = await BillRunChargeVersionYearHelper.add({ chargeVersionId: testRecord.id })
           testBillRunChargeVersionYears.push(billRunChargeVersionYear)
         }
       })
@@ -172,11 +174,11 @@ describe('Charge Version model', () => {
       let testChargeReferences
 
       beforeEach(async () => {
-        const { id } = testRecord
+        testRecord = await ChargeVersionHelper.add()
 
         testChargeReferences = []
         for (let i = 0; i < 2; i++) {
-          const chargeReference = await ChargeReferenceHelper.add({ description: `CE ${i}`, chargeVersionId: id })
+          const chargeReference = await ChargeReferenceHelper.add({ chargeVersionId: testRecord.id })
           testChargeReferences.push(chargeReference)
         }
       })

--- a/test/models/charge-version.model.test.js
+++ b/test/models/charge-version.model.test.js
@@ -110,36 +110,6 @@ describe('Charge Version model', () => {
       })
     })
 
-    describe('when linking to licence', () => {
-      let testLicence
-
-      beforeEach(async () => {
-        testLicence = await LicenceHelper.add()
-
-        const { id: licenceId } = testLicence
-        testRecord = await ChargeVersionHelper.add({ licenceId })
-      })
-
-      it('can successfully run a related query', async () => {
-        const query = await ChargeVersionModel.query()
-          .innerJoinRelated('licence')
-
-        expect(query).to.exist()
-      })
-
-      it('can eager load the licence', async () => {
-        const result = await ChargeVersionModel.query()
-          .findById(testRecord.id)
-          .withGraphFetched('licence')
-
-        expect(result).to.be.instanceOf(ChargeVersionModel)
-        expect(result.id).to.equal(testRecord.id)
-
-        expect(result.licence).to.be.an.instanceOf(LicenceModel)
-        expect(result.licence).to.equal(testLicence)
-      })
-    })
-
     describe('when linking to change reason', () => {
       let testChangeReason
 
@@ -202,6 +172,36 @@ describe('Charge Version model', () => {
         expect(result.chargeReferences[0]).to.be.an.instanceOf(ChargeReferenceModel)
         expect(result.chargeReferences).to.include(testChargeReferences[0])
         expect(result.chargeReferences).to.include(testChargeReferences[1])
+      })
+    })
+
+    describe('when linking to licence', () => {
+      let testLicence
+
+      beforeEach(async () => {
+        testLicence = await LicenceHelper.add()
+
+        const { id: licenceId } = testLicence
+        testRecord = await ChargeVersionHelper.add({ licenceId })
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await ChargeVersionModel.query()
+          .innerJoinRelated('licence')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the licence', async () => {
+        const result = await ChargeVersionModel.query()
+          .findById(testRecord.id)
+          .withGraphFetched('licence')
+
+        expect(result).to.be.instanceOf(ChargeVersionModel)
+        expect(result.id).to.equal(testRecord.id)
+
+        expect(result.licence).to.be.an.instanceOf(LicenceModel)
+        expect(result.licence).to.equal(testLicence)
       })
     })
   })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4196

> Part of the work for two-part tariff annual billing

Our billing engines work on the basis of starting by selecting the appropriate billing accounts, then the data needed to generate bills for them.

This means we are going from charging information (charge versions, references and elements) _to_ review information (also charge versions, references and elements!)

When we created the review models, we included the relationships to link them to charging information. But we didn't do the same on the charging side.

In order to generate the bills, we need to be able to link from that direction hence this change.