### PR TITLE
Update scheduled notification default status from 'sending' to 'pending'

### DIFF
--- a/app/presenters/jobs/notifications/notify-status.presenter.js
+++ b/app/presenters/jobs/notifications/notify-status.presenter.js
@@ -6,7 +6,7 @@
  */
 
 const SCHEDULED_NOTIFICATIONS_STATUS = {
-  sending: 'sending',
+  pending: 'pending',
   sent: 'sent',
   error: 'error'
 }
@@ -27,7 +27,7 @@ const SCHEDULED_NOTIFICATIONS_STATUS = {
  * When we make the initial call to notify we do not receive a status, but we do receive a 'statusCode' (201) and
  * 'statusText' ("CREATED"). This is inferred to mean the notifications is in the "created" state. This is the initial
  * 'notifyStatus' value set for a 'scheduledNotification' (when no error has occurred), and the 'status' is set to
- * sending.
+ * pending.
  *
  * @param {string} notifyStatus - the status from notify
  * @param {string} scheduledNotification - a 'scheduled notification'
@@ -62,8 +62,8 @@ function go(notifyStatus, scheduledNotification) {
  */
 function _emailStatus(notifyStatus) {
   const emailStatuses = {
-    created: SCHEDULED_NOTIFICATIONS_STATUS.sending,
-    sending: SCHEDULED_NOTIFICATIONS_STATUS.sending,
+    created: SCHEDULED_NOTIFICATIONS_STATUS.pending,
+    sending: SCHEDULED_NOTIFICATIONS_STATUS.pending,
     delivered: SCHEDULED_NOTIFICATIONS_STATUS.sent,
     'permanent-failure': SCHEDULED_NOTIFICATIONS_STATUS.error,
     'technical-failure': SCHEDULED_NOTIFICATIONS_STATUS.error,
@@ -91,8 +91,8 @@ function _emailStatus(notifyStatus) {
 function _letterStatus(notifyStatus) {
   const letterStatuses = {
     accepted: SCHEDULED_NOTIFICATIONS_STATUS.sent,
-    created: SCHEDULED_NOTIFICATIONS_STATUS.sending,
-    sending: SCHEDULED_NOTIFICATIONS_STATUS.sending,
+    created: SCHEDULED_NOTIFICATIONS_STATUS.pending,
+    sending: SCHEDULED_NOTIFICATIONS_STATUS.pending,
     delivered: SCHEDULED_NOTIFICATIONS_STATUS.sent,
     received: SCHEDULED_NOTIFICATIONS_STATUS.sent,
     'permanent-failure': SCHEDULED_NOTIFICATIONS_STATUS.error,

--- a/app/presenters/notifications/setup/notify-update.presenter.js
+++ b/app/presenters/notifications/setup/notify-update.presenter.js
@@ -30,7 +30,7 @@ function go(notify) {
     notifyId: notify.id,
     notifyStatus: notify.statusText,
     plaintext: notify.plaintext,
-    status: 'sending'
+    status: 'pending'
   }
 }
 

--- a/app/services/jobs/notifications/fetch-scheduled-notifications.service.js
+++ b/app/services/jobs/notifications/fetch-scheduled-notifications.service.js
@@ -25,7 +25,7 @@ async function go() {
 
   return ScheduledNotificationModel.query()
     .select(['id', 'notifyId', 'status', 'notifyStatus', 'log', 'eventId', 'createdAt'])
-    .where('status', 'sending')
+    .where('status', 'pending')
     .andWhere('createdAt', '>=', sevenDaysAgo)
 }
 

--- a/test/presenters/jobs/notifications/notify-status.presenter.test.js
+++ b/test/presenters/jobs/notifications/notify-status.presenter.test.js
@@ -18,7 +18,7 @@ describe('Notifications Setup - Notify status presenter', () => {
     beforeEach(() => {
       scheduledNotification = {
         messageType: 'email',
-        status: 'sending'
+        status: 'pending'
       }
     })
 
@@ -32,7 +32,7 @@ describe('Notifications Setup - Notify status presenter', () => {
 
         expect(result).to.equal({
           notifyStatus: 'created',
-          status: 'sending'
+          status: 'pending'
         })
       })
     })
@@ -47,7 +47,7 @@ describe('Notifications Setup - Notify status presenter', () => {
 
         expect(result).to.equal({
           notifyStatus: 'sending',
-          status: 'sending'
+          status: 'pending'
         })
       })
     })
@@ -134,7 +134,7 @@ describe('Notifications Setup - Notify status presenter', () => {
     beforeEach(() => {
       scheduledNotification = {
         messageType: 'letter',
-        status: 'sending'
+        status: 'pending'
       }
     })
 
@@ -163,7 +163,7 @@ describe('Notifications Setup - Notify status presenter', () => {
 
         expect(result).to.equal({
           notifyStatus: 'created',
-          status: 'sending'
+          status: 'pending'
         })
       })
     })
@@ -178,7 +178,7 @@ describe('Notifications Setup - Notify status presenter', () => {
 
         expect(result).to.equal({
           notifyStatus: 'sending',
-          status: 'sending'
+          status: 'pending'
         })
       })
     })

--- a/test/presenters/notifications/setup/notify-update.presenter.test.js
+++ b/test/presenters/notifications/setup/notify-update.presenter.test.js
@@ -29,7 +29,7 @@ describe('Notifications Setup - Notify update presenter', () => {
       notifyId: '123',
       notifyStatus: 'created',
       plaintext: 'My dearest margery',
-      status: 'sending'
+      status: 'pending'
     })
   })
 

--- a/test/services/jobs/notifications/fetch-scheduled-notifications.service.test.js
+++ b/test/services/jobs/notifications/fetch-scheduled-notifications.service.test.js
@@ -28,7 +28,7 @@ describe('Job - Notifications - Fetch scheduled notifications service', () => {
 
     scheduledNotification = await ScheduledNotificationHelper.add({
       eventId: event.id,
-      status: 'sending'
+      status: 'pending'
     })
 
     // The 'scheduledNotification' status is 'error'
@@ -74,7 +74,7 @@ describe('Job - Notifications - Fetch scheduled notifications service', () => {
         log: null,
         notifyId: null,
         notifyStatus: null,
-        status: 'sending'
+        status: 'pending'
       })
     })
   })

--- a/test/services/jobs/notifications/notifications-status-updates.service.test.js
+++ b/test/services/jobs/notifications/notifications-status-updates.service.test.js
@@ -45,14 +45,14 @@ describe('Job - Notifications - Process notifications status updates service', (
 
     scheduledNotification = await ScheduledNotificationHelper.add({
       eventId: event.id,
-      status: 'sending',
+      status: 'pending',
       notifyStatus: 'created',
       createdAt: timestampForPostgres()
     })
 
     scheduledNotification2 = await ScheduledNotificationHelper.add({
       eventId: event.id,
-      status: 'sending',
+      status: 'pending',
       notifyStatus: 'created',
       createdAt: timestampForPostgres()
     })
@@ -179,7 +179,7 @@ describe('Job - Notifications - Process notifications status updates service', (
       const refreshScheduledNotification = await scheduledNotification.$query()
 
       expect(refreshScheduledNotification.notifyStatus).to.equal('created')
-      expect(refreshScheduledNotification.status).to.equal('sending')
+      expect(refreshScheduledNotification.status).to.equal('pending')
 
       expect(refreshScheduledNotification).to.equal(scheduledNotification)
     })

--- a/test/services/jobs/notifications/update-notifications.service.tests.js
+++ b/test/services/jobs/notifications/update-notifications.service.tests.js
@@ -32,7 +32,7 @@ describe('Notifications Setup - Update Notifications service', () => {
     scheduledNotification = await ScheduledNotificationHelper.add({
       createdAt: timestampForPostgres(),
       eventId,
-      status: 'sending'
+      status: 'pending'
     })
   })
 

--- a/test/services/notifications/setup/batch-notifications.service.test.js
+++ b/test/services/notifications/setup/batch-notifications.service.test.js
@@ -107,7 +107,7 @@ describe('Notifications Setup - Batch notifications service', () => {
             periodStartDate: '1 April 2022'
           },
           sendAfter: result[0].sendAfter,
-          status: 'sending',
+          status: 'pending',
           log: null,
           licences: [recipients.primaryUser.licence_refs],
           individualId: null,
@@ -134,7 +134,7 @@ describe('Notifications Setup - Batch notifications service', () => {
             periodStartDate: '1 April 2022'
           },
           sendAfter: result[1].sendAfter,
-          status: 'sending',
+          status: 'pending',
           log: null,
           licences: [recipients.returnsAgent.licence_refs],
           individualId: null,
@@ -167,7 +167,7 @@ describe('Notifications Setup - Batch notifications service', () => {
             periodStartDate: '1 April 2022'
           },
           sendAfter: result[2].sendAfter,
-          status: 'sending',
+          status: 'pending',
           log: null,
           licences: [recipients.licenceHolder.licence_refs],
           individualId: null,
@@ -200,7 +200,7 @@ describe('Notifications Setup - Batch notifications service', () => {
             periodStartDate: '1 April 2022'
           },
           sendAfter: result[3].sendAfter,
-          status: 'sending',
+          status: 'pending',
           log: null,
           licences: [recipients.returnsTo.licence_refs],
           individualId: null,
@@ -233,7 +233,7 @@ describe('Notifications Setup - Batch notifications service', () => {
             periodStartDate: '1 April 2022'
           },
           sendAfter: result[4].sendAfter,
-          status: 'sending',
+          status: 'pending',
           log: null,
           licences: [firstMultiple, secondMultiple],
           individualId: null,
@@ -357,7 +357,7 @@ describe('Notifications Setup - Batch notifications service', () => {
             periodStartDate: '1 April 2022'
           },
           sendAfter: result[1].sendAfter,
-          status: 'sending',
+          status: 'pending',
           log: null,
           licences: [recipients.returnsAgent.licence_refs],
           individualId: null,


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4961

We had an assumption that using a status of 'sending' for a scheduled notification did not conflict with the existing legacy code.

This is not the case.

To avoid interacting with the legacy notification status update mechanism we have introduced a new status for scheduled notifications which is 'pending'.

This is, for all intents and purposes, the same as sending (without the legacy code attempting to update the status).

The legacy code report will be updated to allow this new 'pending' status.