### PR TITLE
Fix TPT match & allocate for licence end b4 charge

### DIFF
--- a/app/services/bill-runs/match/fetch-charge-versions.service.js
+++ b/app/services/bill-runs/match/fetch-charge-versions.service.js
@@ -23,6 +23,7 @@ const Workflow = require('../../../models/workflow.model.js')
  * - have an end date on or after the start of the billing period
  * - not be linked to a licence in the workflow
  * - not be linked to a licence that 'ended' before the billing period
+ * - not be linked to a licence that 'ended' before its start date
  * - have a status of current
  * - be linked to a charge reference that is marked as two-part-tariff
  *
@@ -57,6 +58,15 @@ async function _fetch(regionId, billingPeriod, supplementary) {
     })
     .where((builder) => {
       builder.whereNull('licence.revokedDate').orWhere('licence.revokedDate', '>=', billingPeriod.startDate)
+    })
+    .where((builder) => {
+      builder.whereNull('licence.expiredDate').orWhereColumn('licence.expiredDate', '>=', 'chargeVersions.startDate')
+    })
+    .where((builder) => {
+      builder.whereNull('licence.lapsedDate').orWhereColumn('licence.lapsedDate', '>=', 'chargeVersions.startDate')
+    })
+    .where((builder) => {
+      builder.whereNull('licence.revokedDate').orWhereColumn('licence.revokedDate', '>=', 'chargeVersions.startDate')
     })
     .whereNotExists(
       Workflow.query()

--- a/test/services/bill-runs/match/fetch-charge-versions.service.test.js
+++ b/test/services/bill-runs/match/fetch-charge-versions.service.test.js
@@ -43,7 +43,7 @@ let otherChargeReference
 let otherLicence
 let supplementary
 
-describe('Fetch Charge Versions service', () => {
+describe('Bill Runs - Match - Fetch Charge Versions service', () => {
   const billingPeriod = {
     startDate: new Date('2023-04-01'),
     endDate: new Date('2024-03-31')
@@ -215,6 +215,30 @@ describe('Fetch Charge Versions service', () => {
         })
 
         chargeVersion = await ChargeVersionHelper.add({ licenceId: licence.id, licenceRef: licence.licenceRef })
+
+        chargeReference = await ChargeReferenceHelper.add({
+          adjustments: { s127: true },
+          chargeVersionId: chargeVersion.id,
+          chargeCategory: chargeCategory.id
+        })
+      })
+
+      it('returns no records', async () => {
+        const results = await FetchChargeVersionsService.go(region.id, billingPeriod)
+
+        expect(results).to.be.empty()
+      })
+    })
+
+    describe('because the licence ended (expired, lapsed or revoked) before the charge version starts', () => {
+      beforeEach(async () => {
+        licence = await LicenceHelper.add({ revokedDate: new Date('2023-06-01'), regionId: region.id })
+
+        chargeVersion = await ChargeVersionHelper.add({
+          licenceId: licence.id,
+          licenceRef: licence.licenceRef,
+          startDate: new Date('2023-07-01')
+        })
 
         chargeReference = await ChargeReferenceHelper.add({
           adjustments: { s127: true },


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4957

Whilst testing two-part tariff supplementary (see WATER-4201 ), we've found a scenario that causes the match & allocate step to error.

For example, licence 01/123 has the following charge versions (assume everything TPT that needs to be ticked is ticked!)

- 2022-04-01 to 2023-10-05 (abs period 1 Apr to 31 Mar)
- 2023-10-06 onwards (abs period 1 Apr to 31 Mar)

If we created a TPT bill run (annual or supplementary, it doesn't matter) for 2023-2024, the match & allocate engine will process both charge versions.

Now imagine, the licence gets revoked on 2023-08-01. To match charge versions to returns we have to work out the 'charge-period'. This is essentially the intersection of the charge version and licence dates, with the billing period.

In our example, there is no charge period for that second charge version: the licence ended before the charge version starts. This is the scenario the TPT billing engine, specifically the match & allocate engine, isn't handling.

This change updates it to handle this.