### PR TITLE
Use existing title helpers in review pages part 2

### DIFF
--- a/app/presenters/bill-runs/review/review-bill-run.presenter.js
+++ b/app/presenters/bill-runs/review/review-bill-run.presenter.js
@@ -5,7 +5,14 @@
  * @module ReviewBillRunPresenter
  */
 
-const { formatLongDate, generateBillRunTitle } = require('../../base.presenter.js')
+const {
+  formatBillRunType,
+  formatChargeScheme,
+  formatFinancialYear,
+  formatLongDate,
+  generateBillRunTitle,
+  titleCase
+} = require('../../base.presenter.js')
 
 /**
  * Prepares and processes bill run, licence and filter data for presentation
@@ -86,18 +93,31 @@ function _prepareLicences(licences) {
 }
 
 function _prepareBillRun(billRun, preparedLicences) {
+  const {
+    batchType,
+    createdAt,
+    id: billRunId,
+    region,
+    reviewLicences,
+    scheme,
+    status,
+    summer,
+    toFinancialYearEnding
+  } = billRun
+
   return {
-    billRunId: billRun.id,
-    billRunTitle: generateBillRunTitle(billRun.region.displayName, billRun.batchType, billRun.scheme, billRun.summer),
-    billRunType: 'two-part tariff',
-    dateCreated: formatLongDate(billRun.createdAt),
-    financialYear: _financialYear(billRun.toFinancialYearEnding),
+    billRunId,
+    billRunTitle: generateBillRunTitle(region.displayName, batchType, scheme, summer),
+    billRunType: formatBillRunType(batchType, scheme, summer),
+    chargeScheme: formatChargeScheme(scheme),
+    dateCreated: formatLongDate(createdAt),
+    financialYear: formatFinancialYear(toFinancialYearEnding),
     numberOfLicencesDisplayed: preparedLicences.length,
-    numberOfLicencesToReview: billRun.reviewLicences[0].numberOfLicencesToReview,
-    region: billRun.region.displayName,
-    reviewMessage: _prepareReviewMessage(billRun.reviewLicences[0].numberOfLicencesToReview),
-    status: billRun.status,
-    totalNumberOfLicences: billRun.reviewLicences[0].totalNumberOfLicences
+    numberOfLicencesToReview: reviewLicences[0].numberOfLicencesToReview,
+    region: titleCase(region.displayName),
+    reviewMessage: _prepareReviewMessage(reviewLicences[0].numberOfLicencesToReview),
+    status,
+    totalNumberOfLicences: reviewLicences[0].totalNumberOfLicences
   }
 }
 
@@ -113,13 +133,6 @@ function _prepareReviewMessage(numberOfLicencesToReview) {
   }
 
   return `You need to review ${numberOfLicences} with returns data issues. You can then continue and send the bill run.`
-}
-
-function _financialYear(financialYearEnding) {
-  const startYear = financialYearEnding - 1
-  const endYear = financialYearEnding
-
-  return `${startYear} to ${endYear}`
 }
 
 function _getIssueOnLicence(issues) {

--- a/app/presenters/bill-runs/review/review-bill-run.presenter.js
+++ b/app/presenters/bill-runs/review/review-bill-run.presenter.js
@@ -51,6 +51,44 @@ function go(billRun, filterIssues, filterLicenceHolderNumber, filterLicenceStatu
   return { ...preparedBillRun, preparedLicences, filter }
 }
 
+function _issue(issues) {
+  // if there is more than one issue the issues will be separated by a comma
+  if (issues.includes(',')) {
+    return 'Multiple Issues'
+  }
+
+  return issues
+}
+
+function _prepareBillRun(billRun, preparedLicences) {
+  const {
+    batchType,
+    createdAt,
+    id: billRunId,
+    region,
+    reviewLicences,
+    scheme,
+    status,
+    summer,
+    toFinancialYearEnding
+  } = billRun
+
+  return {
+    billRunId,
+    billRunTitle: generateBillRunTitle(region.displayName, batchType, scheme, summer),
+    billRunType: formatBillRunType(batchType, scheme, summer),
+    chargeScheme: formatChargeScheme(scheme),
+    dateCreated: formatLongDate(createdAt),
+    financialYear: formatFinancialYear(toFinancialYearEnding),
+    numberOfLicencesDisplayed: preparedLicences.length,
+    numberOfLicencesToReview: reviewLicences[0].numberOfLicencesToReview,
+    region: titleCase(region.displayName),
+    reviewMessage: _reviewMessage(reviewLicences[0].numberOfLicencesToReview),
+    status,
+    totalNumberOfLicences: reviewLicences[0].totalNumberOfLicences
+  }
+}
+
 /**
  * Returns true/false values for each issue in the Issue filter based on the filters applied to determine which
  * checkboxes if any should be checked upon loading the page
@@ -83,7 +121,7 @@ function _prepareLicences(licences) {
       id: licence.id,
       licenceRef: licence.licenceRef,
       licenceHolder: licence.licenceHolder,
-      issue: _getIssueOnLicence(licence.issues),
+      issue: _issue(licence.issues),
       progress: licence.progress ? '✓' : '',
       status: licence.status
     })
@@ -92,36 +130,7 @@ function _prepareLicences(licences) {
   return preparedLicences
 }
 
-function _prepareBillRun(billRun, preparedLicences) {
-  const {
-    batchType,
-    createdAt,
-    id: billRunId,
-    region,
-    reviewLicences,
-    scheme,
-    status,
-    summer,
-    toFinancialYearEnding
-  } = billRun
-
-  return {
-    billRunId,
-    billRunTitle: generateBillRunTitle(region.displayName, batchType, scheme, summer),
-    billRunType: formatBillRunType(batchType, scheme, summer),
-    chargeScheme: formatChargeScheme(scheme),
-    dateCreated: formatLongDate(createdAt),
-    financialYear: formatFinancialYear(toFinancialYearEnding),
-    numberOfLicencesDisplayed: preparedLicences.length,
-    numberOfLicencesToReview: reviewLicences[0].numberOfLicencesToReview,
-    region: titleCase(region.displayName),
-    reviewMessage: _prepareReviewMessage(reviewLicences[0].numberOfLicencesToReview),
-    status,
-    totalNumberOfLicences: reviewLicences[0].totalNumberOfLicences
-  }
-}
-
-function _prepareReviewMessage(numberOfLicencesToReview) {
+function _reviewMessage(numberOfLicencesToReview) {
   let numberOfLicences
 
   if (numberOfLicencesToReview === 0) {
@@ -133,15 +142,6 @@ function _prepareReviewMessage(numberOfLicencesToReview) {
   }
 
   return `You need to review ${numberOfLicences} with returns data issues. You can then continue and send the bill run.`
-}
-
-function _getIssueOnLicence(issues) {
-  // if there is more than one issue the issues will be separated by a comma
-  if (issues.includes(',')) {
-    return 'Multiple Issues'
-  }
-
-  return issues
 }
 
 module.exports = {

--- a/app/views/bill-runs/review/review.njk
+++ b/app/views/bill-runs/review/review.njk
@@ -81,7 +81,7 @@
                 classes: "meta-data__label"
               },
               value: {
-                html: '<span data-test="meta-data-scheme">Current</span>',
+                html: '<span data-test="meta-data-scheme">' + chargeScheme + '</span>',
                 classes: "meta-data__value"
               }
             },

--- a/test/presenters/bill-runs/review/review-bill-run.presenter.test.js
+++ b/test/presenters/bill-runs/review/review-bill-run.presenter.test.js
@@ -84,7 +84,7 @@ describe('Bill Runs Review - Review Bill Run presenter', () => {
               issue: 'Multiple Issues'
             }
           ],
-          region: 'Southern (Test replica)',
+          region: 'Southern (Test Replica)',
           reviewMessage:
             'You need to review 1 licence with returns data issues. You can then continue and send the bill run.',
           status: 'review',

--- a/test/presenters/bill-runs/review/review-bill-run.presenter.test.js
+++ b/test/presenters/bill-runs/review/review-bill-run.presenter.test.js
@@ -45,16 +45,19 @@ describe('Bill Runs Review - Review Bill Run presenter', () => {
         expect(result).to.equal({
           billRunId: 'b21bd372-cd04-405d-824e-5180d854121c',
           billRunTitle: 'Southern (Test Replica) two-part tariff',
-          region: 'Southern (Test replica)',
-          status: 'review',
+          billRunType: 'Two-part tariff',
+          chargeScheme: 'Current',
           dateCreated: '17 January 2024',
+          filter: {
+            issues: undefined,
+            licenceHolderNumber: undefined,
+            licenceStatus: undefined,
+            inProgress: undefined,
+            openFilter: false
+          },
           financialYear: '2022 to 2023',
-          billRunType: 'two-part tariff',
           numberOfLicencesDisplayed: 3,
           numberOfLicencesToReview: 1,
-          reviewMessage:
-            'You need to review 1 licence with returns data issues. You can then continue and send the bill run.',
-          totalNumberOfLicences: 3,
           preparedLicences: [
             {
               id: 'cc4bbb18-0d6a-4254-ac2c-7409de814d7e',
@@ -81,13 +84,11 @@ describe('Bill Runs Review - Review Bill Run presenter', () => {
               issue: 'Multiple Issues'
             }
           ],
-          filter: {
-            issues: undefined,
-            licenceHolderNumber: undefined,
-            licenceStatus: undefined,
-            inProgress: undefined,
-            openFilter: false
-          }
+          region: 'Southern (Test replica)',
+          reviewMessage:
+            'You need to review 1 licence with returns data issues. You can then continue and send the bill run.',
+          status: 'review',
+          totalNumberOfLicences: 3
         })
       })
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4201

> Part of the work to support two-part tariff bill runs

When working on adding support for `two_part_supplementary` bill runs, we noticed that the review pages were not using an existing helper to set the bill run title.

Well, we've spotted some more helpers it is not taking advantage of!

This change updates the review bill run to use more existing helpers.