### PR TITLE
Update return versions check page banners

### DIFF
--- a/app/services/return-versions/setup/submit-abstraction-period.service.js
+++ b/app/services/return-versions/setup/submit-abstraction-period.service.js
@@ -36,7 +36,7 @@ async function go(sessionId, requirementIndex, payload, yar) {
     await _save(session, requirementIndex, payload)
 
     if (session.checkPageVisited) {
-      GeneralLib.flashNotification(yar)
+      GeneralLib.flashNotification(yar, 'Updated', 'Requirements for returns updated')
     }
 
     return {

--- a/app/services/return-versions/setup/submit-additional-submission-options.service.js
+++ b/app/services/return-versions/setup/submit-additional-submission-options.service.js
@@ -71,7 +71,7 @@ function _notification(session, payload) {
 
   if (additionalSubmissionOptions !== payload.additionalSubmissionOptions) {
     return {
-      text: 'Changes updated',
+      text: 'Additional submission options updated',
       title: 'Updated'
     }
   }

--- a/app/services/return-versions/setup/submit-agreements-exceptions.service.js
+++ b/app/services/return-versions/setup/submit-agreements-exceptions.service.js
@@ -38,7 +38,7 @@ async function go(sessionId, requirementIndex, payload, yar) {
     await _save(session, requirementIndex, payload)
 
     if (session.checkPageVisited) {
-      GeneralLib.flashNotification(yar)
+      GeneralLib.flashNotification(yar, 'Updated', 'Requirements for returns updated')
     } else {
       GeneralLib.flashNotification(yar, 'Added', 'New requirement added')
     }

--- a/app/services/return-versions/setup/submit-frequency-collected.service.js
+++ b/app/services/return-versions/setup/submit-frequency-collected.service.js
@@ -36,7 +36,7 @@ async function go(sessionId, requirementIndex, payload, yar) {
     await _save(session, requirementIndex, payload)
 
     if (session.checkPageVisited) {
-      GeneralLib.flashNotification(yar)
+      GeneralLib.flashNotification(yar, 'Updated', 'Requirements for returns updated')
     }
 
     return {

--- a/app/services/return-versions/setup/submit-frequency-reported.service.js
+++ b/app/services/return-versions/setup/submit-frequency-reported.service.js
@@ -36,7 +36,7 @@ async function go(sessionId, requirementIndex, payload, yar) {
     await _save(session, requirementIndex, payload)
 
     if (session.checkPageVisited) {
-      GeneralLib.flashNotification(yar)
+      GeneralLib.flashNotification(yar, 'Updated', 'Requirements for returns updated')
     }
 
     return {

--- a/app/services/return-versions/setup/submit-no-returns-required.service.js
+++ b/app/services/return-versions/setup/submit-no-returns-required.service.js
@@ -33,7 +33,7 @@ async function go(sessionId, payload, yar) {
     await _save(session, payload)
 
     if (session.checkPageVisited) {
-      GeneralLib.flashNotification(yar)
+      GeneralLib.flashNotification(yar, 'Updated', 'Return version updated')
     }
 
     return {

--- a/app/services/return-versions/setup/submit-note.service.js
+++ b/app/services/return-versions/setup/submit-note.service.js
@@ -55,18 +55,17 @@ function _notification(session, newNote) {
   const {
     data: { note }
   } = session
-  const text = 'Changes made'
 
   if (!note && newNote) {
     return {
-      text,
+      text: 'Note added',
       title: 'Added'
     }
   }
 
   if (note?.content !== newNote) {
     return {
-      text,
+      text: 'Note updated',
       title: 'Updated'
     }
   }

--- a/app/services/return-versions/setup/submit-points.service.js
+++ b/app/services/return-versions/setup/submit-points.service.js
@@ -39,7 +39,7 @@ async function go(sessionId, requirementIndex, payload, yar) {
     await _save(session, requirementIndex, payload)
 
     if (session.checkPageVisited) {
-      GeneralLib.flashNotification(yar)
+      GeneralLib.flashNotification(yar, 'Updated', 'Requirements for returns updated')
     }
 
     return {

--- a/app/services/return-versions/setup/submit-purpose.service.js
+++ b/app/services/return-versions/setup/submit-purpose.service.js
@@ -42,7 +42,7 @@ async function go(sessionId, requirementIndex, payload, yar) {
     await _save(session, requirementIndex, purposes)
 
     if (session.checkPageVisited) {
-      GeneralLib.flashNotification(yar)
+      GeneralLib.flashNotification(yar, 'Updated', 'Requirements for returns updated')
     }
 
     return {

--- a/app/services/return-versions/setup/submit-reason.service.js
+++ b/app/services/return-versions/setup/submit-reason.service.js
@@ -35,7 +35,7 @@ async function go(sessionId, payload, yar) {
     await _save(session, payload)
 
     if (session.checkPageVisited) {
-      GeneralLib.flashNotification(yar)
+      GeneralLib.flashNotification(yar, 'Updated', 'Return version updated')
     }
 
     return {

--- a/app/services/return-versions/setup/submit-returns-cycle.service.js
+++ b/app/services/return-versions/setup/submit-returns-cycle.service.js
@@ -36,7 +36,7 @@ async function go(sessionId, requirementIndex, payload, yar) {
     await _save(session, requirementIndex, payload)
 
     if (session.checkPageVisited) {
-      GeneralLib.flashNotification(yar)
+      GeneralLib.flashNotification(yar, 'Updated', 'Requirements for returns updated')
     }
 
     return {

--- a/app/services/return-versions/setup/submit-site-description.service.js
+++ b/app/services/return-versions/setup/submit-site-description.service.js
@@ -36,7 +36,7 @@ async function go(sessionId, requirementIndex, payload, yar) {
     await _save(session, requirementIndex, payload)
 
     if (session.checkPageVisited) {
-      GeneralLib.flashNotification(yar)
+      GeneralLib.flashNotification(yar, 'Updated', 'Requirements for returns updated')
     }
 
     return {

--- a/app/services/return-versions/setup/submit-start-date.service.js
+++ b/app/services/return-versions/setup/submit-start-date.service.js
@@ -38,7 +38,7 @@ async function go(sessionId, payload, yar) {
     await _save(session, payload)
 
     if (session.checkPageVisited) {
-      GeneralLib.flashNotification(yar)
+      GeneralLib.flashNotification(yar, 'Updated', 'Return version updated')
     }
 
     return {

--- a/test/services/return-versions/setup/submit-abstraction-period.service.test.js
+++ b/test/services/return-versions/setup/submit-abstraction-period.service.test.js
@@ -107,7 +107,7 @@ describe('Return Versions Setup - Submit Abstraction Period service', () => {
           const [flashType, notification] = yarStub.flash.args[0]
 
           expect(flashType).to.equal('notification')
-          expect(notification).to.equal({ title: 'Updated', text: 'Changes made' })
+          expect(notification).to.equal({ title: 'Updated', text: 'Requirements for returns updated' })
         })
       })
     })

--- a/test/services/return-versions/setup/submit-abstraction-period.service.test.js
+++ b/test/services/return-versions/setup/submit-abstraction-period.service.test.js
@@ -101,7 +101,7 @@ describe('Return Versions Setup - Submit Abstraction Period service', () => {
           })
         })
 
-        it('sets the notification message title to "Updated" and the text to "Changes made" ', async () => {
+        it('sets the notification message title to "Updated" and the text to "Requirements for returns updated" ', async () => {
           await SubmitAbstractionPeriodService.go(session.id, requirementIndex, payload, yarStub)
 
           const [flashType, notification] = yarStub.flash.args[0]

--- a/test/services/return-versions/setup/submit-additional-submission-options.service.test.js
+++ b/test/services/return-versions/setup/submit-additional-submission-options.service.test.js
@@ -63,7 +63,7 @@ describe('Return Versions Setup - Submit Additional Submission Options service',
         const [flashType, notification] = yarStub.flash.args[0]
 
         expect(flashType).to.equal('notification')
-        expect(notification).to.equal({ title: 'Updated', text: 'Changes updated' })
+        expect(notification).to.equal({ title: 'Updated', text: 'Additional submission options updated' })
       })
     })
 
@@ -88,7 +88,7 @@ describe('Return Versions Setup - Submit Additional Submission Options service',
         const [flashType, notification] = yarStub.flash.args[0]
 
         expect(flashType).to.equal('notification')
-        expect(notification).to.equal({ title: 'Updated', text: 'Changes updated' })
+        expect(notification).to.equal({ title: 'Updated', text: 'Additional submission options updated' })
       })
     })
 
@@ -113,7 +113,7 @@ describe('Return Versions Setup - Submit Additional Submission Options service',
         const [flashType, notification] = yarStub.flash.args[0]
 
         expect(flashType).to.equal('notification')
-        expect(notification).to.equal({ title: 'Updated', text: 'Changes updated' })
+        expect(notification).to.equal({ title: 'Updated', text: 'Additional submission options updated' })
       })
     })
 

--- a/test/services/return-versions/setup/submit-agreements-exceptions.service.test.js
+++ b/test/services/return-versions/setup/submit-agreements-exceptions.service.test.js
@@ -106,13 +106,13 @@ describe('Return Versions Setup - Submit Agreements and Exceptions service', () 
           })
         })
 
-        it('sets the notification message title to "Updated" and the text to "Changes made" ', async () => {
+        it('sets the notification message title to "Updated" and the text to "Requirements for returns updated" ', async () => {
           await SubmitAgreementsExceptionsService.go(session.id, requirementIndex, payload, yarStub)
 
           const [flashType, notification] = yarStub.flash.args[0]
 
           expect(flashType).to.equal('notification')
-          expect(notification).to.equal({ title: 'Updated', text: 'Changes made' })
+          expect(notification).to.equal({ title: 'Updated', text: 'Requirements for returns updated' })
         })
       })
     })

--- a/test/services/return-versions/setup/submit-frequency-collected.service.test.js
+++ b/test/services/return-versions/setup/submit-frequency-collected.service.test.js
@@ -93,13 +93,13 @@ describe('Return Versions Setup - Submit Frequency Collected service', () => {
           })
         })
 
-        it('sets the notification message title to "Updated" and the text to "Changes made" ', async () => {
+        it('sets the notification message title to "Updated" and the text to "Requirements for returns updated" ', async () => {
           await SubmitFrequencyCollectedService.go(session.id, requirementIndex, payload, yarStub)
 
           const [flashType, notification] = yarStub.flash.args[0]
 
           expect(flashType).to.equal('notification')
-          expect(notification).to.equal({ title: 'Updated', text: 'Changes made' })
+          expect(notification).to.equal({ title: 'Updated', text: 'Requirements for returns updated' })
         })
       })
     })

--- a/test/services/return-versions/setup/submit-frequency-reported.service.test.js
+++ b/test/services/return-versions/setup/submit-frequency-reported.service.test.js
@@ -93,13 +93,13 @@ describe('Return Versions Setup - Submit Frequency Reported service', () => {
           })
         })
 
-        it('sets the notification message title to "Updated" and the text to "Changes made" ', async () => {
+        it('sets the notification message title to "Updated" and the text to "Requirements for returns updated" ', async () => {
           await SubmitFrequencyReportedService.go(session.id, requirementIndex, payload, yarStub)
 
           const [flashType, notification] = yarStub.flash.args[0]
 
           expect(flashType).to.equal('notification')
-          expect(notification).to.equal({ title: 'Updated', text: 'Changes made' })
+          expect(notification).to.equal({ title: 'Updated', text: 'Requirements for returns updated' })
         })
       })
     })

--- a/test/services/return-versions/setup/submit-no-returns-required.service.test.js
+++ b/test/services/return-versions/setup/submit-no-returns-required.service.test.js
@@ -91,13 +91,13 @@ describe('Return Versions Setup - Submit No Returns Required service', () => {
           })
         })
 
-        it('sets the notification message title to "Updated" and the text to "Changes made" ', async () => {
+        it('sets the notification message title to "Updated" and the text to "Return version updated" ', async () => {
           await SubmitNoReturnsRequiredService.go(session.id, payload, yarStub)
 
           const [flashType, notification] = yarStub.flash.args[0]
 
           expect(flashType).to.equal('notification')
-          expect(notification).to.equal({ title: 'Updated', text: 'Changes made' })
+          expect(notification).to.equal({ title: 'Updated', text: 'Return version updated' })
         })
       })
     })

--- a/test/services/return-versions/setup/submit-note.service.test.js
+++ b/test/services/return-versions/setup/submit-note.service.test.js
@@ -87,7 +87,7 @@ describe('Return Versions Setup - Submit Note service', () => {
           const [flashType, notification] = yarStub.flash.args[0]
 
           expect(flashType).to.equal('notification')
-          expect(notification).to.equal({text: 'Note added', title: 'Added'})
+          expect(notification).to.equal({ text: 'Note added', title: 'Added' })
         })
       })
 

--- a/test/services/return-versions/setup/submit-note.service.test.js
+++ b/test/services/return-versions/setup/submit-note.service.test.js
@@ -87,7 +87,7 @@ describe('Return Versions Setup - Submit Note service', () => {
           const [flashType, notification] = yarStub.flash.args[0]
 
           expect(flashType).to.equal('notification')
-          expect(notification).to.equal({ title: 'Added', text: 'Changes made' })
+          expect(notification).to.equal({text: 'Note added', title: 'Added'})
         })
       })
 
@@ -143,7 +143,7 @@ describe('Return Versions Setup - Submit Note service', () => {
           const [flashType, notification] = yarStub.flash.args[0]
 
           expect(flashType).to.equal('notification')
-          expect(notification).to.equal({ title: 'Updated', text: 'Changes made' })
+          expect(notification).to.equal({ title: 'Updated', text: 'Note updated' })
         })
       })
     })

--- a/test/services/return-versions/setup/submit-points.service.test.js
+++ b/test/services/return-versions/setup/submit-points.service.test.js
@@ -109,7 +109,7 @@ describe('Return Versions Setup - Submit Points service', () => {
           const [flashType, notification] = yarStub.flash.args[0]
 
           expect(flashType).to.equal('notification')
-          expect(notification).to.equal({ title: 'Updated', text: 'Changes made' })
+          expect(notification).to.equal({ title: 'Updated', text: 'Requirements for returns updated' })
         })
       })
     })

--- a/test/services/return-versions/setup/submit-points.service.test.js
+++ b/test/services/return-versions/setup/submit-points.service.test.js
@@ -103,7 +103,7 @@ describe('Return Versions Setup - Submit Points service', () => {
           })
         })
 
-        it('sets the notification message title to "Updated" and the text to "Changes made" ', async () => {
+        it('sets the notification message title to "Updated" and the text to "Requirements for returns updated" ', async () => {
           await SubmitPointsService.go(session.id, requirementIndex, payload, yarStub)
 
           const [flashType, notification] = yarStub.flash.args[0]

--- a/test/services/return-versions/setup/submit-purpose.service.test.js
+++ b/test/services/return-versions/setup/submit-purpose.service.test.js
@@ -108,13 +108,13 @@ describe('Return Versions Setup - Submit Purpose service', () => {
           })
         })
 
-        it('sets the notification message title to "Updated" and the text to "Changes made" ', async () => {
+        it('sets the notification message title to "Updated" and the text to "Requirements for returns updated" ', async () => {
           await SubmitPurposeService.go(session.id, requirementIndex, payload, yarStub)
 
           const [flashType, notification] = yarStub.flash.args[0]
 
           expect(flashType).to.equal('notification')
-          expect(notification).to.equal({ title: 'Updated', text: 'Changes made' })
+          expect(notification).to.equal({ title: 'Updated', text: 'Requirements for returns updated' })
         })
       })
     })

--- a/test/services/return-versions/setup/submit-reason.service.test.js
+++ b/test/services/return-versions/setup/submit-reason.service.test.js
@@ -94,13 +94,13 @@ describe('Return Versions Setup - Submit Reason service', () => {
           })
         })
 
-        it('sets the notification message title to "Updated" and the text to "Changes made" ', async () => {
+        it('sets the notification message title to "Updated" and the text to "Return version updated" ', async () => {
           await SubmitReasonService.go(session.id, payload, yarStub)
 
           const [flashType, notification] = yarStub.flash.args[0]
 
           expect(flashType).to.equal('notification')
-          expect(notification).to.equal({ title: 'Updated', text: 'Changes made' })
+          expect(notification).to.equal({ title: 'Updated', text: 'Return version updated' })
         })
       })
     })

--- a/test/services/return-versions/setup/submit-returns-cycle.service.test.js
+++ b/test/services/return-versions/setup/submit-returns-cycle.service.test.js
@@ -93,13 +93,13 @@ describe('Return Versions Setup - Submit Returns Cycle service', () => {
           })
         })
 
-        it('sets the notification message title to "Updated" and the text to "Changes made" ', async () => {
+        it('sets the notification message title to "Updated" and the text to "Requirements for returns updated" ', async () => {
           await SubmitReturnsCycleService.go(session.id, requirementIndex, payload, yarStub)
 
           const [flashType, notification] = yarStub.flash.args[0]
 
           expect(flashType).to.equal('notification')
-          expect(notification).to.equal({ title: 'Updated', text: 'Changes made' })
+          expect(notification).to.equal({ title: 'Updated', text: 'Requirements for returns updated' })
         })
       })
     })

--- a/test/services/return-versions/setup/submit-site-description.service.test.js
+++ b/test/services/return-versions/setup/submit-site-description.service.test.js
@@ -95,13 +95,13 @@ describe('Return Versions Setup - Submit Site Description service', () => {
           })
         })
 
-        it('sets the notification message title to "Updated" and the text to "Changes made" ', async () => {
+        it('sets the notification message title to "Updated" and the text to "Requirements for returns updated" ', async () => {
           await SubmitSiteDescriptionService.go(session.id, requirementIndex, payload, yarStub)
 
           const [flashType, notification] = yarStub.flash.args[0]
 
           expect(flashType).to.equal('notification')
-          expect(notification).to.equal({ title: 'Updated', text: 'Changes made' })
+          expect(notification).to.equal({ title: 'Updated', text: 'Requirements for returns updated' })
         })
       })
     })

--- a/test/services/return-versions/setup/submit-start-date.service.test.js
+++ b/test/services/return-versions/setup/submit-start-date.service.test.js
@@ -92,13 +92,13 @@ describe('Return Versions Setup - Submit Start Date service', () => {
           })
         })
 
-        it('sets the notification message title to "Updated" and the text to "Changes made" ', async () => {
+        it('sets the notification message title to "Updated" and the text to "Return version updated" ', async () => {
           await SubmitStartDateService.go(session.id, payload, yarStub)
 
           const [flashType, notification] = yarStub.flash.args[0]
 
           expect(flashType).to.equal('notification')
-          expect(notification).to.equal({ title: 'Updated', text: 'Changes made' })
+          expect(notification).to.equal({ title: 'Updated', text: 'Return version updated' })
         })
       })
     })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4869

While working on the return log setup journey, we noticed some differences between the banners on the returns versions check page and our return logs setup check page. In the interest of keeping the service consistent, this PR updated the banners on the check page to make them the same for both.