### PR TITLE
Show credits/debits in view bill for tpt supp.

### DIFF
--- a/app/presenters/base.presenter.js
+++ b/app/presenters/base.presenter.js
@@ -35,26 +35,6 @@ function formatQuantity(units, quantity) {
 }
 
 /**
- * Generates the page title for a bill run, for example, 'Anglian supplementary'
- *
- * Typically the page title when viewing a bill run is the region name followed by the bill run type. We determine the
- * bill run type using the bill run's batch type, scheme and in the case of two-part tariff PRESROC bill runs, whether
- * it is summer only or not.
- *
- * @param {string} regionName - Name of the region the bill run is for
- * @param {string} batchType - The type of bill run; annual, supplementary or two_part_tariff
- * @param {string} scheme - Whether the bill run is PRESROC (alcs) or SROC (sroc)
- * @param {boolean} summer - Applies to PRESROC two-part tariff bill runs. Whether the bill run is for summer only
- *
- * @returns The bill run title to use in bill run pages
- */
-function generateBillRunTitle(regionName, batchType, scheme, summer) {
-  const billRunType = formatBillRunType(batchType, scheme, summer)
-
-  return `${titleCase(regionName)} ${billRunType.toLowerCase()}`
-}
-
-/**
  * Formats an abstraction day and month into its string variant, for example, 1 and 4 becomes '1 April'
  *
  * If either value is null or undefined, it returns null.
@@ -101,35 +81,6 @@ function formatAbstractionPeriod(startDay, startMonth, endDay, endMonth) {
 }
 
 /**
- * Formats how the bill run type for display in views
- *
- * @param {string} batchType - The type of bill run; annual, supplementary, two_part_tariff or two_part_supplementary
- * @param {string} scheme - Whether the bill run is PRESROC (alcs) or SROC (sroc)
- * @param {boolean} summer - Applies to PRESROC two-part tariff bill runs. Whether the bill run is for summer only
- *
- * @returns {string} The bill run type formatted for display
- */
-function formatBillRunType(batchType, scheme, summer) {
-  if (!['two_part_tariff', 'two_part_supplementary'].includes(batchType)) {
-    return titleCase(batchType)
-  }
-
-  if (batchType === 'two_part_supplementary') {
-    return 'Two-part tariff supplementary'
-  }
-
-  if (scheme === 'sroc') {
-    return 'Two-part tariff'
-  }
-
-  if (summer) {
-    return 'Two-part tariff summer'
-  }
-
-  return 'Two-part tariff winter and all year'
-}
-
-/**
  * Converts a date into the format required by the Charging Module, eg 25/03/2021 becomes 25-MAR-2021
  *
  * @param {Date} date - The date to be formatted
@@ -149,21 +100,6 @@ function formatChargingModuleDate(date) {
   const year = date.getFullYear()
 
   return `${day}-${month}-${year}`
-}
-
-/**
- * Formats a bill run's scheme (alcs or sroc) for display in a view (Old or Current)
- *
- * @param {string} scheme - The bill run scheme to format
- *
- * @returns {string} The scheme formatted for display
- */
-function formatChargeScheme(scheme) {
-  if (scheme === 'sroc') {
-    return 'Current'
-  }
-
-  return 'Old'
 }
 
 /**
@@ -326,12 +262,9 @@ function titleCase(value) {
 
 module.exports = {
   convertPenceToPounds,
-  generateBillRunTitle,
   formatAbstractionDate,
   formatAbstractionPeriod,
-  formatBillRunType,
   formatChargingModuleDate,
-  formatChargeScheme,
   formatFinancialYear,
   formatLongDate,
   formatLongDateTime,

--- a/app/presenters/bill-licences/remove-bill-licence.presenter.js
+++ b/app/presenters/bill-licences/remove-bill-licence.presenter.js
@@ -5,14 +5,8 @@
  * @module RemoveBillLicencePresenter
  */
 
-const {
-  formatBillRunType,
-  formatChargeScheme,
-  formatFinancialYear,
-  formatLongDate,
-  formatMoney,
-  titleCase
-} = require('../base.presenter.js')
+const { formatFinancialYear, formatLongDate, formatMoney, titleCase } = require('../base.presenter.js')
+const { formatBillRunType, formatChargeScheme } = require('../billing.presenter.js')
 
 /**
  * Formats data for the confirm remove a bill licence page

--- a/app/presenters/bill-licences/view-bill-licence.presenter.js
+++ b/app/presenters/bill-licences/view-bill-licence.presenter.js
@@ -6,6 +6,7 @@
  */
 
 const { formatMoney } = require('../base.presenter.js')
+const { displayCreditDebitTotals } = require('../billing.presenter.js')
 const ViewCompensationChargeTransactionPresenter = require('./view-compensation-charge-transaction.presenter.js')
 const ViewMinimumChargeTransactionPresenter = require('./view-minimum-charge-transaction.presenter.js')
 const ViewStandardChargeTransactionPresenter = require('./view-standard-charge-transaction.presenter.js')
@@ -22,8 +23,6 @@ const ViewStandardChargeTransactionPresenter = require('./view-standard-charge-t
 function go(billLicence) {
   const { id: billLicenceId, bill, licenceId, licenceRef, transactions } = billLicence
 
-  const displayCreditDebitTotals = _displayCreditDebitTotals(bill.billRun)
-
   const { creditTotal, debitTotal, total } = _totals(transactions)
 
   return {
@@ -31,7 +30,7 @@ function go(billLicence) {
     billId: bill.id,
     creditTotal,
     debitTotal,
-    displayCreditDebitTotals,
+    displayCreditDebitTotals: displayCreditDebitTotals(bill.billRun.batchType),
     licenceId,
     licenceRef,
     removeLicenceLink: _removeLicenceLink(bill.billRun, billLicenceId),
@@ -41,12 +40,6 @@ function go(billLicence) {
     transactions: _transactions(transactions),
     transactionsTotal: total
   }
-}
-
-function _displayCreditDebitTotals(billRun) {
-  const { batchType } = billRun
-
-  return batchType === 'supplementary'
 }
 
 function _removeLicenceLink(billRun, billLicenceId) {

--- a/app/presenters/bill-runs/empty-bill-run-presenter.js
+++ b/app/presenters/bill-runs/empty-bill-run-presenter.js
@@ -5,14 +5,8 @@
  * @module EmptyBillRunPresenter
  */
 
-const {
-  generateBillRunTitle,
-  formatBillRunType,
-  formatChargeScheme,
-  formatFinancialYear,
-  formatLongDate,
-  titleCase
-} = require('../base.presenter.js')
+const { formatFinancialYear, formatLongDate, titleCase } = require('../base.presenter.js')
+const { formatBillRunType, formatChargeScheme, generateBillRunTitle } = require('../billing.presenter.js')
 
 /**
  * Prepares and processes bill run data for presentation

--- a/app/presenters/bill-runs/errored-bill-run-presenter.js
+++ b/app/presenters/bill-runs/errored-bill-run-presenter.js
@@ -5,14 +5,8 @@
  * @module ErroredBillRunPresenter
  */
 
-const {
-  generateBillRunTitle,
-  formatBillRunType,
-  formatChargeScheme,
-  formatFinancialYear,
-  formatLongDate,
-  titleCase
-} = require('../base.presenter.js')
+const { formatFinancialYear, formatLongDate, titleCase } = require('../base.presenter.js')
+const { formatBillRunType, formatChargeScheme, generateBillRunTitle } = require('../billing.presenter.js')
 
 /**
  * Prepares and processes bill run data for presentation

--- a/app/presenters/bill-runs/index-bill-runs.presenter.js
+++ b/app/presenters/bill-runs/index-bill-runs.presenter.js
@@ -5,7 +5,8 @@
  * @module IndexBillRunsPresenter
  */
 
-const { formatBillRunType, formatLongDate, formatMoney, titleCase } = require('../base.presenter.js')
+const { formatLongDate, formatMoney, titleCase } = require('../base.presenter.js')
+const { formatBillRunType } = require('../billing.presenter.js')
 
 /**
  * Formats the summary data for each bill run for use in the /bill-runs page

--- a/app/presenters/bill-runs/review/review-bill-run.presenter.js
+++ b/app/presenters/bill-runs/review/review-bill-run.presenter.js
@@ -5,14 +5,8 @@
  * @module ReviewBillRunPresenter
  */
 
-const {
-  formatBillRunType,
-  formatChargeScheme,
-  formatFinancialYear,
-  formatLongDate,
-  generateBillRunTitle,
-  titleCase
-} = require('../../base.presenter.js')
+const { formatFinancialYear, formatLongDate, titleCase } = require('../../base.presenter.js')
+const { formatBillRunType, formatChargeScheme, generateBillRunTitle } = require('../../billing.presenter.js')
 
 /**
  * Prepares and processes bill run, licence and filter data for presentation

--- a/app/presenters/bill-runs/review/review-licence.presenter.js
+++ b/app/presenters/bill-runs/review/review-licence.presenter.js
@@ -5,12 +5,8 @@
  * @module ReviewLicencePresenter
  */
 
-const {
-  formatAbstractionPeriod,
-  formatFinancialYear,
-  formatLongDate,
-  generateBillRunTitle
-} = require('../../base.presenter.js')
+const { formatAbstractionPeriod, formatFinancialYear, formatLongDate } = require('../../base.presenter.js')
+const { generateBillRunTitle } = require('../../billing.presenter.js')
 const {
   calculateTotalBillableReturns,
   determineReturnLink,

--- a/app/presenters/bill-runs/setup/check/allowed-bill-run.presenter.js
+++ b/app/presenters/bill-runs/setup/check/allowed-bill-run.presenter.js
@@ -5,8 +5,8 @@
  * @module AllowBillRunPresenter
  */
 
-const { formatBillRunType, formatChargeScheme } = require('../../../base.presenter.js')
 const { checkPageBackLink } = require('./base-check.presenter.js')
+const { formatBillRunType, formatChargeScheme } = require('../../../billing.presenter.js')
 const { engineTriggers } = require('../../../../lib/static-lookups.lib.js')
 
 /**

--- a/app/presenters/bill-runs/setup/check/blocked-bill-run.presenter.js
+++ b/app/presenters/bill-runs/setup/check/blocked-bill-run.presenter.js
@@ -5,8 +5,9 @@
  * @module BlockedBillRunPresenter
  */
 
-const { formatBillRunType, formatChargeScheme, formatLongDate } = require('../../../base.presenter.js')
+const { formatLongDate } = require('../../../base.presenter.js')
 const { checkPageBackLink } = require('./base-check.presenter.js')
+const { formatBillRunType, formatChargeScheme } = require('../../../billing.presenter.js')
 
 const LAST_PRESROC_YEAR = 2022
 

--- a/app/presenters/bill-runs/setup/check/no-annual-bill-run.presenter.js
+++ b/app/presenters/bill-runs/setup/check/no-annual-bill-run.presenter.js
@@ -5,7 +5,7 @@
  * @module NoAnnualBillRunPresenter
  */
 
-const { formatBillRunType, formatChargeScheme } = require('../../../base.presenter.js')
+const { formatBillRunType, formatChargeScheme } = require('../../../billing.presenter.js')
 const { checkPageBackLink } = require('./base-check.presenter.js')
 
 /**

--- a/app/presenters/bill-runs/view-bill-run.presenter.js
+++ b/app/presenters/bill-runs/view-bill-run.presenter.js
@@ -6,7 +6,12 @@
  */
 
 const { formatFinancialYear, formatLongDate, formatMoney, titleCase } = require('../base.presenter.js')
-const { formatBillRunType, formatChargeScheme, generateBillRunTitle } = require('../billing.presenter.js')
+const {
+  formatBillRunType,
+  formatChargeScheme,
+  displayCreditDebitTotals,
+  generateBillRunTitle
+} = require('../billing.presenter.js')
 
 /**
  * Formats bill run data ready for presenting in the view bill run page
@@ -50,7 +55,7 @@ function go(billRun, billSummaries) {
     dateCreated: formatLongDate(createdAt),
     debitsCount: _debitsCount(invoiceCount),
     debitsTotal: formatMoney(invoiceValue),
-    displayCreditDebitTotals: _displayCreditDebitTotals(billRun),
+    displayCreditDebitTotals: displayCreditDebitTotals(billRun.batchType),
     financialYear: formatFinancialYear(toFinancialYearEnding),
     pageTitle: generateBillRunTitle(region.displayName, batchType, scheme, summer),
     region: titleCase(region.displayName),
@@ -110,12 +115,6 @@ function _debitsCount(count) {
   }
 
   return `${count} invoices`
-}
-
-function _displayCreditDebitTotals(billRun) {
-  const { batchType } = billRun
-
-  return batchType === 'supplementary'
 }
 
 module.exports = {

--- a/app/presenters/bill-runs/view-bill-run.presenter.js
+++ b/app/presenters/bill-runs/view-bill-run.presenter.js
@@ -5,15 +5,8 @@
  * @module ViewBillRunPresenter
  */
 
-const {
-  generateBillRunTitle,
-  formatBillRunType,
-  formatChargeScheme,
-  formatFinancialYear,
-  formatLongDate,
-  formatMoney,
-  titleCase
-} = require('../base.presenter.js')
+const { formatFinancialYear, formatLongDate, formatMoney, titleCase } = require('../base.presenter.js')
+const { formatBillRunType, formatChargeScheme, generateBillRunTitle } = require('../billing.presenter.js')
 
 /**
  * Formats bill run data ready for presenting in the view bill run page

--- a/app/presenters/bill-runs/view-cancel-bill-run.presenter.js
+++ b/app/presenters/bill-runs/view-cancel-bill-run.presenter.js
@@ -5,13 +5,8 @@
  * @module ViewCancelBillRunPresenter
  */
 
-const {
-  formatBillRunType,
-  formatChargeScheme,
-  formatFinancialYear,
-  formatLongDate,
-  titleCase
-} = require('../base.presenter.js')
+const { formatFinancialYear, formatLongDate, titleCase } = require('../base.presenter.js')
+const { formatBillRunType, formatChargeScheme } = require('../billing.presenter.js')
 
 /**
  * Prepares and processes bill run data for presentation

--- a/app/presenters/bill-runs/view-send-bill-run.presenter.js
+++ b/app/presenters/bill-runs/view-send-bill-run.presenter.js
@@ -5,13 +5,8 @@
  * @module ViewSendBillRunPresenter
  */
 
-const {
-  formatBillRunType,
-  formatChargeScheme,
-  formatFinancialYear,
-  formatLongDate,
-  titleCase
-} = require('../base.presenter.js')
+const { formatFinancialYear, formatLongDate, titleCase } = require('../base.presenter.js')
+const { formatBillRunType, formatChargeScheme } = require('../billing.presenter.js')
 
 /**
  * Prepares and processes bill run data for presentation

--- a/app/presenters/billing.presenter.js
+++ b/app/presenters/billing.presenter.js
@@ -1,0 +1,73 @@
+'use strict'
+
+const { titleCase } = require('./base.presenter.js')
+
+/**
+ * Formats how the bill run type for display in views
+ *
+ * @param {string} batchType - The type of bill run; annual, supplementary, two_part_tariff or two_part_supplementary
+ * @param {string} scheme - Whether the bill run is PRESROC (alcs) or SROC (sroc)
+ * @param {boolean} summer - Applies to PRESROC two-part tariff bill runs. Whether the bill run is for summer only
+ *
+ * @returns {string} The bill run type formatted for display
+ */
+function formatBillRunType(batchType, scheme, summer) {
+  if (!['two_part_tariff', 'two_part_supplementary'].includes(batchType)) {
+    return titleCase(batchType)
+  }
+
+  if (batchType === 'two_part_supplementary') {
+    return 'Two-part tariff supplementary'
+  }
+
+  if (scheme === 'sroc') {
+    return 'Two-part tariff'
+  }
+
+  if (summer) {
+    return 'Two-part tariff summer'
+  }
+
+  return 'Two-part tariff winter and all year'
+}
+
+/**
+ * Formats a bill run's scheme (alcs or sroc) for display in a view (Old or Current)
+ *
+ * @param {string} scheme - The bill run scheme to format
+ *
+ * @returns {string} The scheme formatted for display
+ */
+function formatChargeScheme(scheme) {
+  if (scheme === 'sroc') {
+    return 'Current'
+  }
+
+  return 'Old'
+}
+
+/**
+ * Generates the page title for a bill run, for example, 'Anglian supplementary'
+ *
+ * Typically the page title when viewing a bill run is the region name followed by the bill run type. We determine the
+ * bill run type using the bill run's batch type, scheme and in the case of two-part tariff PRESROC bill runs, whether
+ * it is summer only or not.
+ *
+ * @param {string} regionName - Name of the region the bill run is for
+ * @param {string} batchType - The type of bill run; annual, supplementary or two_part_tariff
+ * @param {string} scheme - Whether the bill run is PRESROC (alcs) or SROC (sroc)
+ * @param {boolean} summer - Applies to PRESROC two-part tariff bill runs. Whether the bill run is for summer only
+ *
+ * @returns The bill run title to use in bill run pages
+ */
+function generateBillRunTitle(regionName, batchType, scheme, summer) {
+  const billRunType = formatBillRunType(batchType, scheme, summer)
+
+  return `${titleCase(regionName)} ${billRunType.toLowerCase()}`
+}
+
+module.exports = {
+  formatBillRunType,
+  formatChargeScheme,
+  generateBillRunTitle
+}

--- a/app/presenters/billing.presenter.js
+++ b/app/presenters/billing.presenter.js
@@ -47,6 +47,24 @@ function formatChargeScheme(scheme) {
 }
 
 /**
+ * Whether a view should display both the credit and debit totals, or just the debits
+ *
+ * If a bill run's batch type is `annual` or `two_part_tariff` then it will only contain debits. So, our billing views
+ * don't bother to show the credit columns and credit total row.
+ *
+ * But supplementary and two-part tariff supplementary bill runs _can_ contain both credit and debit values. In these
+ * cases our billing views will display both. This helper allows them to share the logic which determines when to show
+ * the credit values.
+ *
+ * @param {string} batchType - The bill run batch type
+ *
+ * @returns `true` if both credit and debit totals should be displayed, else `false`
+ */
+function displayCreditDebitTotals(batchType) {
+  return ['supplementary', 'two_part_supplementary'].includes(batchType)
+}
+
+/**
  * Generates the page title for a bill run, for example, 'Anglian supplementary'
  *
  * Typically the page title when viewing a bill run is the region name followed by the bill run type. We determine the
@@ -69,5 +87,6 @@ function generateBillRunTitle(regionName, batchType, scheme, summer) {
 module.exports = {
   formatBillRunType,
   formatChargeScheme,
+  displayCreditDebitTotals,
   generateBillRunTitle
 }

--- a/app/presenters/bills/remove-bill.presenter.js
+++ b/app/presenters/bills/remove-bill.presenter.js
@@ -5,14 +5,8 @@
  * @module RemoveBillPresenter
  */
 
-const {
-  formatBillRunType,
-  formatChargeScheme,
-  formatFinancialYear,
-  formatLongDate,
-  formatMoney,
-  titleCase
-} = require('../base.presenter.js')
+const { formatFinancialYear, formatLongDate, formatMoney, titleCase } = require('../base.presenter.js')
+const { formatBillRunType, formatChargeScheme } = require('../billing.presenter.js')
 
 /**
  * Formats data for the confirm remove a bill page

--- a/app/presenters/bills/view-bill.presenter.js
+++ b/app/presenters/bills/view-bill.presenter.js
@@ -5,14 +5,8 @@
  * @module ViewBillPresenter
  */
 
-const {
-  formatBillRunType,
-  formatChargeScheme,
-  formatFinancialYear,
-  formatLongDate,
-  formatMoney,
-  titleCase
-} = require('../base.presenter.js')
+const { formatFinancialYear, formatLongDate, formatMoney, titleCase } = require('../base.presenter.js')
+const { formatBillRunType, formatChargeScheme } = require('../billing.presenter.js')
 
 /**
  * Formats bill and billing account data ready for presenting in the single licence bill and multi licence bill pages

--- a/app/presenters/bills/view-bill.presenter.js
+++ b/app/presenters/bills/view-bill.presenter.js
@@ -6,7 +6,7 @@
  */
 
 const { formatFinancialYear, formatLongDate, formatMoney, titleCase } = require('../base.presenter.js')
-const { formatBillRunType, formatChargeScheme } = require('../billing.presenter.js')
+const { formatBillRunType, formatChargeScheme, displayCreditDebitTotals } = require('../billing.presenter.js')
 
 /**
  * Formats bill and billing account data ready for presenting in the single licence bill and multi licence bill pages
@@ -39,7 +39,7 @@ function go(bill, billingAccount) {
     dateCreated: formatLongDate(bill.createdAt),
     debitsTotal: _debitsTotal(bill, billRun),
     deminimis: bill.deminimis,
-    displayCreditDebitTotals: _displayCreditDebitTotals(billRun),
+    displayCreditDebitTotals: displayCreditDebitTotals(billRun.batchType),
     financialYear: formatFinancialYear(bill.financialYearEnding),
     flaggedForReissue: bill.flaggedForRebilling,
     pageTitle: `Bill for ${accountName}`,
@@ -78,12 +78,6 @@ function _debitsTotal(bill, billRun) {
   }
 
   return '£0.00'
-}
-
-function _displayCreditDebitTotals(billRun) {
-  const { batchType } = billRun
-
-  return batchType === 'supplementary'
 }
 
 function _billTotal(valueInPence, credit) {

--- a/app/presenters/licences/view-licence-bills.presenter.js
+++ b/app/presenters/licences/view-licence-bills.presenter.js
@@ -5,7 +5,8 @@
  * @module ViewLicenceBillsPresenter
  */
 
-const { formatBillRunType, formatLongDate, formatMoney } = require('../base.presenter.js')
+const { formatLongDate, formatMoney } = require('../base.presenter.js')
+const { formatBillRunType } = require('../billing.presenter.js')
 
 /**
  * Formats data for the `/licences/{id}/bills` view licence bill page

--- a/app/services/bills/view-bill.service.js
+++ b/app/services/bills/view-bill.service.js
@@ -48,6 +48,7 @@ async function go(id) {
     const billLicence = await FetchBillLicence.go(licenceSummaries[0].id)
 
     additionalData = ViewBillLicencePresenter.go(billLicence)
+    console.log('🚀 ~ go ~ additionalData:', additionalData)
   }
 
   return {

--- a/app/services/bills/view-bill.service.js
+++ b/app/services/bills/view-bill.service.js
@@ -48,7 +48,6 @@ async function go(id) {
     const billLicence = await FetchBillLicence.go(licenceSummaries[0].id)
 
     additionalData = ViewBillLicencePresenter.go(billLicence)
-    console.log('🚀 ~ go ~ additionalData:', additionalData)
   }
 
   return {

--- a/test/presenters/base.presenter.test.js
+++ b/test/presenters/base.presenter.test.js
@@ -75,19 +75,6 @@ describe('Base presenter', () => {
     })
   })
 
-  describe('#generateBillRunTitle()', () => {
-    const regionName = 'anglian'
-    const batchType = 'two_part_tariff'
-    const scheme = 'sroc'
-    const summer = false
-
-    it('generates the page title for the bill run, for example, "Anglian two-part tariff"', () => {
-      const result = BasePresenter.generateBillRunTitle(regionName, batchType, scheme, summer)
-
-      expect(result).to.equal('Anglian two-part tariff')
-    })
-  })
-
   describe('#formatAbstractionDate()', () => {
     let day
     let month
@@ -144,96 +131,6 @@ describe('Base presenter', () => {
     })
   })
 
-  describe('#formatBillRunType()', () => {
-    let batchType
-    let scheme
-    let summer
-
-    describe('when the batch type is "annual"', () => {
-      beforeEach(() => {
-        batchType = 'annual'
-      })
-
-      it('returns "Annual"', () => {
-        const result = BasePresenter.formatBillRunType(batchType, scheme, summer)
-
-        expect(result).to.equal('Annual')
-      })
-    })
-
-    describe('when the batch type is "supplementary"', () => {
-      beforeEach(() => {
-        batchType = 'supplementary'
-      })
-
-      it('returns "Supplementary"', () => {
-        const result = BasePresenter.formatBillRunType(batchType, scheme, summer)
-
-        expect(result).to.equal('Supplementary')
-      })
-    })
-
-    describe('when the batch type is "two_part_supplementary"', () => {
-      beforeEach(() => {
-        batchType = 'two_part_supplementary'
-      })
-
-      it('returns "Two-part tariff supplementary"', () => {
-        const result = BasePresenter.formatBillRunType(batchType, scheme, summer)
-
-        expect(result).to.equal('Two-part tariff supplementary')
-      })
-    })
-
-    describe('when the batch type is "two_part_tariff"', () => {
-      beforeEach(() => {
-        batchType = 'two_part_tariff'
-      })
-
-      describe('and the scheme is "sroc"', () => {
-        beforeEach(() => {
-          scheme = 'sroc'
-        })
-
-        it('returns "Two-part tariff"', () => {
-          const result = BasePresenter.formatBillRunType(batchType, scheme, summer)
-
-          expect(result).to.equal('Two-part tariff')
-        })
-      })
-
-      describe('and the scheme is "alcs"', () => {
-        beforeEach(() => {
-          scheme = 'alcs'
-        })
-
-        describe('and it is not summer only', () => {
-          beforeEach(() => {
-            summer = false
-          })
-
-          it('returns "Two-part tariff winter and all year"', () => {
-            const result = BasePresenter.formatBillRunType(batchType, scheme, summer)
-
-            expect(result).to.equal('Two-part tariff winter and all year')
-          })
-        })
-
-        describe('and it is for summer only', () => {
-          beforeEach(() => {
-            summer = true
-          })
-
-          it('returns "Two-part tariff summer"', () => {
-            const result = BasePresenter.formatBillRunType(batchType, scheme, summer)
-
-            expect(result).to.equal('Two-part tariff summer')
-          })
-        })
-      })
-    })
-  })
-
   describe('#formatChargingModuleDate()', () => {
     it('correctly formats the given date, for example, 12-SEP-2021', async () => {
       // We check an array of dates, one for each month, to ensure that every month is formatted correctly
@@ -268,34 +165,6 @@ describe('Base presenter', () => {
         '12-NOV-2021',
         '12-DEC-2021'
       ])
-    })
-  })
-
-  describe('#formatChargeScheme()', () => {
-    let scheme
-
-    describe('when the scheme is "sroc"', () => {
-      beforeEach(() => {
-        scheme = 'sroc'
-      })
-
-      it('returns "Current"', () => {
-        const result = BasePresenter.formatChargeScheme(scheme)
-
-        expect(result).to.equal('Current')
-      })
-    })
-
-    describe('when the scheme is "alcs"', () => {
-      beforeEach(() => {
-        scheme = 'alcs'
-      })
-
-      it('returns "Old"', () => {
-        const result = BasePresenter.formatChargeScheme(scheme)
-
-        expect(result).to.equal('Old')
-      })
     })
   })
 

--- a/test/presenters/bill-licences/view-bill-licence.presenter.test.js
+++ b/test/presenters/bill-licences/view-bill-licence.presenter.test.js
@@ -32,28 +32,6 @@ describe('View Bill Licence presenter', () => {
       Sinon.stub(ViewStandardChargeTransactionPresenter, 'go').returns({ chargeType: 'standard' })
     })
 
-    describe('the "displayCreditDebitTotals" property', () => {
-      describe('when the linked bill run is not supplementary', () => {
-        beforeEach(() => {
-          billLicence.bill.billRun.batchType = 'annual'
-        })
-
-        it('returns false', () => {
-          const result = ViewBillLicencePresenter.go(billLicence)
-
-          expect(result.displayCreditDebitTotals).to.be.false()
-        })
-      })
-
-      describe('when the bill run is supplementary', () => {
-        it('returns true', () => {
-          const result = ViewBillLicencePresenter.go(billLicence)
-
-          expect(result.displayCreditDebitTotals).to.be.true()
-        })
-      })
-    })
-
     describe('the "removeLicenceLink" property', () => {
       describe('when the linked bill run has a status of "ready"', () => {
         beforeEach(() => {

--- a/test/presenters/bill-runs/view-bill-run.presenter.test.js
+++ b/test/presenters/bill-runs/view-bill-run.presenter.test.js
@@ -178,28 +178,6 @@ describe('View Bill Run presenter', () => {
         })
       })
     })
-
-    describe('the "displayCreditDebitTotals" property', () => {
-      describe('when the bill run is not supplementary', () => {
-        beforeEach(() => {
-          billRun.batchType = 'annual'
-        })
-
-        it('returns false', () => {
-          const result = ViewBillRunPresenter.go(billRun, billSummaries)
-
-          expect(result.displayCreditDebitTotals).to.be.false()
-        })
-      })
-
-      describe('when the bill run is supplementary', () => {
-        it('returns true', () => {
-          const result = ViewBillRunPresenter.go(billRun, billSummaries)
-
-          expect(result.displayCreditDebitTotals).to.be.true()
-        })
-      })
-    })
   })
 })
 

--- a/test/presenters/billing.presenter.test.js
+++ b/test/presenters/billing.presenter.test.js
@@ -1,0 +1,144 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Thing under test
+const BillingPresenter = require('../../app/presenters/billing.presenter.js')
+
+describe('Billing presenter', () => {
+  describe('#formatBillRunType()', () => {
+    let batchType
+    let scheme
+    let summer
+
+    describe('when the batch type is "annual"', () => {
+      beforeEach(() => {
+        batchType = 'annual'
+      })
+
+      it('returns "Annual"', () => {
+        const result = BillingPresenter.formatBillRunType(batchType, scheme, summer)
+
+        expect(result).to.equal('Annual')
+      })
+    })
+
+    describe('when the batch type is "supplementary"', () => {
+      beforeEach(() => {
+        batchType = 'supplementary'
+      })
+
+      it('returns "Supplementary"', () => {
+        const result = BillingPresenter.formatBillRunType(batchType, scheme, summer)
+
+        expect(result).to.equal('Supplementary')
+      })
+    })
+
+    describe('when the batch type is "two_part_supplementary"', () => {
+      beforeEach(() => {
+        batchType = 'two_part_supplementary'
+      })
+
+      it('returns "Two-part tariff supplementary"', () => {
+        const result = BillingPresenter.formatBillRunType(batchType, scheme, summer)
+
+        expect(result).to.equal('Two-part tariff supplementary')
+      })
+    })
+
+    describe('when the batch type is "two_part_tariff"', () => {
+      beforeEach(() => {
+        batchType = 'two_part_tariff'
+      })
+
+      describe('and the scheme is "sroc"', () => {
+        beforeEach(() => {
+          scheme = 'sroc'
+        })
+
+        it('returns "Two-part tariff"', () => {
+          const result = BillingPresenter.formatBillRunType(batchType, scheme, summer)
+
+          expect(result).to.equal('Two-part tariff')
+        })
+      })
+
+      describe('and the scheme is "alcs"', () => {
+        beforeEach(() => {
+          scheme = 'alcs'
+        })
+
+        describe('and it is not summer only', () => {
+          beforeEach(() => {
+            summer = false
+          })
+
+          it('returns "Two-part tariff winter and all year"', () => {
+            const result = BillingPresenter.formatBillRunType(batchType, scheme, summer)
+
+            expect(result).to.equal('Two-part tariff winter and all year')
+          })
+        })
+
+        describe('and it is for summer only', () => {
+          beforeEach(() => {
+            summer = true
+          })
+
+          it('returns "Two-part tariff summer"', () => {
+            const result = BillingPresenter.formatBillRunType(batchType, scheme, summer)
+
+            expect(result).to.equal('Two-part tariff summer')
+          })
+        })
+      })
+    })
+  })
+
+  describe('#formatChargeScheme()', () => {
+    let scheme
+
+    describe('when the scheme is "sroc"', () => {
+      beforeEach(() => {
+        scheme = 'sroc'
+      })
+
+      it('returns "Current"', () => {
+        const result = BillingPresenter.formatChargeScheme(scheme)
+
+        expect(result).to.equal('Current')
+      })
+    })
+
+    describe('when the scheme is "alcs"', () => {
+      beforeEach(() => {
+        scheme = 'alcs'
+      })
+
+      it('returns "Old"', () => {
+        const result = BillingPresenter.formatChargeScheme(scheme)
+
+        expect(result).to.equal('Old')
+      })
+    })
+  })
+
+  describe('#generateBillRunTitle()', () => {
+    const regionName = 'anglian'
+    const batchType = 'two_part_tariff'
+    const scheme = 'sroc'
+    const summer = false
+
+    it('generates the page title for the bill run, for example, "Anglian two-part tariff"', () => {
+      const result = BillingPresenter.generateBillRunTitle(regionName, batchType, scheme, summer)
+
+      expect(result).to.equal('Anglian two-part tariff')
+    })
+  })
+})

--- a/test/presenters/billing.presenter.test.js
+++ b/test/presenters/billing.presenter.test.js
@@ -129,6 +129,58 @@ describe('Billing presenter', () => {
     })
   })
 
+  describe('#displayCreditDebitTotals()', () => {
+    let batchType
+
+    describe('when the batch type is "annual"', () => {
+      beforeEach(() => {
+        batchType = 'annual'
+      })
+
+      it('returns "false"', () => {
+        const result = BillingPresenter.displayCreditDebitTotals(batchType)
+
+        expect(result).to.be.false()
+      })
+    })
+
+    describe('when the batch type is "supplementary"', () => {
+      beforeEach(() => {
+        batchType = 'supplementary'
+      })
+
+      it('returns "true"', () => {
+        const result = BillingPresenter.displayCreditDebitTotals(batchType)
+
+        expect(result).to.be.true()
+      })
+    })
+
+    describe('when the batch type is "two_part_supplementary"', () => {
+      beforeEach(() => {
+        batchType = 'two_part_supplementary'
+      })
+
+      it('returns "true"', () => {
+        const result = BillingPresenter.displayCreditDebitTotals(batchType)
+
+        expect(result).to.be.true()
+      })
+    })
+
+    describe('when the batch type is "two_part_tariff"', () => {
+      beforeEach(() => {
+        batchType = 'two_part_tariff'
+      })
+
+      it('returns "false"', () => {
+        const result = BillingPresenter.displayCreditDebitTotals(batchType)
+
+        expect(result).to.be.false()
+      })
+    })
+  })
+
   describe('#generateBillRunTitle()', () => {
     const regionName = 'anglian'
     const batchType = 'two_part_tariff'

--- a/test/presenters/bills/view-bill.presenter.test.js
+++ b/test/presenters/bills/view-bill.presenter.test.js
@@ -171,28 +171,6 @@ describe('View Bill presenter', () => {
         })
       })
     })
-
-    describe('the "displayCreditDebitTotals" property', () => {
-      describe('when the bill run is not supplementary', () => {
-        it('returns false', () => {
-          const result = ViewBillPresenter.go(bill, billingAccount)
-
-          expect(result.displayCreditDebitTotals).to.be.false()
-        })
-      })
-
-      describe('when the bill run is supplementary', () => {
-        beforeEach(() => {
-          bill.billRun.batchType = 'supplementary'
-        })
-
-        it('returns true', () => {
-          const result = ViewBillPresenter.go(bill, billingAccount)
-
-          expect(result.displayCreditDebitTotals).to.be.true()
-        })
-      })
-    })
   })
 })
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4201

> Part of the work to support two-part tariff supplementary bill runs

Spotted whilst adding support for `two_part_supplementary` bill runs. Our view bill page only displays credit and debit totals if the bill run type is 'supplementary'. With us adding two-part tariff supplementary bill runs, we also need it to display them for this bill type.

Because a couple of presenters need this, and we've managed to reduce inconsistencies by ensuring our presenters are using the billing helpers we've created, this change moves the logic to a helper.

But rather than add it to our `BasePresenter`, which is getting a little overloaded, we instead create a new `BillingPresenter`, and move our existing 'billing' helpers to it.

_Then_ we add the helper to this new presenter!

Finaly, we ensure the helper says 'yes' to displaying credits for two-part tariff supplementary! 😁