### PR TITLE
Import company contacts data for a licence

### DIFF
--- a/app/presenters/import/legacy/licence-holder.presenter.js
+++ b/app/presenters/import/legacy/licence-holder.presenter.js
@@ -1,0 +1,28 @@
+'use strict'
+
+/**
+ * Maps the legacy NALD licence holder data to the WRLS format
+ * @module LicenceHolderPresenter
+ */
+
+/**
+ * Maps the legacy NALD licence holder data to the WRLS format
+ *
+ * @param {ImportLegacyLicenceHolderType} licenceHolder - the legacy NALD licence holder
+ *
+ * @returns {object} the NALD licence holder data transformed into the WRLS format for a contact
+ * ready for validation and persisting
+ */
+function go (licenceHolder) {
+  return {
+    companyExternalId: licenceHolder.company_external_id,
+    contactExternalId: licenceHolder.contact_external_id,
+    startDate: licenceHolder.start_date,
+    endDate: null,
+    licenceRoleId: licenceHolder.licence_role_id
+  }
+}
+
+module.exports = {
+  go
+}

--- a/app/services/import/legacy/fetch-licence-holders.service.js
+++ b/app/services/import/legacy/fetch-licence-holders.service.js
@@ -1,0 +1,61 @@
+'use strict'
+
+/**
+ * Fetches the Licence Holder data from the import.NALD_PARTIES table for the licence ref
+ * @module FetchLicenceHolderService
+ */
+
+const { db } = require('../../../../db/db.js')
+
+/**
+ * Fetches the licence holder data from the import.NALD_PARTIES table for the licence ref
+ *
+ * The licence holder is determined from the import.NALD_ABS_LIC_VERSIONS table. We get the earliest start date
+ *
+ * @param {string} regionCode - The NALD region code
+ * @param {string} licenceId - The NALD licence ID
+ *
+ * @returns {Promise<ImportLegacyLicenceHolderType[]>}
+ */
+async function go (regionCode, licenceId) {
+  const query = _query()
+
+  const { rows } = await db.raw(query, [regionCode, licenceId])
+
+  return rows
+}
+
+function _query () {
+  return `
+    SELECT DISTINCT ON (np."ID")
+      (concat_ws(':', np."FGAC_REGION_CODE", np."ID")) AS company_external_id,
+      (concat_ws(':', np."FGAC_REGION_CODE", np."ID")) AS contact_external_id,
+      to_date(nalc."EFF_ST_DATE", 'DD/MM/YYYY') as start_date,
+      lr.id as licence_role_id
+    FROM import."NALD_PARTIES" np
+           INNER JOIN import."NALD_ABS_LIC_VERSIONS" nalc
+                      ON nalc."FGAC_REGION_CODE" = np."FGAC_REGION_CODE"
+                        AND nalc."ACON_APAR_ID" = np."ID"
+           INNER JOIN public.licence_roles lr
+                      ON lr.name = 'licenceHolder'
+    WHERE nalc."FGAC_REGION_CODE" = ?
+      AND nalc."AABL_ID" = ?
+      AND np."APAR_TYPE" != 'ORG'
+    ORDER BY  np."ID", TO_DATE(nalc."EFF_ST_DATE", 'DD/MM/YYYY') ASC
+
+  `
+}
+
+module.exports = {
+  go
+}
+
+/**
+ * @typedef {object} ImportLegacyLicenceHolderType
+ *
+ * @property {string} company_external_id - The company external ID, formatted as 'FGAC_REGION_CODE:ID'.
+ * @property {string} contact_external_id - The contact external ID, formatted as 'FGAC_REGION_CODE:ID'.
+ * @property {Date} start_date - earliest start date for the licence holder
+ * @property {uuid} licence_role_id - the licence role id for the licence holder
+ *
+ */

--- a/app/services/import/legacy/process-licence.service.js
+++ b/app/services/import/legacy/process-licence.service.js
@@ -8,6 +8,7 @@
 const LicenceStructureValidator = require('../../../validators/import/licence-structure.validator.js')
 const PersistLicenceService = require('../persist-licence.service.js')
 const TransformCompaniesService = require('./transform-companies.service.js')
+const TransformLicenceHolderService = require('./transform-licence-holder.service.js')
 const TransformLicenceService = require('./transform-licence.service.js')
 const TransformLicenceVersionPurposeConditionsService = require('./transform-licence-version-purpose-conditions.service.js')
 const TransformLicenceVersionPurposesService = require('./transform-licence-version-purposes.service.js')
@@ -36,6 +37,8 @@ async function go (licenceRef) {
 
     // Transform the company data
     const { transformedCompanies } = await TransformCompaniesService.go(regionCode, naldLicenceId)
+
+    await TransformLicenceHolderService.go(regionCode, naldLicenceId, transformedCompanies)
 
     // Ensure the built licence has all the valid child records we require
     LicenceStructureValidator.go(transformedLicence)

--- a/app/services/import/legacy/transform-licence-holder.service.js
+++ b/app/services/import/legacy/transform-licence-holder.service.js
@@ -1,0 +1,43 @@
+'use strict'
+
+/**
+ * Transforms NALD licence holder data into a valid object that matches the WRLS structure
+ * @module ImportLegacyTransformLicenceHolderService
+ */
+
+const FetchLicenceHolderService = require('./fetch-licence-holders.service.js')
+const LicenceHolderPresenter = require('../../../presenters/import/legacy/licence-holder.presenter.js')
+const ImportLicenceHolderValidator = require('../../../validators/import/licence-holder.validator.js')
+
+/**
+ * Transforms NALD licence holder data into a validated object that matches the WRLS structure
+ *
+ * @param {string} regionCode - The NALD region code
+ * @param {string} licenceId - The NALD licence ID
+ * @param {object[]} transformedCompanies
+ *
+ * @returns {Promise<object>} an object representing an array of valid WRLS transformed companies
+ */
+async function go (regionCode, licenceId, transformedCompanies) {
+  const naldLicenceHolders = await FetchLicenceHolderService.go(regionCode, licenceId)
+
+  naldLicenceHolders.forEach((licenceHolder) => {
+    const matchingLicenceHolder = _matchingCompanyForLicenceHolder(transformedCompanies, licenceHolder)
+
+    const transformedLicenceHolder = LicenceHolderPresenter.go(licenceHolder)
+
+    ImportLicenceHolderValidator.go(transformedLicenceHolder)
+
+    matchingLicenceHolder.licenceHolder = transformedLicenceHolder
+  })
+}
+
+function _matchingCompanyForLicenceHolder (transformedCompanies, licenceHolder) {
+  return transformedCompanies.find((company) => {
+    return company.externalId === licenceHolder.company_external_id
+  })
+}
+
+module.exports = {
+  go
+}

--- a/app/validators/import/licence-holder.validator.js
+++ b/app/validators/import/licence-holder.validator.js
@@ -1,0 +1,34 @@
+'use strict'
+
+/**
+ * @module ImportLicenceHolderValidator
+ */
+
+const Joi = require('joi')
+
+/**
+ * Checks that the imported licence holder data has been transformed and is valid for persisting to WRLS
+ *
+ * @param {object} contact - The transformed licence holder data
+ *
+ * @throws {Joi.ValidationError} - throws a Joi validation error if the validation fails
+ */
+function go (contact) {
+  const schema = Joi.object({
+    companyExternalId: Joi.string().required(),
+    contactExternalId: Joi.string().required(),
+    startDate: Joi.date().required(),
+    endDate: Joi.valid(null).required(),
+    licenceRoleId: Joi.string().guid().required()
+  })
+
+  const result = schema.validate(contact, { convert: false })
+
+  if (result.error) {
+    throw result.error
+  }
+}
+
+module.exports = {
+  go
+}

--- a/test/presenters/import/legacy/licence-holder.presenter.test.js
+++ b/test/presenters/import/legacy/licence-holder.presenter.test.js
@@ -1,0 +1,47 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const { generateUUID } = require('../../../../app/lib/general.lib.js')
+
+// Thing under test
+const LicenceHolderPresenter = require('../../../../app/presenters/import/legacy/licence-holder.presenter.js')
+
+describe('Import Legacy Licence Holder presenter', () => {
+  let legacyLicenceHolder
+  let licenceRoleId
+
+  beforeEach(() => {
+    licenceRoleId = generateUUID()
+
+    legacyLicenceHolder = _legacyLicenceHolder(licenceRoleId)
+  })
+
+  it('correctly transforms the data', () => {
+    const result = LicenceHolderPresenter.go(legacyLicenceHolder)
+
+    expect(result).to.equal({
+      companyExternalId: '1:007',
+      contactExternalId: '1:007',
+      startDate: new Date('2001-01-01'),
+      endDate: null,
+      licenceRoleId
+    })
+  })
+})
+
+function _legacyLicenceHolder (licenceRoleId) {
+  return {
+    company_external_id: '1:007',
+    contact_external_id: '1:007',
+    start_date: new Date('2001-01-01'),
+    endDate: null,
+    licence_role_id: licenceRoleId
+  }
+}

--- a/test/services/import/legacy/process-licence.service.test.js
+++ b/test/services/import/legacy/process-licence.service.test.js
@@ -19,6 +19,7 @@ const TransformLicenceVersionsService = require('../../../../app/services/import
 const TransformLicenceVersionPurposesService = require('../../../../app/services/import/legacy/transform-licence-version-purposes.service.js')
 const TransformLicenceVersionPurposeConditionsService = require('../../../../app/services/import/legacy/transform-licence-version-purpose-conditions.service.js')
 const TransformCompaniesService = require('../../../../app/services/import/legacy/transform-companies.service.js')
+const TransformLicenceHolderService = require('../../../../app/services/import/legacy/transform-licence-holder.service.js')
 
 // Thing under test
 const ProcessLicenceService = require('../../../../app/services/import/legacy/process-licence.service.js')
@@ -44,6 +45,7 @@ describe('Import Legacy Process Licence service', () => {
     Sinon.stub(TransformLicenceVersionPurposesService, 'go').resolves(transformedLicence)
     Sinon.stub(TransformLicenceVersionPurposeConditionsService, 'go').resolves(transformedLicence)
     Sinon.stub(TransformCompaniesService, 'go').resolves({ company: [], transformedCompany: [] })
+    Sinon.stub(TransformLicenceHolderService, 'go').resolves({ })
 
     // BaseRequest depends on the GlobalNotifier to have been set. This happens in app/plugins/global-notifier.plugin.js
     // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this

--- a/test/services/import/legacy/transform-licence-holder.service.test.js
+++ b/test/services/import/legacy/transform-licence-holder.service.test.js
@@ -1,0 +1,86 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { describe, it, beforeEach, afterEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Things to stub
+const FetchLicenceHolderService = require('../../../../app/services/import/legacy/fetch-licence-holders.service.js')
+const { generateUUID } = require('../../../../app/lib/general.lib.js')
+
+// Thing under test
+const TransformLicenceHolderService = require('../../../../app/services/import/legacy/transform-licence-holder.service.js')
+
+describe('Import Legacy Transform Licence Holder service', () => {
+  // NOTE: Clearly this is an incomplete representation of the company returned from TransformedCompaniesService.
+  // But for the purposes of this service it is all that is needed
+  const transformedCompany = { externalId: '1:007' }
+
+  const naldLicenceId = '007'
+  const regionCode = '1'
+
+  let legacyLicenceHolder
+  let licenceRoleId
+  let transformedCompanies
+
+  beforeEach(() => {
+    licenceRoleId = generateUUID()
+
+    legacyLicenceHolder = _legacyLicenceHolder(licenceRoleId)
+
+    transformedCompanies = [{ ...transformedCompany }]
+  })
+
+  afterEach(() => {
+    Sinon.restore()
+  })
+
+  describe('when matching valid legacy licence holder is found', () => {
+    beforeEach(() => {
+      Sinon.stub(FetchLicenceHolderService, 'go').resolves([legacyLicenceHolder])
+    })
+
+    it('returns the companies with the licence holder transformed and validated for WRLS', async () => {
+      await TransformLicenceHolderService.go(regionCode, naldLicenceId, transformedCompanies)
+
+      expect(transformedCompanies).to.equal([
+        {
+          externalId: '1:007',
+          licenceHolder: {
+            companyExternalId: '1:007',
+            contactExternalId: '1:007',
+            endDate: null,
+            licenceRoleId,
+            startDate: new Date('2001-01-01')
+          }
+        }
+      ])
+    })
+  })
+
+  describe('when no matching valid legacy licence holders are found', () => {
+    beforeEach(() => {
+      Sinon.stub(FetchLicenceHolderService, 'go').resolves([])
+    })
+
+    it('returns no licence holder on the company', async () => {
+      await TransformLicenceHolderService.go(regionCode, naldLicenceId, transformedCompanies)
+
+      expect(transformedCompanies[0]).to.equal({ externalId: '1:007' })
+    })
+  })
+})
+
+function _legacyLicenceHolder (licenceRoleId) {
+  return {
+    company_external_id: '1:007',
+    contact_external_id: '1:007',
+    start_date: new Date('2001-01-01'),
+    endDate: null,
+    licence_role_id: licenceRoleId
+  }
+}

--- a/test/validators/import/licence-holder.validator.test.js
+++ b/test/validators/import/licence-holder.validator.test.js
@@ -1,0 +1,182 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const { generateUUID } = require('../../../app/lib/general.lib.js')
+
+// Thing under test
+const ImportLicenceHolderValidator = require('../../../app/validators/import/licence-holder.validator.js')
+
+describe('Import Licence Holder validator', () => {
+  let transformedLicenceHolder
+
+  beforeEach(async () => {
+    transformedLicenceHolder = _transfromedLicenceHolder()
+  })
+
+  describe('when valid data is provided', () => {
+    it('does not throw an error', () => {
+      expect(() => {
+        ImportLicenceHolderValidator.go(transformedLicenceHolder)
+      }).to.not.throw()
+    })
+  })
+
+  describe('the "companyExternalId" property', () => {
+    describe('when it is not a string', () => {
+      beforeEach(() => {
+        transformedLicenceHolder.companyExternalId = 1
+      })
+
+      it('throws an error', async () => {
+        expect(() => {
+          ImportLicenceHolderValidator.go(transformedLicenceHolder)
+        }).to.throw('"companyExternalId" must be a string')
+      })
+    })
+
+    describe('when it is not present', () => {
+      beforeEach(() => {
+        delete transformedLicenceHolder.companyExternalId
+      })
+
+      it('throws an error', async () => {
+        expect(() => {
+          ImportLicenceHolderValidator.go(transformedLicenceHolder)
+        }).to.throw('"companyExternalId" is required')
+      })
+    })
+  })
+
+  describe('the "contactExternalId" property', () => {
+    describe('when it is not a string', () => {
+      beforeEach(() => {
+        transformedLicenceHolder.contactExternalId = 1
+      })
+
+      it('throws an error', async () => {
+        expect(() => {
+          ImportLicenceHolderValidator.go(transformedLicenceHolder)
+        }).to.throw('"contactExternalId" must be a string')
+      })
+    })
+
+    describe('when it is not present', () => {
+      beforeEach(() => {
+        delete transformedLicenceHolder.contactExternalId
+      })
+
+      it('throws an error', async () => {
+        expect(() => {
+          ImportLicenceHolderValidator.go(transformedLicenceHolder)
+        }).to.throw('"contactExternalId" is required')
+      })
+    })
+  })
+
+  describe('the "startDate" property', () => {
+    describe('when it is not a date', () => {
+      beforeEach(() => {
+        transformedLicenceHolder.startDate = 1
+      })
+
+      it('throws an error', async () => {
+        expect(() => {
+          ImportLicenceHolderValidator.go(transformedLicenceHolder)
+        }).to.throw('"startDate" must be a valid date')
+      })
+    })
+
+    describe('when it is not present', () => {
+      beforeEach(() => {
+        delete transformedLicenceHolder.startDate
+      })
+
+      it('throws an error', async () => {
+        expect(() => {
+          ImportLicenceHolderValidator.go(transformedLicenceHolder)
+        }).to.throw('"startDate" is required')
+      })
+    })
+  })
+
+  describe('the "contactExternalId" property', () => {
+    describe('when it is not a null', () => {
+      beforeEach(() => {
+        transformedLicenceHolder.endDate = 1
+      })
+
+      it('throws an error', async () => {
+        expect(() => {
+          ImportLicenceHolderValidator.go(transformedLicenceHolder)
+        }).to.throw('"endDate" must be [null]')
+      })
+    })
+
+    describe('when it is not present', () => {
+      beforeEach(() => {
+        delete transformedLicenceHolder.endDate
+      })
+
+      it('throws an error', async () => {
+        expect(() => {
+          ImportLicenceHolderValidator.go(transformedLicenceHolder)
+        }).to.throw('"endDate" is required')
+      })
+    })
+  })
+
+  describe('the "contactExternalId" property', () => {
+    describe('when it is not a string', () => {
+      beforeEach(() => {
+        transformedLicenceHolder.licenceRoleId = 1
+      })
+
+      it('throws an error', async () => {
+        expect(() => {
+          ImportLicenceHolderValidator.go(transformedLicenceHolder)
+        }).to.throw('"licenceRoleId" must be a string')
+      })
+    })
+
+    describe('when it is not a valid GUID', () => {
+      beforeEach(() => {
+        transformedLicenceHolder.licenceRoleId = '123'
+      })
+
+      it('throws an error', async () => {
+        expect(() => {
+          ImportLicenceHolderValidator.go(transformedLicenceHolder)
+        }).to.throw('"licenceRoleId" must be a valid GUID')
+      })
+    })
+
+    describe('when it is not present', () => {
+      beforeEach(() => {
+        delete transformedLicenceHolder.licenceRoleId
+      })
+
+      it('throws an error', async () => {
+        expect(() => {
+          ImportLicenceHolderValidator.go(transformedLicenceHolder)
+        }).to.throw('"licenceRoleId" is required')
+      })
+    })
+  })
+})
+
+function _transfromedLicenceHolder () {
+  return {
+    companyExternalId: '1:007',
+    contactExternalId: '1:007',
+    startDate: new Date('2001-01-01'),
+    endDate: null,
+    licenceRoleId: generateUUID()
+  }
+}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4668

We need to replace the import service logic to import a licence from NALD.

The current import service iterates all the companies (known as parties in the import.NALD_PARTIES table) and updates CRM_V2 tables.

This change will use the nald licence id and region to update the companies (parties) licence holder data. This means going forwards we will only import companies (parties) licence holder when the licence is imported.

We will insert this imported data in the relevant public views.

This change focuses on the licence holder contact data (for a company) and will link a contact to a company if the contact is a person in the company contacts table.