### PR TITLE
Add notifications setup abstraction alert cancel scaffold

### DIFF
--- a/app/controllers/notices-setup.controller.js
+++ b/app/controllers/notices-setup.controller.js
@@ -8,6 +8,7 @@
 const AdHocLicenceService = require('../services/notices/setup/ad-hoc/ad-hoc-licence.service.js')
 const AlertThresholdsService = require('../services/notices/setup/abstraction-alerts/alert-thresholds.service.js')
 const AlertTypeService = require('../services/notices/setup/abstraction-alerts/alert-type.service.js')
+const CancelAlertsService = require('../services/notices/setup/abstraction-alerts/cancel-alerts.service.js')
 const CancelService = require('../services/notices/setup/cancel.service.js')
 const CheckLicenceMatchesService = require('../services/notices/setup/abstraction-alerts/check-licence-matches.service.js')
 const CheckService = require('../services/notices/setup/check.service.js')
@@ -19,6 +20,7 @@ const ReturnsPeriodService = require('../services/notices/setup/returns-period/r
 const SubmitAdHocLicenceService = require('../services/notices/setup/ad-hoc/submit-ad-hoc-licence.service.js')
 const SubmitAlertThresholdsService = require('../services/notices/setup/abstraction-alerts/submit-alert-thresholds.service.js')
 const SubmitAlertTypeService = require('../services/notices/setup/abstraction-alerts/submit-alert-type.service.js')
+const SubmitCancelAlertsService = require('../services/notices/setup/abstraction-alerts/submit-cancel-alerts.service.js')
 const SubmitCancelService = require('../services/notices/setup/submit-cancel.service.js')
 const SubmitCheckService = require('../services/notices/setup/submit-check.service.js')
 const SubmitRemoveLicencesService = require('../services/notices/setup/submit-remove-licences.service.js')
@@ -65,6 +67,14 @@ async function viewCancel(request, h) {
   const pageData = await CancelService.go(sessionId)
 
   return h.view(`${basePath}/cancel.njk`, pageData)
+}
+
+async function viewCancelAlerts(request, h) {
+  const { sessionId } = request.params
+
+  const pageData = await CancelAlertsService.go(sessionId)
+
+  return h.view(`notices/setup/abstraction-alerts/cancel-alerts.njk`, pageData)
 }
 
 async function viewCheckLicenceMatches(request, h) {
@@ -168,6 +178,16 @@ async function submitCancel(request, h) {
   return h.redirect(`/manage`)
 }
 
+async function submitCancelAlerts(request, h) {
+  const {
+    params: { sessionId }
+  } = request
+
+  await SubmitCancelAlertsService.go(sessionId)
+
+  return h.redirect('')
+}
+
 async function submitCheck(request, h) {
   const {
     auth,
@@ -226,6 +246,7 @@ module.exports = {
   viewAlertThresholds,
   viewAlertType,
   viewCancel,
+  viewCancelAlerts,
   viewCheck,
   viewCheckLicenceMatches,
   viewConfirmation,
@@ -236,6 +257,7 @@ module.exports = {
   submitAlertThresholds,
   submitAlertType,
   submitCancel,
+  submitCancelAlerts,
   submitCheck,
   submitLicence,
   submitRemoveLicences,

--- a/app/presenters/notices/setup/abstraction-alerts/cancel-alerts.presenter.js
+++ b/app/presenters/notices/setup/abstraction-alerts/cancel-alerts.presenter.js
@@ -1,0 +1,19 @@
+'use strict'
+
+/**
+ * Formats data for the `` page
+ * @module CancelAlertsPresenter
+ */
+
+/**
+ * Formats data for the `` page
+ *
+ * @returns {object} - The data formatted for the view template
+ */
+function go() {
+  return {}
+}
+
+module.exports = {
+  go
+}

--- a/app/routes/notices-setup.routes.js
+++ b/app/routes/notices-setup.routes.js
@@ -66,6 +66,30 @@ const routes = [
     }
   },
   {
+    method: 'GET',
+    path: basePath + '/{sessionId}/abstraction-alerts/cancel',
+    options: {
+      handler: NoticesSetupController.viewCancelAlerts,
+      auth: {
+        access: {
+          scope: ['returns']
+        }
+      }
+    }
+  },
+  {
+    method: 'POST',
+    path: basePath + '/{sessionId}/abstraction-alerts/cancel',
+    options: {
+      handler: NoticesSetupController.submitCancelAlerts,
+      auth: {
+        access: {
+          scope: ['returns']
+        }
+      }
+    }
+  },
+  {
     method: 'POST',
     path: basePath + '/{sessionId}/abstraction-alerts/alert-thresholds',
     options: {

--- a/app/services/notices/setup/abstraction-alerts/cancel-alerts.service.js
+++ b/app/services/notices/setup/abstraction-alerts/cancel-alerts.service.js
@@ -1,0 +1,31 @@
+'use strict'
+
+/**
+ * Orchestrates fetching and presenting the data for the `` page
+ *
+ * @module CancelAlertsService
+ */
+
+const CancelAlertsPresenter = require('../../../../presenters/notices/setup/abstraction-alerts/cancel-alerts.presenter.js')
+const SessionModel = require('../../../../models/session.model.js')
+
+/**
+ * Orchestrates fetching and presenting the data for the `` page
+ *
+ * @param {string} sessionId
+ *
+ * @returns {Promise<object>} - The data formatted for the view template
+ */
+async function go(sessionId) {
+  const session = await SessionModel.query().findById(sessionId)
+
+  const pageData = CancelAlertsPresenter.go(session)
+
+  return {
+    ...pageData
+  }
+}
+
+module.exports = {
+  go
+}

--- a/app/services/notices/setup/abstraction-alerts/submit-cancel-alerts.service.js
+++ b/app/services/notices/setup/abstraction-alerts/submit-cancel-alerts.service.js
@@ -1,0 +1,24 @@
+'use strict'
+
+/**
+ * Orchestrates validating the data for `` page
+ *
+ * @module SubmitCancelAlertsService
+ */
+
+const SessionModel = require('../../../../models/session.model.js')
+
+/**
+ * Orchestrates validating the data for `` page
+ *
+ * @param {string} sessionId
+ *
+ * @returns {Promise<object>} - The data formatted for the view template
+ */
+async function go(sessionId) {
+  await SessionModel.query().delete().where('id', sessionId)
+}
+
+module.exports = {
+  go
+}

--- a/app/views/notices/setup/abstraction-alerts/cancel-alerts.njk
+++ b/app/views/notices/setup/abstraction-alerts/cancel-alerts.njk
@@ -1,0 +1,23 @@
+{% extends 'layout.njk' %}
+
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% block breadcrumbs %}
+  {{
+  govukBackLink({
+    text: 'Back',
+    href: backLink
+  })
+  }}
+{% endblock %}
+
+{% block content %}
+  <div>
+    <form method="post">
+      <input type="hidden" name="wrlsCrumb" value="{{wrlsCrumb}}"/>
+
+      {{ govukButton({ text: "Continue", preventDoubleClick: true }) }}
+    </form>
+  </div>
+{% endblock %}

--- a/test/controllers/notices-setup.controller.test.js
+++ b/test/controllers/notices-setup.controller.test.js
@@ -13,6 +13,7 @@ const { postRequestOptions } = require('../support/general.js')
 // Things we need to stub
 const AlertThresholdsService = require('../../app/services/notices/setup/abstraction-alerts/alert-thresholds.service.js')
 const AlertTypeService = require('../../app/services/notices/setup/abstraction-alerts/alert-type.service.js')
+const CancelAlertsService = require('../../app/services/notices/setup/abstraction-alerts/cancel-alerts.service.js')
 const CancelService = require('../../app/services/notices/setup/cancel.service.js')
 const CheckLicenceMatchesService = require('../../app/services/notices/setup/abstraction-alerts/check-licence-matches.service.js')
 const CheckService = require('../../app/services/notices/setup/check.service.js')
@@ -25,6 +26,7 @@ const ReturnsPeriodService = require('../../app/services/notices/setup/returns-p
 const SubmitAdHocLicenceService = require('../../app/services/notices/setup/ad-hoc/submit-ad-hoc-licence.service.js')
 const SubmitAlertThresholdsService = require('../../app/services/notices/setup/abstraction-alerts/submit-alert-thresholds.service.js')
 const SubmitAlertTypeService = require('../../app/services/notices/setup/abstraction-alerts/submit-alert-type.service.js')
+const SubmitCancelAlertsService = require('../../app/services/notices/setup/abstraction-alerts/submit-cancel-alerts.service.js')
 const SubmitCancelService = require('../../app/services/notices/setup/submit-cancel.service.js')
 const SubmitCheckService = require('../../app/services/notices/setup/submit-check.service.js')
 const SubmitRemoveLicencesService = require('../../app/services/notices/setup/submit-remove-licences.service.js')
@@ -365,6 +367,51 @@ describe('Notices Setup controller', () => {
             expect(response.statusCode).to.equal(200)
             expect(response.payload).to.contain('Alert page')
             expect(response.payload).to.contain('There is a problem')
+          })
+        })
+      })
+    })
+
+    describe('/cancel', () => {
+      describe('GET', () => {
+        beforeEach(async () => {
+          getOptions = {
+            method: 'GET',
+            url: basePath + `/${session.id}/abstraction-alerts/cancel`,
+            auth: {
+              strategy: 'session',
+              credentials: { scope: ['returns'] }
+            }
+          }
+
+          Sinon.stub(CancelAlertsService, 'go').resolves({
+            pageTitle: 'Cancel page'
+          })
+        })
+
+        describe('when a request is valid', () => {
+          it('returns the page successfully', async () => {
+            const response = await server.inject(getOptions)
+
+            expect(response.statusCode).to.equal(200)
+            expect(response.payload).to.contain('Cancel page')
+          })
+        })
+      })
+
+      describe('POST', () => {
+        describe('when a request is valid', () => {
+          beforeEach(async () => {
+            postOptions = postRequestOptions(basePath + `/${session.id}/abstraction-alerts/cancel`, {})
+
+            Sinon.stub(SubmitCancelAlertsService, 'go').resolves({})
+          })
+
+          it('redirects to the next page', async () => {
+            const response = await server.inject(postOptions)
+
+            expect(response.statusCode).to.equal(302)
+            expect(response.headers.location).to.equal(``)
           })
         })
       })

--- a/test/presenters/notices/setup/abstraction-alerts/cancel-alerts.presenter.test.js
+++ b/test/presenters/notices/setup/abstraction-alerts/cancel-alerts.presenter.test.js
@@ -1,0 +1,27 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Thing under test
+const CancelAlertsPresenter = require('../../../../../app/presenters/notices/setup/abstraction-alerts/cancel-alerts.presenter.js')
+
+describe('Cancel Alerts Presenter', () => {
+  let session
+
+  beforeEach(() => {
+    session = {}
+  })
+
+  describe('when called', () => {
+    it('returns page data for the view', () => {
+      const result = CancelAlertsPresenter.go(session)
+
+      expect(result).to.equal({})
+    })
+  })
+})

--- a/test/services/notices/setup/abstraction-alerts/cancel-alerts.service.test.js
+++ b/test/services/notices/setup/abstraction-alerts/cancel-alerts.service.test.js
@@ -1,0 +1,33 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Test helpers
+const SessionHelper = require('../../../../support/helpers/session.helper.js')
+
+// Thing under test
+const CancelAlertsService = require('../../../../../app/services/notices/setup/abstraction-alerts/cancel-alerts.service.js')
+
+describe('Cancel Alerts Service', () => {
+  let session
+  let sessionData
+
+  beforeEach(async () => {
+    sessionData = {}
+
+    session = await SessionHelper.add({ data: sessionData })
+  })
+
+  describe('when called', () => {
+    it('returns page data for the view', async () => {
+      const result = await CancelAlertsService.go(session.id)
+
+      expect(result).to.equal({})
+    })
+  })
+})

--- a/test/services/notices/setup/abstraction-alerts/submit-cancel-alerts.service.test.js
+++ b/test/services/notices/setup/abstraction-alerts/submit-cancel-alerts.service.test.js
@@ -1,0 +1,33 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Test helpers
+const SessionHelper = require('../../../../support/helpers/session.helper.js')
+const SessionModel = require('../../../../../app/models/session.model.js')
+
+// Thing under test
+const SubmitCancelAlertsService = require('../../../../../app/services/notices/setup/abstraction-alerts/submit-cancel-alerts.service.js')
+
+describe('Cancel Alerts Service', () => {
+  let session
+
+  beforeEach(async () => {
+    session = await SessionHelper.add()
+  })
+
+  describe('when called', () => {
+    it('clears the session', async () => {
+      await SubmitCancelAlertsService.go(session.id)
+
+      const noSession = await SessionModel.query().where('id', session.id)
+
+      expect(noSession).to.equal([])
+    })
+  })
+})


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5056

We have a pattern on check pages to allow the user to cancel the journey.

This change adds the 'cancel-alert' service, presenters and route. These are barebones and the implementation of the business logic will be added in another change.