### PR TITLE
Fix use of new points in setup ret. req. journey

### DIFF
--- a/app/presenters/return-requirements/check/returns-requirements.presenter.js
+++ b/app/presenters/return-requirements/check/returns-requirements.presenter.js
@@ -106,7 +106,7 @@ function _mapRequirement (requirement, index, licenceVersionPurposePoints) {
 function _mapPoints (requirementPoints, licenceVersionPurposePoints) {
   return requirementPoints.map((point) => {
     const matchedPoint = licenceVersionPurposePoints.find((licenceVersionPurposePoint) => {
-      return licenceVersionPurposePoint.naldPointId.toString() === point.toString()
+      return licenceVersionPurposePoint.naldPointId.toString() === point
     })
 
     return matchedPoint.$describe()

--- a/app/presenters/return-requirements/check/returns-requirements.presenter.js
+++ b/app/presenters/return-requirements/check/returns-requirements.presenter.js
@@ -103,8 +103,8 @@ function _mapRequirement (requirement, index, licenceVersionPurposePoints) {
   }
 }
 
-function _mapPoints (requirementPoints, licenceVersionPurposePoints) {
-  return requirementPoints.map((point) => {
+function _mapPoints (points, licenceVersionPurposePoints) {
+  return points.map((point) => {
     const matchedPoint = licenceVersionPurposePoints.find((licenceVersionPurposePoint) => {
       return licenceVersionPurposePoint.naldPointId.toString() === point
     })

--- a/app/presenters/return-requirements/check/returns-requirements.presenter.js
+++ b/app/presenters/return-requirements/check/returns-requirements.presenter.js
@@ -106,7 +106,7 @@ function _mapRequirement (requirement, index, licenceVersionPurposePoints) {
 function _mapPoints (requirementPoints, licenceVersionPurposePoints) {
   return requirementPoints.map((point) => {
     const matchedPoint = licenceVersionPurposePoints.find((licenceVersionPurposePoint) => {
-      return licenceVersionPurposePoint.id === point
+      return licenceVersionPurposePoint.naldPointId.toString() === point.toString()
     })
 
     return matchedPoint.$describe()

--- a/app/presenters/return-requirements/points.presenter.js
+++ b/app/presenters/return-requirements/points.presenter.js
@@ -43,7 +43,7 @@ function _licencePoints (licenceVersionPurposePoints) {
   // First extract our points from the data, including generating the descriptions
   const licencePoints = licenceVersionPurposePoints.map((licenceVersionPurposePoint) => {
     return {
-      id: licenceVersionPurposePoint.id,
+      id: licenceVersionPurposePoint.naldPointId,
       description: licenceVersionPurposePoint.$describe()
     }
   })

--- a/app/presenters/return-requirements/points.presenter.js
+++ b/app/presenters/return-requirements/points.presenter.js
@@ -43,7 +43,7 @@ function _licencePoints (licenceVersionPurposePoints) {
   // First extract our points from the data, including generating the descriptions
   const licencePoints = licenceVersionPurposePoints.map((licenceVersionPurposePoint) => {
     return {
-      id: licenceVersionPurposePoint.naldPointId,
+      id: licenceVersionPurposePoint.naldPointId.toString(),
       description: licenceVersionPurposePoint.$describe()
     }
   })

--- a/app/presenters/return-requirements/points.presenter.js
+++ b/app/presenters/return-requirements/points.presenter.js
@@ -24,7 +24,7 @@ function go (session, requirementIndex, licenceVersionPurposePoints) {
     licenceId: licence.id,
     licencePoints: _licencePoints(licenceVersionPurposePoints),
     licenceRef: licence.licenceRef,
-    points: requirement?.points ? requirement.points.join(',') : '',
+    selectedNaldPointIds: requirement?.points ? requirement.points.join(',') : '',
     sessionId
   }
 }
@@ -43,7 +43,7 @@ function _licencePoints (licenceVersionPurposePoints) {
   // First extract our points from the data, including generating the descriptions
   const licencePoints = licenceVersionPurposePoints.map((licenceVersionPurposePoint) => {
     return {
-      id: licenceVersionPurposePoint.naldPointId.toString(),
+      naldPointId: licenceVersionPurposePoint.naldPointId.toString(),
       description: licenceVersionPurposePoint.$describe()
     }
   })

--- a/app/services/return-requirements/fetch-points.service.js
+++ b/app/services/return-requirements/fetch-points.service.js
@@ -37,7 +37,8 @@ async function _fetch (licenceId) {
         'ngr1',
         'ngr2',
         'ngr3',
-        'ngr4'
+        'ngr4',
+        'naldPointId'
       ])
     })
 

--- a/app/services/return-requirements/setup/fetch-abstraction-data.service.js
+++ b/app/services/return-requirements/setup/fetch-abstraction-data.service.js
@@ -71,7 +71,8 @@ async function _fetch (licenceId) {
         .modifyGraph('licenceVersionPurposePoints', (pointsBuilder) => {
           pointsBuilder.select([
             'licenceVersionPurposePoints.id',
-            'licenceVersionPurposePoints.description'
+            'licenceVersionPurposePoints.description',
+            'licenceVersionPurposePoints.naldPointId'
           ])
         })
     })

--- a/app/services/return-requirements/setup/generate-from-abstraction-data.service.js
+++ b/app/services/return-requirements/setup/generate-from-abstraction-data.service.js
@@ -180,7 +180,7 @@ function _frequencyReported (licence, licenceVersionPurpose) {
  */
 function _points (licenceVersionPurposePoints) {
   return licenceVersionPurposePoints.map((licenceVersionPurposePoint) => {
-    return licenceVersionPurposePoint.naldPointId
+    return licenceVersionPurposePoint.naldPointId.toString()
   })
 }
 

--- a/app/services/return-requirements/setup/generate-from-abstraction-data.service.js
+++ b/app/services/return-requirements/setup/generate-from-abstraction-data.service.js
@@ -174,13 +174,13 @@ function _frequencyReported (licence, licenceVersionPurpose) {
  * For each point grab the ID and return it as an array of points.
  *
  * Remember, we are transforming the data into what is needed for the session, not what is needed for the UI! Hence, we
- * only need the ID.
+ * only need the naldPointId.
  *
  * @private
  */
 function _points (licenceVersionPurposePoints) {
   return licenceVersionPurposePoints.map((licenceVersionPurposePoint) => {
-    return licenceVersionPurposePoint.id
+    return licenceVersionPurposePoint.naldPointId
   })
 }
 

--- a/app/views/return-requirements/points.njk
+++ b/app/views/return-requirements/points.njk
@@ -41,12 +41,12 @@
       <input type="hidden" name="wrlsCrumb" value="{{wrlsCrumb}}"/>
 
       {% set checkBoxItems = [] %}
-      {% for point in licencePoints %}
+      {% for licencePoint in licencePoints %}
 
         {% set checkBoxItem = {
-          value: point.id,
-          text: point.description,
-          checked: point.id in points
+          value: licencePoint.naldPointId,
+          text: licencePoint.description,
+          checked: licencePoint.naldPointId in selectedNaldPointIds
         } %}
 
         {% set checkBoxItems = (checkBoxItems.push(checkBoxItem), checkBoxItems) %}

--- a/test/presenters/return-requirements/check/returns-requirements.presenter.test.js
+++ b/test/presenters/return-requirements/check/returns-requirements.presenter.test.js
@@ -206,7 +206,8 @@ function _point () {
     ngr1: 'TQ 69212 50394',
     ngr2: null,
     ngr3: null,
-    ngr4: null
+    ngr4: null,
+    naldPointId: 100789
   })
 }
 
@@ -224,7 +225,7 @@ function _requirement () {
     frequencyCollected: 'day',
     frequencyReported: 'day',
     points: [
-      'd03d7d7c-4e33-4b4d-ac9b-6ebac9a5e5f6'
+      '100789'
     ],
     purposes: [{
       id: '772136d1-9184-417b-90cd-91053287d1df',

--- a/test/presenters/return-requirements/points.presenter.test.js
+++ b/test/presenters/return-requirements/points.presenter.test.js
@@ -48,13 +48,13 @@ describe('Return Requirements - Points presenter', () => {
         backLink: '/system/return-requirements/61e07498-f309-4829-96a9-72084a54996d/purpose/0',
         licenceId: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
         licencePoints: [{
-          id: 'd03d7d7c-4e33-4b4d-ac9b-6ebac9a5e5f6',
+          id: '100789',
           description: 'At National Grid Reference TQ 69212 50394 (RIVER MEDWAY AT YALDING INTAKE)'
         }, {
-          id: '07820640-c95a-497b-87d6-9e0d3ef322db',
+          id: '100123',
           description: 'Between National Grid References SO 524 692 and SO 531 689 (KIRKENEL FARM ASHFORD CARBONEL - RIVER TEME)'
         }, {
-          id: '1c925e6c-a788-4a56-9c1e-ebb46c83ef73',
+          id: '100321',
           description: 'Within the area formed by the straight lines running between National Grid References NZ 892 055 NZ 895 054 NZ 893 053 and NZ 892 053 (AREA D)'
         }],
         licenceRef: '01/ABC',
@@ -96,7 +96,7 @@ describe('Return Requirements - Points presenter', () => {
         const result = PointsPresenter.go(session, requirementIndex, licenceVersionPurposePoints)
 
         expect(result.licencePoints).to.equal([{
-          id: 'd03d7d7c-4e33-4b4d-ac9b-6ebac9a5e5f6',
+          id: '100789',
           description: 'At National Grid Reference TQ 69212 50394 (RIVER MEDWAY AT YALDING INTAKE)'
         }])
       })
@@ -111,7 +111,7 @@ describe('Return Requirements - Points presenter', () => {
         const result = PointsPresenter.go(session, requirementIndex, licenceVersionPurposePoints)
 
         expect(result.licencePoints).to.equal([{
-          id: '07820640-c95a-497b-87d6-9e0d3ef322db',
+          id: '100123',
           description: 'Between National Grid References SO 524 692 and SO 531 689 (KIRKENEL FARM ASHFORD CARBONEL - RIVER TEME)'
         }])
       })
@@ -126,7 +126,7 @@ describe('Return Requirements - Points presenter', () => {
         const result = PointsPresenter.go(session, requirementIndex, licenceVersionPurposePoints)
 
         expect(result.licencePoints).to.equal([{
-          id: '1c925e6c-a788-4a56-9c1e-ebb46c83ef73',
+          id: '100321',
           description: 'Within the area formed by the straight lines running between National Grid References NZ 892 055 NZ 895 054 NZ 893 053 and NZ 892 053 (AREA D)'
         }])
       })
@@ -136,16 +136,13 @@ describe('Return Requirements - Points presenter', () => {
   describe('the "points" property', () => {
     describe('when the user has previously submitted points', () => {
       beforeEach(() => {
-        session.requirements[0].points = [
-          'd03d7d7c-4e33-4b4d-ac9b-6ebac9a5e5f6',
-          '07820640-c95a-497b-87d6-9e0d3ef322db'
-        ]
+        session.requirements[0].points = ['100123', '100321']
       })
 
       it('returns a populated points', () => {
         const result = PointsPresenter.go(session, requirementIndex, licenceVersionPurposePoints)
 
-        expect(result.points).to.equal('d03d7d7c-4e33-4b4d-ac9b-6ebac9a5e5f6,07820640-c95a-497b-87d6-9e0d3ef322db')
+        expect(result.points).to.equal('100123,100321')
       })
     })
 
@@ -168,7 +165,8 @@ function _licenceVersionPurposePoints () {
     ngr1: 'TQ 69212 50394',
     ngr2: null,
     ngr3: null,
-    ngr4: null
+    ngr4: null,
+    naldPointId: 100789
   }))
 
   points.push(LicenceVersionPurposePointModel.fromJson({
@@ -177,7 +175,8 @@ function _licenceVersionPurposePoints () {
     ngr1: 'SO 524 692',
     ngr2: 'SO 531 689',
     ngr3: null,
-    ngr4: null
+    ngr4: null,
+    naldPointId: 100123
   }))
 
   points.push(LicenceVersionPurposePointModel.fromJson({
@@ -186,7 +185,8 @@ function _licenceVersionPurposePoints () {
     ngr1: 'NZ 892 055',
     ngr2: 'NZ 895 054',
     ngr3: 'NZ 893 053',
-    ngr4: 'NZ 892 053'
+    ngr4: 'NZ 892 053',
+    naldPointId: 100321
   }))
 
   return points

--- a/test/presenters/return-requirements/points.presenter.test.js
+++ b/test/presenters/return-requirements/points.presenter.test.js
@@ -48,17 +48,17 @@ describe('Return Requirements - Points presenter', () => {
         backLink: '/system/return-requirements/61e07498-f309-4829-96a9-72084a54996d/purpose/0',
         licenceId: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
         licencePoints: [{
-          id: '100789',
+          naldPointId: '100789',
           description: 'At National Grid Reference TQ 69212 50394 (RIVER MEDWAY AT YALDING INTAKE)'
         }, {
-          id: '100123',
+          naldPointId: '100123',
           description: 'Between National Grid References SO 524 692 and SO 531 689 (KIRKENEL FARM ASHFORD CARBONEL - RIVER TEME)'
         }, {
-          id: '100321',
+          naldPointId: '100321',
           description: 'Within the area formed by the straight lines running between National Grid References NZ 892 055 NZ 895 054 NZ 893 053 and NZ 892 053 (AREA D)'
         }],
         licenceRef: '01/ABC',
-        points: '',
+        selectedNaldPointIds: '',
         sessionId: '61e07498-f309-4829-96a9-72084a54996d'
       })
     })
@@ -96,7 +96,7 @@ describe('Return Requirements - Points presenter', () => {
         const result = PointsPresenter.go(session, requirementIndex, licenceVersionPurposePoints)
 
         expect(result.licencePoints).to.equal([{
-          id: '100789',
+          naldPointId: '100789',
           description: 'At National Grid Reference TQ 69212 50394 (RIVER MEDWAY AT YALDING INTAKE)'
         }])
       })
@@ -111,7 +111,7 @@ describe('Return Requirements - Points presenter', () => {
         const result = PointsPresenter.go(session, requirementIndex, licenceVersionPurposePoints)
 
         expect(result.licencePoints).to.equal([{
-          id: '100123',
+          naldPointId: '100123',
           description: 'Between National Grid References SO 524 692 and SO 531 689 (KIRKENEL FARM ASHFORD CARBONEL - RIVER TEME)'
         }])
       })
@@ -126,31 +126,31 @@ describe('Return Requirements - Points presenter', () => {
         const result = PointsPresenter.go(session, requirementIndex, licenceVersionPurposePoints)
 
         expect(result.licencePoints).to.equal([{
-          id: '100321',
+          naldPointId: '100321',
           description: 'Within the area formed by the straight lines running between National Grid References NZ 892 055 NZ 895 054 NZ 893 053 and NZ 892 053 (AREA D)'
         }])
       })
     })
   })
 
-  describe('the "points" property', () => {
+  describe('the "selectedNaldPointIds" property', () => {
     describe('when the user has previously submitted points', () => {
       beforeEach(() => {
         session.requirements[0].points = ['100123', '100321']
       })
 
-      it('returns a populated points', () => {
+      it('returns a string containing the selected points concatenated', () => {
         const result = PointsPresenter.go(session, requirementIndex, licenceVersionPurposePoints)
 
-        expect(result.points).to.equal('100123,100321')
+        expect(result.selectedNaldPointIds).to.equal('100123,100321')
       })
     })
 
     describe('when the user has not previously submitted a point', () => {
-      it('returns an empty points', () => {
+      it('returns an empty string', () => {
         const result = PointsPresenter.go(session, requirementIndex, licenceVersionPurposePoints)
 
-        expect(result.points).to.equal('')
+        expect(result.selectedNaldPointIds).to.equal('')
       })
     })
   })

--- a/test/services/return-requirements/fetch-points.service.test.js
+++ b/test/services/return-requirements/fetch-points.service.test.js
@@ -55,7 +55,8 @@ describe('Return Requirements - Fetch Points service', () => {
         ngr1: licenceVersionPurposePoints[0].ngr1,
         ngr2: licenceVersionPurposePoints[0].ngr2,
         ngr3: licenceVersionPurposePoints[0].ngr3,
-        ngr4: licenceVersionPurposePoints[0].ngr4
+        ngr4: licenceVersionPurposePoints[0].ngr4,
+        naldPointId: licenceVersionPurposePoints[0].naldPointId
       })
 
       expect(results[1]).to.equal({
@@ -64,7 +65,8 @@ describe('Return Requirements - Fetch Points service', () => {
         ngr1: licenceVersionPurposePoints[1].ngr1,
         ngr2: licenceVersionPurposePoints[1].ngr2,
         ngr3: licenceVersionPurposePoints[1].ngr3,
-        ngr4: licenceVersionPurposePoints[1].ngr4
+        ngr4: licenceVersionPurposePoints[1].ngr4,
+        naldPointId: licenceVersionPurposePoints[1].naldPointId
       })
     })
   })

--- a/test/services/return-requirements/points.service.test.js
+++ b/test/services/return-requirements/points.service.test.js
@@ -54,7 +54,8 @@ describe('Return Requirements - Select Points service', () => {
       ngr1: 'TQ 69212 50394',
       ngr2: null,
       ngr3: null,
-      ngr4: null
+      ngr4: null,
+      naldPointId: 100789
     })
 
     Sinon.stub(FetchPointsService, 'go').resolves([point])
@@ -81,12 +82,12 @@ describe('Return Requirements - Select Points service', () => {
         licenceId: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
         licencePoints: [
           {
-            id: 'd03d7d7c-4e33-4b4d-ac9b-6ebac9a5e5f6',
+            naldPointId: '100789',
             description: 'At National Grid Reference TQ 69212 50394 (RIVER MEDWAY AT YALDING INTAKE)'
           }
         ],
         licenceRef: '01/ABC',
-        points: ''
+        selectedNaldPointIds: ''
       }, { skip: ['sessionId'] })
     })
   })

--- a/test/services/return-requirements/setup/fetch-abstraction-data.service.test.js
+++ b/test/services/return-requirements/setup/fetch-abstraction-data.service.test.js
@@ -47,8 +47,16 @@ describe('Return Requirements - Fetch Abstraction Data service', () => {
                 purpose: { description: 'Heat Pump', id: seedIds.allPurposes.purposes.heatPumpId, legacyId: '200', twoPartTariff: false },
                 secondaryPurpose: { id: seedIds.allPurposes.secondaryPurposes.secondaryElectricityId, legacyId: 'ELC' },
                 licenceVersionPurposePoints: [
-                  { description: 'INTAKE POINT', id: seedIds.licenceVersionPurposePoints.electricity1.id },
-                  { description: 'OUT TAKE POINT', id: seedIds.licenceVersionPurposePoints.electricity2.id }
+                  {
+                    description: 'INTAKE POINT',
+                    id: seedIds.licenceVersionPurposePoints.electricity1.id,
+                    naldPointId: seedIds.licenceVersionPurposePoints.electricity1.naldPointId
+                  },
+                  {
+                    description: 'OUT TAKE POINT',
+                    id: seedIds.licenceVersionPurposePoints.electricity2.id,
+                    naldPointId: seedIds.licenceVersionPurposePoints.electricity2.naldPointId
+                  }
                 ]
               },
               {
@@ -63,7 +71,11 @@ describe('Return Requirements - Fetch Abstraction Data service', () => {
                 purpose: { description: 'Vegetable Washing', id: seedIds.allPurposes.purposes.vegetableWashingId, legacyId: '460', twoPartTariff: false },
                 secondaryPurpose: { id: seedIds.allPurposes.secondaryPurposes.secondaryAgricultureId, legacyId: 'AGR' },
                 licenceVersionPurposePoints: [
-                  { description: 'SOUTH BOREHOLE', id: seedIds.licenceVersionPurposePoints.standard.id }
+                  {
+                    description: 'SOUTH BOREHOLE',
+                    id: seedIds.licenceVersionPurposePoints.standard.id,
+                    naldPointId: seedIds.licenceVersionPurposePoints.standard.naldPointId
+                  }
                 ]
               },
               {
@@ -78,7 +90,11 @@ describe('Return Requirements - Fetch Abstraction Data service', () => {
                 purpose: { description: 'Spray Irrigation - Direct', id: seedIds.allPurposes.purposes.sprayIrrigationDirectId, legacyId: '400', twoPartTariff: true },
                 secondaryPurpose: { id: seedIds.allPurposes.secondaryPurposes.secondaryAgricultureId, legacyId: 'AGR' },
                 licenceVersionPurposePoints: [
-                  { description: 'MAIN INTAKE', id: seedIds.licenceVersionPurposePoints.twoPartTariff.id }
+                  {
+                    description: 'MAIN INTAKE',
+                    id: seedIds.licenceVersionPurposePoints.twoPartTariff.id,
+                    naldPointId: seedIds.licenceVersionPurposePoints.twoPartTariff.naldPointId
+                  }
                 ]
               }
             ]

--- a/test/services/return-requirements/setup/generate-from-abstraction-data.service.test.js
+++ b/test/services/return-requirements/setup/generate-from-abstraction-data.service.test.js
@@ -38,7 +38,7 @@ describe('Return Requirements - Generate From Abstraction Data service', () => {
 
         expect(result).to.equal([
           {
-            points: ['d60b0dfe-ef2b-4bc2-a963-b74b25433127', '6c664140-f7ee-4e98-aa88-74590d3fd8fb'],
+            points: ['100987', '100789'],
             purposes: [{
               alias: '', description: 'Heat Pump', id: '24939b40-a187-4bd1-9222-f552a3af6368'
             }],
@@ -55,7 +55,7 @@ describe('Return Requirements - Generate From Abstraction Data service', () => {
             agreementsExceptions: ['none']
           },
           {
-            points: ['bf6a409e-7882-4c5d-9e49-2ebae2936576'],
+            points: ['100123'],
             purposes: [{
               alias: '',
               description: 'Vegetable Washing',
@@ -74,7 +74,7 @@ describe('Return Requirements - Generate From Abstraction Data service', () => {
             agreementsExceptions: ['none']
           },
           {
-            points: ['554cd6c5-5bfe-4133-9828-2f10aa6ac5f8'],
+            points: ['100321'],
             purposes: [{
               alias: '',
               description: 'Spray Irrigation - Direct',
@@ -184,8 +184,8 @@ function _fetchResult (licenceId) {
             },
             secondaryPurpose: { id: '235ed780-f535-4b8d-b367-b5438ac130e9', legacyId: 'ELC' },
             licenceVersionPurposePoints: [
-              { description: 'INTAKE POINT', id: 'd60b0dfe-ef2b-4bc2-a963-b74b25433127' },
-              { description: 'OUT TAKE POINT', id: '6c664140-f7ee-4e98-aa88-74590d3fd8fb' }
+              { description: 'INTAKE POINT', id: 'd60b0dfe-ef2b-4bc2-a963-b74b25433127', naldPointId: 100987 },
+              { description: 'OUT TAKE POINT', id: '6c664140-f7ee-4e98-aa88-74590d3fd8fb', naldPointId: 100789 }
             ]
           }),
           LicenceVersionPurposeModel.fromJson({
@@ -205,7 +205,7 @@ function _fetchResult (licenceId) {
             },
             secondaryPurpose: { id: '827f5181-1acc-452a-aea3-a1d72a21604b', legacyId: 'AGR' },
             licenceVersionPurposePoints: [
-              { description: 'SOUTH BOREHOLE', id: 'bf6a409e-7882-4c5d-9e49-2ebae2936576' }
+              { description: 'SOUTH BOREHOLE', id: 'bf6a409e-7882-4c5d-9e49-2ebae2936576', naldPointId: 100123 }
             ]
           }),
           LicenceVersionPurposeModel.fromJson({
@@ -225,7 +225,7 @@ function _fetchResult (licenceId) {
             },
             secondaryPurpose: { id: '827f5181-1acc-452a-aea3-a1d72a21604b', legacyId: 'AGR' },
             licenceVersionPurposePoints: [
-              { description: 'MAIN INTAKE', id: '554cd6c5-5bfe-4133-9828-2f10aa6ac5f8' }
+              { description: 'MAIN INTAKE', id: '554cd6c5-5bfe-4133-9828-2f10aa6ac5f8', naldPointId: 100321 }
             ]
           })
         ]

--- a/test/services/return-requirements/submit-points.service.test.js
+++ b/test/services/return-requirements/submit-points.service.test.js
@@ -131,11 +131,11 @@ describe('Return Requirements - Submit Points service', () => {
         backLink: `/system/return-requirements/${session.id}/purpose/0`,
         licenceId: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
         licencePoints: [{
-          id: 'd03d7d7c-4e33-4b4d-ac9b-6ebac9a5e5f6',
+          naldPointId: '100789',
           description: 'At National Grid Reference TQ 69212 50394 (RIVER MEDWAY AT YALDING INTAKE)'
         }],
         licenceRef: '01/ABC',
-        points: ''
+        selectedNaldPointIds: ''
       }, { skip: ['sessionId', 'error'] })
     })
 
@@ -158,7 +158,8 @@ function _points () {
     ngr1: 'TQ 69212 50394',
     ngr2: null,
     ngr3: null,
-    ngr4: null
+    ngr4: null,
+    naldPointId: 100789
   })
 
   return [point]


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4600
https://eaflood.atlassian.net/browse/WATER-4645

> Part of the work to migrate return versions from NALD to WRLS

We've been extending and amending the import of return versions from NALD to WRLS as part of our work to switch from NALD to WRLS to manage them.

In [Update Return req set up journey to use new points](https://github.com/DEFRA/water-abstraction-system/pull/1301) we updated the return requirement setup journey to use the new `water.licence_version_purpose_points` table we've created and now populate thanks to [a change to the import](https://github.com/DEFRA/water-abstraction-system/pull/1301).

We then began updating our acceptance tests [to update the return requirement fixtures to use new points](https://github.com/DEFRA/water-abstraction-acceptance-tests/pull/134) but found the 'Copy from existing journey' was failing.

We tracked the issue down to the use of IDs. The changes we had made to the journey to support reading points from `water.licence_version_purpose_points` were the cause.

Starting with the manual journey, we updated the fetch points service to retrieve points information from `water.licence_version_purpose_points`. The ID we provided in the presenter to the view was the `LicenceVersionPurposePoint.id`. This is then what gets stored in the session when a user makes a selection.

Then, we did something similar in the 'Use abstraction data' journey. Again, we retrieve the licence version purpose points and store their IDs in the session.

In both journeys, when you get to the `/check` screen, it will use the `FetchPointsService` to fetch the licence version purpose points again. The presenter for the check page can match the selected points in the session to the results of the fetch points service.

The journey we broke was 'Copy from existing'. In that scenario, the points are sourced from `water.return_requirement_points`, which means they have a different ID than what is in `water.licence_version_purpose_points` that we are storing in the session. This means that when you then get passed to the `/check` page, it is unable to find a match in the results from `FetchPointsService,` so an error is thrown.

Fortunately, the one value both tables share is the NALD point ID. Like with our journey, when you create the return requirement in NALD, you select from the same licence points as ours, which also have a NALD point ID. This means there will _always_ be a match between licence points and return points. You just have to match on NALD Point ID instead of their IDs.