### PR TITLE
Switch to GOV.UK table component for licence bills

### DIFF
--- a/app/views/licences/tabs/bills.njk
+++ b/app/views/licences/tabs/bills.njk
@@ -1,56 +1,69 @@
 {% from "govuk/components/pagination/macro.njk" import govukPagination %}
+{% from "govuk/components/table/macro.njk" import govukTable %}
 
-<table class="govuk-table">
-  <h2 class="govuk-heading-l">Bills</h2>
-  {% if bills.length > 0 %}
-    <table class="govuk-table">
-      <thead class="govuk-table__head">
-      <tr class="govuk-table__row">
-        <th class="govuk-table__header" scope="col">Bill number</th>
-        <th class="govuk-table__header" scope="col">Date created</th>
-        <th class="govuk-table__header" scope="col">Billing account</th>
-        <th class="govuk-table__header" scope="col">Bill run type</th>
-        <th class="govuk-table__header govuk-table__header--numeric" scope="col">Financial year</th>
-        <th class="govuk-table__header govuk-table__header--numeric" scope="col">Bill total</th>
-      </tr>
-      </thead>
-      <tbody class="govuk-table__body">
-      {% for bill in bills %}
-        <tr class="govuk-table__row">
-          <td class="govuk-table__cell" scope="row">
-            <a href="/system/bills/{{ bill.id }}">
-              {{ bill.billNumber }}
-            </a>
-          </td>
-          <td class="govuk-table__cell">
-            {{ bill.dateCreated }}
-          </td>
-          <td class="govuk-table__cell">
-            <a href="/billing-accounts/{{ bill.accountId }}">
-              {{ bill.account }}
-            </a>
-          </td>
-          <td class="govuk-table__cell">
-            {{ bill.runType | title }}
-          </td>
-          <td class="govuk-table__cell govuk-table__cell--numeric">
-            {{ bill.financialYear }}
-          </td>
-          <td class="govuk-table__cell govuk-table__cell--numeric">
-            {{ bill.total }}
-            {% if bill.credit %}
-              <div>Credit</div>
-            {% endif %}
-          </td>
-        </tr>
-      {% endfor %}
-      </tbody>
-    </table>
-  {% else %}
-    <p>No bills sent for this licence.</p>
+<h2 class="govuk-heading-l">Bills</h2>
+
+{% if bills.length == 0 %}
+  <p>No bills sent for this licence.</p>
+{% else %}
+  {% set tableRows = [] %}
+  {% for bill in bills %}
+    {# Set an easier to use index. Also means we can refer to it inside our elementDetail loop #}
+    {% set rowIndex = loop.index0 %}
+
+    {% if bill.credit %}
+      {% set billTotal = bill.total + '<div>credit</div>' %}
+    {% else %}
+      {% set billTotal = bill.total %}
+    {% endif %}
+
+    {% set row = [
+      {
+        html: '<a href="/system/bills/' + bill.id + '">' + bill.billNumber + '</a>',
+        attributes: { 'data-test': 'bill-number-' + rowIndex }
+      },
+      {
+        text: bill.dateCreated,
+        attributes: { 'data-test': 'bill-created-' + rowIndex }
+      },
+      {
+        html: '<a href="/billing-accounts/' + bill.accountId + '">' + bill.account + '</a>',
+        attributes: { 'data-test': 'bill-account-' + rowIndex }
+      },
+      {
+        text: bill.runType,
+        attributes: { 'data-test': 'bill-type-' + rowIndex }
+      },
+      {
+        text: bill.financialYear,
+        attributes: { 'data-test': 'bill-year-' + rowIndex },
+        format: 'numeric'
+      },
+      {
+        html: billTotal,
+        attributes: { 'data-test': 'bill-total-' + rowIndex },
+        format: 'numeric'
+      }
+    ] %}
+
+    {% set tableRows = (tableRows.push(row), tableRows) %}
+  {% endfor %}
+
+  {{ govukTable({
+    attributes: { 'data-test': 'bills-table' },
+    firstCellIsHeader: false,
+    head: [
+      { text: 'Bill number' },
+      { text: 'Date created' },
+      { text: 'Billing account' },
+      { text: 'Bill run type' },
+      { text: 'Financial year', format: 'numeric' },
+      { text: 'Bill total', format: 'numeric' }
+    ],
+    rows: tableRows
+  }) }}
+
+  {% if pagination.numberOfPages > 1 %}
+    {{ govukPagination(pagination.component) }}
   {% endif %}
-</table>
-
-{% if bills and pagination.numberOfPages > 1 %}
-  {{ govukPagination(pagination.component) }}
 {% endif %}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4316

> Part of the work to replace the legacy view licence page

This is a housekeeping task. When we rebuilt the tab, we created the tables using the HTML details provided by the [design system](https://design-system.service.gov.uk/components/table/). Ideally, we use the Nunjucks component instead. We do this because it means that when the package is updated, the components will see those changes automatically. For the HTML, should something change, for example, a class is added, it is on us to manually update all places where we've used the HTML.

So, before this becomes fully live, we are taking the opportunity to update the view to use the Nunjucks version of the component.