### PR TITLE
Add 'Temporary trade' option no-returns-reason page

### DIFF
--- a/app/lib/static-lookups.lib.js
+++ b/app/lib/static-lookups.lib.js
@@ -38,6 +38,7 @@ const returnRequirementReasons = {
   'change-to-special-agreement': 'Change to special agreement',
   'error-correction': 'Error correction',
   'extension-of-licence-validity': 'Limited extension of licence validity (LEV)',
+  'licence-conditions-do-not-require-returns': 'Licence conditions do not require returns',
   'major-change': 'Major change',
   'minor-change': 'Minor change',
   'name-or-address-change': 'Licence holder name or address change',
@@ -47,8 +48,8 @@ const returnRequirementReasons = {
   'returns-exception': 'Returns exception',
   'succession-or-transfer-of-licence': 'Succession or transfer of licence',
   'succession-to-remainder-licence-or-licence-apportionment': 'Succession to remainder licence or licence apportionment',
-  'transfer-and-now-chargeable': 'Licence transferred and now chargeable',
-  'licence-conditions-do-not-require-returns': 'Licence conditions do not require returns'
+  'temporary-trade': 'Temporary trade',
+  'transfer-and-now-chargeable': 'Licence transferred and now chargeable'
 }
 
 const sources = [

--- a/app/validators/return-requirements/no-returns-required.validator.js
+++ b/app/validators/return-requirements/no-returns-required.validator.js
@@ -9,8 +9,9 @@ const Joi = require('joi')
 
 const VALID_VALUES = [
   'abstraction-below-100-cubic-metres-per-day',
+  'licence-conditions-do-not-require-returns',
   'returns-exception',
-  'licence-conditions-do-not-require-returns'
+  'temporary-trade'
 ]
 
 /**

--- a/app/views/return-requirements/no-returns-required.njk
+++ b/app/views/return-requirements/no-returns-required.njk
@@ -48,14 +48,19 @@
             checked: reason == 'abstraction-below-100-cubic-metres-per-day'
           },
           {
+            text: 'Licence conditions do not require returns',
+            value: 'licence-conditions-do-not-require-returns',
+            checked: reason == 'licence-conditions-do-not-require-returns'
+          },
+          {
             text: 'Returns exception',
             value: 'returns-exception',
             checked: reason == 'returns-exception'
           },
           {
-            text: 'Licence conditions do not require returns',
-            value: 'licence-conditions-do-not-require-returns',
-            checked: reason == 'licence-conditions-do-not-require-returns'
+            text: 'Temporary trade',
+            value: 'temporary-trade',
+            checked: reason == 'temporary-trade'
           }
         ]
       }) }}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4612

During a previous PR - ['Change 'Transfer licence' reason for 'No returns needed' journey'](https://github.com/DEFRA/water-abstraction-system/pull/1217) - the 'Temporary trade' option was missed and was not added to the 'Why no returns required?' page.

This PR is focused on adding the 'Temporary trade' option to the 'Why no returns required?' page.