### PR TITLE
Stop display null site desc. in view licence rtn

### DIFF
--- a/app/presenters/licences/view-licence-returns.presenter.js
+++ b/app/presenters/licences/view-licence-returns.presenter.js
@@ -64,7 +64,7 @@ function _returns (returns, canManageReturns) {
 
     return {
       dates: `${formatLongDate(new Date(startDate))} to ${formatLongDate(new Date(endDate))}`,
-      description: metadata.description,
+      description: metadata.description === 'null' ? '' : metadata.description,
       dueDate: formatLongDate(new Date(dueDate)),
       link: _link(status, returnLogId, canManageReturns),
       purpose: _purpose(metadata.purposes),

--- a/test/presenters/licences/view-licence-returns.presenter.test.js
+++ b/test/presenters/licences/view-licence-returns.presenter.test.js
@@ -70,6 +70,30 @@ describe('View Licence returns presenter', () => {
       })
     })
 
+    describe('the "description" property', () => {
+      describe('when description in the metadata is set', () => {
+        it('returns an empty string', () => {
+          const result = ViewLicenceReturnsPresenter.go(returnLogs, hasRequirements, auth)
+
+          expect(result.returns[0].description).to.equal('empty description')
+        })
+      })
+
+      describe('when description in the metadata is "null"', () => {
+        beforeEach(() => {
+          // NOTE: water-abstraction-import sets the value to 'null' rather than null when it imports the return log
+          // from NALD
+          returnLogs[0].metadata.description = 'null'
+        })
+
+        it('returns an empty string', () => {
+          const result = ViewLicenceReturnsPresenter.go(returnLogs, hasRequirements, auth)
+
+          expect(result.returns[0].description).to.equal('')
+        })
+      })
+    })
+
     describe('the "link" property', () => {
       describe('when the return log has a status of "completed"', () => {
         it('returns a link to the view return log page', () => {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4702

If a return log was created from a return requirement with no site description, when a user sees the return log listed in the view licence returns page, they will see `null`.

We've agreed that we should display nothing when this is the case. This change updates the view licence returns page to handle this scenario.

<img width="965" alt="Screenshot 2024-10-04 at 18 10 06" src="https://github.com/user-attachments/assets/20fe1df6-00f6-49db-8fd2-bc0b02787700">
