### PR TITLE
Update notifications details text

### DIFF
--- a/app/views/notifications/setup/review.njk
+++ b/app/views/notifications/setup/review.njk
@@ -25,7 +25,7 @@
       {{
       govukDetails({
         classes: 'govuk-!-margin-bottom-0',
-        summaryText: recipient.licences.length + ' licence numbers',
+        summaryText: recipient.licences.length + ' licences',
         html: newLineArrayItems(recipient.licences)
       })
       }}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4775

The test for the details component should be 'licences' not 'licence numbers'