### PR TITLE
Fix 'return received' backlink for submit return

### DIFF
--- a/app/presenters/return-logs/setup/received.presenter.js
+++ b/app/presenters/return-logs/setup/received.presenter.js
@@ -39,13 +39,13 @@ function go(session) {
 }
 
 function _backLink(session) {
-  const { checkPageVisited, id, licenceId } = session
+  const { checkPageVisited, id, returnLogId } = session
 
   if (checkPageVisited) {
     return `/system/return-logs/setup/${id}/check`
   }
 
-  return `/system/licences/${licenceId}/returns`
+  return `/system/return-logs?id=${returnLogId}`
 }
 
 function _yesterdaysDate() {

--- a/test/presenters/return-logs/setup/received.presenter.test.js
+++ b/test/presenters/return-logs/setup/received.presenter.test.js
@@ -13,14 +13,15 @@ const { formatLongDate } = require('../../../../app/presenters/base.presenter.js
 // Thing under test
 const ReceivedPresenter = require('../../../../app/presenters/return-logs/setup/received.presenter.js')
 
-describe('Return Logs Setup - Received presenter', () => {
+describe('Return Logs - Setup - Received presenter', () => {
   let session
 
   beforeEach(() => {
     session = {
       id: '61e07498-f309-4829-96a9-72084a54996d',
-      returnReference: '012345',
-      licenceId: 'a96ce5c6-2c42-4b3f-946d-0428b5f07ce6'
+      licenceId: 'a96ce5c6-2c42-4b3f-946d-0428b5f07ce6',
+      returnLogId: 'v1:1:01/12/123:10065476:2025-01-06:2025-10-31',
+      returnReference: '012345'
     }
   })
 
@@ -36,7 +37,7 @@ describe('Return Logs Setup - Received presenter', () => {
         receivedDateDay: null,
         receivedDateMonth: null,
         receivedDateYear: null,
-        backLink: '/system/licences/a96ce5c6-2c42-4b3f-946d-0428b5f07ce6/returns',
+        backLink: '/system/return-logs?id=v1:1:01/12/123:10065476:2025-01-06:2025-10-31',
         todaysDate: formatLongDate(new Date()),
         yesterdaysDate: _yesterdaysDate()
       })
@@ -57,16 +58,16 @@ describe('Return Logs Setup - Received presenter', () => {
     })
 
     describe('when the user has come from somewhere else', () => {
-      it('returns a link back to the "Licence" page on the "Returns" tab', () => {
+      it('returns a link back to the view "Return Log" page', () => {
         const result = ReceivedPresenter.go(session)
 
-        expect(result.backLink).to.equal('/system/licences/a96ce5c6-2c42-4b3f-946d-0428b5f07ce6/returns')
+        expect(result.backLink).to.equal('/system/return-logs?id=v1:1:01/12/123:10065476:2025-01-06:2025-10-31')
       })
     })
   })
 
   describe('the "receivedDate" properties', () => {
-    describe('when the user has previously selected todays date as the received date', () => {
+    describe("when the user has previously selected today's date as the received date", () => {
       beforeEach(() => {
         session.receivedDateOptions = 'today'
       })

--- a/test/services/return-logs/setup/received.service.test.js
+++ b/test/services/return-logs/setup/received.service.test.js
@@ -13,13 +13,14 @@ const SessionHelper = require('../../../support/helpers/session.helper.js')
 // Thing under test
 const ReceivedService = require('../../../../app/services/return-logs/setup/received.service.js')
 
-describe('Return Logs Setup - Received service', () => {
+describe('Return Logs - Setup - Received service', () => {
   let session
 
   before(async () => {
     session = await SessionHelper.add({
       data: {
         licenceId: '736144f1-203d-46bb-9968-5137ae06a7bd',
+        returnLogId: 'v1:1:01/12/123:10065476:2025-01-06:2025-10-31',
         returnReference: '012345'
       },
       id: 'd958333a-4acd-4add-9e2b-09e14c6b72f3'
@@ -41,7 +42,7 @@ describe('Return Logs Setup - Received service', () => {
           activeNavBar: 'search',
           pageTitle: 'When was the return received?',
           returnReference: '012345',
-          backLink: `/system/licences/736144f1-203d-46bb-9968-5137ae06a7bd/returns`,
+          backLink: `/system/return-logs?id=v1:1:01/12/123:10065476:2025-01-06:2025-10-31`,
           receivedDateOption: null,
           receivedDateDay: null,
           receivedDateMonth: null,

--- a/test/services/return-logs/setup/submit-received.service.test.js
+++ b/test/services/return-logs/setup/submit-received.service.test.js
@@ -14,7 +14,7 @@ const SessionHelper = require('../../../support/helpers/session.helper.js')
 // Thing under test
 const SubmitReceivedService = require('../../../../app/services/return-logs/setup/submit-received.service.js')
 
-describe('Return Logs Setup - Submit Received service', () => {
+describe('Return Logs - Setup - Submit Received service', () => {
   let payload
   let session
   let sessionData
@@ -24,9 +24,10 @@ describe('Return Logs Setup - Submit Received service', () => {
   beforeEach(async () => {
     sessionData = {
       data: {
+        licenceId: 'cd190dc7-912a-46a5-9421-2750fb1c7ac8',
+        returnLogId: 'v1:1:01/12/123:10065476:2025-01-06:2025-10-31',
         returnReference: '12345',
-        startDate: '2023-04-01T00:00:00.000Z',
-        licenceId: 'cd190dc7-912a-46a5-9421-2750fb1c7ac8'
+        startDate: '2023-04-01T00:00:00.000Z'
       }
     }
 
@@ -153,7 +154,7 @@ describe('Return Logs Setup - Submit Received service', () => {
             receivedDateMonth: null,
             receivedDateYear: null,
             receivedDateOption: null,
-            backLink: `/system/licences/cd190dc7-912a-46a5-9421-2750fb1c7ac8/returns`,
+            backLink: `/system/return-logs?id=v1:1:01/12/123:10065476:2025-01-06:2025-10-31`,
             returnReference: '12345'
           },
           { skip: ['sessionId', 'error', 'todaysDate', 'yesterdaysDate'] }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4844

We've spotted that when you submit a return for the first time, the `< Back` on the "When was the return received?" page takes you to the licence's returns tab, not the 'view return log' page you've just come from.

> This is assuming you've not yet reached the `/check` page, at which point `< Back` will take you there.

This small change fixes it to return you to the return log you've just come from.