### PR TITLE
Update bill run statuses in DetermineExistingBillRunService

### DIFF
--- a/app/services/licences/supplementary/determine-existing-bill-run-years.service.js
+++ b/app/services/licences/supplementary/determine-existing-bill-run-years.service.js
@@ -22,7 +22,7 @@ const BillRunModel = require('../../../models/bill-run.model.js')
  * @param {object[]} years - The years that the licence can be flagged for
  * @param {boolean} twoPartTariff - If there are two-part tariff indicators on the licence
  *
- * @returns {object[]} - The years that can be flagged for supplementary billing
+ * @returns {Promise<object[]>} - The years that can be flagged for supplementary billing
  */
 async function go(regionId, years, twoPartTariff) {
   return _supplementaryBillingYears(regionId, years, twoPartTariff)
@@ -37,11 +37,13 @@ async function go(regionId, years, twoPartTariff) {
  */
 async function _supplementaryBillingYears(regionId, years, twoPartTariff) {
   const batchType = twoPartTariff ? 'two_part_tariff' : 'annual'
+  const billRunStatus = ['sent', 'ready', 'review', 'sending']
 
   const billRuns = await BillRunModel.query()
     .distinct('toFinancialYearEnding')
     .where('regionId', regionId)
     .where('batchType', batchType)
+    .whereIn('status', billRunStatus)
     .whereIn('toFinancialYearEnding', years)
 
   return billRuns.map((billRun) => {

--- a/test/services/licences/supplementary/determine-existing-bill-run-years.service.test.js
+++ b/test/services/licences/supplementary/determine-existing-bill-run-years.service.test.js
@@ -32,10 +32,13 @@ describe('Determine Existing Bill Run Years Service', () => {
         beforeEach(async () => {
           // Add an annual bill run to check this doesn't get picked up when we are looking for twoPartTariff ones
           billRun = await BillRunHelper.add({ batchType: 'annual', status: 'sent', regionId })
+          // Add an errored two-part tariff bill run to check this doesn't get picked up either
+          billRunTwo = await BillRunHelper.add({ batchType: 'two_part_tariff', status: 'error', regionId })
         })
 
         afterEach(async () => {
           await billRun.$query().delete()
+          await billRunTwo.$query().delete()
         })
 
         it('does not return any years', async () => {
@@ -78,6 +81,8 @@ describe('Determine Existing Bill Run Years Service', () => {
         beforeEach(async () => {
           // Add an annual two-part tariff bill run to confirm we only match to non two-part tariff
           billRun = await BillRunHelper.add({ batchType: 'two_part_tariff', status: 'sent', regionId })
+          // Add a cancelled annual bill run to check this doesn't get picked up either
+          billRunTwo = await BillRunHelper.add({ batchType: 'annual', status: 'cancel', regionId })
         })
 
         afterEach(async () => {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4746

This PR is part of our work to clean up the supplementary billing flags. Specifically, this PR focuses on correcting the bill run statuses used when we check if we should flag for two-part tariff supplementary billing. Currently bill run status are not a part of the check, however, there are a few statuses such as 'errored' or 'cancelled' that we don't want to consider.