### PR TITLE
Fix recipients download CSV notification type col.

### DIFF
--- a/app/presenters/notifications/setup/download-recipients.presenter.js
+++ b/app/presenters/notifications/setup/download-recipients.presenter.js
@@ -30,21 +30,21 @@ const HEADERS = [
 ]
 
 /**
- * Formats data for the `/notifications/setup/download` link.
+ * Formats data for the `/notifications/setup/download` link
  *
- * This function takes an array of recipient objects and transforms it into a CSV
- * string suitable for download.
+ * This function takes an array of recipient objects and transforms it into a CSV string suitable for download.
  *
  * The headers are fixed and in the correct order. If a value for a row does not match the header then it will default
  * to an empty string.
  *
  * @param {object[]} recipients - An array of recipients
+ * @param {string} notificationType - The selected notification type
  *
- * @returns {string} - A CSV-formatted string that includes the recipients' data, with the first
- * row as column headers and subsequent rows corresponding to the recipient details.
+ * @returns {string} - A CSV-formatted string that includes the recipients' data, with the first row as column headers
+ * and subsequent rows corresponding to the recipient details.
  */
-function go(recipients) {
-  const rows = _transformToCsv(recipients)
+function go(recipients, notificationType) {
+  const rows = _transformToCsv(recipients, notificationType)
 
   return [HEADERS + '\n', ...rows].join('')
 }
@@ -64,14 +64,15 @@ function _address(contact) {
     contact.postcode
   ]
 }
+
 /**
  * Transforms the recipients' data into a CSV-compatible format.
  *
- * The order of the object dictates the CSV header order.
+ * The order of the properties must match the CSV header order.
  *
  * @private
  */
-function _transformToCsv(recipients) {
+function _transformToCsv(recipients, notificationType) {
   return recipients.map((recipient) => {
     const { contact } = recipient
 
@@ -81,7 +82,7 @@ function _transformToCsv(recipients) {
       formatDateObjectToISO(recipient.start_date),
       formatDateObjectToISO(recipient.end_date),
       formatDateObjectToISO(recipient.due_date),
-      'invitations',
+      notificationType,
       contact ? 'letter' : 'email',
       recipient.contact_type,
       recipient.email || '',

--- a/app/services/notifications/setup/download-recipients.service.js
+++ b/app/services/notifications/setup/download-recipients.service.js
@@ -26,7 +26,7 @@ async function go(sessionId) {
 
   const recipients = await FetchDownloadRecipientsService.go(session)
 
-  const formattedData = DownloadRecipientsPresenter.go(recipients)
+  const formattedData = DownloadRecipientsPresenter.go(recipients, session.notificationType)
 
   return {
     data: formattedData,

--- a/test/presenters/notifications/setup/download-recipients.presenter.test.js
+++ b/test/presenters/notifications/setup/download-recipients.presenter.test.js
@@ -11,6 +11,8 @@ const { expect } = Code
 const DownloadRecipientsPresenter = require('../../../../app/presenters/notifications/setup/download-recipients.presenter.js')
 
 describe('Notifications Setup - Download recipients presenter', () => {
+  const notificationType = 'Returns invitation'
+
   let recipients
 
   beforeEach(() => {
@@ -19,29 +21,27 @@ describe('Notifications Setup - Download recipients presenter', () => {
 
   describe('when provided with "recipients"', () => {
     it('correctly formats the data to a csv string', () => {
-      const result = DownloadRecipientsPresenter.go([
-        recipients.primaryUser,
-        recipients.licenceHolder,
-        recipients.returnsTo,
-        recipients.organisation
-      ])
+      const result = DownloadRecipientsPresenter.go(
+        [recipients.primaryUser, recipients.licenceHolder, recipients.returnsTo, recipients.organisation],
+        notificationType
+      )
 
       expect(result).to.equal(
         // Headers
         'Licence,Return reference,Return period start date,Return period end date,Return due date,Notification type,Message type,Contact type,Email,Recipient name,Address line 1,Address line 2,Address line 3,Address line 4,Address line 5,Address line 6,Postcode\n' +
           // Row - Primary user
-          '"123/46","2434","2018-01-01","2019-01-01","2021-01-01","invitations","email","Primary user","primary.user@important.com",,,,,,,,\n' +
+          '"123/46","2434","2018-01-01","2019-01-01","2021-01-01","Returns invitation","email","Primary user","primary.user@important.com",,,,,,,,\n' +
           // Row - Licence holder
-          '"1/343/3","376439279","2018-01-01","2019-01-01","2021-01-01","invitations","letter","Licence holder",,"Mr J Licence holder only","4","Privet Drive","Line 3","Line 4","Little Whinging","United Kingdom","WD25 7LR"\n' +
+          '"1/343/3","376439279","2018-01-01","2019-01-01","2021-01-01","Returns invitation","letter","Licence holder",,"Mr J Licence holder only","4","Privet Drive","Line 3","Line 4","Little Whinging","United Kingdom","WD25 7LR"\n' +
           // Row - Returns to
-          '"1/343/3","376439279","2018-01-01","2019-01-01","2021-01-01","invitations","letter","Returns to",,"Mr J Returns to (same licence ref as licence holder)","4","Privet Drive","Line 3","Line 4","Surrey","United Kingdom","WD25 7LR"\n' +
+          '"1/343/3","376439279","2018-01-01","2019-01-01","2021-01-01","Returns invitation","letter","Returns to",,"Mr J Returns to (same licence ref as licence holder)","4","Privet Drive","Line 3","Line 4","Surrey","United Kingdom","WD25 7LR"\n' +
           //  Row - Licence holder - organisation
-          '"1/343/3","376439279","2018-01-01","2019-01-01","2021-01-01","invitations","letter","Licence holder",,"Gringotts","4","Privet Drive","Line 3","Line 4","Little Whinging","United Kingdom","WD25 7LR"\n'
+          '"1/343/3","376439279","2018-01-01","2019-01-01","2021-01-01","Returns invitation","letter","Licence holder",,"Gringotts","4","Privet Drive","Line 3","Line 4","Little Whinging","United Kingdom","WD25 7LR"\n'
       )
     })
 
     it('correctly formats the headers', () => {
-      const result = DownloadRecipientsPresenter.go([recipients.primaryUser])
+      const result = DownloadRecipientsPresenter.go([recipients.primaryUser], notificationType)
 
       let [headers] = result.split('\n')
       // We want to test the header includes the new line
@@ -71,7 +71,7 @@ describe('Notifications Setup - Download recipients presenter', () => {
 
     describe('when the recipient is a "primary_user"', () => {
       it('correctly formats the row', () => {
-        const result = DownloadRecipientsPresenter.go([recipients.primaryUser])
+        const result = DownloadRecipientsPresenter.go([recipients.primaryUser], notificationType)
 
         let [, row] = result.split('\n')
         // We want to test the row includes the new line
@@ -83,7 +83,7 @@ describe('Notifications Setup - Download recipients presenter', () => {
             '"2018-01-01",' + // 'Return period start date'
             '"2019-01-01",' + // 'Return period end date'
             '"2021-01-01",' + // 'Return due date'
-            '"invitations",' + // 'Notification type'
+            '"Returns invitation",' + // 'Notification type'
             '"email",' + // 'Message type'
             '"Primary user",' + // 'Contact type'
             '"primary.user@important.com",' + // Email
@@ -103,7 +103,7 @@ describe('Notifications Setup - Download recipients presenter', () => {
       describe('and the "contact" is a "person"', () => {
         describe('and the "person" is a "Licence holder"', () => {
           it('correctly formats the row', () => {
-            const result = DownloadRecipientsPresenter.go([recipients.licenceHolder])
+            const result = DownloadRecipientsPresenter.go([recipients.licenceHolder], notificationType)
 
             let [, row] = result.split('\n')
             // We want to test the row includes the new line
@@ -115,7 +115,7 @@ describe('Notifications Setup - Download recipients presenter', () => {
                 '"2018-01-01",' + // 'Return period start date'
                 '"2019-01-01",' + // 'Return period end date'
                 '"2021-01-01",' + // 'Return due date'
-                '"invitations",' + // 'Notification type'
+                '"Returns invitation",' + // 'Notification type'
                 '"letter",' + // 'Message type'
                 '"Licence holder",' + // 'Contact type'
                 ',' + // Email
@@ -134,7 +134,7 @@ describe('Notifications Setup - Download recipients presenter', () => {
 
         describe('and the "person" is a "Returns to"', () => {
           it('correctly formats the row', () => {
-            const result = DownloadRecipientsPresenter.go([recipients.returnsTo])
+            const result = DownloadRecipientsPresenter.go([recipients.returnsTo], notificationType)
 
             let [, row] = result.split('\n')
             // We want to test the row includes the new line
@@ -146,7 +146,7 @@ describe('Notifications Setup - Download recipients presenter', () => {
                 '"2018-01-01",' + // 'Return period start date'
                 '"2019-01-01",' + // 'Return period end date'
                 '"2021-01-01",' + // 'Return due date'
-                '"invitations",' + // 'Notification type'
+                '"Returns invitation",' + // 'Notification type'
                 '"letter",' + // 'Message type'
                 '"Returns to",' + // 'Contact type'
                 ',' + // Email
@@ -166,7 +166,7 @@ describe('Notifications Setup - Download recipients presenter', () => {
 
       describe('and the "contact" is a "organisation"', () => {
         it('correctly formats the row', () => {
-          const result = DownloadRecipientsPresenter.go([recipients.organisation])
+          const result = DownloadRecipientsPresenter.go([recipients.organisation], notificationType)
 
           let [, row] = result.split('\n')
           // We want to test the row includes the new line
@@ -178,7 +178,7 @@ describe('Notifications Setup - Download recipients presenter', () => {
               '"2018-01-01",' + // 'Return period start date'
               '"2019-01-01",' + // 'Return period end date'
               '"2021-01-01",' + // 'Return due date'
-              '"invitations",' + // 'Notification type'
+              '"Returns invitation",' + // 'Notification type'
               '"letter",' + // 'Message type'
               '"Licence holder",' + // 'Contact type'
               ',' + // Email

--- a/test/services/notifications/setup/download-recipients.service.test.js
+++ b/test/services/notifications/setup/download-recipients.service.test.js
@@ -16,7 +16,7 @@ const SessionHelper = require('../../../support/helpers/session.helper.js')
 const DownloadRecipientsService = require('../../../../app/services/notifications/setup/download-recipients.service.js')
 
 describe('Notifications Setup - Download recipients service', () => {
-  const referenceCode = 'RINV-00R1MQ'
+  const referenceCode = 'RREM-00R1MQ'
 
   let removeLicences
   let session
@@ -26,7 +26,7 @@ describe('Notifications Setup - Download recipients service', () => {
     removeLicences = ''
 
     session = await SessionHelper.add({
-      data: { returnsPeriod: 'quarterFour', referenceCode, notificationType: 'Returns invitation', removeLicences }
+      data: { returnsPeriod: 'quarterFour', referenceCode, notificationType: 'Returns reminder', removeLicences }
     })
 
     testRecipients = _recipients()
@@ -41,8 +41,8 @@ describe('Notifications Setup - Download recipients service', () => {
         // Headers
         'Licence,Return reference,Return period start date,Return period end date,Return due date,Notification type,Message type,Contact type,Email,Recipient name,Address line 1,Address line 2,Address line 3,Address line 4,Address line 5,Address line 6,Postcode\n' +
         // Row - licence holder
-        '"1/343/3","376439279","2018-01-01","2019-01-01","2021-01-01","invitations","letter","Licence holder",,"Mr J Licence holder only","4","Privet Drive","Line 3","Line 4","Little Whinging","United Kingdom","WD25 7LR"\n',
-      filename: `Returns invitation - ${referenceCode}.csv`,
+        '"1/343/3","376439279","2018-01-01","2019-01-01","2021-01-01","Returns reminder","letter","Licence holder",,"Mr J Licence holder only","4","Privet Drive","Line 3","Line 4","Little Whinging","United Kingdom","WD25 7LR"\n',
+      filename: `Returns reminder - ${referenceCode}.csv`,
       type: 'text/csv'
     })
   })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4776

We recently updated our notifications journey, which was focused on invitations to also [add reminders](https://github.com/DEFRA/water-abstraction-system/pull/1725).

However, when we did so, we forgot to update the download CSV function to set the notification type dynamically. This change fixes that oversight.