### PR TITLE
Add notes to View Return Log page

### DIFF
--- a/app/presenters/return-logs/view-return-log.presenter.js
+++ b/app/presenters/return-logs/view-return-log.presenter.js
@@ -221,11 +221,12 @@ function _versions(selectedReturnSubmission, versions, returnLogId) {
   }
 
   return versions.map((version) => {
-    const { createdAt, id, userId: user, version: number } = version
+    const { createdAt, id, notes, userId: user, version: number } = version
 
     return {
       createdAt: `${formatLongDate(createdAt)}`,
       link: `/system/return-logs?id=${returnLogId}&version=${number}`,
+      notes,
       selected: id === selectedReturnSubmission.id,
       version: number,
       user

--- a/app/services/return-logs/fetch-return-log.service.js
+++ b/app/services/return-logs/fetch-return-log.service.js
@@ -80,7 +80,7 @@ async function _fetch(returnId, selectedReturnSubmission) {
 
 async function _fetchAllReturnSubmissions(returnId) {
   return ReturnSubmissionModel.query()
-    .select(['createdAt', 'id', 'version', 'userId'])
+    .select(['createdAt', 'id', 'notes', 'version', 'userId'])
     .where('returnLogId', returnId)
     .orderBy('version', 'desc')
 }

--- a/app/views/return-logs/view.njk
+++ b/app/views/return-logs/view.njk
@@ -328,6 +328,12 @@
               <p class="govuk-!-margin-0">Viewing version {{ version.version }}</p>
               <p class="govuk-!-margin-0">{{ version.user }}</p>
               <p class="govuk-!-margin-0">{{ version.createdAt }}</p>
+              {% if version.notes %}
+                {{ govukDetails({
+                  summaryText: "Notes",
+                  text: version.notes
+                }) }}
+              {% endif %}
             {% endset %}
           {% else %}
             {% set selectedClass = '' %}
@@ -335,6 +341,12 @@
               <p class="govuk-!-margin-0">Version {{ version.version }}</p>
               <p class="govuk-!-margin-0">{{ version.user }}</p>
               <p class="govuk-!-margin-0"><a href="{{ version.link }}">{{ version.createdAt }}</a></p>
+              {% if version.notes %}
+                {{ govukDetails({
+                  summaryText: "Notes",
+                  text: version.notes
+                }) }}
+              {% endif %}
             {% endset %}
           {% endif %}
 

--- a/test/presenters/return-logs/view-return-log.presenter.test.js
+++ b/test/presenters/return-logs/view-return-log.presenter.test.js
@@ -680,6 +680,81 @@ describe('View Return Log presenter', () => {
       })
     })
   })
+
+  describe('the "versions" property', () => {
+    beforeEach(() => {
+      testReturnLog.returnSubmissions = [
+        createInstance(ReturnSubmissionModel, ReturnSubmissionHelper, {
+          id: 'b57bc755-5f94-4760-bc5c-aba690827467',
+          returnLogId: testReturnLog.id
+        })
+      ]
+
+      testReturnLog.versions = [
+        createInstance(ReturnVersionModel, ReturnVersionHelper, {
+          id: testReturnLog.returnSubmissions[0].id,
+          licenceId: testReturnLog.licence.id,
+          notes: 'NOTES_V3',
+          userId: '4f6ab2c7-1361-4360-b83c-dec8cfc02585',
+          version: 3
+        }),
+        createInstance(ReturnVersionModel, ReturnVersionHelper, {
+          licenceId: testReturnLog.licence.id,
+          notes: 'NOTES_V2',
+          userId: '0c807806-500a-448d-83ff-bf12d3138988',
+          version: 2
+        }),
+        createInstance(ReturnVersionModel, ReturnVersionHelper, {
+          licenceId: testReturnLog.licence.id,
+          notes: 'NOTES_V1',
+          userId: '7b08a1a0-10c8-4981-82f5-5157d09205bb',
+          version: 1
+        })
+      ]
+
+      testReturnLog.returnSubmissions[0].returnSubmissionLines = [
+        createInstance(ReturnSubmissionLineModel, ReturnSubmissionLineHelper, {
+          returnSubmissionId: testReturnLog.returnSubmissions[0].id
+        }),
+        createInstance(ReturnSubmissionLineModel, ReturnSubmissionLineHelper, {
+          returnSubmissionId: testReturnLog.returnSubmissions[0].id,
+          startDate: new Date(`2022-01-02`),
+          endDate: new Date(`2022-02-08`)
+        })
+      ]
+    })
+
+    it('returns the versions', () => {
+      const result = ViewReturnLogPresenter.go(testReturnLog, auth)
+
+      expect(result.versions).to.equal(
+        [
+          {
+            link: `/system/return-logs?id=${testReturnLog.id}&version=3`,
+            notes: 'NOTES_V3',
+            selected: true,
+            version: 3,
+            user: '4f6ab2c7-1361-4360-b83c-dec8cfc02585'
+          },
+          {
+            link: `/system/return-logs?id=${testReturnLog.id}&version=2`,
+            notes: 'NOTES_V2',
+            selected: false,
+            version: 2,
+            user: '0c807806-500a-448d-83ff-bf12d3138988'
+          },
+          {
+            link: `/system/return-logs?id=${testReturnLog.id}&version=1`,
+            notes: 'NOTES_V1',
+            selected: false,
+            version: 1,
+            user: '7b08a1a0-10c8-4981-82f5-5157d09205bb'
+          }
+        ],
+        { skip: ['createdAt'] }
+      )
+    })
+  })
 })
 
 function setupSubmission(testReturnLog, nilReturn = false) {

--- a/test/services/return-logs/fetch-return-log.service.test.js
+++ b/test/services/return-logs/fetch-return-log.service.test.js
@@ -41,9 +41,9 @@ describe('Fetch Return Log service', () => {
   describe('when a return log with submissions exists', () => {
     beforeEach(async () => {
       testSubmissions = await Promise.all([
-        ReturnSubmissionHelper.add({ returnLogId: testReturnLog.id, version: 1 }),
-        ReturnSubmissionHelper.add({ returnLogId: testReturnLog.id, version: 2 }),
-        ReturnSubmissionHelper.add({ returnLogId: testReturnLog.id, version: 3 })
+        ReturnSubmissionHelper.add({ returnLogId: testReturnLog.id, version: 1, notes: 'NOTES_V1' }),
+        ReturnSubmissionHelper.add({ returnLogId: testReturnLog.id, version: 2, notes: 'NOTES_V2' }),
+        ReturnSubmissionHelper.add({ returnLogId: testReturnLog.id, version: 3, notes: 'NOTES_V3' })
       ])
 
       await Promise.all([
@@ -118,6 +118,16 @@ describe('Fetch Return Log service', () => {
       })
 
       expect(versions).to.equal([3, 2, 1])
+    })
+
+    it('includes notes for the versions', async () => {
+      const result = await FetchReturnLogService.go(testReturnLog.id)
+
+      const notes = result.versions.map((v) => {
+        return v.notes
+      })
+
+      expect(notes).to.equal(['NOTES_V3', 'NOTES_V2', 'NOTES_V1'])
     })
 
     it('applies readings to selected submission', async () => {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4745

While testing https://eaflood.atlassian.net/browse/WATER-4847 it was noticed that return log notes were not being displayed after submission. This is something that should be part of the View Return Log page -- the list of versions at the bottom should include a note where one has been saved against the version. We therefore add this.