### PR TITLE
Fix displaying 0 qty lines for return logs 

### DIFF
--- a/app/presenters/return-logs/base-return-logs.presenter.js
+++ b/app/presenters/return-logs/base-return-logs.presenter.js
@@ -223,7 +223,7 @@ function _groupLinesByMonth(lines) {
       }
     }
 
-    if (quantity) {
+    if (quantity || quantity === 0) {
       acc[key].quantity += quantity
     }
 

--- a/test/presenters/return-logs/base-return-logs.presenter.test.js
+++ b/test/presenters/return-logs/base-return-logs.presenter.test.js
@@ -439,6 +439,34 @@ describe('Base Return Logs presenter', () => {
             expect(result[1].monthlyTotal).to.be.null()
           })
         })
+
+        describe('and the lines being processed contain zero "quantity"', () => {
+          beforeEach(() => {
+            sampleLines[1].quantity = 0
+          })
+
+          it('returns the monthlyTotal as 0 for the line with a zero "quantity"', () => {
+            const result = BaseReturnLogsPresenter.generateSummaryTableRows(method, frequency, sampleLines)
+
+            expect(result[0].monthlyTotal).to.equal('400')
+            expect(result[1].monthlyTotal).to.equal('0')
+          })
+        })
+
+        describe('and all the lines being processed contain a zero "quantity"', () => {
+          beforeEach(() => {
+            sampleLines.forEach((sampleLine) => {
+              sampleLine.quantity = 0
+            })
+          })
+
+          it('returns the monthlyTotal as 0 for all lines', () => {
+            const result = BaseReturnLogsPresenter.generateSummaryTableRows(method, frequency, sampleLines)
+
+            expect(result[0].monthlyTotal).to.equal('0')
+            expect(result[1].monthlyTotal).to.equal('0')
+          })
+        })
       })
 
       describe('and the abstraction method is not "abstractionVolumes"', () => {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5035

In [Fix display null lines in view return log summary](https://github.com/DEFRA/water-abstraction-system/pull/1881) we dealt with a situation where return submission lines with a `NULL` quantity were being shown as `0` in the UI.

On the face of it, they may appear to mean the same thing, but they are, in fact, different.

`0` means the customer has explicitly told us that no water was abstracted at that time. `NULL` means no value has been submitted.

They've now highlighted a similar issue. If the quantity is `0`, we're displaying nothing. This gets interpreted as `NULL`, i.e. the customer did not submit anything which is incorrect.

This change fixes the issue.
