### PR TITLE
Migration - Add `created_by` to `licence_monitoring_stations`

### DIFF
--- a/app/models/licence-monitoring-station.model.js
+++ b/app/models/licence-monitoring-station.model.js
@@ -39,6 +39,14 @@ class LicenceMonitoringStationModel extends BaseModel {
           from: 'licenceMonitoringStations.licenceVersionPurposeConditionId',
           to: 'licenceVersionPurposeConditions.id'
         }
+      },
+      user: {
+        relation: Model.BelongsToOneRelation,
+        modelClass: 'user.model',
+        join: {
+          from: 'licenceMonitoringStations.createdBy',
+          to: 'users.id'
+        }
       }
     }
   }

--- a/app/models/user.model.js
+++ b/app/models/user.model.js
@@ -45,6 +45,14 @@ class UserModel extends BaseModel {
           to: 'licenceEntities.id'
         }
       },
+      licenceMonitoringStations: {
+        relation: Model.HasManyRelation,
+        modelClass: 'licence-monitoring-station.model',
+        join: {
+          from: 'users.id',
+          to: 'licenceMonitoringStations.createdBy'
+        }
+      },
       returnVersions: {
         relation: Model.HasManyRelation,
         modelClass: 'return-version.model',

--- a/db/migrations/legacy/20221108007027_water-licence-gauging-stations.js
+++ b/db/migrations/legacy/20221108007027_water-licence-gauging-stations.js
@@ -23,6 +23,7 @@ exports.up = function (knex) {
     table.timestamp('date_status_updated', { useTz: false })
     table.timestamp('date_deleted', { useTz: false })
     table.string('alert_type').notNullable().default('reduce')
+    table.integer('created_by')
     table.boolean('is_test').defaultTo(false)
 
     // Legacy timestamps

--- a/db/migrations/public/20250512155246_alter-licence-monitoring-stations-view.js
+++ b/db/migrations/public/20250512155246_alter-licence-monitoring-stations-view.js
@@ -1,0 +1,64 @@
+'use strict'
+
+exports.up = function (knex) {
+  return knex.schema
+    .dropViewIfExists('licence_monitoring_stations')
+    .createView('licence_monitoring_stations', (view) => {
+      // NOTE: We have commented out unused columns from the source table
+      view.as(
+        knex('licence_gauging_stations').withSchema('water').select([
+          'licence_gauging_station_id AS id',
+          'licence_id',
+          'gauging_station_id AS monitoring_station_id',
+          'source',
+          'licence_version_purpose_condition_id',
+          'abstraction_period_start_day',
+          'abstraction_period_start_month ',
+          'abstraction_period_end_day',
+          'abstraction_period_end_month',
+          'restriction_type AS measure_type',
+          'threshold_unit',
+          'threshold_value',
+          'status',
+          'date_status_updated AS status_updated_at',
+          'date_deleted AS deleted_at',
+          'alert_type AS restriction_type',
+          'created_by', // new column
+          // 'is_test',
+          'date_created AS created_at',
+          'date_updated AS updated_at'
+        ])
+      )
+    })
+}
+
+exports.down = function (knex) {
+  return knex.schema
+    .dropViewIfExists('licence_monitoring_stations')
+    .createView('licence_monitoring_stations', (view) => {
+      // NOTE: We have commented out unused columns from the source table
+      view.as(
+        knex('licence_gauging_stations').withSchema('water').select([
+          'licence_gauging_station_id AS id',
+          'licence_id',
+          'gauging_station_id AS monitoring_station_id',
+          'source',
+          'licence_version_purpose_condition_id',
+          'abstraction_period_start_day',
+          'abstraction_period_start_month ',
+          'abstraction_period_end_day',
+          'abstraction_period_end_month',
+          'restriction_type',
+          'threshold_unit',
+          'threshold_value',
+          'status',
+          'date_status_updated AS status_updated_at',
+          'date_deleted AS deleted_at',
+          'alert_type',
+          // 'is_test',
+          'date_created AS created_at',
+          'date_updated AS updated_at'
+        ])
+      )
+    })
+}

--- a/test/models/licence-monitoring-station.model.test.js
+++ b/test/models/licence-monitoring-station.model.test.js
@@ -15,6 +15,8 @@ const LicenceHelper = require('../support/helpers/licence.helper.js')
 const LicenceModel = require('../../app/models/licence.model.js')
 const LicenceVersionPurposeConditionHelper = require('../support/helpers/licence-version-purpose-condition.helper.js')
 const LicenceVersionPurposeConditionModel = require('../../app/models/licence-version-purpose-condition.model.js')
+const UserHelper = require('../support/helpers/user.helper.js')
+const UserModel = require('../../app/models/user.model.js')
 
 // Thing under test
 const LicenceMonitoringStationModel = require('../../app/models/licence-monitoring-station.model.js')
@@ -24,13 +26,16 @@ describe('Licence Monitoring Station model', () => {
   let testLicenceVersionPurposeCondition
   let testMonitoringStation
   let testRecord
+  let testUser
 
   before(async () => {
     testLicence = await LicenceHelper.add()
     testLicenceVersionPurposeCondition = await LicenceVersionPurposeConditionHelper.add()
     testMonitoringStation = await MonitoringStationHelper.add()
+    testUser = await UserHelper.add()
 
     testRecord = await LicenceMonitoringStationHelper.add({
+      createdBy: testUser.id,
       licenceId: testLicence.id,
       licenceVersionPurposeConditionId: testLicenceVersionPurposeCondition.id,
       monitoringStationId: testMonitoringStation.id
@@ -102,6 +107,24 @@ describe('Licence Monitoring Station model', () => {
 
         expect(result.licenceVersionPurposeCondition).to.be.an.instanceOf(LicenceVersionPurposeConditionModel)
         expect(result.licenceVersionPurposeCondition).to.equal(testLicenceVersionPurposeCondition)
+      })
+    })
+
+    describe('when linking to user', () => {
+      it('can successfully run a related query', async () => {
+        const query = await LicenceMonitoringStationModel.query().innerJoinRelated('user')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the user', async () => {
+        const result = await LicenceMonitoringStationModel.query().findById(testRecord.id).withGraphFetched('user')
+
+        expect(result).to.be.instanceOf(LicenceMonitoringStationModel)
+        expect(result.id).to.equal(testRecord.id)
+
+        expect(result.user).to.be.an.instanceOf(UserModel)
+        expect(result.user).to.equal(testUser)
       })
     })
   })

--- a/test/models/user.model.test.js
+++ b/test/models/user.model.test.js
@@ -14,6 +14,8 @@ const GroupHelper = require('../support/helpers/group.helper.js')
 const GroupModel = require('../../app/models/group.model.js')
 const LicenceEntityHelper = require('../support/helpers/licence-entity.helper.js')
 const LicenceEntityModel = require('../../app/models/licence-entity.model.js')
+const LicenceMonitoringStationHelper = require('../support/helpers/licence-monitoring-station.helper.js')
+const LicenceMonitoringStationModel = require('../../app/models/licence-monitoring-station.model.js')
 const ReturnVersionHelper = require('../support/helpers/return-version.helper.js')
 const ReturnVersionModel = require('../../app/models/return-version.model.js')
 const RoleHelper = require('../support/helpers/role.helper.js')
@@ -141,6 +143,37 @@ describe('User model', () => {
 
         expect(result.licenceEntity).to.be.an.instanceOf(LicenceEntityModel)
         expect(result.licenceEntity).to.equal(testLicenceEntity)
+      })
+    })
+
+    describe('when linking to licence monitoring stations', () => {
+      let testLicenceMonitoringStations
+
+      beforeEach(async () => {
+        testLicenceMonitoringStations = []
+        for (let i = 0; i < 2; i++) {
+          const licenceMonitoringStation = await LicenceMonitoringStationHelper.add({ createdBy: testRecord.id })
+
+          testLicenceMonitoringStations.push(licenceMonitoringStation)
+        }
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await UserModel.query().innerJoinRelated('licenceMonitoringStations')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the licence monitoring stations', async () => {
+        const result = await UserModel.query().findById(testRecord.id).withGraphFetched('licenceMonitoringStations')
+
+        expect(result).to.be.instanceOf(UserModel)
+        expect(result.id).to.equal(testRecord.id)
+
+        expect(result.licenceMonitoringStations).to.be.an.array()
+        expect(result.licenceMonitoringStations[0]).to.be.an.instanceOf(LicenceMonitoringStationModel)
+        expect(result.licenceMonitoringStations).to.include(testLicenceMonitoringStations[0])
+        expect(result.licenceMonitoringStations).to.include(testLicenceMonitoringStations[1])
       })
     })
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4999

As part of the work migrating the "Monitoring stations - Tag details page" we are now required to capture the user that created the Tag.

This PR will create a `created_by` column in the `public.licence_monitoring_stations` view and legacy table to enable us to capture the user ID.

The models will also be updated to add the relationship to the `users`.