### PR TITLE
Add notifications setup abstraction alerts check licences table

### DIFF
--- a/app/presenters/notices/setup/abstraction-alerts/check-licence-matches.presenter.js
+++ b/app/presenters/notices/setup/abstraction-alerts/check-licence-matches.presenter.js
@@ -5,13 +5,106 @@
  * @module CheckLicenceMatchesPresenter
  */
 
+const { formatLongDate, sentenceCase, formatAbstractionPeriod } = require('../../../base.presenter.js')
+
 /**
  * Formats data for the `/notices/setup/{sessionId}/abstraction-alerts/check-licence-matches` page
  *
+ * @param session
  * @returns {object} - The data formatted for the view template
  */
-function go() {
-  return {}
+function go(session) {
+  const { licenceMonitoringStations } = session
+
+  return {
+    backLink: `/system/notices/setup/${session.id}/abstraction-alerts/alert-thresholds`,
+    caption: session.monitoringStationName,
+    pageTitle: 'Check the licence matches for the selected thresholds',
+    restrictions: _restrictions(licenceMonitoringStations),
+    restrictionHeading: _restrictionHeading(licenceMonitoringStations)
+  }
+}
+
+function _alert(status, statusUpdatedAt) {
+  if (!statusUpdatedAt) {
+    return null
+  }
+
+  return sentenceCase(status)
+}
+
+function _restriction(restrictionType) {
+  if (restrictionType === 'stop_or_reduce') {
+    return 'Stop or reduce'
+  }
+
+  return sentenceCase(restrictionType)
+}
+
+function _restrictionCount(licenceId, licenceMonitoringStations) {
+  const count = licenceMonitoringStations.filter((licenceMonitoringStation) => {
+    return licenceMonitoringStation.licenceId === licenceId
+  })
+
+  return count.length
+}
+
+function _restrictionHeading(licenceMonitoringStations) {
+  const containsFlow = licenceMonitoringStations.some((licenceMonitoringStation) => {
+    return licenceMonitoringStation.measureType === 'flow'
+  })
+
+  const containsLevel = licenceMonitoringStations.some((licenceMonitoringStation) => {
+    return licenceMonitoringStation.measureType === 'level'
+  })
+
+  if (containsFlow && containsLevel) {
+    return 'Flow and level restriction type and threshold'
+  }
+
+  if (containsFlow) {
+    return 'Flow restriction type and threshold'
+  }
+
+  return 'Level restriction type and threshold'
+}
+
+function _restrictions(licenceMonitoringStations) {
+  return licenceMonitoringStations.map((licenceMonitoringStation) => {
+    const {
+      abstractionPeriodEndDay,
+      abstractionPeriodEndMonth,
+      abstractionPeriodStartDay,
+      abstractionPeriodStartMonth,
+      licenceId,
+      licenceRef,
+      restrictionType,
+      status,
+      statusUpdatedAt,
+      thresholdUnit,
+      thresholdValue
+    } = licenceMonitoringStation
+
+    return {
+      abstractionPeriod: formatAbstractionPeriod(
+        abstractionPeriodStartDay,
+        abstractionPeriodStartMonth,
+        abstractionPeriodEndDay,
+        abstractionPeriodEndMonth
+      ),
+      alert: _alert(status, statusUpdatedAt),
+      alertDate: statusUpdatedAt ? formatLongDate(new Date(statusUpdatedAt)) : null,
+      licenceId,
+      licenceRef,
+      restriction: _restriction(restrictionType),
+      restrictionCount: _restrictionCount(licenceId, licenceMonitoringStations),
+      threshold: `${thresholdValue} ${thresholdUnit}`,
+      action: {
+        link: `/system`,
+        name: 'Remove'
+      }
+    }
+  })
 }
 
 module.exports = {

--- a/app/services/notices/setup/abstraction-alerts/check-licence-matches.service.js
+++ b/app/services/notices/setup/abstraction-alerts/check-licence-matches.service.js
@@ -22,6 +22,7 @@ async function go(sessionId) {
   const pageData = CheckLicenceMatchesPresenter.go(session)
 
   return {
+    activeNavBar: 'manage',
     ...pageData
   }
 }

--- a/app/services/notices/setup/abstraction-alerts/determine-licence-monitoring-stations.service.js
+++ b/app/services/notices/setup/abstraction-alerts/determine-licence-monitoring-stations.service.js
@@ -26,13 +26,14 @@ async function go(id) {
 function _licenceMonitoringStations(licenceMonitoringStations) {
   return licenceMonitoringStations.map((licenceMonitoringStation, index) => {
     const {
-      licence: { licenceRef },
+      licence: { licenceRef, id: licenceId },
       licenceVersionPurposeCondition,
       ...rest
     } = licenceMonitoringStation
 
     return {
       id: `${index}`,
+      licenceId,
       licenceRef,
       ...rest,
       ..._licenceVersionPurpose(licenceVersionPurposeCondition)

--- a/app/services/notices/setup/abstraction-alerts/fetch-monitoring-station.service.js
+++ b/app/services/notices/setup/abstraction-alerts/fetch-monitoring-station.service.js
@@ -46,7 +46,7 @@ async function _fetch(monitoringStationId) {
         ])
         .withGraphFetched('licence')
         .modifyGraph('licence', (licenceBuilder) => {
-          licenceBuilder.select(['licenceRef'])
+          licenceBuilder.select(['id', 'licenceRef'])
         })
         .withGraphFetched('licenceVersionPurposeCondition')
         .modifyGraph('licenceVersionPurposeCondition', (licenceVersionPurposeConditionBuilder) => {

--- a/app/views/macros/licence-monitoring-station-restrictions-table.njk
+++ b/app/views/macros/licence-monitoring-station-restrictions-table.njk
@@ -1,0 +1,121 @@
+{% from "govuk/components/table/macro.njk" import govukTable %}
+
+{% macro licenceMonitoringStationRestrictionsTable(restrictions, restrictionHeading, tableCaption) %}
+
+  {% if restrictions.length > 0 %}
+    {# Create rows for licences linked to the monitoring station #}
+    {% set tableRows = [] %}
+
+    {% for restriction in restrictions %}
+      {# Set an easier to use index #}
+      {% set rowIndex = loop.index0 %}
+
+      {% if rowIndex > 0 %}
+        {% set lastLicenceId = restrictions[rowIndex - 1].licenceId %}
+      {% else %}
+        {% set lastLicenceId = null %}
+      {% endif %}
+
+      {% set tableRow = [] %}
+
+      {% if lastLicenceId !== restriction.licenceId %}
+        {% set licenceCell =
+          {
+            html: '<a class="govuk-link govuk-body-m" href="/system/licences/' + restriction.licenceId + '/summary">' + restriction.licenceRef + '</a>',
+            attributes: { 'data-test': 'licence-ref-' + rowIndex },
+            rowspan: restriction.restrictionCount
+          } %}
+
+        {% set tableRow = (tableRow.push(licenceCell), tableRow) %}
+      {% endif %}
+
+      {% set abstractionPeriodCell =
+        {
+          text: restriction.abstractionPeriod,
+          attributes: { 'data-test': 'abstraction-period-' + rowIndex }
+        } %}
+      {% set tableRow = (tableRow.push(abstractionPeriodCell), tableRow) %}
+
+      {% set restrictionCell =
+        {
+          text: restriction.restriction,
+          attributes: { 'data-test': 'restriction-' + rowIndex }
+        } %}
+
+      {% set tableRow = (tableRow.push(restrictionCell), tableRow) %}
+
+      {% set thresholdCell =
+        {
+          text: restriction.threshold,
+          attributes: { 'data-test': 'threshold-' + rowIndex }
+        } %}
+      {% set tableRow = (tableRow.push(thresholdCell), tableRow) %}
+
+      {% set alertCell =
+        {
+          text: restriction.alert,
+          attributes: { 'data-test': 'alert-' + rowIndex }
+        } %}
+      {% set tableRow = (tableRow.push(alertCell), tableRow) %}
+
+      {% set alertDateCell =
+        {
+          text: restriction.alertDate,
+          attributes: { 'data-test': 'alert-date-' + rowIndex }
+        } %}
+      {% set tableRow = (tableRow.push(alertDateCell), tableRow) %}
+
+
+      {% if restriction.action %}
+        {% set actionCell =
+          {
+            html: '<a href="'+ restriction.action.link +'" class="govuk-link">' + restriction.action.name + '</a>',
+            attributes: { 'data-test': 'action-' + rowIndex }
+          } %}
+        {% set tableRow = (tableRow.push(actionCell), tableRow) %}
+      {% endif %}
+
+      {% set tableRows = (tableRows.push(tableRow), tableRows) %}
+    {% endfor %}
+
+    <div>
+      {{ govukTable({
+        caption: tableCaption,
+        captionClasses: "govuk-table__caption--m",
+        firstCellIsHeader: false,
+        fieldset: {
+          legend: {
+            text: pageTitle,
+            isPageHeading: true,
+            classes: "govuk-fieldset__legend--l govuk-!-margin-bottom-6"
+          }
+        },
+        head: [
+          {
+            text: "Licence"
+          },
+          {
+            text: "Abstraction period",
+            classes: 'govuk-!-width-one-quarter'
+          },
+          {
+            text: restrictionHeading,
+            colspan: 2
+          },
+          {
+            text: "Last type of alert sent and date issued",
+            classes: 'govuk-!-width-one-quarter',
+            colspan: 2
+          },
+          {
+            text: "Action"
+          }
+        ],
+        rows: tableRows
+      }) }}
+    </div>
+  {% else %}
+    <p class="govuk-body">There are no licences tagged with restrictions for this monitoring station</p>
+  {% endif %}
+
+{% endmacro %}

--- a/app/views/notices/setup/abstraction-alerts/check-licence-matches.njk
+++ b/app/views/notices/setup/abstraction-alerts/check-licence-matches.njk
@@ -3,6 +3,9 @@
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/table/macro.njk" import govukTable %}
+
+{% from "macros/licence-monitoring-station-restrictions-table.njk" import licenceMonitoringStationRestrictionsTable %}
 
 {% block breadcrumbs %}
   {{
@@ -15,6 +18,13 @@
 
 {% block content %}
   <div>
+
+    <span class="govuk-caption-l">{{caption}}</span>
+
+    <h2 class="govuk-heading-l">{{ pageTitle }}</h2>
+
+    {{ licenceMonitoringStationRestrictionsTable(restrictions,restrictionHeading) }}
+
     <form method="post">
       <input type="hidden" name="wrlsCrumb" value="{{wrlsCrumb}}"/>
 

--- a/test/fixtures/abstraction-alert-session-data.fixture.js
+++ b/test/fixtures/abstraction-alert-session-data.fixture.js
@@ -4,6 +4,10 @@ const { generateLicenceRef } = require('../support/helpers/licence.helper.js')
 const { generateUUID } = require('../../app/lib/general.lib.js')
 
 function licenceMonitoringStations() {
+  const sharedLicence = {
+    id: generateUUID(),
+    licenceRef: generateLicenceRef()
+  }
   return [
     {
       abstractionPeriodEndDay: 1,
@@ -11,6 +15,7 @@ function licenceMonitoringStations() {
       abstractionPeriodStartDay: 1,
       abstractionPeriodStartMonth: 2,
       id: '0',
+      licenceId: generateUUID(),
       licenceRef: generateLicenceRef(),
       measureType: 'flow',
       restrictionType: 'reduce',
@@ -25,7 +30,8 @@ function licenceMonitoringStations() {
       abstractionPeriodStartDay: 1,
       abstractionPeriodStartMonth: 1,
       id: '1',
-      licenceRef: generateLicenceRef(),
+      licenceId: sharedLicence.id,
+      licenceRef: sharedLicence.licenceRef,
       measureType: 'flow',
       restrictionType: 'stop',
       status: 'resume',
@@ -39,7 +45,8 @@ function licenceMonitoringStations() {
       abstractionPeriodStartDay: 1,
       abstractionPeriodStartMonth: 1,
       id: '2',
-      licenceRef: generateLicenceRef(),
+      licenceId: sharedLicence.id,
+      licenceRef: sharedLicence.licenceRef,
       measureType: 'level',
       restrictionType: 'stop',
       status: 'resume',

--- a/test/presenters/notices/setup/abstraction-alerts/check-licence-matches.presenter.test.js
+++ b/test/presenters/notices/setup/abstraction-alerts/check-licence-matches.presenter.test.js
@@ -7,21 +7,251 @@ const Code = require('@hapi/code')
 const { describe, it, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
+// Test helpers
+const AbstractionAlertSessionData = require('../../../../fixtures/abstraction-alert-session-data.fixture.js')
+
 // Thing under test
 const CheckLicenceMatchesPresenter = require('../../../../../app/presenters/notices/setup/abstraction-alerts/check-licence-matches.presenter.js')
 
 describe('Notices Setup - Abstraction Alerts - Check Licence Matches Presenter', () => {
+  let abstractionAlertSessionData
+  let licenceMonitoringStation
+  let licenceMonitoringStationSharedLicence
   let session
 
   beforeEach(() => {
-    session = {}
+    abstractionAlertSessionData = AbstractionAlertSessionData.monitoringStation()
+
+    licenceMonitoringStation = abstractionAlertSessionData.licenceMonitoringStations[0]
+    licenceMonitoringStationSharedLicence = abstractionAlertSessionData.licenceMonitoringStations[1]
+
+    session = {
+      ...abstractionAlertSessionData
+    }
   })
 
   describe('when called', () => {
     it('returns page data for the view', () => {
       const result = CheckLicenceMatchesPresenter.go(session)
 
-      expect(result).to.equal({})
+      expect(result).to.equal({
+        backLink: `/system/notices/setup/${session.id}/abstraction-alerts/alert-thresholds`,
+        caption: 'Death star',
+        pageTitle: 'Check the licence matches for the selected thresholds',
+        restrictionHeading: 'Flow and level restriction type and threshold',
+        restrictions: [
+          {
+            abstractionPeriod: '1 February to 1 January',
+            action: {
+              link: '/system',
+              name: 'Remove'
+            },
+            alert: null,
+            alertDate: null,
+            licenceId: licenceMonitoringStation.licenceId,
+            licenceRef: licenceMonitoringStation.licenceRef,
+            restriction: 'Reduce',
+            restrictionCount: 1,
+            threshold: '1000 m'
+          },
+          {
+            abstractionPeriod: '1 January to 31 March',
+            action: {
+              link: '/system',
+              name: 'Remove'
+            },
+            alert: null,
+            alertDate: null,
+            licenceId: licenceMonitoringStationSharedLicence.licenceId,
+            licenceRef: licenceMonitoringStationSharedLicence.licenceRef,
+            restriction: 'Stop',
+            restrictionCount: 2,
+            threshold: '100 m3/s'
+          },
+          {
+            abstractionPeriod: '1 January to 31 March',
+            action: {
+              link: '/system',
+              name: 'Remove'
+            },
+            alert: null,
+            alertDate: null,
+            licenceId: licenceMonitoringStationSharedLicence.licenceId,
+            licenceRef: licenceMonitoringStationSharedLicence.licenceRef,
+            restriction: 'Stop',
+            restrictionCount: 2,
+            threshold: '100 m'
+          }
+        ]
+      })
+    })
+
+    describe('the "restrictionHeading" property', () => {
+      describe('when the monitoring station has only "flow" based licence monitoring station records', () => {
+        beforeEach(() => {
+          session.licenceMonitoringStations = [licenceMonitoringStation]
+        })
+
+        it('returns "Flow restriction type and threshold"', () => {
+          const result = CheckLicenceMatchesPresenter.go(session)
+
+          expect(result.restrictionHeading).to.equal('Flow restriction type and threshold')
+        })
+      })
+
+      describe('when the monitoring station has only "level" based licence monitoring station records', () => {
+        beforeEach(() => {
+          session.licenceMonitoringStations = [
+            {
+              ...licenceMonitoringStation,
+              measureType: 'level'
+            }
+          ]
+        })
+
+        it('returns "Flow restriction type and threshold"', () => {
+          const result = CheckLicenceMatchesPresenter.go(session)
+
+          expect(result.restrictionHeading).to.equal('Level restriction type and threshold')
+        })
+      })
+
+      describe('when the monitoring station has both "flow" and "level" based licence monitoring station records', () => {
+        it('returns "Flow and level restriction type and threshold"', () => {
+          const result = CheckLicenceMatchesPresenter.go(session)
+
+          expect(result.restrictionHeading).to.equal('Flow and level restriction type and threshold')
+        })
+      })
+    })
+
+    describe('the "restrictions" property', () => {
+      describe('the "abstraction" property', () => {
+        beforeEach(() => {
+          session.licenceMonitoringStations = [licenceMonitoringStation]
+        })
+
+        it('returns the abstraction period', () => {
+          const result = CheckLicenceMatchesPresenter.go(session)
+
+          expect(result.restrictions[0].abstractionPeriod).to.equal('1 February to 1 January')
+        })
+      })
+
+      describe('the "alert" property', () => {
+        describe('when the licence monitoring station record has never had an alert sent', () => {
+          it('returns null', () => {
+            const result = CheckLicenceMatchesPresenter.go(session)
+
+            expect(result.restrictions[0].alert).to.be.null()
+          })
+        })
+
+        describe('when the licence monitoring station record has had an alert sent', () => {
+          beforeEach(() => {
+            session.licenceMonitoringStations = [
+              {
+                ...licenceMonitoringStation,
+                statusUpdatedAt: '2020-01-01'
+              }
+            ]
+          })
+
+          it('returns the current "status" formatted for display', () => {
+            const result = CheckLicenceMatchesPresenter.go(session)
+
+            expect(result.restrictions[0].alert).to.equal('Resume')
+          })
+        })
+      })
+
+      describe('the "alertDate" property', () => {
+        describe('when the licence monitoring station record has never had an alert sent', () => {
+          it('returns null', () => {
+            const result = CheckLicenceMatchesPresenter.go(session)
+
+            expect(result.restrictions[0].alertDate).to.be.null()
+          })
+        })
+
+        describe('when the licence monitoring station record has had an alert sent', () => {
+          beforeEach(() => {
+            session.licenceMonitoringStations = [
+              {
+                ...licenceMonitoringStation,
+                statusUpdatedAt: '2020-01-01'
+              }
+            ]
+          })
+
+          it('returns the "statusUpdatedAt" formatted for display', () => {
+            const result = CheckLicenceMatchesPresenter.go(session)
+
+            expect(result.restrictions[0].alertDate).to.equal('1 January 2020')
+          })
+        })
+      })
+
+      describe('the "restriction" property', () => {
+        describe("when the licence monitoring station record's restriction type is 'stop_or_reduce'", () => {
+          beforeEach(() => {
+            session.licenceMonitoringStations = [
+              {
+                ...licenceMonitoringStation,
+                restrictionType: 'stop_or_reduce'
+              }
+            ]
+          })
+
+          it('returns "Stop or reduce"', () => {
+            const result = CheckLicenceMatchesPresenter.go(session)
+
+            expect(result.restrictions[0].restriction).to.equal('Stop or reduce')
+          })
+        })
+
+        describe("when the licence monitoring station record's restriction type is 'reduce'", () => {
+          beforeEach(() => {
+            session.licenceMonitoringStations = [
+              {
+                ...licenceMonitoringStation,
+                restrictionType: 'reduce'
+              }
+            ]
+          })
+
+          it('returns "Reduce"', () => {
+            const result = CheckLicenceMatchesPresenter.go(session)
+
+            expect(result.restrictions[0].restriction).to.equal('Reduce')
+          })
+        })
+
+        describe("when the licence monitoring station record's restriction type is 'stop'", () => {
+          beforeEach(() => {
+            session.licenceMonitoringStations = [
+              {
+                ...licenceMonitoringStation,
+                restrictionType: 'stop'
+              }
+            ]
+          })
+
+          it('returns "Stop"', () => {
+            const result = CheckLicenceMatchesPresenter.go(session)
+
+            expect(result.restrictions[0].restriction).to.equal('Stop')
+          })
+        })
+      })
+
+      describe('the "restrictionCount" property', () => {
+        it('returns returns the count of licence monitoring stations for the licence linked to this monitoring station', () => {
+          const result = CheckLicenceMatchesPresenter.go(session)
+
+          expect(result.restrictions[1].restrictionCount).to.equal(2)
+        })
+      })
     })
   })
 })

--- a/test/services/notices/setup/abstraction-alerts/check-licence-matches.service.test.js
+++ b/test/services/notices/setup/abstraction-alerts/check-licence-matches.service.test.js
@@ -8,26 +8,82 @@ const { describe, it, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
+const AbstractionAlertSessionData = require('../../../../fixtures/abstraction-alert-session-data.fixture.js')
 const SessionHelper = require('../../../../support/helpers/session.helper.js')
 
 // Thing under test
 const CheckLicenceMatchesService = require('../../../../../app/services/notices/setup/abstraction-alerts/check-licence-matches.service.js')
 
 describe('Notices Setup - Abstraction Alerts - Check Licence Matches Service', () => {
+  let abstractionAlertSessionData
+  let licenceMonitoringStation
+  let licenceMonitoringStationSharedLicence
   let session
-  let sessionData
 
   beforeEach(async () => {
-    sessionData = {}
+    abstractionAlertSessionData = AbstractionAlertSessionData.monitoringStation()
 
-    session = await SessionHelper.add({ data: sessionData })
+    licenceMonitoringStation = abstractionAlertSessionData.licenceMonitoringStations[0]
+    licenceMonitoringStationSharedLicence = abstractionAlertSessionData.licenceMonitoringStations[1]
+
+    session = await SessionHelper.add({ data: abstractionAlertSessionData })
   })
 
   describe('when called', () => {
     it('returns page data for the view', async () => {
       const result = await CheckLicenceMatchesService.go(session.id)
 
-      expect(result).to.equal({})
+      expect(result).to.equal({
+        activeNavBar: 'manage',
+        backLink: `/system/notices/setup/${session.id}/abstraction-alerts/alert-thresholds`,
+        caption: 'Death star',
+        pageTitle: 'Check the licence matches for the selected thresholds',
+        restrictionHeading: 'Flow and level restriction type and threshold',
+        restrictions: [
+          {
+            abstractionPeriod: '1 February to 1 January',
+            action: {
+              link: '/system',
+              name: 'Remove'
+            },
+            alert: null,
+            alertDate: null,
+            licenceId: licenceMonitoringStation.licenceId,
+            licenceRef: licenceMonitoringStation.licenceRef,
+            restriction: 'Reduce',
+            restrictionCount: 1,
+            threshold: '1000 m'
+          },
+          {
+            abstractionPeriod: '1 January to 31 March',
+            action: {
+              link: '/system',
+              name: 'Remove'
+            },
+            alert: null,
+            alertDate: null,
+            licenceId: licenceMonitoringStationSharedLicence.licenceId,
+            licenceRef: licenceMonitoringStationSharedLicence.licenceRef,
+            restriction: 'Stop',
+            restrictionCount: 2,
+            threshold: '100 m3/s'
+          },
+          {
+            abstractionPeriod: '1 January to 31 March',
+            action: {
+              link: '/system',
+              name: 'Remove'
+            },
+            alert: null,
+            alertDate: null,
+            licenceId: licenceMonitoringStationSharedLicence.licenceId,
+            licenceRef: licenceMonitoringStationSharedLicence.licenceRef,
+            restriction: 'Stop',
+            restrictionCount: 2,
+            threshold: '100 m'
+          }
+        ]
+      })
     })
   })
 })

--- a/test/services/notices/setup/abstraction-alerts/determine-licence-monitoring-stations.service.test.js
+++ b/test/services/notices/setup/abstraction-alerts/determine-licence-monitoring-stations.service.test.js
@@ -37,6 +37,7 @@ describe('Notices Setup - Abstraction Alerts - Determine Licence Monitoring Stat
           thresholdUnit: 'm3/s',
           thresholdValue: 100,
           licence: {
+            id: '123',
             licenceRef: '01/01/01/6880'
           },
           licenceVersionPurposeCondition: null
@@ -53,6 +54,7 @@ describe('Notices Setup - Abstraction Alerts - Determine Licence Monitoring Stat
           thresholdUnit: 'm3/s',
           thresholdValue: 100,
           licence: {
+            id: '456',
             licenceRef: '02/02/02/3116'
           },
           licenceVersionPurposeCondition: {
@@ -84,6 +86,7 @@ describe('Notices Setup - Abstraction Alerts - Determine Licence Monitoring Stat
           abstractionPeriodStartDay: 1,
           abstractionPeriodStartMonth: 2,
           id: '0',
+          licenceId: '123',
           licenceRef: '01/01/01/6880',
           measureType: 'flow',
           restrictionType: 'reduce',
@@ -98,6 +101,7 @@ describe('Notices Setup - Abstraction Alerts - Determine Licence Monitoring Stat
           abstractionPeriodStartDay: 1,
           abstractionPeriodStartMonth: 1,
           id: '1',
+          licenceId: '456',
           licenceRef: '02/02/02/3116',
           measureType: 'flow',
           restrictionType: 'reduce',

--- a/test/services/notices/setup/abstraction-alerts/fetch-monitoring-station.service.test.js
+++ b/test/services/notices/setup/abstraction-alerts/fetch-monitoring-station.service.test.js
@@ -69,6 +69,7 @@ describe('Notices Setup - Abstraction Alerts - Fetch Monitoring Station service'
           abstractionPeriodStartDay: 1,
           abstractionPeriodStartMonth: 2,
           licence: {
+            id: licence.id,
             licenceRef: licence.licenceRef
           },
           licenceVersionPurposeCondition: null,
@@ -85,6 +86,7 @@ describe('Notices Setup - Abstraction Alerts - Fetch Monitoring Station service'
           abstractionPeriodStartDay: null,
           abstractionPeriodStartMonth: null,
           licence: {
+            id: licenceWithVersionPurpose.id,
             licenceRef: licenceWithVersionPurpose.licenceRef
           },
           licenceVersionPurposeCondition: {
@@ -117,6 +119,7 @@ describe('Notices Setup - Abstraction Alerts - Fetch Monitoring Station service'
         abstractionPeriodStartDay: null,
         abstractionPeriodStartMonth: null,
         licence: {
+          id: licenceWithVersionPurpose.id,
           licenceRef: licenceWithVersionPurpose.licenceRef
         },
         licenceVersionPurposeCondition: {
@@ -148,6 +151,7 @@ describe('Notices Setup - Abstraction Alerts - Fetch Monitoring Station service'
         abstractionPeriodStartDay: 1,
         abstractionPeriodStartMonth: 2,
         licence: {
+          id: licence.id,
           licenceRef: licence.licenceRef
         },
         licenceVersionPurposeCondition: null,


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5027

The legacy 'abstraction-alerts/check-licence-matches' page has a table displaying the selected thresholds.

We already have a table for the monitoring stations page, we can use this table in multiple places.

This change adds / updates the logic to display the monitoring restrictions for the check licence matches page.

This change does not implement the remove link logic but link and text have been implemented to prove the marco renders correctly.

We have introduced a new macro 'licenceMonitoringStationRestrictionsTable' this will be used in multiple places and has been adapted from the original table.

A base presenter should be introduced in later changed. For now, a copy has been taken from the monitoring view presenter and used in the check licence matches presenter. The tests are also copied to achieve the same expected output. When the refactor to a common presenter is done these test can be removed as they will be covered by the base presenter.