### PR TITLE
Update Notify client proxy

### DIFF
--- a/app/services/notify/notify-client.service.js
+++ b/app/services/notify/notify-client.service.js
@@ -1,0 +1,63 @@
+'use strict'
+
+/**
+ * Creates a Notify Client
+ * @module NotifyClientService
+ */
+
+const NotifyClient = require('notifications-node-client').NotifyClient
+const axios = require('axios')
+
+const { HttpsProxyAgent } = require('hpagent')
+
+const NotifyConfig = require('../../../config/notify.config.js')
+const RequestConfig = require('../../../config/request.config.js')
+
+/**
+ * Creates a Notify Client
+ *
+ * Returns an instance of {@link https://github.com/alphagov/notifications-node-client | notifications-node-client}
+ * configured to work in environments with and without proxy servers.
+ *
+ * Running locally just instantiating the NotifyClient was all we had to do. But when deployed to our AWS environments
+ * which use the {@link https://www.squid-cache.org/ | Squid proxy server} it failed.
+ *
+ * Initially, we followed the
+ * {@link https://docs.notifications.service.gov.uk/node.html#connect-through-a-proxy-optional | Notify documentation}
+ * but all we saw was the following returned by **Squid**.
+ *
+ * ```text
+ * This proxy and the remote host failed to negotiate a mutually acceptable security settings for handling your request.
+ * It is possible that the remote host does not support secure connections, or the proxy is not satisfied with the host
+ * security credentials.
+ * ```
+ *
+ * It appears this is a {@link https://github.com/axios/axios/issues/6320 | known issue with Axios} and how it sends
+ * data via the proxy. Most workarounds suggest that you need to tell Axios to disable its proxy, and specify
+ * a https agent instead.
+ *
+ * We use {@link https://www.npmjs.com/package/hpagent | hpagent} to set the agent, we have to create our own custom
+ * instance of Axios and tell Notify to use it instead.
+ *
+ * @private
+ */
+function go() {
+  const notifyClient = new NotifyClient(NotifyConfig.apiKey)
+  const proxy = RequestConfig.httpProxy
+
+  if (proxy) {
+    const agent = new HttpsProxyAgent({ proxy })
+    const axiosInstance = axios.create({
+      proxy: false,
+      httpsAgent: agent
+    })
+
+    notifyClient.setClient(axiosInstance)
+  }
+
+  return notifyClient
+}
+
+module.exports = {
+  go
+}

--- a/app/services/notify/notify-email.service.js
+++ b/app/services/notify/notify-email.service.js
@@ -5,9 +5,7 @@
  * @module NotifyEmailService
  */
 
-const NotifyClient = require('notifications-node-client').NotifyClient
-
-const config = require('../../../config/notify.config.js')
+const NotifyClientService = require('./notify-client.service.js')
 
 /**
  * Send an email using GOV.UK Notify
@@ -37,7 +35,7 @@ const config = require('../../../config/notify.config.js')
  * @returns {Promise<object>}
  */
 async function go(templateId, emailAddress, options) {
-  const notifyClient = new NotifyClient(config.apiKey)
+  const notifyClient = NotifyClientService.go()
 
   return _sendEmail(notifyClient, templateId, emailAddress, options)
 }

--- a/app/services/notify/notify-letter.service.js
+++ b/app/services/notify/notify-letter.service.js
@@ -5,9 +5,7 @@
  * @module NotifyLetterService
  */
 
-const NotifyClient = require('notifications-node-client').NotifyClient
-
-const config = require('../../../config/notify.config.js')
+const NotifyClientService = require('./notify-client.service.js')
 
 /**
  * Send a letter using GOV.UK Notify
@@ -41,7 +39,7 @@ const config = require('../../../config/notify.config.js')
  * @returns {Promise<object>}
  */
 async function go(templateId, options) {
-  const notifyClient = new NotifyClient(config.apiKey)
+  const notifyClient = NotifyClientService.go()
 
   return _sendLetter(notifyClient, templateId, options)
 }

--- a/app/services/notify/notify-status.service.js
+++ b/app/services/notify/notify-status.service.js
@@ -5,9 +5,7 @@
  * @module NotifyStatusService
  */
 
-const NotifyClient = require('notifications-node-client').NotifyClient
-
-const config = require('../../../config/notify.config.js')
+const NotifyClientService = require('./notify-client.service.js')
 
 /**
  * Get the status of a notification from GOV.UK Notify
@@ -31,7 +29,7 @@ const config = require('../../../config/notify.config.js')
  * @returns {Promise<object>}
  */
 async function go(notificationId) {
-  const notifyClient = new NotifyClient(config.apiKey)
+  const notifyClient = NotifyClientService.go()
 
   return _statusById(notifyClient, notificationId)
 }

--- a/app/services/notify/notify-statuses.service.js
+++ b/app/services/notify/notify-statuses.service.js
@@ -5,9 +5,7 @@
  * @module NotifyStatusesService
  */
 
-const NotifyClient = require('notifications-node-client').NotifyClient
-
-const config = require('../../../config/notify.config.js')
+const NotifyClientService = require('./notify-client.service.js')
 
 /**
  * Get the statuses of notifications by unique reference from GOV.UK Notify
@@ -21,7 +19,7 @@ const config = require('../../../config/notify.config.js')
  * @returns {Promise<object>}
  */
 async function go(olderThanNotificationId, referenceCode) {
-  const notifyClient = new NotifyClient(config.apiKey)
+  const notifyClient = NotifyClientService.go()
 
   return _statuses(notifyClient, olderThanNotificationId, referenceCode)
 }

--- a/test/services/notify/notify-client.service.test.js
+++ b/test/services/notify/notify-client.service.test.js
@@ -1,0 +1,52 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Test helpers
+const { NotifyClient } = require('notifications-node-client')
+
+// Things we need to stub
+const NotifyConfig = require('../../../config/notify.config.js')
+const RequestConfig = require('../../../config/request.config.js')
+
+// Thing under test
+const NotifyClientService = require('../../../app/services/notify/notify-client.service.js')
+
+describe('Notify - Client service', () => {
+  afterEach(() => {
+    Sinon.restore()
+  })
+
+  describe('when creating a notify client without a proxy', () => {
+    beforeEach(() => {
+      Sinon.stub(RequestConfig, 'httpProxy').value(undefined)
+    })
+
+    it('should create a notify client', () => {
+      const result = NotifyClientService.go()
+
+      expect(result).to.equal(new NotifyClient(NotifyConfig.apiKey))
+    })
+  })
+
+  describe('when creating a notify client with a proxy', () => {
+    beforeEach(() => {
+      Sinon.stub(RequestConfig, 'httpProxy').value('https://test.proxy.defra.gov.uk')
+    })
+
+    it('should create a notify client with the provided proxy url', () => {
+      const result = NotifyClientService.go()
+
+      expect(result.apiClient.restClient.defaults.httpsAgent.proxy.host).to.equal('test.proxy.defra.gov.uk')
+      expect(result.apiClient.restClient.defaults.httpsAgent.proxy.hostname).to.equal('test.proxy.defra.gov.uk')
+      expect(result.apiClient.restClient.defaults.httpsAgent.proxy.href).to.equal('https://test.proxy.defra.gov.uk/')
+      expect(result.apiClient.restClient.defaults.httpsAgent.proxy.origin).to.equal('https://test.proxy.defra.gov.uk')
+    })
+  })
+})


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4961

Previous work has found an issue with using Notify behind our proxy - https://github.com/DEFRA/water-abstraction-import/pull/1076.

This change updates our implementation of the Notify client allow us to pass in the proxy url.