### PR TITLE
Update notifications setup

### DIFF
--- a/app/presenters/notifications/setup/create-event.presenter.js
+++ b/app/presenters/notifications/setup/create-event.presenter.js
@@ -5,17 +5,19 @@
  * @module CreateEventPresenter
  */
 
+const { formatDateObjectToISO } = require('../../../lib/dates.lib.js')
 const { transformStringOfLicencesToArray } = require('../../../lib/general.lib.js')
 
 /**
  * Formats a notification `SessionModel` instance into the data needed for a 'EventModel' record
  *
  * @param {SessionModel} session
+ * @param {object[]} recipients
  *
  * @returns {object} - The data formatted for the view template
  */
-function go(session) {
-  const { referenceCode, recipients, determinedReturnsPeriod, journey, removeLicences = [] } = session
+function go(session, recipients) {
+  const { referenceCode, determinedReturnsPeriod, journey, removeLicences = [] } = session
 
   return {
     licences: _licences(recipients),
@@ -38,12 +40,16 @@ function go(session) {
  * `water.events.licences`. It is not clear where theses are used. But to be consistent we follow the established
  * pattern.
  *
+ * These licences are stored as 'jsonb' so we need to stringify the array to match the schema.
+ *
  * @private
  */
 function _licences(recipients) {
-  return recipients.flatMap((recipient) => {
+  const formattedRecipients = recipients.flatMap((recipient) => {
     return transformStringOfLicencesToArray(recipient.licence_refs)
   })
+
+  return JSON.stringify(formattedRecipients)
 }
 
 /**
@@ -67,10 +73,10 @@ function _name(journey) {
 
 function _returnCycle(returnsPeriod) {
   return {
-    dueDate: returnsPeriod.dueDate,
-    endDate: returnsPeriod.endDate,
-    isSummer: returnsPeriod.summer,
-    startDate: returnsPeriod.startDate
+    dueDate: formatDateObjectToISO(new Date(returnsPeriod.dueDate)),
+    endDate: formatDateObjectToISO(new Date(returnsPeriod.endDate)),
+    isSummer: returnsPeriod.summer === 'true',
+    startDate: formatDateObjectToISO(new Date(returnsPeriod.startDate))
   }
 }
 

--- a/app/services/notifications/setup/create-event.service.js
+++ b/app/services/notifications/setup/create-event.service.js
@@ -6,6 +6,7 @@
  */
 
 const EventModel = require('../../../../app/models/event.model.js')
+const { timestampForPostgres } = require('../../../lib/general.lib.js')
 
 /**
  * Create a 'returnInvitation' or 'returnReminder' notification event
@@ -42,6 +43,8 @@ async function go(event) {
 async function _createEvent(event) {
   return EventModel.query().insert({
     type: 'notification',
+    createdAt: timestampForPostgres(),
+    updatedAt: timestampForPostgres(),
     ...event
   })
 }

--- a/test/services/notifications/setup/create-event.service.tests.js
+++ b/test/services/notifications/setup/create-event.service.tests.js
@@ -23,11 +23,13 @@ describe('Notifications Setup - Create event service', () => {
   it('should create the event (required values)', async () => {
     const result = await CreateEventService.go(event)
 
-    const res = await EventModel.query().findById(result.id)
+    const createdResult = await EventModel.query().findById(result.id)
 
     expect(result).equal({
-      id: res.id,
-      type: 'notification'
+      createdAt: result.createdAt,
+      id: createdResult.id,
+      type: 'notification',
+      updatedAt: result.updatedAt
     })
   })
 
@@ -54,12 +56,12 @@ describe('Notifications Setup - Create event service', () => {
     it('should create the event', async () => {
       const result = await CreateEventService.go(event)
 
-      const res = await EventModel.query().findById(result.id)
+      const createdResult = await EventModel.query().findById(result.id)
 
-      expect(res).equal({
-        createdAt: null,
+      expect(createdResult).equal({
+        createdAt: createdResult.createdAt,
         entities: null,
-        id: res.id,
+        id: createdResult.id,
         issuer: null,
         licences: ['123', '456'],
         metadata: {
@@ -81,7 +83,7 @@ describe('Notifications Setup - Create event service', () => {
         status: 'started',
         subtype: 'returnInvitation',
         type: 'notification',
-        updatedAt: null
+        updatedAt: createdResult.updatedAt
       })
     })
   })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4778

Work has been done previously to implement the service and presenters. This was done to keep changes and code reviews concise.

A result of this has been some wrong assumptions i.e an array of licences stored as a jsonb filed needed to be converted to a json string prior to saving in the database.

This change starts stitching the service together to create an event and start the notification process (just the presenter, the other services will be developed later).

This change also rectifies some initial assumptions and makes sure our saved data matches the legacy schema.