### PR TITLE
Handle TPT licence flags during supp process - pt2

### DIFF
--- a/app/services/bill-runs/send/update-invoice-numbers.service.js
+++ b/app/services/bill-runs/send/update-invoice-numbers.service.js
@@ -30,7 +30,7 @@ async function go(billRun) {
   try {
     const startTime = process.hrtime.bigint()
 
-    const { id: billRunId, externalId } = billRun
+    const { id: billRunId, batchType, externalId } = billRun
 
     await ChargingModuleSendBillRunRequest.send(externalId)
 
@@ -40,7 +40,7 @@ async function go(billRun) {
 
     await _updateBillRun(billRunId, externalBillRun)
 
-    if (billRun.batchType === 'supplementary') {
+    if (batchType === 'supplementary' || batchType === 'two_part_supplementary') {
       await UnflagBilledSupplementaryLicencesService.go(billRun)
     }
 

--- a/app/services/bill-runs/unflag-billed-supplementary-licences.service.js
+++ b/app/services/bill-runs/unflag-billed-supplementary-licences.service.js
@@ -6,9 +6,11 @@
  */
 
 const LicenceModel = require('../../models/licence.model.js')
+const LicenceSupplementaryYearModel = require('../../models/licence-supplementary-year.model.js')
+const WorkflowModel = require('../../models/workflow.model.js')
 
 /**
- * Unflag any licences that were billed as part of a bill run
+ * Unflag all licences in a bill run that resulted in a billing invoice (they are billed)
  *
  * Our `SubmitSendBillRunService` supports both SROC and PRESROC bill runs. But how they unflag bill runs is different.
  *
@@ -19,42 +21,46 @@ const LicenceModel = require('../../models/licence.model.js')
  * In SROC we have the `UnflagUnbilledLicencesService` which deals with licences that didn't result in a bill being
  * created during the generation process.
  *
- * Other than that both queries have to deal with the same scenarios of when _not_ to unflag
+ * A licence is flagged for _standard_ supplementary by a tick on the licence record itself. It is flagged for two-part
+ * tariff with an entry in `licence_supplementary_years`. Hence, when we 'unflag', we have to do it in two different
+ * ways.
  *
- * - licences in workflow
- * - licences updated after the bill run was created
+ * For either type of flag, we don't 'unflag' if the licence is in workflow. This is because when a licence is gets
+ * 'moved to workflow' (has a workflow record with no deleted date), it doesn't automatically get a supplementary flag
+ * applied. But its there because the team are doing something with the licence, so billing needs to be suspended.
  *
- * Essentially, in both cases a user or the import process might have made a change that resulted in the bill run
- * getting flagged. This change will not have been considered as part of the current bill run so needs to be evaluated
- * in the next supplementary bill run. If we remove the flag this won't happen.
+ * We also don't remove the _standard_ supplementary flag if the licence record is updated _after_ the bill run is
+ * created. This tells us _something_ has changed on the licence since the bill run was created. So, just in case, we
+ * want the licence to be processed again in the next supplementary bill run.
  *
- * There is a risk we leave the flag on a licence that was updated for a reason that didn't need it to be included in
- * the next supplementary bill run. But if that is the case no bill will be created and the licence will get unflagged
- * then.
+ * > The use of `licence_supplementary_years` was brought in when we added support for flagging for 2PT SROC
+ * > supplementary. It means we don't have to worry about comparing the dates. It also means we can be more accurate
+ * > about when changes apply from. We hope to move standard SROC supplementary to it in the future.
  *
- * @param {module:BillRunModel} billRun - Instance of the bill run being sent
- *
- * @returns {Promise<number>} Resolves to the count of records updated
+ * @param {module:BillRunModel} billRun - Instance of the bill run being 'sent'
  */
 async function go(billRun) {
-  const { scheme } = billRun
+  const { batchType, scheme } = billRun
 
-  if (scheme === 'sroc') {
-    return _updateCurrentScheme(billRun)
+  if (scheme === 'alcs') {
+    await _unflagOldScheme(billRun)
+
+    return
   }
 
-  return _updateOldScheme(billRun)
+  if (batchType === 'two_part_supplementary') {
+    await _unflagTwoPartTariff(billRun)
+
+    return
+  }
+
+  await _unflagStandard(billRun)
 }
 
-/**
- * PRESROC
- *
- * @private
- */
-async function _updateOldScheme(billRun) {
+async function _unflagOldScheme(billRun) {
   const { createdAt, regionId } = billRun
 
-  return LicenceModel.query()
+  await LicenceModel.query()
     .patch({ includeInPresrocBilling: 'no' })
     .where('updatedAt', '<=', createdAt)
     .where('regionId', regionId)
@@ -62,15 +68,10 @@ async function _updateOldScheme(billRun) {
     .whereNotExists(LicenceModel.relatedQuery('workflows').whereNull('workflows.deletedAt'))
 }
 
-/**
- * SROC
- *
- * @private
- */
-async function _updateCurrentScheme(billRun) {
+async function _unflagStandard(billRun) {
   const { id: billRunId, createdAt } = billRun
 
-  return LicenceModel.query()
+  await LicenceModel.query()
     .patch({ includeInSrocBilling: false })
     .where('updatedAt', '<=', createdAt)
     .whereNotExists(LicenceModel.relatedQuery('workflows').whereNull('workflows.deletedAt'))
@@ -78,6 +79,20 @@ async function _updateCurrentScheme(billRun) {
       LicenceModel.relatedQuery('billLicences')
         .join('bills', 'bills.id', 'billLicences.billId')
         .where('bills.billRunId', billRunId)
+    )
+}
+
+async function _unflagTwoPartTariff(billRun) {
+  const { id: billRunId } = billRun
+
+  await LicenceSupplementaryYearModel.query()
+    .delete()
+    .where('billRunId', billRunId)
+    .whereNotExists(
+      WorkflowModel.query()
+        .select(1)
+        .whereColumn('licenceSupplementaryYears.licenceId', 'workflows.licenceId')
+        .whereNull('workflows.deletedAt')
     )
 }
 

--- a/test/services/bill-runs/send/update-invoice-numbers.service.test.js
+++ b/test/services/bill-runs/send/update-invoice-numbers.service.test.js
@@ -134,7 +134,19 @@ describe('Bill Runs - Send - Update Invoice Numbers service', () => {
         })
       })
 
-      describe('and if the bill run is not supplementary', () => {
+      describe('and if the bill run is two-part supplementary', () => {
+        beforeEach(async () => {
+          billRun.batchType = 'two_part_supplementary'
+        })
+
+        it('also unflags the licences for supplementary billing', async () => {
+          await UpdateInvoiceNumbersService.go(billRun)
+
+          expect(unflagBilledLicencesServiceStub.called).to.be.true()
+        })
+      })
+
+      describe('and if the bill run is neither supplementary or two-part supplementary', () => {
         it('leaves the licences supplementary billing flags alone', async () => {
           await UpdateInvoiceNumbersService.go(billRun)
 

--- a/test/services/bill-runs/unflag-billed-supplementary-licences.service.test.js
+++ b/test/services/bill-runs/unflag-billed-supplementary-licences.service.test.js
@@ -4,13 +4,14 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
 const BillHelper = require('../../support/helpers/bill.helper.js')
 const BillLicenceHelper = require('../../support/helpers/bill-licence.helper.js')
 const LicenceHelper = require('../../support/helpers/licence.helper.js')
+const LicenceSupplementaryYearHelper = require('../../support/helpers/licence-supplementary-year.helper.js')
 const RegionHelper = require('../../support/helpers/region.helper.js')
 const WorkflowHelper = require('../../support/helpers/workflow.helper.js')
 
@@ -19,126 +20,288 @@ const UnflagBilledSupplementaryLicencesService = require('../../../app/services/
 
 describe('Bill Runs - Unflag Billed Supplementary Licences service', () => {
   const { id: regionId } = RegionHelper.select(RegionHelper.TEST_REGION_INDEX)
+  const { id: otherRegionId } = RegionHelper.select(1)
+  const billRun = { id: '42e7a42b-8a9a-42b4-b527-2baaedf952f2', regionId, toFinancialYearEnding: 2024 }
 
-  let billRun
+  describe('when the bill run is "standard" supplementary', () => {
+    describe('and for the old PRESROC charge scheme', () => {
+      const presrocSupplementary = {}
 
-  describe('when there are licences flagged for PRESROC supplementary billing', () => {
-    let licenceNotInRegion
-    let licenceInWorkflow
-    let licenceFlaggedAfterBillRunCreated
-    let licenceFlaggedBeforeBillRunCreated
+      beforeEach(async () => {
+        presrocSupplementary.licenceToBeUnflagged = await LicenceHelper.add({
+          includeInPresrocBilling: 'yes',
+          regionId
+        })
 
-    beforeEach(async () => {
-      const { id: otherRegionId } = RegionHelper.select(1)
-      const updatedAt = new Date('2024-02-02')
+        presrocSupplementary.licenceNotInRegion = await LicenceHelper.add({
+          includeInPresrocBilling: 'yes',
+          regionId: otherRegionId
+        })
 
-      licenceNotInRegion = await LicenceHelper.add({
-        includeInPresrocBilling: 'yes',
-        regionId: otherRegionId,
-        updatedAt
+        presrocSupplementary.licenceInWorkflow = await LicenceHelper.add({
+          includeInPresrocBilling: 'yes',
+          regionId
+        })
+        presrocSupplementary.workflow = await WorkflowHelper.add({
+          licenceId: presrocSupplementary.licenceInWorkflow.id,
+          deletedAt: null
+        })
+
+        // We have to instantiate the bill run createdAt date after the others but before the last licence to ensure the
+        // tests for not unflagging licences updated the bill run is created will pass
+        billRun.batchType = 'supplementary'
+        billRun.createdAt = new Date()
+        billRun.scheme = 'alcs'
+
+        presrocSupplementary.licenceFlaggedAfterBillRunCreated = await LicenceHelper.add({
+          includeInPresrocBilling: 'yes',
+          regionId
+        })
       })
-      licenceInWorkflow = await LicenceHelper.add({
-        includeInPresrocBilling: 'yes',
-        regionId,
-        updatedAt
-      })
-      await WorkflowHelper.add({ licenceId: licenceInWorkflow.id, deletedAt: null })
 
-      licenceFlaggedAfterBillRunCreated = await LicenceHelper.add({
-        includeInPresrocBilling: 'yes',
-        regionId,
-        updatedAt: new Date('2099-01-01')
-      })
-      licenceFlaggedBeforeBillRunCreated = await LicenceHelper.add({
-        includeInPresrocBilling: 'yes',
-        regionId,
-        updatedAt
+      afterEach(async () => {
+        await presrocSupplementary.workflow.$query().delete()
+
+        await presrocSupplementary.licenceToBeUnflagged.$query().delete()
+        await presrocSupplementary.licenceNotInRegion.$query().delete()
+        await presrocSupplementary.licenceInWorkflow.$query().delete()
+        await presrocSupplementary.licenceFlaggedAfterBillRunCreated.$query().delete()
       })
 
-      billRun = {
-        id: 'fa5b8225-b616-4057-a268-1927c2f3eef1',
-        createdAt: new Date('2024-02-03'),
-        regionId,
-        scheme: 'alcs'
-      }
+      describe('the licences in the bill run that were flagged', () => {
+        describe('and are not blocked from being unflagged', () => {
+          it('unflags them', async () => {
+            await UnflagBilledSupplementaryLicencesService.go(billRun)
+
+            const licenceToBeChecked = await presrocSupplementary.licenceToBeUnflagged.$query()
+
+            expect(licenceToBeChecked.includeInPresrocBilling).to.equal('no')
+          })
+        })
+
+        describe('but are in "workflow"', () => {
+          it('leaves flagged for PRESROC standard supplementary billing', async () => {
+            await UnflagBilledSupplementaryLicencesService.go(billRun)
+
+            const licenceToBeChecked = await presrocSupplementary.licenceInWorkflow.$query()
+
+            expect(licenceToBeChecked.includeInPresrocBilling).to.equal('yes')
+          })
+        })
+
+        describe('but were updated after the bill run was created', () => {
+          it('leaves flagged for PRESROC standard supplementary billing', async () => {
+            await UnflagBilledSupplementaryLicencesService.go(billRun)
+
+            const licenceToBeChecked = await presrocSupplementary.licenceFlaggedAfterBillRunCreated.$query()
+
+            expect(licenceToBeChecked.includeInPresrocBilling).to.equal('yes')
+          })
+        })
+      })
+
+      describe('the licences not in the bill run that were flagged', () => {
+        it('leaves flagged for PRESROC standard supplementary billing', async () => {
+          await UnflagBilledSupplementaryLicencesService.go(billRun)
+
+          const licenceToBeChecked = await presrocSupplementary.licenceNotInRegion.$query()
+
+          expect(licenceToBeChecked.includeInPresrocBilling).to.equal('yes')
+        })
+      })
     })
 
-    it('unflags those in the same region, not in workflow, and that were last updated before the bill run was created', async () => {
-      await UnflagBilledSupplementaryLicencesService.go(billRun)
+    describe('and for the SROC charge scheme', () => {
+      const srocSupplementary = {}
 
-      let licenceBeingChecked
+      beforeEach(async () => {
+        srocSupplementary.licenceToBeUnflagged = await LicenceHelper.add({
+          includeInSrocBilling: true,
+          regionId
+        })
+        srocSupplementary.bill = await BillHelper.add({ billRunId: billRun.id })
+        srocSupplementary.billLicence = await BillLicenceHelper.add({
+          billId: srocSupplementary.bill.id,
+          licenceId: srocSupplementary.licenceToBeUnflagged.id
+        })
 
-      // Check licence not in region still flagged
-      licenceBeingChecked = await licenceNotInRegion.$query()
-      expect(licenceBeingChecked.includeInPresrocBilling).to.equal('yes')
+        srocSupplementary.licenceNotInBillRun = await LicenceHelper.add({
+          includeInSrocBilling: true,
+          regionId: otherRegionId
+        })
 
-      // Check licence in workflow still flagged
-      licenceBeingChecked = await licenceInWorkflow.$query()
-      expect(licenceBeingChecked.includeInPresrocBilling).to.equal('yes')
+        srocSupplementary.licenceInWorkflow = await LicenceHelper.add({
+          includeInSrocBilling: true,
+          regionId
+        })
+        srocSupplementary.workflow = await WorkflowHelper.add({
+          licenceId: srocSupplementary.licenceInWorkflow.id,
+          deletedAt: null
+        })
 
-      // Check licence flagged (updated) after the bill run was created
-      licenceBeingChecked = await licenceFlaggedAfterBillRunCreated.$query()
-      expect(licenceBeingChecked.includeInPresrocBilling).to.equal('yes')
+        srocSupplementary.licenceFlaggedAfterBillRunCreated = await LicenceHelper.add({
+          includeInSrocBilling: true,
+          regionId
+        })
 
-      // Finally check the licence which matches the query has been unflagged
-      licenceBeingChecked = await licenceFlaggedBeforeBillRunCreated.$query()
-      expect(licenceBeingChecked.includeInPresrocBilling).to.equal('no')
+        // We have to instantiate the bill run createdAt date last to ensure it is _after_ the updatedAt dates on the
+        // licences
+        billRun.batchType = 'supplementary'
+        billRun.createdAt = new Date()
+        billRun.scheme = 'sroc'
+      })
+
+      afterEach(async () => {
+        await srocSupplementary.workflow.$query().delete()
+        await srocSupplementary.billLicence.$query().delete()
+        await srocSupplementary.bill.$query().delete()
+
+        await srocSupplementary.licenceToBeUnflagged.$query().delete()
+        await srocSupplementary.licenceNotInBillRun.$query().delete()
+        await srocSupplementary.licenceInWorkflow.$query().delete()
+        await srocSupplementary.licenceFlaggedAfterBillRunCreated.$query().delete()
+      })
+
+      describe('the licences in the bill run that were flagged', () => {
+        describe('and are not blocked from being unflagged', () => {
+          it('unflags them', async () => {
+            await UnflagBilledSupplementaryLicencesService.go(billRun)
+
+            const licenceToBeChecked = await srocSupplementary.licenceToBeUnflagged.$query()
+
+            expect(licenceToBeChecked.includeInSrocBilling).to.be.false()
+          })
+        })
+
+        describe('but are in "workflow"', () => {
+          it('leaves flagged for SROC standard supplementary billing', async () => {
+            await UnflagBilledSupplementaryLicencesService.go(billRun)
+
+            const licenceToBeChecked = await srocSupplementary.licenceInWorkflow.$query()
+
+            expect(licenceToBeChecked.includeInSrocBilling).to.be.true()
+          })
+        })
+
+        describe('but were updated after the bill run was created', () => {
+          it('leaves flagged for SROC standard supplementary billing', async () => {
+            await UnflagBilledSupplementaryLicencesService.go(billRun)
+
+            const licenceToBeChecked = await srocSupplementary.licenceFlaggedAfterBillRunCreated.$query()
+
+            expect(licenceToBeChecked.includeInSrocBilling).to.be.true()
+          })
+        })
+      })
+
+      describe('the licences not in the bill run that were flagged', () => {
+        it('leaves flagged for SROC standard supplementary billing', async () => {
+          await UnflagBilledSupplementaryLicencesService.go(billRun)
+
+          const licenceToBeChecked = await srocSupplementary.licenceNotInBillRun.$query()
+
+          expect(licenceToBeChecked.includeInSrocBilling).to.be.true()
+        })
+      })
     })
   })
 
-  describe('when there are licences flagged for SROC supplementary billing', () => {
-    let licenceNotInBillRun
-    let licenceInBillRunAndWorkflow
-    let licenceInBillRunAndFlaggedAfterBillRunCreated
-    let licenceInBillRun
+  describe('when the bill run is "two-part tariff" supplementary', () => {
+    const tptSupplementary = {}
 
     beforeEach(async () => {
-      licenceInBillRun = await LicenceHelper.add({ includeInSrocBilling: true })
+      // NOTE: Unlike standard supplementary, a licence is flagged by having a licence supplementary year record, not by
+      // something on the licence record. Therefore, the presence (or not!) of the sup year record is what
+      // denotes if a licence is flagged. This means for testing, we don't have to create the licence record as well.
 
-      licenceNotInBillRun = await LicenceHelper.add({ includeInSrocBilling: true })
-
-      licenceInBillRunAndWorkflow = await LicenceHelper.add({ includeInSrocBilling: true })
-      await WorkflowHelper.add({ licenceId: licenceInBillRunAndWorkflow.id, deletedAt: null })
-
-      licenceInBillRunAndFlaggedAfterBillRunCreated = await LicenceHelper.add({
-        includeInSrocBilling: true,
-        updatedAt: new Date('2099-01-01')
+      tptSupplementary.licenceToBeUnflaggedSupYear = await LicenceSupplementaryYearHelper.add({
+        billRunId: billRun.id,
+        financialYearEnd: billRun.toFinancialYearEnding
+      })
+      tptSupplementary.bill = await BillHelper.add({ billRunId: billRun.id })
+      tptSupplementary.billLicence = await BillLicenceHelper.add({
+        billId: tptSupplementary.bill.id,
+        licenceId: tptSupplementary.licenceToBeUnflaggedSupYear.licenceId
       })
 
-      billRun = {
-        id: 'fa5b8225-b616-4057-a268-1927c2f3eef1',
-        createdAt: new Date(),
-        regionId,
-        scheme: 'sroc'
-      }
+      tptSupplementary.licenceNotInBillRunSupYear = await LicenceSupplementaryYearHelper.add({
+        financialYearEnd: billRun.toFinancialYearEnding
+      })
 
-      const { id: billId } = await BillHelper.add({ billRunId: billRun.id })
+      tptSupplementary.licenceInWorkflowSupYear = await LicenceSupplementaryYearHelper.add({
+        billRunId: billRun.id,
+        financialYearEnd: billRun.toFinancialYearEnding
+      })
+      tptSupplementary.workflow = await WorkflowHelper.add({
+        licenceId: tptSupplementary.licenceInWorkflowSupYear.licenceId,
+        deletedAt: null
+      })
 
-      await BillLicenceHelper.add({ billId, licenceId: licenceInBillRunAndWorkflow.id })
-      await BillLicenceHelper.add({ billId, licenceId: licenceInBillRunAndFlaggedAfterBillRunCreated.id })
-      await BillLicenceHelper.add({ billId, licenceId: licenceInBillRun.id })
+      // NOTE: Unlike standard where we used a different licence, we can confirm with TpT that if a licence that _is_
+      // assigned to the bill run and was billed (so we are going to delete the sup. year record), has another
+      // entry because the licence was changed after the bill run was created, that we don't delete _that_ record.
+      tptSupplementary.licenceInBillRunButUpdatedSupYear = await LicenceSupplementaryYearHelper.add({
+        billRunId: null,
+        licenceId: tptSupplementary.licenceToBeUnflaggedSupYear.licenceId,
+        financialYearEnd: billRun.toFinancialYearEnding
+      })
+
+      billRun.batchType = 'two_part_supplementary'
+      billRun.createdAt = new Date()
+      billRun.scheme = 'sroc'
     })
 
-    it('unflags only those licences in the bill run that are not in workflow, and that were last updated before the bill run was created)', async () => {
-      await UnflagBilledSupplementaryLicencesService.go(billRun)
+    afterEach(async () => {
+      await tptSupplementary.billLicence.$query().delete()
+      await tptSupplementary.bill.$query().delete()
+      await tptSupplementary.workflow.$query().delete()
 
-      let licenceBeingChecked
+      await tptSupplementary.licenceToBeUnflaggedSupYear.$query().delete()
+      await tptSupplementary.licenceInBillRunButUpdatedSupYear.$query().delete()
+      await tptSupplementary.licenceInWorkflowSupYear.$query().delete()
+      await tptSupplementary.licenceNotInBillRunSupYear.$query().delete()
+    })
 
-      // Check licence not in bill run still flagged
-      licenceBeingChecked = await licenceNotInBillRun.$query()
-      expect(licenceBeingChecked.includeInSrocBilling).to.be.true()
+    describe('the licences in the bill run that were flagged', () => {
+      describe('and are not blocked from being unflagged', () => {
+        it('unflags them', async () => {
+          await UnflagBilledSupplementaryLicencesService.go(billRun)
 
-      // Check licence in bill run but also in workflow still flagged
-      licenceBeingChecked = await licenceInBillRunAndWorkflow.$query()
-      expect(licenceBeingChecked.includeInSrocBilling).to.be.true()
+          const licenceSupYearToBeChecked = await tptSupplementary.licenceToBeUnflaggedSupYear.$query()
 
-      // Check licence in bill run but updated after bill run was created (e.g. charge version approved) still flagged
-      licenceBeingChecked = await licenceInBillRunAndFlaggedAfterBillRunCreated.$query()
-      expect(licenceBeingChecked.includeInSrocBilling).to.be.true()
+          expect(licenceSupYearToBeChecked).not.exists()
+        })
+      })
 
-      // Finally check the licence in the bill run with no other issues has been unflagged
-      licenceBeingChecked = await licenceInBillRun.$query()
-      expect(licenceBeingChecked.includeInSrocBilling).to.be.false()
+      describe('but are in "workflow"', () => {
+        it('leaves flagged for SROC two-part tariff supplementary billing', async () => {
+          await UnflagBilledSupplementaryLicencesService.go(billRun)
+
+          const licenceSupYearToBeChecked = await tptSupplementary.licenceInWorkflowSupYear.$query()
+
+          expect(licenceSupYearToBeChecked).exists()
+        })
+      })
+
+      describe('but were updated after the bill run was created', () => {
+        it('leaves flagged for SROC two-part tariff supplementary billing', async () => {
+          await UnflagBilledSupplementaryLicencesService.go(billRun)
+
+          const licenceSupYearToBeChecked = await tptSupplementary.licenceInBillRunButUpdatedSupYear.$query()
+
+          expect(licenceSupYearToBeChecked).exists()
+        })
+      })
+    })
+
+    describe('the licences not in the bill run that were flagged', () => {
+      it('leaves flagged for SROC two-part tariff supplementary billing', async () => {
+        await UnflagBilledSupplementaryLicencesService.go(billRun)
+
+        const licenceSupYearToBeChecked = await tptSupplementary.licenceNotInBillRunSupYear.$query()
+
+        expect(licenceSupYearToBeChecked).exists()
+      })
     })
   })
 })

--- a/test/services/bill-runs/unflag-unbilled-supplementary-licences.service.test.js
+++ b/test/services/bill-runs/unflag-unbilled-supplementary-licences.service.test.js
@@ -8,7 +8,6 @@ const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const { generateUUID } = require('../../../app/lib/general.lib.js')
 const BillHelper = require('../../support/helpers/bill.helper.js')
 const BillLicenceHelper = require('../../support/helpers/bill-licence.helper.js')
 const LicenceHelper = require('../../support/helpers/licence.helper.js')
@@ -135,19 +134,16 @@ describe('Bill Runs - Unflag Unbilled Supplementary Licences service', () => {
       // denotes if a licence is flagged. This means for testing, we don't have to create the licence record as well.
 
       tptSupplementary.licenceNotInBillRunSupYear = await LicenceSupplementaryYearHelper.add({
-        licenceId: generateUUID(),
         financialYearEnd: billRun.toFinancialYearEnding
       })
 
       tptSupplementary.licenceNotBilledInBillRunSupYear = await LicenceSupplementaryYearHelper.add({
         billRunId: billRun.id,
-        licenceId: generateUUID(),
         financialYearEnd: billRun.toFinancialYearEnding
       })
 
       tptSupplementary.licenceNotBilledInBillRunAndWorkflowSupYear = await LicenceSupplementaryYearHelper.add({
         billRunId: billRun.id,
-        licenceId: generateUUID(),
         financialYearEnd: billRun.toFinancialYearEnding
       })
       tptSupplementary.workflow = await WorkflowHelper.add({
@@ -165,7 +161,7 @@ describe('Bill Runs - Unflag Unbilled Supplementary Licences service', () => {
       })
 
       tptSupplementary.licenceBilledInBillRunSupYear = await LicenceSupplementaryYearHelper.add({
-        licenceId: generateUUID(),
+        billRunId: billRun.id,
         financialYearEnd: billRun.toFinancialYearEnding
       })
       tptSupplementary.bill = await BillHelper.add({ billRunId: billRun.id })
@@ -174,8 +170,6 @@ describe('Bill Runs - Unflag Unbilled Supplementary Licences service', () => {
         licenceId: tptSupplementary.licenceBilledInBillRunSupYear.licenceId
       })
 
-      // We have to instantiate the bill run createdAt date last to ensure it is _after_ the updatedAt dates on the
-      // licences
       billRun.batchType = 'two_part_supplementary'
       billRun.createdAt = new Date()
     })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4201

> Part of the work to support two-part tariff supplementary bill runs

In our previous change [Handle TPT licence flags during supp process - pt1](https://github.com/DEFRA/water-abstraction-system/pull/1771) we added all the logic for dealing with two-part tariff supplementary billing flags (the `water.licence_supplementary_years` table) while the bill run is being set up, created and processed.

The one part we didn't add was when the bill run was finally 'sent', and we need to unflag all billed licences in the bill run.

This is that final change.