### PR TITLE
Fix megalitres content error return logs setup

### DIFF
--- a/app/validators/return-logs/setup/units.validator.js
+++ b/app/validators/return-logs/setup/units.validator.js
@@ -7,7 +7,7 @@
 
 const Joi = require('joi')
 
-const VALID_VALUES = ['cubic-meters', 'litres', 'mega-litres', 'gallons']
+const VALID_VALUES = ['cubic-meters', 'litres', 'megalitres', 'gallons']
 
 /**
  * Validates data submitted for the `/return-logs/setup/{sessionId}/units` page

--- a/app/views/return-logs/setup/units.njk
+++ b/app/views/return-logs/setup/units.njk
@@ -58,9 +58,9 @@
             checked: "litres" === units
           },
           {
-            value: "mega-litres",
-            text: "Mega litres",
-            checked: "mega-litres" === units
+            value: "megalitres",
+            text: "Megalitres",
+            checked: "megalitres" === units
           },
           {
             value: "gallons",

--- a/test/presenters/return-logs/setup/units.presenter.test.js
+++ b/test/presenters/return-logs/setup/units.presenter.test.js
@@ -59,7 +59,7 @@ describe('Return Logs Setup - Units presenter', () => {
       })
     })
 
-    describe('when the user has previously selected "Mega litres" as the reported type', () => {
+    describe('when the user has previously selected "Megalitres" as the reported type', () => {
       beforeEach(() => {
         session.units = 'megalitres'
       })

--- a/test/presenters/return-logs/setup/units.presenter.test.js
+++ b/test/presenters/return-logs/setup/units.presenter.test.js
@@ -61,13 +61,13 @@ describe('Return Logs Setup - Units presenter', () => {
 
     describe('when the user has previously selected "Mega litres" as the reported type', () => {
       beforeEach(() => {
-        session.units = 'mega-litres'
+        session.units = 'megalitres'
       })
 
       it('returns the "units" property populated to re-select the option', () => {
         const result = UnitsPresenter.go(session)
 
-        expect(result.units).to.equal('mega-litres')
+        expect(result.units).to.equal('megalitres')
       })
     })
 

--- a/test/validators/return-logs/setup/units.validator.test.js
+++ b/test/validators/return-logs/setup/units.validator.test.js
@@ -38,9 +38,9 @@ describe('Return Logs Setup - Units validator', () => {
       })
     })
 
-    describe('because the user selected the "mega-litres" option', () => {
+    describe('because the user selected the "megalitres" option', () => {
       beforeEach(() => {
-        payload = { units: 'mega-litres' }
+        payload = { units: 'megalitres' }
       })
 
       it('confirms the payload is valid', () => {


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-system/pull/1612

The units page has a content error displaying 'megalitres'. The page displays it as two words 'mega litres' when it should be one. This PR fixes this.