### PR TITLE
Update notifications check back link

### DIFF
--- a/app/presenters/notifications/setup/check.presenter.js
+++ b/app/presenters/notifications/setup/check.presenter.js
@@ -29,11 +29,7 @@ function go(recipients, page, pagination, session) {
 
   return {
     defaultPageSize,
-    links: {
-      cancel: `/system/notifications/setup/${sessionId}/cancel`,
-      download: `/system/notifications/setup/${sessionId}/download`,
-      removeLicences: journey !== 'ad-hoc' ? `/system/notifications/setup/${sessionId}/remove-licences` : ''
-    },
+    links: _links(sessionId, journey),
     pageTitle: _pageTitle(page, pagination),
     readyToSend: `${NOTIFICATION_TYPES[journey]} are ready to send.`,
     recipients: _recipients(recipients, page),
@@ -69,6 +65,21 @@ function _formatRecipients(recipients) {
       method: `${recipient.message_type} - ${recipient.contact_type}`
     }
   })
+}
+function _links(sessionId, journey) {
+  const links = {
+    back: `/system/notifications/setup/${sessionId}/returns-period`,
+    cancel: `/system/notifications/setup/${sessionId}/cancel`,
+    download: `/system/notifications/setup/${sessionId}/download`,
+    removeLicences: `/system/notifications/setup/${sessionId}/remove-licences`
+  }
+
+  if (journey === 'ad-hoc') {
+    links.back = `/system/notifications/setup/${sessionId}/ad-hoc-licence`
+    links.removeLicences = ''
+  }
+
+  return links
 }
 
 function _pageTitle(page, pagination) {

--- a/app/views/notifications/setup/check.njk
+++ b/app/views/notifications/setup/check.njk
@@ -13,7 +13,7 @@
 {% block breadcrumbs %}
   {{ govukBackLink({
     text: 'Back',
-    href: "returns-period"
+    href: links.back
   }) }}
 {% endblock %}
 

--- a/test/presenters/notifications/setup/check.presenter.test.js
+++ b/test/presenters/notifications/setup/check.presenter.test.js
@@ -54,6 +54,7 @@ describe('Notifications Setup - Check presenter', () => {
       expect(result).to.equal({
         defaultPageSize: 25,
         links: {
+          back: `/system/notifications/setup/${session.id}/returns-period`,
           cancel: `/system/notifications/setup/${session.id}/cancel`,
           download: `/system/notifications/setup/${session.id}/download`,
           removeLicences: `/system/notifications/setup/${session.id}/remove-licences`
@@ -129,6 +130,7 @@ describe('Notifications Setup - Check presenter', () => {
         it('should return the links for "invitations"', () => {
           const result = CheckPresenter.go(testInput, page, pagination, session)
           expect(result.links).to.equal({
+            back: `/system/notifications/setup/${session.id}/returns-period`,
             cancel: `/system/notifications/setup/${session.id}/cancel`,
             download: `/system/notifications/setup/${session.id}/download`,
             removeLicences: `/system/notifications/setup/${session.id}/remove-licences`
@@ -331,6 +333,7 @@ describe('Notifications Setup - Check presenter', () => {
         it('should return the links for "invitations"', () => {
           const result = CheckPresenter.go(testInput, page, pagination, session)
           expect(result.links).to.equal({
+            back: `/system/notifications/setup/${session.id}/ad-hoc-licence`,
             cancel: `/system/notifications/setup/${session.id}/cancel`,
             download: `/system/notifications/setup/${session.id}/download`,
             removeLicences: ``
@@ -532,6 +535,7 @@ describe('Notifications Setup - Check presenter', () => {
         it('should return the links for "invitations"', () => {
           const result = CheckPresenter.go(testInput, page, pagination, session)
           expect(result.links).to.equal({
+            back: `/system/notifications/setup/${session.id}/returns-period`,
             cancel: `/system/notifications/setup/${session.id}/cancel`,
             download: `/system/notifications/setup/${session.id}/download`,
             removeLicences: `/system/notifications/setup/${session.id}/remove-licences`

--- a/test/services/notifications/setup/check.service.test.js
+++ b/test/services/notifications/setup/check.service.test.js
@@ -40,6 +40,7 @@ describe('Notifications Setup - Review service', () => {
       activeNavBar: 'manage',
       defaultPageSize: 25,
       links: {
+        back: `/system/notifications/setup/${session.id}/returns-period`,
         cancel: `/system/notifications/setup/${session.id}/cancel`,
         download: `/system/notifications/setup/${session.id}/download`,
         removeLicences: `/system/notifications/setup/${session.id}/remove-licences`


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4900

The notification setup ad hoc licence journey was added previously.

But the back link was missed in the update.

This change updates the back link to navigate correctly based on the provided journey. This change moves the back link into the present and tests the two possible journey paths.