### PR TITLE
Fix dates in view licence set up tab

### DIFF
--- a/app/presenters/licences/set-up.presenter.js
+++ b/app/presenters/licences/set-up.presenter.js
@@ -179,7 +179,7 @@ function _returnVersions (returnVersions = [{}]) {
         text: 'View',
         link: `/system/return-requirements/${returnVersion.id}/view`
       }],
-      endDate: returnVersion.endDate ? formatLongDate(returnVersion.endDate) : '',
+      endDate: returnVersion.endDate ? formatLongDate(returnVersion.endDate) : '-',
       reason: returnVersion.reason ? returnRequirementReasons[returnVersion.reason] : '',
       startDate: formatLongDate(returnVersion.startDate),
       status: _status(returnVersion.status)

--- a/app/presenters/licences/set-up.presenter.js
+++ b/app/presenters/licences/set-up.presenter.js
@@ -55,9 +55,9 @@ function _agreements (commonData, agreements, auth) {
   return agreements.map((agreement) => {
     return {
       startDate: formatLongDate(agreement.startDate),
-      endDate: agreement.endDate ? formatLongDate(agreement.endDate) : '-',
+      endDate: agreement.endDate ? formatLongDate(agreement.endDate) : '',
       description: agreementDescriptions[_financialAgreementCode(agreement)],
-      signedOn: agreement.signedOn ? formatLongDate(agreement.signedOn) : '-',
+      signedOn: agreement.signedOn ? formatLongDate(agreement.signedOn) : '',
       action: _agreementActionLinks(commonData, agreement, auth)
     }
   })
@@ -135,7 +135,7 @@ function _chargeVersions (chargeVersions) {
     return {
       id: chargeVersion.id,
       startDate: formatLongDate(chargeVersion.startDate),
-      endDate: chargeVersion.endDate ? formatLongDate(chargeVersion.endDate) : '-',
+      endDate: chargeVersion.endDate ? formatLongDate(chargeVersion.endDate) : '',
       status: _status(chargeVersion.status),
       reason: chargeVersion.changeReason?.description,
       action: [
@@ -179,7 +179,7 @@ function _returnVersions (returnVersions = [{}]) {
         text: 'View',
         link: `/system/return-requirements/${returnVersion.id}/view`
       }],
-      endDate: returnVersion.endDate ? formatLongDate(returnVersion.endDate) : '-',
+      endDate: returnVersion.endDate ? formatLongDate(returnVersion.endDate) : '',
       reason: returnVersion.reason ? returnRequirementReasons[returnVersion.reason] : '',
       startDate: formatLongDate(returnVersion.startDate),
       status: _status(returnVersion.status)
@@ -218,7 +218,7 @@ function _workflows (workflows, auth) {
   return workflows.map((workflow) => {
     return {
       action: _workflowAction(workflow, auth),
-      endDate: '-',
+      endDate: '',
       id: workflow.id,
       reason: workflow.data.chargeVersion?.changeReason?.description,
       startDate: _workflowStartDate(workflow),
@@ -269,7 +269,7 @@ function _workflowStartDate (workflow) {
     return formatLongDate(startDate)
   }
 
-  return '-'
+  return ''
 }
 
 module.exports = {

--- a/app/presenters/licences/set-up.presenter.js
+++ b/app/presenters/licences/set-up.presenter.js
@@ -221,7 +221,7 @@ function _workflows (workflows, auth) {
       endDate: '-',
       id: workflow.id,
       reason: workflow.data.chargeVersion?.changeReason?.description,
-      startDate: workflow.createdAt ? formatLongDate(workflow.createdAt) : '-',
+      startDate: _workflowStartDate(workflow),
       status: _status(workflow.status)
     }
   })
@@ -259,6 +259,17 @@ function _workflowActionReviewer (workflow) {
       link: `/licences/${workflow.licenceId}/charge-information/${workflow.id}/review`
     }
   ]
+}
+
+function _workflowStartDate (workflow) {
+  if (workflow.status === 'review') {
+    // Stored as JSON the date is returned as a string. So, we need to convert it to a date type first
+    const startDate = new Date(workflow.data.chargeVersion.dateRange.startDate)
+
+    return formatLongDate(startDate)
+  }
+
+  return '-'
 }
 
 module.exports = {

--- a/app/presenters/licences/set-up.presenter.js
+++ b/app/presenters/licences/set-up.presenter.js
@@ -55,9 +55,9 @@ function _agreements (commonData, agreements, auth) {
   return agreements.map((agreement) => {
     return {
       startDate: formatLongDate(agreement.startDate),
-      endDate: agreement.endDate ? formatLongDate(agreement.endDate) : '',
+      endDate: agreement.endDate ? formatLongDate(agreement.endDate) : '-',
       description: agreementDescriptions[_financialAgreementCode(agreement)],
-      signedOn: agreement.signedOn ? formatLongDate(agreement.signedOn) : '',
+      signedOn: agreement.signedOn ? formatLongDate(agreement.signedOn) : '-',
       action: _agreementActionLinks(commonData, agreement, auth)
     }
   })

--- a/app/services/licences/view-licence-set-up.service.js
+++ b/app/services/licences/view-licence-set-up.service.js
@@ -25,7 +25,9 @@ async function go (licenceId, auth) {
 
   const agreements = await FetchAgreementsService.go(commonData.licenceRef)
   const chargeVersions = await FetchChargeVersionsService.go(licenceId)
+  console.log('🚀 ~ go ~ chargeVersions:', chargeVersions)
   const workflows = await FetchWorkflowsService.go(licenceId)
+  console.log('🚀 ~ go ~ workflows:', workflows)
   const returnVersions = await FetchReturnVersionsService.go(licenceId)
 
   const licenceSetUpData = SetUpPresenter

--- a/app/services/licences/view-licence-set-up.service.js
+++ b/app/services/licences/view-licence-set-up.service.js
@@ -25,9 +25,7 @@ async function go (licenceId, auth) {
 
   const agreements = await FetchAgreementsService.go(commonData.licenceRef)
   const chargeVersions = await FetchChargeVersionsService.go(licenceId)
-  console.log('🚀 ~ go ~ chargeVersions:', chargeVersions)
   const workflows = await FetchWorkflowsService.go(licenceId)
-  console.log('🚀 ~ go ~ workflows:', workflows)
   const returnVersions = await FetchReturnVersionsService.go(licenceId)
 
   const licenceSetUpData = SetUpPresenter

--- a/test/presenters/licences/set-up.presenter.test.js
+++ b/test/presenters/licences/set-up.presenter.test.js
@@ -26,7 +26,7 @@ describe('Licences - Set Up presenter', () => {
   const chargeVersion = {
     id: '0d514aa4-1550-46b1-8195-878957f2a5f8',
     startDate: new Date('2020-01-01'),
-    endDate: new Date('2020-09-01'),
+    endDate: null,
     status: 'current',
     changeReason: { description: 'Major change' },
     licenceId: 'f91bf145-ce8e-481c-a842-4da90348062b'
@@ -34,8 +34,8 @@ describe('Licences - Set Up presenter', () => {
 
   const returnVersion = {
     id: '0312e5eb-67ae-44fb-922c-b1a0b81bc08d',
-    startDate: new Date('2025-01-01'),
-    endDate: new Date('2025-02-01'),
+    startDate: new Date('2020-01-01'),
+    endDate: null,
     status: 'current',
     reason: 'change-to-special-agreement'
   }
@@ -44,7 +44,12 @@ describe('Licences - Set Up presenter', () => {
     id: 'f547f465-0a62-45ff-9909-38825f05e0c4',
     createdAt: new Date('2020-01-01'),
     status: 'review',
-    data: { chargeVersion: { changeReason: { description: 'changed something' } } },
+    data: {
+      chargeVersion: {
+        changeReason: { description: 'changed something' },
+        dateRange: { startDate: '2022-04-01' }
+      }
+    },
     licenceId: 'f91bf145-ce8e-481c-a842-4da90348062b'
   }
 
@@ -118,9 +123,9 @@ describe('Licences - Set Up presenter', () => {
                 text: 'Recalculate bills'
               }
             ],
-            signedOn: '',
+            signedOn: '-',
             description: 'Two-part tariff',
-            endDate: '',
+            endDate: '-',
             startDate: '1 January 2020'
           }
         ])
@@ -294,6 +299,7 @@ describe('Licences - Set Up presenter', () => {
       describe('when the licence is more than 6 years old and all the actions are available for an agreement', () => {
         beforeEach(() => {
           const sixYearsAndOneDayAgo = new Date()
+
           sixYearsAndOneDayAgo.setDate(sixYearsAndOneDayAgo.getDate() - 1)
           sixYearsAndOneDayAgo.setFullYear(sixYearsAndOneDayAgo.getFullYear() - 6)
 
@@ -317,14 +323,14 @@ describe('Licences - Set Up presenter', () => {
         workflows = [{ ...workflow }]
       })
 
-      it('groups both types of data into the \'chargeInformation\' property', () => {
+      it('groups both types of data into the "chargeInformation" property', () => {
         const result = SetUpPresenter.go(chargeVersions, workflows, agreements, returnVersions, auth, commonData)
 
         expect(result.chargeInformation).to.equal([
           {
             action: [],
             id: 'f547f465-0a62-45ff-9909-38825f05e0c4',
-            startDate: '1 January 2020',
+            startDate: '1 April 2022',
             endDate: '-',
             status: 'review',
             reason: 'changed something'
@@ -336,7 +342,7 @@ describe('Licences - Set Up presenter', () => {
             }],
             id: '0d514aa4-1550-46b1-8195-878957f2a5f8',
             startDate: '1 January 2020',
-            endDate: '1 September 2020',
+            endDate: '-',
             status: 'approved',
             reason: 'Major change'
           }
@@ -376,6 +382,7 @@ describe('Licences - Set Up presenter', () => {
       describe('where the end date is populated', () => {
         beforeEach(() => {
           chargeVersions = [{ ...chargeVersion }]
+          chargeVersions[0].endDate = new Date('2024-03-31')
         })
 
         it('correctly presents the data with the end date', () => {
@@ -388,7 +395,7 @@ describe('Licences - Set Up presenter', () => {
             }],
             id: '0d514aa4-1550-46b1-8195-878957f2a5f8',
             startDate: '1 January 2020',
-            endDate: '1 September 2020',
+            endDate: '31 March 2024',
             status: 'approved',
             reason: 'Major change'
           }])
@@ -401,7 +408,7 @@ describe('Licences - Set Up presenter', () => {
         chargeVersions = []
       })
 
-      describe('that have a status of \'review\'', () => {
+      describe('that have a status of "review"', () => {
         beforeEach(() => {
           workflows = [{ ...workflow }]
         })
@@ -420,7 +427,7 @@ describe('Licences - Set Up presenter', () => {
                 text: 'Review'
               }],
               id: 'f547f465-0a62-45ff-9909-38825f05e0c4',
-              startDate: '1 January 2020',
+              startDate: '1 April 2024',
               endDate: '-',
               status: 'review',
               reason: 'changed something'
@@ -435,7 +442,7 @@ describe('Licences - Set Up presenter', () => {
             expect(result.chargeInformation).to.equal([{
               action: [],
               id: 'f547f465-0a62-45ff-9909-38825f05e0c4',
-              startDate: '1 January 2020',
+              startDate: '1 April 2024',
               endDate: '-',
               status: 'review',
               reason: 'changed something'
@@ -444,7 +451,7 @@ describe('Licences - Set Up presenter', () => {
         })
       })
 
-      describe('that have a status of \'to_setup\'', () => {
+      describe('that have a status of "to_setup"', () => {
         beforeEach(() => {
           workflows = [{ ...workflow }]
           workflows[0].status = 'to_setup'
@@ -464,7 +471,7 @@ describe('Licences - Set Up presenter', () => {
                 text: 'Review'
               }],
               id: 'f547f465-0a62-45ff-9909-38825f05e0c4',
-              startDate: '1 January 2020',
+              startDate: '-',
               endDate: '-',
               status: 'to set up',
               reason: 'changed something'
@@ -483,7 +490,7 @@ describe('Licences - Set Up presenter', () => {
             expect(result.chargeInformation).to.equal([{
               action: [],
               id: 'f547f465-0a62-45ff-9909-38825f05e0c4',
-              startDate: '1 January 2020',
+              startDate: '-',
               endDate: '-',
               status: 'to set up',
               reason: 'changed something'
@@ -509,9 +516,9 @@ describe('Licences - Set Up presenter', () => {
                 text: 'View'
               }
             ],
-            endDate: '1 February 2025',
+            endDate: '-',
             reason: 'Change to special agreement',
-            startDate: '1 January 2025',
+            startDate: '1 January 2020',
             status: 'approved'
           }
         ])
@@ -533,9 +540,9 @@ describe('Licences - Set Up presenter', () => {
                   text: 'View'
                 }
               ],
-              endDate: '',
+              endDate: '-',
               reason: '',
-              startDate: '1 January 2025',
+              startDate: '1 January 2020',
               status: 'approved'
             }
           ])
@@ -586,6 +593,7 @@ describe('Licences - Set Up presenter', () => {
           describe('and the licence ends more than 6 years ago', () => {
             beforeEach(() => {
               const sixYearsAndOneDayAgo = new Date()
+
               sixYearsAndOneDayAgo.setDate(sixYearsAndOneDayAgo.getDate() - 1)
               sixYearsAndOneDayAgo.setFullYear(sixYearsAndOneDayAgo.getFullYear() - 6)
 
@@ -617,9 +625,10 @@ describe('Licences - Set Up presenter', () => {
                 .equal('/licences/f91bf145-ce8e-481c-a842-4da90348062b/charge-information/create')
             })
           })
-          describe('and the licence \'ends\' more than 6 years ago', () => {
+          describe('and the licence "ends" more than 6 years ago', () => {
             beforeEach(() => {
               const sixYearsAndOneDayAgo = new Date()
+
               sixYearsAndOneDayAgo.setDate(sixYearsAndOneDayAgo.getDate() - 1)
               sixYearsAndOneDayAgo.setFullYear(sixYearsAndOneDayAgo.getFullYear() - 6)
 

--- a/test/presenters/licences/set-up.presenter.test.js
+++ b/test/presenters/licences/set-up.presenter.test.js
@@ -14,7 +14,7 @@ const FeatureFlagsConfig = require('../../../config/feature-flags.config.js')
 // Thing under test
 const SetUpPresenter = require('../../../app/presenters/licences/set-up.presenter.js')
 
-describe.only('Licences - Set Up presenter', () => {
+describe('Licences - Set Up presenter', () => {
   const agreement = {
     id: '123',
     startDate: new Date('2020-01-01'),

--- a/test/presenters/licences/set-up.presenter.test.js
+++ b/test/presenters/licences/set-up.presenter.test.js
@@ -427,7 +427,7 @@ describe('Licences - Set Up presenter', () => {
                 text: 'Review'
               }],
               id: 'f547f465-0a62-45ff-9909-38825f05e0c4',
-              startDate: '1 April 2024',
+              startDate: '1 April 2022',
               endDate: '-',
               status: 'review',
               reason: 'changed something'
@@ -442,7 +442,7 @@ describe('Licences - Set Up presenter', () => {
             expect(result.chargeInformation).to.equal([{
               action: [],
               id: 'f547f465-0a62-45ff-9909-38825f05e0c4',
-              startDate: '1 April 2024',
+              startDate: '1 April 2022',
               endDate: '-',
               status: 'review',
               reason: 'changed something'

--- a/test/presenters/licences/set-up.presenter.test.js
+++ b/test/presenters/licences/set-up.presenter.test.js
@@ -14,7 +14,7 @@ const FeatureFlagsConfig = require('../../../config/feature-flags.config.js')
 // Thing under test
 const SetUpPresenter = require('../../../app/presenters/licences/set-up.presenter.js')
 
-describe('Licences - Set Up presenter', () => {
+describe.only('Licences - Set Up presenter', () => {
   const agreement = {
     id: '123',
     startDate: new Date('2020-01-01'),
@@ -123,9 +123,9 @@ describe('Licences - Set Up presenter', () => {
                 text: 'Recalculate bills'
               }
             ],
-            signedOn: '-',
+            signedOn: '',
             description: 'Two-part tariff',
-            endDate: '-',
+            endDate: '',
             startDate: '1 January 2020'
           }
         ])
@@ -331,7 +331,7 @@ describe('Licences - Set Up presenter', () => {
             action: [],
             id: 'f547f465-0a62-45ff-9909-38825f05e0c4',
             startDate: '1 April 2022',
-            endDate: '-',
+            endDate: '',
             status: 'review',
             reason: 'changed something'
           },
@@ -342,7 +342,7 @@ describe('Licences - Set Up presenter', () => {
             }],
             id: '0d514aa4-1550-46b1-8195-878957f2a5f8',
             startDate: '1 January 2020',
-            endDate: '-',
+            endDate: '',
             status: 'approved',
             reason: 'Major change'
           }
@@ -372,7 +372,7 @@ describe('Licences - Set Up presenter', () => {
             }],
             id: '0d514aa4-1550-46b1-8195-878957f2a5f8',
             startDate: '1 January 2020',
-            endDate: '-',
+            endDate: '',
             status: 'approved',
             reason: 'Major change'
           }])
@@ -428,7 +428,7 @@ describe('Licences - Set Up presenter', () => {
               }],
               id: 'f547f465-0a62-45ff-9909-38825f05e0c4',
               startDate: '1 April 2022',
-              endDate: '-',
+              endDate: '',
               status: 'review',
               reason: 'changed something'
             }])
@@ -443,7 +443,7 @@ describe('Licences - Set Up presenter', () => {
               action: [],
               id: 'f547f465-0a62-45ff-9909-38825f05e0c4',
               startDate: '1 April 2022',
-              endDate: '-',
+              endDate: '',
               status: 'review',
               reason: 'changed something'
             }])
@@ -471,8 +471,8 @@ describe('Licences - Set Up presenter', () => {
                 text: 'Review'
               }],
               id: 'f547f465-0a62-45ff-9909-38825f05e0c4',
-              startDate: '-',
-              endDate: '-',
+              startDate: '',
+              endDate: '',
               status: 'to set up',
               reason: 'changed something'
             }])
@@ -490,8 +490,8 @@ describe('Licences - Set Up presenter', () => {
             expect(result.chargeInformation).to.equal([{
               action: [],
               id: 'f547f465-0a62-45ff-9909-38825f05e0c4',
-              startDate: '-',
-              endDate: '-',
+              startDate: '',
+              endDate: '',
               status: 'to set up',
               reason: 'changed something'
             }])
@@ -516,7 +516,7 @@ describe('Licences - Set Up presenter', () => {
                 text: 'View'
               }
             ],
-            endDate: '-',
+            endDate: '',
             reason: 'Change to special agreement',
             startDate: '1 January 2020',
             status: 'approved'
@@ -540,7 +540,7 @@ describe('Licences - Set Up presenter', () => {
                   text: 'View'
                 }
               ],
-              endDate: '-',
+              endDate: '',
               reason: '',
               startDate: '1 January 2020',
               status: 'approved'

--- a/test/services/licences/view-licence-set-up.service.test.js
+++ b/test/services/licences/view-licence-set-up.service.test.js
@@ -63,7 +63,12 @@ describe('View Licence Set Up service', () => {
         id: 'f3fe1275-50ff-4f69-98cb-5a35c17654f3',
         createdAt: new Date('2020-01-01'),
         status: 'review',
-        data: { chargeVersion: { changeReason: { description: 'changed something' } } },
+        data: {
+          chargeVersion: {
+            changeReason: { description: 'changed something' },
+            dateRange: { startDate: '2022-04-01' }
+          }
+        },
         licenceId: '456'
       }
     ])
@@ -107,10 +112,10 @@ describe('View Licence Set Up service', () => {
         chargeInformation: [
           {
             action: [],
-            endDate: '-',
+            endDate: '',
             id: 'f3fe1275-50ff-4f69-98cb-5a35c17654f3',
             reason: 'changed something',
-            startDate: '1 January 2020',
+            startDate: '1 April 2022',
             status: 'review'
           },
           {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4556

> Part of the work to replace the legacy view licence page

In testing of the new view licence page, specifically the licence set up tab, it was spotted that when a charge version has a status of `REVIEW` that the date the record was created rather than the start date is displayed in the charge information table.

This is because the record is not a charge version; it is a workflow record, which when approved will become a charge version record. The current presenter logic is not distinguishing between the different types of workflow records, hence the wrong date being displayed.

But hold on. A quick review of the legacy version of the tab shows that when a workflow record does not have a status of `REVIEW` we don't show any dates at all!

Then we spotted that there is inconsistency about whether we use a dash in the end date column. The charge information table does, but the return requirements and agreements tables don't.

So, this change is a general fix-up of dates in the tab.

- for workflow records in `REVIEW` show the start date from the stored charge version details
- for all tables where a date is not set, stop displaying `-`
- do not display any dates for workflow records that have a status other than `REVIEW`