### PR TITLE
Revert helper change to fix broken acceptance test

### DIFF
--- a/test/services/licences/fetch-communications.service.test.js
+++ b/test/services/licences/fetch-communications.service.test.js
@@ -34,6 +34,8 @@ describe('Fetch Communications service', () => {
     scheduledNotification = await ScheduledNotificationModel.add({
       eventId: event.id,
       licences: JSON.stringify([licenceRef]),
+      messageRef: 'returns_invitation_licence_holder_letter',
+      messageType: 'letter',
       notifyStatus: 'delivered'
     })
   })

--- a/test/support/helpers/scheduled-notification.helper.js
+++ b/test/support/helpers/scheduled-notification.helper.js
@@ -4,7 +4,7 @@
  * @module ScheduledNotificationHelper
  */
 
-const { generateUUID, timestampForPostgres } = require('../../../app/lib/general.lib.js')
+const { timestampForPostgres } = require('../../../app/lib/general.lib.js')
 const ScheduledNotificationModel = require('../../../app/models/scheduled-notification.model.js')
 
 /**
@@ -38,20 +38,6 @@ function add(data = {}) {
  */
 function defaults(data = {}) {
   const defaults = {
-    messageType: 'letter',
-    messageRef: 'returns_invitation_licence_holder_letter',
-    personalisation: JSON.stringify({
-      name: 'Mr B Lobby',
-      postcode: 'SW1A 1AA',
-      address_line_1: 'Mr B Lobby',
-      address_line_2: 'BBC Farm',
-      address_line_3: 'Fake town',
-      address_line_4: 'London',
-      address_line_5: 'England'
-    }),
-    status: 'sent',
-    licences: JSON.stringify(['44/67/20/12']),
-    eventId: generateUUID(),
     // INFO: The table does not have a default for the createdAt column.
     createdAt: timestampForPostgres()
   }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4992

In [Add fetch notice service and unit tests](https://github.com/DEFRA/water-abstraction-system/pull/1967) we updated the `scheduled-notification.helper.js` to include a bunch more default values.

The problem is that one was to set an `eventId`, but the table has a foreign key constraint: the value must match an existing `water.events`.

The unit test we think the changes were made for only needs a few fields to be set. We didn't need to default most of them for all the tests to pass.

We should have caught it at review, but this breaks the idea of the 'defaults'. They should only be values needed by the DB to allow us to create a record without error. All other values should come from the unit tests themselves. Hence, before the change, the helper only set the `createdAt` value.

Anyway, the change meant that when the acceptance tests data loader tried to add a scheduled notification using the helper, it failed because of an unknown `eventId`.

This reverts the change to the helper, bringing it back in line with our conventions and gets the acceptance tests passing again.