### PR TITLE
Spike migrating import licence to system

### DIFF
--- a/app/import/helpers/charge-merge.js
+++ b/app/import/helpers/charge-merge.js
@@ -1,0 +1,65 @@
+'use strict'
+
+// TODO: this will need to use built in date
+const moment = require('moment')
+// TODO: you might not need lodash...
+const { last, omit, isEqual } = require('lodash')
+
+const DATE_FORMAT = 'YYYY-MM-DD'
+
+/**
+ * Checks whether 2 objects have adjacent date ranges.
+ * Object a must have an endDate that is either null, or 1 day before
+ * the startDate property of object b
+ * @param {Object} a
+ * @param {Object} b next row
+ * @return {Boolean}
+ */
+const isAdjacentDateRange = (a, b) => {
+  const expectedEndDate = moment(b.startDate).subtract(1, 'day').format(DATE_FORMAT)
+
+  return [null, expectedEndDate].includes(a.endDate)
+}
+
+/**
+ * Default implementation of equality test between two objects
+ * for history merging.
+ * Checks if the objects are equal when taking into account all
+ * properties except startDate and endDate
+ * @param {Object} a
+ * @param {Object} b
+ * @return {Boolean}
+ */
+const equalityTest = (a, b) => {
+  const objA = omit(a, ['startDate', 'endDate'])
+  const objB = omit(b, ['startDate', 'endDate'])
+
+  return isEqual(objA, objB)
+}
+
+/**
+ * Given an array of objects sorted by date, de-duplicates them where adjacent array items
+ * are identical except for their date ranges, extending the endDate property of
+ * earlier element to that of the later element
+ * @param {Array} arr - a list of objects, each with startDate and endDate properties
+ * @param {Function} func - a function which tests if adjacent objects can be merged
+ * @return {Array} an array with histories merged
+ */
+const mergeHistory = (arr, isEqual = equalityTest) => {
+  return arr.reduce((acc, row) => {
+    const previousRow = last(acc)
+
+    if (acc.length && isEqual(row, previousRow) && isAdjacentDateRange(previousRow, row)) {
+      acc[acc.length - 1] = {
+        ...previousRow,
+        endDate: row.endDate
+      }
+    } else {
+      acc.push(row)
+    }
+
+    return acc
+  }, [])
+}
+
+exports.mergeHistory = mergeHistory

--- a/app/import/helpers/date.js
+++ b/app/import/helpers/date.js
@@ -1,0 +1,60 @@
+'use strict'
+
+// TODO: this all needs to be re written to use the built in date
+const moment = require('moment')
+const DATE_FORMAT = 'YYYY-MM-DD'
+const NALD_FORMAT = 'DD/MM/YYYY'
+const NALD_TRANSFER_FORMAT = 'DD/MM/YYYY HH:mm:ss'
+
+const mapNaldDate = (str) => {
+  if (str === 'null') {
+    return null
+  }
+
+  return moment(str, NALD_FORMAT).format(DATE_FORMAT)
+}
+
+const mapIsoDateToNald = (str) => {
+  if (str === null) {
+    return 'null'
+  }
+
+  return moment(str, DATE_FORMAT).format(NALD_FORMAT)
+}
+
+const getSortedDates = (arr) => {
+  const moments = arr
+    .map((str) => { return moment(str, DATE_FORMAT) })
+    .filter((m) => { return m.isValid() })
+
+  const sorted = moments.sort(function (startDate1, startDate2) {
+    return startDate1 - startDate2
+  })
+
+  return sorted
+}
+
+const getMinDate = (arr) => {
+  const sorted = getSortedDates(arr)
+
+  return sorted.length === 0 ? null : sorted[0].format(DATE_FORMAT)
+}
+
+const getMaxDate = (arr) => {
+  const sorted = getSortedDates(arr)
+
+  return sorted.length === 0 ? null : sorted[sorted.length - 1].format(DATE_FORMAT)
+}
+
+const mapTransferDate = (str) => { return moment(str, NALD_TRANSFER_FORMAT).format(DATE_FORMAT) }
+
+const getPreviousDay = (str) => { return moment(str, DATE_FORMAT).subtract(1, 'day').format(DATE_FORMAT) }
+
+module.exports = {
+  mapNaldDate,
+  getMinDate,
+  getMaxDate,
+  mapTransferDate,
+  getPreviousDay,
+  mapIsoDateToNald
+}

--- a/app/import/import.controller.js
+++ b/app/import/import.controller.js
@@ -1,0 +1,21 @@
+'use strict'
+
+const ImportLicenceHandler = require('./licence/services/import-licence.service.js')
+
+/**
+ * Controller for /import endpoints
+ * @module ImportController
+ */
+async function LicenceTrigger (request, h) {
+  const { licenceRef } = request.payload
+
+  console.log('Licence Ref', licenceRef)
+
+  await ImportLicenceHandler.go(licenceRef)
+
+  return h.response().code(204)
+}
+
+module.exports = {
+  LicenceTrigger
+}

--- a/app/import/import.routes.js
+++ b/app/import/import.routes.js
@@ -1,0 +1,19 @@
+'use strict'
+
+const ImportController = require('./import.controller.js')
+
+const routes = [
+  {
+    method: 'POST',
+    path: '/import/licence',
+    handler: ImportController.LicenceTrigger,
+    options: {
+      app: {
+        plainOutput: true
+      },
+      auth: false
+    }
+  }
+]
+
+module.exports = routes

--- a/app/import/licence/import-licence.mapper.js
+++ b/app/import/licence/import-licence.mapper.js
@@ -1,0 +1,17 @@
+'use strict'
+
+const LicenceAgreementsMapper = require('./mappers/agreements.mapper.js')
+
+/**
+ * Maps licence data from the import schema
+ * @module ImportLicenceMapper
+ */
+function go (licence) {
+  return {
+    agreements: LicenceAgreementsMapper.go(licence.tptAgreements, licence.section130Agreements)
+  }
+}
+
+module.exports = {
+  go
+}

--- a/app/import/licence/mappers/agreements.mapper.js
+++ b/app/import/licence/mappers/agreements.mapper.js
@@ -1,0 +1,113 @@
+'use strict'
+
+/**
+ * Maps the licence agreements for two part tariff and a130 agreements
+ * @module LicenceAgreementsMapper
+ */
+
+const date = require('../../helpers/date.js')
+const { mergeHistory } = require('../../helpers/charge-merge.js')
+
+// TODO: why s130 agreements ?
+function go (tptAgreements, s130Agreements = []) {
+  const agreements = _mapAgreements(tptAgreements, s130Agreements = [])
+
+  return agreements
+}
+
+// TODO: is this needed ? - not unique in a wider context
+const _getUniqueKey = (agreement) => { return `${agreement.startDate}:${agreement.endDate}:${agreement.agreementCode}` }
+
+const _mapAgreement = (chargeAgreement) => {
+  // Start date is the later of the agreement start date or the
+  // charge version start date.
+  const startDate = date.getMaxDate([
+    date.mapNaldDate(chargeAgreement.EFF_ST_DATE),
+    date.mapNaldDate(chargeAgreement.charge_version_start_date)
+  ])
+
+  // End date is the earlier of the agreement end date or the
+  // charge version end date.  Either can be null.
+  const endDate = date.getMinDate([
+    date.mapNaldDate(chargeAgreement.EFF_END_DATE),
+    date.mapNaldDate(chargeAgreement.charge_version_end_date)
+  ])
+
+  return {
+    agreementCode: chargeAgreement.AFSA_CODE,
+    startDate,
+    endDate
+  }
+}
+
+const _mapAgreements = (tptAgreements, s130Agreements = []) => {
+  const mappedTptAgreements = _mapTwoPartTariffAgreements(tptAgreements)
+
+  // Map and de-duplicate identical agreements
+  const mapped = [...new Set([...mappedTptAgreements, ...s130Agreements].map(_mapAgreement),
+    _getUniqueKey)]
+
+  // TODO: why do we need to group ?
+  // Group by agreement code
+  const groups = mapped.reduce((group, agreement) => {
+    group[agreement.agreementCode] = group[agreement.agreementCode] ?? []
+    group[agreement.agreementCode].push(agreement)
+
+    return group
+  }, {})
+
+  // TODO: why dop we merge history
+  // For each group, merge history
+  const merged = Object.values(groups).map((group) => {
+    return mergeHistory(
+      group.sort((startDate1, startDate2) => {
+        if ((startDate1, startDate1.startDate) > (startDate2, startDate2.startDate)) {
+          return 1
+        } else {
+          return -1
+        }
+      })
+    )
+  }
+  )
+
+  return merged.flatMap((num) => { return num })
+}
+
+/**
+ * Maps element-level agreements to a single charge-level agreement
+ * with the max possible date range
+ * @param {Array<Object>} tptAgreements
+ * @returns {Object}
+ */
+const _mapElementLevelAgreements = (tptAgreements) => {
+  const startDates = tptAgreements.map((row) => { return date.mapNaldDate(row.EFF_ST_DATE) })
+  const endDates = tptAgreements.map((row) => { return date.mapNaldDate(row.EFF_END_DATE) })
+
+  return {
+    ...tptAgreements[0],
+    EFF_ST_DATE: date.mapIsoDateToNald(date.getMinDate(startDates)),
+    EFF_END_DATE: date.mapIsoDateToNald(date.getMaxDate(endDates))
+  }
+}
+
+const _mapTwoPartTariffAgreements = (tptAgreements) => {
+  const chargeVersionGroups = tptAgreements.reduce((group, item) => {
+    group[item.version_number] = group[item.version_number] ?? []
+    group[item.version_number].push(item)
+
+    return group
+  }, {})
+
+  const mappedGroups = {}
+
+  for (const key in chargeVersionGroups) {
+    mappedGroups[key] = _mapElementLevelAgreements(chargeVersionGroups[key])
+  }
+
+  return Object.values(mappedGroups)
+}
+
+module.exports = {
+  go
+}

--- a/app/import/licence/services/fetch-licence-from-import.service.js
+++ b/app/import/licence/services/fetch-licence-from-import.service.js
@@ -1,0 +1,96 @@
+'use strict'
+
+/**
+ * Service for /import/licence
+ * @module ImportLicenceService
+ */
+const { db } = require('../../../../db/db.js')
+
+async function go (licenceRef) {
+  const licence = await _getLicenceByRef(licenceRef)
+
+  const { ID: id, FGAC_REGION_CODE: regionCode } = licence
+
+  // TODO: rename these ? why section 130 ?
+  const [tptAgreements, section130Agreements] = await Promise.all([
+    _getTwoPartTariffAgreements(regionCode, id),
+    _getSection130Agreements(regionCode, id)
+  ])
+
+  return {
+    licence,
+    section130Agreements,
+    tptAgreements
+  }
+}
+
+async function _getTwoPartTariffAgreements (regionCode, licenceId) {
+  const query =
+    `  SELECT a.*,
+              cv."EFF_END_DATE" as charge_version_end_date,
+              cv."EFF_ST_DATE"  as charge_version_start_date,
+              cv."VERS_NO"      as version_number
+       FROM import."NALD_CHG_VERSIONS" cv
+                JOIN import."NALD_CHG_ELEMENTS" e
+                     ON cv."FGAC_REGION_CODE" = e."FGAC_REGION_CODE" AND cv."VERS_NO" = e."ACVR_VERS_NO" AND
+                        cv."AABL_ID" = e."ACVR_AABL_ID"
+                JOIN import."NALD_CHG_AGRMNTS" a ON e."FGAC_REGION_CODE" = a."FGAC_REGION_CODE" AND e."ID" = a."ACEL_ID"
+       WHERE cv."FGAC_REGION_CODE" = '${regionCode}'
+         -- Exclude charge versions that have been replaced. We know a CV is replaced because it will have the same start and end date
+         AND cv."EFF_END_DATE" <> cv."EFF_ST_DATE"
+         AND cv."AABL_ID" = '${licenceId}'
+         AND a."AFSA_CODE" = 'S127'
+         AND concat_ws(':', cv."FGAC_REGION_CODE", cv."AABL_ID", cv."VERS_NO") in (
+           -- Finds valid charge versions to select from.
+           -- Draft charge versions are omitted.
+           -- Where multiple charge versions begin on the same date,
+           -- pick the one with the greatest version number.
+           select concat_ws(':',
+                            ncv."FGAC_REGION_CODE",
+                            ncv."AABL_ID",
+                            max(ncv."VERS_NO"::integer)::varchar
+                  ) as id
+           from import."NALD_CHG_VERSIONS" ncv
+           where ncv."STATUS" <> 'DRAFT'
+           group by ncv."FGAC_REGION_CODE", ncv."AABL_ID", ncv."EFF_ST_DATE")
+       ORDER BY cv."VERS_NO"::integer;
+    `
+
+  const { rows } = await db.raw(query)
+
+  return rows
+}
+
+async function _getSection130Agreements (regionCode, licenceId) {
+  const query = `
+      SELECT *
+      FROM import."NALD_LH_AGRMNTS" ag
+               JOIN (SELECT DISTINCT cv."FGAC_REGION_CODE", cv."AIIA_ALHA_ACC_NO"
+                     FROM import."NALD_CHG_VERSIONS" cv
+                     WHERE cv."FGAC_REGION_CODE" = '${regionCode}'
+                       AND cv."AABL_ID" = '${licenceId}'
+                       AND cv."STATUS" <> 'DRAFT') cv
+                    ON ag."FGAC_REGION_CODE" = cv."FGAC_REGION_CODE" AND ag."ALHA_ACC_NO" = cv."AIIA_ALHA_ACC_NO"
+                        AND ag."AFSA_CODE" IN ('S127', 'S130S', 'S130T', 'S130U', 'S130W')
+  `
+
+  const { rows } = await db.raw(query)
+
+  return rows
+}
+
+async function _getLicenceByRef (licenceRef) {
+  const query = `
+      SELECT *
+      FROM import."NALD_ABS_LICENCES" l
+      WHERE l."LIC_NO" = '${licenceRef}';
+  `
+
+  const { rows: [row] } = await db.raw(query)
+
+  return row
+}
+
+module.exports = {
+  go
+}

--- a/app/import/licence/services/import-licence.service.js
+++ b/app/import/licence/services/import-licence.service.js
@@ -1,0 +1,27 @@
+'use strict'
+
+/**
+ * Service for /import/licence
+ * @module ImportLicenceHandler
+ */
+
+const ImportLicenceService = require('./fetch-licence-from-import.service.js')
+const ImportLicenceMapper = require('../import-licence.mapper.js')
+
+async function go (licenceRef) {
+  const importLicenceData = await ImportLicenceService.go(licenceRef)
+
+  console.log('Import Licence Data', importLicenceData)
+
+  const transformedData = ImportLicenceMapper.go(importLicenceData)
+
+  console.log('Transformed Licence Data', transformedData)
+
+  // TODO: validate output here
+
+  // TODO: persist data here
+}
+
+module.exports = {
+  go
+}

--- a/app/import/licence/services/licence-persist.service.js
+++ b/app/import/licence/services/licence-persist.service.js
@@ -1,0 +1,6 @@
+'use strict'
+
+/**
+ * Persists Licence data from the import service to water
+ * @module PersistNALDImportLicence
+ */

--- a/app/plugins/router.plugin.js
+++ b/app/plugins/router.plugin.js
@@ -24,6 +24,7 @@ const JobRoutes = require('../routes/jobs.routes.js')
 const LicenceRoutes = require('../routes/licence.routes.js')
 const ReturnRequirementRoutes = require('../routes/return-requirement.routes.js')
 const RootRoutes = require('../routes/root.routes.js')
+const ImportRoutes = require('../import/import.routes.js')
 
 const AirbrakeConfig = require('../../config/airbrake.config.js')
 
@@ -39,7 +40,8 @@ const routes = [
   ...LicenceRoutes,
   ...JobRoutes,
   ...ReturnRequirementRoutes,
-  ...DataRoutes
+  ...DataRoutes,
+  ...ImportRoutes
 ]
 
 const RouterPlugin = {

--- a/knexfile.application.js
+++ b/knexfile.application.js
@@ -24,7 +24,7 @@ const { legacyDbSnakeCaseMappers } = require('./app/lib/legacy-db-snake-case-map
 const knexfile = require('./knexfile')
 
 for (const environment in knexfile) {
-  Object.assign(knexfile[environment], legacyDbSnakeCaseMappers({ underscoreBeforeDigits: true }))
+  Object.assign(knexfile[environment])
 }
 
 module.exports = { ...knexfile }

--- a/test/import/licence/fixtures/licences/agreements.js
+++ b/test/import/licence/fixtures/licences/agreements.js
@@ -1,0 +1,37 @@
+'use strict'
+
+module.exports = {
+  section130Agreements: [],
+  tptAgreements: [
+    {
+      ACEL_ID: '23169',
+      AFSA_CODE: 'S127',
+      EFF_ST_DATE: '03/06/2005',
+      EFF_END_DATE: 'null',
+      SIGNED_DATE: '06/07/2005',
+      FILE_REF: 'null',
+      TEXT: 'null',
+      FGAC_REGION_CODE: '3',
+      SOURCE_CODE: 'null',
+      'BATCH_RUN_DATE\r': 'null',
+      charge_version_end_date: '31/03/2006',
+      charge_version_start_date: '03/06/2005',
+      version_number: '1'
+    },
+    {
+      ACEL_ID: '32840',
+      AFSA_CODE: 'S127',
+      EFF_ST_DATE: '03/06/2005',
+      EFF_END_DATE: 'null',
+      SIGNED_DATE: '06/07/2005',
+      FILE_REF: 'null',
+      TEXT: 'null',
+      FGAC_REGION_CODE: '3',
+      SOURCE_CODE: 'null',
+      'BATCH_RUN_DATE\r': 'null',
+      charge_version_end_date: 'null',
+      charge_version_start_date: '01/04/2006',
+      version_number: '2'
+    }
+  ]
+}

--- a/test/import/licence/fixtures/licences/licence.js
+++ b/test/import/licence/fixtures/licences/licence.js
@@ -1,0 +1,8 @@
+'use strict'
+
+module.exports = {
+  licence: {
+    ID: '99993151',
+    FGAC_REGION_CODE: '3'
+  }
+}

--- a/test/import/licence/import-licence.mapper.test.js
+++ b/test/import/licence/import-licence.mapper.test.js
@@ -1,0 +1,42 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Helpers
+const fixtureLicence = require('./fixtures/licences/licence.js')
+const fixtureAgreements = require('./fixtures/licences/agreements.js')
+
+// Thing under test
+const ImportLicenceMapper = require('../../../app/import/licence/import-licence.mapper.js')
+
+describe.only('Import Licence Mapper', () => {
+  let licence
+
+  beforeEach(() => {
+    licence = {
+      licence: fixtureLicence,
+      ...fixtureAgreements
+    }
+  })
+
+  describe('when provided with a import licence', () => {
+    it('correctly maps the data to the licence', () => {
+      const result = ImportLicenceMapper.go(licence)
+
+      expect(result).to.equal({
+        agreements: [
+          {
+            agreementCode: 'S127',
+            endDate: null,
+            startDate: '2005-06-03'
+          }
+        ]
+      })
+    })
+  })
+})

--- a/test/import/licence/mappers/agreements.mapper.test.js
+++ b/test/import/licence/mappers/agreements.mapper.test.js
@@ -1,0 +1,36 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Helpers
+const fixtureAgreements = require('../fixtures/licences/agreements.js')
+
+// Thing under test
+const LicenceAgreementsMapper = require('../../../../app/import/licence/mappers/agreements.mapper.js')
+
+describe.only('Import Licence Agreements Mapper', () => {
+  let agreements
+
+  beforeEach(() => {
+    agreements = fixtureAgreements
+  })
+
+  describe('when provided with a import licence', () => {
+    it('correctly maps the data to the licence', () => {
+      const result = LicenceAgreementsMapper.go(agreements.tptAgreements, agreements.s130Agreements)
+
+      expect(result).to.equal([
+        {
+          agreementCode: 'S127',
+          endDate: null,
+          startDate: '2005-06-03'
+        }
+      ])
+    })
+  })
+})


### PR DESCRIPTION
https://eaflood.atlassian.net/jira/software/c/projects/WATER/boards/96?quickFilter=347&selectedIssue=WATER-4536

We need to explore and establish how we could migrate the import licence process from the import service.

Questions have been raised around packages used by the import service and wether or not we will keep them or rewrite that functionality. For example, we will replace moment.js with node date time.

A mural board has been made to capture the process, dependencies and order in which we would need to do this work.