### PR TITLE
Update updatedAt date for new supplementary flags

### DIFF
--- a/app/services/licences/supplementary/persist-supplementary-billing-flags.service.js
+++ b/app/services/licences/supplementary/persist-supplementary-billing-flags.service.js
@@ -7,6 +7,7 @@
 
 const CreateLicenceSupplementaryYearService = require('./create-licence-supplementary-year.service.js')
 const LicenceModel = require('../../../models/licence.model.js')
+const { timestampForPostgres } = require('../../../lib/general.lib.js')
 
 /**
  * Persists the supplementary billing flags for a licence
@@ -48,7 +49,11 @@ async function _flagForLicenceSupplementaryYears(twoPartTariffBillingYears, lice
 
 async function _updateLicenceFlags(includeInPresrocBilling, flagForSrocSupplementary, licenceId) {
   return LicenceModel.query()
-    .patch({ includeInPresrocBilling, includeInSrocBilling: flagForSrocSupplementary })
+    .patch({
+      includeInPresrocBilling,
+      includeInSrocBilling: flagForSrocSupplementary,
+      updatedAt: timestampForPostgres()
+    })
     .where('id', licenceId)
 }
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4746

While writing the acceptance tests for the supplementary billing flags process, we identified an issue with the functionality for removing a bill from a bill run. Here's the scenario:

- A licence has two bills in an annual bill run.
- The licence is flagged for supplementary billing when a single bill is removed. This ensures the removed bill will be included in the next supplementary bill run. However, when the annual bill run is marked as sent, it incorrectly removes all flags from the licence. This includes the flag we just set, causing the removed bill to no longer be picked up in the supplementary bill run. Root Cause
- The problem occurs because the updatedAt date on the licence is not being updated when the flags are set.

There is logic that determines whether flags should be removed when a bill run is sent. It works as follows: If the licence has not been updated since the bill run was created, all flags are removed, assuming no changes have occurred. If the licence has been updated, the flags remain, signalling that changes have been made requiring inclusion in the next supplementary bill run. Since the updatedAt date wasn't being updated when the flags were persisted, the system incorrectly determined that the licence hadn't been changed, and it removed the supplementary billing flags.

Fix
This PR resolves the issue by ensuring the updatedAt date on the licence is updated whenever the flags are set. This ensures that:

The system recognizes that a change has occurred on the licence after the bill run was created. The supplementary billing flags remain intact and are correctly picked up in the next supplementary bill run. By updating the updatedAt date, we align the behavior with the intended logic and ensure proper handling of supplementary billing flags.