### PR TITLE
Add orderBy to data fetched for two-part tariff review 

### DIFF
--- a/app/services/bill-runs/two-part-tariff/fetch-review-licence-results.service.js
+++ b/app/services/bill-runs/two-part-tariff/fetch-review-licence-results.service.js
@@ -69,7 +69,15 @@ async function _fetchReviewLicence (licenceId, billRunId) {
     .where('licenceId', licenceId)
     .where('billRunId', billRunId)
     .withGraphFetched('reviewReturns.reviewChargeElements')
+    .modifyGraph('reviewReturns', (builder) => {
+      builder.orderBy('reviewReturns.startDate', 'asc')
+    })
     .withGraphFetched('reviewChargeVersions')
+    .modifyGraph('reviewChargeVersions', (builder) => {
+      builder
+        .join('chargeVersions', 'reviewChargeVersions.chargeVersionId', 'chargeVersions.id')
+        .orderBy('chargeVersions.startDate', 'asc')
+    })
     .withGraphFetched('reviewChargeVersions.chargeVersion')
     .modifyGraph('reviewChargeVersions.chargeVersion', (builder) => {
       builder.select([
@@ -77,6 +85,12 @@ async function _fetchReviewLicence (licenceId, billRunId) {
       ])
     })
     .withGraphFetched('reviewChargeVersions.reviewChargeReferences')
+    .modifyGraph('reviewChargeVersions.reviewChargeReferences', (builder) => {
+      builder
+        .join('chargeReferences', 'reviewChargeReferences.chargeReferenceId', 'chargeReferences.id')
+        .join('chargeCategories', 'chargeReferences.chargeCategoryId', 'chargeCategories.id')
+        .orderBy('chargeCategories.subsistenceCharge', 'desc')
+    })
     .withGraphFetched('reviewChargeVersions.reviewChargeReferences.chargeReference')
     .modifyGraph('reviewChargeVersions.reviewChargeReferences.chargeReference', (builder) => {
       builder.select([
@@ -91,6 +105,11 @@ async function _fetchReviewLicence (licenceId, billRunId) {
       ])
     })
     .withGraphFetched('reviewChargeVersions.reviewChargeReferences.reviewChargeElements')
+    .modifyGraph('reviewChargeVersions.reviewChargeReferences.reviewChargeElements', (builder) => {
+      builder
+        .join('chargeElements', 'reviewChargeElements.chargeElementId', 'chargeElements.id')
+        .orderBy('chargeElements.authorisedAnnualQuantity', 'desc')
+    })
     .withGraphFetched('reviewChargeVersions.reviewChargeReferences.reviewChargeElements.chargeElement')
     .modifyGraph('reviewChargeVersions.reviewChargeReferences.reviewChargeElements.chargeElement', (builder) => {
       builder.select([

--- a/test/services/bill-runs/two-part-tariff/fetch-review-licence-results.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/fetch-review-licence-results.service.test.js
@@ -10,6 +10,7 @@ const { expect } = Code
 
 // Test helpers
 const BillRunHelper = require('../../../support/helpers/bill-run.helper.js')
+const ChargeCategoryHelper = require('../../../support/helpers/charge-category.helper.js')
 const ChargeElementHelper = require('../../../support/helpers/charge-element.helper.js')
 const ChargeReferenceHelper = require('../../../support/helpers/charge-reference.helper.js')
 const ChargeVersionHelper = require('../../../support/helpers/charge-version.helper.js')
@@ -61,6 +62,7 @@ describe('Fetch Review Licence Results Service', () => {
       let returnLog
       let reviewReturn
       let purpose
+      let chargeCategory
 
       beforeEach(async () => {
         licence = await LicenceHelper.add()
@@ -72,7 +74,11 @@ describe('Fetch Review Licence Results Service', () => {
           chargeVersionId: chargeVersion.id
         })
 
-        chargeReference = await ChargeReferenceHelper.add({ chargeVersionId: chargeVersion.id })
+        chargeCategory = await ChargeCategoryHelper.add()
+        chargeReference = await ChargeReferenceHelper.add({
+          chargeVersionId: chargeVersion.id,
+          chargeCategoryId: chargeCategory.id
+        })
         reviewChargeReference = await ReviewChargeReferenceHelper.add({
           reviewChargeVersionId: reviewChargeVersion.id,
           chargeReferenceId: chargeReference.id
@@ -111,6 +117,7 @@ describe('Fetch Review Licence Results Service', () => {
 
       it('returns the licence review data', async () => {
         const result = await FetchReviewLicenceResultsService.go(billRun.id, licence.id)
+        console.log('Result', result.licence[0].reviewChargeVersions[0].reviewChargeReferences)
 
         expect(result.licence).to.equal([{
           id: reviewLicence.id,
@@ -182,7 +189,10 @@ describe('Fetch Review Licence Results Service', () => {
               updatedAt: reviewChargeReference.updatedAt,
               chargeReference: {
                 chargeCategoryId: chargeReference.chargeCategoryId,
-                chargeCategory: null
+                chargeCategory: {
+                  reference: chargeCategory.reference,
+                  shortDescription: chargeCategory.shortDescription
+                }
               },
               reviewChargeElements: [{
                 id: reviewChargeElement.id,

--- a/test/services/bill-runs/two-part-tariff/fetch-review-licence-results.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/fetch-review-licence-results.service.test.js
@@ -117,7 +117,6 @@ describe('Fetch Review Licence Results Service', () => {
 
       it('returns the licence review data', async () => {
         const result = await FetchReviewLicenceResultsService.go(billRun.id, licence.id)
-        console.log('Result', result.licence[0].reviewChargeVersions[0].reviewChargeReferences)
 
         expect(result.licence).to.equal([{
           id: reviewLicence.id,


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4450

During the writing of the acceptance tests for the two-part tariff review pages, we realised there was no ordering on the data being pulled out and displayed. The review licence page fetched the charge versions, charge references, charge elements and returns for a two-part tariff licence. Some licences can have multiple or all of these. With no order happening on the review pages, this makes the acceptance tests difficult to write as they pass for one person's local environment but fail on another because they are being pulled out in different orders. This PR is to add some ordering on the pages.

- The charge versions are being ordered by their start dates.
- The charge references are ordered by the highest subsistence charge
- The charge elements are being ordered by the highest authorised volume
- The returns are being ordered by their start dates.