### PR TITLE
Remove Return version migration debug code

### DIFF
--- a/app/services/jobs/return-logs/fetch-water-undertakers.service.js
+++ b/app/services/jobs/return-logs/fetch-water-undertakers.service.js
@@ -66,7 +66,6 @@ async function go() {
         .where('startDate', '<', quarterlyStartDate)
         .whereColumn('returnVersions.licenceId', 'licences.id')
     )
-    .whereIn('id', ['5599e2b2-4047-48e6-84aa-f6fc23741e05', '95de4f0f-f13f-4ea6-9460-b7f5d6ce8381'])
 }
 
 module.exports = {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4881

What idiots!

When the job to [Create new quarterly return versions for water companies](https://github.com/DEFRA/water-abstraction-system/pull/1648) was added, we completely did not spot that it still contained code intended for debugging.

```javascript
  .whereIn('id', ['5599e2b2-4047-48e6-84aa-f6fc23741e05', '95de4f0f-f13f-4ea6-9460-b7f5d6ce8381'])
```

This would explain why, when trialling against real data for the first time, nothing happened!