### PR TITLE
Notifications returns period options - October - November

### DIFF
--- a/app/lib/static-lookups.lib.js
+++ b/app/lib/static-lookups.lib.js
@@ -16,6 +16,7 @@ const contactTypes = ['person', 'department']
  */
 const monthsAsIntegers = {
   january: 0,
+  october: 9,
   november: 10,
   december: 11
 }

--- a/app/presenters/notifications/setup/returns-period.presenter.js
+++ b/app/presenters/notifications/setup/returns-period.presenter.js
@@ -106,13 +106,10 @@ function _dayBetweenNovemberAndDecemberOptions(currentYear, nextYear) {
  * @returns {boolean} - true if date is in range (29th October - 28th November)
  */
 function _dayIsBetweenOctoberAndNovember(date) {
-  if (date.getMonth() === monthsAsIntegers.october && date.getDate() === twentyNinth) {
-    return true
-  } else if (date.getMonth() === monthsAsIntegers.november && date.getDate() <= twentyEighth) {
-    return true
-  } else {
-    return false
-  }
+  return (
+    (date.getMonth() === monthsAsIntegers.october && date.getDate() === twentyNinth) ||
+    (date.getMonth() === monthsAsIntegers.november && date.getDate() <= twentyEighth)
+  )
 }
 
 function _dayBetweenOctoberAndNovemberOptions(previousYear, currentYear, nextYear) {

--- a/app/presenters/notifications/setup/returns-period.presenter.js
+++ b/app/presenters/notifications/setup/returns-period.presenter.js
@@ -34,6 +34,8 @@ function _returnsPeriod() {
     return _dayInJanuaryOptions(currentYear, previousYear)
   } else if (_dayIsBetweenNovemberAndDecember(today)) {
     return _dayBetweenNovemberAndDecemberOptions(currentYear, nextYear)
+  } else if (_dayIsBetweenOctoberAndNovember(today)) {
+    return _dayBetweenOctoberAndNovemberOptions(previousYear, currentYear, nextYear)
   } else {
     return []
   }
@@ -93,6 +95,40 @@ function _dayBetweenNovemberAndDecemberOptions(currentYear, nextYear) {
       text: `Quarterly 1st January ${nextYear} to 31st March ${nextYear}`,
       hint: {
         text: `Due date 28 April ${nextYear}`
+      }
+    }
+  ]
+}
+
+/*
+ *  When the date is between 29th October - 28th November
+ *
+ * @returns {boolean} - true if date is in range (29th October - 28th November)
+ */
+function _dayIsBetweenOctoberAndNovember(date) {
+  if (date.getMonth() === monthsAsIntegers.october && date.getDate() === twentyNinth) {
+    return true
+  } else if (date.getMonth() === monthsAsIntegers.november && date.getDate() <= twentyEighth) {
+    return true
+  } else {
+    return false
+  }
+}
+
+function _dayBetweenOctoberAndNovemberOptions(previousYear, currentYear, nextYear) {
+  return [
+    {
+      value: currentPeriod,
+      text: `Summer annual 1st November ${previousYear} to 31st October ${currentYear}`,
+      hint: {
+        text: `Due date 28 November ${currentYear}`
+      }
+    },
+    {
+      value: nextPeriod,
+      text: `Quarterly 1st October ${currentYear} to 31st December ${currentYear}`,
+      hint: {
+        text: `Due date 28 January ${nextYear}`
       }
     }
   ]

--- a/test/presenters/notifications/setup/returns-period.presenter.test.js
+++ b/test/presenters/notifications/setup/returns-period.presenter.test.js
@@ -127,6 +127,132 @@ describe('Notifications Setup - Returns Period presenter', () => {
       })
     })
 
+    describe('When the current date is between 29th October - 28th November', () => {
+      describe('and the date is 29th October', () => {
+        beforeEach(() => {
+          month = 9
+          day = 29
+
+          testDate = new Date(currentYear, month, day)
+          clock = Sinon.useFakeTimers(testDate)
+        })
+
+        describe('Option 1 should be for Summer annual 1st November (previous year) to 31st October (current year) with a due date 28 November (current year)', () => {
+          it('should return the correct "text" and "hint" values', () => {
+            const {
+              returnsPeriod: [firstOption]
+            } = ReturnsPeriodPresenter.go()
+
+            expect(firstOption).to.equal({
+              value: 'currentPeriod',
+              text: `Summer annual 1st November ${previousYear} to 31st October ${currentYear}`,
+              hint: {
+                text: `Due date 28 November ${currentYear}`
+              }
+            })
+          })
+        })
+
+        describe('Option 2 should be for Quarterly 1st October (current year) to 31st December (current year) with a due date 28 January (next year)', () => {
+          it('should return the correct "text" and "hint" values', () => {
+            const {
+              returnsPeriod: [, secondOption]
+            } = ReturnsPeriodPresenter.go()
+
+            expect(secondOption).to.equal({
+              value: 'nextPeriod',
+              text: `Quarterly 1st October ${currentYear} to 31st December ${currentYear}`,
+              hint: {
+                text: `Due date 28 January ${nextYear}`
+              }
+            })
+          })
+        })
+      })
+      describe('and the date is in November', () => {
+        beforeEach(() => {
+          month = 10
+          day = 20
+
+          testDate = new Date(currentYear, month, day)
+          clock = Sinon.useFakeTimers(testDate)
+        })
+
+        describe('Option 1 should be for Summer annual 1st November (previous year) to 31st October (current year) with a due date 28 November (current year)', () => {
+          it('should return the correct "text" and "hint" values', () => {
+            const {
+              returnsPeriod: [firstOption]
+            } = ReturnsPeriodPresenter.go()
+
+            expect(firstOption).to.equal({
+              value: 'currentPeriod',
+              text: `Summer annual 1st November ${previousYear} to 31st October ${currentYear}`,
+              hint: {
+                text: `Due date 28 November ${currentYear}`
+              }
+            })
+          })
+        })
+
+        describe('Option 2 should be for Quarterly 1st October (current year) to 31st December (current year) with a due date 28 January (next year)', () => {
+          it('should return the correct "text" and "hint" values', () => {
+            const {
+              returnsPeriod: [, secondOption]
+            } = ReturnsPeriodPresenter.go()
+
+            expect(secondOption).to.equal({
+              value: 'nextPeriod',
+              text: `Quarterly 1st October ${currentYear} to 31st December ${currentYear}`,
+              hint: {
+                text: `Due date 28 January ${nextYear}`
+              }
+            })
+          })
+        })
+      })
+      describe('and the date is 28th November', () => {
+        beforeEach(() => {
+          month = 10
+          day = 28
+
+          testDate = new Date(currentYear, month, day)
+          clock = Sinon.useFakeTimers(testDate)
+        })
+
+        describe('Option 1 should be for Summer annual 1st November (previous year) to 31st October (current year) with a due date 28 November (current year)', () => {
+          it('should return the correct "text" and "hint" values', () => {
+            const {
+              returnsPeriod: [firstOption]
+            } = ReturnsPeriodPresenter.go()
+
+            expect(firstOption).to.equal({
+              value: 'currentPeriod',
+              text: `Summer annual 1st November ${previousYear} to 31st October ${currentYear}`,
+              hint: {
+                text: `Due date 28 November ${currentYear}`
+              }
+            })
+          })
+        })
+
+        describe('Option 2 should be for Quarterly 1st October (current year) to 31st December (current year) with a due date 28 January (next year)', () => {
+          it('should return the correct "text" and "hint" values', () => {
+            const {
+              returnsPeriod: [, secondOption]
+            } = ReturnsPeriodPresenter.go()
+
+            expect(secondOption).to.equal({
+              value: 'nextPeriod',
+              text: `Quarterly 1st October ${currentYear} to 31st December ${currentYear}`,
+              hint: {
+                text: `Due date 28 January ${nextYear}`
+              }
+            })
+          })
+        })
+      })
+    })
+
     describe('When the current date is between 29th November - 31st December', () => {
       describe('and the date is in December', () => {
         beforeEach(() => {

--- a/test/presenters/notifications/setup/returns-period.presenter.test.js
+++ b/test/presenters/notifications/setup/returns-period.presenter.test.js
@@ -11,7 +11,7 @@ const { expect } = Code
 // Thing under test
 const ReturnsPeriodPresenter = require('../../../../app/presenters/notifications/setup/returns-period.presenter.js')
 
-describe('Notifications Setup - Returns Period presenter', () => {
+describe.only('Notifications Setup - Returns Period presenter', () => {
   const currentYear = 2025
   const previousYear = currentYear - 1
   const nextYear = currentYear + 1
@@ -42,42 +42,86 @@ describe('Notifications Setup - Returns Period presenter', () => {
 
   describe('Options availability based on the current date', () => {
     describe('When the current date is between 1st January - 28th January', () => {
-      beforeEach(() => {
-        month = 0
-        day = 15
+      describe('and the date is in January', () => {
+        beforeEach(() => {
+          month = 0
+          day = 15
 
-        testDate = new Date(currentYear, month, day)
-        clock = Sinon.useFakeTimers(testDate)
-      })
+          testDate = new Date(currentYear, month, day)
+          clock = Sinon.useFakeTimers(testDate)
+        })
 
-      describe('Option 1 should be for Quarterly 1st October (previous year) to 31st December (previous year) with a due date 28 Jan (current year)', () => {
-        it('should return the correct "text" and "hint" values', () => {
-          const {
-            returnsPeriod: [firstOption]
-          } = ReturnsPeriodPresenter.go()
+        describe('Option 1 should be for Quarterly 1st October (previous year) to 31st December (previous year) with a due date 28 Jan (current year)', () => {
+          it('should return the correct "text" and "hint" values', () => {
+            const {
+              returnsPeriod: [firstOption]
+            } = ReturnsPeriodPresenter.go()
 
-          expect(firstOption).to.equal({
-            value: 'currentPeriod',
-            text: `Quarterly 1st October ${previousYear} to 31st December ${previousYear}`,
-            hint: {
-              text: `Due date 28 Jan ${currentYear}`
-            }
+            expect(firstOption).to.equal({
+              value: 'currentPeriod',
+              text: `Quarterly 1st October ${previousYear} to 31st December ${previousYear}`,
+              hint: {
+                text: `Due date 28 Jan ${currentYear}`
+              }
+            })
+          })
+        })
+
+        describe('Option 2 should be for Quarterly 1st January (current year) to 31st March (current year) with a due date 28 April (current year)', () => {
+          it('should return the correct "text" and "hint" values', () => {
+            const {
+              returnsPeriod: [, secondOption]
+            } = ReturnsPeriodPresenter.go()
+
+            expect(secondOption).to.equal({
+              value: 'nextPeriod',
+              text: `Quarterly 1st January ${currentYear} to 31st March ${currentYear}`,
+              hint: {
+                text: `Due date 28 April ${currentYear}`
+              }
+            })
           })
         })
       })
 
-      describe('Option 2 should be for Quarterly 1st January (current year) to 31st March (current year) with a due date 28 April (current year)', () => {
-        it('should return the correct "text" and "hint" values', () => {
-          const {
-            returnsPeriod: [, secondOption]
-          } = ReturnsPeriodPresenter.go()
+      describe('and the date is 28th January', () => {
+        beforeEach(() => {
+          month = 0
+          day = 28
 
-          expect(secondOption).to.equal({
-            value: 'nextPeriod',
-            text: `Quarterly 1st January ${currentYear} to 31st March ${currentYear}`,
-            hint: {
-              text: `Due date 28 April ${currentYear}`
-            }
+          testDate = new Date(currentYear, month, day)
+          clock = Sinon.useFakeTimers(testDate)
+        })
+
+        describe('Option 1 should be for Quarterly 1st October (previous year) to 31st December (previous year) with a due date 28 Jan (current year)', () => {
+          it('should return the correct "text" and "hint" values', () => {
+            const {
+              returnsPeriod: [firstOption]
+            } = ReturnsPeriodPresenter.go()
+
+            expect(firstOption).to.equal({
+              value: 'currentPeriod',
+              text: `Quarterly 1st October ${previousYear} to 31st December ${previousYear}`,
+              hint: {
+                text: `Due date 28 Jan ${currentYear}`
+              }
+            })
+          })
+        })
+
+        describe('Option 2 should be for Quarterly 1st January (current year) to 31st March (current year) with a due date 28 April (current year)', () => {
+          it('should return the correct "text" and "hint" values', () => {
+            const {
+              returnsPeriod: [, secondOption]
+            } = ReturnsPeriodPresenter.go()
+
+            expect(secondOption).to.equal({
+              value: 'nextPeriod',
+              text: `Quarterly 1st January ${currentYear} to 31st March ${currentYear}`,
+              hint: {
+                text: `Due date 28 April ${currentYear}`
+              }
+            })
           })
         })
       })

--- a/test/presenters/notifications/setup/returns-period.presenter.test.js
+++ b/test/presenters/notifications/setup/returns-period.presenter.test.js
@@ -11,7 +11,7 @@ const { expect } = Code
 // Thing under test
 const ReturnsPeriodPresenter = require('../../../../app/presenters/notifications/setup/returns-period.presenter.js')
 
-describe.only('Notifications Setup - Returns Period presenter', () => {
+describe('Notifications Setup - Returns Period presenter', () => {
   const currentYear = 2025
   const previousYear = currentYear - 1
   const nextYear = currentYear + 1

--- a/test/presenters/notifications/setup/returns-period.presenter.test.js
+++ b/test/presenters/notifications/setup/returns-period.presenter.test.js
@@ -84,42 +84,85 @@ describe('Notifications Setup - Returns Period presenter', () => {
     })
 
     describe('When the current date is between 29th November - 31st December', () => {
-      beforeEach(() => {
-        month = 11
-        day = 25
+      describe('and the date is in December', () => {
+        beforeEach(() => {
+          month = 11
+          day = 25
 
-        testDate = new Date(currentYear, month, day)
-        clock = Sinon.useFakeTimers(testDate)
-      })
+          testDate = new Date(currentYear, month, day)
+          clock = Sinon.useFakeTimers(testDate)
+        })
 
-      describe('Option 1 should be for Quarterly 1st October (current year) to 31st December (current year) with a due date 28 Jan (next year)', () => {
-        it('should return the correct "text" and "hint" values', () => {
-          const {
-            returnsPeriod: [firstOption]
-          } = ReturnsPeriodPresenter.go()
+        describe('Option 1 should be for Quarterly 1st October (current year) to 31st December (current year) with a due date 28 Jan (next year)', () => {
+          it('should return the correct "text" and "hint" values', () => {
+            const {
+              returnsPeriod: [firstOption]
+            } = ReturnsPeriodPresenter.go()
 
-          expect(firstOption).to.equal({
-            value: 'currentPeriod',
-            text: `Quarterly 1st October ${currentYear} to 31st December ${currentYear}`,
-            hint: {
-              text: `Due date 28 Jan ${nextYear}`
-            }
+            expect(firstOption).to.equal({
+              value: 'currentPeriod',
+              text: `Quarterly 1st October ${currentYear} to 31st December ${currentYear}`,
+              hint: {
+                text: `Due date 28 Jan ${nextYear}`
+              }
+            })
+          })
+        })
+
+        describe('Option 2 should be for Quarterly 1st January (next year) to 31st March (next year) with a due date 28 April (next year)', () => {
+          it('should return the correct "text" and "hint" values', () => {
+            const {
+              returnsPeriod: [, secondOption]
+            } = ReturnsPeriodPresenter.go()
+
+            expect(secondOption).to.equal({
+              value: 'nextPeriod',
+              text: `Quarterly 1st January ${nextYear} to 31st March ${nextYear}`,
+              hint: {
+                text: `Due date 28 April ${nextYear}`
+              }
+            })
           })
         })
       })
+      describe('and the date is 29th November', () => {
+        beforeEach(() => {
+          month = 10
+          day = 29
 
-      describe('Option 2 should be for Quarterly 1st January (next year) to 31st March (next year) with a due date 28 April (next year)', () => {
-        it('should return the correct "text" and "hint" values', () => {
-          const {
-            returnsPeriod: [, secondOption]
-          } = ReturnsPeriodPresenter.go()
+          testDate = new Date(currentYear, month, day)
+          clock = Sinon.useFakeTimers(testDate)
+        })
 
-          expect(secondOption).to.equal({
-            value: 'nextPeriod',
-            text: `Quarterly 1st January ${nextYear} to 31st March ${nextYear}`,
-            hint: {
-              text: `Due date 28 April ${nextYear}`
-            }
+        describe('Option 1 should be for Quarterly 1st October (current year) to 31st December (current year) with a due date 28 Jan (next year)', () => {
+          it('should return the correct "text" and "hint" values', () => {
+            const {
+              returnsPeriod: [firstOption]
+            } = ReturnsPeriodPresenter.go()
+
+            expect(firstOption).to.equal({
+              value: 'currentPeriod',
+              text: `Quarterly 1st October ${currentYear} to 31st December ${currentYear}`,
+              hint: {
+                text: `Due date 28 Jan ${nextYear}`
+              }
+            })
+          })
+        })
+
+        describe('Option 2 should be for Quarterly 1st January (next year) to 31st March (next year) with a due date 28 April (next year)', () => {
+          it('should return the correct "text" and "hint" values', () => {
+            const {
+              returnsPeriod: [, secondOption]
+            } = ReturnsPeriodPresenter.go()
+
+            expect(secondOption).to.equal({
+              value: 'nextPeriod',
+              text: `Quarterly 1st January ${nextYear} to 31st March ${nextYear}`,
+              hint: {
+                text: `Due date 28 April ${nextYear}`
+              }
+            })
           })
         })
       })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4716

As part of the ongoing work to migrate the legacy UI we are replacing the notification journey from the UI and rebuilding in system.

This change adds the notifications returns periods option for between 29th October - 28th November .

The other options will be added in following commits / oir already exist.

The submit logic will be developed in a separate commit so the 'values' used to capture the selected options may change.