### PR TITLE
Add job notifications status update

### DIFF
--- a/app/controllers/jobs.controller.js
+++ b/app/controllers/jobs.controller.js
@@ -7,6 +7,7 @@
 
 const ExportService = require('../services/jobs/export/export.service.js')
 const ProcessLicenceUpdates = require('../services/jobs/licence-updates/process-licence-updates.js')
+const ProcessNotificationsStatusUpdatesService = require('../services/jobs/notifications/notifications-status-updates.service.js')
 const ProcessReturnLogsService = require('../services/jobs/return-logs/process-return-logs.service.js')
 const ProcessSessionStorageCleanupService = require('../services/jobs/session-cleanup/process-session-storage-cleanup.service.js')
 const ProcessTimeLimitedLicencesService = require('../services/jobs/time-limited/process-time-limited-licences.service.js')
@@ -32,6 +33,12 @@ async function exportDb(_request, h) {
 
 async function licenceUpdates(_request, h) {
   ProcessLicenceUpdates.go()
+
+  return h.response().code(NO_CONTENT_STATUS_CODE)
+}
+
+async function notificationsStatusUpdates(_request, h) {
+  ProcessNotificationsStatusUpdatesService.go()
 
   return h.response().code(NO_CONTENT_STATUS_CODE)
 }
@@ -69,6 +76,7 @@ async function returnVersionMigration(request, h) {
 module.exports = {
   exportDb,
   licenceUpdates,
+  notificationsStatusUpdates,
   returnLogs,
   returnVersionMigration,
   sessionCleanup,

--- a/app/routes/jobs.routes.js
+++ b/app/routes/jobs.routes.js
@@ -33,6 +33,20 @@ const routes = [
   },
   {
     method: 'POST',
+    path: '/jobs/notifications-status-updates',
+    options: {
+      handler: JobsController.notificationsStatusUpdates,
+      app: {
+        plainOutput: true
+      },
+      auth: false,
+      plugins: {
+        crumb: false
+      }
+    }
+  },
+  {
+    method: 'POST',
     path: '/jobs/session-cleanup',
     options: {
       handler: JobsController.sessionCleanup,

--- a/app/services/jobs/notifications/notifications-status-updates.service.js
+++ b/app/services/jobs/notifications/notifications-status-updates.service.js
@@ -1,0 +1,15 @@
+'use strict'
+
+/**
+ * Updates the statuses of notifications
+ * @module ProcessNotificationsStatusUpdatesService
+ */
+
+/**
+ * Updates the statuses of notifications
+ */
+async function go() {}
+
+module.exports = {
+  go
+}

--- a/test/controllers/jobs.controller.test.js
+++ b/test/controllers/jobs.controller.test.js
@@ -11,6 +11,7 @@ const { expect } = Code
 // Things we need to stub
 const ExportService = require('../../app/services/jobs/export/export.service.js')
 const ProcessLicenceUpdatesService = require('../../app/services/jobs/licence-updates/process-licence-updates.js')
+const ProcessNotificationsStatusUpdatesServiceService = require('../../app/services/jobs/notifications/notifications-status-updates.service.js')
 const ProcessReturnLogsService = require('../../app/services/jobs/return-logs/process-return-logs.service.js')
 const ProcessSessionStorageCleanupService = require('../../app/services/jobs/session-cleanup/process-session-storage-cleanup.service.js')
 const ProcessTimeLimitedLicencesService = require('../../app/services/jobs/time-limited/process-time-limited-licences.service.js')
@@ -69,6 +70,26 @@ describe('Jobs controller', () => {
       describe('when the request succeeds', () => {
         beforeEach(async () => {
           Sinon.stub(ProcessLicenceUpdatesService, 'go').resolves()
+        })
+
+        it('returns a 204 response', async () => {
+          const response = await server.inject(options)
+
+          expect(response.statusCode).to.equal(204)
+        })
+      })
+    })
+  })
+
+  describe('/jobs/notifications-status-updates', () => {
+    describe('POST', () => {
+      beforeEach(() => {
+        options = { method: 'POST', url: '/jobs/notifications-status-updates' }
+      })
+
+      describe('when the request succeeds', () => {
+        beforeEach(async () => {
+          Sinon.stub(ProcessNotificationsStatusUpdatesServiceService, 'go').resolves()
         })
 
         it('returns a 204 response', async () => {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4961

As part of the work to migrate the legacy notifications into the system repo, we need to have a mechanism to check and update the notifications statuses.

This change add the initial endpoint to trigger the 'ProcessNotificationsStatusUpdatesService'.

This service will check, with Notify, the status of a notification and update the local status.