### PR TITLE
Add quarterly returns submissions to return versions

### DIFF
--- a/app/presenters/return-versions/setup/additional-submission-options.presenter.js
+++ b/app/presenters/return-versions/setup/additional-submission-options.presenter.js
@@ -13,16 +13,19 @@
  * @returns {object} - The data formatted for the view template
  */
 function go (session) {
-  const { id: sessionId, licence: { id: licenceId, licenceRef }, additionalSubmissionOptions } = session
-  const data = {
+  const {
+    id: sessionId, licence: { id: licenceId, licenceRef },
+    additionalSubmissionOptions, quarterlyReturnSubmissions
+  } = session
+
+  return {
     additionalSubmissionOptions: additionalSubmissionOptions ?? [],
     backLink: `/system/return-versions/setup/${sessionId}/check`,
     licenceId,
     licenceRef,
+    quarterlyReturnSubmissions,
     sessionId
   }
-
-  return data
 }
 
 module.exports = {

--- a/app/presenters/return-versions/setup/check/check.presenter.js
+++ b/app/presenters/return-versions/setup/check/check.presenter.js
@@ -16,7 +16,10 @@ const { returnRequirementReasons } = require('../../../../lib/static-lookups.lib
  * @returns {object} The data formatted for the view template
  */
 function go (session) {
-  const { additionalSubmissionOptions, id: sessionId, journey, licence, note, reason } = session
+  const {
+    additionalSubmissionOptions, quarterlyReturnSubmissions,
+    id: sessionId, journey, licence, note, reason
+  } = session
 
   const returnsRequired = journey === 'returns-required'
 
@@ -25,6 +28,7 @@ function go (session) {
     licenceRef: licence.licenceRef,
     note: _note(note),
     pageTitle: `Check the requirements for returns for ${licence.licenceHolder}`,
+    quarterlyReturnSubmissions,
     reason: returnRequirementReasons[reason],
     reasonLink: _reasonLink(sessionId, returnsRequired),
     sessionId,

--- a/app/services/return-versions/setup/check/check.service.js
+++ b/app/services/return-versions/setup/check/check.service.js
@@ -7,6 +7,7 @@
 
 const CheckPresenter = require('../../../../presenters/return-versions/setup/check/check.presenter.js')
 const FetchPointsService = require('../fetch-points.service.js')
+const QuarterlyReturnsService = require('./quarterly-returns.service.js')
 const ReturnRequirementsPresenter = require('../../../../presenters/return-versions/setup/check/returns-requirements.presenter.js')
 const SessionModel = require('../../../../models/session.model.js')
 
@@ -24,6 +25,8 @@ async function go (sessionId, yar) {
   await _markCheckPageVisited(session)
 
   const returnRequirements = await _returnRequirements(session)
+
+  await QuarterlyReturnsService.go(session)
 
   const formattedData = CheckPresenter.go(session)
 

--- a/app/services/return-versions/setup/check/quarterly-returns.service.js
+++ b/app/services/return-versions/setup/check/quarterly-returns.service.js
@@ -1,0 +1,96 @@
+'use strict'
+
+/**
+ * Quarterly returns service
+ * @module QuarterlyReturnsService
+ */
+
+/**
+ * Quarterly returns service
+ *
+ * @param {module:SessionModel} session - The returns requirements session instance
+ *
+ * @returns {object} - The data formatted for the view template
+ */
+async function go (session) {
+  const {
+    licence: { waterUndertaker },
+    returnVersionStartDate, additionalSubmissionOptions, startDateUpdated
+  } = session
+
+  const quarterlyReturnSubmissions = _quarterlyReturnSubmissions(returnVersionStartDate)
+
+  session.quarterlyReturnSubmissions = quarterlyReturnSubmissions
+  session.additionalSubmissionOptions = _additionalSubmissionOptions(
+    additionalSubmissionOptions, waterUndertaker, startDateUpdated, quarterlyReturnSubmissions)
+
+  // We need to set this to false to allow the session
+  session.startDateUpdated = false
+
+  return session.$update()
+}
+
+/**
+ * Checks if the return version is a quarterly returns submission
+ *
+ * A return version is due for quarterly returns submissions when they:
+ * - are a water company and the return version start date is > 1 April 2025
+ *
+ * @param {string} returnVersionStartDate - The return version start date
+ *
+ * @returns {boolean}
+ *
+ * @private
+ */
+function _quarterlyReturnSubmissions (returnVersionStartDate) {
+  const quarterlyReturnSubmissionsStartDate = new Date('2025-04-01')
+
+  return new Date(returnVersionStartDate).getTime() >= quarterlyReturnSubmissionsStartDate.getTime()
+}
+
+/**
+ * Determines the default options
+ *
+ * Previous session data takes priority
+ * If a return version is for quarterly return submissions then it has its own defaults to set
+ * Otherwise default to none
+ *
+ * @param {string[]} additionalSubmissionOptions - The options set already from session
+ * @param {boolean} waterUndertaker - If the return version is for water company
+ * @param {boolean} startDateUpdated - If start date has been updated
+ * @param {boolean} quarterlyReturnSubmissions - If the return version is a quarterly return
+ *
+ * @returns {string[]}
+ *
+ * @private
+ */
+function _additionalSubmissionOptions (
+  additionalSubmissionOptions, waterUndertaker, startDateUpdated, quarterlyReturnSubmissions) {
+  if (!startDateUpdated && additionalSubmissionOptions) {
+    //  fix this logic
+    if (additionalSubmissionOptions) {
+      return additionalSubmissionOptions
+    } else {
+      return _calculateDefaults(waterUndertaker, quarterlyReturnSubmissions)
+    }
+  }
+
+  return _calculateDefaults(waterUndertaker, quarterlyReturnSubmissions)
+}
+
+function _calculateDefaults (waterUndertaker, quarterlyReturnSubmissions) {
+  const options = []
+
+  if (waterUndertaker && quarterlyReturnSubmissions) {
+    options.push('multiple-upload')
+    options.push('quarterly-return-submissions')
+  } else if (waterUndertaker) {
+    options.push('multiple-upload')
+  }
+
+  return options
+}
+
+module.exports = {
+  go
+}

--- a/app/services/return-versions/setup/initiate-session.service.js
+++ b/app/services/return-versions/setup/initiate-session.service.js
@@ -45,19 +45,20 @@ async function _createSession (data) {
 }
 
 function _data (licence, journey) {
-  const { id, licenceRef, licenceVersions, returnVersions, startDate } = licence
+  const { id, licenceRef, licenceVersions, returnVersions, startDate, waterUndertaker } = licence
   const ends = licence.$ends()
 
   return {
     checkPageVisited: false,
     licence: {
-      id,
       currentVersionStartDate: _currentVersionStartDate(licenceVersions),
       endDate: ends ? ends.date : null,
-      licenceRef,
+      id,
       licenceHolder: licence.$licenceHolder(),
+      licenceRef,
       returnVersions,
-      startDate
+      startDate,
+      waterUndertaker
     },
     journey,
     requirements: [{}]
@@ -68,12 +69,13 @@ async function _fetchLicence (licenceId) {
   const licence = await LicenceModel.query()
     .findById(licenceId)
     .select([
-      'id',
       'expiredDate',
+      'id',
       'lapsedDate',
       'licenceRef',
       'revokedDate',
-      'startDate'
+      'startDate',
+      'waterUndertaker'
     ])
     .withGraphFetched('licenceVersions')
     .modifyGraph('licenceVersions', (builder) => {

--- a/app/services/return-versions/setup/submit-start-date.service.js
+++ b/app/services/return-versions/setup/submit-start-date.service.js
@@ -61,6 +61,8 @@ async function _save (session, payload) {
 
   session.startDateOptions = selectedOption
 
+  const oldReturnVersionStartDate = session.returnVersionStartDate
+
   if (selectedOption === 'anotherStartDate') {
     session.startDateDay = payload['start-date-day']
     session.startDateMonth = payload['start-date-month']
@@ -70,6 +72,10 @@ async function _save (session, payload) {
     session.returnVersionStartDate = new Date(`${payload['start-date-year']}-${payload['start-date-month'] - 1}-${payload['start-date-day']}`).toISOString().split('T')[0]
   } else {
     session.returnVersionStartDate = new Date(session.licence.currentVersionStartDate).toISOString().split('T')[0]
+  }
+
+  if (oldReturnVersionStartDate) {
+    session.startDateUpdated = oldReturnVersionStartDate !== session.returnVersionStartDate
   }
 
   return session.$update()

--- a/app/views/return-versions/setup/additional-submission-options.njk
+++ b/app/views/return-versions/setup/additional-submission-options.njk
@@ -56,8 +56,19 @@
           {
             value: "multiple-upload",
             text: "Multiple upload",
-            checked: additionalSubmissionOptions.includes("multiple-upload")
+            checked: additionalSubmissionOptions.includes("multiple-upload"),
+            hint: {
+              text: "Allow large abstractors, such as water companies, to submit returns for multiple licences at the same time."
+            }
           },
+          {
+            value: "quarterly-return-submissions",
+            text: "Quarterly returns submissions",
+            checked: additionalSubmissionOptions.includes("quarterly-return-submissions"),
+            hint: {
+              text: "Allow water companies to submit daliy readings each quarter."
+            }
+          } if quarterlyReturnSubmissions,
           {
             divider: "or"
           },

--- a/app/views/return-versions/setup/check.njk
+++ b/app/views/return-versions/setup/check.njk
@@ -355,7 +355,17 @@
               value: {
                 text: 'Yes' if additionalSubmissionOptions.includes('multiple-upload') else "No"
               }
+            },
+            {
+              classes: 'govuk-summary-list govuk-summary-list__row--no-border',
+              key: {
+              text: 'Quarterly returns submissions',
+              classes: "govuk-body "
+            },
+              value: {
+              text: 'Yes' if additionalSubmissionOptions.includes('quarterly-return-submissions') else "No"
             }
+            } if quarterlyReturnSubmissions
           ]
         }) }}
         {% else %}

--- a/test/presenters/return-versions/setup/additional-submission-options.presenter.test.js
+++ b/test/presenters/return-versions/setup/additional-submission-options.presenter.test.js
@@ -16,19 +16,11 @@ describe('Return Versions Setup - Additional Submission Options presenter', () =
   beforeEach(() => {
     session = {
       id: '61e07498-f309-4829-96a9-72084a54996d',
-      checkPageVisited: false,
       licence: {
         id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
-        currentVersionStartDate: '2023-01-01T00:00:00.000Z',
-        endDate: null,
-        licenceRef: '01/ABC',
-        licenceHolder: 'Turbo Kid',
-        startDate: '2022-04-01T00:00:00.000Z'
+        licenceRef: '01/ABC'
       },
-      journey: 'returns-required',
-      requirements: [{}],
-      startDateOptions: 'licenceStartDate',
-      reason: 'major-change'
+      quarterlyReturnSubmissions: false
     }
   })
 
@@ -37,10 +29,11 @@ describe('Return Versions Setup - Additional Submission Options presenter', () =
       const result = AdditionalSubmissionOptionsPresenter.go(session)
 
       expect(result).to.be.equal({
+        additionalSubmissionOptions: [],
         backLink: `/system/return-versions/setup/${session.id}/check`,
         licenceId: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
-        additionalSubmissionOptions: [],
         licenceRef: '01/ABC',
+        quarterlyReturnSubmissions: false,
         sessionId: session.id
       })
     })

--- a/test/presenters/return-versions/setup/check/check.presenter.test.js
+++ b/test/presenters/return-versions/setup/check/check.presenter.test.js
@@ -15,8 +15,8 @@ describe('Return Versions Setup - Check presenter', () => {
 
   beforeEach(() => {
     session = {
-      id: '61e07498-f309-4829-96a9-72084a54996d',
       checkPageVisited: false,
+      id: '61e07498-f309-4829-96a9-72084a54996d',
       journey: 'returns-required',
       licence: {
         id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
@@ -26,9 +26,10 @@ describe('Return Versions Setup - Check presenter', () => {
         licenceHolder: 'Turbo Kid',
         startDate: '2022-04-01T00:00:00.000Z'
       },
+      quarterlyReturnSubmissions: false,
+      reason: 'major-change',
       returnVersionStartDate: '2023-01-01',
-      startDateOptions: 'licenceStartDate',
-      reason: 'major-change'
+      startDateOptions: 'licenceStartDate'
     }
   })
 
@@ -49,6 +50,7 @@ describe('Return Versions Setup - Check presenter', () => {
           text: 'No notes added'
         },
         pageTitle: 'Check the requirements for returns for Turbo Kid',
+        quarterlyReturnSubmissions: false,
         reason: 'Major change',
         reasonLink: '/system/return-versions/setup/61e07498-f309-4829-96a9-72084a54996d/reason',
         sessionId: '61e07498-f309-4829-96a9-72084a54996d',
@@ -66,7 +68,19 @@ describe('Return Versions Setup - Check presenter', () => {
       it('returns a checked option', () => {
         const result = CheckPresenter.go(session)
 
-        expect(result.additionalSubmissionOptions).to.include('multiple-upload')
+        expect(result.additionalSubmissionOptions).to.equal(['multiple-upload'])
+      })
+    })
+
+    describe('when the user has default additionalSubmissionOptions', () => {
+      beforeEach(() => {
+        session.additionalSubmissionOptions = ['multiple-upload', 'quarterly-return-submissions']
+      })
+
+      it('returns a checked option', () => {
+        const result = CheckPresenter.go(session)
+
+        expect(result.additionalSubmissionOptions).to.equal(['multiple-upload', 'quarterly-return-submissions'])
       })
     })
 

--- a/test/services/return-versions/setup/additional-submission-options.service.test.js
+++ b/test/services/return-versions/setup/additional-submission-options.service.test.js
@@ -19,19 +19,13 @@ describe('Return Versions Setup - Additional Submission Options service', () => 
   beforeEach(async () => {
     session = await SessionHelper.add({
       data: {
-        checkPageVisited: false,
         licence: {
           id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
-          currentVersionStartDate: '2023-01-01T00:00:00.000Z',
           endDate: null,
           licenceRef: '01/ABC',
-          licenceHolder: 'Turbo Kid',
-          startDate: '2022-04-01T00:00:00.000Z'
+          licenceHolder: 'Turbo Kid'
         },
-        journey: 'returns-required',
-        requirements: [{}],
-        startDateOptions: 'licenceStartDate',
-        reason: 'major-change'
+        quarterlyReturnSubmissions: false
       }
     })
   })
@@ -52,7 +46,8 @@ describe('Return Versions Setup - Additional Submission Options service', () => 
         backLink: `/system/return-versions/setup/${session.id}/check`,
         licenceId: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
         licenceRef: '01/ABC',
-        pageTitle: 'Select any additional submission options for the return requirements'
+        pageTitle: 'Select any additional submission options for the return requirements',
+        quarterlyReturnSubmissions: false
       }, { skip: ['sessionId'] })
     })
   })

--- a/test/services/return-versions/setup/check/check.service.test.js
+++ b/test/services/return-versions/setup/check/check.service.test.js
@@ -73,6 +73,7 @@ describe('Return Versions Setup - Check service', () => {
         },
         notification: undefined,
         pageTitle: 'Check the requirements for returns for Turbo Kid',
+        quarterlyReturnSubmissions: false,
         reason: 'Major change',
         reasonLink: `/system/return-versions/setup/${session.id}/reason`,
         requirements: [],

--- a/test/services/return-versions/setup/initiate-session.service.test.js
+++ b/test/services/return-versions/setup/initiate-session.service.test.js
@@ -58,13 +58,14 @@ describe('Return Versions Setup - Initiate Session service', () => {
         expect(data).to.equal({
           checkPageVisited: false,
           licence: {
-            id: licence.id,
             currentVersionStartDate: new Date('2022-05-01'),
             endDate: new Date('2024-08-10'),
-            licenceRef,
+            id: licence.id,
             licenceHolder: 'Licence Holder Ltd',
+            licenceRef,
             returnVersions: [],
-            startDate: new Date('2022-01-01')
+            startDate: new Date('2022-01-01'),
+            waterUndertaker: false
           },
           journey: 'returns-required',
           requirements: [{}]

--- a/test/services/return-versions/setup/submit-additional-submission-options.service.test.js
+++ b/test/services/return-versions/setup/submit-additional-submission-options.service.test.js
@@ -22,25 +22,11 @@ describe('Return Versions Setup - Submit Additional Submission Options service',
   beforeEach(async () => {
     session = await SessionHelper.add({
       data: {
-        checkPageVisited: false,
         licence: {
           id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
-          currentVersionStartDate: '2023-01-01T00:00:00.000Z',
-          endDate: null,
-          licenceRef: '01/ABC',
-          licenceHolder: 'Turbo Kid',
-          returnVersions: [{
-            id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
-            startDate: '2023-01-01T00:00:00.000Z',
-            reason: null,
-            modLogs: []
-          }],
-          startDate: '2022-04-01T00:00:00.000Z'
+          licenceRef: '01/ABC'
         },
-        journey: 'returns-required',
-        requirements: [{}],
-        startDateOptions: 'licenceStartDate',
-        reason: 'major-change'
+        quarterlyReturnSubmissions: false
       }
     })
 
@@ -87,10 +73,11 @@ describe('Return Versions Setup - Submit Additional Submission Options service',
 
         expect(result).to.equal({
           activeNavBar: 'search',
+          additionalSubmissionOptions: [undefined],
           backLink: `/system/return-versions/setup/${session.id}/check`,
-          pageTitle: 'Select any additional submission options for the return requirements',
           licenceRef: '01/ABC',
-          additionalSubmissionOptions: [undefined]
+          pageTitle: 'Select any additional submission options for the return requirements',
+          quarterlyReturnSubmissions: false
         }, { skip: ['id', 'sessionId', 'error', 'licenceId'] })
       })
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4707

As part of the quarterly returns submissions work, we need to add a new checkbox to the additional-submission-options page for the Quarterly returns submissions.

This has introduced some logic to determine if the return version is for a water company and if the return version start date is beyond the start of quarterly returns.