### PR TITLE
Remove more DatabaseSupport.clean() from services/job

### DIFF
--- a/test/services/jobs/export/fetch-table.service.test.js
+++ b/test/services/jobs/export/fetch-table.service.test.js
@@ -9,7 +9,6 @@ const { expect } = Code
 
 // Test helpers
 const ChargeCategoryHelper = require('../../../support/helpers/charge-category.helper.js')
-const DatabaseSupport = require('../../../support/database.js')
 
 // Thing under test
 const FetchTableService = require('../../../../app/services/jobs/export/fetch-table.service.js')
@@ -32,8 +31,6 @@ const billingChargeCategoriesColumnInfo = [
 
 describe('Fetch table service', () => {
   beforeEach(async () => {
-    await DatabaseSupport.clean()
-
     await ChargeCategoryHelper.add()
   })
 


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/124

We had a pattern of calling await DatabaseSupport.clean() in a beforeEach() in any unit test file that depended on adding data to support its tests.

The problem is that the project is becoming so large that it is no longer sustainable. It is also a blocker to moving to a test framework that supports ECMAScript Modules, the official standard format to package JavaScript code. Unit test frameworks other than Hapi Lab run tests in parallel by default. This means you can't have one test running DB clean while another is trying to load data.

New tests avoid the pattern, and where we can, we've been updating old ones when we have had cause to update the unit tests.

But there are always those where it'll be some time before we have cause to look at them again. So, rather than waiting, this change handles updating all tests in test/services/bill-licences to drop their dependence on DatabaseSupport.clean().