### PR TITLE
Override "Missing JSDoc comment" rule for controllers

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,6 +3,14 @@
 module.exports = {
   extends: 'standard', // Maintain Standard.js rules
   ignorePatterns: ['docs/*'],
+  overrides: [
+    {
+      files: ['*.controller.js'],
+      rules: {
+        'jsdoc/require-jsdoc': 'off'
+      }
+    }
+  ],
   parserOptions: {
     sourceType: 'script'
   },

--- a/app/controllers/billing-accounts.controller.js
+++ b/app/controllers/billing-accounts.controller.js
@@ -29,9 +29,7 @@ async function changeAddress (request, h) {
   return h.response(result).code(201)
 }
 
-/**
- * Takes an error from a validator and returns a suitable Boom error
-*/
+// Takes an error from a validator and returns a suitable Boom error
 function _formattedValidationError (error) {
   return Boom.badRequest(error.details[0].message)
 }

--- a/app/controllers/jobs.controller.js
+++ b/app/controllers/jobs.controller.js
@@ -18,6 +18,8 @@ const notFoundStatusCode = 404
  * Triggers export of all relevant tables to CSV and then uploads them to S3
  *
  * > Has to be called something other than 'export' because export is a reserved word
+ * @param _request - the hapi request object
+ * @param h - the hapi response object
  *
  * @returns {Promise<object>} - A promise that resolves to an HTTP response object with a 204 status code
  */

--- a/app/lib/base-notifier.lib.js
+++ b/app/lib/base-notifier.lib.js
@@ -42,7 +42,7 @@ class BaseNotifierLib {
    *
    * @param {string} message - Message to add to the log (INFO)
    * @param {object} [data={}] - An object containing any values to be logged, for example, a bill run ID to be included
-   *  with the log message. Defaults to an empty object
+   * with the log message. Defaults to an empty object
    */
   omg (message, data = {}) {
     this._logger.info(this._formatLogPacket(data), message)
@@ -78,7 +78,7 @@ class BaseNotifierLib {
    * @param {object} [data={}] - An object containing any values to be logged and sent in the notification to Errbit,
    * for example, a bill run ID. Defaults to an empty object
    * @param {Error} [error=null] - An instance of the error to be logged and sent to Errbit. If no error is provided one
-   *  will be created using `message` as the error message
+   * will be created using `message` as the error message
    */
   omfg (message, data = {}, error = null) {
     // This deals with anyone calling omfg() with `omfg('It broke', null, error)` which would cause things to break

--- a/app/lib/legacy-db-snake-case-mappers.lib.js
+++ b/app/lib/legacy-db-snake-case-mappers.lib.js
@@ -30,7 +30,7 @@ const { camelCase, knexIdentifierMappers, snakeCase } = require('objection/lib/u
  * it passes control to the out-of-the-box solution.
  *
  * @param {object} opt - Object containing options used by
- *  {@link https://vincit.github.io/objection.js/api/objection/#knexsnakecasemappers|knexsnakecasemappers()}
+ * {@link https://vincit.github.io/objection.js/api/objection/#knexsnakecasemappers|knexsnakecasemappers()}
  *
  * @returns object containing Knex postProcessResponse() and wrapIdentifier() hooks
  */


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/125

We use skinny controllers that don't do much more than call a service and return a view. We have therefore decided that it is not necessary to add JSDoc comments to our controllers.

This PR will add an override to the linting rules so that JSDoc comments are not required for the controllers.