### PR TITLE
Fix return log download csv for meter readings

### DIFF
--- a/app/lib/transform-to-csv.lib.js
+++ b/app/lib/transform-to-csv.lib.js
@@ -61,7 +61,7 @@ function _transformValueToCSV(value) {
   }
 
   // Return integers and booleans as they are (not converted to a string)
-  if (Number.isInteger(value) || typeof value === 'boolean') {
+  if ((typeof value === 'number' && !Number.isNaN(value)) || typeof value === 'boolean') {
     return `${value}`
   }
 

--- a/app/services/return-logs/fetch-download-return-log.service.js
+++ b/app/services/return-logs/fetch-download-return-log.service.js
@@ -35,7 +35,7 @@ async function _fetch(returnLogId, version) {
         .orderBy('version', 'desc')
         .withGraphFetched('returnSubmissionLines')
         .modifyGraph('returnSubmissionLines', (returnSubmissionLinesBuilder) => {
-          returnSubmissionLinesBuilder.select(['id', 'startDate', 'quantity']).orderBy('startDate', 'asc')
+          returnSubmissionLinesBuilder.select(['id', 'startDate', 'endDate', 'quantity']).orderBy('startDate', 'asc')
         })
     })
 }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4860

During testing of [Download return log as CSV](https://github.com/DEFRA/water-abstraction-system/pull/1736), an error was encounter when attempting to download csv's for return logs marked meter reading. This was found to be because of the missing `endDate` value needed to apply readings against each return submission line.

This PR fixes the failing return log csv download.