### PR TITLE
Do not display draft return versions in set up

### DIFF
--- a/app/services/licences/fetch-return-versions.service.js
+++ b/app/services/licences/fetch-return-versions.service.js
@@ -28,6 +28,7 @@ async function _fetch (licenceId) {
       'reason'
     ])
     .where('licenceId', licenceId)
+    .whereNot('status', 'draft')
     .orderBy([
       { column: 'startDate', order: 'desc' },
       { column: 'version', order: 'desc' }

--- a/test/services/licences/fetch-return-versions.service.test.js
+++ b/test/services/licences/fetch-return-versions.service.test.js
@@ -24,12 +24,17 @@ describe('Fetch Return Versions service', () => {
 
   describe('when the licence has return versions data', () => {
     beforeEach(async () => {
-      // NOTE: We add 2, both with the same start date to ensure the order that they are returned is as expected
+      // NOTE: We add these 2, both with the same start date to ensure the order that they are returned as expected
       supersededReturnVersion = await ReturnVersionHelper.add({
         startDate, status: 'superseded', version: 100
       })
       currentReturnVersion = await ReturnVersionHelper.add({
         licenceId: supersededReturnVersion.licenceId, startDate, status: 'current', version: 101
+      })
+
+      // We add this 3rd one with a status of draft to ensure it is not included
+      await ReturnVersionHelper.add({
+        licenceId: supersededReturnVersion.licenceId, startDate: new Date('2022-05-01'), status: 'draft', version: 102
       })
 
       currentReturnVersionModLog = await ModLogHelper.add({


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4407

> Part of the work to replace NALD for handling return requirements

When we [started displaying return versions](https://github.com/DEFRA/water-abstraction-system/pull/1054) in the view licence set up tab, we should have excluded those with a 'draft' status.

These have been imported from NALD but found to have no return requirements, which isn't valid in NALD.

Once the return requirements have gone live in WRLS, a decision will be made on what to do with them. Until then, we need to ensure they don't appear in this table.