### PR TITLE
Do not include 2PT supp. licences already assigned

### DIFF
--- a/app/services/bill-runs/match/fetch-charge-versions.service.js
+++ b/app/services/bill-runs/match/fetch-charge-versions.service.js
@@ -85,7 +85,7 @@ async function _fetch(regionId, billingPeriod, supplementary) {
           LicenceSupplementaryYearModel.query()
             .select(1)
             .whereColumn('licenceSupplementaryYears.licenceId', 'chargeVersions.licenceId')
-            .whereColumn('licenceSupplementaryYears.financialYearEnd', billingPeriod.endDate.getFullYear())
+            .where('licenceSupplementaryYears.financialYearEnd', billingPeriod.endDate.getFullYear())
         )
       } else {
         builder.whereRaw('1=1')

--- a/app/services/bill-runs/match/fetch-charge-versions.service.js
+++ b/app/services/bill-runs/match/fetch-charge-versions.service.js
@@ -86,6 +86,7 @@ async function _fetch(regionId, billingPeriod, supplementary) {
             .select(1)
             .whereColumn('licenceSupplementaryYears.licenceId', 'chargeVersions.licenceId')
             .where('licenceSupplementaryYears.financialYearEnd', billingPeriod.endDate.getFullYear())
+            .whereNull('licenceSupplementaryYears.billRunId')
         )
       } else {
         builder.whereRaw('1=1')

--- a/test/services/bill-runs/match/fetch-charge-versions.service.test.js
+++ b/test/services/bill-runs/match/fetch-charge-versions.service.test.js
@@ -271,6 +271,26 @@ describe('Fetch Charge Versions service', () => {
           expect(results).to.be.empty()
         })
       })
+
+      describe('and the licence has been flagged for supplementary but is already assigned to a bill run', () => {
+        beforeEach(async () => {
+          licenceSupplementaryYear = await LicenceSupplementaryYearHelper.add({
+            billRunId: '210d0685-5d61-44d3-9206-46ec037d8b73',
+            licenceId: licence.id,
+            financialYearEnd: billingPeriod.endDate.getFullYear()
+          })
+        })
+
+        afterEach(async () => {
+          await licenceSupplementaryYear.$query().delete()
+        })
+
+        it('returns no records', async () => {
+          const results = await FetchChargeVersionsService.go(region.id, billingPeriod, supplementary)
+
+          expect(results).to.be.empty()
+        })
+      })
     })
   })
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4201

> Part of the work to support two-part tariff supplementary bill runs

When writing up the ticket to cover the changes made, we realised we'd made a mistake with how we were fetching the charge versions when matching and allocating for a two-part tariff supplementary licence.

We've updated `app/services/bill-runs/match/fetch-charge-versions.service.js` to handle the two, two-part tariff bill run types. But when we added the `where` clause for supplementary, we had forgotten to ensure it ignores licences already assigned to a bill run.

In reality, you shouldn't be able to set up a two-part tariff supplementary, assign a licence, and then create another bill run for that region while the first is in progress.

But we figured it was better to be safe than sorry! Plus, it makes the intention more evident.