### PR TITLE
Fix Workflow does not contain permissions alert

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -3,6 +3,9 @@ name: auto-merge
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   auto-merge:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: CI
 
 on: push
 
+permissions:
+  contents: read
+
 jobs:
   build:
     # You must use a Linux environment when using service containers or container jobs


### PR DESCRIPTION
Potential fix for [https://github.com/DEFRA/water-abstraction-system/security/code-scanning/72](https://github.com/DEFRA/water-abstraction-system/security/code-scanning/72) and [https://github.com/DEFRA/water-abstraction-system/security/code-scanning/73](https://github.com/DEFRA/water-abstraction-system/security/code-scanning/73)

GitHub code scanning has recently started flagging our workflows for not including a permissions block.

> If a GitHub Actions job or workflow has no explicit permissions set, then the repository permissions are used. Repositories created under organizations inherit the organization permissions. The organizations or repositories created before February 2023 have the default permissions set to read-write. Often these permissions do not adhere to the principle of least privilege and can be reduced to read-only, leaving the write permission only to a specific types as `issues:` write or `pull-requests: write`.

This is the copilot suggested fix to resolve the issue.

---

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will explicitly set the permissions for the `GITHUB_TOKEN` to `contents: read`, which is sufficient for the operations performed in this workflow. This change ensures that the workflow adheres to the principle of least privilege and avoids granting unnecessary permissions.

---

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._



