### PR TITLE
Increase controllers unit test coverage

### DIFF
--- a/test/controllers/bills.controller.test.js
+++ b/test/controllers/bills.controller.test.js
@@ -12,6 +12,7 @@ const { expect } = Code
 const { postRequestOptions } = require('../support/general.js')
 
 // Things we need to stub
+const Boom = require('@hapi/boom')
 const RemoveBillService = require('../../app/services/bills/remove-bill.service.js')
 const SubmitRemoveBillService = require('../../app/services/bills/submit-remove-bill.service.js')
 const ViewBillService = require('../../app/services/bills/view-bill.service.js')
@@ -80,6 +81,22 @@ describe('Bills controller', () => {
             expect(response.statusCode).to.equal(200)
             expect(response.payload).to.contain('Bill for Mr B Blobby')
             expect(response.payload).to.contain('2 transactions')
+            expect(response.payload).to.contain('Current')
+          })
+        })
+
+        describe('and it is for a bill with a single licence pre sroc', () => {
+          beforeEach(async () => {
+            Sinon.stub(ViewBillService, 'go').resolves(_testSingleLicenceBillPreSroc())
+          })
+
+          it('returns the page successfully', async () => {
+            const response = await server.inject(options)
+
+            expect(response.statusCode).to.equal(200)
+            expect(response.payload).to.contain('Bill for Mr B Blobby')
+            expect(response.payload).to.contain('2 transactions')
+            expect(response.payload).to.contain('Old')
           })
         })
       })
@@ -116,19 +133,39 @@ describe('Bills controller', () => {
     describe('POST', () => {
       beforeEach(() => {
         options = postRequestOptions(`${rootPath}/remove`)
-
-        Sinon.stub(SubmitRemoveBillService, 'go').resolves(
-          '/billing/batch/c04ea618-d1ad-494b-bdc4-1bfa670876d0/processing'
-        )
       })
 
-      it('redirects to the legacy processing bill run page', async () => {
-        const response = await server.inject(options)
+      describe('when a request is valid', () => {
+        beforeEach(() => {
+          Sinon.stub(SubmitRemoveBillService, 'go').resolves(
+            '/billing/batch/c04ea618-d1ad-494b-bdc4-1bfa670876d0/processing'
+          )
+        })
 
-        expect(response.statusCode).to.equal(302)
-        expect(response.headers.location).to.equal(
-          '/billing/batch/c04ea618-d1ad-494b-bdc4-1bfa670876d0/processing'
-        )
+        it('redirects to the legacy processing bill run page', async () => {
+          const response = await server.inject(options)
+
+          expect(response.statusCode).to.equal(302)
+          expect(response.headers.location).to.equal(
+            '/billing/batch/c04ea618-d1ad-494b-bdc4-1bfa670876d0/processing'
+          )
+        })
+      })
+
+      describe('when the request fails', () => {
+        describe('because the removing service threw an error', () => {
+          beforeEach(async () => {
+            Sinon.stub(Boom, 'badImplementation').returns(new Boom.Boom('Bang', { statusCode: 500 }))
+            Sinon.stub(SubmitRemoveBillService, 'go').rejects()
+          })
+
+          it('returns the error page', async () => {
+            const response = await server.inject(options)
+
+            expect(response.statusCode).to.equal(200)
+            expect(response.payload).to.contain('Sorry, there is a problem with the service')
+          })
+        })
       })
     })
   })
@@ -217,6 +254,76 @@ function _testSingleLicenceBill () {
     licenceId: '6d4236b2-add7-4446-9472-6ffc98b0ded1',
     licenceRef: '17/99/001/G/999',
     scheme: 'sroc',
+    tableCaption: '2 transactions',
+    transactions: [
+      {
+        additionalCharges: '',
+        adjustments: '',
+        billableDays: '214/214',
+        chargeCategoryDescription: 'Medium loss, non-tidal, greater than 83 up to and including 142 ML/yr',
+        chargeElements: [{
+          purpose: 'Trickle Irrigation - Direct',
+          abstractionPeriod: '1 April to 31 October',
+          volume: '21.474ML'
+        }],
+        chargePeriod: '1 April 2023 to 31 March 2024',
+        chargeReference: '4.5.13 (£11.62)',
+        chargeType: 'standard',
+        creditAmount: '',
+        debitAmount: '£1,162.00',
+        description: 'Water abstraction charge: Original',
+        quantity: '100ML'
+      },
+      {
+        billableDays: '214/214',
+        chargePeriod: '1 April 2023 to 31 March 2024',
+        chargeType: 'compensation',
+        creditAmount: '',
+        debitAmount: '£0.00',
+        description: 'Compensation charge',
+        quantity: '100ML'
+      }
+    ],
+    transactionsTotal: '£1,162.00'
+  }
+}
+
+function _testSingleLicenceBillPreSroc () {
+  return {
+    accountName: 'Mr B Blobby',
+    accountNumber: 'E99999999A',
+    addressLines: [
+      'C/O Noel Edmonds',
+      'Crinkley Bottom',
+      'Cricket St Thomas',
+      'Somerset',
+      'TA20 1KL'
+    ],
+    billId: '8b8b8831-d671-4456-93cd-30310e6fdf7a',
+    billingAccountId: '7771d5a3-305c-4564-8167-74ba0cc4f08e',
+    billNumber: 'EAI9999999T',
+    billRunId: '420e948f-1992-437e-8a47-74c0066cb017',
+    billRunNumber: 10010,
+    billRunStatus: 'sent',
+    billRunType: 'Supplementary',
+    chargeScheme: 'Old',
+    contactName: null,
+    credit: false,
+    creditsTotal: '£0.00',
+    dateCreated: '1 November 2023',
+    debitsTotal: '£1,162.00',
+    deminimis: false,
+    displayCreditDebitTotals: true,
+    financialYear: '2023 to 2024',
+    flaggedForReissue: false,
+    region: 'South West',
+    total: '£1,162.00',
+    transactionFile: 'nalei50002t',
+    creditTotal: '£0.00',
+    debitTotal: '£1,162.00',
+    licenceId: '6d4236b2-add7-4446-9472-6ffc98b0ded1',
+    licenceRef: '17/99/001/G/999',
+    scheme: 'alcs',
     tableCaption: '2 transactions',
     transactions: [
       {

--- a/test/controllers/jobs.controller.test.js
+++ b/test/controllers/jobs.controller.test.js
@@ -18,7 +18,7 @@ const ProcessReturnLogsService = require('../../app/services/jobs/return-logs/pr
 // For running our service
 const { init } = require('../../app/server.js')
 
-describe('Jobs controller', () => {
+describe.only('Jobs controller', () => {
   let options
   let server
 
@@ -122,7 +122,31 @@ describe('Jobs controller', () => {
     describe('when the requested cycle is summer', () => {
       describe('POST', () => {
         beforeEach(() => {
-          options = { method: 'POST', url: '/jobs/return-logs/summer' }
+          options = { method: 'POST', url: '/jobs/return-logs/summer', payload: {} }
+        })
+
+        describe('when the request succeeds', () => {
+          beforeEach(async () => {
+            Sinon.stub(ProcessReturnLogsService, 'go').resolves()
+          })
+
+          it('returns a 204 response', async () => {
+            const response = await server.inject(options)
+
+            expect(response.statusCode).to.equal(204)
+          })
+        })
+      })
+    })
+
+    describe('when the licence reference is known', () => {
+      describe('POST', () => {
+        beforeEach(() => {
+          options = {
+            method: 'POST',
+            url: '/jobs/return-logs/summer',
+            payload: { licenceReference: 'AT/Test' }
+          }
         })
 
         describe('when the request succeeds', () => {
@@ -159,7 +183,7 @@ describe('Jobs controller', () => {
       })
     })
 
-    describe('when the requested cycel is unknown', () => {
+    describe('when the requested cycle is unknown', () => {
       describe('POST', () => {
         beforeEach(() => {
           options = { method: 'POST', url: '/jobs/return-logs/winter' }

--- a/test/controllers/jobs.controller.test.js
+++ b/test/controllers/jobs.controller.test.js
@@ -18,7 +18,7 @@ const ProcessReturnLogsService = require('../../app/services/jobs/return-logs/pr
 // For running our service
 const { init } = require('../../app/server.js')
 
-describe.only('Jobs controller', () => {
+describe('Jobs controller', () => {
   let options
   let server
 


### PR DESCRIPTION
As part of the maintenance work, this PR is set to increase the unit test coverage of the jobs, bill-runs-setup, bills, and bill-licences controller. These added tests, take the test coverage up to 100% in all these files.