### PR TITLE
Fix incorrect edit link for void returns

### DIFF
--- a/app/presenters/licences/view-licence-returns.presenter.js
+++ b/app/presenters/licences/view-licence-returns.presenter.js
@@ -81,6 +81,10 @@ function _status (returnLog) {
   // Work out if the return is overdue (status is still 'due' and it is past the due date)
   const today = new Date()
 
+  // The due date held in the record is date-only. If we compared it against 'today' without this step any return due
+  // 'today' would be flagged as overdue when it is still due (just!)
+  today.setHours(0, 0, 0, 0)
+
   if (status === 'due' && dueDate < today) {
     return 'overdue'
   }

--- a/app/presenters/licences/view-licence-returns.presenter.js
+++ b/app/presenters/licences/view-licence-returns.presenter.js
@@ -27,7 +27,7 @@ function go (returnLogs, hasRequirements) {
 }
 
 function _link (status, returnLogId) {
-  if (status === 'completed') {
+  if (['completed', 'void'].includes(status)) {
     return `/returns/return?id=${returnLogId}`
   }
 

--- a/test/presenters/licences/view-licence-returns.presenter.test.js
+++ b/test/presenters/licences/view-licence-returns.presenter.test.js
@@ -92,10 +92,10 @@ describe('View Licence returns presenter', () => {
           returnLogs[1].status = 'void'
         })
 
-        it('returns a link to the edit return log page', () => {
+        it('returns a link to the view return log page', () => {
           const result = ViewLicenceReturnsPresenter.go(returnLogs, hasRequirements)
 
-          expect(result.returns[1].link).to.equal('/return/internal?returnId=v1:1:01/123:10046820:2020-01-02:2020-02-01')
+          expect(result.returns[1].link).to.equal('/returns/return?id=v1:1:01/123:10046820:2020-01-02:2020-02-01')
         })
       })
     })

--- a/test/presenters/licences/view-licence-returns.presenter.test.js
+++ b/test/presenters/licences/view-licence-returns.presenter.test.js
@@ -49,6 +49,135 @@ describe('View Licence returns presenter', () => {
         ]
       })
     })
+
+    describe('the "dates" property', () => {
+      it('returns the start and end date in long format (2 January 2020 to 1 February 2020)', () => {
+        const result = ViewLicenceReturnsPresenter.go(returnLogs, hasRequirements)
+
+        expect(result.returns[0].dates).to.equal('2 January 2020 to 1 February 2020')
+      })
+    })
+
+    describe('the "link" property', () => {
+      describe('when the return log has a status of "completed"', () => {
+        it('returns a link to the view return log page', () => {
+          const result = ViewLicenceReturnsPresenter.go(returnLogs, hasRequirements)
+
+          expect(result.returns[0].link).to.equal('/returns/return?id=v1:1:01/123:10046821:2020-01-02:2020-02-01')
+        })
+      })
+
+      describe('when the return log has a status of "due"', () => {
+        it('returns a link to the edit return log page', () => {
+          const result = ViewLicenceReturnsPresenter.go(returnLogs, hasRequirements)
+
+          expect(result.returns[1].link).to.equal('/return/internal?returnId=v1:1:01/123:10046820:2020-01-02:2020-02-01')
+        })
+      })
+
+      describe('when the return log has a status of "received"', () => {
+        beforeEach(() => {
+          returnLogs[1].status = 'received'
+        })
+
+        it('returns a link to the edit return log page', () => {
+          const result = ViewLicenceReturnsPresenter.go(returnLogs, hasRequirements)
+
+          expect(result.returns[1].link).to.equal('/return/internal?returnId=v1:1:01/123:10046820:2020-01-02:2020-02-01')
+        })
+      })
+
+      describe('when the return log has a status of "void"', () => {
+        beforeEach(() => {
+          returnLogs[1].status = 'void'
+        })
+
+        it('returns a link to the edit return log page', () => {
+          const result = ViewLicenceReturnsPresenter.go(returnLogs, hasRequirements)
+
+          expect(result.returns[1].link).to.equal('/return/internal?returnId=v1:1:01/123:10046820:2020-01-02:2020-02-01')
+        })
+      })
+    })
+
+    describe('the "purpose" property', () => {
+      describe("when the first purpose in the return log's metadata does not have an alias", () => {
+        it("returns the purpose's tertiary description", () => {
+          const result = ViewLicenceReturnsPresenter.go(returnLogs, hasRequirements)
+
+          expect(result.returns[1].purpose).to.equal('SPRAY IRRIGATION')
+        })
+      })
+
+      describe("when the first purpose in the return log's metadata is has an alias", () => {
+        beforeEach(() => {
+          returnLogs[1].metadata.purposes[0].alias = 'Spray irrigation - top field only'
+        })
+
+        it("returns the purpose's alias", () => {
+          const result = ViewLicenceReturnsPresenter.go(returnLogs, hasRequirements)
+
+          expect(result.returns[1].purpose).to.equal('Spray irrigation - top field only')
+        })
+      })
+    })
+
+    describe('the "status" property', () => {
+      describe('when the return log has a status of "completed"', () => {
+        it('returns "complete"', () => {
+          const result = ViewLicenceReturnsPresenter.go(returnLogs, hasRequirements)
+
+          expect(result.returns[0].status).to.equal('complete')
+        })
+      })
+
+      describe('when the return log has a status of "due"', () => {
+        describe('and the due date is less than today', () => {
+          it('returns "overdue"', () => {
+            const result = ViewLicenceReturnsPresenter.go(returnLogs, hasRequirements)
+
+            expect(result.returns[1].status).to.equal('overdue')
+          })
+        })
+
+        describe('and the due date is equal to or greater than today', () => {
+          beforeEach(() => {
+            returnLogs[1].dueDate = new Date()
+            returnLogs[1].dueDate.setHours(0, 0, 0, 0)
+          })
+
+          it('returns "due"', () => {
+            const result = ViewLicenceReturnsPresenter.go(returnLogs, hasRequirements)
+
+            expect(result.returns[1].status).to.equal('due')
+          })
+        })
+      })
+
+      describe('when the return log has a status of "received"', () => {
+        beforeEach(() => {
+          returnLogs[1].status = 'received'
+        })
+
+        it('returns "received"', () => {
+          const result = ViewLicenceReturnsPresenter.go(returnLogs, hasRequirements)
+
+          expect(result.returns[1].status).to.equal('received')
+        })
+      })
+
+      describe('when the return log has a status of "void"', () => {
+        beforeEach(() => {
+          returnLogs[1].status = 'void'
+        })
+
+        it('returns "void"', () => {
+          const result = ViewLicenceReturnsPresenter.go(returnLogs, hasRequirements)
+
+          expect(result.returns[1].status).to.equal('void')
+        })
+      })
+    })
   })
 
   describe('the "noReturnsMessage" property', () => {

--- a/test/presenters/licences/view-licence-returns.presenter.test.js
+++ b/test/presenters/licences/view-licence-returns.presenter.test.js
@@ -11,11 +11,85 @@ const { expect } = Code
 const ViewLicenceReturnsPresenter = require('../../../app/presenters/licences/view-licence-returns.presenter.js')
 
 describe('View Licence returns presenter', () => {
-  let returnsData
+  let returnLogs
   let hasRequirements
 
-  const returnItem = {
-    id: 'd5912c1d-3928-48e9-b2fc-e99a96d704a3',
+  beforeEach(() => {
+    hasRequirements = true
+    returnLogs = _returnLogs()
+  })
+
+  describe('when provided with returns data', () => {
+    it('correctly presents the data', () => {
+      const result = ViewLicenceReturnsPresenter.go(returnLogs, hasRequirements)
+
+      expect(result).to.equal({
+        noReturnsMessage: null,
+        returns: [
+          {
+            dates: '2 January 2020 to 1 February 2020',
+            description: 'empty description',
+            dueDate: '28 November 2012',
+            link: '/returns/return?id=v1:1:01/123:10046821:2020-01-02:2020-02-01',
+            purpose: 'SPRAY IRRIGATION',
+            reference: '10046821',
+            returnLogId: 'v1:1:01/123:10046821:2020-01-02:2020-02-01',
+            status: 'complete'
+          },
+          {
+            dates: '2 January 2020 to 1 February 2020',
+            description: 'empty description',
+            dueDate: '28 November 2012',
+            link: '/return/internal?returnId=v1:1:01/123:10046820:2020-01-02:2020-02-01',
+            purpose: 'SPRAY IRRIGATION',
+            reference: '10046820',
+            returnLogId: 'v1:1:01/123:10046820:2020-01-02:2020-02-01',
+            status: 'overdue'
+          }
+        ]
+      })
+    })
+  })
+
+  describe('the "noReturnsMessage" property', () => {
+    describe('when a licence has returns and requirements', () => {
+      it('returns null', () => {
+        const result = ViewLicenceReturnsPresenter.go(returnLogs, hasRequirements)
+
+        expect(result.noReturnsMessage).to.be.null()
+      })
+    })
+
+    describe('when a licence has NO requirements and NO returns', () => {
+      beforeEach(() => {
+        returnLogs = []
+        hasRequirements = false
+      })
+
+      it('returns the message "No requirements for returns have been set up for this licence."', () => {
+        const result = ViewLicenceReturnsPresenter.go(returnLogs, hasRequirements)
+
+        expect(result.noReturnsMessage).to.equal('No requirements for returns have been set up for this licence.')
+      })
+    })
+
+    describe('when a licence has requirements but NO returns', () => {
+      beforeEach(() => {
+        returnLogs = []
+      })
+
+      it('returns the message "No returns for this licence."', () => {
+        const result = ViewLicenceReturnsPresenter.go(returnLogs, hasRequirements)
+
+        expect(result.noReturnsMessage).to.equal('No returns for this licence.')
+      })
+    })
+  })
+})
+
+function _returnLogs () {
+  const returnLog = {
+    id: 'v1:1:01/123:10046821:2020-01-02:2020-02-01',
     dueDate: new Date('2012-11-28'),
     status: 'completed',
     startDate: new Date('2020/01/02'),
@@ -40,86 +114,16 @@ describe('View Licence returns presenter', () => {
       ],
       description: 'empty description'
     },
-    returnReference: '1068'
+    returnReference: '10046821'
   }
 
-  beforeEach(() => {
-    hasRequirements = true
-    returnsData = [
-      { ...returnItem },
-      {
-        ...returnItem,
-        id: '2fb6d1be-5d56-45de-a252-3c1e8a955991',
-        status: 'due',
-        returnReference: '1069'
-      }
-    ]
-  })
-
-  describe('when provided with returns data', () => {
-    it('correctly presents the data', () => {
-      const result = ViewLicenceReturnsPresenter.go(returnsData, hasRequirements)
-
-      expect(result).to.equal({
-        noReturnsMessage: null,
-        returns: [
-          {
-            dates: '2 January 2020 to 1 February 2020',
-            description: 'empty description',
-            dueDate: '28 November 2012',
-            link: '/returns/return?id=d5912c1d-3928-48e9-b2fc-e99a96d704a3',
-            purpose: 'SPRAY IRRIGATION',
-            reference: '1068',
-            returnLogId: 'd5912c1d-3928-48e9-b2fc-e99a96d704a3',
-            status: 'complete'
-          },
-          {
-            dates: '2 January 2020 to 1 February 2020',
-            description: 'empty description',
-            dueDate: '28 November 2012',
-            link: '/return/internal?returnId=2fb6d1be-5d56-45de-a252-3c1e8a955991',
-            purpose: 'SPRAY IRRIGATION',
-            reference: '1069',
-            returnLogId: '2fb6d1be-5d56-45de-a252-3c1e8a955991',
-            status: 'overdue'
-          }
-        ]
-      })
-    })
-  })
-
-  describe('the "noReturnsMessage" property', () => {
-    describe('when a licence has returns and requirements', () => {
-      it('returns null', () => {
-        const result = ViewLicenceReturnsPresenter.go(returnsData, hasRequirements)
-
-        expect(result.noReturnsMessage).to.be.null()
-      })
-    })
-
-    describe('when a licence has NO requirements and NO returns', () => {
-      beforeEach(() => {
-        returnsData = []
-        hasRequirements = false
-      })
-
-      it('returns the message "No requirements for returns have been set up for this licence."', () => {
-        const result = ViewLicenceReturnsPresenter.go(returnsData, hasRequirements)
-
-        expect(result.noReturnsMessage).to.equal('No requirements for returns have been set up for this licence.')
-      })
-    })
-
-    describe('when a licence has requirements but NO returns', () => {
-      beforeEach(() => {
-        returnsData = []
-      })
-
-      it('returns the message "No returns for this licence."', () => {
-        const result = ViewLicenceReturnsPresenter.go(returnsData, hasRequirements)
-
-        expect(result.noReturnsMessage).to.equal('No returns for this licence.')
-      })
-    })
-  })
-})
+  return [
+    { ...returnLog },
+    {
+      ...returnLog,
+      id: 'v1:1:01/123:10046820:2020-01-02:2020-02-01',
+      status: 'due',
+      returnReference: '10046820'
+    }
+  ]
+}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4661

Our users have noticed that we provide a link for `VOID` returns on the view licence page that takes them to the returns edit page. Users should not be able to edit a `VOID` return; unfortunately, there is nothing on the legacy edit page to stop this.

So, we need to fix the link to take users to view returns page, not edit.

---

While working on this, we also found that the status was showing return logs due 'today' incorrectly (they were showing as "overdue" when the status should be "due").