### PR TITLE
Fix null values in view monitoring station page

### DIFF
--- a/app/presenters/monitoring-stations/view.presenter.js
+++ b/app/presenters/monitoring-stations/view.presenter.js
@@ -41,15 +41,15 @@ function go(monitoringStation, auth) {
   } = monitoringStation
 
   return {
-    gridReference,
+    gridReference: gridReference ?? '',
     monitoringStationId,
     pageTitle: _pageTitle(riverName, monitoringStationName),
     permissionToManageLinks: auth.credentials.scope.includes('manage_gauging_station_licence_links'),
     permissionToSendAlerts: auth.credentials.scope.includes('hof_notifications'),
     restrictionHeading: _restrictionHeading(licenceMonitoringStations),
     restrictions: _restrictions(licenceMonitoringStations),
-    stationReference,
-    wiskiId
+    stationReference: stationReference ?? '',
+    wiskiId: wiskiId ?? ''
   }
 }
 

--- a/app/views/monitoring-stations/view.njk
+++ b/app/views/monitoring-stations/view.njk
@@ -31,7 +31,7 @@
       rows: [
         {
           key: { text: "Grid reference", classes: "meta-data__label" },
-          value: { html: '<span data-test="meta-data-grid-region">' + gridReference + '</span>', classes: "meta-data__value" }
+          value: { html: '<span data-test="meta-data-grid-reference">' + gridReference + '</span>', classes: "meta-data__value" }
         },
         {
           key: { text: "WISKI ID", classes: "meta-data__label" },

--- a/test/presenters/monitoring-stations/view.presenter.test.js
+++ b/test/presenters/monitoring-stations/view.presenter.test.js
@@ -75,8 +75,30 @@ describe('Monitoring Stations - View presenter', () => {
             threshold: '100 m3/s'
           }
         ],
-        stationReference: null,
-        wiskiId: null
+        stationReference: '',
+        wiskiId: ''
+      })
+    })
+  })
+
+  describe('the "gridReference" property', () => {
+    describe('when a monitoring station has a grid reference', () => {
+      it('returns the grid reference', () => {
+        const result = ViewPresenter.go(monitoringStation, auth)
+
+        expect(result.gridReference).to.equal('TL2664640047')
+      })
+    })
+
+    describe('when a monitoring station does not have a grid reference', () => {
+      beforeEach(() => {
+        monitoringStation.gridReference = null
+      })
+
+      it('returns an empty string', () => {
+        const result = ViewPresenter.go(monitoringStation, auth)
+
+        expect(result.gridReference).to.equal('')
       })
     })
   })
@@ -311,6 +333,50 @@ describe('Monitoring Stations - View presenter', () => {
         const result = ViewPresenter.go(monitoringStation, auth)
 
         expect(result.restrictions[0].restrictionCount).to.equal(2)
+      })
+    })
+  })
+
+  describe('the "stationReference" property', () => {
+    describe('when a monitoring station has a station reference', () => {
+      beforeEach(() => {
+        monitoringStation.stationReference = 'STN12345'
+      })
+
+      it('returns the station reference', () => {
+        const result = ViewPresenter.go(monitoringStation, auth)
+
+        expect(result.stationReference).to.equal('STN12345')
+      })
+    })
+
+    describe('when a monitoring station does not have a station reference', () => {
+      it('returns an empty string', () => {
+        const result = ViewPresenter.go(monitoringStation, auth)
+
+        expect(result.stationReference).to.equal('')
+      })
+    })
+  })
+
+  describe('the "wiskiId" property', () => {
+    describe('when a monitoring station has a WSKI Id', () => {
+      beforeEach(() => {
+        monitoringStation.wiskiId = 'WSK12345'
+      })
+
+      it('returns the WSKI Id', () => {
+        const result = ViewPresenter.go(monitoringStation, auth)
+
+        expect(result.wiskiId).to.equal('WSK12345')
+      })
+    })
+
+    describe('when a monitoring station does not have a WSKI Id', () => {
+      it('returns an empty string', () => {
+        const result = ViewPresenter.go(monitoringStation, auth)
+
+        expect(result.wiskiId).to.equal('')
       })
     })
   })

--- a/test/services/monitoring-stations/view.service.test.js
+++ b/test/services/monitoring-stations/view.service.test.js
@@ -86,8 +86,8 @@ describe('Monitoring Stations - View service', () => {
             threshold: '100 m3/s'
           }
         ],
-        stationReference: null,
-        wiskiId: null
+        stationReference: '',
+        wiskiId: ''
       })
     })
   })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4736

We had some issues in the initial version of the new view monitoring station page we built. We [then fixed them](https://github.com/DEFRA/water-abstraction-system/pull/1470).

As part of that change, we dropped some logic in the presenter that converted `null` to an empty string.

We thought it was unnecessary, but we were wrong!

In Nunjucks, if you render a value using `{{ gridReference }}` Nunjucks will automatically convert `undefined` and `null` to an empty string. This means you don't have to do anything in the presenter.

But, if you render the value as part of some string concatenation, this no longer happens and `null` gets converted into `'null'`. A common reason for doing this is adding a data-test attribute to GDS components that don't allow us to add custom attributes.

Note the `'<span data-test="meta-data-grid-reference">' + gridReference + '</span>'` below.

```
  {{ govukSummaryList({
    classes: 'govuk-summary-list--no-border',
    attributes: {
      'data-test': 'meta-data'
    },
    rows: [
      {
        key: { text: "Grid reference", classes: "meta-data__label" },
        value: { html: '<span data-test="meta-data-grid-reference">' + gridReference + '</span>', classes: "meta-data__value" }
      }
    ]
  }) }}
```

This change puts back the logic. It also corrects a misnamed attribute!