### PR TITLE
Incorrect status showing on licence set up page

### DIFF
--- a/test/services/return-requirements/generate-return-version.service.test.js
+++ b/test/services/return-requirements/generate-return-version.service.test.js
@@ -176,7 +176,7 @@ describe('Generate Return Version service', () => {
 
       expect(result.returnRequirements).to.equal([])
       expect(result.returnVersion.createdBy).to.equal(userId)
-      expect(result.returnVersion.endDate).to.equal('2024-04-01T00:00:00.000Z')
+      expect(result.returnVersion.endDate).to.be.null()
       expect(result.returnVersion.licenceId).to.equal(licenceId)
       expect(result.returnVersion.multipleUpload).to.be.false()
       expect(result.returnVersion.notes).to.be.undefined()
@@ -184,12 +184,6 @@ describe('Generate Return Version service', () => {
       expect(result.returnVersion.startDate).to.equal(new Date(sessionData.licence.currentVersionStartDate))
       expect(result.returnVersion.status).to.equal('current')
       expect(result.returnVersion.version).to.equal(1)
-    })
-
-    it('processes the existing return versions', async () => {
-      await GenerateReturnVersionService.go(sessionData, userId)
-
-      expect(ProcessExistingReturnVersionsService.go.called).to.be.true()
     })
   })
 })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4671

An issue has been found during QA where if you find a licence that has no existing returns. Then create 2 or 3 "no return required" journeys followed by a new "return required" journey. That the statuses are not updating correctly.

This problem is related to the issue that wasn't quite fixed in this PR https://github.com/DEFRA/water-abstraction-system/pull/1325

The problem was caused by the logic that determines if there are previous return versions. Previously, it relied on the session data. However, this has proved unreliable when returns have been generated via the "no returns required" journey. Therefore, I have amended this logic to check the actual `return_versions` table rather than the session data.