### PR TITLE
Fix licence set up links

### DIFF
--- a/app/views/licences/tabs/set-up.njk
+++ b/app/views/licences/tabs/set-up.njk
@@ -134,7 +134,7 @@
   <p>
     {{ govukButton({
       text: "Set up a new charge",
-      href: setupNewCharge,
+      href: links.chargeInformation.setupNewCharge ,
       classes: "govuk-button--secondary govuk-!-margin-right-3"
     }) }}
   </p>
@@ -144,7 +144,7 @@
   <p>
     {{ govukButton({
       text: "Make licence non-chargeable",
-      href: makeLicenceNonChargeable,
+      href: links.chargeInformation.makeLicenceNonChargeable,
       classes: "govuk-button--secondary"
     }) }}
   </p>
@@ -204,7 +204,7 @@
 {% if links.agreements.setUpAgreement %}
   {{ govukButton({
     text: "Set up a new agreement",
-    href: setUpAgreement,
+    href: links.agreements.setUpAgreement,
     classes: "govuk-button--secondary"
   }) }}
 {% endif %}

--- a/app/views/licences/tabs/set-up.njk
+++ b/app/views/licences/tabs/set-up.njk
@@ -134,7 +134,7 @@
   <p>
     {{ govukButton({
       text: "Set up a new charge",
-      href: links.chargeInformation.setupNewCharge ,
+      href: links.chargeInformation.setupNewCharge,
       classes: "govuk-button--secondary govuk-!-margin-right-3"
     }) }}
   </p>


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4422

During a refactor the links for the page where wrapped up into a single object.

The previous links where missed. This change adds the link to the href block of the gov uk buttons.

The links are used in the if condition and work / where done as part of the original refactor.