### PR TITLE
Update notifications setup abstraction check licence remove service

### DIFF
--- a/app/presenters/notices/setup/abstraction-alerts/check-licence-matches.presenter.js
+++ b/app/presenters/notices/setup/abstraction-alerts/check-licence-matches.presenter.js
@@ -32,6 +32,13 @@ function go(session) {
   }
 }
 
+function _action(sessionId, licenceMonitoringStation) {
+  return {
+    link: `/system/notices/setup/${sessionId}/abstraction-alerts/remove-threshold/${licenceMonitoringStation.id}`,
+    text: 'Remove'
+  }
+}
+
 function _relevantLicenceMonitoringStations(licenceMonitoringStations, alertThresholds, removedThresholds) {
   const relevantLicenceMonitoringStations = licenceMonitoringStations.filter((licenceMonitoringStation) => {
     return alertThresholds.includes(licenceMonitoringStation.thresholdGroup)
@@ -66,13 +73,6 @@ function _restrictions(licenceMonitoringStations, alertThresholds, removedThresh
   })
 
   return formatRestrictions(preparedLicenceMonitoringStations)
-}
-
-function _action(sessionId, licenceMonitoringStation) {
-  return {
-    link: `/system/notices/setup/${sessionId}/abstraction-alerts/remove-threshold/${licenceMonitoringStation.id}`,
-    text: 'Remove'
-  }
 }
 
 module.exports = {

--- a/app/presenters/notices/setup/abstraction-alerts/check-licence-matches.presenter.js
+++ b/app/presenters/notices/setup/abstraction-alerts/check-licence-matches.presenter.js
@@ -53,13 +53,12 @@ function _restrictions(licenceMonitoringStations, alertThresholds, removedThresh
     removedThresholds
   )
 
+  const multipleRestrictions = relevantLicenceMonitoringStations.length > 1
+
   const preparedLicenceMonitoringStations = relevantLicenceMonitoringStations.map((licenceMonitoringStation) => {
     return {
       ...licenceMonitoringStation,
-      action: {
-        link: `/system/notices/setup/${sessionId}/abstraction-alerts/remove-threshold/${licenceMonitoringStation.id}`,
-        text: 'Remove'
-      },
+      action: multipleRestrictions ? _action(sessionId, licenceMonitoringStation) : null,
       statusUpdatedAt: licenceMonitoringStation.statusUpdatedAt
         ? new Date(licenceMonitoringStation.statusUpdatedAt)
         : null
@@ -67,6 +66,13 @@ function _restrictions(licenceMonitoringStations, alertThresholds, removedThresh
   })
 
   return formatRestrictions(preparedLicenceMonitoringStations)
+}
+
+function _action(sessionId, licenceMonitoringStation) {
+  return {
+    link: `/system/notices/setup/${sessionId}/abstraction-alerts/remove-threshold/${licenceMonitoringStation.id}`,
+    text: 'Remove'
+  }
 }
 
 module.exports = {

--- a/test/presenters/notices/setup/abstraction-alerts/check-licence-matches.presenter.test.js
+++ b/test/presenters/notices/setup/abstraction-alerts/check-licence-matches.presenter.test.js
@@ -195,7 +195,7 @@ describe('Notices Setup - Abstraction Alerts - Check Licence Matches Presenter',
               session.removedThresholds = [licenceMonitoringStationOne.id, licenceMonitoringStationTwo.id]
             })
 
-            it('should not show any remove links fro the remaining restriction', () => {
+            it('should not show any remove links for the remaining restriction', () => {
               const result = CheckLicenceMatchesPresenter.go(session)
 
               expect(result.restrictions).to.equal([

--- a/test/presenters/notices/setup/abstraction-alerts/check-licence-matches.presenter.test.js
+++ b/test/presenters/notices/setup/abstraction-alerts/check-licence-matches.presenter.test.js
@@ -189,6 +189,30 @@ describe('Notices Setup - Abstraction Alerts - Check Licence Matches Presenter',
               }
             ])
           })
+
+          describe('when there is only one threshold left to display', () => {
+            beforeEach(() => {
+              session.removedThresholds = [licenceMonitoringStationOne.id, licenceMonitoringStationTwo.id]
+            })
+
+            it('should not show any remove links fro the remaining restriction', () => {
+              const result = CheckLicenceMatchesPresenter.go(session)
+
+              expect(result.restrictions).to.equal([
+                {
+                  abstractionPeriod: '1 January to 31 March',
+                  action: null,
+                  alert: null,
+                  alertDate: null,
+                  licenceId: licenceMonitoringStationThree.licence.id,
+                  licenceRef: licenceMonitoringStationThree.licence.licenceRef,
+                  restriction: 'Stop',
+                  restrictionCount: 1,
+                  threshold: '100 m'
+                }
+              ])
+            })
+          })
         })
       })
     })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5028

We have changed the legacy check licence matches page to allow individual thresholds / licence monitoring stations to be removed.

This change updates the previous work to not show the remove link when there is only one restriction left from the relevant licence monitoring list.