### PR TITLE
Fix notifications duplicate licence refs

### DIFF
--- a/app/services/notifications/setup/fetch-recipients.service.js
+++ b/app/services/notifications/setup/fetch-recipients.service.js
@@ -257,7 +257,14 @@ FROM (
     ON ler.company_entity_id = ldh.company_entity_id AND ler."role" = 'primary_user'
   INNER JOIN public.licence_entities le
     ON le.id = ler.licence_entity_id
-  INNER JOIN public.return_logs rl
+  INNER JOIN (
+    SELECT DISTINCT ON (rl.licence_ref)
+      rl.licence_ref,
+      rl.status,
+      rl.metadata,
+      rl.due_date
+    FROM public.return_logs rl
+  )  as rl
     ON rl.licence_ref = ldh.licence_ref
   WHERE
     rl.status = 'due'
@@ -275,7 +282,14 @@ FROM (
     ON ler.company_entity_id = ldh.company_entity_id AND ler."role" = 'user_returns'
   INNER JOIN public.licence_entities le
     ON le.id = ler.licence_entity_id
-  INNER JOIN public.return_logs rl
+  INNER JOIN (
+    SELECT DISTINCT ON (rl.licence_ref)
+        rl.licence_ref,
+        rl.status,
+        rl.metadata,
+        rl.due_date
+      FROM public.return_logs rl
+  )  as rl
     ON rl.licence_ref = ldh.licence_ref
   WHERE
     rl.status = 'due'


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4775

When a "recipient" is fetched the return logs might have multiple occurrences of with the same "licence_ref". When this was is the case we received duplicate "licence_refs" as a string like this: "01/114,01/114".

This change fixes this issue but selecting a distinct return logs by the licence ref.

We do no need to change the download service as we expect multiple "licence_refs" and return log references for the CSV.