### PR TITLE
Add reference code to notification views

### DIFF
--- a/app/presenters/notifications/setup/ad-hoc-licence.presenter.js
+++ b/app/presenters/notifications/setup/ad-hoc-licence.presenter.js
@@ -9,13 +9,15 @@
  * Formats data for the `/notifications/setup/{sessionId}/ad-hoc-licence` page
  *
  * @param {string} licenceRef
+ * @param {string} referenceCode - the unique generated reference code
  *
  * @returns {object} - The data formatted for the view template
  */
-function go(licenceRef) {
+function go(licenceRef, referenceCode) {
   return {
     licenceRef: licenceRef || null,
-    pageTitle: 'Enter a licence number'
+    pageTitle: 'Enter a licence number',
+    referenceCode
   }
 }
 

--- a/app/presenters/notifications/setup/check.presenter.js
+++ b/app/presenters/notifications/setup/check.presenter.js
@@ -19,17 +19,18 @@ const { defaultPageSize } = require('../../../../config/database.config.js')
  * @returns {object} - The data formatted for the view template
  */
 function go(recipients, page, pagination, session) {
-  const { id: sessionId, journey } = session
+  const { id: sessionId, journey, referenceCode } = session
 
   return {
     defaultPageSize,
-    text: _text(page, pagination, journey),
-    recipients: _recipients(recipients, page),
-    recipientsAmount: recipients.length,
     links: {
       download: `/system/notifications/setup/${sessionId}/download`,
       removeLicences: journey !== 'ad-hoc' ? `/system/notifications/setup/${sessionId}/remove-licences` : ''
-    }
+    },
+    recipients: _recipients(recipients, page),
+    recipientsAmount: recipients.length,
+    referenceCode,
+    text: _text(page, pagination, journey)
   }
 }
 

--- a/app/presenters/notifications/setup/remove-licences.presenter.js
+++ b/app/presenters/notifications/setup/remove-licences.presenter.js
@@ -9,13 +9,15 @@
  * Formats data for the `/notifications/setup/remove-licences` page
  *
  * @param {string[]} removeLicences - List of licences to remove from the recipients list
+ * @param {string} referenceCode - the unique generated reference code
  *
  * @returns {object} - The data formatted for the view template
  */
-function go(removeLicences) {
+function go(removeLicences, referenceCode) {
   return {
-    pageTitle: 'Enter the licence numbers to remove from the mailing list',
     hint: 'Separate the licences numbers with a comma or new line.',
+    pageTitle: 'Enter the licence numbers to remove from the mailing list',
+    referenceCode,
     removeLicences
   }
 }

--- a/app/presenters/notifications/setup/returns-period.presenter.js
+++ b/app/presenters/notifications/setup/returns-period.presenter.js
@@ -17,10 +17,13 @@ const { formatLongDate } = require('../../base.presenter.js')
  * @returns {object} - The data formatted for the view template
  */
 function go(session) {
+  const { referenceCode } = session
+
   const savedReturnsPeriod = session.returnsPeriod ?? null
 
   return {
     backLink: '/manage',
+    referenceCode,
     returnsPeriod: _returnsPeriod(savedReturnsPeriod)
   }
 }

--- a/app/services/notifications/setup/ad-hoc-licence.service.js
+++ b/app/services/notifications/setup/ad-hoc-licence.service.js
@@ -21,7 +21,7 @@ const SessionModel = require('../../../models/session.model.js')
 async function go(sessionId) {
   const session = await SessionModel.query().findById(sessionId)
 
-  const formattedData = AdHocLicencePresenter.go(session.licenceRef)
+  const formattedData = AdHocLicencePresenter.go(session.licenceRef, session.referenceCode)
 
   return {
     activeNavBar: 'manage',

--- a/app/services/notifications/setup/remove-licences.service.js
+++ b/app/services/notifications/setup/remove-licences.service.js
@@ -20,7 +20,7 @@ async function go(sessionId) {
 
   const { removeLicences = [] } = session
 
-  const formattedData = RemoveLicencesPresenter.go(removeLicences)
+  const formattedData = RemoveLicencesPresenter.go(removeLicences, session.referenceCode)
 
   return {
     activeNavBar: 'manage',

--- a/app/services/notifications/setup/submit-ad-hoc-licence.service.js
+++ b/app/services/notifications/setup/submit-ad-hoc-licence.service.js
@@ -30,7 +30,7 @@ async function go(sessionId, payload) {
 
   const validationResult = await _validate(payload)
 
-  const formattedData = AdHocLicencePresenter.go(payload.licenceRef)
+  const formattedData = AdHocLicencePresenter.go(payload.licenceRef, session.referenceCode)
 
   if (validationResult) {
     return {

--- a/app/services/notifications/setup/submit-remove-licences.service.js
+++ b/app/services/notifications/setup/submit-remove-licences.service.js
@@ -28,7 +28,7 @@ async function go(sessionId, payload) {
   const validationResult = _validate(payload, validLicences)
 
   if (validationResult) {
-    const formattedData = RemoveLicencesPresenter.go(payload.removeLicences)
+    const formattedData = RemoveLicencesPresenter.go(payload.removeLicences, session.referenceCode)
 
     return {
       activeNavBar: 'manage',

--- a/app/views/notifications/setup/ad-hoc-licence.njk
+++ b/app/views/notifications/setup/ad-hoc-licence.njk
@@ -31,6 +31,8 @@
       <input type="hidden" name="wrlsCrumb" value="{{wrlsCrumb}}"/>
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-two-thirds">
+            <span class="govuk-caption-l"> Notification {{referenceCode}} </span>
+
             {{ govukInput({
             label: {
               text: pageTitle,

--- a/app/views/notifications/setup/check.njk
+++ b/app/views/notifications/setup/check.njk
@@ -47,6 +47,8 @@
 
 {% block content %}
   <div class="govuk-body">
+    <span class="govuk-caption-l"> Notification {{referenceCode}} </span>
+
     <h1 class="govuk-heading-l"> {{ text.title }} </h1>
 
     <p> {{ text.readyToSend }}</p>

--- a/app/views/notifications/setup/remove-licences.njk
+++ b/app/views/notifications/setup/remove-licences.njk
@@ -28,6 +28,8 @@
     <form method="post">
       <input type="hidden" name="wrlsCrumb" value="{{ wrlsCrumb }}" />
 
+      <span class="govuk-caption-l"> Notification {{referenceCode}} </span>
+
       {{ govukTextarea({
         name: "removeLicences",
         id: "remove-licences",

--- a/app/views/notifications/setup/view-returns-period.njk
+++ b/app/views/notifications/setup/view-returns-period.njk
@@ -28,6 +28,8 @@
     <form method="post">
       <input type="hidden" name="wrlsCrumb" value="{{ wrlsCrumb }}"/>
 
+      <span class="govuk-caption-l"> Notification {{referenceCode}} </span>
+
       {{ govukRadios({
         name: "returnsPeriod",
         errorMessage: error,

--- a/test/presenters/notifications/setup/ad-hoc-licence.presenter.test.js
+++ b/test/presenters/notifications/setup/ad-hoc-licence.presenter.test.js
@@ -11,14 +11,17 @@ const { expect } = Code
 const AdHocLicencePresenter = require('../../../../app/presenters/notifications/setup/ad-hoc-licence.presenter.js')
 
 describe('Notifications Setup - Ad Hoc Licence presenter', () => {
+  const referenceCode = 'ADHC-1234'
+
   let licenceRef
 
   it('correctly presents the data', () => {
-    const result = AdHocLicencePresenter.go(licenceRef)
+    const result = AdHocLicencePresenter.go(licenceRef, referenceCode)
 
     expect(result).to.equal({
       licenceRef: null,
-      pageTitle: 'Enter a licence number'
+      pageTitle: 'Enter a licence number',
+      referenceCode
     })
   })
 
@@ -28,11 +31,12 @@ describe('Notifications Setup - Ad Hoc Licence presenter', () => {
     })
 
     it('correctly presents the data', () => {
-      const result = AdHocLicencePresenter.go(licenceRef)
+      const result = AdHocLicencePresenter.go(licenceRef, referenceCode)
 
       expect(result).to.equal({
         licenceRef: '01/111',
-        pageTitle: 'Enter a licence number'
+        pageTitle: 'Enter a licence number',
+        referenceCode
       })
     })
   })

--- a/test/presenters/notifications/setup/check.presenter.test.js
+++ b/test/presenters/notifications/setup/check.presenter.test.js
@@ -28,7 +28,7 @@ describe('Notifications Setup - Check presenter', () => {
       numberOfPages: 1
     }
 
-    session = { id: generateUUID(), journey: 'invitations' }
+    session = { id: generateUUID(), journey: 'invitations', referenceCode: 'RINV-123' }
 
     testRecipients = RecipientsFixture.recipients()
     // This data is used to ensure the recipients are grouped when they have the same licence ref / name.
@@ -112,6 +112,7 @@ describe('Notifications Setup - Check presenter', () => {
           }
         ],
         recipientsAmount: 9,
+        referenceCode: 'RINV-123',
         text: {
           continueButton: 'Send',
           readyToSend: 'Returns invitations are ready to send.',
@@ -123,6 +124,7 @@ describe('Notifications Setup - Check presenter', () => {
     describe('when the journey is for "invitations"', () => {
       beforeEach(() => {
         session.journey = 'invitations'
+        session.referenceCode = 'RINV-123'
       })
 
       describe('the "links" property', () => {
@@ -331,6 +333,7 @@ describe('Notifications Setup - Check presenter', () => {
     describe('when the journey is for "ad-hoc"', () => {
       beforeEach(() => {
         session.journey = 'ad-hoc'
+        session.referenceCode = 'ADHC-123'
       })
 
       describe('the "links" property', () => {

--- a/test/presenters/notifications/setup/remove-licences.presenter.test.js
+++ b/test/presenters/notifications/setup/remove-licences.presenter.test.js
@@ -12,13 +12,15 @@ const RemoveLicencesPresenter = require('../../../../app/presenters/notification
 
 describe('Notifications Setup - Remove licences presenter', () => {
   const licences = []
+  const referenceCode = 'RINV-1234'
 
   it('correctly presents the data', () => {
-    const result = RemoveLicencesPresenter.go(licences)
+    const result = RemoveLicencesPresenter.go(licences, referenceCode)
 
     expect(result).to.equal({
       hint: 'Separate the licences numbers with a comma or new line.',
       pageTitle: 'Enter the licence numbers to remove from the mailing list',
+      referenceCode,
       removeLicences: []
     })
   })

--- a/test/presenters/notifications/setup/returns-period.presenter.test.js
+++ b/test/presenters/notifications/setup/returns-period.presenter.test.js
@@ -25,15 +25,23 @@ describe('Notifications Setup - Returns Period presenter', () => {
     clock.restore()
   })
 
-  describe('the "backLink" property', () => {
+  describe('the data', () => {
     beforeEach(() => {
+      session = { referenceCode: 'RINV-123' }
       testDate = new Date(`${currentYear}-01-15`)
       clock = Sinon.useFakeTimers(testDate)
     })
+
     it('correctly presents the data', () => {
       const result = ReturnsPeriodPresenter.go(session)
 
-      expect(result).to.equal({ backLink: '/manage' }, { skip: ['returnsPeriod'] })
+      expect(result).to.equal(
+        {
+          backLink: '/manage',
+          referenceCode: 'RINV-123'
+        },
+        { skip: ['returnsPeriod'] }
+      )
     })
   })
 

--- a/test/services/notifications/setup/ad-hoc-licence.service.test.js
+++ b/test/services/notifications/setup/ad-hoc-licence.service.test.js
@@ -18,7 +18,7 @@ describe('Notifications Setup - Ad Hoc Licence service', () => {
   let session
 
   beforeEach(async () => {
-    session = await SessionHelper.add({ data: { licenceRef: '01/111' } })
+    session = await SessionHelper.add({ data: { licenceRef: '01/111', referenceCode: 'ADHC-1234' } })
   })
 
   afterEach(() => {
@@ -32,7 +32,8 @@ describe('Notifications Setup - Ad Hoc Licence service', () => {
       expect(result).to.equal({
         activeNavBar: 'manage',
         licenceRef: '01/111',
-        pageTitle: 'Enter a licence number'
+        pageTitle: 'Enter a licence number',
+        referenceCode: 'ADHC-1234'
       })
     })
   })

--- a/test/services/notifications/setup/check.service.test.js
+++ b/test/services/notifications/setup/check.service.test.js
@@ -25,7 +25,7 @@ describe('Notifications Setup - Review service', () => {
     removeLicences = ''
 
     session = await SessionHelper.add({
-      data: { returnsPeriod: 'quarterFour', removeLicences, journey: 'invitations' }
+      data: { returnsPeriod: 'quarterFour', removeLicences, journey: 'invitations', referenceCode: 'RINV-123' }
     })
 
     testRecipients = RecipientsFixture.recipients()
@@ -55,6 +55,7 @@ describe('Notifications Setup - Review service', () => {
         }
       ],
       recipientsAmount: 1,
+      referenceCode: 'RINV-123',
       text: {
         continueButton: 'Send',
         readyToSend: 'Returns invitations are ready to send.',

--- a/test/services/notifications/setup/remove-licences.service.test.js
+++ b/test/services/notifications/setup/remove-licences.service.test.js
@@ -19,7 +19,7 @@ describe('Notifications Setup - Remove licences service', () => {
   let session
 
   beforeEach(async () => {
-    session = await SessionHelper.add({ data: { licences } })
+    session = await SessionHelper.add({ data: { licences, referenceCode: 'RINV-1234' } })
   })
 
   it('correctly presents the data', async () => {
@@ -29,6 +29,7 @@ describe('Notifications Setup - Remove licences service', () => {
       activeNavBar: 'manage',
       hint: 'Separate the licences numbers with a comma or new line.',
       pageTitle: 'Enter the licence numbers to remove from the mailing list',
+      referenceCode: 'RINV-1234',
       removeLicences: []
     })
   })

--- a/test/services/notifications/setup/returns-period.service.test.js
+++ b/test/services/notifications/setup/returns-period.service.test.js
@@ -19,7 +19,7 @@ describe('Notifications Setup - Returns Period service', () => {
   let session
 
   before(async () => {
-    session = await SessionHelper.add()
+    session = await SessionHelper.add({ data: { referenceCode: 'RINV-123' } })
 
     const testDate = new Date('2024-12-01')
 
@@ -38,6 +38,7 @@ describe('Notifications Setup - Returns Period service', () => {
         activeNavBar: 'manage',
         backLink: '/manage',
         pageTitle: 'Select the returns periods for the invitations',
+        referenceCode: 'RINV-123',
         returnsPeriod: [
           {
             checked: false,

--- a/test/services/notifications/setup/submit-ad-hoc-licence.service.test.js
+++ b/test/services/notifications/setup/submit-ad-hoc-licence.service.test.js
@@ -20,7 +20,7 @@ describe('Notifications Setup - Submit Ad Hoc Licence service', () => {
   let session
 
   beforeEach(async () => {
-    session = await SessionHelper.add({ data: {} })
+    session = await SessionHelper.add({ data: { referenceCode: 'ADHC-1234' } })
   })
 
   describe('when called', () => {
@@ -64,7 +64,8 @@ describe('Notifications Setup - Submit Ad Hoc Licence service', () => {
             error: {
               text: 'Enter a licence number'
             },
-            pageTitle: 'Enter a licence number'
+            pageTitle: 'Enter a licence number',
+            referenceCode: 'ADHC-1234'
           })
         })
       })
@@ -85,7 +86,8 @@ describe('Notifications Setup - Submit Ad Hoc Licence service', () => {
             error: {
               text: 'Enter a valid licence number'
             },
-            pageTitle: 'Enter a licence number'
+            pageTitle: 'Enter a licence number',
+            referenceCode: 'ADHC-1234'
           })
         })
       })
@@ -108,7 +110,8 @@ describe('Notifications Setup - Submit Ad Hoc Licence service', () => {
               text: 'There are no returns due for licence 01/145'
             },
             licenceRef: '01/145',
-            pageTitle: 'Enter a licence number'
+            pageTitle: 'Enter a licence number',
+            referenceCode: 'ADHC-1234'
           })
         })
       })

--- a/test/services/notifications/setup/submit-remove-licences.services.test.js
+++ b/test/services/notifications/setup/submit-remove-licences.services.test.js
@@ -29,7 +29,7 @@ describe('Notifications Setup - Submit Remove licences service', () => {
   })
 
   beforeEach(async () => {
-    session = await SessionHelper.add({ data: { returnsPeriod: 'quarterFour' } })
+    session = await SessionHelper.add({ data: { returnsPeriod: 'quarterFour', referenceCode: 'RINV-123' } })
 
     validLicences = [{ licenceRef: '1234' }]
 
@@ -85,6 +85,7 @@ describe('Notifications Setup - Submit Remove licences service', () => {
           },
           hint: 'Separate the licences numbers with a comma or new line.',
           removeLicences: '789',
+          referenceCode: 'RINV-123',
           pageTitle: 'Enter the licence numbers to remove from the mailing list'
         })
       })

--- a/test/services/notifications/setup/submit-returns-period.services.test.js
+++ b/test/services/notifications/setup/submit-returns-period.services.test.js
@@ -31,7 +31,7 @@ describe('Notifications Setup - Submit Returns Period service', () => {
   describe('when submitting as returns period ', () => {
     describe('is successful', () => {
       beforeEach(async () => {
-        session = await SessionHelper.add()
+        session = await SessionHelper.add({ data: { referenceCode: 'RINV-1234' } })
 
         payload = { returnsPeriod: 'quarterFour' }
       })
@@ -55,7 +55,7 @@ describe('Notifications Setup - Submit Returns Period service', () => {
 
     describe('fails validation', () => {
       beforeEach(async () => {
-        session = await SessionHelper.add()
+        session = await SessionHelper.add({ data: { referenceCode: 'RINV-1234' } })
         payload = {}
       })
       it('correctly presents the data with the error', async () => {
@@ -68,6 +68,7 @@ describe('Notifications Setup - Submit Returns Period service', () => {
             text: 'Select the returns periods for the invitations'
           },
           pageTitle: 'Select the returns periods for the invitations',
+          referenceCode: 'RINV-1234',
           returnsPeriod: [
             {
               checked: false,


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4900

This change refactors all the view pages for the notifications setup journey.

We have a common view pattern of displaying relevant information above the page title for users.

This change adds the reference code above the page title for all pages on the notifications setup journey.

The reference code is unique to each journey. It is created when the session is initialised and is used to name downloadable file.