### PR TITLE
Fix financial year column for billing account page

### DIFF
--- a/app/presenters/billing-account/view-billing-account.presenter.js
+++ b/app/presenters/billing-account/view-billing-account.presenter.js
@@ -78,7 +78,7 @@ function _bills(bills) {
       billRunType: formatBillRunType(billRun.batchType, billRun.scheme, billRun.summer),
       billTotal: bill.credit ? formatMoney(bill.netAmount) + ' Credit' : formatMoney(bill.netAmount),
       dateCreated: formatLongDate(bill.createdAt),
-      financialYear: bill.financialYear
+      financialYear: bill.financialYearEnding
     }
   })
 }

--- a/app/services/billing-accounts/fetch-view-billing-account.service.js
+++ b/app/services/billing-accounts/fetch-view-billing-account.service.js
@@ -5,8 +5,6 @@
  * @module FetchViewBillingAccountService
  */
 
-const { ref } = require('objection')
-
 const BillingAccountModel = require('../../models/billing-account.model.js')
 const BillModel = require('../../models/bill.model.js')
 
@@ -59,14 +57,7 @@ async function _fetchBillingAccount(id) {
 
 async function _fetchBills(billingAccountId, page) {
   return BillModel.query()
-    .select([
-      'id',
-      'createdAt',
-      'credit',
-      'invoiceNumber',
-      'netAmount',
-      ref('bills.metadata:FIN_YEAR').castInt().as('financialYear')
-    ])
+    .select(['id', 'createdAt', 'credit', 'financialYearEnding', 'invoiceNumber', 'netAmount'])
     .withGraphFetched('billRun')
     .modifyGraph('billRun', (builder) => {
       builder.select(['id', 'batchType', 'billRunNumber', 'scheme', 'source', 'summer'])

--- a/test/fixtures/billing-accounts.fixtures.js
+++ b/test/fixtures/billing-accounts.fixtures.js
@@ -57,7 +57,7 @@ function billingAccount() {
         credit: false,
         invoiceNumber: false,
         netAmount: 10384,
-        financialYear: 2021,
+        financialYearEnding: 2021,
         billRun: {
           id: 'eee30072-ad12-426a-9d69-c712f38e581d',
           batchType: 'annual',

--- a/test/services/billing-accounts/fetch-view-billing-account.service.test.js
+++ b/test/services/billing-accounts/fetch-view-billing-account.service.test.js
@@ -130,17 +130,17 @@ describe('Fetch Billing Account service', () => {
           {
             id: bill.id,
             createdAt: bill.createdAt,
-            credit: null,
-            invoiceNumber: null,
-            netAmount: null,
-            financialYear: null,
+            credit: bill.credit,
+            invoiceNumber: bill.invoiceNumber,
+            netAmount: bill.netAmount,
+            financialYearEnding: bill.financialYearEnding,
             billRun: {
               id: billRun.id,
-              batchType: 'supplementary',
-              billRunNumber: null,
-              scheme: 'sroc',
-              source: 'wrls',
-              summer: false
+              batchType: billRun.batchType,
+              billRunNumber: billRun.billRunNumber,
+              scheme: billRun.scheme,
+              source: billRun.source,
+              summer: billRun.summer
             }
           }
         ],


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4988

While testing the billing account page, it was noticed that some rows for the financial year column were blank. Upon further inspection, this was due to the financial year being taken from a metadata column instead of its correct column in the `bills` table.

This PR will fix the empty financial year rows for the billing account page.