### PR TITLE
Update notification setup default event status

### DIFF
--- a/app/presenters/notifications/setup/create-event.presenter.js
+++ b/app/presenters/notifications/setup/create-event.presenter.js
@@ -11,6 +11,9 @@ const { transformStringOfLicencesToArray } = require('../../../lib/general.lib.j
 /**
  * Formats a notification `SessionModel` instance into the data needed for a 'EventModel' record
  *
+ * We set the event 'status' to 'complete' to allow the report to show on the 'notifications/report' page. This is
+ * dictated by the legacy code.
+ *
  * @param {SessionModel} session
  * @param {object[]} recipients
  * @param {object} auth - The auth object taken from `request.auth` containing user details
@@ -32,7 +35,7 @@ function go(session, recipients, auth) {
       returnCycle: _returnCycle(determinedReturnsPeriod)
     },
     referenceCode,
-    status: 'started',
+    status: 'completed',
     subtype: _subType(journey)
   }
 }

--- a/app/services/notifications/setup/batch-notifications.service.js
+++ b/app/services/notifications/setup/batch-notifications.service.js
@@ -24,7 +24,6 @@ const NotifyConfig = require('../../../../config/notify.config.js')
  * - save the notifications to `water.scheduled_notifications`
  * - check the status of the notifications with Notify (sent or otherwise)
  * - update the notifications status in `water.scheduled_notifications` (with the updated Notify status)
- * - return the number of successful and failed notifications
  *
  * This will need to be done in batches because Notify has a rate limit (3,000 messages per minute). It also means the persisting of the notifications can use PostgreSQL's ability to batch insert (this is much greater than the Notify
  * rate limit).
@@ -35,28 +34,16 @@ const NotifyConfig = require('../../../../config/notify.config.js')
  * @param {string} journey
  * @param {string} eventId - the event id to link all the notifications to an event
  *
- * @returns {object} - the number of sent and errored notifications
  */
 async function go(recipients, determinedReturnsPeriod, referenceCode, journey, eventId) {
   const { batchSize, delay } = NotifyConfig
 
-  let sent = 0
-  let error = 0
-
   for (let i = 0; i < recipients.length; i += batchSize) {
     const batchRecipients = recipients.slice(i, i + batchSize)
 
-    const batch = await _batch(batchRecipients, determinedReturnsPeriod, referenceCode, journey, eventId)
+    await _batch(batchRecipients, determinedReturnsPeriod, referenceCode, journey, eventId)
 
     await _delay(delay)
-
-    sent += batch.sent
-    error += batch.error
-  }
-
-  return {
-    sent,
-    error
   }
 }
 

--- a/test/presenters/notifications/setup/create-event.presenter.test.js
+++ b/test/presenters/notifications/setup/create-event.presenter.test.js
@@ -70,7 +70,7 @@ describe('Notifications Setup - Event presenter', () => {
         }
       },
       referenceCode: 'RINV-123',
-      status: 'started',
+      status: 'completed',
       subtype: 'returnInvitation'
     })
   })

--- a/test/services/notifications/setup/batch-notifications.service.test.js
+++ b/test/services/notifications/setup/batch-notifications.service.test.js
@@ -244,21 +244,6 @@ describe('Notifications Setup - Batch notifications service', () => {
       ])
     })
 
-    it('should return with no errors', async () => {
-      const result = await BatchNotificationsService.go(
-        testRecipients,
-        determinedReturnsPeriod,
-        referenceCode,
-        journey,
-        eventId
-      )
-
-      expect(result).to.equal({
-        error: 0,
-        sent: 5
-      })
-    })
-
     if (stubNotify) {
       it('correctly sends the "email" data to Notify', async () => {
         await BatchNotificationsService.go(testRecipients, determinedReturnsPeriod, referenceCode, journey, eventId)
@@ -316,21 +301,6 @@ describe('Notifications Setup - Batch notifications service', () => {
       ]
 
       _stubUnSuccessfulNotify()
-    })
-
-    it('should return the "error" count in the response', async () => {
-      const result = await BatchNotificationsService.go(
-        testRecipients,
-        determinedReturnsPeriod,
-        referenceCode,
-        journey,
-        eventId
-      )
-
-      expect(result).to.equal({
-        error: 1,
-        sent: 2
-      })
     })
 
     it('should persist the scheduled notifications with the errors', async () => {

--- a/test/services/notifications/setup/submit-check.service.test.js
+++ b/test/services/notifications/setup/submit-check.service.test.js
@@ -106,7 +106,7 @@ describe('Notifications Setup - Submit Check service', () => {
         }
       },
       referenceCode: 'RINV-123',
-      status: 'started',
+      status: 'completed',
       subtype: 'returnInvitation'
     }
 

--- a/test/services/notifications/setup/submit-check.service.test.js
+++ b/test/services/notifications/setup/submit-check.service.test.js
@@ -24,9 +24,9 @@ const SubmitCheckService = require('../../../../app/services/notifications/setup
 describe('Notifications Setup - Submit Check service', () => {
   let auth
   let notifierStub
+  let recipients
   let referenceCode
   let session
-  let recipients
   let testRecipients
 
   beforeEach(async () => {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4778

There was a previous assumption of using setting the event status to 'started' when it is created. This resulted in the event not showing on the legacy on the 'notifications/report' page.

This change updates the default status to 'completed'. This will not change in our code base.

This lead to exploring where the 'sent' and 'error' values on the options object are used in the legacy code. They are not used as far as we can tell.

The recipients count displayed on the 'notifications/report' page is taken from 'metadata.recipients'.

The errors are 'counted' based on a query in the legacy code and does not use the 'metadata.error' key.