### PR TITLE
Add contact to view billing account page

### DIFF
--- a/app/presenters/billing-account/view-billing-account.presenter.js
+++ b/app/presenters/billing-account/view-billing-account.presenter.js
@@ -101,7 +101,9 @@ function _bills(bills) {
 }
 
 function _contact(contact) {
-  if (!contact) return null
+  if (!contact) {
+    return null
+  }
 
   if (contact.contactType === 'person') {
     return `FAO ${titleCase(contact.firstName)} ${titleCase(contact.lastName)}`

--- a/app/presenters/billing-account/view-billing-account.presenter.js
+++ b/app/presenters/billing-account/view-billing-account.presenter.js
@@ -49,7 +49,7 @@ function go(billingAccountData, licenceId) {
  * @returns {string[]} An array of formatted address lines for display.
  */
 function _address(address, contact, company) {
-  const contactName = contact ? `FAO ${titleCase(contact.$name())}` : null
+  const contactName = contact ? `FAO ${contact.$name()}` : null
   const companyName = titleCase(company.name)
 
   const addressLines = [

--- a/app/presenters/billing-account/view-billing-account.presenter.js
+++ b/app/presenters/billing-account/view-billing-account.presenter.js
@@ -43,7 +43,7 @@ function go(billingAccountData, licenceId) {
  * out any empty address lines, applies title casing to each one, and appends the postcode in uppercase.
  *
  * @param {module:AddressModel} address - The address associated with the billing account.
- * @param {module:AddressModel} contact - The contact associated with the billing account.
+ * @param {module:ContactModel} contact - The contact associated with the billing account.
  * @param {module:CompanyModel} company - The company associated with the billing account.
  *
  * @returns {string[]} An array of formatted address lines for display.

--- a/app/presenters/billing-account/view-billing-account.presenter.js
+++ b/app/presenters/billing-account/view-billing-account.presenter.js
@@ -49,7 +49,7 @@ function go(billingAccountData, licenceId) {
  * @returns {string[]} An array of formatted address lines for display.
  */
 function _address(address, contact, company) {
-  const companyContact = _contact(contact)
+  const contactName = `FAO ${contact.$name()}`
   const companyName = titleCase(company.name)
 
   const addressLines = [
@@ -67,7 +67,7 @@ function _address(address, contact, company) {
     addressLines.push(address['postcode'].toUpperCase())
   }
 
-  return [companyName, companyContact, ...addressLines].filter(Boolean)
+  return [companyName, contactName, ...addressLines].filter(Boolean)
 }
 
 function _backLink(licenceId) {
@@ -98,22 +98,6 @@ function _bills(bills) {
       financialYear: bill.financialYearEnding
     }
   })
-}
-
-function _contact(contact) {
-  if (!contact) {
-    return null
-  }
-
-  if (contact.contactType === 'person') {
-    return `FAO ${titleCase(contact.firstName)} ${titleCase(contact.lastName)}`
-  }
-
-  if (contact.contactType === 'department') {
-    return `FAO ${titleCase(contact.department)}`
-  }
-
-  return null
 }
 
 module.exports = {

--- a/app/presenters/billing-account/view-billing-account.presenter.js
+++ b/app/presenters/billing-account/view-billing-account.presenter.js
@@ -49,7 +49,7 @@ function go(billingAccountData, licenceId) {
  * @returns {string[]} An array of formatted address lines for display.
  */
 function _address(address, contact, company) {
-  const contactName = `FAO ${contact.$name()}`
+  const contactName = contact ? `FAO ${titleCase(contact.$name())}` : null
   const companyName = titleCase(company.name)
 
   const addressLines = [

--- a/app/presenters/billing-account/view-billing-account.presenter.js
+++ b/app/presenters/billing-account/view-billing-account.presenter.js
@@ -24,7 +24,7 @@ function go(billingAccountData, licenceId) {
 
   return {
     accountNumber: billingAccount.accountNumber,
-    address: _address(billingAccountAddresses[0].address, company),
+    address: _address(billingAccountAddresses[0].address, billingAccountAddresses[0].contact, company),
     backLink: _backLink(licenceId),
     billingAccountId: id,
     bills: _bills(bills),
@@ -43,13 +43,16 @@ function go(billingAccountData, licenceId) {
  * out any empty address lines, applies title casing to each one, and appends the postcode in uppercase.
  *
  * @param {module:AddressModel} address - The address associated with the billing account.
+ * @param {module:AddressModel} contact - The contact associated with the billing account.
  * @param {module:CompanyModel} company - The company associated with the billing account.
  *
  * @returns {string[]} An array of formatted address lines for display.
  */
-function _address(address, company) {
+function _address(address, contact, company) {
+  const companyContact = _contact(contact)
+  const companyName = titleCase(company.name)
+
   const addressLines = [
-    company.name,
     address['address1'],
     address['address2'],
     address['address3'],
@@ -64,7 +67,7 @@ function _address(address, company) {
     addressLines.push(address['postcode'].toUpperCase())
   }
 
-  return addressLines
+  return [companyName, companyContact, ...addressLines].filter(Boolean)
 }
 
 function _backLink(licenceId) {
@@ -95,6 +98,20 @@ function _bills(bills) {
       financialYear: bill.financialYearEnding
     }
   })
+}
+
+function _contact(contact) {
+  if (!contact) return null
+
+  if (contact.contactType === 'person') {
+    return `FAO ${titleCase(contact.firstName)} ${titleCase(contact.lastName)}`
+  }
+
+  if (contact.contactType === 'department') {
+    return `FAO ${titleCase(contact.department)}`
+  }
+
+  return null
 }
 
 module.exports = {

--- a/app/services/billing-accounts/fetch-view-billing-account.service.js
+++ b/app/services/billing-accounts/fetch-view-billing-account.service.js
@@ -40,7 +40,7 @@ async function _fetchBillingAccount(id) {
     .select(['id', 'accountNumber', 'createdAt', 'lastTransactionFile', 'lastTransactionFileCreatedAt'])
     .withGraphFetched('billingAccountAddresses')
     .modifyGraph('billingAccountAddresses', (builder) => {
-      builder.select('id')
+      builder.select('id').orderBy('createdAt', 'desc').limit(1)
     })
     .withGraphFetched('company')
     .modifyGraph('company', (builder) => {

--- a/app/services/billing-accounts/fetch-view-billing-account.service.js
+++ b/app/services/billing-accounts/fetch-view-billing-account.service.js
@@ -50,6 +50,10 @@ async function _fetchBillingAccount(id) {
     .modifyGraph('billingAccountAddresses.address', (builder) => {
       builder.select(['id', 'address1', 'address2', 'address3', 'address4', 'address5', 'address6', 'postcode'])
     })
+    .withGraphFetched('billingAccountAddresses.contact')
+    .modifyGraph('billingAccountAddresses.contact', (builder) => {
+      builder.select(['id', 'contactType', 'department', 'firstName', 'lastName'])
+    })
 }
 
 async function _fetchBills(billingAccountId, page) {

--- a/test/controllers/billing-accounts.controller.test.js
+++ b/test/controllers/billing-accounts.controller.test.js
@@ -183,7 +183,15 @@ function _viewBillingAccount() {
   return {
     activeNavBar: 'search',
     accountNumber: 'S88897992A',
-    address: ['Ferns Surfacing Limited', 'Tutsham Farm', 'West Farleigh', 'Maidstone', 'Kent', 'Me15 0ne'],
+    address: [
+      'Ferns Surfacing Limited',
+      'FAO Test Testingson',
+      'Tutsham Farm',
+      'West Farleigh',
+      'Maidstone',
+      'Kent',
+      'Me15 0ne'
+    ],
     billingAccountId: '9b03843e-848b-497e-878e-4a6628d4f683',
     bills: [
       {

--- a/test/fixtures/billing-accounts.fixtures.js
+++ b/test/fixtures/billing-accounts.fixtures.js
@@ -1,11 +1,21 @@
 'use strict'
 
+const ContactModel = require('../../app/models/contact.model.js')
+
 /**
  * Represents a complete response from `FetchBillingAccountService`
  *
  * @returns {object} an object representing the billing account, bills and its related licence
  */
 function billingAccount() {
+  const contact = ContactModel.fromJson({
+    id: '93403c8c-ff7d-4ec7-a6be-7a4451e3ac72',
+    contactType: 'person',
+    department: 'Testing department',
+    firstName: 'Test',
+    lastName: 'Testingson'
+  })
+
   return {
     billingAccount: {
       id: '9b03843e-848b-497e-878e-4a6628d4f683',
@@ -26,13 +36,7 @@ function billingAccount() {
             address6: 'Kent',
             postcode: 'ME15 0NE'
           },
-          contact: {
-            id: '93403c8c-ff7d-4ec7-a6be-7a4451e3ac72',
-            contactType: 'person',
-            department: 'Testing department',
-            firstName: 'Test',
-            lastName: 'Testingson'
-          }
+          contact
         }
       ],
       company: {

--- a/test/fixtures/billing-accounts.fixtures.js
+++ b/test/fixtures/billing-accounts.fixtures.js
@@ -25,6 +25,13 @@ function billingAccount() {
             address5: 'Maidstone',
             address6: 'Kent',
             postcode: 'ME15 0NE'
+          },
+          contact: {
+            id: '93403c8c-ff7d-4ec7-a6be-7a4451e3ac72',
+            contactType: 'person',
+            department: 'Testing department',
+            firstName: 'Test',
+            lastName: 'Testingson'
           }
         }
       ],

--- a/test/presenters/billing-accounts/view-billing-account.presenter.test.js
+++ b/test/presenters/billing-accounts/view-billing-account.presenter.test.js
@@ -131,7 +131,7 @@ describe('View Billing Account presenter', () => {
 
         expect(result.address).to.equal([
           'Ferns Surfacing Limited',
-          'FAO Testing Department',
+          'FAO Testing department',
           'Tutsham Farm',
           'West Farleigh',
           'Maidstone',

--- a/test/presenters/billing-accounts/view-billing-account.presenter.test.js
+++ b/test/presenters/billing-accounts/view-billing-account.presenter.test.js
@@ -104,7 +104,7 @@ describe('View Billing Account presenter', () => {
 
     describe('when there is no contact', () => {
       beforeEach(() => {
-        billingAccountData.billingAccount.billingAccountAddresses[0].contact = {}
+        billingAccountData.billingAccount.billingAccountAddresses[0].contact = null
       })
 
       it('returns an array of populated address lines title cased, the postcode capitalised, and no contact included', () => {

--- a/test/presenters/billing-accounts/view-billing-account.presenter.test.js
+++ b/test/presenters/billing-accounts/view-billing-account.presenter.test.js
@@ -28,7 +28,15 @@ describe('View Billing Account presenter', () => {
 
       expect(result).to.equal({
         accountNumber: 'S88897992A',
-        address: ['Ferns Surfacing Limited', 'Tutsham Farm', 'West Farleigh', 'Maidstone', 'Kent', 'ME15 0NE'],
+        address: [
+          'Ferns Surfacing Limited',
+          'FAO Test Testingson',
+          'Tutsham Farm',
+          'West Farleigh',
+          'Maidstone',
+          'Kent',
+          'ME15 0NE'
+        ],
         backLink: {
           title: 'Go back to bills',
           link: `/system/licences/${licenceId}/bills`
@@ -66,6 +74,7 @@ describe('View Billing Account presenter', () => {
 
         expect(result.address).to.equal([
           'Ferns Surfacing Limited',
+          'FAO Test Testingson',
           'Tutsham Farm',
           'West Farleigh',
           'Test Road',
@@ -83,6 +92,66 @@ describe('View Billing Account presenter', () => {
 
         expect(result.address).to.equal([
           'Ferns Surfacing Limited',
+          'FAO Test Testingson',
+          'Tutsham Farm',
+          'West Farleigh',
+          'Maidstone',
+          'Kent',
+          'ME15 0NE'
+        ])
+      })
+    })
+
+    describe('when there is no contact', () => {
+      beforeEach(() => {
+        billingAccountData.billingAccount.billingAccountAddresses[0].contact = {}
+      })
+
+      it('returns an array of populated address lines title cased, the postcode capitalised, and no contact included', () => {
+        const result = ViewBillingAccountPresenter.go(billingAccountData, licenceId)
+
+        expect(result.address).to.equal([
+          'Ferns Surfacing Limited',
+          'Tutsham Farm',
+          'West Farleigh',
+          'Maidstone',
+          'Kent',
+          'ME15 0NE'
+        ])
+      })
+    })
+
+    describe('when the contact is a department', () => {
+      beforeEach(() => {
+        billingAccountData.billingAccount.billingAccountAddresses[0].contact.contactType = 'department'
+      })
+
+      it('returns an array of populated address lines title cased, the postcode capitalised, and the department name included', () => {
+        const result = ViewBillingAccountPresenter.go(billingAccountData, licenceId)
+
+        expect(result.address).to.equal([
+          'Ferns Surfacing Limited',
+          'FAO Testing Department',
+          'Tutsham Farm',
+          'West Farleigh',
+          'Maidstone',
+          'Kent',
+          'ME15 0NE'
+        ])
+      })
+    })
+
+    describe('when the contact is a person', () => {
+      beforeEach(() => {
+        billingAccountData.billingAccount.billingAccountAddresses[0].contact.contactType = 'person'
+      })
+
+      it('returns an array of populated address lines title cased, the postcode capitalised, and the persons first and last names included', () => {
+        const result = ViewBillingAccountPresenter.go(billingAccountData, licenceId)
+
+        expect(result.address).to.equal([
+          'Ferns Surfacing Limited',
+          'FAO Test Testingson',
           'Tutsham Farm',
           'West Farleigh',
           'Maidstone',

--- a/test/services/billing-accounts/fetch-view-billing-account.service.test.js
+++ b/test/services/billing-accounts/fetch-view-billing-account.service.test.js
@@ -13,6 +13,7 @@ const BillHelper = require('../../support/helpers/bill.helper.js')
 const BillingAccountAddressHelper = require('../../support/helpers/billing-account-address.helper.js')
 const BillingAccountHelper = require('../../support/helpers/billing-account.helper.js')
 const BillRunHelper = require('../../support/helpers/bill-run.helper.js')
+const ContactHelper = require('../../support/helpers/contact.helper.js')
 const CompanyHelper = require('../../support/helpers/company.helper.js')
 
 // Thing under test
@@ -28,10 +29,12 @@ describe('Fetch Billing Account service', () => {
   let billRun2
   let billRun3
   let company
+  let contact
 
   describe('when a matching billing account exists', () => {
     beforeEach(async () => {
       address = await AddressHelper.add()
+      contact = await ContactHelper.add()
       company = await CompanyHelper.add()
 
       billingAccount = await BillingAccountHelper.add({ companyId: company.id })
@@ -39,7 +42,8 @@ describe('Fetch Billing Account service', () => {
 
       billingAccountAddress = await BillingAccountAddressHelper.add({
         addressId: address.id,
-        billingAccountId
+        billingAccountId,
+        contactId: contact.id
       })
 
       billRun1 = await BillRunHelper.add({
@@ -92,6 +96,13 @@ describe('Fetch Billing Account service', () => {
                 address5: null,
                 address6: null,
                 postcode: 'BS1 5AH'
+              },
+              contact: {
+                id: contact.id,
+                contactType: contact.contactType,
+                department: contact.department,
+                firstName: contact.firstName,
+                lastName: contact.lastName
               }
             }
           ],

--- a/test/services/billing-accounts/view-billing-account.service.test.js
+++ b/test/services/billing-accounts/view-billing-account.service.test.js
@@ -33,7 +33,15 @@ describe('View Billing Account service', () => {
       expect(result).to.equal({
         activeNavBar: 'search',
         accountNumber: 'S88897992A',
-        address: ['Ferns Surfacing Limited', 'Tutsham Farm', 'West Farleigh', 'Maidstone', 'Kent', 'ME15 0NE'],
+        address: [
+          'Ferns Surfacing Limited',
+          'FAO Test Testingson',
+          'Tutsham Farm',
+          'West Farleigh',
+          'Maidstone',
+          'Kent',
+          'ME15 0NE'
+        ],
         backLink: {
           title: 'Go back to bills',
           link: `/system/licences/53325713-1364-4f6b-a244-8771a36a1248/bills`


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4988

While testing the change address functionality from the view billing account page, it was noticed that upon updating the FAO(For the Attention Of), it would be displayed as part of the address on the legacy billing account page. As a result, this should be replicated on the new billing account page.

This PR adds the FAO to the address on the view billing account page.