### PR TITLE
Change 'Transfer licence' reason for 'No returns needed' journey

### DIFF
--- a/app/lib/static-lookups.lib.js
+++ b/app/lib/static-lookups.lib.js
@@ -48,7 +48,7 @@ const returnRequirementReasons = {
   'succession-or-transfer-of-licence': 'Succession or transfer of licence',
   'succession-to-remainder-licence-or-licence-apportionment': 'Succession to remainder licence or licence apportionment',
   'transfer-and-now-chargeable': 'Licence transferred and now chargeable',
-  'transfer-licence': 'Transfer licence'
+  'licence-conditions-do-not-require-returns': 'Licence conditions do not require returns'
 }
 
 const sources = [

--- a/app/services/return-requirements/submit-no-returns-required.service.js
+++ b/app/services/return-requirements/submit-no-returns-required.service.js
@@ -8,7 +8,7 @@
 const NoReturnsRequiredPresenter = require('../../presenters/return-requirements/no-returns-required.presenter.js')
 const NoReturnsRequiredValidator = require('../../validators/return-requirements/no-returns-required.validator.js')
 const SessionModel = require('../../models/session.model.js')
-const GeneralLib = require('../../lib/general.lib')
+const GeneralLib = require('../../lib/general.lib.js')
 
 /**
  * Orchestrates validating the data for `/return-requirements/{sessionId}/no-returns-required` page

--- a/app/validators/return-requirements/no-returns-required.validator.js
+++ b/app/validators/return-requirements/no-returns-required.validator.js
@@ -10,7 +10,7 @@ const Joi = require('joi')
 const VALID_VALUES = [
   'abstraction-below-100-cubic-metres-per-day',
   'returns-exception',
-  'transfer-licence'
+  'licence-conditions-do-not-require-returns'
 ]
 
 /**

--- a/app/views/return-requirements/no-returns-required.njk
+++ b/app/views/return-requirements/no-returns-required.njk
@@ -51,9 +51,9 @@
             checked: reason == 'returns-exception'
           },
           {
-            text: 'Transfer licence',
-            value: 'transfer-licence',
-            checked: reason == 'transfer-licence'
+            text: 'Licence conditions do not require returns',
+            value: 'licence-conditions-do-not-require-returns',
+            checked: reason == 'licence-conditions-do-not-require-returns'
           }
         ]
       }) }}
@@ -61,6 +61,4 @@
       {{ govukButton({ text: "Continue", preventDoubleClick: true }) }}
     </form>
   </div>
-
-
 {% endblock %}

--- a/test/presenters/return-requirements/no-returns-required.presenter.test.js
+++ b/test/presenters/return-requirements/no-returns-required.presenter.test.js
@@ -69,13 +69,13 @@ describe('Return Requirements - No Returns Required presenter', () => {
   describe('the "reason" property', () => {
     describe('when the user has previously submitted a reason', () => {
       beforeEach(() => {
-        session.reason = 'transfer-licence'
+        session.reason = 'licence-conditions-do-not-require-returns'
       })
 
       it('returns a populated reason', () => {
         const result = NoReturnsRequiredPresenter.go(session)
 
-        expect(result.reason).to.equal('transfer-licence')
+        expect(result.reason).to.equal('licence-conditions-do-not-require-returns')
       })
     })
 

--- a/test/services/return-requirements/initiate-session.service.test.js
+++ b/test/services/return-requirements/initiate-session.service.test.js
@@ -116,7 +116,7 @@ describe('Return Requirements - Initiate Session service', () => {
       describe('and has return versions but they do not have requirements (so cannot be copied from)', () => {
         beforeEach(async () => {
           await ReturnVersionHelper.add({
-            licenceId: licence.id, reason: 'transfer-licence', startDate: new Date('2021-10-11'), status: 'current'
+            licenceId: licence.id, reason: 'returns-exception', startDate: new Date('2021-10-11'), status: 'current'
           })
         })
 

--- a/test/validators/return-requirements/no-returns-required.validator.test.js
+++ b/test/validators/return-requirements/no-returns-required.validator.test.js
@@ -13,7 +13,7 @@ const NoReturnsRequiredValidator = require('../../../app/validators/return-requi
 describe('No Returns Required validator', () => {
   describe('when valid data is provided', () => {
     it('confirms the data is valid', () => {
-      const result = NoReturnsRequiredValidator.go({ reason: 'transfer-licence' })
+      const result = NoReturnsRequiredValidator.go({ reason: 'licence-conditions-do-not-require-returns' })
 
       expect(result.value).to.exist()
       expect(result.error).not.to.exist()


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4612

A decision has been made to change the 'Transfer licence' option for the 'no returns needed' page to 'Licence conditions do not require returns'. This also includes changing the return version reason being saved in the database as 'transfer-licence' to 'licence-conditions-do-not-require-returns'.

This PR is focused on amending the option from 'Transfer licence' to 'Licence conditions do not require returns'.