### PR TITLE
Update ret. req. setup use abstraction & copy

### DIFF
--- a/app/models/licence-version-purpose.model.js
+++ b/app/models/licence-version-purpose.model.js
@@ -82,6 +82,7 @@ class LicenceVersionPurposeModel extends BaseModel {
           .modifyGraph('purpose', (builder) => {
             builder.select([
               'id',
+              'description',
               'legacyId',
               'twoPartTariff'
             ])

--- a/app/services/return-requirements/generate-from-existing-requirements.service.js
+++ b/app/services/return-requirements/generate-from-existing-requirements.service.js
@@ -95,6 +95,13 @@ async function _fetch (returnVersionId) {
         'purposeId'
       ])
     })
+    .withGraphFetched('returnRequirements.returnRequirementPurposes.purpose')
+    .modifyGraph('returnRequirements.returnRequirementPurposes.purpose', (builder) => {
+      builder.select([
+        'id',
+        'description'
+      ])
+    })
 }
 
 function _points (returnRequirementPoints) {
@@ -105,7 +112,13 @@ function _points (returnRequirementPoints) {
 
 function _purposes (returnRequirementPurposes) {
   return returnRequirementPurposes.map((returnRequirementPurpose) => {
-    return returnRequirementPurpose.purposeId
+    const { description, id } = returnRequirementPurpose.purpose
+
+    return {
+      alias: '',
+      description,
+      id
+    }
   })
 }
 

--- a/app/services/return-requirements/generate-from-existing-requirements.service.js
+++ b/app/services/return-requirements/generate-from-existing-requirements.service.js
@@ -91,6 +91,7 @@ async function _fetch (returnVersionId) {
     .withGraphFetched('returnRequirements.returnRequirementPurposes')
     .modifyGraph('returnRequirements.returnRequirementPurposes', (builder) => {
       builder.select([
+        'alias',
         'id',
         'purposeId'
       ])
@@ -115,7 +116,7 @@ function _purposes (returnRequirementPurposes) {
     const { description, id } = returnRequirementPurpose.purpose
 
     return {
-      alias: '',
+      alias: returnRequirementPurpose.alias || '',
       description,
       id
     }

--- a/app/services/return-requirements/setup/generate-from-abstraction-data.service.js
+++ b/app/services/return-requirements/setup/generate-from-abstraction-data.service.js
@@ -240,7 +240,7 @@ function _transformForSetup (licence) {
 
     return {
       points: _points(matchingPermitPurpose),
-      purposes: [purpose.id],
+      purposes: [{ alias: '', description: purpose.description, id: purpose.id }],
       returnsCycle: _returnsCycle(startMonth, endMonth),
       siteDescription: _siteDescription(matchingPermitPurpose),
       abstractionPeriod: {

--- a/test/services/return-requirements/cancel.service.test.js
+++ b/test/services/return-requirements/cancel.service.test.js
@@ -34,12 +34,8 @@ describe('Return Requirements - Cancel service', () => {
         },
         journey: 'returns-required',
         requirements: [{
-          points: [
-            'At National Grid Reference TQ 6520 5937 (POINT A, ADDINGTON SANDPITS)'
-          ],
-          purposes: [
-            'Mineral Washing'
-          ],
+          points: ['At National Grid Reference TQ 6520 5937 (POINT A, ADDINGTON SANDPITS)'],
+          purposes: [{ alias: '', description: 'Mineral Washing', id: '3a865331-d2f3-4acc-ac85-527fa2b0d2dd' }],
           returnsCycle: 'winter-and-all-year',
           siteDescription: 'Bore hole in rear field',
           abstractionPeriod: {

--- a/test/services/return-requirements/check-licence-ended.service.test.js
+++ b/test/services/return-requirements/check-licence-ended.service.test.js
@@ -28,6 +28,7 @@ describe('Return Requirements - CheckLicenceEndedService', () => {
 
     it('fetches licence data correctly', async () => {
       const result = await CheckLicenceEndedService.go(licence.id)
+
       expect(result).to.be.false()
     })
   })

--- a/test/services/return-requirements/check.service.test.js
+++ b/test/services/return-requirements/check.service.test.js
@@ -34,7 +34,7 @@ describe('Return Requirements - Check service', () => {
           startDate: '2022-04-01T00:00:00.000Z'
         },
         journey: 'returns-required',
-        requirements: [],
+        requirements: [{}],
         startDateOptions: 'licenceStartDate',
         reason: 'major-change'
       }

--- a/test/services/return-requirements/generate-from-existing-requirements.service.test.js
+++ b/test/services/return-requirements/generate-from-existing-requirements.service.test.js
@@ -29,7 +29,11 @@ describe('Return Requirements - Generate From Existing Requirements service', ()
       expect(result).to.equal([
         {
           points: ['1234'],
-          purposes: [returnVersion.returnRequirements[0].returnRequirementPurposes[0].purposeId],
+          purposes: [{
+            alias: '',
+            description: 'Spray Irrigation - Storage',
+            id: returnVersion.returnRequirements[0].returnRequirementPurposes[0].purposeId
+          }],
           returnsCycle: 'winter-and-all-year',
           siteDescription: 'FIRST BOREHOLE AT AVALON',
           abstractionPeriod: {
@@ -44,7 +48,11 @@ describe('Return Requirements - Generate From Existing Requirements service', ()
         },
         {
           points: ['4321'],
-          purposes: [returnVersion.returnRequirements[1].returnRequirementPurposes[0].purposeId],
+          purposes: [{
+            alias: '',
+            description: 'Spray Irrigation - Storage',
+            id: returnVersion.returnRequirements[1].returnRequirementPurposes[0].purposeId
+          }],
           returnsCycle: 'summer',
           siteDescription: 'SECOND BOREHOLE AT AVALON',
           abstractionPeriod: {

--- a/test/services/return-requirements/generate-from-existing-requirements.service.test.js
+++ b/test/services/return-requirements/generate-from-existing-requirements.service.test.js
@@ -30,7 +30,7 @@ describe('Return Requirements - Generate From Existing Requirements service', ()
         {
           points: ['1234'],
           purposes: [{
-            alias: '',
+            alias: returnVersion.returnRequirements[0].returnRequirementPurposes[0].alias,
             description: 'Spray Irrigation - Storage',
             id: returnVersion.returnRequirements[0].returnRequirementPurposes[0].purposeId
           }],

--- a/test/services/return-requirements/remove.service.test.js
+++ b/test/services/return-requirements/remove.service.test.js
@@ -36,12 +36,8 @@ describe('Return Requirements - Remove service', () => {
         },
         journey: 'returns-required',
         requirements: [{
-          points: [
-            'At National Grid Reference TQ 6520 5937 (POINT A, ADDINGTON SANDPITS)'
-          ],
-          purposes: [
-            'Mineral Washing'
-          ],
+          points: ['At National Grid Reference TQ 6520 5937 (POINT A, ADDINGTON SANDPITS)'],
+          purposes: [{ alias: '', description: 'Mineral Washing', id: '3a865331-d2f3-4acc-ac85-527fa2b0d2dd' }],
           returnsCycle: 'winter-and-all-year',
           siteDescription: 'Bore hole in rear field',
           abstractionPeriod: {

--- a/test/services/return-requirements/setup/fetch-abstraction-data.service.test.js
+++ b/test/services/return-requirements/setup/fetch-abstraction-data.service.test.js
@@ -15,7 +15,7 @@ const LicenceAgreementModel = require('../../../../app/models/licence-agreement.
 // Thing under test
 const FetchAbstractionDataService = require('../../../../app/services/return-requirements/setup/fetch-abstraction-data.service.js')
 
-describe('Return Requirements - Return requirements Fetch Points service', () => {
+describe('Return Requirements - Fetch Abstraction Data service', () => {
   let seedIds
 
   beforeEach(async () => {
@@ -60,7 +60,7 @@ describe('Return Requirements - Return requirements Fetch Points service', () =>
                 dailyQuantity: 455,
                 externalId: '1:10065380',
                 primaryPurpose: { id: seedIds.allPurposes.primaryPurposes.primaryElectricityId, legacyId: 'P' },
-                purpose: { id: seedIds.allPurposes.purposes.heatPumpId, legacyId: '200', twoPartTariff: false },
+                purpose: { description: 'Heat Pump', id: seedIds.allPurposes.purposes.heatPumpId, legacyId: '200', twoPartTariff: false },
                 secondaryPurpose: { id: seedIds.allPurposes.secondaryPurposes.secondaryElectricityId, legacyId: 'ELC' }
               },
               {
@@ -72,7 +72,7 @@ describe('Return Requirements - Return requirements Fetch Points service', () =>
                 dailyQuantity: 2675,
                 externalId: '1:10065381',
                 primaryPurpose: { id: seedIds.allPurposes.primaryPurposes.primaryAgricultureId, legacyId: 'A' },
-                purpose: { id: seedIds.allPurposes.purposes.vegetableWashingId, legacyId: '460', twoPartTariff: false },
+                purpose: { description: 'Vegetable washing', id: seedIds.allPurposes.purposes.vegetableWashingId, legacyId: '460', twoPartTariff: false },
                 secondaryPurpose: { id: seedIds.allPurposes.secondaryPurposes.secondaryAgricultureId, legacyId: 'AGR' }
               },
               {
@@ -84,7 +84,7 @@ describe('Return Requirements - Return requirements Fetch Points service', () =>
                 dailyQuantity: 300,
                 externalId: '1:10065382',
                 primaryPurpose: { id: seedIds.allPurposes.primaryPurposes.primaryAgricultureId, legacyId: 'A' },
-                purpose: { id: seedIds.allPurposes.purposes.sprayIrrigationDirectId, legacyId: '400', twoPartTariff: true },
+                purpose: { description: 'Spray Irrigation - Direct', id: seedIds.allPurposes.purposes.sprayIrrigationDirectId, legacyId: '400', twoPartTariff: true },
                 secondaryPurpose: { id: seedIds.allPurposes.secondaryPurposes.secondaryAgricultureId, legacyId: 'AGR' }
               }
             ]

--- a/test/services/return-requirements/setup/generate-from-abstraction-data.service.test.js
+++ b/test/services/return-requirements/setup/generate-from-abstraction-data.service.test.js
@@ -39,7 +39,9 @@ describe('Return Requirements - Generate From Abstraction Data service', () => {
         expect(result).to.equal([
           {
             points: ['10030400', '10030401'],
-            purposes: ['24939b40-a187-4bd1-9222-f552a3af6368'],
+            purposes: [{
+              alias: '', description: 'Heat Pump', id: '24939b40-a187-4bd1-9222-f552a3af6368'
+            }],
             returnsCycle: 'summer',
             siteDescription: 'INTAKE POINT',
             abstractionPeriod: {
@@ -54,7 +56,11 @@ describe('Return Requirements - Generate From Abstraction Data service', () => {
           },
           {
             points: ['10030500'],
-            purposes: ['e5b3b9bc-59c5-46d3-b019-5cf5467d4f0f'],
+            purposes: [{
+              alias: '',
+              description: 'Vegetable Washing',
+              id: 'e5b3b9bc-59c5-46d3-b019-5cf5467d4f0f'
+            }],
             returnsCycle: 'winter-and-all-year',
             siteDescription: 'SOUTH BOREHOLE',
             abstractionPeriod: {
@@ -69,7 +75,11 @@ describe('Return Requirements - Generate From Abstraction Data service', () => {
           },
           {
             points: ['10030600'],
-            purposes: ['76c8c08c-4fef-421a-83d6-16d8000311a4'],
+            purposes: [{
+              alias: '',
+              description: 'Spray Irrigation - Direct',
+              id: '76c8c08c-4fef-421a-83d6-16d8000311a4'
+            }],
             returnsCycle: 'winter-and-all-year',
             siteDescription: 'MAIN INTAKE',
             abstractionPeriod: {
@@ -179,7 +189,12 @@ function _fetchResult (licenceId) {
             dailyQuantity: 455,
             externalId: '1:10065380',
             primaryPurpose: { id: 'd7c327ce-246d-4370-a6fe-1f2c6ba7a22a', legacyId: 'P' },
-            purpose: { id: '24939b40-a187-4bd1-9222-f552a3af6368', legacyId: '200', twoPartTariff: false },
+            purpose: {
+              id: '24939b40-a187-4bd1-9222-f552a3af6368',
+              description: 'Heat Pump',
+              legacyId: '200',
+              twoPartTariff: false
+            },
             secondaryPurpose: { id: '235ed780-f535-4b8d-b367-b5438ac130e9', legacyId: 'ELC' }
           }),
           LicenceVersionPurposeModel.fromJson({
@@ -191,7 +206,12 @@ function _fetchResult (licenceId) {
             dailyQuantity: 2675,
             externalId: '1:10065381',
             primaryPurpose: { id: 'd780c2a1-aad4-485c-90d8-47496ba2277e', legacyId: 'A' },
-            purpose: { id: 'e5b3b9bc-59c5-46d3-b019-5cf5467d4f0f', legacyId: '460', twoPartTariff: false },
+            purpose: {
+              id: 'e5b3b9bc-59c5-46d3-b019-5cf5467d4f0f',
+              description: 'Vegetable Washing',
+              legacyId: '460',
+              twoPartTariff: false
+            },
             secondaryPurpose: { id: '827f5181-1acc-452a-aea3-a1d72a21604b', legacyId: 'AGR' }
           }),
           LicenceVersionPurposeModel.fromJson({
@@ -203,7 +223,12 @@ function _fetchResult (licenceId) {
             dailyQuantity: 300,
             externalId: '1:10065382',
             primaryPurpose: { id: 'd780c2a1-aad4-485c-90d8-47496ba2277e', legacyId: 'A' },
-            purpose: { id: '76c8c08c-4fef-421a-83d6-16d8000311a4', legacyId: '400', twoPartTariff: true },
+            purpose: {
+              id: '76c8c08c-4fef-421a-83d6-16d8000311a4',
+              description: 'Spray Irrigation - Direct',
+              legacyId: '400',
+              twoPartTariff: true
+            },
             secondaryPurpose: { id: '827f5181-1acc-452a-aea3-a1d72a21604b', legacyId: 'AGR' }
           })
         ]

--- a/test/services/return-requirements/submit-cancel.service.test.js
+++ b/test/services/return-requirements/submit-cancel.service.test.js
@@ -34,12 +34,8 @@ describe('Return Requirements - Submit Cancel service', () => {
         },
         journey: 'returns-required',
         requirements: [{
-          points: [
-            'At National Grid Reference TQ 6520 5937 (POINT A, ADDINGTON SANDPITS)'
-          ],
-          purposes: [
-            'Mineral Washing'
-          ],
+          points: ['At National Grid Reference TQ 6520 5937 (POINT A, ADDINGTON SANDPITS)'],
+          purposes: [{ alias: '', description: 'Mineral Washing', id: '3a865331-d2f3-4acc-ac85-527fa2b0d2dd' }],
           returnsCycle: 'winter-and-all-year',
           siteDescription: 'Bore hole in rear field',
           abstractionPeriod: {

--- a/test/services/return-requirements/submit-remove.service.test.js
+++ b/test/services/return-requirements/submit-remove.service.test.js
@@ -38,12 +38,8 @@ describe('Return Requirements - Submit Remove service', () => {
         },
         journey: 'returns-required',
         requirements: [{
-          points: [
-            'At National Grid Reference TQ 6520 5937 (POINT A, ADDINGTON SANDPITS)'
-          ],
-          purposes: [
-            'Mineral Washing'
-          ],
+          points: ['At National Grid Reference TQ 6520 5937 (POINT A, ADDINGTON SANDPITS)'],
+          purposes: [{ alias: '', description: 'Mineral Washing', id: '3a865331-d2f3-4acc-ac85-527fa2b0d2dd' }],
           returnsCycle: 'winter-and-all-year',
           siteDescription: 'Bore hole in rear field',
           abstractionPeriod: {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4573

> Part of the return requirements set up work

In [Add optional alias to return requirement purpose](https://github.com/DEFRA/water-abstraction-system/pull/1177) we added the ability to assign a purpose description (alias) to the purposes selected when setting up a new return requirement.

As part of that, we made a change to how we store the purposes in the session. No longer do we just store the ID; we now store an object.

```javascript
{
  purposes: [{
    alias: 'spray all over the place',
    description: 'Spray Irrigation - Direct',
    id: '42d5f68d-0b7a-4d29-b04e-943362746f59'
  }]
}
```

The 'Select a purpose' now expects the purposes inside the session to be in this format and will persist in this manner when you submit your selection. But the 'Start with abstraction data' and 'Copy existing requirement' journeys are still persisting the purposes in the session using the old `{ purposes: ['42d5f68d-0b7a-4d29-b04e-943362746f59'] }` format.

This change updates them and gets all 3 journeys working again.