### PR TITLE
Fix order of charge vers. in view licence - again!

### DIFF
--- a/app/services/licences/fetch-charge-versions.service.js
+++ b/app/services/licences/fetch-charge-versions.service.js
@@ -36,7 +36,7 @@ async function _fetch (licenceId) {
     })
     .orderBy([
       { column: 'startDate', order: 'desc' },
-      { column: 'endDate', order: 'desc' }
+      { column: 'versionNumber', order: 'desc' }
     ])
 }
 

--- a/test/services/licences/fetch-charge-versions.service.test.js
+++ b/test/services/licences/fetch-charge-versions.service.test.js
@@ -18,13 +18,11 @@ const FetchChargeVersionsService =
 
 describe('Fetch Charge Versions service', () => {
   const licenceId = generateUUID()
-  // These dates were taken from a real licence where our first iteration was not showing the charge versions in the
-  // correct order!
-  const startDate = new Date('2018-04-01')
-  const endDate = new Date('2030-03-31')
 
-  let currentChargeVersionId
-  let supersededChargeVersionId
+  let currentChargeVersionWithEndDateId
+  let currentChargeVersionWithoutEndDateId
+  let supersededChargeVersionWithEndDateId
+  let supersededChargeVersionWithoutEndDateId
 
   describe('when the licence has charge versions data', () => {
     beforeEach(async () => {
@@ -33,23 +31,49 @@ describe('Fetch Charge Versions service', () => {
       // Create multiple charge versions to ensure we get them in the right order
       let chargeVersion = await ChargeVersionHelper.add({
         changeReasonId: changeReason.id,
-        endDate,
+        endDate: new Date('2030-03-31'),
         licenceId,
         scheme: 'alcs',
-        startDate,
-        status: 'superseded'
+        startDate: new Date('2018-04-01'),
+        status: 'superseded',
+        versionNumber: 1
       })
 
-      supersededChargeVersionId = chargeVersion.id
+      supersededChargeVersionWithEndDateId = chargeVersion.id
 
       chargeVersion = await ChargeVersionHelper.add({
         changeReasonId: changeReason.id,
+        endDate: null,
         licenceId,
         scheme: 'alcs',
-        startDate
+        startDate: new Date('2021-04-01'),
+        status: 'superseded',
+        versionNumber: 3
       })
 
-      currentChargeVersionId = chargeVersion.id
+      supersededChargeVersionWithoutEndDateId = chargeVersion.id
+
+      chargeVersion = await ChargeVersionHelper.add({
+        changeReasonId: changeReason.id,
+        endDate: null,
+        licenceId,
+        scheme: 'alcs',
+        startDate: new Date('2021-04-01'),
+        versionNumber: 4
+      })
+
+      currentChargeVersionWithoutEndDateId = chargeVersion.id
+
+      chargeVersion = await ChargeVersionHelper.add({
+        changeReasonId: changeReason.id,
+        endDate: new Date('2021-03-31'),
+        licenceId,
+        scheme: 'alcs',
+        startDate: new Date('2018-04-01'),
+        versionNumber: 2
+      })
+
+      currentChargeVersionWithEndDateId = chargeVersion.id
     })
 
     it('returns the matching charge versions data', async () => {
@@ -61,19 +85,39 @@ describe('Fetch Charge Versions service', () => {
             description: 'Strategic review of charges (SRoC)'
           },
           endDate: null,
-          id: currentChargeVersionId,
+          id: currentChargeVersionWithoutEndDateId,
           licenceId,
-          startDate,
+          startDate: new Date('2021-04-01'),
           status: 'current'
         },
         {
           changeReason: {
             description: 'Strategic review of charges (SRoC)'
           },
-          endDate,
-          id: supersededChargeVersionId,
+          endDate: null,
+          id: supersededChargeVersionWithoutEndDateId,
           licenceId,
-          startDate,
+          startDate: new Date('2021-04-01'),
+          status: 'superseded'
+        },
+        {
+          changeReason: {
+            description: 'Strategic review of charges (SRoC)'
+          },
+          endDate: new Date('2021-03-31'),
+          id: currentChargeVersionWithEndDateId,
+          licenceId,
+          startDate: new Date('2018-04-01'),
+          status: 'current'
+        },
+        {
+          changeReason: {
+            description: 'Strategic review of charges (SRoC)'
+          },
+          endDate: new Date('2030-03-31'),
+          id: supersededChargeVersionWithEndDateId,
+          licenceId,
+          startDate: new Date('2018-04-01'),
           status: 'superseded'
         }
       ])


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4556

> Part of the work to replace the legacy view licence page

We thought we'd nailed the ordering of the charge versions in the new licence setup tab of our new view licence screen in [Fix order of charge versions in view licence page](https://github.com/DEFRA/water-abstraction-system/pull/1162).

However, it's still not quite right. The previous fix assumed a 'superseded' charge version would always have an end date. However, it turns out this is not always the case. If followed by a 'current' charge version that also has an end date (because another has been added after it), sorting by end date means the 'current' comes after the 'superseded'.

Having double-checked the legacy code, they have are sorting by start date then version number. As it is the legacy view's order we're trying to match, we're just going to crack on and make the change to do the same thing.