### PR TITLE
Add Notify status service

### DIFF
--- a/app/services/notify/notify-status.service.js
+++ b/app/services/notify/notify-status.service.js
@@ -1,7 +1,7 @@
 'use strict'
 
 /**
- * Get the status of a notifications from GOV.UK Notify
+ * Get the status of a notification from GOV.UK Notify
  * @module NotifyStatusService
  */
 
@@ -10,7 +10,7 @@ const NotifyClient = require('notifications-node-client').NotifyClient
 const config = require('../../../config/notify.config.js')
 
 /**
- * Get the status of a notifications from GOV.UK Notify
+ * Get the status of a notification from GOV.UK Notify
  *
  * https://docs.notifications.service.gov.uk/node.html#get-message-status
  *

--- a/app/services/notify/notify-status.service.js
+++ b/app/services/notify/notify-status.service.js
@@ -1,0 +1,45 @@
+'use strict'
+
+/**
+ * Get the status of a notifications from GOV.UK Notify
+ * @module NotifyStatusService
+ */
+
+const NotifyClient = require('notifications-node-client').NotifyClient
+
+const config = require('../../../config/notify.config.js')
+
+/**
+ * Get the status of a notifications from GOV.UK Notify
+ *
+ * https://docs.notifications.service.gov.uk/node.html#get-message-status
+ *
+ * @param {string} notificationId
+ *
+ * @returns {Promise<object>}
+ */
+async function go(notificationId) {
+  const notifyClient = new NotifyClient(config.apiKey)
+
+  return _statusById(notifyClient, notificationId)
+}
+
+async function _statusById(notifyClient, notificationId) {
+  try {
+    const response = await notifyClient.getNotificationById(notificationId)
+
+    return {
+      status: response.data.status
+    }
+  } catch (error) {
+    return {
+      status: error.status,
+      message: error.message,
+      errors: error.response.data.errors
+    }
+  }
+}
+
+module.exports = {
+  go
+}

--- a/test/services/notify/notify-status.service.test.js
+++ b/test/services/notify/notify-status.service.test.js
@@ -1,0 +1,95 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Test helpers
+const { NotifyClient } = require('notifications-node-client')
+const { stubNotify } = require('../../../config/notify.config.js')
+
+// Thing under test
+const NotifyStatusService = require('../../../app/services/notify/notify-status.service.js')
+
+describe('Notify - Status service', () => {
+  let notifyStub
+  let notificationId
+
+  beforeEach(() => {
+    // If you wish to test live notify replace this with a real notification id
+    notificationId = '5a714bec-4ca0-45ba-8edf-8fa37db09499'
+  })
+
+  afterEach(() => {
+    Sinon.restore()
+  })
+
+  describe('when the call to "notify" is successful', () => {
+    beforeEach(() => {
+      notifyStub = _stubSuccessfulNotify()
+    })
+
+    it('should call notify', async () => {
+      const result = await NotifyStatusService.go(notificationId)
+
+      expect(result).to.equal({
+        status: 'received'
+      })
+    })
+
+    if (stubNotify) {
+      it('should use the notify client', async () => {
+        await NotifyStatusService.go(notificationId)
+
+        expect(notifyStub.calledWith(notificationId)).to.equal(true)
+      })
+    }
+  })
+
+  describe('when the call to "notify" is unsuccessful', () => {
+    beforeEach(() => {
+      // This is a bad uuid and should not exist in notify
+      notificationId = '616d49cf-4a7e-4188-a7e4-682f1a41dd83'
+
+      notifyStub = _stubUnSuccessfulNotify()
+    })
+
+    it('should return an error', async () => {
+      const result = await NotifyStatusService.go(notificationId)
+
+      expect(result).to.equal({
+        status: 404,
+        message: 'Request failed with status code 404',
+        errors: [{ error: 'NoResultFound', message: 'No result found' }]
+      })
+    })
+  })
+})
+
+function _stubSuccessfulNotify() {
+  if (stubNotify) {
+    return Sinon.stub(NotifyClient.prototype, 'getNotificationById').resolves({
+      data: {
+        status: 'received'
+      }
+    })
+  }
+}
+
+function _stubUnSuccessfulNotify() {
+  if (stubNotify) {
+    return Sinon.stub(NotifyClient.prototype, 'getNotificationById').rejects({
+      status: 404,
+      message: 'Request failed with status code 404',
+      response: {
+        data: {
+          errors: [{ error: 'NoResultFound', message: 'No result found' }]
+        }
+      }
+    })
+  }
+}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4778

This change adds the 'NotifyStatusService' which checks the status of a single notification in notify.

Similar to previous Notify services it's tests can be used against the live GOV.UK Notify.

However, to do so would require a valid notification id stored with notify. As this would require the test to use one of our other Notify services (within the test itself) to create the notification it has been decided to have this as a manual step for the time being.