### PR TITLE
Lint - spaces around blocks and expressions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,9 +9,6 @@ module.exports = {
     '@stylistic/js'
   ],
   rules: {
-    'arrow-body-style': ['error', 'always'],
-    'import/extensions': ['error', 'always'],
-    strict: ['error', 'global'],
     '@stylistic/js/arrow-parens': ['error', 'always'],
     '@stylistic/js/implicit-arrow-linebreak': ['off'],
     '@stylistic/js/max-len': ['error', {
@@ -22,8 +19,17 @@ module.exports = {
     }],
     '@stylistic/js/padding-line-between-statements': [
       'error',
-      { blankLine: 'always', prev: '*', next: 'return' }
-    ]
+      { blankLine: 'always', prev: '*', next: 'block' },
+      { blankLine: 'always', prev: '*', next: 'expression' },
+      { blankLine: 'always', prev: '*', next: 'return' },
+      { blankLine: 'always', prev: 'block', next: '*' },
+      { blankLine: 'always', prev: 'block', next: 'function' },
+      { blankLine: 'always', prev: 'expression', next: '*' },
+      { blankLine: 'always', prev: 'function', next: '*' }
+    ],
+    'arrow-body-style': ['error', 'always'],
+    'import/extensions': ['error', 'always'],
+    strict: ['error', 'global']
   }
 }
 

--- a/test/presenters/return-requirements/view.presenter.test.js
+++ b/test/presenters/return-requirements/view.presenter.test.js
@@ -122,10 +122,12 @@ describe('Return Requirements - View presenter', () => {
           expect(result.createdBy).to.equal('Migrated from NALD')
         })
       })
+
       describe('and there is a user linked to the return', () => {
         beforeEach(() => {
           requirementsForReturns.user = { username: 'iron@man.net' }
         })
+
         it('returns the users username', () => {
           const result = ViewPresenter.go(requirementsForReturns)
 


### PR DESCRIPTION
This change should enforce linting on commons NITs picked up in pull requests.

6 Rules have been added.

1. `blankLine: 'always', prev: '*', next: 'block'`: Requires a blank line before a block statement ({}).

2. `blankLine: 'always', prev: '*', next: 'expression'`: Requires a blank line before an expression statement.

3. `blankLine: 'always', prev: 'block', next: '*'`: Requires a blank line after a block statement ({}).

4. `blankLine: 'always', prev: 'block', next: 'function'`: Requires a blank line after a block statement ({}) followed by a function declaration.

5. `blankLine: 'always', prev: 'expression', next: '*'`: Requires a blank line after an expression statement.

6. `blankLine: 'always', prev: 'function', next: '*'`: Requires a blank line after a function declaration.

This combination should also enforce the blank space after a describe block and a space before an expect expression in the test files.

https://github.com/DEFRA/water-abstraction-team/blob/main/coding_conventions.md