### PR TITLE
Update return logs helper

### DIFF
--- a/test/support/helpers/return-log.helper.js
+++ b/test/support/helpers/return-log.helper.js
@@ -51,7 +51,7 @@ function defaults (data = {}) {
   const licenceRef = data.licenceRef ? data.licenceRef : generateLicenceRef()
   const returnReference = data.returnReference ? data.returnReference : randomInteger(10000000, 19999999)
   const timestamp = timestampForPostgres()
-  const receivedDate = data.receivedDate === null ? null : new Date('2023-04-12')
+  const receivedDate = data.receivedDate ? data.receivedDate : null
 
   const defaults = {
     id: generateReturnLogId('2022-04-01', '2023-03-31', 1, licenceRef, returnReference),
@@ -64,7 +64,7 @@ function defaults (data = {}) {
     returnReference,
     returnsFrequency: 'month',
     startDate: new Date('2022-04-01'),
-    status: 'completed',
+    status: 'due',
     updatedAt: timestamp
   }
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4523

While migrating the fixture files for the acceptance tests, it was noticed that the return-log helper defaults the return-log as being status 'completed' and therefore it has a 'receivedDate'. 

Our acceptance tests use these helpers to load the data from our fixture file. 

We have instances of tests breaking because of the return-log helper. The tests set up the data in a fixtures file that is sent to the `load.service` endpoint as a request payload. Hapi when passing a payload will strip out any null values. For these failing tests the 'recievedDate' needs to be null. When hapi removes the null values, the data passed to the helper will have no 'recievedDate' property, meaning the helper will then use the default data, which populated the date.

This change is to default the return-log helper as a due return rather than a completed return, removing the default data in 'recievedDate' and changing the status to 'due' so the data is more real.
This solves our acceptance test issue, without breaking any unit tests either.

