### PR TITLE
Add JSDoc as dependency to validate documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,11 @@ jobs:
         run: |
           npm run lint
 
+      # Next generate docs. This checks any JSDoc changes are valid
+      - name: Run docs check
+        run: |
+          npm run docs
+
       - name: Database migrations
         run: |
           npm run migrate:test

--- a/.gitignore
+++ b/.gitignore
@@ -45,5 +45,8 @@ lcov.info
 # Build assets
 app/public/build
 
+# JSDoc documentation output
+docs/
+
 # ignore husky config
 .husky/

--- a/.jsdoc.js
+++ b/.jsdoc.js
@@ -21,7 +21,10 @@ module.exports = {
   // JSDoc plugins to load
   plugins: [
     // Supports converting the Markdown text in our comments to HTML in the documentation
-    'plugins/markdown'
+    'plugins/markdown',
+    // Removes all symbols that begin with an underscore from the doc output. This saves us having to comment all
+    // our private methods with a @private tag
+    'plugins/underscore'
   ],
   // Having enabled recurse in our options, we also need to tell JSDoc how deep to go
   recurseDepth: 10,

--- a/.jsdoc.js
+++ b/.jsdoc.js
@@ -9,8 +9,6 @@ module.exports = {
     encoding: 'utf8',
     // We output the generated documentation to `docs/` instead of `out/` (the default)
     destination: 'docs/',
-    // Direct JSDoc to our package JSON to extract project name, version etc
-    package: 'package.json',
     // The README to present on the documentation home page. In lieu of anything else we give it the project's README
     readme: 'README.md',
     // Whether to recurse into subdirectories

--- a/.jsdoc.js
+++ b/.jsdoc.js
@@ -10,8 +10,8 @@ module.exports = {
     // We output the generated documentation to `docs/` instead of `out/` (the default)
     destination: 'docs/',
     // Treat errors as fatal errors, and treat warnings as errors
-    // NOTE: We seem to get a 1 (error) exit code if there is a parsing issue irrespective of how this is set. It
-    // doesn't appear to effect the behaviour of JSDoc
+    // NOTE: We seem to get a 1 (error) exit code if there is a parsing issue irrespective of how this is set. Reading
+    // into the code, this appears to be for tools that hook into JSDoc's event emitters rather than the command line.
     pedantic: true,
     // The README to present on the documentation home page. In lieu of anything else we give it the project's README
     readme: 'README.md',

--- a/.jsdoc.js
+++ b/.jsdoc.js
@@ -1,0 +1,50 @@
+
+'use strict'
+
+module.exports = {
+  // Some of these are exposed via the command line. Specifying them here means we only need to pass this conf file
+  // as an argument to jsdoc on the command line.
+  opts: {
+    // Defaults to UTF8 but we are just being explicit
+    encoding: 'utf8',
+    // We output the generated documentation to `docs/` instead of `out/` (the default)
+    destination: 'docs/',
+    // Direct JSDoc to our package JSON to extract project name, version etc
+    package: 'package.json',
+    // The README to present on the documentation home page. In lieu of anything else we give it the project's README
+    readme: 'README.md',
+    // Whether to recurse into subdirectories
+    recurse: true,
+    // Log detailed information to the console when JSDoc runs. This allows us to track down errors
+    verbose: true
+  },
+  // JSDoc plugins to load
+  plugins: [
+    // Supports converting the Markdown text in our comments to HTML in the documentation
+    'plugins/markdown'
+  ],
+  // Having enabled recurse in our options, we also need to tell JSDoc how deep to go
+  recurseDepth: 10,
+  source: {
+    include: ['./app'],
+    includePattern: '.js$',
+    excludePattern: '(db/|docs/|node_modules/|test/)'
+  },
+  // The type of source file. JSDoc recommends you use the value `module` unless none of your code files use ECMAScript
+  // >=2015 syntax
+  sourceType: 'module',
+  // Settings for interpreting JSDoc tags
+  tags: {
+    // We want JSDoc to error if it encounters an unknown tag
+    allowUnknownTags: false,
+    // We don't use the closure syntax so only expect to encounter tags from the JSDoc dictionary
+    dictionaries: ['jsdoc']
+  },
+  // Settings for generating output with JSDoc templates
+  templates: {
+    // Set to `true` to use a monospaced font for links to other code symbols, but not links to websites
+    cleverLinks: true,
+    // Set to `false` so we don't use a monospaced font for all links
+    monospaceLinks: false
+  }
+}

--- a/.jsdoc.js
+++ b/.jsdoc.js
@@ -9,6 +9,10 @@ module.exports = {
     encoding: 'utf8',
     // We output the generated documentation to `docs/` instead of `out/` (the default)
     destination: 'docs/',
+    // Treat errors as fatal errors, and treat warnings as errors
+    // NOTE: We seem to get a 1 (error) exit code if there is a parsing issue irrespective of how this is set. It
+    // doesn't appear to effect the behaviour of JSDoc
+    pedantic: true,
     // The README to present on the documentation home page. In lieu of anything else we give it the project's README
     readme: 'README.md',
     // Whether to recurse into subdirectories

--- a/app/services/bill-runs/annual/fetch-billing-accounts.service.js
+++ b/app/services/bill-runs/annual/fetch-billing-accounts.service.js
@@ -27,7 +27,7 @@ const Workflow = require('../../../models/workflow.model.js')
  * @param {String} regionId - UUID of the region being billed that the licences must be linked to
  * @param {Object} billingPeriod - Object with a `startDate` and `endDate` property representing the period being billed
  *
- * @returns {Promise<[module:BillingAccountModel]>} An array of `BillingAccountModel` to be billed and their relevant
+ * @returns {Promise<module:BillingAccountModel[]>} An array of `BillingAccountModel` to be billed and their relevant
  * licence, charge version, charge element etc records needed to generate the bill run
  */
 async function go (regionId, billingPeriod) {

--- a/app/services/bill-runs/cancel-bill-run.service.js
+++ b/app/services/bill-runs/cancel-bill-run.service.js
@@ -13,7 +13,7 @@ const CancelBillRunPresenter = require('../../presenters/bill-runs/cancel-bill-r
  *
  * @param {string} id - The UUID of the bill run to cancel
  *
- * @returns {Promise<Object>} an object representing the `pageData` needed by the cancel bill run template. It contains
+ * @returns {Promise<Object}> an object representing the `pageData` needed by the cancel bill run template. It contains
  * details of the bill run.
  */
 async function go (id) {

--- a/app/services/bill-runs/cancel-bill-run.service.js
+++ b/app/services/bill-runs/cancel-bill-run.service.js
@@ -13,7 +13,7 @@ const CancelBillRunPresenter = require('../../presenters/bill-runs/cancel-bill-r
  *
  * @param {string} id - The UUID of the bill run to cancel
  *
- * @returns {Promise<Object}> an object representing the `pageData` needed by the cancel bill run template. It contains
+ * @returns {Promise<Object>} an object representing the `pageData` needed by the cancel bill run template. It contains
  * details of the bill run.
  */
 async function go (id) {

--- a/app/services/bill-runs/consolidate-date-ranges.service.js
+++ b/app/services/bill-runs/consolidate-date-ranges.service.js
@@ -44,9 +44,11 @@
  *   { startDate: 2023-11-01, endDate: 2023-12-01 }  // Range 4 unchanged
  * ]
  *
- * @param {{startDate: Date, endDate: Date}[]} dateRanges Array containing a series of date ranges to be consolidated.
+ * @param {Object[]} dateRanges - The series of date ranges to be consolidated.
+ * @param {Date} dateRanges[].startDate - The start date for the range
+ * @param {Date} dateRanges[].endDate - The end date of the range
  *
- * @returns {{startDate: Date, endDate: Date}[]} An array of the consolidated date ranges
+ * @returns {Object[]} An array of the consolidated date ranges
  */
 function go (dateRanges) {
   // We sort the date ranges by start date from earliest to latest to make life easier when consolidating them

--- a/app/services/bill-runs/consolidate-date-ranges.service.js
+++ b/app/services/bill-runs/consolidate-date-ranges.service.js
@@ -11,38 +11,46 @@
  *
  * Say we have the following dates:
  *
+ * ```javascript
  * [
  *   { startDate: 2023-01-01, endDate: 2023-03-01 }, // Range 1
  *   { startDate: 2023-02-01, endDate: 2023-04-01 }, // Range 2
  *   { startDate: 2023-06-01, endDate: 2023-07-01 }  // Range 3
  * ]
+ * ```
  *
  * The first two date ranges overlap (as the second one starts before the first one ends) so we merge them into one date
  * range. The third date range does not overlap anything, so we leave it alone. Our resulting consolidated date ranges
  * therefore looks like this:
  *
+ * ```javascript
  * [
  *   { startDate: 2023-01-01, endDate: 2023-04-01 }, // Ranges 1 & 2 merged
  *   { startDate: 2023-06-01, endDate: 2023-07-01 }  // Range 3 unchanged
  * ]
+ * ```
  *
  * Note that if a range starts on the same day the previous range ends, that is classed as one continuous range. But a
  * range that starts the day _after_ the previous range ends is classed as a separate range to that previous one. eg:
  *
+ * ```javascript
  * [
  *   { startDate: 2023-01-01, endDate: 2023-04-01 }, // Range 1, ending on 1st April
  *   { startDate: 2023-04-01, endDate: 2023-07-01 }, // Range 2, starting on 1st April
  *   { startDate: 2023-10-01, endDate: 2023-10-31 }, // Range 3, ending on 31st October
  *   { startDate: 2023-11-01, endDate: 2023-12-01 }  // Range 4, starting on 1st November
  * ]
+ * ```
  *
  * Consolidates to:
  *
+ * ```javascript
  * [
  *   { startDate: 2023-01-01, endDate: 2023-07-01 }, // Ranges 1 & 2 merged
  *   { startDate: 2023-10-01, endDate: 2023-10-31 }, // Range 3 unchanged
  *   { startDate: 2023-11-01, endDate: 2023-12-01 }  // Range 4 unchanged
  * ]
+ * ```
  *
  * @param {Object[]} dateRanges - The series of date ranges to be consolidated.
  * @param {Date} dateRanges[].startDate - The start date for the range

--- a/app/services/bill-runs/send-bill-run.service.js
+++ b/app/services/bill-runs/send-bill-run.service.js
@@ -13,7 +13,7 @@ const SendBillRunPresenter = require('../../presenters/bill-runs/send-bill-run.p
  *
  * @param {string} id - The UUID of the bill run to send
  *
- * @returns {Promise<Object}> an object representing the `pageData` needed by the send bill run template. It contains
+ * @returns {Promise<Object>} an object representing the `pageData` needed by the send bill run template. It contains
  * details of the bill run.
  */
 async function go (id) {

--- a/app/services/bill-runs/two-part-tariff/fetch-billing-accounts.service.js
+++ b/app/services/bill-runs/two-part-tariff/fetch-billing-accounts.service.js
@@ -27,7 +27,7 @@ const ChargeVersionModel = require('../../../models/charge-version.model.js')
  *
  * @param {string} billRunId - The UUID of the two-part tariff bill run to fetches billing accounts for
  *
- * @returns {Promise<[module:BillingAccountModel]>} An array of `BillingAccountModel` to be billed and their relevant
+ * @returns {Promise<module:BillingAccountModel[]>} An array of `BillingAccountModel` to be billed and their relevant
  * licence, charge version, charge element etc records, plus the two-part tariff review details needed to generate the
  * bill run
  */

--- a/app/services/bill-runs/two-part-tariff/remove-bill-run-licence.service.js
+++ b/app/services/bill-runs/two-part-tariff/remove-bill-run-licence.service.js
@@ -15,7 +15,7 @@ const RemoveBillRunLicencePresenter = require('../../../presenters/bill-runs/two
  * @param {string} billRunId - The UUID of the bill run that the licence is in
  * @param {string} licenceId - UUID of the licence to remove from the bill run
  *
- * @returns {Promise<Object}> an object representing the `pageData` needed by the remove licence template. It contains
+ * @returns {Promise<Object>} an object representing the `pageData` needed by the remove licence template. It contains
  * details of the bill run & the licence reference.
  */
 async function go (billRunId, licenceId) {

--- a/app/services/jobs/export/convert-to-csv.service.js
+++ b/app/services/jobs/export/convert-to-csv.service.js
@@ -8,7 +8,7 @@
 /**
  * Converts data to a CSV formatted string
  *
- * @param {[]} data An array representing either the headers or rows from a db table
+ * @param {String[]} data - An array representing either the headers or rows from a db table
  *
  * @returns {String} A CSV formatted string
  */
@@ -22,10 +22,6 @@ function go (data) {
 
 /**
  * Transforms each row or header to CSV format and joins the values with commas
- *
- * @param {[*]} data The data to be transformed to CSV
- *
- * @returns {String[]} An array of transformed data
  */
 function _transformDataToCSV (data) {
   const transformedRow = data.map((value) => {
@@ -37,10 +33,6 @@ function _transformDataToCSV (data) {
 
 /**
  * Transform a value to CSV format
- *
- * @param {*} value The value to transform
- *
- * @returns {*} The value transformed to CSV format
  */
 function _transformValueToCSV (value) {
   // Return empty string for undefined or null values

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "@hapi/lab": "^25.1.3",
         "@stylistic/eslint-plugin-js": "^1.8.1",
         "eslint": "^8.57.0",
+        "jsdoc": "^4.0.3",
         "mock-fs": "^5.2.0",
         "nock": "^13.3.2",
         "pino-pretty": "^10.2.0",
@@ -2705,6 +2706,18 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@jsdoc/salty": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@jsdoc/salty/-/salty-0.2.8.tgz",
+      "integrity": "sha512-5e+SFVavj1ORKlKaKr2BmTOekmXbelU7dC0cDkQLqag7xfuTPuGMUFx7KWJuv4bYZrTsoL2Z18VVCOKYxzoHcg==",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.17.21"
+      },
+      "engines": {
+        "node": ">=v12.0.0"
+      }
+    },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
       "version": "5.1.1-v1",
       "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/eslint-scope-5-internals/-/eslint-scope-5-internals-5.1.1-v1.tgz",
@@ -4113,6 +4126,28 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
+    "node_modules/@types/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "dev": true
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+      "dev": true,
+      "dependencies": {
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
+      }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "dev": true
+    },
     "node_modules/@types/node": {
       "version": "18.8.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.8.2.tgz",
@@ -4559,6 +4594,12 @@
       "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
       "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw=="
     },
+    "node_modules/bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "dev": true
+    },
     "node_modules/bowser": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
@@ -4739,6 +4780,18 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw=="
+    },
+    "node_modules/catharsis": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.9.0.tgz",
+      "integrity": "sha512-prMTQVpcns/tzFgFVkVp6ak6RykZyWb3gu8ckUpd6YkTlacOd3DXGJjIpD4Q6zJirizvaiAjSSHlOsA+6sNh2A==",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.17.15"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
     },
     "node_modules/chalk": {
       "version": "2.4.2",
@@ -5156,6 +5209,18 @@
       "dev": true,
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/error-ex": {
@@ -7321,10 +7386,57 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/js2xmlparser": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-4.0.2.tgz",
+      "integrity": "sha512-6n4D8gLlLf1n5mNLQPRfViYzu9RATblzPEtm1SthMX1Pjao0r9YI9nw7ZIfRxQMERS87mcswrg+r/OYrPRX6jA==",
+      "dev": true,
+      "dependencies": {
+        "xmlcreate": "^2.0.4"
+      }
+    },
     "node_modules/jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg=="
+    },
+    "node_modules/jsdoc": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-4.0.3.tgz",
+      "integrity": "sha512-Nu7Sf35kXJ1MWDZIMAuATRQTg1iIPdzh7tqJ6jjvaU/GfDf+qi5UV8zJR3Mo+/pYFvm8mzay4+6O5EWigaQBQw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.20.15",
+        "@jsdoc/salty": "^0.2.1",
+        "@types/markdown-it": "^14.1.1",
+        "bluebird": "^3.7.2",
+        "catharsis": "^0.9.0",
+        "escape-string-regexp": "^2.0.0",
+        "js2xmlparser": "^4.0.2",
+        "klaw": "^3.0.0",
+        "markdown-it": "^14.1.0",
+        "markdown-it-anchor": "^8.6.7",
+        "marked": "^4.0.10",
+        "mkdirp": "^1.0.4",
+        "requizzle": "^0.2.3",
+        "strip-json-comments": "^3.1.0",
+        "underscore": "~1.13.2"
+      },
+      "bin": {
+        "jsdoc": "jsdoc.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/jsdoc/node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/jsesc": {
       "version": "2.5.2",
@@ -7425,6 +7537,15 @@
         "json-buffer": "3.0.1"
       }
     },
+    "node_modules/klaw": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/klaw/-/klaw-3.0.0.tgz",
+      "integrity": "sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.9"
+      }
+    },
     "node_modules/knex": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/knex/-/knex-2.5.1.tgz",
@@ -7494,6 +7615,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "dev": true,
+      "dependencies": {
+        "uc.micro": "^2.0.0"
       }
     },
     "node_modules/load-json-file": {
@@ -7588,6 +7718,51 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/markdown-it": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
+      "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/markdown-it-anchor": {
+      "version": "8.6.7",
+      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-8.6.7.tgz",
+      "integrity": "sha512-FlCHFwNnutLgVTflOYHPW2pPcl2AACqVzExlkGQNsi4CJgqOHN7YTgDd4LuhgN1BFO3TS0vLAruV1Td6dwWPJA==",
+      "dev": true,
+      "peerDependencies": {
+        "@types/markdown-it": "*",
+        "markdown-it": "*"
+      }
+    },
+    "node_modules/marked": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+      "dev": true,
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "dev": true
     },
     "node_modules/merge-descriptors": {
       "version": "1.0.1",
@@ -8652,6 +8827,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/qs": {
       "version": "6.5.3",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
@@ -8864,6 +9048,15 @@
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/requizzle": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.4.tgz",
+      "integrity": "sha512-JRrFk1D4OQ4SqovXOgdav+K8EAhSB/LJZqCz8tbX0KObcdeM15Ss59ozWMBWmmINMagCwmqn4ZNryUGpBsl6Jw==",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.17.21"
       }
     },
     "node_modules/resolve": {
@@ -9708,6 +9901,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "dev": true
+    },
     "node_modules/uglify-js": {
       "version": "3.17.3",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.3.tgz",
@@ -9735,6 +9934,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/underscore": {
+      "version": "1.13.7",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.7.tgz",
+      "integrity": "sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==",
+      "dev": true
     },
     "node_modules/update-browserslist-db": {
       "version": "1.0.10",
@@ -9944,6 +10149,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/xmlcreate": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-2.0.4.tgz",
+      "integrity": "sha512-nquOebG4sngPmGPICTS5EnxqhKbCmz5Ox5hsszI2T6U5qdrJizBc+0ilYSEjTSzU0yZcmvppztXe/5Al5fUwdg==",
+      "dev": true
     },
     "node_modules/xtend": {
       "version": "4.0.2",
@@ -12187,6 +12398,15 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "@jsdoc/salty": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@jsdoc/salty/-/salty-0.2.8.tgz",
+      "integrity": "sha512-5e+SFVavj1ORKlKaKr2BmTOekmXbelU7dC0cDkQLqag7xfuTPuGMUFx7KWJuv4bYZrTsoL2Z18VVCOKYxzoHcg==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.21"
+      }
+    },
     "@nicolo-ribaudo/eslint-scope-5-internals": {
       "version": "5.1.1-v1",
       "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/eslint-scope-5-internals/-/eslint-scope-5-internals-5.1.1-v1.tgz",
@@ -13363,6 +13583,28 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
+    "@types/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "dev": true
+    },
+    "@types/markdown-it": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+      "dev": true,
+      "requires": {
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
+      }
+    },
+    "@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "dev": true
+    },
     "@types/node": {
       "version": "18.8.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.8.2.tgz",
@@ -13691,6 +13933,12 @@
       "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
       "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw=="
     },
+    "bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "dev": true
+    },
     "bowser": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
@@ -13809,6 +14057,15 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw=="
+    },
+    "catharsis": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.9.0.tgz",
+      "integrity": "sha512-prMTQVpcns/tzFgFVkVp6ak6RykZyWb3gu8ckUpd6YkTlacOd3DXGJjIpD4Q6zJirizvaiAjSSHlOsA+6sNh2A==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.15"
+      }
     },
     "chalk": {
       "version": "2.4.2",
@@ -14115,6 +14372,12 @@
       "requires": {
         "once": "^1.4.0"
       }
+    },
+    "entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true
     },
     "error-ex": {
       "version": "1.3.2",
@@ -15651,10 +15914,50 @@
         "argparse": "^2.0.1"
       }
     },
+    "js2xmlparser": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-4.0.2.tgz",
+      "integrity": "sha512-6n4D8gLlLf1n5mNLQPRfViYzu9RATblzPEtm1SthMX1Pjao0r9YI9nw7ZIfRxQMERS87mcswrg+r/OYrPRX6jA==",
+      "dev": true,
+      "requires": {
+        "xmlcreate": "^2.0.4"
+      }
+    },
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg=="
+    },
+    "jsdoc": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-4.0.3.tgz",
+      "integrity": "sha512-Nu7Sf35kXJ1MWDZIMAuATRQTg1iIPdzh7tqJ6jjvaU/GfDf+qi5UV8zJR3Mo+/pYFvm8mzay4+6O5EWigaQBQw==",
+      "dev": true,
+      "requires": {
+        "@babel/parser": "^7.20.15",
+        "@jsdoc/salty": "^0.2.1",
+        "@types/markdown-it": "^14.1.1",
+        "bluebird": "^3.7.2",
+        "catharsis": "^0.9.0",
+        "escape-string-regexp": "^2.0.0",
+        "js2xmlparser": "^4.0.2",
+        "klaw": "^3.0.0",
+        "markdown-it": "^14.1.0",
+        "markdown-it-anchor": "^8.6.7",
+        "marked": "^4.0.10",
+        "mkdirp": "^1.0.4",
+        "requizzle": "^0.2.3",
+        "strip-json-comments": "^3.1.0",
+        "underscore": "~1.13.2"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+          "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+          "dev": true
+        }
+      }
     },
     "jsesc": {
       "version": "2.5.2",
@@ -15737,6 +16040,15 @@
         "json-buffer": "3.0.1"
       }
     },
+    "klaw": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/klaw/-/klaw-3.0.0.tgz",
+      "integrity": "sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.9"
+      }
+    },
     "knex": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/knex/-/knex-2.5.1.tgz",
@@ -15773,6 +16085,15 @@
       "requires": {
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
+      }
+    },
+    "linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "dev": true,
+      "requires": {
+        "uc.micro": "^2.0.0"
       }
     },
     "load-json-file": {
@@ -15846,6 +16167,39 @@
       "requires": {
         "yallist": "^4.0.0"
       }
+    },
+    "markdown-it": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
+      "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+      "dev": true,
+      "requires": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      }
+    },
+    "markdown-it-anchor": {
+      "version": "8.6.7",
+      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-8.6.7.tgz",
+      "integrity": "sha512-FlCHFwNnutLgVTflOYHPW2pPcl2AACqVzExlkGQNsi4CJgqOHN7YTgDd4LuhgN1BFO3TS0vLAruV1Td6dwWPJA==",
+      "dev": true,
+      "requires": {}
+    },
+    "marked": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+      "dev": true
+    },
+    "mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "dev": true
     },
     "merge-descriptors": {
       "version": "1.0.1",
@@ -16636,6 +16990,12 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
+    "punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "dev": true
+    },
     "qs": {
       "version": "6.5.3",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
@@ -16784,6 +17144,15 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
+    },
+    "requizzle": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.4.tgz",
+      "integrity": "sha512-JRrFk1D4OQ4SqovXOgdav+K8EAhSB/LJZqCz8tbX0KObcdeM15Ss59ozWMBWmmINMagCwmqn4ZNryUGpBsl6Jw==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.21"
+      }
     },
     "resolve": {
       "version": "1.22.1",
@@ -17388,6 +17757,12 @@
         "possible-typed-array-names": "^1.0.0"
       }
     },
+    "uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "dev": true
+    },
     "uglify-js": {
       "version": "3.17.3",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.3.tgz",
@@ -17406,6 +17781,12 @@
         "has-symbols": "^1.0.3",
         "which-boxed-primitive": "^1.0.2"
       }
+    },
+    "underscore": {
+      "version": "1.13.7",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.7.tgz",
+      "integrity": "sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==",
+      "dev": true
     },
     "update-browserslist-db": {
       "version": "1.0.10",
@@ -17557,6 +17938,12 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
       "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==",
+      "dev": true
+    },
+    "xmlcreate": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-2.0.4.tgz",
+      "integrity": "sha512-nquOebG4sngPmGPICTS5EnxqhKbCmz5Ox5hsszI2T6U5qdrJizBc+0ilYSEjTSzU0yZcmvppztXe/5Al5fUwdg==",
       "dev": true
     },
     "xtend": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "start": "node index.js",
     "build": "bin/build",
+    "docs": "jsdoc -c .jsdoc.js",
     "migrate:make": "knex migrate:make --",
     "migrate:make:test": "NODE_ENV=test knex migrate:make --migrations-directory db/migrations/legacy --",
     "migrate": "knex migrate:latest",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@hapi/lab": "^25.1.3",
     "@stylistic/eslint-plugin-js": "^1.8.1",
     "eslint": "^8.57.0",
+    "jsdoc": "^4.0.3",
     "mock-fs": "^5.2.0",
     "nock": "^13.3.2",
     "pino-pretty": "^10.2.0",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@hapi/lab": "^25.1.3",
     "@stylistic/eslint-plugin-js": "^1.8.1",
     "eslint": "^8.57.0",
-    "jsdoc": "^4.0.3",
+    "jsdoc": "~4.0.3",
     "mock-fs": "^5.2.0",
     "nock": "^13.3.2",
     "pino-pretty": "^10.2.0",


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/125

Using [JSDoc comments](https://jsdoc.app/) to document our code has become our convention.

We add `@module` declarations by default, detail our public methods, including params and returns, and have even added markdown sections in some places.

Recently, we went on a deep dive of **JSDoc** to generate documentation based on what we've added so far. The good news is that it confirmed that we've got a lot of stuff right! But there are some things we need to correct, plus some errors that make comments invalid.

This change adds **JSDoc** as a dev dependency to the project. We can then use it to generate documentation on request. We then add it to our CI, where it will error when it encounters documentation it cannot parse, which serves as a means to validate that what we've done is 'error-free'.

To ensure CI doesn't fail after this change, we correct our current errors.

From now on, we'll catch any parsing errors. Hopefully, generating the documentation will also allow us to view how what we've added is presented. Having carried out this work, we know there are some issues to be fixed, but those are for another PR!

