### PR TITLE
Add notifications download route

### DIFF
--- a/app/controllers/notifications-setup.controller.js
+++ b/app/controllers/notifications-setup.controller.js
@@ -1,16 +1,32 @@
 'use strict'
 
-const ReturnsPeriodService = require('../services/notifications/setup/returns-period.service.js')
-const ReviewService = require('../services/notifications/setup/review.service.js')
-const SubmitReturnsPeriodService = require('../services/notifications/setup/submit-returns-period.service.js')
-const InitiateSessionService = require('../services/notifications/setup/initiate-session.service.js')
-
 /**
  * Controller for /notifications/setup endpoints
  * @module NotificationsSetupController
  */
 
+const DownloadRecipientsService = require('../services/notifications/setup/download-recipients.service.js')
+const InitiateSessionService = require('../services/notifications/setup/initiate-session.service.js')
+const ReturnsPeriodService = require('../services/notifications/setup/returns-period.service.js')
+const ReviewService = require('../services/notifications/setup/review.service.js')
+const SubmitReturnsPeriodService = require('../services/notifications/setup/submit-returns-period.service.js')
+
 const basePath = 'notifications/setup'
+
+async function downloadRecipients(request, h) {
+  const {
+    params: { sessionId }
+  } = request
+
+  const { data, type, filename } = await DownloadRecipientsService.go(sessionId)
+
+  return h
+    .response(data)
+    .type(type)
+    .encoding('binary')
+    .header('Content-Type', type)
+    .header('Content-Disposition', `attachment; filename="${filename}"`)
+}
 
 async function viewReturnsPeriod(request, h) {
   const {
@@ -55,6 +71,7 @@ async function submitReturnsPeriod(request, h) {
 }
 
 module.exports = {
+  downloadRecipients,
   viewReturnsPeriod,
   viewReview,
   setup,

--- a/app/routes/notifications-setup.routes.js
+++ b/app/routes/notifications-setup.routes.js
@@ -19,6 +19,18 @@ const routes = [
   },
   {
     method: 'GET',
+    path: basePath + '/{sessionId}/download',
+    options: {
+      handler: NotificationsSetupController.downloadRecipients,
+      auth: {
+        access: {
+          scope: ['returns']
+        }
+      }
+    }
+  },
+  {
+    method: 'GET',
     path: basePath + '/{sessionId}/returns-period',
     options: {
       handler: NotificationsSetupController.viewReturnsPeriod,

--- a/app/services/notifications/setup/download-recipients.service.js
+++ b/app/services/notifications/setup/download-recipients.service.js
@@ -5,6 +5,8 @@
  * @module DownloadRecipientsService
  */
 
+const SessionModel = require('../../../models/session.model.js')
+
 /**
  * Orchestrates fetching and formatting the data needed for the notifications setup download link
  *
@@ -12,15 +14,20 @@
  *
  * It does not seem necessary to use a data stream to create the csv as the data is relatively small.
  *
+ * @param {string} sessionId - The UUID for setup ad-hoc returns notification session record
+ *
  * @returns {Promise<object>} The data for the download link (csv string, filename and type)
  */
-async function go() {
+async function go(sessionId) {
+  const session = await SessionModel.query().findById(sessionId)
+  const { notificationType, referenceCode } = session
+
   const csv = 'Licences\n12234\n'
 
   return {
     data: csv,
     type: 'text/csv',
-    filename: 'recipients.csv'
+    filename: `${notificationType} - ${referenceCode}.csv`
   }
 }
 

--- a/app/services/notifications/setup/download-recipients.service.js
+++ b/app/services/notifications/setup/download-recipients.service.js
@@ -10,9 +10,8 @@ const SessionModel = require('../../../models/session.model.js')
 /**
  * Orchestrates fetching and formatting the data needed for the notifications setup download link
  *
- * The service will fetch recipients and then create a csv with the recipients' data.
- *
- * It does not seem necessary to use a data stream to create the csv as the data is relatively small.
+ * This service creates a csv file of recipient for the user to download. It does not seem necessary to use a `Stream`
+ * to create the csv as the data is relatively small.
  *
  * @param {string} sessionId - The UUID for setup ad-hoc returns notification session record
  *

--- a/app/services/notifications/setup/download-recipients.service.js
+++ b/app/services/notifications/setup/download-recipients.service.js
@@ -9,9 +9,10 @@
  * Orchestrates fetching and formatting the data needed for the notifications setup download link
  *
  * The service will fetch recipients and then create a csv with the recipients' data.
- * The service will return the name of the file and file type.
  *
- * @returns {Promise<object>} The data for the download link
+ * It does not seem necessary to use a data stream to create the csv as the data is relatively small.
+ *
+ * @returns {Promise<object>} The data for the download link (csv string, filename and type)
  */
 async function go() {
   const csv = 'Licences\n12234\n'

--- a/app/services/notifications/setup/download-recipients.service.js
+++ b/app/services/notifications/setup/download-recipients.service.js
@@ -1,0 +1,28 @@
+'use strict'
+
+/**
+ * Orchestrates fetching and formatting the data needed for the notifications setup download link
+ * @module DownloadRecipientsService
+ */
+
+/**
+ * Orchestrates fetching and formatting the data needed for the notifications setup download link
+ *
+ * The service will fetch recipients and then create a csv with the recipients' data.
+ * The service will return the name of the file and file type.
+ *
+ * @returns {Promise<object>} The data for the download link
+ */
+async function go() {
+  const csv = 'Licences\n12234\n'
+
+  return {
+    data: csv,
+    type: 'text/csv',
+    filename: 'recipients.csv'
+  }
+}
+
+module.exports = {
+  go
+}

--- a/app/services/notifications/setup/initiate-session.service.js
+++ b/app/services/notifications/setup/initiate-session.service.js
@@ -1,29 +1,68 @@
 'use strict'
 
 /**
- * Initiates the session record used for setting up a new ad-hoc returns notification
+ * Initiates the session record used for setting up a new returns notification
  * @module InitiateSessionService
  */
 
 const SessionModel = require('../../../models/session.model.js')
 
+const NOTIFICATION_TYPES = {
+  invitation: {
+    prefix: 'RINV-',
+    type: 'Returns invitation'
+  },
+  reminder: {
+    prefix: 'RREM-',
+    type: 'Returns reminder'
+  }
+}
+
 /**
- * Initiates the session record used for setting up a new ad-hoc returns notification
+ * Initiates the session record used for setting up a new returns notification
  *
- * During the setup journey for a new ad-hoc returns notification we temporarily store the data in a `SessionModel`
+ * During the setup journey for a new returns notification we temporarily store the data in a `SessionModel`
  * instance. It is expected that on each page of the journey the GET will fetch the session record and use it to
  * populate the view.
  * When the page is submitted the session record will be updated with the next piece of data.
  *
- * At the end when the journey is complete the data from the session will be used to create the ad-hoc returns
+ * At the end when the journey is complete the data from the session will be used to create the returns
  * notification and the session record itself deleted.
+ *
+ * This session will be used for both types of notifications (invitations and reminders). We set the prefix and type
+ * for the upstream services to use e.g. the prefix and code are used in the filename of a csv file.
  *
  * @returns {Promise<module:SessionModel>} the newly created session record
  */
 async function go() {
-  // NOTE: data defaults to {} when a new record is created. But Objection.js throws a 'The query is empty' if we pass
-  // nothing into `insert()`.
-  return SessionModel.query().insert({ data: {} }).returning('id')
+  const { prefix, type } = NOTIFICATION_TYPES['invitation']
+
+  return SessionModel.query()
+    .insert({
+      data: {
+        referenceCode: _generateReferenceCode(prefix),
+        notificationType: type
+      }
+    })
+    .returning('id')
+}
+
+/**
+ * A function to generate a pseudo-unique reference code for recipients notifications
+ *
+ * @param {string} prefix
+ *
+ * @returns {string} A reference code with a prefix and random string (RINV-A14GB8)
+ */
+function _generateReferenceCode(prefix) {
+  const possible = 'ABCDEFGHJKLMNPQRTUVWXYZ0123456789'
+  const length = 6
+  let text = ''
+
+  for (let i = 0; i < length; i++) {
+    text += possible.charAt(Math.floor(Math.random() * possible.length))
+  }
+  return prefix + text
 }
 
 module.exports = {

--- a/app/views/notifications/setup/review.njk
+++ b/app/views/notifications/setup/review.njk
@@ -56,7 +56,7 @@
         text: "Download recipients",
         classes: "govuk-button--secondary",
         href: links.download,
-        preventDoubleClick: true,
+        preventDoubleClick: true
       }) }}
 
       {{ govukButton({

--- a/app/views/notifications/setup/review.njk
+++ b/app/views/notifications/setup/review.njk
@@ -56,7 +56,7 @@
         text: "Download recipients",
         classes: "govuk-button--secondary",
         href: links.download,
-        preventDoubleClick: true
+        preventDoubleClick: true,
       }) }}
 
       {{ govukButton({

--- a/test/controllers/notifications-setup.controller.test.js
+++ b/test/controllers/notifications-setup.controller.test.js
@@ -214,7 +214,7 @@ function _viewReturnsPeriod() {
 
 function _viewReview() {
   return {
-    pageTitle: 'Review the mailing listr',
+    pageTitle: 'Review the mailing list',
     activeNavBar: 'manage'
   }
 }

--- a/test/controllers/notifications-setup.controller.test.js
+++ b/test/controllers/notifications-setup.controller.test.js
@@ -11,6 +11,7 @@ const { expect } = Code
 const { postRequestOptions } = require('../support/general.js')
 
 // Things we need to stub
+const DownloadRecipientsService = require('../../app/services/notifications/setup/download-recipients.service.js')
 const InitiateSessionService = require('../../app/services/notifications/setup/initiate-session.service.js')
 const ReturnsPeriodService = require('../../app/services/notifications/setup/returns-period.service.js')
 const ReviewService = require('../../app/services/notifications/setup/review.service.js')
@@ -68,6 +69,36 @@ describe('Notifications Setup controller', () => {
 
           expect(response.statusCode).to.equal(302)
           expect(response.headers.location).to.equal(`/system/notifications/setup/${session.id}/returns-period`)
+        })
+      })
+    })
+  })
+
+  describe('notifications/setup/download', () => {
+    describe('GET', () => {
+      beforeEach(async () => {
+        getOptions = {
+          method: 'GET',
+          url: basePath + `/${session.id}/download`,
+          auth: {
+            strategy: 'session',
+            credentials: { scope: ['returns'] }
+          }
+        }
+      })
+      describe('when a request is valid', () => {
+        beforeEach(async () => {
+          Sinon.stub(InitiateSessionService, 'go').resolves(session)
+          Sinon.stub(DownloadRecipientsService, 'go').returns({ data: 'test', type: 'type/csv', filename: 'test.csv' })
+        })
+
+        it('returns the file successfully', async () => {
+          const response = await server.inject(getOptions)
+
+          expect(response.statusCode).to.equal(200)
+          expect(response.headers['content-type']).to.equal('type/csv')
+          expect(response.headers['content-disposition']).to.equal('attachment; filename="test.csv"')
+          expect(response.payload).to.equal('test')
         })
       })
     })

--- a/test/services/notifications/setup/download-recipients.service.test.js
+++ b/test/services/notifications/setup/download-recipients.service.test.js
@@ -16,7 +16,7 @@ const DownloadRecipientsService = require('../../../../app/services/notification
 describe('Notifications Setup - Download recipients service', () => {
   const referenceCode = 'RINV-00R1MQ'
 
-  let session  
+  let session
 
   before(async () => {
     session = await SessionHelper.add({

--- a/test/services/notifications/setup/download-recipients.service.test.js
+++ b/test/services/notifications/setup/download-recipients.service.test.js
@@ -14,8 +14,9 @@ const SessionHelper = require('../../../support/helpers/session.helper.js')
 const DownloadRecipientsService = require('../../../../app/services/notifications/setup/download-recipients.service.js')
 
 describe('Notifications Setup - Download recipients service', () => {
-  let session
   const referenceCode = 'RINV-00R1MQ'
+
+  let session  
 
   before(async () => {
     session = await SessionHelper.add({

--- a/test/services/notifications/setup/download-recipients.service.test.js
+++ b/test/services/notifications/setup/download-recipients.service.test.js
@@ -1,0 +1,25 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Thing under test
+const DownloadRecipientsService = require('../../../../app/services/notifications/setup/download-recipients.service.js')
+
+describe('Notifications Setup - Download recipients service', () => {
+  describe('when provided with "recipients"', () => {
+    it('correctly returns the csv string, filename and type', async () => {
+      const result = await DownloadRecipientsService.go()
+
+      expect(result).to.equal({
+        data: 'Licences\n12234\n',
+        filename: 'recipients.csv',
+        type: 'text/csv'
+      })
+    })
+  })
+})

--- a/test/services/notifications/setup/download-recipients.service.test.js
+++ b/test/services/notifications/setup/download-recipients.service.test.js
@@ -11,15 +11,13 @@ const { expect } = Code
 const DownloadRecipientsService = require('../../../../app/services/notifications/setup/download-recipients.service.js')
 
 describe('Notifications Setup - Download recipients service', () => {
-  describe('when provided with "recipients"', () => {
-    it('correctly returns the csv string, filename and type', async () => {
-      const result = await DownloadRecipientsService.go()
+  it('correctly returns the csv string, filename and type', async () => {
+    const result = await DownloadRecipientsService.go()
 
-      expect(result).to.equal({
-        data: 'Licences\n12234\n',
-        filename: 'recipients.csv',
-        type: 'text/csv'
-      })
+    expect(result).to.equal({
+      data: 'Licences\n12234\n',
+      filename: 'recipients.csv',
+      type: 'text/csv'
     })
   })
 })

--- a/test/services/notifications/setup/download-recipients.service.test.js
+++ b/test/services/notifications/setup/download-recipients.service.test.js
@@ -4,19 +4,31 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it } = (exports.lab = Lab.script())
+const { describe, it, before } = (exports.lab = Lab.script())
 const { expect } = Code
+
+// Test helpers
+const SessionHelper = require('../../../support/helpers/session.helper.js')
 
 // Thing under test
 const DownloadRecipientsService = require('../../../../app/services/notifications/setup/download-recipients.service.js')
 
 describe('Notifications Setup - Download recipients service', () => {
+  let session
+  const referenceCode = 'RINV-00R1MQ'
+
+  before(async () => {
+    session = await SessionHelper.add({
+      data: { returnsPeriod: 'quarterFour', referenceCode, notificationType: 'Returns invitation' }
+    })
+  })
+
   it('correctly returns the csv string, filename and type', async () => {
-    const result = await DownloadRecipientsService.go()
+    const result = await DownloadRecipientsService.go(session.id)
 
     expect(result).to.equal({
       data: 'Licences\n12234\n',
-      filename: 'recipients.csv',
+      filename: `Returns invitation - ${referenceCode}.csv`,
       type: 'text/csv'
     })
   })

--- a/test/services/notifications/setup/initiate-session.service.test.js
+++ b/test/services/notifications/setup/initiate-session.service.test.js
@@ -15,12 +15,26 @@ const InitiateSessionService = require('../../../../app/services/notifications/s
 
 describe('Notifications Setup - Initiate Session service', () => {
   describe('when called', () => {
-    it('creates a new session record with an empty data property', async () => {
+    it('creates a new session record', async () => {
       const result = await InitiateSessionService.go()
 
       const matchingSession = await SessionModel.query().findById(result.id)
 
-      expect(matchingSession.data).to.equal({})
+      expect(matchingSession.data).to.equal({
+        notificationType: 'Returns invitation',
+        referenceCode: matchingSession.referenceCode // randomly generated
+      })
+    })
+
+    describe('the "referenceCode" property', () => {
+      it('returns a reference code for an "invitation" notification', async () => {
+        const result = await InitiateSessionService.go()
+
+        const matchingSession = await SessionModel.query().findById(result.id)
+
+        expect(matchingSession.referenceCode).to.include('RINV-')
+        expect(matchingSession.referenceCode.length).to.equal(11)
+      })
     })
   })
 })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4776

As part of the work to implement notifications in the system repo we have a requirement to download the recipients data as a CSV.

This change adds the controller, service and route for the notifications download link.

This is the plumbing before adding the presenter and joining the fetch service in.