### PR TITLE
Only use 1st site description in return reqs set up

### DIFF
--- a/app/services/return-requirements/setup/generate-from-abstraction-data.service.js
+++ b/app/services/return-requirements/setup/generate-from-abstraction-data.service.js
@@ -204,7 +204,7 @@ function _points (matchingPermitPurpose) {
  * > This is from the abs data the local name on the point
  *
  * The problem is a purpose can have multiple points. So, we grab all the local name values for each point in the
- * matched permit purpose, strip out any nulls or undefined and then join them with ' - ' to form the site description.
+ * matched permit purpose, strip out any nulls or undefined and then select the first one to form the site description.
  */
 function _siteDescription (matchingPermitPurpose) {
   const localNames = matchingPermitPurpose.purposePoints.map((purposePoint) => {
@@ -213,8 +213,8 @@ function _siteDescription (matchingPermitPurpose) {
 
   // NOTE: This is doing two things at once. It first filters the local names by passing each one to Boolean(). It will
   // return true or false depending on whether the value is 'truthy'. In our case this means null or undefined will be
-  // stripped from the array. What's left it calls `.join()` on.
-  return localNames.filter(Boolean).join(' - ')
+  // stripped from the array. From whats left we select the first one.
+  return localNames.filter(Boolean)[0]
 }
 
 /**

--- a/test/services/return-requirements/setup/generate-from-abstraction-data.service.test.js
+++ b/test/services/return-requirements/setup/generate-from-abstraction-data.service.test.js
@@ -41,7 +41,7 @@ describe('Return Requirements - Generate From Abstraction Data service', () => {
             points: ['10030400', '10030401'],
             purposes: ['24939b40-a187-4bd1-9222-f552a3af6368'],
             returnsCycle: 'summer',
-            siteDescription: 'INTAKE POINT - OUT TAKE POINT',
+            siteDescription: 'INTAKE POINT',
             abstractionPeriod: {
               'end-abstraction-period-day': 31,
               'end-abstraction-period-month': 10,


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4442

> Part of the work to replace NALD for handling return requirements

In [Use abstraction data to create return requirements](https://github.com/DEFRA/water-abstraction-system/pull/1107) we added the logic to the return requirements set up journey that allows a user to generate return requirements from a licence's existing abstraction data.

One of the scenarios we had to tackle was how to populate the site description for a return requirement that has multiple points. At the time, we went with concatenating them all using ' - '.

After some additional testing, it has been decided that it is clearer if we just use the first available site description. Whatever we opt for we can see users will change it anyway. Just picking one at least improves how the return requirement is displayed on the page.