### PR TITLE
Refactor the existing purpose condition types to be consistent

### DIFF
--- a/test/models/licence-version-purpose-condition-type.model.test.js
+++ b/test/models/licence-version-purpose-condition-type.model.test.js
@@ -8,21 +8,23 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const LicenceVersionPurposeConditionModel = require('../../app/models/licence-version-purpose-condition.model.js')
 const LicenceVersionPurposeConditionHelper = require('../support/helpers/licence-version-purpose-condition.helper.js')
+const LicenceVersionPurposeConditionModel = require('../../app/models/licence-version-purpose-condition.model.js')
+const LicenceVersionPurposesConditionsTypeSeeder = require('../support/seeders/licence-version-purpose-condition-types.seeder.js')
 
 // Thing under test
 const LicenceVersionPurposeConditionTypeModel = require('../../app/models/licence-version-purpose-condition-type.model.js')
 
-describe('Licence Version Purposes model', () => {
-  const testRecordId = '4eac5d7e-21e4-475c-8108-3e0c2ece181f'
+describe('Licence Version Purposes Condition Type model', () => {
+  const licenceVersionPurposeConditionType = LicenceVersionPurposesConditionsTypeSeeder.data[0]
 
   describe('Basic query', () => {
     it('can successfully run a basic query', async () => {
-      const result = await LicenceVersionPurposeConditionTypeModel.query().findById(testRecordId)
+      const result = await LicenceVersionPurposeConditionTypeModel
+        .query().findById(licenceVersionPurposeConditionType.id)
 
       expect(result).to.be.an.instanceOf(LicenceVersionPurposeConditionTypeModel)
-      expect(result.id).to.equal(testRecordId)
+      expect(result.id).to.equal(licenceVersionPurposeConditionType.id)
     })
   })
 
@@ -32,7 +34,7 @@ describe('Licence Version Purposes model', () => {
 
       beforeEach(async () => {
         testLicenceVersionPurposeCondition = await LicenceVersionPurposeConditionHelper.add({
-          licenceVersionPurposeConditionTypeId: testRecordId
+          licenceVersionPurposeConditionTypeId: licenceVersionPurposeConditionType.id
         })
       })
 
@@ -45,11 +47,11 @@ describe('Licence Version Purposes model', () => {
 
       it('can eager load the licence version purpose condition', async () => {
         const result = await LicenceVersionPurposeConditionTypeModel.query()
-          .findById(testRecordId)
+          .findById(licenceVersionPurposeConditionType.id)
           .withGraphFetched('licenceVersionPurposeConditions')
 
         expect(result).to.be.instanceOf(LicenceVersionPurposeConditionTypeModel)
-        expect(result.id).to.equal(testRecordId)
+        expect(result.id).to.equal(licenceVersionPurposeConditionType.id)
 
         const foundRecord = result.licenceVersionPurposeConditions.find((record) => {
           return record.id === testLicenceVersionPurposeCondition.id

--- a/test/models/licence-version-purpose-condition.model.test.js
+++ b/test/models/licence-version-purpose-condition.model.test.js
@@ -9,9 +9,10 @@ const { expect } = Code
 
 // Test helpers
 const LicenceVersionPurposeConditionHelper = require('../support/helpers/licence-version-purpose-condition.helper.js')
+const LicenceVersionPurposeConditionTypeModel = require('../../app/models/licence-version-purpose-condition-type.model.js')
 const LicenceVersionPurposeHelper = require('../support/helpers/licence-version-purpose.helper.js')
 const LicenceVersionPurposeModel = require('../../app/models/licence-version-purpose.model.js')
-const LicenceVersionPurposeConditionTypeModel = require('../../app/models/licence-version-purpose-condition-type.model.js')
+const LicenceVersionPurposesConditionsTypeSeeder = require('../support/seeders/licence-version-purpose-condition-types.seeder.js')
 
 // Thing under test
 const LicenceVersionPurposeConditionModel = require('../../app/models/licence-version-purpose-condition.model.js')
@@ -65,11 +66,11 @@ describe('Licence Version Purpose Condition model', () => {
     })
 
     describe('when linking to licence version purpose condition type', () => {
-      const testLicenceVersionPurposeConditionTypeId = '4eac5d7e-21e4-475c-8108-3e0c2ece181f'
+      const licenceVersionPurposeConditionType = LicenceVersionPurposesConditionsTypeSeeder.data[0]
 
       beforeEach(async () => {
         testRecord = await LicenceVersionPurposeConditionHelper.add({
-          licenceVersionPurposeConditionTypeId: testLicenceVersionPurposeConditionTypeId
+          licenceVersionPurposeConditionTypeId: licenceVersionPurposeConditionType.id
         })
       })
 
@@ -89,7 +90,7 @@ describe('Licence Version Purpose Condition model', () => {
         expect(result.id).to.equal(testRecord.id)
 
         expect(result.licenceVersionPurposeConditionType).to.be.an.instanceOf(LicenceVersionPurposeConditionTypeModel)
-        expect(result.licenceVersionPurposeConditionType.id).to.equal(testLicenceVersionPurposeConditionTypeId)
+        expect(result.licenceVersionPurposeConditionType.id).to.equal(licenceVersionPurposeConditionType.id)
       })
     })
   })

--- a/test/services/licences/fetch-licence-summary.service.test.js
+++ b/test/services/licences/fetch-licence-summary.service.test.js
@@ -18,6 +18,7 @@ const LicenceHolderSeeder = require('../../support/seeders/licence-holder.seeder
 const LicenceVersionHelper = require('../../support/helpers/licence-version.helper.js')
 const LicenceVersionPurposeConditionHelper = require('../../support/helpers/licence-version-purpose-condition.helper.js')
 const LicenceVersionPurposeHelper = require('../../support/helpers/licence-version-purpose.helper.js')
+const LicenceVersionPurposesConditionsTypeSeeder = require('../../support/seeders/licence-version-purpose-condition-types.seeder.js')
 const PermitLicenceHelper = require('../../support/helpers/permit-licence.helper.js')
 const PurposeSeeder = require('../../support/seeders/purposes.seeder.js')
 const RegionHelper = require('../../support/helpers/region.helper.js')
@@ -34,11 +35,16 @@ describe('Fetch Licence Summary service', () => {
   let licenceVersion
   let licenceVersionPurpose
   let licenceVersionPurposeCondition
+  let licenceVersionPurposeConditionType
   let permitLicence
   let purpose
   let region
 
   beforeEach(async () => {
+    licenceVersionPurposeConditionType = LicenceVersionPurposesConditionsTypeSeeder.data.find((conditionType) => {
+      return conditionType.displayTitle === 'Aggregate condition link between licences'
+    })
+
     region = await RegionHelper.add()
 
     licence = await LicenceHelper.add({
@@ -64,7 +70,7 @@ describe('Fetch Licence Summary service', () => {
 
     licenceVersionPurposeCondition = await LicenceVersionPurposeConditionHelper.add({
       licenceVersionPurposeId: licenceVersionPurpose.id,
-      licenceVersionPurposeConditionTypeId: '4c0b378d-a9c2-4b50-b1bd-9aeefe988f93'
+      licenceVersionPurposeConditionTypeId: licenceVersionPurposeConditionType.id
     })
 
     licenceHolderSeed = await LicenceHolderSeeder.seed(licence.licenceRef)
@@ -141,7 +147,7 @@ describe('Fetch Licence Summary service', () => {
               licenceVersionPurposeConditions: [{
                 id: licenceVersionPurposeCondition.id,
                 licenceVersionPurposeConditionType: {
-                  id: '4c0b378d-a9c2-4b50-b1bd-9aeefe988f93',
+                  id: licenceVersionPurposeConditionType.id,
                   displayTitle: 'Aggregate condition link between licences'
                 }
               }]

--- a/test/support/seeders/data/licence-versions-purposes-condition-types.js
+++ b/test/support/seeders/data/licence-versions-purposes-condition-types.js
@@ -1,0 +1,544 @@
+'use strict'
+
+module.exports = [
+  {
+    id: 'a71c352b-04a8-4f32-b349-929ec1607704',
+    code: 'NSQ',
+    subcode: 'M3FN',
+    description: 'Non Standard Quantities',
+    subcodeDescription: 'Cubic Metres Per Fortnight',
+    displayTitle: 'Non standard quantities cubic metres per fortnight',
+    createdAt: new Date('2023-12-14'),
+    updatedAt: new Date('2024-07-30')
+  },
+  {
+    id: '56729fac-cd3c-4136-8763-c9c6f8f7a85d',
+    code: 'NSQ',
+    subcode: 'M3WK',
+    description: 'Non Standard Quantities',
+    subcodeDescription: 'Cubic Metres Per Week',
+    displayTitle: 'Non standard quantities cubic metres per week',
+    createdAt: new Date('2023-12-14'),
+    updatedAt: new Date('2024-07-30')
+  },
+  {
+    id: 'f9dd5078-d365-45e3-be57-d9859c6d4599',
+    code: 'NSQ',
+    subcode: 'PER',
+    description: 'Non Standard Quantities',
+    subcodeDescription: 'Text Defined Periodicity',
+    displayTitle: 'Non standard quantities',
+    createdAt: new Date('2023-12-14'),
+    updatedAt: new Date('2024-07-30')
+  },
+  {
+    id: '875e9fde-67c2-42bb-8e0c-2033c78b0bbe',
+    code: 'OTH',
+    subcode: 'GEN',
+    description: 'Other Standard Conditions',
+    subcodeDescription: 'General',
+    displayTitle: 'General conditions',
+    createdAt: new Date('2023-12-14'),
+    updatedAt: new Date('2024-07-30')
+  },
+  {
+    id: '692bc351-5d50-427a-ad96-cd4328eb21d2',
+    code: 'PTAK',
+    subcode: 'COMP',
+    description: 'Proportional Take',
+    subcodeDescription: 'Complex',
+    displayTitle: 'Complex proportional take',
+    createdAt: new Date('2023-12-14'),
+    updatedAt: new Date('2024-07-30')
+  },
+  {
+    id: '047ae10c-85a9-4d92-890a-6e7c4c1d4153',
+    code: 'PTAK',
+    subcode: 'PCENT',
+    description: 'Proportional Take',
+    subcodeDescription: 'Percentage Take',
+    displayTitle: 'Proportional percentage take',
+    createdAt: new Date('2023-12-14'),
+    updatedAt: new Date('2024-07-30')
+  },
+  {
+    id: 'e25b9fa3-5038-4b83-8ed0-58648358a143',
+    code: 'RAT',
+    subcode: 'LPS',
+    description: 'Rates',
+    subcodeDescription: 'Litres Per Second',
+    displayTitle: 'Rates litres per second',
+    createdAt: new Date('2023-12-14'),
+    updatedAt: new Date('2024-07-30')
+  },
+  {
+    id: '4a142b01-5588-4dfc-9330-920c996babe0',
+    code: 'RAT',
+    subcode: 'M3D',
+    description: 'Rates',
+    subcodeDescription: 'M3 Per Day',
+    displayTitle: 'Rates m3 per day',
+    createdAt: new Date('2023-12-14'),
+    updatedAt: new Date('2024-07-30')
+  },
+  {
+    id: '98a1ad74-f753-4900-add8-e12779078f4a',
+    code: 'RAT',
+    subcode: 'M3M',
+    description: 'Rates',
+    subcodeDescription: 'M3 Per Month',
+    displayTitle: 'Rates m3 per month',
+    createdAt: new Date('2023-12-14'),
+    updatedAt: new Date('2024-07-30')
+  },
+  {
+    id: 'fe52f2df-8536-4865-b364-ff8b7e146928',
+    code: 'RAT',
+    subcode: 'M3S',
+    description: 'Rates',
+    subcodeDescription: 'M3 Per Second',
+    displayTitle: 'Rates m3 per second',
+    createdAt: new Date('2023-12-14'),
+    updatedAt: new Date('2024-07-30')
+  },
+  {
+    id: '60f41084-c014-4a0e-8036-f748390b7791',
+    code: 'S57',
+    subcode: 'BANI',
+    description: 'Spray Irrigation',
+    subcodeDescription: 'Ban Imposed',
+    displayTitle: 'Spray irrigation ban imposed',
+    createdAt: new Date('2023-12-14'),
+    updatedAt: new Date('2024-07-30')
+  },
+  {
+    id: '97f2634f-7357-4a43-b126-6a0d45eaf02c',
+    code: 'S57',
+    subcode: 'BANP',
+    description: 'Spray Irrigation',
+    subcodeDescription: 'Ban Proposed',
+    displayTitle: 'Spray irrigation ban proposed',
+    createdAt: new Date('2023-12-14'),
+    updatedAt: new Date('2024-07-30')
+  },
+  {
+    id: '03a6f321-f726-4835-9625-6aa593b06cda',
+    code: 'XREG',
+    subcode: 'PTS',
+    description: 'Cross Regional Point',
+    subcodeDescription: 'Licensed Point Falls Within Another Region',
+    displayTitle: 'Licensed point falls within another region',
+    createdAt: new Date('2023-12-14'),
+    updatedAt: new Date('2024-07-30')
+  },
+  {
+    id: '8187812c-0533-4b0f-8433-3f5b2f463f86',
+    code: 'AGG',
+    subcode: 'LLX',
+    description: 'Aggregate',
+    subcodeDescription: 'Licence To Licence; Cross Regional Condition Link Between Licences',
+    displayTitle: 'Aggregate condition cross regional link between licences',
+    createdAt: new Date('2023-12-14'),
+    updatedAt: new Date('2024-07-30')
+  },
+  {
+    id: '265497c2-d3fb-41ab-9167-c3204fce3e3c',
+    code: 'PWS',
+    subcode: 'WSL',
+    description: 'Public Water Supply',
+    subcodeDescription: 'Water Supply Licensee',
+    displayTitle: 'Public water supply licensee',
+    createdAt: new Date('2023-12-14'),
+    updatedAt: new Date('2024-07-30')
+  },
+  {
+    id: '54df1201-b6a1-4909-ae29-cc1a3d93e469',
+    code: 'EEL',
+    subcode: 'REGS',
+    description: 'Eel Regulations',
+    subcodeDescription: 'Pass/Screen - Eel Regs SI3344',
+    displayTitle: 'Fish pass/screen - eel regs SI3344',
+    createdAt: new Date('2023-12-14'),
+    updatedAt: new Date('2024-07-30')
+  },
+  {
+    id: '31dde8db-de9a-4b41-abd8-2efc88d6db68',
+    code: 'DEROG',
+    subcode: 'CLAUS',
+    description: 'Derogation',
+    subcodeDescription: 'Derogation Clause',
+    displayTitle: 'Derogation clause',
+    createdAt: new Date('2023-12-14'),
+    updatedAt: new Date('2024-07-30')
+  },
+  {
+    id: '03abbecd-2445-4209-a96c-fe4c9a857065',
+    code: 'TLTD',
+    subcode: 'LEVFL',
+    description: 'Time Limited',
+    subcodeDescription: 'Limited Extension of Validity - Full Licence Expiry',
+    displayTitle: 'Time Limited Extension of Validity - Full Licence Expiry',
+    createdAt: new Date('2024-01-12'),
+    updatedAt: new Date('2024-07-30')
+  },
+  {
+    id: '0afdae8f-4fc9-4623-83a9-246ca862047f',
+    code: 'TLTD',
+    subcode: 'LEVTL',
+    description: 'Time Limited',
+    subcodeDescription: 'Limited Extension of Validity - Time Limited Variation',
+    displayTitle: 'Time Limited Extension of Validity - Time Limited Variation',
+    createdAt: new Date('2024-01-12'),
+    updatedAt: new Date('2024-07-30')
+  },
+  {
+    id: '478dc963-46d6-4464-862c-283d3991fd63',
+    code: 'AGG',
+    subcode: 'LLL',
+    description: 'Aggregate',
+    subcodeDescription: 'Licence To Licence; Link Between Licences',
+    displayTitle: 'Aggregate condition link between licences',
+    createdAt: new Date('2023-12-14'),
+    updatedAt: new Date('2024-07-30')
+  },
+  {
+    id: '1617d5f0-8ad0-443f-a897-318260db88f1',
+    code: 'CES',
+    subcode: 'CHE',
+    description: 'Cessation Condition',
+    subcodeDescription: 'Chemical',
+    displayTitle: 'Chemical cessation condition',
+    createdAt: new Date('2023-12-14'),
+    updatedAt: new Date('2024-07-30')
+  },
+  {
+    id: '7f53fb27-9002-43b1-8b0f-04a338ab7333',
+    code: 'CES',
+    subcode: 'DEP',
+    description: 'Cessation Condition',
+    subcodeDescription: 'Dependent On Release From Schemes/Other Licences',
+    displayTitle: 'Cessation dependant on releases from schemes / other licences',
+    createdAt: new Date('2023-12-14'),
+    updatedAt: new Date('2024-07-30')
+  },
+  {
+    id: 'f2c1072f-6654-44c9-80c5-683c446ac87f',
+    code: 'CES',
+    subcode: 'FLOW',
+    description: 'Cessation Condition',
+    subcodeDescription: 'Flow',
+    displayTitle: 'Flow cessation condition',
+    createdAt: new Date('2023-12-14'),
+    updatedAt: new Date('2024-07-30')
+  },
+  {
+    id: '259db7c3-00cd-4f42-86a8-996d470f700c',
+    code: 'CES',
+    subcode: 'GWL',
+    description: 'Cessation Condition',
+    subcodeDescription: 'Groundwater Level',
+    displayTitle: 'Groundwater level cessation condition',
+    createdAt: new Date('2023-12-14'),
+    updatedAt: new Date('2024-07-30')
+  },
+  {
+    id: 'f5dc9b11-3a7b-4d91-9113-bdb41289a43d',
+    code: 'CES',
+    subcode: 'LEV',
+    description: 'Cessation Condition',
+    subcodeDescription: 'Level',
+    displayTitle: 'Level cessation condition',
+    createdAt: new Date('2023-12-14'),
+    updatedAt: new Date('2024-07-30')
+  },
+  {
+    id: '3bf80bb2-cbba-4897-a1f1-f1b3055930f7',
+    code: 'CES',
+    subcode: 'POL',
+    description: 'Cessation Condition',
+    subcodeDescription: 'Political - Hosepipe Ban',
+    displayTitle: 'Political cessation condition',
+    createdAt: new Date('2023-12-14'),
+    updatedAt: new Date('2024-07-30')
+  },
+  {
+    id: 'b4d445c9-1ea0-4918-b97b-48e8c4496fb0',
+    code: 'AGG',
+    subcode: 'LPL',
+    description: 'Aggregate',
+    subcodeDescription: 'Licence To Purpose; Link Between Different Licences',
+    displayTitle: 'Aggregate condition licence to purpose between different licences',
+    createdAt: new Date('2023-12-14'),
+    updatedAt: new Date('2024-07-30')
+  },
+  {
+    id: '8f118be4-c132-4d96-8c0a-f2918cdd371b',
+    code: 'BYPAS',
+    subcode: 'FLOW',
+    description: 'By-Pass Flow',
+    subcodeDescription: 'Flow',
+    displayTitle: 'By-pass flow',
+    createdAt: new Date('2023-12-14'),
+    updatedAt: new Date('2024-07-30')
+  },
+  {
+    id: 'b942a057-5da1-4382-926f-ae3fa98cb484',
+    code: 'COMB',
+    subcode: 'LINK',
+    description: 'Condition To Indicate Licence  Split On Nald',
+    subcodeDescription: 'Link Between Split Licences',
+    displayTitle: 'Link between split licences',
+    createdAt: new Date('2023-12-14'),
+    updatedAt: new Date('2024-07-30')
+  },
+  {
+    id: '558d51fa-e84b-4a49-b85c-3cd1f017abe1',
+    code: 'COMP',
+    subcode: 'GEN',
+    description: 'Complex Condition',
+    subcodeDescription: 'General',
+    displayTitle: 'Complex condition',
+    createdAt: new Date('2023-12-14'),
+    updatedAt: new Date('2024-07-30')
+  },
+  {
+    id: 'a111a541-b3b8-48e3-a405-1fe0efa5f9a9',
+    code: 'COMPR',
+    subcode: 'FLOW',
+    description: 'Compensation Release',
+    subcodeDescription: 'Flow',
+    displayTitle: 'Flow compensation release',
+    createdAt: new Date('2023-12-14'),
+    updatedAt: new Date('2024-07-30')
+  },
+  {
+    id: '8c059046-2a0b-498a-b9a6-053159cd14c5',
+    code: 'FILL',
+    subcode: 'FILL',
+    description: 'Filling/Emptying Clause',
+    subcodeDescription: 'Filling/Emptying To Be Notified To Agency',
+    displayTitle: 'Filling/emptying to be notified to Agency',
+    createdAt: new Date('2023-12-14'),
+    updatedAt: new Date('2024-07-30')
+  },
+  {
+    id: '32618825-4fda-474e-b6e3-33b9ab4ea708',
+    code: 'FILL',
+    subcode: 'SEAS',
+    description: 'Filling/Emptying Clause',
+    subcodeDescription: 'Filling/Emptying Season Limited',
+    displayTitle: 'Filling/emptying season limited',
+    createdAt: new Date('2023-12-14'),
+    updatedAt: new Date('2024-07-30')
+  },
+  {
+    id: '965bbf07-06c9-4b25-8f0c-755a83dfb27a',
+    code: 'INFLO',
+    subcode: 'TYPE',
+    description: 'Inflow Control',
+    subcodeDescription: 'Control Type',
+    displayTitle: 'Inflow control type',
+    createdAt: new Date('2023-12-14'),
+    updatedAt: new Date('2024-07-30')
+  },
+  {
+    id: '7e2da099-3a5f-45b6-94f4-8e9f677fa095',
+    code: 'LINTY',
+    subcode: 'TYPE',
+    description: 'Type Of Lining',
+    subcodeDescription: 'Type',
+    displayTitle: 'Type of lining',
+    createdAt: new Date('2023-12-14'),
+    updatedAt: new Date('2024-07-30')
+  },
+  {
+    id: '2410d74c-5f7b-4c1f-bd1c-1f67d63a5cd0',
+    code: 'LOK',
+    subcode: 'OFF',
+    description: 'Lockable Structures Required',
+    subcodeDescription: 'Locked',
+    displayTitle: 'Lockable structures required',
+    createdAt: new Date('2023-12-14'),
+    updatedAt: new Date('2024-07-30')
+  },
+  {
+    id: 'edcf5946-6e1d-41e4-97b2-39e7ee3e705d',
+    code: 'MAINT',
+    subcode: 'FLOW',
+    description: 'Maintained Flow',
+    subcodeDescription: 'Flow',
+    displayTitle: 'Maintained flow',
+    createdAt: new Date('2023-12-14'),
+    updatedAt: new Date('2024-07-30')
+  },
+  {
+    id: '769d0915-04c8-4838-9da4-9986f4677f4f',
+    code: 'MCOMP',
+    subcode: 'MEANS',
+    description: 'Means Of Compensation Flow Release',
+    subcodeDescription: 'Means',
+    displayTitle: 'Means of compensation flow release',
+    createdAt: new Date('2023-12-14'),
+    updatedAt: new Date('2024-07-30')
+  },
+  {
+    id: '4339796c-fc0e-41a8-9ea8-f3502529cf92',
+    code: 'NSQ',
+    subcode: 'M3MO',
+    description: 'Non Standard Quantities',
+    subcodeDescription: 'Cubic Metres Per Month',
+    displayTitle: 'Non standard quantities cubic metres per month',
+    createdAt: new Date('2023-12-14'),
+    updatedAt: new Date('2024-07-30')
+  },
+  {
+    id: 'e8807cab-124d-47c9-9b19-4efb2c35e213',
+    code: 'TRA',
+    subcode: 'TRAN',
+    description: 'Transfer',
+    subcodeDescription: 'Transfer',
+    displayTitle: 'Transfer',
+    createdAt: new Date('2023-12-14'),
+    updatedAt: new Date('2024-07-30')
+  },
+  {
+    id: '8501db0e-8227-43a4-bd21-a5d4857e2506',
+    code: 'WLM',
+    subcode: 'GW',
+    description: 'Water Level Monitoring',
+    subcodeDescription: 'Ground Water',
+    displayTitle: 'Water level monitoring groundwater',
+    createdAt: new Date('2023-12-14'),
+    updatedAt: new Date('2024-07-30')
+  },
+  {
+    id: '91777b9d-3df0-40a8-a5e6-115f543c0908',
+    code: 'WLM',
+    subcode: 'SW',
+    description: 'Water Level Monitoring',
+    subcodeDescription: 'Surface Water',
+    displayTitle: 'Water level monitoring surface water',
+    createdAt: new Date('2023-12-14'),
+    updatedAt: new Date('2024-07-30')
+  },
+  {
+    id: '629e6598-40a5-4d62-8229-cf1264c35bff',
+    code: 'WQM',
+    subcode: 'GW',
+    description: 'Water Quality Monitoring',
+    subcodeDescription: 'Groundwater',
+    displayTitle: 'Water quality monitoring groundwater',
+    createdAt: new Date('2023-12-14'),
+    updatedAt: new Date('2024-07-30')
+  },
+  {
+    id: '6fd1ad95-6755-430a-b32b-d9adbb0ba476',
+    code: 'WQM',
+    subcode: 'SW',
+    description: 'Water Quality Monitoring',
+    subcodeDescription: 'Surface Water',
+    displayTitle: 'Water quality monitoring surface water',
+    createdAt: new Date('2023-12-14'),
+    updatedAt: new Date('2024-07-30')
+  },
+  {
+    id: '3b2c530b-0d81-44b7-9b12-752e458a0ae6',
+    code: 'TLTD',
+    subcode: 'VAR',
+    description: 'Time Limited',
+    subcodeDescription: 'Variation',
+    displayTitle: 'Time limited variation',
+    createdAt: new Date('2023-12-14'),
+    updatedAt: new Date('2024-07-30')
+  },
+  {
+    id: '3888f275-6281-4685-90a8-65451ef01ca4',
+    code: 'WRT',
+    subcode: 'QTY',
+    description: 'Water Rights Trade',
+    subcodeDescription: 'Traded Quantity',
+    displayTitle: 'Water rights trade quantity',
+    createdAt: new Date('2023-12-14'),
+    updatedAt: new Date('2024-07-30')
+  },
+  {
+    id: 'c3f5648f-efbd-4c46-9b86-4ddd6bd3ce61',
+    code: 'WRT',
+    subcode: 'PUR',
+    description: 'Water Rights Trade',
+    subcodeDescription: 'Traded Purpose',
+    displayTitle: 'Water rights trade purpose',
+    createdAt: new Date('2023-12-14'),
+    updatedAt: new Date('2024-07-30')
+  },
+  {
+    id: '7f036649-4ef1-48c9-9bdc-7f2415604801',
+    code: 'WRT',
+    subcode: 'PNT',
+    description: 'Water Rights Trade',
+    subcodeDescription: 'Traded Point',
+    displayTitle: 'Water rights trade point',
+    createdAt: new Date('2023-12-14'),
+    updatedAt: new Date('2024-07-30')
+  },
+  {
+    id: 'cddc2c57-7036-4557-953d-13440b90fa8e',
+    code: 'TLTD',
+    subcode: 'MINQ',
+    description: 'Time Limited',
+    subcodeDescription: 'Minimum Quantity',
+    displayTitle: 'Time limited minimum quantity',
+    createdAt: new Date('2023-12-14'),
+    updatedAt: new Date('2024-07-30')
+  },
+  {
+    id: '6f031296-bb36-4d19-980c-21545d7eeee8',
+    code: 'TLTD',
+    subcode: 'SD',
+    description: 'Time Limited',
+    subcodeDescription: 'Self Destruct',
+    displayTitle: 'Time limited self destruct',
+    createdAt: new Date('2023-12-14'),
+    updatedAt: new Date('2024-07-30')
+  },
+  {
+    id: 'bf53e6ad-af27-4e67-b100-d86001d21f1c',
+    code: 'AGG',
+    subcode: 'PP',
+    description: 'Aggregate',
+    subcodeDescription: 'Purpose To Purpose; Link Within A Licence',
+    displayTitle: 'Aggregate condition purpose to purpose within a licence',
+    createdAt: new Date('2023-12-14'),
+    updatedAt: new Date('2024-07-30')
+  },
+  {
+    id: 'a5ddff18-f9b1-4b7a-9c20-fad7677aa7f2',
+    code: 'AGG',
+    subcode: 'PPL',
+    description: 'Aggregate',
+    subcodeDescription: 'Purpose To Purpose ; Link Between Different Licences',
+    displayTitle: 'Aggregate condition purpose to purpose between different licences',
+    createdAt: new Date('2023-12-14'),
+    updatedAt: new Date('2024-07-30')
+  },
+  {
+    id: '18ade96c-75ae-4bc3-9580-b8a574f3f9e5',
+    code: 'AGI',
+    subcode: 'DIM',
+    description: 'Additional Groundwater Information',
+    subcodeDescription: 'Dimensions',
+    displayTitle: 'Additional groundwater information dimensions',
+    createdAt: new Date('2023-12-14'),
+    updatedAt: new Date('2024-07-30')
+  },
+  {
+    id: '9aced507-2135-4804-9490-46c84607a08d',
+    code: 'INFLR',
+    subcode: 'RATE',
+    description: 'Inflow Rate',
+    subcodeDescription: 'Rate',
+    displayTitle: 'Inflow rate',
+    createdAt: new Date('2023-12-14'),
+    updatedAt: new Date('2024-07-30')
+  }
+]

--- a/test/support/seeders/licence-version-purpose-condition-types.seeder.js
+++ b/test/support/seeders/licence-version-purpose-condition-types.seeder.js
@@ -4,7 +4,11 @@
  * @module LicenceVersionPurposeConditionTypeSeeder
  */
 
+const data = require('./data/licence-versions-purposes-condition-types.js')
+const { buildSeedValueString } = require('./seed-builder.js')
 const { db } = require('../../../db/db.js')
+
+const keys = ['id', 'code', 'subcode', 'description', 'subcodeDescription', 'displayTitle', 'createdAt', 'updatedAt']
 
 /**
  * Add all of the licence version purpose conditions to the database
@@ -12,68 +16,13 @@ const { db } = require('../../../db/db.js')
  */
 async function seed () {
   await db.raw(`
-    INSERT INTO water.licence_version_purpose_condition_types (licence_version_purpose_condition_type_id,code,subcode,description,subcode_description,date_created,date_updated,display_title) VALUES
-  ('4c0b378d-a9c2-4b50-b1bd-9aeefe988f93','AGG','LLL','Aggregate','Licence To Licence; Link Between Licences','2024-07-04 16:00:17.997679','2024-07-04 16:00:17.997679','Aggregate condition link between licences'),
-  ('69e08cfb-9fdd-4ba2-9cd3-e74f4c36f94f','AGG','LLX','Aggregate','Licence To Licence; Cross Regional Condition Link Between Licences','2024-07-04 16:00:17.997679','2024-07-04 16:00:17.997679','Aggregate condition cross regional link between licences'),
-  ('4eac5d7e-21e4-475c-8108-3e0c2ece181f','AGG','LPL','Aggregate','Licence To Purpose; Link Between Different Licences','2024-07-04 16:00:17.997679','2024-07-04 16:00:17.997679','Aggregate condition licence to purpose between different licences'),
-  ('f7f9604c-6c7b-43b0-a0a8-13ca1ed7dd73','AGG','PP','Aggregate','Purpose To Purpose; Link Within A Licence','2024-07-04 16:00:17.997679','2024-07-04 16:00:17.997679','Aggregate condition purpose to purpose within a licence'),
-  ('379b6514-e714-4c17-9b91-957ea92c5ee4','AGG','PPL','Aggregate','Purpose To Purpose ; Link Between Different Licences','2024-07-04 16:00:17.997679','2024-07-04 16:00:17.997679','Aggregate condition purpose to purpose between different licences'),
-  ('1a52a0b5-2dee-4006-b539-eb780ddb42d7','AGI','DIM','Additional Groundwater Information','Dimensions','2024-07-04 16:00:17.997679','2024-07-04 16:00:17.997679','Additional groundwater information dimensions'),
-  ('da59a9c8-3a39-4e40-ad4a-db26118dc46f','BYPAS','FLOW','By-Pass Flow','Flow','2024-07-04 16:00:17.997679','2024-07-04 16:00:17.997679','By-pass flow'),
-  ('c7b88fe7-b3df-41ae-844d-0e5e47e80d8a','CES','CHE','Cessation Condition','Chemical','2024-07-04 16:00:17.997679','2024-07-04 16:00:17.997679','Chemical cessation condition'),
-  ('49ae5c07-19c4-485c-a1e0-a28be3e10290','CES','DEP','Cessation Condition','Dependent On Release From Schemes/Other Licences','2024-07-04 16:00:17.997679','2024-07-04 16:00:17.997679','Cessation dependant on releases from schemes / other licences'),
-  ('540e2453-5741-4637-bfc5-57d76e2cecf9','CES','FLOW','Cessation Condition','Flow','2024-07-04 16:00:17.997679','2024-07-04 16:00:17.997679','Flow cessation condition');
-INSERT INTO water.licence_version_purpose_condition_types (licence_version_purpose_condition_type_id,code,subcode,description,subcode_description,date_created,date_updated,display_title) VALUES
-  ('5e06bb53-bd9d-47e4-86d0-dd56d1a2ed5b','CES','GWL','Cessation Condition','Groundwater Level','2024-07-04 16:00:17.997679','2024-07-04 16:00:17.997679','Groundwater level cessation condition'),
-  ('abca0b8e-9745-4628-8a73-614d2df93977','CES','LEV','Cessation Condition','Level','2024-07-04 16:00:17.997679','2024-07-04 16:00:17.997679','Level cessation condition'),
-  ('d8934dcd-6370-4424-9fc1-b9bbd5d06d6d','CES','POL','Cessation Condition','Political - Hosepipe Ban','2024-07-04 16:00:17.997679','2024-07-04 16:00:17.997679','Political cessation condition'),
-  ('bb96e6f2-7883-41ce-9d15-fc07da82393b','COMB','LINK','Condition To Indicate Licence  Split On Nald','Link Between Split Licences','2024-07-04 16:00:17.997679','2024-07-04 16:00:17.997679','Link between split licences'),
-  ('2984e051-8a71-4442-926a-dcbe1c6aa4da','COMP','GEN','Complex Condition','General','2024-07-04 16:00:17.997679','2024-07-04 16:00:17.997679','Complex condition'),
-  ('6d4e0df8-1bd8-412c-8309-232359dd6af2','COMPR','FLOW','Compensation Release','Flow','2024-07-04 16:00:17.997679','2024-07-04 16:00:17.997679','Flow compensation release'),
-  ('dad942a1-04c8-424e-b1b0-6c464ffed073','DEROG','CLAUS','Derogation','Derogation Clause','2024-07-04 16:00:17.997679','2024-07-04 16:00:17.997679','Derogation clause'),
-  ('7596130e-65ec-48b7-bb79-10449bf847c7','EEL','REGS','Eel Regulations','Pass/Screen - Eel Regs SI3344','2024-07-04 16:00:17.997679','2024-07-04 16:00:17.997679','Fish pass/screen - eel regs SI3344'),
-  ('79ce9e30-3f50-4437-a5f4-f614c4be980e','FILL','FILL','Filling/Emptying Clause','Filling/Emptying To Be Notified To Agency','2024-07-04 16:00:17.997679','2024-07-04 16:00:17.997679','Filling/emptying to be notified to Agency'),
-  ('52e7cdb0-8499-41d5-84ca-e2fd872fa404','FILL','SEAS','Filling/Emptying Clause','Filling/Emptying Season Limited','2024-07-04 16:00:17.997679','2024-07-04 16:00:17.997679','Filling/emptying season limited');
-INSERT INTO water.licence_version_purpose_condition_types (licence_version_purpose_condition_type_id,code,subcode,description,subcode_description,date_created,date_updated,display_title) VALUES
-  ('dbaf32aa-dadc-495a-a440-303ca2b74043','INFLO','TYPE','Inflow Control','Control Type','2024-07-04 16:00:17.997679','2024-07-04 16:00:17.997679','Inflow control type'),
-  ('173f909a-5a42-4fcd-945e-e65cae5d0257','INFLR','RATE','Inflow Rate','Rate','2024-07-04 16:00:17.997679','2024-07-04 16:00:17.997679','Inflow rate'),
-  ('69b75fcf-979a-46cf-a520-ab3162177349','LINTY','TYPE','Type Of Lining','Type','2024-07-04 16:00:17.997679','2024-07-04 16:00:17.997679','Type of lining'),
-  ('e7a03f97-3920-4c88-9dd3-cb9c0c3b8103','LOK','OFF','Lockable Structures Required','Locked','2024-07-04 16:00:17.997679','2024-07-04 16:00:17.997679','Lockable structures required'),
-  ('3e08ac41-b719-4928-bc44-6a983a91497a','MAINT','FLOW','Maintained Flow','Flow','2024-07-04 16:00:17.997679','2024-07-04 16:00:17.997679','Maintained flow'),
-  ('20ece354-b8c4-4e11-a5c4-4030acaffd44','MCOMP','MEANS','Means Of Compensation Flow Release','Means','2024-07-04 16:00:17.997679','2024-07-04 16:00:17.997679','Means of compensation flow release'),
-  ('35d9aff6-233a-4e23-b882-6ec29ec6567f','NSQ','M3FN','Non Standard Quantities','Cubic Metres Per Fortnight','2024-07-04 16:00:17.997679','2024-07-04 16:00:17.997679','Non standard quantities cubic metres per fortnight'),
-  ('59954d44-5e46-42e2-87f9-b8cc0f7b646a','NSQ','M3MO','Non Standard Quantities','Cubic Metres Per Month','2024-07-04 16:00:17.997679','2024-07-04 16:00:17.997679','Non standard quantities cubic metres per month'),
-  ('ddf14927-9b41-40ac-8e6a-9e930643968e','NSQ','M3WK','Non Standard Quantities','Cubic Metres Per Week','2024-07-04 16:00:17.997679','2024-07-04 16:00:17.997679','Non standard quantities cubic metres per week'),
-  ('f1f69f3d-3b41-4afb-a1ba-cf50b17945db','NSQ','PER','Non Standard Quantities','Text Defined Periodicity','2024-07-04 16:00:17.997679','2024-07-04 16:00:17.997679','Non standard quantities');
-INSERT INTO water.licence_version_purpose_condition_types (licence_version_purpose_condition_type_id,code,subcode,description,subcode_description,date_created,date_updated,display_title) VALUES
-  ('eb2c3a1c-d744-4bb7-9abb-5ca56d7ab194','OTH','GEN','Other Standard Conditions','General','2024-07-04 16:00:17.997679','2024-07-04 16:00:17.997679','General conditions'),
-  ('4195c9d9-3587-404b-b1f8-713ae752f18a','PTAK','COMP','Proportional Take','Complex','2024-07-04 16:00:17.997679','2024-07-04 16:00:17.997679','Complex proportional take'),
-  ('e9fb6ebf-67aa-47ae-b8c3-344cf3f886a7','PTAK','PCENT','Proportional Take','Percentage Take','2024-07-04 16:00:17.997679','2024-07-04 16:00:17.997679','Proportional percentage take'),
-  ('a131f6ec-a36e-4eb4-98ec-cb23c92de519','PWS','WSL','Public Water Supply','Water Supply Licensee','2024-07-04 16:00:17.997679','2024-07-04 16:00:17.997679','Public water supply licensee'),
-  ('0699414c-0dc8-4015-9a65-7327530ff31d','RAT','LPS','Rates','Litres Per Second','2024-07-04 16:00:17.997679','2024-07-04 16:00:17.997679','Rates litres per second'),
-  ('ffa9fe37-fd43-4950-ab50-5787fdc8a2e6','RAT','M3D','Rates','M3 Per Day','2024-07-04 16:00:17.997679','2024-07-04 16:00:17.997679','Rates m3 per day'),
-  ('5e20c28a-aa3d-4c69-a26d-ae7c84680348','RAT','M3M','Rates','M3 Per Month','2024-07-04 16:00:17.997679','2024-07-04 16:00:17.997679','Rates m3 per month'),
-  ('e8ab0098-86b8-4479-bce2-a5df53b9f634','RAT','M3S','Rates','M3 Per Second','2024-07-04 16:00:17.997679','2024-07-04 16:00:17.997679','Rates m3 per second'),
-  ('34ddefea-209a-468a-b3fd-50f5f7f291b0','S57','BANI','Spray Irrigation','Ban Imposed','2024-07-04 16:00:17.997679','2024-07-04 16:00:17.997679','Spray irrigation ban imposed'),
-  ('adc8d3a8-2b20-4fa5-a4f4-c64d05b29317','S57','BANP','Spray Irrigation','Ban Proposed','2024-07-04 16:00:17.997679','2024-07-04 16:00:17.997679','Spray irrigation ban proposed');
-INSERT INTO water.licence_version_purpose_condition_types (licence_version_purpose_condition_type_id,code,subcode,description,subcode_description,date_created,date_updated,display_title) VALUES
-  ('b66671e4-1ac7-4c08-be11-5712f7a5b67c','TLTD','MINQ','Time Limited','Minimum Quantity','2024-07-04 16:00:17.997679','2024-07-04 16:00:17.997679','Time limited minimum quantity'),
-  ('deaf47a9-9ee4-4e8e-ba86-03cab3948b9b','TLTD','SD','Time Limited','Self Destruct','2024-07-04 16:00:17.997679','2024-07-04 16:00:17.997679','Time limited self destruct'),
-  ('f3e99a33-c239-4b42-9168-bfb69f78a4e3','TLTD','VAR','Time Limited','Variation','2024-07-04 16:00:17.997679','2024-07-04 16:00:17.997679','Time limited variation'),
-  ('c2d5dac0-625a-40e2-81ad-1a26963ef55d','TLTD','LEVFL','Time Limited','Limited Extension of Validity - Full Licence Expiry','2024-07-04 16:00:17.997679','2024-07-04 16:00:17.997679','Time Limited Extension of Validity - Full Licence Expiry'),
-  ('1f20c437-286f-4dc3-abe5-1374893057b9','TLTD','LEVTL','Time Limited','Limited Extension of Validity - Time Limited Variation','2024-07-04 16:00:17.997679','2024-07-04 16:00:17.997679','Time Limited Extension of Validity - Time Limited Variation'),
-  ('9faef5f5-9ca3-475c-8b6e-85b926a58a58','TRA','TRAN','Transfer','Transfer','2024-07-04 16:00:17.997679','2024-07-04 16:00:17.997679','Transfer'),
-  ('8824e1b9-9570-4306-9954-67db55067d8f','WLM','GW','Water Level Monitoring','Ground Water','2024-07-04 16:00:17.997679','2024-07-04 16:00:17.997679','Water level monitoring groundwater'),
-  ('c26cfab1-e3be-43a6-a7b9-a9aa2e1244fa','WLM','SW','Water Level Monitoring','Surface Water','2024-07-04 16:00:17.997679','2024-07-04 16:00:17.997679','Water level monitoring surface water'),
-  ('bc8f2f1f-56aa-4d6f-9ba4-c5f6e5b1aca0','WQM','GW','Water Quality Monitoring','Groundwater','2024-07-04 16:00:17.997679','2024-07-04 16:00:17.997679','Water quality monitoring groundwater'),
-  ('b6a145dd-0643-4d60-8ec9-bea2eceacfc0','WQM','SW','Water Quality Monitoring','Surface Water','2024-07-04 16:00:17.997679','2024-07-04 16:00:17.997679','Water quality monitoring surface water');
-INSERT INTO water.licence_version_purpose_condition_types (licence_version_purpose_condition_type_id,code,subcode,description,subcode_description,date_created,date_updated,display_title) VALUES
-  ('8c2f662e-0be9-4834-8ac2-a5d9efdc03ac','WRT','PNT','Water Rights Trade','Traded Point','2024-07-04 16:00:17.997679','2024-07-04 16:00:17.997679','Water rights trade point'),
-  ('71856a20-35b9-420d-b30e-52189647f3c5','WRT','PUR','Water Rights Trade','Traded Purpose','2024-07-04 16:00:17.997679','2024-07-04 16:00:17.997679','Water rights trade purpose'),
-  ('5580610f-65a1-4c22-a412-53ee6b935ea2','WRT','QTY','Water Rights Trade','Traded Quantity','2024-07-04 16:00:17.997679','2024-07-04 16:00:17.997679','Water rights trade quantity'),
-  ('6765cff9-33fa-4c1c-9e07-51a7d37e451a','XREG','PTS','Cross Regional Point','Licensed Point Falls Within Another Region','2024-07-04 16:00:17.997679','2024-07-04 16:00:17.997679','Licensed point falls within another region');`)
+    INSERT INTO  public.licence_version_purpose_condition_types (id, code, subcode, description, subcode_description, display_title, created_at, updated_at)
+      VALUES ${buildSeedValueString(keys, data)};
+  `
+  )
 }
 
 module.exports = {
+  data,
   seed
 }

--- a/test/support/seeders/seed-builder.js
+++ b/test/support/seeders/seed-builder.js
@@ -17,7 +17,7 @@ function buildSeedValueString (keys, data) {
           valueString += ','
         }
       } catch (e) {
-        console.log('Failed: ', obj)
+        console.error('Failed: ', obj)
       }
     })
 

--- a/test/support/seeders/seed-builder.js
+++ b/test/support/seeders/seed-builder.js
@@ -6,14 +6,18 @@ function buildSeedValueString (keys, data) {
   data.forEach((obj, i) => {
     valueString += '('
     keys.forEach((key, index) => {
-      if (key === 'createdAt' || key === 'updatedAt') {
-        valueString += `'${obj[key].toISOString()}'`
-      } else {
-        valueString += `'${obj[key]}'`
-      }
+      try {
+        if (key === 'createdAt' || key === 'updatedAt') {
+          valueString += `'${obj[key].toISOString()}'`
+        } else {
+          valueString += `'${obj[key]}'`
+        }
 
-      if (index < keys.length - 1) {
-        valueString += ','
+        if (index < keys.length - 1) {
+          valueString += ','
+        }
+      } catch (e) {
+        console.log('Failed: ', obj)
       }
     })
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4535

As part of migrating the import service into the wabs system repo we are adding seeders to the tests which will add what we call reference data the test database.

This is currently running and adding other seeders in the test database.

This change aligns the licence version purpose condition type seeder. Mainly using a data file for us to access this static data in the tests and using the build value string function to build the values to insert into the database.
