### PR TITLE
Add abstraction method to lic. purpose points

### DIFF
--- a/db/migrations/legacy/20221108007039_water-licence-version-purpose-points.js
+++ b/db/migrations/legacy/20221108007039_water-licence-version-purpose-points.js
@@ -20,6 +20,7 @@ exports.up = function (knex) {
       table.text('external_id')
       table.integer('nald_point_id')
       table.uuid('point_id')
+      table.text('abstraction_method')
 
       // Legacy timestamps
       table.timestamp('date_created', { useTz: false }).notNullable().defaultTo(knex.fn.now())

--- a/db/migrations/public/20241003073555_alter-licence-version-purpose-points-view.js
+++ b/db/migrations/public/20241003073555_alter-licence-version-purpose-points-view.js
@@ -1,0 +1,36 @@
+'use strict'
+
+const viewName = 'licence_version_purpose_points'
+
+exports.up = function (knex) {
+  return knex
+    .schema
+    .dropViewIfExists(viewName)
+    .createView(viewName, (view) => {
+      view.as(knex('licence_version_purpose_points').withSchema('water').select([
+        'id',
+        'licence_version_purpose_id',
+        'point_id',
+        'external_id',
+        'abstraction_method',
+        'date_created AS created_at',
+        'date_updated AS updated_at'
+      ]))
+    })
+}
+
+exports.down = function (knex) {
+  return knex
+    .schema
+    .dropViewIfExists(viewName)
+    .createView(viewName, (view) => {
+      view.as(knex('licence_version_purpose_points').withSchema('water').select([
+        'id',
+        'licence_version_purpose_id',
+        'point_id',
+        'external_id',
+        'date_created AS created_at',
+        'date_updated AS updated_at'
+      ]))
+    })
+}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4645

> Part of the work to migrate return versions from NALD to WRLS

We recently [Updated view licence summary to use new points data](https://github.com/DEFRA/water-abstraction-system/pull/1316). This is part of a series of changes to help us move away from extracting point information from the licence JSON blob in `permit.licence`.

We're also looking to migrate the pages linked to from the view licence summary, which are currently in the legacy [water-abstraction-ui](https://github.com/DEFRA/water-abstraction-ui). One of them is information on 'points'. We thought we'd captured everything 'point' related in [the changes we made to the points schema](https://github.com/DEFRA/water-abstraction-service/pull/2638) but have since spotted 'Means of abstraction'.

This is linked to an abstraction purpose point in NALD and gives how water will be abstracted there, for example, "Surface Mounted Pump (Fixed)". We'll [populate this field](https://github.com/DEFRA/water-abstraction-import/pull/1029) as we import a licence's point information from NALD.

This change updates the view so we can access the new field.