### PR TITLE
Update fetch event notifications service tests

### DIFF
--- a/app/services/jobs/notifications/fetch-event-notifications.service.js
+++ b/app/services/jobs/notifications/fetch-event-notifications.service.js
@@ -24,7 +24,7 @@ const EventModel = require('../../../models/event.model.js')
  */
 async function go() {
   return EventModel.query()
-    .select('referenceCode')
+    .select('id')
     .whereExists(EventModel.relatedQuery('scheduledNotifications').whereIn('status', ['sending']))
     .andWhere('status', 'completed')
     .andWhere('type', 'notification')


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4961

There is an issue when running this test with the rest of the test suit.

Other tests are creating events with similar data to this. The expectation of the original test was the occurrence of only one event with the status 'completed' and type 'notification'.

Other tests are now creating the same condition.

To fix this we need to explicitly test that the result of the query contains our expected event.

This also mean we need to test for the absence of the events that should not be returned.

This change implements both of these fixes.