### PR TITLE
Add notifications setup abstraction check licence remove link

### DIFF
--- a/app/presenters/notices/setup/abstraction-alerts/check-licence-matches.presenter.js
+++ b/app/presenters/notices/setup/abstraction-alerts/check-licence-matches.presenter.js
@@ -15,13 +15,13 @@ const { determineRestrictionHeading, formatRestrictions } = require('../../../mo
  * @returns {object} - The data formatted for the view template
  */
 function go(session) {
-  const { licenceMonitoringStations, alertThresholds, monitoringStationName, id } = session
+  const { licenceMonitoringStations, alertThresholds, monitoringStationName, id: sessionId } = session
 
   return {
-    backLink: `/system/notices/setup/${id}/abstraction-alerts/alert-thresholds`,
+    backLink: `/system/notices/setup/${sessionId}/abstraction-alerts/alert-thresholds`,
     caption: monitoringStationName,
     pageTitle: 'Check the licence matches for the selected thresholds',
-    restrictions: _restrictions(licenceMonitoringStations, alertThresholds),
+    restrictions: _restrictions(licenceMonitoringStations, alertThresholds, sessionId),
     restrictionHeading: determineRestrictionHeading(licenceMonitoringStations)
   }
 }
@@ -32,7 +32,7 @@ function _relevantLicenceMonitoringStations(licenceMonitoringStations, alertThre
   })
 }
 
-function _restrictions(licenceMonitoringStations, alertThresholds) {
+function _restrictions(licenceMonitoringStations, alertThresholds, sessionId) {
   const relevantLicenceMonitoringStations = _relevantLicenceMonitoringStations(
     licenceMonitoringStations,
     alertThresholds
@@ -42,7 +42,7 @@ function _restrictions(licenceMonitoringStations, alertThresholds) {
     return {
       ...licenceMonitoringStation,
       action: {
-        link: `/system/licence-monitoring-station`,
+        link: `/system/notices/setup/${sessionId}/abstraction-alerts/remove/${licenceMonitoringStation.id}`,
         text: 'Remove'
       },
       statusUpdatedAt: licenceMonitoringStation.statusUpdatedAt

--- a/app/services/notices/setup/abstraction-alerts/fetch-monitoring-station.service.js
+++ b/app/services/notices/setup/abstraction-alerts/fetch-monitoring-station.service.js
@@ -27,6 +27,7 @@ async function _fetch(monitoringStationId) {
     .modifyGraph('licenceMonitoringStations', (licenceMonitoringStationsBuilder) => {
       licenceMonitoringStationsBuilder
         .select([
+          'licenceMonitoringStations.id',
           'licenceMonitoringStations.abstractionPeriodEndDay',
           'licenceMonitoringStations.abstractionPeriodEndMonth',
           'licenceMonitoringStations.abstractionPeriodStartDay',

--- a/test/fixtures/abstraction-alert-session-data.fixture.js
+++ b/test/fixtures/abstraction-alert-session-data.fixture.js
@@ -10,6 +10,7 @@ function licenceMonitoringStations() {
       abstractionPeriodEndMonth: 1,
       abstractionPeriodStartDay: 1,
       abstractionPeriodStartMonth: 2,
+      id: generateUUID(),
       licence: {
         licenceRef: generateLicenceRef(),
         id: generateUUID()
@@ -27,6 +28,7 @@ function licenceMonitoringStations() {
       abstractionPeriodEndMonth: 3,
       abstractionPeriodStartDay: 1,
       abstractionPeriodStartMonth: 1,
+      id: generateUUID(),
       licence: {
         licenceRef: generateLicenceRef(),
         id: generateUUID()
@@ -44,6 +46,7 @@ function licenceMonitoringStations() {
       abstractionPeriodEndMonth: 3,
       abstractionPeriodStartDay: 1,
       abstractionPeriodStartMonth: 1,
+      id: generateUUID(),
       licence: {
         licenceRef: generateLicenceRef(),
         id: generateUUID()

--- a/test/presenters/notices/setup/abstraction-alerts/check-licence-matches.presenter.test.js
+++ b/test/presenters/notices/setup/abstraction-alerts/check-licence-matches.presenter.test.js
@@ -48,7 +48,7 @@ describe('Notices Setup - Abstraction Alerts - Check Licence Matches Presenter',
           {
             abstractionPeriod: '1 February to 1 January',
             action: {
-              link: '/system/licence-monitoring-station',
+              link: `/system/notices/setup/${session.id}/abstraction-alerts/remove/${licenceMonitoringStationOne.id}`,
               text: 'Remove'
             },
             alert: null,
@@ -62,7 +62,7 @@ describe('Notices Setup - Abstraction Alerts - Check Licence Matches Presenter',
           {
             abstractionPeriod: '1 January to 31 March',
             action: {
-              link: '/system/licence-monitoring-station',
+              link: `/system/notices/setup/${session.id}/abstraction-alerts/remove/${licenceMonitoringStationTwo.id}`,
               text: 'Remove'
             },
             alert: null,
@@ -76,7 +76,7 @@ describe('Notices Setup - Abstraction Alerts - Check Licence Matches Presenter',
           {
             abstractionPeriod: '1 January to 31 March',
             action: {
-              link: '/system/licence-monitoring-station',
+              link: `/system/notices/setup/${session.id}/abstraction-alerts/remove/${licenceMonitoringStationThree.id}`,
               text: 'Remove'
             },
             alert: null,
@@ -104,7 +104,7 @@ describe('Notices Setup - Abstraction Alerts - Check Licence Matches Presenter',
             {
               abstractionPeriod: '1 February to 1 January',
               action: {
-                link: '/system/licence-monitoring-station',
+                link: `/system/notices/setup/${session.id}/abstraction-alerts/remove/${licenceMonitoringStationOne.id}`,
                 text: 'Remove'
               },
               alert: null,
@@ -123,7 +123,7 @@ describe('Notices Setup - Abstraction Alerts - Check Licence Matches Presenter',
             const result = CheckLicenceMatchesPresenter.go(session)
 
             expect(result.restrictions[0].action).to.equal({
-              link: '/system/licence-monitoring-station',
+              link: `/system/notices/setup/${session.id}/abstraction-alerts/remove/${licenceMonitoringStationOne.id}`,
               text: 'Remove'
             })
           })

--- a/test/services/notices/setup/abstraction-alerts/check-licence-matches.service.test.js
+++ b/test/services/notices/setup/abstraction-alerts/check-licence-matches.service.test.js
@@ -53,7 +53,7 @@ describe('Notices Setup - Abstraction Alerts - Check Licence Matches Service', (
           {
             abstractionPeriod: '1 February to 1 January',
             action: {
-              link: '/system/licence-monitoring-station',
+              link: `/system/notices/setup/${session.id}/abstraction-alerts/remove/${licenceMonitoringStationOne.id}`,
               text: 'Remove'
             },
             alert: null,
@@ -67,7 +67,7 @@ describe('Notices Setup - Abstraction Alerts - Check Licence Matches Service', (
           {
             abstractionPeriod: '1 January to 31 March',
             action: {
-              link: '/system/licence-monitoring-station',
+              link: `/system/notices/setup/${session.id}/abstraction-alerts/remove/${licenceMonitoringStationTwo.id}`,
               text: 'Remove'
             },
             alert: null,
@@ -81,7 +81,7 @@ describe('Notices Setup - Abstraction Alerts - Check Licence Matches Service', (
           {
             abstractionPeriod: '1 January to 31 March',
             action: {
-              link: '/system/licence-monitoring-station',
+              link: `/system/notices/setup/${session.id}/abstraction-alerts/remove/${licenceMonitoringStationThree.id}`,
               text: 'Remove'
             },
             alert: null,

--- a/test/services/notices/setup/abstraction-alerts/determine-licence-monitoring-stations.service.test.js
+++ b/test/services/notices/setup/abstraction-alerts/determine-licence-monitoring-stations.service.test.js
@@ -36,6 +36,7 @@ describe('Notices Setup - Abstraction Alerts - Determine Licence Monitoring Stat
           statusUpdatedAt: null,
           thresholdUnit: 'm3/s',
           thresholdValue: 100,
+          id: 'c4f6d976-3b18-44bc-b2b4-a649421faf2e',
           licence: {
             id: '123',
             licenceRef: '01/01/01/6880'
@@ -53,6 +54,7 @@ describe('Notices Setup - Abstraction Alerts - Determine Licence Monitoring Stat
           statusUpdatedAt: null,
           thresholdUnit: 'm3/s',
           thresholdValue: 100,
+          id: '0cfcfcb0-989e-481f-9cc1-10a69d82ff3f',
           licence: {
             id: '456',
             licenceRef: '02/02/02/3116'
@@ -85,6 +87,7 @@ describe('Notices Setup - Abstraction Alerts - Determine Licence Monitoring Stat
           abstractionPeriodEndMonth: 1,
           abstractionPeriodStartDay: 1,
           abstractionPeriodStartMonth: 2,
+          id: 'c4f6d976-3b18-44bc-b2b4-a649421faf2e',
           measureType: 'flow',
           restrictionType: 'reduce',
           status: 'resume',
@@ -102,6 +105,7 @@ describe('Notices Setup - Abstraction Alerts - Determine Licence Monitoring Stat
           abstractionPeriodEndMonth: 3,
           abstractionPeriodStartDay: 1,
           abstractionPeriodStartMonth: 1,
+          id: '0cfcfcb0-989e-481f-9cc1-10a69d82ff3f',
           measureType: 'level',
           restrictionType: 'reduce',
           status: 'resume',

--- a/test/services/notices/setup/abstraction-alerts/fetch-monitoring-station.service.test.js
+++ b/test/services/notices/setup/abstraction-alerts/fetch-monitoring-station.service.test.js
@@ -20,6 +20,8 @@ const FetchMonitoringStationService = require('../../../../../app/services/notic
 
 describe('Notices Setup - Abstraction Alerts - Fetch Monitoring Station service', () => {
   let licence
+  let licenceMonitoringStation
+  let licenceMonitoringStationWithVersionPurpose
   let licenceVersionPurpose
   let licenceVersionPurposeCondition
   let licenceWithVersionPurpose
@@ -31,7 +33,7 @@ describe('Notices Setup - Abstraction Alerts - Fetch Monitoring Station service'
     // A licence with the abstraction data from the Licence monitoring station
     licence = await LicenceHelper.add({ licenceRef: `01/01/01/${generateRandomInteger(1, 9999)}` })
 
-    await LicenceMonitoringStationHelper.add({
+    licenceMonitoringStation = await LicenceMonitoringStationHelper.add({
       licenceId: licence.id,
       monitoringStationId: monitoringStation.id,
       abstractionPeriodEndDay: '01',
@@ -49,7 +51,7 @@ describe('Notices Setup - Abstraction Alerts - Fetch Monitoring Station service'
       licenceVersionPurposeId: licenceVersionPurpose.id
     })
 
-    await LicenceMonitoringStationHelper.add({
+    licenceMonitoringStationWithVersionPurpose = await LicenceMonitoringStationHelper.add({
       licenceId: licenceWithVersionPurpose.id,
       licenceVersionPurposeConditionId: licenceVersionPurposeCondition.id,
       monitoringStationId: monitoringStation.id
@@ -68,6 +70,7 @@ describe('Notices Setup - Abstraction Alerts - Fetch Monitoring Station service'
           abstractionPeriodEndMonth: 1,
           abstractionPeriodStartDay: 1,
           abstractionPeriodStartMonth: 2,
+          id: licenceMonitoringStation.id,
           licence: {
             id: licence.id,
             licenceRef: licence.licenceRef
@@ -85,6 +88,7 @@ describe('Notices Setup - Abstraction Alerts - Fetch Monitoring Station service'
           abstractionPeriodEndMonth: null,
           abstractionPeriodStartDay: null,
           abstractionPeriodStartMonth: null,
+          id: licenceMonitoringStationWithVersionPurpose.id,
           licence: {
             id: licenceWithVersionPurpose.id,
             licenceRef: licenceWithVersionPurpose.licenceRef
@@ -118,6 +122,7 @@ describe('Notices Setup - Abstraction Alerts - Fetch Monitoring Station service'
         abstractionPeriodEndMonth: null,
         abstractionPeriodStartDay: null,
         abstractionPeriodStartMonth: null,
+        id: licenceMonitoringStationWithVersionPurpose.id,
         licence: {
           id: licenceWithVersionPurpose.id,
           licenceRef: licenceWithVersionPurpose.licenceRef
@@ -150,6 +155,7 @@ describe('Notices Setup - Abstraction Alerts - Fetch Monitoring Station service'
         abstractionPeriodEndMonth: 1,
         abstractionPeriodStartDay: 1,
         abstractionPeriodStartMonth: 2,
+        id: licenceMonitoringStation.id,
         licence: {
           id: licence.id,
           licenceRef: licence.licenceRef


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5028

We have changed the legacy check licence matches page to allow individual thresholds / licence monitoring stations to be removed.

This change update the stubbed link with the correct path and  licence monitoring station id.

The endpoint does not exist yet. And will be added in a later change.