### PR TITLE
Fix back link for copy existing in rtn vers setup

### DIFF
--- a/app/presenters/return-versions/setup/existing.presenter.js
+++ b/app/presenters/return-versions/setup/existing.presenter.js
@@ -19,6 +19,7 @@ function go (session) {
   const { id: sessionId, licence } = session
 
   return {
+    backLink: `/system/return-versions/setup/${sessionId}/method`,
     existingOptions: _existingOptions(licence.returnVersions),
     licenceRef: licence.licenceRef,
     sessionId

--- a/app/views/return-versions/setup/existing.njk
+++ b/app/views/return-versions/setup/existing.njk
@@ -9,7 +9,7 @@
   {{
     govukBackLink({
       text: 'Back',
-      href: '/system/return-requirements/' + sessionId + "/setup"
+      href: backLink
     })
   }}
 {% endblock %}

--- a/test/presenters/return-versions/setup/existing.presenter.test.js
+++ b/test/presenters/return-versions/setup/existing.presenter.test.js
@@ -42,10 +42,19 @@ describe('Return Versions Setup - Existing presenter', () => {
       const result = ExistingPresenter.go(session)
 
       expect(result).to.equal({
+        backLink: '/system/return-versions/setup/61e07498-f309-4829-96a9-72084a54996d/method',
         existingOptions: [{ value: '60b5d10d-1372-4fb2-b222-bfac81da69ab', text: '1 January 2023' }],
         licenceRef: '01/ABC',
         sessionId: '61e07498-f309-4829-96a9-72084a54996d'
       })
+    })
+  })
+
+  describe('the "backLink" property', () => {
+    it('returns a link back to the "setup" page', () => {
+      const result = ExistingPresenter.go(session)
+
+      expect(result.backLink).to.equal('/system/return-versions/setup/61e07498-f309-4829-96a9-72084a54996d/method')
     })
   })
 

--- a/test/services/return-versions/setup/existing.service.test.js
+++ b/test/services/return-versions/setup/existing.service.test.js
@@ -54,6 +54,7 @@ describe('Return Versions Setup - Existing service', () => {
       expect(result).to.equal({
         activeNavBar: 'search',
         pageTitle: 'Use previous requirements for returns',
+        backLink: `/system/return-versions/setup/${session.id}/method`,
         existingOptions: [{ value: '60b5d10d-1372-4fb2-b222-bfac81da69ab', text: '1 January 2023' }],
         licenceRef: '01/ABC'
       }, { skip: ['sessionId'] })

--- a/test/services/return-versions/setup/submit-existing.service.test.js
+++ b/test/services/return-versions/setup/submit-existing.service.test.js
@@ -89,6 +89,7 @@ describe('Return Versions Setup - Submit Existing service', () => {
         expect(result).to.equal({
           activeNavBar: 'search',
           pageTitle: 'Use previous requirements for returns',
+          backLink: `/system/return-versions/setup/${session.id}/method`,
           existingOptions: [{ value: '60b5d10d-1372-4fb2-b222-bfac81da69ab', text: '1 January 2023' }],
           licenceRef: '01/ABC'
         }, { skip: ['sessionId', 'error'] })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4283

We noticed when prepping for a discussion about return version setup that going back from the 'Use previous requirements for returns' page in the return version setup journey results in a 404.

Basically, when we carried out a refactor to [Rename return-requirements route return-versions](https://github.com/DEFRA/water-abstraction-system/pull/1431), we didn't spot that the backlink had been built differently than all the other pages in the journey.

So, it is still trying to go back to the defunct route. This change fixes it.