### PR TITLE
Fix user model tests

### DIFF
--- a/test/models/user.model.test.js
+++ b/test/models/user.model.test.js
@@ -76,14 +76,18 @@ describe('User model', () => {
           .findById(testRecord.id)
           .withGraphFetched('chargeVersionNotes')
 
+        const foundChargeVersionNoteOne = result.chargeVersionNotes
+          .find((chargeVersionNote) => { return chargeVersionNote.id === testChargeVersionNoteOne.id })
+        const foundChargeVersionNoteTwo = result.chargeVersionNotes
+          .find((chargeVersionNote) => { return chargeVersionNote.id === testChargeVersionNoteTwo.id })
+
         expect(result).to.be.instanceOf(UserModel)
         expect(result.id).to.equal(testRecord.id)
 
         expect(result.chargeVersionNotes).to.be.an.array()
-        expect(result.chargeVersionNotes).to.have.length(2)
-        expect(result.chargeVersionNotes[0]).to.be.an.instanceOf(ChargeVersionNoteModel)
-        expect(result.chargeVersionNotes[0]).to.equal(testChargeVersionNoteOne)
-        expect(result.chargeVersionNotes[1]).to.equal(testChargeVersionNoteTwo)
+        expect(foundChargeVersionNoteOne).to.be.an.instanceOf(ChargeVersionNoteModel)
+        expect(foundChargeVersionNoteOne).to.equal(testChargeVersionNoteOne)
+        expect(foundChargeVersionNoteTwo).to.equal(testChargeVersionNoteTwo)
       })
     })
 


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/124

As part of ongoing work to remove database cleans from the test suit we are getting intermittent tests failing. In this case we are seeing tests interfering with each other when they use the user id's form the ref data.

As these are fixed (seeded) there maybe some cross over in tests. So we update the tests to find the individual elements it has created and asserts against that, rather than length of an array or position of the element in the array.