### PR TITLE
Add remove licences page for notifications setup

### DIFF
--- a/app/controllers/notifications-setup.controller.js
+++ b/app/controllers/notifications-setup.controller.js
@@ -7,6 +7,7 @@
 
 const DownloadRecipientsService = require('../services/notifications/setup/download-recipients.service.js')
 const InitiateSessionService = require('../services/notifications/setup/initiate-session.service.js')
+const RemoveLicencesService = require('../services/notifications/setup/remove-licences.service.js')
 const ReturnsPeriodService = require('../services/notifications/setup/returns-period.service.js')
 const ReviewService = require('../services/notifications/setup/review.service.js')
 const SubmitReturnsPeriodService = require('../services/notifications/setup/submit-returns-period.service.js')
@@ -26,6 +27,16 @@ async function downloadRecipients(request, h) {
     .encoding('binary')
     .header('Content-Type', type)
     .header('Content-Disposition', `attachment; filename="${filename}"`)
+}
+
+async function viewRemoveLicences(request, h) {
+  const {
+    params: { sessionId }
+  } = request
+
+  const pageData = await RemoveLicencesService.go(sessionId)
+
+  return h.view(`${basePath}/remove-licences.njk`, pageData)
 }
 
 async function viewReturnsPeriod(request, h) {
@@ -72,6 +83,7 @@ async function submitReturnsPeriod(request, h) {
 
 module.exports = {
   downloadRecipients,
+  viewRemoveLicences,
   viewReturnsPeriod,
   viewReview,
   setup,

--- a/app/presenters/notifications/setup/remove-licences.presenter.js
+++ b/app/presenters/notifications/setup/remove-licences.presenter.js
@@ -1,0 +1,25 @@
+'use strict'
+
+/**
+ * Formats data for the `/notifications/setup/remove-licences` page
+ * @module RemoveLicencesPresenter
+ */
+
+/**
+ * Formats data for the `/notifications/setup/remove-licences` page
+ *
+ * @param {string[]} licences - List of licences to remove from the recipients list
+ *
+ * @returns {object} - The data formatted for the view template
+ */
+function go(licences) {
+  return {
+    pageTitle: 'Enter the licence numbers to remove from the mailing list',
+    hint: 'Separate the licences numbers with a comma or new line.',
+    licences
+  }
+}
+
+module.exports = {
+  go
+}

--- a/app/presenters/notifications/setup/review.presenter.js
+++ b/app/presenters/notifications/setup/review.presenter.js
@@ -25,7 +25,8 @@ function go(recipients, page, pagination, sessionId) {
     recipients: _recipients(recipients, page),
     recipientsAmount: recipients.length,
     links: {
-      download: `/system/notifications/setup/${sessionId}/download`
+      download: `/system/notifications/setup/${sessionId}/download`,
+      removeLicences: `/system/notifications/setup/${sessionId}/remove-licences`
     }
   }
 }

--- a/app/routes/notifications-setup.routes.js
+++ b/app/routes/notifications-setup.routes.js
@@ -43,6 +43,18 @@ const routes = [
   },
   {
     method: 'GET',
+    path: basePath + '/{sessionId}/remove-licences',
+    options: {
+      handler: NotificationsSetupController.viewRemoveLicences,
+      auth: {
+        access: {
+          scope: ['returns']
+        }
+      }
+    }
+  },
+  {
+    method: 'GET',
     path: basePath + '/{sessionId}/review',
     options: {
       handler: NotificationsSetupController.viewReview,

--- a/app/services/notifications/setup/remove-licences.service.js
+++ b/app/services/notifications/setup/remove-licences.service.js
@@ -1,0 +1,33 @@
+'use strict'
+
+/**
+ * Orchestrates fetching and presenting the licences to remove for the notifications setup remove licences page
+ * @module RemoveLicencesService
+ */
+
+const RemoveLicencesPresenter = require('../../../presenters/notifications/setup/remove-licences.presenter.js')
+const SessionModel = require('../../../models/session.model.js')
+
+/**
+ * Orchestrates fetching and presenting the licences to remove for the notifications setup remove licences page
+ *
+ * @param {string} sessionId - The UUID for setup ad-hoc returns notification session record
+ *
+ * @returns {object} The view data for the remove licences page
+ */
+async function go(sessionId) {
+  const session = await SessionModel.query().findById(sessionId)
+
+  const { licencesToRemove = [] } = session
+
+  const formattedData = RemoveLicencesPresenter.go(licencesToRemove)
+
+  return {
+    activeNavBar: 'manage',
+    ...formattedData
+  }
+}
+
+module.exports = {
+  go
+}

--- a/app/views/notifications/setup/remove-licences.njk
+++ b/app/views/notifications/setup/remove-licences.njk
@@ -1,0 +1,39 @@
+{% extends 'layout.njk' %}
+{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from 'govuk/components/error-summary/macro.njk' import govukErrorSummary %}
+
+{% block breadcrumbs %}
+  {{ govukBackLink({
+    text: 'Back',
+    href: "review"
+  }) }}
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-body">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-three-quarters">
+        <form method="post">
+          <input type="hidden" name="wrlsCrumb" value="{{ wrlsCrumb }}" />
+
+          {{ govukTextarea({
+            name: "licences",
+            id: "remove-licences",
+            label: {
+              text: pageTitle,
+              classes: "govuk-label--l",
+              isPageHeading: true
+            },
+            hint: {
+              text: hint
+            }
+          }) }}
+
+          {{ govukButton({ text: "Continue", preventDoubleClick: true }) }}
+        </form>
+      </div>
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/notifications/setup/review.njk
+++ b/app/views/notifications/setup/review.njk
@@ -61,7 +61,9 @@
 
       {{ govukButton({
         text: "Remove licences",
-        classes: "govuk-button--secondary"
+        classes: "govuk-button--secondary",
+        href: links.removeLicences,
+        preventDoubleClick: true
       }) }}
     </div>
 

--- a/test/controllers/notifications-setup.controller.test.js
+++ b/test/controllers/notifications-setup.controller.test.js
@@ -13,6 +13,7 @@ const { postRequestOptions } = require('../support/general.js')
 // Things we need to stub
 const DownloadRecipientsService = require('../../app/services/notifications/setup/download-recipients.service.js')
 const InitiateSessionService = require('../../app/services/notifications/setup/initiate-session.service.js')
+const RemoveLicencesService = require('../../app/services/notifications/setup/remove-licences.service.js')
 const ReturnsPeriodService = require('../../app/services/notifications/setup/returns-period.service.js')
 const ReviewService = require('../../app/services/notifications/setup/review.service.js')
 const SubmitReturnsPeriodService = require('../../app/services/notifications/setup/submit-returns-period.service.js')
@@ -99,6 +100,38 @@ describe('Notifications Setup controller', () => {
           expect(response.headers['content-type']).to.equal('type/csv')
           expect(response.headers['content-disposition']).to.equal('attachment; filename="test.csv"')
           expect(response.payload).to.equal('test')
+        })
+      })
+    })
+  })
+
+  describe('notifications/setup/remove-licences', () => {
+    describe('GET', () => {
+      beforeEach(async () => {
+        getOptions = {
+          method: 'GET',
+          url: basePath + `/${session.id}/remove-licences`,
+          auth: {
+            strategy: 'session',
+            credentials: { scope: ['returns'] }
+          }
+        }
+      })
+
+      describe('when a request is valid', () => {
+        beforeEach(async () => {
+          Sinon.stub(InitiateSessionService, 'go').resolves(session)
+          Sinon.stub(RemoveLicencesService, 'go').returns(_viewRemoveLicence())
+        })
+
+        it('returns the page successfully', async () => {
+          const response = await server.inject(getOptions)
+
+          const pageData = _viewRemoveLicence()
+
+          expect(response.statusCode).to.equal(200)
+          expect(response.payload).to.contain(pageData.activeNavBar)
+          expect(response.payload).to.contain(pageData.pageTitle)
         })
       })
     })
@@ -209,6 +242,14 @@ function _viewReturnsPeriod() {
     backLink: '/manage',
     activeNavBar: 'manage',
     returnsPeriod: []
+  }
+}
+
+function _viewRemoveLicence() {
+  return {
+    pageTitle: 'Remove licences',
+    hint: 'hint to remove',
+    activeNavBar: 'manage'
   }
 }
 

--- a/test/presenters/notifications/setup/remove-licences.presenter.test.js
+++ b/test/presenters/notifications/setup/remove-licences.presenter.test.js
@@ -1,0 +1,25 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Thing under test
+const RemoveLicencesPresenter = require('../../../../app/presenters/notifications/setup/remove-licences.presenter.js')
+
+describe('Notifications Setup - Remove licences presenter', () => {
+  const licences = []
+
+  it('correctly presents the data', () => {
+    const result = RemoveLicencesPresenter.go(licences)
+
+    expect(result).to.equal({
+      hint: 'Separate the licences numbers with a comma or new line.',
+      pageTitle: 'Enter the licence numbers to remove from the mailing list',
+      licences: []
+    })
+  })
+})

--- a/test/presenters/notifications/setup/review.presenter.test.js
+++ b/test/presenters/notifications/setup/review.presenter.test.js
@@ -53,7 +53,8 @@ describe('Notifications Setup - Review presenter', () => {
       expect(result).to.equal({
         defaultPageSize: 25,
         links: {
-          download: `/system/notifications/setup/${sessionId}/download`
+          download: `/system/notifications/setup/${sessionId}/download`,
+          removeLicences: `/system/notifications/setup/${sessionId}/remove-licences`
         },
         pageTitle: 'Send returns invitations',
         recipients: [

--- a/test/services/notifications/setup/remove-licences.service.test.js
+++ b/test/services/notifications/setup/remove-licences.service.test.js
@@ -1,0 +1,35 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Test helpers
+const SessionHelper = require('../../../support/helpers/session.helper.js')
+
+// Thing under test
+const RemoveLicencesService = require('../../../../app/services/notifications/setup/remove-licences.service.js')
+
+describe('Notifications Setup - Remove licences service', () => {
+  const licences = []
+
+  let session
+
+  beforeEach(async () => {
+    session = await SessionHelper.add({ data: { licences } })
+  })
+
+  it('correctly presents the data', async () => {
+    const result = await RemoveLicencesService.go(session.id)
+
+    expect(result).to.equal({
+      activeNavBar: 'manage',
+      hint: 'Separate the licences numbers with a comma or new line.',
+      pageTitle: 'Enter the licence numbers to remove from the mailing list',
+      licences: []
+    })
+  })
+})

--- a/test/services/notifications/setup/review.service.test.js
+++ b/test/services/notifications/setup/review.service.test.js
@@ -44,7 +44,8 @@ describe('Notifications Setup - Review service', () => {
       activeNavBar: 'manage',
       defaultPageSize: 25,
       links: {
-        download: `/system/notifications/setup/${session.id}/download`
+        download: `/system/notifications/setup/${session.id}/download`,
+        removeLicences: `/system/notifications/setup/${session.id}/remove-licences`
       },
       pageTitle: 'Send returns invitations',
       page: 1,


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4777

As part of the work to implement notifications in the system repo we have a requirement allow the user to remove licences from teh recipients list.

This change adds the view element of the remove-licences page. It adds the controller, presenter and service to display the remove-licences page.

The submit and re-render logic will be done in a later change.