### PR TITLE
Remove DatabaseSupport.clean() from bill-runs

### DIFF
--- a/test/services/bill-runs/annual/process-bill-run.service.test.js
+++ b/test/services/bill-runs/annual/process-bill-run.service.test.js
@@ -5,7 +5,7 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, beforeEach, afterEach } = exports.lab = Lab.script()
+const { describe, it, before, beforeEach, afterEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
@@ -16,7 +16,6 @@ const { determineCurrentFinancialYear } = require('../../../../app/lib/general.l
 
 // Things we need to stub
 const ChargingModuleGenerateRequest = require('../../../../app/requests/charging-module/generate-bill-run.request.js')
-const DatabaseSupport = require('../../../support/database.js')
 const FetchBillingAccountsService = require('../../../../app/services/bill-runs/annual/fetch-billing-accounts.service.js')
 const HandleErroredBillRunService = require('../../../../app/services/bill-runs/handle-errored-bill-run.service.js')
 const LegacyRefreshBillRunRequest = require('../../../../app/requests/legacy/refresh-bill-run.request.js')
@@ -31,14 +30,15 @@ describe('Annual Process Bill Run service', () => {
   let billRun
   let notifierStub
 
-  beforeEach(async () => {
-    await DatabaseSupport.clean()
+  before(async () => {
     const financialYearEnd = billingPeriod.startDate.getFullYear()
 
     billRun = await BillRunHelper.add({
       batchType: 'annual', fromFinancialYearEnding: financialYearEnd, toFinancialYearEnding: financialYearEnd
     })
+  })
 
+  beforeEach(async () => {
     // BaseRequest depends on the GlobalNotifier to have been set. This happens in app/plugins/global-notifier.plugin.js
     // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
     // test we recreate the condition by setting it directly with our own stub


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/124

We had a pattern of calling `await DatabaseSupport.clean()` in a `beforeEach()` in any unit test file that depended on adding data to support its tests.

The problem is that the project is becoming so large that it is no longer sustainable. It is also a blocker to moving to a test framework that supports [ECMAScript Modules](https://nodejs.org/api/esm.html), [the official standard format](https://tc39.github.io/ecma262/#sec-modules) to package JavaScript code. Unit test frameworks other than [Hapi Lab](https://hapi.dev/module/lab/) run tests in parallel by default. This means you can't have one test running DB clean while another is trying to load data.

New tests avoid the pattern, and where we can, we've been updating old ones when we have had cause to update the unit tests.

But there are always those where it'll be some time before we have cause to look at them again. So, rather than waiting, this change handles updating all tests in `test/services/bill-runs` to drop their dependence on `DatabaseSupport.clean()`.