### PR TITLE
Return logs check page - start reading

### DIFF
--- a/app/controllers/return-logs-setup.controller.js
+++ b/app/controllers/return-logs-setup.controller.js
@@ -248,12 +248,13 @@ async function submitReported(request, h) {
     return h.view('return-logs/setup/reported.njk', pageData)
   }
 
-  if (pageData.checkPageVisited) {
-    return h.redirect(`/system/return-logs/setup/${sessionId}/check`)
-  }
-
+  // If the user has selected 'Meter readings' we always redirect to the start-reading page
   if (pageData.reported === 'meter-readings') {
     return h.redirect(`/system/return-logs/setup/${sessionId}/start-reading`)
+  }
+
+  if (pageData.checkPageVisited) {
+    return h.redirect(`/system/return-logs/setup/${sessionId}/check`)
   }
 
   return h.redirect(`/system/return-logs/setup/${sessionId}/units`)

--- a/app/presenters/return-logs/setup/check.presenter.js
+++ b/app/presenters/return-logs/setup/check.presenter.js
@@ -89,6 +89,7 @@ function _alwaysRequiredPageData(session) {
       nilReturn: `/system/return-logs/setup/${sessionId}/submission`,
       received: `/system/return-logs/setup/${sessionId}/received`,
       reported: `/system/return-logs/setup/${sessionId}/reported`,
+      startReading: `/system/return-logs/setup/${sessionId}/start-reading`,
       units: `/system/return-logs/setup/${sessionId}/units`
     },
     nilReturn: journey === 'nil-return' ? 'Yes' : 'No',

--- a/app/views/return-logs/setup/check.njk
+++ b/app/views/return-logs/setup/check.njk
@@ -138,18 +138,18 @@
           }
         } if nilReturn === "No",
         {
-          key: { text: "Meter details" },
-          value: { html: meterDetails },
+          key: { text: "Start meter reading" },
+          value: { text: startReading },
           actions: {
             items: [
               {
-                href: links.meterDetails,
+                href: links.startReading,
                 text: "Change",
-                visuallyHiddenText: "meter details"
+                visuallyHiddenText: "start meter reading"
               }
             ]
           }
-        } if nilReturn === "No",
+        } if nilReturn === "No" and displayReadings,
         {
           key: { text: "Units" },
           value: { text: units },
@@ -159,6 +159,19 @@
                 href: links.units,
                 text: "Change",
                 visuallyHiddenText: "unit of measure"
+              }
+            ]
+          }
+        } if nilReturn === "No",
+        {
+          key: { text: "Meter details" },
+          value: { html: meterDetails },
+          actions: {
+            items: [
+              {
+                href: links.meterDetails,
+                text: "Change",
+                visuallyHiddenText: "meter details"
               }
             ]
           }

--- a/test/controllers/return-logs-setup.controller.test.js
+++ b/test/controllers/return-logs-setup.controller.test.js
@@ -411,28 +411,61 @@ describe('Return Logs - Setup - Controller', () => {
     describe('POST', () => {
       describe('when the request succeeds', () => {
         describe('and the page has not been visited previously', () => {
-          beforeEach(() => {
-            Sinon.stub(SubmitReportedService, 'go').resolves({})
+          describe('and "Meter readings" has been selected', () => {
+            beforeEach(() => {
+              Sinon.stub(SubmitReportedService, 'go').resolves({ reported: 'meter-readings' })
+            })
+
+            it('redirects to the "start-reading" page', async () => {
+              const response = await server.inject(_postOptions(path, {}))
+
+              expect(response.statusCode).to.equal(302)
+              expect(response.headers.location).to.equal(`/system/return-logs/setup/${sessionId}/start-reading`)
+            })
           })
 
-          it('redirects to the "units" page', async () => {
-            const response = await server.inject(_postOptions(path, {}))
+          describe('and "Abstraction Volumes" has been selected', () => {
+            beforeEach(() => {
+              Sinon.stub(SubmitReportedService, 'go').resolves({ reported: 'abstraction-volumes' })
+            })
 
-            expect(response.statusCode).to.equal(302)
-            expect(response.headers.location).to.equal(`/system/return-logs/setup/${sessionId}/units`)
+            it('redirects to the "units" page', async () => {
+              const response = await server.inject(_postOptions(path, {}))
+
+              expect(response.statusCode).to.equal(302)
+              expect(response.headers.location).to.equal(`/system/return-logs/setup/${sessionId}/units`)
+            })
           })
         })
 
         describe('and the page has been visited previously', () => {
-          beforeEach(() => {
-            Sinon.stub(SubmitReportedService, 'go').resolves({ checkPageVisited: true })
+          describe('and "Meter readings" has been selected', () => {
+            beforeEach(() => {
+              Sinon.stub(SubmitReportedService, 'go').resolves({ checkPageVisited: true, reported: 'meter-readings' })
+            })
+
+            it('redirects to the "start-reading" page', async () => {
+              const response = await server.inject(_postOptions(path, {}))
+
+              expect(response.statusCode).to.equal(302)
+              expect(response.headers.location).to.equal(`/system/return-logs/setup/${sessionId}/start-reading`)
+            })
           })
 
-          it('redirects to the "check" page', async () => {
-            const response = await server.inject(_postOptions(path, {}))
+          describe('and "Abstraction Volumes" has been selected', () => {
+            beforeEach(() => {
+              Sinon.stub(SubmitReportedService, 'go').resolves({
+                checkPageVisited: true,
+                reported: 'abstraction-volumes'
+              })
+            })
 
-            expect(response.statusCode).to.equal(302)
-            expect(response.headers.location).to.equal(`/system/return-logs/setup/${sessionId}/check`)
+            it('redirects to the "check" page', async () => {
+              const response = await server.inject(_postOptions(path, {}))
+
+              expect(response.statusCode).to.equal(302)
+              expect(response.headers.location).to.equal(`/system/return-logs/setup/${sessionId}/check`)
+            })
           })
         })
 

--- a/test/presenters/return-logs/setup/check.presenter.test.js
+++ b/test/presenters/return-logs/setup/check.presenter.test.js
@@ -31,6 +31,7 @@ describe('Return Logs Setup - Check presenter', () => {
           nilReturn: '/system/return-logs/setup/e840675e-9fb9-4ce1-bf0a-d140f5c57f47/submission',
           received: '/system/return-logs/setup/e840675e-9fb9-4ce1-bf0a-d140f5c57f47/received',
           reported: '/system/return-logs/setup/e840675e-9fb9-4ce1-bf0a-d140f5c57f47/reported',
+          startReading: '/system/return-logs/setup/e840675e-9fb9-4ce1-bf0a-d140f5c57f47/start-reading',
           units: '/system/return-logs/setup/e840675e-9fb9-4ce1-bf0a-d140f5c57f47/units'
         },
         meter10TimesDisplay: 'yes',
@@ -127,6 +128,7 @@ describe('Return Logs Setup - Check presenter', () => {
             nilReturn: '/system/return-logs/setup/e840675e-9fb9-4ce1-bf0a-d140f5c57f47/submission',
             received: '/system/return-logs/setup/e840675e-9fb9-4ce1-bf0a-d140f5c57f47/received',
             reported: '/system/return-logs/setup/e840675e-9fb9-4ce1-bf0a-d140f5c57f47/reported',
+            startReading: '/system/return-logs/setup/e840675e-9fb9-4ce1-bf0a-d140f5c57f47/start-reading',
             units: '/system/return-logs/setup/e840675e-9fb9-4ce1-bf0a-d140f5c57f47/units'
           },
           nilReturn: 'Yes',

--- a/test/services/return-logs/setup/check.service.test.js
+++ b/test/services/return-logs/setup/check.service.test.js
@@ -59,6 +59,7 @@ describe('Return Logs Setup - Check service', () => {
           nilReturn: `/system/return-logs/setup/${session.id}/submission`,
           received: `/system/return-logs/setup/${session.id}/received`,
           reported: `/system/return-logs/setup/${session.id}/reported`,
+          startReading: `/system/return-logs/setup/${session.id}/start-reading`,
           units: `/system/return-logs/setup/${session.id}/units`
         },
         meter10TimesDisplay: undefined,


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4806

This PR will focus on adding a "change" link to the "Enter the start meter reading" page in the "Reporting details" section of the "Return logs check" page. This will allow the user to navigate to the "Change meter reading" page to update the meter reading.

Originally, the start meter reading was part of the summary section of the "Return logs check" page and was intended to be entered after the user had arrived on the "check" page. However, since this data is always required when using meter readings, it has been moved so that the user has to enter the start reading before arriving on the check page.

I have also altered the route when the "Reporting figures" are changed. If changed to "Meter readings", the user will then be required to enter a start meter reading.