### PR TITLE
Enable 2PT supplementary bill run to be created

### DIFF
--- a/app/services/bill-runs/determine-billing-periods.service.js
+++ b/app/services/bill-runs/determine-billing-periods.service.js
@@ -49,8 +49,8 @@ function _billingPeriods(billRunType, financialYear) {
 
   const years = { startYear: financialYear.startDate.getFullYear(), endYear: financialYear.endDate.getFullYear() }
 
-  // Annual and two-part-tariff bill runs will always be a single period
-  if (['annual', 'two_part_tariff'].includes(billRunType)) {
+  // Annual, two-part tariff, and two-part tariff supplementary bill runs will always be a single period
+  if (['annual', 'two_part_tariff', 'two_part_supplementary'].includes(billRunType)) {
     _addBillingPeriod(billingPeriods, years.startYear, years.endYear)
 
     return billingPeriods

--- a/app/services/bill-runs/match/fetch-licences.service.js
+++ b/app/services/bill-runs/match/fetch-licences.service.js
@@ -13,12 +13,14 @@ const FetchChargeVersionsService = require('./fetch-charge-versions.service.js')
  *
  * @param {string} regionId - UUID of the region being billed that the licences must be linked to
  * @param {object} billingPeriod - Object with a `startDate` and `endDate` property representing the period being billed
+ * @param {boolean} [supplementary=false] - flag to indicate if an annual or supplementary two-part tariff bill run is
+ * being created
  *
  * @returns {Promise<object[]>} the licences to be matched, each containing an array of charge versions applicable for
  * two-part tariff
  */
-async function go(regionId, billingPeriod) {
-  const chargeVersions = await FetchChargeVersionsService.go(regionId, billingPeriod)
+async function go(regionId, billingPeriod, supplementary = false) {
+  const chargeVersions = await FetchChargeVersionsService.go(regionId, billingPeriod, supplementary)
 
   const uniqueLicenceIds = _extractUniqueLicenceIds(chargeVersions)
 

--- a/app/services/bill-runs/match/match-and-allocate.service.js
+++ b/app/services/bill-runs/match/match-and-allocate.service.js
@@ -29,7 +29,8 @@ const PrepareReturnLogsService = require('./prepare-return-logs.service.js')
  * @returns {Promise<boolean>} - True if there are any licences matched to returns, false otherwise
  */
 async function go(billRun, billingPeriod) {
-  const licences = await FetchLicencesService.go(billRun.regionId, billingPeriod)
+  const supplementary = billRun.batchType === 'two_part_supplementary'
+  const licences = await FetchLicencesService.go(billRun.regionId, billingPeriod, supplementary)
 
   if (licences.length > 0) {
     await _process(licences, billingPeriod, billRun)

--- a/app/services/bill-runs/setup/submit-check.service.js
+++ b/app/services/bill-runs/setup/submit-check.service.js
@@ -48,11 +48,7 @@ async function go(sessionId, auth) {
   // blocking bill run was found. This is just protection against malicious use, or more likely, someone has left the
   // page idle and another user has triggered a bill run that now blocks it.
   if (blockingResults.trigger !== engineTriggers.neither) {
-    // Temporary code to end the journey if the bill run type is two-part supplementary as processing this bill run type
-    // is not currently possible
-    if (session.type !== 'two_part_supplementary') {
-      await CreateService.go(session, blockingResults, auth.credentials.user)
-    }
+    await CreateService.go(session, blockingResults, auth.credentials.user)
 
     return {}
   }

--- a/app/services/bill-runs/start-bill-run-process.service.js
+++ b/app/services/bill-runs/start-bill-run-process.service.js
@@ -11,6 +11,7 @@ const InitiateBillRunService = require('./initiate-bill-run.service.js')
 const NoBillingPeriodsError = require('../../errors/no-billing-periods.error.js')
 const SupplementaryProcessBillRunService = require('./supplementary/process-bill-run.service.js')
 const TwoPartTariffProcessBillRunService = require('./two-part-tariff/process-bill-run.service.js')
+const TwoPartTariffSupplementaryProcessBillRunService = require('./tpt-supplementary/process-bill-run.service.js')
 
 /**
  * Manages the creation of a new bill run
@@ -54,6 +55,9 @@ function _processBillRun(billRun, billingPeriods) {
       break
     case 'two_part_tariff':
       TwoPartTariffProcessBillRunService.go(billRun, billingPeriods)
+      break
+    case 'two_part_supplementary':
+      TwoPartTariffSupplementaryProcessBillRunService.go(billRun, billingPeriods)
       break
   }
 }

--- a/app/services/bill-runs/tpt-supplementary/process-bill-run.service.js
+++ b/app/services/bill-runs/tpt-supplementary/process-bill-run.service.js
@@ -1,0 +1,71 @@
+'use strict'
+
+/**
+ * Process a two-part tariff supplementary bill run for the given billing period
+ * @module ProcessBillRunService
+ */
+
+const BillRunModel = require('../../../models/bill-run.model.js')
+const { calculateAndLogTimeTaken, currentTimeInNanoseconds } = require('../../../lib/general.lib.js')
+const HandleErroredBillRunService = require('../handle-errored-bill-run.service.js')
+const MatchAndAllocateService = require('../match/match-and-allocate.service.js')
+
+/**
+ * Process a two-part tariff supplementary bill run for the given billing period
+ *
+ * Matches and allocates licences to returns for a two-part tariff bill run
+ *
+ * The results of the matching process are then persisted to the database ready for the results to be reviewed. The bill
+ * run status is also updated to 'review'.
+ *
+ * In the unlikely event of no licences match to returns it will set the status to 'empty'. It will also handle updating
+ * the bill run if an error occurs during the process.
+ *
+ * @param {module:BillRunModel} billRun - The two-part tariff supplementary bill run being processed
+ * @param {object[]} billingPeriods - An array of billing periods each containing a `startDate` and `endDate`. For 2PT
+ * this will only ever contain a single period
+ */
+async function go(billRun, billingPeriods) {
+  const { id: billRunId } = billRun
+  // NOTE: billingPeriods come from `DetermineBillingPeriodsService` which always returns an array because it is used by
+  // all billing types. For two-part tariff we know it will only contain one because 2PT supplementary bill runs are
+  // only for a single financial year
+  const billingPeriod = billingPeriods[0]
+
+  try {
+    const startTime = currentTimeInNanoseconds()
+
+    await _updateStatus(billRunId, 'processing')
+
+    // `populated` will be set to true if `MatchAndAllocateService` processes at least one licence
+    const populated = await MatchAndAllocateService.go(billRun, billingPeriod)
+
+    await _setBillRunStatus(billRunId, populated)
+
+    calculateAndLogTimeTaken(startTime, 'Process bill run complete', { billRunId, type: 'two_part_supplementary' })
+  } catch (error) {
+    await HandleErroredBillRunService.go(billRunId)
+    global.GlobalNotifier.omfg('Process bill run failed', { billRun }, error)
+  }
+}
+
+async function _setBillRunStatus(billRunId, populated) {
+  // It is highly unlikely no licences were matched to returns. So we default status to 'review'
+  let status = 'review'
+
+  // Just in case no licences were found to be matched to returns we set the status to 'empty'
+  if (!populated) {
+    status = 'empty'
+  }
+
+  // Update the bill run's status
+  await _updateStatus(billRunId, status)
+}
+
+async function _updateStatus(billRunId, status) {
+  await BillRunModel.query().findById(billRunId).patch({ status })
+}
+
+module.exports = {
+  go
+}

--- a/test/services/bill-runs/determine-billing-periods.service.test.js
+++ b/test/services/bill-runs/determine-billing-periods.service.test.js
@@ -10,7 +10,7 @@ const { expect } = Code
 // Thing under test
 const DetermineBillingPeriodsService = require('../../../app/services/bill-runs/determine-billing-periods.service.js')
 
-describe('Determine Billing Periods service', () => {
+describe('Bill Runs - Determine Billing Periods service', () => {
   let billRunType
   let financialYearEnding
 
@@ -34,6 +34,23 @@ describe('Determine Billing Periods service', () => {
   describe('when the bill run type is "two_part_tariff"', () => {
     beforeEach(() => {
       billRunType = 'two_part_tariff'
+      financialYearEnding = 2024
+    })
+
+    it('returns a single billing period for the financial year provided', () => {
+      const result = DetermineBillingPeriodsService.go(billRunType, financialYearEnding)
+
+      expect(result).to.have.length(1)
+      expect(result[0]).to.equal({
+        startDate: new Date('2023-04-01'),
+        endDate: new Date('2024-03-31')
+      })
+    })
+  })
+
+  describe('when the bill run type is "two_part_supplementary"', () => {
+    beforeEach(() => {
+      billRunType = 'two_part_supplementary'
       financialYearEnding = 2024
     })
 

--- a/test/services/bill-runs/tpt-supplementary/process-bill-run.service.test.js
+++ b/test/services/bill-runs/tpt-supplementary/process-bill-run.service.test.js
@@ -1,0 +1,129 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Things we need to stub
+const BillRunModel = require('../../../../app/models/bill-run.model.js')
+const HandleErroredBillRunService = require('../../../../app/services/bill-runs/handle-errored-bill-run.service.js')
+
+// Thing under test
+const MatchAndAllocateService = require('../../../../app/services/bill-runs/match/match-and-allocate.service.js')
+const ProcessBillRunService = require('../../../../app/services/bill-runs/tpt-supplementary/process-bill-run.service.js')
+
+describe('Bill Runs - TpT Supplementary - Process Bill Run service', () => {
+  const billingPeriods = [{ startDate: new Date('2023-04-01'), endDate: new Date('2024-03-31') }]
+  const billRun = { id: '410c84a5-39d3-441a-97ca-6104e14d00a2' }
+
+  let billRunPatchStub
+  let handleErroredBillRunStub
+  let notifierStub
+
+  beforeEach(async () => {
+    billRunPatchStub = Sinon.stub().resolves()
+
+    Sinon.stub(BillRunModel, 'query').returns({
+      findById: Sinon.stub().returnsThis(),
+      patch: billRunPatchStub
+    })
+
+    // BaseRequest depends on the GlobalNotifier to have been set. This happens in app/plugins/global-notifier.plugin.js
+    // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
+    // test we recreate the condition by setting it directly with our own stub
+    notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
+    global.GlobalNotifier = notifierStub
+  })
+
+  afterEach(() => {
+    Sinon.restore()
+    delete global.GlobalNotifier
+  })
+
+  describe('when the service is called', () => {
+    describe('and no licences are matched and allocated', () => {
+      beforeEach(() => {
+        Sinon.stub(MatchAndAllocateService, 'go').resolves(false)
+      })
+
+      it('sets the bill run status first to "processing" and then to "empty"', async () => {
+        await ProcessBillRunService.go(billRun, billingPeriods)
+
+        expect(billRunPatchStub.calledTwice).to.be.true()
+        expect(billRunPatchStub.firstCall.firstArg).to.equal({ status: 'processing' })
+        expect(billRunPatchStub.secondCall.firstArg).to.equal({ status: 'empty' })
+      })
+
+      it('logs the time taken', async () => {
+        await ProcessBillRunService.go(billRun, billingPeriods)
+
+        const args = notifierStub.omg.firstCall.args
+
+        expect(args[0]).to.equal('Process bill run complete')
+        expect(args[1].timeTakenMs).to.exist()
+        expect(args[1].billRunId).to.equal(billRun.id)
+        expect(args[1].type).to.equal('two_part_supplementary')
+      })
+    })
+
+    describe('and licences are matched and allocated', () => {
+      beforeEach(() => {
+        Sinon.stub(MatchAndAllocateService, 'go').resolves(true)
+      })
+
+      it('sets the bill run status first to "processing" and then to "review"', async () => {
+        await ProcessBillRunService.go(billRun, billingPeriods)
+
+        expect(billRunPatchStub.calledTwice).to.be.true()
+        expect(billRunPatchStub.firstCall.firstArg).to.equal({ status: 'processing' })
+        expect(billRunPatchStub.secondCall.firstArg).to.equal({ status: 'review' })
+      })
+
+      it('logs the time taken', async () => {
+        await ProcessBillRunService.go(billRun, billingPeriods)
+
+        const args = notifierStub.omg.firstCall.args
+
+        expect(args[0]).to.equal('Process bill run complete')
+        expect(args[1].timeTakenMs).to.exist()
+        expect(args[1].billRunId).to.equal(billRun.id)
+        expect(args[1].type).to.equal('two_part_supplementary')
+      })
+    })
+  })
+
+  describe('when the service errors', () => {
+    let thrownError
+
+    beforeEach(() => {
+      handleErroredBillRunStub = Sinon.stub(HandleErroredBillRunService, 'go')
+
+      thrownError = new Error('ERROR')
+      Sinon.stub(MatchAndAllocateService, 'go').rejects(thrownError)
+    })
+
+    it('calls HandleErroredBillRunService with no error code', async () => {
+      await ProcessBillRunService.go(billRun, billingPeriods)
+
+      const args = handleErroredBillRunStub.firstCall.args
+
+      expect(args[0]).to.equal(billRun.id)
+    })
+
+    it('logs the error', async () => {
+      await ProcessBillRunService.go(billRun, billingPeriods)
+
+      const args = notifierStub.omfg.firstCall.args
+
+      expect(args[0]).to.equal('Process bill run failed')
+      expect(args[1].billRun.id).to.equal(billRun.id)
+      expect(args[2]).to.be.an.error()
+      expect(args[2].name).to.equal(thrownError.name)
+      expect(args[2].message).to.equal(`${thrownError.message}`)
+    })
+  })
+})


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4201

> Part of the work to support two-part tariff bill runs

Prior to this change, we'd updated the set-up bill run to include an option for two-part tariff supplementary, and added all the checks to ensure it was possible.

However, we have some temporary code that causes the engine to do nothing when the create button is clicked on the `/check` bill run page.

This change removes that. We also add a service to manage the processing of the bill run, and update some of the supporting services to allow this to happen.