### PR TITLE
Remove more DatabaseSupport.clean() from tests

### DIFF
--- a/test/services/bills/fetch-bill-summary.service.test.js
+++ b/test/services/bills/fetch-bill-summary.service.test.js
@@ -8,14 +8,13 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const BillingAccountHelper = require('../../support/helpers/billing-account.helper.js')
-const BillingAccountAddressHelper = require('../../support/helpers/billing-account-address.helper.js')
 const BillHelper = require('../../support/helpers/bill.helper.js')
 const BillLicenceHelper = require('../../support/helpers/bill-licence.helper.js')
 const BillRunHelper = require('../../support/helpers/bill-run.helper.js')
+const BillingAccountAddressHelper = require('../../support/helpers/billing-account-address.helper.js')
+const BillingAccountHelper = require('../../support/helpers/billing-account.helper.js')
 const CompanyHelper = require('../../support/helpers/company.helper.js')
 const ContactHelper = require('../../support/helpers/contact.helper.js')
-const DatabaseSupport = require('../../support/database.js')
 const RegionHelper = require('../../support/helpers/region.helper.js')
 
 // Thing under test
@@ -26,46 +25,56 @@ describe('Fetch Bill Summary service', () => {
 
   let agentCompanyId
   let bill
-  let billingAccountId
-  let billingAccountAddressId
   let billRunId
+  let billingAccount
+  let billingAccountAddressId
+  let billingAccountId
   let companyId
   let contactId
   let regionId
 
   beforeEach(async () => {
-    await DatabaseSupport.clean()
-
     const company = await CompanyHelper.add()
+
     companyId = company.id
 
-    const billingAccount = await BillingAccountHelper.add({ accountNumber: 'T65757520A', companyId })
+    billingAccount = await BillingAccountHelper.add({ companyId })
+
     billingAccountId = billingAccount.id
 
     const agentCompany = await CompanyHelper.add({ name: 'Agent Company Ltd' })
+
     agentCompanyId = agentCompany.id
 
     const contact = await ContactHelper.add()
+
     contactId = contact.id
 
     const billingAccountAddress = await BillingAccountAddressHelper.add({
       billingAccountId, companyId: agentCompanyId, contactId, endDate: null
     })
+
     billingAccountAddressId = billingAccountAddress.id
 
     const region = await RegionHelper.add({ displayName: 'Stormlands' })
+
     regionId = region.id
 
     const billRun = await BillRunHelper.add({
       billRunNumber: 1075, createdAt: new Date('2023-05-01'), status: 'ready', regionId
     })
+
     billRunId = billRun.id
 
-    bill = await BillHelper.add({ accountNumber: 'T65757520A', billingAccountId, billRunId, netAmount: 1045 })
+    bill = await BillHelper
+      .add({ accountNumber: billingAccount.accountNumber, billingAccountId, billRunId, netAmount: 1045 })
+
     const billId = bill.id
 
     for (let i = 0; i < 2; i++) {
-      const billLicence = await BillLicenceHelper.add({ billId, licenceRef: `01/0${i + 1}/26/9400` })
+      const billLicence = await BillLicenceHelper
+        .add({ billId, licenceRef: `01/0${i + 1}/26/9400` })
+
       billLicences.push(billLicence)
     }
   })
@@ -79,7 +88,7 @@ describe('Fetch Bill Summary service', () => {
         netAmount: 1045,
         billingAccount: {
           id: billingAccountId,
-          accountNumber: 'T65757520A',
+          accountNumber: billingAccount.accountNumber,
           company: {
             id: companyId,
             name: 'Example Trading Ltd',

--- a/test/services/bills/fetch-bill.service.test.js
+++ b/test/services/bills/fetch-bill.service.test.js
@@ -9,11 +9,10 @@ const { expect } = Code
 
 // Test helpers
 const BillHelper = require('../../support/helpers/bill.helper.js')
+const BillLicenceHelper = require('../../support/helpers/bill-licence.helper.js')
 const BillModel = require('../../../app/models/bill.model.js')
 const BillRunHelper = require('../../support/helpers/bill-run.helper.js')
 const BillRunModel = require('../../../app/models/bill-run.model.js')
-const BillLicenceHelper = require('../../support/helpers/bill-licence.helper.js')
-const DatabaseSupport = require('../../support/database.js')
 const RegionHelper = require('../../support/helpers/region.helper.js')
 const RegionModel = require('../../../app/models/region.model.js')
 const TransactionHelper = require('../../support/helpers/transaction.helper.js')
@@ -29,8 +28,6 @@ describe('Fetch Bill service', () => {
   let unlinkedBillLicence
 
   beforeEach(async () => {
-    await DatabaseSupport.clean()
-
     linkedRegion = await RegionHelper.add()
     linkedBillRun = await BillRunHelper.add({ regionId: linkedRegion.id })
 

--- a/test/services/bills/submit-remove-bill.services.test.js
+++ b/test/services/bills/submit-remove-bill.services.test.js
@@ -10,7 +10,6 @@ const { expect } = Code
 
 // Test helpers
 const BillHelper = require('../../support/helpers/bill.helper.js')
-const DatabaseSupport = require('../../support/database.js')
 
 // Things we need to stub
 const LegacyDeleteBillRequest = require('../../../app/requests/legacy/delete-bill.request.js')
@@ -25,8 +24,6 @@ describe('Submit Remove Bill service', () => {
   let legacyDeleteBillRequestStub
 
   beforeEach(async () => {
-    await DatabaseSupport.clean()
-
     bill = await BillHelper.add()
 
     legacyDeleteBillRequestStub = Sinon.stub(LegacyDeleteBillRequest, 'send').resolves()

--- a/test/services/data/deduplicate/de-duplicate-licence.service.test.js
+++ b/test/services/data/deduplicate/de-duplicate-licence.service.test.js
@@ -8,32 +8,32 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const DatabaseSupport = require('../../../support/database.js')
 const LicenceHelper = require('../../../support/helpers/licence.helper.js')
 const LicenceModel = require('../../../../app/models/licence.model.js')
+const { generateLicenceRef } = require('../../../support/helpers/licence.helper.js')
 
 // Thing under test
 const DeDuplicateLicenceService = require('../../../../app/services/data/deduplicate/de-duplicate-licence.service.js')
 
 describe('De-duplicate Licence service', () => {
-  const licenceRef = '01/120'
-
   let invalidLicence
+  let licenceRef
   let validLicences
 
   beforeEach(async () => {
-    await DatabaseSupport.clean()
+    licenceRef = generateLicenceRef()
 
     validLicences = []
 
     // Create our valid licence
     let licence = await LicenceHelper.add({ licenceRef })
+
     validLicences.push(licence.id)
 
     // Create other valid licences that will match our search. We need to ensure these do not get deleted by the service
-    licence = await LicenceHelper.add({ licenceRef: 'WA/01/120' })
+    licence = await LicenceHelper.add({ licenceRef: generateLicenceRef() })
     validLicences.push(licence.id)
-    licence = await LicenceHelper.add({ licenceRef: '02/01/120/R01' })
+    licence = await LicenceHelper.add({ licenceRef: generateLicenceRef() })
     validLicences.push(licence.id)
   })
 
@@ -41,7 +41,7 @@ describe('De-duplicate Licence service', () => {
     describe('with a space', () => {
       describe('at the start of the reference', () => {
         beforeEach(async () => {
-          invalidLicence = await LicenceHelper.add({ licenceRef: ' 01/120' })
+          invalidLicence = await LicenceHelper.add({ licenceRef: ` ${licenceRef}` })
         })
 
         it('removes just that invalid licence', async () => {
@@ -59,7 +59,7 @@ describe('De-duplicate Licence service', () => {
 
       describe('at the end of the reference', () => {
         beforeEach(async () => {
-          invalidLicence = await LicenceHelper.add({ licenceRef: '01/120 ' })
+          invalidLicence = await LicenceHelper.add({ licenceRef: `${licenceRef} ` })
         })
 
         it('removes just that invalid licence', async () => {
@@ -77,7 +77,7 @@ describe('De-duplicate Licence service', () => {
 
       describe('at the start and end of the reference', () => {
         beforeEach(async () => {
-          invalidLicence = await LicenceHelper.add({ licenceRef: ' 01/120 ' })
+          invalidLicence = await LicenceHelper.add({ licenceRef: ` ${licenceRef} ` })
         })
 
         it('removes just that invalid licence', async () => {
@@ -97,7 +97,7 @@ describe('De-duplicate Licence service', () => {
     describe('with a newline', () => {
       describe('at the start of the reference', () => {
         beforeEach(async () => {
-          invalidLicence = await LicenceHelper.add({ licenceRef: '\n01/120' })
+          invalidLicence = await LicenceHelper.add({ licenceRef: `\n${licenceRef}` })
         })
 
         it('removes just that invalid licence', async () => {
@@ -115,7 +115,7 @@ describe('De-duplicate Licence service', () => {
 
       describe('at the end of the reference', () => {
         beforeEach(async () => {
-          invalidLicence = await LicenceHelper.add({ licenceRef: '01/120\n' })
+          invalidLicence = await LicenceHelper.add({ licenceRef: `${licenceRef}\n` })
         })
 
         it('removes just that invalid licence', async () => {
@@ -133,7 +133,7 @@ describe('De-duplicate Licence service', () => {
 
       describe('at the start and end of the reference', () => {
         beforeEach(async () => {
-          invalidLicence = await LicenceHelper.add({ licenceRef: '\n01/120\n' })
+          invalidLicence = await LicenceHelper.add({ licenceRef: `\n${licenceRef}\n` })
         })
 
         it('removes just that invalid licence', async () => {

--- a/test/services/licences/determine-licence-has-return-versions.service.test.js
+++ b/test/services/licences/determine-licence-has-return-versions.service.test.js
@@ -8,7 +8,6 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const DatabaseSupport = require('../../support/database.js')
 const ReturnVersionHelper = require('../../support/helpers/return-version.helper.js')
 
 // Thing under test
@@ -17,10 +16,6 @@ const FetchLicenceHasRequirementsService =
 
 describe('Fetch Licence Has Requirements service', () => {
   const licenceId = 'e004c0c9-0316-42fc-a6e3-5ae9a271b3c6'
-
-  beforeEach(async () => {
-    await DatabaseSupport.clean()
-  })
 
   describe('when the licence has return versions', () => {
     beforeEach(async () => {

--- a/test/services/licences/fetch-communications.service.test.js
+++ b/test/services/licences/fetch-communications.service.test.js
@@ -8,23 +8,21 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const DatabaseSupport = require('../../support/database.js')
 const EventHelper = require('../../support/helpers/event.helper.js')
 const ScheduledNotificationModel = require('../../support/helpers/scheduled-notification.helper.js')
+const { generateLicenceRef } = require('../../support/helpers/licence.helper.js')
 
 // Thing under test
 const FetchCommunicationsService =
   require('../../../app/services/licences/fetch-communications.service.js')
 
 describe('Fetch Communications service', () => {
-  const licenceRef = '01/01'
+  const licenceRef = generateLicenceRef()
 
   let event
   let scheduledNotification
 
   beforeEach(async () => {
-    await DatabaseSupport.clean()
-
     event = await EventHelper.add({
       createdAt: new Date('2024-06-01'),
       licences: JSON.stringify([licenceRef]),

--- a/test/services/licences/fetch-customer-contacts.service.test.js
+++ b/test/services/licences/fetch-customer-contacts.service.test.js
@@ -11,7 +11,6 @@ const { expect } = Code
 const CompanyContactHelper = require('../../support/helpers/company-contact.helper.js')
 const CompanyHelper = require('../../support/helpers/company.helper.js')
 const ContactHelper = require('../../support/helpers/contact.helper.js')
-const DatabaseSupport = require('../../support/database.js')
 const LicenceDocumentHelper = require('../../support/helpers/licence-document.helper.js')
 const LicenceDocumentRoleHelper = require('../../support/helpers/licence-document-role.helper.js')
 const LicenceHelper = require('../../support/helpers/licence.helper.js')
@@ -26,19 +25,18 @@ describe('Fetch Customer Contacts service', () => {
   let contactId
   let licenceId
 
-  beforeEach(async () => {
-    await DatabaseSupport.clean()
-  })
-
   describe('when the licence has customer contact details', () => {
     beforeEach(async () => {
       const licence = await LicenceHelper.add()
+
       licenceId = licence.id
 
       const company = await CompanyHelper.add()
+
       companyId = company.id
 
       const contact = await ContactHelper.add()
+
       contactId = contact.id
 
       const { id: licenceDocumentId } = await LicenceDocumentHelper.add({ licenceRef: licence.licenceRef })

--- a/test/services/licences/fetch-licence-contacts.service.test.js
+++ b/test/services/licences/fetch-licence-contacts.service.test.js
@@ -11,7 +11,6 @@ const { expect } = Code
 const AddressHelper = require('../../support/helpers/address.helper.js')
 const CompanyHelper = require('../../support/helpers/company.helper.js')
 const ContactHelper = require('../../support/helpers/contact.helper.js')
-const DatabaseSupport = require('../../support/database.js')
 const LicenceDocumentHelper = require('../../support/helpers/licence-document.helper.js')
 const LicenceDocumentRolesHelper = require('../../support/helpers/licence-document-role.helper.js')
 const LicenceHelper = require('../../support/helpers/licence.helper.js')
@@ -25,24 +24,24 @@ describe('Fetch Licence Contacts service', () => {
   let companyId
   let contactId
 
-  beforeEach(async () => {
-    await DatabaseSupport.clean()
-  })
-
   describe('when the licence has contact details', () => {
     beforeEach(async () => {
       const licence = await LicenceHelper.add()
+
       licenceId = licence.id
 
       const company = await CompanyHelper.add()
+
       companyId = company.id
 
       const contact = await ContactHelper.add()
+
       contactId = contact.id
 
       const { id: licenceDocumentId } = await LicenceDocumentHelper.add({ licenceRef: licence.licenceRef })
       const { id: licenceRoleId } = await LicenceRoleHelper.add()
       const { id: addressId } = await AddressHelper.add()
+
       await LicenceDocumentRolesHelper.add({
         endDate: null,
         licenceDocumentId,

--- a/test/services/licences/fetch-licence-returns.service.test.js
+++ b/test/services/licences/fetch-licence-returns.service.test.js
@@ -8,19 +8,15 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const DatabaseSupport = require('../../support/database.js')
-const LicenceHelper = require('../../support/helpers/licence.helper')
+const LicenceHelper = require('../../support/helpers/licence.helper.js')
 const ReturnLogHelper = require('../../support/helpers/return-log.helper.js')
+const { generateUUID } = require('../../../app/lib/general.lib.js')
 
 // Thing under test
-const FetchLicenceReturnsService = require('../../../app/services/licences/fetch-licence-returns.service')
+const FetchLicenceReturnsService = require('../../../app/services/licences/fetch-licence-returns.service.js')
 
 describe('Fetch licence returns service', () => {
-  const licenceId = 'fef693fd-eb6f-478d-9f79-ab24749c5dc6'
-
-  beforeEach(async () => {
-    await DatabaseSupport.clean()
-  })
+  let licenceId
 
   describe('when the licence has return logs', () => {
     const dueDate = new Date('2020-04-01')
@@ -28,7 +24,7 @@ describe('Fetch licence returns service', () => {
     const startDate = new Date('2020-02-01')
     const latestDueDate = new Date('2020-05-01')
     const firstReturn = {
-      id: '5fef371e-d0b5-4fd5-a7ff-a67d04b3f451',
+      id: generateUUID(),
       dueDate,
       endDate,
       metadata: '323',
@@ -39,15 +35,15 @@ describe('Fetch licence returns service', () => {
 
     const latestReturn = {
       ...firstReturn,
-      id: 'b80f87a3-a274-4232-b536-750670d79928',
+      id: generateUUID(),
       returnReference: '123',
       dueDate: latestDueDate
     }
 
     beforeEach(async () => {
-      const license = await LicenceHelper.add({
-        id: licenceId
-      })
+      const license = await LicenceHelper.add()
+
+      licenceId = license.id
 
       firstReturn.licenceRef = license.licenceRef
       latestReturn.licenceRef = license.licenceRef

--- a/test/services/licences/fetch-return-versions.service.test.js
+++ b/test/services/licences/fetch-return-versions.service.test.js
@@ -8,7 +8,6 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const DatabaseSupport = require('../../support/database.js')
 const ReturnVersionHelper = require('../../support/helpers/return-version.helper.js')
 
 // Thing under test
@@ -17,10 +16,6 @@ const FetchReturnVersionsService =
 
 describe('Fetch Return Versions service', () => {
   let returnVersion
-
-  beforeEach(async () => {
-    await DatabaseSupport.clean()
-  })
 
   describe('when the licence has return versions data', () => {
     beforeEach(async () => {

--- a/test/services/return-requirements/abstraction-period.service.test.js
+++ b/test/services/return-requirements/abstraction-period.service.test.js
@@ -8,7 +8,6 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const DatabaseSupport = require('../../support/database.js')
 const SessionHelper = require('../../support/helpers/session.helper.js')
 
 // Thing under test
@@ -20,8 +19,6 @@ describe('Return Requirements - Abstraction Period service', () => {
   let session
 
   beforeEach(async () => {
-    await DatabaseSupport.clean()
-
     session = await SessionHelper.add({
       data: {
         checkPageVisited: false,

--- a/test/services/return-requirements/add.service.test.js
+++ b/test/services/return-requirements/add.service.test.js
@@ -8,7 +8,6 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const DatabaseSupport = require('../../support/database.js')
 const SessionHelper = require('../../support/helpers/session.helper.js')
 
 // Thing under test
@@ -18,8 +17,6 @@ describe('Return Requirements - Add service', () => {
   let session
 
   beforeEach(async () => {
-    await DatabaseSupport.clean()
-
     session = await SessionHelper.add({
       data: {
         checkPageVisited: false,

--- a/test/services/return-requirements/additional-submission-options.service.test.js
+++ b/test/services/return-requirements/additional-submission-options.service.test.js
@@ -8,7 +8,6 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const DatabaseSupport = require('../../support/database.js')
 const SessionHelper = require('../../support/helpers/session.helper.js')
 
 // Thing under test
@@ -18,8 +17,6 @@ describe('Return Requirements - Additional Submission Options service', () => {
   let session
 
   beforeEach(async () => {
-    await DatabaseSupport.clean()
-
     session = await SessionHelper.add({
       data: {
         checkPageVisited: false,

--- a/test/services/return-requirements/agreements-exceptions.service.test.js
+++ b/test/services/return-requirements/agreements-exceptions.service.test.js
@@ -8,7 +8,6 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const DatabaseSupport = require('../../support/database.js')
 const SessionHelper = require('../../support/helpers/session.helper.js')
 
 // Thing under test
@@ -20,8 +19,6 @@ describe('Return Requirements - Agreements Exceptions service', () => {
   let session
 
   beforeEach(async () => {
-    await DatabaseSupport.clean()
-
     session = await SessionHelper.add({
       data: {
         checkPageVisited: false,

--- a/test/services/return-requirements/cancel.service.test.js
+++ b/test/services/return-requirements/cancel.service.test.js
@@ -8,8 +8,8 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const DatabaseSupport = require('../../support/database.js')
 const SessionHelper = require('../../support/helpers/session.helper.js')
+const { generateUUID } = require('../../../app/lib/general.lib.js')
 
 // Thing under test
 const CancelService = require('../../../app/services/return-requirements/cancel.service.js')
@@ -18,10 +18,8 @@ describe('Return Requirements - Cancel service', () => {
   let session
 
   beforeEach(async () => {
-    await DatabaseSupport.clean()
-
     session = await SessionHelper.add({
-      id: '61e07498-f309-4829-96a9-72084a54996d',
+      id: generateUUID(),
       data: {
         checkPageVisited: false,
         licence: {
@@ -68,14 +66,15 @@ describe('Return Requirements - Cancel service', () => {
 
       expect(result).to.equal({
         activeNavBar: 'search',
-        pageTitle: 'You are about to cancel these requirements for returns',
-        backLink: '/system/return-requirements/61e07498-f309-4829-96a9-72084a54996d/check',
-        licenceRef: '01/ABC',
+        backLink: `/system/return-requirements/${session.id}/check`,
         licenceId: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
+        licenceRef: '01/ABC',
+        pageTitle: 'You are about to cancel these requirements for returns',
         reason: 'Major change',
         returnRequirements: ['Winter and all year monthly requirements for returns, Bore hole in rear field.'],
+        sessionId: session.id,
         startDate: '1 January 2023'
-      }, { skip: ['sessionId'] })
+      })
     })
   })
 })

--- a/test/services/return-requirements/check-licence-ended.service.test.js
+++ b/test/services/return-requirements/check-licence-ended.service.test.js
@@ -8,7 +8,6 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const DatabaseSupport = require('../../support/database.js')
 const LicenceHelper = require('../../support/helpers/licence.helper.js')
 
 // Thing under test
@@ -16,10 +15,6 @@ const CheckLicenceEndedService = require('../../../app/services/return-requireme
 
 describe('Return Requirements - CheckLicenceEndedService', () => {
   let licence
-
-  beforeEach(async () => {
-    await DatabaseSupport.clean()
-  })
 
   describe('go', () => {
     beforeEach(async () => {

--- a/test/services/return-requirements/delete-note.service.test.js
+++ b/test/services/return-requirements/delete-note.service.test.js
@@ -9,7 +9,6 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const DatabaseSupport = require('../../support/database.js')
 const SessionHelper = require('../../support/helpers/session.helper.js')
 
 // Thing under test
@@ -20,8 +19,6 @@ describe('Return Requirements - Delete Note service', () => {
   let yarStub
 
   beforeEach(async () => {
-    await DatabaseSupport.clean()
-
     session = await SessionHelper.add({
       data: {
         checkPageVisited: false,

--- a/test/services/return-requirements/existing.service.test.js
+++ b/test/services/return-requirements/existing.service.test.js
@@ -8,7 +8,6 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const DatabaseSupport = require('../../support/database.js')
 const SessionHelper = require('../../support/helpers/session.helper.js')
 
 // Thing under test
@@ -18,7 +17,6 @@ describe('Return Requirements - Existing service', () => {
   let session
 
   beforeEach(async () => {
-    await DatabaseSupport.clean()
     session = await SessionHelper.add({
       data: {
         checkPageVisited: false,

--- a/test/services/return-requirements/fetch-points.service.test.js
+++ b/test/services/return-requirements/fetch-points.service.test.js
@@ -8,7 +8,6 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const DatabaseSupport = require('../../support/database.js')
 const LicenceHelper = require('../../support/helpers/licence.helper.js')
 const PermitLicenceHelper = require('../../support/helpers/permit-licence.helper.js')
 const RegionHelper = require('../../support/helpers/region.helper.js')
@@ -21,8 +20,6 @@ describe('Return Requirements - Return requirements Fetch Points service', () =>
   let region
 
   beforeEach(async () => {
-    await DatabaseSupport.clean()
-
     region = await RegionHelper.add()
 
     // Create the initial licenceId

--- a/test/services/return-requirements/frequency-collected.service.test.js
+++ b/test/services/return-requirements/frequency-collected.service.test.js
@@ -20,8 +20,6 @@ describe('Return Requirements - Frequency Collected service', () => {
   let session
 
   beforeEach(async () => {
-    await DatabaseSupport.clean()
-
     session = await SessionHelper.add({
       data: {
         checkPageVisited: false,

--- a/test/services/return-requirements/frequency-reported.service.test.js
+++ b/test/services/return-requirements/frequency-reported.service.test.js
@@ -20,8 +20,6 @@ describe('Return Requirements - Frequency Reported service', () => {
   let session
 
   beforeEach(async () => {
-    await DatabaseSupport.clean()
-
     session = await SessionHelper.add({
       data: {
         checkPageVisited: false,

--- a/test/services/return-requirements/no-returns-required.service.test.js
+++ b/test/services/return-requirements/no-returns-required.service.test.js
@@ -8,7 +8,6 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const DatabaseSupport = require('../../support/database.js')
 const SessionHelper = require('../../support/helpers/session.helper.js')
 
 // Thing under test
@@ -18,8 +17,6 @@ describe('Return Requirements - No Returns Required service', () => {
   let session
 
   beforeEach(async () => {
-    await DatabaseSupport.clean()
-
     session = await SessionHelper.add({
       data: {
         checkPageVisited: false,

--- a/test/services/return-requirements/note.service.test.js
+++ b/test/services/return-requirements/note.service.test.js
@@ -8,7 +8,6 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const DatabaseSupport = require('../../support/database.js')
 const SessionHelper = require('../../support/helpers/session.helper.js')
 
 // Thing under test
@@ -18,8 +17,6 @@ describe('Return Requirements - Note service', () => {
   let session
 
   beforeEach(async () => {
-    await DatabaseSupport.clean()
-
     session = await SessionHelper.add({
       data: {
         checkPageVisited: false,

--- a/test/services/return-requirements/points.service.test.js
+++ b/test/services/return-requirements/points.service.test.js
@@ -9,7 +9,6 @@ const { describe, it, beforeEach, afterEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const DatabaseSupport = require('../../support/database.js')
 const SessionHelper = require('../../support/helpers/session.helper.js')
 
 // Things we need to stub
@@ -24,8 +23,6 @@ describe('Return Requirements - Select Points service', () => {
   let session
 
   beforeEach(async () => {
-    await DatabaseSupport.clean()
-
     session = await SessionHelper.add({
       data: {
         checkPageVisited: false,

--- a/test/services/return-requirements/purpose.service.test.js
+++ b/test/services/return-requirements/purpose.service.test.js
@@ -24,8 +24,6 @@ describe('Return Requirements - Purpose service', () => {
   let session
 
   beforeEach(async () => {
-    await DatabaseSupport.clean()
-
     Sinon.stub(FetchPurposesService, 'go').resolves([
       { id: '14794d57-1acf-4c91-8b48-4b1ec68bfd6f', description: 'Heat Pump' },
       { id: '49088608-ee9f-491a-8070-6831240945ac', description: 'Horticultural Watering' }

--- a/test/services/return-requirements/reason.service.test.js
+++ b/test/services/return-requirements/reason.service.test.js
@@ -8,7 +8,6 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const DatabaseSupport = require('../../support/database.js')
 const SessionHelper = require('../../support/helpers/session.helper.js')
 
 // Thing under test
@@ -18,7 +17,6 @@ describe('Return Requirements - Reason service', () => {
   let session
 
   beforeEach(async () => {
-    await DatabaseSupport.clean()
     session = await SessionHelper.add({
       data: {
         checkPageVisited: false,

--- a/test/services/return-requirements/remove.service.test.js
+++ b/test/services/return-requirements/remove.service.test.js
@@ -8,8 +8,8 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const DatabaseSupport = require('../../support/database.js')
 const SessionHelper = require('../../support/helpers/session.helper.js')
+const { generateUUID } = require('../../../app/lib/general.lib.js')
 
 // Thing under test
 const RemoveService = require('../../../app/services/return-requirements/remove.service.js')
@@ -20,10 +20,8 @@ describe('Return Requirements - Remove service', () => {
   let session
 
   beforeEach(async () => {
-    await DatabaseSupport.clean()
-
     session = await SessionHelper.add({
-      id: '61e07498-f309-4829-96a9-72084a54996d',
+      id: generateUUID(),
       data: {
         checkPageVisited: false,
         licence: {
@@ -69,13 +67,14 @@ describe('Return Requirements - Remove service', () => {
 
       expect(result).to.equal({
         activeNavBar: 'search',
-        pageTitle: 'You are about to remove these requirements for returns',
-        backLink: '/system/return-requirements/61e07498-f309-4829-96a9-72084a54996d/check',
-        licenceRef: '01/ABC',
+        backLink: `/system/return-requirements/${session.id}/check`,
         licenceId: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
+        licenceRef: '01/ABC',
+        pageTitle: 'You are about to remove these requirements for returns',
         returnRequirement: 'Winter and all year monthly requirements for returns, Bore hole in rear field.',
+        sessionId: session.id,
         startDate: '1 January 2023'
-      }, { skip: ['sessionId'] })
+      })
     })
   })
 })

--- a/test/services/return-requirements/returns-cycle.service.test.js
+++ b/test/services/return-requirements/returns-cycle.service.test.js
@@ -8,7 +8,6 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const DatabaseSupport = require('../../support/database.js')
 const SessionHelper = require('../../support/helpers/session.helper.js')
 
 // Thing under test
@@ -20,8 +19,6 @@ describe('Return Requirements - Returns Cycle service', () => {
   let session
 
   beforeEach(async () => {
-    await DatabaseSupport.clean()
-
     session = await SessionHelper.add({
       data: {
         checkPageVisited: false,

--- a/test/services/return-requirements/setup/fetch-abstraction-data.service.test.js
+++ b/test/services/return-requirements/setup/fetch-abstraction-data.service.test.js
@@ -8,7 +8,6 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const DatabaseSupport = require('../../../support/database.js')
 const LicenceAbstractionDataSeeder = require('../../../support/seeders/licence-abstraction-data.seeder.js')
 const LicenceAgreementModel = require('../../../../app/models/licence-agreement.model.js')
 
@@ -19,9 +18,7 @@ describe('Return Requirements - Fetch Abstraction Data service', () => {
   let seedIds
 
   beforeEach(async () => {
-    await DatabaseSupport.clean()
-
-    seedIds = await LicenceAbstractionDataSeeder.seed('01/12/34/1000')
+    seedIds = await LicenceAbstractionDataSeeder.seed()
   })
 
   describe('when called', () => {
@@ -52,37 +49,37 @@ describe('Return Requirements - Fetch Abstraction Data service', () => {
             status: 'current',
             licenceVersionPurposes: [
               {
-                id: seedIds.licenceVersionPurposes.electricityId,
+                id: seedIds.licenceVersionPurposes.electricity.id,
                 abstractionPeriodEndDay: 31,
                 abstractionPeriodEndMonth: 3,
                 abstractionPeriodStartDay: 1,
                 abstractionPeriodStartMonth: 1,
                 dailyQuantity: 455,
-                externalId: '1:10065380',
+                externalId: seedIds.licenceVersionPurposes.electricity.externalId,
                 primaryPurpose: { id: seedIds.allPurposes.primaryPurposes.primaryElectricityId, legacyId: 'P' },
                 purpose: { description: 'Heat Pump', id: seedIds.allPurposes.purposes.heatPumpId, legacyId: '200', twoPartTariff: false },
                 secondaryPurpose: { id: seedIds.allPurposes.secondaryPurposes.secondaryElectricityId, legacyId: 'ELC' }
               },
               {
-                id: seedIds.licenceVersionPurposes.standardId,
+                id: seedIds.licenceVersionPurposes.standard.id,
                 abstractionPeriodEndDay: 31,
                 abstractionPeriodEndMonth: 3,
                 abstractionPeriodStartDay: 1,
                 abstractionPeriodStartMonth: 1,
                 dailyQuantity: 2675,
-                externalId: '1:10065381',
+                externalId: seedIds.licenceVersionPurposes.standard.externalId,
                 primaryPurpose: { id: seedIds.allPurposes.primaryPurposes.primaryAgricultureId, legacyId: 'A' },
                 purpose: { description: 'Vegetable Washing', id: seedIds.allPurposes.purposes.vegetableWashingId, legacyId: '460', twoPartTariff: false },
                 secondaryPurpose: { id: seedIds.allPurposes.secondaryPurposes.secondaryAgricultureId, legacyId: 'AGR' }
               },
               {
-                id: seedIds.licenceVersionPurposes.twoPartTariffId,
+                id: seedIds.licenceVersionPurposes.twoPartTariff.id,
                 abstractionPeriodEndDay: 31,
                 abstractionPeriodEndMonth: 3,
                 abstractionPeriodStartDay: 1,
                 abstractionPeriodStartMonth: 1,
                 dailyQuantity: 300,
-                externalId: '1:10065382',
+                externalId: seedIds.licenceVersionPurposes.twoPartTariff.externalId,
                 primaryPurpose: { id: seedIds.allPurposes.primaryPurposes.primaryAgricultureId, legacyId: 'A' },
                 purpose: { description: 'Spray Irrigation - Direct', id: seedIds.allPurposes.purposes.sprayIrrigationDirectId, legacyId: '400', twoPartTariff: true },
                 secondaryPurpose: { id: seedIds.allPurposes.secondaryPurposes.secondaryAgricultureId, legacyId: 'AGR' }

--- a/test/services/return-requirements/setup/setup.service.test.js
+++ b/test/services/return-requirements/setup/setup.service.test.js
@@ -8,7 +8,6 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const DatabaseSupport = require('../../../support/database.js')
 const SessionHelper = require('../../../support/helpers/session.helper.js')
 
 // Thing under test
@@ -18,8 +17,6 @@ describe('Return Requirements - Setup service', () => {
   let session
 
   beforeEach(async () => {
-    await DatabaseSupport.clean()
-
     session = await SessionHelper.add({
       data: {
         checkPageVisited: false,

--- a/test/services/return-requirements/setup/submit-setup.service.test.js
+++ b/test/services/return-requirements/setup/submit-setup.service.test.js
@@ -9,7 +9,6 @@ const { describe, it, beforeEach, afterEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const DatabaseSupport = require('../../../support/database.js')
 const SessionHelper = require('../../../support/helpers/session.helper.js')
 
 // Things we need to stub
@@ -23,8 +22,6 @@ describe('Return Requirements - Submit Setup service', () => {
   let session
 
   beforeEach(async () => {
-    await DatabaseSupport.clean()
-
     session = await SessionHelper.add({
       data: {
         checkPageVisited: false,

--- a/test/services/return-requirements/site-description.service.test.js
+++ b/test/services/return-requirements/site-description.service.test.js
@@ -8,7 +8,6 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const DatabaseSupport = require('../../support/database.js')
 const SessionHelper = require('../../support/helpers/session.helper.js')
 
 // Things under test
@@ -20,8 +19,6 @@ describe('Return Requirements - Site Description service', () => {
   let session
 
   beforeEach(async () => {
-    await DatabaseSupport.clean()
-
     session = await SessionHelper.add({
       data: {
         checkPageVisited: false,

--- a/test/services/return-requirements/start-date.service.test.js
+++ b/test/services/return-requirements/start-date.service.test.js
@@ -9,7 +9,6 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const DatabaseSupport = require('../../support/database.js')
 const FeatureFlagsConfig = require('../../../config/feature-flags.config.js')
 const SessionHelper = require('../../support/helpers/session.helper.js')
 
@@ -20,8 +19,6 @@ describe('Return Requirements - Start Date service', () => {
   let session
 
   beforeEach(async () => {
-    await DatabaseSupport.clean()
-
     session = await SessionHelper.add({
       data: {
         checkPageVisited: false,

--- a/test/services/return-requirements/submit-abstraction-period.service.test.js
+++ b/test/services/return-requirements/submit-abstraction-period.service.test.js
@@ -9,7 +9,6 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const DatabaseSupport = require('../../support/database.js')
 const SessionHelper = require('../../support/helpers/session.helper.js')
 
 // Thing under test
@@ -24,8 +23,6 @@ describe('Return Requirements - Submit Abstraction Period service', () => {
   let yarStub
 
   beforeEach(async () => {
-    await DatabaseSupport.clean()
-
     sessionData = {
       data: {
         checkPageVisited: false,

--- a/test/services/return-requirements/submit-additional-submission-options.service.test.js
+++ b/test/services/return-requirements/submit-additional-submission-options.service.test.js
@@ -9,7 +9,6 @@ const { describe, it, beforeEach, afterEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const DatabaseSupport = require('../../support/database.js')
 const SessionHelper = require('../../support/helpers/session.helper.js')
 
 // Thing under test
@@ -21,8 +20,6 @@ describe('Return Requirements - Submit Additional Submission Options service', (
   let yarStub
 
   beforeEach(async () => {
-    await DatabaseSupport.clean()
-
     session = await SessionHelper.add({
       data: {
         checkPageVisited: false,

--- a/test/services/return-requirements/submit-agreements-exceptions.service.test.js
+++ b/test/services/return-requirements/submit-agreements-exceptions.service.test.js
@@ -9,7 +9,6 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const DatabaseSupport = require('../../support/database.js')
 const SessionHelper = require('../../support/helpers/session.helper.js')
 
 // Thing under test
@@ -24,8 +23,6 @@ describe('Return Requirements - Submit Agreements and Exceptions service', () =>
   let yarStub
 
   beforeEach(async () => {
-    await DatabaseSupport.clean()
-
     sessionData = {
       data: {
         checkPageVisited: false,

--- a/test/services/return-requirements/submit-cancel.service.test.js
+++ b/test/services/return-requirements/submit-cancel.service.test.js
@@ -8,8 +8,8 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const DatabaseSupport = require('../../support/database.js')
 const SessionHelper = require('../../support/helpers/session.helper.js')
+const { generateUUID } = require('../../../app/lib/general.lib.js')
 
 // Thing under test
 const SubmitCancelService = require('../../../app/services/return-requirements/submit-cancel.service.js')
@@ -18,10 +18,8 @@ describe('Return Requirements - Submit Cancel service', () => {
   let session
 
   beforeEach(async () => {
-    await DatabaseSupport.clean()
-
     session = await SessionHelper.add({
-      id: '61e07498-f309-4829-96a9-72084a54996d',
+      id: generateUUID(),
       data: {
         checkPageVisited: false,
         licence: {

--- a/test/services/return-requirements/submit-existing.service.test.js
+++ b/test/services/return-requirements/submit-existing.service.test.js
@@ -9,7 +9,6 @@ const { describe, it, beforeEach, afterEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const DatabaseSupport = require('../../support/database.js')
 const SessionHelper = require('../../support/helpers/session.helper.js')
 
 // Things we need to stub
@@ -24,8 +23,6 @@ describe('Return Requirements - Submit Existing service', () => {
   let sessionData
 
   beforeEach(async () => {
-    await DatabaseSupport.clean()
-
     sessionData = {
       data: {
         checkPageVisited: false,

--- a/test/services/return-requirements/submit-frequency-collected.service.test.js
+++ b/test/services/return-requirements/submit-frequency-collected.service.test.js
@@ -9,7 +9,6 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const DatabaseSupport = require('../../support/database.js')
 const SessionHelper = require('../../support/helpers/session.helper.js')
 
 // Thing under test
@@ -24,8 +23,6 @@ describe('Return Requirements - Submit Frequency Collected service', () => {
   let yarStub
 
   beforeEach(async () => {
-    await DatabaseSupport.clean()
-
     sessionData = {
       data: {
         checkPageVisited: false,

--- a/test/services/return-requirements/submit-frequency-reported.service.test.js
+++ b/test/services/return-requirements/submit-frequency-reported.service.test.js
@@ -9,7 +9,6 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const DatabaseSupport = require('../../support/database.js')
 const SessionHelper = require('../../support/helpers/session.helper.js')
 
 // Thing under test
@@ -24,8 +23,6 @@ describe('Return Requirements - Submit Frequency Reported service', () => {
   let yarStub
 
   beforeEach(async () => {
-    await DatabaseSupport.clean()
-
     sessionData = {
       data: {
         checkPageVisited: false,

--- a/test/services/return-requirements/submit-no-returns-required.service.test.js
+++ b/test/services/return-requirements/submit-no-returns-required.service.test.js
@@ -9,7 +9,6 @@ const { describe, it, afterEach, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const DatabaseSupport = require('../../support/database.js')
 const SessionHelper = require('../../support/helpers/session.helper.js')
 
 // Thing under test
@@ -22,8 +21,6 @@ describe('Return Requirements - Submit No Returns Required service', () => {
   let yarStub
 
   beforeEach(async () => {
-    await DatabaseSupport.clean()
-
     sessionData = {
       data: {
         checkPageVisited: false,

--- a/test/services/return-requirements/submit-note.service.test.js
+++ b/test/services/return-requirements/submit-note.service.test.js
@@ -9,7 +9,6 @@ const { describe, it, beforeEach, afterEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const DatabaseSupport = require('../../support/database.js')
 const SessionHelper = require('../../support/helpers/session.helper.js')
 
 // Thing under test
@@ -23,8 +22,6 @@ describe('Return Requirements - Submit Note service', () => {
   let yarStub
 
   beforeEach(async () => {
-    await DatabaseSupport.clean()
-
     session = await SessionHelper.add({
       data: {
         checkPageVisited: false,

--- a/test/services/return-requirements/submit-points.service.test.js
+++ b/test/services/return-requirements/submit-points.service.test.js
@@ -9,7 +9,6 @@ const { describe, it, beforeEach, afterEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const DatabaseSupport = require('../../support/database.js')
 const SessionHelper = require('../../support/helpers/session.helper.js')
 
 // Things we need to stub
@@ -27,8 +26,6 @@ describe('Return Requirements - Submit Points service', () => {
   let yarStub
 
   beforeEach(async () => {
-    await DatabaseSupport.clean()
-
     sessionData = {
       data: {
         checkPageVisited: false,

--- a/test/services/return-requirements/submit-reason.service.test.js
+++ b/test/services/return-requirements/submit-reason.service.test.js
@@ -9,7 +9,6 @@ const { describe, it, beforeEach, afterEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const DatabaseSupport = require('../../support/database.js')
 const SessionHelper = require('../../support/helpers/session.helper.js')
 
 // Thing under test
@@ -22,8 +21,6 @@ describe('Return Requirements - Submit Reason service', () => {
   let yarStub
 
   beforeEach(async () => {
-    await DatabaseSupport.clean()
-
     sessionData = {
       data: {
         checkPageVisited: false,

--- a/test/services/return-requirements/submit-remove.service.test.js
+++ b/test/services/return-requirements/submit-remove.service.test.js
@@ -9,8 +9,8 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const DatabaseSupport = require('../../support/database.js')
 const SessionHelper = require('../../support/helpers/session.helper.js')
+const { generateUUID } = require('../../../app/lib/general.lib.js')
 
 // Thing under test
 const SubmitRemoveService = require('../../../app/services/return-requirements/submit-remove.service.js')
@@ -22,10 +22,8 @@ describe('Return Requirements - Submit Remove service', () => {
   let yarStub
 
   beforeEach(async () => {
-    await DatabaseSupport.clean()
-
     session = await SessionHelper.add({
-      id: '61e07498-f309-4829-96a9-72084a54996d',
+      id: generateUUID(),
       data: {
         checkPageVisited: false,
         licence: {

--- a/test/services/return-requirements/submit-returns-cycle.service.test.js
+++ b/test/services/return-requirements/submit-returns-cycle.service.test.js
@@ -9,7 +9,6 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const DatabaseSupport = require('../../support/database.js')
 const SessionHelper = require('../../support/helpers/session.helper.js')
 
 // Thing under test
@@ -24,8 +23,6 @@ describe('Return Requirements - Submit Returns Cycle service', () => {
   let yarStub
 
   beforeEach(async () => {
-    await DatabaseSupport.clean()
-
     sessionData = {
       data: {
         checkPageVisited: false,

--- a/test/services/return-requirements/submit-site-description.service.test.js
+++ b/test/services/return-requirements/submit-site-description.service.test.js
@@ -9,7 +9,6 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const DatabaseSupport = require('../../support/database.js')
 const SessionHelper = require('../../support/helpers/session.helper.js')
 
 // Things under test
@@ -24,8 +23,6 @@ describe('Return Requirements - Submit Site Description service', () => {
   let yarStub
 
   beforeEach(async () => {
-    await DatabaseSupport.clean()
-
     sessionData = {
       data: {
         checkPageVisited: false,

--- a/test/services/return-requirements/submit-start-date.service.test.js
+++ b/test/services/return-requirements/submit-start-date.service.test.js
@@ -9,7 +9,6 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const DatabaseSupport = require('../../support/database.js')
 const FeatureFlagsConfig = require('../../../config/feature-flags.config.js')
 const SessionHelper = require('../../support/helpers/session.helper.js')
 
@@ -23,8 +22,6 @@ describe('Return Requirements - Submit Start Date service', () => {
   let yarStub
 
   beforeEach(async () => {
-    await DatabaseSupport.clean()
-
     sessionData = {
       data: {
         checkPageVisited: false,

--- a/test/support/helpers/financial-agreement.helper.js
+++ b/test/support/helpers/financial-agreement.helper.js
@@ -50,7 +50,7 @@ function defaults (data = {}) {
 }
 
 function generateFinancialAgreementCode () {
-  return `S${randomInteger(100, 199)}`
+  return `S${randomInteger(100, 999)}`
 }
 
 module.exports = {

--- a/test/support/helpers/licence-version-purpose.helper.js
+++ b/test/support/helpers/licence-version-purpose.helper.js
@@ -53,7 +53,7 @@ function defaults (data = {}) {
     abstractionPeriodStartMonth: 1,
     abstractionPeriodEndDay: 31,
     abstractionPeriodEndMonth: 3,
-    externalId: `9:${randomInteger(10000, 99999)}`,
+    externalId: generateLicenceVersionPurposeExternalId(),
     licenceVersionId: generateUUID(),
     primaryPurposeId: generateUUID(),
     purposeId: generateUUID(),
@@ -69,7 +69,12 @@ function defaults (data = {}) {
   }
 }
 
+function generateLicenceVersionPurposeExternalId () {
+  return `${randomInteger(0, 9)}:${randomInteger(10000, 99999)}`
+}
+
 module.exports = {
   add,
-  defaults
+  defaults,
+  generateLicenceVersionPurposeExternalId
 }

--- a/test/support/helpers/licence-version.helper.js
+++ b/test/support/helpers/licence-version.helper.js
@@ -51,7 +51,7 @@ function defaults (data = {}) {
     increment: 0,
     status: 'current',
     startDate: new Date('2022-01-01'),
-    externalId: `9:${randomInteger(10000, 99999)}:1:0`,
+    externalId: generateLicenceVersionExternalId(),
     createdAt: timestamp,
     updatedAt: timestamp
   }
@@ -62,7 +62,12 @@ function defaults (data = {}) {
   }
 }
 
+function generateLicenceVersionExternalId () {
+  return `${randomInteger(0, 9)}:${randomInteger(10000, 99999)}:1:0`
+}
+
 module.exports = {
   add,
-  defaults
+  defaults,
+  generateLicenceVersionExternalId
 }

--- a/test/support/seeders/licence-abstraction-data.seeder.js
+++ b/test/support/seeders/licence-abstraction-data.seeder.js
@@ -9,6 +9,7 @@ const PrimaryPurposesSeeder = require('./primary-purpose.seeder.js')
 const PurposesSeeder = require('./purposes.seeder.js')
 
 const FinancialAgreementHelper = require('../helpers/financial-agreement.helper.js')
+const FinancialAgreementModel = require('../../../app/models/financial-agreement.model.js')
 const LicenceFinancialAgreement = require('../helpers/licence-agreement.helper.js')
 const LicenceHelper = require('../helpers/licence.helper.js')
 const LicenceVersionHelper = require('../helpers/licence-version.helper.js')
@@ -16,10 +17,8 @@ const LicenceVersionPurposeHelper = require('../helpers/licence-version-purpose.
 const PermitLicenceHelper = require('../helpers/permit-licence.helper.js')
 const RegionHelper = require('../helpers/region.helper.js')
 const { generateLicenceRef } = require('../helpers/licence.helper.js')
-const { generateFinancialAgreementCode } = require('../helpers/financial-agreement.helper')
-const { generateLicenceVersionExternalId } = require('../helpers/licence-version.helper')
-const { generateLicenceVersionPurposeExternalId } = require('../helpers/licence-version-purpose.helper')
-const FinancialAgreementModel = require('../../../app/models/financial-agreement.model.js')
+const { generateLicenceVersionExternalId } = require('../helpers/licence-version.helper.js')
+const { generateLicenceVersionPurposeExternalId } = require('../helpers/licence-version-purpose.helper.js')
 
 /**
  * Seeds a licence with all the related records to get a 'real' set of abstraction data
@@ -66,8 +65,24 @@ async function seed (optionalLicenceRef = undefined) {
 }
 
 async function _financialAgreements () {
-  const section126 = await FinancialAgreementModel.query().select().where('code', 'S126').limit(1).first()
-  const twoPartTariff = await FinancialAgreementModel.query().select().where('code', 'S127').limit(1).first()
+  let section126 = await FinancialAgreementModel.query().select().where('code', 'S126').limit(1).first()
+  let twoPartTariff = await FinancialAgreementModel.query().select().where('code', 'S127').limit(1).first()
+
+  // This is temporary whilst the clean is called by other tests.
+  // TODO: remove this when all database cleans have been removed
+  if (!section126) {
+    section126 = await FinancialAgreementHelper.add({
+      code: 'S126',
+      description: 'Section 126'
+    })
+  }
+
+  if (!twoPartTariff) {
+    twoPartTariff = await FinancialAgreementHelper.add({
+      code: 'S127',
+      description: 'Section 127 (Two Part Tariff)'
+    })
+  }
 
   return { section126Id: section126.id, twoPartTariffId: twoPartTariff.id }
 }


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/124

This change like all things initially started small changing  bills and licences services tests. As i moved on the return requirements most of them were straight forwards. However some complexity was added with the licence-abstraction-data.seeder.js. Some temporary code has been introduced to create the financial agreements if they don't exists (they are queried and used if they exists). This is necessary as some test are still cleaning the database. 

We had a pattern of calling `await DatabaseSupport.clean()` in a `beforeEach()` in any unit test file that depended on adding data to support its tests.

The problem is that the project is becoming so large that it is no longer sustainable. It is also a blocker to moving to a test framework that supports [ECMAScript Modules](https://nodejs.org/api/esm.html), [the official standard format](https://tc39.github.io/ecma262/#sec-modules) to package JavaScript code. Unit test frameworks other than [Hapi Lab](https://hapi.dev/module/lab/) run tests in parallel by default. This means you can't have one test running DB clean while another is trying to load data.

New tests avoid the pattern, and where we can, we've been updating old ones when we have had cause to update the unit tests.

But there are always those where it'll be some time before we have cause to look at them again. So, rather than waiting, this change handles updating all tests in `test/services/bill-licences` to drop their dependence on `DatabaseSupport.clean()`.