### PR TITLE
Updated notification remove licences page

### DIFF
--- a/app/views/notifications/setup/remove-licences.njk
+++ b/app/views/notifications/setup/remove-licences.njk
@@ -43,6 +43,8 @@
         value: removeLicences
       }) }}
 
+      <p class="govuk-body">This will assemble the mailing list. It will not send the letters yet.</p>
+
       {{ govukButton({ text: "Continue", preventDoubleClick: true }) }}
     </form>
   </div>


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4777

As part of the work to implement notifications in the system repo we have a requirement allow the user to remove licences from the recipients list.

This change updates the notifications remove licence page to include additional body text letting the user know the