### PR TITLE
Update notification setup submit check tests

### DIFF
--- a/app/services/notifications/setup/submit-check.service.js
+++ b/app/services/notifications/setup/submit-check.service.js
@@ -21,7 +21,7 @@ const { currentTimeInNanoseconds, calculateAndLogTimeTaken } = require('../../..
  * @param {string} sessionId - The UUID for the notification setup session record
  * @param {object} auth - The auth object taken from `request.auth` containing user details
  *
- * @returns {string} - the created eventId
+ * @returns {Promise<string>} - the created eventId
  */
 async function go(sessionId, auth) {
   const session = await SessionModel.query().findById(sessionId)

--- a/test/services/notifications/setup/submit-check.service.test.js
+++ b/test/services/notifications/setup/submit-check.service.test.js
@@ -9,12 +9,12 @@ const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
+const EventModel = require('../../../../app/models/event.model.js')
 const RecipientsFixture = require('../../../fixtures/recipients.fixtures.js')
 const SessionHelper = require('../../../support/helpers/session.helper.js')
 
 // Things we need to stub
 const BatchNotificationsService = require('../../../../app/services/notifications/setup/batch-notifications.service.js')
-const CreateEventService = require('../../../../app/services/notifications/setup/create-event.service.js')
 const DetermineRecipientsService = require('../../../../app/services/notifications/setup/determine-recipients.service.js')
 const RecipientsService = require('../../../../app/services/notifications/setup/fetch-recipients.service.js')
 
@@ -22,26 +22,23 @@ const RecipientsService = require('../../../../app/services/notifications/setup/
 const SubmitCheckService = require('../../../../app/services/notifications/setup/submit-check.service.js')
 
 describe('Notifications Setup - Submit Check service', () => {
-  const eventId = 'c1cae668-3dad-4806-94e2-eb3f27222ed9'
-
   let auth
   let notifierStub
-  let recipients
+  let referenceCode
   let session
+  let recipients
   let testRecipients
 
   beforeEach(async () => {
     notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
     global.GlobalNotifier = notifierStub
 
-    recipients = RecipientsFixture.recipients()
-
-    testRecipients = [recipients.primaryUser]
+    referenceCode = `RINV-${Math.floor(1000 + Math.random() * 9000).toString()}`
 
     session = await SessionHelper.add({
       data: {
         journey: 'invitations',
-        referenceCode: 'RINV-123',
+        referenceCode,
         returnsPeriod: 'quarterFour',
         determinedReturnsPeriod: {
           name: 'allYear',
@@ -63,8 +60,9 @@ describe('Notifications Setup - Submit Check service', () => {
 
     recipients = RecipientsFixture.recipients()
 
+    testRecipients = [recipients.primaryUser]
+
     Sinon.stub(BatchNotificationsService, 'go').resolves({ sent: 1, error: 0 })
-    Sinon.stub(CreateEventService, 'go').resolves({ id: eventId })
     Sinon.stub(DetermineRecipientsService, 'go').returns(testRecipients)
     Sinon.stub(RecipientsService, 'go').resolves(testRecipients)
   })
@@ -74,43 +72,26 @@ describe('Notifications Setup - Submit Check service', () => {
     delete global.GlobalNotifier
   })
 
-  it('correctly returns the event id ', async () => {
+  it('correctly returns the event id', async () => {
     const result = await SubmitCheckService.go(session.id, auth)
 
-    expect(result).to.equal(eventId)
+    const event = await EventModel.query().where('reference_code', referenceCode).first()
+
+    expect(result).to.equal(event.id)
   })
 
-  it('correctly triggers the "DetermineRecipientsService"', async () => {
-    await SubmitCheckService.go(session.id, auth)
+  it('should call the batch notification service', async () => {
+    const result = await SubmitCheckService.go(session.id, auth)
 
-    expect(DetermineRecipientsService.go.calledWith(testRecipients)).to.be.true()
-  })
-
-  it('correctly triggers the "CreateEventService"', async () => {
-    await SubmitCheckService.go(session.id, auth)
-
-    const expected = {
-      issuer: 'hello@world.com',
-      licences: `["${testRecipients[0].licence_refs}"]`,
-      metadata: {
-        name: 'Returns: invitation',
-        options: {
-          excludeLicences: []
-        },
-        recipients: 1,
-        returnCycle: {
-          dueDate: '2025-04-28',
-          endDate: '2023-03-31',
-          isSummer: false,
-          startDate: '2022-04-01'
-        }
-      },
-      referenceCode: 'RINV-123',
-      status: 'started',
-      subtype: 'returnInvitation'
-    }
-
-    expect(CreateEventService.go.calledWith(expected)).to.be.true()
+    expect(
+      BatchNotificationsService.go.calledWith(
+        testRecipients,
+        session.data.determinedReturnsPeriod,
+        referenceCode,
+        session.data.journey,
+        result
+      )
+    ).to.be.true()
   })
 
   it('should not throw an error', async () => {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4778

The previous test stubbed the 'CreateEventService', this was previously acceptable however due to a recent refactor where we return the event id from the 'SubmitCheckService'. We need to improve the assertion of the event id, by checking the event is created in the database.

This change aligns the tests with our other test pattern of using the real database data.

This change also adds a test for the 'BatchNotificationsService' this is a complicated service which is crucial to the whole notification process. This has been tested independent, however we want to assure that the function is called (and the args are correct) and is able to process as it falls outside of the async/await functionality.