### PR TITLE
Alter two-part tariff returns allocation by date

### DIFF
--- a/app/services/bill-runs/two-part-tariff/allocate-returns-to-charge-element.service.js
+++ b/app/services/bill-runs/two-part-tariff/allocate-returns-to-charge-element.service.js
@@ -128,9 +128,23 @@ function _matchLines (chargeElement, returnSubmissionLines) {
       return false
     }
 
-    const { startDate, endDate } = returnSubmissionLine
+    const { startDate: lineStartDate, endDate: lineEndDate } = returnSubmissionLine
 
-    return periodsOverlap(chargeElement.abstractionPeriods, [{ startDate, endDate }])
+    // If the endDate of the return submission line is after the end date of the charge elements abstraction period then
+    // we do not want to allocate this. Here we are creating an array of the abstraction periods endDates (since there
+    // can be more than 1), then by doing Math.max we can compare the end of the abstraction period to the end date of
+    // the return submission line
+    const abstractionPeriodsEndDates = chargeElement.abstractionPeriods.map((abstractionPeriod) => {
+      return abstractionPeriod.endDate
+    })
+
+    const abstractionEndDate = new Date(Math.max(...abstractionPeriodsEndDates))
+
+    if (lineEndDate <= abstractionEndDate) {
+      return periodsOverlap(chargeElement.abstractionPeriods, [{ lineStartDate, lineEndDate }])
+    }
+
+    return false
   })
 }
 

--- a/app/services/bill-runs/two-part-tariff/allocate-returns-to-charge-element.service.js
+++ b/app/services/bill-runs/two-part-tariff/allocate-returns-to-charge-element.service.js
@@ -128,7 +128,7 @@ function _matchLines (chargeElement, returnSubmissionLines) {
       return false
     }
 
-    const { startDate: lineStartDate, endDate: lineEndDate } = returnSubmissionLine
+    const { startDate, endDate } = returnSubmissionLine
 
     // If the endDate of the return submission line is after the end date of the charge elements abstraction period then
     // we do not want to allocate this. Here we are creating an array of the abstraction periods endDates (since there
@@ -140,8 +140,8 @@ function _matchLines (chargeElement, returnSubmissionLines) {
 
     const abstractionEndDate = new Date(Math.max(...abstractionPeriodsEndDates))
 
-    if (lineEndDate <= abstractionEndDate) {
-      return periodsOverlap(chargeElement.abstractionPeriods, [{ lineStartDate, lineEndDate }])
+    if (endDate <= abstractionEndDate) {
+      return periodsOverlap(chargeElement.abstractionPeriods, [{ startDate, endDate }])
     }
 
     return false

--- a/app/services/bill-runs/two-part-tariff/match-and-allocate.service.js
+++ b/app/services/bill-runs/two-part-tariff/match-and-allocate.service.js
@@ -43,10 +43,12 @@ async function _process (licences, billingPeriod, billRun) {
     await PrepareReturnLogsService.go(licence, billingPeriod)
 
     const { chargeVersions, returnLogs } = licence
+
     chargeVersions.forEach((chargeVersion) => {
       PrepareChargeVersionService.go(chargeVersion, billingPeriod)
 
       const { chargeReferences } = chargeVersion
+
       chargeReferences.forEach((chargeReference) => {
         chargeReference.allocatedQuantity = 0
 

--- a/test/services/bill-runs/two-part-tariff/allocate-returns-to-charge-element.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/allocate-returns-to-charge-element.service.test.js
@@ -258,13 +258,13 @@ describe('Allocate Returns to Charge Element Service', () => {
           testData.matchingReturns[0].returnSubmissions[0].returnSubmissionLines[7].endDate = new Date('2023-04-31')
         })
 
-        it('allocates 32 to the charge element and sets "chargeDatesOverlap" to true', () => {
+        it('allocates 28 to the charge element and sets "chargeDatesOverlap" to true', () => {
           const { chargeElement, chargeReference, matchingReturns } = testData
 
           AllocateReturnsToChargeElementService.go(chargeElement, matchingReturns, chargePeriod, chargeReference)
 
-          expect(chargeElement.allocatedQuantity).to.equal(32)
-          expect(chargeElement.returnLogs[0].allocatedQuantity).to.equal(32)
+          expect(chargeElement.allocatedQuantity).to.equal(28)
+          expect(chargeElement.returnLogs[0].allocatedQuantity).to.equal(28)
           expect(chargeElement.chargeDatesOverlap).to.be.true()
         })
       })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4586

During testing for the two-part tariff engine, it was raised that some returns when split over two charge versions were allocating incorrectly to the first charge version rather than the second one. 

The example given is a licence with two charge versions. The first charge version ends on the 16th of May and the second one begins on the 17th. The returns are done on a monthly frequency, so the first return that ended in April is correctly allocated to the first charge element. 
However, the second return which starts with May, allocated the first line (01/05/22 - 31/05/22), to the first charge element again (the one ending on the 16th of May), rather than the second one. 

The business would like it that when a return has a frequency of monthly or weekly and it is split over a charge version, the return volume for the week/month is allocated to the charge version that is live at the month's end or week's end. 

This PR is changing the way we deal with allocating the lines. We have added a date check where a line's end date must be within the end date of the abstraction period it's trying to allocate to.