### PR TITLE
Licence tag details - user bug

### DIFF
--- a/app/presenters/monitoring-stations/licence.presenter.js
+++ b/app/presenters/monitoring-stations/licence.presenter.js
@@ -29,6 +29,16 @@ function go(lastAlert, monitoringStationLicenceTags) {
   }
 }
 
+function _created(createdAt, user) {
+  const created = `Created on ${formatLongDate(createdAt)}`
+
+  if (user) {
+    return `${created} by ${user.username}`
+  }
+
+  return created
+}
+
 function _lastAlertSent(lastAlert) {
   if (lastAlert) {
     const { contact, createdAt, messageType, recipient, sendingAlertType } = lastAlert
@@ -49,7 +59,7 @@ function _licenceTags(licenceMonitoringStations) {
       _linkedConditionDetails(licenceVersionPurposeCondition)
 
     return {
-      created: `Created on ${formatLongDate(createdAt)} by ${user.username}`,
+      created: _created(createdAt, user),
       effectOfRestriction,
       licenceVersionStatus,
       linkedCondition,

--- a/test/presenters/monitoring-stations/licence.presenter.test.js
+++ b/test/presenters/monitoring-stations/licence.presenter.test.js
@@ -160,6 +160,30 @@ describe('Monitoring Stations - Licence presenter', () => {
         ])
       })
     })
+
+    describe('when the licence monitoring station record is NOT linked to a user', () => {
+      beforeEach(() => {
+        monitoringStationLicenceTags.licenceMonitoringStations[0].user = null
+      })
+
+      it('correctly formats the licence monitoring station created string', () => {
+        const result = LicencePresenter.go(lastAlert, monitoringStationLicenceTags)
+
+        expect(result.licenceTags[0].created).to.equal('Created on 23 April 2025')
+      })
+    })
+
+    describe('when the licence monitoring station record is linked to a user', () => {
+      beforeEach(() => {
+        monitoringStationLicenceTags.licenceMonitoringStations[0].user = { username: 'a.user@wrls.gov.uk' }
+      })
+
+      it('correctly formats the licence monitoring station created string', () => {
+        const result = LicencePresenter.go(lastAlert, monitoringStationLicenceTags)
+
+        expect(result.licenceTags[0].created).to.equal('Created on 23 April 2025 by a.user@wrls.gov.uk')
+      })
+    })
   })
 
   describe('the "monitoringStationName" property', () => {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4999

During QA a bug has been found when a user has not been assigned to the licence monitoring station record.

Assigning a user to this record is new functionality that is currently being introduced. This means the 'user' field will currently be null for most records.

This PR contains a fix to resolve the issue of the page blowing up when a user does not exist.