### PR TITLE
Fix JSDOC's lint description and type issues

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -36,14 +36,14 @@ module.exports = {
     'arrow-body-style': ['error', 'always'],
     'import/extensions': ['error', 'always'],
     strict: ['error', 'global'],
-    // 'jsdoc/require-description': 'warn',
-    // 'jsdoc/require-param': 'warn',
-    // 'jsdoc/require-returns': 'warn',
-    // 'jsdoc/check-tag-names': 'warn',
-    // 'jsdoc/check-alignment': 'warn',
-    // 'jsdoc/newline-after-description': 'off', // does not work with 'use strict'
-    // 'jsdoc/check-indentation': 'warn',
-    // 'jsdoc/lines-before-block': 'warn',
+    'jsdoc/require-description': 'warn',
+    'jsdoc/require-param': 'warn',
+    'jsdoc/require-returns': 'warn',
+    'jsdoc/check-tag-names': 'warn',
+    'jsdoc/check-alignment': 'warn',
+    'jsdoc/newline-after-description': 'off', // does not work with 'use strict'
+    'jsdoc/check-indentation': 'warn',
+    'jsdoc/lines-before-block': 'warn',
     'jsdoc/check-types': 'warn',
     'jsdoc/require-hyphen-before-param-description': 'warn'
   }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -51,7 +51,7 @@ module.exports = {
 
 /*
 
-This is the code to enforce agreed conventionsk
+This is the code to enforce agreed conventions
 
 npm packages needed -
     "eslint-plugin-require-sort": "^1.3.0",

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -36,14 +36,14 @@ module.exports = {
     'arrow-body-style': ['error', 'always'],
     'import/extensions': ['error', 'always'],
     strict: ['error', 'global'],
-    'jsdoc/require-description': 'warn',
-    'jsdoc/require-param': 'warn',
-    'jsdoc/require-returns': 'warn',
-    'jsdoc/check-tag-names': 'warn',
-    'jsdoc/check-alignment': 'warn',
-    'jsdoc/newline-after-description': 'off', // does not work with 'use strict'
-    'jsdoc/check-indentation': 'warn',
-    'jsdoc/lines-before-block': 'warn',
+    // 'jsdoc/require-description': 'warn',
+    // 'jsdoc/require-param': 'warn',
+    // 'jsdoc/require-returns': 'warn',
+    // 'jsdoc/check-tag-names': 'warn',
+    // 'jsdoc/check-alignment': 'warn',
+    // 'jsdoc/newline-after-description': 'off', // does not work with 'use strict'
+    // 'jsdoc/check-indentation': 'warn',
+    // 'jsdoc/lines-before-block': 'warn',
     'jsdoc/check-types': 'warn',
     'jsdoc/require-hyphen-before-param-description': 'warn'
   }
@@ -51,7 +51,7 @@ module.exports = {
 
 /*
 
-This is the code to enforce agreed conventions
+This is the code to enforce agreed conventionsk
 
 npm packages needed -
     "eslint-plugin-require-sort": "^1.3.0",

--- a/app/errors/expanded.error.js
+++ b/app/errors/expanded.error.js
@@ -4,8 +4,8 @@ class ExpandedError extends Error {
   /**
    * Custom error that allows additional data properties to be assigned to the error instance
    *
-   * @param {String} message - Message that will be given to the error instance
-   * @param {Object} data - An object containing the additional data properties to be assigned to the error instance
+   * @param {string} message - Message that will be given to the error instance
+   * @param {object} data - An object containing the additional data properties to be assigned to the error instance
    */
   constructor (message, data) {
     super(message)

--- a/app/lib/base-notifier.lib.js
+++ b/app/lib/base-notifier.lib.js
@@ -24,9 +24,9 @@ const AirbrakeConfig = require('../../config/airbrake.config.js')
  * > This is a very 'serious' project dealing with very dry finance and regulation rules. We love what we do but having
  * > the opportunity to use `omg('The bill run looks fantastic!')` in our work day can only help us smile more!
  *
- * @param {Object} [logger] An instance of {@link https://github.com/pinojs/pino|pino}. If 'null' the class will
+ * @param {object} [logger] - An instance of {@link https://github.com/pinojs/pino|pino}. If 'null' the class will
  * create a new instance instead.
- * @param {Object} [notifier] An instance of {@link https://github.com/airbrake/airbrake-js|airbrake-js} `Notifier`
+ * @param {object} [notifier] - An instance of {@link https://github.com/airbrake/airbrake-js|airbrake-js} `Notifier`
  * which our 'AirbrakePlugin` adds to Hapi. If 'null' the class will create a new instance instead.
  */
 class BaseNotifierLib {
@@ -40,8 +40,8 @@ class BaseNotifierLib {
    *
    * The message will be added as an `INFO` level log message.
    *
-   * @param {string} message Message to add to the log (INFO)
-   * @param {Object} [data={}] An object containing any values to be logged, for example, a bill run ID to be included
+   * @param {string} message - Message to add to the log (INFO)
+   * @param {object} [data={}] - An object containing any values to be logged, for example, a bill run ID to be included
    *  with the log message. Defaults to an empty object
    */
   omg (message, data = {}) {
@@ -74,10 +74,10 @@ class BaseNotifierLib {
    * notifier.omfg('Bill run failed to generate.', { id: billRun.id })
    * ```
    *
-   * @param {string} message Message to add to the log (ERROR)
-   * @param {Object} [data={}] An object containing any values to be logged and sent in the notification to Errbit, for
-   *  example, a bill run ID. Defaults to an empty object
-   * @param {Error} [error=null] An instance of the error to be logged and sent to Errbit. If no error is provided one
+   * @param {string} message - Message to add to the log (ERROR)
+   * @param {object} [data={}] - An object containing any values to be logged and sent in the notification to Errbit,
+   * for example, a bill run ID. Defaults to an empty object
+   * @param {Error} [error=null] - An instance of the error to be logged and sent to Errbit. If no error is provided one
    *  will be created using `message` as the error message
    */
   omfg (message, data = {}, error = null) {
@@ -177,7 +177,7 @@ class BaseNotifierLib {
    * Returns an instance of {@link https://github.com/pinojs/pino|Pino} the logger our dependency Hapi-pino brings in.
    * We can then call `info()` and `error()` on it in order to create our log entries.
    *
-   * @param {Object} [logger] An instance of {@link https://github.com/pinojs/pino|pino}. If 'null' the method will
+   * @param {object} [logger] - An instance of {@link https://github.com/pinojs/pino|pino}. If 'null' the method will
    * create a new instance.
    */
   _setLogger (logger) {
@@ -194,7 +194,7 @@ class BaseNotifierLib {
    * Returns an instance of {@link https://github.com/airbrake/airbrake-js|airbrake-js} `Notifier` which when called
    * with `notify()` will record errors in our Errbit instance.
    *
-   * @param {Object} [notifier] An instance of the {@link https://github.com/airbrake/airbrake-js|airbrake-js}
+   * @param {object} [notifier] - An instance of the {@link https://github.com/airbrake/airbrake-js|airbrake-js}
    * `Notifier`. If 'null' the class will create a new instance instead.
    */
   _setNotifier (notifier) {

--- a/app/lib/general.lib.js
+++ b/app/lib/general.lib.js
@@ -27,7 +27,7 @@ const { randomUUID } = require('crypto')
  *
  * @param {bigint} startTime - the time the process started in nanoseconds
  * @param {string} message - the message to log
- * @param {Object} [data] - additional data to include with the log output
+ * @param {object} [data] - additional data to include with the log output
  */
 function calculateAndLogTimeTaken (startTime, message, data = {}) {
   const endTime = currentTimeInNanoseconds()
@@ -74,7 +74,7 @@ function currentTimeInNanoseconds () {
  * We often need to work out what the start and end date for the current financial year is. But because the financial
  * year starts on 01-APR and finishes on 31-MAR what that year is will change dependent on the current date.
  *
- * @returns {Object} An object containing a `startDate` and `endDate`
+ * @returns {object} An object containing a `startDate` and `endDate`
  */
 function determineCurrentFinancialYear () {
   const currentDate = new Date()
@@ -103,7 +103,7 @@ function determineCurrentFinancialYear () {
  *
  * This function adds a key/value to 'notification' in yar.
  *
- * @param {Object} yar - The Hapi `request.yar` session manager passed on by the controller
+ * @param {object} yar - The Hapi `request.yar` session manager passed on by the controller
  * @param {string} [title='Updated'] - title for the notification
  * @param {string} [text='Changes made'] - text for the notification
  *
@@ -122,9 +122,9 @@ function flashNotification (yar, title = 'Updated', text = 'Changes made') {
  * Nation Grid References are saved against the abstraction point. This function checks for these references and builds
  * a string that defines the details of the abstraction point.
  *
- * @param {Object} pointDetail - Object containing all the details for the point
+ * @param {object} pointDetail - Object containing all the details for the point
  *
- * @returns {String} a description of the abstraction point
+ * @returns {string} a description of the abstraction point
  */
 function generateAbstractionPointDetail (pointDetail) {
   let abstractionPoint = null
@@ -161,9 +161,9 @@ function generateAbstractionPointDetail (pointDetail) {
  *
  * This follows the same out put as generateAbstractionPointDetail but the points have already been merged
  *
- * @param {Object} pointDetail - Object containing all the details for the point
+ * @param {object} pointDetail - Object containing all the details for the point
  *
- * @returns {String} a description of the abstraction point
+ * @returns {string} a description of the abstraction point
  */
 function generatePointDetail (pointDetail) {
   let abstractionPoint = null
@@ -205,7 +205,7 @@ function generatePointDetail (pointDetail) {
  *
  * https://nodejs.org/api/crypto.html#cryptorandomuuidoptions
  *
- * @returns {String} a randomly generated UUID
+ * @returns {string} a randomly generated UUID
  */
 function generateUUID () {
   return randomUUID({ disableEntropyCache: true })
@@ -234,8 +234,8 @@ function generateUUID () {
  * Else, having compared all the `checkPeriods` against each `referencePeriod` and finding no overlaps the function will
  * return false.
  *
- * @param {Object[]} referencePeriods Each period is an object containing a `startDate` and `endDate` property
- * @param {Object[]} checkPeriods Each period is an object containing a `startDate` and `endDate` property. These
+ * @param {object[]} referencePeriods - Each period is an object containing a `startDate` and `endDate` property
+ * @param {object[]} checkPeriods - Each period is an object containing a `startDate` and `endDate` property. These
  * periods will be checked against the `referencePeriods for any overlaps
  *
  * @returns {boolean} Returns true if there _any_ check period overlaps with a reference period, else false
@@ -300,8 +300,8 @@ function timestampForPostgres () {
  * - Additional charges - supportedSourceName
  * - Additional charges - waterCompanyCharge
  *
- * @param {Object} left - First transaction to match
- * @param {Object} right - Second transaction to match
+ * @param {object} left - First transaction to match
+ * @param {object} right - Second transaction to match
  *
  * @returns {boolean} true if a match else false
  */

--- a/app/lib/legacy-db-snake-case-mappers.lib.js
+++ b/app/lib/legacy-db-snake-case-mappers.lib.js
@@ -29,7 +29,7 @@ const { camelCase, knexIdentifierMappers, snakeCase } = require('objection/lib/u
  * It simply looks for the value 'crm_v2' and when seen, returns it as is without any formatting. For everything else,
  * it passes control to the out-of-the-box solution.
  *
- * @param {Object} opt Object containing options used by
+ * @param {object} opt - Object containing options used by
  *  {@link https://vincit.github.io/objection.js/api/objection/#knexsnakecasemappers|knexsnakecasemappers()}
  *
  * @returns object containing Knex postProcessResponse() and wrapIdentifier() hooks

--- a/app/lib/request-notifier.lib.js
+++ b/app/lib/request-notifier.lib.js
@@ -23,11 +23,11 @@ class RequestNotifierLib extends BaseNotifierLib {
   /**
    * Instantiate a new instance
    *
-   * @param {string} id The request ID taken from a {@link https://hapi.dev/api/?v=20.1.2#request|Hapi request}
+   * @param {string} id - The request ID taken from a {@link https://hapi.dev/api/?v=20.1.2#request|Hapi request}
    * instance. Used to link notifications to the requests that generated them
-   * @param {Object} logger An instance of {@link https://github.com/pinojs/pino|pino}, a Node JSON logger
+   * @param {object} logger - An instance of {@link https://github.com/pinojs/pino|pino}, a Node JSON logger
    * which the {@link https://github.com/pinojs/hapi-pino|hapi-pino} plugin adds to Hapi
-   * @param {Object} notifier An instance of the {@link https://github.com/airbrake/airbrake-js|airbrake-js} `notify()`
+   * @param {object} notifier - An instance of the {@link https://github.com/airbrake/airbrake-js|airbrake-js} `notify()`
    * method which our 'AirbrakePlugin` adds to Hapi
    */
   constructor (id, logger, notifier) {

--- a/app/models/contact.model.js
+++ b/app/models/contact.model.js
@@ -81,7 +81,7 @@ class ContactModel extends BaseModel {
    * single `customerName` value. What we have implemented here replicates what the legacy code was doing to derive
    * what that name should be.
    *
-   * @returns {String} The name for the contact derived from its various parts
+   * @returns {string} The name for the contact derived from its various parts
    */
   $name () {
     if (this.contactType === 'department') {

--- a/app/models/licence-version-purpose.model.js
+++ b/app/models/licence-version-purpose.model.js
@@ -115,7 +115,7 @@ class LicenceVersionPurposeModel extends BaseModel {
    * This information is used when we have to generate return requirements from the current abstraction data and
    * determine what collection and reporting frequency to use.
    *
-   * @returns {Boolean} true if the overall purpose is electricity generation (P-ELC-240 or P-ELC-200) else false
+   * @returns {boolean} true if the overall purpose is electricity generation (P-ELC-240 or P-ELC-200) else false
    */
   $electricityGeneration () {
     if (this.primaryPurpose.legacyId !== 'P') {

--- a/app/models/session.model.js
+++ b/app/models/session.model.js
@@ -44,7 +44,7 @@ class SessionModel extends BaseModel {
    * We think this makes working with the `SessionModel` the same as working with the normal, structured model
    * instances.
    *
-   * @param {Object} _queryContext - Objection.js query context which we do not use
+   * @param {object} _queryContext - Objection.js query context which we do not use
    */
   $afterFind (_queryContext) {
     for (const [key, value] of Object.entries(this.data)) {
@@ -73,7 +73,7 @@ class SessionModel extends BaseModel {
    * Ignoring `id` and the timestamps, this method extracts all the other properties on the instance into an object
    * then calls `patch({ data: currentData })`, saving calling modules the trouble!
    *
-   * @returns {Promise<Number>} - the number of affected rows. In our case this will always be 1!
+   * @returns {Promise<number>} - the number of affected rows. In our case this will always be 1!
    */
   async $update () {
     const { id, createdAt, data, updatedAt, ...currentData } = this

--- a/app/plugins/views.plugin.js
+++ b/app/plugins/views.plugin.js
@@ -57,8 +57,8 @@ const ViewsPlugin = {
  *
  * Tl;DR; It the object we pass to Vision `compile:` must be a function that returns a function :-)
  *
- * @param {string} template The content of the template
- * @param {Object} options Vision's `config.compileOptions` property which we assign the Nunjucks Environment instance
+ * @param {string} template - The content of the template
+ * @param {object} options - Vision's `config.compileOptions` property which we assign the Nunjucks Environment instance
  * to in `prepare()` below
  */
 function compile (template, options) {
@@ -84,9 +84,9 @@ function compile (template, options) {
  *
  * > Credit to https://www.solarwinter.net/hapi-vision-and-who-am-i/ for highlighting we could do this
  *
- * @param {Object} request Instance of a Hapi {@link https://hapi.dev/api/?v=21.3.2#request Request}
+ * @param {object} request - Instance of a Hapi {@link https://hapi.dev/api/?v=21.3.2#request Request}
  *
- * @returns {Object} the global context for all templates
+ * @returns {object} the global context for all templates
  */
 function context (request) {
   return {
@@ -118,9 +118,9 @@ function context (request) {
  * Nunjucks, require or can be configured. If `prepare:` is in the plugin options Vision will call it as part of
  * its initialisation so you can configure your chosen view engine.
  *
- * @param {*} config The engine configuration object allowing updates to be made. This is useful for engines like
+ * @param {*} config - The engine configuration object allowing updates to be made. This is useful for engines like
  * Nunjucks that rely on additional state for rendering
- * @param {*} next Has the signature `function(err)`
+ * @param {*} next - Has the signature `function(err)`
  *
  * @returns the result of calling `next()`
  */
@@ -150,10 +150,10 @@ function prepare (config, next) {
  * Some users are also eligible to see a 'Contact information' link, which allows them to set their contact details
  * which will be used when generating, for example, renewal notifications.
  *
- * @param {Object} auth The `auth` property added to each Hapi request by the `AuthPlugin`. It tells us whether a user
+ * @param {object} auth - The `auth` property added to each Hapi request by the `AuthPlugin`. It tells us whether a user
  * is authenticated and what scopes (permissions) they have
  *
- * @returns {Object[]} if the user is authenticated navigation links to display in the top-level GOV.UK header
+ * @returns {object[]} if the user is authenticated navigation links to display in the top-level GOV.UK header
  */
 function _navigationLinks (auth) {
   if (!auth.isAuthenticated) {

--- a/app/presenters/base.presenter.js
+++ b/app/presenters/base.presenter.js
@@ -6,9 +6,9 @@
  * This is such a simply calculation it could be done in place. But by having it as a named method we make it clear
  * what we are doing rather than those that follow having to derive the intent.
  *
- * @param {Number} value
+ * @param {number} value
  *
- * @returns {Number} the value divided by 100
+ * @returns {number} the value divided by 100
  */
 function convertPenceToPounds (value) {
   return value / 100
@@ -37,8 +37,8 @@ function generateBillRunTitle (regionName, batchType, scheme, summer) {
 /**
  * Formats an abstraction day and month into its string variant, for example, 1 and 4 becomes '1 April'
  *
- * @param {Number} abstractionDay
- * @param {Number} abstractionMonth Note: the index starts at 1, for example, 4 would be April
+ * @param {number} abstractionDay
+ * @param {number} abstractionMonth - Note: the index starts at 1, for example, 4 would be April
  *
  * @returns {string} The abstraction date formatted as a 'DD MMMM' string
  */
@@ -53,10 +53,10 @@ function formatAbstractionDate (abstractionDay, abstractionMonth) {
 /**
  * Formats an abstraction period into its string variant, for example, '1 April to 31 October'
  *
- * @param {Number} startDay
- * @param {Number} startMonth
- * @param {Number} endDay
- * @param {Number} endMonth
+ * @param {number} startDay
+ * @param {number} startMonth
+ * @param {number} endDay
+ * @param {number} endMonth
  *
  * @returns {string} The abstraction period formatted as a 'DD MMMM to DD MMMM' string
  */
@@ -95,7 +95,7 @@ function formatBillRunType (batchType, scheme, summer) {
 /**
  * Converts a date into the format required by the Charging Module, eg 25/03/2021 becomes 25-MAR-2021
  *
- * @param {Date} date The date to be formatted
+ * @param {Date} date - The date to be formatted
  *
  * @returns {string} The date formatted as a 'DD-MMM-YYYY' string
  */
@@ -145,7 +145,7 @@ function formatFinancialYear (financialYearEnding) {
 /**
  * Formats a date into a human readable day, month and year string, for example, '12 September 2021'
  *
- * @param {Date} date The date to be formatted
+ * @param {Date} date - The date to be formatted
  *
  * @returns {string} The date formatted as a 'DD MMMM YYYY' string
  */
@@ -156,7 +156,7 @@ function formatLongDate (date) {
 /**
  * Formats a date into a human readable day, month, year and time string, for example, '12 September 2021 at 21:43:44'
  *
- * @param {Date} date The date to be formatted
+ * @param {Date} date - The date to be formatted
  *
  * @returns {string} The date formatted as a 'DD MMMM YYYY at HH:MM:SS' string
  */
@@ -179,8 +179,8 @@ function formatLongDateTime (date) {
  *
  * > Credit to https://stackoverflow.com/a/32154217/6117745 for showing numbers with commas
  *
- * @param {Number} valueInPence The value (in pence) to display as money
- * @param {Boolean} signed Whether to add the - sign to the start of the returned string if valueInPence is negative
+ * @param {number} valueInPence - The value (in pence) to display as money
+ * @param {boolean} signed - Whether to add the - sign to the start of the returned string if valueInPence is negative
  *
  * @returns {string} The value formatted as a money string with commas and currency symbol plus optional sign
  */
@@ -201,7 +201,7 @@ function formatMoney (valueInPence, signed = false) {
 /**
  * Formats a number, which represents a value in pence to pounds, for example, 12776805 as '127768.05'
  *
- * @param {*} valueInPence The value to be formatted to pounds
+ * @param {*} valueInPence - The value to be formatted to pounds
  *
  * @returns {string} The value converted to pounds and formatted to two decimal places
  */
@@ -214,8 +214,8 @@ function formatPounds (valueInPence) {
 /**
  * Pads a number to a given length with leading zeroes and returns the result as a string
  *
- * @param {Number} number The number to be padded
- * @param {Number} length How many characters in length the final string should be
+ * @param {number} number - The number to be padded
+ * @param {number} length - How many characters in length the final string should be
  *
  * @returns {string} The number padded with zeros to the specified length
  */

--- a/app/presenters/bill-licences/remove-bill-licence.presenter.js
+++ b/app/presenters/bill-licences/remove-bill-licence.presenter.js
@@ -19,7 +19,7 @@ const {
  *
  * @param {module:BillLicenceModel} billLicence - an instance of `BillLicenceModel` with associated billing data
  *
- * @returns {Object} - the prepared bill licence summary data to be passed to the confirm remove a bill licence page
+ * @returns {object} - the prepared bill licence summary data to be passed to the confirm remove a bill licence page
  */
 function go (billLicence) {
   const { id: billLicenceId, bill, licenceRef, transactions } = billLicence

--- a/app/presenters/bill-licences/view-bill-licence.presenter.js
+++ b/app/presenters/bill-licences/view-bill-licence.presenter.js
@@ -13,10 +13,10 @@ const ViewStandardChargeTransactionPresenter = require('./view-standard-charge-t
 /**
  * Formats data for a bill licence including its transactions into what is needed for the bill-licence page
  *
- * @param {module:BillLicenceModel} billLicence an instance of `BillLicence` with linked bill, bill run and
+ * @param {module:BillLicenceModel} billLicence - an instance of `BillLicence` with linked bill, bill run and
  * transactions
  *
- * @returns {Object} a formatted representation of the bill licence and its transactions specifically for the
+ * @returns {object} a formatted representation of the bill licence and its transactions specifically for the
  * view bill-licence page
  */
 function go (billLicence) {

--- a/app/presenters/bill-licences/view-compensation-charge-transaction.presenter.js
+++ b/app/presenters/bill-licences/view-compensation-charge-transaction.presenter.js
@@ -12,10 +12,10 @@ const { formatLongDate, formatMoney } = require('../base.presenter.js')
  *
  * The format of the object the presenter returns will differ depending on the scheme the transaction is for.
  *
- * @param {module:TransactionModel} transaction an instance of `TransactionModel` that represents a compensation charge
- * transaction
+ * @param {module:TransactionModel} transaction - an instance of `TransactionModel` that represents a compensation
+ * charge transaction
  *
- * @returns {Object} a formatted representation of the transaction specifically for the bill-licence page
+ * @returns {object} a formatted representation of the transaction specifically for the bill-licence page
  */
 function go (transaction) {
   if (transaction.scheme === 'sroc') {

--- a/app/presenters/bill-licences/view-minimum-charge-transaction.presenter.js
+++ b/app/presenters/bill-licences/view-minimum-charge-transaction.presenter.js
@@ -10,10 +10,10 @@ const { formatMoney } = require('../base.presenter.js')
 /**
  * Formats data for minimum charge transaction for the bill-licence page
  *
- * @param {module:TransactionModel} transaction an instance of `TransactionModel` that represents a minimum charge
+ * @param {module:TransactionModel} transaction - an instance of `TransactionModel` that represents a minimum charge
  * transaction
  *
- * @returns {Object} a formatted representation of the transaction specifically for the bill-licence page
+ * @returns {object} a formatted representation of the transaction specifically for the bill-licence page
  */
 function go (transaction) {
   const {

--- a/app/presenters/bill-licences/view-standard-charge-transaction.presenter.js
+++ b/app/presenters/bill-licences/view-standard-charge-transaction.presenter.js
@@ -18,10 +18,10 @@ const {
  *
  * The format of the object the presenter returns will differ depending on the scheme the transaction is for.
  *
- * @param {module:TransactionModel} transaction an instance of `TransactionModel` that represents a compensation charge
- * transaction
+ * @param {module:TransactionModel} transaction - an instance of `TransactionModel` that represents a compensation
+ * charge transaction
  *
- * @returns {Object} a formatted representation of the transaction specifically for the bill-licence page
+ * @returns {object} a formatted representation of the transaction specifically for the bill-licence page
  */
 function go (transaction) {
   if (transaction.scheme === 'sroc') {

--- a/app/presenters/bill-runs/cancel-bill-run.presenter.js
+++ b/app/presenters/bill-runs/cancel-bill-run.presenter.js
@@ -18,7 +18,7 @@ const {
  *
  * @param {module:BillRunModel} billRun - an instance of `BillRunModel`
  *
- * @returns {Object} - the prepared bill run data to be passed to the cancel bill run confirmation page
+ * @returns {object} - the prepared bill run data to be passed to the cancel bill run confirmation page
  */
 function go (billRun) {
   const {

--- a/app/presenters/bill-runs/create-bill-run.presenter.js
+++ b/app/presenters/bill-runs/create-bill-run.presenter.js
@@ -11,9 +11,9 @@
  * Because the legacy code does not use our views of the legacy data, the response needs to be formatted to use the
  * legacy field names.
  *
- * @param {module:BillRunModel} billRun An instance of the newly created bill run
+ * @param {module:BillRunModel} billRun - An instance of the newly created bill run
  *
- * @returns {Object} the formatted response
+ * @returns {object} the formatted response
  */
 function go (billRun) {
   const {

--- a/app/presenters/bill-runs/empty-bill-run-presenter.js
+++ b/app/presenters/bill-runs/empty-bill-run-presenter.js
@@ -19,7 +19,7 @@ const {
  *
  * @param {module:BillRunModel} billRun - an instance of `BillRunModel`
  *
- * @returns {Object} - the prepared bill run data to be passed to the empty bill run page
+ * @returns {object} - the prepared bill run data to be passed to the empty bill run page
  */
 function go (billRun) {
   const {

--- a/app/presenters/bill-runs/errored-bill-run-presenter.js
+++ b/app/presenters/bill-runs/errored-bill-run-presenter.js
@@ -19,7 +19,7 @@ const {
  *
  * @param {module:BillRunModel} billRun - an instance of `BillRunModel`
  *
- * @returns {Object} - the prepared bill run data to be passed to the errored bill run page
+ * @returns {object} - the prepared bill run data to be passed to the errored bill run page
  */
 function go (billRun) {
   const {

--- a/app/presenters/bill-runs/index-bill-runs.presenter.js
+++ b/app/presenters/bill-runs/index-bill-runs.presenter.js
@@ -17,7 +17,7 @@ const {
  *
  * @param {module:BillRunModel[]} billRuns - The bill runs containing the data to be summarised for the view
  *
- * @returns {Object[]} Each bill run summary formatted for use in the `index.njk` template for `/bill-runs`
+ * @returns {object[]} Each bill run summary formatted for use in the `index.njk` template for `/bill-runs`
  */
 function go (billRuns) {
   return billRuns.map((billRun) => {

--- a/app/presenters/bill-runs/send-bill-run.presenter.js
+++ b/app/presenters/bill-runs/send-bill-run.presenter.js
@@ -18,7 +18,7 @@ const {
  *
  * @param {module:BillRunModel} billRun - an instance of `BillRunModel`
  *
- * @returns {Object} - the prepared bill run data to be passed to the send bill run confirmation page
+ * @returns {object} - the prepared bill run data to be passed to the send bill run confirmation page
  */
 function go (billRun) {
   const {

--- a/app/presenters/bill-runs/setup/create.presenter.js
+++ b/app/presenters/bill-runs/setup/create.presenter.js
@@ -21,7 +21,7 @@ const LAST_PRESROC_YEAR = 2022
  * @param {module:SessionModel} session - The session instance for the setup bill run journey
  * @param {module:BillRunModel} billRun - The matching instance of `BillRunModel` to the setup options selected
  *
- * @returns {Object} - The data formatted for the view template
+ * @returns {object} - The data formatted for the view template
  */
 function go (session, billRun) {
   const {

--- a/app/presenters/bill-runs/setup/region.presenter.js
+++ b/app/presenters/bill-runs/setup/region.presenter.js
@@ -11,7 +11,7 @@
  * @param {module:SessionModel} session - The session instance to format
  * @param {module:RegionsModel[]} regions - UUID and display name of all regions
  *
- * @returns {Object} - The data formatted for the view template
+ * @returns {object} - The data formatted for the view template
  */
 function go (session, regions) {
   return {

--- a/app/presenters/bill-runs/setup/season.presenter.js
+++ b/app/presenters/bill-runs/setup/season.presenter.js
@@ -10,7 +10,7 @@
  *
  * @param {module:SessionModel} session - The session instance to format
  *
- * @returns {Object} - The data formatted for the view template
+ * @returns {object} - The data formatted for the view template
  */
 function go (session) {
   return {

--- a/app/presenters/bill-runs/setup/type.presenter.js
+++ b/app/presenters/bill-runs/setup/type.presenter.js
@@ -10,7 +10,7 @@
  *
  * @param {module:SessionModel} session - The session instance to format
  *
- * @returns {Object} - The data formatted for the view template
+ * @returns {object} - The data formatted for the view template
  */
 function go (session) {
   return {

--- a/app/presenters/bill-runs/setup/year.presenter.js
+++ b/app/presenters/bill-runs/setup/year.presenter.js
@@ -10,7 +10,7 @@
  *
  * @param {module:SessionModel} session - The session instance to format
  *
- * @returns {Object} - The data formatted for the view template
+ * @returns {object} - The data formatted for the view template
  */
 function go (session) {
   return {

--- a/app/presenters/bill-runs/two-part-tariff/amend-adjustment-factor.presenter.js
+++ b/app/presenters/bill-runs/two-part-tariff/amend-adjustment-factor.presenter.js
@@ -12,9 +12,9 @@ const { formatLongDate, formatFinancialYear } = require('../../base.presenter.js
  *
  * @param {module:BillRunModel} billRun - the data from the bill run
  * @param {module:ReviewChargeReference} reviewChargeReference - the data from the review charge reference
- * @param {String} licenceId - the UUID of the licence being reviewed
+ * @param {string} licenceId - the UUID of the licence being reviewed
  *
- * @returns {Object} the prepared bill run and charge reference data to be passed to the amend adjustment factor page
+ * @returns {object} the prepared bill run and charge reference data to be passed to the amend adjustment factor page
  */
 function go (billRun, reviewChargeReference, licenceId) {
   return {

--- a/app/presenters/bill-runs/two-part-tariff/amend-authorised-volume.presenter.js
+++ b/app/presenters/bill-runs/two-part-tariff/amend-authorised-volume.presenter.js
@@ -12,9 +12,9 @@ const { formatLongDate, formatFinancialYear } = require('../../base.presenter.js
  *
  * @param {module:BillRunModel} billRun - the data from the bill run
  * @param {module:ReviewChargeReference} reviewChargeReference - the data from the review charge reference
- * @param {String} licenceId - the UUID of the licence being reviewed
+ * @param {string} licenceId - the UUID of the licence being reviewed
  *
- * @returns {Object} the prepared bill run and charge reference data to be passed to the amend authorised volume page
+ * @returns {object} the prepared bill run and charge reference data to be passed to the amend authorised volume page
  */
 function go (billRun, reviewChargeReference, licenceId) {
   return {

--- a/app/presenters/bill-runs/two-part-tariff/amend-billable-returns.presenter.js
+++ b/app/presenters/bill-runs/two-part-tariff/amend-billable-returns.presenter.js
@@ -13,9 +13,9 @@ const { formatLongDate } = require('../../base.presenter.js')
  *
  * @param {module:BillRunModel} billRun - the data from the bill run
  * @param {module:ReviewChargeElement} reviewChargeElement - the data from the review charge element
- * @param {String} licenceId - the UUID of the licence being reviewed
+ * @param {string} licenceId - the UUID of the licence being reviewed
  *
- * @returns {Object} the prepared bill run and charge element data to be passed to the edit billable returns page
+ * @returns {object} the prepared bill run and charge element data to be passed to the edit billable returns page
  */
 function go (billRun, reviewChargeElement, licenceId) {
   return {

--- a/app/presenters/bill-runs/two-part-tariff/charge-reference-details.presenter.js
+++ b/app/presenters/bill-runs/two-part-tariff/charge-reference-details.presenter.js
@@ -14,9 +14,9 @@ const { formatLongDate, formatFinancialYear } = require('../../base.presenter.js
  *
  * @param {module:BillRunModel} billRun - the data from the bill run
  * @param {module:ReviewChargeReference} reviewChargeReference - the data from the review charge reference
- * @param {String} licenceId - the UUID of the licence the charge reference is linked to
+ * @param {string} licenceId - the UUID of the licence the charge reference is linked to
  *
- * @returns {Object} the prepared bill run and charge reference data to be passed to the charge reference details page
+ * @returns {object} the prepared bill run and charge reference data to be passed to the charge reference details page
  */
 function go (billRun, reviewChargeReference, licenceId) {
   const { hasAggregateOrChargeFactor, adjustments } = _adjustments(reviewChargeReference)

--- a/app/presenters/bill-runs/two-part-tariff/match-details.presenter.js
+++ b/app/presenters/bill-runs/two-part-tariff/match-details.presenter.js
@@ -13,9 +13,9 @@ const { formatAbstractionPeriod, formatLongDate } = require('../../base.presente
  *
  * @param {module:BillRunModel} billRun - the data from the bill run
  * @param {module:ReviewChargeElement} reviewChargeElement - the data from the review charge element
- * @param {String} licenceId - the UUID of the licence the charge element is linked to
+ * @param {string} licenceId - the UUID of the licence the charge element is linked to
  *
- * @returns {Object} the prepared bill run and charge element data to be passed to the match details page
+ * @returns {object} the prepared bill run and charge element data to be passed to the match details page
  */
 function go (billRun, reviewChargeElement, licenceId) {
   return {

--- a/app/presenters/bill-runs/two-part-tariff/remove-bill-run-licence.presenter.js
+++ b/app/presenters/bill-runs/two-part-tariff/remove-bill-run-licence.presenter.js
@@ -14,7 +14,7 @@ const { formatFinancialYear, formatLongDate } = require('../../base.presenter.js
  * @param {string} licenceId - UUID of the licence to remove from the bill run
  * @param {string} licenceRef - the licence reference of the licence to remove from the bill run
  *
- * @returns {Object} - the prepared data to be passed to the remove licence template
+ * @returns {object} - the prepared data to be passed to the remove licence template
  */
 function go (billRun, licenceId, licenceRef) {
   const { billRunNumber, createdAt, region, status, toFinancialYearEnding } = billRun

--- a/app/presenters/bill-runs/two-part-tariff/review-bill-run.presenter.js
+++ b/app/presenters/bill-runs/two-part-tariff/review-bill-run.presenter.js
@@ -10,19 +10,19 @@ const { formatLongDate } = require('../../base.presenter.js')
 /**
  * Prepares and processes bill run, licence and filter data for presentation
  *
- * @param {module:BillRunModel} billRun The data from the bill run
- * @param {{Object[]}} filterIssues An array of issues to filter the results by. This will only contain data when
+ * @param {module:BillRunModel} billRun - The data from the bill run
+ * @param {{Object[]}} filterIssues - An array of issues to filter the results by. This will only contain data when
  * there is a POST request, which only occurs when a filter is applied to the results. NOTE: if there is only a single
  * issue this will be a string, not an array
- * @param {String} filterLicenceHolderNumber The licence holder or licence number to filter the results by. This will
+ * @param {string} filterLicenceHolderNumber - The licence holder or licence number to filter the results by. This will
  * only contain data when there is a POST request, which only occurs when a filter is applied to the results.
- * @param {String} filterLicenceStatus The status of the licence to filter the results by. This also only contains data
+ * @param {string} filterLicenceStatus - The status of the licence to filter the results by. This also only contains
+ * data when there is a POST request.
+ * @param {string} filterProgress - The progress of the licence to filter the results by. This also only contains data
  * when there is a POST request.
- * @param {String} filterProgress The progress of the licence to filter the results by. This also only contains data
- * when there is a POST request.
- * @param {module:LicenceModel} licences The licences data associated with the bill run
+ * @param {module:LicenceModel} licences - The licences data associated with the bill run
  *
- * @returns {Object} The prepared bill run,licence and filter data to be passed to the review page
+ * @returns {object} The prepared bill run,licence and filter data to be passed to the review page
  */
 function go (billRun, filterIssues, filterLicenceHolderNumber, filterLicenceStatus, filterProgress, licences) {
   const preparedLicences = _prepareLicences(licences)

--- a/app/presenters/bill-runs/two-part-tariff/review-licence.presenter.js
+++ b/app/presenters/bill-runs/two-part-tariff/review-licence.presenter.js
@@ -16,7 +16,7 @@ const { formatAbstractionPeriod, formatLongDate } = require('../../base.presente
  * @param {module:BillRunModel} billRun - the data from the bill run
  * @param {module:ReviewLicenceModel} licence - the data from review licence
  *
- * @returns {Object} the prepared bill run and licence data to be passed to the review licence page
+ * @returns {object} the prepared bill run and licence data to be passed to the review licence page
  */
 function go (billRun, licence) {
   return {

--- a/app/presenters/bills/remove-bill.presenter.js
+++ b/app/presenters/bills/remove-bill.presenter.js
@@ -19,7 +19,7 @@ const {
  *
  * @param {module:BillModel} bill - an instance of `BillModel` with associated billing data
  *
- * @returns {Object} - the prepared bill summary data to be passed to the confirm remove a bill page
+ * @returns {object} - the prepared bill summary data to be passed to the confirm remove a bill page
  */
 function go (bill) {
   const { id: billId, billingAccount, billLicences, billRun } = bill

--- a/app/presenters/charging-module/create-customer-change.presenter.js
+++ b/app/presenters/charging-module/create-customer-change.presenter.js
@@ -44,15 +44,15 @@
  *
  * Anything set to null the Charging Module API will set to `null` in the record it sends to SSCL.
  *
- * @param {module:BillingAccountModel} billingAccount the billing account having its address changed
+ * @param {module:BillingAccountModel} billingAccount - the billing account having its address changed
  * (required)
- * @param {module:AddressModel} address the address it is being changed to (required)
- * @param {module:CompanyModel} company the agent company selected or created during the process (if the user made no
+ * @param {module:AddressModel} address - the address it is being changed to (required)
+ * @param {module:CompanyModel} company - the agent company selected or created during the process (if the user made no
  * change to the agent company this should be an unset instance)
- * @param {module:ContactModel} contact the contact created during the process (if the user did not create an FAO this
+ * @param {module:ContactModel} contact - the contact created during the process (if the user did not create an FAO this
  * should be an unset instance)
  *
- * @returns {Object} the request data needed in the format required by the Charging Module
+ * @returns {object} the request data needed in the format required by the Charging Module
  */
 function go (billingAccount, address, company, contact) {
   const { accountNumber: customerReference } = billingAccount
@@ -142,8 +142,8 @@ function _formattedAddress (address, contact) {
 /**
  * Truncates a string adding an ellipsis at the end to indicate that the string has been shortened
  *
- * @param {string} stringToTruncate The string to be truncated
- * @param {number} maximumLength The maximum length to the truncated string
+ * @param {string} stringToTruncate - The string to be truncated
+ * @param {number} maximumLength - The maximum length to the truncated string
  *
  * @returns {string} - The truncated string.
  */

--- a/app/presenters/charging-module/create-transaction.presenter.js
+++ b/app/presenters/charging-module/create-transaction.presenter.js
@@ -5,12 +5,12 @@ const { formatChargingModuleDate } = require('../base.presenter.js')
 /**
  * Formats a transaction as a Charging Module API transaction request
  *
- * @param {Object} transaction the transaction object
- * @param {Object} billingPeriod The billing period of the transaction
- * @param {string} accountNumber known as the customer reference in the Charging Module API
- * @param {module:LicenceModel} licence an instance of LicenceModel
+ * @param {object} transaction - the transaction object
+ * @param {object} billingPeriod - The billing period of the transaction
+ * @param {string} accountNumber - known as the customer reference in the Charging Module API
+ * @param {module:LicenceModel} licence - an instance of LicenceModel
  *
- * @returns {Object} an object to be used as the body in a Charging Module POST transaction request
+ * @returns {object} an object to be used as the body in a Charging Module POST transaction request
  */
 function go (transaction, accountNumber, licence) {
   const periodStart = formatChargingModuleDate(transaction.startDate)

--- a/app/presenters/licences/communications.presenter.js
+++ b/app/presenters/licences/communications.presenter.js
@@ -10,7 +10,7 @@ const { formatLongDate, sentenceCase } = require('../base.presenter.js')
 /**
  * Formats data for the `/licences/{id}/communications` view licence communications page
  *
- * @returns {Object} The data formatted for the view template
+ * @returns {object} The data formatted for the view template
  */
 function go (communications) {
   return {

--- a/app/presenters/licences/customer-contacts.presenter.js
+++ b/app/presenters/licences/customer-contacts.presenter.js
@@ -10,11 +10,11 @@ const ContactModel = require('../../models/contact.model.js')
 /**
  * Formats data for the `/licences/{id}/contact-details` view customer contact details page
  *
- * @param {Object[]} customerContacts - The results from `FetchCustomerContactsService` to be formatted for the view
+ * @param {object[]} customerContacts - The results from `FetchCustomerContactsService` to be formatted for the view
  * template
  *
- * @returns {Object} The data formatted for the view template
- * @returns {Object} The data formatted for the view template
+ * @returns {object} The data formatted for the view template
+ * @returns {object} The data formatted for the view template
  */
 function go (customerContacts) {
   return {

--- a/app/presenters/licences/licence-contacts.presenter.js
+++ b/app/presenters/licences/licence-contacts.presenter.js
@@ -8,7 +8,7 @@
 /**
  * Formats data for the `/licences/{id}/contact-details` view licence contact details page
  *
- * @returns {Object} The data formatted for the view template
+ * @returns {object} The data formatted for the view template
  */
 function go (contacts) {
   return {

--- a/app/presenters/licences/set-up.presenter.js
+++ b/app/presenters/licences/set-up.presenter.js
@@ -31,10 +31,10 @@ const agreementDescriptions = {
  * @param {module:WorkflowModel[]} workflows - All in-progress workflow records for the licence
  * @param {module:LicenceAgreementModel[]} agreements - All agreements records for the licence
  * @param {module:ReturnVersionModel[]} returnVersions - All returns version records for the licence
- * @param {Object} auth - The auth object taken from `request.auth` containing user details
- * @param {Object} commonData - Licence data already formatted for the view's shared elements
+ * @param {object} auth - The auth object taken from `request.auth` containing user details
+ * @param {object} commonData - Licence data already formatted for the view's shared elements
  *
- * @returns {Object} The data formatted for the view template
+ * @returns {object} The data formatted for the view template
  */
 function go (chargeVersions, workflows, agreements, returnVersions, auth, commonData) {
   const enableRequirementsForReturns = FeatureFlagsConfig.enableRequirementsForReturns

--- a/app/presenters/licences/view-licence-bills.presenter.js
+++ b/app/presenters/licences/view-licence-bills.presenter.js
@@ -10,7 +10,7 @@ const { formatBillRunType, formatLongDate, formatMoney } = require('../base.pres
 /**
  * Formats data for the `/licences/{id}/bills` view licence bill page
  *
- * @returns {Object} The data formatted for the view template
+ * @returns {object} The data formatted for the view template
  */
 function go (bills) {
   return {

--- a/app/presenters/licences/view-licence-returns.presenter.js
+++ b/app/presenters/licences/view-licence-returns.presenter.js
@@ -13,7 +13,7 @@ const { formatLongDate } = require('../base.presenter.js')
  * @param {module:ReturnLogModel[]} returnLogs - The results from `FetchLicenceReturnsService` to be formatted
  * @param {boolean} hasRequirements - True if the licence has return requirements else false
  *
- * @returns {Object} The data formatted for the view template
+ * @returns {object} The data formatted for the view template
  */
 function go (returnLogs, hasRequirements) {
   const returns = _returns(returnLogs)

--- a/app/presenters/licences/view-licence-summary.presenter.js
+++ b/app/presenters/licences/view-licence-summary.presenter.js
@@ -13,7 +13,7 @@ const { generateAbstractionPointDetail } = require('../../lib/general.lib.js')
  *
  * @param {module:LicenceModel} licence - The licence the summary data will be extracted from
  *
- * @returns {Object} The data formatted for the view template
+ * @returns {object} The data formatted for the view template
  */
 function go (licence) {
   const {

--- a/app/presenters/licences/view-licence.presenter.js
+++ b/app/presenters/licences/view-licence.presenter.js
@@ -12,7 +12,7 @@ const { formatLongDate } = require('../base.presenter.js')
  *
  * @param {module:LicenceModel} licence - The licence where the data will be extracted for from
  *
- * @returns {Object} The data formatted for the view template
+ * @returns {object} The data formatted for the view template
  */
 function go (licence, auth) {
   const {

--- a/app/presenters/paginator.presenter.js
+++ b/app/presenters/paginator.presenter.js
@@ -106,7 +106,7 @@ const COMPLEX_END_PAGINATOR = 'end'
  * @param {number} selectedPageNumber - the page of results selected for viewing
  * @param {string} path - the URL path the paginator should use, for example, `'/system/bill-runs'`
  *
- * @returns {Object} if no pagination is needed just the `numberOfPages` is returned else a `component:` property is
+ * @returns {object} if no pagination is needed just the `numberOfPages` is returned else a `component:` property is
  * also included that can be directly passed to the `govukPagination()` in the view.
  */
 function go (numberOfRecords, selectedPageNumber, path) {

--- a/app/presenters/return-requirements/abstraction-period.presenter.js
+++ b/app/presenters/return-requirements/abstraction-period.presenter.js
@@ -11,7 +11,7 @@
  * @param {module:SessionModel} session - The returns requirements session instance
  * @param {string} requirementIndex - The index of the requirement being added or changed
  *
- * @returns {Object} - The data formatted for the view template
+ * @returns {object} - The data formatted for the view template
  */
 function go (session, requirementIndex) {
   const { id: sessionId, licence, requirements } = session

--- a/app/presenters/return-requirements/additional-submission-options.presenter.js
+++ b/app/presenters/return-requirements/additional-submission-options.presenter.js
@@ -10,7 +10,7 @@
  *
  * @param {module:SessionModel} session - The returns requirements session instance
  *
- * @returns {Object} - The data formatted for the view template
+ * @returns {object} - The data formatted for the view template
  */
 function go (session) {
   const { id: sessionId, licence: { id: licenceId, licenceRef }, additionalSubmissionOptions } = session

--- a/app/presenters/return-requirements/agreements-exceptions.presenter.js
+++ b/app/presenters/return-requirements/agreements-exceptions.presenter.js
@@ -11,7 +11,7 @@
  * @param {module:SessionModel} session - The returns requirements session instance
  * @param {string} requirementIndex - The index of the requirement being added or changed
  *
- * @returns {Object} - The data formatted for the view template
+ * @returns {object} - The data formatted for the view template
  */
 function go (session, requirementIndex) {
   const { id: sessionId, licence, requirements } = session

--- a/app/presenters/return-requirements/cancel.presenter.js
+++ b/app/presenters/return-requirements/cancel.presenter.js
@@ -13,7 +13,7 @@ const { returnRequirementFrequencies, returnRequirementReasons } = require('../.
  *
  * @param {module:SessionModel} session - The returns requirements session instance
  *
- * @returns {Object} - The data formatted for the view template
+ * @returns {object} - The data formatted for the view template
  */
 function go (session) {
   const { id: sessionId, journey, licence, reason, requirements } = session

--- a/app/presenters/return-requirements/check/returns-requirements.presenter.js
+++ b/app/presenters/return-requirements/check/returns-requirements.presenter.js
@@ -20,11 +20,11 @@ const agreementsExceptionsText = {
 /**
  * Formats return requirements data for the `/return-requirements/{sessionId}/check` page
  *
- * @param {Object[]} requirements - The existing return requirements in the current session
- * @param {Object[]} points - The points related to the licence
+ * @param {object[]} requirements - The existing return requirements in the current session
+ * @param {object[]} points - The points related to the licence
  * @param {string} journey - Whether the setup journey is 'no-returns-required' or 'returns-required'
  *
- * @returns {Object} returns requirement data needed by the view template
+ * @returns {object} returns requirement data needed by the view template
  */
 
 function go (requirements, points, journey) {

--- a/app/presenters/return-requirements/existing.presenter.js
+++ b/app/presenters/return-requirements/existing.presenter.js
@@ -13,7 +13,7 @@ const { returnRequirementReasons } = require('../../lib/static-lookups.lib.js')
  *
  * @param {module:SessionModel} session - The returns requirements session instance
  *
- * @returns {Object} The data formatted for the view template
+ * @returns {object} The data formatted for the view template
  */
 function go (session) {
   const { id: sessionId, licence } = session

--- a/app/presenters/return-requirements/frequency-collected.presenter.js
+++ b/app/presenters/return-requirements/frequency-collected.presenter.js
@@ -11,7 +11,7 @@
  * @param {module:SessionModel} session - The returns requirements session instance
  * @param {string} requirementIndex - The index of the requirement being added or changed
  *
- * @returns {Object} - The data formatted for the view template
+ * @returns {object} - The data formatted for the view template
  */
 function go (session, requirementIndex) {
   const { id: sessionId, licence, requirements } = session

--- a/app/presenters/return-requirements/frequency-reported.presenter.js
+++ b/app/presenters/return-requirements/frequency-reported.presenter.js
@@ -11,7 +11,7 @@
  * @param {module:SessionModel} session - The returns requirements session instance
  * @param {string} requirementIndex - The index of the requirement being added or changed
  *
- * @returns {Object} - The data formatted for the view template
+ * @returns {object} - The data formatted for the view template
  */
 function go (session, requirementIndex) {
   const { id: sessionId, licence, requirements } = session

--- a/app/presenters/return-requirements/no-returns-required.presenter.js
+++ b/app/presenters/return-requirements/no-returns-required.presenter.js
@@ -10,7 +10,7 @@
  *
  * @param {module:SessionModel} session - The returns requirements session instance
  *
- * @returns {Object} - The data formatted for the view template
+ * @returns {object} - The data formatted for the view template
  */
 function go (session) {
   const { id: sessionId, licence, reason } = session

--- a/app/presenters/return-requirements/note.presenter.js
+++ b/app/presenters/return-requirements/note.presenter.js
@@ -10,7 +10,7 @@
  *
  * @param {module:SessionModel} session - The returns requirements session instance
  *
- * @returns {Object} The data formatted for the view template
+ * @returns {object} The data formatted for the view template
  */
 function go (session) {
   const { id: sessionId, licence, note } = session

--- a/app/presenters/return-requirements/points.presenter.js
+++ b/app/presenters/return-requirements/points.presenter.js
@@ -12,9 +12,9 @@ const { generateAbstractionPointDetail } = require('../../lib/general.lib.js')
  *
  * @param {module:SessionModel} session - The returns requirements session instance
  * @param {string} requirementIndex - The index of the requirement being added or changed
- * @param {Object[]} pointsData - The points data from the licence
+ * @param {object[]} pointsData - The points data from the licence
  *
- * @returns {Object} - The data formatted for the view template
+ * @returns {object} - The data formatted for the view template
  */
 function go (session, requirementIndex, pointsData) {
   const { id: sessionId, licence, requirements } = session

--- a/app/presenters/return-requirements/purpose.presenter.js
+++ b/app/presenters/return-requirements/purpose.presenter.js
@@ -12,7 +12,7 @@
  * @param {string} requirementIndex - The index of the requirement being added or changed
  * @param {module:PurposeModel[]} licencePurposes - All the purposes for the licence
  *
- * @returns {Object} - The data formatted for the view template
+ * @returns {object} - The data formatted for the view template
  */
 function go (session, requirementIndex, licencePurposes) {
   const { id: sessionId, licence, requirements } = session

--- a/app/presenters/return-requirements/reason.presenter.js
+++ b/app/presenters/return-requirements/reason.presenter.js
@@ -10,7 +10,7 @@
  *
  * @param {module:SessionModel} session - The returns requirements session instance
  *
- * @returns {Object} The data formatted for the view template
+ * @returns {object} The data formatted for the view template
  */
 function go (session) {
   const { id: sessionId, licence, reason } = session

--- a/app/presenters/return-requirements/remove.presenter.js
+++ b/app/presenters/return-requirements/remove.presenter.js
@@ -14,7 +14,7 @@ const { returnRequirementFrequencies } = require('../../lib/static-lookups.lib.j
  * @param {module:SessionModel} session - The returns requirements session instance
  * @param {string} requirementIndex - The index of the requirement being added or changed
  *
- * @returns {Object} - The data formatted for the view template
+ * @returns {object} - The data formatted for the view template
  */
 function go (session, requirementIndex) {
   const { id: sessionId, licence, requirements } = session

--- a/app/presenters/return-requirements/returns-cycle.presenter.js
+++ b/app/presenters/return-requirements/returns-cycle.presenter.js
@@ -11,7 +11,7 @@
  * @param {module:SessionModel} session - The returns requirements session instance
  * @param {string} requirementIndex - The index of the requirement being added or changed
  *
- * @returns {Object} - The data formatted for the view template
+ * @returns {object} - The data formatted for the view template
  */
 function go (session, requirementIndex) {
   const { id: sessionId, licence, requirements } = session

--- a/app/presenters/return-requirements/setup.presenter.js
+++ b/app/presenters/return-requirements/setup.presenter.js
@@ -10,7 +10,7 @@
  *
  * @param {module:SessionModel} session - The returns requirements session instance
  *
- * @returns {Object} - The data formatted for the view template
+ * @returns {object} - The data formatted for the view template
  */
 function go (session) {
   const { id: sessionId, licence, setup } = session

--- a/app/presenters/return-requirements/site-description.presenter.js
+++ b/app/presenters/return-requirements/site-description.presenter.js
@@ -11,7 +11,7 @@
  * @param {module:SessionModel} session - The returns requirements session instance
  * @param {string} requirementIndex - The index of the requirement being added or changed
  *
- * @returns {Object} - The data formatted for the view template
+ * @returns {object} - The data formatted for the view template
  */
 function go (session, requirementIndex) {
   const { id: sessionId, licence, requirements } = session

--- a/app/presenters/return-requirements/start-date.presenter.js
+++ b/app/presenters/return-requirements/start-date.presenter.js
@@ -13,7 +13,7 @@ const { formatLongDate } = require('../base.presenter.js')
  *
  * @param {module:SessionModel} session - The returns requirements session instance
  *
- * @returns {Object} The data formatted for the view template
+ * @returns {object} The data formatted for the view template
  */
 function go (session) {
   const {

--- a/app/presenters/return-requirements/view.presenter.js
+++ b/app/presenters/return-requirements/view.presenter.js
@@ -16,7 +16,7 @@ const { returnRequirementReasons, returnRequirementFrequencies } = require('../.
  * @param {ReturnVersionModel[]} returnVersion - The return version and associated, licence, and return requirements
  * (requirement, points, purposes) returned by FetchRequirementsForReturns
  *
- * @returns {Object} requirements for returns data needed by the view template
+ * @returns {object} requirements for returns data needed by the view template
  */
 
 function go (returnVersion) {

--- a/app/requests/base.request.js
+++ b/app/requests/base.request.js
@@ -21,7 +21,7 @@ const requestConfig = require('../../config/request.config.js')
  * Sinon to stub `requestConfig`; the const appeared to have its values fixed when the file was required, whereas a
  * function generates its values each time it's called.
  *
- * @returns {Object} default options to pass to Got when making a request
+ * @returns {object} default options to pass to Got when making a request
  */
 function defaultOptions () {
   return {
@@ -74,9 +74,9 @@ function defaultOptions () {
  * > Note: This function has been called `deleteRequest` here rather than `delete` as `delete` is a reserved word.
  *
  * @param {string} url - The full URL that you wish to connect to
- * @param {Object} additionalOptions - Append to or replace the options passed to Got when making the request
+ * @param {object} additionalOptions - Append to or replace the options passed to Got when making the request
  *
- * @returns {Promise<Object>} The result of the request; whether it succeeded and the response or error returned
+ * @returns {Promise<object>} The result of the request; whether it succeeded and the response or error returned
  */
 async function deleteRequest (url, additionalOptions = {}) {
   return _sendRequest('delete', url, additionalOptions)
@@ -99,9 +99,9 @@ async function deleteRequest (url, additionalOptions = {}) {
  * be a Got error instance.
  *
  * @param {string} url - The full URL that you wish to connect to
- * @param {Object} additionalOptions - Append to or replace the options passed to Got when making the request
+ * @param {object} additionalOptions - Append to or replace the options passed to Got when making the request
  *
- * @returns {Promise<Object>} The result of the request; whether it succeeded and the response or error returned
+ * @returns {Promise<object>} The result of the request; whether it succeeded and the response or error returned
  */
 async function get (url, additionalOptions = {}) {
   return _sendRequest('get', url, additionalOptions)
@@ -140,9 +140,9 @@ async function _importGot () {
  * we need to diagnose the problem.
  *
  * @param {string} method - the type of request made, for example, 'GET', 'POST, or 'PATCH'
- * @param {Object} result - the result object we generate
+ * @param {object} result - the result object we generate
  * @param {string} url - the requested url
- * @param {Object} additionalOptions - any additional options that were passed to Got by the calling service
+ * @param {object} additionalOptions - any additional options that were passed to Got by the calling service
  */
 function _logFailure (method, result, url, additionalOptions) {
   const data = {
@@ -174,7 +174,7 @@ function _logFailure (method, result, url, additionalOptions) {
  *
  * Those that use this module can add to, extend or replace the options we pass to Got when a request is made.
  *
- * @param {Object} additionalOptions - Object of custom options
+ * @param {object} additionalOptions - Object of custom options
  */
 function _requestOptions (additionalOptions) {
   return { ...defaultOptions(), ...additionalOptions }

--- a/app/requests/charging-module.request.js
+++ b/app/requests/charging-module.request.js
@@ -17,7 +17,7 @@ const servicesConfig = require('../../config/services.config.js')
  *
  * @param {string} path - The path to send the request to (do not include the starting /)
  *
- * @returns {Promise<Object>} An object representing the result of the request
+ * @returns {Promise<object>} An object representing the result of the request
  */
 async function deleteRequest (path) {
   const result = await _sendRequest(path, BaseRequest.delete)
@@ -30,7 +30,7 @@ async function deleteRequest (path) {
  *
  * @param {string} path - The route to send the request to (do not include the starting /)
  *
- * @returns {Promise<Object>} An object representing the result of the request
+ * @returns {Promise<object>} An object representing the result of the request
  */
 async function get (path) {
   const result = await _sendRequest(path, BaseRequest.get)
@@ -43,7 +43,7 @@ async function get (path) {
  *
  * @param {string} path - The path to send the request to (do not include the starting /)
  *
- * @returns {Promise<Object>} An object representing the result of the request
+ * @returns {Promise<object>} An object representing the result of the request
  */
 async function patch (path) {
   const result = await _sendRequest(path, BaseRequest.patch)
@@ -55,9 +55,9 @@ async function patch (path) {
  * Sends a POST request to the Charging Module for the provided path
  *
  * @param {string} path - The path to send the request to (do not include the starting /)
- * @param {Object} [body] - The body of the request
+ * @param {object} [body] - The body of the request
  *
- * @returns {Promise<Object>} An object representing the result of the request
+ * @returns {Promise<object>} An object representing the result of the request
  */
 async function post (path, body = {}) {
   const result = await _sendRequest(path, BaseRequest.post, body)

--- a/app/requests/charging-module/calculate-charge.request.js
+++ b/app/requests/charging-module/calculate-charge.request.js
@@ -13,9 +13,9 @@ const ChargingModuleRequest = require('../charging-module.request.js')
  * See {@link https://defra.github.io/sroc-charging-module-api-docs/#/calculate/CalculateCharge | API docs} for
  * more details
  *
- * @param {Object} transactionData - The transaction details to be sent in the body of the request
+ * @param {object} transactionData - The transaction details to be sent in the body of the request
  *
- * @returns {Promise<Object>} The result of the request; whether it succeeded and the response or error returned
+ * @returns {Promise<object>} The result of the request; whether it succeeded and the response or error returned
  */
 async function send (transactionData) {
   const path = 'v3/wrls/calculate-charge'

--- a/app/requests/charging-module/create-bill-run.request.js
+++ b/app/requests/charging-module/create-bill-run.request.js
@@ -17,7 +17,7 @@ const ChargingModuleRequest = require('../charging-module.request.js')
  * @param {string} regionId - The UUID of the region the bill run is to be created for
  * @param {string} ruleset - The ruleset that the bill run is to be created for, either `sroc` or `presroc`
  *
- * @returns {Promise<Object>} The result of the request; whether it succeeded and the response or error returned
+ * @returns {Promise<object>} The result of the request; whether it succeeded and the response or error returned
  */
 async function send (regionId, ruleset) {
   const region = await _getChargeRegionId(regionId)

--- a/app/requests/charging-module/create-customer-change.request.js
+++ b/app/requests/charging-module/create-customer-change.request.js
@@ -13,9 +13,9 @@ const ChargingModuleRequest = require('../charging-module.request.js')
  * See {@link https://defra.github.io/sroc-charging-module-api-docs/#/customer/CreateCustomerChange | API docs} for more
  * details
  *
- * @param {Object} customerChangeData - The customer change details to be sent in the body of the request
+ * @param {object} customerChangeData - The customer change details to be sent in the body of the request
  *
- * @returns {Promise<Object>} The result of the request; whether it succeeded and the response or error returned
+ * @returns {Promise<object>} The result of the request; whether it succeeded and the response or error returned
  */
 async function send (customerChangeData) {
   const path = 'v3/wrls/customer-changes'

--- a/app/requests/charging-module/create-transaction.request.js
+++ b/app/requests/charging-module/create-transaction.request.js
@@ -14,9 +14,9 @@ const ChargingModuleRequest = require('../charging-module.request.js')
  * more details
  *
  * @param {string} billRunId - UUID of the Charging Module API bill run the new bills will be assigned to
- * @param {Object} transactionData - The transaction details to be sent in the body of the request
+ * @param {object} transactionData - The transaction details to be sent in the body of the request
  *
- * @returns {Promise<Object>} The result of the request; whether it succeeded and the response or error returned
+ * @returns {Promise<object>} The result of the request; whether it succeeded and the response or error returned
  */
 async function send (billRunId, transactionData) {
   const path = `v3/wrls/bill-runs/${billRunId}/transactions`

--- a/app/requests/charging-module/delete-bill-run.request.js
+++ b/app/requests/charging-module/delete-bill-run.request.js
@@ -15,7 +15,7 @@ const ChargingModuleRequest = require('../charging-module.request.js')
  *
  * @param {string} billRunId - UUID of the Charging Module API bill run to delete
  *
- * @returns {Promise<Object>} The result of the request; whether it succeeded and the response or error returned
+ * @returns {Promise<object>} The result of the request; whether it succeeded and the response or error returned
  */
 async function send (billRunId) {
   const path = `v3/wrls/bill-runs/${billRunId}`

--- a/app/requests/charging-module/generate-bill-run.request.js
+++ b/app/requests/charging-module/generate-bill-run.request.js
@@ -15,7 +15,7 @@ const ChargingModuleRequest = require('../charging-module.request.js')
  *
  * @param {string} billRunId - UUID of the Charging Module API bill run to generate
  *
- * @returns {Promise<Object>} The result of the request; whether it succeeded and the response or error returned
+ * @returns {Promise<object>} The result of the request; whether it succeeded and the response or error returned
  */
 async function send (billRunId) {
   const path = `v3/wrls/bill-runs/${billRunId}/generate`

--- a/app/requests/charging-module/reissue-bill.request.js
+++ b/app/requests/charging-module/reissue-bill.request.js
@@ -15,10 +15,10 @@ const ChargingModuleRequest = require('../charging-module.request.js')
  * See {@link https://defra.github.io/sroc-charging-module-api-docs/#/bill-run/RebillBillRunInvoice | CHA API docs} for
  * more details
  *
- * @param {String} billRunId - UUID of the Charging Module API bill run the new bills will be assigned to
- * @param {String} billId - UUID of the Charging Module the bill to be reissued
+ * @param {string} billRunId - UUID of the Charging Module API bill run the new bills will be assigned to
+ * @param {string} billId - UUID of the Charging Module the bill to be reissued
  *
- * @returns {Promise<Object>} The result of the request; whether it succeeded and the response or error returned
+ * @returns {Promise<object>} The result of the request; whether it succeeded and the response or error returned
 */
 async function send (billRunId, billId) {
   const path = `v3/wrls/bill-runs/${billRunId}/invoices/${billId}/rebill`

--- a/app/requests/charging-module/send-bill-run.request.js
+++ b/app/requests/charging-module/send-bill-run.request.js
@@ -31,7 +31,7 @@ const WaitForStatusRequest = require('./wait-for-status.request.js')
  *
  * @param {string} billRunId - UUID of the charging module API bill run to send
  *
- * @returns {Promise<Object>} the promise returned is not intended to resolve to any particular value
+ * @returns {Promise<object>} the promise returned is not intended to resolve to any particular value
  */
 async function send (billRunId) {
   await _approve(billRunId)

--- a/app/requests/charging-module/token.request.js
+++ b/app/requests/charging-module/token.request.js
@@ -12,7 +12,7 @@ const servicesConfig = require('../../../config/services.config.js')
 /**
  * Connects with the Charging Module API's Cognito service to get a JWT for authentication
  *
- * @returns {Promise<Object>} An object containing the `accessToken:` to use in future Charging Module requests
+ * @returns {Promise<object>} An object containing the `accessToken:` to use in future Charging Module requests
  */
 async function send () {
   const url = new URL('/oauth2/token', servicesConfig.chargingModule.token.url)

--- a/app/requests/charging-module/view-bill-run-status.request.js
+++ b/app/requests/charging-module/view-bill-run-status.request.js
@@ -15,7 +15,7 @@ const ChargingModuleRequest = require('../charging-module.request.js')
  *
  * @param {string} billRunId - UUID of the Charging Module API bill run to view the status of
  *
- * @returns {Promise<Object>} The result of the request; whether it succeeded and the response or error returned
+ * @returns {Promise<object>} The result of the request; whether it succeeded and the response or error returned
  */
 async function send (billRunId) {
   const path = `v3/wrls/bill-runs/${billRunId}/status`

--- a/app/requests/charging-module/view-bill-run.request.js
+++ b/app/requests/charging-module/view-bill-run.request.js
@@ -15,7 +15,7 @@ const ChargingModuleRequest = require('../../requests/charging-module.request.js
  *
  * @param {string} billRunId - UUID of the charging module API bill run to view
  *
- * @returns {Promise<Object>} The result of the request; whether it succeeded and the response or error returned
+ * @returns {Promise<object>} The result of the request; whether it succeeded and the response or error returned
  */
 async function send (billRunId) {
   const path = `v3/wrls/bill-runs/${billRunId}`

--- a/app/requests/charging-module/view-bill.request.js
+++ b/app/requests/charging-module/view-bill.request.js
@@ -13,10 +13,10 @@ const ChargingModuleRequest = require('../charging-module.request.js')
  * See {@link https://defra.github.io/sroc-charging-module-api-docs/#/bill-run/ViewBillRunInvoice | API docs} for more
  * details
  *
- * @param {String} billRunId - UUID of the Charging Module API bill run the bill is on
- * @param {String} billId - UUID of the Charging Module bill to view
+ * @param {string} billRunId - UUID of the Charging Module API bill run the bill is on
+ * @param {string} billId - UUID of the Charging Module bill to view
  *
- * @returns {Promise<Object>} The result of the request; whether it succeeded and the response or error returned
+ * @returns {Promise<object>} The result of the request; whether it succeeded and the response or error returned
 */
 async function send (billRunId, billId) {
   const path = `v3/wrls/bill-runs/${billRunId}/invoices/${billId}`

--- a/app/requests/charging-module/wait-for-status.request.js
+++ b/app/requests/charging-module/wait-for-status.request.js
@@ -43,7 +43,7 @@ const billingConfig = require('../../../config/billing.config.js')
  * @param {string[]} statusesToWaitFor - Array of statuses to wait for, for example, `['billed', 'billing_not_required]`
  * @param {number} [maximumAttempts] - Number of times to check the status before giving up. Defaults to 120
  *
- * @returns {Promise<Object>} returns the results of the wait
+ * @returns {Promise<object>} returns the results of the wait
  */
 async function send (billRunId, statusesToWaitFor, maximumAttempts = 120) {
   let attempts = 0

--- a/app/requests/legacy.request.js
+++ b/app/requests/legacy.request.js
@@ -69,7 +69,7 @@ const services = {
  * @param {boolean} [apiRequest] - Whether the request is to the service's API endpoints (JSON response) or web (HTML
  * response). Defaults to true
  *
- * @returns {Promise<Object>} An object representing the result of the request
+ * @returns {Promise<object>} An object representing the result of the request
  */
 async function deleteRequest (serviceName, path, userId = null, apiRequest = true) {
   return _sendRequest(BaseRequest.delete, serviceName, path, userId, apiRequest)
@@ -86,7 +86,7 @@ async function deleteRequest (serviceName, path, userId = null, apiRequest = tru
  * @param {boolean} [apiRequest] - Whether the request is to the service's API endpoints (JSON response) or web (HTML
  * response). Defaults to true
  *
- * @returns {Promise<Object>} An object representing the result of the request
+ * @returns {Promise<object>} An object representing the result of the request
  */
 async function get (serviceName, path, userId = null, apiRequest = true) {
   return _sendRequest(BaseRequest.get, serviceName, path, userId, apiRequest)
@@ -95,16 +95,16 @@ async function get (serviceName, path, userId = null, apiRequest = true) {
 /**
  * Sends a POST request to the legacy service for the provided path
  *
- * @param {string} serviceName name of the legacy service to call (background, crm, external, idm, import, internal,
+ * @param {string} serviceName - name of the legacy service to call (background, crm, external, idm, import, internal,
  * permits, reporting, returns or water)
  * @param {string} path - The path to send the request to (do not include the starting /)
  * @param {string} [userId] - If the legacy endpoint needs to check a user's authorisation their ID to be added as a
  * header. Defaults to null
  * @param {boolean} [apiRequest] - Whether the request is to the service's API endpoints (JSON response) or web (HTML
  * response). Defaults to true
- * @param {Object} [body] - Data to be sent in the request body to the service as JSON
+ * @param {object} [body] - Data to be sent in the request body to the service as JSON
  *
- * @returns {Promise<Object>} An object representing the result of the request
+ * @returns {Promise<object>} An object representing the result of the request
  */
 async function post (serviceName, path, userId = null, apiRequest = true, body = {}) {
   return _sendRequest(BaseRequest.post, serviceName, path, userId, apiRequest, body)

--- a/app/requests/legacy/create-bill-run.request.js
+++ b/app/requests/legacy/create-bill-run.request.js
@@ -18,7 +18,7 @@ const LegacyRequest = require('../legacy.request.js')
  * @param {boolean} [summer] - Only relates to two-part tariff. In PRESROC 2PT bill runs were split by summer or winter
  * and all-year. This tells the legacy engine which kind of 2PT bill run to generate
  *
- * @returns {Promise<Object>} The result of the request; whether it succeeded and the response or error returned
+ * @returns {Promise<object>} The result of the request; whether it succeeded and the response or error returned
  */
 async function send (batchType, regionId, financialYearEnding, user, summer = false) {
   const { id: userId, username: userEmail } = user

--- a/app/requests/legacy/delete-bill-licence.request.js
+++ b/app/requests/legacy/delete-bill-licence.request.js
@@ -22,7 +22,7 @@ const LegacyRequest = require('../legacy.request.js')
  * @param {string} billLicenceId - UUID of the bill licence to be removed
  * @param {module:UserModel} user - Instance representing the user that originated the request
  *
- * @returns {Promise<Object>} The result of the request; whether it succeeded and the response or error returned
+ * @returns {Promise<object>} The result of the request; whether it succeeded and the response or error returned
  */
 async function send (billLicenceId, user) {
   const { id: userId } = user

--- a/app/requests/legacy/delete-bill.request.js
+++ b/app/requests/legacy/delete-bill.request.js
@@ -23,7 +23,7 @@ const LegacyRequest = require('../legacy.request.js')
  * @param {string} billId - UUID of the bill to be removed
  * @param {module:UserModel} user - Instance representing the user that originated the request
  *
- * @returns {Promise<Object>} The result of the request; whether it succeeded and the response or error returned
+ * @returns {Promise<object>} The result of the request; whether it succeeded and the response or error returned
  */
 async function send (billRunId, billId, user) {
   const { id: userId } = user

--- a/app/requests/legacy/refresh-bill-run.request.js
+++ b/app/requests/legacy/refresh-bill-run.request.js
@@ -19,7 +19,7 @@ const LegacyRequest = require('../legacy.request.js')
  *
  * @param {string} billRunId - UUID of the bill run to refresh
  *
- * @returns {Promise<Object>} The result of the request; whether it succeeded and the response or error returned
+ * @returns {Promise<object>} The result of the request; whether it succeeded and the response or error returned
  */
 async function send (billRunId) {
   const path = `billing/batches/${billRunId}/refresh`

--- a/app/services/bill-licences/fetch-bill-licence-summary.service.js
+++ b/app/services/bill-licences/fetch-bill-licence-summary.service.js
@@ -18,7 +18,7 @@ const BillLicenceModel = require('../../models/bill-licence.model.js')
  *
  * @param {string} billLicenceId - The UUID for the bill licence to fetch a summary of
  *
- * @returns {Promise<Object>} the matching instance of BillLicenceModel plus the linked bill, billing account and bill
+ * @returns {Promise<object>} the matching instance of BillLicenceModel plus the linked bill, billing account and bill
  * run. Also all transactions linked to the bill licence so we can work out the total for the licence
  */
 async function go (billLicenceId) {

--- a/app/services/bill-licences/fetch-bill-licence.service.js
+++ b/app/services/bill-licences/fetch-bill-licence.service.js
@@ -14,9 +14,9 @@ const BillLicenceModel = require('../../models/bill-licence.model.js')
  *
  * Was built to provide the data needed for the '/bill-licences/{id}' page
  *
- * @param {string} id The UUID for the bill licence to fetch
+ * @param {string} id - The UUID for the bill licence to fetch
  *
- * @returns {Promise<Object>} the matching instance of BillLicenceModel plus the linked bill and bill run. Also all
+ * @returns {Promise<object>} the matching instance of BillLicenceModel plus the linked bill and bill run. Also all
  * transactions linked to the bill licence and their linked charge reference details
  */
 async function go (id) {

--- a/app/services/bill-licences/remove-bill-licence.service.js
+++ b/app/services/bill-licences/remove-bill-licence.service.js
@@ -13,7 +13,7 @@ const RemoveBillLicencePresenter = require('../../presenters/bill-licences/remov
  *
  * @param {string} billLicenceId - The UUID for the bill licence to remove
  *
- * @returns {Promise<Object>} a formatted representation of the bill licence, its bill, billing account and the bill run
+ * @returns {Promise<object>} a formatted representation of the bill licence, its bill, billing account and the bill run
  * it is linked to for the remove bill licence page
  */
 async function go (billLicenceId) {

--- a/app/services/bill-licences/submit-remove-bill-licence.service.js
+++ b/app/services/bill-licences/submit-remove-bill-licence.service.js
@@ -12,7 +12,7 @@ const LegacyDeleteBillLicenceRequest = require('../../requests/legacy/delete-bil
  * Orchestrates the removing of a bill licence from a bill run
  *
  * @param {string} billLicenceId - UUID of the bill licence to be removed
- * @param {Object} user - Instance of `UserModel` that represents the user making the request
+ * @param {object} user - Instance of `UserModel` that represents the user making the request
  *
  * @returns {Promise<string>} Returns the redirect path the controller needs
  */

--- a/app/services/bill-licences/view-bill-licence.service.js
+++ b/app/services/bill-licences/view-bill-licence.service.js
@@ -11,9 +11,9 @@ const ViewBillLicencePresenter = require('../../presenters/bill-licences/view-bi
 /**
  * Orchestrates fetching and presenting the data needed for the view bill licence page
  *
- * @param {string} id The UUID for the bill licence to view
+ * @param {string} id - The UUID for the bill licence to view
  *
- * @returns {Promise<Object>} a formatted representation of the bill licence and its transactions for use in the bill
+ * @returns {Promise<object>} a formatted representation of the bill licence and its transactions for use in the bill
  * licence view page
  */
 async function go (id) {

--- a/app/services/bill-runs/annual/fetch-billing-accounts.service.js
+++ b/app/services/bill-runs/annual/fetch-billing-accounts.service.js
@@ -24,8 +24,8 @@ const Workflow = require('../../../models/workflow.model.js')
  * - be linked to a charge version which has an end date after the start of the billing period
  * - be linked to a charge version which has a status of 'current'
  *
- * @param {String} regionId - UUID of the region being billed that the licences must be linked to
- * @param {Object} billingPeriod - Object with a `startDate` and `endDate` property representing the period being billed
+ * @param {string} regionId - UUID of the region being billed that the licences must be linked to
+ * @param {object} billingPeriod - Object with a `startDate` and `endDate` property representing the period being billed
  *
  * @returns {Promise<module:BillingAccountModel[]>} An array of `BillingAccountModel` to be billed and their relevant
  * licence, charge version, charge element etc records needed to generate the bill run
@@ -135,7 +135,7 @@ async function _fetchNew (regionId, billingPeriod) {
  *
  * @param {module:QueryBuilder} query - an instance of the Objection QueryBuilder being generated
  * @param {string} regionId - UUID of the region being billed that the licences must be linked to
- * @param {Object} billingPeriod - Object with a `startDate` and `endDate` property representing the period being billed
+ * @param {object} billingPeriod - Object with a `startDate` and `endDate` property representing the period being billed
  *
  * @returns {module:QueryBuilder} the builder instance passed in with the additional `where` clauses added
  */

--- a/app/services/bill-runs/annual/process-bill-run.service.js
+++ b/app/services/bill-runs/annual/process-bill-run.service.js
@@ -33,7 +33,7 @@ const HandleErroredBillRunService = require('../handle-errored-bill-run.service.
  * as **Ready**.
  *
  * @param {module:BillRunModel} billRun - The annual bill run being processed
- * @param {Object[]} billingPeriods - An array of billing periods each containing a `startDate` and `endDate`. For
+ * @param {object[]} billingPeriods - An array of billing periods each containing a `startDate` and `endDate`. For
  * annual this will only ever contain a single period
  */
 async function go (billRun, billingPeriods) {

--- a/app/services/bill-runs/annual/process-billing-period.service.js
+++ b/app/services/bill-runs/annual/process-billing-period.service.js
@@ -22,10 +22,10 @@ const BillingConfig = require('../../../../config/billing.config.js')
  * Process the billing accounts for a given billing period and creates their annual bills
  *
  * @param {module:BillRunModel} billRun - The newly created bill run we need to process
- * @param {Object} billingPeriod - An object representing the financial year the bills will be for
+ * @param {object} billingPeriod - An object representing the financial year the bills will be for
  * @param {module:BillingAccountModel[]} billingAccounts - The billing accounts to create bills for
  *
- * @returns {Promise<Boolean>} true if the bill run is not empty (there are transactions to bill) else false
+ * @returns {Promise<boolean>} true if the bill run is not empty (there are transactions to bill) else false
  */
 async function go (billRun, billingPeriod, billingAccounts) {
   let billRunIsPopulated = false
@@ -173,7 +173,7 @@ function _extractBillableLicences (allBillLicences) {
  * @param {*} licence - the licence we're looking for an against bill licence record
  * @param {*} billId - the ID of the bill we're creating
  *
- * @return {Object} returns either an existing bill licence we previously created or a new one for the licence and bill
+ * @return {object} returns either an existing bill licence we previously created or a new one for the licence and bill
  * being generated
  */
 function _findOrCreateBillLicence (billLicences, licence, billId) {

--- a/app/services/bill-runs/calculate-authorised-and-billable-days.service.js
+++ b/app/services/bill-runs/calculate-authorised-and-billable-days.service.js
@@ -44,17 +44,17 @@ const ONE_DAY_IN_MILLISECONDS = 24 * 60 * 60 * 1000
  * have multiple charge elements. But we must return a single **Authorised** and **Billable** days calculation. This
  * problem is what this service tackles.
  *
- * @param {{startDate: Date, endDate: Date}} chargePeriod Charge period is determined as the overlap between a charge
+ * @param {{startDate: Date, endDate: Date}} chargePeriod - Charge period is determined as the overlap between a charge
  *  version's start and end dates, and the billing period's (financial year) start and end dates. So, when the charge
  *  version and billing period are compared the charge period's start date is the latest of the two, and the end date is
  *  the earliest of their end dates
- * @param {{startDate: Date, endDate: Date}} billingPeriod The period a bill run is being calculated for. Currently,
+ * @param {{startDate: Date, endDate: Date}} billingPeriod - The period a bill run is being calculated for. Currently,
  *  this always equates to a financial year, for example, 2022-04-01 to 2023-03-31
- * @param {module:ChargeReferenceModel} chargeReference A charge version can have multiple charge references, though
+ * @param {module:ChargeReferenceModel} chargeReference - A charge version can have multiple charge references, though
  *  each will have a different reference, for example, 4.1.10. Each reference can have multiple charge elements and it's
  *  these that hold the abstraction period data
  *
- * @returns {Object} An object containing an `authorisedDays` and `billableDays` property
+ * @returns {object} An object containing an `authorisedDays` and `billableDays` property
  */
 function go (chargePeriod, billingPeriod, chargeReference) {
   const { chargeElements } = chargeReference
@@ -95,7 +95,7 @@ function go (chargePeriod, billingPeriod, chargeReference) {
  * Finally, we add 1 to the result to make it inclusive of the last day. This is because our dates are set at
  * midnight which means `endDate.getTime()` is the time at `endDate 00:00:00`.
  *
- * @param {Object} abstractionOverlapPeriod a start and end date representing the part of the abstraction period that
+ * @param {object} abstractionOverlapPeriod - a start and end date representing the part of the abstraction period that
  * overlaps the reference period
  *
  * @returns {number} the length of the period in days (inclusive)
@@ -124,11 +124,11 @@ function _calculateDays (abstractionOverlapPeriod) {
  * - 01-JUL-2022 to 31-DEC-2022 - overlap is also 01-JUL-2022 to 31-DEC-2022 because it falls inside the billing period
  * - 01-NOV-2022 to 31-MAY-2023 - overlap is 01-NOV-2022 to 31-MAR-2023
  *
- * @param {Object} referencePeriod either the billing period or charge period
- * @param {Object} abstractionPeriod an object containing `startDate` and `endDate` date representing the abstraction
+ * @param {object} referencePeriod - either the billing period or charge period
+ * @param {object} abstractionPeriod - an object containing `startDate` and `endDate` date representing the abstraction
  *  period relative to the reference
  *
- * @returns {Object} an object with a start and end date representing the part of the abstraction period that overlaps
+ * @returns {object} an object with a start and end date representing the part of the abstraction period that overlaps
  *  the reference period
  */
 function _calculateAbstractionOverlapPeriod (referencePeriod, abstractionPeriod) {

--- a/app/services/bill-runs/cancel-bill-run.service.js
+++ b/app/services/bill-runs/cancel-bill-run.service.js
@@ -13,7 +13,7 @@ const CancelBillRunPresenter = require('../../presenters/bill-runs/cancel-bill-r
  *
  * @param {string} id - The UUID of the bill run to cancel
  *
- * @returns {Promise<Object>} an object representing the `pageData` needed by the cancel bill run template. It contains
+ * @returns {Promise<object>} an object representing the `pageData` needed by the cancel bill run template. It contains
  * details of the bill run.
  */
 async function go (id) {

--- a/app/services/bill-runs/consolidate-date-ranges.service.js
+++ b/app/services/bill-runs/consolidate-date-ranges.service.js
@@ -52,11 +52,11 @@
  * ]
  * ```
  *
- * @param {Object[]} dateRanges - The series of date ranges to be consolidated.
+ * @param {object[]} dateRanges - The series of date ranges to be consolidated.
  * @param {Date} dateRanges[].startDate - The start date for the range
  * @param {Date} dateRanges[].endDate - The end date of the range
  *
- * @returns {Object[]} An array of the consolidated date ranges
+ * @returns {object[]} An array of the consolidated date ranges
  */
 function go (dateRanges) {
   // We sort the date ranges by start date from earliest to latest to make life easier when consolidating them

--- a/app/services/bill-runs/create-bill-run-event.service.js
+++ b/app/services/bill-runs/create-bill-run-event.service.js
@@ -12,10 +12,10 @@ const GeneralLib = require('../../lib/general.lib.js')
 /**
  * Create an event for when a new bill run is initialised
  *
- * @param {module:BillRunModel} billRun An instance of `BillRunModel` representing the initialised bill run
- * @param {String} issuer The email address of the user triggering the event
+ * @param {module:BillRunModel} billRun - An instance of `BillRunModel` representing the initialised bill run
+ * @param {string} issuer - The email address of the user triggering the event
  *
- * @returns {Promise<Object>} The newly created event record
+ * @returns {Promise<object>} The newly created event record
  */
 async function go (billRun, issuer) {
   // The legacy `water.events` table does not have a default set for its timestamp fields. So, we have to manually set

--- a/app/services/bill-runs/create-bill-run.service.js
+++ b/app/services/bill-runs/create-bill-run.service.js
@@ -10,16 +10,16 @@ const BillRunModel = require('../../models/bill-run.model.js')
 /**
  * Create a new bill run
  *
- * @param {Object} regionId The regionId for the selected region
- * @param {Object} financialYearEndings Object that contains the from and to financial year endings
- * @param {Object} options Optional params to be overridden
- * @param {String} [options.batchType=supplementary] The type of bill run to create. Defaults to 'supplementary'
- * @param {String} [options.scheme=sroc] The applicable charging scheme. Defaults to 'sroc'
- * @param {String} [options.source=wrls] Where the bill run originated from. Records imported from NALD have the
+ * @param {object} regionId - The regionId for the selected region
+ * @param {object} financialYearEndings - Object that contains the from and to financial year endings
+ * @param {object} options - Optional params to be overridden
+ * @param {string} [options.batchType=supplementary] - The type of bill run to create. Defaults to 'supplementary'
+ * @param {string} [options.scheme=sroc] - The applicable charging scheme. Defaults to 'sroc'
+ * @param {string} [options.source=wrls] - Where the bill run originated from. Records imported from NALD have the
  *  source 'nald'. Those created in the service use 'wrls'. Defaults to 'wrls'
- * @param {String} [options.externalId=null] The id of the bill run as created in the Charging Module
- * @param {String} [options.status=queued] The status that the bill run should be created with
- * @param {Number} [options.errorCode=null] Numeric error code
+ * @param {string} [options.externalId=null] - The id of the bill run as created in the Charging Module
+ * @param {string} [options.status=queued] - The status that the bill run should be created with
+ * @param {number} [options.errorCode=null] - Numeric error code
  *
  * @returns {Promise<module:BillRunModel>} The newly created bill run instance with the `.region` property populated
  */

--- a/app/services/bill-runs/determine-abstraction-periods.service.js
+++ b/app/services/bill-runs/determine-abstraction-periods.service.js
@@ -41,13 +41,13 @@
  * Finally, we filter out any of these abstraction periods which don't overlap with the reference period, and return the
  * results.
  *
- * @param {Object} referencePeriod either the billing period or charge period
- * @param {Number} startDay the abstraction start day value
- * @param {Number} startMonth the abstraction start month value
- * @param {Number} endDay the abstraction end day value
- * @param {Number} endMonth the abstraction end month value
+ * @param {object} referencePeriod - either the billing period or charge period
+ * @param {number} startDay - the abstraction start day value
+ * @param {number} startMonth - the abstraction start month value
+ * @param {number} endDay - the abstraction end day value
+ * @param {number} endMonth - the abstraction end month value
  *
- * @returns {Object[]} An array of abstraction periods each containing a start and end date
+ * @returns {object[]} An array of abstraction periods each containing a start and end date
  */
 function go (referencePeriod, startDay, startMonth, endDay, endMonth) {
   const abstractionPeriodsWithYears = _determineYears(referencePeriod, startDay, startMonth, endDay, endMonth)

--- a/app/services/bill-runs/determine-billing-periods.service.js
+++ b/app/services/bill-runs/determine-billing-periods.service.js
@@ -29,9 +29,9 @@ const SROC_FIRST_FIN_YEAR_END = 2023
  * Our 3 billing engines then use these periods to generate the bill run.
  *
  * @param {string} billRunType - The type of bill run, for example, 'annual' or 'supplementary'
- * @param {Number} [financialYearEnding] - End year of the bill run. Only populated for two-part-tariff
+ * @param {number} [financialYearEnding] - End year of the bill run. Only populated for two-part-tariff
  *
- * @returns {Object[]} An array of billing periods each containing a `startDate` and `endDate`.
+ * @returns {object[]} An array of billing periods each containing a `startDate` and `endDate`.
  */
 function go (billRunType, financialYearEnding) {
   const financialYear = _financialYear(financialYearEnding)

--- a/app/services/bill-runs/determine-blocking-bill-run.service.js
+++ b/app/services/bill-runs/determine-blocking-bill-run.service.js
@@ -30,7 +30,7 @@ const FetchMatchingBillRunService = require('./fetch-matching-bill-run.service.j
  * @param {string} [season] - Applies only to PRESROC two-part tariff. Whether the bill run is summer or winter
  * all-year
  *
- * @returns {Promise<Object[]>} The matching bill run(s) if any. For annual and two-part tariff only one bill run
+ * @returns {Promise<object[]>} The matching bill run(s) if any. For annual and two-part tariff only one bill run
  * instance will be returned. For supplementary 2 bill runs may be returned depending on whether there is both an SROC
  * and PRESROC match.
  */

--- a/app/services/bill-runs/determine-charge-period.service.js
+++ b/app/services/bill-runs/determine-charge-period.service.js
@@ -54,10 +54,10 @@
  * When this happens we return an Object with `null` start and end dates. Calling services then know there is no valid
  * charge period and to avoid trying to calculate any billable days.
  *
- * @param {module:ChargeVersionModel} chargeVersion The charge version being processed for billing
- * @param {Object} billingPeriod Object with a `startDate` and `endDate` property representing the period being billed
+ * @param {module:ChargeVersionModel} chargeVersion - The charge version being processed for billing
+ * @param {object} billingPeriod - Object with a `startDate` and `endDate` property representing the period being billed
  *
- * @returns {Object} The start and end date of the calculated charge period
+ * @returns {object} The start and end date of the calculated charge period
  */
 function go (chargeVersion, billingPeriod) {
   const latestStartDateTimestamp = Math.max(

--- a/app/services/bill-runs/determine-minimum-charge.service.js
+++ b/app/services/bill-runs/determine-minimum-charge.service.js
@@ -13,10 +13,10 @@
  *
  * If either of those tests is false then the service will return false.
  *
- * @param {module:ChargeVersionModel} chargeVersion The charge version being checked for minimum charge
- * @param {Object} chargePeriod Object with a `startDate` and `endDate` property representing the chargeable period
+ * @param {module:ChargeVersionModel} chargeVersion - The charge version being checked for minimum charge
+ * @param {object} chargePeriod - Object with a `startDate` and `endDate` property representing the chargeable period
  *
- * @returns {Boolean} true if minimum charge applies else false
+ * @returns {boolean} true if minimum charge applies else false
  */
 function go (chargeVersion, chargePeriod) {
   const chargePeriodStartTimestamp = chargePeriod.startDate.getTime()

--- a/app/services/bill-runs/fetch-bill-run.service.js
+++ b/app/services/bill-runs/fetch-bill-run.service.js
@@ -13,9 +13,9 @@ const { db } = require('../../../db/db.js')
  *
  * Was built to provide the data needed for the '/bill-runs/{id}' page
  *
- * @param {string} id The UUID for the bill run to fetch
+ * @param {string} id - The UUID for the bill run to fetch
  *
- * @returns {Promise<Object>} the matching instance of BillRunModel plus a summary (Billing account number and contact,
+ * @returns {Promise<object>} the matching instance of BillRunModel plus a summary (Billing account number and contact,
  * licence, numbers, financial year and total net amount) for each bill linked to the bill run
  */
 async function go (id) {

--- a/app/services/bill-runs/fetch-live-bill-runs.service.js
+++ b/app/services/bill-runs/fetch-live-bill-runs.service.js
@@ -40,7 +40,7 @@ const LAST_PRESROC_YEAR = 2022
  * @param {number} financialYearEnding - The end year of the financial period to look at
  * @param {boolean} supplementary - true if we're trying to create a supplementary bill run else false
  *
- * @returns {Promise<Object[]>} An array of `BillRunModel` which are live for the region and financial year specified
+ * @returns {Promise<object[]>} An array of `BillRunModel` which are live for the region and financial year specified
  */
 async function go (regionId, financialYearEnding, supplementary) {
   const liveBillRuns = await _fetchLiveBillRuns(regionId)

--- a/app/services/bill-runs/fetch-matching-bill-run.service.js
+++ b/app/services/bill-runs/fetch-matching-bill-run.service.js
@@ -35,7 +35,7 @@ const LAST_PRESROC_YEAR = 2022
  * @param {boolean} [summer] - Applies only to PRESROC two-part tariff. Whether the bill run is summer or winter
  * all-year
  *
- * @returns {Promise<Object[]>} The matching bill run(s) if any. For annual and two-part tariff only one bill run
+ * @returns {Promise<object[]>} The matching bill run(s) if any. For annual and two-part tariff only one bill run
  * instance will be returned. For supplementary 2 bill runs may be returned depending on whether there is both an SROC
  * and PRESROC in progress.
  */

--- a/app/services/bill-runs/fetch-region.service.js
+++ b/app/services/bill-runs/fetch-region.service.js
@@ -13,10 +13,10 @@ const RegionModel = require('../../models/region.model.js')
  * This is a temporary service to help us confirm we are selecting the correct data to use when creating a
  * supplementary bill run. Its primary aim is to meet the acceptance criteria defined in WATER-3787.
  *
- * @param {String} naldRegionId The NALD region ID (a number between 1 to 9, 9 being the test region) for the region
+ * @param {string} naldRegionId - The NALD region ID (a number between 1 to 9, 9 being the test region) for the region
  *  to find
  *
- * @returns {Object} Instance of `RegionModel` with the matching NALD Region ID
+ * @returns {object} Instance of `RegionModel` with the matching NALD Region ID
  */
 async function go (naldRegionId) {
   const region = await _fetch(naldRegionId)

--- a/app/services/bill-runs/generate-transactions.service.js
+++ b/app/services/bill-runs/generate-transactions.service.js
@@ -24,14 +24,14 @@ const CalculateAuthorisedAndBillableDaysServiceService = require('./calculate-au
  * They will then be returned in an array for further processing before being persisted to the DB as
  * `billing_transactions`.
  *
- * @param {String} billLicenceId The UUID of the bill licence the transaction will be linked to
- * @param {Object} chargeReference The charge reference the transaction generated from
- * @param {Object} billingPeriod A start and end date representing the billing period for the bill run
- * @param {Object} chargePeriod A start and end date representing the charge period for the charge version
- * @param {Boolean} newLicence Whether the charge version is linked to a new licence
- * @param {Boolean} waterUndertaker Whether the charge version is linked to a water undertaker licence
+ * @param {string} billLicenceId - The UUID of the bill licence the transaction will be linked to
+ * @param {object} chargeReference - The charge reference the transaction generated from
+ * @param {object} billingPeriod - A start and end date representing the billing period for the bill run
+ * @param {object} chargePeriod - A start and end date representing the charge period for the charge version
+ * @param {boolean} newLicence - Whether the charge version is linked to a new licence
+ * @param {boolean} waterUndertaker - Whether the charge version is linked to a water undertaker licence
  *
- * @returns {Object[]} an array of 0, 1 or 2 transaction objects
+ * @returns {object[]} an array of 0, 1 or 2 transaction objects
  */
 function go (billLicenceId, chargeReference, billingPeriod, chargePeriod, newLicence, waterUndertaker) {
   const { authorisedDays, billableDays } = CalculateAuthorisedAndBillableDaysServiceService.go(

--- a/app/services/bill-runs/handle-errored-bill-run.service.js
+++ b/app/services/bill-runs/handle-errored-bill-run.service.js
@@ -16,8 +16,8 @@ const BillRunModel = require('../../models/bill-run.model.js')
  * Note that although this is async we would generally not call it asynchronously as the intent is you can call it and
  * continue with whatever error logging is required
  *
- * @param {String} billRunId UUID of the bill run to be marked with `error` status
- * @param {Number} [errorCode] Numeric error code as defined in BillRunModel. Defaults to `null`
+ * @param {string} billRunId - UUID of the bill run to be marked with `error` status
+ * @param {number} [errorCode] - Numeric error code as defined in BillRunModel. Defaults to `null`
  */
 async function go (billRunId, errorCode = null) {
   try {

--- a/app/services/bill-runs/index-bill-runs.service.js
+++ b/app/services/bill-runs/index-bill-runs.service.js
@@ -15,7 +15,7 @@ const PaginatorPresenter = require('../../presenters/paginator.presenter.js')
  *
  * @param {string} page - the page number of bill runs to be viewed
  *
- * @returns {Promise<Object>} an object representing the `pageData` needed by the index bill run template. It contains
+ * @returns {Promise<object>} an object representing the `pageData` needed by the index bill run template. It contains
  * summary details for each bill run for the page selected, the template's pagination control, the title and the
  * status of any busy bill runs
  */

--- a/app/services/bill-runs/initiate-bill-run.service.js
+++ b/app/services/bill-runs/initiate-bill-run.service.js
@@ -18,10 +18,10 @@ const ExpandedError = require('../../errors/expanded.error.js')
  * Initiating a new bill run means creating both the `billing_batch` and `event` record with the appropriate data,
  * along with a bill run record in the SROC Charging Module API.
  *
- * @param {Object} financialYearEndings Object that contains the from and to financial year endings
- * @param {String} regionId Id of the region the bill run is for
- * @param {String} batchType Type of bill run, for example, supplementary
- * @param {String} userEmail Email address of the user who initiated the bill run
+ * @param {object} financialYearEndings - Object that contains the from and to financial year endings
+ * @param {string} regionId - Id of the region the bill run is for
+ * @param {string} batchType - Type of bill run, for example, supplementary
+ * @param {string} userEmail - Email address of the user who initiated the bill run
  *
  * @returns {Promise<module:BillRunModel>} The newly created bill run instance
  */

--- a/app/services/bill-runs/reissue/fetch-bills-to-be-reissued.service.js
+++ b/app/services/bill-runs/reissue/fetch-bills-to-be-reissued.service.js
@@ -10,7 +10,7 @@ const BillModel = require('../../../models/bill.model.js')
 /**
  * Takes a region and fetches sroc bills in that region marked for reissuing, along with their transactions
  *
- * @param {String} regionId The uuid of the region
+ * @param {string} regionId - The uuid of the region
  *
  * @returns {Promise<module:BillModel[]>} An array of bills to be reissued
  */

--- a/app/services/bill-runs/reissue/reissue-bill.service.js
+++ b/app/services/bill-runs/reissue/reissue-bill.service.js
@@ -30,14 +30,14 @@ const { generateUUID } = require('../../../lib/general.lib.js')
  * and that reissuing bill is itself reissued, then `originalBillId` will still point directly to the original
  * source bill.
  *
- * @param {module:BillModel} sourceBill The bill to be reissued. Note that we expect it to include the bill
+ * @param {module:BillModel} sourceBill - The bill to be reissued. Note that we expect it to include the bill
  * licences and transactions
- * @param {module:BillRunModel} reissueBillRun The bill run that the new bills should belong to
+ * @param {module:BillRunModel} reissueBillRun - The bill run that the new bills should belong to
  *
- * @returns {Promise<Object>} dataToReturn Data that has been generated while reissuing the bill
- * @returns {Object[]} dataToReturn.bills Array of bills
- * @returns {Object[]} dataToReturn.billLicences Array of bill licences
- * @returns {Object[]} dataToReturn.transactions Array of transactions
+ * @returns {Promise<object>} dataToReturn Data that has been generated while reissuing the bill
+ * @returns {object[]} dataToReturn.bills Array of bills
+ * @returns {object[]} dataToReturn.billLicences Array of bill licences
+ * @returns {object[]} dataToReturn.transactions Array of transactions
  */
 
 async function go (sourceBill, reissueBillRun) {

--- a/app/services/bill-runs/reissue/reissue-bills.service.js
+++ b/app/services/bill-runs/reissue/reissue-bills.service.js
@@ -20,9 +20,9 @@ const TransactionModel = require('../../../models/transaction.model.js')
  * licence and transaction data which we batch persist once all bills have been reissued. Finally, we return a boolean
  * to indicate whether or not any bills were reissued.
  *
- * @param {module:BillRunModel} reissueBillRun The bill run that the reissued bills will be created on
+ * @param {module:BillRunModel} reissueBillRun - The bill run that the reissued bills will be created on
  *
- * @returns {Boolean} `true` if any bills were reissued; `false` if not
+ * @returns {boolean} `true` if any bills were reissued; `false` if not
 */
 
 async function go (reissueBillRun) {

--- a/app/services/bill-runs/send-bill-run.service.js
+++ b/app/services/bill-runs/send-bill-run.service.js
@@ -13,7 +13,7 @@ const SendBillRunPresenter = require('../../presenters/bill-runs/send-bill-run.p
  *
  * @param {string} id - The UUID of the bill run to send
  *
- * @returns {Promise<Object>} an object representing the `pageData` needed by the send bill run template. It contains
+ * @returns {Promise<object>} an object representing the `pageData` needed by the send bill run template. It contains
  * details of the bill run.
  */
 async function go (id) {

--- a/app/services/bill-runs/send-transactions.service.js
+++ b/app/services/bill-runs/send-transactions.service.js
@@ -16,12 +16,12 @@ const ChargingModuleCreateTransactionPresenter = require('../../presenters/charg
  * Each sent transaction is updated with a status of `charge_created` and the external id returned by the
  * Charging Module.
  *
- * @param {Object[]} transactions - The transactions to be sent to the Charging Module
+ * @param {object[]} transactions - The transactions to be sent to the Charging Module
  * @param {string} billRunExternalId - The Charging Module bill run id that the transactions are to be created on
  * @param {string} accountNumber - The billing account number for the transactions
  * @param {module:LicenceModel} licence - The licence that each transaction is linked to
  *
- * @returns {Promise<Object[]>} Array of transactions which have been sent to the Charging Module and updated with its
+ * @returns {Promise<object[]>} Array of transactions which have been sent to the Charging Module and updated with its
  * response
  */
 async function go (transactions, billRunExternalId, accountNumber, licence) {

--- a/app/services/bill-runs/setup/create.service.js
+++ b/app/services/bill-runs/setup/create.service.js
@@ -18,8 +18,8 @@ const StartBillRunProcessService = require('../start-bill-run-process.service.js
  * Once the bill runs have been triggered it finishes by deleting the setup session. Control is handed back to the
  * controller whilst the engines create and being building the bill runs.
  *
- * @param {Object} user - Instance of `UserModel` that represents the user making the request
- * @param {Object} existsResults - Results of `ExistsService` returned in the controller and passed on to this service
+ * @param {object} user - Instance of `UserModel` that represents the user making the request
+ * @param {object} existsResults - Results of `ExistsService` returned in the controller and passed on to this service
  *
  * @returns {Promise} A promise is returned but it does not resolve to anything we expect the caller to use
  */

--- a/app/services/bill-runs/setup/determine-financial-year-end.service.js
+++ b/app/services/bill-runs/setup/determine-financial-year-end.service.js
@@ -31,7 +31,7 @@ const { determineCurrentFinancialYear } = require('../../../lib/general.lib.js')
  *
  * If it doesn't, we 'bump' the financial end year to back to the year of the last annual bill run.
  *
- * @returns {Promise<Number>} The financial end year to use for selected bill run type and region
+ * @returns {Promise<number>} The financial end year to use for selected bill run type and region
  */
 async function go (regionId, billRunType, year = null) {
   const currentFinancialYear = determineCurrentFinancialYear()

--- a/app/services/bill-runs/setup/exists.service.js
+++ b/app/services/bill-runs/setup/exists.service.js
@@ -24,7 +24,7 @@ const SessionModel = require('../../../models/session.model.js')
  *
  * @param {string} sessionId - The UUID for setup bill run session record
  *
- * @returns {Promise<Object>} It always returns the session and the results of looking for matching bill runs plus a
+ * @returns {Promise<object>} It always returns the session and the results of looking for matching bill runs plus a
  * `pageData:` property.
  *
  * If no matches are found `pageData` will be `null`.

--- a/app/services/bill-runs/setup/fetch-regions.service.js
+++ b/app/services/bill-runs/setup/fetch-regions.service.js
@@ -10,7 +10,7 @@ const RegionModel = require('../../../models/region.model.js')
 /**
  * Fetches just the ID and display name for all regions
  *
- * @returns {Promise<Object[]>} The display name and ID for all regions in the service ordered by display name
+ * @returns {Promise<object[]>} The display name and ID for all regions in the service ordered by display name
  */
 async function go () {
   return RegionModel.query()

--- a/app/services/bill-runs/setup/region.service.js
+++ b/app/services/bill-runs/setup/region.service.js
@@ -17,7 +17,7 @@ const SessionModel = require('../../../models/session.model.js')
  *
  * @param {string} sessionId - The UUID for setup bill run session record
  *
- * @returns {Promise<Object>} The view data for the region page
+ * @returns {Promise<object>} The view data for the region page
  */
 async function go (sessionId) {
   const session = await SessionModel.query().findById(sessionId)

--- a/app/services/bill-runs/setup/season.service.js
+++ b/app/services/bill-runs/setup/season.service.js
@@ -16,7 +16,7 @@ const SeasonPresenter = require('../../../presenters/bill-runs/setup/season.pres
  *
  * @param {string} sessionId - The UUID for setup bill run session record
  *
- * @returns {Promise<Object>} The view data for the season page
+ * @returns {Promise<object>} The view data for the season page
  */
 async function go (sessionId) {
   const session = await SessionModel.query().findById(sessionId)

--- a/app/services/bill-runs/setup/submit-region.service.js
+++ b/app/services/bill-runs/setup/submit-region.service.js
@@ -25,9 +25,9 @@ const SessionModel = require('../../../models/session.model.js')
  * re-render the view with an error message.
  *
  * @param {string} sessionId - The UUID of the current session
- * @param {Object} payload - The submitted form data
+ * @param {object} payload - The submitted form data
  *
- * @returns {Promise<Object>} An object with a `setupComplete:` property if there are no errors else the page data for
+ * @returns {Promise<object>} An object with a `setupComplete:` property if there are no errors else the page data for
  * the region page including the validation error details
  */
 async function go (sessionId, payload) {

--- a/app/services/bill-runs/setup/submit-season.service.js
+++ b/app/services/bill-runs/setup/submit-season.service.js
@@ -23,9 +23,9 @@ const SeasonValidator = require('../../../validators/bill-runs/setup/season.vali
  * re-render the view with an error message.
  *
  * @param {string} sessionId - The UUID of the current session
- * @param {Object} payload - The submitted form data
+ * @param {object} payload - The submitted form data
  *
- * @returns {Promise<Object>} An empty object if there are no errors else the page data for the type page including the
+ * @returns {Promise<object>} An empty object if there are no errors else the page data for the type page including the
  * validation error details
  */
 async function go (sessionId, payload) {

--- a/app/services/bill-runs/setup/submit-type.service.js
+++ b/app/services/bill-runs/setup/submit-type.service.js
@@ -23,9 +23,9 @@ const TypeValidator = require('../../../validators/bill-runs/setup/type.validato
  * re-render the view with an error message.
  *
  * @param {string} sessionId - The UUID of the current session
- * @param {Object} payload - The submitted form data
+ * @param {object} payload - The submitted form data
  *
- * @returns {Promise<Object>} An empty object if there are no errors else the page data for the type page including the
+ * @returns {Promise<object>} An empty object if there are no errors else the page data for the type page including the
  * validation error details
  */
 async function go (sessionId, payload) {

--- a/app/services/bill-runs/setup/submit-year.service.js
+++ b/app/services/bill-runs/setup/submit-year.service.js
@@ -24,9 +24,9 @@ const YearValidator = require('../../../validators/bill-runs/setup/year.validato
  * re-render the view with an error message.
  *
  * @param {string} sessionId - The UUID of the current session
- * @param {Object} payload - The submitted form data
+ * @param {object} payload - The submitted form data
  *
- * @returns {Promise<Object>} An object with a `setupComplete:` property if there are no errors else the page data for
+ * @returns {Promise<object>} An object with a `setupComplete:` property if there are no errors else the page data for
  * the year page including the validation error details
  */
 async function go (sessionId, payload) {

--- a/app/services/bill-runs/setup/type.service.js
+++ b/app/services/bill-runs/setup/type.service.js
@@ -16,7 +16,7 @@ const TypePresenter = require('../../../presenters/bill-runs/setup/type.presente
  *
  * @param {string} sessionId - The UUID for setup bill run session record
  *
- * @returns {Promise<Object>} The view data for the type page
+ * @returns {Promise<object>} The view data for the type page
  */
 async function go (sessionId) {
   const session = await SessionModel.query().findById(sessionId)

--- a/app/services/bill-runs/setup/year.service.js
+++ b/app/services/bill-runs/setup/year.service.js
@@ -16,7 +16,7 @@ const SessionModel = require('../../../models/session.model.js')
  *
  * @param {string} sessionId - The UUID for setup bill run session record
  *
- * @returns {Promise<Object>} The view data for the year page
+ * @returns {Promise<object>} The view data for the year page
  */
 async function go (sessionId) {
   const session = await SessionModel.query().findById(sessionId)

--- a/app/services/bill-runs/start-bill-run-process.service.js
+++ b/app/services/bill-runs/start-bill-run-process.service.js
@@ -16,12 +16,12 @@ const TwoPartTariffProcessBillRunService = require('./two-part-tariff/process-bi
 /**
  * Manages the creation of a new bill run
  *
- * @param {String} regionId Id of the region the bill run is for
- * @param {String} batchType Type of bill run, for example, supplementary
- * @param {String} userEmail Email address of the user who initiated the bill run
- * @param {Number} financialYearEnding End year of the bill run. Only populated for two-part-tariff
+ * @param {string} regionId - Id of the region the bill run is for
+ * @param {string} batchType - Type of bill run, for example, supplementary
+ * @param {string} userEmail - Email address of the user who initiated the bill run
+ * @param {number} financialYearEnding - End year of the bill run. Only populated for two-part-tariff
  *
- * @returns {Promise<Object>} Object that will be the JSON response returned to the client
+ * @returns {Promise<object>} Object that will be the JSON response returned to the client
  */
 async function go (regionId, batchType, userEmail, financialYearEnding) {
   const billingPeriods = DetermineBillingPeriodsService.go(batchType, financialYearEnding)

--- a/app/services/bill-runs/supplementary/fetch-billing-accounts.service.js
+++ b/app/services/bill-runs/supplementary/fetch-billing-accounts.service.js
@@ -10,9 +10,9 @@ const BillingAccountModel = require('../../../models/billing-account.model.js')
 /**
  * Fetch all billing accounts for the supplied charge versions
  *
- * @param {module:ChargeVersionModel[]} chargeVersions An array of charge versions
+ * @param {module:ChargeVersionModel[]} chargeVersions - An array of charge versions
  *
- * @returns {Promise<Object[]>} Array of objects in the format { billingAccountId: '...', accountNumber: '...' }
+ * @returns {Promise<object[]>} Array of objects in the format { billingAccountId: '...', accountNumber: '...' }
  */
 async function go (chargeVersions) {
   const uniqueBillingAccountIds = _extractUniqueBillingAccountIds(chargeVersions)

--- a/app/services/bill-runs/supplementary/fetch-charge-versions.service.js
+++ b/app/services/bill-runs/supplementary/fetch-charge-versions.service.js
@@ -25,10 +25,10 @@ const Workflow = require('../../../models/workflow.model.js')
  * From this initial result we extract an array of unique licence IDs and then remove any that are non-chargeable (we
  * need to know about them in order to unset the licence's sroc billing flag).
  *
- * @param {String} regionId UUID of the region being billed that the licences must be linked to
- * @param {Object} billingPeriod Object with a `startDate` and `endDate` property representing the period being billed
+ * @param {string} regionId - UUID of the region being billed that the licences must be linked to
+ * @param {object} billingPeriod - Object with a `startDate` and `endDate` property representing the period being billed
  *
- * @returns {Promise<Object>} Contains an array of unique licence IDs and array of charge versions to be processed
+ * @returns {Promise<object>} Contains an array of unique licence IDs and array of charge versions to be processed
  */
 async function go (regionId, billingPeriod) {
   const allChargeVersions = await _fetch(regionId, billingPeriod)

--- a/app/services/bill-runs/supplementary/fetch-previous-transactions.service.js
+++ b/app/services/bill-runs/supplementary/fetch-previous-transactions.service.js
@@ -14,10 +14,10 @@ const TransactionModel = require('../../../models/transaction.model.js')
  *
  * @param {string} billingAccountId - The UUID that identifies the billing account we need to fetch transactions for
  * @param {string} licenceId - The UUID that identifies the licence we need to fetch transactions for
- * @param {Number} financialYearEnding - The year the financial billing period ends that we need to fetch transactions
+ * @param {number} financialYearEnding - The year the financial billing period ends that we need to fetch transactions
  * for
  *
- * @returns {Promise<Object[]>} The resulting matched transactions
+ * @returns {Promise<object[]>} The resulting matched transactions
  */
 async function go (billingAccountId, licenceId, financialYearEnding) {
   const transactions = await _fetch(billingAccountId, licenceId, financialYearEnding)

--- a/app/services/bill-runs/supplementary/pre-generate-billing-data.service.js
+++ b/app/services/bill-runs/supplementary/pre-generate-billing-data.service.js
@@ -13,12 +13,12 @@ const { generateUUID } = require('../../../lib/general.lib.js')
  * a keyed object of bills and a keyed object of bill licences. The bills are keyed by the bill ID, and the bill
  * licences are keyed by the concatenated bill id and licence id.
  * *
- * @param {module:ChargeVersionModel[]} chargeVersions Array of charge versions which provide the billing
+ * @param {module:ChargeVersionModel[]} chargeVersions - Array of charge versions which provide the billing
  * accounts and licences to use
- * @param {String} billRunId The bill run id to be added to the billing invoices
- * @param {Object} billingPeriod The billing period of the billing invoices
+ * @param {string} billRunId - The bill run id to be added to the billing invoices
+ * @param {object} billingPeriod - The billing period of the billing invoices
  *
- * @returns {Promise<Object>} An object containing arrays of bills and billLicences objects
+ * @returns {Promise<object>} An object containing arrays of bills and billLicences objects
  */
 async function go (chargeVersions, billRunId, billingPeriod) {
   const billingAccounts = await FetchBillingAccountsService.go(chargeVersions)

--- a/app/services/bill-runs/supplementary/process-bill-run.service.js
+++ b/app/services/bill-runs/supplementary/process-bill-run.service.js
@@ -20,7 +20,7 @@ const UnflagUnbilledLicencesService = require('./unflag-unbilled-licences.servic
  * required bills and transactions for it in both this service and the Charging Module.
  *
  * @param {module:BillRunModel} billRun
- * @param {Object[]} billingPeriods An array of billing periods each containing a `startDate` and `endDate`
+ * @param {object[]} billingPeriods - An array of billing periods each containing a `startDate` and `endDate`
  */
 async function go (billRun, billingPeriods) {
   const { id: billRunId } = billRun

--- a/app/services/bill-runs/supplementary/process-billing-period.service.js
+++ b/app/services/bill-runs/supplementary/process-billing-period.service.js
@@ -20,11 +20,11 @@ const TransactionModel = require('../../../models/transaction.model.js')
 /**
  * Creates the bills and transactions in both WRLS and the Charging Module API
  *
- * @param {module:BillRunModel} billRun The newly created bill run we need to process
- * @param {Object} billingPeriod An object representing the financial year the transactions are for
- * @param {module:ChargeVersionModel[]} chargeVersions The charge versions to create transactions for
+ * @param {module:BillRunModel} billRun - The newly created bill run we need to process
+ * @param {object} billingPeriod - An object representing the financial year the transactions are for
+ * @param {module:ChargeVersionModel[]} chargeVersions - The charge versions to create transactions for
  *
- * @returns {Boolean} true if the bill run is not empty (there are transactions to bill) else false
+ * @returns {boolean} true if the bill run is not empty (there are transactions to bill) else false
  */
 async function go (billRun, billingPeriod, chargeVersions) {
   if (chargeVersions.length === 0) {

--- a/app/services/bill-runs/supplementary/process-transactions.service.js
+++ b/app/services/bill-runs/supplementary/process-transactions.service.js
@@ -17,12 +17,12 @@ const ReverseTransactionsService = require('./reverse-transactions.service.js')
  * sent to the Charging Module) and any matching pairs of transactions which would cancel each other out are removed.
  * Any remaining reversed credits and calculated debits are returned.
  *
- * @param {Object[]} calculatedTransactions - The calculated transactions to be processed
+ * @param {object[]} calculatedTransactions - The calculated transactions to be processed
  * @param {string} billingAccountId - The UUID that identifies the billing account we are processing transactions for
- * @param {Object} billLicence - A generated bill licence that identifies the licence we need to match against
- * @param {Object} billingPeriod - Object with a `startDate` and `endDate` property representing the period being billed
+ * @param {object} billLicence - A generated bill licence that identifies the licence we need to match against
+ * @param {object} billingPeriod - Object with a `startDate` and `endDate` property representing the period being billed
  *
- * @returns {Promise<Object[]>} An array of the remaining calculated transactions (ie. those which were not cancelled
+ * @returns {Promise<object[]>} An array of the remaining calculated transactions (ie. those which were not cancelled
  *  out by a previous matching credit)
  */
 async function go (calculatedTransactions, billingAccountId, billLicence, billingPeriod) {

--- a/app/services/bill-runs/supplementary/reverse-transactions.service.js
+++ b/app/services/bill-runs/supplementary/reverse-transactions.service.js
@@ -17,7 +17,7 @@ const { generateUUID } = require('../../../lib/general.lib.js')
  * @param {module:TransactionModel[]} transactions - Array of transactions to be reversed
  * @param {string} billLicenceId - The bill licence UUID these transactions are to be added to
  *
- * @returns {Object[]} Array of reversed transactions with `billLicenceId` set to the id of the supplied `billLicence`
+ * @returns {object[]} Array of reversed transactions with `billLicenceId` set to the id of the supplied `billLicence`
  */
 function go (transactions, billLicenceId) {
   return _reverseTransactions(transactions, billLicenceId)

--- a/app/services/bill-runs/supplementary/unflag-billed-licences.service.js
+++ b/app/services/bill-runs/supplementary/unflag-billed-licences.service.js
@@ -34,7 +34,7 @@ const LicenceModel = require('../../../models/licence.model.js')
  *
  * @param {module:BillRunModel} billRun - Instance of the bill run being sent
  *
- * @returns {Promise<Number>} Resolves to the count of records updated
+ * @returns {Promise<number>} Resolves to the count of records updated
  */
 async function go (billRun) {
   const { scheme } = billRun

--- a/app/services/bill-runs/supplementary/unflag-unbilled-licences.service.js
+++ b/app/services/bill-runs/supplementary/unflag-unbilled-licences.service.js
@@ -32,9 +32,9 @@ const LicenceModel = require('../../../models/licence.model.js')
  * running are slim. But we feel it prudent to still check plus it keeps the services consistent.
  *
  * @param {module:BillRunModel} billRun - Instance of the bill run being processed
- * @param {String[]} allLicenceIds - All licence UUIDs being processed in the bill run
+ * @param {string[]} allLicenceIds - All licence UUIDs being processed in the bill run
  *
- * @returns {Promise<Number>} Resolves to the count of records updated
+ * @returns {Promise<number>} Resolves to the count of records updated
  */
 async function go (billRun, allLicenceIds) {
   const { id: billRunId, createdAt } = billRun

--- a/app/services/bill-runs/two-part-tariff/amend-adjustment-factor.service.js
+++ b/app/services/bill-runs/two-part-tariff/amend-adjustment-factor.service.js
@@ -11,11 +11,11 @@ const FetchReviewChargeReferenceService = require('./fetch-review-charge-referen
 /**
  * Orchestrates fetching and presenting the data needed for the amend adjustment factor page
  *
- * @param {String} billRunId - The UUID for the bill run
- * @param {String} licenceId - The UUID of the licence that is being reviewed
- * @param {String} reviewChargeReferenceId - The UUID of the review charge reference being viewed
+ * @param {string} billRunId - The UUID for the bill run
+ * @param {string} licenceId - The UUID of the licence that is being reviewed
+ * @param {string} reviewChargeReferenceId - The UUID of the review charge reference being viewed
  *
- * @returns {Promise<Object>} the 'pageData' needed to view the amend adjustment factor page
+ * @returns {Promise<object>} the 'pageData' needed to view the amend adjustment factor page
  */
 async function go (billRunId, licenceId, reviewChargeReferenceId) {
   const {

--- a/app/services/bill-runs/two-part-tariff/amend-authorised-volume.service.js
+++ b/app/services/bill-runs/two-part-tariff/amend-authorised-volume.service.js
@@ -11,11 +11,11 @@ const FetchAuthorisedVolumeService = require('./fetch-authorised-volume.service.
 /**
  * Orchestrates fetching and presenting the data needed for the amend authorised volume page
  *
- * @param {String} billRunId - The UUID for the bill run
- * @param {String} licenceId - The UUID of the licence that is being reviewed
- * @param {String} reviewChargeReferenceId - The UUID of the review charge reference being viewed
+ * @param {string} billRunId - The UUID for the bill run
+ * @param {string} licenceId - The UUID of the licence that is being reviewed
+ * @param {string} reviewChargeReferenceId - The UUID of the review charge reference being viewed
  *
- * @returns {Promise<Object>} the 'pageData' needed to view the amend authorised volume page
+ * @returns {Promise<object>} the 'pageData' needed to view the amend authorised volume page
  */
 async function go (billRunId, licenceId, reviewChargeReferenceId) {
   const { billRun, reviewChargeReference } = await FetchAuthorisedVolumeService.go(billRunId, reviewChargeReferenceId)

--- a/app/services/bill-runs/two-part-tariff/amend-billable-returns.service.js
+++ b/app/services/bill-runs/two-part-tariff/amend-billable-returns.service.js
@@ -11,11 +11,11 @@ const FetchMatchDetailsService = require('./fetch-match-details.service.js')
 /**
  * Orchestrates fetching and presenting the data needed for the amend billable returns page
  *
- * @param {String} billRunId - The UUID for the bill run
- * @param {String} licenceId - The UUID of the licence that is being reviewed
- * @param {String} reviewChargeElementId - The UUID of the review charge element being viewed
+ * @param {string} billRunId - The UUID for the bill run
+ * @param {string} licenceId - The UUID of the licence that is being reviewed
+ * @param {string} reviewChargeElementId - The UUID of the review charge element being viewed
  *
- * @returns {Promise<Object>} the 'pageData' needed to view the edit billable return volumes page
+ * @returns {Promise<object>} the 'pageData' needed to view the edit billable return volumes page
  */
 async function go (billRunId, licenceId, reviewChargeElementId) {
   const { billRun, reviewChargeElement } = await FetchMatchDetailsService.go(billRunId, reviewChargeElementId)

--- a/app/services/bill-runs/two-part-tariff/calculate-charge.service.js
+++ b/app/services/bill-runs/two-part-tariff/calculate-charge.service.js
@@ -18,9 +18,9 @@ const ReviewChargeReferenceModel = require('../../../models/review-charge-refere
  * It does this by sending a transaction based on the selected charge reference to the charging module so that it can
  * calculate the charge. The charge amount is then added to a flash message which will be displayed to the user.
  *
- * @param {String} licenceId - The UUID of the licence related to the charge
- * @param {String} reviewChargeReferenceId - The UUID of the charge reference review data to calculate the charge on
- * @param {Object} yar - The Hapi `request.yar` session manager passed on by the controller
+ * @param {string} licenceId - The UUID of the licence related to the charge
+ * @param {string} reviewChargeReferenceId - The UUID of the charge reference review data to calculate the charge on
+ * @param {object} yar - The Hapi `request.yar` session manager passed on by the controller
  */
 async function go (licenceId, reviewChargeReferenceId, yar) {
   const reviewChargeReference = await _fetchReviewChargeReference(reviewChargeReferenceId)

--- a/app/services/bill-runs/two-part-tariff/charge-reference-details.service.js
+++ b/app/services/bill-runs/two-part-tariff/charge-reference-details.service.js
@@ -13,12 +13,12 @@ const FetchReviewChargeReferenceService = require('./fetch-review-charge-referen
  * Orchestrates fetching and presenting the data needed for the charge reference details page in a two-part tariff bill
  * run
  *
- * @param {String} billRunId - The UUID for the bill run
- * @param {String} licenceId - The UUID of the licence that is being reviewed
- * @param {String} reviewChargeReferenceId - The UUID of the charge reference being reviewed
- * @param {Object} yar - The Hapi `request.yar` session manager passed on by the controller
+ * @param {string} billRunId - The UUID for the bill run
+ * @param {string} licenceId - The UUID of the licence that is being reviewed
+ * @param {string} reviewChargeReferenceId - The UUID of the charge reference being reviewed
+ * @param {object} yar - The Hapi `request.yar` session manager passed on by the controller
  *
- * @returns {Promise<Object>} the 'pageData' needed for the review charge reference page. It contains details of the
+ * @returns {Promise<object>} the 'pageData' needed for the review charge reference page. It contains details of the
  * bill run, charge reference and the charge adjustments
  */
 async function go (billRunId, licenceId, reviewChargeReferenceId, yar) {

--- a/app/services/bill-runs/two-part-tariff/determine-licence-issues.service.js
+++ b/app/services/bill-runs/two-part-tariff/determine-licence-issues.service.js
@@ -167,7 +167,7 @@ function _getMatchingReturns (returnLogs, licenceReturnLogs) {
 /**
  * Returns a list of issues that would put a licence into a status of 'review'
  *
- * @returns {Object[]} An array of issues that would put a licence into a status of 'review'
+ * @returns {object[]} An array of issues that would put a licence into a status of 'review'
  */
 function _getReviewStatuses () {
   // the keys for the issues that will put the licence into review status

--- a/app/services/bill-runs/two-part-tariff/fetch-authorised-volume.service.js
+++ b/app/services/bill-runs/two-part-tariff/fetch-authorised-volume.service.js
@@ -12,10 +12,10 @@ const ReviewChargeReferenceModel = require('../../../models/review-charge-refere
 /**
  * Fetches the charge reference details for an individual licence
  *
- * @param {String} billRunId - UUID of the bill run
- * @param {String} reviewChargeReferenceId - The UUID of the review charge reference being viewed
+ * @param {string} billRunId - UUID of the bill run
+ * @param {string} reviewChargeReferenceId - The UUID of the review charge reference being viewed
  *
- * @returns {Promise<Object>} An object containing the bill run and review charge reference instances
+ * @returns {Promise<object>} An object containing the bill run and review charge reference instances
  */
 async function go (billRunId, reviewChargeReferenceId) {
   const billRun = await _fetchBillRun(billRunId)

--- a/app/services/bill-runs/two-part-tariff/fetch-bill-run-licences.service.js
+++ b/app/services/bill-runs/two-part-tariff/fetch-bill-run-licences.service.js
@@ -17,20 +17,20 @@ const DatabaseConfig = require('../../../../config/database.config.js')
  * Fetches specifically the bill run data, a list of the licences in the bill run with the licence holder and licence
  * ref.
  *
- * @param {String} id The UUID for the bill run
- * @param {{Object[]}} filterIssues An array of issues to filter the results by. This will only contain data when
+ * @param {string} id - The UUID for the bill run
+ * @param {{Object[]}} filterIssues - An array of issues to filter the results by. This will only contain data when
  * there is a POST request, which only occurs when a filter is applied to the results. NOTE: if there is only a single
  * issue this will be a string, not an array
- * @param {String} filterLicenceHolderNumber The licence holder or licence number to filter the results by. This will
+ * @param {string} filterLicenceHolderNumber - The licence holder or licence number to filter the results by. This will
  * only contain data when there is a POST request, which only occurs when a filter is applied to the results.
- * @param {String} filterLicenceStatus The status of the licence to filter the results by. This also only contains data
- * when there is a POST request.
- * @param {String} filterProgress The progress of the licence to filter the results by. This also only contains data
+ * @param {string} filterLicenceStatus - The status of the licence to filter the results by. This also only contains
+ * data when there is a POST request.
+ * @param {string} filterProgress - The progress of the licence to filter the results by. This also only contains data
  * when there is a POST request.
  * @param {number} page - the page number of licences to be viewed
  *
- * @returns {Promise<Object>} An object containing the billRun data and an array of licences for the bill run that match
- * the selected 'page in the data. Also included is any data that has been used to filter the results
+ * @returns {Promise<object>} An object containing the billRun data and an array of licences for the bill run that match
+ * the selected page in the data. Also included is any data that has been used to filter the results
  */
 async function go (id, filterIssues, filterLicenceHolderNumber, filterLicenceStatus, filterProgress, page) {
   const billRun = await _fetchBillRun(id)

--- a/app/services/bill-runs/two-part-tariff/fetch-charge-versions.service.js
+++ b/app/services/bill-runs/two-part-tariff/fetch-charge-versions.service.js
@@ -25,10 +25,10 @@ const Workflow = require('../../../models/workflow.model.js')
  * - have a status of current
  * - be linked to a charge reference that is marked as two-part-tariff
  *
- * @param {String} regionId - UUID of the region being billed
- * @param {Object} billingPeriod - Object with a `startDate` and `endDate` property representing the period being billed
+ * @param {string} regionId - UUID of the region being billed
+ * @param {object} billingPeriod - Object with a `startDate` and `endDate` property representing the period being billed
  *
- * @returns {Promise<Object>} Contains an array of two-part tariff charge versions with linked licences, charge
+ * @returns {Promise<object>} Contains an array of two-part tariff charge versions with linked licences, charge
  * references, charge elements and related purpose
  */
 async function go (regionId, billingPeriod) {

--- a/app/services/bill-runs/two-part-tariff/fetch-licences.service.js
+++ b/app/services/bill-runs/two-part-tariff/fetch-licences.service.js
@@ -11,10 +11,10 @@ const FetchChargeVersionsService = require('./fetch-charge-versions.service.js')
  * Fetches 2PT Licences for the matching region and billing period plus the charge versions associated with them grouped
  * by licence
  *
- * @param {String} regionId UUID of the region being billed that the licences must be linked to
- * @param {Object} billingPeriod Object with a `startDate` and `endDate` property representing the period being billed
+ * @param {string} regionId - UUID of the region being billed that the licences must be linked to
+ * @param {object} billingPeriod - Object with a `startDate` and `endDate` property representing the period being billed
  *
- * @returns {Promise<Object[]>} the licences to be matched, each containing an array of charge versions applicable for
+ * @returns {Promise<object[]>} the licences to be matched, each containing an array of charge versions applicable for
  * two-part tariff
  */
 async function go (regionId, billingPeriod) {

--- a/app/services/bill-runs/two-part-tariff/fetch-match-details.service.js
+++ b/app/services/bill-runs/two-part-tariff/fetch-match-details.service.js
@@ -13,10 +13,10 @@ const ReviewChargeElementModel = require('../../../models/review-charge-element.
 /**
  * Fetches the match details for an individual charge element
  *
- * @param {String} billRunId - UUID of the bill run
- * @param {String} reviewChargeElementId - The UUID of the review charge element being viewed
+ * @param {string} billRunId - UUID of the bill run
+ * @param {string} reviewChargeElementId - The UUID of the review charge element being viewed
  *
- * @returns {Promise<Object>} An object containing the bill run and review charge element instances
+ * @returns {Promise<object>} An object containing the bill run and review charge element instances
  */
 async function go (billRunId, reviewChargeElementId) {
   const billRun = await _fetchBillRun(billRunId)

--- a/app/services/bill-runs/two-part-tariff/fetch-return-logs-for-licence.service.js
+++ b/app/services/bill-runs/two-part-tariff/fetch-return-logs-for-licence.service.js
@@ -12,10 +12,10 @@ const ReturnLogModel = require('../../../models/return-log.model.js')
 /**
  * Fetch all SROC return logs to be processed as part of two-part-tariff billing
  * *
- * @param {String} licenceRef The reference of the licence that the return log relates to
- * @param {Object} billingPeriod Object with a `startDate` and `endDate` property representing the period being billed
+ * @param {string} licenceRef - The reference of the licence that the return log relates to
+ * @param {object} billingPeriod - Object with a `startDate` and `endDate` property representing the period being billed
  *
- * @returns {Promise<Object>} Contains an array of `returnLogs` and the associated current `returnSubmissions`, and
+ * @returns {Promise<object>} Contains an array of `returnLogs` and the associated current `returnSubmissions`, and
  * `returnSubmissionLines` if they exist
  */
 async function go (licenceRef, billingPeriod) {

--- a/app/services/bill-runs/two-part-tariff/fetch-review-charge-reference.service.js
+++ b/app/services/bill-runs/two-part-tariff/fetch-review-charge-reference.service.js
@@ -13,10 +13,10 @@ const ReviewChargeReferenceModel = require('../../../models/review-charge-refere
 /**
  * Fetches the charge reference details for an individual licence
  *
- * @param {String} billRunId - UUID of the bill run
- * @param {String} reviewChargeReferenceId - The UUID of the review charge reference being viewed
+ * @param {string} billRunId - UUID of the bill run
+ * @param {string} reviewChargeReferenceId - The UUID of the review charge reference being viewed
  *
- * @returns {Promise<Object>} An object containing the bill run and review charge reference instances
+ * @returns {Promise<object>} An object containing the bill run and review charge reference instances
  */
 async function go (billRunId, reviewChargeReferenceId) {
   const billRun = await _fetchBillRun(billRunId)

--- a/app/services/bill-runs/two-part-tariff/fetch-review-licence-results.service.js
+++ b/app/services/bill-runs/two-part-tariff/fetch-review-licence-results.service.js
@@ -14,10 +14,10 @@ const ReviewLicenceModel = require('../../../models/review-licence.model.js')
 /**
  * Fetches the bill run and an individual licences review data for a two-part tariff bill run
  *
- * @param {module:BillRunModel} billRunId UUID of the bill run
- * @param {module:LicenceModel} licenceId UUID of the individual licence to review
+ * @param {module:BillRunModel} billRunId - UUID of the bill run
+ * @param {module:LicenceModel} licenceId - UUID of the individual licence to review
  *
- * @returns {Promise<Object[]>} Contains an array of bill run data and review licence data
+ * @returns {Promise<object[]>} Contains an array of bill run data and review licence data
  */
 async function go (billRunId, licenceId) {
   const billRun = await _fetchBillRun(billRunId)

--- a/app/services/bill-runs/two-part-tariff/generate-transaction.service.js
+++ b/app/services/bill-runs/two-part-tariff/generate-transaction.service.js
@@ -23,14 +23,14 @@ const { generateUUID } = require('../../../lib/general.lib.js')
  * So, we have to grab those values as well. Finally, because the standard annual bill run will have handled the
  * compensation charge we don't have to generate an additional transaction alongside our two-part tariff one.
  *
- * @param {String} billLicenceId - The UUID of the bill licence the transaction will be linked to
+ * @param {string} billLicenceId - The UUID of the bill licence the transaction will be linked to
  * @param {module:ChargeReferenceModel} chargeReference - The charge reference the transaction generated will be
  * generated from
- * @param {Object} chargePeriod - A start and end date representing the charge period for the transaction
- * @param {Boolean} newLicence - Whether the charge reference is linked to a new licence
- * @param {Boolean} waterUndertaker - Whether the charge reference is linked to a water undertaker licence
+ * @param {object} chargePeriod - A start and end date representing the charge period for the transaction
+ * @param {boolean} newLicence - Whether the charge reference is linked to a new licence
+ * @param {boolean} waterUndertaker - Whether the charge reference is linked to a water undertaker licence
  *
- * @returns {Object} the two-part tariff transaction
+ * @returns {object} the two-part tariff transaction
  */
 function go (billLicenceId, chargeReference, chargePeriod, newLicence, waterUndertaker) {
   const billableQuantity = _billableQuantity(chargeReference.chargeElements)

--- a/app/services/bill-runs/two-part-tariff/match-and-allocate.service.js
+++ b/app/services/bill-runs/two-part-tariff/match-and-allocate.service.js
@@ -24,9 +24,9 @@ const PrepareReturnLogsService = require('./prepare-return-logs.service.js')
  * After processing each license, the results are persisted using PersistAllocatedLicenceToResultsService.
  *
  * @param {module:BillRunModel} billRun - The bill run object containing billing information
- * @param {Object} billingPeriod - A single billing period containing a `startDate` and `endDate`
+ * @param {object} billingPeriod - A single billing period containing a `startDate` and `endDate`
  *
- * @returns {Promise<Boolean>} - True if there are any licences matched to returns, false otherwise
+ * @returns {Promise<boolean>} - True if there are any licences matched to returns, false otherwise
  */
 async function go (billRun, billingPeriod) {
   const licences = await FetchLicencesService.go(billRun.regionId, billingPeriod)

--- a/app/services/bill-runs/two-part-tariff/match-details.service.js
+++ b/app/services/bill-runs/two-part-tariff/match-details.service.js
@@ -12,12 +12,12 @@ const MatchDetailsPresenter = require('../../../presenters/bill-runs/two-part-ta
 /**
  * Orchestrates fetching and presenting the data needed for the view match details page for a charge element
  *
- * @param {String} billRunId - The UUID for the bill run
- * @param {String} licenceId - The UUID of the licence that is being reviewed
- * @param {String} reviewChargeElementId - The UUID of the review charge element being viewed
- * @param {Object} yar - The Hapi `request.yar` session manager passed on by the controller
+ * @param {string} billRunId - The UUID for the bill run
+ * @param {string} licenceId - The UUID of the licence that is being reviewed
+ * @param {string} reviewChargeElementId - The UUID of the review charge element being viewed
+ * @param {object} yar - The Hapi `request.yar` session manager passed on by the controller
  *
- * @returns {Promise<Object>} the 'pageData' needed to view the match details of an individual charge
+ * @returns {Promise<object>} the 'pageData' needed to view the match details of an individual charge
  */
 async function go (billRunId, licenceId, reviewChargeElementId, yar) {
   const { billRun, reviewChargeElement } = await FetchMatchDetailsService.go(billRunId, reviewChargeElementId)

--- a/app/services/bill-runs/two-part-tariff/persist-allocated-licence-to-results.service.js
+++ b/app/services/bill-runs/two-part-tariff/persist-allocated-licence-to-results.service.js
@@ -23,7 +23,7 @@ const ReviewReturnModel = require('../../../models/review-return.model.js')
  * We need to persist all this information ready for use in the review screens that our users use to asses if the
  * matching and allocating looks correct or if any issues need resolving first.
  *
- * @param {String} billRunId - the ID of the two-part tariff bill run being generated
+ * @param {string} billRunId - the ID of the two-part tariff bill run being generated
  * @param {module:LicenceModel} licence - the two-part tariff licence included in the bill run, along with their match
  * and allocation results
  */

--- a/app/services/bill-runs/two-part-tariff/prepare-charge-version.service.js
+++ b/app/services/bill-runs/two-part-tariff/prepare-charge-version.service.js
@@ -24,7 +24,7 @@ const DetermineChargePeriodService = require('../determine-charge-period.service
  * abstractionPeriods.
  *
  * @param {module:ChargeVersionModel} chargeVersion - The charge version to prepare
- * @param {Object} billingPeriod Object with a `startDate` and `endDate` property representing the period being billed
+ * @param {object} billingPeriod - Object with a `startDate` and `endDate` property representing the period being billed
  */
 function go (chargeVersion, billingPeriod) {
   const { chargeReferences } = chargeVersion

--- a/app/services/bill-runs/two-part-tariff/prepare-return-logs.service.js
+++ b/app/services/bill-runs/two-part-tariff/prepare-return-logs.service.js
@@ -19,7 +19,7 @@ const { periodsOverlap } = require('../../../lib/general.lib.js')
  * issues.
  *
  * @param {module:LicenceModel} licence - An individual licence to prepare the return logs for
- * @param {Object} billingPeriod Object with a `startDate` and `endDate` property representing the period being billed
+ * @param {object} billingPeriod - Object with a `startDate` and `endDate` property representing the period being billed
  */
 async function go (licence, billingPeriod) {
   await _prepareReturnLogs(licence, billingPeriod)

--- a/app/services/bill-runs/two-part-tariff/process-bill-run.service.js
+++ b/app/services/bill-runs/two-part-tariff/process-bill-run.service.js
@@ -20,7 +20,7 @@ const MatchAndAllocateService = require('./match-and-allocate.service.js')
  * the bill run if an error occurs during the process.
  *
  * @param {module:BillRunModel} billRun - The two-part tariff bill run being processed
- * @param {Object[]} billingPeriods - An array of billing periods each containing a `startDate` and `endDate`. For 2PT
+ * @param {object[]} billingPeriods - An array of billing periods each containing a `startDate` and `endDate`. For 2PT
  * this will only ever contain a single period
  */
 async function go (billRun, billingPeriods) {

--- a/app/services/bill-runs/two-part-tariff/process-billing-period.service.js
+++ b/app/services/bill-runs/two-part-tariff/process-billing-period.service.js
@@ -22,10 +22,10 @@ const BillingConfig = require('../../../../config/billing.config.js')
  * Process the billing accounts for a given billing period and creates their annual two-part tariff bills
  *
  * @param {module:BillRunModel} billRun - The two-part tariff bill run we need to process
- * @param {Object} billingPeriod - An object representing the financial year the bills will be for
+ * @param {object} billingPeriod - An object representing the financial year the bills will be for
  * @param {module:BillingAccountModel[]} billingAccounts - The billing accounts to create bills for
  *
- * @returns {Promise<Boolean>} true if the bill run is not empty (there are transactions to bill) else false
+ * @returns {Promise<boolean>} true if the bill run is not empty (there are transactions to bill) else false
  */
 async function go (billRun, billingPeriod, billingAccounts) {
   let billRunIsPopulated = false
@@ -173,11 +173,11 @@ function _extractBillableLicences (allBillLicences) {
  * Because we're processing the charge versions for a billing account the same licence might appear more than once. This
  * means we need to find the existing bill licence record or if one doesn't exist create it.
  *
- * @param {Object[]} billLicences - The existing bill licences created for the bill being generated
- * @param {Object} licence - the licence we're looking for an existing bill licence record
- * @param {String} billId - the ID of the bill we're creating
+ * @param {object[]} billLicences - The existing bill licences created for the bill being generated
+ * @param {object} licence - the licence we're looking for an existing bill licence record
+ * @param {string} billId - the ID of the bill we're creating
  *
- * @return {Object} returns either an existing bill licence or a new one for the licence and bill being generated
+ * @return {object} returns either an existing bill licence or a new one for the licence and bill being generated
  */
 function _findOrCreateBillLicence (billLicences, licence, billId) {
   const { id: licenceId, licenceRef } = licence

--- a/app/services/bill-runs/two-part-tariff/remove-bill-run-licence.service.js
+++ b/app/services/bill-runs/two-part-tariff/remove-bill-run-licence.service.js
@@ -15,7 +15,7 @@ const RemoveBillRunLicencePresenter = require('../../../presenters/bill-runs/two
  * @param {string} billRunId - The UUID of the bill run that the licence is in
  * @param {string} licenceId - UUID of the licence to remove from the bill run
  *
- * @returns {Promise<Object>} an object representing the `pageData` needed by the remove licence template. It contains
+ * @returns {Promise<object>} an object representing the `pageData` needed by the remove licence template. It contains
  * details of the bill run & the licence reference.
  */
 async function go (billRunId, licenceId) {

--- a/app/services/bill-runs/two-part-tariff/review-bill-run.service.js
+++ b/app/services/bill-runs/two-part-tariff/review-bill-run.service.js
@@ -12,11 +12,11 @@ const ReviewBillRunPresenter = require('../../../presenters/bill-runs/two-part-t
 /**
  * Orchestrates fetching and presenting the data needed for the review bill run page
  *
- * @param {String} id The UUID for the bill run to review
+ * @param {string} id - The UUID for the bill run to review
  * @param {string} page - the page number of licences to be viewed
- * @param {Object} yar - The Hapi `request.yar` session manager passed on by the controller
+ * @param {object} yar - The Hapi `request.yar` session manager passed on by the controller
  *
- * @returns {Promise<Object>} An object representing the `pageData` needed by the review bill run template. It contains
+ * @returns {Promise<object>} An object representing the `pageData` needed by the review bill run template. It contains
  * details of the bill run and the licences linked to it as well as any data that has been used to filter the results.
  */
 async function go (id, page, yar) {

--- a/app/services/bill-runs/two-part-tariff/review-licence.service.js
+++ b/app/services/bill-runs/two-part-tariff/review-licence.service.js
@@ -13,9 +13,9 @@ const ReviewLicencePresenter = require('../../../presenters/bill-runs/two-part-t
  *
  * @param {module:BillRunModel} billRunId - The UUID for the bill run
  * @param {module:LicenceModel} licenceId - The UUID of the licence that is being reviewed
- * @param {Object} yar - The Hapi `request.yar` session manager passed on by the controller
+ * @param {object} yar - The Hapi `request.yar` session manager passed on by the controller
  *
- * @returns {Promise<Object>} the 'pageData' needed for the review licence page. It contains the licence, bill run,
+ * @returns {Promise<object>} the 'pageData' needed for the review licence page. It contains the licence, bill run,
  * matched and unmatched returns and the licence charge data
  */
 async function go (billRunId, licenceId, yar) {

--- a/app/services/bill-runs/two-part-tariff/submit-amended-adjustment-factor.service.js
+++ b/app/services/bill-runs/two-part-tariff/submit-amended-adjustment-factor.service.js
@@ -13,13 +13,13 @@ const ReviewChargeReferenceModel = require('../../../models/review-charge-refere
 /**
  * Orchestrates validating the data for the amend adjustment factor page and patching the db value
 
- * @param {String} billRunId - The UUID for the bill run
- * @param {String} licenceId - The UUID of the licence that is being reviewed
- * @param {String} reviewChargeReferenceId - The UUID of the review charge reference being updated
- * @param {Object} payload - The submitted form data
- * @param {Object} yar - The Hapi `request.yar` session manager passed on by the controller
+ * @param {string} billRunId - The UUID for the bill run
+ * @param {string} licenceId - The UUID of the licence that is being reviewed
+ * @param {string} reviewChargeReferenceId - The UUID of the review charge reference being updated
+ * @param {object} payload - The submitted form data
+ * @param {object} yar - The Hapi `request.yar` session manager passed on by the controller
  *
- * @returns {Promise<Object>} The updated value for the adjustment factor
+ * @returns {Promise<object>} The updated value for the adjustment factor
  */
 async function go (billRunId, licenceId, reviewChargeReferenceId, payload, yar) {
   const validationResult = _validate(payload)

--- a/app/services/bill-runs/two-part-tariff/submit-amended-authorised-volume.service.js
+++ b/app/services/bill-runs/two-part-tariff/submit-amended-authorised-volume.service.js
@@ -13,13 +13,13 @@ const ReviewChargeReferenceModel = require('../../../models/review-charge-refere
 /**
  * Orchestrates validating the data for the amend authorised volume page and patching the db value
  *
- * @param {String} billRunId - The UUID for the bill run
- * @param {String} licenceId - The UUID of the licence that is being reviewed
- * @param {String} reviewChargeReferenceId - The UUID of the review charge reference being updated
- * @param {Object} payload - The submitted form data
- * @param {Object} yar - The Hapi `request.yar` session manager passed on by the controller
+ * @param {string} billRunId - The UUID for the bill run
+ * @param {string} licenceId - The UUID of the licence that is being reviewed
+ * @param {string} reviewChargeReferenceId - The UUID of the review charge reference being updated
+ * @param {object} payload - The submitted form data
+ * @param {object} yar - The Hapi `request.yar` session manager passed on by the controller
  *
- * @returns {Promise<Object>} The updated value for the authorised volume
+ * @returns {Promise<object>} The updated value for the authorised volume
  */
 async function go (billRunId, licenceId, reviewChargeReferenceId, payload, yar) {
   const validationResult = _validate(payload)

--- a/app/services/bill-runs/two-part-tariff/submit-amended-billable-returns.service.js
+++ b/app/services/bill-runs/two-part-tariff/submit-amended-billable-returns.service.js
@@ -13,13 +13,13 @@ const ReviewChargeElementModel = require('../../../models/review-charge-element.
 /**
  * Orchestrates validating the data for the amend billable returns page and patching the db value
  *
- * @param {String} billRunId - The UUID for the bill run
- * @param {String} licenceId - The UUID of the licence that is being reviewed
- * @param {String} reviewChargeElementId - The UUID of the review charge element being updated
- * @param {Object} payload - The submitted form data
- * @param {Object} yar - The Hapi `request.yar` session manager passed on by the controller
+ * @param {string} billRunId - The UUID for the bill run
+ * @param {string} licenceId - The UUID of the licence that is being reviewed
+ * @param {string} reviewChargeElementId - The UUID of the review charge element being updated
+ * @param {object} payload - The submitted form data
+ * @param {object} yar - The Hapi `request.yar` session manager passed on by the controller
  *
- * @returns {Promise<Object>} The updated value for the billable returns
+ * @returns {Promise<object>} The updated value for the billable returns
  */
 async function go (billRunId, licenceId, reviewChargeElementId, payload, yar) {
   const validationResult = _validate(payload)

--- a/app/services/bill-runs/two-part-tariff/submit-remove-bill-run-licence.service.js
+++ b/app/services/bill-runs/two-part-tariff/submit-remove-bill-run-licence.service.js
@@ -21,7 +21,7 @@ const ReviewLicenceModel = require('../../../models/review-licence.model.js')
  *
  * @param {string} billRunId - The UUID of the bill run that the licence is in
  * @param {string} licenceId - UUID of the licence to remove from the bill run
- * @param {Object} yar - The Hapi `request.yar` session manager passed on by the controller
+ * @param {object} yar - The Hapi `request.yar` session manager passed on by the controller
  *
  * @returns {Promise<boolean>} true if all the licences have been removed from the bill run else false
  */

--- a/app/services/bill-runs/two-part-tariff/submit-review-bill-run.service.js
+++ b/app/services/bill-runs/two-part-tariff/submit-review-bill-run.service.js
@@ -8,9 +8,9 @@
 /**
  * Updates the session cookie with the filter data needed for the two-part tariff review bill run page
  *
- * @param {String} billRunId - The UUID of the bill run
- * @param {Object} payload The `request.payload` containing the filter data.
- * @param {Object} yar - The Hapi `request.yar` session manager passed on by the controller
+ * @param {string} billRunId - The UUID of the bill run
+ * @param {object} payload - The `request.payload` containing the filter data.
+ * @param {object} yar - The Hapi `request.yar` session manager passed on by the controller
  */
 async function go (billRunId, payload, yar) {
   const clearFilters = payload?.clearFilters

--- a/app/services/bill-runs/two-part-tariff/submit-review-licence.service.js
+++ b/app/services/bill-runs/two-part-tariff/submit-review-licence.service.js
@@ -20,10 +20,10 @@ const ReviewLicenceModel = require('../../../models/review-licence.model.js')
  *
  * @param {module:BillRunModel} billRunId - The UUID for the bill run
  * @param {module:LicenceModel} licenceId - The UUID of the licence that is being reviewed
- * @param {Object} payload - The Hapi `request.payload` object passed on by the controller
- * @param {Object} yar - The Hapi `request.yar` session manager passed on by the controller
+ * @param {object} payload - The Hapi `request.payload` object passed on by the controller
+ * @param {object} yar - The Hapi `request.yar` session manager passed on by the controller
  *
- * @returns {Promise<Object>} resolves to the result of the update query. Not intended to be used
+ * @returns {Promise<object>} resolves to the result of the update query. Not intended to be used
  */
 async function go (billRunId, licenceId, payload, yar) {
   const parsedPayload = _parsePayload(payload)

--- a/app/services/bill-runs/view-bill-run.service.js
+++ b/app/services/bill-runs/view-bill-run.service.js
@@ -14,9 +14,9 @@ const FetchBillRunService = require('./fetch-bill-run.service.js')
 /**
  * Orchestrates fetching and presenting the data needed for the bill run page
  *
- * @param {string} id The UUID for the bill run to view
+ * @param {string} id - The UUID for the bill run to view
  *
- * @returns {Promise<Object>} an object representing the `pageData` needed by the view bill run template. It contains
+ * @returns {Promise<object>} an object representing the `pageData` needed by the view bill run template. It contains
  * details of the bill run and the bills linked to it plus the page title.
  */
 async function go (id) {

--- a/app/services/billing-accounts/change-address.service.js
+++ b/app/services/billing-accounts/change-address.service.js
@@ -44,12 +44,12 @@ const SendCustomerChangeService = require('./send-customer-change.service.js')
  * Add to that all SOP wants is a name and address which means we have to do a lot of work to format the data we receive
  * into something the CHA will accept.
  *
- * @param {String} billingAccountId The UUID for the billing account being updated
- * @param {Object} address The validated address details
- * @param {Object} [agentCompany] The validated agent company details
- * @param {Object} [contact] The validated contact details
+ * @param {string} billingAccountId - The UUID for the billing account being updated
+ * @param {object} address - The validated address details
+ * @param {object} [agentCompany] - The validated agent company details
+ * @param {object} [contact] - The validated contact details
  *
- * @returns {Promise<Object>} contains a copy of the persisted address, agent company and contact if they were also
+ * @returns {Promise<object>} contains a copy of the persisted address, agent company and contact if they were also
  * changed
  */
 async function go (billingAccountId, address, agentCompany = {}, contact = {}) {
@@ -113,13 +113,13 @@ async function _fetchBillingAccount (billingAccountId) {
  * The object we return has all 3 entities whether they were persisted or not. This gets passed back to the UI via the
  * controller and is what it needs to then be able to redirect the user to the correct page.
  *
- * @param {Date} timestamp the timestamp to be used for any date created or updated values when persisting
- * @param {module:BillingAccountModel} billingAccount the billing account having its address changed
- * @param {module:AddressModel} address the new address to be persisted (expected to be populated)
- * @param {module:CompanyModel} company the new agent company to be persisted (not expected to be populated)
- * @param {module:ContactModel} contact the new contact to be persisted (not expected to be populated)
+ * @param {Date} timestamp - the timestamp to be used for any date created or updated values when persisting
+ * @param {module:BillingAccountModel} billingAccount - the billing account having its address changed
+ * @param {module:AddressModel} address - the new address to be persisted (expected to be populated)
+ * @param {module:CompanyModel} company - the new agent company to be persisted (not expected to be populated)
+ * @param {module:ContactModel} contact - the new contact to be persisted (not expected to be populated)
  *
- * @returns {Promise<Object>} a single object that contains the persisted billingAccountAddress, plus address, agent
+ * @returns {Promise<object>} a single object that contains the persisted billingAccountAddress, plus address, agent
  * company and contact
  */
 async function _persist (timestamp, billingAccount, address, company, contact) {

--- a/app/services/billing-accounts/send-customer-change.service.js
+++ b/app/services/billing-accounts/send-customer-change.service.js
@@ -22,12 +22,12 @@ const ExpandedError = require('../../errors/expanded.error.js')
  *
  * Should the request fail it will generate and throw an error.
  *
- * @param {module:BillingAccountModel} billingAccount The billing account we are changing the address details
+ * @param {module:BillingAccountModel} billingAccount - The billing account we are changing the address details
  * for
- * @param {module:AddressModel} address The new address
- * @param {module:CompanyModel} company The agent company for the billing account if one was selected or setup by the
+ * @param {module:AddressModel} address - The new address
+ * @param {module:CompanyModel} company - The agent company for the billing account if one was selected or setup by the
  * user during the change address journey
- * @param {module:ContactModel} contact The new contact for the billing account if an FAO was setup by the user during
+ * @param {module:ContactModel} contact - The new contact for the billing account if an FAO was setup by the user during
  * the change address journey
  */
 async function go (billingAccount, address, company, contact) {

--- a/app/services/bills/fetch-bill-service.js
+++ b/app/services/bills/fetch-bill-service.js
@@ -13,9 +13,9 @@ const { db } = require('../../../db/db.js')
  *
  * Was built to provide the data needed for the '/bills/{id}' page
  *
- * @param {string} id The UUID for the bill to fetch
+ * @param {string} id - The UUID for the bill to fetch
  *
- * @returns {Promise<Object>} the matching instance of BillModel plus a summary (ID, reference, and total net amount)
+ * @returns {Promise<object>} the matching instance of BillModel plus a summary (ID, reference, and total net amount)
  * for each licence linked to the bill
  */
 async function go (id) {

--- a/app/services/bills/fetch-bill-summary.service.js
+++ b/app/services/bills/fetch-bill-summary.service.js
@@ -18,7 +18,7 @@ const BillModel = require('../../models/bill.model.js')
  *
  * @param {string} billId - The UUID for the bill to fetch a summary of
  *
- * @returns {Promise<Object>} the matching instance of BillModel plus the linked billing account and bill
+ * @returns {Promise<object>} the matching instance of BillModel plus the linked billing account and bill
  * run. Also all bill licences linked to the bill so we can display which licences are in the bill
  */
 async function go (billId) {

--- a/app/services/bills/remove-bill.service.js
+++ b/app/services/bills/remove-bill.service.js
@@ -13,7 +13,7 @@ const RemoveBillPresenter = require('../../presenters/bills/remove-bill.presente
  *
  * @param {string} billId - The UUID for the bill to remove
  *
- * @returns {Promise<Object>} a formatted representation of the bill, its billing account and the bill run it is linked
+ * @returns {Promise<object>} a formatted representation of the bill, its billing account and the bill run it is linked
  * to for the remove bill page
  */
 async function go (billId) {

--- a/app/services/bills/submit-remove-bill.service.js
+++ b/app/services/bills/submit-remove-bill.service.js
@@ -12,7 +12,7 @@ const LegacyDeleteBillRequest = require('../../requests/legacy/delete-bill.reque
  * Orchestrates the removing of a bill from a bill run
  *
  * @param {string} billId - UUID of the bill to be removed
- * @param {Object} user - Instance of `UserModel` that represents the user making the request
+ * @param {object} user - Instance of `UserModel` that represents the user making the request
  *
  * @returns {Promise<string>} Returns the redirect path the controller needs
  */

--- a/app/services/bills/view-bill.service.js
+++ b/app/services/bills/view-bill.service.js
@@ -24,9 +24,9 @@ const ViewLicenceSummariesPresenter = require('../../presenters/bills/view-licen
  * Else when there is just 1 licence we show all the transactions details instead (saving the user an extra click!). For
  * this we need to fetch the bill licence and use `ViewBillLicencePresenter` to generate the data.
  *
- * @param {string} id The UUID for the bill to view
+ * @param {string} id - The UUID for the bill to view
  *
- * @returns {Promise<Object>} a formatted representation of the bill, its bill run and billing account plus summaries
+ * @returns {Promise<object>} a formatted representation of the bill, its bill run and billing account plus summaries
  * for all the licences linked to the bill for use in the bill view page
  */
 async function go (id) {

--- a/app/services/data/deduplicate/submit-deduplicate.service.js
+++ b/app/services/data/deduplicate/submit-deduplicate.service.js
@@ -20,7 +20,7 @@ const DeDuplicateService = require('./de-duplicate-licence.service.js')
  * controller will redirect the user to the search page and have it search for the licence reference. If the tool has
  * done its job the page should no longer error.
  *
- * @returns {Promise<Object>} an object containing a parsed version of the licence reference submitted else an error
+ * @returns {Promise<object>} an object containing a parsed version of the licence reference submitted else an error
  * message if nothing was entered
  */
 async function go (payload) {

--- a/app/services/data/load/load.service.js
+++ b/app/services/data/load/load.service.js
@@ -195,9 +195,9 @@ const LOAD_HELPERS = {
  * `LicenceDocumentHeaderHelper`. You _must_ provide all elements for the query. Transformed to SQL this would be
  * `SELECT entity_id FROM crm.entity WHERE entity_type = 'regime'`.
  *
- * @param {Object} payload - the body from the request containing the entities to be created
+ * @param {object} payload - the body from the request containing the entities to be created
  *
- * @returns {Promise<Object>} for each entity type passed in an array of ID's for the records created, for example
+ * @returns {Promise<object>} for each entity type passed in an array of ID's for the records created, for example
  *
  * ```javascript
  * {

--- a/app/services/fetch-billing-account.service.js
+++ b/app/services/fetch-billing-account.service.js
@@ -10,7 +10,7 @@ const BillingAccount = require('../models/billing-account.model.js')
 /**
  * Fetch the matching Billing account plus the current billing account address record linked to it
  *
- * @param {string} id The UUID for the billing account to fetch
+ * @param {string} id - The UUID for the billing account to fetch
  *
  * @returns the matching instance of BillModel including linked company and just the current account address record
  */

--- a/app/services/health/fetch-import-jobs.service.js
+++ b/app/services/health/fetch-import-jobs.service.js
@@ -74,7 +74,7 @@ async function go () {
 /**
  * Calculates the current date minus the number of days passed to it
  *
- * @param {Number} days The number of days to be deducted from the currect date
+ * @param {number} days - The number of days to be deducted from the currect date
  *
  * @returns {Date} The current date minus the number days passed to the function
  */

--- a/app/services/health/fetch-system-info.service.js
+++ b/app/services/health/fetch-system-info.service.js
@@ -12,7 +12,7 @@ const exec = util.promisify(require('child_process').exec)
 /**
  * Returns information about the `system` repo in the format required by the info service
  *
- * @returns {Promise<Object>} An object containing the `name`, `serviceName`, `version`, `commit` & `jobs`
+ * @returns {Promise<object>} An object containing the `name`, `serviceName`, `version`, `commit` & `jobs`
  */
 async function go () {
   return {

--- a/app/services/idm/fetch-user-roles-and-groups.service.js
+++ b/app/services/idm/fetch-user-roles-and-groups.service.js
@@ -18,9 +18,9 @@ const UserModel = require('../../models/user.model.js')
  * later added to a group which also includes that role). It also returns an array of groups that the user is a member
  * of, along with `userFound` to explicitly indicate whether or not the user id exists.
  *
- * @param {Number} userId The user id to get roles and groups for
+ * @param {number} userId - The user id to get roles and groups for
  *
- * @returns {Promise<Object>} result The resulting roles and groups
+ * @returns {Promise<object>} result The resulting roles and groups
  * @returns {UserModel} result.user Returns the UserModel representing the user, or `null` if the user is not found
  * @returns {RoleModel[]} result.roles An array of RoleModel objects representing the roles the user has
  * @returns {GroupModel[]} result.groups An array of GroupModel objects representing the groups the user is a member of

--- a/app/services/import/legacy-import/fetch-licence-versions.service.js
+++ b/app/services/import/legacy-import/fetch-licence-versions.service.js
@@ -45,7 +45,7 @@ module.exports = {
 
 /**
  * A legacy licence version
- * @typedef {Object} LegacyLicenceVersionsType
+ * @typedef {object} LegacyLicenceVersionsType
  *
  * @property {string} EFF_ST_DATE - date in UK format | 'null'
  */

--- a/app/services/import/legacy-import/fetch-licence.service.js
+++ b/app/services/import/legacy-import/fetch-licence.service.js
@@ -58,7 +58,7 @@ module.exports = {
 /**
  * A legacy licence
  *
- * @typedef {Object} LegacyLicenceType
+ * @typedef {object} LegacyLicenceType
  *
  * @property {string} AREP_AREA_CODE
  * @property {string} AREP_EIUC_CODE

--- a/app/services/import/legacy-import/licence.mapper.js
+++ b/app/services/import/legacy-import/licence.mapper.js
@@ -35,7 +35,7 @@ function _mapLicence (licence, licenceVersions) {
 /**
  * Creates a JSON object of the region data
  *
- * @param {Object} licenceData
+ * @param {object} licenceData
  * @return {RegionsType}
  */
 const _regions = (licenceData) => {
@@ -58,7 +58,7 @@ const _regions = (licenceData) => {
  *
  * @param {LegacyLicenceType} licence
  * @param {LegacyLicenceVersionsArray} licenceVersions
- * @return {String} YYYY-MM-DD
+ * @return {string} YYYY-MM-DD
  */
 const _startDate = (licence, licenceVersions) => {
   if (licence.ORIG_EFF_DATE !== 'null') {

--- a/app/services/import/legacy-licence.service.js
+++ b/app/services/import/legacy-licence.service.js
@@ -15,7 +15,7 @@ const PersistLicenceService = require('./persist-licence.service.js')
  * Imports a licence from the legacy import tables. Maps and validates the data and then saves to the database.
  *
  * @param {string} licenceRef - The licence reference of the licence
- * @returns {Promise<Object>} an object representing the saved licence in the database
+ * @returns {Promise<object>} an object representing the saved licence in the database
  */
 async function go (licenceRef) {
   const licenceData = await FetchLegacyImportLicenceService.go(licenceRef)

--- a/app/services/import/licence-validator.service.js
+++ b/app/services/import/licence-validator.service.js
@@ -24,7 +24,7 @@ module.exports = {
 
 /**
  * A valid licence that is in the correct shape / format to save in the database
- * @typedef {Object} ImportLicenceType
+ * @typedef {object} ImportLicenceType
  *
  * @property {string | null} expiredDate
  * @property {string | null} lapsedDate
@@ -38,7 +38,7 @@ module.exports = {
 
 /**
  * A valid licence 'regions' json colum
- * @typedef {Object} RegionsType
+ * @typedef {object} RegionsType
  *
  * @property {string} regionalChargeArea
  * @property {string} localEnvironmentAgencyPlanCode

--- a/app/services/import/licence-version-purpose-condition.service.js
+++ b/app/services/import/licence-version-purpose-condition.service.js
@@ -10,7 +10,7 @@ const LicenceVersionPurposeConditionValidator = require('../../validators/import
 /**
  * Add a new licence version purpose condition
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  *
  * @returns {Promise<module:LicenceVersionPurposeConditionModel>} The instance of the newly created record
  */

--- a/app/services/jobs/export/compress-schema-folder.service.js
+++ b/app/services/jobs/export/compress-schema-folder.service.js
@@ -10,9 +10,9 @@ const tar = require('tar')
 /**
  * Create a compressed tarball (.tgz) from a given schema folder
  *
- * @param {String} schemaFolderPath
+ * @param {string} schemaFolderPath
  *
- * @returns {Promise<String>} The path to the created tarball file
+ * @returns {Promise<string>} The path to the created tarball file
  */
 async function go (schemaFolderPath) {
   const file = `${schemaFolderPath}.tgz`

--- a/app/services/jobs/export/convert-to-csv.service.js
+++ b/app/services/jobs/export/convert-to-csv.service.js
@@ -8,9 +8,9 @@
 /**
  * Converts data to a CSV formatted string
  *
- * @param {String[]} data - An array representing either the headers or rows from a db table
+ * @param {string[]} data - An array representing either the headers or rows from a db table
  *
- * @returns {String} A CSV formatted string
+ * @returns {string} A CSV formatted string
  */
 function go (data) {
   if (!data) {

--- a/app/services/jobs/export/delete-files.service.js
+++ b/app/services/jobs/export/delete-files.service.js
@@ -10,7 +10,7 @@ const fsPromises = require('fs').promises
 /**
  * Deletes a folder and its content or an individual file
  *
- * @param {String} path The folder or file path that we want to delete
+ * @param {string} path - The folder or file path that we want to delete
  */
 async function go (path) {
   try {

--- a/app/services/jobs/export/export-table.service.js
+++ b/app/services/jobs/export/export-table.service.js
@@ -14,9 +14,9 @@ const WriteTableToFileService = require('./write-table-to-file.service.js')
  * Exports the specific database table by fetching the database query (input stream) and passing it to a write stream
  * service which transforms the data to a CSV format
  *
- * @param {String} tableName The name of the database table to export
- * @param {String} schemaFolderPath The folder path where the schema files are stored
- * @param {String} schemaName The name of the database schema
+ * @param {string} tableName - The name of the database table to export
+ * @param {string} schemaFolderPath - The folder path where the schema files are stored
+ * @param {string} schemaName - The name of the database schema
  */
 async function go (tableName, schemaFolderPath, schemaName) {
   const data = await FetchTableService.go(tableName, schemaName)

--- a/app/services/jobs/export/fetch-table-names.service.js
+++ b/app/services/jobs/export/fetch-table-names.service.js
@@ -10,9 +10,9 @@ const { db } = require('../../../../db/db.js')
 /**
  * Retrieves the table names for a specific schema
  *
- * @param schemaName The name of the schema from which to fetch the table names
+ * @param schemaName - The name of the schema from which to fetch the table names
  *
- * @returns {Promise<String[]>} Table names for the specified schema
+ * @returns {Promise<string[]>} Table names for the specified schema
  */
 async function go (schemaName) {
   const tableData = await _fetchTableNames(schemaName)

--- a/app/services/jobs/export/fetch-table.service.js
+++ b/app/services/jobs/export/fetch-table.service.js
@@ -11,10 +11,10 @@ const { db } = require('../../../../db/db.js')
  * Retrieves headers, a knex query for the table rows and the table name from the table in the db, and returns them as
  * an object
  *
- * @param {String} tableName The name of the table to retrieve
- * @param {string} schemaName The schema that the table belongs to
+ * @param {string} tableName - The name of the table to retrieve
+ * @param {string} schemaName - The schema that the table belongs to
  *
- * @returns {Promise<Object>} The headers, query and table name from the table
+ * @returns {Promise<object>} The headers, query and table name from the table
  */
 async function go (tableName, schemaName) {
   const data = {

--- a/app/services/jobs/export/schema-export.service.js
+++ b/app/services/jobs/export/schema-export.service.js
@@ -19,7 +19,7 @@ const SendToS3BucketService = require('./send-to-s3-bucket.service.js')
  * into a compressed tarball file and uploading this to the S3 bucket. Finally deleting the schema folder and the
  * schema.tgz file
  *
- * @param {String} schemaName The name of the database schema to export
+ * @param {string} schemaName - The name of the database schema to export
  */
 async function go (schemaName) {
   const schemaFolderPath = _folderToUpload(schemaName)
@@ -45,9 +45,9 @@ async function go (schemaName) {
 /**
  * Generates the folder path where the schema will be temporarily stored for upload
  *
- * @param {String} schemaName The name of the database schema
+ * @param {string} schemaName - The name of the database schema
  *
- * @returns {String} The folder path where the schema will be temporarily stored
+ * @returns {string} The folder path where the schema will be temporarily stored
  */
 function _folderToUpload (schemaName) {
   const temporaryFilePath = os.tmpdir()

--- a/app/services/jobs/export/send-to-s3-bucket.service.js
+++ b/app/services/jobs/export/send-to-s3-bucket.service.js
@@ -17,7 +17,7 @@ const S3Config = require('../../../../config/s3.config.js')
 /**
  * Sends a file to our AWS S3 Bucket using the filePath that it receives
  *
- * @param {String} filePath A string containing the path of the file to send to the S3 bucket
+ * @param {string} filePath - A string containing the path of the file to send to the S3 bucket
  */
 async function go (filePath) {
   const bucketName = S3Config.s3.bucket

--- a/app/services/jobs/export/write-table-to-file.service.js
+++ b/app/services/jobs/export/write-table-to-file.service.js
@@ -15,9 +15,9 @@ const ConvertToCSVService = require('./convert-to-csv.service.js')
 
 /**
  * Converts data into CSV format and writes it to a file
- *  @param {Object} data The knex query to fetch the table
- *  @param {String} schemaFolderPath The folder path of the schema
- *  @param {String} tableName The name of the table
+ *  @param {object} data - The knex query to fetch the table
+ *  @param {string} schemaFolderPath - The folder path of the schema
+ *  @param {string} tableName - The name of the table
  */
 async function go (headers, rows, schemaFolderPath, tableName) {
   const filePath = await _filenameWithPath(tableName, schemaFolderPath)
@@ -55,10 +55,10 @@ function _transformDataStream () {
  * Returns a file path by joining the schema folder path with the file name.
  * The schema path has already been created with the temporary directory
  *
- * @param {String} tableName The name of the table
- * @param {String} schemaFolderPath The folder path of the schema
+ * @param {string} tableName - The name of the table
+ * @param {string} schemaFolderPath - The folder path of the schema
  *
- * @returns {Promise<String>} The full file path
+ * @returns {Promise<string>} The full file path
  */
 async function _filenameWithPath (tableName, schemaFolderPath) {
   await fsPromises.mkdir(schemaFolderPath, { recursive: true })

--- a/app/services/jobs/licence-updates/fetch-licence-updates.service.js
+++ b/app/services/jobs/licence-updates/fetch-licence-updates.service.js
@@ -19,7 +19,7 @@ const { db } = require('../../../../db/db.js')
  * Also, if a workflow record already exists for the licence version, for example, it is already under review, it will
  * also be excluded from the results.
  *
- * @returns {Promise<Object[]>} The ID for each licence version created in the last 2 months without a workflow record,
+ * @returns {Promise<object[]>} The ID for each licence version created in the last 2 months without a workflow record,
  * plus associated licence ID and whether a charge version exists for the licence
  */
 async function go () {

--- a/app/services/jobs/time-limited/fetch-time-limited-licences.service.js
+++ b/app/services/jobs/time-limited/fetch-time-limited-licences.service.js
@@ -20,7 +20,7 @@ const { db } = require('../../../../db/db.js')
  * - not be linked to a licence in the workflow
  * - have a related `purpose` that is due to expire in less than 50 days
  *
- * @returns {Promise<Object[]>} The licence IDs with time-limited elements and their current licence version ID (needed
+ * @returns {Promise<object[]>} The licence IDs with time-limited elements and their current licence version ID (needed
  * else we break the workflow). Also the ID of the charge version that has the time limited charge element
  */
 async function go () {

--- a/app/services/licences/determine-licence-has-return-versions.service.js
+++ b/app/services/licences/determine-licence-has-return-versions.service.js
@@ -12,7 +12,7 @@ const ReturnVersionModel = require('../../models/return-version.model.js')
  *
  * @param {string} licenceId - The UUID of the licence to determine if return versions exist
  *
- * @returns {Promise<Boolean>} true if the licence has return versions else false
+ * @returns {Promise<boolean>} true if the licence has return versions else false
  */
 async function go (licenceId) {
   const requirement = await _fetch(licenceId)

--- a/app/services/licences/fetch-agreements.service.js
+++ b/app/services/licences/fetch-agreements.service.js
@@ -12,7 +12,7 @@ const LicenceAgreementModel = require('../../models/licence-agreement.model.js')
  *
  * @param {string} licenceRef - The licence ref for the licence to fetch licence agreements for
  *
- * @returns {Promise<Object>} the data needed to populate the view licence page's set up tab
+ * @returns {Promise<object>} the data needed to populate the view licence page's set up tab
  */
 async function go (licenceRef) {
   return _fetch(licenceRef)

--- a/app/services/licences/fetch-charge-versions.service.js
+++ b/app/services/licences/fetch-charge-versions.service.js
@@ -12,7 +12,7 @@ const ChargeVersionModel = require('../../models/charge-version.model.js')
  *
  * @param {string} licenceId - The UUID for the licence to fetch charge versions for
  *
- * @returns {Promise<Object>} the data needed to populate the view licence page's set up tab
+ * @returns {Promise<object>} the data needed to populate the view licence page's set up tab
  */
 async function go (licenceId) {
   return _fetch(licenceId)

--- a/app/services/licences/fetch-communications.service.js
+++ b/app/services/licences/fetch-communications.service.js
@@ -14,9 +14,9 @@ const DatabaseConfig = require('../../../config/database.config.js')
  *
  * Was built to provide the data needed for the '/licences/{id}/communications' page
  *
- * @param {string} licenceId The UUID for the licence to fetch
+ * @param {string} licenceId - The UUID for the licence to fetch
  *
- * @returns {Promise<Object>} the data needed to populate the view licence page's communications tab
+ * @returns {Promise<object>} the data needed to populate the view licence page's communications tab
  */
 async function go (licenceRef, page) {
   const { results, total } = await _fetch(licenceRef, page)

--- a/app/services/licences/fetch-customer-contacts.service.js
+++ b/app/services/licences/fetch-customer-contacts.service.js
@@ -12,7 +12,7 @@ const { db } = require('../../../db/db.js')
  *
  * @param {string} licenceId - The UUID for the licence to fetch
  *
- * @returns {Promise<Object>} the data needed to populate the view licence page's contact details tab
+ * @returns {Promise<object>} the data needed to populate the view licence page's contact details tab
  */
 async function go (licenceId) {
   return _fetch(licenceId)

--- a/app/services/licences/fetch-licence-bills.service.js
+++ b/app/services/licences/fetch-licence-bills.service.js
@@ -14,7 +14,7 @@ const DatabaseConfig = require('../../../config/database.config.js')
  *
  * @param {string} licenceId - The UUID for the licence to fetch
  *
- * @returns {Promise<Object>} the data needed to populate the view licence page's bills tab
+ * @returns {Promise<object>} the data needed to populate the view licence page's bills tab
  */
 async function go (licenceId, page) {
   const { results, total } = await _fetch(licenceId, page)

--- a/app/services/licences/fetch-licence-contacts.service.js
+++ b/app/services/licences/fetch-licence-contacts.service.js
@@ -12,7 +12,7 @@ const { db } = require('../../../db/db.js')
  *
  * @param {string} licenceId - The UUID for the licence to fetch
  *
- * @returns {Promise<Object>} the data needed to populate the view licence page's contact details tab
+ * @returns {Promise<object>} the data needed to populate the view licence page's contact details tab
  */
 async function go (licenceId) {
   return _fetch(licenceId)

--- a/app/services/licences/fetch-licence-returns.service.js
+++ b/app/services/licences/fetch-licence-returns.service.js
@@ -14,7 +14,7 @@ const DatabaseConfig = require('../../../config/database.config.js')
  *
  * @param {string} licenceId - The UUID for the licence to fetch
  *
- * @returns {Promise<Object>} the data needed to populate the view licence page's returns tab
+ * @returns {Promise<object>} the data needed to populate the view licence page's returns tab
  */
 async function go (licenceId, page) {
   const { results, total } = await _fetch(licenceId, page)

--- a/app/services/licences/fetch-licence.service.js
+++ b/app/services/licences/fetch-licence.service.js
@@ -12,9 +12,9 @@ const LicenceModel = require('../../models/licence.model.js')
  *
  * Was built to provide the data needed for the '/licences/{id}' page
  *
- * @param {string} id The UUID for the licence to fetch
+ * @param {string} id - The UUID for the licence to fetch
  *
- * @returns {Promise<Object>} the data needed to populate the view licence page and some elements of the summary tab
+ * @returns {Promise<object>} the data needed to populate the view licence page and some elements of the summary tab
  */
 async function go (id) {
   const licence = await _fetchLicence(id)

--- a/app/services/licences/fetch-return-versions.service.js
+++ b/app/services/licences/fetch-return-versions.service.js
@@ -12,7 +12,7 @@ const ReturnVersionModel = require('../../models/return-version.model.js')
  *
  * @param {string} licenceId - The licence id for the licence to fetch return requirements
  *
- * @returns {Promise<Object>} the data needed to populate the view licence page's set up tab
+ * @returns {Promise<object>} the data needed to populate the view licence page's set up tab
  */
 async function go (licenceId) {
   return _fetch(licenceId)

--- a/app/services/licences/fetch-workflows.service.js
+++ b/app/services/licences/fetch-workflows.service.js
@@ -12,7 +12,7 @@ const WorkflowModel = require('../../models/workflow.model.js')
  *
  * @param {string} licenceId - The UUID for the licence to fetch workflow data for
  *
- * @returns {Promise<Object>} the data needed to populate the view licence page's set up tab
+ * @returns {Promise<object>} the data needed to populate the view licence page's set up tab
  */
 async function go (licenceId) {
   return _fetch(licenceId)

--- a/app/services/licences/supplementary/create-licence-supplementary-year.service.js
+++ b/app/services/licences/supplementary/create-licence-supplementary-year.service.js
@@ -11,8 +11,8 @@ const LicenceSupplementaryYearModel = require('../../../models/licence-supplemen
  * Creates a licenceSupplementaryYears record based on the provided licence data
  *
  * @param {module:LicenceModel} licenceId - The UUID of the licence to be persisted
- * @param {Object[]} financialYearEnds - An array of the financial year ends to be persisted as individual records
- * @param {Boolean} twoPartTariff - If there are any two-part tariff indicators on the licence
+ * @param {object[]} financialYearEnds - An array of the financial year ends to be persisted as individual records
+ * @param {boolean} twoPartTariff - If there are any two-part tariff indicators on the licence
  */
 async function go (licenceId, financialYearEnds, twoPartTariff) {
   for (const financialYearEnd of financialYearEnds) {

--- a/app/services/licences/supplementary/determine-billing-years.service.js
+++ b/app/services/licences/supplementary/determine-billing-years.service.js
@@ -19,7 +19,7 @@ const LAST_PRE_SROC_FINANCIAL_YEAR_END = 2022
  * @param {Date} endDate - The end date up to which to calculate financial years. If not provided,
  * the current date will be used.
  *
- * @returns {Object[]} - The financial year end that are impacted by the changes between the start and end dates and are
+ * @returns {object[]} - The financial year end that are impacted by the changes between the start and end dates and are
  * relevant for SROC.
  */
 function go (startDate, endDate) {

--- a/app/services/licences/supplementary/determine-charge-version-years.service.js
+++ b/app/services/licences/supplementary/determine-charge-version-years.service.js
@@ -14,9 +14,9 @@ const ChargeVersionModel = require('../../../models/charge-version.model.js')
  * billing. This is worked out based on the charge versions scheme and if any related charge reference has a two-part
  * tariff indicator. If they do, then flagForBilling is set to true.
  *
- * @param {String} chargeVersionId - The UUID for the charge version to fetch
+ * @param {string} chargeVersionId - The UUID for the charge version to fetch
  *
- * @returns {Object} - An object containing the related licence, charge version start and end date and if the licence
+ * @returns {object} - An object containing the related licence, charge version start and end date and if the licence
  * should be flagged for two-part tariff supplementary billing
  */
 async function go (chargeVersionId) {

--- a/app/services/licences/supplementary/determine-existing-bill-run-years.service.js
+++ b/app/services/licences/supplementary/determine-existing-bill-run-years.service.js
@@ -18,11 +18,11 @@ const BillRunModel = require('../../../models/bill-run.model.js')
  * want to flag any years on the licence that hasn't had a bill run already created, as the change on the licence will
  * get picked up when the annual/ two-part tariff bill run is created for that year.
  *
- * @param {String} regionId - The UUID of the region to search for
- * @param {Object[]} years - The years that the licence can be flagged for
- * @param {Boolean} twoPartTariff - If there are two-part tariff indicators on the licence
+ * @param {string} regionId - The UUID of the region to search for
+ * @param {object[]} years - The years that the licence can be flagged for
+ * @param {boolean} twoPartTariff - If there are two-part tariff indicators on the licence
  *
- * @returns {Object[]} - The years that can be flagged for supplementary billing
+ * @returns {object[]} - The years that can be flagged for supplementary billing
  */
 async function go (regionId, years, twoPartTariff) {
   return _supplementaryBillingYears(regionId, years, twoPartTariff)

--- a/app/services/licences/supplementary/process-billing-flag.service.js
+++ b/app/services/licences/supplementary/process-billing-flag.service.js
@@ -29,7 +29,7 @@ const { calculateAndLogTimeTaken, currentTimeInNanoseconds } = require('../../..
  * Finally, we call the `CreateLicenceSupplementaryYearService`, which persists our final list of years along with the
  * licence ID and whether two-part tariff is true.
  *
- * @param {Object} payload - The payload from the request
+ * @param {object} payload - The payload from the request
  */
 async function go (payload) {
   try {

--- a/app/services/licences/view-licence-bills.service.js
+++ b/app/services/licences/view-licence-bills.service.js
@@ -15,7 +15,7 @@ const ViewLicenceService = require('./view-licence.service.js')
  *
  * @param {string} licenceId - The UUID of the licence
  *
- * @returns {Promise<Object>} an object representing the `pageData` needed by the licence bills template.
+ * @returns {Promise<object>} an object representing the `pageData` needed by the licence bills template.
  */
 async function go (licenceId, auth, page) {
   const commonData = await ViewLicenceService.go(licenceId, auth)

--- a/app/services/licences/view-licence-communications.service.js
+++ b/app/services/licences/view-licence-communications.service.js
@@ -14,9 +14,9 @@ const ViewLicenceService = require('./view-licence.service.js')
  * Orchestrates fetching and presenting the data needed for the licence communications page
  *
  * @param {string} licenceId - The UUID of the licence
- * @param {Object} auth - The auth object taken from `request.auth` containing user details
+ * @param {object} auth - The auth object taken from `request.auth` containing user details
  *
- * @returns {Promise<Object>} an object representing the `pageData` needed by the licence communication template.
+ * @returns {Promise<object>} an object representing the `pageData` needed by the licence communication template.
  */
 async function go (licenceId, auth, page) {
   const commonData = await ViewLicenceService.go(licenceId, auth)

--- a/app/services/licences/view-licence-contact-details.service.js
+++ b/app/services/licences/view-licence-contact-details.service.js
@@ -15,9 +15,9 @@ const ViewLicenceService = require('./view-licence.service.js')
  * Orchestrates fetching and presenting the data needed for the licence contact details page
  *
  * @param {string} licenceId - The UUID of the licence
- * @param {Object} auth - The auth object taken from `request.auth` containing user details
+ * @param {object} auth - The auth object taken from `request.auth` containing user details
  *
- * @returns {Promise<Object>} an object representing the `pageData` needed by the licence contact details template.
+ * @returns {Promise<object>} an object representing the `pageData` needed by the licence contact details template.
  */
 async function go (licenceId, auth) {
   const commonData = await ViewLicenceService.go(licenceId, auth)

--- a/app/services/licences/view-licence-returns.service.js
+++ b/app/services/licences/view-licence-returns.service.js
@@ -15,10 +15,10 @@ const ViewLicenceService = require('./view-licence.service.js')
  * Orchestrates fetching and presenting the data needed for the licence summary page
  *
  * @param {string} licenceId - The UUID of the licence
- * @param {Object} auth - The auth object taken from `request.auth` containing user details
- * @param {Object} page - The current page for the pagination service
+ * @param {object} auth - The auth object taken from `request.auth` containing user details
+ * @param {object} page - The current page for the pagination service
  *
- * @returns {Promise<Object>} an object representing the `pageData` needed by the licence summary template.
+ * @returns {Promise<object>} an object representing the `pageData` needed by the licence summary template.
  */
 async function go (licenceId, auth, page) {
   const commonData = await ViewLicenceService.go(licenceId, auth)

--- a/app/services/licences/view-licence-set-up.service.js
+++ b/app/services/licences/view-licence-set-up.service.js
@@ -16,9 +16,9 @@ const ViewLicenceService = require('./view-licence.service.js')
  * Orchestrates fetching and presenting the data needed for the licence set up page
  *
  * @param {string} licenceId - The UUID of the licence
- * @param {Object} auth - The auth object taken from `request.auth` containing user details
+ * @param {object} auth - The auth object taken from `request.auth` containing user details
  *
- * @returns {Promise<Object>} an object representing the `pageData` needed by the licence set up template.
+ * @returns {Promise<object>} an object representing the `pageData` needed by the licence set up template.
  */
 async function go (licenceId, auth) {
   const commonData = await ViewLicenceService.go(licenceId, auth)

--- a/app/services/licences/view-licence-summary.service.js
+++ b/app/services/licences/view-licence-summary.service.js
@@ -15,7 +15,7 @@ const ViewLicenceService = require('./view-licence.service.js')
  * @param {string} licenceId - The UUID of the licence
  * @param {object} auth - The auth object taken from `request.auth` containing user details
  *
- * @returns {Promise<Object>} an object representing the `pageData` needed by the licence summary template.
+ * @returns {Promise<object>} an object representing the `pageData` needed by the licence summary template.
  */
 async function go (licenceId, auth) {
   const commonData = await ViewLicenceService.go(licenceId, auth)

--- a/app/services/licences/view-licence.service.js
+++ b/app/services/licences/view-licence.service.js
@@ -12,8 +12,8 @@ const ViewLicencePresenter = require('../../presenters/licences/view-licence.pre
  * Orchestrates fetching and presenting the data needed for the licence summary page
  *
  * @param {string} licenceId - The UUID of the licence
- * @param {Object} auth - The auth object taken from `request.auth` containing user details
- * @returns {Promise<Object>} an object representing the `pageData` needed by the licence summary template.
+ * @param {object} auth - The auth object taken from `request.auth` containing user details
+ * @returns {Promise<object>} an object representing the `pageData` needed by the licence summary template.
  */
 async function go (licenceId, auth) {
   const licenceData = await FetchLicenceService.go(licenceId)

--- a/app/services/plugins/auth.service.js
+++ b/app/services/plugins/auth.service.js
@@ -20,16 +20,16 @@ const FetchUserRolesAndGroupsService = require('../idm/fetch-user-roles-and-grou
  *
  * Finally, we return a 'permission' object. This is used to determine which nav bar menu items a user sees.
  *
- * @param {Number} userId The user id to be authenticated
+ * @param {number} userId - The user id to be authenticated
  *
- * @returns {Object} response
- * @returns {Boolean} response.isValid Indicates whether the user was found
- * @returns {Object} response.credentials User credentials found in the IDM
+ * @returns {object} response
+ * @returns {boolean} response.isValid Indicates whether the user was found
+ * @returns {object} response.credentials User credentials found in the IDM
  * @returns {UserModel} response.credentials.user Object representing the user
  * @returns {RoleModel[]} response.credentials.roles Objects representing the roles the user has
  * @returns {GroupModel[]} response.credentials.groups Objects representing the groups the user is assigned to
- * @returns {String[]} response.credentials.scope The names of the roles the user has, for route authorisation purposes
- * @returns {Object} response.credentials.permission Object with each top level permission as a key and true or false
+ * @returns {string[]} response.credentials.scope The names of the roles the user has, for route authorisation purposes
+ * @returns {object} response.credentials.permission Object with each top level permission as a key and true or false
  * whether the user has authorisation to access the area
  */
 async function go (userId) {
@@ -60,9 +60,9 @@ async function go (userId) {
  *
  * They are used by the nav bar to determine which menu items should be visible.
  *
- * @param {String[]} scope All the scopes (roles) a user has access to
+ * @param {string[]} scope - All the scopes (roles) a user has access to
  *
- * @returns {Object} Each top level permissions is a key. The value is true or false as to whether the user has
+ * @returns {object} Each top level permissions is a key. The value is true or false as to whether the user has
  * permission to access that area of the service
  */
 function _permission (scope = []) {

--- a/app/services/plugins/error-pages.service.js
+++ b/app/services/plugins/error-pages.service.js
@@ -15,9 +15,9 @@
  * {@link https://hapi.dev/api/?v=21.3.2#response-toolkit | response toolkit} to continue with the response or not. If
  * not the `ErrorPagesPlugin` will use the `statusCode` returned to determine which error page to show.
  *
- * @param {Object} request An instance of a {@link https://hapi.dev/api/?v=21.3.2#request | Hapi request}
+ * @param {object} request - An instance of a {@link https://hapi.dev/api/?v=21.3.2#request | Hapi request}
  *
- * @returns {Object} Contains the properties `stopResponse:` and `statusCode:` which are used by the plugin to
+ * @returns {object} Contains the properties `stopResponse:` and `statusCode:` which are used by the plugin to
  * decide how to direct the response
  */
 function go (request) {
@@ -80,7 +80,7 @@ function _logError (statusCode, request) {
  * Finally, this service is called for _all_ responses so we need to handle standard responses, for example, 200 on a
  * request for an asset.
  *
- * @param {Object} request The instance of {@link https://hapi.dev/api/?v=21.3.2#request | Hapi request}
+ * @param {object} request - The instance of {@link https://hapi.dev/api/?v=21.3.2#request | Hapi request}
  *
  * @returns {boolean} true if the response should be stopped and redirected to an error page else false
  */

--- a/app/services/plugins/filter-routes.service.js
+++ b/app/services/plugins/filter-routes.service.js
@@ -23,10 +23,10 @@
  * This service is used by the `RouterPlugin` to check which routes need filtering before it then registers them with
  * the Hapi server instance.
  *
- * @param {Object[]} routes An array of Hapi routes expected to be provided by the `RouterPlugin`
- * @param {string} environment The current environment ('dev', 'tst', 'tra', 'pre' or 'prd')
+ * @param {object[]} routes - An array of Hapi routes expected to be provided by the `RouterPlugin`
+ * @param {string} environment - The current environment ('dev', 'tst', 'tra', 'pre' or 'prd')
  *
- * @returns {Object[]} an array of Hapi routes, filtered depending on the current environment and whether any paths
+ * @returns {object[]} an array of Hapi routes, filtered depending on the current environment and whether any paths
  * have been registered as needing filtering
  */
 function go (routes, environment) {

--- a/app/services/plugins/hapi-pino-ignore-request.service.js
+++ b/app/services/plugins/hapi-pino-ignore-request.service.js
@@ -31,8 +31,8 @@
  *
  * So, we also do not log any requests to `/assets/*`.
  *
- * @param {Object} _options The options passed to the HapiPino plugin
- * @param {request} request Hapi request object created internally for each incoming request
+ * @param {object} _options - The options passed to the HapiPino plugin
+ * @param {request} request - Hapi request object created internally for each incoming request
  *
  * @returns {boolean} true if the request should be ignored, else false
  */

--- a/app/services/plugins/hapi-pino-log-in-test.service.js
+++ b/app/services/plugins/hapi-pino-log-in-test.service.js
@@ -14,7 +14,7 @@
  * But there will be times when trying to diagnose an issue that we will want log output. So using an env var we can
  * override the default and tell hapi-pino to log everything as normal.
  *
- * @returns {Object} an empty object or one containing Hapi-pino config to tell it not to log events
+ * @returns {object} an empty object or one containing Hapi-pino config to tell it not to log events
  */
 function go (logInTest) {
   if (process.env.NODE_ENV !== 'test' || logInTest) {

--- a/app/services/plugins/payload-cleaning.service.js
+++ b/app/services/plugins/payload-cleaning.service.js
@@ -92,9 +92,9 @@ function go (payload) {
  * We store the result and then call `keepValue()` to determine if the property should be retained in the object. If
  * it should we add it to a new object we create and update as we loop through. Else we quietly drop it.
  *
- * @param {Object} obj The object you wish to loop through and clean
+ * @param {object} obj - The object you wish to loop through and clean
  *
- * @returns {Object} The cleaned object
+ * @returns {object} The cleaned object
  */
 function _cleanObject (obj) {
   if (obj === null) {
@@ -137,7 +137,7 @@ function _cleanObject (obj) {
  * We store the result and then call `keepValue()` to determine if the value should be retained in the array. If it
  * should we add it to a new array we create and update as we loop through. Else we quietly drop it.
  *
- * @param {Array} array The object you wish to loop through and clean
+ * @param {Array} array - The object you wish to loop through and clean
  * @returns {Array} The cleaned array
  */
 function _cleanArray (array) {
@@ -168,7 +168,7 @@ function _cleanArray (array) {
  *
  * This includes objects which end up as `{}`, empty arrays, and empty strings
  *
- * @param value Value we are making the decision for
+ * @param value - Value we are making the decision for
  *
  * @returns `true` if the `Object`, `Array` or `String` is not 'empty'. Else `false`
  */
@@ -196,7 +196,7 @@ function _keepValue (value) {
  *
  * Else we just return the value as is.
  *
- * @param value Value to be cleaned
+ * @param value - Value to be cleaned
  *
  * @returns The 'cleaned' value if a `String` else the original value
  */

--- a/app/services/return-requirements/abstraction-period.service.js
+++ b/app/services/return-requirements/abstraction-period.service.js
@@ -17,7 +17,7 @@ const SessionModel = require('../../models/session.model.js')
  * @param {string} sessionId - The UUID of the current session
  * @param {string} requirementIndex - The index of the requirement being added or changed
  *
- * @returns {Promise<Object>} The view data for the abstraction period page
+ * @returns {Promise<object>} The view data for the abstraction period page
 */
 async function go (sessionId, requirementIndex) {
   const session = await SessionModel.query().findById(sessionId)

--- a/app/services/return-requirements/additional-submission-options.service.js
+++ b/app/services/return-requirements/additional-submission-options.service.js
@@ -18,7 +18,7 @@ const SessionModel = require('../../models/session.model.js')
  *
  * @param {string} sessionId - The UUID of the current session
  *
- * @returns {Promise<Object>} The view data for the points page
+ * @returns {Promise<object>} The view data for the points page
 */
 async function go (sessionId) {
   const session = await SessionModel.query().findById(sessionId)

--- a/app/services/return-requirements/agreements-exceptions.service.js
+++ b/app/services/return-requirements/agreements-exceptions.service.js
@@ -17,7 +17,7 @@ const SessionModel = require('../../models/session.model.js')
  * @param {string} sessionId - The UUID of the current session
  * @param {string} requirementIndex - The index of the requirement being added or changed
  *
- * @returns {Promise<Object>} The view data for the agreements and exceptions page
+ * @returns {Promise<object>} The view data for the agreements and exceptions page
 */
 async function go (sessionId, requirementIndex) {
   const session = await SessionModel.query().findById(sessionId)

--- a/app/services/return-requirements/cancel.service.js
+++ b/app/services/return-requirements/cancel.service.js
@@ -16,7 +16,7 @@ const SessionModel = require('../../models/session.model.js')
  *
  * @param {string} sessionId - The UUID of the current session
  *
- * @returns {Promise<Object>} The view data for the cancel requirements page
+ * @returns {Promise<object>} The view data for the cancel requirements page
 */
 async function go (sessionId) {
   const session = await SessionModel.query().findById(sessionId)

--- a/app/services/return-requirements/check.service.js
+++ b/app/services/return-requirements/check.service.js
@@ -14,9 +14,9 @@ const SessionModel = require('../../models/session.model.js')
  * Orchestrates fetching and presenting the data for `/return-requirements/{sessionId}/check` page
  *
  * @param {string} sessionId - The UUID for return requirement setup session record
- * @param {Object} yar - The Hapi `request.yar` session manager passed on by the controller
+ * @param {object} yar - The Hapi `request.yar` session manager passed on by the controller
  *
- * @returns {Promise<Object>} page data needed by the view template
+ * @returns {Promise<object>} page data needed by the view template
  */
 async function go (sessionId, yar) {
   const session = await SessionModel.query().findById(sessionId)

--- a/app/services/return-requirements/delete-note.service.js
+++ b/app/services/return-requirements/delete-note.service.js
@@ -14,7 +14,7 @@ const SessionModel = require('../../models/session.model.js')
  * Then it removes the notes data from the session.
  *
  * @param {string} sessionId - The id of the current session
- * @param {Object} yar - The Hapi `request.yar` session manager passed on by the controller
+ * @param {object} yar - The Hapi `request.yar` session manager passed on by the controller
  *
  * @returns {Promise} A promise is returned but it does not resolve to anything we expect the caller to use
  */

--- a/app/services/return-requirements/existing.service.js
+++ b/app/services/return-requirements/existing.service.js
@@ -16,7 +16,7 @@ const SessionModel = require('../../models/session.model.js')
  *
  * @param {string} sessionId - The UUID of the current session
  *
- * @returns {Promise<Object>} The view data for the purpose page
+ * @returns {Promise<object>} The view data for the purpose page
 */
 async function go (sessionId) {
   const session = await SessionModel.query().findById(sessionId)

--- a/app/services/return-requirements/fetch-points.service.js
+++ b/app/services/return-requirements/fetch-points.service.js
@@ -14,7 +14,7 @@ const LicenceModel = require('../../models/licence.model.js')
  *
  * @param {string} licenceId - The UUID for the licence to fetch
  *
- * @returns {Promise<Object>} The points data for the matching licenceId
+ * @returns {Promise<object>} The points data for the matching licenceId
  */
 async function go (licenceId) {
   const data = await _fetchPoints(licenceId)

--- a/app/services/return-requirements/fetch-purposes.service.js
+++ b/app/services/return-requirements/fetch-purposes.service.js
@@ -12,7 +12,7 @@ const PurposeModel = require('../../models/purpose.model.js')
  *
  * @param {string} licenceId - The UUID for the licence to fetch
  *
- * @returns {Promise<Object>} The distinct purposes for the matching licence's current version
+ * @returns {Promise<object>} The distinct purposes for the matching licence's current version
  */
 async function go (licenceId) {
   return _fetch(licenceId)

--- a/app/services/return-requirements/frequency-collected.service.js
+++ b/app/services/return-requirements/frequency-collected.service.js
@@ -17,7 +17,7 @@ const SessionModel = require('../../models/session.model.js')
  * @param {string} sessionId - The UUID of the current session
  * @param {string} requirementIndex - The index of the requirement being added or changed
  *
- * @returns {Promise<Object>} The view data for the frequency collected page
+ * @returns {Promise<object>} The view data for the frequency collected page
 */
 async function go (sessionId, requirementIndex) {
   const session = await SessionModel.query().findById(sessionId)

--- a/app/services/return-requirements/frequency-reported.service.js
+++ b/app/services/return-requirements/frequency-reported.service.js
@@ -17,7 +17,7 @@ const SessionModel = require('../../models/session.model.js')
  * @param {string} sessionId - The UUID of the current session
  * @param {string} requirementIndex - The index of the requirement being added or changed
  *
- * @returns {Promise<Object>} The view data for the frequency reported page
+ * @returns {Promise<object>} The view data for the frequency reported page
 */
 async function go (sessionId, requirementIndex) {
   const session = await SessionModel.query().findById(sessionId)

--- a/app/services/return-requirements/generate-from-existing-requirements.service.js
+++ b/app/services/return-requirements/generate-from-existing-requirements.service.js
@@ -20,7 +20,7 @@ const ReturnVersionModel = require('../../models/return-version.model.js')
  *
  * @param {string} returnVersionId - The UUID of the selected return version to copy requirements from
  *
- * @returns {Promise<Object[]>} an array of return requirements generated from the existing return version and ready to
+ * @returns {Promise<object[]>} an array of return requirements generated from the existing return version and ready to
  * be persisted to the setup session
  */
 async function go (returnVersionId) {

--- a/app/services/return-requirements/generate-return-version-requirements.service.js
+++ b/app/services/return-requirements/generate-return-version-requirements.service.js
@@ -16,10 +16,10 @@ const ReturnRequirementModel = require('../../models/return-requirement.model.js
  * Creates the data needed to populate the `return_requirements`, `return_requirement_points` and
  * `return_requirement_purposes` tables.
  *
- * @param {String} licenceId - The UUID of the licence the requirements are for
- * @param {Object[]} requirements - The return requirements data from the session
+ * @param {string} licenceId - The UUID of the licence the requirements are for
+ * @param {object[]} requirements - The return requirements data from the session
  *
- * @returns {Promise<Object>} The new return version requirements data for a licence
+ * @returns {Promise<object>} The new return version requirements data for a licence
  */
 async function go (licenceId, requirements) {
   const naldRegionId = await _fetchNaldRegionId(licenceId)

--- a/app/services/return-requirements/generate-return-version.service.js
+++ b/app/services/return-requirements/generate-return-version.service.js
@@ -18,7 +18,7 @@ const ReturnVersionModel = require('../../models/return-version.model.js')
  * @param {string} sessionData - The session data required to set up a new return version for a licence
  * @param {number} userId - The id of the logged in user
  *
- * @returns {Promise<Object>} The new return version and requirement data for a licence
+ * @returns {Promise<object>} The new return version and requirement data for a licence
  */
 async function go (sessionData, userId) {
   const returnVersionsExist = sessionData.licence.returnVersions.length > 0

--- a/app/services/return-requirements/initiate-session.service.js
+++ b/app/services/return-requirements/initiate-session.service.js
@@ -21,8 +21,8 @@ const SessionModel = require('../../models/session.model.js')
  * At the end when the journey is complete the data from the session will be used to create the return requirement and
  * the session record itself deleted.
  *
- * @param {String} licenceId - the ID of the licence the return requirement will be created for
- * @param {String} journey - whether the set up journey needed is 'no-returns-required' or 'returns-required'
+ * @param {string} licenceId - the ID of the licence the return requirement will be created for
+ * @param {string} journey - whether the set up journey needed is 'no-returns-required' or 'returns-required'
  *
  * @returns {Promise<module:SessionModel>} the newly created session record
  */

--- a/app/services/return-requirements/no-returns-required.service.js
+++ b/app/services/return-requirements/no-returns-required.service.js
@@ -16,7 +16,7 @@ const SessionModel = require('../../models/session.model.js')
  *
  * @param {string} sessionId - The UUID for return requirement setup session record
  *
- * @returns {Promise<Object>} The view data for the no returns required page
+ * @returns {Promise<object>} The view data for the no returns required page
  */
 async function go (sessionId) {
   const session = await SessionModel.query().findById(sessionId)

--- a/app/services/return-requirements/note.service.js
+++ b/app/services/return-requirements/note.service.js
@@ -16,7 +16,7 @@ const SessionModel = require('../../models/session.model.js')
  *
  * @param {string} sessionId - The UUID for return requirement setup session record
  *
- * @returns {Promise<Object>} The view data for the note page
+ * @returns {Promise<object>} The view data for the note page
  */
 async function go (sessionId) {
   const session = await SessionModel.query().findById(sessionId)

--- a/app/services/return-requirements/persist-return-version.service.js
+++ b/app/services/return-requirements/persist-return-version.service.js
@@ -17,7 +17,7 @@ const ReturnVersionModel = require('../../models/return-version.model.js')
  * `return_requirements`, `return_requirement_points` and `return_requirement_purposes` tables which are required to
  * create a new return version for a licence.
  *
- * @param {Object} returnVersionData - The return version data required to persist a new return version for a licence
+ * @param {object} returnVersionData - The return version data required to persist a new return version for a licence
  */
 async function go (returnVersionData) {
   const { returnRequirements, returnVersion } = returnVersionData

--- a/app/services/return-requirements/points.service.js
+++ b/app/services/return-requirements/points.service.js
@@ -18,7 +18,7 @@ const SessionModel = require('../../models/session.model.js')
  * @param {string} sessionId - The UUID of the current session
  * @param {string} requirementIndex - The index of the requirement being added or changed
  *
- * @returns {Promise<Object>} The view data for the points page
+ * @returns {Promise<object>} The view data for the points page
 */
 async function go (sessionId, requirementIndex) {
   const session = await SessionModel.query().findById(sessionId)

--- a/app/services/return-requirements/process-existing-return-versions.service.js
+++ b/app/services/return-requirements/process-existing-return-versions.service.js
@@ -14,7 +14,7 @@ const ReturnVersionModel = require('../../models/return-version.model.js')
  * its `status` or `endDate` to be updated. An `endDate` may also need to be calculated for the new return version if
  * it is to be inserted between existing return versions, or is superseding an existing one that has an `endDate`.
  *
- * @param {String} licenceId - The UUID of the licence the requirements are for
+ * @param {string} licenceId - The UUID of the licence the requirements are for
  * @param {Date} newVersionStartDate - The date that the new return version starts
  *
  * @returns {Promise<Date>} The calculated `endDate` for the new return version if there is one. Null will be returned

--- a/app/services/return-requirements/purpose.service.js
+++ b/app/services/return-requirements/purpose.service.js
@@ -18,7 +18,7 @@ const SessionModel = require('../../models/session.model.js')
  * @param {string} sessionId - The UUID of the current session
  * @param {string} requirementIndex - The index of the requirement being added or changed
  *
- * @returns {Promise<Object>} The view data for the purpose page
+ * @returns {Promise<object>} The view data for the purpose page
 */
 async function go (sessionId, requirementIndex) {
   const session = await SessionModel.query().findById(sessionId)

--- a/app/services/return-requirements/reason.service.js
+++ b/app/services/return-requirements/reason.service.js
@@ -16,7 +16,7 @@ const SessionModel = require('../../models/session.model.js')
  *
  * @param {string} id - The UUID for return requirement setup session record
  *
- * @returns {Promise<Object>} page data needed by the view template
+ * @returns {Promise<object>} page data needed by the view template
  */
 async function go (sessionId) {
   const session = await SessionModel.query().findById(sessionId)

--- a/app/services/return-requirements/remove.service.js
+++ b/app/services/return-requirements/remove.service.js
@@ -17,7 +17,7 @@ const SessionModel = require('../../models/session.model.js')
  * @param {string} sessionId - The UUID of the current session
  * @param {string} requirementIndex - The index of the requirement being removed
  *
- * @returns {Promise<Object>} The view data for the remove requirements page
+ * @returns {Promise<object>} The view data for the remove requirements page
 */
 async function go (sessionId, requirementIndex) {
   const session = await SessionModel.query().findById(sessionId)

--- a/app/services/return-requirements/returns-cycle.service.js
+++ b/app/services/return-requirements/returns-cycle.service.js
@@ -17,7 +17,7 @@ const SessionModel = require('../../models/session.model.js')
  * @param {string} sessionId - The UUID of the current session
  * @param {string} requirementIndex - The index of the requirement being added or changed
  *
- * @returns {Promise<Object>} The view data for the returns cycle page
+ * @returns {Promise<object>} The view data for the returns cycle page
 */
 async function go (sessionId, requirementIndex) {
   const session = await SessionModel.query().findById(sessionId)

--- a/app/services/return-requirements/setup/generate-from-abstraction-data.service.js
+++ b/app/services/return-requirements/setup/generate-from-abstraction-data.service.js
@@ -29,7 +29,7 @@ const TWO_PART_IRRIGATION_IDS = ['380', '390', '400', '410', '420', '600', '620'
  *
  * @param {string} licenceId - The UUID of the licence to fetch abstraction data from and generate return requirements
  *
- * @returns {Promise<Object[]>} an array of return requirements generated from the licence's abstraction and ready to
+ * @returns {Promise<object[]>} an array of return requirements generated from the licence's abstraction and ready to
  * be persisted to the setup session
  */
 async function go (licenceId) {

--- a/app/services/return-requirements/setup/setup.service.js
+++ b/app/services/return-requirements/setup/setup.service.js
@@ -16,7 +16,7 @@ const SessionModel = require('../../../models/session.model.js')
  *
  * @param {string} sessionId - The UUID for return requirement setup session record
  *
- * @returns {Promise<Object>} page data needed by the view template
+ * @returns {Promise<object>} page data needed by the view template
  */
 async function go (sessionId) {
   const session = await SessionModel.query().findById(sessionId)

--- a/app/services/return-requirements/setup/submit-setup.service.js
+++ b/app/services/return-requirements/setup/submit-setup.service.js
@@ -20,9 +20,9 @@ const SetupValidator = require('../../../validators/return-requirements/setup.va
  * controller will redirect to the next page in the journey depending on which radio item was chosen.
  *
  * @param {string} sessionId - The UUID of the current session
- * @param {Object} payload - The submitted form data
+ * @param {object} payload - The submitted form data
  *
- * @returns {Promise<Object>} If no errors a the url for where the user should be redirected else the page data for the
+ * @returns {Promise<object>} If no errors a the url for where the user should be redirected else the page data for the
  * setup page including the validation error details
  */
 async function go (sessionId, payload) {

--- a/app/services/return-requirements/site-description.service.js
+++ b/app/services/return-requirements/site-description.service.js
@@ -17,7 +17,7 @@ const SiteDescriptionPresenter = require('../../presenters/return-requirements/s
  * @param {string} sessionId - The UUID of the current session
  * @param {string} requirementIndex - The index of the requirement being added or changed
  *
- * @returns {Promise<Object>} The view data for the site description page
+ * @returns {Promise<object>} The view data for the site description page
 */
 async function go (sessionId, requirementIndex) {
   const session = await SessionModel.query().findById(sessionId)

--- a/app/services/return-requirements/start-date.service.js
+++ b/app/services/return-requirements/start-date.service.js
@@ -16,7 +16,7 @@ const StartDatePresenter = require('../../presenters/return-requirements/start-d
  *
  * @param {string} sessionId - The UUID of the current session
  *
- * @returns {Promise<Object>} The view data for the start date page
+ * @returns {Promise<object>} The view data for the start date page
 */
 async function go (sessionId) {
   const session = await SessionModel.query().findById(sessionId)

--- a/app/services/return-requirements/submit-abstraction-period.service.js
+++ b/app/services/return-requirements/submit-abstraction-period.service.js
@@ -21,10 +21,10 @@ const SessionModel = require('../../models/session.model.js')
  *
  * @param {string} sessionId - The UUID of the current session
  * @param {string} requirementIndex - The index of the requirement being added or changed
- * @param {Object} payload - The submitted form data
- * @param {Object} yar - The Hapi `request.yar` session manager passed on by the controller
+ * @param {object} payload - The submitted form data
+ * @param {object} yar - The Hapi `request.yar` session manager passed on by the controller
  *
- * @returns {Promise<Object>} If no errors a flag that determines whether the user is returned to the check page else
+ * @returns {Promise<object>} If no errors a flag that determines whether the user is returned to the check page else
  * the page data for the abstraction period page including the validation error details
  */
 async function go (sessionId, requirementIndex, payload, yar) {

--- a/app/services/return-requirements/submit-additional-submission-options.service.js
+++ b/app/services/return-requirements/submit-additional-submission-options.service.js
@@ -19,10 +19,10 @@ const SessionModel = require('../../models/session.model.js')
  * controller will redirect to the next page in the journey.
  *
  * @param {string} sessionId - The id of the current session
- * @param {Object} payload - The submitted form data
- * @param {Object} yar - The Hapi `request.yar` session manager passed on by the controller
+ * @param {object} payload - The submitted form data
+ * @param {object} yar - The Hapi `request.yar` session manager passed on by the controller
  *
- * @returns {Promise<Object>} If no errors it returns an empty object else the page data for the note page including the
+ * @returns {Promise<object>} If no errors it returns an empty object else the page data for the note page including the
  * validation error details
  */
 async function go (sessionId, payload, yar) {

--- a/app/services/return-requirements/submit-agreements-exceptions.service.js
+++ b/app/services/return-requirements/submit-agreements-exceptions.service.js
@@ -21,10 +21,10 @@ const SessionModel = require('../../models/session.model.js')
  *
  * @param {string} sessionId - The UUID of the current session
  * @param {string} requirementIndex - The index of the requirement being added or changed
- * @param {Object} payload - The submitted form data
- * @param {Object} yar - The Hapi `request.yar` session manager passed on by the controller
+ * @param {object} payload - The submitted form data
+ * @param {object} yar - The Hapi `request.yar` session manager passed on by the controller
  *
- * @returns {Promise<Object>} If no errors a flag that determines whether the user is returned to the check page else
+ * @returns {Promise<object>} If no errors a flag that determines whether the user is returned to the check page else
  * the page data for the agreements exceptions page including the validation error details
  */
 async function go (sessionId, requirementIndex, payload, yar) {

--- a/app/services/return-requirements/submit-check.service.js
+++ b/app/services/return-requirements/submit-check.service.js
@@ -19,10 +19,10 @@ const SessionModel = require('../../models/session.model.js')
  *
  * If valid it converts the session data to return requirements records then deletes the session record.
  *
- * @param {String} sessionId - The UUID for return requirement setup session record
- * @param {Number} userId - The id of the logged in user
+ * @param {string} sessionId - The UUID for return requirement setup session record
+ * @param {number} userId - The id of the logged in user
  *
- * @returns {String} The licence ID
+ * @returns {string} The licence ID
  */
 async function go (sessionId, userId) {
   const session = await SessionModel.query().findById(sessionId)

--- a/app/services/return-requirements/submit-existing.service.js
+++ b/app/services/return-requirements/submit-existing.service.js
@@ -21,9 +21,9 @@ const SessionModel = require('../../models/session.model.js')
  * the session.
  *
  * @param {string} sessionId - The UUID of the current session
- * @param {Object} payload - The submitted form data
+ * @param {object} payload - The submitted form data
  *
- * @returns {Promise<Object>} If no errors an empty object else the page data for the existing page including the
+ * @returns {Promise<object>} If no errors an empty object else the page data for the existing page including the
  * validation error details
  */
 async function go (sessionId, payload) {

--- a/app/services/return-requirements/submit-frequency-collected.service.js
+++ b/app/services/return-requirements/submit-frequency-collected.service.js
@@ -21,10 +21,10 @@ const SessionModel = require('../../models/session.model.js')
  *
  * @param {string} sessionId - The UUID of the current session
  * @param {string} requirementIndex - The index of the requirement being added or changed
- * @param {Object} payload - The submitted form data
- * @param {Object} yar - The Hapi `request.yar` session manager passed on by the controller
+ * @param {object} payload - The submitted form data
+ * @param {object} yar - The Hapi `request.yar` session manager passed on by the controller
  *
- * @returns {Promise<Object>} If no errors a flag that determines whether the user is returned to the check page else
+ * @returns {Promise<object>} If no errors a flag that determines whether the user is returned to the check page else
  * the page data for the frequency collected page including the validation error details
  */
 async function go (sessionId, requirementIndex, payload, yar) {

--- a/app/services/return-requirements/submit-frequency-reported.service.js
+++ b/app/services/return-requirements/submit-frequency-reported.service.js
@@ -21,10 +21,10 @@ const SessionModel = require('../../models/session.model.js')
  *
  * @param {string} sessionId - The UUID of the current session
  * @param {string} requirementIndex - The index of the requirement being added or changed
- * @param {Object} payload - The submitted form data
- * @param {Object} yar - The Hapi `request.yar` session manager passed on by the controller
+ * @param {object} payload - The submitted form data
+ * @param {object} yar - The Hapi `request.yar` session manager passed on by the controller
  *
- * @returns {Promise<Object>} If no errors a flag that determines whether the user is returned to the check page else
+ * @returns {Promise<object>} If no errors a flag that determines whether the user is returned to the check page else
  * the page data for the frequency reported page including the validation error details
  */
 async function go (sessionId, requirementIndex, payload, yar) {

--- a/app/services/return-requirements/submit-no-returns-required.service.js
+++ b/app/services/return-requirements/submit-no-returns-required.service.js
@@ -20,10 +20,10 @@ const GeneralLib = require('../../lib/general.lib.js')
  * controller will redirect to the next page in the journey.
  *
  * @param {string} sessionId - The id of the current session
- * @param {Object} payload - The submitted form data
- * @param {Object} yar - The Hapi `request.yar` session manager passed on by the controller
+ * @param {object} payload - The submitted form data
+ * @param {object} yar - The Hapi `request.yar` session manager passed on by the controller
  *
- * @returns {Promise<Object>} The page data for the no returns required page
+ * @returns {Promise<object>} The page data for the no returns required page
  */
 async function go (sessionId, payload, yar) {
   const session = await SessionModel.query().findById(sessionId)

--- a/app/services/return-requirements/submit-note.service.js
+++ b/app/services/return-requirements/submit-note.service.js
@@ -19,11 +19,11 @@ const SessionModel = require('../../models/session.model.js')
  * controller will redirect to the next page in the journey.
  *
  * @param {string} sessionId - The id of the current session
- * @param {Object} payload - The submitted form data
- * @param {Object} user - The logged in user details
- * @param {Object} yar - The Hapi `request.yar` session manager passed on by the controller
+ * @param {object} payload - The submitted form data
+ * @param {object} user - The logged in user details
+ * @param {object} yar - The Hapi `request.yar` session manager passed on by the controller
  *
- * @returns {Promise<Object>} If no errors it returns an empty object else the page data for the note page including the
+ * @returns {Promise<object>} If no errors it returns an empty object else the page data for the note page including the
  * validation error details
  */
 async function go (sessionId, payload, user, yar) {

--- a/app/services/return-requirements/submit-points.service.js
+++ b/app/services/return-requirements/submit-points.service.js
@@ -22,10 +22,10 @@ const SessionModel = require('../../models/session.model.js')
  *
  * @param {string} sessionId - The UUID of the current session
  * @param {string} requirementIndex - The index of the requirement being added or changed
- * @param {Object} payload - The submitted form data
- * @param {Object} yar - The Hapi `request.yar` session manager passed on by the controller
+ * @param {object} payload - The submitted form data
+ * @param {object} yar - The Hapi `request.yar` session manager passed on by the controller
  *
- * @returns {Promise<Object>} If no errors a flag that determines whether the user is returned to the check page else
+ * @returns {Promise<object>} If no errors a flag that determines whether the user is returned to the check page else
  * the page data for the points page including the validation error details
  */
 async function go (sessionId, requirementIndex, payload, yar) {

--- a/app/services/return-requirements/submit-purpose.service.js
+++ b/app/services/return-requirements/submit-purpose.service.js
@@ -22,10 +22,10 @@ const SessionModel = require('../../models/session.model.js')
  *
  * @param {string} sessionId - The UUID of the current session
  * @param {string} requirementIndex - The index of the requirement being added or changed
- * @param {Object} payload - The submitted form data
- * @param {Object} yar - The Hapi `request.yar` session manager passed on by the controller
+ * @param {object} payload - The submitted form data
+ * @param {object} yar - The Hapi `request.yar` session manager passed on by the controller
  *
- * @returns {Promise<Object>} If no errors a flag that determines whether the user is returned to the check page else
+ * @returns {Promise<object>} If no errors a flag that determines whether the user is returned to the check page else
  * the page data for the purpose page including the validation error details
  */
 async function go (sessionId, requirementIndex, payload, yar) {

--- a/app/services/return-requirements/submit-reason.service.js
+++ b/app/services/return-requirements/submit-reason.service.js
@@ -20,10 +20,10 @@ const SessionModel = require('../../models/session.model.js')
  * controller will redirect to the next page in the journey.
  *
  * @param {string} sessionId - The UUID of the current session
- * @param {Object} payload - The submitted form data
- * @param {Object} yar - The Hapi `request.yar` session manager passed on by the controller
+ * @param {object} payload - The submitted form data
+ * @param {object} yar - The Hapi `request.yar` session manager passed on by the controller
  *
- * @returns {Promise<Object>} If no errors a flag that determines whether the user is returned to the check page else
+ * @returns {Promise<object>} If no errors a flag that determines whether the user is returned to the check page else
  * the page data for the reason page including the validation error details
  */
 async function go (sessionId, payload, yar) {

--- a/app/services/return-requirements/submit-remove.service.js
+++ b/app/services/return-requirements/submit-remove.service.js
@@ -15,7 +15,7 @@ const SessionModel = require('../../models/session.model.js')
  *
  * @param {string} sessionId - The UUID for the return requirement setup session record
  * @param {number} requirementIndex - The index of the requirement being removed
- * @param {Object} yar - The Hapi `request.yar` session manager passed on by the controller
+ * @param {object} yar - The Hapi `request.yar` session manager passed on by the controller
  *
  * @returns {Promise} the promise returned is not intended to resolve to any particular value
  */

--- a/app/services/return-requirements/submit-returns-cycle.service.js
+++ b/app/services/return-requirements/submit-returns-cycle.service.js
@@ -21,10 +21,10 @@ const SessionModel = require('../../models/session.model.js')
  *
  * @param {string} sessionId - The UUID of the current session
  * @param {string} requirementIndex - The index of the requirement being added or changed
- * @param {Object} payload - The submitted form data
- * @param {Object} yar - The Hapi `request.yar` session manager passed on by the controller
+ * @param {object} payload - The submitted form data
+ * @param {object} yar - The Hapi `request.yar` session manager passed on by the controller
  *
- * @returns {Promise<Object>} If no errors a flag that determines whether the user is returned to the check page else
+ * @returns {Promise<object>} If no errors a flag that determines whether the user is returned to the check page else
  * the page data for the returns cycle page including the validation error details
  */
 async function go (sessionId, requirementIndex, payload, yar) {

--- a/app/services/return-requirements/submit-site-description.service.js
+++ b/app/services/return-requirements/submit-site-description.service.js
@@ -21,10 +21,10 @@ const SiteDescriptionValidator = require('../../validators/return-requirements/s
  *
  * @param {string} sessionId - The UUID of the current session
  * @param {string} requirementIndex - The index of the requirement being added or changed
- * @param {Object} payload - The submitted form data
- * @param {Object} yar - The Hapi `request.yar` session manager passed on by the controller
+ * @param {object} payload - The submitted form data
+ * @param {object} yar - The Hapi `request.yar` session manager passed on by the controller
  *
- * @returns {Promise<Object>} If no errors a flag that determines whether the user is returned to the check page else
+ * @returns {Promise<object>} If no errors a flag that determines whether the user is returned to the check page else
  * the page data for the site description page including the validation error details
  */
 async function go (sessionId, requirementIndex, payload, yar) {

--- a/app/services/return-requirements/submit-start-date.service.js
+++ b/app/services/return-requirements/submit-start-date.service.js
@@ -21,10 +21,10 @@ const StartDateValidator = require('../../validators/return-requirements/start-d
  * controller will redirect to the next page in the journey.
  *
  * @param {string} sessionId - The UUID of the current session
- * @param {Object} payload - The submitted form data
- * @param {Object} yar - The Hapi `request.yar` session manager passed on by the controller
+ * @param {object} payload - The submitted form data
+ * @param {object} yar - The Hapi `request.yar` session manager passed on by the controller
  *
- * @returns {Promise<Object>} If no errors 2 flags that determine whether the user is returned to the check page or the
+ * @returns {Promise<object>} If no errors 2 flags that determine whether the user is returned to the check page or the
  * next page in the journey else the page data for the start date page including the validation error details
  */
 async function go (sessionId, payload, yar) {

--- a/app/services/return-requirements/view.service.js
+++ b/app/services/return-requirements/view.service.js
@@ -13,7 +13,7 @@ const ViewPresenter = require('../../presenters/return-requirements/view.present
  *
  * @param {string} returnVersionId - The UUID for return requirement version
  *
- * @returns {Promise<Object>} page data needed by the view template
+ * @returns {Promise<object>} page data needed by the view template
  */
 async function go (returnVersionId) {
   const requirementsForReturns = await FetchReturnVersionService.go(returnVersionId)

--- a/app/validators/bill-runs/setup/region.validator.js
+++ b/app/validators/bill-runs/setup/region.validator.js
@@ -10,9 +10,9 @@ const Joi = require('joi')
 /**
  * Validates data submitted for the `/bill-runs/setup/{sessionId}/region` page
  *
- * @param {Object} payload - The payload from the request to be validated
+ * @param {object} payload - The payload from the request to be validated
  *
- * @returns {Object} the result from calling Joi's schema.validate(). It will be an object with a `value:` property. If
+ * @returns {object} the result from calling Joi's schema.validate(). It will be an object with a `value:` property. If
  * any errors are found the `error:` property will also exist detailing what the issues were
  */
 function go (data, regions) {

--- a/app/validators/bill-runs/setup/season.validator.js
+++ b/app/validators/bill-runs/setup/season.validator.js
@@ -15,9 +15,9 @@ const VALID_VALUES = [
 /**
  * Validates data submitted for the `/bill-runs/setup/{sessionId}/season` page
  *
- * @param {Object} payload - The payload from the request to be validated
+ * @param {object} payload - The payload from the request to be validated
  *
- * @returns {Object} the result from calling Joi's schema.validate(). It will be an object with a `value:` property. If
+ * @returns {object} the result from calling Joi's schema.validate(). It will be an object with a `value:` property. If
  * any errors are found the `error:` property will also exist detailing what the issues were
  */
 function go (data) {

--- a/app/validators/bill-runs/setup/type.validator.js
+++ b/app/validators/bill-runs/setup/type.validator.js
@@ -17,9 +17,9 @@ const VALID_VALUES = [
 /**
  * Validates data submitted for the `/bill-runs/setup/{sessionId}/type` page
  *
- * @param {Object} payload - The payload from the request to be validated
+ * @param {object} payload - The payload from the request to be validated
  *
- * @returns {Object} the result from calling Joi's schema.validate(). It will be an object with a `value:` property. If
+ * @returns {object} the result from calling Joi's schema.validate(). It will be an object with a `value:` property. If
  * any errors are found the `error:` property will also exist detailing what the issues were
  */
 function go (data) {

--- a/app/validators/bill-runs/setup/year.validator.js
+++ b/app/validators/bill-runs/setup/year.validator.js
@@ -17,9 +17,9 @@ const VALID_VALUES = [
 /**
  * Validates data submitted for the `/bill-runs/setup/{sessionId}/year` page
  *
- * @param {Object} payload - The payload from the request to be validated
+ * @param {object} payload - The payload from the request to be validated
  *
- * @returns {Object} the result from calling Joi's schema.validate(). It will be an object with a `value:` property. If
+ * @returns {object} the result from calling Joi's schema.validate(). It will be an object with a `value:` property. If
  * any errors are found the `error:` property will also exist detailing what the issues were
  */
 function go (data) {

--- a/app/validators/bill-runs/two-part-tariff/adjustment-factor.validator.js
+++ b/app/validators/bill-runs/two-part-tariff/adjustment-factor.validator.js
@@ -18,11 +18,11 @@ const Joi = require('joi')
  * The validation happening here is to ensure that the adjustments have been entered. Both have a
  * minimum value of 0 and they both get validated to either 2 or 15 decimal places.
  *
- * @param {Object} payload - The payload from the request to be validated
- * @param {Number} maxNumberOfDecimals - The maximum number of decimal places the factor can be validated to
- * @param {String} validationType - The type of factor being validated, this is to add to the validation messages
+ * @param {object} payload - The payload from the request to be validated
+ * @param {number} maxNumberOfDecimals - The maximum number of decimal places the factor can be validated to
+ * @param {string} validationType - The type of factor being validated, this is to add to the validation messages
  *
- * @returns {Object} the result from calling Joi's schema.validate(). It will be an object with a `value:` property. If
+ * @returns {object} the result from calling Joi's schema.validate(). It will be an object with a `value:` property. If
  * any errors are found the `error:` property will also exist detailing what the issues were
  */
 function go (payload, maxNumberOfDecimals, validationType) {

--- a/app/validators/bill-runs/two-part-tariff/authorised-volume.validator.js
+++ b/app/validators/bill-runs/two-part-tariff/authorised-volume.validator.js
@@ -17,9 +17,9 @@ const Joi = require('joi')
  * The validation happening here is to ensure that the volume has been entered, it has a maximum 6 decimal places and
  * is more than the totalBillableReturns.
  *
- * @param {Object} payload - The payload from the request to be validated
+ * @param {object} payload - The payload from the request to be validated
  *
- * @returns {Object} the result from calling Joi's schema.validate(). It will be an object with a `value:` property. If
+ * @returns {object} the result from calling Joi's schema.validate(). It will be an object with a `value:` property. If
  * any errors are found the `error:` property will also exist detailing what the issues were
  */
 function go (payload) {

--- a/app/validators/bill-runs/two-part-tariff/billable-returns.validator.js
+++ b/app/validators/bill-runs/two-part-tariff/billable-returns.validator.js
@@ -16,9 +16,9 @@ const Joi = require('joi')
  * there own custom volume. The validation happening here is to ensure that a user selects either option and if its the
  * custom one, that they enter a number above 0 but below the authorised volume and that the number is less than 6
  * decimal places.
- * @param {Object} payload - The payload from the request to be validated
+ * @param {object} payload - The payload from the request to be validated
  *
- * @returns {Object} the result from calling Joi's schema.validate(). It will be an object with a `value:` property. If
+ * @returns {object} the result from calling Joi's schema.validate(). It will be an object with a `value:` property. If
  * any errors are found the `error:` property will also exist detailing what the issues were
  */
 function go (payload) {

--- a/app/validators/change-address.validator.js
+++ b/app/validators/change-address.validator.js
@@ -13,9 +13,9 @@ const StaticLookupsLib = require('../lib/static-lookups.lib.js')
  *
  * The JOI schema was interpreted from what we found in water-abstraction-service/src/modules/invoice-accounts/routes.js
  *
- * @param {Object} data The data to be validated (assumed to be the request payload)
+ * @param {object} data - The data to be validated (assumed to be the request payload)
  *
- * @returns {Object} the result from calling Joi's schema.validate(). It will be an object with a `value:` property. If
+ * @returns {object} the result from calling Joi's schema.validate(). It will be an object with a `value:` property. If
  * any errors are found the `error:` property will also exist detailing what the issues were
 */
 function go (data) {

--- a/app/validators/import/licence-version-purpose-condition.validator.js
+++ b/app/validators/import/licence-version-purpose-condition.validator.js
@@ -9,10 +9,10 @@ const Joi = require('joi')
 /**
  * Checks that the data for inserting/updating the water.licence_version_purpose_conditions table is valid
  *
- * @param {Object} data The data to be validated
+ * @param {object} data - The data to be validated
  *
  *
- * @returns {Object} the result from calling Joi's schema.validate(). It will be an object with a `value:` property. If
+ * @returns {object} the result from calling Joi's schema.validate(). It will be an object with a `value:` property. If
  * any errors are found the `error:` property will also exist detailing what the issues were
 */
 function go (data) {

--- a/app/validators/import/licence.validator.js
+++ b/app/validators/import/licence.validator.js
@@ -11,7 +11,7 @@ const CustomDateValidator = require('../custom/date.validators.js')
 /**
  * Checks that the data for inserting/updating the water.licence table is valid
  *
- * @param {ImportLicenceType} data The data to be validated
+ * @param {ImportLicenceType} data - The data to be validated
  *
  * Throws an error if anything fails
  *

--- a/app/validators/return-requirements/abstraction-period.validator.js
+++ b/app/validators/return-requirements/abstraction-period.validator.js
@@ -16,9 +16,9 @@ const { leftPadZeroes } = require('../../presenters/base.presenter.js')
  * a valid start-date and end-date for the licence. If these requirements are not met, the validation will return an
  * error.
  *
- * @param {Object} payload - The payload from the request to be validated.
+ * @param {object} payload - The payload from the request to be validated.
  *
- * @returns {Object} - The result from calling Joi's schema.validate(). If any errors are found the 'error: ' property
+ * @returns {object} - The result from calling Joi's schema.validate(). If any errors are found the 'error: ' property
  * will also exist, detailing what the issue is.
  */
 function go (payload) {

--- a/app/validators/return-requirements/additional-submission-options.validator.js
+++ b/app/validators/return-requirements/additional-submission-options.validator.js
@@ -14,9 +14,9 @@ const Joi = require('joi')
  * Users must select one or more points linked to the licence.
  * If these requirements are not met the validation will return an error.
  *
- * @param {Object} options - The options extracted from payload taken from the request to be validated
+ * @param {object} options - The options extracted from payload taken from the request to be validated
  *
- * @returns {Object} The result from calling Joi's schema.validate(). If any errors are found the `error:` property will
+ * @returns {object} The result from calling Joi's schema.validate(). If any errors are found the `error:` property will
  * also exist detailing what the issue is.
  */
 function go (payload) {

--- a/app/validators/return-requirements/agreements-exceptions.validator.js
+++ b/app/validators/return-requirements/agreements-exceptions.validator.js
@@ -14,9 +14,9 @@ const Joi = require('joi')
  * Users must select one or more agreements and exceptions linked to the licence. If these requirements are not met
  * the validation will return an error.
  *
- * @param {Object} payload - The payload from the request to be validated
+ * @param {object} payload - The payload from the request to be validated
  *
- * @returns {Object} The result from calling Joi's schema.validate(). If any errors are found the
+ * @returns {object} The result from calling Joi's schema.validate(). If any errors are found the
  * `error:` property will also exist detailing what the issue is.
  */
 function go (payload) {

--- a/app/validators/return-requirements/existing.validator.js
+++ b/app/validators/return-requirements/existing.validator.js
@@ -12,9 +12,9 @@ const errorMessage = 'Select a return version'
 /**
  * Validates data submitted for the `/return-requirements/{sessionId}/existing` page
  *
- * @param {Object} payload - The payload from the request to be validated
+ * @param {object} payload - The payload from the request to be validated
  *
- * @returns {Object} the result from calling Joi's schema.validate(). It will be an object with a `value:` property. If
+ * @returns {object} the result from calling Joi's schema.validate(). It will be an object with a `value:` property. If
  * any errors are found the `error:` property will also exist detailing what the issues were
  */
 function go (data, returnVersions) {

--- a/app/validators/return-requirements/frequency-collected.validator.js
+++ b/app/validators/return-requirements/frequency-collected.validator.js
@@ -14,9 +14,9 @@ const Joi = require('joi')
  * Users must select one frequency for the returns cycle. If this requirement is not met the validation will return an
  * error.
  *
- * @param {Object} payload - The payload from the request to be validated
+ * @param {object} payload - The payload from the request to be validated
  *
- * @returns {Object} The result from calling Joi's schema.validate(). If any errors are found the `error:` property will
+ * @returns {object} The result from calling Joi's schema.validate(). If any errors are found the `error:` property will
  * also exist detailing what the issue is.
  */
 function go (payload) {

--- a/app/validators/return-requirements/frequency-reported.validator.js
+++ b/app/validators/return-requirements/frequency-reported.validator.js
@@ -14,9 +14,9 @@ const Joi = require('joi')
  * Users must select one frequency for the returns cycle. If this requirement is not met the validation will return an
  * error.
  *
- * @param {Object} payload - The payload from the request to be validated
+ * @param {object} payload - The payload from the request to be validated
  *
- * @returns {Object} The result from calling Joi's schema.validate(). If any errors are found the `error:` property will
+ * @returns {object} The result from calling Joi's schema.validate(). If any errors are found the `error:` property will
  * also exist detailing what the issue is.
  */
 

--- a/app/validators/return-requirements/no-returns-required.validator.js
+++ b/app/validators/return-requirements/no-returns-required.validator.js
@@ -17,9 +17,9 @@ const VALID_VALUES = [
 /**
  * Validates data submitted for the `/return-requirements/{sessionId}/no-returns-required` page
  *
- * @param {Object} payload - The payload from the request to be validated
+ * @param {object} payload - The payload from the request to be validated
  *
- * @returns {Object} the result from calling Joi's schema.validate(). It will be an object with a `value:` property. If
+ * @returns {object} the result from calling Joi's schema.validate(). It will be an object with a `value:` property. If
  * any errors are found the `error:` property will also exist detailing what the issues were
  */
 function go (data) {

--- a/app/validators/return-requirements/note.validator.js
+++ b/app/validators/return-requirements/note.validator.js
@@ -10,9 +10,9 @@ const Joi = require('joi')
 /**
  * Validates data submitted for the `/return-requirements/{sessionId}/note` page
  *
- * @param {Object} payload - The payload from the request to be validated
+ * @param {object} payload - The payload from the request to be validated
  *
- * @returns {Object} the result from calling Joi's schema.validate(). It will be an object with a `value:` property. If
+ * @returns {object} the result from calling Joi's schema.validate(). It will be an object with a `value:` property. If
  * any errors are found the `error:` property will also exist detailing what the issues were
  */
 function go (data) {

--- a/app/validators/return-requirements/points.validator.js
+++ b/app/validators/return-requirements/points.validator.js
@@ -13,9 +13,9 @@ const Joi = require('joi')
  * When setting up a requirement users must specify points for the return requirement. Users must select one or more
  * points linked to the licence. If these requirements are not met the validation will return an error.
  *
- * @param {Object} payload - The payload from the request to be validated
+ * @param {object} payload - The payload from the request to be validated
  *
- * @returns {Object} The result from calling Joi's schema.validate(). If any errors are found the `error:` property will
+ * @returns {object} The result from calling Joi's schema.validate(). If any errors are found the `error:` property will
  * also exist detailing what the issue is.
  */
 function go (payload) {

--- a/app/validators/return-requirements/purpose.validator.js
+++ b/app/validators/return-requirements/purpose.validator.js
@@ -17,9 +17,9 @@ const Joi = require('joi')
  * Users also have the option to add an alias (purpose description) to the purpose. This is not required but if added
  * we check to ensure it is no more than 100 characters.
  *
- * @param {Object[]} purposes - The selected purposes and aliases (if entered) from the payload
+ * @param {object[]} purposes - The selected purposes and aliases (if entered) from the payload
  *
- * @returns {Object} The result from calling Joi's schema.validate(). If any errors are found the
+ * @returns {object} The result from calling Joi's schema.validate(). If any errors are found the
  * `error:` property will also exist detailing what the issue is.
  */
 function go (purposes, purposeIds) {

--- a/app/validators/return-requirements/reason.validator.js
+++ b/app/validators/return-requirements/reason.validator.js
@@ -14,9 +14,9 @@ const errorMessage = 'Select the reason for the requirements for returns'
 /**
  * Validates data submitted for the `/return-requirements/{sessionId}/reason` page
  *
- * @param {Object} payload - The payload from the request to be validated
+ * @param {object} payload - The payload from the request to be validated
  *
- * @returns {Object} the result from calling Joi's schema.validate(). It will be an object with a `value:` property. If
+ * @returns {object} the result from calling Joi's schema.validate(). It will be an object with a `value:` property. If
  * any errors are found the `error:` property will also exist detailing what the issues were
  */
 function go (data) {

--- a/app/validators/return-requirements/returns-cycle.validator.js
+++ b/app/validators/return-requirements/returns-cycle.validator.js
@@ -13,9 +13,9 @@ const Joi = require('joi')
  * When setting up a requirement users must specify a returns cycle for the return requirement. Users must select one
  * period for the returns cycle. If this requirement is not met the validation will return an error.
  *
- * @param {Object} payload - The payload from the request to be validated
+ * @param {object} payload - The payload from the request to be validated
  *
- * @returns {Object} The result from calling Joi's schema.validate(). The result from calling Joi's schema.validate().
+ * @returns {object} The result from calling Joi's schema.validate(). The result from calling Joi's schema.validate().
  * If any errors are found the `error:` property will also exist detailing what the issue is.
  */
 function go (payload) {

--- a/app/validators/return-requirements/setup.validator.js
+++ b/app/validators/return-requirements/setup.validator.js
@@ -16,9 +16,9 @@ const VALID_VALUES = [
 /**
  * Validates data submitted for the `/return-requirements/{sessionId}/setup` page
  *
- * @param {Object} payload - The payload from the request to be validated
+ * @param {object} payload - The payload from the request to be validated
  *
- * @returns {Object} the result from calling Joi's schema.validate(). It will be an object with a `value:` property. If
+ * @returns {object} the result from calling Joi's schema.validate(). It will be an object with a `value:` property. If
  * any errors are found the `error:` property will also exist detailing what the issues were
  */
 function go (data) {

--- a/app/validators/return-requirements/site-description.validator.js
+++ b/app/validators/return-requirements/site-description.validator.js
@@ -15,9 +15,9 @@ const Joi = require('joi')
  * the validation will return one of 3 errors, one for empty description and 2 more for above or below
  * character limits.
  *
- * @param {Object} payload - The payload from the request to be validated
+ * @param {object} payload - The payload from the request to be validated
  *
- * @returns {Object} the result from calling Joi's schema.validate(). If any errors are found the
+ * @returns {object} the result from calling Joi's schema.validate(). If any errors are found the
  * `error:` property will also exist detailing what the issue is.
  */
 function go (payload) {

--- a/app/validators/return-requirements/start-date.validator.js
+++ b/app/validators/return-requirements/start-date.validator.js
@@ -24,11 +24,11 @@ const { leftPadZeroes } = require('../../presenters/base.presenter.js')
  * Finally, we also need to validate that the user selected one of the options; licence version start date or a custom
  * date.
  *
- * @param {Object} payload - The payload from the request to be validated
+ * @param {object} payload - The payload from the request to be validated
  * @param {string} licenceStartDate - the date the original version of the licence starts from
  * @param {string} licenceEndDate - the date the licence has or will end if one is set
  *
- * @returns {Object} the result from calling Joi's schema.validate(). It will be an object with a `value:` property. If
+ * @returns {object} the result from calling Joi's schema.validate(). It will be an object with a `value:` property. If
  * any errors are found the `error:` property will also exist detailing what the issues were
  */
 function go (payload, licenceStartDate, licenceEndDate) {

--- a/test/support/general.js
+++ b/test/support/general.js
@@ -31,13 +31,13 @@
  * the 'crumb' in the POST request.
  *
  * @param {string} path - the full path for the request
- * @param {Object} [payload={}] - the payload to be sent in the request. Set to null if no payload should be sent
+ * @param {object} [payload={}] - the payload to be sent in the request. Set to null if no payload should be sent
  * @param {string[]} [scope=[billing]] - the auth scope to apply to the request. Set to null if no auth should be
  * applied
  * @param {string} [crumb=WYuCN5hiKnNkLpmUrEQj6Xer49FqfBPv20VO1C5wQHk] - the CSRF 'crumb' value to be used to verify the
  * request. Set to null if no crumb should be applied
  *
- * @returns {Object} the options to be used in the call to `server.inject()`
+ * @returns {object} the options to be used in the call to `server.inject()`
  */
 function postRequestOptions (
   path,
@@ -66,8 +66,8 @@ function postRequestOptions (
 /**
  * Generate a random integer within a range (inclusive)
  *
- * @param {Number} min - lowest number (integer) in the range (inclusive)
- * @param {Number} max - largest number (integer) in the range (inclusive)
+ * @param {number} min - lowest number (integer) in the range (inclusive)
+ * @param {number} max - largest number (integer) in the range (inclusive)
  *
  * Credit https://stackoverflow.com/a/7228322
  *
@@ -85,7 +85,7 @@ function randomInteger (min, max) {
  * Where we want to select a real value but don't care which, this can be used by the helper so select a random entry
  * from the reference data.
  *
- * @param {Object[]} data - an array of values to randomly select from
+ * @param {object[]} data - an array of values to randomly select from
  *
  * @returns a random entry from the data provided
  */

--- a/test/support/helpers/address.helper.js
+++ b/test/support/helpers/address.helper.js
@@ -21,7 +21,7 @@ const { randomInteger } = require('../general.js')
  * - `dataSource` - wrls
  * - `uprn` - [randomly generated - 340116]
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  *
  * @returns {module:AddressModel} The instance of the newly created record
  */
@@ -39,7 +39,7 @@ function add (data = {}) {
  * It will override or append to them any data provided. Mainly used by the `add()` method, we make it available
  * for use in tests to avoid having to duplicate values.
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  */
 function defaults (data = {}) {
   const defaults = {

--- a/test/support/helpers/bill-licence.helper.js
+++ b/test/support/helpers/bill-licence.helper.js
@@ -17,7 +17,7 @@ const LicenceHelper = require('./licence.helper.js')
  * - `licenceRef` - [randomly generated - 01/123]
  * - `licenceId` - [random UUID]
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  *
  * @returns {Promise<module:BillLicenceModel>} The instance of the newly created record
  */
@@ -35,7 +35,7 @@ async function add (data = {}) {
  * It will override or append to them any data provided. Mainly used by the `add()` method, we make it available
  * for use in tests to avoid having to duplicate values.
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  */
 function defaults (data = {}) {
   const defaults = {

--- a/test/support/helpers/bill-run-charge-version-year.helper.js
+++ b/test/support/helpers/bill-run-charge-version-year.helper.js
@@ -18,7 +18,7 @@ const { generateUUID } = require('../../../app/lib/general.lib.js')
  * - `batchType` - annual
  * - `summer` - false
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  *
  * @returns {Promise<module:BillRunChargeVersionYearModel>} The instance of the newly created record
  */
@@ -36,7 +36,7 @@ function add (data = {}) {
  * It will override or append to them any data provided. Mainly used by the `add()` method, we make it available
  * for use in tests to avoid having to duplicate values.
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  */
 function defaults (data = {}) {
   const defaults = {

--- a/test/support/helpers/bill-run-volume.helper.js
+++ b/test/support/helpers/bill-run-volume.helper.js
@@ -17,7 +17,7 @@ const { generateUUID } = require('../../../app/lib/general.lib.js')
  * - `summer` - false
  * - `billRunId` - [random UUID]
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  *
  * @returns {Promise<module:BillRunVolumeModel>} The instance of the newly created record
  */
@@ -35,7 +35,7 @@ function add (data = {}) {
  * It will override or append to them any data provided. Mainly used by the `add()` method, we make it available
  * for use in tests to avoid having to duplicate values.
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  */
 function defaults (data = {}) {
   const defaults = {

--- a/test/support/helpers/bill-run.helper.js
+++ b/test/support/helpers/bill-run.helper.js
@@ -20,7 +20,7 @@ const { generateUUID } = require('../../../app/lib/general.lib.js')
  * - `scheme` - sroc
  * - `source` - wrls
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  *
  * @returns {Promise<module:BillRunModel>} The instance of the newly created record
  */
@@ -38,7 +38,7 @@ function add (data = {}) {
  * It will override or append to them any data provided. Mainly used by the `add()` method, we make it available
  * for use in tests to avoid having to duplicate values.
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  */
 function defaults (data = {}) {
   const defaults = {

--- a/test/support/helpers/bill.helper.js
+++ b/test/support/helpers/bill.helper.js
@@ -19,7 +19,7 @@ const { generateAccountNumber } = require('./billing-account.helper.js')
  * - `billRunId` - [random UUID]
  * - `financialYearEnding` - 2023
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  *
  * @returns {Promise<module:BillModel>} The instance of the newly created record
  */
@@ -37,7 +37,7 @@ async function add (data = {}) {
  * It will override or append to them any data provided. Mainly used by the `add()` method, we make it available
  * for use in tests to avoid having to duplicate values.
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  */
 function defaults (data = {}) {
   const defaults = {

--- a/test/support/helpers/billing-account-address.helper.js
+++ b/test/support/helpers/billing-account-address.helper.js
@@ -16,7 +16,7 @@ const { generateUUID } = require('../../../app/lib/general.lib.js')
  * - `addressId` - [random UUID]
  * - `startDate` - 2023-08-18
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  *
  * @returns {Promise<module:BillingAccountAddressModel>} The instance of the newly created record
  */
@@ -34,7 +34,7 @@ function add (data = {}) {
  * It will override or append to them any data provided. Mainly used by the `add()` method, we make it available
  * for use in tests to avoid having to duplicate values.
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  */
 function defaults (data = {}) {
   const defaults = {

--- a/test/support/helpers/billing-account.helper.js
+++ b/test/support/helpers/billing-account.helper.js
@@ -16,7 +16,7 @@ const { generateUUID } = require('../../../app/lib/general.lib.js')
  * - `accountNumber` - [randomly generated - T12345678A]
  * - `companyId` - [random UUID]
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  *
  * @returns {Promise<module:BillingAccountModel>} The instance of the newly created record
  */
@@ -34,7 +34,7 @@ function add (data = {}) {
  * It will override or append to them any data provided. Mainly used by the `add()` method, we make it available
  * for use in tests to avoid having to duplicate values.
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  */
 function defaults (data = {}) {
   const defaults = {

--- a/test/support/helpers/change-reason.helper.js
+++ b/test/support/helpers/change-reason.helper.js
@@ -16,10 +16,10 @@ const { selectRandomEntry } = require('../general.js')
  * So, they are seeded automatically when tests are run. Tests that need to link to a record can use this method to
  * select a specific entry, or have it it return one at random.
  *
- * @param {Number} [index=-1] - The reference entry to select. Defaults to -1 which means an entry will be returned at
+ * @param {number} [index=-1] - The reference entry to select. Defaults to -1 which means an entry will be returned at
  * random from the reference data
  *
- * @returns {Object} The selected reference entry or one picked at random
+ * @returns {object} The selected reference entry or one picked at random
  */
 function select (index = -1) {
   if (index > -1) {

--- a/test/support/helpers/charge-category.helper.js
+++ b/test/support/helpers/charge-category.helper.js
@@ -25,7 +25,7 @@ const { randomInteger } = require('../general.js')
  * - `maxVolume` - 5000,
  * - `dateCreated` - Date.now()
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  *
  * @returns {Promise<module:ChargeCategoryModel>} The instance of the newly created record
  */
@@ -43,7 +43,7 @@ function add (data = {}) {
  * It will override or append to them any data provided. Mainly used by the `add()` method, we make it available
  * for use in tests to avoid having to duplicate values.
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  */
 function defaults (data = {}) {
   const defaults = {

--- a/test/support/helpers/charge-element.helper.js
+++ b/test/support/helpers/charge-element.helper.js
@@ -29,7 +29,7 @@ const { generateUUID } = require('../../../app/lib/general.lib.js')
  * - `purposeId` - [random UUID]
  * - `section127Agreement` - true
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  *
  * @returns {Promise<module:ChargeElementModel>} The instance of the newly created record
  */
@@ -47,7 +47,7 @@ function add (data = {}) {
  * It will override or append to them any data provided. Mainly used by the `add()` method, we make it available
  * for use in tests to avoid having to duplicate values.
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  */
 function defaults (data = {}) {
   const defaults = {

--- a/test/support/helpers/charge-reference.helper.js
+++ b/test/support/helpers/charge-reference.helper.js
@@ -30,7 +30,7 @@ const { generateUUID } = require('../../../app/lib/general.lib.js')
  * - `abstractionPeriodEndDay` - 31
  * - `abstractionPeriodEndMonth` - 12
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  *
  * @returns {Promise<module:ChargeReferenceModel>} The instance of the newly created record
  */
@@ -48,7 +48,7 @@ function add (data = {}) {
  * It will override or append to them any data provided. Mainly used by the `add()` method, we make it available
  * for use in tests to avoid having to duplicate values.
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  */
 function defaults (data = {}) {
   const defaults = {

--- a/test/support/helpers/charge-version-note.helper.js
+++ b/test/support/helpers/charge-version-note.helper.js
@@ -15,7 +15,7 @@ const ChargeVersionNoteModel = require('../../../app/models/charge-version-note.
  * - `note` - 'This is a test note'
  * - `userId` - [randomly generated - 100001]
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  *
  * @returns {Promise<module:NoteModel>} The instance of the newly created record
  */
@@ -33,7 +33,7 @@ function add (data = {}) {
  * It will override or append to them any data provided. Mainly used by the `add()` method, we make it available
  * for use in tests to avoid having to duplicate values.
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  */
 function defaults (data = {}) {
   const defaults = {

--- a/test/support/helpers/charge-version.helper.js
+++ b/test/support/helpers/charge-version.helper.js
@@ -23,7 +23,7 @@ const { generateLicenceRef } = require('./licence.helper.js')
  * - `status` - current
  * - `licenceId` - [random UUID]
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  *
  * @returns {Promise<module:ChargeVersionModel>} The instance of the newly created record
  */
@@ -41,7 +41,7 @@ async function add (data = {}) {
  * It will override or append to them any data provided. Mainly used by the `add()` method, we make it available
  * for use in tests to avoid having to duplicate values.
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  */
 function defaults (data = {}) {
   const defaults = {

--- a/test/support/helpers/company-address.helper.js
+++ b/test/support/helpers/company-address.helper.js
@@ -17,7 +17,7 @@ const { generateUUID } = require('../../../app/lib/general.lib.js')
  * - `licenceRoleId` - [random UUID]
  * - `startDate` - 2022-04-01
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  *
  * @returns {Promise<module:CompanyAddressModel>} The instance of the newly created record
  */
@@ -35,7 +35,7 @@ function add (data = {}) {
  * It will override or append to them any data provided. Mainly used by the `add()` method, we make it available
  * for use in tests to avoid having to duplicate values.
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  */
 function defaults (data = {}) {
   const defaults = {

--- a/test/support/helpers/company-contact.helper.js
+++ b/test/support/helpers/company-contact.helper.js
@@ -17,7 +17,7 @@ const { generateUUID } = require('../../../app/lib/general.lib.js')
  * - `licenceRoleId` - [random UUID]
  * - `startDate` - 2022-04-01
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  *
  * @returns {Promise<module:CompanyContactModel>} The instance of the newly created record
  */
@@ -35,7 +35,7 @@ function add (data = {}) {
  * It will override or append to them any data provided. Mainly used by the `add()` method, we make it available
  * for use in tests to avoid having to duplicate values.
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  */
 function defaults (data = {}) {
   const defaults = {

--- a/test/support/helpers/company.helper.js
+++ b/test/support/helpers/company.helper.js
@@ -17,7 +17,7 @@ const { randomInteger } = require('../general.js')
  * - `companyNumber` - [randomly generated - 24296934]
  * - `organisationType` - limitedCompany
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  *
  * @returns {Promise<module:CompanyModel>} The instance of the newly created record
  */
@@ -35,7 +35,7 @@ function add (data = {}) {
  * It will override or append to them any data provided. Mainly used by the `add()` method, we make it available
  * for use in tests to avoid having to duplicate values.
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  */
 function defaults (data = {}) {
   const defaults = {

--- a/test/support/helpers/contact.helper.js
+++ b/test/support/helpers/contact.helper.js
@@ -17,7 +17,7 @@ const ContactModel = require('../../../app/models/contact.model.js')
  * - `contactType` - person
  * - `email` - amara.gupta@example.com
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  *
  * @returns {Promise<module:ContactModel>} The instance of the newly created record
  */
@@ -35,7 +35,7 @@ function add (data = {}) {
  * It will override or append to them any data provided. Mainly used by the `add()` method, we make it available
  * for use in tests to avoid having to duplicate values.
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  */
 function defaults (data = {}) {
   const defaults = {

--- a/test/support/helpers/event.helper.js
+++ b/test/support/helpers/event.helper.js
@@ -28,7 +28,7 @@ const { generateUUID, timestampForPostgres } = require('../../../app/lib/general
  * - `createdAt` - current Date and time as an ISO string
  * - `updatedAt` - current Date and time as an ISO string
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  *
  * @returns {Promise<module:EventModel>} The instance of the newly created record
  */
@@ -46,7 +46,7 @@ function add (data = {}) {
  * It will override or append to them any data provided. Mainly used by the `add()` method, we make it available
  * for use in tests to avoid having to duplicate values.
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  */
 function defaults (data = {}) {
   const timestamp = timestampForPostgres()

--- a/test/support/helpers/financial-agreement.helper.js
+++ b/test/support/helpers/financial-agreement.helper.js
@@ -16,10 +16,10 @@ const { selectRandomEntry } = require('../general.js')
  * So, they are seeded automatically when tests are run. Tests that need to link to a record can use this method to
  * select a specific entry, or have it it return one at random.
  *
- * @param {Number} [index=-1] - The reference entry to select. Defaults to -1 which means an entry will be returned at
+ * @param {number} [index=-1] - The reference entry to select. Defaults to -1 which means an entry will be returned at
  * random from the reference data
  *
- * @returns {Object} The selected reference entry or one picked at random
+ * @returns {object} The selected reference entry or one picked at random
  */
 function select (index = -1) {
   if (index > -1) {

--- a/test/support/helpers/gauging-station.helper.js
+++ b/test/support/helpers/gauging-station.helper.js
@@ -20,7 +20,7 @@ const { timestampForPostgres } = require('../../../app/lib/general.lib.js')
  * - `label` - MEVAGISSEY FIRE STATION
  * - `createdAt` - new Date()
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  *
  * @returns {Promise<module:GaugingStationModel>} The instance of the newly created record
  */
@@ -38,7 +38,7 @@ async function add (data = {}) {
  * It will override or append to them any data provided. Mainly used by the `add()` method, we make it available
  * for use in tests to avoid having to duplicate values.
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  */
 function defaults (data = {}) {
   const timestamp = timestampForPostgres()

--- a/test/support/helpers/group-role.helper.js
+++ b/test/support/helpers/group-role.helper.js
@@ -16,10 +16,10 @@ const GroupRoles = require('../../../db/seeds/data/group-roles.js')
  * So, they are seeded automatically when tests are run. Tests that need to link to a record can use this method to
  * select a specific entry, or have it it return one at random.
  *
- * @param {Number} [index=-1] - The reference entry to select. Defaults to -1 which means an entry will be returned at
+ * @param {number} [index=-1] - The reference entry to select. Defaults to -1 which means an entry will be returned at
  * random from the reference data
  *
- * @returns {Object} The selected reference entry or one picked at random
+ * @returns {object} The selected reference entry or one picked at random
  */
 function select (index = -1) {
   if (index > -1) {

--- a/test/support/helpers/group.helper.js
+++ b/test/support/helpers/group.helper.js
@@ -16,10 +16,10 @@ const Groups = require('../../../db/seeds/data/groups.js')
  * So, they are seeded automatically when tests are run. Tests that need to link to a record can use this method to
  * select a specific entry, or have it it return one at random.
  *
- * @param {Number} [index=-1] - The reference entry to select. Defaults to -1 which means an entry will be returned at
+ * @param {number} [index=-1] - The reference entry to select. Defaults to -1 which means an entry will be returned at
  * random from the reference data
  *
- * @returns {Object} The selected reference entry or one picked at random
+ * @returns {object} The selected reference entry or one picked at random
  */
 function select (index = -1) {
   if (index > -1) {

--- a/test/support/helpers/licence-agreement.helper.js
+++ b/test/support/helpers/licence-agreement.helper.js
@@ -17,7 +17,7 @@ const LicenceHelper = require('./licence.helper.js')
  * - `licenceRef` - [randomly generated - 01/123]
  * - `startDate` - 2023-01-01
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  *
  * @returns {Promise<module:LicenceAgreementModel>} The instance of the newly created record
  */
@@ -35,7 +35,7 @@ async function add (data = {}) {
  * It will override or append to them any data provided. Mainly used by the `add()` method, we make it available
  * for use in tests to avoid having to duplicate values.
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  */
 function defaults (data = {}) {
   const defaults = {

--- a/test/support/helpers/licence-document-header.helper.js
+++ b/test/support/helpers/licence-document-header.helper.js
@@ -19,7 +19,7 @@ const LicenceDocumentHeaderModel = require('../../../app/models/licence-document
  * - `licenceRef` - [randomly generated - 01/123]
  * - `metadata` - [object intended to be persisted] as JSON]
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  *
  * @returns {Promise<module:LicenceDocumentHeaderModel>} The instance of the newly created record
  */
@@ -37,7 +37,7 @@ async function add (data = {}) {
  * It will override or append to them any data provided. Mainly used by the `add()` method, we make it available
  * for use in tests to avoid having to duplicate values.
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  */
 function defaults (data = {}) {
   const defaults = {

--- a/test/support/helpers/licence-document-role.helper.js
+++ b/test/support/helpers/licence-document-role.helper.js
@@ -18,7 +18,7 @@ const LicenceDocumentRoleModel = require('../../../app/models/licence-document-r
  * - `licenceRoleId` - [random UUID]
  * - `startDate` - new Date('2022-01-01')
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  *
  * @returns {Promise<module:LicenceDocumentRoleModel>} The instance of the newly created record
  */
@@ -36,7 +36,7 @@ async function add (data = {}) {
  * It will override or append to them any data provided. Mainly used by the `add()` method, we make it available
  * for use in tests to avoid having to duplicate values.
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  */
 function defaults (data = {}) {
   const defaults = {

--- a/test/support/helpers/licence-document.helper.js
+++ b/test/support/helpers/licence-document.helper.js
@@ -15,7 +15,7 @@ const LicenceDocumentModel = require('../../../app/models/licence-document.model
  * - `licenceRef` - [randomly generated - 01/123]
  * - `startDate` - new Date('2022-01-01')
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  *
  * @returns {Promise<module:LicenceDocumentModel>} The instance of the newly created record
  */
@@ -33,7 +33,7 @@ async function add (data = {}) {
  * It will override or append to them any data provided. Mainly used by the `add()` method, we make it available
  * for use in tests to avoid having to duplicate values.
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  */
 function defaults (data = {}) {
   const defaults = {

--- a/test/support/helpers/licence-entity-role.helper.js
+++ b/test/support/helpers/licence-entity-role.helper.js
@@ -18,7 +18,7 @@ const LicenceEntityRoleModel = require('../../../app/models/licence-entity-role.
  * - `regimeEntityId` - [random UUID]
  * - `companyEntityId` - [random UUID]
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  *
  * @returns {Promise<module:LicenceEntityRoleModel>} The instance of the newly created record
  */
@@ -36,7 +36,7 @@ async function add (data = {}) {
  * It will override or append to them any data provided. Mainly used by the `add()` method, we make it available
  * for use in tests to avoid having to duplicate values.
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  */
 function defaults (data = {}) {
   const defaults = {

--- a/test/support/helpers/licence-entity.helper.js
+++ b/test/support/helpers/licence-entity.helper.js
@@ -16,7 +16,7 @@ const LicenceEntityModel = require('../../../app/models/licence-entity.model.js'
  * - `name` - grace.hopper@example.com
  * - `type` - individual
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  *
  * @returns {Promise<module:LicenceEntityModel>} The instance of the newly created record
  */
@@ -34,7 +34,7 @@ async function add (data = {}) {
  * It will override or append to them any data provided. Mainly used by the `add()` method, we make it available
  * for use in tests to avoid having to duplicate values.
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  */
 function defaults (data = {}) {
   const defaults = {

--- a/test/support/helpers/licence-gauging-station.helper.js
+++ b/test/support/helpers/licence-gauging-station.helper.js
@@ -21,7 +21,7 @@ const LicenceGaugingStationModel = require('../../../app/models/licence-gauging-
  * - `createdAt` - Date.now()
  * - `updatedAt` - Date.now()
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  *
  * @returns {Promise<module:LicenceGaugingStationModel>} The instance of the newly created record
  */
@@ -39,7 +39,7 @@ async function add (data = {}) {
  * It will override or append to them any data provided. Mainly used by the `add()` method, we make it available
  * for use in tests to avoid having to duplicate values.
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  */
 function defaults (data = {}) {
   const defaults = {

--- a/test/support/helpers/licence-role.helper.js
+++ b/test/support/helpers/licence-role.helper.js
@@ -14,7 +14,7 @@ const LicenceRoleModel = require('../../../app/models/licence-role.model.js')
  * - `name` - licenceHolder
  * - `label` - Licence Holder
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  *
  * @returns {Promise<module:LicenceRoleModel>} The instance of the newly created record
  */
@@ -32,7 +32,7 @@ async function add (data = {}) {
  * It will override or append to them any data provided. Mainly used by the `add()` method, we make it available
  * for use in tests to avoid having to duplicate values.
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  */
 function defaults (data = {}) {
   const defaults = {

--- a/test/support/helpers/licence-supplementary-year.helper.js
+++ b/test/support/helpers/licence-supplementary-year.helper.js
@@ -15,7 +15,7 @@ const LicenceSupplementaryYearModel = require('../../../app/models/licence-suppl
  * - `licenceId` - [random UUID]
  * - `financialYearEnd` - 2023
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  *
  * @returns {Promise<module:LicenceSupplementaryYearModel>} The instance of the newly created record
  */
@@ -33,7 +33,7 @@ function add (data = {}) {
  * It will override or append to them any data provided. Mainly used by the `add()` method, we make it available
  * for use in tests to avoid having to duplicate values.
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here in the database
  */
 function defaults (data = {}) {
   const defaults = {

--- a/test/support/helpers/licence-version-purpose-condition-type.helper.js
+++ b/test/support/helpers/licence-version-purpose-condition-type.helper.js
@@ -16,10 +16,10 @@ const { data: licenceVersionPurposeConditionTypes } = require('../../../db/seeds
  * So, they are seeded automatically when tests are run. Tests that need to link to a record can use this method to
  * select a specific entry, or have it it return one at random.
  *
- * @param {Number} [index=-1] - The reference entry to select. Defaults to -1 which means an entry will be returned at
+ * @param {number} [index=-1] - The reference entry to select. Defaults to -1 which means an entry will be returned at
  * random from the reference data
  *
- * @returns {Object} The selected reference entry or one picked at random
+ * @returns {object} The selected reference entry or one picked at random
  */
 function select (index = -1) {
   if (index > -1) {

--- a/test/support/helpers/licence-version-purpose-condition.helper.js
+++ b/test/support/helpers/licence-version-purpose-condition.helper.js
@@ -21,7 +21,7 @@ const { randomInteger } = require('../general.js')
  * - `dateCreated` - new Date()
  * - `dateUpdated` - new Date()
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  *
  * @returns {Promise<module:LicenceVersionPurposeConditionModel>} The instance of the newly created record
  */
@@ -39,7 +39,7 @@ async function add (data = {}) {
  * It will override or append to them any data provided. Mainly used by the `add()` method, we make it available
  * for use in tests to avoid having to duplicate values.
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  */
 function defaults (data = {}) {
   const timestamp = timestampForPostgres()

--- a/test/support/helpers/licence-version-purpose.helper.js
+++ b/test/support/helpers/licence-version-purpose.helper.js
@@ -25,7 +25,7 @@ const { randomInteger } = require('../general.js')
  * - `created` - new Date()
  * - `updated` - new Date()
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  *
  * @returns {Promise<module:LicenceVersionPurposeModel>} The instance of the newly created record
  */
@@ -43,7 +43,7 @@ async function add (data = {}) {
  * It will override or append to them any data provided. Mainly used by the `add()` method, we make it available
  * for use in tests to avoid having to duplicate values.
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  */
 function defaults (data = {}) {
   const timestamp = timestampForPostgres()

--- a/test/support/helpers/licence-version.helper.js
+++ b/test/support/helpers/licence-version.helper.js
@@ -22,7 +22,7 @@ const { randomInteger } = require('../general.js')
  * - `createdAt` - new Date()
  * - `updatedAt` - new Date()
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  *
  * @returns {Promise<module:LicenceVersionModel>} The instance of the newly created record
  */
@@ -40,7 +40,7 @@ async function add (data = {}) {
  * It will override or append to them any data provided. Mainly used by the `add()` method, we make it available
  * for use in tests to avoid having to duplicate values.
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  */
 function defaults (data = {}) {
   const timestamp = timestampForPostgres()

--- a/test/support/helpers/licence.helper.js
+++ b/test/support/helpers/licence.helper.js
@@ -19,7 +19,7 @@ const { randomInteger } = require('../general.js')
  * - `regions` - { historicalAreaCode: 'SAAR', regionalChargeArea: 'Southern' }
  * - `startDate` - new Date('2022-01-01')
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  *
  * @returns {Promise<module:LicenceModel>} The instance of the newly created record
  */
@@ -37,7 +37,7 @@ async function add (data = {}) {
  * It will override or append to them any data provided. Mainly used by the `add()` method, we make it available
  * for use in tests to avoid having to duplicate values.
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  */
 function defaults (data = {}) {
   const defaults = {

--- a/test/support/helpers/mod-log.helper.js
+++ b/test/support/helpers/mod-log.helper.js
@@ -21,7 +21,7 @@ const { generateLicenceRef } = require('./licence.helper.js')
  * - `licenceRef` - [randomly generated - 01/12/34/1000]
  * - `licenceExternalId` - [randomly generated - 9:99999]
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  *
  * @returns {Promise<module:ModLogModel>} The instance of the newly created record
  */
@@ -39,7 +39,7 @@ function add (data = {}) {
  * It will override or append to them any data provided. Mainly used by the `add()` method, we make it available
  * for use in tests to avoid having to duplicate values.
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  */
 function defaults (data = {}) {
   const regionCode = randomInteger(1, 9)

--- a/test/support/helpers/permit-licence.helper.js
+++ b/test/support/helpers/permit-licence.helper.js
@@ -18,7 +18,7 @@ const { generateLicenceRef } = require('./licence.helper.js')
  * - `licenceRef` - [randomly generated - 01/123]
  * - `licenceDataValue` - large JSON blob. See _licenceDataValue() for details
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  *
  * @returns {Promise<module:PermitLicenceModel>} The instance of the newly created record
  */
@@ -36,7 +36,7 @@ async function add (data = {}) {
  * It will override or append to them any data provided. Mainly used by the `add()` method, we make it available
  * for use in tests to avoid having to duplicate values.
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  */
 function defaults (data = {}) {
   const licenceRef = data.licenceRef ? data.licenceRef : generateLicenceRef()

--- a/test/support/helpers/primary-purpose.helper.js
+++ b/test/support/helpers/primary-purpose.helper.js
@@ -16,10 +16,10 @@ const { data: primaryPurposes } = require('../../../db/seeds/data/primary-purpos
  * So, they are seeded automatically when tests are run. Tests that need to link to a record can use this method to
  * select a specific entry, or have it it return one at random.
  *
- * @param {Number} [index=-1] - The reference entry to select. Defaults to -1 which means an entry will be returned at
+ * @param {number} [index=-1] - The reference entry to select. Defaults to -1 which means an entry will be returned at
  * random from the reference data
  *
- * @returns {Object} The selected reference entry or one picked at random
+ * @returns {object} The selected reference entry or one picked at random
  */
 function select (index = -1) {
   if (index > -1) {

--- a/test/support/helpers/purpose.helper.js
+++ b/test/support/helpers/purpose.helper.js
@@ -16,10 +16,10 @@ const { data: purposes } = require('../../../db/seeds/data/purposes.js')
  * So, they are seeded automatically when tests are run. Tests that need to link to a record can use this method to
  * select a specific entry, or have it it return one at random.
  *
- * @param {Number} [index=-1] - The reference entry to select. Defaults to -1 which means an entry will be returned at
+ * @param {number} [index=-1] - The reference entry to select. Defaults to -1 which means an entry will be returned at
  * random from the reference data
  *
- * @returns {Object} The selected reference entry or one picked at random
+ * @returns {object} The selected reference entry or one picked at random
  */
 function select (index = -1) {
   if (index > -1) {

--- a/test/support/helpers/region.helper.js
+++ b/test/support/helpers/region.helper.js
@@ -18,10 +18,10 @@ const TEST_REGION_INDEX = 8
  * So, they are seeded automatically when tests are run. Tests that need to link to a record can use this method to
  * select a specific entry, or have it it return one at random.
  *
- * @param {Number} [index=-1] - The reference entry to select. Defaults to -1 which means an entry will be returned at
+ * @param {number} [index=-1] - The reference entry to select. Defaults to -1 which means an entry will be returned at
  * random from the reference data
  *
- * @returns {Object} The selected reference entry or one picked at random
+ * @returns {object} The selected reference entry or one picked at random
  */
 function select (index = -1) {
   if (index > -1) {

--- a/test/support/helpers/return-log.helper.js
+++ b/test/support/helpers/return-log.helper.js
@@ -27,7 +27,7 @@ const ReturnLogModel = require('../../../app/models/return-log.model.js')
  * - `status` - completed
  * - `updatedAt` - new Date()
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  *
  * @returns {Promise<module:ReturnLogModel>} The instance of the newly created record
  */
@@ -45,7 +45,7 @@ function add (data = {}) {
  * It will override or append to them any data provided. Mainly used by the `add()` method, we make it available
  * for use in tests to avoid having to duplicate values.
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  */
 function defaults (data = {}) {
   const licenceRef = data.licenceRef ? data.licenceRef : generateLicenceRef()

--- a/test/support/helpers/return-requirement-point.helper.js
+++ b/test/support/helpers/return-requirement-point.helper.js
@@ -18,7 +18,7 @@ const ReturnRequirementPointModel = require('../../../app/models/return-requirem
  * - `ngr1` - [randomly generated - TL 5143 7153]
  * - `returnRequirementId` - [random UUID]
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  *
  * @returns {Promise<module:ReturnRequirementPointModel>} The instance of the newly created record
  */
@@ -36,7 +36,7 @@ function add (data = {}) {
  * It will override or append to them any data provided. Mainly used by the `add()` method, we make it available
  * for use in tests to avoid having to duplicate values.
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  */
 function defaults (data = {}) {
   const naldPointId = data.naldPointId ? data.naldPointId : generateNaldPointId()

--- a/test/support/helpers/return-requirement-purpose.helper.js
+++ b/test/support/helpers/return-requirement-purpose.helper.js
@@ -22,7 +22,7 @@ const SecondaryPurposeHelper = require('../helpers/secondary-purpose.helper.js')
  * - `secondaryPurposeId` - [randomly selected UUID from secondary purposes]
  * - `returnRequirementId` - [random UUID]
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  *
  * @returns {Promise<module:ReturnRequirementPurposeModel>} The instance of the newly created record
  */
@@ -40,7 +40,7 @@ function add (data = {}) {
  * It will override or append to them any data provided. Mainly used by the `add()` method, we make it available
  * for use in tests to avoid having to duplicate values.
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  */
 function defaults (data = {}) {
   const purpose = PurposeHelper.select()

--- a/test/support/helpers/return-requirement.helper.js
+++ b/test/support/helpers/return-requirement.helper.js
@@ -23,7 +23,7 @@ const ReturnRequirementModel = require('../../../app/models/return-requirement.m
  * - `returnVersionId` - [random UUID]
  * - `siteDescription` - BOREHOLE AT AVALON
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  *
  * @returns {Promise<module:ReturnRequirementModel>} The instance of the newly created record
  */
@@ -41,7 +41,7 @@ function add (data = {}) {
  * It will override or append to them any data provided. Mainly used by the `add()` method, we make it available
  * for use in tests to avoid having to duplicate values.
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  */
 function defaults (data = {}) {
   const legacyId = data.legacyId ? data.legacyId : randomInteger(100, 99999)

--- a/test/support/helpers/return-submission-line.helper.js
+++ b/test/support/helpers/return-submission-line.helper.js
@@ -23,7 +23,7 @@ const ReturnSubmissionLineModel = require('../../../app/models/return-submission
  * - `readingType` - measured
  * - `userUnit` - m³
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  *
  * @returns {Promise<module:ReturnSubmissionLineModel>} The instance of the newly created record
  */
@@ -41,7 +41,7 @@ function add (data = {}) {
  * It will override or append to them any data provided. Mainly used by the `add()` method, we make it available
  * for use in tests to avoid having to duplicate values.
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  */
 function defaults (data = {}) {
   const defaults = {

--- a/test/support/helpers/return-submission.helper.js
+++ b/test/support/helpers/return-submission.helper.js
@@ -24,7 +24,7 @@ const ReturnSubmissionModel = require('../../../app/models/return-submission.mod
  * - `nilReturn` - false
  * - `current` - true
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  *
  * @returns {Promise<module:ReturnSubmissionModel>} The instance of the newly created record
  */
@@ -42,7 +42,7 @@ function add (data = {}) {
  * It will override or append to them any data provided. Mainly used by the `add()` method, we make it available
  * for use in tests to avoid having to duplicate values.
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  */
 function defaults (data = {}) {
   const defaults = {

--- a/test/support/helpers/return-version.helper.js
+++ b/test/support/helpers/return-version.helper.js
@@ -20,7 +20,7 @@ const ReturnVersionModel = require('../../../app/models/return-version.model.js'
  * - `status` - current
  * - `version` - 100
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  *
  * @returns {Promise<module:ReturnVersionModel>} The instance of the newly created record
  */
@@ -38,7 +38,7 @@ function add (data = {}) {
  * It will override or append to them any data provided. Mainly used by the `add()` method, we make it available
  * for use in tests to avoid having to duplicate values.
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  */
 function defaults (data = {}) {
   const version = data.version ? data.version : 100

--- a/test/support/helpers/review-charge-element-return.helper.js
+++ b/test/support/helpers/review-charge-element-return.helper.js
@@ -15,7 +15,7 @@ const ReviewChargeElementReturnModel = require('../../../app/models/review-charg
  * - `reviewChargeElementId` - [random UUID]
  * - `reviewReturnId` - [random UUID]
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  *
  * @returns {Promise<module:ReviewChargeElementReturnModel>} The instance of the newly created record
  */
@@ -33,7 +33,7 @@ function add (data = {}) {
  * It will override or append to them any data provided. Mainly used by the `add()` method, we make it available
  * for use in tests to avoid having to duplicate values.
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here in the database
  */
 function defaults (data = {}) {
   const defaults = {

--- a/test/support/helpers/review-charge-element.helper.js
+++ b/test/support/helpers/review-charge-element.helper.js
@@ -20,7 +20,7 @@ const ReviewChargeElementModel = require('../../../app/models/review-charge-elem
  * - `status` - ready
  * - `amendedAllocated` - 0
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  *
  * @returns {Promise<module:ReviewChargeElementModel>} The instance of the newly created record
  */
@@ -38,7 +38,7 @@ function add (data = {}) {
  * It will override or append to them any data provided. Mainly used by the `add()` method, we make it available
  * for use in tests to avoid having to duplicate values.
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here in the database
  */
 function defaults (data = {}) {
   const defaults = {

--- a/test/support/helpers/review-charge-reference.helper.js
+++ b/test/support/helpers/review-charge-reference.helper.js
@@ -25,7 +25,7 @@ const ReviewChargeReferenceModel = require('../../../app/models/review-charge-re
  * - `authorisedVolume` - 50
  * - `amendedAuthorisedVolume` - 50
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  *
  * @returns {Promise<module:ReviewChargeReferenceModel>} The instance of the newly created record
  */
@@ -43,7 +43,7 @@ function add (data = {}) {
  * It will override or append to them any data provided. Mainly used by the `add()` method, we make it available
  * for use in tests to avoid having to duplicate values.
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here in the database
  */
 function defaults (data = {}) {
   const defaults = {

--- a/test/support/helpers/review-charge-version.helper.js
+++ b/test/support/helpers/review-charge-version.helper.js
@@ -18,7 +18,7 @@ const ReviewChargeVersionModel = require('../../../app/models/review-charge-vers
  * - `chargePeriodStartDate` - 2022-04-01
  * - `chargePeriodEndDate` - 2022-06-05
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  *
  * @returns {Promise<module:ReviewChargeVersionModel>} The instance of the newly created record
  */
@@ -36,7 +36,7 @@ function add (data = {}) {
  * It will override or append to them any data provided. Mainly used by the `add()` method, we make it available
  * for use in tests to avoid having to duplicate values.
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here in the database
  */
 function defaults (data = {}) {
   const defaults = {

--- a/test/support/helpers/review-licence.helper.js
+++ b/test/support/helpers/review-licence.helper.js
@@ -21,7 +21,7 @@ const ReviewLicenceModel = require('../../../app/models/review-licence.model.js'
  * - `status` - ready
  * - `issues` - null
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  *
  * @returns {Promise<module:ReviewLicenceModel>} The instance of the newly created record
  */
@@ -39,7 +39,7 @@ function add (data = {}) {
  * It will override or append to them any data provided. Mainly used by the `add()` method, we make it available
  * for use in tests to avoid having to duplicate values.
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here in the database
  */
 function defaults (data = {}) {
   const defaults = {

--- a/test/support/helpers/review-return.helper.js
+++ b/test/support/helpers/review-return.helper.js
@@ -32,7 +32,7 @@ const ReviewReturnModel = require('../../../app/models/review-return.model.js')
  * - `endDate` - 2022-05-06
  * - `issues` - null
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  *
  * @returns {Promise<module:ReviewReturnModel>} The instance of the newly created record
  */
@@ -50,7 +50,7 @@ function add (data = {}) {
  * It will override or append to them any data provided. Mainly used by the `add()` method, we make it available
  * for use in tests to avoid having to duplicate values.
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here in the database
  */
 function defaults (data = {}) {
   const licenceRef = data.licenceRef ? data.licenceRef : generateLicenceRef()

--- a/test/support/helpers/role.helper.js
+++ b/test/support/helpers/role.helper.js
@@ -16,10 +16,10 @@ const { data: roles } = require('../../../db/seeds/data/roles.js')
  * So, they are seeded automatically when tests are run. Tests that need to link to a record can use this method to
  * select a specific entry, or have it it return one at random.
  *
- * @param {Number} [index=-1] - The reference entry to select. Defaults to -1 which means an entry will be returned at
+ * @param {number} [index=-1] - The reference entry to select. Defaults to -1 which means an entry will be returned at
  * random from the reference data
  *
- * @returns {Object} The selected reference entry or one picked at random
+ * @returns {object} The selected reference entry or one picked at random
  */
 function select (index = -1) {
   if (index > -1) {

--- a/test/support/helpers/scheduled-notification.helper.js
+++ b/test/support/helpers/scheduled-notification.helper.js
@@ -14,7 +14,7 @@ const ScheduledNotificationModel = require('../../../app/models/scheduled-notifi
  *
  * - `createdAt` - new Date()
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  *
  * @returns {Promise<module:ScheduledNotificationModel>} The instance of the newly created record
  */
@@ -32,7 +32,7 @@ function add (data = {}) {
  * It will override or append to them any data provided. Mainly used by the `add()` method, we make it available
  * for use in tests to avoid having to duplicate values.
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  */
 function defaults (data = {}) {
   const defaults = {

--- a/test/support/helpers/secondary-purpose.helper.js
+++ b/test/support/helpers/secondary-purpose.helper.js
@@ -16,10 +16,10 @@ const { data: secondaryPurposes } = require('../../../db/seeds/data/secondary-pu
  * So, they are seeded automatically when tests are run. Tests that need to link to a record can use this method to
  * select a specific entry, or have it it return one at random.
  *
- * @param {Number} [index=-1] - The reference entry to select. Defaults to -1 which means an entry will be returned at
+ * @param {number} [index=-1] - The reference entry to select. Defaults to -1 which means an entry will be returned at
  * random from the reference data
  *
- * @returns {Object} The selected reference entry or one picked at random
+ * @returns {object} The selected reference entry or one picked at random
  */
 function select (index = -1) {
   if (index > -1) {

--- a/test/support/helpers/session.helper.js
+++ b/test/support/helpers/session.helper.js
@@ -14,7 +14,7 @@ const SessionModel = require('../../../app/models/session.model.js')
  * - `id` - [random UUID]
  * - `data` - [empty object {}]
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  *
  * @returns {Promise<module:SessionModel>} The instance of the newly created record
  */
@@ -32,7 +32,7 @@ function add (data = {}) {
  * It will override or append to them any data provided. Mainly used by the `add()` method, we make it available
  * for use in tests to avoid having to duplicate values.
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here in the database
  */
 function defaults (data = {}) {
   const defaults = {}

--- a/test/support/helpers/transaction.helper.js
+++ b/test/support/helpers/transaction.helper.js
@@ -37,7 +37,7 @@ const TransactionModel = require('../../../app/models/transaction.model.js')
  * - `startDate` - start date for the current financial year (01-APR-20??)
  * - `volume` - 11
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  *
  * @returns {Promise<module:TransactionModel>} The instance of the newly created record
  */
@@ -55,7 +55,7 @@ function add (data = {}) {
  * It will override or append to them any data provided. Mainly used by the `add()` method, we make it available
  * for use in tests to avoid having to duplicate values.
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  */
 function defaults (data = {}) {
   const { startDate, endDate } = determineCurrentFinancialYear()

--- a/test/support/helpers/user-group.helper.js
+++ b/test/support/helpers/user-group.helper.js
@@ -20,7 +20,7 @@ const DEFAULT_INDEX = 4
  * - `userId` - [randomly generated - 100001]
  * - `groupId` - [random UUID]
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  *
  * @returns {Promise<module:UserGroupModel>} The instance of the newly created record
  */
@@ -38,7 +38,7 @@ function add (data = {}) {
  * It will override or append to them any data provided. Mainly used by the `add()` method, we make it available
  * for use in tests to avoid having to duplicate values.
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  */
 function defaults (data = {}) {
   const defaults = {
@@ -63,10 +63,10 @@ function defaults (data = {}) {
  * So, they are seeded automatically when tests are run. Tests that need to link to a record can use this method to
  * select a specific entry, or have it it return one at random.
  *
- * @param {Number} [index=-1] - The reference entry to select. Defaults to -1 which means an entry will be returned at
+ * @param {number} [index=-1] - The reference entry to select. Defaults to -1 which means an entry will be returned at
  * random from the reference data
  *
- * @returns {Object} The selected reference entry or one picked at random
+ * @returns {object} The selected reference entry or one picked at random
  */
 function select (index = -1) {
   if (index > -1) {

--- a/test/support/helpers/user-role.helper.js
+++ b/test/support/helpers/user-role.helper.js
@@ -16,7 +16,7 @@ const UserRoleModel = require('../../../app/models/user-role.model.js')
  * - `userId` - [randomly generated - 100001]
  * - `roleId` - [random UUID]
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  *
  * @returns {Promise<module:UserRoleModel>} The instance of the newly created record
  */
@@ -34,7 +34,7 @@ function add (data = {}) {
  * It will override or append to them any data provided. Mainly used by the `add()` method, we make it available
  * for use in tests to avoid having to duplicate values.
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  */
 function defaults (data = {}) {
   const defaults = {

--- a/test/support/helpers/user.helper.js
+++ b/test/support/helpers/user.helper.js
@@ -22,7 +22,7 @@ const DEFAULT_INDEX = 4
  * - `badLogins` - 0
  * - `application` - water_admin
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  *
  * @returns {Promise<module:UserModel>} The instance of the newly created record
  */
@@ -43,7 +43,7 @@ function add (data = {}) {
  * It will override or append to them any data provided. Mainly used by the `add()` method, we make it available
  * for use in tests to avoid having to duplicate values.
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  */
 function defaults (data = {}) {
   const defaults = {
@@ -74,10 +74,10 @@ function generateUserId () {
  * So, they are seeded automatically when tests are run. Tests that need to link to a record can use this method to
  * select a specific entry, or have it it return one at random.
  *
- * @param {Number} [index=-1] - The reference entry to select. Defaults to -1 which means an entry will be returned at
+ * @param {number} [index=-1] - The reference entry to select. Defaults to -1 which means an entry will be returned at
  * random from the reference data
  *
- * @returns {Object} The selected reference entry or one picked at random
+ * @returns {object} The selected reference entry or one picked at random
  */
 function select (index = -1) {
   if (index > -1) {

--- a/test/support/helpers/workflow.helper.js
+++ b/test/support/helpers/workflow.helper.js
@@ -17,7 +17,7 @@ const WorkflowModel = require('../../../app/models/workflow.model.js')
  * - `data` - { chargeVersion: null },
  * - `createdAt` - the current date and time
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  *
  * @returns {Promise<module:WorkflowModel>} The instance of the newly created record
  */
@@ -35,7 +35,7 @@ function add (data = {}) {
  * It will override or append to them any data provided. Mainly used by the `add()` method, we make it available
  * for use in tests to avoid having to duplicate values.
  *
- * @param {Object} [data] Any data you want to use instead of the defaults used here or in the database
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  */
 function defaults (data = {}) {
   const defaults = {

--- a/test/support/seeders/licence-abstraction-data.seeder.js
+++ b/test/support/seeders/licence-abstraction-data.seeder.js
@@ -32,9 +32,9 @@ const { generateLicenceVersionPurposeExternalId } = require('../helpers/licence-
  * - 1 permit licence containing 3 legacy purposes which match to the 3 licence version purposes, the first containing 2
  *   points and the rest 1
  *
- * @param {String | undefined} optionalLicenceRef - The licence reference to use for the seeded licence
+ * @param {string | undefined} optionalLicenceRef - The licence reference to use for the seeded licence
  *
- * @returns {Promise<Object>} all the named IDs for then seeded records in an object
+ * @returns {Promise<object>} all the named IDs for then seeded records in an object
  */
 async function seed (optionalLicenceRef = undefined) {
   const records = {}

--- a/test/support/seeders/licence-holder.seeder.js
+++ b/test/support/seeders/licence-holder.seeder.js
@@ -12,8 +12,8 @@ const LicenceRoleHelper = require('../helpers/licence-role.helper.js')
 /**
  * Adds a company to the provided licence that is set up to be the licence holder
  *
- * @param {String} licenceRef - The licence reference that the company will be the licence holder for
- * @param {String} [name] - The name of the company that will be the licence holder
+ * @param {string} licenceRef - The licence reference that the company will be the licence holder for
+ * @param {string} [name] - The name of the company that will be the licence holder
  *
  * @returns {Promise<module:LicenceDocumentRoleHelper>} the licence document role which will link through to all the
  * entities that make up the licence holder

--- a/test/support/seeders/registered-to-and-licence-name.seeder.js
+++ b/test/support/seeders/registered-to-and-licence-name.seeder.js
@@ -19,7 +19,7 @@ const LicenceEntityHelper = require('../helpers/licence-entity.helper.js')
  * modifier on the `LicenceModel`.
  *
  * @param {module:LicenceModel} licence - The licence instance we are setting up the records for
- * @param {String} [licenceName] The custom licence name to use
+ * @param {string} [licenceName] - The custom licence name to use
  */
 async function seed (licence, licenceName = 'My custom licence name') {
   const { licenceRef } = licence

--- a/test/support/seeders/requirements-for-returns.seeder.js
+++ b/test/support/seeders/requirements-for-returns.seeder.js
@@ -26,7 +26,7 @@ const UserHelper = require('../helpers/user.helper.js')
  *
  * Because of this it can be useful to test presenters and services that need to transform the data.
  *
- * @returns {Promise<Object>} a 'complete' `ReturnVersionModel` instance with two return requirements, each containing a
+ * @returns {Promise<object>} a 'complete' `ReturnVersionModel` instance with two return requirements, each containing a
  * point and a purpose plus an instance of `UserModel` for the user that created it and `LicenceModel` for the licence
  * it is linked to
  */


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/125

- Previous work https://github.com/DEFRA/water-abstraction-system/pull/1269

Building on from previous work of using eslint to handle out code conventions this change will use the auto fix feature of eslint and fix any errors relating to a jsoc description not having a - to separate and also fix any types that are incorrectly named i.e Object shoudl dbe object.

Some of the more complex changes such as adding returns and parameters to the jsdocs will be left to be done as when the file is touched or when time permits addressing tech debt.