### PR TITLE
Improve coverage on lib date

### DIFF
--- a/test/lib/dates.lib.test.js
+++ b/test/lib/dates.lib.test.js
@@ -29,6 +29,12 @@ describe('Dates lib', () => {
 
       expect(result).to.equal('2020-07-20')
     })
+
+    it('throws an error is the date is not a valid date', () => {
+      expect(() => {
+        return DateLib.formatStandardDateToISO('20/07/20')
+      }).to.throw('20-07-20 is not a valid date')
+    })
   })
 
   describe('isValidDate', () => {
@@ -46,7 +52,7 @@ describe('Dates lib', () => {
 
     describe('if the year is a leap year', () => {
       describe('and the date is 2020-02-29 (a valid date)', () => {
-        it('returns the date', () => {
+        it('returns true', () => {
           const result = DateLib.isValidDate('2020-02-29')
 
           expect(result).to.be.true()
@@ -54,20 +60,52 @@ describe('Dates lib', () => {
       })
 
       describe('and the date is 2020-02-30 (not a valid date)', () => {
-        it('returns the date', () => {
+        it('returns false', () => {
           const result = DateLib.isValidDate('2020-02-30')
 
           expect(result).to.be.false()
         })
       })
+
+      describe('and the year is divisible by 400', () => {
+        it('returns true', () => {
+          const result = DateLib.isValidDate('2000-02-20')
+
+          expect(result).to.be.true()
+        })
+      })
     })
 
     describe('if the year is not a leap year', () => {
-      describe('and the date is 2021-02-29', () => {
+      describe('and the day is greater than the last day of February 2021-02-28 in a none leap year', () => {
         it('returns false', () => {
           const result = DateLib.isValidDate('2021-02-29')
 
           expect(result).to.be.false()
+        })
+      })
+
+      describe('and the day is greater than the last day of a leap year', () => {
+        it('returns false', () => {
+          const result = DateLib.isValidDate('1999-02-30')
+
+          expect(result).to.be.false()
+        })
+      })
+
+      describe('and the month is not February', () => {
+        it('returns true', () => {
+          const result = DateLib.isValidDate('1999-03-27')
+
+          expect(result).to.be.true()
+        })
+      })
+
+      describe('and the day is not before the last day of February', () => {
+        it('returns true', () => {
+          const result = DateLib.isValidDate('1999-02-27')
+
+          expect(result).to.be.true()
         })
       })
     })
@@ -75,13 +113,13 @@ describe('Dates lib', () => {
 
   describe('isISODateFormat', () => {
     it('should return false if the date is not in the iso format - yyyy-mm-dd', () => {
-      const result = DateLib.isValidDate('20/07/2020')
+      const result = DateLib.isISODateFormat('20/07/2020')
 
       expect(result).to.be.false()
     })
 
     it('should return true if the date is in the iso format - yyyy-mm-dd', () => {
-      const result = DateLib.isValidDate('2020-07-20')
+      const result = DateLib.isISODateFormat('2020-07-20')
 
       expect(result).to.be.true()
     })


### PR DESCRIPTION
As part of ongoing work to improve the tests we are attempting to improve the code coverage where possible / reasonable.

This change improves the coverage on:

- a private method that handles leap years this has been tested through the is valid date function

- fixing a mistake in the test which was calling the wrong function ( a date is in the ISO date format)