### PR TITLE
Two-part tariff due returns to show as blank

### DIFF
--- a/app/presenters/bill-runs/two-part-tariff/review-licence.presenter.js
+++ b/app/presenters/bill-runs/two-part-tariff/review-licence.presenter.js
@@ -250,7 +250,7 @@ function _prepareReturnVolume (reviewChargeElement) {
   if (reviewReturns) {
     reviewReturns.forEach((reviewReturn) => {
       if (reviewReturn.returnStatus === 'due') {
-        returnVolumes.push(`Overdue (${reviewReturn.returnReference})`)
+        returnVolumes.push(`overdue (${reviewReturn.returnReference})`)
       } else {
         returnVolumes.push(`${reviewReturn.quantity} ML (${reviewReturn.returnReference})`)
       }

--- a/app/presenters/bill-runs/two-part-tariff/review-licence.presenter.js
+++ b/app/presenters/bill-runs/two-part-tariff/review-licence.presenter.js
@@ -249,7 +249,11 @@ function _prepareReturnVolume (reviewChargeElement) {
 
   if (reviewReturns) {
     reviewReturns.forEach((reviewReturn) => {
-      returnVolumes.push(`${reviewReturn.quantity} ML (${reviewReturn.returnReference})`)
+      if (reviewReturn.returnStatus === 'due') {
+        returnVolumes.push(`(${reviewReturn.returnReference})`)
+      } else {
+        returnVolumes.push(`${reviewReturn.quantity} ML (${reviewReturn.returnReference})`)
+      }
     })
   }
 

--- a/app/presenters/bill-runs/two-part-tariff/review-licence.presenter.js
+++ b/app/presenters/bill-runs/two-part-tariff/review-licence.presenter.js
@@ -250,7 +250,7 @@ function _prepareReturnVolume (reviewChargeElement) {
   if (reviewReturns) {
     reviewReturns.forEach((reviewReturn) => {
       if (reviewReturn.returnStatus === 'due') {
-        returnVolumes.push(`(${reviewReturn.returnReference})`)
+        returnVolumes.push(`Overdue (${reviewReturn.returnReference})`)
       } else {
         returnVolumes.push(`${reviewReturn.quantity} ML (${reviewReturn.returnReference})`)
       }

--- a/test/presenters/bill-runs/two-part-tariff/review-licence.presenter.test.js
+++ b/test/presenters/bill-runs/two-part-tariff/review-licence.presenter.test.js
@@ -170,7 +170,7 @@ describe('Review Licence presenter', () => {
         it('formats the charge elements return total correctly', () => {
           const result = ReviewLicencePresenter.go(billRun, licence)
 
-          expect(result.chargeData[0].chargeReferences[0].chargeElements[0].returnVolume).to.equal(['(10031343)'])
+          expect(result.chargeData[0].chargeReferences[0].chargeElements[0].returnVolume).to.equal(['Overdue (10031343)'])
         })
 
         it('formats the returns link correctly', () => {

--- a/test/presenters/bill-runs/two-part-tariff/review-licence.presenter.test.js
+++ b/test/presenters/bill-runs/two-part-tariff/review-licence.presenter.test.js
@@ -152,6 +152,7 @@ describe('Review Licence presenter', () => {
       describe('when a return has a status of "due"', () => {
         beforeEach(() => {
           licence[0].reviewReturns[0].returnStatus = 'due'
+          licence[0].reviewChargeVersions[0].reviewChargeReferences[0].reviewChargeElements[0].reviewReturns[0].returnStatus = 'due'
         })
 
         it('changes the status text to "overdue"', () => {
@@ -164,6 +165,12 @@ describe('Review Licence presenter', () => {
           const result = ReviewLicencePresenter.go(billRun, licence)
 
           expect(result.matchedReturns[0].returnTotal).to.equal('/')
+        })
+
+        it('formats the charge elements return total correctly', () => {
+          const result = ReviewLicencePresenter.go(billRun, licence)
+
+          expect(result.chargeData[0].chargeReferences[0].chargeElements[0].returnVolume).to.equal(['(10031343)'])
         })
 
         it('formats the returns link correctly', () => {

--- a/test/presenters/bill-runs/two-part-tariff/review-licence.presenter.test.js
+++ b/test/presenters/bill-runs/two-part-tariff/review-licence.presenter.test.js
@@ -170,7 +170,7 @@ describe('Review Licence presenter', () => {
         it('formats the charge elements return total correctly', () => {
           const result = ReviewLicencePresenter.go(billRun, licence)
 
-          expect(result.chargeData[0].chargeReferences[0].chargeElements[0].returnVolume).to.equal(['Overdue (10031343)'])
+          expect(result.chargeData[0].chargeReferences[0].chargeElements[0].returnVolume).to.equal(['overdue (10031343)'])
         })
 
         it('formats the returns link correctly', () => {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4606

During testing for the two-part tariff review pages, it was raised that the billing and data team wanted to amend the returns displaying under a charge element. When a return matches a charge element, we show these under the review charge element section with their allocated quantity. 
A due return currently displays `0 ML`. The billing and data team wants to remove this and show a due return as blank instead of `0 ML`. They say that showing `0 ML` gives the false impression that the return is a nil return, rather than a due return. This PR is for this change.