### PR TITLE
Fix Ret. Req. logic to determine cycle for 2PT

### DIFF
--- a/app/services/return-requirements/setup/generate-from-abstraction-data.service.js
+++ b/app/services/return-requirements/setup/generate-from-abstraction-data.service.js
@@ -102,7 +102,7 @@ function _returnsCycle (startMonth, endMonth) {
  * |100 - 2500|Daily     |Daily    |
  * |Above 2500|Daily     |Daily    |
  *
- * ### Irrigation with two-part tariff
+ * ### Irrigation with two-part tariff (purpose is 2PT _and_ licence has 2PT agreement)
  *
  * |CM per day|Collection|Reporting|
  * |----------|----------|---------|
@@ -119,13 +119,17 @@ function _returnsCycle (startMonth, endMonth) {
  * |Above 2500|Weekly    |Weekly   |
  *
  */
-function _frequencyCollected (licenceVersionPurpose, waterUndertaker) {
+function _frequencyCollected (licence, licenceVersionPurpose) {
+  const { twoPartTariffAgreement, waterUndertaker } = licence
   const { dailyQuantity, purpose } = licenceVersionPurpose
 
-  // Licensee is a water company, the purpose is for electricity generation or two=part tariff irrigation
-  if (waterUndertaker ||
-    licenceVersionPurpose.$electricityGeneration() ||
-    TWO_PART_IRRIGATION_IDS.includes(purpose.legacyId)) {
+  // Licensee is a water company or the purpose is for electricity generation
+  if (waterUndertaker || licenceVersionPurpose.$electricityGeneration()) {
+    return returnRequirementFrequencies.day
+  }
+
+  // Licensee has a two-part tariff agreement and the purpose is two-part tariff
+  if (twoPartTariffAgreement && TWO_PART_IRRIGATION_IDS.includes(purpose.legacyId)) {
     return returnRequirementFrequencies.day
   }
 
@@ -144,7 +148,8 @@ function _frequencyCollected (licenceVersionPurpose, waterUndertaker) {
  *
  * See the tables in _frequencyCollected() for details
  */
-function _frequencyReported (licenceVersionPurpose, waterUndertaker) {
+function _frequencyReported (licence, licenceVersionPurpose) {
+  const { waterUndertaker } = licence
   const { dailyQuantity } = licenceVersionPurpose
 
   // Licensee is a water company or the purpose is for electricity generation
@@ -244,8 +249,8 @@ function _transformForSetup (licence) {
         'start-abstraction-period-day': startDay,
         'start-abstraction-period-month': startMonth
       },
-      frequencyReported: _frequencyReported(licenceVersionPurpose, licence.waterUndertaker),
-      frequencyCollected: _frequencyCollected(licenceVersionPurpose, licence.waterUndertaker),
+      frequencyReported: _frequencyReported(licence, licenceVersionPurpose),
+      frequencyCollected: _frequencyCollected(licence, licenceVersionPurpose),
       agreementsExceptions: _agreementExceptions(licence)
     }
   })

--- a/test/services/return-requirements/setup/generate-from-abstraction-data.service.test.js
+++ b/test/services/return-requirements/setup/generate-from-abstraction-data.service.test.js
@@ -78,7 +78,7 @@ describe('Return Requirements - Generate From Abstraction Data service', () => {
               'start-abstraction-period-month': 5
             },
             frequencyReported: 'monthly',
-            frequencyCollected: 'daily',
+            frequencyCollected: 'monthly',
             agreementsExceptions: ['none']
           }
         ])
@@ -99,6 +99,17 @@ describe('Return Requirements - Generate From Abstraction Data service', () => {
         expect(result[0].agreementsExceptions).to.equal(['two-part-tariff'])
         expect(result[1].agreementsExceptions).to.equal(['two-part-tariff'])
         expect(result[2].agreementsExceptions).to.equal(['two-part-tariff'])
+      })
+
+      it('sets the collection frequency to "daily" for the two-part tariff spray purpose', async () => {
+        const result = await GenerateFromAbstractionDataService.go(licenceId)
+
+        // We assert the others haven't changed because of this
+        expect(result[0].frequencyCollected).to.equal('daily')
+        expect(result[1].frequencyCollected).to.equal('weekly')
+
+        // We then assert that the 3rd requirement has changed because of this
+        expect(result[2].frequencyCollected).to.equal('daily')
       })
     })
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4512

> Part of the work to replace NALD for handling return requirements

We want to be able to offer users the option to generate return requirements from the licence's abstraction data. On the `/setup` page, they can select this option, and the service is expected to generate return requirements using the source abstraction data against the licence.

We added support for this in [Use abstraction data to create return requirements](https://github.com/DEFRA/water-abstraction-system/pull/1107). But after double-checking the test scenarios we've made a mistake in the logic.

We've determined a return requirement will be linked to a purpose that is two-part tariff purely based on the purpose's two-part tariff flag. This effects the collection and reporting cycle we pick for the return requirement.

But the purpose can only be interpreted as two-part tariff if the licence also has a two-part tariff agreement. So, the purpose might be spray irrigation, for example, which is flagged as two-part tariff. But if the licence doesn't also have a two-part tariff agreement we need to ignore that when determining the cycles for the return requirement.

This change fixes our logic in `GenerateFromAbstractionDataService`.