### PR TITLE
Tell JSDoc linter to ignore private functions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -46,6 +46,11 @@ module.exports = {
     'jsdoc/lines-before-block': 'warn',
     'jsdoc/check-types': 'warn',
     'jsdoc/require-hyphen-before-param-description': 'warn'
+  },
+  settings: {
+    jsdoc: {
+      mode: 'jsdoc'
+    }
   }
 }
 

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -49,7 +49,8 @@ module.exports = {
   },
   settings: {
     jsdoc: {
-      mode: 'jsdoc'
+      mode: 'jsdoc',
+      ignorePrivate: true
     }
   }
 }

--- a/app/lib/base-notifier.lib.js
+++ b/app/lib/base-notifier.lib.js
@@ -135,6 +135,8 @@ class BaseNotifierLib {
    *
    * By doing it this way we can _still_ pass a `data` arg to `omfg()` and include those values in our log entry along
    * with the error.
+   *
+   * @private
    */
   _formatLogPacket (data, error) {
     const packet = {
@@ -160,6 +162,8 @@ class BaseNotifierLib {
    * But this means Airbrake's `message:` property becomes ignored. Errbit will set the issue title using the error's
    * `message` instead. In order to see our message when a 'proper' error is passed in we include our `message` as a
    * property of `session:`.
+   *
+   * @private
    */
   _formatNotifyPacket (data, error, message) {
     return {
@@ -179,6 +183,8 @@ class BaseNotifierLib {
    *
    * @param {object} [logger] - An instance of {@link https://github.com/pinojs/pino|pino}. If 'null' the method will
    * create a new instance.
+   *
+   * @private
    */
   _setLogger (logger) {
     if (logger) {
@@ -196,6 +202,8 @@ class BaseNotifierLib {
    *
    * @param {object} [notifier] - An instance of the {@link https://github.com/airbrake/airbrake-js|airbrake-js}
    * `Notifier`. If 'null' the class will create a new instance instead.
+   *
+   * @private
    */
   _setNotifier (notifier) {
     if (notifier) {

--- a/app/lib/dates.lib.js
+++ b/app/lib/dates.lib.js
@@ -76,6 +76,8 @@ function isISODateFormat (dateString) {
  *
  * @param {dateString} dateString - The date in the iso format 2001-01-01
  * @returns {boolean}
+ *
+ * @private
  */
 function _isValidLeapYearDate (dateString) {
   const [year, month, day] = dateString.split('-')

--- a/app/lib/request-notifier.lib.js
+++ b/app/lib/request-notifier.lib.js
@@ -53,6 +53,8 @@ class RequestNotifierLib extends BaseNotifierLib {
    * ```
    * { $.req.id = "1617655289640:533c1e381364:1671:kn526tbx:10000" }
    * ```
+   *
+   * @private
    */
   _formatLogPacket (data, error) {
     const dataWithRequestId = {
@@ -76,6 +78,8 @@ class RequestNotifierLib extends BaseNotifierLib {
    * ```
    * { $.req.id = "1617655289640:533c1e381364:1671:kn526tbx:10000" }
    * ```
+   *
+   * @private
    */
   _formatNotifyPacket (data, error, message) {
     const dataWithRequestId = {

--- a/app/plugins/views.plugin.js
+++ b/app/plugins/views.plugin.js
@@ -154,6 +154,8 @@ function prepare (config, next) {
  * is authenticated and what scopes (permissions) they have
  *
  * @returns {object[]} if the user is authenticated navigation links to display in the top-level GOV.UK header
+ *
+ * @private
  */
 function _navigationLinks (auth) {
   if (!auth.isAuthenticated) {

--- a/app/presenters/bill-runs/two-part-tariff/amend-billable-returns.presenter.js
+++ b/app/presenters/bill-runs/two-part-tariff/amend-billable-returns.presenter.js
@@ -46,6 +46,8 @@ function go (billRun, reviewChargeElement, licenceId) {
  * The user can only enter a volume on the billable returns that is less than the authorised volume. The authorised
  * volume is either the authorised volume on the charge element or the authorised volume on the charge reference.
  * Whichever is lower.
+ *
+ * @private
  */
 function _authorisedQuantity (reviewChargeElement) {
   const { chargeElement, reviewChargeReference } = reviewChargeElement

--- a/app/presenters/bill-runs/two-part-tariff/review-bill-run.presenter.js
+++ b/app/presenters/bill-runs/two-part-tariff/review-bill-run.presenter.js
@@ -47,6 +47,8 @@ function go (billRun, filterIssues, filterLicenceHolderNumber, filterLicenceStat
 /**
  * Returns true/false values for each issue in the Issue filter based on the filters applied to determine which
  * checkboxes if any should be checked upon loading the page
+ *
+ * @private
  */
 function _prepareIssues (filterIssues) {
   return {

--- a/app/presenters/charging-module/create-customer-change.presenter.js
+++ b/app/presenters/charging-module/create-customer-change.presenter.js
@@ -146,6 +146,8 @@ function _formattedAddress (address, contact) {
  * @param {number} maximumLength - The maximum length to the truncated string
  *
  * @returns {string} - The truncated string.
+ *
+ * @private
  */
 function _truncate (stringToTruncate, maximumLength) {
   // Don't truncate if the string is equal to or less than maximum length

--- a/app/requests/base.request.js
+++ b/app/requests/base.request.js
@@ -143,6 +143,8 @@ async function _importGot () {
  * @param {object} result - the result object we generate
  * @param {string} url - the requested url
  * @param {object} additionalOptions - any additional options that were passed to Got by the calling service
+ *
+ * @private
  */
 function _logFailure (method, result, url, additionalOptions) {
   const data = {
@@ -175,6 +177,8 @@ function _logFailure (method, result, url, additionalOptions) {
  * Those that use this module can add to, extend or replace the options we pass to Got when a request is made.
  *
  * @param {object} additionalOptions - Object of custom options
+ *
+ * @private
  */
 function _requestOptions (additionalOptions) {
   return { ...defaultOptions(), ...additionalOptions }

--- a/app/requests/charging-module.request.js
+++ b/app/requests/charging-module.request.js
@@ -67,6 +67,8 @@ async function post (path, body = {}) {
 
 /**
  * Sends a request to the Charging Module using the provided BaseRequest method
+ *
+ * @private
  */
 async function _sendRequest (path, method, body) {
   const authentication = await global.HapiServerMethods.getChargingModuleToken()
@@ -87,6 +89,8 @@ async function _sendRequest (path, method, body) {
  * - the body (which is always a JSON object) for our POST requests
  * - the option to tell Got that we expect JSON responses. This means Got will automatically handle parsing the
  *   response to a JSON object for us
+ *
+ * @private
  */
 function _requestOptions (accessToken, body) {
   return {
@@ -104,6 +108,8 @@ function _requestOptions (accessToken, body) {
 
 /**
  * Parses the charging module response returned from BaseRequest
+ *
+ * @private
  */
 function _parseResult (result) {
   const { body, headers, statusCode } = result.response

--- a/app/requests/charging-module/create-bill-run.request.js
+++ b/app/requests/charging-module/create-bill-run.request.js
@@ -29,6 +29,8 @@ async function send (regionId, ruleset) {
 
 /**
  * Gets the single-letter charge region code for the provided regionId UUID
+ *
+ * @private
  */
 async function _getChargeRegionId (regionId) {
   const result = await RegionModel.query()

--- a/app/requests/charging-module/wait-for-status.request.js
+++ b/app/requests/charging-module/wait-for-status.request.js
@@ -78,6 +78,8 @@ async function send (billRunId, statusesToWaitFor, maximumAttempts = 120) {
  * Pause between requests so that we are not bombarding the Charging Module
  *
  * The default is 1 second but we make this configurable mainly to allow us to override the pause in unit tests
+ *
+ * @private
  */
 function _pause () {
   return setTimeout(billingConfig.waitForStatusPauseInMs)

--- a/app/requests/legacy.request.js
+++ b/app/requests/legacy.request.js
@@ -112,6 +112,8 @@ async function post (serviceName, path, userId = null, apiRequest = true, body =
 
 /**
  * Sends a request to a legacy service using the provided BaseRequest method
+ *
+ * @private
  */
 async function _sendRequest (method, serviceName, path, userId, apiRequest, body) {
   const service = _service(serviceName)
@@ -142,6 +144,8 @@ function _service (serviceName) {
  * - the body (which is always a JSON object) for our POST requests
  * - the option to tell Got that we expect JSON responses. This means Got will automatically handle parsing the
  *   response to a JSON object for us
+ *
+ * @private
  */
 function _requestOptions (service, userId, apiRequest, body) {
   const prefixUrl = apiRequest ? new URL(service.api, service.base).href : service.base
@@ -176,6 +180,8 @@ function _requestOptions (service, userId, apiRequest, body) {
 
 /**
  * Parses the charging module response returned from BaseRequest
+ *
+ * @private
  */
 function _parseResult (result) {
   const { body, statusCode } = result.response

--- a/app/services/bill-runs/annual/fetch-billing-accounts.service.js
+++ b/app/services/bill-runs/annual/fetch-billing-accounts.service.js
@@ -138,6 +138,8 @@ async function _fetchNew (regionId, billingPeriod) {
  * @param {object} billingPeriod - Object with a `startDate` and `endDate` property representing the period being billed
  *
  * @returns {module:QueryBuilder} the builder instance passed in with the additional `where` clauses added
+ *
+ * @private
  */
 function _whereClauseForChargeVersions (query, regionId, billingPeriod) {
   return query
@@ -178,6 +180,8 @@ function _whereClauseForChargeVersions (query, regionId, billingPeriod) {
  * Bill runs are formed of 'bills' which are a 1-to-1 with billing accounts. But whether a billing account should
  * be included is _all_ based on the charge versions they are linked to. So, all the work of filtering what will be
  * considered is done here by combining a `select(1)` with our `_whereClauseForChargeVersions()` function.
+ *
+ * @private
  */
 function _whereExistsClause (regionId, billingPeriod) {
   let query = ChargeVersionModel.query().select(1)

--- a/app/services/bill-runs/annual/process-billing-period.service.js
+++ b/app/services/bill-runs/annual/process-billing-period.service.js
@@ -88,6 +88,8 @@ async function go (billRun, billingPeriod, billingAccounts) {
  * The complication is we group transactions by licence (via the bill licence) not charge version. So, as we iterate
  * the charge versions we have to determine if its for a licence that we have already generated a bill licence for, or
  * we have to create a new one.
+ *
+ * @private
  */
 async function _createBillLicencesAndTransactions (billId, billingAccount, billRunExternalId, billingPeriod) {
   const allBillLicences = []
@@ -117,6 +119,8 @@ async function _createBillLicencesAndTransactions (billId, billingAccount, billR
 
 /**
  * Handles generating the transaction data for a given charge version and then sending it to the Charging Module API.
+ *
+ * @private
  */
 async function _createTransactions (billLicenceId, billingPeriod, chargeVersion, billRunExternalId, accountNumber) {
   const chargePeriod = DetermineChargePeriodService.go(chargeVersion, billingPeriod)
@@ -137,6 +141,8 @@ async function _createTransactions (billLicenceId, billingPeriod, chargeVersion,
  * A billing account can be linked to multiple licences but not all of them may be billable. We add a flag to each
  * one that demotes if transactions were generated. So we can easily filter the billable ones out. But we also need
  * to remove that flag because it doesn't exist in the DB and will cause issues if we try and persist the object.
+ *
+ * @private
  */
 function _extractBillableLicences (allBillLicences) {
   const billableBillLicences = []
@@ -175,6 +181,8 @@ function _extractBillableLicences (allBillLicences) {
  *
  * @return {object} returns either an existing bill licence we previously created or a new one for the licence and bill
  * being generated
+ *
+ * @private
  */
 function _findOrCreateBillLicence (billLicences, licence, billId) {
   const { id: licenceId, licenceRef } = licence
@@ -210,6 +218,8 @@ function _findOrCreateBillLicence (billLicences, licence, billId) {
  *
  * This function iterates the charge references and combines the transactions generated into a 'flat' array of all
  * the transactions for the charge version and returns it.
+ *
+ * @private
  */
 function _generateTransactionData (billLicenceId, billingPeriod, chargePeriod, chargeVersion) {
   try {
@@ -242,6 +252,8 @@ function _generateTransactionData (billLicenceId, billingPeriod, chargePeriod, c
  * our bill.
  *
  * Once everything has been generated we persist the results to the DB.
+ *
+ * @private
  */
 async function _processBillingAccount (billingAccount, billRun, billingPeriod) {
   const { id: billingAccountId, accountNumber } = billingAccount

--- a/app/services/bill-runs/calculate-authorised-and-billable-days.service.js
+++ b/app/services/bill-runs/calculate-authorised-and-billable-days.service.js
@@ -99,6 +99,8 @@ function go (chargePeriod, billingPeriod, chargeReference) {
  * overlaps the reference period
  *
  * @returns {number} the length of the period in days (inclusive)
+ *
+ * @private
  */
 function _calculateDays (abstractionOverlapPeriod) {
   const difference = abstractionOverlapPeriod.endDate.getTime() - abstractionOverlapPeriod.startDate.getTime()
@@ -130,6 +132,8 @@ function _calculateDays (abstractionOverlapPeriod) {
  *
  * @returns {object} an object with a start and end date representing the part of the abstraction period that overlaps
  *  the reference period
+ *
+ * @private
  */
 function _calculateAbstractionOverlapPeriod (referencePeriod, abstractionPeriod) {
   const latestStartDateTimestamp = Math.max(abstractionPeriod.startDate, referencePeriod.startDate)

--- a/app/services/bill-runs/consolidate-date-ranges.service.js
+++ b/app/services/bill-runs/consolidate-date-ranges.service.js
@@ -79,6 +79,8 @@ function _sortDates (dateRanges) {
  * or not they overlap.
  *
  * Based on https://stackoverflow.com/a/67717721
+ *
+ * @private
  */
 function _consolidateDates (dateRanges) {
   // We use reduce to build up an array of consolidated date ranges as we iterate over our initial dateRanges array.

--- a/app/services/bill-runs/determine-billing-periods.service.js
+++ b/app/services/bill-runs/determine-billing-periods.service.js
@@ -78,6 +78,8 @@ function _billingPeriods (billRunType, financialYear) {
  * TODO: Whilst we still have `POST /bill-runs` to support bill runs created using the legacy setup bill run journey we
  * can receive requests where financialYearEnding has not been set. This exists to handle that scenario and can be
  * deleted when we are confident we can delete that end point.
+ *
+ * @private
  */
 function _financialYear (financialYearEnding) {
   if (financialYearEnding) {

--- a/app/services/bill-runs/fetch-bill-run.service.js
+++ b/app/services/bill-runs/fetch-bill-run.service.js
@@ -88,6 +88,8 @@ async function _fetchBillRun (id) {
  * We could have made things simpler by performing separate queries and then transforming all the results into what we
  * need this service to return. But we opted to go for performance this time, avoiding multiple requests to the DB and
  * getting the query to provide the data we need without having to transform the result.
+ *
+ * @private
  */
 async function _fetchBillSummaries (id) {
   const results = await db

--- a/app/services/bill-runs/generate-transactions.service.js
+++ b/app/services/bill-runs/generate-transactions.service.js
@@ -70,6 +70,8 @@ function go (billLicenceId, chargeReference, billingPeriod, chargePeriod, newLic
 /**
  * Generates a compensation transaction by taking a standard transaction and overwriting it with the supplied billing id
  * and the correct charge type and description for a compensation charge.
+ *
+ * @private
  */
 function _compensationTransaction (standardTransaction) {
   return {
@@ -91,6 +93,8 @@ function _description (chargeReference) {
 
 /**
  * Returns a json representation of all charge elements in a charge reference
+ *
+ * @private
  */
 function _generateElements (chargeReference) {
   const jsonChargeElements = chargeReference.chargeElements.map((chargeElement) => {
@@ -102,6 +106,8 @@ function _generateElements (chargeReference) {
 
 /**
  * Generates a standard transaction based on the supplied data, along with some default fields (eg. status)
+ *
+ * @private
  */
 function _standardTransaction (
   billLicenceId,

--- a/app/services/bill-runs/submit-cancel-bill-run.service.js
+++ b/app/services/bill-runs/submit-cancel-bill-run.service.js
@@ -105,6 +105,8 @@ function _cannotBeDeleted (status) {
  *
  * But we need to ensure no one exploits the `POST /bill-runs/{id}/cancel` endpoint to try and delete a 'sent' bill
  * run. So, we always have to fetch the bill run to check its status is not one that prevents us deleting it.
+ *
+ * @private
  */
 async function _fetchBillRun (id) {
   return BillRunModel.query()
@@ -128,6 +130,8 @@ async function _fetchBillRun (id) {
  * Transactions have to be deleted before bill licences. Bill licences have to be cleared before bills. Bills, batch
  * charge version years, and bill run volumes have to be cleared before we can delete the bill run. But we can do
  * those in parallel.
+ *
+ * @private
  */
 async function _removeBillingRecords (billRunId) {
   try {
@@ -167,6 +171,8 @@ async function _removeBillRunChargeVersionYears (billRunId) {
 /**
  * We've opted to do this particular query using knex raw rather than via the Objection models due to the need for
  * multiple joins.
+ *
+ * @private
  */
 async function _removeBillRunTransactions (billRunId) {
   return db.raw(`
@@ -199,6 +205,8 @@ async function _removeChargeElements (billRunId) {
  * As the `review_charge_elements` table has a join with the `review_charge_references` table we need to delete the
  * `review_charge_elements` table first. This function does that so we can process in parallel the deletion of the
  * elements and references whilst also deleting the records from the `review_charge_elements_returns` table.
+ *
+ * @private
  */
 async function _removeChargeElementsAndReferences (billRunId) {
   await _removeChargeElements(billRunId)
@@ -240,6 +248,8 @@ async function _removeReturns (billRunId) {
 /**
  * We always call this function as part of cancelling a bill run. However, there will only be records if the bill run
  * is an SROC tw-part tariff bill run in 'review'.
+ *
+ * @private
  */
 async function _removeReviewResults (billRunId) {
   try {

--- a/app/services/bill-runs/submit-send-bill-run.service.js
+++ b/app/services/bill-runs/submit-send-bill-run.service.js
@@ -57,6 +57,8 @@ async function go (billRunId) {
  *
  * But we need to ensure no one exploits the `POST /bill-runs/{id}/send` endpoint. So, we always have to fetch the bill
  * run to check its status is not one that prevents us deleting it.
+ *
+ * @private
  */
 async function _fetchBillRun (id) {
   return BillRunModel.query()

--- a/app/services/bill-runs/supplementary/fetch-charge-versions.service.js
+++ b/app/services/bill-runs/supplementary/fetch-charge-versions.service.js
@@ -128,6 +128,8 @@ async function _fetch (regionId, billingPeriod) {
  * When a licence is made "non-chargeable" the supplementary billing flag gets set and a charge version created that
  * has no `invoice_account_id`. For the purpose of billing we are not interested in non-chargeable charge versions.
  * We are interested in the associated licences to ensure that their supplementary billing flag is unset.
+ *
+ * @private
  */
 function _extractLicenceIdsThenRemoveNonChargeableChargeVersions (allChargeVersions) {
   const chargeVersions = []

--- a/app/services/bill-runs/supplementary/fetch-previous-transactions.service.js
+++ b/app/services/bill-runs/supplementary/fetch-previous-transactions.service.js
@@ -30,6 +30,8 @@ async function go (billingAccountId, licenceId, financialYearEnding) {
  *
  * If a credit matches to a debit then its something that was dealt with in a previous supplementary bill run. We need
  * to know only about debits that have not been credited.
+ *
+ * @private
  */
 function _cleanse (transactions) {
   const credits = transactions.filter((transaction) => {

--- a/app/services/bill-runs/supplementary/pre-generate-billing-data.service.js
+++ b/app/services/bill-runs/supplementary/pre-generate-billing-data.service.js
@@ -51,16 +51,20 @@ function _generateBillLicence (billId, licenceId, licenceRef) {
 }
 
 /**
-  * We pre-generate bill licences for every combination of bill and licence in the charge versions so that we don't
-  * need to fetch any data from the db during the main charge version processing loop. This function generates the
-  * required bill licences and returns an object where each key is a concatenated bill id and licence id, and each value
-  * is the bill licence for that combination of bill and licence, ie:
-  *
-  * {
-  *   'key-1': { billLicenceId: 'bill-licence-1', ... },
-  *   'key-2': { billLicenceId: 'bill-licence-2', ... }
-  * }
-  */
+ * We pre-generate bill licences for every combination of bill and licence in the charge versions so that we don't
+ * need to fetch any data from the db during the main charge version processing loop. This function generates the
+ * required bill licences and returns an object where each key is a concatenated bill id and licence id, and each value
+ * is the bill licence for that combination of bill and licence, ie:
+ *
+ * ```javascript
+ * {
+ *   'key-1': { billLicenceId: 'bill-licence-1', ... },
+ *   'key-2': { billLicenceId: 'bill-licence-2', ... }
+ * }
+ * ```
+ *
+ * @private
+ */
 function _preGenerateBillLicences (chargeVersions, bills) {
   const keyedBillLicences = chargeVersions.reduce((acc, chargeVersion) => {
     const { id: billId } = bills[chargeVersion.billingAccountId]
@@ -88,15 +92,19 @@ function _billLicenceKey (billId, licenceId) {
 }
 
 /**
-  * We pre-generate bills for every billing account so that we don't need to fetch any data from the db during the main
-  * charge version processing loop. This function generates the required bill licences and returns an object where
-  * each key is the billing account id, and each value is the bill, ie:
-  *
-  * {
-  *   'uuid-1': { id: 'uuid-1', ... },
-  *   'uuid-2': { id: 'uuid-2', ... }
-  * }
-  */
+ * We pre-generate bills for every billing account so that we don't need to fetch any data from the db during the main
+ * charge version processing loop. This function generates the required bill licences and returns an object where
+ * each key is the billing account id, and each value is the bill, ie:
+ *
+ * ```javascript
+ * {
+ *   'uuid-1': { id: 'uuid-1', ... },
+ *   'uuid-2': { id: 'uuid-2', ... }
+ * }
+ * ```
+ *
+ * @private
+ */
 function _preGenerateBills (billingAccounts, billRunId, billingPeriod) {
   const keyedBills = billingAccounts.reduce((acc, billingAccount) => {
     const { id: billingAccountId, accountNumber } = billingAccount

--- a/app/services/bill-runs/supplementary/process-bill-run.service.js
+++ b/app/services/bill-runs/supplementary/process-bill-run.service.js
@@ -73,6 +73,8 @@ async function _fetchChargeVersions (billRun, billingPeriod) {
  * Finalises the bill run by unflagging all unbilled licences, requesting the Charging Module run its generate
  * process, and refreshes the bill run locally. However if there were no resulting bill licences then we simply
  * unflag the unbilled licences and mark the bill run with `empty` status
+ *
+ * @private
  */
 async function _finaliseBillRun (billRun, accumulatedLicenceIds, resultsOfProcessing) {
   // Creating a new set from accumulatedLicenceIds gives us just the unique ids. Objection does not accept sets in

--- a/app/services/bill-runs/supplementary/process-billing-period.service.js
+++ b/app/services/bill-runs/supplementary/process-billing-period.service.js
@@ -48,6 +48,8 @@ async function go (billRun, billingPeriod, chargeVersions) {
 /**
  * Iterates over the populated billing data and builds an object of data to be persisted. This process includes sending
  * "create transaction" requests to the Charging Module as this data is needed to fully create our transaction records
+ *
+ * @private
  */
 async function _buildDataToPersist (billingData, billingPeriod, billRunExternalId) {
   const dataToPersist = {
@@ -87,6 +89,7 @@ async function _buildDataToPersist (billingData, billingPeriod, billRunExternalI
  * more charge versions and the key's value is an object containing the associated licence, bill and bill
  * licence, along with any required transactions, eg:
  *
+ * ```javascript
  * {
  *   'bill-licence-id-1': {
  *     billLicence: '...',     // instance of the bill licence
@@ -98,6 +101,9 @@ async function _buildDataToPersist (billingData, billingPeriod, billRunExternalI
  *     // Same object structure as above
  *   }
  * }
+ * ```
+ *
+ * @private
  */
 function _buildBillingDataWithTransactions (chargeVersions, preGeneratedData, billingPeriod) {
   // We use reduce to build up the object as this allows us to start with an empty object and populate it with each
@@ -129,6 +135,8 @@ function _buildBillingDataWithTransactions (chargeVersions, preGeneratedData, bi
 
 /**
  * Persists the transaction, bill and bill licence records in the db
+ *
+ * @private
  */
 async function _persistData (dataToPersist) {
   // If we don't have any transactions to persist then we also won't have any bills or bill licences, so we

--- a/app/services/bill-runs/supplementary/process-transactions.service.js
+++ b/app/services/bill-runs/supplementary/process-transactions.service.js
@@ -47,6 +47,8 @@ async function go (calculatedTransactions, billingAccountId, billLicence, billin
  * NOTE: This function will mutate the provided array of reversed transactions if one of the transactions in it will
  * cancel the calculated transaction; in this case, we remove the reversed transaction from the array as it can only
  * cancel one calculated transaction.
+ *
+ * @private
  */
 function _cancelCalculatedTransaction (calculatedTransaction, reversedTransactions) {
   const result = reversedTransactions.findIndex((reversedTransaction) => {
@@ -67,6 +69,8 @@ function _cancelCalculatedTransaction (calculatedTransaction, reversedTransactio
  * to the same bill licence which would send the same data to the Charging Module (and therefore return the same values)
  * but with opposing credit flags -- in other words, a credit and a debit which cancel each other out. All remaining
  * transactions (both calculated transactions and reverse transactions) are returned.
+ *
+ * @private
  */
 function _cleanseTransactions (calculatedTransactions, reverseTransactions) {
   const cleansedTransactionLines = []

--- a/app/services/bill-runs/supplementary/reverse-transactions.service.js
+++ b/app/services/bill-runs/supplementary/reverse-transactions.service.js
@@ -27,6 +27,8 @@ function go (transactions, billLicenceId) {
  * Receives an array of debit transactions and returns transactions that will reverse them. These transactions are
  * identical except the `credit` flag is set to 'true', the status is set to `candidate`, the `billLicenceId` is for the
  * bill licence we are creating, and a new transaction ID is generated.
+ *
+ * @private
  */
 function _reverseTransactions (transactions, billLicenceId) {
   return transactions.map((transaction) => {

--- a/app/services/bill-runs/supplementary/unflag-billed-licences.service.js
+++ b/app/services/bill-runs/supplementary/unflag-billed-licences.service.js
@@ -48,6 +48,8 @@ async function go (billRun) {
 
 /**
  * PRESROC
+ *
+ * @private
  */
 async function _updateOldScheme (billRun) {
   const { createdAt, regionId } = billRun
@@ -65,6 +67,8 @@ async function _updateOldScheme (billRun) {
 
 /**
  * SROC
+ *
+ * @private
  */
 async function _updateCurrentScheme (billRun) {
   const { id: billRunId, createdAt } = billRun

--- a/app/services/bill-runs/two-part-tariff/allocate-returns-to-charge-element.service.js
+++ b/app/services/bill-runs/two-part-tariff/allocate-returns-to-charge-element.service.js
@@ -154,6 +154,8 @@ function _matchLines (chargeElement, returnSubmissionLines) {
 
 /**
  * Checks a return record for potential issues based on specific criteria and flags it accordingly
+ *
+ * @private
  */
 function _checkReturnForIssues (matchedReturn) {
   if (matchedReturn.nilReturn) {

--- a/app/services/bill-runs/two-part-tariff/determine-licence-issues.service.js
+++ b/app/services/bill-runs/two-part-tariff/determine-licence-issues.service.js
@@ -168,6 +168,8 @@ function _getMatchingReturns (returnLogs, licenceReturnLogs) {
  * Returns a list of issues that would put a licence into a status of 'review'
  *
  * @returns {object[]} An array of issues that would put a licence into a status of 'review'
+ *
+ * @private
  */
 function _getReviewStatuses () {
   // the keys for the issues that will put the licence into review status
@@ -245,6 +247,8 @@ function _returnLogIssues (returnLog, licence) {
  * - If no matching returns have a status of 'due', `noReturnsReceived` and 'someReturnsNotReceived is `false`.
  * - If some of the matching returns, but not all, have a status of 'due', `someReturnsNotReceived` is `true`.
  * - If all matching returns have a status of 'due', `noReturnsReceived` is `true`.
+ *
+ * @private
  */
 function _returnsReceivedStatus (returnLogs, licenceReturnLogs) {
   const matchingReturnLogs = _getMatchingReturns(returnLogs, licenceReturnLogs)

--- a/app/services/bill-runs/two-part-tariff/generate-bill-run.service.js
+++ b/app/services/bill-runs/two-part-tariff/generate-bill-run.service.js
@@ -64,6 +64,8 @@ async function go (billRunId) {
  *
  * This means we've already determined the billing period and recorded it against the bill run. So, we retrieve it from
  * the bill run rather than pass it into the service.
+ *
+ * @private
  */
 function _billingPeriod (billRun) {
   const { toFinancialYearEnding } = billRun
@@ -123,6 +125,8 @@ async function _finaliseBillRun (billRun, billRunPopulated) {
  * The go() has to deal with updating the status of the bill run and then passing a response back to the request to
  * avoid the user seeing a timeout in their browser. So, this is where we actually generate the bills and record the
  * time taken.
+ *
+ * @private
  */
 async function _generateBillRun (billRun) {
   const { id: billRunId } = billRun

--- a/app/services/bill-runs/two-part-tariff/generate-transaction.service.js
+++ b/app/services/bill-runs/two-part-tariff/generate-transaction.service.js
@@ -68,6 +68,8 @@ function _description (chargeReference) {
 
 /**
  * Returns a json representation of all charge elements in a charge reference
+ *
+ * @private
  */
 function _generateElements (chargeReference) {
   const jsonChargeElements = chargeReference.chargeElements.map((chargeElement) => {
@@ -81,6 +83,8 @@ function _generateElements (chargeReference) {
 
 /**
  * Generates a standard transaction based on the supplied data, along with some default fields (eg. status)
+ *
+ * @private
  */
 function _standardTransaction (
   billLicenceId,

--- a/app/services/bill-runs/two-part-tariff/match-returns-to-charge-element.service.js
+++ b/app/services/bill-runs/two-part-tariff/match-returns-to-charge-element.service.js
@@ -42,6 +42,8 @@ function _addMatchingReturnsToElement (matchingReturns, chargeElement) {
 
 /**
  * Filters and returns logs that match a given charge element based on legacy ID and abstraction periods
+ *
+ * @private
  */
 function _matchReturns (chargeElement, returnLogs) {
   const elementCode = chargeElement.purpose.legacyId

--- a/app/services/bill-runs/two-part-tariff/process-billing-period.service.js
+++ b/app/services/bill-runs/two-part-tariff/process-billing-period.service.js
@@ -88,6 +88,8 @@ async function go (billRun, billingPeriod, billingAccounts) {
  * The complication is we group transactions by licence (via the bill licence) not charge version. So, as we iterate
  * the charge versions we have to determine if its for a licence that we have already generated a bill licence for, or
  * we have to create a new one.
+ *
+ * @private
  */
 async function _createBillLicencesAndTransactions (billId, billingAccount, billRunExternalId, billingPeriod) {
   const allBillLicences = []
@@ -117,6 +119,8 @@ async function _createBillLicencesAndTransactions (billId, billingAccount, billR
 
 /**
  * Handles generating the transaction data for a given charge version and then sending it to the Charging Module API.
+ *
+ * @private
  */
 async function _createTransactions (billLicenceId, billingPeriod, chargeVersion, billRunExternalId, accountNumber) {
   const chargePeriod = DetermineChargePeriodService.go(chargeVersion, billingPeriod)
@@ -141,6 +145,8 @@ async function _createTransactions (billLicenceId, billingPeriod, chargeVersion,
  * A billing account can be linked to multiple licences but not all of them may be billable. We add a flag to each
  * one that denotes if transactions were generated so we can easily filter the billable ones out. But we also need
  * to remove that flag because it doesn't exist in the DB and will cause issues if we try and persist the object.
+ *
+ * @private
  */
 function _extractBillableLicences (allBillLicences) {
   const billableBillLicences = []
@@ -178,6 +184,8 @@ function _extractBillableLicences (allBillLicences) {
  * @param {string} billId - the ID of the bill we're creating
  *
  * @return {object} returns either an existing bill licence or a new one for the licence and bill being generated
+ *
+ * @private
  */
 function _findOrCreateBillLicence (billLicences, licence, billId) {
   const { id: licenceId, licenceRef } = licence
@@ -209,6 +217,8 @@ function _findOrCreateBillLicence (billLicences, licence, billId) {
  * This information needs to be passed to the Charging Module API as it affects the calculation.
  *
  * This function iterates the charge references generating a transaction for each one.
+ *
+ * @private
  */
 function _generateTransactionData (billLicenceId, chargePeriod, chargeVersion) {
   try {
@@ -244,6 +254,8 @@ function _generateTransactionData (billLicenceId, chargePeriod, chargeVersion) {
  * our bill.
  *
  * Once everything has been generated we persist the results to the DB.
+ *
+ * @private
  */
 async function _processBillingAccount (billingAccount, billRun, billingPeriod) {
   const { id: billingAccountId, accountNumber } = billingAccount

--- a/app/services/billing-accounts/change-address.service.js
+++ b/app/services/billing-accounts/change-address.service.js
@@ -175,6 +175,8 @@ async function _patchExistingBillingAccountAddressEndDate (trx, billingAccountId
  *
  * We can get the same result with a single query by using `onConflict()`. If we get a match we just overwrite the
  * existing record with our new data.
+ *
+ * @private
  */
 async function _persistBillingAccountAddress (trx, billingAccountAddress) {
   return billingAccountAddress.$query(trx)
@@ -211,6 +213,8 @@ async function _persistBillingAccountAddress (trx, billingAccountAddress) {
  * > about duplication. This then avoids the problem. But until we can amend the DB design it is better that where a
  * > record in our DB is locked to OS Places, it should reflect whatever OS Places currently returns, not what it
  * > returned when first added.
+ *
+ * @private
  */
 async function _persistAddress (trx, address) {
   if (address.id) {
@@ -260,6 +264,8 @@ async function _persistAddress (trx, address) {
  * > about duplication. This then avoids the problem. But until we can amend the DB design it is better that where a
  * > record in our DB is locked to Companies House, it should reflect whatever Companies House currently returns, not
  * > what it returned when first added.
+ *
+ * @private
  */
 async function _persistCompany (trx, company) {
   if (company.id || !company.name) {
@@ -284,6 +290,8 @@ async function _persistCompany (trx, company) {
  *
  * If the contact type is not set then the user has opted not to apply an FAO in the journey. So, we just return the
  * empty `ContactModel` instance.
+ *
+ * @private
  */
 async function _persistContact (trx, contact) {
   if (!contact.contactType) {
@@ -311,6 +319,8 @@ async function _persistContact (trx, contact) {
  *
  * Finally, where we do have populated instances we destructure them. This transforms the model instances into POJO's
  * again just making things cleaner.
+ *
+ * @private
  */
 function _response (persistedData) {
   const { address, company, contact, billingAccountAddress } = persistedData

--- a/app/services/bills/fetch-bill-service.js
+++ b/app/services/bills/fetch-bill-service.js
@@ -80,6 +80,8 @@ async function _fetchBill (id) {
  * To get the query to return a single line for each licence we need to use DISTINCT. So, due to the complexity of the
  * query needed we've had to drop back down to Knex and generate the query ourselves rather than going through
  * Objection.js.
+ *
+ * @private
  */
 async function _fetchLicenceSummaries (id) {
   return db

--- a/app/services/data/load/load.service.js
+++ b/app/services/data/load/load.service.js
@@ -272,6 +272,8 @@ async function go (payload) {
  * `instance.regimeEntityId` we'll confirm it is an object with a `schema:` property. We then replace the value of
  * `instance.regimeEntityId` with the result of a query based on the details provided. In this case `SELECT entity_id
  * FROM crm.entity WHERE entity_type = 'regime'`.
+ *
+ * @private
  */
 async function _applyLookups (instance) {
   const keys = Object.keys(instance)
@@ -300,6 +302,8 @@ async function _applyLookups (instance) {
  * So, this is a 'fudge' to avoid having to go back and re-create loads of views just to include the flag. The constant
  * `LOAD_HELPERS` identifies those entities that have a `is_test` field. When we load one that does we trigger this
  * function to update the flag on the source table. Then when `/data/tear-down` runs it will know to clear it.
+ *
+ * @private
  */
 async function _applyTestFlag (legacy, id) {
   const { schema, table, id: tableId } = legacy

--- a/app/services/health/fetch-import-jobs.service.js
+++ b/app/services/health/fetch-import-jobs.service.js
@@ -74,9 +74,11 @@ async function go () {
 /**
  * Calculates the current date minus the number of days passed to it
  *
- * @param {number} days - The number of days to be deducted from the currect date
+ * @param {number} days - The number of days to be deducted from the current date
  *
  * @returns {Date} The current date minus the number days passed to the function
+ *
+ * @private
  */
 function _subtractDaysFromCurrentDate (days) {
   const date = new Date()

--- a/app/services/idm/fetch-user-roles-and-groups.service.js
+++ b/app/services/idm/fetch-user-roles-and-groups.service.js
@@ -53,6 +53,8 @@ async function go (userId) {
  * The user object we get back from the query has the roles and groups attached to it. The service returns the user,
  * roles and groups separately so we remove the roles and groups from the user object so we aren't returning the same
  * data twice.
+ *
+ * @private
  */
 function _extractRolesAndGroupsFromUser (user) {
   const { roles, groups } = user
@@ -68,6 +70,8 @@ function _extractRolesAndGroupsFromUser (user) {
  * We want to extract the roles and remove them from the groups in order to keep the Group objects clean and avoid
  * duplication in the object returned by the service. This function returns a flat array of all the group Roles objects,
  * deleting them from the Group objects in the process
+ *
+ * @private
  */
 function _extractRolesFromGroups (groups) {
   return groups.flatMap((group) => {

--- a/app/services/import/legacy-import/fetch-licence-versions.service.js
+++ b/app/services/import/legacy-import/fetch-licence-versions.service.js
@@ -22,7 +22,7 @@ async function _getLicenceVersions (licenceId, regionCode) {
 
   const { rows } = await db.raw(query)
 
-  return select(rows)
+  return _select(rows)
 }
 
 /**
@@ -30,8 +30,10 @@ async function _getLicenceVersions (licenceId, regionCode) {
  *
  * @param {{}} rows - the licence version columns
  * @returns {LegacyLicenceVersionsArray}
+ *
+ * @private
  */
-function select (rows) {
+function _select (rows) {
   return rows.map((row) => {
     return {
       EFF_ST_DATE: row.EFF_ST_DATE

--- a/app/services/import/legacy-import/fetch-licence.service.js
+++ b/app/services/import/legacy-import/fetch-licence.service.js
@@ -26,7 +26,7 @@ async function _getLicenceByRef (licenceRef) {
 
   const { rows: [row] } = await db.raw(query)
 
-  return select(row)
+  return _select(row)
 }
 
 /**
@@ -34,8 +34,10 @@ async function _getLicenceByRef (licenceRef) {
  *
  * @param {any} licence
  * @returns {LegacyLicenceType}
+ *
+ * @private
  */
-function select (licence) {
+function _select (licence) {
   return {
     AREP_AREA_CODE: licence.AREP_AREA_CODE,
     AREP_EIUC_CODE: licence.AREP_EIUC_CODE,

--- a/app/services/import/legacy-import/licence.mapper.js
+++ b/app/services/import/legacy-import/licence.mapper.js
@@ -37,6 +37,8 @@ function _mapLicence (licence, licenceVersions) {
  *
  * @param {object} licenceData
  * @return {RegionsType}
+ *
+ * @private
  */
 const _regions = (licenceData) => {
   const historicalAreaCode = licenceData.AREP_AREA_CODE
@@ -59,6 +61,8 @@ const _regions = (licenceData) => {
  * @param {LegacyLicenceType} licence
  * @param {LegacyLicenceVersionsArray} licenceVersions
  * @return {string} YYYY-MM-DD
+ *
+ * @private
  */
 const _startDate = (licence, licenceVersions) => {
   if (licence.ORIG_EFF_DATE !== 'null') {

--- a/app/services/import/licence-validator.service.js
+++ b/app/services/import/licence-validator.service.js
@@ -37,7 +37,7 @@ module.exports = {
  */
 
 /**
- * A valid licence 'regions' json colum
+ * A valid licence 'regions' json column
  * @typedef {object} RegionsType
  *
  * @property {string} regionalChargeArea

--- a/app/services/jobs/export/convert-to-csv.service.js
+++ b/app/services/jobs/export/convert-to-csv.service.js
@@ -22,6 +22,8 @@ function go (data) {
 
 /**
  * Transforms each row or header to CSV format and joins the values with commas
+ *
+ * @private
  */
 function _transformDataToCSV (data) {
   const transformedRow = data.map((value) => {
@@ -33,6 +35,8 @@ function _transformDataToCSV (data) {
 
 /**
  * Transform a value to CSV format
+ *
+ * @private
  */
 function _transformValueToCSV (value) {
   // Return empty string for undefined or null values

--- a/app/services/jobs/export/schema-export.service.js
+++ b/app/services/jobs/export/schema-export.service.js
@@ -48,6 +48,8 @@ async function go (schemaName) {
  * @param {string} schemaName - The name of the database schema
  *
  * @returns {string} The folder path where the schema will be temporarily stored
+ *
+ * @private
  */
 function _folderToUpload (schemaName) {
   const temporaryFilePath = os.tmpdir()

--- a/app/services/jobs/export/send-to-s3-bucket.service.js
+++ b/app/services/jobs/export/send-to-s3-bucket.service.js
@@ -37,6 +37,8 @@ async function go (filePath) {
  *
  * If the environment has a proxy then we set that here. The default timeout is 6 minutes but we believe that is far too
  * long to wait. So, we set 'connectionTimeout' to be 10 seconds.
+ *
+ * @private
  */
 function _customConfig () {
   return {

--- a/app/services/jobs/export/write-table-to-file.service.js
+++ b/app/services/jobs/export/write-table-to-file.service.js
@@ -39,6 +39,8 @@ async function go (headers, rows, schemaFolderPath, tableName) {
  * Creates and returns a Transform stream that converts incoming objects to CSV rows
  *
  * @returns {Transform} A transform stream with objectMode set to true
+ *
+ * @private
  */
 function _transformDataStream () {
   return new Transform({
@@ -59,6 +61,8 @@ function _transformDataStream () {
  * @param {string} schemaFolderPath - The folder path of the schema
  *
  * @returns {Promise<string>} The full file path
+ *
+ * @private
  */
 async function _filenameWithPath (tableName, schemaFolderPath) {
   await fsPromises.mkdir(schemaFolderPath, { recursive: true })

--- a/app/services/licences/supplementary/determine-billing-years.service.js
+++ b/app/services/licences/supplementary/determine-billing-years.service.js
@@ -45,6 +45,8 @@ function go (startDate, endDate) {
  * impacted by the change. We only care about the financial year ends. So if the startDate for a new chargeVersion is
  * `2022-05-31`, the financial year end is considered to be `2023` since the financial years run April to March. Same
  * goes for if a charge versions endDate is `2023-03-05`, the financial year end is `2023`.
+ *
+ * @private
  */
 function _adjustedFinancialYearEnd (date) {
   let year = date.getFullYear()

--- a/app/services/licences/supplementary/determine-existing-bill-run-years.service.js
+++ b/app/services/licences/supplementary/determine-existing-bill-run-years.service.js
@@ -32,6 +32,8 @@ async function go (regionId, years, twoPartTariff) {
  * We need to verify which years annual two-part tariff bill runs have been sent. A year shouldn't be flagged for a
  * supplementary bill run if the annual bill run hasn't been sent yet, as any licence changes will be handled in the
  * annual run.
+ *
+ * @private
  */
 async function _supplementaryBillingYears (regionId, years, twoPartTariff) {
   const batchType = twoPartTariff ? 'two_part_tariff' : 'annual'

--- a/app/services/plugins/auth.service.js
+++ b/app/services/plugins/auth.service.js
@@ -64,6 +64,8 @@ async function go (userId) {
  *
  * @returns {object} Each top level permissions is a key. The value is true or false as to whether the user has
  * permission to access that area of the service
+ *
+ * @private
  */
 function _permission (scope = []) {
   const billRuns = scope.includes('billing')

--- a/app/services/plugins/error-pages.service.js
+++ b/app/services/plugins/error-pages.service.js
@@ -44,6 +44,8 @@ function go (request) {
  * If the request object reflects a 2xx or 3xx response then the status code will be a property of the request. But if
  * it's because an error is thrown, `request` is actually a Boom error instance which means the status code is
  * somewhere else. So, we need this bit of logic to figure out what status code we're dealing with!
+ *
+ * @private
  */
 function _extractStatusCode (request) {
   const { response } = request
@@ -83,6 +85,8 @@ function _logError (statusCode, request) {
  * @param {object} request - The instance of {@link https://hapi.dev/api/?v=21.3.2#request | Hapi request}
  *
  * @returns {boolean} true if the response should be stopped and redirected to an error page else false
+ *
+ * @private
  */
 function _stopResponse (request) {
   // `isBoom` is only present when dealing with requests that have resulted in an error being thrown.
@@ -105,6 +109,8 @@ function _stopResponse (request) {
  * This will only be called when _stopResponse() has determined we need to redirect to an error page. In this case
  * we need to ensure the code we return is secure and will not get the response blocked by the WAF we have in our AWS
  * environments.
+ *
+ * @private
  */
 function _determineSafeStatusCode (statusCode) {
   // The status code will be a 2xx or 3xx so safe to return as is

--- a/app/services/plugins/payload-cleaning.service.js
+++ b/app/services/plugins/payload-cleaning.service.js
@@ -95,6 +95,8 @@ function go (payload) {
  * @param {object} obj - The object you wish to loop through and clean
  *
  * @returns {object} The cleaned object
+ *
+ * @private
  */
 function _cleanObject (obj) {
   if (obj === null) {
@@ -139,6 +141,8 @@ function _cleanObject (obj) {
  *
  * @param {Array} array - The object you wish to loop through and clean
  * @returns {Array} The cleaned array
+ *
+ * @private
  */
 function _cleanArray (array) {
   const cleanedArray = []
@@ -171,6 +175,8 @@ function _cleanArray (array) {
  * @param value - Value we are making the decision for
  *
  * @returns `true` if the `Object`, `Array` or `String` is not 'empty'. Else `false`
+ *
+ * @private
  */
 function _keepValue (value) {
   if (value === null) {
@@ -199,6 +205,8 @@ function _keepValue (value) {
  * @param value - Value to be cleaned
  *
  * @returns The 'cleaned' value if a `String` else the original value
+ *
+ * @private
  */
 function _cleanValue (value) {
   if (typeof value === 'string') {

--- a/app/services/return-requirements/process-existing-return-versions.service.js
+++ b/app/services/return-requirements/process-existing-return-versions.service.js
@@ -71,6 +71,8 @@ async function go (licenceId, newVersionStartDate) {
  *
  * This function finds return version **3** and updates its end date to the start date of the new return version minus
  * 1 day. We don't care about the end date because the new return version doesn't need one.
+ *
+ * @private
  */
 async function _endLatestVersion (previousVersions, newVersionStartDate, endDate) {
   const matchedReturnVersion = previousVersions.find((previousVersion) => {
@@ -108,6 +110,8 @@ async function _endLatestVersion (previousVersions, newVersionStartDate, endDate
  * This function finds return version **2** and updates its end date to the start date of the new return version minus
  * 1 day. We also return the end date from version **2** as this needs to be applied to the new return version. Hence,
  * we are _inserting between versions_.
+ *
+ * @private
  */
 async function _insertBetweenVersions (previousVersions, newVersionStartDate, endDate) {
   const matchedReturnVersion = previousVersions.find((previousVersion) => {
@@ -166,6 +170,8 @@ function _previousVersions (licenceId) {
  *
  * This function finds return version **3** and updates its status to `superseded`. We don't care about the end date
  * because the new return version doesn't need one.
+ *
+ * @private
  */
 async function _replaceLatestVersion (previousVersions, newVersionStartDate) {
   const matchedReturnVersion = previousVersions.find((previousVersion) => {
@@ -207,6 +213,8 @@ async function _replaceLatestVersion (previousVersions, newVersionStartDate) {
  * This function finds return version **2** and updates its status to `superseded`. We also return the end date from
  * version **2** as this needs to be applied to the new return version as its end date. Hence, we are _replacing a
  * previous version_.
+ *
+ * @private
  */
 async function _replacePreviousVersion (previousVersions, newVersionStartDate) {
   const matchedReturnVersion = previousVersions.find((previousVersion) => {

--- a/app/services/return-requirements/setup/fetch-abstraction-data.service.js
+++ b/app/services/return-requirements/setup/fetch-abstraction-data.service.js
@@ -33,6 +33,8 @@ async function go (licenceId) {
 /**
  * Fetch the specified licence, its current version, and other linked records we need to generate return requirements
  * from
+ *
+ * @private
  */
 async function _fetch (licenceId) {
   return LicenceModel.query()

--- a/app/services/return-requirements/setup/generate-from-abstraction-data.service.js
+++ b/app/services/return-requirements/setup/generate-from-abstraction-data.service.js
@@ -46,6 +46,8 @@ async function go (licenceId) {
  * Because a user can select multiple agreements or exceptions we return it as an array. If none apply you have to
  * explicitly select it as well. Hence, we return that as an option so that the view can pre-select it should a user
  * return to the page to make changes.
+ *
+ * @private
  */
 function _agreementExceptions (licence) {
   const { twoPartTariffAgreement } = licence
@@ -64,6 +66,8 @@ function _agreementExceptions (licence) {
  * 'winter-and-all-year'.
  *
  * Fortunately, to confirm this we don't have to look at the day, we can just check the months involved!
+ *
+ * @private
  */
 function _returnsCycle (startMonth, endMonth) {
   const summerMonths = [4, 5, 6, 7, 8, 9, 10]
@@ -117,6 +121,7 @@ function _returnsCycle (startMonth, endMonth) {
  * |100 - 2500|Monthly   |Monthly  |
  * |Above 2500|Weekly    |Weekly   |
  *
+ * @private
  */
 function _frequencyCollected (licence, licenceVersionPurpose) {
   const { twoPartTariffAgreement, waterUndertaker } = licence
@@ -146,6 +151,8 @@ function _frequencyCollected (licence, licenceVersionPurpose) {
  * various factors
  *
  * See the tables in _frequencyCollected() for details
+ *
+ * @private
  */
 function _frequencyReported (licence, licenceVersionPurpose) {
   const { waterUndertaker } = licence
@@ -173,6 +180,8 @@ function _frequencyReported (licence, licenceVersionPurpose) {
  * first part is the region code, but the second part is NALD's ID for the licence purpose. `_fetch()` will have
  * extracted the legacy purposes from permit licence's JSONB dump. We just need to grab the one that matches the ID we
  * get from `externalId`. With that we can get to the points info and generate `points:` and `siteDescription:`.
+ *
+ * @private
  */
 function _matchingPermitPurpose (permitLicence, licenceVersionPurpose) {
   const { externalId } = licenceVersionPurpose
@@ -190,6 +199,8 @@ function _matchingPermitPurpose (permitLicence, licenceVersionPurpose) {
  *
  * Remember, we are transforming the data into what is needed for the session, not what is needed for the UI! Hence, we
  * only need the ID.
+ *
+ * @private
  */
 function _points (matchingPermitPurpose) {
   return matchingPermitPurpose.purposePoints.map((purposePoint) => {
@@ -204,6 +215,8 @@ function _points (matchingPermitPurpose) {
  *
  * The problem is a purpose can have multiple points. So, we grab all the local name values for each point in the
  * matched permit purpose, strip out any nulls or undefined and then select the first one to form the site description.
+ *
+ * @private
  */
 function _siteDescription (matchingPermitPurpose) {
   const localNames = matchingPermitPurpose.purposePoints.map((purposePoint) => {
@@ -222,6 +235,8 @@ function _siteDescription (matchingPermitPurpose) {
  *
  * What we return matches what you would see in the session if you chose the manual journey. This is what allows a
  * user to make changes from the `/check` page to the requirements we generate.
+ *
+ * @private
  */
 function _transformForSetup (licence) {
   const { licenceVersionPurposes } = licence.$currentVersion()

--- a/app/services/return-requirements/submit-abstraction-period.service.js
+++ b/app/services/return-requirements/submit-abstraction-period.service.js
@@ -63,6 +63,8 @@ async function _save (session, requirementIndex, payload) {
 /**
  * Combines the existing session data with the submitted payload formatted by the presenter. If nothing is submitted by
  * the user, payload will be an empty object.
+ *
+ * @private
  */
 function _submittedSessionData (session, requirementIndex, payload) {
   session.requirements[requirementIndex].abstractionPeriod = Object.keys(payload).length > 0 ? payload : null

--- a/app/services/return-requirements/submit-additional-submission-options.service.js
+++ b/app/services/return-requirements/submit-additional-submission-options.service.js
@@ -58,6 +58,8 @@ async function go (sessionId, payload, yar) {
 * When a single additional submission option is checked by the user, it returns as a string. When multiple options are
  * checked, the 'additionalSubmissionOptions' is returned as an array.
  * This function works to make those single selected string 'additionalSubmissionOptions' into an array for uniformity.
+ *
+ * @private
  */
 function _handleOneOptionSelected (payload) {
   if (!Array.isArray(payload.additionalSubmissionOptions)) {

--- a/app/services/return-requirements/submit-agreements-exceptions.service.js
+++ b/app/services/return-requirements/submit-agreements-exceptions.service.js
@@ -62,6 +62,8 @@ async function go (sessionId, requirementIndex, payload, yar) {
  * When a single agreement and exception is checked by the user, it returns as a string. When multiple agreements and
  * exceptions are checked, the 'agreementsExceptions' is returned as an array. This function works to make those single
  * selected string 'agreementsExceptions' into an array for uniformity.
+ *
+ * @private
  */
 function _handleOneOptionSelected (payload) {
   if (!Array.isArray(payload.agreementsExceptions)) {

--- a/app/services/return-requirements/submit-points.service.js
+++ b/app/services/return-requirements/submit-points.service.js
@@ -62,6 +62,8 @@ async function go (sessionId, requirementIndex, payload, yar) {
  * When a single point is checked by the user, it returns as a string. When multiple points are checked, the
  * 'points' is returned as an array. This function works to make those single selected string 'points' into an array
  * for uniformity.
+ *
+ * @private
  */
 function _handleOneOptionSelected (payload) {
   if (!Array.isArray(payload.points)) {

--- a/app/services/return-requirements/submit-purpose.service.js
+++ b/app/services/return-requirements/submit-purpose.service.js
@@ -83,6 +83,8 @@ function _combinePurposeDetails (payload, licencePurposes) {
  * When a single purpose is checked by the user, it returns as a string. When multiple purposes are checked, the
  * 'purposes' is returned as an array. This function works to make those single selected string 'purposes' into an array
  * for uniformity.
+ *
+ * @private
  */
 function _handleOneOptionSelected (payload) {
   if (!payload.purposes) {
@@ -102,6 +104,8 @@ async function _save (session, requirementIndex, purposes) {
 
 /**
  * Combines the existing session data with the submitted payload formatted by the presenter
+ *
+ * @private
  */
 function _submittedSessionData (session, requirementIndex, purposes, licencePurposes) {
   session.requirements[requirementIndex].purposes = purposes

--- a/app/services/return-requirements/submit-site-description.service.js
+++ b/app/services/return-requirements/submit-site-description.service.js
@@ -63,6 +63,8 @@ async function _save (session, requirementIndex, payload) {
 /**
  * Combines the existing session data with the submitted payload formatted by the presenter. If nothing is submitted by
  * the user, payload will be an empty object.
+ *
+ * @private
  */
 function _submittedSessionData (session, requirementIndex, payload) {
   session.requirements[requirementIndex].siteDescription = payload.siteDescription ? payload.siteDescription : null

--- a/app/validators/bill-runs/two-part-tariff/adjustment-factor.validator.js
+++ b/app/validators/bill-runs/two-part-tariff/adjustment-factor.validator.js
@@ -36,6 +36,8 @@ function go (payload, maxNumberOfDecimals, validationType) {
  * two items (if a decimal is present). The first item represents the part before the decimal, while the second item
  * represents the part after. By assessing if the length of the second string is less than 3 or 16, we can validate if
  * there the correct number of decimals.
+ *
+ * @private
  */
 function _customValidation (quantity, helpers, maxNumberOfDecimals, validationType) {
   const quantityParts = quantity.toString().split('.')

--- a/app/validators/bill-runs/two-part-tariff/authorised-volume.validator.js
+++ b/app/validators/bill-runs/two-part-tariff/authorised-volume.validator.js
@@ -45,6 +45,8 @@ function go (payload) {
  * two items (if a decimal is present). The first item represents the part before the decimal, while the second item
  * represents the part after. By assessing if the length of the second string is less than o equal to 6, we can validate
  * if there are the correct number of decimals.
+ *
+ * @private
  */
 function _customValidation (quantity, helpers) {
   const maxNumberOfDecimals = 6

--- a/app/validators/bill-runs/two-part-tariff/billable-returns.validator.js
+++ b/app/validators/bill-runs/two-part-tariff/billable-returns.validator.js
@@ -38,6 +38,8 @@ function go (payload) {
  * items (if a decimal is present). The first item represents the part before the decimal, while the second item
  * represents the part after. By assessing if the length of the second string is less than 7, we can validate if there
  * the correct number of decimals.
+ *
+ * @private
  */
 function customValidation (customQuantity, helpers) {
   const maxNumberOfDecimals = 7


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/125

We recently added a new [eslint-plugin-jsdoc](https://github.com/gajus/eslint-plugin-jsdoc) plugin in [Lint JSDOC's](https://github.com/DEFRA/water-abstraction-system/pull/1269) to take our work of helping new and existing devs follow our JSDoc conventions to the next level.

For reference, we aim to document all our public functions. Forcing devs to write about why something exists is a handy way to try and slow them down and think about what they are doing!

But we don't ask anyone to document private functions, for example, `function _determineStartDate()` — basically, anything with a leading underscore. However, there are times when a comment is handy. We have to do some gnarly stuff on this service, and sometimes, we can't make the code self-documenting. 😢

At the moment, the plugin is penalising us for doing this. These comments don't include params and return statements because that was not the intent of the comment.

So, this change is about getting the plugin to ignore private methods.