### PR TITLE
Update `alter-licences-view` migration script

### DIFF
--- a/db/migrations/public/20240807160605_alter-licences-view.js
+++ b/db/migrations/public/20240807160605_alter-licences-view.js
@@ -22,6 +22,7 @@ exports.up = function (knex) {
         // 'is_test',
         'include_in_supplementary_billing AS include_in_presroc_billing',
         'include_in_sroc_supplementary_billing AS include_in_sroc_billing',
+        // 'include_in_sroc_tpt_supplementary_billing AS include_in_sroc_tpt_billing',
         'date_created AS created_at',
         'date_updated AS updated_at'
       ]))


### PR DESCRIPTION
Following on from this PR https://github.com/DEFRA/water-abstraction-system/pull/1242 where the `include_in_sroc_tpt_billing` column was removed from the view. The intention was to then create migration scripts to remove the column from the table.

However, we have realised that if we do this, given the way the migration scripts run. When all the migrations relating to the removal of this column are pushed up to our servers and they run together. An error will be generated as the migrations will try to remove the column from the table before it is removed from the view.

We have therefore opted for what we do when removing legacy columns from our views. We just comment out the column in the view migration and leave the column in the table.

This PR will update the migration that was created previously.