### PR TITLE
Add notifications setup abstraction alerts check licence matches

### DIFF
--- a/app/controllers/notices-setup.controller.js
+++ b/app/controllers/notices-setup.controller.js
@@ -142,7 +142,7 @@ async function submitAlertThresholds(request, h) {
     return h.view(`notices/setup/abstraction-alerts/alert-thresholds.view.njk`, pageData)
   }
 
-  return h.redirect(`/system/notices/setup/${sessionId}/abstraction-alerts/check`)
+  return h.redirect(`/system/notices/setup/${sessionId}/abstraction-alerts/check-licence-matches`)
 }
 
 async function submitAlertType(request, h) {

--- a/app/controllers/notices-setup.controller.js
+++ b/app/controllers/notices-setup.controller.js
@@ -9,6 +9,7 @@ const AdHocLicenceService = require('../services/notices/setup/ad-hoc/ad-hoc-lic
 const AlertThresholdsService = require('../services/notices/setup/abstraction-alerts/alert-thresholds.service.js')
 const AlertTypeService = require('../services/notices/setup/abstraction-alerts/alert-type.service.js')
 const CancelService = require('../services/notices/setup/cancel.service.js')
+const CheckLicenceMatchesService = require('../services/notices/setup/abstraction-alerts/check-licence-matches.service.js')
 const CheckService = require('../services/notices/setup/check.service.js')
 const ConfirmationService = require('../services/notices/setup/confirmation.service.js')
 const DownloadRecipientsService = require('../services/notices/setup/download-recipients.service.js')
@@ -64,6 +65,14 @@ async function viewCancel(request, h) {
   const pageData = await CancelService.go(sessionId)
 
   return h.view(`${basePath}/cancel.njk`, pageData)
+}
+
+async function viewCheckLicenceMatches(request, h) {
+  const { sessionId } = request.params
+
+  const pageData = await CheckLicenceMatchesService.go(sessionId)
+
+  return h.view(`notices/setup/abstraction-alerts/check-licence-matches.njk`, pageData)
 }
 
 async function viewConfirmation(request, h) {
@@ -217,9 +226,10 @@ module.exports = {
   viewAlertThresholds,
   viewAlertType,
   viewCancel,
+  viewCheck,
+  viewCheckLicenceMatches,
   viewConfirmation,
   viewLicence,
-  viewCheck,
   viewRemoveLicences,
   viewReturnsPeriod,
   setup,

--- a/app/presenters/notices/setup/abstraction-alerts/check-licence-matches.presenter.js
+++ b/app/presenters/notices/setup/abstraction-alerts/check-licence-matches.presenter.js
@@ -1,12 +1,12 @@
 'use strict'
 
 /**
- * Formats data for the `/notices/setup/{sessionId}/abstraction-alert/check-licence-matches` page
+ * Formats data for the `/notices/setup/{sessionId}/abstraction-alerts/check-licence-matches` page
  * @module CheckLicenceMatchesPresenter
  */
 
 /**
- * Formats data for the `/notices/setup/{sessionId}/abstraction-alert/check-licence-matches` page
+ * Formats data for the `/notices/setup/{sessionId}/abstraction-alerts/check-licence-matches` page
  *
  * @returns {object} - The data formatted for the view template
  */

--- a/app/presenters/notices/setup/abstraction-alerts/check-licence-matches.presenter.js
+++ b/app/presenters/notices/setup/abstraction-alerts/check-licence-matches.presenter.js
@@ -1,0 +1,19 @@
+'use strict'
+
+/**
+ * Formats data for the `/notices/setup/{sessionId}/abstraction-alert/check-licence-matches` page
+ * @module CheckLicenceMatchesPresenter
+ */
+
+/**
+ * Formats data for the `/notices/setup/{sessionId}/abstraction-alert/check-licence-matches` page
+ *
+ * @returns {object} - The data formatted for the view template
+ */
+function go() {
+  return {}
+}
+
+module.exports = {
+  go
+}

--- a/app/routes/notices-setup.routes.js
+++ b/app/routes/notices-setup.routes.js
@@ -31,7 +31,7 @@ const routes = [
   },
   {
     method: 'GET',
-    path: basePath + `/{sessionId}/abstraction-alerts/alert-type`,
+    path: basePath + '/{sessionId}/abstraction-alerts/alert-type',
     options: {
       handler: NoticesSetupController.viewAlertType,
       auth: {
@@ -43,7 +43,7 @@ const routes = [
   },
   {
     method: 'POST',
-    path: basePath + `/{sessionId}/abstraction-alerts/alert-type`,
+    path: basePath + '/{sessionId}/abstraction-alerts/alert-type',
     options: {
       handler: NoticesSetupController.submitAlertType,
       auth: {
@@ -55,7 +55,7 @@ const routes = [
   },
   {
     method: 'GET',
-    path: basePath + `/{sessionId}/abstraction-alerts/alert-thresholds`,
+    path: basePath + '/{sessionId}/abstraction-alerts/alert-thresholds',
     options: {
       handler: NoticesSetupController.viewAlertThresholds,
       auth: {
@@ -67,7 +67,7 @@ const routes = [
   },
   {
     method: 'POST',
-    path: basePath + `/{sessionId}/abstraction-alerts/alert-thresholds`,
+    path: basePath + '/{sessionId}/abstraction-alerts/alert-thresholds',
     options: {
       handler: NoticesSetupController.submitAlertThresholds,
       auth: {

--- a/app/routes/notices-setup.routes.js
+++ b/app/routes/notices-setup.routes.js
@@ -4,8 +4,6 @@ const NoticesSetupController = require('../controllers/notices-setup.controller.
 
 const basePath = '/notices/setup'
 
-const ABSTRACTION_ALERTS_PATH = 'abstraction-alerts'
-
 const routes = [
   {
     method: 'GET',
@@ -33,7 +31,7 @@ const routes = [
   },
   {
     method: 'GET',
-    path: basePath + `/{sessionId}/${ABSTRACTION_ALERTS_PATH}/alert-type`,
+    path: basePath + `/{sessionId}/abstraction-alerts/alert-type`,
     options: {
       handler: NoticesSetupController.viewAlertType,
       auth: {
@@ -45,7 +43,7 @@ const routes = [
   },
   {
     method: 'POST',
-    path: basePath + `/{sessionId}/${ABSTRACTION_ALERTS_PATH}/alert-type`,
+    path: basePath + `/{sessionId}/abstraction-alerts/alert-type`,
     options: {
       handler: NoticesSetupController.submitAlertType,
       auth: {
@@ -57,7 +55,7 @@ const routes = [
   },
   {
     method: 'GET',
-    path: basePath + `/{sessionId}/${ABSTRACTION_ALERTS_PATH}/alert-thresholds`,
+    path: basePath + `/{sessionId}/abstraction-alerts/alert-thresholds`,
     options: {
       handler: NoticesSetupController.viewAlertThresholds,
       auth: {
@@ -69,7 +67,7 @@ const routes = [
   },
   {
     method: 'POST',
-    path: basePath + `/{sessionId}/${ABSTRACTION_ALERTS_PATH}/alert-thresholds`,
+    path: basePath + `/{sessionId}/abstraction-alerts/alert-thresholds`,
     options: {
       handler: NoticesSetupController.submitAlertThresholds,
       auth: {
@@ -81,7 +79,7 @@ const routes = [
   },
   {
     method: 'GET',
-    path: basePath + `/{sessionId}/${ABSTRACTION_ALERTS_PATH}/check-licence-matches`,
+    path: basePath + `/{sessionId}/abstraction-alerts/check-licence-matches`,
     options: {
       handler: NoticesSetupController.viewCheckLicenceMatches,
       auth: {

--- a/app/routes/notices-setup.routes.js
+++ b/app/routes/notices-setup.routes.js
@@ -4,6 +4,8 @@ const NoticesSetupController = require('../controllers/notices-setup.controller.
 
 const basePath = '/notices/setup'
 
+const ABSTRACTION_ALERTS_PATH = 'abstraction-alerts'
+
 const routes = [
   {
     method: 'GET',
@@ -31,7 +33,7 @@ const routes = [
   },
   {
     method: 'GET',
-    path: basePath + '/{sessionId}/abstraction-alerts/alert-type',
+    path: basePath + `/{sessionId}/${ABSTRACTION_ALERTS_PATH}/alert-type`,
     options: {
       handler: NoticesSetupController.viewAlertType,
       auth: {
@@ -43,7 +45,7 @@ const routes = [
   },
   {
     method: 'POST',
-    path: basePath + '/{sessionId}/abstraction-alerts/alert-type',
+    path: basePath + `/{sessionId}/${ABSTRACTION_ALERTS_PATH}/alert-type`,
     options: {
       handler: NoticesSetupController.submitAlertType,
       auth: {
@@ -55,7 +57,7 @@ const routes = [
   },
   {
     method: 'GET',
-    path: basePath + '/{sessionId}/abstraction-alerts/alert-thresholds',
+    path: basePath + `/{sessionId}/${ABSTRACTION_ALERTS_PATH}/alert-thresholds`,
     options: {
       handler: NoticesSetupController.viewAlertThresholds,
       auth: {
@@ -67,9 +69,21 @@ const routes = [
   },
   {
     method: 'POST',
-    path: basePath + '/{sessionId}/abstraction-alerts/alert-thresholds',
+    path: basePath + `/{sessionId}/${ABSTRACTION_ALERTS_PATH}/alert-thresholds`,
     options: {
       handler: NoticesSetupController.submitAlertThresholds,
+      auth: {
+        access: {
+          scope: ['returns']
+        }
+      }
+    }
+  },
+  {
+    method: 'GET',
+    path: basePath + `/{sessionId}/${ABSTRACTION_ALERTS_PATH}/check-licence-matches`,
+    options: {
+      handler: NoticesSetupController.viewCheckLicenceMatches,
       auth: {
         access: {
           scope: ['returns']

--- a/app/services/notices/setup/abstraction-alerts/check-licence-matches.service.js
+++ b/app/services/notices/setup/abstraction-alerts/check-licence-matches.service.js
@@ -1,0 +1,31 @@
+'use strict'
+
+/**
+ * Orchestrates presenting the data for the `/notices/setup/{sessionId}/abstraction-alert/check-licence-matches` page
+ *
+ * @module CheckLicenceMatchesService
+ */
+
+const CheckLicenceMatchesPresenter = require('../../../../presenters/notices/setup/abstraction-alerts/check-licence-matches.presenter.js')
+const SessionModel = require('../../../../models/session.model.js')
+
+/**
+ * Orchestrates presenting the data for the `/notices/setup/{sessionId}/abstraction-alert/check-licence-matches` page
+ *
+ * @param {string} sessionId
+ *
+ * @returns {Promise<object>} - The data formatted for the view template
+ */
+async function go(sessionId) {
+  const session = await SessionModel.query().findById(sessionId)
+
+  const pageData = CheckLicenceMatchesPresenter.go(session)
+
+  return {
+    ...pageData
+  }
+}
+
+module.exports = {
+  go
+}

--- a/app/services/notices/setup/abstraction-alerts/check-licence-matches.service.js
+++ b/app/services/notices/setup/abstraction-alerts/check-licence-matches.service.js
@@ -1,7 +1,7 @@
 'use strict'
 
 /**
- * Orchestrates presenting the data for the `/notices/setup/{sessionId}/abstraction-alert/check-licence-matches` page
+ * Orchestrates presenting the data for the `/notices/setup/{sessionId}/abstraction-alerts/check-licence-matches` page
  *
  * @module CheckLicenceMatchesService
  */
@@ -10,9 +10,9 @@ const CheckLicenceMatchesPresenter = require('../../../../presenters/notices/set
 const SessionModel = require('../../../../models/session.model.js')
 
 /**
- * Orchestrates presenting the data for the `/notices/setup/{sessionId}/abstraction-alert/check-licence-matches` page
+ * Orchestrates presenting the data for the `/notices/setup/{sessionId}/abstraction-alerts/check-licence-matches` page
  *
- * @param {string} sessionId
+ * @param {string} sessionId - The UUID of the current session
  *
  * @returns {Promise<object>} - The data formatted for the view template
  */

--- a/app/views/notices/setup/abstraction-alerts/check-licence-matches.njk
+++ b/app/views/notices/setup/abstraction-alerts/check-licence-matches.njk
@@ -6,10 +6,10 @@
 
 {% block breadcrumbs %}
   {{
-  govukBackLink({
-    text: 'Back',
-    href: backLink
-  })
+    govukBackLink({
+      text: 'Back',
+      href: backLink
+    })
   }}
 {% endblock %}
 

--- a/app/views/notices/setup/abstraction-alerts/check-licence-matches.njk
+++ b/app/views/notices/setup/abstraction-alerts/check-licence-matches.njk
@@ -1,0 +1,24 @@
+{% extends 'layout.njk' %}
+
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+
+{% block breadcrumbs %}
+  {{
+  govukBackLink({
+    text: 'Back',
+    href: backLink
+  })
+  }}
+{% endblock %}
+
+{% block content %}
+  <div>
+    <form method="post">
+      <input type="hidden" name="wrlsCrumb" value="{{wrlsCrumb}}"/>
+
+      {{ govukButton({ text: "Continue", preventDoubleClick: true }) }}
+    </form>
+  </div>
+{% endblock %}

--- a/test/controllers/notices-setup.controller.test.js
+++ b/test/controllers/notices-setup.controller.test.js
@@ -14,6 +14,7 @@ const { postRequestOptions } = require('../support/general.js')
 const AlertThresholdsService = require('../../app/services/notices/setup/abstraction-alerts/alert-thresholds.service.js')
 const AlertTypeService = require('../../app/services/notices/setup/abstraction-alerts/alert-type.service.js')
 const CancelService = require('../../app/services/notices/setup/cancel.service.js')
+const CheckLicenceMatchesService = require('../../app/services/notices/setup/abstraction-alerts/check-licence-matches.service.js')
 const CheckService = require('../../app/services/notices/setup/check.service.js')
 const ConfirmationService = require('../../app/services/notices/setup/confirmation.service.js')
 const DownloadRecipientsService = require('../../app/services/notices/setup/download-recipients.service.js')
@@ -362,6 +363,34 @@ describe('Notices Setup controller', () => {
             expect(response.statusCode).to.equal(200)
             expect(response.payload).to.contain('Alert page')
             expect(response.payload).to.contain('There is a problem')
+          })
+        })
+      })
+    })
+
+    describe('/check-licence-matches', () => {
+      describe('GET', () => {
+        beforeEach(async () => {
+          getOptions = {
+            method: 'GET',
+            url: basePath + `/${session.id}/abstraction-alerts/check-licence-matches`,
+            auth: {
+              strategy: 'session',
+              credentials: { scope: ['returns'] }
+            }
+          }
+
+          Sinon.stub(CheckLicenceMatchesService, 'go').resolves({
+            pageTitle: 'Check licence page'
+          })
+        })
+
+        describe('when a request is valid', () => {
+          it('returns the page successfully', async () => {
+            const response = await server.inject(getOptions)
+
+            expect(response.statusCode).to.equal(200)
+            expect(response.payload).to.contain('Check licence page')
           })
         })
       })

--- a/test/controllers/notices-setup.controller.test.js
+++ b/test/controllers/notices-setup.controller.test.js
@@ -277,7 +277,9 @@ describe('Notices Setup controller', () => {
             const response = await server.inject(postOptions)
 
             expect(response.statusCode).to.equal(302)
-            expect(response.headers.location).to.equal(`/system/notices/setup/${session.id}/abstraction-alerts/check`)
+            expect(response.headers.location).to.equal(
+              `/system/notices/setup/${session.id}/abstraction-alerts/check-licence-matches`
+            )
           })
         })
 

--- a/test/presenters/notices/setup/abstraction-alerts/check-licence-matches.presenter.test.js
+++ b/test/presenters/notices/setup/abstraction-alerts/check-licence-matches.presenter.test.js
@@ -1,0 +1,27 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Thing under test
+const CheckLicenceMatchesPresenter = require('../../../../../app/presenters/notices/setup/abstraction-alerts/check-licence-matches.presenter.js')
+
+describe('Notices Setup - Abstraction Alerts - Check Licence Matches Presenter', () => {
+  let session
+
+  beforeEach(() => {
+    session = {}
+  })
+
+  describe('when called', () => {
+    it('returns page data for the view', () => {
+      const result = CheckLicenceMatchesPresenter.go(session)
+
+      expect(result).to.equal({})
+    })
+  })
+})

--- a/test/services/notices/setup/abstraction-alerts/check-licence-matches.service.test.js
+++ b/test/services/notices/setup/abstraction-alerts/check-licence-matches.service.test.js
@@ -1,0 +1,33 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Test helpers
+const SessionHelper = require('../../../../support/helpers/session.helper.js')
+
+// Thing under test
+const CheckLicenceMatchesService = require('../../../../../app/services/notices/setup/abstraction-alerts/check-licence-matches.service.js')
+
+describe('Notices Setup - Abstraction Alerts - Check Licence Matches Service', () => {
+  let session
+  let sessionData
+
+  beforeEach(async () => {
+    sessionData = {}
+
+    session = await SessionHelper.add({ data: sessionData })
+  })
+
+  describe('when called', () => {
+    it('returns page data for the view', async () => {
+      const result = await CheckLicenceMatchesService.go(session.id)
+
+      expect(result).to.equal({})
+    })
+  })
+})


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5026

We are replacing the legacy notification abstraction alert journey. We are going through page by page and adding roughly similar page for some parts of the journey. With the intention of reusing the existing send notification logic we built previously.

This changes adds the check licence matches scaffolded logic. It adds a basic controller, view, presenter and service to view the page.

The implementation for the page will be added in a later change.