### PR TITLE
Update model tests to use before block

### DIFF
--- a/test/models/billing-account-address.model.test.js
+++ b/test/models/billing-account-address.model.test.js
@@ -4,7 +4,7 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, before } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -22,13 +22,34 @@ const ContactModel = require('../../app/models/contact.model.js')
 const BillingAccountAddressModel = require('../../app/models/billing-account-address.model.js')
 
 describe('Billing Account Address model', () => {
+  let testAddress
+  let testBillingAccount
+  let testContact
+  let testCompany
   let testRecord
 
-  describe('Basic query', () => {
-    beforeEach(async () => {
-      testRecord = await BillingAccountAddressHelper.add()
-    })
+  before(async () => {
+    // Link contact
+    testContact = await ContactHelper.add()
+    const { id: contactId } = testContact
 
+    // Link billing account
+    testBillingAccount = await BillingAccountHelper.add()
+    const { id: billingAccountId } = testBillingAccount
+
+    // Link company
+    testCompany = await CompanyHelper.add()
+    const { id: companyId } = testCompany
+
+    // Link address
+    testAddress = await AddressHelper.add()
+    const { id: addressId } = testAddress
+
+    // Test record
+    testRecord = await BillingAccountAddressHelper.add({ addressId, companyId, billingAccountId, contactId })
+  })
+
+  describe('Basic query', () => {
     it('can successfully run a basic query', async () => {
       const result = await BillingAccountAddressModel.query().findById(testRecord.id)
 
@@ -39,13 +60,6 @@ describe('Billing Account Address model', () => {
 
   describe('Relationships', () => {
     describe('when linking to address', () => {
-      let testAddress
-
-      beforeEach(async () => {
-        testAddress = await AddressHelper.add()
-        testRecord = await BillingAccountAddressHelper.add({ addressId: testAddress.id })
-      })
-
       it('can successfully run a related query', async () => {
         const query = await BillingAccountAddressModel.query().innerJoinRelated('address')
 
@@ -64,13 +78,6 @@ describe('Billing Account Address model', () => {
     })
 
     describe('when linking to company', () => {
-      let testCompany
-
-      beforeEach(async () => {
-        testCompany = await CompanyHelper.add()
-        testRecord = await BillingAccountAddressHelper.add({ companyId: testCompany.id })
-      })
-
       it('can successfully run a related query', async () => {
         const query = await BillingAccountAddressModel.query().innerJoinRelated('company')
 
@@ -89,13 +96,6 @@ describe('Billing Account Address model', () => {
     })
 
     describe('when linking to billing account', () => {
-      let testBillingAccount
-
-      beforeEach(async () => {
-        testBillingAccount = await BillingAccountHelper.add()
-        testRecord = await BillingAccountAddressHelper.add({ billingAccountId: testBillingAccount.id })
-      })
-
       it('can successfully run a related query', async () => {
         const query = await BillingAccountAddressModel.query().innerJoinRelated('billingAccount')
 
@@ -116,13 +116,6 @@ describe('Billing Account Address model', () => {
     })
 
     describe('when linking to contact', () => {
-      let testContact
-
-      beforeEach(async () => {
-        testContact = await ContactHelper.add()
-        testRecord = await BillingAccountAddressHelper.add({ contactId: testContact.id })
-      })
-
       it('can successfully run a related query', async () => {
         const query = await BillingAccountAddressModel.query().innerJoinRelated('contact')
 

--- a/test/models/change-reason.model.test.js
+++ b/test/models/change-reason.model.test.js
@@ -4,7 +4,7 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, before, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, before } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -18,10 +18,20 @@ const ChangeReasonModel = require('../../app/models/change-reason.model.js')
 const CHANGE_REASON_SUCCESSION_REMAINDER_INDEX = 9
 
 describe('Change Reason model', () => {
+  let testChargeVersions
   let testRecord
 
   before(async () => {
     testRecord = ChangeReasonHelper.select(CHANGE_REASON_SUCCESSION_REMAINDER_INDEX)
+    const { id } = testRecord
+
+    // Link charge versions
+    testChargeVersions = []
+    for (let i = 0; i < 2; i++) {
+      const chargeVersion = await ChargeVersionHelper.add({ changeReasonId: id })
+
+      testChargeVersions.push(chargeVersion)
+    }
   })
 
   describe('Basic query', () => {
@@ -35,19 +45,6 @@ describe('Change Reason model', () => {
 
   describe('Relationships', () => {
     describe('when linking to charge versions', () => {
-      let testChargeVersions
-
-      beforeEach(async () => {
-        const { id } = testRecord
-
-        testChargeVersions = []
-        for (let i = 0; i < 2; i++) {
-          const chargeVersion = await ChargeVersionHelper.add({ changeReasonId: id })
-
-          testChargeVersions.push(chargeVersion)
-        }
-      })
-
       it('can successfully run a related query', async () => {
         const query = await ChangeReasonModel.query().innerJoinRelated('chargeVersions')
 

--- a/test/models/charge-category.model.test.js
+++ b/test/models/charge-category.model.test.js
@@ -4,7 +4,7 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, before } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -16,10 +16,20 @@ const ChargeReferenceModel = require('../../app/models/charge-reference.model.js
 const ChargeCategoryModel = require('../../app/models/charge-category.model.js')
 
 describe('Charge Category model', () => {
+  let testChargeReferences
   let testRecord
 
-  beforeEach(() => {
+  before(async () => {
     testRecord = ChargeCategoryHelper.select()
+    const { id } = testRecord
+
+    // Link charge references
+    testChargeReferences = []
+    for (let i = 0; i < 2; i++) {
+      const chargeReference = await ChargeReferenceHelper.add({ description: `CE ${i}`, chargeCategoryId: id })
+
+      testChargeReferences.push(chargeReference)
+    }
   })
 
   describe('Basic query', () => {
@@ -33,19 +43,6 @@ describe('Charge Category model', () => {
 
   describe('Relationships', () => {
     describe('when linking to charge references', () => {
-      let testChargeReferences
-
-      beforeEach(async () => {
-        const { id } = testRecord
-
-        testChargeReferences = []
-        for (let i = 0; i < 2; i++) {
-          const chargeReference = await ChargeReferenceHelper.add({ description: `CE ${i}`, chargeCategoryId: id })
-
-          testChargeReferences.push(chargeReference)
-        }
-      })
-
       it('can successfully run a related query', async () => {
         const query = await ChargeCategoryModel.query().innerJoinRelated('chargeReferences')
 

--- a/test/models/company-address.model.test.js
+++ b/test/models/company-address.model.test.js
@@ -4,7 +4,7 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, before } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -20,13 +20,29 @@ const LicenceRoleModel = require('../../app/models/licence-role.model.js')
 const CompanyAddressModel = require('../../app/models/company-address.model.js')
 
 describe('Company Address model', () => {
+  let testAddress
+  let testCompany
+  let testLicenceRole
   let testRecord
 
-  describe('Basic query', () => {
-    beforeEach(async () => {
-      testRecord = await CompanyAddressHelper.add()
-    })
+  before(async () => {
+    // Link licence role
+    testLicenceRole = await LicenceRoleHelper.select()
+    const { id: licenceRoleId } = testLicenceRole
 
+    // Link company
+    testCompany = await CompanyHelper.add()
+    const { id: companyId } = testCompany
+
+    // Link address
+    testAddress = await AddressHelper.add()
+    const { id: addressId } = testAddress
+
+    // Test record
+    testRecord = await CompanyAddressHelper.add({ addressId, companyId, licenceRoleId })
+  })
+
+  describe('Basic query', () => {
     it('can successfully run a basic query', async () => {
       const result = await CompanyAddressModel.query().findById(testRecord.id)
 
@@ -37,16 +53,6 @@ describe('Company Address model', () => {
 
   describe('Relationships', () => {
     describe('when linking to address', () => {
-      let testAddress
-
-      beforeEach(async () => {
-        testAddress = await AddressHelper.add()
-
-        const { id: addressId } = testAddress
-
-        testRecord = await CompanyAddressHelper.add({ addressId })
-      })
-
       it('can successfully run a related query', async () => {
         const query = await CompanyAddressModel.query().innerJoinRelated('address')
 
@@ -65,16 +71,6 @@ describe('Company Address model', () => {
     })
 
     describe('when linking to company', () => {
-      let testCompany
-
-      beforeEach(async () => {
-        testCompany = await CompanyHelper.add()
-
-        const { id: companyId } = testCompany
-
-        testRecord = await CompanyAddressHelper.add({ companyId })
-      })
-
       it('can successfully run a related query', async () => {
         const query = await CompanyAddressModel.query().innerJoinRelated('company')
 
@@ -93,16 +89,6 @@ describe('Company Address model', () => {
     })
 
     describe('when linking to licence role', () => {
-      let testLicenceRole
-
-      beforeEach(async () => {
-        testLicenceRole = await LicenceRoleHelper.select()
-
-        const { id: licenceRoleId } = testLicenceRole
-
-        testRecord = await CompanyAddressHelper.add({ licenceRoleId })
-      })
-
       it('can successfully run a related query', async () => {
         const query = await CompanyAddressModel.query().innerJoinRelated('licenceRole')
 

--- a/test/models/company-contact.model.test.js
+++ b/test/models/company-contact.model.test.js
@@ -4,7 +4,7 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, before } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -20,13 +20,29 @@ const LicenceRoleModel = require('../../app/models/licence-role.model.js')
 const CompanyContactModel = require('../../app/models/company-contact.model.js')
 
 describe('Company Contacts model', () => {
+  let testCompany
+  let testContact
+  let testLicenceRole
   let testRecord
 
-  describe('Basic query', () => {
-    beforeEach(async () => {
-      testRecord = await CompanyContactHelper.add()
-    })
+  before(async () => {
+    // Link licence role
+    testLicenceRole = await LicenceRoleHelper.select()
+    const { id: licenceRoleId } = testLicenceRole
 
+    // Link contact
+    testContact = await ContactHelper.add()
+    const { id: contactId } = testContact
+
+    // Link company
+    testCompany = await CompanyHelper.add()
+    const { id: companyId } = testCompany
+
+    // Test record
+    testRecord = await CompanyContactHelper.add({ companyId, contactId, licenceRoleId })
+  })
+
+  describe('Basic query', () => {
     it('can successfully run a basic query', async () => {
       const result = await CompanyContactModel.query().findById(testRecord.id)
 
@@ -37,16 +53,6 @@ describe('Company Contacts model', () => {
 
   describe('Relationships', () => {
     describe('when linking to company', () => {
-      let testCompany
-
-      beforeEach(async () => {
-        testCompany = await CompanyHelper.add()
-
-        const { id: companyId } = testCompany
-
-        testRecord = await CompanyContactHelper.add({ companyId })
-      })
-
       it('can successfully run a related query', async () => {
         const query = await CompanyContactModel.query().innerJoinRelated('company')
 
@@ -65,16 +71,6 @@ describe('Company Contacts model', () => {
     })
 
     describe('when linking to contact', () => {
-      let testContact
-
-      beforeEach(async () => {
-        testContact = await ContactHelper.add()
-
-        const { id: contactId } = testContact
-
-        testRecord = await CompanyContactHelper.add({ contactId })
-      })
-
       it('can successfully run a related query', async () => {
         const query = await CompanyContactModel.query().innerJoinRelated('contact')
 
@@ -93,16 +89,6 @@ describe('Company Contacts model', () => {
     })
 
     describe('when linking to licence role', () => {
-      let testLicenceRole
-
-      beforeEach(async () => {
-        testLicenceRole = await LicenceRoleHelper.select()
-
-        const { id: licenceRoleId } = testLicenceRole
-
-        testRecord = await CompanyContactHelper.add({ licenceRoleId })
-      })
-
       it('can successfully run a related query', async () => {
         const query = await CompanyContactModel.query().innerJoinRelated('licenceRole')
 

--- a/test/models/event.model.test.js
+++ b/test/models/event.model.test.js
@@ -4,7 +4,7 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, before } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -16,7 +16,7 @@ const EventModel = require('../../app/models/event.model.js')
 describe('Event model', () => {
   let testRecord
 
-  beforeEach(async () => {
+  before(async () => {
     testRecord = await EventHelper.add()
   })
 

--- a/test/models/financial-agreement.model.test.js
+++ b/test/models/financial-agreement.model.test.js
@@ -18,10 +18,20 @@ const FinancialAgreementModel = require('../../app/models/financial-agreement.mo
 const FINANCIAL_AGREEMENT_MVAL_INDEX = 7
 
 describe('Financial Agreement model', () => {
+  let testLicenceAgreements
   let testRecord
 
   before(async () => {
+    // Test record
     testRecord = FinancialAgreementHelper.select(FINANCIAL_AGREEMENT_MVAL_INDEX)
+
+    // Link to licence agreements
+    testLicenceAgreements = []
+    for (let i = 0; i < 2; i++) {
+      const licenceAgreement = await LicenceAgreementHelper.add({ financialAgreementId: testRecord.id })
+
+      testLicenceAgreements.push(licenceAgreement)
+    }
   })
 
   describe('Basic query', () => {
@@ -35,17 +45,6 @@ describe('Financial Agreement model', () => {
 
   describe('Relationships', () => {
     describe('when linking to licence agreements', () => {
-      let testLicenceAgreements
-
-      before(async () => {
-        testLicenceAgreements = []
-        for (let i = 0; i < 2; i++) {
-          const licenceAgreement = await LicenceAgreementHelper.add({ financialAgreementId: testRecord.id })
-
-          testLicenceAgreements.push(licenceAgreement)
-        }
-      })
-
       it('can successfully run a related query', async () => {
         const query = await FinancialAgreementModel.query().innerJoinRelated('licenceAgreements')
 

--- a/test/models/licence-agreement.model.test.js
+++ b/test/models/licence-agreement.model.test.js
@@ -4,7 +4,7 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, before, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, before } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -20,13 +20,24 @@ const LicenceAgreementModel = require('../../app/models/licence-agreement.model.
 const FINANCIAL_AGREEMENT_MCHG_INDEX = 6
 
 describe('Licence Agreement model', () => {
+  let testFinancialAgreement
+  let testLicence
   let testRecord
 
-  describe('Basic query', () => {
-    beforeEach(async () => {
-      testRecord = await LicenceAgreementHelper.add()
-    })
+  before(async () => {
+    // Link to financial agreement
+    testFinancialAgreement = FinancialAgreementHelper.select(FINANCIAL_AGREEMENT_MCHG_INDEX)
+    const { id: financialAgreementId } = testFinancialAgreement
 
+    // Link to licence
+    testLicence = await LicenceHelper.add()
+    const { licenceRef } = testLicence
+
+    // Test record
+    testRecord = await LicenceAgreementHelper.add({ financialAgreementId, licenceRef })
+  })
+
+  describe('Basic query', () => {
     it('can successfully run a basic query', async () => {
       const result = await LicenceAgreementModel.query().findById(testRecord.id)
 
@@ -37,16 +48,6 @@ describe('Licence Agreement model', () => {
 
   describe('Relationships', () => {
     describe('when linking to financial agreement', () => {
-      let testFinancialAgreement
-
-      before(async () => {
-        testFinancialAgreement = FinancialAgreementHelper.select(FINANCIAL_AGREEMENT_MCHG_INDEX)
-
-        const { id: financialAgreementId } = testFinancialAgreement
-
-        testRecord = await LicenceAgreementHelper.add({ financialAgreementId })
-      })
-
       it('can successfully run a related query', async () => {
         const query = await LicenceAgreementModel.query().innerJoinRelated('financialAgreement')
 
@@ -67,16 +68,6 @@ describe('Licence Agreement model', () => {
     })
 
     describe('when linking to licence', () => {
-      let testLicence
-
-      beforeEach(async () => {
-        testLicence = await LicenceHelper.add()
-
-        const { licenceRef } = testLicence
-
-        testRecord = await LicenceAgreementHelper.add({ licenceRef })
-      })
-
       it('can successfully run a related query', async () => {
         const query = await LicenceAgreementModel.query().innerJoinRelated('licence')
 

--- a/test/models/licence-document-role.model.test.js
+++ b/test/models/licence-document-role.model.test.js
@@ -4,7 +4,7 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, before } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -24,13 +24,45 @@ const LicenceRoleModel = require('../../app/models/licence-role.model.js')
 const LicenceDocumentRoleModel = require('../../app/models/licence-document-role.model.js')
 
 describe('Licence Document Role model', () => {
+  let testAddress
+  let testCompany
+  let testContact
+  let testLicenceDocument
+  let testLicenceRole
   let testRecord
 
-  describe('Basic query', () => {
-    beforeEach(async () => {
-      testRecord = await LicenceDocumentRoleHelper.add()
-    })
+  before(async () => {
+    // Link address
+    testAddress = await AddressHelper.add()
+    const { id: addressId } = testAddress
 
+    // Link company
+    testCompany = await CompanyHelper.add()
+    const { id: companyId } = testCompany
+
+    // Link contact
+    testContact = await ContactHelper.add()
+    const { id: contactId } = testContact
+
+    // Link licence document
+    testLicenceDocument = await LicenceDocumentHelper.add()
+    const { id: licenceDocumentId } = testLicenceDocument
+
+    // Link licence role
+    testLicenceRole = await LicenceRoleHelper.select()
+    const { id: licenceRoleId } = testLicenceRole
+
+    // Test record
+    testRecord = await LicenceDocumentRoleHelper.add({
+      addressId,
+      companyId,
+      contactId,
+      licenceDocumentId,
+      licenceRoleId
+    })
+  })
+
+  describe('Basic query', () => {
     it('can successfully run a basic query', async () => {
       const result = await LicenceDocumentRoleModel.query().findById(testRecord.id)
 
@@ -41,16 +73,6 @@ describe('Licence Document Role model', () => {
 
   describe('Relationships', () => {
     describe('when linking to address', () => {
-      let testAddress
-
-      beforeEach(async () => {
-        testAddress = await AddressHelper.add()
-
-        const { id: addressId } = testAddress
-
-        testRecord = await LicenceDocumentRoleHelper.add({ addressId })
-      })
-
       it('can successfully run a related query', async () => {
         const query = await LicenceDocumentRoleModel.query().innerJoinRelated('address')
 
@@ -69,16 +91,6 @@ describe('Licence Document Role model', () => {
     })
 
     describe('when linking to company', () => {
-      let testCompany
-
-      beforeEach(async () => {
-        testCompany = await CompanyHelper.add()
-
-        const { id: companyId } = testCompany
-
-        testRecord = await LicenceDocumentRoleHelper.add({ companyId })
-      })
-
       it('can successfully run a related query', async () => {
         const query = await LicenceDocumentRoleModel.query().innerJoinRelated('company')
 
@@ -97,16 +109,6 @@ describe('Licence Document Role model', () => {
     })
 
     describe('when linking to contact', () => {
-      let testContact
-
-      beforeEach(async () => {
-        testContact = await ContactHelper.add()
-
-        const { id: contactId } = testContact
-
-        testRecord = await LicenceDocumentRoleHelper.add({ contactId })
-      })
-
       it('can successfully run a related query', async () => {
         const query = await LicenceDocumentRoleModel.query().innerJoinRelated('contact')
 
@@ -125,16 +127,6 @@ describe('Licence Document Role model', () => {
     })
 
     describe('when linking to licence document', () => {
-      let testLicenceDocument
-
-      beforeEach(async () => {
-        testLicenceDocument = await LicenceDocumentHelper.add()
-
-        const { id: licenceDocumentId } = testLicenceDocument
-
-        testRecord = await LicenceDocumentRoleHelper.add({ licenceDocumentId })
-      })
-
       it('can successfully run a related query', async () => {
         const query = await LicenceDocumentRoleModel.query().innerJoinRelated('licenceDocument')
 
@@ -155,16 +147,6 @@ describe('Licence Document Role model', () => {
     })
 
     describe('when linking to licence role', () => {
-      let testLicenceRole
-
-      beforeEach(async () => {
-        testLicenceRole = await LicenceRoleHelper.select()
-
-        const { id: licenceRoleId } = testLicenceRole
-
-        testRecord = await LicenceDocumentRoleHelper.add({ licenceRoleId })
-      })
-
       it('can successfully run a related query', async () => {
         const query = await LicenceDocumentRoleModel.query().innerJoinRelated('licenceRole')
 

--- a/test/models/licence-document.model.test.js
+++ b/test/models/licence-document.model.test.js
@@ -4,7 +4,7 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, before } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -18,13 +18,29 @@ const LicenceDocumentRoleModel = require('../../app/models/licence-document-role
 const LicenceDocumentModel = require('../../app/models/licence-document.model.js')
 
 describe('Licence Document model', () => {
+  let testLicence
+  let testLicenceDocumentRoles
   let testRecord
 
-  describe('Basic query', () => {
-    beforeEach(async () => {
-      testRecord = await LicenceDocumentHelper.add()
-    })
+  before(async () => {
+    // Link to licence
+    testLicence = await LicenceHelper.add()
+    const { licenceRef } = testLicence
 
+    // Test record
+    testRecord = await LicenceDocumentHelper.add({ licenceRef })
+    const { id: licenceDocumentId } = testRecord
+
+    // Link to licence document roles
+    testLicenceDocumentRoles = []
+    for (let i = 0; i < 2; i++) {
+      const licenceDocumentRole = await LicenceDocumentRoleHelper.add({ licenceDocumentId })
+
+      testLicenceDocumentRoles.push(licenceDocumentRole)
+    }
+  })
+
+  describe('Basic query', () => {
     it('can successfully run a basic query', async () => {
       const result = await LicenceDocumentModel.query().findById(testRecord.id)
 
@@ -35,16 +51,6 @@ describe('Licence Document model', () => {
 
   describe('Relationships', () => {
     describe('when linking to licence', () => {
-      let testLicence
-
-      beforeEach(async () => {
-        testLicence = await LicenceHelper.add()
-
-        const { licenceRef } = testLicence
-
-        testRecord = await LicenceDocumentHelper.add({ licenceRef })
-      })
-
       it('can successfully run a related query', async () => {
         const query = await LicenceDocumentModel.query().innerJoinRelated('licence')
 
@@ -63,21 +69,6 @@ describe('Licence Document model', () => {
     })
 
     describe('when linking to licence document roles', () => {
-      let testLicenceDocumentRoles
-
-      beforeEach(async () => {
-        testRecord = await LicenceDocumentHelper.add()
-
-        const { id: licenceDocumentId } = testRecord
-
-        testLicenceDocumentRoles = []
-        for (let i = 0; i < 2; i++) {
-          const licenceDocumentRole = await LicenceDocumentRoleHelper.add({ licenceDocumentId })
-
-          testLicenceDocumentRoles.push(licenceDocumentRole)
-        }
-      })
-
       it('can successfully run a related query', async () => {
         const query = await LicenceDocumentModel.query().innerJoinRelated('licenceDocumentRoles')
 

--- a/test/models/licence-role.model.test.js
+++ b/test/models/licence-role.model.test.js
@@ -4,7 +4,7 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, before } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -20,13 +20,42 @@ const LicenceRoleHelper = require('../support/helpers/licence-role.helper.js')
 const LicenceRoleModel = require('../../app/models/licence-role.model.js')
 
 describe('Licence Role model', () => {
+  let testCompanyAddresses
+  let testCompanyContacts
+  let testLicenceDocumentRoles
   let testRecord
 
-  describe('Basic query', () => {
-    beforeEach(async () => {
-      testRecord = await LicenceRoleHelper.select()
-    })
+  before(async () => {
+    // Test record
+    testRecord = await LicenceRoleHelper.select()
+    const { id: licenceRoleId } = testRecord
 
+    // Link company addresses
+    testCompanyAddresses = []
+    for (let i = 0; i < 2; i++) {
+      const companyAddress = await CompanyAddressHelper.add({ licenceRoleId })
+
+      testCompanyAddresses.push(companyAddress)
+    }
+
+    // Link company contacts
+    testCompanyContacts = []
+    for (let i = 0; i < 2; i++) {
+      const companyContact = await CompanyContactHelper.add({ licenceRoleId })
+
+      testCompanyContacts.push(companyContact)
+    }
+
+    // Link licence document roles
+    testLicenceDocumentRoles = []
+    for (let i = 0; i < 2; i++) {
+      const licenceDocumentRole = await LicenceDocumentRoleHelper.add({ licenceRoleId })
+
+      testLicenceDocumentRoles.push(licenceDocumentRole)
+    }
+  })
+
+  describe('Basic query', () => {
     it('can successfully run a basic query', async () => {
       const result = await LicenceRoleModel.query().findById(testRecord.id)
 
@@ -37,21 +66,6 @@ describe('Licence Role model', () => {
 
   describe('Relationships', () => {
     describe('when linking to company addresses', () => {
-      let testCompanyAddresses
-
-      beforeEach(async () => {
-        testRecord = await LicenceRoleHelper.select()
-
-        const { id: licenceRoleId } = testRecord
-
-        testCompanyAddresses = []
-        for (let i = 0; i < 2; i++) {
-          const companyAddress = await CompanyAddressHelper.add({ licenceRoleId })
-
-          testCompanyAddresses.push(companyAddress)
-        }
-      })
-
       it('can successfully run a related query', async () => {
         const query = await LicenceRoleModel.query().innerJoinRelated('companyAddresses')
 
@@ -72,21 +86,6 @@ describe('Licence Role model', () => {
     })
 
     describe('when linking to company contacts', () => {
-      let testCompanyContacts
-
-      beforeEach(async () => {
-        testRecord = await LicenceRoleHelper.select()
-
-        const { id: licenceRoleId } = testRecord
-
-        testCompanyContacts = []
-        for (let i = 0; i < 2; i++) {
-          const companyContact = await CompanyContactHelper.add({ licenceRoleId })
-
-          testCompanyContacts.push(companyContact)
-        }
-      })
-
       it('can successfully run a related query', async () => {
         const query = await LicenceRoleModel.query().innerJoinRelated('companyContacts')
 
@@ -107,21 +106,6 @@ describe('Licence Role model', () => {
     })
 
     describe('when linking to licence document roles', () => {
-      let testLicenceDocumentRoles
-
-      beforeEach(async () => {
-        testRecord = await LicenceRoleHelper.select()
-
-        const { id: licenceRoleId } = testRecord
-
-        testLicenceDocumentRoles = []
-        for (let i = 0; i < 2; i++) {
-          const licenceDocumentRole = await LicenceDocumentRoleHelper.add({ licenceRoleId })
-
-          testLicenceDocumentRoles.push(licenceDocumentRole)
-        }
-      })
-
       it('can successfully run a related query', async () => {
         const query = await LicenceRoleModel.query().innerJoinRelated('licenceDocumentRoles')
 


### PR DESCRIPTION
DEFRA/water-abstraction-team#128

This PR is part of our ongoing work to make unit tests faster, more efficient and less flakey, focusing on the model unit tests.

We are simplifying the database seeding process by moving it to a top-level before block instead of using beforeEach. Since the model unit tests check the relationships between table models, putting all the test data in one place means we only need to seed the database once instead of before each test. By seeding less data into the test database, our hope is that the tests run faster, the code is cleaner, and they are less flakey due to conflicting test data.