### PR TITLE
Add create licence supplementary years service

### DIFF
--- a/app/services/bill-runs/two-part-tariff/submit-remove-bill-run-licence.service.js
+++ b/app/services/bill-runs/two-part-tariff/submit-remove-bill-run-licence.service.js
@@ -6,8 +6,8 @@
  */
 
 const BillRunModel = require('../../../models/bill-run.model.js')
+const CreateLicenceSupplementaryYearService = require('../../licences/supplementary/create-licence-supplementary-year.service.js')
 const LicenceModel = require('../../../models/licence.model.js')
-const LicenceSupplementaryYearModel = require('../../../models/licence-supplementary-year.model.js')
 const RemoveReviewDataService = require('./remove-review-data.service.js')
 const ReviewLicenceModel = require('../../../models/review-licence.model.js')
 
@@ -57,15 +57,11 @@ async function _allLicencesRemoved (billRunId) {
 }
 
 async function _flagForSupplementaryBilling (licenceId, billRunId) {
+  const twoPartTariff = true
   const { toFinancialYearEnding } = await BillRunModel.query()
     .findById(billRunId)
 
-  return LicenceSupplementaryYearModel.query()
-    .insert({
-      licenceId,
-      twoPartTariff: true,
-      financialYearEnd: toFinancialYearEnding
-    })
+  return CreateLicenceSupplementaryYearService.go(licenceId, [toFinancialYearEnding], twoPartTariff)
 }
 
 module.exports = {

--- a/app/services/licences/supplementary/create-licence-supplementary-year.service.js
+++ b/app/services/licences/supplementary/create-licence-supplementary-year.service.js
@@ -1,0 +1,50 @@
+'use strict'
+
+/**
+ * Creates a licenceSupplementaryYears record based on the provided licence data
+ * @module CreateLicenceSupplementaryYearService
+ */
+
+const LicenceSupplementaryYearModel = require('../../../models/licence-supplementary-year.model.js')
+
+/**
+ * Creates a licenceSupplementaryYears record based on the provided licence data
+ *
+ * @param {module:LicenceModel} licenceId - The UUID of the licence to be persisted
+ * @param {Object[]} years - An array of the years to be persisted as individual records
+ * @param {Boolean} twoPartTariff - If there are any two-part tariff indicators on the licence
+ */
+async function go (licenceId, years, twoPartTariff) {
+  for (const year of years) {
+    const existingLicenceSupplementaryYears = await _fetchExistingLicenceSupplementaryYears(
+      licenceId, year, twoPartTariff
+    )
+
+    // Create a new record only if no existing record matches all the provided properties, and where 'billRunId' is null
+    if (existingLicenceSupplementaryYears.length === 0) {
+      await _persistSupplementaryBillingYearsData(licenceId, year, twoPartTariff)
+    }
+  }
+}
+
+async function _fetchExistingLicenceSupplementaryYears (licenceId, year, twoPartTariff) {
+  return LicenceSupplementaryYearModel.query()
+    .select('id')
+    .where('licenceId', licenceId)
+    .where('financialYearEnd', year)
+    .where('twoPartTariff', twoPartTariff)
+    .where('billRunId', null)
+}
+
+async function _persistSupplementaryBillingYearsData (licenceId, year, twoPartTariff) {
+  return LicenceSupplementaryYearModel.query()
+    .insert({
+      licenceId,
+      financialYearEnd: year,
+      twoPartTariff
+    })
+}
+
+module.exports = {
+  go
+}

--- a/app/services/licences/supplementary/create-licence-supplementary-year.service.js
+++ b/app/services/licences/supplementary/create-licence-supplementary-year.service.js
@@ -11,7 +11,7 @@ const LicenceSupplementaryYearModel = require('../../../models/licence-supplemen
  * Creates a licenceSupplementaryYears record based on the provided licence data
  *
  * @param {module:LicenceModel} licenceId - The UUID of the licence to be persisted
- * @param {Object[]} years - An array of the financial year ends to be persisted as individual records
+ * @param {Object[]} financialYearEnds - An array of the financial year ends to be persisted as individual records
  * @param {Boolean} twoPartTariff - If there are any two-part tariff indicators on the licence
  */
 async function go (licenceId, financialYearEnds, twoPartTariff) {

--- a/test/services/licences/supplementary/create-licence-supplementary-year.service.test.js
+++ b/test/services/licences/supplementary/create-licence-supplementary-year.service.test.js
@@ -18,18 +18,18 @@ const CreateLicenceSupplementaryYearService = require('../../../../app/services/
 describe('Create Licence Supplementary Years Service', () => {
   let licenceId
   let twoPartTariff
-  let years
+  let financialYearEnds
 
   describe('when provided a licenceId, years and twoPartTariff data', () => {
     beforeEach(async () => {
       licenceId = generateUUID()
       twoPartTariff = true
-      years = [2023]
+      financialYearEnds = [2023]
     })
 
     describe('that does not already exist', () => {
       it('persists the data', async () => {
-        await CreateLicenceSupplementaryYearService.go(licenceId, years, twoPartTariff)
+        await CreateLicenceSupplementaryYearService.go(licenceId, financialYearEnds, twoPartTariff)
 
         const result = await _fetchLicenceSupplementaryYears(licenceId)
 
@@ -37,7 +37,7 @@ describe('Create Licence Supplementary Years Service', () => {
         expect(result[0]).to.equal({
           licenceId,
           billRunId: null,
-          financialYearEnd: years[0],
+          financialYearEnd: financialYearEnds[0],
           twoPartTariff
         }, { skip: ['id'] })
       })
@@ -50,7 +50,7 @@ describe('Create Licence Supplementary Years Service', () => {
 
       describe('without the billRunId', () => {
         it('does not persist the data', async () => {
-          await CreateLicenceSupplementaryYearService.go(licenceId, years, twoPartTariff)
+          await CreateLicenceSupplementaryYearService.go(licenceId, financialYearEnds, twoPartTariff)
 
           const result = await _fetchLicenceSupplementaryYears(licenceId)
 
@@ -72,7 +72,7 @@ describe('Create Licence Supplementary Years Service', () => {
         })
 
         it('persist the data', async () => {
-          await CreateLicenceSupplementaryYearService.go(licenceId, years, twoPartTariff)
+          await CreateLicenceSupplementaryYearService.go(licenceId, financialYearEnds, twoPartTariff)
 
           const result = await _fetchLicenceSupplementaryYears(licenceId)
 

--- a/test/services/licences/supplementary/create-licence-supplementary-year.service.test.js
+++ b/test/services/licences/supplementary/create-licence-supplementary-year.service.test.js
@@ -1,0 +1,93 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const { generateUUID } = require('../../../../app/lib/general.lib.js')
+const LicenceSupplementaryYearHelper = require('../../../support/helpers/licence-supplementary-year.helper.js')
+const LicenceSupplementaryYearModel = require('../../../../app/models/licence-supplementary-year.model.js')
+
+// Thing under test
+const CreateLicenceSupplementaryYearService = require('../../../../app/services/licences/supplementary/create-licence-supplementary-year.service.js')
+
+describe('Create Licence Supplementary Years Service', () => {
+  let licenceId
+  let years
+  let twoPartTariff
+
+  describe('when provided a licenceId, years and twoPartTariff data', () => {
+    beforeEach(async () => {
+      licenceId = generateUUID()
+      years = [2023]
+      twoPartTariff = true
+    })
+
+    describe('that does not already exist', () => {
+      it('persists the data', async () => {
+        await CreateLicenceSupplementaryYearService.go(licenceId, years, twoPartTariff)
+
+        const result = await _fetchLicenceSupplementaryYears(licenceId)
+
+        expect(result).to.have.length(1)
+        expect(result[0].licenceId).to.equal(licenceId)
+      })
+    })
+
+    describe('that already exist', () => {
+      beforeEach(async () => {
+        await LicenceSupplementaryYearHelper.add({ licenceId, financialYearEnd: 2023, twoPartTariff: true })
+      })
+
+      describe('without the billRunId', () => {
+        it('does not persist the data', async () => {
+          await CreateLicenceSupplementaryYearService.go(licenceId, years, twoPartTariff)
+
+          const result = await _fetchLicenceSupplementaryYears(licenceId)
+
+          expect(result).to.have.length(1)
+          expect(result[0].licenceId).to.equal(licenceId)
+        })
+      })
+
+      describe('with the billRunId', () => {
+        let billRunId
+
+        beforeEach(async () => {
+          billRunId = generateUUID()
+
+          await LicenceSupplementaryYearModel.query()
+            .update({ billRunId })
+            .where('licenceId', licenceId)
+            .orderBy('billRunId')
+        })
+
+        it('persist the data', async () => {
+          await CreateLicenceSupplementaryYearService.go(licenceId, years, twoPartTariff)
+
+          const result = await _fetchLicenceSupplementaryYears(licenceId)
+
+          expect(result).to.have.length(2)
+          expect(result[0].billRunId).to.equal(billRunId)
+          expect(result[1].billRunId).to.equal(null)
+        })
+      })
+    })
+  })
+})
+
+function _fetchLicenceSupplementaryYears (licenceId) {
+  return LicenceSupplementaryYearModel.query()
+    .select([
+      'id',
+      'licenceId',
+      'billRunId',
+      'financialYearEnd',
+      'twoPartTariff'
+    ])
+    .where('licenceId', licenceId)
+}

--- a/test/services/licences/supplementary/create-licence-supplementary-year.service.test.js
+++ b/test/services/licences/supplementary/create-licence-supplementary-year.service.test.js
@@ -34,7 +34,12 @@ describe('Create Licence Supplementary Years Service', () => {
         const result = await _fetchLicenceSupplementaryYears(licenceId)
 
         expect(result).to.have.length(1)
-        expect(result[0].licenceId).to.equal(licenceId)
+        expect(result[0]).to.equal({
+          licenceId,
+          billRunId: null,
+          financialYearEnd: years[0],
+          twoPartTariff
+        }, { skip: ['id'] })
       })
     })
 

--- a/test/services/licences/supplementary/create-licence-supplementary-year.service.test.js
+++ b/test/services/licences/supplementary/create-licence-supplementary-year.service.test.js
@@ -17,14 +17,14 @@ const CreateLicenceSupplementaryYearService = require('../../../../app/services/
 
 describe('Create Licence Supplementary Years Service', () => {
   let licenceId
-  let years
   let twoPartTariff
+  let years
 
   describe('when provided a licenceId, years and twoPartTariff data', () => {
     beforeEach(async () => {
       licenceId = generateUUID()
-      years = [2023]
       twoPartTariff = true
+      years = [2023]
     })
 
     describe('that does not already exist', () => {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4588
https://github.com/DEFRA/water-abstraction-system/pull/1236

The new two-part tariff supplementary bill run requires licences to be recorded in our new LicenceSupplementaryYears table, along with the years they affect. The first ticket we picked up for this new process was amending the existing annual two-part tariff review pages. A licence can be removed from the bill run there and this should be flagged. This was added to the existing review page journey. Since starting work on the other flagging tickets it became clear that the process of adding the licence into our LicenceSupplementaryYears table is going to be repeated if we don't pull this out into its own service. So that is what this PR is for, making a service just for creating the licence record that can be shared amongst the various ways a licence can be flagged.