### PR TITLE
Update Banners to incorporate 2PT Supplementary Bills

### DIFF
--- a/app/presenters/licences/view-licence.presenter.js
+++ b/app/presenters/licences/view-licence.presenter.js
@@ -58,18 +58,7 @@ function _notification (licence) {
   const baseMessage = 'This licence has been marked for the next '
 
   if (licenceSupplementaryYears.length > 0) {
-    if (includeInPresrocBilling === 'yes' && includeInSrocBilling === true) {
-      return baseMessage + 'two-part tariff supplementary bill run and supplementary bill runs for the current and old charge schemes.'
-    }
-    if (includeInPresrocBilling === 'yes') {
-      return baseMessage + 'two-part tariff supplementary bill run and the supplementary bill run for the old charge scheme.'
-    }
-
-    if (includeInSrocBilling === true) {
-      return baseMessage + 'two-part tariff supplementary bill run and the supplementary bill run.'
-    }
-
-    return baseMessage + 'two-part tariff supplementary bill run.'
+    return _tptNotification(baseMessage, includeInPresrocBilling, includeInSrocBilling)
   }
 
   if (includeInPresrocBilling === 'yes' && includeInSrocBilling === true) {
@@ -90,6 +79,21 @@ function _roles (auth) {
   return auth.credentials.roles.map((role) => {
     return role.role
   })
+}
+
+function _tptNotification (baseMessage, includeInPresrocBilling, includeInSrocBilling) {
+  if (includeInPresrocBilling === 'yes' && includeInSrocBilling === true) {
+    return baseMessage + 'two-part tariff supplementary bill run and supplementary bill runs for the current and old charge schemes.'
+  }
+  if (includeInPresrocBilling === 'yes') {
+    return baseMessage + 'two-part tariff supplementary bill run and the supplementary bill run for the old charge scheme.'
+  }
+
+  if (includeInSrocBilling === true) {
+    return baseMessage + 'two-part tariff supplementary bill run and the supplementary bill run.'
+  }
+
+  return baseMessage + 'two-part tariff supplementary bill run.'
 }
 
 function _warning (ends) {

--- a/app/presenters/licences/view-licence.presenter.js
+++ b/app/presenters/licences/view-licence.presenter.js
@@ -54,18 +54,33 @@ function _licenceName (licence) {
 }
 
 function _notification (licence) {
-  const { includeInPresrocBilling, includeInSrocBilling } = licence
-  const baseMessage = 'This licence has been marked for the next supplementary bill run'
+  const { includeInPresrocBilling, includeInSrocBilling, licenceSupplementaryYears } = licence
+  const baseMessage = 'This licence has been marked for the next '
+
+  if (licenceSupplementaryYears.length > 0) {
+    if (includeInPresrocBilling === 'yes' && includeInSrocBilling === true) {
+      return baseMessage + 'two-part tariff supplementary bill run and supplementary bill runs for the current and old charge schemes.'
+    }
+    if (includeInPresrocBilling === 'yes') {
+      return baseMessage + 'two-part tariff supplementary bill run and the supplementary bill run for the old charge scheme.'
+    }
+
+    if (includeInSrocBilling === true) {
+      return baseMessage + 'two-part tariff supplementary bill run and the supplementary bill run.'
+    }
+
+    return baseMessage + 'two-part tariff supplementary bill run.'
+  }
 
   if (includeInPresrocBilling === 'yes' && includeInSrocBilling === true) {
-    return baseMessage + 's for the current and old charge schemes.'
+    return baseMessage + 'supplementary bill runs for the current and old charge schemes.'
   }
   if (includeInPresrocBilling === 'yes') {
-    return baseMessage + ' for the old charge scheme.'
+    return baseMessage + 'supplementary bill run for the old charge scheme.'
   }
 
   if (includeInSrocBilling === true) {
-    return baseMessage + '.'
+    return baseMessage + 'supplementary bill run.'
   }
 
   return null

--- a/app/services/licences/fetch-licence.service.js
+++ b/app/services/licences/fetch-licence.service.js
@@ -35,6 +35,17 @@ async function _fetch (licenceId) {
     ])
     .modify('licenceName')
     .modify('primaryUser')
+    .withGraphFetched('licenceSupplementaryYears')
+    .modifyGraph('licenceSupplementaryYears', (builder) => {
+      builder
+        .select([
+          'id',
+          'licenceId',
+          'billRunId',
+          'financialYearEnd',
+          'twoPartTariff'
+        ])
+    })
     .withGraphFetched('workflows')
     .modifyGraph('workflows', (builder) => {
       builder

--- a/app/services/licences/fetch-licence.service.js
+++ b/app/services/licences/fetch-licence.service.js
@@ -39,12 +39,9 @@ async function _fetch (licenceId) {
     .modifyGraph('licenceSupplementaryYears', (builder) => {
       builder
         .select([
-          'id',
-          'licenceId',
-          'billRunId',
-          'financialYearEnd',
-          'twoPartTariff'
+          'id'
         ])
+        .where('twoPartTariff', true)
     })
     .withGraphFetched('workflows')
     .modifyGraph('workflows', (builder) => {

--- a/test/presenters/licences/view-licence.presenter.test.js
+++ b/test/presenters/licences/view-licence.presenter.test.js
@@ -69,7 +69,7 @@ describe('View Licence presenter', () => {
   })
 
   describe('the "notification" property', () => {
-    describe('when the licence has NOT been flagged for either supplementary bill run', () => {
+    describe('when the licence has NOT been flagged for any supplementary bill runs', () => {
       it('returns "null"', () => {
         const result = ViewLicencePresenter.go(licence, auth)
 
@@ -111,6 +111,58 @@ describe('View Licence presenter', () => {
         const result = ViewLicencePresenter.go(licence, auth)
 
         expect(result.notification).to.equal('This licence has been marked for the next supplementary bill runs for the current and old charge schemes.')
+      })
+    })
+
+    describe('when the licence has been flagged just for the next TPT supplementary bill run', () => {
+      beforeEach(() => {
+        licence.licenceSupplementaryYears.push({ id: '1636ab31-3b79-4fec-9e51-be89835e9981' })
+      })
+
+      it('returns a notification just for TPT supplementary', () => {
+        const result = ViewLicencePresenter.go(licence, auth)
+
+        expect(result.notification).to.equal('This licence has been marked for the next two-part tariff supplementary bill run.')
+      })
+    })
+
+    describe('when the licence has been flagged for the next TPT & PRESROC supplementary bill runs', () => {
+      beforeEach(() => {
+        licence.licenceSupplementaryYears.push({ id: '1636ab31-3b79-4fec-9e51-be89835e9981' })
+        licence.includeInPresrocBilling = 'yes'
+      })
+
+      it('returns a notification for TPT & PRESROC supplementary', () => {
+        const result = ViewLicencePresenter.go(licence, auth)
+
+        expect(result.notification).to.equal('This licence has been marked for the next two-part tariff supplementary bill run and the supplementary bill run for the old charge scheme.')
+      })
+    })
+
+    describe('when the licence has been flagged for the next TPT & SROC supplementary bill runs', () => {
+      beforeEach(() => {
+        licence.licenceSupplementaryYears.push({ id: '1636ab31-3b79-4fec-9e51-be89835e9981' })
+        licence.includeInSrocBilling = true
+      })
+
+      it('returns a notification for TPT & SROC supplementary', () => {
+        const result = ViewLicencePresenter.go(licence, auth)
+
+        expect(result.notification).to.equal('This licence has been marked for the next two-part tariff supplementary bill run and the supplementary bill run.')
+      })
+    })
+
+    describe('when the licence has been flagged for the next TPT, PRESROC & SROC supplementary bill runs', () => {
+      beforeEach(() => {
+        licence.licenceSupplementaryYears.push({ id: '1636ab31-3b79-4fec-9e51-be89835e9981' })
+        licence.includeInPresrocBilling = 'yes'
+        licence.includeInSrocBilling = true
+      })
+
+      it('returns a notification for TPT, PRESROC & SROC supplementary', () => {
+        const result = ViewLicencePresenter.go(licence, auth)
+
+        expect(result.notification).to.equal('This licence has been marked for the next two-part tariff supplementary bill run and supplementary bill runs for the current and old charge schemes.')
       })
     })
   })
@@ -280,6 +332,7 @@ function _licence () {
         }
       }
     },
+    licenceSupplementaryYears: [],
     workflows: [{ id: 'b6f44c94-25e4-4ca8-a7db-364534157ba7', status: 'to_setup' }]
   })
 

--- a/test/services/licences/fetch-licence.service.test.js
+++ b/test/services/licences/fetch-licence.service.test.js
@@ -10,6 +10,7 @@ const { expect } = Code
 // Test helpers
 const LicenceHelper = require('../../support/helpers/licence.helper.js')
 const LicenceModel = require('../../../app/models/licence.model.js')
+const licenceSupplementaryYearHelper = require('../../support/helpers/licence-supplementary-year.helper.js')
 const WorkflowHelper = require('../../support/helpers/workflow.helper.js')
 
 // Thing under test
@@ -17,11 +18,19 @@ const FetchLicenceService = require('../../../app/services/licences/fetch-licenc
 
 describe('Fetch Licence service', () => {
   let licence
+  let licenceSupplementaryYearId
   let workflow
 
   describe('when there is a matching licence', () => {
     beforeEach(async () => {
       licence = await LicenceHelper.add()
+
+      const licenceSupplementaryYear = await licenceSupplementaryYearHelper.add({
+        licenceId: licence.id,
+        twoPartTariff: true
+      })
+
+      licenceSupplementaryYearId = licenceSupplementaryYear.id
 
       // We add two workflow records: one reflects that the licence is in workflow, so of that it previously was but
       // has been dealt with. We want to ensure these soft-deleted records are ignored so licences are not flagged
@@ -43,6 +52,9 @@ describe('Fetch Licence service', () => {
         revokedDate: null,
         lapsedDate: null,
         licenceDocumentHeader: null,
+        licenceSupplementaryYears: [{
+          id: licenceSupplementaryYearId
+        }],
         workflows: [{
           id: workflow.id,
           status: workflow.status

--- a/test/services/licences/view-licence.service.test.js
+++ b/test/services/licences/view-licence.service.test.js
@@ -114,6 +114,7 @@ function _licence () {
         }
       }
     },
+    licenceSupplementaryYears: [],
     workflows: [{ id: 'b6f44c94-25e4-4ca8-a7db-364534157ba7', status: 'to_setup' }]
   })
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4587

Now that we are introducing the new bill run type, we need to update the banner options shown on the other licence pages. 2PT Supplementary Billing will have its own banner which could be combined with the 2 existing banners at any point.

In this PR the new banners will be created and added to the view licence page.