### PR TITLE
Add missing return requirement set up reasons

### DIFF
--- a/app/lib/static-lookups.lib.js
+++ b/app/lib/static-lookups.lib.js
@@ -34,7 +34,9 @@ const returnRequirementFrequencies = {
 
 const returnRequirementReasons = {
   'abstraction-below-100-cubic-metres-per-day': 'Abstraction amount below 100 cubic metres per day',
+  'change-to-return-requirements': 'Change to requirements for returns',
   'change-to-special-agreement': 'Change to special agreement',
+  'error-correction': 'Error correction',
   'extension-of-licence-validity': 'Limited extension of licence validity (LEV)',
   'major-change': 'Major change',
   'minor-change': 'Minor change',

--- a/app/validators/return-requirements/reason.validator.js
+++ b/app/validators/return-requirements/reason.validator.js
@@ -7,19 +7,7 @@
 
 const Joi = require('joi')
 
-const VALID_VALUES = [
-  'change-to-special-agreement',
-  'name-or-address-change',
-  'transfer-and-now-chargeable',
-  'extension-of-licence-validity',
-  'major-change',
-  'minor-change',
-  'new-licence-in-part-succession-or-licence-apportionment',
-  'new-licence',
-  'new-special-agreement',
-  'succession-or-transfer-of-licence',
-  'succession-to-remainder-licence-or-licence-apportionment'
-]
+const { returnRequirementReasons } = require('../../lib/static-lookups.lib.js')
 
 const errorMessage = 'Select the reason for the requirements for returns'
 
@@ -32,10 +20,12 @@ const errorMessage = 'Select the reason for the requirements for returns'
  * any errors are found the `error:` property will also exist detailing what the issues were
  */
 function go (data) {
+  const validValues = Object.keys(returnRequirementReasons)
+
   const schema = Joi.object({
     reason: Joi.string()
       .required()
-      .valid(...VALID_VALUES)
+      .valid(...validValues)
       .messages({
         'any.required': errorMessage,
         'any.only': errorMessage,

--- a/app/views/return-requirements/reason.njk
+++ b/app/views/return-requirements/reason.njk
@@ -39,9 +39,19 @@
         },
         items: [
           {
+            text: 'Change to requirements for returns',
+            value: 'change-to-return-requirements',
+            checked: 'change-to-return-requirements' === reason
+          },
+          {
             text: 'Change to special agreement',
             value: 'change-to-special-agreement',
             checked: 'change-to-special-agreement' === reason
+          },
+          {
+            text: 'Error correction',
+            value: 'error-correction',
+            checked: 'error-correction' === reason
           },
           {
             text: 'Licence holder name or address change',


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4265

> Part of the work to migrate return requirements from NALD to WRLS

It appears the design we implemented for the 'Select the reason' page of the returns required setup journey was missing 2 options. Somewhere between testing and pulling together the wire frames, they got left off.

This change adds the missing options to the page.

For reference, they are

- Change to requirements for returns
- Error correction