### PR TITLE
Include water.points in data tear down

### DIFF
--- a/app/services/data/tear-down/water-schema.service.js
+++ b/app/services/data/tear-down/water-schema.service.js
@@ -7,6 +7,11 @@
 
 const { db } = require('../../../../db/db.js')
 
+/**
+ * Removes all data created for acceptance tests from the water schema
+ *
+ * @returns {Promise<object>}
+ */
 async function go () {
   return _deleteAllTestData()
 }
@@ -182,6 +187,20 @@ async function _deleteAllTestData () {
 
   DELETE
   FROM
+    "water"."points" AS p
+      USING "water"."return_requirement_points" AS "rrpt",
+    "water"."return_requirements" AS "rr",
+    "water"."return_versions" AS "rv",
+    "water"."licences" AS "l"
+  WHERE
+    "l"."is_test" = TRUE
+    AND "p"."id" = "rrpt"."point_id"
+    AND "rrpt"."return_requirement_id" = "rr"."return_requirement_id"
+    AND "rr"."return_version_id" = "rv"."return_version_id"
+    AND "rv"."licence_id" = "l"."licence_id";
+
+  DELETE
+  FROM
     "water"."return_requirement_points" AS "rrpt"
       USING "water"."return_requirements" AS "rr",
     "water"."return_versions" AS "rv",
@@ -239,6 +258,20 @@ async function _deleteAllTestData () {
     "water"."financial_agreement_types"
   WHERE
     "is_test" = TRUE;
+
+  DELETE
+  FROM
+    "water"."points" AS "p"
+      USING"water"."licence_version_purpose_points" AS "lvpp",
+    "water"."licence_version_purposes" AS "lvp",
+    "water"."licence_versions" AS "lv",
+    "water"."licences" AS "l"
+  WHERE
+    "l"."is_test" = TRUE
+    AND "p"."id" = "lvpp"."point_id"
+    AND "lvpp"."licence_version_purpose_id" = "lvp"."licence_version_purpose_id"
+    AND "lvp"."licence_version_id" = "lv"."licence_version_id"
+    AND "lv"."licence_id" = "l"."licence_id";
 
   DELETE
   FROM


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4600
https://eaflood.atlassian.net/browse/WATER-4645

> Part of the work to migrate return versions from NALD to WRLS

In [Update the 'points' data solution](https://github.com/DEFRA/water-abstraction-system/pull/1352), we updated this project to source point information (where water is extracted) from new tables we'd created instead of extracting it from the `permit.licence` JSONB blob.

At the same time we included it in our data loader, which is used by [water-abstraction-acceptance-tests](https://github.com/DEFRA/water-abstraction-acceptance-tests). But we forgot to include it in the data tear down, which is also used by the acceptance tests to avoid orphaned test data causing other issues.