### PR TITLE
Update notifications setup abstraction thresholds view

### DIFF
--- a/app/presenters/notices/setup/abstraction-alerts/alert-thresholds.presenter.js
+++ b/app/presenters/notices/setup/abstraction-alerts/alert-thresholds.presenter.js
@@ -19,7 +19,7 @@ function go(session) {
     backLink: `/system/notices/setup/${session.id}/abstraction-alerts/alert-type`,
     caption: session.monitoringStationName,
     pageTitle: 'Which thresholds do you need to send an alert for?',
-    thresholdOptions: _thresholdOptions(session.licenceMonitoringStations, session.alertThresholds, session.alertType)
+    thresholdOptions: _thresholdOptions(session.licenceMonitoringStations, session.alertType, session.alertThresholds)
   }
 }
 
@@ -40,7 +40,7 @@ function _relevantLicenceMonitoringStations(stations, alertType) {
   })
 }
 
-function _thresholdOptions(licenceMonitoringStations, alertThresholds = [], alertType) {
+function _thresholdOptions(licenceMonitoringStations, alertType, alertThresholds = []) {
   const relevantLicenceMonitoringStations = _relevantLicenceMonitoringStations(licenceMonitoringStations, alertType)
 
   return relevantLicenceMonitoringStations.map((licenceMonitoringStation) => {

--- a/app/presenters/notices/setup/abstraction-alerts/alert-thresholds.presenter.js
+++ b/app/presenters/notices/setup/abstraction-alerts/alert-thresholds.presenter.js
@@ -30,13 +30,12 @@ function go(session) {
  *
  * @private
  */
-function _relevantLicenceMonitoringStations(stations, alertType) {
-  return stations.filter((station) => {
-    if (alertType === 'stop' || alertType === 'reduce') {
-      return station.restriction_type === alertType
-    }
-
-    return Boolean(station.restriction_type)
+function _relevantLicenceMonitoringStations(licenceMonitoringStations, alertType) {
+  if (alertType !== 'stop' && alertType !== 'reduce') {
+    return licenceMonitoringStations
+  }
+  return licenceMonitoringStations.filter((licenceMonitoringStation) => {
+    return licenceMonitoringStation.restriction_type === alertType
   })
 }
 

--- a/app/presenters/notices/setup/abstraction-alerts/alert-thresholds.presenter.js
+++ b/app/presenters/notices/setup/abstraction-alerts/alert-thresholds.presenter.js
@@ -34,6 +34,7 @@ function _relevantLicenceMonitoringStations(licenceMonitoringStations, alertType
   if (alertType !== 'stop' && alertType !== 'reduce') {
     return licenceMonitoringStations
   }
+
   return licenceMonitoringStations.filter((licenceMonitoringStation) => {
     return licenceMonitoringStation.restriction_type === alertType
   })

--- a/app/presenters/notices/setup/abstraction-alerts/alert-thresholds.presenter.js
+++ b/app/presenters/notices/setup/abstraction-alerts/alert-thresholds.presenter.js
@@ -19,12 +19,31 @@ function go(session) {
     backLink: `/system/notices/setup/${session.id}/abstraction-alerts/alert-type`,
     caption: session.monitoringStationName,
     pageTitle: 'Which thresholds do you need to send an alert for?',
-    thresholdOptions: _thresholdOptions(session.licenceMonitoringStations, session.alertThresholds)
+    thresholdOptions: _thresholdOptions(session.licenceMonitoringStations, session.alertThresholds, session.alertType)
   }
 }
 
-function _thresholdOptions(licenceMonitoringStations, alertThresholds = []) {
-  return licenceMonitoringStations.map((licenceMonitoringStation) => {
+/**
+ * Filters licence monitoring stations based on alert type.
+ *
+ * When the alert type is not 'stop' or 'reduce', all stations with any restriction are included.
+ *
+ * @private
+ */
+function _relevantLicenceMonitoringStations(stations, alertType) {
+  return stations.filter((station) => {
+    if (alertType === 'stop' || alertType === 'reduce') {
+      return station.restriction_type === alertType
+    }
+
+    return Boolean(station.restriction_type)
+  })
+}
+
+function _thresholdOptions(licenceMonitoringStations, alertThresholds = [], alertType) {
+  const relevantLicenceMonitoringStations = _relevantLicenceMonitoringStations(licenceMonitoringStations, alertType)
+
+  return relevantLicenceMonitoringStations.map((licenceMonitoringStation) => {
     return {
       checked: alertThresholds.includes(licenceMonitoringStation.id),
       value: licenceMonitoringStation.id,

--- a/test/fixtures/abstraction-alert-session-data.fixture.js
+++ b/test/fixtures/abstraction-alert-session-data.fixture.js
@@ -3,6 +3,62 @@
 const { generateLicenceRef } = require('../support/helpers/licence.helper.js')
 const { generateUUID } = require('../../app/lib/general.lib.js')
 
+function licenceMonitoringStations() {
+  return [
+    {
+      abstraction_period_end_day: 1,
+      abstraction_period_end_month: 1,
+      abstraction_period_start_day: 1,
+      abstraction_period_start_month: 2,
+      id: '0',
+      licence_id: generateUUID(),
+      licence_ref: generateLicenceRef(),
+      licence_version_purpose_condition_id: null,
+      measure_type: 'flow',
+      restriction_type: 'reduce',
+      start_date: new Date('2022-01-01').toISOString(),
+      status: 'resume',
+      status_updated_at: null,
+      threshold_unit: 'm',
+      threshold_value: 1000
+    },
+    {
+      abstraction_period_end_day: 31,
+      abstraction_period_end_month: 3,
+      abstraction_period_start_day: 1,
+      abstraction_period_start_month: 1,
+      id: '1',
+      licence_id: generateUUID(),
+      licence_ref: generateLicenceRef(),
+      licence_version_purpose_condition_id: generateUUID(),
+      measure_type: 'flow',
+      restriction_type: 'stop',
+      start_date: new Date('2022-01-01').toISOString(),
+      status: 'resume',
+      status_updated_at: null,
+      threshold_unit: 'm3/s',
+      threshold_value: 100
+    },
+    {
+      abstraction_period_end_day: 31,
+      abstraction_period_end_month: 3,
+      abstraction_period_start_day: 1,
+      abstraction_period_start_month: 1,
+      id: '2',
+      licence_id: generateUUID(),
+      licence_ref: generateLicenceRef(),
+      licence_version_purpose_condition_id: generateUUID(),
+      measure_type: 'level',
+      restriction_type: 'stop',
+      start_date: new Date('2022-01-01').toISOString(),
+      status: 'resume',
+      status_updated_at: null,
+      threshold_unit: 'm',
+      threshold_value: 100
+    }
+  ]
+}
+
 /**
  * Represents a complete response from `MonitoringStationService`
  *
@@ -12,42 +68,7 @@ const { generateUUID } = require('../../app/lib/general.lib.js')
  */
 function monitoringStation() {
   return {
-    licenceMonitoringStations: [
-      {
-        abstraction_period_end_day: 1,
-        abstraction_period_end_month: 1,
-        abstraction_period_start_day: 1,
-        abstraction_period_start_month: 2,
-        id: '0',
-        licence_id: generateUUID(),
-        licence_ref: generateLicenceRef(),
-        licence_version_purpose_condition_id: null,
-        measure_type: 'flow',
-        restriction_type: 'reduce',
-        start_date: new Date('2022-01-01').toISOString(),
-        status: 'resume',
-        status_updated_at: null,
-        threshold_unit: 'm',
-        threshold_value: 1000
-      },
-      {
-        abstraction_period_end_day: 31,
-        abstraction_period_end_month: 3,
-        abstraction_period_start_day: 1,
-        abstraction_period_start_month: 1,
-        id: '1',
-        licence_id: generateUUID(),
-        licence_ref: generateLicenceRef(),
-        licence_version_purpose_condition_id: generateUUID(),
-        measure_type: 'level',
-        restriction_type: 'reduce',
-        start_date: new Date('2022-01-01').toISOString(),
-        status: 'resume',
-        status_updated_at: null,
-        threshold_unit: 'm3/s',
-        threshold_value: 100
-      }
-    ],
+    licenceMonitoringStations: licenceMonitoringStations(),
     monitoringStationId: generateUUID(),
     monitoringStationName: 'Death star'
   }

--- a/test/presenters/notices/setup/abstraction-alerts/alert-thresholds.presenter.test.js
+++ b/test/presenters/notices/setup/abstraction-alerts/alert-thresholds.presenter.test.js
@@ -126,7 +126,7 @@ describe('Notices Setup - Abstraction Alerts - Alert Thresholds Presenter', () =
           }
         })
 
-        it('returns page data for the view, with only the thresholds with stop restrictions', () => {
+        it('returns page data for the view, with only the thresholds with reduce restrictions', () => {
           const result = AlertThresholdsPresenter.go(session)
 
           expect(result.thresholdOptions).to.equal([
@@ -142,51 +142,10 @@ describe('Notices Setup - Abstraction Alerts - Alert Thresholds Presenter', () =
         })
       })
 
-      describe('and the "alertType" is "warning" ', () => {
+      describe('"and the alert type is not "stop" or "reduce"', () => {
         beforeEach(() => {
           session = {
-            ...AbstractionAlertSessionData.monitoringStation(),
-            alertType: 'warning'
-          }
-        })
-
-        it('returns page data for the view, with all the thresholds', () => {
-          const result = AlertThresholdsPresenter.go(session)
-
-          expect(result.thresholdOptions).to.equal([
-            {
-              checked: false,
-              hint: {
-                text: 'Flow thresholds for this station (m)'
-              },
-              text: '1000 m',
-              value: '0'
-            },
-            {
-              checked: false,
-              hint: {
-                text: 'Flow thresholds for this station (m3/s)'
-              },
-              text: '100 m3/s',
-              value: '1'
-            },
-            {
-              checked: false,
-              hint: {
-                text: 'Level thresholds for this station (m)'
-              },
-              text: '100 m',
-              value: '2'
-            }
-          ])
-        })
-      })
-
-      describe('and the "alertType" is "resume" ', () => {
-        beforeEach(() => {
-          session = {
-            ...AbstractionAlertSessionData.monitoringStation(),
-            alertType: 'resume'
+            ...AbstractionAlertSessionData.monitoringStation()
           }
         })
 

--- a/test/presenters/notices/setup/abstraction-alerts/alert-thresholds.presenter.test.js
+++ b/test/presenters/notices/setup/abstraction-alerts/alert-thresholds.presenter.test.js
@@ -17,7 +17,10 @@ describe('Notices Setup - Abstraction Alerts - Alert Thresholds Presenter', () =
   let session
 
   beforeEach(() => {
-    session = AbstractionAlertSessionData.monitoringStation()
+    session = {
+      ...AbstractionAlertSessionData.monitoringStation(),
+      alertType: 'stop'
+    }
   })
 
   describe('when called', () => {
@@ -32,18 +35,18 @@ describe('Notices Setup - Abstraction Alerts - Alert Thresholds Presenter', () =
           {
             checked: false,
             hint: {
-              text: 'Flow thresholds for this station (m)'
+              text: 'Flow thresholds for this station (m3/s)'
             },
-            text: '1000 m',
-            value: '0'
+            text: '100 m3/s',
+            value: '1'
           },
           {
             checked: false,
             hint: {
-              text: 'Level thresholds for this station (m3/s)'
+              text: 'Level thresholds for this station (m)'
             },
-            text: '100 m3/s',
-            value: '1'
+            text: '100 m',
+            value: '2'
           }
         ]
       })
@@ -54,7 +57,8 @@ describe('Notices Setup - Abstraction Alerts - Alert Thresholds Presenter', () =
         beforeEach(() => {
           session = {
             ...AbstractionAlertSessionData.monitoringStation(),
-            alertThresholds: ['0']
+            alertThresholds: ['1'],
+            alertType: 'stop'
           }
         })
 
@@ -65,6 +69,94 @@ describe('Notices Setup - Abstraction Alerts - Alert Thresholds Presenter', () =
             {
               checked: true,
               hint: {
+                text: 'Flow thresholds for this station (m3/s)'
+              },
+              text: '100 m3/s',
+              value: '1'
+            },
+            {
+              checked: false,
+              hint: {
+                text: 'Level thresholds for this station (m)'
+              },
+              text: '100 m',
+              value: '2'
+            }
+          ])
+        })
+      })
+
+      describe('and the "alertType" is "stop" ', () => {
+        beforeEach(() => {
+          session = {
+            ...AbstractionAlertSessionData.monitoringStation(),
+            alertType: 'stop'
+          }
+        })
+
+        it('returns page data for the view, with only the thresholds with stop restrictions', () => {
+          const result = AlertThresholdsPresenter.go(session)
+
+          expect(result.thresholdOptions).to.equal([
+            {
+              checked: false,
+              hint: {
+                text: 'Flow thresholds for this station (m3/s)'
+              },
+              text: '100 m3/s',
+              value: '1'
+            },
+            {
+              checked: false,
+              hint: {
+                text: 'Level thresholds for this station (m)'
+              },
+              text: '100 m',
+              value: '2'
+            }
+          ])
+        })
+      })
+
+      describe('and the "alertType" is "reduce" ', () => {
+        beforeEach(() => {
+          session = {
+            ...AbstractionAlertSessionData.monitoringStation(),
+            alertType: 'reduce'
+          }
+        })
+
+        it('returns page data for the view, with only the thresholds with stop restrictions', () => {
+          const result = AlertThresholdsPresenter.go(session)
+
+          expect(result.thresholdOptions).to.equal([
+            {
+              checked: false,
+              hint: {
+                text: 'Flow thresholds for this station (m)'
+              },
+              text: '1000 m',
+              value: '0'
+            }
+          ])
+        })
+      })
+
+      describe('and the "alertType" is "warning" ', () => {
+        beforeEach(() => {
+          session = {
+            ...AbstractionAlertSessionData.monitoringStation(),
+            alertType: 'warning'
+          }
+        })
+
+        it('returns page data for the view, with all the thresholds', () => {
+          const result = AlertThresholdsPresenter.go(session)
+
+          expect(result.thresholdOptions).to.equal([
+            {
+              checked: false,
+              hint: {
                 text: 'Flow thresholds for this station (m)'
               },
               text: '1000 m',
@@ -73,10 +165,58 @@ describe('Notices Setup - Abstraction Alerts - Alert Thresholds Presenter', () =
             {
               checked: false,
               hint: {
-                text: 'Level thresholds for this station (m3/s)'
+                text: 'Flow thresholds for this station (m3/s)'
               },
               text: '100 m3/s',
               value: '1'
+            },
+            {
+              checked: false,
+              hint: {
+                text: 'Level thresholds for this station (m)'
+              },
+              text: '100 m',
+              value: '2'
+            }
+          ])
+        })
+      })
+
+      describe('and the "alertType" is "resume" ', () => {
+        beforeEach(() => {
+          session = {
+            ...AbstractionAlertSessionData.monitoringStation(),
+            alertType: 'resume'
+          }
+        })
+
+        it('returns page data for the view, with all the thresholds', () => {
+          const result = AlertThresholdsPresenter.go(session)
+
+          expect(result.thresholdOptions).to.equal([
+            {
+              checked: false,
+              hint: {
+                text: 'Flow thresholds for this station (m)'
+              },
+              text: '1000 m',
+              value: '0'
+            },
+            {
+              checked: false,
+              hint: {
+                text: 'Flow thresholds for this station (m3/s)'
+              },
+              text: '100 m3/s',
+              value: '1'
+            },
+            {
+              checked: false,
+              hint: {
+                text: 'Level thresholds for this station (m)'
+              },
+              text: '100 m',
+              value: '2'
             }
           ])
         })

--- a/test/presenters/notices/setup/abstraction-alerts/alert-type.presenter.test.js
+++ b/test/presenters/notices/setup/abstraction-alerts/alert-type.presenter.test.js
@@ -64,5 +64,83 @@ describe('Notices - Setup - Abstraction Alerts - Alert Type Presenter', () => {
         pageTitle: 'Select the type of alert you need to send'
       })
     })
+
+    describe('and there is a previous selection', () => {
+      describe('and the selection was "warning', () => {
+        beforeEach(() => {
+          sessionData.alertType = 'warning'
+        })
+
+        it('returns page data for the view, with the option selected', () => {
+          const result = AlertTypePresenter.go(sessionData)
+
+          expect(result.alertTypeOptions[0]).to.equal({
+            checked: true,
+            hint: {
+              text: 'Tell licence holders they may need to reduce or stop water abstraction soon.'
+            },
+            text: 'Warning',
+            value: 'warning'
+          })
+        })
+      })
+
+      describe('and the selection was "reduce', () => {
+        beforeEach(() => {
+          sessionData.alertType = 'reduce'
+        })
+
+        it('returns page data for the view, with the option selected', () => {
+          const result = AlertTypePresenter.go(sessionData)
+
+          expect(result.alertTypeOptions[1]).to.equal({
+            checked: true,
+            hint: {
+              text: 'Tell licence holders they can take water at a reduced amount.'
+            },
+            text: 'Reduce',
+            value: 'reduce'
+          })
+        })
+      })
+
+      describe('and the selection was "stop', () => {
+        beforeEach(() => {
+          sessionData.alertType = 'stop'
+        })
+
+        it('returns page data for the view, with the option selected', () => {
+          const result = AlertTypePresenter.go(sessionData)
+
+          expect(result.alertTypeOptions[2]).to.equal({
+            checked: true,
+            hint: {
+              text: 'Tell licence holders they must stop taking water.'
+            },
+            text: 'Stop',
+            value: 'stop'
+          })
+        })
+      })
+
+      describe('and the selection was "resume', () => {
+        beforeEach(() => {
+          sessionData.alertType = 'resume'
+        })
+
+        it('returns page data for the view, with the option selected', () => {
+          const result = AlertTypePresenter.go(sessionData)
+
+          expect(result.alertTypeOptions[3]).to.equal({
+            checked: true,
+            hint: {
+              text: 'Tell licence holders they can take water at the normal amount.'
+            },
+            text: 'Resume',
+            value: 'resume'
+          })
+        })
+      })
+    })
   })
 })

--- a/test/services/notices/setup/abstraction-alerts/alert-thresholds.service.test.js
+++ b/test/services/notices/setup/abstraction-alerts/alert-thresholds.service.test.js
@@ -19,7 +19,10 @@ describe('Notices Setup - Abstraction Alerts - Alert Thresholds Service', () => 
   let sessionData
 
   beforeEach(async () => {
-    sessionData = AbstractionAlertSessionData.monitoringStation()
+    sessionData = {
+      ...AbstractionAlertSessionData.monitoringStation(),
+      alertType: 'stop'
+    }
 
     session = await SessionHelper.add({ data: sessionData })
   })
@@ -37,18 +40,18 @@ describe('Notices Setup - Abstraction Alerts - Alert Thresholds Service', () => 
           {
             checked: false,
             hint: {
-              text: 'Flow thresholds for this station (m)'
+              text: 'Flow thresholds for this station (m3/s)'
             },
-            text: '1000 m',
-            value: '0'
+            text: '100 m3/s',
+            value: '1'
           },
           {
             checked: false,
             hint: {
-              text: 'Level thresholds for this station (m3/s)'
+              text: 'Level thresholds for this station (m)'
             },
-            text: '100 m3/s',
-            value: '1'
+            text: '100 m',
+            value: '2'
           }
         ]
       })

--- a/test/services/notices/setup/abstraction-alerts/submit-alert-thresholds.service.test.js
+++ b/test/services/notices/setup/abstraction-alerts/submit-alert-thresholds.service.test.js
@@ -21,7 +21,11 @@ describe('Notices Setup - Abstraction Alerts - Alert Thresholds Submit Service',
 
   beforeEach(async () => {
     payload = { thresholds: [] }
-    sessionData = AbstractionAlertSessionData.monitoringStation()
+
+    sessionData = {
+      ...AbstractionAlertSessionData.monitoringStation(),
+      alertType: 'stop'
+    }
 
     session = await SessionHelper.add({ data: sessionData })
   })
@@ -65,18 +69,18 @@ describe('Notices Setup - Abstraction Alerts - Alert Thresholds Submit Service',
           {
             checked: false,
             hint: {
-              text: 'Flow thresholds for this station (m)'
+              text: 'Flow thresholds for this station (m3/s)'
             },
-            text: '1000 m',
-            value: '0'
+            text: '100 m3/s',
+            value: '1'
           },
           {
             checked: false,
             hint: {
-              text: 'Level thresholds for this station (m3/s)'
+              text: 'Level thresholds for this station (m)'
             },
-            text: '100 m3/s',
-            value: '1'
+            text: '100 m',
+            value: '2'
           }
         ]
       })

--- a/test/services/notices/setup/abstraction-alerts/submit-alert-thresholds.service.test.js
+++ b/test/services/notices/setup/abstraction-alerts/submit-alert-thresholds.service.test.js
@@ -21,7 +21,6 @@ describe('Notices Setup - Abstraction Alerts - Alert Thresholds Submit Service',
 
   describe('when called', () => {
     beforeEach(async () => {
-
       sessionData = {
         ...AbstractionAlertSessionData.monitoringStation(),
         alertType: 'stop'
@@ -72,7 +71,13 @@ describe('Notices Setup - Abstraction Alerts - Alert Thresholds Submit Service',
   describe('when validation fails', () => {
     describe('and there are no previous "alertThresholds"', () => {
       beforeEach(async () => {
-        sessionData = AbstractionAlertSessionData.monitoringStation()
+        const abstractionAlertSessionData = AbstractionAlertSessionData.monitoringStation()
+
+        sessionData = {
+          ...abstractionAlertSessionData,
+          alertThresholds: [abstractionAlertSessionData.licenceMonitoringStations[0].id],
+          alertType: 'stop'
+        }
 
         payload = {}
 
@@ -90,19 +95,19 @@ describe('Notices Setup - Abstraction Alerts - Alert Thresholds Submit Service',
           thresholdOptions: [
             {
               checked: false,
-              value: '0',
-              text: '1000 m',
               hint: {
-                text: 'Flow thresholds for this station (m)'
-              }
+                text: 'Flow thresholds for this station (m3/s)'
+              },
+              text: '100 m3/s',
+              value: '1'
             },
             {
               checked: false,
-              value: '1',
-              text: '100 m3/s',
               hint: {
-                text: 'Level thresholds for this station (m3/s)'
-              }
+                text: 'Level thresholds for this station (m)'
+              },
+              text: '100 m',
+              value: '2'
             }
           ]
         })
@@ -115,7 +120,8 @@ describe('Notices Setup - Abstraction Alerts - Alert Thresholds Submit Service',
 
         sessionData = {
           ...abstractionAlertSessionData,
-          alertThresholds: [abstractionAlertSessionData.licenceMonitoringStations[0].id]
+          alertThresholds: [abstractionAlertSessionData.licenceMonitoringStations[0].id],
+          alertType: 'stop'
         }
 
         payload = {}
@@ -134,19 +140,19 @@ describe('Notices Setup - Abstraction Alerts - Alert Thresholds Submit Service',
           thresholdOptions: [
             {
               checked: false,
-              value: '0',
-              text: '1000 m',
               hint: {
-                text: 'Flow thresholds for this station (m)'
-              }
+                text: 'Flow thresholds for this station (m3/s)'
+              },
+              text: '100 m3/s',
+              value: '1'
             },
             {
               checked: false,
-              value: '1',
-              text: '100 m3/s',
               hint: {
-                text: 'Level thresholds for this station (m3/s)'
-              }
+                text: 'Level thresholds for this station (m)'
+              },
+              text: '100 m',
+              value: '2'
             }
           ]
         })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5026

We are replacing the legacy notification abstraction alert journey. We are going through page by page and adding roughly similar page for some parts of the journey. With the intention of reusing the existing send notification logic we built previously.

This change updates a previously wrong assumption of showing all thresholds for all alert type. This is not the case.

There are two restriction types 'stop' and 'reduce'. When either of these are selected as the alert type then we need to only show those restrictions, when the alert type is something else then show all the thresholds.