### PR TITLE
Add quarterly returns submissions to return versions

### DIFF
--- a/app/lib/dates.lib.js
+++ b/app/lib/dates.lib.js
@@ -114,23 +114,18 @@ function _isLeapYear (year) {
 }
 
 /**
- * Checks if the return version is a quarterly returns submission
+ * Checks if the given date is a quarterly returns submission
  *
- * A return version is due for quarterly returns submissions when they:
- * - are a water company and the return version start date > 1 April 2025
+ * A quarterly returns submission will be true when the date provided is >= 1 April 2025
  *
- * This function only handles the return version start date.
- *
- * @param {string} returnVersionStartDate - The return version start date
+ * @param {string} date - The date to compare against the quarterly return submissions date
  *
  * @returns {boolean}
  *
  * @private
  */
-function isQuarterlyReturnSubmissions (returnVersionStartDate) {
-  const quarterlyReturnSubmissionsStartDate = new Date('2025-04-01')
-
-  return new Date(returnVersionStartDate).getTime() >= quarterlyReturnSubmissionsStartDate.getTime()
+function isQuarterlyReturnSubmissions (date) {
+  return new Date(date).getTime() >= new Date('2025-04-01').getTime()
 }
 
 module.exports = {

--- a/app/lib/dates.lib.js
+++ b/app/lib/dates.lib.js
@@ -113,9 +113,30 @@ function _isLeapYear (year) {
   return false
 }
 
+/**
+ * Checks if the return version is a quarterly returns submission
+ *
+ * A return version is due for quarterly returns submissions when they:
+ * - are a water company and the return version start date > 1 April 2025
+ *
+ * This function only handles the return version start date.
+ *
+ * @param {string} returnVersionStartDate - The return version start date
+ *
+ * @returns {boolean}
+ *
+ * @private
+ */
+function isQuarterlyReturnSubmissions (returnVersionStartDate) {
+  const quarterlyReturnSubmissionsStartDate = new Date('2025-04-01')
+
+  return new Date(returnVersionStartDate).getTime() >= quarterlyReturnSubmissionsStartDate.getTime()
+}
+
 module.exports = {
   formatDateObjectToISO,
   formatStandardDateToISO,
   isISODateFormat,
-  isValidDate
+  isValidDate,
+  isQuarterlyReturnSubmissions
 }

--- a/app/lib/dates.lib.js
+++ b/app/lib/dates.lib.js
@@ -132,6 +132,6 @@ module.exports = {
   formatDateObjectToISO,
   formatStandardDateToISO,
   isISODateFormat,
-  isValidDate,
-  isQuarterlyReturnSubmissions
+  isQuarterlyReturnSubmissions,
+  isValidDate
 }

--- a/app/lib/dates.lib.js
+++ b/app/lib/dates.lib.js
@@ -120,7 +120,7 @@ function _isLeapYear (year) {
  *
  * @param {string} date - The date to compare against the quarterly return submissions date
  *
- * @returns {boolean}
+ * @returns {boolean} - Will return true if the date is for a quarterly return submission
  *
  * @private
  */

--- a/app/presenters/return-versions/setup/additional-submission-options.presenter.js
+++ b/app/presenters/return-versions/setup/additional-submission-options.presenter.js
@@ -5,6 +5,8 @@
  * @module AdditionalSubmissionOptionsPresenter
  */
 
+const { isQuarterlyReturnSubmissions } = require('../../../lib/dates.lib.js')
+
 /**
  * Formats data for the `/return-versions/setup/{sessionId}/additional-submission-options` page
  *
@@ -13,7 +15,10 @@
  * @returns {object} - The data formatted for the view template
  */
 function go (session) {
-  const { id: sessionId, licence: { id: licenceId, licenceRef }, multipleUpload, noAdditionalOptions } = session
+  const {
+    id: sessionId, licence: { id: licenceId, licenceRef },
+    multipleUpload, noAdditionalOptions, returnVersionStartDate, quarterlyReturns
+  } = session
 
   return {
     backLink: `/system/return-versions/setup/${sessionId}/check`,
@@ -21,6 +26,8 @@ function go (session) {
     licenceRef,
     multipleUpload,
     noAdditionalOptions,
+    quarterlyReturnSubmissions: isQuarterlyReturnSubmissions(returnVersionStartDate),
+    quarterlyReturns,
     sessionId
   }
 }

--- a/app/services/return-versions/setup/submit-additional-submission-options.service.js
+++ b/app/services/return-versions/setup/submit-additional-submission-options.service.js
@@ -83,6 +83,8 @@ function _notification (session, payload) {
 async function _save (session, payload) {
   session.multipleUpload = payload.additionalSubmissionOptions.includes('multiple-upload')
 
+  session.quarterlyReturns = payload.additionalSubmissionOptions.includes('quarterly-returns')
+
   session.noAdditionalOptions = payload.additionalSubmissionOptions.includes('none')
 
   return session.$update()

--- a/app/services/return-versions/setup/submit-start-date.service.js
+++ b/app/services/return-versions/setup/submit-start-date.service.js
@@ -9,6 +9,7 @@ const GeneralLib = require('../../../lib/general.lib.js')
 const SessionModel = require('../../../models/session.model.js')
 const StartDatePresenter = require('../../../presenters/return-versions/setup/start-date.presenter.js')
 const StartDateValidator = require('../../../validators/return-versions/setup/start-date.validator.js')
+const { isQuarterlyReturnSubmissions } = require('../../../lib/dates.lib.js')
 
 /**
  * Orchestrates validating the data for `/return-versions/setup/{sessionId}/start-date` page
@@ -56,6 +57,27 @@ async function go (sessionId, payload, yar) {
   }
 }
 
+/**
+ * Default Quarterly Returns
+ *
+ * When a return version is for a water company and the start date is for quarterly returns.
+ *
+ * We need to default the quarterly returns to true.
+ *
+ * However, we only want to do this on the initial setting of the start date after that it is in the users control.
+ *
+ * @param {SessionModel} session
+ *
+ * @private
+ */
+function _defaultQuarterlyReturns (session) {
+  if (!session.checkPageVisited &&
+    isQuarterlyReturnSubmissions(session.returnVersionStartDate) &&
+    session.licence.waterUndertaker) {
+    session.quarterlyReturns = true
+  }
+}
+
 async function _save (session, payload) {
   const selectedOption = payload['start-date-options']
 
@@ -69,6 +91,8 @@ async function _save (session, payload) {
   } else {
     session.returnVersionStartDate = new Date(session.licence.currentVersionStartDate)
   }
+
+  _defaultQuarterlyReturns(session)
 
   return session.$update()
 }

--- a/app/views/return-versions/setup/additional-submission-options.njk
+++ b/app/views/return-versions/setup/additional-submission-options.njk
@@ -56,8 +56,19 @@
           {
             value: "multiple-upload",
             text: "Multiple upload",
-            checked: multipleUpload
+            checked: multipleUpload,
+            hint: {
+              text: "Allow large abstractors, such as water companies, to submit returns for multiple licences at the same time."
+            }
           },
+          {
+            value: "quarterly-returns",
+            text: "Quarterly returns submissions",
+            checked: quarterlyReturns,
+            hint: {
+              text: "Allow water companies to submit daliy readings each quarter."
+            }
+          } if quarterlyReturnSubmissions,
           {
             divider: "or"
           },

--- a/test/lib/dates.lib.test.js
+++ b/test/lib/dates.lib.test.js
@@ -86,4 +86,18 @@ describe('Dates lib', () => {
       expect(result).to.be.true()
     })
   })
+
+  describe('isQuarterlyReturnSubmissions', () => {
+    it('should return true if the date is >= 2025-04-01', () => {
+      const result = DateLib.isQuarterlyReturnSubmissions('2025-04-01')
+
+      expect(result).to.be.true()
+    })
+
+    it('should return false if the date is < 2025-04-01', () => {
+      const result = DateLib.isQuarterlyReturnSubmissions('2025-03-31')
+
+      expect(result).to.be.false()
+    })
+  })
 })

--- a/test/presenters/return-versions/setup/additional-submission-options.presenter.test.js
+++ b/test/presenters/return-versions/setup/additional-submission-options.presenter.test.js
@@ -111,7 +111,7 @@ describe('Return Versions Setup - Additional Submission Options presenter', () =
   })
 
   describe('the "quarterlyReturnSubmissions" property', () => {
-    describe('when the return version start date is in scope for quarterly returns', () => {
+    describe('when the return version start date is in for quarterly returns', () => {
       beforeEach(() => {
         session.returnVersionStartDate = '2025-04-01'
       })
@@ -123,7 +123,7 @@ describe('Return Versions Setup - Additional Submission Options presenter', () =
       })
     })
 
-    describe('when the return version start date is not in scope for quarterly returns', () => {
+    describe('when the return version start date is not for quarterly returns', () => {
       beforeEach(() => {
         session.returnVersionStartDate = '2001-01-01'
       })

--- a/test/presenters/return-versions/setup/additional-submission-options.presenter.test.js
+++ b/test/presenters/return-versions/setup/additional-submission-options.presenter.test.js
@@ -43,6 +43,8 @@ describe('Return Versions Setup - Additional Submission Options presenter', () =
         licenceRef: '01/ABC',
         multipleUpload: false,
         noAdditionalOptions: undefined,
+        quarterlyReturnSubmissions: false,
+        quarterlyReturns: undefined,
         sessionId: session.id
       })
     })
@@ -78,6 +80,58 @@ describe('Return Versions Setup - Additional Submission Options presenter', () =
         const result = AdditionalSubmissionOptionsPresenter.go(session)
 
         expect(result.multipleUpload).to.be.false()
+      })
+    })
+  })
+
+  describe('the "quarterlyReturns" property', () => {
+    describe('when the user has previously submitted "quarterlyReturns" for additional options or it has been set initially when the licence holder is a water company and the return version start date is a quarterly return', () => {
+      beforeEach(() => {
+        session.quarterlyReturns = true
+      })
+
+      it('returns true', () => {
+        const result = AdditionalSubmissionOptionsPresenter.go(session)
+
+        expect(result.quarterlyReturns).to.be.true()
+      })
+    })
+
+    describe('when the user has not previously submitted "quarterlyReturns" for additional options', () => {
+      beforeEach(() => {
+        session.quarterlyReturns = undefined
+      })
+
+      it('returns false', () => {
+        const result = AdditionalSubmissionOptionsPresenter.go(session)
+
+        expect(result.quarterlyReturns).to.be.undefined()
+      })
+    })
+  })
+
+  describe('the "quarterlyReturnSubmissions" property', () => {
+    describe('when the return version start date is in scope for quarterly returns', () => {
+      beforeEach(() => {
+        session.returnVersionStartDate = '2025-04-01'
+      })
+
+      it('returns true', () => {
+        const result = AdditionalSubmissionOptionsPresenter.go(session)
+
+        expect(result.quarterlyReturnSubmissions).to.be.true()
+      })
+    })
+
+    describe('when the return version start date is not in scope for quarterly returns', () => {
+      beforeEach(() => {
+        session.returnVersionStartDate = '2001-01-01'
+      })
+
+      it('returns true', () => {
+        const result = AdditionalSubmissionOptionsPresenter.go(session)
+
+        expect(result.quarterlyReturnSubmissions).to.be.false()
       })
     })
   })

--- a/test/services/return-versions/setup/additional-submission-options.service.test.js
+++ b/test/services/return-versions/setup/additional-submission-options.service.test.js
@@ -51,6 +51,8 @@ describe('Return Versions Setup - Additional Submission Options service', () => 
       expect(result).to.equal({
         multipleUpload: false,
         noAdditionalOptions: undefined,
+        quarterlyReturnSubmissions: false,
+        quarterlyReturns: undefined,
         activeNavBar: 'search',
         backLink: `/system/return-versions/setup/${session.id}/check`,
         licenceId: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',

--- a/test/services/return-versions/setup/submit-additional-submission-options.service.test.js
+++ b/test/services/return-versions/setup/submit-additional-submission-options.service.test.js
@@ -26,22 +26,11 @@ describe('Return Versions Setup - Submit Additional Submission Options service',
         journey: 'returns-required',
         licence: {
           id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
-          currentVersionStartDate: '2023-01-01T00:00:00.000Z',
           endDate: null,
           licenceRef: '01/ABC',
-          licenceHolder: 'Turbo Kid',
-          returnVersions: [{
-            id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
-            startDate: '2023-01-01T00:00:00.000Z',
-            reason: null,
-            modLogs: []
-          }],
-          startDate: '2022-04-01T00:00:00.000Z'
+          licenceHolder: 'Turbo Kid'
         },
-        multipleUpload: false,
-        reason: 'major-change',
-        requirements: [{}],
-        startDateOptions: 'licenceStartDate'
+        multipleUpload: false
       }
     })
 
@@ -103,6 +92,31 @@ describe('Return Versions Setup - Submit Additional Submission Options service',
       })
     })
 
+    describe('with quarterly returns selected', () => {
+      beforeEach(() => {
+        payload = {
+          additionalSubmissionOptions: 'quarterly-returns'
+        }
+      })
+
+      it('saves the submitted value', async () => {
+        await SubmitAdditionalSubmissionOptionsService.go(session.id, payload, yarStub)
+
+        const refreshedSession = await session.$query()
+
+        expect(refreshedSession.quarterlyReturns).to.be.true()
+      })
+
+      it('sets the notification message to "Updated"', async () => {
+        await SubmitAdditionalSubmissionOptionsService.go(session.id, payload, yarStub)
+
+        const [flashType, notification] = yarStub.flash.args[0]
+
+        expect(flashType).to.equal('notification')
+        expect(notification).to.equal({ title: 'Updated', text: 'Changes updated' })
+      })
+    })
+
     describe('with an invalid payload', () => {
       beforeEach(() => {
         payload = {}
@@ -117,7 +131,9 @@ describe('Return Versions Setup - Submit Additional Submission Options service',
           pageTitle: 'Select any additional submission options for the return requirements',
           licenceRef: '01/ABC',
           multipleUpload: false,
-          noAdditionalOptions: undefined
+          noAdditionalOptions: undefined,
+          quarterlyReturnSubmissions: false,
+          quarterlyReturns: undefined
         }, { skip: ['id', 'sessionId', 'error', 'licenceId'] })
       })
 

--- a/test/services/return-versions/setup/submit-start-date.service.test.js
+++ b/test/services/return-versions/setup/submit-start-date.service.test.js
@@ -27,17 +27,18 @@ describe('Return Versions Setup - Submit Start Date service', () => {
         checkPageVisited: false,
         licence: {
           id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
-          currentVersionStartDate: '2023-01-01T00:00:00.000Z',
+          currentVersionStartDate: '2023-01-01',
           endDate: null,
           licenceRef: '01/ABC',
           licenceHolder: 'Turbo Kid',
           returnVersions: [{
             id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
-            startDate: '2023-01-01T00:00:00.000Z',
+            startDate: '2023-01-01',
             reason: null,
             modLogs: []
           }],
-          startDate: '2022-04-01T00:00:00.000Z'
+          startDate: '2022-04-01',
+          waterUndertaker: true
         },
         journey: 'returns-required',
         requirements: [{}],
@@ -100,7 +101,7 @@ describe('Return Versions Setup - Submit Start Date service', () => {
       })
     })
 
-    describe('with a valid payload (another start date', () => {
+    describe('with a valid payload (another start date)', () => {
       beforeEach(async () => {
         payload = {
           'start-date-options': 'anotherStartDate',
@@ -120,6 +121,37 @@ describe('Return Versions Setup - Submit Start Date service', () => {
         expect(refreshedSession.startDateMonth).to.equal('11')
         expect(refreshedSession.startDateYear).to.equal('2023')
         expect(new Date(refreshedSession.returnVersionStartDate)).to.equal(new Date('2023-11-26'))
+      })
+
+      it('returns the correct details the controller needs to redirect the journey', async () => {
+        const result = await SubmitStartDateService.go(session.id, payload, yarStub)
+
+        expect(result).to.equal({ checkPageVisited: false, journey: 'returns-required' })
+      })
+    })
+
+    describe('with a valid payload and is for quarterly returns', () => {
+      beforeEach(async () => {
+        payload = {
+          'start-date-options': 'anotherStartDate',
+          'start-date-day': '01',
+          'start-date-month': '04',
+          'start-date-year': '2025'
+        }
+      })
+
+      it('saves the submitted values', async () => {
+        await SubmitStartDateService.go(session.id, payload, yarStub)
+
+        const refreshedSession = await session.$query()
+
+        expect(refreshedSession.startDateOptions).to.equal('anotherStartDate')
+        expect(refreshedSession.startDateDay).to.equal('01')
+        expect(refreshedSession.startDateMonth).to.equal('04')
+        expect(refreshedSession.startDateYear).to.equal('2025')
+        expect(new Date(refreshedSession.returnVersionStartDate)).to.equal(new Date('2025-04-01'))
+
+        expect(refreshedSession.quarterlyReturns).to.be.true()
       })
 
       it('returns the correct details the controller needs to redirect the journey', async () => {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4707

As part of the quarterly returns submissions work, we need to add a new checkbox to the additional-submission-options page for the Quarterly returns submissions.

When the return version start date is >= April 01 2025 then this is considered a quarterly return.

If the return version is for a water company and the return version start date is for a quarterly return. Then the quarterly return should be defaulted to true. This logic has been determined by the business.