### PR TITLE
Update pagination presenter to handle existing query args

### DIFF
--- a/app/presenters/paginator.presenter.js
+++ b/app/presenters/paginator.presenter.js
@@ -105,18 +105,21 @@ const COMPLEX_END_PAGINATOR = 'end'
  * @param {number} numberOfRecords - the total number of records or results of the thing being paginated
  * @param {number} selectedPageNumber - the page of results selected for viewing
  * @param {string} path - the URL path the paginator should use, for example, `'/system/bill-runs'`
+ * @param {object} queryArgs - the current query arguments to be added to the pagination links
  *
  * @returns {object} if no pagination is needed just the `numberOfPages` is returned else a `component:` property is
  * also included that can be directly passed to the `govukPagination()` in the view.
  */
-function go(numberOfRecords, selectedPageNumber, path) {
+function go(numberOfRecords, selectedPageNumber, path, queryArgs = {}) {
   const numberOfPages = Math.ceil(numberOfRecords / DatabaseConfig.defaultPageSize)
 
   if (numberOfPages < 2) {
     return { numberOfPages }
   }
 
-  const component = _component(selectedPageNumber, numberOfPages, path)
+  const queryString = _queryString(queryArgs)
+
+  const component = _component(selectedPageNumber, numberOfPages, path, queryString)
 
   return {
     component,
@@ -124,90 +127,90 @@ function go(numberOfRecords, selectedPageNumber, path) {
   }
 }
 
-function _component(selectedPageNumber, numberOfPages, path) {
-  const items = _items(selectedPageNumber, numberOfPages, path)
+function _component(selectedPageNumber, numberOfPages, path, queryString) {
+  const items = _items(selectedPageNumber, numberOfPages, path, queryString)
 
   const component = { items }
 
   if (selectedPageNumber !== 1) {
-    component.previous = { href: `${path}?page=${selectedPageNumber - 1}` }
+    component.previous = { href: `${path}?page=${selectedPageNumber - 1}${queryString}` }
   }
 
   if (selectedPageNumber !== numberOfPages) {
-    component.next = { href: `${path}?page=${selectedPageNumber + 1}` }
+    component.next = { href: `${path}?page=${selectedPageNumber + 1}${queryString}` }
   }
 
   return component
 }
 
-function _complexPaginatorEnd(selectedPageNumber, numberOfPages, path) {
+function _complexPaginatorEnd(selectedPageNumber, numberOfPages, path, queryString) {
   const items = []
 
-  items.push(_item(1, selectedPageNumber, path))
+  items.push(_item(1, selectedPageNumber, path, queryString))
   items.push({ ellipsis: true })
-  items.push(_item(numberOfPages - 4, selectedPageNumber, path))
-  items.push(_item(numberOfPages - 3, selectedPageNumber, path))
-  items.push(_item(numberOfPages - 2, selectedPageNumber, path))
-  items.push(_item(numberOfPages - 1, selectedPageNumber, path))
-  items.push(_item(numberOfPages, selectedPageNumber, path))
+  items.push(_item(numberOfPages - 4, selectedPageNumber, path, queryString))
+  items.push(_item(numberOfPages - 3, selectedPageNumber, path, queryString))
+  items.push(_item(numberOfPages - 2, selectedPageNumber, path, queryString))
+  items.push(_item(numberOfPages - 1, selectedPageNumber, path, queryString))
+  items.push(_item(numberOfPages, selectedPageNumber, path, queryString))
 
   return items
 }
 
-function _complexPaginatorMiddle(selectedPageNumber, numberOfPages, path) {
+function _complexPaginatorMiddle(selectedPageNumber, numberOfPages, path, queryString) {
   const items = []
 
-  items.push(_item(1, selectedPageNumber, path))
+  items.push(_item(1, selectedPageNumber, path, queryString))
   items.push({ ellipsis: true })
-  items.push(_item(selectedPageNumber - 1, selectedPageNumber, path))
-  items.push(_item(selectedPageNumber, selectedPageNumber, path))
-  items.push(_item(selectedPageNumber + 1, selectedPageNumber, path))
+  items.push(_item(selectedPageNumber - 1, selectedPageNumber, path, queryString))
+  items.push(_item(selectedPageNumber, selectedPageNumber, path, queryString))
+  items.push(_item(selectedPageNumber + 1, selectedPageNumber, path, queryString))
   items.push({ ellipsis: true })
-  items.push(_item(numberOfPages, selectedPageNumber, path))
+  items.push(_item(numberOfPages, selectedPageNumber, path, queryString))
 
   return items
 }
 
-function _complexPaginatorStart(selectedPageNumber, numberOfPages, path) {
+function _complexPaginatorStart(selectedPageNumber, numberOfPages, path, queryString) {
   const items = []
 
-  items.push(_item(1, selectedPageNumber, path))
-  items.push(_item(2, selectedPageNumber, path))
-  items.push(_item(3, selectedPageNumber, path))
-  items.push(_item(4, selectedPageNumber, path))
-  items.push(_item(5, selectedPageNumber, path))
+  items.push(_item(1, selectedPageNumber, path, queryString))
+  items.push(_item(2, selectedPageNumber, path, queryString))
+  items.push(_item(3, selectedPageNumber, path, queryString))
+  items.push(_item(4, selectedPageNumber, path, queryString))
+  items.push(_item(5, selectedPageNumber, path, queryString))
   items.push({ ellipsis: true })
-  items.push(_item(numberOfPages, selectedPageNumber, path))
+  items.push(_item(numberOfPages, selectedPageNumber, path, queryString))
 
   return items
 }
 
-function _item(pageNumber, selectedPageNumber, path) {
+function _item(pageNumber, selectedPageNumber, path, queryString) {
   return {
     number: pageNumber,
     visuallyHiddenText: `Page ${pageNumber}`,
-    href: pageNumber === 1 ? path : `${path}?page=${pageNumber}`,
+    href: pageNumber === 1 ? path : `${path}?page=${pageNumber}${queryString}`,
     current: pageNumber === selectedPageNumber
   }
 }
 
-function _items(selectedPageNumber, numberOfPages, path) {
+function _items(selectedPageNumber, numberOfPages, path, queryString) {
   const paginatorType = _paginatorType(selectedPageNumber, numberOfPages)
 
   let items
 
   switch (paginatorType) {
     case COMPLEX_START_PAGINATOR:
-      items = _complexPaginatorStart(selectedPageNumber, numberOfPages, path)
+      items = _complexPaginatorStart(selectedPageNumber, numberOfPages, path, queryString)
       break
     case COMPLEX_MIDDLE_PAGINATOR:
-      items = _complexPaginatorMiddle(selectedPageNumber, numberOfPages, path)
+      items = _complexPaginatorMiddle(selectedPageNumber, numberOfPages, path, queryString)
       break
     case COMPLEX_END_PAGINATOR:
-      items = _complexPaginatorEnd(selectedPageNumber, numberOfPages, path)
+      items = _complexPaginatorEnd(selectedPageNumber, numberOfPages, path, queryString)
       break
     default:
-      items = _simplePaginator(selectedPageNumber, numberOfPages, path)
+      items = _simplePaginator(selectedPageNumber, numberOfPages, path, queryString)
   }
 
   return items
@@ -229,11 +232,21 @@ function _paginatorType(selectedPageNumber, numberOfPages) {
   return COMPLEX_MIDDLE_PAGINATOR
 }
 
-function _simplePaginator(selectedPageNumber, numberOfPages, path) {
+function _queryString(queryArgs) {
+  const args = []
+
+  for (const [key, value] of Object.entries(queryArgs)) {
+    args.push(`&${key}=${value}`)
+  }
+
+  return args.join('')
+}
+
+function _simplePaginator(selectedPageNumber, numberOfPages, path, queryString) {
   const items = []
 
   for (let i = 1; i <= numberOfPages; i++) {
-    items.push(_item(i, selectedPageNumber, path))
+    items.push(_item(i, selectedPageNumber, path, queryString))
   }
 
   return items

--- a/test/presenters/paginator.presenter.test.js
+++ b/test/presenters/paginator.presenter.test.js
@@ -20,6 +20,7 @@ describe('Paginator Presenter', () => {
   // NOTE: We set the number of records according to the default page size we use in these tests (50) to get the number
   // of pages we expect
   let numberOfRecords
+  let queryArgs
   let selectedPage
 
   before(async () => {
@@ -48,834 +49,2441 @@ describe('Paginator Presenter', () => {
   })
 
   describe('when pagination is needed', () => {
-    describe('for 2 pages', () => {
-      beforeEach(() => {
-        numberOfRecords = 75
-      })
-
-      describe('and the first page is selected', () => {
+    describe('and there are no query arguments', () => {
+      describe('for 2 pages', () => {
         beforeEach(() => {
-          selectedPage = 1
+          numberOfRecords = 75
         })
 
-        it('returns [1] 2 Next ->', () => {
-          const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path)
+        describe('and the first page is selected', () => {
+          beforeEach(() => {
+            selectedPage = 1
+          })
 
-          expect(result).equal({
-            numberOfPages: 2,
-            component: {
-              items: [
-                { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: true },
-                { number: 2, visuallyHiddenText: 'Page 2', href: '/system/bill-runs?page=2', current: false }
-              ],
-              next: { href: '/system/bill-runs?page=2' }
-            }
+          it('returns [1] 2 Next ->', () => {
+            const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path)
+
+            expect(result).equal({
+              numberOfPages: 2,
+              component: {
+                items: [
+                  { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: true },
+                  { number: 2, visuallyHiddenText: 'Page 2', href: '/system/bill-runs?page=2', current: false }
+                ],
+                next: { href: '/system/bill-runs?page=2' }
+              }
+            })
+          })
+        })
+
+        describe('and the last page is selected', () => {
+          beforeEach(() => {
+            selectedPage = 2
+          })
+
+          it('returns <- Previous 1 [2]', () => {
+            const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path)
+
+            expect(result).equal({
+              numberOfPages: 2,
+              component: {
+                items: [
+                  { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: false },
+                  { number: 2, visuallyHiddenText: 'Page 2', href: '/system/bill-runs?page=2', current: true }
+                ],
+                previous: { href: '/system/bill-runs?page=1' }
+              }
+            })
           })
         })
       })
 
-      describe('and the last page is selected', () => {
+      describe('for 3 pages', () => {
         beforeEach(() => {
-          selectedPage = 2
+          numberOfRecords = 125
         })
 
-        it('returns <- Previous 1 [2]', () => {
-          const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path)
+        describe('and the first page is selected', () => {
+          beforeEach(() => {
+            selectedPage = 1
+          })
 
-          expect(result).equal({
-            numberOfPages: 2,
-            component: {
-              items: [
-                { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: false },
-                { number: 2, visuallyHiddenText: 'Page 2', href: '/system/bill-runs?page=2', current: true }
-              ],
-              previous: { href: '/system/bill-runs?page=1' }
-            }
+          it('returns [1] 2  3 Next ->', () => {
+            const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path)
+
+            expect(result).equal({
+              numberOfPages: 3,
+              component: {
+                items: [
+                  { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: true },
+                  { number: 2, visuallyHiddenText: 'Page 2', href: '/system/bill-runs?page=2', current: false },
+                  { number: 3, visuallyHiddenText: 'Page 3', href: '/system/bill-runs?page=3', current: false }
+                ],
+                next: { href: '/system/bill-runs?page=2' }
+              }
+            })
+          })
+        })
+
+        describe('and page 2 is selected', () => {
+          beforeEach(() => {
+            selectedPage = 2
+          })
+
+          it('returns <- Previous 1 [2] 3 Next ->', () => {
+            const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path)
+
+            expect(result).equal({
+              numberOfPages: 3,
+              component: {
+                items: [
+                  { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: false },
+                  { number: 2, visuallyHiddenText: 'Page 2', href: '/system/bill-runs?page=2', current: true },
+                  { number: 3, visuallyHiddenText: 'Page 3', href: '/system/bill-runs?page=3', current: false }
+                ],
+                next: { href: '/system/bill-runs?page=3' },
+                previous: { href: '/system/bill-runs?page=1' }
+              }
+            })
+          })
+        })
+
+        describe('and the last page is selected', () => {
+          beforeEach(() => {
+            selectedPage = 3
+          })
+
+          it('returns <- Previous 1 2 [3]', () => {
+            const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path)
+
+            expect(result).equal({
+              numberOfPages: 3,
+              component: {
+                items: [
+                  { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: false },
+                  { number: 2, visuallyHiddenText: 'Page 2', href: '/system/bill-runs?page=2', current: false },
+                  { number: 3, visuallyHiddenText: 'Page 3', href: '/system/bill-runs?page=3', current: true }
+                ],
+                previous: { href: '/system/bill-runs?page=2' }
+              }
+            })
+          })
+        })
+      })
+
+      describe('for 4 pages', () => {
+        beforeEach(() => {
+          numberOfRecords = 175
+        })
+
+        describe('and the first page is selected', () => {
+          beforeEach(() => {
+            selectedPage = 1
+          })
+
+          it('returns [1] 2 3 4 Next ->', () => {
+            const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path)
+
+            expect(result).equal({
+              numberOfPages: 4,
+              component: {
+                items: [
+                  { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: true },
+                  { number: 2, visuallyHiddenText: 'Page 2', href: '/system/bill-runs?page=2', current: false },
+                  { number: 3, visuallyHiddenText: 'Page 3', href: '/system/bill-runs?page=3', current: false },
+                  { number: 4, visuallyHiddenText: 'Page 4', href: '/system/bill-runs?page=4', current: false }
+                ],
+                next: { href: '/system/bill-runs?page=2' }
+              }
+            })
+          })
+        })
+
+        describe('and page 2 is selected', () => {
+          beforeEach(() => {
+            selectedPage = 2
+          })
+
+          it('returns <- Previous 1 [2] 3 4 Next ->', () => {
+            const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path)
+
+            expect(result).equal({
+              numberOfPages: 4,
+              component: {
+                items: [
+                  { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: false },
+                  { number: 2, visuallyHiddenText: 'Page 2', href: '/system/bill-runs?page=2', current: true },
+                  { number: 3, visuallyHiddenText: 'Page 3', href: '/system/bill-runs?page=3', current: false },
+                  { number: 4, visuallyHiddenText: 'Page 4', href: '/system/bill-runs?page=4', current: false }
+                ],
+                next: { href: '/system/bill-runs?page=3' },
+                previous: { href: '/system/bill-runs?page=1' }
+              }
+            })
+          })
+        })
+
+        describe('and the last page is selected', () => {
+          beforeEach(() => {
+            selectedPage = 4
+          })
+
+          it('returns <- Previous 1 2 3 [4]', () => {
+            const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path)
+
+            expect(result).equal({
+              numberOfPages: 4,
+              component: {
+                items: [
+                  { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: false },
+                  { number: 2, visuallyHiddenText: 'Page 2', href: '/system/bill-runs?page=2', current: false },
+                  { number: 3, visuallyHiddenText: 'Page 3', href: '/system/bill-runs?page=3', current: false },
+                  { number: 4, visuallyHiddenText: 'Page 4', href: '/system/bill-runs?page=4', current: true }
+                ],
+                previous: { href: '/system/bill-runs?page=3' }
+              }
+            })
+          })
+        })
+      })
+
+      describe('for 5 pages', () => {
+        beforeEach(() => {
+          numberOfRecords = 225
+        })
+
+        describe('and the first page is selected', () => {
+          beforeEach(() => {
+            selectedPage = 1
+          })
+
+          it('returns [1] 2 3 4 5 Next ->', () => {
+            const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path)
+
+            expect(result).equal({
+              numberOfPages: 5,
+              component: {
+                items: [
+                  { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: true },
+                  { number: 2, visuallyHiddenText: 'Page 2', href: '/system/bill-runs?page=2', current: false },
+                  { number: 3, visuallyHiddenText: 'Page 3', href: '/system/bill-runs?page=3', current: false },
+                  { number: 4, visuallyHiddenText: 'Page 4', href: '/system/bill-runs?page=4', current: false },
+                  { number: 5, visuallyHiddenText: 'Page 5', href: '/system/bill-runs?page=5', current: false }
+                ],
+                next: { href: '/system/bill-runs?page=2' }
+              }
+            })
+          })
+        })
+
+        describe('and page 3 is selected', () => {
+          beforeEach(() => {
+            selectedPage = 3
+          })
+
+          it('returns <- Previous 1 2 [3] 4 5 Next ->', () => {
+            const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path)
+
+            expect(result).equal({
+              numberOfPages: 5,
+              component: {
+                items: [
+                  { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: false },
+                  { number: 2, visuallyHiddenText: 'Page 2', href: '/system/bill-runs?page=2', current: false },
+                  { number: 3, visuallyHiddenText: 'Page 3', href: '/system/bill-runs?page=3', current: true },
+                  { number: 4, visuallyHiddenText: 'Page 4', href: '/system/bill-runs?page=4', current: false },
+                  { number: 5, visuallyHiddenText: 'Page 5', href: '/system/bill-runs?page=5', current: false }
+                ],
+                next: { href: '/system/bill-runs?page=4' },
+                previous: { href: '/system/bill-runs?page=2' }
+              }
+            })
+          })
+        })
+
+        describe('and the last page is selected', () => {
+          beforeEach(() => {
+            selectedPage = 5
+          })
+
+          it('returns <- Previous 1 2 3 4 [5]', () => {
+            const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path)
+
+            expect(result).equal({
+              numberOfPages: 5,
+              component: {
+                items: [
+                  { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: false },
+                  { number: 2, visuallyHiddenText: 'Page 2', href: '/system/bill-runs?page=2', current: false },
+                  { number: 3, visuallyHiddenText: 'Page 3', href: '/system/bill-runs?page=3', current: false },
+                  { number: 4, visuallyHiddenText: 'Page 4', href: '/system/bill-runs?page=4', current: false },
+                  { number: 5, visuallyHiddenText: 'Page 5', href: '/system/bill-runs?page=5', current: true }
+                ],
+                previous: { href: '/system/bill-runs?page=4' }
+              }
+            })
+          })
+        })
+      })
+
+      describe('for 6 pages', () => {
+        beforeEach(() => {
+          numberOfRecords = 275
+        })
+
+        describe('and the first page is selected', () => {
+          beforeEach(() => {
+            selectedPage = 1
+          })
+
+          it('returns [1] 2 3 4 5 6 Next ->', () => {
+            const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path)
+
+            expect(result).equal({
+              numberOfPages: 6,
+              component: {
+                items: [
+                  { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: true },
+                  { number: 2, visuallyHiddenText: 'Page 2', href: '/system/bill-runs?page=2', current: false },
+                  { number: 3, visuallyHiddenText: 'Page 3', href: '/system/bill-runs?page=3', current: false },
+                  { number: 4, visuallyHiddenText: 'Page 4', href: '/system/bill-runs?page=4', current: false },
+                  { number: 5, visuallyHiddenText: 'Page 5', href: '/system/bill-runs?page=5', current: false },
+                  { number: 6, visuallyHiddenText: 'Page 6', href: '/system/bill-runs?page=6', current: false }
+                ],
+                next: { href: '/system/bill-runs?page=2' }
+              }
+            })
+          })
+        })
+
+        describe('and page 3 is selected', () => {
+          beforeEach(() => {
+            selectedPage = 3
+          })
+
+          it('returns <- Previous 1 2 [3] 4 5 6 Next ->', () => {
+            const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path)
+
+            expect(result).equal({
+              numberOfPages: 6,
+              component: {
+                items: [
+                  { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: false },
+                  { number: 2, visuallyHiddenText: 'Page 2', href: '/system/bill-runs?page=2', current: false },
+                  { number: 3, visuallyHiddenText: 'Page 3', href: '/system/bill-runs?page=3', current: true },
+                  { number: 4, visuallyHiddenText: 'Page 4', href: '/system/bill-runs?page=4', current: false },
+                  { number: 5, visuallyHiddenText: 'Page 5', href: '/system/bill-runs?page=5', current: false },
+                  { number: 6, visuallyHiddenText: 'Page 6', href: '/system/bill-runs?page=6', current: false }
+                ],
+                next: { href: '/system/bill-runs?page=4' },
+                previous: { href: '/system/bill-runs?page=2' }
+              }
+            })
+          })
+        })
+
+        describe('and the last page is selected', () => {
+          beforeEach(() => {
+            selectedPage = 6
+          })
+
+          it('returns <- Previous 1 2 3 4 5 [6]', () => {
+            const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path)
+
+            expect(result).equal({
+              numberOfPages: 6,
+              component: {
+                items: [
+                  { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: false },
+                  { number: 2, visuallyHiddenText: 'Page 2', href: '/system/bill-runs?page=2', current: false },
+                  { number: 3, visuallyHiddenText: 'Page 3', href: '/system/bill-runs?page=3', current: false },
+                  { number: 4, visuallyHiddenText: 'Page 4', href: '/system/bill-runs?page=4', current: false },
+                  { number: 5, visuallyHiddenText: 'Page 5', href: '/system/bill-runs?page=5', current: false },
+                  { number: 6, visuallyHiddenText: 'Page 6', href: '/system/bill-runs?page=6', current: true }
+                ],
+                previous: { href: '/system/bill-runs?page=5' }
+              }
+            })
+          })
+        })
+      })
+
+      describe('for 7 pages', () => {
+        beforeEach(() => {
+          numberOfRecords = 325
+        })
+
+        describe('and the first page is selected', () => {
+          beforeEach(() => {
+            selectedPage = 1
+          })
+
+          it('returns [1] 2 3 4 5 6 7 Next ->', () => {
+            const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path)
+
+            expect(result).equal({
+              numberOfPages: 7,
+              component: {
+                items: [
+                  { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: true },
+                  { number: 2, visuallyHiddenText: 'Page 2', href: '/system/bill-runs?page=2', current: false },
+                  { number: 3, visuallyHiddenText: 'Page 3', href: '/system/bill-runs?page=3', current: false },
+                  { number: 4, visuallyHiddenText: 'Page 4', href: '/system/bill-runs?page=4', current: false },
+                  { number: 5, visuallyHiddenText: 'Page 5', href: '/system/bill-runs?page=5', current: false },
+                  { number: 6, visuallyHiddenText: 'Page 6', href: '/system/bill-runs?page=6', current: false },
+                  { number: 7, visuallyHiddenText: 'Page 7', href: '/system/bill-runs?page=7', current: false }
+                ],
+                next: { href: '/system/bill-runs?page=2' }
+              }
+            })
+          })
+        })
+
+        describe('and page 4 is selected', () => {
+          beforeEach(() => {
+            selectedPage = 4
+          })
+
+          it('returns <- Previous 1 2 3 [4] 5 6 7 Next ->', () => {
+            const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path)
+
+            expect(result).equal({
+              numberOfPages: 7,
+              component: {
+                items: [
+                  { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: false },
+                  { number: 2, visuallyHiddenText: 'Page 2', href: '/system/bill-runs?page=2', current: false },
+                  { number: 3, visuallyHiddenText: 'Page 3', href: '/system/bill-runs?page=3', current: false },
+                  { number: 4, visuallyHiddenText: 'Page 4', href: '/system/bill-runs?page=4', current: true },
+                  { number: 5, visuallyHiddenText: 'Page 5', href: '/system/bill-runs?page=5', current: false },
+                  { number: 6, visuallyHiddenText: 'Page 6', href: '/system/bill-runs?page=6', current: false },
+                  { number: 7, visuallyHiddenText: 'Page 7', href: '/system/bill-runs?page=7', current: false }
+                ],
+                next: { href: '/system/bill-runs?page=5' },
+                previous: { href: '/system/bill-runs?page=3' }
+              }
+            })
+          })
+        })
+
+        describe('and the last page is selected', () => {
+          beforeEach(() => {
+            selectedPage = 7
+          })
+
+          it('returns <- Previous 1 2 3 4 5 6 [7]', () => {
+            const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path)
+
+            expect(result).equal({
+              numberOfPages: 7,
+              component: {
+                items: [
+                  { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: false },
+                  { number: 2, visuallyHiddenText: 'Page 2', href: '/system/bill-runs?page=2', current: false },
+                  { number: 3, visuallyHiddenText: 'Page 3', href: '/system/bill-runs?page=3', current: false },
+                  { number: 4, visuallyHiddenText: 'Page 4', href: '/system/bill-runs?page=4', current: false },
+                  { number: 5, visuallyHiddenText: 'Page 5', href: '/system/bill-runs?page=5', current: false },
+                  { number: 6, visuallyHiddenText: 'Page 6', href: '/system/bill-runs?page=6', current: false },
+                  { number: 7, visuallyHiddenText: 'Page 7', href: '/system/bill-runs?page=7', current: true }
+                ],
+                previous: { href: '/system/bill-runs?page=6' }
+              }
+            })
+          })
+        })
+      })
+
+      describe('for 8 pages', () => {
+        beforeEach(() => {
+          numberOfRecords = 375
+        })
+
+        describe('and the first page is selected', () => {
+          beforeEach(() => {
+            selectedPage = 1
+          })
+
+          it('returns [1] 2 3 4 5 .. 8 Next ->', () => {
+            const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path)
+
+            expect(result).equal({
+              numberOfPages: 8,
+              component: {
+                items: [
+                  { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: true },
+                  { number: 2, visuallyHiddenText: 'Page 2', href: '/system/bill-runs?page=2', current: false },
+                  { number: 3, visuallyHiddenText: 'Page 3', href: '/system/bill-runs?page=3', current: false },
+                  { number: 4, visuallyHiddenText: 'Page 4', href: '/system/bill-runs?page=4', current: false },
+                  { number: 5, visuallyHiddenText: 'Page 5', href: '/system/bill-runs?page=5', current: false },
+                  { ellipsis: true },
+                  { number: 8, visuallyHiddenText: 'Page 8', href: '/system/bill-runs?page=8', current: false }
+                ],
+                next: { href: '/system/bill-runs?page=2' }
+              }
+            })
+          })
+        })
+
+        describe('and page 4 is selected', () => {
+          beforeEach(() => {
+            selectedPage = 4
+          })
+
+          it('returns <- Previous 1 2 3 [4] 5 .. 8 Next ->', () => {
+            const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path)
+
+            expect(result).equal({
+              numberOfPages: 8,
+              component: {
+                items: [
+                  { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: false },
+                  { number: 2, visuallyHiddenText: 'Page 2', href: '/system/bill-runs?page=2', current: false },
+                  { number: 3, visuallyHiddenText: 'Page 3', href: '/system/bill-runs?page=3', current: false },
+                  { number: 4, visuallyHiddenText: 'Page 4', href: '/system/bill-runs?page=4', current: true },
+                  { number: 5, visuallyHiddenText: 'Page 5', href: '/system/bill-runs?page=5', current: false },
+                  { ellipsis: true },
+                  { number: 8, visuallyHiddenText: 'Page 8', href: '/system/bill-runs?page=8', current: false }
+                ],
+                next: { href: '/system/bill-runs?page=5' },
+                previous: { href: '/system/bill-runs?page=3' }
+              }
+            })
+          })
+        })
+
+        describe('and page 5 is selected', () => {
+          beforeEach(() => {
+            selectedPage = 5
+          })
+
+          it('returns <- Previous 1 .. 4 [5] 6 7 8 Next ->', () => {
+            const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path)
+
+            expect(result).equal({
+              numberOfPages: 8,
+              component: {
+                items: [
+                  { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: false },
+                  { ellipsis: true },
+                  { number: 4, visuallyHiddenText: 'Page 4', href: '/system/bill-runs?page=4', current: false },
+                  { number: 5, visuallyHiddenText: 'Page 5', href: '/system/bill-runs?page=5', current: true },
+                  { number: 6, visuallyHiddenText: 'Page 6', href: '/system/bill-runs?page=6', current: false },
+                  { number: 7, visuallyHiddenText: 'Page 7', href: '/system/bill-runs?page=7', current: false },
+                  { number: 8, visuallyHiddenText: 'Page 8', href: '/system/bill-runs?page=8', current: false }
+                ],
+                next: { href: '/system/bill-runs?page=6' },
+                previous: { href: '/system/bill-runs?page=4' }
+              }
+            })
+          })
+        })
+
+        describe('and the last page is selected', () => {
+          beforeEach(() => {
+            selectedPage = 8
+          })
+
+          it('returns <- Previous 1 .. 4 5 6 7 [8]', () => {
+            const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path)
+
+            expect(result).equal({
+              numberOfPages: 8,
+              component: {
+                items: [
+                  { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: false },
+                  { ellipsis: true },
+                  { number: 4, visuallyHiddenText: 'Page 4', href: '/system/bill-runs?page=4', current: false },
+                  { number: 5, visuallyHiddenText: 'Page 5', href: '/system/bill-runs?page=5', current: false },
+                  { number: 6, visuallyHiddenText: 'Page 6', href: '/system/bill-runs?page=6', current: false },
+                  { number: 7, visuallyHiddenText: 'Page 7', href: '/system/bill-runs?page=7', current: false },
+                  { number: 8, visuallyHiddenText: 'Page 8', href: '/system/bill-runs?page=8', current: true }
+                ],
+                previous: { href: '/system/bill-runs?page=7' }
+              }
+            })
+          })
+        })
+      })
+
+      describe('for 9 pages', () => {
+        beforeEach(() => {
+          numberOfRecords = 425
+        })
+
+        describe('and the first page is selected', () => {
+          beforeEach(() => {
+            selectedPage = 1
+          })
+
+          it('returns [1] 2 3 4 5 .. 9 Next ->', () => {
+            const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path)
+
+            expect(result).equal({
+              numberOfPages: 9,
+              component: {
+                items: [
+                  { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: true },
+                  { number: 2, visuallyHiddenText: 'Page 2', href: '/system/bill-runs?page=2', current: false },
+                  { number: 3, visuallyHiddenText: 'Page 3', href: '/system/bill-runs?page=3', current: false },
+                  { number: 4, visuallyHiddenText: 'Page 4', href: '/system/bill-runs?page=4', current: false },
+                  { number: 5, visuallyHiddenText: 'Page 5', href: '/system/bill-runs?page=5', current: false },
+                  { ellipsis: true },
+                  { number: 9, visuallyHiddenText: 'Page 9', href: '/system/bill-runs?page=9', current: false }
+                ],
+                next: { href: '/system/bill-runs?page=2' }
+              }
+            })
+          })
+        })
+
+        describe('and page 4 is selected', () => {
+          beforeEach(() => {
+            selectedPage = 4
+          })
+
+          it('returns <- Previous 1 2 3 [4] 5 .. 9 Next ->', () => {
+            const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path)
+
+            expect(result).equal({
+              numberOfPages: 9,
+              component: {
+                items: [
+                  { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: false },
+                  { number: 2, visuallyHiddenText: 'Page 2', href: '/system/bill-runs?page=2', current: false },
+                  { number: 3, visuallyHiddenText: 'Page 3', href: '/system/bill-runs?page=3', current: false },
+                  { number: 4, visuallyHiddenText: 'Page 4', href: '/system/bill-runs?page=4', current: true },
+                  { number: 5, visuallyHiddenText: 'Page 5', href: '/system/bill-runs?page=5', current: false },
+                  { ellipsis: true },
+                  { number: 9, visuallyHiddenText: 'Page 9', href: '/system/bill-runs?page=9', current: false }
+                ],
+                next: { href: '/system/bill-runs?page=5' },
+                previous: { href: '/system/bill-runs?page=3' }
+              }
+            })
+          })
+        })
+
+        describe('and page 5 is selected', () => {
+          beforeEach(() => {
+            selectedPage = 5
+          })
+
+          it('returns <- Previous 1 .. 4 [5] 6 .. 9 Next ->', () => {
+            const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path)
+
+            expect(result).equal({
+              numberOfPages: 9,
+              component: {
+                items: [
+                  { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: false },
+                  { ellipsis: true },
+                  { number: 4, visuallyHiddenText: 'Page 4', href: '/system/bill-runs?page=4', current: false },
+                  { number: 5, visuallyHiddenText: 'Page 5', href: '/system/bill-runs?page=5', current: true },
+                  { number: 6, visuallyHiddenText: 'Page 6', href: '/system/bill-runs?page=6', current: false },
+                  { ellipsis: true },
+                  { number: 9, visuallyHiddenText: 'Page 9', href: '/system/bill-runs?page=9', current: false }
+                ],
+                next: { href: '/system/bill-runs?page=6' },
+                previous: { href: '/system/bill-runs?page=4' }
+              }
+            })
+          })
+        })
+
+        describe('and page 6 is selected', () => {
+          beforeEach(() => {
+            selectedPage = 6
+          })
+
+          it('returns <- Previous 1 .. 5 [6] 7 8 9 Next ->', () => {
+            const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path)
+
+            expect(result).equal({
+              numberOfPages: 9,
+              component: {
+                items: [
+                  { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: false },
+                  { ellipsis: true },
+                  { number: 5, visuallyHiddenText: 'Page 5', href: '/system/bill-runs?page=5', current: false },
+                  { number: 6, visuallyHiddenText: 'Page 6', href: '/system/bill-runs?page=6', current: true },
+                  { number: 7, visuallyHiddenText: 'Page 7', href: '/system/bill-runs?page=7', current: false },
+                  { number: 8, visuallyHiddenText: 'Page 8', href: '/system/bill-runs?page=8', current: false },
+                  { number: 9, visuallyHiddenText: 'Page 9', href: '/system/bill-runs?page=9', current: false }
+                ],
+                next: { href: '/system/bill-runs?page=7' },
+                previous: { href: '/system/bill-runs?page=5' }
+              }
+            })
+          })
+        })
+
+        describe('and the last page is selected', () => {
+          beforeEach(() => {
+            selectedPage = 9
+          })
+
+          it('returns <- Previous 1 .. 5 6 7 8 [9]', () => {
+            const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path)
+
+            expect(result).equal({
+              numberOfPages: 9,
+              component: {
+                items: [
+                  { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: false },
+                  { ellipsis: true },
+                  { number: 5, visuallyHiddenText: 'Page 5', href: '/system/bill-runs?page=5', current: false },
+                  { number: 6, visuallyHiddenText: 'Page 6', href: '/system/bill-runs?page=6', current: false },
+                  { number: 7, visuallyHiddenText: 'Page 7', href: '/system/bill-runs?page=7', current: false },
+                  { number: 8, visuallyHiddenText: 'Page 8', href: '/system/bill-runs?page=8', current: false },
+                  { number: 9, visuallyHiddenText: 'Page 9', href: '/system/bill-runs?page=9', current: true }
+                ],
+                previous: { href: '/system/bill-runs?page=8' }
+              }
+            })
+          })
+        })
+      })
+
+      describe('for 100 pages', () => {
+        beforeEach(() => {
+          numberOfRecords = 4975
+        })
+
+        describe('and the first page is selected', () => {
+          beforeEach(() => {
+            selectedPage = 1
+          })
+
+          it('returns [1] 2 3 4 5 .. 100 Next ->', () => {
+            const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path)
+
+            expect(result).equal({
+              numberOfPages: 100,
+              component: {
+                items: [
+                  { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: true },
+                  { number: 2, visuallyHiddenText: 'Page 2', href: '/system/bill-runs?page=2', current: false },
+                  { number: 3, visuallyHiddenText: 'Page 3', href: '/system/bill-runs?page=3', current: false },
+                  { number: 4, visuallyHiddenText: 'Page 4', href: '/system/bill-runs?page=4', current: false },
+                  { number: 5, visuallyHiddenText: 'Page 5', href: '/system/bill-runs?page=5', current: false },
+                  { ellipsis: true },
+                  { number: 100, visuallyHiddenText: 'Page 100', href: '/system/bill-runs?page=100', current: false }
+                ],
+                next: { href: '/system/bill-runs?page=2' }
+              }
+            })
+          })
+        })
+
+        describe('and page 4 is selected', () => {
+          beforeEach(() => {
+            selectedPage = 4
+          })
+
+          it('returns <- Previous 1 2 3 [4] 5 .. 100 Next ->', () => {
+            const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path)
+
+            expect(result).equal({
+              numberOfPages: 100,
+              component: {
+                items: [
+                  { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: false },
+                  { number: 2, visuallyHiddenText: 'Page 2', href: '/system/bill-runs?page=2', current: false },
+                  { number: 3, visuallyHiddenText: 'Page 3', href: '/system/bill-runs?page=3', current: false },
+                  { number: 4, visuallyHiddenText: 'Page 4', href: '/system/bill-runs?page=4', current: true },
+                  { number: 5, visuallyHiddenText: 'Page 5', href: '/system/bill-runs?page=5', current: false },
+                  { ellipsis: true },
+                  { number: 100, visuallyHiddenText: 'Page 100', href: '/system/bill-runs?page=100', current: false }
+                ],
+                next: { href: '/system/bill-runs?page=5' },
+                previous: { href: '/system/bill-runs?page=3' }
+              }
+            })
+          })
+        })
+
+        describe('and page 49 is selected', () => {
+          beforeEach(() => {
+            selectedPage = 49
+          })
+
+          it('returns <- Previous 1 .. 48 [49] 50 .. 100 Next ->', () => {
+            const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path)
+
+            expect(result).equal({
+              numberOfPages: 100,
+              component: {
+                items: [
+                  { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: false },
+                  { ellipsis: true },
+                  { number: 48, visuallyHiddenText: 'Page 48', href: '/system/bill-runs?page=48', current: false },
+                  { number: 49, visuallyHiddenText: 'Page 49', href: '/system/bill-runs?page=49', current: true },
+                  { number: 50, visuallyHiddenText: 'Page 50', href: '/system/bill-runs?page=50', current: false },
+                  { ellipsis: true },
+                  { number: 100, visuallyHiddenText: 'Page 100', href: '/system/bill-runs?page=100', current: false }
+                ],
+                next: { href: '/system/bill-runs?page=50' },
+                previous: { href: '/system/bill-runs?page=48' }
+              }
+            })
+          })
+        })
+
+        describe('and page 97 is selected', () => {
+          beforeEach(() => {
+            selectedPage = 97
+          })
+
+          it('returns <- Previous 1 .. 96 [97] 98 99 100 Next ->', () => {
+            const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path)
+
+            expect(result).equal({
+              numberOfPages: 100,
+              component: {
+                items: [
+                  { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: false },
+                  { ellipsis: true },
+                  { number: 96, visuallyHiddenText: 'Page 96', href: '/system/bill-runs?page=96', current: false },
+                  { number: 97, visuallyHiddenText: 'Page 97', href: '/system/bill-runs?page=97', current: true },
+                  { number: 98, visuallyHiddenText: 'Page 98', href: '/system/bill-runs?page=98', current: false },
+                  { number: 99, visuallyHiddenText: 'Page 99', href: '/system/bill-runs?page=99', current: false },
+                  { number: 100, visuallyHiddenText: 'Page 100', href: '/system/bill-runs?page=100', current: false }
+                ],
+                next: { href: '/system/bill-runs?page=98' },
+                previous: { href: '/system/bill-runs?page=96' }
+              }
+            })
+          })
+        })
+
+        describe('and the last page is selected', () => {
+          beforeEach(() => {
+            selectedPage = 100
+          })
+
+          it('returns <- Previous 1 .. 96 97 98 99 [100]', () => {
+            const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path)
+
+            expect(result).equal({
+              numberOfPages: 100,
+              component: {
+                items: [
+                  { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: false },
+                  { ellipsis: true },
+                  { number: 96, visuallyHiddenText: 'Page 96', href: '/system/bill-runs?page=96', current: false },
+                  { number: 97, visuallyHiddenText: 'Page 97', href: '/system/bill-runs?page=97', current: false },
+                  { number: 98, visuallyHiddenText: 'Page 98', href: '/system/bill-runs?page=98', current: false },
+                  { number: 99, visuallyHiddenText: 'Page 99', href: '/system/bill-runs?page=99', current: false },
+                  { number: 100, visuallyHiddenText: 'Page 100', href: '/system/bill-runs?page=100', current: true }
+                ],
+                previous: { href: '/system/bill-runs?page=99' }
+              }
+            })
           })
         })
       })
     })
 
-    describe('for 3 pages', () => {
+    describe('and there are query arguments', () => {
       beforeEach(() => {
-        numberOfRecords = 125
+        queryArgs = {
+          'billing-account-id': 'c17c0a2b-6950-490b-8c3a-4dc9f01da368',
+          'licence-id': '354fc0bd-0820-4611-a6af-874480bbae3b'
+        }
       })
 
-      describe('and the first page is selected', () => {
+      describe('for 2 pages', () => {
         beforeEach(() => {
-          selectedPage = 1
+          numberOfRecords = 75
         })
 
-        it('returns [1] 2  3 Next ->', () => {
-          const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path)
+        describe('and the first page is selected', () => {
+          beforeEach(() => {
+            selectedPage = 1
+          })
 
-          expect(result).equal({
-            numberOfPages: 3,
-            component: {
-              items: [
-                { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: true },
-                { number: 2, visuallyHiddenText: 'Page 2', href: '/system/bill-runs?page=2', current: false },
-                { number: 3, visuallyHiddenText: 'Page 3', href: '/system/bill-runs?page=3', current: false }
-              ],
-              next: { href: '/system/bill-runs?page=2' }
-            }
+          it('returns [1] 2 Next ->', () => {
+            const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path, queryArgs)
+
+            expect(result).equal({
+              numberOfPages: 2,
+              component: {
+                items: [
+                  { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: true },
+                  {
+                    number: 2,
+                    visuallyHiddenText: 'Page 2',
+                    href: '/system/bill-runs?page=2&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  }
+                ],
+                next: {
+                  href: '/system/bill-runs?page=2&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b'
+                }
+              }
+            })
+          })
+        })
+
+        describe('and the last page is selected', () => {
+          beforeEach(() => {
+            selectedPage = 2
+          })
+
+          it('returns <- Previous 1 [2]', () => {
+            const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path, queryArgs)
+
+            expect(result).equal({
+              numberOfPages: 2,
+              component: {
+                items: [
+                  { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: false },
+                  {
+                    number: 2,
+                    visuallyHiddenText: 'Page 2',
+                    href: '/system/bill-runs?page=2&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: true
+                  }
+                ],
+                previous: {
+                  href: '/system/bill-runs?page=1&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b'
+                }
+              }
+            })
           })
         })
       })
 
-      describe('and page 2 is selected', () => {
+      describe('for 3 pages', () => {
         beforeEach(() => {
-          selectedPage = 2
+          numberOfRecords = 125
         })
 
-        it('returns <- Previous 1 [2] 3 Next ->', () => {
-          const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path)
+        describe('and the first page is selected', () => {
+          beforeEach(() => {
+            selectedPage = 1
+          })
 
-          expect(result).equal({
-            numberOfPages: 3,
-            component: {
-              items: [
-                { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: false },
-                { number: 2, visuallyHiddenText: 'Page 2', href: '/system/bill-runs?page=2', current: true },
-                { number: 3, visuallyHiddenText: 'Page 3', href: '/system/bill-runs?page=3', current: false }
-              ],
-              next: { href: '/system/bill-runs?page=3' },
-              previous: { href: '/system/bill-runs?page=1' }
-            }
+          it('returns [1] 2  3 Next ->', () => {
+            const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path, queryArgs)
+
+            expect(result).equal({
+              numberOfPages: 3,
+              component: {
+                items: [
+                  { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: true },
+                  {
+                    number: 2,
+                    visuallyHiddenText: 'Page 2',
+                    href: '/system/bill-runs?page=2&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  {
+                    number: 3,
+                    visuallyHiddenText: 'Page 3',
+                    href: '/system/bill-runs?page=3&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  }
+                ],
+                next: {
+                  href: '/system/bill-runs?page=2&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b'
+                }
+              }
+            })
+          })
+        })
+
+        describe('and page 2 is selected', () => {
+          beforeEach(() => {
+            selectedPage = 2
+          })
+
+          it('returns <- Previous 1 [2] 3 Next ->', () => {
+            const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path, queryArgs)
+
+            expect(result).equal({
+              numberOfPages: 3,
+              component: {
+                items: [
+                  { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: false },
+                  {
+                    number: 2,
+                    visuallyHiddenText: 'Page 2',
+                    href: '/system/bill-runs?page=2&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: true
+                  },
+                  {
+                    number: 3,
+                    visuallyHiddenText: 'Page 3',
+                    href: '/system/bill-runs?page=3&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  }
+                ],
+                next: {
+                  href: '/system/bill-runs?page=3&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b'
+                },
+                previous: {
+                  href: '/system/bill-runs?page=1&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b'
+                }
+              }
+            })
+          })
+        })
+
+        describe('and the last page is selected', () => {
+          beforeEach(() => {
+            selectedPage = 3
+          })
+
+          it('returns <- Previous 1 2 [3]', () => {
+            const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path, queryArgs)
+
+            expect(result).equal({
+              numberOfPages: 3,
+              component: {
+                items: [
+                  { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: false },
+                  {
+                    number: 2,
+                    visuallyHiddenText: 'Page 2',
+                    href: '/system/bill-runs?page=2&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  {
+                    number: 3,
+                    visuallyHiddenText: 'Page 3',
+                    href: '/system/bill-runs?page=3&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: true
+                  }
+                ],
+                previous: {
+                  href: '/system/bill-runs?page=2&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b'
+                }
+              }
+            })
           })
         })
       })
 
-      describe('and the last page is selected', () => {
+      describe('for 4 pages', () => {
         beforeEach(() => {
-          selectedPage = 3
+          numberOfRecords = 175
         })
 
-        it('returns <- Previous 1 2 [3]', () => {
-          const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path)
+        describe('and the first page is selected', () => {
+          beforeEach(() => {
+            selectedPage = 1
+          })
 
-          expect(result).equal({
-            numberOfPages: 3,
-            component: {
-              items: [
-                { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: false },
-                { number: 2, visuallyHiddenText: 'Page 2', href: '/system/bill-runs?page=2', current: false },
-                { number: 3, visuallyHiddenText: 'Page 3', href: '/system/bill-runs?page=3', current: true }
-              ],
-              previous: { href: '/system/bill-runs?page=2' }
-            }
+          it('returns [1] 2 3 4 Next ->', () => {
+            const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path, queryArgs)
+
+            expect(result).equal({
+              numberOfPages: 4,
+              component: {
+                items: [
+                  { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: true },
+                  {
+                    number: 2,
+                    visuallyHiddenText: 'Page 2',
+                    href: '/system/bill-runs?page=2&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  {
+                    number: 3,
+                    visuallyHiddenText: 'Page 3',
+                    href: '/system/bill-runs?page=3&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  {
+                    number: 4,
+                    visuallyHiddenText: 'Page 4',
+                    href: '/system/bill-runs?page=4&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  }
+                ],
+                next: {
+                  href: '/system/bill-runs?page=2&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b'
+                }
+              }
+            })
           })
         })
-      })
-    })
 
-    describe('for 4 pages', () => {
-      beforeEach(() => {
-        numberOfRecords = 175
-      })
+        describe('and page 2 is selected', () => {
+          beforeEach(() => {
+            selectedPage = 2
+          })
 
-      describe('and the first page is selected', () => {
-        beforeEach(() => {
-          selectedPage = 1
-        })
+          it('returns <- Previous 1 [2] 3 4 Next ->', () => {
+            const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path, queryArgs)
 
-        it('returns [1] 2 3 4 Next ->', () => {
-          const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path)
-
-          expect(result).equal({
-            numberOfPages: 4,
-            component: {
-              items: [
-                { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: true },
-                { number: 2, visuallyHiddenText: 'Page 2', href: '/system/bill-runs?page=2', current: false },
-                { number: 3, visuallyHiddenText: 'Page 3', href: '/system/bill-runs?page=3', current: false },
-                { number: 4, visuallyHiddenText: 'Page 4', href: '/system/bill-runs?page=4', current: false }
-              ],
-              next: { href: '/system/bill-runs?page=2' }
-            }
+            expect(result).equal({
+              numberOfPages: 4,
+              component: {
+                items: [
+                  { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: false },
+                  {
+                    number: 2,
+                    visuallyHiddenText: 'Page 2',
+                    href: '/system/bill-runs?page=2&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: true
+                  },
+                  {
+                    number: 3,
+                    visuallyHiddenText: 'Page 3',
+                    href: '/system/bill-runs?page=3&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  {
+                    number: 4,
+                    visuallyHiddenText: 'Page 4',
+                    href: '/system/bill-runs?page=4&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  }
+                ],
+                next: {
+                  href: '/system/bill-runs?page=3&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b'
+                },
+                previous: {
+                  href: '/system/bill-runs?page=1&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b'
+                }
+              }
+            })
           })
         })
-      })
 
-      describe('and page 2 is selected', () => {
-        beforeEach(() => {
-          selectedPage = 2
-        })
-
-        it('returns <- Previous 1 [2] 3 4 Next ->', () => {
-          const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path)
-
-          expect(result).equal({
-            numberOfPages: 4,
-            component: {
-              items: [
-                { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: false },
-                { number: 2, visuallyHiddenText: 'Page 2', href: '/system/bill-runs?page=2', current: true },
-                { number: 3, visuallyHiddenText: 'Page 3', href: '/system/bill-runs?page=3', current: false },
-                { number: 4, visuallyHiddenText: 'Page 4', href: '/system/bill-runs?page=4', current: false }
-              ],
-              next: { href: '/system/bill-runs?page=3' },
-              previous: { href: '/system/bill-runs?page=1' }
-            }
+        describe('and the last page is selected', () => {
+          beforeEach(() => {
+            selectedPage = 4
           })
-        })
-      })
 
-      describe('and the last page is selected', () => {
-        beforeEach(() => {
-          selectedPage = 4
-        })
+          it('returns <- Previous 1 2 3 [4]', () => {
+            const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path, queryArgs)
 
-        it('returns <- Previous 1 2 3 [4]', () => {
-          const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path)
-
-          expect(result).equal({
-            numberOfPages: 4,
-            component: {
-              items: [
-                { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: false },
-                { number: 2, visuallyHiddenText: 'Page 2', href: '/system/bill-runs?page=2', current: false },
-                { number: 3, visuallyHiddenText: 'Page 3', href: '/system/bill-runs?page=3', current: false },
-                { number: 4, visuallyHiddenText: 'Page 4', href: '/system/bill-runs?page=4', current: true }
-              ],
-              previous: { href: '/system/bill-runs?page=3' }
-            }
-          })
-        })
-      })
-    })
-
-    describe('for 5 pages', () => {
-      beforeEach(() => {
-        numberOfRecords = 225
-      })
-
-      describe('and the first page is selected', () => {
-        beforeEach(() => {
-          selectedPage = 1
-        })
-
-        it('returns [1] 2 3 4 5 Next ->', () => {
-          const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path)
-
-          expect(result).equal({
-            numberOfPages: 5,
-            component: {
-              items: [
-                { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: true },
-                { number: 2, visuallyHiddenText: 'Page 2', href: '/system/bill-runs?page=2', current: false },
-                { number: 3, visuallyHiddenText: 'Page 3', href: '/system/bill-runs?page=3', current: false },
-                { number: 4, visuallyHiddenText: 'Page 4', href: '/system/bill-runs?page=4', current: false },
-                { number: 5, visuallyHiddenText: 'Page 5', href: '/system/bill-runs?page=5', current: false }
-              ],
-              next: { href: '/system/bill-runs?page=2' }
-            }
-          })
-        })
-      })
-
-      describe('and page 3 is selected', () => {
-        beforeEach(() => {
-          selectedPage = 3
-        })
-
-        it('returns <- Previous 1 2 [3] 4 5 Next ->', () => {
-          const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path)
-
-          expect(result).equal({
-            numberOfPages: 5,
-            component: {
-              items: [
-                { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: false },
-                { number: 2, visuallyHiddenText: 'Page 2', href: '/system/bill-runs?page=2', current: false },
-                { number: 3, visuallyHiddenText: 'Page 3', href: '/system/bill-runs?page=3', current: true },
-                { number: 4, visuallyHiddenText: 'Page 4', href: '/system/bill-runs?page=4', current: false },
-                { number: 5, visuallyHiddenText: 'Page 5', href: '/system/bill-runs?page=5', current: false }
-              ],
-              next: { href: '/system/bill-runs?page=4' },
-              previous: { href: '/system/bill-runs?page=2' }
-            }
+            expect(result).equal({
+              numberOfPages: 4,
+              component: {
+                items: [
+                  { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: false },
+                  {
+                    number: 2,
+                    visuallyHiddenText: 'Page 2',
+                    href: '/system/bill-runs?page=2&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  {
+                    number: 3,
+                    visuallyHiddenText: 'Page 3',
+                    href: '/system/bill-runs?page=3&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  {
+                    number: 4,
+                    visuallyHiddenText: 'Page 4',
+                    href: '/system/bill-runs?page=4&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: true
+                  }
+                ],
+                previous: {
+                  href: '/system/bill-runs?page=3&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b'
+                }
+              }
+            })
           })
         })
       })
 
-      describe('and the last page is selected', () => {
+      describe('for 5 pages', () => {
         beforeEach(() => {
-          selectedPage = 5
+          numberOfRecords = 225
         })
 
-        it('returns <- Previous 1 2 3 4 [5]', () => {
-          const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path)
+        describe('and the first page is selected', () => {
+          beforeEach(() => {
+            selectedPage = 1
+          })
 
-          expect(result).equal({
-            numberOfPages: 5,
-            component: {
-              items: [
-                { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: false },
-                { number: 2, visuallyHiddenText: 'Page 2', href: '/system/bill-runs?page=2', current: false },
-                { number: 3, visuallyHiddenText: 'Page 3', href: '/system/bill-runs?page=3', current: false },
-                { number: 4, visuallyHiddenText: 'Page 4', href: '/system/bill-runs?page=4', current: false },
-                { number: 5, visuallyHiddenText: 'Page 5', href: '/system/bill-runs?page=5', current: true }
-              ],
-              previous: { href: '/system/bill-runs?page=4' }
-            }
+          it('returns [1] 2 3 4 5 Next ->', () => {
+            const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path, queryArgs)
+
+            expect(result).equal({
+              numberOfPages: 5,
+              component: {
+                items: [
+                  { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: true },
+                  {
+                    number: 2,
+                    visuallyHiddenText: 'Page 2',
+                    href: '/system/bill-runs?page=2&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  {
+                    number: 3,
+                    visuallyHiddenText: 'Page 3',
+                    href: '/system/bill-runs?page=3&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  {
+                    number: 4,
+                    visuallyHiddenText: 'Page 4',
+                    href: '/system/bill-runs?page=4&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  {
+                    number: 5,
+                    visuallyHiddenText: 'Page 5',
+                    href: '/system/bill-runs?page=5&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  }
+                ],
+                next: {
+                  href: '/system/bill-runs?page=2&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b'
+                }
+              }
+            })
           })
         })
-      })
-    })
 
-    describe('for 6 pages', () => {
-      beforeEach(() => {
-        numberOfRecords = 275
-      })
+        describe('and page 3 is selected', () => {
+          beforeEach(() => {
+            selectedPage = 3
+          })
 
-      describe('and the first page is selected', () => {
-        beforeEach(() => {
-          selectedPage = 1
-        })
+          it('returns <- Previous 1 2 [3] 4 5 Next ->', () => {
+            const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path, queryArgs)
 
-        it('returns [1] 2 3 4 5 6 Next ->', () => {
-          const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path)
-
-          expect(result).equal({
-            numberOfPages: 6,
-            component: {
-              items: [
-                { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: true },
-                { number: 2, visuallyHiddenText: 'Page 2', href: '/system/bill-runs?page=2', current: false },
-                { number: 3, visuallyHiddenText: 'Page 3', href: '/system/bill-runs?page=3', current: false },
-                { number: 4, visuallyHiddenText: 'Page 4', href: '/system/bill-runs?page=4', current: false },
-                { number: 5, visuallyHiddenText: 'Page 5', href: '/system/bill-runs?page=5', current: false },
-                { number: 6, visuallyHiddenText: 'Page 6', href: '/system/bill-runs?page=6', current: false }
-              ],
-              next: { href: '/system/bill-runs?page=2' }
-            }
+            expect(result).equal({
+              numberOfPages: 5,
+              component: {
+                items: [
+                  { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: false },
+                  {
+                    number: 2,
+                    visuallyHiddenText: 'Page 2',
+                    href: '/system/bill-runs?page=2&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  {
+                    number: 3,
+                    visuallyHiddenText: 'Page 3',
+                    href: '/system/bill-runs?page=3&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: true
+                  },
+                  {
+                    number: 4,
+                    visuallyHiddenText: 'Page 4',
+                    href: '/system/bill-runs?page=4&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  {
+                    number: 5,
+                    visuallyHiddenText: 'Page 5',
+                    href: '/system/bill-runs?page=5&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  }
+                ],
+                next: {
+                  href: '/system/bill-runs?page=4&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b'
+                },
+                previous: {
+                  href: '/system/bill-runs?page=2&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b'
+                }
+              }
+            })
           })
         })
-      })
 
-      describe('and page 3 is selected', () => {
-        beforeEach(() => {
-          selectedPage = 3
-        })
-
-        it('returns <- Previous 1 2 [3] 4 5 6 Next ->', () => {
-          const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path)
-
-          expect(result).equal({
-            numberOfPages: 6,
-            component: {
-              items: [
-                { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: false },
-                { number: 2, visuallyHiddenText: 'Page 2', href: '/system/bill-runs?page=2', current: false },
-                { number: 3, visuallyHiddenText: 'Page 3', href: '/system/bill-runs?page=3', current: true },
-                { number: 4, visuallyHiddenText: 'Page 4', href: '/system/bill-runs?page=4', current: false },
-                { number: 5, visuallyHiddenText: 'Page 5', href: '/system/bill-runs?page=5', current: false },
-                { number: 6, visuallyHiddenText: 'Page 6', href: '/system/bill-runs?page=6', current: false }
-              ],
-              next: { href: '/system/bill-runs?page=4' },
-              previous: { href: '/system/bill-runs?page=2' }
-            }
+        describe('and the last page is selected', () => {
+          beforeEach(() => {
+            selectedPage = 5
           })
-        })
-      })
 
-      describe('and the last page is selected', () => {
-        beforeEach(() => {
-          selectedPage = 6
-        })
+          it('returns <- Previous 1 2 3 4 [5]', () => {
+            const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path, queryArgs)
 
-        it('returns <- Previous 1 2 3 4 5 [6]', () => {
-          const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path)
-
-          expect(result).equal({
-            numberOfPages: 6,
-            component: {
-              items: [
-                { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: false },
-                { number: 2, visuallyHiddenText: 'Page 2', href: '/system/bill-runs?page=2', current: false },
-                { number: 3, visuallyHiddenText: 'Page 3', href: '/system/bill-runs?page=3', current: false },
-                { number: 4, visuallyHiddenText: 'Page 4', href: '/system/bill-runs?page=4', current: false },
-                { number: 5, visuallyHiddenText: 'Page 5', href: '/system/bill-runs?page=5', current: false },
-                { number: 6, visuallyHiddenText: 'Page 6', href: '/system/bill-runs?page=6', current: true }
-              ],
-              previous: { href: '/system/bill-runs?page=5' }
-            }
-          })
-        })
-      })
-    })
-
-    describe('for 7 pages', () => {
-      beforeEach(() => {
-        numberOfRecords = 325
-      })
-
-      describe('and the first page is selected', () => {
-        beforeEach(() => {
-          selectedPage = 1
-        })
-
-        it('returns [1] 2 3 4 5 6 7 Next ->', () => {
-          const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path)
-
-          expect(result).equal({
-            numberOfPages: 7,
-            component: {
-              items: [
-                { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: true },
-                { number: 2, visuallyHiddenText: 'Page 2', href: '/system/bill-runs?page=2', current: false },
-                { number: 3, visuallyHiddenText: 'Page 3', href: '/system/bill-runs?page=3', current: false },
-                { number: 4, visuallyHiddenText: 'Page 4', href: '/system/bill-runs?page=4', current: false },
-                { number: 5, visuallyHiddenText: 'Page 5', href: '/system/bill-runs?page=5', current: false },
-                { number: 6, visuallyHiddenText: 'Page 6', href: '/system/bill-runs?page=6', current: false },
-                { number: 7, visuallyHiddenText: 'Page 7', href: '/system/bill-runs?page=7', current: false }
-              ],
-              next: { href: '/system/bill-runs?page=2' }
-            }
-          })
-        })
-      })
-
-      describe('and page 4 is selected', () => {
-        beforeEach(() => {
-          selectedPage = 4
-        })
-
-        it('returns <- Previous 1 2 3 [4] 5 6 7 Next ->', () => {
-          const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path)
-
-          expect(result).equal({
-            numberOfPages: 7,
-            component: {
-              items: [
-                { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: false },
-                { number: 2, visuallyHiddenText: 'Page 2', href: '/system/bill-runs?page=2', current: false },
-                { number: 3, visuallyHiddenText: 'Page 3', href: '/system/bill-runs?page=3', current: false },
-                { number: 4, visuallyHiddenText: 'Page 4', href: '/system/bill-runs?page=4', current: true },
-                { number: 5, visuallyHiddenText: 'Page 5', href: '/system/bill-runs?page=5', current: false },
-                { number: 6, visuallyHiddenText: 'Page 6', href: '/system/bill-runs?page=6', current: false },
-                { number: 7, visuallyHiddenText: 'Page 7', href: '/system/bill-runs?page=7', current: false }
-              ],
-              next: { href: '/system/bill-runs?page=5' },
-              previous: { href: '/system/bill-runs?page=3' }
-            }
+            expect(result).equal({
+              numberOfPages: 5,
+              component: {
+                items: [
+                  { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: false },
+                  {
+                    number: 2,
+                    visuallyHiddenText: 'Page 2',
+                    href: '/system/bill-runs?page=2&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  {
+                    number: 3,
+                    visuallyHiddenText: 'Page 3',
+                    href: '/system/bill-runs?page=3&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  {
+                    number: 4,
+                    visuallyHiddenText: 'Page 4',
+                    href: '/system/bill-runs?page=4&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  {
+                    number: 5,
+                    visuallyHiddenText: 'Page 5',
+                    href: '/system/bill-runs?page=5&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: true
+                  }
+                ],
+                previous: {
+                  href: '/system/bill-runs?page=4&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b'
+                }
+              }
+            })
           })
         })
       })
 
-      describe('and the last page is selected', () => {
+      describe('for 6 pages', () => {
         beforeEach(() => {
-          selectedPage = 7
+          numberOfRecords = 275
         })
 
-        it('returns <- Previous 1 2 3 4 5 6 [7]', () => {
-          const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path)
+        describe('and the first page is selected', () => {
+          beforeEach(() => {
+            selectedPage = 1
+          })
 
-          expect(result).equal({
-            numberOfPages: 7,
-            component: {
-              items: [
-                { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: false },
-                { number: 2, visuallyHiddenText: 'Page 2', href: '/system/bill-runs?page=2', current: false },
-                { number: 3, visuallyHiddenText: 'Page 3', href: '/system/bill-runs?page=3', current: false },
-                { number: 4, visuallyHiddenText: 'Page 4', href: '/system/bill-runs?page=4', current: false },
-                { number: 5, visuallyHiddenText: 'Page 5', href: '/system/bill-runs?page=5', current: false },
-                { number: 6, visuallyHiddenText: 'Page 6', href: '/system/bill-runs?page=6', current: false },
-                { number: 7, visuallyHiddenText: 'Page 7', href: '/system/bill-runs?page=7', current: true }
-              ],
-              previous: { href: '/system/bill-runs?page=6' }
-            }
+          it('returns [1] 2 3 4 5 6 Next ->', () => {
+            const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path, queryArgs)
+
+            expect(result).equal({
+              numberOfPages: 6,
+              component: {
+                items: [
+                  { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: true },
+                  {
+                    number: 2,
+                    visuallyHiddenText: 'Page 2',
+                    href: '/system/bill-runs?page=2&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  {
+                    number: 3,
+                    visuallyHiddenText: 'Page 3',
+                    href: '/system/bill-runs?page=3&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  {
+                    number: 4,
+                    visuallyHiddenText: 'Page 4',
+                    href: '/system/bill-runs?page=4&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  {
+                    number: 5,
+                    visuallyHiddenText: 'Page 5',
+                    href: '/system/bill-runs?page=5&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  {
+                    number: 6,
+                    visuallyHiddenText: 'Page 6',
+                    href: '/system/bill-runs?page=6&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  }
+                ],
+                next: {
+                  href: '/system/bill-runs?page=2&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b'
+                }
+              }
+            })
           })
         })
-      })
-    })
 
-    describe('for 8 pages', () => {
-      beforeEach(() => {
-        numberOfRecords = 375
-      })
+        describe('and page 3 is selected', () => {
+          beforeEach(() => {
+            selectedPage = 3
+          })
 
-      describe('and the first page is selected', () => {
-        beforeEach(() => {
-          selectedPage = 1
-        })
+          it('returns <- Previous 1 2 [3] 4 5 6 Next ->', () => {
+            const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path, queryArgs)
 
-        it('returns [1] 2 3 4 5 .. 8 Next ->', () => {
-          const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path)
-
-          expect(result).equal({
-            numberOfPages: 8,
-            component: {
-              items: [
-                { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: true },
-                { number: 2, visuallyHiddenText: 'Page 2', href: '/system/bill-runs?page=2', current: false },
-                { number: 3, visuallyHiddenText: 'Page 3', href: '/system/bill-runs?page=3', current: false },
-                { number: 4, visuallyHiddenText: 'Page 4', href: '/system/bill-runs?page=4', current: false },
-                { number: 5, visuallyHiddenText: 'Page 5', href: '/system/bill-runs?page=5', current: false },
-                { ellipsis: true },
-                { number: 8, visuallyHiddenText: 'Page 8', href: '/system/bill-runs?page=8', current: false }
-              ],
-              next: { href: '/system/bill-runs?page=2' }
-            }
+            expect(result).equal({
+              numberOfPages: 6,
+              component: {
+                items: [
+                  { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: false },
+                  {
+                    number: 2,
+                    visuallyHiddenText: 'Page 2',
+                    href: '/system/bill-runs?page=2&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  {
+                    number: 3,
+                    visuallyHiddenText: 'Page 3',
+                    href: '/system/bill-runs?page=3&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: true
+                  },
+                  {
+                    number: 4,
+                    visuallyHiddenText: 'Page 4',
+                    href: '/system/bill-runs?page=4&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  {
+                    number: 5,
+                    visuallyHiddenText: 'Page 5',
+                    href: '/system/bill-runs?page=5&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  {
+                    number: 6,
+                    visuallyHiddenText: 'Page 6',
+                    href: '/system/bill-runs?page=6&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  }
+                ],
+                next: {
+                  href: '/system/bill-runs?page=4&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b'
+                },
+                previous: {
+                  href: '/system/bill-runs?page=2&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b'
+                }
+              }
+            })
           })
         })
-      })
 
-      describe('and page 4 is selected', () => {
-        beforeEach(() => {
-          selectedPage = 4
-        })
-
-        it('returns <- Previous 1 2 3 [4] 5 .. 8 Next ->', () => {
-          const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path)
-
-          expect(result).equal({
-            numberOfPages: 8,
-            component: {
-              items: [
-                { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: false },
-                { number: 2, visuallyHiddenText: 'Page 2', href: '/system/bill-runs?page=2', current: false },
-                { number: 3, visuallyHiddenText: 'Page 3', href: '/system/bill-runs?page=3', current: false },
-                { number: 4, visuallyHiddenText: 'Page 4', href: '/system/bill-runs?page=4', current: true },
-                { number: 5, visuallyHiddenText: 'Page 5', href: '/system/bill-runs?page=5', current: false },
-                { ellipsis: true },
-                { number: 8, visuallyHiddenText: 'Page 8', href: '/system/bill-runs?page=8', current: false }
-              ],
-              next: { href: '/system/bill-runs?page=5' },
-              previous: { href: '/system/bill-runs?page=3' }
-            }
+        describe('and the last page is selected', () => {
+          beforeEach(() => {
+            selectedPage = 6
           })
-        })
-      })
 
-      describe('and page 5 is selected', () => {
-        beforeEach(() => {
-          selectedPage = 5
-        })
+          it('returns <- Previous 1 2 3 4 5 [6]', () => {
+            const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path, queryArgs)
 
-        it('returns <- Previous 1 .. 4 [5] 6 7 8 Next ->', () => {
-          const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path)
-
-          expect(result).equal({
-            numberOfPages: 8,
-            component: {
-              items: [
-                { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: false },
-                { ellipsis: true },
-                { number: 4, visuallyHiddenText: 'Page 4', href: '/system/bill-runs?page=4', current: false },
-                { number: 5, visuallyHiddenText: 'Page 5', href: '/system/bill-runs?page=5', current: true },
-                { number: 6, visuallyHiddenText: 'Page 6', href: '/system/bill-runs?page=6', current: false },
-                { number: 7, visuallyHiddenText: 'Page 7', href: '/system/bill-runs?page=7', current: false },
-                { number: 8, visuallyHiddenText: 'Page 8', href: '/system/bill-runs?page=8', current: false }
-              ],
-              next: { href: '/system/bill-runs?page=6' },
-              previous: { href: '/system/bill-runs?page=4' }
-            }
-          })
-        })
-      })
-
-      describe('and the last page is selected', () => {
-        beforeEach(() => {
-          selectedPage = 8
-        })
-
-        it('returns <- Previous 1 .. 4 5 6 7 [8]', () => {
-          const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path)
-
-          expect(result).equal({
-            numberOfPages: 8,
-            component: {
-              items: [
-                { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: false },
-                { ellipsis: true },
-                { number: 4, visuallyHiddenText: 'Page 4', href: '/system/bill-runs?page=4', current: false },
-                { number: 5, visuallyHiddenText: 'Page 5', href: '/system/bill-runs?page=5', current: false },
-                { number: 6, visuallyHiddenText: 'Page 6', href: '/system/bill-runs?page=6', current: false },
-                { number: 7, visuallyHiddenText: 'Page 7', href: '/system/bill-runs?page=7', current: false },
-                { number: 8, visuallyHiddenText: 'Page 8', href: '/system/bill-runs?page=8', current: true }
-              ],
-              previous: { href: '/system/bill-runs?page=7' }
-            }
-          })
-        })
-      })
-    })
-
-    describe('for 9 pages', () => {
-      beforeEach(() => {
-        numberOfRecords = 425
-      })
-
-      describe('and the first page is selected', () => {
-        beforeEach(() => {
-          selectedPage = 1
-        })
-
-        it('returns [1] 2 3 4 5 .. 9 Next ->', () => {
-          const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path)
-
-          expect(result).equal({
-            numberOfPages: 9,
-            component: {
-              items: [
-                { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: true },
-                { number: 2, visuallyHiddenText: 'Page 2', href: '/system/bill-runs?page=2', current: false },
-                { number: 3, visuallyHiddenText: 'Page 3', href: '/system/bill-runs?page=3', current: false },
-                { number: 4, visuallyHiddenText: 'Page 4', href: '/system/bill-runs?page=4', current: false },
-                { number: 5, visuallyHiddenText: 'Page 5', href: '/system/bill-runs?page=5', current: false },
-                { ellipsis: true },
-                { number: 9, visuallyHiddenText: 'Page 9', href: '/system/bill-runs?page=9', current: false }
-              ],
-              next: { href: '/system/bill-runs?page=2' }
-            }
+            expect(result).equal({
+              numberOfPages: 6,
+              component: {
+                items: [
+                  { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: false },
+                  {
+                    number: 2,
+                    visuallyHiddenText: 'Page 2',
+                    href: '/system/bill-runs?page=2&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  {
+                    number: 3,
+                    visuallyHiddenText: 'Page 3',
+                    href: '/system/bill-runs?page=3&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  {
+                    number: 4,
+                    visuallyHiddenText: 'Page 4',
+                    href: '/system/bill-runs?page=4&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  {
+                    number: 5,
+                    visuallyHiddenText: 'Page 5',
+                    href: '/system/bill-runs?page=5&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  {
+                    number: 6,
+                    visuallyHiddenText: 'Page 6',
+                    href: '/system/bill-runs?page=6&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: true
+                  }
+                ],
+                previous: {
+                  href: '/system/bill-runs?page=5&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b'
+                }
+              }
+            })
           })
         })
       })
 
-      describe('and page 4 is selected', () => {
+      describe('for 7 pages', () => {
         beforeEach(() => {
-          selectedPage = 4
+          numberOfRecords = 325
         })
 
-        it('returns <- Previous 1 2 3 [4] 5 .. 9 Next ->', () => {
-          const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path)
+        describe('and the first page is selected', () => {
+          beforeEach(() => {
+            selectedPage = 1
+          })
 
-          expect(result).equal({
-            numberOfPages: 9,
-            component: {
-              items: [
-                { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: false },
-                { number: 2, visuallyHiddenText: 'Page 2', href: '/system/bill-runs?page=2', current: false },
-                { number: 3, visuallyHiddenText: 'Page 3', href: '/system/bill-runs?page=3', current: false },
-                { number: 4, visuallyHiddenText: 'Page 4', href: '/system/bill-runs?page=4', current: true },
-                { number: 5, visuallyHiddenText: 'Page 5', href: '/system/bill-runs?page=5', current: false },
-                { ellipsis: true },
-                { number: 9, visuallyHiddenText: 'Page 9', href: '/system/bill-runs?page=9', current: false }
-              ],
-              next: { href: '/system/bill-runs?page=5' },
-              previous: { href: '/system/bill-runs?page=3' }
-            }
+          it('returns [1] 2 3 4 5 6 7 Next ->', () => {
+            const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path, queryArgs)
+
+            expect(result).equal({
+              numberOfPages: 7,
+              component: {
+                items: [
+                  { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: true },
+                  {
+                    number: 2,
+                    visuallyHiddenText: 'Page 2',
+                    href: '/system/bill-runs?page=2&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  {
+                    number: 3,
+                    visuallyHiddenText: 'Page 3',
+                    href: '/system/bill-runs?page=3&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  {
+                    number: 4,
+                    visuallyHiddenText: 'Page 4',
+                    href: '/system/bill-runs?page=4&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  {
+                    number: 5,
+                    visuallyHiddenText: 'Page 5',
+                    href: '/system/bill-runs?page=5&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  {
+                    number: 6,
+                    visuallyHiddenText: 'Page 6',
+                    href: '/system/bill-runs?page=6&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  {
+                    number: 7,
+                    visuallyHiddenText: 'Page 7',
+                    href: '/system/bill-runs?page=7&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  }
+                ],
+                next: {
+                  href: '/system/bill-runs?page=2&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b'
+                }
+              }
+            })
+          })
+        })
+
+        describe('and page 4 is selected', () => {
+          beforeEach(() => {
+            selectedPage = 4
+          })
+
+          it('returns <- Previous 1 2 3 [4] 5 6 7 Next ->', () => {
+            const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path, queryArgs)
+
+            expect(result).equal({
+              numberOfPages: 7,
+              component: {
+                items: [
+                  { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: false },
+                  {
+                    number: 2,
+                    visuallyHiddenText: 'Page 2',
+                    href: '/system/bill-runs?page=2&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  {
+                    number: 3,
+                    visuallyHiddenText: 'Page 3',
+                    href: '/system/bill-runs?page=3&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  {
+                    number: 4,
+                    visuallyHiddenText: 'Page 4',
+                    href: '/system/bill-runs?page=4&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: true
+                  },
+                  {
+                    number: 5,
+                    visuallyHiddenText: 'Page 5',
+                    href: '/system/bill-runs?page=5&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  {
+                    number: 6,
+                    visuallyHiddenText: 'Page 6',
+                    href: '/system/bill-runs?page=6&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  {
+                    number: 7,
+                    visuallyHiddenText: 'Page 7',
+                    href: '/system/bill-runs?page=7&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  }
+                ],
+                next: {
+                  href: '/system/bill-runs?page=5&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b'
+                },
+                previous: {
+                  href: '/system/bill-runs?page=3&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b'
+                }
+              }
+            })
+          })
+        })
+
+        describe('and the last page is selected', () => {
+          beforeEach(() => {
+            selectedPage = 7
+          })
+
+          it('returns <- Previous 1 2 3 4 5 6 [7]', () => {
+            const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path, queryArgs)
+
+            expect(result).equal({
+              numberOfPages: 7,
+              component: {
+                items: [
+                  { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: false },
+                  {
+                    number: 2,
+                    visuallyHiddenText: 'Page 2',
+                    href: '/system/bill-runs?page=2&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  {
+                    number: 3,
+                    visuallyHiddenText: 'Page 3',
+                    href: '/system/bill-runs?page=3&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  {
+                    number: 4,
+                    visuallyHiddenText: 'Page 4',
+                    href: '/system/bill-runs?page=4&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  {
+                    number: 5,
+                    visuallyHiddenText: 'Page 5',
+                    href: '/system/bill-runs?page=5&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  {
+                    number: 6,
+                    visuallyHiddenText: 'Page 6',
+                    href: '/system/bill-runs?page=6&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  {
+                    number: 7,
+                    visuallyHiddenText: 'Page 7',
+                    href: '/system/bill-runs?page=7&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: true
+                  }
+                ],
+                previous: {
+                  href: '/system/bill-runs?page=6&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b'
+                }
+              }
+            })
           })
         })
       })
 
-      describe('and page 5 is selected', () => {
+      describe('for 8 pages', () => {
         beforeEach(() => {
-          selectedPage = 5
+          numberOfRecords = 375
         })
 
-        it('returns <- Previous 1 .. 4 [5] 6 .. 9 Next ->', () => {
-          const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path)
+        describe('and the first page is selected', () => {
+          beforeEach(() => {
+            selectedPage = 1
+          })
 
-          expect(result).equal({
-            numberOfPages: 9,
-            component: {
-              items: [
-                { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: false },
-                { ellipsis: true },
-                { number: 4, visuallyHiddenText: 'Page 4', href: '/system/bill-runs?page=4', current: false },
-                { number: 5, visuallyHiddenText: 'Page 5', href: '/system/bill-runs?page=5', current: true },
-                { number: 6, visuallyHiddenText: 'Page 6', href: '/system/bill-runs?page=6', current: false },
-                { ellipsis: true },
-                { number: 9, visuallyHiddenText: 'Page 9', href: '/system/bill-runs?page=9', current: false }
-              ],
-              next: { href: '/system/bill-runs?page=6' },
-              previous: { href: '/system/bill-runs?page=4' }
-            }
+          it('returns [1] 2 3 4 5 .. 8 Next ->', () => {
+            const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path, queryArgs)
+
+            expect(result).equal({
+              numberOfPages: 8,
+              component: {
+                items: [
+                  { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: true },
+                  {
+                    number: 2,
+                    visuallyHiddenText: 'Page 2',
+                    href: '/system/bill-runs?page=2&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  {
+                    number: 3,
+                    visuallyHiddenText: 'Page 3',
+                    href: '/system/bill-runs?page=3&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  {
+                    number: 4,
+                    visuallyHiddenText: 'Page 4',
+                    href: '/system/bill-runs?page=4&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  {
+                    number: 5,
+                    visuallyHiddenText: 'Page 5',
+                    href: '/system/bill-runs?page=5&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  { ellipsis: true },
+                  {
+                    number: 8,
+                    visuallyHiddenText: 'Page 8',
+                    href: '/system/bill-runs?page=8&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  }
+                ],
+                next: {
+                  href: '/system/bill-runs?page=2&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b'
+                }
+              }
+            })
+          })
+        })
+
+        describe('and page 4 is selected', () => {
+          beforeEach(() => {
+            selectedPage = 4
+          })
+
+          it('returns <- Previous 1 2 3 [4] 5 .. 8 Next ->', () => {
+            const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path, queryArgs)
+
+            expect(result).equal({
+              numberOfPages: 8,
+              component: {
+                items: [
+                  { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: false },
+                  {
+                    number: 2,
+                    visuallyHiddenText: 'Page 2',
+                    href: '/system/bill-runs?page=2&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  {
+                    number: 3,
+                    visuallyHiddenText: 'Page 3',
+                    href: '/system/bill-runs?page=3&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  {
+                    number: 4,
+                    visuallyHiddenText: 'Page 4',
+                    href: '/system/bill-runs?page=4&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: true
+                  },
+                  {
+                    number: 5,
+                    visuallyHiddenText: 'Page 5',
+                    href: '/system/bill-runs?page=5&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  { ellipsis: true },
+                  {
+                    number: 8,
+                    visuallyHiddenText: 'Page 8',
+                    href: '/system/bill-runs?page=8&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  }
+                ],
+                next: {
+                  href: '/system/bill-runs?page=5&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b'
+                },
+                previous: {
+                  href: '/system/bill-runs?page=3&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b'
+                }
+              }
+            })
+          })
+        })
+
+        describe('and page 5 is selected', () => {
+          beforeEach(() => {
+            selectedPage = 5
+          })
+
+          it('returns <- Previous 1 .. 4 [5] 6 7 8 Next ->', () => {
+            const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path, queryArgs)
+
+            expect(result).equal({
+              numberOfPages: 8,
+              component: {
+                items: [
+                  { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: false },
+                  { ellipsis: true },
+                  {
+                    number: 4,
+                    visuallyHiddenText: 'Page 4',
+                    href: '/system/bill-runs?page=4&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  {
+                    number: 5,
+                    visuallyHiddenText: 'Page 5',
+                    href: '/system/bill-runs?page=5&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: true
+                  },
+                  {
+                    number: 6,
+                    visuallyHiddenText: 'Page 6',
+                    href: '/system/bill-runs?page=6&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  {
+                    number: 7,
+                    visuallyHiddenText: 'Page 7',
+                    href: '/system/bill-runs?page=7&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  {
+                    number: 8,
+                    visuallyHiddenText: 'Page 8',
+                    href: '/system/bill-runs?page=8&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  }
+                ],
+                next: {
+                  href: '/system/bill-runs?page=6&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b'
+                },
+                previous: {
+                  href: '/system/bill-runs?page=4&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b'
+                }
+              }
+            })
+          })
+        })
+
+        describe('and the last page is selected', () => {
+          beforeEach(() => {
+            selectedPage = 8
+          })
+
+          it('returns <- Previous 1 .. 4 5 6 7 [8]', () => {
+            const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path, queryArgs)
+
+            expect(result).equal({
+              numberOfPages: 8,
+              component: {
+                items: [
+                  { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: false },
+                  { ellipsis: true },
+                  {
+                    number: 4,
+                    visuallyHiddenText: 'Page 4',
+                    href: '/system/bill-runs?page=4&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  {
+                    number: 5,
+                    visuallyHiddenText: 'Page 5',
+                    href: '/system/bill-runs?page=5&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  {
+                    number: 6,
+                    visuallyHiddenText: 'Page 6',
+                    href: '/system/bill-runs?page=6&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  {
+                    number: 7,
+                    visuallyHiddenText: 'Page 7',
+                    href: '/system/bill-runs?page=7&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  {
+                    number: 8,
+                    visuallyHiddenText: 'Page 8',
+                    href: '/system/bill-runs?page=8&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: true
+                  }
+                ],
+                previous: {
+                  href: '/system/bill-runs?page=7&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b'
+                }
+              }
+            })
           })
         })
       })
 
-      describe('and page 6 is selected', () => {
+      describe('for 9 pages', () => {
         beforeEach(() => {
-          selectedPage = 6
+          numberOfRecords = 425
         })
 
-        it('returns <- Previous 1 .. 5 [6] 7 8 9 Next ->', () => {
-          const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path)
+        describe('and the first page is selected', () => {
+          beforeEach(() => {
+            selectedPage = 1
+          })
 
-          expect(result).equal({
-            numberOfPages: 9,
-            component: {
-              items: [
-                { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: false },
-                { ellipsis: true },
-                { number: 5, visuallyHiddenText: 'Page 5', href: '/system/bill-runs?page=5', current: false },
-                { number: 6, visuallyHiddenText: 'Page 6', href: '/system/bill-runs?page=6', current: true },
-                { number: 7, visuallyHiddenText: 'Page 7', href: '/system/bill-runs?page=7', current: false },
-                { number: 8, visuallyHiddenText: 'Page 8', href: '/system/bill-runs?page=8', current: false },
-                { number: 9, visuallyHiddenText: 'Page 9', href: '/system/bill-runs?page=9', current: false }
-              ],
-              next: { href: '/system/bill-runs?page=7' },
-              previous: { href: '/system/bill-runs?page=5' }
-            }
+          it('returns [1] 2 3 4 5 .. 9 Next ->', () => {
+            const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path, queryArgs)
+
+            expect(result).equal({
+              numberOfPages: 9,
+              component: {
+                items: [
+                  { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: true },
+                  {
+                    number: 2,
+                    visuallyHiddenText: 'Page 2',
+                    href: '/system/bill-runs?page=2&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  {
+                    number: 3,
+                    visuallyHiddenText: 'Page 3',
+                    href: '/system/bill-runs?page=3&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  {
+                    number: 4,
+                    visuallyHiddenText: 'Page 4',
+                    href: '/system/bill-runs?page=4&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  {
+                    number: 5,
+                    visuallyHiddenText: 'Page 5',
+                    href: '/system/bill-runs?page=5&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  { ellipsis: true },
+                  {
+                    number: 9,
+                    visuallyHiddenText: 'Page 9',
+                    href: '/system/bill-runs?page=9&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  }
+                ],
+                next: {
+                  href: '/system/bill-runs?page=2&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b'
+                }
+              }
+            })
+          })
+        })
+
+        describe('and page 4 is selected', () => {
+          beforeEach(() => {
+            selectedPage = 4
+          })
+
+          it('returns <- Previous 1 2 3 [4] 5 .. 9 Next ->', () => {
+            const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path, queryArgs)
+
+            expect(result).equal({
+              numberOfPages: 9,
+              component: {
+                items: [
+                  { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: false },
+                  {
+                    number: 2,
+                    visuallyHiddenText: 'Page 2',
+                    href: '/system/bill-runs?page=2&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  {
+                    number: 3,
+                    visuallyHiddenText: 'Page 3',
+                    href: '/system/bill-runs?page=3&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  {
+                    number: 4,
+                    visuallyHiddenText: 'Page 4',
+                    href: '/system/bill-runs?page=4&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: true
+                  },
+                  {
+                    number: 5,
+                    visuallyHiddenText: 'Page 5',
+                    href: '/system/bill-runs?page=5&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  { ellipsis: true },
+                  {
+                    number: 9,
+                    visuallyHiddenText: 'Page 9',
+                    href: '/system/bill-runs?page=9&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  }
+                ],
+                next: {
+                  href: '/system/bill-runs?page=5&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b'
+                },
+                previous: {
+                  href: '/system/bill-runs?page=3&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b'
+                }
+              }
+            })
+          })
+        })
+
+        describe('and page 5 is selected', () => {
+          beforeEach(() => {
+            selectedPage = 5
+          })
+
+          it('returns <- Previous 1 .. 4 [5] 6 .. 9 Next ->', () => {
+            const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path, queryArgs)
+
+            expect(result).equal({
+              numberOfPages: 9,
+              component: {
+                items: [
+                  { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: false },
+                  { ellipsis: true },
+                  {
+                    number: 4,
+                    visuallyHiddenText: 'Page 4',
+                    href: '/system/bill-runs?page=4&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  {
+                    number: 5,
+                    visuallyHiddenText: 'Page 5',
+                    href: '/system/bill-runs?page=5&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: true
+                  },
+                  {
+                    number: 6,
+                    visuallyHiddenText: 'Page 6',
+                    href: '/system/bill-runs?page=6&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  { ellipsis: true },
+                  {
+                    number: 9,
+                    visuallyHiddenText: 'Page 9',
+                    href: '/system/bill-runs?page=9&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  }
+                ],
+                next: {
+                  href: '/system/bill-runs?page=6&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b'
+                },
+                previous: {
+                  href: '/system/bill-runs?page=4&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b'
+                }
+              }
+            })
+          })
+        })
+
+        describe('and page 6 is selected', () => {
+          beforeEach(() => {
+            selectedPage = 6
+          })
+
+          it('returns <- Previous 1 .. 5 [6] 7 8 9 Next ->', () => {
+            const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path, queryArgs)
+
+            expect(result).equal({
+              numberOfPages: 9,
+              component: {
+                items: [
+                  { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: false },
+                  { ellipsis: true },
+                  {
+                    number: 5,
+                    visuallyHiddenText: 'Page 5',
+                    href: '/system/bill-runs?page=5&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  {
+                    number: 6,
+                    visuallyHiddenText: 'Page 6',
+                    href: '/system/bill-runs?page=6&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: true
+                  },
+                  {
+                    number: 7,
+                    visuallyHiddenText: 'Page 7',
+                    href: '/system/bill-runs?page=7&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  {
+                    number: 8,
+                    visuallyHiddenText: 'Page 8',
+                    href: '/system/bill-runs?page=8&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  {
+                    number: 9,
+                    visuallyHiddenText: 'Page 9',
+                    href: '/system/bill-runs?page=9&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  }
+                ],
+                next: {
+                  href: '/system/bill-runs?page=7&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b'
+                },
+                previous: {
+                  href: '/system/bill-runs?page=5&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b'
+                }
+              }
+            })
+          })
+        })
+
+        describe('and the last page is selected', () => {
+          beforeEach(() => {
+            selectedPage = 9
+          })
+
+          it('returns <- Previous 1 .. 5 6 7 8 [9]', () => {
+            const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path, queryArgs)
+
+            expect(result).equal({
+              numberOfPages: 9,
+              component: {
+                items: [
+                  { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: false },
+                  { ellipsis: true },
+                  {
+                    number: 5,
+                    visuallyHiddenText: 'Page 5',
+                    href: '/system/bill-runs?page=5&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  {
+                    number: 6,
+                    visuallyHiddenText: 'Page 6',
+                    href: '/system/bill-runs?page=6&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  {
+                    number: 7,
+                    visuallyHiddenText: 'Page 7',
+                    href: '/system/bill-runs?page=7&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  {
+                    number: 8,
+                    visuallyHiddenText: 'Page 8',
+                    href: '/system/bill-runs?page=8&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  {
+                    number: 9,
+                    visuallyHiddenText: 'Page 9',
+                    href: '/system/bill-runs?page=9&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: true
+                  }
+                ],
+                previous: {
+                  href: '/system/bill-runs?page=8&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b'
+                }
+              }
+            })
           })
         })
       })
 
-      describe('and the last page is selected', () => {
+      describe('for 100 pages', () => {
         beforeEach(() => {
-          selectedPage = 9
+          numberOfRecords = 4975
         })
 
-        it('returns <- Previous 1 .. 5 6 7 8 [9]', () => {
-          const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path)
+        describe('and the first page is selected', () => {
+          beforeEach(() => {
+            selectedPage = 1
+          })
 
-          expect(result).equal({
-            numberOfPages: 9,
-            component: {
-              items: [
-                { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: false },
-                { ellipsis: true },
-                { number: 5, visuallyHiddenText: 'Page 5', href: '/system/bill-runs?page=5', current: false },
-                { number: 6, visuallyHiddenText: 'Page 6', href: '/system/bill-runs?page=6', current: false },
-                { number: 7, visuallyHiddenText: 'Page 7', href: '/system/bill-runs?page=7', current: false },
-                { number: 8, visuallyHiddenText: 'Page 8', href: '/system/bill-runs?page=8', current: false },
-                { number: 9, visuallyHiddenText: 'Page 9', href: '/system/bill-runs?page=9', current: true }
-              ],
-              previous: { href: '/system/bill-runs?page=8' }
-            }
+          it('returns [1] 2 3 4 5 .. 100 Next ->', () => {
+            const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path, queryArgs)
+
+            expect(result).equal({
+              numberOfPages: 100,
+              component: {
+                items: [
+                  {
+                    number: 1,
+                    visuallyHiddenText: 'Page 1',
+                    href: '/system/bill-runs',
+                    current: true
+                  },
+                  {
+                    number: 2,
+                    visuallyHiddenText: 'Page 2',
+                    href: '/system/bill-runs?page=2&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  {
+                    number: 3,
+                    visuallyHiddenText: 'Page 3',
+                    href: '/system/bill-runs?page=3&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  {
+                    number: 4,
+                    visuallyHiddenText: 'Page 4',
+                    href: '/system/bill-runs?page=4&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  {
+                    number: 5,
+                    visuallyHiddenText: 'Page 5',
+                    href: '/system/bill-runs?page=5&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  { ellipsis: true },
+                  {
+                    number: 100,
+                    visuallyHiddenText: 'Page 100',
+                    href: '/system/bill-runs?page=100&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  }
+                ],
+                next: {
+                  href: '/system/bill-runs?page=2&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b'
+                }
+              }
+            })
           })
         })
-      })
-    })
 
-    describe('for 100 pages', () => {
-      beforeEach(() => {
-        numberOfRecords = 4975
-      })
+        describe('and page 4 is selected', () => {
+          beforeEach(() => {
+            selectedPage = 4
+          })
 
-      describe('and the first page is selected', () => {
-        beforeEach(() => {
-          selectedPage = 1
-        })
+          it('returns <- Previous 1 2 3 [4] 5 .. 100 Next ->', () => {
+            const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path, queryArgs)
 
-        it('returns [1] 2 3 4 5 .. 100 Next ->', () => {
-          const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path)
-
-          expect(result).equal({
-            numberOfPages: 100,
-            component: {
-              items: [
-                { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: true },
-                { number: 2, visuallyHiddenText: 'Page 2', href: '/system/bill-runs?page=2', current: false },
-                { number: 3, visuallyHiddenText: 'Page 3', href: '/system/bill-runs?page=3', current: false },
-                { number: 4, visuallyHiddenText: 'Page 4', href: '/system/bill-runs?page=4', current: false },
-                { number: 5, visuallyHiddenText: 'Page 5', href: '/system/bill-runs?page=5', current: false },
-                { ellipsis: true },
-                { number: 100, visuallyHiddenText: 'Page 100', href: '/system/bill-runs?page=100', current: false }
-              ],
-              next: { href: '/system/bill-runs?page=2' }
-            }
+            expect(result).equal({
+              numberOfPages: 100,
+              component: {
+                items: [
+                  {
+                    number: 1,
+                    visuallyHiddenText: 'Page 1',
+                    href: '/system/bill-runs',
+                    current: false
+                  },
+                  {
+                    number: 2,
+                    visuallyHiddenText: 'Page 2',
+                    href: '/system/bill-runs?page=2&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  {
+                    number: 3,
+                    visuallyHiddenText: 'Page 3',
+                    href: '/system/bill-runs?page=3&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  {
+                    number: 4,
+                    visuallyHiddenText: 'Page 4',
+                    href: '/system/bill-runs?page=4&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: true
+                  },
+                  {
+                    number: 5,
+                    visuallyHiddenText: 'Page 5',
+                    href: '/system/bill-runs?page=5&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  { ellipsis: true },
+                  {
+                    number: 100,
+                    visuallyHiddenText: 'Page 100',
+                    href: '/system/bill-runs?page=100&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  }
+                ],
+                next: {
+                  href: '/system/bill-runs?page=5&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b'
+                },
+                previous: {
+                  href: '/system/bill-runs?page=3&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b'
+                }
+              }
+            })
           })
         })
-      })
 
-      describe('and page 4 is selected', () => {
-        beforeEach(() => {
-          selectedPage = 4
-        })
+        describe('and page 49 is selected', () => {
+          beforeEach(() => {
+            selectedPage = 49
+          })
 
-        it('returns <- Previous 1 2 3 [4] 5 .. 100 Next ->', () => {
-          const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path)
+          it('returns <- Previous 1 .. 48 [49] 50 .. 100 Next ->', () => {
+            const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path, queryArgs)
 
-          expect(result).equal({
-            numberOfPages: 100,
-            component: {
-              items: [
-                { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: false },
-                { number: 2, visuallyHiddenText: 'Page 2', href: '/system/bill-runs?page=2', current: false },
-                { number: 3, visuallyHiddenText: 'Page 3', href: '/system/bill-runs?page=3', current: false },
-                { number: 4, visuallyHiddenText: 'Page 4', href: '/system/bill-runs?page=4', current: true },
-                { number: 5, visuallyHiddenText: 'Page 5', href: '/system/bill-runs?page=5', current: false },
-                { ellipsis: true },
-                { number: 100, visuallyHiddenText: 'Page 100', href: '/system/bill-runs?page=100', current: false }
-              ],
-              next: { href: '/system/bill-runs?page=5' },
-              previous: { href: '/system/bill-runs?page=3' }
-            }
+            expect(result).equal({
+              numberOfPages: 100,
+              component: {
+                items: [
+                  {
+                    number: 1,
+                    visuallyHiddenText: 'Page 1',
+                    href: '/system/bill-runs',
+                    current: false
+                  },
+                  { ellipsis: true },
+                  {
+                    number: 48,
+                    visuallyHiddenText: 'Page 48',
+                    href: '/system/bill-runs?page=48&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  {
+                    number: 49,
+                    visuallyHiddenText: 'Page 49',
+                    href: '/system/bill-runs?page=49&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: true
+                  },
+                  {
+                    number: 50,
+                    visuallyHiddenText: 'Page 50',
+                    href: '/system/bill-runs?page=50&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  { ellipsis: true },
+                  {
+                    number: 100,
+                    visuallyHiddenText: 'Page 100',
+                    href: '/system/bill-runs?page=100&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  }
+                ],
+                next: {
+                  href: '/system/bill-runs?page=50&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b'
+                },
+                previous: {
+                  href: '/system/bill-runs?page=48&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b'
+                }
+              }
+            })
           })
         })
-      })
 
-      describe('and page 49 is selected', () => {
-        beforeEach(() => {
-          selectedPage = 49
-        })
+        describe('and page 97 is selected', () => {
+          beforeEach(() => {
+            selectedPage = 97
+          })
 
-        it('returns <- Previous 1 .. 48 [49] 50 .. 100 Next ->', () => {
-          const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path)
+          it('returns <- Previous 1 .. 96 [97] 98 99 100 Next ->', () => {
+            const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path, queryArgs)
 
-          expect(result).equal({
-            numberOfPages: 100,
-            component: {
-              items: [
-                { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: false },
-                { ellipsis: true },
-                { number: 48, visuallyHiddenText: 'Page 48', href: '/system/bill-runs?page=48', current: false },
-                { number: 49, visuallyHiddenText: 'Page 49', href: '/system/bill-runs?page=49', current: true },
-                { number: 50, visuallyHiddenText: 'Page 50', href: '/system/bill-runs?page=50', current: false },
-                { ellipsis: true },
-                { number: 100, visuallyHiddenText: 'Page 100', href: '/system/bill-runs?page=100', current: false }
-              ],
-              next: { href: '/system/bill-runs?page=50' },
-              previous: { href: '/system/bill-runs?page=48' }
-            }
+            expect(result).equal({
+              numberOfPages: 100,
+              component: {
+                items: [
+                  {
+                    number: 1,
+                    visuallyHiddenText: 'Page 1',
+                    href: '/system/bill-runs',
+                    current: false
+                  },
+                  { ellipsis: true },
+                  {
+                    number: 96,
+                    visuallyHiddenText: 'Page 96',
+                    href: '/system/bill-runs?page=96&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  {
+                    number: 97,
+                    visuallyHiddenText: 'Page 97',
+                    href: '/system/bill-runs?page=97&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: true
+                  },
+                  {
+                    number: 98,
+                    visuallyHiddenText: 'Page 98',
+                    href: '/system/bill-runs?page=98&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  {
+                    number: 99,
+                    visuallyHiddenText: 'Page 99',
+                    href: '/system/bill-runs?page=99&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  {
+                    number: 100,
+                    visuallyHiddenText: 'Page 100',
+                    href: '/system/bill-runs?page=100&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  }
+                ],
+                next: {
+                  href: '/system/bill-runs?page=98&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b'
+                },
+                previous: {
+                  href: '/system/bill-runs?page=96&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b'
+                }
+              }
+            })
           })
         })
-      })
 
-      describe('and page 97 is selected', () => {
-        beforeEach(() => {
-          selectedPage = 97
-        })
-
-        it('returns <- Previous 1 .. 96 [97] 98 99 100 Next ->', () => {
-          const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path)
-
-          expect(result).equal({
-            numberOfPages: 100,
-            component: {
-              items: [
-                { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: false },
-                { ellipsis: true },
-                { number: 96, visuallyHiddenText: 'Page 96', href: '/system/bill-runs?page=96', current: false },
-                { number: 97, visuallyHiddenText: 'Page 97', href: '/system/bill-runs?page=97', current: true },
-                { number: 98, visuallyHiddenText: 'Page 98', href: '/system/bill-runs?page=98', current: false },
-                { number: 99, visuallyHiddenText: 'Page 99', href: '/system/bill-runs?page=99', current: false },
-                { number: 100, visuallyHiddenText: 'Page 100', href: '/system/bill-runs?page=100', current: false }
-              ],
-              next: { href: '/system/bill-runs?page=98' },
-              previous: { href: '/system/bill-runs?page=96' }
-            }
+        describe('and the last page is selected', () => {
+          beforeEach(() => {
+            selectedPage = 100
           })
-        })
-      })
 
-      describe('and the last page is selected', () => {
-        beforeEach(() => {
-          selectedPage = 100
-        })
+          it('returns <- Previous 1 .. 96 97 98 99 [100]', () => {
+            const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path, queryArgs)
 
-        it('returns <- Previous 1 .. 96 97 98 99 [100]', () => {
-          const result = PaginatorPresenter.go(numberOfRecords, selectedPage, path)
-
-          expect(result).equal({
-            numberOfPages: 100,
-            component: {
-              items: [
-                { number: 1, visuallyHiddenText: 'Page 1', href: '/system/bill-runs', current: false },
-                { ellipsis: true },
-                { number: 96, visuallyHiddenText: 'Page 96', href: '/system/bill-runs?page=96', current: false },
-                { number: 97, visuallyHiddenText: 'Page 97', href: '/system/bill-runs?page=97', current: false },
-                { number: 98, visuallyHiddenText: 'Page 98', href: '/system/bill-runs?page=98', current: false },
-                { number: 99, visuallyHiddenText: 'Page 99', href: '/system/bill-runs?page=99', current: false },
-                { number: 100, visuallyHiddenText: 'Page 100', href: '/system/bill-runs?page=100', current: true }
-              ],
-              previous: { href: '/system/bill-runs?page=99' }
-            }
+            expect(result).equal({
+              numberOfPages: 100,
+              component: {
+                items: [
+                  {
+                    number: 1,
+                    visuallyHiddenText: 'Page 1',
+                    href: '/system/bill-runs',
+                    current: false
+                  },
+                  { ellipsis: true },
+                  {
+                    number: 96,
+                    visuallyHiddenText: 'Page 96',
+                    href: '/system/bill-runs?page=96&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  {
+                    number: 97,
+                    visuallyHiddenText: 'Page 97',
+                    href: '/system/bill-runs?page=97&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  {
+                    number: 98,
+                    visuallyHiddenText: 'Page 98',
+                    href: '/system/bill-runs?page=98&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  {
+                    number: 99,
+                    visuallyHiddenText: 'Page 99',
+                    href: '/system/bill-runs?page=99&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: false
+                  },
+                  {
+                    number: 100,
+                    visuallyHiddenText: 'Page 100',
+                    href: '/system/bill-runs?page=100&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b',
+                    current: true
+                  }
+                ],
+                previous: {
+                  href: '/system/bill-runs?page=99&billing-account-id=c17c0a2b-6950-490b-8c3a-4dc9f01da368&licence-id=354fc0bd-0820-4611-a6af-874480bbae3b'
+                }
+              }
+            })
           })
         })
       })


### PR DESCRIPTION
While [migrating the view billing account page](https://github.com/DEFRA/water-abstraction-system/pull/1883), we encountered issues integrating pagination alongside the existing query parameter for licenceId. This led to inconsistent behaviour when navigating between pages of bills. To resolve this, we've updated the pagination presenter to correctly handle existing query arguments, ensuring more reliable pagination now and improving compatibility with future pages that may also include query parameters.

This PR updates the pagination presenter to handle existing query arguments.