### PR TITLE
Return logs check page - enter links

### DIFF
--- a/app/presenters/return-logs/setup/check.presenter.js
+++ b/app/presenters/return-logs/setup/check.presenter.js
@@ -183,7 +183,7 @@ function _linkDetails(endDate, method, returnsFrequency, sessionId) {
   const yearMonth = `${endDate.getFullYear()}-${endDate.getMonth()}`
 
   return {
-    href: `/system/return-logs/setup/${sessionId}/${yearMonth}`,
+    href: `/system/return-logs/setup/${sessionId}/${linkTextMethod}/${yearMonth}`,
     text
   }
 }

--- a/test/presenters/return-logs/setup/check.presenter.test.js
+++ b/test/presenters/return-logs/setup/check.presenter.test.js
@@ -77,7 +77,7 @@ describe('Return Logs Setup - Check presenter', () => {
           rows: [
             {
               link: {
-                href: '/system/return-logs/setup/e840675e-9fb9-4ce1-bf0a-d140f5c57f47/2023-3',
+                href: '/system/return-logs/setup/e840675e-9fb9-4ce1-bf0a-d140f5c57f47/volumes/2023-3',
                 text: 'Enter monthly volumes'
               },
               month: 'April 2023',
@@ -86,7 +86,7 @@ describe('Return Logs Setup - Check presenter', () => {
             },
             {
               link: {
-                href: '/system/return-logs/setup/e840675e-9fb9-4ce1-bf0a-d140f5c57f47/2023-4',
+                href: '/system/return-logs/setup/e840675e-9fb9-4ce1-bf0a-d140f5c57f47/volumes/2023-4',
                 text: 'Enter monthly volumes'
               },
               month: 'May 2023',
@@ -95,7 +95,7 @@ describe('Return Logs Setup - Check presenter', () => {
             },
             {
               link: {
-                href: '/system/return-logs/setup/e840675e-9fb9-4ce1-bf0a-d140f5c57f47/2023-5',
+                href: '/system/return-logs/setup/e840675e-9fb9-4ce1-bf0a-d140f5c57f47/volumes/2023-5',
                 text: 'Enter monthly volumes'
               },
               month: 'June 2023',
@@ -350,7 +350,7 @@ describe('Return Logs Setup - Check presenter', () => {
             expect(result.summaryTableData.rows).to.equal([
               {
                 link: {
-                  href: '/system/return-logs/setup/e840675e-9fb9-4ce1-bf0a-d140f5c57f47/2023-3',
+                  href: '/system/return-logs/setup/e840675e-9fb9-4ce1-bf0a-d140f5c57f47/volumes/2023-3',
                   text: 'Enter monthly volumes'
                 },
                 month: 'April 2023',
@@ -359,7 +359,7 @@ describe('Return Logs Setup - Check presenter', () => {
               },
               {
                 link: {
-                  href: '/system/return-logs/setup/e840675e-9fb9-4ce1-bf0a-d140f5c57f47/2023-4',
+                  href: '/system/return-logs/setup/e840675e-9fb9-4ce1-bf0a-d140f5c57f47/volumes/2023-4',
                   text: 'Enter monthly volumes'
                 },
                 month: 'May 2023',
@@ -368,7 +368,7 @@ describe('Return Logs Setup - Check presenter', () => {
               },
               {
                 link: {
-                  href: '/system/return-logs/setup/e840675e-9fb9-4ce1-bf0a-d140f5c57f47/2023-5',
+                  href: '/system/return-logs/setup/e840675e-9fb9-4ce1-bf0a-d140f5c57f47/volumes/2023-5',
                   text: 'Enter monthly volumes'
                 },
                 month: 'June 2023',
@@ -401,7 +401,7 @@ describe('Return Logs Setup - Check presenter', () => {
             expect(result.summaryTableData.rows).to.equal([
               {
                 link: {
-                  href: '/system/return-logs/setup/e840675e-9fb9-4ce1-bf0a-d140f5c57f47/2023-3',
+                  href: '/system/return-logs/setup/e840675e-9fb9-4ce1-bf0a-d140f5c57f47/volumes/2023-3',
                   text: 'Enter monthly volumes'
                 },
                 month: 'April 2023',
@@ -410,7 +410,7 @@ describe('Return Logs Setup - Check presenter', () => {
               },
               {
                 link: {
-                  href: '/system/return-logs/setup/e840675e-9fb9-4ce1-bf0a-d140f5c57f47/2023-4',
+                  href: '/system/return-logs/setup/e840675e-9fb9-4ce1-bf0a-d140f5c57f47/volumes/2023-4',
                   text: 'Enter monthly volumes'
                 },
                 month: 'May 2023',
@@ -419,7 +419,7 @@ describe('Return Logs Setup - Check presenter', () => {
               },
               {
                 link: {
-                  href: '/system/return-logs/setup/e840675e-9fb9-4ce1-bf0a-d140f5c57f47/2023-5',
+                  href: '/system/return-logs/setup/e840675e-9fb9-4ce1-bf0a-d140f5c57f47/volumes/2023-5',
                   text: 'Enter monthly volumes'
                 },
                 month: 'June 2023',
@@ -474,7 +474,7 @@ describe('Return Logs Setup - Check presenter', () => {
             expect(result.summaryTableData.rows).to.equal([
               {
                 link: {
-                  href: '/system/return-logs/setup/e840675e-9fb9-4ce1-bf0a-d140f5c57f47/2023-3',
+                  href: '/system/return-logs/setup/e840675e-9fb9-4ce1-bf0a-d140f5c57f47/volumes/2023-3',
                   text: 'Enter daily volumes'
                 },
                 month: 'April 2023',
@@ -507,7 +507,7 @@ describe('Return Logs Setup - Check presenter', () => {
             expect(result.summaryTableData.rows).to.equal([
               {
                 link: {
-                  href: '/system/return-logs/setup/e840675e-9fb9-4ce1-bf0a-d140f5c57f47/2023-3',
+                  href: '/system/return-logs/setup/e840675e-9fb9-4ce1-bf0a-d140f5c57f47/volumes/2023-3',
                   text: 'Enter daily volumes'
                 },
                 month: 'April 2023',
@@ -570,7 +570,7 @@ describe('Return Logs Setup - Check presenter', () => {
             expect(result.summaryTableData.rows).to.equal([
               {
                 link: {
-                  href: '/system/return-logs/setup/e840675e-9fb9-4ce1-bf0a-d140f5c57f47/2023-3',
+                  href: '/system/return-logs/setup/e840675e-9fb9-4ce1-bf0a-d140f5c57f47/readings/2023-3',
                   text: 'Enter monthly readings'
                 },
                 month: 'April 2023',
@@ -580,7 +580,7 @@ describe('Return Logs Setup - Check presenter', () => {
               },
               {
                 link: {
-                  href: '/system/return-logs/setup/e840675e-9fb9-4ce1-bf0a-d140f5c57f47/2023-4',
+                  href: '/system/return-logs/setup/e840675e-9fb9-4ce1-bf0a-d140f5c57f47/readings/2023-4',
                   text: 'Enter monthly readings'
                 },
                 month: 'May 2023',
@@ -590,7 +590,7 @@ describe('Return Logs Setup - Check presenter', () => {
               },
               {
                 link: {
-                  href: '/system/return-logs/setup/e840675e-9fb9-4ce1-bf0a-d140f5c57f47/2023-5',
+                  href: '/system/return-logs/setup/e840675e-9fb9-4ce1-bf0a-d140f5c57f47/readings/2023-5',
                   text: 'Enter monthly readings'
                 },
                 month: 'June 2023',
@@ -612,7 +612,7 @@ describe('Return Logs Setup - Check presenter', () => {
               expect(result.summaryTableData.rows).to.equal([
                 {
                   link: {
-                    href: '/system/return-logs/setup/e840675e-9fb9-4ce1-bf0a-d140f5c57f47/2023-3',
+                    href: '/system/return-logs/setup/e840675e-9fb9-4ce1-bf0a-d140f5c57f47/readings/2023-3',
                     text: 'Enter monthly readings'
                   },
                   month: 'April 2023',
@@ -622,7 +622,7 @@ describe('Return Logs Setup - Check presenter', () => {
                 },
                 {
                   link: {
-                    href: '/system/return-logs/setup/e840675e-9fb9-4ce1-bf0a-d140f5c57f47/2023-4',
+                    href: '/system/return-logs/setup/e840675e-9fb9-4ce1-bf0a-d140f5c57f47/readings/2023-4',
                     text: 'Enter monthly readings'
                   },
                   month: 'May 2023',
@@ -632,7 +632,7 @@ describe('Return Logs Setup - Check presenter', () => {
                 },
                 {
                   link: {
-                    href: '/system/return-logs/setup/e840675e-9fb9-4ce1-bf0a-d140f5c57f47/2023-5',
+                    href: '/system/return-logs/setup/e840675e-9fb9-4ce1-bf0a-d140f5c57f47/readings/2023-5',
                     text: 'Enter monthly readings'
                   },
                   month: 'June 2023',
@@ -668,7 +668,7 @@ describe('Return Logs Setup - Check presenter', () => {
             expect(result.summaryTableData.rows).to.equal([
               {
                 link: {
-                  href: '/system/return-logs/setup/e840675e-9fb9-4ce1-bf0a-d140f5c57f47/2023-3',
+                  href: '/system/return-logs/setup/e840675e-9fb9-4ce1-bf0a-d140f5c57f47/readings/2023-3',
                   text: 'Enter monthly readings'
                 },
                 month: 'April 2023',
@@ -678,7 +678,7 @@ describe('Return Logs Setup - Check presenter', () => {
               },
               {
                 link: {
-                  href: '/system/return-logs/setup/e840675e-9fb9-4ce1-bf0a-d140f5c57f47/2023-4',
+                  href: '/system/return-logs/setup/e840675e-9fb9-4ce1-bf0a-d140f5c57f47/readings/2023-4',
                   text: 'Enter monthly readings'
                 },
                 month: 'May 2023',
@@ -688,7 +688,7 @@ describe('Return Logs Setup - Check presenter', () => {
               },
               {
                 link: {
-                  href: '/system/return-logs/setup/e840675e-9fb9-4ce1-bf0a-d140f5c57f47/2023-5',
+                  href: '/system/return-logs/setup/e840675e-9fb9-4ce1-bf0a-d140f5c57f47/readings/2023-5',
                   text: 'Enter monthly readings'
                 },
                 month: 'June 2023',
@@ -744,7 +744,7 @@ describe('Return Logs Setup - Check presenter', () => {
             expect(result.summaryTableData.rows).to.equal([
               {
                 link: {
-                  href: '/system/return-logs/setup/e840675e-9fb9-4ce1-bf0a-d140f5c57f47/2023-3',
+                  href: '/system/return-logs/setup/e840675e-9fb9-4ce1-bf0a-d140f5c57f47/readings/2023-3',
                   text: 'Enter daily readings'
                 },
                 month: 'April 2023',
@@ -779,7 +779,7 @@ describe('Return Logs Setup - Check presenter', () => {
             expect(result.summaryTableData.rows).to.equal([
               {
                 link: {
-                  href: '/system/return-logs/setup/e840675e-9fb9-4ce1-bf0a-d140f5c57f47/2023-3',
+                  href: '/system/return-logs/setup/e840675e-9fb9-4ce1-bf0a-d140f5c57f47/readings/2023-3',
                   text: 'Enter daily readings'
                 },
                 month: 'April 2023',


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4870

This PR will update the location that the enter volumes/readings links point to on the "Check details" page prior to work commencing on  tickets https://eaflood.atlassian.net/browse/WATER-4870 and https://eaflood.atlassian.net/browse/WATER-4813

Initially this link was designed to point to a single page that would handle both readings and volumes. But we think it would be better to split these out into their own separate pages.