### PR TITLE
Fix error with return cycles seeder

### DIFF
--- a/db/seeds/16-return-cycles.seed.js
+++ b/db/seeds/16-return-cycles.seed.js
@@ -13,6 +13,12 @@ async function seed () {
 async function _upsert (cycle) {
   return ReturnCycleModel.query()
     .insert({ ...cycle, createdAt: timestampForPostgres(), updatedAt: timestampForPostgres() })
+    .onConflict(['startDate', 'endDate', 'summer'])
+    .merge([
+      'dueDate',
+      'submittedInWrls',
+      'updatedAt'
+    ])
 }
 
 module.exports = {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4543

In [Create return cycle](https://github.com/DEFRA/water-abstraction-system/pull/1353) we added a new seeder for return cycles.

They are part reference and part transactional records. When starting with a clean environment, you would need to seed existing return cycles. Going forward, they are automatically created as part of creating return logs. When we create the first return log for a cycle, if the cycle record does not exist, we make it.

When we added the seeder, though, the query we wrote was purely an insert. It should have been an `upsert` because seeders need to be written so they can be run multiple times against the same environment (both test and 'real').

This fixes the query used to actually be an upsert.