### PR TITLE
Update acceptance test tear down service

### DIFF
--- a/app/services/data/tear-down/water-schema.service.js
+++ b/app/services/data/tear-down/water-schema.service.js
@@ -246,12 +246,6 @@ async function _deleteAllTestData () {
 
   DELETE
   FROM
-    "water"."regions"
-  WHERE
-    "is_test" = TRUE;
-
-  DELETE
-  FROM
     "water"."purposes_primary"
   WHERE
     "is_test" = TRUE;

--- a/test/support/seeders/data/region.data.js
+++ b/test/support/seeders/data/region.data.js
@@ -80,6 +80,7 @@ module.exports = [
     name: 'Test Region',
     displayName: 'Test Region',
     createdAt: new Date('2024-07-18'),
-    updatedAt: new Date('2024-07-18')
+    updatedAt: new Date('2024-07-18'),
+    isTest: true
   }
 ]

--- a/test/support/seeders/data/region.data.js
+++ b/test/support/seeders/data/region.data.js
@@ -80,7 +80,6 @@ module.exports = [
     name: 'Test Region',
     displayName: 'Test Region',
     createdAt: new Date('2024-07-18'),
-    updatedAt: new Date('2024-07-18'),
-    isTest: true
+    updatedAt: new Date('2024-07-18')
   }
 ]


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-acceptance-tests/pull/129

During the removal of our region data in the acceptance tests, it was noted that the new region seeder was being deleted in the tear-down service. The tear-down service relies on knowing if the region associated with the data is a test region or not through the 'isTest' property. After deleting the associated data with the test region it then deletes the region itself. As our region is now seeded and not being loaded fo every test, this last delete needs to be removed.
This PR is removing that.