### PR TITLE
Incorrect status showing on licence set up page

### DIFF
--- a/app/services/return-requirements/process-existing-return-versions.service.js
+++ b/app/services/return-requirements/process-existing-return-versions.service.js
@@ -26,6 +26,11 @@ async function go (licenceId, newVersionStartDate) {
 
   let result
 
+  result = await _replacePreviousVersion(previousVersions, newVersionStartDate)
+  if (result) {
+    return result
+  }
+
   result = await _endLatestVersion(previousVersions, newVersionStartDate, previousVersionEndDate)
   if (result) {
     return null
@@ -39,11 +44,6 @@ async function go (licenceId, newVersionStartDate) {
   result = await _replaceLatestVersion(previousVersions, newVersionStartDate)
   if (result) {
     return null
-  }
-
-  result = await _replacePreviousVersion(previousVersions, newVersionStartDate)
-  if (result) {
-    return result
   }
 
   return null
@@ -219,7 +219,7 @@ async function _replaceLatestVersion (previousVersions, newVersionStartDate) {
 async function _replacePreviousVersion (previousVersions, newVersionStartDate) {
   const matchedReturnVersion = previousVersions.find((previousVersion) => {
     return previousVersion.startDate.getTime() === newVersionStartDate.getTime() &&
-      previousVersion.endDate > newVersionStartDate
+      previousVersion.endDate.getTime() >= newVersionStartDate.getTime()
   })
 
   if (!matchedReturnVersion) {

--- a/app/services/return-requirements/process-existing-return-versions.service.js
+++ b/app/services/return-requirements/process-existing-return-versions.service.js
@@ -219,7 +219,7 @@ async function _replaceLatestVersion (previousVersions, newVersionStartDate) {
 async function _replacePreviousVersion (previousVersions, newVersionStartDate) {
   const matchedReturnVersion = previousVersions.find((previousVersion) => {
     return previousVersion.startDate.getTime() === newVersionStartDate.getTime() &&
-      previousVersion.endDate.getTime() >= newVersionStartDate.getTime()
+      previousVersion.endDate >= newVersionStartDate
   })
 
   if (!matchedReturnVersion) {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4671

Carrying on from the issue that was fixed in https://github.com/DEFRA/water-abstraction-system/pull/1363 another issue has been found with the status.

The problem can be recreated by:

1. New requirements added with a start date of 01/04/2022 that will have no end date.
2. Another new requirement is added with a start date 1 day later on the 02/04/2022. This will put an end date on the one created in step 1. of 01/04/2022. So the first will start and end on the same day.
3. Set up another new requirement with a start date of the 01/04/2022. This new requirement should replace the first but instead is just added and does not replace anything.

![Screenshot 2024-09-27 at 14 20 04](https://github.com/user-attachments/assets/fd042ba6-fcad-4b73-887d-4a59b1a9ce73)

There are 2 issues that together appear to be causing this problem. The first was the order in which the checks were being carried out to see where the new return fitted in. The second was that it wasn’t expecting a return with a start and end date to be the same. This PR should fix those problems.