### PR TITLE
Highlight code with no tests but reported in coverage

### DIFF
--- a/.labrc.js
+++ b/.labrc.js
@@ -3,7 +3,17 @@
 module.exports = {
   verbose: true,
   coverage: true,
-  'coverage-exclude': ['db/seeds'],
+  'coverage-exclude': [
+    'db/seeds',
+    'app/controllers/check.controller.js', // Test helper endpoints
+    // Most plugins are not tested directly (but are inherently tested by other tests loading the web server)
+    // The plugins below do no get 100% coverage, this comment is here to highlight this.
+    'app/plugins/airbrake.plugin.js',
+    'app/plugins/auth.plugin.js',
+    'app/plugins/hapi-pino.plugin.js',
+    'app/plugins/stop.plugin.js',
+    'app/plugins/views.plugin.js'
+  ],
   // lcov reporter required for SonarQube
   reporter: ['console', 'html', 'lcov'],
   output: ['stdout', 'coverage/coverage.html', 'coverage/lcov.info'],


### PR DESCRIPTION
As part of ongoing improvements we are trying to make sure all code has coverage (where deemed reasonable).

Some of our code may be tested indirectly and this helps cover parts of the codebase.

In this change we are highlighting that the:

- app server does not have/ or need a test
- check endpoints are for testing and is no production code so this is deemed to not need a test
- app plugins are inherently tested when testing with the server running with hapi lab

We can look to test these specifically at a later date.