### PR TITLE
Update validation msg for ret. req. copy existing

### DIFF
--- a/app/validators/return-requirements/existing.validator.js
+++ b/app/validators/return-requirements/existing.validator.js
@@ -7,7 +7,7 @@
 
 const Joi = require('joi')
 
-const errorMessage = 'Select a previous requirements for returns'
+const errorMessage = 'Select a return version'
 
 /**
  * Validates data submitted for the `/return-requirements/{sessionId}/existing` page

--- a/test/services/return-requirements/submit-existing.service.test.js
+++ b/test/services/return-requirements/submit-existing.service.test.js
@@ -100,7 +100,7 @@ describe('Return Requirements - Submit Existing service', () => {
         it('includes an error for the input element', async () => {
           const result = await SubmitExistingService.go(session.id, payload)
 
-          expect(result.error).to.equal({ text: 'Select a previous requirements for returns' })
+          expect(result.error).to.equal({ text: 'Select a return version' })
         })
       })
     })

--- a/test/validators/return-requirements/existing.validator.test.js
+++ b/test/validators/return-requirements/existing.validator.test.js
@@ -36,7 +36,7 @@ describe('Existing validator', () => {
 
         expect(result.value).to.exist()
         expect(result.error).to.exist()
-        expect(result.error.details[0].message).to.equal('Select a previous requirements for returns')
+        expect(result.error.details[0].message).to.equal('Select a return version')
       })
     })
 
@@ -46,7 +46,7 @@ describe('Existing validator', () => {
 
         expect(result.value).to.exist()
         expect(result.error).to.exist()
-        expect(result.error.details[0].message).to.equal('Select a previous requirements for returns')
+        expect(result.error.details[0].message).to.equal('Select a return version')
       })
     })
   })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4283

In [Update validation msg for ret. req. copy existing](https://github.com/DEFRA/water-abstraction-system/pull/1112) we updated the validation message if a user doesn't select an option in the copy existing return requirements page to "Select a previous requirements for returns".

Our design team, however, were originally going to use "Select a return version". Having seen the updated text it in the flesh, they've decided to go with their original plan.

This change sets the validation message to be "Select a return version".