### PR TITLE
Fix duplicate monitoring stations in view licence

### DIFF
--- a/app/presenters/licences/view-licence-summary.presenter.js
+++ b/app/presenters/licences/view-licence-summary.presenter.js
@@ -181,9 +181,21 @@ function _licenceHolder (licence) {
 }
 
 function _monitoringStations (licenceGaugingStations) {
-  return licenceGaugingStations.map((licenceGaugingStation) => {
-    return licenceGaugingStation.gaugingStation
-  })
+  const monitoringStations = []
+
+  for (const licenceGaugingStation of licenceGaugingStations) {
+    const alreadySeen = monitoringStations.some((monitoringStation) => {
+      return monitoringStation.id === licenceGaugingStation.gaugingStation.id
+    })
+
+    if (alreadySeen) {
+      continue
+    }
+
+    monitoringStations.push(licenceGaugingStation.gaugingStation)
+  }
+
+  return monitoringStations
 }
 
 function _points (permitLicence) {

--- a/test/presenters/licences/view-licence-summary.presenter.test.js
+++ b/test/presenters/licences/view-licence-summary.presenter.test.js
@@ -789,7 +789,7 @@ describe('View Licence Summary presenter', () => {
   })
 
   describe('the "monitoringStations" property', () => {
-    describe('when the licence has no gauging stations', () => {
+    describe('when the licence is linked to no monitoring stations', () => {
       beforeEach(() => {
         licence.licenceGaugingStations = []
       })
@@ -801,8 +801,8 @@ describe('View Licence Summary presenter', () => {
       })
     })
 
-    describe('when the licence has a gauging station', () => {
-      it('will return any array with the monitoring station details', async () => {
+    describe('when the licence is linked to a single monitoring station', () => {
+      it("will return an array with the monitoring station's details", async () => {
         const result = await ViewLicenceSummaryPresenter.go(licence)
 
         expect(result.monitoringStations).to.equal([{
@@ -812,30 +812,47 @@ describe('View Licence Summary presenter', () => {
       })
     })
 
-    describe('when the licence has multiple gauging stations', () => {
-      beforeEach(() => {
-        licence.licenceGaugingStations.push({
-          id: '13f7504d-2750-4dd9-94dd-929e99e900a0',
-          gaugingStation: {
-            id: '4a6493b0-1d8d-429f-a7a0-3a6541d5ff1f',
-            label: 'AVALON FIRE STATION'
-          }
+    describe('when the licence is linked to multiple monitoring stations', () => {
+      describe('that are all different', () => {
+        beforeEach(() => {
+          licence.licenceGaugingStations.push({
+            id: '13f7504d-2750-4dd9-94dd-929e99e900a0',
+            gaugingStation: {
+              id: '4a6493b0-1d8d-429f-a7a0-3a6541d5ff1f',
+              label: 'AVALON FIRE STATION'
+            }
+          })
+        })
+
+        it('will return an array with each monitoring stations details', async () => {
+          const result = await ViewLicenceSummaryPresenter.go(licence)
+
+          expect(result.monitoringStations).to.equal([
+            { id: 'ac075651-4781-4e24-a684-b943b98607ca', label: 'MEVAGISSEY FIRE STATION' },
+            { id: '4a6493b0-1d8d-429f-a7a0-3a6541d5ff1f', label: 'AVALON FIRE STATION' }
+          ])
         })
       })
 
-      it('will return any array with the monitoring station details', async () => {
-        const result = await ViewLicenceSummaryPresenter.go(licence)
+      describe('that are all the same station', () => {
+        beforeEach(() => {
+          licence.licenceGaugingStations.push({
+            id: 'e813542c-50a0-4497-be1a-00af3a810cac',
+            gaugingStation: {
+              id: 'ac075651-4781-4e24-a684-b943b98607ca',
+              label: 'MEVAGISSEY FIRE STATION'
+            }
+          })
+        })
 
-        expect(result.monitoringStations).to.equal([
-          {
+        it("will return an array with just the one monitoring station's details", async () => {
+          const result = await ViewLicenceSummaryPresenter.go(licence)
+
+          expect(result.monitoringStations).to.equal([{
             id: 'ac075651-4781-4e24-a684-b943b98607ca',
             label: 'MEVAGISSEY FIRE STATION'
-          },
-          {
-            id: '4a6493b0-1d8d-429f-a7a0-3a6541d5ff1f',
-            label: 'AVALON FIRE STATION'
-          }
-        ])
+          }])
+        })
       })
     })
   })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4331

> Part of the work to replace the legacy view licence page

After attempting to [simplify the logic that builds the view licence page's summary tab](https://github.com/DEFRA/water-abstraction-system/pull/1132) we've spotted that we may have introduced a bug.

We have found a licence that has been linked to the same gauging station multiple times. This results in seeing the same station listed multiple times in the summary.

Like the other sections, where something is duplicated, we should see only one entry. This change fixes the logic and ensures the list is distinct.