### PR TITLE
Import company address data for a licence

### DIFF
--- a/app/services/import/legacy/fetch-company-address.service.js
+++ b/app/services/import/legacy/fetch-company-address.service.js
@@ -96,11 +96,11 @@ async function _getReturnsTo (regionCode, licenceId) {
       lr.id as licence_role_id,
       lr.name as licence_role_name
     FROM import."NALD_LIC_ROLES" nlr
-           INNER JOIN import."NALD_PARTIES" np
-                      ON np."FGAC_REGION_CODE" = nlr."FGAC_REGION_CODE"
-                        AND np."ID" = nlr."ACON_APAR_ID"
-           INNER JOIN public.licence_roles AS lr
-                      ON lr.name = 'returnsTo'
+      INNER JOIN import."NALD_PARTIES" np
+        ON np."FGAC_REGION_CODE" = nlr."FGAC_REGION_CODE"
+        AND np."ID" = nlr."ACON_APAR_ID"
+      INNER JOIN public.licence_roles AS lr
+        ON lr.name = 'returnsTo'
     WHERE nlr."FGAC_REGION_CODE" = ?
       AND nlr."AABL_ID" = ?
       AND nlr."ACON_AADD_ID" IS NOT NULL


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4669

We need to replace the import service logic to import a licence from NALD.

The current import service iterates all the companies (known as parties in the import.NALD_PARTIES table) and updates CRM_V2 tables.

This change will use the nald licence id and region to update the addresses' data. This will insert or update the company addresses record.

This change will build on top of the previous work to add the licence holder to the company address logic and will introduce the licence role for a company address. The only licence role we are interested in is the 'returnsTo' licence role.

This is not a concept in nald and is created for WRLS to link an address to company.

We will insert this imported data in the relevant public views.