### PR TITLE
Update return log check page banners

### DIFF
--- a/app/services/return-logs/setup/submit-meter-details.service.js
+++ b/app/services/return-logs/setup/submit-meter-details.service.js
@@ -34,7 +34,7 @@ async function go(sessionId, payload, yar) {
     await _save(session, payload)
 
     if (session.checkPageVisited) {
-      GeneralLib.flashNotification(yar)
+      GeneralLib.flashNotification(yar, 'Updated', 'Reporting details changed')
     }
 
     return {

--- a/app/services/return-logs/setup/submit-meter-provided.service.js
+++ b/app/services/return-logs/setup/submit-meter-provided.service.js
@@ -34,7 +34,7 @@ async function go(sessionId, payload, yar) {
     await _save(session, payload)
 
     if (session.checkPageVisited && payload.meterProvided === 'no') {
-      GeneralLib.flashNotification(yar)
+      GeneralLib.flashNotification(yar, 'Updated', 'Reporting details changed')
     }
 
     return {

--- a/app/services/return-logs/setup/submit-received.service.js
+++ b/app/services/return-logs/setup/submit-received.service.js
@@ -36,7 +36,7 @@ async function go(sessionId, payload, yar) {
     await _save(session, payload)
 
     if (session.checkPageVisited) {
-      GeneralLib.flashNotification(yar)
+      GeneralLib.flashNotification(yar, 'Updated', 'Reporting details changed')
     }
 
     return {

--- a/app/services/return-logs/setup/submit-reported.service.js
+++ b/app/services/return-logs/setup/submit-reported.service.js
@@ -34,7 +34,7 @@ async function go(sessionId, payload, yar) {
     await _save(session, payload)
 
     if (session.checkPageVisited) {
-      GeneralLib.flashNotification(yar)
+      GeneralLib.flashNotification(yar, 'Updated', 'Reporting details changed')
     }
 
     return {

--- a/app/services/return-logs/setup/submit-start-reading.service.js
+++ b/app/services/return-logs/setup/submit-start-reading.service.js
@@ -34,7 +34,7 @@ async function go(sessionId, payload, yar) {
     await _save(session, payload)
 
     if (session.checkPageVisited) {
-      GeneralLib.flashNotification(yar)
+      GeneralLib.flashNotification(yar, 'Updated', 'Reporting details changed')
     }
 
     return {

--- a/app/services/return-logs/setup/submit-units.service.js
+++ b/app/services/return-logs/setup/submit-units.service.js
@@ -34,7 +34,7 @@ async function go(sessionId, payload, yar) {
     await _save(session, payload)
 
     if (session.checkPageVisited) {
-      GeneralLib.flashNotification(yar)
+      GeneralLib.flashNotification(yar, 'Updated', 'Reporting details changed')
     }
 
     return {

--- a/app/services/return-versions/setup/delete-note.service.js
+++ b/app/services/return-versions/setup/delete-note.service.js
@@ -19,8 +19,8 @@ const SessionModel = require('../../../models/session.model.js')
 async function go(sessionId, yar) {
   const session = await SessionModel.query().findById(sessionId)
   const notification = {
-    title: 'Removed',
-    text: 'Note removed'
+    title: 'Deleted',
+    text: 'Note deleted'
   }
 
   yar.flash('notification', notification)

--- a/test/services/return-logs/setup/submit-meter-details.service.test.js
+++ b/test/services/return-logs/setup/submit-meter-details.service.test.js
@@ -79,13 +79,13 @@ describe('Return Logs Setup - Submit Meter Details service', () => {
         })
       })
 
-      it('sets the notification message title to "Updated" and the text to "Changes made" ', async () => {
+      it('sets the notification message title to "Updated" and the text to "Reporting details changed" ', async () => {
         await SubmitMeterDetailsService.go(session.id, payload, yarStub)
 
         const [flashType, notification] = yarStub.flash.args[0]
 
         expect(flashType).to.equal('notification')
-        expect(notification).to.equal({ title: 'Updated', text: 'Changes made' })
+        expect(notification).to.equal({ title: 'Updated', text: 'Reporting details changed' })
       })
     })
 

--- a/test/services/return-logs/setup/submit-meter-provided.service.test.js
+++ b/test/services/return-logs/setup/submit-meter-provided.service.test.js
@@ -116,13 +116,13 @@ describe('Return Logs Setup - Submit Meter Provided service', () => {
             expect(result).to.equal({ checkPageVisited: true, meterProvided: 'no', reported: 'abstraction-volumes' })
           })
 
-          it('sets the notification message title to "Updated" and the text to "Changes made" ', async () => {
+          it('sets the notification message title to "Updated" and the text to "Reporting details changed" ', async () => {
             await SubmitMeterProvidedService.go(session.id, payload, yarStub)
 
             const [flashType, notification] = yarStub.flash.args[0]
 
             expect(flashType).to.equal('notification')
-            expect(notification).to.equal({ title: 'Updated', text: 'Changes made' })
+            expect(notification).to.equal({ title: 'Updated', text: 'Reporting details changed' })
           })
         })
       })

--- a/test/services/return-logs/setup/submit-received.service.test.js
+++ b/test/services/return-logs/setup/submit-received.service.test.js
@@ -78,13 +78,13 @@ describe('Return Logs - Setup - Submit Received service', () => {
           })
         })
 
-        it('sets the notification message title to "Updated" and the text to "Changes made" ', async () => {
+        it('sets the notification message title to "Updated" and the text to "Reporting details changed" ', async () => {
           await SubmitReceivedService.go(session.id, payload, yarStub)
 
           const [flashType, notification] = yarStub.flash.args[0]
 
           expect(flashType).to.equal('notification')
-          expect(notification).to.equal({ title: 'Updated', text: 'Changes made' })
+          expect(notification).to.equal({ title: 'Updated', text: 'Reporting details changed' })
         })
       })
     })

--- a/test/services/return-logs/setup/submit-reported.service.test.js
+++ b/test/services/return-logs/setup/submit-reported.service.test.js
@@ -71,13 +71,13 @@ describe('Return Logs Setup - Submit Reported service', () => {
           })
         })
 
-        it('sets the notification message title to "Updated" and the text to "Changes made" ', async () => {
+        it('sets the notification message title to "Updated" and the text to "Reporting details changed" ', async () => {
           await SubmitReportedService.go(session.id, payload, yarStub)
 
           const [flashType, notification] = yarStub.flash.args[0]
 
           expect(flashType).to.equal('notification')
-          expect(notification).to.equal({ title: 'Updated', text: 'Changes made' })
+          expect(notification).to.equal({ title: 'Updated', text: 'Reporting details changed' })
         })
       })
     })

--- a/test/services/return-logs/setup/submit-start-reading.service.test.js
+++ b/test/services/return-logs/setup/submit-start-reading.service.test.js
@@ -79,13 +79,13 @@ describe('Return Logs Setup - Submit Start Reading service', () => {
           })
         })
 
-        it('sets the notification message title to "Updated" and the text to "Changes made" ', async () => {
+        it('sets the notification message title to "Updated" and the text to "Reporting details changed" ', async () => {
           await SubmitStartReadingService.go(session.id, payload, yarStub)
 
           const [flashType, notification] = yarStub.flash.args[0]
 
           expect(flashType).to.equal('notification')
-          expect(notification).to.equal({ title: 'Updated', text: 'Changes made' })
+          expect(notification).to.equal({ title: 'Updated', text: 'Reporting details changed' })
         })
       })
     })

--- a/test/services/return-logs/setup/submit-units.service.test.js
+++ b/test/services/return-logs/setup/submit-units.service.test.js
@@ -69,13 +69,13 @@ describe('Return Logs Setup - Submit Units service', () => {
           })
         })
 
-        it('sets the notification message title to "Updated" and the text to "Changes made" ', async () => {
+        it('sets the notification message title to "Updated" and the text to "Reporting details changed" ', async () => {
           await SubmitUnitsService.go(session.id, payload, yarStub)
 
           const [flashType, notification] = yarStub.flash.args[0]
 
           expect(flashType).to.equal('notification')
-          expect(notification).to.equal({ title: 'Updated', text: 'Changes made' })
+          expect(notification).to.equal({ title: 'Updated', text: 'Reporting details changed' })
         })
       })
     })

--- a/test/services/return-versions/setup/delete-note.service.test.js
+++ b/test/services/return-versions/setup/delete-note.service.test.js
@@ -54,12 +54,12 @@ describe('Return Versions Setup - Delete Note service', () => {
     expect(refreshedSession.note).to.be.undefined()
   })
 
-  it('sets the notification message to "Removed"', async () => {
+  it('sets the notification message to "Deleted"', async () => {
     await DeleteNoteService.go(session.id, yarStub)
 
     const [flashType, notification] = yarStub.flash.args[0]
 
     expect(flashType).to.equal('notification')
-    expect(notification).to.equal({ title: 'Removed', text: 'Note removed' })
+    expect(notification).to.equal({ title: 'Deleted', text: 'Note deleted' })
   })
 })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4869

While working on the return log setup journey, we noticed some differences between the banners on the returns versions check page and our return logs setup check page. In the interest of keeping the service consistent, this PR updated the banners on the check page to make them the same for both.