### PR TITLE
Update notifications setup abstraction check licence remove service flash notification

### DIFF
--- a/app/controllers/notices-setup.controller.js
+++ b/app/controllers/notices-setup.controller.js
@@ -79,9 +79,12 @@ async function viewCancelAlerts(request, h) {
 }
 
 async function viewCheckLicenceMatches(request, h) {
-  const { sessionId } = request.params
+  const {
+    params: { sessionId },
+    yar
+  } = request
 
-  const pageData = await CheckLicenceMatchesService.go(sessionId)
+  const pageData = await CheckLicenceMatchesService.go(sessionId, yar)
 
   return h.view(`notices/setup/abstraction-alerts/check-licence-matches.njk`, pageData)
 }
@@ -134,9 +137,12 @@ async function viewCheck(request, h) {
 }
 
 async function viewRemoveThreshold(request, h) {
-  const { sessionId, licenceMonitoringStationId } = request.params
+  const {
+    params: { sessionId, licenceMonitoringStationId },
+    yar
+  } = request
 
-  await RemoveThresholdService.go(sessionId, licenceMonitoringStationId)
+  await RemoveThresholdService.go(sessionId, licenceMonitoringStationId, yar)
 
   return h.redirect(`/system/notices/setup/${sessionId}/abstraction-alerts/check-licence-matches`)
 }

--- a/app/presenters/monitoring-stations/base.presenter.js
+++ b/app/presenters/monitoring-stations/base.presenter.js
@@ -92,12 +92,33 @@ function formatRestrictions(licenceMonitoringStations) {
       alertDate: statusUpdatedAt ? formatLongDate(statusUpdatedAt) : null,
       licenceId: licence.id,
       licenceRef: licence.licenceRef,
-      restriction: _restriction(restrictionType),
+      restriction: formatRestrictionType(restrictionType),
       restrictionCount: _restrictionCount(licence.id, licenceMonitoringStations),
       threshold: `${thresholdValue} ${thresholdUnit}`,
       action
     }
   })
+}
+
+/**
+ * Formats the restriction type
+ *
+ * This can be 'stop', 'reduce' or 'stop_and_reduce'.
+ *
+ * When the restriction type is 'stop_and_reduce', we want to show the user 'Stop and reduce'.
+ *
+ * When it is something else it just needs to be in sentence case
+ *
+ * @param {string} restrictionType
+ *
+ * @returns {string}
+ */
+function formatRestrictionType(restrictionType) {
+  if (restrictionType === 'stop_or_reduce') {
+    return 'Stop or reduce'
+  }
+
+  return sentenceCase(restrictionType)
 }
 
 function _alert(status, statusUpdatedAt) {
@@ -106,14 +127,6 @@ function _alert(status, statusUpdatedAt) {
   }
 
   return sentenceCase(status)
-}
-
-function _restriction(restrictionType) {
-  if (restrictionType === 'stop_or_reduce') {
-    return 'Stop or reduce'
-  }
-
-  return sentenceCase(restrictionType)
 }
 
 function _restrictionCount(licenceId, licenceMonitoringStations) {
@@ -125,6 +138,7 @@ function _restrictionCount(licenceId, licenceMonitoringStations) {
 }
 
 module.exports = {
-  formatRestrictions,
-  determineRestrictionHeading
+  determineRestrictionHeading,
+  formatRestrictionType,
+  formatRestrictions
 }

--- a/app/services/notices/setup/abstraction-alerts/check-licence-matches.service.js
+++ b/app/services/notices/setup/abstraction-alerts/check-licence-matches.service.js
@@ -13,16 +13,21 @@ const SessionModel = require('../../../../models/session.model.js')
  * Orchestrates presenting the data for the `/notices/setup/{sessionId}/abstraction-alerts/check-licence-matches` page
  *
  * @param {string} sessionId - The UUID of the current session
+ * @param {object} yar - The Hapi `request.yar` session manager passed on by the controller
  *
  * @returns {Promise<object>} - The data formatted for the view template
  */
-async function go(sessionId) {
+async function go(sessionId, yar) {
   const session = await SessionModel.query().findById(sessionId)
 
   const pageData = CheckLicenceMatchesPresenter.go(session)
 
+  const notification = yar.flash('notification')[0]
+
   return {
-    ...pageData
+    activeNavBar: 'manage',
+    ...pageData,
+    notification
   }
 }
 

--- a/app/services/notices/setup/abstraction-alerts/remove-threshold.service.js
+++ b/app/services/notices/setup/abstraction-alerts/remove-threshold.service.js
@@ -6,19 +6,32 @@
  * @module RemoveThresholdService
  */
 
+const GeneralLib = require('../../../../lib/general.lib.js')
 const SessionModel = require('../../../../models/session.model.js')
+const { formatRestrictionType } = require('../../../../presenters/monitoring-stations/base.presenter.js')
 
 /**
  * Orchestrates removing the licence monitoring station from the thresholds list for - `/notices/setup/{sessionId}/abstraction-alerts/remove-threshold/{licenceMonitoringStationId}` page
  *
  * @param {string} sessionId
  * @param {string} licenceMonitoringStationId
+ * @param {object} yar - The Hapi `request.yar` session manager passed on by the controller
  *
  */
-async function go(sessionId, licenceMonitoringStationId) {
+async function go(sessionId, licenceMonitoringStationId, yar) {
   const session = await SessionModel.query().findById(sessionId)
 
   await _save(session, licenceMonitoringStationId)
+
+  GeneralLib.flashNotification(yar, 'Updated', _notificationMessage(session, licenceMonitoringStationId))
+}
+
+function _notificationMessage(session, licenceMonitoringStationId) {
+  const licenceMonitoringStation = session.licenceMonitoringStations.find((licenceMonitoringStation) => {
+    return licenceMonitoringStation.id === licenceMonitoringStationId
+  })
+
+  return `Removed ${licenceMonitoringStation.licence.licenceRef} ${formatRestrictionType(licenceMonitoringStation.restrictionType)} ${licenceMonitoringStation.thresholdValue}${licenceMonitoringStation.thresholdUnit}`
 }
 
 async function _save(session, licenceMonitoringStationId) {

--- a/app/services/notices/setup/abstraction-alerts/remove-threshold.service.js
+++ b/app/services/notices/setup/abstraction-alerts/remove-threshold.service.js
@@ -27,8 +27,8 @@ async function go(sessionId, licenceMonitoringStationId, yar) {
 }
 
 function _notificationMessage(session, licenceMonitoringStationId) {
-  const licenceMonitoringStation = session.licenceMonitoringStations.find((licenceMonitoringStation) => {
-    return licenceMonitoringStation.id === licenceMonitoringStationId
+  const licenceMonitoringStation = session.licenceMonitoringStations.find((station) => {
+    return station.id === licenceMonitoringStationId
   })
 
   return `Removed ${licenceMonitoringStation.licence.licenceRef} ${formatRestrictionType(licenceMonitoringStation.restrictionType)} ${licenceMonitoringStation.thresholdValue}${licenceMonitoringStation.thresholdUnit}`

--- a/app/views/notices/setup/abstraction-alerts/check-licence-matches.njk
+++ b/app/views/notices/setup/abstraction-alerts/check-licence-matches.njk
@@ -2,6 +2,7 @@
 
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
 
 {% from "macros/licence-monitoring-station-restrictions-table.njk" import licenceMonitoringStationRestrictionsTable %}
@@ -17,6 +18,13 @@
 
 {% block content %}
   <div>
+
+    {% if notification %}
+      {{ govukNotificationBanner({
+        titleText: notification.title,
+        text: notification.text
+      }) }}
+    {% endif %}
 
     <span class="govuk-caption-l">{{caption}}</span>
 

--- a/test/presenters/monitoring-stations/base.presenter.test.js
+++ b/test/presenters/monitoring-stations/base.presenter.test.js
@@ -210,4 +210,22 @@ describe('Monitoring Stations - Base presenter', () => {
       })
     })
   })
+
+  describe('#formatRestrictionType', () => {
+    describe('when the "RestrictionType" is "stop_or_reduce"', () => {
+      it('returns the restriction type in sentence case', () => {
+        const result = BasePresenter.formatRestrictionType('stop_or_reduce')
+
+        expect(result).to.equal('Stop or reduce')
+      })
+    })
+
+    describe('when the "RestrictionType" is not "stop_or_reduce"', () => {
+      it('returns the restriction type in sentence case', () => {
+        const result = BasePresenter.formatRestrictionType('stop')
+
+        expect(result).to.equal('Stop')
+      })
+    })
+  })
 })

--- a/test/services/notices/setup/abstraction-alerts/check-licence-matches.service.test.js
+++ b/test/services/notices/setup/abstraction-alerts/check-licence-matches.service.test.js
@@ -3,8 +3,9 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
+const Sinon = require('sinon')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -20,6 +21,7 @@ describe('Notices Setup - Abstraction Alerts - Check Licence Matches Service', (
   let licenceMonitoringStationTwo
   let session
   let sessionData
+  let yarStub
 
   beforeEach(async () => {
     const abstractionAlertSessionData = AbstractionAlertSessionData.monitoringStation()
@@ -38,15 +40,23 @@ describe('Notices Setup - Abstraction Alerts - Check Licence Matches Service', (
     }
 
     session = await SessionHelper.add({ data: sessionData })
+
+    yarStub = { flash: Sinon.stub().resolves() }
+  })
+
+  afterEach(() => {
+    Sinon.restore()
   })
 
   describe('when called', () => {
     it('returns page data for the view', async () => {
-      const result = await CheckLicenceMatchesService.go(session.id)
+      const result = await CheckLicenceMatchesService.go(session.id, yarStub)
 
       expect(result).to.equal({
+        activeNavBar: 'manage',
         backLink: `/system/notices/setup/${session.id}/abstraction-alerts/alert-thresholds`,
         caption: 'Death star',
+        notification: undefined,
         pageTitle: 'Check the licence matches for the selected thresholds',
         restrictionHeading: 'Flow and level restriction type and threshold',
         restrictions: [
@@ -93,6 +103,18 @@ describe('Notices Setup - Abstraction Alerts - Check Licence Matches Service', (
             threshold: '100 m'
           }
         ]
+      })
+    })
+
+    describe('when there is a notification', () => {
+      beforeEach(() => {
+        yarStub = { flash: Sinon.stub().returns(['Test notification']) }
+      })
+
+      it('should set the notification', async () => {
+        const result = await CheckLicenceMatchesService.go(session.id, yarStub)
+
+        expect(result.notification).to.equal('Test notification')
       })
     })
   })

--- a/test/services/notices/setup/abstraction-alerts/remove-threshold.service.test.js
+++ b/test/services/notices/setup/abstraction-alerts/remove-threshold.service.test.js
@@ -3,31 +3,49 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
+const Sinon = require('sinon')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
+const AbstractionAlertSessionData = require('../../../../fixtures/abstraction-alert-session-data.fixture.js')
 const SessionHelper = require('../../../../support/helpers/session.helper.js')
-const { generateUUID } = require('../../../../../app/lib/general.lib.js')
 
 // Thing under test
 const RemoveThresholdService = require('../../../../../app/services/notices/setup/abstraction-alerts/remove-threshold.service.js')
 
 describe('Remove Threshold Service', () => {
-  let session
+  let abstractionAlertSessionData
   let licenceMonitoringStationId
+  let licenceMonitoringStationOne
+  let session
+  let yarStub
+
+  beforeEach(() => {
+    abstractionAlertSessionData = AbstractionAlertSessionData.monitoringStation()
+
+    licenceMonitoringStationOne = abstractionAlertSessionData.licenceMonitoringStations[0]
+
+    licenceMonitoringStationId = licenceMonitoringStationOne.id
+
+    yarStub = { flash: Sinon.stub() }
+  })
+
+  afterEach(() => {
+    Sinon.restore()
+  })
 
   describe('when called', () => {
     describe('and there are no thresholds currently removed', () => {
       beforeEach(async () => {
-        licenceMonitoringStationId = generateUUID()
-
-        session = await SessionHelper.add()
+        session = await SessionHelper.add({
+          data: abstractionAlertSessionData
+        })
       })
 
       it('saves the "licenceMonitoringStationId" to the session to be excluded from the list', async () => {
-        await RemoveThresholdService.go(session.id, licenceMonitoringStationId)
+        await RemoveThresholdService.go(session.id, licenceMonitoringStationId, yarStub)
 
         const refreshedSession = await session.$query()
 
@@ -37,21 +55,43 @@ describe('Remove Threshold Service', () => {
 
     describe('and there are existing "removedThresholds"', () => {
       beforeEach(async () => {
-        licenceMonitoringStationId = generateUUID()
-
         session = await SessionHelper.add({
           data: {
+            ...abstractionAlertSessionData,
             removedThresholds: [licenceMonitoringStationId]
           }
         })
       })
 
       it('saves the "licenceMonitoringStationId" to the session with the existing "removedThresholds"', async () => {
-        await RemoveThresholdService.go(session.id, licenceMonitoringStationId)
+        await RemoveThresholdService.go(session.id, licenceMonitoringStationId, yarStub)
 
         const refreshedSession = await session.$query()
 
         expect(refreshedSession.removedThresholds).to.equal([licenceMonitoringStationId, licenceMonitoringStationId])
+      })
+    })
+
+    describe('and there is a notification', () => {
+      beforeEach(async () => {
+        session = await SessionHelper.add({
+          data: {
+            ...abstractionAlertSessionData,
+            removedThresholds: [licenceMonitoringStationId]
+          }
+        })
+      })
+      it('sets a flash message', async () => {
+        await RemoveThresholdService.go(session.id, licenceMonitoringStationId, yarStub)
+
+        // Check we add the flash message
+        const [flashType, bannerMessage] = yarStub.flash.args[0]
+
+        expect(flashType).to.equal('notification')
+        expect(bannerMessage).to.equal({
+          text: `Removed ${licenceMonitoringStationOne.licence.licenceRef} Reduce 1000m`,
+          title: 'Updated'
+        })
       })
     })
   })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5028

We have changed the legacy check licence matches page to allow individual thresholds / licence monitoring stations to be removed.

This change adds a notification banner to show the user they have removed a restriction / threshold from the list.