### PR TITLE
Add determine bill flags service

### DIFF
--- a/app/services/bills/submit-remove-bill.service.js
+++ b/app/services/bills/submit-remove-bill.service.js
@@ -6,10 +6,17 @@
  */
 
 const BillModel = require('../../models/bill.model.js')
+const BillLicenceModel = require('../../models/bill-licence.model.js')
+
 const LegacyDeleteBillRequest = require('../../requests/legacy/delete-bill.request.js')
+const ProcessBillingFlagService = require('../licences/supplementary/process-billing-flag.service.js')
 
 /**
  * Orchestrates the removing of a bill from a bill run
+ *
+ * This involves calling the `ProcessBillingFlagService` for all the licences associated with the bill for the correct
+ * supplementary billing flags to be added to them and then to handle deleting the bill itself calling the legacy
+ * service
  *
  * @param {string} billId - UUID of the bill to be removed
  * @param {object} user - Instance of `UserModel` that represents the user making the request
@@ -19,6 +26,7 @@ const LegacyDeleteBillRequest = require('../../requests/legacy/delete-bill.reque
 async function go(billId, user) {
   const { billRunId } = await _fetchBill(billId)
 
+  await _flagRemovedBill(billId)
   await LegacyDeleteBillRequest.send(billRunId, billId, user)
 
   return `/billing/batch/${billRunId}/processing`
@@ -26,6 +34,22 @@ async function go(billId, user) {
 
 async function _fetchBill(billId) {
   return BillModel.query().findById(billId).select(['id', 'billRunId'])
+}
+
+async function _fetchBillLicences(billId) {
+  return BillLicenceModel.query().where('billId', billId).select('id')
+}
+
+async function _flagRemovedBill(billId) {
+  const billLicences = await _fetchBillLicences(billId)
+
+  for (const billLicence of billLicences) {
+    const payload = {
+      billLicenceId: billLicence.id
+    }
+
+    await ProcessBillingFlagService.go(payload)
+  }
 }
 
 module.exports = {

--- a/app/services/licences/supplementary/fetch-existing-licence-details.service.js
+++ b/app/services/licences/supplementary/fetch-existing-licence-details.service.js
@@ -41,6 +41,7 @@ function _query() {
       l.expired_date,
       l.lapsed_date,
       l.revoked_date,
+      l.region_id,
       (CASE l.include_in_presroc_billing
         WHEN 'yes' THEN TRUE
         ELSE FALSE

--- a/test/services/bills/submit-remove-bill.services.test.js
+++ b/test/services/bills/submit-remove-bill.services.test.js
@@ -10,23 +10,30 @@ const { expect } = Code
 
 // Test helpers
 const BillHelper = require('../../support/helpers/bill.helper.js')
+const BillLicenceHelper = require('../../support/helpers/bill-licence.helper.js')
 
 // Things we need to stub
 const LegacyDeleteBillRequest = require('../../../app/requests/legacy/delete-bill.request.js')
+const ProcessBillingFlagService = require('../../../app/services/licences/supplementary/process-billing-flag.service.js')
 
 // Thing under test
 const SubmitRemoveBillService = require('../../../app/services/bills/submit-remove-bill.service.js')
 
-describe('Submit Remove Bill service', () => {
+describe.only('Submit Remove Bill service', () => {
   const user = { id: '0aa9dcaa-9a26-4a77-97ab-c17db54d38a1', useremail: 'carol.shaw@atari.com' }
 
   let bill
   let legacyDeleteBillRequestStub
+  let processBillingFlagsStub
 
   beforeEach(async () => {
     bill = await BillHelper.add()
+    // Add two licences to the bill
+    await BillLicenceHelper.add({ billId: bill.id })
+    await BillLicenceHelper.add({ billId: bill.id })
 
     legacyDeleteBillRequestStub = Sinon.stub(LegacyDeleteBillRequest, 'send').resolves()
+    processBillingFlagsStub = Sinon.stub(ProcessBillingFlagService, 'go').resolves()
   })
 
   afterEach(() => {
@@ -34,6 +41,12 @@ describe('Submit Remove Bill service', () => {
   })
 
   describe('when called', () => {
+    it('flags the two licences in the bill for supplementary billing', async () => {
+      await SubmitRemoveBillService.go(bill.id, user)
+
+      expect(processBillingFlagsStub.calledTwice).to.be.true()
+    })
+
     it('sends a request to the legacy service to delete the bill', async () => {
       await SubmitRemoveBillService.go(bill.id, user)
 

--- a/test/services/bills/submit-remove-bill.services.test.js
+++ b/test/services/bills/submit-remove-bill.services.test.js
@@ -19,7 +19,7 @@ const ProcessBillingFlagService = require('../../../app/services/licences/supple
 // Thing under test
 const SubmitRemoveBillService = require('../../../app/services/bills/submit-remove-bill.service.js')
 
-describe.only('Submit Remove Bill service', () => {
+describe('Submit Remove Bill service', () => {
   const user = { id: '0aa9dcaa-9a26-4a77-97ab-c17db54d38a1', useremail: 'carol.shaw@atari.com' }
 
   let bill

--- a/test/services/licences/supplementary/fetch-existing-licence-details.service.test.js
+++ b/test/services/licences/supplementary/fetch-existing-licence-details.service.test.js
@@ -35,6 +35,7 @@ describe('Fetch Existing Licence Details Service', () => {
         const result = await FetchExistingLicenceDetailsService.go(licence.id)
 
         expect(result.id).to.equal(licence.id)
+        expect(result.region_id).to.equal(licence.regionId)
         expect(result.revoked_date).to.equal(new Date('2024-08-01'))
         expect(result.lapsed_date).to.equal(new Date('2024-06-01'))
         expect(result.expired_date).to.equal(new Date('2024-04-01'))
@@ -73,6 +74,7 @@ describe('Fetch Existing Licence Details Service', () => {
         const result = await FetchExistingLicenceDetailsService.go(licence.id)
 
         expect(result.id).to.equal(licence.id)
+        expect(result.region_id).to.equal(licence.regionId)
         expect(result.revoked_date).to.equal(null)
         expect(result.lapsed_date).to.equal(null)
         expect(result.expired_date).to.equal(null)


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4746

This PR contributes to cleaning up the supplementary billing flagging process, specifically focusing on handling bills removed from a bill run.

When a bill run is created, users can remove bills from it. Depending on the type of bill run, the following actions are required:

Annual Bill Run: The licences in the bill must be flagged for inclusion in the next supplementary bill run.
Supplementary Bill Run: Since the licences in the bill are already flagged (which is why they were included in this bill run), the existing flag must be maintained. 

Previously, bill flagging logic was handled entirely in legacy code. While the endpoint in the service repository still processes other aspects of licence removal, the flagging logic has been moved to our new ProcessBillingFlagsService. This service ensures flags are correctly determined before the legacy endpoint is called.