### PR TITLE
Fix blown server logs in import service

### DIFF
--- a/app/services/import/legacy-licence.service.js
+++ b/app/services/import/legacy-licence.service.js
@@ -18,23 +18,15 @@ const PersistLicenceService = require('./persist-licence.service.js')
  * @returns {Promise<Object>} an object representing the saved licence in the database
  */
 async function go (licenceRef) {
-  console.debug('Importing licence ref: ', licenceRef)
   const licenceData = await FetchLegacyImportLicenceService.go(licenceRef)
 
-  console.debug('Imported licence data: ', licenceData)
   const licenceVersionsData = await FetchLegacyImportLicenceVersionsService.go(licenceData)
 
-  console.debug('Imported licence versions data: ', licenceVersionsData)
-
   const mappedLicenceData = await LegacyImportLicenceMapper.go(licenceData, licenceVersionsData)
-
-  console.debug('Mapped imported licence data: ', mappedLicenceData)
 
   ImportLicenceValidatorService.go(mappedLicenceData)
 
   const savedLicence = await PersistLicenceService.go(mappedLicenceData)
-
-  console.debug('Saved Licence: ', savedLicence)
 
   return savedLicence
 }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4575

> Part of the work to replace the legacy licence import in readiness for ReSP

In [Import Licence](https://github.com/DEFRA/water-abstraction-system/pull/1191), we added our first steps of migrating the legacy licence import from [water-abstraction-import](https://github.com/DEFRA/water-abstraction.import). Because this is still in development, we added some debug logging to check the licence the import service was pinging and what data we were reading from NALD.

What we hadn't realised is that `console` calls, even `console.debug()`, don't go through any kind of determination in Node.js. The calls to, for example, `console.info()`, `console.debug()`, or `console.error()` just determine whether Node outputs them to **stdout** or **stderr**.

So, they are _always_ output. If the logging was done through our [Hapi-pino plugin](https://github.com/hapijs/hapi-pino) then we could control the log levels. But we have no such control in Node.

We have got [a change in the works](https://github.com/DEFRA/water-abstraction-system/pull/1195) where the debug calls are removed. But that is so large it is taking time to be processed. In the meantime, this debug output is starting to cause our non-prod environments to crash because they are filling up the limited disk space.

This quick change gets them out now.