### PR TITLE
Fix order of charge versions in view licence page

### DIFF
--- a/app/services/licences/fetch-charge-versions.service.js
+++ b/app/services/licences/fetch-charge-versions.service.js
@@ -35,7 +35,8 @@ async function _fetch (licenceId) {
       ])
     })
     .orderBy([
-      { column: 'startDate', order: 'desc' }
+      { column: 'startDate', order: 'desc' },
+      { column: 'endDate', order: 'desc' }
     ])
 }
 

--- a/test/services/licences/fetch-charge-versions.service.test.js
+++ b/test/services/licences/fetch-charge-versions.service.test.js
@@ -8,32 +8,35 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const DatabaseSupport = require('../../support/database.js')
 const ChargeVersionHelper = require('../../support/helpers/charge-version.helper.js')
 const ChangeReasonHelper = require('../../support/helpers/change-reason.helper.js')
+const { generateUUID } = require('../../../app/lib/general.lib.js')
 
 // Thing under test
 const FetchChargeVersionsService =
   require('../../../app/services/licences/fetch-charge-versions.service.js')
 
 describe('Fetch Charge Versions service', () => {
-  let testRecord
+  const licenceId = generateUUID()
+  const startDate = new Date('2022-04-01')
 
-  beforeEach(async () => {
-    await DatabaseSupport.clean()
-  })
+  let testRecordId
 
   describe('when the licence has charge versions data', () => {
     beforeEach(async () => {
       const changeReason = await ChangeReasonHelper.add()
 
-      testRecord = await ChargeVersionHelper.add({
-        changeReasonId: changeReason.id
+      const chargeVersion = await ChargeVersionHelper.add({
+        changeReasonId: changeReason.id,
+        licenceId,
+        startDate
       })
+
+      testRecordId = chargeVersion.id
     })
 
     it('returns the matching charge versions data', async () => {
-      const result = await FetchChargeVersionsService.go(testRecord.licenceId)
+      const result = await FetchChargeVersionsService.go(licenceId)
 
       expect(result).to.equal([
         {
@@ -41,9 +44,9 @@ describe('Fetch Charge Versions service', () => {
             description: 'Strategic review of charges (SRoC)'
           },
           endDate: null,
-          id: testRecord.id,
-          licenceId: testRecord.licenceId,
-          startDate: testRecord.startDate,
+          id: testRecordId,
+          licenceId,
+          startDate,
           status: 'current'
         }
       ])

--- a/test/services/licences/fetch-charge-versions.service.test.js
+++ b/test/services/licences/fetch-charge-versions.service.test.js
@@ -18,21 +18,38 @@ const FetchChargeVersionsService =
 
 describe('Fetch Charge Versions service', () => {
   const licenceId = generateUUID()
-  const startDate = new Date('2022-04-01')
+  // These dates were taken from a real licence where our first iteration was not showing the charge versions in the
+  // correct order!
+  const startDate = new Date('2018-04-01')
+  const endDate = new Date('2030-03-31')
 
-  let testRecordId
+  let currentChargeVersionId
+  let supersededChargeVersionId
 
   describe('when the licence has charge versions data', () => {
     beforeEach(async () => {
       const changeReason = await ChangeReasonHelper.add()
 
-      const chargeVersion = await ChargeVersionHelper.add({
+      // Create multiple charge versions to ensure we get them in the right order
+      let chargeVersion = await ChargeVersionHelper.add({
+        changeReasonId: changeReason.id,
+        endDate,
+        licenceId,
+        scheme: 'alcs',
+        startDate,
+        status: 'superseded'
+      })
+
+      supersededChargeVersionId = chargeVersion.id
+
+      chargeVersion = await ChargeVersionHelper.add({
         changeReasonId: changeReason.id,
         licenceId,
+        scheme: 'alcs',
         startDate
       })
 
-      testRecordId = chargeVersion.id
+      currentChargeVersionId = chargeVersion.id
     })
 
     it('returns the matching charge versions data', async () => {
@@ -44,10 +61,20 @@ describe('Fetch Charge Versions service', () => {
             description: 'Strategic review of charges (SRoC)'
           },
           endDate: null,
-          id: testRecordId,
+          id: currentChargeVersionId,
           licenceId,
           startDate,
           status: 'current'
+        },
+        {
+          changeReason: {
+            description: 'Strategic review of charges (SRoC)'
+          },
+          endDate,
+          id: supersededChargeVersionId,
+          licenceId,
+          startDate,
+          status: 'superseded'
         }
       ])
     })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4556

> Part of the work to replace the legacy view licence page

Spotted in testing is that if a licence has 2 charge versions with the same start date (one will be 'approved' and the other will display as 'replaced'), it is possible that they will be ordered incorrectly. In this scenario, the 'approved' should be first in the table (the one without an end date) and then the 'replaced'.

Because we only sort by start date, when we encounter 2 charge versions with the same start date, we are not in control of the order they are displayed in.

This change fixes the issue by simply adding sort by end date `DESC` to the query.