### PR TITLE
Update Two-part tariff annual years for 2024-25

### DIFF
--- a/app/presenters/bill-runs/setup/year.presenter.js
+++ b/app/presenters/bill-runs/setup/year.presenter.js
@@ -56,8 +56,7 @@ function _financialYearsData(licenceSupplementaryYears, selectedYear) {
 
 function _tptAnnualFinancialYearsData(selectedYear) {
   return [
-    { text: '2023 to 2024', value: 2024, checked: selectedYear === '2024' },
-    { text: '2022 to 2023', value: 2023, checked: selectedYear === '2023' },
+    { text: '2024 to 2025', value: 2025, checked: selectedYear === '2025' },
     { text: '2021 to 2022', value: 2022, checked: selectedYear === '2022' },
     { text: '2020 to 2021', value: 2021, checked: selectedYear === '2021' }
   ]

--- a/test/presenters/bill-runs/setup/year.presenter.test.js
+++ b/test/presenters/bill-runs/setup/year.presenter.test.js
@@ -121,14 +121,9 @@ describe('Bill Runs - Setup - Year presenter', () => {
 function _financialYearsData(selectedYear) {
   return [
     {
-      text: '2023 to 2024',
-      value: 2024,
-      checked: selectedYear === '2024'
-    },
-    {
-      text: '2022 to 2023',
-      value: 2023,
-      checked: selectedYear === '2023'
+      text: '2024 to 2025',
+      value: 2025,
+      checked: selectedYear === '2025'
     },
     {
       text: '2021 to 2022',


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5064

Currently, when you create a two-part tariff annual bill run, the journey presents you with a screen where you pick the financial year for which you are creating it.

This is because, for 'reasons', a backlog of two-part tariff annual bill runs has built up. Ordinarily, they would be processed yearly, so they it behaves like standard annual. Users don't select a year because the 'current' year (and for 2PT, 'current' means the previous financial year) is assumed.

Knowing this page in the annual year is only temporary, we decided to hard-code the years presented rather than waste resources trying to be 'clever'.

This ticket would have been to the 'drop the page'; however, some of the older two-part tariff bill runs are still on the backlog to be processed. Only 2022-23 and 2023-24 have been.

This change updates the page to display the following options

- 2024 to 2025
- 2021 to 2022
- 2020 to 2021

![water-5064](https://github.com/user-attachments/assets/96d2b53a-28aa-43ad-92be-9d36d7ffd4e5)
