### PR TITLE
Rearrange return log setup routes

### DIFF
--- a/app/controllers/return-logs-setup.controller.js
+++ b/app/controllers/return-logs-setup.controller.js
@@ -42,7 +42,7 @@ async function setup(request, h) {
   const { returnLogId } = request.query
   const session = await InitiateSessionService.go(returnLogId)
 
-  return h.redirect(`/system/return-logs/setup/${session.id}/start`)
+  return h.redirect(`/system/return-logs/setup/${session.id}/received`)
 }
 
 async function start(request, h) {
@@ -83,7 +83,7 @@ async function submitReceived(request, h) {
     return h.view('return-logs/setup/received.njk', pageData)
   }
 
-  return h.redirect(`/system/return-logs/setup/${sessionId}/reported`)
+  return h.redirect(`/system/return-logs/setup/${sessionId}/start`)
 }
 
 async function submitReported(request, h) {
@@ -110,7 +110,7 @@ async function submitStart(request, h) {
     return h.view('return-logs/setup/start.njk', pageData)
   }
 
-  return h.redirect(`/system/return-logs/setup/${sessionId}/received`)
+  return h.redirect(`/system/return-logs/setup/${sessionId}/reported`)
 }
 
 async function submitUnits(request, h) {

--- a/app/presenters/return-logs/setup/received.presenter.js
+++ b/app/presenters/return-logs/setup/received.presenter.js
@@ -15,6 +15,7 @@
 function go(session) {
   const {
     id: sessionId,
+    licenceId,
     returnReference,
     receivedDateOptions,
     receivedDateDay,
@@ -23,14 +24,14 @@ function go(session) {
   } = session
 
   return {
+    backLink: `/system/licences/${licenceId}/returns`,
     pageTitle: 'When was the return received?',
-    receivedDateOption: receivedDateOptions ?? null,
     receivedDateDay: receivedDateDay ?? null,
     receivedDateMonth: receivedDateMonth ?? null,
+    receivedDateOption: receivedDateOptions ?? null,
     receivedDateYear: receivedDateYear ?? null,
-    sessionId,
     returnReference,
-    backLink: `/system/return-logs/setup/${sessionId}/start`
+    sessionId
   }
 }
 

--- a/app/presenters/return-logs/setup/reported.presenter.js
+++ b/app/presenters/return-logs/setup/reported.presenter.js
@@ -20,7 +20,7 @@ function go(session) {
     reported: reported ?? null,
     sessionId,
     returnReference,
-    backLink: `/system/return-logs/setup/${sessionId}/received`
+    backLink: `/system/return-logs/setup/${sessionId}/start`
   }
 }
 

--- a/app/presenters/return-logs/setup/start.presenter.js
+++ b/app/presenters/return-logs/setup/start.presenter.js
@@ -16,6 +16,7 @@ const { formatAbstractionPeriod, formatLongDate } = require('../../base.presente
  */
 function go(session) {
   const {
+    id: sessionId,
     beenReceived,
     dueDate,
     endDate,
@@ -41,6 +42,7 @@ function go(session) {
       periodEndDay,
       periodEndMonth
     )}`,
+    backLink: `/system/return-logs/setup/${sessionId}/received`,
     beenReceived,
     journey: journey ?? null,
     licenceId,

--- a/app/views/return-logs/setup/start.njk
+++ b/app/views/return-logs/setup/start.njk
@@ -9,10 +9,12 @@
 
 {% block breadcrumbs %}
   {# Back link #}
-  {{ govukBackLink({
-      text: 'Go back to summary',
-      href: '/system/licences/'+ licenceId +'/returns'
-  }) }}
+  {{
+    govukBackLink({
+      text: 'Back',
+      href: backLink
+    })
+  }}
 {% endblock %}
 
 {% block content %}

--- a/test/controllers/return-logs-setup.controller.test.js
+++ b/test/controllers/return-logs-setup.controller.test.js
@@ -69,11 +69,11 @@ describe('Return Logs Setup controller', () => {
           Sinon.stub(InitiateSessionService, 'go').resolves(session)
         })
 
-        it('returns the page successfully', async () => {
+        it('redirects to the "received" page', async () => {
           const response = await server.inject(options)
 
           expect(response.statusCode).to.equal(302)
-          expect(response.headers.location).to.equal(`/system/return-logs/setup/${session.id}/start`)
+          expect(response.headers.location).to.equal(`/system/return-logs/setup/${session.id}/received`)
         })
       })
     })
@@ -121,12 +121,12 @@ describe('Return Logs Setup controller', () => {
             Sinon.stub(SubmitReceivedService, 'go').resolves({})
           })
 
-          it('redirects to the "reported" page', async () => {
+          it('redirects to the "start" page', async () => {
             const response = await server.inject(options)
 
             expect(response.statusCode).to.equal(302)
             expect(response.headers.location).to.equal(
-              '/system/return-logs/setup/e0c77b74-7326-493d-be5e-0d1ad41594b5/reported'
+              '/system/return-logs/setup/e0c77b74-7326-493d-be5e-0d1ad41594b5/start'
             )
           })
         })
@@ -267,12 +267,12 @@ describe('Return Logs Setup controller', () => {
             Sinon.stub(SubmitStartService, 'go').resolves({})
           })
 
-          it('redirects to the "received" page', async () => {
+          it('redirects to the "reported" page', async () => {
             const response = await server.inject(options)
 
             expect(response.statusCode).to.equal(302)
             expect(response.headers.location).to.equal(
-              '/system/return-logs/setup/e0c77b74-7326-493d-be5e-0d1ad41594b5/received'
+              '/system/return-logs/setup/e0c77b74-7326-493d-be5e-0d1ad41594b5/reported'
             )
           })
         })

--- a/test/presenters/return-logs/setup/received.presenter.test.js
+++ b/test/presenters/return-logs/setup/received.presenter.test.js
@@ -16,7 +16,8 @@ describe('Return Logs Setup - Received presenter', () => {
   beforeEach(() => {
     session = {
       id: '61e07498-f309-4829-96a9-72084a54996d',
-      returnReference: '012345'
+      returnReference: '012345',
+      licenceId: 'a96ce5c6-2c42-4b3f-946d-0428b5f07ce6'
     }
   })
 
@@ -32,7 +33,7 @@ describe('Return Logs Setup - Received presenter', () => {
         receivedDateDay: null,
         receivedDateMonth: null,
         receivedDateYear: null,
-        backLink: '/system/return-logs/setup/61e07498-f309-4829-96a9-72084a54996d/start'
+        backLink: '/system/licences/a96ce5c6-2c42-4b3f-946d-0428b5f07ce6/returns'
       })
     })
   })

--- a/test/presenters/return-logs/setup/reported.presenter.test.js
+++ b/test/presenters/return-logs/setup/reported.presenter.test.js
@@ -29,7 +29,7 @@ describe('Return Logs Setup - Reported presenter', () => {
         sessionId: '61e07498-f309-4829-96a9-72084a54996d',
         returnReference: '012345',
         reported: null,
-        backLink: '/system/return-logs/setup/61e07498-f309-4829-96a9-72084a54996d/received'
+        backLink: '/system/return-logs/setup/61e07498-f309-4829-96a9-72084a54996d/start'
       })
     })
   })

--- a/test/presenters/return-logs/setup/start.presenter.test.js
+++ b/test/presenters/return-logs/setup/start.presenter.test.js
@@ -23,6 +23,7 @@ describe('Return Logs Setup - Start presenter', () => {
 
       expect(result).to.equal({
         abstractionPeriod: 'From 1 January to 31 December',
+        backLink: '/system/return-logs/setup/e840675e-9fb9-4ce1-bf0a-d140f5c57f47/received',
         beenReceived: false,
         journey: null,
         licenceId: 'db3731ae-3dde-4778-a81e-9be549cfc0e1',
@@ -96,6 +97,7 @@ describe('Return Logs Setup - Start presenter', () => {
 
 function _testSession() {
   return {
+    id: 'e840675e-9fb9-4ce1-bf0a-d140f5c57f47',
     beenReceived: false,
     dueDate: '2023-04-28T00:00:00.000Z',
     endDate: '2023-03-31T00:00:00.000Z',

--- a/test/services/return-logs/setup/received.service.test.js
+++ b/test/services/return-logs/setup/received.service.test.js
@@ -41,7 +41,7 @@ describe('Return Logs Setup - Received service', () => {
           activeNavBar: 'search',
           pageTitle: 'When was the return received?',
           returnReference: '012345',
-          backLink: `/system/return-logs/setup/${session.id}/start`,
+          backLink: `/system/licences/736144f1-203d-46bb-9968-5137ae06a7bd/returns`,
           receivedDateOption: null,
           receivedDateDay: null,
           receivedDateMonth: null,

--- a/test/services/return-logs/setup/reported.service.test.js
+++ b/test/services/return-logs/setup/reported.service.test.js
@@ -39,7 +39,7 @@ describe('Return Logs Setup - Reported service', () => {
           pageTitle: 'How was this return reported?',
           activeNavBar: 'search',
           returnReference: '012345',
-          backLink: `/system/return-logs/setup/${session.id}/received`,
+          backLink: `/system/return-logs/setup/${session.id}/start`,
           reported: null
         },
         { skip: ['sessionId'] }

--- a/test/services/return-logs/setup/start.service.test.js
+++ b/test/services/return-logs/setup/start.service.test.js
@@ -28,6 +28,7 @@ describe('Return Logs Setup - Start service', () => {
       expect(result).to.equal({
         abstractionPeriod: 'From 1 January to 31 December',
         activeNavBar: 'search',
+        backLink: `/system/return-logs/setup/${sessionId}/received`,
         beenReceived: false,
         journey: null,
         licenceId: 'db3731ae-3dde-4778-a81e-9be549cfc0e1',

--- a/test/services/return-logs/setup/submit-received.service.test.js
+++ b/test/services/return-logs/setup/submit-received.service.test.js
@@ -23,7 +23,8 @@ describe('Return Logs Setup - Submit Received service', () => {
     sessionData = {
       data: {
         returnReference: '12345',
-        startDate: '2023-04-01T00:00:00.000Z'
+        startDate: '2023-04-01T00:00:00.000Z',
+        licenceId: 'cd190dc7-912a-46a5-9421-2750fb1c7ac8'
       }
     }
 
@@ -115,7 +116,7 @@ describe('Return Logs Setup - Submit Received service', () => {
             receivedDateMonth: null,
             receivedDateYear: null,
             receivedDateOption: null,
-            backLink: `/system/return-logs/setup/${session.id}/start`,
+            backLink: `/system/licences/cd190dc7-912a-46a5-9421-2750fb1c7ac8/returns`,
             returnReference: '12345'
           },
           { skip: ['sessionId', 'error'] }

--- a/test/services/return-logs/setup/submit-reported.service.test.js
+++ b/test/services/return-logs/setup/submit-reported.service.test.js
@@ -56,7 +56,7 @@ describe('Return Logs Setup - Submit Reported service', () => {
             pageTitle: 'How was this return reported?',
             activeNavBar: 'search',
             reported: null,
-            backLink: `/system/return-logs/setup/${session.id}/received`,
+            backLink: `/system/return-logs/setup/${session.id}/start`,
             returnReference: '12345'
           },
           { skip: ['sessionId', 'error'] }

--- a/test/services/return-logs/setup/submit-start.service.test.js
+++ b/test/services/return-logs/setup/submit-start.service.test.js
@@ -53,6 +53,7 @@ describe('Return Logs Setup - Submit Start service', () => {
         expect(result).to.equal({
           abstractionPeriod: 'From 1 January to 31 December',
           activeNavBar: 'search',
+          backLink: `/system/return-logs/setup/${session.id}/received`,
           beenReceived: false,
           error: { text: 'Select what you want to do with this return' },
           journey: null,


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4836
https://eaflood.atlassian.net/browse/WATER-4844

After starting work on the return log setup journey, the pages for "What do you want to do with this return?" and "When was the return received?" were completed. Since then, the business has decided to swap the order of these pages. The journey now begins with entering the return received date, followed by selecting what to do with the return. This change makes sense, as all the options for handling the return previously led to entering a received date. By starting with the received date page, we capture that data upfront before users proceed with their chosen path. This PR implements the change to reorder these pages.