### PR TITLE
Add abstraction alerts download recipients

### DIFF
--- a/app/presenters/notices/setup/abstraction-alerts-download-recipients.presenter.js
+++ b/app/presenters/notices/setup/abstraction-alerts-download-recipients.presenter.js
@@ -42,7 +42,7 @@ const HEADERS = [
  * to an empty string.
  *
  * @param {object[]} recipients - An array of recipients
- * @param {object} session -
+ * @param {SessionModel} session - The session instance
  *
  * @returns {string} - A CSV-formatted string that includes the recipients' data, with the first row as column headers
  * and subsequent rows corresponding to the recipient details.

--- a/app/presenters/notices/setup/abstraction-alerts-download-recipients.presenter.js
+++ b/app/presenters/notices/setup/abstraction-alerts-download-recipients.presenter.js
@@ -1,0 +1,123 @@
+'use strict'
+
+/**
+ * Formats data for the `/notices/setup/download` link when the journey is for 'abstraction-alert'
+ * @module AbstractionAlertDownloadRecipientsPresenter
+ */
+
+const { contactName } = require('../../crm.presenter.js')
+const { formatAbstractionPeriod } = require('../../base.presenter.js')
+const { transformArrayToCSVRow } = require('../../../lib/transform-to-csv.lib.js')
+
+const HEADERS = [
+  'Licence',
+  'Abstraction periods',
+  'Measure type',
+  'Threshold',
+  'Notification type',
+  'Message type',
+  'Contact type',
+  'Email',
+  'Recipient name',
+  'Address line 1',
+  'Address line 2',
+  'Address line 3',
+  'Address line 4',
+  'Address line 5',
+  'Address line 6',
+  'Postcode'
+]
+
+/**
+ * Formats data for the `/notices/setup/download` link when the journey is for 'abstraction-alert'
+ *
+ * A licence monitoring station can share the same licence reference as other stations. As a result, recipients may
+ * receive multiple notifications for the same licence but from different monitoring stations. This leads to duplicate
+ * entries in the recipient list. When generating a CSV download, it reflects the same list of recipients as those who
+ * will be notified.
+ *
+ * The distinguishing factors between these "duplicates" are the measure type and threshold values.
+ *
+ * The headers are fixed and in the correct order. If a value for a row does not match the header then it will default
+ * to an empty string.
+ *
+ * @param {object[]} recipients - An array of recipients
+ * @param {object} session -
+ *
+ * @returns {string} - A CSV-formatted string that includes the recipients' data, with the first row as column headers
+ * and subsequent rows corresponding to the recipient details.
+ */
+function go(recipients, session) {
+  const rows = _transformToCsv(recipients, session)
+
+  return [HEADERS + '\n', ...rows].join('')
+}
+
+function _address(contact) {
+  if (!contact) {
+    return ['', '', '', '', '', '', '']
+  }
+
+  return [
+    contact.addressLine1,
+    contact.addressLine2,
+    contact.addressLine3,
+    contact.addressLine4,
+    contact.town || contact.county,
+    contact.country,
+    contact.postcode
+  ]
+}
+
+function _row(matchingRecipient, licenceMonitoringStation, notificationType) {
+  const { contact } = matchingRecipient
+
+  return [
+    matchingRecipient.licence_refs,
+    formatAbstractionPeriod(
+      licenceMonitoringStation.abstractionPeriodStartDay,
+      licenceMonitoringStation.abstractionPeriodStartMonth,
+      licenceMonitoringStation.abstractionPeriodEndDay,
+      licenceMonitoringStation.abstractionPeriodEndMonth
+    ),
+    licenceMonitoringStation.measureType,
+    `${licenceMonitoringStation.thresholdValue} ${licenceMonitoringStation.thresholdUnit}`,
+    notificationType,
+    contact ? 'letter' : 'email',
+    matchingRecipient.contact_type,
+    matchingRecipient.email || '',
+    contact ? contactName(matchingRecipient.contact) : '',
+    ..._address(contact)
+  ]
+}
+
+/**
+ * Transforms the recipients' data into a CSV-compatible format.
+ *
+ * The order of the properties must match the CSV header order.
+ *
+ * @private
+ */
+function _transformToCsv(recipients, session) {
+  const { relevantLicenceMonitoringStations, notificationType } = session
+
+  const rows = []
+
+  for (const licenceMonitoringStation of relevantLicenceMonitoringStations) {
+    const matchingRecipients = recipients.filter((recipient) => {
+      return recipient.licence_refs === licenceMonitoringStation.licence.licenceRef
+    })
+
+    for (const matchingRecipient of matchingRecipients) {
+      const row = _row(matchingRecipient, licenceMonitoringStation, notificationType)
+
+      rows.push(transformArrayToCSVRow(row))
+    }
+  }
+
+  return rows
+}
+
+module.exports = {
+  go
+}

--- a/app/services/notices/setup/download-recipients.service.js
+++ b/app/services/notices/setup/download-recipients.service.js
@@ -5,7 +5,9 @@
  * @module DownloadRecipientsService
  */
 
+const AbstractionAlertDownloadRecipientsPresenter = require('../../../presenters/notices/setup/abstraction-alerts-download-recipients.presenter.js')
 const DownloadRecipientsPresenter = require('../../../presenters/notices/setup/download-recipients.presenter.js')
+const FetchAbstractionAlertRecipientsService = require('./fetch-abstraction-alert-recipients.service.js')
 const FetchDownloadRecipientsService = require('./fetch-download-recipients.service.js')
 const SessionModel = require('../../../models/session.model.js')
 
@@ -24,9 +26,17 @@ async function go(sessionId) {
 
   const { notificationType, referenceCode } = session
 
-  const recipients = await FetchDownloadRecipientsService.go(session)
+  let formattedData
 
-  const formattedData = DownloadRecipientsPresenter.go(recipients, session.notificationType)
+  if (session.journey === 'abstraction-alert') {
+    const recipients = await FetchAbstractionAlertRecipientsService.go(session)
+
+    formattedData = AbstractionAlertDownloadRecipientsPresenter.go(recipients, session)
+  } else {
+    const recipients = await FetchDownloadRecipientsService.go(session)
+
+    formattedData = DownloadRecipientsPresenter.go(recipients, session.notificationType)
+  }
 
   return {
     data: formattedData,

--- a/test/presenters/notices/setup/abstraction-alert-download-recipients.presenter.test.js
+++ b/test/presenters/notices/setup/abstraction-alert-download-recipients.presenter.test.js
@@ -1,0 +1,200 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Test helpers
+const AbstractionAlertSessionData = require('../../../fixtures/abstraction-alert-session-data.fixture.js')
+const RecipientsFixture = require('../../../fixtures/recipients.fixtures.js')
+
+// Thing under test
+const AbstractionAlertDownloadRecipientsPresenter = require('../../../../app/presenters/notices/setup/abstraction-alerts-download-recipients.presenter.js')
+
+describe('Notices - Setup - Abstraction alert download recipients presenter', () => {
+  let session
+  let recipients
+  let testRecipients
+  let licenceMonitoringStationOne
+  let licenceMonitoringStationTwo
+
+  beforeEach(() => {
+    recipients = RecipientsFixture.alertsRecipients()
+
+    testRecipients = [...Object.values(recipients)]
+
+    const abstractionAlertSessionData = AbstractionAlertSessionData.monitoringStation()
+
+    licenceMonitoringStationOne = abstractionAlertSessionData.licenceMonitoringStations[0]
+    licenceMonitoringStationTwo = abstractionAlertSessionData.licenceMonitoringStations[1]
+
+    const relevantLicenceMonitoringStations = [
+      {
+        ...licenceMonitoringStationOne,
+        licence: {
+          licenceRef: recipients.primaryUser.licence_refs
+        }
+      },
+      {
+        ...licenceMonitoringStationTwo,
+        licence: {
+          licenceRef: recipients.licenceHolder.licence_refs
+        }
+      }
+    ]
+
+    session = {
+      relevantLicenceMonitoringStations,
+      notificationType: 'Abstraction alert'
+    }
+  })
+
+  it('correctly formats the data to a csv string', () => {
+    const result = AbstractionAlertDownloadRecipientsPresenter.go(testRecipients, session)
+
+    expect(result).to.equal(
+      // Headers
+      'Licence,Abstraction periods,Measure type,Threshold,Notification type,Message type,Contact type,Email,Recipient name,Address line 1,Address line 2,Address line 3,Address line 4,Address line 5,Address line 6,Postcode\n' +
+        // Row - Additional contact
+        `"${recipients.primaryUser.licence_refs}","1 February to 1 January","level","1000 m","Abstraction alert","email","Additional contact","additional.contact@important.com",,,,,,,,\n` +
+        // Row - Primary user
+        `"${recipients.primaryUser.licence_refs}","1 February to 1 January","level","1000 m","Abstraction alert","email","Primary user","primary.user@important.com",,,,,,,,\n` +
+        // Row - Licence holder
+        `"${recipients.licenceHolder.licence_refs}","1 January to 31 March","flow","100 m3/s","Abstraction alert","letter","Licence holder",,"Mr H J Licence holder","1","Privet Drive",,,"Little Whinging",,"WD25 7LR"\n`
+    )
+  })
+
+  it('correctly formats the headers', () => {
+    const result = AbstractionAlertDownloadRecipientsPresenter.go(testRecipients, session)
+
+    let [headers] = result.split('\n')
+    // We want to test the header includes the new line
+    headers += '\n'
+
+    expect(headers).to.equal(
+      'Licence,' +
+        'Abstraction periods,' +
+        'Measure type,' +
+        'Threshold,' +
+        'Notification type,' +
+        'Message type,' +
+        'Contact type,' +
+        'Email,' +
+        'Recipient name,' +
+        'Address line 1,' +
+        'Address line 2,' +
+        'Address line 3,' +
+        'Address line 4,' +
+        'Address line 5,' +
+        'Address line 6,' +
+        'Postcode' +
+        '\n'
+    )
+  })
+
+  describe('when the recipient is a "primary_user"', () => {
+    it('correctly formats the row', () => {
+      const result = AbstractionAlertDownloadRecipientsPresenter.go([recipients.primaryUser], session)
+
+      let [, row] = result.split('\n')
+      // We want to test the row includes the new line
+      row += '\n'
+
+      expect(row).to.equal(
+        `"${recipients.additionalContact.licence_refs}",` + // Licence
+          '"1 February to 1 January",' + // 'Abstraction periods'
+          '"level",' + // 'Measure type'
+          '"1000 m",' + // 'Threshold'
+          '"Abstraction alert",' + // 'Notification type'
+          '"email",' + // 'Message type'
+          '"Primary user",' + // 'Contact type'
+          '"primary.user@important.com",' + // Email
+          ',' + // 'Recipient name''
+          ',' + // 'Address line 1'
+          ',' + // 'Address line 2'
+          ',' + // 'Address line 3'
+          ',' + // 'Address line 4'
+          ',' + // 'Address line 5'
+          ',' + // 'Address line 6'
+          '\n' // Postcode and End of CSV line
+      )
+    })
+  })
+
+  describe('when the recipient is a "licence holder"', () => {
+    describe('and the "contact" is a "person"', () => {
+      it('correctly formats the row', () => {
+        const result = AbstractionAlertDownloadRecipientsPresenter.go([recipients.licenceHolder], session)
+
+        let [, row] = result.split('\n')
+        // We want to test the row includes the new line
+        row += '\n'
+
+        expect(row).to.equal(
+          `"${recipients.licenceHolder.licence_refs}",` + // Licence
+            '"1 January to 31 March",' + // 'Abstraction periods'
+            '"flow",' + // 'Measure type'
+            '"100 m3/s",' + // 'Threshold'
+            '"Abstraction alert",' + // 'Notification type'
+            '"letter",' + // 'Message type'
+            '"Licence holder",' + // 'Contact type'
+            ',' + // Email
+            '"Mr H J Licence holder",' + // 'Recipient name''
+            '"1",' + // 'Address line 1'
+            '"Privet Drive",' + // 'Address line 2'
+            ',' + // 'Address line 3'
+            ',' + // 'Address line 4'
+            '"Little Whinging",' + // 'Address line 5' - town
+            ',' + // 'Address line 6' - country
+            '"WD25 7LR"' + // Postcode
+            '\n' // End of CSV line
+        )
+      })
+    })
+
+    describe('and the "contact" is a "organisation"', () => {
+      it('correctly formats the row', () => {
+        const result = AbstractionAlertDownloadRecipientsPresenter.go(
+          [
+            {
+              ...recipients.licenceHolder,
+              contact: {
+                ...recipients.licenceHolder.contact,
+                type: 'Organisation',
+                name: 'Gringotts'
+              }
+            }
+          ],
+          session
+        )
+
+        let [, row] = result.split('\n')
+        // We want to test the row includes the new line
+        row += '\n'
+
+        expect(row).to.equal(
+          `"${recipients.licenceHolder.licence_refs}",` + // Licence
+            '"1 January to 31 March",' + // 'Abstraction periods'
+            '"flow",' + // 'Measure type'
+            '"100 m3/s",' + // 'Threshold'
+            '"Abstraction alert",' + // 'Notification type'
+            '"letter",' + // 'Message type'
+            '"Licence holder",' + // 'Contact type'
+            ',' + // Email
+            '"Gringotts",' + // 'Recipient name''
+            '"1",' + // 'Address line 1'
+            '"Privet Drive",' + // 'Address line 2'
+            ',' + // 'Address line 3'
+            ',' + // 'Address line 4'
+            '"Little Whinging",' + // 'Address line 5' - town
+            ',' + // 'Address line 6' - country
+            '"WD25 7LR"' + // Postcode
+            '\n' // End of CSV line
+        )
+      })
+    })
+  })
+})


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5065

We have existing logic to allow the recipients to be downloaded for the returns journey. We can not reuse the existing fetch and presenter logic.

But we can use the same fetch we are using for to render the recipients.

This change adds the presenter to format the csv for the abstraction alerts download link.

The download recipients service has been update to trigger this presenter (and use the correct fetch). This has been done by using the session journey as the trigger. This is the same pattern we have used to tie th abstraction alerts into existing recipients journey.

A licence monitoring station can share the same licence reference as other stations. As a result, recipients may receive multiple notifications for the same licence but from different monitoring stations. This leads to duplicate entries in the recipient list. When generating a CSV download, it reflects the same list of recipients as those who will be notified.