### PR TITLE
Add notifications setup link

### DIFF
--- a/app/presenters/notifications/setup/check.presenter.js
+++ b/app/presenters/notifications/setup/check.presenter.js
@@ -31,7 +31,8 @@ function go(recipients, page, pagination, session) {
     defaultPageSize,
     links: {
       download: `/system/notifications/setup/${sessionId}/download`,
-      removeLicences: journey !== 'ad-hoc' ? `/system/notifications/setup/${sessionId}/remove-licences` : ''
+      removeLicences: journey !== 'ad-hoc' ? `/system/notifications/setup/${sessionId}/remove-licences` : '',
+      cancel: `/system/notifications/setup/${sessionId}/cancel`
     },
     pageTitle: _pageTitle(page, pagination),
     readyToSend: `${NOTIFICATION_TYPES[journey]} are ready to send.`,

--- a/app/presenters/notifications/setup/check.presenter.js
+++ b/app/presenters/notifications/setup/check.presenter.js
@@ -30,9 +30,9 @@ function go(recipients, page, pagination, session) {
   return {
     defaultPageSize,
     links: {
+      cancel: `/system/notifications/setup/${sessionId}/cancel`,
       download: `/system/notifications/setup/${sessionId}/download`,
-      removeLicences: journey !== 'ad-hoc' ? `/system/notifications/setup/${sessionId}/remove-licences` : '',
-      cancel: `/system/notifications/setup/${sessionId}/cancel`
+      removeLicences: journey !== 'ad-hoc' ? `/system/notifications/setup/${sessionId}/remove-licences` : ''
     },
     pageTitle: _pageTitle(page, pagination),
     readyToSend: `${NOTIFICATION_TYPES[journey]} are ready to send.`,

--- a/app/views/notifications/setup/check.njk
+++ b/app/views/notifications/setup/check.njk
@@ -102,10 +102,19 @@
       {{ govukPagination(pagination.component) }}
     {% endif %}
 
-    <form method="post">
-      <input type="hidden" name="wrlsCrumb" value="{{ wrlsCrumb }}"/>
+    <div class="govuk-button-group">
+      <form method="post">
+        <input type="hidden" name="wrlsCrumb" value="{{ wrlsCrumb }}"/>
 
-      {{ govukButton({ text: 'Send', preventDoubleClick: true }) }}
-    </form>
+        {{ govukButton({ text: 'Send', preventDoubleClick: true }) }}
+
+        {{ govukButton({
+          text: "Cancel",
+          classes: "govuk-button--secondary",
+          href: links.cancel,
+          preventDoubleClick: true
+        }) }}
+      </form>
+    </div>
   </div>
 {% endblock %}

--- a/test/presenters/notifications/setup/check.presenter.test.js
+++ b/test/presenters/notifications/setup/check.presenter.test.js
@@ -54,6 +54,7 @@ describe('Notifications Setup - Check presenter', () => {
       expect(result).to.equal({
         defaultPageSize: 25,
         links: {
+          cancel: `/system/notifications/setup/${session.id}/cancel`,
           download: `/system/notifications/setup/${session.id}/download`,
           removeLicences: `/system/notifications/setup/${session.id}/remove-licences`
         },
@@ -128,6 +129,7 @@ describe('Notifications Setup - Check presenter', () => {
         it('should return the links for "invitations"', () => {
           const result = CheckPresenter.go(testInput, page, pagination, session)
           expect(result.links).to.equal({
+            cancel: `/system/notifications/setup/${session.id}/cancel`,
             download: `/system/notifications/setup/${session.id}/download`,
             removeLicences: `/system/notifications/setup/${session.id}/remove-licences`
           })
@@ -329,6 +331,7 @@ describe('Notifications Setup - Check presenter', () => {
         it('should return the links for "invitations"', () => {
           const result = CheckPresenter.go(testInput, page, pagination, session)
           expect(result.links).to.equal({
+            cancel: `/system/notifications/setup/${session.id}/cancel`,
             download: `/system/notifications/setup/${session.id}/download`,
             removeLicences: ``
           })
@@ -529,6 +532,7 @@ describe('Notifications Setup - Check presenter', () => {
         it('should return the links for "invitations"', () => {
           const result = CheckPresenter.go(testInput, page, pagination, session)
           expect(result.links).to.equal({
+            cancel: `/system/notifications/setup/${session.id}/cancel`,
             download: `/system/notifications/setup/${session.id}/download`,
             removeLicences: `/system/notifications/setup/${session.id}/remove-licences`
           })

--- a/test/services/notifications/setup/check.service.test.js
+++ b/test/services/notifications/setup/check.service.test.js
@@ -40,6 +40,7 @@ describe('Notifications Setup - Review service', () => {
       activeNavBar: 'manage',
       defaultPageSize: 25,
       links: {
+        cancel: `/system/notifications/setup/${session.id}/cancel`,
         download: `/system/notifications/setup/${session.id}/download`,
         removeLicences: `/system/notifications/setup/${session.id}/remove-licences`
       },


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4901

This change updates the notifications setup check presenter to provide the cancel link to the user.

The cancel endpoint has not been implemented yet so the user will page not found. The work to implement this feature will be done in another change.