### PR TITLE
Add Continue bill run btn to 2PT review screen

### DIFF
--- a/app/presenters/bill-runs/two-part-tariff/review-bill-run.presenter.js
+++ b/app/presenters/bill-runs/two-part-tariff/review-bill-run.presenter.js
@@ -75,6 +75,7 @@ function _prepareLicences (licences) {
 
 function _prepareBillRun (billRun, preparedLicences) {
   return {
+    billRunId: billRun.id,
     region: billRun.region.displayName,
     status: billRun.status,
     dateCreated: formatLongDate(billRun.createdAt),

--- a/app/views/bill-runs/review.njk
+++ b/app/views/bill-runs/review.njk
@@ -107,8 +107,16 @@
     }) }}
   </section>
 
-  {# Cancel bill run button #}
+  {# Continue and Cancel bill run buttons #}
   <section class="govuk-!-margin-bottom-9">
+    {% if numberOfLicencesToReview === 0 %}
+      {{ govukButton({
+        classes: "govuk-!-margin-right-1 govuk-!-margin-bottom-0",
+        text: "Continue bill run",
+        href: "/system/bill-runs/" + billRunId  + "/two-part-tariff",
+        preventDoubleClick: true
+      }) }}
+    {% endif %}
     {{ govukButton({
       classes: "govuk-button--secondary govuk-!-margin-bottom-0",
       text: "Cancel bill run",

--- a/test/presenters/bill-runs/two-part-tariff/review-bill-run.presenter.test.js
+++ b/test/presenters/bill-runs/two-part-tariff/review-bill-run.presenter.test.js
@@ -40,6 +40,7 @@ describe('Review Bill Run presenter', () => {
         )
 
         expect(result).to.equal({
+          billRunId: 'b21bd372-cd04-405d-824e-5180d854121c',
           region: 'Southern (Test replica)',
           status: 'review',
           dateCreated: '17 January 2024',


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4196

> Part of the work for two-part tariff annual billing

Now that we are ready to generate bills and have the bill run from our two-part tariff review data we need to give the user the button to trigger it!

The button should only be visible when there are no review issues remaining. This change adds the button to the review view template.