### PR TITLE
Add wlrs licence id to the nald licence import

### DIFF
--- a/app/services/import/legacy/fetch-licence.service.js
+++ b/app/services/import/legacy/fetch-licence.service.js
@@ -66,11 +66,14 @@ function _query () {
           AND nalv."AABL_ID" = nal."ID"
           AND nalv."STATUS" <> 'DRAFT'
       ) AS earliest_version_start_date,
-      r.id AS region_id
+      r.id AS region_id,
+      l.id as wrls_licence_id
     FROM
       "import"."NALD_ABS_LICENCES" nal
     LEFT JOIN
       public.regions r ON r.nald_region_id = (nal."FGAC_REGION_CODE")::INTEGER
+    LEFT JOIN
+      public.licences l ON l.licence_ref = nal."LIC_NO"
     WHERE
       nal."LIC_NO" = ?;
   `
@@ -98,4 +101,5 @@ module.exports = {
  * @property {Date} revoked_date
  * @property {Date} earliest_version_start_date
  * @property {string} region_id
+ * @property {uuid} wrls_licence_id - licence id used to determine if a licence already exists in WRLS
  */

--- a/app/services/import/legacy/process-licence.service.js
+++ b/app/services/import/legacy/process-licence.service.js
@@ -26,7 +26,8 @@ async function go (licenceRef) {
     const startTime = currentTimeInNanoseconds()
 
     // Transform the parent legacy licence record first
-    const { naldLicenceId, regionCode, transformedLicence } = await TransformLicenceService.go(licenceRef)
+    const { naldLicenceId, regionCode, transformedLicence, wrlsLicenceId } =
+      await TransformLicenceService.go(licenceRef)
 
     // Pass the transformed licence through each transformation step, building the licence as we go
     await TransformLicenceVersionsService.go(regionCode, naldLicenceId, transformedLicence)
@@ -41,6 +42,10 @@ async function go (licenceRef) {
 
     // Either insert or update the licence in WRLS
     const licenceId = await PersistLicenceService.go(transformedLicence, transformedCompanies)
+
+    if (wrlsLicenceId) {
+      // Process mod logs
+    }
 
     calculateAndLogTimeTaken(startTime, 'Legacy licence import complete', { licenceId, licenceRef })
   } catch (error) {

--- a/app/services/import/legacy/transform-licence.service.js
+++ b/app/services/import/legacy/transform-licence.service.js
@@ -26,7 +26,8 @@ async function go (licenceRef) {
   return {
     naldLicenceId: naldLicence.id,
     regionCode: naldLicence.region_code,
-    transformedLicence
+    transformedLicence,
+    wrlsLicenceId: naldLicence.wrls_licence_id
   }
 }
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4545

Relevant changes - https://github.com/DEFRA/water-abstraction-system/pull/1294

As part of the ongoing work to migrate the legacy import jobs we need to establish if a licence already exists in the wrls database.

We check if the licence already exists, if it does then we want to do nothing. If it does not exist we want to generate return logs.

This change is added to highlight where we need to add this additional logic. And the service call will be added in another piece of work.