### PR TITLE
Update notifications setup scheduled notifications

### DIFF
--- a/app/presenters/notifications/setup/scheduled-notifications.presenter.js
+++ b/app/presenters/notifications/setup/scheduled-notifications.presenter.js
@@ -94,7 +94,8 @@ function _email(recipient, returnsPeriod, referenceCode, journey, eventId) {
     },
     recipient: recipient.email,
     reference: referenceCode,
-    sendAfter: _sendAfter(),
+    // NOTE: The legacy code uses the 'sendAfter' to know when a notification is sent.
+    sendAfter: timestampForPostgres(),
     templateId
   }
 }

--- a/app/presenters/notifications/setup/scheduled-notifications.presenter.js
+++ b/app/presenters/notifications/setup/scheduled-notifications.presenter.js
@@ -8,7 +8,7 @@
 const { contactName, contactAddress } = require('../../crm.presenter.js')
 const { formatLongDate } = require('../../base.presenter.js')
 const { notifyTemplates } = require('../../../lib/notify-templates.lib.js')
-const { transformStringOfLicencesToArray } = require('../../../lib/general.lib.js')
+const { transformStringOfLicencesToArray, timestampForPostgres } = require('../../../lib/general.lib.js')
 
 /**
  * Formats recipients into scheduled notifications for a returns invitation or reminder
@@ -94,6 +94,7 @@ function _email(recipient, returnsPeriod, referenceCode, journey, eventId) {
     },
     recipient: recipient.email,
     reference: referenceCode,
+    sendAfter: _sendAfter(),
     templateId
   }
 }
@@ -152,6 +153,7 @@ function _letter(recipient, returnsPeriod, referenceCode, journey, eventId) {
       ..._returnsPeriod(returnsPeriod)
     },
     reference: referenceCode,
+    sendAfter: _sendAfter(),
     templateId
   }
 }
@@ -229,6 +231,15 @@ function _messageRef(journey, messageType, contactType) {
   }
 
   return MESSAGE_REFS[journey][messageType][contactType]
+}
+
+/**
+ * The legacy code uses the 'sendAfter' to know when a notification is sent.
+ *
+ * @private
+ */
+function _sendAfter() {
+  return timestampForPostgres()
 }
 
 module.exports = {

--- a/app/presenters/notifications/setup/scheduled-notifications.presenter.js
+++ b/app/presenters/notifications/setup/scheduled-notifications.presenter.js
@@ -94,7 +94,6 @@ function _email(recipient, returnsPeriod, referenceCode, journey, eventId) {
     },
     recipient: recipient.email,
     reference: referenceCode,
-    // NOTE: The legacy code uses the 'sendAfter' to know when a notification is sent.
     sendAfter: timestampForPostgres(),
     templateId
   }
@@ -154,7 +153,6 @@ function _letter(recipient, returnsPeriod, referenceCode, journey, eventId) {
       ..._returnsPeriod(returnsPeriod)
     },
     reference: referenceCode,
-    // NOTE: The legacy code uses the 'sendAfter' to know when a notification is sent.
     sendAfter: timestampForPostgres(),
     templateId
   }

--- a/app/presenters/notifications/setup/scheduled-notifications.presenter.js
+++ b/app/presenters/notifications/setup/scheduled-notifications.presenter.js
@@ -233,15 +233,6 @@ function _messageRef(journey, messageType, contactType) {
   return MESSAGE_REFS[journey][messageType][contactType]
 }
 
-/**
- * The legacy code uses the 'sendAfter' to know when a notification is sent.
- *
- * @private
- */
-function _sendAfter() {
-  return timestampForPostgres()
-}
-
 module.exports = {
   go
 }

--- a/app/presenters/notifications/setup/scheduled-notifications.presenter.js
+++ b/app/presenters/notifications/setup/scheduled-notifications.presenter.js
@@ -153,7 +153,8 @@ function _letter(recipient, returnsPeriod, referenceCode, journey, eventId) {
       ..._returnsPeriod(returnsPeriod)
     },
     reference: referenceCode,
-    sendAfter: _sendAfter(),
+    // NOTE: The legacy code uses the 'sendAfter' to know when a notification is sent.
+    sendAfter: timestampForPostgres(),
     templateId
   }
 }

--- a/test/presenters/notifications/setup/scheduled-notifications.presenter.test.js
+++ b/test/presenters/notifications/setup/scheduled-notifications.presenter.test.js
@@ -3,8 +3,9 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
+const Sinon = require('sinon')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -18,6 +19,7 @@ describe('Notifications Setup - Scheduled Notifications Presenter', () => {
   const eventId = 'c1cae668-3dad-4806-94e2-eb3f27222ed9'
 
   let determinedReturnsPeriod
+  let clock
   let journey
   let recipients
   let testRecipients
@@ -36,6 +38,12 @@ describe('Notifications Setup - Scheduled Notifications Presenter', () => {
     recipients = RecipientsFixture.recipients()
 
     testRecipients = [...Object.values(recipients)]
+
+    clock = Sinon.useFakeTimers(new Date(`2025-01-01`))
+  })
+
+  afterEach(() => {
+    clock.restore()
   })
 
   it('correctly transform the recipients into notifications', () => {
@@ -62,6 +70,7 @@ describe('Notifications Setup - Scheduled Notifications Presenter', () => {
         },
         recipient: 'primary.user@important.com',
         reference: 'TEST-123',
+        sendAfter: '2025-01-01T00:00:00.000Z',
         templateId: '2fa7fc83-4df1-4f52-bccf-ff0faeb12b6f'
       },
       {
@@ -76,6 +85,7 @@ describe('Notifications Setup - Scheduled Notifications Presenter', () => {
         },
         reference: 'TEST-123',
         recipient: 'returns.agent@important.com',
+        sendAfter: '2025-01-01T00:00:00.000Z',
         templateId: '41c45bd4-8225-4d7e-a175-b48b613b5510'
       },
       {
@@ -95,6 +105,7 @@ describe('Notifications Setup - Scheduled Notifications Presenter', () => {
           returnDueDate: '28 April 2025'
         },
         reference: 'TEST-123',
+        sendAfter: '2025-01-01T00:00:00.000Z',
         templateId: '4fe80aed-c5dd-44c3-9044-d0289d635019'
       },
       {
@@ -114,6 +125,7 @@ describe('Notifications Setup - Scheduled Notifications Presenter', () => {
           returnDueDate: '28 April 2025'
         },
         reference: 'TEST-123',
+        sendAfter: '2025-01-01T00:00:00.000Z',
         templateId: '0e535549-99a2-44a9-84a7-589b12d00879'
       },
       {
@@ -133,6 +145,7 @@ describe('Notifications Setup - Scheduled Notifications Presenter', () => {
           returnDueDate: '28 April 2025'
         },
         reference: 'TEST-123',
+        sendAfter: '2025-01-01T00:00:00.000Z',
         templateId: '4fe80aed-c5dd-44c3-9044-d0289d635019'
       }
     ])
@@ -171,6 +184,7 @@ describe('Notifications Setup - Scheduled Notifications Presenter', () => {
               },
               recipient: 'primary.user@important.com',
               reference: 'TEST-123',
+              sendAfter: '2025-01-01T00:00:00.000Z',
               templateId: '2fa7fc83-4df1-4f52-bccf-ff0faeb12b6f'
             }
           ])
@@ -204,6 +218,7 @@ describe('Notifications Setup - Scheduled Notifications Presenter', () => {
               },
               recipient: 'returns.agent@important.com',
               reference: 'TEST-123',
+              sendAfter: '2025-01-01T00:00:00.000Z',
               templateId: '41c45bd4-8225-4d7e-a175-b48b613b5510'
             }
           ])
@@ -237,6 +252,7 @@ describe('Notifications Setup - Scheduled Notifications Presenter', () => {
               },
               recipient: 'primary.user@important.com',
               reference: 'TEST-123',
+              sendAfter: '2025-01-01T00:00:00.000Z',
               templateId: '2fa7fc83-4df1-4f52-bccf-ff0faeb12b6f'
             }
           ])
@@ -277,6 +293,7 @@ describe('Notifications Setup - Scheduled Notifications Presenter', () => {
                 returnDueDate: '28 April 2025'
               },
               reference: 'TEST-123',
+              sendAfter: '2025-01-01T00:00:00.000Z',
               templateId: '4fe80aed-c5dd-44c3-9044-d0289d635019'
             }
           ])
@@ -315,6 +332,7 @@ describe('Notifications Setup - Scheduled Notifications Presenter', () => {
                 returnDueDate: '28 April 2025'
               },
               reference: 'TEST-123',
+              sendAfter: '2025-01-01T00:00:00.000Z',
               templateId: '0e535549-99a2-44a9-84a7-589b12d00879'
             }
           ])
@@ -353,6 +371,7 @@ describe('Notifications Setup - Scheduled Notifications Presenter', () => {
                 returnDueDate: '28 April 2025'
               },
               reference: 'TEST-123',
+              sendAfter: '2025-01-01T00:00:00.000Z',
               templateId: '4fe80aed-c5dd-44c3-9044-d0289d635019'
             }
           ])
@@ -394,6 +413,7 @@ describe('Notifications Setup - Scheduled Notifications Presenter', () => {
               },
               recipient: 'primary.user@important.com',
               reference: 'TEST-123',
+              sendAfter: '2025-01-01T00:00:00.000Z',
               templateId: 'f1144bc7-8bdc-4e82-87cb-1a6c69445836'
             }
           ])
@@ -427,6 +447,7 @@ describe('Notifications Setup - Scheduled Notifications Presenter', () => {
               },
               recipient: 'returns.agent@important.com',
               reference: 'TEST-123',
+              sendAfter: '2025-01-01T00:00:00.000Z',
               templateId: '038e1807-d1b5-4f09-a5a6-d7eee9030a7a'
             }
           ])
@@ -460,6 +481,7 @@ describe('Notifications Setup - Scheduled Notifications Presenter', () => {
               },
               recipient: 'primary.user@important.com',
               reference: 'TEST-123',
+              sendAfter: '2025-01-01T00:00:00.000Z',
               templateId: 'f1144bc7-8bdc-4e82-87cb-1a6c69445836'
             }
           ])
@@ -500,6 +522,7 @@ describe('Notifications Setup - Scheduled Notifications Presenter', () => {
                 returnDueDate: '28 April 2025'
               },
               reference: 'TEST-123',
+              sendAfter: '2025-01-01T00:00:00.000Z',
               templateId: 'c01c808b-094b-4a3a-ab9f-a6e86bad36ba'
             }
           ])
@@ -538,6 +561,7 @@ describe('Notifications Setup - Scheduled Notifications Presenter', () => {
                 returnDueDate: '28 April 2025'
               },
               reference: 'TEST-123',
+              sendAfter: '2025-01-01T00:00:00.000Z',
               templateId: 'e9f132c7-a550-4e18-a5c1-78375f07aa2d'
             }
           ])
@@ -576,6 +600,7 @@ describe('Notifications Setup - Scheduled Notifications Presenter', () => {
                 returnDueDate: '28 April 2025'
               },
               reference: 'TEST-123',
+              sendAfter: '2025-01-01T00:00:00.000Z',
               templateId: 'c01c808b-094b-4a3a-ab9f-a6e86bad36ba'
             }
           ])


### PR DESCRIPTION
 https://eaflood.atlassian.net/browse/WATER-4778

 The legacy ui uses a column 'send_after' in 'water.scheduled_notification.send_after' to track when a notification is set.

 This change adds this timestamp so we know then a notification is created and sent.

 The legacy code has a mechanism that uses this column to determine when to check the status of the notifications. We will turn this off in another change in the water-abstraction-service repo.