### PR TITLE
Add enableSystemLicenceView toggle to missed links

### DIFF
--- a/app/controllers/return-requirements.controller.js
+++ b/app/controllers/return-requirements.controller.js
@@ -6,13 +6,14 @@
  */
 
 const AbstractionPeriodService = require('../services/return-requirements/abstraction-period.service.js')
-const AdditionalSubmissionOptionsService = require('../services/return-requirements/additional-submission-options.service.js')
 const AddService = require('../services/return-requirements/add.service.js')
+const AdditionalSubmissionOptionsService = require('../services/return-requirements/additional-submission-options.service.js')
 const AgreementsExceptionsService = require('../services/return-requirements/agreements-exceptions.service.js')
 const CancelService = require('../services/return-requirements/cancel.service.js')
 const CheckService = require('../services/return-requirements/check.service.js')
 const DeleteNoteService = require('../services/return-requirements/delete-note.service.js')
 const ExistingService = require('../services/return-requirements/existing.service.js')
+const FeatureFlagsConfig = require('../../config/feature-flags.config.js')
 const FrequencyCollectedService = require('../services/return-requirements/frequency-collected.service.js')
 const FrequencyReportedService = require('../services/return-requirements/frequency-reported.service.js')
 const NoReturnsRequiredService = require('../services/return-requirements/no-returns-required.service.js')
@@ -295,7 +296,11 @@ async function submitCancel (request, h) {
 
   await SubmitCancel.go(sessionId)
 
-  return h.redirect(`/licences/${licenceId}#charge`)
+  if (FeatureFlagsConfig.enableSystemLicenceView) {
+    return h.redirect(`/system/licences/${licenceId}/set-up`)
+  } else {
+    return h.redirect(`/licences/${licenceId}#charge`)
+  }
 }
 
 async function submitCheck (request, h) {

--- a/app/presenters/return-requirements/start-date.presenter.js
+++ b/app/presenters/return-requirements/start-date.presenter.js
@@ -5,6 +5,7 @@
  * @module StartDatePresenter
 */
 
+const FeatureFlagsConfig = require('../../../config/feature-flags.config.js')
 const { formatLongDate } = require('../base.presenter.js')
 
 /**
@@ -44,7 +45,11 @@ function _backLink (session) {
     return `/system/return-requirements/${id}/check`
   }
 
-  return `/licences/${licence.id}#charge`
+  if (FeatureFlagsConfig.enableSystemLicenceView) {
+    return `/system/licences/${licence.id}/set-up`
+  } else {
+    return `/licences/${licence.id}#charge`
+  }
 }
 
 function _licenceVersionStartDate (licence) {


### PR DESCRIPTION
When doing the original work on adding the feature flags some redirects and links where missed.

This change adds the toggle to the links / redirects picked up when in test.

https://eaflood.atlassian.net/browse/WATER-4466

Previous work - https://github.com/DEFRA/water-abstraction-system/pull/1130