### PR TITLE
Fix notifications confirmation ad hoc banner

### DIFF
--- a/app/presenters/notifications/setup/confirmation.presenter.js
+++ b/app/presenters/notifications/setup/confirmation.presenter.js
@@ -36,7 +36,7 @@ function _type(subType) {
   const subTypes = {
     returnInvitation: 'invitations',
     returnReminder: 'reminders',
-    adHoc: 'ad-hoc'
+    adHocReminder: 'ad-hoc'
   }
 
   return subTypes[subType]

--- a/test/presenters/notifications/setup/confirmation.presenter.test.js
+++ b/test/presenters/notifications/setup/confirmation.presenter.test.js
@@ -18,7 +18,7 @@ describe('Notifications Setup - Confirmation presenter', () => {
   beforeEach(() => {
     event = {
       id: '123',
-      subtype: 'adHoc',
+      subtype: 'adHocReminder',
       referenceCode
     }
   })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4778

There is an issue with the ad hoc confirmation banner showing 'undefined' instead of 'ad-hoc'.

This is due to a change in the subStub used when persisting the 'ad-hoc' journey in the database.

This change updates the confirmation presenter to use this update subType.