### PR TITLE
Alan's Update view return version with mod log

### DIFF
--- a/app/presenters/return-requirements/view.presenter.js
+++ b/app/presenters/return-requirements/view.presenter.js
@@ -27,7 +27,7 @@ function go (returnVersion) {
     additionalSubmissionOptions: {
       multipleUpload: multipleUpload === true ? 'Yes' : 'No'
     },
-    createdBy: returnVersion.$createdBy() ? returnVersion.$createdBy() : 'Migrated from NALD',
+    createdBy: _createdBy(returnVersion),
     createdDate: formatLongDate(new Date(returnVersion.$createdAt())),
     licenceId: licence.id,
     licenceRef: licence.licenceRef,
@@ -94,6 +94,16 @@ function _buildAgreementExceptions (returnRequirement) {
   }
 
   return agreementsExceptions
+}
+
+function _createdBy (returnVersion) {
+  const createdBy = returnVersion.$createdBy()
+
+  if (createdBy) {
+    return createdBy
+  }
+
+  return 'Migrated from NALD'
 }
 
 function _mapRequirement (requirement) {

--- a/app/presenters/return-requirements/view.presenter.js
+++ b/app/presenters/return-requirements/view.presenter.js
@@ -8,7 +8,7 @@
 const { formatAbstractionDate } = require('../base.presenter.js')
 const { formatLongDate } = require('../base.presenter.js')
 const { generatePointDetail } = require('../../lib/general.lib.js')
-const { returnRequirementFrequencies } = require('../../lib/static-lookups.lib.js')
+const { returnRequirementReasons, returnRequirementFrequencies } = require('../../lib/static-lookups.lib.js')
 
 /**
  * Formats requirements for returns data for the `/return-requirements/{sessionId}/view` page
@@ -33,7 +33,7 @@ function go (returnVersion) {
     licenceRef: licence.licenceRef,
     notes: returnVersion.$notes(),
     pageTitle: `Requirements for returns for ${licence.$licenceHolder()}`,
-    reason: returnVersion.$reason() ? returnVersion.$reason() : '',
+    reason: _reason(returnVersion),
     requirements: _requirements(returnRequirements),
     startDate: formatLongDate(startDate),
     status
@@ -125,6 +125,25 @@ function _points (returnRequirementPoints) {
   return returnRequirementPoints.map((returnRequirementPoint) => {
     return generatePointDetail(returnRequirementPoint)
   })
+}
+
+/**
+ * The history helper $reason() will return either the reason saved against the return version record, the reason
+ * captured in the first mod log entry, or null.
+ *
+ * If its the reason saved against the return version we have to map it to its display version first.
+ *
+ * @private
+ */
+function _reason (returnVersion) {
+  const reason = returnVersion.$reason()
+  const mappedReason = returnRequirementReasons[reason]
+
+  if (mappedReason) {
+    return mappedReason
+  }
+
+  return reason ?? ''
 }
 
 function _requirements (requirements) {

--- a/app/presenters/return-requirements/view.presenter.js
+++ b/app/presenters/return-requirements/view.presenter.js
@@ -28,7 +28,7 @@ function go (returnVersion) {
       multipleUpload: multipleUpload === true ? 'Yes' : 'No'
     },
     createdBy: _createdBy(returnVersion),
-    createdDate: formatLongDate(new Date(returnVersion.$createdAt())),
+    createdDate: formatLongDate(returnVersion.$createdAt()),
     licenceId: licence.id,
     licenceRef: licence.licenceRef,
     notes: returnVersion.$notes(),

--- a/app/views/return-requirements/view.njk
+++ b/app/views/return-requirements/view.njk
@@ -78,7 +78,7 @@
     <h2 class="govuk-heading-l govuk-!-margin-bottom-4">Notes</h2>
     <hr class="govuk-section-break  govuk-!-margin-bottom-2 govuk-section-break--visible">
     <p>
-      {{ newLine(notes) | escape }}
+      {{ newLine(notes) }}
     </p>
     <hr class="govuk-section-break  govuk-!-margin-bottom-2 govuk-section-break--visible">
   </div>

--- a/test/presenters/return-requirements/view.presenter.test.js
+++ b/test/presenters/return-requirements/view.presenter.test.js
@@ -19,9 +19,7 @@ describe('Return Requirements - View presenter', () => {
   let returnVersion
 
   beforeEach(() => {
-    const returnVersionData = _returnVersion()
-
-    returnVersion = ReturnVersionModel.fromJson(returnVersionData)
+    returnVersion = _returnVersion()
   })
 
   it('correctly presents the data', () => {
@@ -311,7 +309,7 @@ function _returnVersion () {
     }
   })
 
-  return {
+  const returnVersionData = {
     createdAt: new Date('2022-04-05'),
     id: '3f09ce0b-288c-4c0b-b519-7329fe70a6cc',
     multipleUpload: false,
@@ -352,4 +350,6 @@ function _returnVersion () {
       }]
     }]
   }
+
+  return ReturnVersionModel.fromJson(returnVersionData)
 }

--- a/test/presenters/return-requirements/view.presenter.test.js
+++ b/test/presenters/return-requirements/view.presenter.test.js
@@ -8,6 +8,8 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
+const ContactModel = require('../../../app/models/contact.model.js')
+const LicenceModel = require('../../../app/models/licence.model.js')
 const ReturnVersionModel = require('../../../app/models/return-version.model.js')
 
 // Thing under test
@@ -33,8 +35,8 @@ describe('Return Requirements - View presenter', () => {
       createdDate: '5 April 2022',
       licenceId: '761bc44f-80d5-49ae-ab46-0a90495417b5',
       licenceRef: '01/123',
-      notes: 'A special note',
-      pageTitle: 'Requirements for returns for Mr Ingles',
+      notes: ['A special note'],
+      pageTitle: 'Requirements for returns for Mrs A J Easley',
       reason: 'New licence',
       requirements: [
         {
@@ -111,7 +113,7 @@ describe('Return Requirements - View presenter', () => {
     it("returns the title incorporating the licence holder's name", () => {
       const result = ViewPresenter.go(returnVersion)
 
-      expect(result.pageTitle).to.equal('Requirements for returns for Mr Ingles')
+      expect(result.pageTitle).to.equal('Requirements for returns for Mrs A J Easley')
     })
   })
 
@@ -272,6 +274,24 @@ describe('Return Requirements - View presenter', () => {
 })
 
 function _returnVersion () {
+  const contact = ContactModel.fromJson({
+    firstName: 'Annie',
+    middleInitials: 'J',
+    lastName: 'Easley',
+    salutation: 'Mrs'
+  })
+
+  const licence = LicenceModel.fromJson({
+    id: '761bc44f-80d5-49ae-ab46-0a90495417b5',
+    licenceRef: '01/123',
+    licenceDocument: {
+      licenceDocumentRoles: [{
+        id: '3b903973-2143-47fe-b7a2-b205aa8eb933',
+        contact
+      }]
+    }
+  })
+
   return {
     createdAt: new Date('2022-04-05'),
     id: '3f09ce0b-288c-4c0b-b519-7329fe70a6cc',
@@ -282,11 +302,7 @@ function _returnVersion () {
     status: 'current',
     modLogs: [],
     user: { id: 1, username: 'carol.shaw@atari.com' },
-    licence: {
-      id: '761bc44f-80d5-49ae-ab46-0a90495417b5',
-      licenceRef: '01/123',
-      $licenceHolder: () => { return 'Mr Ingles' }
-    },
+    licence,
     returnRequirements: [{
       abstractionPeriodEndDay: 31,
       abstractionPeriodEndMonth: 10,

--- a/test/presenters/return-requirements/view.presenter.test.js
+++ b/test/presenters/return-requirements/view.presenter.test.js
@@ -22,251 +22,249 @@ describe('Return Requirements - View presenter', () => {
     returnVersion = ReturnVersionModel.fromJson(returnVersionData)
   })
 
-  describe('when provided with a return version', () => {
-    it('correctly presents the data', () => {
+  it('correctly presents the data', () => {
+    const result = ViewPresenter.go(returnVersion)
+
+    expect(result).to.equal({
+      additionalSubmissionOptions: {
+        multipleUpload: 'No'
+      },
+      createdBy: 'carol.shaw@atari.com',
+      createdDate: '5 April 2022',
+      licenceId: '761bc44f-80d5-49ae-ab46-0a90495417b5',
+      licenceRef: '01/123',
+      notes: 'A special note',
+      pageTitle: 'Requirements for returns for Mr Ingles',
+      reason: 'New licence',
+      requirements: [
+        {
+          abstractionPeriod: 'From 1 April to 31 October',
+          agreementsExceptions: 'None',
+          frequencyCollected: 'monthly',
+          frequencyReported: 'monthly',
+          points: ['At National Grid Reference SE 4044 7262 (Borehole in top field)'],
+          purposes: ['Spray Irrigation - Direct'],
+          returnReference: 10012345,
+          returnsCycle: 'Winter and all year',
+          siteDescription: 'Borehole in field',
+          title: 'Borehole in field'
+        }
+      ],
+      startDate: '1 April 2022',
+      status: 'current'
+    })
+  })
+
+  describe('the "additionalSubmissionOptions" property', () => {
+    describe('when multipleUpload is true', () => {
+      beforeEach(() => {
+        returnVersion.multipleUpload = true
+      })
+
+      it('returns "Yes"', () => {
+        const result = ViewPresenter.go(returnVersion)
+
+        expect(result.additionalSubmissionOptions.multipleUpload).to.equal('Yes')
+      })
+    })
+
+    describe('when multipleUpload is false', () => {
+      it('returns "No"', () => {
+        const result = ViewPresenter.go(returnVersion)
+
+        expect(result.additionalSubmissionOptions.multipleUpload).to.equal('No')
+      })
+    })
+  })
+
+  describe('the "createdBy" property', () => {
+    describe('when there is no user linked to the return', () => {
+      beforeEach(() => {
+        returnVersion.user = null
+      })
+
+      it('returns "Migrated from NALD" ', () => {
+        const result = ViewPresenter.go(returnVersion)
+
+        expect(result.createdBy).to.equal('Migrated from NALD')
+      })
+    })
+
+    describe('when there is a user linked to the return', () => {
+      it("returns the user's username", () => {
+        const result = ViewPresenter.go(returnVersion)
+
+        expect(result.createdBy).to.equal('carol.shaw@atari.com')
+      })
+    })
+  })
+
+  describe('the "createdDate" property', () => {
+    it('returns created date', () => {
       const result = ViewPresenter.go(returnVersion)
 
-      expect(result).to.equal({
-        additionalSubmissionOptions: {
-          multipleUpload: 'No'
-        },
-        createdBy: 'carol.shaw@atari.com',
-        createdDate: '5 April 2022',
-        licenceId: '761bc44f-80d5-49ae-ab46-0a90495417b5',
-        licenceRef: '01/123',
-        notes: 'A special note',
-        pageTitle: 'Requirements for returns for Mr Ingles',
-        reason: 'New licence',
-        requirements: [
-          {
-            abstractionPeriod: 'From 1 April to 31 October',
-            agreementsExceptions: 'None',
-            frequencyCollected: 'monthly',
-            frequencyReported: 'monthly',
-            points: ['At National Grid Reference SE 4044 7262 (Borehole in top field)'],
-            purposes: ['Spray Irrigation - Direct'],
-            returnReference: 10012345,
-            returnsCycle: 'Winter and all year',
-            siteDescription: 'Borehole in field',
-            title: 'Borehole in field'
-          }
-        ],
-        startDate: '1 April 2022',
-        status: 'current'
-      })
+      expect(result.createdDate).to.equal('5 April 2022')
     })
+  })
 
-    describe('the "additionalSubmissionOptions" property', () => {
-      describe('when multipleUpload is true', () => {
-        beforeEach(() => {
-          returnVersion.multipleUpload = true
-        })
+  describe('the "pageTitle" property', () => {
+    it("returns the title incorporating the licence holder's name", () => {
+      const result = ViewPresenter.go(returnVersion)
 
-        it('returns "Yes"', () => {
-          const result = ViewPresenter.go(returnVersion)
-
-          expect(result.additionalSubmissionOptions.multipleUpload).to.equal('Yes')
-        })
-      })
-
-      describe('when multipleUpload is false', () => {
-        it('returns "No"', () => {
-          const result = ViewPresenter.go(returnVersion)
-
-          expect(result.additionalSubmissionOptions.multipleUpload).to.equal('No')
-        })
-      })
+      expect(result.pageTitle).to.equal('Requirements for returns for Mr Ingles')
     })
+  })
 
-    describe('the "createdBy" property', () => {
-      describe('when there is no user linked to the return', () => {
-        beforeEach(() => {
-          returnVersion.user = null
-        })
-
-        it('returns "Migrated from NALD" ', () => {
-          const result = ViewPresenter.go(returnVersion)
-
-          expect(result.createdBy).to.equal('Migrated from NALD')
-        })
-      })
-
-      describe('when there is a user linked to the return', () => {
-        it("returns the user's username", () => {
-          const result = ViewPresenter.go(returnVersion)
-
-          expect(result.createdBy).to.equal('carol.shaw@atari.com')
-        })
-      })
-    })
-
-    describe('the "createdDate" property', () => {
-      it('returns created date', () => {
+  describe('the "reason" property', () => {
+    describe('when there is a reason', () => {
+      it('returns the formatted reason', () => {
         const result = ViewPresenter.go(returnVersion)
 
-        expect(result.createdDate).to.equal('5 April 2022')
+        expect(result.reason).to.equal('New licence')
       })
     })
 
-    describe('the "pageTitle" property', () => {
-      it("returns the title incorporating the licence holder's name", () => {
+    describe('when there is no reason', () => {
+      beforeEach(() => {
+        returnVersion.reason = null
+      })
+
+      it('returns an empty string', () => {
         const result = ViewPresenter.go(returnVersion)
 
-        expect(result.pageTitle).to.equal('Requirements for returns for Mr Ingles')
+        expect(result.reason).to.equal('')
+      })
+    })
+  })
+
+  describe('the "requirements" property', () => {
+    describe('the requirements "abstractionPeriod" property', () => {
+      it('formats the abstraction period for display', () => {
+        const result = ViewPresenter.go(returnVersion)
+
+        const { abstractionPeriod } = result.requirements[0]
+
+        expect(abstractionPeriod).to.equal('From 1 April to 31 October')
       })
     })
 
-    describe('the "reason" property', () => {
-      describe('when there is a reason', () => {
-        it('returns the formatted reason', () => {
+    describe('the requirements "agreementsExceptions" property', () => {
+      describe('when no agreements or exceptions have been applied', () => {
+        it('returns "None"', () => {
           const result = ViewPresenter.go(returnVersion)
 
-          expect(result.reason).to.equal('New licence')
+          const { agreementsExceptions } = result.requirements[0]
+
+          expect(agreementsExceptions).to.equal('None')
         })
       })
 
-      describe('when there is no reason', () => {
+      describe('when one agreement or exception was applied', () => {
         beforeEach(() => {
-          returnVersion.reason = null
+          returnVersion.returnRequirements[0].gravityFill = true
         })
 
-        it('returns an empty string', () => {
+        it("returns it's display text (Gravity fill)", () => {
           const result = ViewPresenter.go(returnVersion)
 
-          expect(result.reason).to.equal('')
+          const { agreementsExceptions } = result.requirements[0]
+
+          expect(agreementsExceptions).to.equal('Gravity fill')
+        })
+      })
+
+      describe('when two agreements or exceptions were selected', () => {
+        beforeEach(() => {
+          returnVersion.returnRequirements[0].gravityFill = true
+          returnVersion.returnRequirements[0].reabstraction = true
+        })
+
+        it('returns them joined with an "and" (Gravity fill and Transfer re-abstraction scheme)', () => {
+          const result = ViewPresenter.go(returnVersion)
+
+          const { agreementsExceptions } = result.requirements[0]
+
+          expect(agreementsExceptions).to.equal('Gravity fill and Transfer re-abstraction scheme')
+        })
+      })
+
+      describe('when more than two options were selected', () => {
+        beforeEach(() => {
+          returnVersion.returnRequirements[0].fiftySixException = true
+          returnVersion.returnRequirements[0].gravityFill = true
+          returnVersion.returnRequirements[0].reabstraction = true
+          returnVersion.returnRequirements[0].twoPartTariff = true
+        })
+
+        it('returns them joined with an ", and" (Gravity fill, Transfer re-abstraction scheme, Two-part tariff, and 56 returns exception)', () => {
+          const result = ViewPresenter.go(returnVersion)
+
+          const { agreementsExceptions } = result.requirements[0]
+
+          expect(agreementsExceptions).to.equal('Gravity fill, Transfer re-abstraction scheme, Two-part tariff, and 56 returns exception')
         })
       })
     })
 
-    describe('the "requirements" property', () => {
-      describe('the requirements "abstractionPeriod" property', () => {
-        it('formats the abstraction period for display', () => {
+    describe('the requirements "points" property', () => {
+      // Formatting of the points uses GeneralLib.generateAbstractionPointDetail() so testing is 'light' here
+      it('formats the points for display', () => {
+        const result = ViewPresenter.go(returnVersion)
+
+        const { points } = result.requirements[0]
+
+        expect(points).to.equal(['At National Grid Reference SE 4044 7262 (Borehole in top field)'])
+      })
+    })
+
+    describe('the requirements "purposes" property', () => {
+      describe('when a purpose description (alias) was added to the purpose', () => {
+        beforeEach(() => {
+          returnVersion.returnRequirements[0].returnRequirementPurposes[0].alias = 'spray indiscreetly'
+        })
+
+        it('formats the purposes for display with the purpose description in brackets', () => {
           const result = ViewPresenter.go(returnVersion)
 
-          const { abstractionPeriod } = result.requirements[0]
+          const { purposes } = result.requirements[0]
 
-          expect(abstractionPeriod).to.equal('From 1 April to 31 October')
+          expect(purposes).to.equal(['Spray Irrigation - Direct (spray indiscreetly)'])
         })
       })
 
-      describe('the requirements "agreementsExceptions" property', () => {
-        describe('when no agreements or exceptions have been applied', () => {
-          it('returns "None"', () => {
-            const result = ViewPresenter.go(returnVersion)
-
-            const { agreementsExceptions } = result.requirements[0]
-
-            expect(agreementsExceptions).to.equal('None')
-          })
-        })
-
-        describe('when one agreement or exception was applied', () => {
-          beforeEach(() => {
-            returnVersion.returnRequirements[0].gravityFill = true
-          })
-
-          it("returns it's display text (Gravity fill)", () => {
-            const result = ViewPresenter.go(returnVersion)
-
-            const { agreementsExceptions } = result.requirements[0]
-
-            expect(agreementsExceptions).to.equal('Gravity fill')
-          })
-        })
-
-        describe('when two agreements or exceptions were selected', () => {
-          beforeEach(() => {
-            returnVersion.returnRequirements[0].gravityFill = true
-            returnVersion.returnRequirements[0].reabstraction = true
-          })
-
-          it('returns them joined with an "and" (Gravity fill and Transfer re-abstraction scheme)', () => {
-            const result = ViewPresenter.go(returnVersion)
-
-            const { agreementsExceptions } = result.requirements[0]
-
-            expect(agreementsExceptions).to.equal('Gravity fill and Transfer re-abstraction scheme')
-          })
-        })
-
-        describe('when more than two options were selected', () => {
-          beforeEach(() => {
-            returnVersion.returnRequirements[0].fiftySixException = true
-            returnVersion.returnRequirements[0].gravityFill = true
-            returnVersion.returnRequirements[0].reabstraction = true
-            returnVersion.returnRequirements[0].twoPartTariff = true
-          })
-
-          it('returns them joined with an ", and" (Gravity fill, Transfer re-abstraction scheme, Two-part tariff, and 56 returns exception)', () => {
-            const result = ViewPresenter.go(returnVersion)
-
-            const { agreementsExceptions } = result.requirements[0]
-
-            expect(agreementsExceptions).to.equal('Gravity fill, Transfer re-abstraction scheme, Two-part tariff, and 56 returns exception')
-          })
-        })
-      })
-
-      describe('the requirements "points" property', () => {
-        // Formatting of the points uses GeneralLib.generateAbstractionPointDetail() so testing is 'light' here
-        it('formats the points for display', () => {
+      describe('when a purpose description (alias) was not added to the purpose', () => {
+        it('formats the purposes for display with just the default description', () => {
           const result = ViewPresenter.go(returnVersion)
 
-          const { points } = result.requirements[0]
+          const { purposes } = result.requirements[0]
 
-          expect(points).to.equal(['At National Grid Reference SE 4044 7262 (Borehole in top field)'])
+          expect(purposes).to.equal(['Spray Irrigation - Direct'])
+        })
+      })
+    })
+
+    describe('the requirements "returnsCycle" property', () => {
+      describe('when the requirement is for the "summer" returns cycle', () => {
+        beforeEach(() => {
+          returnVersion.returnRequirements[0].summer = true
+        })
+
+        it('formats the cycle for display (Summer)', () => {
+          const result = ViewPresenter.go(returnVersion)
+
+          const { returnsCycle } = result.requirements[0]
+
+          expect(returnsCycle).to.equal('Summer')
         })
       })
 
-      describe('the requirements "purposes" property', () => {
-        describe('when a purpose description (alias) was added to the purpose', () => {
-          beforeEach(() => {
-            returnVersion.returnRequirements[0].returnRequirementPurposes[0].alias = 'spray indiscreetly'
-          })
+      describe('when the requirement is for the "winter-and-all-year" returns cycle', () => {
+        it('formats the cycle for display (Winter and all year)', () => {
+          const result = ViewPresenter.go(returnVersion)
 
-          it('formats the purposes for display with the purpose description in brackets', () => {
-            const result = ViewPresenter.go(returnVersion)
+          const { returnsCycle } = result.requirements[0]
 
-            const { purposes } = result.requirements[0]
-
-            expect(purposes).to.equal(['Spray Irrigation - Direct (spray indiscreetly)'])
-          })
-        })
-
-        describe('when a purpose description (alias) was not added to the purpose', () => {
-          it('formats the purposes for display with just the default description', () => {
-            const result = ViewPresenter.go(returnVersion)
-
-            const { purposes } = result.requirements[0]
-
-            expect(purposes).to.equal(['Spray Irrigation - Direct'])
-          })
-        })
-      })
-
-      describe('the requirements "returnsCycle" property', () => {
-        describe('when the requirement is for the "summer" returns cycle', () => {
-          beforeEach(() => {
-            returnVersion.returnRequirements[0].summer = true
-          })
-
-          it('formats the cycle for display (Summer)', () => {
-            const result = ViewPresenter.go(returnVersion)
-
-            const { returnsCycle } = result.requirements[0]
-
-            expect(returnsCycle).to.equal('Summer')
-          })
-        })
-
-        describe('when the requirement is for the "winter-and-all-year" returns cycle', () => {
-          it('formats the cycle for display (Winter and all year)', () => {
-            const result = ViewPresenter.go(returnVersion)
-
-            const { returnsCycle } = result.requirements[0]
-
-            expect(returnsCycle).to.equal('Winter and all year')
-          })
+          expect(returnsCycle).to.equal('Winter and all year')
         })
       })
     })

--- a/test/presenters/return-requirements/view.presenter.test.js
+++ b/test/presenters/return-requirements/view.presenter.test.js
@@ -131,10 +131,29 @@ describe('Return Requirements - View presenter', () => {
         returnVersion.reason = null
       })
 
-      it('returns an empty string', () => {
-        const result = ViewPresenter.go(returnVersion)
+      describe('and no mod log entries', () => {
+        it('returns an empty string', () => {
+          const result = ViewPresenter.go(returnVersion)
 
-        expect(result.reason).to.equal('')
+          expect(result.reason).to.equal('')
+        })
+      })
+
+      describe('but there is a mod log entry with a reason', () => {
+        beforeEach(() => {
+          returnVersion.modLogs = [{
+            naldDate: new Date('2019-03-01'),
+            note: null,
+            reasonDescription: 'Record loaded during migration',
+            userId: 'TTESTER'
+          }]
+        })
+
+        it('returns reason from the mod log', () => {
+          const result = ViewPresenter.go(returnVersion)
+
+          expect(result.reason).to.equal('Record loaded during migration')
+        })
       })
     })
   })

--- a/test/support/seeders/requirements-for-returns.seeder.js
+++ b/test/support/seeders/requirements-for-returns.seeder.js
@@ -38,10 +38,7 @@ async function seed () {
   const licence = await LicenceHelper.add()
 
   // Create a return version to which we'll link multiple return requirements
-  const returnVersion = await ReturnVersionHelper.add({
-    licenceId: licence.id,
-    createdBy: user.id
-  })
+  const returnVersion = await ReturnVersionHelper.add({ licenceId: licence.id, createdBy: user.id })
 
   // Create the first requirement record
   let returnRequirement = await _returnRequirement(


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4634

In this instance, we felt it was more constructive to provide the feedback for the original [Update view return version to include mod log info](https://github.com/DEFRA/water-abstraction-system/pull/1261) proposed PR as a series of commits from where the code has been left.

This can be used to guide suggested changes, hopefully with better context than just PR comments.