### PR TITLE
Add current financial year end function to dates lib

### DIFF
--- a/app/lib/dates.lib.js
+++ b/app/lib/dates.lib.js
@@ -51,7 +51,7 @@ function daysFromPeriod(periodStartDate, periodEndDate) {
  *
  * @returns {number} The year in which the financial year ends
  */
-function determineCurrentFinancialYearEnd(date) {
+function determineFinancialYearEnd(date) {
   let year = date.getFullYear()
 
   if (date.getMonth() >= APRIL) {

--- a/app/lib/dates.lib.js
+++ b/app/lib/dates.lib.js
@@ -338,7 +338,7 @@ function _cloneDate(dateToClone) {
 
 module.exports = {
   daysFromPeriod,
-  determineCurrentFinancialYearEnd,
+  determineFinancialYearEnd,
   determineEarliestDate,
   determineLatestDate,
   formatDateObjectToISO,

--- a/app/lib/dates.lib.js
+++ b/app/lib/dates.lib.js
@@ -47,7 +47,7 @@ function daysFromPeriod(periodStartDate, periodEndDate) {
  * The financial year runs from April 1st to March 31st. If the given date falls on or after April 1st,
  * the financial year end will be in the following calendar year. Otherwise, it remains in the current year.
  *
- * @param {Date} date - The date in the iso format 2001-01-01
+ * @param {Date} date - The date to determine the financial year for
  *
  * @returns {number} The year in which the financial year ends
  */

--- a/app/lib/dates.lib.js
+++ b/app/lib/dates.lib.js
@@ -5,6 +5,7 @@
  * @module DatesLib
  */
 
+const APRIL = 3
 const FEBRUARY = 2
 const LAST_DAY_OF_FEB_STANDARD_YEAR = 28
 const LAST_DAY_OF_FEB_LEAP_YEAR = 29
@@ -38,6 +39,26 @@ function daysFromPeriod(periodStartDate, periodEndDate) {
   }
 
   return days
+}
+
+/**
+ * Determine the current financial year end
+ *
+ * The financial year runs from April 1st to March 31st. If the given date falls on or after April 1st,
+ * the financial year end will be in the following calendar year. Otherwise, it remains in the current year.
+ *
+ * @param {Date} date - The date in the iso format 2001-01-01
+ *
+ * @returns {number} The year in which the financial year ends
+ */
+function determineCurrentFinancialYearEnd(date) {
+  let year = date.getFullYear()
+
+  if (date.getMonth() >= APRIL) {
+    year++
+  }
+
+  return year
 }
 
 /**
@@ -317,6 +338,7 @@ function _cloneDate(dateToClone) {
 
 module.exports = {
   daysFromPeriod,
+  determineCurrentFinancialYearEnd,
   determineEarliestDate,
   determineLatestDate,
   formatDateObjectToISO,

--- a/app/lib/dates.lib.js
+++ b/app/lib/dates.lib.js
@@ -42,7 +42,7 @@ function daysFromPeriod(periodStartDate, periodEndDate) {
 }
 
 /**
- * Determine the current financial year end
+ * Determine the financial year end for a given date
  *
  * The financial year runs from April 1st to March 31st. If the given date falls on or after April 1st,
  * the financial year end will be in the following calendar year. Otherwise, it remains in the current year.

--- a/app/presenters/licences/supplementary/mark-for-supplementary-billing.presenter.js
+++ b/app/presenters/licences/supplementary/mark-for-supplementary-billing.presenter.js
@@ -6,8 +6,8 @@
  */
 
 const { formatFinancialYear } = require('../../base.presenter.js')
+const { determineFinancialYearEnd } = require('../../../lib/dates.lib.js')
 
-const APRIL = 3
 const LAST_PRE_SROC_FINANCIAL_YEAR_END = 2022
 const PREVIOUS_SIX_YEARS = 6
 
@@ -28,21 +28,6 @@ function go(licence) {
 }
 
 /**
- * Determines the current financial year end based on the current date.
- * The financial year end is the end of March, so if the current month is April or later the end of the financial year
- * is the next calendar year. Otherwise it is the current year.
- */
-function _determineCurrentFinancialYearEnd() {
-  const currentDate = new Date()
-  const currentYear = currentDate.getFullYear()
-  const currentMonth = currentDate.getMonth()
-
-  const currentFinancialYearEnd = currentMonth >= APRIL ? currentYear + 1 : currentYear
-
-  return currentFinancialYearEnd
-}
-
-/**
  * Calculates and formats the last six financial years for display on the mark for supplementary billing page.
  *
  * When marking a licence for supplementary billing, financial years from 2023 onward (SROC billing)
@@ -51,7 +36,7 @@ function _determineCurrentFinancialYearEnd() {
  * covered by pre-SROC (up to six years).
  */
 function _yearsToDisplay() {
-  const currentFinancialYearEnd = _determineCurrentFinancialYearEnd()
+  const currentFinancialYearEnd = determineFinancialYearEnd(new Date())
   const lastSixFinancialYears = []
 
   for (let i = 0; i < PREVIOUS_SIX_YEARS; i++) {

--- a/app/services/licences/supplementary/determine-billing-years.service.js
+++ b/app/services/licences/supplementary/determine-billing-years.service.js
@@ -5,7 +5,7 @@
  * @module DetermineBillingYearsService
  */
 
-const { determineCurrentFinancialYearEnd } = require('../../../lib/dates.lib.js')
+const { determineFinancialYearEnd } = require('../../../lib/dates.lib.js')
 
 const LAST_PRE_SROC_FINANCIAL_YEAR_END = 2022
 
@@ -26,9 +26,9 @@ const LAST_PRE_SROC_FINANCIAL_YEAR_END = 2022
 function go(startDate, endDate) {
   const years = []
 
-  const startYear = determineCurrentFinancialYearEnd(startDate)
+  const startYear = determineFinancialYearEnd(startDate)
   // As some changes don't have an end date we need to take this into consideration
-  const endYear = determineCurrentFinancialYearEnd(endDate || new Date())
+  const endYear = determineFinancialYearEnd(endDate || new Date())
 
   for (let year = startYear; year <= endYear; year++) {
     // SROC supplementary billing started in the financial year 2022/2023. Anything before this year is not considered

--- a/app/services/licences/supplementary/determine-billing-years.service.js
+++ b/app/services/licences/supplementary/determine-billing-years.service.js
@@ -5,7 +5,8 @@
  * @module DetermineBillingYearsService
  */
 
-const APRIL = 3
+const { determineCurrentFinancialYearEnd } = require('../../../lib/dates.lib.js')
+
 const LAST_PRE_SROC_FINANCIAL_YEAR_END = 2022
 
 /**
@@ -25,9 +26,9 @@ const LAST_PRE_SROC_FINANCIAL_YEAR_END = 2022
 function go(startDate, endDate) {
   const years = []
 
-  const startYear = _adjustedFinancialYearEnd(startDate)
+  const startYear = determineCurrentFinancialYearEnd(startDate)
   // As some changes don't have an end date we need to take this into consideration
-  const endYear = _adjustedFinancialYearEnd(endDate || new Date())
+  const endYear = determineCurrentFinancialYearEnd(endDate || new Date())
 
   for (let year = startYear; year <= endYear; year++) {
     // SROC supplementary billing started in the financial year 2022/2023. Anything before this year is not considered
@@ -38,24 +39,6 @@ function go(startDate, endDate) {
   }
 
   return years
-}
-
-/**
- * When flagging a licence for the supplementary bill run, we need to consider which financial years have been
- * impacted by the change. We only care about the financial year ends. So if the startDate for a new chargeVersion is
- * `2022-05-31`, the financial year end is considered to be `2023` since the financial years run April to March. Same
- * goes for if a charge versions endDate is `2023-03-05`, the financial year end is `2023`.
- *
- * @private
- */
-function _adjustedFinancialYearEnd(date) {
-  let year = date.getFullYear()
-
-  if (date.getMonth() >= APRIL) {
-    year++
-  }
-
-  return year
 }
 
 module.exports = {

--- a/test/lib/dates.lib.test.js
+++ b/test/lib/dates.lib.test.js
@@ -42,7 +42,7 @@ describe('Dates lib', () => {
     })
   })
 
-  describe('determineCurrentFinancialYearEnd', () => {
+  describe('determineFinancialYearEnd', () => {
     let date
 
     describe('given a date starting on or after 1st April', () => {
@@ -51,7 +51,7 @@ describe('Dates lib', () => {
       })
 
       it('returns the correct financial year end', () => {
-        const result = DateLib.determineCurrentFinancialYearEnd(date)
+        const result = DateLib.determineFinancialYearEnd(date)
 
         expect(result).to.equal(2023)
       })
@@ -63,7 +63,7 @@ describe('Dates lib', () => {
       })
 
       it('returns the correct financial year end', () => {
-        const result = DateLib.determineCurrentFinancialYearEnd(date)
+        const result = DateLib.determineFinancialYearEnd(date)
 
         expect(result).to.equal(2022)
       })

--- a/test/lib/dates.lib.test.js
+++ b/test/lib/dates.lib.test.js
@@ -42,6 +42,34 @@ describe('Dates lib', () => {
     })
   })
 
+  describe('determineCurrentFinancialYearEnd', () => {
+    let date
+
+    describe('given a date starting on or after 1st April', () => {
+      before(async () => {
+        date = new Date('2022-04-01')
+      })
+
+      it('returns the correct financial year end', () => {
+        const result = DateLib.determineCurrentFinancialYearEnd(date)
+
+        expect(result).to.equal(2023)
+      })
+    })
+
+    describe('given a date starting before 1st April', () => {
+      before(async () => {
+        date = new Date('2022-02-21')
+      })
+
+      it('returns the correct financial year end', () => {
+        const result = DateLib.determineCurrentFinancialYearEnd(date)
+
+        expect(result).to.equal(2022)
+      })
+    })
+  })
+
   describe('determineEarliestDate', () => {
     let dates
 


### PR DESCRIPTION
While working on tickets that required calculating the current financial year end, we decided to move the related functions into dates.lib. This makes them easier to reuse and unit test. This PR implements that change.