### PR TITLE
Update use previous in ret. req setup with mod log

### DIFF
--- a/app/models/return-version.model.js
+++ b/app/models/return-version.model.js
@@ -55,18 +55,20 @@ class ReturnVersionModel extends BaseModel {
    * Modifiers allow us to reuse logic in queries, eg. select the return version, user that created it, and/or all mod
    * log records:
    *
+   * ```javascript
    * return ReturnVersionModel.query()
    *   .findById(returnVersionId)
    *   .modify('history')
+   * ```
    *
    * See {@link https://vincit.github.io/objection.js/recipes/modifiers.html | Modifiers} for more details
+   *
+   * @returns {object} an object defining modifier functions for this model
    */
   static get modifiers () {
     return {
-      /**
-       * history modifier fetches all the related records needed to determine history properties, for example, created
-       * at, created by, and notes from the record, its user, and its NALD mod logs (where they exist)
-       */
+      // history modifier fetches all the related records needed to determine history properties, for example, created
+      // at, created by, and notes from the record, its user, and its NALD mod logs (where they exist)
       history (query) {
         query
           .withGraphFetched('modLogs')

--- a/app/presenters/return-requirements/existing.presenter.js
+++ b/app/presenters/return-requirements/existing.presenter.js
@@ -27,7 +27,8 @@ function go (session) {
 
 function _existingOptions (returnVersions) {
   return returnVersions.map((returnVersion) => {
-    const { id, reason, startDate } = returnVersion
+    const { id, startDate } = returnVersion
+    const reason = _reason(returnVersion)
 
     // NOTE: because the session data is stored in a JSONB field when we get the instance from the DB the date values
     // are in JS Date format (string). So, we have to convert it to a date before calling `formatLongDate()`
@@ -36,9 +37,26 @@ function _existingOptions (returnVersions) {
 
     return {
       value: id,
-      text: reason ? `${formattedStartDate} - ${returnRequirementReasons[reason]}` : formattedStartDate
+      text: reason ? `${formattedStartDate} - ${reason}` : formattedStartDate
     }
   })
+}
+
+function _reason (returnVersion) {
+  const { modLogs, reason } = returnVersion
+
+  // The return version was created in WRLS or we were able to map the NALD reason during import
+  if (reason) {
+    return returnRequirementReasons[reason]
+  }
+
+  // The return version has no mod logs or the first entry does not have a reason recorded
+  if (modLogs.length === 0 || !modLogs[0].reasonDescription) {
+    return null
+  }
+
+  // Fallback to the reason against the first mod log entry for the return version
+  return modLogs[0].reasonDescription
 }
 
 module.exports = {

--- a/app/services/return-requirements/existing.service.js
+++ b/app/services/return-requirements/existing.service.js
@@ -17,7 +17,7 @@ const SessionModel = require('../../models/session.model.js')
  * @param {string} sessionId - The UUID of the current session
  *
  * @returns {Promise<object>} The view data for the purpose page
-*/
+ */
 async function go (sessionId) {
   const session = await SessionModel.query().findById(sessionId)
 

--- a/app/services/return-requirements/initiate-session.service.js
+++ b/app/services/return-requirements/initiate-session.service.js
@@ -102,6 +102,15 @@ async function _fetchLicence (licenceId) {
         )
         .orderBy('startDate', 'desc')
     })
+    .withGraphFetched('returnVersions.modLogs')
+    .modifyGraph('returnVersions.modLogs', (builder) => {
+      builder
+        .select([
+          'id',
+          'reasonDescription'
+        ])
+        .orderBy('externalId', 'asc')
+    })
     // See licence.model.js `static get modifiers` if you are unsure about what this is doing
     .modify('licenceHolder')
 

--- a/test/presenters/return-requirements/existing.presenter.test.js
+++ b/test/presenters/return-requirements/existing.presenter.test.js
@@ -26,7 +26,8 @@ describe('Return Requirements - Existing presenter', () => {
         returnVersions: [{
           id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
           startDate: '2023-01-01T00:00:00.000Z',
-          reason: null
+          reason: null,
+          modLogs: []
         }],
         startDate: '2022-04-01T00:00:00.000Z'
       },
@@ -50,12 +51,44 @@ describe('Return Requirements - Existing presenter', () => {
 
   describe('the "existingOptions" property', () => {
     describe('when the return versions do not contain a "reason"', () => {
-      it('returns the version ID as the option value and just the start date as the option text', () => {
-        const result = ExistingPresenter.go(session)
+      describe('and do not contain any mod logs', () => {
+        it('returns the version ID as the option value and just the start date as the option text', () => {
+          const result = ExistingPresenter.go(session)
 
-        expect(result.existingOptions).to.equal([
-          { value: '60b5d10d-1372-4fb2-b222-bfac81da69ab', text: '1 January 2023' }
-        ])
+          expect(result.existingOptions).to.equal([
+            { value: '60b5d10d-1372-4fb2-b222-bfac81da69ab', text: '1 January 2023' }
+          ])
+        })
+      })
+
+      describe('but do contain mod logs', () => {
+        describe('but the first entry does not have a reason', () => {
+          beforeEach(() => {
+            session.licence.returnVersions[0].modLogs.push({ reasonDescription: null })
+          })
+
+          it('returns the version ID as the option value and just the start date as the option text', () => {
+            const result = ExistingPresenter.go(session)
+
+            expect(result.existingOptions).to.equal([
+              { value: '60b5d10d-1372-4fb2-b222-bfac81da69ab', text: '1 January 2023' }
+            ])
+          })
+        })
+
+        describe('and the first entry does have a reason', () => {
+          beforeEach(() => {
+            session.licence.returnVersions[0].modLogs.push({ reasonDescription: 'Record Loaded During Migration' })
+          })
+
+          it('returns the version ID as the option value and the start date and reason as the option text', () => {
+            const result = ExistingPresenter.go(session)
+
+            expect(result.existingOptions).to.equal([
+              { value: '60b5d10d-1372-4fb2-b222-bfac81da69ab', text: '1 January 2023 - Record Loaded During Migration' }
+            ])
+          })
+        })
       })
     })
 

--- a/test/services/return-requirements/existing.service.test.js
+++ b/test/services/return-requirements/existing.service.test.js
@@ -29,7 +29,8 @@ describe('Return Requirements - Existing service', () => {
           returnVersions: [{
             id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
             startDate: '2023-01-01T00:00:00.000Z',
-            reason: null
+            reason: null,
+            modLogs: []
           }],
           startDate: '2022-04-01T00:00:00.000Z'
         },

--- a/test/services/return-requirements/frequency-collected.service.test.js
+++ b/test/services/return-requirements/frequency-collected.service.test.js
@@ -28,6 +28,12 @@ describe('Return Requirements - Frequency Collected service', () => {
           endDate: null,
           licenceRef: '01/ABC',
           licenceHolder: 'Turbo Kid',
+          returnVersions: [{
+            id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
+            startDate: '2023-01-01T00:00:00.000Z',
+            reason: null,
+            modLogs: []
+          }],
           startDate: '2022-04-01T00:00:00.000Z'
         },
         journey: 'returns-required',

--- a/test/services/return-requirements/frequency-reported.service.test.js
+++ b/test/services/return-requirements/frequency-reported.service.test.js
@@ -28,6 +28,12 @@ describe('Return Requirements - Frequency Reported service', () => {
           endDate: null,
           licenceRef: '01/ABC',
           licenceHolder: 'Turbo Kid',
+          returnVersions: [{
+            id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
+            startDate: '2023-01-01T00:00:00.000Z',
+            reason: null,
+            modLogs: []
+          }],
           startDate: '2022-04-01T00:00:00.000Z'
         },
         journey: 'returns-required',

--- a/test/services/return-requirements/initiate-session.service.test.js
+++ b/test/services/return-requirements/initiate-session.service.test.js
@@ -11,6 +11,7 @@ const { expect } = Code
 const LicenceHelper = require('../../support/helpers/licence.helper.js')
 const LicenceHolderSeeder = require('../../support/seeders/licence-holder.seeder.js')
 const LicenceVersionHelper = require('../../support/helpers/licence-version.helper.js')
+const ModLogHelper = require('../../support/helpers/mod-log.helper.js')
 const ReturnRequirementHelper = require('../../support/helpers/return-requirement.helper.js')
 const ReturnVersionHelper = require('../../support/helpers/return-version.helper.js')
 const { generateLicenceRef } = require('../../support/helpers/licence.helper.js')
@@ -21,8 +22,9 @@ const InitiateSessionService = require('../../../app/services/return-requirement
 describe('Return Requirements - Initiate Session service', () => {
   let journey
   let licence
-  let returnVersionId
   let licenceRef
+  let modLog
+  let returnVersionId
 
   beforeEach(async () => {
     // Create the licence record with an 'end' date so we can confirm the session gets populated with the licence's
@@ -77,6 +79,7 @@ describe('Return Requirements - Initiate Session service', () => {
 
           returnVersionId = returnVersion.id
 
+          modLog = await ModLogHelper.add({ reasonDescription: 'Record Loaded During Migration', returnVersionId })
           await ReturnRequirementHelper.add({ returnVersionId })
         })
 
@@ -88,7 +91,8 @@ describe('Return Requirements - Initiate Session service', () => {
           expect(returnVersions).to.equal([{
             id: returnVersionId,
             reason: 'new-licence',
-            startDate: new Date('2022-05-01')
+            startDate: new Date('2022-05-01'),
+            modLogs: [{ id: modLog.id, reasonDescription: modLog.reasonDescription }]
           }])
         })
       })

--- a/test/services/return-requirements/no-returns-required.service.test.js
+++ b/test/services/return-requirements/no-returns-required.service.test.js
@@ -26,6 +26,12 @@ describe('Return Requirements - No Returns Required service', () => {
           endDate: null,
           licenceRef: '01/ABC',
           licenceHolder: 'Turbo Kid',
+          returnVersions: [{
+            id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
+            startDate: '2023-01-01T00:00:00.000Z',
+            reason: null,
+            modLogs: []
+          }],
           startDate: '2022-04-01T00:00:00.000Z'
         },
         journey: 'no-returns-required',

--- a/test/services/return-requirements/note.service.test.js
+++ b/test/services/return-requirements/note.service.test.js
@@ -26,6 +26,12 @@ describe('Return Requirements - Note service', () => {
           endDate: null,
           licenceRef: '01/ABC',
           licenceHolder: 'Turbo Kid',
+          returnVersions: [{
+            id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
+            startDate: '2023-01-01T00:00:00.000Z',
+            reason: null,
+            modLogs: []
+          }],
           startDate: '2022-04-01T00:00:00.000Z'
         },
         journey: 'returns-required',

--- a/test/services/return-requirements/points.service.test.js
+++ b/test/services/return-requirements/points.service.test.js
@@ -32,6 +32,12 @@ describe('Return Requirements - Select Points service', () => {
           endDate: null,
           licenceRef: '01/ABC',
           licenceHolder: 'Turbo Kid',
+          returnVersions: [{
+            id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
+            startDate: '2023-01-01T00:00:00.000Z',
+            reason: null,
+            modLogs: []
+          }],
           startDate: '2022-04-01T00:00:00.000Z'
         },
         journey: 'returns-required',

--- a/test/services/return-requirements/purpose.service.test.js
+++ b/test/services/return-requirements/purpose.service.test.js
@@ -37,6 +37,12 @@ describe('Return Requirements - Purpose service', () => {
           endDate: null,
           licenceRef: '01/ABC',
           licenceHolder: 'Turbo Kid',
+          returnVersions: [{
+            id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
+            startDate: '2023-01-01T00:00:00.000Z',
+            reason: null,
+            modLogs: []
+          }],
           startDate: '2022-04-01T00:00:00.000Z'
         },
         journey: 'returns-required',

--- a/test/services/return-requirements/reason.service.test.js
+++ b/test/services/return-requirements/reason.service.test.js
@@ -26,6 +26,12 @@ describe('Return Requirements - Reason service', () => {
           endDate: null,
           licenceRef: '01/ABC',
           licenceHolder: 'Turbo Kid',
+          returnVersions: [{
+            id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
+            startDate: '2023-01-01T00:00:00.000Z',
+            reason: null,
+            modLogs: []
+          }],
           startDate: '2022-04-01T00:00:00.000Z'
         },
         journey: 'returns-required',

--- a/test/services/return-requirements/remove.service.test.js
+++ b/test/services/return-requirements/remove.service.test.js
@@ -30,6 +30,12 @@ describe('Return Requirements - Remove service', () => {
           endDate: null,
           licenceRef: '01/ABC',
           licenceHolder: 'Turbo Kid',
+          returnVersions: [{
+            id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
+            startDate: '2023-01-01T00:00:00.000Z',
+            reason: null,
+            modLogs: []
+          }],
           startDate: '2022-04-01T00:00:00.000Z'
         },
         journey: 'returns-required',

--- a/test/services/return-requirements/returns-cycle.service.test.js
+++ b/test/services/return-requirements/returns-cycle.service.test.js
@@ -28,6 +28,12 @@ describe('Return Requirements - Returns Cycle service', () => {
           endDate: null,
           licenceRef: '01/ABC',
           licenceHolder: 'Turbo Kid',
+          returnVersions: [{
+            id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
+            startDate: '2023-01-01T00:00:00.000Z',
+            reason: null,
+            modLogs: []
+          }],
           startDate: '2022-04-01T00:00:00.000Z'
         },
         journey: 'returns-required',

--- a/test/services/return-requirements/site-description.service.test.js
+++ b/test/services/return-requirements/site-description.service.test.js
@@ -28,6 +28,12 @@ describe('Return Requirements - Site Description service', () => {
           endDate: null,
           licenceRef: '01/ABC',
           licenceHolder: 'Turbo Kid',
+          returnVersions: [{
+            id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
+            startDate: '2023-01-01T00:00:00.000Z',
+            reason: null,
+            modLogs: []
+          }],
           startDate: '2022-04-01T00:00:00.000Z'
         },
         journey: 'returns-required',

--- a/test/services/return-requirements/start-date.service.test.js
+++ b/test/services/return-requirements/start-date.service.test.js
@@ -28,6 +28,12 @@ describe('Return Requirements - Start Date service', () => {
           endDate: null,
           licenceRef: '01/ABC',
           licenceHolder: 'Turbo Kid',
+          returnVersions: [{
+            id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
+            startDate: '2023-01-01T00:00:00.000Z',
+            reason: null,
+            modLogs: []
+          }],
           startDate: '2022-04-01T00:00:00.000Z'
         },
         journey: 'returns-required',

--- a/test/services/return-requirements/submit-abstraction-period.service.test.js
+++ b/test/services/return-requirements/submit-abstraction-period.service.test.js
@@ -32,6 +32,12 @@ describe('Return Requirements - Submit Abstraction Period service', () => {
           endDate: null,
           licenceRef: '01/ABC',
           licenceHolder: 'Turbo Kid',
+          returnVersions: [{
+            id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
+            startDate: '2023-01-01T00:00:00.000Z',
+            reason: null,
+            modLogs: []
+          }],
           startDate: '2022-04-01T00:00:00.000Z'
         },
         journey: 'returns-required',

--- a/test/services/return-requirements/submit-additional-submission-options.service.test.js
+++ b/test/services/return-requirements/submit-additional-submission-options.service.test.js
@@ -29,6 +29,12 @@ describe('Return Requirements - Submit Additional Submission Options service', (
           endDate: null,
           licenceRef: '01/ABC',
           licenceHolder: 'Turbo Kid',
+          returnVersions: [{
+            id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
+            startDate: '2023-01-01T00:00:00.000Z',
+            reason: null,
+            modLogs: []
+          }],
           startDate: '2022-04-01T00:00:00.000Z'
         },
         journey: 'returns-required',

--- a/test/services/return-requirements/submit-agreements-exceptions.service.test.js
+++ b/test/services/return-requirements/submit-agreements-exceptions.service.test.js
@@ -32,6 +32,12 @@ describe('Return Requirements - Submit Agreements and Exceptions service', () =>
           endDate: null,
           licenceRef: '01/ABC',
           licenceHolder: 'Turbo Kid',
+          returnVersions: [{
+            id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
+            startDate: '2023-01-01T00:00:00.000Z',
+            reason: null,
+            modLogs: []
+          }],
           startDate: '2022-04-01T00:00:00.000Z'
         },
         journey: 'returns-required',

--- a/test/services/return-requirements/submit-cancel.service.test.js
+++ b/test/services/return-requirements/submit-cancel.service.test.js
@@ -28,6 +28,12 @@ describe('Return Requirements - Submit Cancel service', () => {
           endDate: null,
           licenceRef: '01/ABC',
           licenceHolder: 'Turbo Kid',
+          returnVersions: [{
+            id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
+            startDate: '2023-01-01T00:00:00.000Z',
+            reason: null,
+            modLogs: []
+          }],
           startDate: '2022-04-01T00:00:00.000Z'
         },
         journey: 'returns-required',

--- a/test/services/return-requirements/submit-existing.service.test.js
+++ b/test/services/return-requirements/submit-existing.service.test.js
@@ -35,7 +35,8 @@ describe('Return Requirements - Submit Existing service', () => {
           returnVersions: [{
             id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
             startDate: '2023-01-01T00:00:00.000Z',
-            reason: null
+            reason: null,
+            modLogs: []
           }],
           startDate: '2022-04-01T00:00:00.000Z'
         },

--- a/test/services/return-requirements/submit-frequency-collected.service.test.js
+++ b/test/services/return-requirements/submit-frequency-collected.service.test.js
@@ -32,6 +32,12 @@ describe('Return Requirements - Submit Frequency Collected service', () => {
           endDate: null,
           licenceRef: '01/ABC',
           licenceHolder: 'Turbo Kid',
+          returnVersions: [{
+            id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
+            startDate: '2023-01-01T00:00:00.000Z',
+            reason: null,
+            modLogs: []
+          }],
           startDate: '2022-04-01T00:00:00.000Z'
         },
         journey: 'returns-required',

--- a/test/services/return-requirements/submit-frequency-reported.service.test.js
+++ b/test/services/return-requirements/submit-frequency-reported.service.test.js
@@ -32,6 +32,12 @@ describe('Return Requirements - Submit Frequency Reported service', () => {
           endDate: null,
           licenceRef: '01/ABC',
           licenceHolder: 'Turbo Kid',
+          returnVersions: [{
+            id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
+            startDate: '2023-01-01T00:00:00.000Z',
+            reason: null,
+            modLogs: []
+          }],
           startDate: '2022-04-01T00:00:00.000Z'
         },
         journey: 'returns-required',

--- a/test/services/return-requirements/submit-no-returns-required.service.test.js
+++ b/test/services/return-requirements/submit-no-returns-required.service.test.js
@@ -30,6 +30,12 @@ describe('Return Requirements - Submit No Returns Required service', () => {
           endDate: null,
           licenceRef: '01/ABC',
           licenceHolder: 'Turbo Kid',
+          returnVersions: [{
+            id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
+            startDate: '2023-01-01T00:00:00.000Z',
+            reason: null,
+            modLogs: []
+          }],
           startDate: '2022-04-01T00:00:00.000Z'
         },
         journey: 'no-returns-required',

--- a/test/services/return-requirements/submit-note.service.test.js
+++ b/test/services/return-requirements/submit-note.service.test.js
@@ -31,6 +31,12 @@ describe('Return Requirements - Submit Note service', () => {
           endDate: null,
           licenceRef: '01/ABC',
           licenceHolder: 'Turbo Kid',
+          returnVersions: [{
+            id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
+            startDate: '2023-01-01T00:00:00.000Z',
+            reason: null,
+            modLogs: []
+          }],
           startDate: '2022-04-01T00:00:00.000Z'
         },
         journey: 'returns-required',

--- a/test/services/return-requirements/submit-points.service.test.js
+++ b/test/services/return-requirements/submit-points.service.test.js
@@ -35,6 +35,12 @@ describe('Return Requirements - Submit Points service', () => {
           endDate: null,
           licenceRef: '01/ABC',
           licenceHolder: 'Turbo Kid',
+          returnVersions: [{
+            id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
+            startDate: '2023-01-01T00:00:00.000Z',
+            reason: null,
+            modLogs: []
+          }],
           startDate: '2022-04-01T00:00:00.000Z'
         },
         journey: 'returns-required',

--- a/test/services/return-requirements/submit-purpose.service.test.js
+++ b/test/services/return-requirements/submit-purpose.service.test.js
@@ -35,6 +35,12 @@ describe('Return Requirements - Submit Purpose service', () => {
           endDate: null,
           licenceRef: '01/ABC',
           licenceHolder: 'Turbo Kid',
+          returnVersions: [{
+            id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
+            startDate: '2023-01-01T00:00:00.000Z',
+            reason: null,
+            modLogs: []
+          }],
           startDate: '2022-04-01T00:00:00.000Z'
         },
         journey: 'returns-required',

--- a/test/services/return-requirements/submit-reason.service.test.js
+++ b/test/services/return-requirements/submit-reason.service.test.js
@@ -30,6 +30,12 @@ describe('Return Requirements - Submit Reason service', () => {
           endDate: null,
           licenceRef: '01/ABC',
           licenceHolder: 'Turbo Kid',
+          returnVersions: [{
+            id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
+            startDate: '2023-01-01T00:00:00.000Z',
+            reason: null,
+            modLogs: []
+          }],
           startDate: '2022-04-01T00:00:00.000Z'
         },
         journey: 'returns-required',

--- a/test/services/return-requirements/submit-remove.service.test.js
+++ b/test/services/return-requirements/submit-remove.service.test.js
@@ -32,6 +32,12 @@ describe('Return Requirements - Submit Remove service', () => {
           endDate: null,
           licenceRef: '01/ABC',
           licenceHolder: 'Turbo Kid',
+          returnVersions: [{
+            id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
+            startDate: '2023-01-01T00:00:00.000Z',
+            reason: null,
+            modLogs: []
+          }],
           startDate: '2022-04-01T00:00:00.000Z'
         },
         journey: 'returns-required',

--- a/test/services/return-requirements/submit-returns-cycle.service.test.js
+++ b/test/services/return-requirements/submit-returns-cycle.service.test.js
@@ -32,6 +32,12 @@ describe('Return Requirements - Submit Returns Cycle service', () => {
           endDate: null,
           licenceRef: '01/ABC',
           licenceHolder: 'Turbo Kid',
+          returnVersions: [{
+            id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
+            startDate: '2023-01-01T00:00:00.000Z',
+            reason: null,
+            modLogs: []
+          }],
           startDate: '2022-04-01T00:00:00.000Z'
         },
         journey: 'returns-required',

--- a/test/services/return-requirements/submit-site-description.service.test.js
+++ b/test/services/return-requirements/submit-site-description.service.test.js
@@ -32,6 +32,12 @@ describe('Return Requirements - Submit Site Description service', () => {
           endDate: null,
           licenceRef: '01/ABC',
           licenceHolder: 'Turbo Kid',
+          returnVersions: [{
+            id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
+            startDate: '2023-01-01T00:00:00.000Z',
+            reason: null,
+            modLogs: []
+          }],
           startDate: '2022-04-01T00:00:00.000Z'
         },
         journey: 'returns-required',

--- a/test/services/return-requirements/submit-start-date.service.test.js
+++ b/test/services/return-requirements/submit-start-date.service.test.js
@@ -31,6 +31,12 @@ describe('Return Requirements - Submit Start Date service', () => {
           endDate: null,
           licenceRef: '01/ABC',
           licenceHolder: 'Turbo Kid',
+          returnVersions: [{
+            id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
+            startDate: '2023-01-01T00:00:00.000Z',
+            reason: null,
+            modLogs: []
+          }],
           startDate: '2022-04-01T00:00:00.000Z'
         },
         journey: 'returns-required',


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4640

> Part of the work to display a licence's history to users (mod log)

In [Update view return version to include mod log info](https://github.com/DEFRA/water-abstraction-system/pull/1261), we updated the view return version page to include details taken from a return version's mod log history.

Then, in [Update return versions table with reasons in view](https://github.com/DEFRA/water-abstraction-system/pull/1281), we updated the table of return requirements in the view licence setup tab to display the mod log reason for return versions without a mapping.

The final place we display return version reasons is the 'Use previous requirements for returns' page in the return version set-up journey.

This change updates the logic for return versions without a reason but that have a mod log with a reason: we use its description.