### PR TITLE
Fix return logs setup single volume validation

### DIFF
--- a/app/validators/return-logs/setup/single-volume.validator.js
+++ b/app/validators/return-logs/setup/single-volume.validator.js
@@ -30,12 +30,12 @@ function go(payload) {
         'any.only': singleVolumeError,
         'string.empty': singleVolumeError
       }),
-    singleVolumeQuantity: Joi.number().min(1).when('singleVolume', { is: 'yes', then: Joi.required() }).messages({
+    singleVolumeQuantity: Joi.number().positive().when('singleVolume', { is: 'yes', then: Joi.required() }).messages({
       'any.required': singleVolumeQuantityError,
       'number.base': singleVolumeQuantityError,
-      'number.min': singleVolumeQuantityError,
       'number.max': singleVolumeQuantityError,
-      'number.unsafe': singleVolumeQuantityError
+      'number.unsafe': singleVolumeQuantityError,
+      'number.positive': singleVolumeQuantityError
     })
   })
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4852

While testing for the above ticket, it was noticed that the single volume page didn't allow a user to enter a number less than 1 and validate it. If a user enters 0.5, then this should be accepted. This PR updates the validation to only allow positive numbers, thus removing the need for a min volume. 