### PR TITLE
Sort Notifications recipients

### DIFF
--- a/app/presenters/notifications/setup/review.presenter.js
+++ b/app/presenters/notifications/setup/review.presenter.js
@@ -102,12 +102,12 @@ function _recipients(recipients, page) {
 }
 
 /**
- * Sorts an array of contact objects alphabetically by the contact's name.
- * The contact name is assumed to be the first element in the `contact` array
- * (as constructed by the CRM presenter function `contactName`).
+ * Sorts an array of recipients objects alphabetically by the contact's name.
  *
- * This function compares the first element of the `contact` array for each
- * object to determine alphabetical order.
+ * ```javascript
+ * // The contact name is assumed to be the first element in the `contact` array
+ * const [name] = a.contact
+ * ```
  *
  * @private
  */

--- a/app/presenters/notifications/setup/review.presenter.js
+++ b/app/presenters/notifications/setup/review.presenter.js
@@ -75,16 +75,47 @@ function _pagination(recipients, page) {
   return recipients.slice(pageNumber - defaultPageSize, pageNumber)
 }
 
+/**
+ * Sorts, maps, and paginates the recipients list.
+ *
+ * This function first maps over the recipients to transform each recipient object into a new format,
+ * then sorts the resulting array of transformed recipients alphabetically by their contact's name.
+ * After sorting, it uses pagination to return only the relevant subset of recipients for the given page.
+ *
+ * The map and sort are performed before pagination, as it is necessary to have the recipients in a defined
+ * order before determining which recipients should appear on the page.
+ *
+ * @private
+ */
 function _recipients(recipients, page) {
-  const paginatedRecipients = _pagination(recipients, page)
+  const sortedRecipients = recipients
+    .map((recipient) => {
+      return {
+        contact: _contact(recipient),
+        licences: _licences(recipient.licence_refs),
+        method: `${recipient.message_type} - ${recipient.contact_type}`
+      }
+    })
+    .sort(_sortContactAlphabeticallyByName)
 
-  return paginatedRecipients.map((recipient) => {
-    return {
-      contact: _contact(recipient),
-      licences: _licences(recipient.licence_refs),
-      method: `${recipient.message_type} - ${recipient.contact_type}`
-    }
-  })
+  return _pagination(sortedRecipients, page)
+}
+
+/**
+ * Sorts an array of contact objects alphabetically by the contact's name.
+ * The contact name is assumed to be the first element in the `contact` array
+ * (as constructed by the CRM presenter function `contactName`).
+ *
+ * This function compares the first element of the `contact` array for each
+ * object to determine alphabetical order.
+ *
+ * @private
+ */
+function _sortContactAlphabeticallyByName(a, b) {
+  if (a.contact[0] < b.contact[0]) return -1
+  if (a.contact[0] > b.contact[0]) return 1
+
+  return 0
 }
 
 module.exports = {

--- a/app/presenters/notifications/setup/review.presenter.js
+++ b/app/presenters/notifications/setup/review.presenter.js
@@ -106,7 +106,7 @@ function _recipients(recipients, page) {
  *
  * ```javascript
  * // The contact name is assumed to be the first element in the `contact` array
- * const [name] = a.contact
+ * const [name] = recipient.contact
  * ```
  *
  * @private

--- a/app/presenters/notifications/setup/review.presenter.js
+++ b/app/presenters/notifications/setup/review.presenter.js
@@ -112,8 +112,13 @@ function _recipients(recipients, page) {
  * @private
  */
 function _sortContactAlphabeticallyByName(a, b) {
-  if (a.contact[0] < b.contact[0]) return -1
-  if (a.contact[0] > b.contact[0]) return 1
+  if (a.contact[0] < b.contact[0]) {
+    return -1
+  }
+
+  if (a.contact[0] > b.contact[0]) {
+    return 1
+  }
 
   return 0
 }

--- a/test/fixtures/recipients.fixtures.js
+++ b/test/fixtures/recipients.fixtures.js
@@ -25,9 +25,11 @@ function recipients() {
  */
 function duplicateRecipients() {
   const duplicateLicenceRef = generateLicenceRef()
+  const licenceDuplicateLicenceRef = generateLicenceRef()
+
   return {
-    duplicateLicenceHolder: _addDuplicateLicenceHolder(duplicateLicenceRef),
-    duplicateReturnsTo: _addDuplicateReturnsTo(duplicateLicenceRef),
+    duplicateLicenceHolder: _addDuplicateLicenceHolder(licenceDuplicateLicenceRef),
+    duplicateReturnsTo: _addDuplicateReturnsTo(licenceDuplicateLicenceRef),
     duplicatePrimaryUser: _addDuplicatePrimaryUser(duplicateLicenceRef),
     duplicateReturnsAgent: _addDuplicateReturnsAgent(duplicateLicenceRef)
   }
@@ -45,7 +47,7 @@ function _addDuplicateLicenceHolder(licenceRef) {
 function _addDuplicateReturnsTo(licenceRef) {
   return {
     licence_refs: licenceRef,
-    contact_type: 'Returns To',
+    contact_type: 'Returns to',
     contact: _contact('4', 'Duplicate Returns to', 'Returns to'),
     contact_hash_id: 'b1b355491c7d42778890c545e08797ea'
   }
@@ -96,7 +98,7 @@ function _addDuplicateReturnsAgent(licenceRef) {
     contact: null,
     contact_hash_id: '2e6918568dfbc1d78e2fbe279fftt990',
     contact_type: 'Returns agent',
-    recipient: 'returns.agent@important.com'
+    email: 'returns.agent@important.com'
   }
 }
 

--- a/test/presenters/notifications/setup/review.presenter.test.js
+++ b/test/presenters/notifications/setup/review.presenter.test.js
@@ -27,6 +27,9 @@ describe('Notifications Setup - Review presenter', () => {
     }
 
     testRecipients = RecipientsFixture.recipients()
+    // This data is used to ensure the recipients are grouped when they have the same licence ref / name.
+    // Ignore the fact that these would be considered duplicates elsewhere in the code
+    // (e.g. contact hash / address being identical)
     testDuplicateRecipients = RecipientsFixture.duplicateRecipients()
 
     testInput = [...Object.values(testRecipients), ...Object.values(testDuplicateRecipients)].map((recipient) => {

--- a/test/presenters/notifications/setup/review.presenter.test.js
+++ b/test/presenters/notifications/setup/review.presenter.test.js
@@ -18,6 +18,7 @@ describe('Notifications Setup - Review presenter', () => {
   let pagination
   let testInput
   let testRecipients
+  let testDuplicateRecipients
 
   beforeEach(() => {
     page = 1
@@ -26,8 +27,9 @@ describe('Notifications Setup - Review presenter', () => {
     }
 
     testRecipients = RecipientsFixture.recipients()
+    testDuplicateRecipients = RecipientsFixture.duplicateRecipients()
 
-    testInput = Object.values(testRecipients).map((recipient) => {
+    testInput = [...Object.values(testRecipients), ...Object.values(testDuplicateRecipients)].map((recipient) => {
       return {
         ...recipient,
         // The determine recipients service will add the message_type relevant to the recipient
@@ -39,7 +41,7 @@ describe('Notifications Setup - Review presenter', () => {
   })
 
   describe('when provided with "recipients"', () => {
-    it('correctly presents the data', () => {
+    it('correctly presents the data (in alphabetical order)', () => {
       const result = ReviewPresenter.go(testInput, page, pagination)
 
       expect(result).to.equal({
@@ -47,24 +49,19 @@ describe('Notifications Setup - Review presenter', () => {
         pageTitle: 'Send returns invitations',
         recipients: [
           {
-            contact: ['primary.user@important.com'],
-            licences: [testRecipients.primaryUser.licence_refs],
-            method: 'Letter or email - Primary user'
+            contact: ['Mr H J Duplicate Licence holder', '4', 'Privet Drive', 'Little Whinging', 'Surrey', 'WD25 7LR'],
+            licences: [testDuplicateRecipients.duplicateLicenceHolder.licence_refs],
+            method: 'Letter or email - Licence holder'
           },
           {
-            contact: ['returns.agent@important.com'],
-            licences: [testRecipients.returnsAgent.licence_refs],
-            method: 'Letter or email - Returns agent'
+            contact: ['Mr H J Duplicate Returns to', '4', 'Privet Drive', 'Little Whinging', 'Surrey', 'WD25 7LR'],
+            licences: [testDuplicateRecipients.duplicateReturnsTo.licence_refs],
+            method: 'Letter or email - Returns to'
           },
           {
             contact: ['Mr H J Licence holder', '1', 'Privet Drive', 'Little Whinging', 'Surrey', 'WD25 7LR'],
             licences: [testRecipients.licenceHolder.licence_refs],
             method: 'Letter or email - Licence holder'
-          },
-          {
-            contact: ['Mr H J Returns to', '2', 'Privet Drive', 'Little Whinging', 'Surrey', 'WD25 7LR'],
-            licences: [testRecipients.returnsTo.licence_refs],
-            method: 'Letter or email - Returns to'
           },
           {
             contact: [
@@ -77,9 +74,34 @@ describe('Notifications Setup - Review presenter', () => {
             ],
             licences: testRecipients.licenceHolderWithMultipleLicences.licence_refs.split(','),
             method: 'Letter or email - Licence holder'
+          },
+          {
+            contact: ['Mr H J Returns to', '2', 'Privet Drive', 'Little Whinging', 'Surrey', 'WD25 7LR'],
+            licences: [testRecipients.returnsTo.licence_refs],
+            method: 'Letter or email - Returns to'
+          },
+          {
+            contact: ['primary.user@important.com'],
+            licences: [testRecipients.primaryUser.licence_refs],
+            method: 'Letter or email - Primary user'
+          },
+          {
+            contact: ['primary.user@important.com'],
+            licences: [testDuplicateRecipients.duplicatePrimaryUser.licence_refs],
+            method: 'Letter or email - Primary user'
+          },
+          {
+            contact: ['returns.agent@important.com'],
+            licences: [testRecipients.returnsAgent.licence_refs],
+            method: 'Letter or email - Returns agent'
+          },
+          {
+            contact: ['returns.agent@important.com'],
+            licences: [testDuplicateRecipients.duplicateReturnsAgent.licence_refs],
+            method: 'Letter or email - Returns agent'
           }
         ],
-        recipientsAmount: 5
+        recipientsAmount: 9
       })
     })
 
@@ -90,24 +112,26 @@ describe('Notifications Setup - Review presenter', () => {
 
           expect(result.recipients).to.equal([
             {
-              contact: ['primary.user@important.com'],
-              licences: [testRecipients.primaryUser.licence_refs],
-              method: 'Letter or email - Primary user'
+              contact: [
+                'Mr H J Duplicate Licence holder',
+                '4',
+                'Privet Drive',
+                'Little Whinging',
+                'Surrey',
+                'WD25 7LR'
+              ],
+              licences: [testDuplicateRecipients.duplicateLicenceHolder.licence_refs],
+              method: 'Letter or email - Licence holder'
             },
             {
-              contact: ['returns.agent@important.com'],
-              licences: [testRecipients.returnsAgent.licence_refs],
-              method: 'Letter or email - Returns agent'
+              contact: ['Mr H J Duplicate Returns to', '4', 'Privet Drive', 'Little Whinging', 'Surrey', 'WD25 7LR'],
+              licences: [testDuplicateRecipients.duplicateReturnsTo.licence_refs],
+              method: 'Letter or email - Returns to'
             },
             {
               contact: ['Mr H J Licence holder', '1', 'Privet Drive', 'Little Whinging', 'Surrey', 'WD25 7LR'],
               licences: [testRecipients.licenceHolder.licence_refs],
               method: 'Letter or email - Licence holder'
-            },
-            {
-              contact: ['Mr H J Returns to', '2', 'Privet Drive', 'Little Whinging', 'Surrey', 'WD25 7LR'],
-              licences: [testRecipients.returnsTo.licence_refs],
-              method: 'Letter or email - Returns to'
             },
             {
               contact: [
@@ -120,6 +144,31 @@ describe('Notifications Setup - Review presenter', () => {
               ],
               licences: testRecipients.licenceHolderWithMultipleLicences.licence_refs.split(','),
               method: 'Letter or email - Licence holder'
+            },
+            {
+              contact: ['Mr H J Returns to', '2', 'Privet Drive', 'Little Whinging', 'Surrey', 'WD25 7LR'],
+              licences: [testRecipients.returnsTo.licence_refs],
+              method: 'Letter or email - Returns to'
+            },
+            {
+              contact: ['primary.user@important.com'],
+              licences: [testRecipients.primaryUser.licence_refs],
+              method: 'Letter or email - Primary user'
+            },
+            {
+              contact: ['primary.user@important.com'],
+              licences: [testDuplicateRecipients.duplicatePrimaryUser.licence_refs],
+              method: 'Letter or email - Primary user'
+            },
+            {
+              contact: ['returns.agent@important.com'],
+              licences: [testRecipients.returnsAgent.licence_refs],
+              method: 'Letter or email - Returns agent'
+            },
+            {
+              contact: ['returns.agent@important.com'],
+              licences: [testDuplicateRecipients.duplicateReturnsAgent.licence_refs],
+              method: 'Letter or email - Returns agent'
             }
           ])
         })
@@ -199,7 +248,7 @@ describe('Notifications Setup - Review presenter', () => {
 
       describe('and there are >= 25 recipients', () => {
         beforeEach(() => {
-          testInput = [...testInput, ...testInput, ...testInput, ...testInput, ...testInput, ...testInput]
+          testInput = [...testInput, ...testInput, ...testInput]
 
           pagination = {
             numberOfPages: 2
@@ -228,7 +277,7 @@ describe('Notifications Setup - Review presenter', () => {
           it('returns the remaining recipients', () => {
             const result = ReviewPresenter.go(testInput, page, pagination)
 
-            expect(result.recipients.length).to.equal(5)
+            expect(result.recipients.length).to.equal(2)
           })
 
           it('returns the updated "pageTitle"', () => {

--- a/test/services/notifications/setup/determine-recipients.service.test.js
+++ b/test/services/notifications/setup/determine-recipients.service.test.js
@@ -132,7 +132,7 @@ describe('Notifications Setup - Determine Recipients service', () => {
             type: 'Person'
           },
           contact_hash_id: 'b1b355491c7d42778890c545e08797ea',
-          contact_type: 'Licence holder',
+          contact_type: 'both',
           email: null,
           licence_refs: testDuplicateRecipients.duplicateLicenceHolder.licence_refs,
           message_type: 'Letter'
@@ -194,7 +194,7 @@ describe('Notifications Setup - Determine Recipients service', () => {
               type: 'Person'
             },
             contact_hash_id: 'b1b355491c7d42778890c545e08797ea',
-            contact_type: 'Licence holder',
+            contact_type: 'both',
             email: null,
             licence_refs: testDuplicateRecipients.duplicateLicenceHolder.licence_refs,
             message_type: 'Letter'


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4775

This change introduces a sort on the recipients array in the presenter. It sorts by the contacts name.

We need to work out the name before we can sort. So we first map the recipients and then sort.

This will result in all the recipients being mapped and sorted, with only 25 (the current default pagination per page) of the results being used. We have deemed this acceptable for the sake of simplicity and have accounted for performance concerns.

This change also introduces the duplicate recipient fixtures data into the presenter test to ensure recipients are grouped by the name (and subsequently the licence ref)