### PR TITLE
Handle return requirements with no site desc.

### DIFF
--- a/app/presenters/return-requirements/view.presenter.js
+++ b/app/presenters/return-requirements/view.presenter.js
@@ -114,8 +114,8 @@ function _mapRequirement (requirement) {
     purposes: _purposes(requirement.returnRequirementPurposes),
     returnReference: requirement.legacyId,
     returnsCycle: requirement.summer === true ? 'Summer' : 'Winter and all year',
-    siteDescription: requirement.siteDescription,
-    title: requirement.siteDescription
+    siteDescription: requirement.siteDescription ?? '',
+    title: requirement.siteDescription ?? ''
   }
 }
 

--- a/app/views/return-requirements/view.njk
+++ b/app/views/return-requirements/view.njk
@@ -88,13 +88,20 @@
     <div class="govuk-!-margin-bottom-9">
       <h2 class="govuk-heading-l govuk-!-margin-bottom-4">Requirements for returns</h2>
 
-      {# Bookmarks - only displays when there us more than 1 return requirement #}
+      {# Bookmarks - only displays when there is more than 1 return requirement #}
       {% if requirements.length > 1 %}
         <div class="govuk-body govuk-!-margin-bottom-6">
           <ul>
             {% for requirement in requirements %}
               {% set requirementIndex = loop.index0 %}
-              <li><a href="#requirement-{{ requirementIndex }}">Return reference {{ requirement.returnReference }} - {{ requirement.siteDescription }}</a></li>
+              {% set bookmarkTitle %}
+                {% if requirement.siteDescription == '' %}
+                  Return reference {{ requirement.returnReference }}
+                {% else %}
+                  Return reference {{ requirement.returnReference }} - {{ requirement.siteDescription }}
+                {% endif %}
+              {% endset %}
+              <li><a href="#requirement-{{ requirementIndex }}">{{ bookmarkTitle }}</a></li>
             {% endfor %}
           </ul>
         </div>

--- a/test/presenters/return-requirements/view.presenter.test.js
+++ b/test/presenters/return-requirements/view.presenter.test.js
@@ -288,6 +288,58 @@ describe('Return Requirements - View presenter', () => {
         })
       })
     })
+
+    describe('the requirements "siteDescription" property', () => {
+      describe('when there is a site description', () => {
+        it('returns the site description', () => {
+          const result = ViewPresenter.go(returnVersion)
+
+          const { siteDescription } = result.requirements[0]
+
+          expect(siteDescription).to.equal('Borehole in field')
+        })
+      })
+
+      describe('when there is no site description', () => {
+        beforeEach(() => {
+          returnVersion.returnRequirements[0].siteDescription = null
+        })
+
+        it('returns an empty string', () => {
+          const result = ViewPresenter.go(returnVersion)
+
+          const { siteDescription } = result.requirements[0]
+
+          expect(siteDescription).to.equal('')
+        })
+      })
+    })
+
+    describe('the requirements "title" property', () => {
+      describe('when there is a site description', () => {
+        it('returns the site description as the title', () => {
+          const result = ViewPresenter.go(returnVersion)
+
+          const { title } = result.requirements[0]
+
+          expect(title).to.equal('Borehole in field')
+        })
+      })
+
+      describe('when there is no site description', () => {
+        beforeEach(() => {
+          returnVersion.returnRequirements[0].siteDescription = null
+        })
+
+        it('returns an empty string as the title', () => {
+          const result = ViewPresenter.go(returnVersion)
+
+          const { title } = result.requirements[0]
+
+          expect(title).to.equal('')
+        })
+      })
+    })
   })
 })
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4685

We recently [Added the site description to bookmark links in the view return version page](https://github.com/DEFRA/water-abstraction-system/pull/1358).

In testing, our QA team has spotted that some return requirements we've imported from NALD do not have a site description.

When WRLS takes over return management, site description will be a mandatory field. However, we'll still have to support viewing returns imported from NALD.

So, this change updates the view to handle return requirements with no site description.