### PR TITLE
Fix display null lines in view return log summary

### DIFF
--- a/app/presenters/return-logs/base-return-logs.presenter.js
+++ b/app/presenters/return-logs/base-return-logs.presenter.js
@@ -218,11 +218,14 @@ function _groupLinesByMonth(lines) {
     if (!acc[key]) {
       acc[key] = {
         endDate,
-        quantity: 0,
+        quantity: null,
         userUnit
       }
     }
-    acc[key].quantity += quantity
+
+    if (quantity) {
+      acc[key].quantity += quantity
+    }
 
     if (reading) {
       acc[key].reading = reading

--- a/test/presenters/return-logs/base-return-logs.presenter.test.js
+++ b/test/presenters/return-logs/base-return-logs.presenter.test.js
@@ -327,7 +327,7 @@ describe('Base Return Logs presenter', () => {
     })
   })
 
-  describe.only('#generateSummaryTableRows()', () => {
+  describe('#generateSummaryTableRows()', () => {
     const id = 'e3cb54dc-f895-4918-bab7-0819fd870a1f'
 
     let frequency

--- a/test/presenters/return-logs/base-return-logs.presenter.test.js
+++ b/test/presenters/return-logs/base-return-logs.presenter.test.js
@@ -327,7 +327,7 @@ describe('Base Return Logs presenter', () => {
     })
   })
 
-  describe('#generateSummaryTableRows()', () => {
+  describe.only('#generateSummaryTableRows()', () => {
     const id = 'e3cb54dc-f895-4918-bab7-0819fd870a1f'
 
     let frequency
@@ -409,6 +409,34 @@ describe('Base Return Logs presenter', () => {
 
             expect(result[0].unitTotal).to.equal('87,987.699')
             expect(result[1].unitTotal).to.equal('109,984.624')
+          })
+        })
+
+        describe('and the lines being processed contain a null "quantity"', () => {
+          beforeEach(() => {
+            sampleLines[1].quantity = null
+          })
+
+          it('still returns the monthlyTotal as null for the line with a null "quantity"', () => {
+            const result = BaseReturnLogsPresenter.generateSummaryTableRows(method, frequency, sampleLines)
+
+            expect(result[0].monthlyTotal).to.equal('400')
+            expect(result[1].monthlyTotal).to.be.null()
+          })
+        })
+
+        describe('and all the lines being processed contain a null "quantity"', () => {
+          beforeEach(() => {
+            sampleLines.forEach((sampleLine) => {
+              sampleLine.quantity = null
+            })
+          })
+
+          it('returns the monthlyTotal as null for all lines', () => {
+            const result = BaseReturnLogsPresenter.generateSummaryTableRows(method, frequency, sampleLines)
+
+            expect(result[0].monthlyTotal).to.be.null()
+            expect(result[1].monthlyTotal).to.be.null()
           })
         })
       })
@@ -510,6 +538,32 @@ describe('Base Return Logs presenter', () => {
             const result = BaseReturnLogsPresenter.generateSummaryTableRows(method, frequency, sampleLines)
 
             expect(result[0].unitTotal).to.equal('329,953.872')
+          })
+        })
+
+        describe('and the lines being processed contain a null "quantity"', () => {
+          beforeEach(() => {
+            sampleLines[1].quantity = null
+          })
+
+          it('still returns the monthlyTotal as a formatted string', () => {
+            const result = BaseReturnLogsPresenter.generateSummaryTableRows(method, frequency, sampleLines)
+
+            expect(result[0].monthlyTotal).to.equal('1,000')
+          })
+        })
+
+        describe('and all the lines being processed contain a null "quantity"', () => {
+          beforeEach(() => {
+            sampleLines.forEach((sampleLine) => {
+              sampleLine.quantity = null
+            })
+          })
+
+          it('returns the monthlyTotal as null', () => {
+            const result = BaseReturnLogsPresenter.generateSummaryTableRows(method, frequency, sampleLines)
+
+            expect(result[0].monthlyTotal).to.be.null()
           })
         })
       })

--- a/test/services/bill-runs/tpt-supplementary/fetch-billing-accounts.service.test.js
+++ b/test/services/bill-runs/tpt-supplementary/fetch-billing-accounts.service.test.js
@@ -333,7 +333,6 @@ describe('Bill Runs - TPT Supplementary - Fetch Billing Accounts service', () =>
 
     it('does not duplicate the results', async () => {
       const results = await FetchBillingAccountsService.go(seedData.billRun.id, seedData.billingPeriod)
-      // console.dir(results, { depth: null, colors: true })
 
       expect(results).to.have.length(1)
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4861

UAT quickly highlighted an issue with our new view return log page.

The new page now contains a monthly summary of the submission lines. Currently, it generates a total per month, including for monthly. If a month has no entries, i.e. the line(s) is `null` it displays '0'.

The problem for the users is they are losing 'information'. They can't tell from the summary whether the user submitted '0' for the line(s), or didn't submit anything. If you click through to the weekly or daily detail we do display null entries as empty. But we don't in the summary, which is a real problem for monthly, as there is no 'detail' view.

This change fixes the helper function that generates the data for the lines shown in the view to return null where all lines are null so the view can display nothing.