### PR TITLE
Add quarterly returns submissions to check return versions

### DIFF
--- a/app/presenters/return-versions/setup/check/check.presenter.js
+++ b/app/presenters/return-versions/setup/check/check.presenter.js
@@ -6,6 +6,7 @@
  */
 
 const { formatLongDate } = require('../../../base.presenter.js')
+const { isQuarterlyReturnSubmissions } = require('../../../../lib/dates.lib.js')
 const { returnRequirementReasons } = require('../../../../lib/static-lookups.lib.js')
 
 /**
@@ -16,7 +17,10 @@ const { returnRequirementReasons } = require('../../../../lib/static-lookups.lib
  * @returns {object} The data formatted for the view template
  */
 function go (session) {
-  const { multipleUpload, id: sessionId, journey, licence, note, reason } = session
+  const {
+    id: sessionId, journey, licence, multipleUpload, note, reason,
+    returnVersionStartDate, quarterlyReturns
+  } = session
 
   const returnsRequired = journey === 'returns-required'
 
@@ -28,7 +32,9 @@ function go (session) {
     reason: returnRequirementReasons[reason],
     reasonLink: _reasonLink(sessionId, returnsRequired),
     sessionId,
-    startDate: _startDate(session)
+    startDate: _startDate(session),
+    quarterlyReturnSubmissions: isQuarterlyReturnSubmissions(returnVersionStartDate),
+    quarterlyReturns
   }
 }
 

--- a/app/presenters/return-versions/setup/check/check.presenter.js
+++ b/app/presenters/return-versions/setup/check/check.presenter.js
@@ -25,16 +25,16 @@ function go (session) {
   const returnsRequired = journey === 'returns-required'
 
   return {
-    multipleUpload,
     licenceRef: licence.licenceRef,
+    multipleUpload,
     note: _note(note),
     pageTitle: `Check the requirements for returns for ${licence.licenceHolder}`,
+    quarterlyReturnSubmissions: isQuarterlyReturnSubmissions(returnVersionStartDate),
+    quarterlyReturns,
     reason: returnRequirementReasons[reason],
     reasonLink: _reasonLink(sessionId, returnsRequired),
     sessionId,
-    startDate: _startDate(session),
-    quarterlyReturnSubmissions: isQuarterlyReturnSubmissions(returnVersionStartDate),
-    quarterlyReturns
+    startDate: _startDate(session)
   }
 }
 

--- a/app/views/return-versions/setup/additional-submission-options.njk
+++ b/app/views/return-versions/setup/additional-submission-options.njk
@@ -63,7 +63,7 @@
           },
           {
             value: "quarterly-returns",
-            text: "Quarterly returns submissions",
+            text: "Quarterly return submissions",
             checked: quarterlyReturns,
             hint: {
               text: "Allow water companies to submit daliy readings each quarter."

--- a/app/views/return-versions/setup/check.njk
+++ b/app/views/return-versions/setup/check.njk
@@ -355,7 +355,17 @@
               value: {
                 text: 'Yes' if multipleUpload else "No"
               }
+            },
+            {
+              classes: 'govuk-summary-list govuk-summary-list__row--no-border',
+              key: {
+              text: 'Quarterly returns submissions',
+              classes: "govuk-body "
+            },
+              value: {
+              text: 'Yes' if quarterlyReturns else "No"
             }
+            }if quarterlyReturnSubmissions
           ]
         }) }}
         {% else %}

--- a/app/views/return-versions/setup/check.njk
+++ b/app/views/return-versions/setup/check.njk
@@ -359,7 +359,7 @@
             {
               classes: 'govuk-summary-list govuk-summary-list__row--no-border',
               key: {
-              text: 'Quarterly returns submissions',
+              text: 'Quarterly return submissions',
               classes: "govuk-body "
             },
               value: {

--- a/test/presenters/return-versions/setup/check/check.presenter.test.js
+++ b/test/presenters/return-versions/setup/check/check.presenter.test.js
@@ -50,6 +50,8 @@ describe('Return Versions Setup - Check presenter', () => {
           text: 'No notes added'
         },
         pageTitle: 'Check the requirements for returns for Turbo Kid',
+        quarterlyReturnSubmissions: false,
+        quarterlyReturns: undefined,
         reason: 'Major change',
         reasonLink: '/system/return-versions/setup/61e07498-f309-4829-96a9-72084a54996d/reason',
         sessionId: '61e07498-f309-4829-96a9-72084a54996d',
@@ -76,6 +78,66 @@ describe('Return Versions Setup - Check presenter', () => {
         const result = CheckPresenter.go(session)
 
         expect(result.multipleUpload).to.be.false()
+      })
+    })
+  })
+
+  describe('the "quarterlyReturns" property', () => {
+    describe('when there is a quarterlyReturns', () => {
+      beforeEach(() => {
+        session.quarterlyReturns = true
+      })
+
+      it('returns true', () => {
+        const result = CheckPresenter.go(session)
+
+        expect(result.quarterlyReturns).to.be.true()
+      })
+    })
+
+    describe('when there is not a quarterlyReturns', () => {
+      beforeEach(() => {
+        session.quarterlyReturns = false
+      })
+
+      it('returns false', () => {
+        const result = CheckPresenter.go(session)
+
+        expect(result.quarterlyReturns).to.be.false()
+      })
+    })
+
+    describe('when quarterlyReturns has not been set', () => {
+      it('returns undefined', () => {
+        const result = CheckPresenter.go(session)
+
+        expect(result.quarterlyReturns).to.be.undefined()
+      })
+    })
+  })
+
+  describe('the "quarterlyReturnSubmissions" property', () => {
+    describe('when the return version start date is for quarterly returns', () => {
+      beforeEach(() => {
+        session.returnVersionStartDate = '2025-04-01'
+      })
+
+      it('returns true', () => {
+        const result = CheckPresenter.go(session)
+
+        expect(result.quarterlyReturnSubmissions).to.be.true()
+      })
+    })
+
+    describe('when the return version start date is not for quarterly returns', () => {
+      beforeEach(() => {
+        session.returnVersionStartDate = '2001-01-01'
+      })
+
+      it('returns false', () => {
+        const result = CheckPresenter.go(session)
+
+        expect(result.quarterlyReturnSubmissions).to.be.false()
       })
     })
   })

--- a/test/services/return-versions/setup/check/check.service.test.js
+++ b/test/services/return-versions/setup/check/check.service.test.js
@@ -74,6 +74,8 @@ describe('Return Versions Setup - Check service', () => {
         },
         notification: undefined,
         pageTitle: 'Check the requirements for returns for Turbo Kid',
+        quarterlyReturnSubmissions: false,
+        quarterlyReturns: undefined,
         reason: 'Major change',
         reasonLink: `/system/return-versions/setup/${session.id}/reason`,
         requirements: [],


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4707

As part of the quarterly returns submissions work, we need to add a new summary list item to the return version check page.

This change adds a new summary list item - Quarterly returns submissions. The logic involved in calculating whether to show hide the list item was done as part of the previous work to add this to the additional options page - https://github.com/DEFRA/water-abstraction-system/pull/1482