### PR TITLE
Mark for supplementary billing charge version bug

### DIFF
--- a/app/services/licences/supplementary/determine-charge-version-flags.service.js
+++ b/app/services/licences/supplementary/determine-charge-version-flags.service.js
@@ -51,7 +51,7 @@ async function go(chargeVersionId) {
     result.flagForPreSrocSupplementary = true
   }
 
-  if (!twoPartTariff && scheme === 'sroc') {
+  if (scheme === 'sroc') {
     result.flagForSrocSupplementary = true
   }
 

--- a/test/services/licences/supplementary/determine-charge-version-flags.service.test.js
+++ b/test/services/licences/supplementary/determine-charge-version-flags.service.test.js
@@ -125,7 +125,7 @@ describe('Determine Charge Version Flags Service', () => {
             const result = await DetermineChargeVersionFlagsService.go(chargeVersion.id)
 
             expect(result.flagForPreSrocSupplementary).to.equal(false)
-            expect(result.flagForSrocSupplementary).to.equal(false)
+            expect(result.flagForSrocSupplementary).to.equal(true)
             expect(result.flagForTwoPartTariffSupplementary).to.equal(true)
           })
         })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4874

Following our last release, a live issue was reported where charge versions were not being flagged for supplementary billing. The issue stemmed from a misunderstanding in the flagging logic: when a two-part tariff charge version was approved, the service only flagged for two-part tariff years instead of also marking the licence for SROC supplementary billing.

This PR corrects the logic so that any change to a charge version will now always trigger either a pre-SROC or SROC flag, as all changes impact the annual bill run. Two-part tariff flags will still be added when applicable but are now treated as additional flags, ensuring correct flagging for all scenarios.