### PR TITLE
Return logs - enter volumes

### DIFF
--- a/app/controllers/return-logs-setup.controller.js
+++ b/app/controllers/return-logs-setup.controller.js
@@ -35,7 +35,9 @@ const SubmitSingleVolumeService = require('../services/return-logs/setup/submit-
 const SubmitStartReadingService = require('../services/return-logs/setup/submit-start-reading.service.js')
 const SubmitSubmissionService = require('../services/return-logs/setup/submit-submission.service.js')
 const SubmitUnitsService = require('../services/return-logs/setup/submit-units.service.js')
+const SubmitVolumesService = require('../services/return-logs/setup/submit-volumes.service.js')
 const UnitsService = require('../services/return-logs/setup/units.service.js')
+const VolumesService = require('../services/return-logs/setup/volumes.service.js')
 
 async function cancel(request, h) {
   const { sessionId } = request.params
@@ -397,11 +399,34 @@ async function submitUnits(request, h) {
   return h.redirect(`/system/return-logs/setup/${sessionId}/meter-provided`)
 }
 
+async function submitVolumes(request, h) {
+  const {
+    params: { sessionId, yearMonth },
+    payload,
+    yar
+  } = request
+
+  const pageData = await SubmitVolumesService.go(sessionId, payload, yar, yearMonth)
+
+  if (pageData.error) {
+    return h.view('return-logs/setup/volumes.njk', pageData)
+  }
+
+  return h.redirect(`/system/return-logs/setup/${sessionId}/check`)
+}
+
 async function units(request, h) {
   const { sessionId } = request.params
   const pageData = await UnitsService.go(sessionId)
 
   return h.view('return-logs/setup/units.njk', pageData)
+}
+
+async function volumes(request, h) {
+  const { sessionId, yearMonth } = request.params
+  const pageData = await VolumesService.go(sessionId, yearMonth)
+
+  return h.view('return-logs/setup/volumes.njk', pageData)
 }
 
 module.exports = {
@@ -436,5 +461,7 @@ module.exports = {
   submitStartReading,
   submitSubmission,
   submitUnits,
-  units
+  submitVolumes,
+  units,
+  volumes
 }

--- a/app/presenters/return-logs/setup/readings.presenter.js
+++ b/app/presenters/return-logs/setup/readings.presenter.js
@@ -1,7 +1,7 @@
 'use strict'
 
 /**
- * Formats meter reading data ready for presenting in the `/return-logs/setup/{sessionId}/readings/{yearMonth}` page
+ * Format data for the `/return-logs/setup/{sessionId}/readings/{yearMonth}` page
  * @module ReadingsPresenter
  */
 

--- a/app/presenters/return-logs/setup/volumes.presenter.js
+++ b/app/presenters/return-logs/setup/volumes.presenter.js
@@ -2,7 +2,7 @@
 
 /**
  * Format data for the `/return-logs/setup/{sessionId}/volumes/{yearMonth}` page
- * @module ReadingsPresenter
+ * @module VolumesPresenter
  */
 
 const { formatLongDate, sentenceCase } = require('../../base.presenter.js')

--- a/app/presenters/return-logs/setup/volumes.presenter.js
+++ b/app/presenters/return-logs/setup/volumes.presenter.js
@@ -1,0 +1,70 @@
+'use strict'
+
+/**
+ * Format data for the `/return-logs/setup/{sessionId}/volumes/{yearMonth}` page
+ * @module ReadingsPresenter
+ */
+
+const { formatLongDate, sentenceCase } = require('../../base.presenter.js')
+
+/**
+ * Format data for the `/return-logs/setup/{sessionId}/volumes/{yearMonth}` page
+ *
+ * @param {module:SessionModel} session - The returns log session instance
+ * @param {string} yearMonth - The year and zero-indexed month to view, eg. `2014-0` for January 2014
+ *
+ * @returns {object} page data needed by the view template
+ */
+function go(session, yearMonth) {
+  const { id: sessionId, lines, returnReference, units } = session
+
+  const [requestedYear, requestedMonth] = _determineRequestedYearAndMonth(yearMonth)
+
+  const requestedMonthLines = lines.filter((line) => {
+    const endDate = new Date(line.endDate)
+
+    return endDate.getFullYear() === requestedYear && endDate.getMonth() === requestedMonth
+  })
+
+  return {
+    backLink: `/system/return-logs/setup/${sessionId}/check`,
+    inputLines: _inputLines(requestedMonthLines),
+    pageTitle: _pageTitle(new Date(requestedMonthLines[0].endDate)),
+    returnReference,
+    units: units === 'cubic-metres' ? 'Cubic metres' : sentenceCase(units)
+  }
+}
+
+function _determineRequestedYearAndMonth(yearMonth) {
+  // Splitting a string like `2014-0` by the dash gives us an array of strings ['2014', '0']. We chain `.map(Number)` to
+  // then create a new array, applying the Number() function to each one. The result is an array of numbers [2014, 0].
+  return yearMonth.split('-').map(Number)
+}
+
+function _inputLines(lines) {
+  return lines.map((line) => {
+    const { endDate, quantity } = line
+
+    const lineData = {
+      endDate,
+      formattedEndDate: formatLongDate(new Date(endDate)),
+      quantity
+    }
+
+    if (line.error) {
+      lineData.error = line.error
+    }
+
+    return lineData
+  })
+}
+
+function _pageTitle(date) {
+  const titleDate = date.toLocaleDateString('en-GB', { year: 'numeric', month: 'long' })
+
+  return `Water abstracted ${titleDate}`
+}
+
+module.exports = {
+  go
+}

--- a/app/routes/return-logs-setup.routes.js
+++ b/app/routes/return-logs-setup.routes.js
@@ -221,6 +221,30 @@ const routes = [
   },
   {
     method: 'GET',
+    path: '/return-logs/setup/{sessionId}/volumes/{yearMonth}',
+    options: {
+      handler: ReturnLogsSetupController.volumes,
+      auth: {
+        access: {
+          scope: ['billing']
+        }
+      }
+    }
+  },
+  {
+    method: 'POST',
+    path: '/return-logs/setup/{sessionId}/volumes/{yearMonth}',
+    options: {
+      handler: ReturnLogsSetupController.submitVolumes,
+      auth: {
+        access: {
+          scope: ['billing']
+        }
+      }
+    }
+  },
+  {
+    method: 'GET',
     path: '/return-logs/setup/{sessionId}/received',
     options: {
       handler: ReturnLogsSetupController.received,

--- a/app/services/return-logs/setup/submit-readings.service.js
+++ b/app/services/return-logs/setup/submit-readings.service.js
@@ -1,7 +1,7 @@
 'use strict'
 
 /**
- * Orchestrates validating the data for `/return-logs/setup/{sessionId}/readings/{yearMonth}` page
+ * Orchestrates validating the data for the `/return-logs/setup/{sessionId}/readings/{yearMonth}` page
  * @module SubmitReadingsService
  */
 
@@ -11,7 +11,7 @@ const ReadingsValidator = require('../../../validators/return-logs/setup/reading
 const SessionModel = require('../../../models/session.model.js')
 
 /**
- * Orchestrates validating the data for `/return-logs/setup/{sessionId}/readings/{yearMonth}` page
+ * Orchestrates validating the data for the `/return-logs/setup/{sessionId}/readings/{yearMonth}` page
  *
  * @param {string} sessionId - The UUID of the current session
  * @param {object} payload - The submitted form data

--- a/app/services/return-logs/setup/submit-readings.service.js
+++ b/app/services/return-logs/setup/submit-readings.service.js
@@ -1,7 +1,7 @@
 'use strict'
 
 /**
- * Orchestrates validating the data for the `/return-logs/setup/{sessionId}/readings/{yearMonth}` page
+ * Orchestrates validating the data for `/return-logs/setup/{sessionId}/readings/{yearMonth}` page
  * @module SubmitReadingsService
  */
 
@@ -11,7 +11,7 @@ const ReadingsValidator = require('../../../validators/return-logs/setup/reading
 const SessionModel = require('../../../models/session.model.js')
 
 /**
- * Orchestrates validating the data for the `/return-logs/setup/{sessionId}/readings/{yearMonth}` page
+ * Orchestrates validating the data for `/return-logs/setup/{sessionId}/readings/{yearMonth}` page
  *
  * @param {string} sessionId - The UUID of the current session
  * @param {object} payload - The submitted form data

--- a/app/services/return-logs/setup/submit-volumes.service.js
+++ b/app/services/return-logs/setup/submit-volumes.service.js
@@ -6,9 +6,9 @@
  */
 
 const GeneralLib = require('../../../lib/general.lib.js')
+const SessionModel = require('../../../models/session.model.js')
 const VolumesPresenter = require('../../../presenters/return-logs/setup/volumes.presenter.js')
 const VolumesValidator = require('../../../validators/return-logs/setup/volumes.validator.js')
-const SessionModel = require('../../../models/session.model.js')
 
 /**
  * Orchestrates validating the data for `/return-logs/setup/{sessionId}/volumes/{yearMonth}` page

--- a/app/services/return-logs/setup/submit-volumes.service.js
+++ b/app/services/return-logs/setup/submit-volumes.service.js
@@ -1,0 +1,124 @@
+'use strict'
+
+/**
+ * Orchestrates validating the data for the `/return-logs/setup/{sessionId}/volumes/{yearMonth}` page
+ * @module SubmitVolumesService
+ */
+
+const GeneralLib = require('../../../lib/general.lib.js')
+const VolumesPresenter = require('../../../presenters/return-logs/setup/volumes.presenter.js')
+const VolumesValidator = require('../../../validators/return-logs/setup/volumes.validator.js')
+const SessionModel = require('../../../models/session.model.js')
+
+/**
+ * Orchestrates validating the data for the `/return-logs/setup/{sessionId}/volumes/{yearMonth}` page
+ *
+ * @param {string} sessionId - The UUID of the current session
+ * @param {object} payload - The submitted form data
+ * @param {object} yar - The Hapi `request.yar` session manager passed on by the controller
+ * @param {string} yearMonth - The year and zero-indexed month to view, eg. `2014-0` for January 2014
+ *
+ * @returns {Promise<object>} If no errors it returns an empty object else the page data for the volumes page including
+ * the validation error details
+ */
+async function go(sessionId, payload, yar, yearMonth) {
+  const session = await SessionModel.query().findById(sessionId)
+
+  const [requestedYear, requestedMonth] = _determineRequestedYearAndMonth(yearMonth)
+
+  const validationResult = _validate(payload, requestedYear, requestedMonth, session)
+
+  if (!validationResult) {
+    await _save(payload, session, requestedYear, requestedMonth)
+
+    GeneralLib.flashNotification(yar, 'Updated', 'Volumes have been updated')
+
+    return {}
+  }
+
+  _addValidationResultToSession(payload, session, requestedYear, requestedMonth, validationResult)
+
+  const formattedData = VolumesPresenter.go(session, yearMonth)
+
+  return {
+    activeNavBar: 'search',
+    error: validationResult,
+    ...formattedData
+  }
+}
+
+function _addValidationResultToSession(payload, session, requestedYear, requestedMonth, validationResult) {
+  session.lines.forEach((line) => {
+    const endDate = new Date(line.endDate)
+
+    if (endDate.getFullYear() === requestedYear && endDate.getMonth() === requestedMonth) {
+      // Unlike when the session is saved, we do not convert the volume to a number here. This is because we want to
+      // return what was submitted in the payload to the view following failed validation, which could be a string
+      line.quantity = payload[line.endDate] ?? null
+      line.error = _lineError(line, validationResult)
+    }
+  })
+}
+
+function _determineRequestedYearAndMonth(yearMonth) {
+  // Splitting a string like `2014-0` by the dash gives us an array of strings ['2014', '0']. We chain `.map(Number)` to
+  // then create a new array, applying the Number() function to each one. The result is an array of numbers [2014, 0].
+  return yearMonth.split('-').map(Number)
+}
+
+function _lineError(line, validationResult) {
+  const error = validationResult.find((validationError) => {
+    return validationError.href === `#${line.endDate}`
+  })
+
+  if (error) {
+    return error.text
+  }
+
+  return null
+}
+
+/**
+ * Saves the volumes for the specified yearMonth. As the payload will not contain lines where there is no volume
+ * entered. We update all the session lines for the specified yearMonth and assign a null volume where it does not
+ * exist in the payload. We do this because if a line previously had a volume which was then subsequently removed
+ * there would be no entry for that line in the payload. We therefore need to set the volume to null in that situation.
+ *
+ * @private
+ */
+async function _save(payload, session, requestedYear, requestedMonth) {
+  session.lines.forEach((line) => {
+    const endDate = new Date(line.endDate)
+
+    if (endDate.getFullYear() === requestedYear && endDate.getMonth() === requestedMonth) {
+      // The volumes are always in text format in the payload so we convert to a number before updating the session
+      line.quantity = payload[line.endDate] ? Number(payload[line.endDate]) : null
+    }
+  })
+
+  return session.$update()
+}
+
+function _validate(payload, requestedYear, requestedMonth, session) {
+  // If the payload is empty, we don't need to validate anything
+  if (Object.keys(payload).length === 0) {
+    return null
+  }
+
+  const validation = VolumesValidator.go(payload, requestedYear, requestedMonth, session)
+
+  if (!validation.error) {
+    return null
+  }
+
+  return validation.error.details.map((error) => {
+    return {
+      text: error.message,
+      href: `#${error.path[0]}`
+    }
+  })
+}
+
+module.exports = {
+  go
+}

--- a/app/services/return-logs/setup/submit-volumes.service.js
+++ b/app/services/return-logs/setup/submit-volumes.service.js
@@ -1,7 +1,7 @@
 'use strict'
 
 /**
- * Orchestrates validating the data for the `/return-logs/setup/{sessionId}/volumes/{yearMonth}` page
+ * Orchestrates validating the data for `/return-logs/setup/{sessionId}/volumes/{yearMonth}` page
  * @module SubmitVolumesService
  */
 
@@ -11,7 +11,7 @@ const VolumesValidator = require('../../../validators/return-logs/setup/volumes.
 const SessionModel = require('../../../models/session.model.js')
 
 /**
- * Orchestrates validating the data for the `/return-logs/setup/{sessionId}/volumes/{yearMonth}` page
+ * Orchestrates validating the data for `/return-logs/setup/{sessionId}/volumes/{yearMonth}` page
  *
  * @param {string} sessionId - The UUID of the current session
  * @param {object} payload - The submitted form data

--- a/app/services/return-logs/setup/submit-volumes.service.js
+++ b/app/services/return-logs/setup/submit-volumes.service.js
@@ -26,7 +26,7 @@ async function go(sessionId, payload, yar, yearMonth) {
 
   const [requestedYear, requestedMonth] = _determineRequestedYearAndMonth(yearMonth)
 
-  const validationResult = _validate(payload, requestedYear, requestedMonth, session)
+  const validationResult = _validate(payload)
 
   if (!validationResult) {
     await _save(payload, session, requestedYear, requestedMonth)
@@ -99,13 +99,13 @@ async function _save(payload, session, requestedYear, requestedMonth) {
   return session.$update()
 }
 
-function _validate(payload, requestedYear, requestedMonth, session) {
+function _validate(payload) {
   // If the payload is empty, we don't need to validate anything
   if (Object.keys(payload).length === 0) {
     return null
   }
 
-  const validation = VolumesValidator.go(payload, requestedYear, requestedMonth, session)
+  const validation = VolumesValidator.go(payload)
 
   if (!validation.error) {
     return null

--- a/app/services/return-logs/setup/volumes.service.js
+++ b/app/services/return-logs/setup/volumes.service.js
@@ -1,8 +1,7 @@
 'use strict'
 
 /**
- * Orchestrates fetching and presenting the data needed for the `/return-logs/setup/{sessionId}/volumes/{yearMonth}`
- * page
+ * Orchestrates fetching and presenting the data needed for `/return-logs/setup/{sessionId}/volumes/{yearMonth}` page
  * @module VolumesService
  */
 
@@ -10,8 +9,7 @@ const VolumesPresenter = require('../../../presenters/return-logs/setup/volumes.
 const SessionModel = require('../../../models/session.model.js')
 
 /**
- * Orchestrates fetching and presenting the data needed for the `/return-logs/setup/{sessionId}/volumes/{yearMonth}`
- * page
+ * Orchestrates fetching and presenting the data needed for `/return-logs/setup/{sessionId}/volumes/{yearMonth}` page
  *
  * @param {string} sessionId - The UUID of the current session
  * @param {string} yearMonth - The year and zero-indexed month to view, eg. `2014-0` for January 2014

--- a/app/services/return-logs/setup/volumes.service.js
+++ b/app/services/return-logs/setup/volumes.service.js
@@ -1,0 +1,34 @@
+'use strict'
+
+/**
+ * Orchestrates fetching and presenting the data needed for the `/return-logs/setup/{sessionId}/volumes/{yearMonth}`
+ * page
+ * @module VolumesService
+ */
+
+const VolumesPresenter = require('../../../presenters/return-logs/setup/volumes.presenter.js')
+const SessionModel = require('../../../models/session.model.js')
+
+/**
+ * Orchestrates fetching and presenting the data needed for the `/return-logs/setup/{sessionId}/volumes/{yearMonth}`
+ * page
+ *
+ * @param {string} sessionId - The UUID of the current session
+ * @param {string} yearMonth - The year and zero-indexed month to view, eg. `2014-0` for January 2014
+ *
+ * @returns {Promise<object>} The view data for the volumes page
+ */
+async function go(sessionId, yearMonth) {
+  const session = await SessionModel.query().findById(sessionId)
+
+  const formattedData = VolumesPresenter.go(session, yearMonth)
+
+  return {
+    activeNavBar: 'search',
+    ...formattedData
+  }
+}
+
+module.exports = {
+  go
+}

--- a/app/services/return-logs/setup/volumes.service.js
+++ b/app/services/return-logs/setup/volumes.service.js
@@ -5,8 +5,8 @@
  * @module VolumesService
  */
 
-const VolumesPresenter = require('../../../presenters/return-logs/setup/volumes.presenter.js')
 const SessionModel = require('../../../models/session.model.js')
+const VolumesPresenter = require('../../../presenters/return-logs/setup/volumes.presenter.js')
 
 /**
  * Orchestrates fetching and presenting the data needed for `/return-logs/setup/{sessionId}/volumes/{yearMonth}` page

--- a/app/validators/return-logs/setup/volumes.validator.js
+++ b/app/validators/return-logs/setup/volumes.validator.js
@@ -1,0 +1,32 @@
+'use strict'
+
+/**
+ * Validates data submitted for the `/return-logs/setup/{sessionId}/volumes/{yearMonth}` page
+ * @module VolumesValidator
+ */
+
+const Joi = require('joi')
+
+/**
+ * Validates data submitted for the `/return-logs/setup/{sessionId}/volumes/{yearMonth}` page
+ *
+ * @param {object} payload - The payload from the request to be validated
+ *
+ * @returns {object} the result from calling Joi's schema.validate(). It will be an object with a `value:` property. If
+ * any errors are found the `error:` property will also exist detailing what the issues were
+ */
+function go(payload) {
+  const schema = Joi.object().pattern(
+    /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/, // Regex to match keys like '2024-04-01T00:00:00.000Z'
+    Joi.number().min(0).messages({
+      'number.base': 'Volumes must be a number or blank',
+      'number.min': 'Volumes must be a positive number'
+    })
+  )
+
+  return schema.validate(payload, { abortEarly: false })
+}
+
+module.exports = {
+  go
+}

--- a/app/views/return-logs/setup/volumes.njk
+++ b/app/views/return-logs/setup/volumes.njk
@@ -1,0 +1,69 @@
+{% extends 'layout.njk' %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from 'govuk/components/error-summary/macro.njk' import govukErrorSummary %}
+{% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
+
+{% block breadcrumbs %}
+  {# Back link #}
+  {{
+    govukBackLink({
+      text: 'Back',
+      href: backLink
+    })
+  }}
+{% endblock %}
+
+{% block content %}
+  {# Error summary #}
+  {% if error %}
+    {{ govukErrorSummary({
+      titleText: 'There is a problem',
+      errorList: error
+    }) }}
+  {% endif %}
+
+  {# Main heading #}
+  <div>
+    <span class="govuk-caption-l">Return reference {{ returnReference }}</span>
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-2">{{ pageTitle }}</h1>
+  </div>
+
+  {# Display the lines to input the abstraction volumes #}
+  <form method="post">
+    <input type="hidden" name="wrlsCrumb" value="{{wrlsCrumb}}"/>
+
+    {% call govukFieldset({
+      legend: {
+        html: 'Volumes',
+        isPageHeading: false,
+        classes: "govuk-fieldset__legend--m"
+      }
+      }) %}
+
+      {% for line in inputLines %}
+        {# Create the input fields #}
+        {{ govukInput({
+          label: {
+            text: line.formattedEndDate
+          },
+          classes: "govuk-input--width-10",
+          id: line.endDate,
+          name: line.endDate,
+          value: line.quantity,
+          inputmode: 'numeric',
+          suffix: {
+            text: units
+          },
+          errorMessage: {
+              text: line.error
+            } if line.error
+        }) }}
+      {% endfor %}
+    {% endcall %}
+
+    {{ govukButton({ text: "Continue", preventDoubleClick: true }) }}
+  </form>
+
+{% endblock %}

--- a/test/presenters/return-logs/setup/volumes.presenter.test.js
+++ b/test/presenters/return-logs/setup/volumes.presenter.test.js
@@ -1,0 +1,166 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Thing under test
+const VolumesPresenter = require('../../../../app/presenters/return-logs/setup/volumes.presenter.js')
+
+describe('Return Logs Setup - Volumes presenter', () => {
+  let session
+  let yearMonth
+
+  beforeEach(() => {
+    session = _sessionData()
+    yearMonth = '2023-4'
+  })
+
+  describe('when provided with a populated session', () => {
+    it('correctly presents the data', () => {
+      const result = VolumesPresenter.go(session, yearMonth)
+
+      expect(result).to.equal({
+        backLink: '/system/return-logs/setup/e840675e-9fb9-4ce1-bf0a-d140f5c57f47/check',
+        inputLines: [
+          {
+            endDate: '2023-05-31T00:00:00.000Z',
+            formattedEndDate: '31 May 2023',
+            quantity: undefined
+          }
+        ],
+        pageTitle: 'Water abstracted May 2023',
+        returnReference: '1234',
+        units: 'Cubic metres'
+      })
+    })
+  })
+
+  describe('the "inputLines" property', () => {
+    describe('when the user is entering volumes for April', () => {
+      beforeEach(() => {
+        yearMonth = '2023-3'
+      })
+
+      it('returns the line data for April 2023', () => {
+        const result = VolumesPresenter.go(session, yearMonth)
+
+        expect(result.inputLines).to.equal([
+          {
+            endDate: '2023-04-30T00:00:00.000Z',
+            formattedEndDate: '30 April 2023',
+            quantity: 100
+          }
+        ])
+      })
+      describe('and a validation error exists on the line', () => {
+        beforeEach(() => {
+          session.lines[0].error = 'There is an error on this line'
+        })
+
+        it('includes the error message in the line data', () => {
+          const result = VolumesPresenter.go(session, yearMonth)
+
+          expect(result.inputLines).to.equal([
+            {
+              endDate: '2023-04-30T00:00:00.000Z',
+              formattedEndDate: '30 April 2023',
+              quantity: 100,
+              error: 'There is an error on this line'
+            }
+          ])
+        })
+      })
+    })
+  })
+
+  describe('the "pageTitle" property', () => {
+    describe('when the user is entering volumes for June 2023', () => {
+      beforeEach(() => {
+        yearMonth = '2023-5'
+      })
+
+      it('returns the page title for June', () => {
+        const result = VolumesPresenter.go(session, yearMonth)
+
+        expect(result.pageTitle).to.equal('Water abstracted June 2023')
+      })
+    })
+  })
+
+  describe('the "units" property', () => {
+    describe('when the user has used cubic metres', () => {
+      beforeEach(() => {
+        session.units = 'cubic-metres'
+      })
+
+      it('returns the unit of measurement as "Cubic metres"', () => {
+        const result = VolumesPresenter.go(session, yearMonth)
+
+        expect(result.units).to.equal('Cubic metres')
+      })
+    })
+
+    describe('when the user has used litres', () => {
+      beforeEach(() => {
+        session.units = 'litres'
+      })
+
+      it('returns the unit of measurement as "Litres"', () => {
+        const result = VolumesPresenter.go(session, yearMonth)
+
+        expect(result.units).to.equal('Litres')
+      })
+    })
+
+    describe('when the user has used megalitres', () => {
+      beforeEach(() => {
+        session.units = 'megalitres'
+      })
+
+      it('returns the unit of measurement as "Megalitres"', () => {
+        const result = VolumesPresenter.go(session, yearMonth)
+
+        expect(result.units).to.equal('Megalitres')
+      })
+    })
+
+    describe('when the user has used gallons', () => {
+      beforeEach(() => {
+        session.units = 'gallons'
+      })
+
+      it('returns the unit of measurement as "Gallons"', () => {
+        const result = VolumesPresenter.go(session, yearMonth)
+
+        expect(result.units).to.equal('Gallons')
+      })
+    })
+  })
+})
+
+function _sessionData() {
+  return {
+    id: 'e840675e-9fb9-4ce1-bf0a-d140f5c57f47',
+    lines: [
+      {
+        endDate: '2023-04-30T00:00:00.000Z',
+        quantity: 100,
+        startDate: '2023-04-01T00:00:00.000Z'
+      },
+      {
+        endDate: '2023-05-31T00:00:00.000Z',
+        startDate: '2023-05-01T00:00:00.000Z'
+      },
+      {
+        endDate: '2023-06-30T00:00:00.000Z',
+        startDate: '2023-06-01T00:00:00.000Z'
+      }
+    ],
+    returnReference: '1234',
+    units: 'cubic-metres'
+  }
+}

--- a/test/services/return-logs/setup/submit-volumes.service.test.js
+++ b/test/services/return-logs/setup/submit-volumes.service.test.js
@@ -1,0 +1,181 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Test helpers
+const SessionHelper = require('../../../support/helpers/session.helper.js')
+
+// Thing under test
+const SubmitVolumesService = require('../../../../app/services/return-logs/setup/submit-volumes.service.js')
+
+describe('Return Logs Setup - Submit Volumes service', () => {
+  let payload
+  let session
+  let sessionData
+  let yarStub
+  let yearMonth
+
+  beforeEach(async () => {
+    sessionData = {
+      data: {
+        lines: [
+          {
+            endDate: '2023-04-30T00:00:00.000Z',
+            quantity: 100,
+            startDate: '2023-04-01T00:00:00.000Z'
+          },
+          {
+            endDate: '2023-05-31T00:00:00.000Z',
+            startDate: '2023-05-01T00:00:00.000Z'
+          },
+          {
+            endDate: '2023-06-30T00:00:00.000Z',
+            quantity: 300,
+            startDate: '2023-06-01T00:00:00.000Z'
+          }
+        ],
+        returnReference: '1234',
+        units: 'cubic-metres'
+      }
+    }
+
+    session = await SessionHelper.add(sessionData)
+
+    yarStub = { flash: Sinon.stub() }
+  })
+
+  describe('when called', () => {
+    describe('with a valid payload', () => {
+      describe('and no volumes have been entered', () => {
+        beforeEach(() => {
+          payload = {}
+          yearMonth = '2023-4' // May 2023
+        })
+
+        it('saves the volume for May as null', async () => {
+          await SubmitVolumesService.go(session.id, payload, yarStub, yearMonth)
+
+          const refreshedSession = await session.$query()
+
+          expect(refreshedSession.lines).to.equal([
+            {
+              endDate: '2023-04-30T00:00:00.000Z',
+              quantity: 100,
+              startDate: '2023-04-01T00:00:00.000Z'
+            },
+            {
+              endDate: '2023-05-31T00:00:00.000Z',
+              quantity: null,
+              startDate: '2023-05-01T00:00:00.000Z'
+            },
+            {
+              endDate: '2023-06-30T00:00:00.000Z',
+              quantity: 300,
+              startDate: '2023-06-01T00:00:00.000Z'
+            }
+          ])
+        })
+
+        it('sets the notification message title to "Updated" and the text to "Volumes have been updated" ', async () => {
+          await SubmitVolumesService.go(session.id, payload, yarStub, yearMonth)
+
+          const [flashType, notification] = yarStub.flash.args[0]
+
+          expect(flashType).to.equal('notification')
+          expect(notification).to.equal({ title: 'Updated', text: 'Volumes have been updated' })
+        })
+      })
+
+      describe('and a volume has been entered', () => {
+        beforeEach(() => {
+          payload = { '2023-06-30T00:00:00.000Z': '200' }
+          yearMonth = '2023-5' // June 2023
+        })
+
+        it('saves the volume for June as 200', async () => {
+          await SubmitVolumesService.go(session.id, payload, yarStub, yearMonth)
+
+          const refreshedSession = await session.$query()
+
+          expect(refreshedSession.lines).to.equal([
+            {
+              endDate: '2023-04-30T00:00:00.000Z',
+              quantity: 100,
+              startDate: '2023-04-01T00:00:00.000Z'
+            },
+            {
+              endDate: '2023-05-31T00:00:00.000Z',
+              startDate: '2023-05-01T00:00:00.000Z'
+            },
+            {
+              endDate: '2023-06-30T00:00:00.000Z',
+              quantity: 200,
+              startDate: '2023-06-01T00:00:00.000Z'
+            }
+          ])
+        })
+
+        it('sets the notification message title to "Updated" and the text to "Volumes have been updated" ', async () => {
+          await SubmitVolumesService.go(session.id, payload, yarStub, yearMonth)
+
+          const [flashType, notification] = yarStub.flash.args[0]
+
+          expect(flashType).to.equal('notification')
+          expect(notification).to.equal({ title: 'Updated', text: 'Volumes have been updated' })
+        })
+      })
+    })
+
+    describe('with an invalid payload', () => {
+      beforeEach(() => {
+        payload = { '2023-04-30T00:00:00.000Z': 'INVALID' }
+        yearMonth = '2023-3' // April 2023
+      })
+
+      it('returns the page data for the view', async () => {
+        const result = await SubmitVolumesService.go(session.id, payload, yarStub, yearMonth)
+
+        expect(result).to.equal({
+          activeNavBar: 'search',
+          error: [
+            {
+              href: '#2023-04-30T00:00:00.000Z',
+              text: 'Volumes must be a number or blank'
+            }
+          ],
+          backLink: `/system/return-logs/setup/${session.id}/check`,
+          inputLines: [
+            {
+              endDate: '2023-04-30T00:00:00.000Z',
+              error: 'Volumes must be a number or blank',
+              formattedEndDate: '30 April 2023',
+              quantity: 'INVALID'
+            }
+          ],
+          pageTitle: 'Water abstracted April 2023',
+          returnReference: '1234',
+          units: 'Cubic metres'
+        })
+      })
+
+      describe('because the user has not entered a number', () => {
+        it('includes an error for the radio form element', async () => {
+          const result = await SubmitVolumesService.go(session.id, payload, yarStub, yearMonth)
+
+          expect(result.error).to.equal([
+            {
+              href: '#2023-04-30T00:00:00.000Z',
+              text: 'Volumes must be a number or blank'
+            }
+          ])
+        })
+      })
+    })
+  })
+})

--- a/test/services/return-logs/setup/volumes.service.test.js
+++ b/test/services/return-logs/setup/volumes.service.test.js
@@ -1,0 +1,61 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, before } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Test helpers
+const SessionHelper = require('../../../support/helpers/session.helper.js')
+
+// Thing under test
+const VolumesService = require('../../../../app/services/return-logs/setup/volumes.service.js')
+
+describe('Return Logs Setup - Volumes service', () => {
+  const yearMonth = '2023-3'
+
+  let session
+
+  before(async () => {
+    session = await SessionHelper.add({
+      data: {
+        lines: [
+          {
+            endDate: '2023-04-30T00:00:00.000Z',
+            quantity: 100,
+            startDate: '2023-04-01T00:00:00.000Z'
+          },
+          {
+            endDate: '2023-05-31T00:00:00.000Z',
+            startDate: '2023-05-01T00:00:00.000Z'
+          }
+        ],
+        returnReference: '1234',
+        units: 'cubic-metres'
+      }
+    })
+  })
+
+  describe('when called', () => {
+    it('returns page data for the view', async () => {
+      const result = await VolumesService.go(session.id, yearMonth)
+
+      expect(result).to.equal({
+        activeNavBar: 'search',
+        backLink: `/system/return-logs/setup/${session.id}/check`,
+        inputLines: [
+          {
+            endDate: '2023-04-30T00:00:00.000Z',
+            formattedEndDate: '30 April 2023',
+            quantity: 100
+          }
+        ],
+        pageTitle: 'Water abstracted April 2023',
+        returnReference: '1234',
+        units: 'Cubic metres'
+      })
+    })
+  })
+})

--- a/test/validators/return-logs/setup/volumes.validator.test.js
+++ b/test/validators/return-logs/setup/volumes.validator.test.js
@@ -1,0 +1,57 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Thing under test
+const VolumesValidator = require('../../../../app/validators/return-logs/setup/volumes.validator.js')
+
+describe('Return Logs Setup - Volumes validator', () => {
+  let payload
+
+  describe('when a valid payload is provided', () => {
+    describe('because the user entered a valid volume', () => {
+      beforeEach(() => {
+        payload = { '2023-05-31T00:00:00.000Z': '200' }
+      })
+
+      it('confirms the payload is valid', () => {
+        const result = VolumesValidator.go(payload)
+
+        expect(result.error).not.to.exist()
+      })
+    })
+  })
+
+  describe('when an invalid payload is provided', () => {
+    describe('because the user did not enter a number', () => {
+      beforeEach(() => {
+        payload = { '2023-05-31T00:00:00.000Z': 'INVALID' }
+      })
+
+      it('fails validation with the message "Volumes must be a number or blank"', () => {
+        const result = VolumesValidator.go(payload)
+
+        expect(result.error).to.exist()
+        expect(result.error.details[0].message).to.equal('Volumes must be a number or blank')
+      })
+    })
+
+    describe('because the user entered a negative number', () => {
+      beforeEach(() => {
+        payload = { '2023-05-31T00:00:00.000Z': '-200' }
+      })
+
+      it('fails validation with the message "Volumes must be a positive number"', () => {
+        const result = VolumesValidator.go(payload)
+
+        expect(result.error).to.exist()
+        expect(result.error.details[0].message).to.equal('Volumes must be a positive number')
+      })
+    })
+  })
+})


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4813

Build a page to allow users to enter/update abstraction volumes.

The page will have different numbers of entry fields depending on the frequency of collection (e.g. daily - 1 entry field per day, weekly - 1 entry field per week or monthly - 1 entry field per month).

Only entries for the selected month will be displayed.