### PR TITLE
Add company address model and relationships

### DIFF
--- a/app/models/address.model.js
+++ b/app/models/address.model.js
@@ -24,6 +24,14 @@ class AddressModel extends BaseModel {
           to: 'billingAccountAddresses.addressId'
         }
       },
+      companyAddresses: {
+        relation: Model.HasManyRelation,
+        modelClass: 'company-address.model',
+        join: {
+          from: 'addresses.id',
+          to: 'companyAddresses.addressId'
+        }
+      },
       licenceDocumentRoles: {
         relation: Model.HasManyRelation,
         modelClass: 'licence-document-role.model',

--- a/app/models/company-address.model.js
+++ b/app/models/company-address.model.js
@@ -1,0 +1,47 @@
+'use strict'
+
+/**
+ * Model for company_addresses (crm_v2.company_addresses)
+ * @module CompanyAddressModel
+ */
+
+const { Model } = require('objection')
+
+const BaseModel = require('./base.model.js')
+
+class CompanyAddressModel extends BaseModel {
+  static get tableName () {
+    return 'companyAddresses'
+  }
+
+  static get relationMappings () {
+    return {
+      address: {
+        relation: Model.BelongsToOneRelation,
+        modelClass: 'address.model',
+        join: {
+          from: 'companyAddresses.addressId',
+          to: 'addresses.id'
+        }
+      },
+      company: {
+        relation: Model.BelongsToOneRelation,
+        modelClass: 'company.model',
+        join: {
+          from: 'companyAddresses.companyId',
+          to: 'companies.id'
+        }
+      },
+      licenceRole: {
+        relation: Model.BelongsToOneRelation,
+        modelClass: 'licence-role.model',
+        join: {
+          from: 'companyAddresses.licenceRoleId',
+          to: 'licenceRoles.id'
+        }
+      }
+    }
+  }
+}
+
+module.exports = CompanyAddressModel

--- a/app/models/company.model.js
+++ b/app/models/company.model.js
@@ -64,6 +64,14 @@ class CompanyModel extends BaseModel {
           to: 'billingAccounts.companyId'
         }
       },
+      companyAddresses: {
+        relation: Model.HasManyRelation,
+        modelClass: 'company-address.model',
+        join: {
+          from: 'companies.id',
+          to: 'companyAddresses.companyId'
+        }
+      },
       licenceDocumentRoles: {
         relation: Model.HasManyRelation,
         modelClass: 'licence-document-role.model',

--- a/app/models/licence-role.model.js
+++ b/app/models/licence-role.model.js
@@ -16,6 +16,14 @@ class LicenceRoleModel extends BaseModel {
 
   static get relationMappings () {
     return {
+      companyAddresses: {
+        relation: Model.HasManyRelation,
+        modelClass: 'company-address.model',
+        join: {
+          from: 'licenceRoles.id',
+          to: 'companyAddresses.licenceRoleId'
+        }
+      },
       licenceDocumentRoles: {
         relation: Model.HasManyRelation,
         modelClass: 'licence-document-role.model',

--- a/app/services/data/load/load.service.js
+++ b/app/services/data/load/load.service.js
@@ -22,6 +22,7 @@ const ChargeCategoryHelper = require('../../../../test/support/helpers/charge-ca
 const ChargeElementHelper = require('../../../../test/support/helpers/charge-element.helper.js')
 const ChargeReferenceHelper = require('../../../../test/support/helpers/charge-reference.helper.js')
 const ChargeVersionHelper = require('../../../../test/support/helpers/charge-version.helper.js')
+const CompanyAddressHelper = require('../../../../test/support/helpers/company-address.helper.js')
 const CompanyContactHelper = require('../../../../test/support/helpers/company-contact.helper.js')
 const CompanyHelper = require('../../../../test/support/helpers/company.helper.js')
 const ContactHelper = require('../../../../test/support/helpers/contact.helper.js')
@@ -85,6 +86,7 @@ const LOAD_HELPERS = {
   chargeElements: { helper: ChargeElementHelper, test: true, legacy: { schema: 'water', table: 'charge_purposes', id: 'charge_purpose_id' } },
   chargeReferences: { helper: ChargeReferenceHelper, test: true, legacy: { schema: 'water', table: 'charge_elements', id: 'charge_element_id' } },
   chargeVersions: { helper: ChargeVersionHelper, test: true, legacy: { schema: 'water', table: 'charge_versions', id: 'charge_version_id' } },
+  companyAddresses: { helper: CompanyAddressHelper, test: true, legacy: { schema: 'crm_v2', table: 'company_addresses', id: 'company_address_id' } },
   companyContacts: { helper: CompanyContactHelper, test: true, legacy: { schema: 'crm_v2', table: 'company_contacts', id: 'company_contact_id' } },
   companies: { helper: CompanyHelper, test: true, legacy: { schema: 'crm_v2', table: 'companies', id: 'company_id' } },
   contacts: { helper: ContactHelper, test: true, legacy: { schema: 'crm_v2', table: 'contacts', id: 'contact_id' } },

--- a/db/migrations/legacy/20221108003010_crm-v2-company-addresses.js
+++ b/db/migrations/legacy/20221108003010_crm-v2-company-addresses.js
@@ -1,0 +1,36 @@
+'use strict'
+
+const tableName = 'company_addresses'
+
+exports.up = function (knex) {
+  return knex
+    .schema
+    .withSchema('crm_v2')
+    .createTable(tableName, (table) => {
+      // Primary Key
+      table.uuid('company_address_id').primary().defaultTo(knex.raw('gen_random_uuid()'))
+
+      // Data
+      table.uuid('company_id').notNullable()
+      table.uuid('address_id').notNullable()
+      table.uuid('role_id').notNullable()
+      table.boolean('is_default').notNullable().defaultTo(false)
+      table.date('start_date').notNullable()
+      table.date('end_date')
+      table.boolean('is_test').notNullable().defaultTo(false)
+
+      // Legacy timestamps
+      table.timestamp('date_created', { useTz: false }).notNullable().defaultTo(knex.fn.now())
+      table.timestamp('date_updated', { useTz: false }).notNullable().defaultTo(knex.fn.now())
+
+      // Constraints
+      table.unique(['company_id', 'address_id', 'role_id'], { useConstraint: true })
+    })
+}
+
+exports.down = function (knex) {
+  return knex
+    .schema
+    .withSchema('crm_v2')
+    .dropTableIfExists(tableName)
+}

--- a/db/migrations/public/20240625082201_create-company-addresses-view.js
+++ b/db/migrations/public/20240625082201_create-company-addresses-view.js
@@ -1,0 +1,29 @@
+'use strict'
+
+const viewName = 'company_addresses'
+
+exports.up = function (knex) {
+  return knex
+    .schema
+    .createView(viewName, (view) => {
+      // NOTE: We have commented out unused columns from the source table
+      view.as(knex('company_addresses').withSchema('crm_v2').select([
+        'company_address_id AS id',
+        'company_id',
+        'address_id',
+        'role_id AS licence_role_id',
+        'is_default AS default',
+        'start_date',
+        'end_date',
+        // is_test
+        'date_created AS created_at',
+        'date_updated AS updated_at'
+      ]))
+    })
+}
+
+exports.down = function (knex) {
+  return knex
+    .schema
+    .dropViewIfExists(viewName)
+}

--- a/test/models/address.model.test.js
+++ b/test/models/address.model.test.js
@@ -11,6 +11,8 @@ const { expect } = Code
 const AddressHelper = require('../support/helpers/address.helper.js')
 const BillingAccountAddressHelper = require('../support/helpers/billing-account-address.helper.js')
 const BillingAccountAddressModel = require('../../app/models/billing-account-address.model.js')
+const CompanyAddressHelper = require('../support/helpers/company-address.helper.js')
+const CompanyAddressModel = require('../../app/models/company-address.model.js')
 const DatabaseSupport = require('../support/database.js')
 const LicenceDocumentRoleHelper = require('../support/helpers/licence-document-role.helper.js')
 const LicenceDocumentRoleModel = require('../../app/models/licence-document-role.model.js')
@@ -75,6 +77,43 @@ describe('Address model', () => {
         expect(result.billingAccountAddresses[0]).to.be.an.instanceOf(BillingAccountAddressModel)
         expect(result.billingAccountAddresses).to.include(testBillingAccountAddresses[0])
         expect(result.billingAccountAddresses).to.include(testBillingAccountAddresses[1])
+      })
+    })
+
+    describe('when linking to company addresses', () => {
+      let testCompanyAddresses
+
+      beforeEach(async () => {
+        testRecord = await AddressHelper.add()
+
+        const { id: addressId } = testRecord
+
+        testCompanyAddresses = []
+        for (let i = 0; i < 2; i++) {
+          const companyAddress = await CompanyAddressHelper.add({ addressId })
+          testCompanyAddresses.push(companyAddress)
+        }
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await AddressModel.query()
+          .innerJoinRelated('companyAddresses')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the company addresses', async () => {
+        const result = await AddressModel.query()
+          .findById(testRecord.id)
+          .withGraphFetched('companyAddresses')
+
+        expect(result).to.be.instanceOf(AddressModel)
+        expect(result.id).to.equal(testRecord.id)
+
+        expect(result.companyAddresses).to.be.an.array()
+        expect(result.companyAddresses[0]).to.be.an.instanceOf(CompanyAddressModel)
+        expect(result.companyAddresses).to.include(testCompanyAddresses[0])
+        expect(result.companyAddresses).to.include(testCompanyAddresses[1])
       })
     })
 

--- a/test/models/company-address.model.test.js
+++ b/test/models/company-address.model.test.js
@@ -1,0 +1,134 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const AddressHelper = require('../support/helpers/address.helper.js')
+const AddressModel = require('../../app/models/address.model.js')
+const CompanyAddressHelper = require('../support/helpers/company-address.helper.js')
+const DatabaseSupport = require('../support/database.js')
+const CompanyHelper = require('../support/helpers/company.helper.js')
+const CompanyModel = require('../../app/models/company.model.js')
+const LicenceRoleHelper = require('../support/helpers/licence-role.helper.js')
+const LicenceRoleModel = require('../../app/models/licence-role.model.js')
+
+// Thing under test
+const CompanyAddressModel = require('../../app/models/company-address.model.js')
+
+describe('Company Address model', () => {
+  let testRecord
+
+  beforeEach(async () => {
+    await DatabaseSupport.clean()
+  })
+
+  describe('Basic query', () => {
+    beforeEach(async () => {
+      testRecord = await CompanyAddressHelper.add()
+    })
+
+    it('can successfully run a basic query', async () => {
+      const result = await CompanyAddressModel.query().findById(testRecord.id)
+
+      expect(result).to.be.an.instanceOf(CompanyAddressModel)
+      expect(result.id).to.equal(testRecord.id)
+    })
+  })
+
+  describe('Relationships', () => {
+    describe('when linking to address', () => {
+      let testAddress
+
+      beforeEach(async () => {
+        testAddress = await AddressHelper.add()
+
+        const { id: addressId } = testAddress
+        testRecord = await CompanyAddressHelper.add({ addressId })
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await CompanyAddressModel.query()
+          .innerJoinRelated('address')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the address', async () => {
+        const result = await CompanyAddressModel.query()
+          .findById(testRecord.id)
+          .withGraphFetched('address')
+
+        expect(result).to.be.instanceOf(CompanyAddressModel)
+        expect(result.id).to.equal(testRecord.id)
+
+        expect(result.address).to.be.an.instanceOf(AddressModel)
+        expect(result.address).to.equal(testAddress)
+      })
+    })
+
+    describe('when linking to company', () => {
+      let testCompany
+
+      beforeEach(async () => {
+        testCompany = await CompanyHelper.add()
+
+        const { id: companyId } = testCompany
+        testRecord = await CompanyAddressHelper.add({ companyId })
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await CompanyAddressModel.query()
+          .innerJoinRelated('company')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the company', async () => {
+        const result = await CompanyAddressModel.query()
+          .findById(testRecord.id)
+          .withGraphFetched('company')
+
+        expect(result).to.be.instanceOf(CompanyAddressModel)
+        expect(result.id).to.equal(testRecord.id)
+
+        expect(result.company).to.be.an.instanceOf(CompanyModel)
+        expect(result.company).to.equal(testCompany)
+      })
+    })
+
+    describe('when linking to licence role', () => {
+      let testLicenceRole
+
+      beforeEach(async () => {
+        testLicenceRole = await LicenceRoleHelper.add()
+
+        const { id: licenceRoleId } = testLicenceRole
+        testRecord = await CompanyAddressHelper.add({ licenceRoleId })
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await CompanyAddressModel.query()
+          .innerJoinRelated('licenceRole')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the licence role', async () => {
+        const result = await CompanyAddressModel.query()
+          .findById(testRecord.id)
+          .withGraphFetched('licenceRole')
+
+        expect(result).to.be.instanceOf(CompanyAddressModel)
+        expect(result.id).to.equal(testRecord.id)
+
+        expect(result.licenceRole).to.be.an.instanceOf(LicenceRoleModel)
+        expect(result.licenceRole).to.equal(testLicenceRole)
+      })
+    })
+  })
+})

--- a/test/models/company.model.test.js
+++ b/test/models/company.model.test.js
@@ -12,6 +12,8 @@ const BillingAccountAddressHelper = require('../support/helpers/billing-account-
 const BillingAccountAddressModel = require('../../app/models/billing-account-address.model.js')
 const BillingAccountHelper = require('../support/helpers/billing-account.helper.js')
 const BillingAccountModel = require('../../app/models/billing-account.model.js')
+const CompanyAddressHelper = require('../support/helpers/company-address.helper.js')
+const CompanyAddressModel = require('../../app/models/company-address.model.js')
 const CompanyHelper = require('../support/helpers/company.helper.js')
 const DatabaseSupport = require('../support/database.js')
 const LicenceDocumentRoleHelper = require('../support/helpers/licence-document-role.helper.js')
@@ -113,6 +115,43 @@ describe('Company model', () => {
         expect(result.billingAccounts[0]).to.be.an.instanceOf(BillingAccountModel)
         expect(result.billingAccounts).to.include(testBillingAccounts[0])
         expect(result.billingAccounts).to.include(testBillingAccounts[1])
+      })
+    })
+
+    describe('when linking to company addresses', () => {
+      let testCompanyAddresses
+
+      beforeEach(async () => {
+        testRecord = await CompanyHelper.add()
+
+        const { id: companyId } = testRecord
+
+        testCompanyAddresses = []
+        for (let i = 0; i < 2; i++) {
+          const companyAddress = await CompanyAddressHelper.add({ companyId })
+          testCompanyAddresses.push(companyAddress)
+        }
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await CompanyModel.query()
+          .innerJoinRelated('companyAddresses')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the company addresses', async () => {
+        const result = await CompanyModel.query()
+          .findById(testRecord.id)
+          .withGraphFetched('companyAddresses')
+
+        expect(result).to.be.instanceOf(CompanyModel)
+        expect(result.id).to.equal(testRecord.id)
+
+        expect(result.companyAddresses).to.be.an.array()
+        expect(result.companyAddresses[0]).to.be.an.instanceOf(CompanyAddressModel)
+        expect(result.companyAddresses).to.include(testCompanyAddresses[0])
+        expect(result.companyAddresses).to.include(testCompanyAddresses[1])
       })
     })
 

--- a/test/models/licence-role.model.test.js
+++ b/test/models/licence-role.model.test.js
@@ -8,6 +8,8 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
+const CompanyAddressHelper = require('../support/helpers/company-address.helper.js')
+const CompanyAddressModel = require('../../app/models/company-address.model.js')
 const DatabaseSupport = require('../support/database.js')
 const LicenceDocumentRoleHelper = require('../support/helpers/licence-document-role.helper.js')
 const LicenceDocumentRoleModel = require('../../app/models/licence-document-role.model.js')
@@ -37,6 +39,43 @@ describe('Licence Role model', () => {
   })
 
   describe('Relationships', () => {
+    describe('when linking to company addresses', () => {
+      let testCompanyAddresses
+
+      beforeEach(async () => {
+        testRecord = await LicenceRoleHelper.add()
+
+        const { id: licenceRoleId } = testRecord
+
+        testCompanyAddresses = []
+        for (let i = 0; i < 2; i++) {
+          const companyAddress = await CompanyAddressHelper.add({ licenceRoleId })
+          testCompanyAddresses.push(companyAddress)
+        }
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await LicenceRoleModel.query()
+          .innerJoinRelated('companyAddresses')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the company addresses', async () => {
+        const result = await LicenceRoleModel.query()
+          .findById(testRecord.id)
+          .withGraphFetched('companyAddresses')
+
+        expect(result).to.be.instanceOf(LicenceRoleModel)
+        expect(result.id).to.equal(testRecord.id)
+
+        expect(result.companyAddresses).to.be.an.array()
+        expect(result.companyAddresses[0]).to.be.an.instanceOf(CompanyAddressModel)
+        expect(result.companyAddresses).to.include(testCompanyAddresses[0])
+        expect(result.companyAddresses).to.include(testCompanyAddresses[1])
+      })
+    })
+
     describe('when linking to licence document roles', () => {
       let testLicenceDocumentRoles
 

--- a/test/support/helpers/company-address.helper.js
+++ b/test/support/helpers/company-address.helper.js
@@ -1,0 +1,57 @@
+'use strict'
+
+/**
+ * @module CompanyAddressHelper
+ */
+
+const CompanyAddressModel = require('../../../app/models/company-address.model.js')
+const { generateUUID } = require('../../../app/lib/general.lib.js')
+
+/**
+ * Add a new company address
+ *
+ * If no `data` is provided, default values will be used. These are
+ *
+ * - `addressId` - [random UUID]
+ * - `companyId` - [random UUID]
+ * - `licenceRoleId` - [random UUID]
+ * - `startDate` - 2022-04-01
+ *
+ * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ *
+ * @returns {Promise<module:CompanyAddressModel>} The instance of the newly created record
+ */
+function add (data = {}) {
+  const insertData = defaults(data)
+
+  return CompanyAddressModel.query()
+    .insert({ ...insertData })
+    .returning('*')
+}
+
+/**
+ * Returns the defaults used
+ *
+ * It will override or append to them any data provided. Mainly used by the `add()` method, we make it available
+ * for use in tests to avoid having to duplicate values.
+ *
+ * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ */
+function defaults (data = {}) {
+  const defaults = {
+    addressId: generateUUID(),
+    companyId: generateUUID(),
+    licenceRoleId: generateUUID(),
+    startDate: new Date('2022-04-01')
+  }
+
+  return {
+    ...defaults,
+    ...data
+  }
+}
+
+module.exports = {
+  add,
+  defaults
+}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3981

We recently [added a new acceptance test data loader](https://eaflood.atlassian.net/browse/WATER-3981) to replace the slow and flaky legacy acceptance test data loader in [water-abstraction-service](https://github.com/DEFRA/water-abstraction-service).

However, a couple of our acceptance tests fail when using our new test data. After investigation, it turns out that the legacy charge information setup journey relies on their being a `crm_v2.company_addresses` record linking a company to its addresses.

It can find the companies linked to our licence. But once you select the company to use it then goes looking for the possible addresses. With the old test data you get to pick from 2 because there are `crm_v2.company_addresses`. With our new test data you are taken to the enter a postcode screen as a fallback to the legacy code not finding any addresses.

At the moment this is the only reason we've come across that depends on this table. But we need it to make this journey work.

SO, this change adds the model and links it to `CompanyModel`. We then ensure it is cleaned down in the tear-down and available in our data loader.