### PR TITLE
Update notifications setup scheduled notification presenter

### DIFF
--- a/app/presenters/notifications/setup/scheduled-notifications.presenter.js
+++ b/app/presenters/notifications/setup/scheduled-notifications.presenter.js
@@ -97,7 +97,7 @@ function _email(recipient, returnsPeriod, referenceCode, journey, eventId) {
   const messageType = 'email'
 
   return {
-    ..._common(referenceCode, templateId, eventId, recipient),
+    ..._common(referenceCode, templateId, eventId),
     licences: _licences(recipient.licence_refs),
     messageType,
     messageRef: _messageRef(journey, messageType, recipient.contact_type),

--- a/app/presenters/notifications/setup/scheduled-notifications.presenter.js
+++ b/app/presenters/notifications/setup/scheduled-notifications.presenter.js
@@ -59,6 +59,17 @@ function _addressLines(contact) {
   return addressLines
 }
 
+function _common(referenceCode, templateId, eventId) {
+  const createdAt = timestampForPostgres()
+
+  return {
+    createdAt,
+    eventId,
+    reference: referenceCode,
+    sendAfter: createdAt,
+    templateId
+  }
+}
 /**
  * An email notification requires an email address alongside the expected payload:
  *
@@ -83,22 +94,17 @@ function _addressLines(contact) {
 function _email(recipient, returnsPeriod, referenceCode, journey, eventId) {
   const templateId = _emailTemplate(recipient.contact_type, journey)
 
-  const createdAt = timestampForPostgres()
   const messageType = 'email'
 
   return {
-    createdAt,
-    eventId,
+    ..._common(referenceCode, templateId, eventId, recipient),
     licences: _licences(recipient.licence_refs),
     messageType,
     messageRef: _messageRef(journey, messageType, recipient.contact_type),
     personalisation: {
       ..._returnsPeriod(returnsPeriod)
     },
-    recipient: recipient.email,
-    reference: referenceCode,
-    sendAfter: createdAt,
-    templateId
+    recipient: recipient.email
   }
 }
 
@@ -140,15 +146,12 @@ function _emailTemplate(contactType, journey) {
  */
 function _letter(recipient, returnsPeriod, referenceCode, journey, eventId) {
   const name = contactName(recipient.contact)
-
   const templateId = _letterTemplate(recipient.contact_type, journey)
 
-  const createdAt = timestampForPostgres()
   const messageType = 'letter'
 
   return {
-    createdAt,
-    eventId,
+    ..._common(referenceCode, templateId, eventId, recipient),
     licences: _licences(recipient.licence_refs),
     messageType,
     messageRef: _messageRef(journey, messageType, recipient.contact_type),
@@ -156,10 +159,7 @@ function _letter(recipient, returnsPeriod, referenceCode, journey, eventId) {
       name,
       ..._addressLines(recipient.contact),
       ..._returnsPeriod(returnsPeriod)
-    },
-    reference: referenceCode,
-    sendAfter: createdAt,
-    templateId
+    }
   }
 }
 

--- a/app/presenters/notifications/setup/scheduled-notifications.presenter.js
+++ b/app/presenters/notifications/setup/scheduled-notifications.presenter.js
@@ -151,7 +151,7 @@ function _letter(recipient, returnsPeriod, referenceCode, journey, eventId) {
   const messageType = 'letter'
 
   return {
-    ..._common(referenceCode, templateId, eventId, recipient),
+    ..._common(referenceCode, templateId, eventId),
     licences: _licences(recipient.licence_refs),
     messageType,
     messageRef: _messageRef(journey, messageType, recipient.contact_type),

--- a/app/presenters/notifications/setup/scheduled-notifications.presenter.js
+++ b/app/presenters/notifications/setup/scheduled-notifications.presenter.js
@@ -83,8 +83,11 @@ function _addressLines(contact) {
 function _email(recipient, returnsPeriod, referenceCode, journey, eventId) {
   const templateId = _emailTemplate(recipient.contact_type, journey)
 
+  const createdAt = timestampForPostgres()
   const messageType = 'email'
+
   return {
+    createdAt,
     eventId,
     licences: _licences(recipient.licence_refs),
     messageType,
@@ -94,7 +97,7 @@ function _email(recipient, returnsPeriod, referenceCode, journey, eventId) {
     },
     recipient: recipient.email,
     reference: referenceCode,
-    sendAfter: timestampForPostgres(),
+    sendAfter: createdAt,
     templateId
   }
 }
@@ -140,9 +143,11 @@ function _letter(recipient, returnsPeriod, referenceCode, journey, eventId) {
 
   const templateId = _letterTemplate(recipient.contact_type, journey)
 
+  const createdAt = timestampForPostgres()
   const messageType = 'letter'
 
   return {
+    createdAt,
     eventId,
     licences: _licences(recipient.licence_refs),
     messageType,
@@ -153,7 +158,7 @@ function _letter(recipient, returnsPeriod, referenceCode, journey, eventId) {
       ..._returnsPeriod(returnsPeriod)
     },
     reference: referenceCode,
-    sendAfter: timestampForPostgres(),
+    sendAfter: createdAt,
     templateId
   }
 }

--- a/test/presenters/notifications/setup/scheduled-notifications.presenter.test.js
+++ b/test/presenters/notifications/setup/scheduled-notifications.presenter.test.js
@@ -59,6 +59,7 @@ describe('Notifications Setup - Scheduled Notifications Presenter', () => {
 
     expect(result).to.equal([
       {
+        createdAt: '2025-01-01T00:00:00.000Z',
         eventId,
         licences: `["${recipients.primaryUser.licence_refs}"]`,
         messageRef: 'returns_invitation_primary_user_email',
@@ -74,6 +75,7 @@ describe('Notifications Setup - Scheduled Notifications Presenter', () => {
         templateId: '2fa7fc83-4df1-4f52-bccf-ff0faeb12b6f'
       },
       {
+        createdAt: '2025-01-01T00:00:00.000Z',
         eventId,
         licences: `["${recipients.returnsAgent.licence_refs}"]`,
         messageRef: 'returns_invitation_returns_agent_email',
@@ -89,6 +91,7 @@ describe('Notifications Setup - Scheduled Notifications Presenter', () => {
         templateId: '41c45bd4-8225-4d7e-a175-b48b613b5510'
       },
       {
+        createdAt: '2025-01-01T00:00:00.000Z',
         eventId,
         licences: `["${recipients.licenceHolder.licence_refs}"]`,
         messageRef: 'returns_invitation_licence_holder_letter',
@@ -109,6 +112,7 @@ describe('Notifications Setup - Scheduled Notifications Presenter', () => {
         templateId: '4fe80aed-c5dd-44c3-9044-d0289d635019'
       },
       {
+        createdAt: '2025-01-01T00:00:00.000Z',
         eventId,
         licences: `["${recipients.returnsTo.licence_refs}"]`,
         messageRef: 'returns_invitation_returns_to_letter',
@@ -129,6 +133,7 @@ describe('Notifications Setup - Scheduled Notifications Presenter', () => {
         templateId: '0e535549-99a2-44a9-84a7-589b12d00879'
       },
       {
+        createdAt: '2025-01-01T00:00:00.000Z',
         eventId,
         licences: `["${firstMultiple}","${secondMultiple}"]`,
         messageRef: 'returns_invitation_licence_holder_letter',
@@ -173,6 +178,7 @@ describe('Notifications Setup - Scheduled Notifications Presenter', () => {
 
           expect(result).to.equal([
             {
+              createdAt: '2025-01-01T00:00:00.000Z',
               eventId,
               licences: `["${recipients.primaryUser.licence_refs}"]`,
               messageRef: 'returns_invitation_primary_user_email',
@@ -207,6 +213,7 @@ describe('Notifications Setup - Scheduled Notifications Presenter', () => {
 
           expect(result).to.equal([
             {
+              createdAt: '2025-01-01T00:00:00.000Z',
               eventId,
               licences: `["${recipients.returnsAgent.licence_refs}"]`,
               messageRef: 'returns_invitation_returns_agent_email',
@@ -241,6 +248,7 @@ describe('Notifications Setup - Scheduled Notifications Presenter', () => {
 
           expect(result).to.equal([
             {
+              createdAt: '2025-01-01T00:00:00.000Z',
               eventId,
               licences: `["${recipients.primaryUser.licence_refs}"]`,
               messageRef: 'returns_invitation_primary_user_email',
@@ -277,6 +285,7 @@ describe('Notifications Setup - Scheduled Notifications Presenter', () => {
 
           expect(result).to.equal([
             {
+              createdAt: '2025-01-01T00:00:00.000Z',
               eventId,
               licences: `["${recipients.licenceHolder.licence_refs}"]`,
               messageRef: 'returns_invitation_licence_holder_letter',
@@ -316,6 +325,7 @@ describe('Notifications Setup - Scheduled Notifications Presenter', () => {
 
           expect(result).to.equal([
             {
+              createdAt: '2025-01-01T00:00:00.000Z',
               eventId,
               licences: `["${recipients.returnsTo.licence_refs}"]`,
               messageRef: 'returns_invitation_returns_to_letter',
@@ -355,6 +365,7 @@ describe('Notifications Setup - Scheduled Notifications Presenter', () => {
 
           expect(result).to.equal([
             {
+              createdAt: '2025-01-01T00:00:00.000Z',
               eventId,
               licences: `["${recipients.licenceHolder.licence_refs}"]`,
               messageRef: 'returns_invitation_licence_holder_letter',
@@ -402,6 +413,7 @@ describe('Notifications Setup - Scheduled Notifications Presenter', () => {
 
           expect(result).to.equal([
             {
+              createdAt: '2025-01-01T00:00:00.000Z',
               eventId,
               licences: `["${recipients.primaryUser.licence_refs}"]`,
               messageRef: 'returns_reminder_primary_user_email',
@@ -436,6 +448,7 @@ describe('Notifications Setup - Scheduled Notifications Presenter', () => {
 
           expect(result).to.equal([
             {
+              createdAt: '2025-01-01T00:00:00.000Z',
               eventId,
               licences: `["${recipients.returnsAgent.licence_refs}"]`,
               messageRef: 'returns_reminder_returns_agent_email',
@@ -470,6 +483,7 @@ describe('Notifications Setup - Scheduled Notifications Presenter', () => {
 
           expect(result).to.equal([
             {
+              createdAt: '2025-01-01T00:00:00.000Z',
               eventId,
               licences: `["${recipients.primaryUser.licence_refs}"]`,
               messageRef: 'returns_reminder_primary_user_email',
@@ -506,6 +520,7 @@ describe('Notifications Setup - Scheduled Notifications Presenter', () => {
 
           expect(result).to.equal([
             {
+              createdAt: '2025-01-01T00:00:00.000Z',
               eventId,
               licences: `["${recipients.licenceHolder.licence_refs}"]`,
               messageRef: 'returns_reminder_licence_holder_letter',
@@ -545,6 +560,7 @@ describe('Notifications Setup - Scheduled Notifications Presenter', () => {
 
           expect(result).to.equal([
             {
+              createdAt: '2025-01-01T00:00:00.000Z',
               eventId,
               licences: `["${recipients.returnsTo.licence_refs}"]`,
               messageRef: 'returns_reminder_returns_to_letter',
@@ -584,6 +600,7 @@ describe('Notifications Setup - Scheduled Notifications Presenter', () => {
 
           expect(result).to.equal([
             {
+              createdAt: '2025-01-01T00:00:00.000Z',
               eventId,
               licences: `["${recipients.licenceHolder.licence_refs}"]`,
               messageRef: 'returns_reminder_licence_holder_letter',


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4778

When a 'scheduled_notification' is saved to  'water.scheduled_notifications' there is a not null constraint on the table for the 'createdAt' column.

This is not defaulted so we need to manually set and pass this in.

This change updates the scheduled notification presenter to add the 'createdAt' field.