### PR TITLE
Fix when the "Record receipt" option is displayed

### DIFF
--- a/app/presenters/return-logs/setup/start.presenter.js
+++ b/app/presenters/return-logs/setup/start.presenter.js
@@ -16,6 +16,7 @@ const { formatAbstractionPeriod, formatLongDate } = require('../../base.presente
  */
 function go(session) {
   const {
+    beenReceived,
     dueDate,
     endDate,
     journey,
@@ -26,7 +27,6 @@ function go(session) {
     periodEndDay,
     periodEndMonth,
     purposes,
-    receivedDate,
     returnReference,
     siteDescription,
     startDate,
@@ -41,7 +41,7 @@ function go(session) {
       periodEndDay,
       periodEndMonth
     )}`,
-    displayRecordReceipt: receivedDate === null,
+    beenReceived,
     journey: journey ?? null,
     licenceId,
     licenceRef,

--- a/app/services/return-logs/setup/initiate-session.service.js
+++ b/app/services/return-logs/setup/initiate-session.service.js
@@ -34,10 +34,9 @@ async function go(returnLogId) {
 }
 
 function _data(returnLog) {
-  const beenReceived = returnLog.receivedDate !== null
   const formattedPurposes = _formatPurposes(returnLog.purposes)
 
-  returnLog.beenReceived = beenReceived
+  returnLog.beenReceived = returnLog.receivedDate !== null
   returnLog.purposes = formattedPurposes
 
   return returnLog

--- a/app/services/return-logs/setup/initiate-session.service.js
+++ b/app/services/return-logs/setup/initiate-session.service.js
@@ -34,7 +34,10 @@ async function go(returnLogId) {
 }
 
 function _data(returnLog) {
+  const beenReceived = returnLog.receivedDate !== null
   const formattedPurposes = _formatPurposes(returnLog.purposes)
+
+  returnLog.beenReceived = beenReceived
   returnLog.purposes = formattedPurposes
 
   return returnLog

--- a/app/views/return-logs/setup/start.njk
+++ b/app/views/return-logs/setup/start.njk
@@ -124,7 +124,7 @@
         },
         {
           divider: "or"
-        } if displayRecordReceipt === false,
+        } if beenReceived === true,
         {
           value: "nil-return",
           text: "Enter a nil return",
@@ -132,12 +132,12 @@
         },
         {
           divider: "or"
-        } if displayRecordReceipt === true,
+        } if beenReceived === false,
         {
           value: "record-receipt",
           text: "Record receipt",
           checked: journey === "record-receipt"
-        } if displayRecordReceipt === true
+        } if beenReceived === false
       ]
     }) }}
 

--- a/test/presenters/return-logs/setup/start.presenter.test.js
+++ b/test/presenters/return-logs/setup/start.presenter.test.js
@@ -23,7 +23,7 @@ describe('Return Logs Setup - Start presenter', () => {
 
       expect(result).to.equal({
         abstractionPeriod: 'From 1 January to 31 December',
-        displayRecordReceipt: true,
+        beenReceived: false,
         journey: null,
         licenceId: 'db3731ae-3dde-4778-a81e-9be549cfc0e1',
         licenceRef: '01/111',
@@ -34,20 +34,6 @@ describe('Return Logs Setup - Start presenter', () => {
         siteDescription: 'POINT A, TIDAL RIVER MEDWAY AT ISLE OF GRAIN',
         status: 'overdue',
         tariffType: 'Standard tariff'
-      })
-    })
-
-    describe('the "displayRecordReceipt" property', () => {
-      describe('when the return log has a received date', () => {
-        beforeEach(() => {
-          session.receivedDate = '2023-04-27T00:00:00.000Z'
-        })
-
-        it('sets the property to false', () => {
-          const result = StartPresenter.go(session)
-
-          expect(result.displayRecordReceipt).to.be.false()
-        })
       })
     })
 
@@ -110,21 +96,21 @@ describe('Return Logs Setup - Start presenter', () => {
 
 function _testSession() {
   return {
-    status: 'due',
+    beenReceived: false,
     dueDate: '2023-04-28T00:00:00.000Z',
     endDate: '2023-03-31T00:00:00.000Z',
-    purposes: 'Evaporative Cooling',
     licenceId: 'db3731ae-3dde-4778-a81e-9be549cfc0e1',
-    startDate: '2022-04-01T00:00:00.000Z',
     licenceRef: '01/111',
-    underQuery: false,
     periodEndDay: 31,
-    receivedDate: null,
-    twoPartTariff: false,
     periodEndMonth: 12,
     periodStartDay: 1,
+    periodStartMonth: 1,
+    purposes: 'Evaporative Cooling',
     returnReference: '1234',
     siteDescription: 'POINT A, TIDAL RIVER MEDWAY AT ISLE OF GRAIN',
-    periodStartMonth: 1
+    startDate: '2022-04-01T00:00:00.000Z',
+    status: 'due',
+    twoPartTariff: false,
+    underQuery: false
   }
 }

--- a/test/services/return-logs/setup/start.service.test.js
+++ b/test/services/return-logs/setup/start.service.test.js
@@ -28,7 +28,7 @@ describe('Return Logs Setup - Start service', () => {
       expect(result).to.equal({
         abstractionPeriod: 'From 1 January to 31 December',
         activeNavBar: 'search',
-        displayRecordReceipt: true,
+        beenReceived: false,
         journey: null,
         licenceId: 'db3731ae-3dde-4778-a81e-9be549cfc0e1',
         licenceRef: '01/111',
@@ -47,22 +47,22 @@ describe('Return Logs Setup - Start service', () => {
 async function _session() {
   const session = SessionHelper.add({
     data: {
-      status: 'due',
-      dueDate: new Date('2023-04-28'),
-      endDate: new Date('2023-03-31'),
-      purposes: 'Evaporative Cooling',
+      beenReceived: false,
+      dueDate: '2023-04-28T00:00:00.000Z',
+      endDate: '2023-03-31T00:00:00.000Z',
       licenceId: 'db3731ae-3dde-4778-a81e-9be549cfc0e1',
-      startDate: new Date('2022-04-01'),
       licenceRef: '01/111',
-      underQuery: false,
       periodEndDay: 31,
-      receivedDate: null,
-      twoPartTariff: false,
       periodEndMonth: 12,
       periodStartDay: 1,
+      periodStartMonth: 1,
+      purposes: 'Evaporative Cooling',
       returnReference: '1234',
       siteDescription: 'POINT A, TIDAL RIVER MEDWAY AT ISLE OF GRAIN',
-      periodStartMonth: 1
+      startDate: '2022-04-01T00:00:00.000Z',
+      status: 'due',
+      twoPartTariff: false,
+      underQuery: false
     }
   })
 

--- a/test/services/return-logs/setup/submit-start.service.test.js
+++ b/test/services/return-logs/setup/submit-start.service.test.js
@@ -53,7 +53,7 @@ describe('Return Logs Setup - Submit Start service', () => {
         expect(result).to.equal({
           abstractionPeriod: 'From 1 January to 31 December',
           activeNavBar: 'search',
-          displayRecordReceipt: true,
+          beenReceived: false,
           error: { text: 'Select what you want to do with this return' },
           journey: null,
           licenceId: 'db3731ae-3dde-4778-a81e-9be549cfc0e1',
@@ -74,22 +74,22 @@ describe('Return Logs Setup - Submit Start service', () => {
 async function _session() {
   const session = SessionHelper.add({
     data: {
-      status: 'due',
-      dueDate: new Date('2023-04-28'),
-      endDate: new Date('2023-03-31'),
-      purposes: 'Evaporative Cooling',
+      beenReceived: false,
+      dueDate: '2023-04-28T00:00:00.000Z',
+      endDate: '2023-03-31T00:00:00.000Z',
       licenceId: 'db3731ae-3dde-4778-a81e-9be549cfc0e1',
-      startDate: new Date('2022-04-01'),
       licenceRef: '01/111',
-      underQuery: false,
       periodEndDay: 31,
-      receivedDate: null,
-      twoPartTariff: false,
       periodEndMonth: 12,
       periodStartDay: 1,
+      periodStartMonth: 1,
+      purposes: 'Evaporative Cooling',
       returnReference: '1234',
       siteDescription: 'POINT A, TIDAL RIVER MEDWAY AT ISLE OF GRAIN',
-      periodStartMonth: 1
+      startDate: '2022-04-01T00:00:00.000Z',
+      status: 'due',
+      twoPartTariff: false,
+      underQuery: false
     }
   })
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4836

The "Record receipt" option is dynamic and only displayed if the return log has no receipt date recorded against it.

Currently in order to determine if the option should be displayed the session data is checked to see if the `receivedDate` date has been populated. If not the option is displayed.

The problem arises if the user goes down the Enter & Submit route, enters & submits a received date and then decides they have made an error and goes "back". In this scenario, the "Record receipt" option will be hidden as the session data will now contain a `receivedDate`.

To resolve this issue when the session is initiated a new `beenReceived` data item will be added to the session data. This will be a boolean set to `true` if it has been received, false if not.