### PR TITLE
Lower case H for licence holder on 2pt review page

### DIFF
--- a/app/views/bill-runs/review-licence.njk
+++ b/app/views/bill-runs/review-licence.njk
@@ -36,7 +36,7 @@
       <h1 class="govuk-heading-xl govuk-!-margin-bottom-1">{{pageTitle}}</h1>
 
       <p class="govuk-body">
-        <span data-test='licence-holder'>Licence Holder {{ licence.licenceHolder }} </span>
+        <span data-test='licence-holder'>Licence holder {{ licence.licenceHolder }} </span>
         <div>{{ statusTag(licence.status) }}</div>
       </p>
     </div>


### PR DESCRIPTION
This PR is a content change to make the h in licence holder a lowercase, as per the design prototype.