### PR TITLE
Fix back in view licence contact details text

### DIFF
--- a/app/views/licences/licence-contact-details.njk
+++ b/app/views/licences/licence-contact-details.njk
@@ -4,7 +4,7 @@
 
 {% block breadcrumbs %}
   {{ govukBackLink({
-    text: 'Back to summary',
+    text: 'Go back to summary',
     href: '/system/licences/' + licenceId + '/summary'
   }) }}
 {% endblock %}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4559

When walking a new member through some areas of the system, we noticed that the 'backlink' we use in the view licence contact details page we built is inconsistent with all our other pages, including the view licence purposes page, which branches from the same view licence summary page.

This change fixes the inconsistency.

<details>
<summary>Before</summary>

![Screenshot 2024-11-15 at 16 17 51](https://github.com/user-attachments/assets/4dc297d9-f04b-4f9f-9d42-6900d9f54996)

</details>

<details>
<summary>After</summary>

![Screenshot 2024-11-15 at 16 17 29](https://github.com/user-attachments/assets/7add0cfa-ea30-4220-91a5-2ce569f43cd2)

</details>