### PR TITLE
Refactor licence contact details into CRM presenter

### DIFF
--- a/app/presenters/crm.presenter.js
+++ b/app/presenters/crm.presenter.js
@@ -1,0 +1,115 @@
+'use strict'
+
+const CONTACT_ADDRESS_FIELDS = [
+  'addressLine1',
+  'addressLine2',
+  'addressLine3',
+  'addressLine4',
+  'town',
+  'county',
+  'postcode',
+  'country'
+]
+
+const ROLES = ['Licence holder', 'Returns to', 'Licence contact']
+
+/**
+ * Extracts and returns the address components from a contact object.
+ *
+ * This function maps over the `CONTACT_ADDRESS_FIELDS` array, using each field to
+ * extract the corresponding value from the `contact` object. It then filters out
+ * any falsy values (e.g., `undefined`, `null`, or empty strings) from the resulting
+ * array, returning only the valid/ required address components.
+ *
+ * @param {object} contact - The contact object from which to extract address components.
+ *
+ * @returns {string[]}} An array of non-falsy address values extracted from the contact object.
+ */
+function contactAddress(contact) {
+  return CONTACT_ADDRESS_FIELDS.map((contactAddressField) => {
+    return contact[contactAddressField]
+  }).filter(Boolean)
+}
+
+/**
+ * Constructs and returns the full name of a contact based on their type and available properties.
+ *
+ * If the contact is of type `Person`, the function combines the `salutation`, `forename`,
+ * `initials`, and `name` properties, prioritizing the `initials` over the `forename` if the
+ * `initials` is provided. It filters out any falsy values and joins the remaining components
+ * into a full name string. If the contact is not a person, it simply returns the `name` property.
+ *
+ * @param {object} contact - The contact object
+ *
+ * @returns {string} A string representing the full name of the contact.
+ */
+function contactName(contact) {
+  if (contact.type === 'Person') {
+    const { salutation, forename, initials, name } = contact
+
+    // NOTE: Prioritise the initials and use the contact forename if initials is null
+    const initialsOrForename = initials || forename
+
+    const nameComponents = [salutation, initialsOrForename, name]
+
+    const filteredNameComponents = nameComponents.filter((item) => {
+      return item
+    })
+
+    return filteredNameComponents.join(' ')
+  }
+
+  return contact.name
+}
+
+/**
+ * Extracts specific details (address, role, and name) for a list of contacts.
+ *
+ * This function maps over the provided `contacts` array and for each contact,
+ * it extracts the `address`, `role`, and `name` using helper functions (`contactAddress`,
+ * `contactName`) and includes the `role` directly.
+ *
+ * @param {object[]} contacts - The list of contacts
+ *
+ * @returns {object[]} A new array where each object contains the contact's `address`,
+ * `role`, and `name`.
+ */
+function contactDetails(contacts) {
+  return contacts.map((contact) => {
+    return {
+      address: contactAddress(contact),
+      role: contact.role,
+      name: contactName(contact)
+    }
+  })
+}
+
+/**
+ * Filters a list of contacts based on their role and returns their details.
+ *
+ * ```javascript
+ * // Filtered roles
+ * const ROLES = ['Licence holder', 'Returns to', 'Licence contact']
+ * ```
+ *
+ * This function filters the `contacts` array, keeping only the contacts whose `role`
+ * is included in the `ROLES` array. Theses contacts are then formatted.
+ *
+ * @param {object[]} contacts - The list of contact objects to be filtered.
+ *
+ * @returns {object[]} The filtered and formatted contacts
+ */
+function filteredContactDetailsByRole(contacts) {
+  const filteredContactDetails = contacts.filter((contact) => {
+    return ROLES.includes(contact.role)
+  })
+
+  return contactDetails(filteredContactDetails)
+}
+
+module.exports = {
+  contactDetails,
+  contactAddress,
+  contactName,
+  filteredContactDetailsByRole
+}

--- a/app/presenters/licences/view-licence-contact-details.presenter.js
+++ b/app/presenters/licences/view-licence-contact-details.presenter.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { filteredContactDetailsByRole } = require('../crm.presenter.js')
+
 /**
  * Formats data for the `/licences/{id}/licence-contact` view licence contact details link page
  * @module ViewLicenceContactDetailsPresenter
@@ -18,70 +20,9 @@ function go(licence) {
   return {
     licenceId,
     licenceRef,
-    licenceContactDetails: _licenceContactDetails(licenceDocumentHeader),
+    licenceContactDetails: filteredContactDetailsByRole(licenceDocumentHeader.metadata.contacts),
     pageTitle: 'Licence contact details'
   }
-}
-
-function _licenceContactAddress(contact) {
-  const contactAddressFields = [
-    'addressLine1',
-    'addressLine2',
-    'addressLine3',
-    'addressLine4',
-    'town',
-    'county',
-    'postcode',
-    'country'
-  ]
-
-  // NOTE:  Maps over the `contactAddressFields` array to create an array of values from the `contact` object. Each
-  // `contactAddressField` corresponds to a property in the `contact` object, mapping and creating a contactAddress
-  // array. The `filter(Boolean)` function then removes falsy values from the `contactAddress` array.
-  const contactAddress = contactAddressFields
-    .map((contactAddressField) => {
-      return contact[contactAddressField]
-    })
-    .filter(Boolean)
-
-  return contactAddress
-}
-
-function _licenceContactName(contact) {
-  if (contact.type === 'Person') {
-    const { salutation, forename, initials, name } = contact
-
-    // NOTE: Prioritise the initials and use the contact forename if initials is null
-    const initialsOrForename = initials || forename
-
-    const nameComponents = [salutation, initialsOrForename, name]
-
-    const filteredNameComponents = nameComponents.filter((item) => {
-      return item
-    })
-
-    return filteredNameComponents.join(' ')
-  }
-
-  return contact.name
-}
-
-function _licenceContactDetails(licenceDocumentHeader) {
-  const licenceContactDetailsData = licenceDocumentHeader.metadata.contacts
-
-  const roles = ['Licence holder', 'Returns to', 'Licence contact']
-
-  const filteredContactDetails = licenceContactDetailsData.filter((licenceContactDetail) => {
-    return roles.includes(licenceContactDetail.role)
-  })
-
-  return filteredContactDetails.map((contact) => {
-    return {
-      address: _licenceContactAddress(contact),
-      role: contact.role,
-      name: _licenceContactName(contact)
-    }
-  })
 }
 
 module.exports = {

--- a/test/presenters/crm.presenter.test.js
+++ b/test/presenters/crm.presenter.test.js
@@ -105,6 +105,7 @@ describe('CRM presenter', () => {
       })
     })
   })
+
   describe('#filteredContactDetailsByRole()', () => {
     describe('when given multiple valid contacts', () => {
       let invalidContact

--- a/test/presenters/crm.presenter.test.js
+++ b/test/presenters/crm.presenter.test.js
@@ -1,0 +1,130 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Thing under test
+const CRMPresenter = require('../../app/presenters/crm.presenter.js')
+
+describe('CRM presenter', () => {
+  let contact
+
+  beforeEach(() => {
+    contact = {
+      // Name
+      type: 'Person',
+      salutation: 'Mr',
+      initials: 'B T',
+      forename: 'Bruce',
+      name: 'Wayne',
+      // Address
+      addressLine1: 'Wayne Manor',
+      addressLine2: null,
+      addressLine3: '',
+      addressLine4: undefined,
+      town: 'Gotham City',
+      county: 'Gotham County',
+      postcode: '10001',
+      country: 'USA',
+      // Role
+      role: 'Licence holder'
+    }
+  })
+
+  describe('#contactDetails()', () => {
+    describe('when given multiple valid contacts', () => {
+      it('correctly returns the contact details', () => {
+        const result = CRMPresenter.contactDetails([contact])
+        expect(result).to.equal([
+          {
+            address: ['Wayne Manor', 'Gotham City', 'Gotham County', '10001', 'USA'],
+            name: 'Mr B T Wayne',
+            role: 'Licence holder'
+          }
+        ])
+      })
+    })
+  })
+  describe('#contactAddress()', () => {
+    describe('when given an address', () => {
+      it('correctly returns the address, with only the required fields and no falsey values', () => {
+        const result = CRMPresenter.contactAddress(contact)
+
+        expect(result).to.equal(['Wayne Manor', 'Gotham City', 'Gotham County', '10001', 'USA'])
+      })
+    })
+  })
+
+  describe('#contactName()', () => {
+    describe('when the "type" is "person"', () => {
+      describe('and they have initials', () => {
+        it('correctly formats the name to use the initials', () => {
+          const result = CRMPresenter.contactName(contact)
+
+          expect(result).to.equal('Mr B T Wayne')
+        })
+      })
+
+      describe('and they have initials and a forename', () => {
+        it('correctly formats the name to use the initials', () => {
+          const result = CRMPresenter.contactName(contact)
+
+          expect(result).to.equal('Mr B T Wayne')
+        })
+      })
+
+      describe('and they have a forename and no initials', () => {
+        beforeEach(() => {
+          contact.initials = null
+        })
+
+        it('correctly formats the name to use the forename', () => {
+          const result = CRMPresenter.contactName(contact)
+
+          expect(result).to.equal('Mr Bruce Wayne')
+        })
+      })
+    })
+
+    describe('when the "type" is not "person"', () => {
+      describe('and they have initals', () => {
+        beforeEach(() => {
+          contact.type = 'Organisation'
+          contact.name = 'ACME Ltd'
+        })
+
+        it('correctly formats the name to use the initals', () => {
+          const result = CRMPresenter.contactName(contact)
+
+          expect(result).to.equal('ACME Ltd')
+        })
+      })
+    })
+  })
+  describe('#filteredContactDetailsByRole()', () => {
+    describe('when given multiple valid contacts', () => {
+      let invalidContact
+      beforeEach(() => {
+        invalidContact = {
+          ...contact,
+          role: 'Butler'
+        }
+      })
+
+      it('correctly returns the filtered contact details', () => {
+        const result = CRMPresenter.filteredContactDetailsByRole([contact, invalidContact])
+        expect(result).to.equal([
+          {
+            address: ['Wayne Manor', 'Gotham City', 'Gotham County', '10001', 'USA'],
+            name: 'Mr B T Wayne',
+            role: 'Licence holder'
+          }
+        ])
+      })
+    })
+  })
+})


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4775

As part of the work to migrate the notifications into the system repo.

We currently format the contact from crm.document_header.metadata in the view licence contact details presenter.

We now have a requirement to use the contact details in multiple places.

This change refactors the code from the  view licence contact details presenter into a shared crm presenter.