### PR TITLE
Add createdAt to Version history modifiers

### DIFF
--- a/app/models/charge-version.model.js
+++ b/app/models/charge-version.model.js
@@ -94,11 +94,15 @@ class ChargeVersionModel extends BaseModel {
   /**
    * Modifiers allow us to reuse logic in queries, eg. select the charge version, note, and/or all mod log records:
    *
+   * ```javascript
    * return ChargeVersionModel.query()
    *   .findById(chargeVersionId)
    *   .modify('history')
+   * ```
    *
    * See {@link https://vincit.github.io/objection.js/recipes/modifiers.html | Modifiers} for more details
+   *
+   * @returns {object}
    */
   static get modifiers () {
     return {
@@ -106,7 +110,10 @@ class ChargeVersionModel extends BaseModel {
       // at, and created by from the record, plus its note, change reason, and NALD mod logs (where they exist)
       history (query) {
         query
-          .select(['createdBy'])
+          .select([
+            'createdAt',
+            'createdBy'
+          ])
           .withGraphFetched('modLogs')
           .modifyGraph('modLogs', (builder) => {
             builder.select([

--- a/app/models/licence-version.model.js
+++ b/app/models/licence-version.model.js
@@ -58,11 +58,15 @@ class LicenceVersionModel extends BaseModel {
   /**
    * Modifiers allow us to reuse logic in queries, eg. select the licence version and all mod log records:
    *
+   * ```javascript
    * return LicenceVersionModel.query()
    *   .findById(licenceVersionId)
    *   .modify('history')
+   * ```
    *
    * See {@link https://vincit.github.io/objection.js/recipes/modifiers.html | Modifiers} for more details
+   *
+   * @returns {object}
    */
   static get modifiers () {
     return {
@@ -70,6 +74,7 @@ class LicenceVersionModel extends BaseModel {
       // at, created by, and notes from the record and its NALD mod logs (where they exist)
       history (query) {
         query
+          .select(['createdAt'])
           .withGraphFetched('modLogs')
           .modifyGraph('modLogs', (builder) => {
             builder.select([

--- a/app/models/return-version.model.js
+++ b/app/models/return-version.model.js
@@ -71,6 +71,12 @@ class ReturnVersionModel extends BaseModel {
       // at, created by, and notes from the record, its user, and its NALD mod logs (where they exist)
       history (query) {
         query
+          .select([
+            'createdAt',
+            'createdBy',
+            'notes',
+            'reason'
+          ])
           .withGraphFetched('modLogs')
           .modifyGraph('modLogs', (builder) => {
             builder.select([

--- a/test/services/return-requirements/fetch-return-version.service.test.js
+++ b/test/services/return-requirements/fetch-return-version.service.test.js
@@ -37,6 +37,7 @@ describe('Return Requirements - Fetch Return Version service', () => {
 
       expect(result).to.equal({
         createdAt: returnVersion.createdAt,
+        createdBy: user.id,
         id: returnVersion.id,
         multipleUpload: false,
         notes: null,


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4566

> Part of the work to display NALD mod log records as history in WRLS

We recently added a new `history()` modifier to the charge, licence, and return version models that allows us to pull through the mod log and, in some cases, user details when querying for a record. We then call `$` instance methods to determine who created a record or what the reason was.

We're using it in [Build new licence history page](https://github.com/DEFRA/water-abstraction-system/pull/1182), but that change has highlighted that to make `$createdAt()` work, we have to ensure we include `createdAt` in the parent query's `select()`.

This should be dealt with in the `history()` modifier. This change makes it so!