### PR TITLE
Add quarterly returns submissions to return versions

### DIFF
--- a/app/presenters/return-versions/setup/additional-submission-options.presenter.js
+++ b/app/presenters/return-versions/setup/additional-submission-options.presenter.js
@@ -33,7 +33,6 @@ function go (session) {
 
 /**
  * Checks if the return version is a quarterly returns submission
- * @private
  *
  * A return version is due for quarterly returns submissions when they:
  * - are a water company and the return version start date is > 1 April 2025
@@ -44,6 +43,8 @@ function go (session) {
  * @param {string} startDateDay - The return version start day
  *
  * @returns {boolean}
+ *
+ * @private
  */
 function _quarterlyReturnSubmissions (waterUndertaker, startDateYear, startDateMonth, startDateDay) {
   const returnVersionStartDate = new Date(`${startDateYear}-${startDateMonth}-${startDateDay}`)
@@ -55,7 +56,6 @@ function _quarterlyReturnSubmissions (waterUndertaker, startDateYear, startDateM
 
 /**
  * Determines the default options
- * @private
  *
  * Previous session data takes priority
  * If a return version is for quarterly return submissions then it has it's own defaults to set
@@ -65,6 +65,8 @@ function _quarterlyReturnSubmissions (waterUndertaker, startDateYear, startDateM
  * @param {boolean} quarterlyReturnSubmissions - If the return version is for quarterly return submissions
  *
  * @returns {string[]}
+ *
+ * @private
  */
 function _additionalSubmissionOptions (additionalSubmissionOptions, quarterlyReturnSubmissions) {
   if (additionalSubmissionOptions) {

--- a/app/presenters/return-versions/setup/additional-submission-options.presenter.js
+++ b/app/presenters/return-versions/setup/additional-submission-options.presenter.js
@@ -18,11 +18,11 @@ function go (session) {
     startDateYear, startDateMonth, startDateDay, additionalSubmissionOptions
   } = session
 
-  const quarterlyReturnSubmissions = _quarterlyReturnSubmissions(
-    waterUndertaker, startDateYear, startDateMonth, startDateDay)
+  const quarterlyReturnSubmissions = _quarterlyReturnSubmissions(startDateYear, startDateMonth, startDateDay)
 
   return {
-    additionalSubmissionOptions: _additionalSubmissionOptions(additionalSubmissionOptions, quarterlyReturnSubmissions),
+    additionalSubmissionOptions:
+      _additionalSubmissionOptions(additionalSubmissionOptions, waterUndertaker),
     backLink: `/system/return-versions/setup/${sessionId}/check`,
     licenceId,
     licenceRef,
@@ -37,7 +37,6 @@ function go (session) {
  * A return version is due for quarterly returns submissions when they:
  * - are a water company and the return version start date is > 1 April 2025
  *
- * @param {boolean} waterUndertaker - If the return version is for water company
  * @param {string} startDateYear - The return version start year
  * @param {string} startDateMonth - The return version start month
  * @param {string} startDateDay - The return version start day
@@ -46,12 +45,12 @@ function go (session) {
  *
  * @private
  */
-function _quarterlyReturnSubmissions (waterUndertaker, startDateYear, startDateMonth, startDateDay) {
+function _quarterlyReturnSubmissions (startDateYear, startDateMonth, startDateDay) {
   const returnVersionStartDate = new Date(`${startDateYear}-${startDateMonth}-${startDateDay}`)
 
   const quarterlyReturnSubmissionsStartDate = new Date('2025-04-01')
 
-  return waterUndertaker && returnVersionStartDate.getTime() >= quarterlyReturnSubmissionsStartDate.getTime()
+  return returnVersionStartDate.getTime() >= quarterlyReturnSubmissionsStartDate.getTime()
 }
 
 /**
@@ -62,18 +61,18 @@ function _quarterlyReturnSubmissions (waterUndertaker, startDateYear, startDateM
  * Otherwise default to none
  *
  * @param {string[]} additionalSubmissionOptions - The options set already from session
- * @param {boolean} quarterlyReturnSubmissions - If the return version is for quarterly return submissions
+ * @param {boolean} waterUndertaker - If the return version is for water company
  *
  * @returns {string[]}
  *
  * @private
  */
-function _additionalSubmissionOptions (additionalSubmissionOptions, quarterlyReturnSubmissions) {
+function _additionalSubmissionOptions (additionalSubmissionOptions, waterUndertaker) {
   if (additionalSubmissionOptions) {
     return additionalSubmissionOptions
   }
 
-  if (quarterlyReturnSubmissions) { return ['multiple-upload', 'quarterly-return-submissions'] }
+  if (waterUndertaker) { return ['multiple-upload', 'quarterly-return-submissions'] }
 
   return ['none']
 }

--- a/app/presenters/return-versions/setup/additional-submission-options.presenter.js
+++ b/app/presenters/return-versions/setup/additional-submission-options.presenter.js
@@ -13,16 +13,67 @@
  * @returns {object} - The data formatted for the view template
  */
 function go (session) {
-  const { id: sessionId, licence: { id: licenceId, licenceRef }, additionalSubmissionOptions } = session
-  const data = {
-    additionalSubmissionOptions: additionalSubmissionOptions ?? [],
+  const {
+    id: sessionId, licence: { id: licenceId, licenceRef, waterUndertaker },
+    startDateYear, startDateMonth, startDateDay, additionalSubmissionOptions
+  } = session
+
+  const quarterlyReturnSubmissions = _quarterlyReturnSubmissions(
+    waterUndertaker, startDateYear, startDateMonth, startDateDay)
+
+  return {
+    additionalSubmissionOptions: _additionalSubmissionOptions(additionalSubmissionOptions, quarterlyReturnSubmissions),
     backLink: `/system/return-versions/setup/${sessionId}/check`,
     licenceId,
     licenceRef,
-    sessionId
+    sessionId,
+    quarterlyReturnSubmissions
+  }
+}
+
+/**
+ * Checks if the return version is a quarterly returns submission
+ * @private
+ *
+ * A return version is due for quarterly returns submissions when they:
+ * - are a water company and the return version start date is > 1 April 2025
+ *
+ * @param {boolean} waterUndertaker - If the return version is for water company
+ * @param {string} startDateYear - The return version start year
+ * @param {string} startDateMonth - The return version start month
+ * @param {string} startDateDay - The return version start day
+ *
+ * @returns {boolean}
+ */
+function _quarterlyReturnSubmissions (waterUndertaker, startDateYear, startDateMonth, startDateDay) {
+  const returnVersionStartDate = new Date(`${startDateYear}-${startDateMonth}-${startDateDay}`)
+
+  const quarterlyReturnSubmissionsStartDate = new Date('2025-04-01')
+
+  return waterUndertaker && returnVersionStartDate.getTime() >= quarterlyReturnSubmissionsStartDate.getTime()
+}
+
+/**
+ * Determines the default options
+ * @private
+ *
+ * Previous session data takes priority
+ * If a return version is for quarterly return submissions then it has it's own defaults to set
+ * Otherwise default to none
+ *
+ * @param {string[]} additionalSubmissionOptions - The options set already from session
+ * @param {boolean} quarterlyReturnSubmissions - If the return version is for quarterly return submissions
+ *
+ * @returns {string[]}
+ */
+function _additionalSubmissionOptions (additionalSubmissionOptions, quarterlyReturnSubmissions) {
+  if (additionalSubmissionOptions) {
+    return additionalSubmissionOptions
   }
 
-  return data
+  if (quarterlyReturnSubmissions) { return ['multiple-upload', 'quarterly-return-submissions'] }
+
+  return ['none']
 }
 
 module.exports = {

--- a/app/presenters/return-versions/setup/additional-submission-options.presenter.js
+++ b/app/presenters/return-versions/setup/additional-submission-options.presenter.js
@@ -14,63 +14,18 @@
  */
 function go (session) {
   const {
-    id: sessionId, licence: { id: licenceId, licenceRef, waterUndertaker },
-    returnVersionStartDate, additionalSubmissionOptions
+    id: sessionId, licence: { id: licenceId, licenceRef },
+    additionalSubmissionOptions, quarterlyReturnSubmissions
   } = session
 
-  const quarterlyReturnSubmissions = _quarterlyReturnSubmissions(returnVersionStartDate)
-
   return {
-    additionalSubmissionOptions:
-      _additionalSubmissionOptions(additionalSubmissionOptions, waterUndertaker),
+    additionalSubmissionOptions,
     backLink: `/system/return-versions/setup/${sessionId}/check`,
     licenceId,
     licenceRef,
     sessionId,
     quarterlyReturnSubmissions
   }
-}
-
-/**
- * Checks if the return version is a quarterly returns submission
- *
- * A return version is due for quarterly returns submissions when they:
- * - are a water company and the return version start date is > 1 April 2025
- *
- * @param {string} returnVersionStartDate - The return version start date
- *
- * @returns {boolean}
- *
- * @private
- */
-function _quarterlyReturnSubmissions (returnVersionStartDate) {
-  const quarterlyReturnSubmissionsStartDate = new Date('2025-04-01')
-
-  return new Date(returnVersionStartDate).getTime() >= quarterlyReturnSubmissionsStartDate.getTime()
-}
-
-/**
- * Determines the default options
- *
- * Previous session data takes priority
- * If a return version is for quarterly return submissions then it has it's own defaults to set
- * Otherwise default to none
- *
- * @param {string[]} additionalSubmissionOptions - The options set already from session
- * @param {boolean} waterUndertaker - If the return version is for water company
- *
- * @returns {string[]}
- *
- * @private
- */
-function _additionalSubmissionOptions (additionalSubmissionOptions, waterUndertaker) {
-  if (additionalSubmissionOptions) {
-    return additionalSubmissionOptions
-  }
-
-  if (waterUndertaker) { return ['multiple-upload', 'quarterly-return-submissions'] }
-
-  return ['none']
 }
 
 module.exports = {

--- a/app/presenters/return-versions/setup/additional-submission-options.presenter.js
+++ b/app/presenters/return-versions/setup/additional-submission-options.presenter.js
@@ -15,10 +15,10 @@
 function go (session) {
   const {
     id: sessionId, licence: { id: licenceId, licenceRef, waterUndertaker },
-    startDateYear, startDateMonth, startDateDay, additionalSubmissionOptions
+    returnVersionStartDate, additionalSubmissionOptions
   } = session
 
-  const quarterlyReturnSubmissions = _quarterlyReturnSubmissions(startDateYear, startDateMonth, startDateDay)
+  const quarterlyReturnSubmissions = _quarterlyReturnSubmissions(returnVersionStartDate)
 
   return {
     additionalSubmissionOptions:
@@ -37,20 +37,16 @@ function go (session) {
  * A return version is due for quarterly returns submissions when they:
  * - are a water company and the return version start date is > 1 April 2025
  *
- * @param {string} startDateYear - The return version start year
- * @param {string} startDateMonth - The return version start month
- * @param {string} startDateDay - The return version start day
+ * @param {string} returnVersionStartDate - The return version start date
  *
  * @returns {boolean}
  *
  * @private
  */
-function _quarterlyReturnSubmissions (startDateYear, startDateMonth, startDateDay) {
-  const returnVersionStartDate = new Date(`${startDateYear}-${startDateMonth}-${startDateDay}`)
-
+function _quarterlyReturnSubmissions (returnVersionStartDate) {
   const quarterlyReturnSubmissionsStartDate = new Date('2025-04-01')
 
-  return returnVersionStartDate.getTime() >= quarterlyReturnSubmissionsStartDate.getTime()
+  return new Date(returnVersionStartDate).getTime() >= quarterlyReturnSubmissionsStartDate.getTime()
 }
 
 /**

--- a/app/presenters/return-versions/setup/additional-submission-options.presenter.js
+++ b/app/presenters/return-versions/setup/additional-submission-options.presenter.js
@@ -19,7 +19,7 @@ function go (session) {
   } = session
 
   return {
-    additionalSubmissionOptions,
+    additionalSubmissionOptions: additionalSubmissionOptions ?? ['none'],
     backLink: `/system/return-versions/setup/${sessionId}/check`,
     licenceId,
     licenceRef,

--- a/app/presenters/return-versions/setup/check/check.presenter.js
+++ b/app/presenters/return-versions/setup/check/check.presenter.js
@@ -16,12 +16,16 @@ const { returnRequirementReasons } = require('../../../../lib/static-lookups.lib
  * @returns {object} The data formatted for the view template
  */
 function go (session) {
-  const { additionalSubmissionOptions, id: sessionId, journey, licence, note, reason } = session
+  const {
+    additionalSubmissionOptions, quarterlyReturnSubmissions,
+    id: sessionId, journey, licence, note, reason
+  } = session
 
   const returnsRequired = journey === 'returns-required'
 
   return {
     additionalSubmissionOptions: additionalSubmissionOptions ?? [],
+    quarterlyReturnSubmissions,
     licenceRef: licence.licenceRef,
     note: _note(note),
     pageTitle: `Check the requirements for returns for ${licence.licenceHolder}`,

--- a/app/services/return-versions/setup/check/check.service.js
+++ b/app/services/return-versions/setup/check/check.service.js
@@ -7,6 +7,7 @@
 
 const CheckPresenter = require('../../../../presenters/return-versions/setup/check/check.presenter.js')
 const FetchPointsService = require('../fetch-points.service.js')
+const RecalculateAdditionalOptions = require('./recalculate-additional-options.service.js')
 const ReturnRequirementsPresenter = require('../../../../presenters/return-versions/setup/check/returns-requirements.presenter.js')
 const SessionModel = require('../../../../models/session.model.js')
 
@@ -24,6 +25,8 @@ async function go (sessionId, yar) {
   await _markCheckPageVisited(session)
 
   const returnRequirements = await _returnRequirements(session)
+
+  RecalculateAdditionalOptions.go(session)
 
   const formattedData = CheckPresenter.go(session)
 

--- a/app/services/return-versions/setup/check/check.service.js
+++ b/app/services/return-versions/setup/check/check.service.js
@@ -26,7 +26,7 @@ async function go (sessionId, yar) {
 
   const returnRequirements = await _returnRequirements(session)
 
-  RecalculateAdditionalOptions.go(session)
+  await RecalculateAdditionalOptions.go(session)
 
   const formattedData = CheckPresenter.go(session)
 

--- a/app/services/return-versions/setup/check/recalculate-additional-options.service.js
+++ b/app/services/return-versions/setup/check/recalculate-additional-options.service.js
@@ -1,0 +1,98 @@
+'use strict'
+
+/**
+ * Recalculate additional options when the start date has changed
+ * @module RecalculateAdditionalOptions
+ */
+
+/**
+ * Recalculate additional options when the start date has changed
+ *
+ * @param {module:SessionModel} session - The returns requirements session instance
+ *
+ * @returns {object} - The data formatted for the view template
+ */
+function go (session) {
+  const {
+    licence: { waterUndertaker },
+    returnVersionStartDate, additionalSubmissionOptions, startDateUpdated
+  } = session
+
+  const quarterlyReturnSubmissions = _quarterlyReturnSubmissions(returnVersionStartDate)
+
+  session.quarterlyReturnSubmissions = quarterlyReturnSubmissions
+  session.additionalSubmissionOptions = _additionalSubmissionOptions(
+    additionalSubmissionOptions, waterUndertaker, startDateUpdated, quarterlyReturnSubmissions)
+
+  // We need to set this to false to allow the session
+  session.startDateUpdated = false
+
+  return session.$update()
+}
+
+/**
+ * Checks if the return version is a quarterly returns submission
+ *
+ * A return version is due for quarterly returns submissions when they:
+ * - are a water company and the return version start date is > 1 April 2025
+ *
+ * @param {string} returnVersionStartDate - The return version start date
+ *
+ * @returns {boolean}
+ *
+ * @private
+ */
+function _quarterlyReturnSubmissions (returnVersionStartDate) {
+  const quarterlyReturnSubmissionsStartDate = new Date('2025-04-01')
+
+  return new Date(returnVersionStartDate).getTime() >= quarterlyReturnSubmissionsStartDate.getTime()
+}
+
+/**
+ * Determines the default options
+ *
+ * Previous session data takes priority
+ * If a return version is for quarterly return submissions then it has its own defaults to set
+ * Otherwise default to none
+ *
+ * @param {string[]} additionalSubmissionOptions - The options set already from session
+ * @param {boolean} waterUndertaker - If the return version is for water company
+ * @param {boolean} startDateUpdated - If start date has been updated
+ * @param {boolean} quarterlyReturnSubmissions - If the return version is a quarterly return
+ *
+ * @returns {string[]}
+ *
+ * @private
+ */
+function _additionalSubmissionOptions (
+  additionalSubmissionOptions, waterUndertaker, startDateUpdated, quarterlyReturnSubmissions) {
+  if (!startDateUpdated && additionalSubmissionOptions) {
+    //  fix this logic
+    if (additionalSubmissionOptions) {
+      return additionalSubmissionOptions
+    } else {
+      return _calculateDefaults(waterUndertaker, quarterlyReturnSubmissions)
+    }
+  } else {
+    return _calculateDefaults(waterUndertaker, quarterlyReturnSubmissions)
+  }
+}
+
+function _calculateDefaults (waterUndertaker, quarterlyReturnSubmissions) {
+  const options = []
+
+  if (waterUndertaker && quarterlyReturnSubmissions) {
+    options.push('multiple-upload')
+    options.push('quarterly-return-submissions')
+  } else if (waterUndertaker) {
+    options.push('multiple-upload')
+  } else {
+    options.push('none')
+  }
+
+  return options
+}
+
+module.exports = {
+  go
+}

--- a/app/services/return-versions/setup/check/recalculate-additional-options.service.js
+++ b/app/services/return-versions/setup/check/recalculate-additional-options.service.js
@@ -12,7 +12,7 @@
  *
  * @returns {object} - The data formatted for the view template
  */
-function go (session) {
+async function go (session) {
   const {
     licence: { waterUndertaker },
     returnVersionStartDate, additionalSubmissionOptions, startDateUpdated

--- a/app/services/return-versions/setup/initiate-session.service.js
+++ b/app/services/return-versions/setup/initiate-session.service.js
@@ -45,7 +45,7 @@ async function _createSession (data) {
 }
 
 function _data (licence, journey) {
-  const { id, licenceRef, licenceVersions, returnVersions, startDate } = licence
+  const { id, licenceRef, licenceVersions, returnVersions, startDate, waterUndertaker } = licence
   const ends = licence.$ends()
 
   return {
@@ -57,7 +57,8 @@ function _data (licence, journey) {
       licenceRef,
       licenceHolder: licence.$licenceHolder(),
       returnVersions,
-      startDate
+      startDate,
+      waterUndertaker
     },
     journey,
     requirements: [{}]
@@ -73,7 +74,8 @@ async function _fetchLicence (licenceId) {
       'lapsedDate',
       'licenceRef',
       'revokedDate',
-      'startDate'
+      'startDate',
+      'waterUndertaker'
     ])
     .withGraphFetched('licenceVersions')
     .modifyGraph('licenceVersions', (builder) => {

--- a/app/services/return-versions/setup/submit-start-date.service.js
+++ b/app/services/return-versions/setup/submit-start-date.service.js
@@ -61,6 +61,8 @@ async function _save (session, payload) {
 
   session.startDateOptions = selectedOption
 
+  const oldReturnVersionStartDate = session.returnVersionStartDate
+
   if (selectedOption === 'anotherStartDate') {
     session.startDateDay = payload['start-date-day']
     session.startDateMonth = payload['start-date-month']
@@ -70,6 +72,10 @@ async function _save (session, payload) {
     session.returnVersionStartDate = new Date(`${payload['start-date-year']}-${payload['start-date-month'] - 1}-${payload['start-date-day']}`).toISOString().split('T')[0]
   } else {
     session.returnVersionStartDate = new Date(session.licence.currentVersionStartDate).toISOString().split('T')[0]
+  }
+
+  if (oldReturnVersionStartDate) {
+    session.startDateUpdated = oldReturnVersionStartDate !== session.returnVersionStartDate
   }
 
   return session.$update()

--- a/app/views/return-versions/setup/additional-submission-options.njk
+++ b/app/views/return-versions/setup/additional-submission-options.njk
@@ -56,8 +56,19 @@
           {
             value: "multiple-upload",
             text: "Multiple upload",
-            checked: additionalSubmissionOptions.includes("multiple-upload")
+            checked: additionalSubmissionOptions.includes("multiple-upload"),
+            hint: {
+              text: "Allow large abstractors, such as water companies, to submit returns for multiple licences at the same time."
+            }
           },
+          {
+            value: "quarterly-return-submissions",
+            text: "Quarterly returns submissions",
+            checked: additionalSubmissionOptions.includes("quarterly-return-submissions"),
+            hint: {
+              text: "Allow water companies to submit daliy readings each quarter."
+            }
+          } if quarterlyReturnSubmissions,
           {
             divider: "or"
           },

--- a/app/views/return-versions/setup/check.njk
+++ b/app/views/return-versions/setup/check.njk
@@ -355,7 +355,17 @@
               value: {
                 text: 'Yes' if additionalSubmissionOptions.includes('multiple-upload') else "No"
               }
+            },
+            {
+              classes: 'govuk-summary-list govuk-summary-list__row--no-border',
+              key: {
+              text: 'Quarterly returns submissions',
+              classes: "govuk-body "
+            },
+              value: {
+              text: 'Yes' if additionalSubmissionOptions.includes('quarterly-return-submissions') else "No"
             }
+            } if quarterlyReturnSubmissions
           ]
         }) }}
         {% else %}

--- a/test/presenters/return-versions/setup/additional-submission-options.presenter.test.js
+++ b/test/presenters/return-versions/setup/additional-submission-options.presenter.test.js
@@ -80,29 +80,43 @@ describe('Return Versions Setup - Additional Submission Options presenter', () =
 
   describe('the "quarterlyReturnSubmissions" property', () => {
     describe('when the return version is for quarterly return submissions', () => {
-      describe('the option for quarterly return submissions is present', () => {
-        beforeEach(() => {
-          session.licence.waterUndertaker = true
-          session.startDateYear = '2025'
-          session.startDateMonth = '4'
-          session.startDateDay = '1'
-        })
+      beforeEach(() => {
+        session.licence.waterUndertaker = true
+        session.startDateYear = '2025'
+        session.startDateMonth = '4'
+        session.startDateDay = '1'
+      })
 
-        it('returns the options', () => {
+      it('returns quarterly returns submissions as true', () => {
+        const result = AdditionalSubmissionOptionsPresenter.go(session)
+
+        expect(result.quarterlyReturnSubmissions).to.equal(true)
+      })
+
+      describe('and the licence holder is a water company', () => {
+        it('returns the default options', () => {
           const result = AdditionalSubmissionOptionsPresenter.go(session)
 
-          expect(result.quarterlyReturnSubmissions).to.equal(true)
+          expect(result.additionalSubmissionOptions).to.include('multiple-upload')
           expect(result.additionalSubmissionOptions).to.include('quarterly-return-submissions')
         })
       })
 
-      describe('the option for quarterly return submissions is present but the session options have previously been set', () => {
+      describe('and the licence holder is not a water company', () => {
+        beforeEach(() => {
+          session.licence.waterUndertaker = false
+        })
+
+        it('returns the default options', () => {
+          const result = AdditionalSubmissionOptionsPresenter.go(session)
+
+          expect(result.additionalSubmissionOptions).to.equal(['none'])
+        })
+      })
+
+      describe('and there is existing session data', () => {
         beforeEach(() => {
           session.additionalSubmissionOptions = ['none']
-          session.licence.waterUndertaker = true
-          session.startDateYear = '2025'
-          session.startDateMonth = '4'
-          session.startDateDay = '1'
         })
 
         it('returns the session options', () => {
@@ -111,26 +125,26 @@ describe('Return Versions Setup - Additional Submission Options presenter', () =
           expect(result.additionalSubmissionOptions).to.include('none')
         })
       })
-
-      describe('the option for quarterly return submissions is defaulted if no previous session is set', () => {
-        beforeEach(() => {
-          session.licence.waterUndertaker = true
-          session.startDateYear = '2025'
-          session.startDateMonth = '4'
-          session.startDateDay = '1'
-        })
-
-        it('returns the options', () => {
-          const result = AdditionalSubmissionOptionsPresenter.go(session)
-
-          expect(result.additionalSubmissionOptions).to.include('multiple-upload')
-          expect(result.additionalSubmissionOptions).to.include('quarterly-return-submissions')
-        })
-      })
     })
 
     describe('when the return version is not for quarterly return submissions', () => {
-      describe('when the licence is not for a water company', () => {
+      beforeEach(() => {
+        session.licence.waterUndertaker = true
+        session.startDateYear = '2025'
+        session.startDateMonth = '3'
+        session.startDateDay = '31'
+      })
+
+      describe('and the licence is for a water company', () => {
+        it('returns the options', () => {
+          const result = AdditionalSubmissionOptionsPresenter.go(session)
+
+          expect(result.quarterlyReturnSubmissions).to.be.false()
+          expect(result.additionalSubmissionOptions).to.equal(['multiple-upload', 'quarterly-return-submissions'])
+        })
+      })
+
+      describe('and the licence is not for a water company', () => {
         beforeEach(() => {
           session.licence.waterUndertaker = false
         })
@@ -139,23 +153,7 @@ describe('Return Versions Setup - Additional Submission Options presenter', () =
           const result = AdditionalSubmissionOptionsPresenter.go(session)
 
           expect(result.quarterlyReturnSubmissions).to.be.false()
-          expect(result.additionalSubmissionOptions).to.not.include('quarterly-return-submissions')
-        })
-      })
-
-      describe('when the licence is for a water company but the start date is past the quarterly returns submissions date', () => {
-        beforeEach(() => {
-          session.licence.waterUndertaker = true
-          session.startDateYear = '2025'
-          session.startDateMonth = '3'
-          session.startDateDay = '31'
-        })
-
-        it('returns the options', () => {
-          const result = AdditionalSubmissionOptionsPresenter.go(session)
-
-          expect(result.quarterlyReturnSubmissions).to.be.false()
-          expect(result.additionalSubmissionOptions).to.not.include('quarterly-return-submissions')
+          expect(result.additionalSubmissionOptions).to.equal(['none'])
         })
       })
     })

--- a/test/presenters/return-versions/setup/additional-submission-options.presenter.test.js
+++ b/test/presenters/return-versions/setup/additional-submission-options.presenter.test.js
@@ -23,7 +23,8 @@ describe('Return Versions Setup - Additional Submission Options presenter', () =
         endDate: null,
         licenceRef: '01/ABC',
         licenceHolder: 'Turbo Kid',
-        startDate: '2022-04-01T00:00:00.000Z'
+        startDate: '2022-04-01T00:00:00.000Z',
+        waterUndertaker: false
       },
       journey: 'returns-required',
       requirements: [{}],
@@ -39,9 +40,10 @@ describe('Return Versions Setup - Additional Submission Options presenter', () =
       expect(result).to.be.equal({
         backLink: `/system/return-versions/setup/${session.id}/check`,
         licenceId: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
-        additionalSubmissionOptions: [],
+        additionalSubmissionOptions: ['none'],
         licenceRef: '01/ABC',
-        sessionId: session.id
+        sessionId: session.id,
+        quarterlyReturnSubmissions: false
       })
     })
   })
@@ -71,7 +73,90 @@ describe('Return Versions Setup - Additional Submission Options presenter', () =
       it('returns empty options', () => {
         const result = AdditionalSubmissionOptionsPresenter.go(session)
 
-        expect(result.additionalSubmissionOptions).to.be.empty()
+        expect(result.additionalSubmissionOptions).to.equal(['none'])
+      })
+    })
+  })
+
+  describe('the "quarterlyReturnSubmissions" property', () => {
+    describe('when the return version is for quarterly return submissions', () => {
+      describe('the option for quarterly return submissions is present', () => {
+        beforeEach(() => {
+          session.licence.waterUndertaker = true
+          session.startDateYear = '2025'
+          session.startDateMonth = '4'
+          session.startDateDay = '1'
+        })
+
+        it('returns the options', () => {
+          const result = AdditionalSubmissionOptionsPresenter.go(session)
+
+          expect(result.quarterlyReturnSubmissions).to.equal(true)
+          expect(result.additionalSubmissionOptions).to.include('quarterly-return-submissions')
+        })
+      })
+
+      describe('the option for quarterly return submissions is present but the session options have previously been set', () => {
+        beforeEach(() => {
+          session.additionalSubmissionOptions = ['none']
+          session.licence.waterUndertaker = true
+          session.startDateYear = '2025'
+          session.startDateMonth = '4'
+          session.startDateDay = '1'
+        })
+
+        it('returns the session options', () => {
+          const result = AdditionalSubmissionOptionsPresenter.go(session)
+
+          expect(result.additionalSubmissionOptions).to.include('none')
+        })
+      })
+
+      describe('the option for quarterly return submissions is defaulted if no previous session is set', () => {
+        beforeEach(() => {
+          session.licence.waterUndertaker = true
+          session.startDateYear = '2025'
+          session.startDateMonth = '4'
+          session.startDateDay = '1'
+        })
+
+        it('returns the options', () => {
+          const result = AdditionalSubmissionOptionsPresenter.go(session)
+
+          expect(result.additionalSubmissionOptions).to.include('multiple-upload')
+          expect(result.additionalSubmissionOptions).to.include('quarterly-return-submissions')
+        })
+      })
+    })
+
+    describe('when the return version is not for quarterly return submissions', () => {
+      describe('when the licence is not for a water company', () => {
+        beforeEach(() => {
+          session.licence.waterUndertaker = false
+        })
+
+        it('returns the options', () => {
+          const result = AdditionalSubmissionOptionsPresenter.go(session)
+
+          expect(result.quarterlyReturnSubmissions).to.be.false()
+          expect(result.additionalSubmissionOptions).to.not.include('quarterly-return-submissions')
+        })
+      })
+
+      describe('when the licence is for a water company but the start date is past the quarterly returns submissions date', () => {
+        beforeEach(() => {
+          session.licence.waterUndertaker = true
+          session.startDateYear = '2025'
+          session.startDateMonth = '3'
+          session.startDateDay = '31'
+        })
+
+        it('returns the options', () => {
+          const result = AdditionalSubmissionOptionsPresenter.go(session)
+
+          expect(result.quarterlyReturnSubmissions).to.be.false()
+          expect(result.additionalSubmissionOptions).to.not.include('quarterly-return-submissions')
+        })
       })
     })
   })

--- a/test/presenters/return-versions/setup/additional-submission-options.presenter.test.js
+++ b/test/presenters/return-versions/setup/additional-submission-options.presenter.test.js
@@ -54,99 +54,91 @@ describe('Return Versions Setup - Additional Submission Options presenter', () =
   })
 
   describe('the "additionalSubmissionOptions" property', () => {
-    describe('when the user has previously submitted additional submission options', () => {
-      beforeEach(() => {
-        session.additionalSubmissionOptions = ['multiple-upload']
-      })
-
-      it('returns the options', () => {
-        const result = AdditionalSubmissionOptionsPresenter.go(session)
-
-        expect(result.additionalSubmissionOptions).to.include('multiple-upload')
-      })
-    })
-
-    describe('when the user has not previously chosen options', () => {
-      it('returns empty options', () => {
-        const result = AdditionalSubmissionOptionsPresenter.go(session)
-
-        expect(result.additionalSubmissionOptions).to.equal(['none'])
-      })
-    })
-  })
-
-  describe('the "quarterlyReturnSubmissions" property', () => {
-    describe('when the return version is for quarterly return submissions', () => {
-      beforeEach(() => {
-        session.licence.waterUndertaker = true
-        session.returnVersionStartDate = '2025-04-01'
-      })
-
-      it('returns quarterly returns submissions as true', () => {
-        const result = AdditionalSubmissionOptionsPresenter.go(session)
-
-        expect(result.quarterlyReturnSubmissions).to.equal(true)
-      })
-
-      describe('and the licence holder is a water company', () => {
-        it('returns the default options', () => {
-          const result = AdditionalSubmissionOptionsPresenter.go(session)
-
-          expect(result.additionalSubmissionOptions).to.include('multiple-upload')
-          expect(result.additionalSubmissionOptions).to.include('quarterly-return-submissions')
-        })
-      })
-
-      describe('and the licence holder is not a water company', () => {
+    describe('when the return version start date', () => {
+      describe('has been updated', () => {
         beforeEach(() => {
-          session.licence.waterUndertaker = false
+          session.startDateUpdated = true
         })
 
-        it('returns the default options', () => {
-          const result = AdditionalSubmissionOptionsPresenter.go(session)
+        describe('and the return version is for a water company', () => {
+          beforeEach(() => {
+            session.licence.waterUndertaker = true
+          })
 
-          expect(result.additionalSubmissionOptions).to.equal(['none'])
+          describe('and is not a quarterly return ', () => {
+            beforeEach(() => {
+              session.returnVersionStartDate = '2025-03-01'
+            })
+
+            it('return the water company default', () => {
+              const result = AdditionalSubmissionOptionsPresenter.go(session)
+
+              expect(result.additionalSubmissionOptions).to.equal(['multiple-upload'])
+            })
+          })
+
+          describe('and is a quarterly return', () => {
+            beforeEach(() => {
+              session.returnVersionStartDate = '2025-04-01'
+            })
+
+            it('returns the default for water company and quarterly return', () => {
+              const result = AdditionalSubmissionOptionsPresenter.go(session)
+
+              expect(result.additionalSubmissionOptions).to.equal(['multiple-upload', 'quarterly-return-submissions'])
+            })
+          })
+        })
+
+        describe('and the return version is not for a water company', () => {
+          beforeEach(() => {
+            session.returnVersionStartDate = '2025-03-01'
+            session.licence.waterUndertaker = false
+          })
+
+          it('return none as the default', () => {
+            const result = AdditionalSubmissionOptionsPresenter.go(session)
+
+            expect(result.additionalSubmissionOptions).to.equal(['none'])
+          })
         })
       })
-
-      describe('and there is existing session data', () => {
+      describe('has not been updated', () => {
         beforeEach(() => {
           session.additionalSubmissionOptions = ['none']
+          session.startDateUpdated = false
         })
 
-        it('returns the session options', () => {
+        it('uses the session data', () => {
           const result = AdditionalSubmissionOptionsPresenter.go(session)
 
-          expect(result.additionalSubmissionOptions).to.include('none')
+          expect(result.additionalSubmissionOptions).to.equal(['none'])
         })
       })
     })
 
-    describe('when the return version is not for quarterly return submissions', () => {
-      beforeEach(() => {
-        session.licence.waterUndertaker = true
-        session.returnVersionStartDate = '2025-03-01'
-      })
-
-      describe('and the licence is for a water company', () => {
-        it('returns the options', () => {
-          const result = AdditionalSubmissionOptionsPresenter.go(session)
-
-          expect(result.quarterlyReturnSubmissions).to.be.false()
-          expect(result.additionalSubmissionOptions).to.equal(['multiple-upload', 'quarterly-return-submissions'])
-        })
-      })
-
-      describe('and the licence is not for a water company', () => {
+    describe('the "quarterlyReturnSubmissions" property', () => {
+      describe('when the return version is for quarterly return submissions', () => {
         beforeEach(() => {
-          session.licence.waterUndertaker = false
+          session.returnVersionStartDate = '2025-04-01'
         })
 
-        it('returns the options', () => {
+        it('returns "quarterlyReturnSubmissions" as true', () => {
           const result = AdditionalSubmissionOptionsPresenter.go(session)
 
-          expect(result.quarterlyReturnSubmissions).to.be.false()
-          expect(result.additionalSubmissionOptions).to.equal(['none'])
+          expect(result.quarterlyReturnSubmissions).to.equal(true)
+        })
+      })
+
+      describe('when the return version is not for quarterly return submissions', () => {
+        beforeEach(() => {
+          session.returnVersionStartDate = '2025-03-20'
+        })
+
+        it('returns "quarterlyReturnSubmissions" as true', () => {
+          const result = AdditionalSubmissionOptionsPresenter.go(session)
+
+          expect(result.quarterlyReturnSubmissions).to.equal(false)
         })
       })
     })

--- a/test/presenters/return-versions/setup/additional-submission-options.presenter.test.js
+++ b/test/presenters/return-versions/setup/additional-submission-options.presenter.test.js
@@ -19,16 +19,13 @@ describe('Return Versions Setup - Additional Submission Options presenter', () =
       checkPageVisited: false,
       licence: {
         id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
-        currentVersionStartDate: '2023-01-01T00:00:00.000Z',
         endDate: null,
         licenceRef: '01/ABC',
         licenceHolder: 'Turbo Kid',
-        startDate: '2022-04-01T00:00:00.000Z',
         waterUndertaker: false
       },
       journey: 'returns-required',
       requirements: [{}],
-      startDateOptions: 'licenceStartDate',
       reason: 'major-change'
     }
   })
@@ -82,9 +79,7 @@ describe('Return Versions Setup - Additional Submission Options presenter', () =
     describe('when the return version is for quarterly return submissions', () => {
       beforeEach(() => {
         session.licence.waterUndertaker = true
-        session.startDateYear = '2025'
-        session.startDateMonth = '4'
-        session.startDateDay = '1'
+        session.returnVersionStartDate = '2025-04-01'
       })
 
       it('returns quarterly returns submissions as true', () => {
@@ -130,9 +125,7 @@ describe('Return Versions Setup - Additional Submission Options presenter', () =
     describe('when the return version is not for quarterly return submissions', () => {
       beforeEach(() => {
         session.licence.waterUndertaker = true
-        session.startDateYear = '2025'
-        session.startDateMonth = '3'
-        session.startDateDay = '31'
+        session.returnVersionStartDate = '2025-03-01'
       })
 
       describe('and the licence is for a water company', () => {

--- a/test/presenters/return-versions/setup/additional-submission-options.presenter.test.js
+++ b/test/presenters/return-versions/setup/additional-submission-options.presenter.test.js
@@ -25,6 +25,7 @@ describe('Return Versions Setup - Additional Submission Options presenter', () =
         waterUndertaker: false
       },
       journey: 'returns-required',
+      quarterlyReturnSubmissions: false,
       requirements: [{}],
       reason: 'major-change'
     }
@@ -54,93 +55,13 @@ describe('Return Versions Setup - Additional Submission Options presenter', () =
   })
 
   describe('the "additionalSubmissionOptions" property', () => {
-    describe('when the return version start date', () => {
-      describe('has been updated', () => {
-        beforeEach(() => {
-          session.startDateUpdated = true
-        })
-
-        describe('and the return version is for a water company', () => {
-          beforeEach(() => {
-            session.licence.waterUndertaker = true
-          })
-
-          describe('and is not a quarterly return ', () => {
-            beforeEach(() => {
-              session.returnVersionStartDate = '2025-03-01'
-            })
-
-            it('return the water company default', () => {
-              const result = AdditionalSubmissionOptionsPresenter.go(session)
-
-              expect(result.additionalSubmissionOptions).to.equal(['multiple-upload'])
-            })
-          })
-
-          describe('and is a quarterly return', () => {
-            beforeEach(() => {
-              session.returnVersionStartDate = '2025-04-01'
-            })
-
-            it('returns the default for water company and quarterly return', () => {
-              const result = AdditionalSubmissionOptionsPresenter.go(session)
-
-              expect(result.additionalSubmissionOptions).to.equal(['multiple-upload', 'quarterly-return-submissions'])
-            })
-          })
-        })
-
-        describe('and the return version is not for a water company', () => {
-          beforeEach(() => {
-            session.returnVersionStartDate = '2025-03-01'
-            session.licence.waterUndertaker = false
-          })
-
-          it('return none as the default', () => {
-            const result = AdditionalSubmissionOptionsPresenter.go(session)
-
-            expect(result.additionalSubmissionOptions).to.equal(['none'])
-          })
-        })
-      })
-      describe('has not been updated', () => {
-        beforeEach(() => {
-          session.additionalSubmissionOptions = ['none']
-          session.startDateUpdated = false
-        })
-
-        it('uses the session data', () => {
-          const result = AdditionalSubmissionOptionsPresenter.go(session)
-
-          expect(result.additionalSubmissionOptions).to.equal(['none'])
-        })
-      })
+    beforeEach(() => {
+      session.additionalSubmissionOptions = ['multiple-upload']
     })
+    it('returns the object with session data', () => {
+      const result = AdditionalSubmissionOptionsPresenter.go(session)
 
-    describe('the "quarterlyReturnSubmissions" property', () => {
-      describe('when the return version is for quarterly return submissions', () => {
-        beforeEach(() => {
-          session.returnVersionStartDate = '2025-04-01'
-        })
-
-        it('returns "quarterlyReturnSubmissions" as true', () => {
-          const result = AdditionalSubmissionOptionsPresenter.go(session)
-
-          expect(result.quarterlyReturnSubmissions).to.equal(true)
-        })
-      })
-
-      describe('when the return version is not for quarterly return submissions', () => {
-        beforeEach(() => {
-          session.returnVersionStartDate = '2025-03-20'
-        })
-
-        it('returns "quarterlyReturnSubmissions" as true', () => {
-          const result = AdditionalSubmissionOptionsPresenter.go(session)
-
-          expect(result.quarterlyReturnSubmissions).to.equal(false)
-        })
-      })
+      expect(result.additionalSubmissionOptions).to.equal(['multiple-upload'])
     })
   })
 })

--- a/test/presenters/return-versions/setup/check/check.presenter.test.js
+++ b/test/presenters/return-versions/setup/check/check.presenter.test.js
@@ -15,8 +15,9 @@ describe('Return Versions Setup - Check presenter', () => {
 
   beforeEach(() => {
     session = {
-      id: '61e07498-f309-4829-96a9-72084a54996d',
+      additionalSubmissionOptions: ['none'],
       checkPageVisited: false,
+      id: '61e07498-f309-4829-96a9-72084a54996d',
       journey: 'returns-required',
       licence: {
         id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
@@ -26,9 +27,10 @@ describe('Return Versions Setup - Check presenter', () => {
         licenceHolder: 'Turbo Kid',
         startDate: '2022-04-01T00:00:00.000Z'
       },
+      quarterlyReturnSubmissions: true,
+      reason: 'major-change',
       returnVersionStartDate: '2023-01-01',
-      startDateOptions: 'licenceStartDate',
-      reason: 'major-change'
+      startDateOptions: 'licenceStartDate'
     }
   })
 
@@ -37,7 +39,7 @@ describe('Return Versions Setup - Check presenter', () => {
       const result = CheckPresenter.go(session)
 
       expect(result).to.equal({
-        additionalSubmissionOptions: [],
+        additionalSubmissionOptions: ['none'],
         licenceRef: '01/ABC',
         note: {
           actions: [
@@ -49,6 +51,7 @@ describe('Return Versions Setup - Check presenter', () => {
           text: 'No notes added'
         },
         pageTitle: 'Check the requirements for returns for Turbo Kid',
+        quarterlyReturnSubmissions: true,
         reason: 'Major change',
         reasonLink: '/system/return-versions/setup/61e07498-f309-4829-96a9-72084a54996d/reason',
         sessionId: '61e07498-f309-4829-96a9-72084a54996d',
@@ -71,10 +74,10 @@ describe('Return Versions Setup - Check presenter', () => {
     })
 
     describe('when the user has not checked an option', () => {
-      it('returns no options', () => {
+      it('returns none option', () => {
         const result = CheckPresenter.go(session)
 
-        expect(result.additionalSubmissionOptions).to.be.empty()
+        expect(result.additionalSubmissionOptions).to.equal(['none'])
       })
     })
   })

--- a/test/services/return-versions/setup/additional-submission-options.service.test.js
+++ b/test/services/return-versions/setup/additional-submission-options.service.test.js
@@ -20,6 +20,7 @@ describe('Return Versions Setup - Additional Submission Options service', () => 
     session = await SessionHelper.add({
       data: {
         checkPageVisited: false,
+        journey: 'returns-required',
         licence: {
           id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
           endDate: null,
@@ -27,10 +28,10 @@ describe('Return Versions Setup - Additional Submission Options service', () => 
           licenceHolder: 'Turbo Kid',
           waterUndertaker: false
         },
-        journey: 'returns-required',
+        quarterlyReturnSubmissions: false,
+        reason: 'major-change',
         requirements: [{}],
-        startDateOptions: 'licenceStartDate',
-        reason: 'major-change'
+        startDateOptions: 'licenceStartDate'
       }
     })
   })

--- a/test/services/return-versions/setup/additional-submission-options.service.test.js
+++ b/test/services/return-versions/setup/additional-submission-options.service.test.js
@@ -22,11 +22,9 @@ describe('Return Versions Setup - Additional Submission Options service', () => 
         checkPageVisited: false,
         licence: {
           id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
-          currentVersionStartDate: '2023-01-01T00:00:00.000Z',
           endDate: null,
           licenceRef: '01/ABC',
           licenceHolder: 'Turbo Kid',
-          startDate: '2022-04-01T00:00:00.000Z',
           waterUndertaker: false
         },
         journey: 'returns-required',

--- a/test/services/return-versions/setup/additional-submission-options.service.test.js
+++ b/test/services/return-versions/setup/additional-submission-options.service.test.js
@@ -26,7 +26,8 @@ describe('Return Versions Setup - Additional Submission Options service', () => 
           endDate: null,
           licenceRef: '01/ABC',
           licenceHolder: 'Turbo Kid',
-          startDate: '2022-04-01T00:00:00.000Z'
+          startDate: '2022-04-01T00:00:00.000Z',
+          waterUndertaker: false
         },
         journey: 'returns-required',
         requirements: [{}],
@@ -48,11 +49,12 @@ describe('Return Versions Setup - Additional Submission Options service', () => 
 
       expect(result).to.equal({
         activeNavBar: 'search',
-        additionalSubmissionOptions: [],
+        additionalSubmissionOptions: ['none'],
         backLink: `/system/return-versions/setup/${session.id}/check`,
         licenceId: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
         licenceRef: '01/ABC',
-        pageTitle: 'Select any additional submission options for the return requirements'
+        pageTitle: 'Select any additional submission options for the return requirements',
+        quarterlyReturnSubmissions: false
       }, { skip: ['sessionId'] })
     })
   })

--- a/test/services/return-versions/setup/check/check.service.test.js
+++ b/test/services/return-versions/setup/check/check.service.test.js
@@ -25,6 +25,7 @@ describe('Return Versions Setup - Check service', () => {
     session = await SessionHelper.add({
       data: {
         checkPageVisited: false,
+        journey: 'returns-required',
         licence: {
           id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
           currentVersionStartDate: '2023-01-01T00:00:00.000Z',
@@ -33,11 +34,10 @@ describe('Return Versions Setup - Check service', () => {
           licenceHolder: 'Turbo Kid',
           startDate: '2022-04-01T00:00:00.000Z'
         },
-        returnVersionStartDate: '2023-01-01',
-        journey: 'returns-required',
+        reason: 'major-change',
         requirements: [{}],
-        startDateOptions: 'licenceStartDate',
-        reason: 'major-change'
+        returnVersionStartDate: '2023-01-01',
+        startDateOptions: 'licenceStartDate'
       }
     })
 
@@ -60,7 +60,7 @@ describe('Return Versions Setup - Check service', () => {
 
       expect(result).to.equal({
         activeNavBar: 'search',
-        additionalSubmissionOptions: [],
+        additionalSubmissionOptions: ['none'],
         licenceRef: '01/ABC',
         note: {
           actions: [
@@ -73,6 +73,7 @@ describe('Return Versions Setup - Check service', () => {
         },
         notification: undefined,
         pageTitle: 'Check the requirements for returns for Turbo Kid',
+        quarterlyReturnSubmissions: false,
         reason: 'Major change',
         reasonLink: `/system/return-versions/setup/${session.id}/reason`,
         requirements: [],

--- a/test/services/return-versions/setup/check/recalculate-additional-options.service.test.js
+++ b/test/services/return-versions/setup/check/recalculate-additional-options.service.test.js
@@ -1,0 +1,127 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Test helpers
+const SessionHelper = require('../../../../support/helpers/session.helper.js')
+
+// Thing under test
+const RecalculateAdditionalOptions = require('../../../../../app/services/return-versions/setup/check/recalculate-additional-options.service.js')
+
+describe.skip('Return Versions Check - Recalculate additional options', () => {
+  let session
+
+  beforeEach(async () => {
+    session = await SessionHelper.add({
+      data: {
+        licence: {
+          waterUndertaker: false
+        }
+      }
+    })
+  })
+
+  describe('when called', () => {
+    it('fetches the current setup session record', async () => {
+      await RecalculateAdditionalOptions.go(session)
+
+      expect(session).to.equal({})
+    })
+  })
+
+  // describe('the "additionalSubmissionOptions" property', () => {
+  //   describe('when the return version start date', () => {
+  //     describe('has been updated', () => {
+  //       beforeEach(() => {
+  //         session.startDateUpdated = true
+  //       })
+  //
+  //       describe('and the return version is for a water company', () => {
+  //         beforeEach(() => {
+  //           session.licence.waterUndertaker = true
+  //         })
+  //
+  //         describe('and is not a quarterly return ', () => {
+  //           beforeEach(() => {
+  //             session.returnVersionStartDate = '2025-03-01'
+  //           })
+  //
+  //           it('return the water company default', () => {
+  //             const result = AdditionalSubmissionOptionsPresenter.go(session)
+  //
+  //             expect(result.additionalSubmissionOptions).to.equal(['multiple-upload'])
+  //           })
+  //         })
+  //
+  //         describe('and is a quarterly return', () => {
+  //           beforeEach(() => {
+  //             session.returnVersionStartDate = '2025-04-01'
+  //           })
+  //
+  //           it('returns the default for water company and quarterly return', () => {
+  //             const result = AdditionalSubmissionOptionsPresenter.go(session)
+  //
+  //             expect(result.additionalSubmissionOptions).to.equal(['multiple-upload', 'quarterly-return-submissions'])
+  //           })
+  //         })
+  //       })
+  //
+  //       describe('and the return version is not for a water company', () => {
+  //         beforeEach(() => {
+  //           session.returnVersionStartDate = '2025-03-01'
+  //           session.licence.waterUndertaker = false
+  //         })
+  //
+  //         it('return none as the default', () => {
+  //           const result = AdditionalSubmissionOptionsPresenter.go(session)
+  //
+  //           expect(result.additionalSubmissionOptions).to.equal(['none'])
+  //         })
+  //       })
+  //     })
+  //     describe('has not been updated', () => {
+  //       beforeEach(() => {
+  //         session.additionalSubmissionOptions = ['none']
+  //         session.startDateUpdated = false
+  //       })
+  //
+  //       it('uses the session data', () => {
+  //         const result = AdditionalSubmissionOptionsPresenter.go(session)
+  //
+  //         expect(result.additionalSubmissionOptions).to.equal(['none'])
+  //       })
+  //     })
+  //   })
+  //
+  //   describe('the "quarterlyReturnSubmissions" property', () => {
+  //     describe('when the return version is for quarterly return submissions', () => {
+  //       beforeEach(() => {
+  //         session.returnVersionStartDate = '2025-04-01'
+  //       })
+  //
+  //       it('returns "quarterlyReturnSubmissions" as true', () => {
+  //         const result = AdditionalSubmissionOptionsPresenter.go(session)
+  //
+  //         expect(result.quarterlyReturnSubmissions).to.equal(true)
+  //       })
+  //     })
+  //
+  //     describe('when the return version is not for quarterly return submissions', () => {
+  //       beforeEach(() => {
+  //         session.returnVersionStartDate = '2025-03-20'
+  //       })
+  //
+  //       it('returns "quarterlyReturnSubmissions" as true', () => {
+  //         const result = AdditionalSubmissionOptionsPresenter.go(session)
+  //
+  //         expect(result.quarterlyReturnSubmissions).to.equal(false)
+  //       })
+  //     })
+  //   })
+  // })
+})

--- a/test/services/return-versions/setup/initiate-session.service.test.js
+++ b/test/services/return-versions/setup/initiate-session.service.test.js
@@ -64,7 +64,8 @@ describe('Return Versions Setup - Initiate Session service', () => {
             licenceRef,
             licenceHolder: 'Licence Holder Ltd',
             returnVersions: [],
-            startDate: new Date('2022-01-01')
+            startDate: new Date('2022-01-01'),
+            waterUndertaker: false
           },
           journey: 'returns-required',
           requirements: [{}]

--- a/test/services/return-versions/setup/submit-additional-submission-options.service.test.js
+++ b/test/services/return-versions/setup/submit-additional-submission-options.service.test.js
@@ -35,7 +35,8 @@ describe('Return Versions Setup - Submit Additional Submission Options service',
             reason: null,
             modLogs: []
           }],
-          startDate: '2022-04-01T00:00:00.000Z'
+          startDate: '2022-04-01T00:00:00.000Z',
+          waterUndertaker: false
         },
         journey: 'returns-required',
         requirements: [{}],
@@ -90,7 +91,8 @@ describe('Return Versions Setup - Submit Additional Submission Options service',
           backLink: `/system/return-versions/setup/${session.id}/check`,
           pageTitle: 'Select any additional submission options for the return requirements',
           licenceRef: '01/ABC',
-          additionalSubmissionOptions: [undefined]
+          additionalSubmissionOptions: [undefined],
+          quarterlyReturnSubmissions: false
         }, { skip: ['id', 'sessionId', 'error', 'licenceId'] })
       })
 

--- a/test/services/return-versions/setup/submit-additional-submission-options.service.test.js
+++ b/test/services/return-versions/setup/submit-additional-submission-options.service.test.js
@@ -14,7 +14,7 @@ const SessionHelper = require('../../../support/helpers/session.helper.js')
 // Thing under test
 const SubmitAdditionalSubmissionOptionsService = require('../../../../app/services/return-versions/setup/submit-additional-submission-options.service.js')
 
-describe('Return Versions Setup - Submit Additional Submission Options service', () => {
+describe.only('Return Versions Setup - Submit Additional Submission Options service', () => {
   let payload
   let session
   let yarStub
@@ -23,6 +23,7 @@ describe('Return Versions Setup - Submit Additional Submission Options service',
     session = await SessionHelper.add({
       data: {
         checkPageVisited: false,
+        journey: 'returns-required',
         licence: {
           id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
           currentVersionStartDate: '2023-01-01T00:00:00.000Z',
@@ -35,13 +36,14 @@ describe('Return Versions Setup - Submit Additional Submission Options service',
             reason: null,
             modLogs: []
           }],
+          additionalSubmissionOptions: ['none'],
+          quarterlyReturnSubmissions: false,
           startDate: '2022-04-01T00:00:00.000Z',
           waterUndertaker: false
         },
-        journey: 'returns-required',
+        reason: 'major-change',
         requirements: [{}],
-        startDateOptions: 'licenceStartDate',
-        reason: 'major-change'
+        startDateOptions: 'licenceStartDate'
       }
     })
 
@@ -92,7 +94,7 @@ describe('Return Versions Setup - Submit Additional Submission Options service',
           pageTitle: 'Select any additional submission options for the return requirements',
           licenceRef: '01/ABC',
           additionalSubmissionOptions: [undefined],
-          quarterlyReturnSubmissions: false
+          quarterlyReturnSubmissions: undefined
         }, { skip: ['id', 'sessionId', 'error', 'licenceId'] })
       })
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4707

As part of the quarterly returns submissions work, we need to add a new checkbox to the additional-submission-options page for the Quarterly returns submissions.

This has introduced some logic to determine if the return version is for a water company and if the return version start date is beyond the start of quarterly returns.