### PR TITLE
Fix missing page title in check recipients page

### DIFF
--- a/app/presenters/notifications/setup/check.presenter.js
+++ b/app/presenters/notifications/setup/check.presenter.js
@@ -8,6 +8,12 @@
 const { contactName, contactAddress } = require('../../crm.presenter.js')
 const { defaultPageSize } = require('../../../../config/database.config.js')
 
+const NOTIFICATION_TYPES = {
+  'ad-hoc': 'Ad-hoc notifications',
+  invitations: 'Returns invitations',
+  reminders: 'Returns reminders'
+}
+
 /**
  * Formats data for the `/notifications/setup/check` page
  *
@@ -27,10 +33,11 @@ function go(recipients, page, pagination, session) {
       download: `/system/notifications/setup/${sessionId}/download`,
       removeLicences: journey !== 'ad-hoc' ? `/system/notifications/setup/${sessionId}/remove-licences` : ''
     },
+    pageTitle: _pageTitle(page, pagination),
+    readyToSend: `${NOTIFICATION_TYPES[journey]} are ready to send.`,
     recipients: _recipients(recipients, page),
     recipientsAmount: recipients.length,
-    referenceCode,
-    text: _text(page, pagination, journey)
+    referenceCode
   }
 }
 
@@ -63,24 +70,12 @@ function _formatRecipients(recipients) {
   })
 }
 
-function _text(page, pagination, journey) {
-  const type = {
-    'ad-hoc': 'Ad-hoc notifications',
-    invitations: 'Returns invitations',
-    reminders: 'Returns reminders'
-  }
-
-  let title = `Check the recipients`
-
+function _pageTitle(page, pagination) {
   if (pagination.numberOfPages > 1) {
-    title += ` (page ${page} of ${pagination.numberOfPages})`
+    return `Check the recipients (page ${page} of ${pagination.numberOfPages})`
   }
 
-  return {
-    title,
-    readyToSend: `${type[journey]} are ready to send.`,
-    continueButton: 'Send'
-  }
+  return `Check the recipients`
 }
 
 /**

--- a/app/views/notifications/setup/check.njk
+++ b/app/views/notifications/setup/check.njk
@@ -49,9 +49,9 @@
   <div class="govuk-body">
     <span class="govuk-caption-l"> Notification {{referenceCode}} </span>
 
-    <h1 class="govuk-heading-l"> {{ text.title }} </h1>
+    <h1 class="govuk-heading-l"> {{ pageTitle }} </h1>
 
-    <p> {{ text.readyToSend }}</p>
+    <p> {{ readyToSend }}</p>
 
     <div class="govuk-button-group">
 
@@ -105,7 +105,7 @@
     <form method="post">
       <input type="hidden" name="wrlsCrumb" value="{{ wrlsCrumb }}"/>
 
-      {{ govukButton({ text: text.continueButton, preventDoubleClick: true }) }}
+      {{ govukButton({ text: 'Send', preventDoubleClick: true }) }}
     </form>
   </div>
 {% endblock %}

--- a/test/presenters/notifications/setup/check.presenter.test.js
+++ b/test/presenters/notifications/setup/check.presenter.test.js
@@ -57,6 +57,8 @@ describe('Notifications Setup - Check presenter', () => {
           download: `/system/notifications/setup/${session.id}/download`,
           removeLicences: `/system/notifications/setup/${session.id}/remove-licences`
         },
+        pageTitle: 'Check the recipients',
+        readyToSend: 'Returns invitations are ready to send.',
         recipients: [
           {
             contact: ['Mr H J Duplicate Licence holder', '4', 'Privet Drive', 'Little Whinging', 'Surrey', 'WD25 7LR'],
@@ -112,12 +114,7 @@ describe('Notifications Setup - Check presenter', () => {
           }
         ],
         recipientsAmount: 9,
-        referenceCode: 'RINV-123',
-        text: {
-          continueButton: 'Send',
-          readyToSend: 'Returns invitations are ready to send.',
-          title: 'Check the recipients'
-        }
+        referenceCode: 'RINV-123'
       })
     })
 
@@ -294,14 +291,10 @@ describe('Notifications Setup - Check presenter', () => {
               expect(result.recipients.length).to.equal(25)
             })
 
-            it('returns the updated "text"', () => {
+            it('returns the updated "pageTitle"', () => {
               const result = CheckPresenter.go(testInput, page, pagination, session)
 
-              expect(result.text).to.equal({
-                continueButton: 'Send',
-                readyToSend: 'Returns invitations are ready to send.',
-                title: 'Check the recipients (page 1 of 2)'
-              })
+              expect(result.pageTitle).to.equal('Check the recipients (page 1 of 2)')
             })
           })
 
@@ -316,14 +309,10 @@ describe('Notifications Setup - Check presenter', () => {
               expect(result.recipients.length).to.equal(2)
             })
 
-            it('returns the updated "text"', () => {
+            it('returns the updated "pageTitle"', () => {
               const result = CheckPresenter.go(testInput, page, pagination, session)
 
-              expect(result.text).to.equal({
-                continueButton: 'Send',
-                readyToSend: 'Returns invitations are ready to send.',
-                title: 'Check the recipients (page 2 of 2)'
-              })
+              expect(result.pageTitle).to.equal('Check the recipients (page 2 of 2)')
             })
           })
         })
@@ -503,14 +492,10 @@ describe('Notifications Setup - Check presenter', () => {
               expect(result.recipients.length).to.equal(25)
             })
 
-            it('returns the updated "text"', () => {
+            it('returns the updated "pageTitle"', () => {
               const result = CheckPresenter.go(testInput, page, pagination, session)
 
-              expect(result.text).to.equal({
-                continueButton: 'Send',
-                readyToSend: 'Ad-hoc notifications are ready to send.',
-                title: 'Check the recipients (page 1 of 2)'
-              })
+              expect(result.pageTitle).to.equal('Check the recipients (page 1 of 2)')
             })
           })
 
@@ -525,14 +510,10 @@ describe('Notifications Setup - Check presenter', () => {
               expect(result.recipients.length).to.equal(2)
             })
 
-            it('returns the updated "text"', () => {
+            it('returns the updated "pageTitle"', () => {
               const result = CheckPresenter.go(testInput, page, pagination, session)
 
-              expect(result.text).to.equal({
-                continueButton: 'Send',
-                readyToSend: 'Ad-hoc notifications are ready to send.',
-                title: 'Check the recipients (page 2 of 2)'
-              })
+              expect(result.pageTitle).to.equal('Check the recipients (page 2 of 2)')
             })
           })
         })
@@ -711,14 +692,10 @@ describe('Notifications Setup - Check presenter', () => {
               expect(result.recipients.length).to.equal(25)
             })
 
-            it('returns the updated "text"', () => {
+            it('returns the updated "pageTitle"', () => {
               const result = CheckPresenter.go(testInput, page, pagination, session)
 
-              expect(result.text).to.equal({
-                continueButton: 'Send',
-                readyToSend: 'Returns reminders are ready to send.',
-                title: 'Check the recipients (page 1 of 2)'
-              })
+              expect(result.pageTitle).to.equal('Check the recipients (page 1 of 2)')
             })
           })
 
@@ -733,14 +710,10 @@ describe('Notifications Setup - Check presenter', () => {
               expect(result.recipients.length).to.equal(2)
             })
 
-            it('returns the updated "text"', () => {
+            it('returns the updated "pageTitle"', () => {
               const result = CheckPresenter.go(testInput, page, pagination, session)
 
-              expect(result.text).to.equal({
-                continueButton: 'Send',
-                readyToSend: 'Returns reminders are ready to send.',
-                title: 'Check the recipients (page 2 of 2)'
-              })
+              expect(result.pageTitle).to.equal('Check the recipients (page 2 of 2)')
             })
           })
         })

--- a/test/services/notifications/setup/check.service.test.js
+++ b/test/services/notifications/setup/check.service.test.js
@@ -47,6 +47,8 @@ describe('Notifications Setup - Review service', () => {
       pagination: {
         numberOfPages: 1
       },
+      pageTitle: 'Check the recipients',
+      readyToSend: 'Returns invitations are ready to send.',
       recipients: [
         {
           contact: ['primary.user@important.com'],
@@ -55,12 +57,7 @@ describe('Notifications Setup - Review service', () => {
         }
       ],
       recipientsAmount: 1,
-      referenceCode: 'RINV-123',
-      text: {
-        continueButton: 'Send',
-        readyToSend: 'Returns invitations are ready to send.',
-        title: 'Check the recipients'
-      }
+      referenceCode: 'RINV-123'
     })
   })
 })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4775

A recent refactoring to this page meant we no longer passed in a property `pageTitle`. The layout expects this to set the title for the page in the browser.

Needing to move the title out of `text:` to its own property meant there was no need to group the text properties; hence, this change splits them out.

We drop `send:`, which we thought might be worth keeping in case we are expected to do something else with the button. But in light of this fix, we decided to drop it now and sort it later if the request comes in.