### PR TITLE
Fix QA issues in new Monitoring stations page

### DIFF
--- a/app/presenters/monitoring-stations/view-monitoring-stations.presenter.js
+++ b/app/presenters/monitoring-stations/view-monitoring-stations.presenter.js
@@ -119,7 +119,7 @@ function _groupLicences (licences) {
 
     if (!grouped[id]) {
       grouped[id] = {
-        licenceId: id,
+        id,
         licenceRef,
         linkages: []
       }

--- a/app/views/monitoring-stations/view.njk
+++ b/app/views/monitoring-stations/view.njk
@@ -14,7 +14,7 @@
   {# Back link #}
   {{
     govukBackLink({
-      text: 'Back',
+      text: 'Go back to search',
       href: "/licences"
     })
   }}

--- a/test/presenters/monitoring-stations/view-monitoring-stations.presenter.test.js
+++ b/test/presenters/monitoring-stations/view-monitoring-stations.presenter.test.js
@@ -34,7 +34,7 @@ describe('View Monitoring Stations presenter', () => {
         stationReference: null,
         licences: [
           {
-            licenceId: '3cd1481c-e96a-45fc-8f2b-1849564b95a5',
+            id: '3cd1481c-e96a-45fc-8f2b-1849564b95a5',
             licenceRef: 'AT/TEST',
             linkages: [
               {
@@ -214,7 +214,7 @@ describe('View Monitoring Stations presenter', () => {
               stationReference: null,
               licences: [
                 {
-                  licenceId: '3cd1481c-e96a-45fc-8f2b-1849564b95a5',
+                  id: '3cd1481c-e96a-45fc-8f2b-1849564b95a5',
                   licenceRef: 'AT/TEST',
                   linkages: [{
                     abstractionPeriod: '1 April to 31 August',
@@ -240,7 +240,7 @@ describe('View Monitoring Stations presenter', () => {
                   }]
                 },
                 {
-                  licenceId: 'fb46704b-0e8c-488e-9b58-faf87b6d9a01',
+                  id: 'fb46704b-0e8c-488e-9b58-faf87b6d9a01',
                   licenceRef: 'AT/TEST/2',
                   linkages: [{
                     abstractionPeriod: '1 February to 22 July',

--- a/test/services/monitoring-stations/view.service.test.js
+++ b/test/services/monitoring-stations/view.service.test.js
@@ -45,7 +45,7 @@ describe('View service', () => {
         stationReference: null,
         licences: [
           {
-            licenceId: '3cd1481c-e96a-45fc-8f2b-1849564b95a5',
+            id: '3cd1481c-e96a-45fc-8f2b-1849564b95a5',
             licenceRef: 'AT/TEST',
             linkages: [
               {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4679

We are working on [migrating the monitoring station page](https://github.com/DEFRA/water-abstraction-system/pull/1340) from the legacy UI to this repo. Our fantastic QA team have spotted some issues with the first iteration that this change addresses.

- The `< Back` link was supposed to be `< Go back to search`
- When a monitoring station (gauging station) is linked to a licence, the link to the licence is broken

This change fixes those issues.