### PR TITLE
Update return versions table with reasons in view

### DIFF
--- a/app/presenters/licences/set-up.presenter.js
+++ b/app/presenters/licences/set-up.presenter.js
@@ -172,6 +172,25 @@ function _financialAgreementCode (agreement) {
   return agreement.financialAgreement.code
 }
 
+/**
+ * The history helper $reason() will return either the reason saved against the return version record, the reason
+ * captured in the first mod log entry, or null.
+ *
+ * If its the reason saved against the return version we have to map it to its display version first.
+ *
+ * @private
+ */
+function _reason (returnVersion) {
+  const reason = returnVersion.$reason()
+  const mappedReason = returnRequirementReasons[reason]
+
+  if (mappedReason) {
+    return mappedReason
+  }
+
+  return reason ?? ''
+}
+
 function _returnVersions (returnVersions = [{}]) {
   return returnVersions.map((returnVersion) => {
     return {
@@ -180,7 +199,7 @@ function _returnVersions (returnVersions = [{}]) {
         link: `/system/return-requirements/${returnVersion.id}/view`
       }],
       endDate: returnVersion.endDate ? formatLongDate(returnVersion.endDate) : '',
-      reason: returnVersion.reason ? returnRequirementReasons[returnVersion.reason] : '',
+      reason: _reason(returnVersion),
       startDate: formatLongDate(returnVersion.startDate),
       status: returnVersion.status
     }

--- a/app/services/licences/fetch-return-versions.service.js
+++ b/app/services/licences/fetch-return-versions.service.js
@@ -32,6 +32,15 @@ async function _fetch (licenceId) {
       { column: 'startDate', order: 'desc' },
       { column: 'version', order: 'desc' }
     ])
+    .withGraphFetched('modLogs')
+    .modifyGraph('modLogs', (builder) => {
+      builder
+        .select([
+          'id',
+          'reasonDescription'
+        ])
+        .orderBy('externalId', 'asc')
+    })
 }
 
 module.exports = {

--- a/test/presenters/licences/set-up.presenter.test.js
+++ b/test/presenters/licences/set-up.presenter.test.js
@@ -8,6 +8,9 @@ const Sinon = require('sinon')
 const { describe, it, afterEach, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
+// Test helpers
+const ReturnVersionModel = require('../../../app/models/return-version.model.js')
+
 // Things we need to stub
 const FeatureFlagsConfig = require('../../../config/feature-flags.config.js')
 
@@ -32,14 +35,6 @@ describe('Licences - Set Up presenter', () => {
     licenceId: 'f91bf145-ce8e-481c-a842-4da90348062b'
   }
 
-  const returnVersion = {
-    id: '0312e5eb-67ae-44fb-922c-b1a0b81bc08d',
-    startDate: new Date('2020-01-01'),
-    endDate: null,
-    status: 'current',
-    reason: 'change-to-special-agreement'
-  }
-
   const workflow = {
     id: 'f547f465-0a62-45ff-9909-38825f05e0c4',
     createdAt: new Date('2020-01-01'),
@@ -57,6 +52,7 @@ describe('Licences - Set Up presenter', () => {
   let auth
   let chargeVersions
   let commonData
+  let returnVersion
   let returnVersions
   let workflows
 
@@ -80,6 +76,18 @@ describe('Licences - Set Up presenter', () => {
         date: new Date()
       }
     }
+
+    returnVersion = ReturnVersionModel.fromJson({
+      id: '0312e5eb-67ae-44fb-922c-b1a0b81bc08d',
+      startDate: new Date('2020-01-01'),
+      endDate: null,
+      status: 'current',
+      reason: 'change-to-special-agreement',
+      modLogs: [{
+        id: '956a876a-2a51-4e86-bb39-3101395a741b',
+        reasonDescription: 'Special Agreement - Change'
+      }]
+    })
 
     agreements = []
     chargeVersions = []
@@ -546,7 +554,7 @@ describe('Licences - Set Up presenter', () => {
 
     describe('that includes return versions', () => {
       beforeEach(() => {
-        returnVersions = [{ ...returnVersion }]
+        returnVersions = [returnVersion]
       })
 
       it('correctly presents the returns versions data', () => {
@@ -570,7 +578,9 @@ describe('Licences - Set Up presenter', () => {
 
       describe('and the data is missing', () => {
         beforeEach(() => {
-          returnVersions = [{ ...returnVersion, endDate: null, reason: null }]
+          returnVersion.endDate = null
+          returnVersion.reason = null
+          returnVersions = [returnVersion]
         })
 
         it('correctly presents the returns versions data with the missing data defaults', () => {
@@ -585,7 +595,7 @@ describe('Licences - Set Up presenter', () => {
                 }
               ],
               endDate: '',
-              reason: '',
+              reason: 'Special Agreement - Change',
               startDate: '1 January 2020',
               status: 'current'
             }

--- a/test/services/licences/fetch-return-versions.service.test.js
+++ b/test/services/licences/fetch-return-versions.service.test.js
@@ -8,6 +8,7 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
+const ModLogHelper = require('../../support/helpers/mod-log.helper.js')
 const ReturnVersionHelper = require('../../support/helpers/return-version.helper.js')
 
 // Thing under test
@@ -18,6 +19,7 @@ describe('Fetch Return Versions service', () => {
   const startDate = new Date('2022-04-01')
 
   let currentReturnVersion
+  let currentReturnVersionModLog
   let supersededReturnVersion
 
   describe('when the licence has return versions data', () => {
@@ -28,6 +30,10 @@ describe('Fetch Return Versions service', () => {
       })
       currentReturnVersion = await ReturnVersionHelper.add({
         licenceId: supersededReturnVersion.licenceId, startDate, status: 'current', version: 101
+      })
+
+      currentReturnVersionModLog = await ModLogHelper.add({
+        reasonDescription: 'Record Loaded During Migration', returnVersionId: currentReturnVersion.id
       })
     })
 
@@ -40,14 +46,19 @@ describe('Fetch Return Versions service', () => {
           startDate: new Date('2022-04-01'),
           endDate: null,
           status: 'current',
-          reason: 'new-licence'
+          reason: 'new-licence',
+          modLogs: [{
+            id: currentReturnVersionModLog.id,
+            reasonDescription: 'Record Loaded During Migration'
+          }]
         },
         {
           id: supersededReturnVersion.id,
           startDate: new Date('2022-04-01'),
           endDate: null,
           status: 'superseded',
-          reason: 'new-licence'
+          reason: 'new-licence',
+          modLogs: []
         }
       ])
     })

--- a/test/services/licences/view-licence-set-up.service.test.js
+++ b/test/services/licences/view-licence-set-up.service.test.js
@@ -59,6 +59,7 @@ describe('View Licence Set Up service', () => {
       reason: 'change-to-special-agreement',
       modLogs: []
     })
+
     Sinon.stub(FetchReturnVersionsService, 'go').returns([returnVersion])
 
     Sinon.stub(FetchWorkflowsService, 'go').returns([

--- a/test/services/licences/view-licence-set-up.service.test.js
+++ b/test/services/licences/view-licence-set-up.service.test.js
@@ -8,6 +8,9 @@ const Sinon = require('sinon')
 const { describe, it, beforeEach, afterEach } = exports.lab = Lab.script()
 const { expect } = Code
 
+// Test helpers
+const ReturnVersionModel = require('../../../app/models/return-version.model.js')
+
 // Things we need to stub
 const FeatureFlagsConfig = require('../../../config/feature-flags.config.js')
 const FetchAgreementsService = require('../../../app/services/licences/fetch-agreements.service.js')
@@ -48,15 +51,15 @@ describe('View Licence Set Up service', () => {
       }
     ])
 
-    Sinon.stub(FetchReturnVersionsService, 'go').returns([
-      {
-        id: '0312e5eb-67ae-44fb-922c-b1a0b81bc08d',
-        startDate: new Date('2025-01-01'),
-        endDate: new Date('2025-02-01'),
-        status: 'current',
-        reason: 'change-to-special-agreement'
-      }
-    ])
+    const returnVersion = ReturnVersionModel.fromJson({
+      id: '0312e5eb-67ae-44fb-922c-b1a0b81bc08d',
+      startDate: new Date('2025-01-01'),
+      endDate: new Date('2025-02-01'),
+      status: 'current',
+      reason: 'change-to-special-agreement',
+      modLogs: []
+    })
+    Sinon.stub(FetchReturnVersionsService, 'go').returns([returnVersion])
 
     Sinon.stub(FetchWorkflowsService, 'go').returns([
       {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4639

> Part of the work to display a licence's history to users (mod log)

In [Update view return version to include mod log info](https://github.com/DEFRA/water-abstraction-system/pull/1261), we update the view return version page to include details taken from a return version's mod log history.

You access that from the table 'Requirements for returns' on the view licence page's setup tab. We haven't incorporated pulling missing details from the return version history there, which means they are now out of sync.

This change updates how we generate the page data to include the same information we show when you click through to the view return version page.