### PR TITLE
Fix default licence view createdBy

### DIFF
--- a/app/presenters/return-requirements/view.presenter.js
+++ b/app/presenters/return-requirements/view.presenter.js
@@ -36,7 +36,7 @@ function go (requirementsForReturns) {
     startDate: formatLongDate(startDate),
     status: _status(status),
     createdDate: formatLongDate(createdAt),
-    createdBy: user ? user.username : ''
+    createdBy: user ? user.username : 'Migrated from NALD'
   }
 }
 

--- a/test/presenters/return-requirements/view.presenter.test.js
+++ b/test/presenters/return-requirements/view.presenter.test.js
@@ -84,7 +84,7 @@ describe('Return Requirements - View presenter', () => {
         additionalSubmissionOptions: {
           multipleUpload: 'No'
         },
-        createdBy: '',
+        createdBy: 'Migrated from NALD',
         createdDate: '1 December 2020',
         licenceId: 'c32ab7c6-e342-47b2-9c2e-d178ca89c5e5',
         licenceRef: '02/01',
@@ -116,10 +116,10 @@ describe('Return Requirements - View presenter', () => {
 
     describe('the "createdBy" property', () => {
       describe('and there is no user linked to the return', () => {
-        it('returns an empty string', () => {
+        it('returns "Migrated from NALD" ', () => {
           const result = ViewPresenter.go(requirementsForReturns)
 
-          expect(result.createdBy).to.equal('')
+          expect(result.createdBy).to.equal('Migrated from NALD')
         })
       })
       describe('and there is a user linked to the return', () => {

--- a/test/services/return-requirements/view.service.test.js
+++ b/test/services/return-requirements/view.service.test.js
@@ -41,7 +41,7 @@ describe('Return Requirements - View service', () => {
         additionalSubmissionOptions: {
           multipleUpload: 'No'
         },
-        createdBy: '',
+        createdBy: 'Migrated from NALD',
         createdDate: returnVersion.createdAt.toLocaleDateString('en-GB', { year: 'numeric', month: 'long', day: 'numeric' }),
         licenceId: licence.id,
         licenceRef: result.licenceRef,


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4422

When a return version does not have a user linked to the record the default string should be "Migrated from NALD".

The assumption is a user can not create a return unless they are logged in. When the return is saved the user will be captured and stored in the createdBy column. Therefore, if the created by field is null then it is safe to assume the data has been migrated from NALD.