### PR TITLE
https://eaflood.atlassian.net/browse/WATER-4579

### DIFF
--- a/db/seeds/reference-data.js
+++ b/db/seeds/reference-data.js
@@ -3,11 +3,15 @@
 const LicenceVersionPurposeConditionTypeSeeder = require('../../test/support/seeders/licence-version-purpose-condition-types.seeder.js')
 const RegionsSeeder = require('../../test/support/seeders/regions.seeder.js')
 const PurposesSeeder = require('../../test/support/seeders/purposes.seeder.js')
+const PrimaryPurposesSeeder = require('../../test/support/seeders/primary-purpose.seeder.js')
+const SecondaryPurposesSeeder = require('../../test/support/seeders/secondary-purpose.seeder.js')
 
 async function seed () {
   await LicenceVersionPurposeConditionTypeSeeder.seed()
   await RegionsSeeder.seed()
   await PurposesSeeder.seed()
+  await PrimaryPurposesSeeder.seed()
+  await SecondaryPurposesSeeder.seed()
 }
 
 module.exports = {

--- a/db/seeds/reference-data.js
+++ b/db/seeds/reference-data.js
@@ -2,10 +2,12 @@
 
 const LicenceVersionPurposeConditionTypeSeeder = require('../../test/support/seeders/licence-version-purpose-condition-types.seeder.js')
 const RegionsSeeder = require('../../test/support/seeders/regions.seeder.js')
+const PurposesSeeder = require('../../test/support/seeders/purposes.seeder.js')
 
 async function seed () {
   await LicenceVersionPurposeConditionTypeSeeder.seed()
   await RegionsSeeder.seed()
+  await PurposesSeeder.seed()
 }
 
 module.exports = {

--- a/test/models/charge-element.model.test.js
+++ b/test/models/charge-element.model.test.js
@@ -13,9 +13,9 @@ const ChargeReferenceHelper = require('../support/helpers/charge-reference.helpe
 const ChargeReferenceModel = require('../../app/models/charge-reference.model.js')
 const DatabaseSupport = require('../support/database.js')
 const PurposeModel = require('../../app/models/purpose.model.js')
-const PurposeHelper = require('../support/helpers/purpose.helper.js')
-const ReviewChargeElementModel = require('../../app/models/review-charge-element.model.js')
+const PurposesSeeder = require('../support/seeders/purposes.seeder.js')
 const ReviewChargeElementHelper = require('../support/helpers/review-charge-element.helper.js')
+const ReviewChargeElementModel = require('../../app/models/review-charge-element.model.js')
 
 // Thing under test
 const ChargeElementModel = require('../../app/models/charge-element.model.js')
@@ -48,6 +48,7 @@ describe('Charge Element model', () => {
         testChargeReference = await ChargeReferenceHelper.add()
 
         const { id: chargeReferenceId } = testChargeReference
+
         testRecord = await ChargeElementHelper.add({ chargeReferenceId })
       })
 
@@ -75,9 +76,10 @@ describe('Charge Element model', () => {
       let testPurpose
 
       beforeEach(async () => {
-        testPurpose = await PurposeHelper.add()
+        testPurpose = PurposesSeeder.data[0]
 
         const { id: purposeId } = testPurpose
+
         testRecord = await ChargeElementHelper.add({ purposeId })
       })
 
@@ -110,6 +112,7 @@ describe('Charge Element model', () => {
         testReviewChargeElements = []
         for (let i = 0; i < 2; i++) {
           const reviewChargeElement = await ReviewChargeElementHelper.add({ chargeElementId: testRecord.id })
+
           testReviewChargeElements.push(reviewChargeElement)
         }
       })

--- a/test/models/charge-reference.model.test.js
+++ b/test/models/charge-reference.model.test.js
@@ -19,9 +19,9 @@ const ChargeVersionHelper = require('../support/helpers/charge-version.helper.js
 const ChargeVersionModel = require('../../app/models/charge-version.model.js')
 const DatabaseSupport = require('../support/database.js')
 const PurposeModel = require('../../app/models/purpose.model.js')
-const PurposeHelper = require('../support/helpers/purpose.helper.js')
-const ReviewChargeReferenceModel = require('../../app/models/review-charge-reference.model.js')
+const PurposesSeeder = require('../support/seeders/purposes.seeder.js')
 const ReviewChargeReferenceHelper = require('../support/helpers/review-charge-reference.helper.js')
+const ReviewChargeReferenceModel = require('../../app/models/review-charge-reference.model.js')
 const TransactionHelper = require('../support/helpers/transaction.helper.js')
 const TransactionModel = require('../../app/models/transaction.model.js')
 
@@ -59,6 +59,7 @@ describe('Charge Reference model', () => {
         testBillRunVolumes = []
         for (let i = 0; i < 2; i++) {
           const billRunVolume = await BillRunVolumeHelper.add({ chargeReferenceId: id })
+
           testBillRunVolumes.push(billRunVolume)
         }
       })
@@ -92,6 +93,7 @@ describe('Charge Reference model', () => {
         testChargeCategory = await ChargeCategoryHelper.add()
 
         const { id: chargeCategoryId } = testChargeCategory
+
         testRecord = await ChargeReferenceHelper.add({ chargeCategoryId })
       })
 
@@ -124,6 +126,7 @@ describe('Charge Reference model', () => {
         testChargeElements = []
         for (let i = 0; i < 2; i++) {
           const chargeElement = await ChargeElementHelper.add({ chargeReferenceId: testRecord.id })
+
           testChargeElements.push(chargeElement)
         }
       })
@@ -157,6 +160,7 @@ describe('Charge Reference model', () => {
         testChargeVersion = await ChargeVersionHelper.add()
 
         const { id: chargeVersionId } = testChargeVersion
+
         testRecord = await ChargeReferenceHelper.add({ chargeVersionId })
       })
 
@@ -184,9 +188,10 @@ describe('Charge Reference model', () => {
       let testPurpose
 
       beforeEach(async () => {
-        testPurpose = await PurposeHelper.add()
+        testPurpose = PurposesSeeder.data[0]
 
         const { id: purposeId } = testPurpose
+
         testRecord = await ChargeReferenceHelper.add({ purposeId })
       })
 
@@ -219,6 +224,7 @@ describe('Charge Reference model', () => {
         testReviewChargeReferences = []
         for (let i = 0; i < 2; i++) {
           const reviewChargeReference = await ReviewChargeReferenceHelper.add({ chargeReferenceId: testRecord.id })
+
           testReviewChargeReferences.push(reviewChargeReference)
         }
       })
@@ -254,6 +260,7 @@ describe('Charge Reference model', () => {
         testTransactions = []
         for (let i = 0; i < 2; i++) {
           const transaction = await TransactionHelper.add({ chargeReferenceId: testRecord.id })
+
           testTransactions.push(transaction)
         }
       })

--- a/test/models/licence-version-purpose.model.test.js
+++ b/test/models/licence-version-purpose.model.test.js
@@ -8,27 +8,34 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const DatabaseSupport = require('../support/database.js')
-const LicenceVersionModel = require('../../app/models/licence-version.model.js')
 const LicenceVersionHelper = require('../support/helpers/licence-version.helper.js')
+const LicenceVersionModel = require('../../app/models/licence-version.model.js')
 const LicenceVersionPurposeConditionHelper = require('../support/helpers/licence-version-purpose-condition.helper.js')
 const LicenceVersionPurposeConditionModel = require('../../app/models/licence-version-purpose-condition.model.js')
 const LicenceVersionPurposeHelper = require('../support/helpers/licence-version-purpose.helper.js')
 const PrimaryPurposeHelper = require('../support/helpers/primary-purpose.helper.js')
 const PrimaryPurposeModel = require('../../app/models/primary-purpose.model.js')
+const PrimaryPurposesSeeder = require('../support/seeders/primary-purpose.seeder.js')
 const PurposeHelper = require('../support/helpers/purpose.helper.js')
 const PurposeModel = require('../../app/models/purpose.model.js')
 const SecondaryPurposeHelper = require('../support/helpers/secondary-purpose.helper.js')
 const SecondaryPurposeModel = require('../../app/models/secondary-purpose.model.js')
+const SecondaryPurposeSeeder = require('../support/seeders/secondary-purpose.seeder.js')
+const PurposesSeeder = require('../support/seeders/purposes.seeder.js')
 
 // Thing under test
 const LicenceVersionPurposeModel = require('../../app/models/licence-version-purpose.model.js')
 
-describe('Licence Version Purposes model', () => {
+describe.only('Licence Version Purposes model', () => {
   let testRecord
+  let secondaryPurposeId
+  let primaryPurposeId
+  let purposeId
 
-  beforeEach(async () => {
-    await DatabaseSupport.clean()
+  beforeEach(() => {
+    primaryPurposeId = PrimaryPurposesSeeder.data[0].id
+    secondaryPurposeId = SecondaryPurposeSeeder.data[0].id
+    purposeId = PurposesSeeder.data[0].id
   })
 
   describe('Basic query', () => {
@@ -115,13 +122,7 @@ describe('Licence Version Purposes model', () => {
     })
 
     describe('when linking to primary purpose', () => {
-      let testPrimaryPurpose
-
       beforeEach(async () => {
-        testPrimaryPurpose = await PrimaryPurposeHelper.add()
-
-        const { id: primaryPurposeId } = testPrimaryPurpose
-
         testRecord = await LicenceVersionPurposeHelper.add({ primaryPurposeId })
       })
 
@@ -141,18 +142,12 @@ describe('Licence Version Purposes model', () => {
         expect(result.id).to.equal(testRecord.id)
 
         expect(result.primaryPurpose).to.be.an.instanceOf(PrimaryPurposeModel)
-        expect(result.primaryPurpose.id).to.equal(testPrimaryPurpose.id)
+        expect(result.primaryPurpose.id).to.equal(primaryPurposeId)
       })
     })
 
     describe('when linking to purpose', () => {
-      let testPurpose
-
       beforeEach(async () => {
-        testPurpose = await PurposeHelper.add()
-
-        const { id: purposeId } = testPurpose
-
         testRecord = await LicenceVersionPurposeHelper.add({ purposeId })
       })
 
@@ -172,18 +167,12 @@ describe('Licence Version Purposes model', () => {
         expect(result.id).to.equal(testRecord.id)
 
         expect(result.purpose).to.be.an.instanceOf(PurposeModel)
-        expect(result.purpose.id).to.equal(testPurpose.id)
+        expect(result.purpose.id).to.equal(purposeId)
       })
     })
 
     describe('when linking to secondary purpose', () => {
-      let testSecondaryPurpose
-
       beforeEach(async () => {
-        testSecondaryPurpose = await SecondaryPurposeHelper.add()
-
-        const { id: secondaryPurposeId } = testSecondaryPurpose
-
         testRecord = await LicenceVersionPurposeHelper.add({ secondaryPurposeId })
       })
 
@@ -203,7 +192,7 @@ describe('Licence Version Purposes model', () => {
         expect(result.id).to.equal(testRecord.id)
 
         expect(result.secondaryPurpose).to.be.an.instanceOf(SecondaryPurposeModel)
-        expect(result.secondaryPurpose.id).to.equal(testSecondaryPurpose.id)
+        expect(result.secondaryPurpose.id).to.equal(secondaryPurposeId)
       })
     })
   })
@@ -231,14 +220,16 @@ describe('Licence Version Purposes model', () => {
     let validPurpose
     let validSecondaryPurpose
 
-    beforeEach(async () => {
-      invalidPrimaryPurpose = await PrimaryPurposeHelper.add({ legacyId: 'A' })
-      invalidSecondaryPurpose = await SecondaryPurposeHelper.add({ legacyId: 'AGR' })
-      invalidPurpose = await PurposeHelper.add({ legacyId: '400' })
+    beforeEach(() => {
+      invalidPrimaryPurpose = PrimaryPurposesSeeder.data[0]
+      invalidSecondaryPurpose = SecondaryPurposeSeeder.data[0]
+      invalidPurpose = PurposesSeeder.data.find((purpose) => { return purpose.legacy_id === '400' })
 
-      validPrimaryPurpose = await PrimaryPurposeHelper.add({ legacyId: 'P' })
-      validSecondaryPurpose = await SecondaryPurposeHelper.add({ legacyId: 'ELC' })
-      validPurpose = await PurposeHelper.add({ legacyId: '200' })
+      validPrimaryPurpose = PrimaryPurposesSeeder.data.find(({ legacyId }) => { return legacyId === 'P' })
+      validSecondaryPurpose = SecondaryPurposeSeeder.data.find(({ legacyId }) => { return legacyId === 'ELC' })
+      validPurpose = PurposesSeeder.data.find((purpose) => { return purpose.legacy_id === '200' })
+
+      console.log('i', invalidPrimaryPurpose, invalidSecondaryPurpose, invalidPurpose)
     })
 
     describe('but the primary purpose is not "P" (Production Of Energy)', () => {

--- a/test/models/licence-version-purpose.model.test.js
+++ b/test/models/licence-version-purpose.model.test.js
@@ -16,9 +16,9 @@ const LicenceVersionPurposeHelper = require('../support/helpers/licence-version-
 const PrimaryPurposeModel = require('../../app/models/primary-purpose.model.js')
 const PrimaryPurposesSeeder = require('../support/seeders/primary-purpose.seeder.js')
 const PurposeModel = require('../../app/models/purpose.model.js')
+const PurposesSeeder = require('../support/seeders/purposes.seeder.js')
 const SecondaryPurposeModel = require('../../app/models/secondary-purpose.model.js')
 const SecondaryPurposeSeeder = require('../support/seeders/secondary-purpose.seeder.js')
-const PurposesSeeder = require('../support/seeders/purposes.seeder.js')
 
 // Thing under test
 const LicenceVersionPurposeModel = require('../../app/models/licence-version-purpose.model.js')
@@ -221,20 +221,18 @@ describe('Licence Version Purposes model', () => {
       invalidPrimaryPurpose = PrimaryPurposesSeeder.data[0]
       invalidSecondaryPurpose = SecondaryPurposeSeeder.data[0]
       invalidPurpose = PurposesSeeder.data.find((purpose) => {
-        return purpose.legacy_id === '400'
+        return purpose.legacyId === '400'
       })
 
       validPrimaryPurpose = PrimaryPurposesSeeder.data.find((primaryPurpose) => {
-        return primaryPurpose.legacy_id === 'P'
+        return primaryPurpose.legacyId === 'P'
       })
       validSecondaryPurpose = SecondaryPurposeSeeder.data.find((secondaryPurpose) => {
-        return secondaryPurpose.legacy_id === 'ELC'
+        return secondaryPurpose.legacyId === 'ELC'
       })
       validPurpose = PurposesSeeder.data.find((purpose) => {
-        return purpose.legacy_id === '200'
+        return purpose.legacyId === '200'
       })
-
-      console.log('i', invalidPrimaryPurpose, invalidSecondaryPurpose, invalidPurpose)
     })
 
     describe('but the primary purpose is not "P" (Production Of Energy)', () => {

--- a/test/models/licence-version-purpose.model.test.js
+++ b/test/models/licence-version-purpose.model.test.js
@@ -13,12 +13,9 @@ const LicenceVersionModel = require('../../app/models/licence-version.model.js')
 const LicenceVersionPurposeConditionHelper = require('../support/helpers/licence-version-purpose-condition.helper.js')
 const LicenceVersionPurposeConditionModel = require('../../app/models/licence-version-purpose-condition.model.js')
 const LicenceVersionPurposeHelper = require('../support/helpers/licence-version-purpose.helper.js')
-const PrimaryPurposeHelper = require('../support/helpers/primary-purpose.helper.js')
 const PrimaryPurposeModel = require('../../app/models/primary-purpose.model.js')
 const PrimaryPurposesSeeder = require('../support/seeders/primary-purpose.seeder.js')
-const PurposeHelper = require('../support/helpers/purpose.helper.js')
 const PurposeModel = require('../../app/models/purpose.model.js')
-const SecondaryPurposeHelper = require('../support/helpers/secondary-purpose.helper.js')
 const SecondaryPurposeModel = require('../../app/models/secondary-purpose.model.js')
 const SecondaryPurposeSeeder = require('../support/seeders/secondary-purpose.seeder.js')
 const PurposesSeeder = require('../support/seeders/purposes.seeder.js')
@@ -26,7 +23,7 @@ const PurposesSeeder = require('../support/seeders/purposes.seeder.js')
 // Thing under test
 const LicenceVersionPurposeModel = require('../../app/models/licence-version-purpose.model.js')
 
-describe.only('Licence Version Purposes model', () => {
+describe('Licence Version Purposes model', () => {
   let testRecord
   let secondaryPurposeId
   let primaryPurposeId
@@ -223,11 +220,19 @@ describe.only('Licence Version Purposes model', () => {
     beforeEach(() => {
       invalidPrimaryPurpose = PrimaryPurposesSeeder.data[0]
       invalidSecondaryPurpose = SecondaryPurposeSeeder.data[0]
-      invalidPurpose = PurposesSeeder.data.find((purpose) => { return purpose.legacy_id === '400' })
+      invalidPurpose = PurposesSeeder.data.find((purpose) => {
+        return purpose.legacy_id === '400'
+      })
 
-      validPrimaryPurpose = PrimaryPurposesSeeder.data.find(({ legacyId }) => { return legacyId === 'P' })
-      validSecondaryPurpose = SecondaryPurposeSeeder.data.find(({ legacyId }) => { return legacyId === 'ELC' })
-      validPurpose = PurposesSeeder.data.find((purpose) => { return purpose.legacy_id === '200' })
+      validPrimaryPurpose = PrimaryPurposesSeeder.data.find((primaryPurpose) => {
+        return primaryPurpose.legacy_id === 'P'
+      })
+      validSecondaryPurpose = SecondaryPurposeSeeder.data.find((secondaryPurpose) => {
+        return secondaryPurpose.legacy_id === 'ELC'
+      })
+      validPurpose = PurposesSeeder.data.find((purpose) => {
+        return purpose.legacy_id === '200'
+      })
 
       console.log('i', invalidPrimaryPurpose, invalidSecondaryPurpose, invalidPurpose)
     })

--- a/test/models/licence-version.model.test.js
+++ b/test/models/licence-version.model.test.js
@@ -13,8 +13,8 @@ const LicenceHelper = require('../support/helpers/licence.helper.js')
 const LicenceModel = require('../../app/models/licence.model.js')
 const LicenceVersionHelper = require('../support/helpers/licence-version.helper.js')
 const LicenceVersionPurposesHelper = require('../support/helpers/licence-version-purpose.helper.js')
-const PurposeHelper = require('../support/helpers/purpose.helper.js')
 const PurposeModel = require('../../app/models/purpose.model.js')
+const PurposesSeeder = require('../support/seeders/purposes.seeder.js')
 
 // Thing under test
 const LicenceVersionModel = require('../../app/models/licence-version.model.js')
@@ -45,6 +45,7 @@ describe('Licence Version model', () => {
         testLicence = await LicenceHelper.add()
 
         const { id: licenceId } = testLicence
+
         testRecord = await LicenceVersionHelper.add({ licenceId })
       })
 
@@ -73,9 +74,10 @@ describe('Licence Version model', () => {
 
       beforeEach(async () => {
         testRecord = await LicenceVersionHelper.add()
-        purpose = await PurposeHelper.add()
+        purpose = PurposesSeeder.data[0]
 
         const { id } = testRecord
+
         await LicenceVersionPurposesHelper.add({
           licenceVersionId: id,
           purposeId: purpose.id

--- a/test/models/primary-purpose.model.test.js
+++ b/test/models/primary-purpose.model.test.js
@@ -8,10 +8,9 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const DatabaseSupport = require('../support/database.js')
 const LicenceVersionPurposeHelper = require('../support/helpers/licence-version-purpose.helper.js')
 const LicenceVersionPurposeModel = require('../../app/models/licence-version-purpose.model.js')
-const PrimaryPurposeHelper = require('../support/helpers/primary-purpose.helper.js')
+const PrimaryPurposeHelper = require('../support/seeders/primary-purpose.seeder.js')
 const ReturnRequirementPurposeHelper = require('../support/helpers/return-requirement-purpose.helper.js')
 const ReturnRequirementPurposeModel = require('../../app/models/return-requirement-purpose.model.js')
 
@@ -21,13 +20,9 @@ const PrimaryPurposeModel = require('../../app/models/primary-purpose.model.js')
 describe('Primary Purpose model', () => {
   let testRecord
 
-  beforeEach(async () => {
-    await DatabaseSupport.clean()
-  })
-
   describe('Basic query', () => {
     beforeEach(async () => {
-      testRecord = await PrimaryPurposeHelper.add()
+      testRecord = PrimaryPurposeHelper.data[0]
     })
 
     it('can successfully run a basic query', async () => {
@@ -43,13 +38,14 @@ describe('Primary Purpose model', () => {
       let testLicenceVersionPurposes
 
       beforeEach(async () => {
-        testRecord = await PrimaryPurposeHelper.add()
+        testRecord = PrimaryPurposeHelper.data[0]
 
         testLicenceVersionPurposes = []
         for (let i = 0; i < 2; i++) {
           const licenceVersionPurpose = await LicenceVersionPurposeHelper.add({
             notes: `TEST licence Version purpose ${i}`, primaryPurposeId: testRecord.id
           })
+
           testLicenceVersionPurposes.push(licenceVersionPurpose)
         }
       })
@@ -80,13 +76,14 @@ describe('Primary Purpose model', () => {
       let testReturnRequirementPurposes
 
       beforeEach(async () => {
-        testRecord = await PrimaryPurposeHelper.add()
+        testRecord = PrimaryPurposeHelper.data[0]
 
         testReturnRequirementPurposes = []
         for (let i = 0; i < 2; i++) {
           const returnRequirementPurpose = await ReturnRequirementPurposeHelper.add({
             alias: `TEST return requirement purpose ${i}`, primaryPurposeId: testRecord.id
           })
+
           testReturnRequirementPurposes.push(returnRequirementPurpose)
         }
       })

--- a/test/models/purpose.model.test.js
+++ b/test/models/purpose.model.test.js
@@ -12,10 +12,9 @@ const ChargeElementHelper = require('../support/helpers/charge-element.helper.js
 const ChargeElementModel = require('../../app/models/charge-element.model.js')
 const ChargeReferenceHelper = require('../support/helpers/charge-reference.helper.js')
 const ChargeReferenceModel = require('../../app/models/charge-reference.model.js')
-const DatabaseSupport = require('../support/database.js')
 const LicenceVersionPurposeHelper = require('../support/helpers/licence-version-purpose.helper.js')
 const LicenceVersionPurposeModel = require('../../app/models/licence-version-purpose.model.js')
-const PurposeHelper = require('../support/helpers/purpose.helper.js')
+const PurposeSeeder = require('../support/seeders/purposes.seeder.js')
 const ReturnRequirementPurposeHelper = require('../support/helpers/return-requirement-purpose.helper.js')
 const ReturnRequirementPurposeModel = require('../../app/models/return-requirement-purpose.model.js')
 
@@ -25,13 +24,9 @@ const PurposeModel = require('../../app/models/purpose.model.js')
 describe('Purpose model', () => {
   let testRecord
 
-  beforeEach(async () => {
-    await DatabaseSupport.clean()
-  })
-
   describe('Basic query', () => {
     beforeEach(async () => {
-      testRecord = await PurposeHelper.add()
+      testRecord = PurposeSeeder.data[0]
     })
 
     it('can successfully run a basic query', async () => {
@@ -47,11 +42,12 @@ describe('Purpose model', () => {
       let testChargeElements
 
       beforeEach(async () => {
-        testRecord = await PurposeHelper.add()
+        testRecord = PurposeSeeder.data[0]
 
         testChargeElements = []
         for (let i = 0; i < 2; i++) {
           const chargeElement = await ChargeElementHelper.add({ purposeId: testRecord.id })
+
           testChargeElements.push(chargeElement)
         }
       })
@@ -82,11 +78,12 @@ describe('Purpose model', () => {
       let testChargeReferences
 
       beforeEach(async () => {
-        testRecord = await PurposeHelper.add()
+        testRecord = PurposeSeeder.data[0]
 
         testChargeReferences = []
         for (let i = 0; i < 2; i++) {
           const chargeReference = await ChargeReferenceHelper.add({ purposeId: testRecord.id })
+
           testChargeReferences.push(chargeReference)
         }
       })
@@ -117,11 +114,12 @@ describe('Purpose model', () => {
       let testLicenceVersionPurposes
 
       beforeEach(async () => {
-        testRecord = await PurposeHelper.add()
+        testRecord = PurposeSeeder.data[0]
 
         testLicenceVersionPurposes = []
         for (let i = 0; i < 2; i++) {
           const licenceVersionPurpose = await LicenceVersionPurposeHelper.add({ purposeId: testRecord.id })
+
           testLicenceVersionPurposes.push(licenceVersionPurpose)
         }
       })
@@ -152,11 +150,12 @@ describe('Purpose model', () => {
       let testReturnRequirementPurposes
 
       beforeEach(async () => {
-        testRecord = await PurposeHelper.add()
+        testRecord = PurposeSeeder.data[0]
 
         testReturnRequirementPurposes = []
         for (let i = 0; i < 2; i++) {
           const returnRequirementPurpose = await ReturnRequirementPurposeHelper.add({ purposeId: testRecord.id })
+
           testReturnRequirementPurposes.push(returnRequirementPurpose)
         }
       })

--- a/test/models/return-requirement-purpose.model.test.js
+++ b/test/models/return-requirement-purpose.model.test.js
@@ -8,26 +8,21 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const DatabaseSupport = require('../support/database.js')
-const PrimaryPurposeHelper = require('../support/helpers/primary-purpose.helper.js')
 const PrimaryPurposeModel = require('../../app/models/primary-purpose.model.js')
+const PrimaryPurposesSeeder = require('../support/seeders/primary-purpose.seeder.js')
 const PurposeModel = require('../../app/models/purpose.model.js')
-const PurposeHelper = require('../support/helpers/purpose.helper.js')
+const PurposesSeeder = require('../support/seeders/purposes.seeder.js')
 const ReturnRequirementHelper = require('../support/helpers/return-requirement.helper.js')
 const ReturnRequirementModel = require('../../app/models/return-requirement.model.js')
 const ReturnRequirementPurposeHelper = require('../support/helpers/return-requirement-purpose.helper.js')
-const SecondaryPurposeHelper = require('../support/helpers/secondary-purpose.helper.js')
 const SecondaryPurposeModel = require('../../app/models/secondary-purpose.model.js')
+const SecondaryPurposesSeeder = require('../support/seeders/secondary-purpose.seeder.js')
 
 // Thing under test
 const ReturnRequirementPurposeModel = require('../../app/models/return-requirement-purpose.model.js')
 
 describe('Return Requirement Purpose model', () => {
   let testRecord
-
-  beforeEach(async () => {
-    await DatabaseSupport.clean()
-  })
 
   describe('Basic query', () => {
     beforeEach(async () => {
@@ -47,10 +42,9 @@ describe('Return Requirement Purpose model', () => {
       let testPrimaryPurpose
 
       beforeEach(async () => {
-        testPrimaryPurpose = await PrimaryPurposeHelper.add()
+        testPrimaryPurpose = PrimaryPurposesSeeder.data[0]
 
-        const { id: primaryPurposeId } = testPrimaryPurpose
-        testRecord = await ReturnRequirementPurposeHelper.add({ primaryPurposeId })
+        testRecord = await ReturnRequirementPurposeHelper.add({ primaryPurposeId: testPrimaryPurpose.id })
       })
 
       it('can successfully run a related query', async () => {
@@ -77,9 +71,10 @@ describe('Return Requirement Purpose model', () => {
       let testPurpose
 
       beforeEach(async () => {
-        testPurpose = await PurposeHelper.add()
+        testPurpose = PurposesSeeder.data[0]
 
         const { id: purposeId } = testPurpose
+
         testRecord = await ReturnRequirementPurposeHelper.add({ purposeId })
       })
 
@@ -110,6 +105,7 @@ describe('Return Requirement Purpose model', () => {
         testReturnRequirement = await ReturnRequirementHelper.add()
 
         const { id: returnRequirementId } = testReturnRequirement
+
         testRecord = await ReturnRequirementPurposeHelper.add({ returnRequirementId })
       })
 
@@ -138,9 +134,10 @@ describe('Return Requirement Purpose model', () => {
     let testSecondaryPurpose
 
     beforeEach(async () => {
-      testSecondaryPurpose = await SecondaryPurposeHelper.add()
+      testSecondaryPurpose = SecondaryPurposesSeeder.data[0]
 
       const { id: secondaryPurposeId } = testSecondaryPurpose
+
       testRecord = await ReturnRequirementPurposeHelper.add({ secondaryPurposeId })
     })
 

--- a/test/models/secondary-purpose.model.test.js
+++ b/test/models/secondary-purpose.model.test.js
@@ -8,33 +8,24 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const DatabaseSupport = require('../support/database.js')
 const LicenceVersionPurposeHelper = require('../support/helpers/licence-version-purpose.helper.js')
 const LicenceVersionPurposeModel = require('../../app/models/licence-version-purpose.model.js')
 const ReturnRequirementPurposeHelper = require('../support/helpers/return-requirement-purpose.helper.js')
 const ReturnRequirementPurposeModel = require('../../app/models/return-requirement-purpose.model.js')
-const SecondaryPurposeHelper = require('../support/helpers/secondary-purpose.helper.js')
+const SecondaryPurposeSeeder = require('../support/seeders/secondary-purpose.seeder.js')
 
 // Thing under test
 const SecondaryPurposeModel = require('../../app/models/secondary-purpose.model.js')
 
 describe('Secondary Purpose model', () => {
-  let testRecord
-
-  beforeEach(async () => {
-    await DatabaseSupport.clean()
-  })
+  const testRecordId = SecondaryPurposeSeeder.data[0].id
 
   describe('Basic query', () => {
-    beforeEach(async () => {
-      testRecord = await SecondaryPurposeHelper.add()
-    })
-
     it('can successfully run a basic query', async () => {
-      const result = await SecondaryPurposeModel.query().findById(testRecord.id)
+      const result = await SecondaryPurposeModel.query().findById(testRecordId)
 
       expect(result).to.be.an.instanceOf(SecondaryPurposeModel)
-      expect(result.id).to.equal(testRecord.id)
+      expect(result.id).to.equal(testRecordId)
     })
   })
 
@@ -43,13 +34,12 @@ describe('Secondary Purpose model', () => {
       let testLicenceVersionPurposes
 
       beforeEach(async () => {
-        testRecord = await SecondaryPurposeHelper.add()
-
         testLicenceVersionPurposes = []
         for (let i = 0; i < 2; i++) {
           const licenceVersionPurpose = await LicenceVersionPurposeHelper.add({
-            notes: `TEST licence Version purpose ${i}`, secondaryPurposeId: testRecord.id
+            notes: `TEST licence Version purpose ${i}`, secondaryPurposeId: testRecordId
           })
+
           testLicenceVersionPurposes.push(licenceVersionPurpose)
         }
       })
@@ -63,11 +53,11 @@ describe('Secondary Purpose model', () => {
 
       it('can eager load the bill licences', async () => {
         const result = await SecondaryPurposeModel.query()
-          .findById(testRecord.id)
+          .findById(testRecordId)
           .withGraphFetched('licenceVersionPurposes')
 
         expect(result).to.be.instanceOf(SecondaryPurposeModel)
-        expect(result.id).to.equal(testRecord.id)
+        expect(result.id).to.equal(testRecordId)
 
         expect(result.licenceVersionPurposes).to.be.an.array()
         expect(result.licenceVersionPurposes[0]).to.be.an.instanceOf(LicenceVersionPurposeModel)
@@ -80,13 +70,12 @@ describe('Secondary Purpose model', () => {
       let testReturnRequirementPurposes
 
       beforeEach(async () => {
-        testRecord = await SecondaryPurposeHelper.add()
-
         testReturnRequirementPurposes = []
         for (let i = 0; i < 2; i++) {
           const returnRequirementPurpose = await ReturnRequirementPurposeHelper.add({
-            alias: `TEST return requirement purpose ${i}`, secondaryPurposeId: testRecord.id
+            alias: `TEST return requirement purpose ${i}`, secondaryPurposeId: testRecordId
           })
+
           testReturnRequirementPurposes.push(returnRequirementPurpose)
         }
       })
@@ -100,11 +89,11 @@ describe('Secondary Purpose model', () => {
 
       it('can eager load the bill licences', async () => {
         const result = await SecondaryPurposeModel.query()
-          .findById(testRecord.id)
+          .findById(testRecordId)
           .withGraphFetched('returnRequirementPurposes')
 
         expect(result).to.be.instanceOf(SecondaryPurposeModel)
-        expect(result.id).to.equal(testRecord.id)
+        expect(result.id).to.equal(testRecordId)
 
         expect(result.returnRequirementPurposes).to.be.an.array()
         expect(result.returnRequirementPurposes[0]).to.be.an.instanceOf(ReturnRequirementPurposeModel)

--- a/test/services/bill-licences/fetch-bill-licence.service.test.js
+++ b/test/services/bill-licences/fetch-bill-licence.service.test.js
@@ -9,17 +9,17 @@ const { expect } = Code
 
 // Test helpers
 const BillHelper = require('../../support/helpers/bill.helper.js')
-const BillModel = require('../../../app/models/bill.model.js')
 const BillLicenceHelper = require('../../support/helpers/bill-licence.helper.js')
 const BillLicenceModel = require('../../../app/models/bill-licence.model.js')
+const BillModel = require('../../../app/models/bill.model.js')
 const BillRunHelper = require('../../support/helpers/bill-run.helper.js')
 const BillRunModel = require('../../../app/models/bill-run.model.js')
 const ChargeElementHelper = require('../../support/helpers/charge-element.helper.js')
 const ChargeElementModel = require('../../../app/models/charge-element.model.js')
 const ChargeReferenceHelper = require('../../support/helpers/charge-reference.helper.js')
 const ChargeReferenceModel = require('../../../app/models/charge-reference.model.js')
-const PurposeHelper = require('../../support/helpers/purpose.helper.js')
 const PurposeModel = require('../../../app/models/purpose.model.js')
+const PurposeSeeder = require('../../support/seeders/purposes.seeder.js')
 const TransactionHelper = require('../../support/helpers/transaction.helper.js')
 const TransactionModel = require('../../../app/models/transaction.model.js')
 
@@ -91,9 +91,10 @@ describe('Fetch Bill Licence service', () => {
     describe('and it is for an SROC bill run', () => {
       beforeEach(async () => {
         linkedChargeReference = await ChargeReferenceHelper.add()
-        linkedPurpose = await PurposeHelper.add()
+        linkedPurpose = PurposeSeeder.data[0]
 
         const { id: chargeReferenceId } = linkedChargeReference
+
         await Promise.all([
           ChargeElementHelper.add({ chargeReferenceId, purposeId: linkedPurpose.id }),
           ChargeElementHelper.add({ chargeReferenceId, purposeId: linkedPurpose.id })
@@ -139,14 +140,17 @@ describe('Fetch Bill Licence service', () => {
 
         for (let i = 0; i < returnedTransactions.length; i++) {
           const { chargeReference: returnedChargeReference } = returnedTransactions[i]
+
           expect(returnedChargeReference.id).to.equal(linkedChargeReference.id)
           expect(returnedChargeReference).to.be.an.instanceOf(ChargeReferenceModel)
 
           const { chargeElements: returnedChargeElements } = returnedChargeReference
+
           expect(returnedChargeElements).to.have.length(2)
           expect(returnedChargeElements[0]).to.be.an.instanceOf(ChargeElementModel)
 
           const { purpose: returnedPurpose } = returnedChargeElements[0]
+
           expect(returnedPurpose.id).to.equal(linkedPurpose.id)
           expect(returnedPurpose).to.be.an.instanceOf(PurposeModel)
         }
@@ -155,7 +159,7 @@ describe('Fetch Bill Licence service', () => {
 
     describe('and it is for a PRESROC bill run', () => {
       beforeEach(async () => {
-        linkedPurpose = await PurposeHelper.add()
+        linkedPurpose = PurposeSeeder.data[0]
         linkedChargeReference = await ChargeReferenceHelper.add({ purposeId: linkedPurpose.id })
 
         const { id: chargeReferenceId } = linkedChargeReference
@@ -199,14 +203,17 @@ describe('Fetch Bill Licence service', () => {
 
         for (let i = 0; i < returnedTransactions.length; i++) {
           const { chargeReference: returnedChargeReference } = returnedTransactions[i]
+
           expect(returnedChargeReference.id).to.equal(linkedChargeReference.id)
           expect(returnedChargeReference).to.be.an.instanceOf(ChargeReferenceModel)
 
           const { purpose: returnedPurpose } = returnedChargeReference
+
           expect(returnedPurpose.id).to.equal(linkedPurpose.id)
           expect(returnedPurpose).to.be.an.instanceOf(PurposeModel)
 
           const { chargeElements: returnedChargeElements } = returnedChargeReference
+
           expect(returnedChargeElements).to.be.empty()
         }
       })

--- a/test/services/bill-runs/two-part-tariff/fetch-charge-versions.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/fetch-charge-versions.service.test.js
@@ -13,16 +13,16 @@ const ChargeCategoryHelper = require('../../../support/helpers/charge-category.h
 const ChargeElementHelper = require('../../../support/helpers/charge-element.helper.js')
 const ChargeReferenceHelper = require('../../../support/helpers/charge-reference.helper.js')
 const ChargeVersionHelper = require('../../../support/helpers/charge-version.helper.js')
-const WorkflowHelper = require('../../../support/helpers/workflow.helper.js')
 const DatabaseSupport = require('../../../support/database.js')
 const LicenceHelper = require('../../../support/helpers/licence.helper.js')
 const LicenceHolderSeeder = require('../../../support/seeders/licence-holder.seeder.js')
 const LicenceModel = require('../../../../app/models/licence.model.js')
-const PurposeHelper = require('../../../support/helpers/purpose.helper.js')
+const PurposeSeeder = require('../../../support/seeders/purposes.seeder.js')
 const RegionHelper = require('../../../support/helpers/region.helper.js')
+const WorkflowHelper = require('../../../support/helpers/workflow.helper.js')
 
 // Thing under test
-const FetchChargeVersionsService = require('../../../../app/services/bill-runs/two-part-tariff/fetch-charge-versions.service')
+const FetchChargeVersionsService = require('../../../../app/services/bill-runs/two-part-tariff/fetch-charge-versions.service.js')
 
 describe('Fetch Charge Versions service', () => {
   const billingPeriod = {
@@ -34,14 +34,19 @@ describe('Fetch Charge Versions service', () => {
 
   let chargeCategoryId
   let regionId
+  let purposeId
 
   beforeEach(async () => {
     await DatabaseSupport.clean()
 
+    purposeId = PurposeSeeder.data.find((purpose) => { return purpose.legacyId === '420' }).id
+
     const chargeCategory = await ChargeCategoryHelper.add({ reference: '4.3.41' })
+
     chargeCategoryId = chargeCategory.id
 
     const region = await RegionHelper.add()
+
     regionId = region.id
   })
 
@@ -64,9 +69,6 @@ describe('Fetch Charge Versions service', () => {
         chargeCategoryId,
         adjustments: { s127: true, aggregate: 0.562114443 }
       })
-
-      const purposeId = '4f300bf3-9d6d-44a2-ac76-ce3c02e7e81b'
-      await PurposeHelper.add({ id: purposeId, legacyId: '420' })
 
       await ChargeElementHelper.add({
         id: '1a966bd1-dbce-499d-ae94-b1d6ab72f0b2',
@@ -92,6 +94,7 @@ describe('Fetch Charge Versions service', () => {
         chargeCategoryId,
         adjustments: { s127: true }
       })
+
       await ChargeElementHelper.add({
         chargeReferenceId: chargeReference.id,
         authorisedAnnualQuantity: 100,
@@ -158,7 +161,7 @@ describe('Fetch Charge Versions service', () => {
               abstractionPeriodEndMonth: 3,
               authorisedAnnualQuantity: 200,
               purpose: {
-                id: '4f300bf3-9d6d-44a2-ac76-ce3c02e7e81b',
+                id: purposeId,
                 legacyId: '420',
                 description: 'Spray Irrigation - Storage'
               }
@@ -172,7 +175,7 @@ describe('Fetch Charge Versions service', () => {
               abstractionPeriodEndMonth: 3,
               authorisedAnnualQuantity: 100,
               purpose: {
-                id: '4f300bf3-9d6d-44a2-ac76-ce3c02e7e81b',
+                id: purposeId,
                 legacyId: '420',
                 description: 'Spray Irrigation - Storage'
               }

--- a/test/services/bill-runs/two-part-tariff/fetch-review-licence-results.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/fetch-review-licence-results.service.test.js
@@ -16,13 +16,13 @@ const ChargeReferenceHelper = require('../../../support/helpers/charge-reference
 const ChargeVersionHelper = require('../../../support/helpers/charge-version.helper.js')
 const DatabaseSupport = require('../../../support/database.js')
 const LicenceHelper = require('../../../support/helpers/licence.helper.js')
-const PurposeHelper = require('../../../support/helpers/purpose.helper.js')
+const PurposesSeeder = require('../../../support/seeders/purposes.seeder.js')
 const RegionHelper = require('../../../support/helpers/region.helper.js')
 const ReturnLogHelper = require('../../../support/helpers/return-log.helper.js')
-const ReviewChargeVersionHelper = require('../../../support/helpers/review-charge-version.helper.js')
 const ReviewChargeElementHelper = require('../../../support/helpers/review-charge-element.helper.js')
 const ReviewChargeElementReturnHelper = require('../../../support/helpers/review-charge-element-return.helper.js')
 const ReviewChargeReferenceHelper = require('../../../support/helpers/review-charge-reference.helper.js')
+const ReviewChargeVersionHelper = require('../../../support/helpers/review-charge-version.helper.js')
 const ReviewLicenceHelper = require('../../../support/helpers/review-licence.helper.js')
 const ReviewReturnHelper = require('../../../support/helpers/review-return.helper.js')
 
@@ -84,7 +84,7 @@ describe('Fetch Review Licence Results Service', () => {
           chargeReferenceId: chargeReference.id
         })
 
-        purpose = await PurposeHelper.add()
+        purpose = PurposesSeeder.data[0]
         chargeElement = await ChargeElementHelper.add({ chargeReferenceId: chargeReference.id, purposeId: purpose.id })
         reviewChargeElement = await ReviewChargeElementHelper.add({
           reviewChargeReferenceId: reviewChargeReference.id,

--- a/test/services/licences/fetch-licence-summary.service.test.js
+++ b/test/services/licences/fetch-licence-summary.service.test.js
@@ -9,17 +9,17 @@ const { expect } = Code
 
 // Test helpers
 const GaugingStationHelper = require('../../support/helpers/gauging-station.helper.js')
+const LicenceDocumentHeaderHelper = require('../../support/helpers/licence-document-header.helper.js')
 const LicenceEntityHelper = require('../../support/helpers/licence-entity.helper.js')
 const LicenceEntityRoleHelper = require('../../support/helpers/licence-entity-role.helper.js')
-const LicenceHelper = require('../../support/helpers/licence.helper.js')
-const LicenceDocumentHeaderHelper = require('../../support/helpers/licence-document-header.helper.js')
 const LicenceGaugingStationHelper = require('../../support/helpers/licence-gauging-station.helper.js')
+const LicenceHelper = require('../../support/helpers/licence.helper.js')
 const LicenceHolderSeeder = require('../../support/seeders/licence-holder.seeder.js')
 const LicenceVersionHelper = require('../../support/helpers/licence-version.helper.js')
-const LicenceVersionPurposeHelper = require('../../support/helpers/licence-version-purpose.helper.js')
 const LicenceVersionPurposeConditionHelper = require('../../support/helpers/licence-version-purpose-condition.helper.js')
-const PurposeHelper = require('../../support/helpers/purpose.helper.js')
+const LicenceVersionPurposeHelper = require('../../support/helpers/licence-version-purpose.helper.js')
 const PermitLicenceHelper = require('../../support/helpers/permit-licence.helper.js')
+const PurposeSeeder = require('../../support/seeders/purposes.seeder.js')
 const RegionHelper = require('../../support/helpers/region.helper.js')
 
 // Thing under test
@@ -55,7 +55,7 @@ describe('Fetch Licence Summary service', () => {
       licenceId: licence.id, startDate: new Date('2022-05-01')
     })
 
-    purpose = await PurposeHelper.add()
+    purpose = PurposeSeeder.data[0]
 
     licenceVersionPurpose = await LicenceVersionPurposeHelper.add({
       licenceVersionId: licenceVersion.id,
@@ -136,7 +136,7 @@ describe('Fetch Licence Summary service', () => {
               instantQuantity: null,
               purpose: {
                 id: purpose.id,
-                description: 'Spray Irrigation - Storage'
+                description: purpose.description
               },
               licenceVersionPurposeConditions: [{
                 id: licenceVersionPurposeCondition.id,

--- a/test/services/return-requirements/fetch-purposes.service.test.js
+++ b/test/services/return-requirements/fetch-purposes.service.test.js
@@ -10,7 +10,7 @@ const { expect } = Code
 // Test helpers
 const LicenceVersionHelper = require('../../support/helpers/licence-version.helper.js')
 const LicenceVersionPurposeHelper = require('../../support/helpers/licence-version-purpose.helper.js')
-const PurposeHelper = require('../../support/helpers/purpose.helper.js')
+const PurposesSeeder = require('../../support/seeders/purposes.seeder.js')
 
 // Thing under test
 const FetchPurposesService = require('../../../app/services/return-requirements/fetch-purposes.service.js')
@@ -23,13 +23,12 @@ describe('Return Requirements - Fetch Purposes service', () => {
     // Create the initial licenceVersion
     licenceVersion = await LicenceVersionHelper.add()
 
-    // Create 3 purposes. Note - we purposefully don't add them in alphabetical order so we can test they get sorted
-    // by the service
-    purposes = await Promise.all([
-      PurposeHelper.add({ description: 'Large Garden Watering' }),
-      PurposeHelper.add({ description: 'Heat Pump' }),
-      PurposeHelper.add({ description: 'Horticultural Watering' })
-    ])
+    // we purposefully don't add them in alphabetical order so we can test they get sorted by the service
+    purposes = [
+      { ...PurposesSeeder.data.find((purpose) => { return purpose.description === 'Large Garden Watering' }) },
+      { ...PurposesSeeder.data.find((purpose) => { return purpose.description === 'Heat Pump' }) },
+      { ...PurposesSeeder.data.find((purpose) => { return purpose.description === 'Horticultural Watering' }) }
+    ]
 
     // Create the licenceVersionPurposes. Note - two of them are for the same purpose. This is common in the service
     // where, for example, a licence might abstract water from 2 different points for the same purpose, but they were

--- a/test/services/return-requirements/setup/fetch-abstraction-data.service.test.js
+++ b/test/services/return-requirements/setup/fetch-abstraction-data.service.test.js
@@ -72,7 +72,7 @@ describe('Return Requirements - Fetch Abstraction Data service', () => {
                 dailyQuantity: 2675,
                 externalId: '1:10065381',
                 primaryPurpose: { id: seedIds.allPurposes.primaryPurposes.primaryAgricultureId, legacyId: 'A' },
-                purpose: { description: 'Vegetable washing', id: seedIds.allPurposes.purposes.vegetableWashingId, legacyId: '460', twoPartTariff: false },
+                purpose: { description: 'Vegetable Washing', id: seedIds.allPurposes.purposes.vegetableWashingId, legacyId: '460', twoPartTariff: false },
                 secondaryPurpose: { id: seedIds.allPurposes.secondaryPurposes.secondaryAgricultureId, legacyId: 'AGR' }
               },
               {

--- a/test/support/seeders/data/primary-purposes.js
+++ b/test/support/seeders/data/primary-purposes.js
@@ -1,0 +1,60 @@
+'use strict'
+
+module.exports = [
+  {
+    id: 'b6bb3b77-cfe8-4f22-8dc9-e92713ca3156',
+    legacy_id: 'A',
+    description: 'Agriculture',
+    created_at: '2023-12-14 14:00:08.855217',
+    updated_at: '2024-07-23 14:00:04.511591'
+  },
+  {
+    id: '3019b676-e8c6-4bc1-8336-b7862489af70',
+    legacy_id: 'E',
+    description: 'Environmental',
+    created_at: '2023-12-14 14:00:08.855217',
+    updated_at: '2024-07-23 14:00:04.511591'
+  },
+  {
+    id: 'd6259e5e-9bb4-4743-b565-e61ec05afc0a',
+    legacy_id: 'I',
+    description: 'Industrial, Commercial And Public Services',
+    created_at: '2023-12-14 14:00:08.855217',
+    updated_at: '2024-07-23 14:00:04.511591'
+  },
+  {
+    id: 'c096d17b-7369-4c6b-a230-fb0bc5109b9c',
+    legacy_id: 'M',
+    description: 'Amenity',
+    created_at: '2023-12-14 14:00:08.855217',
+    updated_at: '2024-07-23 14:00:04.511591'
+  },
+  {
+    id: '4bbc388a-38cf-425c-bf8f-d609e6a5f57a',
+    legacy_id: 'P',
+    description: 'Production Of Energy',
+    created_at: '2023-12-14 14:00:08.855217',
+    updated_at: '2024-07-23 14:00:04.511591'
+  },
+  {
+    id: '7cc6fa87-2e69-4cb3-9abb-a5700ec49b36',
+    legacy_id: 'W',
+    description: 'Water Supply',
+    created_at: '2023-12-14 14:00:08.855217',
+    updated_at: '2024-07-23 14:00:04.511591'
+  },
+  {
+    id: '6ad72bf8-ab8e-4fb6-99b0-f54a7acc3a53',
+    legacy_id: 'X',
+    description: 'Impounding',
+    created_at: '2023-12-14 14:00:08.855217',
+    updated_at: '2024-07-23 14:00:04.511591'
+  },
+  {
+    id: 'a38014a7-b8e3-4c3d-87b4-32ca1616d29b',
+    legacy_id: 'C',
+    description: 'Crown And Government',
+    created_at: '2023-12-14 14:00:08.855217',
+    updated_at: '2024-07-23 14:00:04.511591'
+  }
+]

--- a/test/support/seeders/data/primary-purposes.js
+++ b/test/support/seeders/data/primary-purposes.js
@@ -5,56 +5,56 @@ module.exports = [
     id: 'b6bb3b77-cfe8-4f22-8dc9-e92713ca3156',
     legacyId: 'A',
     description: 'Agriculture',
-    createdAt: '2023-12-14 14:00:08.855217',
-    updatedAt: '2024-07-23 14:00:04.511591'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: '3019b676-e8c6-4bc1-8336-b7862489af70',
     legacyId: 'E',
     description: 'Environmental',
-    createdAt: '2023-12-14 14:00:08.855217',
-    updatedAt: '2024-07-23 14:00:04.511591'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: 'd6259e5e-9bb4-4743-b565-e61ec05afc0a',
     legacyId: 'I',
     description: 'Industrial, Commercial And Public Services',
-    createdAt: '2023-12-14 14:00:08.855217',
-    updatedAt: '2024-07-23 14:00:04.511591'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: 'c096d17b-7369-4c6b-a230-fb0bc5109b9c',
     legacyId: 'M',
     description: 'Amenity',
-    createdAt: '2023-12-14 14:00:08.855217',
-    updatedAt: '2024-07-23 14:00:04.511591'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: '4bbc388a-38cf-425c-bf8f-d609e6a5f57a',
     legacyId: 'P',
     description: 'Production Of Energy',
-    createdAt: '2023-12-14 14:00:08.855217',
-    updatedAt: '2024-07-23 14:00:04.511591'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: '7cc6fa87-2e69-4cb3-9abb-a5700ec49b36',
     legacyId: 'W',
     description: 'Water Supply',
-    createdAt: '2023-12-14 14:00:08.855217',
-    updatedAt: '2024-07-23 14:00:04.511591'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: '6ad72bf8-ab8e-4fb6-99b0-f54a7acc3a53',
     legacyId: 'X',
     description: 'Impounding',
-    createdAt: '2023-12-14 14:00:08.855217',
-    updatedAt: '2024-07-23 14:00:04.511591'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: 'a38014a7-b8e3-4c3d-87b4-32ca1616d29b',
     legacyId: 'C',
     description: 'Crown And Government',
-    createdAt: '2023-12-14 14:00:08.855217',
-    updatedAt: '2024-07-23 14:00:04.511591'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   }
 ]

--- a/test/support/seeders/data/primary-purposes.js
+++ b/test/support/seeders/data/primary-purposes.js
@@ -3,58 +3,58 @@
 module.exports = [
   {
     id: 'b6bb3b77-cfe8-4f22-8dc9-e92713ca3156',
-    legacy_id: 'A',
+    legacyId: 'A',
     description: 'Agriculture',
-    created_at: '2023-12-14 14:00:08.855217',
-    updated_at: '2024-07-23 14:00:04.511591'
+    createdAt: '2023-12-14 14:00:08.855217',
+    updatedAt: '2024-07-23 14:00:04.511591'
   },
   {
     id: '3019b676-e8c6-4bc1-8336-b7862489af70',
-    legacy_id: 'E',
+    legacyId: 'E',
     description: 'Environmental',
-    created_at: '2023-12-14 14:00:08.855217',
-    updated_at: '2024-07-23 14:00:04.511591'
+    createdAt: '2023-12-14 14:00:08.855217',
+    updatedAt: '2024-07-23 14:00:04.511591'
   },
   {
     id: 'd6259e5e-9bb4-4743-b565-e61ec05afc0a',
-    legacy_id: 'I',
+    legacyId: 'I',
     description: 'Industrial, Commercial And Public Services',
-    created_at: '2023-12-14 14:00:08.855217',
-    updated_at: '2024-07-23 14:00:04.511591'
+    createdAt: '2023-12-14 14:00:08.855217',
+    updatedAt: '2024-07-23 14:00:04.511591'
   },
   {
     id: 'c096d17b-7369-4c6b-a230-fb0bc5109b9c',
-    legacy_id: 'M',
+    legacyId: 'M',
     description: 'Amenity',
-    created_at: '2023-12-14 14:00:08.855217',
-    updated_at: '2024-07-23 14:00:04.511591'
+    createdAt: '2023-12-14 14:00:08.855217',
+    updatedAt: '2024-07-23 14:00:04.511591'
   },
   {
     id: '4bbc388a-38cf-425c-bf8f-d609e6a5f57a',
-    legacy_id: 'P',
+    legacyId: 'P',
     description: 'Production Of Energy',
-    created_at: '2023-12-14 14:00:08.855217',
-    updated_at: '2024-07-23 14:00:04.511591'
+    createdAt: '2023-12-14 14:00:08.855217',
+    updatedAt: '2024-07-23 14:00:04.511591'
   },
   {
     id: '7cc6fa87-2e69-4cb3-9abb-a5700ec49b36',
-    legacy_id: 'W',
+    legacyId: 'W',
     description: 'Water Supply',
-    created_at: '2023-12-14 14:00:08.855217',
-    updated_at: '2024-07-23 14:00:04.511591'
+    createdAt: '2023-12-14 14:00:08.855217',
+    updatedAt: '2024-07-23 14:00:04.511591'
   },
   {
     id: '6ad72bf8-ab8e-4fb6-99b0-f54a7acc3a53',
-    legacy_id: 'X',
+    legacyId: 'X',
     description: 'Impounding',
-    created_at: '2023-12-14 14:00:08.855217',
-    updated_at: '2024-07-23 14:00:04.511591'
+    createdAt: '2023-12-14 14:00:08.855217',
+    updatedAt: '2024-07-23 14:00:04.511591'
   },
   {
     id: 'a38014a7-b8e3-4c3d-87b4-32ca1616d29b',
-    legacy_id: 'C',
+    legacyId: 'C',
     description: 'Crown And Government',
-    created_at: '2023-12-14 14:00:08.855217',
-    updated_at: '2024-07-23 14:00:04.511591'
+    createdAt: '2023-12-14 14:00:08.855217',
+    updatedAt: '2024-07-23 14:00:04.511591'
   }
 ]

--- a/test/support/seeders/data/purposes.data.js
+++ b/test/support/seeders/data/purposes.data.js
@@ -7,8 +7,8 @@ module.exports = [
     description: 'Animal Watering & General Use In Non Farming Situations',
     lossFactor: 'medium',
     twoPartTariff: false,
-    createdAt: '2023-12-14 14:00:08.862915',
-    updatedAt: '2024-07-22 14:00:08.035262'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: '59492ab7-a1a2-4cb3-b483-0dd6f9e45aec',
@@ -16,8 +16,8 @@ module.exports = [
     description: 'Boiler Feed',
     lossFactor: 'medium',
     twoPartTariff: false,
-    createdAt: '2023-12-14 14:00:08.862915',
-    updatedAt: '2024-07-22 14:00:08.035262'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: '464c1270-aa9a-48d9-9e96-2744d374f56c',
@@ -25,8 +25,8 @@ module.exports = [
     description: 'Conveying Materials',
     lossFactor: 'medium',
     twoPartTariff: false,
-    createdAt: '2023-12-14 14:00:08.862915',
-    updatedAt: '2024-07-22 14:00:08.035262'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: '7fb06487-8abc-4642-9ce5-80116b98ae12',
@@ -34,8 +34,8 @@ module.exports = [
     description: 'Drinking, Cooking, Sanitary, Washing, (Small Garden) - Commercial/Industrial/Public Services',
     lossFactor: 'medium',
     twoPartTariff: false,
-    createdAt: '2023-12-14 14:00:08.862915',
-    updatedAt: '2024-07-22 14:00:08.035262'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: 'dc0a1059-f6a9-4432-8408-fa32df710196',
@@ -43,8 +43,8 @@ module.exports = [
     description: 'Drinking, Cooking, Sanitary, Washing, (Small Garden) - Household',
     lossFactor: 'medium',
     twoPartTariff: false,
-    createdAt: '2023-12-14 14:00:08.862915',
-    updatedAt: '2024-07-22 14:00:08.035262'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: '8b17770a-ced1-475e-b0e2-ba4f3ebe262e',
@@ -52,8 +52,8 @@ module.exports = [
     description: 'Dust Suppression',
     lossFactor: 'high',
     twoPartTariff: false,
-    createdAt: '2023-12-14 14:00:08.862915',
-    updatedAt: '2024-07-22 14:00:08.035262'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: '0b65dc1a-8a40-453e-9a20-9a18acd19dc3',
@@ -61,8 +61,8 @@ module.exports = [
     description: 'Effluent/Slurry Dilution',
     lossFactor: 'very low',
     twoPartTariff: false,
-    createdAt: '2023-12-14 14:00:08.862915',
-    updatedAt: '2024-07-22 14:00:08.035262'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: '4e6d0ad8-7203-46f2-8d77-12110c85c3f8',
@@ -70,8 +70,8 @@ module.exports = [
     description: 'Evaporative Cooling',
     lossFactor: 'high',
     twoPartTariff: false,
-    createdAt: '2023-12-14 14:00:08.862915',
-    updatedAt: '2024-07-22 14:00:08.035262'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: 'a6dcf24c-7751-4f88-b772-af8c485b7f27',
@@ -79,8 +79,8 @@ module.exports = [
     description: 'Fish Farm/Cress Pond Throughflow',
     lossFactor: 'very low',
     twoPartTariff: false,
-    createdAt: '2023-12-14 14:00:08.862915',
-    updatedAt: '2024-07-22 14:00:08.035262'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: '92b555f8-ae9e-4257-bda2-87776a81c207',
@@ -88,8 +88,8 @@ module.exports = [
     description: 'Fish Pass/Canoe Pass',
     lossFactor: 'very low',
     twoPartTariff: false,
-    createdAt: '2023-12-14 14:00:08.862915',
-    updatedAt: '2024-07-22 14:00:08.035262'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: '9d9d9528-a992-424f-bdf4-f867d5639ea0',
@@ -97,8 +97,8 @@ module.exports = [
     description: 'Gas Suppression/Scrubbing',
     lossFactor: 'medium',
     twoPartTariff: false,
-    createdAt: '2023-12-14 14:00:08.862915',
-    updatedAt: '2024-07-22 14:00:08.035262'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: '06615efb-b13b-4d16-957c-6ab6cb779417',
@@ -106,8 +106,8 @@ module.exports = [
     description: 'General Cooling (Existing Licences Only) (High Loss)',
     lossFactor: 'high',
     twoPartTariff: false,
-    createdAt: '2023-12-14 14:00:08.862915',
-    updatedAt: '2024-07-22 14:00:08.035262'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: '6506f380-ca07-4fe0-aa10-bf17252cb065',
@@ -115,8 +115,8 @@ module.exports = [
     description: 'General Cooling (Existing Licences Only) (Low Loss)',
     lossFactor: 'low',
     twoPartTariff: false,
-    createdAt: '2023-12-14 14:00:08.862915',
-    updatedAt: '2024-07-22 14:00:08.035262'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: '289d1644-5215-4a20-af9e-5664fa9a18c7',
@@ -124,8 +124,8 @@ module.exports = [
     description: 'General Farming & Domestic',
     lossFactor: 'medium',
     twoPartTariff: false,
-    createdAt: '2023-12-14 14:00:08.862915',
-    updatedAt: '2024-07-22 14:00:08.035262'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: '019f30ab-ea80-48cf-a5fc-0b0642cef4d5',
@@ -133,8 +133,8 @@ module.exports = [
     description: 'General Use Relating To Secondary Category (High Loss)',
     lossFactor: 'high',
     twoPartTariff: false,
-    createdAt: '2023-12-14 14:00:08.862915',
-    updatedAt: '2024-07-22 14:00:08.035262'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: 'f48f5c29-8231-4552-bb98-3f04234ca6cb',
@@ -142,8 +142,8 @@ module.exports = [
     description: 'General Use Relating To Secondary Category (Medium Loss)',
     lossFactor: 'medium',
     twoPartTariff: false,
-    createdAt: '2023-12-14 14:00:08.862915',
-    updatedAt: '2024-07-22 14:00:08.035262'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: '8eff7b9a-7f62-40bc-8a86-91d38ed61b9a',
@@ -151,8 +151,8 @@ module.exports = [
     description: 'General Use Relating To Secondary Category (Low Loss)',
     lossFactor: 'low',
     twoPartTariff: false,
-    createdAt: '2023-12-14 14:00:08.862915',
-    updatedAt: '2024-07-22 14:00:08.035262'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: '73e8a003-279b-49a2-839b-adf9daae5e9a',
@@ -160,8 +160,8 @@ module.exports = [
     description: 'General Use Relating To Secondary Category (Very Low Loss)',
     lossFactor: 'very low',
     twoPartTariff: false,
-    createdAt: '2023-12-14 14:00:08.862915',
-    updatedAt: '2024-07-22 14:00:08.035262'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: 'e08d935b-2870-42ad-84c0-68103671d617',
@@ -169,8 +169,8 @@ module.exports = [
     description: 'General Washing/Process Washing',
     lossFactor: 'medium',
     twoPartTariff: false,
-    createdAt: '2023-12-14 14:00:08.862915',
-    updatedAt: '2024-07-22 14:00:08.035262'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: 'b18e9132-0efd-43e4-a318-b2e060f8bfb3',
@@ -178,8 +178,8 @@ module.exports = [
     description: 'Heat Pump',
     lossFactor: 'very low',
     twoPartTariff: false,
-    createdAt: '2023-12-14 14:00:08.862915',
-    updatedAt: '2024-07-22 14:00:08.035262'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: '3cd7606f-ffd1-4ae6-82a1-d76ea5261321',
@@ -187,8 +187,8 @@ module.exports = [
     description: 'Horticultural Watering',
     lossFactor: 'medium',
     twoPartTariff: false,
-    createdAt: '2023-12-14 14:00:08.862915',
-    updatedAt: '2024-07-22 14:00:08.035262'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: '60ab5147-577a-4722-b77f-0c6558b16817',
@@ -196,8 +196,8 @@ module.exports = [
     description: 'Hydraulic Rams',
     lossFactor: 'very low',
     twoPartTariff: false,
-    createdAt: '2023-12-14 14:00:08.862915',
-    updatedAt: '2024-07-22 14:00:08.035262'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: '7fa8eadc-ccfe-4a9d-b91f-0fecd8209140',
@@ -205,8 +205,8 @@ module.exports = [
     description: 'Hydraulic Testing',
     lossFactor: 'very low',
     twoPartTariff: false,
-    createdAt: '2023-12-14 14:00:08.862915',
-    updatedAt: '2024-07-22 14:00:08.035262'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: '54fc8048-733a-4f50-bd12-cc9f66da2c9b',
@@ -214,8 +214,8 @@ module.exports = [
     description: 'Hydroelectric Power Generation',
     lossFactor: 'very low',
     twoPartTariff: false,
-    createdAt: '2023-12-14 14:00:08.862915',
-    updatedAt: '2024-07-22 14:00:08.035262'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: '8a9f62ab-781f-4003-846a-b47f1b189fe7',
@@ -223,8 +223,8 @@ module.exports = [
     description: 'Lake & Pond Throughflow',
     lossFactor: 'very low',
     twoPartTariff: false,
-    createdAt: '2023-12-14 14:00:08.862915',
-    updatedAt: '2024-07-22 14:00:08.035262'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: '8780c9d2-cb49-4ffa-b846-09380adf278e',
@@ -232,8 +232,8 @@ module.exports = [
     description: 'Large Garden Watering',
     lossFactor: 'medium',
     twoPartTariff: false,
-    createdAt: '2023-12-14 14:00:08.862915',
-    updatedAt: '2024-07-22 14:00:08.035262'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: 'aa510d6e-f145-494b-918f-13b8b5500788',
@@ -241,8 +241,8 @@ module.exports = [
     description: 'Laundry Use',
     lossFactor: 'medium',
     twoPartTariff: false,
-    createdAt: '2023-12-14 14:00:08.862915',
-    updatedAt: '2024-07-22 14:00:08.035262'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: '681795bb-cf19-4b02-9fb0-e86b69b721e9',
@@ -250,8 +250,8 @@ module.exports = [
     description: 'Make-Up Or Top Up Water',
     lossFactor: 'high',
     twoPartTariff: false,
-    createdAt: '2023-12-14 14:00:08.862915',
-    updatedAt: '2024-07-22 14:00:08.035262'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: 'c0392edc-31aa-4f02-817d-4bde8c8d22a2',
@@ -259,8 +259,8 @@ module.exports = [
     description: 'Milling & Water Power Other Than Electricity Generation',
     lossFactor: 'very low',
     twoPartTariff: false,
-    createdAt: '2023-12-14 14:00:08.862915',
-    updatedAt: '2024-07-22 14:00:08.035262'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: 'ccb4cf71-028d-4567-80ec-e860cab7cd47',
@@ -268,8 +268,8 @@ module.exports = [
     description: 'Mineral Washing',
     lossFactor: 'low',
     twoPartTariff: false,
-    createdAt: '2023-12-14 14:00:08.862915',
-    updatedAt: '2024-07-22 14:00:08.035262'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: '09af974e-5162-41fd-b963-b97eb30fd084',
@@ -277,8 +277,8 @@ module.exports = [
     description: 'Non-Evaporative Cooling',
     lossFactor: 'low',
     twoPartTariff: false,
-    createdAt: '2023-12-14 14:00:08.862915',
-    updatedAt: '2024-07-22 14:00:08.035262'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: 'bd6d01a8-0d3a-4cc8-a56e-150a524e2956',
@@ -286,8 +286,8 @@ module.exports = [
     description: 'Pollution Remediation',
     lossFactor: 'very low',
     twoPartTariff: false,
-    createdAt: '2023-12-14 14:00:08.862915',
-    updatedAt: '2024-07-22 14:00:08.035262'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: '772136d1-9184-417b-90cd-91053287d1df',
@@ -295,8 +295,8 @@ module.exports = [
     description: 'Potable Water Supply - Direct',
     lossFactor: 'medium',
     twoPartTariff: false,
-    createdAt: '2023-12-14 14:00:08.862915',
-    updatedAt: '2024-07-22 14:00:08.035262'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: 'd45eb987-5f6d-48a7-9130-c2f0de0573c0',
@@ -304,8 +304,8 @@ module.exports = [
     description: 'Potable Water Supply - Storage',
     lossFactor: 'medium',
     twoPartTariff: false,
-    createdAt: '2023-12-14 14:00:08.862915',
-    updatedAt: '2024-07-22 14:00:08.035262'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: '2688807a-ee41-4f17-bcf2-816f3afa72dd',
@@ -313,8 +313,8 @@ module.exports = [
     description: 'Process Water',
     lossFactor: 'medium',
     twoPartTariff: false,
-    createdAt: '2023-12-14 14:00:08.862915',
-    updatedAt: '2024-07-22 14:00:08.035262'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: '286c222c-cf21-4103-9135-a22c1cf0cead',
@@ -322,8 +322,8 @@ module.exports = [
     description: 'Raw Water Supply',
     lossFactor: 'medium',
     twoPartTariff: false,
-    createdAt: '2023-12-14 14:00:08.862915',
-    updatedAt: '2024-07-22 14:00:08.035262'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: '7c4681d6-61e8-478f-97e0-90e0b22c0edd',
@@ -331,8 +331,8 @@ module.exports = [
     description: 'River Recirculation',
     lossFactor: 'very low',
     twoPartTariff: false,
-    createdAt: '2023-12-14 14:00:08.862915',
-    updatedAt: '2024-07-22 14:00:08.035262'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: 'a52dc94a-964a-47ac-b55a-2ef07aca7087',
@@ -340,8 +340,8 @@ module.exports = [
     description: 'Spray Irrigation - Anti Frost',
     lossFactor: 'medium',
     twoPartTariff: true,
-    createdAt: '2023-12-14 14:00:08.862915',
-    updatedAt: '2024-07-22 14:00:08.035262'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: '23f1626c-0afa-4a1d-86ae-3bc985049e03',
@@ -349,8 +349,8 @@ module.exports = [
     description: 'Spray Irrigation - Anti Frost Storage',
     lossFactor: 'medium',
     twoPartTariff: true,
-    createdAt: '2023-12-14 14:00:08.862915',
-    updatedAt: '2024-07-22 14:00:08.035262'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: '4ad11971-be6a-4da5-af04-563c76205b0e',
@@ -358,8 +358,8 @@ module.exports = [
     description: 'Spray Irrigation - Direct',
     lossFactor: 'high',
     twoPartTariff: true,
-    createdAt: '2023-12-14 14:00:08.862915',
-    updatedAt: '2024-07-22 14:00:08.035262'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: 'a3424107-ef96-47ac-be76-a8b86de3271a',
@@ -367,8 +367,8 @@ module.exports = [
     description: 'Spray Irrigation - Spray Irrigation Definition Order',
     lossFactor: 'high',
     twoPartTariff: true,
-    createdAt: '2023-12-14 14:00:08.862915',
-    updatedAt: '2024-07-22 14:00:08.035262'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: 'da576426-70bc-4f76-b05b-849bba48a8e8',
@@ -376,8 +376,8 @@ module.exports = [
     description: 'Spray Irrigation - Storage',
     lossFactor: 'high',
     twoPartTariff: true,
-    createdAt: '2023-12-14 14:00:08.862915',
-    updatedAt: '2024-07-22 14:00:08.035262'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: '68952835-592a-48e8-a6ea-b5ab0c71716d',
@@ -385,8 +385,8 @@ module.exports = [
     description: 'Supply To A Canal For Throughflow',
     lossFactor: 'very low',
     twoPartTariff: false,
-    createdAt: '2023-12-14 14:00:08.862915',
-    updatedAt: '2024-07-22 14:00:08.035262'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: 'bba3436e-3af9-40e4-9a56-aad81ae046ef',
@@ -394,8 +394,8 @@ module.exports = [
     description: 'Supply To A Leat For Throughflow',
     lossFactor: 'very low',
     twoPartTariff: false,
-    createdAt: '2023-12-14 14:00:08.862915',
-    updatedAt: '2024-07-22 14:00:08.035262'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: 'cb5273f5-1962-477c-9c23-bec96e1409ef',
@@ -403,8 +403,8 @@ module.exports = [
     description: 'Transfer Between Sources (Pre Water Act 2003)',
     lossFactor: 'very low',
     twoPartTariff: false,
-    createdAt: '2023-12-14 14:00:08.862915',
-    updatedAt: '2024-07-22 14:00:08.035262'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: '96218b0a-07cf-4a4c-85e7-204ccbe5a7e6',
@@ -412,8 +412,8 @@ module.exports = [
     description: 'Vegetable Washing',
     lossFactor: 'low',
     twoPartTariff: false,
-    createdAt: '2023-12-14 14:00:08.862915',
-    updatedAt: '2024-07-22 14:00:08.035262'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: '722b0f7b-4258-4b39-999c-8942a77371b4',
@@ -421,8 +421,8 @@ module.exports = [
     description: 'Water Bottling',
     lossFactor: 'medium',
     twoPartTariff: false,
-    createdAt: '2023-12-14 14:00:08.862915',
-    updatedAt: '2024-07-22 14:00:08.035262'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: 'e1d58b9b-cd4a-43a9-950e-c9244ab9ab0e',
@@ -430,8 +430,8 @@ module.exports = [
     description: 'Water Wheels Not Used For Power',
     lossFactor: 'very low',
     twoPartTariff: false,
-    createdAt: '2023-12-14 14:00:08.862915',
-    updatedAt: '2024-07-22 14:00:08.035262'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: 'a7bb7cbc-d417-4eaa-961b-4d8a75a5e1f9',
@@ -439,8 +439,8 @@ module.exports = [
     description: 'Impounding (for any purpose excluding impounding for HEP)',
     lossFactor: 'non-chargeable',
     twoPartTariff: false,
-    createdAt: '2023-12-14 14:00:08.862915',
-    updatedAt: '2024-07-22 14:00:08.035262'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: 'e4cabe35-e4f6-4d7d-855d-6d126f77b4fd',
@@ -448,8 +448,8 @@ module.exports = [
     description: 'Trickle Irrigation - Direct',
     lossFactor: 'high',
     twoPartTariff: true,
-    createdAt: '2023-12-14 14:00:08.862915',
-    updatedAt: '2024-07-22 14:00:08.035262'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: 'b6e13514-81da-4cfe-b6de-6a13a22e010e',
@@ -457,8 +457,8 @@ module.exports = [
     description: 'Trickle Irrigation - Under Cover/Containers',
     lossFactor: 'high',
     twoPartTariff: false,
-    createdAt: '2023-12-14 14:00:08.862915',
-    updatedAt: '2024-07-22 14:00:08.035262'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: '80c45e3e-8487-40e3-b661-834efedb3d15',
@@ -466,8 +466,8 @@ module.exports = [
     description: 'Trickle Irrigation - Storage',
     lossFactor: 'high',
     twoPartTariff: true,
-    createdAt: '2023-12-14 14:00:08.862915',
-    updatedAt: '2024-07-22 14:00:08.035262'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: '443e7f1a-6d1d-4193-989d-2c94fb4c9656',
@@ -475,8 +475,8 @@ module.exports = [
     description: 'Flood Irrigation, Including Water Meadows, Warping And Pest Control',
     lossFactor: 'very low',
     twoPartTariff: false,
-    createdAt: '2023-12-14 14:00:08.862915',
-    updatedAt: '2024-07-22 14:00:08.035262'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: 'ddcf9fe3-26b7-4ef2-8bf1-1226f11652be',
@@ -484,8 +484,8 @@ module.exports = [
     description: 'Wet Fencing And Nature Conservation',
     lossFactor: 'very low',
     twoPartTariff: false,
-    createdAt: '2023-12-14 14:00:08.862915',
-    updatedAt: '2024-07-22 14:00:08.035262'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: '96655751-b02c-42d8-a305-1859f9a17287',
@@ -493,8 +493,8 @@ module.exports = [
     description: 'Transfer Between Sources (Post Water Act 2003)',
     lossFactor: 'very low',
     twoPartTariff: false,
-    createdAt: '2023-12-14 14:00:08.862915',
-    updatedAt: '2024-07-22 14:00:08.035262'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: 'a7eb6005-fca6-416d-878a-52ac0ead9b6f',
@@ -502,8 +502,8 @@ module.exports = [
     description: 'Dewatering',
     lossFactor: 'very low',
     twoPartTariff: false,
-    createdAt: '2023-12-14 14:00:08.862915',
-    updatedAt: '2024-07-22 14:00:08.035262'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: '10e3bd38-15dc-41d7-a77b-153d6e3c7d1b',
@@ -511,8 +511,8 @@ module.exports = [
     description: 'Hydraulic Fracturing (Fracking)',
     lossFactor: 'high',
     twoPartTariff: false,
-    createdAt: '2023-12-14 14:00:08.862915',
-    updatedAt: '2024-07-22 14:00:08.035262'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: '6e4807d8-7d9d-4ff6-bdb2-b3b121077873',
@@ -520,7 +520,7 @@ module.exports = [
     description: 'Wet Fencing and Agriculture',
     lossFactor: 'very low',
     twoPartTariff: false,
-    createdAt: '2023-12-14 14:00:08.862915',
-    updatedAt: '2024-07-22 14:00:08.035262'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   }
 ]

--- a/test/support/seeders/data/purposes.data.js
+++ b/test/support/seeders/data/purposes.data.js
@@ -3,524 +3,524 @@
 module.exports = [
   {
     id: '64b8e40e-0d13-401e-90e1-0e498cda9fcb',
-    legacy_id: '10',
+    legacyId: '10',
     description: 'Animal Watering & General Use In Non Farming Situations',
-    loss_factor: 'medium',
-    two_part_tariff: false,
-    created_at: '2023-12-14 14:00:08.862915',
-    updated_at: '2024-07-22 14:00:08.035262'
+    lossFactor: 'medium',
+    twoPartTariff: false,
+    createdAt: '2023-12-14 14:00:08.862915',
+    updatedAt: '2024-07-22 14:00:08.035262'
   },
   {
     id: '59492ab7-a1a2-4cb3-b483-0dd6f9e45aec',
-    legacy_id: '20',
+    legacyId: '20',
     description: 'Boiler Feed',
-    loss_factor: 'medium',
-    two_part_tariff: false,
-    created_at: '2023-12-14 14:00:08.862915',
-    updated_at: '2024-07-22 14:00:08.035262'
+    lossFactor: 'medium',
+    twoPartTariff: false,
+    createdAt: '2023-12-14 14:00:08.862915',
+    updatedAt: '2024-07-22 14:00:08.035262'
   },
   {
     id: '464c1270-aa9a-48d9-9e96-2744d374f56c',
-    legacy_id: '30',
+    legacyId: '30',
     description: 'Conveying Materials',
-    loss_factor: 'medium',
-    two_part_tariff: false,
-    created_at: '2023-12-14 14:00:08.862915',
-    updated_at: '2024-07-22 14:00:08.035262'
+    lossFactor: 'medium',
+    twoPartTariff: false,
+    createdAt: '2023-12-14 14:00:08.862915',
+    updatedAt: '2024-07-22 14:00:08.035262'
   },
   {
     id: '7fb06487-8abc-4642-9ce5-80116b98ae12',
-    legacy_id: '40',
+    legacyId: '40',
     description: 'Drinking, Cooking, Sanitary, Washing, (Small Garden) - Commercial/Industrial/Public Services',
-    loss_factor: 'medium',
-    two_part_tariff: false,
-    created_at: '2023-12-14 14:00:08.862915',
-    updated_at: '2024-07-22 14:00:08.035262'
+    lossFactor: 'medium',
+    twoPartTariff: false,
+    createdAt: '2023-12-14 14:00:08.862915',
+    updatedAt: '2024-07-22 14:00:08.035262'
   },
   {
     id: 'dc0a1059-f6a9-4432-8408-fa32df710196',
-    legacy_id: '50',
+    legacyId: '50',
     description: 'Drinking, Cooking, Sanitary, Washing, (Small Garden) - Household',
-    loss_factor: 'medium',
-    two_part_tariff: false,
-    created_at: '2023-12-14 14:00:08.862915',
-    updated_at: '2024-07-22 14:00:08.035262'
+    lossFactor: 'medium',
+    twoPartTariff: false,
+    createdAt: '2023-12-14 14:00:08.862915',
+    updatedAt: '2024-07-22 14:00:08.035262'
   },
   {
     id: '8b17770a-ced1-475e-b0e2-ba4f3ebe262e',
-    legacy_id: '60',
+    legacyId: '60',
     description: 'Dust Suppression',
-    loss_factor: 'high',
-    two_part_tariff: false,
-    created_at: '2023-12-14 14:00:08.862915',
-    updated_at: '2024-07-22 14:00:08.035262'
+    lossFactor: 'high',
+    twoPartTariff: false,
+    createdAt: '2023-12-14 14:00:08.862915',
+    updatedAt: '2024-07-22 14:00:08.035262'
   },
   {
     id: '0b65dc1a-8a40-453e-9a20-9a18acd19dc3',
-    legacy_id: '70',
+    legacyId: '70',
     description: 'Effluent/Slurry Dilution',
-    loss_factor: 'very low',
-    two_part_tariff: false,
-    created_at: '2023-12-14 14:00:08.862915',
-    updated_at: '2024-07-22 14:00:08.035262'
+    lossFactor: 'very low',
+    twoPartTariff: false,
+    createdAt: '2023-12-14 14:00:08.862915',
+    updatedAt: '2024-07-22 14:00:08.035262'
   },
   {
     id: '4e6d0ad8-7203-46f2-8d77-12110c85c3f8',
-    legacy_id: '80',
+    legacyId: '80',
     description: 'Evaporative Cooling',
-    loss_factor: 'high',
-    two_part_tariff: false,
-    created_at: '2023-12-14 14:00:08.862915',
-    updated_at: '2024-07-22 14:00:08.035262'
+    lossFactor: 'high',
+    twoPartTariff: false,
+    createdAt: '2023-12-14 14:00:08.862915',
+    updatedAt: '2024-07-22 14:00:08.035262'
   },
   {
     id: 'a6dcf24c-7751-4f88-b772-af8c485b7f27',
-    legacy_id: '90',
+    legacyId: '90',
     description: 'Fish Farm/Cress Pond Throughflow',
-    loss_factor: 'very low',
-    two_part_tariff: false,
-    created_at: '2023-12-14 14:00:08.862915',
-    updated_at: '2024-07-22 14:00:08.035262'
+    lossFactor: 'very low',
+    twoPartTariff: false,
+    createdAt: '2023-12-14 14:00:08.862915',
+    updatedAt: '2024-07-22 14:00:08.035262'
   },
   {
     id: '92b555f8-ae9e-4257-bda2-87776a81c207',
-    legacy_id: '100',
+    legacyId: '100',
     description: 'Fish Pass/Canoe Pass',
-    loss_factor: 'very low',
-    two_part_tariff: false,
-    created_at: '2023-12-14 14:00:08.862915',
-    updated_at: '2024-07-22 14:00:08.035262'
+    lossFactor: 'very low',
+    twoPartTariff: false,
+    createdAt: '2023-12-14 14:00:08.862915',
+    updatedAt: '2024-07-22 14:00:08.035262'
   },
   {
     id: '9d9d9528-a992-424f-bdf4-f867d5639ea0',
-    legacy_id: '110',
+    legacyId: '110',
     description: 'Gas Suppression/Scrubbing',
-    loss_factor: 'medium',
-    two_part_tariff: false,
-    created_at: '2023-12-14 14:00:08.862915',
-    updated_at: '2024-07-22 14:00:08.035262'
+    lossFactor: 'medium',
+    twoPartTariff: false,
+    createdAt: '2023-12-14 14:00:08.862915',
+    updatedAt: '2024-07-22 14:00:08.035262'
   },
   {
     id: '06615efb-b13b-4d16-957c-6ab6cb779417',
-    legacy_id: '120',
+    legacyId: '120',
     description: 'General Cooling (Existing Licences Only) (High Loss)',
-    loss_factor: 'high',
-    two_part_tariff: false,
-    created_at: '2023-12-14 14:00:08.862915',
-    updated_at: '2024-07-22 14:00:08.035262'
+    lossFactor: 'high',
+    twoPartTariff: false,
+    createdAt: '2023-12-14 14:00:08.862915',
+    updatedAt: '2024-07-22 14:00:08.035262'
   },
   {
     id: '6506f380-ca07-4fe0-aa10-bf17252cb065',
-    legacy_id: '130',
+    legacyId: '130',
     description: 'General Cooling (Existing Licences Only) (Low Loss)',
-    loss_factor: 'low',
-    two_part_tariff: false,
-    created_at: '2023-12-14 14:00:08.862915',
-    updated_at: '2024-07-22 14:00:08.035262'
+    lossFactor: 'low',
+    twoPartTariff: false,
+    createdAt: '2023-12-14 14:00:08.862915',
+    updatedAt: '2024-07-22 14:00:08.035262'
   },
   {
     id: '289d1644-5215-4a20-af9e-5664fa9a18c7',
-    legacy_id: '140',
+    legacyId: '140',
     description: 'General Farming & Domestic',
-    loss_factor: 'medium',
-    two_part_tariff: false,
-    created_at: '2023-12-14 14:00:08.862915',
-    updated_at: '2024-07-22 14:00:08.035262'
+    lossFactor: 'medium',
+    twoPartTariff: false,
+    createdAt: '2023-12-14 14:00:08.862915',
+    updatedAt: '2024-07-22 14:00:08.035262'
   },
   {
     id: '019f30ab-ea80-48cf-a5fc-0b0642cef4d5',
-    legacy_id: '150',
+    legacyId: '150',
     description: 'General Use Relating To Secondary Category (High Loss)',
-    loss_factor: 'high',
-    two_part_tariff: false,
-    created_at: '2023-12-14 14:00:08.862915',
-    updated_at: '2024-07-22 14:00:08.035262'
+    lossFactor: 'high',
+    twoPartTariff: false,
+    createdAt: '2023-12-14 14:00:08.862915',
+    updatedAt: '2024-07-22 14:00:08.035262'
   },
   {
     id: 'f48f5c29-8231-4552-bb98-3f04234ca6cb',
-    legacy_id: '160',
+    legacyId: '160',
     description: 'General Use Relating To Secondary Category (Medium Loss)',
-    loss_factor: 'medium',
-    two_part_tariff: false,
-    created_at: '2023-12-14 14:00:08.862915',
-    updated_at: '2024-07-22 14:00:08.035262'
+    lossFactor: 'medium',
+    twoPartTariff: false,
+    createdAt: '2023-12-14 14:00:08.862915',
+    updatedAt: '2024-07-22 14:00:08.035262'
   },
   {
     id: '8eff7b9a-7f62-40bc-8a86-91d38ed61b9a',
-    legacy_id: '170',
+    legacyId: '170',
     description: 'General Use Relating To Secondary Category (Low Loss)',
-    loss_factor: 'low',
-    two_part_tariff: false,
-    created_at: '2023-12-14 14:00:08.862915',
-    updated_at: '2024-07-22 14:00:08.035262'
+    lossFactor: 'low',
+    twoPartTariff: false,
+    createdAt: '2023-12-14 14:00:08.862915',
+    updatedAt: '2024-07-22 14:00:08.035262'
   },
   {
     id: '73e8a003-279b-49a2-839b-adf9daae5e9a',
-    legacy_id: '180',
+    legacyId: '180',
     description: 'General Use Relating To Secondary Category (Very Low Loss)',
-    loss_factor: 'very low',
-    two_part_tariff: false,
-    created_at: '2023-12-14 14:00:08.862915',
-    updated_at: '2024-07-22 14:00:08.035262'
+    lossFactor: 'very low',
+    twoPartTariff: false,
+    createdAt: '2023-12-14 14:00:08.862915',
+    updatedAt: '2024-07-22 14:00:08.035262'
   },
   {
     id: 'e08d935b-2870-42ad-84c0-68103671d617',
-    legacy_id: '190',
+    legacyId: '190',
     description: 'General Washing/Process Washing',
-    loss_factor: 'medium',
-    two_part_tariff: false,
-    created_at: '2023-12-14 14:00:08.862915',
-    updated_at: '2024-07-22 14:00:08.035262'
+    lossFactor: 'medium',
+    twoPartTariff: false,
+    createdAt: '2023-12-14 14:00:08.862915',
+    updatedAt: '2024-07-22 14:00:08.035262'
   },
   {
     id: 'b18e9132-0efd-43e4-a318-b2e060f8bfb3',
-    legacy_id: '200',
+    legacyId: '200',
     description: 'Heat Pump',
-    loss_factor: 'very low',
-    two_part_tariff: false,
-    created_at: '2023-12-14 14:00:08.862915',
-    updated_at: '2024-07-22 14:00:08.035262'
+    lossFactor: 'very low',
+    twoPartTariff: false,
+    createdAt: '2023-12-14 14:00:08.862915',
+    updatedAt: '2024-07-22 14:00:08.035262'
   },
   {
     id: '3cd7606f-ffd1-4ae6-82a1-d76ea5261321',
-    legacy_id: '210',
+    legacyId: '210',
     description: 'Horticultural Watering',
-    loss_factor: 'medium',
-    two_part_tariff: false,
-    created_at: '2023-12-14 14:00:08.862915',
-    updated_at: '2024-07-22 14:00:08.035262'
+    lossFactor: 'medium',
+    twoPartTariff: false,
+    createdAt: '2023-12-14 14:00:08.862915',
+    updatedAt: '2024-07-22 14:00:08.035262'
   },
   {
     id: '60ab5147-577a-4722-b77f-0c6558b16817',
-    legacy_id: '220',
+    legacyId: '220',
     description: 'Hydraulic Rams',
-    loss_factor: 'very low',
-    two_part_tariff: false,
-    created_at: '2023-12-14 14:00:08.862915',
-    updated_at: '2024-07-22 14:00:08.035262'
+    lossFactor: 'very low',
+    twoPartTariff: false,
+    createdAt: '2023-12-14 14:00:08.862915',
+    updatedAt: '2024-07-22 14:00:08.035262'
   },
   {
     id: '7fa8eadc-ccfe-4a9d-b91f-0fecd8209140',
-    legacy_id: '230',
+    legacyId: '230',
     description: 'Hydraulic Testing',
-    loss_factor: 'very low',
-    two_part_tariff: false,
-    created_at: '2023-12-14 14:00:08.862915',
-    updated_at: '2024-07-22 14:00:08.035262'
+    lossFactor: 'very low',
+    twoPartTariff: false,
+    createdAt: '2023-12-14 14:00:08.862915',
+    updatedAt: '2024-07-22 14:00:08.035262'
   },
   {
     id: '54fc8048-733a-4f50-bd12-cc9f66da2c9b',
-    legacy_id: '240',
+    legacyId: '240',
     description: 'Hydroelectric Power Generation',
-    loss_factor: 'very low',
-    two_part_tariff: false,
-    created_at: '2023-12-14 14:00:08.862915',
-    updated_at: '2024-07-22 14:00:08.035262'
+    lossFactor: 'very low',
+    twoPartTariff: false,
+    createdAt: '2023-12-14 14:00:08.862915',
+    updatedAt: '2024-07-22 14:00:08.035262'
   },
   {
     id: '8a9f62ab-781f-4003-846a-b47f1b189fe7',
-    legacy_id: '250',
+    legacyId: '250',
     description: 'Lake & Pond Throughflow',
-    loss_factor: 'very low',
-    two_part_tariff: false,
-    created_at: '2023-12-14 14:00:08.862915',
-    updated_at: '2024-07-22 14:00:08.035262'
+    lossFactor: 'very low',
+    twoPartTariff: false,
+    createdAt: '2023-12-14 14:00:08.862915',
+    updatedAt: '2024-07-22 14:00:08.035262'
   },
   {
     id: '8780c9d2-cb49-4ffa-b846-09380adf278e',
-    legacy_id: '260',
+    legacyId: '260',
     description: 'Large Garden Watering',
-    loss_factor: 'medium',
-    two_part_tariff: false,
-    created_at: '2023-12-14 14:00:08.862915',
-    updated_at: '2024-07-22 14:00:08.035262'
+    lossFactor: 'medium',
+    twoPartTariff: false,
+    createdAt: '2023-12-14 14:00:08.862915',
+    updatedAt: '2024-07-22 14:00:08.035262'
   },
   {
     id: 'aa510d6e-f145-494b-918f-13b8b5500788',
-    legacy_id: '270',
+    legacyId: '270',
     description: 'Laundry Use',
-    loss_factor: 'medium',
-    two_part_tariff: false,
-    created_at: '2023-12-14 14:00:08.862915',
-    updated_at: '2024-07-22 14:00:08.035262'
+    lossFactor: 'medium',
+    twoPartTariff: false,
+    createdAt: '2023-12-14 14:00:08.862915',
+    updatedAt: '2024-07-22 14:00:08.035262'
   },
   {
     id: '681795bb-cf19-4b02-9fb0-e86b69b721e9',
-    legacy_id: '280',
+    legacyId: '280',
     description: 'Make-Up Or Top Up Water',
-    loss_factor: 'high',
-    two_part_tariff: false,
-    created_at: '2023-12-14 14:00:08.862915',
-    updated_at: '2024-07-22 14:00:08.035262'
+    lossFactor: 'high',
+    twoPartTariff: false,
+    createdAt: '2023-12-14 14:00:08.862915',
+    updatedAt: '2024-07-22 14:00:08.035262'
   },
   {
     id: 'c0392edc-31aa-4f02-817d-4bde8c8d22a2',
-    legacy_id: '290',
+    legacyId: '290',
     description: 'Milling & Water Power Other Than Electricity Generation',
-    loss_factor: 'very low',
-    two_part_tariff: false,
-    created_at: '2023-12-14 14:00:08.862915',
-    updated_at: '2024-07-22 14:00:08.035262'
+    lossFactor: 'very low',
+    twoPartTariff: false,
+    createdAt: '2023-12-14 14:00:08.862915',
+    updatedAt: '2024-07-22 14:00:08.035262'
   },
   {
     id: 'ccb4cf71-028d-4567-80ec-e860cab7cd47',
-    legacy_id: '300',
+    legacyId: '300',
     description: 'Mineral Washing',
-    loss_factor: 'low',
-    two_part_tariff: false,
-    created_at: '2023-12-14 14:00:08.862915',
-    updated_at: '2024-07-22 14:00:08.035262'
+    lossFactor: 'low',
+    twoPartTariff: false,
+    createdAt: '2023-12-14 14:00:08.862915',
+    updatedAt: '2024-07-22 14:00:08.035262'
   },
   {
     id: '09af974e-5162-41fd-b963-b97eb30fd084',
-    legacy_id: '310',
+    legacyId: '310',
     description: 'Non-Evaporative Cooling',
-    loss_factor: 'low',
-    two_part_tariff: false,
-    created_at: '2023-12-14 14:00:08.862915',
-    updated_at: '2024-07-22 14:00:08.035262'
+    lossFactor: 'low',
+    twoPartTariff: false,
+    createdAt: '2023-12-14 14:00:08.862915',
+    updatedAt: '2024-07-22 14:00:08.035262'
   },
   {
     id: 'bd6d01a8-0d3a-4cc8-a56e-150a524e2956',
-    legacy_id: '320',
+    legacyId: '320',
     description: 'Pollution Remediation',
-    loss_factor: 'very low',
-    two_part_tariff: false,
-    created_at: '2023-12-14 14:00:08.862915',
-    updated_at: '2024-07-22 14:00:08.035262'
+    lossFactor: 'very low',
+    twoPartTariff: false,
+    createdAt: '2023-12-14 14:00:08.862915',
+    updatedAt: '2024-07-22 14:00:08.035262'
   },
   {
     id: '772136d1-9184-417b-90cd-91053287d1df',
-    legacy_id: '330',
+    legacyId: '330',
     description: 'Potable Water Supply - Direct',
-    loss_factor: 'medium',
-    two_part_tariff: false,
-    created_at: '2023-12-14 14:00:08.862915',
-    updated_at: '2024-07-22 14:00:08.035262'
+    lossFactor: 'medium',
+    twoPartTariff: false,
+    createdAt: '2023-12-14 14:00:08.862915',
+    updatedAt: '2024-07-22 14:00:08.035262'
   },
   {
     id: 'd45eb987-5f6d-48a7-9130-c2f0de0573c0',
-    legacy_id: '340',
+    legacyId: '340',
     description: 'Potable Water Supply - Storage',
-    loss_factor: 'medium',
-    two_part_tariff: false,
-    created_at: '2023-12-14 14:00:08.862915',
-    updated_at: '2024-07-22 14:00:08.035262'
+    lossFactor: 'medium',
+    twoPartTariff: false,
+    createdAt: '2023-12-14 14:00:08.862915',
+    updatedAt: '2024-07-22 14:00:08.035262'
   },
   {
     id: '2688807a-ee41-4f17-bcf2-816f3afa72dd',
-    legacy_id: '350',
+    legacyId: '350',
     description: 'Process Water',
-    loss_factor: 'medium',
-    two_part_tariff: false,
-    created_at: '2023-12-14 14:00:08.862915',
-    updated_at: '2024-07-22 14:00:08.035262'
+    lossFactor: 'medium',
+    twoPartTariff: false,
+    createdAt: '2023-12-14 14:00:08.862915',
+    updatedAt: '2024-07-22 14:00:08.035262'
   },
   {
     id: '286c222c-cf21-4103-9135-a22c1cf0cead',
-    legacy_id: '360',
+    legacyId: '360',
     description: 'Raw Water Supply',
-    loss_factor: 'medium',
-    two_part_tariff: false,
-    created_at: '2023-12-14 14:00:08.862915',
-    updated_at: '2024-07-22 14:00:08.035262'
+    lossFactor: 'medium',
+    twoPartTariff: false,
+    createdAt: '2023-12-14 14:00:08.862915',
+    updatedAt: '2024-07-22 14:00:08.035262'
   },
   {
     id: '7c4681d6-61e8-478f-97e0-90e0b22c0edd',
-    legacy_id: '370',
+    legacyId: '370',
     description: 'River Recirculation',
-    loss_factor: 'very low',
-    two_part_tariff: false,
-    created_at: '2023-12-14 14:00:08.862915',
-    updated_at: '2024-07-22 14:00:08.035262'
+    lossFactor: 'very low',
+    twoPartTariff: false,
+    createdAt: '2023-12-14 14:00:08.862915',
+    updatedAt: '2024-07-22 14:00:08.035262'
   },
   {
     id: 'a52dc94a-964a-47ac-b55a-2ef07aca7087',
-    legacy_id: '380',
+    legacyId: '380',
     description: 'Spray Irrigation - Anti Frost',
-    loss_factor: 'medium',
-    two_part_tariff: true,
-    created_at: '2023-12-14 14:00:08.862915',
-    updated_at: '2024-07-22 14:00:08.035262'
+    lossFactor: 'medium',
+    twoPartTariff: true,
+    createdAt: '2023-12-14 14:00:08.862915',
+    updatedAt: '2024-07-22 14:00:08.035262'
   },
   {
     id: '23f1626c-0afa-4a1d-86ae-3bc985049e03',
-    legacy_id: '390',
+    legacyId: '390',
     description: 'Spray Irrigation - Anti Frost Storage',
-    loss_factor: 'medium',
-    two_part_tariff: true,
-    created_at: '2023-12-14 14:00:08.862915',
-    updated_at: '2024-07-22 14:00:08.035262'
+    lossFactor: 'medium',
+    twoPartTariff: true,
+    createdAt: '2023-12-14 14:00:08.862915',
+    updatedAt: '2024-07-22 14:00:08.035262'
   },
   {
     id: '4ad11971-be6a-4da5-af04-563c76205b0e',
-    legacy_id: '400',
+    legacyId: '400',
     description: 'Spray Irrigation - Direct',
-    loss_factor: 'high',
-    two_part_tariff: true,
-    created_at: '2023-12-14 14:00:08.862915',
-    updated_at: '2024-07-22 14:00:08.035262'
+    lossFactor: 'high',
+    twoPartTariff: true,
+    createdAt: '2023-12-14 14:00:08.862915',
+    updatedAt: '2024-07-22 14:00:08.035262'
   },
   {
     id: 'a3424107-ef96-47ac-be76-a8b86de3271a',
-    legacy_id: '410',
+    legacyId: '410',
     description: 'Spray Irrigation - Spray Irrigation Definition Order',
-    loss_factor: 'high',
-    two_part_tariff: true,
-    created_at: '2023-12-14 14:00:08.862915',
-    updated_at: '2024-07-22 14:00:08.035262'
+    lossFactor: 'high',
+    twoPartTariff: true,
+    createdAt: '2023-12-14 14:00:08.862915',
+    updatedAt: '2024-07-22 14:00:08.035262'
   },
   {
     id: 'da576426-70bc-4f76-b05b-849bba48a8e8',
-    legacy_id: '420',
+    legacyId: '420',
     description: 'Spray Irrigation - Storage',
-    loss_factor: 'high',
-    two_part_tariff: true,
-    created_at: '2023-12-14 14:00:08.862915',
-    updated_at: '2024-07-22 14:00:08.035262'
+    lossFactor: 'high',
+    twoPartTariff: true,
+    createdAt: '2023-12-14 14:00:08.862915',
+    updatedAt: '2024-07-22 14:00:08.035262'
   },
   {
     id: '68952835-592a-48e8-a6ea-b5ab0c71716d',
-    legacy_id: '430',
+    legacyId: '430',
     description: 'Supply To A Canal For Throughflow',
-    loss_factor: 'very low',
-    two_part_tariff: false,
-    created_at: '2023-12-14 14:00:08.862915',
-    updated_at: '2024-07-22 14:00:08.035262'
+    lossFactor: 'very low',
+    twoPartTariff: false,
+    createdAt: '2023-12-14 14:00:08.862915',
+    updatedAt: '2024-07-22 14:00:08.035262'
   },
   {
     id: 'bba3436e-3af9-40e4-9a56-aad81ae046ef',
-    legacy_id: '440',
+    legacyId: '440',
     description: 'Supply To A Leat For Throughflow',
-    loss_factor: 'very low',
-    two_part_tariff: false,
-    created_at: '2023-12-14 14:00:08.862915',
-    updated_at: '2024-07-22 14:00:08.035262'
+    lossFactor: 'very low',
+    twoPartTariff: false,
+    createdAt: '2023-12-14 14:00:08.862915',
+    updatedAt: '2024-07-22 14:00:08.035262'
   },
   {
     id: 'cb5273f5-1962-477c-9c23-bec96e1409ef',
-    legacy_id: '450',
+    legacyId: '450',
     description: 'Transfer Between Sources (Pre Water Act 2003)',
-    loss_factor: 'very low',
-    two_part_tariff: false,
-    created_at: '2023-12-14 14:00:08.862915',
-    updated_at: '2024-07-22 14:00:08.035262'
+    lossFactor: 'very low',
+    twoPartTariff: false,
+    createdAt: '2023-12-14 14:00:08.862915',
+    updatedAt: '2024-07-22 14:00:08.035262'
   },
   {
     id: '96218b0a-07cf-4a4c-85e7-204ccbe5a7e6',
-    legacy_id: '460',
+    legacyId: '460',
     description: 'Vegetable Washing',
-    loss_factor: 'low',
-    two_part_tariff: false,
-    created_at: '2023-12-14 14:00:08.862915',
-    updated_at: '2024-07-22 14:00:08.035262'
+    lossFactor: 'low',
+    twoPartTariff: false,
+    createdAt: '2023-12-14 14:00:08.862915',
+    updatedAt: '2024-07-22 14:00:08.035262'
   },
   {
     id: '722b0f7b-4258-4b39-999c-8942a77371b4',
-    legacy_id: '470',
+    legacyId: '470',
     description: 'Water Bottling',
-    loss_factor: 'medium',
-    two_part_tariff: false,
-    created_at: '2023-12-14 14:00:08.862915',
-    updated_at: '2024-07-22 14:00:08.035262'
+    lossFactor: 'medium',
+    twoPartTariff: false,
+    createdAt: '2023-12-14 14:00:08.862915',
+    updatedAt: '2024-07-22 14:00:08.035262'
   },
   {
     id: 'e1d58b9b-cd4a-43a9-950e-c9244ab9ab0e',
-    legacy_id: '480',
+    legacyId: '480',
     description: 'Water Wheels Not Used For Power',
-    loss_factor: 'very low',
-    two_part_tariff: false,
-    created_at: '2023-12-14 14:00:08.862915',
-    updated_at: '2024-07-22 14:00:08.035262'
+    lossFactor: 'very low',
+    twoPartTariff: false,
+    createdAt: '2023-12-14 14:00:08.862915',
+    updatedAt: '2024-07-22 14:00:08.035262'
   },
   {
     id: 'a7bb7cbc-d417-4eaa-961b-4d8a75a5e1f9',
-    legacy_id: '490',
+    legacyId: '490',
     description: 'Impounding (for any purpose excluding impounding for HEP)',
-    loss_factor: 'non-chargeable',
-    two_part_tariff: false,
-    created_at: '2023-12-14 14:00:08.862915',
-    updated_at: '2024-07-22 14:00:08.035262'
+    lossFactor: 'non-chargeable',
+    twoPartTariff: false,
+    createdAt: '2023-12-14 14:00:08.862915',
+    updatedAt: '2024-07-22 14:00:08.035262'
   },
   {
     id: 'e4cabe35-e4f6-4d7d-855d-6d126f77b4fd',
-    legacy_id: '600',
+    legacyId: '600',
     description: 'Trickle Irrigation - Direct',
-    loss_factor: 'high',
-    two_part_tariff: true,
-    created_at: '2023-12-14 14:00:08.862915',
-    updated_at: '2024-07-22 14:00:08.035262'
+    lossFactor: 'high',
+    twoPartTariff: true,
+    createdAt: '2023-12-14 14:00:08.862915',
+    updatedAt: '2024-07-22 14:00:08.035262'
   },
   {
     id: 'b6e13514-81da-4cfe-b6de-6a13a22e010e',
-    legacy_id: '610',
+    legacyId: '610',
     description: 'Trickle Irrigation - Under Cover/Containers',
-    loss_factor: 'high',
-    two_part_tariff: false,
-    created_at: '2023-12-14 14:00:08.862915',
-    updated_at: '2024-07-22 14:00:08.035262'
+    lossFactor: 'high',
+    twoPartTariff: false,
+    createdAt: '2023-12-14 14:00:08.862915',
+    updatedAt: '2024-07-22 14:00:08.035262'
   },
   {
     id: '80c45e3e-8487-40e3-b661-834efedb3d15',
-    legacy_id: '620',
+    legacyId: '620',
     description: 'Trickle Irrigation - Storage',
-    loss_factor: 'high',
-    two_part_tariff: true,
-    created_at: '2023-12-14 14:00:08.862915',
-    updated_at: '2024-07-22 14:00:08.035262'
+    lossFactor: 'high',
+    twoPartTariff: true,
+    createdAt: '2023-12-14 14:00:08.862915',
+    updatedAt: '2024-07-22 14:00:08.035262'
   },
   {
     id: '443e7f1a-6d1d-4193-989d-2c94fb4c9656',
-    legacy_id: '630',
+    legacyId: '630',
     description: 'Flood Irrigation, Including Water Meadows, Warping And Pest Control',
-    loss_factor: 'very low',
-    two_part_tariff: false,
-    created_at: '2023-12-14 14:00:08.862915',
-    updated_at: '2024-07-22 14:00:08.035262'
+    lossFactor: 'very low',
+    twoPartTariff: false,
+    createdAt: '2023-12-14 14:00:08.862915',
+    updatedAt: '2024-07-22 14:00:08.035262'
   },
   {
     id: 'ddcf9fe3-26b7-4ef2-8bf1-1226f11652be',
-    legacy_id: '640',
+    legacyId: '640',
     description: 'Wet Fencing And Nature Conservation',
-    loss_factor: 'very low',
-    two_part_tariff: false,
-    created_at: '2023-12-14 14:00:08.862915',
-    updated_at: '2024-07-22 14:00:08.035262'
+    lossFactor: 'very low',
+    twoPartTariff: false,
+    createdAt: '2023-12-14 14:00:08.862915',
+    updatedAt: '2024-07-22 14:00:08.035262'
   },
   {
     id: '96655751-b02c-42d8-a305-1859f9a17287',
-    legacy_id: '650',
+    legacyId: '650',
     description: 'Transfer Between Sources (Post Water Act 2003)',
-    loss_factor: 'very low',
-    two_part_tariff: false,
-    created_at: '2023-12-14 14:00:08.862915',
-    updated_at: '2024-07-22 14:00:08.035262'
+    lossFactor: 'very low',
+    twoPartTariff: false,
+    createdAt: '2023-12-14 14:00:08.862915',
+    updatedAt: '2024-07-22 14:00:08.035262'
   },
   {
     id: 'a7eb6005-fca6-416d-878a-52ac0ead9b6f',
-    legacy_id: '660',
+    legacyId: '660',
     description: 'Dewatering',
-    loss_factor: 'very low',
-    two_part_tariff: false,
-    created_at: '2023-12-14 14:00:08.862915',
-    updated_at: '2024-07-22 14:00:08.035262'
+    lossFactor: 'very low',
+    twoPartTariff: false,
+    createdAt: '2023-12-14 14:00:08.862915',
+    updatedAt: '2024-07-22 14:00:08.035262'
   },
   {
     id: '10e3bd38-15dc-41d7-a77b-153d6e3c7d1b',
-    legacy_id: '670',
+    legacyId: '670',
     description: 'Hydraulic Fracturing (Fracking)',
-    loss_factor: 'high',
-    two_part_tariff: false,
-    created_at: '2023-12-14 14:00:08.862915',
-    updated_at: '2024-07-22 14:00:08.035262'
+    lossFactor: 'high',
+    twoPartTariff: false,
+    createdAt: '2023-12-14 14:00:08.862915',
+    updatedAt: '2024-07-22 14:00:08.035262'
   },
   {
     id: '6e4807d8-7d9d-4ff6-bdb2-b3b121077873',
-    legacy_id: '645',
+    legacyId: '645',
     description: 'Wet Fencing and Agriculture',
-    loss_factor: 'very low',
-    two_part_tariff: false,
-    created_at: '2023-12-14 14:00:08.862915',
-    updated_at: '2024-07-22 14:00:08.035262'
+    lossFactor: 'very low',
+    twoPartTariff: false,
+    createdAt: '2023-12-14 14:00:08.862915',
+    updatedAt: '2024-07-22 14:00:08.035262'
   }
 ]

--- a/test/support/seeders/data/purposes.data.js
+++ b/test/support/seeders/data/purposes.data.js
@@ -1,0 +1,526 @@
+'use strict'
+
+module.exports = [
+  {
+    id: '64b8e40e-0d13-401e-90e1-0e498cda9fcb',
+    legacy_id: '10',
+    description: 'Animal Watering & General Use In Non Farming Situations',
+    loss_factor: 'medium',
+    two_part_tariff: false,
+    created_at: '2023-12-14 14:00:08.862915',
+    updated_at: '2024-07-22 14:00:08.035262'
+  },
+  {
+    id: '59492ab7-a1a2-4cb3-b483-0dd6f9e45aec',
+    legacy_id: '20',
+    description: 'Boiler Feed',
+    loss_factor: 'medium',
+    two_part_tariff: false,
+    created_at: '2023-12-14 14:00:08.862915',
+    updated_at: '2024-07-22 14:00:08.035262'
+  },
+  {
+    id: '464c1270-aa9a-48d9-9e96-2744d374f56c',
+    legacy_id: '30',
+    description: 'Conveying Materials',
+    loss_factor: 'medium',
+    two_part_tariff: false,
+    created_at: '2023-12-14 14:00:08.862915',
+    updated_at: '2024-07-22 14:00:08.035262'
+  },
+  {
+    id: '7fb06487-8abc-4642-9ce5-80116b98ae12',
+    legacy_id: '40',
+    description: 'Drinking, Cooking, Sanitary, Washing, (Small Garden) - Commercial/Industrial/Public Services',
+    loss_factor: 'medium',
+    two_part_tariff: false,
+    created_at: '2023-12-14 14:00:08.862915',
+    updated_at: '2024-07-22 14:00:08.035262'
+  },
+  {
+    id: 'dc0a1059-f6a9-4432-8408-fa32df710196',
+    legacy_id: '50',
+    description: 'Drinking, Cooking, Sanitary, Washing, (Small Garden) - Household',
+    loss_factor: 'medium',
+    two_part_tariff: false,
+    created_at: '2023-12-14 14:00:08.862915',
+    updated_at: '2024-07-22 14:00:08.035262'
+  },
+  {
+    id: '8b17770a-ced1-475e-b0e2-ba4f3ebe262e',
+    legacy_id: '60',
+    description: 'Dust Suppression',
+    loss_factor: 'high',
+    two_part_tariff: false,
+    created_at: '2023-12-14 14:00:08.862915',
+    updated_at: '2024-07-22 14:00:08.035262'
+  },
+  {
+    id: '0b65dc1a-8a40-453e-9a20-9a18acd19dc3',
+    legacy_id: '70',
+    description: 'Effluent/Slurry Dilution',
+    loss_factor: 'very low',
+    two_part_tariff: false,
+    created_at: '2023-12-14 14:00:08.862915',
+    updated_at: '2024-07-22 14:00:08.035262'
+  },
+  {
+    id: '4e6d0ad8-7203-46f2-8d77-12110c85c3f8',
+    legacy_id: '80',
+    description: 'Evaporative Cooling',
+    loss_factor: 'high',
+    two_part_tariff: false,
+    created_at: '2023-12-14 14:00:08.862915',
+    updated_at: '2024-07-22 14:00:08.035262'
+  },
+  {
+    id: 'a6dcf24c-7751-4f88-b772-af8c485b7f27',
+    legacy_id: '90',
+    description: 'Fish Farm/Cress Pond Throughflow',
+    loss_factor: 'very low',
+    two_part_tariff: false,
+    created_at: '2023-12-14 14:00:08.862915',
+    updated_at: '2024-07-22 14:00:08.035262'
+  },
+  {
+    id: '92b555f8-ae9e-4257-bda2-87776a81c207',
+    legacy_id: '100',
+    description: 'Fish Pass/Canoe Pass',
+    loss_factor: 'very low',
+    two_part_tariff: false,
+    created_at: '2023-12-14 14:00:08.862915',
+    updated_at: '2024-07-22 14:00:08.035262'
+  },
+  {
+    id: '9d9d9528-a992-424f-bdf4-f867d5639ea0',
+    legacy_id: '110',
+    description: 'Gas Suppression/Scrubbing',
+    loss_factor: 'medium',
+    two_part_tariff: false,
+    created_at: '2023-12-14 14:00:08.862915',
+    updated_at: '2024-07-22 14:00:08.035262'
+  },
+  {
+    id: '06615efb-b13b-4d16-957c-6ab6cb779417',
+    legacy_id: '120',
+    description: 'General Cooling (Existing Licences Only) (High Loss)',
+    loss_factor: 'high',
+    two_part_tariff: false,
+    created_at: '2023-12-14 14:00:08.862915',
+    updated_at: '2024-07-22 14:00:08.035262'
+  },
+  {
+    id: '6506f380-ca07-4fe0-aa10-bf17252cb065',
+    legacy_id: '130',
+    description: 'General Cooling (Existing Licences Only) (Low Loss)',
+    loss_factor: 'low',
+    two_part_tariff: false,
+    created_at: '2023-12-14 14:00:08.862915',
+    updated_at: '2024-07-22 14:00:08.035262'
+  },
+  {
+    id: '289d1644-5215-4a20-af9e-5664fa9a18c7',
+    legacy_id: '140',
+    description: 'General Farming & Domestic',
+    loss_factor: 'medium',
+    two_part_tariff: false,
+    created_at: '2023-12-14 14:00:08.862915',
+    updated_at: '2024-07-22 14:00:08.035262'
+  },
+  {
+    id: '019f30ab-ea80-48cf-a5fc-0b0642cef4d5',
+    legacy_id: '150',
+    description: 'General Use Relating To Secondary Category (High Loss)',
+    loss_factor: 'high',
+    two_part_tariff: false,
+    created_at: '2023-12-14 14:00:08.862915',
+    updated_at: '2024-07-22 14:00:08.035262'
+  },
+  {
+    id: 'f48f5c29-8231-4552-bb98-3f04234ca6cb',
+    legacy_id: '160',
+    description: 'General Use Relating To Secondary Category (Medium Loss)',
+    loss_factor: 'medium',
+    two_part_tariff: false,
+    created_at: '2023-12-14 14:00:08.862915',
+    updated_at: '2024-07-22 14:00:08.035262'
+  },
+  {
+    id: '8eff7b9a-7f62-40bc-8a86-91d38ed61b9a',
+    legacy_id: '170',
+    description: 'General Use Relating To Secondary Category (Low Loss)',
+    loss_factor: 'low',
+    two_part_tariff: false,
+    created_at: '2023-12-14 14:00:08.862915',
+    updated_at: '2024-07-22 14:00:08.035262'
+  },
+  {
+    id: '73e8a003-279b-49a2-839b-adf9daae5e9a',
+    legacy_id: '180',
+    description: 'General Use Relating To Secondary Category (Very Low Loss)',
+    loss_factor: 'very low',
+    two_part_tariff: false,
+    created_at: '2023-12-14 14:00:08.862915',
+    updated_at: '2024-07-22 14:00:08.035262'
+  },
+  {
+    id: 'e08d935b-2870-42ad-84c0-68103671d617',
+    legacy_id: '190',
+    description: 'General Washing/Process Washing',
+    loss_factor: 'medium',
+    two_part_tariff: false,
+    created_at: '2023-12-14 14:00:08.862915',
+    updated_at: '2024-07-22 14:00:08.035262'
+  },
+  {
+    id: 'b18e9132-0efd-43e4-a318-b2e060f8bfb3',
+    legacy_id: '200',
+    description: 'Heat Pump',
+    loss_factor: 'very low',
+    two_part_tariff: false,
+    created_at: '2023-12-14 14:00:08.862915',
+    updated_at: '2024-07-22 14:00:08.035262'
+  },
+  {
+    id: '3cd7606f-ffd1-4ae6-82a1-d76ea5261321',
+    legacy_id: '210',
+    description: 'Horticultural Watering',
+    loss_factor: 'medium',
+    two_part_tariff: false,
+    created_at: '2023-12-14 14:00:08.862915',
+    updated_at: '2024-07-22 14:00:08.035262'
+  },
+  {
+    id: '60ab5147-577a-4722-b77f-0c6558b16817',
+    legacy_id: '220',
+    description: 'Hydraulic Rams',
+    loss_factor: 'very low',
+    two_part_tariff: false,
+    created_at: '2023-12-14 14:00:08.862915',
+    updated_at: '2024-07-22 14:00:08.035262'
+  },
+  {
+    id: '7fa8eadc-ccfe-4a9d-b91f-0fecd8209140',
+    legacy_id: '230',
+    description: 'Hydraulic Testing',
+    loss_factor: 'very low',
+    two_part_tariff: false,
+    created_at: '2023-12-14 14:00:08.862915',
+    updated_at: '2024-07-22 14:00:08.035262'
+  },
+  {
+    id: '54fc8048-733a-4f50-bd12-cc9f66da2c9b',
+    legacy_id: '240',
+    description: 'Hydroelectric Power Generation',
+    loss_factor: 'very low',
+    two_part_tariff: false,
+    created_at: '2023-12-14 14:00:08.862915',
+    updated_at: '2024-07-22 14:00:08.035262'
+  },
+  {
+    id: '8a9f62ab-781f-4003-846a-b47f1b189fe7',
+    legacy_id: '250',
+    description: 'Lake & Pond Throughflow',
+    loss_factor: 'very low',
+    two_part_tariff: false,
+    created_at: '2023-12-14 14:00:08.862915',
+    updated_at: '2024-07-22 14:00:08.035262'
+  },
+  {
+    id: '8780c9d2-cb49-4ffa-b846-09380adf278e',
+    legacy_id: '260',
+    description: 'Large Garden Watering',
+    loss_factor: 'medium',
+    two_part_tariff: false,
+    created_at: '2023-12-14 14:00:08.862915',
+    updated_at: '2024-07-22 14:00:08.035262'
+  },
+  {
+    id: 'aa510d6e-f145-494b-918f-13b8b5500788',
+    legacy_id: '270',
+    description: 'Laundry Use',
+    loss_factor: 'medium',
+    two_part_tariff: false,
+    created_at: '2023-12-14 14:00:08.862915',
+    updated_at: '2024-07-22 14:00:08.035262'
+  },
+  {
+    id: '681795bb-cf19-4b02-9fb0-e86b69b721e9',
+    legacy_id: '280',
+    description: 'Make-Up Or Top Up Water',
+    loss_factor: 'high',
+    two_part_tariff: false,
+    created_at: '2023-12-14 14:00:08.862915',
+    updated_at: '2024-07-22 14:00:08.035262'
+  },
+  {
+    id: 'c0392edc-31aa-4f02-817d-4bde8c8d22a2',
+    legacy_id: '290',
+    description: 'Milling & Water Power Other Than Electricity Generation',
+    loss_factor: 'very low',
+    two_part_tariff: false,
+    created_at: '2023-12-14 14:00:08.862915',
+    updated_at: '2024-07-22 14:00:08.035262'
+  },
+  {
+    id: 'ccb4cf71-028d-4567-80ec-e860cab7cd47',
+    legacy_id: '300',
+    description: 'Mineral Washing',
+    loss_factor: 'low',
+    two_part_tariff: false,
+    created_at: '2023-12-14 14:00:08.862915',
+    updated_at: '2024-07-22 14:00:08.035262'
+  },
+  {
+    id: '09af974e-5162-41fd-b963-b97eb30fd084',
+    legacy_id: '310',
+    description: 'Non-Evaporative Cooling',
+    loss_factor: 'low',
+    two_part_tariff: false,
+    created_at: '2023-12-14 14:00:08.862915',
+    updated_at: '2024-07-22 14:00:08.035262'
+  },
+  {
+    id: 'bd6d01a8-0d3a-4cc8-a56e-150a524e2956',
+    legacy_id: '320',
+    description: 'Pollution Remediation',
+    loss_factor: 'very low',
+    two_part_tariff: false,
+    created_at: '2023-12-14 14:00:08.862915',
+    updated_at: '2024-07-22 14:00:08.035262'
+  },
+  {
+    id: '772136d1-9184-417b-90cd-91053287d1df',
+    legacy_id: '330',
+    description: 'Potable Water Supply - Direct',
+    loss_factor: 'medium',
+    two_part_tariff: false,
+    created_at: '2023-12-14 14:00:08.862915',
+    updated_at: '2024-07-22 14:00:08.035262'
+  },
+  {
+    id: 'd45eb987-5f6d-48a7-9130-c2f0de0573c0',
+    legacy_id: '340',
+    description: 'Potable Water Supply - Storage',
+    loss_factor: 'medium',
+    two_part_tariff: false,
+    created_at: '2023-12-14 14:00:08.862915',
+    updated_at: '2024-07-22 14:00:08.035262'
+  },
+  {
+    id: '2688807a-ee41-4f17-bcf2-816f3afa72dd',
+    legacy_id: '350',
+    description: 'Process Water',
+    loss_factor: 'medium',
+    two_part_tariff: false,
+    created_at: '2023-12-14 14:00:08.862915',
+    updated_at: '2024-07-22 14:00:08.035262'
+  },
+  {
+    id: '286c222c-cf21-4103-9135-a22c1cf0cead',
+    legacy_id: '360',
+    description: 'Raw Water Supply',
+    loss_factor: 'medium',
+    two_part_tariff: false,
+    created_at: '2023-12-14 14:00:08.862915',
+    updated_at: '2024-07-22 14:00:08.035262'
+  },
+  {
+    id: '7c4681d6-61e8-478f-97e0-90e0b22c0edd',
+    legacy_id: '370',
+    description: 'River Recirculation',
+    loss_factor: 'very low',
+    two_part_tariff: false,
+    created_at: '2023-12-14 14:00:08.862915',
+    updated_at: '2024-07-22 14:00:08.035262'
+  },
+  {
+    id: 'a52dc94a-964a-47ac-b55a-2ef07aca7087',
+    legacy_id: '380',
+    description: 'Spray Irrigation - Anti Frost',
+    loss_factor: 'medium',
+    two_part_tariff: true,
+    created_at: '2023-12-14 14:00:08.862915',
+    updated_at: '2024-07-22 14:00:08.035262'
+  },
+  {
+    id: '23f1626c-0afa-4a1d-86ae-3bc985049e03',
+    legacy_id: '390',
+    description: 'Spray Irrigation - Anti Frost Storage',
+    loss_factor: 'medium',
+    two_part_tariff: true,
+    created_at: '2023-12-14 14:00:08.862915',
+    updated_at: '2024-07-22 14:00:08.035262'
+  },
+  {
+    id: '4ad11971-be6a-4da5-af04-563c76205b0e',
+    legacy_id: '400',
+    description: 'Spray Irrigation - Direct',
+    loss_factor: 'high',
+    two_part_tariff: true,
+    created_at: '2023-12-14 14:00:08.862915',
+    updated_at: '2024-07-22 14:00:08.035262'
+  },
+  {
+    id: 'a3424107-ef96-47ac-be76-a8b86de3271a',
+    legacy_id: '410',
+    description: 'Spray Irrigation - Spray Irrigation Definition Order',
+    loss_factor: 'high',
+    two_part_tariff: true,
+    created_at: '2023-12-14 14:00:08.862915',
+    updated_at: '2024-07-22 14:00:08.035262'
+  },
+  {
+    id: 'da576426-70bc-4f76-b05b-849bba48a8e8',
+    legacy_id: '420',
+    description: 'Spray Irrigation - Storage',
+    loss_factor: 'high',
+    two_part_tariff: true,
+    created_at: '2023-12-14 14:00:08.862915',
+    updated_at: '2024-07-22 14:00:08.035262'
+  },
+  {
+    id: '68952835-592a-48e8-a6ea-b5ab0c71716d',
+    legacy_id: '430',
+    description: 'Supply To A Canal For Throughflow',
+    loss_factor: 'very low',
+    two_part_tariff: false,
+    created_at: '2023-12-14 14:00:08.862915',
+    updated_at: '2024-07-22 14:00:08.035262'
+  },
+  {
+    id: 'bba3436e-3af9-40e4-9a56-aad81ae046ef',
+    legacy_id: '440',
+    description: 'Supply To A Leat For Throughflow',
+    loss_factor: 'very low',
+    two_part_tariff: false,
+    created_at: '2023-12-14 14:00:08.862915',
+    updated_at: '2024-07-22 14:00:08.035262'
+  },
+  {
+    id: 'cb5273f5-1962-477c-9c23-bec96e1409ef',
+    legacy_id: '450',
+    description: 'Transfer Between Sources (Pre Water Act 2003)',
+    loss_factor: 'very low',
+    two_part_tariff: false,
+    created_at: '2023-12-14 14:00:08.862915',
+    updated_at: '2024-07-22 14:00:08.035262'
+  },
+  {
+    id: '96218b0a-07cf-4a4c-85e7-204ccbe5a7e6',
+    legacy_id: '460',
+    description: 'Vegetable Washing',
+    loss_factor: 'low',
+    two_part_tariff: false,
+    created_at: '2023-12-14 14:00:08.862915',
+    updated_at: '2024-07-22 14:00:08.035262'
+  },
+  {
+    id: '722b0f7b-4258-4b39-999c-8942a77371b4',
+    legacy_id: '470',
+    description: 'Water Bottling',
+    loss_factor: 'medium',
+    two_part_tariff: false,
+    created_at: '2023-12-14 14:00:08.862915',
+    updated_at: '2024-07-22 14:00:08.035262'
+  },
+  {
+    id: 'e1d58b9b-cd4a-43a9-950e-c9244ab9ab0e',
+    legacy_id: '480',
+    description: 'Water Wheels Not Used For Power',
+    loss_factor: 'very low',
+    two_part_tariff: false,
+    created_at: '2023-12-14 14:00:08.862915',
+    updated_at: '2024-07-22 14:00:08.035262'
+  },
+  {
+    id: 'a7bb7cbc-d417-4eaa-961b-4d8a75a5e1f9',
+    legacy_id: '490',
+    description: 'Impounding (for any purpose excluding impounding for HEP)',
+    loss_factor: 'non-chargeable',
+    two_part_tariff: false,
+    created_at: '2023-12-14 14:00:08.862915',
+    updated_at: '2024-07-22 14:00:08.035262'
+  },
+  {
+    id: 'e4cabe35-e4f6-4d7d-855d-6d126f77b4fd',
+    legacy_id: '600',
+    description: 'Trickle Irrigation - Direct',
+    loss_factor: 'high',
+    two_part_tariff: true,
+    created_at: '2023-12-14 14:00:08.862915',
+    updated_at: '2024-07-22 14:00:08.035262'
+  },
+  {
+    id: 'b6e13514-81da-4cfe-b6de-6a13a22e010e',
+    legacy_id: '610',
+    description: 'Trickle Irrigation - Under Cover/Containers',
+    loss_factor: 'high',
+    two_part_tariff: false,
+    created_at: '2023-12-14 14:00:08.862915',
+    updated_at: '2024-07-22 14:00:08.035262'
+  },
+  {
+    id: '80c45e3e-8487-40e3-b661-834efedb3d15',
+    legacy_id: '620',
+    description: 'Trickle Irrigation - Storage',
+    loss_factor: 'high',
+    two_part_tariff: true,
+    created_at: '2023-12-14 14:00:08.862915',
+    updated_at: '2024-07-22 14:00:08.035262'
+  },
+  {
+    id: '443e7f1a-6d1d-4193-989d-2c94fb4c9656',
+    legacy_id: '630',
+    description: 'Flood Irrigation, Including Water Meadows, Warping And Pest Control',
+    loss_factor: 'very low',
+    two_part_tariff: false,
+    created_at: '2023-12-14 14:00:08.862915',
+    updated_at: '2024-07-22 14:00:08.035262'
+  },
+  {
+    id: 'ddcf9fe3-26b7-4ef2-8bf1-1226f11652be',
+    legacy_id: '640',
+    description: 'Wet Fencing And Nature Conservation',
+    loss_factor: 'very low',
+    two_part_tariff: false,
+    created_at: '2023-12-14 14:00:08.862915',
+    updated_at: '2024-07-22 14:00:08.035262'
+  },
+  {
+    id: '96655751-b02c-42d8-a305-1859f9a17287',
+    legacy_id: '650',
+    description: 'Transfer Between Sources (Post Water Act 2003)',
+    loss_factor: 'very low',
+    two_part_tariff: false,
+    created_at: '2023-12-14 14:00:08.862915',
+    updated_at: '2024-07-22 14:00:08.035262'
+  },
+  {
+    id: 'a7eb6005-fca6-416d-878a-52ac0ead9b6f',
+    legacy_id: '660',
+    description: 'Dewatering',
+    loss_factor: 'very low',
+    two_part_tariff: false,
+    created_at: '2023-12-14 14:00:08.862915',
+    updated_at: '2024-07-22 14:00:08.035262'
+  },
+  {
+    id: '10e3bd38-15dc-41d7-a77b-153d6e3c7d1b',
+    legacy_id: '670',
+    description: 'Hydraulic Fracturing (Fracking)',
+    loss_factor: 'high',
+    two_part_tariff: false,
+    created_at: '2023-12-14 14:00:08.862915',
+    updated_at: '2024-07-22 14:00:08.035262'
+  },
+  {
+    id: '6e4807d8-7d9d-4ff6-bdb2-b3b121077873',
+    legacy_id: '645',
+    description: 'Wet Fencing and Agriculture',
+    loss_factor: 'very low',
+    two_part_tariff: false,
+    created_at: '2023-12-14 14:00:08.862915',
+    updated_at: '2024-07-22 14:00:08.035262'
+  }
+]

--- a/test/support/seeders/data/secondary-purposes.js
+++ b/test/support/seeders/data/secondary-purposes.js
@@ -5,441 +5,441 @@ module.exports = [
     id: '2457bfeb-a120-4b57-802a-46494bd22f82',
     legacyId: 'AGR',
     description: 'General Agriculture',
-    createdAt: '2023-12-14 14:00:08.859089',
-    updatedAt: '2024-07-23 14:00:04.516391'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: 'd0708921-b5c1-4a5b-b63b-31aab46016d8',
     legacyId: 'AQF',
     description: 'Aquaculture Fish',
-    createdAt: '2023-12-14 14:00:08.859089',
-    updatedAt: '2024-07-23 14:00:04.516391'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: '3dce7cf6-0ed2-48bd-ad6c-bf6c71f79db4',
     legacyId: 'AQP',
     description: 'Aquaculture Plant',
-    createdAt: '2023-12-14 14:00:08.859089',
-    updatedAt: '2024-07-23 14:00:04.516391'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: 'c05b93dd-a48f-49a8-a5e6-782252c18f9d',
     legacyId: 'BRW',
     description: 'Breweries/Wine',
-    createdAt: '2023-12-14 14:00:08.859089',
-    updatedAt: '2024-07-23 14:00:04.516391'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: '2d7ba5e2-b6e7-4ed2-a2d1-a1ad3f97229f',
     legacyId: 'BUS',
     description: 'Business Parks',
-    createdAt: '2023-12-14 14:00:08.859089',
-    updatedAt: '2024-07-23 14:00:04.516391'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: '7ea553b0-03df-4081-bcaa-e1f704aa3291',
     legacyId: 'CHE',
     description: 'Chemicals',
-    createdAt: '2023-12-14 14:00:08.859089',
-    updatedAt: '2024-07-23 14:00:04.516391'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: 'ceb6ae1d-fc8c-4cf9-ae01-269122c24c8d',
     legacyId: 'CON',
     description: 'Construction',
-    createdAt: '2023-12-14 14:00:08.859089',
-    updatedAt: '2024-07-23 14:00:04.516391'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: 'd83bc811-b48f-4e87-9916-4c47943d224c',
     legacyId: 'CRN',
     description: 'Crown And Government',
-    createdAt: '2023-12-14 14:00:08.859089',
-    updatedAt: '2024-07-23 14:00:04.516391'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: 'a50fd6db-96ab-46c6-804e-ddd035a4f1b4',
     legacyId: 'DAR',
     description: 'Dairies',
-    createdAt: '2023-12-14 14:00:08.859089',
-    updatedAt: '2024-07-23 14:00:04.516391'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: 'c8d3f626-a4d5-42ea-9f72-6e22c524048e',
     legacyId: 'ELC',
     description: 'Electricity',
-    createdAt: '2023-12-14 14:00:08.859089',
-    updatedAt: '2024-07-23 14:00:04.516391'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: 'e35d4bf3-9c23-48fc-881c-a258b78bb2d1',
     legacyId: 'EXT',
     description: 'Extractive',
-    createdAt: '2023-12-14 14:00:08.859089',
-    updatedAt: '2024-07-23 14:00:04.516391'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: 'eb7c97fd-a718-4136-a7a2-4f0151e0188c',
     legacyId: 'FAD',
     description: 'Food & Drink',
-    createdAt: '2023-12-14 14:00:08.859089',
-    updatedAt: '2024-07-23 14:00:04.516391'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: '9ca665af-5356-4a6d-b509-b96ee64de27a',
     legacyId: 'FOR',
     description: 'Forestry',
-    createdAt: '2023-12-14 14:00:08.859089',
-    updatedAt: '2024-07-23 14:00:04.516391'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: 'a76d6e29-88d1-4fa3-9136-d961a9cdb1bf',
     legacyId: 'GOF',
     description: 'Golf Courses',
-    createdAt: '2023-12-14 14:00:08.859089',
-    updatedAt: '2024-07-23 14:00:04.516391'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: 'ce8e913d-55fb-4f21-b2b2-755084661662',
     legacyId: 'HOL',
     description: 'Holiday Sites, Camp Sites & Tourist Attractions',
-    createdAt: '2023-12-14 14:00:08.859089',
-    updatedAt: '2024-07-23 14:00:04.516391'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: 'c7be8e7a-37a0-459a-bf26-97af4f120834',
     legacyId: 'HOR',
     description: 'Horticulture And Nurseries',
-    createdAt: '2023-12-14 14:00:08.859089',
-    updatedAt: '2024-07-23 14:00:04.516391'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: '2c397566-4cde-41c0-8cca-d152b554f528',
     legacyId: 'HOS',
     description: 'Hospitals',
-    createdAt: '2023-12-14 14:00:08.859089',
-    updatedAt: '2024-07-23 14:00:04.516391'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: 'c4165b99-f4f1-4124-acad-e512371d1bf7',
     legacyId: 'HTL',
     description: 'Hotels, Public Houses And Conference Centres',
-    createdAt: '2023-12-14 14:00:08.859089',
-    updatedAt: '2024-07-23 14:00:04.516391'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: '70abbcfd-b7b9-4eef-9f39-29468b32ce0e',
     legacyId: 'IND',
     description: 'Industrial/Commercial/Energy/Public Services',
-    createdAt: '2023-12-14 14:00:08.859089',
-    updatedAt: '2024-07-23 14:00:04.516391'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: 'ecd25cff-3749-49fd-ba30-9c86483b4a12',
     legacyId: 'LAU',
     description: 'Laundry',
-    createdAt: '2023-12-14 14:00:08.859089',
-    updatedAt: '2024-07-23 14:00:04.516391'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: 'ad036953-0e1b-43ce-a359-f452f344c4da',
     legacyId: 'MCH',
     description: 'Machinery And Electronics',
-    createdAt: '2023-12-14 14:00:08.859089',
-    updatedAt: '2024-07-23 14:00:04.516391'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: 'd5fb3110-0dde-46f7-b7a3-94d06052d8fc',
     legacyId: 'MEC',
     description: 'Mechanical Non Electrical',
-    createdAt: '2023-12-14 14:00:08.859089',
-    updatedAt: '2024-07-23 14:00:04.516391'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: '86708863-167a-4865-8383-cde90e7d1b43',
     legacyId: 'MIN',
     description: 'Mineral Products',
-    createdAt: '2023-12-14 14:00:08.859089',
-    updatedAt: '2024-07-23 14:00:04.516391'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: 'af1eec87-602c-41de-a982-2417bbc320a2',
     legacyId: 'MTL',
     description: 'Metal',
-    createdAt: '2023-12-14 14:00:08.859089',
-    updatedAt: '2024-07-23 14:00:04.516391'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: '7cff0b52-da01-4a29-b29c-a4bba4036324',
     legacyId: 'MUN',
     description: 'Municipal Grounds',
-    createdAt: '2023-12-14 14:00:08.859089',
-    updatedAt: '2024-07-23 14:00:04.516391'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: '4bbdf3ff-9efa-4303-bea8-f7d419022922',
     legacyId: 'NAV',
     description: 'Navigation',
-    createdAt: '2023-12-14 14:00:08.859089',
-    updatedAt: '2024-07-23 14:00:04.516391'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: '00237355-5b18-44d9-a5c4-785e387739fb',
     legacyId: 'NRE',
     description: 'Non-Remedial River/Wetland Support',
-    createdAt: '2023-12-14 14:00:08.859089',
-    updatedAt: '2024-07-23 14:00:04.516391'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: '789824ee-140e-4871-b453-b17ac12ab095',
     legacyId: 'ORC',
     description: 'Orchards',
-    createdAt: '2023-12-14 14:00:08.859089',
-    updatedAt: '2024-07-23 14:00:04.516391'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: '303cc214-6118-417b-b6ee-343257af3a3b',
     legacyId: 'OTE',
     description: 'Other Environmental Improvements',
-    createdAt: '2023-12-14 14:00:08.859089',
-    updatedAt: '2024-07-23 14:00:04.516391'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: 'f85ab791-e943-4492-a3bb-c0b3ad3f0712',
     legacyId: 'OTI',
     description: 'Other Industrial/Commercial/Public Services',
-    createdAt: '2023-12-14 14:00:08.859089',
-    updatedAt: '2024-07-23 14:00:04.516391'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: 'a58ef991-ea9b-4443-862d-811327ccd3dc',
     legacyId: 'PAD',
     description: 'Public Administration',
-    createdAt: '2023-12-14 14:00:08.859089',
-    updatedAt: '2024-07-23 14:00:04.516391'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: 'e882c4a6-53d0-4b82-b921-499d25428134',
     legacyId: 'PAP',
     description: 'Paper And Printing',
-    createdAt: '2023-12-14 14:00:08.859089',
-    updatedAt: '2024-07-23 14:00:04.516391'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: 'f47814e0-a7a9-45be-af75-4d2b58784be0',
     legacyId: 'PET',
     description: 'Petrochemicals',
-    createdAt: '2023-12-14 14:00:08.859089',
-    updatedAt: '2024-07-23 14:00:04.516391'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: '6cbb6f30-64bd-47e5-b852-5089e7088568',
     legacyId: 'PRI',
     description: 'Private Non-Industrial',
-    createdAt: '2023-12-14 14:00:08.859089',
-    updatedAt: '2024-07-23 14:00:04.516391'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: '8b324ba7-7d82-46d8-ae61-bc343e388745',
     legacyId: 'PRV',
     description: 'Private Water Supply',
-    createdAt: '2023-12-14 14:00:08.859089',
-    updatedAt: '2024-07-23 14:00:04.516391'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: '2362c06f-bb1e-4649-8342-29cc94017774',
     legacyId: 'PUM',
     description: 'Pump & Treat',
-    createdAt: '2023-12-14 14:00:08.859089',
-    updatedAt: '2024-07-23 14:00:04.516391'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: '866fe96a-1536-4396-85b3-de073ac2f92f',
     legacyId: 'PWS',
     description: 'Public Water Supply',
-    createdAt: '2023-12-14 14:00:08.859089',
-    updatedAt: '2024-07-23 14:00:04.516391'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: '1d3877a3-c5cf-405a-9e07-4fe94689f4ea',
     legacyId: 'PWU',
     description: 'Private Water Undertaking',
-    createdAt: '2023-12-14 14:00:08.859089',
-    updatedAt: '2024-07-23 14:00:04.516391'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: 'b9a4c156-77e8-4891-95f4-6df745e58d42',
     legacyId: 'RAC',
     description: 'Racecourses',
-    createdAt: '2023-12-14 14:00:08.859089',
-    updatedAt: '2024-07-23 14:00:04.516391'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: '04d711bb-607c-4814-aca9-0c6bd39e0ea4',
     legacyId: 'REF',
     description: 'Refuse And Recycling',
-    createdAt: '2023-12-14 14:00:08.859089',
-    updatedAt: '2024-07-23 14:00:04.516391'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: '3c2a4aab-c2a7-4fea-aa06-bcdf2d9e499f',
     legacyId: 'REM',
     description: 'Remedial River/Wetland Support',
-    createdAt: '2023-12-14 14:00:08.859089',
-    updatedAt: '2024-07-23 14:00:04.516391'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: 'c0691f62-1022-4cef-8f9b-575099f62c20',
     legacyId: 'RES',
     description: 'Research Non- University/College',
-    createdAt: '2023-12-14 14:00:08.859089',
-    updatedAt: '2024-07-23 14:00:04.516391'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: 'b6d3c0c8-4018-4553-9393-0e87a3c91a8f',
     legacyId: 'RET',
     description: 'Retail',
-    createdAt: '2023-12-14 14:00:08.859089',
-    updatedAt: '2024-07-23 14:00:04.516391'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: 'bf32cb71-8f5a-4055-913a-3c16942abb8c',
     legacyId: 'RUB',
     description: 'Rubber',
-    createdAt: '2023-12-14 14:00:08.859089',
-    updatedAt: '2024-07-23 14:00:04.516391'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: 'f06c3e2e-0a0b-4cd5-81bd-04d527bd8533',
     legacyId: 'SCH',
     description: 'Schools And Colleges',
-    createdAt: '2023-12-14 14:00:08.859089',
-    updatedAt: '2024-07-23 14:00:04.516391'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: 'b6fbd08e-a4ad-4a9b-871e-30ac51efee78',
     legacyId: 'SLA',
     description: 'Slaughtering',
-    createdAt: '2023-12-14 14:00:08.859089',
-    updatedAt: '2024-07-23 14:00:04.516391'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: '59bd435f-5651-4cc5-bdf8-fb8e3697f95a',
     legacyId: 'SPO',
     description: 'Sports Grounds/Facilities',
-    createdAt: '2023-12-14 14:00:08.859089',
-    updatedAt: '2024-07-23 14:00:04.516391'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: '9c16f3e8-4ea0-4292-8802-8427bec0571a',
     legacyId: 'TRA',
     description: 'Transport',
-    createdAt: '2023-12-14 14:00:08.859089',
-    updatedAt: '2024-07-23 14:00:04.516391'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: 'c778de53-0fd4-445e-af86-3c441f79e07b',
     legacyId: 'TXT',
     description: 'Textiles & Leather',
-    createdAt: '2023-12-14 14:00:08.859089',
-    updatedAt: '2024-07-23 14:00:04.516391'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: '9b1828d1-d319-4d6c-a620-d9828c455fcb',
     legacyId: 'UNK',
     description: 'Unknown (for impounding exluding impoundments for HEP)',
-    createdAt: '2023-12-14 14:00:08.859089',
-    updatedAt: '2024-07-23 14:00:04.516391'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: 'eecd8280-9b2f-4279-b300-d4b3441bd87c',
     legacyId: 'WAT',
     description: 'Water Supply Related',
-    createdAt: '2023-12-14 14:00:08.859089',
-    updatedAt: '2024-07-23 14:00:04.516391'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: 'f6f7b6bf-6447-4092-8cd6-27cae2d8956e',
     legacyId: 'ZOO',
     description: 'Zoos/Kennels/Stables',
-    createdAt: '2023-12-14 14:00:08.859089',
-    updatedAt: '2024-07-23 14:00:04.516391'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: '490db793-eddf-4fed-93ce-78260b8d0584',
     legacyId: 'CRW',
     description: 'Crown - Other',
-    createdAt: '2023-12-14 14:00:08.859089',
-    updatedAt: '2024-07-23 14:00:04.516391'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: '09545099-a184-4e98-be2a-e749d24392e9',
     legacyId: 'GOV',
     description: 'Government Departments - Other',
-    createdAt: '2023-12-14 14:00:08.859089',
-    updatedAt: '2024-07-23 14:00:04.516391'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: '6bb0f9c0-7ef0-4da4-9c0f-2a60fc6b4785',
     legacyId: 'DET',
     description: 'Detention And Immigration Centres',
-    createdAt: '2023-12-14 14:00:08.859089',
-    updatedAt: '2024-07-23 14:00:04.516391'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: '3fd3cf82-47ff-4f01-b523-96959f2d635b',
     legacyId: 'VIF',
     description: 'Visiting Armed Forces',
-    createdAt: '2023-12-14 14:00:08.859089',
-    updatedAt: '2024-07-23 14:00:04.516391'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: '8b836771-6d7e-4277-b03f-473c0504d02b',
     legacyId: 'FRT',
     description: 'Government Or Crown Forestry',
-    createdAt: '2023-12-14 14:00:08.859089',
-    updatedAt: '2024-07-23 14:00:04.516391'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: '489930ca-cef9-4604-86be-31ef01954cc7',
     legacyId: 'CVY',
     description: 'Statutory Water Conservancy Operation',
-    createdAt: '2023-12-14 14:00:08.859089',
-    updatedAt: '2024-07-23 14:00:04.516391'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: '607f230d-e96b-4383-a588-f7976cbf3e6b',
     legacyId: 'HRB',
     description: 'Ports And Harbour Authority Operation',
-    createdAt: '2023-12-14 14:00:08.859089',
-    updatedAt: '2024-07-23 14:00:04.516391'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: '075d0549-4075-47f4-9e1a-944e96a63eec',
     legacyId: 'DRG',
     description: 'Drainage Operations',
-    createdAt: '2023-12-14 14:00:08.859089',
-    updatedAt: '2024-07-23 14:00:04.516391'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: '678fa94b-6320-44d2-a21d-5d772040de6c',
     legacyId: 'POW',
     description: 'Domestic Premises Related',
-    createdAt: '2023-12-14 14:00:08.859089',
-    updatedAt: '2024-07-23 14:00:04.516391'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: 'd4f9f23b-1602-4846-9b05-07a49d2bd9c5',
     legacyId: 'MOD',
     description: 'Mod (Ministry Of Defence)',
-    createdAt: '2023-12-14 14:00:08.859089',
-    updatedAt: '2024-07-23 14:00:04.516391'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   },
   {
     id: '7f75f247-5b3c-4785-954c-207456a4d6c4',
     legacyId: 'OOG',
     description: 'Onshore Oil and Gas Extraction',
-    createdAt: '2023-12-14 14:00:08.859089',
-    updatedAt: '2024-07-23 14:00:04.516391'
+    createdAt: new Date('2024-07-22'),
+    updatedAt: new Date('2024-07-22')
   }
 ]

--- a/test/support/seeders/data/secondary-purposes.js
+++ b/test/support/seeders/data/secondary-purposes.js
@@ -3,443 +3,443 @@
 module.exports = [
   {
     id: '2457bfeb-a120-4b57-802a-46494bd22f82',
-    legacy_id: 'AGR',
+    legacyId: 'AGR',
     description: 'General Agriculture',
-    created_at: '2023-12-14 14:00:08.859089',
-    updated_at: '2024-07-23 14:00:04.516391'
+    createdAt: '2023-12-14 14:00:08.859089',
+    updatedAt: '2024-07-23 14:00:04.516391'
   },
   {
     id: 'd0708921-b5c1-4a5b-b63b-31aab46016d8',
-    legacy_id: 'AQF',
+    legacyId: 'AQF',
     description: 'Aquaculture Fish',
-    created_at: '2023-12-14 14:00:08.859089',
-    updated_at: '2024-07-23 14:00:04.516391'
+    createdAt: '2023-12-14 14:00:08.859089',
+    updatedAt: '2024-07-23 14:00:04.516391'
   },
   {
     id: '3dce7cf6-0ed2-48bd-ad6c-bf6c71f79db4',
-    legacy_id: 'AQP',
+    legacyId: 'AQP',
     description: 'Aquaculture Plant',
-    created_at: '2023-12-14 14:00:08.859089',
-    updated_at: '2024-07-23 14:00:04.516391'
+    createdAt: '2023-12-14 14:00:08.859089',
+    updatedAt: '2024-07-23 14:00:04.516391'
   },
   {
     id: 'c05b93dd-a48f-49a8-a5e6-782252c18f9d',
-    legacy_id: 'BRW',
+    legacyId: 'BRW',
     description: 'Breweries/Wine',
-    created_at: '2023-12-14 14:00:08.859089',
-    updated_at: '2024-07-23 14:00:04.516391'
+    createdAt: '2023-12-14 14:00:08.859089',
+    updatedAt: '2024-07-23 14:00:04.516391'
   },
   {
     id: '2d7ba5e2-b6e7-4ed2-a2d1-a1ad3f97229f',
-    legacy_id: 'BUS',
+    legacyId: 'BUS',
     description: 'Business Parks',
-    created_at: '2023-12-14 14:00:08.859089',
-    updated_at: '2024-07-23 14:00:04.516391'
+    createdAt: '2023-12-14 14:00:08.859089',
+    updatedAt: '2024-07-23 14:00:04.516391'
   },
   {
     id: '7ea553b0-03df-4081-bcaa-e1f704aa3291',
-    legacy_id: 'CHE',
+    legacyId: 'CHE',
     description: 'Chemicals',
-    created_at: '2023-12-14 14:00:08.859089',
-    updated_at: '2024-07-23 14:00:04.516391'
+    createdAt: '2023-12-14 14:00:08.859089',
+    updatedAt: '2024-07-23 14:00:04.516391'
   },
   {
     id: 'ceb6ae1d-fc8c-4cf9-ae01-269122c24c8d',
-    legacy_id: 'CON',
+    legacyId: 'CON',
     description: 'Construction',
-    created_at: '2023-12-14 14:00:08.859089',
-    updated_at: '2024-07-23 14:00:04.516391'
+    createdAt: '2023-12-14 14:00:08.859089',
+    updatedAt: '2024-07-23 14:00:04.516391'
   },
   {
     id: 'd83bc811-b48f-4e87-9916-4c47943d224c',
-    legacy_id: 'CRN',
+    legacyId: 'CRN',
     description: 'Crown And Government',
-    created_at: '2023-12-14 14:00:08.859089',
-    updated_at: '2024-07-23 14:00:04.516391'
+    createdAt: '2023-12-14 14:00:08.859089',
+    updatedAt: '2024-07-23 14:00:04.516391'
   },
   {
     id: 'a50fd6db-96ab-46c6-804e-ddd035a4f1b4',
-    legacy_id: 'DAR',
+    legacyId: 'DAR',
     description: 'Dairies',
-    created_at: '2023-12-14 14:00:08.859089',
-    updated_at: '2024-07-23 14:00:04.516391'
+    createdAt: '2023-12-14 14:00:08.859089',
+    updatedAt: '2024-07-23 14:00:04.516391'
   },
   {
     id: 'c8d3f626-a4d5-42ea-9f72-6e22c524048e',
-    legacy_id: 'ELC',
+    legacyId: 'ELC',
     description: 'Electricity',
-    created_at: '2023-12-14 14:00:08.859089',
-    updated_at: '2024-07-23 14:00:04.516391'
+    createdAt: '2023-12-14 14:00:08.859089',
+    updatedAt: '2024-07-23 14:00:04.516391'
   },
   {
     id: 'e35d4bf3-9c23-48fc-881c-a258b78bb2d1',
-    legacy_id: 'EXT',
+    legacyId: 'EXT',
     description: 'Extractive',
-    created_at: '2023-12-14 14:00:08.859089',
-    updated_at: '2024-07-23 14:00:04.516391'
+    createdAt: '2023-12-14 14:00:08.859089',
+    updatedAt: '2024-07-23 14:00:04.516391'
   },
   {
     id: 'eb7c97fd-a718-4136-a7a2-4f0151e0188c',
-    legacy_id: 'FAD',
+    legacyId: 'FAD',
     description: 'Food & Drink',
-    created_at: '2023-12-14 14:00:08.859089',
-    updated_at: '2024-07-23 14:00:04.516391'
+    createdAt: '2023-12-14 14:00:08.859089',
+    updatedAt: '2024-07-23 14:00:04.516391'
   },
   {
     id: '9ca665af-5356-4a6d-b509-b96ee64de27a',
-    legacy_id: 'FOR',
+    legacyId: 'FOR',
     description: 'Forestry',
-    created_at: '2023-12-14 14:00:08.859089',
-    updated_at: '2024-07-23 14:00:04.516391'
+    createdAt: '2023-12-14 14:00:08.859089',
+    updatedAt: '2024-07-23 14:00:04.516391'
   },
   {
     id: 'a76d6e29-88d1-4fa3-9136-d961a9cdb1bf',
-    legacy_id: 'GOF',
+    legacyId: 'GOF',
     description: 'Golf Courses',
-    created_at: '2023-12-14 14:00:08.859089',
-    updated_at: '2024-07-23 14:00:04.516391'
+    createdAt: '2023-12-14 14:00:08.859089',
+    updatedAt: '2024-07-23 14:00:04.516391'
   },
   {
     id: 'ce8e913d-55fb-4f21-b2b2-755084661662',
-    legacy_id: 'HOL',
+    legacyId: 'HOL',
     description: 'Holiday Sites, Camp Sites & Tourist Attractions',
-    created_at: '2023-12-14 14:00:08.859089',
-    updated_at: '2024-07-23 14:00:04.516391'
+    createdAt: '2023-12-14 14:00:08.859089',
+    updatedAt: '2024-07-23 14:00:04.516391'
   },
   {
     id: 'c7be8e7a-37a0-459a-bf26-97af4f120834',
-    legacy_id: 'HOR',
+    legacyId: 'HOR',
     description: 'Horticulture And Nurseries',
-    created_at: '2023-12-14 14:00:08.859089',
-    updated_at: '2024-07-23 14:00:04.516391'
+    createdAt: '2023-12-14 14:00:08.859089',
+    updatedAt: '2024-07-23 14:00:04.516391'
   },
   {
     id: '2c397566-4cde-41c0-8cca-d152b554f528',
-    legacy_id: 'HOS',
+    legacyId: 'HOS',
     description: 'Hospitals',
-    created_at: '2023-12-14 14:00:08.859089',
-    updated_at: '2024-07-23 14:00:04.516391'
+    createdAt: '2023-12-14 14:00:08.859089',
+    updatedAt: '2024-07-23 14:00:04.516391'
   },
   {
     id: 'c4165b99-f4f1-4124-acad-e512371d1bf7',
-    legacy_id: 'HTL',
+    legacyId: 'HTL',
     description: 'Hotels, Public Houses And Conference Centres',
-    created_at: '2023-12-14 14:00:08.859089',
-    updated_at: '2024-07-23 14:00:04.516391'
+    createdAt: '2023-12-14 14:00:08.859089',
+    updatedAt: '2024-07-23 14:00:04.516391'
   },
   {
     id: '70abbcfd-b7b9-4eef-9f39-29468b32ce0e',
-    legacy_id: 'IND',
+    legacyId: 'IND',
     description: 'Industrial/Commercial/Energy/Public Services',
-    created_at: '2023-12-14 14:00:08.859089',
-    updated_at: '2024-07-23 14:00:04.516391'
+    createdAt: '2023-12-14 14:00:08.859089',
+    updatedAt: '2024-07-23 14:00:04.516391'
   },
   {
     id: 'ecd25cff-3749-49fd-ba30-9c86483b4a12',
-    legacy_id: 'LAU',
+    legacyId: 'LAU',
     description: 'Laundry',
-    created_at: '2023-12-14 14:00:08.859089',
-    updated_at: '2024-07-23 14:00:04.516391'
+    createdAt: '2023-12-14 14:00:08.859089',
+    updatedAt: '2024-07-23 14:00:04.516391'
   },
   {
     id: 'ad036953-0e1b-43ce-a359-f452f344c4da',
-    legacy_id: 'MCH',
+    legacyId: 'MCH',
     description: 'Machinery And Electronics',
-    created_at: '2023-12-14 14:00:08.859089',
-    updated_at: '2024-07-23 14:00:04.516391'
+    createdAt: '2023-12-14 14:00:08.859089',
+    updatedAt: '2024-07-23 14:00:04.516391'
   },
   {
     id: 'd5fb3110-0dde-46f7-b7a3-94d06052d8fc',
-    legacy_id: 'MEC',
+    legacyId: 'MEC',
     description: 'Mechanical Non Electrical',
-    created_at: '2023-12-14 14:00:08.859089',
-    updated_at: '2024-07-23 14:00:04.516391'
+    createdAt: '2023-12-14 14:00:08.859089',
+    updatedAt: '2024-07-23 14:00:04.516391'
   },
   {
     id: '86708863-167a-4865-8383-cde90e7d1b43',
-    legacy_id: 'MIN',
+    legacyId: 'MIN',
     description: 'Mineral Products',
-    created_at: '2023-12-14 14:00:08.859089',
-    updated_at: '2024-07-23 14:00:04.516391'
+    createdAt: '2023-12-14 14:00:08.859089',
+    updatedAt: '2024-07-23 14:00:04.516391'
   },
   {
     id: 'af1eec87-602c-41de-a982-2417bbc320a2',
-    legacy_id: 'MTL',
+    legacyId: 'MTL',
     description: 'Metal',
-    created_at: '2023-12-14 14:00:08.859089',
-    updated_at: '2024-07-23 14:00:04.516391'
+    createdAt: '2023-12-14 14:00:08.859089',
+    updatedAt: '2024-07-23 14:00:04.516391'
   },
   {
     id: '7cff0b52-da01-4a29-b29c-a4bba4036324',
-    legacy_id: 'MUN',
+    legacyId: 'MUN',
     description: 'Municipal Grounds',
-    created_at: '2023-12-14 14:00:08.859089',
-    updated_at: '2024-07-23 14:00:04.516391'
+    createdAt: '2023-12-14 14:00:08.859089',
+    updatedAt: '2024-07-23 14:00:04.516391'
   },
   {
     id: '4bbdf3ff-9efa-4303-bea8-f7d419022922',
-    legacy_id: 'NAV',
+    legacyId: 'NAV',
     description: 'Navigation',
-    created_at: '2023-12-14 14:00:08.859089',
-    updated_at: '2024-07-23 14:00:04.516391'
+    createdAt: '2023-12-14 14:00:08.859089',
+    updatedAt: '2024-07-23 14:00:04.516391'
   },
   {
     id: '00237355-5b18-44d9-a5c4-785e387739fb',
-    legacy_id: 'NRE',
+    legacyId: 'NRE',
     description: 'Non-Remedial River/Wetland Support',
-    created_at: '2023-12-14 14:00:08.859089',
-    updated_at: '2024-07-23 14:00:04.516391'
+    createdAt: '2023-12-14 14:00:08.859089',
+    updatedAt: '2024-07-23 14:00:04.516391'
   },
   {
     id: '789824ee-140e-4871-b453-b17ac12ab095',
-    legacy_id: 'ORC',
+    legacyId: 'ORC',
     description: 'Orchards',
-    created_at: '2023-12-14 14:00:08.859089',
-    updated_at: '2024-07-23 14:00:04.516391'
+    createdAt: '2023-12-14 14:00:08.859089',
+    updatedAt: '2024-07-23 14:00:04.516391'
   },
   {
     id: '303cc214-6118-417b-b6ee-343257af3a3b',
-    legacy_id: 'OTE',
+    legacyId: 'OTE',
     description: 'Other Environmental Improvements',
-    created_at: '2023-12-14 14:00:08.859089',
-    updated_at: '2024-07-23 14:00:04.516391'
+    createdAt: '2023-12-14 14:00:08.859089',
+    updatedAt: '2024-07-23 14:00:04.516391'
   },
   {
     id: 'f85ab791-e943-4492-a3bb-c0b3ad3f0712',
-    legacy_id: 'OTI',
+    legacyId: 'OTI',
     description: 'Other Industrial/Commercial/Public Services',
-    created_at: '2023-12-14 14:00:08.859089',
-    updated_at: '2024-07-23 14:00:04.516391'
+    createdAt: '2023-12-14 14:00:08.859089',
+    updatedAt: '2024-07-23 14:00:04.516391'
   },
   {
     id: 'a58ef991-ea9b-4443-862d-811327ccd3dc',
-    legacy_id: 'PAD',
+    legacyId: 'PAD',
     description: 'Public Administration',
-    created_at: '2023-12-14 14:00:08.859089',
-    updated_at: '2024-07-23 14:00:04.516391'
+    createdAt: '2023-12-14 14:00:08.859089',
+    updatedAt: '2024-07-23 14:00:04.516391'
   },
   {
     id: 'e882c4a6-53d0-4b82-b921-499d25428134',
-    legacy_id: 'PAP',
+    legacyId: 'PAP',
     description: 'Paper And Printing',
-    created_at: '2023-12-14 14:00:08.859089',
-    updated_at: '2024-07-23 14:00:04.516391'
+    createdAt: '2023-12-14 14:00:08.859089',
+    updatedAt: '2024-07-23 14:00:04.516391'
   },
   {
     id: 'f47814e0-a7a9-45be-af75-4d2b58784be0',
-    legacy_id: 'PET',
+    legacyId: 'PET',
     description: 'Petrochemicals',
-    created_at: '2023-12-14 14:00:08.859089',
-    updated_at: '2024-07-23 14:00:04.516391'
+    createdAt: '2023-12-14 14:00:08.859089',
+    updatedAt: '2024-07-23 14:00:04.516391'
   },
   {
     id: '6cbb6f30-64bd-47e5-b852-5089e7088568',
-    legacy_id: 'PRI',
+    legacyId: 'PRI',
     description: 'Private Non-Industrial',
-    created_at: '2023-12-14 14:00:08.859089',
-    updated_at: '2024-07-23 14:00:04.516391'
+    createdAt: '2023-12-14 14:00:08.859089',
+    updatedAt: '2024-07-23 14:00:04.516391'
   },
   {
     id: '8b324ba7-7d82-46d8-ae61-bc343e388745',
-    legacy_id: 'PRV',
+    legacyId: 'PRV',
     description: 'Private Water Supply',
-    created_at: '2023-12-14 14:00:08.859089',
-    updated_at: '2024-07-23 14:00:04.516391'
+    createdAt: '2023-12-14 14:00:08.859089',
+    updatedAt: '2024-07-23 14:00:04.516391'
   },
   {
     id: '2362c06f-bb1e-4649-8342-29cc94017774',
-    legacy_id: 'PUM',
+    legacyId: 'PUM',
     description: 'Pump & Treat',
-    created_at: '2023-12-14 14:00:08.859089',
-    updated_at: '2024-07-23 14:00:04.516391'
+    createdAt: '2023-12-14 14:00:08.859089',
+    updatedAt: '2024-07-23 14:00:04.516391'
   },
   {
     id: '866fe96a-1536-4396-85b3-de073ac2f92f',
-    legacy_id: 'PWS',
+    legacyId: 'PWS',
     description: 'Public Water Supply',
-    created_at: '2023-12-14 14:00:08.859089',
-    updated_at: '2024-07-23 14:00:04.516391'
+    createdAt: '2023-12-14 14:00:08.859089',
+    updatedAt: '2024-07-23 14:00:04.516391'
   },
   {
     id: '1d3877a3-c5cf-405a-9e07-4fe94689f4ea',
-    legacy_id: 'PWU',
+    legacyId: 'PWU',
     description: 'Private Water Undertaking',
-    created_at: '2023-12-14 14:00:08.859089',
-    updated_at: '2024-07-23 14:00:04.516391'
+    createdAt: '2023-12-14 14:00:08.859089',
+    updatedAt: '2024-07-23 14:00:04.516391'
   },
   {
     id: 'b9a4c156-77e8-4891-95f4-6df745e58d42',
-    legacy_id: 'RAC',
+    legacyId: 'RAC',
     description: 'Racecourses',
-    created_at: '2023-12-14 14:00:08.859089',
-    updated_at: '2024-07-23 14:00:04.516391'
+    createdAt: '2023-12-14 14:00:08.859089',
+    updatedAt: '2024-07-23 14:00:04.516391'
   },
   {
     id: '04d711bb-607c-4814-aca9-0c6bd39e0ea4',
-    legacy_id: 'REF',
+    legacyId: 'REF',
     description: 'Refuse And Recycling',
-    created_at: '2023-12-14 14:00:08.859089',
-    updated_at: '2024-07-23 14:00:04.516391'
+    createdAt: '2023-12-14 14:00:08.859089',
+    updatedAt: '2024-07-23 14:00:04.516391'
   },
   {
     id: '3c2a4aab-c2a7-4fea-aa06-bcdf2d9e499f',
-    legacy_id: 'REM',
+    legacyId: 'REM',
     description: 'Remedial River/Wetland Support',
-    created_at: '2023-12-14 14:00:08.859089',
-    updated_at: '2024-07-23 14:00:04.516391'
+    createdAt: '2023-12-14 14:00:08.859089',
+    updatedAt: '2024-07-23 14:00:04.516391'
   },
   {
     id: 'c0691f62-1022-4cef-8f9b-575099f62c20',
-    legacy_id: 'RES',
+    legacyId: 'RES',
     description: 'Research Non- University/College',
-    created_at: '2023-12-14 14:00:08.859089',
-    updated_at: '2024-07-23 14:00:04.516391'
+    createdAt: '2023-12-14 14:00:08.859089',
+    updatedAt: '2024-07-23 14:00:04.516391'
   },
   {
     id: 'b6d3c0c8-4018-4553-9393-0e87a3c91a8f',
-    legacy_id: 'RET',
+    legacyId: 'RET',
     description: 'Retail',
-    created_at: '2023-12-14 14:00:08.859089',
-    updated_at: '2024-07-23 14:00:04.516391'
+    createdAt: '2023-12-14 14:00:08.859089',
+    updatedAt: '2024-07-23 14:00:04.516391'
   },
   {
     id: 'bf32cb71-8f5a-4055-913a-3c16942abb8c',
-    legacy_id: 'RUB',
+    legacyId: 'RUB',
     description: 'Rubber',
-    created_at: '2023-12-14 14:00:08.859089',
-    updated_at: '2024-07-23 14:00:04.516391'
+    createdAt: '2023-12-14 14:00:08.859089',
+    updatedAt: '2024-07-23 14:00:04.516391'
   },
   {
     id: 'f06c3e2e-0a0b-4cd5-81bd-04d527bd8533',
-    legacy_id: 'SCH',
+    legacyId: 'SCH',
     description: 'Schools And Colleges',
-    created_at: '2023-12-14 14:00:08.859089',
-    updated_at: '2024-07-23 14:00:04.516391'
+    createdAt: '2023-12-14 14:00:08.859089',
+    updatedAt: '2024-07-23 14:00:04.516391'
   },
   {
     id: 'b6fbd08e-a4ad-4a9b-871e-30ac51efee78',
-    legacy_id: 'SLA',
+    legacyId: 'SLA',
     description: 'Slaughtering',
-    created_at: '2023-12-14 14:00:08.859089',
-    updated_at: '2024-07-23 14:00:04.516391'
+    createdAt: '2023-12-14 14:00:08.859089',
+    updatedAt: '2024-07-23 14:00:04.516391'
   },
   {
     id: '59bd435f-5651-4cc5-bdf8-fb8e3697f95a',
-    legacy_id: 'SPO',
+    legacyId: 'SPO',
     description: 'Sports Grounds/Facilities',
-    created_at: '2023-12-14 14:00:08.859089',
-    updated_at: '2024-07-23 14:00:04.516391'
+    createdAt: '2023-12-14 14:00:08.859089',
+    updatedAt: '2024-07-23 14:00:04.516391'
   },
   {
     id: '9c16f3e8-4ea0-4292-8802-8427bec0571a',
-    legacy_id: 'TRA',
+    legacyId: 'TRA',
     description: 'Transport',
-    created_at: '2023-12-14 14:00:08.859089',
-    updated_at: '2024-07-23 14:00:04.516391'
+    createdAt: '2023-12-14 14:00:08.859089',
+    updatedAt: '2024-07-23 14:00:04.516391'
   },
   {
     id: 'c778de53-0fd4-445e-af86-3c441f79e07b',
-    legacy_id: 'TXT',
+    legacyId: 'TXT',
     description: 'Textiles & Leather',
-    created_at: '2023-12-14 14:00:08.859089',
-    updated_at: '2024-07-23 14:00:04.516391'
+    createdAt: '2023-12-14 14:00:08.859089',
+    updatedAt: '2024-07-23 14:00:04.516391'
   },
   {
     id: '9b1828d1-d319-4d6c-a620-d9828c455fcb',
-    legacy_id: 'UNK',
+    legacyId: 'UNK',
     description: 'Unknown (for impounding exluding impoundments for HEP)',
-    created_at: '2023-12-14 14:00:08.859089',
-    updated_at: '2024-07-23 14:00:04.516391'
+    createdAt: '2023-12-14 14:00:08.859089',
+    updatedAt: '2024-07-23 14:00:04.516391'
   },
   {
     id: 'eecd8280-9b2f-4279-b300-d4b3441bd87c',
-    legacy_id: 'WAT',
+    legacyId: 'WAT',
     description: 'Water Supply Related',
-    created_at: '2023-12-14 14:00:08.859089',
-    updated_at: '2024-07-23 14:00:04.516391'
+    createdAt: '2023-12-14 14:00:08.859089',
+    updatedAt: '2024-07-23 14:00:04.516391'
   },
   {
     id: 'f6f7b6bf-6447-4092-8cd6-27cae2d8956e',
-    legacy_id: 'ZOO',
+    legacyId: 'ZOO',
     description: 'Zoos/Kennels/Stables',
-    created_at: '2023-12-14 14:00:08.859089',
-    updated_at: '2024-07-23 14:00:04.516391'
+    createdAt: '2023-12-14 14:00:08.859089',
+    updatedAt: '2024-07-23 14:00:04.516391'
   },
   {
     id: '490db793-eddf-4fed-93ce-78260b8d0584',
-    legacy_id: 'CRW',
+    legacyId: 'CRW',
     description: 'Crown - Other',
-    created_at: '2023-12-14 14:00:08.859089',
-    updated_at: '2024-07-23 14:00:04.516391'
+    createdAt: '2023-12-14 14:00:08.859089',
+    updatedAt: '2024-07-23 14:00:04.516391'
   },
   {
     id: '09545099-a184-4e98-be2a-e749d24392e9',
-    legacy_id: 'GOV',
+    legacyId: 'GOV',
     description: 'Government Departments - Other',
-    created_at: '2023-12-14 14:00:08.859089',
-    updated_at: '2024-07-23 14:00:04.516391'
+    createdAt: '2023-12-14 14:00:08.859089',
+    updatedAt: '2024-07-23 14:00:04.516391'
   },
   {
     id: '6bb0f9c0-7ef0-4da4-9c0f-2a60fc6b4785',
-    legacy_id: 'DET',
+    legacyId: 'DET',
     description: 'Detention And Immigration Centres',
-    created_at: '2023-12-14 14:00:08.859089',
-    updated_at: '2024-07-23 14:00:04.516391'
+    createdAt: '2023-12-14 14:00:08.859089',
+    updatedAt: '2024-07-23 14:00:04.516391'
   },
   {
     id: '3fd3cf82-47ff-4f01-b523-96959f2d635b',
-    legacy_id: 'VIF',
+    legacyId: 'VIF',
     description: 'Visiting Armed Forces',
-    created_at: '2023-12-14 14:00:08.859089',
-    updated_at: '2024-07-23 14:00:04.516391'
+    createdAt: '2023-12-14 14:00:08.859089',
+    updatedAt: '2024-07-23 14:00:04.516391'
   },
   {
     id: '8b836771-6d7e-4277-b03f-473c0504d02b',
-    legacy_id: 'FRT',
+    legacyId: 'FRT',
     description: 'Government Or Crown Forestry',
-    created_at: '2023-12-14 14:00:08.859089',
-    updated_at: '2024-07-23 14:00:04.516391'
+    createdAt: '2023-12-14 14:00:08.859089',
+    updatedAt: '2024-07-23 14:00:04.516391'
   },
   {
     id: '489930ca-cef9-4604-86be-31ef01954cc7',
-    legacy_id: 'CVY',
+    legacyId: 'CVY',
     description: 'Statutory Water Conservancy Operation',
-    created_at: '2023-12-14 14:00:08.859089',
-    updated_at: '2024-07-23 14:00:04.516391'
+    createdAt: '2023-12-14 14:00:08.859089',
+    updatedAt: '2024-07-23 14:00:04.516391'
   },
   {
     id: '607f230d-e96b-4383-a588-f7976cbf3e6b',
-    legacy_id: 'HRB',
+    legacyId: 'HRB',
     description: 'Ports And Harbour Authority Operation',
-    created_at: '2023-12-14 14:00:08.859089',
-    updated_at: '2024-07-23 14:00:04.516391'
+    createdAt: '2023-12-14 14:00:08.859089',
+    updatedAt: '2024-07-23 14:00:04.516391'
   },
   {
     id: '075d0549-4075-47f4-9e1a-944e96a63eec',
-    legacy_id: 'DRG',
+    legacyId: 'DRG',
     description: 'Drainage Operations',
-    created_at: '2023-12-14 14:00:08.859089',
-    updated_at: '2024-07-23 14:00:04.516391'
+    createdAt: '2023-12-14 14:00:08.859089',
+    updatedAt: '2024-07-23 14:00:04.516391'
   },
   {
     id: '678fa94b-6320-44d2-a21d-5d772040de6c',
-    legacy_id: 'POW',
+    legacyId: 'POW',
     description: 'Domestic Premises Related',
-    created_at: '2023-12-14 14:00:08.859089',
-    updated_at: '2024-07-23 14:00:04.516391'
+    createdAt: '2023-12-14 14:00:08.859089',
+    updatedAt: '2024-07-23 14:00:04.516391'
   },
   {
     id: 'd4f9f23b-1602-4846-9b05-07a49d2bd9c5',
-    legacy_id: 'MOD',
+    legacyId: 'MOD',
     description: 'Mod (Ministry Of Defence)',
-    created_at: '2023-12-14 14:00:08.859089',
-    updated_at: '2024-07-23 14:00:04.516391'
+    createdAt: '2023-12-14 14:00:08.859089',
+    updatedAt: '2024-07-23 14:00:04.516391'
   },
   {
     id: '7f75f247-5b3c-4785-954c-207456a4d6c4',
-    legacy_id: 'OOG',
+    legacyId: 'OOG',
     description: 'Onshore Oil and Gas Extraction',
-    created_at: '2023-12-14 14:00:08.859089',
-    updated_at: '2024-07-23 14:00:04.516391'
+    createdAt: '2023-12-14 14:00:08.859089',
+    updatedAt: '2024-07-23 14:00:04.516391'
   }
 ]

--- a/test/support/seeders/data/secondary-purposes.js
+++ b/test/support/seeders/data/secondary-purposes.js
@@ -1,0 +1,445 @@
+'use strict'
+
+module.exports = [
+  {
+    id: '2457bfeb-a120-4b57-802a-46494bd22f82',
+    legacy_id: 'AGR',
+    description: 'General Agriculture',
+    created_at: '2023-12-14 14:00:08.859089',
+    updated_at: '2024-07-23 14:00:04.516391'
+  },
+  {
+    id: 'd0708921-b5c1-4a5b-b63b-31aab46016d8',
+    legacy_id: 'AQF',
+    description: 'Aquaculture Fish',
+    created_at: '2023-12-14 14:00:08.859089',
+    updated_at: '2024-07-23 14:00:04.516391'
+  },
+  {
+    id: '3dce7cf6-0ed2-48bd-ad6c-bf6c71f79db4',
+    legacy_id: 'AQP',
+    description: 'Aquaculture Plant',
+    created_at: '2023-12-14 14:00:08.859089',
+    updated_at: '2024-07-23 14:00:04.516391'
+  },
+  {
+    id: 'c05b93dd-a48f-49a8-a5e6-782252c18f9d',
+    legacy_id: 'BRW',
+    description: 'Breweries/Wine',
+    created_at: '2023-12-14 14:00:08.859089',
+    updated_at: '2024-07-23 14:00:04.516391'
+  },
+  {
+    id: '2d7ba5e2-b6e7-4ed2-a2d1-a1ad3f97229f',
+    legacy_id: 'BUS',
+    description: 'Business Parks',
+    created_at: '2023-12-14 14:00:08.859089',
+    updated_at: '2024-07-23 14:00:04.516391'
+  },
+  {
+    id: '7ea553b0-03df-4081-bcaa-e1f704aa3291',
+    legacy_id: 'CHE',
+    description: 'Chemicals',
+    created_at: '2023-12-14 14:00:08.859089',
+    updated_at: '2024-07-23 14:00:04.516391'
+  },
+  {
+    id: 'ceb6ae1d-fc8c-4cf9-ae01-269122c24c8d',
+    legacy_id: 'CON',
+    description: 'Construction',
+    created_at: '2023-12-14 14:00:08.859089',
+    updated_at: '2024-07-23 14:00:04.516391'
+  },
+  {
+    id: 'd83bc811-b48f-4e87-9916-4c47943d224c',
+    legacy_id: 'CRN',
+    description: 'Crown And Government',
+    created_at: '2023-12-14 14:00:08.859089',
+    updated_at: '2024-07-23 14:00:04.516391'
+  },
+  {
+    id: 'a50fd6db-96ab-46c6-804e-ddd035a4f1b4',
+    legacy_id: 'DAR',
+    description: 'Dairies',
+    created_at: '2023-12-14 14:00:08.859089',
+    updated_at: '2024-07-23 14:00:04.516391'
+  },
+  {
+    id: 'c8d3f626-a4d5-42ea-9f72-6e22c524048e',
+    legacy_id: 'ELC',
+    description: 'Electricity',
+    created_at: '2023-12-14 14:00:08.859089',
+    updated_at: '2024-07-23 14:00:04.516391'
+  },
+  {
+    id: 'e35d4bf3-9c23-48fc-881c-a258b78bb2d1',
+    legacy_id: 'EXT',
+    description: 'Extractive',
+    created_at: '2023-12-14 14:00:08.859089',
+    updated_at: '2024-07-23 14:00:04.516391'
+  },
+  {
+    id: 'eb7c97fd-a718-4136-a7a2-4f0151e0188c',
+    legacy_id: 'FAD',
+    description: 'Food & Drink',
+    created_at: '2023-12-14 14:00:08.859089',
+    updated_at: '2024-07-23 14:00:04.516391'
+  },
+  {
+    id: '9ca665af-5356-4a6d-b509-b96ee64de27a',
+    legacy_id: 'FOR',
+    description: 'Forestry',
+    created_at: '2023-12-14 14:00:08.859089',
+    updated_at: '2024-07-23 14:00:04.516391'
+  },
+  {
+    id: 'a76d6e29-88d1-4fa3-9136-d961a9cdb1bf',
+    legacy_id: 'GOF',
+    description: 'Golf Courses',
+    created_at: '2023-12-14 14:00:08.859089',
+    updated_at: '2024-07-23 14:00:04.516391'
+  },
+  {
+    id: 'ce8e913d-55fb-4f21-b2b2-755084661662',
+    legacy_id: 'HOL',
+    description: 'Holiday Sites, Camp Sites & Tourist Attractions',
+    created_at: '2023-12-14 14:00:08.859089',
+    updated_at: '2024-07-23 14:00:04.516391'
+  },
+  {
+    id: 'c7be8e7a-37a0-459a-bf26-97af4f120834',
+    legacy_id: 'HOR',
+    description: 'Horticulture And Nurseries',
+    created_at: '2023-12-14 14:00:08.859089',
+    updated_at: '2024-07-23 14:00:04.516391'
+  },
+  {
+    id: '2c397566-4cde-41c0-8cca-d152b554f528',
+    legacy_id: 'HOS',
+    description: 'Hospitals',
+    created_at: '2023-12-14 14:00:08.859089',
+    updated_at: '2024-07-23 14:00:04.516391'
+  },
+  {
+    id: 'c4165b99-f4f1-4124-acad-e512371d1bf7',
+    legacy_id: 'HTL',
+    description: 'Hotels, Public Houses And Conference Centres',
+    created_at: '2023-12-14 14:00:08.859089',
+    updated_at: '2024-07-23 14:00:04.516391'
+  },
+  {
+    id: '70abbcfd-b7b9-4eef-9f39-29468b32ce0e',
+    legacy_id: 'IND',
+    description: 'Industrial/Commercial/Energy/Public Services',
+    created_at: '2023-12-14 14:00:08.859089',
+    updated_at: '2024-07-23 14:00:04.516391'
+  },
+  {
+    id: 'ecd25cff-3749-49fd-ba30-9c86483b4a12',
+    legacy_id: 'LAU',
+    description: 'Laundry',
+    created_at: '2023-12-14 14:00:08.859089',
+    updated_at: '2024-07-23 14:00:04.516391'
+  },
+  {
+    id: 'ad036953-0e1b-43ce-a359-f452f344c4da',
+    legacy_id: 'MCH',
+    description: 'Machinery And Electronics',
+    created_at: '2023-12-14 14:00:08.859089',
+    updated_at: '2024-07-23 14:00:04.516391'
+  },
+  {
+    id: 'd5fb3110-0dde-46f7-b7a3-94d06052d8fc',
+    legacy_id: 'MEC',
+    description: 'Mechanical Non Electrical',
+    created_at: '2023-12-14 14:00:08.859089',
+    updated_at: '2024-07-23 14:00:04.516391'
+  },
+  {
+    id: '86708863-167a-4865-8383-cde90e7d1b43',
+    legacy_id: 'MIN',
+    description: 'Mineral Products',
+    created_at: '2023-12-14 14:00:08.859089',
+    updated_at: '2024-07-23 14:00:04.516391'
+  },
+  {
+    id: 'af1eec87-602c-41de-a982-2417bbc320a2',
+    legacy_id: 'MTL',
+    description: 'Metal',
+    created_at: '2023-12-14 14:00:08.859089',
+    updated_at: '2024-07-23 14:00:04.516391'
+  },
+  {
+    id: '7cff0b52-da01-4a29-b29c-a4bba4036324',
+    legacy_id: 'MUN',
+    description: 'Municipal Grounds',
+    created_at: '2023-12-14 14:00:08.859089',
+    updated_at: '2024-07-23 14:00:04.516391'
+  },
+  {
+    id: '4bbdf3ff-9efa-4303-bea8-f7d419022922',
+    legacy_id: 'NAV',
+    description: 'Navigation',
+    created_at: '2023-12-14 14:00:08.859089',
+    updated_at: '2024-07-23 14:00:04.516391'
+  },
+  {
+    id: '00237355-5b18-44d9-a5c4-785e387739fb',
+    legacy_id: 'NRE',
+    description: 'Non-Remedial River/Wetland Support',
+    created_at: '2023-12-14 14:00:08.859089',
+    updated_at: '2024-07-23 14:00:04.516391'
+  },
+  {
+    id: '789824ee-140e-4871-b453-b17ac12ab095',
+    legacy_id: 'ORC',
+    description: 'Orchards',
+    created_at: '2023-12-14 14:00:08.859089',
+    updated_at: '2024-07-23 14:00:04.516391'
+  },
+  {
+    id: '303cc214-6118-417b-b6ee-343257af3a3b',
+    legacy_id: 'OTE',
+    description: 'Other Environmental Improvements',
+    created_at: '2023-12-14 14:00:08.859089',
+    updated_at: '2024-07-23 14:00:04.516391'
+  },
+  {
+    id: 'f85ab791-e943-4492-a3bb-c0b3ad3f0712',
+    legacy_id: 'OTI',
+    description: 'Other Industrial/Commercial/Public Services',
+    created_at: '2023-12-14 14:00:08.859089',
+    updated_at: '2024-07-23 14:00:04.516391'
+  },
+  {
+    id: 'a58ef991-ea9b-4443-862d-811327ccd3dc',
+    legacy_id: 'PAD',
+    description: 'Public Administration',
+    created_at: '2023-12-14 14:00:08.859089',
+    updated_at: '2024-07-23 14:00:04.516391'
+  },
+  {
+    id: 'e882c4a6-53d0-4b82-b921-499d25428134',
+    legacy_id: 'PAP',
+    description: 'Paper And Printing',
+    created_at: '2023-12-14 14:00:08.859089',
+    updated_at: '2024-07-23 14:00:04.516391'
+  },
+  {
+    id: 'f47814e0-a7a9-45be-af75-4d2b58784be0',
+    legacy_id: 'PET',
+    description: 'Petrochemicals',
+    created_at: '2023-12-14 14:00:08.859089',
+    updated_at: '2024-07-23 14:00:04.516391'
+  },
+  {
+    id: '6cbb6f30-64bd-47e5-b852-5089e7088568',
+    legacy_id: 'PRI',
+    description: 'Private Non-Industrial',
+    created_at: '2023-12-14 14:00:08.859089',
+    updated_at: '2024-07-23 14:00:04.516391'
+  },
+  {
+    id: '8b324ba7-7d82-46d8-ae61-bc343e388745',
+    legacy_id: 'PRV',
+    description: 'Private Water Supply',
+    created_at: '2023-12-14 14:00:08.859089',
+    updated_at: '2024-07-23 14:00:04.516391'
+  },
+  {
+    id: '2362c06f-bb1e-4649-8342-29cc94017774',
+    legacy_id: 'PUM',
+    description: 'Pump & Treat',
+    created_at: '2023-12-14 14:00:08.859089',
+    updated_at: '2024-07-23 14:00:04.516391'
+  },
+  {
+    id: '866fe96a-1536-4396-85b3-de073ac2f92f',
+    legacy_id: 'PWS',
+    description: 'Public Water Supply',
+    created_at: '2023-12-14 14:00:08.859089',
+    updated_at: '2024-07-23 14:00:04.516391'
+  },
+  {
+    id: '1d3877a3-c5cf-405a-9e07-4fe94689f4ea',
+    legacy_id: 'PWU',
+    description: 'Private Water Undertaking',
+    created_at: '2023-12-14 14:00:08.859089',
+    updated_at: '2024-07-23 14:00:04.516391'
+  },
+  {
+    id: 'b9a4c156-77e8-4891-95f4-6df745e58d42',
+    legacy_id: 'RAC',
+    description: 'Racecourses',
+    created_at: '2023-12-14 14:00:08.859089',
+    updated_at: '2024-07-23 14:00:04.516391'
+  },
+  {
+    id: '04d711bb-607c-4814-aca9-0c6bd39e0ea4',
+    legacy_id: 'REF',
+    description: 'Refuse And Recycling',
+    created_at: '2023-12-14 14:00:08.859089',
+    updated_at: '2024-07-23 14:00:04.516391'
+  },
+  {
+    id: '3c2a4aab-c2a7-4fea-aa06-bcdf2d9e499f',
+    legacy_id: 'REM',
+    description: 'Remedial River/Wetland Support',
+    created_at: '2023-12-14 14:00:08.859089',
+    updated_at: '2024-07-23 14:00:04.516391'
+  },
+  {
+    id: 'c0691f62-1022-4cef-8f9b-575099f62c20',
+    legacy_id: 'RES',
+    description: 'Research Non- University/College',
+    created_at: '2023-12-14 14:00:08.859089',
+    updated_at: '2024-07-23 14:00:04.516391'
+  },
+  {
+    id: 'b6d3c0c8-4018-4553-9393-0e87a3c91a8f',
+    legacy_id: 'RET',
+    description: 'Retail',
+    created_at: '2023-12-14 14:00:08.859089',
+    updated_at: '2024-07-23 14:00:04.516391'
+  },
+  {
+    id: 'bf32cb71-8f5a-4055-913a-3c16942abb8c',
+    legacy_id: 'RUB',
+    description: 'Rubber',
+    created_at: '2023-12-14 14:00:08.859089',
+    updated_at: '2024-07-23 14:00:04.516391'
+  },
+  {
+    id: 'f06c3e2e-0a0b-4cd5-81bd-04d527bd8533',
+    legacy_id: 'SCH',
+    description: 'Schools And Colleges',
+    created_at: '2023-12-14 14:00:08.859089',
+    updated_at: '2024-07-23 14:00:04.516391'
+  },
+  {
+    id: 'b6fbd08e-a4ad-4a9b-871e-30ac51efee78',
+    legacy_id: 'SLA',
+    description: 'Slaughtering',
+    created_at: '2023-12-14 14:00:08.859089',
+    updated_at: '2024-07-23 14:00:04.516391'
+  },
+  {
+    id: '59bd435f-5651-4cc5-bdf8-fb8e3697f95a',
+    legacy_id: 'SPO',
+    description: 'Sports Grounds/Facilities',
+    created_at: '2023-12-14 14:00:08.859089',
+    updated_at: '2024-07-23 14:00:04.516391'
+  },
+  {
+    id: '9c16f3e8-4ea0-4292-8802-8427bec0571a',
+    legacy_id: 'TRA',
+    description: 'Transport',
+    created_at: '2023-12-14 14:00:08.859089',
+    updated_at: '2024-07-23 14:00:04.516391'
+  },
+  {
+    id: 'c778de53-0fd4-445e-af86-3c441f79e07b',
+    legacy_id: 'TXT',
+    description: 'Textiles & Leather',
+    created_at: '2023-12-14 14:00:08.859089',
+    updated_at: '2024-07-23 14:00:04.516391'
+  },
+  {
+    id: '9b1828d1-d319-4d6c-a620-d9828c455fcb',
+    legacy_id: 'UNK',
+    description: 'Unknown (for impounding exluding impoundments for HEP)',
+    created_at: '2023-12-14 14:00:08.859089',
+    updated_at: '2024-07-23 14:00:04.516391'
+  },
+  {
+    id: 'eecd8280-9b2f-4279-b300-d4b3441bd87c',
+    legacy_id: 'WAT',
+    description: 'Water Supply Related',
+    created_at: '2023-12-14 14:00:08.859089',
+    updated_at: '2024-07-23 14:00:04.516391'
+  },
+  {
+    id: 'f6f7b6bf-6447-4092-8cd6-27cae2d8956e',
+    legacy_id: 'ZOO',
+    description: 'Zoos/Kennels/Stables',
+    created_at: '2023-12-14 14:00:08.859089',
+    updated_at: '2024-07-23 14:00:04.516391'
+  },
+  {
+    id: '490db793-eddf-4fed-93ce-78260b8d0584',
+    legacy_id: 'CRW',
+    description: 'Crown - Other',
+    created_at: '2023-12-14 14:00:08.859089',
+    updated_at: '2024-07-23 14:00:04.516391'
+  },
+  {
+    id: '09545099-a184-4e98-be2a-e749d24392e9',
+    legacy_id: 'GOV',
+    description: 'Government Departments - Other',
+    created_at: '2023-12-14 14:00:08.859089',
+    updated_at: '2024-07-23 14:00:04.516391'
+  },
+  {
+    id: '6bb0f9c0-7ef0-4da4-9c0f-2a60fc6b4785',
+    legacy_id: 'DET',
+    description: 'Detention And Immigration Centres',
+    created_at: '2023-12-14 14:00:08.859089',
+    updated_at: '2024-07-23 14:00:04.516391'
+  },
+  {
+    id: '3fd3cf82-47ff-4f01-b523-96959f2d635b',
+    legacy_id: 'VIF',
+    description: 'Visiting Armed Forces',
+    created_at: '2023-12-14 14:00:08.859089',
+    updated_at: '2024-07-23 14:00:04.516391'
+  },
+  {
+    id: '8b836771-6d7e-4277-b03f-473c0504d02b',
+    legacy_id: 'FRT',
+    description: 'Government Or Crown Forestry',
+    created_at: '2023-12-14 14:00:08.859089',
+    updated_at: '2024-07-23 14:00:04.516391'
+  },
+  {
+    id: '489930ca-cef9-4604-86be-31ef01954cc7',
+    legacy_id: 'CVY',
+    description: 'Statutory Water Conservancy Operation',
+    created_at: '2023-12-14 14:00:08.859089',
+    updated_at: '2024-07-23 14:00:04.516391'
+  },
+  {
+    id: '607f230d-e96b-4383-a588-f7976cbf3e6b',
+    legacy_id: 'HRB',
+    description: 'Ports And Harbour Authority Operation',
+    created_at: '2023-12-14 14:00:08.859089',
+    updated_at: '2024-07-23 14:00:04.516391'
+  },
+  {
+    id: '075d0549-4075-47f4-9e1a-944e96a63eec',
+    legacy_id: 'DRG',
+    description: 'Drainage Operations',
+    created_at: '2023-12-14 14:00:08.859089',
+    updated_at: '2024-07-23 14:00:04.516391'
+  },
+  {
+    id: '678fa94b-6320-44d2-a21d-5d772040de6c',
+    legacy_id: 'POW',
+    description: 'Domestic Premises Related',
+    created_at: '2023-12-14 14:00:08.859089',
+    updated_at: '2024-07-23 14:00:04.516391'
+  },
+  {
+    id: 'd4f9f23b-1602-4846-9b05-07a49d2bd9c5',
+    legacy_id: 'MOD',
+    description: 'Mod (Ministry Of Defence)',
+    created_at: '2023-12-14 14:00:08.859089',
+    updated_at: '2024-07-23 14:00:04.516391'
+  },
+  {
+    id: '7f75f247-5b3c-4785-954c-207456a4d6c4',
+    legacy_id: 'OOG',
+    description: 'Onshore Oil and Gas Extraction',
+    created_at: '2023-12-14 14:00:08.859089',
+    updated_at: '2024-07-23 14:00:04.516391'
+  }
+]

--- a/test/support/seeders/licence-abstraction-data.seeder.js
+++ b/test/support/seeders/licence-abstraction-data.seeder.js
@@ -4,16 +4,18 @@
  * @module LicenceAbstractionDataSeeder
  */
 
+const SecondaryPurposesSeeder = require('./secondary-purpose.seeder.js')
+const PrimaryPurposesSeeder = require('./primary-purpose.seeder.js')
+const PurposesSeeder = require('./purposes.seeder.js')
+
 const FinancialAgreementHelper = require('../helpers/financial-agreement.helper.js')
 const LicenceFinancialAgreement = require('../helpers/licence-agreement.helper.js')
 const LicenceHelper = require('../helpers/licence.helper.js')
 const LicenceVersionHelper = require('../helpers/licence-version.helper.js')
 const LicenceVersionPurposeHelper = require('../helpers/licence-version-purpose.helper.js')
 const PermitLicenceHelper = require('../helpers/permit-licence.helper.js')
-const PrimaryPurposeHelper = require('../helpers/primary-purpose.helper.js')
-const PurposeHelper = require('../helpers/purpose.helper.js')
 const RegionHelper = require('../helpers/region.helper.js')
-const SecondaryPurposeHelper = require('../helpers/secondary-purpose.helper.js')
+const { purpose } = require('../../../app/controllers/return-requirements.controller')
 
 /**
  * Seeds a licence with all the related records to get a 'real' set of abstraction data
@@ -190,43 +192,19 @@ async function _permitLicence (licenceRef) {
 }
 
 async function _purposes () {
-  const { id: heatPumpId } = await PurposeHelper.add({
-    legacyId: '200',
-    description: 'Heat Pump',
-    twoPartTariff: false
-  })
+  const { id: heatPumpId } = PurposesSeeder.data.find((purpose) => { return purpose.legacyId === '200' })
 
-  const { id: sprayIrrigationDirectId } = await PurposeHelper.add({
-    legacyId: '400',
-    description: 'Spray Irrigation - Direct',
-    twoPartTariff: true
-  })
+  const { id: sprayIrrigationDirectId } = PurposesSeeder.data.find((purpose) => { return purpose.legacyId === '400' })
 
-  const { id: vegetableWashingId } = await PurposeHelper.add({
-    legacyId: '460',
-    description: 'Vegetable washing',
-    twoPartTariff: false
-  })
+  const { id: vegetableWashingId } = PurposesSeeder.data.find((purpose) => { return purpose.legacyId === '460' })
 
-  const { id: primaryAgricultureId } = await PrimaryPurposeHelper.add({
-    legacyId: 'A',
-    description: 'Agriculture'
-  })
+  const { id: primaryAgricultureId } = PrimaryPurposesSeeder.data.find((purpose) => { return purpose.legacyId === 'A' })
 
-  const { id: primaryElectricityId } = await PrimaryPurposeHelper.add({
-    legacyId: 'P',
-    description: 'Production Of Energy'
-  })
+  const { id: primaryElectricityId } = PrimaryPurposesSeeder.data.find((purpose) => { return purpose.legacyId === 'P' })
 
-  const { id: secondaryAgricultureId } = await SecondaryPurposeHelper.add({
-    legacyId: 'AGR',
-    description: 'General Agriculture'
-  })
+  const { id: secondaryAgricultureId } = SecondaryPurposesSeeder.data.find((purpose) => { return purpose.legacyId === 'AGR' })
 
-  const { id: secondaryElectricityId } = await SecondaryPurposeHelper.add({
-    legacyId: 'ELC',
-    description: 'Electricity'
-  })
+  const { id: secondaryElectricityId } = SecondaryPurposesSeeder.data.find((purpose) => { return purpose.legacyId === 'ELC' })
 
   return {
     purposes: { heatPumpId, sprayIrrigationDirectId, vegetableWashingId },

--- a/test/support/seeders/primary-purpose.seeder.js
+++ b/test/support/seeders/primary-purpose.seeder.js
@@ -1,0 +1,28 @@
+'use strict'
+
+/**
+ * @module PrimaryPurposesSeeder
+ */
+
+const data = require('./data/primary-purposes.js')
+const { buildSeedValueString } = require('./seed-builder.js')
+const { db } = require('../../../db/db.js')
+
+const keys = ['id', 'legacy_id', 'description', 'created_at', 'updated_at']
+
+/**
+ * Add all the purposes to the database
+ *
+ */
+async function seed () {
+  await db.raw(`
+    INSERT INTO  public.primary_purposes (id, legacy_id, description, created_at, updated_at)
+      VALUES ${buildSeedValueString(keys, data)};
+  `
+  )
+}
+
+module.exports = {
+  seed,
+  data
+}

--- a/test/support/seeders/primary-purpose.seeder.js
+++ b/test/support/seeders/primary-purpose.seeder.js
@@ -8,7 +8,7 @@ const data = require('./data/primary-purposes.js')
 const { buildSeedValueString } = require('./seed-builder.js')
 const { db } = require('../../../db/db.js')
 
-const keys = ['id', 'legacy_id', 'description', 'created_at', 'updated_at']
+const keys = ['id', 'legacyId', 'description', 'createdAt', 'updatedAt']
 
 /**
  * Add all the purposes to the database

--- a/test/support/seeders/purposes.seeder.js
+++ b/test/support/seeders/purposes.seeder.js
@@ -8,7 +8,7 @@ const data = require('./data/purposes.data.js')
 const { buildSeedValueString } = require('./seed-builder.js')
 const { db } = require('../../../db/db.js')
 
-const keys = ['id', 'legacy_id', 'description', 'loss_factor', 'two_part_tariff', 'created_at', 'updated_at']
+const keys = ['id', 'legacyId', 'description', 'lossFactor', 'twoPartTariff', 'createdAt', 'updatedAt']
 
 /**
  * Add all the purposes to the database

--- a/test/support/seeders/purposes.seeder.js
+++ b/test/support/seeders/purposes.seeder.js
@@ -1,0 +1,28 @@
+'use strict'
+
+/**
+ * @module PurposesSeeder
+ */
+
+const purposeData = require('./data/purposes.data.js')
+const { buildSeedValueString } = require('./seed-builder.js')
+const { db } = require('../../../db/db.js')
+
+const keys = ['id', 'legacy_id', 'description', 'loss_factor', 'two_part_tariff', 'created_at', 'updated_at']
+
+/**
+ * Add all the purposes to the database
+ *
+ */
+async function seed () {
+  await db.raw(`
+    INSERT INTO  public.purposes (id, legacy_id, description, loss_factor, two_part_tariff, created_at, updated_at)
+      VALUES ${buildSeedValueString(keys, purposeData)};
+  `
+  )
+}
+
+module.exports = {
+  seed,
+  purposeData
+}

--- a/test/support/seeders/purposes.seeder.js
+++ b/test/support/seeders/purposes.seeder.js
@@ -4,7 +4,7 @@
  * @module PurposesSeeder
  */
 
-const purposeData = require('./data/purposes.data.js')
+const data = require('./data/purposes.data.js')
 const { buildSeedValueString } = require('./seed-builder.js')
 const { db } = require('../../../db/db.js')
 
@@ -17,12 +17,12 @@ const keys = ['id', 'legacy_id', 'description', 'loss_factor', 'two_part_tariff'
 async function seed () {
   await db.raw(`
     INSERT INTO  public.purposes (id, legacy_id, description, loss_factor, two_part_tariff, created_at, updated_at)
-      VALUES ${buildSeedValueString(keys, purposeData)};
+      VALUES ${buildSeedValueString(keys, data)};
   `
   )
 }
 
 module.exports = {
   seed,
-  purposeData
+  data
 }

--- a/test/support/seeders/requirements-for-returns.seeder.js
+++ b/test/support/seeders/requirements-for-returns.seeder.js
@@ -93,7 +93,9 @@ async function _returnRequirement (
 
   returnRequirement.returnRequirementPoints = [point]
 
-  const purpose = PurposesSeeder.data.find((purpose) => { return purpose.legacyId === '420' })
+  const purpose = PurposesSeeder.data.find((purpose) => {
+    return purpose.legacyId === '420'
+  })
 
   const returnRequirementPurpose = await ReturnRequirementPurposeHelper.add({
     purposeId: purpose.id, returnRequirementId, alias

--- a/test/support/seeders/requirements-for-returns.seeder.js
+++ b/test/support/seeders/requirements-for-returns.seeder.js
@@ -4,14 +4,14 @@
  * @module RequirementsForReturnsSeeder
  */
 
-const { generateUUID } = require('../../../app/lib/general.lib.js')
 const LicenceHelper = require('../helpers/licence.helper.js')
-const PurposeHelper = require('../helpers/purpose.helper.js')
+const PurposesSeeder = require('../seeders/purposes.seeder.js')
+const ReturnRequirementHelper = require('../helpers/return-requirement.helper.js')
 const ReturnRequirementPointHelper = require('../helpers/return-requirement-point.helper.js')
 const ReturnRequirementPurposeHelper = require('../helpers/return-requirement-purpose.helper.js')
-const ReturnRequirementHelper = require('../helpers/return-requirement.helper.js')
 const ReturnVersionHelper = require('../helpers/return-version.helper.js')
 const UserHelper = require('../helpers/user.helper.js')
+const { generateUUID } = require('../../../app/lib/general.lib.js')
 
 /**
  * Add a complete 'requirements for returns' record, including return version, requirements, points and purposes
@@ -93,7 +93,7 @@ async function _returnRequirement (
 
   returnRequirement.returnRequirementPoints = [point]
 
-  const purpose = await PurposeHelper.add()
+  const purpose = PurposesSeeder.data.find((purpose) => { return purpose.legacyId === '420' })
 
   const returnRequirementPurpose = await ReturnRequirementPurposeHelper.add({
     purposeId: purpose.id, returnRequirementId, alias

--- a/test/support/seeders/secondary-purpose.seeder.js
+++ b/test/support/seeders/secondary-purpose.seeder.js
@@ -8,7 +8,7 @@ const data = require('./data/secondary-purposes.js')
 const { buildSeedValueString } = require('./seed-builder.js')
 const { db } = require('../../../db/db.js')
 
-const keys = ['id', 'legacy_id', 'description', 'created_at', 'updated_at']
+const keys = ['id', 'legacyId', 'description', 'createdAt', 'updatedAt']
 
 /**
  * Add all the purposes to the database

--- a/test/support/seeders/secondary-purpose.seeder.js
+++ b/test/support/seeders/secondary-purpose.seeder.js
@@ -1,0 +1,28 @@
+'use strict'
+
+/**
+ * @module SecondaryPurposesSeeder
+ */
+
+const data = require('./data/secondary-purposes.js')
+const { buildSeedValueString } = require('./seed-builder.js')
+const { db } = require('../../../db/db.js')
+
+const keys = ['id', 'legacy_id', 'description', 'created_at', 'updated_at']
+
+/**
+ * Add all the purposes to the database
+ *
+ */
+async function seed () {
+  await db.raw(`
+    INSERT INTO  public.secondary_purposes (id, legacy_id, description, created_at, updated_at)
+      VALUES ${buildSeedValueString(keys, data)};
+  `
+  )
+}
+
+module.exports = {
+  seed,
+  data
+}

--- a/test/support/seeders/seed-builder.js
+++ b/test/support/seeders/seed-builder.js
@@ -6,7 +6,11 @@ function buildSeedValueString (keys, data) {
   data.forEach((obj, i) => {
     valueString += '('
     keys.forEach((key, index) => {
-      valueString += `'${obj[key]}'`
+      if (key === 'createdAt' || key === 'updatedAt') {
+        valueString += `'${obj[key].toISOString()}'`
+      } else {
+        valueString += `'${obj[key]}'`
+      }
 
       if (index < keys.length - 1) {
         valueString += ','

--- a/test/support/seeders/seed-builder.js
+++ b/test/support/seeders/seed-builder.js
@@ -1,0 +1,28 @@
+'use strict'
+
+function buildSeedValueString (keys, data) {
+  let valueString = ''
+
+  data.forEach((obj, i) => {
+    valueString += '('
+    keys.forEach((key, index) => {
+      valueString += `'${obj[key]}'`
+
+      if (index < keys.length - 1) {
+        valueString += ','
+      }
+    })
+
+    valueString += ')'
+
+    if (i < data.length - 1) {
+      valueString += ','
+    }
+  })
+
+  return valueString
+}
+
+module.exports = {
+  buildSeedValueString
+}


### PR DESCRIPTION
The public.purposes, public.primary_purpose and public.secondary_purpose tables are what we call reference data. We assume these tables will not change frequently, if ever.

As part of the work to replace the legacy import service we have decided to seed any data we have deemed reference data.

We will use these seeders in testing.

This change will add a seeder for the reference data for purposes, primary purpose and secondary purpose. It will export its data to be used in tests. 

Where test have failed they have been updated and where possible the db clean function has been removed from the bfe. 