### PR TITLE
Spike allowing test to be independent of cleanup.

### DIFF
--- a/db/clean.js
+++ b/db/clean.js
@@ -1,0 +1,28 @@
+'use strict'
+
+if (process.env.NODE_ENV !== 'test') {
+  console.error('NODE_ENV is not set to test!')
+  process.exit(1)
+}
+
+const Database = require('../test/support/database.js')
+
+// NOTE: We have to close the knex instance after execution to avoid Node process hanging due to open connections
+// https://knexjs.org/faq/recipes.html#node-instance-doesn-t-stop-after-using-knex
+//
+// To do this we have added a function to close the connection in database support
+async function run () {
+  console.log('Database clean for tests')
+
+  try {
+    await Database.clean()
+    console.log('Database cleaned')
+  } catch (error) {
+    process.exit(1)
+  } finally {
+    Database.closeConnection()
+    console.log('Database connection closed for cleaning')
+  }
+}
+
+run()

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "seed": "knex seed:run --knexfile knexfile.application.js",
     "lint": "eslint $(git diff --name-only --diff-filter=ACMRTUXB  | grep -E \"\\.(js)$\")",
     "lint:all": "eslint .",
+    "pretest": "NODE_ENV=test node db/clean.js",
     "test": "lab --silent-skips --shuffle",
     "postinstall": "npm run build",
     "version": "npx --yes auto-changelog -p --commit-limit false && git add CHANGELOG.md"

--- a/test/services/bill-licences/fetch-bill-licence.service.test.js
+++ b/test/services/bill-licences/fetch-bill-licence.service.test.js
@@ -18,7 +18,6 @@ const ChargeElementHelper = require('../../support/helpers/charge-element.helper
 const ChargeElementModel = require('../../../app/models/charge-element.model.js')
 const ChargeReferenceHelper = require('../../support/helpers/charge-reference.helper.js')
 const ChargeReferenceModel = require('../../../app/models/charge-reference.model.js')
-const DatabaseSupport = require('../../support/database.js')
 const PurposeHelper = require('../../support/helpers/purpose.helper.js')
 const PurposeModel = require('../../../app/models/purpose.model.js')
 const TransactionHelper = require('../../support/helpers/transaction.helper.js')
@@ -35,8 +34,6 @@ describe('Fetch Bill Licence service', () => {
   let testBillLicence
 
   beforeEach(async () => {
-    await DatabaseSupport.clean()
-
     linkedBillRun = await BillRunHelper.add({ status: 'ready' })
     linkedBill = await BillHelper.add({ billRunId: linkedBillRun.id })
 

--- a/test/services/bill-runs/determine-blocking-bill-run.service.test.js
+++ b/test/services/bill-runs/determine-blocking-bill-run.service.test.js
@@ -9,28 +9,33 @@ const { expect } = Code
 
 // Test helpers
 const BillRunHelper = require('../../support/helpers/bill-run.helper.js')
-const DatabaseSupport = require('../../support/database.js')
-const { determineCurrentFinancialYear } = require('../../../app/lib/general.lib.js')
 const RegionHelper = require('../../support/helpers/region.helper.js')
+const { determineCurrentFinancialYear } = require('../../../app/lib/general.lib.js')
+const { generateUUID } = require('../../../app/lib/general.lib.js')
 
 // Thing under test
 const DetermineBlockingBillRunService = require('../../../app/services/bill-runs/determine-blocking-bill-run.service.js')
 
 describe('Determine Blocking Bill Run service', () => {
   let batchType
+  let billRunIdOne
+  let billRunIdTwo
   let financialEndYear
   let regionId
   let season
   let toFinancialYearEnding
 
   beforeEach(async () => {
-    await DatabaseSupport.clean()
-
     const { endDate } = determineCurrentFinancialYear()
+
     toFinancialYearEnding = endDate.getFullYear()
 
     const region = await RegionHelper.add()
+
     regionId = region.id
+
+    billRunIdOne = generateUUID()
+    billRunIdTwo = generateUUID()
   })
 
   describe('when the user is setting up an annual bill run', () => {
@@ -43,7 +48,7 @@ describe('Determine Blocking Bill Run service', () => {
       beforeEach(async () => {
         await Promise.all([
           BillRunHelper.add({
-            id: '1021c5bc-673c-48fa-98dd-733b46c84f90', regionId, batchType: 'annual', status: 'ready', toFinancialYearEnding, scheme: 'sroc'
+            id: billRunIdOne, regionId, batchType: 'annual', status: 'ready', toFinancialYearEnding, scheme: 'sroc'
           })
         ])
       })
@@ -52,7 +57,7 @@ describe('Determine Blocking Bill Run service', () => {
         const results = await DetermineBlockingBillRunService.go(regionId, batchType, financialEndYear)
 
         expect(results).to.have.length(1)
-        expect(results[0].id).to.equal('1021c5bc-673c-48fa-98dd-733b46c84f90')
+        expect(results[0].id).to.equal(billRunIdOne)
       })
     })
 
@@ -60,7 +65,7 @@ describe('Determine Blocking Bill Run service', () => {
       describe('but a live bill run exists for the same year', () => {
         beforeEach(async () => {
           await BillRunHelper.add({
-            id: '1021c5bc-673c-48fa-98dd-733b46c84f90', regionId, batchType: 'two_part_tariff', status: 'review', toFinancialYearEnding, scheme: 'sroc'
+            id: billRunIdOne, regionId, batchType: 'two_part_tariff', status: 'review', toFinancialYearEnding, scheme: 'sroc'
           })
         })
 
@@ -68,14 +73,15 @@ describe('Determine Blocking Bill Run service', () => {
           const results = await DetermineBlockingBillRunService.go(regionId, batchType, financialEndYear)
 
           expect(results).to.have.length(1)
-          expect(results[0].id).to.equal('1021c5bc-673c-48fa-98dd-733b46c84f90')
+
+          expect(results[0].id).to.equal(billRunIdOne)
         })
       })
 
       describe('but a live bill run exists for a different year', () => {
         beforeEach(async () => {
           await BillRunHelper.add({
-            id: '1021c5bc-673c-48fa-98dd-733b46c84f90', regionId, batchType: 'two_part_tariff', status: 'review', toFinancialYearEnding: toFinancialYearEnding - 1, scheme: 'sroc'
+            id: billRunIdOne, regionId, batchType: 'two_part_tariff', status: 'review', toFinancialYearEnding: toFinancialYearEnding - 1, scheme: 'sroc'
           })
         })
 
@@ -107,7 +113,7 @@ describe('Determine Blocking Bill Run service', () => {
         beforeEach(async () => {
           await Promise.all([
             BillRunHelper.add({
-              id: '1021c5bc-673c-48fa-98dd-733b46c84f90', regionId, batchType: 'two_part_tariff', status: 'review', toFinancialYearEnding, scheme: 'sroc'
+              id: billRunIdOne, regionId, batchType: 'two_part_tariff', status: 'review', toFinancialYearEnding, scheme: 'sroc'
             })
           ])
         })
@@ -116,7 +122,7 @@ describe('Determine Blocking Bill Run service', () => {
           const results = await DetermineBlockingBillRunService.go(regionId, batchType, financialEndYear)
 
           expect(results).to.have.length(1)
-          expect(results[0].id).to.equal('1021c5bc-673c-48fa-98dd-733b46c84f90')
+          expect(results[0].id).to.equal(billRunIdOne)
         })
       })
 
@@ -124,7 +130,7 @@ describe('Determine Blocking Bill Run service', () => {
         describe('but a live bill run exists for the same year', () => {
           beforeEach(async () => {
             await BillRunHelper.add({
-              id: '1021c5bc-673c-48fa-98dd-733b46c84f90', regionId, batchType: 'supplementary', status: 'ready', toFinancialYearEnding, scheme: 'sroc'
+              id: billRunIdOne, regionId, batchType: 'supplementary', status: 'ready', toFinancialYearEnding, scheme: 'sroc'
             })
           })
 
@@ -132,7 +138,7 @@ describe('Determine Blocking Bill Run service', () => {
             const results = await DetermineBlockingBillRunService.go(regionId, batchType, financialEndYear)
 
             expect(results).to.have.length(1)
-            expect(results[0].id).to.equal('1021c5bc-673c-48fa-98dd-733b46c84f90')
+            expect(results[0].id).to.equal(billRunIdOne)
           })
         })
 
@@ -157,7 +163,7 @@ describe('Determine Blocking Bill Run service', () => {
         beforeEach(async () => {
           await Promise.all([
             BillRunHelper.add({
-              id: '1021c5bc-673c-48fa-98dd-733b46c84f90', regionId, batchType: 'two_part_tariff', status: 'review', toFinancialYearEnding: 2022, summer: true, scheme: 'alcs'
+              id: billRunIdOne, regionId, batchType: 'two_part_tariff', status: 'review', toFinancialYearEnding: 2022, summer: true, scheme: 'alcs'
             })
           ])
         })
@@ -166,7 +172,7 @@ describe('Determine Blocking Bill Run service', () => {
           const results = await DetermineBlockingBillRunService.go(regionId, batchType, financialEndYear, season)
 
           expect(results).to.have.length(1)
-          expect(results[0].id).to.equal('1021c5bc-673c-48fa-98dd-733b46c84f90')
+          expect(results[0].id).to.equal(billRunIdOne)
         })
       })
 
@@ -174,7 +180,7 @@ describe('Determine Blocking Bill Run service', () => {
         describe('but a live bill run exists for the same year', () => {
           beforeEach(async () => {
             await BillRunHelper.add({
-              id: '1021c5bc-673c-48fa-98dd-733b46c84f90', regionId, batchType: 'supplementary', status: 'ready', toFinancialYearEnding: 2022, scheme: 'alcs'
+              id: billRunIdOne, regionId, batchType: 'supplementary', status: 'ready', toFinancialYearEnding: 2022, scheme: 'alcs'
             })
           })
 
@@ -182,14 +188,14 @@ describe('Determine Blocking Bill Run service', () => {
             const results = await DetermineBlockingBillRunService.go(regionId, batchType, financialEndYear, season)
 
             expect(results).to.have.length(1)
-            expect(results[0].id).to.equal('1021c5bc-673c-48fa-98dd-733b46c84f90')
+            expect(results[0].id).to.equal(billRunIdOne)
           })
         })
 
         describe('but a live bill run exists for a different year', () => {
           beforeEach(async () => {
             await BillRunHelper.add({
-              id: '1021c5bc-673c-48fa-98dd-733b46c84f90', regionId, batchType: 'annual', status: 'ready', toFinancialYearEnding: toFinancialYearEnding - 1, scheme: 'sroc'
+              id: billRunIdOne, regionId, batchType: 'annual', status: 'ready', toFinancialYearEnding: toFinancialYearEnding - 1, scheme: 'sroc'
             })
           })
 
@@ -221,10 +227,10 @@ describe('Determine Blocking Bill Run service', () => {
       beforeEach(async () => {
         await Promise.all([
           BillRunHelper.add({
-            id: '1021c5bc-673c-48fa-98dd-733b46c84f90', regionId, batchType: 'supplementary', status: 'ready', toFinancialYearEnding, scheme: 'sroc'
+            id: billRunIdOne, regionId, batchType: 'supplementary', status: 'ready', toFinancialYearEnding, scheme: 'sroc'
           }),
           BillRunHelper.add({
-            id: 'b65bb671-8961-4d0c-93f4-d19e1998e778', regionId, batchType: 'supplementary', status: 'ready', toFinancialYearEnding: 2022, scheme: 'alcs'
+            id: billRunIdTwo, regionId, batchType: 'supplementary', status: 'ready', toFinancialYearEnding: 2022, scheme: 'alcs'
           })
         ])
       })
@@ -233,15 +239,15 @@ describe('Determine Blocking Bill Run service', () => {
         const results = await DetermineBlockingBillRunService.go(regionId, batchType, financialEndYear)
 
         expect(results).to.have.length(2)
-        expect(results[0].id).to.equal('1021c5bc-673c-48fa-98dd-733b46c84f90')
-        expect(results[1].id).to.equal('b65bb671-8961-4d0c-93f4-d19e1998e778')
+        expect(results[0].id).to.equal(billRunIdOne)
+        expect(results[1].id).to.equal(billRunIdTwo)
       })
     })
 
     describe('and there is only an SROC matching bill run', () => {
       beforeEach(async () => {
         await BillRunHelper.add({
-          id: '1021c5bc-673c-48fa-98dd-733b46c84f90', regionId, batchType: 'supplementary', status: 'ready', toFinancialYearEnding, scheme: 'sroc'
+          id: billRunIdOne, regionId, batchType: 'supplementary', status: 'ready', toFinancialYearEnding, scheme: 'sroc'
         })
       })
 
@@ -250,14 +256,14 @@ describe('Determine Blocking Bill Run service', () => {
           const results = await DetermineBlockingBillRunService.go(regionId, batchType, financialEndYear)
 
           expect(results).to.have.length(1)
-          expect(results[0].id).to.equal('1021c5bc-673c-48fa-98dd-733b46c84f90')
+          expect(results[0].id).to.equal(billRunIdOne)
         })
       })
 
       describe('and a live PRESROC bill run', () => {
         beforeEach(async () => {
           await BillRunHelper.add({
-            id: 'b65bb671-8961-4d0c-93f4-d19e1998e778', regionId, batchType: 'two_part_tariff', status: 'review', toFinancialYearEnding: 2022, scheme: 'alcs'
+            id: billRunIdTwo, regionId, batchType: 'two_part_tariff', status: 'review', toFinancialYearEnding: 2022, scheme: 'alcs'
           })
         })
 
@@ -265,8 +271,8 @@ describe('Determine Blocking Bill Run service', () => {
           const results = await DetermineBlockingBillRunService.go(regionId, batchType, financialEndYear)
 
           expect(results).to.have.length(2)
-          expect(results[0].id).to.equal('1021c5bc-673c-48fa-98dd-733b46c84f90')
-          expect(results[1].id).to.equal('b65bb671-8961-4d0c-93f4-d19e1998e778')
+          expect(results[0].id).to.equal(billRunIdOne)
+          expect(results[1].id).to.equal(billRunIdTwo)
         })
       })
     })
@@ -274,7 +280,7 @@ describe('Determine Blocking Bill Run service', () => {
     describe('and there is only a PRESROC matching bill run', () => {
       beforeEach(async () => {
         await BillRunHelper.add({
-          id: 'b65bb671-8961-4d0c-93f4-d19e1998e778', regionId, batchType: 'supplementary', status: 'ready', toFinancialYearEnding: 2022, scheme: 'alcs'
+          id: billRunIdTwo, regionId, batchType: 'supplementary', status: 'ready', toFinancialYearEnding: 2022, scheme: 'alcs'
         })
       })
 
@@ -283,14 +289,14 @@ describe('Determine Blocking Bill Run service', () => {
           const results = await DetermineBlockingBillRunService.go(regionId, batchType, financialEndYear)
 
           expect(results).to.have.length(1)
-          expect(results[0].id).to.equal('b65bb671-8961-4d0c-93f4-d19e1998e778')
+          expect(results[0].id).to.equal(billRunIdTwo)
         })
       })
 
       describe('and a live SROC bill run', () => {
         beforeEach(async () => {
           await BillRunHelper.add({
-            id: '1021c5bc-673c-48fa-98dd-733b46c84f90', regionId, batchType: 'two_part_tariff', status: 'review', toFinancialYearEnding, scheme: 'sroc'
+            id: billRunIdOne, regionId, batchType: 'two_part_tariff', status: 'review', toFinancialYearEnding, scheme: 'sroc'
           })
         })
 
@@ -298,8 +304,8 @@ describe('Determine Blocking Bill Run service', () => {
           const results = await DetermineBlockingBillRunService.go(regionId, batchType, financialEndYear)
 
           expect(results).to.have.length(2)
-          expect(results[1].id).to.equal('b65bb671-8961-4d0c-93f4-d19e1998e778')
-          expect(results[0].id).to.equal('1021c5bc-673c-48fa-98dd-733b46c84f90')
+          expect(results[1].id).to.equal(billRunIdTwo)
+          expect(results[0].id).to.equal(billRunIdOne)
         })
       })
     })
@@ -309,10 +315,10 @@ describe('Determine Blocking Bill Run service', () => {
         beforeEach(async () => {
           await Promise.all([
             BillRunHelper.add({
-              id: '1021c5bc-673c-48fa-98dd-733b46c84f90', regionId, batchType: 'annual', status: 'processing', toFinancialYearEnding, scheme: 'sroc'
+              id: billRunIdOne, regionId, batchType: 'annual', status: 'processing', toFinancialYearEnding, scheme: 'sroc'
             }),
             BillRunHelper.add({
-              id: 'b65bb671-8961-4d0c-93f4-d19e1998e778', regionId, batchType: 'two_part_tariff', status: 'review', toFinancialYearEnding: 2022, scheme: 'alcs'
+              id: billRunIdTwo, regionId, batchType: 'two_part_tariff', status: 'review', toFinancialYearEnding: 2022, scheme: 'alcs'
             })
           ])
         })
@@ -322,14 +328,14 @@ describe('Determine Blocking Bill Run service', () => {
         describe('for the same year', () => {
           beforeEach(async () => {
             await BillRunHelper.add({
-              id: '1021c5bc-673c-48fa-98dd-733b46c84f90', regionId, batchType: 'annual', status: 'processing', toFinancialYearEnding, scheme: 'sroc'
+              id: billRunIdOne, regionId, batchType: 'annual', status: 'processing', toFinancialYearEnding, scheme: 'sroc'
             })
 
             it('returns just the single match', async () => {
               const results = await DetermineBlockingBillRunService.go(regionId, batchType, financialEndYear)
 
               expect(results).to.have.length(1)
-              expect(results[0].id).to.equal('1021c5bc-673c-48fa-98dd-733b46c84f90')
+              expect(results[0].id).to.equal(billRunIdOne)
             })
           })
         })
@@ -337,7 +343,7 @@ describe('Determine Blocking Bill Run service', () => {
         describe('for a different year', () => {
           beforeEach(async () => {
             await BillRunHelper.add({
-              id: '1021c5bc-673c-48fa-98dd-733b46c84f90', regionId, batchType: 'annual', status: 'processing', toFinancialYearEnding: toFinancialYearEnding - 1, scheme: 'sroc'
+              id: billRunIdOne, regionId, batchType: 'annual', status: 'processing', toFinancialYearEnding: toFinancialYearEnding - 1, scheme: 'sroc'
             })
           })
 
@@ -352,14 +358,14 @@ describe('Determine Blocking Bill Run service', () => {
       describe('but a live PRESROC bill run exists', () => {
         beforeEach(async () => {
           await BillRunHelper.add({
-            id: 'b65bb671-8961-4d0c-93f4-d19e1998e778', regionId, batchType: 'two_part_tariff', status: 'review', toFinancialYearEnding: 2022, scheme: 'alcs'
+            id: billRunIdTwo, regionId, batchType: 'two_part_tariff', status: 'review', toFinancialYearEnding: 2022, scheme: 'alcs'
           })
 
           it('returns just the single match', async () => {
             const results = await DetermineBlockingBillRunService.go(regionId, batchType, financialEndYear)
 
             expect(results).to.have.length(1)
-            expect(results[0].id).to.equal('b65bb671-8961-4d0c-93f4-d19e1998e778')
+            expect(results[0].id).to.equal(billRunIdTwo)
           })
         })
       })

--- a/test/services/bill-runs/fetch-live-bill-runs.service.test.js
+++ b/test/services/bill-runs/fetch-live-bill-runs.service.test.js
@@ -9,7 +9,6 @@ const { expect } = Code
 
 // Test helpers
 const BillRunHelper = require('../../support/helpers/bill-run.helper.js')
-const DatabaseSupport = require('../../support/database.js')
 const RegionHelper = require('../../support/helpers/region.helper.js')
 const { determineCurrentFinancialYear } = require('../../../app/lib/general.lib.js')
 
@@ -19,21 +18,20 @@ const FetchLiveBillRunsService = require('../../../app/services/bill-runs/fetch-
 describe('Fetch Live Bill Runs service', () => {
   const currentFinancialYear = determineCurrentFinancialYear()
 
+  let billRun
   let financialYearEnding
   let regionId
 
   beforeEach(async () => {
-    await DatabaseSupport.clean()
-
     const region = await RegionHelper.add()
+
     regionId = region.id
   })
 
   describe('when there is a live bill run', () => {
     describe('and it is for the current year (SROC)', () => {
       beforeEach(async () => {
-        await BillRunHelper.add({
-          id: '1021c5bc-673c-48fa-98dd-733b46c84f90',
+        billRun = await BillRunHelper.add({
           regionId,
           batchType: 'supplementary',
           status: 'ready',
@@ -51,7 +49,7 @@ describe('Fetch Live Bill Runs service', () => {
           const results = await FetchLiveBillRunsService.go(regionId, financialYearEnding, false)
 
           expect(results).to.have.length(1)
-          expect(results[0].id).to.equal('1021c5bc-673c-48fa-98dd-733b46c84f90')
+          expect(results[0].id).to.equal(billRun.id)
         })
       })
 
@@ -64,7 +62,7 @@ describe('Fetch Live Bill Runs service', () => {
           const results = await FetchLiveBillRunsService.go(regionId, financialYearEnding, true)
 
           expect(results).to.have.length(1)
-          expect(results[0].id).to.equal('1021c5bc-673c-48fa-98dd-733b46c84f90')
+          expect(results[0].id).to.equal(billRun.id)
         })
       })
 
@@ -83,8 +81,7 @@ describe('Fetch Live Bill Runs service', () => {
 
     describe('and it is for the previous year (SROC)', () => {
       beforeEach(async () => {
-        await BillRunHelper.add({
-          id: '1021c5bc-673c-48fa-98dd-733b46c84f90',
+        billRun = await BillRunHelper.add({
           regionId,
           batchType: 'supplementary',
           status: 'ready',
@@ -126,15 +123,14 @@ describe('Fetch Live Bill Runs service', () => {
           const results = await FetchLiveBillRunsService.go(regionId, financialYearEnding, false)
 
           expect(results).to.have.length(1)
-          expect(results[0].id).to.equal('1021c5bc-673c-48fa-98dd-733b46c84f90')
+          expect(results[0].id).to.equal(billRun.id)
         })
       })
     })
 
     describe('and it is for the last PRESROC year (PRESROC)', () => {
       beforeEach(async () => {
-        await BillRunHelper.add({
-          id: '1021c5bc-673c-48fa-98dd-733b46c84f90',
+        billRun = await BillRunHelper.add({
           regionId,
           batchType: 'supplementary',
           status: 'ready',
@@ -164,7 +160,7 @@ describe('Fetch Live Bill Runs service', () => {
           const results = await FetchLiveBillRunsService.go(regionId, financialYearEnding, true)
 
           expect(results).to.have.length(1)
-          expect(results[0].id).to.equal('1021c5bc-673c-48fa-98dd-733b46c84f90')
+          expect(results[0].id).to.equal(billRun.id)
         })
       })
 

--- a/test/services/idm/fetch-user-roles-and-groups.service.test.js
+++ b/test/services/idm/fetch-user-roles-and-groups.service.test.js
@@ -8,13 +8,13 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const DatabaseSupport = require('../../support/database.js')
 const GroupHelper = require('../../support/helpers/group.helper.js')
 const GroupRoleHelper = require('../../support/helpers/group-role.helper.js')
 const RoleHelper = require('../../support/helpers/role.helper.js')
 const UserGroupHelper = require('../../support/helpers/user-group.helper.js')
 const UserHelper = require('../../support/helpers/user.helper.js')
 const UserRoleHelper = require('../../support/helpers/user-role.helper.js')
+const { generateUUID } = require('../../../app/lib/general.lib.js')
 
 // Thing under test
 const FetchUserRolesAndGroupsService = require('../../../app/services/idm/fetch-user-roles-and-groups.service.js')
@@ -26,9 +26,11 @@ describe('Fetch User Roles And Groups service', () => {
   let testGroup
 
   beforeEach(async () => {
-    await DatabaseSupport.clean()
-
-    testUser = await UserHelper.add()
+    testUser = await UserHelper.add(
+      {
+        username: `${generateUUID()}@test.com`
+      }
+    )
 
     // Create a role and assign it directly to the user
     testRoleForUser = await RoleHelper.add({ role: 'role_for_user' })
@@ -44,6 +46,7 @@ describe('Fetch User Roles And Groups service', () => {
     await RoleHelper.add({ role: 'not_assigned_role' })
     const notAssignedGroup = await GroupHelper.add({ group: 'not_assigned' })
     const notAssignedGroupRole = await RoleHelper.add({ role: 'not_assigned_group_role' })
+
     await GroupRoleHelper.add({ groupId: notAssignedGroup.id, roleId: notAssignedGroupRole.id })
   })
 

--- a/test/services/licences/fetch-licence-bills.service.test.js
+++ b/test/services/licences/fetch-licence-bills.service.test.js
@@ -8,23 +8,27 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const DatabaseSupport = require('../../support/database.js')
-const BillLicenceHelper = require('../../support/helpers/bill-licence.helper.js')
 const BillHelper = require('../../support/helpers/bill.helper.js')
+const BillLicenceHelper = require('../../support/helpers/bill-licence.helper.js')
 const BillRunHelper = require('../../support/helpers/bill-run.helper.js')
+const { generateUUID } = require('../../../app/lib/general.lib.js')
 
 // Thing under test
 const FetchLicenceBillService = require('../../../app/services/licences/fetch-licence-bills.service.js')
 
 describe('Fetch Licence Bills service', () => {
-  const billId = '72988ec1-9fb2-4b87-b0a0-3c0be628a72c'
-  const billingAccountId = '0ba3b707-72ee-4296-b177-a19afff10688'
-  const billRunId = 'd40004d5-a99b-40a7-adf2-22d36d5b20b5'
   const createdDate = new Date('2022-01-01')
-  const licenceId = '96d97293-1a62-4ad0-bcb6-24f68a203e6b'
+
+  let billId
+  let billingAccountId
+  let billRunId
+  let licenceId
 
   beforeEach(async () => {
-    await DatabaseSupport.clean()
+    billId = generateUUID()
+    billingAccountId = generateUUID()
+    billRunId = generateUUID()
+    licenceId = generateUUID()
   })
 
   describe('when the licence has bills', () => {

--- a/test/services/licences/fetch-licence.service.test.js
+++ b/test/services/licences/fetch-licence.service.test.js
@@ -8,7 +8,6 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const DatabaseSupport = require('../../support/database.js')
 const LicenceEntityHelper = require('../../support/helpers/licence-entity.helper.js')
 const LicenceEntityRoleHelper = require('../../support/helpers/licence-entity-role.helper.js')
 const LicenceHelper = require('../../support/helpers/licence.helper.js')
@@ -21,14 +20,9 @@ const FetchLicenceService = require('../../../app/services/licences/fetch-licenc
 describe('Fetch licence service', () => {
   let licence
 
-  beforeEach(async () => {
-    await DatabaseSupport.clean()
-  })
-
   describe('when there is no optional data in the model', () => {
     beforeEach(async () => {
       licence = await LicenceHelper.add({
-        id: 'a8256ea1-4509-4992-b30f-d011509e5f62',
         expiredDate: null,
         include_in_presroc_billing: 'yes',
         include_in_sroc_billing: true,
@@ -43,7 +37,7 @@ describe('Fetch licence service', () => {
     it('returns results', async () => {
       const result = await FetchLicenceService.go(licence.id)
 
-      expect(result.id).to.equal('a8256ea1-4509-4992-b30f-d011509e5f62')
+      expect(result.id).to.equal(licence.id)
       expect(result.ends).to.equal(null)
       expect(result.expiredDate).to.equal(null)
       expect(result.lapsedDate).to.equal(null)
@@ -75,6 +69,7 @@ describe('Fetch licence service', () => {
 
     it('returns results', async () => {
       const result = await FetchLicenceService.go(licence.id)
+
       expect(result.registeredTo).to.equal('grace.hopper@example.com')
       expect(result.licenceName).to.equal('Test Company Ltd')
       expect(result.ends).to.equal({

--- a/test/support/database.js
+++ b/test/support/database.js
@@ -85,7 +85,12 @@ async function _viewNames (schema) {
   })
 }
 
+async function closeConnection () {
+  await db.destroy()
+}
+
 module.exports = {
   clean,
+  closeConnection,
   wipe
 }


### PR DESCRIPTION
Currently, tests need to run await DatabaseSupport.clean() which we assume is taking considerable time for us to investigate making the tests more performant. 

Proposal:

> When `npm test` is run have a script run prior to the test to clean the database once.
>
> Update tests to manage themselves with unique ids. Use the id created by the DB and pass it around the test or use our generateUUID function where appropriate to allow the test to generate their own id's/