### PR TITLE
Replace `==` in the views with `===`

### DIFF
--- a/app/views/bill-runs/index.njk
+++ b/app/views/bill-runs/index.njk
@@ -10,17 +10,17 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       {# Bill runs busy banner #}
-      {% if busy == 'both' %}
+      {% if busy === 'both' %}
         {{ govukNotificationBanner({
             html: '<p class="govuk-notification-banner__heading">Bill runs are currently busy building and cancelling.</p>
               <p class="govuk-body">Please wait for these bill runs to finish before creating another one.</p>'
         }) }}
-      {% elif busy == 'building' %}
+      {% elif busy === 'building' %}
         {{ govukNotificationBanner({
             html: '<p class="govuk-notification-banner__heading">A bill run is currently building.</p>
               <p class="govuk-body">Please wait for this bill run to finish building before creating another one.</p>'
         }) }}
-      {% elif busy == 'cancelling' %}
+      {% elif busy === 'cancelling' %}
         {{ govukNotificationBanner({
             html: '<p class="govuk-notification-banner__heading">A bill run is currently cancelling.</p>
               <p class="govuk-body">Please wait for this bill run to finish cancelling before creating another one.</p>'
@@ -44,7 +44,7 @@
   <div class="govuk-grid-row govuk-!-margin-bottom-9">
     <div class="govuk-grid-column-full">
       {# Results #}
-      {% if billRuns|length == 0 %}
+      {% if billRuns|length === 0 %}
         <p>No bill runs found.</p>
       {% else %}
         <h2 class="govuk-heading-l govuk-!-margin-top-6">View a bill run</h2>
@@ -66,7 +66,7 @@
               {{ billRun.createdAt }}
             {% endif %}
 
-            {% if billRun.scheme == 'alcs' %}
+            {% if billRun.scheme === 'alcs' %}
               <div class="govuk-body-s govuk-!-margin-0">Old charge scheme</div>
             {% endif %}
           {% endset %}

--- a/app/views/bill-runs/review/review-licence.njk
+++ b/app/views/bill-runs/review/review-licence.njk
@@ -234,7 +234,7 @@
     </div>
   </div>
 
-  {% if matchedReturns === 0 and unmatchedReturns === 0 %}
+  {% if matchedReturns.length === 0 and unmatchedReturns.length === 0 %}
     {# No Returns #}
     <h2 class="govuk-heading-m">No two-part tariff returns</h2>
   {% else %}

--- a/app/views/bill-runs/review/review-licence.njk
+++ b/app/views/bill-runs/review/review-licence.njk
@@ -12,7 +12,7 @@
 {# Helper for generating both the matched and unmatched returns tables #}
 {% macro returnsTable(matchType, returns) %}
   {% set caption %}
-    {% if matchType == 'matched' %}
+    {% if matchType === 'matched' %}
       Matched returns
     {% else %}
       Unmatched returns
@@ -234,7 +234,7 @@
     </div>
   </div>
 
-  {% if matchedReturns == 0 and unmatchedReturns == 0 %}
+  {% if matchedReturns === 0 and unmatchedReturns === 0 %}
     {# No Returns #}
     <h2 class="govuk-heading-m">No two-part tariff returns</h2>
   {% else %}

--- a/app/views/bill-runs/setup/region.njk
+++ b/app/views/bill-runs/setup/region.njk
@@ -33,7 +33,7 @@
 
       {% set regionItems = [] %}
       {% for region in regions %}
-        {% set regionItem = { text: region.displayName, value: region.id, checked: region.id == selectedRegion } %}
+        {% set regionItem = { text: region.displayName, value: region.id, checked: region.id === selectedRegion } %}
 
         {# Push our item into the region items array #}
         {% set regionItems = (regionItems.push(regionItem), regionItems) %}

--- a/app/views/bill-runs/setup/season.njk
+++ b/app/views/bill-runs/setup/season.njk
@@ -48,12 +48,12 @@
           {
             text: 'Summer',
             value: 'summer',
-            checked: 'summer' == selectedSeason
+            checked: 'summer' === selectedSeason
           },
           {
             text: 'Winter and All year',
             value: 'winter_all_year',
-            checked: 'winter_all_year' == selectedSeason
+            checked: 'winter_all_year' === selectedSeason
           }
         ]
       }) }}

--- a/app/views/bill-runs/setup/type.njk
+++ b/app/views/bill-runs/setup/type.njk
@@ -36,17 +36,17 @@
           {
             text: 'Annual',
             value: 'annual',
-            checked: 'annual' == selectedType
+            checked: 'annual' === selectedType
           },
           {
             text: 'Supplementary',
             value: 'supplementary',
-            checked: 'supplementary' == selectedType
+            checked: 'supplementary' === selectedType
           },
           {
             text: 'Two-part tariff',
             value: 'two_part_tariff',
-            checked: 'two_part_tariff' == selectedType,
+            checked: 'two_part_tariff' === selectedType,
             hint: {
               text: 'Second part charges only'
             }
@@ -54,7 +54,7 @@
           {
             text: 'Two-part tariff supplementary',
             value: 'two_part_supplementary',
-            checked: 'two_part_supplementary' == selectedType,
+            checked: 'two_part_supplementary' === selectedType,
             hint: {
               text: 'Second part charges for the current charge scheme only'
             }
@@ -65,17 +65,17 @@
           {
             text: 'Annual',
             value: 'annual',
-            checked: 'annual' == selectedType
+            checked: 'annual' === selectedType
           },
           {
             text: 'Supplementary',
             value: 'supplementary',
-            checked: 'supplementary' == selectedType
+            checked: 'supplementary' === selectedType
           },
           {
             text: 'Two-part tariff',
             value: 'two_part_tariff',
-            checked: 'two_part_tariff' == selectedType
+            checked: 'two_part_tariff' === selectedType
           }
         ] %}
       {% endif %}

--- a/app/views/bill-runs/view.njk
+++ b/app/views/bill-runs/view.njk
@@ -203,7 +203,7 @@
       {% set licenceCell %}
         {% set licencesList %}
           {% for licence in bill.licences %}
-            {% if (loop.index0 + 1) == bill.licencesCount %}
+            {% if (loop.index0 + 1) === bill.licencesCount %}
               {{licence}}
             {% else %}
               {{licence}}<br>

--- a/app/views/licences/history.njk
+++ b/app/views/licences/history.njk
@@ -32,7 +32,7 @@
     <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">History</h1>
   </div>
 
-  {% if entries.length == 0 %}
+  {% if entries.length === 0 %}
     <p>No history for this licence.</p>
   {% else %}
     {% set tableRows = [] %}

--- a/app/views/licences/tabs/bills.njk
+++ b/app/views/licences/tabs/bills.njk
@@ -3,7 +3,7 @@
 
 <h2 class="govuk-heading-l">Bills</h2>
 
-{% if bills.length == 0 %}
+{% if bills.length === 0 %}
   <p>No bills sent for this licence.</p>
 {% else %}
   {% set tableRows = [] %}

--- a/app/views/licences/tabs/communications.njk
+++ b/app/views/licences/tabs/communications.njk
@@ -13,7 +13,7 @@
 
 <h2 class="govuk-heading-l">Communications</h2>
 
-{% if communications.length == 0 %}
+{% if communications.length === 0 %}
   <p data-test='no-communications-msg'>No communications for this licence.</p>
 {% else %}
   {% set tableRows = [] %}

--- a/app/views/licences/tabs/set-up.njk
+++ b/app/views/licences/tabs/set-up.njk
@@ -15,7 +15,7 @@
 <h2 class="govuk-heading-l">Licence set up</h2>
   <h3 class="govuk-heading-m"> Requirements for returns </h3>
 
-  {% if returnVersions.length == 0 %}
+  {% if returnVersions.length === 0 %}
     <p class="govuk-body"> No requirements for returns have been set up for this licence.</p>
   {% else %}
     {% set returnVersionsTableRows = [] %}
@@ -84,7 +84,7 @@
 
 <h3 class="govuk-heading-m"> Charge information </h3>
 
-{% if chargeInformation.length == 0 %}
+{% if chargeInformation.length === 0 %}
   <p class="govuk-body"> No charge information for this licence.</p>
 {% else %}
   {% set chargeVersionRows = [] %}
@@ -156,7 +156,7 @@
 
 <h3 class="govuk-heading-m"> Charging agreements </h3>
 
-{% if agreements.length == 0 %}
+{% if agreements.length === 0 %}
   <p class="govuk-body"> No agreements for this licence.</p>
 {% else %}
   {% set agreementRows = [] %}

--- a/app/views/return-logs/setup/meter-provided.njk
+++ b/app/views/return-logs/setup/meter-provided.njk
@@ -50,12 +50,12 @@
           {
             value: "yes",
             text: "Yes",
-            checked: "yes" == meterProvided
+            checked: "yes" === meterProvided
           },
           {
             value: "no",
             text: "No",
-            checked: "no" == meterProvided
+            checked: "no" === meterProvided
           }
         ]
       }) }}

--- a/app/views/return-logs/setup/received.njk
+++ b/app/views/return-logs/setup/received.njk
@@ -87,17 +87,17 @@
           {
             value: "today",
             text: "Today",
-            checked: receivedDateOption == 'today'
+            checked: receivedDateOption === 'today'
           },
           {
             value: "yesterday",
             text: "Yesterday",
-            checked: receivedDateOption == 'yesterday'
+            checked: receivedDateOption === 'yesterday'
           },
           {
             value: "custom-date",
             text: "Custom date",
-            checked: receivedDateOption == 'custom-date',
+            checked: receivedDateOption === 'custom-date',
             conditional: {
               html: dateInputHTML
             }

--- a/app/views/return-logs/setup/reported.njk
+++ b/app/views/return-logs/setup/reported.njk
@@ -50,12 +50,12 @@
           {
             value: "meter-readings",
             text: "Meter Readings",
-            checked: "meter-readings" == reported
+            checked: "meter-readings" === reported
           },
           {
             value: "abstraction-volumes",
             text: "Abstraction Volumes",
-            checked: "abstraction-volumes" == reported
+            checked: "abstraction-volumes" === reported
           }
         ]
       }) }}

--- a/app/views/return-logs/setup/units.njk
+++ b/app/views/return-logs/setup/units.njk
@@ -50,22 +50,22 @@
           {
             value: "cubic-meters",
             text: "Cubic Meters",
-            checked: "cubic-meters" == units
+            checked: "cubic-meters" === units
           },
           {
             value: "litres",
             text: "Litres",
-            checked: "litres" == units
+            checked: "litres" === units
           },
           {
             value: "mega-litres",
             text: "Mega litres",
-            checked: "mega-litres" == units
+            checked: "mega-litres" === units
           },
           {
             value: "gallons",
             text: "Gallons",
-            checked: "gallons" == units
+            checked: "gallons" === units
           }
         ]
       }) }}

--- a/app/views/return-versions/setup/no-returns-required.njk
+++ b/app/views/return-versions/setup/no-returns-required.njk
@@ -45,22 +45,22 @@
           {
             text: 'Abstraction amount below 100 cubic metres per day',
             value:  'abstraction-below-100-cubic-metres-per-day',
-            checked: reason == 'abstraction-below-100-cubic-metres-per-day'
+            checked: reason === 'abstraction-below-100-cubic-metres-per-day'
           },
           {
             text: 'Licence conditions do not require returns',
             value: 'licence-conditions-do-not-require-returns',
-            checked: reason == 'licence-conditions-do-not-require-returns'
+            checked: reason === 'licence-conditions-do-not-require-returns'
           },
           {
             text: 'Returns exception',
             value: 'returns-exception',
-            checked: reason == 'returns-exception'
+            checked: reason === 'returns-exception'
           },
           {
             text: 'Temporary trade',
             value: 'temporary-trade',
-            checked: reason == 'temporary-trade'
+            checked: reason === 'temporary-trade'
           }
         ]
       }) }}

--- a/app/views/return-versions/setup/start-date.njk
+++ b/app/views/return-versions/setup/start-date.njk
@@ -87,7 +87,7 @@
             hint: {
               text:  licenceVersionStartDate
             },
-            checked: startDateOption == 'licenceStartDate'
+            checked: startDateOption === 'licenceStartDate'
           },
           {
             id: 'another-start-date',
@@ -96,7 +96,7 @@
             hint: {
               text: 'For example, 27 3 2007'
             },
-            checked: startDateOption == 'anotherStartDate',
+            checked: startDateOption === 'anotherStartDate',
             conditional: {
               html: dateInputHTML
             }

--- a/app/views/return-versions/view.njk
+++ b/app/views/return-versions/view.njk
@@ -89,7 +89,7 @@
             {% for requirement in requirements %}
               {% set requirementIndex = loop.index0 %}
               {% set bookmarkTitle %}
-                {% if requirement.siteDescription == '' %}
+                {% if requirement.siteDescription === '' %}
                   Return reference {{ requirement.returnReference }}
                 {% else %}
                   Return reference {{ requirement.returnReference }} - {{ requirement.siteDescription | safe }}


### PR DESCRIPTION
It has been spotted in a few views that we have been using `==` rather than `===`.

Generally, we use the strict comparison `===` to compare content & type unless it is necessary to perform a loose equality comparison.

It looks like it is not necessary to use `==` in the views. So where applicable they will be updated to `===`.