### PR TITLE
Display msg for multiple abs amounts in view

### DIFF
--- a/app/presenters/licences/view-licence-summary.presenter.js
+++ b/app/presenters/licences/view-licence-summary.presenter.js
@@ -49,6 +49,7 @@ function go (licence) {
     licenceId: id,
     monitoringStations: _monitoringStations(licenceGaugingStations),
     purposes,
+    purposesCount: licenceVersionPurposes ? licenceVersionPurposes.length : 0,
     region: region.displayName,
     sourceOfSupply: points[0]?.point_source?.NAME ?? null,
     startDate: formatLongDate(startDate)
@@ -58,7 +59,7 @@ function go (licence) {
 function _abstractionAmounts (licenceVersionPurposes) {
   const details = []
 
-  if (!licenceVersionPurposes) {
+  if (!licenceVersionPurposes || licenceVersionPurposes.length > 1) {
     return details
   }
 

--- a/app/views/licences/tabs/summary.njk
+++ b/app/views/licences/tabs/summary.njk
@@ -136,15 +136,20 @@
     </div>
   {% endif %}
 
-  {% if abstractionAmounts.length > 0 %}
+  {% if purposesCount > 0 %}
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key">Abstraction amounts</dt>
       <dd class="govuk-summary-list__value">
-        <ul class="govuk-list govuk-!-margin-bottom-0">
-          {% for quantity in abstractionAmounts %}
-            <li>{{ quantity }}</li>
-          {% endfor %}
-        </ul>
+        {% if purposesCount > 1 %}
+          <div>Multiple abstractions</div>
+          <a href="/licences/{{ documentId }}/purposes">View details of the amounts</a>
+        {% else %}
+          <ul class="govuk-list govuk-!-margin-bottom-0">
+            {% for quantity in abstractionAmounts %}
+              <li>{{ quantity }}</li>
+            {% endfor %}
+          </ul>
+        {% endif %}
       </dd>
     </div>
   {% endif %}

--- a/test/presenters/licences/view-licence-summary.presenter.test.js
+++ b/test/presenters/licences/view-licence-summary.presenter.test.js
@@ -46,6 +46,7 @@ describe('View Licence Summary presenter', () => {
           caption: 'Purposes',
           data: ['Spray Irrigation - Storage', 'Spray Irrigation - Direct']
         },
+        purposesCount: 3,
         region: 'Avalon',
         sourceOfSupply: 'SURFACE WATER SOURCE OF SUPPLY',
         startDate: '1 April 2019'

--- a/test/presenters/licences/view-licence-summary.presenter.test.js
+++ b/test/presenters/licences/view-licence-summary.presenter.test.js
@@ -25,12 +25,7 @@ describe('View Licence Summary presenter', () => {
       const result = ViewLicenceSummaryPresenter.go(licence)
 
       expect(result).to.equal({
-        abstractionAmounts: [
-          '180000.00 cubic metres per year',
-          '720.00 cubic metres per day',
-          '144.00 cubic metres per hour',
-          '40.00 cubic metres per second'
-        ],
+        abstractionAmounts: [],
         abstractionConditions: ['Derogation clause', 'General conditions', 'Non standard quantities'],
         abstractionPeriods: ['1 April to 31 October', '1 November to 31 March'],
         abstractionPeriodsAndPurposesLinkText: 'View details of your purposes, periods and amounts',
@@ -71,7 +66,7 @@ describe('View Licence Summary presenter', () => {
       })
     })
 
-    describe('when the there is at least one licence version purpose', () => {
+    describe('when the there is one licence version purpose', () => {
       beforeEach(() => {
         licence.licenceVersions[0].licenceVersionPurposes = [{
           id: '7f5e0838-d87a-4c2e-8e9b-09d6814b9ec4',
@@ -150,6 +145,14 @@ describe('View Licence Summary presenter', () => {
 
           expect(result.abstractionAmounts).to.include('40.00 cubic metres per second')
         })
+      })
+    })
+
+    describe('when the there are multiple licence version purposes', () => {
+      it('returns an empty array', () => {
+        const result = ViewLicenceSummaryPresenter.go(licence)
+
+        expect(result.abstractionAmounts).to.be.empty()
       })
     })
   })

--- a/test/services/licences/view-licence-summary.service.test.js
+++ b/test/services/licences/view-licence-summary.service.test.js
@@ -18,7 +18,7 @@ const ViewLicenceService = require('../../../app/services/licences/view-licence.
 // Thing under test
 const ViewLicenceSummaryService = require('../../../app/services/licences/view-licence-summary.service.js')
 
-describe.only('View Licence Summary service', () => {
+describe('View Licence Summary service', () => {
   const testId = '2c80bd22-a005-4cf4-a2a2-73812a9861de'
 
   let fetchLicenceResult

--- a/test/services/licences/view-licence-summary.service.test.js
+++ b/test/services/licences/view-licence-summary.service.test.js
@@ -18,7 +18,7 @@ const ViewLicenceService = require('../../../app/services/licences/view-licence.
 // Thing under test
 const ViewLicenceSummaryService = require('../../../app/services/licences/view-licence-summary.service.js')
 
-describe('View Licence Summary service', () => {
+describe.only('View Licence Summary service', () => {
   const testId = '2c80bd22-a005-4cf4-a2a2-73812a9861de'
 
   let fetchLicenceResult
@@ -61,6 +61,7 @@ describe('View Licence Summary service', () => {
           }],
           licenceName: 'fake licence',
           purposes: null,
+          purposesCount: 0,
           region: 'Avalon',
           sourceOfSupply: 'SURFACE WATER SOURCE OF SUPPLY',
           startDate: '1 April 2019'


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4333

> Part of the work to replace the legacy view licence page

When we first built our version of the view licence page's summary tab, we applied the same logic when it came to a licence with multiple purposes: don't display abstraction amounts!

This is because the amounts could be different across the purposes and you can't just sum them. It is possible that the total amount of abstraction might be different on the licence when compared to the sum of its purposes (welcome to water abstraction!)

The old logic therefore hid the field. But we know anecdotally some users say you cannot see abstraction amounts in WRLS because of this behaviour.

So, in this change, when a licence has multiple purposes, we'll instead show a message and a link to the screen that shows the amounts for each purpose. Where a licence has one purpose, we'll continue to display the amounts.