### PR TITLE
Feature notificaitons setup abstraction alert check licence matches view

### DIFF
--- a/app/controllers/notices-setup.controller.js
+++ b/app/controllers/notices-setup.controller.js
@@ -142,7 +142,7 @@ async function submitAlertThresholds(request, h) {
     return h.view(`notices/setup/abstraction-alerts/alert-thresholds.view.njk`, pageData)
   }
 
-  return h.redirect(`/system/notices/setup/${sessionId}/abstraction-alerts/check`)
+  return h.redirect(`/system/notices/setup/${sessionId}/abstraction-alerts/check-licence-matches`)
 }
 
 async function submitAlertType(request, h) {

--- a/app/controllers/notices-setup.controller.js
+++ b/app/controllers/notices-setup.controller.js
@@ -9,6 +9,7 @@ const AdHocLicenceService = require('../services/notices/setup/ad-hoc/ad-hoc-lic
 const AlertThresholdsService = require('../services/notices/setup/abstraction-alerts/alert-thresholds.service.js')
 const AlertTypeService = require('../services/notices/setup/abstraction-alerts/alert-type.service.js')
 const CancelService = require('../services/notices/setup/cancel.service.js')
+const CheckLicenceMatchesService = require('../services/notices/setup/abstraction-alerts/check-licence-matches.service.js')
 const CheckService = require('../services/notices/setup/check.service.js')
 const ConfirmationService = require('../services/notices/setup/confirmation.service.js')
 const DownloadRecipientsService = require('../services/notices/setup/download-recipients.service.js')
@@ -64,6 +65,14 @@ async function viewCancel(request, h) {
   const pageData = await CancelService.go(sessionId)
 
   return h.view(`${basePath}/cancel.njk`, pageData)
+}
+
+async function viewCheckLicenceMatches(request, h) {
+  const { sessionId } = request.params
+
+  const pageData = await CheckLicenceMatchesService.go(sessionId)
+
+  return h.view(`notices/setup/abstraction-alerts/check-licence-matches.njk`, pageData)
 }
 
 async function viewConfirmation(request, h) {
@@ -217,9 +226,10 @@ module.exports = {
   viewAlertThresholds,
   viewAlertType,
   viewCancel,
+  viewCheck,
+  viewCheckLicenceMatches,
   viewConfirmation,
   viewLicence,
-  viewCheck,
   viewRemoveLicences,
   viewReturnsPeriod,
   setup,

--- a/app/presenters/notices/setup/abstraction-alerts/check-licence-matches.presenter.js
+++ b/app/presenters/notices/setup/abstraction-alerts/check-licence-matches.presenter.js
@@ -5,6 +5,8 @@
  * @module CheckLicenceMatchesPresenter
  */
 
+const { formatAbstractionPeriod } = require('../../../base.presenter.js')
+
 /**
  * Formats data for the `/notices/setup/{sessionId}/abstraction-alert/check-licence-matches` page
  *
@@ -19,10 +21,38 @@ function go(session) {
   }
 }
 
+function _threshold(licenceMonitoringStation) {
+  return {
+    abstractionPeriod: formatAbstractionPeriod(
+      licenceMonitoringStation.abstraction_period_start_day,
+      licenceMonitoringStation.abstraction_period_start_month,
+      licenceMonitoringStation.abstraction_period_end_month,
+      licenceMonitoringStation.abstraction_period_end_month
+    ),
+    flow: licenceMonitoringStation.restriction_type,
+    threshold: `${licenceMonitoringStation.threshold_value} ${licenceMonitoringStation.threshold_unit}`
+  }
+}
+
 function _licences(alertThresholds, licenceMonitoringStations) {
-  return licenceMonitoringStations.filter((lms) => {
-    return alertThresholds.includes(lms.id)
-  })
+  const grouped = {}
+
+  for (const licenceMonitoringStation of licenceMonitoringStations) {
+    if (alertThresholds.includes(licenceMonitoringStation.id)) {
+      const key = licenceMonitoringStation.licence_ref
+
+      if (!grouped[key]) {
+        grouped[key] = {
+          licenceRef: key,
+          thresholds: []
+        }
+      }
+
+      grouped[key].thresholds.push(_threshold(licenceMonitoringStation))
+    }
+  }
+
+  return Object.values(grouped)
 }
 
 module.exports = {

--- a/app/presenters/notices/setup/abstraction-alerts/check-licence-matches.presenter.js
+++ b/app/presenters/notices/setup/abstraction-alerts/check-licence-matches.presenter.js
@@ -34,6 +34,12 @@ function _threshold(licenceMonitoringStation) {
   }
 }
 
+/**
+ * Groups licence monitoring stations by licence reference and collects threshold data for stations whose IDs match the
+ * provided alert thresholds.
+ *
+ * @private
+ */
 function _licences(alertThresholds, licenceMonitoringStations) {
   const grouped = {}
 

--- a/app/presenters/notices/setup/abstraction-alerts/check-licence-matches.presenter.js
+++ b/app/presenters/notices/setup/abstraction-alerts/check-licence-matches.presenter.js
@@ -8,10 +8,21 @@
 /**
  * Formats data for the `/notices/setup/{sessionId}/abstraction-alert/check-licence-matches` page
  *
+ * @param {module:SessionModel} session - The session instance
+ *
  * @returns {object} - The data formatted for the view template
  */
-function go() {
-  return {}
+function go(session) {
+  const { alertThresholds, licenceMonitoringStations } = session
+  return {
+    licences: _licences(alertThresholds, licenceMonitoringStations)
+  }
+}
+
+function _licences(alertThresholds, licenceMonitoringStations) {
+  return licenceMonitoringStations.filter((lms) => {
+    return alertThresholds.includes(lms.id)
+  })
 }
 
 module.exports = {

--- a/app/presenters/notices/setup/abstraction-alerts/check-licence-matches.presenter.js
+++ b/app/presenters/notices/setup/abstraction-alerts/check-licence-matches.presenter.js
@@ -1,0 +1,19 @@
+'use strict'
+
+/**
+ * Formats data for the `/notices/setup/{sessionId}/abstraction-alert/check-licence-matches` page
+ * @module CheckLicenceMatchesPresenter
+ */
+
+/**
+ * Formats data for the `/notices/setup/{sessionId}/abstraction-alert/check-licence-matches` page
+ *
+ * @returns {object} - The data formatted for the view template
+ */
+function go() {
+  return {}
+}
+
+module.exports = {
+  go
+}

--- a/app/routes/notices-setup.routes.js
+++ b/app/routes/notices-setup.routes.js
@@ -4,6 +4,8 @@ const NoticesSetupController = require('../controllers/notices-setup.controller.
 
 const basePath = '/notices/setup'
 
+const ABSTRACTION_ALERTS_PATH = 'abstraction-alerts'
+
 const routes = [
   {
     method: 'GET',
@@ -31,7 +33,7 @@ const routes = [
   },
   {
     method: 'GET',
-    path: basePath + '/{sessionId}/abstraction-alerts/alert-type',
+    path: basePath + `/{sessionId}/${ABSTRACTION_ALERTS_PATH}/alert-type`,
     options: {
       handler: NoticesSetupController.viewAlertType,
       auth: {
@@ -43,7 +45,7 @@ const routes = [
   },
   {
     method: 'POST',
-    path: basePath + '/{sessionId}/abstraction-alerts/alert-type',
+    path: basePath + `/{sessionId}/${ABSTRACTION_ALERTS_PATH}/alert-type`,
     options: {
       handler: NoticesSetupController.submitAlertType,
       auth: {
@@ -55,7 +57,7 @@ const routes = [
   },
   {
     method: 'GET',
-    path: basePath + '/{sessionId}/abstraction-alerts/alert-thresholds',
+    path: basePath + `/{sessionId}/${ABSTRACTION_ALERTS_PATH}/alert-thresholds`,
     options: {
       handler: NoticesSetupController.viewAlertThresholds,
       auth: {
@@ -67,9 +69,21 @@ const routes = [
   },
   {
     method: 'POST',
-    path: basePath + '/{sessionId}/abstraction-alerts/alert-thresholds',
+    path: basePath + `/{sessionId}/${ABSTRACTION_ALERTS_PATH}/alert-thresholds`,
     options: {
       handler: NoticesSetupController.submitAlertThresholds,
+      auth: {
+        access: {
+          scope: ['returns']
+        }
+      }
+    }
+  },
+  {
+    method: 'GET',
+    path: basePath + `/{sessionId}/${ABSTRACTION_ALERTS_PATH}/check-licence-matches`,
+    options: {
+      handler: NoticesSetupController.viewCheckLicenceMatches,
       auth: {
         access: {
           scope: ['returns']

--- a/app/services/notices/setup/abstraction-alerts/check-licence-matches.service.js
+++ b/app/services/notices/setup/abstraction-alerts/check-licence-matches.service.js
@@ -1,0 +1,31 @@
+'use strict'
+
+/**
+ * Orchestrates presenting the data for the `/notices/setup/{sessionId}/abstraction-alert/check-licence-matches` page
+ *
+ * @module CheckLicenceMatchesService
+ */
+
+const CheckLicenceMatchesPresenter = require('../../../../presenters/notices/setup/abstraction-alerts/check-licence-matches.presenter.js')
+const SessionModel = require('../../../../models/session.model.js')
+
+/**
+ * Orchestrates presenting the data for the `/notices/setup/{sessionId}/abstraction-alert/check-licence-matches` page
+ *
+ * @param {string} sessionId
+ *
+ * @returns {Promise<object>} - The data formatted for the view template
+ */
+async function go(sessionId) {
+  const session = await SessionModel.query().findById(sessionId)
+
+  const pageData = CheckLicenceMatchesPresenter.go(session)
+
+  return {
+    ...pageData
+  }
+}
+
+module.exports = {
+  go
+}

--- a/app/services/notices/setup/abstraction-alerts/check-licence-matches.service.js
+++ b/app/services/notices/setup/abstraction-alerts/check-licence-matches.service.js
@@ -22,6 +22,7 @@ async function go(sessionId) {
   const pageData = CheckLicenceMatchesPresenter.go(session)
 
   return {
+    activeNavBar: 'manage',
     ...pageData
   }
 }

--- a/app/views/notices/setup/abstraction-alerts/check-licence-matches.njk
+++ b/app/views/notices/setup/abstraction-alerts/check-licence-matches.njk
@@ -1,0 +1,24 @@
+{% extends 'layout.njk' %}
+
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+
+{% block breadcrumbs %}
+  {{
+  govukBackLink({
+    text: 'Back',
+    href: backLink
+  })
+  }}
+{% endblock %}
+
+{% block content %}
+  <div>
+    <form method="post">
+      <input type="hidden" name="wrlsCrumb" value="{{wrlsCrumb}}"/>
+
+      {{ govukButton({ text: "Continue", preventDoubleClick: true }) }}
+    </form>
+  </div>
+{% endblock %}

--- a/test/controllers/notices-setup.controller.test.js
+++ b/test/controllers/notices-setup.controller.test.js
@@ -14,6 +14,7 @@ const { postRequestOptions } = require('../support/general.js')
 const AlertThresholdsService = require('../../app/services/notices/setup/abstraction-alerts/alert-thresholds.service.js')
 const AlertTypeService = require('../../app/services/notices/setup/abstraction-alerts/alert-type.service.js')
 const CancelService = require('../../app/services/notices/setup/cancel.service.js')
+const CheckLicenceMatchesService = require('../../app/services/notices/setup/abstraction-alerts/check-licence-matches.service.js')
 const CheckService = require('../../app/services/notices/setup/check.service.js')
 const ConfirmationService = require('../../app/services/notices/setup/confirmation.service.js')
 const DownloadRecipientsService = require('../../app/services/notices/setup/download-recipients.service.js')
@@ -362,6 +363,34 @@ describe('Notices Setup controller', () => {
             expect(response.statusCode).to.equal(200)
             expect(response.payload).to.contain('Alert page')
             expect(response.payload).to.contain('There is a problem')
+          })
+        })
+      })
+    })
+
+    describe('/check-licence-matches', () => {
+      describe('GET', () => {
+        beforeEach(async () => {
+          getOptions = {
+            method: 'GET',
+            url: basePath + `/${session.id}/abstraction-alerts/check-licence-matches`,
+            auth: {
+              strategy: 'session',
+              credentials: { scope: ['returns'] }
+            }
+          }
+
+          Sinon.stub(CheckLicenceMatchesService, 'go').resolves({
+            pageTitle: 'Check licence page'
+          })
+        })
+
+        describe('when a request is valid', () => {
+          it('returns the page successfully', async () => {
+            const response = await server.inject(getOptions)
+
+            expect(response.statusCode).to.equal(200)
+            expect(response.payload).to.contain('Check licence page')
           })
         })
       })

--- a/test/controllers/notices-setup.controller.test.js
+++ b/test/controllers/notices-setup.controller.test.js
@@ -277,7 +277,9 @@ describe('Notices Setup controller', () => {
             const response = await server.inject(postOptions)
 
             expect(response.statusCode).to.equal(302)
-            expect(response.headers.location).to.equal(`/system/notices/setup/${session.id}/abstraction-alerts/check`)
+            expect(response.headers.location).to.equal(
+              `/system/notices/setup/${session.id}/abstraction-alerts/check-licence-matches`
+            )
           })
         })
 

--- a/test/fixtures/abstraction-alert-session-data.fixture.js
+++ b/test/fixtures/abstraction-alert-session-data.fixture.js
@@ -11,6 +11,9 @@ const { generateUUID } = require('../../app/lib/general.lib.js')
  * @returns {object} an object representing the monitoring stations service
  */
 function monitoringStation() {
+  const licenceWithMultipleThresholdsLicenceRef = generateLicenceRef()
+  const licenceWithMultipleThresholdsLicenceId = generateUUID()
+
   return {
     licenceMonitoringStations: [
       {
@@ -36,8 +39,8 @@ function monitoringStation() {
         abstraction_period_start_day: 1,
         abstraction_period_start_month: 1,
         id: '1',
-        licence_id: generateUUID(),
-        licence_ref: generateLicenceRef(),
+        licence_id: licenceWithMultipleThresholdsLicenceId,
+        licence_ref: licenceWithMultipleThresholdsLicenceRef,
         licence_version_purpose_condition_id: generateUUID(),
         measure_type: 'level',
         restriction_type: 'reduce',
@@ -46,6 +49,23 @@ function monitoringStation() {
         status_updated_at: null,
         threshold_unit: 'm3/s',
         threshold_value: 100
+      },
+      {
+        abstraction_period_end_day: 28,
+        abstraction_period_end_month: 4,
+        abstraction_period_start_day: 4,
+        abstraction_period_start_month: 2,
+        id: '2',
+        licence_id: licenceWithMultipleThresholdsLicenceId,
+        licence_ref: licenceWithMultipleThresholdsLicenceRef,
+        licence_version_purpose_condition_id: generateUUID(),
+        measure_type: 'level',
+        restriction_type: 'stop',
+        start_date: new Date('2022-01-01').toISOString(),
+        status: 'resume',
+        status_updated_at: null,
+        threshold_unit: 'm',
+        threshold_value: 1000
       }
     ],
     monitoringStationId: generateUUID(),

--- a/test/presenters/notices/setup/abstraction-alerts/alert-thresholds.presenter.test.js
+++ b/test/presenters/notices/setup/abstraction-alerts/alert-thresholds.presenter.test.js
@@ -44,6 +44,14 @@ describe('Notices Setup - Abstraction Alerts - Alert Thresholds Presenter', () =
             },
             text: '100 m3/s',
             value: '1'
+          },
+          {
+            checked: false,
+            hint: {
+              text: 'Level thresholds for this station (m)'
+            },
+            text: '1000 m',
+            value: '2'
           }
         ]
       })
@@ -77,6 +85,14 @@ describe('Notices Setup - Abstraction Alerts - Alert Thresholds Presenter', () =
               },
               text: '100 m3/s',
               value: '1'
+            },
+            {
+              checked: false,
+              hint: {
+                text: 'Level thresholds for this station (m)'
+              },
+              text: '1000 m',
+              value: '2'
             }
           ])
         })

--- a/test/presenters/notices/setup/abstraction-alerts/check-licence-matches.presenter.test.js
+++ b/test/presenters/notices/setup/abstraction-alerts/check-licence-matches.presenter.test.js
@@ -1,0 +1,27 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Thing under test
+const CheckLicenceMatchesPresenter = require('../../../../../app/presenters/notices/setup/abstraction-alerts/check-licence-matches.presenter.js')
+
+describe('Notices Setup - Abstraction Alerts - Check Licence Matches Presenter', () => {
+  let session
+
+  beforeEach(() => {
+    session = {}
+  })
+
+  describe('when called', () => {
+    it('returns page data for the view', () => {
+      const result = CheckLicenceMatchesPresenter.go(session)
+
+      expect(result).to.equal({})
+    })
+  })
+})

--- a/test/presenters/notices/setup/abstraction-alerts/check-licence-matches.presenter.test.js
+++ b/test/presenters/notices/setup/abstraction-alerts/check-licence-matches.presenter.test.js
@@ -7,14 +7,22 @@ const Code = require('@hapi/code')
 const { describe, it, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
+// Test helpers
+const AbstractionAlertSessionData = require('../../../../fixtures/abstraction-alert-session-data.fixture.js')
+
 // Thing under test
 const CheckLicenceMatchesPresenter = require('../../../../../app/presenters/notices/setup/abstraction-alerts/check-licence-matches.presenter.js')
 
 describe('Notices Setup - Abstraction Alerts - Check Licence Matches Presenter', () => {
+  let abstractionAlertSessionData
   let session
 
   beforeEach(() => {
-    session = {}
+    abstractionAlertSessionData = AbstractionAlertSessionData.monitoringStation()
+    session = {
+      ...abstractionAlertSessionData,
+      alertThresholds: [abstractionAlertSessionData.licenceMonitoringStations[0].id]
+    }
   })
 
   describe('when called', () => {
@@ -22,6 +30,12 @@ describe('Notices Setup - Abstraction Alerts - Check Licence Matches Presenter',
       const result = CheckLicenceMatchesPresenter.go(session)
 
       expect(result).to.equal({})
+    })
+
+    it.only('returns the selected licence monitoring stations from the "alertThresholds"', () => {
+      const result = CheckLicenceMatchesPresenter.go(session)
+
+      expect(result.licences).to.equal([abstractionAlertSessionData.licenceMonitoringStations[0]])
     })
   })
 })

--- a/test/services/notices/setup/abstraction-alerts/alert-thresholds.service.test.js
+++ b/test/services/notices/setup/abstraction-alerts/alert-thresholds.service.test.js
@@ -49,6 +49,14 @@ describe('Notices Setup - Abstraction Alerts - Alert Thresholds Service', () => 
             },
             text: '100 m3/s',
             value: '1'
+          },
+          {
+            checked: false,
+            hint: {
+              text: 'Level thresholds for this station (m)'
+            },
+            text: '1000 m',
+            value: '2'
           }
         ]
       })

--- a/test/services/notices/setup/abstraction-alerts/check-licence-matches.service.test.js
+++ b/test/services/notices/setup/abstraction-alerts/check-licence-matches.service.test.js
@@ -8,17 +8,27 @@ const { describe, it, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
+const AbstractionAlertSessionData = require('../../../../fixtures/abstraction-alert-session-data.fixture.js')
 const SessionHelper = require('../../../../support/helpers/session.helper.js')
 
 // Thing under test
 const CheckLicenceMatchesService = require('../../../../../app/services/notices/setup/abstraction-alerts/check-licence-matches.service.js')
 
 describe('Notices Setup - Abstraction Alerts - Check Licence Matches Service', () => {
+  let abstractionAlertSessionData
+  let licenceWithThreshold
   let session
   let sessionData
 
   beforeEach(async () => {
-    sessionData = {}
+    abstractionAlertSessionData = AbstractionAlertSessionData.monitoringStation()
+
+    licenceWithThreshold = abstractionAlertSessionData.licenceMonitoringStations[0]
+
+    sessionData = {
+      ...abstractionAlertSessionData,
+      alertThresholds: [licenceWithThreshold.id]
+    }
 
     session = await SessionHelper.add({ data: sessionData })
   })
@@ -27,7 +37,21 @@ describe('Notices Setup - Abstraction Alerts - Check Licence Matches Service', (
     it('returns page data for the view', async () => {
       const result = await CheckLicenceMatchesService.go(session.id)
 
-      expect(result).to.equal({})
+      expect(result).to.equal({
+        activeNavBar: 'manage',
+        licences: [
+          {
+            licenceRef: licenceWithThreshold.licence_ref,
+            thresholds: [
+              {
+                abstractionPeriod: '1 February to 1 January',
+                flow: 'reduce',
+                threshold: '1000 m'
+              }
+            ]
+          }
+        ]
+      })
     })
   })
 })

--- a/test/services/notices/setup/abstraction-alerts/check-licence-matches.service.test.js
+++ b/test/services/notices/setup/abstraction-alerts/check-licence-matches.service.test.js
@@ -1,0 +1,33 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Test helpers
+const SessionHelper = require('../../../../support/helpers/session.helper.js')
+
+// Thing under test
+const CheckLicenceMatchesService = require('../../../../../app/services/notices/setup/abstraction-alerts/check-licence-matches.service.js')
+
+describe('Notices Setup - Abstraction Alerts - Check Licence Matches Service', () => {
+  let session
+  let sessionData
+
+  beforeEach(async () => {
+    sessionData = {}
+
+    session = await SessionHelper.add({ data: sessionData })
+  })
+
+  describe('when called', () => {
+    it('returns page data for the view', async () => {
+      const result = await CheckLicenceMatchesService.go(session.id)
+
+      expect(result).to.equal({})
+    })
+  })
+})

--- a/test/services/notices/setup/abstraction-alerts/submit-alert-thresholds.service.test.js
+++ b/test/services/notices/setup/abstraction-alerts/submit-alert-thresholds.service.test.js
@@ -77,6 +77,14 @@ describe('Notices Setup - Abstraction Alerts - Alert Thresholds Submit Service',
             },
             text: '100 m3/s',
             value: '1'
+          },
+          {
+            checked: false,
+            hint: {
+              text: 'Level thresholds for this station (m)'
+            },
+            text: '1000 m',
+            value: '2'
           }
         ]
       })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5026

We are replacing the legacy notification abstraction alert journey. We are going through page by page and adding roughly similar page for some parts of the journey. With the intention of reusing the existing send notification logic we built previously.

This changes updates the check licence matches controller, view, presenter and service to render the licences previously selected on the alert thresholds page, with the same information as the legacy page. 

When multiple thresholds for a licence are present they are grouped by licence, but show their own abstraction period, flow and level restrictions and the last alert type.

The remove / exclude logic will be added in another change.