### PR TITLE
Add code coverage report to job summary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,11 @@ jobs:
           npm test
           sed -i 's/\/home\/runner\/work\/water-abstraction-system\/water-abstraction-system\//\/github\/workspace\//g' coverage/lcov.info
 
+      - name: Code coverage
+        uses: livewing/lcov-job-summary@v1.2.0
+        with:
+          lcov: coverage/lcov.info
+
       - name: Analyze with SonarCloud
         if: github.actor != 'dependabot[bot]'
         uses: sonarsource/sonarcloud-github-action@master

--- a/.labrc.js
+++ b/.labrc.js
@@ -3,6 +3,7 @@
 module.exports = {
   verbose: true,
   coverage: true,
+  'coverage-exclude': ['db/seeds'],
   // lcov reporter required for SonarCloud
   reporter: ['console', 'html', 'lcov'],
   output: ['stdout', 'coverage/coverage.html', 'coverage/lcov.info'],


### PR DESCRIPTION
During a team meeting, it was suggested that tracking missing code coverage might be easier if we could see it in GitHub as we made changes.

SonarCloud can add a summary to your PR. But it does this for each change, which gets noisy, and it is still only the summary. Then, it was mentioned that users of Jest will often expect to see a job summary detailing the coverage.

So, a quick check of that is available in GitHub actions led to [Write LCOV Report to Job Summary](https://github.com/marketplace/actions/write-lcov-report-to-job-summary).

We think it does just the trick!

![Screenshot 2024-11-13 at 08 34 28](https://github.com/user-attachments/assets/4f524e15-a2dd-4412-bbac-414b977e5f55)
