### PR TITLE
Replace Math random calls with 'safe' alternate

### DIFF
--- a/app/lib/general.lib.js
+++ b/app/lib/general.lib.js
@@ -5,7 +5,7 @@
  * @module GeneralLib
  */
 
-const { randomUUID } = require('crypto')
+const { randomInt, randomUUID } = require('node:crypto')
 
 /**
  * Calculates and logs the time taken in milliseconds between the provided `startTime` and the current time
@@ -113,6 +113,18 @@ function flashNotification(yar, title = 'Updated', text = 'Changes made') {
     title,
     text
   })
+}
+
+/**
+ * Generate a random integer within a range (inclusive)
+ *
+ * @param {number} min - lowest number (integer) in the range (inclusive)
+ * @param {number} max - largest number (integer) in the range (inclusive)
+ *
+ * @returns a number between min and max (inclusive)
+ */
+function generateRandomInteger(min, max) {
+  return randomInt(min, max)
 }
 
 /**
@@ -302,6 +314,7 @@ module.exports = {
   currentTimeInNanoseconds,
   determineCurrentFinancialYear,
   flashNotification,
+  generateRandomInteger,
   generateUUID,
   periodsOverlap,
   timestampForPostgres,

--- a/app/services/notices/setup/initiate-session.service.js
+++ b/app/services/notices/setup/initiate-session.service.js
@@ -5,8 +5,7 @@
  * @module InitiateSessionService
  */
 
-const { randomInt } = require('node:crypto')
-
+const { generateRandomInteger } = require('../../../lib/general.lib.js')
 const DetermineLicenceMonitoringStationsService = require('./abstraction-alerts/determine-licence-monitoring-stations.service.js')
 const SessionModel = require('../../../models/session.model.js')
 
@@ -114,10 +113,11 @@ async function go(notificationType, monitoringStationId = null) {
 function _generateReferenceCode(prefix) {
   const possible = 'ABCDEFGHJKLMNPQRTUVWXYZ0123456789'
   const length = 6
+
   let text = ''
 
   for (let i = 0; i < length; i++) {
-    text += possible.charAt(randomInt(0, 32))
+    text += possible.charAt(generateRandomInteger(0, possible.length))
   }
   return prefix + text
 }

--- a/app/services/notices/setup/initiate-session.service.js
+++ b/app/services/notices/setup/initiate-session.service.js
@@ -5,6 +5,8 @@
  * @module InitiateSessionService
  */
 
+const { randomInt } = require('node:crypto')
+
 const DetermineLicenceMonitoringStationsService = require('./abstraction-alerts/determine-licence-monitoring-stations.service.js')
 const SessionModel = require('../../../models/session.model.js')
 
@@ -115,7 +117,7 @@ function _generateReferenceCode(prefix) {
   let text = ''
 
   for (let i = 0; i < length; i++) {
-    text += possible.charAt(Math.floor(Math.random() * possible.length))
+    text += possible.charAt(randomInt(0, 32))
   }
   return prefix + text
 }

--- a/test/models/charge-version.model.test.js
+++ b/test/models/charge-version.model.test.js
@@ -19,7 +19,7 @@ const ChargeReferenceModel = require('../../app/models/charge-reference.model.js
 const ChargeVersionHelper = require('../support/helpers/charge-version.helper.js')
 const ChargeVersionNoteHelper = require('../support/helpers/charge-version-note.helper.js')
 const ChargeVersionNoteModel = require('../../app/models/charge-version-note.model.js')
-const { randomInteger } = require('../support/general.js')
+const { generateRandomInteger } = require('../../app/lib/general.lib.js')
 const LicenceHelper = require('../support/helpers/licence.helper.js')
 const LicenceModel = require('../../app/models/licence.model.js')
 const ModLogHelper = require('../support/helpers/mod-log.helper.js')
@@ -288,8 +288,8 @@ describe('Charge Version model', () => {
 
     describe('when the charge version has mod log history', () => {
       beforeEach(async () => {
-        const regionCode = randomInteger(1, 9)
-        const firstNaldId = randomInteger(100, 99998)
+        const regionCode = generateRandomInteger(1, 9)
+        const firstNaldId = generateRandomInteger(100, 99998)
 
         await ModLogHelper.add({
           externalId: `${regionCode}:${firstNaldId}`,
@@ -374,8 +374,8 @@ describe('Charge Version model', () => {
 
       describe('and has mod log history', () => {
         beforeEach(async () => {
-          const regionCode = randomInteger(1, 9)
-          const firstNaldId = randomInteger(100, 99998)
+          const regionCode = generateRandomInteger(1, 9)
+          const firstNaldId = generateRandomInteger(100, 99998)
 
           await ModLogHelper.add({ externalId: `${regionCode}:${firstNaldId}`, chargeVersionId, userId: 'FIRST' })
           await ModLogHelper.add({ externalId: `${regionCode}:${firstNaldId + 1}`, chargeVersionId, userId: 'SECOND' })
@@ -448,8 +448,8 @@ describe('Charge Version model', () => {
       describe('and has mod log history', () => {
         describe('but none of the mod log history has notes', () => {
           beforeEach(async () => {
-            const regionCode = randomInteger(1, 9)
-            const firstNaldId = randomInteger(100, 99998)
+            const regionCode = generateRandomInteger(1, 9)
+            const firstNaldId = generateRandomInteger(100, 99998)
 
             await ModLogHelper.add({
               externalId: `${regionCode}:${firstNaldId}`,
@@ -475,8 +475,8 @@ describe('Charge Version model', () => {
 
         describe('and some of the mod log history has notes', () => {
           beforeEach(async () => {
-            const regionCode = randomInteger(1, 9)
-            const firstNaldId = randomInteger(100, 99998)
+            const regionCode = generateRandomInteger(1, 9)
+            const firstNaldId = generateRandomInteger(100, 99998)
 
             await ModLogHelper.add({
               externalId: `${regionCode}:${firstNaldId}`,
@@ -539,8 +539,8 @@ describe('Charge Version model', () => {
       describe('and has mod log history', () => {
         describe('but the mod log history has no reason description recorded in the first entry', () => {
           beforeEach(async () => {
-            const regionCode = randomInteger(1, 9)
-            const firstNaldId = randomInteger(100, 99998)
+            const regionCode = generateRandomInteger(1, 9)
+            const firstNaldId = generateRandomInteger(100, 99998)
 
             await ModLogHelper.add({
               externalId: `${regionCode}:${firstNaldId}`,
@@ -566,8 +566,8 @@ describe('Charge Version model', () => {
 
       describe('and the mod log history has a reason description recorded in the first entry', () => {
         beforeEach(async () => {
-          const regionCode = randomInteger(1, 9)
-          const firstNaldId = randomInteger(100, 99998)
+          const regionCode = generateRandomInteger(1, 9)
+          const firstNaldId = generateRandomInteger(100, 99998)
 
           await ModLogHelper.add({
             externalId: `${regionCode}:${firstNaldId}`,

--- a/test/models/licence-version.model.test.js
+++ b/test/models/licence-version.model.test.js
@@ -8,7 +8,7 @@ const { describe, it, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const { randomInteger } = require('../support/general.js')
+const { generateRandomInteger } = require('../../app/lib/general.lib.js')
 const LicenceHelper = require('../support/helpers/licence.helper.js')
 const LicenceModel = require('../../app/models/licence.model.js')
 const LicenceVersionHelper = require('../support/helpers/licence-version.helper.js')
@@ -150,8 +150,8 @@ describe('Licence Version model', () => {
 
     describe('when the licence version has mod log history', () => {
       beforeEach(async () => {
-        const regionCode = randomInteger(1, 9)
-        const firstNaldId = randomInteger(100, 99998)
+        const regionCode = generateRandomInteger(1, 9)
+        const firstNaldId = generateRandomInteger(100, 99998)
 
         await ModLogHelper.add({
           externalId: `${regionCode}:${firstNaldId}`,
@@ -190,8 +190,8 @@ describe('Licence Version model', () => {
 
     describe('when the licence version has mod log history', () => {
       beforeEach(async () => {
-        const regionCode = randomInteger(1, 9)
-        const firstNaldId = randomInteger(100, 99998)
+        const regionCode = generateRandomInteger(1, 9)
+        const firstNaldId = generateRandomInteger(100, 99998)
 
         await ModLogHelper.add({ externalId: `${regionCode}:${firstNaldId}`, licenceVersionId, userId: 'FIRST' })
         await ModLogHelper.add({ externalId: `${regionCode}:${firstNaldId + 1}`, licenceVersionId, userId: 'SECOND' })
@@ -224,8 +224,8 @@ describe('Licence Version model', () => {
     describe('when the licence version has mod log history', () => {
       describe('but none of the mod log history has notes', () => {
         beforeEach(async () => {
-          const regionCode = randomInteger(1, 9)
-          const firstNaldId = randomInteger(100, 99998)
+          const regionCode = generateRandomInteger(1, 9)
+          const firstNaldId = generateRandomInteger(100, 99998)
 
           await ModLogHelper.add({
             externalId: `${regionCode}:${firstNaldId}`,
@@ -251,8 +251,8 @@ describe('Licence Version model', () => {
 
       describe('and some of the mod log history has notes', () => {
         beforeEach(async () => {
-          const regionCode = randomInteger(1, 9)
-          const firstNaldId = randomInteger(100, 99998)
+          const regionCode = generateRandomInteger(1, 9)
+          const firstNaldId = generateRandomInteger(100, 99998)
 
           await ModLogHelper.add({
             externalId: `${regionCode}:${firstNaldId}`,
@@ -293,8 +293,8 @@ describe('Licence Version model', () => {
     describe('when the licence version has mod log history', () => {
       describe('but the mod log history has no reason description recorded in the first entry', () => {
         beforeEach(async () => {
-          const regionCode = randomInteger(1, 9)
-          const firstNaldId = randomInteger(100, 99998)
+          const regionCode = generateRandomInteger(1, 9)
+          const firstNaldId = generateRandomInteger(100, 99998)
 
           await ModLogHelper.add({
             externalId: `${regionCode}:${firstNaldId}`,
@@ -319,8 +319,8 @@ describe('Licence Version model', () => {
 
       describe('and the mod log history has a reason description recorded in the first entry', () => {
         beforeEach(async () => {
-          const regionCode = randomInteger(1, 9)
-          const firstNaldId = randomInteger(100, 99998)
+          const regionCode = generateRandomInteger(1, 9)
+          const firstNaldId = generateRandomInteger(100, 99998)
 
           await ModLogHelper.add({
             externalId: `${regionCode}:${firstNaldId}`,

--- a/test/models/return-version.model.test.js
+++ b/test/models/return-version.model.test.js
@@ -8,7 +8,8 @@ const { describe, it, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const { randomInteger, randomRegionCode } = require('../support/general.js')
+const { generateRandomInteger } = require('../../app/lib/general.lib.js')
+const { randomRegionCode } = require('../support/general.js')
 const LicenceHelper = require('../support/helpers/licence.helper.js')
 const LicenceModel = require('../../app/models/licence.model.js')
 const ModLogHelper = require('../support/helpers/mod-log.helper.js')
@@ -188,7 +189,7 @@ describe('Return Version model', () => {
     describe('when a return version has mod log history', () => {
       beforeEach(async () => {
         const regionCode = randomRegionCode()
-        const firstNaldId = randomInteger(100, 99998)
+        const firstNaldId = generateRandomInteger(100, 99998)
 
         await ModLogHelper.add({
           externalId: `${regionCode}:${firstNaldId}`,
@@ -273,7 +274,7 @@ describe('Return Version model', () => {
       describe('and has mod log history', () => {
         beforeEach(async () => {
           const regionCode = randomRegionCode()
-          const firstNaldId = randomInteger(100, 99998)
+          const firstNaldId = generateRandomInteger(100, 99998)
 
           await ModLogHelper.add({ externalId: `${regionCode}:${firstNaldId}`, returnVersionId, userId: 'FIRST' })
           await ModLogHelper.add({ externalId: `${regionCode}:${firstNaldId + 1}`, returnVersionId, userId: 'SECOND' })
@@ -337,7 +338,7 @@ describe('Return Version model', () => {
         describe('and none of the mod log history has notes', () => {
           beforeEach(async () => {
             const regionCode = randomRegionCode()
-            const firstNaldId = randomInteger(100, 99998)
+            const firstNaldId = generateRandomInteger(100, 99998)
 
             await ModLogHelper.add({
               externalId: `${regionCode}:${firstNaldId}`,
@@ -364,7 +365,7 @@ describe('Return Version model', () => {
         describe('and some of the mod log history has notes', () => {
           beforeEach(async () => {
             const regionCode = randomRegionCode()
-            const firstNaldId = randomInteger(100, 99998)
+            const firstNaldId = generateRandomInteger(100, 99998)
 
             await ModLogHelper.add({
               externalId: `${regionCode}:${firstNaldId}`,
@@ -396,7 +397,7 @@ describe('Return Version model', () => {
             returnVersionId = id
 
             const regionCode = randomRegionCode()
-            const firstNaldId = randomInteger(100, 99998)
+            const firstNaldId = generateRandomInteger(100, 99998)
 
             await ModLogHelper.add({
               externalId: `${regionCode}:${firstNaldId}`,
@@ -468,7 +469,7 @@ describe('Return Version model', () => {
         describe('but the mod log history has no reason description recorded in the first entry', () => {
           beforeEach(async () => {
             const regionCode = randomRegionCode()
-            const firstNaldId = randomInteger(100, 99998)
+            const firstNaldId = generateRandomInteger(100, 99998)
 
             await ModLogHelper.add({
               externalId: `${regionCode}:${firstNaldId}`,
@@ -494,7 +495,7 @@ describe('Return Version model', () => {
         describe('and the mod log history has a reason description recorded in the first entry', () => {
           beforeEach(async () => {
             const regionCode = randomRegionCode()
-            const firstNaldId = randomInteger(100, 99998)
+            const firstNaldId = generateRandomInteger(100, 99998)
 
             await ModLogHelper.add({
               externalId: `${regionCode}:${firstNaldId}`,

--- a/test/services/monitoring-stations/fetch-monitoring-station.service.test.js
+++ b/test/services/monitoring-stations/fetch-monitoring-station.service.test.js
@@ -8,7 +8,7 @@ const { describe, it, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const { randomInteger } = require('../../support/general.js')
+const { generateRandomInteger } = require('../../../app/lib/general.lib.js')
 const LicenceHelper = require('../../support/helpers/licence.helper.js')
 const LicenceMonitoringStationHelper = require('../../support/helpers/licence-monitoring-station.helper.js')
 const LicenceVersionHelper = require('../../support/helpers/licence-version.helper.js')
@@ -62,7 +62,7 @@ describe('Monitoring Stations - Fetch Monitoring Station service', () => {
         })
 
         // NOTE: We control the licence references used to assert the licence sorting is working as expected
-        licenceWithCondition = await LicenceHelper.add({ licenceRef: `02/02/02/${randomInteger(1, 9999)}` })
+        licenceWithCondition = await LicenceHelper.add({ licenceRef: `02/02/02/${generateRandomInteger(1, 9999)}` })
         const licenceVersion = await LicenceVersionHelper.add({ licenceId: licenceWithCondition.id })
 
         licenceWithConditionPurpose = await LicenceVersionPurposeHelper.add({ licenceVersionId: licenceVersion.id })
@@ -75,7 +75,7 @@ describe('Monitoring Stations - Fetch Monitoring Station service', () => {
           monitoringStationId: monitoringStation.id
         })
 
-        licenceWithoutConditions = await LicenceHelper.add({ licenceRef: `01/01/01/${randomInteger(1, 9999)}` })
+        licenceWithoutConditions = await LicenceHelper.add({ licenceRef: `01/01/01/${generateRandomInteger(1, 9999)}` })
         licenceMonitoringStationTwo = await LicenceMonitoringStationHelper.add({
           licenceId: licenceWithoutConditions.id,
           monitoringStationId: monitoringStation.id

--- a/test/support/general.js
+++ b/test/support/general.js
@@ -5,6 +5,8 @@
  * @module GeneralHelper
  */
 
+const { randomInt } = require('node:crypto')
+
 /**
  * Generate the POST request options needed for `server.inject()`
  *
@@ -77,12 +79,10 @@ function postRequestOptions(
  * @param {number} min - lowest number (integer) in the range (inclusive)
  * @param {number} max - largest number (integer) in the range (inclusive)
  *
- * Credit https://stackoverflow.com/a/7228322
- *
  * @returns a number between min and max (inclusive)
  */
 function randomInteger(min, max) {
-  return Math.floor(Math.random() * (max - min + 1) + min)
+  return randomInt(min, max)
 }
 
 /**

--- a/test/support/general.js
+++ b/test/support/general.js
@@ -5,7 +5,7 @@
  * @module GeneralHelper
  */
 
-const { randomInt } = require('node:crypto')
+const { generateRandomInteger } = require('../../app/lib/general.lib.js')
 
 /**
  * Generate the POST request options needed for `server.inject()`
@@ -74,18 +74,6 @@ function postRequestOptions(
 }
 
 /**
- * Generate a random integer within a range (inclusive)
- *
- * @param {number} min - lowest number (integer) in the range (inclusive)
- * @param {number} max - largest number (integer) in the range (inclusive)
- *
- * @returns a number between min and max (inclusive)
- */
-function randomInteger(min, max) {
-  return randomInt(min, max)
-}
-
-/**
  * Select a random entry from an array of entries
  *
  * Was built when we started using real reference data within the unit tests, for example, regions and purposes.
@@ -98,7 +86,7 @@ function randomInteger(min, max) {
  * @returns a random entry from the data provided
  */
 function selectRandomEntry(data) {
-  const randomIndex = randomInteger(0, data.length - 1)
+  const randomIndex = generateRandomInteger(0, data.length - 1)
 
   return data[randomIndex]
 }
@@ -115,12 +103,11 @@ function selectRandomEntry(data) {
  * @returns a random number
  */
 function randomRegionCode() {
-  return randomInteger(1, 999999)
+  return generateRandomInteger(1, 999999)
 }
 
 module.exports = {
   postRequestOptions,
-  randomInteger,
   randomRegionCode,
   selectRandomEntry
 }

--- a/test/support/helpers/address.helper.js
+++ b/test/support/helpers/address.helper.js
@@ -5,7 +5,7 @@
  */
 
 const AddressModel = require('../../../app/models/address.model.js')
-const { randomInteger } = require('../general.js')
+const { generateRandomInteger } = require('../../../app/lib/general.lib.js')
 
 /**
  * Add a new address
@@ -67,7 +67,7 @@ function defaults(data = {}) {
  * @returns {string} - A random UPRN
  */
 function generateUprn() {
-  return randomInteger(100, 999999)
+  return generateRandomInteger(100, 999999)
 }
 
 /**
@@ -78,8 +78,8 @@ function generateUprn() {
  * @returns {string} - A random external id
  */
 function generateExternalId() {
-  const regionCode = randomInteger(1, 9)
-  const addressId = randomInteger(100, 99998)
+  const regionCode = generateRandomInteger(1, 9)
+  const addressId = generateRandomInteger(100, 99998)
 
   return `${regionCode}:${addressId}`
 }

--- a/test/support/helpers/billing-account.helper.js
+++ b/test/support/helpers/billing-account.helper.js
@@ -4,9 +4,8 @@
  * @module BillingAccountHelper
  */
 
-const { randomInteger } = require('../general.js')
 const BillingAccountModel = require('../../../app/models/billing-account.model.js')
-const { generateUUID } = require('../../../app/lib/general.lib.js')
+const { generateRandomInteger, generateUUID } = require('../../../app/lib/general.lib.js')
 
 /**
  * Add a new billing account
@@ -58,7 +57,7 @@ function defaults(data = {}) {
  * @returns {string} - The generated account number
  */
 function generateAccountNumber() {
-  const numbering = randomInteger(10000000, 99999999)
+  const numbering = generateRandomInteger(10000000, 99999999)
 
   return `T${numbering}A`
 }

--- a/test/support/helpers/company.helper.js
+++ b/test/support/helpers/company.helper.js
@@ -5,7 +5,7 @@
  */
 
 const CompanyModel = require('../../../app/models/company.model.js')
-const { randomInteger } = require('../general.js')
+const { generateRandomInteger } = require('../../../app/lib/general.lib.js')
 
 /**
  * Add a new company
@@ -55,7 +55,7 @@ function defaults(data = {}) {
  * @returns {int} - A random company number
  */
 function generateCompanyNumber() {
-  return randomInteger(1000000, 9999999).toString()
+  return generateRandomInteger(1000000, 9999999).toString()
 }
 
 /**
@@ -66,8 +66,8 @@ function generateCompanyNumber() {
  * @returns {string} - A random external id
  */
 function generateExternalId() {
-  const regionCode = randomInteger(1, 9)
-  const partyId = randomInteger(100, 9999998)
+  const regionCode = generateRandomInteger(1, 9)
+  const partyId = generateRandomInteger(100, 9999998)
 
   return `${regionCode}:${partyId}`
 }

--- a/test/support/helpers/licence-document-header.helper.js
+++ b/test/support/helpers/licence-document-header.helper.js
@@ -4,8 +4,7 @@
  * @module LicenceDocumentHelper
  */
 
-const { randomInteger } = require('../general.js')
-const { generateUUID } = require('../../../app/lib/general.lib.js')
+const { generateRandomInteger, generateUUID } = require('../../../app/lib/general.lib.js')
 const { generateLicenceRef } = require('./licence.helper.js')
 const LicenceDocumentHeaderModel = require('../../../app/models/licence-document-header.model.js')
 
@@ -44,7 +43,7 @@ async function add(data = {}) {
 function defaults(data = {}) {
   const defaults = {
     regimeEntityId: generateUUID(),
-    naldId: randomInteger(1000, 199999),
+    naldId: generateRandomInteger(1000, 199999),
     licenceRef: generateLicenceRef(),
     metadata: _metadata()
   }

--- a/test/support/helpers/licence-version-purpose-condition.helper.js
+++ b/test/support/helpers/licence-version-purpose-condition.helper.js
@@ -4,10 +4,9 @@
  * @module LicenceVersionPurposeConditionHelper
  */
 
-const { generateUUID, timestampForPostgres } = require('../../../app/lib/general.lib.js')
+const { generateRandomInteger, generateUUID, timestampForPostgres } = require('../../../app/lib/general.lib.js')
 const LicenceVersionPurposeConditionModel = require('../../../app/models/licence-version-purpose-condition.model.js')
 const LicenceVersionPurposeConditionTypeHelper = require('./licence-version-purpose-condition-type.helper.js')
-const { randomInteger } = require('../general.js')
 
 /**
  * Add a new licence version purpose condition
@@ -17,7 +16,7 @@ const { randomInteger } = require('../general.js')
  * - `licenceVersionPurposeConditionId` - [random UUID]
  * - `licenceVersionPurposeId` - [random UUID]
  * - `licenceVersionPurposeConditionTypeId` - [randomly selected UUID from licence version purpose condition types]
- * - `externalId` - [9:${randomInteger(10000, 99999)}:1:0]
+ * - `externalId` - [9:${generateRandomInteger(10000, 99999)}:1:0]
  * - `source` - [nald]
  * - `dateCreated` - new Date()
  * - `dateUpdated` - new Date()
@@ -51,7 +50,7 @@ function defaults(data = {}) {
   const defaults = {
     licenceVersionPurposeId: generateUUID(),
     licenceVersionPurposeConditionTypeId,
-    externalId: `9:${randomInteger(10000, 99999)}:1:0`,
+    externalId: `9:${generateRandomInteger(10000, 99999)}:1:0`,
     source: 'nald',
     createdAt: timestamp,
     updatedAt: timestamp

--- a/test/support/helpers/licence-version-purpose-point.helper.js
+++ b/test/support/helpers/licence-version-purpose-point.helper.js
@@ -4,8 +4,7 @@
  * @module LicenceVersionPurposePointHelper
  */
 
-const { generateUUID } = require('../../../app/lib/general.lib.js')
-const { randomInteger } = require('../general.js')
+const { generateRandomInteger, generateUUID } = require('../../../app/lib/general.lib.js')
 const LicenceVersionPurposePointModel = require('../../../app/models/licence-version-purpose-point.model.js')
 const PointHelper = require('./point.helper.js')
 
@@ -65,7 +64,7 @@ function defaults(data = {}) {
 function generateLicenceVersionPurposePointExternalId() {
   const naldPointId = PointHelper.generateNaldPointId()
 
-  return `9:${randomInteger(100, 99999)}:${naldPointId}`
+  return `9:${generateRandomInteger(100, 99999)}:${naldPointId}`
 }
 
 module.exports = {

--- a/test/support/helpers/licence-version-purpose.helper.js
+++ b/test/support/helpers/licence-version-purpose.helper.js
@@ -4,11 +4,10 @@
  * @module LicenceVersionPurposesHelper
  */
 
-const { generateUUID, timestampForPostgres } = require('../../../app/lib/general.lib.js')
+const { generateRandomInteger, generateUUID, timestampForPostgres } = require('../../../app/lib/general.lib.js')
 const LicenceVersionPurposeModel = require('../../../app/models/licence-version-purpose.model.js')
 const PrimaryPurposeHelper = require('./primary-purpose.helper.js')
 const PurposeHelper = require('./purpose.helper.js')
-const { randomInteger } = require('../general.js')
 const SecondaryPurposeHelper = require('./secondary-purpose.helper.js')
 
 /**
@@ -83,7 +82,7 @@ function defaults(data = {}) {
  * @returns {string} - A randomly generated external id
  */
 function generateLicenceVersionPurposeExternalId() {
-  return `${randomInteger(0, 9)}:${randomInteger(10000, 99999)}`
+  return `${generateRandomInteger(0, 9)}:${generateRandomInteger(10000, 99999)}`
 }
 
 module.exports = {

--- a/test/support/helpers/licence-version.helper.js
+++ b/test/support/helpers/licence-version.helper.js
@@ -4,9 +4,8 @@
  * @module LicenceVersionHelper
  */
 
-const { generateUUID, timestampForPostgres } = require('../../../app/lib/general.lib.js')
+const { generateRandomInteger, generateUUID, timestampForPostgres } = require('../../../app/lib/general.lib.js')
 const LicenceVersionModel = require('../../../app/models/licence-version.model.js')
-const { randomInteger } = require('../general.js')
 
 /**
  * Add a new licence version
@@ -70,7 +69,7 @@ function defaults(data = {}) {
  * @returns {string} - A randomly generated externalId
  */
 function generateLicenceVersionExternalId() {
-  return `${randomInteger(0, 9)}:${randomInteger(10000, 99999)}:${randomInteger(1, 100)}:0`
+  return `${generateRandomInteger(0, 9)}:${generateRandomInteger(10000, 99999)}:${generateRandomInteger(1, 100)}:0`
 }
 
 module.exports = {

--- a/test/support/helpers/licence.helper.js
+++ b/test/support/helpers/licence.helper.js
@@ -5,7 +5,7 @@
  */
 
 const LicenceModel = require('../../../app/models/licence.model.js')
-const { randomInteger } = require('../general.js')
+const { generateRandomInteger } = require('../../../app/lib/general.lib.js')
 const RegionHelper = require('./region.helper.js')
 
 /**
@@ -64,9 +64,9 @@ function defaults(data = {}) {
  * @returns {string} - A randomly generated licence reference
  */
 function generateLicenceRef() {
-  const secondPart = randomInteger(10, 99)
-  const thirdPart = randomInteger(10, 99)
-  const fourthPart = randomInteger(1000, 9999)
+  const secondPart = generateRandomInteger(10, 99)
+  const thirdPart = generateRandomInteger(10, 99)
+  const fourthPart = generateRandomInteger(1000, 9999)
 
   return `01/${secondPart}/${thirdPart}/${fourthPart}`
 }

--- a/test/support/helpers/mod-log.helper.js
+++ b/test/support/helpers/mod-log.helper.js
@@ -4,9 +4,10 @@
  * @module ModLogHelper
  */
 
-const ModLogModel = require('../../../app/models/mod-log.model.js')
-const { randomInteger, randomRegionCode } = require('../general.js')
+const { randomRegionCode } = require('../general.js')
+const { generateRandomInteger } = require('../../../app/lib/general.lib.js')
 const { generateLicenceRef } = require('./licence.helper.js')
+const ModLogModel = require('../../../app/models/mod-log.model.js')
 
 /**
  * Add a new mod log
@@ -73,9 +74,9 @@ function defaults(data = {}) {
  * @returns {string} The generated external ID
  */
 function generateRegionNaldPatternExternalId(regionCode = null) {
-  const regionCodeToUse = regionCode ?? randomInteger(1, 9)
+  const regionCodeToUse = regionCode ?? generateRandomInteger(1, 9)
 
-  return `${regionCodeToUse}:${randomInteger(100, 99999)}`
+  return `${regionCodeToUse}:${generateRandomInteger(100, 99999)}`
 }
 
 module.exports = {

--- a/test/support/helpers/point.helper.js
+++ b/test/support/helpers/point.helper.js
@@ -4,7 +4,7 @@
  * @module PointHelper
  */
 
-const { randomInteger } = require('../general.js')
+const { generateRandomInteger } = require('../../../app/lib/general.lib.js')
 const PointModel = require('../../../app/models/point.model.js')
 const SourceHelper = require('./source.helper.js')
 
@@ -68,7 +68,7 @@ function generateNationalGridReference() {
   // square references that cover the majority of the UK (sorry far North!)
   const codes = ['SD', 'SE', 'SJ', 'SK', 'SO', 'SP', 'ST', 'SU', 'SY', 'SZ', 'TA', 'TF', 'TL', 'TQ', 'TV', 'TG', 'TM']
 
-  return `${codes[randomInteger(0, 16)]} ${randomInteger(100, 999)} ${randomInteger(100, 999)}`
+  return `${codes[generateRandomInteger(0, 16)]} ${generateRandomInteger(100, 999)} ${generateRandomInteger(100, 999)}`
 }
 
 /**
@@ -77,7 +77,7 @@ function generateNationalGridReference() {
  * @returns {string} - A randomly generated point ID
  */
 function generateNaldPointId() {
-  return randomInteger(1, 99999)
+  return generateRandomInteger(1, 99999)
 }
 
 module.exports = {

--- a/test/support/helpers/region.helper.js
+++ b/test/support/helpers/region.helper.js
@@ -4,7 +4,7 @@
  * @module RegionHelper
  */
 
-const { randomInteger } = require('../general.js')
+const { generateRandomInteger } = require('../../../app/lib/general.lib.js')
 const { data: regions } = require('../../../db/seeds/data/regions.js')
 
 // The `BILL_RUN_REGION_INDEX` is only to be used for testing bill run services that need to know details of bill runs
@@ -32,7 +32,7 @@ function select(index = -1) {
   }
 
   // 2 is deducted from the length of the array so that the Test Bill Run Region is not selected randomly
-  const randomIndex = randomInteger(0, regions.length - 2)
+  const randomIndex = generateRandomInteger(0, regions.length - 2)
 
   return regions[randomIndex]
 }

--- a/test/support/helpers/return-requirement-point.helper.js
+++ b/test/support/helpers/return-requirement-point.helper.js
@@ -4,8 +4,7 @@
  * @module ReturnRequirementPointHelper
  */
 
-const { generateUUID } = require('../../../app/lib/general.lib.js')
-const { randomInteger } = require('../general.js')
+const { generateRandomInteger, generateUUID } = require('../../../app/lib/general.lib.js')
 const PointHelper = require('./point.helper.js')
 const ReturnRequirementPointModel = require('../../../app/models/return-requirement-point.model.js')
 
@@ -65,7 +64,7 @@ function defaults(data = {}) {
 function generateReturnRequirementPointExternalId() {
   const naldPointId = PointHelper.generateNaldPointId()
 
-  return `9:${randomInteger(100, 99999)}:${naldPointId}`
+  return `9:${generateRandomInteger(100, 99999)}:${naldPointId}`
 }
 
 module.exports = {

--- a/test/support/helpers/return-requirement-purpose.helper.js
+++ b/test/support/helpers/return-requirement-purpose.helper.js
@@ -4,8 +4,7 @@
  * @module ReturnRequirementPurposeHelper
  */
 
-const { generateUUID } = require('../../../app/lib/general.lib.js')
-const { randomInteger } = require('../general.js')
+const { generateRandomInteger, generateUUID } = require('../../../app/lib/general.lib.js')
 const PrimaryPurposeHelper = require('./primary-purpose.helper.js')
 const PurposeHelper = require('./purpose.helper.js')
 const ReturnRequirementPurposeModel = require('../../../app/models/return-requirement-purpose.model.js')
@@ -49,7 +48,7 @@ function defaults(data = {}) {
   const primaryPurpose = PrimaryPurposeHelper.select()
   const secondaryPurpose = SecondaryPurposeHelper.select()
 
-  const externalId = `9:${randomInteger(100, 99999)}:${primaryPurpose.legacyId}:${secondaryPurpose.legacyId}:${purpose.legacyId}`
+  const externalId = `9:${generateRandomInteger(100, 99999)}:${primaryPurpose.legacyId}:${secondaryPurpose.legacyId}:${purpose.legacyId}`
 
   const defaults = {
     externalId,

--- a/test/support/helpers/return-requirement.helper.js
+++ b/test/support/helpers/return-requirement.helper.js
@@ -4,8 +4,7 @@
  * @module ReturnRequirementHelper
  */
 
-const { generateUUID } = require('../../../app/lib/general.lib.js')
-const { randomInteger } = require('../general.js')
+const { generateRandomInteger, generateUUID } = require('../../../app/lib/general.lib.js')
 const ReturnRequirementModel = require('../../../app/models/return-requirement.model.js')
 
 /**
@@ -77,7 +76,7 @@ function defaults(data = {}) {
  * @returns {number}
  */
 function generateLegacyId() {
-  return randomInteger(100, 19999999)
+  return generateRandomInteger(100, 19999999)
 }
 
 module.exports = {

--- a/test/support/helpers/return-version.helper.js
+++ b/test/support/helpers/return-version.helper.js
@@ -4,8 +4,8 @@
  * @module ReturnVersionHelper
  */
 
-const { generateUUID } = require('../../../app/lib/general.lib.js')
-const { randomInteger, randomRegionCode } = require('../general.js')
+const { randomRegionCode } = require('../general.js')
+const { generateRandomInteger, generateUUID } = require('../../../app/lib/general.lib.js')
 const ReturnVersionModel = require('../../../app/models/return-version.model.js')
 
 /**
@@ -46,7 +46,7 @@ function defaults(data = {}) {
   const version = data.version ? data.version : 100
 
   const defaults = {
-    externalId: `${randomRegionCode()}:${randomInteger(100, 99999)}:${version}`,
+    externalId: `${randomRegionCode()}:${generateRandomInteger(100, 99999)}:${version}`,
     licenceId: generateUUID(),
     reason: 'new-licence',
     startDate: new Date('2022-04-01'),

--- a/test/support/helpers/user.helper.js
+++ b/test/support/helpers/user.helper.js
@@ -4,8 +4,8 @@
  * @module UserHelper
  */
 
-const { randomInteger, selectRandomEntry } = require('../general.js')
-const { generateUUID } = require('../../../app/lib/general.lib.js')
+const { selectRandomEntry } = require('../general.js')
+const { generateRandomInteger, generateUUID } = require('../../../app/lib/general.lib.js')
 const UserModel = require('../../../app/models/user.model.js')
 const { data: users } = require('../../../db/seeds/data/users.js')
 
@@ -69,7 +69,7 @@ function defaults(data = {}) {
  */
 function generateUserId() {
   // The last ID in the pre-seeded users is 100010
-  return randomInteger(100011, 199999)
+  return generateRandomInteger(100011, 199999)
 }
 
 /**


### PR DESCRIPTION
We mainly use `Math.random()` in our unit tests to support generating references for various types of records. Recently, we used it in our `production` logic for the first time to [generate the reference for new notices](https://github.com/DEFRA/water-abstraction-system/pull/1682).

None of this is security-based, but every time we make a change that touches these areas, we get a security ping from both GitHub and SonarQube.

This is because `Math.random()` is not cryptographically secure. It only returns a pseudo-random number. It is common to generate random numbers in security, for example, generating 'salt' for encryption. But your encryption could be cracked if the number is not truly random.

That's why any use of `Math.random` sets alarm bells ringing.

We're safe in how we use it, but wouldn't it be nice not to have to repeatedly say so?!

This change adds a suggested alternate to `Math.random()` based on [Crypto randomInt()](https://nodejs.org/api/crypto.html#cryptorandomintmin-max-callback), which will calm everyone down!