### PR TITLE
Add notifications setup update notifications

### DIFF
--- a/app/services/notifications/setup/update-notifications.service.js
+++ b/app/services/notifications/setup/update-notifications.service.js
@@ -14,12 +14,32 @@ const ScheduledNotificationModel = require('../../../../app/models/scheduled-not
  * https://www.postgresql.org/docs/current/postgres-fdw.html#POSTGRES-FDW-OPTIONS-REMOTE-EXECUTION. The calling
  * service will handle the batch process.
  *
+ * We have used an insert with onConflict to allow us to provide an array of notifications to reduce the calls needed to
+ * the database.
+ *
+ * ```javascript
+ * [
+ *   {
+ *     notifyId: '1234',
+ *     notifyStatus: 'received',
+ *     status: 'sent'
+ *   },
+ *   {
+ *     notifyId: '123',
+ *     status: 'sent'
+ *   }
+ * ]
+ * ```
+ *
  * @param {object} notifications
  *
  * @returns {object} - the Updated notifications
  */
 async function go(notifications) {
-  return ScheduledNotificationModel.query().insert(notifications).onConflict('id').merge(['status', 'notifyStatus'])
+  return ScheduledNotificationModel.query()
+    .insert(notifications)
+    .onConflict('notifyId')
+    .merge(['status', 'notifyStatus'])
 }
 
 module.exports = {

--- a/app/services/notifications/setup/update-notifications.service.js
+++ b/app/services/notifications/setup/update-notifications.service.js
@@ -16,10 +16,9 @@ const ScheduledNotificationModel = require('../../../../app/models/scheduled-not
  *
  * @param {object} notifications
  *
- * @returns {object} - the Updated notifications
  */
 async function go(notifications) {
-  return ScheduledNotificationModel.query().insert(notifications).onConflict('id').merge(['status', 'notifyStatus'])
+  await ScheduledNotificationModel.query().insert(notifications).onConflict('id').merge(['status', 'notifyStatus'])
 }
 
 module.exports = {

--- a/app/services/notifications/setup/update-notifications.service.js
+++ b/app/services/notifications/setup/update-notifications.service.js
@@ -14,32 +14,12 @@ const ScheduledNotificationModel = require('../../../../app/models/scheduled-not
  * https://www.postgresql.org/docs/current/postgres-fdw.html#POSTGRES-FDW-OPTIONS-REMOTE-EXECUTION. The calling
  * service will handle the batch process.
  *
- * We have used an insert with onConflict to allow us to provide an array of notifications to reduce the calls needed to
- * the database.
- *
- * ```javascript
- * [
- *   {
- *     notifyId: '1234',
- *     notifyStatus: 'received',
- *     status: 'sent'
- *   },
- *   {
- *     notifyId: '123',
- *     status: 'sent'
- *   }
- * ]
- * ```
- *
  * @param {object} notifications
  *
  * @returns {object} - the Updated notifications
  */
 async function go(notifications) {
-  return ScheduledNotificationModel.query()
-    .insert(notifications)
-    .onConflict('notifyId')
-    .merge(['status', 'notifyStatus'])
+  return ScheduledNotificationModel.query().insert(notifications).onConflict('id').merge(['status', 'notifyStatus'])
 }
 
 module.exports = {

--- a/app/services/notifications/setup/update-notifications.service.js
+++ b/app/services/notifications/setup/update-notifications.service.js
@@ -1,0 +1,27 @@
+'use strict'
+
+/**
+ * Update notifications
+ * @module UpdateNotificationsService
+ */
+
+const ScheduledNotificationModel = require('../../../../app/models/scheduled-notification.model.js')
+
+/**
+ * Update notifications
+ *
+ * This query uses postgresql's ability to insert with batches. There is a limitation on the batch size
+ * https://www.postgresql.org/docs/current/postgres-fdw.html#POSTGRES-FDW-OPTIONS-REMOTE-EXECUTION. The calling
+ * service will handle the batch process.
+ *
+ * @param {object} notifications
+ *
+ * @returns {object} - the Updated notifications
+ */
+async function go(notifications) {
+  return ScheduledNotificationModel.query().insert(notifications).onConflict('id').merge(['status', 'notifyStatus'])
+}
+
+module.exports = {
+  go
+}

--- a/test/services/notifications/setup/update-notifications.service.tests.js
+++ b/test/services/notifications/setup/update-notifications.service.tests.js
@@ -9,9 +9,9 @@ const { expect } = Code
 
 // Test helpers
 const EventHelper = require('../../../support/helpers/event.helper.js')
+const { timestampForPostgres } = require('../../../../app/lib/general.lib.js')
 const ScheduledNotificationHelper = require('../../../support/helpers/scheduled-notification.helper.js')
 const ScheduledNotificationModel = require('../../../../app/models/scheduled-notification.model.js')
-const { timestampForPostgres } = require('../../../../app/lib/general.lib.js')
 
 // Thing under test
 const UpdateNotificationsService = require('../../../../app/services/notifications/setup/update-notifications.service.js')

--- a/test/services/notifications/setup/update-notifications.service.tests.js
+++ b/test/services/notifications/setup/update-notifications.service.tests.js
@@ -52,9 +52,9 @@ describe('Notifications Setup - Update Notifications service', () => {
     it("updates only the notification's required values", async () => {
       await UpdateNotificationsService.go(notifications)
 
-      const createdResult = await ScheduledNotificationModel.query().where('eventId', eventId)
+      const result = await scheduledNotification.$query()
 
-      expect(createdResult).equal([
+      expect(result).equal(
         {
           companyId: null,
           createdAt: new Date(scheduledNotification.createdAt),

--- a/test/services/notifications/setup/update-notifications.service.tests.js
+++ b/test/services/notifications/setup/update-notifications.service.tests.js
@@ -9,14 +9,14 @@ const { expect } = Code
 
 // Test helpers
 const EventHelper = require('../../../support/helpers/event.helper.js')
-const { timestampForPostgres, generateUUID } = require('../../../../app/lib/general.lib.js')
+const { timestampForPostgres } = require('../../../../app/lib/general.lib.js')
 const ScheduledNotificationHelper = require('../../../support/helpers/scheduled-notification.helper.js')
 const ScheduledNotificationModel = require('../../../../app/models/scheduled-notification.model.js')
 
 // Thing under test
 const UpdateNotificationsService = require('../../../../app/services/notifications/setup/update-notifications.service.js')
 
-describe.only('Notifications Setup - Update Notifications service', () => {
+describe('Notifications Setup - Update Notifications service', () => {
   let eventId
   let notifications
   let scheduledNotification
@@ -32,7 +32,6 @@ describe.only('Notifications Setup - Update Notifications service', () => {
 
     scheduledNotification = await ScheduledNotificationHelper.add({
       createdAt: timestampForPostgres(),
-      notifyId: generateUUID(),
       eventId,
       status: 'sending'
     })
@@ -88,7 +87,6 @@ describe.only('Notifications Setup - Update Notifications service', () => {
       scheduledNotification2 = await ScheduledNotificationHelper.add({
         createdAt: timestampForPostgres(),
         eventId,
-        notifyId: generateUUID(),
         status: 'sending'
       })
 

--- a/test/services/notifications/setup/update-notifications.service.tests.js
+++ b/test/services/notifications/setup/update-notifications.service.tests.js
@@ -9,14 +9,14 @@ const { expect } = Code
 
 // Test helpers
 const EventHelper = require('../../../support/helpers/event.helper.js')
-const { timestampForPostgres } = require('../../../../app/lib/general.lib.js')
+const { timestampForPostgres, generateUUID } = require('../../../../app/lib/general.lib.js')
 const ScheduledNotificationHelper = require('../../../support/helpers/scheduled-notification.helper.js')
 const ScheduledNotificationModel = require('../../../../app/models/scheduled-notification.model.js')
 
 // Thing under test
 const UpdateNotificationsService = require('../../../../app/services/notifications/setup/update-notifications.service.js')
 
-describe('Notifications Setup - Update Notifications service', () => {
+describe.only('Notifications Setup - Update Notifications service', () => {
   let eventId
   let notifications
   let scheduledNotification
@@ -32,6 +32,7 @@ describe('Notifications Setup - Update Notifications service', () => {
 
     scheduledNotification = await ScheduledNotificationHelper.add({
       createdAt: timestampForPostgres(),
+      notifyId: generateUUID(),
       eventId,
       status: 'sending'
     })
@@ -87,6 +88,7 @@ describe('Notifications Setup - Update Notifications service', () => {
       scheduledNotification2 = await ScheduledNotificationHelper.add({
         createdAt: timestampForPostgres(),
         eventId,
+        notifyId: generateUUID(),
         status: 'sending'
       })
 

--- a/test/services/notifications/setup/update-notifications.service.tests.js
+++ b/test/services/notifications/setup/update-notifications.service.tests.js
@@ -9,9 +9,8 @@ const { expect } = Code
 
 // Test helpers
 const EventHelper = require('../../../support/helpers/event.helper.js')
-const { timestampForPostgres } = require('../../../../app/lib/general.lib.js')
 const ScheduledNotificationHelper = require('../../../support/helpers/scheduled-notification.helper.js')
-const ScheduledNotificationModel = require('../../../../app/models/scheduled-notification.model.js')
+const { timestampForPostgres } = require('../../../../app/lib/general.lib.js')
 
 // Thing under test
 const UpdateNotificationsService = require('../../../../app/services/notifications/setup/update-notifications.service.js')
@@ -54,31 +53,29 @@ describe('Notifications Setup - Update Notifications service', () => {
 
       const result = await scheduledNotification.$query()
 
-      expect(result).equal(
-        {
-          companyId: null,
-          createdAt: new Date(scheduledNotification.createdAt),
-          eventId,
-          id: scheduledNotification.id,
-          individualId: null,
-          jobId: null,
-          licences: null,
-          log: null,
-          messageRef: null,
-          messageType: null,
-          metadata: null,
-          nextStatusCheck: null,
-          notificationType: null,
-          notifyId: null,
-          notifyStatus: 'received',
-          personalisation: null,
-          plaintext: null,
-          recipient: null,
-          sendAfter: null,
-          status: 'sent',
-          statusChecks: null
-        }
-      ])
+      expect(result).equal({
+        companyId: null,
+        createdAt: new Date(scheduledNotification.createdAt),
+        eventId,
+        id: scheduledNotification.id,
+        individualId: null,
+        jobId: null,
+        licences: null,
+        log: null,
+        messageRef: null,
+        messageType: null,
+        metadata: null,
+        nextStatusCheck: null,
+        notificationType: null,
+        notifyId: null,
+        notifyStatus: 'received',
+        personalisation: null,
+        plaintext: null,
+        recipient: null,
+        sendAfter: null,
+        status: 'sent',
+        statusChecks: null
+      })
     })
   })
 
@@ -105,59 +102,90 @@ describe('Notifications Setup - Update Notifications service', () => {
       ]
     })
 
-    it('updates the notifications required values', async () => {
+    it('updates the first notification', async () => {
       await UpdateNotificationsService.go(notifications)
 
-      let result = await scheduledNotification.$query()
+      const result = await scheduledNotification.$query()
 
-      expect(result).equal(
-        {
-          companyId: null,
-          createdAt: new Date(scheduledNotification.createdAt),
-          eventId,
-          id: scheduledNotification.id,
-          individualId: null,
-          jobId: null,
-          licences: null,
-          log: null,
-          messageRef: null,
-          messageType: null,
-          metadata: null,
-          nextStatusCheck: null,
-          notificationType: null,
-          notifyId: null,
-          notifyStatus: 'received',
-          personalisation: null,
-          plaintext: null,
-          recipient: null,
-          sendAfter: null,
-          status: 'sent',
-          statusChecks: null
-        },
-        {
-          companyId: null,
-          createdAt: new Date(scheduledNotification2.createdAt),
-          eventId,
-          id: scheduledNotification2.id,
-          individualId: null,
-          jobId: null,
-          licences: null,
-          log: null,
-          messageRef: null,
-          messageType: null,
-          metadata: null,
-          nextStatusCheck: null,
-          notificationType: null,
-          notifyId: null,
-          notifyStatus: null,
-          personalisation: null,
-          plaintext: null,
-          recipient: null,
-          sendAfter: null,
-          status: 'sent',
-          statusChecks: null
-        }
-      ])
+      expect(result).equal({
+        companyId: null,
+        createdAt: new Date(scheduledNotification.createdAt),
+        eventId,
+        id: scheduledNotification.id,
+        individualId: null,
+        jobId: null,
+        licences: null,
+        log: null,
+        messageRef: null,
+        messageType: null,
+        metadata: null,
+        nextStatusCheck: null,
+        notificationType: null,
+        notifyId: null,
+        notifyStatus: 'received',
+        personalisation: null,
+        plaintext: null,
+        recipient: null,
+        sendAfter: null,
+        status: 'sent',
+        statusChecks: null
+      })
+
+      const result2 = await scheduledNotification2.$query()
+
+      expect(result2).to.equal({
+        companyId: null,
+        createdAt: new Date(scheduledNotification2.createdAt),
+        eventId,
+        id: scheduledNotification2.id,
+        individualId: null,
+        jobId: null,
+        licences: null,
+        log: null,
+        messageRef: null,
+        messageType: null,
+        metadata: null,
+        nextStatusCheck: null,
+        notificationType: null,
+        notifyId: null,
+        notifyStatus: null,
+        personalisation: null,
+        plaintext: null,
+        recipient: null,
+        sendAfter: null,
+        status: 'sent',
+        statusChecks: null
+      })
+    })
+
+    it('updates the second notification', async () => {
+      await UpdateNotificationsService.go(notifications)
+
+      const result = await scheduledNotification2.$query()
+
+      expect(result).to.equal({
+        companyId: null,
+        createdAt: new Date(scheduledNotification2.createdAt),
+        eventId,
+        id: scheduledNotification2.id,
+        individualId: null,
+        jobId: null,
+        licences: null,
+        log: null,
+        messageRef: null,
+        messageType: null,
+        metadata: null,
+        nextStatusCheck: null,
+        notificationType: null,
+        notifyId: null,
+        notifyStatus: null,
+        personalisation: null,
+        plaintext: null,
+        recipient: null,
+        sendAfter: null,
+        status: 'sent',
+        statusChecks: null
+      })
     })
   })
 })

--- a/test/services/notifications/setup/update-notifications.service.tests.js
+++ b/test/services/notifications/setup/update-notifications.service.tests.js
@@ -49,7 +49,7 @@ describe('Notifications Setup - Update Notifications service', () => {
       ]
     })
 
-    it('should update a single notification (and only update the required values)', async () => {
+    it("updates only the notification's required values", async () => {
       await UpdateNotificationsService.go(notifications)
 
       const createdResult = await ScheduledNotificationModel.query().where('eventId', eventId)

--- a/test/services/notifications/setup/update-notifications.service.tests.js
+++ b/test/services/notifications/setup/update-notifications.service.tests.js
@@ -130,32 +130,6 @@ describe('Notifications Setup - Update Notifications service', () => {
         status: 'sent',
         statusChecks: null
       })
-
-      const result2 = await scheduledNotification2.$query()
-
-      expect(result2).to.equal({
-        companyId: null,
-        createdAt: new Date(scheduledNotification2.createdAt),
-        eventId,
-        id: scheduledNotification2.id,
-        individualId: null,
-        jobId: null,
-        licences: null,
-        log: null,
-        messageRef: null,
-        messageType: null,
-        metadata: null,
-        nextStatusCheck: null,
-        notificationType: null,
-        notifyId: null,
-        notifyStatus: null,
-        personalisation: null,
-        plaintext: null,
-        recipient: null,
-        sendAfter: null,
-        status: 'sent',
-        statusChecks: null
-      })
     })
 
     it('updates the second notification', async () => {

--- a/test/services/notifications/setup/update-notifications.service.tests.js
+++ b/test/services/notifications/setup/update-notifications.service.tests.js
@@ -1,0 +1,163 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Test helpers
+const EventHelper = require('../../../support/helpers/event.helper.js')
+const ScheduledNotificationHelper = require('../../../support/helpers/scheduled-notification.helper.js')
+const ScheduledNotificationModel = require('../../../../app/models/scheduled-notification.model.js')
+const { timestampForPostgres } = require('../../../../app/lib/general.lib.js')
+
+// Thing under test
+const UpdateNotificationsService = require('../../../../app/services/notifications/setup/update-notifications.service.js')
+
+describe('Notifications Setup - Update notification service', () => {
+  let eventId
+  let notifications
+  let scheduledNotification
+  let scheduledNotification2
+
+  beforeEach(async () => {
+    const event = await EventHelper.add({
+      type: 'notification',
+      subtype: 'returnsInvitation'
+    })
+
+    eventId = event.id
+
+    scheduledNotification = await ScheduledNotificationHelper.add({
+      createdAt: timestampForPostgres(),
+      eventId,
+      status: 'sending'
+    })
+  })
+
+  describe('when updating a single notification', () => {
+    beforeEach(async () => {
+      notifications = [
+        {
+          createdAt: new Date(scheduledNotification.createdAt),
+          id: scheduledNotification.id,
+          notifyStatus: 'received',
+          status: 'sent'
+        }
+      ]
+    })
+
+    it('should update a single notification (and only update the required values)', async () => {
+      await UpdateNotificationsService.go(notifications)
+
+      const createdResult = await ScheduledNotificationModel.query().where('eventId', eventId)
+
+      expect(createdResult).equal([
+        {
+          companyId: null,
+          createdAt: new Date(scheduledNotification.createdAt),
+          eventId,
+          id: scheduledNotification.id,
+          individualId: null,
+          jobId: null,
+          licences: null,
+          log: null,
+          messageRef: null,
+          messageType: null,
+          metadata: null,
+          nextStatusCheck: null,
+          notificationType: null,
+          notifyId: null,
+          notifyStatus: 'received',
+          personalisation: null,
+          plaintext: null,
+          recipient: null,
+          sendAfter: null,
+          status: 'sent',
+          statusChecks: null
+        }
+      ])
+    })
+  })
+
+  describe('when updating multiple notifications', () => {
+    beforeEach(async () => {
+      scheduledNotification2 = await ScheduledNotificationHelper.add({
+        createdAt: timestampForPostgres(),
+        eventId,
+        status: 'sending'
+      })
+
+      notifications = [
+        {
+          createdAt: new Date(scheduledNotification.createdAt),
+          id: scheduledNotification.id,
+          notifyStatus: 'received',
+          status: 'sent'
+        },
+        {
+          createdAt: new Date(scheduledNotification2.createdAt),
+          id: scheduledNotification2.id,
+          status: 'sent'
+        }
+      ]
+    })
+
+    it('should return the saved notifications', async () => {
+      await UpdateNotificationsService.go(notifications)
+
+      const createdResult = await ScheduledNotificationModel.query().where('eventId', eventId)
+
+      expect(createdResult).equal([
+        {
+          companyId: null,
+          createdAt: new Date(scheduledNotification.createdAt),
+          eventId,
+          id: scheduledNotification.id,
+          individualId: null,
+          jobId: null,
+          licences: null,
+          log: null,
+          messageRef: null,
+          messageType: null,
+          metadata: null,
+          nextStatusCheck: null,
+          notificationType: null,
+          notifyId: null,
+          notifyStatus: 'received',
+          personalisation: null,
+          plaintext: null,
+          recipient: null,
+          sendAfter: null,
+          status: 'sent',
+          statusChecks: null
+        },
+        {
+          companyId: null,
+          createdAt: new Date(scheduledNotification2.createdAt),
+          eventId,
+          id: scheduledNotification2.id,
+          individualId: null,
+          jobId: null,
+          licences: null,
+          log: null,
+          messageRef: null,
+          messageType: null,
+          metadata: null,
+          nextStatusCheck: null,
+          notificationType: null,
+          notifyId: null,
+          notifyStatus: null,
+          personalisation: null,
+          plaintext: null,
+          recipient: null,
+          sendAfter: null,
+          status: 'sent',
+          statusChecks: null
+        }
+      ])
+    })
+  })
+})

--- a/test/services/notifications/setup/update-notifications.service.tests.js
+++ b/test/services/notifications/setup/update-notifications.service.tests.js
@@ -108,9 +108,9 @@ describe('Notifications Setup - Update Notifications service', () => {
     it('updates the notifications required values', async () => {
       await UpdateNotificationsService.go(notifications)
 
-      const createdResult = await ScheduledNotificationModel.query().where('eventId', eventId)
+      let result = await scheduledNotification.$query()
 
-      expect(createdResult).equal([
+      expect(result).equal(
         {
           companyId: null,
           createdAt: new Date(scheduledNotification.createdAt),

--- a/test/services/notifications/setup/update-notifications.service.tests.js
+++ b/test/services/notifications/setup/update-notifications.service.tests.js
@@ -105,7 +105,7 @@ describe('Notifications Setup - Update Notifications service', () => {
       ]
     })
 
-    it('should return the saved notifications', async () => {
+    it('updates the notifications required values', async () => {
       await UpdateNotificationsService.go(notifications)
 
       const createdResult = await ScheduledNotificationModel.query().where('eventId', eventId)

--- a/test/services/notifications/setup/update-notifications.service.tests.js
+++ b/test/services/notifications/setup/update-notifications.service.tests.js
@@ -16,7 +16,7 @@ const { timestampForPostgres } = require('../../../../app/lib/general.lib.js')
 // Thing under test
 const UpdateNotificationsService = require('../../../../app/services/notifications/setup/update-notifications.service.js')
 
-describe('Notifications Setup - Update notification service', () => {
+describe('Notifications Setup - Update Notifications service', () => {
   let eventId
   let notifications
   let scheduledNotification


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4961

When a notification has been sent to GOV.UK Notify we need to check the status of the notification. We receive various statuses from Notify.

This change introduces an 'UpdateNotificationsService'. This service will update the 'status' and 'notifyStatus' for a 'scheduledNotification'.