### PR TITLE
Update notices setup abstraction alerts - alert type

### DIFF
--- a/app/services/notices/setup/abstraction-alerts/submit-alert-type.service.js
+++ b/app/services/notices/setup/abstraction-alerts/submit-alert-type.service.js
@@ -10,6 +10,8 @@ const AlertTypePresenter = require('../../../../presenters/notices/setup/abstrac
 const AlertTypeValidator = require('../../../../validators/notices/setup/abstraction-alerts/alert-type.validator.js')
 const SessionModel = require('../../../../models/session.model.js')
 
+const ALERT_TYPE_KEY = 'alert-type'
+
 /**
  * Orchestrates validating the data for `/notices/setup/{sessionId}/abstraction-alerts/alert-type` page
  *
@@ -29,7 +31,7 @@ async function go(sessionId, payload) {
     return {}
   }
 
-  session.alertType = payload['alert-type']
+  session.alertType = payload[ALERT_TYPE_KEY]
 
   const pageData = AlertTypePresenter.go(session)
 
@@ -41,11 +43,11 @@ async function go(sessionId, payload) {
 }
 
 async function _save(session, payload) {
-  if (session.alertType !== payload['alert-type']) {
+  if (session.alertType !== payload[ALERT_TYPE_KEY]) {
     session.alertThresholds = []
   }
 
-  session.alertType = payload['alert-type']
+  session.alertType = payload[ALERT_TYPE_KEY]
 
   return session.$update()
 }

--- a/app/services/notices/setup/abstraction-alerts/submit-alert-type.service.js
+++ b/app/services/notices/setup/abstraction-alerts/submit-alert-type.service.js
@@ -29,6 +29,8 @@ async function go(sessionId, payload) {
     return {}
   }
 
+  session.alertType = payload['alert-type']
+
   const pageData = AlertTypePresenter.go(session)
 
   return {

--- a/test/services/notices/setup/abstraction-alerts/submit-alert-type.service.test.js
+++ b/test/services/notices/setup/abstraction-alerts/submit-alert-type.service.test.js
@@ -150,7 +150,7 @@ describe('Notices Setup - Abstraction Alerts - Alert Type Service', () => {
         session = await SessionHelper.add({ data: sessionData })
       })
 
-      it('returns page data for the view, with errors', async () => {
+      it('returns page data for the view, with errors (and the selected alert type checked)', async () => {
         const result = await SubmitAlertTypeService.go(session.id, payload)
 
         expect(result).to.equal({
@@ -173,7 +173,7 @@ describe('Notices Setup - Abstraction Alerts - Alert Type Service', () => {
               value: 'reduce'
             },
             {
-              checked: false,
+              checked: true,
               hint: {
                 text: 'Tell licence holders they must stop taking water.'
               },


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5014

We have introduced an additional validation step which is triggered when there are no licence monitoring stations with the alert type the user has selected.

When we added this change we missed setting the selected box with the users provided alert type.

This change updates the alert-type submit service to pass the user selected alert type into the alert type submit presenter.