### PR TITLE
Fix broken return version start date page

### DIFF
--- a/app/services/return-versions/setup/submit-start-date.service.js
+++ b/app/services/return-versions/setup/submit-start-date.service.js
@@ -69,7 +69,7 @@ async function _save (session, payload) {
     // January is actually 0, February is 1 etc. This is why we deduct 1 from the month.
     session.returnVersionStartDate = new Date(`${payload['start-date-year']}-${payload['start-date-month'] - 1}-${payload['start-date-day']}`).toISOString().split('T')[0]
   } else {
-    session.returnVersionStartDate = new Date(session.licence.currentVersionStartDate).toISOString().split('T')[0]
+    session.returnVersionStartDate = new Date(session.licence.currentVersionStartDate)
   }
 
   return session.$update()

--- a/app/services/return-versions/setup/submit-start-date.service.js
+++ b/app/services/return-versions/setup/submit-start-date.service.js
@@ -65,9 +65,7 @@ async function _save (session, payload) {
     session.startDateDay = payload['start-date-day']
     session.startDateMonth = payload['start-date-month']
     session.startDateYear = payload['start-date-year']
-    // Reminder! Because of the unique qualities of Javascript, Year and Day are literal values, month is an index! So,
-    // January is actually 0, February is 1 etc. This is why we deduct 1 from the month.
-    session.returnVersionStartDate = new Date(`${payload['start-date-year']}-${payload['start-date-month'] - 1}-${payload['start-date-day']}`).toISOString().split('T')[0]
+    session.returnVersionStartDate = new Date(`${payload['start-date-year']}-${payload['start-date-month']}-${payload['start-date-day']}`)
   } else {
     session.returnVersionStartDate = new Date(session.licence.currentVersionStartDate)
   }

--- a/test/services/return-versions/setup/check/generate-return-version.service.test.js
+++ b/test/services/return-versions/setup/check/generate-return-version.service.test.js
@@ -81,7 +81,7 @@ describe('Return Versions Setup - Generate Return Version service', () => {
       expect(result.returnVersion.multipleUpload).to.be.false()
       expect(result.returnVersion.notes).to.be.undefined()
       expect(result.returnVersion.reason).to.equal(sessionData.reason)
-      expect(result.returnVersion.startDate).to.equal(new Date('2023-02-13 '))
+      expect(result.returnVersion.startDate).to.equal(new Date('2023-02-13'))
       expect(result.returnVersion.status).to.equal('current')
       // Version number is 103 because this is the next version number after the previous version
       expect(result.returnVersion.version).to.equal(103)
@@ -134,7 +134,7 @@ describe('Return Versions Setup - Generate Return Version service', () => {
       expect(result.returnVersion.multipleUpload).to.be.true()
       expect(result.returnVersion.notes).to.equal(sessionData.note.content)
       expect(result.returnVersion.reason).to.equal(sessionData.reason)
-      expect(result.returnVersion.startDate).to.equal(new Date('2023-02-13 '))
+      expect(result.returnVersion.startDate).to.equal(new Date('2023-02-13'))
       expect(result.returnVersion.status).to.equal('current')
       // Version number is 1 because no previous return versions exist
       expect(result.returnVersion.version).to.equal(1)
@@ -179,7 +179,7 @@ describe('Return Versions Setup - Generate Return Version service', () => {
       expect(result.returnVersion.multipleUpload).to.be.false()
       expect(result.returnVersion.notes).to.be.undefined()
       expect(result.returnVersion.reason).to.equal(sessionData.reason)
-      expect(result.returnVersion.startDate).to.equal(new Date('2023-02-13 '))
+      expect(result.returnVersion.startDate).to.equal(new Date('2023-02-13'))
       expect(result.returnVersion.status).to.equal('current')
       expect(result.returnVersion.version).to.equal(1)
     })

--- a/test/services/return-versions/setup/check/generate-return-version.service.test.js
+++ b/test/services/return-versions/setup/check/generate-return-version.service.test.js
@@ -61,7 +61,7 @@ describe('Return Versions Setup - Generate Return Version service', () => {
           ],
           currentVersionStartDate: '2023-02-13T00:00:00.000Z'
         },
-        returnVersionStartDate: '2023-02-13',
+        returnVersionStartDate: '2023-02-13T00:00:00.000Z',
         requirements: ['return requirements data'],
         checkPageVisited: true,
         startDateOptions: 'licenceStartDate'

--- a/test/services/return-versions/setup/submit-start-date.service.test.js
+++ b/test/services/return-versions/setup/submit-start-date.service.test.js
@@ -58,12 +58,13 @@ describe('Return Versions Setup - Submit Start Date service', () => {
         }
       })
 
-      it('saves the submitted option', async () => {
+      it.only('saves the submitted option', async () => {
         await SubmitStartDateService.go(session.id, payload, yarStub)
 
         const refreshedSession = await session.$query()
 
         expect(refreshedSession.startDateOptions).to.equal('licenceStartDate')
+        expect(new Date(refreshedSession.returnVersionStartDate)).to.equal(new Date('2023-01-01'))
       })
 
       describe('and the page has been not been visited', () => {

--- a/test/services/return-versions/setup/submit-start-date.service.test.js
+++ b/test/services/return-versions/setup/submit-start-date.service.test.js
@@ -119,7 +119,7 @@ describe('Return Versions Setup - Submit Start Date service', () => {
         expect(refreshedSession.startDateDay).to.equal('26')
         expect(refreshedSession.startDateMonth).to.equal('11')
         expect(refreshedSession.startDateYear).to.equal('2023')
-        expect(refreshedSession.returnVersionStartDate).to.equal('2023-10-26')
+        expect(refreshedSession.returnVersionStartDate).to.equal('2023-11-26')
       })
 
       it('returns the correct details the controller needs to redirect the journey', async () => {

--- a/test/services/return-versions/setup/submit-start-date.service.test.js
+++ b/test/services/return-versions/setup/submit-start-date.service.test.js
@@ -119,7 +119,7 @@ describe('Return Versions Setup - Submit Start Date service', () => {
         expect(refreshedSession.startDateDay).to.equal('26')
         expect(refreshedSession.startDateMonth).to.equal('11')
         expect(refreshedSession.startDateYear).to.equal('2023')
-        expect(refreshedSession.returnVersionStartDate).to.equal('2023-11-26')
+        expect(new Date(refreshedSession.returnVersionStartDate)).to.equal(new Date('2023-11-26'))
       })
 
       it('returns the correct details the controller needs to redirect the journey', async () => {

--- a/test/services/return-versions/setup/submit-start-date.service.test.js
+++ b/test/services/return-versions/setup/submit-start-date.service.test.js
@@ -58,7 +58,7 @@ describe('Return Versions Setup - Submit Start Date service', () => {
         }
       })
 
-      it.only('saves the submitted option', async () => {
+      it('saves the submitted option', async () => {
         await SubmitStartDateService.go(session.id, payload, yarStub)
 
         const refreshedSession = await session.$query()


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4687

In [Decouple start date logic](https://github.com/DEFRA/water-abstraction-system/pull/1461) we made a change to support adding quarterly returns.

It was determined the logic for working out the start date from the values entered by the user was being duplicated in other places. The change ensured the logic stays in just the `SubmitStartDateService`, and added a new property `returnVersionStartDate` that other services could use instead.

Unfortunately, an error was introduced.

```javascript
  // app/services/return-versions/setup/submit-start-date.service.js

  // Reminder! Because of the unique qualities of Javascript, Year and Day are literal values, month is an index! So,
  // January is actually 0, February is 1 etc. This is why we deduct 1 from the month.
  session.returnVersionStartDate = new Date(`${payload['start-date-year']}-${payload['start-date-month'] - 1}-${payload['start-date-day']}`).toISOString().split('T')[0]
```

This way of creating the date was added. It uses a [template literal](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals) to combine the values provided by the user and pass it as an argument o JavaScript's `new Date()`.

But it also applies a common fix for the fact JavaScript expects month to be provided as an index, not literally! So, January = 0, February = 1 etc.

The problem is `new Date('2024-04-01')` is not the same as `new Date(2024, 4, 1)`. The first _will_ return you 1 April 2024, the second will return 1 March 2024.

JavaScript understands that 'month' is literal when you provide a string argument to `new Date()`. It is only when passing month as a separate value that you have to treat it as an index.

The result for the return versions setup journey is that a user is entering, for example, `13 May 2019` on the start page, but we're storing (and would eventually persist!) `13 April 2019`.

This change fixes the issue.

![Screenshot 2024-11-08 at 08 49 58](https://github.com/user-attachments/assets/bdeb7b94-8d2f-42ea-99d1-4abdb6a4b0ef)

![Screenshot 2024-11-08 at 08 50 10](https://github.com/user-attachments/assets/89727ca3-a63b-453c-87ea-f8eea1995db6)
