### PR TITLE
Add notification setup confirmation page

### DIFF
--- a/app/controllers/notifications-setup.controller.js
+++ b/app/controllers/notifications-setup.controller.js
@@ -7,6 +7,7 @@
 
 const AdHocLicenceService = require('../services/notifications/setup/ad-hoc-licence.service.js')
 const CancelService = require('../services/notifications/setup/cancel.service.js')
+const ConfirmationService = require('../services/notifications/setup/confirmation.service.js')
 const CheckService = require('../services/notifications/setup/check.service.js')
 const DownloadRecipientsService = require('../services/notifications/setup/download-recipients.service.js')
 const InitiateSessionService = require('../services/notifications/setup/initiate-session.service.js')
@@ -41,6 +42,14 @@ async function viewCancel(request, h) {
   const pageData = await CancelService.go(sessionId)
 
   return h.view(`${basePath}/cancel.njk`, pageData)
+}
+
+async function viewConfirmation(request, h) {
+  const { sessionId } = request.params
+
+  const pageData = await ConfirmationService.go(sessionId)
+
+  return h.view(`${basePath}/confirmation.njk`, pageData)
 }
 
 async function viewLicence(request, h) {
@@ -154,6 +163,7 @@ async function submitReturnsPeriod(request, h) {
 module.exports = {
   downloadRecipients,
   viewCancel,
+  viewConfirmation,
   viewLicence,
   viewCheck,
   viewRemoveLicences,

--- a/app/controllers/notifications-setup.controller.js
+++ b/app/controllers/notifications-setup.controller.js
@@ -45,9 +45,9 @@ async function viewCancel(request, h) {
 }
 
 async function viewConfirmation(request, h) {
-  const { sessionId } = request.params
+  const { eventId } = request.params
 
-  const pageData = await ConfirmationService.go(sessionId)
+  const pageData = await ConfirmationService.go(eventId)
 
   return h.view(`${basePath}/confirmation.njk`, pageData)
 }
@@ -113,9 +113,9 @@ async function submitCheck(request, h) {
     params: { sessionId }
   } = request
 
-  SubmitCheckService.go(sessionId, auth)
+  const eventId = await SubmitCheckService.go(sessionId, auth)
 
-  return h.redirect(`/system/${basePath}/${sessionId}/confirmation`)
+  return h.redirect(`/system/${basePath}/${eventId}/confirmation`)
 }
 
 async function submitLicence(request, h) {

--- a/app/presenters/notifications/setup/confirmation.presenter.js
+++ b/app/presenters/notifications/setup/confirmation.presenter.js
@@ -16,6 +16,7 @@ function go(event) {
   const { referenceCode, subtype, id: eventId } = event
 
   const type = _type(subtype)
+
   return {
     forwardLink: `/notifications/report/${eventId}`,
     pageTitle: `Returns ${type} sent`,

--- a/app/presenters/notifications/setup/confirmation.presenter.js
+++ b/app/presenters/notifications/setup/confirmation.presenter.js
@@ -1,26 +1,45 @@
 'use strict'
 
 /**
- * Formats data for the `/notifications/setup/{sessionId}/confirmation` page
+ * Formats data for the `/notifications/setup/{eventId}/confirmation` page
  * @module ConfirmationPresenter
  */
 
 /**
- * Formats data for the `/notifications/setup/{sessionId}/confirmation` page
+ * Formats data for the `/notifications/setup/{eventId}/confirmation` page
  *
- * @param {module:SessionModel} session - The session instance
+ * @param {module:EventModel} event
  *
  * @returns {object} - The data formatted for the view template
  */
-function go(session) {
-  const { referenceCode, journey } = session
+function go(event) {
+  const { referenceCode, subtype } = event
 
+  const type = _type(subtype)
   return {
     backLink: `/manage`,
     forwardLink: '/notifications/report',
-    pageTitle: `Returns ${journey} sent`,
+    pageTitle: `Returns ${type} sent`,
     referenceCode
   }
+}
+
+/**
+ * An Event 'subType' is a legacy code concept we have needed to adapt to conform to existing patterns.
+ *
+ * We convert our 'journey' keys into 'supTypes' when we create an event. As we have no access to the session for the
+ * confirmation page we need to remap these 'supTypes' into 'journey' keys to display to the user to keep conformity.
+ *
+ * @private
+ */
+function _type(subType) {
+  const subTypes = {
+    returnInvitation: 'invitations',
+    returnReminder: 'reminders',
+    adHoc: 'ad-hoc'
+  }
+
+  return subTypes[subType]
 }
 
 module.exports = {

--- a/app/presenters/notifications/setup/confirmation.presenter.js
+++ b/app/presenters/notifications/setup/confirmation.presenter.js
@@ -13,12 +13,11 @@
  * @returns {object} - The data formatted for the view template
  */
 function go(event) {
-  const { referenceCode, subtype } = event
+  const { referenceCode, subtype, id: eventId } = event
 
   const type = _type(subtype)
   return {
-    backLink: `/manage`,
-    forwardLink: '/notifications/report',
+    forwardLink: `/notifications/report/${eventId}`,
     pageTitle: `Returns ${type} sent`,
     referenceCode
   }

--- a/app/presenters/notifications/setup/confirmation.presenter.js
+++ b/app/presenters/notifications/setup/confirmation.presenter.js
@@ -1,0 +1,28 @@
+'use strict'
+
+/**
+ * Formats data for the `/notifications/setup/{sessionId}/confirmation` page
+ * @module ConfirmationPresenter
+ */
+
+/**
+ * Formats data for the `/notifications/setup/{sessionId}/confirmation` page
+ *
+ * @param {module:SessionModel} session - The session instance
+ *
+ * @returns {object} - The data formatted for the view template
+ */
+function go(session) {
+  const { referenceCode, journey } = session
+
+  return {
+    backLink: `/manage`,
+    forwardLink: '/notifications/report',
+    pageTitle: `Returns ${journey} sent`,
+    referenceCode
+  }
+}
+
+module.exports = {
+  go
+}

--- a/app/routes/notifications-setup.routes.js
+++ b/app/routes/notifications-setup.routes.js
@@ -103,7 +103,7 @@ const routes = [
   },
   {
     method: 'GET',
-    path: basePath + '/{sessionId}/confirmation',
+    path: basePath + '/{eventId}/confirmation',
     options: {
       handler: NotificationsSetupController.viewConfirmation,
       auth: {

--- a/app/routes/notifications-setup.routes.js
+++ b/app/routes/notifications-setup.routes.js
@@ -103,6 +103,18 @@ const routes = [
   },
   {
     method: 'GET',
+    path: basePath + '/{sessionId}/confirmation',
+    options: {
+      handler: NotificationsSetupController.viewConfirmation,
+      auth: {
+        access: {
+          scope: ['returns']
+        }
+      }
+    }
+  },
+  {
+    method: 'GET',
     path: basePath + '/{sessionId}/returns-period',
     options: {
       handler: NotificationsSetupController.viewReturnsPeriod,

--- a/app/services/notifications/setup/confirmation.service.js
+++ b/app/services/notifications/setup/confirmation.service.js
@@ -1,0 +1,31 @@
+'use strict'
+
+/**
+ * Orchestrates presenting the data for `/notifications/setup/{sessionId}/confirmation` page
+ * @module ConfirmationService
+ */
+
+const ConfirmationPresenter = require('../../../presenters/notifications/setup/confirmation.presenter.js')
+const SessionModel = require('../../../models/session.model.js')
+
+/**
+ * Orchestrates presenting the data for `/notifications/setup/{sessionId}/confirmation` page
+ *
+ * @param {string} sessionId - The UUID for the notification setup session record
+ *
+ * @returns {Promise<object>} The view data for the licence page
+ */
+async function go(sessionId) {
+  const session = await SessionModel.query().findById(sessionId)
+
+  const formattedData = ConfirmationPresenter.go(session)
+
+  return {
+    activeNavBar: 'manage',
+    ...formattedData
+  }
+}
+
+module.exports = {
+  go
+}

--- a/app/services/notifications/setup/confirmation.service.js
+++ b/app/services/notifications/setup/confirmation.service.js
@@ -1,29 +1,33 @@
 'use strict'
 
 /**
- * Orchestrates presenting the data for `/notifications/setup/{sessionId}/confirmation` page
+ * Orchestrates presenting the data for `/notifications/setup/{eventId}/confirmation` page
  * @module ConfirmationService
  */
 
 const ConfirmationPresenter = require('../../../presenters/notifications/setup/confirmation.presenter.js')
-const SessionModel = require('../../../models/session.model.js')
+const EventModel = require('../../../models/event.model.js')
 
 /**
- * Orchestrates presenting the data for `/notifications/setup/{sessionId}/confirmation` page
+ * Orchestrates presenting the data for `/notifications/setup/{eventId}/confirmation` page
  *
- * @param {string} sessionId - The UUID for the notification setup session record
+ * @param {string} eventId - The UUID for the event
  *
  * @returns {Promise<object>} The view data for the licence page
  */
-async function go(sessionId) {
-  const session = await SessionModel.query().findById(sessionId)
+async function go(eventId) {
+  const event = await _getEventId(eventId)
 
-  const formattedData = ConfirmationPresenter.go(session)
+  const formattedData = ConfirmationPresenter.go(event)
 
   return {
     activeNavBar: 'manage',
     ...formattedData
   }
+}
+
+async function _getEventId(eventId) {
+  return EventModel.query().findById(eventId)
 }
 
 module.exports = {

--- a/app/services/notifications/setup/confirmation.service.js
+++ b/app/services/notifications/setup/confirmation.service.js
@@ -16,7 +16,7 @@ const EventModel = require('../../../models/event.model.js')
  * @returns {Promise<object>} The view data for the licence page
  */
 async function go(eventId) {
-  const event = await _getEventId(eventId)
+  const event = await EventModel.query().findById(eventId)
 
   const formattedData = ConfirmationPresenter.go(event)
 
@@ -24,10 +24,6 @@ async function go(eventId) {
     activeNavBar: 'manage',
     ...formattedData
   }
-}
-
-async function _getEventId(eventId) {
-  return EventModel.query().findById(eventId)
 }
 
 module.exports = {

--- a/app/services/notifications/setup/submit-check.service.js
+++ b/app/services/notifications/setup/submit-check.service.js
@@ -21,23 +21,22 @@ const { currentTimeInNanoseconds, calculateAndLogTimeTaken } = require('../../..
  * @param {string} sessionId - The UUID for the notification setup session record
  * @param {object} auth - The auth object taken from `request.auth` containing user details
  *
+ * @returns {string} - the created eventId
  */
 async function go(sessionId, auth) {
-  try {
-    const startTime = currentTimeInNanoseconds()
+  const session = await SessionModel.query().findById(sessionId)
 
-    const session = await SessionModel.query().findById(sessionId)
+  const recipients = await _recipients(session)
 
-    const recipients = await _recipients(session)
+  const event = await _event(session, recipients, auth)
 
-    const { id: eventId } = await _event(session, recipients, auth)
+  const { determinedReturnsPeriod, referenceCode, journey } = session
 
-    await _notifications(session, recipients, eventId)
+  await session.$query().delete()
 
-    calculateAndLogTimeTaken(startTime, 'Send notifications complete', {})
-  } catch (error) {
-    global.GlobalNotifier.omfg('Send notifications failed', { sessionId }, error)
-  }
+  _processNotifications(determinedReturnsPeriod, referenceCode, journey, recipients, event)
+
+  return event.id
 }
 
 async function _event(session, recipients, auth) {
@@ -46,14 +45,16 @@ async function _event(session, recipients, auth) {
   return CreateEventService.go(event)
 }
 
-async function _notifications(session, recipients, eventId) {
-  return BatchNotificationsService.go(
-    recipients,
-    session.determinedReturnsPeriod,
-    session.referenceCode,
-    session.journey,
-    eventId
-  )
+async function _processNotifications(determinedReturnsPeriod, referenceCode, journey, recipients, event) {
+  try {
+    const startTime = currentTimeInNanoseconds()
+
+    await BatchNotificationsService.go(recipients, determinedReturnsPeriod, referenceCode, journey, event.id)
+
+    calculateAndLogTimeTaken(startTime, 'Send notifications complete', {})
+  } catch (error) {
+    global.GlobalNotifier.omfg('Send notifications failed', { event }, error)
+  }
 }
 
 async function _recipients(session) {

--- a/app/views/notifications/setup/confirmation.njk
+++ b/app/views/notifications/setup/confirmation.njk
@@ -1,5 +1,4 @@
 {% extends 'layout.njk' %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/panel/macro.njk" import govukPanel %}
 
 

--- a/app/views/notifications/setup/confirmation.njk
+++ b/app/views/notifications/setup/confirmation.njk
@@ -2,12 +2,6 @@
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/panel/macro.njk" import govukPanel %}
 
-{% block breadcrumbs %}
-  {{ govukBackLink({
-    text: 'Back',
-    href: backLink
-  }) }}
-{% endblock %}
 
 {% block content %}
   <div class="govuk-body">

--- a/app/views/notifications/setup/confirmation.njk
+++ b/app/views/notifications/setup/confirmation.njk
@@ -1,0 +1,21 @@
+{% extends 'layout.njk' %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/panel/macro.njk" import govukPanel %}
+
+{% block breadcrumbs %}
+  {{ govukBackLink({
+    text: 'Back',
+    href: backLink
+  }) }}
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-body">
+     {{ govukPanel({
+      titleText: pageTitle,
+      html: "Your reference number is <br><strong>" + referenceCode + "</strong>"
+    }) }}
+
+    <a class="govuk-link" href="{{ forwardLink }}">View notifications report</a>
+  </div>
+{% endblock %}

--- a/app/views/notifications/setup/confirmation.njk
+++ b/app/views/notifications/setup/confirmation.njk
@@ -11,7 +11,7 @@
 
 {% block content %}
   <div class="govuk-body">
-     {{ govukPanel({
+    {{ govukPanel({
       titleText: pageTitle,
       html: "Your reference number is <br><strong>" + referenceCode + "</strong>"
     }) }}

--- a/test/controllers/notifications-setup.controller.test.js
+++ b/test/controllers/notifications-setup.controller.test.js
@@ -518,7 +518,6 @@ function _viewCheck() {
 function _viewConfirmation() {
   return {
     activeNavBar: 'manage',
-    backLink: `/manage`,
     forwardLink: '/notifications/report',
     pageTitle: `Returns invitations sent`,
     referenceCode: 'RINV-CPFRQ4'

--- a/test/controllers/notifications-setup.controller.test.js
+++ b/test/controllers/notifications-setup.controller.test.js
@@ -152,6 +152,7 @@ describe('Notifications Setup controller', () => {
 
         beforeEach(async () => {
           eventId = '1233'
+
           Sinon.stub(SubmitCheckService, 'go').returns(eventId)
           postOptions = postRequestOptions(basePath + `/${session.id}/check`, {})
         })

--- a/test/controllers/notifications-setup.controller.test.js
+++ b/test/controllers/notifications-setup.controller.test.js
@@ -11,13 +11,14 @@ const { expect } = Code
 const { postRequestOptions } = require('../support/general.js')
 
 // Things we need to stub
+const CancelService = require('../../app/services/notifications/setup/cancel.service.js')
+const CheckService = require('../../app/services/notifications/setup/check.service.js')
+const ConfirmationService = require('../../app/services/notifications/setup/confirmation.service.js')
 const DownloadRecipientsService = require('../../app/services/notifications/setup/download-recipients.service.js')
 const InitiateSessionService = require('../../app/services/notifications/setup/initiate-session.service.js')
 const LicenceService = require('../../app/services/notifications/setup/ad-hoc-licence.service.js')
 const RemoveLicencesService = require('../../app/services/notifications/setup/remove-licences.service.js')
 const ReturnsPeriodService = require('../../app/services/notifications/setup/returns-period.service.js')
-const CancelService = require('../../app/services/notifications/setup/cancel.service.js')
-const CheckService = require('../../app/services/notifications/setup/check.service.js')
 const SubmitCancelService = require('../../app/services/notifications/setup/submit-cancel.service.js')
 const SubmitCheckService = require('../../app/services/notifications/setup/submit-check.service.js')
 const SubmitLicenceService = require('../../app/services/notifications/setup/submit-ad-hoc-licence.service.js')
@@ -157,6 +158,37 @@ describe('Notifications Setup controller', () => {
 
           expect(response.statusCode).to.equal(302)
           expect(response.headers.location).to.equal(`/system/notifications/setup/${session.id}/confirmation`)
+        })
+      })
+    })
+  })
+
+  describe('notifications/setup/confirmation', () => {
+    describe('GET', () => {
+      beforeEach(async () => {
+        getOptions = {
+          method: 'GET',
+          url: basePath + `/${session.id}/confirmation`,
+          auth: {
+            strategy: 'session',
+            credentials: { scope: ['returns'] }
+          }
+        }
+      })
+      describe('when a request is valid', () => {
+        beforeEach(async () => {
+          Sinon.stub(InitiateSessionService, 'go').resolves(session)
+          Sinon.stub(ConfirmationService, 'go').returns(_viewConfirmation())
+        })
+
+        it('returns the page successfully', async () => {
+          const response = await server.inject(getOptions)
+
+          const pageData = _viewConfirmation()
+
+          expect(response.statusCode).to.equal(200)
+          expect(response.payload).to.contain(pageData.activeNavBar)
+          expect(response.payload).to.contain(pageData.pageTitle)
         })
       })
     })
@@ -473,5 +505,15 @@ function _viewCheck() {
   return {
     pageTitle: 'Check the recipients',
     activeNavBar: 'manage'
+  }
+}
+
+function _viewConfirmation() {
+  return {
+    activeNavBar: 'manage',
+    backLink: `/manage`,
+    forwardLink: '/notifications/report',
+    pageTitle: `Returns invitations sent`,
+    referenceCode: 'RINV-CPFRQ4'
   }
 }

--- a/test/controllers/notifications-setup.controller.test.js
+++ b/test/controllers/notifications-setup.controller.test.js
@@ -148,8 +148,11 @@ describe('Notifications Setup controller', () => {
 
     describe('POST', () => {
       describe('when the request succeeds', () => {
+        let eventId
+
         beforeEach(async () => {
-          Sinon.stub(SubmitCheckService, 'go').returns()
+          eventId = '1233'
+          Sinon.stub(SubmitCheckService, 'go').returns(eventId)
           postOptions = postRequestOptions(basePath + `/${session.id}/check`, {})
         })
 
@@ -157,7 +160,7 @@ describe('Notifications Setup controller', () => {
           const response = await server.inject(postOptions)
 
           expect(response.statusCode).to.equal(302)
-          expect(response.headers.location).to.equal(`/system/notifications/setup/${session.id}/confirmation`)
+          expect(response.headers.location).to.equal(`/system/notifications/setup/${eventId}/confirmation`)
         })
       })
     })
@@ -165,10 +168,14 @@ describe('Notifications Setup controller', () => {
 
   describe('notifications/setup/confirmation', () => {
     describe('GET', () => {
+      let eventId
+
       beforeEach(async () => {
+        eventId = '123'
+
         getOptions = {
           method: 'GET',
-          url: basePath + `/${session.id}/confirmation`,
+          url: basePath + `/${eventId}/confirmation`,
           auth: {
             strategy: 'session',
             credentials: { scope: ['returns'] }

--- a/test/presenters/notifications/setup/confirmation.presenter.test.js
+++ b/test/presenters/notifications/setup/confirmation.presenter.test.js
@@ -13,17 +13,17 @@ const ConfirmationPresenter = require('../../../../app/presenters/notifications/
 describe('Notifications Setup - Confirmation presenter', () => {
   const referenceCode = 'ADHC-1234'
 
-  let session
+  let event
 
   beforeEach(() => {
-    session = {
-      journey: 'ad-hoc',
+    event = {
+      subtype: 'adHoc',
       referenceCode
     }
   })
 
   it('correctly presents the data', () => {
-    const result = ConfirmationPresenter.go(session)
+    const result = ConfirmationPresenter.go(event)
 
     expect(result).to.equal({
       backLink: `/manage`,
@@ -35,7 +35,7 @@ describe('Notifications Setup - Confirmation presenter', () => {
 
   describe('when the journey is "ad-hoc"', () => {
     it('correctly presents the data', () => {
-      const result = ConfirmationPresenter.go(session)
+      const result = ConfirmationPresenter.go(event)
 
       expect(result).to.equal({
         backLink: `/manage`,
@@ -48,11 +48,11 @@ describe('Notifications Setup - Confirmation presenter', () => {
 
   describe('and the journey is "invitations"', () => {
     beforeEach(() => {
-      session.journey = 'invitations'
+      event.subtype = 'returnInvitation'
     })
 
     it('correctly presents the data', () => {
-      const result = ConfirmationPresenter.go(session)
+      const result = ConfirmationPresenter.go(event)
 
       expect(result).to.equal({
         backLink: `/manage`,
@@ -65,11 +65,11 @@ describe('Notifications Setup - Confirmation presenter', () => {
 
   describe('and the journey is "reminders"', () => {
     beforeEach(() => {
-      session.journey = 'reminders'
+      event.subtype = 'returnReminder'
     })
 
     it('correctly presents the data', () => {
-      const result = ConfirmationPresenter.go(session)
+      const result = ConfirmationPresenter.go(event)
 
       expect(result).to.equal({
         backLink: `/manage`,

--- a/test/presenters/notifications/setup/confirmation.presenter.test.js
+++ b/test/presenters/notifications/setup/confirmation.presenter.test.js
@@ -17,6 +17,7 @@ describe('Notifications Setup - Confirmation presenter', () => {
 
   beforeEach(() => {
     event = {
+      id: '123',
       subtype: 'adHoc',
       referenceCode
     }
@@ -26,8 +27,7 @@ describe('Notifications Setup - Confirmation presenter', () => {
     const result = ConfirmationPresenter.go(event)
 
     expect(result).to.equal({
-      backLink: `/manage`,
-      forwardLink: '/notifications/report',
+      forwardLink: '/notifications/report/123',
       pageTitle: `Returns ad-hoc sent`,
       referenceCode: 'ADHC-1234'
     })
@@ -38,8 +38,7 @@ describe('Notifications Setup - Confirmation presenter', () => {
       const result = ConfirmationPresenter.go(event)
 
       expect(result).to.equal({
-        backLink: `/manage`,
-        forwardLink: '/notifications/report',
+        forwardLink: '/notifications/report/123',
         pageTitle: `Returns ad-hoc sent`,
         referenceCode: 'ADHC-1234'
       })
@@ -55,8 +54,7 @@ describe('Notifications Setup - Confirmation presenter', () => {
       const result = ConfirmationPresenter.go(event)
 
       expect(result).to.equal({
-        backLink: `/manage`,
-        forwardLink: '/notifications/report',
+        forwardLink: '/notifications/report/123',
         pageTitle: `Returns invitations sent`,
         referenceCode: 'ADHC-1234'
       })
@@ -72,8 +70,7 @@ describe('Notifications Setup - Confirmation presenter', () => {
       const result = ConfirmationPresenter.go(event)
 
       expect(result).to.equal({
-        backLink: `/manage`,
-        forwardLink: '/notifications/report',
+        forwardLink: '/notifications/report/123',
         pageTitle: `Returns reminders sent`,
         referenceCode: 'ADHC-1234'
       })

--- a/test/presenters/notifications/setup/confirmation.presenter.test.js
+++ b/test/presenters/notifications/setup/confirmation.presenter.test.js
@@ -1,0 +1,82 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Thing under test
+const ConfirmationPresenter = require('../../../../app/presenters/notifications/setup/confirmation.presenter.js')
+
+describe('Notifications Setup - Confirmation presenter', () => {
+  const referenceCode = 'ADHC-1234'
+
+  let session
+
+  beforeEach(() => {
+    session = {
+      journey: 'ad-hoc',
+      referenceCode
+    }
+  })
+
+  it('correctly presents the data', () => {
+    const result = ConfirmationPresenter.go(session)
+
+    expect(result).to.equal({
+      backLink: `/manage`,
+      forwardLink: '/notifications/report',
+      pageTitle: `Returns ad-hoc sent`,
+      referenceCode: 'ADHC-1234'
+    })
+  })
+
+  describe('when the journey is "ad-hoc"', () => {
+    it('correctly presents the data', () => {
+      const result = ConfirmationPresenter.go(session)
+
+      expect(result).to.equal({
+        backLink: `/manage`,
+        forwardLink: '/notifications/report',
+        pageTitle: `Returns ad-hoc sent`,
+        referenceCode: 'ADHC-1234'
+      })
+    })
+  })
+
+  describe('and the journey is "invitations"', () => {
+    beforeEach(() => {
+      session.journey = 'invitations'
+    })
+
+    it('correctly presents the data', () => {
+      const result = ConfirmationPresenter.go(session)
+
+      expect(result).to.equal({
+        backLink: `/manage`,
+        forwardLink: '/notifications/report',
+        pageTitle: `Returns invitations sent`,
+        referenceCode: 'ADHC-1234'
+      })
+    })
+  })
+
+  describe('and the journey is "reminders"', () => {
+    beforeEach(() => {
+      session.journey = 'reminders'
+    })
+
+    it('correctly presents the data', () => {
+      const result = ConfirmationPresenter.go(session)
+
+      expect(result).to.equal({
+        backLink: `/manage`,
+        forwardLink: '/notifications/report',
+        pageTitle: `Returns reminders sent`,
+        referenceCode: 'ADHC-1234'
+      })
+    })
+  })
+})

--- a/test/services/notifications/setup/confirmation.service.test.js
+++ b/test/services/notifications/setup/confirmation.service.test.js
@@ -1,0 +1,41 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Test helpers
+const SessionHelper = require('../../../support/helpers/session.helper.js')
+
+// Thing under test
+const ConfirmationService = require('../../../../app/services/notifications/setup/confirmation.service.js')
+
+describe('Notifications Setup - Confirmation service', () => {
+  let session
+
+  beforeEach(async () => {
+    session = await SessionHelper.add({ data: { referenceCode: 'ADHC-1234', journey: 'ad-hoc' } })
+  })
+
+  afterEach(() => {
+    Sinon.restore()
+  })
+
+  describe('when called', () => {
+    it('returns page data for the view', async () => {
+      const result = await ConfirmationService.go(session.id)
+
+      expect(result).to.equal({
+        activeNavBar: 'manage',
+        backLink: '/manage',
+        forwardLink: '/notifications/report',
+        pageTitle: 'Returns ad-hoc sent',
+        referenceCode: 'ADHC-1234'
+      })
+    })
+  })
+})

--- a/test/services/notifications/setup/confirmation.service.test.js
+++ b/test/services/notifications/setup/confirmation.service.test.js
@@ -9,16 +9,22 @@ const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const EventHelper = require('../../../support/helpers/event.helper.js')
 
 // Thing under test
 const ConfirmationService = require('../../../../app/services/notifications/setup/confirmation.service.js')
 
 describe('Notifications Setup - Confirmation service', () => {
-  let session
+  const referenceCode = 'RINV-123'
+
+  let event
 
   beforeEach(async () => {
-    session = await SessionHelper.add({ data: { referenceCode: 'ADHC-1234', journey: 'ad-hoc' } })
+    event = await EventHelper.add({
+      type: 'notification',
+      subtype: 'returnInvitation',
+      referenceCode
+    })
   })
 
   afterEach(() => {
@@ -27,14 +33,14 @@ describe('Notifications Setup - Confirmation service', () => {
 
   describe('when called', () => {
     it('returns page data for the view', async () => {
-      const result = await ConfirmationService.go(session.id)
+      const result = await ConfirmationService.go(event.id)
 
       expect(result).to.equal({
         activeNavBar: 'manage',
         backLink: '/manage',
         forwardLink: '/notifications/report',
-        pageTitle: 'Returns ad-hoc sent',
-        referenceCode: 'ADHC-1234'
+        pageTitle: 'Returns invitations sent',
+        referenceCode: 'RINV-123'
       })
     })
   })

--- a/test/services/notifications/setup/confirmation.service.test.js
+++ b/test/services/notifications/setup/confirmation.service.test.js
@@ -37,8 +37,7 @@ describe('Notifications Setup - Confirmation service', () => {
 
       expect(result).to.equal({
         activeNavBar: 'manage',
-        backLink: '/manage',
-        forwardLink: '/notifications/report',
+        forwardLink: `/notifications/report/${event.id}`,
         pageTitle: 'Returns invitations sent',
         referenceCode: 'RINV-123'
       })

--- a/test/services/notifications/setup/submit-check.service.test.js
+++ b/test/services/notifications/setup/submit-check.service.test.js
@@ -74,6 +74,12 @@ describe('Notifications Setup - Submit Check service', () => {
     delete global.GlobalNotifier
   })
 
+  it('correctly returns the event id ', async () => {
+    const result = await SubmitCheckService.go(session.id, auth)
+
+    expect(result).to.equal(eventId)
+  })
+
   it('correctly triggers the "DetermineRecipientsService"', async () => {
     await SubmitCheckService.go(session.id, auth)
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4778

Previous work has been done to add the notification batch service that will send the notification to GOV.UK Notify and save the initial state to the database.

This change adds the confirmation pages controller, service and presenter.

When the user presses send on the notification setup check page they will be redirected to this confirmation page.

This concludes the user journey.