### PR TITLE
Add `console.dir()` check to github CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,19 +78,11 @@ jobs:
         run: |
           ! grep -R 'describe.only(\|it.only(' test
 
-      # Alongside this, check we haven't accidentally left any `console.log()` while checking results in app and tests
+      # Alongside this, check we haven't accidentally left any `console.log` or `console.dir` while checking results in app and tests
       - name: Temporary log check
         run: |
-          if grep -R 'console.log(' ./app/ ./test/; then
-            echo "console.log statement found. Please remove it."
-            exit 1
-          fi
-
-      # Also check we haven't accidentally left any `console.dir()` while checking results in app and tests
-      - name: Temporary log check
-        run: |
-          if grep -R 'console.dir(' ./app/ ./test/; then
-            echo "console.dir statement found. Please remove it."
+          if grep -R 'console.log(\|console.dir(' ./app/ ./test/; then
+            echo "console statement found. Please remove it."
             exit 1
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,14 @@ jobs:
             exit 1
           fi
 
+      # Also check we haven't accidentally left any `console.dir()` while checking results in app and tests
+      - name: Temporary log check
+        run: |
+          if grep -R 'console.dir(' ./app/ ./test/; then
+            echo "console.dir statement found. Please remove it."
+            exit 1
+          fi
+
       - name: Install Node
         uses: actions/setup-node@v4
         with:

--- a/app/services/licences/view-licence.service.js
+++ b/app/services/licences/view-licence.service.js
@@ -18,7 +18,6 @@ const ViewLicencePresenter = require('../../presenters/licences/view-licence.pre
  */
 async function go(licenceId, auth) {
   const licence = await FetchLicenceService.go(licenceId)
-  console.log('🚀🚀🚀 ~ licence:')
   console.dir(licence, { depth: null, colors: true })
 
   const pageData = ViewLicencePresenter.go(licence, auth)

--- a/app/services/licences/view-licence.service.js
+++ b/app/services/licences/view-licence.service.js
@@ -18,6 +18,8 @@ const ViewLicencePresenter = require('../../presenters/licences/view-licence.pre
  */
 async function go(licenceId, auth) {
   const licence = await FetchLicenceService.go(licenceId)
+  console.log('🚀🚀🚀 ~ licence:')
+  console.dir(licence, { depth: null, colors: true })
 
   const pageData = ViewLicencePresenter.go(licence, auth)
 

--- a/app/services/licences/view-licence.service.js
+++ b/app/services/licences/view-licence.service.js
@@ -18,7 +18,6 @@ const ViewLicencePresenter = require('../../presenters/licences/view-licence.pre
  */
 async function go(licenceId, auth) {
   const licence = await FetchLicenceService.go(licenceId)
-  console.dir(licence, { depth: null, colors: true })
 
   const pageData = ViewLicencePresenter.go(licence, auth)
 

--- a/app/services/licences/view-licence.service.js
+++ b/app/services/licences/view-licence.service.js
@@ -18,6 +18,7 @@ const ViewLicencePresenter = require('../../presenters/licences/view-licence.pre
  */
 async function go(licenceId, auth) {
   const licence = await FetchLicenceService.go(licenceId)
+  console.log('🚀🚀🚀 ~ licence:')
 
   const pageData = ViewLicencePresenter.go(licence, auth)
 

--- a/app/services/licences/view-licence.service.js
+++ b/app/services/licences/view-licence.service.js
@@ -18,7 +18,6 @@ const ViewLicencePresenter = require('../../presenters/licences/view-licence.pre
  */
 async function go(licenceId, auth) {
   const licence = await FetchLicenceService.go(licenceId)
-  console.log('🚀🚀🚀 ~ licence:')
 
   const pageData = ViewLicencePresenter.go(licence, auth)
 


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/136

Previously, we had an issue with `console.log()` being found in the system code base - [Check for console.log() in CI](https://github.com/DEFRA/water-abstraction-team/issues/94). This was resolved by adding a check to the Github CI prevent successful builds when `console.log()` statements are present in the codebase.

Now with the use of `console.dir()` to print full Javascript objects, thanks to [Logify 🚀 ](https://github.com/rvsiyad/logify), there has been similar instances of forgetting to remove the print statements, which the CI will not pick up due to the different type of logging. This has led to changes being requested to PRs which has become repetitive. To avoid this, it would be great if our CI could catch these in the future to prevent us from making this mistake.

This PR adds a check for `console.dir()` to the CI.