### PR TITLE
Fix two-part tariff bill runs time out error

### DIFF
--- a/app/services/bill-runs/two-part-tariff/generate-bill-run.service.js
+++ b/app/services/bill-runs/two-part-tariff/generate-bill-run.service.js
@@ -51,7 +51,9 @@ async function go(billRunId) {
   }
 
   await _updateStatus(billRunId, 'processing')
-  await _generateBillRun(billRun)
+
+  // NOTE: We do not await this call intentionally. We don't want to block the user while we generate the bill run
+  _generateBillRun(billRun)
 }
 
 /**


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4871

The billing & data team confirmed their first SROC annual two-part tariff bill run as ready on 10 Jan 2025. However, after seeing the page seem to 'spin its wheels' for a while, they got an error.

When they returned to the bill runs screen, though, the bill run was listed as `READY`. A check of the bill run confirmed everything was fine.

We _know_ the bill run can take a while to create (use the match and allocation information to grab the charges from the [CHA](https://github.com/DEFRA/sroc-charging-module-api) and make the bill run `READY`). That is why we built it to redirect the user to the bill runs page and leave the bill run churning in the background.

But the issue description suggested we'd done something to break that functionality.

Step forward [Stop returning command-only async calls](https://github.com/DEFRA/water-abstraction-system/pull/1499)! A PR to fix a wrong decision about how we were doing `async/await` calls in some scenarios mistakenly included the two-part tariff bill run generation.

This change reverts the change made and gets the service redirecting rather than timing out again.