### PR TITLE
Return "not due yet" status

### DIFF
--- a/app/presenters/licences/view-licence-returns.presenter.js
+++ b/app/presenters/licences/view-licence-returns.presenter.js
@@ -98,27 +98,26 @@ function _status(returnLog) {
   // 'today' would be flagged as overdue when it is still due (just!)
   today.setHours(0, 0, 0, 0)
 
-  // For all status other than due we can just return the status and the return-status-tag macro will know how to
-  // display it
-  if (status !== 'due') {
-    return status
+  if (status === 'due') {
+    if (today > dueDate) {
+      return 'overdue'
+    }
+
+    // A return is considered "due" for 28 days, starting 28 days before the due date
+    // Any date before this period should be marked as "not due yet"
+    const notDueUntil = new Date(dueDate)
+
+    // Calculate the start of the "due" period, which begins 27 days before the due date
+    notDueUntil.setDate(notDueUntil.getDate() - DUE_PERIOD_DAYS)
+
+    // If today is before the "due" period starts, the return is "not due yet"
+    if (today < notDueUntil) {
+      return 'not due yet'
+    }
   }
 
-  if (today > dueDate) {
-    return 'overdue'
-  }
-
-  // A return is considered "due" for 28 days, starting 28 days before the due date
-  // Any date before this period should be marked as "not due yet"
-  const notDueUntil = new Date(dueDate)
-
-  // Calculate the start of the "due" period, which begins 27 days before the due date
-  notDueUntil.setDate(notDueUntil.getDate() - DUE_PERIOD_DAYS)
-
-  // If today is before the "due" period starts, the return is "not due yet"
-  if (today < notDueUntil) {
-    return 'not due yet'
-  }
+  // For all other cases we can just return the status and the return-status-tag macro will know how to display it
+  return status
 }
 
 module.exports = {

--- a/app/presenters/licences/view-licence-returns.presenter.js
+++ b/app/presenters/licences/view-licence-returns.presenter.js
@@ -96,8 +96,22 @@ function _status(returnLog) {
   // 'today' would be flagged as overdue when it is still due (just!)
   today.setHours(0, 0, 0, 0)
 
-  if (status === 'due' && dueDate < today) {
-    return 'overdue'
+  if (status === 'due') {
+    if (dueDate < today) {
+      return 'overdue'
+    }
+
+    // A return is considered "due" for 28 days, starting 28 days before the due date
+    // Any date before this period should be marked as "not due yet"
+    const notDueUntil = new Date(dueDate)
+
+    // Calculate the start of the "due" period, which begins 27 days before the due date
+    notDueUntil.setDate(notDueUntil.getDate() - 27)
+
+    // If today is before the "due" period starts, the return is "not due yet"
+    if (today < notDueUntil) {
+      return 'not due yet'
+    }
   }
 
   // For all other cases we can just return the status and the return-status-tag macro will know how to display it

--- a/app/presenters/licences/view-licence-returns.presenter.js
+++ b/app/presenters/licences/view-licence-returns.presenter.js
@@ -98,26 +98,27 @@ function _status(returnLog) {
   // 'today' would be flagged as overdue when it is still due (just!)
   today.setHours(0, 0, 0, 0)
 
-  if (status === 'due') {
-    if (dueDate < today) {
-      return 'overdue'
-    }
-
-    // A return is considered "due" for 28 days, starting 28 days before the due date
-    // Any date before this period should be marked as "not due yet"
-    const notDueUntil = new Date(dueDate)
-
-    // Calculate the start of the "due" period, which begins 27 days before the due date
-    notDueUntil.setDate(notDueUntil.getDate() - DUE_PERIOD_DAYS)
-
-    // If today is before the "due" period starts, the return is "not due yet"
-    if (today < notDueUntil) {
-      return 'not due yet'
-    }
+  // For all status other than due we can just return the status and the return-status-tag macro will know how to
+  // display it
+  if (status !== 'due') {
+    return status
   }
 
-  // For all other cases we can just return the status and the return-status-tag macro will know how to display it
-  return status
+  if (today > dueDate) {
+    return 'overdue'
+  }
+
+  // A return is considered "due" for 28 days, starting 28 days before the due date
+  // Any date before this period should be marked as "not due yet"
+  const notDueUntil = new Date(dueDate)
+
+  // Calculate the start of the "due" period, which begins 27 days before the due date
+  notDueUntil.setDate(notDueUntil.getDate() - DUE_PERIOD_DAYS)
+
+  // If today is before the "due" period starts, the return is "not due yet"
+  if (today < notDueUntil) {
+    return 'not due yet'
+  }
 }
 
 module.exports = {

--- a/app/presenters/licences/view-licence-returns.presenter.js
+++ b/app/presenters/licences/view-licence-returns.presenter.js
@@ -8,6 +8,8 @@
 const FeatureFlagsConfig = require('../../../config/feature-flags.config.js')
 const { formatLongDate } = require('../base.presenter.js')
 
+const DUE_PERIOD_DAYS = 27
+
 /**
  * Formats data for the `/licences/{id}/returns` view licence returns page
  *
@@ -106,7 +108,7 @@ function _status(returnLog) {
     const notDueUntil = new Date(dueDate)
 
     // Calculate the start of the "due" period, which begins 27 days before the due date
-    notDueUntil.setDate(notDueUntil.getDate() - 27)
+    notDueUntil.setDate(notDueUntil.getDate() - DUE_PERIOD_DAYS)
 
     // If today is before the "due" period starts, the return is "not due yet"
     if (today < notDueUntil) {

--- a/app/presenters/return-logs/base-return-logs.presenter.js
+++ b/app/presenters/return-logs/base-return-logs.presenter.js
@@ -3,6 +3,8 @@
 const { formatNumber, formatQuantity, sentenceCase } = require('../base.presenter.js')
 const { returnRequirementFrequencies, returnUnits, unitNames } = require('../../lib/static-lookups.lib.js')
 
+const DUE_PERIOD_DAYS = 27
+
 /**
  * Converts a quantity from a given unit to cubic metres and formats it
  *
@@ -78,7 +80,7 @@ function formatStatus(returnLog) {
     const notDueUntil = new Date(dueDate)
 
     // Calculate the start of the "due" period, which begins 27 days before the due date
-    notDueUntil.setDate(notDueUntil.getDate() - 27)
+    notDueUntil.setDate(notDueUntil.getDate() - DUE_PERIOD_DAYS)
 
     // If today is before the "due" period starts, the return is "not due yet"
     if (today < notDueUntil) {

--- a/app/presenters/return-logs/base-return-logs.presenter.js
+++ b/app/presenters/return-logs/base-return-logs.presenter.js
@@ -44,8 +44,9 @@ function formatMeterDetails(meter) {
 /**
  * Formats the status for a return log, adjusting for specific conditions.
  *
- * If the return log's status is 'completed', it will be displayed as 'complete'. If the status is 'due' and the due
- * date has passed, it will be displayed as 'overdue'. For all other cases, it will return the status as is.
+ * If the return log's status is 'completed', it will be displayed as 'complete'. If the status is 'due', but there are
+ * 28 days before the returns due date, it will display 'not due yet'. If the status is 'due' and the due date has
+ * passed, it will be displayed as 'overdue'. For all other cases, it will return the status as is.
  *
  * @param {module:ReturnLogModel} returnLog - The return log containing status and due date information
  *
@@ -67,8 +68,22 @@ function formatStatus(returnLog) {
   // 'today' would be flagged as overdue when it is still due (just!)
   today.setHours(0, 0, 0, 0)
 
-  if (status === 'due' && dueDate < today) {
-    return 'overdue'
+  if (status === 'due') {
+    if (dueDate < today) {
+      return 'overdue'
+    }
+
+    // A return is considered "due" for 28 days, starting 28 days before the due date
+    // Any date before this period should be marked as "not due yet"
+    const notDueUntil = new Date(dueDate)
+
+    // Calculate the start of the "due" period, which begins 27 days before the due date
+    notDueUntil.setDate(notDueUntil.getDate() - 27)
+
+    // If today is before the "due" period starts, the return is "not due yet"
+    if (today < notDueUntil) {
+      return 'not due yet'
+    }
   }
 
   // For all other cases we can just return the status and the return-status-tag macro will know how to display it

--- a/app/presenters/return-logs/view-return-log.presenter.js
+++ b/app/presenters/return-logs/view-return-log.presenter.js
@@ -88,18 +88,13 @@ function _actionButton(latest, auth, returnLogId, formattedStatus) {
     return null
   }
 
-  // You cannot edit a void return
-  if (formattedStatus === 'void') {
+  // You cannot edit a void return or a return not due yet
+  if (formattedStatus === 'void' || formattedStatus === 'not due yet') {
     return null
   }
 
   // You cannot submit or edit if you do not have permission to
   if (!auth.credentials.scope.includes('returns')) {
-    return null
-  }
-
-  // You cannot submit or edit a return that is 'not due yet'
-  if (formattedStatus === 'not due yet') {
     return null
   }
 

--- a/app/presenters/return-logs/view-return-log.presenter.js
+++ b/app/presenters/return-logs/view-return-log.presenter.js
@@ -104,7 +104,7 @@ function _actionButton(latest, auth, returnLogId, formattedStatus) {
   }
 
   // You can only edit a completed return
-  if (formattedStatus === 'completed') {
+  if (formattedStatus === 'complete') {
     return {
       value: returnLogId,
       text: 'Edit return'

--- a/app/presenters/return-logs/view-return-log.presenter.js
+++ b/app/presenters/return-logs/view-return-log.presenter.js
@@ -37,7 +37,6 @@ function go(returnLog, auth) {
     returnsFrequency,
     returnSubmissions,
     siteDescription,
-    status,
     startDate,
     twoPartTariff,
     underQuery,
@@ -49,10 +48,11 @@ function go(returnLog, auth) {
 
   const method = selectedReturnSubmission?.$method()
   const units = selectedReturnSubmission?.$units()
+  const formattedStatus = formatStatus(returnLog)
 
   return {
     abstractionPeriod: formatAbstractionPeriod(periodStartDay, periodStartMonth, periodEndDay, periodEndMonth),
-    actionButton: _actionButton(latest, auth, returnLog.id, status),
+    actionButton: _actionButton(latest, auth, returnLog.id, formattedStatus),
     backLink: _backLink(returnLog.id, licence.id, latest),
     displayReadings: method !== 'abstractionVolumes',
     displayTable: _displayTable(selectedReturnSubmission),
@@ -69,9 +69,10 @@ function go(returnLog, auth) {
     receivedDate: receivedDate ? formatLongDate(receivedDate) : null,
     returnReference,
     returnPeriod: `${formatLongDate(startDate)} to ${formatLongDate(endDate)}`,
+    showUnderQuery: formattedStatus !== 'not due yet',
     siteDescription,
     startReading: _startReading(selectedReturnSubmission),
-    status: formatStatus(returnLog),
+    status: formattedStatus,
     summaryTableData: _summaryTableData(selectedReturnSubmission, returnsFrequency),
     tableTitle: _tableTitle(returnsFrequency, method),
     tariff: twoPartTariff ? 'Two-part' : 'Standard',
@@ -81,14 +82,14 @@ function go(returnLog, auth) {
   }
 }
 
-function _actionButton(latest, auth, returnLogId, status) {
+function _actionButton(latest, auth, returnLogId, formattedStatus) {
   // You cannot edit a previous version
   if (!latest) {
     return null
   }
 
   // You cannot edit a void return
-  if (status === 'void') {
+  if (formattedStatus === 'void') {
     return null
   }
 
@@ -97,8 +98,13 @@ function _actionButton(latest, auth, returnLogId, status) {
     return null
   }
 
+  // You cannot submit or edit a return that is 'not due yet'
+  if (formattedStatus === 'not due yet') {
+    return null
+  }
+
   // You can only edit a completed return
-  if (status === 'completed') {
+  if (formattedStatus === 'completed') {
     return {
       href: `/return/internal?returnId=${returnLogId}`,
       text: 'Edit return'

--- a/app/views/macros/return-status-tag.njk
+++ b/app/views/macros/return-status-tag.njk
@@ -5,6 +5,8 @@
     {% set color = 'govuk-tag--orange' %}
   {% elif status === 'void' %}
     {% set color = 'govuk-tag--grey' %}
+  {% elif status === 'not due yet' %}
+    {% set color = 'govuk-tag--grey' %}
   {% elif status === 'due' %}
     {% set color = 'govuk-tag--blue' %}
   {% elif status === 'received' %}

--- a/app/views/return-logs/view.njk
+++ b/app/views/return-logs/view.njk
@@ -130,22 +130,24 @@
           {% endif %}
 
           {# Mark as under query / Resolve query button #}
-          {% if underQuery %}
-            {% set queryButtonText = 'Resolve query' %}
-            {% set queryButtonValue = 'resolve' %}
-          {% else %}
-            {% set queryButtonText = 'Mark as under query' %}
-            {% set queryButtonValue = 'mark' %}
+          {% if showUnderQuery %}
+            {% if underQuery %}
+              {% set queryButtonText = 'Resolve query' %}
+              {% set queryButtonValue = 'resolve' %}
+            {% else %}
+              {% set queryButtonText = 'Mark as under query' %}
+              {% set queryButtonValue = 'mark' %}
+            {% endif %}
+            {{
+              govukButton({
+                text: queryButtonText,
+                classes: "govuk-button--secondary",
+                name: "mark-query",
+                value: queryButtonValue,
+                preventDoubleClick: true
+              })
+            }}
           {% endif %}
-          {{
-            govukButton({
-              text: queryButtonText,
-              classes: "govuk-button--secondary",
-              name: "mark-query",
-              value: queryButtonValue,
-              preventDoubleClick: true
-            })
-          }}
 
           {% if actionButton %}
             </div>

--- a/test/presenters/licences/view-licence-returns.presenter.test.js
+++ b/test/presenters/licences/view-licence-returns.presenter.test.js
@@ -242,6 +242,19 @@ describe('View Licence returns presenter', () => {
             expect(result.returns[1].status).to.equal('due')
           })
         })
+
+        describe('and the due date is 28 days or more from today', () => {
+          beforeEach(() => {
+            returnLogs[1].dueDate = new Date()
+            returnLogs[1].dueDate.setDate(returnLogs[1].dueDate.getDate() + 27)
+          })
+
+          it('returns "not due yet"', () => {
+            const result = ViewLicenceReturnsPresenter.go(returnLogs, hasRequirements, auth)
+
+            expect(result.returns[1].status).to.equal('not due yet')
+          })
+        })
       })
 
       describe('when the return log has a status of "received"', () => {

--- a/test/presenters/return-logs/base-return-logs.presenter.test.js
+++ b/test/presenters/return-logs/base-return-logs.presenter.test.js
@@ -159,7 +159,7 @@ describe('Base Return Logs presenter', () => {
         })
       })
 
-      describe('and the due date is in the future', () => {
+      describe('and the due date is in the next 28 days', () => {
         before(() => {
           const nextWeek = new Date()
           nextWeek.setDate(nextWeek.getDate() + 7)
@@ -170,6 +170,20 @@ describe('Base Return Logs presenter', () => {
           const result = BaseReturnLogsPresenter.formatStatus(testReturnLog)
 
           expect(result).to.equal('due')
+        })
+      })
+
+      describe('and the due date is after the next 28 days', () => {
+        before(() => {
+          const fourWeeks = new Date()
+          fourWeeks.setDate(fourWeeks.getDate() + 27)
+          testReturnLog.dueDate = fourWeeks
+        })
+
+        it('returns not due yet', () => {
+          const result = BaseReturnLogsPresenter.formatStatus(testReturnLog)
+
+          expect(result).to.equal('not due yet')
         })
       })
     })

--- a/test/presenters/return-logs/view-return-log.presenter.test.js
+++ b/test/presenters/return-logs/view-return-log.presenter.test.js
@@ -26,7 +26,7 @@ const ReturnSubmissionLineModel = require('../../../app/models/return-submission
 
 const { unitNames } = require('../../../app/lib/static-lookups.lib.js')
 
-describe.only('View Return Log presenter', () => {
+describe('View Return Log presenter', () => {
   let auth
   let testReturnLog
 
@@ -104,6 +104,20 @@ describe.only('View Return Log presenter', () => {
           value: testReturnLog.id,
           text: 'Edit return'
         })
+      })
+    })
+
+    describe('when the return is not due yet', () => {
+      beforeEach(() => {
+        const notDueUntilDate = new Date()
+        testReturnLog.dueDate = new Date(notDueUntilDate.setDate(notDueUntilDate.getDate() + 27))
+        testReturnLog.status = 'due'
+      })
+
+      it('returns null', () => {
+        const result = ViewReturnLogPresenter.go(testReturnLog, auth)
+
+        expect(result.actionButton).to.be.null()
       })
     })
 
@@ -452,6 +466,34 @@ describe.only('View Return Log presenter', () => {
       const result = ViewReturnLogPresenter.go(testReturnLog, auth)
 
       expect(result.returnPeriod).to.equal('1 April 2022 to 31 March 2023')
+    })
+  })
+
+  describe('the "showUnderQuery" property', () => {
+    describe('when the return has a status of "not due yet"', () => {
+      beforeEach(() => {
+        const notDueUntilDate = new Date()
+        testReturnLog.dueDate = new Date(notDueUntilDate.setDate(notDueUntilDate.getDate() + 27))
+        testReturnLog.status = 'due'
+      })
+
+      it('returns false', () => {
+        const result = ViewReturnLogPresenter.go(testReturnLog, auth)
+
+        expect(result.showUnderQuery).to.be.false()
+      })
+    })
+
+    describe('when the returns status is not "not due yet"', () => {
+      beforeEach(() => {
+        testReturnLog.status = 'completed'
+      })
+
+      it('returns true', () => {
+        const result = ViewReturnLogPresenter.go(testReturnLog, auth)
+
+        expect(result.showUnderQuery).to.be.true()
+      })
     })
   })
 

--- a/test/presenters/return-logs/view-return-log.presenter.test.js
+++ b/test/presenters/return-logs/view-return-log.presenter.test.js
@@ -26,7 +26,7 @@ const ReturnSubmissionLineModel = require('../../../app/models/return-submission
 
 const { unitNames } = require('../../../app/lib/static-lookups.lib.js')
 
-describe('View Return Log presenter', () => {
+describe.only('View Return Log presenter', () => {
   let auth
   let testReturnLog
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4954
https://eaflood.atlassian.net/browse/WATER-4968

There is a need for a status "Not due yet" for a return that is visible to the user so it is clear to them which return is due for submission. This status should be shown for those returns (Quarterly and Annual) that are not due. This PR is adding that status to the view returns page.