### PR TITLE
Fix testing endpoint for supplementary flags

### DIFF
--- a/app/controllers/check.controller.js
+++ b/app/controllers/check.controller.js
@@ -26,9 +26,9 @@ async function flagForBilling (request, h) {
   const { licenceId, expiredDate, lapsedDate, revokedDate } = request.payload
 
   const transformedLicence = {
-    expiredDate,
-    lapsedDate,
-    revokedDate
+    expiredDate: expiredDate ? new Date(expiredDate) : null,
+    lapsedDate: lapsedDate ? new Date(lapsedDate) : null,
+    revokedDate: revokedDate ? new Date(revokedDate) : null
   }
 
   await DetermineSupplementaryBillingFlagsService.go(transformedLicence, licenceId)


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4591

Recently, a PR was raised to create a testing endpoint for flagging a licence for supplementary billing during the import service. This process looks at the licence end dates and determines what flags should be added to the licence. During testing, the feature wasn't working as expected. 

After some investigation, it turns out that the testing endpoint wasn't configured correctly. When the arguments are passed in the body of the request, it converts everything to a String. This means the data we are mocking is in a `String` data type and not a `Date` data type. We need the object to be a `Date` type as during the import that is what would be fetched from the db. 

This PR fixed the object before being passed to the supplementary flagging process.