### PR TITLE
Amend transaction line description for 2PT bills

### DIFF
--- a/app/services/bill-runs/generate-transactions.service.js
+++ b/app/services/bill-runs/generate-transactions.service.js
@@ -89,7 +89,7 @@ function _description(chargeReference) {
     return `Water abstraction charge: ${chargeReference.description}`
   }
 
-  return `Two-part tariff basic water abstraction charge: ${chargeReference.description}`
+  return `Two-part tariff first part water abstraction charge: ${chargeReference.description}`
 }
 
 /**

--- a/app/services/bill-runs/two-part-tariff/generate-transaction.service.js
+++ b/app/services/bill-runs/two-part-tariff/generate-transaction.service.js
@@ -63,7 +63,7 @@ function _description(chargeReference) {
     return `Water abstraction charge: ${chargeReference.description}`
   }
 
-  return `Two-part tariff basic water abstraction charge: ${chargeReference.description}`
+  return `Two-part tariff second part water abstraction charge: ${chargeReference.description}`
 }
 
 /**

--- a/test/controllers/bill-licences.controller.test.js
+++ b/test/controllers/bill-licences.controller.test.js
@@ -234,7 +234,7 @@ function _srocPageData() {
         chargeType: 'standard',
         creditAmount: '',
         debitAmount: '£1,787.00',
-        description: 'Two-part tariff basic water abstraction charge: Borehole at Muckton - Sussex',
+        description: 'Two-part tariff first part water abstraction charge: Borehole at Muckton - Sussex',
         quantity: '150ML'
       },
       {

--- a/test/services/bill-runs/generate-transactions.service.test.js
+++ b/test/services/bill-runs/generate-transactions.service.test.js
@@ -273,7 +273,7 @@ describe('Generate Transactions service', () => {
           )
 
           expect(results[0].description).to.equal(
-            `Two-part tariff basic water abstraction charge: ${chargeReference.description}`
+            `Two-part tariff first part water abstraction charge: ${chargeReference.description}`
           )
         })
       })

--- a/test/services/bill-runs/two-part-tariff/generate-transaction.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/generate-transaction.service.test.js
@@ -99,7 +99,7 @@ describe('Generate Transaction service', () => {
           )
 
           expect(result.description).to.equal(
-            'Two-part tariff basic water abstraction charge: Lower Queenstown - Pittisham'
+            'Two-part tariff second part water abstraction charge: Lower Queenstown - Pittisham'
           )
         })
       })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4725

The business has requested amendments to the transaction line description and associated labels in the transaction files generated by the [Charging Module API](https://github.com/DEFRA/sroc-charging-module-api).

The labels require an amendment to the **Charging Module API** itself. However, we generate the line descriptions and send them to the CHA.

This change amends the descriptions we generate for two-part tariff bill runs.

**Annual & Supplementary bill runs**

- `Two-part tariff basic water abstraction charge` to `Two-part tariff first part water abstraction charge`

**Two-part tariff annual and supplementary bill runs**

- `Two-part tariff basic water abstraction charge` to `Two-part tariff second part water abstraction charge`