### PR TITLE
Refactor logic for creating return cycles when importing new licence

### DIFF
--- a/app/services/jobs/return-logs/generate-return-logs.service.js
+++ b/app/services/jobs/return-logs/generate-return-logs.service.js
@@ -24,18 +24,7 @@ const GenerateReturnCycleService = require('./generate-return-cycle.service.js')
  * @returns {Promise<Array>} the array of return log payloads to be created in the database
  */
 async function go (returnRequirements) {
-  const today = formatDateObjectToISO(new Date())
-
-  let allYearReturnCycleId = await FetchReturnCycleService.go(today, false)
-  let summerReturnCycleId = await FetchReturnCycleService.go(today, true)
-
-  if (!allYearReturnCycleId) {
-    allYearReturnCycleId = await GenerateReturnCycleService.go(false)
-  }
-
-  if (!summerReturnCycleId) {
-    summerReturnCycleId = await GenerateReturnCycleService.go(true)
-  }
+  const { allYearReturnCycleId, summerReturnCycleId } = await _fetchReturnCycleId()
 
   const returnLogs = returnRequirements.map(async (requirements) => {
     const startDate = _startDate(requirements.summer, requirements.returnVersion)
@@ -100,6 +89,26 @@ function _earliestDate (summer, returnVersion) {
   })
 
   return new Date(Math.min(...dates))
+}
+
+async function _fetchReturnCycleId () {
+  const today = formatDateObjectToISO(new Date())
+
+  let allYearReturnCycleId = await FetchReturnCycleService.go(today, false)
+  let summerReturnCycleId = await FetchReturnCycleService.go(today, true)
+
+  if (!allYearReturnCycleId) {
+    allYearReturnCycleId = await GenerateReturnCycleService.go(false)
+  }
+
+  if (!summerReturnCycleId) {
+    summerReturnCycleId = await GenerateReturnCycleService.go(true)
+  }
+
+  return {
+    allYearReturnCycleId,
+    summerReturnCycleId
+  }
 }
 
 function _id (requirements, startDate, endDate) {

--- a/app/services/jobs/return-logs/generate-return-logs.service.js
+++ b/app/services/jobs/return-logs/generate-return-logs.service.js
@@ -13,16 +13,30 @@ const {
   cycleStartDate,
   formatDateObjectToISO
 } = require('../../../lib/dates.lib.js')
+const FetchReturnCycleService = require('./fetch-return-cycle.service.js')
+const GenerateReturnCycleService = require('./generate-return-cycle.service.js')
 
 /**
  * Generates the payload for submission to the returns table.
  *
  * @param {Array} returnRequirements - the return requirements to be turned into return logs
- * @param {string} returnCycleId - the UUID of the return cycle
  *
  * @returns {Promise<Array>} the array of return log payloads to be created in the database
  */
-async function go (returnRequirements, returnCycleId) {
+async function go (returnRequirements) {
+  const today = formatDateObjectToISO(new Date())
+
+  let allYearReturnCycleId = await FetchReturnCycleService.go(today, false)
+  let summerReturnCycleId = await FetchReturnCycleService.go(today, true)
+
+  if (!allYearReturnCycleId) {
+    allYearReturnCycleId = await GenerateReturnCycleService.go(false)
+  }
+
+  if (!summerReturnCycleId) {
+    summerReturnCycleId = await GenerateReturnCycleService.go(true)
+  }
+
   const returnLogs = returnRequirements.map(async (requirements) => {
     const startDate = _startDate(requirements.summer, requirements.returnVersion)
     const endDate = _endDate(requirements.summer, requirements.returnVersion)
@@ -37,7 +51,7 @@ async function go (returnRequirements, returnCycleId) {
       id,
       licenceRef: requirements.returnVersion.licence.licenceRef,
       metadata,
-      returnCycleId,
+      returnCycleId: requirements.summer ? summerReturnCycleId : allYearReturnCycleId,
       returnsFrequency: requirements.reportingFrequency,
       returnReference: requirements.legacyId.toString(),
       startDate,
@@ -140,7 +154,7 @@ function _metadataPoints (points) {
 function _metadataPurposes (returnRequirementPurposes) {
   return returnRequirementPurposes.map((returnRequirementPurpose) => {
     return {
-      alias: returnRequirementPurpose.alias,
+      ...(returnRequirementPurpose.alias !== null && { alias: returnRequirementPurpose.alias }),
       primary: {
         code: returnRequirementPurpose.primaryPurpose.legacyId,
         description: returnRequirementPurpose.primaryPurpose.description

--- a/app/services/jobs/return-logs/generate-return-logs.service.js
+++ b/app/services/jobs/return-logs/generate-return-logs.service.js
@@ -24,7 +24,7 @@ const GenerateReturnCycleService = require('./generate-return-cycle.service.js')
  * @returns {Promise<Array>} the array of return log payloads to be created in the database
  */
 async function go (returnRequirements) {
-  const { allYearReturnCycleId, summerReturnCycleId } = await _fetchReturnCycleId()
+  const { allYearReturnCycleId, summerReturnCycleId } = await _fetchReturnCycleIds()
 
   const returnLogs = returnRequirements.map(async (requirements) => {
     const startDate = _startDate(requirements.summer, requirements.returnVersion)
@@ -91,7 +91,7 @@ function _earliestDate (summer, returnVersion) {
   return new Date(Math.min(...dates))
 }
 
-async function _fetchReturnCycleId () {
+async function _fetchReturnCycleIds () {
   const today = formatDateObjectToISO(new Date())
 
   let allYearReturnCycleId = await FetchReturnCycleService.go(today, false)

--- a/app/services/jobs/return-logs/process-licence-return-logs.service.js
+++ b/app/services/jobs/return-logs/process-licence-return-logs.service.js
@@ -28,6 +28,7 @@ const ReturnLogModel = require('../../../models/return-log.model.js')
 async function go (licenceReference) {
   try {
     const startTime = currentTimeInNanoseconds()
+
     const returnRequirements = await FetchLicenceReturnLogsService.go(licenceReference)
     const returnLogs = await GenerateReturnLogsService.go(returnRequirements)
 

--- a/app/services/jobs/return-logs/process-return-logs.service.js
+++ b/app/services/jobs/return-logs/process-return-logs.service.js
@@ -6,10 +6,7 @@
  */
 
 const { calculateAndLogTimeTaken, currentTimeInNanoseconds } = require('../../../lib/general.lib.js')
-const { formatDateObjectToISO } = require('../../../lib/dates.lib.js')
-const FetchReturnCycleService = require('./fetch-return-cycle.service.js')
 const FetchReturnRequirementsService = require('./fetch-return-requirements.service.js')
-const GenerateReturnCycleService = require('./generate-return-cycle.service.js')
 const GenerateReturnLogsService = require('./generate-return-logs.service.js')
 const ReturnLogModel = require('../../../models/return-log.model.js')
 
@@ -41,14 +38,8 @@ async function go (cycle, licenceReference = null) {
     const startTime = currentTimeInNanoseconds()
     const summer = cycle === 'summer'
 
-    let returnCycleId = await FetchReturnCycleService.go(formatDateObjectToISO(new Date()), summer)
-
-    if (!returnCycleId) {
-      returnCycleId = await GenerateReturnCycleService.go(summer)
-    }
-
     const returnRequirements = await FetchReturnRequirementsService.go(summer, licenceReference)
-    const returnLogs = await GenerateReturnLogsService.go(returnRequirements, returnCycleId)
+    const returnLogs = await GenerateReturnLogsService.go(returnRequirements)
 
     await _createReturnLogs(returnLogs)
 

--- a/test/models/return-cycle.model.test.js
+++ b/test/models/return-cycle.model.test.js
@@ -50,8 +50,12 @@ describe('Return Cycle model', () => {
         expect(result).to.be.instanceOf(ReturnCycleModel)
         expect(result.id).to.equal(testRecord.id)
 
-        expect(result.returnLogs[0]).to.be.an.instanceOf(ReturnLogModel)
-        expect(result.returnLogs[0]).to.equal(testReturnLog)
+        const expectedReturnLog = result.returnLogs.find((returnLog) => {
+          return returnLog.id === testReturnLog.id
+        })
+
+        expect(expectedReturnLog).to.be.an.instanceOf(ReturnLogModel)
+        expect(expectedReturnLog).to.equal(testReturnLog)
       })
     })
   })

--- a/test/models/return-cycle.model.test.js
+++ b/test/models/return-cycle.model.test.js
@@ -50,12 +50,9 @@ describe('Return Cycle model', () => {
         expect(result).to.be.instanceOf(ReturnCycleModel)
         expect(result.id).to.equal(testRecord.id)
 
-        const expectedReturnLog = result.returnLogs.find((returnLog) => {
-          return returnLog.id === testReturnLog.id
-        })
-
-        expect(expectedReturnLog).to.be.an.instanceOf(ReturnLogModel)
-        expect(expectedReturnLog).to.equal(testReturnLog)
+        expect(result.returnLogs).to.be.an.array()
+        expect(result.returnLogs[0]).to.be.an.instanceOf(ReturnLogModel)
+        expect(result.returnLogs).to.include(testReturnLog)
       })
     })
   })

--- a/test/models/return-cycle.model.test.js
+++ b/test/models/return-cycle.model.test.js
@@ -17,11 +17,17 @@ const ReturnCycleModel = require('../../app/models/return-cycle.model.js')
 
 describe('Return Cycle model', () => {
   let testRecord
-  let testReturnLog
+  let testReturnLogs
 
   before(async () => {
     testRecord = await ReturnCycleHelper.select()
-    testReturnLog = await ReturnLogHelper.add({ returnCycleId: testRecord.id })
+
+    testReturnLogs = []
+    for (let i = 0; i < 2; i++) {
+      const returnLog = await ReturnLogHelper.add({ returnCycleId: testRecord.id })
+
+      testReturnLogs.push(returnLog)
+    }
   })
 
   describe('Basic query', () => {
@@ -52,7 +58,8 @@ describe('Return Cycle model', () => {
 
         expect(result.returnLogs).to.be.an.array()
         expect(result.returnLogs[0]).to.be.an.instanceOf(ReturnLogModel)
-        expect(result.returnLogs).to.include(testReturnLog)
+        expect(result.returnLogs).to.include(testReturnLogs[0])
+        expect(result.returnLogs).to.include(testReturnLogs[1])
       })
     })
   })

--- a/test/services/jobs/return-logs/fetch-licence-return-requirements.service.test.js
+++ b/test/services/jobs/return-logs/fetch-licence-return-requirements.service.test.js
@@ -1,0 +1,262 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, before } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const LicenceHelper = require('../../../support/helpers/licence.helper.js')
+const PointHelper = require('../../../support/helpers/point.helper.js')
+const PrimaryPurposeHelper = require('../../../support/helpers/primary-purpose.helper.js')
+const PurposeHelper = require('../../../support/helpers/purpose.helper.js')
+const RegionHelper = require('../../../support/helpers/region.helper.js')
+const ReturnRequirementHelper = require('../../../support/helpers/return-requirement.helper.js')
+const ReturnRequirementPointHelper = require('../../../support/helpers/return-requirement-point.helper.js')
+const ReturnRequirementPurposeHelper = require('../../../support/helpers/return-requirement-purpose.helper.js')
+const ReturnVersionHelper = require('../../../support/helpers/return-version.helper.js')
+const SecondaryPurposeHelper = require('../../../support/helpers/secondary-purpose.helper.js')
+
+// Thing under test
+const FetchLicenceReturnRequirementsService = require('../../../../app/services/jobs/return-logs/fetch-licence-return-requirements.service.js')
+
+describe('Fetch licence return requirements service', () => {
+  let licence
+  let point
+  let point2
+  let primaryPurpose
+  let primaryPurpose2
+  let purpose
+  let purpose2
+  let region
+  let returnVersion
+  let returnRequirement
+  let returnRequirement2
+  let returnRequirementPurpose
+  let returnRequirementPurpose2
+  let secondaryPurpose
+  let secondaryPurpose2
+  let summer
+
+  before(async () => {
+    primaryPurpose = PrimaryPurposeHelper.select()
+    purpose = PurposeHelper.select()
+    secondaryPurpose = SecondaryPurposeHelper.select()
+    region = RegionHelper.select()
+    licence = await LicenceHelper.add({ regionId: region.id })
+    returnVersion = await ReturnVersionHelper.add({ licenceId: licence.id })
+    returnRequirement = await ReturnRequirementHelper.add({ returnVersionId: returnVersion.id })
+    point = await PointHelper.add()
+    await ReturnRequirementPointHelper.add({ pointId: point.id, returnRequirementId: returnRequirement.id })
+    returnRequirementPurpose = await ReturnRequirementPurposeHelper.add({
+      primaryPurposeId: primaryPurpose.id,
+      purposeId: purpose.id,
+      returnRequirementId: returnRequirement.id,
+      secondaryPurposeId: secondaryPurpose.id
+    })
+  })
+
+  describe('when summer is false', () => {
+    before(() => {
+      summer = false
+    })
+
+    describe('and one return requirement', () => {
+      it('should return one return requirement', async () => {
+        const result = await FetchLicenceReturnRequirementsService.go(licence.licenceRef)
+
+        expect(result.length).to.equal(1)
+        expect(result[0].id).to.equal(returnRequirement.id)
+        expect(result[0].returnVersionId).to.equal(returnVersion.id)
+        expect(result[0].reportingFrequency).to.equal(returnRequirement.reportingFrequency)
+        expect(result[0].summer).to.equal(returnRequirement.summer)
+        expect(result[0].upload).to.equal(returnRequirement.upload)
+        expect(result[0].abstractionPeriodStartDay).to.equal(returnRequirement.abstractionPeriodStartDay)
+        expect(result[0].abstractionPeriodStartMonth).to.equal(returnRequirement.abstractionPeriodStartMonth)
+        expect(result[0].abstractionPeriodEndDay).to.equal(returnRequirement.abstractionPeriodEndDay)
+        expect(result[0].abstractionPeriodEndMonth).to.equal(returnRequirement.abstractionPeriodEndMonth)
+        expect(result[0].siteDescription).to.equal(returnRequirement.siteDescription)
+        expect(result[0].legacyId).to.equal(returnRequirement.legacyId)
+        expect(result[0].externalId).to.equal(returnRequirement.externalId)
+        expect(result[0].twoPartTariff).to.equal(returnRequirement.twoPartTariff)
+        expect(result[0].returnVersion.endDate).to.equal(returnVersion.endDate)
+        expect(result[0].returnVersion.id).to.equal(returnVersion.id)
+        expect(result[0].returnVersion.startDate).to.equal(returnVersion.startDate)
+        expect(result[0].returnVersion.reason).to.equal(returnVersion.reason)
+        expect(result[0].returnVersion.licence.id).to.equal(licence.id)
+        expect(result[0].returnVersion.licence.expiredDate).to.equal(licence.expiredDate)
+        expect(result[0].returnVersion.licence.lapsedDate).to.equal(licence.lapsedDate)
+        expect(result[0].returnVersion.licence.licenceRef).to.equal(licence.licenceRef)
+        expect(result[0].returnVersion.licence.revokedDate).to.equal(licence.revokedDate)
+        expect(result[0].returnVersion.licence.areacode).to.equal(licence.regions.historicalAreaCode)
+        expect(result[0].returnVersion.licence.region.id).to.equal(region.id)
+        expect(result[0].returnVersion.licence.region.naldRegionId).to.equal(region.naldRegionId)
+        expect(result[0].points[0].description).to.equal(point.description)
+        expect(result[0].points[0].ngr1).to.equal(point.ngr1)
+        expect(result[0].points[0].ngr2).to.equal(point.ngr2)
+        expect(result[0].points[0].ngr3).to.equal(point.ngr3)
+        expect(result[0].points[0].ngr4).to.equal(point.ngr4)
+        expect(result[0].returnRequirementPurposes[0].id).to.equal(returnRequirementPurpose.id)
+        expect(result[0].returnRequirementPurposes[0].returnRequirementId)
+          .to.equal(returnRequirementPurpose.returnRequirementId)
+        expect(result[0].returnRequirementPurposes[0]
+          .primaryPurposeId).to.equal(returnRequirementPurpose.primaryPurposeId)
+        expect(result[0].returnRequirementPurposes[0]
+          .secondaryPurposeId).to.equal(returnRequirementPurpose.secondaryPurposeId)
+        expect(result[0].returnRequirementPurposes[0].purposeId).to.equal(returnRequirementPurpose.purposeId)
+        expect(result[0].returnRequirementPurposes[0].alias).to.equal(returnRequirementPurpose.alias)
+        expect(result[0].returnRequirementPurposes[0].externalId).to.equal(returnRequirementPurpose.externalId)
+        expect(result[0].returnRequirementPurposes[0].primaryPurpose.legacyId).to.equal(primaryPurpose.legacyId)
+        expect(result[0].returnRequirementPurposes[0].primaryPurpose.description)
+          .to.equal(primaryPurpose.description)
+        expect(result[0].returnRequirementPurposes[0].secondaryPurpose.legacyId).to.equal(secondaryPurpose.legacyId)
+        expect(result[0].returnRequirementPurposes[0].secondaryPurpose.description)
+          .to.equal(secondaryPurpose.description)
+        expect(result[0].returnRequirementPurposes[0].purpose.legacyId).to.equal(purpose.legacyId)
+        expect(result[0].returnRequirementPurposes[0].purpose.description).to.equal(purpose.description)
+      })
+    })
+  })
+
+  describe('when summer is true', () => {
+    before(() => {
+      summer = true
+    })
+
+    describe('and there are two return requirements', () => {
+      before(async () => {
+        primaryPurpose = PrimaryPurposeHelper.select()
+        primaryPurpose2 = PrimaryPurposeHelper.select()
+        purpose = PurposeHelper.select()
+        purpose2 = PurposeHelper.select()
+        secondaryPurpose = SecondaryPurposeHelper.select()
+        secondaryPurpose2 = SecondaryPurposeHelper.select()
+        region = RegionHelper.select()
+        licence = await LicenceHelper.add({ regionId: region.id })
+        returnVersion = await ReturnVersionHelper.add({ licenceId: licence.id })
+        returnRequirement = await ReturnRequirementHelper.add({ summer, returnVersionId: returnVersion.id })
+        returnRequirement2 = await ReturnRequirementHelper.add({ summer, returnVersionId: returnVersion.id })
+        point = await PointHelper.add()
+        await ReturnRequirementPointHelper.add({ pointId: point.id, returnRequirementId: returnRequirement.id })
+        returnRequirementPurpose = await ReturnRequirementPurposeHelper.add({
+          primaryPurposeId: primaryPurpose.id,
+          purposeId: purpose.id,
+          returnRequirementId: returnRequirement.id,
+          secondaryPurposeId: secondaryPurpose.id
+        })
+        point2 = await PointHelper.add()
+        await ReturnRequirementPointHelper.add({ pointId: point2.id, returnRequirementId: returnRequirement2.id })
+        returnRequirementPurpose2 = await ReturnRequirementPurposeHelper.add({
+          primaryPurposeId: primaryPurpose2.id,
+          purposeId: purpose2.id,
+          returnRequirementId: returnRequirement2.id,
+          secondaryPurposeId: secondaryPurpose2.id
+        })
+      })
+
+      it('should return two return requirements', async () => {
+        const result = await FetchLicenceReturnRequirementsService.go(licence.licenceRef)
+
+        expect(result.length).to.equal(2)
+        expect(result[0].id).to.equal(returnRequirement.id)
+        expect(result[0].returnVersionId).to.equal(returnVersion.id)
+        expect(result[0].reportingFrequency).to.equal(returnRequirement.reportingFrequency)
+        expect(result[0].summer).to.equal(returnRequirement.summer)
+        expect(result[0].upload).to.equal(returnRequirement.upload)
+        expect(result[0].abstractionPeriodStartDay).to.equal(returnRequirement.abstractionPeriodStartDay)
+        expect(result[0].abstractionPeriodStartMonth).to.equal(returnRequirement.abstractionPeriodStartMonth)
+        expect(result[0].abstractionPeriodEndDay).to.equal(returnRequirement.abstractionPeriodEndDay)
+        expect(result[0].abstractionPeriodEndMonth).to.equal(returnRequirement.abstractionPeriodEndMonth)
+        expect(result[0].siteDescription).to.equal(returnRequirement.siteDescription)
+        expect(result[0].legacyId).to.equal(returnRequirement.legacyId)
+        expect(result[0].externalId).to.equal(returnRequirement.externalId)
+        expect(result[0].twoPartTariff).to.equal(returnRequirement.twoPartTariff)
+        expect(result[0].returnVersion.endDate).to.equal(returnVersion.endDate)
+        expect(result[0].returnVersion.id).to.equal(returnVersion.id)
+        expect(result[0].returnVersion.startDate).to.equal(returnVersion.startDate)
+        expect(result[0].returnVersion.reason).to.equal(returnVersion.reason)
+        expect(result[0].returnVersion.licence.id).to.equal(licence.id)
+        expect(result[0].returnVersion.licence.expiredDate).to.equal(licence.expiredDate)
+        expect(result[0].returnVersion.licence.lapsedDate).to.equal(licence.lapsedDate)
+        expect(result[0].returnVersion.licence.licenceRef).to.equal(licence.licenceRef)
+        expect(result[0].returnVersion.licence.revokedDate).to.equal(licence.revokedDate)
+        expect(result[0].returnVersion.licence.areacode).to.equal(licence.regions.historicalAreaCode)
+        expect(result[0].returnVersion.licence.region.id).to.equal(region.id)
+        expect(result[0].returnVersion.licence.region.naldRegionId).to.equal(region.naldRegionId)
+        expect(result[0].points[0].description).to.equal(point.description)
+        expect(result[0].points[0].ngr1).to.equal(point.ngr1)
+        expect(result[0].points[0].ngr2).to.equal(point.ngr2)
+        expect(result[0].points[0].ngr3).to.equal(point.ngr3)
+        expect(result[0].points[0].ngr4).to.equal(point.ngr4)
+        expect(result[0].returnRequirementPurposes[0].id).to.equal(returnRequirementPurpose.id)
+        expect(result[0].returnRequirementPurposes[0].returnRequirementId)
+          .to.equal(returnRequirementPurpose.returnRequirementId)
+        expect(result[0].returnRequirementPurposes[0]
+          .primaryPurposeId).to.equal(returnRequirementPurpose.primaryPurposeId)
+        expect(result[0].returnRequirementPurposes[0]
+          .secondaryPurposeId).to.equal(returnRequirementPurpose.secondaryPurposeId)
+        expect(result[0].returnRequirementPurposes[0].purposeId).to.equal(returnRequirementPurpose.purposeId)
+        expect(result[0].returnRequirementPurposes[0].alias).to.equal(returnRequirementPurpose.alias)
+        expect(result[0].returnRequirementPurposes[0].externalId).to.equal(returnRequirementPurpose.externalId)
+        expect(result[0].returnRequirementPurposes[0].primaryPurpose.legacyId).to.equal(primaryPurpose.legacyId)
+        expect(result[0].returnRequirementPurposes[0].primaryPurpose.description)
+          .to.equal(primaryPurpose.description)
+        expect(result[0].returnRequirementPurposes[0].secondaryPurpose.legacyId).to.equal(secondaryPurpose.legacyId)
+        expect(result[0].returnRequirementPurposes[0].secondaryPurpose.description)
+          .to.equal(secondaryPurpose.description)
+        expect(result[0].returnRequirementPurposes[0].purpose.legacyId).to.equal(purpose.legacyId)
+        expect(result[0].returnRequirementPurposes[0].purpose.description).to.equal(purpose.description)
+        expect(result[1].id).to.equal(returnRequirement2.id)
+        expect(result[1].returnVersionId).to.equal(returnVersion.id)
+        expect(result[1].reportingFrequency).to.equal(returnRequirement2.reportingFrequency)
+        expect(result[1].summer).to.equal(returnRequirement2.summer)
+        expect(result[1].upload).to.equal(returnRequirement2.upload)
+        expect(result[1].abstractionPeriodStartDay).to.equal(returnRequirement2.abstractionPeriodStartDay)
+        expect(result[1].abstractionPeriodStartMonth).to.equal(returnRequirement2.abstractionPeriodStartMonth)
+        expect(result[1].abstractionPeriodEndDay).to.equal(returnRequirement2.abstractionPeriodEndDay)
+        expect(result[1].abstractionPeriodEndMonth).to.equal(returnRequirement2.abstractionPeriodEndMonth)
+        expect(result[1].siteDescription).to.equal(returnRequirement2.siteDescription)
+        expect(result[1].legacyId).to.equal(returnRequirement2.legacyId)
+        expect(result[1].externalId).to.equal(returnRequirement2.externalId)
+        expect(result[1].twoPartTariff).to.equal(returnRequirement2.twoPartTariff)
+        expect(result[1].returnVersion.endDate).to.equal(returnVersion.endDate)
+        expect(result[1].returnVersion.id).to.equal(returnVersion.id)
+        expect(result[1].returnVersion.startDate).to.equal(returnVersion.startDate)
+        expect(result[1].returnVersion.reason).to.equal(returnVersion.reason)
+        expect(result[1].returnVersion.licence.id).to.equal(licence.id)
+        expect(result[1].returnVersion.licence.expiredDate).to.equal(licence.expiredDate)
+        expect(result[1].returnVersion.licence.lapsedDate).to.equal(licence.lapsedDate)
+        expect(result[1].returnVersion.licence.licenceRef).to.equal(licence.licenceRef)
+        expect(result[1].returnVersion.licence.revokedDate).to.equal(licence.revokedDate)
+        expect(result[1].returnVersion.licence.areacode).to.equal(licence.regions.historicalAreaCode)
+        expect(result[1].returnVersion.licence.region.id).to.equal(region.id)
+        expect(result[1].returnVersion.licence.region.naldRegionId).to.equal(region.naldRegionId)
+        expect(result[1].points[0].description).to.equal(point2.description)
+        expect(result[1].points[0].ngr1).to.equal(point2.ngr1)
+        expect(result[1].points[0].ngr2).to.equal(point2.ngr2)
+        expect(result[1].points[0].ngr3).to.equal(point2.ngr3)
+        expect(result[1].points[0].ngr4).to.equal(point2.ngr4)
+        expect(result[1].returnRequirementPurposes[0].id).to.equal(returnRequirementPurpose2.id)
+        expect(result[1].returnRequirementPurposes[0].returnRequirementId)
+          .to.equal(returnRequirementPurpose2.returnRequirementId)
+        expect(result[1].returnRequirementPurposes[0]
+          .primaryPurposeId).to.equal(returnRequirementPurpose2.primaryPurposeId)
+        expect(result[1].returnRequirementPurposes[0]
+          .secondaryPurposeId).to.equal(returnRequirementPurpose2.secondaryPurposeId)
+        expect(result[1].returnRequirementPurposes[0].purposeId).to.equal(returnRequirementPurpose2.purposeId)
+        expect(result[1].returnRequirementPurposes[0].alias).to.equal(returnRequirementPurpose2.alias)
+        expect(result[1].returnRequirementPurposes[0].externalId).to.equal(returnRequirementPurpose2.externalId)
+        expect(result[1].returnRequirementPurposes[0].primaryPurpose.legacyId).to.equal(primaryPurpose2.legacyId)
+        expect(result[1].returnRequirementPurposes[0].primaryPurpose.description)
+          .to.equal(primaryPurpose2.description)
+        expect(result[1].returnRequirementPurposes[0].secondaryPurpose.legacyId).to.equal(secondaryPurpose2.legacyId)
+        expect(result[1].returnRequirementPurposes[0].secondaryPurpose.description)
+          .to.equal(secondaryPurpose2.description)
+        expect(result[1].returnRequirementPurposes[0].purpose.legacyId).to.equal(purpose2.legacyId)
+        expect(result[1].returnRequirementPurposes[0].purpose.description).to.equal(purpose2.description)
+      })
+    })
+  })
+})

--- a/test/services/jobs/return-logs/fetch-return-cycle.service.test.js
+++ b/test/services/jobs/return-logs/fetch-return-cycle.service.test.js
@@ -29,6 +29,10 @@ describe('Fetch return cycle service', () => {
     previousSummerReturnCycle = await ReturnCycleHelper.select(4)
   })
 
+  afterEach(() => {
+    Sinon.restore()
+  })
+
   describe('when summer is false', () => {
     before(() => {
       summer = false
@@ -117,9 +121,5 @@ describe('Fetch return cycle service', () => {
         expect(result).to.equal(undefined)
       })
     })
-  })
-
-  afterEach(() => {
-    Sinon.restore()
   })
 })

--- a/test/services/jobs/return-logs/fetch-return-cycle.service.test.js
+++ b/test/services/jobs/return-logs/fetch-return-cycle.service.test.js
@@ -66,7 +66,7 @@ describe('Fetch return cycle service', () => {
         })
       })
 
-      it('should create the return cycle and return its id', async () => {
+      it('should return undefined if the return cycle does not exist', async () => {
         const result = await FetchReturnCycleService.go(new Date().toISOString().split('T')[0], summer)
 
         expect(result).to.equal(undefined)
@@ -115,7 +115,7 @@ describe('Fetch return cycle service', () => {
         })
       })
 
-      it('should create the return cycle and return it', async () => {
+      it('should return undefined if the return cycle does not exist', async () => {
         const result = await FetchReturnCycleService.go(new Date().toISOString().split('T')[0], summer)
 
         expect(result).to.equal(undefined)

--- a/test/services/jobs/return-logs/fetch-return-cycle.service.test.js
+++ b/test/services/jobs/return-logs/fetch-return-cycle.service.test.js
@@ -5,7 +5,7 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, before, after } = exports.lab = Lab.script()
+const { describe, it, before, afterEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
@@ -71,10 +71,6 @@ describe('Fetch return cycle service', () => {
 
         expect(result).to.equal(undefined)
       })
-
-      after(() => {
-        Sinon.restore()
-      })
     })
   })
 
@@ -120,10 +116,10 @@ describe('Fetch return cycle service', () => {
 
         expect(result).to.equal(undefined)
       })
-
-      after(() => {
-        Sinon.restore()
-      })
     })
+  })
+
+  afterEach(() => {
+    Sinon.restore()
   })
 })

--- a/test/services/jobs/return-logs/generate-return-logs.service.test.js
+++ b/test/services/jobs/return-logs/generate-return-logs.service.test.js
@@ -3,13 +3,17 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
+const Sinon = require('sinon')
 
-const { describe, it, before } = exports.lab = Lab.script()
+const { describe, it, before, after } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const LicenceHelper = require('../../../support/helpers/licence.helper.js')
+const { formatDateObjectToISO } = require('../../../../app/lib/dates.lib.js')
+const FetchReturnCycleService = require('../../../../app/services/jobs/return-logs/fetch-return-cycle.service.js')
 const FetchReturnRequirementsService = require('../../../../app/services/jobs/return-logs/fetch-return-requirements.service.js')
+const GenerateReturnCycleService = require('../../../../app/services/jobs/return-logs/generate-return-cycle.service.js')
+const LicenceHelper = require('../../../support/helpers/licence.helper.js')
 const PointHelper = require('../../../support/helpers/point.helper.js')
 const PrimaryPurposeHelper = require('../../../support/helpers/primary-purpose.helper.js')
 const PurposeHelper = require('../../../support/helpers/purpose.helper.js')
@@ -32,6 +36,9 @@ describe('Generate return logs service', () => {
   const summerStartDate = new Date(new Date().getFullYear(), 10, 1).toISOString().split('T')[0]
   const summerReturns = []
   const allYearReturns = []
+  const allYearReturnCycleId = 'c095d75e-0e0d-4fe4-b048-150457f3871b'
+  const summerReturnCycleId = 'd095d75e-0e0d-4fe4-b048-150457f3871f'
+  const today = formatDateObjectToISO(new Date())
 
   let expiredDate
   let lapsedDate
@@ -53,860 +60,990 @@ describe('Generate return logs service', () => {
   let secondaryPurpose
   let secondaryPurpose2
   let startDate
+  let summer
 
-  describe('when summer is false, one return requirement and a licenceRef provided', () => {
+  describe('when return cycle exists', () => {
     before(async () => {
-      region = RegionHelper.select()
-      licence = await LicenceHelper.add({ regionId: region.id })
-      returnVersion = await ReturnVersionHelper.add({ licenceId: licence.id })
-
-      returnRequirement = await ReturnRequirementHelper.add({ returnVersionId: returnVersion.id })
-      point = await PointHelper.add()
-      await ReturnRequirementPointHelper.add({ pointId: point.id, returnRequirementId: returnRequirement.id })
-      primaryPurpose = PrimaryPurposeHelper.select()
-      purpose = PurposeHelper.select()
-      secondaryPurpose = SecondaryPurposeHelper.select()
-      returnRequirementPurpose = await ReturnRequirementPurposeHelper.add({
-        primaryPurposeId: primaryPurpose.id,
-        purposeId: purpose.id,
-        returnRequirementId: returnRequirement.id,
-        secondaryPurposeId: secondaryPurpose.id
-      })
-      allYearReturns.push(returnRequirement.legacyId.toString())
-
-      returnRequirements = await FetchReturnRequirementsService.go(false, licence.licenceRef)
+      Sinon.stub(FetchReturnCycleService, 'go')
+        .withArgs(today, false).returns(allYearReturnCycleId)
+        .withArgs(today, true).returns(summerReturnCycleId)
     })
 
-    it('should return one return log payload', async () => {
-      const result = await GenerateReturnLogsService.go(returnRequirements)
-
-      expect(result.length).to.equal(1)
-      expect(result[0].dueDate).to.equal(allYearDueDate)
-      expect(result[0].endDate).to.equal(allYearEndDate)
-      expect(result[0].id).to.equal(`v1:${region.naldRegionId}:${licence.licenceRef}:${returnRequirement.legacyId}:${allYearStartDate}:${allYearEndDate}`)
-      expect(result[0].licenceRef).to.equal(licence.licenceRef)
-      expect(result[0].metadata).to.equal({
-        description: 'BOREHOLE AT AVALON',
-        isCurrent: true,
-        isFinal: false,
-        isSummer: false,
-        isTwoPartTariff: false,
-        isUpload: false,
-        nald: {
-          regionCode: region.naldRegionId,
-          areaCode: licence.regions.historicalAreaCode,
-          formatId: returnRequirement.legacyId,
-          periodStartDay: returnRequirement.abstractionPeriodStartDay.toString(),
-          periodStartMonth: returnRequirement.abstractionPeriodStartMonth.toString(),
-          periodEndDay: returnRequirement.abstractionPeriodEndDay.toString(),
-          periodEndMonth: returnRequirement.abstractionPeriodEndMonth.toString()
-        },
-        points: [{
-          name: point.description,
-          ngr1: point.ngr1,
-          ngr2: point.ngr2,
-          ngr3: point.ngr3,
-          ngr4: point.ngr4
-        }],
-        purposes: [{
-          alias: returnRequirementPurpose.alias,
-          primary: {
-            code: primaryPurpose.legacyId,
-            description: primaryPurpose.description
-          },
-          secondary: {
-            code: secondaryPurpose.legacyId,
-            description: secondaryPurpose.description
-          },
-          tertiary: {
-            code: purpose.legacyId,
-            description: purpose.description
-          }
-        }],
-        version: 1
+    describe('when summer is false', () => {
+      before(async () => {
+        summer = false
       })
-      expect(result[0].returnsFrequency).to.equal('day')
-      expect(result[0].startDate).to.equal(allYearStartDate)
-      expect(result[0].status).to.equal('due')
-      expect(result[0].source).to.equal('WRLS')
+
+      describe('has one return requirement and a licenceRef provided', () => {
+        before(async () => {
+          region = RegionHelper.select()
+          licence = await LicenceHelper.add({ regionId: region.id })
+          returnVersion = await ReturnVersionHelper.add({ licenceId: licence.id })
+
+          returnRequirement = await ReturnRequirementHelper.add({ returnVersionId: returnVersion.id })
+          point = await PointHelper.add()
+          await ReturnRequirementPointHelper.add({ pointId: point.id, returnRequirementId: returnRequirement.id })
+          primaryPurpose = PrimaryPurposeHelper.select()
+          purpose = PurposeHelper.select()
+          secondaryPurpose = SecondaryPurposeHelper.select()
+          returnRequirementPurpose = await ReturnRequirementPurposeHelper.add({
+            alias: null,
+            primaryPurposeId: primaryPurpose.id,
+            purposeId: purpose.id,
+            returnRequirementId: returnRequirement.id,
+            secondaryPurposeId: secondaryPurpose.id
+          })
+          allYearReturns.push(returnRequirement.legacyId.toString())
+
+          returnRequirements = await FetchReturnRequirementsService.go(summer, licence.licenceRef)
+        })
+
+        it('should return one return log payload', async () => {
+          const result = await GenerateReturnLogsService.go(returnRequirements)
+
+          expect(result.length).to.equal(1)
+          expect(result[0].dueDate).to.equal(allYearDueDate)
+          expect(result[0].endDate).to.equal(allYearEndDate)
+          expect(result[0].id).to.equal(`v1:${region.naldRegionId}:${licence.licenceRef}:${returnRequirement.legacyId}:${allYearStartDate}:${allYearEndDate}`)
+          expect(result[0].licenceRef).to.equal(licence.licenceRef)
+          expect(result[0].metadata).to.equal({
+            description: 'BOREHOLE AT AVALON',
+            isCurrent: true,
+            isFinal: false,
+            isSummer: false,
+            isTwoPartTariff: false,
+            isUpload: false,
+            nald: {
+              regionCode: region.naldRegionId,
+              areaCode: licence.regions.historicalAreaCode,
+              formatId: returnRequirement.legacyId,
+              periodStartDay: returnRequirement.abstractionPeriodStartDay.toString(),
+              periodStartMonth: returnRequirement.abstractionPeriodStartMonth.toString(),
+              periodEndDay: returnRequirement.abstractionPeriodEndDay.toString(),
+              periodEndMonth: returnRequirement.abstractionPeriodEndMonth.toString()
+            },
+            points: [{
+              name: point.description,
+              ngr1: point.ngr1,
+              ngr2: point.ngr2,
+              ngr3: point.ngr3,
+              ngr4: point.ngr4
+            }],
+            purposes: [{
+              primary: {
+                code: primaryPurpose.legacyId,
+                description: primaryPurpose.description
+              },
+              secondary: {
+                code: secondaryPurpose.legacyId,
+                description: secondaryPurpose.description
+              },
+              tertiary: {
+                code: purpose.legacyId,
+                description: purpose.description
+              }
+            }],
+            version: 1
+          })
+          expect(result[0].returnCycleId).to.equal(allYearReturnCycleId)
+          expect(result[0].returnsFrequency).to.equal('day')
+          expect(result[0].startDate).to.equal(allYearStartDate)
+          expect(result[0].status).to.equal('due')
+          expect(result[0].source).to.equal('WRLS')
+        })
+      })
+
+      describe('has two return requirements and a licenceRef provided', () => {
+        before(async () => {
+          region = RegionHelper.select()
+          licence = await LicenceHelper.add({ regionId: region.id })
+          returnVersion = await ReturnVersionHelper.add({ licenceId: licence.id })
+
+          returnRequirement = await ReturnRequirementHelper.add({ returnVersionId: returnVersion.id })
+          point = await PointHelper.add()
+          await ReturnRequirementPointHelper.add({ pointId: point.id, returnRequirementId: returnRequirement.id })
+          primaryPurpose = PrimaryPurposeHelper.select()
+          purpose = PurposeHelper.select()
+          secondaryPurpose = SecondaryPurposeHelper.select()
+          returnRequirementPurpose = await ReturnRequirementPurposeHelper.add({
+            primaryPurposeId: primaryPurpose.id,
+            purposeId: purpose.id,
+            returnRequirementId: returnRequirement.id,
+            secondaryPurposeId: secondaryPurpose.id
+          })
+
+          returnRequirement2 = await ReturnRequirementHelper.add({ returnVersionId: returnVersion.id })
+          point2 = await PointHelper.add()
+          await ReturnRequirementPointHelper.add({ pointId: point2.id, returnRequirementId: returnRequirement2.id })
+          primaryPurpose2 = PrimaryPurposeHelper.select()
+          purpose2 = PurposeHelper.select()
+          secondaryPurpose2 = SecondaryPurposeHelper.select()
+          returnRequirementPurpose2 = await ReturnRequirementPurposeHelper.add({
+            primaryPurposeId: primaryPurpose2.id,
+            purposeId: purpose2.id,
+            returnRequirementId: returnRequirement2.id,
+            secondaryPurposeId: secondaryPurpose2.id
+          })
+          allYearReturns.push(returnRequirement.legacyId.toString())
+          allYearReturns.push(returnRequirement2.legacyId.toString())
+        })
+
+        it('should return two return log payloads', async () => {
+          const returnRequirements = await FetchReturnRequirementsService.go(summer, licence.licenceRef)
+          const result = await GenerateReturnLogsService.go(returnRequirements)
+
+          expect(result.length).to.equal(2)
+          expect(result[0].dueDate).to.equal(allYearDueDate)
+          expect(result[0].endDate).to.equal(allYearEndDate)
+          expect(result[0].id).to.equal(`v1:${region.naldRegionId}:${licence.licenceRef}:${returnRequirement.legacyId}:${allYearStartDate}:${allYearEndDate}`)
+          expect(result[0].licenceRef).to.equal(licence.licenceRef)
+          expect(result[0].metadata).to.equal({
+            description: 'BOREHOLE AT AVALON',
+            isCurrent: true,
+            isFinal: false,
+            isSummer: false,
+            isTwoPartTariff: false,
+            isUpload: false,
+            nald: {
+              regionCode: region.naldRegionId,
+              areaCode: licence.regions.historicalAreaCode,
+              formatId: returnRequirement.legacyId,
+              periodStartDay: returnRequirement.abstractionPeriodStartDay.toString(),
+              periodStartMonth: returnRequirement.abstractionPeriodStartMonth.toString(),
+              periodEndDay: returnRequirement.abstractionPeriodEndDay.toString(),
+              periodEndMonth: returnRequirement.abstractionPeriodEndMonth.toString()
+            },
+            points: [{
+              name: point.description,
+              ngr1: point.ngr1,
+              ngr2: point.ngr2,
+              ngr3: point.ngr3,
+              ngr4: point.ngr4
+            }],
+            purposes: [{
+              alias: returnRequirementPurpose.alias,
+              primary: {
+                code: primaryPurpose.legacyId,
+                description: primaryPurpose.description
+              },
+              secondary: {
+                code: secondaryPurpose.legacyId,
+                description: secondaryPurpose.description
+              },
+              tertiary: {
+                code: purpose.legacyId,
+                description: purpose.description
+              }
+            }],
+            version: 1
+          })
+          expect(result[0].returnCycleId).to.equal(allYearReturnCycleId)
+          expect(result[0].returnsFrequency).to.equal('day')
+          expect(result[0].startDate).to.equal(allYearStartDate)
+          expect(result[0].status).to.equal('due')
+          expect(result[0].source).to.equal('WRLS')
+          expect(result[1].dueDate).to.equal(allYearDueDate)
+          expect(result[1].endDate).to.equal(allYearEndDate)
+          expect(result[1].id).to.equal(`v1:${region.naldRegionId}:${licence.licenceRef}:${returnRequirement2.legacyId}:${allYearStartDate}:${allYearEndDate}`)
+          expect(result[1].licenceRef).to.equal(licence.licenceRef)
+          expect(result[1].metadata).to.equal({
+            description: 'BOREHOLE AT AVALON',
+            isCurrent: true,
+            isFinal: false,
+            isSummer: false,
+            isTwoPartTariff: false,
+            isUpload: false,
+            nald: {
+              regionCode: region.naldRegionId,
+              areaCode: licence.regions.historicalAreaCode,
+              formatId: returnRequirement2.legacyId,
+              periodStartDay: returnRequirement2.abstractionPeriodStartDay.toString(),
+              periodStartMonth: returnRequirement2.abstractionPeriodStartMonth.toString(),
+              periodEndDay: returnRequirement2.abstractionPeriodEndDay.toString(),
+              periodEndMonth: returnRequirement2.abstractionPeriodEndMonth.toString()
+            },
+            points: [{
+              name: point2.description,
+              ngr1: point2.ngr1,
+              ngr2: point2.ngr2,
+              ngr3: point2.ngr3,
+              ngr4: point2.ngr4
+            }],
+            purposes: [{
+              alias: returnRequirementPurpose2.alias,
+              primary: {
+                code: primaryPurpose2.legacyId,
+                description: primaryPurpose2.description
+              },
+              secondary: {
+                code: secondaryPurpose2.legacyId,
+                description: secondaryPurpose2.description
+              },
+              tertiary: {
+                code: purpose2.legacyId,
+                description: purpose2.description
+              }
+            }],
+            version: 1
+          })
+          expect(result[1].returnCycleId).to.equal(allYearReturnCycleId)
+          expect(result[1].returnsFrequency).to.equal('day')
+          expect(result[1].startDate).to.equal(allYearStartDate)
+          expect(result[1].status).to.equal('due')
+          expect(result[1].source).to.equal('WRLS')
+        })
+      })
+
+      describe('there is an expired date, one return requirement and a licenceRef provided', () => {
+        before(async () => {
+          expiredDate = new Date(new Date().getFullYear() + 1, 1, 31).toISOString().split('T')[0]
+          region = RegionHelper.select()
+          licence = await LicenceHelper.add({ expiredDate, regionId: region.id })
+          returnVersion = await ReturnVersionHelper.add({ licenceId: licence.id })
+
+          returnRequirement = await ReturnRequirementHelper.add({ returnVersionId: returnVersion.id })
+          point = await PointHelper.add()
+          await ReturnRequirementPointHelper.add({ pointId: point.id, returnRequirementId: returnRequirement.id })
+          primaryPurpose = PrimaryPurposeHelper.select()
+          purpose = PurposeHelper.select()
+          secondaryPurpose = SecondaryPurposeHelper.select()
+          returnRequirementPurpose = await ReturnRequirementPurposeHelper.add({
+            primaryPurposeId: primaryPurpose.id,
+            purposeId: purpose.id,
+            returnRequirementId: returnRequirement.id,
+            secondaryPurposeId: secondaryPurpose.id
+          })
+          allYearReturns.push(returnRequirement.legacyId.toString())
+
+          returnRequirements = await FetchReturnRequirementsService.go(summer, licence.licenceRef)
+        })
+
+        it('should return one return log payload', async () => {
+          const result = await GenerateReturnLogsService.go(returnRequirements)
+
+          expect(result.length).to.equal(1)
+          expect(result[0].dueDate).to.equal(allYearDueDate)
+          expect(result[0].endDate).to.equal(expiredDate)
+          expect(result[0].id).to.equal(`v1:${region.naldRegionId}:${licence.licenceRef}:${returnRequirement.legacyId}:${allYearStartDate}:${expiredDate}`)
+          expect(result[0].licenceRef).to.equal(licence.licenceRef)
+          expect(result[0].metadata).to.equal({
+            description: 'BOREHOLE AT AVALON',
+            isCurrent: true,
+            isFinal: true,
+            isSummer: false,
+            isTwoPartTariff: false,
+            isUpload: false,
+            nald: {
+              regionCode: region.naldRegionId,
+              areaCode: licence.regions.historicalAreaCode,
+              formatId: returnRequirement.legacyId,
+              periodStartDay: returnRequirement.abstractionPeriodStartDay.toString(),
+              periodStartMonth: returnRequirement.abstractionPeriodStartMonth.toString(),
+              periodEndDay: returnRequirement.abstractionPeriodEndDay.toString(),
+              periodEndMonth: returnRequirement.abstractionPeriodEndMonth.toString()
+            },
+            points: [{
+              name: point.description,
+              ngr1: point.ngr1,
+              ngr2: point.ngr2,
+              ngr3: point.ngr3,
+              ngr4: point.ngr4
+            }],
+            purposes: [{
+              alias: returnRequirementPurpose.alias,
+              primary: {
+                code: primaryPurpose.legacyId,
+                description: primaryPurpose.description
+              },
+              secondary: {
+                code: secondaryPurpose.legacyId,
+                description: secondaryPurpose.description
+              },
+              tertiary: {
+                code: purpose.legacyId,
+                description: purpose.description
+              }
+            }],
+            version: 1
+          })
+          expect(result[0].returnCycleId).to.equal(allYearReturnCycleId)
+          expect(result[0].returnsFrequency).to.equal('day')
+          expect(result[0].startDate).to.equal(allYearStartDate)
+          expect(result[0].status).to.equal('due')
+          expect(result[0].source).to.equal('WRLS')
+        })
+      })
+
+      describe('there is an expired date after the end of the cycle, one return requirement and a licenceRef provided', () => {
+        before(async () => {
+          expiredDate = new Date(new Date().getFullYear() + 1, 3, 31).toISOString().split('T')[0]
+          region = RegionHelper.select()
+          licence = await LicenceHelper.add({ expiredDate, regionId: region.id })
+          returnVersion = await ReturnVersionHelper.add({ licenceId: licence.id })
+
+          returnRequirement = await ReturnRequirementHelper.add({ returnVersionId: returnVersion.id })
+          point = await PointHelper.add()
+          await ReturnRequirementPointHelper.add({ pointId: point.id, returnRequirementId: returnRequirement.id })
+          primaryPurpose = PrimaryPurposeHelper.select()
+          purpose = PurposeHelper.select()
+          secondaryPurpose = SecondaryPurposeHelper.select()
+          returnRequirementPurpose = await ReturnRequirementPurposeHelper.add({
+            primaryPurposeId: primaryPurpose.id,
+            purposeId: purpose.id,
+            returnRequirementId: returnRequirement.id,
+            secondaryPurposeId: secondaryPurpose.id
+          })
+          allYearReturns.push(returnRequirement.legacyId.toString())
+
+          returnRequirements = await FetchReturnRequirementsService.go(summer, licence.licenceRef)
+        })
+
+        it('should return one return log payload', async () => {
+          const result = await GenerateReturnLogsService.go(returnRequirements)
+
+          expect(result.length).to.equal(1)
+          expect(result[0].dueDate).to.equal(allYearDueDate)
+          expect(result[0].endDate).to.equal(allYearEndDate)
+          expect(result[0].id).to.equal(`v1:${region.naldRegionId}:${licence.licenceRef}:${returnRequirement.legacyId}:${allYearStartDate}:${allYearEndDate}`)
+          expect(result[0].licenceRef).to.equal(licence.licenceRef)
+          expect(result[0].metadata).to.equal({
+            description: 'BOREHOLE AT AVALON',
+            isCurrent: true,
+            isFinal: false,
+            isSummer: false,
+            isTwoPartTariff: false,
+            isUpload: false,
+            nald: {
+              regionCode: region.naldRegionId,
+              areaCode: licence.regions.historicalAreaCode,
+              formatId: returnRequirement.legacyId,
+              periodStartDay: returnRequirement.abstractionPeriodStartDay.toString(),
+              periodStartMonth: returnRequirement.abstractionPeriodStartMonth.toString(),
+              periodEndDay: returnRequirement.abstractionPeriodEndDay.toString(),
+              periodEndMonth: returnRequirement.abstractionPeriodEndMonth.toString()
+            },
+            points: [{
+              name: point.description,
+              ngr1: point.ngr1,
+              ngr2: point.ngr2,
+              ngr3: point.ngr3,
+              ngr4: point.ngr4
+            }],
+            purposes: [{
+              alias: returnRequirementPurpose.alias,
+              primary: {
+                code: primaryPurpose.legacyId,
+                description: primaryPurpose.description
+              },
+              secondary: {
+                code: secondaryPurpose.legacyId,
+                description: secondaryPurpose.description
+              },
+              tertiary: {
+                code: purpose.legacyId,
+                description: purpose.description
+              }
+            }],
+            version: 1
+          })
+          expect(result[0].returnCycleId).to.equal(allYearReturnCycleId)
+          expect(result[0].returnsFrequency).to.equal('day')
+          expect(result[0].startDate).to.equal(allYearStartDate)
+          expect(result[0].status).to.equal('due')
+          expect(result[0].source).to.equal('WRLS')
+        })
+      })
+
+      describe('there is no licenceReference provided it should return all the return logs that are eligible', () => {
+        it('should return five return log payloads', async () => {
+          const returnRequirements = await FetchReturnRequirementsService.go(false)
+          const results = await GenerateReturnLogsService.go(returnRequirements)
+
+          const returnRequirementExternalId = results.map((returnLog) => {
+            return returnLog.returnReference
+          })
+
+          expect(allYearReturns.every((result) => {
+            return returnRequirementExternalId.includes(result)
+          })).to.equal(true)
+        })
+      })
+    })
+
+    describe('when summer is true', () => {
+      before(async () => {
+        summer = true
+      })
+
+      describe('has one return requirement and a licenceRef provided', () => {
+        before(async () => {
+          region = RegionHelper.select()
+          licence = await LicenceHelper.add({ regionId: region.id })
+          returnVersion = await ReturnVersionHelper.add({ licenceId: licence.id })
+
+          returnRequirement = await ReturnRequirementHelper.add({ summer, returnVersionId: returnVersion.id })
+          point = await PointHelper.add()
+          await ReturnRequirementPointHelper.add({ pointId: point.id, returnRequirementId: returnRequirement.id })
+          primaryPurpose = PrimaryPurposeHelper.select()
+          purpose = PurposeHelper.select()
+          secondaryPurpose = SecondaryPurposeHelper.select()
+          returnRequirementPurpose = await ReturnRequirementPurposeHelper.add({
+            primaryPurposeId: primaryPurpose.id,
+            purposeId: purpose.id,
+            returnRequirementId: returnRequirement.id,
+            secondaryPurposeId: secondaryPurpose.id
+          })
+          summerReturns.push(returnRequirement.legacyId.toString())
+
+          returnRequirements = await FetchReturnRequirementsService.go(summer, licence.licenceRef)
+        })
+
+        it('should return one return log payload', async () => {
+          const result = await GenerateReturnLogsService.go(returnRequirements)
+
+          expect(result.length).to.equal(1)
+          expect(result[0].dueDate).to.equal(summerDueDate)
+          expect(result[0].endDate).to.equal(summerEndDate)
+          expect(result[0].id).to.equal(`v1:${region.naldRegionId}:${licence.licenceRef}:${returnRequirement.legacyId}:${summerStartDate}:${summerEndDate}`)
+          expect(result[0].licenceRef).to.equal(licence.licenceRef)
+          expect(result[0].metadata).to.equal({
+            description: 'BOREHOLE AT AVALON',
+            isCurrent: true,
+            isFinal: false,
+            isSummer: true,
+            isTwoPartTariff: false,
+            isUpload: false,
+            nald: {
+              regionCode: region.naldRegionId,
+              areaCode: licence.regions.historicalAreaCode,
+              formatId: returnRequirement.legacyId,
+              periodStartDay: returnRequirement.abstractionPeriodStartDay.toString(),
+              periodStartMonth: returnRequirement.abstractionPeriodStartMonth.toString(),
+              periodEndDay: returnRequirement.abstractionPeriodEndDay.toString(),
+              periodEndMonth: returnRequirement.abstractionPeriodEndMonth.toString()
+            },
+            points: [{
+              name: point.description,
+              ngr1: point.ngr1,
+              ngr2: point.ngr2,
+              ngr3: point.ngr3,
+              ngr4: point.ngr4
+            }],
+            purposes: [{
+              alias: returnRequirementPurpose.alias,
+              primary: {
+                code: primaryPurpose.legacyId,
+                description: primaryPurpose.description
+              },
+              secondary: {
+                code: secondaryPurpose.legacyId,
+                description: secondaryPurpose.description
+              },
+              tertiary: {
+                code: purpose.legacyId,
+                description: purpose.description
+              }
+            }],
+            version: 1
+          })
+          expect(result[0].returnCycleId).to.equal(summerReturnCycleId)
+          expect(result[0].returnsFrequency).to.equal('day')
+          expect(result[0].startDate).to.equal(summerStartDate)
+          expect(result[0].status).to.equal('due')
+          expect(result[0].source).to.equal('WRLS')
+        })
+      })
+
+      describe('has two return requirements and a licenceRef provided', () => {
+        before(async () => {
+          region = RegionHelper.select()
+          licence = await LicenceHelper.add({ regionId: region.id })
+          returnVersion = await ReturnVersionHelper.add({ licenceId: licence.id })
+
+          returnRequirement = await ReturnRequirementHelper.add({ summer, returnVersionId: returnVersion.id })
+          point = await PointHelper.add()
+          await ReturnRequirementPointHelper.add({ pointId: point.id, returnRequirementId: returnRequirement.id })
+          primaryPurpose = PrimaryPurposeHelper.select()
+          purpose = PurposeHelper.select()
+          secondaryPurpose = SecondaryPurposeHelper.select()
+          returnRequirementPurpose = await ReturnRequirementPurposeHelper.add({
+            primaryPurposeId: primaryPurpose.id,
+            purposeId: purpose.id,
+            returnRequirementId: returnRequirement.id,
+            secondaryPurposeId: secondaryPurpose.id
+          })
+
+          returnRequirement2 = await ReturnRequirementHelper.add({ summer, returnVersionId: returnVersion.id })
+          point2 = await PointHelper.add()
+          await ReturnRequirementPointHelper.add({ pointId: point2.id, returnRequirementId: returnRequirement2.id })
+          primaryPurpose2 = PrimaryPurposeHelper.select()
+          purpose2 = PurposeHelper.select()
+          secondaryPurpose2 = SecondaryPurposeHelper.select()
+          returnRequirementPurpose2 = await ReturnRequirementPurposeHelper.add({
+            primaryPurposeId: primaryPurpose2.id,
+            purposeId: purpose2.id,
+            returnRequirementId: returnRequirement2.id,
+            secondaryPurposeId: secondaryPurpose2.id
+          })
+          summerReturns.push(returnRequirement.legacyId.toString())
+          summerReturns.push(returnRequirement2.legacyId.toString())
+
+          returnRequirements = await FetchReturnRequirementsService.go(summer, licence.licenceRef)
+        })
+
+        it('should return two return log payloads', async () => {
+          const result = await GenerateReturnLogsService.go(returnRequirements)
+
+          expect(result.length).to.equal(2)
+          expect(result[0].dueDate).to.equal(summerDueDate)
+          expect(result[0].endDate).to.equal(summerEndDate)
+          expect(result[0].id).to.equal(`v1:${region.naldRegionId}:${licence.licenceRef}:${returnRequirement.legacyId}:${summerStartDate}:${summerEndDate}`)
+          expect(result[0].licenceRef).to.equal(licence.licenceRef)
+          expect(result[0].metadata).to.equal({
+            description: 'BOREHOLE AT AVALON',
+            isCurrent: true,
+            isFinal: false,
+            isSummer: true,
+            isTwoPartTariff: false,
+            isUpload: false,
+            nald: {
+              regionCode: region.naldRegionId,
+              areaCode: licence.regions.historicalAreaCode,
+              formatId: returnRequirement.legacyId,
+              periodStartDay: returnRequirement.abstractionPeriodStartDay.toString(),
+              periodStartMonth: returnRequirement.abstractionPeriodStartMonth.toString(),
+              periodEndDay: returnRequirement.abstractionPeriodEndDay.toString(),
+              periodEndMonth: returnRequirement.abstractionPeriodEndMonth.toString()
+            },
+            points: [{
+              name: point.description,
+              ngr1: point.ngr1,
+              ngr2: point.ngr2,
+              ngr3: point.ngr3,
+              ngr4: point.ngr4
+            }],
+            purposes: [{
+              alias: returnRequirementPurpose.alias,
+              primary: {
+                code: primaryPurpose.legacyId,
+                description: primaryPurpose.description
+              },
+              secondary: {
+                code: secondaryPurpose.legacyId,
+                description: secondaryPurpose.description
+              },
+              tertiary: {
+                code: purpose.legacyId,
+                description: purpose.description
+              }
+            }],
+            version: 1
+          })
+          expect(result[0].returnCycleId).to.equal(summerReturnCycleId)
+          expect(result[0].returnsFrequency).to.equal('day')
+          expect(result[0].startDate).to.equal(summerStartDate)
+          expect(result[0].status).to.equal('due')
+          expect(result[0].source).to.equal('WRLS')
+          expect(result[1].dueDate).to.equal(summerDueDate)
+          expect(result[1].endDate).to.equal(summerEndDate)
+          expect(result[1].id).to.equal(`v1:${region.naldRegionId}:${licence.licenceRef}:${returnRequirement2.legacyId}:${summerStartDate}:${summerEndDate}`)
+          expect(result[1].licenceRef).to.equal(licence.licenceRef)
+          expect(result[1].metadata).to.equal({
+            description: 'BOREHOLE AT AVALON',
+            isCurrent: true,
+            isFinal: false,
+            isSummer: true,
+            isTwoPartTariff: false,
+            isUpload: false,
+            nald: {
+              regionCode: region.naldRegionId,
+              areaCode: licence.regions.historicalAreaCode,
+              formatId: returnRequirement2.legacyId,
+              periodStartDay: returnRequirement2.abstractionPeriodStartDay.toString(),
+              periodStartMonth: returnRequirement2.abstractionPeriodStartMonth.toString(),
+              periodEndDay: returnRequirement2.abstractionPeriodEndDay.toString(),
+              periodEndMonth: returnRequirement2.abstractionPeriodEndMonth.toString()
+            },
+            points: [{
+              name: point2.description,
+              ngr1: point2.ngr1,
+              ngr2: point2.ngr2,
+              ngr3: point2.ngr3,
+              ngr4: point2.ngr4
+            }],
+            purposes: [{
+              alias: returnRequirementPurpose2.alias,
+              primary: {
+                code: primaryPurpose2.legacyId,
+                description: primaryPurpose2.description
+              },
+              secondary: {
+                code: secondaryPurpose2.legacyId,
+                description: secondaryPurpose2.description
+              },
+              tertiary: {
+                code: purpose2.legacyId,
+                description: purpose2.description
+              }
+            }],
+            version: 1
+          })
+          expect(result[1].returnCycleId).to.equal(summerReturnCycleId)
+          expect(result[1].returnsFrequency).to.equal('day')
+          expect(result[1].startDate).to.equal(summerStartDate)
+          expect(result[1].status).to.equal('due')
+          expect(result[1].source).to.equal('WRLS')
+        })
+      })
+
+      describe('there is a lapsed date, one return requirement and a licenceRef provided', () => {
+        before(async () => {
+          lapsedDate = new Date(new Date().getFullYear() + 1, 8, 31).toISOString().split('T')[0]
+          region = RegionHelper.select()
+          licence = await LicenceHelper.add({ lapsedDate, regionId: region.id })
+          returnVersion = await ReturnVersionHelper.add({ licenceId: licence.id })
+
+          returnRequirement = await ReturnRequirementHelper.add({ summer, returnVersionId: returnVersion.id })
+          point = await PointHelper.add()
+          await ReturnRequirementPointHelper.add({ pointId: point.id, returnRequirementId: returnRequirement.id })
+          primaryPurpose = PrimaryPurposeHelper.select()
+          purpose = PurposeHelper.select()
+          secondaryPurpose = SecondaryPurposeHelper.select()
+          returnRequirementPurpose = await ReturnRequirementPurposeHelper.add({
+            primaryPurposeId: primaryPurpose.id,
+            purposeId: purpose.id,
+            returnRequirementId: returnRequirement.id,
+            secondaryPurposeId: secondaryPurpose.id
+          })
+          summerReturns.push(returnRequirement.legacyId.toString())
+
+          returnRequirements = await FetchReturnRequirementsService.go(summer, licence.licenceRef)
+        })
+
+        it('should return one return log payload', async () => {
+          const result = await GenerateReturnLogsService.go(returnRequirements)
+
+          expect(result.length).to.equal(1)
+          expect(result[0].dueDate).to.equal(summerDueDate)
+          expect(result[0].endDate).to.equal(lapsedDate)
+          expect(result[0].id).to.equal(`v1:${region.naldRegionId}:${licence.licenceRef}:${returnRequirement.legacyId}:${summerStartDate}:${lapsedDate}`)
+          expect(result[0].licenceRef).to.equal(licence.licenceRef)
+          expect(result[0].metadata).to.equal({
+            description: 'BOREHOLE AT AVALON',
+            isCurrent: true,
+            isFinal: true,
+            isSummer: true,
+            isTwoPartTariff: false,
+            isUpload: false,
+            nald: {
+              regionCode: region.naldRegionId,
+              areaCode: licence.regions.historicalAreaCode,
+              formatId: returnRequirement.legacyId,
+              periodStartDay: returnRequirement.abstractionPeriodStartDay.toString(),
+              periodStartMonth: returnRequirement.abstractionPeriodStartMonth.toString(),
+              periodEndDay: returnRequirement.abstractionPeriodEndDay.toString(),
+              periodEndMonth: returnRequirement.abstractionPeriodEndMonth.toString()
+            },
+            points: [{
+              name: point.description,
+              ngr1: point.ngr1,
+              ngr2: point.ngr2,
+              ngr3: point.ngr3,
+              ngr4: point.ngr4
+            }],
+            purposes: [{
+              alias: returnRequirementPurpose.alias,
+              primary: {
+                code: primaryPurpose.legacyId,
+                description: primaryPurpose.description
+              },
+              secondary: {
+                code: secondaryPurpose.legacyId,
+                description: secondaryPurpose.description
+              },
+              tertiary: {
+                code: purpose.legacyId,
+                description: purpose.description
+              }
+            }],
+            version: 1
+          })
+          expect(result[0].returnCycleId).to.equal(summerReturnCycleId)
+          expect(result[0].returnsFrequency).to.equal('day')
+          expect(result[0].startDate).to.equal(summerStartDate)
+          expect(result[0].status).to.equal('due')
+          expect(result[0].source).to.equal('WRLS')
+        })
+      })
+
+      describe('there is a revoked date that is after the cycle, one return requirement and a licenceRef provided', () => {
+        before(async () => {
+          revokedDate = new Date(new Date().getFullYear() + 1, 10, 31).toISOString().split('T')[0]
+          region = RegionHelper.select()
+          licence = await LicenceHelper.add({ revokedDate, regionId: region.id })
+          returnVersion = await ReturnVersionHelper.add({ licenceId: licence.id })
+
+          returnRequirement = await ReturnRequirementHelper.add({ summer, returnVersionId: returnVersion.id })
+          point = await PointHelper.add()
+          await ReturnRequirementPointHelper.add({ pointId: point.id, returnRequirementId: returnRequirement.id })
+          primaryPurpose = PrimaryPurposeHelper.select()
+          purpose = PurposeHelper.select()
+          secondaryPurpose = SecondaryPurposeHelper.select()
+          returnRequirementPurpose = await ReturnRequirementPurposeHelper.add({
+            primaryPurposeId: primaryPurpose.id,
+            purposeId: purpose.id,
+            returnRequirementId: returnRequirement.id,
+            secondaryPurposeId: secondaryPurpose.id
+          })
+          summerReturns.push(returnRequirement.legacyId.toString())
+
+          returnRequirements = await FetchReturnRequirementsService.go(summer, licence.licenceRef)
+        })
+
+        it('should return one return log payload', async () => {
+          const result = await GenerateReturnLogsService.go(returnRequirements)
+
+          expect(result.length).to.equal(1)
+          expect(result[0].dueDate).to.equal(summerDueDate)
+          expect(result[0].endDate).to.equal(summerEndDate)
+          expect(result[0].id).to.equal(`v1:${region.naldRegionId}:${licence.licenceRef}:${returnRequirement.legacyId}:${summerStartDate}:${summerEndDate}`)
+          expect(result[0].licenceRef).to.equal(licence.licenceRef)
+          expect(result[0].metadata).to.equal({
+            description: 'BOREHOLE AT AVALON',
+            isCurrent: true,
+            isFinal: false,
+            isSummer: true,
+            isTwoPartTariff: false,
+            isUpload: false,
+            nald: {
+              regionCode: region.naldRegionId,
+              areaCode: licence.regions.historicalAreaCode,
+              formatId: returnRequirement.legacyId,
+              periodStartDay: returnRequirement.abstractionPeriodStartDay.toString(),
+              periodStartMonth: returnRequirement.abstractionPeriodStartMonth.toString(),
+              periodEndDay: returnRequirement.abstractionPeriodEndDay.toString(),
+              periodEndMonth: returnRequirement.abstractionPeriodEndMonth.toString()
+            },
+            points: [{
+              name: point.description,
+              ngr1: point.ngr1,
+              ngr2: point.ngr2,
+              ngr3: point.ngr3,
+              ngr4: point.ngr4
+            }],
+            purposes: [{
+              alias: returnRequirementPurpose.alias,
+              primary: {
+                code: primaryPurpose.legacyId,
+                description: primaryPurpose.description
+              },
+              secondary: {
+                code: secondaryPurpose.legacyId,
+                description: secondaryPurpose.description
+              },
+              tertiary: {
+                code: purpose.legacyId,
+                description: purpose.description
+              }
+            }],
+            version: 1
+          })
+          expect(result[0].returnCycleId).to.equal(summerReturnCycleId)
+          expect(result[0].returnsFrequency).to.equal('day')
+          expect(result[0].startDate).to.equal(summerStartDate)
+          expect(result[0].status).to.equal('due')
+          expect(result[0].source).to.equal('WRLS')
+        })
+      })
+
+      describe('the return version start date is after the cycle start date, one return requirement and a licenceRef provided', () => {
+        before(async () => {
+          startDate = new Date(new Date().getFullYear(), 11, 1).toISOString().split('T')[0]
+          region = RegionHelper.select()
+          licence = await LicenceHelper.add({ regionId: region.id })
+          returnVersion = await ReturnVersionHelper.add({ licenceId: licence.id, startDate })
+
+          returnRequirement = await ReturnRequirementHelper.add({ summer, returnVersionId: returnVersion.id })
+          point = await PointHelper.add()
+          await ReturnRequirementPointHelper.add({ pointId: point.id, returnRequirementId: returnRequirement.id })
+          primaryPurpose = PrimaryPurposeHelper.select()
+          purpose = PurposeHelper.select()
+          secondaryPurpose = SecondaryPurposeHelper.select()
+          returnRequirementPurpose = await ReturnRequirementPurposeHelper.add({
+            primaryPurposeId: primaryPurpose.id,
+            purposeId: purpose.id,
+            returnRequirementId: returnRequirement.id,
+            secondaryPurposeId: secondaryPurpose.id
+          })
+          summerReturns.push(returnRequirement.legacyId.toString())
+
+          returnRequirements = await FetchReturnRequirementsService.go(summer, licence.licenceRef)
+        })
+
+        it('should return one return log payload', async () => {
+          const result = await GenerateReturnLogsService.go(returnRequirements)
+
+          expect(result.length).to.equal(1)
+          expect(result[0].dueDate).to.equal(summerDueDate)
+          expect(result[0].endDate).to.equal(summerEndDate)
+          expect(result[0].id).to.equal(`v1:${region.naldRegionId}:${licence.licenceRef}:${returnRequirement.legacyId}:${startDate}:${summerEndDate}`)
+          expect(result[0].licenceRef).to.equal(licence.licenceRef)
+          expect(result[0].metadata).to.equal({
+            description: 'BOREHOLE AT AVALON',
+            isCurrent: true,
+            isFinal: false,
+            isSummer: true,
+            isTwoPartTariff: false,
+            isUpload: false,
+            nald: {
+              regionCode: region.naldRegionId,
+              areaCode: licence.regions.historicalAreaCode,
+              formatId: returnRequirement.legacyId,
+              periodStartDay: returnRequirement.abstractionPeriodStartDay.toString(),
+              periodStartMonth: returnRequirement.abstractionPeriodStartMonth.toString(),
+              periodEndDay: returnRequirement.abstractionPeriodEndDay.toString(),
+              periodEndMonth: returnRequirement.abstractionPeriodEndMonth.toString()
+            },
+            points: [{
+              name: point.description,
+              ngr1: point.ngr1,
+              ngr2: point.ngr2,
+              ngr3: point.ngr3,
+              ngr4: point.ngr4
+            }],
+            purposes: [{
+              alias: returnRequirementPurpose.alias,
+              primary: {
+                code: primaryPurpose.legacyId,
+                description: primaryPurpose.description
+              },
+              secondary: {
+                code: secondaryPurpose.legacyId,
+                description: secondaryPurpose.description
+              },
+              tertiary: {
+                code: purpose.legacyId,
+                description: purpose.description
+              }
+            }],
+            version: 1
+          })
+          expect(result[0].returnCycleId).to.equal(summerReturnCycleId)
+          expect(result[0].returnsFrequency).to.equal('day')
+          expect(result[0].startDate).to.equal(startDate)
+          expect(result[0].status).to.equal('due')
+          expect(result[0].source).to.equal('WRLS')
+        })
+      })
+
+      describe('there is no licenceReference is provided it should return all the return logs that are eligible', () => {
+        it('should return five return log payloads', async () => {
+          const returnRequirements = await FetchReturnRequirementsService.go(true)
+          const results = await GenerateReturnLogsService.go(returnRequirements)
+
+          const returnRequirementExternalId = results.map((returnLog) => {
+            return returnLog.returnReference
+          })
+
+          expect(summerReturns.every((result) => {
+            return returnRequirementExternalId.includes(result)
+          })).to.equal(true)
+        })
+      })
+    })
+
+    after(() => {
+      Sinon.restore()
     })
   })
 
-  describe('when summer is true, one return requirement and a licenceRef provided', () => {
+  describe('when return cycle does not exist', () => {
     before(async () => {
-      region = RegionHelper.select()
-      licence = await LicenceHelper.add({ regionId: region.id })
-      returnVersion = await ReturnVersionHelper.add({ licenceId: licence.id })
-
-      returnRequirement = await ReturnRequirementHelper.add({ summer: true, returnVersionId: returnVersion.id })
-      point = await PointHelper.add()
-      await ReturnRequirementPointHelper.add({ pointId: point.id, returnRequirementId: returnRequirement.id })
-      primaryPurpose = PrimaryPurposeHelper.select()
-      purpose = PurposeHelper.select()
-      secondaryPurpose = SecondaryPurposeHelper.select()
-      returnRequirementPurpose = await ReturnRequirementPurposeHelper.add({
-        primaryPurposeId: primaryPurpose.id,
-        purposeId: purpose.id,
-        returnRequirementId: returnRequirement.id,
-        secondaryPurposeId: secondaryPurpose.id
-      })
-      summerReturns.push(returnRequirement.legacyId.toString())
-
-      returnRequirements = await FetchReturnRequirementsService.go(true, licence.licenceRef)
+      Sinon.stub(FetchReturnCycleService, 'go')
+        .withArgs(today, false).returns(undefined)
+        .withArgs(today, true).returns(undefined)
+      Sinon.stub(GenerateReturnCycleService, 'go')
+        .withArgs(false).returns(allYearReturnCycleId)
+        .withArgs(true).returns(summerReturnCycleId)
     })
 
-    it('should return one return log payload', async () => {
-      const result = await GenerateReturnLogsService.go(returnRequirements)
+    describe('has one return requirement and a licenceRef provided', () => {
+      before(async () => {
+        region = RegionHelper.select()
+        licence = await LicenceHelper.add({ regionId: region.id })
+        returnVersion = await ReturnVersionHelper.add({ licenceId: licence.id })
 
-      expect(result.length).to.equal(1)
-      expect(result[0].dueDate).to.equal(summerDueDate)
-      expect(result[0].endDate).to.equal(summerEndDate)
-      expect(result[0].id).to.equal(`v1:${region.naldRegionId}:${licence.licenceRef}:${returnRequirement.legacyId}:${summerStartDate}:${summerEndDate}`)
-      expect(result[0].licenceRef).to.equal(licence.licenceRef)
-      expect(result[0].metadata).to.equal({
-        description: 'BOREHOLE AT AVALON',
-        isCurrent: true,
-        isFinal: false,
-        isSummer: true,
-        isTwoPartTariff: false,
-        isUpload: false,
-        nald: {
-          regionCode: region.naldRegionId,
-          areaCode: licence.regions.historicalAreaCode,
-          formatId: returnRequirement.legacyId,
-          periodStartDay: returnRequirement.abstractionPeriodStartDay.toString(),
-          periodStartMonth: returnRequirement.abstractionPeriodStartMonth.toString(),
-          periodEndDay: returnRequirement.abstractionPeriodEndDay.toString(),
-          periodEndMonth: returnRequirement.abstractionPeriodEndMonth.toString()
-        },
-        points: [{
-          name: point.description,
-          ngr1: point.ngr1,
-          ngr2: point.ngr2,
-          ngr3: point.ngr3,
-          ngr4: point.ngr4
-        }],
-        purposes: [{
-          alias: returnRequirementPurpose.alias,
-          primary: {
-            code: primaryPurpose.legacyId,
-            description: primaryPurpose.description
+        returnRequirement = await ReturnRequirementHelper.add({ summer, returnVersionId: returnVersion.id })
+        point = await PointHelper.add()
+        await ReturnRequirementPointHelper.add({ pointId: point.id, returnRequirementId: returnRequirement.id })
+        primaryPurpose = PrimaryPurposeHelper.select()
+        purpose = PurposeHelper.select()
+        secondaryPurpose = SecondaryPurposeHelper.select()
+        returnRequirementPurpose = await ReturnRequirementPurposeHelper.add({
+          primaryPurposeId: primaryPurpose.id,
+          purposeId: purpose.id,
+          returnRequirementId: returnRequirement.id,
+          secondaryPurposeId: secondaryPurpose.id
+        })
+        summerReturns.push(returnRequirement.legacyId.toString())
+
+        returnRequirements = await FetchReturnRequirementsService.go(summer, licence.licenceRef)
+      })
+
+      it('should return one return log payload', async () => {
+        const result = await GenerateReturnLogsService.go(returnRequirements)
+
+        expect(result.length).to.equal(1)
+        expect(result[0].dueDate).to.equal(summerDueDate)
+        expect(result[0].endDate).to.equal(summerEndDate)
+        expect(result[0].id).to.equal(`v1:${region.naldRegionId}:${licence.licenceRef}:${returnRequirement.legacyId}:${summerStartDate}:${summerEndDate}`)
+        expect(result[0].licenceRef).to.equal(licence.licenceRef)
+        expect(result[0].metadata).to.equal({
+          description: 'BOREHOLE AT AVALON',
+          isCurrent: true,
+          isFinal: false,
+          isSummer: true,
+          isTwoPartTariff: false,
+          isUpload: false,
+          nald: {
+            regionCode: region.naldRegionId,
+            areaCode: licence.regions.historicalAreaCode,
+            formatId: returnRequirement.legacyId,
+            periodStartDay: returnRequirement.abstractionPeriodStartDay.toString(),
+            periodStartMonth: returnRequirement.abstractionPeriodStartMonth.toString(),
+            periodEndDay: returnRequirement.abstractionPeriodEndDay.toString(),
+            periodEndMonth: returnRequirement.abstractionPeriodEndMonth.toString()
           },
-          secondary: {
-            code: secondaryPurpose.legacyId,
-            description: secondaryPurpose.description
-          },
-          tertiary: {
-            code: purpose.legacyId,
-            description: purpose.description
-          }
-        }],
-        version: 1
+          points: [{
+            name: point.description,
+            ngr1: point.ngr1,
+            ngr2: point.ngr2,
+            ngr3: point.ngr3,
+            ngr4: point.ngr4
+          }],
+          purposes: [{
+            alias: returnRequirementPurpose.alias,
+            primary: {
+              code: primaryPurpose.legacyId,
+              description: primaryPurpose.description
+            },
+            secondary: {
+              code: secondaryPurpose.legacyId,
+              description: secondaryPurpose.description
+            },
+            tertiary: {
+              code: purpose.legacyId,
+              description: purpose.description
+            }
+          }],
+          version: 1
+        })
+        expect(result[0].returnCycleId).to.equal(summerReturnCycleId)
+        expect(result[0].returnsFrequency).to.equal('day')
+        expect(result[0].startDate).to.equal(summerStartDate)
+        expect(result[0].status).to.equal('due')
+        expect(result[0].source).to.equal('WRLS')
       })
-      expect(result[0].returnsFrequency).to.equal('day')
-      expect(result[0].startDate).to.equal(summerStartDate)
-      expect(result[0].status).to.equal('due')
-      expect(result[0].source).to.equal('WRLS')
-    })
-  })
-
-  describe('when summer is false, two return requirements and a licenceRef provided', () => {
-    before(async () => {
-      region = RegionHelper.select()
-      licence = await LicenceHelper.add({ regionId: region.id })
-      returnVersion = await ReturnVersionHelper.add({ licenceId: licence.id })
-
-      returnRequirement = await ReturnRequirementHelper.add({ returnVersionId: returnVersion.id })
-      point = await PointHelper.add()
-      await ReturnRequirementPointHelper.add({ pointId: point.id, returnRequirementId: returnRequirement.id })
-      primaryPurpose = PrimaryPurposeHelper.select()
-      purpose = PurposeHelper.select()
-      secondaryPurpose = SecondaryPurposeHelper.select()
-      returnRequirementPurpose = await ReturnRequirementPurposeHelper.add({
-        primaryPurposeId: primaryPurpose.id,
-        purposeId: purpose.id,
-        returnRequirementId: returnRequirement.id,
-        secondaryPurposeId: secondaryPurpose.id
-      })
-
-      returnRequirement2 = await ReturnRequirementHelper.add({ returnVersionId: returnVersion.id })
-      point2 = await PointHelper.add()
-      await ReturnRequirementPointHelper.add({ pointId: point2.id, returnRequirementId: returnRequirement2.id })
-      primaryPurpose2 = PrimaryPurposeHelper.select()
-      purpose2 = PurposeHelper.select()
-      secondaryPurpose2 = SecondaryPurposeHelper.select()
-      returnRequirementPurpose2 = await ReturnRequirementPurposeHelper.add({
-        primaryPurposeId: primaryPurpose2.id,
-        purposeId: purpose2.id,
-        returnRequirementId: returnRequirement2.id,
-        secondaryPurposeId: secondaryPurpose2.id
-      })
-      allYearReturns.push(returnRequirement.legacyId.toString())
-      allYearReturns.push(returnRequirement2.legacyId.toString())
-    })
-
-    it('should return two return log payloads', async () => {
-      const returnRequirements = await FetchReturnRequirementsService.go(false, licence.licenceRef)
-      const result = await GenerateReturnLogsService.go(returnRequirements)
-
-      expect(result.length).to.equal(2)
-      expect(result[0].dueDate).to.equal(allYearDueDate)
-      expect(result[0].endDate).to.equal(allYearEndDate)
-      expect(result[0].id).to.equal(`v1:${region.naldRegionId}:${licence.licenceRef}:${returnRequirement.legacyId}:${allYearStartDate}:${allYearEndDate}`)
-      expect(result[0].licenceRef).to.equal(licence.licenceRef)
-      expect(result[0].metadata).to.equal({
-        description: 'BOREHOLE AT AVALON',
-        isCurrent: true,
-        isFinal: false,
-        isSummer: false,
-        isTwoPartTariff: false,
-        isUpload: false,
-        nald: {
-          regionCode: region.naldRegionId,
-          areaCode: licence.regions.historicalAreaCode,
-          formatId: returnRequirement.legacyId,
-          periodStartDay: returnRequirement.abstractionPeriodStartDay.toString(),
-          periodStartMonth: returnRequirement.abstractionPeriodStartMonth.toString(),
-          periodEndDay: returnRequirement.abstractionPeriodEndDay.toString(),
-          periodEndMonth: returnRequirement.abstractionPeriodEndMonth.toString()
-        },
-        points: [{
-          name: point.description,
-          ngr1: point.ngr1,
-          ngr2: point.ngr2,
-          ngr3: point.ngr3,
-          ngr4: point.ngr4
-        }],
-        purposes: [{
-          alias: returnRequirementPurpose.alias,
-          primary: {
-            code: primaryPurpose.legacyId,
-            description: primaryPurpose.description
-          },
-          secondary: {
-            code: secondaryPurpose.legacyId,
-            description: secondaryPurpose.description
-          },
-          tertiary: {
-            code: purpose.legacyId,
-            description: purpose.description
-          }
-        }],
-        version: 1
-      })
-      expect(result[0].returnsFrequency).to.equal('day')
-      expect(result[0].startDate).to.equal(allYearStartDate)
-      expect(result[0].status).to.equal('due')
-      expect(result[0].source).to.equal('WRLS')
-      expect(result[1].dueDate).to.equal(allYearDueDate)
-      expect(result[1].endDate).to.equal(allYearEndDate)
-      expect(result[1].id).to.equal(`v1:${region.naldRegionId}:${licence.licenceRef}:${returnRequirement2.legacyId}:${allYearStartDate}:${allYearEndDate}`)
-      expect(result[1].licenceRef).to.equal(licence.licenceRef)
-      expect(result[1].metadata).to.equal({
-        description: 'BOREHOLE AT AVALON',
-        isCurrent: true,
-        isFinal: false,
-        isSummer: false,
-        isTwoPartTariff: false,
-        isUpload: false,
-        nald: {
-          regionCode: region.naldRegionId,
-          areaCode: licence.regions.historicalAreaCode,
-          formatId: returnRequirement2.legacyId,
-          periodStartDay: returnRequirement2.abstractionPeriodStartDay.toString(),
-          periodStartMonth: returnRequirement2.abstractionPeriodStartMonth.toString(),
-          periodEndDay: returnRequirement2.abstractionPeriodEndDay.toString(),
-          periodEndMonth: returnRequirement2.abstractionPeriodEndMonth.toString()
-        },
-        points: [{
-          name: point2.description,
-          ngr1: point2.ngr1,
-          ngr2: point2.ngr2,
-          ngr3: point2.ngr3,
-          ngr4: point2.ngr4
-        }],
-        purposes: [{
-          alias: returnRequirementPurpose2.alias,
-          primary: {
-            code: primaryPurpose2.legacyId,
-            description: primaryPurpose2.description
-          },
-          secondary: {
-            code: secondaryPurpose2.legacyId,
-            description: secondaryPurpose2.description
-          },
-          tertiary: {
-            code: purpose2.legacyId,
-            description: purpose2.description
-          }
-        }],
-        version: 1
-      })
-      expect(result[1].returnsFrequency).to.equal('day')
-      expect(result[1].startDate).to.equal(allYearStartDate)
-      expect(result[1].status).to.equal('due')
-      expect(result[1].source).to.equal('WRLS')
-    })
-  })
-
-  describe('when summer is true, two return requirements and a licenceRef provided', () => {
-    before(async () => {
-      region = RegionHelper.select()
-      licence = await LicenceHelper.add({ regionId: region.id })
-      returnVersion = await ReturnVersionHelper.add({ licenceId: licence.id })
-
-      returnRequirement = await ReturnRequirementHelper.add({ summer: true, returnVersionId: returnVersion.id })
-      point = await PointHelper.add()
-      await ReturnRequirementPointHelper.add({ pointId: point.id, returnRequirementId: returnRequirement.id })
-      primaryPurpose = PrimaryPurposeHelper.select()
-      purpose = PurposeHelper.select()
-      secondaryPurpose = SecondaryPurposeHelper.select()
-      returnRequirementPurpose = await ReturnRequirementPurposeHelper.add({
-        primaryPurposeId: primaryPurpose.id,
-        purposeId: purpose.id,
-        returnRequirementId: returnRequirement.id,
-        secondaryPurposeId: secondaryPurpose.id
-      })
-
-      returnRequirement2 = await ReturnRequirementHelper.add({ summer: true, returnVersionId: returnVersion.id })
-      point2 = await PointHelper.add()
-      await ReturnRequirementPointHelper.add({ pointId: point2.id, returnRequirementId: returnRequirement2.id })
-      primaryPurpose2 = PrimaryPurposeHelper.select()
-      purpose2 = PurposeHelper.select()
-      secondaryPurpose2 = SecondaryPurposeHelper.select()
-      returnRequirementPurpose2 = await ReturnRequirementPurposeHelper.add({
-        primaryPurposeId: primaryPurpose2.id,
-        purposeId: purpose2.id,
-        returnRequirementId: returnRequirement2.id,
-        secondaryPurposeId: secondaryPurpose2.id
-      })
-      summerReturns.push(returnRequirement.legacyId.toString())
-      summerReturns.push(returnRequirement2.legacyId.toString())
-
-      returnRequirements = await FetchReturnRequirementsService.go(true, licence.licenceRef)
-    })
-
-    it('should return two return log payloads', async () => {
-      const result = await GenerateReturnLogsService.go(returnRequirements)
-
-      expect(result.length).to.equal(2)
-      expect(result[0].dueDate).to.equal(summerDueDate)
-      expect(result[0].endDate).to.equal(summerEndDate)
-      expect(result[0].id).to.equal(`v1:${region.naldRegionId}:${licence.licenceRef}:${returnRequirement.legacyId}:${summerStartDate}:${summerEndDate}`)
-      expect(result[0].licenceRef).to.equal(licence.licenceRef)
-      expect(result[0].metadata).to.equal({
-        description: 'BOREHOLE AT AVALON',
-        isCurrent: true,
-        isFinal: false,
-        isSummer: true,
-        isTwoPartTariff: false,
-        isUpload: false,
-        nald: {
-          regionCode: region.naldRegionId,
-          areaCode: licence.regions.historicalAreaCode,
-          formatId: returnRequirement.legacyId,
-          periodStartDay: returnRequirement.abstractionPeriodStartDay.toString(),
-          periodStartMonth: returnRequirement.abstractionPeriodStartMonth.toString(),
-          periodEndDay: returnRequirement.abstractionPeriodEndDay.toString(),
-          periodEndMonth: returnRequirement.abstractionPeriodEndMonth.toString()
-        },
-        points: [{
-          name: point.description,
-          ngr1: point.ngr1,
-          ngr2: point.ngr2,
-          ngr3: point.ngr3,
-          ngr4: point.ngr4
-        }],
-        purposes: [{
-          alias: returnRequirementPurpose.alias,
-          primary: {
-            code: primaryPurpose.legacyId,
-            description: primaryPurpose.description
-          },
-          secondary: {
-            code: secondaryPurpose.legacyId,
-            description: secondaryPurpose.description
-          },
-          tertiary: {
-            code: purpose.legacyId,
-            description: purpose.description
-          }
-        }],
-        version: 1
-      })
-      expect(result[0].returnsFrequency).to.equal('day')
-      expect(result[0].startDate).to.equal(summerStartDate)
-      expect(result[0].status).to.equal('due')
-      expect(result[0].source).to.equal('WRLS')
-      expect(result[1].dueDate).to.equal(summerDueDate)
-      expect(result[1].endDate).to.equal(summerEndDate)
-      expect(result[1].id).to.equal(`v1:${region.naldRegionId}:${licence.licenceRef}:${returnRequirement2.legacyId}:${summerStartDate}:${summerEndDate}`)
-      expect(result[1].licenceRef).to.equal(licence.licenceRef)
-      expect(result[1].metadata).to.equal({
-        description: 'BOREHOLE AT AVALON',
-        isCurrent: true,
-        isFinal: false,
-        isSummer: true,
-        isTwoPartTariff: false,
-        isUpload: false,
-        nald: {
-          regionCode: region.naldRegionId,
-          areaCode: licence.regions.historicalAreaCode,
-          formatId: returnRequirement2.legacyId,
-          periodStartDay: returnRequirement2.abstractionPeriodStartDay.toString(),
-          periodStartMonth: returnRequirement2.abstractionPeriodStartMonth.toString(),
-          periodEndDay: returnRequirement2.abstractionPeriodEndDay.toString(),
-          periodEndMonth: returnRequirement2.abstractionPeriodEndMonth.toString()
-        },
-        points: [{
-          name: point2.description,
-          ngr1: point2.ngr1,
-          ngr2: point2.ngr2,
-          ngr3: point2.ngr3,
-          ngr4: point2.ngr4
-        }],
-        purposes: [{
-          alias: returnRequirementPurpose2.alias,
-          primary: {
-            code: primaryPurpose2.legacyId,
-            description: primaryPurpose2.description
-          },
-          secondary: {
-            code: secondaryPurpose2.legacyId,
-            description: secondaryPurpose2.description
-          },
-          tertiary: {
-            code: purpose2.legacyId,
-            description: purpose2.description
-          }
-        }],
-        version: 1
-      })
-      expect(result[1].returnsFrequency).to.equal('day')
-      expect(result[1].startDate).to.equal(summerStartDate)
-      expect(result[1].status).to.equal('due')
-      expect(result[1].source).to.equal('WRLS')
-    })
-  })
-
-  describe('when summer is false, there is an expired date, one return requirement and a licenceRef provided', () => {
-    before(async () => {
-      expiredDate = new Date(new Date().getFullYear() + 1, 1, 31).toISOString().split('T')[0]
-      region = RegionHelper.select()
-      licence = await LicenceHelper.add({ expiredDate, regionId: region.id })
-      returnVersion = await ReturnVersionHelper.add({ licenceId: licence.id })
-
-      returnRequirement = await ReturnRequirementHelper.add({ returnVersionId: returnVersion.id })
-      point = await PointHelper.add()
-      await ReturnRequirementPointHelper.add({ pointId: point.id, returnRequirementId: returnRequirement.id })
-      primaryPurpose = PrimaryPurposeHelper.select()
-      purpose = PurposeHelper.select()
-      secondaryPurpose = SecondaryPurposeHelper.select()
-      returnRequirementPurpose = await ReturnRequirementPurposeHelper.add({
-        primaryPurposeId: primaryPurpose.id,
-        purposeId: purpose.id,
-        returnRequirementId: returnRequirement.id,
-        secondaryPurposeId: secondaryPurpose.id
-      })
-      allYearReturns.push(returnRequirement.legacyId.toString())
-
-      returnRequirements = await FetchReturnRequirementsService.go(false, licence.licenceRef)
-    })
-
-    it('should return one return log payload', async () => {
-      const result = await GenerateReturnLogsService.go(returnRequirements)
-
-      expect(result.length).to.equal(1)
-      expect(result[0].dueDate).to.equal(allYearDueDate)
-      expect(result[0].endDate).to.equal(expiredDate)
-      expect(result[0].id).to.equal(`v1:${region.naldRegionId}:${licence.licenceRef}:${returnRequirement.legacyId}:${allYearStartDate}:${expiredDate}`)
-      expect(result[0].licenceRef).to.equal(licence.licenceRef)
-      expect(result[0].metadata).to.equal({
-        description: 'BOREHOLE AT AVALON',
-        isCurrent: true,
-        isFinal: true,
-        isSummer: false,
-        isTwoPartTariff: false,
-        isUpload: false,
-        nald: {
-          regionCode: region.naldRegionId,
-          areaCode: licence.regions.historicalAreaCode,
-          formatId: returnRequirement.legacyId,
-          periodStartDay: returnRequirement.abstractionPeriodStartDay.toString(),
-          periodStartMonth: returnRequirement.abstractionPeriodStartMonth.toString(),
-          periodEndDay: returnRequirement.abstractionPeriodEndDay.toString(),
-          periodEndMonth: returnRequirement.abstractionPeriodEndMonth.toString()
-        },
-        points: [{
-          name: point.description,
-          ngr1: point.ngr1,
-          ngr2: point.ngr2,
-          ngr3: point.ngr3,
-          ngr4: point.ngr4
-        }],
-        purposes: [{
-          alias: returnRequirementPurpose.alias,
-          primary: {
-            code: primaryPurpose.legacyId,
-            description: primaryPurpose.description
-          },
-          secondary: {
-            code: secondaryPurpose.legacyId,
-            description: secondaryPurpose.description
-          },
-          tertiary: {
-            code: purpose.legacyId,
-            description: purpose.description
-          }
-        }],
-        version: 1
-      })
-      expect(result[0].returnsFrequency).to.equal('day')
-      expect(result[0].startDate).to.equal(allYearStartDate)
-      expect(result[0].status).to.equal('due')
-      expect(result[0].source).to.equal('WRLS')
-    })
-  })
-
-  describe('when summer is false, there is an expired date after the end of the cycle, one return requirement and a licenceRef provided', () => {
-    before(async () => {
-      expiredDate = new Date(new Date().getFullYear() + 1, 3, 31).toISOString().split('T')[0]
-      region = RegionHelper.select()
-      licence = await LicenceHelper.add({ expiredDate, regionId: region.id })
-      returnVersion = await ReturnVersionHelper.add({ licenceId: licence.id })
-
-      returnRequirement = await ReturnRequirementHelper.add({ returnVersionId: returnVersion.id })
-      point = await PointHelper.add()
-      await ReturnRequirementPointHelper.add({ pointId: point.id, returnRequirementId: returnRequirement.id })
-      primaryPurpose = PrimaryPurposeHelper.select()
-      purpose = PurposeHelper.select()
-      secondaryPurpose = SecondaryPurposeHelper.select()
-      returnRequirementPurpose = await ReturnRequirementPurposeHelper.add({
-        primaryPurposeId: primaryPurpose.id,
-        purposeId: purpose.id,
-        returnRequirementId: returnRequirement.id,
-        secondaryPurposeId: secondaryPurpose.id
-      })
-      allYearReturns.push(returnRequirement.legacyId.toString())
-
-      returnRequirements = await FetchReturnRequirementsService.go(false, licence.licenceRef)
-    })
-
-    it('should return one return log payload', async () => {
-      const result = await GenerateReturnLogsService.go(returnRequirements)
-
-      expect(result.length).to.equal(1)
-      expect(result[0].dueDate).to.equal(allYearDueDate)
-      expect(result[0].endDate).to.equal(allYearEndDate)
-      expect(result[0].id).to.equal(`v1:${region.naldRegionId}:${licence.licenceRef}:${returnRequirement.legacyId}:${allYearStartDate}:${allYearEndDate}`)
-      expect(result[0].licenceRef).to.equal(licence.licenceRef)
-      expect(result[0].metadata).to.equal({
-        description: 'BOREHOLE AT AVALON',
-        isCurrent: true,
-        isFinal: false,
-        isSummer: false,
-        isTwoPartTariff: false,
-        isUpload: false,
-        nald: {
-          regionCode: region.naldRegionId,
-          areaCode: licence.regions.historicalAreaCode,
-          formatId: returnRequirement.legacyId,
-          periodStartDay: returnRequirement.abstractionPeriodStartDay.toString(),
-          periodStartMonth: returnRequirement.abstractionPeriodStartMonth.toString(),
-          periodEndDay: returnRequirement.abstractionPeriodEndDay.toString(),
-          periodEndMonth: returnRequirement.abstractionPeriodEndMonth.toString()
-        },
-        points: [{
-          name: point.description,
-          ngr1: point.ngr1,
-          ngr2: point.ngr2,
-          ngr3: point.ngr3,
-          ngr4: point.ngr4
-        }],
-        purposes: [{
-          alias: returnRequirementPurpose.alias,
-          primary: {
-            code: primaryPurpose.legacyId,
-            description: primaryPurpose.description
-          },
-          secondary: {
-            code: secondaryPurpose.legacyId,
-            description: secondaryPurpose.description
-          },
-          tertiary: {
-            code: purpose.legacyId,
-            description: purpose.description
-          }
-        }],
-        version: 1
-      })
-      expect(result[0].returnsFrequency).to.equal('day')
-      expect(result[0].startDate).to.equal(allYearStartDate)
-      expect(result[0].status).to.equal('due')
-      expect(result[0].source).to.equal('WRLS')
-    })
-  })
-
-  describe('when summer is true, there is a lapsed date, one return requirement and a licenceRef provided', () => {
-    before(async () => {
-      lapsedDate = new Date(new Date().getFullYear() + 1, 8, 31).toISOString().split('T')[0]
-      region = RegionHelper.select()
-      licence = await LicenceHelper.add({ lapsedDate, regionId: region.id })
-      returnVersion = await ReturnVersionHelper.add({ licenceId: licence.id })
-
-      returnRequirement = await ReturnRequirementHelper.add({ summer: true, returnVersionId: returnVersion.id })
-      point = await PointHelper.add()
-      await ReturnRequirementPointHelper.add({ pointId: point.id, returnRequirementId: returnRequirement.id })
-      primaryPurpose = PrimaryPurposeHelper.select()
-      purpose = PurposeHelper.select()
-      secondaryPurpose = SecondaryPurposeHelper.select()
-      returnRequirementPurpose = await ReturnRequirementPurposeHelper.add({
-        primaryPurposeId: primaryPurpose.id,
-        purposeId: purpose.id,
-        returnRequirementId: returnRequirement.id,
-        secondaryPurposeId: secondaryPurpose.id
-      })
-      summerReturns.push(returnRequirement.legacyId.toString())
-
-      returnRequirements = await FetchReturnRequirementsService.go(true, licence.licenceRef)
-    })
-
-    it('should return one return log payload', async () => {
-      const result = await GenerateReturnLogsService.go(returnRequirements)
-
-      expect(result.length).to.equal(1)
-      expect(result[0].dueDate).to.equal(summerDueDate)
-      expect(result[0].endDate).to.equal(lapsedDate)
-      expect(result[0].id).to.equal(`v1:${region.naldRegionId}:${licence.licenceRef}:${returnRequirement.legacyId}:${summerStartDate}:${lapsedDate}`)
-      expect(result[0].licenceRef).to.equal(licence.licenceRef)
-      expect(result[0].metadata).to.equal({
-        description: 'BOREHOLE AT AVALON',
-        isCurrent: true,
-        isFinal: true,
-        isSummer: true,
-        isTwoPartTariff: false,
-        isUpload: false,
-        nald: {
-          regionCode: region.naldRegionId,
-          areaCode: licence.regions.historicalAreaCode,
-          formatId: returnRequirement.legacyId,
-          periodStartDay: returnRequirement.abstractionPeriodStartDay.toString(),
-          periodStartMonth: returnRequirement.abstractionPeriodStartMonth.toString(),
-          periodEndDay: returnRequirement.abstractionPeriodEndDay.toString(),
-          periodEndMonth: returnRequirement.abstractionPeriodEndMonth.toString()
-        },
-        points: [{
-          name: point.description,
-          ngr1: point.ngr1,
-          ngr2: point.ngr2,
-          ngr3: point.ngr3,
-          ngr4: point.ngr4
-        }],
-        purposes: [{
-          alias: returnRequirementPurpose.alias,
-          primary: {
-            code: primaryPurpose.legacyId,
-            description: primaryPurpose.description
-          },
-          secondary: {
-            code: secondaryPurpose.legacyId,
-            description: secondaryPurpose.description
-          },
-          tertiary: {
-            code: purpose.legacyId,
-            description: purpose.description
-          }
-        }],
-        version: 1
-      })
-      expect(result[0].returnsFrequency).to.equal('day')
-      expect(result[0].startDate).to.equal(summerStartDate)
-      expect(result[0].status).to.equal('due')
-      expect(result[0].source).to.equal('WRLS')
-    })
-  })
-
-  describe('when summer is true, there is a revoked date that is after the cycle, one return requirement and a licenceRef provided', () => {
-    before(async () => {
-      revokedDate = new Date(new Date().getFullYear() + 1, 10, 31).toISOString().split('T')[0]
-      region = RegionHelper.select()
-      licence = await LicenceHelper.add({ revokedDate, regionId: region.id })
-      returnVersion = await ReturnVersionHelper.add({ licenceId: licence.id })
-
-      returnRequirement = await ReturnRequirementHelper.add({ summer: true, returnVersionId: returnVersion.id })
-      point = await PointHelper.add()
-      await ReturnRequirementPointHelper.add({ pointId: point.id, returnRequirementId: returnRequirement.id })
-      primaryPurpose = PrimaryPurposeHelper.select()
-      purpose = PurposeHelper.select()
-      secondaryPurpose = SecondaryPurposeHelper.select()
-      returnRequirementPurpose = await ReturnRequirementPurposeHelper.add({
-        primaryPurposeId: primaryPurpose.id,
-        purposeId: purpose.id,
-        returnRequirementId: returnRequirement.id,
-        secondaryPurposeId: secondaryPurpose.id
-      })
-      summerReturns.push(returnRequirement.legacyId.toString())
-
-      returnRequirements = await FetchReturnRequirementsService.go(true, licence.licenceRef)
-    })
-
-    it('should return one return log payload', async () => {
-      const result = await GenerateReturnLogsService.go(returnRequirements)
-
-      expect(result.length).to.equal(1)
-      expect(result[0].dueDate).to.equal(summerDueDate)
-      expect(result[0].endDate).to.equal(summerEndDate)
-      expect(result[0].id).to.equal(`v1:${region.naldRegionId}:${licence.licenceRef}:${returnRequirement.legacyId}:${summerStartDate}:${summerEndDate}`)
-      expect(result[0].licenceRef).to.equal(licence.licenceRef)
-      expect(result[0].metadata).to.equal({
-        description: 'BOREHOLE AT AVALON',
-        isCurrent: true,
-        isFinal: false,
-        isSummer: true,
-        isTwoPartTariff: false,
-        isUpload: false,
-        nald: {
-          regionCode: region.naldRegionId,
-          areaCode: licence.regions.historicalAreaCode,
-          formatId: returnRequirement.legacyId,
-          periodStartDay: returnRequirement.abstractionPeriodStartDay.toString(),
-          periodStartMonth: returnRequirement.abstractionPeriodStartMonth.toString(),
-          periodEndDay: returnRequirement.abstractionPeriodEndDay.toString(),
-          periodEndMonth: returnRequirement.abstractionPeriodEndMonth.toString()
-        },
-        points: [{
-          name: point.description,
-          ngr1: point.ngr1,
-          ngr2: point.ngr2,
-          ngr3: point.ngr3,
-          ngr4: point.ngr4
-        }],
-        purposes: [{
-          alias: returnRequirementPurpose.alias,
-          primary: {
-            code: primaryPurpose.legacyId,
-            description: primaryPurpose.description
-          },
-          secondary: {
-            code: secondaryPurpose.legacyId,
-            description: secondaryPurpose.description
-          },
-          tertiary: {
-            code: purpose.legacyId,
-            description: purpose.description
-          }
-        }],
-        version: 1
-      })
-      expect(result[0].returnsFrequency).to.equal('day')
-      expect(result[0].startDate).to.equal(summerStartDate)
-      expect(result[0].status).to.equal('due')
-      expect(result[0].source).to.equal('WRLS')
-    })
-  })
-
-  describe('when summer is true, the return version start date is after the cycle start date, one return requirement and a licenceRef provided', () => {
-    before(async () => {
-      startDate = new Date(new Date().getFullYear(), 11, 1).toISOString().split('T')[0]
-      region = RegionHelper.select()
-      licence = await LicenceHelper.add({ regionId: region.id })
-      returnVersion = await ReturnVersionHelper.add({ licenceId: licence.id, startDate })
-
-      returnRequirement = await ReturnRequirementHelper.add({ summer: true, returnVersionId: returnVersion.id })
-      point = await PointHelper.add()
-      await ReturnRequirementPointHelper.add({ pointId: point.id, returnRequirementId: returnRequirement.id })
-      primaryPurpose = PrimaryPurposeHelper.select()
-      purpose = PurposeHelper.select()
-      secondaryPurpose = SecondaryPurposeHelper.select()
-      returnRequirementPurpose = await ReturnRequirementPurposeHelper.add({
-        primaryPurposeId: primaryPurpose.id,
-        purposeId: purpose.id,
-        returnRequirementId: returnRequirement.id,
-        secondaryPurposeId: secondaryPurpose.id
-      })
-      summerReturns.push(returnRequirement.legacyId.toString())
-
-      returnRequirements = await FetchReturnRequirementsService.go(true, licence.licenceRef)
-    })
-
-    it('should return one return log payload', async () => {
-      const result = await GenerateReturnLogsService.go(returnRequirements)
-
-      expect(result.length).to.equal(1)
-      expect(result[0].dueDate).to.equal(summerDueDate)
-      expect(result[0].endDate).to.equal(summerEndDate)
-      expect(result[0].id).to.equal(`v1:${region.naldRegionId}:${licence.licenceRef}:${returnRequirement.legacyId}:${startDate}:${summerEndDate}`)
-      expect(result[0].licenceRef).to.equal(licence.licenceRef)
-      expect(result[0].metadata).to.equal({
-        description: 'BOREHOLE AT AVALON',
-        isCurrent: true,
-        isFinal: false,
-        isSummer: true,
-        isTwoPartTariff: false,
-        isUpload: false,
-        nald: {
-          regionCode: region.naldRegionId,
-          areaCode: licence.regions.historicalAreaCode,
-          formatId: returnRequirement.legacyId,
-          periodStartDay: returnRequirement.abstractionPeriodStartDay.toString(),
-          periodStartMonth: returnRequirement.abstractionPeriodStartMonth.toString(),
-          periodEndDay: returnRequirement.abstractionPeriodEndDay.toString(),
-          periodEndMonth: returnRequirement.abstractionPeriodEndMonth.toString()
-        },
-        points: [{
-          name: point.description,
-          ngr1: point.ngr1,
-          ngr2: point.ngr2,
-          ngr3: point.ngr3,
-          ngr4: point.ngr4
-        }],
-        purposes: [{
-          alias: returnRequirementPurpose.alias,
-          primary: {
-            code: primaryPurpose.legacyId,
-            description: primaryPurpose.description
-          },
-          secondary: {
-            code: secondaryPurpose.legacyId,
-            description: secondaryPurpose.description
-          },
-          tertiary: {
-            code: purpose.legacyId,
-            description: purpose.description
-          }
-        }],
-        version: 1
-      })
-      expect(result[0].returnsFrequency).to.equal('day')
-      expect(result[0].startDate).to.equal(startDate)
-      expect(result[0].status).to.equal('due')
-      expect(result[0].source).to.equal('WRLS')
-    })
-  })
-
-  describe('when summer is false, and no licenceReference is provided it should return all the return logs that are eligible', () => {
-    it('should return five return log payloads', async () => {
-      const returnRequirements = await FetchReturnRequirementsService.go(false)
-      const results = await GenerateReturnLogsService.go(returnRequirements)
-
-      const returnRequirementExternalId = results.map((returnLog) => {
-        return returnLog.returnReference
-      })
-
-      expect(allYearReturns.every((result) => { return returnRequirementExternalId.includes(result) })).to.equal(true)
-    })
-  })
-
-  describe('when summer is true, and no licenceReference is provided it should return all the return logs that are eligible', () => {
-    it('should return five return log payloads', async () => {
-      const returnRequirements = await FetchReturnRequirementsService.go(true)
-      const results = await GenerateReturnLogsService.go(returnRequirements)
-
-      const returnRequirementExternalId = results.map((returnLog) => {
-        return returnLog.returnReference
-      })
-
-      expect(summerReturns.every((result) => { return returnRequirementExternalId.includes(result) })).to.equal(true)
     })
   })
 })

--- a/test/services/jobs/return-logs/process-licence-return-logs.service.test.js
+++ b/test/services/jobs/return-logs/process-licence-return-logs.service.test.js
@@ -9,14 +9,18 @@ const { describe, it, before, after } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const GenerateReturnCycleService = require('../../../../app/services/jobs/return-logs/generate-return-cycle.service.js')
-const ReturnLogModel = require('../../../../app/models/return-log.model.js')
 const LicenceHelper = require('../../../support/helpers/licence.helper.js')
+const FetchReturnCycleService = require('../../../../app/services/jobs/return-logs/fetch-return-cycle.service.js')
+const GenerateReturnLogsService = require('../../../../app/services/jobs/return-logs/generate-return-logs.service.js')
+const PrimaryPurposeHelper = require('../../../support/helpers/primary-purpose.helper.js')
+const PurposeHelper = require('../../../support/helpers/purpose.helper.js')
 const RegionHelper = require('../../../support/helpers/region.helper.js')
+const ReturnLogModel = require('../../../../app/models/return-log.model.js')
 const ReturnRequirementHelper = require('../../../support/helpers/return-requirement.helper.js')
 const ReturnRequirementPointHelper = require('../../../support/helpers/return-requirement-point.helper.js')
 const ReturnRequirementPurposeHelper = require('../../../support/helpers/return-requirement-purpose.helper.js')
 const ReturnVersionHelper = require('../../../support/helpers/return-version.helper.js')
+const SecondaryPurposeHelper = require('../../../support/helpers/secondary-purpose.helper.js')
 
 // Thing under test
 const ProcessLicenceReturnLogsService = require('../../../../app/services/jobs/return-logs/process-licence-return-logs.service.js')
@@ -28,25 +32,92 @@ describe('Process licence return logs service', () => {
 
   describe('when a valid licence reference is provided', () => {
     let licence
+    let notifierStub
+    let point
+    let primaryPurpose
+    let purpose
     let region
+    let returnCycleId
     let returnVersion
     let returnRequirement
-    let notifierStub
+    let secondaryPurpose
 
     before(async () => {
       region = RegionHelper.select()
       licence = await LicenceHelper.add({ regionId: region.id })
       returnVersion = await ReturnVersionHelper.add({ licenceId: licence.id })
       returnRequirement = await ReturnRequirementHelper.add({ returnVersionId: returnVersion.id })
-      await ReturnRequirementPointHelper.add({ returnRequirementId: returnRequirement.id })
-      await ReturnRequirementPurposeHelper.add({ returnRequirementId: returnRequirement.id })
+      point = await ReturnRequirementPointHelper.add({ returnRequirementId: returnRequirement.id })
+      primaryPurpose = PrimaryPurposeHelper.select()
+      purpose = PurposeHelper.select()
+      secondaryPurpose = SecondaryPurposeHelper.select()
+      await ReturnRequirementPurposeHelper.add({
+        alias: null,
+        primaryPurposeId: primaryPurpose.id,
+        purposeId: purpose.id,
+        returnRequirementId: returnRequirement.id,
+        secondaryPurposeId: secondaryPurpose.id
+      })
+      returnCycleId = await FetchReturnCycleService.go(new Date().toISOString(), false)
 
       // BaseRequest depends on the GlobalNotifier to have been set.
       // This happens in app/plugins/global-notifier.plugin.js when the app starts up and the plugin is registered.
       // As we're not creating an instance of Hapi server in this test we recreate the condition by setting
       // it directly with our own stub
       notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
-      Sinon.stub(GenerateReturnCycleService, 'go').resolves('g095d75e-0e0d-4fe4-b048-150457f3871g')
+      Sinon.stub(GenerateReturnLogsService, 'go').resolves([{
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        dueDate: allYearDueDate,
+        endDate: allYearEndDate,
+        id: `v1:${region.naldRegionId}:${licence.licenceRef}:${returnRequirement.legacyId}:${allYearStartDate}:${allYearEndDate}`,
+        licenceRef: licence.licenceRef,
+        metadata: {
+          description: 'BOREHOLE AT AVALON',
+          isCurrent: true,
+          isFinal: false,
+          isSummer: false,
+          isTwoPartTariff: false,
+          isUpload: false,
+          nald: {
+            regionCode: region.naldRegionId,
+            areaCode: licence.regions.historicalAreaCode,
+            formatId: returnRequirement.legacyId,
+            periodStartDay: returnRequirement.abstractionPeriodStartDay.toString(),
+            periodStartMonth: returnRequirement.abstractionPeriodStartMonth.toString(),
+            periodEndDay: returnRequirement.abstractionPeriodEndDay.toString(),
+            periodEndMonth: returnRequirement.abstractionPeriodEndMonth.toString()
+          },
+          points: [{
+            name: point.description,
+            ngr1: point.ngr1,
+            ngr2: point.ngr2,
+            ngr3: point.ngr3,
+            ngr4: point.ngr4
+          }],
+          purposes: [{
+            primary: {
+              code: primaryPurpose.legacyId,
+              description: primaryPurpose.description
+            },
+            secondary: {
+              code: secondaryPurpose.legacyId,
+              description: secondaryPurpose.description
+            },
+            tertiary: {
+              code: purpose.legacyId,
+              description: purpose.description
+            }
+          }],
+          version: 1
+        },
+        returnCycleId,
+        returnsFrequency: 'day',
+        returnReference: returnRequirement.legacyId.toString(),
+        startDate: allYearStartDate,
+        status: 'due',
+        source: 'WRLS'
+      }])
       global.GlobalNotifier = notifierStub
     })
 

--- a/test/services/jobs/return-logs/process-return-logs.service.test.js
+++ b/test/services/jobs/return-logs/process-return-logs.service.test.js
@@ -31,6 +31,10 @@ describe('Process return logs service', () => {
 
   let cycle
 
+  afterEach(() => {
+    Sinon.restore()
+  })
+
   describe('cycle is "all-year', () => {
     before(() => {
       cycle = 'all-year'
@@ -172,9 +176,5 @@ describe('Process return logs service', () => {
         expect(result.length).to.equal(0)
       })
     })
-  })
-
-  afterEach(() => {
-    Sinon.restore()
   })
 })

--- a/test/services/jobs/return-logs/process-return-logs.service.test.js
+++ b/test/services/jobs/return-logs/process-return-logs.service.test.js
@@ -5,7 +5,7 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, before, after } = exports.lab = Lab.script()
+const { describe, it, before, afterEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
@@ -143,10 +143,6 @@ describe('Process return logs service', () => {
         expect(result[0].source).to.equal('WRLS')
         expect(result[0].returnCycleId).to.equal(allYearReturnCycleId)
       })
-
-      after(() => {
-        Sinon.restore()
-      })
     })
 
     describe('and a licence reference is provided but there is no matching return requirements', () => {
@@ -160,10 +156,6 @@ describe('Process return logs service', () => {
         const result = await ReturnLogModel.query().where('licenceRef', 'testReference')
 
         expect(result.length).to.equal(0)
-      })
-
-      after(() => {
-        Sinon.restore()
       })
     })
 
@@ -179,10 +171,10 @@ describe('Process return logs service', () => {
 
         expect(result.length).to.equal(0)
       })
-
-      after(() => {
-        Sinon.restore()
-      })
     })
+  })
+
+  afterEach(() => {
+    Sinon.restore()
   })
 })

--- a/test/services/jobs/return-logs/process-return-logs.service.test.js
+++ b/test/services/jobs/return-logs/process-return-logs.service.test.js
@@ -9,160 +9,180 @@ const { describe, it, before, after } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Test helpers
-const FetchReturnCycleService = require('../../../../app/services/jobs/return-logs/fetch-return-cycle.service.js')
-const GenerateReturnCycleService = require('../../../../app/services/jobs/return-logs/generate-return-cycle.service.js')
 const LicenceHelper = require('../../../support/helpers/licence.helper.js')
+const GenerateReturnLogsService = require('../../../../app/services/jobs/return-logs/generate-return-logs.service.js')
+const PrimaryPurposeHelper = require('../../../support/helpers/primary-purpose.helper.js')
+const PurposeHelper = require('../../../support/helpers/purpose.helper.js')
 const RegionHelper = require('../../../support/helpers/region.helper.js')
 const ReturnLogModel = require('../../../../app/models/return-log.model.js')
 const ReturnRequirementHelper = require('../../../support/helpers/return-requirement.helper.js')
 const ReturnRequirementPointHelper = require('../../../support/helpers/return-requirement-point.helper.js')
 const ReturnRequirementPurposeHelper = require('../../../support/helpers/return-requirement-purpose.helper.js')
 const ReturnVersionHelper = require('../../../support/helpers/return-version.helper.js')
+const SecondaryPurposeHelper = require('../../../support/helpers/secondary-purpose.helper.js')
 
 // Thing under test
 const ProcessReturnLogsService = require('../../../../app/services/jobs/return-logs/process-return-logs.service.js')
 
 describe('Process return logs service', () => {
   const allYearDueDate = new Date(new Date().getFullYear() + 1, 3, 28).toISOString().split('T')[0]
-  const summerDueDate = new Date(new Date().getFullYear() + 1, 10, 28).toISOString().split('T')[0]
   const allYearEndDate = new Date(new Date().getFullYear() + 1, 2, 31).toISOString().split('T')[0]
-  const summerEndDate = new Date(new Date().getFullYear() + 1, 9, 31).toISOString().split('T')[0]
   const allYearStartDate = new Date(new Date().getFullYear(), 3, 1).toISOString().split('T')[0]
-  const summerStartDate = new Date(new Date().getFullYear(), 10, 1).toISOString().split('T')[0]
 
-  describe('cycle is "all-year" and a licence reference is provided and there is already a return cycle', () => {
-    let licence
-    let region
-    let returnVersion
-    let returnRequirement
-    let notifierStub
+  let cycle
 
-    before(async () => {
-      Sinon.reset()
-      region = RegionHelper.select()
-      licence = await LicenceHelper.add({ regionId: region.id })
-      returnVersion = await ReturnVersionHelper.add({ licenceId: licence.id })
-      returnRequirement = await ReturnRequirementHelper.add({ returnVersionId: returnVersion.id })
-      await ReturnRequirementPointHelper.add({ returnRequirementId: returnRequirement.id })
-      await ReturnRequirementPurposeHelper.add({ returnRequirementId: returnRequirement.id })
-
-      // BaseRequest depends on the GlobalNotifier to have been set.
-      // This happens in app/plugins/global-notifier.plugin.js when the app starts up and the plugin is registered.
-      // As we're not creating an instance of Hapi server in this test we recreate the condition by setting
-      // it directly with our own stub
-      notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
-      Sinon.stub(FetchReturnCycleService, 'go').resolves('c095d75e-0e0d-4fe4-b048-150457f3871b')
-      Sinon.stub(GenerateReturnCycleService, 'go').resolves('g095d75e-0e0d-4fe4-b048-150457f3871g')
-      global.GlobalNotifier = notifierStub
+  describe('cycle is "all-year', () => {
+    before(() => {
+      cycle = 'all-year'
     })
 
-    it('can successfully save a return log in the database', async () => {
-      await ProcessReturnLogsService.go('all-year', licence.licenceRef)
+    describe('and a licence reference is provided', () => {
+      const allYearReturnCycleId = 'c095d75e-0e0d-4fe4-b048-150457f3871b'
 
-      const result = await ReturnLogModel.query().where('licenceRef', licence.licenceRef)
+      let licence
+      let notifierStub
+      let point
+      let primaryPurpose
+      let purpose
+      let region
+      let returnVersion
+      let returnRequirement
+      let secondaryPurpose
 
-      expect(result.length).to.equal(1)
-      expect(result[0].dueDate).to.equal(new Date(allYearDueDate))
-      expect(result[0].endDate).to.equal(new Date(allYearEndDate))
-      expect(result[0].id).to.equal(`v1:${region.naldRegionId}:${licence.licenceRef}:${returnRequirement.legacyId}:${allYearStartDate}:${allYearEndDate}`)
-      expect(result[0].licenceRef).to.equal(licence.licenceRef)
-      expect(result[0].returnsFrequency).to.equal('day')
-      expect(result[0].startDate).to.equal(new Date(allYearStartDate))
-      expect(result[0].status).to.equal('due')
-      expect(result[0].source).to.equal('WRLS')
-      expect(result[0].returnCycleId).to.equal('c095d75e-0e0d-4fe4-b048-150457f3871b')
+      before(async () => {
+        region = RegionHelper.select()
+        licence = await LicenceHelper.add({ regionId: region.id })
+        returnVersion = await ReturnVersionHelper.add({ licenceId: licence.id })
+        returnRequirement = await ReturnRequirementHelper.add({ returnVersionId: returnVersion.id })
+        point = await ReturnRequirementPointHelper.add({ returnRequirementId: returnRequirement.id })
+        primaryPurpose = PrimaryPurposeHelper.select()
+        purpose = PurposeHelper.select()
+        secondaryPurpose = SecondaryPurposeHelper.select()
+        await ReturnRequirementPurposeHelper.add({
+          alias: null,
+          primaryPurposeId: primaryPurpose.id,
+          purposeId: purpose.id,
+          returnRequirementId: returnRequirement.id,
+          secondaryPurposeId: secondaryPurpose.id
+        })
+
+        // BaseRequest depends on the GlobalNotifier to have been set.
+        // This happens in app/plugins/global-notifier.plugin.js when the app starts up and the plugin is registered.
+        // As we're not creating an instance of Hapi server in this test we recreate the condition by setting
+        // it directly with our own stub
+        notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
+        Sinon.stub(GenerateReturnLogsService, 'go').resolves([{
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          dueDate: allYearDueDate,
+          endDate: allYearEndDate,
+          id: `v1:${region.naldRegionId}:${licence.licenceRef}:${returnRequirement.legacyId}:${allYearStartDate}:${allYearEndDate}`,
+          licenceRef: licence.licenceRef,
+          metadata: {
+            description: 'BOREHOLE AT AVALON',
+            isCurrent: true,
+            isFinal: false,
+            isSummer: false,
+            isTwoPartTariff: false,
+            isUpload: false,
+            nald: {
+              regionCode: region.naldRegionId,
+              areaCode: licence.regions.historicalAreaCode,
+              formatId: returnRequirement.legacyId,
+              periodStartDay: returnRequirement.abstractionPeriodStartDay.toString(),
+              periodStartMonth: returnRequirement.abstractionPeriodStartMonth.toString(),
+              periodEndDay: returnRequirement.abstractionPeriodEndDay.toString(),
+              periodEndMonth: returnRequirement.abstractionPeriodEndMonth.toString()
+            },
+            points: [{
+              name: point.description,
+              ngr1: point.ngr1,
+              ngr2: point.ngr2,
+              ngr3: point.ngr3,
+              ngr4: point.ngr4
+            }],
+            purposes: [{
+              primary: {
+                code: primaryPurpose.legacyId,
+                description: primaryPurpose.description
+              },
+              secondary: {
+                code: secondaryPurpose.legacyId,
+                description: secondaryPurpose.description
+              },
+              tertiary: {
+                code: purpose.legacyId,
+                description: purpose.description
+              }
+            }],
+            version: 1
+          },
+          returnCycleId: allYearReturnCycleId,
+          returnsFrequency: 'day',
+          returnReference: returnRequirement.legacyId.toString(),
+          startDate: allYearStartDate,
+          status: 'due',
+          source: 'WRLS'
+        }])
+        global.GlobalNotifier = notifierStub
+      })
+
+      it('can successfully save a return log in the database', async () => {
+        await ProcessReturnLogsService.go(cycle, licence.licenceRef)
+
+        const result = await ReturnLogModel.query().where('licenceRef', licence.licenceRef)
+
+        expect(result.length).to.equal(1)
+        expect(result[0].dueDate).to.equal(new Date(allYearDueDate))
+        expect(result[0].endDate).to.equal(new Date(allYearEndDate))
+        expect(result[0].id).to.equal(`v1:${region.naldRegionId}:${licence.licenceRef}:${returnRequirement.legacyId}:${allYearStartDate}:${allYearEndDate}`)
+        expect(result[0].licenceRef).to.equal(licence.licenceRef)
+        expect(result[0].returnsFrequency).to.equal('day')
+        expect(result[0].startDate).to.equal(new Date(allYearStartDate))
+        expect(result[0].status).to.equal('due')
+        expect(result[0].source).to.equal('WRLS')
+        expect(result[0].returnCycleId).to.equal(allYearReturnCycleId)
+      })
+
+      after(() => {
+        Sinon.restore()
+      })
     })
 
-    after(() => {
-      Sinon.restore()
-    })
-  })
+    describe('and a licence reference is provided but there is no matching return requirements', () => {
+      before(async () => {
+        Sinon.stub(GenerateReturnLogsService, 'go').resolves([])
+      })
 
-  describe('cycle is "summer" and a licence reference is provided and there is no return cycle', () => {
-    let licence
-    let region
-    let returnVersion
-    let returnRequirement
-    let notifierStub
+      it('will not save anything in the database', async () => {
+        await ProcessReturnLogsService.go(cycle, 'testReference')
 
-    before(async () => {
-      Sinon.reset()
-      region = RegionHelper.select()
-      licence = await LicenceHelper.add({ regionId: region.id })
-      returnVersion = await ReturnVersionHelper.add({ licenceId: licence.id })
-      returnRequirement = await ReturnRequirementHelper.add({ summer: true, returnVersionId: returnVersion.id })
-      await ReturnRequirementPointHelper.add({ returnRequirementId: returnRequirement.id })
-      await ReturnRequirementPurposeHelper.add({ returnRequirementId: returnRequirement.id })
+        const result = await ReturnLogModel.query().where('licenceRef', 'testReference')
 
-      // BaseRequest depends on the GlobalNotifier to have been set.
-      // This happens in app/plugins/global-notifier.plugin.js when the app starts up and the plugin is registered.
-      // As we're not creating an instance of Hapi server in this test we recreate the condition by setting
-      // it directly with our own stub
-      notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
-      Sinon.stub(FetchReturnCycleService, 'go').resolves(undefined)
-      Sinon.stub(GenerateReturnCycleService, 'go').resolves('f095d75e-0e0d-4fe4-b048-150457f3871f')
-      global.GlobalNotifier = notifierStub
+        expect(result.length).to.equal(0)
+      })
+
+      after(() => {
+        Sinon.restore()
+      })
     })
 
-    it('can successfully save a return log in the database', async () => {
-      await ProcessReturnLogsService.go('summer', licence.licenceRef)
+    describe('when it throws an error', () => {
+      before(async () => {
+        Sinon.stub(GenerateReturnLogsService, 'go').resolves([])
+      })
 
-      const result = await ReturnLogModel.query().where('licenceRef', licence.licenceRef)
+      it('will catch it and log it to the console', async () => {
+        await ProcessReturnLogsService.go('all-year', 'testReference')
 
-      expect(result.length).to.equal(1)
-      expect(result[0].dueDate).to.equal(new Date(summerDueDate))
-      expect(result[0].endDate).to.equal(new Date(summerEndDate))
-      expect(result[0].id).to.equal(`v1:${region.naldRegionId}:${licence.licenceRef}:${returnRequirement.legacyId}:${summerStartDate}:${summerEndDate}`)
-      expect(result[0].licenceRef).to.equal(licence.licenceRef)
-      expect(result[0].returnsFrequency).to.equal('day')
-      expect(result[0].startDate).to.equal(new Date(summerStartDate))
-      expect(result[0].status).to.equal('due')
-      expect(result[0].source).to.equal('WRLS')
-      expect(result[0].returnCycleId).to.equal('f095d75e-0e0d-4fe4-b048-150457f3871f')
-    })
+        const result = await ReturnLogModel.query().where('licenceRef', 'testReference')
 
-    after(() => {
-      Sinon.restore()
-    })
-  })
+        expect(result.length).to.equal(0)
+      })
 
-  describe('cycle is "all-year" and a licence reference is provided but there is no matching return requirements', () => {
-    before(async () => {
-      Sinon.reset()
-      Sinon.stub(FetchReturnCycleService, 'go').resolves(undefined)
-      Sinon.stub(GenerateReturnCycleService, 'go').resolves('f095d75e-0e0d-4fe4-b048-150457f3871f')
-    })
-
-    it('will not save anything in the database', async () => {
-      await ProcessReturnLogsService.go('all-year', 'testReference')
-
-      const result = await ReturnLogModel.query().where('licenceRef', 'testReference')
-
-      expect(result.length).to.equal(0)
-    })
-
-    after(() => {
-      Sinon.restore()
-    })
-  })
-
-  describe('when it throws an error', () => {
-    before(async () => {
-      Sinon.reset()
-      Sinon.stub(FetchReturnCycleService, 'go').resolves(undefined)
-      Sinon.stub(GenerateReturnCycleService, 'go').resolves('f095d75e-0e0d-4fe4-b048-150457f3871f')
-    })
-
-    it('will catch it and log it to the console', async () => {
-      await ProcessReturnLogsService.go('all-year', 'testReference')
-
-      const result = await ReturnLogModel.query().where('licenceRef', 'testReference')
-
-      expect(result.length).to.equal(0)
-    })
-
-    after(() => {
-      Sinon.restore()
+      after(() => {
+        Sinon.restore()
+      })
     })
   })
 })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4543

As part of the work to replace the legacy system NALD we need to generate return logs. This PR creates a return cycle if one does not already exist when creating return logs for a new licence when it is imported. This will create the return cycles even if the date for them to be ran has not yet happened. 