### PR TITLE
Fix return version tests

### DIFF
--- a/test/models/return-version.model.test.js
+++ b/test/models/return-version.model.test.js
@@ -8,7 +8,7 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const { randomInteger } = require('../support/general.js')
+const { randomInteger, randomRegionCode } = require('../support/general.js')
 const LicenceHelper = require('../support/helpers/licence.helper.js')
 const LicenceModel = require('../../app/models/licence.model.js')
 const ModLogHelper = require('../support/helpers/mod-log.helper.js')
@@ -198,7 +198,7 @@ describe('Return Version model', () => {
 
     describe('when a return version has mod log history', () => {
       beforeEach(async () => {
-        const regionCode = randomInteger(1, 9)
+        const regionCode = randomRegionCode()
         const firstNaldId = randomInteger(100, 99998)
 
         await ModLogHelper.add({
@@ -279,7 +279,11 @@ describe('Return Version model', () => {
 
       describe('and has mod log history', () => {
         beforeEach(async () => {
-          const regionCode = randomInteger(1, 9)
+          // The externalId combines the region code and first nald id.
+          // The region code should be between 1 and 9.
+          // Due to unique constraint on the external id we need to increase the region code so tests do not create the
+          // same external id
+          const regionCode = randomRegionCode()
           const firstNaldId = randomInteger(100, 99998)
 
           await ModLogHelper.add({ externalId: `${regionCode}:${firstNaldId}`, returnVersionId, userId: 'FIRST' })
@@ -343,7 +347,7 @@ describe('Return Version model', () => {
 
         describe('and none of the mod log history has notes', () => {
           beforeEach(async () => {
-            const regionCode = randomInteger(1, 9)
+            const regionCode = randomRegionCode()
             const firstNaldId = randomInteger(100, 99998)
 
             await ModLogHelper.add({
@@ -366,7 +370,7 @@ describe('Return Version model', () => {
 
         describe('and some of the mod log history has notes', () => {
           beforeEach(async () => {
-            const regionCode = randomInteger(1, 9)
+            const regionCode = randomRegionCode()
             const firstNaldId = randomInteger(100, 99998)
 
             await ModLogHelper.add({
@@ -394,7 +398,7 @@ describe('Return Version model', () => {
 
             returnVersionId = id
 
-            const regionCode = randomInteger(1, 9)
+            const regionCode = randomRegionCode()
             const firstNaldId = randomInteger(100, 99998)
 
             await ModLogHelper.add({
@@ -462,7 +466,7 @@ describe('Return Version model', () => {
 
         describe('but the mod log history has no reason description recorded in the first entry', () => {
           beforeEach(async () => {
-            const regionCode = randomInteger(1, 9)
+            const regionCode = randomRegionCode()
             const firstNaldId = randomInteger(100, 99998)
 
             await ModLogHelper.add({
@@ -484,7 +488,7 @@ describe('Return Version model', () => {
 
         describe('and the mod log history has a reason description recorded in the first entry', () => {
           beforeEach(async () => {
-            const regionCode = randomInteger(1, 9)
+            const regionCode = randomRegionCode()
             const firstNaldId = randomInteger(100, 99998)
 
             await ModLogHelper.add({

--- a/test/models/return-version.model.test.js
+++ b/test/models/return-version.model.test.js
@@ -279,10 +279,6 @@ describe('Return Version model', () => {
 
       describe('and has mod log history', () => {
         beforeEach(async () => {
-          // The externalId combines the region code and first nald id.
-          // The region code should be between 1 and 9.
-          // Due to unique constraint on the external id we need to increase the region code so tests do not create the
-          // same external id
           const regionCode = randomRegionCode()
           const firstNaldId = randomInteger(100, 99998)
 

--- a/test/support/general.js
+++ b/test/support/general.js
@@ -113,6 +113,6 @@ function randomRegionCode () {
 module.exports = {
   postRequestOptions,
   randomInteger,
-  selectRandomEntry,
-  randomRegionCode
+  randomRegionCode,
+  selectRandomEntry
 }

--- a/test/support/general.js
+++ b/test/support/general.js
@@ -95,8 +95,24 @@ function selectRandomEntry (data) {
   return data[randomIndex]
 }
 
+/**
+ * Generates a random region code
+ *
+ * Region codes should be between 1 and 9 based on the fixed region reference data.
+ *
+ * We see issues with this small range when tables have unique constraints when building external id's.
+ *
+ * This function is here to encapsulate this issue and remove any need to explain the issue else where in the tests.
+ *
+ * @returns a random number
+ */
+function randomRegionCode () {
+  return randomInteger(1, 999999)
+}
+
 module.exports = {
   postRequestOptions,
   randomInteger,
-  selectRandomEntry
+  selectRandomEntry,
+  randomRegionCode
 }

--- a/test/support/helpers/mod-log.helper.js
+++ b/test/support/helpers/mod-log.helper.js
@@ -5,7 +5,7 @@
  */
 
 const ModLogModel = require('../../../app/models/mod-log.model.js')
-const { randomInteger } = require('../general.js')
+const { randomInteger, randomRegionCode } = require('../general.js')
 const { generateLicenceRef } = require('./licence.helper.js')
 
 /**
@@ -44,7 +44,7 @@ function add (data = {}) {
  * @returns {object} - Returns the set defaults with the override data spread
  */
 function defaults (data = {}) {
-  const regionCode = randomInteger(1, 9)
+  const regionCode = randomRegionCode()
 
   const defaults = {
     externalId: generateRegionNaldPatternExternalId(regionCode),
@@ -63,6 +63,10 @@ function defaults (data = {}) {
   }
 }
 
+/**
+ *
+ * @param regionCode
+ */
 function generateRegionNaldPatternExternalId (regionCode = null) {
   const regionCodeToUse = regionCode ?? randomInteger(1, 9)
 

--- a/test/support/helpers/mod-log.helper.js
+++ b/test/support/helpers/mod-log.helper.js
@@ -63,10 +63,6 @@ function defaults (data = {}) {
   }
 }
 
-/**
- *
- * @param regionCode
- */
 function generateRegionNaldPatternExternalId (regionCode = null) {
   const regionCodeToUse = regionCode ?? randomInteger(1, 9)
 

--- a/test/support/helpers/return-version.helper.js
+++ b/test/support/helpers/return-version.helper.js
@@ -5,7 +5,7 @@
  */
 
 const { generateUUID } = require('../../../app/lib/general.lib.js')
-const { randomInteger } = require('../general.js')
+const { randomInteger, randomRegionCode } = require('../general.js')
 const ReturnVersionModel = require('../../../app/models/return-version.model.js')
 
 /**
@@ -46,7 +46,7 @@ function defaults (data = {}) {
   const version = data.version ? data.version : 100
 
   const defaults = {
-    externalId: `9:${randomInteger(100, 99999)}:${version}`,
+    externalId: `${randomRegionCode()}:${randomInteger(100, 99999)}:${version}`,
     licenceId: generateUUID(),
     reason: 'new-licence',
     startDate: new Date('2022-04-01'),


### PR DESCRIPTION
As part of ongoing work to remove database cleans from the test suit we are getting intermittent tests failing mainly due to unique constraints where the range is too small to ensure uniqueness.

This change adds a generate random region code function explaining the issue.

The aim of this change is to encapsulate the issue and remove any need to explain the issue else where in the tests.