### PR TITLE
Add await to supplementary controller

### DIFF
--- a/app/controllers/licences.controller.js
+++ b/app/controllers/licences.controller.js
@@ -78,7 +78,7 @@ async function submitMarkForSupplementaryBilling (request, h) {
 }
 
 async function supplementary (request, h) {
-  LicenceSupplementaryProcessBillingFlagService.go(request.payload)
+  await LicenceSupplementaryProcessBillingFlagService.go(request.payload)
 
   return h.response().code(204)
 }


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-acceptance-tests/pull/144

During acceptance test development, an issue was identified with the supplementary flag endpoint. The controller's service call was not awaited, causing a timing problem. In most cases, this went unnoticed as users navigated away from the licence page, allowing sufficient time for the flags to persist.

However, when a charge version awaiting approval is cancelled, users are redirected to the licence setup tab immediately after the POST request. Without the await, the flags may not appear initially, leading to confusion. A page refresh resolves this, showing that the flags were set correctly.

This PR resolves the issue by adding an await to ensure the service completes before redirecting, preventing the mismatch.