### PR TITLE
Fix env var for licence purposes view

### DIFF
--- a/config/feature-flags.config.js
+++ b/config/feature-flags.config.js
@@ -12,7 +12,7 @@ require('dotenv').config()
 const config = {
   // Credit to https://stackoverflow.com/a/323546/6117745 for how to handle
   // converting the env var to a boolean
-  enableLicencePurposesView: (String(process.env.PURPOSES) === 'true') || false,
+  enableLicencePurposesView: (String(process.env.ENABLE_LICENCE_PURPOSES_VIEW) === 'true') || false,
   enableMonitoringStationsView: (String(process.env.ENABLE_MONITORING_STATIONS_VIEW) === 'true') || false,
   enableReissuingBillingBatches: (String(process.env.ENABLE_REISSUING_BILLING_BATCHES) === 'true') || false,
   enableRequirementsForReturns: (String(process.env.ENABLE_REQUIREMENTS_FOR_RETURNS) === 'true') || false,


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4705

As part of the work to move legacy pages into the new system, the licence purposes page was redeveloped and successfully merged in. However, upon testing, it was discovered that the link to the licence purposes page on the licence summary page was still redirecting to the legacy page. Upon inspection, this was due to a misspelling of the environment variable feature flag that shows the new licence purposes page.

This PR fixes the misspelt environment variable and correctly redirects to the new licence purposes page.