### PR TITLE
Add new two-part tariff generate bill run endpoint

### DIFF
--- a/app/controllers/bill-runs.controller.js
+++ b/app/controllers/bill-runs.controller.js
@@ -14,6 +14,7 @@ const CalculateChargeService = require('../services/bill-runs/two-part-tariff/ca
 const CancelBillRunService = require('../services/bill-runs/cancel-bill-run.service.js')
 const ChargeReferenceDetailsService = require('../services/bill-runs/two-part-tariff/charge-reference-details.service.js')
 const CreateBillRunValidator = require('../validators/create-bill-run.validator.js')
+const GenerateBillRunService = require('../services/bill-runs/two-part-tariff/generate-bill-run.service.js')
 const IndexBillRunsService = require('../services/bill-runs/index-bill-runs.service.js')
 const MatchDetailsService = require('../services/bill-runs/two-part-tariff/match-details.service.js')
 const RemoveBillRunLicenceService = require('../services/bill-runs/two-part-tariff/remove-bill-run-licence.service.js')
@@ -295,6 +296,21 @@ async function submitSend (request, h) {
   }
 }
 
+async function twoPartTariff (request, h) {
+  const { id } = request.params
+
+  try {
+    // NOTE: What we are awaiting here is for the GenerateBillRunService to update the status of the bill run to
+    // `processing'.
+    await GenerateBillRunService.go(id)
+
+    // Redirect to the bill runs page
+    return h.redirect('/system/bill-runs')
+  } catch (error) {
+    return Boom.badImplementation(error.message)
+  }
+}
+
 async function view (request, h) {
   const { id } = request.params
 
@@ -328,5 +344,6 @@ module.exports = {
   submitRemoveLicence,
   submitReviewLicence,
   submitSend,
+  twoPartTariff,
   view
 }

--- a/app/routes/bill-runs.routes.js
+++ b/app/routes/bill-runs.routes.js
@@ -269,6 +269,18 @@ const routes = [
         }
       }
     }
+  },
+  {
+    method: 'GET',
+    path: '/bill-runs/{id}/two-part-tariff',
+    handler: BillRunsController.twoPartTariff,
+    options: {
+      auth: {
+        access: {
+          scope: ['billing']
+        }
+      }
+    }
   }
 ]
 

--- a/app/services/bill-runs/two-part-tariff/generate-bill-run.service.js
+++ b/app/services/bill-runs/two-part-tariff/generate-bill-run.service.js
@@ -1,0 +1,23 @@
+'use strict'
+
+/**
+ * Generates a two-part tariff bill run after the users have completed reviewing its match & allocate results
+ * @module GenerateBillRunService
+ */
+
+/**
+ * Generates a two-part tariff bill run after the users have completed reviewing its match & allocate results
+ *
+ * > This is currently a shell that that we intend to expand in subsequent commits
+ *
+ * @param {string} billRunId - The UUID of the two-part tariff bill run in review
+ *
+ * @returns {Promise} the promise returned is not intended to resolve to any particular value
+ */
+async function go (billRunId) {
+  return billRunId
+}
+
+module.exports = {
+  go
+}

--- a/test/controllers/bill-runs.controller.test.js
+++ b/test/controllers/bill-runs.controller.test.js
@@ -16,6 +16,7 @@ const Boom = require('@hapi/boom')
 const CalculateChargeService = require('../../app/services/bill-runs/two-part-tariff/calculate-charge.service.js')
 const CancelBillRunService = require('../../app/services/bill-runs/cancel-bill-run.service.js')
 const ChargeReferenceDetailsService = require('../../app/services/bill-runs/two-part-tariff/charge-reference-details.service.js')
+const GenerateBillRunService = require('../../app/services/bill-runs/two-part-tariff/generate-bill-run.service.js')
 const IndexBillRunsService = require('../../app/services/bill-runs/index-bill-runs.service.js')
 const MatchDetailsService = require('../../app/services/bill-runs/two-part-tariff/match-details.service.js')
 const RemoveBillRunLicenceService = require('../../app/services/bill-runs/two-part-tariff/remove-bill-run-licence.service.js')
@@ -792,6 +793,43 @@ describe('Bill Runs controller', () => {
           beforeEach(async () => {
             Sinon.stub(Boom, 'badImplementation').returns(new Boom.Boom('Bang', { statusCode: 500 }))
             Sinon.stub(SubmitSendBillRunService, 'go').rejects()
+          })
+
+          it('returns the error page', async () => {
+            const response = await server.inject(options)
+
+            expect(response.statusCode).to.equal(200)
+            expect(response.payload).to.contain('Sorry, there is a problem with the service')
+          })
+        })
+      })
+    })
+  })
+
+  describe('/bill-runs/{id}/two-part-tariff', () => {
+    describe('GET', () => {
+      beforeEach(async () => {
+        options = _options('GET', 'two-part-tariff')
+      })
+
+      describe('when a request is valid', () => {
+        beforeEach(() => {
+          Sinon.stub(GenerateBillRunService, 'go').resolves('97db1a27-8308-4aba-b463-8a6af2558b28')
+        })
+
+        it('redirects to the bill runs page', async () => {
+          const response = await server.inject(options)
+
+          expect(response.statusCode).to.equal(302)
+          expect(response.headers.location).to.equal('/system/bill-runs')
+        })
+      })
+
+      describe('when the request fails', () => {
+        describe('because the generate service threw an error', () => {
+          beforeEach(async () => {
+            Sinon.stub(Boom, 'badImplementation').returns(new Boom.Boom('Bang', { statusCode: 500 }))
+            Sinon.stub(GenerateBillRunService, 'go').rejects()
           })
 
           it('returns the error page', async () => {

--- a/test/services/bill-runs/two-part-tariff/generate-bill-run.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/generate-bill-run.service.test.js
@@ -1,0 +1,23 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Thing under test
+const GenerateBillRunService = require('../../../../app/services/bill-runs/two-part-tariff/generate-bill-run.service.js')
+
+describe('Generate Bill Run Service', () => {
+  const billRunId = 'efe4d4b3-cca6-47ba-bcf6-9b848ffb535c'
+
+  describe('when called', () => {
+    it('returns the bill run ID passed to it', async () => {
+      const result = await GenerateBillRunService.go(billRunId)
+
+      expect(result).to.equal(billRunId)
+    })
+  })
+})


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4196

> Part of the work for two-part tariff annual billing

We're ready to generate a bill run from our two-part tariff review data and with [Add Continue bill run btn to 2PT review screen](https://github.com/DEFRA/water-abstraction-system/pull/1122) we have the means to trigger it.

Next, we need the endpoint that the button will hit. This change adds the endpoint (route and controller) plus a 'shell' `GenerateBillRunService` we can start to develop in subsequent changes.