### PR TITLE
Fix View Daily Returns units

### DIFF
--- a/app/presenters/return-submissions/view-return-submission.presenter.js
+++ b/app/presenters/return-submissions/view-return-submission.presenter.js
@@ -72,10 +72,10 @@ function _generateTableRows(lines) {
     const { endDate, quantity, reading, userUnit } = line
 
     const rowData = {
-      cubicMetresQuantity: formatQuantity(userUnit, quantity),
+      cubicMetresQuantity: formatNumber(quantity),
       date: formatLongDate(endDate),
       reading,
-      unitQuantity: formatNumber(quantity)
+      unitQuantity: formatQuantity(userUnit, quantity)
     }
 
     return rowData
@@ -112,8 +112,8 @@ function _total(lines, units) {
   }, 0)
 
   return {
-    cubicMetresTotal: formatQuantity(units, totalQuantity),
-    unitTotal: formatNumber(totalQuantity)
+    cubicMetresTotal: formatNumber(totalQuantity),
+    unitTotal: formatQuantity(units, totalQuantity)
   }
 }
 

--- a/test/presenters/return-submissions/view-return-submission.presenter.test.js
+++ b/test/presenters/return-submissions/view-return-submission.presenter.test.js
@@ -167,17 +167,17 @@ describe('View Return Submissions presenter', () => {
           expect(result.tableData.rows.length).to.equal(28)
           // We use include() as a row can also include a reading key which we don't care about for volumes
           expect(result.tableData.rows[0]).to.include({
-            cubicMetresQuantity: '219,969.248',
+            cubicMetresQuantity: '1,000',
             date: '1 February 2025',
-            unitQuantity: '1,000'
+            unitQuantity: '219,969.248'
           })
         })
 
         it('includes the expected totals', () => {
           const result = ViewReturnSubmissionPresenter.go(testReturnSubmission, '2025-1')
 
-          expect(result.tableData.cubicMetresTotal).to.equal('6,159,138.952')
-          expect(result.tableData.unitTotal).to.equal('28,000')
+          expect(result.tableData.cubicMetresTotal).to.equal('28,000')
+          expect(result.tableData.unitTotal).to.equal('6,159,138.952')
         })
       })
     })


### PR DESCRIPTION
QA discovered an issue where in some scenarios, the cubic metres and return units columns are displayed incorrectly.