### PR TITLE
Fix notifications setup cancel page back link

### DIFF
--- a/app/presenters/notifications/setup/cancel.presenter.js
+++ b/app/presenters/notifications/setup/cancel.presenter.js
@@ -20,6 +20,7 @@ function go(session) {
   const { referenceCode } = session
 
   return {
+    backLink: `/system/notifications/setup/${session.id}/check`,
     pageTitle: 'You are about to cancel this notification',
     referenceCode,
     summaryList: _summaryList(session)

--- a/app/views/notifications/setup/cancel.njk
+++ b/app/views/notifications/setup/cancel.njk
@@ -6,7 +6,7 @@
 {% block breadcrumbs %}
   {{ govukBackLink({
     text: 'Back',
-    href: "/check"
+    href: backLink
   }) }}
 {% endblock %}
 

--- a/test/presenters/notifications/setup/cancel.presenter.test.js
+++ b/test/presenters/notifications/setup/cancel.presenter.test.js
@@ -41,6 +41,7 @@ describe('Notifications Setup - Cancel presenter', () => {
     const result = CancelPresenter.go(session)
 
     expect(result).to.equal({
+      backLink: `/system/notifications/setup/${session.id}/check`,
       pageTitle: 'You are about to cancel this notification',
       referenceCode: 'ADHC-1234',
       summaryList: {

--- a/test/services/notifications/setup/cancel.service.test.js
+++ b/test/services/notifications/setup/cancel.service.test.js
@@ -31,6 +31,7 @@ describe('Notifications Setup - Cancel service', () => {
 
       expect(result).to.equal({
         activeNavBar: 'manage',
+        backLink: `/system/notifications/setup/${session.id}/check`,
         pageTitle: 'You are about to cancel this notification',
         referenceCode: 'ADHC-1234',
         summaryList: {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4775

The back link on the notifications setup cancel page was going to '/check'. This change fixes the back link by giving the absolute path to the view from the presenter.