### PR TITLE
Exclude VOID returns from two-part tariff billing

### DIFF
--- a/app/presenters/bill-runs/two-part-tariff/match-details.presenter.js
+++ b/app/presenters/bill-runs/two-part-tariff/match-details.presenter.js
@@ -119,7 +119,7 @@ function _prepareDate (startDate, endDate) {
 function _returnLinkAndTotal (returnLog) {
   const { returnStatus, allocated, quantity } = returnLog
 
-  if (['due', 'received', 'void'].includes(returnStatus)) {
+  if (['due', 'received'].includes(returnStatus)) {
     return { returnTotal: '/', returnLink: `/return/internal?returnId=${returnLog.returnId}` }
   }
 

--- a/app/presenters/bill-runs/two-part-tariff/review-licence.presenter.js
+++ b/app/presenters/bill-runs/two-part-tariff/review-licence.presenter.js
@@ -250,8 +250,6 @@ function _prepareReturnVolume (reviewChargeElement) {
     reviewReturns.forEach((reviewReturn) => {
       if (reviewReturn.returnStatus === 'due') {
         returnVolumes.push(`overdue (${reviewReturn.returnReference})`)
-      } else if (reviewReturn.returnStatus === 'void') {
-        returnVolumes.push(`void (${reviewReturn.returnReference})`)
       } else {
         returnVolumes.push(`${reviewReturn.quantity} ML (${reviewReturn.returnReference})`)
       }
@@ -262,7 +260,7 @@ function _prepareReturnVolume (reviewChargeElement) {
 }
 
 function _returnLink (returnLog) {
-  if (['due', 'received', 'void'].includes(returnLog.returnStatus)) {
+  if (['due', 'received'].includes(returnLog.returnStatus)) {
     return `/return/internal?returnId=${returnLog.returnId}`
   }
 
@@ -284,7 +282,7 @@ function _returnStatus (returnLog) {
 function _returnTotal (returnLog) {
   const { returnStatus, allocated, quantity } = returnLog
 
-  if (['due', 'received', 'void'].includes(returnStatus)) {
+  if (['due', 'received'].includes(returnStatus)) {
     return '/'
   }
 

--- a/app/services/bill-runs/two-part-tariff/fetch-return-logs-for-licence.service.js
+++ b/app/services/bill-runs/two-part-tariff/fetch-return-logs-for-licence.service.js
@@ -44,6 +44,7 @@ async function _fetch (licenceRef, billingPeriod) {
     // water-abstraction-service filters out old return logs in this way: see
     // `src/lib/services/returns/api-connector.js`
     .where('startDate', '>=', '2008-04-01')
+    .whereNot('status', 'void')
     .where('endDate', '>=', billingPeriod.startDate)
     .where('endDate', '<=', billingPeriod.endDate)
     .whereJsonPath('metadata', '$.isTwoPartTariff', '=', true)

--- a/test/presenters/bill-runs/two-part-tariff/review-licence.presenter.test.js
+++ b/test/presenters/bill-runs/two-part-tariff/review-licence.presenter.test.js
@@ -178,37 +178,6 @@ describe('Review Licence presenter', () => {
           expect(result.matchedReturns[0].returnLink).to.equal('/return/internal?returnId=v1:1:01/60/28/3437:17061181:2022-04-01:2023-03-31')
         })
       })
-
-      describe('when a return has a status of "void"', () => {
-        beforeEach(() => {
-          licence[0].reviewReturns[0].returnStatus = 'void'
-          licence[0].reviewChargeVersions[0].reviewChargeReferences[0].reviewChargeElements[0].reviewReturns[0].returnStatus = 'void'
-        })
-
-        it('changes the status text to "void"', () => {
-          const result = ReviewLicencePresenter.go(billRun, licence)
-
-          expect(result.matchedReturns[0].returnStatus).to.equal('void')
-        })
-
-        it('formats the returns total correctly', () => {
-          const result = ReviewLicencePresenter.go(billRun, licence)
-
-          expect(result.matchedReturns[0].returnTotal).to.equal('/')
-        })
-
-        it('formats the charge elements return total correctly', () => {
-          const result = ReviewLicencePresenter.go(billRun, licence)
-
-          expect(result.chargeData[0].chargeReferences[0].chargeElements[0].returnVolume).to.equal(['void (10031343)'])
-        })
-
-        it('formats the returns link correctly', () => {
-          const result = ReviewLicencePresenter.go(billRun, licence)
-
-          expect(result.matchedReturns[0].returnLink).to.equal('/return/internal?returnId=v1:1:01/60/28/3437:17061181:2022-04-01:2023-03-31')
-        })
-      })
     })
 
     describe('the "underQuery" property', () => {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4709

> Part of our work implementing SROC two-part tariff billing

A request has come from our users after testing the current iteration of reviewing the matches and allocations for a two-part tariff return.

They are satisfied we don't include VOID return logs in the allocation results. But they would rather we exclude them from the process completely. Then, we wouldn't see them in the results, as they seem to make things confusing.

This change excludes VOID return logs (returns that have been replaced because of changes) from the two-part tariff match and allocate process.