### PR TITLE
Notifications returns period options - January

### DIFF
--- a/app/lib/static-lookups.lib.js
+++ b/app/lib/static-lookups.lib.js
@@ -92,12 +92,12 @@ module.exports = {
   billRunTypes,
   companyTypes,
   contactTypes,
+  monthsAsIntegers,
+  naldRegions,
   organisationTypes,
   returnCycleDates,
   returnRequirementFrequencies,
   returnRequirementReasons,
-  naldRegions,
   sources,
-  twoPartTariffReviewIssues,
-  monthsAsIntegers
+  twoPartTariffReviewIssues
 }

--- a/app/lib/static-lookups.lib.js
+++ b/app/lib/static-lookups.lib.js
@@ -6,6 +6,10 @@ const companyTypes = ['person', 'organisation']
 
 const contactTypes = ['person', 'department']
 
+const monthsAsIntegers = {
+  january: 0
+}
+
 const organisationTypes = ['individual', 'limitedCompany', 'limitedLiabilityPartnership', 'publicLimitedCompany']
 
 const returnCycleDates = {
@@ -94,5 +98,6 @@ module.exports = {
   returnRequirementReasons,
   naldRegions,
   sources,
-  twoPartTariffReviewIssues
+  twoPartTariffReviewIssues,
+  monthsAsIntegers
 }

--- a/app/lib/static-lookups.lib.js
+++ b/app/lib/static-lookups.lib.js
@@ -6,6 +6,14 @@ const companyTypes = ['person', 'organisation']
 
 const contactTypes = ['person', 'department']
 
+/*
+ * Helper map for Months of the Year in integer format
+ *
+ * The getMonth() method of Date instances returns the month for this date according to local time,
+ * as a zero-based value (where zero indicates the first month of the year).
+ *
+ * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getMonth
+ */
 const monthsAsIntegers = {
   january: 0
 }

--- a/app/presenters/notifications/setup/returns-period.presenter.js
+++ b/app/presenters/notifications/setup/returns-period.presenter.js
@@ -9,6 +9,7 @@ const { monthsAsIntegers } = require('../../../lib/static-lookups.lib')
 
 const currentPeriod = 'currentPeriod'
 const nextPeriod = 'nextPeriod'
+const twentyEighth = 28
 
 /**
  * Formats data for the `/notifications/setup/returns-period` page
@@ -40,7 +41,7 @@ function _returnsPeriod() {
  *  A date is in January if it is between 1st January - 28th January
  */
 function _dayIsInJanuary(date) {
-  return date.getMonth() === monthsAsIntegers.january && date.getDate() <= 28
+  return date.getMonth() === monthsAsIntegers.january && date.getDate() <= twentyEighth
 }
 
 function _dayIsInJanuaryOptions(currentYear, previousYear) {

--- a/app/presenters/notifications/setup/returns-period.presenter.js
+++ b/app/presenters/notifications/setup/returns-period.presenter.js
@@ -18,7 +18,42 @@ function go() {
 }
 
 function _returnsPeriod() {
+  const today = new Date()
+  const currentYear = today.getFullYear()
+  const previousYear = currentYear - 1
+
+  if (_dayIsInJanuary(today)) {
+    return _dayIsInJanuaryOptions(currentYear, previousYear)
+  }
+
   return []
+}
+
+/*
+ *  Checks if a date is in January
+ *  A date is in January if it is between 1st January - 28th January
+ */
+function _dayIsInJanuary(date) {
+  return date.getMonth() === 0 && date.getDate() >= 1 && date.getDate() <= 28
+}
+
+function _dayIsInJanuaryOptions(currentYear, previousYear) {
+  return [
+    {
+      value: 'quarterlyJanToMarch',
+      text: `Quarterly 1st October ${previousYear} to 31st December ${previousYear}`,
+      hint: {
+        text: `Due date 28 Jan ${currentYear}`
+      }
+    },
+    {
+      value: 'quarterlyAprilToMarch',
+      text: `Quarterly 1st January ${currentYear} to 31st March ${currentYear}`,
+      hint: {
+        text: `Due date 28 April ${currentYear}`
+      }
+    }
+  ]
 }
 
 module.exports = {

--- a/app/presenters/notifications/setup/returns-period.presenter.js
+++ b/app/presenters/notifications/setup/returns-period.presenter.js
@@ -5,6 +5,11 @@
  * @module ReturnsPeriodPresenter
  */
 
+const { monthsAsIntegers } = require('../../../lib/static-lookups.lib')
+
+const currentPeriod = 'currentPeriod'
+const nextPeriod = 'nextPeriod'
+
 /**
  * Formats data for the `/notifications/setup/returns-period` page
  *
@@ -30,24 +35,25 @@ function _returnsPeriod() {
 }
 
 /*
- *  Checks if a date is in January
+ *  Checks if a date is in January (Before the 29th)
+ *
  *  A date is in January if it is between 1st January - 28th January
  */
 function _dayIsInJanuary(date) {
-  return date.getMonth() === 0 && date.getDate() >= 1 && date.getDate() <= 28
+  return date.getMonth() === monthsAsIntegers.january && date.getDate() <= 28
 }
 
 function _dayIsInJanuaryOptions(currentYear, previousYear) {
   return [
     {
-      value: 'quarterlyJanToMarch',
+      value: currentPeriod,
       text: `Quarterly 1st October ${previousYear} to 31st December ${previousYear}`,
       hint: {
         text: `Due date 28 Jan ${currentYear}`
       }
     },
     {
-      value: 'quarterlyAprilToMarch',
+      value: nextPeriod,
       text: `Quarterly 1st January ${currentYear} to 31st March ${currentYear}`,
       hint: {
         text: `Due date 28 April ${currentYear}`

--- a/test/presenters/notifications/setup/returns-period.presenter.test.js
+++ b/test/presenters/notifications/setup/returns-period.presenter.test.js
@@ -56,7 +56,7 @@ describe('Notifications Setup - Returns Period presenter', () => {
           } = ReturnsPeriodPresenter.go()
 
           expect(firstOption).to.equal({
-            value: 'quarterlyJanToMarch',
+            value: 'currentPeriod',
             text: `Quarterly 1st October ${previousYear} to 31st December ${previousYear}`,
             hint: {
               text: `Due date 28 Jan ${currentYear}`
@@ -72,7 +72,7 @@ describe('Notifications Setup - Returns Period presenter', () => {
           } = ReturnsPeriodPresenter.go()
 
           expect(secondOption).to.equal({
-            value: 'quarterlyAprilToMarch',
+            value: 'nextPeriod',
             text: `Quarterly 1st January ${currentYear} to 31st March ${currentYear}`,
             hint: {
               text: `Due date 28 April ${currentYear}`

--- a/test/presenters/notifications/setup/returns-period.presenter.test.js
+++ b/test/presenters/notifications/setup/returns-period.presenter.test.js
@@ -3,19 +3,83 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
+const Sinon = require('sinon')
 
-const { describe, it } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Thing under test
 const ReturnsPeriodPresenter = require('../../../../app/presenters/notifications/setup/returns-period.presenter.js')
 
 describe('Notifications Setup - Returns Period presenter', () => {
+  const currentYear = 2025
+  const previousYear = currentYear - 1
+
+  let testDate
+  let month
+  let day
+  let clock
+
+  afterEach(() => {
+    clock.restore()
+  })
+
   describe('when provided no params', () => {
+    beforeEach(() => {
+      month = 0
+      day = 15
+
+      testDate = new Date(currentYear, month, day)
+      clock = Sinon.useFakeTimers()
+    })
     it('correctly presents the data', () => {
       const result = ReturnsPeriodPresenter.go()
 
-      expect(result).to.equal({ backLink: '/manage', returnsPeriod: [] })
+      expect(result).to.equal({ backLink: '/manage' }, { skip: ['returnsPeriod'] })
+    })
+  })
+
+  describe('Options availability based on the current date', () => {
+    describe('When the current date is between 1st January - 28th January', () => {
+      beforeEach(() => {
+        month = 0
+        day = 15
+
+        testDate = new Date(currentYear, month, day)
+        clock = Sinon.useFakeTimers(testDate)
+      })
+
+      describe('Option 1 should be for Quarterly 1st October (previous year) to 31st December (previous year) with a due date 28 Jan (current year)', () => {
+        it('should return the correct "text" and "hint" values', () => {
+          const {
+            returnsPeriod: [firstOption]
+          } = ReturnsPeriodPresenter.go()
+
+          expect(firstOption).to.equal({
+            value: 'quarterlyJanToMarch',
+            text: `Quarterly 1st October ${previousYear} to 31st December ${previousYear}`,
+            hint: {
+              text: `Due date 28 Jan ${currentYear}`
+            }
+          })
+        })
+      })
+
+      describe('Option 2 should be for Quarterly 1st January (current year) to 31st March (current year) with a due date 28 April (current year)', () => {
+        it('should return the correct "text" and "hint" values', () => {
+          const {
+            returnsPeriod: [, secondOption]
+          } = ReturnsPeriodPresenter.go()
+
+          expect(secondOption).to.equal({
+            value: 'quarterlyAprilToMarch',
+            text: `Quarterly 1st January ${currentYear} to 31st March ${currentYear}`,
+            hint: {
+              text: `Due date 28 April ${currentYear}`
+            }
+          })
+        })
+      })
     })
   })
 })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4716

As part of the ongoing work to migrate the legacy UI we are replacing the notification journey from the UI and rebuilding in system.

This change adds the notifications returns periods option for between january.

The other options will be added in following commits.

The submit logic will be developed in a separate commit so the 'values' used to capture the selected options may change.