### PR TITLE
Two-part tariff void returns to show as void on review screens

### DIFF
--- a/app/presenters/bill-runs/two-part-tariff/review-licence.presenter.js
+++ b/app/presenters/bill-runs/two-part-tariff/review-licence.presenter.js
@@ -250,6 +250,8 @@ function _prepareReturnVolume (reviewChargeElement) {
     reviewReturns.forEach((reviewReturn) => {
       if (reviewReturn.returnStatus === 'due') {
         returnVolumes.push(`overdue (${reviewReturn.returnReference})`)
+      } else if (reviewReturn.returnStatus === 'void') {
+        returnVolumes.push(`void (${reviewReturn.returnReference})`)
       } else {
         returnVolumes.push(`${reviewReturn.quantity} ML (${reviewReturn.returnReference})`)
       }

--- a/test/presenters/bill-runs/two-part-tariff/review-licence.presenter.test.js
+++ b/test/presenters/bill-runs/two-part-tariff/review-licence.presenter.test.js
@@ -178,6 +178,37 @@ describe('Review Licence presenter', () => {
           expect(result.matchedReturns[0].returnLink).to.equal('/return/internal?returnId=v1:1:01/60/28/3437:17061181:2022-04-01:2023-03-31')
         })
       })
+
+      describe('when a return has a status of "void"', () => {
+        beforeEach(() => {
+          licence[0].reviewReturns[0].returnStatus = 'void'
+          licence[0].reviewChargeVersions[0].reviewChargeReferences[0].reviewChargeElements[0].reviewReturns[0].returnStatus = 'void'
+        })
+
+        it('changes the status text to "void"', () => {
+          const result = ReviewLicencePresenter.go(billRun, licence)
+
+          expect(result.matchedReturns[0].returnStatus).to.equal('void')
+        })
+
+        it('formats the returns total correctly', () => {
+          const result = ReviewLicencePresenter.go(billRun, licence)
+
+          expect(result.matchedReturns[0].returnTotal).to.equal('/')
+        })
+
+        it('formats the charge elements return total correctly', () => {
+          const result = ReviewLicencePresenter.go(billRun, licence)
+
+          expect(result.chargeData[0].chargeReferences[0].chargeElements[0].returnVolume).to.equal(['void (10031343)'])
+        })
+
+        it('formats the returns link correctly', () => {
+          const result = ReviewLicencePresenter.go(billRun, licence)
+
+          expect(result.matchedReturns[0].returnLink).to.equal('/return/internal?returnId=v1:1:01/60/28/3437:17061181:2022-04-01:2023-03-31')
+        })
+      })
     })
 
     describe('the "underQuery" property', () => {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4606

During testing for the two-part tariff review pages, it was raised that the billing and data team wanted to amend the returns displaying under a charge element. When a return matches a charge element, we show these under the review charge element section with their allocated quantity. A void return currently displays `0 ML`. The billing and data team wants to remove this and show a void return as "void" instead of `0 ML`. They say that showing `0 ML` gives the false impression that the return is a nil return, rather than a void return. This PR is for this change.