### PR TITLE
Handle TPT licence flags during supp process - pt1

### DIFF
--- a/app/services/bill-licences/submit-remove-bill-licence.service.js
+++ b/app/services/bill-licences/submit-remove-bill-licence.service.js
@@ -8,12 +8,18 @@
 const BillLicenceModel = require('../../models/bill-licence.model.js')
 const LegacyDeleteBillLicenceRequest = require('../../requests/legacy/delete-bill-licence.request.js')
 const ProcessBillingFlagService = require('../licences/supplementary/process-billing-flag.service.js')
+const UnassignLicencesToBillRunService = require('../bill-runs/unassign-licences-to-bill-run.service.js')
 
 /**
  * Orchestrates the removing of a bill licence from a bill run
  *
- * This involves checking if the licence needs to be flagged for supplementary billing by calling the
- * `ProcessBillingFlagService` and then to handle deleting the bill licence itself calling the legacy service
+ * After fetching the bill licence and associated bill, it calls `UnassignBillRunToLicencesService` which will unassign
+ * this bill run from the licences with matching `licence_supplementary_year` records in the bill licence.
+ *
+ * But the licence might not have been flagged, for example, this is not a supplementary bill run. SO, next it checks if
+ * the licence needs to be flagged for supplementary billing by calling the `ProcessBillingFlagService`.
+ *
+ * Finally, it calls the legacy service to handle deleting the bill licence itself.
  *
  * @param {string} billLicenceId - UUID of the bill licence to be removed
  * @param {object} user - Instance of `UserModel` that represents the user making the request
@@ -21,13 +27,12 @@ const ProcessBillingFlagService = require('../licences/supplementary/process-bil
  * @returns {Promise<string>} Returns the redirect path the controller needs
  */
 async function go(billLicenceId, user) {
-  const { bill } = await _fetchBillLicence(billLicenceId)
+  const billLicence = await _fetchBillLicence(billLicenceId)
 
-  const payload = {
-    billLicenceId
-  }
+  const { bill, licenceId } = billLicence
 
-  await ProcessBillingFlagService.go(payload)
+  await UnassignLicencesToBillRunService.go([licenceId], bill.billRunId)
+  await ProcessBillingFlagService.go({ billLicenceId })
   await LegacyDeleteBillLicenceRequest.send(billLicenceId, user)
 
   return `/billing/batch/${bill.billRunId}/processing?invoiceId=${bill.id}`
@@ -36,7 +41,7 @@ async function go(billLicenceId, user) {
 async function _fetchBillLicence(billLicenceId) {
   return BillLicenceModel.query()
     .findById(billLicenceId)
-    .select(['id'])
+    .select(['id', 'licenceId'])
     .withGraphFetched('bill')
     .modifyGraph('bill', (builder) => {
       builder.select(['id', 'billRunId'])

--- a/app/services/bill-runs/assign-bill-run-to-licences.service.js
+++ b/app/services/bill-runs/assign-bill-run-to-licences.service.js
@@ -1,0 +1,56 @@
+'use strict'
+
+/**
+ * Assigns a bill run to licences in the bill run with matching `LicenceSupplementaryYear` records
+ * @module AssignBillRunToLicences
+ */
+
+const { timestampForPostgres } = require('../../lib/general.lib.js')
+const LicenceSupplementaryYearModel = require('../../models/licence-supplementary-year.model.js')
+
+/**
+ * Assigns a bill run to licences in the bill run with matching `LicenceSupplementaryYear` records
+ *
+ * When a licence is changed, either directly because an 'end date' has changed, or indirectly via charge version,
+ * return version, or return log changes it is flagged for supplementary billing.
+ *
+ * For two-part tariff licences, this means an entry is added to `water.licence_supplementary_years`. Should it change
+ * again, we don't add another entry as it is _already_ flagged for supplementary billing.
+ *
+ * That is unless the licence is part of a two-part tariff supplementary bill run in progress. The state of the licence
+ * at the time the bill run was triggered will have determined how, for example, returns were matched and allocated.
+ *
+ * To be sure nothing is missed, we want the service to process the licence for supplementary billing again, if a change
+ * is made after a supplementary bill run is started.
+ *
+ * So, how do we make this happen? Each `licence_supplementary_year` record has a `bill_run_id` field. When we trigger
+ * a supplementary bill run we use this service to assign the bill run ID to each record.
+ *
+ * Then, if a licence changes again a new licence supplementary year record will be created, because the systems that
+ * manage this know to ignore those records with bill run IDs.
+ *
+ * If a licence is removed from a bill run, or the bill run is cancelled we'll remove the bill run ID. Else, when the
+ * bill run is 'sent' the licence supplementary year records for that bill run will get deleted, as those licences will
+ * be considered 'processed' for supplementary billing.
+ *
+ * @param {string} billRunId - The UUID of the bill run to assign the licences to
+ * @param {object[]} licences - An array of licence objects, each containing an 'id' property
+ * @param {object} billingPeriod - An object representing the financial year the bills will be for
+ * @param {boolean} twoPartTariff - Whether we are assigning two-part tariff supplementary years to the bill run
+ */
+async function go(billRunId, licences, billingPeriod, twoPartTariff) {
+  const financialYearEnd = billingPeriod.endDate.getFullYear()
+  const licenceIds = licences.map((licence) => {
+    return licence.id
+  })
+
+  await LicenceSupplementaryYearModel.query()
+    .patch({ billRunId, updatedAt: timestampForPostgres() })
+    .where('financialYearEnd', financialYearEnd)
+    .where('twoPartTariff', twoPartTariff)
+    .whereIn('licenceId', licenceIds)
+}
+
+module.exports = {
+  go
+}

--- a/app/services/bill-runs/cancel/submit-cancel-bill-run.service.js
+++ b/app/services/bill-runs/cancel/submit-cancel-bill-run.service.js
@@ -7,6 +7,7 @@
 
 const CancelBillBunService = require('./cancel-bill-run.service.js')
 const DeleteBillRunService = require('./delete-bill-run.service.js')
+const UnassignBillRunToLicencesService = require('../unassign-bill-run-to-licences.service.js')
 
 /**
  * Orchestrates the cancelling of a bill run
@@ -16,7 +17,10 @@ const DeleteBillRunService = require('./delete-bill-run.service.js')
  *
  * It returns the fetched instance of the bill run, with the status set to 'cancel' if the bill run was cancelled.
  *
- * It then calls `DeleteBillRunService` which will delete the bill run and all its associated records. It will also
+ * It then calls `UnassignBillRunToLicencesService` which will unassign the bill run from any licences with matching
+ * `licence_supplementary_year` records.
+ *
+ * Finally, it calls `DeleteBillRunService` which will delete the bill run and all its associated records. It will also
  * send a delete request to the Charging Module API.
  *
  * We specifically do not await the `DeleteBillRunService` call here as we do not want to block the request. This
@@ -28,6 +32,7 @@ async function go(billRunId) {
   const billRun = await CancelBillBunService.go(billRunId)
 
   if (billRun.status === 'cancel') {
+    await UnassignBillRunToLicencesService.go(billRun.id)
     DeleteBillRunService.go(billRun)
   }
 }

--- a/app/services/bill-runs/match/match-and-allocate.service.js
+++ b/app/services/bill-runs/match/match-and-allocate.service.js
@@ -26,7 +26,7 @@ const PrepareReturnLogsService = require('./prepare-return-logs.service.js')
  * @param {module:BillRunModel} billRun - The bill run object containing billing information
  * @param {object} billingPeriod - A single billing period containing a `startDate` and `endDate`
  *
- * @returns {Promise<boolean>} - True if there are any licences matched to returns, false otherwise
+ * @returns {Promise<object[]>} - the licences found for matching and allocating
  */
 async function go(billRun, billingPeriod) {
   const supplementary = billRun.batchType === 'two_part_supplementary'
@@ -36,7 +36,7 @@ async function go(billRun, billingPeriod) {
     await _process(licences, billingPeriod, billRun)
   }
 
-  return licences.length > 0
+  return licences
 }
 
 async function _process(licences, billingPeriod, billRun) {

--- a/app/services/bill-runs/review/fetch-remove-review-licence.service.js
+++ b/app/services/bill-runs/review/fetch-remove-review-licence.service.js
@@ -26,7 +26,7 @@ async function _fetch(reviewLicenceId) {
     .withGraphFetched('billRun')
     .modifyGraph('billRun', (billRunBuilder) => {
       billRunBuilder
-        .select(['id', 'billRunNumber', 'createdAt', 'status', 'toFinancialYearEnding'])
+        .select(['id', 'batchType', 'billRunNumber', 'createdAt', 'status', 'toFinancialYearEnding'])
         .withGraphFetched('region')
         .modifyGraph('region', (regionBuilder) => {
           regionBuilder.select(['id', 'displayName'])

--- a/app/services/bill-runs/tpt-supplementary/process-bill-run.service.js
+++ b/app/services/bill-runs/tpt-supplementary/process-bill-run.service.js
@@ -5,6 +5,7 @@
  * @module ProcessBillRunService
  */
 
+const AssignBillRunToLicencesService = require('../assign-bill-run-to-licences.service.js')
 const BillRunModel = require('../../../models/bill-run.model.js')
 const { calculateAndLogTimeTaken, currentTimeInNanoseconds } = require('../../../lib/general.lib.js')
 const HandleErroredBillRunService = require('../handle-errored-bill-run.service.js')
@@ -38,7 +39,11 @@ async function go(billRun, billingPeriods) {
     await _updateStatus(billRunId, 'processing')
 
     // `populated` will be set to true if `MatchAndAllocateService` processes at least one licence
-    const populated = await MatchAndAllocateService.go(billRun, billingPeriod)
+    const licences = await MatchAndAllocateService.go(billRun, billingPeriod)
+
+    await AssignBillRunToLicencesService.go(billRunId, licences, billingPeriod, true)
+
+    const populated = licences.length > 0
 
     await _setBillRunStatus(billRunId, populated)
 

--- a/app/services/bill-runs/two-part-tariff/process-billing-period.service.js
+++ b/app/services/bill-runs/two-part-tariff/process-billing-period.service.js
@@ -35,7 +35,7 @@ async function go(billRun, billingPeriod, billingAccounts) {
   }
 
   // We set the batch size and number of billing accounts here rather than determine them for every iteration of the
-  // loop. It's a very minor node towards performance.
+  // loop. It's a very minor nod towards performance.
   const batchSize = BillingConfig.annual.batchSize
   const billingAccountsCount = billingAccounts.length
 

--- a/app/services/bill-runs/unassign-bill-run-to-licences.service.js
+++ b/app/services/bill-runs/unassign-bill-run-to-licences.service.js
@@ -1,0 +1,27 @@
+'use strict'
+
+/**
+ * Unassigns a bill run from licences with matching `LicenceSupplementaryYear` records
+ * @module UnassignBillRunToLicencesService
+ */
+
+const { timestampForPostgres } = require('../../lib/general.lib.js')
+const LicenceSupplementaryYearModel = require('../../models/licence-supplementary-year.model.js')
+
+/**
+ * Unassigns a bill run from licences with matching `LicenceSupplementaryYear` records
+ *
+ * This function removes the association between a bill run and licences by setting the `bill_run_id` to null for all
+ * `LicenceSupplementaryYear` records that have the specified `billRunId`.
+ *
+ * @param {string} billRunId - The UUID of the bill run to be unassigned from the licences
+ */
+async function go(billRunId) {
+  await LicenceSupplementaryYearModel.query()
+    .patch({ billRunId: null, updatedAt: timestampForPostgres() })
+    .where('billRunId', billRunId)
+}
+
+module.exports = {
+  go
+}

--- a/app/services/bill-runs/unassign-licences-to-bill-run.service.js
+++ b/app/services/bill-runs/unassign-licences-to-bill-run.service.js
@@ -1,0 +1,29 @@
+'use strict'
+
+/**
+ * Unassigns licences from a supplementary bill run
+ * @module UnassignLicencesToBillRunService
+ */
+
+const { timestampForPostgres } = require('../../lib/general.lib.js')
+const LicenceSupplementaryYearModel = require('../../models/licence-supplementary-year.model.js')
+
+/**
+ * Unassigns licences from a supplementary bill run
+ *
+ * Sets the `billRunId` field to null for the `LicenceSupplementaryYear` records that match the provided licence IDs
+ * and bill run ID.
+ *
+ * @param {string[]} licenceIds - The UUIDs of the licences to be unassigned from a bill run
+ * @param {string} billRunId - The UUID of the bill run to be unassigned from the licences
+ */
+async function go(licenceIds, billRunId) {
+  await LicenceSupplementaryYearModel.query()
+    .patch({ billRunId: null, updatedAt: timestampForPostgres() })
+    .whereIn('licenceId', licenceIds)
+    .where('billRunId', billRunId)
+}
+
+module.exports = {
+  go
+}

--- a/app/services/bill-runs/unflag-unbilled-supplementary-licences.service.js
+++ b/app/services/bill-runs/unflag-unbilled-supplementary-licences.service.js
@@ -2,55 +2,97 @@
 
 /**
  * Unflag all licences in a bill run that did not result in a billing invoice (they are unbilled)
- * @module UnflagUnbilledLicencesService
+ * @module UnflagUnbilledSupplementaryLicencesService
  */
 
+const BillLicenceModel = require('../../models/bill-licence.model.js')
 const LicenceModel = require('../../models/licence.model.js')
+const LicenceSupplementaryYearModel = require('../../models/licence-supplementary-year.model.js')
+const WorkflowModel = require('../../models/workflow.model.js')
 
 /**
- * Unflag any licences that were not billed as part of a bill run
+ * Unflag all licences in a bill run that did not result in a billing invoice (they are unbilled)
  *
  * Some licences will not result in an invoice (`billing_invoice_licence`) being created. For example, you could add a
  * new charge version that does nothing but change the description of the previous one. In isolation, this would result
  * in an `EMPTY` bill run. If others are being processed at the same time, it would just mean no records are added to
  * the bill run for this licence.
  *
- * If this is the case, we can remove the 'Include in SROC Supplementary Billing' flag from the licence now. Even if the
- * bill run gets cancelled and re-run later the result will be the same.
+ * If this is the case, we can remove the 'Supplementary Billing' flag from the licence now. Even if the bill run gets
+ * cancelled and re-run later the result would be the same.
  *
- * What it also means is we can be accurate with which licences get unflagged when the bill run is finally **SENT**. The
- * PRESROC process doesn't restrict to licences in the bill run. This is because they don't deal with licences that were
- * processed but resulted in no bill in their engine. So, they are forced to consider all flagged licences when the bill
- * run gets 'sent'.
+ * What it also means is unlike the legacy service, we can be accurate with which licences get unflagged when the bill
+ * run is finally **SENT**. The legacy PRESROC process doesn't unflag just licences in the bill run. This is because
+ * they don't deal with licences that were processed but resulted in no bill in their billing engine. So, they are
+ * forced to consider all flagged licences when the bill run gets 'sent'.
  *
- * There are two scenarios of when _not_ to unflag an unbilled licence
+ * A licence is flagged for _standard_ supplementary by a tick on the licence record itself. It is flagged for two-part
+ * tariff with an entry in `licence_supplementary_years`. Hence, when we 'unflag', we have to do it in two different
+ * ways.
  *
- * - if the licence is in workflow
- * - if the licence was updated after the bill run was created
+ * For either type of flag, we don't 'unflag' if the licence is in workflow. This is because when a licence is gets
+ * 'moved to workflow' (has a workflow record with no deleted date), it doesn't automatically get a supplementary flag
+ * applied. But its there because the team are doing something with the licence, so billing needs to be suspended.
  *
- * Unlike `UnflagBilledLicencesService` the chances of these events happening between bill run creation and this service
- * running are slim. But we feel it prudent to still check plus it keeps the services consistent.
+ * We also don't remove the _standard_ supplementary flag if the licence record is updated _after_ the bill run is
+ * created. This tells us _something_ has changed on the licence since the bill run was created. So, just in case, we
+ * want the licence to be processed again in the next supplementary bill run.
+ *
+ * > The use of `licence_supplementary_years` was brought in when we added support for flagging for 2PT SROC
+ * > supplementary. It means we don't have to worry about comparing the dates. It also means we can be more accurate
+ * > about when changes apply from. We hope to move standard SROC supplementary to it in the future.
  *
  * @param {module:BillRunModel} billRun - Instance of the bill run being processed
- * @param {string[]} allLicenceIds - All licence UUIDs being processed in the bill run
- *
- * @returns {Promise<number>} Resolves to the count of records updated
+ * @param {string[]} [allLicenceIds=[]] - If a standard supplementary all licence UUIDs being processed in the bill run
  */
-async function go(billRun, allLicenceIds) {
+async function go(billRun, allLicenceIds = []) {
+  if (billRun.batchType === 'two_part_supplementary') {
+    await _unflagTwoPartTariff(billRun)
+
+    return
+  }
+
+  await _unflagStandard(billRun, allLicenceIds)
+}
+
+async function _unflagStandard(billRun, allLicenceIds) {
   const { id: billRunId, createdAt } = billRun
 
-  const result = await LicenceModel.query()
+  await LicenceModel.query()
     .patch({ includeInSrocBilling: false })
     .where('updatedAt', '<=', createdAt)
-    .whereNotExists(LicenceModel.relatedQuery('workflows').whereNull('workflows.deletedAt'))
     .whereNotExists(
-      LicenceModel.relatedQuery('billLicences')
-        .join('bills', 'bills.id', '=', 'billLicences.billId')
+      WorkflowModel.query().select(1).whereColumn('licences.id', 'workflows.licenceId').whereNull('workflows.deletedAt')
+    )
+    .whereNotExists(
+      BillLicenceModel.query()
+        .select(1)
+        .innerJoin('bills', 'bills.id', '=', 'billLicences.billId')
+        .whereColumn('licences.id', 'billLicences.licenceId')
         .where('bills.billRunId', '=', billRunId)
     )
     .whereIn('id', allLicenceIds)
+}
 
-  return result
+async function _unflagTwoPartTariff(billRun) {
+  const { id: billRunId } = billRun
+
+  await LicenceSupplementaryYearModel.query()
+    .delete()
+    .where('billRunId', billRunId)
+    .whereNotExists(
+      WorkflowModel.query()
+        .select(1)
+        .whereColumn('licenceSupplementaryYears.licenceId', 'workflows.licenceId')
+        .whereNull('workflows.deletedAt')
+    )
+    .whereNotExists(
+      BillLicenceModel.query()
+        .select(1)
+        .innerJoin('bills', 'bills.id', '=', 'billLicences.billId')
+        .whereColumn('licenceSupplementaryYears.licenceId', 'billLicences.licenceId')
+        .where('bills.billRunId', '=', billRunId)
+    )
 }
 
 module.exports = {

--- a/app/services/bills/submit-remove-bill.service.js
+++ b/app/services/bills/submit-remove-bill.service.js
@@ -6,10 +6,10 @@
  */
 
 const BillModel = require('../../models/bill.model.js')
-const BillLicenceModel = require('../../models/bill-licence.model.js')
 
 const LegacyDeleteBillRequest = require('../../requests/legacy/delete-bill.request.js')
 const ProcessBillingFlagService = require('../licences/supplementary/process-billing-flag.service.js')
+const UnassignLicencesToBillRunService = require('../bill-runs/unassign-licences-to-bill-run.service.js')
 
 /**
  * Orchestrates the removing of a bill from a bill run
@@ -24,32 +24,39 @@ const ProcessBillingFlagService = require('../licences/supplementary/process-bil
  * @returns {Promise<string>} Returns the redirect path the controller needs
  */
 async function go(billId, user) {
-  const { billRunId } = await _fetchBill(billId)
+  const bill = await _fetchBill(billId)
 
-  await _flagRemovedBill(billId)
+  const { billLicences, billRunId } = bill
+
+  await _unassignLicencesToBillRun(billRunId, billLicences)
+  await _flagRemovedBill(billLicences)
   await LegacyDeleteBillRequest.send(billRunId, billId, user)
 
   return `/billing/batch/${billRunId}/processing`
 }
 
 async function _fetchBill(billId) {
-  return BillModel.query().findById(billId).select(['id', 'billRunId'])
+  return BillModel.query()
+    .findById(billId)
+    .select(['id', 'billRunId'])
+    .withGraphFetched('billLicences')
+    .modifyGraph('billLicences', (billLicencesBuilder) => {
+      billLicencesBuilder.select(['id', 'licenceId'])
+    })
 }
 
-async function _fetchBillLicences(billId) {
-  return BillLicenceModel.query().where('billId', billId).select('id')
-}
-
-async function _flagRemovedBill(billId) {
-  const billLicences = await _fetchBillLicences(billId)
-
+async function _flagRemovedBill(billLicences) {
   for (const billLicence of billLicences) {
-    const payload = {
-      billLicenceId: billLicence.id
-    }
-
-    await ProcessBillingFlagService.go(payload)
+    await ProcessBillingFlagService.go({ billLicenceId: billLicence.id })
   }
+}
+
+async function _unassignLicencesToBillRun(billRunId, billLicences) {
+  const licenceIds = billLicences.map((billLicence) => {
+    return billLicence.licenceId
+  })
+
+  await UnassignLicencesToBillRunService.go(licenceIds, billRunId)
 }
 
 module.exports = {

--- a/app/services/licences/supplementary/create-licence-supplementary-year.service.js
+++ b/app/services/licences/supplementary/create-licence-supplementary-year.service.js
@@ -39,7 +39,7 @@ async function _fetchExistingLicenceSupplementaryYears(licenceId, financialYearE
 }
 
 async function _persistSupplementaryBillingYearsData(licenceId, financialYearEnd, twoPartTariff) {
-  return LicenceSupplementaryYearModel.query().insert({
+  await LicenceSupplementaryYearModel.query().insert({
     licenceId,
     financialYearEnd,
     twoPartTariff

--- a/test/fixtures/bill-runs-review.fixture.js
+++ b/test/fixtures/bill-runs-review.fixture.js
@@ -14,6 +14,7 @@ function removeReviewLicence() {
     licenceRef: '1/11/11/*11/1111',
     billRun: {
       id: '287aeb25-cf11-429d-8c6f-f98f06db021d',
+      batchType: 'two_part_tariff',
       billRunNumber: 10001,
       createdAt: new Date('2024-10-22'),
       status: 'review',

--- a/test/services/bill-licences/submit-remove-bill-licence.service.test.js
+++ b/test/services/bill-licences/submit-remove-bill-licence.service.test.js
@@ -8,31 +8,45 @@ const Sinon = require('sinon')
 const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
-// Test helpers
-const BillHelper = require('../../support/helpers/bill.helper.js')
-const BillLicenceHelper = require('../../support/helpers/bill-licence.helper.js')
-
 // Things we need to stub
+const BillLicenceModel = require('../../../app/models/bill-licence.model.js')
 const LegacyDeleteBillLicenceRequest = require('../../../app/requests/legacy/delete-bill-licence.request.js')
 const ProcessBillingFlagService = require('../../../app/services/licences/supplementary/process-billing-flag.service.js')
+const UnassignLicencesToBillRunService = require('../../../app/services/bill-runs/unassign-licences-to-bill-run.service.js')
 
 // Thing under test
 const SubmitRemoveBillLicenceService = require('../../../app/services/bill-licences/submit-remove-bill-licence.service.js')
 
-describe('Submit Remove Bill Licence service', () => {
+describe('Bill Licences - Submit Remove Bill Licence service', () => {
   const user = { id: '0aa9dcaa-9a26-4a77-97ab-c17db54d38a1', useremail: 'carol.shaw@atari.com' }
 
-  let bill
   let billLicence
+  let billLicenceStub
   let legacyDeleteBillLicenceRequestStub
-  let ProcessBillingFlagServiceStub
+  let processBillingFlagStub
+  let unassignLicencesToBillRunStub
 
   beforeEach(async () => {
-    bill = await BillHelper.add()
-    billLicence = await BillLicenceHelper.add({ billId: bill.id })
+    billLicence = {
+      id: '59f2510d-4b2f-4b09-a972-e0b2370d191d',
+      licenceId: '5d358719-86b8-454e-a862-7a18a8a25103',
+      bill: {
+        id: '44c459a6-3610-4b84-b515-d4d8785ff87c',
+        billRunId: 'c96106fa-b9a3-4f91-b35d-ec1d3108c390'
+      }
+    }
+
+    billLicenceStub = Sinon.stub().resolves(billLicence)
+    Sinon.stub(BillLicenceModel, 'query').returns({
+      findById: Sinon.stub().returnsThis(),
+      select: Sinon.stub().returnsThis(),
+      withGraphFetched: Sinon.stub().returnsThis(),
+      modifyGraph: billLicenceStub
+    })
 
     legacyDeleteBillLicenceRequestStub = Sinon.stub(LegacyDeleteBillLicenceRequest, 'send').resolves()
-    ProcessBillingFlagServiceStub = Sinon.stub(ProcessBillingFlagService, 'go').resolves()
+    processBillingFlagStub = Sinon.stub(ProcessBillingFlagService, 'go').resolves()
+    unassignLicencesToBillRunStub = Sinon.stub(UnassignLicencesToBillRunService, 'go').resolves()
   })
 
   afterEach(() => {
@@ -40,10 +54,16 @@ describe('Submit Remove Bill Licence service', () => {
   })
 
   describe('when called', () => {
+    it('calls the "UnassignLicencesToBillRunService" to unassign any licence supplementary year records from the bill run', async () => {
+      await SubmitRemoveBillLicenceService.go(billLicence.id, user)
+
+      expect(unassignLicencesToBillRunStub.called).to.be.true()
+    })
+
     it('calls the "ProcessBillingFlagService" to check if the licence needs a supplementary billing flag', async () => {
       await SubmitRemoveBillLicenceService.go(billLicence.id, user)
 
-      expect(ProcessBillingFlagServiceStub.called).to.be.true()
+      expect(processBillingFlagStub.called).to.be.true()
     })
 
     it('sends a request to the legacy service to delete the bill licence', async () => {
@@ -55,7 +75,9 @@ describe('Submit Remove Bill Licence service', () => {
     it('returns the path to the legacy bill run processing page with invoice ID option', async () => {
       const result = await SubmitRemoveBillLicenceService.go(billLicence.id, user)
 
-      expect(result).to.equal(`/billing/batch/${bill.billRunId}/processing?invoiceId=${bill.id}`)
+      expect(result).to.equal(
+        `/billing/batch/${billLicence.bill.billRunId}/processing?invoiceId=${billLicence.bill.id}`
+      )
     })
   })
 })

--- a/test/services/bill-runs/assign-bill-run-to-licences.service.test.js
+++ b/test/services/bill-runs/assign-bill-run-to-licences.service.test.js
@@ -1,0 +1,67 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Things we need to stub
+const LicenceSupplementaryYearModel = require('../../../app/models/licence-supplementary-year.model.js')
+
+// Thing under test
+const AssignBillRunToLicencesService = require('../../../app/services/bill-runs/assign-bill-run-to-licences.service.js')
+
+describe('Bill Runs - Unassign Bill Run To Licence service', () => {
+  const billingPeriod = { startDate: new Date('2022-04-01'), endDate: new Date('2023-03-31') }
+  const billRunId = '091c3d3f-0328-4b10-b1a1-3eccf55416a0'
+  const licences = [{ id: '098e0fff-1c3e-4be3-83b9-8f483ae5b41e' }, { id: '406b8ba4-63b6-442a-86f3-a144f1f63ca9' }]
+  const twoPartTariff = true
+
+  let licenceSupplementaryYearPatch
+  let licenceSupplementaryYearWhereIn
+  let licenceSupplementaryYearWhere
+
+  beforeEach(() => {
+    licenceSupplementaryYearPatch = Sinon.stub().returnsThis()
+    licenceSupplementaryYearWhere = Sinon.stub().returnsThis()
+    licenceSupplementaryYearWhereIn = Sinon.stub()
+
+    Sinon.stub(LicenceSupplementaryYearModel, 'query').returns({
+      patch: licenceSupplementaryYearPatch,
+      where: licenceSupplementaryYearWhere,
+      whereIn: licenceSupplementaryYearWhereIn
+    })
+  })
+
+  afterEach(() => {
+    Sinon.restore()
+  })
+
+  describe('when called', () => {
+    it('assigns the bill run ID to the matching "LicenceSupplementaryYear" records', async () => {
+      await AssignBillRunToLicencesService.go(billRunId, licences, billingPeriod, twoPartTariff)
+
+      const patchArgs = licenceSupplementaryYearPatch.args[0][0]
+
+      expect(patchArgs.billRunId).to.equal(billRunId)
+
+      const financialYearWhereArgs = licenceSupplementaryYearWhere.firstCall.args
+
+      expect(financialYearWhereArgs).to.equal(['financialYearEnd', 2023])
+
+      const twoPartTariffWhereArgs = licenceSupplementaryYearWhere.secondCall.args
+
+      expect(twoPartTariffWhereArgs).to.equal(['twoPartTariff', true])
+
+      const whereInArgs = licenceSupplementaryYearWhereIn.args[0]
+
+      expect(whereInArgs).to.equal([
+        'licenceId',
+        ['098e0fff-1c3e-4be3-83b9-8f483ae5b41e', '406b8ba4-63b6-442a-86f3-a144f1f63ca9']
+      ])
+    })
+  })
+})

--- a/test/services/bill-runs/fetch-two-part-tariff-billing-accounts.service.test.js
+++ b/test/services/bill-runs/fetch-two-part-tariff-billing-accounts.service.test.js
@@ -41,7 +41,7 @@ describe('Bill Runs - Fetch Two Part Tariff Billing Accounts service', () => {
 
   before(async () => {
     region = RegionHelper.select()
-    billRun = await BillRunHelper.add({ regionId: region.id })
+    billRun = await BillRunHelper.add({ batchType: 'two_part_tariff', regionId: region.id })
 
     licence = await LicenceHelper.add({ regionId: region.id })
 

--- a/test/services/bill-runs/match/match-and-allocate.service.test.js
+++ b/test/services/bill-runs/match/match-and-allocate.service.test.js
@@ -20,7 +20,7 @@ const PersistAllocatedLicenceToResultsService = require('../../../../app/service
 // Thing under test
 const MatchAndAllocateService = require('../../../../app/services/bill-runs/match/match-and-allocate.service.js')
 
-describe('Match And Allocate Service', () => {
+describe('Bill Runs - Match - Match And Allocate Service', () => {
   let determineLicenceIssuesServiceStub
   let notifierStub
   let licences
@@ -79,10 +79,11 @@ describe('Match And Allocate Service', () => {
           expect(PersistAllocatedLicenceToResultsService.go.called).to.be.true()
         })
 
-        it('returns "true" as there are licences to process', async () => {
-          const result = await MatchAndAllocateService.go(billRun, billingPeriods)
+        it('returns the licences to be processed', async () => {
+          const results = await MatchAndAllocateService.go(billRun, billingPeriods)
 
-          expect(result).to.be.true()
+          expect(results.length).not.to.equal(0)
+          expect(results[0].licenceRef).to.equal('5/31/14/*S/0116A')
         })
       })
 
@@ -116,10 +117,11 @@ describe('Match And Allocate Service', () => {
           expect(chargeReference.chargeElements[1].allocatedQuantity).to.equal(2)
         })
 
-        it('returns "true" as there are licences to process', async () => {
-          const result = await MatchAndAllocateService.go(billRun, billingPeriods)
+        it('returns the licences to be processed', async () => {
+          const results = await MatchAndAllocateService.go(billRun, billingPeriods)
 
-          expect(result).to.be.true()
+          expect(results.length).not.to.equal(0)
+          expect(results[0].licenceRef).to.equal('5/31/14/*S/0116A')
         })
       })
     })
@@ -152,10 +154,10 @@ describe('Match And Allocate Service', () => {
         expect(PersistAllocatedLicenceToResultsService.go.called).to.be.false()
       })
 
-      it('returns "false" as there are no licences to process', async () => {
-        const result = await MatchAndAllocateService.go(billRun, billingPeriods)
+      it('returns no licences to be processed', async () => {
+        const results = await MatchAndAllocateService.go(billRun, billingPeriods)
 
-        expect(result).to.be.false()
+        expect(results).to.be.empty()
       })
     })
   })

--- a/test/services/bill-runs/review/fetch-remove-review-licence.service.test.js
+++ b/test/services/bill-runs/review/fetch-remove-review-licence.service.test.js
@@ -15,7 +15,7 @@ const ReviewLicenceHelper = require('../../../support/helpers/review-licence.hel
 // Thing under test
 const FetchRemoveReviewLicenceService = require('../../../../app/services/bill-runs/review/fetch-remove-review-licence.service.js')
 
-describe('Bill Runs Review - Fetch Remove Review Licence service', () => {
+describe('Bill Runs - Review - Fetch Remove Review Licence service', () => {
   let billRun
   let region
   let reviewLicence
@@ -38,6 +38,7 @@ describe('Bill Runs Review - Fetch Remove Review Licence service', () => {
         licenceRef: reviewLicence.licenceRef,
         billRun: {
           id: billRun.id,
+          batchType: billRun.batchType,
           billRunNumber: billRun.billRunNumber,
           createdAt: billRun.createdAt,
           status: 'review',

--- a/test/services/bill-runs/review/submit-remove.service.test.js
+++ b/test/services/bill-runs/review/submit-remove.service.test.js
@@ -16,22 +16,24 @@ const CreateLicenceSupplementaryYearService = require('../../../../app/services/
 const FetchRemoveReviewLicenceService = require('../../../../app/services/bill-runs/review/fetch-remove-review-licence.service.js')
 const ProcessBillRunPostRemove = require('../../../../app/services/bill-runs/review/process-bill-run-post-remove.service.js')
 const RemoveReviewLicenceService = require('../../../../app/services/bill-runs/review/remove-review-licence.service.js')
+const UnassignLicencesToBillRunService = require('../../../../app/services/bill-runs/unassign-licences-to-bill-run.service.js')
 
 // Thing under test
 const SubmitRemoveService = require('../../../../app/services/bill-runs/review/submit-remove.service.js')
 
-describe('Bill Runs Review - Submit Remove service', () => {
+describe('Bill Runs - Review - Submit Remove service', () => {
   let createLicenceSupplementaryYearStub
   let removeReviewLicence
   let removeReviewLicenceStub
+  let unassignLicencesToBillRunStub
   let yarStub
 
   beforeEach(() => {
     removeReviewLicence = BillRunsReviewFixture.removeReviewLicence()
 
-    Sinon.stub(FetchRemoveReviewLicenceService, 'go').resolves(removeReviewLicence)
-
     removeReviewLicenceStub = Sinon.stub(RemoveReviewLicenceService, 'go').withArgs(removeReviewLicence.id).resolves()
+
+    unassignLicencesToBillRunStub = Sinon.stub(UnassignLicencesToBillRunService, 'go').resolves()
 
     createLicenceSupplementaryYearStub = Sinon.stub(CreateLicenceSupplementaryYearService, 'go')
       .withArgs(removeReviewLicence.licenceId, [removeReviewLicence.billRun.toFinancialYearEnding], true)
@@ -45,55 +47,178 @@ describe('Bill Runs Review - Submit Remove service', () => {
   })
 
   describe('when called', () => {
-    describe('and this is the last licence in the bill run', () => {
-      beforeEach(() => {
-        Sinon.stub(ProcessBillRunPostRemove, 'go').withArgs(removeReviewLicence.billRun.id).resolves(true)
+    describe('and the bill run is two-part tariff annual', () => {
+      describe('and this is not the last licence in the bill run', () => {
+        beforeEach(() => {
+          Sinon.stub(FetchRemoveReviewLicenceService, 'go').resolves(removeReviewLicence)
+          Sinon.stub(ProcessBillRunPostRemove, 'go').withArgs(removeReviewLicence.billRun.id).resolves(false)
+        })
+
+        it('removes the review licence', async () => {
+          await SubmitRemoveService.go(removeReviewLicence.id, yarStub)
+
+          expect(removeReviewLicenceStub.called).to.be.true()
+        })
+
+        it('does not attempt to unassign the licence from the bill run', async () => {
+          await SubmitRemoveService.go(removeReviewLicence.id, yarStub)
+
+          expect(unassignLicencesToBillRunStub.called).to.be.false()
+        })
+
+        it('flags the licence for supplementary billing', async () => {
+          await SubmitRemoveService.go(removeReviewLicence.id, yarStub)
+
+          expect(createLicenceSupplementaryYearStub.called).to.be.true()
+        })
+
+        it('does add a flash message', async () => {
+          await SubmitRemoveService.go(removeReviewLicence.id, yarStub)
+
+          expect(yarStub.flash.called).to.be.true()
+
+          const [flashType, bannerMessage] = yarStub.flash.args[0]
+
+          expect(flashType).to.equal('banner')
+          expect(bannerMessage).to.equal('Licence 1/11/11/*11/1111 removed from the bill run.')
+        })
+
+        it('returns the bill run ID and a flag to indicate the bill run is not empty', async () => {
+          const result = await SubmitRemoveService.go(removeReviewLicence.id, yarStub)
+
+          expect(result).to.equal({
+            billRunId: '287aeb25-cf11-429d-8c6f-f98f06db021d',
+            empty: false
+          })
+        })
       })
 
-      it('removes the review licence, flags the licence for supplementary billing, does not add a flash message, and returns `empty: true`', async () => {
-        const result = await SubmitRemoveService.go(removeReviewLicence.id, yarStub)
+      describe('and this is the last licence in the bill run', () => {
+        beforeEach(() => {
+          Sinon.stub(FetchRemoveReviewLicenceService, 'go').resolves(removeReviewLicence)
+          Sinon.stub(ProcessBillRunPostRemove, 'go').withArgs(removeReviewLicence.billRun.id).resolves(true)
+        })
 
-        // Confirm we called the remove review licence service with the correct ID
-        expect(removeReviewLicenceStub.called).to.be.true()
+        it('removes the review licence', async () => {
+          await SubmitRemoveService.go(removeReviewLicence.id, yarStub)
 
-        // Confirm we flagged the licence for the next two-part tariff supplementary bill run
-        expect(createLicenceSupplementaryYearStub.called).to.be.true()
+          expect(removeReviewLicenceStub.called).to.be.true()
+        })
 
-        // Check we didn't add the flash message
-        expect(yarStub.flash.called).to.be.false()
+        it('does not attempt to unassign the licence from the bill run', async () => {
+          await SubmitRemoveService.go(removeReviewLicence.id, yarStub)
 
-        // Check we return empty true in our result so the controller knows to redirect to the bill runs page
-        expect(result).to.equal({
-          billRunId: '287aeb25-cf11-429d-8c6f-f98f06db021d',
-          empty: true
+          expect(unassignLicencesToBillRunStub.called).to.be.false()
+        })
+
+        it('flags the licence for supplementary billing', async () => {
+          await SubmitRemoveService.go(removeReviewLicence.id, yarStub)
+
+          expect(createLicenceSupplementaryYearStub.called).to.be.true()
+        })
+
+        it('does not add a flash message', async () => {
+          await SubmitRemoveService.go(removeReviewLicence.id, yarStub)
+
+          expect(yarStub.flash.called).to.be.false()
+        })
+
+        it('returns the bill run ID and a flag to indicate the bill run is empty', async () => {
+          const result = await SubmitRemoveService.go(removeReviewLicence.id, yarStub)
+
+          expect(result).to.equal({
+            billRunId: '287aeb25-cf11-429d-8c6f-f98f06db021d',
+            empty: true
+          })
         })
       })
     })
 
-    describe('and this is not the last licence in the bill run', () => {
-      beforeEach(() => {
-        Sinon.stub(ProcessBillRunPostRemove, 'go').withArgs(removeReviewLicence.billRun.id).resolves(false)
+    describe('and the bill run is for two-part tariff supplementary', () => {
+      describe('and this is not the last licence in the bill run', () => {
+        beforeEach(() => {
+          removeReviewLicence.billRun.batchType = 'two_part_supplementary'
+          Sinon.stub(FetchRemoveReviewLicenceService, 'go').resolves(removeReviewLicence)
+          Sinon.stub(ProcessBillRunPostRemove, 'go').withArgs(removeReviewLicence.billRun.id).resolves(false)
+        })
+
+        it('removes the review licence', async () => {
+          await SubmitRemoveService.go(removeReviewLicence.id, yarStub)
+
+          expect(removeReviewLicenceStub.called).to.be.true()
+        })
+
+        it('does attempt to unassign the licence from the bill run', async () => {
+          await SubmitRemoveService.go(removeReviewLicence.id, yarStub)
+
+          expect(unassignLicencesToBillRunStub.called).to.be.true()
+        })
+
+        it('does not flag the licence for supplementary billing', async () => {
+          await SubmitRemoveService.go(removeReviewLicence.id, yarStub)
+
+          expect(createLicenceSupplementaryYearStub.called).to.be.false()
+        })
+
+        it('does add a flash message', async () => {
+          await SubmitRemoveService.go(removeReviewLicence.id, yarStub)
+
+          expect(yarStub.flash.called).to.be.true()
+
+          const [flashType, bannerMessage] = yarStub.flash.args[0]
+
+          expect(flashType).to.equal('banner')
+          expect(bannerMessage).to.equal('Licence 1/11/11/*11/1111 removed from the bill run.')
+        })
+
+        it('returns the bill run ID and a flag to indicate the bill run is not empty', async () => {
+          const result = await SubmitRemoveService.go(removeReviewLicence.id, yarStub)
+
+          expect(result).to.equal({
+            billRunId: '287aeb25-cf11-429d-8c6f-f98f06db021d',
+            empty: false
+          })
+        })
       })
 
-      it('removes the review licence, flags the licence for supplementary billing, adds a flash message, and returns `empty: false`', async () => {
-        const result = await SubmitRemoveService.go(removeReviewLicence.id, yarStub)
+      describe('and this is the last licence in the bill run', () => {
+        beforeEach(() => {
+          removeReviewLicence.billRun.batchType = 'two_part_supplementary'
+          Sinon.stub(FetchRemoveReviewLicenceService, 'go').resolves(removeReviewLicence)
+          Sinon.stub(ProcessBillRunPostRemove, 'go').withArgs(removeReviewLicence.billRun.id).resolves(true)
+        })
 
-        // Confirm we called the remove review licence service with the correct ID
-        expect(removeReviewLicenceStub.called).to.be.true()
+        it('removes the review licence', async () => {
+          await SubmitRemoveService.go(removeReviewLicence.id, yarStub)
 
-        // Confirm we flagged the licence for the next two-part tariff supplementary bill run
-        expect(createLicenceSupplementaryYearStub.called).to.be.true()
+          expect(removeReviewLicenceStub.called).to.be.true()
+        })
 
-        // Check we add the flash message
-        const [flashType, bannerMessage] = yarStub.flash.args[0]
+        it('does attempt to unassign the licence from the bill run', async () => {
+          await SubmitRemoveService.go(removeReviewLicence.id, yarStub)
 
-        expect(flashType).to.equal('banner')
-        expect(bannerMessage).to.equal('Licence 1/11/11/*11/1111 removed from the bill run.')
+          expect(unassignLicencesToBillRunStub.called).to.be.true()
+        })
 
-        // Check we return empty true in our result so the controller knows to redirect to the bill runs page
-        expect(result).to.equal({
-          billRunId: '287aeb25-cf11-429d-8c6f-f98f06db021d',
-          empty: false
+        it('does not flag the licence for supplementary billing', async () => {
+          await SubmitRemoveService.go(removeReviewLicence.id, yarStub)
+
+          expect(createLicenceSupplementaryYearStub.called).to.be.false()
+        })
+
+        it('does not add a flash message', async () => {
+          await SubmitRemoveService.go(removeReviewLicence.id, yarStub)
+
+          expect(yarStub.flash.called).to.be.false()
+        })
+
+        it('returns the bill run ID and a flag to indicate the bill run is empty', async () => {
+          const result = await SubmitRemoveService.go(removeReviewLicence.id, yarStub)
+
+          expect(result).to.equal({
+            billRunId: '287aeb25-cf11-429d-8c6f-f98f06db021d',
+            empty: true
+          })
         })
       })
     })

--- a/test/services/bill-runs/send/update-invoice-numbers.service.test.js
+++ b/test/services/bill-runs/send/update-invoice-numbers.service.test.js
@@ -20,7 +20,7 @@ const UnflagBilledSupplementaryLicencesService = require('../../../../app/servic
 // Thing under test
 const UpdateInvoiceNumbersService = require('../../../../app/services/bill-runs/send/update-invoice-numbers.service.js')
 
-describe('Bill Runs - Send- Update Invoice Numbers service', () => {
+describe('Bill Runs - Send - Update Invoice Numbers service', () => {
   let billRun
   let chargingModuleSendBillRunRequestStub
   let chargingModuleViewBillRunRequestStub

--- a/test/services/bill-runs/tpt-supplementary/process-bill-run.service.test.js
+++ b/test/services/bill-runs/tpt-supplementary/process-bill-run.service.test.js
@@ -9,6 +9,7 @@ const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Things we need to stub
+const AssignBillRunToLicencesService = require('../../../../app/services/bill-runs/assign-bill-run-to-licences.service.js')
 const BillRunModel = require('../../../../app/models/bill-run.model.js')
 const HandleErroredBillRunService = require('../../../../app/services/bill-runs/handle-errored-bill-run.service.js')
 
@@ -16,7 +17,7 @@ const HandleErroredBillRunService = require('../../../../app/services/bill-runs/
 const MatchAndAllocateService = require('../../../../app/services/bill-runs/match/match-and-allocate.service.js')
 const ProcessBillRunService = require('../../../../app/services/bill-runs/tpt-supplementary/process-bill-run.service.js')
 
-describe('Bill Runs - TpT Supplementary - Process Bill Run service', () => {
+describe('Bill Runs - TPT Supplementary - Process Bill Run service', () => {
   const billingPeriods = [{ startDate: new Date('2023-04-01'), endDate: new Date('2024-03-31') }]
   const billRun = { id: '410c84a5-39d3-441a-97ca-6104e14d00a2' }
 
@@ -31,6 +32,8 @@ describe('Bill Runs - TpT Supplementary - Process Bill Run service', () => {
       findById: Sinon.stub().returnsThis(),
       patch: billRunPatchStub
     })
+
+    Sinon.stub(AssignBillRunToLicencesService, 'go').resolves()
 
     // BaseRequest depends on the GlobalNotifier to have been set. This happens in app/plugins/global-notifier.plugin.js
     // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
@@ -47,7 +50,7 @@ describe('Bill Runs - TpT Supplementary - Process Bill Run service', () => {
   describe('when the service is called', () => {
     describe('and no licences are matched and allocated', () => {
       beforeEach(() => {
-        Sinon.stub(MatchAndAllocateService, 'go').resolves(false)
+        Sinon.stub(MatchAndAllocateService, 'go').resolves([])
       })
 
       it('sets the bill run status first to "processing" and then to "empty"', async () => {
@@ -72,7 +75,11 @@ describe('Bill Runs - TpT Supplementary - Process Bill Run service', () => {
 
     describe('and licences are matched and allocated', () => {
       beforeEach(() => {
-        Sinon.stub(MatchAndAllocateService, 'go').resolves(true)
+        // NOTE: ProcessBillRunService orchestrates the creation of a bill run. The actual work is done in the services
+        // it is calling. As long as MatchAndAllocateService returns a 'licence', ProcessBillRunService will trigger the
+        // work to happen. This is why for these tests it is not critical what we stub MatchAndAllocateService to
+        // return, only that it returns something!
+        Sinon.stub(MatchAndAllocateService, 'go').resolves([{ id: '27e16528-bf00-459e-9980-902feb84a054' }])
       })
 
       it('sets the bill run status first to "processing" and then to "review"', async () => {

--- a/test/services/bill-runs/tpt-supplementary/process-billing-period.service.test.js
+++ b/test/services/bill-runs/tpt-supplementary/process-billing-period.service.test.js
@@ -26,7 +26,7 @@ const TransactionModel = require('../../../../app/models/transaction.model.js')
 // Thing under test
 const ProcessBillingPeriodService = require('../../../../app/services/bill-runs/tpt-supplementary/process-billing-period.service.js')
 
-describe('Bill Runs - Two-part Tariff - Process Billing Period service', () => {
+describe('Bill Runs - TPT Supplementary - Process Billing Period service', () => {
   const billingPeriod = {
     startDate: new Date('2022-04-01'),
     endDate: new Date('2023-03-31')

--- a/test/services/bill-runs/unassign-bill-run-to-licences.service.test.js
+++ b/test/services/bill-runs/unassign-bill-run-to-licences.service.test.js
@@ -1,0 +1,50 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Things we need to stub
+const LicenceSupplementaryYearModel = require('../../../app/models/licence-supplementary-year.model.js')
+
+// Thing under test
+const UnassignBillRunToLicencesService = require('../../../app/services/bill-runs/unassign-bill-run-to-licences.service.js')
+
+describe('Bill Runs - Unassign Bill Run To Licences service', () => {
+  const billRunId = '091c3d3f-0328-4b10-b1a1-3eccf55416a0'
+
+  let licenceSupplementaryYearPatch
+  let licenceSupplementaryYearWhere
+
+  beforeEach(() => {
+    licenceSupplementaryYearPatch = Sinon.stub().returnsThis()
+    licenceSupplementaryYearWhere = Sinon.stub()
+
+    Sinon.stub(LicenceSupplementaryYearModel, 'query').returns({
+      patch: licenceSupplementaryYearPatch,
+      where: licenceSupplementaryYearWhere
+    })
+  })
+
+  afterEach(() => {
+    Sinon.restore()
+  })
+
+  describe('when called', () => {
+    it('updates the matching "LicenceSupplementaryYear" records with a null bill run ID', async () => {
+      await UnassignBillRunToLicencesService.go(billRunId)
+
+      const patchArgs = licenceSupplementaryYearPatch.args[0][0]
+
+      expect(patchArgs.billRunId).to.be.null()
+
+      const whereArgs = licenceSupplementaryYearWhere.args[0]
+
+      expect(whereArgs).to.equal(['billRunId', '091c3d3f-0328-4b10-b1a1-3eccf55416a0'])
+    })
+  })
+})

--- a/test/services/bill-runs/unassign-licences-to-bill-run.service.test.js
+++ b/test/services/bill-runs/unassign-licences-to-bill-run.service.test.js
@@ -1,0 +1,58 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Things we need to stub
+const LicenceSupplementaryYearModel = require('../../../app/models/licence-supplementary-year.model.js')
+
+// Thing under test
+const UnassignLicencesToBillRunService = require('../../../app/services/bill-runs/unassign-licences-to-bill-run.service.js')
+
+describe('Bill Runs - Unassign Licences To Bill Run service', () => {
+  const billRunId = '091c3d3f-0328-4b10-b1a1-3eccf55416a0'
+  const licenceIds = ['098e0fff-1c3e-4be3-83b9-8f483ae5b41e', '406b8ba4-63b6-442a-86f3-a144f1f63ca9']
+
+  let licenceSupplementaryYearPatch
+  let licenceSupplementaryYearWhereIn
+  let licenceSupplementaryYearWhere
+
+  beforeEach(() => {
+    licenceSupplementaryYearPatch = Sinon.stub().returnsThis()
+    licenceSupplementaryYearWhereIn = Sinon.stub().returnsThis()
+    licenceSupplementaryYearWhere = Sinon.stub()
+
+    Sinon.stub(LicenceSupplementaryYearModel, 'query').returns({
+      patch: licenceSupplementaryYearPatch,
+      whereIn: licenceSupplementaryYearWhereIn,
+      where: licenceSupplementaryYearWhere
+    })
+  })
+
+  afterEach(() => {
+    Sinon.restore()
+  })
+
+  describe('when called', () => {
+    it('updates the matching "LicenceSupplementaryYear" records with a null bill run ID', async () => {
+      await UnassignLicencesToBillRunService.go(licenceIds, billRunId)
+
+      const patchArgs = licenceSupplementaryYearPatch.args[0][0]
+
+      expect(patchArgs.billRunId).to.be.null()
+
+      const whereInArgs = licenceSupplementaryYearWhereIn.args[0]
+
+      expect(whereInArgs).to.equal(['licenceId', licenceIds])
+
+      const whereArgs = licenceSupplementaryYearWhere.args[0]
+
+      expect(whereArgs).to.equal(['billRunId', '091c3d3f-0328-4b10-b1a1-3eccf55416a0'])
+    })
+  })
+})

--- a/test/services/bill-runs/unflag-unbilled-supplementary-licences.service.test.js
+++ b/test/services/bill-runs/unflag-unbilled-supplementary-licences.service.test.js
@@ -4,84 +4,100 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
+const { generateUUID } = require('../../../app/lib/general.lib.js')
 const BillHelper = require('../../support/helpers/bill.helper.js')
 const BillLicenceHelper = require('../../support/helpers/bill-licence.helper.js')
 const LicenceHelper = require('../../support/helpers/licence.helper.js')
+const LicenceSupplementaryYearHelper = require('../../support/helpers/licence-supplementary-year.helper.js')
 const WorkflowHelper = require('../../support/helpers/workflow.helper.js')
 
 // Thing under test
 const UnflagUnbilledSupplementaryLicencesService = require('../../../app/services/bill-runs/unflag-unbilled-supplementary-licences.service.js')
 
 describe('Bill Runs - Unflag Unbilled Supplementary Licences service', () => {
-  let billRun
+  const billRun = { id: '42e7a42b-8a9a-42b4-b527-2baaedf952f2', scheme: 'sroc', toFinancialYearEnding: 2024 }
 
-  describe('when there are licences flagged for SROC supplementary billing', () => {
-    let allLicenceIds
-    let licenceNotInBillRun
-    let licenceNotBilledInBillRun
-    let licenceNotBilledInBillRunAndWorkflow
-    let licenceNotBilledInBillRunAndUpdated
-    let licenceBilledInBillRun
+  describe('when the bill run is "standard" supplementary', () => {
+    const stdSupplementary = {}
 
     beforeEach(async () => {
-      licenceNotInBillRun = await LicenceHelper.add({ includeInSrocBilling: true })
-      licenceNotBilledInBillRun = await LicenceHelper.add({ includeInSrocBilling: true })
+      stdSupplementary.licenceNotInBillRun = await LicenceHelper.add({ includeInSrocBilling: true })
+      stdSupplementary.licenceNotBilledInBillRun = await LicenceHelper.add({ includeInSrocBilling: true })
 
-      licenceNotBilledInBillRunAndWorkflow = await LicenceHelper.add({ includeInSrocBilling: true })
-      await WorkflowHelper.add({ licenceId: licenceNotBilledInBillRunAndWorkflow.id, deletedAt: null })
+      stdSupplementary.licenceNotBilledInBillRunAndWorkflow = await LicenceHelper.add({ includeInSrocBilling: true })
+      stdSupplementary.workflow = await WorkflowHelper.add({
+        licenceId: stdSupplementary.licenceNotBilledInBillRunAndWorkflow.id,
+        deletedAt: null
+      })
 
-      licenceNotBilledInBillRunAndUpdated = await LicenceHelper.add({
+      stdSupplementary.licenceNotBilledInBillRunAndUpdated = await LicenceHelper.add({
         includeInSrocBilling: true,
         updatedAt: new Date('2099-01-01')
       })
 
-      licenceBilledInBillRun = await LicenceHelper.add({ includeInSrocBilling: true })
+      stdSupplementary.licenceBilledInBillRun = await LicenceHelper.add({ includeInSrocBilling: true })
+      stdSupplementary.bill = await BillHelper.add({ billRunId: billRun.id })
+      stdSupplementary.billLicence = await BillLicenceHelper.add({
+        billId: stdSupplementary.bill.id,
+        licenceId: stdSupplementary.licenceBilledInBillRun.id
+      })
 
-      allLicenceIds = [
-        licenceNotBilledInBillRun.id,
-        licenceNotBilledInBillRunAndWorkflow.id,
-        licenceNotBilledInBillRunAndUpdated.id,
-        licenceBilledInBillRun.id
+      stdSupplementary.allLicenceIds = [
+        stdSupplementary.licenceNotBilledInBillRun.id,
+        stdSupplementary.licenceNotBilledInBillRunAndWorkflow.id,
+        stdSupplementary.licenceNotBilledInBillRunAndUpdated.id,
+        stdSupplementary.licenceBilledInBillRun.id
       ]
 
-      billRun = {
-        id: '42e7a42b-8a9a-42b4-b527-2baaedf952f2',
-        createdAt: new Date(),
-        scheme: 'sroc'
-      }
+      // We have to instantiate the bill run createdAt date last to ensure it is _after_ the updatedAt dates on the
+      // licences
+      billRun.batchType = 'supplementary'
+      billRun.createdAt = new Date()
     })
 
-    describe('those licences in the current bill run', () => {
-      describe('which were not billed', () => {
-        describe('and are not in workflow or updated after the bill run was created', () => {
-          it('unflags them for SROC supplementary billing', async () => {
-            await UnflagUnbilledSupplementaryLicencesService.go(billRun, allLicenceIds)
+    afterEach(async () => {
+      await stdSupplementary.billLicence.$query().delete()
+      await stdSupplementary.bill.$query().delete()
+      await stdSupplementary.workflow.$query().delete()
 
-            const licenceToBeChecked = await licenceNotBilledInBillRun.$query()
+      await stdSupplementary.licenceBilledInBillRun.$query().delete()
+      await stdSupplementary.licenceNotBilledInBillRunAndUpdated.$query().delete()
+      await stdSupplementary.licenceNotBilledInBillRunAndWorkflow.$query().delete()
+      await stdSupplementary.licenceNotBilledInBillRun.$query().delete()
+      await stdSupplementary.licenceNotInBillRun.$query().delete()
+    })
+
+    describe('the licences in the bill run that were flagged', () => {
+      describe('which were not billed', () => {
+        describe('and are not blocked from being unflagged', () => {
+          it('unflags them', async () => {
+            await UnflagUnbilledSupplementaryLicencesService.go(billRun, stdSupplementary.allLicenceIds)
+
+            const licenceToBeChecked = await stdSupplementary.licenceNotBilledInBillRun.$query()
 
             expect(licenceToBeChecked.includeInSrocBilling).to.be.false()
           })
         })
 
-        describe('but are in workflow', () => {
-          it('leaves flagged for SROC supplementary billing', async () => {
-            await UnflagUnbilledSupplementaryLicencesService.go(billRun, allLicenceIds)
+        describe('but are in "workflow"', () => {
+          it('leaves flagged for SROC standard supplementary billing', async () => {
+            await UnflagUnbilledSupplementaryLicencesService.go(billRun, stdSupplementary.allLicenceIds)
 
-            const licenceToBeChecked = await licenceNotBilledInBillRunAndWorkflow.$query()
+            const licenceToBeChecked = await stdSupplementary.licenceNotBilledInBillRunAndWorkflow.$query()
 
             expect(licenceToBeChecked.includeInSrocBilling).to.be.true()
           })
         })
 
         describe('but were updated after the bill run was created', () => {
-          it('leaves flagged for SROC supplementary billing', async () => {
-            await UnflagUnbilledSupplementaryLicencesService.go(billRun, allLicenceIds)
+          it('leaves flagged for SROC standard supplementary billing', async () => {
+            await UnflagUnbilledSupplementaryLicencesService.go(billRun, stdSupplementary.allLicenceIds)
 
-            const licenceToBeChecked = await licenceNotBilledInBillRunAndUpdated.$query()
+            const licenceToBeChecked = await stdSupplementary.licenceNotBilledInBillRunAndUpdated.$query()
 
             expect(licenceToBeChecked.includeInSrocBilling).to.be.true()
           })
@@ -89,29 +105,145 @@ describe('Bill Runs - Unflag Unbilled Supplementary Licences service', () => {
       })
 
       describe('which were billed', () => {
-        beforeEach(async () => {
-          const { id: billId } = await BillHelper.add({ billRunId: billRun.id })
+        it('leaves flagged SROC standard supplementary billing', async () => {
+          await UnflagUnbilledSupplementaryLicencesService.go(billRun, stdSupplementary.allLicenceIds)
 
-          await BillLicenceHelper.add({ billId, licenceId: licenceBilledInBillRun.id })
-        })
-
-        it('are left flagged (include_in_sroc_billing still true)', async () => {
-          await UnflagUnbilledSupplementaryLicencesService.go(billRun, allLicenceIds)
-
-          const licenceToBeChecked = await licenceBilledInBillRun.$query()
+          const licenceToBeChecked = await stdSupplementary.licenceBilledInBillRun.$query()
 
           expect(licenceToBeChecked.includeInSrocBilling).to.be.true()
         })
       })
     })
 
-    describe('those licences not in the current bill run', () => {
-      it('leaves flagged (include_in_sroc_billing still true)', async () => {
-        await UnflagUnbilledSupplementaryLicencesService.go(billRun, allLicenceIds)
+    describe('the licences not in the bill run that were flagged', () => {
+      it('leaves flagged for SROC standard supplementary billing', async () => {
+        await UnflagUnbilledSupplementaryLicencesService.go(billRun, stdSupplementary.allLicenceIds)
 
-        const licenceToBeChecked = await licenceNotInBillRun.$query()
+        const licenceToBeChecked = await stdSupplementary.licenceNotInBillRun.$query()
 
         expect(licenceToBeChecked.includeInSrocBilling).to.be.true()
+      })
+    })
+  })
+
+  describe('when the bill run is "two-part tariff" supplementary', () => {
+    const tptSupplementary = {}
+
+    beforeEach(async () => {
+      // NOTE: Unlike standard supplementary, a licence is flagged by having a licence supplementary year record, not by
+      // something on the licence record. Therefore, the presence (or not!) of the sup year record is what
+      // denotes if a licence is flagged. This means for testing, we don't have to create the licence record as well.
+
+      tptSupplementary.licenceNotInBillRunSupYear = await LicenceSupplementaryYearHelper.add({
+        licenceId: generateUUID(),
+        financialYearEnd: billRun.toFinancialYearEnding
+      })
+
+      tptSupplementary.licenceNotBilledInBillRunSupYear = await LicenceSupplementaryYearHelper.add({
+        billRunId: billRun.id,
+        licenceId: generateUUID(),
+        financialYearEnd: billRun.toFinancialYearEnding
+      })
+
+      tptSupplementary.licenceNotBilledInBillRunAndWorkflowSupYear = await LicenceSupplementaryYearHelper.add({
+        billRunId: billRun.id,
+        licenceId: generateUUID(),
+        financialYearEnd: billRun.toFinancialYearEnding
+      })
+      tptSupplementary.workflow = await WorkflowHelper.add({
+        licenceId: tptSupplementary.licenceNotBilledInBillRunAndWorkflowSupYear.licenceId,
+        deletedAt: null
+      })
+
+      // NOTE: Unlike standard where we used a different licence, we can confirm with TpT that if a licence that _is_
+      // assigned to the bill run and was not billed (so we are going to delete the sup. year record), has another
+      // entry because the licence was changed after the bill run was created, that we don't delete _that_ record.
+      tptSupplementary.licenceNotBilledInBillRunAndUpdatedSupYear = await LicenceSupplementaryYearHelper.add({
+        billRunId: null,
+        licenceId: tptSupplementary.licenceNotBilledInBillRunSupYear.licenceId,
+        financialYearEnd: billRun.toFinancialYearEnding
+      })
+
+      tptSupplementary.licenceBilledInBillRunSupYear = await LicenceSupplementaryYearHelper.add({
+        licenceId: generateUUID(),
+        financialYearEnd: billRun.toFinancialYearEnding
+      })
+      tptSupplementary.bill = await BillHelper.add({ billRunId: billRun.id })
+      tptSupplementary.billLicence = await BillLicenceHelper.add({
+        billId: tptSupplementary.bill.id,
+        licenceId: tptSupplementary.licenceBilledInBillRunSupYear.licenceId
+      })
+
+      // We have to instantiate the bill run createdAt date last to ensure it is _after_ the updatedAt dates on the
+      // licences
+      billRun.batchType = 'two_part_supplementary'
+      billRun.createdAt = new Date()
+    })
+
+    afterEach(async () => {
+      await tptSupplementary.billLicence.$query().delete()
+      await tptSupplementary.bill.$query().delete()
+      await tptSupplementary.workflow.$query().delete()
+
+      await tptSupplementary.licenceBilledInBillRunSupYear.$query().delete()
+      await tptSupplementary.licenceNotBilledInBillRunAndUpdatedSupYear.$query().delete()
+      await tptSupplementary.licenceNotBilledInBillRunAndWorkflowSupYear.$query().delete()
+      await tptSupplementary.licenceNotBilledInBillRunSupYear.$query().delete()
+      await tptSupplementary.licenceNotInBillRunSupYear.$query().delete()
+    })
+
+    describe('the licences in the bill run that were flagged', () => {
+      describe('which were not billed', () => {
+        describe('and are not blocked from being unflagged', () => {
+          it('unflags them', async () => {
+            await UnflagUnbilledSupplementaryLicencesService.go(billRun)
+
+            const licenceSupYearToBeChecked = await tptSupplementary.licenceNotBilledInBillRunSupYear.$query()
+
+            expect(licenceSupYearToBeChecked).not.exists()
+          })
+        })
+
+        describe('but are in "workflow"', () => {
+          it('leaves flagged for SROC two-part tariff supplementary billing', async () => {
+            await UnflagUnbilledSupplementaryLicencesService.go(billRun)
+
+            const licenceSupYearToBeChecked =
+              await tptSupplementary.licenceNotBilledInBillRunAndWorkflowSupYear.$query()
+
+            expect(licenceSupYearToBeChecked).exists()
+          })
+        })
+
+        describe('but were updated after the bill run was created', () => {
+          it('leaves flagged for SROC two-part tariff supplementary billing', async () => {
+            await UnflagUnbilledSupplementaryLicencesService.go(billRun)
+
+            const licenceSupYearToBeChecked = await tptSupplementary.licenceNotBilledInBillRunAndUpdatedSupYear.$query()
+
+            expect(licenceSupYearToBeChecked).exists()
+          })
+        })
+      })
+
+      describe('which were billed', () => {
+        it('leaves flagged SROC two-part tariff supplementary billing', async () => {
+          await UnflagUnbilledSupplementaryLicencesService.go(billRun)
+
+          const licenceSupYearToBeChecked = await tptSupplementary.licenceBilledInBillRunSupYear.$query()
+
+          expect(licenceSupYearToBeChecked).exists()
+        })
+      })
+    })
+
+    describe('the licences not in the bill run that were flagged', () => {
+      it('leaves flagged for SROC two-part tariff supplementary billing', async () => {
+        await UnflagUnbilledSupplementaryLicencesService.go(billRun)
+
+        const licenceSupYearToBeChecked = await tptSupplementary.licenceNotInBillRunSupYear.$query()
+
+        expect(licenceSupYearToBeChecked).exists()
       })
     })
   })

--- a/test/services/bills/submit-remove-bill.service.test.js
+++ b/test/services/bills/submit-remove-bill.service.test.js
@@ -8,32 +8,45 @@ const Sinon = require('sinon')
 const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
-// Test helpers
-const BillHelper = require('../../support/helpers/bill.helper.js')
-const BillLicenceHelper = require('../../support/helpers/bill-licence.helper.js')
-
 // Things we need to stub
+const BillModel = require('../../../app/models/bill.model.js')
 const LegacyDeleteBillRequest = require('../../../app/requests/legacy/delete-bill.request.js')
 const ProcessBillingFlagService = require('../../../app/services/licences/supplementary/process-billing-flag.service.js')
+const UnassignLicencesToBillRunService = require('../../../app/services/bill-runs/unassign-licences-to-bill-run.service.js')
 
 // Thing under test
 const SubmitRemoveBillService = require('../../../app/services/bills/submit-remove-bill.service.js')
 
-describe('Submit Remove Bill service', () => {
+describe('Bills - Submit Remove Bill service', () => {
   const user = { id: '0aa9dcaa-9a26-4a77-97ab-c17db54d38a1', useremail: 'carol.shaw@atari.com' }
 
   let bill
+  let billStub
   let legacyDeleteBillRequestStub
   let processBillingFlagsStub
+  let unassignLicencesToBillRunStub
 
   beforeEach(async () => {
-    bill = await BillHelper.add()
-    // Add two licences to the bill
-    await BillLicenceHelper.add({ billId: bill.id })
-    await BillLicenceHelper.add({ billId: bill.id })
+    bill = {
+      id: '274a3c01-42fe-4ed0-9212-c703ea5feaab',
+      billRunId: '340c0f17-6e01-4d6c-b2ba-e1ab027364bb',
+      billLicences: [
+        { id: '9d75e160-fe4c-4f1a-bce9-ecc6b35316cb', licenceId: '0716ad45-f5f0-4f3f-b8cb-f24956dcd10d' },
+        { id: '1c61e430-ac5a-43ed-a2e0-854ceb45fce5', licenceId: 'eafe888c-ed7a-405b-8df7-616c8d17e91a' }
+      ]
+    }
+
+    billStub = Sinon.stub().resolves(bill)
+    Sinon.stub(BillModel, 'query').returns({
+      findById: Sinon.stub().returnsThis(),
+      select: Sinon.stub().returnsThis(),
+      withGraphFetched: Sinon.stub().returnsThis(),
+      modifyGraph: billStub
+    })
 
     legacyDeleteBillRequestStub = Sinon.stub(LegacyDeleteBillRequest, 'send').resolves()
     processBillingFlagsStub = Sinon.stub(ProcessBillingFlagService, 'go').resolves()
+    unassignLicencesToBillRunStub = Sinon.stub(UnassignLicencesToBillRunService, 'go').resolves()
   })
 
   afterEach(() => {
@@ -41,6 +54,12 @@ describe('Submit Remove Bill service', () => {
   })
 
   describe('when called', () => {
+    it('unassigns any two-part tariff supplementary licences in the bill from the bill run', async () => {
+      await SubmitRemoveBillService.go(bill.id, user)
+
+      expect(unassignLicencesToBillRunStub.called).to.be.true()
+    })
+
     it('flags the two licences in the bill for supplementary billing', async () => {
       await SubmitRemoveBillService.go(bill.id, user)
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4201

> Part of the work to support two-part tariff supplementary bill runs

In recent changes we've been moving and updating existing billing services to allow us to create [two-part tariff supplementary bill runs](https://github.com/DEFRA/water-abstraction-system/pull/1748).

But like standard supplementary, there is another facet the billing engine has to handle; flagging.

When a licence is changed, for example, its charge or return versions, or a return submission, the system will 'flag' the licence for supplementary billing.

This is a boolean field on the licence record for 'standard' supplementary. For a two-part tariff, we add an entry to `water.licence_supplementary_years`.

> N.B. We aim to do the same for 'standard' supplementary in the future.

But the result is the same.

- Being flagged determines which licences are picked up for processing when a supplementary bill run is created
- When a bill run is 'processed', the engine needs to unflag licences where a bill was not found to be needed
- If a licence is removed from the supplementary bill, the flag needs to remain
- Once the bill run is sent, all billed licences should be unflagged
- Those licences that are changed after the bill run is created, or moved into 'workflow' should not be unflagged

The benefit of the `licence_supplementary_year` entries is that we can assign them to a bill run when it is set up. This means we can know more accurately which licences should be unflagged when a bill run is being 'processed'.

This is part one of the changes and covers the following actions from the UI.

- Assigning to a bill run when the bill run is set up
- Removing a licence from 'review'
- Unflagging unbilled licences when a bill run is continued from 'review'
- Removing a bill from a 'ready' bill run
- Removing a licence from a 'ready' bill run

The scenarios around changing licences after the bill run has been set up or added to workflow are also covered. The one step left to complete is when the bill run is 'sent', at which point all assigned licence supplementary year entries need to be removed. That'll come in part 2, but merging part 1 allows our QA team to get started testing this complex functionality.