### PR TITLE
Feature notifications setup returns period session

### DIFF
--- a/app/controllers/notifications-setup.controller.js
+++ b/app/controllers/notifications-setup.controller.js
@@ -11,8 +11,12 @@ const InitiateSessionService = require('../services/notifications/setup/initiate
 
 const basePath = 'notifications/setup'
 
-async function viewReturnsPeriod(_request, h) {
-  const pageData = ReturnsPeriodService.go()
+async function viewReturnsPeriod(request, h) {
+  const {
+    params: { sessionId }
+  } = request
+
+  const pageData = await ReturnsPeriodService.go(sessionId)
 
   return h.view(`${basePath}/view-returns-period.njk`, {
     ...pageData
@@ -26,9 +30,12 @@ async function setup(_request, h) {
 }
 
 async function submitReturnsPeriod(request, h) {
-  const { payload } = request
+  const {
+    payload,
+    params: { sessionId }
+  } = request
 
-  const pageData = await SubmitReturnsPeriodService.go(payload)
+  const pageData = await SubmitReturnsPeriodService.go(sessionId, payload)
 
   if (pageData.error) {
     return h.view(`${basePath}/view-returns-period.njk`, {

--- a/app/presenters/notifications/setup/returns-period.presenter.js
+++ b/app/presenters/notifications/setup/returns-period.presenter.js
@@ -12,28 +12,31 @@ const { formatLongDate } = require('../../base.presenter')
  * Formats data for the `/notifications/setup/returns-period` page
  *
  * @param {module:SessionModel} session - The session instance to format
+ * @param {module:SessionModel} session.returnsPeriod - The returns period saved from a previous submission
  *
  * @returns {object} - The data formatted for the view template
  */
 function go(session) {
+  const savedReturnsPeriod = session.returnsPeriod ?? null
+
   return {
     backLink: '/manage',
-    returnsPeriod: _returnsPeriod(session)
+    returnsPeriod: _returnsPeriod(savedReturnsPeriod)
   }
 }
 
-function _returnsPeriod(session) {
+function _returnsPeriod(savedReturnsPeriod) {
   const today = new Date()
 
   const [firstReturnPeriod, secondReturnPeriod] = determineUpcomingReturnPeriods(today)
 
-  const currentReturnPeriod = _formatReturnPeriod(firstReturnPeriod, session)
-  const nextReturnPeriod = _formatReturnPeriod(secondReturnPeriod, session)
+  const currentReturnPeriod = _formatReturnPeriod(firstReturnPeriod, savedReturnsPeriod)
+  const nextReturnPeriod = _formatReturnPeriod(secondReturnPeriod, savedReturnsPeriod)
 
   return [currentReturnPeriod, nextReturnPeriod]
 }
 
-function _formatReturnPeriod(returnsPeriod, session) {
+function _formatReturnPeriod(returnsPeriod, savedReturnsPeriod) {
   const textPrefix = _textPrefix(returnsPeriod)
   return {
     value: returnsPeriod.name,
@@ -41,7 +44,7 @@ function _formatReturnPeriod(returnsPeriod, session) {
     hint: {
       text: `Due date ${formatLongDate(returnsPeriod.dueDate)}`
     },
-    checked: returnsPeriod.name === session?.returnsPeriod
+    checked: returnsPeriod.name === savedReturnsPeriod
   }
 }
 

--- a/app/presenters/notifications/setup/returns-period.presenter.js
+++ b/app/presenters/notifications/setup/returns-period.presenter.js
@@ -11,34 +11,37 @@ const { formatLongDate } = require('../../base.presenter')
 /**
  * Formats data for the `/notifications/setup/returns-period` page
  *
+ * @param {module:SessionModel} session - The session instance to format
+ *
  * @returns {object} - The data formatted for the view template
  */
-function go() {
+function go(session) {
   return {
     backLink: '/manage',
-    returnsPeriod: _returnsPeriod()
+    returnsPeriod: _returnsPeriod(session)
   }
 }
 
-function _returnsPeriod() {
+function _returnsPeriod(session) {
   const today = new Date()
 
   const [firstReturnPeriod, secondReturnPeriod] = determineUpcomingReturnPeriods(today)
 
-  const currentReturnPeriod = _formatReturnPeriod(firstReturnPeriod)
-  const nextReturnPeriod = _formatReturnPeriod(secondReturnPeriod)
+  const currentReturnPeriod = _formatReturnPeriod(firstReturnPeriod, session)
+  const nextReturnPeriod = _formatReturnPeriod(secondReturnPeriod, session)
 
   return [currentReturnPeriod, nextReturnPeriod]
 }
 
-function _formatReturnPeriod(returnPeriod) {
-  const textPrefix = _textPrefix(returnPeriod)
+function _formatReturnPeriod(returnsPeriod, session) {
+  const textPrefix = _textPrefix(returnsPeriod)
   return {
-    value: returnPeriod.name,
-    text: `${textPrefix} ${formatLongDate(returnPeriod.startDate)} to ${formatLongDate(returnPeriod.endDate)}`,
+    value: returnsPeriod.name,
+    text: `${textPrefix} ${formatLongDate(returnsPeriod.startDate)} to ${formatLongDate(returnsPeriod.endDate)}`,
     hint: {
-      text: `Due date ${formatLongDate(returnPeriod.dueDate)}`
-    }
+      text: `Due date ${formatLongDate(returnsPeriod.dueDate)}`
+    },
+    checked: returnsPeriod.name === session?.returnsPeriod
   }
 }
 

--- a/app/services/notifications/setup/returns-period.service.js
+++ b/app/services/notifications/setup/returns-period.service.js
@@ -6,15 +6,19 @@
  */
 
 const NotificationsPresenter = require('../../../presenters/notifications/setup/returns-period.presenter.js')
+const SessionModel = require('../../../models/session.model')
 
 /**
  * Formats data for the `/notifications/setup/returns-period` page
  *
+ * @param {string} sessionId - The UUID for setup ad-hoc returns notification session record
  *
  * @returns {object} The view data for the returns period page
  */
-function go() {
-  const formattedData = NotificationsPresenter.go()
+async function go(sessionId) {
+  const session = await SessionModel.query().findById(sessionId)
+
+  const formattedData = NotificationsPresenter.go(session)
 
   return {
     activeNavBar: 'manage',

--- a/test/presenters/notifications/setup/returns-period.presenter.test.js
+++ b/test/presenters/notifications/setup/returns-period.presenter.test.js
@@ -18,8 +18,10 @@ describe('Notifications Setup - Returns Period presenter', () => {
 
   let testDate
   let clock
+  let session = {}
 
   afterEach(() => {
+    session = {}
     clock.restore()
   })
 
@@ -29,13 +31,34 @@ describe('Notifications Setup - Returns Period presenter', () => {
       clock = Sinon.useFakeTimers(testDate)
     })
     it('correctly presents the data', () => {
-      const result = ReturnsPeriodPresenter.go()
+      const result = ReturnsPeriodPresenter.go(session)
 
       expect(result).to.equal({ backLink: '/manage' }, { skip: ['returnsPeriod'] })
     })
   })
 
   describe('the "returnsPeriod" property', () => {
+    describe('when the "session" has a saved returns period', () => {
+      beforeEach(() => {
+        session = { returnsPeriod: 'quarterOne' }
+
+        testDate = new Date(`${currentYear}-01-29`)
+        clock = Sinon.useFakeTimers(testDate)
+      })
+
+      it('should mark the returns period as checked', () => {
+        const {
+          returnsPeriod: [currentReturnPeriod]
+        } = ReturnsPeriodPresenter.go(session)
+
+        expect(currentReturnPeriod).to.equal({
+          checked: true,
+          value: 'quarterOne',
+          text: `Quarterly 1 January ${currentYear} to 31 March ${currentYear}`,
+          hint: { text: `Due date 28 April ${currentYear}` }
+        })
+      })
+    })
     describe('When the current period is due for "quarterOne"', () => {
       describe('and the current date is between 29 January - 28 April', () => {
         beforeEach(() => {
@@ -46,9 +69,10 @@ describe('Notifications Setup - Returns Period presenter', () => {
         it('returns the current return period as "quarterOne"', () => {
           const {
             returnsPeriod: [currentReturnPeriod]
-          } = ReturnsPeriodPresenter.go()
+          } = ReturnsPeriodPresenter.go(session)
 
           expect(currentReturnPeriod).to.equal({
+            checked: false,
             value: 'quarterOne',
             text: `Quarterly 1 January ${currentYear} to 31 March ${currentYear}`,
             hint: { text: `Due date 28 April ${currentYear}` }
@@ -58,9 +82,10 @@ describe('Notifications Setup - Returns Period presenter', () => {
         it('returns the next return period as "allYear"', () => {
           const {
             returnsPeriod: [, nextReturnPeriod]
-          } = ReturnsPeriodPresenter.go()
+          } = ReturnsPeriodPresenter.go(session)
 
           expect(nextReturnPeriod).to.equal({
+            checked: false,
             value: 'allYear',
             text: `Winter and all year 1 April 2024 to 31 March ${currentYear}`,
             hint: { text: `Due date 28 April ${currentYear}` }
@@ -79,9 +104,10 @@ describe('Notifications Setup - Returns Period presenter', () => {
         it('returns the current return period as "quarterTwo"', () => {
           const {
             returnsPeriod: [currentReturnPeriod]
-          } = ReturnsPeriodPresenter.go()
+          } = ReturnsPeriodPresenter.go(session)
 
           expect(currentReturnPeriod).to.equal({
+            checked: false,
             value: 'quarterTwo',
             text: `Quarterly 1 April ${currentYear} to 30 June ${currentYear}`,
             hint: { text: `Due date 28 July ${currentYear}` }
@@ -91,9 +117,10 @@ describe('Notifications Setup - Returns Period presenter', () => {
         it('returns the next return period as "quarterThree"', () => {
           const {
             returnsPeriod: [, nextReturnPeriod]
-          } = ReturnsPeriodPresenter.go()
+          } = ReturnsPeriodPresenter.go(session)
 
           expect(nextReturnPeriod).to.equal({
+            checked: false,
             value: 'quarterThree',
             text: `Quarterly 1 July ${currentYear} to 30 September ${currentYear}`,
             hint: { text: `Due date 28 October ${currentYear}` }
@@ -112,9 +139,10 @@ describe('Notifications Setup - Returns Period presenter', () => {
         it('returns the current return period as "quarterThree"', () => {
           const {
             returnsPeriod: [currentReturnPeriod]
-          } = ReturnsPeriodPresenter.go()
+          } = ReturnsPeriodPresenter.go(session)
 
           expect(currentReturnPeriod).to.equal({
+            checked: false,
             value: 'quarterThree',
             text: `Quarterly 1 July ${currentYear} to 30 September ${currentYear}`,
             hint: { text: `Due date 28 October ${currentYear}` }
@@ -124,9 +152,10 @@ describe('Notifications Setup - Returns Period presenter', () => {
         it('returns the next return period as "summer"', () => {
           const {
             returnsPeriod: [, nextReturnPeriod]
-          } = ReturnsPeriodPresenter.go()
+          } = ReturnsPeriodPresenter.go(session)
 
           expect(nextReturnPeriod).to.equal({
+            checked: false,
             value: 'summer',
             text: `Summer annual 1 November ${previousYear} to 31 October ${currentYear}`,
             hint: { text: `Due date 28 November ${currentYear}` }
@@ -145,9 +174,10 @@ describe('Notifications Setup - Returns Period presenter', () => {
         it('returns the current return period as "summer"', () => {
           const {
             returnsPeriod: [currentReturnPeriod]
-          } = ReturnsPeriodPresenter.go()
+          } = ReturnsPeriodPresenter.go(session)
 
           expect(currentReturnPeriod).to.equal({
+            checked: false,
             value: 'summer',
             text: `Summer annual 1 November ${previousYear} to 31 October ${currentYear}`,
             hint: { text: `Due date 28 November ${currentYear}` }
@@ -157,9 +187,10 @@ describe('Notifications Setup - Returns Period presenter', () => {
         it('returns the next return period as "quarterFour"', () => {
           const {
             returnsPeriod: [, nextReturnPeriod]
-          } = ReturnsPeriodPresenter.go()
+          } = ReturnsPeriodPresenter.go(session)
 
           expect(nextReturnPeriod).to.equal({
+            checked: false,
             value: 'quarterFour',
             text: `Quarterly 1 October ${currentYear} to 31 December ${currentYear}`,
             hint: { text: `Due date 28 January ${nextYear}` }
@@ -178,9 +209,10 @@ describe('Notifications Setup - Returns Period presenter', () => {
         it('returns the current return period as "quarterFour"', () => {
           const {
             returnsPeriod: [currentReturnPeriod]
-          } = ReturnsPeriodPresenter.go()
+          } = ReturnsPeriodPresenter.go(session)
 
           expect(currentReturnPeriod).to.equal({
+            checked: false,
             value: 'quarterFour',
             text: `Quarterly 1 October ${currentYear} to 31 December ${currentYear}`,
             hint: { text: `Due date 28 January ${nextYear}` }
@@ -190,9 +222,10 @@ describe('Notifications Setup - Returns Period presenter', () => {
         it('returns the next return period as "quarterOne"', () => {
           const {
             returnsPeriod: [, nextReturnPeriod]
-          } = ReturnsPeriodPresenter.go()
+          } = ReturnsPeriodPresenter.go(session)
 
           expect(nextReturnPeriod).to.equal({
+            checked: false,
             value: 'quarterOne',
             text: `Quarterly 1 January ${nextYear} to 31 March ${nextYear}`,
             hint: { text: `Due date 28 April ${nextYear}` }
@@ -209,9 +242,10 @@ describe('Notifications Setup - Returns Period presenter', () => {
         it('returns the current return period as "quarterFour" - with the start and end date in the previous year', () => {
           const {
             returnsPeriod: [currentReturnPeriod]
-          } = ReturnsPeriodPresenter.go()
+          } = ReturnsPeriodPresenter.go(session)
 
           expect(currentReturnPeriod).to.equal({
+            checked: false,
             value: 'quarterFour',
             text: `Quarterly 1 October ${previousYear} to 31 December ${previousYear}`,
             hint: { text: `Due date 28 January ${currentYear}` }
@@ -221,9 +255,10 @@ describe('Notifications Setup - Returns Period presenter', () => {
         it('returns the next return period as "quarterFour" - with the start and end date in the current year', () => {
           const {
             returnsPeriod: [, nextReturnPeriod]
-          } = ReturnsPeriodPresenter.go()
+          } = ReturnsPeriodPresenter.go(session)
 
           expect(nextReturnPeriod).to.equal({
+            checked: false,
             value: 'quarterOne',
             text: `Quarterly 1 January ${currentYear} to 31 March ${currentYear}`,
             hint: { text: `Due date 28 April ${currentYear}` }

--- a/test/services/notifications/setup/returns-period.services.test.js
+++ b/test/services/notifications/setup/returns-period.services.test.js
@@ -8,13 +8,19 @@ const Sinon = require('sinon')
 const { describe, it, after, before } = (exports.lab = Lab.script())
 const { expect } = Code
 
+// Test helpers
+const SessionHelper = require('../../../support/helpers/session.helper.js')
+
 // Thing under test
 const ReturnsPeriodService = require('../../../../app/services/notifications/setup/returns-period.service.js')
 
 describe('Notifications Setup - Returns Period service', () => {
   let clock
+  let session
 
-  before(() => {
+  before(async () => {
+    session = await SessionHelper.add()
+
     const testDate = new Date('2024-12-01')
 
     clock = Sinon.useFakeTimers(testDate)
@@ -25,8 +31,8 @@ describe('Notifications Setup - Returns Period service', () => {
   })
 
   describe('when provided no params', () => {
-    it('correctly presents the data', () => {
-      const result = ReturnsPeriodService.go()
+    it('correctly presents the data', async () => {
+      const result = await ReturnsPeriodService.go(session.id)
 
       expect(result).to.equal({
         activeNavBar: 'manage',
@@ -34,6 +40,7 @@ describe('Notifications Setup - Returns Period service', () => {
         pageTitle: 'Select the returns periods for the invitations',
         returnsPeriod: [
           {
+            checked: false,
             hint: {
               text: 'Due date 28 January 2025'
             },
@@ -41,6 +48,7 @@ describe('Notifications Setup - Returns Period service', () => {
             value: 'quarterFour'
           },
           {
+            checked: false,
             hint: {
               text: 'Due date 28 April 2025'
             },


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4716

As part of the ongoing work to migrate the legacy UI we are replacing the notification journey from the UI and rebuilding in system.

This change introduces session save and retrieval for the returns period page. When he user has selected a returns period then this will be saved to the session for the notifications setup journey.