### PR TITLE
Update notifications review to present ad-hoc and invitations journeys

### DIFF
--- a/app/presenters/notifications/setup/review.presenter.js
+++ b/app/presenters/notifications/setup/review.presenter.js
@@ -14,19 +14,21 @@ const { defaultPageSize } = require('../../../../config/database.config.js')
  * @param {object[]} recipients - List of recipient objects, each containing recipient details like email or name.
  * @param {number|string} page - The currently selected page
  * @param {object} pagination - The result from `PaginatorPresenter`
- * @param {string} sessionId - The UUID for setup ad-hoc returns notification session record
+ * @param {string} session - The session instance
  *
  * @returns {object} - The data formatted for the view template
  */
-function go(recipients, page, pagination, sessionId) {
+function go(recipients, page, pagination, session) {
+  const { id: sessionId, journey } = session
+
   return {
     defaultPageSize,
-    pageTitle: _pageTitle(page, pagination),
+    text: _text(page, pagination, journey),
     recipients: _recipients(recipients, page),
     recipientsAmount: recipients.length,
     links: {
       download: `/system/notifications/setup/${sessionId}/download`,
-      removeLicences: `/system/notifications/setup/${sessionId}/remove-licences`
+      removeLicences: journey !== 'ad-hoc' ? `/system/notifications/setup/${sessionId}/remove-licences` : ''
     }
   }
 }
@@ -60,12 +62,23 @@ function _formatRecipients(recipients) {
   })
 }
 
-function _pageTitle(page, pagination) {
-  if (pagination.numberOfPages > 1) {
-    return `Send returns invitations (page ${page} of ${pagination.numberOfPages})`
+function _text(page, pagination, journey) {
+  const type = {
+    'ad-hoc': 'Ad-hoc notifications',
+    invitations: 'Returns invitations'
   }
 
-  return 'Send returns invitations'
+  let title = `Send ${type[journey].toLowerCase()}`
+
+  if (pagination.numberOfPages > 1) {
+    title += ` (page ${page} of ${pagination.numberOfPages})`
+  }
+
+  return {
+    title,
+    readyToSend: `${type[journey]} are ready to send.`,
+    continueButton: 'Send invitations'
+  }
 }
 
 /**

--- a/app/presenters/notifications/setup/review.presenter.js
+++ b/app/presenters/notifications/setup/review.presenter.js
@@ -77,7 +77,7 @@ function _text(page, pagination, journey) {
   return {
     title,
     readyToSend: `${type[journey]} are ready to send.`,
-    continueButton: 'Send invitations'
+    continueButton: 'Send'
   }
 }
 

--- a/app/services/notifications/setup/review.service.js
+++ b/app/services/notifications/setup/review.service.js
@@ -32,7 +32,7 @@ async function go(sessionId, page = 1) {
     `/system/notifications/setup/${sessionId}/review`
   )
 
-  const formattedData = ReviewPresenter.go(recipients, page, pagination, sessionId)
+  const formattedData = ReviewPresenter.go(recipients, page, pagination, session)
 
   return {
     activeNavBar: 'manage',

--- a/app/views/notifications/setup/review.njk
+++ b/app/views/notifications/setup/review.njk
@@ -47,11 +47,12 @@
 
 {% block content %}
   <div class="govuk-body">
-    <h1 class="govuk-heading-l"> {{ pageTitle }} </h1>
+    <h1 class="govuk-heading-l"> {{ text.title }} </h1>
 
-    <p> Returns invitations are ready to send.</p>
+    <p> {{ text.readyToSend }}</p>
 
     <div class="govuk-button-group">
+
       {{ govukButton({
         text: "Download recipients",
         classes: "govuk-button--secondary",
@@ -59,12 +60,14 @@
         preventDoubleClick: true
       }) }}
 
+      {% if links.removeLicences %}
       {{ govukButton({
         text: "Remove licences",
         classes: "govuk-button--secondary",
         href: links.removeLicences,
         preventDoubleClick: true
       }) }}
+      {% endif %}
     </div>
 
     {% if pagination.numberOfPages > 1 %}
@@ -100,7 +103,7 @@
     <form method="post">
       <input type="hidden" name="wrlsCrumb" value="{{ wrlsCrumb }}"/>
 
-      {{ govukButton({ text: "Send invitations", preventDoubleClick: true }) }}
+      {{ govukButton({ text: text.continueButton, preventDoubleClick: true }) }}
     </form>
   </div>
 {% endblock %}

--- a/test/presenters/notifications/setup/review.presenter.test.js
+++ b/test/presenters/notifications/setup/review.presenter.test.js
@@ -113,7 +113,7 @@ describe('Notifications Setup - Review presenter', () => {
         ],
         recipientsAmount: 9,
         text: {
-          continueButton: 'Send invitations',
+          continueButton: 'Send',
           readyToSend: 'Returns invitations are ready to send.',
           title: 'Send returns invitations'
         }
@@ -296,7 +296,7 @@ describe('Notifications Setup - Review presenter', () => {
               const result = ReviewPresenter.go(testInput, page, pagination, session)
 
               expect(result.text).to.equal({
-                continueButton: 'Send invitations',
+                continueButton: 'Send',
                 readyToSend: 'Returns invitations are ready to send.',
                 title: 'Send returns invitations (page 1 of 2)'
               })
@@ -318,7 +318,7 @@ describe('Notifications Setup - Review presenter', () => {
               const result = ReviewPresenter.go(testInput, page, pagination, session)
 
               expect(result.text).to.equal({
-                continueButton: 'Send invitations',
+                continueButton: 'Send',
                 readyToSend: 'Returns invitations are ready to send.',
                 title: 'Send returns invitations (page 2 of 2)'
               })
@@ -504,7 +504,7 @@ describe('Notifications Setup - Review presenter', () => {
               const result = ReviewPresenter.go(testInput, page, pagination, session)
 
               expect(result.text).to.equal({
-                continueButton: 'Send invitations',
+                continueButton: 'Send',
                 readyToSend: 'Ad-hoc notifications are ready to send.',
                 title: 'Send ad-hoc notifications (page 1 of 2)'
               })
@@ -526,7 +526,7 @@ describe('Notifications Setup - Review presenter', () => {
               const result = ReviewPresenter.go(testInput, page, pagination, session)
 
               expect(result.text).to.equal({
-                continueButton: 'Send invitations',
+                continueButton: 'Send',
                 readyToSend: 'Ad-hoc notifications are ready to send.',
                 title: 'Send ad-hoc notifications (page 2 of 2)'
               })

--- a/test/presenters/notifications/setup/review.presenter.test.js
+++ b/test/presenters/notifications/setup/review.presenter.test.js
@@ -15,8 +15,7 @@ const { generateUUID } = require('../../../../app/lib/general.lib.js')
 const ReviewPresenter = require('../../../../app/presenters/notifications/setup/review.presenter.js')
 
 describe('Notifications Setup - Review presenter', () => {
-  const sessionId = generateUUID()
-
+  let session
   let page
   let pagination
   let testInput
@@ -28,6 +27,8 @@ describe('Notifications Setup - Review presenter', () => {
     pagination = {
       numberOfPages: 1
     }
+
+    session = { id: generateUUID(), journey: 'invitations' }
 
     testRecipients = RecipientsFixture.recipients()
     // This data is used to ensure the recipients are grouped when they have the same licence ref / name.
@@ -48,15 +49,14 @@ describe('Notifications Setup - Review presenter', () => {
 
   describe('when provided with "recipients"', () => {
     it('correctly presents the data (in alphabetical order)', () => {
-      const result = ReviewPresenter.go(testInput, page, pagination, sessionId)
+      const result = ReviewPresenter.go(testInput, page, pagination, session)
 
       expect(result).to.equal({
         defaultPageSize: 25,
         links: {
-          download: `/system/notifications/setup/${sessionId}/download`,
-          removeLicences: `/system/notifications/setup/${sessionId}/remove-licences`
+          download: `/system/notifications/setup/${session.id}/download`,
+          removeLicences: `/system/notifications/setup/${session.id}/remove-licences`
         },
-        pageTitle: 'Send returns invitations',
         recipients: [
           {
             contact: ['Mr H J Duplicate Licence holder', '4', 'Privet Drive', 'Little Whinging', 'Surrey', 'WD25 7LR'],
@@ -111,189 +111,426 @@ describe('Notifications Setup - Review presenter', () => {
             method: 'Letter or email - Returns agent'
           }
         ],
-        recipientsAmount: 9
+        recipientsAmount: 9,
+        text: {
+          continueButton: 'Send invitations',
+          readyToSend: 'Returns invitations are ready to send.',
+          title: 'Send returns invitations'
+        }
       })
     })
 
-    describe('the "recipients" property', () => {
-      describe('format all recipient types', () => {
-        it('should return the formatted recipients', () => {
-          const result = ReviewPresenter.go(testInput, page, pagination, sessionId)
+    describe('when the journey is for "invitations"', () => {
+      beforeEach(() => {
+        session.journey = 'invitations'
+      })
 
-          expect(result.recipients).to.equal([
-            {
-              contact: [
-                'Mr H J Duplicate Licence holder',
-                '4',
-                'Privet Drive',
-                'Little Whinging',
-                'Surrey',
-                'WD25 7LR'
-              ],
-              licences: [testDuplicateRecipients.duplicateLicenceHolder.licence_refs],
-              method: 'Letter or email - Licence holder'
-            },
-            {
-              contact: ['Mr H J Duplicate Returns to', '4', 'Privet Drive', 'Little Whinging', 'Surrey', 'WD25 7LR'],
-              licences: [testDuplicateRecipients.duplicateReturnsTo.licence_refs],
-              method: 'Letter or email - Returns to'
-            },
-            {
-              contact: ['Mr H J Licence holder', '1', 'Privet Drive', 'Little Whinging', 'Surrey', 'WD25 7LR'],
-              licences: [testRecipients.licenceHolder.licence_refs],
-              method: 'Letter or email - Licence holder'
-            },
-            {
-              contact: [
-                'Mr H J Licence holder with multiple licences',
-                '3',
-                'Privet Drive',
-                'Little Whinging',
-                'Surrey',
-                'WD25 7LR'
-              ],
-              licences: testRecipients.licenceHolderWithMultipleLicences.licence_refs.split(','),
-              method: 'Letter or email - Licence holder'
-            },
-            {
-              contact: ['Mr H J Returns to', '2', 'Privet Drive', 'Little Whinging', 'Surrey', 'WD25 7LR'],
-              licences: [testRecipients.returnsTo.licence_refs],
-              method: 'Letter or email - Returns to'
-            },
-            {
-              contact: ['primary.user@important.com'],
-              licences: [testRecipients.primaryUser.licence_refs],
-              method: 'Letter or email - Primary user'
-            },
-            {
-              contact: ['primary.user@important.com'],
-              licences: [testDuplicateRecipients.duplicatePrimaryUser.licence_refs],
-              method: 'Letter or email - Primary user'
-            },
-            {
-              contact: ['returns.agent@important.com'],
-              licences: [testRecipients.returnsAgent.licence_refs],
-              method: 'Letter or email - Returns agent'
-            },
-            {
-              contact: ['returns.agent@important.com'],
-              licences: [testDuplicateRecipients.duplicateReturnsAgent.licence_refs],
-              method: 'Letter or email - Returns agent'
-            }
-          ])
-        })
-
-        describe('the "contact" property', () => {
-          describe('when the contact is an email', () => {
-            it('should return the email address', () => {
-              const result = ReviewPresenter.go(testInput, page, pagination, sessionId)
-
-              const testRecipient = result.recipients.find((recipient) =>
-                recipient.licences.includes(testRecipients.primaryUser.licence_refs)
-              )
-
-              expect(testRecipient).to.equal({
-                contact: ['primary.user@important.com'],
-                licences: [`${testRecipients.primaryUser.licence_refs}`],
-                method: 'Letter or email - Primary user'
-              })
-            })
+      describe('the "links" property', () => {
+        it('should return the links for "invitations"', () => {
+          const result = ReviewPresenter.go(testInput, page, pagination, session)
+          expect(result.links).to.equal({
+            download: `/system/notifications/setup/${session.id}/download`,
+            removeLicences: `/system/notifications/setup/${session.id}/remove-licences`
           })
+        })
+      })
 
-          describe('when the contact is an address', () => {
-            it('should convert the contact into an array', () => {
-              const result = ReviewPresenter.go(testInput, page, pagination, sessionId)
+      describe('the "recipients" property', () => {
+        describe('format all recipient types', () => {
+          it('should return the formatted recipients', () => {
+            const result = ReviewPresenter.go(testInput, page, pagination, session)
 
-              const testRecipient = result.recipients.find((recipient) =>
-                recipient.licences.includes(testRecipients.licenceHolder.licence_refs)
-              )
-
-              expect(testRecipient).to.equal({
-                contact: ['Mr H J Licence holder', '1', 'Privet Drive', 'Little Whinging', 'Surrey', 'WD25 7LR'],
-                licences: [`${testRecipients.licenceHolder.licence_refs}`],
+            expect(result.recipients).to.equal([
+              {
+                contact: [
+                  'Mr H J Duplicate Licence holder',
+                  '4',
+                  'Privet Drive',
+                  'Little Whinging',
+                  'Surrey',
+                  'WD25 7LR'
+                ],
+                licences: [testDuplicateRecipients.duplicateLicenceHolder.licence_refs],
                 method: 'Letter or email - Licence holder'
+              },
+              {
+                contact: ['Mr H J Duplicate Returns to', '4', 'Privet Drive', 'Little Whinging', 'Surrey', 'WD25 7LR'],
+                licences: [testDuplicateRecipients.duplicateReturnsTo.licence_refs],
+                method: 'Letter or email - Returns to'
+              },
+              {
+                contact: ['Mr H J Licence holder', '1', 'Privet Drive', 'Little Whinging', 'Surrey', 'WD25 7LR'],
+                licences: [testRecipients.licenceHolder.licence_refs],
+                method: 'Letter or email - Licence holder'
+              },
+              {
+                contact: [
+                  'Mr H J Licence holder with multiple licences',
+                  '3',
+                  'Privet Drive',
+                  'Little Whinging',
+                  'Surrey',
+                  'WD25 7LR'
+                ],
+                licences: testRecipients.licenceHolderWithMultipleLicences.licence_refs.split(','),
+                method: 'Letter or email - Licence holder'
+              },
+              {
+                contact: ['Mr H J Returns to', '2', 'Privet Drive', 'Little Whinging', 'Surrey', 'WD25 7LR'],
+                licences: [testRecipients.returnsTo.licence_refs],
+                method: 'Letter or email - Returns to'
+              },
+              {
+                contact: ['primary.user@important.com'],
+                licences: [testRecipients.primaryUser.licence_refs],
+                method: 'Letter or email - Primary user'
+              },
+              {
+                contact: ['primary.user@important.com'],
+                licences: [testDuplicateRecipients.duplicatePrimaryUser.licence_refs],
+                method: 'Letter or email - Primary user'
+              },
+              {
+                contact: ['returns.agent@important.com'],
+                licences: [testRecipients.returnsAgent.licence_refs],
+                method: 'Letter or email - Returns agent'
+              },
+              {
+                contact: ['returns.agent@important.com'],
+                licences: [testDuplicateRecipients.duplicateReturnsAgent.licence_refs],
+                method: 'Letter or email - Returns agent'
+              }
+            ])
+          })
+
+          describe('the "contact" property', () => {
+            describe('when the contact is an email', () => {
+              it('should return the email address', () => {
+                const result = ReviewPresenter.go(testInput, page, pagination, session)
+
+                const testRecipient = result.recipients.find((recipient) =>
+                  recipient.licences.includes(testRecipients.primaryUser.licence_refs)
+                )
+
+                expect(testRecipient).to.equal({
+                  contact: ['primary.user@important.com'],
+                  licences: [`${testRecipients.primaryUser.licence_refs}`],
+                  method: 'Letter or email - Primary user'
+                })
+              })
+            })
+
+            describe('when the contact is an address', () => {
+              it('should convert the contact into an array', () => {
+                const result = ReviewPresenter.go(testInput, page, pagination, session)
+
+                const testRecipient = result.recipients.find((recipient) =>
+                  recipient.licences.includes(testRecipients.licenceHolder.licence_refs)
+                )
+
+                expect(testRecipient).to.equal({
+                  contact: ['Mr H J Licence holder', '1', 'Privet Drive', 'Little Whinging', 'Surrey', 'WD25 7LR'],
+                  licences: [`${testRecipients.licenceHolder.licence_refs}`],
+                  method: 'Letter or email - Licence holder'
+                })
+              })
+            })
+          })
+
+          describe('the "licences" property', () => {
+            describe('when the recipient has a single licence number', () => {
+              it('should return licence numbers as an array', () => {
+                const result = ReviewPresenter.go(testInput, page, pagination, session)
+
+                const testRecipient = result.recipients.find((recipient) =>
+                  recipient.licences.includes(testRecipients.licenceHolder.licence_refs)
+                )
+
+                expect(testRecipient.licences).to.equal([testRecipients.licenceHolder.licence_refs])
+              })
+            })
+
+            describe('when the recipient has multiple licence numbers', () => {
+              it('should return licence numbers as an array', () => {
+                const result = ReviewPresenter.go(testInput, page, pagination, session)
+
+                const testRecipient = result.recipients.find(
+                  (recipient) =>
+                    JSON.stringify(recipient.licences) ===
+                    JSON.stringify(testRecipients.licenceHolderWithMultipleLicences.licence_refs.split(','))
+                )
+
+                expect(testRecipient.licences).to.equal(
+                  testRecipients.licenceHolderWithMultipleLicences.licence_refs.split(',')
+                )
               })
             })
           })
         })
 
-        describe('the "licences" property', () => {
-          describe('when the recipient has a single licence number', () => {
-            it('should return licence numbers as an array', () => {
-              const result = ReviewPresenter.go(testInput, page, pagination, sessionId)
+        describe('and there are <= 25 recipients ', () => {
+          it('returns all the recipients', () => {
+            const result = ReviewPresenter.go(testInput, page, pagination, session)
 
-              const testRecipient = result.recipients.find((recipient) =>
-                recipient.licences.includes(testRecipients.licenceHolder.licence_refs)
-              )
-
-              expect(testRecipient.licences).to.equal([testRecipients.licenceHolder.licence_refs])
-            })
-          })
-
-          describe('when the recipient has multiple licence numbers', () => {
-            it('should return licence numbers as an array', () => {
-              const result = ReviewPresenter.go(testInput, page, pagination, sessionId)
-
-              const testRecipient = result.recipients.find(
-                (recipient) =>
-                  JSON.stringify(recipient.licences) ===
-                  JSON.stringify(testRecipients.licenceHolderWithMultipleLicences.licence_refs.split(','))
-              )
-
-              expect(testRecipient.licences).to.equal(
-                testRecipients.licenceHolderWithMultipleLicences.licence_refs.split(',')
-              )
-            })
-          })
-        })
-      })
-
-      describe('and there are <= 25 recipients ', () => {
-        it('returns all the recipients', () => {
-          const result = ReviewPresenter.go(testInput, page, pagination, sessionId)
-
-          expect(result.recipients.length).to.equal(testInput.length)
-        })
-      })
-
-      describe('and there are >= 25 recipients', () => {
-        beforeEach(() => {
-          testInput = [...testInput, ...testInput, ...testInput]
-
-          pagination = {
-            numberOfPages: 2
-          }
-        })
-
-        describe('and the page is 1', () => {
-          it('returns the first 25 recipients', () => {
-            const result = ReviewPresenter.go(testInput, page, pagination, sessionId)
-
-            expect(result.recipients.length).to.equal(25)
-          })
-
-          it('returns the updated "pageTitle"', () => {
-            const result = ReviewPresenter.go(testInput, page, pagination, sessionId)
-
-            expect(result.pageTitle).to.equal('Send returns invitations (page 1 of 2)')
+            expect(result.recipients.length).to.equal(testInput.length)
           })
         })
 
-        describe('and there is more than one page', () => {
+        describe('and there are >= 25 recipients', () => {
           beforeEach(() => {
-            page = '2'
+            testInput = [...testInput, ...testInput, ...testInput]
+
+            pagination = {
+              numberOfPages: 2
+            }
           })
 
-          it('returns the remaining recipients', () => {
-            const result = ReviewPresenter.go(testInput, page, pagination, sessionId)
+          describe('and the page is 1', () => {
+            it('returns the first 25 recipients', () => {
+              const result = ReviewPresenter.go(testInput, page, pagination, session)
 
-            expect(result.recipients.length).to.equal(2)
+              expect(result.recipients.length).to.equal(25)
+            })
+
+            it('returns the updated "text"', () => {
+              const result = ReviewPresenter.go(testInput, page, pagination, session)
+
+              expect(result.text).to.equal({
+                continueButton: 'Send invitations',
+                readyToSend: 'Returns invitations are ready to send.',
+                title: 'Send returns invitations (page 1 of 2)'
+              })
+            })
           })
 
-          it('returns the updated "pageTitle"', () => {
-            const result = ReviewPresenter.go(testInput, page, pagination, sessionId)
+          describe('and there is more than one page', () => {
+            beforeEach(() => {
+              page = '2'
+            })
 
-            expect(result.pageTitle).to.equal('Send returns invitations (page 2 of 2)')
+            it('returns the remaining recipients', () => {
+              const result = ReviewPresenter.go(testInput, page, pagination, session)
+
+              expect(result.recipients.length).to.equal(2)
+            })
+
+            it('returns the updated "text"', () => {
+              const result = ReviewPresenter.go(testInput, page, pagination, session)
+
+              expect(result.text).to.equal({
+                continueButton: 'Send invitations',
+                readyToSend: 'Returns invitations are ready to send.',
+                title: 'Send returns invitations (page 2 of 2)'
+              })
+            })
+          })
+        })
+      })
+    })
+
+    describe('when the journey is for "ad-hoc"', () => {
+      beforeEach(() => {
+        session.journey = 'ad-hoc'
+      })
+
+      describe('the "links" property', () => {
+        it('should return the links for "invitations"', () => {
+          const result = ReviewPresenter.go(testInput, page, pagination, session)
+          expect(result.links).to.equal({
+            download: `/system/notifications/setup/${session.id}/download`,
+            removeLicences: ``
+          })
+        })
+      })
+
+      describe('the "recipients" property', () => {
+        describe('format all recipient types', () => {
+          it('should return the formatted recipients', () => {
+            const result = ReviewPresenter.go(testInput, page, pagination, session)
+
+            expect(result.recipients).to.equal([
+              {
+                contact: [
+                  'Mr H J Duplicate Licence holder',
+                  '4',
+                  'Privet Drive',
+                  'Little Whinging',
+                  'Surrey',
+                  'WD25 7LR'
+                ],
+                licences: [testDuplicateRecipients.duplicateLicenceHolder.licence_refs],
+                method: 'Letter or email - Licence holder'
+              },
+              {
+                contact: ['Mr H J Duplicate Returns to', '4', 'Privet Drive', 'Little Whinging', 'Surrey', 'WD25 7LR'],
+                licences: [testDuplicateRecipients.duplicateReturnsTo.licence_refs],
+                method: 'Letter or email - Returns to'
+              },
+              {
+                contact: ['Mr H J Licence holder', '1', 'Privet Drive', 'Little Whinging', 'Surrey', 'WD25 7LR'],
+                licences: [testRecipients.licenceHolder.licence_refs],
+                method: 'Letter or email - Licence holder'
+              },
+              {
+                contact: [
+                  'Mr H J Licence holder with multiple licences',
+                  '3',
+                  'Privet Drive',
+                  'Little Whinging',
+                  'Surrey',
+                  'WD25 7LR'
+                ],
+                licences: testRecipients.licenceHolderWithMultipleLicences.licence_refs.split(','),
+                method: 'Letter or email - Licence holder'
+              },
+              {
+                contact: ['Mr H J Returns to', '2', 'Privet Drive', 'Little Whinging', 'Surrey', 'WD25 7LR'],
+                licences: [testRecipients.returnsTo.licence_refs],
+                method: 'Letter or email - Returns to'
+              },
+              {
+                contact: ['primary.user@important.com'],
+                licences: [testRecipients.primaryUser.licence_refs],
+                method: 'Letter or email - Primary user'
+              },
+              {
+                contact: ['primary.user@important.com'],
+                licences: [testDuplicateRecipients.duplicatePrimaryUser.licence_refs],
+                method: 'Letter or email - Primary user'
+              },
+              {
+                contact: ['returns.agent@important.com'],
+                licences: [testRecipients.returnsAgent.licence_refs],
+                method: 'Letter or email - Returns agent'
+              },
+              {
+                contact: ['returns.agent@important.com'],
+                licences: [testDuplicateRecipients.duplicateReturnsAgent.licence_refs],
+                method: 'Letter or email - Returns agent'
+              }
+            ])
+          })
+
+          describe('the "contact" property', () => {
+            describe('when the contact is an email', () => {
+              it('should return the email address', () => {
+                const result = ReviewPresenter.go(testInput, page, pagination, session)
+
+                const testRecipient = result.recipients.find((recipient) =>
+                  recipient.licences.includes(testRecipients.primaryUser.licence_refs)
+                )
+
+                expect(testRecipient).to.equal({
+                  contact: ['primary.user@important.com'],
+                  licences: [`${testRecipients.primaryUser.licence_refs}`],
+                  method: 'Letter or email - Primary user'
+                })
+              })
+            })
+
+            describe('when the contact is an address', () => {
+              it('should convert the contact into an array', () => {
+                const result = ReviewPresenter.go(testInput, page, pagination, session)
+
+                const testRecipient = result.recipients.find((recipient) =>
+                  recipient.licences.includes(testRecipients.licenceHolder.licence_refs)
+                )
+
+                expect(testRecipient).to.equal({
+                  contact: ['Mr H J Licence holder', '1', 'Privet Drive', 'Little Whinging', 'Surrey', 'WD25 7LR'],
+                  licences: [`${testRecipients.licenceHolder.licence_refs}`],
+                  method: 'Letter or email - Licence holder'
+                })
+              })
+            })
+          })
+
+          describe('the "licences" property', () => {
+            describe('when the recipient has a single licence number', () => {
+              it('should return licence numbers as an array', () => {
+                const result = ReviewPresenter.go(testInput, page, pagination, session)
+
+                const testRecipient = result.recipients.find((recipient) =>
+                  recipient.licences.includes(testRecipients.licenceHolder.licence_refs)
+                )
+
+                expect(testRecipient.licences).to.equal([testRecipients.licenceHolder.licence_refs])
+              })
+            })
+
+            describe('when the recipient has multiple licence numbers', () => {
+              it('should return licence numbers as an array', () => {
+                const result = ReviewPresenter.go(testInput, page, pagination, session)
+
+                const testRecipient = result.recipients.find(
+                  (recipient) =>
+                    JSON.stringify(recipient.licences) ===
+                    JSON.stringify(testRecipients.licenceHolderWithMultipleLicences.licence_refs.split(','))
+                )
+
+                expect(testRecipient.licences).to.equal(
+                  testRecipients.licenceHolderWithMultipleLicences.licence_refs.split(',')
+                )
+              })
+            })
+          })
+        })
+
+        describe('and there are <= 25 recipients ', () => {
+          it('returns all the recipients', () => {
+            const result = ReviewPresenter.go(testInput, page, pagination, session)
+
+            expect(result.recipients.length).to.equal(testInput.length)
+          })
+        })
+
+        describe('and there are >= 25 recipients', () => {
+          beforeEach(() => {
+            testInput = [...testInput, ...testInput, ...testInput]
+
+            pagination = {
+              numberOfPages: 2
+            }
+          })
+
+          describe('and the page is 1', () => {
+            it('returns the first 25 recipients', () => {
+              const result = ReviewPresenter.go(testInput, page, pagination, session)
+
+              expect(result.recipients.length).to.equal(25)
+            })
+
+            it('returns the updated "text"', () => {
+              const result = ReviewPresenter.go(testInput, page, pagination, session)
+
+              expect(result.text).to.equal({
+                continueButton: 'Send invitations',
+                readyToSend: 'Ad-hoc notifications are ready to send.',
+                title: 'Send ad-hoc notifications (page 1 of 2)'
+              })
+            })
+          })
+
+          describe('and there is more than one page', () => {
+            beforeEach(() => {
+              page = '2'
+            })
+
+            it('returns the remaining recipients', () => {
+              const result = ReviewPresenter.go(testInput, page, pagination, session)
+
+              expect(result.recipients.length).to.equal(2)
+            })
+
+            it('returns the updated "text"', () => {
+              const result = ReviewPresenter.go(testInput, page, pagination, session)
+
+              expect(result.text).to.equal({
+                continueButton: 'Send invitations',
+                readyToSend: 'Ad-hoc notifications are ready to send.',
+                title: 'Send ad-hoc notifications (page 2 of 2)'
+              })
+            })
           })
         })
       })

--- a/test/services/notifications/setup/review.service.test.js
+++ b/test/services/notifications/setup/review.service.test.js
@@ -56,7 +56,7 @@ describe('Notifications Setup - Review service', () => {
       ],
       recipientsAmount: 1,
       text: {
-        continueButton: 'Send invitations',
+        continueButton: 'Send',
         readyToSend: 'Returns invitations are ready to send.',
         title: 'Send returns invitations'
       }

--- a/test/services/notifications/setup/review.service.test.js
+++ b/test/services/notifications/setup/review.service.test.js
@@ -24,7 +24,9 @@ describe('Notifications Setup - Review service', () => {
   before(async () => {
     removeLicences = ''
 
-    session = await SessionHelper.add({ data: { returnsPeriod: 'quarterFour', removeLicences } })
+    session = await SessionHelper.add({
+      data: { returnsPeriod: 'quarterFour', removeLicences, journey: 'invitations' }
+    })
 
     testRecipients = RecipientsFixture.recipients()
 
@@ -41,7 +43,6 @@ describe('Notifications Setup - Review service', () => {
         download: `/system/notifications/setup/${session.id}/download`,
         removeLicences: `/system/notifications/setup/${session.id}/remove-licences`
       },
-      pageTitle: 'Send returns invitations',
       page: 1,
       pagination: {
         numberOfPages: 1
@@ -53,7 +54,12 @@ describe('Notifications Setup - Review service', () => {
           method: 'Email - Primary user'
         }
       ],
-      recipientsAmount: 1
+      recipientsAmount: 1,
+      text: {
+        continueButton: 'Send invitations',
+        readyToSend: 'Returns invitations are ready to send.',
+        title: 'Send returns invitations'
+      }
     })
   })
 })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4900

This change introduces the 'journey' context into the notifications setup review service and presenter.

This journey context is used to determine what text is shown to the user relative to the journey.

The ad hoc journey is a 'notification' and the invitations (and reminder - not yet implemented) is an 'invitations'.

The ad hoc journey does not show the remove licences link and has been blanked to be hidden in the view.

The previous static text for additional information and button text has been moved into the presenter to enable dynamic content.

Previous work has been done for the fetching of recipients https://github.com/DEFRA/water-abstraction-system/pull/1718.