### PR TITLE
Fix notice alert type validator

### DIFF
--- a/app/validators/notices/setup/abstraction-alerts/alert-type.validator.js
+++ b/app/validators/notices/setup/abstraction-alerts/alert-type.validator.js
@@ -38,7 +38,9 @@ function go(payload, licenceMonitoringStations) {
  * Returns a list of available alert types based on the restriction types
  * found in the provided licence monitoring stations.
  *
- * Includes the default alert types: 'warning' and 'resume',
+ * If at least one restriction type is 'stop_or_reduce' then all the alert types are valid.
+ *
+ * Includes the default alert types: 'warning' and 'resume'
  * followed by any additional restriction types extracted from the input.
  *
  * @private
@@ -47,6 +49,10 @@ function _availableRestrictionType(licenceMonitoringStations) {
   const restrictionTypes = licenceMonitoringStations.map((licenceMonitoringStation) => {
     return licenceMonitoringStation.restrictionType
   })
+
+  if (restrictionTypes.includes('stop_or_reduce')) {
+    return ['warning', 'resume', 'stop', 'reduce']
+  }
 
   return ['warning', 'resume', ...restrictionTypes]
 }

--- a/test/validators/notices/setup/abstraction-alerts/alert-type.validator.test.js
+++ b/test/validators/notices/setup/abstraction-alerts/alert-type.validator.test.js
@@ -34,6 +34,19 @@ describe('Notices - Setup - Abstraction Alerts - Alert Type Validator', () => {
       expect(result.value).to.exist()
       expect(result.error).not.to.exist()
     })
+
+    describe('when the a restriction type is "stop_or_reduce" and there are no other licence monitoring stations', () => {
+      beforeEach(() => {
+        licenceMonitoringStations = [{ ...licenceMonitoringStations[0], restrictionType: 'stop_or_reduce' }]
+      })
+
+      it('returns with no errors', () => {
+        const result = AlertTypeValidator.go(payload, licenceMonitoringStations)
+
+        expect(result.value).to.exist()
+        expect(result.error).not.to.exist()
+      })
+    })
   })
 
   describe('when called with invalid data', () => {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5061

When a licence monitoring station has the 'stop_or_reduce' restriction type it should be shown as an option to the user for the stop / reduce alert type. This was no happening when the only threshold was for 'stop_or_reduce'.

This change allows the restriction type 'stop_or_reduce' to be valid for all the alert types.

This can result in a user selected stop and only seeing a threshold for 'stop_or_reduce'. This is expected behaviour.