### PR TITLE
Update notification setup notify update status

### DIFF
--- a/app/presenters/notifications/setup/notify-status.presenter.js
+++ b/app/presenters/notifications/setup/notify-status.presenter.js
@@ -6,7 +6,7 @@
  */
 
 const SCHEDULED_NOTIFICATIONS_STATUS = {
-  pending: 'pending',
+  sending: 'sending',
   sent: 'sent',
   error: 'error'
 }
@@ -27,7 +27,7 @@ const SCHEDULED_NOTIFICATIONS_STATUS = {
  * When we make the initial call to notify we do not receive a status, but we do receive a 'statusCode' (201) and
  * 'statusText' ("CREATED"). This is inferred to mean the notifications is in the "created" state. This is the initial
  * 'notifyStatus' value set for a 'scheduledNotification' (when no error has occurred), and the 'status' is set to
- * pending.
+ * sending.
  *
  * @param {string} notifyStatus - the status from notify
  * @param {string} scheduledNotification - a 'scheduled notification'
@@ -62,8 +62,8 @@ function go(notifyStatus, scheduledNotification) {
  */
 function _emailStatus(notifyStatus) {
   const emailStatuses = {
-    created: SCHEDULED_NOTIFICATIONS_STATUS.pending,
-    sending: SCHEDULED_NOTIFICATIONS_STATUS.pending,
+    created: SCHEDULED_NOTIFICATIONS_STATUS.sending,
+    sending: SCHEDULED_NOTIFICATIONS_STATUS.sending,
     delivered: SCHEDULED_NOTIFICATIONS_STATUS.sent,
     'permanent-failure': SCHEDULED_NOTIFICATIONS_STATUS.error,
     'technical-failure': SCHEDULED_NOTIFICATIONS_STATUS.error,
@@ -91,8 +91,8 @@ function _emailStatus(notifyStatus) {
 function _letterStatus(notifyStatus) {
   const letterStatuses = {
     accepted: SCHEDULED_NOTIFICATIONS_STATUS.sent,
-    created: SCHEDULED_NOTIFICATIONS_STATUS.pending,
-    sending: SCHEDULED_NOTIFICATIONS_STATUS.pending,
+    created: SCHEDULED_NOTIFICATIONS_STATUS.sending,
+    sending: SCHEDULED_NOTIFICATIONS_STATUS.sending,
     delivered: SCHEDULED_NOTIFICATIONS_STATUS.sent,
     received: SCHEDULED_NOTIFICATIONS_STATUS.sent,
     'permanent-failure': SCHEDULED_NOTIFICATIONS_STATUS.error,

--- a/app/presenters/notifications/setup/notify-update.presenter.js
+++ b/app/presenters/notifications/setup/notify-update.presenter.js
@@ -30,7 +30,7 @@ function go(notify) {
     notifyId: notify.id,
     notifyStatus: notify.statusText,
     plaintext: notify.plaintext,
-    status: 'pending'
+    status: 'sending'
   }
 }
 

--- a/test/presenters/notifications/setup/notify-status.presenter.test.js
+++ b/test/presenters/notifications/setup/notify-status.presenter.test.js
@@ -18,7 +18,7 @@ describe('Notifications Setup - Notify status presenter', () => {
     beforeEach(() => {
       scheduledNotification = {
         messageType: 'email',
-        status: 'pending'
+        status: 'sending'
       }
     })
 
@@ -32,7 +32,7 @@ describe('Notifications Setup - Notify status presenter', () => {
 
         expect(result).to.equal({
           notifyStatus: 'created',
-          status: 'pending'
+          status: 'sending'
         })
       })
     })
@@ -47,7 +47,7 @@ describe('Notifications Setup - Notify status presenter', () => {
 
         expect(result).to.equal({
           notifyStatus: 'sending',
-          status: 'pending'
+          status: 'sending'
         })
       })
     })
@@ -134,7 +134,7 @@ describe('Notifications Setup - Notify status presenter', () => {
     beforeEach(() => {
       scheduledNotification = {
         messageType: 'letter',
-        status: 'pending'
+        status: 'sending'
       }
     })
 
@@ -163,7 +163,7 @@ describe('Notifications Setup - Notify status presenter', () => {
 
         expect(result).to.equal({
           notifyStatus: 'created',
-          status: 'pending'
+          status: 'sending'
         })
       })
     })
@@ -178,7 +178,7 @@ describe('Notifications Setup - Notify status presenter', () => {
 
         expect(result).to.equal({
           notifyStatus: 'sending',
-          status: 'pending'
+          status: 'sending'
         })
       })
     })

--- a/test/presenters/notifications/setup/notify-update.presenter.test.js
+++ b/test/presenters/notifications/setup/notify-update.presenter.test.js
@@ -29,7 +29,7 @@ describe('Notifications Setup - Notify update presenter', () => {
       notifyId: '123',
       notifyStatus: 'created',
       plaintext: 'My dearest margery',
-      status: 'pending'
+      status: 'sending'
     })
   })
 

--- a/test/services/notifications/setup/batch-notifications.service.test.js
+++ b/test/services/notifications/setup/batch-notifications.service.test.js
@@ -99,7 +99,7 @@ describe('Notifications Setup - Batch notifications service', () => {
             periodStartDate: '1 April 2022'
           },
           sendAfter: result[0].sendAfter,
-          status: 'pending',
+          status: 'sending',
           log: null,
           licences: [recipients.primaryUser.licence_refs],
           individualId: null,
@@ -126,7 +126,7 @@ describe('Notifications Setup - Batch notifications service', () => {
             periodStartDate: '1 April 2022'
           },
           sendAfter: result[1].sendAfter,
-          status: 'pending',
+          status: 'sending',
           log: null,
           licences: [recipients.returnsAgent.licence_refs],
           individualId: null,
@@ -159,7 +159,7 @@ describe('Notifications Setup - Batch notifications service', () => {
             periodStartDate: '1 April 2022'
           },
           sendAfter: result[2].sendAfter,
-          status: 'pending',
+          status: 'sending',
           log: null,
           licences: [recipients.licenceHolder.licence_refs],
           individualId: null,
@@ -192,7 +192,7 @@ describe('Notifications Setup - Batch notifications service', () => {
             periodStartDate: '1 April 2022'
           },
           sendAfter: result[3].sendAfter,
-          status: 'pending',
+          status: 'sending',
           log: null,
           licences: [recipients.returnsTo.licence_refs],
           individualId: null,
@@ -225,7 +225,7 @@ describe('Notifications Setup - Batch notifications service', () => {
             periodStartDate: '1 April 2022'
           },
           sendAfter: result[4].sendAfter,
-          status: 'pending',
+          status: 'sending',
           log: null,
           licences: [firstMultiple, secondMultiple],
           individualId: null,
@@ -379,7 +379,7 @@ describe('Notifications Setup - Batch notifications service', () => {
             periodStartDate: '1 April 2022'
           },
           sendAfter: result[1].sendAfter,
-          status: 'pending',
+          status: 'sending',
           log: null,
           licences: [recipients.returnsAgent.licence_refs],
           individualId: null,


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4778

A previous assumption was made that a 'scheduled_notification' could have the status 'pending'. This fails validation when rendering a report. The legacy UI has a mapper that converts a 'draft' or 'sending' status into a 'pending' status for the `notifications/report{eventId}` page.

As we do not have a 'draft' state we will use the 'sending' status.

Therefore, when we initially send our calls to Notify (and the notification does not error) we will set the 'scheduled_notification.status' to 'sending'.