### PR TITLE
Stop generating optional data in company helper

### DIFF
--- a/test/support/helpers/company.helper.js
+++ b/test/support/helpers/company.helper.js
@@ -14,8 +14,6 @@ const { randomInteger } = require('../general.js')
  *
  * - `name` - Example Trading Ltd
  * - `type` - organisation
- * - `companyNumber` - [randomly generated - 24296934]
- * - `organisationType` - limitedCompany
  *
  * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  *
@@ -42,10 +40,7 @@ function add (data = {}) {
 function defaults (data = {}) {
   const defaults = {
     name: 'Example Trading Ltd',
-    type: 'organisation',
-    companyNumber: generateCompanyNumber(),
-    organisationType: 'limitedCompany',
-    externalId: generateExternalId()
+    type: 'organisation'
   }
 
   return {
@@ -64,15 +59,15 @@ function generateCompanyNumber () {
 }
 
 /**
- * Generate a company extrnal id
+ * Generate a company external id
  *
- * This is build from NALD import data using the region code and party id
+ * This is built from NALD import data using the region code and party id
  *
  * @returns {string} - A random external id
  */
 function generateExternalId () {
   const regionCode = randomInteger(1, 9)
-  const partyId = randomInteger(100, 99998)
+  const partyId = randomInteger(100, 9999998)
 
   return `${regionCode}:${partyId}`
 }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4600
https://eaflood.atlassian.net/browse/WATER-4645

We spotted when working on [Updating all scenarios to use new points solution](https://github.com/DEFRA/water-abstraction-acceptance-tests/pull/137) in **water-abstraction-acceptance-tests** that we were getting intermittent failures.

When we looked at the logs, we often saw.

```text
[15:57:07.633] ERROR (12080): insert into "companies" ("company_number", "external_id", "id", "name", "organisation_type", "type") values ($1, $2, $3, $4, $5, $6) returning * - duplicate key value violates unique constraint "unique_external_id"
    err: {
      "type": "UniqueViolationError",
      "message": "insert into \"companies\" (\"company_number\", \"external_id\", \"id\", \"name\", \"organisation_type\", \"type\") values ($1, $2, $3, $4, $5, $6) returning * - duplicate key value violates unique constraint \"unique_external_id\"",
```

When we checked the `CompanyHelper`, we spotted that we were populating fields, including `external_id`, that were not required. The idea of the helpers is to populate the minimum needed: anything is on the caller to provide. If we don't need to populate these fields, we stand a better chance of avoiding failures due to unique constraint clashes.