### PR TITLE
Fix return log under query notification

### DIFF
--- a/app/controllers/return-logs.controller.js
+++ b/app/controllers/return-logs.controller.js
@@ -20,7 +20,7 @@ async function view(request, h) {
 
   const version = query.version ? Number(query.version) : 0
 
-  const pageData = await ViewReturnLogService.go(query.id, version, auth, request.yar)
+  const pageData = await ViewReturnLogService.go(query.id, version, auth)
 
   return h.view('return-logs/view.njk', pageData)
 }
@@ -28,7 +28,7 @@ async function view(request, h) {
 async function submitView(request, h) {
   const { id } = request.query
 
-  await SubmitViewReturnLogService.go(id, request.yar, request.payload)
+  await SubmitViewReturnLogService.go(id, request.payload)
 
   return h.redirect(`/system/return-logs?id=${id}`)
 }

--- a/app/services/return-logs/submit-view-return-log.service.js
+++ b/app/services/return-logs/submit-view-return-log.service.js
@@ -1,35 +1,31 @@
 'use strict'
 
 /**
- * Handles updating a return log record when the query button is clicked
+ * Handles updating a return log record when the mark/resolve query button is clicked
  * @module SubmitViewReturnLogService
  */
 
+const { timestampForPostgres } = require('../../lib/general.lib.js')
 const ReturnLogModel = require('../../models/return-log.model.js')
 
 /**
- * Handles updating a return log record when the mark query button is clicked
+ * Handles updating a return log record when the mark/resolve query button is clicked
  *
- * The mark query button in the view return log screen toggles whether or not a licence is 'under query'.
+ * The mark/resolve query button in the view return log screen toggles whether or not a licence is 'under query'.
  *
- * If the return log is marked as under query then we update the `ReturnLogModel` record and set a `flash()` message in
- * the session so that when the request is redirected to the `GET` it knows to display a notification banner to confirm.
+ * If the return log is marked as under query then we update the `ReturnLogModel` record. This will cause a notification
+ * banner to display when viewing the return log. so the user knows it is 'under query'.
  *
- * If the return log is marked as not under query (ie. the query is resolved) then we update the `ReturnLogModel` record
- * but don't set a `flash()` message in the session as this is not part of the design.
+ * If the return log was already marked as under query, when the request comes to this page it will update the the
+ * return log to unmark it. When the user is redirected back to the view return log page the notification will be gone.
  *
  * @param {string} returnLogId - The id of the return log to update
- * @param {object} yar - The Hapi Yar session manager
  * @param {object} payload - The submitted form data
  */
-async function go(returnLogId, yar, payload) {
-  const markUnderQuery = payload['mark-query'] === 'mark'
+async function go(returnLogId, payload) {
+  const underQuery = payload['mark-query'] === 'mark'
 
-  if (markUnderQuery) {
-    yar.flash('banner', 'This return has been marked under query.')
-  }
-
-  await ReturnLogModel.query().findById(returnLogId).patch({ underQuery: markUnderQuery })
+  await ReturnLogModel.query().findById(returnLogId).patch({ underQuery, updatedAt: timestampForPostgres() })
 }
 
 module.exports = {

--- a/app/services/return-logs/view-return-log.service.js
+++ b/app/services/return-logs/view-return-log.service.js
@@ -14,20 +14,16 @@ const ViewReturnLogPresenter = require('../../presenters/return-logs/view-return
  * @param {string} returnId - The ID of the return log to view
  * @param {number} version - The version number of the associated return submission to view (0 means 'current')
  * @param {object} auth - The auth object taken from `request.auth` containing user details
- * @param {object} yar - The Hapi `request.yar` session manager passed on by the controller
  *
  * @returns {Promise<object>} an object representing the `pageData` needed by the view return log template.
  */
-async function go(returnId, version, auth, yar) {
+async function go(returnId, version, auth) {
   const returnLog = await FetchReturnLogService.go(returnId, version)
-
-  const [notificationBannerMessage] = yar.flash('banner')
 
   const pageData = ViewReturnLogPresenter.go(returnLog, auth)
 
   return {
     activeNavBar: 'search',
-    notificationBannerMessage,
     ...pageData
   }
 }

--- a/app/views/return-logs/view.njk
+++ b/app/views/return-logs/view.njk
@@ -20,9 +20,9 @@
 
 {% block content %}
   {# Notification banner #}
-  {% if notificationBannerMessage %}
+  {% if underQuery %}
     {{ govukNotificationBanner({
-      text: notificationBannerMessage
+      text: 'This return has been marked under query'
     }) }}
   {%endif%}
 

--- a/test/controllers/return-logs.controller.test.js
+++ b/test/controllers/return-logs.controller.test.js
@@ -8,7 +8,11 @@ const Sinon = require('sinon')
 const { describe, it, before, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
+// Test helpers
+const { postRequestOptions } = require('../support/general.js')
+
 // Things we need to stub
+const SubmitViewReturnLogService = require('../../app/services/return-logs/submit-view-return-log.service.js')
 const ViewReturnLogService = require('../../app/services/return-logs/view-return-log.service.js')
 
 // For running our service
@@ -82,19 +86,26 @@ describe('Return Logs controller', () => {
         })
       })
     })
+
+    describe('POST', () => {
+      describe('when the request succeeds', () => {
+        beforeEach(() => {
+          Sinon.stub(SubmitViewReturnLogService, 'go').resolves()
+        })
+
+        it('redirects back to the "view return log" page', async () => {
+          const response = await server.inject(_postOptions({ returnLogId: 'RETURN_LOG_ID' }))
+
+          expect(response.statusCode).to.equal(302)
+          expect(response.headers.location).to.equal('/system/return-logs?id=RETURN_LOG_ID')
+        })
+      })
+    })
   })
 })
 
-function _getOptions(id = true, version) {
-  const url = new URL('/return-logs', 'http://example.com')
-
-  if (id) {
-    url.searchParams.append('id', 'RETURN_LOG_ID')
-  }
-
-  if (version) {
-    url.searchParams.append('version', version)
-  }
+function _getOptions(includeReturnLogId = true, version) {
+  const url = _url(includeReturnLogId, version)
 
   return {
     method: 'GET',
@@ -104,4 +115,24 @@ function _getOptions(id = true, version) {
       credentials: { scope: ['billing'] }
     }
   }
+}
+
+function _postOptions(payload) {
+  const url = _url(true, null)
+
+  return postRequestOptions(`${url.pathname}${url.search}`, payload)
+}
+
+function _url(includeReturnLogId, version) {
+  const url = new URL('/return-logs', 'http://example.com')
+
+  if (includeReturnLogId) {
+    url.searchParams.append('id', 'RETURN_LOG_ID')
+  }
+
+  if (version) {
+    url.searchParams.append('version', version)
+  }
+
+  return url
 }

--- a/test/services/return-logs/submit-view-return-log.service.test.js
+++ b/test/services/return-logs/submit-view-return-log.service.test.js
@@ -19,7 +19,6 @@ describe('Submit View Return Log Service', () => {
   let payload
   let patchStub
   let mockReturnLog
-  let yarStub
 
   beforeEach(async () => {
     mockReturnLog = ReturnLogModel.fromJson({ ...ReturnLogHelper.defaults() })
@@ -29,8 +28,6 @@ describe('Submit View Return Log Service', () => {
       findById: Sinon.stub().withArgs(mockReturnLog.id).returnsThis(),
       patch: patchStub
     })
-
-    yarStub = { flash: Sinon.stub() }
   })
 
   afterEach(() => {
@@ -43,19 +40,13 @@ describe('Submit View Return Log Service', () => {
         payload = { 'mark-query': 'mark' }
       })
 
-      it('sets a flash message and updates the status of the return log', async () => {
-        await SubmitViewReturnLogService.go(mockReturnLog.id, yarStub, payload)
+      it('updates the "underQuery" flag on the return log to true', async () => {
+        await SubmitViewReturnLogService.go(mockReturnLog.id, payload)
 
         // Check we save the status change
         const [patchObject] = patchStub.args[0]
 
-        expect(patchObject).to.equal({ underQuery: true })
-
-        // Check we add the flash message
-        const [flashType, bannerMessage] = yarStub.flash.args[0]
-
-        expect(flashType).to.equal('banner')
-        expect(bannerMessage).to.equal('This return has been marked under query.')
+        expect(patchObject).to.equal({ underQuery: true }, { skip: ['updatedAt'] })
       })
     })
 
@@ -64,18 +55,13 @@ describe('Submit View Return Log Service', () => {
         payload = { 'mark-query': 'resolve' }
       })
 
-      it('updates the status of the return log with no flash message set', async () => {
-        await SubmitViewReturnLogService.go(mockReturnLog.id, yarStub, payload)
+      it('updates the "underQuery" flag on the return log to false', async () => {
+        await SubmitViewReturnLogService.go(mockReturnLog.id, payload)
 
         // Check we save the status change
         const [patchObject] = patchStub.args[0]
 
-        expect(patchObject).to.equal({ underQuery: false })
-
-        // Check there is no flash message
-        const flashArgs = yarStub.flash.args[0]
-
-        expect(flashArgs).to.not.exist()
+        expect(patchObject).to.equal({ underQuery: false }, { skip: ['updatedAt'] })
       })
     })
   })

--- a/test/services/return-logs/view-return-log.service.test.js
+++ b/test/services/return-logs/view-return-log.service.test.js
@@ -21,8 +21,6 @@ const ReturnLogHelper = require('../../support/helpers/return-log.helper.js')
 const ViewReturnLogService = require('../../../app/services/return-logs/view-return-log.service.js')
 
 describe('View Return Log service', () => {
-  let yarStub
-
   beforeEach(() => {
     const mockReturnLog = ReturnLogModel.fromJson({
       ...ReturnLogHelper.defaults({
@@ -32,10 +30,6 @@ describe('View Return Log service', () => {
     })
 
     Sinon.stub(FetchReturnLogService, 'go').resolves(mockReturnLog)
-
-    yarStub = {
-      flash: Sinon.stub().returns(['NOTIFICATION_BANNER_MESSAGE'])
-    }
   })
 
   afterEach(() => {
@@ -43,13 +37,12 @@ describe('View Return Log service', () => {
   })
 
   it('correctly fetches return log and transforms it via the presenter', async () => {
-    const result = await ViewReturnLogService.go('RETURN_ID', 0, { credentials: { scope: ['returns'] } }, yarStub)
+    const result = await ViewReturnLogService.go('RETURN_ID', 0, { credentials: { scope: ['returns'] } })
 
     // We only check a couple of items here -- the key thing is that the mock return log was fetched and successfully
     // passed to the presenter
     expect(result).to.include({
       activeNavBar: 'search',
-      notificationBannerMessage: 'NOTIFICATION_BANNER_MESSAGE',
       pageTitle: 'Abstraction return'
     })
   })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4893

We recently added the ability to [mark and unmark returns as 'Under query'](https://github.com/DEFRA/water-abstraction-system/pull/1671) to our new view return logs page.

What we didn't spot when it was added is that it follows our 'flash notification' pattern, which doesn't apply in this scenario.

For example, imagine viewing a return log that is not under query.

- the user clicks the `Mark as under query` button
- we set the flag on the return log and redirect them back to the view return log page
- we display a [notification banner](https://design-system.service.gov.uk/components/notification-banner/) that states _"This return has been marked under query."_
- the user refreshes or goes away and comes back to the page, the notification is no longer shown

This is our 'flash notification' pattern. However, it does not apply in this scenario. This is because if it did, once the page has been refreshed, the _only_ indication there is a query with the return log is the state of the button, which now has the label `Resolve query`.

The intent was that the banner remains, for example, in the same way the banner is continuously displayed for licences flagged for supplementary billing.

This change updates the functionality to match the expected behaviour.