### PR TITLE
Add missed ModLog and Points models to test loader

### DIFF
--- a/app/services/data/load/load.service.js
+++ b/app/services/data/load/load.service.js
@@ -42,6 +42,7 @@ const LicenceVersionPurposeHelper = require('../../../../test/support/helpers/li
 const LicenceVersionPurposePointHelper = require('../../../../test/support/helpers/licence-version-purpose-point.helper.js')
 const LicenceVersionHelper = require('../../../../test/support/helpers/licence-version.helper.js')
 const LicenceHelper = require('../../../../test/support/helpers/licence.helper.js')
+const ModLogHelper = require('../../../../test/support/helpers/mod-log.helper.js')
 const PermitLicenceHelper = require('../../../../test/support/helpers/permit-licence.helper.js')
 const ReturnLogHelper = require('../../../../test/support/helpers/return-log.helper.js')
 const ReturnRequirementPointHelper = require('../../../../test/support/helpers/return-requirement-point.helper.js')
@@ -101,6 +102,7 @@ const LOAD_HELPERS = {
   licenceVersionPurposePoints: { helper: LicenceVersionPurposePointHelper, test: false },
   licenceVersions: { helper: LicenceVersionHelper, test: true, legacy: { schema: 'water', table: 'licence_versions', id: 'licence_version_id' } },
   licences: { helper: LicenceHelper, test: true, legacy: { schema: 'water', table: 'licences', id: 'licence_id' } },
+  modLogs: { helper: ModLogHelper, test: false },
   permitLicences: { helper: PermitLicenceHelper, test: false },
   returnLogs: { helper: ReturnLogHelper, test: true, legacy: { schema: 'returns', table: 'returns', id: 'return_id' } },
   returnRequirementPoints: { helper: ReturnRequirementPointHelper, test: false },

--- a/app/services/data/load/load.service.js
+++ b/app/services/data/load/load.service.js
@@ -39,6 +39,7 @@ const LicenceRoleHelper = require('../../../../test/support/helpers/licence-role
 const LicenceSupplementaryYearHelper = require('../../../../test/support/helpers/licence-supplementary-year.helper.js')
 const LicenceVersionPurposeConditionHelper = require('../../../../test/support/helpers/licence-version-purpose-condition.helper.js')
 const LicenceVersionPurposeHelper = require('../../../../test/support/helpers/licence-version-purpose.helper.js')
+const LicenceVersionPurposePointHelper = require('../../../../test/support/helpers/licence-version-purpose-point.helper.js')
 const LicenceVersionHelper = require('../../../../test/support/helpers/licence-version.helper.js')
 const LicenceHelper = require('../../../../test/support/helpers/licence.helper.js')
 const PermitLicenceHelper = require('../../../../test/support/helpers/permit-licence.helper.js')
@@ -97,6 +98,7 @@ const LOAD_HELPERS = {
   LicenceSupplementaryYears: { helper: LicenceSupplementaryYearHelper, test: false },
   licenceVersionPurposeConditions: { helper: LicenceVersionPurposeConditionHelper, test: false },
   licenceVersionPurposes: { helper: LicenceVersionPurposeHelper, test: true, legacy: { schema: 'water', table: 'licence_version_purposes', id: 'licence_version_purpose_id' } },
+  licenceVersionPurposePoints: { helper: LicenceVersionPurposePointHelper, test: false },
   licenceVersions: { helper: LicenceVersionHelper, test: true, legacy: { schema: 'water', table: 'licence_versions', id: 'licence_version_id' } },
   licences: { helper: LicenceHelper, test: true, legacy: { schema: 'water', table: 'licences', id: 'licence_id' } },
   permitLicences: { helper: PermitLicenceHelper, test: false },

--- a/app/services/data/tear-down/water-schema.service.js
+++ b/app/services/data/tear-down/water-schema.service.js
@@ -228,6 +228,18 @@ async function _deleteAllTestData () {
 
   DELETE
   FROM
+    "water"."licence_version_purpose_points" AS "lvpp"
+      USING "water"."licence_version_purposes" AS "lvp",
+    "water"."licence_versions" AS "lv",
+    "water"."licences" AS "l"
+  WHERE
+    "l"."is_test" = TRUE
+    AND "lvpp"."licence_version_purpose_id" = "lvp"."licence_version_purpose_id"
+    AND "lvp"."licence_version_id" = "lv"."licence_version_id"
+    AND "lv"."licence_id" = "l"."licence_id";
+
+  DELETE
+  FROM
     "water"."licence_version_purposes"
   WHERE
     "is_test" = TRUE;

--- a/app/services/data/tear-down/water-schema.service.js
+++ b/app/services/data/tear-down/water-schema.service.js
@@ -24,6 +24,10 @@ async function _deleteAllTestData () {
   ALTER TABLE water.charge_versions DISABLE TRIGGER ALL;
   ALTER TABLE water.charge_version_workflows DISABLE TRIGGER ALL;
   ALTER TABLE water.licence_agreements DISABLE TRIGGER ALL;
+  ALTER TABLE water.licences DISABLE TRIGGER ALL;
+  ALTER TABLE water.licence_versions DISABLE TRIGGER ALL;
+  ALTER TABLE water.licence_version_purposes DISABLE TRIGGER ALL;
+  ALTER TABLE water.licence_version_purpose_conditions DISABLE TRIGGER ALL;
   ALTER TABLE water.return_requirement_purposes DISABLE TRIGGER ALL;
   ALTER TABLE water.return_requirement_points DISABLE TRIGGER ALL;
   ALTER TABLE water.return_requirements DISABLE TRIGGER ALL;
@@ -339,6 +343,10 @@ async function _deleteAllTestData () {
   ALTER TABLE water.charge_versions ENABLE TRIGGER ALL;
   ALTER TABLE water.charge_version_workflows ENABLE TRIGGER ALL;
   ALTER TABLE water.licence_agreements ENABLE TRIGGER ALL;
+  ALTER TABLE water.licences ENABLE TRIGGER ALL;
+  ALTER TABLE water.licence_versions ENABLE TRIGGER ALL;
+  ALTER TABLE water.licence_version_purposes ENABLE TRIGGER ALL;
+  ALTER TABLE water.licence_version_purpose_conditions ENABLE TRIGGER ALL;
   ALTER TABLE water.return_requirement_purposes ENABLE TRIGGER ALL;
   ALTER TABLE water.return_requirement_points ENABLE TRIGGER ALL;
   ALTER TABLE water.return_requirements ENABLE TRIGGER ALL;

--- a/app/services/data/tear-down/water-schema.service.js
+++ b/app/services/data/tear-down/water-schema.service.js
@@ -200,6 +200,16 @@ async function _deleteAllTestData () {
 
   DELETE
   FROM
+    "water"."mod_logs" AS "ml"
+      USING "water"."return_versions" AS "rv",
+    "water"."licences" AS "l"
+  WHERE
+    "l"."is_test" = TRUE
+    AND "ml"."return_version_id" = "rv"."return_version_id"
+    AND "rv"."licence_id" = "l"."licence_id";
+
+  DELETE
+  FROM
     "water"."return_versions" AS "rv"
       USING "water"."licences" AS "l"
   WHERE
@@ -243,6 +253,24 @@ async function _deleteAllTestData () {
     "water"."licence_version_purposes"
   WHERE
     "is_test" = TRUE;
+
+  DELETE
+  FROM
+    "water"."mod_logs" AS "ml"
+      USING "water"."licence_versions" AS "lv",
+    "water"."licences" AS "l"
+  WHERE
+    "l"."is_test" = TRUE
+    AND "ml"."licence_version_id" = "lv"."licence_version_id"
+    AND "lv"."licence_id" = "l"."licence_id";
+
+  DELETE
+  FROM
+    "water"."mod_logs" AS "ml"
+    USING "water"."licences" AS "l"
+  WHERE
+    "l"."is_test" = TRUE
+    AND "ml"."licence_id" = "l"."licence_id";
 
   DELETE
   FROM


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4645
https://eaflood.atlassian.net/browse/WATER-4635

We recently added two new models connected to two new tables to support managing return requirements and viewing licence history.

- [Add Licence Version Purpose Point model](https://github.com/DEFRA/water-abstraction-system/pull/1288)
- [Add Mod Log model](https://github.com/DEFRA/water-abstraction-system/pull/1264)

When we did, though, we forgot to make them available to the acceptance test loader!

Plus, as we are adding them to the test loader, we also need to ensure they are included in the teardown.