### PR TITLE
Refactor scheduled notification to notifications services

### DIFF
--- a/app/models/notification.model.js
+++ b/app/models/notification.model.js
@@ -1,0 +1,31 @@
+'use strict'
+
+/**
+ * Model for notifications (water.scheduled_notification)
+ * @module NotificationModel
+ */
+
+const { Model } = require('objection')
+
+const BaseModel = require('./base.model.js')
+
+class NotificationModel extends BaseModel {
+  static get tableName() {
+    return 'notifications'
+  }
+
+  static get relationMappings() {
+    return {
+      event: {
+        relation: Model.HasOneRelation,
+        modelClass: 'event.model',
+        join: {
+          from: 'notifications.eventId',
+          to: 'events.id'
+        }
+      }
+    }
+  }
+}
+
+module.exports = NotificationModel

--- a/app/presenters/notifications/setup/notifications.presenter.js
+++ b/app/presenters/notifications/setup/notifications.presenter.js
@@ -1,8 +1,8 @@
 'use strict'
 
 /**
- * Formats recipients into scheduled notifications for a returns invitation or reminder
- * @module ScheduledNotificationsPresenter
+ * Formats recipients into notifications for a returns invitation or reminder
+ * @module NotificationsPresenter
  */
 
 const { contactName, contactAddress } = require('../../crm.presenter.js')
@@ -11,12 +11,12 @@ const { notifyTemplates } = require('../../../lib/notify-templates.lib.js')
 const { transformStringOfLicencesToArray, timestampForPostgres } = require('../../../lib/general.lib.js')
 
 /**
- * Formats recipients into scheduled notifications for a returns invitation or reminder
+ * Formats recipients into notifications for a returns invitation or reminder
  *
  * This function prepares data for both sending notifications via a notification service (e.g., Notify)
- * and storing scheduled notification records in a database (e.g., 'water.scheduled_notifications').
+ * and storing notification records in a database (e.g., 'water.scheduled_notifications').
  * It aligns with legacy practices by including parts of the Notify payload and response directly
- * within the scheduled notification objects.
+ * within the notification objects.
  *
  * The output of this function is designed to be used directly for both notification delivery and persistent storage.
  *
@@ -26,20 +26,20 @@ const { transformStringOfLicencesToArray, timestampForPostgres } = require('../.
  * @param {string} journey - the journey should be one of "reminders", "invitations" or "ad-hoc"
  * @param {string} eventId - the event id to link all the notifications to an event
  *
- * @returns {object[]} - the recipients transformed into scheduled notifications
+ * @returns {object[]} - the recipients transformed into notifications
  */
 function go(recipients, returnsPeriod, referenceCode, journey, eventId) {
-  const scheduledNotifications = []
+  const notifications = []
 
   for (const recipient of recipients) {
     if (recipient.email) {
-      scheduledNotifications.push(_email(recipient, returnsPeriod, referenceCode, journey, eventId))
+      notifications.push(_email(recipient, returnsPeriod, referenceCode, journey, eventId))
     } else {
-      scheduledNotifications.push(_letter(recipient, returnsPeriod, referenceCode, journey, eventId))
+      notifications.push(_letter(recipient, returnsPeriod, referenceCode, journey, eventId))
     }
   }
 
-  return scheduledNotifications
+  return notifications
 }
 
 /**
@@ -87,7 +87,7 @@ function _common(referenceCode, templateId, eventId) {
  *    }
  * ```
  *
- * A scheduled notification saves the 'emailAddress' as 'recipient' and so is used as the variables name.
+ * A notification saves the 'emailAddress' as 'recipient' and so is used as the variables name.
  *
  * @private
  */

--- a/app/presenters/notifications/view-notification.presenter.js
+++ b/app/presenters/notifications/view-notification.presenter.js
@@ -10,12 +10,12 @@ const { formatLongDate, sentenceCase } = require('../base.presenter.js')
 /**
  * Formats notification data ready for presenting in the view notification page
  *
- * @param {module:ScheduledNotificationModel} notificationData - The scheduled notification and related licence data
+ * @param {module:NotificationModel} notificationData - The notification and related licence data
  *
  * @returns {object} The data formatted for the view template
  */
 function go(notificationData) {
-  const { messageType, plaintext, personalisation, sendAfter } = notificationData.notification
+  const { messageType, plaintext, personalisation, createdAt } = notificationData.notification
   const { id: licenceId, licenceRef } = notificationData.licence
 
   return {
@@ -25,7 +25,7 @@ function go(notificationData) {
     licenceRef,
     messageType,
     pageTitle: _pageTitle(notificationData.notification),
-    sentDate: formatLongDate(sendAfter)
+    sentDate: formatLongDate(createdAt)
   }
 }
 

--- a/app/services/notifications/fetch-notification.service.js
+++ b/app/services/notifications/fetch-notification.service.js
@@ -6,15 +6,15 @@
  */
 
 const LicenceModel = require('../../models/licence.model.js')
-const ScheduledNotificationsModel = require('../../models/scheduled-notification.model.js')
+const NotificationsModel = require('../../models/notification.model.js')
 
 /**
  * Fetches the matching notification and licence data needed for the view
  *
- * @param {string} notificationId - The UUID for the scheduledNotification
+ * @param {string} notificationId - The UUID for the notification
  * @param {string} licenceId - The UUID for the related licence
  *
- * @returns {Promise<module:ScheduledNotificationsModel>} the matching `ScheduledNotificationsModel` instance and
+ * @returns {Promise<module:NotificationModel>} the matching `NotificationsModel` instance and
  * licence data
  */
 async function go(notificationId, licenceId) {
@@ -29,9 +29,9 @@ async function _fetchLicence(licenceId) {
 }
 
 async function _fetchNotification(notificationId) {
-  return ScheduledNotificationsModel.query()
+  return NotificationsModel.query()
     .findById(notificationId)
-    .select(['messageType', 'personalisation', 'plaintext', 'sendAfter'])
+    .select(['messageType', 'personalisation', 'plaintext', 'createdAt'])
     .withGraphFetched('event')
     .modifyGraph('event', (builder) => {
       builder.select(['metadata'])

--- a/app/services/notifications/setup/batch-notifications.service.js
+++ b/app/services/notifications/setup/batch-notifications.service.js
@@ -11,7 +11,7 @@ const CreateNotificationsService = require('./create-notifications.service.js')
 const NotifyEmailRequest = require('../../../requests/notify/notify-email.request.js')
 const NotifyLetterRequest = require('../../../requests/notify/notify-letter.request.js')
 const NotifyUpdatePresenter = require('../../../presenters/notifications/setup/notify-update.presenter.js')
-const ScheduledNotificationsPresenter = require('../../../presenters/notifications/setup/scheduled-notifications.presenter.js')
+const ScheduledNotificationsPresenter = require('../../../presenters/notifications/setup/notifications.presenter.js')
 const UpdateEventService = require('./update-event.service.js')
 
 const NotifyConfig = require('../../../../config/notify.config.js')

--- a/db/migrations/public/20250407082826_create-notifications-view.js
+++ b/db/migrations/public/20250407082826_create-notifications-view.js
@@ -14,7 +14,7 @@ exports.up = function (knex) {
         'personalisation',
         // 'send_after',
         'status',
-        'log AS notify_error_message',
+        'log AS notify_error',
         'licences',
         // 'individual_entity_id AS individual_id',
         // 'company_entity_id AS company_id',

--- a/db/migrations/public/20250407082826_create-notifications-view.js
+++ b/db/migrations/public/20250407082826_create-notifications-view.js
@@ -1,0 +1,39 @@
+'use strict'
+
+const viewName = 'notifications'
+
+exports.up = function (knex) {
+  return knex.schema.createView(viewName, (view) => {
+    // NOTE: We have commented out unused columns from the source table
+    view.as(
+      knex('scheduled_notification').withSchema('water').select([
+        'id',
+        'recipient',
+        'message_type',
+        'message_ref',
+        'personalisation',
+        // 'send_after',
+        'status',
+        'log AS notify_error_message',
+        'licences',
+        // 'individual_entity_id AS individual_id',
+        // 'company_entity_id AS company_id',
+        // 'medium',
+        'notify_id',
+        'notify_status',
+        'plaintext',
+        'event_id',
+        // 'metadata',
+        // 'status_checks',
+        // 'next_status_check',
+        // 'notification_type',
+        // 'job_id',
+        'date_created AS created_at'
+      ])
+    )
+  })
+}
+
+exports.down = function (knex) {
+  return knex.schema.dropViewIfExists(viewName)
+}

--- a/test/fixtures/notifications.fixture.js
+++ b/test/fixtures/notifications.fixture.js
@@ -50,7 +50,7 @@ function notification() {
       '\n' +
       '# Why you are receiving this notification\n' +
       '\n',
-    sendAfter: new Date('2024-07-02T16:52:17.000Z'),
+    createdAt: new Date('2024-07-02T16:52:17.000Z'),
     event
   })
 

--- a/test/models/notification.model.test.js
+++ b/test/models/notification.model.test.js
@@ -15,7 +15,7 @@ const NotificationHelper = require('../support/helpers/notification.helper.js')
 // Thing under test
 const NotificationModel = require('../../app/models/notification.model.js')
 
-describe.only('Notification model', () => {
+describe('Notification model', () => {
   let testRecord
 
   describe('Basic query', () => {

--- a/test/models/notification.model.test.js
+++ b/test/models/notification.model.test.js
@@ -1,0 +1,61 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Test helpers
+const EventHelper = require('../support/helpers/event.helper.js')
+const EventModel = require('../../app/models/event.model.js')
+const NotificationHelper = require('../support/helpers/notification.helper.js')
+
+// Thing under test
+const NotificationModel = require('../../app/models/notification.model.js')
+
+describe.only('Notification model', () => {
+  let testRecord
+
+  describe('Basic query', () => {
+    beforeEach(async () => {
+      testRecord = await NotificationHelper.add()
+    })
+
+    it('can successfully run a basic query', async () => {
+      const result = await NotificationModel.query().findById(testRecord.id)
+
+      expect(result).to.be.an.instanceOf(NotificationModel)
+      expect(result.id).to.equal(testRecord.id)
+    })
+  })
+
+  describe('Relationships', () => {
+    describe('when linking to event', () => {
+      let testEvent
+
+      beforeEach(async () => {
+        testEvent = await EventHelper.add()
+
+        testRecord = await NotificationHelper.add({ eventId: testEvent.id })
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await NotificationModel.query().innerJoinRelated('event')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the event', async () => {
+        const result = await NotificationModel.query().findById(testRecord.id).withGraphFetched('event')
+
+        expect(result).to.be.instanceOf(NotificationModel)
+        expect(result.id).to.equal(testRecord.id)
+
+        expect(result.event).to.be.an.instanceOf(EventModel)
+        expect(result.event).to.include(testEvent)
+      })
+    })
+  })
+})

--- a/test/presenters/notifications/setup/notifications.presenter.test.js
+++ b/test/presenters/notifications/setup/notifications.presenter.test.js
@@ -12,9 +12,9 @@ const { expect } = Code
 const RecipientsFixture = require('../../../fixtures/recipients.fixtures.js')
 
 // Thing under test
-const ScheduledNotificationsPresenter = require('../../../../app/presenters/notifications/setup/scheduled-notifications.presenter.js')
+const NotificationsPresenter = require('../../../../app/presenters/notifications/setup/notifications.presenter.js')
 
-describe('Notifications Setup - Scheduled Notifications Presenter', () => {
+describe('Notifications Setup - Notifications Presenter', () => {
   const referenceCode = 'TEST-123'
   const eventId = 'c1cae668-3dad-4806-94e2-eb3f27222ed9'
 
@@ -47,13 +47,7 @@ describe('Notifications Setup - Scheduled Notifications Presenter', () => {
   })
 
   it('correctly transform the recipients into notifications', () => {
-    const result = ScheduledNotificationsPresenter.go(
-      testRecipients,
-      determinedReturnsPeriod,
-      referenceCode,
-      journey,
-      eventId
-    )
+    const result = NotificationsPresenter.go(testRecipients, determinedReturnsPeriod, referenceCode, journey, eventId)
 
     const [firstMultiple, secondMultiple] = recipients.licenceHolderWithMultipleLicences.licence_refs.split(',')
 
@@ -168,7 +162,7 @@ describe('Notifications Setup - Scheduled Notifications Presenter', () => {
         })
 
         it('correctly transforms the recipient to a notification', () => {
-          const result = ScheduledNotificationsPresenter.go(
+          const result = NotificationsPresenter.go(
             testRecipients,
             determinedReturnsPeriod,
             referenceCode,
@@ -203,7 +197,7 @@ describe('Notifications Setup - Scheduled Notifications Presenter', () => {
         })
 
         it('correctly transforms the recipient to a notification', () => {
-          const result = ScheduledNotificationsPresenter.go(
+          const result = NotificationsPresenter.go(
             testRecipients,
             determinedReturnsPeriod,
             referenceCode,
@@ -238,7 +232,7 @@ describe('Notifications Setup - Scheduled Notifications Presenter', () => {
         })
 
         it('correctly transforms the recipient to a notification', () => {
-          const result = ScheduledNotificationsPresenter.go(
+          const result = NotificationsPresenter.go(
             testRecipients,
             determinedReturnsPeriod,
             referenceCode,
@@ -275,7 +269,7 @@ describe('Notifications Setup - Scheduled Notifications Presenter', () => {
         })
 
         it('correctly transforms the recipient to a notification', () => {
-          const result = ScheduledNotificationsPresenter.go(
+          const result = NotificationsPresenter.go(
             testRecipients,
             determinedReturnsPeriod,
             referenceCode,
@@ -315,7 +309,7 @@ describe('Notifications Setup - Scheduled Notifications Presenter', () => {
         })
 
         it('correctly transforms the recipient to a notification', () => {
-          const result = ScheduledNotificationsPresenter.go(
+          const result = NotificationsPresenter.go(
             testRecipients,
             determinedReturnsPeriod,
             referenceCode,
@@ -355,7 +349,7 @@ describe('Notifications Setup - Scheduled Notifications Presenter', () => {
         })
 
         it('correctly transforms the recipient to a notification', () => {
-          const result = ScheduledNotificationsPresenter.go(
+          const result = NotificationsPresenter.go(
             testRecipients,
             determinedReturnsPeriod,
             referenceCode,
@@ -403,7 +397,7 @@ describe('Notifications Setup - Scheduled Notifications Presenter', () => {
         })
 
         it('correctly transforms the recipient to a notification', () => {
-          const result = ScheduledNotificationsPresenter.go(
+          const result = NotificationsPresenter.go(
             testRecipients,
             determinedReturnsPeriod,
             referenceCode,
@@ -438,7 +432,7 @@ describe('Notifications Setup - Scheduled Notifications Presenter', () => {
         })
 
         it('correctly transforms the recipient to a notification', () => {
-          const result = ScheduledNotificationsPresenter.go(
+          const result = NotificationsPresenter.go(
             testRecipients,
             determinedReturnsPeriod,
             referenceCode,
@@ -473,7 +467,7 @@ describe('Notifications Setup - Scheduled Notifications Presenter', () => {
         })
 
         it('correctly transforms the recipient to a notification', () => {
-          const result = ScheduledNotificationsPresenter.go(
+          const result = NotificationsPresenter.go(
             testRecipients,
             determinedReturnsPeriod,
             referenceCode,
@@ -510,7 +504,7 @@ describe('Notifications Setup - Scheduled Notifications Presenter', () => {
         })
 
         it('correctly transforms the recipient to a notification', () => {
-          const result = ScheduledNotificationsPresenter.go(
+          const result = NotificationsPresenter.go(
             testRecipients,
             determinedReturnsPeriod,
             referenceCode,
@@ -550,7 +544,7 @@ describe('Notifications Setup - Scheduled Notifications Presenter', () => {
         })
 
         it('correctly transforms the recipient to a notification', () => {
-          const result = ScheduledNotificationsPresenter.go(
+          const result = NotificationsPresenter.go(
             testRecipients,
             determinedReturnsPeriod,
             referenceCode,
@@ -590,7 +584,7 @@ describe('Notifications Setup - Scheduled Notifications Presenter', () => {
         })
 
         it('correctly transforms the recipient to a notification', () => {
-          const result = ScheduledNotificationsPresenter.go(
+          const result = NotificationsPresenter.go(
             testRecipients,
             determinedReturnsPeriod,
             referenceCode,
@@ -638,7 +632,7 @@ describe('Notifications Setup - Scheduled Notifications Presenter', () => {
         })
 
         it('correctly transforms the recipient to a notification', () => {
-          const result = ScheduledNotificationsPresenter.go(
+          const result = NotificationsPresenter.go(
             testRecipients,
             determinedReturnsPeriod,
             referenceCode,
@@ -673,7 +667,7 @@ describe('Notifications Setup - Scheduled Notifications Presenter', () => {
         })
 
         it('correctly transforms the recipient to a notification', () => {
-          const result = ScheduledNotificationsPresenter.go(
+          const result = NotificationsPresenter.go(
             testRecipients,
             determinedReturnsPeriod,
             referenceCode,
@@ -708,7 +702,7 @@ describe('Notifications Setup - Scheduled Notifications Presenter', () => {
         })
 
         it('correctly transforms the recipient to a notification', () => {
-          const result = ScheduledNotificationsPresenter.go(
+          const result = NotificationsPresenter.go(
             testRecipients,
             determinedReturnsPeriod,
             referenceCode,
@@ -745,7 +739,7 @@ describe('Notifications Setup - Scheduled Notifications Presenter', () => {
         })
 
         it('correctly transforms the recipient to a notification', () => {
-          const result = ScheduledNotificationsPresenter.go(
+          const result = NotificationsPresenter.go(
             testRecipients,
             determinedReturnsPeriod,
             referenceCode,
@@ -785,7 +779,7 @@ describe('Notifications Setup - Scheduled Notifications Presenter', () => {
         })
 
         it('correctly transforms the recipient to a notification', () => {
-          const result = ScheduledNotificationsPresenter.go(
+          const result = NotificationsPresenter.go(
             testRecipients,
             determinedReturnsPeriod,
             referenceCode,
@@ -825,7 +819,7 @@ describe('Notifications Setup - Scheduled Notifications Presenter', () => {
         })
 
         it('correctly transforms the recipient to a notification', () => {
-          const result = ScheduledNotificationsPresenter.go(
+          const result = NotificationsPresenter.go(
             testRecipients,
             determinedReturnsPeriod,
             referenceCode,

--- a/test/services/notifications/fetch-notification.service.test.js
+++ b/test/services/notifications/fetch-notification.service.test.js
@@ -11,7 +11,7 @@ const { expect } = Code
 const EventHelper = require('../../support/helpers/event.helper.js')
 const LicenceHelper = require('../../support/helpers/licence.helper.js')
 const NotificationsFixture = require('../../fixtures/notifications.fixture.js')
-const ScheduledNotificationsHelper = require('../../support/helpers/scheduled-notification.helper.js')
+const NotificationsHelper = require('../../support/helpers/notification.helper.js')
 
 // Thing under test
 const FetchNotificationService = require('../../../app/services/notifications/fetch-notification.service.js')
@@ -27,7 +27,7 @@ describe('Fetch Notification service', () => {
     licence = await LicenceHelper.add()
     testNotification = NotificationsFixture.notification()
 
-    notification = await ScheduledNotificationsHelper.add({
+    notification = await NotificationsHelper.add({
       ...testNotification.notification,
       eventId: event.id
     })
@@ -43,6 +43,7 @@ describe('Fetch Notification service', () => {
           licenceRef: licence.licenceRef
         },
         notification: {
+          createdAt: notification.createdAt,
           messageType: 'letter',
           personalisation: {
             postcode: 'ME15 0NE',
@@ -62,7 +63,6 @@ describe('Fetch Notification service', () => {
             '\n' +
             '# Why you are receiving this notification\n' +
             '\n',
-          sendAfter: new Date('2024-07-02T16:52:17.000Z'),
           event: {
             metadata: {
               batch: {

--- a/test/support/helpers/notification.helper.js
+++ b/test/support/helpers/notification.helper.js
@@ -1,0 +1,54 @@
+'use strict'
+
+/**
+ * @module NotificationHelper
+ */
+
+const { timestampForPostgres } = require('../../../app/lib/general.lib.js')
+const NotificationModel = require('../../../app/models/notification.model.js')
+
+/**
+ * Add a new notification
+ *
+ * If no `data` is provided, default values will be used. These are
+ *
+ * - `createdAt` - new Date()
+ *
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
+ *
+ * @returns {Promise<module:NotificationModel>} The instance of the newly created record
+ */
+function add(data = {}) {
+  const insertData = defaults(data)
+
+  return NotificationModel.query()
+    .insert({ ...insertData })
+    .returning('*')
+}
+
+/**
+ * Returns the defaults used
+ *
+ * It will override or append to them any data provided. Mainly used by the `add()` method, we make it available
+ * for use in tests to avoid having to duplicate values.
+ *
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
+ *
+ * @returns {object} - Returns the set defaults with the override data spread
+ */
+function defaults(data = {}) {
+  const defaults = {
+    // INFO: The table does not have a default for the createdAt column.
+    createdAt: timestampForPostgres()
+  }
+
+  return {
+    ...defaults,
+    ...data
+  }
+}
+
+module.exports = {
+  add,
+  defaults
+}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4979

We have previously used a 'scheduledNotifications' view for the 'water.scheduledNotifications' table. We have decided to move to a new view called 'notifications' this is, simply, because we do not schedule notifications to be sent, we just send them.

This change update the notifications logic to use this new notification model and view. 

Anything previously using 'scheduledNotifications' or 'scheduledNotification' has been replaced with 'notifications' and 'notification' respect