### PR TITLE
Update notices batch notifications to use whole session

### DIFF
--- a/app/services/notices/setup/batch-notifications.service.js
+++ b/app/services/notices/setup/batch-notifications.service.js
@@ -30,13 +30,11 @@ const NotifyConfig = require('../../../../config/notify.config.js')
  * rate limit).
  *
  * @param {object[]} recipients
- * @param {object} determinedReturnsPeriod
- * @param {string} referenceCode
- * @param {string} journey
+ * @param {SessionModel} session - The session instance
  * @param {string} eventId - the event id to link all the notifications to an event
  *
  */
-async function go(recipients, determinedReturnsPeriod, referenceCode, journey, eventId) {
+async function go(recipients, session, eventId) {
   const { batchSize, delay } = NotifyConfig
 
   let error = 0
@@ -44,7 +42,7 @@ async function go(recipients, determinedReturnsPeriod, referenceCode, journey, e
   for (let i = 0; i < recipients.length; i += batchSize) {
     const batchRecipients = recipients.slice(i, i + batchSize)
 
-    const batch = await _batch(batchRecipients, determinedReturnsPeriod, referenceCode, journey, eventId)
+    const batch = await _batch(batchRecipients, session, eventId)
 
     await _delay(delay)
 
@@ -54,7 +52,9 @@ async function go(recipients, determinedReturnsPeriod, referenceCode, journey, e
   await UpdateEventService.go(eventId, error)
 }
 
-async function _batch(recipients, determinedReturnsPeriod, referenceCode, journey, eventId) {
+async function _batch(recipients, session, eventId) {
+  const { determinedReturnsPeriod, referenceCode, journey } = session
+
   const notifications = NotificationsPresenter.go(recipients, determinedReturnsPeriod, referenceCode, journey, eventId)
 
   const toSendNotifications = _toSendNotifications(notifications)

--- a/app/services/notices/setup/submit-check.service.js
+++ b/app/services/notices/setup/submit-check.service.js
@@ -30,11 +30,11 @@ async function go(sessionId, auth) {
 
   const notice = await _notice(session, recipients, auth)
 
-  const { determinedReturnsPeriod, referenceCode, journey } = session
+  const sessionCopy = session
 
   await session.$query().delete()
 
-  _processNotifications(determinedReturnsPeriod, referenceCode, journey, recipients, notice)
+  _processNotifications(sessionCopy, recipients, notice)
 
   return notice.id
 }
@@ -45,11 +45,11 @@ async function _notice(session, recipients, auth) {
   return CreateNoticeService.go(event)
 }
 
-async function _processNotifications(determinedReturnsPeriod, referenceCode, journey, recipients, notice) {
+async function _processNotifications(session, recipients, notice) {
   try {
     const startTime = currentTimeInNanoseconds()
 
-    await BatchNotificationsService.go(recipients, determinedReturnsPeriod, referenceCode, journey, notice.id)
+    await BatchNotificationsService.go(recipients, session, notice.id)
 
     calculateAndLogTimeTaken(startTime, 'Send notifications complete', {})
   } catch (error) {

--- a/test/services/notices/setup/submit-check.service.test.js
+++ b/test/services/notices/setup/submit-check.service.test.js
@@ -84,11 +84,22 @@ describe('Notices - Setup - Submit Check service', () => {
     const result = await SubmitCheckService.go(session.id, auth)
 
     expect(
-      BatchNotificationsService.go.calledWith(
+      BatchNotificationsService.go.calledWithMatch(
         testRecipients,
-        session.data.determinedReturnsPeriod,
-        referenceCode,
-        session.data.journey,
+        Sinon.match({
+          id: session.id,
+          data: session.data,
+          journey: 'invitations',
+          referenceCode,
+          returnsPeriod: 'quarterFour',
+          determinedReturnsPeriod: {
+            name: 'allYear',
+            dueDate: '2025-04-28',
+            endDate: '2023-03-31',
+            summer: 'false',
+            startDate: '2022-04-01'
+          }
+        }),
         result
       )
     ).to.be.true()


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5067

We previously implemented the notices journey based on the use of return periods, with the intention of adding abstraction alerts later down the line.

That time has come and we need to adjust some of the existing structures in place to allow us reuse alot of the complex logic.

To do this we will be using the session.journey to trigger any alternative logic to the returns periods.

This means passing the session object around rather than the previous attempt of restricting the session to the submit service.

When we send an abstraction alert we will need to add the threshold to the Notify payload. To simplify the setting of returns / alerts as args we will just pass the session.

This change is part of a series of changes to introduce the abstraction alerts into the notices flow.