### PR TITLE
Update notify services response

### DIFF
--- a/app/services/notify/notify-email.service.js
+++ b/app/services/notify/notify-email.service.js
@@ -47,8 +47,10 @@ async function _sendEmail(notifyClient, templateId, emailAddress, options) {
     const response = await notifyClient.sendEmail(templateId, emailAddress, options)
 
     return {
+      id: response.data.id,
+      plaintext: response.data.content.body,
       status: response.status,
-      id: response.data.id
+      statusText: response.statusText.toLowerCase()
     }
   } catch (error) {
     return {

--- a/app/services/notify/notify-letter.service.js
+++ b/app/services/notify/notify-letter.service.js
@@ -51,8 +51,10 @@ async function _sendLetter(notifyClient, templateId, options) {
     const response = await notifyClient.sendLetter(templateId, options)
 
     return {
+      id: response.data.id,
+      plaintext: response.data.content.body,
       status: response.status,
-      id: response.data.id
+      statusText: response.statusText.toLowerCase()
     }
   } catch (error) {
     return {

--- a/test/services/notifications/setup/batch-notifications.service.test.js
+++ b/test/services/notifications/setup/batch-notifications.service.test.js
@@ -49,8 +49,14 @@ describe('Notifications Setup - Batch notifications service', () => {
   describe('when the batch is successful', () => {
     beforeEach(() => {
       _stubSuccessfulNotify({
-        data: { id: '12345' },
-        status: 201
+        data: {
+          id: '12345',
+          content: {
+            body: 'My dearest margery'
+          }
+        },
+        status: 201,
+        statusText: 'CREATED'
       })
     })
 

--- a/test/services/notify/notify-email.service.test.js
+++ b/test/services/notify/notify-email.service.test.js
@@ -44,9 +44,15 @@ describe('Notify - Email service', () => {
 
   describe('when the call to "notify" is successful', () => {
     beforeEach(() => {
-      notifyStub = _stubSuccessfulNotify(stubNotify, {
-        data: { id: '12345' },
-        status: 201
+      notifyStub = _stubSuccessfulNotify({
+        data: {
+          id: '12345',
+          content: {
+            body: 'My dearest margery'
+          }
+        },
+        status: 201,
+        statusText: 'CREATED'
       })
     })
 
@@ -55,7 +61,9 @@ describe('Notify - Email service', () => {
 
       expect(result).to.equal({
         id: result.id,
-        status: 201
+        plaintext: 'My dearest margery',
+        status: 201,
+        statusText: 'created'
       })
     })
 
@@ -74,7 +82,7 @@ describe('Notify - Email service', () => {
         beforeEach(() => {
           emailAddress = ''
 
-          notifyStub = _stubUnSuccessfulNotify(stubNotify, {
+          notifyStub = _stubUnSuccessfulNotify({
             status: 400,
             message: 'Request failed with status code 400',
             response: {
@@ -110,7 +118,7 @@ describe('Notify - Email service', () => {
         beforeEach(() => {
           delete options.personalisation.periodEndDate
 
-          notifyStub = _stubUnSuccessfulNotify(stubNotify, {
+          notifyStub = _stubUnSuccessfulNotify({
             status: 400,
             message: 'Request failed with status code 400',
             response: {
@@ -145,14 +153,14 @@ describe('Notify - Email service', () => {
   })
 })
 
-function _stubSuccessfulNotify(stub, response) {
-  if (stub) {
+function _stubSuccessfulNotify(response) {
+  if (stubNotify) {
     return Sinon.stub(NotifyClient.prototype, 'sendEmail').resolves(response)
   }
 }
 
-function _stubUnSuccessfulNotify(stub, response) {
-  if (stub) {
+function _stubUnSuccessfulNotify(response) {
+  if (stubNotify) {
     return Sinon.stub(NotifyClient.prototype, 'sendEmail').rejects(response)
   }
 }

--- a/test/services/notify/notify-letter.service.test.js
+++ b/test/services/notify/notify-letter.service.test.js
@@ -46,9 +46,15 @@ describe('Notify - Letter service', () => {
 
   describe('when the call to "notify" is successful', () => {
     beforeEach(() => {
-      notifyStub = _stubSuccessfulNotify(stubNotify, {
-        data: { id: '12345' },
-        status: 201
+      notifyStub = _stubSuccessfulNotify({
+        data: {
+          id: '12345',
+          content: {
+            body: 'My dearest margery'
+          }
+        },
+        status: 201,
+        statusText: 'CREATED'
       })
     })
 
@@ -57,7 +63,9 @@ describe('Notify - Letter service', () => {
 
       expect(result).to.equal({
         id: result.id,
-        status: 201
+        plaintext: 'My dearest margery',
+        status: 201,
+        statusText: 'created'
       })
     })
 
@@ -80,7 +88,7 @@ describe('Notify - Letter service', () => {
           delete options.personalisation.address_line_4
           delete options.personalisation.address_line_5
 
-          notifyStub = _stubUnSuccessfulNotify(stubNotify, {
+          notifyStub = _stubUnSuccessfulNotify({
             status: 400,
             message: 'Request failed with status code 400',
             response: {
@@ -116,7 +124,7 @@ describe('Notify - Letter service', () => {
         beforeEach(() => {
           delete options.personalisation.name
 
-          notifyStub = _stubUnSuccessfulNotify(stubNotify, {
+          notifyStub = _stubUnSuccessfulNotify({
             status: 400,
             message: 'Request failed with status code 400',
             response: {
@@ -151,14 +159,14 @@ describe('Notify - Letter service', () => {
   })
 })
 
-function _stubSuccessfulNotify(stub, response) {
-  if (stub) {
+function _stubSuccessfulNotify(response) {
+  if (stubNotify) {
     return Sinon.stub(NotifyClient.prototype, 'sendLetter').resolves(response)
   }
 }
 
-function _stubUnSuccessfulNotify(stub, response) {
-  if (stub) {
+function _stubUnSuccessfulNotify(response) {
+  if (stubNotify) {
     return Sinon.stub(NotifyClient.prototype, 'sendLetter').rejects(response)
   }
 }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4904

The legacy code uses the 'water.scheduled_notifications' schema to store the returns notifications. As part of the refactor to replace the existing legacy notifications code we need to align our implementation of notifications.

This change adds additional fields to the notify services responses.

We have added the 'statusText' which is used to determine the state of a notify notification. This will be 'CREATED' on a successful response.

The 'statusText' is available for an error but the legacy code does not use / store this. So we are following the existing pattern.

We have also added the 'plaintext' field. This is the raw string of the notification sent to the recipient.