### PR TITLE
Add remove licences from notification queries

### DIFF
--- a/app/services/notifications/setup/download-recipients.service.js
+++ b/app/services/notifications/setup/download-recipients.service.js
@@ -28,7 +28,8 @@ async function go(sessionId) {
 
   const recipients = await FetchDownloadRecipientsService.go(
     determinedReturnsPeriod.returnsPeriod.dueDate,
-    determinedReturnsPeriod.summer
+    determinedReturnsPeriod.summer,
+    session.removeLicences
   )
 
   const formattedData = DownloadRecipientsPresenter.go(recipients)

--- a/app/services/notifications/setup/review.service.js
+++ b/app/services/notifications/setup/review.service.js
@@ -25,7 +25,7 @@ async function go(sessionId, page = 1) {
 
   const { returnsPeriod, summer } = DetermineReturnsPeriodService.go(session.returnsPeriod)
 
-  const recipientsData = await RecipientsService.go(returnsPeriod.dueDate, summer)
+  const recipientsData = await RecipientsService.go(returnsPeriod.dueDate, summer, session.removeLicences)
 
   const recipients = DetermineRecipientsService.go(recipientsData)
 

--- a/app/services/notifications/setup/submit-remove-licences.service.js
+++ b/app/services/notifications/setup/submit-remove-licences.service.js
@@ -40,7 +40,10 @@ async function go(sessionId, payload) {
 }
 
 async function _save(session, payload) {
-  session.removeLicences = [payload.removeLicences]
+  session.removeLicences = payload.removeLicences
+    .replace(/\n/g, ' ') // Replace newlines with spaces
+    .split(/[\s,]+/) // Split by spaces, multiple spaces, or commas
+    .filter((item) => item !== '') // Remove empty strings if any
 
   return session.$update()
 }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4777

As part of the work to implement notifications in the system repo we have a requirement allow the user to remove licences from teh recipients list.

This change adds the functionality to exclude licences from the fetch recipients and fetch download recipients service queries.