### PR TITLE
Fix mark for supp billing page attributes

### DIFF
--- a/app/controllers/licences.controller.js
+++ b/app/controllers/licences.controller.js
@@ -28,7 +28,7 @@ async function markedForSupplementaryBilling (request, h) {
   const pageData = await MarkedForSupplementaryBillingService.go(licenceId)
 
   return h.view('licences/marked-for-supplementary-billing.njk', {
-    pageTitle: 'You’ve marked this licence for the next supplementary bill run',
+    pageTitle: "You've marked this licence for the next supplementary bill run",
     activeNavBar: 'search',
     ...pageData
   })

--- a/app/presenters/licences/supplementary/mark-for-supplementary-billing.presenter.js
+++ b/app/presenters/licences/supplementary/mark-for-supplementary-billing.presenter.js
@@ -57,9 +57,18 @@ function _yearsToDisplay () {
     const year = currentFinancialYearEnd - i
 
     if (year > LAST_PRE_SROC_FINANCIAL_YEAR_END) {
-      lastSixFinancialYears.push({ text: formatFinancialYear(year), value: year })
+      lastSixFinancialYears.push({
+        text: formatFinancialYear(year),
+        value: year,
+        attributes: { 'data-test': `sroc-years-${year}` }
+      })
     } else {
-      lastSixFinancialYears.push({ text: 'Before 2022', value: 'preSroc', hint: { text: 'Old charge scheme' } })
+      lastSixFinancialYears.push({
+        text: 'Before 2022',
+        value: 'preSroc',
+        hint: { text: 'Old charge scheme' },
+        attributes: { 'data-test': 'pre-sroc-years' }
+      })
 
       break
     }


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-acceptance-tests/pull/144

As part of the work for the acceptance tests for supplementary billing flags, this PR introduces the necessary data-test attributes on the view page for the "Mark for Supplementary Billing" feature.