### PR TITLE
Handle special characters in rtn req. bookmarks

### DIFF
--- a/app/views/return-requirements/view.njk
+++ b/app/views/return-requirements/view.njk
@@ -98,7 +98,7 @@
                 {% if requirement.siteDescription == '' %}
                   Return reference {{ requirement.returnReference }}
                 {% else %}
-                  Return reference {{ requirement.returnReference }} - {{ requirement.siteDescription }}
+                  Return reference {{ requirement.returnReference }} - {{ requirement.siteDescription | safe }}
                 {% endif %}
               {% endset %}
               <li><a href="#requirement-{{ requirementIndex }}">{{ bookmarkTitle }}</a></li>


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4685

> Part of the work to migrate managing return requirements from NALD to WRLS

In [Add site description to rtn. req. bookmark links](https://github.com/DEFRA/water-abstraction-system/pull/1358) we added the return requirement site description to the bookmarks we display when viewing a return version with more than one requirement.

However, that change didn't account for users' adding site descriptions that include special characters, such as `" & '`.

When these descriptions are included in the bookmark links, they appear like this.

- `Return reference 100234 - Quantities taken between points X, Y &amp;Z`
- `Return reference 100432 - Opposite &quot;Old cottage&quot; entrance`
- `Return reference 100567 - Borehole in &#39;middle&#39; field`

This change updates the logic to escape these characters.