### PR TITLE
Add return period lib functionality

### DIFF
--- a/app/lib/return-periods.lib.js
+++ b/app/lib/return-periods.lib.js
@@ -1,0 +1,90 @@
+'use strict'
+
+/**
+ * Helper methods to deal with return period dates
+ * @module ReturnPeriodDatesLib
+ */
+
+const { returnCycleDates } = require('./static-lookups.lib.js')
+const { determineCycleStartDate, determineCycleEndDate, determineCycleDueDate } = require('./return-cycle-dates.lib')
+
+/**
+ *
+ * @param {Date} determinationDate
+ */
+function determineReturnsPeriods(determinationDate = new Date()) {
+  const year = determinationDate.getFullYear()
+
+  return {
+    allYear: {
+      name: 'allYear',
+      startDate: determineCycleStartDate(false, determinationDate),
+      endDate: determineCycleEndDate(false, determinationDate),
+      dueDate: determineCycleDueDate(false, determinationDate)
+    },
+    summer: {
+      name: 'summer',
+      startDate: determineCycleStartDate(true, determinationDate),
+      endDate: determineCycleEndDate(true, determinationDate),
+      dueDate: determineCycleDueDate(true, determinationDate)
+    },
+    quarterOne: {
+      name: 'quarterOne',
+      startDate: _startDate(determinationDate, returnCycleDates.quarterOne),
+      endDate: _endDate(determinationDate, returnCycleDates.quarterOne),
+      dueDate: _dueDate(determinationDate, returnCycleDates.quarterOne)
+    },
+    quarterTwo: {
+      name: 'quarterTwo',
+      startDate: _startDate(determinationDate, returnCycleDates.quarterTwo),
+      endDate: _endDate(determinationDate, returnCycleDates.quarterTwo),
+      dueDate: _dueDate(determinationDate, returnCycleDates.quarterTwo)
+    },
+    quarterThree: {
+      name: 'quarterThree',
+      startDate: _startDate(determinationDate, returnCycleDates.quarterThree),
+      endDate: _endDate(determinationDate, returnCycleDates.quarterThree),
+      dueDate: _dueDate(determinationDate, returnCycleDates.quarterThree)
+    },
+    quarterFour: {
+      name: 'quarterFour',
+      startDate: _startDate(determinationDate, returnCycleDates.quarterFour),
+      endDate: _endDate(determinationDate, returnCycleDates.quarterFour),
+      dueDate: _dueDate(determinationDate, returnCycleDates.quarterFour)
+    }
+  }
+}
+
+function _startDate(determinationDate, cycle) {
+  const year = determinationDate.getFullYear()
+
+  const periodStartDay = cycle.startDate.day
+  const periodStartMonth = cycle.startDate.month + 1
+  const periodStartYear = year
+
+  return new Date(`${periodStartYear}-${periodStartMonth}-${periodStartDay}`)
+}
+
+function _endDate(determinationDate, cycle) {
+  const year = determinationDate.getFullYear()
+
+  const periodEndDay = cycle.endDate.day
+  const periodEndMonth = cycle.endDate.month + 1
+  const periodEndYear = year
+
+  return new Date(`${periodEndYear}-${periodEndMonth}-${periodEndDay}`)
+}
+
+function _dueDate(determinationDate, cycle) {
+  const year = determinationDate.getFullYear()
+
+  const periodDueDay = cycle.dueDate.day
+  const periodDueMonth = cycle.dueDate.month + 1
+  const periodDueYear = year
+
+  return new Date(`${periodDueYear}-${periodDueMonth}-${periodDueDay}`)
+}
+
+module.exports = {
+  determineReturnsPeriods
+}

--- a/app/lib/static-lookups.lib.js
+++ b/app/lib/static-lookups.lib.js
@@ -33,6 +33,30 @@ const returnCycleDates = {
     dueDate: { day: 28, month: 10 },
     endDate: { day: 31, month: 9 },
     startDate: { day: 1, month: 10 }
+  },
+  //1st Jan - 31st Mar (Due date 28th Apr) - Quarter
+  quarterOne: {
+    dueDate: { day: 28, month: 3 },
+    endDate: { day: 31, month: 2 },
+    startDate: { day: 1, month: 0 }
+  },
+  // 1st Apr - 30th Jun (Due to 28th Jul) - Quarter
+  quarterTwo: {
+    dueDate: { day: 28, month: 6 },
+    endDate: { day: 30, month: 5 },
+    startDate: { day: 1, month: 3 }
+  },
+  // 1st Jul - 30th Sep (Due date 28th Oct) - Quarter
+  quarterThree: {
+    dueDate: { day: 28, month: 9 },
+    endDate: { day: 30, month: 8 },
+    startDate: { day: 1, month: 6 }
+  },
+  // 1st Oct - 31st Dec (Due date 28th Jan) - Quarter},
+  quarterFour: {
+    dueDate: { day: 28, month: 0 },
+    endDate: { day: 31, month: 11 },
+    startDate: { day: 1, month: 9 }
   }
 }
 

--- a/test/lib/return-periods.lib.test.js
+++ b/test/lib/return-periods.lib.test.js
@@ -1,0 +1,187 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { afterEach, describe, it, beforeEach } = (exports.lab = Lab.script())
+const { expect } = Code
+
+const { returnCycleDates } = require('../../app/lib/static-lookups.lib.js')
+
+// Thing under test
+const ReturnPeriodDatesLib = require('../../app/lib/return-periods.lib.js')
+
+describe('Return Cycle Dates lib', () => {
+  const today = new Date()
+  const year = today.getFullYear()
+
+  let clock
+  let expectedDate
+  let testDate
+
+  afterEach(() => {
+    clock.restore()
+  })
+
+  describe.only('determineReturnsPeriods', () => {
+    let startDate, endDate, dueDate
+    describe('and no date is given (defaults to current date)', () => {
+      beforeEach(() => {
+        testDate = new Date(`${year}-01-01`)
+        clock = Sinon.useFakeTimers(testDate)
+      })
+
+      describe('"allYear"', () => {
+        beforeEach(() => {
+          startDate = new Date(
+            `${year - 1}-${returnCycleDates.allYear.startDate.month + 1}-${returnCycleDates.allYear.startDate.day}`
+          )
+          endDate = new Date(
+            `${year}-${returnCycleDates.allYear.endDate.month + 1}-${returnCycleDates.allYear.endDate.day}`
+          )
+          dueDate = new Date(
+            `${year}-${returnCycleDates.allYear.dueDate.month + 1}-${returnCycleDates.allYear.dueDate.day}`
+          )
+        })
+
+        it('should return the "allYear" period', () => {
+          const result = ReturnPeriodDatesLib.determineReturnsPeriods()
+
+          expect(result.allYear).to.equal({
+            dueDate,
+            endDate,
+            name: 'allYear',
+            startDate
+          })
+        })
+      })
+
+      describe('"summer"', () => {
+        beforeEach(() => {
+          startDate = new Date(
+            `${year - 1}-${returnCycleDates.summer.startDate.month + 1}-${returnCycleDates.summer.startDate.day}`
+          )
+          endDate = new Date(
+            `${year}-${returnCycleDates.summer.endDate.month + 1}-${returnCycleDates.summer.endDate.day}`
+          )
+          dueDate = new Date(
+            `${year}-${returnCycleDates.summer.dueDate.month + 1}-${returnCycleDates.summer.dueDate.day}`
+          )
+        })
+
+        it('should return the "summer" period', () => {
+          const result = ReturnPeriodDatesLib.determineReturnsPeriods()
+
+          expect(result.summer).to.equal({
+            dueDate,
+            endDate,
+            name: 'summer',
+            startDate
+          })
+        })
+      })
+
+      describe('"quarterOne"', () => {
+        beforeEach(() => {
+          startDate = new Date(
+            `${year}-${returnCycleDates.quarterOne.startDate.month + 1}-${returnCycleDates.quarterOne.startDate.day}`
+          )
+          endDate = new Date(
+            `${year}-${returnCycleDates.quarterOne.endDate.month + 1}-${returnCycleDates.quarterOne.endDate.day}`
+          )
+          dueDate = new Date(
+            `${year}-${returnCycleDates.quarterOne.dueDate.month + 1}-${returnCycleDates.quarterOne.dueDate.day}`
+          )
+        })
+
+        it('should return the "quarterOne" period', () => {
+          const result = ReturnPeriodDatesLib.determineReturnsPeriods()
+
+          expect(result.quarterOne).to.equal({
+            dueDate,
+            endDate,
+            name: 'quarterOne',
+            startDate
+          })
+        })
+      })
+
+      describe('"quarterTwo"', () => {
+        beforeEach(() => {
+          startDate = new Date(
+            `${year}-${returnCycleDates.quarterTwo.startDate.month + 1}-${returnCycleDates.quarterTwo.startDate.day}`
+          )
+          endDate = new Date(
+            `${year}-${returnCycleDates.quarterTwo.endDate.month + 1}-${returnCycleDates.quarterTwo.endDate.day}`
+          )
+          dueDate = new Date(
+            `${year}-${returnCycleDates.quarterTwo.dueDate.month + 1}-${returnCycleDates.quarterTwo.dueDate.day}`
+          )
+        })
+
+        it('should return the "quarterTwo" period', () => {
+          const result = ReturnPeriodDatesLib.determineReturnsPeriods()
+
+          expect(result.quarterTwo).to.equal({
+            dueDate,
+            endDate,
+            name: 'quarterTwo',
+            startDate
+          })
+        })
+      })
+
+      describe('"quarterThree"', () => {
+        beforeEach(() => {
+          startDate = new Date(
+            `${year}-${returnCycleDates.quarterThree.startDate.month + 1}-${returnCycleDates.quarterThree.startDate.day}`
+          )
+          endDate = new Date(
+            `${year}-${returnCycleDates.quarterThree.endDate.month + 1}-${returnCycleDates.quarterThree.endDate.day}`
+          )
+          dueDate = new Date(
+            `${year}-${returnCycleDates.quarterThree.dueDate.month + 1}-${returnCycleDates.quarterThree.dueDate.day}`
+          )
+        })
+
+        it('should return the "quarterThree" period', () => {
+          const result = ReturnPeriodDatesLib.determineReturnsPeriods()
+
+          expect(result.quarterThree).to.equal({
+            dueDate,
+            endDate,
+            name: 'quarterThree',
+            startDate
+          })
+        })
+      })
+
+      describe('"quarterFour"', () => {
+        beforeEach(() => {
+          startDate = new Date(
+            `${year}-${returnCycleDates.quarterFour.startDate.month + 1}-${returnCycleDates.quarterFour.startDate.day}`
+          )
+          endDate = new Date(
+            `${year}-${returnCycleDates.quarterFour.endDate.month + 1}-${returnCycleDates.quarterFour.endDate.day}`
+          )
+          dueDate = new Date(
+            `${year}-${returnCycleDates.quarterFour.dueDate.month + 1}-${returnCycleDates.quarterFour.dueDate.day}`
+          )
+        })
+
+        it('should return the "quarterFour" period', () => {
+          const result = ReturnPeriodDatesLib.determineReturnsPeriods()
+
+          expect(result.quarterFour).to.equal({
+            dueDate,
+            endDate,
+            name: 'quarterFour',
+            startDate
+          })
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4716

As part of the ongoing work to migrate the legacy UI we are replacing the notification journey from the UI and rebuilding in system.

This change introduces the logic to handle "quarter" and annual periods.

Quarters are from April to April.

This change also includes functionality to get the current and next return period. This is determined by the due date.