### PR TITLE
Fix return received validation message

### DIFF
--- a/app/validators/return-logs/setup/received-date.validator.js
+++ b/app/validators/return-logs/setup/received-date.validator.js
@@ -44,6 +44,10 @@ function go(payload, startDate) {
 function _fullDate(payload) {
   const { 'received-date-day': day, 'received-date-month': month, 'received-date-year': year } = payload
 
+  if (!year && !month && !day) {
+    return null
+  }
+
   const paddedMonth = month ? leftPadZeroes(month, 2) : ''
   const paddedDay = day ? leftPadZeroes(day, 2) : ''
 

--- a/test/validators/return-logs/setup/received-date.validator.test.js
+++ b/test/validators/return-logs/setup/received-date.validator.test.js
@@ -88,11 +88,11 @@ describe('Return Logs Setup - Received Date validator', () => {
           payload['received-date-year'] = null
         })
 
-        it('fails validation with the message "Enter a real received date"', () => {
+        it('fails validation with the message "Enter a return received date"', () => {
           const result = ReceivedDateValidator.go(payload, returnStartDate)
 
           expect(result.error).to.exist()
-          expect(result.error.details[0].message).to.equal('Enter a real received date')
+          expect(result.error.details[0].message).to.equal('Enter a return received date')
         })
       })
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4844

During testing for the return received page in the return log setup journey, it was noticed that the error message was incorrect for a custom date selected but not entered. This PR fixes that.