### PR TITLE
Add `notes` and `created_by` to `return_submissions`

### DIFF
--- a/db/migrations/legacy/20221108006002_returns-versions.js
+++ b/db/migrations/legacy/20221108006002_returns-versions.js
@@ -15,6 +15,8 @@ exports.up = function (knex) {
     table.jsonb('metadata').notNullable()
     table.boolean('nil_return').notNullable()
     table.boolean('current')
+    table.text('notes')
+    table.integer('created_by')
 
     // Legacy timestamps
     // NOTE: They are not automatically set

--- a/db/migrations/public/20250127153338_alter-return-submissions-view.js
+++ b/db/migrations/public/20250127153338_alter-return-submissions-view.js
@@ -1,0 +1,45 @@
+'use strict'
+
+const viewName = 'return_submissions'
+
+exports.up = function (knex) {
+  return knex.schema.dropViewIfExists(viewName).createView(viewName, (view) => {
+    view.as(
+      knex('versions').withSchema('returns').select([
+        'version_id AS id',
+        'return_id as return_log_id',
+        'user_id',
+        'user_type',
+        'version_number as version',
+        'metadata',
+        'nil_return',
+        'current',
+        'notes', // new column
+        'created_by', // new column
+        'created_at',
+        'updated_at'
+      ])
+    )
+  })
+}
+
+exports.down = function (knex) {
+  return knex.schema.dropViewIfExists(viewName).createView(viewName, (view) => {
+    view.as(
+      knex('versions')
+        .withSchema('returns')
+        .select([
+          'version_id AS id',
+          'return_id as return_log_id',
+          'user_id',
+          'user_type',
+          'version_number as version',
+          'metadata',
+          'nil_return',
+          'current',
+          'created_at',
+          'updated_at'
+        ])
+    )
+  })
+}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4807

New functionality is being created to enable the user to save a note against a return submission, previously referred to as a version.

This PR will add the `notes` and `created_by` columns to the `returns.versions` table in our test DB and update the `return_submissions` view.

PR https://github.com/DEFRA/water-abstraction-returns/pull/406 will make these updates to the `returns.versions` table.