### PR TITLE
Migrate licence document to have data fro unique constraint

### DIFF
--- a/db/migrations/public/20241014124234_alter-licence-documents-view.js.js
+++ b/db/migrations/public/20241014124234_alter-licence-documents-view.js.js
@@ -1,0 +1,45 @@
+'use strict'
+
+const viewName = 'licence_documents'
+
+exports.up = function (knex) {
+  return knex
+    .schema
+    .dropViewIfExists(viewName)
+    .createView(viewName, (view) => {
+      // NOTE: We have commented out unused columns from the source table
+      view.as(knex('documents').withSchema('crm_v2').select([
+        'document_id AS id',
+        'regime',
+        'document_type',
+        'document_ref AS licence_ref',
+        'start_date',
+        'end_date',
+        // 'is_test',
+        'date_deleted AS deleted_at',
+        'date_created AS created_at',
+        'date_updated AS updated_at'
+      ]))
+    })
+}
+
+exports.down = function (knex) {
+  return knex
+    .schema
+    .dropViewIfExists(viewName)
+    .createView(viewName, (view) => {
+      // NOTE: We have commented out unused columns from the source table
+      view.as(knex('documents').withSchema('crm_v2').select([
+        'document_id AS id',
+        // 'regime',
+        // 'document_type',
+        'document_ref AS licence_ref',
+        'start_date',
+        'end_date',
+        // 'is_test',
+        'date_deleted AS deleted_at',
+        'date_created AS created_at',
+        'date_updated AS updated_at'
+      ]))
+    })
+}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4708

As part of the ongoing work to move the import code into WRLS. We have needed to alter the database view in order to enforce the unique constraints on a table.

In this case we need to add defaulted data from document type and regime. This data will likely always be the default.

This change add these two columns to the view to enable an upsert to take place on the unique constraint.