### PR TITLE
Enhance the padding-line lint rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,7 +26,10 @@ module.exports = {
       { blankLine: 'always', prev: 'function', next: '*' },
       // blank lines after every sequence of variable declarations
       { blankLine: 'always', prev: ['const', 'let', 'var'], next: '*' },
-      { blankLine: 'any', prev: ['const', 'let', 'var'], next: ['const', 'let', 'var'] }
+      { blankLine: 'any', prev: ['const', 'let', 'var'], next: ['const', 'let', 'var'] },
+      // blank lines after all directive prologues e.g. 'use strict'
+      { blankLine: 'always', prev: 'directive', next: '*' },
+      { blankLine: 'any', prev: 'directive', next: 'directive' }
     ],
     'arrow-body-style': ['error', 'always'],
     'import/extensions': ['error', 'always'],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,11 +20,9 @@ module.exports = {
     '@stylistic/js/padding-line-between-statements': [
       'error',
       { blankLine: 'always', prev: '*', next: 'block' },
-      { blankLine: 'always', prev: '*', next: 'expression' },
       { blankLine: 'always', prev: '*', next: 'return' },
       { blankLine: 'always', prev: 'block', next: '*' },
       { blankLine: 'always', prev: 'block', next: 'function' },
-      { blankLine: 'always', prev: 'expression', next: '*' },
       { blankLine: 'always', prev: 'function', next: '*' }
     ],
     'arrow-body-style': ['error', 'always'],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,7 +23,10 @@ module.exports = {
       { blankLine: 'always', prev: '*', next: 'return' },
       { blankLine: 'always', prev: 'block', next: '*' },
       { blankLine: 'always', prev: 'block', next: 'function' },
-      { blankLine: 'always', prev: 'function', next: '*' }
+      { blankLine: 'always', prev: 'function', next: '*' },
+      // blank lines after every sequence of variable declarations
+      { blankLine: 'always', prev: ['const', 'let', 'var'], next: '*' },
+      { blankLine: 'any', prev: ['const', 'let', 'var'], next: ['const', 'let', 'var'] }
     ],
     'arrow-body-style': ['error', 'always'],
     'import/extensions': ['error', 'always'],

--- a/app/controllers/root.controller.js
+++ b/app/controllers/root.controller.js
@@ -8,6 +8,7 @@
 function index (_request, _h) {
   return { status: 'alive' }
 }
+
 module.exports = {
   index
 }

--- a/app/presenters/base.presenter.js
+++ b/app/presenters/base.presenter.js
@@ -255,6 +255,7 @@ function titleCase (value) {
 
   words.forEach((word) => {
     const titleCasedWord = word.charAt(0).toUpperCase() + word.slice(1)
+
     titleCasedWords.push(titleCasedWord)
   })
 

--- a/app/presenters/bill-runs/two-part-tariff/review-bill-run.presenter.js
+++ b/app/presenters/bill-runs/two-part-tariff/review-bill-run.presenter.js
@@ -30,6 +30,7 @@ function go (billRun, filterIssues, filterLicenceHolderNumber, filterLicenceStat
   const issues = filterIssues ? _prepareIssues(filterIssues) : filterIssues
 
   const filter = { issues, licenceHolderNumber: filterLicenceHolderNumber, licenceStatus: filterLicenceStatus }
+
   // this opens the filter on the page if any filter data has been received so the user can see the applied filters
   filter.openFilter = (filterIssues || filterLicenceHolderNumber || filterLicenceStatus) !== undefined
 

--- a/app/presenters/licences/set-up.presenter.js
+++ b/app/presenters/licences/set-up.presenter.js
@@ -157,10 +157,12 @@ function _endsSixYearsAgo (endDate) {
   const timeStamp = { hour: 23, minutes: 59, seconds: 59, ms: 999 }
 
   const yesterday = new Date()
+
   yesterday.setDate(yesterday.getDate() - 1)
   yesterday.setHours(timeStamp.hour, timeStamp.minutes, timeStamp.seconds, timeStamp.ms)
 
   const sixYearsFromYesterday = new Date(yesterday.getTime())
+
   sixYearsFromYesterday.setFullYear(yesterday.getFullYear() - sixYears)
 
   return endDate.date < sixYearsFromYesterday


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/115

We enhanced our linting rules to enforce [spaces around blocks and expressions](https://github.com/DEFRA/water-abstraction-system/pull/1143). This is a great step to helping folks 'fall into the pit of success' and avoid reviewers having to nitpick PRs.

But having enabled it, we've spotted that it is highlighting some things that are perfectly acceptable.

![Screenshot 2024-06-27 at 14 38 35](https://github.com/DEFRA/water-abstraction-system/assets/1789650/9210a3cf-57b7-4296-8775-6872756b6f41)

We also think there are a few other options we could add.

So, this change is about building on the [padding-line-between-statements](https://eslint.style/rules/js/padding-line-between-statements) we've already added.
