### PR TITLE
Update notifications setup batch notifications to persist

### DIFF
--- a/test/services/notifications/setup/batch-notifications.service.test.js
+++ b/test/services/notifications/setup/batch-notifications.service.test.js
@@ -9,6 +9,7 @@ const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
+const EventHelper = require('../../../support/helpers/event.helper.js')
 const RecipientsFixture = require('../../../fixtures/recipients.fixtures.js')
 const { stubNotify } = require('../../../../config/notify.config.js')
 
@@ -19,15 +20,15 @@ const { NotifyClient } = require('notifications-node-client')
 const BatchNotificationsService = require('../../../../app/services/notifications/setup/batch-notifications.service.js')
 
 describe('Notifications Setup - Batch notifications service', () => {
-  const eventId = 'c1cae668-3dad-4806-94e2-eb3f27222ed9'
+  const referenceCode = 'RINV-123'
 
   let determinedReturnsPeriod
+  let eventId
   let journey
   let recipients
-  let referenceCode
   let testRecipients
 
-  beforeEach(() => {
+  beforeEach(async () => {
     determinedReturnsPeriod = {
       name: 'allYear',
       dueDate: '2025-04-28',
@@ -37,11 +38,18 @@ describe('Notifications Setup - Batch notifications service', () => {
     }
 
     journey = 'invitations'
-    referenceCode = 'RINV-123'
 
     recipients = RecipientsFixture.recipients()
 
     testRecipients = [...Object.values(recipients)]
+
+    const event = await EventHelper.add({
+      type: 'notification',
+      subtype: 'returnsInvitation',
+      referenceCode
+    })
+
+    eventId = event.id
   })
 
   afterEach(() => {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4778

When a notification has been sent to Notify we need to store the Notify response with our 'scheduled notification'.

This change adds persisting of the 'scheduled notification' to the batch notification service.

Some of the data used for the payload is not required when persisting and has been removed after it has been used from the 'scheduled notification' object.

This change improves the test to check the data going through the batch service is saved correctly.