### PR TITLE
Set flags for existing return version

### DIFF
--- a/app/services/return-versions/setup/existing/fetch-existing-requirements.service.js
+++ b/app/services/return-versions/setup/existing/fetch-existing-requirements.service.js
@@ -25,7 +25,7 @@ async function go(returnVersionId) {
 async function _fetch(returnVersionId) {
   return ReturnVersionModel.query()
     .findById(returnVersionId)
-    .select(['id'])
+    .select(['id', 'multipleUpload', 'quarterlyReturns'])
     .withGraphFetched('returnRequirements')
     .modifyGraph('returnRequirements', (returnRequirementsBuilder) => {
       returnRequirementsBuilder

--- a/app/services/return-versions/setup/existing/generate-from-existing-requirements.service.js
+++ b/app/services/return-versions/setup/existing/generate-from-existing-requirements.service.js
@@ -20,13 +20,17 @@ const FetchExistingRequirementsService = require('./fetch-existing-requirements.
  *
  * @param {string} returnVersionId - The UUID of the selected return version to copy requirements from
  *
- * @returns {Promise<object[]>} an array of return requirements generated from the existing return version and ready to
- * be persisted to the setup session
+ * @returns {Promise<object>}  - an array of return requirements generated from the existing return version and ready to
+ * be persisted to the setup session, if there are multiple uploads and quarterly returns set
  */
 async function go(returnVersionId) {
   const returnVersion = await FetchExistingRequirementsService.go(returnVersionId)
 
-  return _transformForSetup(returnVersion)
+  return {
+    requirements: _transformForSetup(returnVersion),
+    multipleUpload: returnVersion.multipleUpload,
+    quarterlyReturns: returnVersion.quarterlyReturns
+  }
 }
 
 function _agreementExceptions(returnRequirement) {

--- a/app/services/return-versions/setup/existing/generate-from-existing-requirements.service.js
+++ b/app/services/return-versions/setup/existing/generate-from-existing-requirements.service.js
@@ -20,16 +20,16 @@ const FetchExistingRequirementsService = require('./fetch-existing-requirements.
  *
  * @param {string} returnVersionId - The UUID of the selected return version to copy requirements from
  *
- * @returns {Promise<object>}  - an array of return requirements generated from the existing return version and ready to
- * be persisted to the setup session, if there are multiple uploads and quarterly returns set
+ * @returns {Promise<object>}  - return an array of return requirements generated from the existing return version and ready to
+ * be persisted to the setup session, if the return version has multiple uploads and if the return version is for quarterly returns
  */
 async function go(returnVersionId) {
   const returnVersion = await FetchExistingRequirementsService.go(returnVersionId)
 
   return {
-    requirements: _transformForSetup(returnVersion),
     multipleUpload: returnVersion.multipleUpload,
-    quarterlyReturns: returnVersion.quarterlyReturns
+    quarterlyReturns: returnVersion.quarterlyReturns,
+    requirements: _transformForSetup(returnVersion)
   }
 }
 

--- a/app/services/return-versions/setup/existing/submit-existing.service.js
+++ b/app/services/return-versions/setup/existing/submit-existing.service.js
@@ -51,9 +51,10 @@ async function _save(session, payload) {
   const { requirements, multipleUpload, quarterlyReturns } = await GenerateFromExistingRequirementsService.go(
     payload.existing
   )
-  session.requirements = requirements
+
   session.multipleUpload = multipleUpload
   session.quarterlyReturns = quarterlyReturns
+  session.requirements = requirements
 
   return session.$update()
 }

--- a/app/services/return-versions/setup/existing/submit-existing.service.js
+++ b/app/services/return-versions/setup/existing/submit-existing.service.js
@@ -48,7 +48,12 @@ async function go(sessionId, payload) {
 }
 
 async function _save(session, payload) {
-  session.requirements = await GenerateFromExistingRequirementsService.go(payload.existing)
+  const { requirements, multipleUpload, quarterlyReturns } = await GenerateFromExistingRequirementsService.go(
+    payload.existing
+  )
+  session.requirements = requirements
+  session.multipleUpload = multipleUpload
+  session.quarterlyReturns = quarterlyReturns
 
   return session.$update()
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -305,17 +305,17 @@
       }
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.698.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.698.0.tgz",
-      "integrity": "sha512-Upit6pmiCARsglbAw47Bh3c3Eg6MiL86x2dygiK2IW7SX2cIdpE+ITkR2KJf81F995Q4M1m47EHnfnS6J/rWeA==",
+      "version": "3.699.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.699.0.tgz",
+      "integrity": "sha512-x3wV9e6d0esA6Yyg3xWJucMYd/O8JVrNCJnGm/sz3lMYOQGefpVZKZZsHcnzQcTEVAQMF/T5/cdfdvPzIx/esA==",
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.696.0",
-        "@aws-sdk/client-sts": "3.696.0",
+        "@aws-sdk/client-sso-oidc": "3.699.0",
+        "@aws-sdk/client-sts": "3.699.0",
         "@aws-sdk/core": "3.696.0",
-        "@aws-sdk/credential-provider-node": "3.696.0",
+        "@aws-sdk/credential-provider-node": "3.699.0",
         "@aws-sdk/middleware-bucket-endpoint": "3.696.0",
         "@aws-sdk/middleware-expect-continue": "3.696.0",
         "@aws-sdk/middleware-flexible-checksums": "3.697.0",
@@ -495,14 +495,14 @@
       }
     },
     "node_modules/@aws-sdk/client-sso-oidc": {
-      "version": "3.696.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.696.0.tgz",
-      "integrity": "sha512-ikxQ3mo86d1mAq5zTaQAh8rLBERwL+I4MUYu/IVYW2hhl9J2SDsl0SgnKeXQG6S8zWuHcBO587zsZaRta1MQ/g==",
+      "version": "3.699.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.699.0.tgz",
+      "integrity": "sha512-u8a1GorY5D1l+4FQAf4XBUC1T10/t7neuwT21r0ymrtMFSK2a9QqVHKMoLkvavAwyhJnARSBM9/UQC797PFOFw==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
         "@aws-sdk/core": "3.696.0",
-        "@aws-sdk/credential-provider-node": "3.696.0",
+        "@aws-sdk/credential-provider-node": "3.699.0",
         "@aws-sdk/middleware-host-header": "3.696.0",
         "@aws-sdk/middleware-logger": "3.696.0",
         "@aws-sdk/middleware-recursion-detection": "3.696.0",
@@ -543,7 +543,7 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-sts": "^3.696.0"
+        "@aws-sdk/client-sts": "^3.699.0"
       }
     },
     "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/abort-controller": {
@@ -695,15 +695,15 @@
       }
     },
     "node_modules/@aws-sdk/client-sts": {
-      "version": "3.696.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.696.0.tgz",
-      "integrity": "sha512-eJOxR8/UyI7kGSRyE751Ea7MKEzllQs7eNveDJy9OP4t/jsN/P19HJ1YHeA1np40JRTUBfqa6WLAAiIXsk8rkg==",
+      "version": "3.699.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.699.0.tgz",
+      "integrity": "sha512-++lsn4x2YXsZPIzFVwv3fSUVM55ZT0WRFmPeNilYIhZClxHLmVAWKH4I55cY9ry60/aTKYjzOXkWwyBKGsGvQg==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.696.0",
+        "@aws-sdk/client-sso-oidc": "3.699.0",
         "@aws-sdk/core": "3.696.0",
-        "@aws-sdk/credential-provider-node": "3.696.0",
+        "@aws-sdk/credential-provider-node": "3.699.0",
         "@aws-sdk/middleware-host-header": "3.696.0",
         "@aws-sdk/middleware-logger": "3.696.0",
         "@aws-sdk/middleware-recursion-detection": "3.696.0",
@@ -983,15 +983,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.696.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.696.0.tgz",
-      "integrity": "sha512-9WsZZofjPjNAAZhIh7c7FOhLK8CR3RnGgUm1tdZzV6ZSM1BuS2m6rdwIilRxAh3fxxKDkmW/r/aYmmCYwA+AYA==",
+      "version": "3.699.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.699.0.tgz",
+      "integrity": "sha512-dXmCqjJnKmG37Q+nLjPVu22mNkrGHY8hYoOt3Jo9R2zr5MYV7s/NHsCHr+7E+BZ+tfZYLRPeB1wkpTeHiEcdRw==",
       "dependencies": {
         "@aws-sdk/core": "3.696.0",
         "@aws-sdk/credential-provider-env": "3.696.0",
         "@aws-sdk/credential-provider-http": "3.696.0",
         "@aws-sdk/credential-provider-process": "3.696.0",
-        "@aws-sdk/credential-provider-sso": "3.696.0",
+        "@aws-sdk/credential-provider-sso": "3.699.0",
         "@aws-sdk/credential-provider-web-identity": "3.696.0",
         "@aws-sdk/types": "3.696.0",
         "@smithy/credential-provider-imds": "^3.2.6",
@@ -1004,7 +1004,7 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-sts": "^3.696.0"
+        "@aws-sdk/client-sts": "^3.699.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/types": {
@@ -1019,15 +1019,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.696.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.696.0.tgz",
-      "integrity": "sha512-8F6y5FcfRuMJouC5s207Ko1mcVvOXReBOlJmhIwE4QH1CnO/CliIyepnAZrRQ659mo5wIuquz6gXnpYbitEVMg==",
+      "version": "3.699.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.699.0.tgz",
+      "integrity": "sha512-MmEmNDo1bBtTgRmdNfdQksXu4uXe66s0p1hi1YPrn1h59Q605eq/xiWbGL6/3KdkViH6eGUuABeV2ODld86ylg==",
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.696.0",
         "@aws-sdk/credential-provider-http": "3.696.0",
-        "@aws-sdk/credential-provider-ini": "3.696.0",
+        "@aws-sdk/credential-provider-ini": "3.699.0",
         "@aws-sdk/credential-provider-process": "3.696.0",
-        "@aws-sdk/credential-provider-sso": "3.696.0",
+        "@aws-sdk/credential-provider-sso": "3.699.0",
         "@aws-sdk/credential-provider-web-identity": "3.696.0",
         "@aws-sdk/types": "3.696.0",
         "@smithy/credential-provider-imds": "^3.2.6",
@@ -1079,13 +1079,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.696.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.696.0.tgz",
-      "integrity": "sha512-4SSZ9Nk08JSu4/rX1a+dEac/Ims1HCXfV7YLUe5LGdtRLSKRoQQUy+hkFaGYoSugP/p1UfUPl3BuTO9Vv8z1pA==",
+      "version": "3.699.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.699.0.tgz",
+      "integrity": "sha512-Ekp2cZG4pl9D8+uKWm4qO1xcm8/MeiI8f+dnlZm8aQzizeC+aXYy9GyoclSf6daK8KfRPiRfM7ZHBBL5dAfdMA==",
       "dependencies": {
         "@aws-sdk/client-sso": "3.696.0",
         "@aws-sdk/core": "3.696.0",
-        "@aws-sdk/token-providers": "3.696.0",
+        "@aws-sdk/token-providers": "3.699.0",
         "@aws-sdk/types": "3.696.0",
         "@smithy/property-provider": "^3.1.9",
         "@smithy/shared-ini-file-loader": "^3.1.10",
@@ -1559,9 +1559,9 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.696.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.696.0.tgz",
-      "integrity": "sha512-fvTcMADrkwRdNwVmJXi2pSPf1iizmUqczrR1KusH4XehI/KybS4U6ViskRT0v07vpxwL7x+iaD/8fR0PUu5L/g==",
+      "version": "3.699.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.699.0.tgz",
+      "integrity": "sha512-kuiEW9DWs7fNos/SM+y58HCPhcIzm1nEZLhe2/7/6+TvAYLuEWURYsbK48gzsxXlaJ2k/jGY3nIsA7RptbMOwA==",
       "dependencies": {
         "@aws-sdk/types": "3.696.0",
         "@smithy/property-provider": "^3.1.9",
@@ -1573,7 +1573,7 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-sso-oidc": "^3.696.0"
+        "@aws-sdk/client-sso-oidc": "^3.699.0"
       }
     },
     "node_modules/@aws-sdk/token-providers/node_modules/@smithy/types": {
@@ -3320,9 +3320,9 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.5.3.tgz",
-      "integrity": "sha512-96uW8maifUSmehaeW7uydWn7wBc98NEeNI3zN8vqakGpyCQgzyJaA64Z4FCOUmAdCJkhppd/7SZ798Fo4Xx37g==",
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.5.4.tgz",
+      "integrity": "sha512-iFh2Ymn2sCziBRLPuOOxRPkuCx/2gBdXtBGuCUFLUe6bWYjKnhHyIPqGeNkLZ5Aco/5GjebRTBFiWID3sDbrKw==",
       "dependencies": {
         "@smithy/middleware-serde": "^3.0.10",
         "@smithy/protocol-http": "^4.1.7",
@@ -3722,11 +3722,11 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.2.3.tgz",
-      "integrity": "sha512-Hdl9296i/EMptaX7agrSzJZDiz5Y8XPUeBbctTmMtnCguGpqfU3jVsTUan0VLaOhsnquqWLL8Bl5HrlbVGT1og==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.2.4.tgz",
+      "integrity": "sha512-TybiW2LA3kYVd3e+lWhINVu1o26KJbBwOpADnf0L4x/35vLVica77XVR5hvV9+kWeTGeSJ3IHTcYxbRxlbwhsg==",
       "dependencies": {
-        "@smithy/core": "^2.5.3",
+        "@smithy/core": "^2.5.4",
         "@smithy/middleware-serde": "^3.0.10",
         "@smithy/node-config-provider": "^3.1.11",
         "@smithy/shared-ini-file-loader": "^3.1.11",
@@ -3751,14 +3751,14 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "3.0.27",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.27.tgz",
-      "integrity": "sha512-H3J/PjJpLL7Tt+fxDKiOD25sMc94YetlQhCnYeNmina2LZscAdu0ZEZPas/kwePHABaEtqp7hqa5S4UJgMs1Tg==",
+      "version": "3.0.28",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.28.tgz",
+      "integrity": "sha512-vK2eDfvIXG1U64FEUhYxoZ1JSj4XFbYWkK36iz02i3pFwWiDz1Q7jKhGTBCwx/7KqJNk4VS7d7cDLXFOvP7M+g==",
       "dependencies": {
         "@smithy/node-config-provider": "^3.1.11",
         "@smithy/protocol-http": "^4.1.7",
         "@smithy/service-error-classification": "^3.0.10",
-        "@smithy/smithy-client": "^3.4.4",
+        "@smithy/smithy-client": "^3.4.5",
         "@smithy/types": "^3.7.1",
         "@smithy/util-middleware": "^3.0.10",
         "@smithy/util-retry": "^3.0.10",
@@ -4047,12 +4047,12 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.4.4.tgz",
-      "integrity": "sha512-dPGoJuSZqvirBq+yROapBcHHvFjChoAQT8YPWJ820aPHHiowBlB3RL1Q4kPT1hx0qKgJuf+HhyzKi5Gbof4fNA==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.4.5.tgz",
+      "integrity": "sha512-k0sybYT9zlP79sIKd1XGm4TmK0AS1nA2bzDHXx7m0nGi3RQ8dxxQUs4CPkSmQTKAo+KF9aINU3KzpGIpV7UoMw==",
       "dependencies": {
-        "@smithy/core": "^2.5.3",
-        "@smithy/middleware-endpoint": "^3.2.3",
+        "@smithy/core": "^2.5.4",
+        "@smithy/middleware-endpoint": "^3.2.4",
         "@smithy/middleware-stack": "^3.0.10",
         "@smithy/protocol-http": "^4.1.7",
         "@smithy/types": "^3.7.1",
@@ -4174,12 +4174,12 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "3.0.27",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.27.tgz",
-      "integrity": "sha512-GV8NvPy1vAGp7u5iD/xNKUxCorE4nQzlyl057qRac+KwpH5zq8wVq6rE3lPPeuFLyQXofPN6JwxL1N9ojGapiQ==",
+      "version": "3.0.28",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.28.tgz",
+      "integrity": "sha512-6bzwAbZpHRFVJsOztmov5PGDmJYsbNSoIEfHSJJyFLzfBGCCChiO3od9k7E/TLgrCsIifdAbB9nqbVbyE7wRUw==",
       "dependencies": {
         "@smithy/property-provider": "^3.1.10",
-        "@smithy/smithy-client": "^3.4.4",
+        "@smithy/smithy-client": "^3.4.5",
         "@smithy/types": "^3.7.1",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
@@ -4200,15 +4200,15 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "3.0.27",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.27.tgz",
-      "integrity": "sha512-7+4wjWfZqZxZVJvDutO+i1GvL6bgOajEkop4FuR6wudFlqBiqwxw3HoH6M9NgeCd37km8ga8NPp2JacQEtAMPg==",
+      "version": "3.0.28",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.28.tgz",
+      "integrity": "sha512-78ENJDorV1CjOQselGmm3+z7Yqjj5HWCbjzh0Ixuq736dh1oEnD9sAttSBNSLlpZsX8VQnmERqA2fEFlmqWn8w==",
       "dependencies": {
         "@smithy/config-resolver": "^3.0.12",
         "@smithy/credential-provider-imds": "^3.2.7",
         "@smithy/node-config-provider": "^3.1.11",
         "@smithy/property-provider": "^3.1.10",
-        "@smithy/smithy-client": "^3.4.4",
+        "@smithy/smithy-client": "^3.4.5",
         "@smithy/types": "^3.7.1",
         "tslib": "^2.6.2"
       },
@@ -11154,17 +11154,17 @@
       }
     },
     "@aws-sdk/client-s3": {
-      "version": "3.698.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.698.0.tgz",
-      "integrity": "sha512-Upit6pmiCARsglbAw47Bh3c3Eg6MiL86x2dygiK2IW7SX2cIdpE+ITkR2KJf81F995Q4M1m47EHnfnS6J/rWeA==",
+      "version": "3.699.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.699.0.tgz",
+      "integrity": "sha512-x3wV9e6d0esA6Yyg3xWJucMYd/O8JVrNCJnGm/sz3lMYOQGefpVZKZZsHcnzQcTEVAQMF/T5/cdfdvPzIx/esA==",
       "requires": {
         "@aws-crypto/sha1-browser": "5.2.0",
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.696.0",
-        "@aws-sdk/client-sts": "3.696.0",
+        "@aws-sdk/client-sso-oidc": "3.699.0",
+        "@aws-sdk/client-sts": "3.699.0",
         "@aws-sdk/core": "3.696.0",
-        "@aws-sdk/credential-provider-node": "3.696.0",
+        "@aws-sdk/credential-provider-node": "3.699.0",
         "@aws-sdk/middleware-bucket-endpoint": "3.696.0",
         "@aws-sdk/middleware-expect-continue": "3.696.0",
         "@aws-sdk/middleware-flexible-checksums": "3.697.0",
@@ -11380,14 +11380,14 @@
       }
     },
     "@aws-sdk/client-sso-oidc": {
-      "version": "3.696.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.696.0.tgz",
-      "integrity": "sha512-ikxQ3mo86d1mAq5zTaQAh8rLBERwL+I4MUYu/IVYW2hhl9J2SDsl0SgnKeXQG6S8zWuHcBO587zsZaRta1MQ/g==",
+      "version": "3.699.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.699.0.tgz",
+      "integrity": "sha512-u8a1GorY5D1l+4FQAf4XBUC1T10/t7neuwT21r0ymrtMFSK2a9QqVHKMoLkvavAwyhJnARSBM9/UQC797PFOFw==",
       "requires": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
         "@aws-sdk/core": "3.696.0",
-        "@aws-sdk/credential-provider-node": "3.696.0",
+        "@aws-sdk/credential-provider-node": "3.699.0",
         "@aws-sdk/middleware-host-header": "3.696.0",
         "@aws-sdk/middleware-logger": "3.696.0",
         "@aws-sdk/middleware-recursion-detection": "3.696.0",
@@ -11484,15 +11484,15 @@
       }
     },
     "@aws-sdk/client-sts": {
-      "version": "3.696.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.696.0.tgz",
-      "integrity": "sha512-eJOxR8/UyI7kGSRyE751Ea7MKEzllQs7eNveDJy9OP4t/jsN/P19HJ1YHeA1np40JRTUBfqa6WLAAiIXsk8rkg==",
+      "version": "3.699.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.699.0.tgz",
+      "integrity": "sha512-++lsn4x2YXsZPIzFVwv3fSUVM55ZT0WRFmPeNilYIhZClxHLmVAWKH4I55cY9ry60/aTKYjzOXkWwyBKGsGvQg==",
       "requires": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.696.0",
+        "@aws-sdk/client-sso-oidc": "3.699.0",
         "@aws-sdk/core": "3.696.0",
-        "@aws-sdk/credential-provider-node": "3.696.0",
+        "@aws-sdk/credential-provider-node": "3.699.0",
         "@aws-sdk/middleware-host-header": "3.696.0",
         "@aws-sdk/middleware-logger": "3.696.0",
         "@aws-sdk/middleware-recursion-detection": "3.696.0",
@@ -11723,15 +11723,15 @@
       }
     },
     "@aws-sdk/credential-provider-ini": {
-      "version": "3.696.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.696.0.tgz",
-      "integrity": "sha512-9WsZZofjPjNAAZhIh7c7FOhLK8CR3RnGgUm1tdZzV6ZSM1BuS2m6rdwIilRxAh3fxxKDkmW/r/aYmmCYwA+AYA==",
+      "version": "3.699.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.699.0.tgz",
+      "integrity": "sha512-dXmCqjJnKmG37Q+nLjPVu22mNkrGHY8hYoOt3Jo9R2zr5MYV7s/NHsCHr+7E+BZ+tfZYLRPeB1wkpTeHiEcdRw==",
       "requires": {
         "@aws-sdk/core": "3.696.0",
         "@aws-sdk/credential-provider-env": "3.696.0",
         "@aws-sdk/credential-provider-http": "3.696.0",
         "@aws-sdk/credential-provider-process": "3.696.0",
-        "@aws-sdk/credential-provider-sso": "3.696.0",
+        "@aws-sdk/credential-provider-sso": "3.699.0",
         "@aws-sdk/credential-provider-web-identity": "3.696.0",
         "@aws-sdk/types": "3.696.0",
         "@smithy/credential-provider-imds": "^3.2.6",
@@ -11752,15 +11752,15 @@
       }
     },
     "@aws-sdk/credential-provider-node": {
-      "version": "3.696.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.696.0.tgz",
-      "integrity": "sha512-8F6y5FcfRuMJouC5s207Ko1mcVvOXReBOlJmhIwE4QH1CnO/CliIyepnAZrRQ659mo5wIuquz6gXnpYbitEVMg==",
+      "version": "3.699.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.699.0.tgz",
+      "integrity": "sha512-MmEmNDo1bBtTgRmdNfdQksXu4uXe66s0p1hi1YPrn1h59Q605eq/xiWbGL6/3KdkViH6eGUuABeV2ODld86ylg==",
       "requires": {
         "@aws-sdk/credential-provider-env": "3.696.0",
         "@aws-sdk/credential-provider-http": "3.696.0",
-        "@aws-sdk/credential-provider-ini": "3.696.0",
+        "@aws-sdk/credential-provider-ini": "3.699.0",
         "@aws-sdk/credential-provider-process": "3.696.0",
-        "@aws-sdk/credential-provider-sso": "3.696.0",
+        "@aws-sdk/credential-provider-sso": "3.699.0",
         "@aws-sdk/credential-provider-web-identity": "3.696.0",
         "@aws-sdk/types": "3.696.0",
         "@smithy/credential-provider-imds": "^3.2.6",
@@ -11804,13 +11804,13 @@
       }
     },
     "@aws-sdk/credential-provider-sso": {
-      "version": "3.696.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.696.0.tgz",
-      "integrity": "sha512-4SSZ9Nk08JSu4/rX1a+dEac/Ims1HCXfV7YLUe5LGdtRLSKRoQQUy+hkFaGYoSugP/p1UfUPl3BuTO9Vv8z1pA==",
+      "version": "3.699.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.699.0.tgz",
+      "integrity": "sha512-Ekp2cZG4pl9D8+uKWm4qO1xcm8/MeiI8f+dnlZm8aQzizeC+aXYy9GyoclSf6daK8KfRPiRfM7ZHBBL5dAfdMA==",
       "requires": {
         "@aws-sdk/client-sso": "3.696.0",
         "@aws-sdk/core": "3.696.0",
-        "@aws-sdk/token-providers": "3.696.0",
+        "@aws-sdk/token-providers": "3.699.0",
         "@aws-sdk/types": "3.696.0",
         "@smithy/property-provider": "^3.1.9",
         "@smithy/shared-ini-file-loader": "^3.1.10",
@@ -12201,9 +12201,9 @@
       }
     },
     "@aws-sdk/token-providers": {
-      "version": "3.696.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.696.0.tgz",
-      "integrity": "sha512-fvTcMADrkwRdNwVmJXi2pSPf1iizmUqczrR1KusH4XehI/KybS4U6ViskRT0v07vpxwL7x+iaD/8fR0PUu5L/g==",
+      "version": "3.699.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.699.0.tgz",
+      "integrity": "sha512-kuiEW9DWs7fNos/SM+y58HCPhcIzm1nEZLhe2/7/6+TvAYLuEWURYsbK48gzsxXlaJ2k/jGY3nIsA7RptbMOwA==",
       "requires": {
         "@aws-sdk/types": "3.696.0",
         "@smithy/property-provider": "^3.1.9",
@@ -13601,9 +13601,9 @@
       }
     },
     "@smithy/core": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.5.3.tgz",
-      "integrity": "sha512-96uW8maifUSmehaeW7uydWn7wBc98NEeNI3zN8vqakGpyCQgzyJaA64Z4FCOUmAdCJkhppd/7SZ798Fo4Xx37g==",
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.5.4.tgz",
+      "integrity": "sha512-iFh2Ymn2sCziBRLPuOOxRPkuCx/2gBdXtBGuCUFLUe6bWYjKnhHyIPqGeNkLZ5Aco/5GjebRTBFiWID3sDbrKw==",
       "requires": {
         "@smithy/middleware-serde": "^3.0.10",
         "@smithy/protocol-http": "^4.1.7",
@@ -13944,11 +13944,11 @@
       }
     },
     "@smithy/middleware-endpoint": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.2.3.tgz",
-      "integrity": "sha512-Hdl9296i/EMptaX7agrSzJZDiz5Y8XPUeBbctTmMtnCguGpqfU3jVsTUan0VLaOhsnquqWLL8Bl5HrlbVGT1og==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.2.4.tgz",
+      "integrity": "sha512-TybiW2LA3kYVd3e+lWhINVu1o26KJbBwOpADnf0L4x/35vLVica77XVR5hvV9+kWeTGeSJ3IHTcYxbRxlbwhsg==",
       "requires": {
-        "@smithy/core": "^2.5.3",
+        "@smithy/core": "^2.5.4",
         "@smithy/middleware-serde": "^3.0.10",
         "@smithy/node-config-provider": "^3.1.11",
         "@smithy/shared-ini-file-loader": "^3.1.11",
@@ -13969,14 +13969,14 @@
       }
     },
     "@smithy/middleware-retry": {
-      "version": "3.0.27",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.27.tgz",
-      "integrity": "sha512-H3J/PjJpLL7Tt+fxDKiOD25sMc94YetlQhCnYeNmina2LZscAdu0ZEZPas/kwePHABaEtqp7hqa5S4UJgMs1Tg==",
+      "version": "3.0.28",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.28.tgz",
+      "integrity": "sha512-vK2eDfvIXG1U64FEUhYxoZ1JSj4XFbYWkK36iz02i3pFwWiDz1Q7jKhGTBCwx/7KqJNk4VS7d7cDLXFOvP7M+g==",
       "requires": {
         "@smithy/node-config-provider": "^3.1.11",
         "@smithy/protocol-http": "^4.1.7",
         "@smithy/service-error-classification": "^3.0.10",
-        "@smithy/smithy-client": "^3.4.4",
+        "@smithy/smithy-client": "^3.4.5",
         "@smithy/types": "^3.7.1",
         "@smithy/util-middleware": "^3.0.10",
         "@smithy/util-retry": "^3.0.10",
@@ -14211,12 +14211,12 @@
       }
     },
     "@smithy/smithy-client": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.4.4.tgz",
-      "integrity": "sha512-dPGoJuSZqvirBq+yROapBcHHvFjChoAQT8YPWJ820aPHHiowBlB3RL1Q4kPT1hx0qKgJuf+HhyzKi5Gbof4fNA==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.4.5.tgz",
+      "integrity": "sha512-k0sybYT9zlP79sIKd1XGm4TmK0AS1nA2bzDHXx7m0nGi3RQ8dxxQUs4CPkSmQTKAo+KF9aINU3KzpGIpV7UoMw==",
       "requires": {
-        "@smithy/core": "^2.5.3",
-        "@smithy/middleware-endpoint": "^3.2.3",
+        "@smithy/core": "^2.5.4",
+        "@smithy/middleware-endpoint": "^3.2.4",
         "@smithy/middleware-stack": "^3.0.10",
         "@smithy/protocol-http": "^4.1.7",
         "@smithy/types": "^3.7.1",
@@ -14315,12 +14315,12 @@
       }
     },
     "@smithy/util-defaults-mode-browser": {
-      "version": "3.0.27",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.27.tgz",
-      "integrity": "sha512-GV8NvPy1vAGp7u5iD/xNKUxCorE4nQzlyl057qRac+KwpH5zq8wVq6rE3lPPeuFLyQXofPN6JwxL1N9ojGapiQ==",
+      "version": "3.0.28",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.28.tgz",
+      "integrity": "sha512-6bzwAbZpHRFVJsOztmov5PGDmJYsbNSoIEfHSJJyFLzfBGCCChiO3od9k7E/TLgrCsIifdAbB9nqbVbyE7wRUw==",
       "requires": {
         "@smithy/property-provider": "^3.1.10",
-        "@smithy/smithy-client": "^3.4.4",
+        "@smithy/smithy-client": "^3.4.5",
         "@smithy/types": "^3.7.1",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
@@ -14337,15 +14337,15 @@
       }
     },
     "@smithy/util-defaults-mode-node": {
-      "version": "3.0.27",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.27.tgz",
-      "integrity": "sha512-7+4wjWfZqZxZVJvDutO+i1GvL6bgOajEkop4FuR6wudFlqBiqwxw3HoH6M9NgeCd37km8ga8NPp2JacQEtAMPg==",
+      "version": "3.0.28",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.28.tgz",
+      "integrity": "sha512-78ENJDorV1CjOQselGmm3+z7Yqjj5HWCbjzh0Ixuq736dh1oEnD9sAttSBNSLlpZsX8VQnmERqA2fEFlmqWn8w==",
       "requires": {
         "@smithy/config-resolver": "^3.0.12",
         "@smithy/credential-provider-imds": "^3.2.7",
         "@smithy/node-config-provider": "^3.1.11",
         "@smithy/property-provider": "^3.1.10",
-        "@smithy/smithy-client": "^3.4.4",
+        "@smithy/smithy-client": "^3.4.5",
         "@smithy/types": "^3.7.1",
         "tslib": "^2.6.2"
       },

--- a/test/services/return-versions/setup/existing/fetch-existing-requirements.service.test.js
+++ b/test/services/return-versions/setup/existing/fetch-existing-requirements.service.test.js
@@ -32,6 +32,8 @@ describe('Return Versions Setup - Fetch Existing Requirements service', () => {
 
       expect(result).to.equal({
         id: seededReturnVersion.id,
+        multipleUpload: false,
+        quarterlyReturns: false,
         returnRequirements: [
           {
             abstractionPeriodEndDay: 31,

--- a/test/services/return-versions/setup/existing/generate-from-existing-requirements.service.test.js
+++ b/test/services/return-versions/setup/existing/generate-from-existing-requirements.service.test.js
@@ -24,6 +24,34 @@ describe('Return Versions Setup - Generate From Existing Requirements service', 
   })
 
   describe('when a matching return version exists', () => {
+    describe('and "multipleUpload" has been set', () => {
+      beforeEach(() => {
+        fetchResult = _fetchResult(returnVersionId)
+
+        Sinon.stub(FetchExistingRequirementsService, 'go').resolves(fetchResult)
+      })
+
+      it('returns the saved value', async () => {
+        const result = await GenerateFromExistingRequirementsService.go(returnVersionId)
+
+        expect(result.multipleUpload).to.be.false()
+      })
+    })
+
+    describe('and "quarterlyReturns" has been set', () => {
+      beforeEach(() => {
+        fetchResult = _fetchResult(returnVersionId)
+
+        Sinon.stub(FetchExistingRequirementsService, 'go').resolves(fetchResult)
+      })
+
+      it('returns the saved value', async () => {
+        const result = await GenerateFromExistingRequirementsService.go(returnVersionId)
+
+        expect(result.quarterlyReturns).to.be.false()
+      })
+    })
+
     describe('and all its return requirements have a site description', () => {
       beforeEach(() => {
         fetchResult = _fetchResult(returnVersionId)
@@ -34,7 +62,69 @@ describe('Return Versions Setup - Generate From Existing Requirements service', 
       it('returns the details of its return requirements transformed for use in the journey', async () => {
         const result = await GenerateFromExistingRequirementsService.go(returnVersionId)
 
-        expect(result).to.equal([
+        expect(result.requirements).to.equal([
+          {
+            points: [fetchResult.returnRequirements[0].points[0].id],
+            purposes: [
+              {
+                alias: fetchResult.returnRequirements[0].returnRequirementPurposes[0].alias,
+                description: 'Spray Irrigation - Storage',
+                id: fetchResult.returnRequirements[0].returnRequirementPurposes[0].purposeId
+              }
+            ],
+            returnsCycle: 'winter-and-all-year',
+            siteDescription: 'FIRST BOREHOLE AT AVALON',
+            abstractionPeriod: {
+              'end-abstraction-period-day': 31,
+              'end-abstraction-period-month': 3,
+              'start-abstraction-period-day': 1,
+              'start-abstraction-period-month': 4
+            },
+            frequencyReported: 'week',
+            frequencyCollected: 'week',
+            agreementsExceptions: ['none']
+          },
+          {
+            points: [fetchResult.returnRequirements[1].points[0].id],
+            purposes: [
+              {
+                alias: '',
+                description: 'Spray Irrigation - Storage',
+                id: fetchResult.returnRequirements[1].returnRequirementPurposes[0].purposeId
+              }
+            ],
+            returnsCycle: 'summer',
+            siteDescription: 'SECOND BOREHOLE AT AVALON',
+            abstractionPeriod: {
+              'end-abstraction-period-day': 31,
+              'end-abstraction-period-month': 3,
+              'start-abstraction-period-day': 1,
+              'start-abstraction-period-month': 4
+            },
+            frequencyReported: 'month',
+            frequencyCollected: 'week',
+            agreementsExceptions: [
+              '56-returns-exception',
+              'gravity-fill',
+              'transfer-re-abstraction-scheme',
+              'two-part-tariff'
+            ]
+          }
+        ])
+      })
+    })
+
+    describe('and all its return requirements have a site description', () => {
+      beforeEach(() => {
+        fetchResult = _fetchResult(returnVersionId)
+
+        Sinon.stub(FetchExistingRequirementsService, 'go').resolves(fetchResult)
+      })
+
+      it('returns the details of its return requirements transformed for use in the journey', async () => {
+        const result = await GenerateFromExistingRequirementsService.go(returnVersionId)
+
+        expect(result.requirements).to.equal([
           {
             points: [fetchResult.returnRequirements[0].points[0].id],
             purposes: [
@@ -97,7 +187,7 @@ describe('Return Versions Setup - Generate From Existing Requirements service', 
       it('returns the details of its return requirements transformed, falling back to point description for the missing site description', async () => {
         const result = await GenerateFromExistingRequirementsService.go(returnVersionId)
 
-        expect(result).to.equal([
+        expect(result.requirements).to.equal([
           {
             points: [fetchResult.returnRequirements[0].points[0].id],
             purposes: [
@@ -160,6 +250,8 @@ describe('Return Versions Setup - Generate From Existing Requirements service', 
 function _fetchResult(returnVersionId) {
   return {
     id: returnVersionId,
+    multipleUpload: false,
+    quarterlyReturns: false,
     returnRequirements: [
       {
         id: 'b8c8e40f-2557-4ce5-8fd9-fd7f6bb71c30',

--- a/test/services/return-versions/setup/existing/generate-from-existing-requirements.service.test.js
+++ b/test/services/return-versions/setup/existing/generate-from-existing-requirements.service.test.js
@@ -114,68 +114,6 @@ describe('Return Versions Setup - Generate From Existing Requirements service', 
       })
     })
 
-    describe('and all its return requirements have a site description', () => {
-      beforeEach(() => {
-        fetchResult = _fetchResult(returnVersionId)
-
-        Sinon.stub(FetchExistingRequirementsService, 'go').resolves(fetchResult)
-      })
-
-      it('returns the details of its return requirements transformed for use in the journey', async () => {
-        const result = await GenerateFromExistingRequirementsService.go(returnVersionId)
-
-        expect(result.requirements).to.equal([
-          {
-            points: [fetchResult.returnRequirements[0].points[0].id],
-            purposes: [
-              {
-                alias: fetchResult.returnRequirements[0].returnRequirementPurposes[0].alias,
-                description: 'Spray Irrigation - Storage',
-                id: fetchResult.returnRequirements[0].returnRequirementPurposes[0].purposeId
-              }
-            ],
-            returnsCycle: 'winter-and-all-year',
-            siteDescription: 'FIRST BOREHOLE AT AVALON',
-            abstractionPeriod: {
-              'end-abstraction-period-day': 31,
-              'end-abstraction-period-month': 3,
-              'start-abstraction-period-day': 1,
-              'start-abstraction-period-month': 4
-            },
-            frequencyReported: 'week',
-            frequencyCollected: 'week',
-            agreementsExceptions: ['none']
-          },
-          {
-            points: [fetchResult.returnRequirements[1].points[0].id],
-            purposes: [
-              {
-                alias: '',
-                description: 'Spray Irrigation - Storage',
-                id: fetchResult.returnRequirements[1].returnRequirementPurposes[0].purposeId
-              }
-            ],
-            returnsCycle: 'summer',
-            siteDescription: 'SECOND BOREHOLE AT AVALON',
-            abstractionPeriod: {
-              'end-abstraction-period-day': 31,
-              'end-abstraction-period-month': 3,
-              'start-abstraction-period-day': 1,
-              'start-abstraction-period-month': 4
-            },
-            frequencyReported: 'month',
-            frequencyCollected: 'week',
-            agreementsExceptions: [
-              '56-returns-exception',
-              'gravity-fill',
-              'transfer-re-abstraction-scheme',
-              'two-part-tariff'
-            ]
-          }
-        ])
-      })
-    })
-
     describe('but one of its return requirements does not have a site description', () => {
       beforeEach(() => {
         fetchResult = _fetchResult()

--- a/test/services/return-versions/setup/existing/submit-existing.service.test.js
+++ b/test/services/return-versions/setup/existing/submit-existing.service.test.js
@@ -63,9 +63,9 @@ describe('Return Versions Setup - Submit Existing service', () => {
         }
 
         Sinon.stub(GenerateFromExistingRequirementsService, 'go').resolves({
-          requirements: [_transformedReturnRequirement()],
           multipleUpload: false,
-          quarterlyReturns: false
+          quarterlyReturns: false,
+          requirements: [_transformedReturnRequirement()]
         })
       })
 

--- a/test/services/return-versions/setup/existing/submit-existing.service.test.js
+++ b/test/services/return-versions/setup/existing/submit-existing.service.test.js
@@ -62,7 +62,11 @@ describe('Return Versions Setup - Submit Existing service', () => {
           existing: '60b5d10d-1372-4fb2-b222-bfac81da69ab'
         }
 
-        Sinon.stub(GenerateFromExistingRequirementsService, 'go').resolves([_transformedReturnRequirement()])
+        Sinon.stub(GenerateFromExistingRequirementsService, 'go').resolves({
+          requirements: [_transformedReturnRequirement()],
+          multipleUpload: false,
+          quarterlyReturns: false
+        })
       })
 
       it('returns the correct details the controller needs to redirect the journey', async () => {
@@ -77,6 +81,22 @@ describe('Return Versions Setup - Submit Existing service', () => {
         const refreshedSession = await session.$query()
 
         expect(refreshedSession.requirements).to.equal([_transformedReturnRequirement()])
+      })
+
+      it('saves the return versions "multipleUpload" state', async () => {
+        await SubmitExistingService.go(session.id, payload)
+
+        const refreshedSession = await session.$query()
+
+        expect(refreshedSession.multipleUpload).to.equal(false)
+      })
+
+      it('saves the return versions "quarterlyReturns" state', async () => {
+        await SubmitExistingService.go(session.id, payload)
+
+        const refreshedSession = await session.$query()
+
+        expect(refreshedSession.quarterlyReturns).to.equal(false)
       })
     })
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4731

When the copying existing requirements and using previous requirements for returns, the quarterly returns and multiple uploads flags should inherit from the existing return versions.

This takes precedence over the previous defaults set  earlier in the journey.