### PR TITLE
Align regions seeder

### DIFF
--- a/test/services/bill-runs/fetch-region.service.test.js
+++ b/test/services/bill-runs/fetch-region.service.test.js
@@ -14,13 +14,15 @@ const RegionsSeeder = require('../../support/seeders/regions.seeder.js')
 const FetchRegionService = require('../../../app/services/bill-runs/fetch-region.service.js')
 
 describe('Fetch Region service', () => {
-  const { anglian } = RegionsSeeder.regions
+  const region = RegionsSeeder.data.find((region) => {
+    return region.displayName === 'displayName'
+  })
 
   describe('when there is a region with a matching NALD region id', () => {
     it('returns results', async () => {
-      const result = await FetchRegionService.go(anglian.nald_region_id)
+      const result = await FetchRegionService.go(region.naldRegionId)
 
-      expect(result.id).to.equal(anglian.id)
+      expect(result.id).to.equal(region.id)
     })
   })
 

--- a/test/services/bill-runs/fetch-region.service.test.js
+++ b/test/services/bill-runs/fetch-region.service.test.js
@@ -15,7 +15,7 @@ const FetchRegionService = require('../../../app/services/bill-runs/fetch-region
 
 describe('Fetch Region service', () => {
   const region = RegionsSeeder.data.find((region) => {
-    return region.displayName === 'displayName'
+    return region.displayName === 'Test Region'
   })
 
   describe('when there is a region with a matching NALD region id', () => {

--- a/test/services/bill-runs/setup/fetch-regions.service.test.js
+++ b/test/services/bill-runs/setup/fetch-regions.service.test.js
@@ -19,17 +19,12 @@ describe('Bill Runs Setup Fetch Regions service', () => {
       const results = await FetchRegionsService.go()
 
       // This is necessary because other region helpers are adding regions into the database as part of their tests.
-      const expectedRegions = [
-        { id: RegionSeeder.regions.anglian.id, displayName: RegionSeeder.regions.anglian.display_name },
-        { id: RegionSeeder.regions.midlands.id, displayName: RegionSeeder.regions.midlands.display_name },
-        { id: RegionSeeder.regions.north_east.id, displayName: RegionSeeder.regions.north_east.display_name },
-        { id: RegionSeeder.regions.north_west.id, displayName: RegionSeeder.regions.north_west.display_name },
-        { id: RegionSeeder.regions.southern.id, displayName: RegionSeeder.regions.southern.display_name },
-        { id: RegionSeeder.regions.south_west.id, displayName: RegionSeeder.regions.south_west.display_name },
-        { id: RegionSeeder.regions.test_region.id, displayName: RegionSeeder.regions.test_region.display_name },
-        { id: RegionSeeder.regions.thames.id, displayName: RegionSeeder.regions.thames.display_name },
-        { id: RegionSeeder.regions.ea_wales.id, displayName: RegionSeeder.regions.ea_wales.display_name }
-      ]
+      const expectedRegions = RegionSeeder.data.map((region) => {
+        return {
+          id: region.id,
+          displayName: region.displayName
+        }
+      })
 
       // This should be removed and do an exact check when the others tests have been migrated to use the seeded regions
       expectedRegions.forEach((expectedRegion) => {

--- a/test/services/import/legacy-licence.service.test.js
+++ b/test/services/import/legacy-licence.service.test.js
@@ -23,12 +23,14 @@ const LegacyImportLicenceService =
 describe('Legacy import licence service', () => {
   const licenceRef = FixtureLicence.LIC_NO
 
-  const region = RegionsSeeder.regions.test_region
+  const region = RegionsSeeder.data.find((region) => {
+    return region.displayName === 'displayName'
+  })
 
   beforeEach(async () => {
     Sinon.stub(FetchLegacyImportLicenceService, 'go').resolves({
       ...FixtureLicence,
-      FGAC_REGION_CODE: region.nald_region_id
+      FGAC_REGION_CODE: region.naldRegionId
     })
 
     Sinon.stub(FetchLegacyImportLicenceVersionsService, 'go').resolves([...FixtureVersions])

--- a/test/services/import/legacy-licence.service.test.js
+++ b/test/services/import/legacy-licence.service.test.js
@@ -24,7 +24,7 @@ describe('Legacy import licence service', () => {
   const licenceRef = FixtureLicence.LIC_NO
 
   const region = RegionsSeeder.data.find((region) => {
-    return region.displayName === 'displayName'
+    return region.displayName === 'Test Region'
   })
 
   beforeEach(async () => {

--- a/test/services/import/persist-licence.service.test.js
+++ b/test/services/import/persist-licence.service.test.js
@@ -21,7 +21,9 @@ describe('Persist licence service', () => {
   let licence
 
   beforeEach(async () => {
-    region = RegionsSeeder.regions.test_region
+    region = RegionsSeeder.data.find((region) => {
+      return region.displayName === 'displayName'
+    })
   })
 
   describe('when the licence ref does not exist', () => {
@@ -30,7 +32,7 @@ describe('Persist licence service', () => {
         expiredDate: '2015-03-31',
         lapsedDate: null,
         licenceRef: generateLicenceRef(),
-        naldRegionId: region.nald_region_id,
+        naldRegionId: region.naldRegionId,
         regions: {
           historicalAreaCode: 'RIDIN',
           regionalChargeArea: 'Yorkshire',
@@ -75,7 +77,7 @@ describe('Persist licence service', () => {
         expiredDate: '2015-03-31',
         lapsedDate: null,
         licenceRef: generateLicenceRef(),
-        naldRegionId: region.nald_region_id,
+        naldRegionId: region.naldRegionId,
         regions: {
           historicalAreaCode: 'RIDIN',
           regionalChargeArea: 'Yorkshire',
@@ -94,7 +96,7 @@ describe('Persist licence service', () => {
     it('returns newly updated licence', async () => {
       const results = await PersistLicenceService.go({
         licenceRef: licence.licenceRef,
-        naldRegionId: region.nald_region_id,
+        naldRegionId: region.naldRegionId,
         //  not null constraints
         waterUndertaker: true,
         regions: licence.regions,

--- a/test/services/import/persist-licence.service.test.js
+++ b/test/services/import/persist-licence.service.test.js
@@ -22,7 +22,7 @@ describe('Persist licence service', () => {
 
   beforeEach(async () => {
     region = RegionsSeeder.data.find((region) => {
-      return region.displayName === 'displayName'
+      return region.displayName === 'Test Region'
     })
   })
 

--- a/test/support/seeders/data/region.data.js
+++ b/test/support/seeders/data/region.data.js
@@ -1,0 +1,85 @@
+'use strict'
+
+module.exports = [
+  {
+    id: 'a5f868ec-f51c-478d-924c-37852626b7c1',
+    chargeRegionId: 'A',
+    naldRegionId: 1,
+    name: 'Anglian',
+    displayName: 'Anglian',
+    createdAt: new Date('2023-12-14'),
+    updatedAt: new Date('2023-12-14')
+  },
+  {
+    id: '1acb3cc9-ee16-4276-b0f4-37603d791698',
+    chargeRegionId: 'B',
+    naldRegionId: 2,
+    name: 'Midlands',
+    displayName: 'Midlands',
+    createdAt: new Date('2023-12-14'),
+    updatedAt: new Date('2023-12-14')
+  },
+  {
+    id: '36706540-0985-4cef-b7e5-ab4345049b22',
+    chargeRegionId: 'Y',
+    naldRegionId: 3,
+    name: 'North East',
+    displayName: 'North East',
+    createdAt: new Date('2023-12-14'),
+    updatedAt: new Date('2023-12-14')
+  },
+  {
+    id: 'eb57737f-b309-49c2-9ab6-f701e3a6fd96',
+    chargeRegionId: 'N',
+    naldRegionId: 4,
+    name: 'North West',
+    displayName: 'North West',
+    createdAt: new Date('2023-12-14'),
+    updatedAt: new Date('2023-12-14')
+  },
+  {
+    id: '4ccf3c5b-ab4e-48e1-afa8-3b18b5d07fab',
+    chargeRegionId: 'E',
+    naldRegionId: 5,
+    name: 'South West',
+    displayName: 'South West',
+    createdAt: new Date('2023-12-14'),
+    updatedAt: new Date('2023-12-14')
+  },
+  {
+    id: 'd34d9f4f-11ed-46f5-b4fb-15d5988c2870',
+    chargeRegionId: 'S',
+    naldRegionId: 6,
+    name: 'Southern',
+    displayName: 'Southern',
+    createdAt: new Date('2023-12-14'),
+    updatedAt: new Date('2023-12-14')
+  },
+  {
+    id: '7af8fb71-e197-4f85-bee4-23b62ef711c6',
+    chargeRegionId: 'T',
+    naldRegionId: 7,
+    name: 'Thames',
+    displayName: 'Thames',
+    createdAt: new Date('2023-12-14'),
+    updatedAt: new Date('2023-12-14')
+  },
+  {
+    id: '77d44d65-6f33-425e-9075-ae5ac43a0c36',
+    chargeRegionId: 'W',
+    naldRegionId: 8,
+    name: 'EA Wales',
+    displayName: 'Wales',
+    createdAt: new Date('2023-12-14'),
+    updatedAt: new Date('2023-12-14')
+  },
+  {
+    id: 'd0a4123d-1e19-480d-9dd4-f70f3387c4b9',
+    chargeRegionId: 'S',
+    naldRegionId: 9,
+    name: 'Test Region',
+    displayName: 'Test Region',
+    createdAt: new Date('2024-07-18'),
+    updatedAt: new Date('2024-07-18')
+  }
+]

--- a/test/support/seeders/regions.seeder.js
+++ b/test/support/seeders/regions.seeder.js
@@ -4,87 +4,11 @@
  * @module RegionsSeeder
  */
 
+const data = require('./data/region.data.js')
+const { buildSeedValueString } = require('./seed-builder.js')
 const { db } = require('../../../db/db.js')
 
-const regions = {
-  anglian: {
-    id: 'a5f868ec-f51c-478d-924c-37852626b7c1',
-    charge_region_id: 'A',
-    nald_region_id: 1,
-    name: 'Anglian',
-    display_name: 'Anglian'
-  },
-  midlands: {
-    id: '1acb3cc9-ee16-4276-b0f4-37603d791698',
-    charge_region_id: 'B',
-    nald_region_id: 2,
-    name: 'Midlands',
-    display_name: 'Midlands'
-  },
-  north_east: {
-    id: '36706540-0985-4cef-b7e5-ab4345049b22',
-    charge_region_id: 'Y',
-    nald_region_id: 3,
-    name: 'North East',
-    display_name: 'North East'
-  },
-  north_west: {
-    id: 'eb57737f-b309-49c2-9ab6-f701e3a6fd96',
-    charge_region_id: 'N',
-    nald_region_id: 4,
-    name: 'North West',
-    display_name: 'North West'
-  },
-  south_west: {
-    id: '4ccf3c5b-ab4e-48e1-afa8-3b18b5d07fab',
-    charge_region_id: 'E',
-    nald_region_id: 5,
-    name: 'South West',
-    display_name: 'South West'
-  },
-  southern: {
-    id: 'd34d9f4f-11ed-46f5-b4fb-15d5988c2870',
-    charge_region_id: 'S',
-    nald_region_id: 6,
-    name: 'Southern',
-    display_name: 'Southern'
-  },
-  thames: {
-    id: '7af8fb71-e197-4f85-bee4-23b62ef711c6',
-    charge_region_id: 'T',
-    nald_region_id: 7,
-    name: 'Thames',
-    display_name: 'Thames'
-  },
-  ea_wales: {
-    id: '77d44d65-6f33-425e-9075-ae5ac43a0c36',
-    charge_region_id: 'W',
-    nald_region_id: 8,
-    name: 'EA Wales',
-    display_name: 'Wales'
-  },
-  test_region: {
-    // this id corresponds to the id used in the acceptance tests
-    id: 'd0a4123d-1e19-480d-9dd4-f70f3387c4b9',
-    charge_region_id: 'S',
-    nald_region_id: 9,
-    name: 'Test Region',
-    display_name: 'Test Region'
-  }
-}
-
-function createValueStringFromRegions () {
-  let valueString = ''
-
-  for (const regionsKey in regions) {
-    valueString += `('${regions[regionsKey].id}', '${regions[regionsKey].charge_region_id}', '${regions[regionsKey].nald_region_id}', '${regions[regionsKey].name}', '${regions[regionsKey].display_name}')`
-
-    // Add comma to all but the last value
-    valueString += (regionsKey === 'test_region' ? '' : ',')
-  }
-
-  return valueString
-}
+const keys = ['id', 'chargeRegionId', 'naldRegionId', 'name', 'displayName', 'createdAt', 'updatedAt']
 
 /**
  * Add all the regions to the database
@@ -92,13 +16,13 @@ function createValueStringFromRegions () {
  */
 async function seed () {
   await db.raw(`
-    INSERT INTO  public.regions (id, charge_region_id, nald_region_id, name, display_name)
-      VALUES ${createValueStringFromRegions()};
+    INSERT INTO  public.regions (id, charge_region_id, nald_region_id, name, display_name, created_at, updated_at)
+      VALUES ${buildSeedValueString(keys, data)};
   `
   )
 }
 
 module.exports = {
   seed,
-  regions
+  data
 }


### PR DESCRIPTION
The public.regions table is what we call reference data. We assume this table will not change frequently, if ever.

As part of the work to replace the legacy import service we have decided to seed any data we have deemed reference data.

We will use these seeders in testing. We need to add this now as the nald region id when randomly generated is between 1-8. This was causing random test failures when using the normal RegionHelper.add().

This was found because we have moved away from clearing the database before each test and having a pre test clean the database instead. (This is previous work to allow us to potentially speed up the tests and change our test framework)

https://eaflood.atlassian.net/browse/WATER-4575

Old region seeder - https://github.com/DEFRA/water-abstraction-system/pull/1193

Updated seeder pattern - https://github.com/DEFRA/water-abstraction-system/pull/1206