### PR TITLE
Amend 'Agreements' title on Licence set up tab

### DIFF
--- a/app/views/licences/tabs/set-up.njk
+++ b/app/views/licences/tabs/set-up.njk
@@ -154,7 +154,7 @@
 
 <hr />
 
-<h3 class="govuk-heading-m"> Agreements </h3>
+<h3 class="govuk-heading-m"> Charging agreements </h3>
 
 {% if agreements.length == 0 %}
   <p class="govuk-body"> No agreements for this licence.</p>

--- a/test/controllers/licences.controller.test.js
+++ b/test/controllers/licences.controller.test.js
@@ -23,7 +23,7 @@ const ViewLicenceSummaryService = require('../../app/services/licences/view-lice
 // For running our service
 const { init } = require('../../app/server.js')
 
-describe.only('Licences controller', () => {
+describe('Licences controller', () => {
   let options
   let server
 

--- a/test/controllers/licences.controller.test.js
+++ b/test/controllers/licences.controller.test.js
@@ -23,7 +23,7 @@ const ViewLicenceSummaryService = require('../../app/services/licences/view-lice
 // For running our service
 const { init } = require('../../app/server.js')
 
-describe('Licences controller', () => {
+describe.only('Licences controller', () => {
   let options
   let server
 
@@ -339,7 +339,7 @@ describe('Licences controller', () => {
         expect(response.payload).to.contain('Make licence non-chargeable')
 
         // Agreements
-        expect(response.payload).to.contain('Agreements')
+        expect(response.payload).to.contain('Charging agreements')
         // Agreements table headers
         expect(response.payload).to.contain('Agreement')
         expect(response.payload).to.contain('Date signed')
@@ -367,7 +367,7 @@ describe('Licences controller', () => {
         expect(response.payload).to.contain('No requirements for returns have been set up for this licence.')
         expect(response.payload).to.contain('Charge information')
         expect(response.payload).to.contain('No charge information for this licence.')
-        expect(response.payload).to.contain('Agreements')
+        expect(response.payload).to.contain('Charging agreements')
         expect(response.payload).to.contain('No agreements for this licence.')
       })
     })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4603

This PR is focused on changing the title of 'Agreements' in the Licence set up tab to 'Charging agreements'.