### PR TITLE
Remove setting return cycle in ReturnLogHelper

### DIFF
--- a/test/support/helpers/return-log.helper.js
+++ b/test/support/helpers/return-log.helper.js
@@ -4,7 +4,6 @@
  * @module ReturnLogHelper
  */
 
-const { generateUUID } = require('../../../app/lib/general.lib.js')
 const { generateLicenceRef } = require('./licence.helper.js')
 const { randomInteger } = require('../general.js')
 const { timestampForPostgres } = require('../../../app/lib/general.lib.js')
@@ -23,7 +22,6 @@ const ReturnLogModel = require('../../../app/models/return-log.model.js')
  * - `metadata` - {}
  * - `receivedDate` - 2023-04-12
  * - `returnReference` - [randomly generated - 10000321]
- * - `returnCycleId` - UUID
  * - `returnsFrequency` - month
  * - `startDate` - 2022-04-01
  * - `status` - completed
@@ -85,7 +83,6 @@ function defaults (data = {}) {
     },
     receivedDate,
     returnReference,
-    returnCycleId: generateUUID(),
     returnsFrequency: 'month',
     startDate: new Date('2022-04-01'),
     status: 'due',

--- a/test/support/helpers/return-log.helper.js
+++ b/test/support/helpers/return-log.helper.js
@@ -95,12 +95,32 @@ function defaults (data = {}) {
   }
 }
 
+/**
+ * Returns a randomly generated return log Id
+ *
+ * Unlike other tables, the previous team opted to generate a unique ID based on properties of the return log including
+ * start and end dates, version and references.
+ *
+ * So, in order to replicate that we have this helper method, that defaults some of those values, and randomises others
+ * in order to generate a unique return log ID.
+ *
+ * If you have known values, for example, the licence reference they can be passed to this helper and it will
+ * incorporate them into the ID.
+ *
+ * @param {string} [startDate] - the start date as a string, for example '2022-04-01'
+ * @param {string} [endDate] - the end date as a string, for example '2023-03-31'
+ * @param {number} [version] - the version number to use, for example 1
+ * @param {string} [licenceRef] - the licence reference to use
+ * @param {string} [returnReference] - the return requirement reference to use
+ *
+ * @returns {string} the generated return log ID
+ */
 function generateReturnLogId (
   startDate = '2022-04-01',
   endDate = '2023-03-31',
   version = 1,
-  licenceRef,
-  returnReference
+  licenceRef = null,
+  returnReference = null
 ) {
   if (!licenceRef) {
     licenceRef = generateLicenceRef()


### PR DESCRIPTION
When attempting to run the acceptance tests we found most of them were now failing. After investigating we tracked it down to a [recent change made](https://github.com/DEFRA/water-abstraction-system/pull/1353) to the `ReturnLogHelper`.

We started setting `returnCycleId` to a generated UUID. Normally, return logs have this set to the return cycle they fall within. However, if it is set (in the DB proper) the ID _must_ exist in `return.return_cycles`.

We've opted not to replicate foreign key constraints in our test DB legacy migrations because of the additional complexity they would add to our unit tests, for something we don't need to cover in them.

It wasn't being set before, because our premise for the helpers is they set _only_ what is required in order to insert a record. Any fields that are 'optional', are expected to be set within the test using the helper and passed in.

Fortunately, removing the call in the helper hasn't broken any existing tests, further highlighting we don't really need this defaulted for what we are testing. And removing the call gets the acceptance tests passing again!