### PR TITLE
Update controllers to new pageTitle and navBar convention

### DIFF
--- a/app/controllers/notifications-ad-hoc-returns.controller.js
+++ b/app/controllers/notifications-ad-hoc-returns.controller.js
@@ -16,11 +16,7 @@ async function licence(request, h) {
 
   const pageData = await LicenceService.go(sessionId)
 
-  return h.view(`${basePath}/licence.njk`, {
-    activeNavBar: 'manage',
-    pageTitle: 'Enter a licence number',
-    ...pageData
-  })
+  return h.view(`${basePath}/licence.njk`, pageData)
 }
 
 async function setup(_request, h) {
@@ -35,11 +31,7 @@ async function submitLicence(request, h) {
   const pageData = await SubmitLicenceService.go(sessionId, request.payload)
 
   if (pageData.error || pageData.notification) {
-    return h.view(`${basePath}/licence.njk`, {
-      activeNavBar: 'manage',
-      pageTitle: 'Enter a licence number',
-      ...pageData
-    })
+    return h.view(`${basePath}/licence.njk`, pageData)
   }
 
   return h.redirect(`/system/${basePath}/${sessionId}/check-returns`)

--- a/app/presenters/notifications/ad-hoc-returns/licence.presenter.js
+++ b/app/presenters/notifications/ad-hoc-returns/licence.presenter.js
@@ -15,7 +15,8 @@
 function go(session) {
   return {
     sessionId: session.id,
-    licenceRef: session.licenceRef ?? null
+    licenceRef: session.licenceRef ?? null,
+    pageTitle: 'Enter a licence number'
   }
 }
 

--- a/app/presenters/return-logs/setup/received.presenter.js
+++ b/app/presenters/return-logs/setup/received.presenter.js
@@ -23,6 +23,7 @@ function go(session) {
   } = session
 
   return {
+    pageTitle: 'When was the return received?',
     receivedDateOption: receivedDateOptions ?? null,
     receivedDateDay: receivedDateDay ?? null,
     receivedDateMonth: receivedDateMonth ?? null,

--- a/app/presenters/return-versions/setup/abstraction-period.presenter.js
+++ b/app/presenters/return-versions/setup/abstraction-period.presenter.js
@@ -22,6 +22,7 @@ function go(session, requirementIndex) {
     backLink: _backLink(session, requirementIndex),
     licenceId: licence.id,
     licenceRef: licence.licenceRef,
+    pageTitle: 'Enter the abstraction period for the requirements for returns',
     sessionId
   }
 }

--- a/app/presenters/return-versions/setup/additional-submission-options.presenter.js
+++ b/app/presenters/return-versions/setup/additional-submission-options.presenter.js
@@ -32,6 +32,7 @@ function go(session) {
     noAdditionalOptions,
     quarterlyReturnSubmissions: isQuarterlyReturnSubmissions(returnVersionStartDate),
     quarterlyReturns,
+    pageTitle: 'Select any additional submission options for the return requirements',
     sessionId
   }
 }

--- a/app/presenters/return-versions/setup/agreements-exceptions.presenter.js
+++ b/app/presenters/return-versions/setup/agreements-exceptions.presenter.js
@@ -22,6 +22,7 @@ function go(session, requirementIndex) {
     agreementsExceptions: requirement?.agreementsExceptions ? requirement.agreementsExceptions : null,
     licenceId: licence.id,
     licenceRef: licence.licenceRef,
+    pageTitle: 'Select agreements and exceptions for the requirements for returns',
     sessionId
   }
 }

--- a/app/presenters/return-versions/setup/cancel.presenter.js
+++ b/app/presenters/return-versions/setup/cancel.presenter.js
@@ -22,6 +22,7 @@ function go(session) {
     backLink: `/system/return-versions/setup/${sessionId}/check`,
     licenceId: licence.id,
     licenceRef: licence.licenceRef,
+    pageTitle: 'You are about to cancel these requirements for returns',
     reason: returnRequirementReasons[reason],
     returnRequirements: _returnRequirements(journey, requirements),
     startDate: _startDate(session),

--- a/app/presenters/return-versions/setup/existing.presenter.js
+++ b/app/presenters/return-versions/setup/existing.presenter.js
@@ -22,6 +22,7 @@ function go(session) {
     backLink: `/system/return-versions/setup/${sessionId}/method`,
     existingOptions: _existingOptions(licence.returnVersions),
     licenceRef: licence.licenceRef,
+    pageTitle: 'Use previous requirements for returns',
     sessionId
   }
 }

--- a/app/presenters/return-versions/setup/frequency-collected.presenter.js
+++ b/app/presenters/return-versions/setup/frequency-collected.presenter.js
@@ -22,6 +22,7 @@ function go(session, requirementIndex) {
     frequencyCollected: requirement?.frequencyCollected ? requirement.frequencyCollected : null,
     licenceId: licence.id,
     licenceRef: licence.licenceRef,
+    pageTitle: 'Select how often readings or volumes are collected',
     sessionId
   }
 }

--- a/app/presenters/return-versions/setup/frequency-reported.presenter.js
+++ b/app/presenters/return-versions/setup/frequency-reported.presenter.js
@@ -22,6 +22,7 @@ function go(session, requirementIndex) {
     frequencyReported: requirement?.frequencyReported ? requirement.frequencyReported : null,
     licenceId: licence.id,
     licenceRef: licence.licenceRef,
+    pageTitle: 'Select how often readings or volumes are reported',
     sessionId
   }
 }

--- a/app/presenters/return-versions/setup/method.presenter.js
+++ b/app/presenters/return-versions/setup/method.presenter.js
@@ -20,6 +20,7 @@ function go(session) {
     displayCopyExisting: licence.returnVersions.length > 0,
     licenceRef: licence.licenceRef,
     method: method ?? null,
+    pageTitle: 'How do you want to set up the requirements for returns?',
     sessionId
   }
 }

--- a/app/presenters/return-versions/setup/no-returns-required.presenter.js
+++ b/app/presenters/return-versions/setup/no-returns-required.presenter.js
@@ -19,6 +19,7 @@ function go(session) {
     backLink: _backLink(session),
     licenceRef: licence.licenceRef,
     reason: reason || null,
+    pageTitle: 'Why are no returns required?',
     sessionId
   }
 }

--- a/app/presenters/return-versions/setup/note.presenter.js
+++ b/app/presenters/return-versions/setup/note.presenter.js
@@ -19,6 +19,7 @@ function go(session) {
     backLink: `/system/return-versions/setup/${sessionId}/check`,
     licenceRef: licence.licenceRef,
     note: note ? note.content : null,
+    pageTitle: 'Add a note',
     sessionId
   }
 }

--- a/app/presenters/return-versions/setup/points.presenter.js
+++ b/app/presenters/return-versions/setup/points.presenter.js
@@ -24,6 +24,7 @@ function go(session, requirementIndex, points) {
     licenceId: licence.id,
     licencePoints: _licencePoints(points),
     licenceRef: licence.licenceRef,
+    pageTitle: 'Select the points for the requirements for returns',
     selectedPointIds: requirement?.points ? requirement.points.join(',') : '',
     sessionId
   }

--- a/app/presenters/return-versions/setup/purpose.presenter.js
+++ b/app/presenters/return-versions/setup/purpose.presenter.js
@@ -22,6 +22,7 @@ function go(session, requirementIndex, licencePurposes) {
     backLink: _backLink(session),
     licenceId: licence.id,
     licenceRef: licence.licenceRef,
+    pageTitle: 'Select the purpose for the requirements for returns',
     purposes: _purposes(licencePurposes, requirement.purposes),
     sessionId
   }

--- a/app/presenters/return-versions/setup/reason.presenter.js
+++ b/app/presenters/return-versions/setup/reason.presenter.js
@@ -18,6 +18,7 @@ function go(session) {
   return {
     backLink: _backLink(session),
     licenceRef: licence.licenceRef,
+    pageTitle: 'Select the reason for the requirements for returns',
     reason: reason ?? null,
     sessionId
   }

--- a/app/presenters/return-versions/setup/remove.presenter.js
+++ b/app/presenters/return-versions/setup/remove.presenter.js
@@ -24,6 +24,7 @@ function go(session, requirementIndex) {
     backLink: _backLink(session),
     licenceId: licence.id,
     licenceRef: licence.licenceRef,
+    pageTitle: 'You are about to remove these requirements for returns',
     returnRequirement: _formattedReturnRequirement(requirement),
     sessionId,
     startDate: _startDate(session)

--- a/app/presenters/return-versions/setup/returns-cycle.presenter.js
+++ b/app/presenters/return-versions/setup/returns-cycle.presenter.js
@@ -21,6 +21,7 @@ function go(session, requirementIndex) {
     backLink: _backLink(session, requirementIndex),
     licenceId: licence.id,
     licenceRef: licence.licenceRef,
+    pageTitle: 'Select the returns cycle for the requirements for returns',
     returnsCycle: requirement?.returnsCycle ? requirement.returnsCycle : null,
     sessionId
   }

--- a/app/presenters/return-versions/setup/site-description.presenter.js
+++ b/app/presenters/return-versions/setup/site-description.presenter.js
@@ -21,6 +21,7 @@ function go(session, requirementIndex) {
     backLink: _backLink(session, requirementIndex),
     licenceId: licence.id,
     licenceRef: licence.licenceRef,
+    pageTitle: 'Enter a site description for the requirements for returns',
     sessionId,
     siteDescription: requirement?.siteDescription ? requirement.siteDescription : null
   }

--- a/app/presenters/return-versions/setup/start-date.presenter.js
+++ b/app/presenters/return-versions/setup/start-date.presenter.js
@@ -26,6 +26,7 @@ function go(session) {
     licenceId: licence.id,
     licenceRef: licence.licenceRef,
     licenceVersionStartDate: _licenceVersionStartDate(licence),
+    pageTitle: 'Select the start date for the requirements for returns',
     sessionId,
     startDateOption: startDateOptions ?? null
   }

--- a/app/services/notifications/ad-hoc-returns/licence.service.js
+++ b/app/services/notifications/ad-hoc-returns/licence.service.js
@@ -23,6 +23,7 @@ async function go(sessionId) {
   const formattedData = LicencePresenter.go(session)
 
   return {
+    activeNavBar: 'manage',
     ...formattedData
   }
 }

--- a/app/services/notifications/ad-hoc-returns/submit-licence.service.js
+++ b/app/services/notifications/ad-hoc-returns/submit-licence.service.js
@@ -32,6 +32,7 @@ async function go(sessionId, payload) {
 
   if (validationResult) {
     return {
+      activeNavBar: 'manage',
       error: validationResult,
       ...formattedData
     }
@@ -40,6 +41,7 @@ async function go(sessionId, payload) {
   const dueReturns = await _dueReturnsExist(payload.licenceRef)
   if (!dueReturns) {
     return {
+      activeNavBar: 'manage',
       notification: `There are no returns due for licence ${payload.licenceRef}`,
       ...formattedData
     }

--- a/app/services/return-logs/setup/received.service.js
+++ b/app/services/return-logs/setup/received.service.js
@@ -24,7 +24,6 @@ async function go(sessionId) {
   const formattedData = ReceivedPresenter.go(session)
 
   return {
-    pageTitle: 'When was the return received?',
     activeNavBar: 'search',
     ...formattedData
   }

--- a/app/services/return-logs/setup/submit-received.service.js
+++ b/app/services/return-logs/setup/submit-received.service.js
@@ -39,7 +39,6 @@ async function go(sessionId, payload) {
   const formattedData = _submittedSessionData(session, payload)
 
   return {
-    pageTitle: 'When was the return received?',
     activeNavBar: 'search',
     error: validationResult,
     ...formattedData

--- a/app/services/return-versions/setup/abstraction-period.service.js
+++ b/app/services/return-versions/setup/abstraction-period.service.js
@@ -26,7 +26,6 @@ async function go(sessionId, requirementIndex) {
 
   return {
     activeNavBar: 'search',
-    pageTitle: 'Enter the abstraction period for the requirements for returns',
     ...formattedData
   }
 }

--- a/app/services/return-versions/setup/additional-submission-options.service.js
+++ b/app/services/return-versions/setup/additional-submission-options.service.js
@@ -27,7 +27,6 @@ async function go(sessionId) {
 
   return {
     activeNavBar: 'search',
-    pageTitle: 'Select any additional submission options for the return requirements',
     ...formattedData
   }
 }

--- a/app/services/return-versions/setup/agreements-exceptions.service.js
+++ b/app/services/return-versions/setup/agreements-exceptions.service.js
@@ -26,7 +26,6 @@ async function go(sessionId, requirementIndex) {
 
   return {
     activeNavBar: 'search',
-    pageTitle: 'Select agreements and exceptions for the requirements for returns',
     ...formattedData
   }
 }

--- a/app/services/return-versions/setup/cancel.service.js
+++ b/app/services/return-versions/setup/cancel.service.js
@@ -25,7 +25,6 @@ async function go(sessionId) {
 
   return {
     activeNavBar: 'search',
-    pageTitle: 'You are about to cancel these requirements for returns',
     ...formattedData
   }
 }

--- a/app/services/return-versions/setup/existing/existing.service.js
+++ b/app/services/return-versions/setup/existing/existing.service.js
@@ -25,7 +25,6 @@ async function go(sessionId) {
 
   return {
     activeNavBar: 'search',
-    pageTitle: 'Use previous requirements for returns',
     ...formattedData
   }
 }

--- a/app/services/return-versions/setup/existing/submit-existing.service.js
+++ b/app/services/return-versions/setup/existing/submit-existing.service.js
@@ -42,7 +42,6 @@ async function go(sessionId, payload) {
   return {
     activeNavBar: 'search',
     error: validationResult,
-    pageTitle: 'Use previous requirements for returns',
     ...formattedData
   }
 }

--- a/app/services/return-versions/setup/frequency-collected.service.js
+++ b/app/services/return-versions/setup/frequency-collected.service.js
@@ -26,7 +26,6 @@ async function go(sessionId, requirementIndex) {
 
   return {
     activeNavBar: 'search',
-    pageTitle: 'Select how often readings or volumes are collected',
     ...formattedData
   }
 }

--- a/app/services/return-versions/setup/frequency-reported.service.js
+++ b/app/services/return-versions/setup/frequency-reported.service.js
@@ -26,7 +26,6 @@ async function go(sessionId, requirementIndex) {
 
   return {
     activeNavBar: 'search',
-    pageTitle: 'Select how often readings or volumes are reported',
     ...formattedData
   }
 }

--- a/app/services/return-versions/setup/method/method.service.js
+++ b/app/services/return-versions/setup/method/method.service.js
@@ -25,7 +25,6 @@ async function go(sessionId) {
 
   return {
     activeNavBar: 'search',
-    pageTitle: 'How do you want to set up the requirements for returns?',
     ...formattedData
   }
 }

--- a/app/services/return-versions/setup/method/submit-method.service.js
+++ b/app/services/return-versions/setup/method/submit-method.service.js
@@ -43,7 +43,6 @@ async function go(sessionId, payload) {
   return {
     activeNavBar: 'search',
     error: validationResult,
-    pageTitle: 'How do you want to set up the requirements for returns?',
     ...formattedData
   }
 }

--- a/app/services/return-versions/setup/no-returns-required.service.js
+++ b/app/services/return-versions/setup/no-returns-required.service.js
@@ -25,7 +25,6 @@ async function go(sessionId) {
 
   return {
     activeNavBar: 'search',
-    pageTitle: 'Why are no returns required?',
     ...formattedData
   }
 }

--- a/app/services/return-versions/setup/note.service.js
+++ b/app/services/return-versions/setup/note.service.js
@@ -25,7 +25,6 @@ async function go(sessionId) {
 
   return {
     activeNavBar: 'search',
-    pageTitle: 'Add a note',
     ...formattedData
   }
 }

--- a/app/services/return-versions/setup/points.service.js
+++ b/app/services/return-versions/setup/points.service.js
@@ -28,7 +28,6 @@ async function go(sessionId, requirementIndex) {
 
   return {
     activeNavBar: 'search',
-    pageTitle: 'Select the points for the requirements for returns',
     ...formattedData
   }
 }

--- a/app/services/return-versions/setup/purpose.service.js
+++ b/app/services/return-versions/setup/purpose.service.js
@@ -28,7 +28,6 @@ async function go(sessionId, requirementIndex) {
 
   return {
     activeNavBar: 'search',
-    pageTitle: 'Select the purpose for the requirements for returns',
     ...formattedData
   }
 }

--- a/app/services/return-versions/setup/reason.service.js
+++ b/app/services/return-versions/setup/reason.service.js
@@ -25,7 +25,6 @@ async function go(sessionId) {
 
   return {
     activeNavBar: 'search',
-    pageTitle: 'Select the reason for the requirements for returns',
     ...formattedData
   }
 }

--- a/app/services/return-versions/setup/remove.service.js
+++ b/app/services/return-versions/setup/remove.service.js
@@ -27,7 +27,6 @@ async function go(sessionId, requirementIndex) {
 
   return {
     activeNavBar: 'search',
-    pageTitle: 'You are about to remove these requirements for returns',
     ...formattedData
   }
 }

--- a/app/services/return-versions/setup/returns-cycle.service.js
+++ b/app/services/return-versions/setup/returns-cycle.service.js
@@ -26,7 +26,6 @@ async function go(sessionId, requirementIndex) {
 
   return {
     activeNavBar: 'search',
-    pageTitle: 'Select the returns cycle for the requirements for returns',
     ...formattedData
   }
 }

--- a/app/services/return-versions/setup/site-description.service.js
+++ b/app/services/return-versions/setup/site-description.service.js
@@ -26,7 +26,6 @@ async function go(sessionId, requirementIndex) {
 
   return {
     activeNavBar: 'search',
-    pageTitle: 'Enter a site description for the requirements for returns',
     ...formattedData
   }
 }

--- a/app/services/return-versions/setup/start-date.service.js
+++ b/app/services/return-versions/setup/start-date.service.js
@@ -25,7 +25,6 @@ async function go(sessionId) {
 
   return {
     activeNavBar: 'search',
-    pageTitle: 'Select the start date for the requirements for returns',
     ...formattedData
   }
 }

--- a/app/services/return-versions/setup/submit-abstraction-period.service.js
+++ b/app/services/return-versions/setup/submit-abstraction-period.service.js
@@ -49,7 +49,6 @@ async function go(sessionId, requirementIndex, payload, yar) {
   return {
     activeNavBar: 'search',
     error: validationResult,
-    pageTitle: 'Enter the abstraction period for the requirements for returns',
     ...submittedSessionData
   }
 }

--- a/app/services/return-versions/setup/submit-additional-submission-options.service.js
+++ b/app/services/return-versions/setup/submit-additional-submission-options.service.js
@@ -49,7 +49,6 @@ async function go(sessionId, payload, yar) {
   return {
     activeNavBar: 'search',
     error: validationResult,
-    pageTitle: 'Select any additional submission options for the return requirements',
     ...submittedSessionData
   }
 }

--- a/app/services/return-versions/setup/submit-agreements-exceptions.service.js
+++ b/app/services/return-versions/setup/submit-agreements-exceptions.service.js
@@ -53,7 +53,6 @@ async function go(sessionId, requirementIndex, payload, yar) {
   return {
     activeNavBar: 'search',
     error: validationResult,
-    pageTitle: 'Select agreements and exceptions for the requirements for returns',
     ...formattedData
   }
 }

--- a/app/services/return-versions/setup/submit-frequency-collected.service.js
+++ b/app/services/return-versions/setup/submit-frequency-collected.service.js
@@ -49,7 +49,6 @@ async function go(sessionId, requirementIndex, payload, yar) {
   return {
     activeNavBar: 'search',
     error: validationResult,
-    pageTitle: 'Select how often readings or volumes are collected',
     ...formattedData
   }
 }

--- a/app/services/return-versions/setup/submit-frequency-reported.service.js
+++ b/app/services/return-versions/setup/submit-frequency-reported.service.js
@@ -49,7 +49,6 @@ async function go(sessionId, requirementIndex, payload, yar) {
   return {
     activeNavBar: 'search',
     error: validationResult,
-    pageTitle: 'Select how often readings or volumes are reported',
     ...formattedData
   }
 }

--- a/app/services/return-versions/setup/submit-no-returns-required.service.js
+++ b/app/services/return-versions/setup/submit-no-returns-required.service.js
@@ -47,7 +47,6 @@ async function go(sessionId, payload, yar) {
   return {
     activeNavBar: 'search',
     error: validationResult,
-    pageTitle: 'Why are no returns required?',
     ...formattedData
   }
 }

--- a/app/services/return-versions/setup/submit-note.service.js
+++ b/app/services/return-versions/setup/submit-note.service.js
@@ -47,7 +47,6 @@ async function go(sessionId, payload, user, yar) {
   return {
     activeNavBar: 'search',
     error: validationResult,
-    pageTitle: 'Add a note',
     ...submittedSessionData
   }
 }

--- a/app/services/return-versions/setup/submit-points.service.js
+++ b/app/services/return-versions/setup/submit-points.service.js
@@ -53,7 +53,6 @@ async function go(sessionId, requirementIndex, payload, yar) {
   return {
     activeNavBar: 'search',
     error: validationResult,
-    pageTitle: 'Select the points for the requirements for returns',
     ...formattedData
   }
 }

--- a/app/services/return-versions/setup/submit-purpose.service.js
+++ b/app/services/return-versions/setup/submit-purpose.service.js
@@ -55,7 +55,6 @@ async function go(sessionId, requirementIndex, payload, yar) {
   return {
     activeNavBar: 'search',
     error: validationResult,
-    pageTitle: 'Select the purpose for the requirements for returns',
     ...submittedSessionData
   }
 }

--- a/app/services/return-versions/setup/submit-reason.service.js
+++ b/app/services/return-versions/setup/submit-reason.service.js
@@ -48,7 +48,6 @@ async function go(sessionId, payload, yar) {
   return {
     activeNavBar: 'search',
     error: validationResult,
-    pageTitle: 'Select the reason for the requirements for returns',
     ...formattedData
   }
 }

--- a/app/services/return-versions/setup/submit-returns-cycle.service.js
+++ b/app/services/return-versions/setup/submit-returns-cycle.service.js
@@ -49,7 +49,6 @@ async function go(sessionId, requirementIndex, payload, yar) {
   return {
     activeNavBar: 'search',
     error: validationResult,
-    pageTitle: 'Select the returns cycle for the requirements for returns',
     ...formattedData
   }
 }

--- a/app/services/return-versions/setup/submit-site-description.service.js
+++ b/app/services/return-versions/setup/submit-site-description.service.js
@@ -49,7 +49,6 @@ async function go(sessionId, requirementIndex, payload, yar) {
   return {
     activeNavBar: 'search',
     error: validationResult,
-    pageTitle: 'Enter a site description for the requirements for returns',
     ...submittedSessionData
   }
 }

--- a/app/services/return-versions/setup/submit-start-date.service.js
+++ b/app/services/return-versions/setup/submit-start-date.service.js
@@ -52,7 +52,6 @@ async function go(sessionId, payload, yar) {
   return {
     activeNavBar: 'search',
     error: validationResult,
-    pageTitle: 'Select the start date for the requirements for returns',
     ...submittedSessionData
   }
 }

--- a/app/services/return-versions/view.service.js
+++ b/app/services/return-versions/view.service.js
@@ -18,11 +18,11 @@ const ViewPresenter = require('../../presenters/return-versions/view.presenter.j
 async function go(returnVersionId) {
   const requirementsForReturns = await FetchReturnVersionService.go(returnVersionId)
 
-  const data = ViewPresenter.go(requirementsForReturns)
+  const formattedData = ViewPresenter.go(requirementsForReturns)
 
   return {
     activeNavBar: 'search',
-    ...data
+    ...formattedData
   }
 }
 

--- a/test/controllers/notifications-ad-hoc-returns.controller.test.js
+++ b/test/controllers/notifications-ad-hoc-returns.controller.test.js
@@ -77,7 +77,8 @@ describe('Notifications Ad Hoc Returns controller', () => {
         options = _getOptions('licence')
 
         Sinon.stub(LicenceService, 'go').resolves({
-          sessionId: 'e0c77b74-7326-493d-be5e-0d1ad41594b5'
+          sessionId: 'e0c77b74-7326-493d-be5e-0d1ad41594b5',
+          pageTitle: 'Enter a licence number'
         })
       })
 
@@ -85,14 +86,8 @@ describe('Notifications Ad Hoc Returns controller', () => {
         it('returns the page successfully', async () => {
           const response = await server.inject(options)
 
-          const pageData = {
-            pageTitle: 'Enter a licence number',
-            activeNavBar: 'manage'
-          }
-
           expect(response.statusCode).to.equal(200)
-          expect(response.payload).to.contain(pageData.activeNavBar)
-          expect(response.payload).to.contain(pageData.pageTitle)
+          expect(response.payload).to.contain('Enter a licence number')
         })
       })
     })

--- a/test/presenters/notifications/ad-hoc-returns/licence.presenter.test.js
+++ b/test/presenters/notifications/ad-hoc-returns/licence.presenter.test.js
@@ -27,7 +27,8 @@ describe('Ad-hoc Returns Licence presenter', () => {
 
         expect(result).to.equal({
           sessionId: '86d7555c-0518-4f9c-9148-38f71fd4f6e7',
-          licenceRef: null
+          licenceRef: null,
+          pageTitle: 'Enter a licence number'
         })
       })
     })
@@ -42,7 +43,8 @@ describe('Ad-hoc Returns Licence presenter', () => {
 
         expect(result).to.equal({
           sessionId: '86d7555c-0518-4f9c-9148-38f71fd4f6e7',
-          licenceRef: '01/111'
+          licenceRef: '01/111',
+          pageTitle: 'Enter a licence number'
         })
       })
     })

--- a/test/presenters/return-logs/setup/received.presenter.test.js
+++ b/test/presenters/return-logs/setup/received.presenter.test.js
@@ -25,6 +25,7 @@ describe('Return Logs Setup - Received presenter', () => {
       const result = ReceivedPresenter.go(session)
 
       expect(result).to.equal({
+        pageTitle: 'When was the return received?',
         sessionId: '61e07498-f309-4829-96a9-72084a54996d',
         returnReference: '012345',
         receivedDateOption: null,

--- a/test/presenters/return-versions/setup/abstraction-period.presenter.test.js
+++ b/test/presenters/return-versions/setup/abstraction-period.presenter.test.js
@@ -43,6 +43,7 @@ describe('Return Versions Setup - Abstraction Period presenter', () => {
         backLink: '/system/return-versions/setup/61e07498-f309-4829-96a9-72084a54996d/points/0',
         licenceId: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
         licenceRef: '01/ABC',
+        pageTitle: 'Enter the abstraction period for the requirements for returns',
         sessionId: '61e07498-f309-4829-96a9-72084a54996d'
       })
     })

--- a/test/presenters/return-versions/setup/additional-submission-options.presenter.test.js
+++ b/test/presenters/return-versions/setup/additional-submission-options.presenter.test.js
@@ -45,6 +45,7 @@ describe('Return Versions Setup - Additional Submission Options presenter', () =
         noAdditionalOptions: undefined,
         quarterlyReturnSubmissions: false,
         quarterlyReturns: undefined,
+        pageTitle: 'Select any additional submission options for the return requirements',
         sessionId: session.id
       })
     })

--- a/test/presenters/return-versions/setup/agreements-exceptions.presenter.test.js
+++ b/test/presenters/return-versions/setup/agreements-exceptions.presenter.test.js
@@ -43,6 +43,7 @@ describe('Return Versions Setup - Agreements Exceptions presenter', () => {
         backLink: '/system/return-versions/setup/61e07498-f309-4829-96a9-72084a54996d/frequency-reported/0',
         licenceId: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
         licenceRef: '01/ABC',
+        pageTitle: 'Select agreements and exceptions for the requirements for returns',
         sessionId: '61e07498-f309-4829-96a9-72084a54996d'
       })
     })

--- a/test/presenters/return-versions/setup/cancel.presenter.test.js
+++ b/test/presenters/return-versions/setup/cancel.presenter.test.js
@@ -56,6 +56,7 @@ describe('Return Versions Setup - Cancel presenter', () => {
         backLink: '/system/return-versions/setup/61e07498-f309-4829-96a9-72084a54996d/check',
         licenceId: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
         licenceRef: '01/ABC',
+        pageTitle: 'You are about to cancel these requirements for returns',
         reason: 'Major change',
         returnRequirements: ['Winter and all year monthly requirements for returns, Bore hole in rear field.'],
         sessionId: '61e07498-f309-4829-96a9-72084a54996d',

--- a/test/presenters/return-versions/setup/existing.presenter.test.js
+++ b/test/presenters/return-versions/setup/existing.presenter.test.js
@@ -47,6 +47,7 @@ describe('Return Versions Setup - Existing presenter', () => {
         backLink: '/system/return-versions/setup/61e07498-f309-4829-96a9-72084a54996d/method',
         existingOptions: [{ value: '60b5d10d-1372-4fb2-b222-bfac81da69ab', text: '1 January 2023' }],
         licenceRef: '01/ABC',
+        pageTitle: 'Use previous requirements for returns',
         sessionId: '61e07498-f309-4829-96a9-72084a54996d'
       })
     })

--- a/test/presenters/return-versions/setup/frequency-collected.presenter.test.js
+++ b/test/presenters/return-versions/setup/frequency-collected.presenter.test.js
@@ -43,6 +43,7 @@ describe('Return Versions Setup - Frequency Collected presenter', () => {
         frequencyCollected: null,
         licenceId: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
         licenceRef: '01/ABC',
+        pageTitle: 'Select how often readings or volumes are collected',
         sessionId: '61e07498-f309-4829-96a9-72084a54996d'
       })
     })

--- a/test/presenters/return-versions/setup/frequency-reported.presenter.test.js
+++ b/test/presenters/return-versions/setup/frequency-reported.presenter.test.js
@@ -43,6 +43,7 @@ describe('Return Versions Setup - Frequency Reported presenter', () => {
         frequencyReported: null,
         licenceId: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
         licenceRef: '01/ABC',
+        pageTitle: 'Select how often readings or volumes are reported',
         sessionId: '61e07498-f309-4829-96a9-72084a54996d'
       })
     })

--- a/test/presenters/return-versions/setup/method.presenter.test.js
+++ b/test/presenters/return-versions/setup/method.presenter.test.js
@@ -47,6 +47,7 @@ describe('Return Versions Setup - Method presenter', () => {
         backLink: '/system/return-versions/setup/61e07498-f309-4829-96a9-72084a54996d/reason',
         displayCopyExisting: true,
         licenceRef: '01/ABC',
+        pageTitle: 'How do you want to set up the requirements for returns?',
         sessionId: '61e07498-f309-4829-96a9-72084a54996d',
         method: null
       })

--- a/test/presenters/return-versions/setup/no-returns-required.presenter.test.js
+++ b/test/presenters/return-versions/setup/no-returns-required.presenter.test.js
@@ -38,6 +38,7 @@ describe('Return Versions Setup - No Returns Required presenter', () => {
       expect(result).to.equal({
         backLink: '/system/return-versions/setup/61e07498-f309-4829-96a9-72084a54996d/start-date',
         licenceRef: '01/ABC',
+        pageTitle: 'Why are no returns required?',
         reason: null,
         sessionId: '61e07498-f309-4829-96a9-72084a54996d'
       })

--- a/test/presenters/return-versions/setup/note.presenter.test.js
+++ b/test/presenters/return-versions/setup/note.presenter.test.js
@@ -40,6 +40,7 @@ describe('Return Versions Setup - Note presenter', () => {
         backLink: '/system/return-versions/setup/61e07498-f309-4829-96a9-72084a54996d/check',
         licenceRef: '01/ABC',
         note: null,
+        pageTitle: 'Add a note',
         sessionId: '61e07498-f309-4829-96a9-72084a54996d'
       })
     })

--- a/test/presenters/return-versions/setup/points.presenter.test.js
+++ b/test/presenters/return-versions/setup/points.presenter.test.js
@@ -64,6 +64,7 @@ describe('Return Versions Setup - Points presenter', () => {
           }
         ],
         licenceRef: '01/ABC',
+        pageTitle: 'Select the points for the requirements for returns',
         selectedPointIds: '',
         sessionId: '61e07498-f309-4829-96a9-72084a54996d'
       })

--- a/test/presenters/return-versions/setup/purpose.presenter.test.js
+++ b/test/presenters/return-versions/setup/purpose.presenter.test.js
@@ -50,6 +50,7 @@ describe('Return Versions Setup - Purpose presenter', () => {
         backLink: '/system/return-versions/setup/61e07498-f309-4829-96a9-72084a54996d/method',
         licenceId: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
         licenceRef: '01/ABC',
+        pageTitle: 'Select the purpose for the requirements for returns',
         purposes: [
           { alias: '', checked: false, description: 'Heat Pump', id: '14794d57-1acf-4c91-8b48-4b1ec68bfd6f' },
           {

--- a/test/presenters/return-versions/setup/reason.presenter.test.js
+++ b/test/presenters/return-versions/setup/reason.presenter.test.js
@@ -38,6 +38,7 @@ describe('Return Versions Setup - Reason presenter', () => {
       expect(result).to.equal({
         backLink: '/system/return-versions/setup/61e07498-f309-4829-96a9-72084a54996d/start-date',
         licenceRef: '01/ABC',
+        pageTitle: 'Select the reason for the requirements for returns',
         reason: null,
         sessionId: '61e07498-f309-4829-96a9-72084a54996d'
       })

--- a/test/presenters/return-versions/setup/remove.presenter.test.js
+++ b/test/presenters/return-versions/setup/remove.presenter.test.js
@@ -58,6 +58,7 @@ describe('Return Versions Setup - Remove presenter', () => {
         backLink: '/system/return-versions/setup/61e07498-f309-4829-96a9-72084a54996d/check',
         licenceId: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
         licenceRef: '01/ABC',
+        pageTitle: 'You are about to remove these requirements for returns',
         returnRequirement: 'Winter and all year monthly requirements for returns, Bore hole in rear field.',
         sessionId: '61e07498-f309-4829-96a9-72084a54996d',
         startDate: '1 January 2023'

--- a/test/presenters/return-versions/setup/returns-cycle.presenter.test.js
+++ b/test/presenters/return-versions/setup/returns-cycle.presenter.test.js
@@ -42,6 +42,7 @@ describe('Return Versions Setup - Returns Cycle presenter', () => {
         backLink: '/system/return-versions/setup/61e07498-f309-4829-96a9-72084a54996d/abstraction-period/0',
         licenceId: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
         licenceRef: '01/ABC',
+        pageTitle: 'Select the returns cycle for the requirements for returns',
         returnsCycle: null,
         sessionId: '61e07498-f309-4829-96a9-72084a54996d'
       })

--- a/test/presenters/return-versions/setup/site-description.presenter.test.js
+++ b/test/presenters/return-versions/setup/site-description.presenter.test.js
@@ -42,6 +42,7 @@ describe('Return Versions Setup - Site Description presenter', () => {
         backLink: '/system/return-versions/setup/61e07498-f309-4829-96a9-72084a54996d/returns-cycle/0',
         licenceId: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
         licenceRef: '01/ABC',
+        pageTitle: 'Enter a site description for the requirements for returns',
         sessionId: '61e07498-f309-4829-96a9-72084a54996d',
         siteDescription: null
       })

--- a/test/presenters/return-versions/setup/start-date.presenter.test.js
+++ b/test/presenters/return-versions/setup/start-date.presenter.test.js
@@ -46,6 +46,7 @@ describe('Return Versions Setup - Start Date presenter', () => {
         licenceId: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
         licenceRef: '01/ABC',
         licenceVersionStartDate: '1 January 2023',
+        pageTitle: 'Select the start date for the requirements for returns',
         sessionId: '61e07498-f309-4829-96a9-72084a54996d',
         startDateOption: null
       })

--- a/test/services/notifications/ad-hoc-returns/licence.service.test.js
+++ b/test/services/notifications/ad-hoc-returns/licence.service.test.js
@@ -30,8 +30,10 @@ describe('Notifications Ad-hoc Returns - Licence service', () => {
       const result = await LicenceService.go(session.id)
 
       expect(result).to.equal({
+        activeNavBar: 'manage',
         sessionId: session.id,
-        licenceRef: '01/111'
+        licenceRef: '01/111',
+        pageTitle: 'Enter a licence number'
       })
     })
   })

--- a/test/services/notifications/ad-hoc-returns/submit-licence.service.test.js
+++ b/test/services/notifications/ad-hoc-returns/submit-licence.service.test.js
@@ -59,11 +59,13 @@ describe('Ad-hoc Returns Licence service', () => {
           const result = await SubmitLicenceService.go(session.id, payload)
 
           expect(result).to.equal({
+            activeNavBar: 'manage',
             sessionId: session.id,
             licenceRef: null,
             error: {
               text: 'Enter a licence number'
-            }
+            },
+            pageTitle: 'Enter a licence number'
           })
         })
       })
@@ -79,11 +81,13 @@ describe('Ad-hoc Returns Licence service', () => {
           const result = await SubmitLicenceService.go(session.id, payload)
 
           expect(result).to.equal({
+            activeNavBar: 'manage',
             sessionId: session.id,
             licenceRef: null,
             error: {
               text: 'Enter a licence number'
-            }
+            },
+            pageTitle: 'Enter a licence number'
           })
         })
       })
@@ -101,9 +105,11 @@ describe('Ad-hoc Returns Licence service', () => {
           const result = await SubmitLicenceService.go(session.id, payload)
 
           expect(result).to.equal({
+            activeNavBar: 'manage',
             sessionId: session.id,
             licenceRef: null,
-            notification: 'There are no returns due for licence 01/145'
+            notification: 'There are no returns due for licence 01/145',
+            pageTitle: 'Enter a licence number'
           })
         })
       })


### PR DESCRIPTION
DEFRA/water-abstraction-team#132

During the migration of legacy pages into our new system repository, we identified inconsistencies in how the pageTitle and navBar were being managed. In some cases, they were defined in the controller, in others within the services, and occasionally in the presenter. After reviewing our coding conventions, we have agreed that, moving forward, the pageTitle should be set in the presenter, while the navBar should be managed in the service called from the controller.

This PR aligns the repository with these updated conventions.