### PR TITLE
Linting should not apply to the docs folder

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,6 +2,7 @@
 
 module.exports = {
   extends: 'standard', // Maintain Standard.js rules
+  ignorePatterns: ['docs/*'],
   parserOptions: {
     sourceType: 'script'
   },


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/115

Previous work - https://github.com/DEFRA/water-abstraction-system/pull/1253

When the docs are generated, and you run linting (locally) then the linting is being applied to the docs folder. This change ignores the docs folder for linting purposes.