### PR TITLE
Save quarterly returns submissions option

### DIFF
--- a/app/services/return-versions/setup/check/generate-return-version.service.js
+++ b/app/services/return-versions/setup/check/generate-return-version.service.js
@@ -8,6 +8,7 @@
 const GenerateReturnVersionRequirementsService = require('./generate-return-version-requirements.service.js')
 const ProcessExistingReturnVersionsService = require('./process-existing-return-versions.service.js')
 const ReturnVersionModel = require('../../../../models/return-version.model.js')
+const { isQuarterlyReturnSubmissions } = require('../../../../lib/dates.lib')
 
 /**
  * Uses the session data to generate the data sets required to create a new return version for a licence
@@ -49,9 +50,14 @@ async function _generateReturnRequirements (sessionData) {
 async function _generateReturnVersion (nextVersionNumber, sessionData, userId) {
   const startDate = new Date(sessionData.returnVersionStartDate)
   let endDate = null
+  let quarterlyReturns = false
 
   if (nextVersionNumber > 1) {
     endDate = await ProcessExistingReturnVersionsService.go(sessionData.licence.id, startDate)
+  }
+
+  if (isQuarterlyReturnSubmissions(sessionData.returnVersionStartDate)) {
+    quarterlyReturns = sessionData.quarterlyReturns
   }
 
   return {
@@ -60,6 +66,7 @@ async function _generateReturnVersion (nextVersionNumber, sessionData, userId) {
     licenceId: sessionData.licence.id,
     multipleUpload: sessionData.multipleUpload,
     notes: sessionData?.note?.content,
+    quarterlyReturns,
     reason: sessionData.reason,
     startDate,
     status: 'current',

--- a/test/services/return-versions/setup/check/generate-return-version.service.test.js
+++ b/test/services/return-versions/setup/check/generate-return-version.service.test.js
@@ -81,9 +81,11 @@ describe('Return Versions Setup - Generate Return Version service', () => {
       expect(result.returnVersion.licenceId).to.equal(licenceId)
       expect(result.returnVersion.multipleUpload).to.be.false()
       expect(result.returnVersion.notes).to.be.undefined()
+      expect(result.returnVersion.quarterlyReturns).to.be.false()
       expect(result.returnVersion.reason).to.equal(sessionData.reason)
       expect(result.returnVersion.startDate).to.equal(new Date('2023-02-13'))
       expect(result.returnVersion.status).to.equal('current')
+
       // Version number is 103 because this is the next version number after the previous version
       expect(result.returnVersion.version).to.equal(103)
       expect(ProcessExistingReturnVersionsService.go.called).to.be.true()
@@ -117,8 +119,9 @@ describe('Return Versions Setup - Generate Return Version service', () => {
           userEmail: 'admin-internal@wrls.gov.uk'
         },
         reason: 'change-to-special-agreement',
+        quarterlyReturns: true,
         requirements: ['return requirements data'],
-        returnVersionStartDate: '2023-02-13',
+        returnVersionStartDate: '2025-04-01', // date set for quarterly returns
         startDateOptions: 'anotherStartDate'
       }
     })
@@ -132,8 +135,9 @@ describe('Return Versions Setup - Generate Return Version service', () => {
       expect(result.returnVersion.licenceId).to.equal(licenceId)
       expect(result.returnVersion.multipleUpload).to.be.true()
       expect(result.returnVersion.notes).to.equal(sessionData.note.content)
+      expect(result.returnVersion.quarterlyReturns).to.be.true()
       expect(result.returnVersion.reason).to.equal(sessionData.reason)
-      expect(result.returnVersion.startDate).to.equal(new Date('2023-02-13'))
+      expect(result.returnVersion.startDate).to.equal(new Date('2025-04-01'))
       expect(result.returnVersion.status).to.equal('current')
       // Version number is 1 because no previous return versions exist
       expect(result.returnVersion.version).to.equal(1)


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4707

As part of the quarterly returns submissions work, we need to persist the quarterly returns option that has been either defaulted or set by the user.

This change the quarterlyReturns key to the generated return version before it is persisted.

We will only persist the 'quarterlyReturns' if the return version start date is for quarterly return submissions period (>= 2025-04-01).