### PR TITLE
Switch to GOV.UK table component for licence comms

### DIFF
--- a/app/views/licences/tabs/communications.njk
+++ b/app/views/licences/tabs/communications.njk
@@ -1,44 +1,61 @@
 {% from "govuk/components/pagination/macro.njk" import govukPagination %}
+{% from "govuk/components/table/macro.njk" import govukTable %}
+
+{% macro communicationType(communication) %}
+  {% if communication.type.pdf %}
+    <p class="govuk-body govuk-!-margin-bottom-0">{{ communication.type.label }}<span class="govuk-visually-hidden"> {{ communication.type.sentVia }}</span></p>
+  {% else %}
+    <a href="/licences/{{ documentId }}/communications/{{ communication.id }}" class="govuk-link">{{ communication.type.label }}
+      <span class="govuk-visually-hidden"> {{ communication.type.sentVia }}</span>
+    </a>
+  {% endif %}
+{% endmacro %}
 
 <h2 class="govuk-heading-l">Communications</h2>
 
 {% if communications.length == 0 %}
-  <p> No communications for this licence. </p>
-{% endif %}
+  <p data-test='no-communications-msg'>No communications for this licence.</p>
+{% else %}
+  {% set tableRows = [] %}
+  {% for communication in communications %}
+    {# Set an easier to use index. Also means we can refer to it inside our elementDetail loop #}
+    {% set rowIndex = loop.index0 %}
 
-{% if communications.length > 0 %}
-  <table class="govuk-table">
-    <thead class="govuk-table__head">
-    <tr class="govuk-table__row">
-      <th scope="col" class="govuk-table__header">Type</th>
-      <th scope="col" class="govuk-table__header">Sent</th>
-      <th scope="col" class="govuk-table__header">Sender</th>
-      <th scope="col" class="govuk-table__header">Method</th>
-    </tr>
-    </thead>
-    <tbody class="govuk-table__body">
-    {% for communication in communications %}
-      <tr class="govuk-table__row">
-        <td class="govuk-table__cell">
-          {% if communication.type.pdf %}
-            <p class="govuk-body govuk-!-margin-bottom-0"> {{ communication.type.label }} </p>
-            <span class="govuk-visually-hidden"> {{ communication.type.sentVia }} </span>
-          {% else %}
-            <a href="/licences/{{ documentId }}/communications/{{ communication.id }}" class="govuk-link">
-              {{ communication.type.label }}
-              <span class="govuk-visually-hidden"> {{ communication.type.sentVia }} </span>
-            </a>
-          {% endif %}
-        </td>
-        <td class="govuk-table__cell">{{ communication.sent }}</td>
-        <td class="govuk-table__cell">{{ communication.sender }}</td>
-        <td class="govuk-table__cell">{{ communication.method }}</td>
-      </tr>
-    {% endfor %}
-    </tbody>
-  </table>
-{% endif %}
+    {% set row = [
+      {
+        html: communicationType(communication),
+        attributes: { 'data-test': 'communication-type-' + rowIndex }
+      },
+      {
+        text: communication.sent,
+        attributes: { 'data-test': 'communication-sent-' + rowIndex }
+      },
+      {
+        text: communication.sender,
+        attributes: { 'data-test': 'communication-sender-' + rowIndex }
+      },
+      {
+        text: communication.method,
+        attributes: { 'data-test': 'communication-method-' + rowIndex }
+      }
+    ] %}
 
-{% if communications.length > 0 and pagination.numberOfPages > 1 %}
-  {{ govukPagination(pagination.component) }}
+    {% set tableRows = (tableRows.push(row), tableRows) %}
+  {% endfor %}
+
+  {{ govukTable({
+    attributes: { 'data-test': 'communications-table' },
+    firstCellIsHeader: false,
+    head: [
+      { text: 'Type' },
+      { text: 'Sent' },
+      { text: 'Sender' },
+      { text: 'Method' }
+    ],
+    rows: tableRows
+  }) }}
+
+  {% if pagination.numberOfPages > 1 %}
+    {{ govukPagination(pagination.component) }}
+  {% endif %}
 {% endif %}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4315

> Part of the work to replace the legacy view licence page

This is a housekeeping task. When we rebuilt the tab, we created the tables using the HTML details provided by the [design system](https://design-system.service.gov.uk/components/table/). Ideally, we use the Nunjucks component instead. We do this because it means that when the package is updated, the components will see those changes automatically. For the HTML, should something change, for example, a class is added, it is on us to manually update all places where we've used the HTML.

So, before this becomes fully live, we are taking the opportunity to update the view to use the Nunjucks version of the component.