### PR TITLE
Add 'messageRef' to notifications setup scheduled notifications presenter

### DIFF
--- a/app/presenters/notifications/setup/scheduled-notifications.presenter.js
+++ b/app/presenters/notifications/setup/scheduled-notifications.presenter.js
@@ -86,7 +86,7 @@ function _email(recipient, returnsPeriod, referenceCode, journey) {
   return {
     licences: _licences(recipient.licence_refs),
     messageType,
-    messageRef: _messageRef(messageType, journey, recipient.contact_type),
+    messageRef: _messageRef(journey, messageType, recipient.contact_type),
     personalisation: {
       ..._returnsPeriod(returnsPeriod)
     },
@@ -142,7 +142,7 @@ function _letter(recipient, returnsPeriod, referenceCode, journey) {
   return {
     licences: _licences(recipient.licence_refs),
     messageType,
-    messageRef: _messageRef(messageType, journey, recipient.contact_type),
+    messageRef: _messageRef(journey, messageType, recipient.contact_type),
     personalisation: {
       name,
       ..._addressLines(recipient.contact),
@@ -197,27 +197,27 @@ function _licences(licenceRefs) {
  *
  * @private
  */
-function _messageRef(messageType, journey, contactType) {
+function _messageRef(journey, messageType, contactType) {
   const MESSAGE_REFS = {
-    email: {
-      invitations: {
+    invitations: {
+      email: {
         'Primary user': 'returns_invitation_primary_user_email',
         both: 'returns_invitation_primary_user_email',
         'Returns agent': 'returns_invitation_returns_agent_email'
       },
-      reminders: {
-        'Primary user': 'returns_reminder_primary_user_email',
-        both: 'returns_reminder_primary_user_email',
-        'Returns agent': 'returns_reminder_returns_agent_email'
-      }
-    },
-    letter: {
-      invitations: {
+      letter: {
         'Licence holder': 'returns_invitation_licence_holder_letter',
         both: 'returns_invitation_licence_holder_letter',
         'Returns to': 'returns_invitation_returns_to_letter'
+      }
+    },
+    reminders: {
+      email: {
+        'Primary user': 'returns_reminder_primary_user_email',
+        both: 'returns_reminder_primary_user_email',
+        'Returns agent': 'returns_reminder_returns_agent_email'
       },
-      reminders: {
+      letter: {
         'Licence holder': 'returns_reminder_licence_holder_letter',
         both: 'returns_reminder_licence_holder_letter',
         'Returns to': 'returns_reminder_returns_to_letter'
@@ -225,7 +225,7 @@ function _messageRef(messageType, journey, contactType) {
     }
   }
 
-  return MESSAGE_REFS[messageType][journey][contactType]
+  return MESSAGE_REFS[journey][messageType][contactType]
 }
 
 module.exports = {

--- a/test/presenters/notifications/setup/scheduled-notifications.presenter.test.js
+++ b/test/presenters/notifications/setup/scheduled-notifications.presenter.test.js
@@ -45,6 +45,7 @@ describe('Notifications Setup - Scheduled Notifications Presenter', () => {
     expect(result).to.equal([
       {
         licences: `["${recipients.primaryUser.licence_refs}"]`,
+        messageRef: 'returns_invitation_primary_user_email',
         messageType: 'email',
         personalisation: {
           periodEndDate: '31 March 2025',
@@ -57,6 +58,7 @@ describe('Notifications Setup - Scheduled Notifications Presenter', () => {
       },
       {
         licences: `["${recipients.returnsAgent.licence_refs}"]`,
+        messageRef: 'returns_invitation_returns_agent_email',
         messageType: 'email',
         personalisation: {
           periodEndDate: '31 March 2025',
@@ -69,6 +71,7 @@ describe('Notifications Setup - Scheduled Notifications Presenter', () => {
       },
       {
         licences: `["${recipients.licenceHolder.licence_refs}"]`,
+        messageRef: 'returns_invitation_licence_holder_letter',
         messageType: 'letter',
         personalisation: {
           address_line_1: '1',
@@ -86,6 +89,7 @@ describe('Notifications Setup - Scheduled Notifications Presenter', () => {
       },
       {
         licences: `["${recipients.returnsTo.licence_refs}"]`,
+        messageRef: 'returns_invitation_returns_to_letter',
         messageType: 'letter',
         personalisation: {
           address_line_1: '2',
@@ -103,6 +107,7 @@ describe('Notifications Setup - Scheduled Notifications Presenter', () => {
       },
       {
         licences: `["${firstMultiple}","${secondMultiple}"]`,
+        messageRef: 'returns_invitation_licence_holder_letter',
         messageType: 'letter',
         personalisation: {
           address_line_1: '3',
@@ -143,6 +148,7 @@ describe('Notifications Setup - Scheduled Notifications Presenter', () => {
           expect(result).to.equal([
             {
               licences: `["${recipients.primaryUser.licence_refs}"]`,
+              messageRef: 'returns_invitation_primary_user_email',
               messageType: 'email',
               personalisation: {
                 periodEndDate: '31 March 2025',
@@ -173,6 +179,7 @@ describe('Notifications Setup - Scheduled Notifications Presenter', () => {
           expect(result).to.equal([
             {
               licences: `["${recipients.returnsAgent.licence_refs}"]`,
+              messageRef: 'returns_invitation_returns_agent_email',
               messageType: 'email',
               personalisation: {
                 periodEndDate: '31 March 2025',
@@ -203,6 +210,7 @@ describe('Notifications Setup - Scheduled Notifications Presenter', () => {
           expect(result).to.equal([
             {
               licences: `["${recipients.primaryUser.licence_refs}"]`,
+              messageRef: 'returns_invitation_primary_user_email',
               messageType: 'email',
               personalisation: {
                 periodEndDate: '31 March 2025',
@@ -235,6 +243,7 @@ describe('Notifications Setup - Scheduled Notifications Presenter', () => {
           expect(result).to.equal([
             {
               licences: `["${recipients.licenceHolder.licence_refs}"]`,
+              messageRef: 'returns_invitation_licence_holder_letter',
               messageType: 'letter',
               personalisation: {
                 address_line_1: '1',
@@ -270,6 +279,7 @@ describe('Notifications Setup - Scheduled Notifications Presenter', () => {
           expect(result).to.equal([
             {
               licences: `["${recipients.returnsTo.licence_refs}"]`,
+              messageRef: 'returns_invitation_returns_to_letter',
               messageType: 'letter',
               personalisation: {
                 address_line_1: '2',
@@ -305,6 +315,7 @@ describe('Notifications Setup - Scheduled Notifications Presenter', () => {
           expect(result).to.equal([
             {
               licences: `["${recipients.licenceHolder.licence_refs}"]`,
+              messageRef: 'returns_invitation_licence_holder_letter',
               messageType: 'letter',
               personalisation: {
                 address_line_1: '1',
@@ -348,6 +359,7 @@ describe('Notifications Setup - Scheduled Notifications Presenter', () => {
           expect(result).to.equal([
             {
               licences: `["${recipients.primaryUser.licence_refs}"]`,
+              messageRef: 'returns_reminder_primary_user_email',
               messageType: 'email',
               personalisation: {
                 periodEndDate: '31 March 2025',
@@ -378,6 +390,7 @@ describe('Notifications Setup - Scheduled Notifications Presenter', () => {
           expect(result).to.equal([
             {
               licences: `["${recipients.returnsAgent.licence_refs}"]`,
+              messageRef: 'returns_reminder_returns_agent_email',
               messageType: 'email',
               personalisation: {
                 periodEndDate: '31 March 2025',
@@ -408,6 +421,7 @@ describe('Notifications Setup - Scheduled Notifications Presenter', () => {
           expect(result).to.equal([
             {
               licences: `["${recipients.primaryUser.licence_refs}"]`,
+              messageRef: 'returns_reminder_primary_user_email',
               messageType: 'email',
               personalisation: {
                 periodEndDate: '31 March 2025',
@@ -440,6 +454,7 @@ describe('Notifications Setup - Scheduled Notifications Presenter', () => {
           expect(result).to.equal([
             {
               licences: `["${recipients.licenceHolder.licence_refs}"]`,
+              messageRef: 'returns_reminder_licence_holder_letter',
               messageType: 'letter',
               personalisation: {
                 address_line_1: '1',
@@ -475,6 +490,7 @@ describe('Notifications Setup - Scheduled Notifications Presenter', () => {
           expect(result).to.equal([
             {
               licences: `["${recipients.returnsTo.licence_refs}"]`,
+              messageRef: 'returns_reminder_returns_to_letter',
               messageType: 'letter',
               personalisation: {
                 address_line_1: '2',
@@ -510,6 +526,7 @@ describe('Notifications Setup - Scheduled Notifications Presenter', () => {
           expect(result).to.equal([
             {
               licences: `["${recipients.licenceHolder.licence_refs}"]`,
+              messageRef: 'returns_reminder_licence_holder_letter',
               messageType: 'letter',
               personalisation: {
                 address_line_1: '1',


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4778

The legacy code has the concept of 'message_refs' found in 'water.scheduled_notification.message_ref'. This is used to group notifications by a unique type.

This column is used by the legacy code in multiple query's to retrieve notifications.

This changes adds a key map for these 'message_refs'.

As we have introduced the concept of 'both' for a 'contact_type' we use what we call the primary recipient for the 'message_ref'. When the licence is 'registered' we use the 'Primary user', when the licence is 'unregistered' we use the 'Licence holder'. This is consistent with other areas of our codebase (they use the same 'template_id').