### PR TITLE
Fix how no abs period data in view rtn vers shown

### DIFF
--- a/app/presenters/base.presenter.js
+++ b/app/presenters/base.presenter.js
@@ -59,16 +59,23 @@ function formatAbstractionDate(abstractionDay, abstractionMonth) {
 /**
  * Formats an abstraction period into its string variant, for example, '1 April to 31 October'
  *
+ * If the provided abstraction data is null or undefined, it returns 'Not given'.
+ *
  * @param {number} startDay
  * @param {number} startMonth
  * @param {number} endDay
  * @param {number} endMonth
  *
- * @returns {string} The abstraction period formatted as a 'DD MMMM to DD MMMM' string
+ * @returns {string} The abstraction period formatted as a 'DD MMMM to DD MMMM' string, unless the abstraction period
+ * cannot be determined, in which case it returns 'Not given'
  */
 function formatAbstractionPeriod(startDay, startMonth, endDay, endMonth) {
   const startDate = formatAbstractionDate(startDay, startMonth)
   const endDate = formatAbstractionDate(endDay, endMonth)
+
+  if (!startDate || !endDate) {
+    return 'Not given'
+  }
 
   return `${startDate} to ${endDate}`
 }

--- a/app/presenters/base.presenter.js
+++ b/app/presenters/base.presenter.js
@@ -59,7 +59,7 @@ function formatAbstractionDate(abstractionDay, abstractionMonth) {
 /**
  * Formats an abstraction period into its string variant, for example, '1 April to 31 October'
  *
- * If the provided abstraction data is null or undefined, it returns 'Not given'.
+ * If the provided abstraction data is null or undefined, it returns null.
  *
  * @param {number} startDay
  * @param {number} startMonth
@@ -67,14 +67,14 @@ function formatAbstractionDate(abstractionDay, abstractionMonth) {
  * @param {number} endMonth
  *
  * @returns {string} The abstraction period formatted as a 'DD MMMM to DD MMMM' string, unless the abstraction period
- * cannot be determined, in which case it returns 'Not given'
+ * cannot be determined, in which case it returns null
  */
 function formatAbstractionPeriod(startDay, startMonth, endDay, endMonth) {
   const startDate = formatAbstractionDate(startDay, startMonth)
   const endDate = formatAbstractionDate(endDay, endMonth)
 
   if (!startDate || !endDate) {
-    return 'Not given'
+    return null
   }
 
   return `${startDate} to ${endDate}`

--- a/app/presenters/base.presenter.js
+++ b/app/presenters/base.presenter.js
@@ -37,12 +37,18 @@ function generateBillRunTitle(regionName, batchType, scheme, summer) {
 /**
  * Formats an abstraction day and month into its string variant, for example, 1 and 4 becomes '1 April'
  *
+ * If either value is null or undefined, it returns null.
+ *
  * @param {number} abstractionDay
  * @param {number} abstractionMonth - Note: the index starts at 1, for example, 4 would be April
  *
- * @returns {string} The abstraction date formatted as a 'DD MMMM' string
+ * @returns {string|null} The abstraction date formatted as a 'DD MMMM' string or null if either value is not set
  */
 function formatAbstractionDate(abstractionDay, abstractionMonth) {
+  if (!abstractionDay || !abstractionMonth) {
+    return null
+  }
+
   // NOTE: Because of the unique qualities of Javascript, Year and Day are literal values, month is an index! So,
   // January is actually 0, February is 1 etc. This is why we are always deducting 1 from the months.
   const abstractionDate = new Date(1970, abstractionMonth - 1, abstractionDay)

--- a/app/presenters/return-versions/view.presenter.js
+++ b/app/presenters/return-versions/view.presenter.js
@@ -5,7 +5,7 @@
  * @module ViewPresenter
  */
 
-const { formatAbstractionDate } = require('../base.presenter.js')
+const { formatAbstractionPeriod } = require('../base.presenter.js')
 const { formatLongDate } = require('../base.presenter.js')
 const { isQuarterlyReturnSubmissions } = require('../../lib/dates.lib.js')
 const { returnRequirementReasons, returnRequirementFrequencies } = require('../../lib/static-lookups.lib.js')
@@ -39,13 +39,14 @@ function go(returnVersion) {
 }
 
 function _abstractionPeriod(requirement) {
-  const { abstractionPeriodStartDay, abstractionPeriodStartMonth, abstractionPeriodEndDay, abstractionPeriodEndMonth } =
-    requirement
+  const abstractionPeriod = formatAbstractionPeriod(
+    requirement.abstractionPeriodStartDay,
+    requirement.abstractionPeriodStartMonth,
+    requirement.abstractionPeriodEndDay,
+    requirement.abstractionPeriodEndMonth
+  )
 
-  const startDate = formatAbstractionDate(abstractionPeriodStartDay, abstractionPeriodStartMonth)
-  const endDate = formatAbstractionDate(abstractionPeriodEndDay, abstractionPeriodEndMonth)
-
-  return `From ${startDate} to ${endDate}`
+  return abstractionPeriod ?? ''
 }
 
 function _agreementsExceptions(returnRequirement) {

--- a/test/presenters/base.presenter.test.js
+++ b/test/presenters/base.presenter.test.js
@@ -85,10 +85,10 @@ describe('Base presenter', () => {
     let endMonth
 
     describe('when the abstraction period is not set', () => {
-      it('returns the "Not given" message', async () => {
+      it('returns null', async () => {
         const result = BasePresenter.formatAbstractionPeriod(startDay, startMonth, endDay, endMonth)
 
-        expect(result).to.equal('Not given')
+        expect(result).to.be.null()
       })
     })
 

--- a/test/presenters/base.presenter.test.js
+++ b/test/presenters/base.presenter.test.js
@@ -79,15 +79,32 @@ describe('Base presenter', () => {
   })
 
   describe('#formatAbstractionPeriod()', () => {
-    const startDay = 1
-    const startMonth = 4
-    const endDay = 12
-    const endMonth = 9
+    let startDay
+    let startMonth
+    let endDay
+    let endMonth
 
-    it('correctly formats the given period, for example, 1 April to 12 September', async () => {
-      const result = BasePresenter.formatAbstractionPeriod(startDay, startMonth, endDay, endMonth)
+    describe('when the abstraction period is not set', () => {
+      it('returns the "Not given" message', async () => {
+        const result = BasePresenter.formatAbstractionPeriod(startDay, startMonth, endDay, endMonth)
 
-      expect(result).to.equal('1 April to 12 September')
+        expect(result).to.equal('Not given')
+      })
+    })
+
+    describe('when the abstraction period is set', () => {
+      beforeEach(() => {
+        startDay = 1
+        startMonth = 4
+        endDay = 12
+        endMonth = 9
+      })
+
+      it('correctly formats the given period, for example, 1 April to 12 September', async () => {
+        const result = BasePresenter.formatAbstractionPeriod(startDay, startMonth, endDay, endMonth)
+
+        expect(result).to.equal('1 April to 12 September')
+      })
     })
   })
 

--- a/test/presenters/base.presenter.test.js
+++ b/test/presenters/base.presenter.test.js
@@ -53,13 +53,28 @@ describe('Base presenter', () => {
   })
 
   describe('#formatAbstractionDate()', () => {
-    const day = 12
-    const month = 9
+    let day
+    let month
 
-    it('correctly formats the given date, for example, 12 September', async () => {
-      const result = BasePresenter.formatAbstractionDate(day, month)
+    describe('when the abstraction day and month are not set', () => {
+      it('returns null', async () => {
+        const result = BasePresenter.formatAbstractionDate(day, month)
 
-      expect(result).to.equal('12 September')
+        expect(result).to.be.null()
+      })
+    })
+
+    describe('when the abstraction day and month are set', () => {
+      beforeEach(() => {
+        day = 12
+        month = 9
+      })
+
+      it('correctly formats the given date, for example, 12 September', async () => {
+        const result = BasePresenter.formatAbstractionDate(day, month)
+
+        expect(result).to.equal('12 September')
+      })
     })
   })
 

--- a/test/presenters/return-versions/view.presenter.test.js
+++ b/test/presenters/return-versions/view.presenter.test.js
@@ -16,7 +16,7 @@ const ReturnVersionModel = require('../../../app/models/return-version.model.js'
 // Thing under test
 const ViewPresenter = require('../../../app/presenters/return-versions/view.presenter.js')
 
-describe('Return Versions - View presenter', () => {
+describe.only('Return Versions - View presenter', () => {
   let returnVersion
 
   beforeEach(() => {
@@ -39,7 +39,7 @@ describe('Return Versions - View presenter', () => {
       reason: 'New licence',
       requirements: [
         {
-          abstractionPeriod: 'From 1 April to 31 October',
+          abstractionPeriod: '1 April to 31 October',
           agreementsExceptions: 'None',
           frequencyCollected: 'monthly',
           frequencyReported: 'monthly',
@@ -205,12 +205,29 @@ describe('Return Versions - View presenter', () => {
 
   describe('the "requirements" property', () => {
     describe('the requirements "abstractionPeriod" property', () => {
-      it('formats the abstraction period for display', () => {
-        const result = ViewPresenter.go(returnVersion)
+      describe('when the abstraction period has been set', () => {
+        it('formats the abstraction period for display', () => {
+          const result = ViewPresenter.go(returnVersion)
 
-        const { abstractionPeriod } = result.requirements[0]
+          const { abstractionPeriod } = result.requirements[0]
 
-        expect(abstractionPeriod).to.equal('From 1 April to 31 October')
+          expect(abstractionPeriod).to.equal('1 April to 31 October')
+        })
+      })
+
+      describe('when the abstraction period has not been set', () => {
+        beforeEach(() => {
+          returnVersion.returnRequirements[0].abstractionPeriodEndDay = null
+          returnVersion.returnRequirements[0].abstractionPeriodEndMonth = null
+          returnVersion.returnRequirements[0].abstractionPeriodStartDay = null
+          returnVersion.returnRequirements[0].abstractionPeriodStartMonth = null
+        })
+
+        it('returns an empty string', () => {
+          const result = ViewPresenter.go(returnVersion)
+
+          expect(result.requirements[0].abstractionPeriod).to.equal('')
+        })
       })
     })
 

--- a/test/presenters/return-versions/view.presenter.test.js
+++ b/test/presenters/return-versions/view.presenter.test.js
@@ -16,7 +16,7 @@ const ReturnVersionModel = require('../../../app/models/return-version.model.js'
 // Thing under test
 const ViewPresenter = require('../../../app/presenters/return-versions/view.presenter.js')
 
-describe.only('Return Versions - View presenter', () => {
+describe('Return Versions - View presenter', () => {
   let returnVersion
 
   beforeEach(() => {

--- a/test/services/return-versions/view.service.test.js
+++ b/test/services/return-versions/view.service.test.js
@@ -48,7 +48,7 @@ describe('Return Versions - View service', () => {
         reason: 'New licence',
         requirements: [
           {
-            abstractionPeriod: 'From 1 April to 31 October',
+            abstractionPeriod: '1 April to 31 October',
             agreementsExceptions: 'None',
             frequencyCollected: 'monthly',
             frequencyReported: 'monthly',


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4886

When attempting to run the North East two-part tariff bill run for 2023-24, the B&D team got an error. When we dug in, we found it was due to a licence having a return log with no abstraction period.

The return log had no abstraction period because the return requirement it was based on didn't have an abstraction period set. But when you view the problem return version, the abstraction period is displayed as **From 30 November to 30 November**.

After debugging the issue, we traced the problem to how [new Date()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/Date) handles nulls.

```javascript
const abstractionDay = null
const abstractionMonth = null

const abstractionDate = new Date(1970, abstractionMonth - 1, abstractionDay)
console.log(abstractionDate)
// 1969-11-30T00:00:00.000Z

const formattedAbstractionDate = abstractionDate.toLocaleDateString('en-GB', { day: 'numeric', month: 'long' })
console.log(formattedAbstractionDate)
// 30 November

const raw = new Date(1970, +0 - 1, +0)
console.log(raw)
// 1969-11-30T00:00:00.000Z
```

Rather than throw an error, it converts them to `+0`. The result when we have no abstraction period data is that we are calling `new Date(1970, +0 - 1, +0)`; hence, it always returns **30 November**.

This change updates `formatAbstractionDate()` to return `null` if passed null data. Then, in the view return version page, we use this to determine that we need to display `Not given` instead (this is what the legacy page shows for return logs with no abstraction period data).