### PR TITLE
Amend supplementary billing editing return journey

### DIFF
--- a/app/services/licences/supplementary/determine-return-log-years.service.js
+++ b/app/services/licences/supplementary/determine-return-log-years.service.js
@@ -34,7 +34,7 @@ async function go (returnLogId) {
     flagForBilling: false
   }
 
-  if (startDate < SROC_START_DATE) {
+  if (endDate < SROC_START_DATE) {
     return result
   }
 

--- a/test/services/licences/supplementary/determine-return-log-years.service.test.js
+++ b/test/services/licences/supplementary/determine-return-log-years.service.test.js
@@ -61,15 +61,40 @@ describe('Determine Return Log Years Service', () => {
     })
 
     describe('that has a start date before the SROC billing start date', () => {
-      beforeEach(async () => {
-        returnLog = await ReturnLogHelper.add({ licenceRef: licence.licenceRef, startDate: new Date('2022-03-01') })
+      describe('and the end date is before the SROC billing start date', () => {
+        beforeEach(async () => {
+          returnLog = await ReturnLogHelper.add({
+            licenceRef: licence.licenceRef,
+            startDate: new Date('2021-04-01'),
+            endDate: new Date('2022-03-31'),
+            metadata: { isTwoPartTariff: true }
+          })
+        })
+
+        it('returns flagForBilling as false and twoPartTariff as true', async () => {
+          const result = await DetermineReturnLogYearsService.go(returnLog.id)
+
+          expect(result.flagForBilling).to.equal(false)
+          expect(result.twoPartTariff).to.equal(true)
+        })
       })
 
-      it('returns flagForBilling and twoPartTariff as false', async () => {
-        const result = await DetermineReturnLogYearsService.go(returnLog.id)
+      describe('and the end date is after the SROC billing start date', () => {
+        beforeEach(async () => {
+          returnLog = await ReturnLogHelper.add({
+            licenceRef: licence.licenceRef,
+            startDate: new Date('2022-03-01'),
+            endDate: new Date('2023-03-01'),
+            metadata: { isTwoPartTariff: true }
+          })
+        })
 
-        expect(result.flagForBilling).to.equal(false)
-        expect(result.twoPartTariff).to.equal(false)
+        it('returns flagForBilling and twoPartTariff as false', async () => {
+          const result = await DetermineReturnLogYearsService.go(returnLog.id)
+
+          expect(result.flagForBilling).to.equal(true)
+          expect(result.twoPartTariff).to.equal(true)
+        })
       })
     })
   })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4589

During testing for the above ticket, it was noticed that if an edited return straddled the pre sroc and sroc financial years then no years where being persisted for the licence supplementary years table. This change allows the correct sroc years to be added to the table.