### PR TITLE
Add notices determines relevant licence monitoring stations

### DIFF
--- a/app/presenters/notices/setup/abstraction-alerts/check-licence-matches.presenter.js
+++ b/app/presenters/notices/setup/abstraction-alerts/check-licence-matches.presenter.js
@@ -5,6 +5,7 @@
  * @module CheckLicenceMatchesPresenter
  */
 
+const DetermineRelevantLicenceMonitoringStationsService = require('../../../../services/notices/setup/abstraction-alerts/determine-relevant-licence-monitoring-stations.service.js')
 const { determineRestrictionHeading, formatRestrictions } = require('../../../monitoring-stations/base.presenter.js')
 
 /**
@@ -40,22 +41,8 @@ function _action(sessionId, licenceMonitoringStation) {
   }
 }
 
-function _relevantLicenceMonitoringStations(licenceMonitoringStations, alertThresholds, removedThresholds) {
-  const relevantLicenceMonitoringStations = licenceMonitoringStations.filter((licenceMonitoringStation) => {
-    return alertThresholds.includes(licenceMonitoringStation.thresholdGroup)
-  })
-
-  if (removedThresholds) {
-    return relevantLicenceMonitoringStations.filter((licenceMonitoringStation) => {
-      return !removedThresholds.includes(licenceMonitoringStation.id)
-    })
-  }
-
-  return relevantLicenceMonitoringStations
-}
-
 function _restrictions(licenceMonitoringStations, alertThresholds, removedThresholds, sessionId) {
-  const relevantLicenceMonitoringStations = _relevantLicenceMonitoringStations(
+  const relevantLicenceMonitoringStations = DetermineRelevantLicenceMonitoringStationsService.go(
     licenceMonitoringStations,
     alertThresholds,
     removedThresholds

--- a/app/services/notices/setup/abstraction-alerts/determine-relevant-licence-monitoring-stations.service.js
+++ b/app/services/notices/setup/abstraction-alerts/determine-relevant-licence-monitoring-stations.service.js
@@ -1,0 +1,43 @@
+'use strict'
+
+/**
+ * Determines relevant licence monitoring stations for the `abstraction-alerts` journey
+ *
+ * @module DetermineRelevantLicenceMonitoringStationsService
+ */
+
+/**
+ * Determines relevant licence monitoring stations for the `abstraction-alerts` journey
+ *
+ * When building the `abstraction-alerts` journey there is a starting array of 'licenceMonitoringStations'. The user
+ * must select at least one 'licenceMonitoringStation' in order to progress the journey. So the
+ * 'selectedLicenceMonitoringStations' will always have a length > 0.
+ *
+ * A user can remove 'licenceMonitoringStations' for a licence. When this happens we need to return the
+ * 'licenceMonitoringStations' with those choices removed.
+ *
+ * We keep the original array intact.
+ *
+ * @param {Array<object>} licenceMonitoringStations
+ * @param {Array<string>} selectedLicenceMonitoringStations
+ * @param {Array<string>} removedLicenceMonitoringStations
+ *
+ * @returns {Array<object>}
+ */
+function go(licenceMonitoringStations, selectedLicenceMonitoringStations, removedLicenceMonitoringStations) {
+  const relevantLicenceMonitoringStations = licenceMonitoringStations.filter((licenceMonitoringStation) => {
+    return selectedLicenceMonitoringStations.includes(licenceMonitoringStation.thresholdGroup)
+  })
+
+  if (removedLicenceMonitoringStations) {
+    return relevantLicenceMonitoringStations.filter((licenceMonitoringStation) => {
+      return !removedLicenceMonitoringStations.includes(licenceMonitoringStation.id)
+    })
+  }
+
+  return relevantLicenceMonitoringStations
+}
+
+module.exports = {
+  go
+}

--- a/app/services/notices/setup/abstraction-alerts/submit-check-licence-matches.service.js
+++ b/app/services/notices/setup/abstraction-alerts/submit-check-licence-matches.service.js
@@ -6,9 +6,8 @@
  * @module SubmitCheckLicenceMatchesService
  */
 
-const CheckLicenceMatchesPresenter = require('../../../../presenters/notices/setup/abstraction-alerts/check-licence-matches.presenter.js')
-const SessionModel = require('../../../../models/session.model.js')
 const DetermineRelevantLicenceMonitoringStationsService = require('./determine-relevant-licence-monitoring-stations.service.js')
+const SessionModel = require('../../../../models/session.model.js')
 
 /**
  * Orchestrates saving the data for the `/notices/setup/{sessionId}/abstraction-alerts/check-licence-matches` page
@@ -19,9 +18,7 @@ const DetermineRelevantLicenceMonitoringStationsService = require('./determine-r
 async function go(sessionId) {
   const session = await SessionModel.query().findById(sessionId)
 
-  const pageData = CheckLicenceMatchesPresenter.go(session)
-
-  await _save(session, pageData)
+  await _save(session)
 }
 
 async function _save(session) {

--- a/app/services/notices/setup/abstraction-alerts/submit-check-licence-matches.service.js
+++ b/app/services/notices/setup/abstraction-alerts/submit-check-licence-matches.service.js
@@ -8,6 +8,7 @@
 
 const CheckLicenceMatchesPresenter = require('../../../../presenters/notices/setup/abstraction-alerts/check-licence-matches.presenter.js')
 const SessionModel = require('../../../../models/session.model.js')
+const DetermineRelevantLicenceMonitoringStationsService = require('./determine-relevant-licence-monitoring-stations.service.js')
 
 /**
  * Orchestrates saving the data for the `/notices/setup/{sessionId}/abstraction-alerts/check-licence-matches` page
@@ -23,12 +24,21 @@ async function go(sessionId) {
   await _save(session, pageData)
 }
 
-async function _save(session, pageData) {
-  const relevantLicenceRefs = pageData.restrictions.map((restriction) => {
-    return restriction.licenceRef
+async function _save(session) {
+  const { alertThresholds, licenceMonitoringStations, removedThresholds } = session
+
+  const relevantLicenceMonitoringStations = DetermineRelevantLicenceMonitoringStationsService.go(
+    licenceMonitoringStations,
+    alertThresholds,
+    removedThresholds
+  )
+
+  const relevantLicenceRefs = relevantLicenceMonitoringStations.map((station) => {
+    return station.licence.licenceRef
   })
 
   session.licenceRefs = Array.from(new Set(relevantLicenceRefs))
+  session.relevantLicenceMonitoringStations = relevantLicenceMonitoringStations
 
   return session.$update()
 }

--- a/test/services/notices/setup/abstraction-alerts/determine-relevant-licence-monitoring-stations.service.test.js
+++ b/test/services/notices/setup/abstraction-alerts/determine-relevant-licence-monitoring-stations.service.test.js
@@ -1,0 +1,82 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Test helpers
+const AbstractionAlertSessionData = require('../../../../fixtures/abstraction-alert-session-data.fixture.js')
+
+// Thing under test
+const DetermineRelevantLicenceMonitoringStationsService = require('../../../../../app/services/notices/setup/abstraction-alerts/determine-relevant-licence-monitoring-stations.service.js')
+
+describe('Notices Setup - Abstraction Alerts - Determine relevant licence monitoring stations service', () => {
+  let licenceMonitoringStationOne
+  let licenceMonitoringStationThree
+  let licenceMonitoringStationTwo
+  let licenceMonitoringStations
+  let removedLicenceMonitoringStations
+  let selectedLicenceMonitoringStations
+
+  beforeEach(async () => {
+    const abstractionAlertSessionData = AbstractionAlertSessionData.monitoringStation()
+
+    licenceMonitoringStations = abstractionAlertSessionData.licenceMonitoringStations
+
+    licenceMonitoringStationOne = licenceMonitoringStations[0]
+    licenceMonitoringStationTwo = licenceMonitoringStations[1]
+    licenceMonitoringStationThree = licenceMonitoringStations[2]
+
+    selectedLicenceMonitoringStations = [
+      licenceMonitoringStationOne.thresholdGroup,
+      licenceMonitoringStationTwo.thresholdGroup,
+      licenceMonitoringStationThree.thresholdGroup
+    ]
+  })
+
+  it('returns the licence monitoring stations', () => {
+    const result = DetermineRelevantLicenceMonitoringStationsService.go(
+      licenceMonitoringStations,
+      selectedLicenceMonitoringStations,
+      removedLicenceMonitoringStations
+    )
+
+    expect(result).to.equal([licenceMonitoringStationOne, licenceMonitoringStationTwo, licenceMonitoringStationThree])
+  })
+
+  describe('when there are "selectedLicenceMonitoringStations"', () => {
+    beforeEach(() => {
+      selectedLicenceMonitoringStations = [licenceMonitoringStationOne.thresholdGroup]
+    })
+    it('returns only the lLicence monitoring stations previously selected', () => {
+      const result = DetermineRelevantLicenceMonitoringStationsService.go(
+        licenceMonitoringStations,
+        selectedLicenceMonitoringStations,
+        removedLicenceMonitoringStations
+      )
+
+      expect(result).to.equal([licenceMonitoringStationOne])
+    })
+  })
+
+  describe('when there are "removedLicenceMonitoringStations"', () => {
+    beforeEach(() => {
+      removedLicenceMonitoringStations = [licenceMonitoringStationOne.id]
+    })
+
+    it('returns only the licence monitoring stations previously selected and not removed', () => {
+      const result = DetermineRelevantLicenceMonitoringStationsService.go(
+        licenceMonitoringStations,
+        selectedLicenceMonitoringStations,
+        removedLicenceMonitoringStations
+      )
+
+      expect(result.length).to.equal(2)
+
+      expect(result).to.equal([licenceMonitoringStationTwo, licenceMonitoringStationThree])
+    })
+  })
+})

--- a/test/services/notices/setup/abstraction-alerts/submit-check-licence-matches.service.test.js
+++ b/test/services/notices/setup/abstraction-alerts/submit-check-licence-matches.service.test.js
@@ -15,77 +15,113 @@ const SessionHelper = require('../../../../support/helpers/session.helper.js')
 const SubmitCheckLicenceMatchesService = require('../../../../../app/services/notices/setup/abstraction-alerts/submit-check-licence-matches.service.js')
 
 describe('Notices Setup - Abstraction Alerts - Submit Check Licence Matches Service', () => {
-  let alertThresholdGroupOne
-  let alertThresholdGroupThree
-  let alertThresholdGroupTwo
+  let licenceMonitoringStationDuplicate
+  let licenceMonitoringStationOne
+  let licenceMonitoringStationThree
+  let licenceMonitoringStationTwo
   let session
   let sessionData
 
   beforeEach(async () => {
     const abstractionAlertSessionData = AbstractionAlertSessionData.monitoringStation()
 
-    alertThresholdGroupOne = abstractionAlertSessionData.licenceMonitoringStations[0]
-    alertThresholdGroupTwo = abstractionAlertSessionData.licenceMonitoringStations[1]
-    alertThresholdGroupThree = abstractionAlertSessionData.licenceMonitoringStations[2]
+    licenceMonitoringStationOne = abstractionAlertSessionData.licenceMonitoringStations[0]
+    licenceMonitoringStationTwo = abstractionAlertSessionData.licenceMonitoringStations[1]
+    licenceMonitoringStationThree = abstractionAlertSessionData.licenceMonitoringStations[2]
+
+    // A licence monitoring station can have the same licence as another. When this is the case we need to check we
+    // handle duplicate licence refs and that we do no strip / remove them unexpectedly
+    licenceMonitoringStationDuplicate = licenceMonitoringStationOne
 
     sessionData = {
       ...abstractionAlertSessionData,
       alertThresholds: [
-        alertThresholdGroupOne.thresholdGroup,
-        alertThresholdGroupTwo.thresholdGroup,
-        alertThresholdGroupThree.thresholdGroup
+        licenceMonitoringStationOne.thresholdGroup,
+        licenceMonitoringStationTwo.thresholdGroup,
+        licenceMonitoringStationThree.thresholdGroup
       ]
     }
   })
 
   describe('when called', () => {
-    describe('and there are no thresholds removed', () => {
+    describe('and there are no licence monitoring stations removed', () => {
       beforeEach(async () => {
         session = await SessionHelper.add({ data: sessionData })
       })
 
-      it('saves the submitted value', async () => {
+      it('saves the "licenceRefs" to the session', async () => {
         await SubmitCheckLicenceMatchesService.go(session.id)
 
         const refreshedSession = await session.$query()
 
         expect(refreshedSession.licenceRefs).to.equal([
-          alertThresholdGroupOne.licence.licenceRef,
-          alertThresholdGroupTwo.licence.licenceRef,
-          alertThresholdGroupThree.licence.licenceRef
+          licenceMonitoringStationOne.licence.licenceRef,
+          licenceMonitoringStationTwo.licence.licenceRef,
+          licenceMonitoringStationThree.licence.licenceRef
+        ])
+      })
+
+      it('saves the "relevantLicenceMonitoringStations" to the session', async () => {
+        await SubmitCheckLicenceMatchesService.go(session.id)
+
+        const refreshedSession = await session.$query()
+
+        expect(refreshedSession.relevantLicenceMonitoringStations).to.equal([
+          licenceMonitoringStationOne,
+          licenceMonitoringStationTwo,
+          licenceMonitoringStationThree
         ])
       })
     })
 
     describe('and there are duplicate licence refs', () => {
       beforeEach(async () => {
-        sessionData.licenceMonitoringStations = [alertThresholdGroupOne, alertThresholdGroupOne]
+        sessionData.licenceMonitoringStations = [licenceMonitoringStationOne, licenceMonitoringStationDuplicate]
 
         session = await SessionHelper.add({ data: sessionData })
       })
 
-      it('saves the submitted value with duplicates removed', async () => {
+      it('saves the "licenceRefs" to the session with duplicates removed', async () => {
         await SubmitCheckLicenceMatchesService.go(session.id)
 
         const refreshedSession = await session.$query()
 
-        expect(refreshedSession.licenceRefs).to.equal([alertThresholdGroupOne.licence.licenceRef])
+        expect(refreshedSession.licenceRefs).to.equal([licenceMonitoringStationOne.licence.licenceRef])
+      })
+
+      it('saves the "relevantLicenceMonitoringStations" to the session', async () => {
+        await SubmitCheckLicenceMatchesService.go(session.id)
+
+        const refreshedSession = await session.$query()
+
+        expect(refreshedSession.relevantLicenceMonitoringStations).to.equal([
+          licenceMonitoringStationOne,
+          licenceMonitoringStationDuplicate
+        ])
       })
     })
 
-    describe('and there are thresholds removed', () => {
+    describe('and there are no licence monitoring stations removed', () => {
       beforeEach(async () => {
-        sessionData.removedThresholds = [alertThresholdGroupOne.id, alertThresholdGroupTwo.id]
+        sessionData.removedThresholds = [licenceMonitoringStationOne.id, licenceMonitoringStationTwo.id]
 
         session = await SessionHelper.add({ data: sessionData })
       })
 
-      it('saves the submitted value, without the removed thresholds', async () => {
+      it('saves the "licenceRefs" to the session without the removed thresholds', async () => {
         await SubmitCheckLicenceMatchesService.go(session.id)
 
         const refreshedSession = await session.$query()
 
-        expect(refreshedSession.licenceRefs).to.equal([alertThresholdGroupThree.licence.licenceRef])
+        expect(refreshedSession.licenceRefs).to.equal([licenceMonitoringStationThree.licence.licenceRef])
+      })
+
+      it('saves the "relevantLicenceMonitoringStations" to the session', async () => {
+        await SubmitCheckLicenceMatchesService.go(session.id)
+
+        const refreshedSession = await session.$query()
+
+        expect(refreshedSession.relevantLicenceMonitoringStations).to.equal([licenceMonitoringStationThree])
       })
     })
   })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5067

We previously added functionality to save the licence refs to the session in the 'SubmitCheckLicenceMatchesService'. This was to make the code simpler on the recipients part of the journey.

We have found another use case of adding the 'relevant' licence monitoring stations to the session.

This change adds a new session object 'relevantLicenceMonitoringStations' to the session for the 'abstraction-alert' journey. This will be used by the recipient to send notifications to the stations recipients.

As this has complex functionality and needed in two places it has been added / tested as its own service.

A few tweaks to the wording has been made to better align with what it is actually doing. They are not thresholds but licence monitoring stations.