### PR TITLE
Fix arrow-body-style eslint rule

### DIFF
--- a/app/lib/general.lib.js
+++ b/app/lib/general.lib.js
@@ -289,8 +289,12 @@ function transformStringOfLicencesToArray(licences) {
   return licences
     .replace(/\n/g, ',') // Replace newlines with commas
     .split(',') // Split by commas
-    .map((item) => item.trim()) // Trim any leading/trailing spaces
-    .filter((item) => item !== '') // Remove empty strings if any
+    .map((item) => {
+      return item.trim()
+    }) // Trim any leading/trailing spaces
+    .filter((item) => {
+      return item !== ''
+    }) // Remove empty strings if any
 }
 
 module.exports = {

--- a/app/presenters/return-submissions/view-return-submission.presenter.js
+++ b/app/presenters/return-submissions/view-return-submission.presenter.js
@@ -21,9 +21,9 @@ function go(returnSubmission, yearMonth) {
   const { returnSubmissionLines } = returnSubmission
 
   const [requestedYear, requestedMonth] = _determineRequestedYearAndMonth(yearMonth)
-  const requestedMonthLines = returnSubmissionLines.filter(
-    (line) => line.endDate.getFullYear() === requestedYear && line.endDate.getMonth() === requestedMonth
-  )
+  const requestedMonthLines = returnSubmissionLines.filter((line) => {
+    return line.endDate.getFullYear() === requestedYear && line.endDate.getMonth() === requestedMonth
+  })
 
   const method = returnSubmission.$method()
   const units = returnSubmission.$units()

--- a/app/services/jobs/notifications/notifications-status-updates.service.js
+++ b/app/services/jobs/notifications/notifications-status-updates.service.js
@@ -73,7 +73,9 @@ async function _notificationStatus(scheduledNotification) {
 async function _updateNotifications(toSendNotifications) {
   const settledPromises = await Promise.allSettled(toSendNotifications)
 
-  return settledPromises.map((settledPromise) => settledPromise.value)
+  return settledPromises.map((settledPromise) => {
+    return settledPromise.value
+  })
 }
 
 function _toUpdateNotifications(scheduledNotifications) {

--- a/app/services/notifications/setup/batch-notifications.service.js
+++ b/app/services/notifications/setup/batch-notifications.service.js
@@ -140,7 +140,9 @@ async function _sendEmail(scheduledNotification) {
 async function _sentNotifications(toSendNotifications) {
   const settledPromises = await Promise.allSettled(toSendNotifications)
 
-  return settledPromises.map((settledPromise) => settledPromise.value)
+  return settledPromises.map((settledPromise) => {
+    return settledPromise.value
+  })
 }
 
 /**

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -39,9 +39,8 @@ module.exports = [
       jsdoc: jsdocPlugin,
       import: neostandard.plugins['import-x']
     },
+    // NOTE: Special case for arrow-body-style below
     rules: {
-      // Enforce braces around the function body of arrow functions
-      'arrow-body-style': ['error', 'always'],
       // Enforce .js extension when requiring files
       'import/extensions': ['error', 'always'],
       // Enforce 'use strict' declarations in all modules
@@ -86,7 +85,17 @@ module.exports = [
   // Adds prettier ESLint rules. It automatically sets up eslint-config-prettier, which turns off any rules declared
   // above that conflict with prettier. That shouldn't be any, as we tell neostandard not to include any style rules
   // and the ones we've declared we've done as per eslint-config-prettier docs on special rules. As recommended by
-  // eslint-plugin-prettier, we declare this config last
+  // eslint-plugin-prettier, we declare this config last ... _almost_!
   // https://github.com/prettier/eslint-plugin-prettier?tab=readme-ov-file#configuration-new-eslintconfigjs
-  eslintPluginPrettierRecommended
+  eslintPluginPrettierRecommended,
+  // Normally this would be declared with the rest of the rules above. However, there is a known issue with
+  // eslint-plugin-prettier and the arrow-body-style rule. In _some_ cases, use of ESLint's autofix will result in code
+  // that prettier will deem invalid. There is no fix for this, so the plugin folks avoid the issue by disabling the
+  // rule. This means to get it back, we have to declare it _after_ the config eslint-plugin-prettier applies.
+  {
+    rules: {
+      // Enforce braces around the function body of arrow functions
+      'arrow-body-style': ['error', 'always']
+    }
+  }
 ]

--- a/test/presenters/notifications/setup/check.presenter.test.js
+++ b/test/presenters/notifications/setup/check.presenter.test.js
@@ -211,9 +211,9 @@ describe('Notifications Setup - Check presenter', () => {
               it('should return the email address', () => {
                 const result = CheckPresenter.go(testInput, page, pagination, session)
 
-                const testRecipient = result.recipients.find((recipient) =>
-                  recipient.licences.includes(testRecipients.primaryUser.licence_refs)
-                )
+                const testRecipient = result.recipients.find((recipient) => {
+                  return recipient.licences.includes(testRecipients.primaryUser.licence_refs)
+                })
 
                 expect(testRecipient).to.equal({
                   contact: ['primary.user@important.com'],
@@ -227,9 +227,9 @@ describe('Notifications Setup - Check presenter', () => {
               it('should convert the contact into an array', () => {
                 const result = CheckPresenter.go(testInput, page, pagination, session)
 
-                const testRecipient = result.recipients.find((recipient) =>
-                  recipient.licences.includes(testRecipients.licenceHolder.licence_refs)
-                )
+                const testRecipient = result.recipients.find((recipient) => {
+                  return recipient.licences.includes(testRecipients.licenceHolder.licence_refs)
+                })
 
                 expect(testRecipient).to.equal({
                   contact: ['Mr H J Licence holder', '1', 'Privet Drive', 'Little Whinging', 'Surrey', 'WD25 7LR'],
@@ -245,9 +245,9 @@ describe('Notifications Setup - Check presenter', () => {
               it('should return licence numbers as an array', () => {
                 const result = CheckPresenter.go(testInput, page, pagination, session)
 
-                const testRecipient = result.recipients.find((recipient) =>
-                  recipient.licences.includes(testRecipients.licenceHolder.licence_refs)
-                )
+                const testRecipient = result.recipients.find((recipient) => {
+                  return recipient.licences.includes(testRecipients.licenceHolder.licence_refs)
+                })
 
                 expect(testRecipient.licences).to.equal([testRecipients.licenceHolder.licence_refs])
               })
@@ -257,11 +257,14 @@ describe('Notifications Setup - Check presenter', () => {
               it('should return licence numbers as an array', () => {
                 const result = CheckPresenter.go(testInput, page, pagination, session)
 
-                const testRecipient = result.recipients.find(
-                  (recipient) =>
-                    JSON.stringify(recipient.licences) ===
-                    JSON.stringify(testRecipients.licenceHolderWithMultipleLicences.licence_refs.split(','))
-                )
+                const testRecipient = result.recipients.find((recipient) => {
+                  const licences = JSON.stringify(recipient.licences)
+                  const licenceRefs = JSON.stringify(
+                    testRecipients.licenceHolderWithMultipleLicences.licence_refs.split(',')
+                  )
+
+                  return licences === licenceRefs
+                })
 
                 expect(testRecipient.licences).to.equal(
                   testRecipients.licenceHolderWithMultipleLicences.licence_refs.split(',')
@@ -414,9 +417,9 @@ describe('Notifications Setup - Check presenter', () => {
               it('should return the email address', () => {
                 const result = CheckPresenter.go(testInput, page, pagination, session)
 
-                const testRecipient = result.recipients.find((recipient) =>
-                  recipient.licences.includes(testRecipients.primaryUser.licence_refs)
-                )
+                const testRecipient = result.recipients.find((recipient) => {
+                  return recipient.licences.includes(testRecipients.primaryUser.licence_refs)
+                })
 
                 expect(testRecipient).to.equal({
                   contact: ['primary.user@important.com'],
@@ -430,9 +433,9 @@ describe('Notifications Setup - Check presenter', () => {
               it('should convert the contact into an array', () => {
                 const result = CheckPresenter.go(testInput, page, pagination, session)
 
-                const testRecipient = result.recipients.find((recipient) =>
-                  recipient.licences.includes(testRecipients.licenceHolder.licence_refs)
-                )
+                const testRecipient = result.recipients.find((recipient) => {
+                  return recipient.licences.includes(testRecipients.licenceHolder.licence_refs)
+                })
 
                 expect(testRecipient).to.equal({
                   contact: ['Mr H J Licence holder', '1', 'Privet Drive', 'Little Whinging', 'Surrey', 'WD25 7LR'],
@@ -448,9 +451,9 @@ describe('Notifications Setup - Check presenter', () => {
               it('should return licence numbers as an array', () => {
                 const result = CheckPresenter.go(testInput, page, pagination, session)
 
-                const testRecipient = result.recipients.find((recipient) =>
-                  recipient.licences.includes(testRecipients.licenceHolder.licence_refs)
-                )
+                const testRecipient = result.recipients.find((recipient) => {
+                  return recipient.licences.includes(testRecipients.licenceHolder.licence_refs)
+                })
 
                 expect(testRecipient.licences).to.equal([testRecipients.licenceHolder.licence_refs])
               })
@@ -460,11 +463,14 @@ describe('Notifications Setup - Check presenter', () => {
               it('should return licence numbers as an array', () => {
                 const result = CheckPresenter.go(testInput, page, pagination, session)
 
-                const testRecipient = result.recipients.find(
-                  (recipient) =>
-                    JSON.stringify(recipient.licences) ===
-                    JSON.stringify(testRecipients.licenceHolderWithMultipleLicences.licence_refs.split(','))
-                )
+                const testRecipient = result.recipients.find((recipient) => {
+                  const licences = JSON.stringify(recipient.licences)
+                  const licenceRefs = JSON.stringify(
+                    testRecipients.licenceHolderWithMultipleLicences.licence_refs.split(',')
+                  )
+
+                  return licences === licenceRefs
+                })
 
                 expect(testRecipient.licences).to.equal(
                   testRecipients.licenceHolderWithMultipleLicences.licence_refs.split(',')
@@ -616,9 +622,9 @@ describe('Notifications Setup - Check presenter', () => {
               it('should return the email address', () => {
                 const result = CheckPresenter.go(testInput, page, pagination, session)
 
-                const testRecipient = result.recipients.find((recipient) =>
-                  recipient.licences.includes(testRecipients.primaryUser.licence_refs)
-                )
+                const testRecipient = result.recipients.find((recipient) => {
+                  return recipient.licences.includes(testRecipients.primaryUser.licence_refs)
+                })
 
                 expect(testRecipient).to.equal({
                   contact: ['primary.user@important.com'],
@@ -632,9 +638,9 @@ describe('Notifications Setup - Check presenter', () => {
               it('should convert the contact into an array', () => {
                 const result = CheckPresenter.go(testInput, page, pagination, session)
 
-                const testRecipient = result.recipients.find((recipient) =>
-                  recipient.licences.includes(testRecipients.licenceHolder.licence_refs)
-                )
+                const testRecipient = result.recipients.find((recipient) => {
+                  return recipient.licences.includes(testRecipients.licenceHolder.licence_refs)
+                })
 
                 expect(testRecipient).to.equal({
                   contact: ['Mr H J Licence holder', '1', 'Privet Drive', 'Little Whinging', 'Surrey', 'WD25 7LR'],
@@ -650,9 +656,9 @@ describe('Notifications Setup - Check presenter', () => {
               it('should return licence numbers as an array', () => {
                 const result = CheckPresenter.go(testInput, page, pagination, session)
 
-                const testRecipient = result.recipients.find((recipient) =>
-                  recipient.licences.includes(testRecipients.licenceHolder.licence_refs)
-                )
+                const testRecipient = result.recipients.find((recipient) => {
+                  return recipient.licences.includes(testRecipients.licenceHolder.licence_refs)
+                })
 
                 expect(testRecipient.licences).to.equal([testRecipients.licenceHolder.licence_refs])
               })
@@ -662,11 +668,14 @@ describe('Notifications Setup - Check presenter', () => {
               it('should return licence numbers as an array', () => {
                 const result = CheckPresenter.go(testInput, page, pagination, session)
 
-                const testRecipient = result.recipients.find(
-                  (recipient) =>
-                    JSON.stringify(recipient.licences) ===
-                    JSON.stringify(testRecipients.licenceHolderWithMultipleLicences.licence_refs.split(','))
-                )
+                const testRecipient = result.recipients.find((recipient) => {
+                  const licences = JSON.stringify(recipient.licences)
+                  const licenceRefs = JSON.stringify(
+                    testRecipients.licenceHolderWithMultipleLicences.licence_refs.split(',')
+                  )
+
+                  return licences === licenceRefs
+                })
 
                 expect(testRecipient.licences).to.equal(
                   testRecipients.licenceHolderWithMultipleLicences.licence_refs.split(',')

--- a/test/presenters/return-submissions/view-return-submission.presenter.test.js
+++ b/test/presenters/return-submissions/view-return-submission.presenter.test.js
@@ -162,7 +162,9 @@ describe('View Return Submissions presenter', () => {
         it('includes the expected headers', () => {
           const result = ViewReturnSubmissionPresenter.go(testReturnSubmission, '2025-1')
 
-          const headers = result.tableData.headers.map((header) => header.text)
+          const headers = result.tableData.headers.map((header) => {
+            return header.text
+          })
 
           expect(headers).to.equal(['Day', 'Cubic metres'])
         })
@@ -196,7 +198,9 @@ describe('View Return Submissions presenter', () => {
         it('includes the expected headers', () => {
           const result = ViewReturnSubmissionPresenter.go(testReturnSubmission, '2025-1')
 
-          const headers = result.tableData.headers.map((header) => header.text)
+          const headers = result.tableData.headers.map((header) => {
+            return header.text
+          })
 
           expect(headers).to.equal(['Day', 'Gallons', 'Cubic metres'])
         })
@@ -231,7 +235,9 @@ describe('View Return Submissions presenter', () => {
       it('includes the expected headers', () => {
         const result = ViewReturnSubmissionPresenter.go(testReturnSubmission, '2025-1')
 
-        const headers = result.tableData.headers.map((header) => header.text)
+        const headers = result.tableData.headers.map((header) => {
+          return header.text
+        })
 
         expect(headers).to.equal(['Day', 'Reading', 'Cubic metres'])
       })
@@ -264,7 +270,9 @@ describe('View Return Submissions presenter', () => {
       it('includes the expected headers', () => {
         const result = ViewReturnSubmissionPresenter.go(testReturnSubmission, '2025-1')
 
-        const headers = result.tableData.headers.map((header) => header.text)
+        const headers = result.tableData.headers.map((header) => {
+          return header.text
+        })
 
         expect(headers).to.equal(['Day', 'Reading', 'Gallons', 'Cubic metres'])
       })
@@ -279,7 +287,9 @@ describe('View Return Submissions presenter', () => {
       it('includes the expected headers', () => {
         const result = ViewReturnSubmissionPresenter.go(testReturnSubmission, '2025-1')
 
-        const headers = result.tableData.headers.map((header) => header.text)
+        const headers = result.tableData.headers.map((header) => {
+          return header.text
+        })
 
         expect(headers).to.include('Day')
       })
@@ -303,7 +313,9 @@ describe('View Return Submissions presenter', () => {
       it('includes the expected headers', () => {
         const result = ViewReturnSubmissionPresenter.go(testReturnSubmission, '2025-3')
 
-        const headers = result.tableData.headers.map((header) => header.text)
+        const headers = result.tableData.headers.map((header) => {
+          return header.text
+        })
 
         expect(headers).to.include('Week ending')
       })

--- a/test/services/jobs/notifications/fetch-scheduled-notifications.service.test.js
+++ b/test/services/jobs/notifications/fetch-scheduled-notifications.service.test.js
@@ -63,7 +63,9 @@ describe('Job - Notifications - Fetch scheduled notifications service', () => {
     it('returns the event marked for "sending"', async () => {
       const result = await FetchScheduledNotificationsService.go()
 
-      const foundEvent = result.find((resultEvent) => resultEvent.eventId === event.id)
+      const foundEvent = result.find((resultEvent) => {
+        return resultEvent.eventId === event.id
+      })
 
       expect(foundEvent).to.equal({
         createdAt: scheduledNotification.createdAt,
@@ -81,7 +83,9 @@ describe('Job - Notifications - Fetch scheduled notifications service', () => {
     it('does not return the event', async () => {
       const result = await FetchScheduledNotificationsService.go()
 
-      const foundEvent = result.find((resultEvent) => resultEvent.eventId === unlikelyEvent.id)
+      const foundEvent = result.find((resultEvent) => {
+        return resultEvent.eventId === unlikelyEvent.id
+      })
 
       expect(foundEvent).to.be.undefined()
     })
@@ -91,7 +95,9 @@ describe('Job - Notifications - Fetch scheduled notifications service', () => {
     it('does not return the event', async () => {
       const result = await FetchScheduledNotificationsService.go()
 
-      const foundEvent = result.find((resultEvent) => resultEvent.eventId === olderThanRetentionEvent.id)
+      const foundEvent = result.find((resultEvent) => {
+        return resultEvent.eventId === olderThanRetentionEvent.id
+      })
 
       expect(foundEvent).to.be.undefined()
     })

--- a/test/services/notifications/setup/fetch-download-recipients.service.test.js
+++ b/test/services/notifications/setup/fetch-download-recipients.service.test.js
@@ -52,8 +52,12 @@ describe('Notifications Setup - Fetch Download Recipients service', () => {
         it('correctly returns "Primary user" and "Returns agent" contacts', async () => {
           const result = await FetchDownloadRecipientsService.go(session)
 
-          const primaryUser = result.find((item) => item.contact_type === 'Primary user')
-          const returnsAgent = result.find((item) => item.contact_type === 'Returns agent')
+          const primaryUser = result.find((item) => {
+            return item.contact_type === 'Primary user'
+          })
+          const returnsAgent = result.find((item) => {
+            return item.contact_type === 'Returns agent'
+          })
 
           expect(primaryUser).to.equal({
             contact: null,
@@ -83,7 +87,9 @@ describe('Notifications Setup - Fetch Download Recipients service', () => {
         it('correctly returns "Licence holder" contact', async () => {
           const result = await FetchDownloadRecipientsService.go(session)
 
-          const found = result.filter((item) => item.licence_ref === testRecipients.licenceHolder.licenceRef)
+          const found = result.filter((item) => {
+            return item.licence_ref === testRecipients.licenceHolder.licenceRef
+          })
 
           expect(found).to.equal([
             {
@@ -119,7 +125,9 @@ describe('Notifications Setup - Fetch Download Recipients service', () => {
         it('correctly returns duplicate "Licence holder" and "Returns to" contacts', async () => {
           const result = await FetchDownloadRecipientsService.go(session)
 
-          const found = result.filter((item) => item.licence_ref === testRecipients.licenceHolderAndReturnTo.licenceRef)
+          const found = result.filter((item) => {
+            return item.licence_ref === testRecipients.licenceHolderAndReturnTo.licenceRef
+          })
 
           expect(found).to.equal([
             {
@@ -186,8 +194,12 @@ describe('Notifications Setup - Fetch Download Recipients service', () => {
         it('correctly returns recipients without the "removeLicences"', async () => {
           const result = await FetchDownloadRecipientsService.go(session)
 
-          const primaryUser = result.find((item) => item.contact_type === 'Primary user')
-          const returnsAgent = result.find((item) => item.contact_type === 'Returns agent')
+          const primaryUser = result.find((item) => {
+            return item.contact_type === 'Primary user'
+          })
+          const returnsAgent = result.find((item) => {
+            return item.contact_type === 'Returns agent'
+          })
 
           expect(primaryUser).to.be.undefined()
 
@@ -207,8 +219,12 @@ describe('Notifications Setup - Fetch Download Recipients service', () => {
         it('correctly returns "Primary user" and "Returns agent" contacts', async () => {
           const result = await FetchDownloadRecipientsService.go(session)
 
-          const primaryUser = result.find((item) => item.contact_type === 'Primary user')
-          const returnsAgent = result.find((item) => item.contact_type === 'Returns agent')
+          const primaryUser = result.find((item) => {
+            return item.contact_type === 'Primary user'
+          })
+          const returnsAgent = result.find((item) => {
+            return item.contact_type === 'Returns agent'
+          })
 
           expect(primaryUser).to.equal({
             contact: null,
@@ -242,7 +258,9 @@ describe('Notifications Setup - Fetch Download Recipients service', () => {
         it('correctly returns "Licence holder" contact', async () => {
           const result = await FetchDownloadRecipientsService.go(session)
 
-          const found = result.filter((item) => item.licence_ref === testRecipients.licenceHolder.licenceRef)
+          const found = result.filter((item) => {
+            return item.licence_ref === testRecipients.licenceHolder.licenceRef
+          })
 
           expect(found).to.equal([
             {
@@ -282,7 +300,9 @@ describe('Notifications Setup - Fetch Download Recipients service', () => {
         it('correctly returns duplicate "Licence holder" and "Returns to" contacts', async () => {
           const result = await FetchDownloadRecipientsService.go(session)
 
-          const found = result.filter((item) => item.licence_ref === testRecipients.licenceHolderAndReturnTo.licenceRef)
+          const found = result.filter((item) => {
+            return item.licence_ref === testRecipients.licenceHolderAndReturnTo.licenceRef
+          })
 
           expect(found).to.equal([
             {

--- a/test/services/notifications/setup/fetch-recipients.service.test.js
+++ b/test/services/notifications/setup/fetch-recipients.service.test.js
@@ -46,7 +46,9 @@ describe('Notifications Setup - Recipients service', () => {
       it('correctly returns the "primary user" instead of the "Licence holder"', async () => {
         const result = await RecipientsService.go(session)
 
-        const [testRecipient] = result.filter((res) => res.licence_refs.includes(recipients.primaryUser.licenceRef))
+        const [testRecipient] = result.filter((res) => {
+          return res.licence_refs.includes(recipients.primaryUser.licenceRef)
+        })
 
         expect(testRecipient).to.equal({
           licence_refs: recipients.primaryUser.licenceRef,
@@ -61,9 +63,9 @@ describe('Notifications Setup - Recipients service', () => {
         it('correctly returns the "returns agent" as well as the primary user', async () => {
           const result = await RecipientsService.go(session)
 
-          const [, testRecipientReturnsAgent] = result.filter((res) =>
-            res.licence_refs.includes(recipients.primaryUser.licenceRef)
-          )
+          const [, testRecipientReturnsAgent] = result.filter((res) => {
+            return res.licence_refs.includes(recipients.primaryUser.licenceRef)
+          })
 
           expect(testRecipientReturnsAgent).to.equal({
             licence_refs: recipients.primaryUser.licenceRef,
@@ -80,7 +82,9 @@ describe('Notifications Setup - Recipients service', () => {
       it('correctly returns the licence holder data', async () => {
         const result = await RecipientsService.go(session)
 
-        const [testRecipient] = result.filter((res) => res.licence_refs.includes(recipients.licenceHolder.licenceRef))
+        const [testRecipient] = result.filter((res) => {
+          return res.licence_refs.includes(recipients.licenceHolder.licenceRef)
+        })
 
         expect(testRecipient).to.equal({
           licence_refs: recipients.licenceHolder.licenceRef,
@@ -111,9 +115,9 @@ describe('Notifications Setup - Recipients service', () => {
       it('correctly returns the licence holder and returns to data', async () => {
         const result = await RecipientsService.go(session)
 
-        const [licenceHolder, returnsTo] = result.filter((res) =>
-          res.licence_refs.includes(recipients.licenceHolderAndReturnTo.licenceRef)
-        )
+        const [licenceHolder, returnsTo] = result.filter((res) => {
+          return res.licence_refs.includes(recipients.licenceHolderAndReturnTo.licenceRef)
+        })
 
         expect(licenceHolder).to.equal({
           licence_refs: recipients.licenceHolderAndReturnTo.licenceRef,
@@ -173,7 +177,9 @@ describe('Notifications Setup - Recipients service', () => {
       it('correctly returns recipients without the "removeLicences"', async () => {
         const result = await RecipientsService.go(session)
 
-        const [testRecipient] = result.filter((res) => res.licence_refs.includes(recipients.primaryUser.licenceRef))
+        const [testRecipient] = result.filter((res) => {
+          return res.licence_refs.includes(recipients.primaryUser.licenceRef)
+        })
 
         expect(testRecipient).to.be.undefined()
       })
@@ -189,7 +195,9 @@ describe('Notifications Setup - Recipients service', () => {
       it('correctly returns the "primary user" instead of the "Licence holder"', async () => {
         const result = await RecipientsService.go(session)
 
-        const [testRecipient] = result.filter((res) => res.licence_refs.includes(recipients.primaryUser.licenceRef))
+        const [testRecipient] = result.filter((res) => {
+          return res.licence_refs.includes(recipients.primaryUser.licenceRef)
+        })
 
         expect(testRecipient).to.equal({
           licence_refs: recipients.primaryUser.licenceRef,
@@ -208,9 +216,9 @@ describe('Notifications Setup - Recipients service', () => {
         it('correctly returns the "returns agent" as well as the primary user', async () => {
           const result = await RecipientsService.go(session)
 
-          const [, testRecipientReturnsAgent] = result.filter((res) =>
-            res.licence_refs.includes(recipients.primaryUser.licenceRef)
-          )
+          const [, testRecipientReturnsAgent] = result.filter((res) => {
+            return res.licence_refs.includes(recipients.primaryUser.licenceRef)
+          })
 
           expect(testRecipientReturnsAgent).to.equal({
             licence_refs: recipients.primaryUser.licenceRef,
@@ -231,7 +239,9 @@ describe('Notifications Setup - Recipients service', () => {
       it('correctly returns the licence holder data', async () => {
         const result = await RecipientsService.go(session)
 
-        const [testRecipient] = result.filter((res) => res.licence_refs.includes(recipients.licenceHolder.licenceRef))
+        const [testRecipient] = result.filter((res) => {
+          return res.licence_refs.includes(recipients.licenceHolder.licenceRef)
+        })
 
         expect(testRecipient).to.equal({
           licence_refs: recipients.licenceHolder.licenceRef,
@@ -266,9 +276,9 @@ describe('Notifications Setup - Recipients service', () => {
       it('correctly returns the licence holder and returns to data', async () => {
         const result = await RecipientsService.go(session)
 
-        const [licenceHolder, returnsTo] = result.filter((res) =>
-          res.licence_refs.includes(recipients.licenceHolderAndReturnTo.licenceRef)
-        )
+        const [licenceHolder, returnsTo] = result.filter((res) => {
+          return res.licence_refs.includes(recipients.licenceHolderAndReturnTo.licenceRef)
+        })
 
         expect(licenceHolder).to.equal({
           licence_refs: recipients.licenceHolderAndReturnTo.licenceRef,

--- a/test/services/return-logs/fetch-return-log.service.test.js
+++ b/test/services/return-logs/fetch-return-log.service.test.js
@@ -112,7 +112,12 @@ describe('Fetch Return Log service', () => {
       const result = await FetchReturnLogService.go(testReturnLog.id)
 
       expect(result.versions).to.have.length(3)
-      expect(result.versions.map((v) => v.version)).to.equal([3, 2, 1])
+
+      const versions = result.versions.map((v) => {
+        return v.version
+      })
+
+      expect(versions).to.equal([3, 2, 1])
     })
 
     it('applies readings to selected submission', async () => {


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/115

Some time back, we updated our linting config to use [prettier](https://prettier.io/) and [neostandard](https://github.com/neostandard/neostandard), managed by [ESLint](https://eslint.org/), to try and enforce a consistent style.

One of our [long-standing conventions](https://github.com/DEFRA/water-abstraction-team/blob/main/coding_conventions.md#arrow-functions) has been that arrow functions should _always_ use block body instead of concise body.

```javascript
const materials = [
  'Hydrogen',
  'Helium',
  'Lithium',
  'Beryllium'
]

// Use Block body version
materials.forEach((material) => {
  console.log(`${material} - ${material.length}`)
})

// Do not use Concise body version
materials.forEach((material) => console.log(`${material} - ${material.length}`))
```

In **ESLint** this is the [arrow-body-style](https://eslint.org/docs/latest/rules/arrow-body-style) rule.

We retained this rule and thought it was being enforced. However, we spotted instances of concise body being used since the change in our linting, and after checking, we confirmed the rule is no longer being enforced.

It's because [eslint-plugin-prettier](https://github.com/prettier/eslint-plugin-prettier) is switching it off. It does this because if you use **ESLint's** autofix, there is a chance it will result in code **prettier** will then flag as invalid. This scenario has no fix, so the folks at **eslint-plugin-prettier** opted to disable it.

They also encourage you to load the **eslint-plugin-prettier** config last in your `eslint.config.js` file so they can disable any rules you might have enabled that **prettier** will find problematic.

That is why a rule we specifically added is not being enforced!

To be fair, **eslint-plugin-prettier** doesn't say you _can't_ enable the rule. It just says you should be aware of this issue, and they disable it by default to prevent those who aren't from seeing errors.

So, in this change, we ensure it is enforced and resolve all instances that have managed to creep in.