### PR TITLE
Make Bill run value blank when in Review Status

### DIFF
--- a/app/presenters/bill-runs/index-bill-runs.presenter.js
+++ b/app/presenters/bill-runs/index-bill-runs.presenter.js
@@ -43,10 +43,18 @@ function go (billRuns) {
       region: titleCase(region),
       scheme,
       status,
-      total: formatMoney(netTotal, true),
+      total: _formatTotal(status, batchType, netTotal),
       type: formatBillRunType(batchType, scheme, summer)
     }
   })
+}
+
+function _formatTotal (status, batchType, netTotal) {
+  if (status === 'review' && batchType === 'two_part_tariff') {
+    return ''
+  }
+
+  return formatMoney(netTotal, true)
 }
 
 function _link (billRunId, status, scheme) {

--- a/test/presenters/bill-runs/index-bill-runs.presenter.test.js
+++ b/test/presenters/bill-runs/index-bill-runs.presenter.test.js
@@ -174,6 +174,23 @@ describe('Index Bill Runs presenter', () => {
         })
       })
     })
+
+    describe('the "total" property', () => {
+      describe('when a bill run is two-part tariff', () => {
+        describe('and has the status "review"', () => {
+          beforeEach(() => {
+            billRuns[0].batchType = 'two_part_tariff'
+            billRuns[0].status = 'review'
+          })
+
+          it('does not return a pound value', () => {
+            const results = IndexBillRunsPresenter.go(billRuns)
+
+            expect(results[0].total).to.equal('')
+          })
+        })
+      })
+    })
   })
 })
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4549

During the testing for the two-part tariff review pages, it was noted by the billing and data team that when a 2pt bill run is displayed with a status of review then the value column is always £0.00. The business requested that this column be empty rather than showing a figure of £0.00. This PR makes that change.