### PR TITLE
Add notifications setup ad hoc licence fetch

### DIFF
--- a/app/services/notifications/setup/fetch-download-recipients.service.js
+++ b/app/services/notifications/setup/fetch-download-recipients.service.js
@@ -56,11 +56,11 @@ const { transformStringOfLicencesToArray } = require('../../../lib/general.lib.j
  * @returns {Promise<object[]>} - matching recipients
  */
 async function go(session) {
-  if (session.journey !== 'ad-hoc') {
-    return _fetchRecipients(session)
+  if (session.journey === 'ad-hoc') {
+    return _fetchRecipient(session)
   }
 
-  return _fetchRecipient(session)
+  return _fetchRecipients(session)
 }
 
 async function _fetchRecipient(session) {

--- a/app/services/notifications/setup/fetch-download-recipients.service.js
+++ b/app/services/notifications/setup/fetch-download-recipients.service.js
@@ -22,9 +22,9 @@ const { transformStringOfLicencesToArray } = require('../../../lib/general.lib.j
  * based on a 'licenceRef'. And the other is for any journey that needs multiple recipients based on the selected
  * returns period.
  *
- * For the 'ad-hoc' journey we determine the recipients from the returns logs based on the provided 'licenceRe'.
+ * For the 'ad-hoc' journey we determine the recipients from the returns logs based on the provided 'licenceRef'.
  *
- * For the 'ad-hoc' journey we start by determining which licence we need to send a notifications for, by
+ * We start by determining which licence we need to send notifications for, by
  * looking for return logs with a matching 'licenceRef' the user has entered.
  *
  * For each licence linked to one of these return logs, we extract the contact information. This is complicated by a

--- a/app/services/notifications/setup/fetch-download-recipients.service.js
+++ b/app/services/notifications/setup/fetch-download-recipients.service.js
@@ -66,7 +66,9 @@ async function go(session) {
 async function _fetchRecipient(session) {
   const { licenceRef } = session
 
-  const where = 'AND ldh.licence_ref = ?'
+  const where = `
+    AND ldh.licence_ref = ?
+  `
 
   const bindings = [licenceRef, licenceRef]
 
@@ -82,7 +84,11 @@ async function _fetchRecipients(session) {
 
   const dueDate = returnsPeriod.dueDate
 
-  const where = "AND rl.due_date = ?\n    AND rl.metadata->>'isSummer' = ?\n    AND NOT (ldh.licence_ref = ANY (?))"
+  const where = `
+    AND rl.due_date = ?
+    AND rl.metadata->>'isSummer' = ?
+    AND NOT (ldh.licence_ref = ANY (?))
+  `
 
   const bindings = [dueDate, summer, removeLicences, dueDate, summer, removeLicences]
 

--- a/app/services/notifications/setup/fetch-download-recipients.service.js
+++ b/app/services/notifications/setup/fetch-download-recipients.service.js
@@ -18,8 +18,14 @@ const { transformStringOfLicencesToArray } = require('../../../lib/general.lib.j
  * Our overall goal is that a 'recipient' receives only one notification, irrespective of how many licences they are
  * linked to, or what roles they have.
  *
- * We start by determining which licences we need to send notifications for, by looking for 'due' return logs with a
- * matching 'due date' and cycle (summer or winter and all year).
+ * We have two mechanisms for returning a recipient. One is for the 'ad-hoc' journey which is for an individual licence
+ * based on a 'licenceRef'. And the other is for any journey that needs multiple recipients based on the selected
+ * returns period.
+ *
+ * For the 'ad-hoc' journey we determine the recipients from the returns logs based on the provided 'licenceRe'.
+ *
+ * For the 'ad-hoc' journey we start by determining which licence we need to send a notifications for, by
+ * looking for return logs with a matching 'licenceRef' the user has entered.
  *
  * For each licence linked to one of these return logs, we extract the contact information. This is complicated by a
  * number of factors.

--- a/app/services/notifications/setup/fetch-recipients.service.js
+++ b/app/services/notifications/setup/fetch-recipients.service.js
@@ -151,32 +151,48 @@ const { transformStringOfLicencesToArray } = require('../../../lib/general.lib.j
  * @returns {Promise<object[]>} The contact data for all the outstanding return logs
  */
 async function go(session) {
-  const { returnsPeriod, summer } = DetermineReturnsPeriodService.go(session.returnsPeriod)
+  if (session.journey !== 'ad-hoc') {
+    return _fetchRecipients(session)
+  }
 
-  const removeLicences = transformStringOfLicencesToArray(session.removeLicences)
+  return _fetchRecipient(session)
+}
 
-  const { rows } = await _fetch(returnsPeriod.dueDate, summer, removeLicences)
+async function _fetchRecipient(session) {
+  const { licenceRef } = session
+
+  const where = 'AND ldh.licence_ref = ?'
+
+  const bindings = [licenceRef, licenceRef, licenceRef]
+
+  const { rows } = await _fetch(bindings, where)
 
   return rows
 }
 
-async function _fetch(dueDate, summer, removeLicences) {
-  const query = _query()
+async function _fetchRecipients(session) {
+  const { returnsPeriod, summer } = DetermineReturnsPeriodService.go(session.returnsPeriod)
 
-  return db.raw(query, [
-    dueDate,
-    summer,
-    removeLicences,
-    dueDate,
-    summer,
-    removeLicences,
-    dueDate,
-    summer,
-    removeLicences
-  ])
+  const removeLicences = transformStringOfLicencesToArray(session.removeLicences)
+
+  const dueDate = returnsPeriod.dueDate
+
+  const where = "AND rl.due_date = ?\n    AND rl.metadata->>'isSummer' = ?\n    AND NOT (ldh.licence_ref = ANY (?))"
+
+  const bindings = [dueDate, summer, removeLicences, dueDate, summer, removeLicences, dueDate, summer, removeLicences]
+
+  const { rows } = await _fetch(bindings, where)
+
+  return rows
 }
 
-function _query() {
+async function _fetch(bindings, where) {
+  const query = _query(where)
+
+  return db.raw(query, bindings)
+}
+
+function _query(additionalWhereClause) {
   return `SELECT
   string_agg(licence_ref, ',' ORDER BY licence_ref) AS licence_refs,
   contact_type,
@@ -200,9 +216,8 @@ FROM (
   INNER JOIN LATERAL jsonb_array_elements(ldh.metadata -> 'contacts') AS contacts ON true
   WHERE
     rl.status = 'due'
-    AND rl.due_date = ?
     AND rl.metadata->>'isCurrent' = 'true'
-    AND rl.metadata->>'isSummer' = ?
+    ${additionalWhereClause}
     AND contacts->>'role' IN ('Licence holder', 'Returns to')
     AND NOT EXISTS (
       SELECT
@@ -212,7 +227,6 @@ FROM (
         ler.company_entity_id = ldh.company_entity_id
         AND ler."role" IN ('primary_user', 'user_returns')
     )
-    AND NOT (ldh.licence_ref = ANY (?))
   UNION ALL
   SELECT
     ldh.licence_ref,
@@ -229,10 +243,8 @@ FROM (
     ON rl.licence_ref = ldh.licence_ref
   WHERE
     rl.status = 'due'
-    AND rl.due_date = ?
     AND rl.metadata->>'isCurrent' = 'true'
-    AND rl.metadata->>'isSummer' = ?
-    AND NOT (ldh.licence_ref = ANY (?))
+    ${additionalWhereClause}
   UNION ALL
   SELECT
     ldh.licence_ref,
@@ -249,10 +261,8 @@ FROM (
     ON rl.licence_ref = ldh.licence_ref
   WHERE
     rl.status = 'due'
-    AND rl.due_date = ?
     AND rl.metadata->>'isCurrent' = 'true'
-    AND rl.metadata->>'isSummer' = ?
-    AND NOT (ldh.licence_ref = ANY (?))
+    ${additionalWhereClause}
 ) contacts
 GROUP BY
   contact_type,

--- a/app/services/notifications/setup/fetch-recipients.service.js
+++ b/app/services/notifications/setup/fetch-recipients.service.js
@@ -18,8 +18,17 @@ const { transformStringOfLicencesToArray } = require('../../../lib/general.lib.j
  * Our overall goal is that a 'recipient' receives only one notification, irrespective of how many licences they are
  * linked to, or what roles they have.
  *
- * We start by determining which licences we need to send notifications for, by looking for 'due' return logs with a
- * matching 'due date' and cycle (summer or winter and all year).
+ * We have two mechanisms for returning a recipient. One is for the 'ad-hoc' journey which is for an individual licence
+ * based on a 'licenceRef'. And the other is for any journey that needs multiple recipients based on the selected
+ * returns period.
+ *
+ * For the 'ad-hoc' journey we determine the recipients from the returns logs based on the provided 'licenceRe'.
+ *
+ * For the 'ad-hoc' journey we start by determining which licence we need to send a notifications for, by
+ * looking for return logs with a matching 'licenceRef' the user has entered.
+ *
+ * For the multiple recipients journey we start by determining which licences we need to send notifications for, by
+ * looking for 'due' return logs with a matching 'due date' and cycle (summer or winter and all year).
  *
  * For each licence linked to one of these return logs, we extract the contact information. This is complicated by a
  * number of factors.
@@ -97,7 +106,11 @@ const { transformStringOfLicencesToArray } = require('../../../lib/general.lib.j
  * Those contacts with the same hash ID that cannot be grouped, for example, because one has the `contact_type='Licence
  * holder'` and the other `contact_type='Returns to'` will be handled by `DetermineRecipientsService`.
  *
- * The end result is all the email, or letter contacts for each licence with a 'due' return for the period selected.
+ * For the 'ad-hoc' journey the end result is all the email, or letter contacts for that  licence with a 'due'
+ * return for any period.
+ *
+ * For the multiple recipient journeys the end result is all the email, or letter contacts for each licence with a 'due'
+ * return for the period selected.
  *
  * ```javascript
  * [
@@ -151,11 +164,11 @@ const { transformStringOfLicencesToArray } = require('../../../lib/general.lib.j
  * @returns {Promise<object[]>} The contact data for all the outstanding return logs
  */
 async function go(session) {
-  if (session.journey !== 'ad-hoc') {
-    return _fetchRecipients(session)
+  if (session.journey === 'ad-hoc') {
+    return _fetchRecipient(session)
   }
 
-  return _fetchRecipient(session)
+  return _fetchRecipients(session)
 }
 
 async function _fetchRecipient(session) {

--- a/app/services/notifications/setup/fetch-recipients.service.js
+++ b/app/services/notifications/setup/fetch-recipients.service.js
@@ -22,9 +22,9 @@ const { transformStringOfLicencesToArray } = require('../../../lib/general.lib.j
  * based on a 'licenceRef'. And the other is for any journey that needs multiple recipients based on the selected
  * returns period.
  *
- * For the 'ad-hoc' journey we determine the recipients from the returns logs based on the provided 'licenceRe'.
+ * For the 'ad-hoc' journey we determine the recipients from the returns logs based on the provided 'licenceRef'.
  *
- * For the 'ad-hoc' journey we start by determining which licence we need to send a notifications for, by
+ * We start by determining which licence we need to send notifications for, by
  * looking for return logs with a matching 'licenceRef' the user has entered.
  *
  * For the multiple recipients journey we start by determining which licences we need to send notifications for, by

--- a/app/services/notifications/setup/fetch-recipients.service.js
+++ b/app/services/notifications/setup/fetch-recipients.service.js
@@ -174,7 +174,9 @@ async function go(session) {
 async function _fetchRecipient(session) {
   const { licenceRef } = session
 
-  const where = 'AND ldh.licence_ref = ?'
+  const where = `
+    AND ldh.licence_ref = ?
+  `
 
   const bindings = [licenceRef, licenceRef, licenceRef]
 
@@ -190,8 +192,11 @@ async function _fetchRecipients(session) {
 
   const dueDate = returnsPeriod.dueDate
 
-  const where = "AND rl.due_date = ?\n    AND rl.metadata->>'isSummer' = ?\n    AND NOT (ldh.licence_ref = ANY (?))"
-
+  const where = `
+    AND rl.due_date = ?
+    AND rl.metadata->>'isSummer' = ?
+    AND NOT (ldh.licence_ref = ANY (?))
+  `
   const bindings = [dueDate, summer, removeLicences, dueDate, summer, removeLicences, dueDate, summer, removeLicences]
 
   const { rows } = await _fetch(bindings, where)

--- a/test/services/notifications/setup/fetch-download-recipients.service.test.js
+++ b/test/services/notifications/setup/fetch-download-recipients.service.test.js
@@ -29,9 +29,6 @@ describe('Notifications Setup - Fetch Download Recipients service', () => {
     clock = Sinon.useFakeTimers(new Date(`${year}-01-01`))
 
     dueDate = `${year}-04-28` // This needs to differ from any other returns log tests
-    removeLicences = ''
-
-    session = { returnsPeriod: 'quarterFour', removeLicences }
 
     testRecipients = await LicenceDocumentHeaderSeeder.seed(true, dueDate)
   })
@@ -40,145 +37,303 @@ describe('Notifications Setup - Fetch Download Recipients service', () => {
     clock.restore()
   })
 
-  describe('when there are recipients', () => {
-    it('correctly returns "Primary user" and "Returns agent" contacts', async () => {
-      const result = await FetchDownloadRecipientsService.go(session)
+  describe('when the "journey" is for notifications', () => {
+    beforeEach(() => {
+      removeLicences = ''
 
-      const primaryUser = result.find((item) => item.contact_type === 'Primary user')
-      const returnsAgent = result.find((item) => item.contact_type === 'Returns agent')
-
-      expect(primaryUser).to.equal({
-        contact: null,
-        contact_type: 'Primary user',
-        due_date: new Date(dueDate),
-        email: 'primary.user@important.com',
-        end_date: endDate,
-        licence_ref: testRecipients.primaryUser.licenceRef,
-        return_reference: testRecipients.primaryUser.returnLog.returnReference,
-        start_date: startDate
-      })
-
-      expect(returnsAgent).to.equal({
-        contact: null,
-        contact_type: 'Returns agent',
-        due_date: new Date(dueDate),
-        email: 'returns.agent@important.com',
-        end_date: endDate,
-        licence_ref: testRecipients.primaryUser.licenceRef,
-        return_reference: testRecipients.primaryUser.returnLog.returnReference,
-        start_date: startDate
-      })
+      session = { journey: 'notifications', returnsPeriod: 'quarterFour', removeLicences }
     })
 
-    it('correctly returns "Licence holder" contact', async () => {
-      const result = await FetchDownloadRecipientsService.go(session)
+    describe('when there are recipients', () => {
+      describe('when there is a "primary user"', () => {
+        it('correctly returns "Primary user" and "Returns agent" contacts', async () => {
+          const result = await FetchDownloadRecipientsService.go(session)
 
-      const found = result.filter((item) => item.licence_ref === testRecipients.licenceHolder.licenceRef)
+          const primaryUser = result.find((item) => item.contact_type === 'Primary user')
+          const returnsAgent = result.find((item) => item.contact_type === 'Returns agent')
 
-      expect(found).to.equal([
-        {
-          contact: {
-            addressLine1: '4',
-            addressLine2: 'Privet Drive',
-            addressLine3: null,
-            addressLine4: null,
-            country: null,
-            county: 'Surrey',
-            forename: 'Harry',
-            initials: 'J',
-            name: 'Licence holder only',
-            postcode: 'WD25 7LR',
-            role: 'Licence holder',
-            salutation: null,
-            town: 'Little Whinging',
-            type: 'Person'
-          },
-          contact_type: 'Licence holder',
-          due_date: new Date(dueDate),
-          email: null,
-          end_date: endDate,
-          licence_ref: testRecipients.licenceHolder.licenceRef,
-          return_reference: testRecipients.licenceHolder.returnLog.returnReference,
-          start_date: startDate
-        }
-      ])
-    })
+          expect(primaryUser).to.equal({
+            contact: null,
+            contact_type: 'Primary user',
+            due_date: new Date(dueDate),
+            email: 'primary.user@important.com',
+            end_date: endDate,
+            licence_ref: testRecipients.primaryUser.licenceRef,
+            return_reference: testRecipients.primaryUser.returnLog.returnReference,
+            start_date: startDate
+          })
 
-    it('correctly returns duplicate "Licence holder" and "Returns to" contacts', async () => {
-      const result = await FetchDownloadRecipientsService.go(session)
-
-      const found = result.filter((item) => item.licence_ref === testRecipients.licenceHolderAndReturnTo.licenceRef)
-
-      expect(found).to.equal([
-        {
-          contact: {
-            addressLine1: '4',
-            addressLine2: 'Privet Drive',
-            addressLine3: null,
-            addressLine4: null,
-            country: null,
-            county: 'Surrey',
-            forename: 'Harry',
-            initials: 'J',
-            name: 'Licence holder and returns to',
-            postcode: 'WD25 7LR',
-            role: 'Licence holder',
-            salutation: null,
-            town: 'Little Whinging',
-            type: 'Person'
-          },
-          contact_type: 'Licence holder',
-          due_date: new Date(dueDate),
-          email: null,
-          end_date: endDate,
-          licence_ref: testRecipients.licenceHolderAndReturnTo.licenceRef,
-          return_reference: testRecipients.licenceHolderAndReturnTo.returnLog.returnReference,
-          start_date: startDate
-        },
-        {
-          contact: {
-            addressLine1: '4',
-            addressLine2: 'Privet Drive',
-            addressLine3: null,
-            addressLine4: null,
-            country: null,
-            county: 'Surrey',
-            forename: 'Harry',
-            initials: 'J',
-            name: 'Licence holder and returns to',
-            postcode: 'WD25 7LR',
-            role: 'Returns to',
-            salutation: null,
-            town: 'Little Whinging',
-            type: 'Person'
-          },
-          contact_type: 'Returns to',
-          due_date: new Date(dueDate),
-          email: null,
-          end_date: endDate,
-          licence_ref: testRecipients.licenceHolderAndReturnTo.licenceRef,
-          return_reference: testRecipients.licenceHolderAndReturnTo.returnLog.returnReference,
-          start_date: startDate
-        }
-      ])
-    })
-
-    describe('and there are licence to exclude from the recipients', () => {
-      beforeEach(() => {
-        removeLicences = testRecipients.primaryUser.licenceRef
-
-        session = { returnsPeriod: 'quarterFour', removeLicences }
+          expect(returnsAgent).to.equal({
+            contact: null,
+            contact_type: 'Returns agent',
+            due_date: new Date(dueDate),
+            email: 'returns.agent@important.com',
+            end_date: endDate,
+            licence_ref: testRecipients.primaryUser.licenceRef,
+            return_reference: testRecipients.primaryUser.returnLog.returnReference,
+            start_date: startDate
+          })
+        })
       })
 
-      it('correctly returns recipients without the "removeLicences"', async () => {
-        const result = await FetchDownloadRecipientsService.go(session)
+      describe('when the licence number only has one recipient which has the "licence holder" role', () => {
+        it('correctly returns "Licence holder" contact', async () => {
+          const result = await FetchDownloadRecipientsService.go(session)
 
-        const primaryUser = result.find((item) => item.contact_type === 'Primary user')
-        const returnsAgent = result.find((item) => item.contact_type === 'Returns agent')
+          const found = result.filter((item) => item.licence_ref === testRecipients.licenceHolder.licenceRef)
 
-        expect(primaryUser).to.be.undefined()
+          expect(found).to.equal([
+            {
+              contact: {
+                addressLine1: '4',
+                addressLine2: 'Privet Drive',
+                addressLine3: null,
+                addressLine4: null,
+                country: null,
+                county: 'Surrey',
+                forename: 'Harry',
+                initials: 'J',
+                name: 'Licence holder only',
+                postcode: 'WD25 7LR',
+                role: 'Licence holder',
+                salutation: null,
+                town: 'Little Whinging',
+                type: 'Person'
+              },
+              contact_type: 'Licence holder',
+              due_date: new Date(dueDate),
+              email: null,
+              end_date: endDate,
+              licence_ref: testRecipients.licenceHolder.licenceRef,
+              return_reference: testRecipients.licenceHolder.returnLog.returnReference,
+              start_date: startDate
+            }
+          ])
+        })
+      })
 
-        expect(returnsAgent).to.be.undefined()
+      describe('when the licence has one recipient which has both the "licence holder" and "Returns to" role', () => {
+        it('correctly returns duplicate "Licence holder" and "Returns to" contacts', async () => {
+          const result = await FetchDownloadRecipientsService.go(session)
+
+          const found = result.filter((item) => item.licence_ref === testRecipients.licenceHolderAndReturnTo.licenceRef)
+
+          expect(found).to.equal([
+            {
+              contact: {
+                addressLine1: '4',
+                addressLine2: 'Privet Drive',
+                addressLine3: null,
+                addressLine4: null,
+                country: null,
+                county: 'Surrey',
+                forename: 'Harry',
+                initials: 'J',
+                name: 'Licence holder and returns to',
+                postcode: 'WD25 7LR',
+                role: 'Licence holder',
+                salutation: null,
+                town: 'Little Whinging',
+                type: 'Person'
+              },
+              contact_type: 'Licence holder',
+              due_date: new Date(dueDate),
+              email: null,
+              end_date: endDate,
+              licence_ref: testRecipients.licenceHolderAndReturnTo.licenceRef,
+              return_reference: testRecipients.licenceHolderAndReturnTo.returnLog.returnReference,
+              start_date: startDate
+            },
+            {
+              contact: {
+                addressLine1: '4',
+                addressLine2: 'Privet Drive',
+                addressLine3: null,
+                addressLine4: null,
+                country: null,
+                county: 'Surrey',
+                forename: 'Harry',
+                initials: 'J',
+                name: 'Licence holder and returns to',
+                postcode: 'WD25 7LR',
+                role: 'Returns to',
+                salutation: null,
+                town: 'Little Whinging',
+                type: 'Person'
+              },
+              contact_type: 'Returns to',
+              due_date: new Date(dueDate),
+              email: null,
+              end_date: endDate,
+              licence_ref: testRecipients.licenceHolderAndReturnTo.licenceRef,
+              return_reference: testRecipients.licenceHolderAndReturnTo.returnLog.returnReference,
+              start_date: startDate
+            }
+          ])
+        })
+      })
+
+      describe('and there are licence to exclude from the recipients', () => {
+        beforeEach(() => {
+          removeLicences = testRecipients.primaryUser.licenceRef
+
+          session = { returnsPeriod: 'quarterFour', removeLicences }
+        })
+
+        it('correctly returns recipients without the "removeLicences"', async () => {
+          const result = await FetchDownloadRecipientsService.go(session)
+
+          const primaryUser = result.find((item) => item.contact_type === 'Primary user')
+          const returnsAgent = result.find((item) => item.contact_type === 'Returns agent')
+
+          expect(primaryUser).to.be.undefined()
+
+          expect(returnsAgent).to.be.undefined()
+        })
+      })
+    })
+  })
+
+  describe('when the "journey" is for an ad hoc licence', () => {
+    describe('when there are recipients', () => {
+      describe('when there is a "primary user"', () => {
+        beforeEach(() => {
+          session = { journey: 'ad-hoc', licenceRef: testRecipients.primaryUser.licenceRef }
+        })
+
+        it('correctly returns "Primary user" and "Returns agent" contacts', async () => {
+          const result = await FetchDownloadRecipientsService.go(session)
+
+          const primaryUser = result.find((item) => item.contact_type === 'Primary user')
+          const returnsAgent = result.find((item) => item.contact_type === 'Returns agent')
+
+          expect(primaryUser).to.equal({
+            contact: null,
+            contact_type: 'Primary user',
+            due_date: new Date(dueDate),
+            email: 'primary.user@important.com',
+            end_date: endDate,
+            licence_ref: testRecipients.primaryUser.licenceRef,
+            return_reference: testRecipients.primaryUser.returnLog.returnReference,
+            start_date: startDate
+          })
+
+          expect(returnsAgent).to.equal({
+            contact: null,
+            contact_type: 'Returns agent',
+            due_date: new Date(dueDate),
+            email: 'returns.agent@important.com',
+            end_date: endDate,
+            licence_ref: testRecipients.primaryUser.licenceRef,
+            return_reference: testRecipients.primaryUser.returnLog.returnReference,
+            start_date: startDate
+          })
+        })
+      })
+
+      describe('when the licence number only has one recipient which has the "licence holder" role', () => {
+        beforeEach(() => {
+          session = { journey: 'ad-hoc', licenceRef: testRecipients.licenceHolder.licenceRef }
+        })
+
+        it('correctly returns "Licence holder" contact', async () => {
+          const result = await FetchDownloadRecipientsService.go(session)
+
+          const found = result.filter((item) => item.licence_ref === testRecipients.licenceHolder.licenceRef)
+
+          expect(found).to.equal([
+            {
+              contact: {
+                addressLine1: '4',
+                addressLine2: 'Privet Drive',
+                addressLine3: null,
+                addressLine4: null,
+                country: null,
+                county: 'Surrey',
+                forename: 'Harry',
+                initials: 'J',
+                name: 'Licence holder only',
+                postcode: 'WD25 7LR',
+                role: 'Licence holder',
+                salutation: null,
+                town: 'Little Whinging',
+                type: 'Person'
+              },
+              contact_type: 'Licence holder',
+              due_date: new Date(dueDate),
+              email: null,
+              end_date: endDate,
+              licence_ref: testRecipients.licenceHolder.licenceRef,
+              return_reference: testRecipients.licenceHolder.returnLog.returnReference,
+              start_date: startDate
+            }
+          ])
+        })
+      })
+
+      describe('when the licence has one recipient which has both the "licence holder" and "Returns to" role', () => {
+        beforeEach(() => {
+          session = { journey: 'ad-hoc', licenceRef: testRecipients.licenceHolderAndReturnTo.licenceRef }
+        })
+
+        it('correctly returns duplicate "Licence holder" and "Returns to" contacts', async () => {
+          const result = await FetchDownloadRecipientsService.go(session)
+
+          const found = result.filter((item) => item.licence_ref === testRecipients.licenceHolderAndReturnTo.licenceRef)
+
+          expect(found).to.equal([
+            {
+              contact: {
+                addressLine1: '4',
+                addressLine2: 'Privet Drive',
+                addressLine3: null,
+                addressLine4: null,
+                country: null,
+                county: 'Surrey',
+                forename: 'Harry',
+                initials: 'J',
+                name: 'Licence holder and returns to',
+                postcode: 'WD25 7LR',
+                role: 'Licence holder',
+                salutation: null,
+                town: 'Little Whinging',
+                type: 'Person'
+              },
+              contact_type: 'Licence holder',
+              due_date: new Date(dueDate),
+              email: null,
+              end_date: endDate,
+              licence_ref: testRecipients.licenceHolderAndReturnTo.licenceRef,
+              return_reference: testRecipients.licenceHolderAndReturnTo.returnLog.returnReference,
+              start_date: startDate
+            },
+            {
+              contact: {
+                addressLine1: '4',
+                addressLine2: 'Privet Drive',
+                addressLine3: null,
+                addressLine4: null,
+                country: null,
+                county: 'Surrey',
+                forename: 'Harry',
+                initials: 'J',
+                name: 'Licence holder and returns to',
+                postcode: 'WD25 7LR',
+                role: 'Returns to',
+                salutation: null,
+                town: 'Little Whinging',
+                type: 'Person'
+              },
+              contact_type: 'Returns to',
+              due_date: new Date(dueDate),
+              email: null,
+              end_date: endDate,
+              licence_ref: testRecipients.licenceHolderAndReturnTo.licenceRef,
+              return_reference: testRecipients.licenceHolderAndReturnTo.returnLog.returnReference,
+              start_date: startDate
+            }
+          ])
+        })
       })
     })
   })

--- a/test/services/notifications/setup/fetch-recipients.service.test.js
+++ b/test/services/notifications/setup/fetch-recipients.service.test.js
@@ -15,163 +15,306 @@ const RecipientsService = require('../../../../app/services/notifications/setup/
 const Sinon = require('sinon')
 
 describe('Notifications Setup - Recipients service', () => {
+  const dueDate = '2025-04-28'
   const year = 2025
 
   let clock
-  let session
-  let dueDate
   let recipients
-  let removeLicences
+  let session
 
   before(async () => {
     clock = Sinon.useFakeTimers(new Date(`${year}-01-01`))
-
-    dueDate = '2025-04-28'
-    removeLicences = ''
-
-    session = { returnsPeriod: 'quarterFour', removeLicences }
 
     recipients = await LicenceDocumentHeaderSeeder.seed(true, dueDate)
   })
 
   afterEach(() => {
     clock.restore()
+    clock.restore()
   })
 
-  describe('when there is a "primary user"', () => {
-    it('correctly returns the "primary user" instead of the "Licence holder"', async () => {
-      const result = await RecipientsService.go(session)
+  describe('when the "journey" is for notifications', () => {
+    let removeLicences
 
-      const [testRecipient] = result.filter((res) => res.licence_refs.includes(recipients.primaryUser.licenceRef))
-
-      expect(testRecipient).to.equal({
-        licence_refs: recipients.primaryUser.licenceRef,
-        contact: null,
-        contact_hash_id: '90129f6aa5bf2ad50aa3fefd3f8cf86a',
-        contact_type: 'Primary user',
-        email: 'primary.user@important.com'
-      })
+    beforeEach(() => {
+      removeLicences = ''
+      session = { journey: 'invitations', returnsPeriod: 'quarterFour', removeLicences }
     })
 
-    describe('and there is a "returns agent" (known as userReturns in the DB)', () => {
-      it('correctly returns the "returns agent" as well as the primary user', async () => {
+    describe('when there is a "primary user"', () => {
+      it('correctly returns the "primary user" instead of the "Licence holder"', async () => {
         const result = await RecipientsService.go(session)
 
-        const [, testRecipientReturnsAgent] = result.filter((res) =>
-          res.licence_refs.includes(recipients.primaryUser.licenceRef)
-        )
+        const [testRecipient] = result.filter((res) => res.licence_refs.includes(recipients.primaryUser.licenceRef))
 
-        expect(testRecipientReturnsAgent).to.equal({
+        expect(testRecipient).to.equal({
           licence_refs: recipients.primaryUser.licenceRef,
           contact: null,
-          contact_hash_id: '2e6918568dfbc1d78e2fbe279aaee990',
-          contact_type: 'Returns agent',
-          email: 'returns.agent@important.com'
+          contact_hash_id: '90129f6aa5bf2ad50aa3fefd3f8cf86a',
+          contact_type: 'Primary user',
+          email: 'primary.user@important.com'
+        })
+      })
+
+      describe('and there is a "returns agent" (known as userReturns in the DB)', () => {
+        it('correctly returns the "returns agent" as well as the primary user', async () => {
+          const result = await RecipientsService.go(session)
+
+          const [, testRecipientReturnsAgent] = result.filter((res) =>
+            res.licence_refs.includes(recipients.primaryUser.licenceRef)
+          )
+
+          expect(testRecipientReturnsAgent).to.equal({
+            licence_refs: recipients.primaryUser.licenceRef,
+            contact: null,
+            contact_hash_id: '2e6918568dfbc1d78e2fbe279aaee990',
+            contact_type: 'Returns agent',
+            email: 'returns.agent@important.com'
+          })
         })
       })
     })
-  })
 
-  describe('when the licence number only has one recipient which has the "licence holder" role', () => {
-    it('correctly returns the licence holder data', async () => {
-      const result = await RecipientsService.go(session)
+    describe('when the licence number only has one recipient which has the "licence holder" role', () => {
+      it('correctly returns the licence holder data', async () => {
+        const result = await RecipientsService.go(session)
 
-      const [testRecipient] = result.filter((res) => res.licence_refs.includes(recipients.licenceHolder.licenceRef))
+        const [testRecipient] = result.filter((res) => res.licence_refs.includes(recipients.licenceHolder.licenceRef))
 
-      expect(testRecipient).to.equal({
-        licence_refs: recipients.licenceHolder.licenceRef,
-        contact: {
-          addressLine1: '4',
-          addressLine2: 'Privet Drive',
-          addressLine3: null,
-          addressLine4: null,
-          country: null,
-          county: 'Surrey',
-          forename: 'Harry',
-          initials: 'J',
-          name: 'Licence holder only',
-          postcode: 'WD25 7LR',
-          role: 'Licence holder',
-          salutation: null,
-          town: 'Little Whinging',
-          type: 'Person'
-        },
-        contact_hash_id: '22f6457b6be9fd63d8a9a8dd2ed61214',
-        contact_type: 'Licence holder',
-        email: null
+        expect(testRecipient).to.equal({
+          licence_refs: recipients.licenceHolder.licenceRef,
+          contact: {
+            addressLine1: '4',
+            addressLine2: 'Privet Drive',
+            addressLine3: null,
+            addressLine4: null,
+            country: null,
+            county: 'Surrey',
+            forename: 'Harry',
+            initials: 'J',
+            name: 'Licence holder only',
+            postcode: 'WD25 7LR',
+            role: 'Licence holder',
+            salutation: null,
+            town: 'Little Whinging',
+            type: 'Person'
+          },
+          contact_hash_id: '22f6457b6be9fd63d8a9a8dd2ed61214',
+          contact_type: 'Licence holder',
+          email: null
+        })
+      })
+    })
+
+    describe('when the licence has one recipient which has both the "licence holder" and "Returns to" role', () => {
+      it('correctly returns the licence holder and returns to data', async () => {
+        const result = await RecipientsService.go(session)
+
+        const [licenceHolder, returnsTo] = result.filter((res) =>
+          res.licence_refs.includes(recipients.licenceHolderAndReturnTo.licenceRef)
+        )
+
+        expect(licenceHolder).to.equal({
+          licence_refs: recipients.licenceHolderAndReturnTo.licenceRef,
+          contact: {
+            addressLine1: '4',
+            addressLine2: 'Privet Drive',
+            addressLine3: null,
+            addressLine4: null,
+            country: null,
+            county: 'Surrey',
+            forename: 'Harry',
+            initials: 'J',
+            name: 'Licence holder and returns to',
+            postcode: 'WD25 7LR',
+            role: 'Licence holder',
+            salutation: null,
+            town: 'Little Whinging',
+            type: 'Person'
+          },
+          contact_hash_id: 'b1b355491c7d42778890c545e08797ea',
+          contact_type: 'Licence holder',
+          email: null
+        })
+
+        expect(returnsTo).to.equal({
+          licence_refs: recipients.licenceHolderAndReturnTo.licenceRef,
+          contact: {
+            addressLine1: '4',
+            addressLine2: 'Privet Drive',
+            addressLine3: null,
+            addressLine4: null,
+            country: null,
+            county: 'Surrey',
+            forename: 'Harry',
+            initials: 'J',
+            name: 'Licence holder and returns to',
+            postcode: 'WD25 7LR',
+            role: 'Returns to',
+            salutation: null,
+            town: 'Little Whinging',
+            type: 'Person'
+          },
+          contact_hash_id: 'b1b355491c7d42778890c545e08797ea',
+          contact_type: 'Returns to',
+          email: null
+        })
+      })
+    })
+
+    describe('when there are licence to exclude from the recipients', () => {
+      beforeEach(() => {
+        removeLicences = recipients.primaryUser.licenceRef
+
+        session = { returnsPeriod: 'quarterFour', removeLicences }
+      })
+
+      it('correctly returns recipients without the "removeLicences"', async () => {
+        const result = await RecipientsService.go(session)
+
+        const [testRecipient] = result.filter((res) => res.licence_refs.includes(recipients.primaryUser.licenceRef))
+
+        expect(testRecipient).to.be.undefined()
       })
     })
   })
 
-  describe('when the licence has one recipient which has both the "licence holder" and "Returns to" role', () => {
-    it('correctly returns the licence holder and returns to data', async () => {
-      const result = await RecipientsService.go(session)
-
-      const [licenceHolder, returnsTo] = result.filter((res) =>
-        res.licence_refs.includes(recipients.licenceHolderAndReturnTo.licenceRef)
-      )
-
-      expect(licenceHolder).to.equal({
-        licence_refs: recipients.licenceHolderAndReturnTo.licenceRef,
-        contact: {
-          addressLine1: '4',
-          addressLine2: 'Privet Drive',
-          addressLine3: null,
-          addressLine4: null,
-          country: null,
-          county: 'Surrey',
-          forename: 'Harry',
-          initials: 'J',
-          name: 'Licence holder and returns to',
-          postcode: 'WD25 7LR',
-          role: 'Licence holder',
-          salutation: null,
-          town: 'Little Whinging',
-          type: 'Person'
-        },
-        contact_hash_id: 'b1b355491c7d42778890c545e08797ea',
-        contact_type: 'Licence holder',
-        email: null
+  describe('when the "journey" is for an ad hoc licence', () => {
+    describe('when there is a "primary user"', () => {
+      beforeEach(() => {
+        session = { journey: 'ad-hoc', licenceRef: recipients.primaryUser.licenceRef }
       })
 
-      expect(returnsTo).to.equal({
-        licence_refs: recipients.licenceHolderAndReturnTo.licenceRef,
-        contact: {
-          addressLine1: '4',
-          addressLine2: 'Privet Drive',
-          addressLine3: null,
-          addressLine4: null,
-          country: null,
-          county: 'Surrey',
-          forename: 'Harry',
-          initials: 'J',
-          name: 'Licence holder and returns to',
-          postcode: 'WD25 7LR',
-          role: 'Returns to',
-          salutation: null,
-          town: 'Little Whinging',
-          type: 'Person'
-        },
-        contact_hash_id: 'b1b355491c7d42778890c545e08797ea',
-        contact_type: 'Returns to',
-        email: null
+      it('correctly returns the "primary user" instead of the "Licence holder"', async () => {
+        const result = await RecipientsService.go(session)
+
+        const [testRecipient] = result.filter((res) => res.licence_refs.includes(recipients.primaryUser.licenceRef))
+
+        expect(testRecipient).to.equal({
+          licence_refs: recipients.primaryUser.licenceRef,
+          contact: null,
+          contact_hash_id: '90129f6aa5bf2ad50aa3fefd3f8cf86a',
+          contact_type: 'Primary user',
+          email: 'primary.user@important.com'
+        })
+      })
+
+      describe('and there is a "returns agent" (known as userReturns in the DB)', () => {
+        beforeEach(() => {
+          session = { journey: 'ad-hoc', licenceRef: recipients.primaryUser.licenceRef }
+        })
+
+        it('correctly returns the "returns agent" as well as the primary user', async () => {
+          const result = await RecipientsService.go(session)
+
+          const [, testRecipientReturnsAgent] = result.filter((res) =>
+            res.licence_refs.includes(recipients.primaryUser.licenceRef)
+          )
+
+          expect(testRecipientReturnsAgent).to.equal({
+            licence_refs: recipients.primaryUser.licenceRef,
+            contact: null,
+            contact_hash_id: '2e6918568dfbc1d78e2fbe279aaee990',
+            contact_type: 'Returns agent',
+            email: 'returns.agent@important.com'
+          })
+        })
       })
     })
-  })
 
-  describe('when there are licence to exclude from the recipients', () => {
-    beforeEach(() => {
-      removeLicences = recipients.primaryUser.licenceRef
+    describe('when the licence number only has one recipient which has the "licence holder" role', () => {
+      beforeEach(() => {
+        session = { journey: 'ad-hoc', licenceRef: recipients.licenceHolder.licenceRef }
+      })
 
-      session = { returnsPeriod: 'quarterFour', removeLicences }
+      it('correctly returns the licence holder data', async () => {
+        const result = await RecipientsService.go(session)
+
+        const [testRecipient] = result.filter((res) => res.licence_refs.includes(recipients.licenceHolder.licenceRef))
+
+        expect(testRecipient).to.equal({
+          licence_refs: recipients.licenceHolder.licenceRef,
+          contact: {
+            addressLine1: '4',
+            addressLine2: 'Privet Drive',
+            addressLine3: null,
+            addressLine4: null,
+            country: null,
+            county: 'Surrey',
+            forename: 'Harry',
+            initials: 'J',
+            name: 'Licence holder only',
+            postcode: 'WD25 7LR',
+            role: 'Licence holder',
+            salutation: null,
+            town: 'Little Whinging',
+            type: 'Person'
+          },
+          contact_hash_id: '22f6457b6be9fd63d8a9a8dd2ed61214',
+          contact_type: 'Licence holder',
+          email: null
+        })
+      })
     })
 
-    it('correctly returns recipients without the "removeLicences"', async () => {
-      const result = await RecipientsService.go(session)
+    describe('when the licence has one recipient which has both the "licence holder" and "Returns to" role', () => {
+      beforeEach(() => {
+        session = { journey: 'ad-hoc', licenceRef: recipients.licenceHolderAndReturnTo.licenceRef }
+      })
 
-      const [testRecipient] = result.filter((res) => res.licence_refs.includes(recipients.primaryUser.licenceRef))
+      it('correctly returns the licence holder and returns to data', async () => {
+        const result = await RecipientsService.go(session)
 
-      expect(testRecipient).to.be.undefined()
+        const [licenceHolder, returnsTo] = result.filter((res) =>
+          res.licence_refs.includes(recipients.licenceHolderAndReturnTo.licenceRef)
+        )
+
+        expect(licenceHolder).to.equal({
+          licence_refs: recipients.licenceHolderAndReturnTo.licenceRef,
+          contact: {
+            addressLine1: '4',
+            addressLine2: 'Privet Drive',
+            addressLine3: null,
+            addressLine4: null,
+            country: null,
+            county: 'Surrey',
+            forename: 'Harry',
+            initials: 'J',
+            name: 'Licence holder and returns to',
+            postcode: 'WD25 7LR',
+            role: 'Licence holder',
+            salutation: null,
+            town: 'Little Whinging',
+            type: 'Person'
+          },
+          contact_hash_id: 'b1b355491c7d42778890c545e08797ea',
+          contact_type: 'Licence holder',
+          email: null
+        })
+
+        expect(returnsTo).to.equal({
+          licence_refs: recipients.licenceHolderAndReturnTo.licenceRef,
+          contact: {
+            addressLine1: '4',
+            addressLine2: 'Privet Drive',
+            addressLine3: null,
+            addressLine4: null,
+            country: null,
+            county: 'Surrey',
+            forename: 'Harry',
+            initials: 'J',
+            name: 'Licence holder and returns to',
+            postcode: 'WD25 7LR',
+            role: 'Returns to',
+            salutation: null,
+            town: 'Little Whinging',
+            type: 'Person'
+          },
+          contact_hash_id: 'b1b355491c7d42778890c545e08797ea',
+          contact_type: 'Returns to',
+          email: null
+        })
+      })
     })
   })
 })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4900

This change introduces the 'journey' context into the notifications setup fetch services.

Due to the complexity of the queries we have decided to pass the session into the fetch services. The session contains a journey key which we use to determine what query to make.

When the journey is for an ad hoc licence we only want to fetch the recipients for that licence (we are not concerned with the returns period, due date and if is a summer return).

This change replaces some of the existing fetch requests 'where' clauses. As the query is a template literal string we can 'inject' the relevant where clause into the query.

The previous returns periods query results should not be affected.