### PR TITLE
Update notices abstraction alerts doc paths

### DIFF
--- a/app/presenters/notices/setup/abstraction-alerts/alert-thresholds.presenter.js
+++ b/app/presenters/notices/setup/abstraction-alerts/alert-thresholds.presenter.js
@@ -1,14 +1,14 @@
 'use strict'
 
 /**
- * Formats data for the `/notices/setup/{sessionId}/abstraction-alert/alert-thresholds` page
+ * Formats data for the `/notices/setup/{sessionId}/abstraction-alerts/alert-thresholds` page
  * @module AlertThresholdsPresenter
  */
 
 const { titleCase } = require('../../../base.presenter.js')
 
 /**
- * Formats data for the `/notices/setup/{sessionId}/abstraction-alert/alert-thresholds` page
+ * Formats data for the `/notices/setup/{sessionId}/abstraction-alerts/alert-thresholds` page
  *
  * @param {module:SessionModel} session - The session instance
  *

--- a/app/presenters/notices/setup/abstraction-alerts/alert-type.presenter.js
+++ b/app/presenters/notices/setup/abstraction-alerts/alert-type.presenter.js
@@ -1,13 +1,13 @@
 'use strict'
 
 /**
- * Formats data for the `/notices/setup/{sessionId}/abstraction-alert/alert-type` page
+ * Formats data for the `/notices/setup/{sessionId}/abstraction-alerts/alert-type` page
  *
  * @module AlertTypePresenter
  */
 
 /**
- * Formats data for the `/notices/setup/{sessionId}/abstraction-alert/alert-type` page
+ * Formats data for the `/notices/setup/{sessionId}/abstraction-alerts/alert-type` page
  *
  * @param {module:SessionModel} session - The session instance
  *

--- a/app/services/notices/setup/abstraction-alerts/alert-thresholds.service.js
+++ b/app/services/notices/setup/abstraction-alerts/alert-thresholds.service.js
@@ -1,7 +1,7 @@
 'use strict'
 
 /**
- * Orchestrates presenting the data for `/notices/setup/{sessionId}/abstraction-alert/alert-thresholds` page
+ * Orchestrates presenting the data for `/notices/setup/{sessionId}/abstraction-alerts/alert-thresholds` page
  *
  * @module AlertThresholdsService
  */
@@ -10,7 +10,7 @@ const AlertThresholdsPresenter = require('../../../../presenters/notices/setup/a
 const SessionModel = require('../../../../models/session.model.js')
 
 /**
- * Orchestrates presenting the data for `/notices/setup/{sessionId}/abstraction-alert/alert-thresholds` page
+ * Orchestrates presenting the data for `/notices/setup/{sessionId}/abstraction-alerts/alert-thresholds` page
  *
  * @param {string} sessionId
  *

--- a/app/services/notices/setup/abstraction-alerts/alert-type.service.js
+++ b/app/services/notices/setup/abstraction-alerts/alert-type.service.js
@@ -1,7 +1,7 @@
 'use strict'
 
 /**
- * Orchestrates presenting the data for `/notices/setup/{sessionId}/abstraction-alert/alert-type` page
+ * Orchestrates presenting the data for `/notices/setup/{sessionId}/abstraction-alerts/alert-type` page
  *
  * @module AlertTypeService
  */
@@ -10,7 +10,7 @@ const AlertTypePresenter = require('../../../../presenters/notices/setup/abstrac
 const SessionModel = require('../../../../models/session.model.js')
 
 /**
- * Orchestrates presenting the data for `/notices/setup/{sessionId}/abstraction-alert/alert-type` page
+ * Orchestrates presenting the data for `/notices/setup/{sessionId}/abstraction-alerts/alert-type` page
  *
  * @param {string} sessionId
  *

--- a/app/services/notices/setup/abstraction-alerts/submit-alert-thresholds.service.js
+++ b/app/services/notices/setup/abstraction-alerts/submit-alert-thresholds.service.js
@@ -1,7 +1,7 @@
 'use strict'
 
 /**
- * Orchestrates validating the data for `/notices/setup/{sessionId}/abstraction-alert/alert-thresholds` page
+ * Orchestrates validating the data for `/notices/setup/{sessionId}/abstraction-alerts/alert-thresholds` page
  *
  * @module SubmitAlertThresholdsService
  */
@@ -13,7 +13,7 @@ const SessionModel = require('../../../../models/session.model.js')
 const ALERT_THRESHOLDS_KEY = 'alert-thresholds'
 
 /**
- * Orchestrates validating the data for `/notices/setup/{sessionId}/abstraction-alert/alert-thresholds` page
+ * Orchestrates validating the data for `/notices/setup/{sessionId}/abstraction-alerts/alert-thresholds` page
  *
  * @param {string} sessionId
  * @param {object} payload - The submitted form data

--- a/app/validators/notices/setup/abstraction-alerts/alert-thresholds.validator.js
+++ b/app/validators/notices/setup/abstraction-alerts/alert-thresholds.validator.js
@@ -1,7 +1,7 @@
 'use strict'
 
 /**
- * Validates data submitted for the `/notices/setup/{sessionId}/abstraction-alert/alert-thresholds` page
+ * Validates data submitted for the `/notices/setup/{sessionId}/abstraction-alerts/alert-thresholds` page
  *
  * @module AlertThresholdsValidator
  */
@@ -11,7 +11,7 @@ const Joi = require('joi')
 const ERROR_MESSAGE = 'Select applicable threshold(s)'
 
 /**
- * Validates data submitted for the `/notices/setup/{sessionId}/abstraction-alert/alert-thresholds` page
+ * Validates data submitted for the `/notices/setup/{sessionId}/abstraction-alerts/alert-thresholds` page
  *
  * @param {object} payload - The payload from the request to be validated
  *


### PR DESCRIPTION
The journey for abstraction alerts in on the path '/notices/setup/{sessionId}/abstraction-alerts/'.

Some of the docs are not using the correct path.

This change updates the doc paths to match the actual path used in the route.