### PR TITLE
Update tear down service

### DIFF
--- a/app/services/data/tear-down/public-schema.service.js
+++ b/app/services/data/tear-down/public-schema.service.js
@@ -68,22 +68,6 @@ async function _deleteAllTestData () {
 
   DELETE
   FROM
-    "public"."review_charge_elements" AS "rce"
-      USING "public"."review_charge_references" AS "rcr",
-    "public"."review_charge_versions" AS "rcv",
-    "public"."review_licences" AS "rl",
-    "public"."bill_runs" AS "br",
-    "public"."regions" AS "r"
-  WHERE
-    "r"."nald_region_id" = 9
-    AND "rce"."review_charge_reference_id" = "rcr"."id"
-    AND "rcr"."review_charge_version_id" = "rcv"."id"
-    AND "rcv"."review_licence_id" = "rl"."id"
-    AND "rl"."bill_run_id" = "br"."id"
-    AND "br"."region_id" = "r"."id";
-
-  DELETE
-  FROM
     "public"."review_charge_references" AS "rcr"
       USING "public"."review_charge_versions" AS "rcv",
     "public"."review_licences" AS "rl",

--- a/app/services/data/tear-down/public-schema.service.js
+++ b/app/services/data/tear-down/public-schema.service.js
@@ -1,0 +1,132 @@
+'use strict'
+
+/**
+ * Removes all data created for acceptance tests from the public schema
+ * @module PublicSchemaService
+ */
+
+const { db } = require('../../../../db/db.js')
+
+async function go () {
+  return _deleteAllTestData()
+}
+
+async function _deleteAllTestData () {
+  return db.raw(`
+  ALTER TABLE public.review_returns DISABLE TRIGGER ALL;
+  ALTER TABLE public.review_charge_elements_returns DISABLE TRIGGER ALL;
+  ALTER TABLE public.review_charge_elements DISABLE TRIGGER ALL;
+  ALTER TABLE public.review_charge_references DISABLE TRIGGER ALL;
+  ALTER TABLE public.review_charge_versions DISABLE TRIGGER ALL;
+  ALTER TABLE public.review_licences DISABLE TRIGGER ALL;
+
+  DELETE
+  FROM
+    "public"."review_returns" AS "rr"
+      USING "public"."review_licences" AS "rl",
+    "public"."bill_runs" AS "br",
+    "public"."regions" AS "r"
+  WHERE
+    "r"."nald_region_id" = 9
+    AND "rr"."review_licence_id" = "rl"."id"
+    AND "rl"."bill_run_id" = "br"."id"
+    AND "br"."region_id" = "r"."id";
+
+  DELETE
+  FROM
+    "public"."review_charge_elements_returns" AS "rcer"
+      USING "public"."review_charge_elements" AS "rce",
+    "public"."review_charge_references" AS "rcr",
+    "public"."review_charge_versions" AS "rcv",
+    "public"."review_licences" AS "rl",
+    "public"."bill_runs" AS "br",
+    "public"."regions" AS "r"
+  WHERE
+    "r"."nald_region_id" = 9
+    AND "rcer"."review_charge_element_id" = "rce"."id"
+    AND "rce"."review_charge_reference_id" = "rcr"."id"
+    AND "rcr"."review_charge_version_id" = "rcv"."id"
+    AND "rcv"."review_licence_id" = "rl"."id"
+    AND "rl"."bill_run_id" = "br"."id"
+    AND "br"."region_id" = "r"."id";
+
+  DELETE
+  FROM
+    "public"."review_charge_elements" AS "rce"
+      USING "public"."review_charge_references" AS "rcr",
+    "public"."review_charge_versions" AS "rcv",
+    "public"."review_licences" AS "rl",
+    "public"."bill_runs" AS "br",
+    "public"."regions" AS "r"
+  WHERE
+  "r"."nald_region_id" = 9
+    AND "rce"."review_charge_reference_id" = "rcr"."id"
+    AND "rcr"."review_charge_version_id" = "rcv"."id"
+    AND "rcv"."review_licence_id" = "rl"."id"
+    AND "rl"."bill_run_id" = "br"."id"
+    AND "br"."region_id" = "r"."id";
+
+  DELETE
+  FROM
+    "public"."review_charge_elements" AS "rce"
+      USING "public"."review_charge_references" AS "rcr",
+    "public"."review_charge_versions" AS "rcv",
+    "public"."review_licences" AS "rl",
+    "public"."bill_runs" AS "br",
+    "public"."regions" AS "r"
+  WHERE
+    "r"."nald_region_id" = 9
+    AND "rce"."review_charge_reference_id" = "rcr"."id"
+    AND "rcr"."review_charge_version_id" = "rcv"."id"
+    AND "rcv"."review_licence_id" = "rl"."id"
+    AND "rl"."bill_run_id" = "br"."id"
+    AND "br"."region_id" = "r"."id";
+
+  DELETE
+  FROM
+    "public"."review_charge_references" AS "rcr"
+      USING "public"."review_charge_versions" AS "rcv",
+    "public"."review_licences" AS "rl",
+    "public"."bill_runs" AS "br",
+    "public"."regions" AS "r"
+  WHERE
+    "r"."nald_region_id" = 9
+    AND "rcr"."review_charge_version_id" = "rcv"."id"
+    AND "rcv"."review_licence_id" = "rl"."id"
+    AND "rl"."bill_run_id" = "br"."id"
+    AND "br"."region_id" = "r"."id";
+
+  DELETE
+  FROM
+    "public"."review_charge_versions" AS "rcv"
+      USING "public"."review_licences" AS "rl",
+    "public"."bill_runs" AS "br",
+    "public"."regions" AS "r"
+  WHERE
+    "r"."nald_region_id" = 9
+    AND "rcv"."review_licence_id" = "rl"."id"
+    AND "rl"."bill_run_id" = "br"."id"
+    AND "br"."region_id" = "r"."id";
+
+  DELETE
+  FROM
+    "public"."review_licences" AS "rl"
+      USING "public"."bill_runs" AS "br",
+    "public"."regions" AS "r"
+  WHERE
+    "r"."nald_region_id" = 9
+    AND "rl"."bill_run_id" = "br"."id"
+    AND "br"."region_id" = "r"."id";
+
+  ALTER TABLE public.review_returns ENABLE TRIGGER ALL;
+  ALTER TABLE public.review_charge_elements_returns ENABLE TRIGGER ALL;
+  ALTER TABLE public.review_charge_elements ENABLE TRIGGER ALL;
+  ALTER TABLE public.review_charge_references ENABLE TRIGGER ALL;
+  ALTER TABLE public.review_charge_versions ENABLE TRIGGER ALL;
+  ALTER TABLE public.review_licences ENABLE TRIGGER ALL;
+  `)
+}
+
+module.exports = {
+  go
+}

--- a/app/services/data/tear-down/public-schema.service.js
+++ b/app/services/data/tear-down/public-schema.service.js
@@ -13,13 +13,6 @@ async function go () {
 
 async function _deleteAllTestData () {
   return db.raw(`
-  ALTER TABLE public.review_returns DISABLE TRIGGER ALL;
-  ALTER TABLE public.review_charge_elements_returns DISABLE TRIGGER ALL;
-  ALTER TABLE public.review_charge_elements DISABLE TRIGGER ALL;
-  ALTER TABLE public.review_charge_references DISABLE TRIGGER ALL;
-  ALTER TABLE public.review_charge_versions DISABLE TRIGGER ALL;
-  ALTER TABLE public.review_licences DISABLE TRIGGER ALL;
-
   DELETE
   FROM
     "public"."review_returns" AS "rr"
@@ -101,13 +94,6 @@ async function _deleteAllTestData () {
     "r"."nald_region_id" = 9
     AND "rl"."bill_run_id" = "br"."id"
     AND "br"."region_id" = "r"."id";
-
-  ALTER TABLE public.review_returns ENABLE TRIGGER ALL;
-  ALTER TABLE public.review_charge_elements_returns ENABLE TRIGGER ALL;
-  ALTER TABLE public.review_charge_elements ENABLE TRIGGER ALL;
-  ALTER TABLE public.review_charge_references ENABLE TRIGGER ALL;
-  ALTER TABLE public.review_charge_versions ENABLE TRIGGER ALL;
-  ALTER TABLE public.review_licences ENABLE TRIGGER ALL;
   `)
 }
 

--- a/app/services/data/tear-down/tear-down.service.js
+++ b/app/services/data/tear-down/tear-down.service.js
@@ -9,14 +9,17 @@ const CrmSchemaService = require('./crm-schema.service.js')
 const { calculateAndLogTimeTaken, currentTimeInNanoseconds } = require('../../../../app/lib/general.lib.js')
 const IdmSchemaService = require('./idm-schema.service.js')
 const PermitSchemaService = require('./permit-schema.service.js')
+const PublicSchemaService = require('./public-schema.service.js')
 const ReturnsSchemaService = require('./returns-schema.service.js')
 const WaterSchemaService = require('./water-schema.service.js')
-const PublicSchemaService = require('./public-schema.service.js')
 
 async function go () {
   const startTime = currentTimeInNanoseconds()
 
+  // The public schema relies on the test region to identify what data to delete. This is therefore deleted first so we
+  // don't risk the test region being deleted first
   await PublicSchemaService.go()
+
   await Promise.all([
     CrmSchemaService.go(),
     IdmSchemaService.go(),

--- a/app/services/data/tear-down/tear-down.service.js
+++ b/app/services/data/tear-down/tear-down.service.js
@@ -11,10 +11,12 @@ const IdmSchemaService = require('./idm-schema.service.js')
 const PermitSchemaService = require('./permit-schema.service.js')
 const ReturnsSchemaService = require('./returns-schema.service.js')
 const WaterSchemaService = require('./water-schema.service.js')
+const PublicSchemaService = require('./public-schema.service.js')
 
 async function go () {
   const startTime = currentTimeInNanoseconds()
 
+  await PublicSchemaService.go()
   await Promise.all([
     CrmSchemaService.go(),
     IdmSchemaService.go(),

--- a/test/services/data/tear-down/tear-down.service.test.js
+++ b/test/services/data/tear-down/tear-down.service.test.js
@@ -12,6 +12,7 @@ const { expect } = Code
 const CrmSchemaService = require('../../../../app/services/data/tear-down/crm-schema.service.js')
 const IdmSchemaService = require('../../../../app/services/data/tear-down/idm-schema.service.js')
 const PermitSchemaService = require('../../../../app/services/data/tear-down/permit-schema.service.js')
+const PublicSchemaService = require('../../../../app/services/data/tear-down/public-schema.service.js')
 const ReturnsSchemaService = require('../../../../app/services/data/tear-down/returns-schema.service.js')
 const WaterSchemaService = require('../../../../app/services/data/tear-down/water-schema.service.js')
 
@@ -23,6 +24,7 @@ describe('Tear down service', () => {
   let idmSchemaServiceStub
   let notifierStub
   let permitSchemaServiceStub
+  let publicSchemaServiceStub
   let returnsSchemaServiceStub
   let waterSchemaServiceStub
 
@@ -36,6 +38,7 @@ describe('Tear down service', () => {
     crmSchemaServiceStub = Sinon.stub(CrmSchemaService, 'go').resolves()
     idmSchemaServiceStub = Sinon.stub(IdmSchemaService, 'go').resolves()
     permitSchemaServiceStub = Sinon.stub(PermitSchemaService, 'go').resolves()
+    publicSchemaServiceStub = Sinon.stub(PublicSchemaService, 'go').resolves()
     returnsSchemaServiceStub = Sinon.stub(ReturnsSchemaService, 'go').resolves()
     waterSchemaServiceStub = Sinon.stub(WaterSchemaService, 'go').resolves()
   })
@@ -55,6 +58,7 @@ describe('Tear down service', () => {
     expect(crmSchemaServiceStub.called).to.be.true()
     expect(idmSchemaServiceStub.called).to.be.true()
     expect(permitSchemaServiceStub.called).to.be.true()
+    expect(publicSchemaServiceStub.called).to.be.true()
     expect(returnsSchemaServiceStub.called).to.be.true()
     expect(waterSchemaServiceStub.called).to.be.true()
   })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4450

Following on from writing the acceptance test for the two-part tariff review processed, we realised our tear-down service doesn't include the new tables created for the two-part tariff review. This PR is updating the tear-down service to add in those tables. This means all the data created from running the acceptance tests gets deleted.