### PR TITLE
Update abstraction alert fixture

### DIFF
--- a/test/fixtures/abstraction-alert-session-data.fixture.js
+++ b/test/fixtures/abstraction-alert-session-data.fixture.js
@@ -3,9 +3,14 @@
 const { generateLicenceRef } = require('../support/helpers/licence.helper.js')
 const { generateUUID } = require('../../app/lib/general.lib.js')
 
+/**
+ * Create licence monitoring station test data
+ *
+ * @returns {object} - Returns three unique licence monitoring stations
+ */
 function licenceMonitoringStations() {
-  return [
-    {
+  return {
+    one: {
       abstractionPeriodEndDay: 1,
       abstractionPeriodEndMonth: 1,
       abstractionPeriodStartDay: 1,
@@ -23,7 +28,7 @@ function licenceMonitoringStations() {
       thresholdUnit: 'm',
       thresholdValue: 1000
     },
-    {
+    two: {
       abstractionPeriodEndDay: 31,
       abstractionPeriodEndMonth: 3,
       abstractionPeriodStartDay: 1,
@@ -41,7 +46,7 @@ function licenceMonitoringStations() {
       thresholdUnit: 'm3/s',
       thresholdValue: 100
     },
-    {
+    three: {
       abstractionPeriodEndDay: 31,
       abstractionPeriodEndMonth: 3,
       abstractionPeriodStartDay: 1,
@@ -59,7 +64,7 @@ function licenceMonitoringStations() {
       thresholdUnit: 'm',
       thresholdValue: 100
     }
-  ]
+  }
 }
 
 /**
@@ -67,16 +72,45 @@ function licenceMonitoringStations() {
  *
  * We do not use the fetch service for the fixture as we format the data to be in a usable state for the session
  *
+ * @param {object[]} [_licenceMonitoringStations] - override the default licenceMonitoringStations
+ *
  * @returns {object} an object representing the monitoring stations service
  */
-function monitoringStation() {
+function get(_licenceMonitoringStations) {
+  const lms = _licenceMonitoringStations || licenceMonitoringStations()
+
   return {
-    licenceMonitoringStations: licenceMonitoringStations(),
+    licenceMonitoringStations: [...Object.values(lms)],
     monitoringStationId: generateUUID(),
     monitoringStationName: 'Death star'
   }
 }
 
+/**
+ * Relevant licence monitoring stations are licence monitoring stations selected by the user to receive alert
+ * notifications.
+ *
+ * This is a necessary complexity to the test setup. Each test was previously creating this array of relevant
+ * licence monitoring stations. This helper function should simplify the test setup.
+ *
+ * We mainly need to map licence monitoring stations to recipients. This is done through matching the licence ref.
+ *
+ * @param {string[]} licenceRefs
+ *
+ * @returns {object[]} an array of the licence monitoring station
+ */
+function relevantLicenceMonitoringStations(licenceRefs) {
+  const lms = [...Object.values(licenceMonitoringStations())]
+
+  for (let i = 0; i < licenceRefs.length; i++) {
+    lms[i].licence.licenceRef = licenceRefs[i]
+  }
+
+  return lms
+}
+
 module.exports = {
-  monitoringStation
+  get,
+  licenceMonitoringStations,
+  relevantLicenceMonitoringStations
 }

--- a/test/presenters/notices/setup/abstraction-alert-notifications.presenter.test.js
+++ b/test/presenters/notices/setup/abstraction-alert-notifications.presenter.test.js
@@ -20,36 +20,19 @@ describe('Notices - Setup - Abstraction alert notifications presenter', () => {
   const eventId = 'c1cae668-3dad-4806-94e2-eb3f27222ed9'
 
   let clock
-  let session
   let recipients
+  let session
   let testRecipients
-  let licenceMonitoringStationOne
-  let licenceMonitoringStationTwo
 
   beforeEach(() => {
     recipients = RecipientsFixture.alertsRecipients()
 
     testRecipients = [...Object.values(recipients)]
 
-    const abstractionAlertSessionData = AbstractionAlertSessionData.monitoringStation()
-
-    licenceMonitoringStationOne = abstractionAlertSessionData.licenceMonitoringStations[0]
-    licenceMonitoringStationTwo = abstractionAlertSessionData.licenceMonitoringStations[1]
-
-    const relevantLicenceMonitoringStations = [
-      {
-        ...licenceMonitoringStationOne,
-        licence: {
-          licenceRef: recipients.primaryUser.licence_refs
-        }
-      },
-      {
-        ...licenceMonitoringStationTwo,
-        licence: {
-          licenceRef: recipients.licenceHolder.licence_refs
-        }
-      }
-    ]
+    const relevantLicenceMonitoringStations = AbstractionAlertSessionData.relevantLicenceMonitoringStations([
+      recipients.primaryUser.licence_refs,
+      recipients.licenceHolder.licence_refs
+    ])
 
     session = {
       journey: 'abstraction-alerts',
@@ -112,25 +95,10 @@ describe('Notices - Setup - Abstraction alert notifications presenter', () => {
 
   describe('when a licence has more than one licence monitoring stations to send alerts to', () => {
     beforeEach(() => {
-      const abstractionAlertSessionData = AbstractionAlertSessionData.monitoringStation()
-
-      licenceMonitoringStationOne = abstractionAlertSessionData.licenceMonitoringStations[0]
-      licenceMonitoringStationTwo = abstractionAlertSessionData.licenceMonitoringStations[1]
-
-      const relevantLicenceMonitoringStations = [
-        {
-          ...licenceMonitoringStationOne,
-          licence: {
-            licenceRef: recipients.primaryUser.licence_refs
-          }
-        },
-        {
-          ...licenceMonitoringStationTwo,
-          licence: {
-            licenceRef: recipients.primaryUser.licence_refs
-          }
-        }
-      ]
+      const relevantLicenceMonitoringStations = AbstractionAlertSessionData.relevantLicenceMonitoringStations([
+        recipients.primaryUser.licence_refs,
+        recipients.primaryUser.licence_refs
+      ])
 
       session = {
         journey: 'abstraction-alerts',
@@ -193,14 +161,9 @@ describe('Notices - Setup - Abstraction alert notifications presenter', () => {
 
   describe('when a "primaryUser" has abstraction alerts', () => {
     beforeEach(() => {
-      session.relevantLicenceMonitoringStations = [
-        {
-          ...licenceMonitoringStationOne,
-          licence: {
-            licenceRef: recipients.primaryUser.licence_refs
-          }
-        }
-      ]
+      session.relevantLicenceMonitoringStations = AbstractionAlertSessionData.relevantLicenceMonitoringStations([
+        recipients.primaryUser.licence_refs
+      ])
 
       testRecipients[0].licence_refs = recipients.licenceHolder.licence_refs
     })
@@ -261,14 +224,9 @@ describe('Notices - Setup - Abstraction alert notifications presenter', () => {
 
   describe('when a "licenceHolder" has abstraction alerts', () => {
     beforeEach(() => {
-      session.relevantLicenceMonitoringStations = [
-        {
-          ...licenceMonitoringStationTwo,
-          licence: {
-            licenceRef: recipients.licenceHolder.licence_refs
-          }
-        }
-      ]
+      session.relevantLicenceMonitoringStations = AbstractionAlertSessionData.relevantLicenceMonitoringStations([
+        recipients.licenceHolder.licence_refs
+      ])
     })
 
     it('correctly transform the recipients (and associated licence monitoring stations) into notifications', () => {

--- a/test/presenters/notices/setup/abstraction-alerts/alert-email-address.presenter.test.js
+++ b/test/presenters/notices/setup/abstraction-alerts/alert-email-address.presenter.test.js
@@ -26,7 +26,7 @@ describe('Alert Email Address Presenter', () => {
       }
     }
 
-    session = AbstractionAlertSessionData.monitoringStation()
+    session = AbstractionAlertSessionData.get()
   })
 
   describe('when called', () => {

--- a/test/presenters/notices/setup/abstraction-alerts/alert-thresholds.presenter.test.js
+++ b/test/presenters/notices/setup/abstraction-alerts/alert-thresholds.presenter.test.js
@@ -14,20 +14,16 @@ const AbstractionAlertSessionData = require('../../../../fixtures/abstraction-al
 const AlertThresholdsPresenter = require('../../../../../app/presenters/notices/setup/abstraction-alerts/alert-thresholds.presenter.js')
 
 describe('Notices Setup - Abstraction Alerts - Alert Thresholds Presenter', () => {
-  let licenceMonitoringStationOne
-  let licenceMonitoringStationThree
-  let licenceMonitoringStationTwo
+  let licenceMonitoringStations
   let session
 
   beforeEach(() => {
+    licenceMonitoringStations = AbstractionAlertSessionData.licenceMonitoringStations()
+
     session = {
-      ...AbstractionAlertSessionData.monitoringStation(),
+      ...AbstractionAlertSessionData.get(licenceMonitoringStations),
       alertType: 'stop'
     }
-
-    licenceMonitoringStationOne = session.licenceMonitoringStations[0].thresholdGroup
-    licenceMonitoringStationTwo = session.licenceMonitoringStations[1].thresholdGroup
-    licenceMonitoringStationThree = session.licenceMonitoringStations[2].thresholdGroup
   })
 
   describe('when called', () => {
@@ -45,7 +41,7 @@ describe('Notices Setup - Abstraction Alerts - Alert Thresholds Presenter', () =
               text: 'Flow threshold'
             },
             text: '100 m3/s',
-            value: licenceMonitoringStationTwo
+            value: licenceMonitoringStations.two.thresholdGroup
           },
           {
             checked: false,
@@ -53,7 +49,7 @@ describe('Notices Setup - Abstraction Alerts - Alert Thresholds Presenter', () =
               text: 'Level threshold'
             },
             text: '100 m',
-            value: licenceMonitoringStationThree
+            value: licenceMonitoringStations.three.thresholdGroup
           }
         ]
       })
@@ -62,11 +58,7 @@ describe('Notices Setup - Abstraction Alerts - Alert Thresholds Presenter', () =
     describe('the "thresholdOptions" property', () => {
       describe('when there are already selected thresholds', () => {
         beforeEach(() => {
-          session = {
-            ...AbstractionAlertSessionData.monitoringStation(),
-            alertThresholds: [licenceMonitoringStationTwo],
-            alertType: 'stop'
-          }
+          session.alertThresholds = [licenceMonitoringStations.two.thresholdGroup]
         })
 
         it('returns page data for the view, with the thresholds checked', () => {
@@ -75,13 +67,13 @@ describe('Notices Setup - Abstraction Alerts - Alert Thresholds Presenter', () =
           expect(result.thresholdOptions).to.equal([
             {
               checked: true,
-              value: licenceMonitoringStationTwo,
+              value: licenceMonitoringStations.two.thresholdGroup,
               text: '100 m3/s',
               hint: { text: 'Flow threshold' }
             },
             {
               checked: false,
-              value: licenceMonitoringStationThree,
+              value: licenceMonitoringStations.three.thresholdGroup,
               text: '100 m',
               hint: { text: 'Level threshold' }
             }
@@ -91,10 +83,7 @@ describe('Notices Setup - Abstraction Alerts - Alert Thresholds Presenter', () =
 
       describe('and the "alertType" is "stop" ', () => {
         beforeEach(() => {
-          session = {
-            ...AbstractionAlertSessionData.monitoringStation(),
-            alertType: 'stop'
-          }
+          session.alertType = 'stop'
         })
 
         it('returns page data for the view, with only the thresholds with stop restrictions', () => {
@@ -103,13 +92,13 @@ describe('Notices Setup - Abstraction Alerts - Alert Thresholds Presenter', () =
           expect(result.thresholdOptions).to.equal([
             {
               checked: false,
-              value: licenceMonitoringStationTwo,
+              value: licenceMonitoringStations.two.thresholdGroup,
               text: '100 m3/s',
               hint: { text: 'Flow threshold' }
             },
             {
               checked: false,
-              value: licenceMonitoringStationThree,
+              value: licenceMonitoringStations.three.thresholdGroup,
               text: '100 m',
               hint: { text: 'Level threshold' }
             }
@@ -118,8 +107,8 @@ describe('Notices Setup - Abstraction Alerts - Alert Thresholds Presenter', () =
 
         describe('and a licence monitoring station is "stop_or_reduce" ', () => {
           beforeEach(() => {
-            session.licenceMonitoringStations[1].responseType = 'stop_or_reduce'
-            session.licenceMonitoringStations[2].responseType = 'stop'
+            licenceMonitoringStations.two.responseType = 'stop_or_reduce'
+            licenceMonitoringStations.three.responseType = 'stop'
           })
 
           it('returns page data for the view, with only the thresholds with reduce restrictions', () => {
@@ -128,13 +117,13 @@ describe('Notices Setup - Abstraction Alerts - Alert Thresholds Presenter', () =
             expect(result.thresholdOptions).to.equal([
               {
                 checked: false,
-                value: licenceMonitoringStationTwo,
+                value: licenceMonitoringStations.two.thresholdGroup,
                 text: '100 m3/s',
                 hint: { text: 'Flow threshold' }
               },
               {
                 checked: false,
-                value: licenceMonitoringStationThree,
+                value: licenceMonitoringStations.three.thresholdGroup,
                 text: '100 m',
                 hint: { text: 'Level threshold' }
               }
@@ -145,10 +134,7 @@ describe('Notices Setup - Abstraction Alerts - Alert Thresholds Presenter', () =
 
       describe('and the "alertType" is "reduce" ', () => {
         beforeEach(() => {
-          session = {
-            ...AbstractionAlertSessionData.monitoringStation(),
-            alertType: 'reduce'
-          }
+          session.alertType = 'reduce'
         })
 
         it('returns page data for the view, with only the thresholds with reduce restrictions', () => {
@@ -157,7 +143,7 @@ describe('Notices Setup - Abstraction Alerts - Alert Thresholds Presenter', () =
           expect(result.thresholdOptions).to.equal([
             {
               checked: false,
-              value: licenceMonitoringStationOne,
+              value: licenceMonitoringStations.one.thresholdGroup,
               text: '1000 m',
               hint: { text: 'Level threshold' }
             }
@@ -167,9 +153,8 @@ describe('Notices Setup - Abstraction Alerts - Alert Thresholds Presenter', () =
 
       describe('"and the alert type is not "stop" or "reduce"', () => {
         beforeEach(() => {
-          session = {
-            ...AbstractionAlertSessionData.monitoringStation()
-          }
+          // This could be 'resume' or 'warning'
+          delete session.alertType
         })
 
         it('returns page data for the view, with all the thresholds', () => {
@@ -178,19 +163,19 @@ describe('Notices Setup - Abstraction Alerts - Alert Thresholds Presenter', () =
           expect(result.thresholdOptions).to.equal([
             {
               checked: false,
-              value: licenceMonitoringStationOne,
+              value: licenceMonitoringStations.one.thresholdGroup,
               text: '1000 m',
               hint: { text: 'Level threshold' }
             },
             {
               checked: false,
-              value: licenceMonitoringStationTwo,
+              value: licenceMonitoringStations.two.thresholdGroup,
               text: '100 m3/s',
               hint: { text: 'Flow threshold' }
             },
             {
               checked: false,
-              value: licenceMonitoringStationThree,
+              value: licenceMonitoringStations.three.thresholdGroup,
               text: '100 m',
               hint: { text: 'Level threshold' }
             }

--- a/test/presenters/notices/setup/abstraction-alerts/alert-type.presenter.test.js
+++ b/test/presenters/notices/setup/abstraction-alerts/alert-type.presenter.test.js
@@ -17,7 +17,7 @@ describe('Notices - Setup - Abstraction Alerts - Alert Type Presenter', () => {
   let sessionData
 
   beforeEach(async () => {
-    sessionData = AbstractionAlertSessionData.monitoringStation()
+    sessionData = AbstractionAlertSessionData.get()
   })
 
   describe('when called', () => {

--- a/test/presenters/notices/setup/abstraction-alerts/cancel-alerts.presenter.test.js
+++ b/test/presenters/notices/setup/abstraction-alerts/cancel-alerts.presenter.test.js
@@ -18,7 +18,7 @@ describe('Cancel Alerts Presenter', () => {
 
   beforeEach(() => {
     session = {
-      ...AbstractionAlertSessionData.monitoringStation(),
+      ...AbstractionAlertSessionData.get(),
       alertType: 'resume'
     }
   })

--- a/test/presenters/notices/setup/abstraction-alerts/check-licence-matches.presenter.test.js
+++ b/test/presenters/notices/setup/abstraction-alerts/check-licence-matches.presenter.test.js
@@ -14,23 +14,20 @@ const AbstractionAlertSessionData = require('../../../../fixtures/abstraction-al
 const CheckLicenceMatchesPresenter = require('../../../../../app/presenters/notices/setup/abstraction-alerts/check-licence-matches.presenter.js')
 
 describe('Notices Setup - Abstraction Alerts - Check Licence Matches Presenter', () => {
-  let licenceMonitoringStationOne
-  let licenceMonitoringStationThree
-  let licenceMonitoringStationTwo
+  let licenceMonitoringStations
   let session
 
   beforeEach(async () => {
-    const abstractionAlertSessionData = AbstractionAlertSessionData.monitoringStation()
-    licenceMonitoringStationOne = abstractionAlertSessionData.licenceMonitoringStations[0]
-    licenceMonitoringStationTwo = abstractionAlertSessionData.licenceMonitoringStations[1]
-    licenceMonitoringStationThree = abstractionAlertSessionData.licenceMonitoringStations[2]
+    licenceMonitoringStations = AbstractionAlertSessionData.licenceMonitoringStations()
+
+    const abstractionAlertSessionData = AbstractionAlertSessionData.get(licenceMonitoringStations)
 
     session = {
       ...abstractionAlertSessionData,
       alertThresholds: [
-        licenceMonitoringStationOne.thresholdGroup,
-        licenceMonitoringStationTwo.thresholdGroup,
-        licenceMonitoringStationThree.thresholdGroup
+        licenceMonitoringStations.one.thresholdGroup,
+        licenceMonitoringStations.two.thresholdGroup,
+        licenceMonitoringStations.three.thresholdGroup
       ]
     }
   })
@@ -49,13 +46,13 @@ describe('Notices Setup - Abstraction Alerts - Check Licence Matches Presenter',
           {
             abstractionPeriod: '1 February to 1 January',
             action: {
-              link: `/system/notices/setup/${session.id}/abstraction-alerts/remove-threshold/${licenceMonitoringStationOne.id}`,
+              link: `/system/notices/setup/${session.id}/abstraction-alerts/remove-threshold/${licenceMonitoringStations.one.id}`,
               text: 'Remove'
             },
             alert: null,
             alertDate: null,
-            licenceId: licenceMonitoringStationOne.licence.id,
-            licenceRef: licenceMonitoringStationOne.licence.licenceRef,
+            licenceId: licenceMonitoringStations.one.licence.id,
+            licenceRef: licenceMonitoringStations.one.licence.licenceRef,
             restriction: 'Reduce',
             restrictionCount: 1,
             threshold: '1000 m'
@@ -63,13 +60,13 @@ describe('Notices Setup - Abstraction Alerts - Check Licence Matches Presenter',
           {
             abstractionPeriod: '1 January to 31 March',
             action: {
-              link: `/system/notices/setup/${session.id}/abstraction-alerts/remove-threshold/${licenceMonitoringStationTwo.id}`,
+              link: `/system/notices/setup/${session.id}/abstraction-alerts/remove-threshold/${licenceMonitoringStations.two.id}`,
               text: 'Remove'
             },
             alert: null,
             alertDate: null,
-            licenceId: licenceMonitoringStationTwo.licence.id,
-            licenceRef: licenceMonitoringStationTwo.licence.licenceRef,
+            licenceId: licenceMonitoringStations.two.licence.id,
+            licenceRef: licenceMonitoringStations.two.licence.licenceRef,
             restriction: 'Stop',
             restrictionCount: 1,
             threshold: '100 m3/s'
@@ -77,13 +74,13 @@ describe('Notices Setup - Abstraction Alerts - Check Licence Matches Presenter',
           {
             abstractionPeriod: '1 January to 31 March',
             action: {
-              link: `/system/notices/setup/${session.id}/abstraction-alerts/remove-threshold/${licenceMonitoringStationThree.id}`,
+              link: `/system/notices/setup/${session.id}/abstraction-alerts/remove-threshold/${licenceMonitoringStations.three.id}`,
               text: 'Remove'
             },
             alert: null,
             alertDate: null,
-            licenceId: licenceMonitoringStationThree.licence.id,
-            licenceRef: licenceMonitoringStationThree.licence.licenceRef,
+            licenceId: licenceMonitoringStations.three.licence.id,
+            licenceRef: licenceMonitoringStations.three.licence.licenceRef,
             restriction: 'Stop',
             restrictionCount: 1,
             threshold: '100 m'
@@ -100,13 +97,13 @@ describe('Notices Setup - Abstraction Alerts - Check Licence Matches Presenter',
           expect(result.restrictions[0]).to.equal({
             abstractionPeriod: '1 February to 1 January',
             action: {
-              link: `/system/notices/setup/${session.id}/abstraction-alerts/remove-threshold/${licenceMonitoringStationOne.id}`,
+              link: `/system/notices/setup/${session.id}/abstraction-alerts/remove-threshold/${licenceMonitoringStations.one.id}`,
               text: 'Remove'
             },
             alert: null,
             alertDate: null,
-            licenceId: licenceMonitoringStationOne.licence.id,
-            licenceRef: licenceMonitoringStationOne.licence.licenceRef,
+            licenceId: licenceMonitoringStations.one.licence.id,
+            licenceRef: licenceMonitoringStations.one.licence.licenceRef,
             restriction: 'Reduce',
             restrictionCount: 1,
             threshold: '1000 m'
@@ -118,7 +115,7 @@ describe('Notices Setup - Abstraction Alerts - Check Licence Matches Presenter',
             const result = CheckLicenceMatchesPresenter.go(session)
 
             expect(result.restrictions[0].action).to.equal({
-              link: `/system/notices/setup/${session.id}/abstraction-alerts/remove-threshold/${licenceMonitoringStationOne.id}`,
+              link: `/system/notices/setup/${session.id}/abstraction-alerts/remove-threshold/${licenceMonitoringStations.one.id}`,
               text: 'Remove'
             })
           })
@@ -151,7 +148,7 @@ describe('Notices Setup - Abstraction Alerts - Check Licence Matches Presenter',
 
         describe('when there are thresholds removed from the list', () => {
           beforeEach(() => {
-            session.removedThresholds = [licenceMonitoringStationOne.id]
+            session.removedThresholds = [licenceMonitoringStations.one.id]
           })
 
           it('returns only the thresholds previously selected and not removed', () => {
@@ -163,13 +160,13 @@ describe('Notices Setup - Abstraction Alerts - Check Licence Matches Presenter',
               {
                 abstractionPeriod: '1 January to 31 March',
                 action: {
-                  link: `/system/notices/setup/${session.id}/abstraction-alerts/remove-threshold/${licenceMonitoringStationTwo.id}`,
+                  link: `/system/notices/setup/${session.id}/abstraction-alerts/remove-threshold/${licenceMonitoringStations.two.id}`,
                   text: 'Remove'
                 },
                 alert: null,
                 alertDate: null,
-                licenceId: licenceMonitoringStationTwo.licence.id,
-                licenceRef: licenceMonitoringStationTwo.licence.licenceRef,
+                licenceId: licenceMonitoringStations.two.licence.id,
+                licenceRef: licenceMonitoringStations.two.licence.licenceRef,
                 restriction: 'Stop',
                 restrictionCount: 1,
                 threshold: '100 m3/s'
@@ -177,13 +174,13 @@ describe('Notices Setup - Abstraction Alerts - Check Licence Matches Presenter',
               {
                 abstractionPeriod: '1 January to 31 March',
                 action: {
-                  link: `/system/notices/setup/${session.id}/abstraction-alerts/remove-threshold/${licenceMonitoringStationThree.id}`,
+                  link: `/system/notices/setup/${session.id}/abstraction-alerts/remove-threshold/${licenceMonitoringStations.three.id}`,
                   text: 'Remove'
                 },
                 alert: null,
                 alertDate: null,
-                licenceId: licenceMonitoringStationThree.licence.id,
-                licenceRef: licenceMonitoringStationThree.licence.licenceRef,
+                licenceId: licenceMonitoringStations.three.licence.id,
+                licenceRef: licenceMonitoringStations.three.licence.licenceRef,
                 restriction: 'Stop',
                 restrictionCount: 1,
                 threshold: '100 m'
@@ -193,7 +190,7 @@ describe('Notices Setup - Abstraction Alerts - Check Licence Matches Presenter',
 
           describe('when there is only one threshold left to display', () => {
             beforeEach(() => {
-              session.removedThresholds = [licenceMonitoringStationOne.id, licenceMonitoringStationTwo.id]
+              session.removedThresholds = [licenceMonitoringStations.one.id, licenceMonitoringStations.two.id]
             })
 
             it('should not show any remove links for the remaining restriction', () => {
@@ -205,8 +202,8 @@ describe('Notices Setup - Abstraction Alerts - Check Licence Matches Presenter',
                   action: null,
                   alert: null,
                   alertDate: null,
-                  licenceId: licenceMonitoringStationThree.licence.id,
-                  licenceRef: licenceMonitoringStationThree.licence.licenceRef,
+                  licenceId: licenceMonitoringStations.three.licence.id,
+                  licenceRef: licenceMonitoringStations.three.licence.licenceRef,
                   restriction: 'Stop',
                   restrictionCount: 1,
                   threshold: '100 m'

--- a/test/services/notices/setup/abstraction-alerts/alert-email-address.service.test.js
+++ b/test/services/notices/setup/abstraction-alerts/alert-email-address.service.test.js
@@ -28,7 +28,7 @@ describe('Alert Email Address Service', () => {
       }
     }
 
-    sessionData = AbstractionAlertSessionData.monitoringStation()
+    sessionData = AbstractionAlertSessionData.get()
     session = await SessionHelper.add({ data: sessionData })
   })
 

--- a/test/services/notices/setup/abstraction-alerts/alert-thresholds.service.test.js
+++ b/test/services/notices/setup/abstraction-alerts/alert-thresholds.service.test.js
@@ -15,19 +15,17 @@ const SessionHelper = require('../../../../support/helpers/session.helper.js')
 const AlertThresholdsService = require('../../../../../app/services/notices/setup/abstraction-alerts/alert-thresholds.service.js')
 
 describe('Notices Setup - Abstraction Alerts - Alert Thresholds Service', () => {
-  let alertThresholdGroupOne
-  let alertThresholdGroupTwo
   let session
   let sessionData
+  let licenceMonitoringStations
 
   beforeEach(async () => {
+    licenceMonitoringStations = AbstractionAlertSessionData.licenceMonitoringStations()
+
     sessionData = {
-      ...AbstractionAlertSessionData.monitoringStation(),
+      ...AbstractionAlertSessionData.get(licenceMonitoringStations),
       alertType: 'stop'
     }
-
-    alertThresholdGroupOne = sessionData.licenceMonitoringStations[1].thresholdGroup
-    alertThresholdGroupTwo = sessionData.licenceMonitoringStations[2].thresholdGroup
 
     session = await SessionHelper.add({ data: sessionData })
   })
@@ -48,7 +46,7 @@ describe('Notices Setup - Abstraction Alerts - Alert Thresholds Service', () => 
               text: 'Flow threshold'
             },
             text: '100 m3/s',
-            value: alertThresholdGroupOne
+            value: licenceMonitoringStations.two.thresholdGroup
           },
           {
             checked: false,
@@ -56,7 +54,7 @@ describe('Notices Setup - Abstraction Alerts - Alert Thresholds Service', () => 
               text: 'Level threshold'
             },
             text: '100 m',
-            value: alertThresholdGroupTwo
+            value: licenceMonitoringStations.three.thresholdGroup
           }
         ]
       })

--- a/test/services/notices/setup/abstraction-alerts/alert-type.service.test.js
+++ b/test/services/notices/setup/abstraction-alerts/alert-type.service.test.js
@@ -20,7 +20,7 @@ describe('Notices Setup - Abstraction Alerts - Alert Type Service', () => {
   let sessionData
 
   beforeEach(async () => {
-    sessionData = AbstractionAlertSessionData.monitoringStation()
+    sessionData = AbstractionAlertSessionData.get()
     session = await SessionHelper.add({ data: sessionData })
   })
 

--- a/test/services/notices/setup/abstraction-alerts/cancel-alerts.service.test.js
+++ b/test/services/notices/setup/abstraction-alerts/cancel-alerts.service.test.js
@@ -20,7 +20,7 @@ describe('Cancel Alerts Service', () => {
 
   beforeEach(async () => {
     sessionData = {
-      ...AbstractionAlertSessionData.monitoringStation(),
+      ...AbstractionAlertSessionData.get(),
       alertType: 'resume'
     }
 

--- a/test/services/notices/setup/abstraction-alerts/check-licence-matches.service.test.js
+++ b/test/services/notices/setup/abstraction-alerts/check-licence-matches.service.test.js
@@ -16,26 +16,22 @@ const SessionHelper = require('../../../../support/helpers/session.helper.js')
 const CheckLicenceMatchesService = require('../../../../../app/services/notices/setup/abstraction-alerts/check-licence-matches.service.js')
 
 describe('Notices Setup - Abstraction Alerts - Check Licence Matches Service', () => {
-  let licenceMonitoringStationOne
-  let licenceMonitoringStationThree
-  let licenceMonitoringStationTwo
+  let licenceMonitoringStations
   let session
   let sessionData
   let yarStub
 
   beforeEach(async () => {
-    const abstractionAlertSessionData = AbstractionAlertSessionData.monitoringStation()
+    licenceMonitoringStations = AbstractionAlertSessionData.licenceMonitoringStations()
 
-    licenceMonitoringStationOne = abstractionAlertSessionData.licenceMonitoringStations[0]
-    licenceMonitoringStationTwo = abstractionAlertSessionData.licenceMonitoringStations[1]
-    licenceMonitoringStationThree = abstractionAlertSessionData.licenceMonitoringStations[2]
+    const abstractionAlertSessionData = AbstractionAlertSessionData.get(licenceMonitoringStations)
 
     sessionData = {
       ...abstractionAlertSessionData,
       alertThresholds: [
-        licenceMonitoringStationOne.thresholdGroup,
-        licenceMonitoringStationTwo.thresholdGroup,
-        licenceMonitoringStationThree.thresholdGroup
+        licenceMonitoringStations.one.thresholdGroup,
+        licenceMonitoringStations.two.thresholdGroup,
+        licenceMonitoringStations.three.thresholdGroup
       ]
     }
 
@@ -64,13 +60,13 @@ describe('Notices Setup - Abstraction Alerts - Check Licence Matches Service', (
           {
             abstractionPeriod: '1 February to 1 January',
             action: {
-              link: `/system/notices/setup/${session.id}/abstraction-alerts/remove-threshold/${licenceMonitoringStationOne.id}`,
+              link: `/system/notices/setup/${session.id}/abstraction-alerts/remove-threshold/${licenceMonitoringStations.one.id}`,
               text: 'Remove'
             },
             alert: null,
             alertDate: null,
-            licenceId: licenceMonitoringStationOne.licence.id,
-            licenceRef: licenceMonitoringStationOne.licence.licenceRef,
+            licenceId: licenceMonitoringStations.one.licence.id,
+            licenceRef: licenceMonitoringStations.one.licence.licenceRef,
             restriction: 'Reduce',
             restrictionCount: 1,
             threshold: '1000 m'
@@ -78,13 +74,13 @@ describe('Notices Setup - Abstraction Alerts - Check Licence Matches Service', (
           {
             abstractionPeriod: '1 January to 31 March',
             action: {
-              link: `/system/notices/setup/${session.id}/abstraction-alerts/remove-threshold/${licenceMonitoringStationTwo.id}`,
+              link: `/system/notices/setup/${session.id}/abstraction-alerts/remove-threshold/${licenceMonitoringStations.two.id}`,
               text: 'Remove'
             },
             alert: null,
             alertDate: null,
-            licenceId: licenceMonitoringStationTwo.licence.id,
-            licenceRef: licenceMonitoringStationTwo.licence.licenceRef,
+            licenceId: licenceMonitoringStations.two.licence.id,
+            licenceRef: licenceMonitoringStations.two.licence.licenceRef,
             restriction: 'Stop',
             restrictionCount: 1,
             threshold: '100 m3/s'
@@ -92,13 +88,13 @@ describe('Notices Setup - Abstraction Alerts - Check Licence Matches Service', (
           {
             abstractionPeriod: '1 January to 31 March',
             action: {
-              link: `/system/notices/setup/${session.id}/abstraction-alerts/remove-threshold/${licenceMonitoringStationThree.id}`,
+              link: `/system/notices/setup/${session.id}/abstraction-alerts/remove-threshold/${licenceMonitoringStations.three.id}`,
               text: 'Remove'
             },
             alert: null,
             alertDate: null,
-            licenceId: licenceMonitoringStationThree.licence.id,
-            licenceRef: licenceMonitoringStationThree.licence.licenceRef,
+            licenceId: licenceMonitoringStations.three.licence.id,
+            licenceRef: licenceMonitoringStations.three.licence.licenceRef,
             restriction: 'Stop',
             restrictionCount: 1,
             threshold: '100 m'

--- a/test/services/notices/setup/abstraction-alerts/determine-relevant-licence-monitoring-stations.service.test.js
+++ b/test/services/notices/setup/abstraction-alerts/determine-relevant-licence-monitoring-stations.service.test.js
@@ -23,7 +23,7 @@ describe('Notices Setup - Abstraction Alerts - Determine relevant licence monito
   let selectedLicenceMonitoringStations
 
   beforeEach(async () => {
-    const abstractionAlertSessionData = AbstractionAlertSessionData.monitoringStation()
+    const abstractionAlertSessionData = AbstractionAlertSessionData.get()
 
     licenceMonitoringStations = abstractionAlertSessionData.licenceMonitoringStations
 

--- a/test/services/notices/setup/abstraction-alerts/remove-threshold.service.test.js
+++ b/test/services/notices/setup/abstraction-alerts/remove-threshold.service.test.js
@@ -15,19 +15,16 @@ const SessionHelper = require('../../../../support/helpers/session.helper.js')
 // Thing under test
 const RemoveThresholdService = require('../../../../../app/services/notices/setup/abstraction-alerts/remove-threshold.service.js')
 
-describe('Remove Threshold Service', () => {
-  let abstractionAlertSessionData
-  let licenceMonitoringStationId
-  let licenceMonitoringStationOne
+describe('Notices Setup - Abstraction Alerts - Remove Threshold Service', () => {
+  let licenceMonitoringStations
   let session
+  let sessionData
   let yarStub
 
   beforeEach(() => {
-    abstractionAlertSessionData = AbstractionAlertSessionData.monitoringStation()
+    licenceMonitoringStations = AbstractionAlertSessionData.licenceMonitoringStations()
 
-    licenceMonitoringStationOne = abstractionAlertSessionData.licenceMonitoringStations[0]
-
-    licenceMonitoringStationId = licenceMonitoringStationOne.id
+    sessionData = AbstractionAlertSessionData.get(licenceMonitoringStations)
 
     yarStub = { flash: Sinon.stub() }
   })
@@ -40,16 +37,16 @@ describe('Remove Threshold Service', () => {
     describe('and there are no thresholds currently removed', () => {
       beforeEach(async () => {
         session = await SessionHelper.add({
-          data: abstractionAlertSessionData
+          data: sessionData
         })
       })
 
       it('saves the "licenceMonitoringStationId" to the session to be excluded from the list', async () => {
-        await RemoveThresholdService.go(session.id, licenceMonitoringStationId, yarStub)
+        await RemoveThresholdService.go(session.id, licenceMonitoringStations.one.id, yarStub)
 
         const refreshedSession = await session.$query()
 
-        expect(refreshedSession.removedThresholds).to.equal([licenceMonitoringStationId])
+        expect(refreshedSession.removedThresholds).to.equal([licenceMonitoringStations.one.id])
       })
     })
 
@@ -57,18 +54,21 @@ describe('Remove Threshold Service', () => {
       beforeEach(async () => {
         session = await SessionHelper.add({
           data: {
-            ...abstractionAlertSessionData,
-            removedThresholds: [licenceMonitoringStationId]
+            ...sessionData,
+            removedThresholds: [licenceMonitoringStations.one.id]
           }
         })
       })
 
       it('saves the "licenceMonitoringStationId" to the session with the existing "removedThresholds"', async () => {
-        await RemoveThresholdService.go(session.id, licenceMonitoringStationId, yarStub)
+        await RemoveThresholdService.go(session.id, licenceMonitoringStations.one.id, yarStub)
 
         const refreshedSession = await session.$query()
 
-        expect(refreshedSession.removedThresholds).to.equal([licenceMonitoringStationId, licenceMonitoringStationId])
+        expect(refreshedSession.removedThresholds).to.equal([
+          licenceMonitoringStations.one.id,
+          licenceMonitoringStations.one.id
+        ])
       })
     })
 
@@ -76,20 +76,20 @@ describe('Remove Threshold Service', () => {
       beforeEach(async () => {
         session = await SessionHelper.add({
           data: {
-            ...abstractionAlertSessionData,
-            removedThresholds: [licenceMonitoringStationId]
+            ...sessionData,
+            removedThresholds: [licenceMonitoringStations.one.id]
           }
         })
       })
       it('sets a flash message', async () => {
-        await RemoveThresholdService.go(session.id, licenceMonitoringStationId, yarStub)
+        await RemoveThresholdService.go(session.id, licenceMonitoringStations.one.id, yarStub)
 
         // Check we add the flash message
         const [flashType, bannerMessage] = yarStub.flash.args[0]
 
         expect(flashType).to.equal('notification')
         expect(bannerMessage).to.equal({
-          text: `Removed ${licenceMonitoringStationOne.licence.licenceRef} Reduce 1000m`,
+          text: `Removed ${licenceMonitoringStations.one.licence.licenceRef} Reduce 1000m`,
           title: 'Updated'
         })
       })

--- a/test/services/notices/setup/abstraction-alerts/submit-alert-email-address.service.test.js
+++ b/test/services/notices/setup/abstraction-alerts/submit-alert-email-address.service.test.js
@@ -29,7 +29,7 @@ describe('Submit Alert Email Address Service', () => {
       }
     }
     payload = { alertEmailAddress: 'saved-email-address' }
-    sessionData = AbstractionAlertSessionData.monitoringStation()
+    sessionData = AbstractionAlertSessionData.get()
 
     session = await SessionHelper.add({ data: sessionData })
   })

--- a/test/services/notices/setup/abstraction-alerts/submit-alert-thresholds.service.test.js
+++ b/test/services/notices/setup/abstraction-alerts/submit-alert-thresholds.service.test.js
@@ -15,26 +15,22 @@ const SessionHelper = require('../../../../support/helpers/session.helper.js')
 const SubmitAlertThresholdsService = require('../../../../../app/services/notices/setup/abstraction-alerts/submit-alert-thresholds.service.js')
 
 describe('Notices Setup - Abstraction Alerts - Alert Thresholds Submit Service', () => {
-  let alertThresholdGroupOne
-  let alertThresholdGroupThree
-  let alertThresholdGroupTwo
+  let licenceMonitoringStations
   let payload
   let session
   let sessionData
 
   describe('when called', () => {
     beforeEach(async () => {
+      licenceMonitoringStations = AbstractionAlertSessionData.licenceMonitoringStations()
+
       sessionData = {
-        ...AbstractionAlertSessionData.monitoringStation(),
+        ...AbstractionAlertSessionData.get(licenceMonitoringStations),
         alertType: 'stop'
       }
 
-      alertThresholdGroupOne = sessionData.licenceMonitoringStations[0].thresholdGroup
-      alertThresholdGroupTwo = sessionData.licenceMonitoringStations[1].thresholdGroup
-      alertThresholdGroupThree = sessionData.licenceMonitoringStations[2].thresholdGroup
-
       payload = {
-        'alert-thresholds': [alertThresholdGroupOne, alertThresholdGroupTwo]
+        'alert-thresholds': [licenceMonitoringStations.one.thresholdGroup, licenceMonitoringStations.two.thresholdGroup]
       }
 
       session = await SessionHelper.add({ data: sessionData })
@@ -50,7 +46,7 @@ describe('Notices Setup - Abstraction Alerts - Alert Thresholds Submit Service',
       describe('and one threshold has been selected ', () => {
         beforeEach(() => {
           payload = {
-            'alert-thresholds': alertThresholdGroupOne
+            'alert-thresholds': licenceMonitoringStations.one.thresholdGroup
           }
         })
 
@@ -59,7 +55,7 @@ describe('Notices Setup - Abstraction Alerts - Alert Thresholds Submit Service',
 
           const refreshedSession = await session.$query()
 
-          expect(refreshedSession.alertThresholds).to.equal([alertThresholdGroupOne])
+          expect(refreshedSession.alertThresholds).to.equal([licenceMonitoringStations.one.thresholdGroup])
         })
       })
 
@@ -69,7 +65,10 @@ describe('Notices Setup - Abstraction Alerts - Alert Thresholds Submit Service',
 
           const refreshedSession = await session.$query()
 
-          expect(refreshedSession.alertThresholds).to.equal([alertThresholdGroupOne, alertThresholdGroupTwo])
+          expect(refreshedSession.alertThresholds).to.equal([
+            licenceMonitoringStations.one.thresholdGroup,
+            licenceMonitoringStations.two.thresholdGroup
+          ])
         })
       })
     })
@@ -78,11 +77,11 @@ describe('Notices Setup - Abstraction Alerts - Alert Thresholds Submit Service',
   describe('when validation fails', () => {
     describe('and there are no previous "alertThresholds"', () => {
       beforeEach(async () => {
-        const abstractionAlertSessionData = AbstractionAlertSessionData.monitoringStation()
+        const abstractionAlertSessionData = AbstractionAlertSessionData.get()
 
         sessionData = {
           ...abstractionAlertSessionData,
-          alertThresholds: [alertThresholdGroupOne],
+          alertThresholds: [licenceMonitoringStations.one.thresholdGroup],
           alertType: 'stop'
         }
 
@@ -106,7 +105,7 @@ describe('Notices Setup - Abstraction Alerts - Alert Thresholds Submit Service',
                 text: 'Flow threshold'
               },
               text: '100 m3/s',
-              value: alertThresholdGroupTwo
+              value: licenceMonitoringStations.two.thresholdGroup
             },
             {
               checked: false,
@@ -114,7 +113,7 @@ describe('Notices Setup - Abstraction Alerts - Alert Thresholds Submit Service',
                 text: 'Level threshold'
               },
               text: '100 m',
-              value: alertThresholdGroupThree
+              value: licenceMonitoringStations.three.thresholdGroup
             }
           ]
         })
@@ -123,11 +122,11 @@ describe('Notices Setup - Abstraction Alerts - Alert Thresholds Submit Service',
 
     describe('and there are previous "alertThresholds"', () => {
       beforeEach(async () => {
-        const abstractionAlertSessionData = AbstractionAlertSessionData.monitoringStation()
+        const abstractionAlertSessionData = AbstractionAlertSessionData.get()
 
         sessionData = {
           ...abstractionAlertSessionData,
-          alertThresholds: [alertThresholdGroupOne],
+          alertThresholds: [licenceMonitoringStations.one.thresholdGroup],
           alertType: 'stop'
         }
 
@@ -151,7 +150,7 @@ describe('Notices Setup - Abstraction Alerts - Alert Thresholds Submit Service',
                 text: 'Flow threshold'
               },
               text: '100 m3/s',
-              value: alertThresholdGroupTwo
+              value: licenceMonitoringStations.two.thresholdGroup
             },
             {
               checked: false,
@@ -159,7 +158,7 @@ describe('Notices Setup - Abstraction Alerts - Alert Thresholds Submit Service',
                 text: 'Level threshold'
               },
               text: '100 m',
-              value: alertThresholdGroupThree
+              value: licenceMonitoringStations.three.thresholdGroup
             }
           ]
         })

--- a/test/services/notices/setup/abstraction-alerts/submit-alert-type.service.test.js
+++ b/test/services/notices/setup/abstraction-alerts/submit-alert-type.service.test.js
@@ -21,7 +21,7 @@ describe('Notices Setup - Abstraction Alerts - Alert Type Service', () => {
 
   beforeEach(() => {
     payload = { 'alert-type': 'stop' }
-    sessionData = AbstractionAlertSessionData.monitoringStation()
+    sessionData = AbstractionAlertSessionData.get()
   })
 
   describe('when called', () => {

--- a/test/services/notices/setup/abstraction-alerts/submit-check-licence-matches.service.test.js
+++ b/test/services/notices/setup/abstraction-alerts/submit-check-licence-matches.service.test.js
@@ -16,29 +16,25 @@ const SubmitCheckLicenceMatchesService = require('../../../../../app/services/no
 
 describe('Notices Setup - Abstraction Alerts - Submit Check Licence Matches Service', () => {
   let licenceMonitoringStationDuplicate
-  let licenceMonitoringStationOne
-  let licenceMonitoringStationThree
-  let licenceMonitoringStationTwo
+  let licenceMonitoringStations
   let session
   let sessionData
 
   beforeEach(async () => {
-    const abstractionAlertSessionData = AbstractionAlertSessionData.monitoringStation()
+    licenceMonitoringStations = AbstractionAlertSessionData.licenceMonitoringStations()
 
-    licenceMonitoringStationOne = abstractionAlertSessionData.licenceMonitoringStations[0]
-    licenceMonitoringStationTwo = abstractionAlertSessionData.licenceMonitoringStations[1]
-    licenceMonitoringStationThree = abstractionAlertSessionData.licenceMonitoringStations[2]
+    const abstractionAlertSessionData = AbstractionAlertSessionData.get(licenceMonitoringStations)
 
     // A licence monitoring station can have the same licence as another. When this is the case we need to check we
     // handle duplicate licence refs and that we do no strip / remove them unexpectedly
-    licenceMonitoringStationDuplicate = licenceMonitoringStationOne
+    licenceMonitoringStationDuplicate = licenceMonitoringStations.one
 
     sessionData = {
       ...abstractionAlertSessionData,
       alertThresholds: [
-        licenceMonitoringStationOne.thresholdGroup,
-        licenceMonitoringStationTwo.thresholdGroup,
-        licenceMonitoringStationThree.thresholdGroup
+        licenceMonitoringStations.one.thresholdGroup,
+        licenceMonitoringStations.two.thresholdGroup,
+        licenceMonitoringStations.three.thresholdGroup
       ]
     }
   })
@@ -55,9 +51,9 @@ describe('Notices Setup - Abstraction Alerts - Submit Check Licence Matches Serv
         const refreshedSession = await session.$query()
 
         expect(refreshedSession.licenceRefs).to.equal([
-          licenceMonitoringStationOne.licence.licenceRef,
-          licenceMonitoringStationTwo.licence.licenceRef,
-          licenceMonitoringStationThree.licence.licenceRef
+          licenceMonitoringStations.one.licence.licenceRef,
+          licenceMonitoringStations.two.licence.licenceRef,
+          licenceMonitoringStations.three.licence.licenceRef
         ])
       })
 
@@ -67,16 +63,16 @@ describe('Notices Setup - Abstraction Alerts - Submit Check Licence Matches Serv
         const refreshedSession = await session.$query()
 
         expect(refreshedSession.relevantLicenceMonitoringStations).to.equal([
-          licenceMonitoringStationOne,
-          licenceMonitoringStationTwo,
-          licenceMonitoringStationThree
+          licenceMonitoringStations.one,
+          licenceMonitoringStations.two,
+          licenceMonitoringStations.three
         ])
       })
     })
 
     describe('and there are duplicate licence refs', () => {
       beforeEach(async () => {
-        sessionData.licenceMonitoringStations = [licenceMonitoringStationOne, licenceMonitoringStationDuplicate]
+        sessionData.licenceMonitoringStations = [licenceMonitoringStations.one, licenceMonitoringStationDuplicate]
 
         session = await SessionHelper.add({ data: sessionData })
       })
@@ -86,7 +82,7 @@ describe('Notices Setup - Abstraction Alerts - Submit Check Licence Matches Serv
 
         const refreshedSession = await session.$query()
 
-        expect(refreshedSession.licenceRefs).to.equal([licenceMonitoringStationOne.licence.licenceRef])
+        expect(refreshedSession.licenceRefs).to.equal([licenceMonitoringStations.one.licence.licenceRef])
       })
 
       it('saves the "relevantLicenceMonitoringStations" to the session', async () => {
@@ -95,7 +91,7 @@ describe('Notices Setup - Abstraction Alerts - Submit Check Licence Matches Serv
         const refreshedSession = await session.$query()
 
         expect(refreshedSession.relevantLicenceMonitoringStations).to.equal([
-          licenceMonitoringStationOne,
+          licenceMonitoringStations.one,
           licenceMonitoringStationDuplicate
         ])
       })
@@ -103,7 +99,7 @@ describe('Notices Setup - Abstraction Alerts - Submit Check Licence Matches Serv
 
     describe('and there are no licence monitoring stations removed', () => {
       beforeEach(async () => {
-        sessionData.removedThresholds = [licenceMonitoringStationOne.id, licenceMonitoringStationTwo.id]
+        sessionData.removedThresholds = [licenceMonitoringStations.one.id, licenceMonitoringStations.two.id]
 
         session = await SessionHelper.add({ data: sessionData })
       })
@@ -113,7 +109,7 @@ describe('Notices Setup - Abstraction Alerts - Submit Check Licence Matches Serv
 
         const refreshedSession = await session.$query()
 
-        expect(refreshedSession.licenceRefs).to.equal([licenceMonitoringStationThree.licence.licenceRef])
+        expect(refreshedSession.licenceRefs).to.equal([licenceMonitoringStations.three.licence.licenceRef])
       })
 
       it('saves the "relevantLicenceMonitoringStations" to the session', async () => {
@@ -121,7 +117,7 @@ describe('Notices Setup - Abstraction Alerts - Submit Check Licence Matches Serv
 
         const refreshedSession = await session.$query()
 
-        expect(refreshedSession.relevantLicenceMonitoringStations).to.equal([licenceMonitoringStationThree])
+        expect(refreshedSession.relevantLicenceMonitoringStations).to.equal([licenceMonitoringStations.three])
       })
     })
   })

--- a/test/services/notices/setup/initiate-session.service.test.js
+++ b/test/services/notices/setup/initiate-session.service.test.js
@@ -147,7 +147,7 @@ describe('Notices - Setup - Initiate Session service', () => {
       let monitoringStationData
 
       beforeEach(() => {
-        monitoringStationData = AbstractionAlertSessionData.monitoringStation()
+        monitoringStationData = AbstractionAlertSessionData.get()
 
         Sinon.stub(DetermineLicenceMonitoringStationsService, 'go').resolves(monitoringStationData)
       })

--- a/test/validators/notices/setup/abstraction-alerts/alert-type.validator.test.js
+++ b/test/validators/notices/setup/abstraction-alerts/alert-type.validator.test.js
@@ -16,20 +16,21 @@ const AlertTypeValidator = require('../../../../../app/validators/notices/setup/
 describe('Notices - Setup - Abstraction Alerts - Alert Type Validator', () => {
   let payload
   let licenceMonitoringStations
+  let licenceMonitoringStationsData
 
   beforeEach(() => {
     payload = {
       'alert-type': 'stop'
     }
 
-    const abstractionAlertSessionData = AbstractionAlertSessionData.monitoringStation()
+    licenceMonitoringStations = AbstractionAlertSessionData.licenceMonitoringStations()
 
-    licenceMonitoringStations = abstractionAlertSessionData.licenceMonitoringStations
+    licenceMonitoringStationsData = [...Object.values(licenceMonitoringStations)]
   })
 
   describe('when called with valid data', () => {
     it('returns with no errors', () => {
-      const result = AlertTypeValidator.go(payload, licenceMonitoringStations)
+      const result = AlertTypeValidator.go(payload, licenceMonitoringStationsData)
 
       expect(result.value).to.exist()
       expect(result.error).not.to.exist()
@@ -37,11 +38,11 @@ describe('Notices - Setup - Abstraction Alerts - Alert Type Validator', () => {
 
     describe('when the a restriction type is "stop_or_reduce" and there are no other licence monitoring stations', () => {
       beforeEach(() => {
-        licenceMonitoringStations = [{ ...licenceMonitoringStations[0], restrictionType: 'stop_or_reduce' }]
+        licenceMonitoringStationsData = [{ ...licenceMonitoringStations.one, restrictionType: 'stop_or_reduce' }]
       })
 
       it('returns with no errors', () => {
-        const result = AlertTypeValidator.go(payload, licenceMonitoringStations)
+        const result = AlertTypeValidator.go(payload, licenceMonitoringStationsData)
 
         expect(result.value).to.exist()
         expect(result.error).not.to.exist()
@@ -56,7 +57,7 @@ describe('Notices - Setup - Abstraction Alerts - Alert Type Validator', () => {
       })
 
       it('returns with errors', () => {
-        const result = AlertTypeValidator.go(payload, licenceMonitoringStations)
+        const result = AlertTypeValidator.go(payload, licenceMonitoringStationsData)
 
         expect(result.value).to.exist()
         expect(result.error).to.exist()
@@ -66,16 +67,16 @@ describe('Notices - Setup - Abstraction Alerts - Alert Type Validator', () => {
 
     describe('and the "alert-type" is not available', () => {
       beforeEach(() => {
-        licenceMonitoringStations = [
+        licenceMonitoringStationsData = [
           {
-            ...licenceMonitoringStations[0],
+            ...licenceMonitoringStations.one,
             restrictionType: 'warning'
           }
         ]
       })
 
       it('returns with errors', () => {
-        const result = AlertTypeValidator.go(payload, licenceMonitoringStations)
+        const result = AlertTypeValidator.go(payload, licenceMonitoringStationsData)
 
         expect(result.value).to.exist()
         expect(result.error).to.exist()


### PR DESCRIPTION
We are nearing the end of the abstraction alerts journey. We have been using the existing fixture to facilitate a simple test setup.

This has grown more complex as the journey has developed.

We previously returned an array of licence monitoring stations, we then accessed this test data using the index. This had some limitations and lead to some complex/ long code to get access to the data.

This change updates the abstraction alert fixture to export the licence monitoring stations as an object. As these have no specific name we have named them numbers, so 'one', 'two' and 'three'.

This makes it simpler to access the data.

To aid in keeping other tests unaffected we have added a optional arg to the existing function - '_licenceMonitoringStations'. This allows us to set / update the licence monitoring station data before setting getting the expected session object.

We have also introduced a simplified version of getting the relevant licence monitoring stations. These are stations that the user has selected. Once we are passed a certain point in the journey this becomes a consistent value used.

The fixture exports a new function for the relevant licence monitoring stations. This receives an array of licence refs and returns the licence monitoring stations with these licence refs assigned.

This is extremely useful to simplify test setup in the later journey and enables a better test to be performed.