### PR TITLE
Determine billing account backlink based on route

### DIFF
--- a/app/controllers/billing-accounts.controller.js
+++ b/app/controllers/billing-accounts.controller.js
@@ -27,9 +27,9 @@ async function changeAddress(request, h) {
 
 async function view(request, h) {
   const { id } = request.params
-  const { page = 1 } = request.query
+  const { id: licenceId, page = 1 } = request.query
 
-  const pageData = await ViewBillingAccountService.go(id, page)
+  const pageData = await ViewBillingAccountService.go(id, licenceId, page)
 
   return h.view('billing-accounts/view.njk', pageData)
 }

--- a/app/controllers/billing-accounts.controller.js
+++ b/app/controllers/billing-accounts.controller.js
@@ -27,7 +27,7 @@ async function changeAddress(request, h) {
 
 async function view(request, h) {
   const { id } = request.params
-  const { id: licenceId, page = 1 } = request.query
+  const { 'licence-id': licenceId, page = 1 } = request.query
 
   const pageData = await ViewBillingAccountService.go(id, licenceId, page)
 

--- a/app/presenters/billing-account/view-billing-account.presenter.js
+++ b/app/presenters/billing-account/view-billing-account.presenter.js
@@ -31,7 +31,6 @@ function go(billingAccountData, licenceId) {
     createdDate: formatLongDate(createdAt),
     customerFile: lastTransactionFile,
     lastUpdated: lastTransactionFileCreatedAt ? formatLongDate(lastTransactionFileCreatedAt) : null,
-    licenceId,
     pageTitle: 'Billing account for ' + titleCase(company.name),
     pagination
   }

--- a/app/presenters/billing-account/view-billing-account.presenter.js
+++ b/app/presenters/billing-account/view-billing-account.presenter.js
@@ -12,19 +12,20 @@ const { formatBillRunType } = require('../billing.presenter.js')
  * Formats billing account data ready for presenting in the view billing account page
  *
  * @param {object} billingAccountData -The results from `FetchViewBillingAccountService`
+ * @param {string|undefined} licenceId - The UUID of the licence related to the billing account, if available, used to
+ * determine the backlink
  *
  * @returns {object} The data formatted for the view template
  */
-function go(billingAccountData) {
+function go(billingAccountData, licenceId) {
   const { billingAccount, bills, pagination } = billingAccountData
   const { billingAccountAddresses, company, createdAt, id, lastTransactionFile, lastTransactionFileCreatedAt } =
     billingAccount
 
-  const { id: licenceId } = billingAccount.bills[0].billLicences[0].licence
-
   return {
     accountNumber: billingAccount.accountNumber,
     address: _address(billingAccountAddresses[0].address, company),
+    backLink: _backLink(licenceId),
     billingAccountId: id,
     bills: _bills(bills),
     createdDate: formatLongDate(createdAt),
@@ -65,6 +66,20 @@ function _address(address, company) {
   }
 
   return addressLines
+}
+
+function _backLink(licenceId) {
+  if (licenceId) {
+    return {
+      title: 'Go back to bills',
+      link: `/system/licences/${licenceId}/bills`
+    }
+  }
+
+  return {
+    title: 'Go back to search',
+    link: '/licences'
+  }
 }
 
 function _bills(bills) {

--- a/app/services/billing-accounts/fetch-view-billing-account.service.js
+++ b/app/services/billing-accounts/fetch-view-billing-account.service.js
@@ -49,10 +49,6 @@ async function _fetchBillingAccount(id) {
     .modifyGraph('billingAccountAddresses.address', (builder) => {
       builder.select(['id', 'address1', 'address2', 'address3', 'address4', 'address5', 'address6', 'postcode'])
     })
-    .withGraphFetched('bills.billLicences.licence')
-    .modifyGraph('bills.billLicences.licence', (builder) => {
-      builder.select('id')
-    })
 }
 
 async function _fetchBills(billingAccountId, page) {

--- a/app/services/billing-accounts/view-billing-account.service.js
+++ b/app/services/billing-accounts/view-billing-account.service.js
@@ -24,7 +24,14 @@ async function go(id, licenceId, page) {
 
   const pageData = ViewBillingAccountPresenter.go(billingAccountData, licenceId)
 
-  const pagination = PaginatorPresenter.go(pageData.pagination.total, Number(page), `/system/billing-accounts/${id}`)
+  const queryArgs = licenceId ? { 'licence-id': licenceId } : {}
+
+  const pagination = PaginatorPresenter.go(
+    pageData.pagination.total,
+    Number(page),
+    `/system/billing-accounts/${id}`,
+    queryArgs
+  )
 
   return {
     activeNavBar: 'search',

--- a/app/services/billing-accounts/view-billing-account.service.js
+++ b/app/services/billing-accounts/view-billing-account.service.js
@@ -13,14 +13,16 @@ const ViewBillingAccountPresenter = require('../../presenters/billing-account/vi
  * Orchestrates fetching and presenting the data needed for the view billing account page
  *
  * @param {string} id - The UUID of the billing account to view
+ * @param {string|undefined} licenceId - The UUID of the licence related to the billing account, if available, used to
+ * determine the backlink
  * @param {number|string} page - The current page for the pagination service
  *
  * @returns {Promise<object>} an object representing the `pageData` needed by the view billing account template.
  */
-async function go(id, page) {
+async function go(id, licenceId, page) {
   const billingAccountData = await FetchViewBillingAccountService.go(id, page)
 
-  const pageData = ViewBillingAccountPresenter.go(billingAccountData)
+  const pageData = ViewBillingAccountPresenter.go(billingAccountData, licenceId)
 
   const pagination = PaginatorPresenter.go(pageData.pagination.total, Number(page), `/system/billing-accounts/${id}`)
 

--- a/app/views/billing-accounts/view.njk
+++ b/app/views/billing-accounts/view.njk
@@ -10,8 +10,8 @@
   {# Back link #}
   {{
     govukBackLink({
-      text: 'Go back to bills',
-      href:  '/system/licences/' + licenceId + '/bills'
+      text: backLink.title,
+      href: backLink.link
     })
   }}
 {% endblock %}

--- a/app/views/licences/tabs/bills.njk
+++ b/app/views/licences/tabs/bills.njk
@@ -27,7 +27,7 @@
         attributes: { 'data-test': 'bill-created-' + rowIndex }
       },
       {
-        html: '<a href="'+ bill.billingAccountLink + '?id=' + licenceId + '">' + bill.accountNumber + '</a>',
+        html: '<a href="'+ bill.billingAccountLink + '?licence-id=' + licenceId + '">' + bill.accountNumber + '</a>',
         attributes: { 'data-test': 'bill-account-' + rowIndex }
       },
       {

--- a/app/views/licences/tabs/bills.njk
+++ b/app/views/licences/tabs/bills.njk
@@ -27,7 +27,7 @@
         attributes: { 'data-test': 'bill-created-' + rowIndex }
       },
       {
-        html: '<a href="'+ bill.billingAccountLink + '">' + bill.accountNumber + '</a>',
+        html: '<a href="'+ bill.billingAccountLink + '?id=' + licenceId + '">' + bill.accountNumber + '</a>',
         attributes: { 'data-test': 'bill-account-' + rowIndex }
       },
       {

--- a/test/controllers/billing-accounts.controller.test.js
+++ b/test/controllers/billing-accounts.controller.test.js
@@ -49,27 +49,55 @@ describe('Billing Accounts controller', () => {
 
   describe('/billing-accounts/{billingAccountId}', () => {
     describe('GET', () => {
-      beforeEach(() => {
-        options = {
-          method: 'GET',
-          url: '/billing-accounts/2e71429d-3fd1-4ed1-a45e-eb5616873018',
-          auth: {
-            strategy: 'session',
-            credentials: { scope: ['billing'] }
-          }
-        }
-      })
-
-      describe('when the request succeeds', () => {
+      describe('when a licenceId is passed as a query parameter', () => {
         beforeEach(() => {
-          Sinon.stub(ViewBillingAccountService, 'go').resolves(_viewBillingAccount())
+          options = {
+            method: 'GET',
+            url: '/billing-accounts/2e71429d-3fd1-4ed1-a45e-eb5616873018?izd=9a437fad-86b7-4495-8b26-061662cf8037',
+            auth: {
+              strategy: 'session',
+              credentials: { scope: ['billing'] }
+            }
+          }
         })
 
-        it('returns the page successfully', async () => {
-          const response = await server.inject(options)
+        describe('when the request succeeds', () => {
+          beforeEach(() => {
+            Sinon.stub(ViewBillingAccountService, 'go').resolves(_viewBillingAccount())
+          })
 
-          expect(response.statusCode).to.equal(200)
-          expect(response.payload).to.contain('Billing account for Ferns Surfacing Limited')
+          it('returns the page successfully', async () => {
+            const response = await server.inject(options)
+
+            expect(response.statusCode).to.equal(200)
+            expect(response.payload).to.contain('Billing account for Ferns Surfacing Limited')
+          })
+        })
+      })
+
+      describe('when no licenceId is passed as a query parameter', () => {
+        beforeEach(() => {
+          options = {
+            method: 'GET',
+            url: '/billing-accounts/2e71429d-3fd1-4ed1-a45e-eb5616873018',
+            auth: {
+              strategy: 'session',
+              credentials: { scope: ['billing'] }
+            }
+          }
+        })
+
+        describe('when the request succeeds', () => {
+          beforeEach(() => {
+            Sinon.stub(ViewBillingAccountService, 'go').resolves(_viewBillingAccount())
+          })
+
+          it('returns the page successfully', async () => {
+            const response = await server.inject(options)
+
+            expect(response.statusCode).to.equal(200)
+            expect(response.payload).to.contain('Billing account for Ferns Surfacing Limited')
+          })
         })
       })
     })
@@ -171,7 +199,10 @@ function _viewBillingAccount() {
     createdDate: '14 December 2023',
     customerFile: 'naltc0001',
     lastUpdated: '6 May 2025',
-    licenceId: '91aff99a-3204-4727-86bd-7bdf3ef24533',
+    backLink: {
+      title: 'Go back to bills',
+      link: `/system/licences/9a437fad-86b7-4495-8b26-061662cf8037/bills`
+    },
     pageTitle: 'Billing account for Ferns Surfacing Limited',
     pagination: { numberOfPages: 1 }
   }

--- a/test/controllers/billing-accounts.controller.test.js
+++ b/test/controllers/billing-accounts.controller.test.js
@@ -53,7 +53,7 @@ describe('Billing Accounts controller', () => {
         beforeEach(() => {
           options = {
             method: 'GET',
-            url: '/billing-accounts/2e71429d-3fd1-4ed1-a45e-eb5616873018?izd=9a437fad-86b7-4495-8b26-061662cf8037',
+            url: '/billing-accounts/2e71429d-3fd1-4ed1-a45e-eb5616873018?licence-id=9a437fad-86b7-4495-8b26-061662cf8037',
             auth: {
               strategy: 'session',
               credentials: { scope: ['billing'] }

--- a/test/fixtures/billing-accounts.fixtures.js
+++ b/test/fixtures/billing-accounts.fixtures.js
@@ -28,23 +28,6 @@ function billingAccount() {
           }
         }
       ],
-      bills: [
-        {
-          id: '3d1b5d1f-9b57-4a28-bde1-1d57cd77b203',
-          createdAt: new Date('2023-12-14T18:42:59.659Z'),
-          credit: false,
-          invoiceNumber: false,
-          netAmount: 10384,
-          financialYear: 2021,
-          billLicences: [
-            {
-              licence: {
-                id: '1c26e4f8-bce8-427f-8a88-72e704a4ca04'
-              }
-            }
-          ]
-        }
-      ],
       company: {
         id: '55a71eb5-e0e1-443e-9a25-c529cccfd6df',
         name: 'Ferns Surfacing Limited'
@@ -68,7 +51,6 @@ function billingAccount() {
         }
       }
     ],
-    licenceId: '91aff99a-3204-4727-86bd-7bdf3ef24533',
     pagination: { total: 1 }
   }
 }

--- a/test/presenters/billing-accounts/view-billing-account.presenter.test.js
+++ b/test/presenters/billing-accounts/view-billing-account.presenter.test.js
@@ -15,18 +15,24 @@ const ViewBillingAccountPresenter = require('../../../app/presenters/billing-acc
 
 describe('View Billing Account presenter', () => {
   let billingAccountData
+  let licenceId
 
   beforeEach(() => {
     billingAccountData = BillingAccountsFixture.billingAccount()
+    licenceId = '634aecc9-1086-41b1-a1cd-37247f8d321b'
   })
 
   describe('when provided with a populated billing account', () => {
     it('returns the correctly presents the data', () => {
-      const result = ViewBillingAccountPresenter.go(billingAccountData)
+      const result = ViewBillingAccountPresenter.go(billingAccountData, licenceId)
 
       expect(result).to.equal({
         accountNumber: 'S88897992A',
         address: ['Ferns Surfacing Limited', 'Tutsham Farm', 'West Farleigh', 'Maidstone', 'Kent', 'ME15 0NE'],
+        backLink: {
+          title: 'Go back to bills',
+          link: `/system/licences/${licenceId}/bills`
+        },
         billingAccountId: '9b03843e-848b-497e-878e-4a6628d4f683',
         bills: [
           {
@@ -42,7 +48,6 @@ describe('View Billing Account presenter', () => {
         createdDate: '14 December 2023',
         customerFile: null,
         lastUpdated: null,
-        licenceId: '1c26e4f8-bce8-427f-8a88-72e704a4ca04',
         pageTitle: 'Billing account for Ferns Surfacing Limited',
         pagination: { total: 1 }
       })
@@ -57,7 +62,7 @@ describe('View Billing Account presenter', () => {
       })
 
       it('returns an array of address lines title cased with the postcode capitalised', () => {
-        const result = ViewBillingAccountPresenter.go(billingAccountData)
+        const result = ViewBillingAccountPresenter.go(billingAccountData, licenceId)
 
         expect(result.address).to.equal([
           'Ferns Surfacing Limited',
@@ -74,7 +79,7 @@ describe('View Billing Account presenter', () => {
 
     describe('when some address lines are null', () => {
       it('returns an array of populated address lines title cased with the postcode capitalised', () => {
-        const result = ViewBillingAccountPresenter.go(billingAccountData)
+        const result = ViewBillingAccountPresenter.go(billingAccountData, licenceId)
 
         expect(result.address).to.equal([
           'Ferns Surfacing Limited',
@@ -88,6 +93,34 @@ describe('View Billing Account presenter', () => {
     })
   })
 
+  describe('the "backLink" property', () => {
+    describe('when the licenceId is undefined', () => {
+      beforeEach(() => {
+        licenceId = undefined
+      })
+
+      it('returns the title "Go back to search" and the link to search page', () => {
+        const result = ViewBillingAccountPresenter.go(billingAccountData, licenceId)
+
+        expect(result.backLink).to.equal({
+          title: 'Go back to search',
+          link: '/licences'
+        })
+      })
+    })
+
+    describe('when the licenceId is not undefined', () => {
+      it('returns the title "Go back to bills" and the link to licence bills page', () => {
+        const result = ViewBillingAccountPresenter.go(billingAccountData, licenceId)
+
+        expect(result.backLink).to.equal({
+          title: 'Go back to bills',
+          link: `/system/licences/${licenceId}/bills`
+        })
+      })
+    })
+  })
+
   describe('the "bills" property', () => {
     describe('the "bills.billNumber" property', () => {
       describe('when the "invoiceNumber" is populated', () => {
@@ -96,7 +129,7 @@ describe('View Billing Account presenter', () => {
         })
 
         it('returns the "invoiceNumber" value', () => {
-          const result = ViewBillingAccountPresenter.go(billingAccountData)
+          const result = ViewBillingAccountPresenter.go(billingAccountData, licenceId)
 
           expect(result.bills[0].billNumber).to.equal('Test123')
         })
@@ -104,7 +137,7 @@ describe('View Billing Account presenter', () => {
 
       describe('when the "invoiceNumber" is null', () => {
         it('returns the string "Zero value bill"', () => {
-          const result = ViewBillingAccountPresenter.go(billingAccountData)
+          const result = ViewBillingAccountPresenter.go(billingAccountData, licenceId)
 
           expect(result.bills[0].billNumber).to.equal('Zero value bill')
         })
@@ -118,7 +151,7 @@ describe('View Billing Account presenter', () => {
         })
 
         it('returns the formatted "bill.netAmount" value followed by the string "Credit"', () => {
-          const result = ViewBillingAccountPresenter.go(billingAccountData)
+          const result = ViewBillingAccountPresenter.go(billingAccountData, licenceId)
 
           expect(result.bills[0].billTotal).to.equal('£103.84 Credit')
         })
@@ -126,7 +159,7 @@ describe('View Billing Account presenter', () => {
 
       describe('when the "bill.credit" property is false', () => {
         it('returns the formatted "bill.netAmount" value', () => {
-          const result = ViewBillingAccountPresenter.go(billingAccountData)
+          const result = ViewBillingAccountPresenter.go(billingAccountData, licenceId)
 
           expect(result.bills[0].billTotal).to.equal('£103.84')
         })
@@ -141,7 +174,7 @@ describe('View Billing Account presenter', () => {
       })
 
       it('returns the formatted "lastTransactionFileCreatedAt" date value', () => {
-        const result = ViewBillingAccountPresenter.go(billingAccountData)
+        const result = ViewBillingAccountPresenter.go(billingAccountData, licenceId)
 
         expect(result.lastUpdated).to.equal('14 December 2023')
       })
@@ -149,7 +182,7 @@ describe('View Billing Account presenter', () => {
 
     describe('when the "lastTransactionFileCreatedAt" is null', () => {
       it('returns null', () => {
-        const result = ViewBillingAccountPresenter.go(billingAccountData)
+        const result = ViewBillingAccountPresenter.go(billingAccountData, licenceId)
 
         expect(result.lastUpdated).to.be.null()
       })

--- a/test/services/billing-accounts/fetch-view-billing-account.service.test.js
+++ b/test/services/billing-accounts/fetch-view-billing-account.service.test.js
@@ -10,12 +10,10 @@ const { expect } = Code
 // Test helpers
 const AddressHelper = require('../../support/helpers/address.helper.js')
 const BillHelper = require('../../support/helpers/bill.helper.js')
-const BillLicenceHelper = require('../../support/helpers/bill-licence.helper.js')
 const BillingAccountAddressHelper = require('../../support/helpers/billing-account-address.helper.js')
 const BillingAccountHelper = require('../../support/helpers/billing-account.helper.js')
 const BillRunHelper = require('../../support/helpers/bill-run.helper.js')
 const CompanyHelper = require('../../support/helpers/company.helper.js')
-const LicenceHelper = require('../../support/helpers/licence.helper.js')
 
 // Thing under test
 const FetchViewBillingAccountService = require('../../../app/services/billing-accounts/fetch-view-billing-account.service.js')
@@ -26,11 +24,8 @@ describe('Fetch Billing Account service', () => {
   let billingAccount
   let billingAccountAddress
   let billingAccountId
-  let billLicence
   let billRun
   let company
-  let licence
-  let licenceId
 
   describe('when a matching billing account exists', () => {
     beforeEach(async () => {
@@ -50,14 +45,6 @@ describe('Fetch Billing Account service', () => {
       bill = await BillHelper.add({
         billingAccountId,
         billRunId: billRun.id
-      })
-
-      licence = await LicenceHelper.add()
-      licenceId = licence.id
-
-      billLicence = await BillLicenceHelper.add({
-        billId: bill.id,
-        licenceId
       })
     })
 
@@ -89,42 +76,7 @@ describe('Fetch Billing Account service', () => {
           company: {
             id: company.id,
             name: 'Example Trading Ltd'
-          },
-          bills: [
-            {
-              id: bill.id,
-              billingAccountId: bill.billingAccountId,
-              address: bill.address,
-              accountNumber: bill.accountNumber,
-              netAmount: bill.netAmount,
-              credit: bill.credit,
-              billRunId: billRun.id,
-              financialYearEnding: bill.financialYearEnding,
-              invoiceNumber: bill.invoiceNumber,
-              legacyId: bill.legacyId,
-              metadata: bill.metadata,
-              creditNoteValue: bill.creditNoteValue,
-              invoiceValue: bill.invoiceValue,
-              deminimis: bill.deminimis,
-              externalId: bill.externalId,
-              flaggedForRebilling: bill.flaggedForRebilling,
-              originalBillId: bill.originalBillId,
-              rebillingState: bill.rebillingState,
-              createdAt: bill.createdAt,
-              updatedAt: bill.updatedAt,
-              billLicences: [
-                {
-                  id: billLicence.id,
-                  billId: billLicence.billId,
-                  licenceRef: billLicence.licenceRef,
-                  licenceId: billLicence.licenceId,
-                  createdAt: billLicence.createdAt,
-                  updatedAt: billLicence.updatedAt,
-                  licence: { id: licenceId }
-                }
-              ]
-            }
-          ]
+          }
         },
         bills: [
           {

--- a/test/services/billing-accounts/view-billing-account.service.test.js
+++ b/test/services/billing-accounts/view-billing-account.service.test.js
@@ -24,12 +24,20 @@ describe('View Billing Account service', () => {
 
   describe('when a billing account with a matching ID exists', () => {
     it('correctly presents the data', async () => {
-      const result = await ViewBillingAccountService.go('64d7fc10-f046-4444-ba32-bb917dd8cde6', 1)
+      const result = await ViewBillingAccountService.go(
+        '64d7fc10-f046-4444-ba32-bb917dd8cde6',
+        '53325713-1364-4f6b-a244-8771a36a1248',
+        1
+      )
 
       expect(result).to.equal({
         activeNavBar: 'search',
         accountNumber: 'S88897992A',
         address: ['Ferns Surfacing Limited', 'Tutsham Farm', 'West Farleigh', 'Maidstone', 'Kent', 'ME15 0NE'],
+        backLink: {
+          title: 'Go back to bills',
+          link: `/system/licences/53325713-1364-4f6b-a244-8771a36a1248/bills`
+        },
         billingAccountId: '9b03843e-848b-497e-878e-4a6628d4f683',
         bills: [
           {
@@ -45,7 +53,6 @@ describe('View Billing Account service', () => {
         createdDate: '14 December 2023',
         customerFile: null,
         lastUpdated: null,
-        licenceId: '1c26e4f8-bce8-427f-8a88-72e704a4ca04',
         pageTitle: 'Billing account for Ferns Surfacing Limited',
         pagination: { numberOfPages: 1 }
       })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4988

During testing, we noticed that the legacy billing account page could still be accessed via the internal search tool. To address this, we added functionality to [access the new billing account page via search](https://github.com/DEFRA/water-abstraction-ui/pull/2694).

Following this change, we need to update the backlink behaviour on the billing account page. The destination of the backlink should depend on how the user navigated to the page:

- If accessed via the internal search tool, the backlink should return the user to the search page.
- If accessed via the licence bills tab, the backlink should return the user to the bills page.

This PR updates the billing account page to handle backlink routing accordingly.