### PR TITLE
Add Notify statuses service

### DIFF
--- a/app/services/notify/notify-statuses.service.js
+++ b/app/services/notify/notify-statuses.service.js
@@ -1,0 +1,50 @@
+'use strict'
+
+/**
+ * Get the statuses of a notification by unique reference from GOV.UK Notify
+ * @module NotifyStatusesService
+ */
+
+const NotifyClient = require('notifications-node-client').NotifyClient
+
+const config = require('../../../config/notify.config.js')
+
+/**
+ * Get the statuses of a notification by unique reference from GOV.UK Notify
+ *
+ * https://docs.notifications.service.gov.uk/node.html#get-the-status-of-multiple-messages
+ *
+ * @param {string|null} olderThanNotificationId - the client returns the next 250 received notifications older than
+ * the given id
+ * @param {string} referenceCode - This reference identifies a single unique notification or a batch of notifications
+ *
+ * @returns {Promise<object>}
+ */
+async function go(olderThanNotificationId = null, referenceCode) {
+  const notifyClient = new NotifyClient(config.apiKey)
+
+  return _statuses(notifyClient, olderThanNotificationId, referenceCode)
+}
+
+async function _statuses(notifyClient, olderThanNotificationId, referenceCode) {
+  try {
+    const templateType = null
+    const status = null
+
+    const response = await notifyClient.getNotifications(templateType, status, referenceCode, olderThanNotificationId)
+
+    return {
+      data: response.data.notifications
+    }
+  } catch (error) {
+    return {
+      status: error.status,
+      message: error.message,
+      errors: error.response.data.errors
+    }
+  }
+}
+
+module.exports = {
+  go
+}

--- a/test/services/notify/notify-statuses.service.test.js
+++ b/test/services/notify/notify-statuses.service.test.js
@@ -1,0 +1,117 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Test helpers
+const { NotifyClient } = require('notifications-node-client')
+
+// Thing under test
+const NotifyStatusesService = require('../../../app/services/notify/notify-statuses.service.js')
+
+describe('Notify - Batch status service', () => {
+  let notificationId
+  let notifyStub
+  let referenceCode
+
+  beforeEach(() => {
+    // If you wish to test live notify replace this with a real notification id
+    notificationId = null
+    // If you wish to test live notify replace this with a real unique reference
+    referenceCode = 'RINV-97CN09'
+  })
+
+  afterEach(() => {
+    Sinon.restore()
+  })
+
+  describe('when the call to "notify" is successful', () => {
+    beforeEach(() => {
+      notifyStub = _stubSuccessfulNotify({
+        data: {
+          notifications: [{ status: 'received', reference: 'RINV-97CN09' }]
+        }
+      })
+    })
+
+    it('should call notify', async () => {
+      const result = await NotifyStatusesService.go(notificationId, referenceCode)
+
+      expect(result).to.equal({
+        data: [
+          {
+            reference: 'RINV-97CN09',
+            status: 'received'
+          }
+        ]
+      })
+    })
+
+    it('should use the notify client', async () => {
+      await NotifyStatusesService.go(notificationId, referenceCode)
+
+      expect(notifyStub.calledWith(null, null, referenceCode, notificationId)).to.equal(true)
+    })
+  })
+
+  describe('and there are no "notifications"', () => {
+    beforeEach(() => {
+      // This is a bad uuid and should not exist in notify
+      notificationId = '616d49cf-4a7e-4188-a7e4-682f1a41dd83'
+
+      notifyStub = _stubSuccessfulNotify({
+        data: {
+          notifications: []
+        }
+      })
+    })
+
+    it('should return an empty array', async () => {
+      const result = await NotifyStatusesService.go(notificationId, referenceCode)
+
+      expect(result).to.equal({
+        data: []
+      })
+    })
+  })
+
+  describe('when the call to "notify" is unsuccessful', () => {
+    beforeEach(() => {
+      // This is a bad uuid and should not exist in notify
+      notificationId = '616d49cf-4a7e-4188-a7e4-682f1a41dd83'
+
+      notifyStub = _stubUnSuccessfulNotify()
+    })
+
+    it('should return an error', async () => {
+      const result = await NotifyStatusesService.go(notificationId, referenceCode)
+
+      expect(result).to.equal({
+        status: 404,
+        message: 'Request failed with status code 404',
+        errors: [{ error: 'NoResultFound', message: 'No result found' }]
+      })
+    })
+  })
+})
+
+function _stubSuccessfulNotify(response) {
+  return Sinon.stub(NotifyClient.prototype, 'getNotifications').resolves(response)
+}
+
+function _stubUnSuccessfulNotify() {
+  return Sinon.stub(NotifyClient.prototype, 'getNotifications').rejects({
+    status: 404,
+    message: 'Request failed with status code 404',
+    response: {
+      data: {
+        errors: [{ error: 'NoResultFound', message: 'No result found' }]
+      }
+    }
+  })
+}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4904

This change adds the 'NotifyStatusesService' which checks the status of a multiple notifications in notify.

To retrieve the notifications specific to a 'group' a unique 'reference' is used in notify. We send a unique 'reference' for most notifications.

We can use this unique 'reference' with the Notify api to get multiple statuses.

There is a limit of 250 notifications returned. This can be 'paginated' in a way by providing the last notification id from the previous call.

Notify returns the most recent statuses initially - https://docs.notifications.service.gov.uk/node.html#olderthan-optional.

Unlike our previous Notify services it's tests cannot be used against the live GOV.UK Notify. They would be too complicated and would require using our code to set up tests (what if that code is broken).