### PR TITLE
Fix View Daily Returns column order

### DIFF
--- a/app/presenters/return-submissions/view-return-submission.presenter.js
+++ b/app/presenters/return-submissions/view-return-submission.presenter.js
@@ -91,12 +91,12 @@ function _generateTableHeaders(units, method, frequency) {
     headers.push({ text: 'Day' })
   }
 
-  if (units !== unitNames.CUBIC_METRES) {
-    headers.push({ text: sentenceCase(returnUnits[units].label), format: 'numeric' })
-  }
-
   if (method !== 'abstractionVolumes') {
     headers.push({ text: 'Reading', format: 'numeric' })
+  }
+
+  if (units !== unitNames.CUBIC_METRES) {
+    headers.push({ text: sentenceCase(returnUnits[units].label), format: 'numeric' })
   }
 
   headers.push({ text: 'Cubic metres', format: 'numeric' })

--- a/test/presenters/return-submissions/view-return-submission.presenter.test.js
+++ b/test/presenters/return-submissions/view-return-submission.presenter.test.js
@@ -185,7 +185,7 @@ describe('View Return Submissions presenter', () => {
     describe('when the return submission contains readings', () => {
       beforeEach(() => {
         testReturnSubmission = _createSubmission({ readings: true })
-        Sinon.stub(testReturnSubmission, '$method').returns('oneMeter')
+        Sinon.stub(testReturnSubmission, '$method').returns('NOT_ABSTRACTION_VOLUMES')
       })
 
       it('includes the expected headers', () => {
@@ -211,6 +211,22 @@ describe('View Return Submissions presenter', () => {
         const result = ViewReturnSubmissionPresenter.go(testReturnSubmission, '2025-1')
 
         expect(result.tableData.cubicMetresTotal).to.equal('28,000')
+      })
+    })
+
+    describe('when the return submission contains non-cubic metre volumes and readings', () => {
+      beforeEach(() => {
+        testReturnSubmission = _createSubmission({ readings: true })
+        Sinon.stub(testReturnSubmission, '$units').returns(unitNames.GALLONS)
+        Sinon.stub(testReturnSubmission, '$method').returns('NOT_ABSTRACTION_VOLUMES')
+      })
+
+      it('includes the expected headers', () => {
+        const result = ViewReturnSubmissionPresenter.go(testReturnSubmission, '2025-1')
+
+        const headers = result.tableData.headers.map((header) => header.text)
+
+        expect(headers).to.equal(['Day', 'Reading', 'Gallons', 'Cubic metres'])
       })
     })
 


### PR DESCRIPTION
QA discovered an issue when viewing a return log with both volumes and meter readings -- the column headings are in the wrong order, so the volumes are labelled as readings as vice-versa. This PR fixes this by swapping the column heading order.