### PR TITLE
Amend recipients download CSV headers (licence)

### DIFF
--- a/app/presenters/notifications/setup/download-recipients.presenter.js
+++ b/app/presenters/notifications/setup/download-recipients.presenter.js
@@ -10,7 +10,7 @@ const { formatDateObjectToISO } = require('../../../lib/dates.lib.js')
 const { transformArrayToCSVRow } = require('../../../lib/transform-to-csv.lib.js')
 
 const HEADERS = [
-  'Licences',
+  'Licence',
   'Return references',
   'Returns period start date',
   'Returns period end date',

--- a/app/presenters/notifications/setup/download-recipients.presenter.js
+++ b/app/presenters/notifications/setup/download-recipients.presenter.js
@@ -11,10 +11,10 @@ const { transformArrayToCSVRow } = require('../../../lib/transform-to-csv.lib.js
 
 const HEADERS = [
   'Licence',
-  'Return references',
-  'Returns period start date',
-  'Returns period end date',
-  'Returns due date',
+  'Return reference',
+  'Return period start date',
+  'Return period end date',
+  'Return due date',
   'Message type',
   'Message reference',
   'Email',

--- a/test/presenters/notifications/setup/download-recipients.presenter.test.js
+++ b/test/presenters/notifications/setup/download-recipients.presenter.test.js
@@ -28,7 +28,7 @@ describe('Notifications Setup - Download recipients presenter', () => {
 
       expect(result).to.equal(
         // Headers
-        'Licence,Return references,Returns period start date,Returns period end date,Returns due date,Message type,Message reference,Email,Recipient name,Address line 1,Address line 2,Address line 3,Address line 4,Address line 5,Address line 6,Postcode\n' +
+        'Licence,Return reference,Return period start date,Return period end date,Return due date,Message type,Message reference,Email,Recipient name,Address line 1,Address line 2,Address line 3,Address line 4,Address line 5,Address line 6,Postcode\n' +
           // Row - Primary user
           '"123/46","2434","2018-01-01","2019-01-01","2021-01-01","email","invitations","primary.user@important.com",,,,,,,,\n' +
           // Row - Licence holder
@@ -49,10 +49,10 @@ describe('Notifications Setup - Download recipients presenter', () => {
 
       expect(headers).to.equal(
         'Licence,' +
-          'Return references,' +
-          'Returns period start date,' +
-          'Returns period end date,' +
-          'Returns due date,' +
+          'Return reference,' +
+          'Return period start date,' +
+          'Return period end date,' +
+          'Return due date,' +
           'Message type,' +
           'Message reference,' +
           'Email,' +
@@ -78,10 +78,10 @@ describe('Notifications Setup - Download recipients presenter', () => {
 
         expect(row).to.equal(
           '"123/46",' + // Licence
-            '"2434",' + // 'Return references'
-            '"2018-01-01",' + // 'Returns period start date'
-            '"2019-01-01",' + // 'Returns period end date'
-            '"2021-01-01",' + // 'Returns due date'
+            '"2434",' + // 'Return reference'
+            '"2018-01-01",' + // 'Return period start date'
+            '"2019-01-01",' + // 'Return period end date'
+            '"2021-01-01",' + // 'Return due date'
             '"email",' + // 'Message type'
             '"invitations",' + // 'Message reference'
             '"primary.user@important.com",' + // Email
@@ -109,10 +109,10 @@ describe('Notifications Setup - Download recipients presenter', () => {
 
             expect(row).to.equal(
               '"1/343/3",' + // Licence
-                '"376439279",' + // 'Return references'
-                '"2018-01-01",' + // 'Returns period start date'
-                '"2019-01-01",' + // 'Returns period end date'
-                '"2021-01-01",' + // 'Returns due date'
+                '"376439279",' + // 'Return reference'
+                '"2018-01-01",' + // 'Return period start date'
+                '"2019-01-01",' + // 'Return period end date'
+                '"2021-01-01",' + // 'Return due date'
                 '"letter",' + // 'Message type'
                 '"invitations",' + // 'Message reference'
                 ',' + // Email
@@ -139,10 +139,10 @@ describe('Notifications Setup - Download recipients presenter', () => {
 
             expect(row).to.equal(
               '"1/343/3",' + // Licence
-                '"376439279",' + // 'Return references'
-                '"2018-01-01",' + // 'Returns period start date'
-                '"2019-01-01",' + // 'Returns period end date'
-                '"2021-01-01",' + // 'Returns due date'
+                '"376439279",' + // 'Return reference'
+                '"2018-01-01",' + // 'Return period start date'
+                '"2019-01-01",' + // 'Return period end date'
+                '"2021-01-01",' + // 'Return due date'
                 '"letter",' + // 'Message type'
                 '"invitations",' + // 'Message reference'
                 ',' + // Email
@@ -170,10 +170,10 @@ describe('Notifications Setup - Download recipients presenter', () => {
 
           expect(row).to.equal(
             '"1/343/3",' + // Licence
-              '"376439279",' + // 'Return references'
-              '"2018-01-01",' + // 'Returns period start date'
-              '"2019-01-01",' + // 'Returns period end date'
-              '"2021-01-01",' + // 'Returns due date'
+              '"376439279",' + // 'Return reference'
+              '"2018-01-01",' + // 'Return period start date'
+              '"2019-01-01",' + // 'Return period end date'
+              '"2021-01-01",' + // 'Return due date'
               '"letter",' + // 'Message type'
               '"invitations",' + // 'Message reference'
               ',' + // Email

--- a/test/presenters/notifications/setup/download-recipients.presenter.test.js
+++ b/test/presenters/notifications/setup/download-recipients.presenter.test.js
@@ -28,7 +28,7 @@ describe('Notifications Setup - Download recipients presenter', () => {
 
       expect(result).to.equal(
         // Headers
-        'Licences,Return references,Returns period start date,Returns period end date,Returns due date,Message type,Message reference,Email,Recipient name,Address line 1,Address line 2,Address line 3,Address line 4,Address line 5,Address line 6,Postcode\n' +
+        'Licence,Return references,Returns period start date,Returns period end date,Returns due date,Message type,Message reference,Email,Recipient name,Address line 1,Address line 2,Address line 3,Address line 4,Address line 5,Address line 6,Postcode\n' +
           // Row - Primary user
           '"123/46","2434","2018-01-01","2019-01-01","2021-01-01","email","invitations","primary.user@important.com",,,,,,,,\n' +
           // Row - Licence holder
@@ -48,7 +48,7 @@ describe('Notifications Setup - Download recipients presenter', () => {
       headers += '\n'
 
       expect(headers).to.equal(
-        'Licences,' +
+        'Licence,' +
           'Return references,' +
           'Returns period start date,' +
           'Returns period end date,' +

--- a/test/presenters/notifications/setup/download-recipients.presenter.test.js
+++ b/test/presenters/notifications/setup/download-recipients.presenter.test.js
@@ -77,7 +77,7 @@ describe('Notifications Setup - Download recipients presenter', () => {
         row += '\n'
 
         expect(row).to.equal(
-          '"123/46",' + // Licences
+          '"123/46",' + // Licence
             '"2434",' + // 'Return references'
             '"2018-01-01",' + // 'Returns period start date'
             '"2019-01-01",' + // 'Returns period end date'
@@ -108,7 +108,7 @@ describe('Notifications Setup - Download recipients presenter', () => {
             row += '\n'
 
             expect(row).to.equal(
-              '"1/343/3",' + // Licences
+              '"1/343/3",' + // Licence
                 '"376439279",' + // 'Return references'
                 '"2018-01-01",' + // 'Returns period start date'
                 '"2019-01-01",' + // 'Returns period end date'
@@ -138,7 +138,7 @@ describe('Notifications Setup - Download recipients presenter', () => {
             row += '\n'
 
             expect(row).to.equal(
-              '"1/343/3",' + // Licences
+              '"1/343/3",' + // Licence
                 '"376439279",' + // 'Return references'
                 '"2018-01-01",' + // 'Returns period start date'
                 '"2019-01-01",' + // 'Returns period end date'
@@ -169,7 +169,7 @@ describe('Notifications Setup - Download recipients presenter', () => {
           row += '\n'
 
           expect(row).to.equal(
-            '"1/343/3",' + // Licences
+            '"1/343/3",' + // Licence
               '"376439279",' + // 'Return references'
               '"2018-01-01",' + // 'Returns period start date'
               '"2019-01-01",' + // 'Returns period end date'

--- a/test/services/notifications/setup/download-recipients.service.test.js
+++ b/test/services/notifications/setup/download-recipients.service.test.js
@@ -39,7 +39,7 @@ describe('Notifications Setup - Download recipients service', () => {
     expect(result).to.equal({
       data:
         // Headers
-        'Licences,Return references,Returns period start date,Returns period end date,Returns due date,Message type,Message reference,Email,Recipient name,Address line 1,Address line 2,Address line 3,Address line 4,Address line 5,Address line 6,Postcode\n' +
+        'Licence,Return references,Returns period start date,Returns period end date,Returns due date,Message type,Message reference,Email,Recipient name,Address line 1,Address line 2,Address line 3,Address line 4,Address line 5,Address line 6,Postcode\n' +
         // Row - licence holder
         '"1/343/3","376439279","2018-01-01","2019-01-01","2021-01-01","letter","invitations",,"Mr J Licence holder only","4","Privet Drive","Line 3","Line 4","Little Whinging","United Kingdom","WD25 7LR"\n',
       filename: `Returns invitation - ${referenceCode}.csv`,

--- a/test/services/notifications/setup/download-recipients.service.test.js
+++ b/test/services/notifications/setup/download-recipients.service.test.js
@@ -39,7 +39,7 @@ describe('Notifications Setup - Download recipients service', () => {
     expect(result).to.equal({
       data:
         // Headers
-        'Licence,Return references,Returns period start date,Returns period end date,Returns due date,Message type,Message reference,Email,Recipient name,Address line 1,Address line 2,Address line 3,Address line 4,Address line 5,Address line 6,Postcode\n' +
+        'Licence,Return reference,Return period start date,Return period end date,Return due date,Message type,Message reference,Email,Recipient name,Address line 1,Address line 2,Address line 3,Address line 4,Address line 5,Address line 6,Postcode\n' +
         // Row - licence holder
         '"1/343/3","376439279","2018-01-01","2019-01-01","2021-01-01","letter","invitations",,"Mr J Licence holder only","4","Privet Drive","Line 3","Line 4","Little Whinging","United Kingdom","WD25 7LR"\n',
       filename: `Returns invitation - ${referenceCode}.csv`,


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4776

We were asked to split the recipients by licence number in the download. This means each licence is on a single line. But we hadn't spotted that the column header was still pluralised as `Licences`.

We've also finally realised that though the ask was 'a licence on each line', it's more like 'a return log on each line'.

This is because the information requested in the CSV is at return log level at its lowest. We cannot group return references, start, end, due dates, etc.

So, the same applies to the return log-related headers.