### PR TITLE
Add option to run tests without cleaning

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "lint": "eslint .",
     "pretest": "NODE_ENV=test node db/clean.js",
     "test": "lab --silent-skips --shuffle",
+    "test:skip": "lab --silent-skips --shuffle",
     "postinstall": "npm run build",
     "version": "npx --yes auto-changelog -p --commit-limit false && git add CHANGELOG.md"
   },


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/124

Over the last few months, we have been working through our test suite, removing all calls to `DatabaseSupport.clean()`. Our aim was to get to a position where the database is only cleaned before the test suite runs.

We're there now, which means our test suite is faster, and we can consider moving to a modern test framework that will run tests in parallel.

To achieve this position, we clean the DB before each test run and seed all the reference data the tests need. We see the benefit when running the full test suite compared to the previous state. But when you are working on a feature and only want to run specific tests, this upfront step is very noticeable.

In theory, the changes we've made _should_ mean cleaning the DB is unnecessary. It's a handy way of spotting tests likely to be flaky! But it is still prudent to have clean then test as the default. However, it would be handy to have the option to skip the clean to speed up our TDD red-green-refactor cycle.

This change adds a new `test:skip` script to `package.json`. The call is the same as the current one for `test`. The fact it isn't called `test:` means [npm](https://www.npmjs.com/) won't call `pretest:` before it is run. Simples!