### PR TITLE
Move reusable two-part tariff billing services

### DIFF
--- a/app/controllers/bill-runs.controller.js
+++ b/app/controllers/bill-runs.controller.js
@@ -7,7 +7,7 @@
 
 const Boom = require('@hapi/boom')
 
-const GenerateBillRunService = require('../services/bill-runs/two-part-tariff/generate-bill-run.service.js')
+const GenerateTwoPartTariffBillRunService = require('../services/bill-runs/generate-two-part-tariff-bill-run.service.js')
 const IndexBillRunsService = require('../services/bill-runs/index-bill-runs.service.js')
 const SubmitCancelBillRunService = require('../services/bill-runs/cancel/submit-cancel-bill-run.service.js')
 const SubmitSendBillRunService = require('../services/bill-runs/send/submit-send-bill-run.service.js')
@@ -66,7 +66,7 @@ async function twoPartTariff(request, h) {
   try {
     // NOTE: What we are awaiting here is for the GenerateBillRunService to update the status of the bill run to
     // `processing'.
-    await GenerateBillRunService.go(id)
+    await GenerateTwoPartTariffBillRunService.go(id)
 
     // Redirect to the bill runs page
     return h.redirect('/system/bill-runs')

--- a/app/services/bill-runs/generate-two-part-tariff-bill-run.service.js
+++ b/app/services/bill-runs/generate-two-part-tariff-bill-run.service.js
@@ -5,19 +5,15 @@
  * @module GenerateBillRunService
  */
 
-const BillRunError = require('../../../errors/bill-run.error.js')
-const BillRunModel = require('../../../models/bill-run.model.js')
-const ChargingModuleGenerateBillRunRequest = require('../../../requests/charging-module/generate-bill-run.request.js')
-const ExpandedError = require('../../../errors/expanded.error.js')
-const {
-  calculateAndLogTimeTaken,
-  currentTimeInNanoseconds,
-  timestampForPostgres
-} = require('../../../lib/general.lib.js')
-const FetchTwoPartTariffBillingAccountsService = require('../fetch-two-part-tariff-billing-accounts.service.js')
-const HandleErroredBillRunService = require('../handle-errored-bill-run.service.js')
-const LegacyRefreshBillRunRequest = require('../../../requests/legacy/refresh-bill-run.request.js')
-const ProcessBillingPeriodService = require('./process-billing-period.service.js')
+const BillRunError = require('../../errors/bill-run.error.js')
+const BillRunModel = require('../../models/bill-run.model.js')
+const ChargingModuleGenerateBillRunRequest = require('../../requests/charging-module/generate-bill-run.request.js')
+const ExpandedError = require('../../errors/expanded.error.js')
+const { calculateAndLogTimeTaken, currentTimeInNanoseconds, timestampForPostgres } = require('../../lib/general.lib.js')
+const FetchTwoPartTariffBillingAccountsService = require('./fetch-two-part-tariff-billing-accounts.service.js')
+const HandleErroredBillRunService = require('./handle-errored-bill-run.service.js')
+const LegacyRefreshBillRunRequest = require('../../requests/legacy/refresh-bill-run.request.js')
+const ProcessAnnualBillingPeriodService = require('./two-part-tariff/process-billing-period.service.js')
 
 /**
  * Generates a two-part tariff bill run after the users have completed reviewing its match & allocate results
@@ -136,7 +132,7 @@ async function _processBillingPeriod(billingPeriod, billRun) {
 
   const billingAccounts = await _fetchBillingAccounts(billRunId)
 
-  const billRunPopulated = await ProcessBillingPeriodService.go(billRun, billingPeriod, billingAccounts)
+  const billRunPopulated = await ProcessAnnualBillingPeriodService.go(billRun, billingPeriod, billingAccounts)
 
   await _finaliseBillRun(billRun, billRunPopulated)
 }

--- a/app/services/bill-runs/generate-two-part-tariff-bill-run.service.js
+++ b/app/services/bill-runs/generate-two-part-tariff-bill-run.service.js
@@ -14,6 +14,7 @@ const FetchTwoPartTariffBillingAccountsService = require('./fetch-two-part-tarif
 const HandleErroredBillRunService = require('./handle-errored-bill-run.service.js')
 const LegacyRefreshBillRunRequest = require('../../requests/legacy/refresh-bill-run.request.js')
 const ProcessAnnualBillingPeriodService = require('./two-part-tariff/process-billing-period.service.js')
+const ProcessSupplementaryBillingPeriodService = require('./tpt-supplementary/process-billing-period.service.js')
 
 /**
  * Generates a two-part tariff bill run after the users have completed reviewing its match & allocate results
@@ -132,7 +133,12 @@ async function _processBillingPeriod(billingPeriod, billRun) {
 
   const billingAccounts = await _fetchBillingAccounts(billRunId)
 
-  const billRunPopulated = await ProcessAnnualBillingPeriodService.go(billRun, billingPeriod, billingAccounts)
+  let billRunPopulated = false
+  if (billRun.batchType === 'two_part_tariff') {
+    billRunPopulated = await ProcessAnnualBillingPeriodService.go(billRun, billingPeriod, billingAccounts)
+  } else {
+    billRunPopulated = await ProcessSupplementaryBillingPeriodService.go(billRun, billingPeriod, billingAccounts)
+  }
 
   await _finaliseBillRun(billRun, billRunPopulated)
 }

--- a/app/services/bill-runs/generate-two-part-tariff-transaction.service.js
+++ b/app/services/bill-runs/generate-two-part-tariff-transaction.service.js
@@ -2,10 +2,10 @@
 
 /**
  * Generate a two-part tariff transaction data from the the charge reference and other information passed in
- * @module GenerateTransactionService
+ * @module GenerateTwoPartTariffTransactionService
  */
 
-const { generateUUID } = require('../../../lib/general.lib.js')
+const { generateUUID } = require('../../lib/general.lib.js')
 
 /**
  * Generate a two-part tariff transaction data from the the charge reference and other information passed in

--- a/app/services/bill-runs/tpt-supplementary/process-billing-period.service.js
+++ b/app/services/bill-runs/tpt-supplementary/process-billing-period.service.js
@@ -1,0 +1,23 @@
+'use strict'
+
+/**
+ * Process the billing accounts for a given billing period and creates their supplementary two-part tariff bills
+ * @module ProcessBillingPeriodService
+ */
+
+/**
+ * Process the billing accounts for a given billing period and creates their supplementary two-part tariff bills
+ *
+ * @param {module:BillRunModel} _billRun - The two-part tariff supplementary bill run we need to process
+ * @param {object} _billingPeriod - An object representing the financial year the bills will be for
+ * @param {module:BillingAccountModel[]} _billingAccounts - The billing accounts to create bills for
+ *
+ * @returns {Promise<boolean>} true if the bill run is not empty (there are transactions to bill) else false
+ */
+async function go(_billRun, _billingPeriod, _billingAccounts) {
+  throw Error('Not implemented')
+}
+
+module.exports = {
+  go
+}

--- a/app/services/bill-runs/two-part-tariff/process-billing-period.service.js
+++ b/app/services/bill-runs/two-part-tariff/process-billing-period.service.js
@@ -21,7 +21,7 @@ const BillingConfig = require('../../../../config/billing.config.js')
 /**
  * Process the billing accounts for a given billing period and creates their annual two-part tariff bills
  *
- * @param {module:BillRunModel} billRun - The two-part tariff bill run we need to process
+ * @param {module:BillRunModel} billRun - The two-part tariff annual bill run we need to process
  * @param {object} billingPeriod - An object representing the financial year the bills will be for
  * @param {module:BillingAccountModel[]} billingAccounts - The billing accounts to create bills for
  *

--- a/app/services/bill-runs/two-part-tariff/process-billing-period.service.js
+++ b/app/services/bill-runs/two-part-tariff/process-billing-period.service.js
@@ -12,7 +12,7 @@ const BillLicenceModel = require('../../../models/bill-licence.model.js')
 const DetermineChargePeriodService = require('../determine-charge-period.service.js')
 const DetermineMinimumChargeService = require('../determine-minimum-charge.service.js')
 const { generateUUID } = require('../../../lib/general.lib.js')
-const GenerateTransactionService = require('./generate-transaction.service.js')
+const GenerateTwoPartTariffTransactionService = require('../generate-two-part-tariff-transaction.service.js')
 const SendTransactionsService = require('../send-transactions.service.js')
 const TransactionModel = require('../../../models/transaction.model.js')
 
@@ -227,7 +227,7 @@ function _generateTransactionData(billLicenceId, chargePeriod, chargeVersion) {
     const transactions = []
 
     chargeVersion.chargeReferences.forEach((chargeReference) => {
-      const transaction = GenerateTransactionService.go(
+      const transaction = GenerateTwoPartTariffTransactionService.go(
         billLicenceId,
         chargeReference,
         chargePeriod,

--- a/test/controllers/bill-runs.controller.test.js
+++ b/test/controllers/bill-runs.controller.test.js
@@ -13,7 +13,7 @@ const { postRequestOptions } = require('../support/general.js')
 
 // Things we need to stub
 const Boom = require('@hapi/boom')
-const GenerateBillRunService = require('../../app/services/bill-runs/two-part-tariff/generate-bill-run.service.js')
+const GenerateTwoPartTariffBillRunService = require('../../app/services/bill-runs/generate-two-part-tariff-bill-run.service.js')
 const IndexBillRunsService = require('../../app/services/bill-runs/index-bill-runs.service.js')
 const SubmitCancelBillRunService = require('../../app/services/bill-runs/cancel/submit-cancel-bill-run.service.js')
 const SubmitSendBillRunService = require('../../app/services/bill-runs/send/submit-send-bill-run.service.js')
@@ -276,7 +276,7 @@ describe('Bill Runs controller', () => {
 
       describe('when a request is valid', () => {
         beforeEach(() => {
-          Sinon.stub(GenerateBillRunService, 'go').resolves('97db1a27-8308-4aba-b463-8a6af2558b28')
+          Sinon.stub(GenerateTwoPartTariffBillRunService, 'go').resolves('97db1a27-8308-4aba-b463-8a6af2558b28')
         })
 
         it('redirects to the bill runs page', async () => {
@@ -291,7 +291,7 @@ describe('Bill Runs controller', () => {
         describe('because the generate service threw an error', () => {
           beforeEach(async () => {
             Sinon.stub(Boom, 'badImplementation').returns(new Boom.Boom('Bang', { statusCode: 500 }))
-            Sinon.stub(GenerateBillRunService, 'go').rejects()
+            Sinon.stub(GenerateTwoPartTariffBillRunService, 'go').rejects()
           })
 
           it('returns the error page', async () => {

--- a/test/services/bill-runs/generate-two-part-tariff-transaction.service.test.js
+++ b/test/services/bill-runs/generate-two-part-tariff-transaction.service.test.js
@@ -8,9 +8,9 @@ const { describe, it, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Thing under test
-const GenerateTransactionService = require('../../../../app/services/bill-runs/two-part-tariff/generate-transaction.service.js')
+const GenerateTwoPartTariffTransactionService = require('../../../app/services/bill-runs/generate-two-part-tariff-transaction.service.js')
 
-describe('Generate Transaction service', () => {
+describe('Bill Runs - Generate Two Part Tariff Transaction service', () => {
   const billLicenceId = '5e2afb53-ca92-4515-ad71-36a7cefbcebb'
 
   let chargePeriod
@@ -32,7 +32,7 @@ describe('Generate Transaction service', () => {
   describe('when called', () => {
     describe('with a charge reference that has volume to be billed', () => {
       it('returns a two-part tariff transaction ready to be persisted', () => {
-        const result = GenerateTransactionService.go(
+        const result = GenerateTwoPartTariffTransactionService.go(
           billLicenceId,
           chargeReference,
           chargePeriod,
@@ -90,7 +90,7 @@ describe('Generate Transaction service', () => {
         })
 
         it('returns the two-part tariff prefixed description', () => {
-          const result = GenerateTransactionService.go(
+          const result = GenerateTwoPartTariffTransactionService.go(
             billLicenceId,
             chargeReference,
             chargePeriod,
@@ -112,7 +112,7 @@ describe('Generate Transaction service', () => {
       })
 
       it('returns null', () => {
-        const result = GenerateTransactionService.go(
+        const result = GenerateTwoPartTariffTransactionService.go(
           billLicenceId,
           chargeReference,
           chargePeriod,

--- a/test/services/bill-runs/tpt-supplementary/process-billing-period.service.test.js
+++ b/test/services/bill-runs/tpt-supplementary/process-billing-period.service.test.js
@@ -1,0 +1,19 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Thing under test
+const ProcessBillingPeriodService = require('../../../../app/services/bill-runs/tpt-supplementary/process-billing-period.service.js')
+
+describe('Bill Runs - Two-part Tariff - Process Billing Period service', () => {
+  describe('when the service is called', () => {
+    it('throws an error', async () => {
+      await expect(ProcessBillingPeriodService.go()).to.reject()
+    })
+  })
+})

--- a/test/services/bill-runs/two-part-tariff/process-billing-period.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/process-billing-period.service.test.js
@@ -19,12 +19,12 @@ const RegionHelper = require('../../../support/helpers/region.helper.js')
 const BillRunError = require('../../../../app/errors/bill-run.error.js')
 const BillRunModel = require('../../../../app/models/bill-run.model.js')
 const ChargingModuleCreateTransactionRequest = require('../../../../app/requests/charging-module/create-transaction.request.js')
-const GenerateTransactionService = require('../../../../app/services/bill-runs/two-part-tariff/generate-transaction.service.js')
+const GenerateTwoPartTariffTransactionService = require('../../../../app/services/bill-runs/generate-two-part-tariff-transaction.service.js')
 
 // Thing under test
 const ProcessBillingPeriodService = require('../../../../app/services/bill-runs/two-part-tariff/process-billing-period.service.js')
 
-describe('Two-part Tariff - Process Billing Period service', () => {
+describe('Bill Runs - Two-part Tariff - Process Billing Period service', () => {
   const billingPeriod = {
     startDate: new Date('2022-04-01'),
     endDate: new Date('2023-03-31')
@@ -198,7 +198,7 @@ describe('Two-part Tariff - Process Billing Period service', () => {
 
     describe('because generating the calculated transaction fails', () => {
       beforeEach(async () => {
-        Sinon.stub(GenerateTransactionService, 'go').throws()
+        Sinon.stub(GenerateTwoPartTariffTransactionService, 'go').throws()
       })
 
       it('throws a BillRunError with the correct code', async () => {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4201

> Part of the work to support two-part tariff supplementary bill runs

In [Move reusable supplementary billing services](https://github.com/DEFRA/water-abstraction-system/pull/1760) we shifted some existing supplementary billing services to make them reusable by the two-part tariff supplementary billing engine we're building.

Our [spike](https://github.com/DEFRA/water-abstraction-system/pull/1412) has shown there are some two-part tariff annual billing services we can also make reusable.