### PR TITLE
Update Notify services to requests

### DIFF
--- a/app/requests/notify/notify-client.request.js
+++ b/app/requests/notify/notify-client.request.js
@@ -2,7 +2,7 @@
 
 /**
  * Creates a Notify Client
- * @module NotifyClientService
+ * @module NotifyClientRequest
  */
 
 const NotifyClient = require('notifications-node-client').NotifyClient

--- a/app/requests/notify/notify-email.request.js
+++ b/app/requests/notify/notify-email.request.js
@@ -1,16 +1,16 @@
 'use strict'
 
 /**
- * Send a letter using GOV.UK Notify
- * @module NotifyLetterService
+ * Send an email using GOV.UK Notify
+ * @module NotifyEmailRequest
  */
 
-const NotifyClientService = require('./notify-client.service.js')
+const NotifyClientRequest = require('./notify-client.request.js')
 
 /**
- * Send a letter using GOV.UK Notify
+ * Send an email using GOV.UK Notify
  *
- * https://docs.notifications.service.gov.uk/node.html#send-a-letter
+ * https://docs.notifications.service.gov.uk/node.html#send-an-email
  *
  * Notify has the option to provide an 'options' object. This is the object which populates templates placeholders
  * (known as 'personalisation') and other options such as a 'reference' for identifying single unique message
@@ -19,34 +19,30 @@ const NotifyClientService = require('./notify-client.service.js')
  * ```javascript
  *   const options = {
  *       personalisation: {
- *        //The address must have at least 3 lines.
- *        "address_line_1": "Amala Bird", // required string
- *        "address_line_2": "123 High Street", // required string
- *        "address_line_3": "Richmond upon Thames", // required string
- *        "address_line_4": "Middlesex",
- *        "address_line_5": "SW14 6BF",  // last line of address you include must be a postcode or a country name  outside the UK
- *        name: 'test', // matches the template placeholder {{ name }}
+ *         name: 'test', // matches the template placeholder {{ name }}
  *       },
  *       reference: 'ABC-123' // A unique identifier which identifies a single unique message or a batch of messages
  *     }
  * ```
+ *
  * > If there are any dates types for any placeholder be sure to format the date prior to sending to notify. Otherwise,
  * the output will be formatted like: 'Wed Feb 19 2025 09:14:15 GMT+0000 (Greenwich Mean Time)'
  *
  * @param {string} templateId
+ * @param {string} emailAddress
  * @param {object} options
  *
  * @returns {Promise<object>}
  */
-async function go(templateId, options) {
-  const notifyClient = NotifyClientService.go()
+async function send(templateId, emailAddress, options) {
+  const notifyClient = NotifyClientRequest.go()
 
-  return _sendLetter(notifyClient, templateId, options)
+  return _sendEmail(notifyClient, templateId, emailAddress, options)
 }
 
-async function _sendLetter(notifyClient, templateId, options) {
+async function _sendEmail(notifyClient, templateId, emailAddress, options) {
   try {
-    const response = await notifyClient.sendLetter(templateId, options)
+    const response = await notifyClient.sendEmail(templateId, emailAddress, options)
 
     return {
       id: response.data.id,
@@ -61,12 +57,12 @@ async function _sendLetter(notifyClient, templateId, options) {
       errors: error.response.data.errors
     }
 
-    global.GlobalNotifier.omfg('Notify send letter failed', errorDetails)
+    global.GlobalNotifier.omfg('Notify send email failed', errorDetails)
 
     return errorDetails
   }
 }
 
 module.exports = {
-  go
+  send
 }

--- a/app/requests/notify/notify-letter.request.js
+++ b/app/requests/notify/notify-letter.request.js
@@ -1,16 +1,16 @@
 'use strict'
 
 /**
- * Send an email using GOV.UK Notify
- * @module NotifyEmailService
+ * Send a letter using GOV.UK Notify
+ * @module NotifyLetterRequest
  */
 
-const NotifyClientService = require('./notify-client.service.js')
+const NotifyClientRequest = require('./notify-client.request.js')
 
 /**
- * Send an email using GOV.UK Notify
+ * Send a letter using GOV.UK Notify
  *
- * https://docs.notifications.service.gov.uk/node.html#send-an-email
+ * https://docs.notifications.service.gov.uk/node.html#send-a-letter
  *
  * Notify has the option to provide an 'options' object. This is the object which populates templates placeholders
  * (known as 'personalisation') and other options such as a 'reference' for identifying single unique message
@@ -19,30 +19,34 @@ const NotifyClientService = require('./notify-client.service.js')
  * ```javascript
  *   const options = {
  *       personalisation: {
- *         name: 'test', // matches the template placeholder {{ name }}
+ *        //The address must have at least 3 lines.
+ *        "address_line_1": "Amala Bird", // required string
+ *        "address_line_2": "123 High Street", // required string
+ *        "address_line_3": "Richmond upon Thames", // required string
+ *        "address_line_4": "Middlesex",
+ *        "address_line_5": "SW14 6BF",  // last line of address you include must be a postcode or a country name  outside the UK
+ *        name: 'test', // matches the template placeholder {{ name }}
  *       },
  *       reference: 'ABC-123' // A unique identifier which identifies a single unique message or a batch of messages
  *     }
  * ```
- *
  * > If there are any dates types for any placeholder be sure to format the date prior to sending to notify. Otherwise,
  * the output will be formatted like: 'Wed Feb 19 2025 09:14:15 GMT+0000 (Greenwich Mean Time)'
  *
  * @param {string} templateId
- * @param {string} emailAddress
  * @param {object} options
  *
  * @returns {Promise<object>}
  */
-async function go(templateId, emailAddress, options) {
-  const notifyClient = NotifyClientService.go()
+async function send(templateId, options) {
+  const notifyClient = NotifyClientRequest.go()
 
-  return _sendEmail(notifyClient, templateId, emailAddress, options)
+  return _sendLetter(notifyClient, templateId, options)
 }
 
-async function _sendEmail(notifyClient, templateId, emailAddress, options) {
+async function _sendLetter(notifyClient, templateId, options) {
   try {
-    const response = await notifyClient.sendEmail(templateId, emailAddress, options)
+    const response = await notifyClient.sendLetter(templateId, options)
 
     return {
       id: response.data.id,
@@ -57,12 +61,12 @@ async function _sendEmail(notifyClient, templateId, emailAddress, options) {
       errors: error.response.data.errors
     }
 
-    global.GlobalNotifier.omfg('Notify send email failed', errorDetails)
+    global.GlobalNotifier.omfg('Notify send letter failed', errorDetails)
 
     return errorDetails
   }
 }
 
 module.exports = {
-  go
+  send
 }

--- a/app/requests/notify/notify-status.request.js
+++ b/app/requests/notify/notify-status.request.js
@@ -2,10 +2,10 @@
 
 /**
  * Get the status of a notification from GOV.UK Notify
- * @module NotifyStatusService
+ * @module NotifyStatusRequest
  */
 
-const NotifyClientService = require('./notify-client.service.js')
+const NotifyClientRequest = require('./notify-client.request.js')
 
 /**
  * Get the status of a notification from GOV.UK Notify
@@ -28,8 +28,8 @@ const NotifyClientService = require('./notify-client.service.js')
  *
  * @returns {Promise<object>}
  */
-async function go(notificationId) {
-  const notifyClient = NotifyClientService.go()
+async function send(notificationId) {
+  const notifyClient = NotifyClientRequest.go()
 
   return _statusById(notifyClient, notificationId)
 }
@@ -55,5 +55,5 @@ async function _statusById(notifyClient, notificationId) {
 }
 
 module.exports = {
-  go
+  send
 }

--- a/app/requests/notify/notify-statuses.request.js
+++ b/app/requests/notify/notify-statuses.request.js
@@ -2,10 +2,10 @@
 
 /**
  * Get the statuses of notifications by unique reference from GOV.UK Notify
- * @module NotifyStatusesService
+ * @module NotifyStatusesRequest
  */
 
-const NotifyClientService = require('./notify-client.service.js')
+const NotifyClientRequest = require('./notify-client.request.js')
 
 /**
  * Get the statuses of notifications by unique reference from GOV.UK Notify
@@ -18,8 +18,8 @@ const NotifyClientService = require('./notify-client.service.js')
  *
  * @returns {Promise<object>}
  */
-async function go(olderThanNotificationId, referenceCode) {
-  const notifyClient = NotifyClientService.go()
+async function send(olderThanNotificationId, referenceCode) {
+  const notifyClient = NotifyClientRequest.go()
 
   return _statuses(notifyClient, olderThanNotificationId, referenceCode)
 }
@@ -44,5 +44,5 @@ async function _statuses(notifyClient, olderThanNotificationId, referenceCode) {
 }
 
 module.exports = {
-  go
+  send
 }

--- a/app/services/jobs/notifications/notifications-status-updates.service.js
+++ b/app/services/jobs/notifications/notifications-status-updates.service.js
@@ -10,7 +10,7 @@ const { setTimeout } = require('node:timers/promises')
 const FetchScheduledNotificationsService = require('./fetch-scheduled-notifications.service.js')
 const NotifyConfig = require('../../../../config/notify.config.js')
 const NotifyStatusPresenter = require('../../../presenters/jobs/notifications/notify-status.presenter.js')
-const NotifyStatusService = require('../../notify/notify-status.service.js')
+const NotifyStatusRequest = require('../../../requests/notify/notify-status.request.js')
 const UpdateEventErrorCountService = require('./update-event-error-count.service.js')
 const UpdateNotificationsService = require('./update-notifications.service.js')
 
@@ -59,7 +59,7 @@ async function _delay(delay) {
 }
 
 async function _notificationStatus(scheduledNotification) {
-  const notifyResponse = await NotifyStatusService.go(scheduledNotification.notifyId)
+  const notifyResponse = await NotifyStatusRequest.send(scheduledNotification.notifyId)
 
   if (notifyResponse.errors) {
     return scheduledNotification

--- a/app/services/notifications/setup/batch-notifications.service.js
+++ b/app/services/notifications/setup/batch-notifications.service.js
@@ -8,8 +8,8 @@
 const { setTimeout } = require('node:timers/promises')
 
 const CreateNotificationsService = require('./create-notifications.service.js')
-const NotifyEmailService = require('../../notify/notify-email.service.js')
-const NotifyLetterService = require('../../notify/notify-letter.service.js')
+const NotifyEmailRequest = require('../../../requests/notify/notify-email.request.js')
+const NotifyLetterRequest = require('../../../requests/notify/notify-letter.request.js')
 const NotifyUpdatePresenter = require('../../../presenters/notifications/setup/notify-update.presenter.js')
 const ScheduledNotificationsPresenter = require('../../../presenters/notifications/setup/scheduled-notifications.presenter.js')
 const UpdateEventService = require('./update-event.service.js')
@@ -116,7 +116,7 @@ function _scheduledNotification(scheduledNotification, notifyResponse) {
 }
 
 async function _sendLetter(scheduledNotification) {
-  const notifyResponse = await NotifyLetterService.go(scheduledNotification.templateId, {
+  const notifyResponse = await NotifyLetterRequest.send(scheduledNotification.templateId, {
     personalisation: scheduledNotification.personalisation,
     reference: scheduledNotification.reference
   })
@@ -125,7 +125,7 @@ async function _sendLetter(scheduledNotification) {
 }
 
 async function _sendEmail(scheduledNotification) {
-  const notifyResponse = await NotifyEmailService.go(
+  const notifyResponse = await NotifyEmailRequest.send(
     scheduledNotification.templateId,
     scheduledNotification.recipient,
     {

--- a/test/requests/notify/notify-client.service.test.js
+++ b/test/requests/notify/notify-client.service.test.js
@@ -16,9 +16,9 @@ const NotifyConfig = require('../../../config/notify.config.js')
 const RequestConfig = require('../../../config/request.config.js')
 
 // Thing under test
-const NotifyClientService = require('../../../app/services/notify/notify-client.service.js')
+const NotifyClientRequest = require('../../../app/requests/notify/notify-client.request.js')
 
-describe('Notify - Client service', () => {
+describe('Notify - Client request', () => {
   afterEach(() => {
     Sinon.restore()
   })
@@ -29,7 +29,7 @@ describe('Notify - Client service', () => {
     })
 
     it('should create a notify client', () => {
-      const result = NotifyClientService.go()
+      const result = NotifyClientRequest.go()
 
       expect(result).to.equal(new NotifyClient(NotifyConfig.apiKey))
     })
@@ -41,7 +41,7 @@ describe('Notify - Client service', () => {
     })
 
     it('should create a notify client with the provided proxy url', () => {
-      const result = NotifyClientService.go()
+      const result = NotifyClientRequest.go()
 
       expect(result.apiClient.restClient.defaults.httpsAgent.proxy.host).to.equal('test.proxy.defra.gov.uk')
       expect(result.apiClient.restClient.defaults.httpsAgent.proxy.hostname).to.equal('test.proxy.defra.gov.uk')

--- a/test/requests/notify/notify-email.service.test.js
+++ b/test/requests/notify/notify-email.service.test.js
@@ -14,9 +14,9 @@ const { notifyTemplates } = require('../../../app/lib/notify-templates.lib.js')
 const { stubNotify } = require('../../../config/notify.config.js')
 
 // Thing under test
-const NotifyEmailService = require('../../../app/services/notify/notify-email.service.js')
+const NotifyEmailRequest = require('../../../app/requests/notify/notify-email.request.js')
 
-describe('Notify - Email service', () => {
+describe('Notify - Email request', () => {
   let emailAddress
   let notifierStub
   let notifyStub
@@ -62,7 +62,7 @@ describe('Notify - Email service', () => {
     })
 
     it('should call notify', async () => {
-      const result = await NotifyEmailService.go(templateId, emailAddress, options)
+      const result = await NotifyEmailRequest.send(templateId, emailAddress, options)
 
       expect(result).to.equal({
         id: result.id,
@@ -74,7 +74,7 @@ describe('Notify - Email service', () => {
 
     if (stubNotify) {
       it('should use the notify client', async () => {
-        await NotifyEmailService.go(templateId, emailAddress, options)
+        await NotifyEmailRequest.send(templateId, emailAddress, options)
 
         expect(notifyStub.calledWith(templateId, emailAddress, options)).to.equal(true)
       })
@@ -104,7 +104,7 @@ describe('Notify - Email service', () => {
         })
 
         it('should return an error', async () => {
-          const result = await NotifyEmailService.go(templateId, emailAddress, options)
+          const result = await NotifyEmailRequest.send(templateId, emailAddress, options)
 
           expect(result).to.equal({
             status: 400,
@@ -140,7 +140,7 @@ describe('Notify - Email service', () => {
         })
 
         it('should return an error', async () => {
-          const result = await NotifyEmailService.go(templateId, emailAddress, options)
+          const result = await NotifyEmailRequest.send(templateId, emailAddress, options)
 
           expect(result).to.equal({
             status: 400,

--- a/test/requests/notify/notify-letter.service.test.js
+++ b/test/requests/notify/notify-letter.service.test.js
@@ -14,9 +14,9 @@ const { notifyTemplates } = require('../../../app/lib/notify-templates.lib.js')
 const { stubNotify } = require('../../../config/notify.config.js')
 
 // Thing under test
-const NotifyLetterService = require('../../../app/services/notify/notify-letter.service.js')
+const NotifyLetterRequest = require('../../../app/requests/notify/notify-letter.request.js')
 
-describe('Notify - Letter service', () => {
+describe('Notify - Letter request', () => {
   let notifierStub
   let notifyStub
   let options
@@ -64,7 +64,7 @@ describe('Notify - Letter service', () => {
     })
 
     it('should call notify', async () => {
-      const result = await NotifyLetterService.go(templateId, options)
+      const result = await NotifyLetterRequest.send(templateId, options)
 
       expect(result).to.equal({
         id: result.id,
@@ -76,7 +76,7 @@ describe('Notify - Letter service', () => {
 
     if (stubNotify) {
       it('should use the notify client', async () => {
-        await NotifyLetterService.go(templateId, options)
+        await NotifyLetterRequest.send(templateId, options)
 
         expect(notifyStub.calledWith(templateId, options)).to.equal(true)
       })
@@ -110,7 +110,7 @@ describe('Notify - Letter service', () => {
         })
 
         it('should return an error', async () => {
-          const result = await NotifyLetterService.go(templateId, options)
+          const result = await NotifyLetterRequest.send(templateId, options)
 
           expect(result).to.equal({
             status: 400,
@@ -146,7 +146,7 @@ describe('Notify - Letter service', () => {
         })
 
         it('should return an error', async () => {
-          const result = await NotifyLetterService.go(templateId, options)
+          const result = await NotifyLetterRequest.send(templateId, options)
 
           expect(result).to.equal({
             status: 400,

--- a/test/requests/notify/notify-status.service.test.js
+++ b/test/requests/notify/notify-status.service.test.js
@@ -13,9 +13,9 @@ const { NotifyClient } = require('notifications-node-client')
 const { stubNotify } = require('../../../config/notify.config.js')
 
 // Thing under test
-const NotifyStatusService = require('../../../app/services/notify/notify-status.service.js')
+const NotifyStatusRequest = require('../../../app/requests/notify/notify-status.request.js')
 
-describe('Notify - Status service', () => {
+describe('Notify - Status request', () => {
   let notificationId
   let notifierStub
   let notifyStub
@@ -39,7 +39,7 @@ describe('Notify - Status service', () => {
     })
 
     it('should call notify', async () => {
-      const result = await NotifyStatusService.go(notificationId)
+      const result = await NotifyStatusRequest.send(notificationId)
 
       expect(result).to.equal({
         status: 'received'
@@ -48,7 +48,7 @@ describe('Notify - Status service', () => {
 
     if (stubNotify) {
       it('should use the notify client', async () => {
-        await NotifyStatusService.go(notificationId)
+        await NotifyStatusRequest.send(notificationId)
 
         expect(notifyStub.calledWith(notificationId)).to.equal(true)
       })
@@ -64,7 +64,7 @@ describe('Notify - Status service', () => {
     })
 
     it('should return an error', async () => {
-      const result = await NotifyStatusService.go(notificationId)
+      const result = await NotifyStatusRequest.send(notificationId)
 
       expect(result).to.equal({
         status: 404,

--- a/test/requests/notify/notify-statuses.service.test.js
+++ b/test/requests/notify/notify-statuses.service.test.js
@@ -12,9 +12,9 @@ const { expect } = Code
 const { NotifyClient } = require('notifications-node-client')
 
 // Thing under test
-const NotifyStatusesService = require('../../../app/services/notify/notify-statuses.service.js')
+const NotifyStatusesRequest = require('../../../app/requests/notify/notify-statuses.request.js')
 
-describe('Notify - Statuses service', () => {
+describe('Notify - Statuses request', () => {
   let notificationId
   let notifyStub
   let referenceCode
@@ -38,7 +38,7 @@ describe('Notify - Statuses service', () => {
     })
 
     it('should call notify', async () => {
-      const result = await NotifyStatusesService.go(notificationId, referenceCode)
+      const result = await NotifyStatusesRequest.send(notificationId, referenceCode)
 
       expect(result).to.equal({
         data: [
@@ -51,7 +51,7 @@ describe('Notify - Statuses service', () => {
     })
 
     it('should use the notify client', async () => {
-      await NotifyStatusesService.go(notificationId, referenceCode)
+      await NotifyStatusesRequest.send(notificationId, referenceCode)
 
       expect(notifyStub.calledWith(null, null, referenceCode, notificationId)).to.equal(true)
     })
@@ -69,7 +69,7 @@ describe('Notify - Statuses service', () => {
     })
 
     it('should return an empty array', async () => {
-      const result = await NotifyStatusesService.go(notificationId, referenceCode)
+      const result = await NotifyStatusesRequest.send(notificationId, referenceCode)
 
       expect(result).to.equal({
         data: []
@@ -83,7 +83,7 @@ describe('Notify - Statuses service', () => {
     })
 
     it('should return an error', async () => {
-      const result = await NotifyStatusesService.go(notificationId, referenceCode)
+      const result = await NotifyStatusesRequest.send(notificationId, referenceCode)
 
       expect(result).to.equal({
         status: 404,


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4961

We have an established pattern of putting third party services we interact with in the requests folder and name them request.

This change refactors the Notify services into Notify Requests.

All the module names, file names will be updated.

The test folder will align with the app folder.