### PR TITLE
Incorrect status showing on licence set up page

### DIFF
--- a/app/services/return-requirements/generate-return-version.service.js
+++ b/app/services/return-requirements/generate-return-version.service.js
@@ -60,7 +60,8 @@ async function _generateReturnVersion (returnVersionsExist, sessionData, userId)
   const startDate = _calculateStartDate(sessionData)
   let endDate = null
 
-  if (returnVersionsExist) {
+  // If the journey is for 'no-returns-required' `returnVersionsExist` will always be false
+  if (returnVersionsExist || sessionData.journey === 'no-returns-required') {
     endDate = await ProcessExistingReturnVersionsService.go(sessionData.licence.id, startDate)
   }
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4671

When a new requirements for returns is created to replace an existing requirements for returns the Status of the old requirements for returns is staying as ‘APPROVED’ in circumstances where the status should be ‘REPLACED’.

This issue is occurring in the no returns required journey. Before the process to update existing return versions is called a check is done to see if any previous return versions exist. However this is done using the session data `const returnVersionsExist = sessionData.licence.returnVersions.length > 0` Unfortunately when no returns are required, this property is never set in session data. So when no returns are required the service always thinks there are no previous versions so it doesn't worry about updating any existing ones.

This PR will fix the issue by always running the `ProcessExistingReturnVersionsService` for the no returns required journey.