### PR TITLE
Fix returns link in view licence page

### DIFF
--- a/app/presenters/licences/view-licence-returns.presenter.js
+++ b/app/presenters/licences/view-licence-returns.presenter.js
@@ -41,10 +41,10 @@ function _formatReturnToTableRow (returns) {
       dates: `${formatLongDate(new Date(startDate))} to ${formatLongDate(new Date(endDate))}`,
       description: metadata.description,
       dueDate: formatLongDate(new Date(dueDate)),
-      id: returnLog.id,
       link: _link(status, returnLogId),
       purpose: _formatPurpose(metadata.purposes),
       reference: returnReference,
+      returnLogId,
       status: _formatStatus(returnLog)
     }
   })

--- a/app/presenters/licences/view-licence-returns.presenter.js
+++ b/app/presenters/licences/view-licence-returns.presenter.js
@@ -1,14 +1,14 @@
 'use strict'
 
 /**
- * Formats common data for the `/licences/{id}/*` view licence pages
+ * Formats data for the `/licences/{id}/returns` view licence returns page
  * @module ViewLicenceReturnsPresenter
  */
 
 const { formatLongDate } = require('../base.presenter.js')
 
 /**
- * Formats common data for the `/licences/{id}/*` view licence pages
+ * Formats data for the `/licences/{id}/returns` view licence returns page
  *
  * @param {module:ReturnLogModel[]} returnsData - The session for the return requirement journey
  * @param {boolean} hasRequirements - If the licence has return versions then it has requirements
@@ -16,7 +16,7 @@ const { formatLongDate } = require('../base.presenter.js')
  * @returns {Object} The data formatted for the view template
  */
 function go (returnsData, hasRequirements) {
-  const returns = _formatReturnToTableRow(returnsData)
+  const returns = _returns(returnsData)
 
   const hasReturns = returns.length > 0
 
@@ -25,49 +25,6 @@ function go (returnsData, hasRequirements) {
     returns,
     noReturnsMessage: _noReturnsMessage(hasReturns, hasRequirements)
   }
-}
-
-function _formatPurpose (purpose) {
-  const [firstPurpose] = purpose
-
-  return firstPurpose.alias ? firstPurpose.alias : firstPurpose.tertiary.description
-}
-
-function _formatReturnToTableRow (returns) {
-  return returns.map((returnLog) => {
-    const { endDate, dueDate, id: returnLogId, metadata, returnReference, startDate, status } = returnLog
-
-    return {
-      dates: `${formatLongDate(new Date(startDate))} to ${formatLongDate(new Date(endDate))}`,
-      description: metadata.description,
-      dueDate: formatLongDate(new Date(dueDate)),
-      link: _link(status, returnLogId),
-      purpose: _formatPurpose(metadata.purposes),
-      reference: returnReference,
-      returnLogId,
-      status: _formatStatus(returnLog)
-    }
-  })
-}
-
-function _formatStatus (returnLog) {
-  const { status, dueDate } = returnLog
-
-  // If the return is completed we are required to display it as 'complete'. This also takes priority over the other
-  // statues
-  if (status === 'completed') {
-    return 'complete'
-  }
-
-  // Work out if the return is overdue (status is still 'due' and it is past the due date)
-  const today = new Date()
-
-  if (status === 'due' && dueDate < today) {
-    return 'overdue'
-  }
-
-  // For all other cases we can just return the status and the return-status-tag macro will know how to display it
-  return status
 }
 
 function _link (status, returnLogId) {
@@ -88,6 +45,49 @@ function _noReturnsMessage (hasReturns, hasRequirements) {
   }
 
   return null
+}
+
+function _purpose (purpose) {
+  const [firstPurpose] = purpose
+
+  return firstPurpose.alias ? firstPurpose.alias : firstPurpose.tertiary.description
+}
+
+function _returns (returns) {
+  return returns.map((returnLog) => {
+    const { endDate, dueDate, id: returnLogId, metadata, returnReference, startDate, status } = returnLog
+
+    return {
+      dates: `${formatLongDate(new Date(startDate))} to ${formatLongDate(new Date(endDate))}`,
+      description: metadata.description,
+      dueDate: formatLongDate(new Date(dueDate)),
+      link: _link(status, returnLogId),
+      purpose: _purpose(metadata.purposes),
+      reference: returnReference,
+      returnLogId,
+      status: _status(returnLog)
+    }
+  })
+}
+
+function _status (returnLog) {
+  const { status, dueDate } = returnLog
+
+  // If the return is completed we are required to display it as 'complete'. This also takes priority over the other
+  // statues
+  if (status === 'completed') {
+    return 'complete'
+  }
+
+  // Work out if the return is overdue (status is still 'due' and it is past the due date)
+  const today = new Date()
+
+  if (status === 'due' && dueDate < today) {
+    return 'overdue'
+  }
+
+  // For all other cases we can just return the status and the return-status-tag macro will know how to display it
+  return status
 }
 
 module.exports = {

--- a/app/presenters/licences/view-licence-returns.presenter.js
+++ b/app/presenters/licences/view-licence-returns.presenter.js
@@ -10,13 +10,13 @@ const { formatLongDate } = require('../base.presenter.js')
 /**
  * Formats data for the `/licences/{id}/returns` view licence returns page
  *
- * @param {module:ReturnLogModel[]} returnsData - The session for the return requirement journey
- * @param {boolean} hasRequirements - If the licence has return versions then it has requirements
+ * @param {module:ReturnLogModel[]} returnLogs - The results from `FetchLicenceReturnsService` to be formatted
+ * @param {boolean} hasRequirements - True if the licence has return requirements else false
  *
  * @returns {Object} The data formatted for the view template
  */
-function go (returnsData, hasRequirements) {
-  const returns = _returns(returnsData)
+function go (returnLogs, hasRequirements) {
+  const returns = _returns(returnLogs)
 
   const hasReturns = returns.length > 0
 

--- a/app/presenters/licences/view-licence-returns.presenter.js
+++ b/app/presenters/licences/view-licence-returns.presenter.js
@@ -21,7 +21,6 @@ function go (returnLogs, hasRequirements) {
   const hasReturns = returns.length > 0
 
   return {
-    activeTab: 'returns',
     returns,
     noReturnsMessage: _noReturnsMessage(hasReturns, hasRequirements)
   }

--- a/app/presenters/licences/view-licence-returns.presenter.js
+++ b/app/presenters/licences/view-licence-returns.presenter.js
@@ -35,13 +35,16 @@ function _formatPurpose (purpose) {
 
 function _formatReturnToTableRow (returns) {
   return returns.map((returnLog) => {
+    const { endDate, dueDate, id: returnLogId, metadata, returnReference, startDate, status } = returnLog
+
     return {
-      dates: `${formatLongDate(new Date(returnLog.startDate))} to ${formatLongDate(new Date(returnLog.endDate))}`,
-      description: returnLog.metadata.description,
-      dueDate: formatLongDate(new Date(returnLog.dueDate)),
+      dates: `${formatLongDate(new Date(startDate))} to ${formatLongDate(new Date(endDate))}`,
+      description: metadata.description,
+      dueDate: formatLongDate(new Date(dueDate)),
       id: returnLog.id,
-      purpose: _formatPurpose(returnLog.metadata.purposes),
-      reference: returnLog.returnReference,
+      link: _link(status, returnLogId),
+      purpose: _formatPurpose(metadata.purposes),
+      reference: returnReference,
       status: _formatStatus(returnLog)
     }
   })
@@ -58,12 +61,21 @@ function _formatStatus (returnLog) {
 
   // Work out if the return is overdue (status is still 'due' and it is past the due date)
   const today = new Date()
+
   if (status === 'due' && dueDate < today) {
     return 'overdue'
   }
 
   // For all other cases we can just return the status and the return-status-tag macro will know how to display it
   return status
+}
+
+function _link (status, returnLogId) {
+  if (status === 'completed') {
+    return `/returns/return?id=${returnLogId}`
+  }
+
+  return `/return/internal?returnId=${returnLogId}`
 }
 
 function _noReturnsMessage (hasReturns, hasRequirements) {

--- a/app/services/licences/view-licence-returns.service.js
+++ b/app/services/licences/view-licence-returns.service.js
@@ -31,6 +31,7 @@ async function go (licenceId, auth, page) {
   const pagination = PaginatorPresenter.go(returnsData.pagination.total, Number(page), `/system/licences/${licenceId}/returns`)
 
   return {
+    activeTab: 'returns',
     ...pageData,
     ...commonData,
     pagination

--- a/app/views/licences/tabs/returns.njk
+++ b/app/views/licences/tabs/returns.njk
@@ -10,7 +10,7 @@
 {% else %}
 
   {% macro referenceColumn(return) %}
-    <a href="/return/internal?returnId={{ return.id }}" class="govuk-link">{{ return.reference }} </a>
+    <a href="{{ return.link }}" class="govuk-link">{{ return.reference }} </a>
     <p class="govuk-body-s"> {{ return.dates }}</p>
   {% endmacro %}
 

--- a/app/views/licences/tabs/returns.njk
+++ b/app/views/licences/tabs/returns.njk
@@ -3,28 +3,23 @@
 
 {% from "macros/return-status-tag.njk" import statusTag %}
 
+{% macro referenceColumn(return) %}
+  <a href="{{ return.link }}" class="govuk-link">{{ return.reference }} </a>
+  <p class="govuk-body-s">{{ return.dates }}</p>
+{% endmacro %}
+
 <h2 class="govuk-heading-l">Returns</h2>
 
 {% if noReturnsMessage %}
-  <p> {{ noReturnsMessage }} </p>
+  <p>{{ noReturnsMessage }}</p>
 {% else %}
-
-  {% macro referenceColumn(return) %}
-    <a href="{{ return.link }}" class="govuk-link">{{ return.reference }} </a>
-    <p class="govuk-body-s"> {{ return.dates }}</p>
-  {% endmacro %}
-
-  {% set returnRows = [] %}
+  {% set tableRows = [] %}
 
   {% for returnItem in  returns %}
     {# Set an easier to use index. Also means we can refer to it inside our elementDetail loop #}
     {% set rowIndex = loop.index0 %}
 
-    {% set returnStatusTag %}
-      {{ statusTag(returnItem.status, true) }}
-    {% endset %}
-
-    {% set returnRows = (returnRows.push([
+    {% set row = [
       {
         html: referenceColumn(returnItem),
         attributes: { 'data-test': 'return-reference-' + rowIndex }
@@ -38,10 +33,12 @@
         attributes: { 'data-test': 'return-due-date-' + rowIndex }
       },
       {
-        html: returnStatusTag,
+        html: statusTag(returnItem.status, true),
         attributes: { 'data-test': 'return-status-' + rowIndex }
       }
-    ]), returnRows) %}
+    ] %}
+
+    {% set tableRows = (tableRows.push(row), tableRows) %}
   {% endfor %}
 
   {{ govukTable({
@@ -59,10 +56,10 @@
         text: 'Status'
       }
     ],
-    rows: returnRows
+    rows: tableRows
   }) }}
-{% endif %}
 
-{% if pagination.numberOfPages > 1 %}
-  {{ govukPagination(pagination.component) }}
+  {% if pagination.numberOfPages > 1 %}
+    {{ govukPagination(pagination.component) }}
+  {% endif %}
 {% endif %}

--- a/app/views/licences/tabs/returns.njk
+++ b/app/views/licences/tabs/returns.njk
@@ -17,22 +17,29 @@
   {% set returnRows = [] %}
 
   {% for returnItem in  returns %}
+    {# Set an easier to use index. Also means we can refer to it inside our elementDetail loop #}
+    {% set rowIndex = loop.index0 %}
+
     {% set returnStatusTag %}
       {{ statusTag(returnItem.status, true) }}
     {% endset %}
 
     {% set returnRows = (returnRows.push([
       {
-        html: referenceColumn(returnItem)
+        html: referenceColumn(returnItem),
+        attributes: { 'data-test': 'return-reference-' + rowIndex }
       },
       {
-        html:  returnItem.purpose +  "<p class=\"govuk-body-s\">" + returnItem.description + "</p>"
+        html:  returnItem.purpose +  "<p class=\"govuk-body-s\">" + returnItem.description + "</p>",
+        attributes: { 'data-test': 'return-purpose-' + rowIndex }
       },
       {
-        text: returnItem.dueDate
+        text: returnItem.dueDate,
+        attributes: { 'data-test': 'return-due-date-' + rowIndex }
       },
       {
-        html: returnStatusTag
+        html: returnStatusTag,
+        attributes: { 'data-test': 'return-status-' + rowIndex }
       }
     ]), returnRows) %}
   {% endfor %}

--- a/test/presenters/licences/view-licence-returns.presenter.test.js
+++ b/test/presenters/licences/view-licence-returns.presenter.test.js
@@ -61,7 +61,6 @@ describe('View Licence returns presenter', () => {
       const result = ViewLicenceReturnsPresenter.go(returnsData, hasRequirements)
 
       expect(result).to.equal({
-        activeTab: 'returns',
         noReturnsMessage: null,
         returns: [
           {

--- a/test/presenters/licences/view-licence-returns.presenter.test.js
+++ b/test/presenters/licences/view-licence-returns.presenter.test.js
@@ -68,20 +68,20 @@ describe('View Licence returns presenter', () => {
             dates: '2 January 2020 to 1 February 2020',
             description: 'empty description',
             dueDate: '28 November 2012',
-            id: 'd5912c1d-3928-48e9-b2fc-e99a96d704a3',
             link: '/returns/return?id=d5912c1d-3928-48e9-b2fc-e99a96d704a3',
             purpose: 'SPRAY IRRIGATION',
             reference: '1068',
+            returnLogId: 'd5912c1d-3928-48e9-b2fc-e99a96d704a3',
             status: 'complete'
           },
           {
             dates: '2 January 2020 to 1 February 2020',
             description: 'empty description',
             dueDate: '28 November 2012',
-            id: '2fb6d1be-5d56-45de-a252-3c1e8a955991',
             link: '/return/internal?returnId=2fb6d1be-5d56-45de-a252-3c1e8a955991',
             purpose: 'SPRAY IRRIGATION',
             reference: '1069',
+            returnLogId: '2fb6d1be-5d56-45de-a252-3c1e8a955991',
             status: 'overdue'
           }
         ]

--- a/test/presenters/licences/view-licence-returns.presenter.test.js
+++ b/test/presenters/licences/view-licence-returns.presenter.test.js
@@ -69,6 +69,7 @@ describe('View Licence returns presenter', () => {
             description: 'empty description',
             dueDate: '28 November 2012',
             id: 'd5912c1d-3928-48e9-b2fc-e99a96d704a3',
+            link: '/returns/return?id=d5912c1d-3928-48e9-b2fc-e99a96d704a3',
             purpose: 'SPRAY IRRIGATION',
             reference: '1068',
             status: 'complete'
@@ -78,6 +79,7 @@ describe('View Licence returns presenter', () => {
             description: 'empty description',
             dueDate: '28 November 2012',
             id: '2fb6d1be-5d56-45de-a252-3c1e8a955991',
+            link: '/return/internal?returnId=2fb6d1be-5d56-45de-a252-3c1e8a955991',
             purpose: 'SPRAY IRRIGATION',
             reference: '1069',
             status: 'overdue'

--- a/test/presenters/licences/view-licence-returns.presenter.test.js
+++ b/test/presenters/licences/view-licence-returns.presenter.test.js
@@ -15,7 +15,7 @@ describe('View Licence returns presenter', () => {
   let hasRequirements
 
   const returnItem = {
-    id: 'mock-id-1',
+    id: 'd5912c1d-3928-48e9-b2fc-e99a96d704a3',
     dueDate: new Date('2012-11-28'),
     status: 'completed',
     startDate: new Date('2020/01/02'),
@@ -49,7 +49,7 @@ describe('View Licence returns presenter', () => {
       { ...returnItem },
       {
         ...returnItem,
-        id: 'mock-id-2',
+        id: '2fb6d1be-5d56-45de-a252-3c1e8a955991',
         status: 'due',
         returnReference: '1069'
       }
@@ -65,22 +65,22 @@ describe('View Licence returns presenter', () => {
         noReturnsMessage: null,
         returns: [
           {
-            id: 'mock-id-1',
-            reference: '1068',
-            purpose: 'SPRAY IRRIGATION',
-            dueDate: '28 November 2012',
-            status: 'complete',
             dates: '2 January 2020 to 1 February 2020',
-            description: 'empty description'
+            description: 'empty description',
+            dueDate: '28 November 2012',
+            id: 'd5912c1d-3928-48e9-b2fc-e99a96d704a3',
+            purpose: 'SPRAY IRRIGATION',
+            reference: '1068',
+            status: 'complete'
           },
           {
-            id: 'mock-id-2',
-            reference: '1069',
-            purpose: 'SPRAY IRRIGATION',
-            dueDate: '28 November 2012',
-            status: 'overdue',
             dates: '2 January 2020 to 1 February 2020',
-            description: 'empty description'
+            description: 'empty description',
+            dueDate: '28 November 2012',
+            id: '2fb6d1be-5d56-45de-a252-3c1e8a955991',
+            purpose: 'SPRAY IRRIGATION',
+            reference: '1069',
+            status: 'overdue'
           }
         ]
       })
@@ -96,25 +96,25 @@ describe('View Licence returns presenter', () => {
       })
     })
 
-    describe('when a licence has NO returns and NO requirements', () => {
+    describe('when a licence has NO requirements and NO returns', () => {
       beforeEach(() => {
         returnsData = []
         hasRequirements = false
       })
 
-      it('presents the No returns and No requirements message "No requirements for returns have been set up for this licence."', () => {
+      it('returns the message "No requirements for returns have been set up for this licence."', () => {
         const result = ViewLicenceReturnsPresenter.go(returnsData, hasRequirements)
 
         expect(result.noReturnsMessage).to.equal('No requirements for returns have been set up for this licence.')
       })
     })
 
-    describe('when a licence has returns but no requirements', () => {
+    describe('when a licence has requirements but NO returns', () => {
       beforeEach(() => {
         returnsData = []
       })
 
-      it('presents the returns but no requirements message "No returns for this licence."', () => {
+      it('returns the message "No returns for this licence."', () => {
         const result = ViewLicenceReturnsPresenter.go(returnsData, hasRequirements)
 
         expect(result.noReturnsMessage).to.equal('No returns for this licence.')

--- a/test/services/licences/view-licence-returns.service.test.js
+++ b/test/services/licences/view-licence-returns.service.test.js
@@ -11,18 +11,15 @@ const { expect } = Code
 // Things we need to stub
 const DetermineLicenceHasReturnVersionsService = require('../../../app/services/licences/determine-licence-has-return-versions.service.js')
 const FetchLicenceReturnsService = require('../../../app/services/licences/fetch-licence-returns.service.js')
-const PaginatorPresenter = require('../../../app/presenters/paginator.presenter.js')
-const ViewLicenceReturnsPresenter = require('../../../app/presenters/licences/view-licence-returns.presenter.js')
 const ViewLicenceService = require('../../../app/services/licences/view-licence.service.js')
 
 // Thing under test
 const ViewLicenceReturnsService = require('../../../app/services/licences/view-licence-returns.service.js')
 
-describe('View Licence service returns', () => {
+describe('View Licence Returns service', () => {
   const testId = '2c80bd22-a005-4cf4-a2a2-73812a9861de'
   const page = 1
   const auth = {}
-  const pagination = { page }
 
   beforeEach(async () => {
     Sinon.stub(DetermineLicenceHasReturnVersionsService, 'go').returns(true)
@@ -30,13 +27,6 @@ describe('View Licence service returns', () => {
     Sinon.stub(FetchLicenceReturnsService, 'go').resolves({
       pagination: { total: 1 },
       returns: []
-    })
-
-    Sinon.stub(PaginatorPresenter, 'go').returns(pagination)
-
-    Sinon.stub(ViewLicenceReturnsPresenter, 'go').returns({
-      returns: [],
-      activeTab: 'returns'
     })
 
     Sinon.stub(ViewLicenceService, 'go').resolves({
@@ -54,10 +44,10 @@ describe('View Licence service returns', () => {
         const result = await ViewLicenceReturnsService.go(testId, auth, page)
 
         expect(result).to.equal({
-          licenceName: 'fake licence',
-          returns: [],
           activeTab: 'returns',
-          pagination: { page: 1 }
+          returns: [],
+          licenceName: 'fake licence',
+          pagination: { numberOfPages: 1 }
         })
       })
     })

--- a/test/services/licences/view-licence-returns.service.test.js
+++ b/test/services/licences/view-licence-returns.service.test.js
@@ -46,6 +46,7 @@ describe('View Licence Returns service', () => {
         expect(result).to.equal({
           activeTab: 'returns',
           returns: [],
+          noReturnsMessage: 'No returns for this licence.',
           licenceName: 'fake licence',
           pagination: { numberOfPages: 1 }
         })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4557

> Part of the work to replace the legacy view licence page

When building our version of the returns tab in the view licence page, we didn't spot that the link for 'complete' licences goes to a different URL than the one for 'due' licences.

Our current implementation is sending users to a page where we are asking them to enter the details again for a complete return!

This change fixes the issue.