### PR TITLE
Replace view licence contact details page

### DIFF
--- a/app/controllers/licences.controller.js
+++ b/app/controllers/licences.controller.js
@@ -9,11 +9,13 @@ const InitiateSessionService = require('../services/return-requirements/initiate
 const ViewLicenceBillsService = require('../services/licences/view-licence-bills.service.js')
 const ViewLicenceCommunicationsService = require('../services/licences/view-licence-communications.service.js')
 const ViewLicenceContactDetailsService = require('../services/licences/view-licence-contact-details.service.js')
+const ViewLicenceContactService = require('../services/licences/view-licence-contact.service.js')
 const ViewLicenceReturnsService = require('../services/licences/view-licence-returns.service.js')
 const ViewLicenceSetUpService = require('../services/licences/view-licence-set-up.service.js')
 const ViewLicenceSummaryService = require('../services/licences/view-licence-summary.service.js')
 
 const ViewLicencePage = 'licences/view.njk'
+const ViewLicenceContactPage = 'licences/licence-contact.njk'
 
 async function noReturnsRequired (request, h) {
   const { id } = request.params
@@ -61,6 +63,17 @@ async function viewCommunications (request, h) {
   })
 }
 
+async function viewLicenceContact (request, h) {
+  const { params: { id }, auth } = request
+
+  //const data = await ViewLicenceContactDetailsService.go(id, auth)
+  const data = await ViewLicenceContactService.go(id, auth)
+
+  return h.view(ViewLicenceContactPage, {
+    ...data
+  })
+}
+
 async function viewContacts (request, h) {
   const { params: { id }, auth } = request
 
@@ -96,6 +109,7 @@ module.exports = {
   returnsRequired,
   viewBills,
   viewCommunications,
+  viewLicenceContact,
   viewContacts,
   viewReturns,
   viewSetUp,

--- a/app/presenters/licences/view-licence-contact.presenter.js
+++ b/app/presenters/licences/view-licence-contact.presenter.js
@@ -1,0 +1,48 @@
+'use strict'
+
+/**
+ * Formats data for the `/licences/{id}/licence-contact` view licence contact page
+ * @module ViewLicenceContactPresenter
+ */
+
+/**
+ * Formats data for the `/licences/{id}/licence-contact` view licence contact page
+ *
+ * @returns {Object} The data formatted for the view template
+ */
+function go (contacts) {
+  return {
+    licenceContacts: _licenceContacts(contacts)
+  }
+}
+
+function _licenceContactName (contact) {
+  if (contact.contactId) {
+    return `${contact.firstName || ''} ${contact.lastName}`.trim()
+  }
+
+  return contact.companyName
+}
+
+function _licenceContacts (contacts) {
+  return contacts.map((contact) => {
+    return {
+      address: {
+        address1: contact.address1,
+        address2: contact.address2,
+        address3: contact.address3,
+        address4: contact.address4,
+        address5: contact.address5,
+        address6: contact.address6,
+        country: contact.country,
+        postcode: contact.postcode
+      },
+      communicationType: contact.communicationType,
+      name: _licenceContactName(contact)
+    }
+  })
+}
+
+module.exports = {
+  go
+}

--- a/app/routes/licence.routes.js
+++ b/app/routes/licence.routes.js
@@ -22,6 +22,11 @@ const routes = [
   },
   {
     method: 'GET',
+    path: '/licences/{id}/licence-contact',
+    handler: LicencesController.viewLicenceContact
+  },
+  {
+    method: 'GET',
     path: '/licences/{id}/contact-details',
     handler: LicencesController.viewContacts
   },

--- a/app/services/licences/fetch-licence-contact.service.js
+++ b/app/services/licences/fetch-licence-contact.service.js
@@ -1,0 +1,52 @@
+'use strict'
+
+/**
+ * Fetches all return logs for a licence which is needed for the view '/licences/{id}/licence-contact` page
+ * @module FetchLicenceContactService
+ */
+
+const { db } = require('../../../db/db.js')
+
+/**
+ * Fetches all contact details for a licence which is needed for the view '/licences/{id}/licence-contact` page
+ *
+ * @param {string} licenceId - The UUID for the licence to fetch
+ *
+ * @returns {Promise<Object>} the data needed to populate the view licence page's contact details link page
+ */
+async function go (licenceId) {
+  return _fetch(licenceId)
+}
+
+async function _fetch (licenceId) {
+  return db.withSchema('public')
+    .select([
+      'lr.label AS communicationType',
+      'cmp.id AS companyId',
+      'cmp.name AS companyName',
+      'con.id AS contactId',
+      'con.firstName',
+      'con.lastName',
+      'a.address1',
+      'a.address2',
+      'a.address3',
+      'a.address4',
+      'a.address5',
+      'a.address6',
+      'a.postcode',
+      'a.country'
+    ])
+    .from('licenceDocuments AS ld')
+    .innerJoin('licences AS l', 'l.licenceRef', '=', 'ld.licenceRef')
+    .innerJoin('licenceDocumentRoles AS ldr', 'ldr.licenceDocumentId', '=', 'ld.id')
+    .innerJoin('licenceRoles AS lr', 'lr.id', '=', 'ldr.licenceRoleId')
+    .innerJoin('companies AS cmp', 'cmp.id', '=', 'ldr.companyId')
+    .leftJoin('contacts AS con', 'con.id', '=', 'ldr.contactId')
+    .innerJoin('addresses AS a', 'a.id', '=', 'ldr.addressId')
+    .where('l.id', '=', licenceId)
+    .orderBy('lr.label', 'asc')
+}
+
+module.exports = {
+  go
+}

--- a/app/services/licences/view-licence-contact.service.js
+++ b/app/services/licences/view-licence-contact.service.js
@@ -1,0 +1,38 @@
+'use strict'
+
+/**
+ * Orchestrates fetching and presenting the data needed for the view licence contact page
+ * @module ViewLicenceContactService
+ */
+
+
+const FetchLicenceContactService = require('./fetch-licence-contact.service.js')
+const LicenceContactPresenter = require('../../presenters/licences/view-licence-contact.presenter.js')
+const ViewLicenceService = require('./view-licence.service.js')
+
+
+/**
+ * Orchestrates fetching and presenting the data needed for the licence contact page
+ *
+ * @param {string} licenceId - The UUID of the licence
+ * @param {Object} auth - The auth object taken from `request.auth` containing user details
+ *
+ * @returns {Promise<Object>} an object representing the `pageData` needed by the licence contact details template.
+ */
+async function go (licenceId, auth) {
+  const commonData = await ViewLicenceService.go(licenceId, auth)
+
+  // Licence contact details
+  const licenceContacts = await FetchLicenceContactService.go(licenceId)
+  const licenceContactsData = LicenceContactPresenter.go(licenceContacts)
+
+
+  return {
+    ...commonData,
+    ...licenceContactsData
+  }
+}
+
+module.exports = {
+  go
+}

--- a/app/views/licences/licence-contact.njk
+++ b/app/views/licences/licence-contact.njk
@@ -1,0 +1,81 @@
+{% extends 'layout.njk' %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
+{% from "govuk/components/tabs/macro.njk" import govukTabs %}
+{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
+
+{% block breadcrumbs %}
+  {{ govukBackLink({
+    text: 'Go back to summary',
+    href: '/system/licences/' + licenceId + '/summary'
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+  <span class="govuk-caption-l">Licence number {{ licenceRef }}</span>
+  <h1 class="govuk-heading-l">Licence contact details: {{ licenceName }} </h1>
+
+{% from "govuk/components/table/macro.njk" import govukTable %}
+
+{% macro displayAddress(address) %}
+  {% if address.address1 %}
+    <p class="govuk-body govuk-!-margin-bottom-0">{{ address.address1 }}</p>
+  {% endif %}
+  {% if address.address2 %}
+    <p class="govuk-body govuk-!-margin-bottom-0">{{ address.address2 }}</p>
+  {% endif %}
+  {% if address.address3 %}
+    <p class="govuk-body govuk-!-margin-bottom-0">{{ address.address3 }}</p>
+  {% endif %}
+  {% if address.address4 %}
+    <p class="govuk-body govuk-!-margin-bottom-0">{{ address.address4 }}</p>
+  {% endif %}
+  {% if address.address5 %}
+    <p class="govuk-body govuk-!-margin-bottom-0">{{ address.address5 }}</p>
+  {% endif %}
+  {% if address.address6 %}
+    <p class="govuk-body govuk-!-margin-bottom-0">{{ address.address6 }}</p>
+  {% endif %}
+  {% if address.country %}
+    <p class="govuk-body govuk-!-margin-bottom-0">{{ address.country }}</p>
+  {% endif %}
+  {% if address.postcode %}
+    <p class="govuk-body govuk-!-margin-bottom-0">{{ address.postcode }}</p>
+  {% endif %}
+{% endmacro %}
+
+{% for licenceContact in licenceContacts %}
+  {# Set an easier to use index. Also means we can refer to it inside our elementDetail loop #}
+
+  <h3 class="govuk-heading-m">{{ licenceContact.communicationType }}</h3>
+  <hr class="govuk-section-break govuk-section-break--visible">
+
+  {{ govukSummaryList({
+  rows: [{
+      key: {
+        text: "Name",
+        classes:"govuk-!-font-weight-regular"
+      },
+      value: {
+        text: licenceContact.name
+      }
+    },
+    {
+      key: {
+        text: "Address",
+        classes:"govuk-!-font-weight-regular"
+      },
+      value: {
+        html: displayAddress(licenceContact.address)
+      }
+    }]
+}) }}
+
+
+{% endfor %}
+
+
+
+{% endblock %}

--- a/app/views/licences/tabs/summary.njk
+++ b/app/views/licences/tabs/summary.njk
@@ -8,9 +8,13 @@
     <dt class="govuk-summary-list__key">Licence Holder</dt>
     <dd class="govuk-summary-list__value">
       <span class="govuk-form-group">{{ licenceHolder }}</span>
-      <a class="govuk-form-group" href="/licences/{{ documentId }}/contact">View licence contact details</a>
+      <a class="govuk-form-group" href="/licences/{{ documentId }}/contact">View licence contact details$$$</a>
+      <a class="govuk-form-group" href="/system/licences/{{ licenceId }}/licence-contact">View licence contact details@@@</a>
+      <span class="govuk-form-group">{{ documentIdDetails }}</span>
     </dd>
   </div>
+
+
 
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">Effective from</dt>


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4559

**Context**

We recently rebuilt the legacy view licence page, implementing the new version in our shiny new codebase water-abstraction-system. Substantial changes needed to be made to support the return requirements, so this was a great opportunity to also deal with the tech debt of the legacy view licence page.  One of the pages that is linked to from the summary tab is the view licence contacts page. If we move that into our code base, we make another small dent in moving away from the legacy code.

![water-4559_legacy_page](https://github.com/user-attachments/assets/d220dc31-0be5-4f0b-a4fd-e37ede98f33e)

**Task**
The page is currently accessed from the view licence summary tab (search for any licence on main page, select licence, summary tab will be shown).

![Screenshot 2024-07-04 at 09 32 56](https://github.com/user-attachments/assets/7b131a62-8ca6-4459-aac1-d3f2269bbe91)

The task is to ‘spike’ rebuilding the page as is, but following the conventions and patterns used in water-abstraction-system.
