### PR TITLE
Add 'issuer' to notification setup create event service

### DIFF
--- a/app/controllers/notifications-setup.controller.js
+++ b/app/controllers/notifications-setup.controller.js
@@ -99,9 +99,12 @@ async function submitCancel(request, h) {
 }
 
 async function submitCheck(request, h) {
-  const { sessionId } = request.params
+  const {
+    auth,
+    params: { sessionId }
+  } = request
 
-  SubmitCheckService.go(sessionId)
+  SubmitCheckService.go(sessionId, auth)
 
   return h.redirect(`/system/${basePath}/${sessionId}/confirmation`)
 }

--- a/app/presenters/notifications/setup/create-event.presenter.js
+++ b/app/presenters/notifications/setup/create-event.presenter.js
@@ -13,14 +13,16 @@ const { transformStringOfLicencesToArray } = require('../../../lib/general.lib.j
  *
  * @param {SessionModel} session
  * @param {object[]} recipients
+ * @param {object} auth - The auth object taken from `request.auth` containing user details
  *
  * @returns {object} - The data formatted for the view template
  */
-function go(session, recipients) {
+function go(session, recipients, auth) {
   const { referenceCode, determinedReturnsPeriod, journey, removeLicences = [] } = session
 
   return {
     licences: _licences(recipients),
+    issuer: auth.credentials.user.username,
     metadata: {
       name: _name(journey),
       options: {

--- a/app/services/notifications/setup/submit-check.service.js
+++ b/app/services/notifications/setup/submit-check.service.js
@@ -19,9 +19,10 @@ const { currentTimeInNanoseconds, calculateAndLogTimeTaken } = require('../../..
  * This service will transform the recipients into notifications and start processing notifications.
  *
  * @param {string} sessionId - The UUID for the notification setup session record
+ * @param {object} auth - The auth object taken from `request.auth` containing user details
  *
  */
-async function go(sessionId) {
+async function go(sessionId, auth) {
   try {
     const startTime = currentTimeInNanoseconds()
 
@@ -29,7 +30,7 @@ async function go(sessionId) {
 
     const recipients = await _recipients(session)
 
-    await _event(session, recipients)
+    await _event(session, recipients, auth)
 
     _notifications(session, recipients)
 
@@ -39,8 +40,8 @@ async function go(sessionId) {
   }
 }
 
-async function _event(session, recipients) {
-  const event = CreateEventPresenter.go(session, recipients)
+async function _event(session, recipients, auth) {
+  const event = CreateEventPresenter.go(session, recipients, auth)
 
   return CreateEventService.go(event)
 }

--- a/test/presenters/notifications/setup/create-event.presenter.test.js
+++ b/test/presenters/notifications/setup/create-event.presenter.test.js
@@ -14,8 +14,9 @@ const RecipientsFixture = require('../../../fixtures/recipients.fixtures.js')
 const CreateEventPresenter = require('../../../../app/presenters/notifications/setup/create-event.presenter.js')
 
 describe('Notifications Setup - Event presenter', () => {
-  let session
+  let auth
   let recipients
+  let session
   let testRecipients
 
   beforeEach(async () => {
@@ -34,14 +35,23 @@ describe('Notifications Setup - Event presenter', () => {
         summer: 'true'
       }
     }
+
+    auth = {
+      credentials: {
+        user: {
+          username: 'hello@world.com'
+        }
+      }
+    }
   })
 
   it('correctly presents the data', () => {
-    const result = CreateEventPresenter.go(session, testRecipients)
+    const result = CreateEventPresenter.go(session, testRecipients, auth)
 
     const [firstMultiple, secondMultiple] = recipients.licenceHolderWithMultipleLicences.licence_refs.split(',')
 
     expect(result).to.equal({
+      issuer: 'hello@world.com',
       licences:
         `["${recipients.primaryUser.licence_refs}","${recipients.returnsAgent.licence_refs}",` +
         `"${recipients.licenceHolder.licence_refs}","${recipients.returnsTo.licence_refs}",` +
@@ -65,9 +75,17 @@ describe('Notifications Setup - Event presenter', () => {
     })
   })
 
+  describe('the "issuer" property', () => {
+    it('correctly return the email address from the auth credentials', () => {
+      const result = CreateEventPresenter.go(session, testRecipients, auth)
+
+      expect(result.issuer).to.equal('hello@world.com')
+    })
+  })
+
   describe('the "licences" property', () => {
     it('correctly return a JSON string containing an array of all licences from all recipients', () => {
-      const result = CreateEventPresenter.go(session, testRecipients)
+      const result = CreateEventPresenter.go(session, testRecipients, auth)
 
       const [firstMultiple, secondMultiple] = recipients.licenceHolderWithMultipleLicences.licence_refs.split(',')
 
@@ -87,7 +105,7 @@ describe('Notifications Setup - Event presenter', () => {
         })
 
         it('correctly returns the exclude licences', () => {
-          const result = CreateEventPresenter.go(session, testRecipients)
+          const result = CreateEventPresenter.go(session, testRecipients, auth)
 
           expect(result.metadata.options.excludeLicences).to.equal(['123', '456'])
         })
@@ -99,7 +117,7 @@ describe('Notifications Setup - Event presenter', () => {
         })
 
         it('correctly returns the exclude licences', () => {
-          const result = CreateEventPresenter.go(session, testRecipients)
+          const result = CreateEventPresenter.go(session, testRecipients, auth)
 
           expect(result.metadata.options.excludeLicences).to.equal([])
         })
@@ -112,7 +130,7 @@ describe('Notifications Setup - Event presenter', () => {
       })
 
       it('correctly returns the length of recipients', () => {
-        const result = CreateEventPresenter.go(session, testRecipients)
+        const result = CreateEventPresenter.go(session, testRecipients, auth)
 
         expect(result.metadata.recipients).to.equal(5)
       })
@@ -129,7 +147,7 @@ describe('Notifications Setup - Event presenter', () => {
       })
 
       it('correctly returns the return cycle', () => {
-        const result = CreateEventPresenter.go(session, testRecipients)
+        const result = CreateEventPresenter.go(session, testRecipients, auth)
 
         expect(result.metadata.returnCycle).to.equal({
           dueDate: '2025-07-28',
@@ -147,13 +165,13 @@ describe('Notifications Setup - Event presenter', () => {
     })
 
     it('correctly sets the "metadata.name"', () => {
-      const result = CreateEventPresenter.go(session, testRecipients)
+      const result = CreateEventPresenter.go(session, testRecipients, auth)
 
       expect(result.metadata.name).to.equal('Returns: invitation')
     })
 
     it('correctly sets the "subtype"', () => {
-      const result = CreateEventPresenter.go(session, testRecipients)
+      const result = CreateEventPresenter.go(session, testRecipients, auth)
 
       expect(result.subtype).to.equal('returnInvitation')
     })
@@ -165,13 +183,13 @@ describe('Notifications Setup - Event presenter', () => {
     })
 
     it('correctly sets the "metadata.name"', () => {
-      const result = CreateEventPresenter.go(session, testRecipients)
+      const result = CreateEventPresenter.go(session, testRecipients, auth)
 
       expect(result.metadata.name).to.equal('Returns: reminder')
     })
 
     it('correctly sets the "subtype"', () => {
-      const result = CreateEventPresenter.go(session, testRecipients)
+      const result = CreateEventPresenter.go(session, testRecipients, auth)
 
       expect(result.subtype).to.equal('returnReminder')
     })
@@ -183,13 +201,13 @@ describe('Notifications Setup - Event presenter', () => {
     })
 
     it('correctly sets the "metadata.name"', () => {
-      const result = CreateEventPresenter.go(session, testRecipients)
+      const result = CreateEventPresenter.go(session, testRecipients, auth)
 
       expect(result.metadata.name).to.equal('')
     })
 
     it('correctly sets the "subtype"', () => {
-      const result = CreateEventPresenter.go(session, testRecipients)
+      const result = CreateEventPresenter.go(session, testRecipients, auth)
 
       expect(result.subtype).to.equal('')
     })

--- a/test/services/notifications/setup/submit-check.service.test.js
+++ b/test/services/notifications/setup/submit-check.service.test.js
@@ -21,6 +21,7 @@ const RecipientsService = require('../../../../app/services/notifications/setup/
 const SubmitCheckService = require('../../../../app/services/notifications/setup/submit-check.service.js')
 
 describe('Notifications Setup - Submit Check service', () => {
+  let auth
   let notifierStub
   let recipients
   let session
@@ -49,6 +50,14 @@ describe('Notifications Setup - Submit Check service', () => {
       }
     })
 
+    auth = {
+      credentials: {
+        user: {
+          username: 'hello@world.com'
+        }
+      }
+    }
+
     recipients = RecipientsFixture.recipients()
 
     Sinon.stub(CreateEventService, 'go').resolves()
@@ -62,15 +71,16 @@ describe('Notifications Setup - Submit Check service', () => {
   })
 
   it('correctly triggers the "DetermineRecipientsService"', async () => {
-    await SubmitCheckService.go(session.id)
+    await SubmitCheckService.go(session.id, auth)
 
     expect(DetermineRecipientsService.go.calledWith(testRecipients)).to.be.true()
   })
 
   it('correctly triggers the "CreateEventService"', async () => {
-    await SubmitCheckService.go(session.id)
+    await SubmitCheckService.go(session.id, auth)
 
     const expected = {
+      issuer: 'hello@world.com',
       licences: `["${testRecipients[0].licence_refs}"]`,
       metadata: {
         name: 'Returns: invitation',
@@ -94,7 +104,7 @@ describe('Notifications Setup - Submit Check service', () => {
   })
 
   it('should not throw an error', async () => {
-    await SubmitCheckService.go(session.id)
+    await SubmitCheckService.go(session.id, auth)
 
     expect(notifierStub.omfg.called).to.be.false()
   })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4778

When notifications are sent we need to store the 'issuer' this is taken from the signed-in users auth credentials.

This change add the 'issuer' to the create event logic and correctly stores the value in the database.