### PR TITLE
Fix unit tests after enablingSystemLicenceView tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
       POSTGRES_DB_TEST: wabs_system_test
       ENVIRONMENT: dev
       COOKIE_SECRET: 1a1028df-a2af-468a-929b-e3a274be1208
+      ENABLE_SYSTEM_LICENCE_VIEW: true
 
 
     # Service containers to run with `runner-job`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,6 @@ jobs:
       POSTGRES_DB_TEST: wabs_system_test
       ENVIRONMENT: dev
       COOKIE_SECRET: 1a1028df-a2af-468a-929b-e3a274be1208
-      ENABLE_SYSTEM_LICENCE_VIEW: true
-
 
     # Service containers to run with `runner-job`
     services:

--- a/test/presenters/return-requirements/start-date.presenter.test.js
+++ b/test/presenters/return-requirements/start-date.presenter.test.js
@@ -38,7 +38,7 @@ describe('Return Requirements - Start Date presenter', () => {
         anotherStartDateDay: null,
         anotherStartDateMonth: null,
         anotherStartDateYear: null,
-        backLink: '/licences/8b7f78ba-f3ad-4cb6-a058-78abc4d1383d#charge',
+        backLink: '/system/licences/8b7f78ba-f3ad-4cb6-a058-78abc4d1383d/set-up',
         licenceId: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
         licenceRef: '01/ABC',
         licenceVersionStartDate: '1 January 2023',
@@ -65,7 +65,7 @@ describe('Return Requirements - Start Date presenter', () => {
       it("returns a link back to the licence page's charge tab", () => {
         const result = StartDatePresenter.go(session)
 
-        expect(result.backLink).to.equal('/licences/8b7f78ba-f3ad-4cb6-a058-78abc4d1383d#charge')
+        expect(result.backLink).to.equal('/system/licences/8b7f78ba-f3ad-4cb6-a058-78abc4d1383d/set-up')
       })
     })
   })

--- a/test/presenters/return-requirements/start-date.presenter.test.js
+++ b/test/presenters/return-requirements/start-date.presenter.test.js
@@ -3,11 +3,13 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
+const Sinon = require('sinon')
 
 const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Thing under test
+const FeatureFlagsConfig = require('../../../config/feature-flags.config.js')
 const StartDatePresenter = require('../../../app/presenters/return-requirements/start-date.presenter.js')
 
 describe('Return Requirements - Start Date presenter', () => {
@@ -28,6 +30,8 @@ describe('Return Requirements - Start Date presenter', () => {
       journey: 'returns-required',
       requirements: [{}]
     }
+
+    Sinon.stub(FeatureFlagsConfig, 'enableSystemLicenceView').value(true)
   })
 
   describe('when provided with a session', () => {

--- a/test/services/return-requirements/start-date.service.test.js
+++ b/test/services/return-requirements/start-date.service.test.js
@@ -3,12 +3,14 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
+const Sinon = require('sinon')
 
 const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
 const DatabaseSupport = require('../../support/database.js')
+const FeatureFlagsConfig = require('../../../config/feature-flags.config.js')
 const SessionHelper = require('../../support/helpers/session.helper.js')
 
 // Thing under test
@@ -35,6 +37,8 @@ describe('Return Requirements - Start Date service', () => {
         requirements: [{}]
       }
     })
+
+    Sinon.stub(FeatureFlagsConfig, 'enableSystemLicenceView').value(true)
   })
 
   describe('when called', () => {

--- a/test/services/return-requirements/start-date.service.test.js
+++ b/test/services/return-requirements/start-date.service.test.js
@@ -53,7 +53,7 @@ describe('Return Requirements - Start Date service', () => {
         anotherStartDateDay: null,
         anotherStartDateMonth: null,
         anotherStartDateYear: null,
-        backLink: '/licences/8b7f78ba-f3ad-4cb6-a058-78abc4d1383d#charge',
+        backLink: '/system/licences/8b7f78ba-f3ad-4cb6-a058-78abc4d1383d/set-up',
         licenceId: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
         licenceRef: '01/ABC',
         licenceVersionStartDate: '1 January 2023',

--- a/test/services/return-requirements/submit-start-date.service.test.js
+++ b/test/services/return-requirements/submit-start-date.service.test.js
@@ -137,7 +137,7 @@ describe('Return Requirements - Submit Start Date service', () => {
           anotherStartDateDay: null,
           anotherStartDateMonth: null,
           anotherStartDateYear: null,
-          backLink: '/licences/8b7f78ba-f3ad-4cb6-a058-78abc4d1383d#charge',
+          backLink: '/system/licences/8b7f78ba-f3ad-4cb6-a058-78abc4d1383d/set-up',
           licenceId: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
           licenceRef: '01/ABC',
           licenceVersionStartDate: '1 January 2023',

--- a/test/services/return-requirements/submit-start-date.service.test.js
+++ b/test/services/return-requirements/submit-start-date.service.test.js
@@ -10,6 +10,7 @@ const { expect } = Code
 
 // Test helpers
 const DatabaseSupport = require('../../support/database.js')
+const FeatureFlagsConfig = require('../../../config/feature-flags.config.js')
 const SessionHelper = require('../../support/helpers/session.helper.js')
 
 // Thing under test
@@ -126,6 +127,8 @@ describe('Return Requirements - Submit Start Date service', () => {
     describe('with an invalid payload', () => {
       beforeEach(async () => {
         payload = {}
+
+        Sinon.stub(FeatureFlagsConfig, 'enableSystemLicenceView').value(true)
       })
 
       it('returns the page data for the view', async () => {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4555

As the new licence view page for `water-abstraction-system` is now being enabled, this has caused some of our unit tests to fail. After looking at some of the failing tests, this seems to be because of a new URL endpoint being used.

This PR will fix the failing unit tests within `water-abstraction-system`.