### PR TITLE
Update notification setup batch notifications service test to work with live notify

### DIFF
--- a/db/migrations/legacy/20221108007033_water-scheduled-notification.js
+++ b/db/migrations/legacy/20221108007033_water-scheduled-notification.js
@@ -21,7 +21,7 @@ exports.up = function (knex) {
     table.string('medium')
     table.string('notify_id')
     table.string('notify_status')
-    table.string('plaintext')
+    table.text('plaintext')
     table.uuid('event_id')
     table.jsonb('metadata')
     table.bigint('status_checks')


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4778

We have made an effort to allow out notifications tests to function with the live notify service.

This change updates the batch notifications service test to allow this testing to occur.

We have updated the expected results to use the data stored in the database for the 'plaintext' and 'notifyId' as these are returned from notify, and we can not simulate them.

When testing the errors there was an issue with stubbing our 'NotifyService.sendEmail' to always reject. An update has been made to only reject on the first call. This improves the test by asserting that when an error with notify occurs our other 'scheduled notifications' are unaffected.

We also found an issue with the test database table 'scheduled_notification'. The 'plaintext' column was set to 'string'. This is too small for our use case as the 'plaintext' from Notify is larger than 255.