### PR TITLE
Update Licence entity role to Has Many Relation

### DIFF
--- a/app/models/licence-document-header.model.js
+++ b/app/models/licence-document-header.model.js
@@ -51,8 +51,8 @@ class LicenceDocumentHeaderModel extends BaseModel {
           to: 'licences.licenceRef'
         }
       },
-      licenceEntityRole: {
-        relation: Model.HasOneRelation,
+      licenceEntityRoles: {
+        relation: Model.HasManyRelation,
         modelClass: 'licence-entity-role.model',
         join: {
           from: 'licenceDocumentHeaders.companyEntityId',

--- a/app/models/licence.model.js
+++ b/app/models/licence.model.js
@@ -235,16 +235,16 @@ class LicenceModel extends BaseModel {
           .modifyGraph('licenceDocumentHeader', (builder) => {
             builder.select(['id'])
           })
-          .withGraphFetched('licenceDocumentHeader.licenceEntityRole')
-          .modifyGraph('licenceDocumentHeader.licenceEntityRole', (builder) => {
+          .withGraphFetched('licenceDocumentHeader.licenceEntityRoles')
+          .modifyGraph('licenceDocumentHeader.licenceEntityRoles', (builder) => {
             builder.select(['id']).where('role', 'primary_user')
           })
-          .withGraphFetched('licenceDocumentHeader.licenceEntityRole.licenceEntity')
-          .modifyGraph('licenceDocumentHeader.licenceEntityRole.licenceEntity', (builder) => {
+          .withGraphFetched('licenceDocumentHeader.licenceEntityRoles.licenceEntity')
+          .modifyGraph('licenceDocumentHeader.licenceEntityRoles.licenceEntity', (builder) => {
             builder.select(['id'])
           })
-          .withGraphFetched('licenceDocumentHeader.licenceEntityRole.licenceEntity.user')
-          .modifyGraph('licenceDocumentHeader.licenceEntityRole.licenceEntity.user', (builder) => {
+          .withGraphFetched('licenceDocumentHeader.licenceEntityRoles.licenceEntity.user')
+          .modifyGraph('licenceDocumentHeader.licenceEntityRoles.licenceEntity.user', (builder) => {
             builder.select(['id', 'username'])
           })
       }
@@ -411,11 +411,18 @@ class LicenceModel extends BaseModel {
    *
    * Within the UI this what determines whether you see the "Registered to" link in the view licence page's top section.
    *
+   * This query will find the `licenceEntityRole` with the role 'primary_user'. As we can expect multiple
+   * `licenceEntityRoles` we need to take the first (and expected to be only) `licenceEntityRole` from the received
+   * array of `licenceEntityRoles`.
+   *
+   * > We understand that `licenceEntityRoles` can be associated with the same `company_entity_id`. A common example
+   * of this is having a 'Primary user' and a 'Returns agent' (known as `user_agent` in the database)
+   *
    * @returns {(module:UserModel|null)} the primary user if the licence has one and the additional properties needed to
    * to determine it have been set, else `null`
    */
   $primaryUser() {
-    const primaryUser = this?.licenceDocumentHeader?.licenceEntityRole?.licenceEntity?.user
+    const primaryUser = this?.licenceDocumentHeader?.licenceEntityRoles?.[0]?.licenceEntity?.user
 
     return primaryUser || null
   }

--- a/test/models/licence-document-header.model.test.js
+++ b/test/models/licence-document-header.model.test.js
@@ -62,7 +62,7 @@ describe('Licence Document Header model', () => {
 
     describe('when linking to licence entity role', () => {
       it('can successfully run a related query', async () => {
-        const query = await LicenceDocumentHeaderModel.query().innerJoinRelated('licenceEntityRole')
+        const query = await LicenceDocumentHeaderModel.query().innerJoinRelated('licenceEntityRoles')
 
         expect(query).to.exist()
       })
@@ -70,13 +70,15 @@ describe('Licence Document Header model', () => {
       it('can eager load the licence entity role', async () => {
         const result = await LicenceDocumentHeaderModel.query()
           .findById(testRecord.id)
-          .withGraphFetched('licenceEntityRole')
+          .withGraphFetched('licenceEntityRoles')
 
         expect(result).to.be.instanceOf(LicenceDocumentHeaderModel)
         expect(result.id).to.equal(testRecord.id)
 
-        expect(result.licenceEntityRole).to.be.an.instanceOf(LicenceEntityRoleModel)
-        expect(result.licenceEntityRole).to.equal(testLicenceEntityRole)
+        const [licenceEntityRole] = result.licenceEntityRoles
+
+        expect(licenceEntityRole).to.be.an.instanceOf(LicenceEntityRoleModel)
+        expect(licenceEntityRole).to.equal(testLicenceEntityRole)
       })
     })
   })

--- a/test/models/licence-document-header.model.test.js
+++ b/test/models/licence-document-header.model.test.js
@@ -60,14 +60,14 @@ describe('Licence Document Header model', () => {
       })
     })
 
-    describe('when linking to licence entity role', () => {
+    describe('when linking to licence entity roles', () => {
       it('can successfully run a related query', async () => {
         const query = await LicenceDocumentHeaderModel.query().innerJoinRelated('licenceEntityRoles')
 
         expect(query).to.exist()
       })
 
-      it('can eager load the licence entity role', async () => {
+      it('can eager load the licence entity roles', async () => {
         const result = await LicenceDocumentHeaderModel.query()
           .findById(testRecord.id)
           .withGraphFetched('licenceEntityRoles')

--- a/test/presenters/licences/view-licence.presenter.test.js
+++ b/test/presenters/licences/view-licence.presenter.test.js
@@ -71,7 +71,7 @@ describe('View Licence presenter', () => {
 
     describe('when the licence does not have a primary user (registered user)', () => {
       beforeEach(() => {
-        licence.licenceDocumentHeader.licenceEntityRole = null
+        licence.licenceDocumentHeader.licenceEntityRoles = []
       })
 
       it('returns "Unregistered licence"', () => {
@@ -347,16 +347,18 @@ function _licence() {
     licenceDocumentHeader: {
       id: 'e8f491f0-0c60-4083-9d41-d2be69f17a1e',
       licenceName: 'Between two ferns',
-      licenceEntityRole: {
-        id: 'd7eecfc1-7afa-49f7-8bef-5dc477696a2d',
-        licenceEntity: {
-          id: 'ba7702cf-cd87-4419-a04c-8cea4e0cfdc2',
-          user: {
-            id: 10036,
-            username: 'grace.hopper@example.co.uk'
+      licenceEntityRoles: [
+        {
+          id: 'd7eecfc1-7afa-49f7-8bef-5dc477696a2d',
+          licenceEntity: {
+            id: 'ba7702cf-cd87-4419-a04c-8cea4e0cfdc2',
+            user: {
+              id: 10036,
+              username: 'grace.hopper@example.co.uk'
+            }
           }
         }
-      }
+      ]
     },
     licenceSupplementaryYears: [],
     workflows: [{ id: 'b6f44c94-25e4-4ca8-a7db-364534157ba7', status: 'to_setup' }]

--- a/test/services/licences/view-licence.service.test.js
+++ b/test/services/licences/view-licence.service.test.js
@@ -101,16 +101,18 @@ function _licence() {
     licenceDocumentHeader: {
       id: 'e8f491f0-0c60-4083-9d41-d2be69f17a1e',
       licenceName: 'Between two ferns',
-      licenceEntityRole: {
-        id: 'd7eecfc1-7afa-49f7-8bef-5dc477696a2d',
-        licenceEntity: {
-          id: 'ba7702cf-cd87-4419-a04c-8cea4e0cfdc2',
-          user: {
-            id: 10036,
-            username: 'grace.hopper@example.co.uk'
+      licenceEntityRoles: [
+        {
+          id: 'd7eecfc1-7afa-49f7-8bef-5dc477696a2d',
+          licenceEntity: {
+            id: 'ba7702cf-cd87-4419-a04c-8cea4e0cfdc2',
+            user: {
+              id: 10036,
+              username: 'grace.hopper@example.co.uk'
+            }
           }
         }
-      }
+      ]
     },
     licenceSupplementaryYears: [],
     workflows: [{ id: 'b6f44c94-25e4-4ca8-a7db-364534157ba7', status: 'to_setup' }]


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4879

As part of the work to show the "Primary user" and "Returns agent" in the licence contact details page. We noticed our previous assumption of a licence entity role having one relation was incorrect.

A licence entity role can have many relations. This is commonly found when a licence entity role with a 'Primary user' also has a 'Returns agent' (know as a 'user'agent' in the db)

This change updates the `licenceEntityRole` to `licenceEntityRoles` and updates any necessary code / tests that fail.