### PR TITLE
Add history attributes to LicenceVersionModel

### DIFF
--- a/app/models/licence-version.model.js
+++ b/app/models/licence-version.model.js
@@ -169,6 +169,27 @@ class LicenceVersionModel extends BaseModel {
     return notes
   }
 
+  /**
+   * Determine the reason the 'source' record was created using history
+   *
+   * > We recommend adding the `history` modifier to your query to support this determination
+   *
+   * NALD has a concept called 'mod log'. When someone creates a new licence, charge, or return version, they can
+   * provide a reason and a note, which is saved as the 'mod log'. Who created the 'mod log' and when is also captured.
+   *
+   * It was intended to record a history of changes to the licence.
+   *
+   * In NALD a licence version can have multiple mod logs, each with their own reason. There is currently no reason
+   * captured against the WRLS licence version.
+   *
+   * @returns {string} the reason the 'source' record was created, else `null` if it cannot be determined
+   */
+  $reason () {
+    const firstModLog = this._firstModLog()
+
+    return firstModLog?.reasonDescription ?? null
+  }
+
   _firstModLog () {
     if (this.modLogs.length > 0) {
       return this.modLogs[0]

--- a/app/models/licence-version.model.js
+++ b/app/models/licence-version.model.js
@@ -54,6 +54,36 @@ class LicenceVersionModel extends BaseModel {
       }
     }
   }
+
+  /**
+   * Modifiers allow us to reuse logic in queries, eg. select the licence version and all mod log records:
+   *
+   * return LicenceVersionModel.query()
+   *   .findById(licenceVersionId)
+   *   .modify('history')
+   *
+   * See {@link https://vincit.github.io/objection.js/recipes/modifiers.html | Modifiers} for more details
+   */
+  static get modifiers () {
+    return {
+      // history modifier fetches all the related records needed to determine history properties, for example, created
+      // at, created by, and notes from the record and its NALD mod logs (where they exist)
+      history (query) {
+        query
+          .withGraphFetched('modLogs')
+          .modifyGraph('modLogs', (builder) => {
+            builder.select([
+              'id',
+              'naldDate',
+              'note',
+              'reasonDescription',
+              'userId'
+            ])
+              .orderBy('externalId', 'asc')
+          })
+      }
+    }
+  }
 }
 
 module.exports = LicenceVersionModel

--- a/app/models/licence-version.model.js
+++ b/app/models/licence-version.model.js
@@ -86,6 +86,33 @@ class LicenceVersionModel extends BaseModel {
   }
 
   /**
+   * Determine the created at date of the 'source' record using history
+   *
+   * > We recommend adding the `history` modifier to your query to support this determination
+   *
+   * NALD has a concept called 'mod log'. When someone creates a new licence, charge, or return version, they can
+   * provide a reason and a note, which is saved as the 'mod log'. Who created the 'mod log' and when is also captured.
+   *
+   * It was intended to record a history of changes to the licence.
+   *
+   * Unfortunately, NALD doesn't enforce it's creation. But as the NALD version records don't capture the who and when,
+   * they are the best 'source' we have to determine this information for imported records.
+   *
+   * If there are mod logs for this record, it extracts the date from the first entry, for example, `2019-06-02`, and
+   * returns it. Else, it falls back to using the return version's `createdAt` time stamp.
+   *
+   * > The NALD date takes priority, because all records will have a created at date. But in the case of imported
+   * > records this will be when it was imported to WRLS, which can be some time after it was created in NALD.
+   *
+   * @returns {Date} the date the 'source' record was created
+   */
+  $createdAt () {
+    const firstModLog = this._firstModLog()
+
+    return firstModLog?.naldDate ?? this.createdAt
+  }
+
+  /**
    * Determine which user created the 'source' record using history
    *
    * > We recommend adding the `history` modifier to your query to support this determination

--- a/app/models/licence-version.model.js
+++ b/app/models/licence-version.model.js
@@ -142,6 +142,33 @@ class LicenceVersionModel extends BaseModel {
     return firstModLog?.userId ?? null
   }
 
+  /**
+   * Determine the notes for the record using its history
+   *
+   * > We recommend adding the `history` modifier to your query to support this determination
+   *
+   * NALD has a concept called 'mod log'. When someone creates a new licence, charge, or return version, they can
+   * provide a reason and a note, which is saved as the 'mod log'. Who created the 'mod log' and when is also captured.
+   *
+   * It was intended to record a history of changes to the licence.
+   *
+   * In NALD a licence version can have multiple mod logs, each with their own note. There is currently no note captured
+   * against the WRLS licence version.
+   *
+   * @returns {string[]} an array of all the notes in ascending date order taken from the record's history
+   */
+  $notes () {
+    const notes = []
+
+    for (const modLog of this.modLogs) {
+      if (modLog.note) {
+        notes.push(modLog.note)
+      }
+    }
+
+    return notes
+  }
+
   _firstModLog () {
     if (this.modLogs.length > 0) {
       return this.modLogs[0]

--- a/app/models/licence-version.model.js
+++ b/app/models/licence-version.model.js
@@ -84,6 +84,44 @@ class LicenceVersionModel extends BaseModel {
       }
     }
   }
+
+  /**
+   * Determine which user created the 'source' record using history
+   *
+   * > We recommend adding the `history` modifier to your query to support this determination
+   *
+   * NALD has a concept called 'mod log'. When someone creates a new licence, charge, or return version, they can
+   * provide a reason and a note, which is saved as the 'mod log'. Who created the 'mod log' and when is also captured.
+   *
+   * It was intended to record a history of changes to the licence.
+   *
+   * Unfortunately, NALD doesn't enforce it's creation. But as the NALD version records don't capture the who and when,
+   * they are the best 'source' we have to determine this information for imported records.
+   *
+   * Licence versions are not managed in WRLS, so we do not capture a `created_by` value. The only source for this is
+   * the mod logs.
+   *
+   * If mod logs exist it extracts the user ID from the first mod log record, for example, `JSMITH`. If one exists it is
+   * the 'source'.
+   *
+   * If no mod logs exist it will return `null`.
+   *
+   * @returns {string} the user name of the user that created the 'source' record, else `null` if it cannot be
+   * determined
+   */
+  $createdBy () {
+    const firstModLog = this._firstModLog()
+
+    return firstModLog?.userId ?? null
+  }
+
+  _firstModLog () {
+    if (this.modLogs.length > 0) {
+      return this.modLogs[0]
+    }
+
+    return null
+  }
 }
 
 module.exports = LicenceVersionModel

--- a/app/models/return-version.model.js
+++ b/app/models/return-version.model.js
@@ -92,6 +92,33 @@ class ReturnVersionModel extends BaseModel {
   }
 
   /**
+   * Determine the created at date of the 'source' record using history
+   *
+   * > We recommend adding the `history` modifier to your query to support this determination
+   *
+   * NALD has a concept called 'mod log'. When someone creates a new licence, charge, or return version, they can
+   * provide a reason and a note, which is saved as the 'mod log'. Who created the 'mod log' and when is also captured.
+   *
+   * It was intended to record a history of changes to the licence.
+   *
+   * Unfortunately, NALD doesn't enforce it's creation. But as the NALD version records don't capture the who and when,
+   * they are the best 'source' we have to determine this information for imported records.
+   *
+   * If there are mod logs for this record, it extracts the date from the first entry, for example, `2019-06-02`, and
+   * returns it. Else, it falls back to using the return version's `createdAt` time stamp.
+   *
+   * > The NALD date takes priority, because all records will have a created at date. But in the case of imported
+   * > records this will be when it was imported to WRLS, which can be some time after it was created in NALD.
+   *
+   * @returns {Date} the date the 'source' record was created
+   */
+  $createdAt () {
+    const firstModLog = this._firstModLog()
+
+    return firstModLog?.naldDate ?? this.createdAt
+  }
+
+  /**
    * Determine which user created the 'source' record using history
    *
    * > We recommend adding the `history` modifier to your query to support this determination
@@ -123,33 +150,6 @@ class ReturnVersionModel extends BaseModel {
     const firstModLog = this._firstModLog()
 
     return firstModLog?.userId ?? null
-  }
-
-  /**
-   * Determine the created at date of the 'source' record using history
-   *
-   * > We recommend adding the `history` modifier to your query to support this determination
-   *
-   * NALD has a concept called 'mod log'. When someone creates a new licence, charge, or return version, they can
-   * provide a reason and a note, which is saved as the 'mod log'. Who created the 'mod log' and when is also captured.
-   *
-   * It was intended to record a history of changes to the licence.
-   *
-   * Unfortunately, NALD doesn't enforce it's creation. But as the NALD version records don't capture the who and when,
-   * they are the best 'source' we have to determine this information for imported records.
-   *
-   * If there are mod logs for this record, it extracts the date from the first entry, for example, `2019-06-02`, and
-   * returns it. Else, it falls back to using the return version's `createdAt` time stamp.
-   *
-   * > The NALD date takes priority, because all records will have a created at date. But in the case of imported
-   * > records this will be when it was imported to WRLS, which can be some time after it was created in NALD.
-   *
-   * @returns {Date} the date the 'source' record was created
-   */
-  $createdAt () {
-    const firstModLog = this._firstModLog()
-
-    return firstModLog?.naldDate ?? this.createdAt
   }
 
   /**

--- a/app/models/return-version.model.js
+++ b/app/models/return-version.model.js
@@ -56,7 +56,7 @@ class ReturnVersionModel extends BaseModel {
    * log records:
    *
    * return ReturnVersionModel.query()
-   *   .findById(licenceId)
+   *   .findById(returnVersionId)
    *   .modify('history')
    *
    * See {@link https://vincit.github.io/objection.js/recipes/modifiers.html | Modifiers} for more details

--- a/test/models/licence-version.model.test.js
+++ b/test/models/licence-version.model.test.js
@@ -144,6 +144,42 @@ describe('Licence Version model', () => {
     })
   })
 
+  describe('$createdAt', () => {
+    describe('when the licence version has no mod log history', () => {
+      beforeEach(async () => {
+        testRecord = await LicenceVersionModel.query().findById(licenceVersionId).modify('history')
+      })
+
+      it('returns the licence version "created at" time stamp', () => {
+        const result = testRecord.$createdAt()
+
+        expect(result).to.equal(testRecord.createdAt)
+      })
+    })
+
+    describe('when the licence version has mod log history', () => {
+      beforeEach(async () => {
+        const regionCode = randomInteger(1, 9)
+        const firstNaldId = randomInteger(100, 99998)
+
+        await ModLogHelper.add({
+          externalId: `${regionCode}:${firstNaldId}`, naldDate: new Date('2012-06-01'), licenceVersionId
+        })
+        await ModLogHelper.add({
+          externalId: `${regionCode}:${firstNaldId + 1}`, naldDate: new Date('2012-06-02'), licenceVersionId
+        })
+
+        testRecord = await LicenceVersionModel.query().findById(licenceVersionId).modify('history')
+      })
+
+      it('returns the first mod log NALD date', () => {
+        const result = testRecord.$createdAt()
+
+        expect(result).to.equal(new Date('2012-06-01'))
+      })
+    })
+  })
+
   describe('$createdBy', () => {
     describe('when the licence version has no mod log history', () => {
       beforeEach(async () => {

--- a/test/models/licence-version.model.test.js
+++ b/test/models/licence-version.model.test.js
@@ -211,4 +211,66 @@ describe('Licence Version model', () => {
       })
     })
   })
+
+  describe('$notes', () => {
+    describe('when the licence version has no mod log history', () => {
+      beforeEach(async () => {
+        testRecord = await LicenceVersionModel.query().findById(licenceVersionId).modify('history')
+      })
+
+      it('returns an empty array', () => {
+        const result = testRecord.$notes()
+
+        expect(result).to.be.an.array()
+        expect(result).to.be.empty()
+      })
+    })
+
+    describe('when the licence version has mod log history', () => {
+      describe('but none of the mod log history has notes', () => {
+        beforeEach(async () => {
+          const regionCode = randomInteger(1, 9)
+          const firstNaldId = randomInteger(100, 99998)
+
+          await ModLogHelper.add({
+            externalId: `${regionCode}:${firstNaldId}`, note: null, licenceVersionId
+          })
+          await ModLogHelper.add({
+            externalId: `${regionCode}:${firstNaldId + 1}`, note: null, licenceVersionId
+          })
+
+          testRecord = await LicenceVersionModel.query().findById(licenceVersionId).modify('history')
+        })
+
+        it('returns an empty array', () => {
+          const result = testRecord.$notes()
+
+          expect(result).to.be.an.array()
+          expect(result).to.be.empty()
+        })
+      })
+
+      describe('and some of the mod log history has notes', () => {
+        beforeEach(async () => {
+          const regionCode = randomInteger(1, 9)
+          const firstNaldId = randomInteger(100, 99998)
+
+          await ModLogHelper.add({
+            externalId: `${regionCode}:${firstNaldId}`, note: null, licenceVersionId
+          })
+          await ModLogHelper.add({
+            externalId: `${regionCode}:${firstNaldId + 1}`, note: 'Transfer per app 12-DEF', licenceVersionId
+          })
+
+          testRecord = await LicenceVersionModel.query().findById(licenceVersionId).modify('history')
+        })
+
+        it('returns an array containing just the notes from the mod logs with them', () => {
+          const result = testRecord.$notes()
+
+          expect(result).to.equal(['Transfer per app 12-DEF'])
+        })
+      })
+    })
+  })
 })

--- a/test/models/return-version.model.test.js
+++ b/test/models/return-version.model.test.js
@@ -177,6 +177,48 @@ describe('Return Version model', () => {
     })
   })
 
+  describe('$createdAt', () => {
+    beforeEach(async () => {
+      const { id } = await ReturnVersionHelper.add()
+
+      returnVersionId = id
+    })
+
+    describe('when a return version has no mod log history', () => {
+      beforeEach(async () => {
+        testRecord = await ReturnVersionModel.query().findById(returnVersionId).modify('history')
+      })
+
+      it('returns the return version "created at" time stamp', () => {
+        const result = testRecord.$createdAt()
+
+        expect(result).to.equal(testRecord.createdAt)
+      })
+    })
+
+    describe('when a return version has mod log history', () => {
+      beforeEach(async () => {
+        const regionCode = randomInteger(1, 9)
+        const firstNaldId = randomInteger(100, 99998)
+
+        await ModLogHelper.add({
+          externalId: `${regionCode}:${firstNaldId}`, naldDate: new Date('2012-06-01'), returnVersionId
+        })
+        await ModLogHelper.add({
+          externalId: `${regionCode}:${firstNaldId + 1}`, naldDate: new Date('2012-06-02'), returnVersionId
+        })
+
+        testRecord = await ReturnVersionModel.query().findById(returnVersionId).modify('history')
+      })
+
+      it('returns the first mod log NALD date', () => {
+        const result = testRecord.$createdAt()
+
+        expect(result).to.equal(new Date('2012-06-01'))
+      })
+    })
+  })
+
   describe('$createdBy', () => {
     describe('when the return version was created in WRLS', () => {
       let testUser
@@ -251,48 +293,6 @@ describe('Return Version model', () => {
 
           expect(result).to.equal('FIRST')
         })
-      })
-    })
-  })
-
-  describe('$createdAt', () => {
-    beforeEach(async () => {
-      const { id } = await ReturnVersionHelper.add()
-
-      returnVersionId = id
-    })
-
-    describe('when a return version has no mod log history', () => {
-      beforeEach(async () => {
-        testRecord = await ReturnVersionModel.query().findById(returnVersionId).modify('history')
-      })
-
-      it('returns the return version "created at" time stamp', () => {
-        const result = testRecord.$createdAt()
-
-        expect(result).to.equal(testRecord.createdAt)
-      })
-    })
-
-    describe('when a return version has mod log history', () => {
-      beforeEach(async () => {
-        const regionCode = randomInteger(1, 9)
-        const firstNaldId = randomInteger(100, 99998)
-
-        await ModLogHelper.add({
-          externalId: `${regionCode}:${firstNaldId}`, naldDate: new Date('2012-06-01'), returnVersionId
-        })
-        await ModLogHelper.add({
-          externalId: `${regionCode}:${firstNaldId + 1}`, naldDate: new Date('2012-06-02'), returnVersionId
-        })
-
-        testRecord = await ReturnVersionModel.query().findById(returnVersionId).modify('history')
-      })
-
-      it('returns the first mod log NALD date', () => {
-        const result = testRecord.$createdAt()
-
-        expect(result).to.equal(new Date('2012-06-01'))
       })
     })
   })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4560

> Part of the work to display NALD mod log records as history in WRLS

So, we are now importing mod logs from NALD and have added a model linked to charge, licence and return version models to allow us to retrieve them from the database.

We are in the process of building [a new licence history page](https://github.com/DEFRA/water-abstraction-system/pull/1182) and will need to create a view of the licence version in the future.

Because of this, we believe adding a modifier and instance methods to the `LicenceVersionModel` that will handle fetching the mod logs and determining this information is valuable.

This change updates the `LicenceVersionModel` with these properties. This is similar to the work we did in [Add history attributes to ReturnVersionModel](https://github.com/DEFRA/water-abstraction-system/pull/1267).