### PR TITLE
Update notifications status updates service

### DIFF
--- a/test/services/jobs/notifications/notifications-status-updates.service.test.js
+++ b/test/services/jobs/notifications/notifications-status-updates.service.test.js
@@ -71,7 +71,7 @@ describe('Job - Notifications - Process notifications status updates service', (
       _stubSuccessfulNotify()
     })
 
-    it.only('returns the first scheduled notification data', { timeout: 3000 }, async () => {
+    it('returns the first scheduled notification data', { timeout: 3000 }, async () => {
       await ProcessNotificationsStatusUpdatesService.go()
 
       const updatedResult = await scheduledNotification.$query()

--- a/test/services/jobs/notifications/notifications-status-updates.service.test.js
+++ b/test/services/jobs/notifications/notifications-status-updates.service.test.js
@@ -71,7 +71,7 @@ describe('Job - Notifications - Process notifications status updates service', (
       _stubSuccessfulNotify()
     })
 
-    it('returns the first scheduled notification data', async () => {
+    it.only('returns the first scheduled notification data', { timeout: 3000 }, async () => {
       await ProcessNotificationsStatusUpdatesService.go()
 
       const updatedResult = await scheduledNotification.$query()


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4961

We are seeing an issues with the same test timing out.

This test is taking just a bit longer than 2 seconds to complete. Our default timeout is 2 seconds.

This test only takes longer when run after the 'Notifications Setup - Batch notifications service' test suite.

When run before / alone the test only takes roughly 224 ms.

The change increases the timeout to 3 seconds for this specific test.

This keeps the time low to highlight further issues.