### PR TITLE
Fix notifications returns period page title

### DIFF
--- a/app/services/notifications/setup/returns-period.service.js
+++ b/app/services/notifications/setup/returns-period.service.js
@@ -18,7 +18,7 @@ function go() {
 
   return {
     activeNavBar: 'manage',
-    pageTitle: 'Select which returns period to send invitations for',
+    pageTitle: 'Select the returns periods for the invitations',
     ...formattedData
   }
 }

--- a/test/controllers/notifications.controller.test.js
+++ b/test/controllers/notifications.controller.test.js
@@ -72,7 +72,7 @@ describe('Notifications Setup controller', () => {
 
 function _viewReturnsPeriod() {
   return {
-    pageTitle: 'Select which returns period to send invitations for',
+    pageTitle: 'Select the returns periods for the invitations',
     backLink: '/manage',
     activeNavBar: 'manage',
     returnsPeriod: []

--- a/test/services/notifications/setup/returns-period.services.test.js
+++ b/test/services/notifications/setup/returns-period.services.test.js
@@ -18,7 +18,7 @@ describe('Notifications Setup - Returns Period service', () => {
       expect(result).to.equal({
         activeNavBar: 'manage',
         backLink: '/manage',
-        pageTitle: 'Select which returns period to send invitations for',
+        pageTitle: 'Select the returns periods for the invitations',
         returnsPeriod: []
       })
     })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4716

Previous work to scaffold the notifications and returns period - https://github.com/DEFRA/water-abstraction-system/pull/1522

This change updates the returns period page title based on inconsistent wording used in the acceptance criteria.