### PR TITLE
Fix order of return versions in view licence

### DIFF
--- a/app/services/licences/fetch-return-versions.service.js
+++ b/app/services/licences/fetch-return-versions.service.js
@@ -29,7 +29,8 @@ async function _fetch (licenceId) {
     ])
     .where('licenceId', licenceId)
     .orderBy([
-      { column: 'startDate', order: 'desc' }
+      { column: 'startDate', order: 'desc' },
+      { column: 'version', order: 'desc' }
     ])
 }
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4407

> Part of the work to replace NALD for handling return requirements

Spotted in testing is that if a licence has 2 return versions with the same start date (one will be 'approved' and the other will display as 'replaced'), it is possible that they will be ordered incorrectly. In this scenario, the 'approved' should be first in the table, followed by 'replaced'.

We had exactly the [same issue with charge versions](https://github.com/DEFRA/water-abstraction-system/pull/1162). The solution was to order them first by start date, then by version number. So, we apply the same sorting to when we fetch the return versions.

<details>
<summary>Before</summary>

![Screenshot 2024-08-09 at 16 02 31](https://github.com/user-attachments/assets/1ec1f3c3-53bf-4e1e-bc7f-fd2ada13f358)

</details>

<details>
<summary>After</summary>

![Screenshot 2024-08-09 at 16 21 55](https://github.com/user-attachments/assets/76a98727-92dc-4e20-bf60-3a1818b4077d)

</details>