### PR TITLE
Fix dupe results in TPT supp. Fetch Billing Acc.

### DIFF
--- a/app/services/bill-runs/tpt-supplementary/fetch-billing-accounts.service.js
+++ b/app/services/bill-runs/tpt-supplementary/fetch-billing-accounts.service.js
@@ -87,7 +87,7 @@ async function _fetch(billRunId, billingPeriod) {
     .orderBy([{ column: 'billingAccounts.accountNumber' }])
     .withGraphFetched('chargeVersions')
     .modifyGraph('chargeVersions', (builder) => {
-      builder.select([
+      builder.distinct([
         'chargeVersions.id',
         'chargeVersions.scheme',
         'chargeVersions.startDate',


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4952

In [Handle credit-only TPT tariff supplementary bills](https://github.com/DEFRA/water-abstraction-system/pull/1804), we had to change how we fetched the billing accounts to be processed as bills in the bill run.

This was because we had to 'break' the direct link between the licences match & allocate found and processed, and those that go through the process billing period engine.

Match & allocate can only handle two-part tariff charge versions, but the process billing period engine needs to handle non-two-part tariff charge versions. This is to determine if a credit is required, for example, when a licence has added a new charge version that removes the two-part tariff agreement.

So, rather than having a single fetch billing account service used by both two-part tariff bill run types, we created a specific service for each engine.

The one we added for supplementary eschews selecting only those licences with `review_licences` records. Instead, it fetches all billing accounts linked to a licence with a 'licence supplementary year' (LSY) record that has been assigned to the bill run.

That appeared fine until our QA team reported an error in UAT. We tracked down the issue to our new supplementary `FetchBillingAccountsService`. If duplicate LSYs exist, duplicate charge versions are returned against each billing account.

How can you get duplicate LSY records, I hear you ask?

Imagine you have made a change to a licence. This causes it to get flagged for two-part tariff supplementary, and the first entry is made to LSYs.

You then create a two-part tariff supplementary bill run, so the LSY is assigned to that bill run. In review, though, you spot you've made a mistake. But instead of removing it from review and making the change, you make the change _then_ remove it.

The supplementary flagging engine will create a new YSL record when it sees the existing one for the licence is already assigned to a bill run. This is to ensure that new changes are not missed.

In our example, we now have two LSY records for the licence. When the next two-part tariff supplementary bill run is created, both will be assigned to the bill run. This is how we end up with `FetchBillingAccountsService` pulling duplicate charge version records.

Thankfully, a one-word change is all that is needed to avoid this issue!