### PR TITLE
Refactor returns period options logic

### DIFF
--- a/app/lib/static-lookups.lib.js
+++ b/app/lib/static-lookups.lib.js
@@ -15,7 +15,9 @@ const contactTypes = ['person', 'department']
  * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getMonth
  */
 const monthsAsIntegers = {
-  january: 0
+  january: 0,
+  november: 10,
+  december: 11
 }
 
 const organisationTypes = ['individual', 'limitedCompany', 'limitedLiabilityPartnership', 'publicLimitedCompany']

--- a/app/lib/static-lookups.lib.js
+++ b/app/lib/static-lookups.lib.js
@@ -92,12 +92,12 @@ module.exports = {
   billRunTypes,
   companyTypes,
   contactTypes,
+  monthsAsIntegers,
+  naldRegions,
   organisationTypes,
   returnCycleDates,
   returnRequirementFrequencies,
   returnRequirementReasons,
-  naldRegions,
   sources,
-  twoPartTariffReviewIssues,
-  monthsAsIntegers
+  twoPartTariffReviewIssues
 }

--- a/app/lib/static-lookups.lib.js
+++ b/app/lib/static-lookups.lib.js
@@ -6,6 +6,10 @@ const companyTypes = ['person', 'organisation']
 
 const contactTypes = ['person', 'department']
 
+const monthsAsIntegers = {
+  january: 0
+}
+
 const organisationTypes = ['individual', 'limitedCompany', 'limitedLiabilityPartnership', 'publicLimitedCompany']
 
 const returnCycleDates = {
@@ -94,5 +98,6 @@ module.exports = {
   returnRequirementReasons,
   naldRegions,
   sources,
-  twoPartTariffReviewIssues
+  twoPartTariffReviewIssues,
+  monthsAsIntegers
 }

--- a/app/lib/static-lookups.lib.js
+++ b/app/lib/static-lookups.lib.js
@@ -6,6 +6,14 @@ const companyTypes = ['person', 'organisation']
 
 const contactTypes = ['person', 'department']
 
+/*
+ * Helper map for Months of the Year in integer format
+ *
+ * The getMonth() method of Date instances returns the month for this date according to local time,
+ * as a zero-based value (where zero indicates the first month of the year).
+ *
+ * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getMonth
+ */
 const monthsAsIntegers = {
   january: 0
 }

--- a/app/presenters/notifications/setup/returns-period.presenter.js
+++ b/app/presenters/notifications/setup/returns-period.presenter.js
@@ -5,12 +5,13 @@
  * @module ReturnsPeriodPresenter
  */
 
-const { monthsAsIntegers } = require('../../../lib/static-lookups.lib')
+const { formatLongDate } = require('../../base.presenter')
 
 const currentPeriod = 'currentPeriod'
 const nextPeriod = 'nextPeriod'
-const twentyEighth = 28
-const twentyNinth = 29
+
+const dueApril = '04-28'
+const dueJanuary = '01-28'
 
 /**
  * Formats data for the `/notifications/setup/returns-period` page
@@ -45,25 +46,26 @@ function _returnsPeriod() {
  *  A date is in January if it is between 1st January - 28th January
  */
 function _dayIsInJanuary(date) {
-  return date.getMonth() === monthsAsIntegers.january && date.getDate() <= twentyEighth
+  const startDate = new Date(date.getFullYear(), 0, 1) // January 1
+  const endDate = new Date(date.getFullYear(), 0, 28) // January 28
+
+  return _isDateBetween(date, startDate, endDate)
 }
 
 function _dayInJanuaryOptions(currentYear, previousYear) {
   return [
-    {
-      value: currentPeriod,
-      text: `Quarterly 1st October ${previousYear} to 31st December ${previousYear}`,
-      hint: {
-        text: `Due date 28 Jan ${currentYear}`
-      }
-    },
-    {
-      value: nextPeriod,
-      text: `Quarterly 1st January ${currentYear} to 31st March ${currentYear}`,
-      hint: {
-        text: `Due date 28 April ${currentYear}`
-      }
-    }
+    _quarterlyOptions(
+      currentPeriod,
+      new Date(`${previousYear}-10-01`),
+      new Date(`${previousYear}-12-31`),
+      new Date(`${currentYear}-${dueJanuary}`)
+    ),
+    _quarterlyOptions(
+      nextPeriod,
+      new Date(`${currentYear}-01-01`),
+      new Date(`${currentYear}-03-31`),
+      new Date(`${currentYear}-${dueApril}`)
+    )
   ]
 }
 
@@ -73,29 +75,45 @@ function _dayInJanuaryOptions(currentYear, previousYear) {
  * @returns {boolean} - true if date is in range (29th November - 31st December)
  */
 function _dayIsBetweenNovemberAndDecember(date) {
-  return (
-    date.getMonth() === monthsAsIntegers.december ||
-    (date.getMonth() === monthsAsIntegers.november && date.getDate() === twentyNinth)
-  )
+  const startDate = new Date(date.getFullYear(), 10, 29) // November 29
+  const endDate = new Date(date.getFullYear(), 11, 31) // December 31
+
+  return _isDateBetween(date, startDate, endDate)
 }
 
 function _dayBetweenNovemberAndDecemberOptions(currentYear, nextYear) {
   return [
-    {
-      value: currentPeriod,
-      text: `Quarterly 1st October ${currentYear} to 31st December ${currentYear}`,
-      hint: {
-        text: `Due date 28 Jan ${nextYear}`
-      }
-    },
-    {
-      value: nextPeriod,
-      text: `Quarterly 1st January ${nextYear} to 31st March ${nextYear}`,
-      hint: {
-        text: `Due date 28 April ${nextYear}`
-      }
-    }
+    _quarterlyOptions(
+      currentPeriod,
+      new Date(`${currentYear}-10-01`),
+      new Date(`${currentYear}-12-31`),
+      new Date(`${nextYear}-${dueJanuary}`)
+    ),
+    _quarterlyOptions(
+      nextPeriod,
+      new Date(`${nextYear}-01-01`),
+      new Date(`${nextYear}-03-31`),
+      new Date(`${nextYear}-${dueApril}`)
+    )
   ]
+}
+
+function _quarterlyOptions(period, fromDate, toDate, dueDate) {
+  return {
+    value: period,
+    text: `Quarterly ${formatLongDate(fromDate)} to ${formatLongDate(toDate)}`,
+    hint: {
+      text: `Due date ${formatLongDate(dueDate)}`
+    }
+  }
+}
+
+function _isDateBetween(targetDate, startDate, endDate) {
+  const target = new Date(targetDate).getTime()
+  const start = new Date(startDate).getTime()
+  const end = new Date(endDate).getTime()
+
+  return target >= start && target <= end
 }
 
 module.exports = {

--- a/app/presenters/notifications/setup/returns-period.presenter.js
+++ b/app/presenters/notifications/setup/returns-period.presenter.js
@@ -9,6 +9,7 @@ const { monthsAsIntegers } = require('../../../lib/static-lookups.lib')
 
 const currentPeriod = 'currentPeriod'
 const nextPeriod = 'nextPeriod'
+const twentyEighth = 28
 
 /**
  * Formats data for the `/notifications/setup/returns-period` page
@@ -40,7 +41,7 @@ function _returnsPeriod() {
  *  A date is in January if it is between 1st January - 28th January
  */
 function _dayIsInJanuary(date) {
-  return date.getMonth() === monthsAsIntegers.january && date.getDate() <= 28
+  return date.getMonth() === monthsAsIntegers.january && date.getDate() <= twentyEighth
 }
 
 function _dayIsInJanuaryOptions(currentYear, previousYear) {

--- a/app/presenters/notifications/setup/returns-period.presenter.js
+++ b/app/presenters/notifications/setup/returns-period.presenter.js
@@ -10,6 +10,7 @@ const { monthsAsIntegers } = require('../../../lib/static-lookups.lib')
 const currentPeriod = 'currentPeriod'
 const nextPeriod = 'nextPeriod'
 const twentyEighth = 28
+const twentyNinth = 29
 
 /**
  * Formats data for the `/notifications/setup/returns-period` page
@@ -27,9 +28,12 @@ function _returnsPeriod() {
   const today = new Date()
   const currentYear = today.getFullYear()
   const previousYear = currentYear - 1
+  const nextYear = currentYear + 1
 
   if (_dayIsInJanuary(today)) {
-    return _dayIsInJanuaryOptions(currentYear, previousYear)
+    return _dayInJanuaryOptions(currentYear, previousYear)
+  } else if (_dayIsBetweenNovemberAndDecember(today)) {
+    return _dayBetweenNovemberAndDecemberOptions(currentYear, nextYear)
   }
 
   return []
@@ -44,7 +48,7 @@ function _dayIsInJanuary(date) {
   return date.getMonth() === monthsAsIntegers.january && date.getDate() <= twentyEighth
 }
 
-function _dayIsInJanuaryOptions(currentYear, previousYear) {
+function _dayInJanuaryOptions(currentYear, previousYear) {
   return [
     {
       value: currentPeriod,
@@ -58,6 +62,37 @@ function _dayIsInJanuaryOptions(currentYear, previousYear) {
       text: `Quarterly 1st January ${currentYear} to 31st March ${currentYear}`,
       hint: {
         text: `Due date 28 April ${currentYear}`
+      }
+    }
+  ]
+}
+
+/*
+ *  When the date is between 29th November - 31st December
+ *
+ * @returns {boolean} - true if date is in range (29th November - 31st December)
+ */
+function _dayIsBetweenNovemberAndDecember(date) {
+  return (
+    date.getMonth() === monthsAsIntegers.december ||
+    (date.getMonth() === monthsAsIntegers.november && date.getDate() === twentyNinth)
+  )
+}
+
+function _dayBetweenNovemberAndDecemberOptions(currentYear, nextYear) {
+  return [
+    {
+      value: currentPeriod,
+      text: `Quarterly 1st October ${currentYear} to 31st December ${currentYear}`,
+      hint: {
+        text: `Due date 28 Jan ${nextYear}`
+      }
+    },
+    {
+      value: nextPeriod,
+      text: `Quarterly 1st January ${nextYear} to 31st March ${nextYear}`,
+      hint: {
+        text: `Due date 28 April ${nextYear}`
       }
     }
   ]

--- a/app/presenters/notifications/setup/returns-period.presenter.js
+++ b/app/presenters/notifications/setup/returns-period.presenter.js
@@ -18,7 +18,42 @@ function go() {
 }
 
 function _returnsPeriod() {
+  const today = new Date()
+  const currentYear = today.getFullYear()
+  const previousYear = currentYear - 1
+
+  if (_dayIsInJanuary(today)) {
+    return _dayIsInJanuaryOptions(currentYear, previousYear)
+  }
+
   return []
+}
+
+/*
+ *  Checks if a date is in January
+ *  A date is in January if it is between 1st January - 28th January
+ */
+function _dayIsInJanuary(date) {
+  return date.getMonth() === 0 && date.getDate() >= 1 && date.getDate() <= 28
+}
+
+function _dayIsInJanuaryOptions(currentYear, previousYear) {
+  return [
+    {
+      value: 'quarterlyJanToMarch',
+      text: `Quarterly 1st October ${previousYear} to 31st December ${previousYear}`,
+      hint: {
+        text: `Due date 28 Jan ${currentYear}`
+      }
+    },
+    {
+      value: 'quarterlyAprilToMarch',
+      text: `Quarterly 1st January ${currentYear} to 31st March ${currentYear}`,
+      hint: {
+        text: `Due date 28 April ${currentYear}`
+      }
+    }
+  ]
 }
 
 module.exports = {

--- a/app/presenters/notifications/setup/returns-period.presenter.js
+++ b/app/presenters/notifications/setup/returns-period.presenter.js
@@ -34,9 +34,9 @@ function _returnsPeriod() {
     return _dayInJanuaryOptions(currentYear, previousYear)
   } else if (_dayIsBetweenNovemberAndDecember(today)) {
     return _dayBetweenNovemberAndDecemberOptions(currentYear, nextYear)
+  } else {
+    return []
   }
-
-  return []
 }
 
 /*

--- a/app/presenters/notifications/setup/returns-period.presenter.js
+++ b/app/presenters/notifications/setup/returns-period.presenter.js
@@ -5,6 +5,11 @@
  * @module ReturnsPeriodPresenter
  */
 
+const { monthsAsIntegers } = require('../../../lib/static-lookups.lib')
+
+const currentPeriod = 'currentPeriod'
+const nextPeriod = 'nextPeriod'
+
 /**
  * Formats data for the `/notifications/setup/returns-period` page
  *
@@ -30,24 +35,25 @@ function _returnsPeriod() {
 }
 
 /*
- *  Checks if a date is in January
+ *  Checks if a date is in January (Before the 29th)
+ *
  *  A date is in January if it is between 1st January - 28th January
  */
 function _dayIsInJanuary(date) {
-  return date.getMonth() === 0 && date.getDate() >= 1 && date.getDate() <= 28
+  return date.getMonth() === monthsAsIntegers.january && date.getDate() <= 28
 }
 
 function _dayIsInJanuaryOptions(currentYear, previousYear) {
   return [
     {
-      value: 'quarterlyJanToMarch',
+      value: currentPeriod,
       text: `Quarterly 1st October ${previousYear} to 31st December ${previousYear}`,
       hint: {
         text: `Due date 28 Jan ${currentYear}`
       }
     },
     {
-      value: 'quarterlyAprilToMarch',
+      value: nextPeriod,
       text: `Quarterly 1st January ${currentYear} to 31st March ${currentYear}`,
       hint: {
         text: `Due date 28 April ${currentYear}`

--- a/test/presenters/notifications/setup/returns-period.presenter.test.js
+++ b/test/presenters/notifications/setup/returns-period.presenter.test.js
@@ -11,9 +11,10 @@ const { expect } = Code
 // Thing under test
 const ReturnsPeriodPresenter = require('../../../../app/presenters/notifications/setup/returns-period.presenter.js')
 
-describe('Notifications Setup - Returns Period presenter', () => {
+describe.only('Notifications Setup - Returns Period presenter', () => {
   const currentYear = 2025
   const previousYear = currentYear - 1
+  const nextYear = currentYear + 1
 
   let testDate
   let month
@@ -76,6 +77,48 @@ describe('Notifications Setup - Returns Period presenter', () => {
             text: `Quarterly 1st January ${currentYear} to 31st March ${currentYear}`,
             hint: {
               text: `Due date 28 April ${currentYear}`
+            }
+          })
+        })
+      })
+    })
+
+    describe('When the current date is between 29th November - 31st December', () => {
+      beforeEach(() => {
+        month = 11
+        day = 25
+
+        testDate = new Date(currentYear, month, day)
+        clock = Sinon.useFakeTimers(testDate)
+      })
+
+      describe('Option 1 should be for Quarterly 1st October (current year) to 31st December (current year) with a due date 28 Jan (next year)', () => {
+        it('should return the correct "text" and "hint" values', () => {
+          const {
+            returnsPeriod: [firstOption]
+          } = ReturnsPeriodPresenter.go()
+
+          expect(firstOption).to.equal({
+            value: 'currentPeriod',
+            text: `Quarterly 1st October ${currentYear} to 31st December ${currentYear}`,
+            hint: {
+              text: `Due date 28 Jan ${nextYear}`
+            }
+          })
+        })
+      })
+
+      describe('Option 2 should be for Quarterly 1st January (next year) to 31st March (next year) with a due date 28 April (next year)', () => {
+        it('should return the correct "text" and "hint" values', () => {
+          const {
+            returnsPeriod: [, secondOption]
+          } = ReturnsPeriodPresenter.go()
+
+          expect(secondOption).to.equal({
+            value: 'nextPeriod',
+            text: `Quarterly 1st January ${nextYear} to 31st March ${nextYear}`,
+            hint: {
+              text: `Due date 28 April ${nextYear}`
             }
           })
         })

--- a/test/presenters/notifications/setup/returns-period.presenter.test.js
+++ b/test/presenters/notifications/setup/returns-period.presenter.test.js
@@ -11,7 +11,7 @@ const { expect } = Code
 // Thing under test
 const ReturnsPeriodPresenter = require('../../../../app/presenters/notifications/setup/returns-period.presenter.js')
 
-describe('Notifications Setup - Returns Period presenter', () => {
+describe.only('Notifications Setup - Returns Period presenter', () => {
   const currentYear = 2025
   const previousYear = currentYear - 1
   const nextYear = currentYear + 1
@@ -58,9 +58,9 @@ describe('Notifications Setup - Returns Period presenter', () => {
 
           expect(firstOption).to.equal({
             value: 'currentPeriod',
-            text: `Quarterly 1st October ${previousYear} to 31st December ${previousYear}`,
+            text: `Quarterly 1 October ${previousYear} to 31 December ${previousYear}`,
             hint: {
-              text: `Due date 28 Jan ${currentYear}`
+              text: `Due date 28 January ${currentYear}`
             }
           })
         })
@@ -74,7 +74,7 @@ describe('Notifications Setup - Returns Period presenter', () => {
 
           expect(secondOption).to.equal({
             value: 'nextPeriod',
-            text: `Quarterly 1st January ${currentYear} to 31st March ${currentYear}`,
+            text: `Quarterly 1 January ${currentYear} to 31 March ${currentYear}`,
             hint: {
               text: `Due date 28 April ${currentYear}`
             }
@@ -100,9 +100,9 @@ describe('Notifications Setup - Returns Period presenter', () => {
 
           expect(firstOption).to.equal({
             value: 'currentPeriod',
-            text: `Quarterly 1st October ${currentYear} to 31st December ${currentYear}`,
+            text: `Quarterly 1 October ${currentYear} to 31 December ${currentYear}`,
             hint: {
-              text: `Due date 28 Jan ${nextYear}`
+              text: `Due date 28 January ${nextYear}`
             }
           })
         })
@@ -116,7 +116,7 @@ describe('Notifications Setup - Returns Period presenter', () => {
 
           expect(secondOption).to.equal({
             value: 'nextPeriod',
-            text: `Quarterly 1st January ${nextYear} to 31st March ${nextYear}`,
+            text: `Quarterly 1 January ${nextYear} to 31 March ${nextYear}`,
             hint: {
               text: `Due date 28 April ${nextYear}`
             }

--- a/test/presenters/notifications/setup/returns-period.presenter.test.js
+++ b/test/presenters/notifications/setup/returns-period.presenter.test.js
@@ -81,51 +81,6 @@ describe('Notifications Setup - Returns Period presenter', () => {
           })
         })
       })
-      expect(result).to.equal({ backLink: '/manage' }, { skip: ['returnsPeriod'] })
-    })
-  })
-
-  describe('Options availability based on the current date', () => {
-    describe('When the current date is between 1st January - 28th January', () => {
-      beforeEach(() => {
-        month = 0
-        day = 15
-
-        testDate = new Date(currentYear, month, day)
-        clock = Sinon.useFakeTimers(testDate)
-      })
-
-      describe('Option 1 should be for Quarterly 1st October (previous year) to 31st December (previous year) with a due date 28 Jan (current year)', () => {
-        it('should return the correct "text" and "hint" values', () => {
-          const {
-            returnsPeriod: [firstOption]
-          } = ReturnsPeriodPresenter.go()
-
-          expect(firstOption).to.equal({
-            value: 'currentPeriod',
-            text: `Quarterly 1st October ${previousYear} to 31st December ${previousYear}`,
-            hint: {
-              text: `Due date 28 Jan ${currentYear}`
-            }
-          })
-        })
-      })
-
-      describe('Option 2 should be for Quarterly 1st January (current year) to 31st March (current year) with a due date 28 April (current year)', () => {
-        it('should return the correct "text" and "hint" values', () => {
-          const {
-            returnsPeriod: [, secondOption]
-          } = ReturnsPeriodPresenter.go()
-
-          expect(secondOption).to.equal({
-            value: 'nextPeriod',
-            text: `Quarterly 1st January ${currentYear} to 31st March ${currentYear}`,
-            hint: {
-              text: `Due date 28 April ${currentYear}`
-            }
-          })
-        })
-      })
     })
 
     describe('When the current date is between 29th November - 31st December', () => {

--- a/test/presenters/notifications/setup/returns-period.presenter.test.js
+++ b/test/presenters/notifications/setup/returns-period.presenter.test.js
@@ -56,7 +56,7 @@ describe('Notifications Setup - Returns Period presenter', () => {
           } = ReturnsPeriodPresenter.go()
 
           expect(firstOption).to.equal({
-            value: 'quarterlyJanToMarch',
+            value: 'currentPeriod',
             text: `Quarterly 1st October ${previousYear} to 31st December ${previousYear}`,
             hint: {
               text: `Due date 28 Jan ${currentYear}`
@@ -72,7 +72,7 @@ describe('Notifications Setup - Returns Period presenter', () => {
           } = ReturnsPeriodPresenter.go()
 
           expect(secondOption).to.equal({
-            value: 'quarterlyAprilToMarch',
+            value: 'nextPeriod',
             text: `Quarterly 1st January ${currentYear} to 31st March ${currentYear}`,
             hint: {
               text: `Due date 28 April ${currentYear}`

--- a/test/presenters/notifications/setup/returns-period.presenter.test.js
+++ b/test/presenters/notifications/setup/returns-period.presenter.test.js
@@ -3,19 +3,83 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
+const Sinon = require('sinon')
 
-const { describe, it } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Thing under test
 const ReturnsPeriodPresenter = require('../../../../app/presenters/notifications/setup/returns-period.presenter.js')
 
 describe('Notifications Setup - Returns Period presenter', () => {
+  const currentYear = 2025
+  const previousYear = currentYear - 1
+
+  let testDate
+  let month
+  let day
+  let clock
+
+  afterEach(() => {
+    clock.restore()
+  })
+
   describe('when provided no params', () => {
+    beforeEach(() => {
+      month = 0
+      day = 15
+
+      testDate = new Date(currentYear, month, day)
+      clock = Sinon.useFakeTimers()
+    })
     it('correctly presents the data', () => {
       const result = ReturnsPeriodPresenter.go()
 
-      expect(result).to.equal({ backLink: '/manage', returnsPeriod: [] })
+      expect(result).to.equal({ backLink: '/manage' }, { skip: ['returnsPeriod'] })
+    })
+  })
+
+  describe('Options availability based on the current date', () => {
+    describe('When the current date is between 1st January - 28th January', () => {
+      beforeEach(() => {
+        month = 0
+        day = 15
+
+        testDate = new Date(currentYear, month, day)
+        clock = Sinon.useFakeTimers(testDate)
+      })
+
+      describe('Option 1 should be for Quarterly 1st October (previous year) to 31st December (previous year) with a due date 28 Jan (current year)', () => {
+        it('should return the correct "text" and "hint" values', () => {
+          const {
+            returnsPeriod: [firstOption]
+          } = ReturnsPeriodPresenter.go()
+
+          expect(firstOption).to.equal({
+            value: 'quarterlyJanToMarch',
+            text: `Quarterly 1st October ${previousYear} to 31st December ${previousYear}`,
+            hint: {
+              text: `Due date 28 Jan ${currentYear}`
+            }
+          })
+        })
+      })
+
+      describe('Option 2 should be for Quarterly 1st January (current year) to 31st March (current year) with a due date 28 April (current year)', () => {
+        it('should return the correct "text" and "hint" values', () => {
+          const {
+            returnsPeriod: [, secondOption]
+          } = ReturnsPeriodPresenter.go()
+
+          expect(secondOption).to.equal({
+            value: 'quarterlyAprilToMarch',
+            text: `Quarterly 1st January ${currentYear} to 31st March ${currentYear}`,
+            hint: {
+              text: `Due date 28 April ${currentYear}`
+            }
+          })
+        })
+      })
     })
   })
 })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4716

Previous has been done to implement the required output for the work in the ticket. 

But we can do more in the code to make this closer to the returns cycles. 

This change will refactor the returns period presenter to better align with the workings of return cycles, rather than just fixing dates boundaries with no specific reason / meaning.