### PR TITLE
Fix ordering of points and purposes in ret. req.

### DIFF
--- a/app/services/return-requirements/fetch-licence-purposes.service.js
+++ b/app/services/return-requirements/fetch-licence-purposes.service.js
@@ -28,6 +28,9 @@ async function _fetch (licenceId) {
     .innerJoin('licenceVersions', 'licenceVersionPurposes.licenceVersionId', 'licenceVersions.id')
     .where('licenceVersions.licenceId', licenceId)
     .where('licenceVersions.status', 'current')
+    .orderBy([
+      { column: 'purposes.description', order: 'asc' }
+    ])
 }
 
 module.exports = {

--- a/app/services/return-requirements/fetch-points.service.js
+++ b/app/services/return-requirements/fetch-points.service.js
@@ -44,6 +44,7 @@ async function _fetchPoints (licenceId) {
 function _abstractPointsData (result) {
   const pointsData = []
 
+  // First extract from the current_version's purposes the various points
   result.purposes.forEach((purpose) => {
     purpose.purposePoints.forEach((point) => {
       const pointDetail = point.point_detail
@@ -51,7 +52,16 @@ function _abstractPointsData (result) {
     })
   })
 
-  return pointsData
+  // Then sort the extracted points to give us a consistent display order and return
+  return pointsData.sort((first, second) => {
+    // NOTE: This ensures we don't call localeCompare with null or undefined values
+    const firstLocalName = first.LOCAL_NAME ? first.LOCAL_NAME : ''
+    const secondLocalName = second.LOCAL_NAME ? second.LOCAL_NAME : ''
+
+    // NOTE: localeCompare() handles dealing with values in different cases automatically! So we don't have to lowercase
+    // everything before then comparing.
+    return firstLocalName.localeCompare(secondLocalName)
+  })
 }
 
 module.exports = {

--- a/test/services/return-requirements/fetch-licence-purposes.service.test.js
+++ b/test/services/return-requirements/fetch-licence-purposes.service.test.js
@@ -28,9 +28,9 @@ describe('Return Requirements - Fetch Licence Purposes service', () => {
 
     // Create 3 descriptions for the purposes
     purposes = await Promise.all([
+      await PurposeHelper.add({ id: '8290bb6a-4265-4cc8-b9bb-37cde1357d5d', description: 'Large Garden Watering' }),
       await PurposeHelper.add({ id: '14794d57-1acf-4c91-8b48-4b1ec68bfd6f', description: 'Heat Pump' }),
-      await PurposeHelper.add({ id: '49088608-ee9f-491a-8070-6831240945ac', description: 'Horticultural Watering' }),
-      await PurposeHelper.add({ id: '8290bb6a-4265-4cc8-b9bb-37cde1357d5d', description: 'Large Garden Watering' })
+      await PurposeHelper.add({ id: '49088608-ee9f-491a-8070-6831240945ac', description: 'Horticultural Watering' })
     ])
 
     // Create the licenceVersionPurposes with the purposes and licenceVersion
@@ -46,16 +46,18 @@ describe('Return Requirements - Fetch Licence Purposes service', () => {
     it('fetches the data', async () => {
       const result = await FetchLicencePurposesService.go(licenceVersion.licenceId)
 
-      expect(result).to.equal([{
+      expect(result[0]).to.equal({
         id: '14794d57-1acf-4c91-8b48-4b1ec68bfd6f',
         description: 'Heat Pump'
-      }, {
+      })
+      expect(result[1]).to.equal({
         id: '49088608-ee9f-491a-8070-6831240945ac',
         description: 'Horticultural Watering'
-      }, {
+      })
+      expect(result[2]).to.equal({
         id: '8290bb6a-4265-4cc8-b9bb-37cde1357d5d',
         description: 'Large Garden Watering'
-      }])
+      })
     })
   })
 

--- a/test/services/return-requirements/fetch-points.service.test.js
+++ b/test/services/return-requirements/fetch-points.service.test.js
@@ -53,7 +53,25 @@ describe('Return Requirements - Return requirements Fetch Points service', () =>
                     NGR4_NORTH: 'null',
                     NGR4_SHEET: 'null'
                   }
-                }]
+                },
+                {
+                  point_detail: {
+                    NGR1_EAST: '6520',
+                    NGR2_EAST: 'null',
+                    NGR3_EAST: 'null',
+                    NGR4_EAST: 'null',
+                    LOCAL_NAME: 'POINT A, ADDINGTON SANDPITS',
+                    NGR1_NORTH: '5937',
+                    NGR1_SHEET: 'TQ',
+                    NGR2_NORTH: 'null',
+                    NGR2_SHEET: 'null',
+                    NGR3_NORTH: 'null',
+                    NGR3_SHEET: 'null',
+                    NGR4_NORTH: 'null',
+                    NGR4_SHEET: 'null'
+                  }
+                }
+              ]
             }]
           }
         }
@@ -63,9 +81,25 @@ describe('Return Requirements - Return requirements Fetch Points service', () =>
 
   describe('when called', () => {
     it('returns result', async () => {
-      const result = await FetchPointsService.go(licence.id)
+      const results = await FetchPointsService.go(licence.id)
 
-      expect(result).to.equal([{
+      expect(results[0]).to.equal({
+        NGR1_EAST: '6520',
+        NGR2_EAST: 'null',
+        NGR3_EAST: 'null',
+        NGR4_EAST: 'null',
+        LOCAL_NAME: 'POINT A, ADDINGTON SANDPITS',
+        NGR1_NORTH: '5937',
+        NGR1_SHEET: 'TQ',
+        NGR2_NORTH: 'null',
+        NGR2_SHEET: 'null',
+        NGR3_NORTH: 'null',
+        NGR3_SHEET: 'null',
+        NGR4_NORTH: 'null',
+        NGR4_SHEET: 'null'
+      })
+
+      expect(results[1]).to.equal({
         NGR1_EAST: '69212',
         NGR2_EAST: 'null',
         NGR3_EAST: 'null',
@@ -79,7 +113,7 @@ describe('Return Requirements - Return requirements Fetch Points service', () =>
         NGR3_SHEET: 'null',
         NGR4_NORTH: 'null',
         NGR4_SHEET: 'null'
-      }])
+      })
     })
   })
 })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4478

When running the acceptance tests we've created for the returns requirement setup journeys, we've encountered random failures. Typically, it will pass on one machine but then fail on another.

We've tracked the root cause down to the fact we have not imposed an order in how we list the purposes and points during the journey. This means the test is always selecting option 1, for example, and then asserting it is 'Foo'. But depending on the machine the test is running on option 1 might have displayed as 'Bar'. This means the assertion fails.

This change ensures the points and purposes in the journey are listed in a consistent controlled manor. This will fix the tests and make things better for all!