### PR TITLE
Tidy up view licence inconsistencies

### DIFF
--- a/app/presenters/licences/view-licence-communications.presenter.js
+++ b/app/presenters/licences/view-licence-communications.presenter.js
@@ -2,13 +2,15 @@
 
 /**
  * Formats data for the `/licences/{id}/communications` view licence communications page
- * @module CommunicationsPresenter
+ * @module ViewLicenceCommunicationsPresenter
  */
 
 const { formatLongDate, sentenceCase } = require('../base.presenter.js')
 
 /**
  * Formats data for the `/licences/{id}/communications` view licence communications page
+ *
+ * @param {module:WorkflowModel[]} communications - All in-progress workflow records for the licence
  *
  * @returns {object} The data formatted for the view template
  */

--- a/app/presenters/licences/view-licence-set-up.presenter.js
+++ b/app/presenters/licences/view-licence-set-up.presenter.js
@@ -2,14 +2,15 @@
 
 /**
  * Formats data for the `/licences/{id}/set-up` view licence set up page
- * @module SetUpPresenter
+ * @module ViewLicenceSetUpPresenter
  */
 
-const FeatureFlagsConfig = require('../../../config/feature-flags.config.js')
 const { formatLongDate } = require('../base.presenter.js')
 const { returnRequirementReasons } = require('../../lib/static-lookups.lib.js')
 
-const roles = {
+const FeatureFlagsConfig = require('../../../config/feature-flags.config.js')
+
+const ROLES = {
   billing: 'billing',
   deleteAgreements: 'delete_agreements',
   manageAgreements: 'manage_agreements',
@@ -17,7 +18,7 @@ const roles = {
   workflowReviewer: 'charge_version_workflow_reviewer'
 }
 
-const agreementDescriptions = {
+const AGREEMENTS = {
   S127: 'Two-part tariff',
   S130S: 'Canal and Rivers Trust, supported source (S130S)',
   S130U: 'Canal and Rivers Trust, unsupported source (S130U)',
@@ -58,7 +59,7 @@ function _agreements (commonData, agreements, auth, enableTwoPartSupplementary) 
     return {
       startDate: formatLongDate(agreement.startDate),
       endDate: agreement.endDate ? formatLongDate(agreement.endDate) : '',
-      description: agreementDescriptions[_financialAgreementCode(agreement)],
+      description: AGREEMENTS[_financialAgreementCode(agreement)],
       signedOn: agreement.signedOn ? formatLongDate(agreement.signedOn) : '',
       action: _agreementActionLinks(commonData, agreement, auth, enableTwoPartSupplementary)
     }
@@ -66,7 +67,7 @@ function _agreements (commonData, agreements, auth, enableTwoPartSupplementary) 
 }
 
 function _agreementActionLinks (commonData, agreement, auth, enableTwoPartSupplementary) {
-  if (!auth.credentials.scope.includes(roles.manageAgreements)) {
+  if (!auth.credentials.scope.includes(ROLES.manageAgreements)) {
     return []
   }
 
@@ -77,7 +78,7 @@ function _agreementActionLinks (commonData, agreement, auth, enableTwoPartSupple
   const actionLinks = []
   const hasNotEnded = agreement.endDate === null
 
-  if (auth.credentials.scope.includes(roles.deleteAgreements)) {
+  if (auth.credentials.scope.includes(ROLES.deleteAgreements)) {
     actionLinks.push({
       text: 'Delete',
       link: `/licences/${commonData.licenceId}/agreements/${agreement.id}/delete`
@@ -97,7 +98,7 @@ function _agreementActionLinks (commonData, agreement, auth, enableTwoPartSupple
     const isNotMarkedForSupplementaryBilling = commonData.includeInPresrocBilling === 'no'
 
     if (hasNotEnded && is2PTAgreement && isNotMarkedForSupplementaryBilling &&
-      auth.credentials.scope.includes(roles.billing)) {
+      auth.credentials.scope.includes(ROLES.billing)) {
       actionLinks.push({
         text: 'Recalculate bills',
         link: `/licences/${commonData.licenceId}/mark-for-supplementary-billing`
@@ -109,7 +110,7 @@ function _agreementActionLinks (commonData, agreement, auth, enableTwoPartSupple
 }
 
 function _agreementLinks (auth, commonData) {
-  if (auth.credentials.scope.includes(roles.manageAgreements) && !_endsSixYearsAgo(commonData.ends)) {
+  if (auth.credentials.scope.includes(ROLES.manageAgreements) && !_endsSixYearsAgo(commonData.ends)) {
     return {
       setUpAgreement: `/licences/${commonData.licenceId}/agreements/select-type`
     }
@@ -119,7 +120,7 @@ function _agreementLinks (auth, commonData) {
 }
 
 function _chargeInformationLinks (auth, commonData) {
-  if (auth.credentials.scope.includes(roles.workflowEditor) && !_endsSixYearsAgo(commonData.ends)) {
+  if (auth.credentials.scope.includes(ROLES.workflowEditor) && !_endsSixYearsAgo(commonData.ends)) {
     return {
       setupNewCharge: `/licences/${commonData.licenceId}/charge-information/create`,
       makeLicenceNonChargeable: `/licences/${commonData.licenceId}/charge-information/non-chargeable-reason?start=1`
@@ -204,7 +205,7 @@ function _reason (returnVersion) {
 }
 
 function _recalculateBills (agreements, auth, commonData, enableTwoPartSupplementary) {
-  if (auth.credentials.scope.includes(roles.billing) &&
+  if (auth.credentials.scope.includes(ROLES.billing) &&
     _hasTwoPartTariffAgreement(agreements) &&
     enableTwoPartSupplementary
   ) {
@@ -254,11 +255,11 @@ function _workflows (workflows, auth) {
 }
 
 function _workflowAction (workflow, auth) {
-  if (workflow.status === 'to_setup' && auth.credentials.scope.includes(roles.workflowEditor)) {
+  if (workflow.status === 'to_setup' && auth.credentials.scope.includes(ROLES.workflowEditor)) {
     return _workflowActionEditor(workflow)
   }
 
-  if (auth.credentials.scope.includes(roles.workflowReviewer)) {
+  if (auth.credentials.scope.includes(ROLES.workflowReviewer)) {
     return _workflowActionReviewer(workflow)
   }
 

--- a/app/services/licences/fetch-communications.service.js
+++ b/app/services/licences/fetch-communications.service.js
@@ -14,7 +14,8 @@ const DatabaseConfig = require('../../../config/database.config.js')
  *
  * Was built to provide the data needed for the '/licences/{id}/communications' page
  *
- * @param {string} licenceId - The UUID for the licence to fetch
+ * @param {string} licenceRef - The reference for the licence to fetch
+ * @param {number|string} page - The current page for the pagination service
  *
  * @returns {Promise<object>} the data needed to populate the view licence page's communications tab
  */

--- a/app/services/licences/fetch-licence-bills.service.js
+++ b/app/services/licences/fetch-licence-bills.service.js
@@ -13,6 +13,7 @@ const DatabaseConfig = require('../../../config/database.config.js')
  * Fetches all bills for a licence which is needed for the view '/licences/{id}/bills` page
  *
  * @param {string} licenceId - The UUID for the licence to fetch
+ * @param {number|string} page - The current page for the pagination service
  *
  * @returns {Promise<object>} the data needed to populate the view licence page's bills tab
  */

--- a/app/services/licences/fetch-licence-returns.service.js
+++ b/app/services/licences/fetch-licence-returns.service.js
@@ -13,6 +13,7 @@ const DatabaseConfig = require('../../../config/database.config.js')
  * Fetches all return logs for a licence which is needed for the view '/licences/{id}/returns` page
  *
  * @param {string} licenceId - The UUID for the licence to fetch
+ * @param {number|string} page - The current page for the pagination service
  *
  * @returns {Promise<object>} the data needed to populate the view licence page's returns tab
  */

--- a/app/services/licences/view-licence-bills.service.js
+++ b/app/services/licences/view-licence-bills.service.js
@@ -14,6 +14,8 @@ const ViewLicenceService = require('./view-licence.service.js')
  * Orchestrates fetching and presenting the data needed for the view licence bills tab
  *
  * @param {string} licenceId - The UUID of the licence
+ * @param {object} auth - The auth object taken from `request.auth` containing user details
+ * @param {number|string} page - The current page for the pagination service
  *
  * @returns {Promise<object>} an object representing the `pageData` needed by the licence bills template.
  */

--- a/app/services/licences/view-licence-communications.service.js
+++ b/app/services/licences/view-licence-communications.service.js
@@ -5,16 +5,17 @@
  * @module ViewLicenceCommunicationsService
  */
 
-const CommunicationsPresenter = require('../../presenters/licences/communications.presenter.js')
 const FetchCommunicationsService = require('./fetch-communications.service.js')
 const PaginatorPresenter = require('../../presenters/paginator.presenter.js')
 const ViewLicenceService = require('./view-licence.service.js')
+const ViewLicenceCommunicationsPresenter = require('../../presenters/licences/view-licence-communications.presenter.js')
 
 /**
  * Orchestrates fetching and presenting the data needed for the licence communications page
  *
  * @param {string} licenceId - The UUID of the licence
  * @param {object} auth - The auth object taken from `request.auth` containing user details
+ * @param {number|string} page - The current page for the pagination service
  *
  * @returns {Promise<object>} an object representing the `pageData` needed by the licence communication template.
  */
@@ -22,7 +23,7 @@ async function go (licenceId, auth, page) {
   const commonData = await ViewLicenceService.go(licenceId, auth)
 
   const communications = await FetchCommunicationsService.go(commonData.licenceRef, page)
-  const communicationsData = CommunicationsPresenter.go(communications.communications)
+  const communicationsData = ViewLicenceCommunicationsPresenter.go(communications.communications)
 
   const pagination = PaginatorPresenter.go(communications.pagination.total, Number(page), `/system/licences/${licenceId}/communications`)
 

--- a/app/services/licences/view-licence-returns.service.js
+++ b/app/services/licences/view-licence-returns.service.js
@@ -16,7 +16,7 @@ const ViewLicenceService = require('./view-licence.service.js')
  *
  * @param {string} licenceId - The UUID of the licence
  * @param {object} auth - The auth object taken from `request.auth` containing user details
- * @param {object} page - The current page for the pagination service
+ * @param {number|string} page - The current page for the pagination service
  *
  * @returns {Promise<object>} an object representing the `pageData` needed by the licence summary template.
  */

--- a/app/services/licences/view-licence-set-up.service.js
+++ b/app/services/licences/view-licence-set-up.service.js
@@ -9,7 +9,7 @@ const FetchAgreementsService = require('./fetch-agreements.service.js')
 const FetchChargeVersionsService = require('./fetch-charge-versions.service.js')
 const FetchReturnVersionsService = require('./fetch-return-versions.service.js')
 const FetchWorkflowsService = require('./fetch-workflows.service.js')
-const SetUpPresenter = require('../../presenters/licences/set-up.presenter.js')
+const ViewLicenceSetUpPresenter = require('../../presenters/licences/view-licence-set-up.presenter.js')
 const ViewLicenceService = require('./view-licence.service.js')
 
 /**
@@ -28,7 +28,9 @@ async function go (licenceId, auth) {
   const workflows = await FetchWorkflowsService.go(licenceId)
   const returnVersions = await FetchReturnVersionsService.go(licenceId)
 
-  const licenceSetUpData = SetUpPresenter.go(chargeVersions, workflows, agreements, returnVersions, auth, commonData)
+  const licenceSetUpData = ViewLicenceSetUpPresenter.go(
+    chargeVersions, workflows, agreements, returnVersions, auth, commonData
+  )
 
   return {
     activeTab: 'set-up',

--- a/test/presenters/licences/view-licence-communications.presenter.test.js
+++ b/test/presenters/licences/view-licence-communications.presenter.test.js
@@ -8,9 +8,9 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { expect } = Code
 
 // Thing under test
-const CommunicationsPresenter = require('../../../app/presenters/licences/communications.presenter.js')
+const ViewLicenceCommunicationsPresenter = require('../../../app/presenters/licences/view-licence-communications.presenter.js')
 
-describe('Communications presenter', () => {
+describe('View Licence Communications presenter', () => {
   let communications
 
   beforeEach(() => {
@@ -35,7 +35,7 @@ describe('Communications presenter', () => {
 
   describe('when provided with populated communications data', () => {
     it('correctly presents the data', () => {
-      const result = CommunicationsPresenter.go(communications)
+      const result = ViewLicenceCommunicationsPresenter.go(communications)
 
       expect(result).to.equal({
         communications: [{
@@ -60,7 +60,7 @@ describe('Communications presenter', () => {
         })
 
         it('returns that communication type', () => {
-          const result = CommunicationsPresenter.go(communications)
+          const result = ViewLicenceCommunicationsPresenter.go(communications)
 
           expect(result.communications[0].type).to.equal({
             label: 'Returns: invitation',
@@ -72,7 +72,7 @@ describe('Communications presenter', () => {
 
       describe('when the message ref does not contain pdf', () => {
         it('returns that communication type', () => {
-          const result = CommunicationsPresenter.go(communications)
+          const result = ViewLicenceCommunicationsPresenter.go(communications)
 
           expect(result.communications[0].type).to.equal({
             label: 'Returns: invitation',
@@ -90,7 +90,7 @@ describe('Communications presenter', () => {
 
       describe('when the message type is present', () => {
         it('returns the method key in sentence case', () => {
-          const result = CommunicationsPresenter.go(communications)
+          const result = ViewLicenceCommunicationsPresenter.go(communications)
 
           expect(result.communications[0].method).to.equal('I am in sentence case')
         })
@@ -104,7 +104,7 @@ describe('Communications presenter', () => {
       })
 
       it('returns the type object with an alert text', () => {
-        const result = CommunicationsPresenter.go(communications)
+        const result = ViewLicenceCommunicationsPresenter.go(communications)
 
         expect(result.communications[0].type).to.equal({
           label: 'Test - Water abstraction alert',

--- a/test/presenters/licences/view-licence-set-up.presenter.test.js
+++ b/test/presenters/licences/view-licence-set-up.presenter.test.js
@@ -15,9 +15,9 @@ const ReturnVersionModel = require('../../../app/models/return-version.model.js'
 const FeatureFlagsConfig = require('../../../config/feature-flags.config.js')
 
 // Thing under test
-const SetUpPresenter = require('../../../app/presenters/licences/set-up.presenter.js')
+const ViewLicenceSetUpPresenter = require('../../../app/presenters/licences/view-licence-set-up.presenter.js')
 
-describe('Licences - Set Up presenter', () => {
+describe('View Licence Set Up presenter', () => {
   const agreement = {
     id: '123',
     startDate: new Date('2020-01-01'),
@@ -118,7 +118,9 @@ describe('Licences - Set Up presenter', () => {
         })
 
         it('correctly presents the agreements data', () => {
-          const result = SetUpPresenter.go(chargeVersions, workflows, agreements, returnVersions, auth, commonData)
+          const result = ViewLicenceSetUpPresenter.go(
+            chargeVersions, workflows, agreements, returnVersions, auth, commonData
+          )
 
           expect(result.agreements).to.equal([
             {
@@ -146,7 +148,9 @@ describe('Licences - Set Up presenter', () => {
 
         describe('when all the actions are available for an agreement', () => {
           it('shows delete, end and recalculate bills actions', () => {
-            const result = SetUpPresenter.go(chargeVersions, workflows, agreements, returnVersions, auth, commonData)
+            const result = ViewLicenceSetUpPresenter.go(
+              chargeVersions, workflows, agreements, returnVersions, auth, commonData
+            )
 
             expect(result.agreements[0].action).to.equal([
               {
@@ -172,7 +176,9 @@ describe('Licences - Set Up presenter', () => {
             })
 
             it('there are no actions', () => {
-              const result = SetUpPresenter.go(chargeVersions, workflows, agreements, returnVersions, auth, commonData)
+              const result = ViewLicenceSetUpPresenter.go(
+                chargeVersions, workflows, agreements, returnVersions, auth, commonData
+              )
 
               expect(result.agreements[0].action).to.equal([])
             })
@@ -184,7 +190,9 @@ describe('Licences - Set Up presenter', () => {
             })
 
             it('there is no action link to delete', () => {
-              const result = SetUpPresenter.go(chargeVersions, workflows, agreements, returnVersions, auth, commonData)
+              const result = ViewLicenceSetUpPresenter.go(
+                chargeVersions, workflows, agreements, returnVersions, auth, commonData
+              )
 
               expect(result.agreements[0].action).to.equal([
                 {
@@ -205,7 +213,9 @@ describe('Licences - Set Up presenter', () => {
             })
 
             it('there is no action link to end the agreement', () => {
-              const result = SetUpPresenter.go(chargeVersions, workflows, agreements, returnVersions, auth, commonData)
+              const result = ViewLicenceSetUpPresenter.go(
+                chargeVersions, workflows, agreements, returnVersions, auth, commonData
+              )
 
               expect(result.agreements[0].action).to.equal([
                 {
@@ -222,7 +232,9 @@ describe('Licences - Set Up presenter', () => {
             })
 
             it('there is no action link to Recalculate bills', () => {
-              const result = SetUpPresenter.go(chargeVersions, workflows, agreements, returnVersions, auth, commonData)
+              const result = ViewLicenceSetUpPresenter.go(
+                chargeVersions, workflows, agreements, returnVersions, auth, commonData
+              )
 
               expect(result.agreements[0].action).to.equal([
                 {
@@ -241,7 +253,9 @@ describe('Licences - Set Up presenter', () => {
         describe('when the financial agreement code ', () => {
           describe('is for Two-part tariff ', () => {
             it('correctly maps the code to the description', () => {
-              const result = SetUpPresenter.go(chargeVersions, workflows, agreements, returnVersions, auth, commonData)
+              const result = ViewLicenceSetUpPresenter.go(
+                chargeVersions, workflows, agreements, returnVersions, auth, commonData
+              )
 
               expect(result.agreements[0].description).to.equal('Two-part tariff')
             })
@@ -253,7 +267,9 @@ describe('Licences - Set Up presenter', () => {
             })
 
             it('correctly maps the code to the description', () => {
-              const result = SetUpPresenter.go(chargeVersions, workflows, agreements, returnVersions, auth, commonData)
+              const result = ViewLicenceSetUpPresenter.go(
+                chargeVersions, workflows, agreements, returnVersions, auth, commonData
+              )
 
               expect(result.agreements[0].description).to.equal('Canal and Rivers Trust, supported source (S130S)')
             })
@@ -265,7 +281,9 @@ describe('Licences - Set Up presenter', () => {
             })
 
             it('correctly maps the code to the description', () => {
-              const result = SetUpPresenter.go(chargeVersions, workflows, agreements, returnVersions, auth, commonData)
+              const result = ViewLicenceSetUpPresenter.go(
+                chargeVersions, workflows, agreements, returnVersions, auth, commonData
+              )
 
               expect(result.agreements[0].description).to.equal('Canal and Rivers Trust, unsupported source (S130U)')
             })
@@ -276,7 +294,7 @@ describe('Licences - Set Up presenter', () => {
               agreement.financialAgreement.code = 'S126'
             })
             it('correctly maps the code to the description', () => {
-              const result = SetUpPresenter
+              const result = ViewLicenceSetUpPresenter
                 .go(chargeVersions, workflows, agreements, returnVersions, auth, commonData)
 
               expect(result.agreements[0].description).to.equal('Abatement')
@@ -290,7 +308,9 @@ describe('Licences - Set Up presenter', () => {
           })
 
           it('shows delete, end and recalculate bills actions', () => {
-            const result = SetUpPresenter.go(chargeVersions, workflows, agreements, returnVersions, auth, commonData)
+            const result = ViewLicenceSetUpPresenter.go(
+              chargeVersions, workflows, agreements, returnVersions, auth, commonData
+            )
 
             expect(result.agreements[0].action).to.equal([
               {
@@ -322,7 +342,9 @@ describe('Licences - Set Up presenter', () => {
           })
 
           it('shows delete, end and recalculate bills actions', () => {
-            const result = SetUpPresenter.go(chargeVersions, workflows, agreements, returnVersions, auth, commonData)
+            const result = ViewLicenceSetUpPresenter.go(
+              chargeVersions, workflows, agreements, returnVersions, auth, commonData
+            )
 
             expect(result.agreements[0].action).to.equal([])
           })
@@ -337,7 +359,9 @@ describe('Licences - Set Up presenter', () => {
         })
 
         it('groups both types of data into the "chargeInformation" property', () => {
-          const result = SetUpPresenter.go(chargeVersions, workflows, agreements, returnVersions, auth, commonData)
+          const result = ViewLicenceSetUpPresenter.go(
+            chargeVersions, workflows, agreements, returnVersions, auth, commonData
+          )
 
           expect(result.chargeInformation).to.equal([
             {
@@ -377,7 +401,9 @@ describe('Licences - Set Up presenter', () => {
           })
 
           it('correctly presents the data with a dash for the end date', () => {
-            const result = SetUpPresenter.go(chargeVersions, workflows, agreements, returnVersions, auth, commonData)
+            const result = ViewLicenceSetUpPresenter.go(
+              chargeVersions, workflows, agreements, returnVersions, auth, commonData
+            )
 
             expect(result.chargeInformation).to.equal([{
               action: [{
@@ -401,7 +427,9 @@ describe('Licences - Set Up presenter', () => {
           })
 
           it('correctly presents the data with the end date', () => {
-            const result = SetUpPresenter.go(chargeVersions, workflows, agreements, returnVersions, auth, commonData)
+            const result = ViewLicenceSetUpPresenter.go(
+              chargeVersions, workflows, agreements, returnVersions, auth, commonData
+            )
 
             expect(result.chargeInformation).to.equal([{
               action: [{
@@ -435,7 +463,9 @@ describe('Licences - Set Up presenter', () => {
             })
 
             it('correctly presents the data and workflow actions', () => {
-              const result = SetUpPresenter.go(chargeVersions, workflows, agreements, returnVersions, auth, commonData)
+              const result = ViewLicenceSetUpPresenter.go(
+                chargeVersions, workflows, agreements, returnVersions, auth, commonData
+              )
 
               expect(result.chargeInformation).to.equal([{
                 action: [{
@@ -454,7 +484,9 @@ describe('Licences - Set Up presenter', () => {
 
           describe('and the user is not permitted to review workflow records', () => {
             it('correctly presents the data and workflow actions', () => {
-              const result = SetUpPresenter.go(chargeVersions, workflows, agreements, returnVersions, auth, commonData)
+              const result = ViewLicenceSetUpPresenter.go(
+                chargeVersions, workflows, agreements, returnVersions, auth, commonData
+              )
 
               expect(result.chargeInformation).to.equal([{
                 action: [],
@@ -480,7 +512,9 @@ describe('Licences - Set Up presenter', () => {
             })
 
             it('correctly presents the data and workflow actions', () => {
-              const result = SetUpPresenter.go(chargeVersions, workflows, agreements, returnVersions, auth, commonData)
+              const result = ViewLicenceSetUpPresenter.go(
+                chargeVersions, workflows, agreements, returnVersions, auth, commonData
+              )
 
               expect(result.chargeInformation).to.equal([{
                 action: [{
@@ -499,7 +533,9 @@ describe('Licences - Set Up presenter', () => {
 
           describe('and the user is not permitted to review workflow records', () => {
             it('correctly presents the data and workflow actions', () => {
-              const result = SetUpPresenter.go(chargeVersions, workflows, agreements, returnVersions, auth, commonData)
+              const result = ViewLicenceSetUpPresenter.go(
+                chargeVersions, workflows, agreements, returnVersions, auth, commonData
+              )
 
               expect(result.chargeInformation).to.equal([{
                 action: [],
@@ -525,7 +561,9 @@ describe('Licences - Set Up presenter', () => {
             })
 
             it('correctly presents the data and workflow actions', () => {
-              const result = SetUpPresenter.go(chargeVersions, workflows, agreements, returnVersions, auth, commonData)
+              const result = ViewLicenceSetUpPresenter.go(
+                chargeVersions, workflows, agreements, returnVersions, auth, commonData
+              )
 
               expect(result.chargeInformation).to.equal([{
                 action: [{
@@ -548,7 +586,9 @@ describe('Licences - Set Up presenter', () => {
             })
 
             it('correctly presents the data and workflow actions', () => {
-              const result = SetUpPresenter.go(chargeVersions, workflows, agreements, returnVersions, auth, commonData)
+              const result = ViewLicenceSetUpPresenter.go(
+                chargeVersions, workflows, agreements, returnVersions, auth, commonData
+              )
 
               expect(result.chargeInformation).to.equal([{
                 action: [],
@@ -569,7 +609,9 @@ describe('Licences - Set Up presenter', () => {
         })
 
         it('correctly presents the returns versions data', () => {
-          const result = SetUpPresenter.go(chargeVersions, workflows, agreements, returnVersions, auth, commonData)
+          const result = ViewLicenceSetUpPresenter.go(
+            chargeVersions, workflows, agreements, returnVersions, auth, commonData
+          )
 
           expect(result.returnVersions).to.equal([
             {
@@ -595,7 +637,9 @@ describe('Licences - Set Up presenter', () => {
           })
 
           it('correctly presents the returns versions data with the missing data defaults', () => {
-            const result = SetUpPresenter.go(chargeVersions, workflows, agreements, returnVersions, auth, commonData)
+            const result = ViewLicenceSetUpPresenter.go(
+              chargeVersions, workflows, agreements, returnVersions, auth, commonData
+            )
 
             expect(result.returnVersions).to.equal([
               {
@@ -632,7 +676,7 @@ describe('Licences - Set Up presenter', () => {
               })
 
               it('correctly presents the set up agreement link ', () => {
-                const result = SetUpPresenter.go(
+                const result = ViewLicenceSetUpPresenter.go(
                   chargeVersions,
                   workflows,
                   agreements,
@@ -656,7 +700,7 @@ describe('Licences - Set Up presenter', () => {
               })
 
               it('the agreement link is not present', () => {
-                const result = SetUpPresenter
+                const result = ViewLicenceSetUpPresenter
                   .go(chargeVersions, workflows, agreements, returnVersions, auth, commonData)
 
                 expect(result.links.agreements.setUpAgreement).to.be.undefined()
@@ -678,7 +722,7 @@ describe('Licences - Set Up presenter', () => {
               })
 
               it('the agreement link is not present', () => {
-                const result = SetUpPresenter.go(
+                const result = ViewLicenceSetUpPresenter.go(
                   chargeVersions,
                   workflows,
                   agreements,
@@ -696,7 +740,7 @@ describe('Licences - Set Up presenter', () => {
           describe('and the user can edit a workflow  ', () => {
             describe('and the licence does not end more than 6 years ago', () => {
               it('return the associated links', () => {
-                const result = SetUpPresenter.go(
+                const result = ViewLicenceSetUpPresenter.go(
                   chargeVersions,
                   workflows,
                   agreements,
@@ -728,7 +772,7 @@ describe('Licences - Set Up presenter', () => {
               })
 
               it('returns no links for editing', () => {
-                const result = SetUpPresenter.go(
+                const result = ViewLicenceSetUpPresenter.go(
                   chargeVersions,
                   workflows,
                   agreements,
@@ -746,7 +790,9 @@ describe('Licences - Set Up presenter', () => {
         describe('when the user wants to manage return versions', () => {
           describe('and the "enableRequirementsForReturns" feature toggle is true', () => {
             it('return the associated links', () => {
-              const result = SetUpPresenter.go(chargeVersions, workflows, agreements, returnVersions, auth, commonData)
+              const result = ViewLicenceSetUpPresenter.go(
+                chargeVersions, workflows, agreements, returnVersions, auth, commonData
+              )
 
               expect(result.links.returnVersions.returnsRequired).to
                 .equal('/system/licences/f91bf145-ce8e-481c-a842-4da90348062b/returns-required')
@@ -761,7 +807,9 @@ describe('Licences - Set Up presenter', () => {
             })
 
             it('return no returnVersions links', () => {
-              const result = SetUpPresenter.go(chargeVersions, workflows, agreements, returnVersions, auth, commonData)
+              const result = ViewLicenceSetUpPresenter.go(
+                chargeVersions, workflows, agreements, returnVersions, auth, commonData
+              )
 
               expect(result.links.returnVersions).to.equal({})
             })
@@ -785,7 +833,9 @@ describe('Licences - Set Up presenter', () => {
             })
 
             it('correctly presents the recalculate bills link', () => {
-              const result = SetUpPresenter.go(chargeVersions, workflows, agreements, returnVersions, auth, commonData)
+              const result = ViewLicenceSetUpPresenter.go(
+                chargeVersions, workflows, agreements, returnVersions, auth, commonData
+              )
 
               expect(result.links.recalculateBills.markForSupplementaryBilling).to.equal(
                 '/system/licences/f91bf145-ce8e-481c-a842-4da90348062b/mark-for-supplementary-billing'
@@ -802,7 +852,9 @@ describe('Licences - Set Up presenter', () => {
             })
 
             it('the recalculate bills link is not present', () => {
-              const result = SetUpPresenter.go(chargeVersions, workflows, agreements, returnVersions, auth, commonData)
+              const result = ViewLicenceSetUpPresenter.go(
+                chargeVersions, workflows, agreements, returnVersions, auth, commonData
+              )
 
               expect(result.recalculateBills).to.be.undefined()
             })
@@ -817,7 +869,9 @@ describe('Licences - Set Up presenter', () => {
           })
 
           it('the recalculate bills link is not present', () => {
-            const result = SetUpPresenter.go(chargeVersions, workflows, agreements, returnVersions, auth, commonData)
+            const result = ViewLicenceSetUpPresenter.go(
+              chargeVersions, workflows, agreements, returnVersions, auth, commonData
+            )
 
             expect(result.recalculateBills).to.be.undefined()
           })


### PR DESCRIPTION
This is just some housekeeping to resolve some inconsistencies spotted when working on another housekeeping task ([Return requirements tidy up](https://github.com/DEFRA/water-abstraction-team/issues/126)).

The view licence 'tab' pages follow the convention `view-licence-[tab name].service.js` in services but have a mixed convention in the presenters.

This is a quick PR to tidy up this inconsistency.