### PR TITLE
Add `,` between abstraction points in point model

### DIFF
--- a/app/models/point.model.js
+++ b/app/models/point.model.js
@@ -71,7 +71,7 @@ class PointModel extends BaseModel {
 
     // If ng4 is populated then we know this point is an 'area'
     if (this.ngr4) {
-      abstractionPoint = `Within the area formed by the straight lines running between National Grid References ${this.ngr1} ${this.ngr2} ${this.ngr3} and ${this.ngr4}`
+      abstractionPoint = `Within the area formed by the straight lines running between National Grid References ${this.ngr1}, ${this.ngr2}, ${this.ngr3} and ${this.ngr4}`
     } else if (this.ngr2) {
       // If ng2 is populated then we know this point is a 'reach'
       abstractionPoint = `Between National Grid References ${this.ngr1} and ${this.ngr2}`

--- a/test/models/point.model.test.js
+++ b/test/models/point.model.test.js
@@ -190,7 +190,7 @@ describe('Point model', () => {
         it('returns an "area" description including the supplementary', () => {
           const result = testRecord.$describe()
 
-          expect(result).to.equal('Within the area formed by the straight lines running between National Grid References ST 58212 72697 ST 58151 72683 ST 58145 72727 and ST 58222 72744 (Head office)')
+          expect(result).to.equal('Within the area formed by the straight lines running between National Grid References ST 58212 72697, ST 58151 72683, ST 58145 72727 and ST 58222 72744 (Head office)')
         })
       })
 
@@ -198,7 +198,7 @@ describe('Point model', () => {
         it('returns just the "area" description', () => {
           const result = testRecord.$describe()
 
-          expect(result).to.equal('Within the area formed by the straight lines running between National Grid References ST 58212 72697 ST 58151 72683 ST 58145 72727 and ST 58222 72744')
+          expect(result).to.equal('Within the area formed by the straight lines running between National Grid References ST 58212 72697, ST 58151 72683, ST 58145 72727 and ST 58222 72744')
         })
       })
     })

--- a/test/presenters/return-versions/setup/points.presenter.test.js
+++ b/test/presenters/return-versions/setup/points.presenter.test.js
@@ -55,7 +55,7 @@ describe('Return Versions Setup - Points presenter', () => {
           description: 'Between National Grid References SO 524 692 and SO 531 689 (KIRKENEL FARM ASHFORD CARBONEL - RIVER TEME)'
         }, {
           id: '1c925e6c-a788-4a56-9c1e-ebb46c83ef73',
-          description: 'Within the area formed by the straight lines running between National Grid References NZ 892 055 NZ 895 054 NZ 893 053 and NZ 892 053 (AREA D)'
+          description: 'Within the area formed by the straight lines running between National Grid References NZ 892 055, NZ 895 054, NZ 893 053 and NZ 892 053 (AREA D)'
         }],
         licenceRef: '01/ABC',
         selectedPointIds: '',
@@ -127,7 +127,7 @@ describe('Return Versions Setup - Points presenter', () => {
 
         expect(result.licencePoints).to.equal([{
           id: '1c925e6c-a788-4a56-9c1e-ebb46c83ef73',
-          description: 'Within the area formed by the straight lines running between National Grid References NZ 892 055 NZ 895 054 NZ 893 053 and NZ 892 053 (AREA D)'
+          description: 'Within the area formed by the straight lines running between National Grid References NZ 892 055, NZ 895 054, NZ 893 053 and NZ 892 053 (AREA D)'
         }])
       })
     })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4705

During the testing of the licence purposes page, it was noticed that the legacy page included commas between abstraction points. Within the new system, the abstraction points are generated via the `$describe` modifier on the point model, which is called when fetching data. To keep with the original legacy page format, we will add commas to the `$describe` modifier for multiple abstraction points.

This PR will add commas between abstraction points created by the point model `$describe` modifier.