### PR TITLE
Update notifications setup abstraction alerts fetch / determine session data

### DIFF
--- a/test/services/notices/setup/abstraction-alerts/fetch-licence-monitoring-stations.service.test.js
+++ b/test/services/notices/setup/abstraction-alerts/fetch-licence-monitoring-stations.service.test.js
@@ -9,16 +9,18 @@ const { expect } = Code
 
 // Test helpers
 const LicenceHelper = require('../../../../support/helpers/licence.helper.js')
-const LicenceMonitoringStationModel = require('../../../../support/helpers/licence-monitoring-station.helper.js')
+const LicenceMonitoringStationHelper = require('../../../../support/helpers/licence-monitoring-station.helper.js')
 const LicenceVersionPurposeConditionHelper = require('../../../../support/helpers/licence-version-purpose-condition.helper.js')
 const LicenceVersionPurposesHelper = require('../../../../support/helpers/licence-version-purpose.helper.js')
 const MonitoringStationHelper = require('../../../../support/helpers/monitoring-station.helper.js')
+const { generateRandomInteger } = require('../../../../../app/lib/general.lib.js')
 
 // Thing under test
 const FetchLicenceMonitoringStationsService = require('../../../../../app/services/notices/setup/abstraction-alerts/fetch-licence-monitoring-stations.service.js')
 
 describe('Notices Setup - Abstraction Alerts - Fetch Licence Monitoring Stations service', () => {
   let licence
+  let licenceVersionPurpose
   let licenceVersionPurposeCondition
   let licenceWithVersionPurpose
   let monitoringStation
@@ -27,98 +29,111 @@ describe('Notices Setup - Abstraction Alerts - Fetch Licence Monitoring Stations
     monitoringStation = await MonitoringStationHelper.add()
 
     // A licence with the abstraction data from the Licence monitoring station
-    licence = await LicenceHelper.add()
+    licence = await LicenceHelper.add({ licenceRef: `01/01/01/${generateRandomInteger(1, 9999)}` })
 
-    await LicenceMonitoringStationModel.add({
+    await LicenceMonitoringStationHelper.add({
       licenceId: licence.id,
       monitoringStationId: monitoringStation.id,
-      abstraction_period_end_day: '01',
-      abstraction_period_end_month: '01',
-      abstraction_period_start_day: '01',
-      abstraction_period_start_month: '02'
+      abstractionPeriodEndDay: '01',
+      abstractionPeriodEndMonth: '01',
+      abstractionPeriodStartDay: '01',
+      abstractionPeriodStartMonth: '02'
     })
 
     // A licence with the abstraction data from the licence version purpose
-    licenceWithVersionPurpose = await LicenceHelper.add()
+    licenceWithVersionPurpose = await LicenceHelper.add({ licenceRef: `02/02/02/${generateRandomInteger(1, 9999)}` })
 
-    const licenceVersionPurposes = await LicenceVersionPurposesHelper.add()
+    licenceVersionPurpose = await LicenceVersionPurposesHelper.add()
 
     licenceVersionPurposeCondition = await LicenceVersionPurposeConditionHelper.add({
-      licenceVersionPurposeId: licenceVersionPurposes.id
+      licenceVersionPurposeId: licenceVersionPurpose.id
     })
 
-    await LicenceMonitoringStationModel.add({
+    await LicenceMonitoringStationHelper.add({
       licenceId: licenceWithVersionPurpose.id,
       licenceVersionPurposeConditionId: licenceVersionPurposeCondition.id,
-      monitoringStationId: monitoringStation.id,
-      abstraction_period_end_day: '01',
-      abstraction_period_end_month: '01',
-      abstraction_period_start_day: '01',
-      abstraction_period_start_month: '02'
+      monitoringStationId: monitoringStation.id
     })
   })
 
   it('correctly returns the data', async () => {
     const result = await FetchLicenceMonitoringStationsService.go(monitoringStation.id)
 
-    expect(result).to.equal([
-      {
-        abstraction_period_end_day: 1,
-        abstraction_period_end_month: 1,
-        abstraction_period_start_day: 1,
-        abstraction_period_start_month: 2,
-        label: 'MONITOR PLACE',
-        licence_id: licence.id,
-        licence_ref: licence.licenceRef,
-        licence_version_purpose_condition_id: null,
-        measure_type: 'flow',
-        restriction_type: 'reduce',
-        start_date: new Date('2022-01-01'),
-        status: 'resume',
-        status_updated_at: null,
-        threshold_unit: 'm3/s',
-        threshold_value: 100
-      },
-      {
-        abstraction_period_end_day: 31,
-        abstraction_period_end_month: 3,
-        abstraction_period_start_day: 1,
-        abstraction_period_start_month: 1,
-        label: 'MONITOR PLACE',
-        licence_id: licenceWithVersionPurpose.id,
-        licence_ref: licenceWithVersionPurpose.licenceRef,
-        licence_version_purpose_condition_id: licenceVersionPurposeCondition.id,
-        measure_type: 'flow',
-        restriction_type: 'reduce',
-        start_date: new Date('2022-01-01'),
-        status: 'resume',
-        status_updated_at: null,
-        threshold_unit: 'm3/s',
-        threshold_value: 100
-      }
-    ])
+    expect(result).to.equal({
+      id: monitoringStation.id,
+      label: 'MONITOR PLACE',
+      licenceMonitoringStations: [
+        {
+          abstractionPeriodEndDay: 1,
+          abstractionPeriodEndMonth: 1,
+          abstractionPeriodStartDay: 1,
+          abstractionPeriodStartMonth: 2,
+          licence: {
+            licenceRef: licence.licenceRef
+          },
+          licenceVersionPurposeCondition: null,
+          measureType: 'flow',
+          restrictionType: 'reduce',
+          status: 'resume',
+          statusUpdatedAt: null,
+          thresholdUnit: 'm3/s',
+          thresholdValue: 100
+        },
+        {
+          abstractionPeriodEndDay: null,
+          abstractionPeriodEndMonth: null,
+          abstractionPeriodStartDay: null,
+          abstractionPeriodStartMonth: null,
+          licence: {
+            licenceRef: licenceWithVersionPurpose.licenceRef
+          },
+          licenceVersionPurposeCondition: {
+            id: licenceVersionPurposeCondition.id,
+            licenceVersionPurpose: {
+              abstractionPeriodEndDay: 31,
+              abstractionPeriodEndMonth: 3,
+              abstractionPeriodStartDay: 1,
+              abstractionPeriodStartMonth: 1
+            }
+          },
+          measureType: 'flow',
+          restrictionType: 'reduce',
+          status: 'resume',
+          statusUpdatedAt: null,
+          thresholdUnit: 'm3/s',
+          thresholdValue: 100
+        }
+      ]
+    })
   })
 
   describe('when the licence has a licence version purpose', () => {
     it('correctly returns the data', async () => {
       const result = await FetchLicenceMonitoringStationsService.go(monitoringStation.id)
 
-      expect(result[1]).to.equal({
-        abstraction_period_end_day: 31,
-        abstraction_period_end_month: 3,
-        abstraction_period_start_day: 1,
-        abstraction_period_start_month: 1,
-        label: 'MONITOR PLACE',
-        licence_id: licenceWithVersionPurpose.id,
-        licence_ref: licenceWithVersionPurpose.licenceRef,
-        licence_version_purpose_condition_id: licenceVersionPurposeCondition.id,
-        measure_type: 'flow',
-        restriction_type: 'reduce',
-        start_date: new Date('2022-01-01'),
+      expect(result.licenceMonitoringStations[1]).to.equal({
+        abstractionPeriodEndDay: null,
+        abstractionPeriodEndMonth: null,
+        abstractionPeriodStartDay: null,
+        abstractionPeriodStartMonth: null,
+        licence: {
+          licenceRef: licenceWithVersionPurpose.licenceRef
+        },
+        licenceVersionPurposeCondition: {
+          id: licenceVersionPurposeCondition.id,
+          licenceVersionPurpose: {
+            abstractionPeriodEndDay: 31,
+            abstractionPeriodEndMonth: 3,
+            abstractionPeriodStartDay: 1,
+            abstractionPeriodStartMonth: 1
+          }
+        },
+        measureType: 'flow',
+        restrictionType: 'reduce',
         status: 'resume',
-        status_updated_at: null,
-        threshold_unit: 'm3/s',
-        threshold_value: 100
+        statusUpdatedAt: null,
+        thresholdUnit: 'm3/s',
+        thresholdValue: 100
       })
     })
   })
@@ -127,22 +142,21 @@ describe('Notices Setup - Abstraction Alerts - Fetch Licence Monitoring Stations
     it('correctly returns the data', async () => {
       const result = await FetchLicenceMonitoringStationsService.go(monitoringStation.id)
 
-      expect(result[0]).to.equal({
-        abstraction_period_end_day: 1,
-        abstraction_period_end_month: 1,
-        abstraction_period_start_day: 1,
-        abstraction_period_start_month: 2,
-        label: 'MONITOR PLACE',
-        licence_id: licence.id,
-        licence_ref: licence.licenceRef,
-        licence_version_purpose_condition_id: null,
-        measure_type: 'flow',
-        restriction_type: 'reduce',
-        start_date: new Date('2022-01-01'),
+      expect(result.licenceMonitoringStations[0]).to.equal({
+        abstractionPeriodEndDay: 1,
+        abstractionPeriodEndMonth: 1,
+        abstractionPeriodStartDay: 1,
+        abstractionPeriodStartMonth: 2,
+        licence: {
+          licenceRef: licence.licenceRef
+        },
+        licenceVersionPurposeCondition: null,
+        measureType: 'flow',
+        restrictionType: 'reduce',
         status: 'resume',
-        status_updated_at: null,
-        threshold_unit: 'm3/s',
-        threshold_value: 100
+        statusUpdatedAt: null,
+        thresholdUnit: 'm3/s',
+        thresholdValue: 100
       })
     })
   })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5026

There was a previous assumption that we needed to do a raw query to get the licence monitoring stations. This is not the case as the table and data we need already exist in the monitoring station code.

This change updates the fetch licence mounting station to use a similar fetch to the one that already exists (with some columns removed).

This change also updates the determine licence monitoring stations service to use the newly fetched data.