### PR TITLE
Update fetch event notifications to only withing the last seven days

### DIFF
--- a/app/services/jobs/notifications/fetch-event-notifications.service.js
+++ b/app/services/jobs/notifications/fetch-event-notifications.service.js
@@ -8,6 +8,8 @@
 
 const EventModel = require('../../../models/event.model.js')
 
+const SEVEN_DAYS = 7
+
 /**
  * Fetches the scheduled notifications for events with a status of 'completed' and associated scheduled notifications
  * that have a status of 'sending'.
@@ -25,7 +27,7 @@ const EventModel = require('../../../models/event.model.js')
 async function go() {
   const today = new Date()
   const sevenDaysAgo = new Date()
-  sevenDaysAgo.setDate(today.getDate() - 7)
+  sevenDaysAgo.setDate(today.getDate() - SEVEN_DAYS)
 
   return EventModel.query()
     .select('id')

--- a/app/services/jobs/notifications/fetch-event-notifications.service.js
+++ b/app/services/jobs/notifications/fetch-event-notifications.service.js
@@ -23,11 +23,16 @@ const EventModel = require('../../../models/event.model.js')
  * @returns {Promise<object[]>} - an 'event' with an array of 'scheduledNotifications'
  */
 async function go() {
+  const today = new Date()
+  const sevenDaysAgo = new Date()
+  sevenDaysAgo.setDate(today.getDate() - 7)
+
   return EventModel.query()
     .select('id')
     .whereExists(EventModel.relatedQuery('scheduledNotifications').whereIn('status', ['sending']))
     .andWhere('status', 'completed')
     .andWhere('type', 'notification')
+    .andWhere('createdAt', '>=', sevenDaysAgo)
     .withGraphFetched('scheduledNotifications')
     .modifyGraph('scheduledNotifications', (builder) => {
       builder.select(['id', 'notifyId', 'status', 'notifyStatus', 'log']).whereIn('status', ['sending'])


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4961

This change updates the FetchEventNotificationsService to ensure that only events with scheduled notifications, where the createdAt date is within the last 7 days, are returned. This aligns with GOV.UK Notify's retention policy, which requires data to be kept for no more than 7 days.