### PR TITLE
Return log setup single volume saved to session

### DIFF
--- a/app/services/return-logs/setup/submit-single-volume.service.js
+++ b/app/services/return-logs/setup/submit-single-volume.service.js
@@ -48,7 +48,7 @@ async function go(sessionId, payload) {
 
 async function _save(session, payload) {
   session.singleVolume = payload.singleVolume
-  session.singleVolumeQuantity = payload.singleVolumeQuantity
+  session.singleVolumeQuantity = Number(payload.singleVolumeQuantity)
 
   return session.$update()
 }

--- a/test/services/return-logs/setup/submit-single-volume.service.test.js
+++ b/test/services/return-logs/setup/submit-single-volume.service.test.js
@@ -32,7 +32,7 @@ describe('Return Logs Setup - Submit Single Volume service', () => {
   describe('when called', () => {
     describe('with a valid payload', () => {
       beforeEach(async () => {
-        payload = { singleVolume: 'no' }
+        payload = { singleVolume: 'yes', singleVolumeQuantity: '1000' }
       })
 
       it('saves the submitted option', async () => {
@@ -40,26 +40,27 @@ describe('Return Logs Setup - Submit Single Volume service', () => {
 
         const refreshedSession = await session.$query()
 
-        expect(refreshedSession.singleVolume).to.equal('no')
-      })
-
-      describe('and the user has previously selected "no" to a single volume being provided', () => {
-        it('returns the correct details the controller needs to redirect the journey', async () => {
-          const result = await SubmitSingleVolumeService.go(session.id, payload)
-
-          expect(result).to.equal({ singleVolume: 'no' })
-        })
+        expect(refreshedSession.singleVolume).to.equal('yes')
+        expect(refreshedSession.singleVolumeQuantity).to.equal(1000)
       })
 
       describe('and the user has previously selected "yes" to a single volume being provided', () => {
-        beforeEach(async () => {
-          payload = { singleVolume: 'yes', singleVolumeQuantity: '1000' }
-        })
-
         it('returns the correct details the controller needs to redirect the journey', async () => {
           const result = await SubmitSingleVolumeService.go(session.id, payload)
 
           expect(result).to.equal({ singleVolume: 'yes' })
+        })
+      })
+
+      describe('and the user has previously selected "no" to a single volume being provided', () => {
+        beforeEach(async () => {
+          payload = { singleVolume: 'no' }
+        })
+
+        it('returns the correct details the controller needs to redirect the journey', async () => {
+          const result = await SubmitSingleVolumeService.go(session.id, payload)
+
+          expect(result).to.equal({ singleVolume: 'no' })
         })
       })
     })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4852
https://github.com/DEFRA/water-abstraction-system/pull/1768

During work on the return log setup journey, it was noticed that user-entered data wasn't being saved to the session correctly. The data being saved incorrectly was saved as a string whereas we want it to be saved as a number. This PR is fixing one of the property's singleVolumeQuantity to be saved under the correct type.