### PR TITLE
Return logs - add a note bug

### DIFF
--- a/app/services/return-logs/setup/submit-note.service.js
+++ b/app/services/return-logs/setup/submit-note.service.js
@@ -83,7 +83,7 @@ async function _save(session, payload, user) {
 }
 
 function _submittedSessionData(session, payload) {
-  session.note = payload.note ? payload.note : null
+  session.note = { content: payload.note ? payload.note : null }
 
   return NotePresenter.go(session)
 }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4807

An issue has been found when a note is entered that generates a validation error, the note text is not being returned to the user.

This PR will fix that issue by ensuring that any text that has been entered is returned to the view when a validation error occurs.