### PR TITLE
Use existing helpers in view bill page

### DIFF
--- a/app/presenters/bills/view-bill.presenter.js
+++ b/app/presenters/bills/view-bill.presenter.js
@@ -5,7 +5,14 @@
  * @module ViewBillPresenter
  */
 
-const { formatLongDate, formatMoney, titleCase } = require('../base.presenter.js')
+const {
+  formatBillRunType,
+  formatChargeScheme,
+  formatFinancialYear,
+  formatLongDate,
+  formatMoney,
+  titleCase
+} = require('../base.presenter.js')
 
 /**
  * Formats bill and billing account data ready for presenting in the single licence bill and multi licence bill pages
@@ -29,9 +36,9 @@ function go(bill, billingAccount) {
     billRunId: billRun.id,
     billRunNumber: billRun.billRunNumber,
     billRunStatus: billRun.status,
-    billRunType: _billRunType(billRun),
+    billRunType: formatBillRunType(billRun.batchType, billRun.scheme, billRun.summer),
     billTotal: _billTotal(bill.netAmount, bill.credit),
-    chargeScheme: _scheme(billRun),
+    chargeScheme: formatChargeScheme(billRun.scheme),
     contactName: billingAccount.$contactName(),
     credit: bill.credit,
     creditsTotal: _creditsTotal(bill, billRun),
@@ -39,7 +46,7 @@ function go(bill, billingAccount) {
     debitsTotal: _debitsTotal(bill, billRun),
     deminimis: bill.deminimis,
     displayCreditDebitTotals: _displayCreditDebitTotals(billRun),
-    financialYear: _financialYear(bill),
+    financialYear: formatFinancialYear(bill.financialYearEnding),
     flaggedForReissue: bill.flaggedForRebilling,
     pageTitle: `Bill for ${accountName}`,
     region: titleCase(billRun.region.displayName),
@@ -47,24 +54,6 @@ function go(bill, billingAccount) {
   }
 
   return formattedBill
-}
-
-function _billRunType(billRun) {
-  const { batchType, summer, scheme } = billRun
-
-  if (batchType !== 'two_part_tariff') {
-    return titleCase(batchType)
-  }
-
-  if (scheme === 'sroc') {
-    return 'Two-part tariff'
-  }
-
-  if (summer) {
-    return 'Two-part tariff summer'
-  }
-
-  return 'Two-part tariff winter and all year'
 }
 
 function _creditsTotal(bill, billRun) {
@@ -101,20 +90,6 @@ function _displayCreditDebitTotals(billRun) {
   const { batchType } = billRun
 
   return batchType === 'supplementary'
-}
-
-function _financialYear(bill) {
-  const { financialYearEnding } = bill
-
-  return `${financialYearEnding - 1} to ${financialYearEnding}`
-}
-
-function _scheme(billRun) {
-  if (billRun.scheme === 'sroc') {
-    return 'Current'
-  }
-
-  return 'Old'
 }
 
 function _billTotal(valueInPence, credit) {

--- a/test/presenters/bills/view-bill.presenter.test.js
+++ b/test/presenters/bills/view-bill.presenter.test.js
@@ -54,68 +54,6 @@ describe('View Bill presenter', () => {
       })
     })
 
-    describe('the "billRunType" property', () => {
-      describe('when the bill run is annual', () => {
-        it('returns Annual', () => {
-          const result = ViewBillPresenter.go(bill, billingAccount)
-
-          expect(result.billRunType).to.equal('Annual')
-        })
-      })
-
-      describe('when the bill run is supplementary', () => {
-        beforeEach(() => {
-          bill.billRun.batchType = 'supplementary'
-        })
-
-        it('returns Supplementary', () => {
-          const result = ViewBillPresenter.go(bill, billingAccount)
-
-          expect(result.billRunType).to.equal('Supplementary')
-        })
-      })
-
-      describe('when the bill run is two_part_tariff', () => {
-        beforeEach(() => {
-          bill.billRun.batchType = 'two_part_tariff'
-        })
-
-        describe('and the scheme is sroc', () => {
-          it('returns Supplementary', () => {
-            const result = ViewBillPresenter.go(bill, billingAccount)
-
-            expect(result.billRunType).to.equal('Two-part tariff')
-          })
-        })
-
-        describe('and the scheme is alcs', () => {
-          beforeEach(() => {
-            bill.billRun.scheme = 'alcs'
-          })
-
-          describe('and it is not summer only', () => {
-            it('returns Supplementary', () => {
-              const result = ViewBillPresenter.go(bill, billingAccount)
-
-              expect(result.billRunType).to.equal('Two-part tariff winter and all year')
-            })
-          })
-
-          describe('and it is for summer only', () => {
-            beforeEach(() => {
-              bill.billRun.summer = true
-            })
-
-            it('returns Supplementary', () => {
-              const result = ViewBillPresenter.go(bill, billingAccount)
-
-              expect(result.billRunType).to.equal('Two-part tariff summer')
-            })
-          })
-        })
-      })
-    })
-
     describe('the "billTotal" property', () => {
       describe('when the bill is a debit', () => {
         it('returns just the bill total formatted as money', () => {
@@ -134,28 +72,6 @@ describe('View Bill presenter', () => {
           const result = ViewBillPresenter.go(bill, billingAccount)
 
           expect(result.billTotal).to.equal('£213,178.00 credit')
-        })
-      })
-    })
-
-    describe('the "chargeScheme" property', () => {
-      describe('when the bill run is sroc', () => {
-        it('returns Current', () => {
-          const result = ViewBillPresenter.go(bill, billingAccount)
-
-          expect(result.chargeScheme).to.equal('Current')
-        })
-      })
-
-      describe('when the bill run is alcs', () => {
-        beforeEach(() => {
-          bill.billRun.scheme = 'alcs'
-        })
-
-        it('returns Old', () => {
-          const result = ViewBillPresenter.go(bill, billingAccount)
-
-          expect(result.chargeScheme).to.equal('Old')
         })
       })
     })
@@ -275,22 +191,6 @@ describe('View Bill presenter', () => {
 
           expect(result.displayCreditDebitTotals).to.be.true()
         })
-      })
-    })
-
-    describe('the "financialYear" property', () => {
-      it('returns the bill run start and end financial year', () => {
-        const result = ViewBillPresenter.go(bill, billingAccount)
-
-        expect(result.financialYear).to.equal('2022 to 2023')
-      })
-    })
-
-    describe('the "region" property', () => {
-      it("returns the bill run's region display name in title case", () => {
-        const result = ViewBillPresenter.go(bill, billingAccount)
-
-        expect(result.region).to.equal('South West')
       })
     })
   })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4201

> Part of the work to support two-part tariff bill runs

Spotted whilst adding support for two_part_supplementary bill runs. Our view bill page displays the bill run type. When we generated a two-part tariff supplementary bill run, we saw that the type was displayed incorrectly in the view. When we checked we found it was like PR's #1562 and #1747, where a view was not taking advantage of the available helpers.

This change updates the view bill presenter to take advantage of them, which also resolves our bill run type issue!