### PR TITLE
Fix licence agreements recalculate link bug

### DIFF
--- a/app/presenters/licences/view-licence.presenter.js
+++ b/app/presenters/licences/view-licence.presenter.js
@@ -29,6 +29,8 @@ function go (licence, auth) {
 
   return {
     documentId: licenceDocumentHeader.id,
+    ends,
+    includeInPresrocBilling,
     licenceId: id,
     licenceName: _licenceName(licence),
     licenceRef,
@@ -37,9 +39,7 @@ function go (licence, auth) {
     primaryUser,
     roles: _roles(auth),
     warning: _warning(ends),
-    workflowWarning: _workflowWarning(workflows),
-    includeInPresrocBilling,
-    ends
+    workflowWarning: _workflowWarning(workflows)
   }
 }
 

--- a/app/presenters/licences/view-licence.presenter.js
+++ b/app/presenters/licences/view-licence.presenter.js
@@ -18,12 +18,14 @@ const { formatLongDate } = require('../base.presenter.js')
 function go (licence, auth) {
   const {
     id,
+    includeInPresrocBilling,
     licenceDocumentHeader,
     licenceRef,
     workflows
   } = licence
 
   const primaryUser = licence.$primaryUser()
+  const ends = licence.$ends()
 
   return {
     documentId: licenceDocumentHeader.id,
@@ -34,8 +36,10 @@ function go (licence, auth) {
     pageTitle: `Licence ${licenceRef}`,
     primaryUser,
     roles: _roles(auth),
-    warning: _warning(licence),
-    workflowWarning: _workflowWarning(workflows)
+    warning: _warning(ends),
+    workflowWarning: _workflowWarning(workflows),
+    includeInPresrocBilling,
+    ends
   }
 }
 
@@ -73,9 +77,8 @@ function _roles (auth) {
   })
 }
 
-function _warning (licence) {
+function _warning (ends) {
   const today = new Date()
-  const ends = licence.$ends()
 
   if (!ends || ends.date > today) {
     return null

--- a/test/presenters/licences/view-licence.presenter.test.js
+++ b/test/presenters/licences/view-licence.presenter.test.js
@@ -28,6 +28,8 @@ describe('View Licence presenter', () => {
 
       expect(result).to.equal({
         documentId: 'e8f491f0-0c60-4083-9d41-d2be69f17a1e',
+        ends: null,
+        includeInPresrocBilling: 'no',
         licenceId: 'f1288f6c-8503-4dc1-b114-75c408a14bd0',
         licenceName: 'Between two ferns',
         licenceRef: '01/123',

--- a/test/services/licences/view-licence.service.test.js
+++ b/test/services/licences/view-licence.service.test.js
@@ -42,6 +42,8 @@ describe('View Licence service', () => {
         activeNavBar: 'search',
         documentId: 'e8f491f0-0c60-4083-9d41-d2be69f17a1e',
         licenceId: 'f1288f6c-8503-4dc1-b114-75c408a14bd0',
+        ends: null,
+        includeInPresrocBilling: 'no',
         licenceName: 'Between two ferns',
         licenceRef: '01/123',
         notification: null,


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-system/pull/1291

During a recent bug fix for the view-licence presenter, we removed some data from the presenter that we thought was redundant to it. This data is needed, so this PR is adding it back in thus fixing some broken functionality that was created by removing it (mainly the recalculate bills link showing for a licence agreement).