### PR TITLE
Update determine charge versions flags service

### DIFF
--- a/app/services/licences/supplementary/process-billing-flag.service.js
+++ b/app/services/licences/supplementary/process-billing-flag.service.js
@@ -77,9 +77,9 @@ async function _determineFlags(payload) {
   }
   if (payload.licenceId) {
     return DetermineLicenceFlagsService.go(payload.licenceId, payload.scheme)
-  } else {
-    throw new Error('Invalid payload for process billing flags service')
   }
+
+  throw new Error('Invalid payload for process billing flags service')
 }
 
 async function _determineTwoPartTariffYears(twoPartTariffBillingYears, result) {

--- a/test/services/licences/supplementary/process-billing-flag.service.test.js
+++ b/test/services/licences/supplementary/process-billing-flag.service.test.js
@@ -24,7 +24,6 @@ const ProcessBillingFlagService = require('../../../../app/services/licences/sup
 describe('Process Billing Flag Service', () => {
   let notifierStub
   let payload
-  let persistSupplementaryBillingFlagsServiceStub
 
   beforeEach(() => {
     // The service depends on GlobalNotifier to have been set. This happens in app/plugins/global-notifier.plugin.js
@@ -33,12 +32,13 @@ describe('Process Billing Flag Service', () => {
     notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
     global.GlobalNotifier = notifierStub
 
-    persistSupplementaryBillingFlagsServiceStub = Sinon.stub(PersistSupplementaryBillingFlagsService, 'go').resolves()
+    Sinon.stub(PersistSupplementaryBillingFlagsService, 'go').resolves()
   })
 
   afterEach(() => {
     Sinon.restore()
   })
+
   describe('when given a valid payload', () => {
     describe('with a chargeVersionId & workflowId', () => {
       before(() => {
@@ -51,29 +51,15 @@ describe('Process Billing Flag Service', () => {
       describe('that should be flagged for two-part tariff supplementary billing', () => {
         beforeEach(() => {
           Sinon.stub(DetermineChargeVersionFlagsService, 'go').resolves(_licenceData(true))
-          Sinon.stub(DetermineWorkflowFlagsService, 'go').resolves(_licenceData(true))
-
-          const determineExistingBillRuYearsServiceStub = Sinon.stub(DetermineExistingBillRunYearsService, 'go')
-          determineExistingBillRuYearsServiceStub.onCall(0).resolves([2023])
-          determineExistingBillRuYearsServiceStub.onCall(1).resolves([2024])
+          Sinon.stub(DetermineExistingBillRunYearsService, 'go').resolves([2023])
         })
 
         it('calls "PersistSupplementaryBillingFlagsService" with the correct flags to persist', async () => {
           await ProcessBillingFlagService.go(payload)
 
-          expect(persistSupplementaryBillingFlagsServiceStub.calledTwice).to.be.true()
-
           expect(
-            persistSupplementaryBillingFlagsServiceStub.firstCall.calledWith(
+            PersistSupplementaryBillingFlagsService.go.calledOnceWith(
               [2023],
-              false,
-              true,
-              'aad74a3d-59ea-4c18-8091-02b0f8b0a147'
-            )
-          ).to.be.true()
-          expect(
-            persistSupplementaryBillingFlagsServiceStub.secondCall.calledWith(
-              [2024],
               false,
               true,
               'aad74a3d-59ea-4c18-8091-02b0f8b0a147'
@@ -102,18 +88,8 @@ describe('Process Billing Flag Service', () => {
         it('calls "PersistSupplementaryBillingFlagsService" to persist the flags', async () => {
           await ProcessBillingFlagService.go(payload)
 
-          expect(persistSupplementaryBillingFlagsServiceStub.calledTwice).to.be.true()
-
           expect(
-            persistSupplementaryBillingFlagsServiceStub.firstCall.calledWith(
-              [],
-              false,
-              true,
-              'aad74a3d-59ea-4c18-8091-02b0f8b0a147'
-            )
-          ).to.be.true()
-          expect(
-            persistSupplementaryBillingFlagsServiceStub.secondCall.calledWith(
+            PersistSupplementaryBillingFlagsService.go.calledOnceWith(
               [],
               false,
               true,


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4746

This PR contributes to cleaning up the supplementary billing flagging process, specifically focusing on updating the `determine charge versions flags service`. Currently, the service is equipped to handle new charge versions being approved and flagging the licence based on the new charge version. However, this doesn't consider the fact that the licence has been in workflow and might need additional flags because it couldn't be picked up for billing. For example:
A new two-part tariff charge version gets approved for 2022-2023 and the licence needs to flag 2022 and 2023 in the licence supplementary years table. This is done successfully with the current service but if the licence then missed its annual bill run because it was in workflow waiting for that charge version to be approved, it would then also need an sroc supplementary flag as well.

This PR fixes that issue.