### PR TITLE
Add Mod Log model

### DIFF
--- a/app/models/charge-version.model.js
+++ b/app/models/charge-version.model.js
@@ -64,6 +64,14 @@ class ChargeVersionModel extends BaseModel {
           to: 'licences.id'
         }
       },
+      modLogs: {
+        relation: Model.HasManyRelation,
+        modelClass: 'mod-log.model',
+        join: {
+          from: 'chargeVersions.id',
+          to: 'modLogs.chargeVersionId'
+        }
+      },
       reviewChargeVersions: {
         relation: Model.HasManyRelation,
         modelClass: 'review-charge-version.model',

--- a/app/models/licence-version.model.js
+++ b/app/models/licence-version.model.js
@@ -32,6 +32,14 @@ class LicenceVersionModel extends BaseModel {
           to: 'licenceVersionPurposes.licenceVersionId'
         }
       },
+      modLogs: {
+        relation: Model.HasManyRelation,
+        modelClass: 'mod-log.model',
+        join: {
+          from: 'licenceVersions.id',
+          to: 'modLogs.licenceVersionId'
+        }
+      },
       purposes: {
         relation: Model.ManyToManyRelation,
         modelClass: 'purpose.model',

--- a/app/models/licence.model.js
+++ b/app/models/licence.model.js
@@ -72,6 +72,14 @@ class LicenceModel extends BaseModel {
           to: 'licenceVersions.licenceId'
         }
       },
+      modLogs: {
+        relation: Model.HasManyRelation,
+        modelClass: 'mod-log.model',
+        join: {
+          from: 'licences.id',
+          to: 'modLogs.licenceId'
+        }
+      },
       permitLicence: {
         relation: Model.HasOneRelation,
         modelClass: 'permit-licence.model',

--- a/app/models/mod-log.model.js
+++ b/app/models/mod-log.model.js
@@ -1,0 +1,16 @@
+'use strict'
+
+/**
+ * Model for mod log (water.mod_logs)
+ * @module ModLogModel
+ */
+
+const BaseModel = require('./base.model.js')
+
+class ModLogModel extends BaseModel {
+  static get tableName () {
+    return 'modLogs'
+  }
+}
+
+module.exports = ModLogModel

--- a/app/models/mod-log.model.js
+++ b/app/models/mod-log.model.js
@@ -5,11 +5,26 @@
  * @module ModLogModel
  */
 
+const { Model } = require('objection')
+
 const BaseModel = require('./base.model.js')
 
 class ModLogModel extends BaseModel {
   static get tableName () {
     return 'modLogs'
+  }
+
+  static get relationMappings () {
+    return {
+      licence: {
+        relation: Model.BelongsToOneRelation,
+        modelClass: 'licence.model',
+        join: {
+          from: 'modLogs.licenceId',
+          to: 'licences.id'
+        }
+      }
+    }
   }
 }
 

--- a/app/models/mod-log.model.js
+++ b/app/models/mod-log.model.js
@@ -39,6 +39,14 @@ class ModLogModel extends BaseModel {
           from: 'modLogs.licenceVersionId',
           to: 'licenceVersions.id'
         }
+      },
+      returnVersion: {
+        relation: Model.BelongsToOneRelation,
+        modelClass: 'return-version.model',
+        join: {
+          from: 'modLogs.returnVersionId',
+          to: 'returnVersions.id'
+        }
       }
     }
   }

--- a/app/models/mod-log.model.js
+++ b/app/models/mod-log.model.js
@@ -16,6 +16,14 @@ class ModLogModel extends BaseModel {
 
   static get relationMappings () {
     return {
+      chargeVersion: {
+        relation: Model.BelongsToOneRelation,
+        modelClass: 'charge-version.model',
+        join: {
+          from: 'modLogs.chargeVersionId',
+          to: 'chargeVersions.id'
+        }
+      },
       licence: {
         relation: Model.BelongsToOneRelation,
         modelClass: 'licence.model',

--- a/app/models/mod-log.model.js
+++ b/app/models/mod-log.model.js
@@ -31,6 +31,14 @@ class ModLogModel extends BaseModel {
           from: 'modLogs.licenceId',
           to: 'licences.id'
         }
+      },
+      licenceVersion: {
+        relation: Model.BelongsToOneRelation,
+        modelClass: 'licence-version.model',
+        join: {
+          from: 'modLogs.licenceVersionId',
+          to: 'licenceVersions.id'
+        }
       }
     }
   }

--- a/app/models/return-version.model.js
+++ b/app/models/return-version.model.js
@@ -24,6 +24,14 @@ class ReturnVersionModel extends BaseModel {
           to: 'licences.id'
         }
       },
+      modLogs: {
+        relation: Model.HasManyRelation,
+        modelClass: 'mod-log.model',
+        join: {
+          from: 'returnVersions.id',
+          to: 'modLogs.returnVersionId'
+        }
+      },
       returnRequirements: {
         relation: Model.HasManyRelation,
         modelClass: 'return-requirement.model',

--- a/db/migrations/legacy/20221108007038_water-mod-logs.js
+++ b/db/migrations/legacy/20221108007038_water-mod-logs.js
@@ -1,0 +1,53 @@
+'use strict'
+
+const tableName = 'mod_logs'
+
+exports.up = function (knex) {
+  return knex
+    .schema
+    .withSchema('water')
+    .createTable(tableName, (table) => {
+      // Primary Key
+      table.uuid('id').primary().defaultTo(knex.raw('gen_random_uuid()'))
+
+      // Data
+      table.string('external_id').notNullable()
+      table.string('event_code').notNullable()
+      table.string('event_description').notNullable()
+
+      table.string('reason_type')
+      table.string('reason_code')
+      table.string('reason_description')
+
+      table.date('nald_date').notNullable()
+      table.string('user_id').notNullable()
+      table.text('note')
+
+      table.string('licence_ref').notNullable()
+      table.string('licence_external_id').notNullable()
+      table.uuid('licence_id')
+
+      table.string('licence_version_external_id')
+      table.uuid('licence_version_id')
+
+      table.string('charge_version_external_id')
+      table.uuid('charge_version_id')
+
+      table.string('return_version_external_id')
+      table.uuid('return_version_id')
+
+      // Timestamps
+      table.timestamp('created_at', { useTz: false }).notNullable().defaultTo(knex.fn.now())
+      table.timestamp('updated_at', { useTz: false }).notNullable().defaultTo(knex.fn.now())
+
+      // Constraints
+      table.unique(['external_id'], { useConstraint: true })
+    })
+}
+
+exports.down = function (knex) {
+  return knex
+    .schema
+    .withSchema('water')
+    .dropTableIfExists(tableName)
+}

--- a/db/migrations/public/20240818105000_create-mod-logs-view.js
+++ b/db/migrations/public/20240818105000_create-mod-logs-view.js
@@ -1,0 +1,40 @@
+'use strict'
+
+const viewName = 'mod_logs'
+
+exports.up = function (knex) {
+  return knex
+    .schema
+    .dropViewIfExists(viewName)
+    .createView(viewName, (view) => {
+      view.as(knex('mod_logs').withSchema('water').select([
+        'id',
+        'external_id',
+        'event_code',
+        'event_description',
+        'reason_type',
+        'reason_code',
+        'reason_description',
+        'nald_date',
+        'user_id',
+        'note',
+        'licence_ref',
+        'licence_external_id',
+        'licence_id',
+        'licence_version_external_id',
+        'licence_version_id',
+        'charge_version_external_id',
+        'charge_version_id',
+        'return_version_external_id',
+        'return_version_id',
+        'created_at',
+        'updated_at'
+      ]))
+    })
+}
+
+exports.down = function (knex) {
+  return knex
+    .schema
+    .dropViewIfExists(viewName)
+}

--- a/test/models/licence-version.model.test.js
+++ b/test/models/licence-version.model.test.js
@@ -12,6 +12,8 @@ const LicenceHelper = require('../support/helpers/licence.helper.js')
 const LicenceModel = require('../../app/models/licence.model.js')
 const LicenceVersionHelper = require('../support/helpers/licence-version.helper.js')
 const LicenceVersionPurposesHelper = require('../support/helpers/licence-version-purpose.helper.js')
+const ModLogHelper = require('../support/helpers/mod-log.helper.js')
+const ModLogModel = require('../../app/models/mod-log.model.js')
 const PurposeHelper = require('../support/helpers/purpose.helper.js')
 const PurposeModel = require('../../app/models/purpose.model.js')
 
@@ -63,6 +65,42 @@ describe('Licence Version model', () => {
 
         expect(result.licence).to.be.an.instanceOf(LicenceModel)
         expect(result.licence).to.equal(testLicence)
+      })
+    })
+
+    describe('when linking to mod logs', () => {
+      let testModLogs
+
+      beforeEach(async () => {
+        testRecord = await LicenceVersionHelper.add()
+
+        testModLogs = []
+        for (let i = 0; i < 2; i++) {
+          const modLog = await ModLogHelper.add({ licenceVersionId: testRecord.id })
+
+          testModLogs.push(modLog)
+        }
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await LicenceVersionModel.query()
+          .innerJoinRelated('modLogs')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the mod logs', async () => {
+        const result = await LicenceVersionModel.query()
+          .findById(testRecord.id)
+          .withGraphFetched('modLogs')
+
+        expect(result).to.be.instanceOf(LicenceVersionModel)
+        expect(result.id).to.equal(testRecord.id)
+
+        expect(result.modLogs).to.be.an.array()
+        expect(result.modLogs[0]).to.be.an.instanceOf(ModLogModel)
+        expect(result.modLogs).to.include(testModLogs[0])
+        expect(result.modLogs).to.include(testModLogs[1])
       })
     })
 

--- a/test/models/licence.model.test.js
+++ b/test/models/licence.model.test.js
@@ -27,6 +27,8 @@ const LicenceGaugingStationModel = require('../../app/models/licence-gauging-sta
 const LicenceRoleHelper = require('../support/helpers/licence-role.helper.js')
 const LicenceVersionHelper = require('../support/helpers/licence-version.helper.js')
 const LicenceVersionModel = require('../../app/models/licence-version.model.js')
+const ModLogHelper = require('../support/helpers/mod-log.helper.js')
+const ModLogModel = require('../../app/models/mod-log.model.js')
 const RegionHelper = require('../support/helpers/region.helper.js')
 const RegionModel = require('../../app/models/region.model.js')
 const ReturnLogHelper = require('../support/helpers/return-log.helper.js')
@@ -302,6 +304,44 @@ describe('Licence model', () => {
         expect(result.licenceVersions[0]).to.be.an.instanceOf(LicenceVersionModel)
         expect(result.licenceVersions).to.include(testLicenceVersions[0])
         expect(result.licenceVersions).to.include(testLicenceVersions[1])
+      })
+    })
+
+    describe('when linking to mod logs', () => {
+      let testModLogs
+
+      beforeEach(async () => {
+        testRecord = await LicenceHelper.add()
+
+        testModLogs = []
+        for (let i = 0; i < 2; i++) {
+          const modLog = await ModLogHelper.add({
+            licenceRef: testRecord.licenceRef, licenceId: testRecord.id
+          })
+
+          testModLogs.push(modLog)
+        }
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await LicenceModel.query()
+          .innerJoinRelated('modLogs')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the mod logs', async () => {
+        const result = await LicenceModel.query()
+          .findById(testRecord.id)
+          .withGraphFetched('modLogs')
+
+        expect(result).to.be.instanceOf(LicenceModel)
+        expect(result.id).to.equal(testRecord.id)
+
+        expect(result.modLogs).to.be.an.array()
+        expect(result.modLogs[0]).to.be.an.instanceOf(ModLogModel)
+        expect(result.modLogs).to.include(testModLogs[0])
+        expect(result.modLogs).to.include(testModLogs[1])
       })
     })
 

--- a/test/models/mod-log.model.test.js
+++ b/test/models/mod-log.model.test.js
@@ -1,0 +1,31 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, before } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const ModLogHelper = require('../support/helpers/mod-log.helper.js')
+
+// Thing under test
+const ModLogModel = require('../../app/models/mod-log.model.js')
+
+describe('Mod Log model', () => {
+  let testRecord
+
+  before(async () => {
+    testRecord = await ModLogHelper.add()
+  })
+
+  describe('Basic query', () => {
+    it('can successfully run a basic query', async () => {
+      const result = await ModLogModel.query().findById(testRecord.id)
+
+      expect(result).to.be.an.instanceOf(ModLogModel)
+      expect(result.id).to.equal(testRecord.id)
+    })
+  })
+})

--- a/test/models/mod-log.model.test.js
+++ b/test/models/mod-log.model.test.js
@@ -8,16 +8,24 @@ const { describe, it, before } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
+const LicenceHelper = require('../support/helpers/licence.helper.js')
+const LicenceModel = require('../../app/models/licence.model.js')
 const ModLogHelper = require('../support/helpers/mod-log.helper.js')
 
 // Thing under test
 const ModLogModel = require('../../app/models/mod-log.model.js')
 
 describe('Mod Log model', () => {
+  let testLicence
   let testRecord
 
   before(async () => {
-    testRecord = await ModLogHelper.add()
+    testLicence = await LicenceHelper.add()
+
+    testRecord = await ModLogHelper.add({
+      licenceRef: testLicence.licenceRef,
+      licenceId: testLicence.id
+    })
   })
 
   describe('Basic query', () => {
@@ -26,6 +34,29 @@ describe('Mod Log model', () => {
 
       expect(result).to.be.an.instanceOf(ModLogModel)
       expect(result.id).to.equal(testRecord.id)
+    })
+  })
+
+  describe('Relationships', () => {
+    describe('when linking to licence', () => {
+      it('can successfully run a related query', async () => {
+        const query = await ModLogModel.query()
+          .innerJoinRelated('licence')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the licence', async () => {
+        const result = await ModLogModel.query()
+          .findById(testRecord.id)
+          .withGraphFetched('licence')
+
+        expect(result).to.be.instanceOf(ModLogModel)
+        expect(result.id).to.equal(testRecord.id)
+
+        expect(result.licence).to.be.an.instanceOf(LicenceModel)
+        expect(result.licence).to.equal(testLicence)
+      })
     })
   })
 })

--- a/test/models/mod-log.model.test.js
+++ b/test/models/mod-log.model.test.js
@@ -8,6 +8,8 @@ const { describe, it, before } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
+const ChargeVersionHelper = require('../support/helpers/charge-version.helper.js')
+const ChargeVersionModel = require('../../app/models/charge-version.model.js')
 const LicenceHelper = require('../support/helpers/licence.helper.js')
 const LicenceModel = require('../../app/models/licence.model.js')
 const ModLogHelper = require('../support/helpers/mod-log.helper.js')
@@ -16,15 +18,18 @@ const ModLogHelper = require('../support/helpers/mod-log.helper.js')
 const ModLogModel = require('../../app/models/mod-log.model.js')
 
 describe('Mod Log model', () => {
+  let testChargeVersion
   let testLicence
   let testRecord
 
   before(async () => {
     testLicence = await LicenceHelper.add()
+    testChargeVersion = await ChargeVersionHelper.add({ licenceRef: testLicence.licenceRef })
 
     testRecord = await ModLogHelper.add({
-      licenceRef: testLicence.licenceRef,
-      licenceId: testLicence.id
+      chargeVersionId: testChargeVersion.id,
+      licenceId: testLicence.id,
+      licenceRef: testLicence.licenceRef
     })
   })
 
@@ -38,6 +43,27 @@ describe('Mod Log model', () => {
   })
 
   describe('Relationships', () => {
+    describe('when linking to charge version', () => {
+      it('can successfully run a related query', async () => {
+        const query = await ModLogModel.query()
+          .innerJoinRelated('chargeVersion')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the charge version', async () => {
+        const result = await ModLogModel.query()
+          .findById(testRecord.id)
+          .withGraphFetched('chargeVersion')
+
+        expect(result).to.be.instanceOf(ModLogModel)
+        expect(result.id).to.equal(testRecord.id)
+
+        expect(result.chargeVersion).to.be.an.instanceOf(ChargeVersionModel)
+        expect(result.chargeVersion).to.equal(testChargeVersion)
+      })
+    })
+
     describe('when linking to licence', () => {
       it('can successfully run a related query', async () => {
         const query = await ModLogModel.query()

--- a/test/models/return-version.model.test.js
+++ b/test/models/return-version.model.test.js
@@ -10,6 +10,8 @@ const { expect } = Code
 // Test helpers
 const LicenceHelper = require('../support/helpers/licence.helper.js')
 const LicenceModel = require('../../app/models/licence.model.js')
+const ModLogHelper = require('../support/helpers/mod-log.helper.js')
+const ModLogModel = require('../../app/models/mod-log.model.js')
 const ReturnRequirementHelper = require('../support/helpers/return-requirement.helper.js')
 const ReturnRequirementModel = require('../../app/models/return-requirement.model.js')
 const ReturnVersionHelper = require('../support/helpers/return-version.helper.js')
@@ -64,6 +66,42 @@ describe('Return Version model', () => {
 
         expect(result.licence).to.be.an.instanceOf(LicenceModel)
         expect(result.licence).to.equal(testLicence)
+      })
+    })
+
+    describe('when linking to mod logs', () => {
+      let testModLogs
+
+      beforeEach(async () => {
+        testRecord = await ReturnVersionHelper.add()
+
+        testModLogs = []
+        for (let i = 0; i < 2; i++) {
+          const modLog = await ModLogHelper.add({ returnVersionId: testRecord.id })
+
+          testModLogs.push(modLog)
+        }
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await ReturnVersionModel.query()
+          .innerJoinRelated('modLogs')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the mod logs', async () => {
+        const result = await ReturnVersionModel.query()
+          .findById(testRecord.id)
+          .withGraphFetched('modLogs')
+
+        expect(result).to.be.instanceOf(ReturnVersionModel)
+        expect(result.id).to.equal(testRecord.id)
+
+        expect(result.modLogs).to.be.an.array()
+        expect(result.modLogs[0]).to.be.an.instanceOf(ModLogModel)
+        expect(result.modLogs).to.include(testModLogs[0])
+        expect(result.modLogs).to.include(testModLogs[1])
       })
     })
 

--- a/test/support/helpers/mod-log.helper.js
+++ b/test/support/helpers/mod-log.helper.js
@@ -1,0 +1,74 @@
+'use strict'
+
+/**
+ * @module ModLogHelper
+ */
+
+const ModLogModel = require('../../../app/models/mod-log.model.js')
+const { randomInteger } = require('../general.js')
+const { generateLicenceRef } = require('./licence.helper.js')
+
+/**
+ * Add a new mod log
+ *
+ * If no `data` is provided, default values will be used. These are
+ *
+ * - `externalId` - [randomly generated - 9:99999]
+ * - `eventCode` - DRFVER
+ * - `eventDescription` - Draft version created
+ * - `naldDate` - 2012-06-01
+ * - `userId` - TTESTER
+ * - `licenceRef` - [randomly generated - 01/12/34/1000]
+ * - `licenceExternalId` - [randomly generated - 9:99999]
+ *
+ * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ *
+ * @returns {Promise<module:ModLogModel>} The instance of the newly created record
+ */
+function add (data = {}) {
+  const insertData = defaults(data)
+
+  return ModLogModel.query()
+    .insert({ ...insertData })
+    .returning('*')
+}
+
+/**
+ * Returns the defaults used
+ *
+ * It will override or append to them any data provided. Mainly used by the `add()` method, we make it available
+ * for use in tests to avoid having to duplicate values.
+ *
+ * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ */
+function defaults (data = {}) {
+  const regionCode = randomInteger(1, 9)
+
+  const defaults = {
+    externalId: generateRegionNaldPatternExternalId(regionCode),
+    eventCode: 'DRFVER',
+    eventDescription: 'Draft version created',
+    naldDate: new Date('2012-06-01'),
+    userId: 'TTESTER',
+    licenceRef: generateLicenceRef(),
+    // The licence and mod log share the same external ID pattern: [region code:NALD ID]
+    licenceExternalId: generateRegionNaldPatternExternalId(regionCode)
+  }
+
+  return {
+    ...defaults,
+    ...data
+  }
+}
+
+function generateRegionNaldPatternExternalId (regionCode = null) {
+  const regionCodeToUse = regionCode ?? randomInteger(1, 9)
+
+  return `${regionCodeToUse}:${randomInteger(100, 99999)}`
+}
+
+module.exports = {
+  add,
+  defaults,
+  generateRegionNaldPatternExternalId
+}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4563
https://eaflood.atlassian.net/browse/WATER-4564
https://eaflood.atlassian.net/browse/WATER-4565

> Part of the work to display a licence's history to users (mod log)

Now that we have a table to hold the imported NALD mod log records, we need a model to access it and relationships to access the mod logs from charge, licence, and return versions.

Once added and linked, we can complete our work to expose this information, for example.

- [Build new licence history page](https://github.com/DEFRA/water-abstraction-system/pull/1182)
- [Update view return version to include mod log info](https://github.com/DEFRA/water-abstraction-system/pull/1261)