### PR TITLE
Handle empty site description in returns setup

### DIFF
--- a/app/services/return-requirements/fetch-existing-requirements.js
+++ b/app/services/return-requirements/fetch-existing-requirements.js
@@ -1,0 +1,75 @@
+'use strict'
+
+/**
+ * Fetches an existing return version and its return requirements in order for a new one to be copied from it
+ * @module FetchExistingRequirementsService
+ */
+
+const ReturnVersionModel = require('../../models/return-version.model.js')
+
+/**
+ * Fetches an existing return version and its return requirements in order for a new one to be copied from it
+ *
+ * In the returns setup journey we allow users to select the option to create new requirements by copying from them from
+ * an existing return version. This service fetches the selected return version and its existing return requirements.
+ * For each one found we'll generate a return requirement setup object in `GenerateFromExistingRequirementsService`.
+ *
+ * @param {string} returnVersionId - The UUID of the selected return version to copy requirements from
+ *
+ * @returns {Promise<module:ReturnVersionModel>} the matching return version and related return requirements
+ */
+async function go (returnVersionId) {
+  return _fetch(returnVersionId)
+}
+
+async function _fetch (returnVersionId) {
+  return ReturnVersionModel.query()
+    .findById(returnVersionId)
+    .select([
+      'id'
+    ])
+    .withGraphFetched('returnRequirements')
+    .modifyGraph('returnRequirements', (builder) => {
+      builder.select([
+        'id',
+        'abstractionPeriodEndDay',
+        'abstractionPeriodEndMonth',
+        'abstractionPeriodStartDay',
+        'abstractionPeriodStartMonth',
+        'collectionFrequency',
+        'fiftySixException',
+        'gravityFill',
+        'reabstraction',
+        'reportingFrequency',
+        'siteDescription',
+        'summer',
+        'twoPartTariff'
+      ])
+    })
+    .withGraphFetched('returnRequirements.points')
+    .modifyGraph('returnRequirements.points', (builder) => {
+      builder.select([
+        'points.id',
+        'points.description'
+      ])
+    })
+    .withGraphFetched('returnRequirements.returnRequirementPurposes')
+    .modifyGraph('returnRequirements.returnRequirementPurposes', (builder) => {
+      builder.select([
+        'id',
+        'alias',
+        'purposeId'
+      ])
+    })
+    .withGraphFetched('returnRequirements.returnRequirementPurposes.purpose')
+    .modifyGraph('returnRequirements.returnRequirementPurposes.purpose', (builder) => {
+      builder.select([
+        'id',
+        'description'
+      ])
+    })
+}
+
+module.exports = {
+  go
+}

--- a/app/services/return-requirements/generate-from-existing-requirements.service.js
+++ b/app/services/return-requirements/generate-from-existing-requirements.service.js
@@ -83,7 +83,8 @@ async function _fetch (returnVersionId) {
     .withGraphFetched('returnRequirements.points')
     .modifyGraph('returnRequirements.points', (builder) => {
       builder.select([
-        'points.id'
+        'points.id',
+        'points.description'
       ])
     })
     .withGraphFetched('returnRequirements.returnRequirementPurposes')
@@ -121,6 +122,14 @@ function _purposes (returnRequirementPurposes) {
   })
 }
 
+function _siteDescription (siteDescription, points) {
+  if (siteDescription) {
+    return siteDescription
+  }
+
+  return points[0].description
+}
+
 function _transformForSetup (returnVersion) {
   const { returnRequirements } = returnVersion
 
@@ -142,7 +151,7 @@ function _transformForSetup (returnVersion) {
       points: _points(points),
       purposes: _purposes(returnRequirementPurposes),
       returnsCycle: summer ? 'summer' : 'winter-and-all-year',
-      siteDescription,
+      siteDescription: _siteDescription(siteDescription, points),
       abstractionPeriod: {
         'end-abstraction-period-day': abstractionPeriodEndDay,
         'end-abstraction-period-month': abstractionPeriodEndMonth,

--- a/app/services/return-requirements/generate-from-existing-requirements.service.js
+++ b/app/services/return-requirements/generate-from-existing-requirements.service.js
@@ -1,18 +1,18 @@
 'use strict'
 
 /**
- * Fetches an existing return version and generates setup return requirements from it
- * @module FetchExistingRequirementsService
+ * Generates returns setup requirements from an existing return version
+ * @module GenerateFromExistingRequirementsService
  */
 
-const ReturnVersionModel = require('../../models/return-version.model.js')
+const FetchExistingRequirementsService = require('./fetch-existing-requirements.js')
 
 /**
- * Fetches an existing return version and generates setup return requirements from it
+ * Generates returns setup requirements from an existing return version
  *
  * In the returns setup journey we allow users to select the option to create new requirements by copying from them
  * from an existing return version. This service fetches the selected return version and its existing return
- * requirements. For each one found we generate a return requirement setup object.
+ * requirements. For each one found it generates a return requirement setup object.
  *
  * Note, we are not creating a `return_requirement` record but an object that matches what the setup journey expects.
  * This means the requirements will display correctly in the `/check` page, and users can amend the values using the
@@ -24,7 +24,7 @@ const ReturnVersionModel = require('../../models/return-version.model.js')
  * be persisted to the setup session
  */
 async function go (returnVersionId) {
-  const returnVersion = await _fetch(returnVersionId)
+  const returnVersion = await FetchExistingRequirementsService.go(returnVersionId)
 
   return _transformForSetup(returnVersion)
 }
@@ -54,54 +54,6 @@ function _agreementExceptions (returnRequirement) {
   }
 
   return agreementsExceptions
-}
-
-async function _fetch (returnVersionId) {
-  return ReturnVersionModel.query()
-    .findById(returnVersionId)
-    .select([
-      'id'
-    ])
-    .withGraphFetched('returnRequirements')
-    .modifyGraph('returnRequirements', (builder) => {
-      builder.select([
-        'id',
-        'abstractionPeriodEndDay',
-        'abstractionPeriodEndMonth',
-        'abstractionPeriodStartDay',
-        'abstractionPeriodStartMonth',
-        'collectionFrequency',
-        'fiftySixException',
-        'gravityFill',
-        'reabstraction',
-        'reportingFrequency',
-        'siteDescription',
-        'summer',
-        'twoPartTariff'
-      ])
-    })
-    .withGraphFetched('returnRequirements.points')
-    .modifyGraph('returnRequirements.points', (builder) => {
-      builder.select([
-        'points.id',
-        'points.description'
-      ])
-    })
-    .withGraphFetched('returnRequirements.returnRequirementPurposes')
-    .modifyGraph('returnRequirements.returnRequirementPurposes', (builder) => {
-      builder.select([
-        'alias',
-        'id',
-        'purposeId'
-      ])
-    })
-    .withGraphFetched('returnRequirements.returnRequirementPurposes.purpose')
-    .modifyGraph('returnRequirements.returnRequirementPurposes.purpose', (builder) => {
-      builder.select([
-        'id',
-        'description'
-      ])
-    })
 }
 
 function _points (points) {

--- a/test/services/return-requirements/fetch-existing-requirements.test.js
+++ b/test/services/return-requirements/fetch-existing-requirements.test.js
@@ -1,0 +1,110 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, before } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const RequirementsForReturnsSeeder = require('../../support/seeders/requirements-for-returns.seeder.js')
+
+// Thing under test
+const FetchExistingRequirementsService = require('../../../app/services/return-requirements/fetch-existing-requirements.js')
+
+describe('Return Requirements - Fetch Existing Requirements service', () => {
+  let returnVersion
+
+  describe('when a matching return version exists', () => {
+    before(async () => {
+      const seedData = await RequirementsForReturnsSeeder.seed()
+
+      returnVersion = seedData.returnVersion
+    })
+
+    it('returns the details of the requirements for returns', async () => {
+      const result = await FetchExistingRequirementsService.go(returnVersion.id)
+
+      const [returnRequirementsOne, returnRequirementsTwo] = result.returnRequirements
+
+      expect(result).to.equal({
+        id: returnVersion.id,
+        returnRequirements: [
+          {
+            id: returnRequirementsOne.id,
+            abstractionPeriodEndDay: 31,
+            abstractionPeriodEndMonth: 3,
+            abstractionPeriodStartDay: 1,
+            abstractionPeriodStartMonth: 4,
+            collectionFrequency: 'week',
+            fiftySixException: false,
+            gravityFill: false,
+            reabstraction: false,
+            reportingFrequency: 'week',
+            siteDescription: 'FIRST BOREHOLE AT AVALON',
+            summer: false,
+            twoPartTariff: false,
+            points: [
+              {
+                id: returnRequirementsOne.points[0].id,
+                description: 'WELL AT WELLINGTON'
+              }
+            ],
+            returnRequirementPurposes: [
+              {
+                id: returnRequirementsOne.returnRequirementPurposes[0].id,
+                alias: 'I have an alias',
+                purposeId: returnRequirementsOne.returnRequirementPurposes[0].purpose.id,
+                purpose: {
+                  id: returnRequirementsOne.returnRequirementPurposes[0].purpose.id,
+                  description: returnRequirementsOne.returnRequirementPurposes[0].purpose.description
+                }
+              }
+            ]
+          },
+          {
+            id: returnRequirementsTwo.id,
+            abstractionPeriodEndDay: 31,
+            abstractionPeriodEndMonth: 3,
+            abstractionPeriodStartDay: 1,
+            abstractionPeriodStartMonth: 4,
+            collectionFrequency: 'week',
+            fiftySixException: true,
+            gravityFill: true,
+            reabstraction: true,
+            reportingFrequency: 'month',
+            siteDescription: 'SECOND BOREHOLE AT AVALON',
+            summer: true,
+            twoPartTariff: true,
+            points: [
+              {
+                id: returnRequirementsTwo.points[0].id,
+                description: 'WELL AT WELLINGTON'
+              }
+            ],
+            returnRequirementPurposes: [
+              {
+                id: returnRequirementsTwo.returnRequirementPurposes[0].id,
+                alias: null,
+                purposeId: returnRequirementsTwo.returnRequirementPurposes[0].purpose.id,
+                purpose: {
+                  id: returnRequirementsTwo.returnRequirementPurposes[0].purpose.id,
+                  description: returnRequirementsTwo.returnRequirementPurposes[0].purpose.description
+                }
+              }
+            ]
+          }
+        ]
+      })
+    })
+  })
+
+  describe('when a matching return version does not exist', () => {
+    it('returns nothing', async () => {
+      const result = await FetchExistingRequirementsService.go('7d0c235a-6556-47dc-8d18-3b2965d49703')
+
+      expect(result).to.be.undefined()
+    })
+  })
+})

--- a/test/services/return-requirements/generate-from-existing-requirements.service.test.js
+++ b/test/services/return-requirements/generate-from-existing-requirements.service.test.js
@@ -17,15 +17,15 @@ const GenerateFromExistingRequirementsService = require('../../../app/services/r
 describe('Return Requirements - Generate From Existing Requirements service', () => {
   let returnVersion
 
+  afterEach(() => {
+    Sinon.restore()
+  })
+
   describe('when a matching return version exists', () => {
     beforeEach(async () => {
       returnVersion = _returnVersion()
 
       Sinon.stub(FetchExistingRequirementsService, 'go').resolves(returnVersion)
-    })
-
-    afterEach(() => {
-      Sinon.restore()
     })
 
     it('returns the details of the its return requirements transformed for use in the journey', async () => {
@@ -76,6 +76,18 @@ describe('Return Requirements - Generate From Existing Requirements service', ()
           ]
         }
       ])
+    })
+  })
+
+  describe('when a matching return version does not exist', () => {
+    beforeEach(async () => {
+      returnVersion = undefined
+
+      Sinon.stub(FetchExistingRequirementsService, 'go').resolves(returnVersion)
+    })
+
+    it('throws an error', async () => {
+      await expect(GenerateFromExistingRequirementsService.go('6d436e7b-c3c9-493c-97f3-b397c899c926')).to.reject()
     })
   })
 })

--- a/test/services/return-requirements/generate-from-existing-requirements.service.test.js
+++ b/test/services/return-requirements/generate-from-existing-requirements.service.test.js
@@ -22,7 +22,7 @@ describe('Return Requirements - Generate From Existing Requirements service', ()
   })
 
   describe('when a matching return version exists', () => {
-    beforeEach(async () => {
+    beforeEach(() => {
       returnVersion = _returnVersion()
 
       Sinon.stub(FetchExistingRequirementsService, 'go').resolves(returnVersion)
@@ -80,7 +80,7 @@ describe('Return Requirements - Generate From Existing Requirements service', ()
   })
 
   describe('when a matching return version does not exist', () => {
-    beforeEach(async () => {
+    beforeEach(() => {
       returnVersion = undefined
 
       Sinon.stub(FetchExistingRequirementsService, 'go').resolves(returnVersion)

--- a/test/services/return-requirements/generate-from-existing-requirements.service.test.js
+++ b/test/services/return-requirements/generate-from-existing-requirements.service.test.js
@@ -22,60 +22,121 @@ describe('Return Requirements - Generate From Existing Requirements service', ()
   })
 
   describe('when a matching return version exists', () => {
-    beforeEach(() => {
-      returnVersion = _returnVersion()
+    describe('and all its return requirements have a site description', () => {
+      beforeEach(() => {
+        returnVersion = _returnVersion()
 
-      Sinon.stub(FetchExistingRequirementsService, 'go').resolves(returnVersion)
+        Sinon.stub(FetchExistingRequirementsService, 'go').resolves(returnVersion)
+      })
+
+      it('returns the details of its return requirements transformed for use in the journey', async () => {
+        const result = await GenerateFromExistingRequirementsService.go(returnVersion.id)
+
+        expect(result).to.equal([
+          {
+            points: [returnVersion.returnRequirements[0].points[0].id],
+            purposes: [{
+              alias: returnVersion.returnRequirements[0].returnRequirementPurposes[0].alias,
+              description: 'Spray Irrigation - Storage',
+              id: returnVersion.returnRequirements[0].returnRequirementPurposes[0].purposeId
+            }],
+            returnsCycle: 'winter-and-all-year',
+            siteDescription: 'FIRST BOREHOLE AT AVALON',
+            abstractionPeriod: {
+              'end-abstraction-period-day': 31,
+              'end-abstraction-period-month': 3,
+              'start-abstraction-period-day': 1,
+              'start-abstraction-period-month': 4
+            },
+            frequencyReported: 'week',
+            frequencyCollected: 'week',
+            agreementsExceptions: ['none']
+          },
+          {
+            points: [returnVersion.returnRequirements[1].points[0].id],
+            purposes: [{
+              alias: '',
+              description: 'Spray Irrigation - Storage',
+              id: returnVersion.returnRequirements[1].returnRequirementPurposes[0].purposeId
+            }],
+            returnsCycle: 'summer',
+            siteDescription: 'SECOND BOREHOLE AT AVALON',
+            abstractionPeriod: {
+              'end-abstraction-period-day': 31,
+              'end-abstraction-period-month': 3,
+              'start-abstraction-period-day': 1,
+              'start-abstraction-period-month': 4
+            },
+            frequencyReported: 'month',
+            frequencyCollected: 'week',
+            agreementsExceptions: [
+              '56-returns-exception',
+              'gravity-fill',
+              'transfer-re-abstraction-scheme',
+              'two-part-tariff'
+            ]
+          }
+        ])
+      })
     })
 
-    it('returns the details of the its return requirements transformed for use in the journey', async () => {
-      const result = await GenerateFromExistingRequirementsService.go(returnVersion.id)
+    describe('but one of its return requirements does not have a site description', () => {
+      beforeEach(() => {
+        returnVersion = _returnVersion()
+        returnVersion.returnRequirements[1].siteDescription = null
 
-      expect(result).to.equal([
-        {
-          points: [returnVersion.returnRequirements[0].points[0].id],
-          purposes: [{
-            alias: returnVersion.returnRequirements[0].returnRequirementPurposes[0].alias,
-            description: 'Spray Irrigation - Storage',
-            id: returnVersion.returnRequirements[0].returnRequirementPurposes[0].purposeId
-          }],
-          returnsCycle: 'winter-and-all-year',
-          siteDescription: 'FIRST BOREHOLE AT AVALON',
-          abstractionPeriod: {
-            'end-abstraction-period-day': 31,
-            'end-abstraction-period-month': 3,
-            'start-abstraction-period-day': 1,
-            'start-abstraction-period-month': 4
+        Sinon.stub(FetchExistingRequirementsService, 'go').resolves(returnVersion)
+      })
+
+      it('returns the details of its return requirements transformed, falling back to point description for the missing site description', async () => {
+        const result = await GenerateFromExistingRequirementsService.go(returnVersion.id)
+
+        expect(result).to.equal([
+          {
+            points: [returnVersion.returnRequirements[0].points[0].id],
+            purposes: [{
+              alias: returnVersion.returnRequirements[0].returnRequirementPurposes[0].alias,
+              description: 'Spray Irrigation - Storage',
+              id: returnVersion.returnRequirements[0].returnRequirementPurposes[0].purposeId
+            }],
+            returnsCycle: 'winter-and-all-year',
+            siteDescription: 'FIRST BOREHOLE AT AVALON',
+            abstractionPeriod: {
+              'end-abstraction-period-day': 31,
+              'end-abstraction-period-month': 3,
+              'start-abstraction-period-day': 1,
+              'start-abstraction-period-month': 4
+            },
+            frequencyReported: 'week',
+            frequencyCollected: 'week',
+            agreementsExceptions: ['none']
           },
-          frequencyReported: 'week',
-          frequencyCollected: 'week',
-          agreementsExceptions: ['none']
-        },
-        {
-          points: [returnVersion.returnRequirements[1].points[0].id],
-          purposes: [{
-            alias: '',
-            description: 'Spray Irrigation - Storage',
-            id: returnVersion.returnRequirements[1].returnRequirementPurposes[0].purposeId
-          }],
-          returnsCycle: 'summer',
-          siteDescription: 'SECOND BOREHOLE AT AVALON',
-          abstractionPeriod: {
-            'end-abstraction-period-day': 31,
-            'end-abstraction-period-month': 3,
-            'start-abstraction-period-day': 1,
-            'start-abstraction-period-month': 4
-          },
-          frequencyReported: 'month',
-          frequencyCollected: 'week',
-          agreementsExceptions: [
-            '56-returns-exception',
-            'gravity-fill',
-            'transfer-re-abstraction-scheme',
-            'two-part-tariff'
-          ]
-        }
-      ])
+          {
+            points: [returnVersion.returnRequirements[1].points[0].id],
+            purposes: [{
+              alias: '',
+              description: 'Spray Irrigation - Storage',
+              id: returnVersion.returnRequirements[1].returnRequirementPurposes[0].purposeId
+            }],
+            returnsCycle: 'summer',
+            siteDescription: 'WELL AT WELLINGTON',
+            abstractionPeriod: {
+              'end-abstraction-period-day': 31,
+              'end-abstraction-period-month': 3,
+              'start-abstraction-period-day': 1,
+              'start-abstraction-period-month': 4
+            },
+            frequencyReported: 'month',
+            frequencyCollected: 'week',
+            agreementsExceptions: [
+              '56-returns-exception',
+              'gravity-fill',
+              'transfer-re-abstraction-scheme',
+              'two-part-tariff'
+            ]
+          }
+        ])
+      })
     })
   })
 

--- a/test/services/return-requirements/generate-from-existing-requirements.service.test.js
+++ b/test/services/return-requirements/generate-from-existing-requirements.service.test.js
@@ -3,12 +3,13 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
+const Sinon = require('sinon')
 
-const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { describe, it, beforeEach, afterEach } = exports.lab = Lab.script()
 const { expect } = Code
 
-// Test helpers
-const RequirementsForReturnsSeed = require('../../support/seeders/requirements-for-returns.seeder.js')
+// Things we need to stub
+const FetchExistingRequirementsService = require('../../../app/services/return-requirements/fetch-existing-requirements.js')
 
 // Thing under test
 const GenerateFromExistingRequirementsService = require('../../../app/services/return-requirements/generate-from-existing-requirements.service.js')
@@ -18,9 +19,13 @@ describe('Return Requirements - Generate From Existing Requirements service', ()
 
   describe('when a matching return version exists', () => {
     beforeEach(async () => {
-      const seedData = await RequirementsForReturnsSeed.seed()
+      returnVersion = _returnVersion()
 
-      returnVersion = seedData.returnVersion
+      Sinon.stub(FetchExistingRequirementsService, 'go').resolves(returnVersion)
+    })
+
+    afterEach(() => {
+      Sinon.restore()
     })
 
     it('returns the details of the its return requirements transformed for use in the journey', async () => {
@@ -74,3 +79,75 @@ describe('Return Requirements - Generate From Existing Requirements service', ()
     })
   })
 })
+
+function _returnVersion () {
+  return {
+    id: '3a591cdc-7ca0-4252-b159-6994b9319e70',
+    returnRequirements: [
+      {
+        id: 'b8c8e40f-2557-4ce5-8fd9-fd7f6bb71c30',
+        abstractionPeriodEndDay: 31,
+        abstractionPeriodEndMonth: 3,
+        abstractionPeriodStartDay: 1,
+        abstractionPeriodStartMonth: 4,
+        collectionFrequency: 'week',
+        fiftySixException: false,
+        gravityFill: false,
+        reabstraction: false,
+        reportingFrequency: 'week',
+        siteDescription: 'FIRST BOREHOLE AT AVALON',
+        summer: false,
+        twoPartTariff: false,
+        points: [
+          {
+            id: '8be0bf17-ba9b-465f-b660-b732f0a131df',
+            description: 'WELL AT WELLINGTON'
+          }
+        ],
+        returnRequirementPurposes: [
+          {
+            id: 'f0709035-4f2a-4294-b4ac-dbd2c47a955f',
+            alias: 'I have an alias',
+            purposeId: 'da576426-70bc-4f76-b05b-849bba48a8e8',
+            purpose: {
+              id: 'da576426-70bc-4f76-b05b-849bba48a8e8',
+              description: 'Spray Irrigation - Storage'
+            }
+          }
+        ]
+      },
+      {
+        id: '01674d01-f54a-4631-9fe6-76d429e2a823',
+        abstractionPeriodEndDay: 31,
+        abstractionPeriodEndMonth: 3,
+        abstractionPeriodStartDay: 1,
+        abstractionPeriodStartMonth: 4,
+        collectionFrequency: 'week',
+        fiftySixException: true,
+        gravityFill: true,
+        reabstraction: true,
+        reportingFrequency: 'month',
+        siteDescription: 'SECOND BOREHOLE AT AVALON',
+        summer: true,
+        twoPartTariff: true,
+        points: [
+          {
+            id: 'e535dfb8-3720-41aa-824d-6a6942d65650',
+            description: 'WELL AT WELLINGTON'
+          }
+        ],
+        returnRequirementPurposes: [
+          {
+            id: '2a6b8b21-6449-4353-8f6f-93457395f7a6',
+            alias: null,
+            purposeId: 'da576426-70bc-4f76-b05b-849bba48a8e8',
+            purpose: {
+              id: 'da576426-70bc-4f76-b05b-849bba48a8e8',
+              description: 'Spray Irrigation - Storage'
+            }
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4701

When working on WATER-4685, our QA team spotted that some return requirements do not have 'Site description' set.

We [made a change to handle this when viewing a return version](https://github.com/DEFRA/water-abstraction-system/pull/1380) (we display nothing!)

But the same issue applies when these return requirements are used for 'copied from existing' when setting up new return versions. They also display as null there.

However, there is a more significant problem. If a user were to complete the manual journey, 'Site description' would be required. We don't want to create new records with an empty required field.

The agreed solution in this scenario is to fall back to what we do when the user selects 'start with abstraction data' instead in the journey. There, we default the site description as the description of the first point against the licence version purpose.

So, in this change, we'll add a fallback to use the first point's description if the site description is null on the return requirement we're copying.