### PR TITLE
Fix down migrations for return logs view

### DIFF
--- a/db/migrations/public/20240807132127_alter-return-logs-view-include-source.js
+++ b/db/migrations/public/20240807132127_alter-return-logs-view-include-source.js
@@ -50,7 +50,7 @@ exports.down = function (knex) {
         // 'source', // always 'NALD'
         'metadata',
         'received_date',
-        'return_requirement',
+        'return_requirement as return_reference',
         'due_date',
         'under_query',
         // 'under_query_comment',

--- a/db/migrations/public/20240918144353_alter-return-logs-view.js
+++ b/db/migrations/public/20240918144353_alter-return-logs-view.js
@@ -47,10 +47,10 @@ exports.down = function (knex) {
         'end_date',
         'returns_frequency',
         'status',
-        // 'source', // always 'NALD'
+        'source',
         'metadata',
         'received_date',
-        'return_requirement',
+        'return_requirement as return_reference',
         'due_date',
         'under_query',
         // 'under_query_comment',


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4542

> Part of the work to migrate return versions from NALD to WRLS

We've been working on generating return logs in this repo, taking over from what NALD does.

This has meant changing what we see in our `return_logs` view.

When preparing a release for `production`, we needed to move our local environments back to the version of **water-abstraction-system** to match production.

This also meant rolling back changes to views to be in sync. When we did that, though, we started hitting lots of errors.

We tracked it down to the `down()` functions in recent alter `return_logs` migrations being wrong. Essentially, they were resetting the view to its original state rather than the previous state.

Fixing the functions means if anyone has to do the same and return to this point in the future, running `npm run rollback` shouldn't break anything.