### PR TITLE
Fix relevant licence monitoring station

### DIFF
--- a/app/presenters/notices/setup/abstraction-alerts/alert-thresholds.presenter.js
+++ b/app/presenters/notices/setup/abstraction-alerts/alert-thresholds.presenter.js
@@ -36,7 +36,10 @@ function _relevantLicenceMonitoringStations(licenceMonitoringStations, alertType
   }
 
   return licenceMonitoringStations.filter((licenceMonitoringStation) => {
-    return licenceMonitoringStation.restrictionType === alertType
+    return (
+      licenceMonitoringStation.restrictionType === alertType ||
+      licenceMonitoringStation.restrictionType === 'stop_or_reduce'
+    )
   })
 }
 

--- a/app/presenters/notices/setup/abstraction-alerts/check-licence-matches.presenter.js
+++ b/app/presenters/notices/setup/abstraction-alerts/check-licence-matches.presenter.js
@@ -21,7 +21,8 @@ function go(session) {
     id: sessionId,
     licenceMonitoringStations,
     monitoringStationName,
-    removedThresholds
+    removedThresholds,
+    alertType
   } = session
 
   return {
@@ -29,7 +30,7 @@ function go(session) {
     cancelLink: `/system/notices/setup/${sessionId}/abstraction-alerts/cancel`,
     caption: monitoringStationName,
     pageTitle: 'Check the licence matches for the selected thresholds',
-    restrictions: _restrictions(licenceMonitoringStations, alertThresholds, removedThresholds, sessionId),
+    restrictions: _restrictions(licenceMonitoringStations, alertThresholds, removedThresholds, sessionId, alertType),
     restrictionHeading: determineRestrictionHeading(licenceMonitoringStations)
   }
 }
@@ -41,11 +42,12 @@ function _action(sessionId, licenceMonitoringStation) {
   }
 }
 
-function _restrictions(licenceMonitoringStations, alertThresholds, removedThresholds, sessionId) {
+function _restrictions(licenceMonitoringStations, alertThresholds, removedThresholds, sessionId, alertType) {
   const relevantLicenceMonitoringStations = DetermineRelevantLicenceMonitoringStationsService.go(
     licenceMonitoringStations,
     alertThresholds,
-    removedThresholds
+    removedThresholds,
+    alertType
   )
 
   const multipleRestrictions = relevantLicenceMonitoringStations.length > 1

--- a/app/services/notices/setup/abstraction-alerts/determine-relevant-licence-monitoring-stations.service.js
+++ b/app/services/notices/setup/abstraction-alerts/determine-relevant-licence-monitoring-stations.service.js
@@ -21,13 +21,18 @@
  * @param {Array<object>} licenceMonitoringStations
  * @param {Array<string>} selectedLicenceMonitoringStations
  * @param {Array<string>} removedLicenceMonitoringStations
+ * @param {string} alertType
  *
  * @returns {Array<object>}
  */
-function go(licenceMonitoringStations, selectedLicenceMonitoringStations, removedLicenceMonitoringStations) {
-  const relevantLicenceMonitoringStations = licenceMonitoringStations.filter((licenceMonitoringStation) => {
-    return selectedLicenceMonitoringStations.includes(licenceMonitoringStation.thresholdGroup)
-  })
+function go(licenceMonitoringStations, selectedLicenceMonitoringStations, removedLicenceMonitoringStations, alertType) {
+  const relevantLicenceMonitoringStations = licenceMonitoringStations
+    .filter((licenceMonitoringStation) => {
+      return _relevantByAlertType(licenceMonitoringStation, alertType)
+    })
+    .filter((licenceMonitoringStation) => {
+      return selectedLicenceMonitoringStations.includes(licenceMonitoringStation.thresholdGroup)
+    })
 
   if (removedLicenceMonitoringStations) {
     return relevantLicenceMonitoringStations.filter((licenceMonitoringStation) => {
@@ -36,6 +41,21 @@ function go(licenceMonitoringStations, selectedLicenceMonitoringStations, remove
   }
 
   return relevantLicenceMonitoringStations
+}
+
+function _relevantByAlertType(licenceMonitoringStation, alertType) {
+  if (alertType !== 'stop' && alertType !== 'reduce') {
+    return licenceMonitoringStation
+  }
+
+  if (
+    licenceMonitoringStation.restrictionType === alertType ||
+    licenceMonitoringStation.restrictionType === 'stop_or_reduce'
+  ) {
+    return licenceMonitoringStation
+  }
+
+  return false
 }
 
 module.exports = {

--- a/app/services/notices/setup/abstraction-alerts/submit-check-licence-matches.service.js
+++ b/app/services/notices/setup/abstraction-alerts/submit-check-licence-matches.service.js
@@ -22,12 +22,13 @@ async function go(sessionId) {
 }
 
 async function _save(session) {
-  const { alertThresholds, licenceMonitoringStations, removedThresholds } = session
+  const { alertThresholds, licenceMonitoringStations, removedThresholds, alertType } = session
 
   const relevantLicenceMonitoringStations = DetermineRelevantLicenceMonitoringStationsService.go(
     licenceMonitoringStations,
     alertThresholds,
-    removedThresholds
+    removedThresholds,
+    alertType
   )
 
   const relevantLicenceRefs = relevantLicenceMonitoringStations.map((station) => {

--- a/test/presenters/notices/setup/abstraction-alerts/alert-thresholds.presenter.test.js
+++ b/test/presenters/notices/setup/abstraction-alerts/alert-thresholds.presenter.test.js
@@ -14,9 +14,9 @@ const AbstractionAlertSessionData = require('../../../../fixtures/abstraction-al
 const AlertThresholdsPresenter = require('../../../../../app/presenters/notices/setup/abstraction-alerts/alert-thresholds.presenter.js')
 
 describe('Notices Setup - Abstraction Alerts - Alert Thresholds Presenter', () => {
-  let alertThresholdGroupOne
-  let alertThresholdGroupThree
-  let alertThresholdGroupTwo
+  let licenceMonitoringStationOne
+  let licenceMonitoringStationThree
+  let licenceMonitoringStationTwo
   let session
 
   beforeEach(() => {
@@ -25,9 +25,9 @@ describe('Notices Setup - Abstraction Alerts - Alert Thresholds Presenter', () =
       alertType: 'stop'
     }
 
-    alertThresholdGroupOne = session.licenceMonitoringStations[0].thresholdGroup
-    alertThresholdGroupTwo = session.licenceMonitoringStations[1].thresholdGroup
-    alertThresholdGroupThree = session.licenceMonitoringStations[2].thresholdGroup
+    licenceMonitoringStationOne = session.licenceMonitoringStations[0].thresholdGroup
+    licenceMonitoringStationTwo = session.licenceMonitoringStations[1].thresholdGroup
+    licenceMonitoringStationThree = session.licenceMonitoringStations[2].thresholdGroup
   })
 
   describe('when called', () => {
@@ -45,7 +45,7 @@ describe('Notices Setup - Abstraction Alerts - Alert Thresholds Presenter', () =
               text: 'Flow threshold'
             },
             text: '100 m3/s',
-            value: alertThresholdGroupTwo
+            value: licenceMonitoringStationTwo
           },
           {
             checked: false,
@@ -53,7 +53,7 @@ describe('Notices Setup - Abstraction Alerts - Alert Thresholds Presenter', () =
               text: 'Level threshold'
             },
             text: '100 m',
-            value: alertThresholdGroupThree
+            value: licenceMonitoringStationThree
           }
         ]
       })
@@ -64,7 +64,7 @@ describe('Notices Setup - Abstraction Alerts - Alert Thresholds Presenter', () =
         beforeEach(() => {
           session = {
             ...AbstractionAlertSessionData.monitoringStation(),
-            alertThresholds: [alertThresholdGroupTwo],
+            alertThresholds: [licenceMonitoringStationTwo],
             alertType: 'stop'
           }
         })
@@ -75,13 +75,13 @@ describe('Notices Setup - Abstraction Alerts - Alert Thresholds Presenter', () =
           expect(result.thresholdOptions).to.equal([
             {
               checked: true,
-              value: alertThresholdGroupTwo,
+              value: licenceMonitoringStationTwo,
               text: '100 m3/s',
               hint: { text: 'Flow threshold' }
             },
             {
               checked: false,
-              value: alertThresholdGroupThree,
+              value: licenceMonitoringStationThree,
               text: '100 m',
               hint: { text: 'Level threshold' }
             }
@@ -103,17 +103,43 @@ describe('Notices Setup - Abstraction Alerts - Alert Thresholds Presenter', () =
           expect(result.thresholdOptions).to.equal([
             {
               checked: false,
-              value: alertThresholdGroupTwo,
+              value: licenceMonitoringStationTwo,
               text: '100 m3/s',
               hint: { text: 'Flow threshold' }
             },
             {
               checked: false,
-              value: alertThresholdGroupThree,
+              value: licenceMonitoringStationThree,
               text: '100 m',
               hint: { text: 'Level threshold' }
             }
           ])
+        })
+
+        describe('and a licence monitoring station is "stop_or_reduce" ', () => {
+          beforeEach(() => {
+            session.licenceMonitoringStations[1].responseType = 'stop_or_reduce'
+            session.licenceMonitoringStations[2].responseType = 'stop'
+          })
+
+          it('returns page data for the view, with only the thresholds with reduce restrictions', () => {
+            const result = AlertThresholdsPresenter.go(session)
+
+            expect(result.thresholdOptions).to.equal([
+              {
+                checked: false,
+                value: licenceMonitoringStationTwo,
+                text: '100 m3/s',
+                hint: { text: 'Flow threshold' }
+              },
+              {
+                checked: false,
+                value: licenceMonitoringStationThree,
+                text: '100 m',
+                hint: { text: 'Level threshold' }
+              }
+            ])
+          })
         })
       })
 
@@ -131,7 +157,7 @@ describe('Notices Setup - Abstraction Alerts - Alert Thresholds Presenter', () =
           expect(result.thresholdOptions).to.equal([
             {
               checked: false,
-              value: alertThresholdGroupOne,
+              value: licenceMonitoringStationOne,
               text: '1000 m',
               hint: { text: 'Level threshold' }
             }
@@ -152,19 +178,19 @@ describe('Notices Setup - Abstraction Alerts - Alert Thresholds Presenter', () =
           expect(result.thresholdOptions).to.equal([
             {
               checked: false,
-              value: alertThresholdGroupOne,
+              value: licenceMonitoringStationOne,
               text: '1000 m',
               hint: { text: 'Level threshold' }
             },
             {
               checked: false,
-              value: alertThresholdGroupTwo,
+              value: licenceMonitoringStationTwo,
               text: '100 m3/s',
               hint: { text: 'Flow threshold' }
             },
             {
               checked: false,
-              value: alertThresholdGroupThree,
+              value: licenceMonitoringStationThree,
               text: '100 m',
               hint: { text: 'Level threshold' }
             }

--- a/test/services/notices/setup/abstraction-alerts/determine-relevant-licence-monitoring-stations.service.test.js
+++ b/test/services/notices/setup/abstraction-alerts/determine-relevant-licence-monitoring-stations.service.test.js
@@ -13,7 +13,7 @@ const AbstractionAlertSessionData = require('../../../../fixtures/abstraction-al
 // Thing under test
 const DetermineRelevantLicenceMonitoringStationsService = require('../../../../../app/services/notices/setup/abstraction-alerts/determine-relevant-licence-monitoring-stations.service.js')
 
-describe.only('Notices Setup - Abstraction Alerts - Determine relevant licence monitoring stations service', () => {
+describe('Notices Setup - Abstraction Alerts - Determine relevant licence monitoring stations service', () => {
   let alertType
   let licenceMonitoringStationOne
   let licenceMonitoringStationThree

--- a/test/services/notices/setup/abstraction-alerts/determine-relevant-licence-monitoring-stations.service.test.js
+++ b/test/services/notices/setup/abstraction-alerts/determine-relevant-licence-monitoring-stations.service.test.js
@@ -13,7 +13,8 @@ const AbstractionAlertSessionData = require('../../../../fixtures/abstraction-al
 // Thing under test
 const DetermineRelevantLicenceMonitoringStationsService = require('../../../../../app/services/notices/setup/abstraction-alerts/determine-relevant-licence-monitoring-stations.service.js')
 
-describe('Notices Setup - Abstraction Alerts - Determine relevant licence monitoring stations service', () => {
+describe.only('Notices Setup - Abstraction Alerts - Determine relevant licence monitoring stations service', () => {
+  let alertType
   let licenceMonitoringStationOne
   let licenceMonitoringStationThree
   let licenceMonitoringStationTwo
@@ -35,13 +36,18 @@ describe('Notices Setup - Abstraction Alerts - Determine relevant licence monito
       licenceMonitoringStationTwo.thresholdGroup,
       licenceMonitoringStationThree.thresholdGroup
     ]
+
+    alertType = 'warning'
+
+    removedLicenceMonitoringStations = []
   })
 
   it('returns the licence monitoring stations', () => {
     const result = DetermineRelevantLicenceMonitoringStationsService.go(
       licenceMonitoringStations,
       selectedLicenceMonitoringStations,
-      removedLicenceMonitoringStations
+      removedLicenceMonitoringStations,
+      alertType
     )
 
     expect(result).to.equal([licenceMonitoringStationOne, licenceMonitoringStationTwo, licenceMonitoringStationThree])
@@ -55,7 +61,8 @@ describe('Notices Setup - Abstraction Alerts - Determine relevant licence monito
       const result = DetermineRelevantLicenceMonitoringStationsService.go(
         licenceMonitoringStations,
         selectedLicenceMonitoringStations,
-        removedLicenceMonitoringStations
+        removedLicenceMonitoringStations,
+        alertType
       )
 
       expect(result).to.equal([licenceMonitoringStationOne])
@@ -71,12 +78,95 @@ describe('Notices Setup - Abstraction Alerts - Determine relevant licence monito
       const result = DetermineRelevantLicenceMonitoringStationsService.go(
         licenceMonitoringStations,
         selectedLicenceMonitoringStations,
-        removedLicenceMonitoringStations
+        removedLicenceMonitoringStations,
+        alertType
       )
 
       expect(result.length).to.equal(2)
 
       expect(result).to.equal([licenceMonitoringStationTwo, licenceMonitoringStationThree])
+    })
+  })
+
+  describe('when the "alertType" is "stop"', () => {
+    beforeEach(() => {
+      alertType = 'stop'
+
+      selectedLicenceMonitoringStations = [licenceMonitoringStationTwo.thresholdGroup]
+    })
+
+    it('returns the licence monitoring stations (with the reduce type removed)', () => {
+      const result = DetermineRelevantLicenceMonitoringStationsService.go(
+        licenceMonitoringStations,
+        selectedLicenceMonitoringStations,
+        removedLicenceMonitoringStations,
+        alertType
+      )
+
+      expect(result).to.equal([licenceMonitoringStationTwo])
+    })
+
+    describe('and a licence monitoring station has the "restrictionType" "stop_or_reduce"', () => {
+      beforeEach(() => {
+        licenceMonitoringStations[2].restrictionType = 'stop_or_reduce'
+
+        selectedLicenceMonitoringStations = [
+          licenceMonitoringStationTwo.thresholdGroup,
+          licenceMonitoringStationThree.thresholdGroup
+        ]
+      })
+
+      it('returns the licence monitoring stations (with the reduce type removed)', () => {
+        const result = DetermineRelevantLicenceMonitoringStationsService.go(
+          licenceMonitoringStations,
+          selectedLicenceMonitoringStations,
+          removedLicenceMonitoringStations,
+          alertType
+        )
+
+        expect(result).to.equal([licenceMonitoringStationTwo, licenceMonitoringStationThree])
+      })
+    })
+  })
+
+  describe('when the "alertType" is "reduce"', () => {
+    beforeEach(() => {
+      alertType = 'reduce'
+
+      selectedLicenceMonitoringStations = [licenceMonitoringStationOne.thresholdGroup]
+    })
+
+    it('returns the licence monitoring stations (with the reduce type removed)', () => {
+      const result = DetermineRelevantLicenceMonitoringStationsService.go(
+        licenceMonitoringStations,
+        selectedLicenceMonitoringStations,
+        removedLicenceMonitoringStations,
+        alertType
+      )
+
+      expect(result).to.equal([licenceMonitoringStationOne])
+    })
+
+    describe('and a licence monitoring station has the "restrictionType" "stop_or_reduce"', () => {
+      beforeEach(() => {
+        licenceMonitoringStations[1].restrictionType = 'stop_or_reduce'
+
+        selectedLicenceMonitoringStations = [
+          licenceMonitoringStationOne.thresholdGroup,
+          licenceMonitoringStationTwo.thresholdGroup
+        ]
+      })
+
+      it('returns the licence monitoring stations (with the reduce type removed)', () => {
+        const result = DetermineRelevantLicenceMonitoringStationsService.go(
+          licenceMonitoringStations,
+          selectedLicenceMonitoringStations,
+          removedLicenceMonitoringStations,
+          alertType
+        )
+
+        expect(result).to.equal([licenceMonitoringStationOne, licenceMonitoringStationTwo])
+      })
     })
   })
 })

--- a/test/services/notices/setup/abstraction-alerts/determine-relevant-licence-monitoring-stations.service.test.js
+++ b/test/services/notices/setup/abstraction-alerts/determine-relevant-licence-monitoring-stations.service.test.js
@@ -116,7 +116,7 @@ describe('Notices Setup - Abstraction Alerts - Determine relevant licence monito
         ]
       })
 
-      it('returns the licence monitoring stations (with the reduce type removed)', () => {
+      it('returns the licence monitoring stations, with "stop_or_reduce" but without the reduce type)', () => {
         const result = DetermineRelevantLicenceMonitoringStationsService.go(
           licenceMonitoringStations,
           selectedLicenceMonitoringStations,
@@ -157,7 +157,7 @@ describe('Notices Setup - Abstraction Alerts - Determine relevant licence monito
         ]
       })
 
-      it('returns the licence monitoring stations (with the reduce type removed)', () => {
+      it('returns the licence monitoring stations, with "stop_or_reduce" but without the stop type)', () => {
         const result = DetermineRelevantLicenceMonitoringStationsService.go(
           licenceMonitoringStations,
           selectedLicenceMonitoringStations,


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5067

We previously implemented a determineLicenceMonitoringStation service which calculates the relevant stations based on user input.

We missed the alertType, which has additional logic related to restrictionType. Specifically, when restrictionType is stop_or_reduce, it should be shown for all alert types. However, when the alertType is 'stop' or 'reduce', we should only show stations with a matching restrictionType or stop_or_reduce.

This change updates the logic to return the correct list of relevant licence monitoring stations.

In summary, we now show all stations for all alert types — except when the alert type is 'stop' or 'reduce', in which case we exclude unrelated types.