### PR TITLE
Add region test seeder

### DIFF
--- a/db/clean.js
+++ b/db/clean.js
@@ -18,6 +18,7 @@ async function run () {
     await Database.clean()
     console.log('Database cleaned')
   } catch (error) {
+    console.log(error)
     process.exit(1)
   } finally {
     Database.closeConnection()

--- a/db/clean.js
+++ b/db/clean.js
@@ -15,7 +15,7 @@ async function run () {
   console.log('Database clean for tests')
 
   try {
-    // await Database.clean()
+    await Database.clean()
     console.log('Database cleaned')
   } catch (error) {
     console.log(error)

--- a/db/clean.js
+++ b/db/clean.js
@@ -15,7 +15,7 @@ async function run () {
   console.log('Database clean for tests')
 
   try {
-    await Database.clean()
+    // await Database.clean()
     console.log('Database cleaned')
   } catch (error) {
     console.log(error)

--- a/db/seeds/reference-data.js
+++ b/db/seeds/reference-data.js
@@ -1,9 +1,11 @@
 'use strict'
 
 const LicenceVersionPurposeConditionTypeSeeder = require('../../test/support/seeders/licence-version-purpose-condition-types.seeder.js')
+const RegionsSeeder = require('../../test/support/seeders/regions.seeder.js')
 
 async function seed () {
   await LicenceVersionPurposeConditionTypeSeeder.seed()
+  await RegionsSeeder.seed()
 }
 
 module.exports = {

--- a/test/services/bill-runs/fetch-region.service.test.js
+++ b/test/services/bill-runs/fetch-region.service.test.js
@@ -4,43 +4,29 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { describe, it } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const DatabaseSupport = require('../../support/database.js')
-const RegionHelper = require('../../support/helpers/region.helper.js')
+const RegionsSeeder = require('../../support/seeders/regions.seeder.js')
 
 // Thing under test
 const FetchRegionService = require('../../../app/services/bill-runs/fetch-region.service.js')
 
 describe('Fetch Region service', () => {
-  const naldRegionId = 9
-  let testRegion
-
-  beforeEach(async () => {
-    await DatabaseSupport.clean()
-  })
+  const { anglian } = RegionsSeeder.regions
 
   describe('when there is a region with a matching NALD region id', () => {
-    beforeEach(async () => {
-      testRegion = await RegionHelper.add({ naldRegionId })
-    })
-
     it('returns results', async () => {
-      const result = await FetchRegionService.go(naldRegionId)
+      const result = await FetchRegionService.go(anglian.nald_region_id)
 
-      expect(result.id).to.equal(testRegion.id)
+      expect(result.id).to.equal(anglian.id)
     })
   })
 
   describe('when there is no region with a matching NALD region id', () => {
-    beforeEach(async () => {
-      testRegion = await RegionHelper.add({ naldRegionId: 99 })
-    })
-
     it('returns no results', async () => {
-      const result = await FetchRegionService.go(naldRegionId)
+      const result = await FetchRegionService.go(21)
 
       expect(result).to.be.undefined()
     })

--- a/test/services/bill-runs/setup/fetch-regions.service.test.js
+++ b/test/services/bill-runs/setup/fetch-regions.service.test.js
@@ -8,31 +8,27 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const DatabaseSupport = require('../../../support/database.js')
-const RegionHelper = require('../../../support/helpers/region.helper.js')
+const RegionSeeder = require('../../../support/seeders/regions.seeder.js')
 
 // Thing under test
 const FetchRegionsService = require('../../../../app/services/bill-runs/setup/fetch-regions.service.js')
 
 describe('Bill Runs Setup Fetch Regions service', () => {
-  beforeEach(async () => {
-    await DatabaseSupport.clean()
-
-    await Promise.all([
-      RegionHelper.add({ id: '19a027c6-4aad-47d3-80e3-3917a4579a5b', displayName: 'Stormlands' }),
-      RegionHelper.add({ id: '3334054e-03b6-4696-9d74-62b8b76a3c64', displayName: 'Westerlands' }),
-      RegionHelper.add({ id: 'e21b987c-7a5f-4eb3-a794-e4aae4a96a28', displayName: 'Riverlands' })
-    ])
-  })
-
   describe('when called', () => {
     it('returns the ID and display name for each region ordered by display name', async () => {
       const results = await FetchRegionsService.go()
 
       expect(results).to.equal([
-        { id: 'e21b987c-7a5f-4eb3-a794-e4aae4a96a28', displayName: 'Riverlands' },
-        { id: '19a027c6-4aad-47d3-80e3-3917a4579a5b', displayName: 'Stormlands' },
-        { id: '3334054e-03b6-4696-9d74-62b8b76a3c64', displayName: 'Westerlands' }
+        { id: RegionSeeder.regions.anglian.id, displayName: RegionSeeder.regions.anglian.display_name },
+        { id: RegionSeeder.regions.midlands.id, displayName: RegionSeeder.regions.midlands.display_name },
+        { id: RegionSeeder.regions.north_east.id, displayName: RegionSeeder.regions.north_east.display_name },
+        { id: RegionSeeder.regions.north_west.id, displayName: RegionSeeder.regions.north_west.display_name },
+        { id: RegionSeeder.regions.southern.id, displayName: RegionSeeder.regions.southern.display_name },
+        { id: RegionSeeder.regions.south_west.id, displayName: RegionSeeder.regions.south_west.display_name },
+        { id: RegionSeeder.regions.test_region.id, displayName: RegionSeeder.regions.test_region.display_name },
+        { id: RegionSeeder.regions.test_region_alt.id, displayName: RegionSeeder.regions.test_region_alt.display_name },
+        { id: RegionSeeder.regions.thames.id, displayName: RegionSeeder.regions.thames.display_name },
+        { id: RegionSeeder.regions.ea_wales.id, displayName: RegionSeeder.regions.ea_wales.display_name }
       ])
     })
   })

--- a/test/services/bill-runs/setup/fetch-regions.service.test.js
+++ b/test/services/bill-runs/setup/fetch-regions.service.test.js
@@ -4,7 +4,7 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { describe, it } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
@@ -18,7 +18,8 @@ describe('Bill Runs Setup Fetch Regions service', () => {
     it('returns the ID and display name for each region ordered by display name', async () => {
       const results = await FetchRegionsService.go()
 
-      expect(results).to.equal([
+      // This is necessary because other region helpers are adding regions into the database as part of their tests.
+      const expectedRegions = [
         { id: RegionSeeder.regions.anglian.id, displayName: RegionSeeder.regions.anglian.display_name },
         { id: RegionSeeder.regions.midlands.id, displayName: RegionSeeder.regions.midlands.display_name },
         { id: RegionSeeder.regions.north_east.id, displayName: RegionSeeder.regions.north_east.display_name },
@@ -29,7 +30,14 @@ describe('Bill Runs Setup Fetch Regions service', () => {
         { id: RegionSeeder.regions.test_region_alt.id, displayName: RegionSeeder.regions.test_region_alt.display_name },
         { id: RegionSeeder.regions.thames.id, displayName: RegionSeeder.regions.thames.display_name },
         { id: RegionSeeder.regions.ea_wales.id, displayName: RegionSeeder.regions.ea_wales.display_name }
-      ])
+      ]
+
+      // This should be removed and do an exact check when the others tests have been migrated to use the seeded regions
+      expectedRegions.forEach((expectedRegion) => {
+        const region = results.find((region) => { return region.id === expectedRegion.id })
+
+        expect(region).to.equal(expectedRegion)
+      })
     })
   })
 })

--- a/test/services/bill-runs/setup/fetch-regions.service.test.js
+++ b/test/services/bill-runs/setup/fetch-regions.service.test.js
@@ -27,7 +27,6 @@ describe('Bill Runs Setup Fetch Regions service', () => {
         { id: RegionSeeder.regions.southern.id, displayName: RegionSeeder.regions.southern.display_name },
         { id: RegionSeeder.regions.south_west.id, displayName: RegionSeeder.regions.south_west.display_name },
         { id: RegionSeeder.regions.test_region.id, displayName: RegionSeeder.regions.test_region.display_name },
-        { id: RegionSeeder.regions.test_region_alt.id, displayName: RegionSeeder.regions.test_region_alt.display_name },
         { id: RegionSeeder.regions.thames.id, displayName: RegionSeeder.regions.thames.display_name },
         { id: RegionSeeder.regions.ea_wales.id, displayName: RegionSeeder.regions.ea_wales.display_name }
       ]

--- a/test/services/import/licence-version-purpose-condition.service.test.js
+++ b/test/services/import/licence-version-purpose-condition.service.test.js
@@ -10,8 +10,8 @@ const { expect } = Code
 const { randomInteger } = require('../../support/general.js')
 
 // Test helpers
-const LicenceVersionPurposeHelper = require('../../support/helpers/licence-version-purpose.helper.js')
 const LicenceVersionPurposeConditionModel = require('../../../app/models/licence-version-purpose-condition.model.js')
+const LicenceVersionPurposeHelper = require('../../support/helpers/licence-version-purpose.helper.js')
 
 // Thing under test
 const LicenceVersionPurposeConditionService = require('../../../app/services/import/licence-version-purpose-condition.service.js')

--- a/test/support/seeders/regions.seeder.js
+++ b/test/support/seeders/regions.seeder.js
@@ -1,0 +1,110 @@
+'use strict'
+
+/**
+ * @module RegionsSeeder
+ */
+
+const { db } = require('../../../db/db.js')
+
+const regions = {
+  anglian: {
+    id: 'a5f868ec-f51c-478d-924c-37852626b7c1',
+    charge_region_id: 'A',
+    nald_region_id: 1,
+    name: 'Anglian',
+    display_name: 'Anglian'
+  },
+  midlands: {
+    id: '1acb3cc9-ee16-4276-b0f4-37603d791698',
+    charge_region_id: 'B',
+    nald_region_id: 2,
+    name: 'Midlands',
+    display_name: 'Midlands'
+  },
+  north_east: {
+    id: '36706540-0985-4cef-b7e5-ab4345049b22',
+    charge_region_id: 'Y',
+    nald_region_id: 3,
+    name: 'North East',
+    display_name: 'North East'
+  },
+  north_west: {
+    id: 'eb57737f-b309-49c2-9ab6-f701e3a6fd96',
+    charge_region_id: 'N',
+    nald_region_id: 4,
+    name: 'North West',
+    display_name: 'North West'
+  },
+  south_west: {
+    id: '4ccf3c5b-ab4e-48e1-afa8-3b18b5d07fab',
+    charge_region_id: 'E',
+    nald_region_id: 5,
+    name: 'South West',
+    display_name: 'South West'
+  },
+  southern: {
+    id: 'd34d9f4f-11ed-46f5-b4fb-15d5988c2870',
+    charge_region_id: 'S',
+    nald_region_id: 6,
+    name: 'Southern',
+    display_name: 'Southern'
+  },
+  thames: {
+    id: '7af8fb71-e197-4f85-bee4-23b62ef711c6',
+    charge_region_id: 'T',
+    nald_region_id: 7,
+    name: 'Thames',
+    display_name: 'Thames'
+  },
+  ea_wales: {
+    id: '77d44d65-6f33-425e-9075-ae5ac43a0c36',
+    charge_region_id: 'W',
+    nald_region_id: 8,
+    name: 'EA Wales',
+    display_name: 'Wales'
+  },
+  test_region: {
+    id: '51dfb3e0-9815-4fb9-b6c1-d1f6c8e56273',
+    charge_region_id: 'S',
+    nald_region_id: 9,
+    name: 'Test Region',
+    display_name: 'Test Region'
+  },
+  test_region_alt: {
+    id: 'd0a4123d-1e19-480d-9dd4-f70f3387c4b9',
+    charge_region_id: 'S',
+    nald_region_id: 9,
+    name: 'Test Region',
+    display_name: 'Test Region'
+  }
+}
+
+function createValueStringFromRegions () {
+  let valueString = ''
+
+  for (const regionsKey in regions) {
+    valueString += `('${regions[regionsKey].id}', '${regions[regionsKey].charge_region_id}', '${regions[regionsKey].nald_region_id}', '${regions[regionsKey].name}', '${regions[regionsKey].display_name}')`
+
+    // Add comma to all but the last value
+    valueString += (regionsKey === 'test_region_alt' ? '' : ',')
+  }
+
+  return valueString
+}
+
+/**
+ * Add all the regions to the database
+ *
+ */
+async function seed () {
+  await db.raw(`
+    INSERT INTO  public.regions (id, charge_region_id, nald_region_id, name, display_name)
+      VALUES ${createValueStringFromRegions()};
+  `
+  )
+}
+
+module.exports = {
+  seed,
+  regions
+}

--- a/test/support/seeders/regions.seeder.js
+++ b/test/support/seeders/regions.seeder.js
@@ -64,13 +64,7 @@ const regions = {
     display_name: 'Wales'
   },
   test_region: {
-    id: '51dfb3e0-9815-4fb9-b6c1-d1f6c8e56273',
-    charge_region_id: 'S',
-    nald_region_id: 9,
-    name: 'Test Region',
-    display_name: 'Test Region'
-  },
-  test_region_alt: {
+    // this id corresponds to the id used in the acceptance tests
     id: 'd0a4123d-1e19-480d-9dd4-f70f3387c4b9',
     charge_region_id: 'S',
     nald_region_id: 9,
@@ -86,7 +80,7 @@ function createValueStringFromRegions () {
     valueString += `('${regions[regionsKey].id}', '${regions[regionsKey].charge_region_id}', '${regions[regionsKey].nald_region_id}', '${regions[regionsKey].name}', '${regions[regionsKey].display_name}')`
 
     // Add comma to all but the last value
-    valueString += (regionsKey === 'test_region_alt' ? '' : ',')
+    valueString += (regionsKey === 'test_region' ? '' : ',')
   }
 
   return valueString


### PR DESCRIPTION

https://eaflood.atlassian.net/browse/WATER-4575

The public.regions table is what we call reference data. We assume this table will not change frequently, if ever. 

As part of the work to replace the legacy import service we have decided to seed any data we have deemed reference data. 

We will use these seeders in testing. We need to add this now as the nald region id when randomly generated is between 1-8. This was causing random test failures when using the normal RegionHelper.add(). 

This was found because we have moved away from clearing the database before each test and having a pre test clean the database instead. (This is previous work to allow us to potentially speed up the tests and change our test framework)

