### PR TITLE
Remove call to generate return logs on import

### DIFF
--- a/app/services/jobs/import/process-import-licence.service.js
+++ b/app/services/jobs/import/process-import-licence.service.js
@@ -7,7 +7,6 @@
 
 const DetermineLicenceEndDateChangedService = require('./determine-licence-end-date-changed.service.js')
 const ProcessBillingFlagService = require('../../licences/supplementary/process-billing-flag.service.js')
-const GenerateReturnLogsService = require('./generate-return-logs.service.js')
 
 /**
  * Process licence for the licences imported from NALD
@@ -32,7 +31,6 @@ async function go(licence) {
 
     if (licenceEndDateChanged) {
       ProcessBillingFlagService.go(payload)
-      GenerateReturnLogsService.go(licence.id, payload)
     }
   } catch (error) {
     global.GlobalNotifier.omfg(`Importing licence ${licence.id}`, null, error)

--- a/test/services/jobs/import/process-import-licence.service.test.js
+++ b/test/services/jobs/import/process-import-licence.service.test.js
@@ -72,19 +72,6 @@ describe('Process Import Licence Service', () => {
 
         expect(stubProcessBillingFlagService.calledWithExactly(expectedPayload)).to.be.true()
       })
-
-      it('should call the "stubDetermineLicenceEndDateChangedService" service ', async () => {
-        await ProcessImportLicence.go(licence)
-
-        const expectedPayload = {
-          expiredDate: licence.expired_date,
-          lapsedDate: licence.lapsed_date,
-          revokedDate: licence.revoked_date,
-          licenceId: licence.id
-        }
-
-        expect(stubGenerateReturnLogsService.calledWithExactly(licence.id, expectedPayload)).to.be.true()
-      })
     })
     describe('and the licence end date has not changed', () => {
       beforeEach(() => {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4728

This change removes the call to generate return logs for ended licence. This feature will be needed when we replace NALD for generating return logs and will be included as part of the new import work when that goes lice.
