### PR TITLE
Update two-part tariff review pages to add Cypress data test attributes 

### DIFF
--- a/app/views/bill-runs/review-licence.njk
+++ b/app/views/bill-runs/review-licence.njk
@@ -356,14 +356,14 @@
                       text: "Total billable returns"
                     },
                     value: {
-                      html: '<div data-test="total-billable-returns-' + chargeReferenceIndex + '">' + chargeReference.totalBillableReturns + '</div>'
+                      html: '<div data-test="charge-version-' + chargeVersionIndex + '-total-billable-returns-' + chargeReferenceIndex + '">' + chargeReference.totalBillableReturns + '</div>'
                     },
                     actions: {
                       items: [
                         {
                           href: licence.licenceId + '/charge-reference-details/' + chargeReference.id,
                           text: chargeReference.chargeReferenceLink.linkName,
-                          attributes: { 'data-test': 'charge-reference-link-' + chargeReferenceIndex }
+                          attributes: { 'data-test': 'charge-version-' + chargeVersionIndex + '-charge-reference-link-' + chargeReferenceIndex }
                         }
                       ]
                     }
@@ -374,7 +374,7 @@
 
                   <div class="govuk-!-margin-top-0">
                     {{ govukSummaryList({
-                      attributes: { 'data-test': 'charge-reference-' + chargeReferenceIndex },
+                      attributes: { 'data-test': 'charge-version-' + chargeVersionIndex + '-charge-reference-' + chargeReferenceIndex },
                       classes: "govuk-!-margin-bottom-9 govuk-section-break govuk-section-break--visible",
                       rows: rows
                     }) }}
@@ -386,14 +386,14 @@
                     {% set elementRows = [] %}
 
                     <div class="govuk-!-margin-top-6">
-                      <span class="govuk-body govuk-!-font-weight-regular" data-test="element-count-{{ chargeElementIndex }}">{{chargeElement.elementNumber}}</span>
+                      <span class="govuk-body govuk-!-font-weight-regular" data-test="charge-version-{{ chargeVersionIndex }}-charge-reference-{{chargeReferenceIndex}}-element-count-{{ chargeElementIndex }}">{{chargeElement.elementNumber}}</span>
                       <span class="float-right">
                         {{ statusTag(chargeElement.elementStatus) }}
                       </span>
-                      <h3 class="govuk-heading-s govuk-!-margin-bottom-1" data-test="element-description-{{ chargeElementIndex }}">{{chargeElement.elementDescription}}
+                      <h3 class="govuk-heading-s govuk-!-margin-bottom-1" data-test="charge-version-{{ chargeVersionIndex }}-charge-reference-{{chargeReferenceIndex}}-element-description-{{ chargeElementIndex }}">{{chargeElement.elementDescription}}
                         <div>
                           {% for chargeElementDate in chargeElement.dates %}
-                            <div data-test="element-dates-{{ chargeElementIndex }}">{{ chargeElementDate }}</div>
+                            <div data-test="charge-version-{{ chargeVersionIndex }}-charge-reference-{{chargeReferenceIndex}}-element-dates-{{ chargeElementIndex }}">{{ chargeElementDate }}</div>
                           {% endfor %}
                         </div>
                         {{ chargeElement.purpose }}
@@ -415,7 +415,7 @@
                             text: 'Issues'
                           },
                           value: {
-                            html: '<div data-test="charge-element-issues-' + chargeElementIndex + '">' + issues + '</div>'
+                            html: '<div data-test="charge-version-' + chargeVersionIndex + '-charge-reference-' + chargeReferenceIndex + '-charge-element-issues-' + chargeElementIndex + '">' + issues + '</div>'
                           }
                         },
                         {
@@ -423,13 +423,13 @@
                             text: 'Billable returns'
                           },
                           value: {
-                            html: '<div data-test="charge-element-billable-returns-' + chargeElementIndex + '">' + chargeElement.billableReturns + '</div>'
+                            html: '<div data-test="charge-version-' + chargeVersionIndex + '-charge-reference-' + chargeReferenceIndex + '-charge-element-billable-returns-' + chargeElementIndex + '">' + chargeElement.billableReturns + '</div>'
                           },
                           actions: {
                             items: [
                             {
                               href: licence.licenceId + '/match-details/' + chargeElement.reviewChargeElementId,
-                              html: '<div data-test="charge-element-match-details-' + chargeElementIndex + '">View match details</div>'
+                              html: '<div data-test="charge-version-' + chargeVersionIndex + '-charge-reference-' + chargeReferenceIndex + '-charge-element-match-details-' + chargeElementIndex + '">View match details</div>'
                             }
                           ]}
                         },
@@ -438,13 +438,13 @@
                             text: 'Return volume'
                           },
                           value: {
-                            html: '<div data-test="charge-element-return-volumes-' + chargeElementIndex + '">' + returnVolumes + '</div>'
+                            html: '<div data-test="charge-version-' + chargeVersionIndex + '-charge-reference-' + chargeReferenceIndex + '-charge-element-return-volumes-' + chargeElementIndex + '">' + returnVolumes + '</div>'
                           }
                         }]
                       %}
 
                       {{ govukSummaryList({
-                        attributes: { 'data-test': 'charge-element-' + chargeElementIndex },
+                        attributes: { 'data-test': 'charge-version-' + chargeVersionIndex + '-charge-reference-' + chargeReferenceIndex + '-charge-element-' + chargeElementIndex },
                         classes: "govuk-!-margin-bottom-9",
                         rows: elementRow
                       }) }}

--- a/app/views/bill-runs/review-licence.njk
+++ b/app/views/bill-runs/review-licence.njk
@@ -345,7 +345,7 @@
             <div class="govuk-grid-column-full">
               <div class="govuk-summary-card ">
                 <div class="govuk-summary-card__title-wrapper ">
-                  <h3 class="govuk-summary-card__title"><span class="govuk-!-font-weight-regular" data-test="reference-{{ chargeReferenceIndex }}">{{chargeReference.chargeCategory}}</span><div data-test="charge-description-{{ chargeReferenceIndex }}">{{chargeReference.chargeDescription}}</div></h3>
+                  <h3 class="govuk-summary-card__title"><span class="govuk-!-font-weight-regular" data-test="charge-version-{{ chargeVersionIndex }}-reference-{{ chargeReferenceIndex }}">{{chargeReference.chargeCategory}}</span><div data-test="charge-version-{{ chargeVersionIndex }}-charge-description-{{ chargeReferenceIndex }}">{{chargeReference.chargeDescription}}</div></h3>
                 </div>
 
                 <div class="govuk-summary-card__content govuk-!-padding-top-0">

--- a/app/views/bill-runs/review-licence.njk
+++ b/app/views/bill-runs/review-licence.njk
@@ -310,7 +310,7 @@
         {% set chargeReferenceText = "charge references " if chargeVersion.chargeReferences.length > 1 else "charge reference " %}
         {% set chargeElementText = "charge elements " if chargeVersion.chargeElementCount > 1 else "charge element " %}
 
-        <div class="govuk-heading-m govuk-!-margin-bottom-1">{{chargeVersion.chargeReferences.length}} {{chargeReferenceText}} with {{chargeVersion.chargeElementCount}} two-part tariff {{chargeElementText}}</div>
+        <div class="govuk-heading-m govuk-!-margin-bottom-1" data-test="charge-version-{{ chargeVersionIndex }}-details">{{chargeVersion.chargeReferences.length}} {{chargeReferenceText}} with {{chargeVersion.chargeElementCount}} two-part tariff {{chargeElementText}}</div>
 
         {# Billing account details #}
         {% set billingAccountLink = '/billing-accounts/' + chargeVersion.billingAccountDetails.billingAccountId %}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4450

We've finished building all the pages for the two-part tariff review and are now working on the acceptance tests. While writing these tests, we found a few places where the data test attribute on the view needs to be updated to make it clearer and easier to find in the acceptance tests file.