### PR TITLE
Update tear down service

### DIFF
--- a/app/services/data/tear-down/idm-schema.service.js
+++ b/app/services/data/tear-down/idm-schema.service.js
@@ -21,7 +21,8 @@ async function _deleteAllTestData () {
       "user_data",
       '$.source'
     ) #>> '{}' = 'acceptance-test-setup'
-    OR "user_name" LIKE '%@example.com';
+    OR "user_name" LIKE '%@example.com'
+    OR "user_name" LIKE 'regression.tests%';
   `)
 }
 


### PR DESCRIPTION
Following on from updates in the acceptance tests repo, all the data being used is now from a fixtures file in the repo [(instead of using the legacy code)](https://github.com/DEFRA/water-abstraction-acceptance-tests/pull/119). We need to update the tear-down services idm schema to include a new like clause when deleting data. This update means all the relevant test data gets deleted every time the acceptance tests are run.