### PR TITLE
Fix assigning bill run to TPT supplementary licences

### DIFF
--- a/app/services/bill-runs/assign-bill-run-to-licences.service.js
+++ b/app/services/bill-runs/assign-bill-run-to-licences.service.js
@@ -2,11 +2,11 @@
 
 /**
  * Assigns a bill run to licences with matching `LicenceSupplementaryYear` records
- * @module AssignBillRunToLicences
+ * @module AssignBillRunToLicencesService
  */
 
+const { db } = require('../../../db/db.js')
 const { timestampForPostgres } = require('../../lib/general.lib.js')
-const LicenceSupplementaryYearModel = require('../../models/licence-supplementary-year.model.js')
 
 /**
  * Assigns a bill run to licences with matching `LicenceSupplementaryYear` records
@@ -24,9 +24,13 @@ const LicenceSupplementaryYearModel = require('../../models/licence-supplementar
  * is made after a supplementary bill run is started.
  *
  * So, how do we make this happen? Each `licence_supplementary_year` record has a `bill_run_id` field. When we trigger
- * a supplementary bill run we use this service to assign the bill run ID to each record.
+ * a supplementary bill run we use this service to assign the bill run ID to each record where
  *
- * Then, if a licence changes again a new licence supplementary year record will be created, because the systems that
+ * - the licence is in the same region as the bill run
+ * - the financial year matches the one the bill run is for
+ * - the record has not already been assigned to another bill run
+ *
+ * Then, if a licence changes again a new licence supplementary year record can be created, because the systems that
  * manage this know to ignore those records with bill run IDs.
  *
  * If a licence is removed from a bill run, or the bill run is cancelled we'll remove the bill run ID. Else, when the
@@ -34,16 +38,45 @@ const LicenceSupplementaryYearModel = require('../../models/licence-supplementar
  * be considered 'processed' for supplementary billing.
  *
  * @param {string} billRunId - The UUID of the bill run to assign the licences to
- * @param {object} billingPeriod - An object representing the financial year the bills will be for
- * @param {boolean} twoPartTariff - Whether we are assigning two-part tariff supplementary years to the bill run
  */
-async function go(billRunId, billingPeriod, twoPartTariff) {
-  const financialYearEnd = billingPeriod.endDate.getFullYear()
+async function go(billRunId) {
+  const params = [billRunId, timestampForPostgres(), billRunId]
+  const query = `
+    UPDATE public.licence_supplementary_years lsy1 SET
+      bill_run_id = ?,
+      updated_at = ?
+    WHERE EXISTS(
+      SELECT
+        1
+      FROM
+        public.licence_supplementary_years lsy2
+      INNER JOIN public.licences l
+        ON l.id = lsy2.licence_id
+      INNER JOIN (
+        SELECT
+          br.id,
+          br.region_id,
+          br.to_financial_year_ending,
+          (CASE
+            WHEN br.batch_type = 'two_part_supplementary' THEN TRUE
+            ELSE FALSE
+          END) AS two_part_tariff
+        FROM
+          public.bill_runs br
+        WHERE
+          br.id = ?
+      ) bill_run
+        ON
+          bill_run.region_id = l.region_id
+          AND bill_run.to_financial_year_ending = lsy2.financial_year_end
+          AND bill_run.two_part_tariff = lsy2.two_part_tariff
+      WHERE
+        lsy1.id = lsy2.id
+        AND lsy2.bill_run_id IS NULL
+    );
+  `
 
-  await LicenceSupplementaryYearModel.query()
-    .patch({ billRunId, updatedAt: timestampForPostgres() })
-    .where('financialYearEnd', financialYearEnd)
-    .where('twoPartTariff', twoPartTariff)
+  await db.raw(query, params)
 }
 
 module.exports = {

--- a/app/services/bill-runs/tpt-supplementary/process-bill-run.service.js
+++ b/app/services/bill-runs/tpt-supplementary/process-bill-run.service.js
@@ -39,7 +39,7 @@ async function go(billRun, billingPeriods) {
 
     await _updateStatus(billRunId, 'processing')
 
-    await AssignBillRunToLicencesService.go(billRunId, billingPeriod, true)
+    await AssignBillRunToLicencesService.go(billRunId)
 
     const populated = await MatchAndAllocateService.go(billRun, billingPeriod)
 

--- a/test/services/bill-runs/assign-bill-run-to-licences.service.test.js
+++ b/test/services/bill-runs/assign-bill-run-to-licences.service.test.js
@@ -3,54 +3,180 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
-const Sinon = require('sinon')
 
 const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
-// Things we need to stub
-const LicenceSupplementaryYearModel = require('../../../app/models/licence-supplementary-year.model.js')
+// Test helpers
+const BillRunHelper = require('../../support/helpers/bill-run.helper.js')
+const { generateUUID } = require('../../../app/lib/general.lib.js')
+const LicenceHelper = require('../../support/helpers/licence.helper.js')
+const LicenceSupplementaryYearHelper = require('../../support/helpers/licence-supplementary-year.helper.js')
+const RegionHelper = require('../../support/helpers/region.helper.js')
 
 // Thing under test
 const AssignBillRunToLicencesService = require('../../../app/services/bill-runs/assign-bill-run-to-licences.service.js')
 
+// NOTE: These are declared outside the describe to make them accessible to our `_cleanUp()` function
+let billRun
+let assignedSameRegionAndYear
+let unassignedSameRegionAndYear
+let unassignedSameRegionDifferentYear
+let unassignedDifferentRegionSameYear
+let unassignedSameRegionAndYearNonTpt
+
 describe('Bill Runs - Assign Bill Run To Licences service', () => {
-  const billingPeriod = { startDate: new Date('2022-04-01'), endDate: new Date('2023-03-31') }
-  const billRunId = '091c3d3f-0328-4b10-b1a1-3eccf55416a0'
-  const twoPartTariff = true
+  let region
 
-  let licenceSupplementaryYearPatch
-  let licenceSupplementaryYearWhere
+  beforeEach(async () => {
+    region = RegionHelper.select()
 
-  beforeEach(() => {
-    licenceSupplementaryYearPatch = Sinon.stub().returnsThis()
-    licenceSupplementaryYearWhere = Sinon.stub().returnsThis()
-
-    Sinon.stub(LicenceSupplementaryYearModel, 'query').returns({
-      patch: licenceSupplementaryYearPatch,
-      where: licenceSupplementaryYearWhere
+    billRun = await BillRunHelper.add({
+      batchType: 'two_part_supplementary',
+      regionId: region.id,
+      scheme: 'sroc',
+      status: 'processing',
+      toFinancialYearEnding: 2024
     })
   })
 
-  afterEach(() => {
-    Sinon.restore()
+  afterEach(async () => {
+    await _cleanUp()
   })
 
-  describe('when called', () => {
-    it('assigns the bill run ID to the matching "LicenceSupplementaryYear" records', async () => {
-      await AssignBillRunToLicencesService.go(billRunId, billingPeriod, twoPartTariff)
+  describe('when the supplementary year records are unassigned', () => {
+    describe('and the financial year matches the bill run in progress', () => {
+      describe('and the type of supplementary is the same', () => {
+        describe('and the licences are for the same region as the bill run', () => {
+          beforeEach(async () => {
+            // Unassigned LSY for same year as bill run, and licence in same region as bill run
+            const licence = await LicenceHelper.add({ regionId: region.id })
+            const licenceSupplementaryYear = await LicenceSupplementaryYearHelper.add({
+              financialYearEnd: 2024,
+              licenceId: licence.id,
+              twoPartTariff: true
+            })
 
-      const patchArgs = licenceSupplementaryYearPatch.args[0][0]
+            unassignedSameRegionAndYear = { licence, licenceSupplementaryYear }
+          })
 
-      expect(patchArgs.billRunId).to.equal(billRunId)
+          it('assigns the bill run to the supplementary year records', async () => {
+            await AssignBillRunToLicencesService.go(billRun.id)
 
-      const financialYearWhereArgs = licenceSupplementaryYearWhere.firstCall.args
+            const result = await unassignedSameRegionAndYear.licenceSupplementaryYear.$query().select()
 
-      expect(financialYearWhereArgs).to.equal(['financialYearEnd', 2023])
+            expect(result.billRunId).to.equal(billRun.id)
+          })
+        })
 
-      const twoPartTariffWhereArgs = licenceSupplementaryYearWhere.secondCall.args
+        describe('but the licences are for a different region to the bill run', () => {
+          beforeEach(async () => {
+            // Unassigned LSY for same year as bill run, but licence in different region to bill run
+            const licence = await LicenceHelper.add({ regionId: generateUUID() })
+            const licenceSupplementaryYear = await LicenceSupplementaryYearHelper.add({
+              financialYearEnd: 2024,
+              licenceId: licence.id,
+              twoPartTariff: true
+            })
 
-      expect(twoPartTariffWhereArgs).to.equal(['twoPartTariff', true])
+            unassignedDifferentRegionSameYear = { licence, licenceSupplementaryYear }
+          })
+
+          it('does not assign the bill run to the supplementary year records', async () => {
+            await AssignBillRunToLicencesService.go(billRun.id)
+
+            const result = await unassignedDifferentRegionSameYear.licenceSupplementaryYear.$query().select()
+
+            expect(result.billRunId).not.to.equal(billRun.id)
+          })
+        })
+      })
+
+      describe('but the type of supplementary is different', () => {
+        beforeEach(async () => {
+          // Unassigned LSY for same year as bill run, and licence in same region as bill run, but is not two-part tariff
+          const licence = await LicenceHelper.add({ regionId: region.id })
+          const licenceSupplementaryYear = await LicenceSupplementaryYearHelper.add({
+            financialYearEnd: 2024,
+            licenceId: licence.id,
+            twoPartTariff: false
+          })
+
+          unassignedSameRegionAndYearNonTpt = { licence, licenceSupplementaryYear }
+        })
+
+        it('does not assign the bill run to the supplementary year records', async () => {
+          await AssignBillRunToLicencesService.go(billRun.id)
+
+          const result = await unassignedSameRegionAndYearNonTpt.licenceSupplementaryYear.$query().select()
+
+          expect(result.billRunId).not.to.equal(billRun.id)
+        })
+      })
+    })
+
+    describe('but the financial year is different to the bill run in progress', () => {
+      beforeEach(async () => {
+        // Unassigned LSY for different year to bill run, but licence in same region as bill run
+        const licence = await LicenceHelper.add({ regionId: region.id })
+        const licenceSupplementaryYear = await LicenceSupplementaryYearHelper.add({
+          financialYearEnd: 2023,
+          licenceId: licence.id,
+          twoPartTariff: true
+        })
+
+        unassignedSameRegionDifferentYear = { licence, licenceSupplementaryYear }
+      })
+
+      it('does not assign the bill run to the supplementary year records', async () => {
+        await AssignBillRunToLicencesService.go(billRun.id)
+
+        const result = await unassignedSameRegionDifferentYear.licenceSupplementaryYear.$query().select()
+
+        expect(result.billRunId).not.to.equal(billRun.id)
+      })
+    })
+  })
+
+  describe('when the supplementary year records are already assigned', () => {
+    beforeEach(async () => {
+      // Already assigned LSY for same year as bill run, and licence in same region as bill run
+      const licence = await LicenceHelper.add({ regionId: region.id })
+      const licenceSupplementaryYear = await LicenceSupplementaryYearHelper.add({
+        billRunId: 'e286f865-ebda-451b-89b6-4da947d6556b',
+        financialYearEnd: 2024,
+        licenceId: licence.id,
+        twoPartTariff: true
+      })
+
+      assignedSameRegionAndYear = { licence, licenceSupplementaryYear }
+    })
+
+    it('does not assign the bill run to the supplementary year records', async () => {
+      await AssignBillRunToLicencesService.go(billRun.id)
+
+      const result = await assignedSameRegionAndYear.licenceSupplementaryYear.$query().select()
+
+      expect(result.billRunId).not.to.equal(billRun.id)
     })
   })
 })
+
+async function _cleanUp() {
+  if (billRun) await billRun.$query().delete()
+
+  await _cleanUpEntry(assignedSameRegionAndYear)
+  await _cleanUpEntry(unassignedSameRegionAndYear)
+  await _cleanUpEntry(unassignedSameRegionDifferentYear)
+  await _cleanUpEntry(unassignedDifferentRegionSameYear)
+  await _cleanUpEntry(unassignedSameRegionAndYearNonTpt)
+}
+
+async function _cleanUpEntry(entry) {
+  if (!entry) {
+    return
+  }
+
+  if (entry.licence) await entry.licence.$query().delete()
+  if (entry.licenceSupplementaryYear) await entry.licence.$query().delete()
+}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4952

In [Handle credit-only TPT tariff supplementary bills](https://github.com/DEFRA/water-abstraction-system/pull/1804), we had to update how licences are assigned to a two-part tariff supplementary bill run. Previously, we assigned whatever licences the match & allocate engine picked up. But when we realised this excluded licences where the change had made them no longer two-part tariff, we had to amend it.

We updated `AssignBillRunToLicencesService` to assign the licence supplementary year records _before_ the match and allocate step and removed the 'licences' filter. We failed to include a filter that constrained the assignment to licences in the same region as the bill run! 🤦

This is causing two-part tariff supplementary to fall over because it is trying to send transactions to the Charging Module API where the region does not match the bill runs.

This change updates `AssignBillRunToLicencesService` to include that filter.