### PR TITLE
Fix return log helper breaking acceptance tests

### DIFF
--- a/test/support/helpers/return-log.helper.js
+++ b/test/support/helpers/return-log.helper.js
@@ -55,8 +55,8 @@ function defaults(data = {}) {
   const returnReference = data.returnReference ? data.returnReference : generateLegacyId()
   const timestamp = timestampForPostgres()
   const receivedDate = data.receivedDate ? data.receivedDate : null
-  const startDate = data.startDate ? data.startDate : new Date('2022-04-01')
-  const endDate = data.endDate ? data.endDate : new Date('2023-03-31')
+  const startDate = data.startDate ? new Date(data.startDate) : new Date('2022-04-01')
+  const endDate = data.endDate ? new Date(data.endDate) : new Date('2023-03-31')
 
   const defaults = {
     id: generateReturnLogId(startDate, endDate, 1, licenceRef, returnReference),


### PR DESCRIPTION
In [Return log for ended licence](https://github.com/DEFRA/water-abstraction-system/pull/1425), we made some housekeeping changes to the `ReturnLogHelper`. We had gone a bit OTT, passing in dates to `new Date()` to make a new date!

So, we scrubbed most of them, and all unit tests and logic were still okay. However, when we came to run the acceptance tests, we found a bunch were broken.

We tracked it down to the acceptance tests having to pass dates as strings to our `app/services/data/load/load.service.js`. In most cases, that is fine, but `ReturnLogHelper` passes these to `generateReturnLogId()`, which in turn passes them to `formatDateObjectToISO()`.

If they are not a date object, `formatDateObjectToISO()` blows up.

So, this quick fix gets our acceptance tests working again.