### PR TITLE
Updated notifications setup query string

### DIFF
--- a/app/controllers/notifications-setup.controller.js
+++ b/app/controllers/notifications-setup.controller.js
@@ -62,9 +62,9 @@ async function viewReview(request, h) {
 }
 
 async function setup(request, h) {
-  const { notification } = request.query
+  const { journey } = request.query
 
-  const { sessionId, path } = await InitiateSessionService.go(notification)
+  const { sessionId, path } = await InitiateSessionService.go(journey)
 
   return h.redirect(`/system/${basePath}/${sessionId}/${path}`)
 }

--- a/test/controllers/notifications-setup.controller.test.js
+++ b/test/controllers/notifications-setup.controller.test.js
@@ -56,7 +56,7 @@ describe('Notifications Setup controller', () => {
         beforeEach(async () => {
           getOptions = {
             method: 'GET',
-            url: '/notifications/setup?notification=invitations',
+            url: '/notifications/setup?journey=invitations',
             auth: {
               strategy: 'session',
               credentials: { scope: ['returns'] }
@@ -84,7 +84,7 @@ describe('Notifications Setup controller', () => {
         beforeEach(async () => {
           getOptions = {
             method: 'GET',
-            url: '/notifications/setup?notification=ad-hoc',
+            url: '/notifications/setup?journey=ad-hoc',
             auth: {
               strategy: 'session',
               credentials: { scope: ['returns'] }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4899

This change updates the notifications setup expected query string to 'journey' to align with the changes made in he water-abstraction-ui.