### PR TITLE
Update scaffold presenter test template.

### DIFF
--- a/templates/presenter.test.js
+++ b/templates/presenter.test.js
@@ -13,7 +13,9 @@ const __MODULE_NAME__ = require('__REQUIRE_PATH__')
 describe('__DESCRIBE_LABEL__', () => {
   let session
 
-  beforeEach(() => {})
+  beforeEach(() => {
+    session = {}
+  })
 
   describe('when called', () => {
     it('returns page data for the view', () => {


### PR DESCRIPTION
The presenter test template is not setting the session to an empty object in the before each function.

This change updates the before each in the presenter.test.js template.