### PR TITLE
View quarterly returns submissions option

### DIFF
--- a/app/presenters/return-versions/view.presenter.js
+++ b/app/presenters/return-versions/view.presenter.js
@@ -8,6 +8,7 @@
 const { formatAbstractionDate } = require('../base.presenter.js')
 const { formatLongDate } = require('../base.presenter.js')
 const { returnRequirementReasons, returnRequirementFrequencies } = require('../../lib/static-lookups.lib.js')
+const { isQuarterlyReturnSubmissions } = require('../../lib/dates.lib')
 
 /**
  * Formats return version data ready for presenting in the view return version page
@@ -18,19 +19,19 @@ const { returnRequirementReasons, returnRequirementFrequencies } = require('../.
  * @returns {object} page data needed by the view template
  */
 function go (returnVersion) {
-  const { licence, multipleUpload, returnRequirements, startDate, status } =
+  const { licence, multipleUpload, quarterlyReturns, returnRequirements, startDate, status } =
     returnVersion
 
   return {
-    additionalSubmissionOptions: {
-      multipleUpload: multipleUpload === true ? 'Yes' : 'No'
-    },
     createdBy: _createdBy(returnVersion),
     createdDate: formatLongDate(returnVersion.$createdAt()),
     licenceId: licence.id,
     licenceRef: licence.licenceRef,
+    multipleUpload: multipleUpload === true ? 'Yes' : 'No',
     notes: returnVersion.$notes(),
     pageTitle: `Requirements for returns for ${licence.$licenceHolder()}`,
+    quarterlyReturnSubmissions: isQuarterlyReturnSubmissions(startDate),
+    quarterlyReturns: quarterlyReturns === true ? 'Yes' : 'No',
     reason: _reason(returnVersion),
     requirements: _requirements(returnRequirements),
     startDate: formatLongDate(startDate),

--- a/app/presenters/return-versions/view.presenter.js
+++ b/app/presenters/return-versions/view.presenter.js
@@ -7,8 +7,8 @@
 
 const { formatAbstractionDate } = require('../base.presenter.js')
 const { formatLongDate } = require('../base.presenter.js')
+const { isQuarterlyReturnSubmissions } = require('../../lib/dates.lib.js')
 const { returnRequirementReasons, returnRequirementFrequencies } = require('../../lib/static-lookups.lib.js')
-const { isQuarterlyReturnSubmissions } = require('../../lib/dates.lib')
 
 /**
  * Formats return version data ready for presenting in the view return version page

--- a/app/services/return-versions/fetch-return-version.service.js
+++ b/app/services/return-versions/fetch-return-version.service.js
@@ -28,6 +28,7 @@ async function _fetch (id) {
       'multipleUpload',
       'notes',
       'reason',
+      'quarterlyReturns',
       'startDate',
       'status'
     ])

--- a/app/views/return-versions/view.njk
+++ b/app/views/return-versions/view.njk
@@ -237,9 +237,19 @@
                 classes: "govuk-body "
               },
               value: {
-                text: additionalSubmissionOptions.multipleUpload
+                text: multipleUpload
             }
+            },
+            {
+              classes: 'govuk-summary-list govuk-summary-list__row--no-border',
+              key: {
+              text: 'Quarterly return submissions',
+              classes: "govuk-body "
+            },
+              value: {
+              text: quarterlyReturns
             }
+            } if quarterlyReturnSubmissions
           ]
         }) }}
     </div>

--- a/test/presenters/return-versions/view.presenter.test.js
+++ b/test/presenters/return-versions/view.presenter.test.js
@@ -108,6 +108,14 @@ describe('Return Versions - View presenter', () => {
     })
   })
 
+  describe('the "pageTitle" property', () => {
+    it("returns the title incorporating the licence holder's name", () => {
+      const result = ViewPresenter.go(returnVersion)
+
+      expect(result.pageTitle).to.equal('Requirements for returns for Mrs A J Easley')
+    })
+  })
+
   describe('the "quarterlyReturns" property', () => {
     describe('when quarterlyReturns is true', () => {
       beforeEach(() => {
@@ -149,14 +157,6 @@ describe('Return Versions - View presenter', () => {
 
         expect(result.quarterlyReturnSubmissions).to.be.false()
       })
-    })
-  })
-
-  describe('the "pageTitle" property', () => {
-    it("returns the title incorporating the licence holder's name", () => {
-      const result = ViewPresenter.go(returnVersion)
-
-      expect(result.pageTitle).to.equal('Requirements for returns for Mrs A J Easley')
     })
   })
 

--- a/test/presenters/return-versions/view.presenter.test.js
+++ b/test/presenters/return-versions/view.presenter.test.js
@@ -108,14 +108,6 @@ describe('Return Versions - View presenter', () => {
     })
   })
 
-  describe('the "pageTitle" property', () => {
-    it("returns the title incorporating the licence holder's name", () => {
-      const result = ViewPresenter.go(returnVersion)
-
-      expect(result.pageTitle).to.equal('Requirements for returns for Mrs A J Easley')
-    })
-  })
-
   describe('the "quarterlyReturns" property', () => {
     describe('when quarterlyReturns is true', () => {
       beforeEach(() => {
@@ -157,6 +149,14 @@ describe('Return Versions - View presenter', () => {
 
         expect(result.quarterlyReturnSubmissions).to.be.false()
       })
+    })
+  })
+
+  describe('the "pageTitle" property', () => {
+    it("returns the title incorporating the licence holder's name", () => {
+      const result = ViewPresenter.go(returnVersion)
+
+      expect(result.pageTitle).to.equal('Requirements for returns for Mrs A J Easley')
     })
   })
 

--- a/test/presenters/return-versions/view.presenter.test.js
+++ b/test/presenters/return-versions/view.presenter.test.js
@@ -27,15 +27,15 @@ describe('Return Versions - View presenter', () => {
     const result = ViewPresenter.go(returnVersion)
 
     expect(result).to.equal({
-      additionalSubmissionOptions: {
-        multipleUpload: 'No'
-      },
       createdBy: 'carol.shaw@atari.com',
       createdDate: '5 April 2022',
       licenceId: '761bc44f-80d5-49ae-ab46-0a90495417b5',
       licenceRef: '01/123',
+      multipleUpload: 'No',
       notes: ['A special note'],
       pageTitle: 'Requirements for returns for Mrs A J Easley',
+      quarterlyReturnSubmissions: false,
+      quarterlyReturns: 'No',
       reason: 'New licence',
       requirements: [
         {
@@ -53,28 +53,6 @@ describe('Return Versions - View presenter', () => {
       ],
       startDate: '1 April 2022',
       status: 'current'
-    })
-  })
-
-  describe('the "additionalSubmissionOptions" property', () => {
-    describe('when multipleUpload is true', () => {
-      beforeEach(() => {
-        returnVersion.multipleUpload = true
-      })
-
-      it('returns "Yes"', () => {
-        const result = ViewPresenter.go(returnVersion)
-
-        expect(result.additionalSubmissionOptions.multipleUpload).to.equal('Yes')
-      })
-    })
-
-    describe('when multipleUpload is false', () => {
-      it('returns "No"', () => {
-        const result = ViewPresenter.go(returnVersion)
-
-        expect(result.additionalSubmissionOptions.multipleUpload).to.equal('No')
-      })
     })
   })
 
@@ -108,11 +86,77 @@ describe('Return Versions - View presenter', () => {
     })
   })
 
+  describe('the "multipleUpload" property', () => {
+    describe('when multipleUpload is true', () => {
+      beforeEach(() => {
+        returnVersion.multipleUpload = true
+      })
+
+      it('returns "Yes"', () => {
+        const result = ViewPresenter.go(returnVersion)
+
+        expect(result.multipleUpload).to.equal('Yes')
+      })
+    })
+
+    describe('when multipleUpload is false', () => {
+      it('returns "No"', () => {
+        const result = ViewPresenter.go(returnVersion)
+
+        expect(result.multipleUpload).to.equal('No')
+      })
+    })
+  })
+
   describe('the "pageTitle" property', () => {
     it("returns the title incorporating the licence holder's name", () => {
       const result = ViewPresenter.go(returnVersion)
 
       expect(result.pageTitle).to.equal('Requirements for returns for Mrs A J Easley')
+    })
+  })
+
+  describe('the "quarterlyReturns" property', () => {
+    describe('when quarterlyReturns is true', () => {
+      beforeEach(() => {
+        returnVersion.quarterlyReturns = true
+      })
+
+      it('returns "Yes"', () => {
+        const result = ViewPresenter.go(returnVersion)
+
+        expect(result.quarterlyReturns).to.equal('Yes')
+      })
+    })
+
+    describe('when quarterlyReturns is false', () => {
+      it('returns "No"', () => {
+        const result = ViewPresenter.go(returnVersion)
+
+        expect(result.quarterlyReturns).to.equal('No')
+      })
+    })
+  })
+
+  describe('the "quarterlyReturnSubmissions" property', () => {
+    describe('when return version start date is for quarterly return submissions', () => {
+      beforeEach(() => {
+        returnVersion.startDate = new Date('2025-04-01')
+      })
+
+      it('returns true', () => {
+        const result = ViewPresenter.go(returnVersion)
+
+        expect(result.quarterlyReturnSubmissions).to.be.true()
+      })
+    })
+
+    describe('when return version start date is not for quarterly return submissions', () => {
+      it('returns false', () => {
+        const result = ViewPresenter.go(returnVersion)
+
+        expect(result.quarterlyReturnSubmissions).to.be.false()
+      })
     })
   })
 

--- a/test/services/return-versions/fetch-return-version.service.test.js
+++ b/test/services/return-versions/fetch-return-version.service.test.js
@@ -41,6 +41,7 @@ describe('Return Versions - Fetch Return Version service', () => {
         id: returnVersion.id,
         multipleUpload: false,
         notes: null,
+        quarterlyReturns: false,
         reason: 'new-licence',
         startDate: new Date('2022-04-01'),
         status: 'current',

--- a/test/services/return-versions/view.service.test.js
+++ b/test/services/return-versions/view.service.test.js
@@ -36,15 +36,15 @@ describe('Return Versions - View service', () => {
 
       expect(result).to.equal({
         activeNavBar: 'search',
-        additionalSubmissionOptions: {
-          multipleUpload: 'No'
-        },
         createdBy: 'carol.shaw@atari.com',
         createdDate: '5 April 2022',
         licenceId: '761bc44f-80d5-49ae-ab46-0a90495417b5',
         licenceRef: '01/123',
+        multipleUpload: 'No',
         notes: ['A special note'],
         pageTitle: 'Requirements for returns for Mrs A J Easley',
+        quarterlyReturnSubmissions: false,
+        quarterlyReturns: 'No',
         reason: 'New licence',
         requirements: [
           {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4730

As part of the quarterly returns submissions work, we need to show the return version is flagged for quarterly returns.

We will only show the 'quarterly return submissions' if the return version start date is for quarterly return submissions period (>= 2025-04-01).

When this is the case we show Yes or no depending on the saved state of the quarterly return.

Previous work to implement the save / persist can be found here https://github.com/DEFRA/water-abstraction-system/pull/1490