### PR TITLE
Trigger 2PT Supplementary Bill Run

### DIFF
--- a/app/controllers/bill-runs-setup.controller.js
+++ b/app/controllers/bill-runs-setup.controller.js
@@ -153,7 +153,7 @@ async function type (request, h) {
 
   return h.view('bill-runs/setup/type.njk', {
     activeNavBar: 'bill-runs',
-    pageTitle: 'Select a bill run type',
+    pageTitle: 'Select bill run type',
     ...pageData
   })
 }

--- a/app/services/bill-runs/setup/submit-region.service.js
+++ b/app/services/bill-runs/setup/submit-region.service.js
@@ -41,11 +41,11 @@ async function go (sessionId, payload) {
 
     // Temporary if statement to end the journey if the bill run is for two-part tariff supplementary
     if (session.type === 'two_part_supplementary') {
-      const formattedData = RegionPresenter.go(session, regions)
+      const temporaryFormattedData = RegionPresenter.go(session, regions)
 
       return {
         error: { text: 'Currently you can progress no further for a two-part tariff supplementary bill run' },
-        ...formattedData
+        ...temporaryFormattedData
       }
     }
 

--- a/app/services/bill-runs/setup/submit-region.service.js
+++ b/app/services/bill-runs/setup/submit-region.service.js
@@ -39,6 +39,16 @@ async function go (sessionId, payload) {
   if (!validationResult) {
     await _save(session, payload)
 
+    // Temporary if statement to end the journey if the bill run is for two-part tariff supplementary
+    if (session.type === 'two_part_supplementary') {
+      const formattedData = RegionPresenter.go(session, regions)
+
+      return {
+        error: { text: 'Currently you can progress no further for a two-part tariff supplementary bill run' },
+        ...formattedData
+      }
+    }
+
     // The journey is complete (we don't need any details) if the bill run type is not 2PT
     return { setupComplete: !session.type.startsWith('two_part') }
   }

--- a/app/validators/bill-runs/setup/type.validator.js
+++ b/app/validators/bill-runs/setup/type.validator.js
@@ -10,7 +10,7 @@ const Joi = require('joi')
 const VALID_VALUES = [
   'annual',
   'supplementary',
-  'tpt_supplementary',
+  'two_part_supplementary',
   'two_part_tariff'
 ]
 

--- a/app/validators/bill-runs/setup/type.validator.js
+++ b/app/validators/bill-runs/setup/type.validator.js
@@ -10,6 +10,7 @@ const Joi = require('joi')
 const VALID_VALUES = [
   'annual',
   'supplementary',
+  'tpt_supplementary',
   'two_part_tariff'
 ]
 

--- a/app/views/bill-runs/setup/type.njk
+++ b/app/views/bill-runs/setup/type.njk
@@ -58,12 +58,18 @@
           {
             text: 'Two-part tariff',
             value: 'two_part_tariff',
-            checked: 'two_part_tariff' == selectedType
+            checked: 'two_part_tariff' == selectedType,
+            hint: {
+              text: 'Second part charges only'
+            }
           },
           {
-            text: 'Two-part tariff Supplementary',
+            text: 'Two-part tariff supplementary',
             value: 'two_part_supplementary',
-            checked: 'two_part_supplementary' == selectedType
+            checked: 'two_part_supplementary' == selectedType,
+            hint: {
+              text: 'Second part charges for the current charge scheme only'
+            }
           }
         ]
       }) }}

--- a/app/views/bill-runs/setup/type.njk
+++ b/app/views/bill-runs/setup/type.njk
@@ -59,6 +59,11 @@
             text: 'Two-part tariff',
             value: 'two_part_tariff',
             checked: 'two_part_tariff' == selectedType
+          },
+          {
+            text: 'Two-part tariff Supplementary',
+            value: 'tpt_supplementary',
+            checked: 'tpt_supplementary' == selectedType
           }
         ]
       }) }}

--- a/app/views/bill-runs/setup/type.njk
+++ b/app/views/bill-runs/setup/type.njk
@@ -62,8 +62,8 @@
           },
           {
             text: 'Two-part tariff Supplementary',
-            value: 'tpt_supplementary',
-            checked: 'tpt_supplementary' == selectedType
+            value: 'two_part_supplementary',
+            checked: 'two_part_supplementary' == selectedType
           }
         ]
       }) }}

--- a/test/controllers/bill-runs-setup.controller.test.js
+++ b/test/controllers/bill-runs-setup.controller.test.js
@@ -278,7 +278,7 @@ describe('Bill Runs Setup controller', () => {
           const response = await server.inject(options)
 
           expect(response.statusCode).to.equal(200)
-          expect(response.payload).to.contain('Select a bill run type')
+          expect(response.payload).to.contain('Select bill run type')
         })
       })
     })

--- a/test/services/bill-runs/setup/submit-region.service.test.js
+++ b/test/services/bill-runs/setup/submit-region.service.test.js
@@ -77,6 +77,25 @@ describe('Bill Runs Setup Submit Region service', () => {
           expect(result.setupComplete).to.be.false()
         })
       })
+
+      describe('and the bill run type was two-part tariff supplementary', () => {
+        beforeEach(async () => {
+          session = await SessionHelper.add({ data: { type: 'two_part_supplementary' } })
+        })
+
+        it('returns page data needed to re-render the view including the error', async () => {
+          const result = await SubmitRegionService.go(session.id, payload)
+
+          expect(result).to.equal({
+            sessionId: session.id,
+            regions,
+            selectedRegion: payload.region,
+            error: {
+              text: 'Currently you can progress no further for a two-part tariff supplementary bill run'
+            }
+          })
+        })
+      })
     })
 
     describe('with an invalid payload', () => {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4200

As we are treating 2PT supplementary as a separate bill run we will need a new journey to trigger it.

In this PR a link for 2PT Supplementary will be added to the list of bill runs that can be triggered.  Selecting this will take you to a screen to select the region.