### PR TITLE
Add notification view and model

### DIFF
--- a/app/models/notification.model.js
+++ b/app/models/notification.model.js
@@ -1,0 +1,31 @@
+'use strict'
+
+/**
+ * Model for notifications (water.scheduled_notification)
+ * @module NotificationModel
+ */
+
+const { Model } = require('objection')
+
+const BaseModel = require('./base.model.js')
+
+class NotificationModel extends BaseModel {
+  static get tableName() {
+    return 'notifications'
+  }
+
+  static get relationMappings() {
+    return {
+      event: {
+        relation: Model.HasOneRelation,
+        modelClass: 'event.model',
+        join: {
+          from: 'notifications.eventId',
+          to: 'events.id'
+        }
+      }
+    }
+  }
+}
+
+module.exports = NotificationModel

--- a/db/migrations/public/20250407082826_create-notifications-view.js
+++ b/db/migrations/public/20250407082826_create-notifications-view.js
@@ -14,7 +14,7 @@ exports.up = function (knex) {
         'personalisation',
         // 'send_after',
         'status',
-        'log AS notify_error_message',
+        'log AS notify_error',
         'licences',
         // 'individual_entity_id AS individual_id',
         // 'company_entity_id AS company_id',

--- a/db/migrations/public/20250407082826_create-notifications-view.js
+++ b/db/migrations/public/20250407082826_create-notifications-view.js
@@ -1,0 +1,39 @@
+'use strict'
+
+const viewName = 'notifications'
+
+exports.up = function (knex) {
+  return knex.schema.createView(viewName, (view) => {
+    // NOTE: We have commented out unused columns from the source table
+    view.as(
+      knex('scheduled_notification').withSchema('water').select([
+        'id',
+        'recipient',
+        'message_type',
+        'message_ref',
+        'personalisation',
+        // 'send_after',
+        'status',
+        'log AS notify_error_message',
+        'licences',
+        // 'individual_entity_id AS individual_id',
+        // 'company_entity_id AS company_id',
+        // 'medium',
+        'notify_id',
+        'notify_status',
+        'plaintext',
+        'event_id',
+        // 'metadata',
+        // 'status_checks',
+        // 'next_status_check',
+        // 'notification_type',
+        // 'job_id',
+        'date_created AS created_at'
+      ])
+    )
+  })
+}
+
+exports.down = function (knex) {
+  return knex.schema.dropViewIfExists(viewName)
+}

--- a/test/models/notification.model.test.js
+++ b/test/models/notification.model.test.js
@@ -15,7 +15,7 @@ const NotificationHelper = require('../support/helpers/notification.helper.js')
 // Thing under test
 const NotificationModel = require('../../app/models/notification.model.js')
 
-describe.only('Notification model', () => {
+describe('Notification model', () => {
   let testRecord
 
   describe('Basic query', () => {

--- a/test/models/notification.model.test.js
+++ b/test/models/notification.model.test.js
@@ -1,0 +1,61 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Test helpers
+const EventHelper = require('../support/helpers/event.helper.js')
+const EventModel = require('../../app/models/event.model.js')
+const NotificationHelper = require('../support/helpers/notification.helper.js')
+
+// Thing under test
+const NotificationModel = require('../../app/models/notification.model.js')
+
+describe.only('Notification model', () => {
+  let testRecord
+
+  describe('Basic query', () => {
+    beforeEach(async () => {
+      testRecord = await NotificationHelper.add()
+    })
+
+    it('can successfully run a basic query', async () => {
+      const result = await NotificationModel.query().findById(testRecord.id)
+
+      expect(result).to.be.an.instanceOf(NotificationModel)
+      expect(result.id).to.equal(testRecord.id)
+    })
+  })
+
+  describe('Relationships', () => {
+    describe('when linking to event', () => {
+      let testEvent
+
+      beforeEach(async () => {
+        testEvent = await EventHelper.add()
+
+        testRecord = await NotificationHelper.add({ eventId: testEvent.id })
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await NotificationModel.query().innerJoinRelated('event')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the event', async () => {
+        const result = await NotificationModel.query().findById(testRecord.id).withGraphFetched('event')
+
+        expect(result).to.be.instanceOf(NotificationModel)
+        expect(result.id).to.equal(testRecord.id)
+
+        expect(result.event).to.be.an.instanceOf(EventModel)
+        expect(result.event).to.include(testEvent)
+      })
+    })
+  })
+})

--- a/test/support/helpers/notification.helper.js
+++ b/test/support/helpers/notification.helper.js
@@ -1,0 +1,54 @@
+'use strict'
+
+/**
+ * @module NotificationHelper
+ */
+
+const { timestampForPostgres } = require('../../../app/lib/general.lib.js')
+const NotificationModel = require('../../../app/models/notification.model.js')
+
+/**
+ * Add a new notification
+ *
+ * If no `data` is provided, default values will be used. These are
+ *
+ * - `createdAt` - new Date()
+ *
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
+ *
+ * @returns {Promise<module:NotificationModel>} The instance of the newly created record
+ */
+function add(data = {}) {
+  const insertData = defaults(data)
+
+  return NotificationModel.query()
+    .insert({ ...insertData })
+    .returning('*')
+}
+
+/**
+ * Returns the defaults used
+ *
+ * It will override or append to them any data provided. Mainly used by the `add()` method, we make it available
+ * for use in tests to avoid having to duplicate values.
+ *
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
+ *
+ * @returns {object} - Returns the set defaults with the override data spread
+ */
+function defaults(data = {}) {
+  const defaults = {
+    // INFO: The table does not have a default for the createdAt column.
+    createdAt: timestampForPostgres()
+  }
+
+  return {
+    ...defaults,
+    ...data
+  }
+}
+
+module.exports = {
+  add,
+  defaults
+}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4961

We have previously used a 'scheduledNotifications' view for the 'water.scheduledNotifications' table. We have decided to move to a new view called 'notifications' this is, simply, because we do not schedule notifications to be sent, we just send them.

This change adds the 'notifications' table view, with the associated model, test and test helper.