### PR TITLE
Add remove licences from notification validation

### DIFF
--- a/app/validators/notifications/setup/remove-licences.validator.js
+++ b/app/validators/notifications/setup/remove-licences.validator.js
@@ -7,7 +7,12 @@
 
 const Joi = require('joi')
 
-const errorMessage = 'Please enter a licence number'
+const errorMessage = 'Separate the licence numbers with a comma or new line'
+// Regex to check the overall format: license numbers separated by commas or newlines
+// (with flexible spacing), but not adjacent separators.
+const formatRegex = /^\s*([^\s,]+(?:(?:\s*,\s*|\s*\n\s*)[^\s,]+)*)\s*$/
+// Regex to specifically check for adjacent commas and newlines (e.g., ",\n" or "\n,").
+const adjacentRegex = /(?:,\s*\n)|(?:\n\s*,)/
 
 /**
  * Validates data submitted for the `/notifications/setup/remove-licences` page
@@ -19,11 +24,17 @@ const errorMessage = 'Please enter a licence number'
  */
 function go(payload) {
   const schema = Joi.object({
-    removeLicences: Joi.string().required().messages({
-      'any.required': errorMessage,
-      'any.only': errorMessage,
-      'string.empty': errorMessage
-    })
+    removeLicences: Joi.string()
+      .allow('')
+      .custom((value, helpers) => {
+        if (!value) return value // Allow empty string
+
+        if (!formatRegex.test(value) || adjacentRegex.test(value)) {
+          return helpers.message(errorMessage)
+        }
+
+        return value
+      }, 'Licence Validation')
   })
 
   return schema.validate(payload, { abortEarly: false })

--- a/test/services/notifications/setup/submit-remove-licences.services.test.js
+++ b/test/services/notifications/setup/submit-remove-licences.services.test.js
@@ -45,7 +45,7 @@ describe('Notifications Setup - Submit Remove licences service', () => {
     describe('fails validation', () => {
       beforeEach(async () => {
         session = await SessionHelper.add()
-        payload = {}
+        payload = { removeLicences: '1234 567' }
       })
 
       it('correctly presents the data with the error', async () => {
@@ -54,10 +54,10 @@ describe('Notifications Setup - Submit Remove licences service', () => {
         expect(result).to.equal({
           activeNavBar: 'manage',
           error: {
-            text: 'Please enter a licence number'
+            text: 'Separate the licence numbers with a comma or new line'
           },
           hint: 'Separate the licences numbers with a comma or new line.',
-          removeLicences: undefined,
+          removeLicences: '1234 567',
           pageTitle: 'Enter the licence numbers to remove from the mailing list'
         })
       })

--- a/test/validators/notifications/setup/remove-licences.validator.test.js
+++ b/test/validators/notifications/setup/remove-licences.validator.test.js
@@ -12,22 +12,74 @@ const RemoveLicencesValidator = require('../../../../app/validators/notification
 
 describe('Notifications Setup - Remove licences validator', () => {
   describe('when valid data is provided', () => {
-    it('confirms the data is valid', () => {
-      const result = RemoveLicencesValidator.go({ removeLicences: '123/67' })
+    describe('and there is one licence provided', () => {
+      it('confirms the data is valid', () => {
+        const result = RemoveLicencesValidator.go({ removeLicences: '123/67' })
 
-      expect(result.value).to.exist()
-      expect(result.error).not.to.exist()
+        expect(result.value).to.exist()
+        expect(result.error).not.to.exist()
+      })
+    })
+
+    describe('and there is more than one licence provided', () => {
+      describe('and the licences are seperated by a ","', () => {
+        it('confirms the data is valid', () => {
+          const result = RemoveLicencesValidator.go({ removeLicences: '123/67, 456, 78*9' })
+
+          expect(result.value).to.exist()
+          expect(result.error).not.to.exist()
+        })
+      })
+
+      describe('and the licences are separated by a "\\n"', () => {
+        it('confirms the data is valid', () => {
+          const result = RemoveLicencesValidator.go({ removeLicences: '123/67\n456  \n789' })
+
+          expect(result.value).to.exist()
+          expect(result.error).not.to.exist()
+        })
+      })
+
+      describe('and the licences are seperated by a "," or "\\n"', () => {
+        it('confirms the data is valid', () => {
+          const result = RemoveLicencesValidator.go({ removeLicences: '123/67, 456 \n789' })
+
+          expect(result.value).to.exist()
+          expect(result.error).not.to.exist()
+        })
+      })
     })
   })
 
   describe('when invalid data is provided', () => {
-    describe('because no "removeLicences" is given', () => {
+    describe('because the licences are seperated by a " " (space)', () => {
       it('fails validation', () => {
-        const result = RemoveLicencesValidator.go({ removeLicences: '' })
+        const result = RemoveLicencesValidator.go({ removeLicences: '123 456' })
 
         expect(result.value).to.exist()
         expect(result.error).to.exist()
-        expect(result.error.details[0].message).to.equal('Please enter a licence number')
+        expect(result.error.details[0].message).to.equal('Separate the licence numbers with a comma or new line')
+      })
+    })
+
+    describe('because the licences are seperated by a "," and "\\n" (e.g., ",\\n" or "\\n,")', () => {
+      it('fails validation', () => {
+        const result = RemoveLicencesValidator.go({ removeLicences: '123,\n456' })
+
+        expect(result.value).to.exist()
+        expect(result.error).to.exist()
+        expect(result.error.details[0].message).to.equal('Separate the licence numbers with a comma or new line')
+      })
+    })
+  })
+
+  describe('when no data is provided', () => {
+    describe('and no licences are given', () => {
+      it('passes validation', () => {
+        const result = RemoveLicencesValidator.go({ removeLicences: '' })
+
+        expect(result.value).to.exist()
+        expect(result.error).not.to.exist()
       })
     })
   })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4777

As part of the work to implement notifications in the system repo we have a requirement allow the user to remove licences from teh recipients list.

This change updates the validation for the remove licences page. The user should be allowed to remove all the licences. In case they have made a mistake and do not need to remove any licences.

The validation should only allow licences seperated by a comma or a new line.