### PR TITLE
Fix import licence log silencer

### DIFF
--- a/app/services/plugins/hapi-pino-ignore-request.service.js
+++ b/app/services/plugins/hapi-pino-ignore-request.service.js
@@ -56,7 +56,7 @@
  * @returns {boolean} true if the request should be ignored, else false
  */
 function go (options, request) {
-  const staticPaths = ['/', '/import/licence', '/status', '/favicon.ico']
+  const staticPaths = ['/', '/import/licence/legacy', '/status', '/favicon.ico']
 
   // If request is a known path ignore it
   if (staticPaths.includes(request.path)) {

--- a/app/services/plugins/hapi-pino-ignore-request.service.js
+++ b/app/services/plugins/hapi-pino-ignore-request.service.js
@@ -48,9 +48,7 @@
  *
  * So, we also do not log any requests to `/assets/*`.
  *
- *
- *
- * @param {Object} _options - The options passed to the HapiPino plugin
+ * @param {object} options - The options passed to the HapiPino plugin
  * @param {request} request  - Hapi request object created internally for each incoming request
  *
  * @returns {boolean} true if the request should be ignored, else false

--- a/test/services/plugins/hapi-pino-ignore-request.service.test.js
+++ b/test/services/plugins/hapi-pino-ignore-request.service.test.js
@@ -27,9 +27,9 @@ describe('Hapi Pino Ignore Request service', () => {
     })
   })
 
-  describe('when the request is for "/import/licence"', () => {
+  describe('when the request is for "/import/licence/legacy"', () => {
     it('returns true', () => {
-      const result = HapiPinoIgnoreRequestService.go({ logAssetRequests: false }, { path: '/status' })
+      const result = HapiPinoIgnoreRequestService.go({ logAssetRequests: false }, { path: '/import/licence/legacy' })
 
       expect(result).to.be.true()
     })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4575

> Part of the work to replace the legacy licence import in readiness for ReSP

Argh! We've done it again! We made a change to [Ignore new /import/licence endpoint in logs](https://github.com/DEFRA/water-abstraction-system/pull/1275), so the logs became silent again instead of outputting 80K requests!

But then in [Import Licence versions](https://github.com/DEFRA/water-abstraction-system/pull/1195) we tweaked the route, and guess what we forgot to do! 😱🤦

This change updates the `HapiPinoIgnoreRequest` with the updated route.