### PR TITLE
Update controllers to new pageTitle and navBar convention

### DIFF
--- a/app/controllers/bill-runs-setup.controller.js
+++ b/app/controllers/bill-runs-setup.controller.js
@@ -23,10 +23,7 @@ async function check(request, h) {
 
   const pageData = await CheckService.go(sessionId)
 
-  return h.view('bill-runs/setup/check.njk', {
-    activeNavBar: 'bill-runs',
-    ...pageData
-  })
+  return h.view('bill-runs/setup/check.njk', pageData)
 }
 
 async function noLicences(request, h) {
@@ -34,10 +31,7 @@ async function noLicences(request, h) {
 
   const pageData = await NoLicencesService.go(sessionId)
 
-  return h.view('bill-runs/setup/no-licences.njk', {
-    activeNavBar: 'bill-runs',
-    ...pageData
-  })
+  return h.view('bill-runs/setup/no-licences.njk', pageData)
 }
 
 async function region(request, h) {
@@ -45,10 +39,7 @@ async function region(request, h) {
 
   const pageData = await RegionService.go(sessionId)
 
-  return h.view('bill-runs/setup/region.njk', {
-    activeNavBar: 'bill-runs',
-    ...pageData
-  })
+  return h.view('bill-runs/setup/region.njk', pageData)
 }
 
 async function season(request, h) {
@@ -56,10 +47,7 @@ async function season(request, h) {
 
   const pageData = await SeasonService.go(sessionId)
 
-  return h.view('bill-runs/setup/season.njk', {
-    activeNavBar: 'bill-runs',
-    ...pageData
-  })
+  return h.view('bill-runs/setup/season.njk', pageData)
 }
 
 async function setup(_request, h) {
@@ -74,10 +62,7 @@ async function submitCheck(request, h) {
   const pageData = await SubmitCheckService.go(sessionId, request.auth)
 
   if (pageData.error) {
-    return h.view('bill-runs/setup/check.njk', {
-      activeNavBar: 'bill-runs',
-      ...pageData
-    })
+    return h.view('bill-runs/setup/check.njk', pageData)
   }
 
   return h.redirect(`/system/bill-runs`)
@@ -89,10 +74,7 @@ async function submitRegion(request, h) {
   const pageData = await SubmitRegionService.go(sessionId, request.payload)
 
   if (pageData.error) {
-    return h.view('bill-runs/setup/region.njk', {
-      activeNavBar: 'bill-runs',
-      ...pageData
-    })
+    return h.view('bill-runs/setup/region.njk', pageData)
   }
 
   if (pageData.setupComplete) {
@@ -108,10 +90,7 @@ async function submitSeason(request, h) {
   const pageData = await SubmitSeasonService.go(sessionId, request.payload)
 
   if (pageData.error) {
-    return h.view('bill-runs/setup/season.njk', {
-      activeNavBar: 'bill-runs',
-      ...pageData
-    })
+    return h.view('bill-runs/setup/season.njk', pageData)
   }
 
   return h.redirect(`/system/bill-runs/setup/${sessionId}/check`)
@@ -123,10 +102,7 @@ async function submitType(request, h) {
   const pageData = await SubmitTypeService.go(sessionId, request.payload)
 
   if (pageData.error) {
-    return h.view('bill-runs/setup/type.njk', {
-      activeNavBar: 'bill-runs',
-      ...pageData
-    })
+    return h.view('bill-runs/setup/type.njk', pageData)
   }
 
   return h.redirect(`/system/bill-runs/setup/${sessionId}/region`)
@@ -138,10 +114,7 @@ async function submitYear(request, h) {
   const pageData = await SubmitYearService.go(sessionId, request.payload)
 
   if (pageData.error) {
-    return h.view('bill-runs/setup/year.njk', {
-      activeNavBar: 'bill-runs',
-      ...pageData
-    })
+    return h.view('bill-runs/setup/year.njk', pageData)
   }
 
   if (pageData.setupComplete) {
@@ -156,10 +129,7 @@ async function type(request, h) {
 
   const pageData = await TypeService.go(sessionId)
 
-  return h.view('bill-runs/setup/type.njk', {
-    activeNavBar: 'bill-runs',
-    ...pageData
-  })
+  return h.view('bill-runs/setup/type.njk', pageData)
 }
 
 async function year(request, h) {
@@ -171,10 +141,7 @@ async function year(request, h) {
     return h.redirect(`/system/bill-runs/setup/${sessionId}/no-licences`)
   }
 
-  return h.view('bill-runs/setup/year.njk', {
-    activeNavBar: 'bill-runs',
-    ...pageData
-  })
+  return h.view('bill-runs/setup/year.njk', pageData)
 }
 
 module.exports = {

--- a/app/controllers/bill-runs.controller.js
+++ b/app/controllers/bill-runs.controller.js
@@ -20,11 +20,7 @@ async function cancel(request, h) {
 
   const pageData = await ViewCancelBillRunService.go(id)
 
-  return h.view('bill-runs/cancel.njk', {
-    pageTitle: "You're about to cancel this bill run",
-    activeNavBar: 'bill-runs',
-    ...pageData
-  })
+  return h.view('bill-runs/cancel.njk', pageData)
 }
 
 async function index(request, h) {
@@ -32,10 +28,7 @@ async function index(request, h) {
 
   const pageData = await IndexBillRunsService.go(page)
 
-  return h.view('bill-runs/index.njk', {
-    activeNavBar: 'bill-runs',
-    ...pageData
-  })
+  return h.view('bill-runs/index.njk', pageData)
 }
 
 async function send(request, h) {
@@ -43,11 +36,7 @@ async function send(request, h) {
 
   const pageData = await ViewSendBillRunService.go(id)
 
-  return h.view('bill-runs/send.njk', {
-    pageTitle: "You're about to send this bill run",
-    activeNavBar: 'bill-runs',
-    ...pageData
-  })
+  return h.view('bill-runs/send.njk', pageData)
 }
 
 async function submitCancel(request, h) {
@@ -91,10 +80,7 @@ async function view(request, h) {
 
   const pageData = await ViewBillRunService.go(id)
 
-  return h.view(pageData.view, {
-    activeNavBar: 'bill-runs',
-    ...pageData
-  })
+  return h.view(pageData.view, pageData)
 }
 
 module.exports = {

--- a/app/presenters/bill-runs/view-cancel-bill-run.presenter.js
+++ b/app/presenters/bill-runs/view-cancel-bill-run.presenter.js
@@ -32,6 +32,7 @@ function go(billRun) {
     chargeScheme: formatChargeScheme(scheme),
     dateCreated: formatLongDate(createdAt),
     financialYear: formatFinancialYear(toFinancialYearEnding),
+    pageTitle: "You're about to cancel this bill run",
     region: titleCase(region.displayName)
   }
 }

--- a/app/presenters/bill-runs/view-send-bill-run.presenter.js
+++ b/app/presenters/bill-runs/view-send-bill-run.presenter.js
@@ -31,6 +31,7 @@ function go(billRun) {
     chargeScheme: formatChargeScheme(scheme),
     dateCreated: formatLongDate(createdAt),
     financialYear: formatFinancialYear(toFinancialYearEnding),
+    pageTitle: "You're about to send this bill run",
     region: titleCase(region.displayName)
   }
 }

--- a/app/services/bill-runs/cancel/view-cancel-bill-run.service.js
+++ b/app/services/bill-runs/cancel/view-cancel-bill-run.service.js
@@ -19,9 +19,12 @@ const ViewCancelBillRunPresenter = require('../../../presenters/bill-runs/view-c
 async function go(id) {
   const billRun = await _fetchBillRun(id)
 
-  const pageData = ViewCancelBillRunPresenter.go(billRun)
+  const formattedData = ViewCancelBillRunPresenter.go(billRun)
 
-  return pageData
+  return {
+    activeNavBar: 'bill-runs',
+    ...formattedData
+  }
 }
 
 async function _fetchBillRun(id) {

--- a/app/services/bill-runs/index-bill-runs.service.js
+++ b/app/services/bill-runs/index-bill-runs.service.js
@@ -36,6 +36,7 @@ async function go(page) {
   const pageTitle = _pageTitle(pagination.numberOfPages, selectedPageNumber)
 
   return {
+    activeNavBar: 'bill-runs',
     billRuns,
     busy: busyResult,
     pageTitle,

--- a/app/services/bill-runs/send/view-send-bill-run.service.js
+++ b/app/services/bill-runs/send/view-send-bill-run.service.js
@@ -19,9 +19,12 @@ const ViewSendBillRunPresenter = require('../../../presenters/bill-runs/view-sen
 async function go(id) {
   const billRun = await _fetchBillRun(id)
 
-  const pageData = ViewSendBillRunPresenter.go(billRun)
+  const formattedData = ViewSendBillRunPresenter.go(billRun)
 
-  return pageData
+  return {
+    activeNavBar: 'bill-runs',
+    ...formattedData
+  }
 }
 
 async function _fetchBillRun(id) {

--- a/app/services/bill-runs/setup/check.service.js
+++ b/app/services/bill-runs/setup/check.service.js
@@ -20,8 +20,12 @@ async function go(sessionId) {
   const session = await SessionModel.query().findById(sessionId)
 
   const blockingResults = await DetermineBlockingBillRunService.go(session)
+  const formattedData = await CheckPresenter.go(session, blockingResults)
 
-  return CheckPresenter.go(session, blockingResults)
+  return {
+    activeNavBar: 'bill-runs',
+    ...formattedData
+  }
 }
 
 module.exports = {

--- a/app/services/bill-runs/setup/no-licences.service.js
+++ b/app/services/bill-runs/setup/no-licences.service.js
@@ -23,6 +23,7 @@ async function go(sessionId) {
   const { displayName: regionName } = await RegionModel.query().findById(regionId).select('displayName')
 
   return {
+    activeNavBar: 'bill-runs',
     pageTitle: `There are no licences marked for two-part tariff supplementary billing in the ${regionName} region`,
     sessionId
   }

--- a/app/services/bill-runs/setup/region.service.js
+++ b/app/services/bill-runs/setup/region.service.js
@@ -23,7 +23,12 @@ async function go(sessionId) {
   const session = await SessionModel.query().findById(sessionId)
   const regions = await FetchRegionsService.go()
 
-  return RegionPresenter.go(session, regions)
+  const formattedData = RegionPresenter.go(session, regions)
+
+  return {
+    activeNavBar: 'bill-runs',
+    ...formattedData
+  }
 }
 
 module.exports = {

--- a/app/services/bill-runs/setup/season.service.js
+++ b/app/services/bill-runs/setup/season.service.js
@@ -21,7 +21,12 @@ const SeasonPresenter = require('../../../presenters/bill-runs/setup/season.pres
 async function go(sessionId) {
   const session = await SessionModel.query().findById(sessionId)
 
-  return SeasonPresenter.go(session)
+  const formattedData = SeasonPresenter.go(session)
+
+  return {
+    activeNavBar: 'bill-runs',
+    ...formattedData
+  }
 }
 
 module.exports = {

--- a/app/services/bill-runs/setup/submit-check.service.js
+++ b/app/services/bill-runs/setup/submit-check.service.js
@@ -58,6 +58,7 @@ async function go(sessionId, auth) {
   const pageData = await CheckPresenter.go(session, blockingResults)
 
   return {
+    activeNavBar: 'bill-runs',
     error: true,
     ...pageData
   }

--- a/app/services/bill-runs/setup/submit-region.service.js
+++ b/app/services/bill-runs/setup/submit-region.service.js
@@ -46,6 +46,7 @@ async function go(sessionId, payload) {
   const formattedData = RegionPresenter.go(session, regions)
 
   return {
+    activeNavBar: 'bill-runs',
     error: validationResult,
     ...formattedData
   }

--- a/app/services/bill-runs/setup/submit-season.service.js
+++ b/app/services/bill-runs/setup/submit-season.service.js
@@ -42,6 +42,7 @@ async function go(sessionId, payload) {
   const pageData = SeasonPresenter.go(session)
 
   return {
+    activeNavBar: 'bill-runs',
     error: validationResult,
     ...pageData
   }

--- a/app/services/bill-runs/setup/submit-type.service.js
+++ b/app/services/bill-runs/setup/submit-type.service.js
@@ -42,6 +42,7 @@ async function go(sessionId, payload) {
   const pageData = TypePresenter.go(session)
 
   return {
+    activeNavBar: 'bill-runs',
     error: validationResult,
     ...pageData
   }

--- a/app/services/bill-runs/setup/submit-year.service.js
+++ b/app/services/bill-runs/setup/submit-year.service.js
@@ -48,6 +48,7 @@ async function go(sessionId, payload) {
   const pageData = YearPresenter.go(licenceSupplementaryYears, session)
 
   return {
+    activeNavBar: 'bill-runs',
     error: validationResult,
     ...pageData
   }

--- a/app/services/bill-runs/setup/type.service.js
+++ b/app/services/bill-runs/setup/type.service.js
@@ -26,6 +26,7 @@ async function go(sessionId) {
   const pageData = TypePresenter.go(session)
 
   return {
+    activeNavBar: 'bill-runs',
     enableTwoPartTariffSupplementary: FeatureFlagsConfig.enableTwoPartTariffSupplementary,
     ...pageData
   }

--- a/app/services/bill-runs/setup/year.service.js
+++ b/app/services/bill-runs/setup/year.service.js
@@ -26,7 +26,12 @@ async function go(sessionId) {
   const twoPartTariffSupplementary = session.type === 'two_part_supplementary'
   const licenceSupplementaryYears = await FetchLicenceSupplementaryYearsService.go(regionId, twoPartTariffSupplementary)
 
-  return YearPresenter.go(licenceSupplementaryYears, session)
+  const formattedData = YearPresenter.go(licenceSupplementaryYears, session)
+
+  return {
+    activeNavBar: 'bill-runs',
+    ...formattedData
+  }
 }
 
 module.exports = {

--- a/app/services/bill-runs/view-bill-run.service.js
+++ b/app/services/bill-runs/view-bill-run.service.js
@@ -22,9 +22,12 @@ const FetchBillRunService = require('./fetch-bill-run.service.js')
 async function go(id) {
   const result = await FetchBillRunService.go(id)
 
-  const pageData = _pageData(result)
+  const formattedData = _pageData(result)
 
-  return pageData
+  return {
+    activeNavBar: 'bill-runs',
+    ...formattedData
+  }
 }
 
 function _pageData(fetchResult) {

--- a/test/presenters/bill-runs/view-cancel-bill-run.presenter.test.js
+++ b/test/presenters/bill-runs/view-cancel-bill-run.presenter.test.js
@@ -30,6 +30,7 @@ describe('Bill Runs - View Cancel Bill Run presenter', () => {
         chargeScheme: 'Current',
         dateCreated: '1 November 2023',
         financialYear: '2023 to 2024',
+        pageTitle: "You're about to cancel this bill run",
         region: 'Wales'
       })
     })

--- a/test/presenters/bill-runs/view-send-bill-run.presenter.test.js
+++ b/test/presenters/bill-runs/view-send-bill-run.presenter.test.js
@@ -29,6 +29,7 @@ describe('Bill Runs - View Send Bill Run presenter', () => {
         chargeScheme: 'Current',
         dateCreated: '1 November 2023',
         financialYear: '2023 to 2024',
+        pageTitle: "You're about to send this bill run",
         region: 'Wales'
       })
     })

--- a/test/services/bill-runs/cancel/view-cancel-bill-run.service.test.js
+++ b/test/services/bill-runs/cancel/view-cancel-bill-run.service.test.js
@@ -55,6 +55,7 @@ describe('Bill Runs - View Cancel Bill Run service', () => {
       const result = await ViewCancelBillRunService.go(billRunId)
 
       expect(result).to.equal({
+        activeNavBar: 'bill-runs',
         backLink: `/system/bill-runs/${billRunId}`,
         billRunId,
         billRunNumber: 10101,
@@ -63,6 +64,7 @@ describe('Bill Runs - View Cancel Bill Run service', () => {
         chargeScheme: 'Current',
         dateCreated: '28 February 2024',
         financialYear: '2024 to 2025',
+        pageTitle: "You're about to cancel this bill run",
         region: 'Avalon'
       })
     })

--- a/test/services/bill-runs/send/view-send-bill-run.service.test.js
+++ b/test/services/bill-runs/send/view-send-bill-run.service.test.js
@@ -56,6 +56,7 @@ describe('Bill Runs - View Send Bill Run service', () => {
       const result = await ViewSendBillRunService.go(billRunId)
 
       expect(result).to.equal({
+        activeNavBar: 'bill-runs',
         billRunId,
         billRunNumber: 10101,
         billRunStatus: 'ready',
@@ -63,6 +64,7 @@ describe('Bill Runs - View Send Bill Run service', () => {
         chargeScheme: 'Current',
         dateCreated: '28 February 2024',
         financialYear: '2024 to 2025',
+        pageTitle: "You're about to send this bill run",
         region: 'Avalon'
       })
     })

--- a/test/services/bill-runs/setup/check.service.test.js
+++ b/test/services/bill-runs/setup/check.service.test.js
@@ -48,6 +48,7 @@ describe('Bill Runs - Setup - Check service', () => {
       const result = await CheckService.go(session.id)
 
       expect(result).to.equal({
+        activeNavBar: 'bill-runs',
         backLink: `/system/bill-runs/setup/${session.id}/region`,
         billRunLink: null,
         billRunNumber: null,

--- a/test/services/bill-runs/setup/no-licences.service.test.js
+++ b/test/services/bill-runs/setup/no-licences.service.test.js
@@ -30,6 +30,7 @@ describe('Bill Runs - Setup - No Licences service', () => {
       const result = await NoLicencesService.go(sessionId)
 
       expect(result).to.equal({
+        activeNavBar: 'bill-runs',
         sessionId,
         pageTitle: `There are no licences marked for two-part tariff supplementary billing in the ${region.displayName} region`
       })

--- a/test/services/bill-runs/setup/region.service.test.js
+++ b/test/services/bill-runs/setup/region.service.test.js
@@ -41,6 +41,7 @@ describe('Bill Runs - Setup - Region service', () => {
       const result = await RegionService.go(session.id)
 
       expect(result).to.equal({
+        activeNavBar: 'bill-runs',
         pageTitle: 'Select the region',
         regions,
         sessionId: session.id,

--- a/test/services/bill-runs/setup/season.service.test.js
+++ b/test/services/bill-runs/setup/season.service.test.js
@@ -25,6 +25,7 @@ describe('Bill Runs - Setup - Type service', () => {
       const result = await SeasonService.go(session.id)
 
       expect(result).to.equal({
+        activeNavBar: 'bill-runs',
         pageTitle: 'Select the season',
         sessionId: session.id,
         selectedSeason: 'summer'

--- a/test/services/bill-runs/setup/submit-check.service.test.js
+++ b/test/services/bill-runs/setup/submit-check.service.test.js
@@ -93,6 +93,7 @@ describe('Bill Runs - Setup - Submit Check service', () => {
         const result = await SubmitCheckService.go(session.id, auth)
 
         expect(result).to.equal({
+          activeNavBar: 'bill-runs',
           error: true,
           backLink: `/system/bill-runs/setup/${session.id}/region`,
           billRunLink: '/system/bill-runs/c0608545-9870-4605-a407-5ff49f8a5182',

--- a/test/services/bill-runs/setup/submit-region.service.test.js
+++ b/test/services/bill-runs/setup/submit-region.service.test.js
@@ -103,6 +103,7 @@ describe('Bill Runs - Setup - Submit Region service', () => {
           const result = await SubmitRegionService.go(session.id, payload)
 
           expect(result).to.equal({
+            activeNavBar: 'bill-runs',
             error: {
               text: 'Select the region'
             },

--- a/test/services/bill-runs/setup/submit-season.service.test.js
+++ b/test/services/bill-runs/setup/submit-season.service.test.js
@@ -54,6 +54,7 @@ describe('Bill Runs - Setup - Submit Season service', () => {
           const result = await SubmitSeasonService.go(session.id, payload)
 
           expect(result).to.equal({
+            activeNavBar: 'bill-runs',
             error: {
               text: 'Select the season'
             },

--- a/test/services/bill-runs/setup/submit-type.service.test.js
+++ b/test/services/bill-runs/setup/submit-type.service.test.js
@@ -54,6 +54,7 @@ describe('Bill Runs - Setup - Submit Type service', () => {
           const result = await SubmitTypeService.go(session.id, payload)
 
           expect(result).to.equal({
+            activeNavBar: 'bill-runs',
             error: {
               text: 'Select the bill run type'
             },

--- a/test/services/bill-runs/setup/submit-year.service.test.js
+++ b/test/services/bill-runs/setup/submit-year.service.test.js
@@ -84,6 +84,7 @@ describe('Bill Runs - Setup - Submit Year service', () => {
           expect(yearsStub.calledWith(regionId, true)).to.be.true()
 
           expect(result).to.equal({
+            activeNavBar: 'bill-runs',
             financialYearsData: [{ text: '2023 to 2024', value: 2024, checked: false }],
             pageTitle: 'Select the financial year',
             sessionId: session.id,

--- a/test/services/bill-runs/setup/type.service.test.js
+++ b/test/services/bill-runs/setup/type.service.test.js
@@ -36,6 +36,7 @@ describe('Bill Runs - Setup - Type service', () => {
       const result = await TypeService.go(session.id)
 
       expect(result).to.equal({
+        activeNavBar: 'bill-runs',
         enableTwoPartTariffSupplementary: false,
         pageTitle: 'Select the bill run type',
         sessionId: session.id,

--- a/test/services/bill-runs/setup/year.service.test.js
+++ b/test/services/bill-runs/setup/year.service.test.js
@@ -36,6 +36,7 @@ describe('Bill Runs - Setup - Year service', () => {
       expect(yearsStub.calledWith(regionId, true)).to.be.true()
 
       expect(result).to.equal({
+        activeNavBar: 'bill-runs',
         financialYearsData: [{ text: '2023 to 2024', value: 2024, checked: true }],
         pageTitle: 'Select the financial year',
         sessionId: session.id,

--- a/test/services/bill-runs/view-bill-run.service.test.js
+++ b/test/services/bill-runs/view-bill-run.service.test.js
@@ -35,6 +35,7 @@ describe('View Bill Run service', () => {
         const result = await ViewBillRunService.go(testId)
 
         expect(result).to.equal({
+          activeNavBar: 'bill-runs',
           billRunId: '2c80bd22-a005-4cf4-a2a2-73812a9861de',
           billRunNumber: 10003,
           billRunStatus: 'empty',
@@ -61,6 +62,7 @@ describe('View Bill Run service', () => {
         const result = await ViewBillRunService.go(testId)
 
         expect(result).to.equal({
+          activeNavBar: 'bill-runs',
           billRunId: '2c80bd22-a005-4cf4-a2a2-73812a9861de',
           billRunNumber: 10003,
           billRunStatus: 'error',
@@ -87,6 +89,7 @@ describe('View Bill Run service', () => {
           const result = await ViewBillRunService.go(testId)
 
           expect(result).to.equal({
+            activeNavBar: 'bill-runs',
             billsCount: '2 Annual bills',
             billRunId: '2c80bd22-a005-4cf4-a2a2-73812a9861de',
             billRunNumber: 10003,
@@ -152,6 +155,7 @@ describe('View Bill Run service', () => {
           const result = await ViewBillRunService.go(testId)
 
           expect(result).to.equal({
+            activeNavBar: 'bill-runs',
             billsCount: '1 Annual bill',
             billRunId: '2c80bd22-a005-4cf4-a2a2-73812a9861de',
             billRunNumber: 10003,


### PR DESCRIPTION
DEFRA/water-abstraction-team#132

During the migration of legacy pages into our new system repository, we identified inconsistencies in how the pageTitle and navBar were being managed. In some cases, they were defined in the controller, in others within the services, and occasionally in the presenter. After reviewing our coding conventions, we have agreed that, moving forward, the pageTitle should be set in the presenter, while the navBar should be managed in the service called from the controller.

This PR aligns the repository with these updated conventions.