### PR TITLE
Update notifications setup abstraction alert types error message

### DIFF
--- a/app/services/notices/setup/abstraction-alerts/submit-alert-type.service.js
+++ b/app/services/notices/setup/abstraction-alerts/submit-alert-type.service.js
@@ -21,7 +21,7 @@ const SessionModel = require('../../../../models/session.model.js')
 async function go(sessionId, payload) {
   const session = await SessionModel.query().findById(sessionId)
 
-  const validationResult = _validate(payload)
+  const validationResult = _validate(payload, session.licenceMonitoringStations)
 
   if (!validationResult) {
     await _save(session, payload)
@@ -48,8 +48,8 @@ async function _save(session, payload) {
   return session.$update()
 }
 
-function _validate(payload) {
-  const validation = AlertTypeValidator.go(payload)
+function _validate(payload, licenceMonitoringStations) {
+  const validation = AlertTypeValidator.go(payload, licenceMonitoringStations)
 
   if (!validation.error) {
     return null

--- a/app/validators/notices/setup/abstraction-alerts/alert-type.validator.js
+++ b/app/validators/notices/setup/abstraction-alerts/alert-type.validator.js
@@ -14,19 +14,41 @@ const errorMessage = 'Select the type of alert you need to send'
  * Validates data submitted for the `/notices/setup/{sessionId}/abstraction-alerts/alert-type` page
  *
  * @param {object} payload - The payload from the request to be validated
+ * @param {object[]} licenceMonitoringStations - used to check if the user has selected an unavailable type
  *
  * @returns {object} the result from calling Joi's schema.validate(). It will be an object with a `value:` property. If
  * any errors are found the `error:` property will also exist detailing what the issues were
  */
-function go(payload) {
+function go(payload, licenceMonitoringStations) {
+  const restrictionTypes = _availableRestrictionType(licenceMonitoringStations)
+
   const schema = Joi.object({
-    'alert-type': Joi.required().messages({
-      'any.required': errorMessage,
-      'any.only': errorMessage
-    })
+    'alert-type': Joi.valid(...restrictionTypes)
+      .required()
+      .messages({
+        'any.required': errorMessage,
+        'any.only': `There are no thresholds with the {#value} restriction type, ${errorMessage}`
+      })
   })
 
   return schema.validate(payload, { abortEarly: false })
+}
+
+/**
+ * Returns a list of available alert types based on the restriction types
+ * found in the provided licence monitoring stations.
+ *
+ * Includes the default alert types: 'warning' and 'resume',
+ * followed by any additional restriction types extracted from the input.
+ *
+ * @private
+ */
+function _availableRestrictionType(licenceMonitoringStations) {
+  const restrictionTypes = licenceMonitoringStations.map((licenceMonitoringStation) => {
+    return licenceMonitoringStation.restrictionType
+  })
+
+  return ['warning', 'resume', ...restrictionTypes]
 }
 
 module.exports = {

--- a/test/services/notices/setup/abstraction-alerts/submit-alert-type.service.test.js
+++ b/test/services/notices/setup/abstraction-alerts/submit-alert-type.service.test.js
@@ -80,57 +80,122 @@ describe('Notices Setup - Abstraction Alerts - Alert Type Service', () => {
   })
 
   describe('when validation fails', () => {
-    beforeEach(async () => {
-      payload = {}
+    describe('and no option has been selected', () => {
+      beforeEach(async () => {
+        payload = {}
 
-      session = await SessionHelper.add({ data: sessionData })
+        session = await SessionHelper.add({ data: sessionData })
+      })
+
+      it('returns page data for the view, with errors', async () => {
+        const result = await SubmitAlertTypeService.go(session.id, payload)
+
+        expect(result).to.equal({
+          activeNavBar: 'manage',
+          alertTypeOptions: [
+            {
+              checked: false,
+              hint: {
+                text: 'Tell licence holders they may need to reduce or stop water abstraction soon.'
+              },
+              text: 'Warning',
+              value: 'warning'
+            },
+            {
+              checked: false,
+              hint: {
+                text: 'Tell licence holders they can take water at a reduced amount.'
+              },
+              text: 'Reduce',
+              value: 'reduce'
+            },
+            {
+              checked: false,
+              hint: {
+                text: 'Tell licence holders they must stop taking water.'
+              },
+              text: 'Stop',
+              value: 'stop'
+            },
+            {
+              checked: false,
+              hint: {
+                text: 'Tell licence holders they can take water at the normal amount.'
+              },
+              text: 'Resume',
+              value: 'resume'
+            }
+          ],
+          backLink: `/system/monitoring-stations/${sessionData.monitoringStationId}`,
+          caption: 'Death star',
+          error: {
+            text: 'Select the type of alert you need to send'
+          },
+          pageTitle: 'Select the type of alert you need to send'
+        })
+      })
     })
 
-    it('returns page data for the view, with errors', async () => {
-      const result = await SubmitAlertTypeService.go(session.id, payload)
+    describe('and "stop" or "reduce" have been selected but no thresholds have that alert type', () => {
+      beforeEach(async () => {
+        payload = { 'alert-type': 'stop' }
 
-      expect(result).to.equal({
-        activeNavBar: 'manage',
-        alertTypeOptions: [
+        sessionData.licenceMonitoringStations = [
           {
-            checked: false,
-            hint: {
-              text: 'Tell licence holders they may need to reduce or stop water abstraction soon.'
-            },
-            text: 'Warning',
-            value: 'warning'
-          },
-          {
-            checked: false,
-            hint: {
-              text: 'Tell licence holders they can take water at a reduced amount.'
-            },
-            text: 'Reduce',
-            value: 'reduce'
-          },
-          {
-            checked: false,
-            hint: {
-              text: 'Tell licence holders they must stop taking water.'
-            },
-            text: 'Stop',
-            value: 'stop'
-          },
-          {
-            checked: false,
-            hint: {
-              text: 'Tell licence holders they can take water at the normal amount.'
-            },
-            text: 'Resume',
-            value: 'resume'
+            ...sessionData.licenceMonitoringStations[0],
+            restrictionType: 'warning'
           }
-        ],
-        backLink: `/system/monitoring-stations/${sessionData.monitoringStationId}`,
-        caption: 'Death star',
-        error: {
-          text: 'Select the type of alert you need to send'
-        },
-        pageTitle: 'Select the type of alert you need to send'
+        ]
+
+        session = await SessionHelper.add({ data: sessionData })
+      })
+
+      it('returns page data for the view, with errors', async () => {
+        const result = await SubmitAlertTypeService.go(session.id, payload)
+
+        expect(result).to.equal({
+          activeNavBar: 'manage',
+          alertTypeOptions: [
+            {
+              checked: false,
+              hint: {
+                text: 'Tell licence holders they may need to reduce or stop water abstraction soon.'
+              },
+              text: 'Warning',
+              value: 'warning'
+            },
+            {
+              checked: false,
+              hint: {
+                text: 'Tell licence holders they can take water at a reduced amount.'
+              },
+              text: 'Reduce',
+              value: 'reduce'
+            },
+            {
+              checked: false,
+              hint: {
+                text: 'Tell licence holders they must stop taking water.'
+              },
+              text: 'Stop',
+              value: 'stop'
+            },
+            {
+              checked: false,
+              hint: {
+                text: 'Tell licence holders they can take water at the normal amount.'
+              },
+              text: 'Resume',
+              value: 'resume'
+            }
+          ],
+          backLink: `/system/monitoring-stations/${sessionData.monitoringStationId}`,
+          caption: 'Death star',
+          error: {
+            text: 'There are no thresholds with the stop restriction type, Select the type of alert you need to send'
+          },
+          pageTitle: 'Select the type of alert you need to send'
+        })
       })
     })
   })

--- a/test/validators/notices/setup/abstraction-alerts/alert-type.validator.test.js
+++ b/test/validators/notices/setup/abstraction-alerts/alert-type.validator.test.js
@@ -7,21 +7,29 @@ const Code = require('@hapi/code')
 const { describe, it, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
+// Test helpers
+const AbstractionAlertSessionData = require('../../../../fixtures/abstraction-alert-session-data.fixture.js')
+
 // Thing under test
 const AlertTypeValidator = require('../../../../../app/validators/notices/setup/abstraction-alerts/alert-type.validator.js')
 
 describe('Notices - Setup - Abstraction Alerts - Alert Type Validator', () => {
   let payload
+  let licenceMonitoringStations
 
   beforeEach(() => {
     payload = {
       'alert-type': 'stop'
     }
+
+    const abstractionAlertSessionData = AbstractionAlertSessionData.monitoringStation()
+
+    licenceMonitoringStations = abstractionAlertSessionData.licenceMonitoringStations
   })
 
   describe('when called with valid data', () => {
     it('returns with no errors', () => {
-      const result = AlertTypeValidator.go(payload)
+      const result = AlertTypeValidator.go(payload, licenceMonitoringStations)
 
       expect(result.value).to.exist()
       expect(result.error).not.to.exist()
@@ -29,16 +37,39 @@ describe('Notices - Setup - Abstraction Alerts - Alert Type Validator', () => {
   })
 
   describe('when called with invalid data', () => {
-    beforeEach(() => {
-      payload = {}
+    describe('and the payload is empty', () => {
+      beforeEach(() => {
+        payload = {}
+      })
+
+      it('returns with errors', () => {
+        const result = AlertTypeValidator.go(payload, licenceMonitoringStations)
+
+        expect(result.value).to.exist()
+        expect(result.error).to.exist()
+        expect(result.error.details[0].message).to.equal('Select the type of alert you need to send')
+      })
     })
 
-    it('returns with errors', () => {
-      const result = AlertTypeValidator.go(payload)
+    describe('and the "alert-type" is not available', () => {
+      beforeEach(() => {
+        licenceMonitoringStations = [
+          {
+            ...licenceMonitoringStations[0],
+            restrictionType: 'warning'
+          }
+        ]
+      })
 
-      expect(result.value).to.exist()
-      expect(result.error).to.exist()
-      expect(result.error.details[0].message).to.equal('Select the type of alert you need to send')
+      it('returns with errors', () => {
+        const result = AlertTypeValidator.go(payload, licenceMonitoringStations)
+
+        expect(result.value).to.exist()
+        expect(result.error).to.exist()
+        expect(result.error.details[0].message).to.equal(
+          'There are no thresholds with the stop restriction type, Select the type of alert you need to send'
+        )
+      })
     })
   })
 })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5033

When a user selects an alert type that is not warning or resume. We need to check that the selected alert type is available as a restriction type to send the alert notification.

This change updates the alert type submit service and validator to check if the selected alert type is available.