### PR TITLE
Add notices abstraction alert notification personalisation

### DIFF
--- a/app/services/notices/setup/batch-notifications.service.js
+++ b/app/services/notices/setup/batch-notifications.service.js
@@ -7,11 +7,12 @@
 
 const { setTimeout } = require('node:timers/promises')
 
+const AbstractionAlertsNotificationsPresenter = require('../../../presenters/notices/setup/abstraction-alerts-notifications.presenter.js')
 const CreateNotificationsService = require('./create-notifications.service.js')
+const NotificationsPresenter = require('../../../presenters/notices/setup/notifications.presenter.js')
 const NotifyEmailRequest = require('../../../requests/notify/notify-email.request.js')
 const NotifyLetterRequest = require('../../../requests/notify/notify-letter.request.js')
 const NotifyUpdatePresenter = require('../../../presenters/notices/setup/notify-update.presenter.js')
-const NotificationsPresenter = require('../../../presenters/notices/setup/notifications.presenter.js')
 const UpdateEventService = require('./update-event.service.js')
 
 const NotifyConfig = require('../../../../config/notify.config.js')
@@ -55,7 +56,13 @@ async function go(recipients, session, eventId) {
 async function _batch(recipients, session, eventId) {
   const { determinedReturnsPeriod, referenceCode, journey } = session
 
-  const notifications = NotificationsPresenter.go(recipients, determinedReturnsPeriod, referenceCode, journey, eventId)
+  let notifications
+
+  if (session.journey === 'abstraction-alert') {
+    notifications = AbstractionAlertsNotificationsPresenter.go(recipients, session, eventId)
+  } else {
+    notifications = NotificationsPresenter.go(recipients, determinedReturnsPeriod, referenceCode, journey, eventId)
+  }
 
   const toSendNotifications = _toSendNotifications(notifications)
 

--- a/test/presenters/notices/setup/abstraction-alert-notifications.presenter.test.js
+++ b/test/presenters/notices/setup/abstraction-alert-notifications.presenter.test.js
@@ -54,6 +54,7 @@ describe('Notices - Setup - Abstraction alert notifications presenter', () => {
     session = {
       journey: 'abstraction-alerts',
       referenceCode,
+      monitoringStationName: abstractionAlertSessionData.monitoringStationName,
       relevantLicenceMonitoringStations
     }
 
@@ -76,7 +77,16 @@ describe('Notices - Setup - Abstraction alert notifications presenter', () => {
         licences: `["${recipients.additionalContact.licence_refs}"]`,
         messageType: 'email',
         messageRef: 'water_abstraction_alert_reduce_warning_email',
-        personalisation: {},
+        personalisation: {
+          condition_text: '',
+          flow_or_level: 'level',
+          issuer_email_address: '',
+          licence_ref: recipients.additionalContact.licence_refs,
+          monitoring_station_name: 'Death star',
+          source: '',
+          threshold_unit: 'm',
+          threshold_value: 1000
+        },
         recipient: 'additional.contact@important.com'
       },
       {
@@ -87,7 +97,17 @@ describe('Notices - Setup - Abstraction alert notifications presenter', () => {
         licences: `["${recipients.primaryUser.licence_refs}"]`,
         messageType: 'email',
         messageRef: 'water_abstraction_alert_reduce_warning_email',
-        personalisation: {},
+        personalisation: {
+          condition_text: '',
+          flow_or_level: 'level',
+          issuer_email_address: '',
+          licence_ref: recipients.primaryUser.licence_refs,
+          monitoring_station_name: 'Death star',
+          source: '',
+          threshold_unit: 'm',
+          threshold_value: 1000
+        },
+
         recipient: 'primary.user@important.com'
       },
       {
@@ -104,7 +124,16 @@ describe('Notices - Setup - Abstraction alert notifications presenter', () => {
           address_line_2: 'Privet Drive',
           address_line_3: 'Little Whinging',
           address_line_4: 'Surrey',
-          address_line_5: 'WD25 7LR'
+          address_line_5: 'WD25 7LR',
+          // common personalisation
+          condition_text: '',
+          flow_or_level: 'flow',
+          issuer_email_address: '',
+          licence_ref: recipients.licenceHolder.licence_refs,
+          monitoring_station_name: 'Death star',
+          source: '',
+          threshold_unit: 'm3/s',
+          threshold_value: 100
         }
       }
     ])
@@ -135,6 +164,7 @@ describe('Notices - Setup - Abstraction alert notifications presenter', () => {
       session = {
         journey: 'abstraction-alerts',
         referenceCode,
+        monitoringStationName: abstractionAlertSessionData.monitoringStationName,
         relevantLicenceMonitoringStations
       }
     })
@@ -151,7 +181,16 @@ describe('Notices - Setup - Abstraction alert notifications presenter', () => {
           licences: `["${recipients.additionalContact.licence_refs}"]`,
           messageType: 'email',
           messageRef: 'water_abstraction_alert_reduce_warning_email',
-          personalisation: {},
+          personalisation: {
+            condition_text: '',
+            flow_or_level: 'level',
+            issuer_email_address: '',
+            licence_ref: recipients.additionalContact.licence_refs,
+            monitoring_station_name: 'Death star',
+            source: '',
+            threshold_unit: 'm',
+            threshold_value: 1000
+          },
           recipient: 'additional.contact@important.com'
         },
         {
@@ -160,7 +199,16 @@ describe('Notices - Setup - Abstraction alert notifications presenter', () => {
           licences: `["${recipients.primaryUser.licence_refs}"]`,
           messageRef: 'water_abstraction_alert_reduce_warning_email',
           messageType: 'email',
-          personalisation: {},
+          personalisation: {
+            condition_text: '',
+            flow_or_level: 'level',
+            issuer_email_address: '',
+            licence_ref: recipients.primaryUser.licence_refs,
+            monitoring_station_name: 'Death star',
+            source: '',
+            threshold_unit: 'm',
+            threshold_value: 1000
+          },
           recipient: 'primary.user@important.com',
           reference: 'TEST-123',
           templateId: '6ec7265d-8ebb-4217-a62b-9bf0216f8c9f'
@@ -173,7 +221,16 @@ describe('Notices - Setup - Abstraction alert notifications presenter', () => {
           licences: `["${recipients.additionalContact.licence_refs}"]`,
           messageType: 'email',
           messageRef: 'water_abstraction_alert_reduce_warning_email',
-          personalisation: {},
+          personalisation: {
+            condition_text: '',
+            flow_or_level: 'flow',
+            issuer_email_address: '',
+            licence_ref: recipients.additionalContact.licence_refs,
+            monitoring_station_name: 'Death star',
+            source: '',
+            threshold_unit: 'm3/s',
+            threshold_value: 100
+          },
           recipient: 'additional.contact@important.com'
         },
         {
@@ -182,7 +239,16 @@ describe('Notices - Setup - Abstraction alert notifications presenter', () => {
           licences: `["${recipients.primaryUser.licence_refs}"]`,
           messageRef: 'water_abstraction_alert_reduce_warning_email',
           messageType: 'email',
-          personalisation: {},
+          personalisation: {
+            condition_text: '',
+            flow_or_level: 'flow',
+            issuer_email_address: '',
+            licence_ref: recipients.primaryUser.licence_refs,
+            monitoring_station_name: 'Death star',
+            source: '',
+            threshold_unit: 'm3/s',
+            threshold_value: 100
+          },
           recipient: 'primary.user@important.com',
           reference: 'TEST-123',
           templateId: '6ec7265d-8ebb-4217-a62b-9bf0216f8c9f'
@@ -217,7 +283,16 @@ describe('Notices - Setup - Abstraction alert notifications presenter', () => {
           licences: `["${recipients.primaryUser.licence_refs}"]`,
           messageType: 'email',
           messageRef: 'water_abstraction_alert_reduce_warning_email',
-          personalisation: {},
+          personalisation: {
+            condition_text: '',
+            flow_or_level: 'level',
+            issuer_email_address: '',
+            licence_ref: recipients.primaryUser.licence_refs,
+            monitoring_station_name: 'Death star',
+            source: '',
+            threshold_unit: 'm',
+            threshold_value: 1000
+          },
           recipient: 'primary.user@important.com'
         }
       ])
@@ -240,7 +315,17 @@ describe('Notices - Setup - Abstraction alert notifications presenter', () => {
             licences: `["${recipients.additionalContact.licence_refs}"]`,
             messageType: 'email',
             messageRef: 'water_abstraction_alert_reduce_warning_email',
-            personalisation: {},
+            personalisation: {
+              condition_text: '',
+              flow_or_level: 'level',
+              issuer_email_address: '',
+              licence_ref: recipients.additionalContact.licence_refs,
+              monitoring_station_name: 'Death star',
+              source: '',
+              threshold_unit: 'm',
+              threshold_value: 1000
+            },
+
             recipient: 'additional.contact@important.com'
           },
           {
@@ -251,7 +336,17 @@ describe('Notices - Setup - Abstraction alert notifications presenter', () => {
             licences: `["${recipients.primaryUser.licence_refs}"]`,
             messageType: 'email',
             messageRef: 'water_abstraction_alert_reduce_warning_email',
-            personalisation: {},
+            personalisation: {
+              condition_text: '',
+              flow_or_level: 'level',
+              issuer_email_address: '',
+              licence_ref: recipients.primaryUser.licence_refs,
+              monitoring_station_name: 'Death star',
+              source: '',
+              threshold_unit: 'm',
+              threshold_value: 1000
+            },
+
             recipient: 'primary.user@important.com'
           }
         ])
@@ -289,7 +384,16 @@ describe('Notices - Setup - Abstraction alert notifications presenter', () => {
             address_line_2: 'Privet Drive',
             address_line_3: 'Little Whinging',
             address_line_4: 'Surrey',
-            address_line_5: 'WD25 7LR'
+            address_line_5: 'WD25 7LR',
+            // common personalisation
+            condition_text: '',
+            flow_or_level: 'flow',
+            issuer_email_address: '',
+            licence_ref: recipients.licenceHolder.licence_refs,
+            monitoring_station_name: 'Death star',
+            source: '',
+            threshold_unit: 'm3/s',
+            threshold_value: 100
           }
         }
       ])
@@ -312,7 +416,16 @@ describe('Notices - Setup - Abstraction alert notifications presenter', () => {
             licences: `["${recipients.additionalContact.licence_refs}"]`,
             messageType: 'email',
             messageRef: 'water_abstraction_alert_reduce_warning_email',
-            personalisation: {},
+            personalisation: {
+              condition_text: '',
+              flow_or_level: 'flow',
+              issuer_email_address: '',
+              licence_ref: recipients.additionalContact.licence_refs,
+              monitoring_station_name: 'Death star',
+              source: '',
+              threshold_unit: 'm3/s',
+              threshold_value: 100
+            },
             recipient: 'additional.contact@important.com'
           },
           {
@@ -329,7 +442,16 @@ describe('Notices - Setup - Abstraction alert notifications presenter', () => {
               address_line_2: 'Privet Drive',
               address_line_3: 'Little Whinging',
               address_line_4: 'Surrey',
-              address_line_5: 'WD25 7LR'
+              address_line_5: 'WD25 7LR',
+              // common personalisation
+              condition_text: '',
+              flow_or_level: 'flow',
+              issuer_email_address: '',
+              licence_ref: recipients.licenceHolder.licence_refs,
+              monitoring_station_name: 'Death star',
+              source: '',
+              threshold_unit: 'm3/s',
+              threshold_value: 100
             }
           }
         ])

--- a/test/services/notices/setup/batch-notifications.service.test.js
+++ b/test/services/notices/setup/batch-notifications.service.test.js
@@ -9,10 +9,11 @@ const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
+const AbstractionAlertSessionData = require('../../../fixtures/abstraction-alert-session-data.fixture.js')
 const EventHelper = require('../../../support/helpers/event.helper.js')
 const EventModel = require('../../../../app/models/event.model.js')
-const RecipientsFixture = require('../../../fixtures/recipients.fixtures.js')
 const NotificationModel = require('../../../../app/models/notification.model.js')
+const RecipientsFixture = require('../../../fixtures/recipients.fixtures.js')
 const { stubNotify } = require('../../../../config/notify.config.js')
 
 // Things we need to stub
@@ -22,7 +23,7 @@ const { NotifyClient } = require('notifications-node-client')
 // Thing under test
 const BatchNotificationsService = require('../../../../app/services/notices/setup/batch-notifications.service.js')
 
-describe('Notices - Setup - Batch notifications service', () => {
+describe.only('Notices - Setup - Batch notifications service', () => {
   const ONE_HUNDRED_MILLISECONDS = 100
   const referenceCode = 'RINV-123'
 
@@ -41,31 +42,6 @@ describe('Notices - Setup - Batch notifications service', () => {
     // correctly, we do not want increase the timeout for the test as we want them to fail if a timeout occurs
     Sinon.stub(NotifyConfig, 'delay').value(ONE_HUNDRED_MILLISECONDS)
 
-    recipients = RecipientsFixture.recipients()
-
-    testRecipients = [...Object.values(recipients)]
-
-    event = await EventHelper.add({
-      type: 'notification',
-      subtype: 'returnsInvitation',
-      referenceCode,
-      metadata: {}
-    })
-
-    eventId = event.id
-
-    session = {
-      determinedReturnsPeriod: {
-        name: 'allYear',
-        dueDate: '2025-04-28',
-        endDate: '2023-03-31',
-        summer: 'false',
-        startDate: '2022-04-01'
-      },
-      journey: 'invitations',
-      referenceCode
-    }
-
     notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
     global.GlobalNotifier = notifierStub
   })
@@ -75,8 +51,357 @@ describe('Notices - Setup - Batch notifications service', () => {
     delete global.GlobalNotifier
   })
 
-  describe('when the batch is successful', () => {
-    beforeEach(() => {
+  describe('when the journey is a return journey', () => {
+    beforeEach(async () => {
+      recipients = RecipientsFixture.recipients()
+
+      testRecipients = [...Object.values(recipients)]
+
+      event = await EventHelper.add({
+        type: 'notification',
+        subtype: 'returnsInvitation',
+        referenceCode,
+        metadata: {}
+      })
+
+      eventId = event.id
+
+      session = {
+        determinedReturnsPeriod: {
+          name: 'allYear',
+          dueDate: '2025-04-28',
+          endDate: '2023-03-31',
+          summer: 'false',
+          startDate: '2022-04-01'
+        },
+        journey: 'invitations',
+        referenceCode
+      }
+    })
+
+    describe('when the batch is successful', () => {
+      beforeEach(() => {
+        _stubSuccessfulNotify({
+          data: {
+            id: '12345',
+            content: {
+              body: 'My dearest margery'
+            }
+          },
+          status: 201,
+          statusText: 'CREATED'
+        })
+      })
+
+      it('should persist the notifications', async () => {
+        await BatchNotificationsService.go(testRecipients, session, eventId)
+
+        const result = await _getNotifications(eventId)
+
+        const [firstMultiple, secondMultiple] = recipients.licenceHolderWithMultipleLicences.licence_refs.split(',')
+
+        expect(result).to.equal([
+          {
+            id: result[0].id,
+            recipient: 'primary.user@important.com',
+            messageType: 'email',
+            messageRef: 'returns_invitation_primary_user_email',
+            personalisation: {
+              periodEndDate: '31 March 2023',
+              returnDueDate: '28 April 2025',
+              periodStartDate: '1 April 2022'
+            },
+            status: 'pending',
+            notifyError: null,
+            licences: [recipients.primaryUser.licence_refs],
+            notifyId: result[0].notifyId,
+            notifyStatus: 'created',
+            plaintext: result[0].plaintext,
+            eventId,
+            createdAt: result[0].createdAt
+          },
+          {
+            id: result[1].id,
+            recipient: 'returns.agent@important.com',
+            messageType: 'email',
+            messageRef: 'returns_invitation_returns_agent_email',
+            personalisation: {
+              periodEndDate: '31 March 2023',
+              returnDueDate: '28 April 2025',
+              periodStartDate: '1 April 2022'
+            },
+            status: 'pending',
+            notifyError: null,
+            licences: [recipients.returnsAgent.licence_refs],
+            notifyId: result[1].notifyId,
+            notifyStatus: 'created',
+            plaintext: result[1].plaintext,
+            eventId,
+            createdAt: result[1].createdAt
+          },
+          {
+            id: result[2].id,
+            recipient: null,
+            messageType: 'letter',
+            messageRef: 'returns_invitation_licence_holder_letter',
+            personalisation: {
+              name: 'Mr H J Licence holder',
+              periodEndDate: '31 March 2023',
+              returnDueDate: '28 April 2025',
+              address_line_1: '1',
+              address_line_2: 'Privet Drive',
+              address_line_3: 'Little Whinging',
+              address_line_4: 'Surrey',
+              address_line_5: 'WD25 7LR',
+              periodStartDate: '1 April 2022'
+            },
+            status: 'pending',
+            notifyError: null,
+            licences: [recipients.licenceHolder.licence_refs],
+            notifyId: result[2].notifyId,
+            notifyStatus: 'created',
+            plaintext: result[2].plaintext,
+            eventId,
+            createdAt: result[2].createdAt
+          },
+          {
+            id: result[3].id,
+            recipient: null,
+            messageType: 'letter',
+            messageRef: 'returns_invitation_returns_to_letter',
+            personalisation: {
+              name: 'Mr H J Returns to',
+              periodEndDate: '31 March 2023',
+              returnDueDate: '28 April 2025',
+              address_line_1: '2',
+              address_line_2: 'Privet Drive',
+              address_line_3: 'Little Whinging',
+              address_line_4: 'Surrey',
+              address_line_5: 'WD25 7LR',
+              periodStartDate: '1 April 2022'
+            },
+            status: 'pending',
+            notifyError: null,
+            licences: [recipients.returnsTo.licence_refs],
+            notifyId: result[3].notifyId,
+            notifyStatus: 'created',
+            plaintext: result[3].plaintext,
+            eventId,
+            createdAt: result[3].createdAt
+          },
+          {
+            id: result[4].id,
+            recipient: null,
+            messageType: 'letter',
+            messageRef: 'returns_invitation_licence_holder_letter',
+            personalisation: {
+              name: 'Mr H J Licence holder with multiple licences',
+              periodEndDate: '31 March 2023',
+              returnDueDate: '28 April 2025',
+              address_line_1: '3',
+              address_line_2: 'Privet Drive',
+              address_line_3: 'Little Whinging',
+              address_line_4: 'Surrey',
+              address_line_5: 'WD25 7LR',
+              periodStartDate: '1 April 2022'
+            },
+            status: 'pending',
+            notifyError: null,
+            licences: [firstMultiple, secondMultiple],
+            notifyId: result[4].notifyId,
+            notifyStatus: 'created',
+            plaintext: result[4].plaintext,
+            eventId,
+            createdAt: result[4].createdAt
+          }
+        ])
+      })
+
+      if (stubNotify) {
+        it('correctly sends the "email" data to Notify', async () => {
+          await BatchNotificationsService.go(testRecipients, session, eventId)
+
+          expect(
+            NotifyClient.prototype.sendEmail.calledWith(
+              '2fa7fc83-4df1-4f52-bccf-ff0faeb12b6f',
+              'primary.user@important.com',
+              {
+                personalisation: {
+                  periodEndDate: '31 March 2023',
+                  periodStartDate: '1 April 2022',
+                  returnDueDate: '28 April 2025'
+                },
+                reference: 'RINV-123'
+              }
+            )
+          ).to.be.true()
+        })
+      }
+      if (stubNotify) {
+        it('correctly sends the "letter" data to Notify', async () => {
+          await BatchNotificationsService.go(testRecipients, session, eventId)
+
+          expect(
+            NotifyClient.prototype.sendLetter.calledWith('4fe80aed-c5dd-44c3-9044-d0289d635019', {
+              personalisation: {
+                address_line_1: '1',
+                address_line_2: 'Privet Drive',
+                address_line_3: 'Little Whinging',
+                address_line_4: 'Surrey',
+                address_line_5: 'WD25 7LR',
+                name: 'Mr H J Licence holder',
+                periodEndDate: '31 March 2023',
+                periodStartDate: '1 April 2022',
+                returnDueDate: '28 April 2025'
+              },
+              reference: 'RINV-123'
+            })
+          ).to.be.true()
+        })
+      }
+    })
+
+    describe('when a call to "notify" is unsuccessful', () => {
+      beforeEach(() => {
+        testRecipients = [
+          {
+            ...recipients.primaryUser,
+            email: 'bad@email'
+          },
+          {
+            ...recipients.returnsAgent
+          }
+        ]
+
+        _stubUnSuccessfulNotify()
+      })
+
+      it('should persist the notifications with the errors', async () => {
+        await BatchNotificationsService.go(testRecipients, session, eventId)
+
+        const result = await _getNotifications(eventId)
+
+        expect(result).to.equal([
+          // This should contain the error
+          {
+            id: result[0].id,
+            recipient: 'bad@email',
+            messageType: 'email',
+            messageRef: 'returns_invitation_primary_user_email',
+            personalisation: {
+              periodEndDate: '31 March 2023',
+              returnDueDate: '28 April 2025',
+              periodStartDate: '1 April 2022'
+            },
+            status: 'error',
+            notifyError:
+              '{"status":400,"message":"Request failed with status code 400","errors":[{"error":"ValidationError","message":"email_address Not a valid email address"}]}',
+            licences: [recipients.primaryUser.licence_refs],
+            notifyId: null,
+            notifyStatus: null,
+            plaintext: null,
+            eventId,
+            createdAt: result[0].createdAt
+          },
+          // notifications without errors should still work
+          {
+            id: result[1].id,
+            recipient: 'returns.agent@important.com',
+            messageType: 'email',
+            messageRef: 'returns_invitation_returns_agent_email',
+            personalisation: {
+              periodEndDate: '31 March 2023',
+              returnDueDate: '28 April 2025',
+              periodStartDate: '1 April 2022'
+            },
+            status: 'pending',
+            notifyError: null,
+            licences: [recipients.returnsAgent.licence_refs],
+            notifyId: result[1].notifyId,
+            notifyStatus: 'created',
+            plaintext: result[1].plaintext,
+            eventId,
+            createdAt: result[1].createdAt
+          }
+        ])
+      })
+
+      it('should update the "event.metadata.error"', async () => {
+        await BatchNotificationsService.go(testRecipients, session, eventId)
+
+        const updatedResult = await EventModel.query().findById(eventId)
+
+        expect(updatedResult.metadata.error).to.equal(1)
+
+        expect(updatedResult).to.equal({
+          createdAt: event.createdAt,
+          entities: null,
+          id: eventId,
+          issuer: 'test.user@defra.gov.uk',
+          licences: null,
+          metadata: {
+            error: 1
+          },
+          referenceCode: 'RINV-123',
+          status: 'start',
+          subtype: 'returnsInvitation',
+          type: 'notification',
+          updatedAt: updatedResult.updatedAt
+        })
+      })
+    })
+  })
+
+  describe('when the journey is "abstraction-alert"', () => {
+    let licenceMonitoringStationOne
+    let licenceMonitoringStationTwo
+
+    beforeEach(async () => {
+      recipients = RecipientsFixture.alertsRecipients()
+
+      testRecipients = [...Object.values(recipients)]
+
+      event = await EventHelper.add({
+        type: 'notification',
+        subtype: 'waterAbstractionAlerts',
+        referenceCode,
+        metadata: {}
+      })
+
+      eventId = event.id
+
+      const abstractionAlertSessionData = AbstractionAlertSessionData.monitoringStation()
+
+      licenceMonitoringStationOne = abstractionAlertSessionData.licenceMonitoringStations[0]
+      licenceMonitoringStationTwo = abstractionAlertSessionData.licenceMonitoringStations[1]
+
+      const relevantLicenceMonitoringStations = [
+        {
+          ...licenceMonitoringStationOne,
+          licence: {
+            licenceRef: recipients.primaryUser.licence_refs
+          }
+        },
+        {
+          ...licenceMonitoringStationTwo,
+          licence: {
+            licenceRef: recipients.licenceHolder.licence_refs
+          }
+        }
+      ]
+
+      session = {
+        ...abstractionAlertSessionData,
+        alertType: 'stop',
+        journey: 'abstraction-alert',
+        name: 'Water abstraction alert',
+        referenceCode: 'WAA-123',
+        relevantLicenceMonitoringStations,
+        removeLicences: [],
+        returnsPeriod: 'quarterFour',
+        subType: 'waterAbstractionAlerts'
+      }
+
       _stubSuccessfulNotify({
         data: {
           id: '12345',
@@ -94,256 +419,86 @@ describe('Notices - Setup - Batch notifications service', () => {
 
       const result = await _getNotifications(eventId)
 
-      const [firstMultiple, secondMultiple] = recipients.licenceHolderWithMultipleLicences.licence_refs.split(',')
-
       expect(result).to.equal([
         {
           id: result[0].id,
-          recipient: 'primary.user@important.com',
+          recipient: 'additional.contact@important.com',
           messageType: 'email',
-          messageRef: 'returns_invitation_primary_user_email',
+          messageRef: 'water_abstraction_alert_reduce_warning_email',
           personalisation: {
-            periodEndDate: '31 March 2023',
-            returnDueDate: '28 April 2025',
-            periodStartDate: '1 April 2022'
+            source: '',
+            licence_ref: '01/19/76/7327',
+            flow_or_level: 'level',
+            condition_text: '',
+            threshold_unit: 'm',
+            threshold_value: 1000,
+            issuer_email_address: '',
+            monitoring_station_name: 'Death star'
           },
           status: 'pending',
           notifyError: null,
-          licences: [recipients.primaryUser.licence_refs],
-          notifyId: result[0].notifyId,
+          licences: [recipients.additionalContact.licence_refs],
+          notifyId: '12345',
           notifyStatus: 'created',
-          plaintext: result[0].plaintext,
+          plaintext: 'My dearest margery',
           eventId,
           createdAt: result[0].createdAt
         },
         {
           id: result[1].id,
-          recipient: 'returns.agent@important.com',
-          messageType: 'email',
-          messageRef: 'returns_invitation_returns_agent_email',
-          personalisation: {
-            periodEndDate: '31 March 2023',
-            returnDueDate: '28 April 2025',
-            periodStartDate: '1 April 2022'
-          },
-          status: 'pending',
-          notifyError: null,
-          licences: [recipients.returnsAgent.licence_refs],
-          notifyId: result[1].notifyId,
-          notifyStatus: 'created',
-          plaintext: result[1].plaintext,
-          eventId,
-          createdAt: result[1].createdAt
-        },
-        {
-          id: result[2].id,
           recipient: null,
           messageType: 'letter',
-          messageRef: 'returns_invitation_licence_holder_letter',
+          messageRef: 'water_abstraction_alert_reduce_warning',
           personalisation: {
             name: 'Mr H J Licence holder',
-            periodEndDate: '31 March 2023',
-            returnDueDate: '28 April 2025',
+            source: '',
+            licence_ref: recipients.additionalContact.licence_refs,
+            flow_or_level: 'flow',
             address_line_1: '1',
             address_line_2: 'Privet Drive',
             address_line_3: 'Little Whinging',
             address_line_4: 'Surrey',
             address_line_5: 'WD25 7LR',
-            periodStartDate: '1 April 2022'
+            condition_text: '',
+            threshold_unit: 'm3/s',
+            threshold_value: 100,
+            issuer_email_address: '',
+            monitoring_station_name: 'Death star'
           },
           status: 'pending',
           notifyError: null,
           licences: [recipients.licenceHolder.licence_refs],
-          notifyId: result[2].notifyId,
+          notifyId: '12345',
           notifyStatus: 'created',
-          plaintext: result[2].plaintext,
-          eventId,
-          createdAt: result[2].createdAt
-        },
-        {
-          id: result[3].id,
-          recipient: null,
-          messageType: 'letter',
-          messageRef: 'returns_invitation_returns_to_letter',
-          personalisation: {
-            name: 'Mr H J Returns to',
-            periodEndDate: '31 March 2023',
-            returnDueDate: '28 April 2025',
-            address_line_1: '2',
-            address_line_2: 'Privet Drive',
-            address_line_3: 'Little Whinging',
-            address_line_4: 'Surrey',
-            address_line_5: 'WD25 7LR',
-            periodStartDate: '1 April 2022'
-          },
-          status: 'pending',
-          notifyError: null,
-          licences: [recipients.returnsTo.licence_refs],
-          notifyId: result[3].notifyId,
-          notifyStatus: 'created',
-          plaintext: result[3].plaintext,
-          eventId,
-          createdAt: result[3].createdAt
-        },
-        {
-          id: result[4].id,
-          recipient: null,
-          messageType: 'letter',
-          messageRef: 'returns_invitation_licence_holder_letter',
-          personalisation: {
-            name: 'Mr H J Licence holder with multiple licences',
-            periodEndDate: '31 March 2023',
-            returnDueDate: '28 April 2025',
-            address_line_1: '3',
-            address_line_2: 'Privet Drive',
-            address_line_3: 'Little Whinging',
-            address_line_4: 'Surrey',
-            address_line_5: 'WD25 7LR',
-            periodStartDate: '1 April 2022'
-          },
-          status: 'pending',
-          notifyError: null,
-          licences: [firstMultiple, secondMultiple],
-          notifyId: result[4].notifyId,
-          notifyStatus: 'created',
-          plaintext: result[4].plaintext,
-          eventId,
-          createdAt: result[4].createdAt
-        }
-      ])
-    })
-
-    if (stubNotify) {
-      it('correctly sends the "email" data to Notify', async () => {
-        await BatchNotificationsService.go(testRecipients, session, eventId)
-
-        expect(
-          NotifyClient.prototype.sendEmail.calledWith(
-            '2fa7fc83-4df1-4f52-bccf-ff0faeb12b6f',
-            'primary.user@important.com',
-            {
-              personalisation: {
-                periodEndDate: '31 March 2023',
-                periodStartDate: '1 April 2022',
-                returnDueDate: '28 April 2025'
-              },
-              reference: 'RINV-123'
-            }
-          )
-        ).to.be.true()
-      })
-    }
-    if (stubNotify) {
-      it('correctly sends the "letter" data to Notify', async () => {
-        await BatchNotificationsService.go(testRecipients, session, eventId)
-
-        expect(
-          NotifyClient.prototype.sendLetter.calledWith('4fe80aed-c5dd-44c3-9044-d0289d635019', {
-            personalisation: {
-              address_line_1: '1',
-              address_line_2: 'Privet Drive',
-              address_line_3: 'Little Whinging',
-              address_line_4: 'Surrey',
-              address_line_5: 'WD25 7LR',
-              name: 'Mr H J Licence holder',
-              periodEndDate: '31 March 2023',
-              periodStartDate: '1 April 2022',
-              returnDueDate: '28 April 2025'
-            },
-            reference: 'RINV-123'
-          })
-        ).to.be.true()
-      })
-    }
-  })
-
-  describe('when a call to "notify" is unsuccessful', () => {
-    beforeEach(() => {
-      testRecipients = [
-        {
-          ...recipients.primaryUser,
-          email: 'bad@email'
-        },
-        {
-          ...recipients.returnsAgent
-        }
-      ]
-
-      _stubUnSuccessfulNotify()
-    })
-
-    it('should persist the notifications with the errors', async () => {
-      await BatchNotificationsService.go(testRecipients, session, eventId)
-
-      const result = await _getNotifications(eventId)
-
-      expect(result).to.equal([
-        // This should contain the error
-        {
-          id: result[0].id,
-          recipient: 'bad@email',
-          messageType: 'email',
-          messageRef: 'returns_invitation_primary_user_email',
-          personalisation: {
-            periodEndDate: '31 March 2023',
-            returnDueDate: '28 April 2025',
-            periodStartDate: '1 April 2022'
-          },
-          status: 'error',
-          notifyError:
-            '{"status":400,"message":"Request failed with status code 400","errors":[{"error":"ValidationError","message":"email_address Not a valid email address"}]}',
-          licences: [recipients.primaryUser.licence_refs],
-          notifyId: null,
-          notifyStatus: null,
-          plaintext: null,
-          eventId,
-          createdAt: result[0].createdAt
-        },
-        // notifications without errors should still work
-        {
-          id: result[1].id,
-          recipient: 'returns.agent@important.com',
-          messageType: 'email',
-          messageRef: 'returns_invitation_returns_agent_email',
-          personalisation: {
-            periodEndDate: '31 March 2023',
-            returnDueDate: '28 April 2025',
-            periodStartDate: '1 April 2022'
-          },
-          status: 'pending',
-          notifyError: null,
-          licences: [recipients.returnsAgent.licence_refs],
-          notifyId: result[1].notifyId,
-          notifyStatus: 'created',
-          plaintext: result[1].plaintext,
+          plaintext: 'My dearest margery',
           eventId,
           createdAt: result[1].createdAt
+        },
+        {
+          id: result[2].id,
+          recipient: 'primary.user@important.com',
+          messageType: 'email',
+          messageRef: 'water_abstraction_alert_reduce_warning_email',
+          personalisation: {
+            source: '',
+            licence_ref: recipients.primaryUser.licence_refs,
+            flow_or_level: 'level',
+            condition_text: '',
+            threshold_unit: 'm',
+            threshold_value: 1000,
+            issuer_email_address: '',
+            monitoring_station_name: 'Death star'
+          },
+          status: 'pending',
+          notifyError: null,
+          licences: [recipients.primaryUser.licence_refs],
+          notifyId: '12345',
+          notifyStatus: 'created',
+          plaintext: 'My dearest margery',
+          eventId,
+          createdAt: result[2].createdAt
         }
       ])
-    })
-
-    it('should update the "event.metadata.error"', async () => {
-      await BatchNotificationsService.go(testRecipients, session, eventId)
-
-      const updatedResult = await EventModel.query().findById(eventId)
-
-      expect(updatedResult.metadata.error).to.equal(1)
-
-      expect(updatedResult).to.equal({
-        createdAt: event.createdAt,
-        entities: null,
-        id: eventId,
-        issuer: 'test.user@defra.gov.uk',
-        licences: null,
-        metadata: {
-          error: 1
-        },
-        referenceCode: 'RINV-123',
-        status: 'start',
-        subtype: 'returnsInvitation',
-        type: 'notification',
-        updatedAt: updatedResult.updatedAt
-      })
     })
   })
 })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5067

We previously implemented the notices journey based on the use of return periods, with the intention of adding abstraction alerts later down the line.

That time has come and we need to adjust some of the existing structures in place to allow us reuse alot of the complex logic.

To do this we will be using the session.journey to trigger any alternative logic to the returns periods.

This means passing the session object around rather than the previous attempt of restricting the session to the submit service.

This change updates the existing presenter to create the personalisation for the notify templates.

They all expect the same data. Some are just structured slight different.

Some personalisation is missing and will be added in a later chang.

To make sure the emails are received the batch notification has been update in this change to allow the abstraction journey to use the correct presenter. This follows our existing strategy using the session.journey