### PR TITLE
Correct Note banner when note deleted

### DIFF
--- a/app/services/return-logs/setup/delete-note.service.js
+++ b/app/services/return-logs/setup/delete-note.service.js
@@ -5,6 +5,7 @@
  * @module DeleteNoteService
  */
 
+const GeneralLib = require('../../../lib/general.lib.js')
 const SessionModel = require('../../../models/session.model.js')
 
 /**
@@ -18,12 +19,8 @@ const SessionModel = require('../../../models/session.model.js')
  */
 async function go(sessionId, yar) {
   const session = await SessionModel.query().findById(sessionId)
-  const notification = {
-    title: 'Removed',
-    text: 'Note removed'
-  }
 
-  yar.flash('notification', notification)
+  GeneralLib.flashNotification(yar, 'Deleted', 'Note deleted')
 
   await _save(session)
 }

--- a/test/services/return-logs/setup/delete-note.service.test.js
+++ b/test/services/return-logs/setup/delete-note.service.test.js
@@ -42,12 +42,12 @@ describe('Return Logs Setup - Delete Note service', () => {
     expect(refreshedSession.note).to.be.undefined()
   })
 
-  it('sets the notification message to "Removed"', async () => {
+  it('sets the notification message to "Deleted"', async () => {
     await DeleteNoteService.go(session.id, yarStub)
 
     const [flashType, notification] = yarStub.flash.args[0]
 
     expect(flashType).to.equal('notification')
-    expect(notification).to.equal({ title: 'Removed', text: 'Note removed' })
+    expect(notification).to.equal({ title: 'Deleted', text: 'Note deleted' })
   })
 })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4807

Whilst tidying up the ticket prior to QA I've spotted that the banner is displaying the wrong message when a note is deleted. It should be showing "Note deleted" but is showing "Note removed".

This PR will fix that issue.