### PR TITLE
Fix view licence abs amounts issue plus refactor

### DIFF
--- a/app/presenters/licences/view-licence-summary.presenter.js
+++ b/app/presenters/licences/view-licence-summary.presenter.js
@@ -29,18 +29,18 @@ function go (licence) {
   const licenceVersionPurposes = _licenceVersionPurposes(licence)
 
   const purposes = _purposes(licenceVersionPurposes)
-  const abstractionData = _abstractionWrapper(licenceVersionPurposes, permitLicence)
+  const abstractionData = _abstractionWrapper(permitLicence)
   const abstractionPeriods = _abstractionPeriods(licenceVersionPurposes)
 
   return {
     ...abstractionData,
     abstractionAmounts: _abstractionAmounts(licenceVersionPurposes),
+    abstractionConditions: _abstractionConditions(licenceVersionPurposes),
     abstractionPeriods,
     abstractionPeriodsAndPurposesLinkText: _abstractionPeriodsAndPurposesLinkText(abstractionPeriods, purposes),
     activeTab: 'summary',
     documentId: licenceDocumentHeader.id,
     endDate: _endDate(expiredDate),
-    id,
     licenceHolder: _licenceHolder(licence),
     licenceId: id,
     monitoringStations: _monitoringStations(licenceGaugingStations),
@@ -122,12 +122,10 @@ function _abstractionPeriods (licenceVersionPurposes) {
   }
 }
 
-function _abstractionWrapper (licenceVersionPurposes, permitLicence) {
+function _abstractionWrapper (permitLicence) {
   const abstractionDetails = _parseAbstractions(permitLicence)
-  const abstractionConditions = _abstractionConditions(licenceVersionPurposes)
 
   return {
-    abstractionConditions,
     abstractionPointLinkText: abstractionDetails.pointLinkText,
     abstractionPoints: abstractionDetails.points,
     abstractionPointsCaption: abstractionDetails.pointsCaption

--- a/app/presenters/licences/view-licence-summary.presenter.js
+++ b/app/presenters/licences/view-licence-summary.presenter.js
@@ -189,7 +189,7 @@ function _monitoringStations (licenceGaugingStations) {
 function _points (permitLicence) {
   const points = []
 
-  if (!permitLicence?.purposes || !permitLicence.purposes[0]?.purposePoints) {
+  if (!permitLicence?.purposes?.[0]?.purposePoints) {
     return points
   }
 

--- a/app/presenters/licences/view-licence-summary.presenter.js
+++ b/app/presenters/licences/view-licence-summary.presenter.js
@@ -31,9 +31,12 @@ function go (licence) {
   const purposes = _generatePurposes(licenceVersionPurposes)
   const monitoringStations = _generateMonitoringStations(licenceGaugingStations)
   const abstractionData = _abstractionWrapper(licenceVersionPurposes, purposes, permitLicence)
+  const abstractionPeriods = _generateAbstractionPeriods(licenceVersionPurposes)
 
   return {
     ...abstractionData,
+    abstractionPeriods,
+    abstractionPeriodsAndPurposesLinkText: _abstractionPeriodsAndPurposesLinkText(abstractionPeriods, purposes),
     activeTab: 'summary',
     documentId: licenceDocumentHeader.id,
     endDate: _endDate(expiredDate),
@@ -47,23 +50,11 @@ function go (licence) {
 }
 
 function _abstractionWrapper (licenceVersionPurposes, purposes, permitLicence) {
-  const abstractionPeriods = _generateAbstractionPeriods(licenceVersionPurposes)
-  let abstractionPeriodsAndPurposesLinkText = null
-
-  if (abstractionPeriods) {
-    const abstractionPeriodsLabel = abstractionPeriods.uniqueAbstractionPeriods.length > 1 ? 'periods' : 'period'
-    const purposesLabel = purposes.data.length > 1 ? 'purposes' : 'purpose'
-
-    abstractionPeriodsAndPurposesLinkText = `View details of your ${purposesLabel}, ${abstractionPeriodsLabel} and amounts`
-  }
-
   const abstractionDetails = _parseAbstractionsAndSourceOfSupply(permitLicence)
   const abstractionConditions = _abstractionConditions(licenceVersionPurposes)
 
   return {
     abstractionConditions,
-    abstractionPeriods,
-    abstractionPeriodsAndPurposesLinkText,
     abstractionPointLinkText: abstractionDetails.pointLinkText,
     abstractionPoints: abstractionDetails.points,
     abstractionPointsCaption: abstractionDetails.pointsCaption,
@@ -116,6 +107,18 @@ function _abstractionConditions (licenceVersionPurposes) {
 
   // Sort them alphabetically
   return uniqueConditions.sort()
+}
+
+function _abstractionPeriodsAndPurposesLinkText (abstractionPeriods, purposes) {
+  let abstractionPeriodsAndPurposesLinkText = null
+
+  if (abstractionPeriods) {
+    const abstractionPeriodsLabel = abstractionPeriods.uniqueAbstractionPeriods.length > 1 ? 'periods' : 'period'
+    const purposesLabel = purposes.data.length > 1 ? 'purposes' : 'purpose'
+    abstractionPeriodsAndPurposesLinkText = `View details of your ${purposesLabel}, ${abstractionPeriodsLabel} and amounts`
+  }
+
+  return abstractionPeriodsAndPurposesLinkText
 }
 
 function _endDate (expiredDate) {

--- a/app/presenters/licences/view-licence-summary.presenter.js
+++ b/app/presenters/licences/view-licence-summary.presenter.js
@@ -42,6 +42,7 @@ function go (licence) {
     endDate: _endDate(expiredDate),
     id,
     licenceHolder: _licenceHolder(licence),
+    licenceId: id,
     monitoringStations: _monitoringStations(licenceGaugingStations),
     purposes,
     region: region.displayName,

--- a/app/presenters/licences/view-licence-summary.presenter.js
+++ b/app/presenters/licences/view-licence-summary.presenter.js
@@ -29,7 +29,7 @@ function go (licence) {
   const licenceVersionPurposes = _licenceVersionPurposes(licence)
 
   const purposes = _generatePurposes(licenceVersionPurposes)
-  const monitoringStations = _generateMonitoringStation(licenceGaugingStations)
+  const monitoringStations = _generateMonitoringStations(licenceGaugingStations)
   const abstractionData = _abstractionWrapper(licenceVersionPurposes, purposes, permitLicence)
 
   return {
@@ -156,7 +156,7 @@ function _generateLicenceHolder (licence) {
   return licenceHolder
 }
 
-function _generateMonitoringStation (licenceGaugingStations) {
+function _generateMonitoringStations (licenceGaugingStations) {
   return licenceGaugingStations.map((licenceGaugingStation) => {
     return licenceGaugingStation.gaugingStation
   })

--- a/app/presenters/licences/view-licence-summary.presenter.js
+++ b/app/presenters/licences/view-licence-summary.presenter.js
@@ -46,6 +46,7 @@ function go (licence) {
     monitoringStations,
     purposes,
     region: region.displayName,
+    sourceOfSupply: permitLicence.purposes[0].purposePoints[0]?.point_source?.NAME ?? null,
     startDate: formatLongDate(startDate)
   }
 }
@@ -79,15 +80,14 @@ function _abstractionAmounts (licenceVersionPurposes) {
 }
 
 function _abstractionWrapper (licenceVersionPurposes, permitLicence) {
-  const abstractionDetails = _parseAbstractionsAndSourceOfSupply(permitLicence)
+  const abstractionDetails = _parseAbstractions(permitLicence)
   const abstractionConditions = _abstractionConditions(licenceVersionPurposes)
 
   return {
     abstractionConditions,
     abstractionPointLinkText: abstractionDetails.pointLinkText,
     abstractionPoints: abstractionDetails.points,
-    abstractionPointsCaption: abstractionDetails.pointsCaption,
-    sourceOfSupply: abstractionDetails.sourceOfSupply
+    abstractionPointsCaption: abstractionDetails.pointsCaption
   }
 }
 
@@ -187,7 +187,7 @@ function _generatePurposes (licenceVersionPurposes) {
   }
 }
 
-function _parseAbstractionsAndSourceOfSupply (permitLicence) {
+function _parseAbstractions (permitLicence) {
   if (!permitLicence ||
     !permitLicence.purposes ||
     permitLicence.purposes.length === 0 ||
@@ -197,10 +197,7 @@ function _parseAbstractionsAndSourceOfSupply (permitLicence) {
     return {
       points: null,
       pointsCaption: null,
-      pointLinkText: null,
-      quantities: null,
-      quantityCaption: null,
-      sourceOfSupply: null
+      pointLinkText: null
     }
   }
 
@@ -226,8 +223,7 @@ function _parseAbstractionsAndSourceOfSupply (permitLicence) {
   return {
     points: uniqueAbstractionPoints.length === 0 ? null : uniqueAbstractionPoints,
     pointsCaption,
-    pointLinkText,
-    sourceOfSupply: permitLicence.purposes[0].purposePoints[0]?.point_source?.NAME ?? null
+    pointLinkText
   }
 }
 

--- a/app/services/licences/fetch-licence-summary.service.js
+++ b/app/services/licences/fetch-licence-summary.service.js
@@ -52,7 +52,11 @@ async function _fetch (licenceId) {
         'abstractionPeriodStartDay',
         'abstractionPeriodStartMonth',
         'abstractionPeriodEndDay',
-        'abstractionPeriodEndMonth'
+        'abstractionPeriodEndMonth',
+        'annualQuantity',
+        'dailyQuantity',
+        'hourlyQuantity',
+        'instantQuantity'
       ])
     })
     .withGraphFetched('licenceVersions.licenceVersionPurposes.purpose')

--- a/app/views/licences/tabs/summary.njk
+++ b/app/views/licences/tabs/summary.njk
@@ -134,12 +134,12 @@
     </dd>
   </div>
 
-  {% if abstractionQuantities %}
+  {% if abstractionAmounts.length > 0 %}
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key">Abstraction amounts</dt>
       <dd class="govuk-summary-list__value">
         <ul class="govuk-list govuk-!-margin-bottom-0">
-          {% for quantity in abstractionQuantities %}
+          {% for quantity in abstractionAmounts %}
             <li>{{ quantity }}</li>
           {% endfor %}
         </ul>

--- a/app/views/licences/tabs/summary.njk
+++ b/app/views/licences/tabs/summary.njk
@@ -50,21 +50,21 @@
     </div>
   {% endif %}
 
-  {% if abstractionPeriods %}
+  {% if abstractionPeriods.length > 0 %}
     <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">{{ abstractionPeriods.caption }}</dt>
+      <dt class="govuk-summary-list__key">{{ abstractionPeriodsCaption }}</dt>
       <dd class="govuk-summary-list__value">
         <div>
-          {% if abstractionPeriods.uniqueAbstractionPeriods.length > 5 %}
-            There are {{ abstractionPeriods.uniqueAbstractionPeriods.length }} periods of abstraction
-          {% elseif abstractionPeriods.uniqueAbstractionPeriods.length > 1 %}
+          {% if abstractionPeriods.length > 5 %}
+            There are {{ abstractionPeriods.length }} periods of abstraction
+          {% elseif abstractionPeriods.length > 1 %}
             <ul class="govuk-list govuk-!-margin-bottom-0">
-              {% for abstractionPeriod in abstractionPeriods.uniqueAbstractionPeriods %}
+              {% for abstractionPeriod in abstractionPeriods %}
                 <li>{{ abstractionPeriod }}</li>
               {% endfor %}
             </ul>
           {% else %}
-            {{ abstractionPeriods.uniqueAbstractionPeriods[0] }}
+            {{ abstractionPeriods[0] }}
           {% endif %}
         </div>
         <a href="/licences/{{ documentId }}/purposes">{{ abstractionPeriodsAndPurposesLinkText }}</a>
@@ -72,7 +72,7 @@
     </div>
   {% endif %}
 
-  {% if abstractionPoints %}
+  {% if abstractionPoints.length > 0 %}
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key">{{ abstractionPointsCaption }}</dt>
       <dd class="govuk-summary-list__value">
@@ -89,7 +89,7 @@
             {{ abstractionPoints[0] }}
           {% endif %}
         </div>
-        <a href="/licences/{{ documentId }}/points">{{ abstractionPointLinkText }}</a>
+        <a href="/licences/{{ documentId }}/points">{{ abstractionPointsLinkText }}</a>
       </dd>
     </div>
   {% endif %}
@@ -114,25 +114,27 @@
     </dd>
   </div>
 
-  <div class="govuk-summary-list__row">
-    <dt class="govuk-summary-list__key">Abstraction conditions</dt>
-    <dd class="govuk-summary-list__value">
-      <div>
-        {% if abstractionConditions.length > 5 %}
-          There are {{ abstractionConditions.length }} abstraction conditions
-        {% elif abstractionConditions.length > 1 %}
-          <ul class="govuk-list govuk-!-margin-bottom-0">
-            {% for condition in abstractionConditions %}
-              <li>{{ condition }}</li>
-            {% endfor %}
-          </ul>
-        {% else %}
-          {{ abstractionConditions[0] }}
-        {% endif %}
-      </div>
-      <a href="/licences/{{ documentId }}/conditions">View details of the abstraction conditions</a>
-    </dd>
-  </div>
+  {% if abstractionConditions.length > 0 %}
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">Abstraction conditions</dt>
+      <dd class="govuk-summary-list__value">
+        <div>
+          {% if abstractionConditions.length > 5 %}
+            There are {{ abstractionConditions.length }} abstraction conditions
+          {% elif abstractionConditions.length > 1 %}
+            <ul class="govuk-list govuk-!-margin-bottom-0">
+              {% for condition in abstractionConditions %}
+                <li>{{ condition }}</li>
+              {% endfor %}
+            </ul>
+          {% else %}
+            {{ abstractionConditions[0] }}
+          {% endif %}
+        </div>
+        <a href="/licences/{{ documentId }}/conditions">View details of the abstraction conditions</a>
+      </dd>
+    </div>
+  {% endif %}
 
   {% if abstractionAmounts.length > 0 %}
     <div class="govuk-summary-list__row">

--- a/test/presenters/licences/view-licence-summary.presenter.test.js
+++ b/test/presenters/licences/view-licence-summary.presenter.test.js
@@ -25,21 +25,24 @@ describe('View Licence Summary presenter', () => {
       const result = ViewLicenceSummaryPresenter.go(licence)
 
       expect(result).to.equal({
+        abstractionAmounts: [
+          '180000.00 cubic metres per year',
+          '720.00 cubic metres per day',
+          '144.00 cubic metres per hour',
+          '40.00 cubic metres per second'
+        ],
         abstractionConditions: ['Derogation clause', 'General conditions', 'Non standard quantities'],
-        abstractionPeriods: {
-          caption: 'Periods of abstraction',
-          uniqueAbstractionPeriods: ['1 April to 31 October', '1 November to 31 March']
-        },
+        abstractionPeriods: ['1 April to 31 October', '1 November to 31 March'],
         abstractionPeriodsAndPurposesLinkText: 'View details of your purposes, periods and amounts',
-        abstractionPointLinkText: 'View details of the abstraction point',
+        abstractionPeriodsCaption: 'Periods of abstraction',
         abstractionPoints: ['At National Grid Reference TL 23198 88603'],
         abstractionPointsCaption: 'Point of abstraction',
-        abstractionQuantities: null,
+        abstractionPointsLinkText: 'View details of the abstraction point',
         activeTab: 'summary',
         documentId: '28665d16-eba3-4c9a-aa55-7ab671b0c4fb',
         endDate: null,
-        id: 'f1288f6c-8503-4dc1-b114-75c408a14bd0',
         licenceHolder: 'Unregistered licence',
+        licenceId: 'f1288f6c-8503-4dc1-b114-75c408a14bd0',
         monitoringStations: [{
           id: 'ac075651-4781-4e24-a684-b943b98607ca',
           label: 'MEVAGISSEY FIRE STATION'
@@ -51,6 +54,102 @@ describe('View Licence Summary presenter', () => {
         region: 'Avalon',
         sourceOfSupply: 'SURFACE WATER SOURCE OF SUPPLY',
         startDate: '1 April 2019'
+      })
+    })
+  })
+
+  describe('the "abstractionAmounts" property', () => {
+    describe('when there are no licence version purposes', () => {
+      beforeEach(() => {
+        licence.licenceVersions[0].licenceVersionPurposes = []
+      })
+
+      it('returns an empty array', () => {
+        const result = ViewLicenceSummaryPresenter.go(licence)
+
+        expect(result.abstractionAmounts).to.be.empty()
+      })
+    })
+
+    describe('when the there is at least one licence version purpose', () => {
+      beforeEach(() => {
+        licence.licenceVersions[0].licenceVersionPurposes = [{
+          id: '7f5e0838-d87a-4c2e-8e9b-09d6814b9ec4',
+          abstractionPeriodStartDay: 1,
+          abstractionPeriodStartMonth: 4,
+          abstractionPeriodEndDay: 31,
+          abstractionPeriodEndMonth: 10,
+          annualQuantity: null,
+          dailyQuantity: null,
+          hourlyQuantity: null,
+          instantQuantity: null,
+          purpose: { id: '0316229a-e76d-4785-bc2c-65075a1a8f50', description: 'Spray Irrigation - Storage' },
+          licenceVersionPurposeConditions: [
+            {
+              id: '3844bf76-107d-49f1-b3fb-54619ac8d300',
+              licenceVersionPurposeConditionType: {
+                id: '2bfb0c37-5bcb-4f15-b017-27bc0afff1a0',
+                displayTitle: 'General conditions'
+              }
+            }
+          ]
+        }]
+      })
+
+      describe('but it has no abstraction amounts', () => {
+        it('returns an empty array', () => {
+          const result = ViewLicenceSummaryPresenter.go(licence)
+
+          expect(result.abstractionAmounts).to.be.empty()
+        })
+      })
+
+      describe('and it has an annual abstraction quantity', () => {
+        beforeEach(() => {
+          licence.licenceVersions[0].licenceVersionPurposes[0].annualQuantity = 180000
+        })
+
+        it('returns the "per year" abstraction amount message', () => {
+          const result = ViewLicenceSummaryPresenter.go(licence)
+
+          expect(result.abstractionAmounts).to.include('180000.00 cubic metres per year')
+        })
+      })
+
+      describe('and it has a daily abstraction quantity', () => {
+        beforeEach(() => {
+          licence.licenceVersions[0].licenceVersionPurposes[0].dailyQuantity = 720
+        })
+
+        it('returns the "per day" abstraction amount message', () => {
+          const result = ViewLicenceSummaryPresenter.go(licence)
+
+          expect(result.abstractionAmounts).to.include('720.00 cubic metres per day')
+        })
+      })
+
+      describe('and it has an hourly abstraction quantity', () => {
+        beforeEach(() => {
+          licence.licenceVersions[0].licenceVersionPurposes[0].hourlyQuantity = 144
+        })
+
+        it('returns the "per hour" abstraction amount message', () => {
+          const result = ViewLicenceSummaryPresenter.go(licence)
+
+          expect(result.abstractionAmounts).to.include('144.00 cubic metres per hour')
+        })
+      })
+
+      describe('and it has an instant abstraction quantity', () => {
+        beforeEach(() => {
+          licence.licenceVersions[0].licenceVersionPurposes[0].instantQuantity = 40
+        })
+
+        it('returns the "per second" abstraction amount message', () => {
+          const result = ViewLicenceSummaryPresenter.go(licence)
+
+          expect(result.abstractionAmounts).to.include('40.00 cubic metres per second')
+        })
       })
     })
   })
@@ -270,10 +369,10 @@ describe('View Licence Summary presenter', () => {
         licence.licenceVersions = []
       })
 
-      it('returns null', () => {
+      it('returns an empty array', () => {
         const result = ViewLicenceSummaryPresenter.go(licence)
 
-        expect(result.abstractionPeriods).to.equal(null)
+        expect(result.abstractionPeriods).to.be.empty()
       })
     })
 
@@ -283,10 +382,10 @@ describe('View Licence Summary presenter', () => {
           licence.licenceVersions[0].licenceVersionPurposes = []
         })
 
-        it('returns null', () => {
+        it('returns an empty array', () => {
           const result = ViewLicenceSummaryPresenter.go(licence)
 
-          expect(result.abstractionPeriods).to.equal(null)
+          expect(result.abstractionPeriods).to.be.empty()
         })
       })
 
@@ -296,13 +395,10 @@ describe('View Licence Summary presenter', () => {
           licence.licenceVersions[0].licenceVersionPurposes.pop()
         })
 
-        it('returns the singular version of the caption and period formatted for display', () => {
+        it('returns the abstraction period formatted for display', () => {
           const result = ViewLicenceSummaryPresenter.go(licence)
 
-          expect(result.abstractionPeriods).to.equal({
-            caption: 'Period of abstraction',
-            uniqueAbstractionPeriods: ['1 April to 31 October']
-          })
+          expect(result.abstractionPeriods).to.equal(['1 April to 31 October'])
         })
       })
 
@@ -312,24 +408,22 @@ describe('View Licence Summary presenter', () => {
             licence.licenceVersions[0].licenceVersionPurposes.pop()
           })
 
-          it('returns the plural version of the caption and periods formatted for display', () => {
+          it('returns the abstraction periods formatted for display', () => {
             const result = ViewLicenceSummaryPresenter.go(licence)
 
-            expect(result.abstractionPeriods).to.equal({
-              caption: 'Periods of abstraction',
-              uniqueAbstractionPeriods: ['1 April to 31 October', '1 November to 31 March']
-            })
+            expect(result.abstractionPeriods).to.equal(['1 April to 31 October', '1 November to 31 March'])
           })
         })
 
-        describe('that have some abstraction periods that are the same', () => {
-          it('returns the plural version of the caption and the unique periods formatted for display', () => {
+        describe('that have the same abstraction periods', () => {
+          beforeEach(() => {
+            licence.licenceVersions[0].licenceVersionPurposes.splice(1, 1)
+          })
+
+          it('returns the abstraction period formatted for display', () => {
             const result = ViewLicenceSummaryPresenter.go(licence)
 
-            expect(result.abstractionPeriods).to.equal({
-              caption: 'Periods of abstraction',
-              uniqueAbstractionPeriods: ['1 April to 31 October', '1 November to 31 March']
-            })
+            expect(result.abstractionPeriods).to.equal(['1 April to 31 October'])
           })
         })
       })
@@ -442,6 +536,182 @@ describe('View Licence Summary presenter', () => {
             })
           })
         })
+      })
+    })
+  })
+
+  describe('the "abstractionPeriodsCaption" property', () => {
+    describe('when no abstraction periods have been extracted from the licence data', () => {
+      beforeEach(() => {
+        licence.licenceVersions = []
+      })
+
+      it('returns the singular caption', () => {
+        const result = ViewLicenceSummaryPresenter.go(licence)
+
+        expect(result.abstractionPeriodsCaption).to.equal('Period of abstraction')
+      })
+    })
+
+    describe('when one unique abstraction period has been extracted from the licence data', () => {
+      beforeEach(() => {
+        licence.licenceVersions[0].licenceVersionPurposes.splice(1, 1)
+      })
+
+      it('returns the singular caption', () => {
+        const result = ViewLicenceSummaryPresenter.go(licence)
+
+        expect(result.abstractionPeriodsCaption).to.equal('Period of abstraction')
+      })
+    })
+
+    describe('when multiple abstraction periods have been extracted from the licence data', () => {
+      it('returns the plural caption', () => {
+        const result = ViewLicenceSummaryPresenter.go(licence)
+
+        expect(result.abstractionPeriodsCaption).to.equal('Periods of abstraction')
+      })
+    })
+  })
+
+  describe('the "abstractionPoints" property', () => {
+    describe('when no abstraction points have been extracted from the licence data', () => {
+      beforeEach(() => {
+        delete licence.permitLicence.purposes
+      })
+
+      it('returns an empty array', () => {
+        const result = ViewLicenceSummaryPresenter.go(licence)
+
+        expect(result.abstractionPoints).to.be.empty()
+      })
+    })
+
+    describe('when one unique abstraction point has been extracted from the licence data', () => {
+      it('returns the abstraction point formatted for display', () => {
+        const result = ViewLicenceSummaryPresenter.go(licence)
+
+        expect(result.abstractionPoints).to.equal(['At National Grid Reference TL 23198 88603'])
+      })
+    })
+
+    describe('when multiple abstraction points have been extracted from the licence data', () => {
+      describe('that are all different', () => {
+        beforeEach(() => {
+          licence.permitLicence.purposes[0].purposePoints.push({
+            point_detail: {
+              NGR1_SHEET: 'TQ',
+              NGR1_EAST: '652',
+              NGR1_NORTH: '593'
+            }
+          })
+        })
+
+        it('returns the abstraction points formatted for display', () => {
+          const result = ViewLicenceSummaryPresenter.go(licence)
+
+          expect(result.abstractionPoints).to.equal(
+            ['At National Grid Reference TL 23198 88603', 'At National Grid Reference TQ 652 593']
+          )
+        })
+      })
+
+      describe('that have the same abstraction point', () => {
+        beforeEach(() => {
+          licence.permitLicence.purposes[0].purposePoints.push({
+            point_detail: {
+              NGR1_SHEET: 'TL',
+              NGR1_EAST: '23198',
+              NGR1_NORTH: '88603'
+            }
+          })
+        })
+
+        it('returns the abstraction point formatted for display', () => {
+          const result = ViewLicenceSummaryPresenter.go(licence)
+
+          expect(result.abstractionPoints).to.equal(['At National Grid Reference TL 23198 88603'])
+        })
+      })
+    })
+  })
+
+  describe('the "abstractionPointsCaption" property', () => {
+    describe('when no abstraction points have been extracted from the licence data', () => {
+      beforeEach(() => {
+        licence.permitLicence.purposes = []
+      })
+
+      it('returns the singular caption', () => {
+        const result = ViewLicenceSummaryPresenter.go(licence)
+
+        expect(result.abstractionPointsCaption).to.equal('Point of abstraction')
+      })
+    })
+
+    describe('when one unique abstraction point has been extracted from the licence data', () => {
+      it('returns the singular caption', () => {
+        const result = ViewLicenceSummaryPresenter.go(licence)
+
+        expect(result.abstractionPointsCaption).to.equal('Point of abstraction')
+      })
+    })
+
+    describe('when multiple abstraction points have been extracted from the licence data', () => {
+      beforeEach(() => {
+        licence.permitLicence.purposes[0].purposePoints.push({
+          point_detail: {
+            NGR1_SHEET: 'TQ',
+            NGR1_EAST: '652',
+            NGR1_NORTH: '593'
+          }
+        })
+      })
+
+      it('returns the plural caption', () => {
+        const result = ViewLicenceSummaryPresenter.go(licence)
+
+        expect(result.abstractionPointsCaption).to.equal('Points of abstraction')
+      })
+    })
+  })
+
+  describe('the "abstractionPointsLinkText" property', () => {
+    describe('when no abstraction points have been extracted from the licence data', () => {
+      beforeEach(() => {
+        licence.permitLicence.purposes = []
+      })
+
+      it('returns the singular caption', () => {
+        const result = ViewLicenceSummaryPresenter.go(licence)
+
+        expect(result.abstractionPointsLinkText).to.equal('View details of the abstraction point')
+      })
+    })
+
+    describe('when one unique abstraction point has been extracted from the licence data', () => {
+      it('returns the singular caption', () => {
+        const result = ViewLicenceSummaryPresenter.go(licence)
+
+        expect(result.abstractionPointsLinkText).to.equal('View details of the abstraction point')
+      })
+    })
+
+    describe('when multiple abstraction points have been extracted from the licence data', () => {
+      beforeEach(() => {
+        licence.permitLicence.purposes[0].purposePoints.push({
+          point_detail: {
+            NGR1_SHEET: 'TQ',
+            NGR1_EAST: '652',
+            NGR1_NORTH: '593'
+          }
+        })
+      })
+
+      it('returns the plural caption', () => {
+        const result = ViewLicenceSummaryPresenter.go(licence)
+
+        expect(result.abstractionPointsLinkText).to.equal('View details of the abstraction points')
       })
     })
   })
@@ -643,492 +913,23 @@ describe('View Licence Summary presenter', () => {
   })
 
   describe('the "sourceOfSupply" property', () => {
-    describe('and it has a source of supply', () => {
-      it('will return the source of supply for use in the licence summary page', async () => {
+    describe('when the permit licence first purpose, purpose point, and point source is not populated', () => {
+      beforeEach(() => {
+        licence.permitLicence.purposes = []
+      })
+
+      it('returns null', async () => {
+        const result = await ViewLicenceSummaryPresenter.go(licence)
+
+        expect(result.sourceOfSupply).to.equal(null)
+      })
+    })
+
+    describe('when the permit licence first purpose, purpose point, and point source is populated', () => {
+      it('returns the point source name', async () => {
         const result = await ViewLicenceSummaryPresenter.go(licence)
 
         expect(result.sourceOfSupply).to.equal('SURFACE WATER SOURCE OF SUPPLY')
-      })
-    })
-
-    describe('and it does not have a source of supply name', () => {
-      beforeEach(() => {
-        licence.permitLicence = {
-          purposes: [{
-            purposePoints: [{
-              point_source: {}
-            }]
-          }]
-        }
-      })
-
-      it('will return null for the source of supply', async () => {
-        const result = await ViewLicenceSummaryPresenter.go(licence)
-
-        expect(result.sourceOfSupply).to.equal(null)
-      })
-    })
-
-    describe('and it does not have a source of supply point_source or point_detail', () => {
-      beforeEach(() => {
-        licence.permitLicence = {
-          purposes: [{
-            purposePoints: [{}]
-          }]
-        }
-      })
-
-      it('will return null for the source of supply and abstraction point information', async () => {
-        const result = await ViewLicenceSummaryPresenter.go(licence)
-
-        expect(result.abstractionPoints).to.equal(null)
-        expect(result.abstractionPointsCaption).to.equal('Point of abstraction')
-        expect(result.abstractionPointLinkText).to.equal('View details of the abstraction point')
-        expect(result.sourceOfSupply).to.equal(null)
-      })
-    })
-
-    describe('and it has an empty purposePoints array', () => {
-      beforeEach(() => {
-        licence.permitLicence = {
-          purposes: [{
-            purposePoints: []
-          }]
-        }
-      })
-
-      it('will return null for the source of supply and abstraction point information', async () => {
-        const result = await ViewLicenceSummaryPresenter.go(licence)
-
-        expect(result.abstractionPoints).to.equal(null)
-        expect(result.abstractionPointsCaption).to.equal(null)
-        expect(result.abstractionPointLinkText).to.equal(null)
-        expect(result.abstractionQuantities).to.equal(null)
-        expect(result.sourceOfSupply).to.equal(null)
-      })
-    })
-
-    describe('and it does not have a purposePoints array', () => {
-      beforeEach(() => {
-        licence.permitLicence = {
-          purposes: [{}]
-        }
-      })
-
-      it('will return null for the source of supply and abstraction point information', async () => {
-        const result = await ViewLicenceSummaryPresenter.go(licence)
-
-        expect(result.abstractionPoints).to.equal(null)
-        expect(result.abstractionPointsCaption).to.equal(null)
-        expect(result.abstractionPointLinkText).to.equal(null)
-        expect(result.abstractionQuantities).to.equal(null)
-        expect(result.sourceOfSupply).to.equal(null)
-      })
-    })
-
-    describe('and it has an empty purposes array', () => {
-      beforeEach(() => {
-        licence.permitLicence = {
-          purposes: []
-        }
-      })
-
-      it('will return null for the source of supply and abstraction point information', async () => {
-        const result = await ViewLicenceSummaryPresenter.go(licence)
-
-        expect(result.abstractionPoints).to.equal(null)
-        expect(result.abstractionPointsCaption).to.equal(null)
-        expect(result.abstractionPointLinkText).to.equal(null)
-        expect(result.abstractionQuantities).to.equal(null)
-        expect(result.sourceOfSupply).to.equal(null)
-      })
-    })
-
-    describe('and it does not have a permitLicence object', () => {
-      beforeEach(() => {
-        licence.permitLicence = undefined
-      })
-
-      it('will return null for the source of supply and abstraction point information', async () => {
-        const result = await ViewLicenceSummaryPresenter.go(licence)
-
-        expect(result.abstractionPoints).to.equal(null)
-        expect(result.abstractionPointsCaption).to.equal(null)
-        expect(result.abstractionPointLinkText).to.equal(null)
-        expect(result.abstractionQuantities).to.equal(null)
-        expect(result.sourceOfSupply).to.equal(null)
-      })
-    })
-
-    describe('and it does not have a purposes array', () => {
-      beforeEach(() => {
-        licence.permitLicence.purposes = undefined
-      })
-
-      it('will return null for the source of supply and abstraction point information', async () => {
-        const result = await ViewLicenceSummaryPresenter.go(licence)
-
-        expect(result.abstractionPoints).to.equal(null)
-        expect(result.abstractionPointsCaption).to.equal(null)
-        expect(result.abstractionPointLinkText).to.equal(null)
-        expect(result.abstractionQuantities).to.equal(null)
-        expect(result.sourceOfSupply).to.equal(null)
-      })
-    })
-
-    describe('and it has an abstraction point with 4 national grid references but NGR4_NORTH is null', () => {
-      beforeEach(() => {
-        licence.permitLicence.purposes[0].purposePoints[0].point_detail = {
-          NGR1_SHEET: 'TL',
-          NGR2_SHEET: 'TM',
-          NGR3_SHEET: 'TN',
-          NGR4_SHEET: 'TO',
-          NGR1_EAST: '23198',
-          NGR2_EAST: '23197',
-          NGR3_EAST: '23196',
-          NGR4_EAST: '23195',
-          NGR1_NORTH: '88603',
-          NGR2_NORTH: '88602',
-          NGR3_NORTH: '88601',
-          NGR4_NORTH: 'null'
-        }
-      })
-
-      it('will return the correct information for the abstraction point', async () => {
-        const result = await ViewLicenceSummaryPresenter.go(licence)
-
-        expect(result.abstractionPoints).to.equal([
-          'Between National Grid References TL 23198 88603 and TM 23197 88602'
-        ])
-        expect(result.abstractionPointsCaption).to.equal('Point of abstraction')
-        expect(result.abstractionPointLinkText).to.equal('View details of the abstraction point')
-      })
-    })
-
-    describe('and it has an abstraction point with 4 national grid references', () => {
-      beforeEach(() => {
-        licence.permitLicence.purposes[0].purposePoints[0].point_detail = {
-          NGR1_SHEET: 'TL',
-          NGR2_SHEET: 'TM',
-          NGR3_SHEET: 'TN',
-          NGR4_SHEET: 'TO',
-          NGR1_EAST: '23198',
-          NGR2_EAST: '23197',
-          NGR3_EAST: '23196',
-          NGR4_EAST: '23195',
-          NGR1_NORTH: '88603',
-          NGR2_NORTH: '88602',
-          NGR3_NORTH: '88601',
-          NGR4_NORTH: '88600'
-        }
-      })
-
-      it('will return the information for the abstraction point', async () => {
-        const result = await ViewLicenceSummaryPresenter.go(licence)
-
-        expect(result.abstractionPoints).to.equal([
-          'Within the area formed by the straight lines running between National Grid References TL 23198 88603 TM 23197 88602 TN 23196 88601 and TO 23195 88600'
-        ])
-        expect(result.abstractionPointsCaption).to.equal('Point of abstraction')
-        expect(result.abstractionPointLinkText).to.equal('View details of the abstraction point')
-      })
-    })
-
-    describe('and it has an abstraction point with 2 national grid references', () => {
-      beforeEach(() => {
-        licence.permitLicence.purposes[0].purposePoints[0].point_detail = {
-          NGR1_SHEET: 'TL',
-          NGR2_SHEET: 'TM',
-          NGR1_EAST: '23198',
-          NGR2_EAST: '23197',
-          NGR1_NORTH: '88603',
-          NGR2_NORTH: '88602'
-        }
-      })
-
-      it('will return the information for the abstraction point', async () => {
-        const result = await ViewLicenceSummaryPresenter.go(licence)
-
-        expect(result.abstractionPoints).to.equal([
-          'Between National Grid References TL 23198 88603 and TM 23197 88602'
-        ])
-        expect(result.abstractionPointsCaption).to.equal('Point of abstraction')
-        expect(result.abstractionPointLinkText).to.equal('View details of the abstraction point')
-      })
-    })
-
-    describe('and it has an NGR2_SHEET abstraction point but NGR2_NORTH is null', () => {
-      beforeEach(() => {
-        licence.permitLicence.purposes[0].purposePoints[0].point_detail = {
-          NGR1_SHEET: 'TL',
-          NGR2_SHEET: 'TM',
-          NGR1_EAST: '23198',
-          NGR2_EAST: '23197',
-          NGR1_NORTH: '88603',
-          NGR2_NORTH: 'null'
-        }
-      })
-
-      it('will return the information for the abstraction point', async () => {
-        const result = await ViewLicenceSummaryPresenter.go(licence)
-
-        expect(result.abstractionPoints).to.equal(['At National Grid Reference TL 23198 88603'])
-        expect(result.abstractionPointsCaption).to.equal('Point of abstraction')
-        expect(result.abstractionPointLinkText).to.equal('View details of the abstraction point')
-      })
-    })
-
-    describe('and it has an abstraction point with 1 national grid references', () => {
-      beforeEach(() => {
-        licence.permitLicence.purposes[0].purposePoints[0].point_detail = {
-          NGR1_SHEET: 'TL',
-          NGR1_EAST: '23198',
-          NGR1_NORTH: '88603'
-        }
-      })
-
-      it('will return the information for the abstraction point', async () => {
-        const result = await ViewLicenceSummaryPresenter.go(licence)
-
-        expect(result.abstractionPoints).to.equal([
-          'At National Grid Reference TL 23198 88603'
-        ])
-        expect(result.abstractionPointsCaption).to.equal('Point of abstraction')
-        expect(result.abstractionPointLinkText).to.equal('View details of the abstraction point')
-      })
-    })
-
-    describe('and it has an abstraction point with 1 national grid references and has a local name', () => {
-      beforeEach(() => {
-        licence.permitLicence.purposes[0].purposePoints[0].point_detail = {
-          LOCAL_NAME: 'Local',
-          NGR1_SHEET: 'TL',
-          NGR1_EAST: '23198',
-          NGR1_NORTH: '88603'
-        }
-      })
-
-      it('will return the information for the abstraction point', async () => {
-        const result = await ViewLicenceSummaryPresenter.go(licence)
-
-        expect(result.abstractionPoints).to.equal([
-          'At National Grid Reference TL 23198 88603 (Local)'
-        ])
-        expect(result.abstractionPointsCaption).to.equal('Point of abstraction')
-        expect(result.abstractionPointLinkText).to.equal('View details of the abstraction point')
-      })
-    })
-
-    describe('and it has two abstraction points with 1 national grid references', () => {
-      beforeEach(() => {
-        licence.permitLicence.purposes[0].purposePoints[0].point_detail = {
-          NGR1_SHEET: 'TL',
-          NGR1_EAST: '23198',
-          NGR1_NORTH: '88603'
-        }
-        licence.permitLicence.purposes[0].purposePoints.push({
-          point_detail: {
-            NGR1_SHEET: 'TM',
-            NGR1_EAST: '23199',
-            NGR1_NORTH: '88604'
-          }
-        })
-      })
-
-      it('will return the information for the abstraction point', async () => {
-        const result = await ViewLicenceSummaryPresenter.go(licence)
-
-        expect(result.abstractionPoints).to.equal([
-          'At National Grid Reference TL 23198 88603',
-          'At National Grid Reference TM 23199 88604'
-        ])
-        expect(result.abstractionPointsCaption).to.equal('Points of abstraction')
-        expect(result.abstractionPointLinkText).to.equal('View details of the abstraction points')
-      })
-    })
-
-    describe('and it has two abstraction points with the same 1 national grid references', () => {
-      beforeEach(() => {
-        licence.permitLicence.purposes[0].purposePoints[0].point_detail = {
-          NGR1_SHEET: 'TL',
-          NGR1_EAST: '23198',
-          NGR1_NORTH: '88603'
-        }
-        licence.permitLicence.purposes[0].purposePoints.push({
-          point_detail: {
-            NGR1_SHEET: 'TL',
-            NGR1_EAST: '23198',
-            NGR1_NORTH: '88603'
-          }
-        })
-      })
-
-      it('will only display one of the abstraction point', async () => {
-        const result = await ViewLicenceSummaryPresenter.go(licence)
-
-        expect(result.abstractionPoints).to.equal([
-          'At National Grid Reference TL 23198 88603'
-        ])
-        expect(result.abstractionPointsCaption).to.equal('Point of abstraction')
-        expect(result.abstractionPointLinkText).to.equal('View details of the abstraction point')
-      })
-    })
-
-    describe('and it has abstraction quantities', () => {
-      beforeEach(() => {
-        licence.permitLicence.purposes[0].ANNUAL_QTY = 265
-        licence.permitLicence.purposes[0].DAILY_QTY = 24
-        licence.permitLicence.purposes[0].HOURLY_QTY = 60
-        licence.permitLicence.purposes[0].INST_QTY = 6
-      })
-
-      it('will display the formatted strings with the rates per period and the correct caption', async () => {
-        const result = await ViewLicenceSummaryPresenter.go(licence)
-
-        expect(result.abstractionQuantities).to.equal([
-          '265.00 cubic metres per year',
-          '24.00 cubic metres per day',
-          '60.00 cubic metres per hour',
-          '6.00 litres per second'
-        ])
-      })
-    })
-
-    describe('and it has one abstraction quantity', () => {
-      beforeEach(() => {
-        licence.permitLicence.purposes[0].ANNUAL_QTY = 265
-      })
-
-      it('will display the formatted string with the rate per period and the correct caption', async () => {
-        const result = await ViewLicenceSummaryPresenter.go(licence)
-
-        expect(result.abstractionQuantities).to.equal([
-          '265.00 cubic metres per year'
-        ])
-      })
-    })
-
-    describe('and it has abstraction ANNUAL_QTY and DAILY_QTY set to null', () => {
-      beforeEach(() => {
-        licence.permitLicence.purposes[0].ANNUAL_QTY = 'null'
-        licence.permitLicence.purposes[0].DAILY_QTY = 'null'
-        licence.permitLicence.purposes[0].HOURLY_QTY = 60
-        licence.permitLicence.purposes[0].INST_QTY = 6
-      })
-
-      it('will display the formatted string with the rate per period and the correct caption', async () => {
-        const result = await ViewLicenceSummaryPresenter.go(licence)
-
-        expect(result.abstractionQuantities).to.equal([
-          '60.00 cubic metres per hour',
-          '6.00 litres per second'
-        ])
-      })
-    })
-
-    describe('and it has abstraction DAILY_QTY set to null', () => {
-      beforeEach(() => {
-        licence.permitLicence.purposes[0].ANNUAL_QTY = 'null'
-        licence.permitLicence.purposes[0].DAILY_QTY = 'null'
-        licence.permitLicence.purposes[0].HOURLY_QTY = 'null'
-        licence.permitLicence.purposes[0].INST_QTY = 6
-      })
-
-      it('will display the formatted string with the rate per period and the correct caption', async () => {
-        const result = await ViewLicenceSummaryPresenter.go(licence)
-
-        expect(result.abstractionQuantities).to.equal([
-          '6.00 litres per second'
-        ])
-      })
-    })
-
-    describe('and it has two purposes with the same abstraction information', () => {
-      beforeEach(() => {
-        licence.permitLicence.purposes = [{
-          ANNUAL_QTY: 265,
-          DAILY_QTY: 24,
-          HOURLY_QTY: 60,
-          INST_QTY: 6,
-          purposePoints: [{
-            point_detail: {
-              NGR1_SHEET: 'TL',
-              NGR1_EAST: '23198',
-              NGR1_NORTH: '88603'
-            },
-            point_source: {
-              NAME: 'SURFACE WATER SOURCE OF SUPPLY'
-            }
-          }]
-        }, {
-          ANNUAL_QTY: 265,
-          DAILY_QTY: 24,
-          HOURLY_QTY: 60,
-          INST_QTY: 6,
-          purposePoints: [{
-            point_detail: {
-              NGR1_SHEET: 'TL',
-              NGR1_EAST: '23198',
-              NGR1_NORTH: '88603'
-            },
-            point_source: {
-              NAME: 'SURFACE WATER SOURCE OF SUPPLY'
-            }
-          }]
-        }]
-      })
-
-      it('will display the formatted string with the rate per period and the correct caption', async () => {
-        const result = await ViewLicenceSummaryPresenter.go(licence)
-
-        expect(result.abstractionQuantities).to.equal([
-          '265.00 cubic metres per year',
-          '24.00 cubic metres per day',
-          '60.00 cubic metres per hour',
-          '6.00 litres per second'
-        ])
-      })
-    })
-
-    describe('and it has two purposes with different abstraction information', () => {
-      beforeEach(() => {
-        licence.permitLicence.purposes = [{
-          ANNUAL_QTY: 265,
-          DAILY_QTY: 24,
-          HOURLY_QTY: 60,
-          INST_QTY: 6,
-          purposePoints: [{
-            point_detail: {
-              NGR1_SHEET: 'TL',
-              NGR1_EAST: '23198',
-              NGR1_NORTH: '88603'
-            },
-            point_source: {
-              NAME: 'SURFACE WATER SOURCE OF SUPPLY'
-            }
-          }]
-        }, {
-          ANNUAL_QTY: 266,
-          DAILY_QTY: 24,
-          HOURLY_QTY: 60,
-          INST_QTY: 6,
-          purposePoints: [{
-            point_detail: {
-              NGR1_SHEET: 'TL',
-              NGR1_EAST: '23198',
-              NGR1_NORTH: '88603'
-            },
-            point_source: {
-              NAME: 'SURFACE WATER SOURCE OF SUPPLY'
-            }
-          }]
-        }]
-      })
-
-      it('will display the formatted string with the rate per period and the correct caption', async () => {
-        const result = await ViewLicenceSummaryPresenter.go(licence)
-
-        expect(result.abstractionQuantities).to.equal(null)
       })
     })
   })
@@ -1172,6 +973,10 @@ function _licence () {
           abstractionPeriodStartMonth: 4,
           abstractionPeriodEndDay: 31,
           abstractionPeriodEndMonth: 10,
+          annualQuantity: 180000,
+          dailyQuantity: 720,
+          hourlyQuantity: 144,
+          instantQuantity: 40,
           purpose: { id: '0316229a-e76d-4785-bc2c-65075a1a8f50', description: 'Spray Irrigation - Storage' },
           licenceVersionPurposeConditions: [
             {
@@ -1196,6 +1001,10 @@ function _licence () {
           abstractionPeriodStartMonth: 11,
           abstractionPeriodEndDay: 31,
           abstractionPeriodEndMonth: 3,
+          annualQuantity: null,
+          dailyQuantity: null,
+          hourlyQuantity: null,
+          instantQuantity: null,
           purpose: { id: '0316229a-e76d-4785-bc2c-65075a1a8f50', description: 'Spray Irrigation - Storage' },
           licenceVersionPurposeConditions: [
             {
@@ -1213,6 +1022,10 @@ function _licence () {
           abstractionPeriodStartMonth: 4,
           abstractionPeriodEndDay: 31,
           abstractionPeriodEndMonth: 10,
+          annualQuantity: null,
+          dailyQuantity: null,
+          hourlyQuantity: null,
+          instantQuantity: null,
           purpose: { id: 'd1fc1c6f-bff0-4da2-a41a-033f151fddc7', description: 'Spray Irrigation - Direct' },
           licenceVersionPurposeConditions: [
             {

--- a/test/services/licences/fetch-licence-summary.service.test.js
+++ b/test/services/licences/fetch-licence-summary.service.test.js
@@ -136,6 +136,10 @@ describe('Fetch Licence Summary service', () => {
               abstractionPeriodStartMonth: 1,
               abstractionPeriodEndDay: 31,
               abstractionPeriodEndMonth: 3,
+              annualQuantity: null,
+              dailyQuantity: null,
+              hourlyQuantity: null,
+              instantQuantity: null,
               purpose: {
                 id: purpose.id,
                 description: 'Spray Irrigation - Storage'

--- a/test/services/licences/view-licence-summary.service.test.js
+++ b/test/services/licences/view-licence-summary.service.test.js
@@ -42,17 +42,18 @@ describe('View Licence Summary service', () => {
         const result = await ViewLicenceSummaryService.go(testId)
 
         expect(result).to.equal({
+          abstractionAmounts: [],
           abstractionConditions: [],
-          abstractionPeriods: null,
+          abstractionPeriods: [],
           abstractionPeriodsAndPurposesLinkText: null,
-          abstractionPointLinkText: 'View details of the abstraction point',
+          abstractionPeriodsCaption: 'Period of abstraction',
           abstractionPoints: ['At National Grid Reference TL 23198 88603'],
           abstractionPointsCaption: 'Point of abstraction',
-          abstractionQuantities: null,
+          abstractionPointsLinkText: 'View details of the abstraction point',
           activeTab: 'summary',
           documentId: '28665d16-eba3-4c9a-aa55-7ab671b0c4fb',
           endDate: null,
-          id: 'f1288f6c-8503-4dc1-b114-75c408a14bd0',
+          licenceId: 'f1288f6c-8503-4dc1-b114-75c408a14bd0',
           licenceHolder: 'Unregistered licence',
           monitoringStations: [{
             id: 'ac075651-4781-4e24-a684-b943b98607ca',


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4322

> Part of our work to replace the legacy view licence page

We found our new licence was crashing when we tried to view a specific licence. When we dug into it, the problem was that even though it had a current version in the `PermitLicenceModel`s `licenceDataValue` field, and that version had purposes, those purposes didn't have abstraction amounts.

It's not common for licences to be in this state, but there is not much we can do as the data comes from NALD. It would have to be corrected there.

So, we need to update the `ViewLicenceSummaryPresenter` code to handle this. But it has been some time since we built the summary tab so we have more experience with the licence abstraction data. For example, we now know these values can be taken from somewhere other than the JSON blob the previous team was using.

This means, along with fixing the issue, we intend to do a little 'housekeeping' along the way to try and simplify how things are working, and to use normalised data wherever we can.