### PR TITLE
Add relation mapping to `LicenceModel`

### DIFF
--- a/app/models/licence.model.js
+++ b/app/models/licence.model.js
@@ -64,6 +64,14 @@ class LicenceModel extends BaseModel {
           to: 'licenceGaugingStations.licenceId'
         }
       },
+      licenceSupplementaryYears: {
+        relation: Model.HasManyRelation,
+        modelClass: 'licence-supplementary-year.model',
+        join: {
+          from: 'licences.id',
+          to: 'licenceSupplementaryYears.licenceId'
+        }
+      },
       licenceVersions: {
         relation: Model.HasManyRelation,
         modelClass: 'licence-version.model',

--- a/test/models/licence.model.test.js
+++ b/test/models/licence.model.test.js
@@ -277,7 +277,7 @@ describe('Licence model', () => {
       })
     })
 
-    describe.only('when linking to licence supplementary years', () => {
+    describe('when linking to licence supplementary years', () => {
       let testLicenceSupplementaryYears
 
       beforeEach(async () => {

--- a/test/models/licence.model.test.js
+++ b/test/models/licence.model.test.js
@@ -28,6 +28,8 @@ const LicenceEntityRoleHelper = require('../support/helpers/licence-entity-role.
 const LicenceGaugingStationHelper = require('../support/helpers/licence-gauging-station.helper.js')
 const LicenceGaugingStationModel = require('../../app/models/licence-gauging-station.model.js')
 const LicenceRoleHelper = require('../support/helpers/licence-role.helper.js')
+const LicenceSupplementaryYearHelper = require('../support/helpers/licence-supplementary-year.helper.js')
+const LicenceSupplementaryYearModel = require('../../app/models/licence-supplementary-year.model.js')
 const LicenceVersionHelper = require('../support/helpers/licence-version.helper.js')
 const LicenceVersionModel = require('../../app/models/licence-version.model.js')
 const ModLogHelper = require('../support/helpers/mod-log.helper.js')
@@ -272,6 +274,42 @@ describe('Licence model', () => {
         expect(result.licenceGaugingStations[0]).to.be.an.instanceOf(LicenceGaugingStationModel)
         expect(result.licenceGaugingStations).to.include(testLicenceGaugingStations[0])
         expect(result.licenceGaugingStations).to.include(testLicenceGaugingStations[1])
+      })
+    })
+
+    describe.only('when linking to licence supplementary years', () => {
+      let testLicenceSupplementaryYears
+
+      beforeEach(async () => {
+        testRecord = await LicenceHelper.add()
+
+        testLicenceSupplementaryYears = []
+        for (let i = 0; i < 2; i++) {
+          const licenceSupplementaryYear = await LicenceSupplementaryYearHelper.add({ licenceId: testRecord.id })
+
+          testLicenceSupplementaryYears.push(licenceSupplementaryYear)
+        }
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await LicenceModel.query()
+          .innerJoinRelated('licenceSupplementaryYears')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the licence supplementary years', async () => {
+        const result = await LicenceModel.query()
+          .findById(testRecord.id)
+          .withGraphFetched('licenceSupplementaryYears')
+
+        expect(result).to.be.instanceOf(LicenceModel)
+        expect(result.id).to.equal(testRecord.id)
+
+        expect(result.licenceSupplementaryYears).to.be.an.array()
+        expect(result.licenceSupplementaryYears[0]).to.be.an.instanceOf(LicenceSupplementaryYearModel)
+        expect(result.licenceSupplementaryYears).to.include(testLicenceSupplementaryYears[0])
+        expect(result.licenceSupplementaryYears).to.include(testLicenceSupplementaryYears[1])
       })
     })
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4587

In order to get the data required to display the two-part tariff supplementary banner, the query in `app/services/licences/fetch-licence.service.js` is going to be updated to include data from the `licence_supplementary_years` table.

However, whilst there is currently a relation mapping to the 'LicenceModel' from the `LicenceSupplementaryYearModel`. There is no relation mapping to the `LicenceSupplementaryYearModel` from the `LicenceModel`. This mapping will be added in this PR.