### PR TITLE
Refactor notices page to use payload instead of saved filters

### DIFF
--- a/app/services/notices/fetch-notices.service.js
+++ b/app/services/notices/fetch-notices.service.js
@@ -72,7 +72,7 @@ function _applyNoticeTypeFilters(query, noticeTypes) {
   // that match either the alert types or the standard notice types
   if (alertTypes.length > 0 && standardNoticeTypes.length > 0) {
     query.whereRaw(
-      `(metadata->'options'->>'sendingAlertType' = ANY (?) AND subtype = 'waterAbstractionAlerts') OR subtype = ANY (?)`,
+      `((metadata->'options'->>'sendingAlertType' = ANY (?) AND subtype = 'waterAbstractionAlerts') OR subtype = ANY (?))`,
       [alertTypes, standardNoticeTypes]
     )
 

--- a/app/services/notices/submit-index.service.js
+++ b/app/services/notices/submit-index.service.js
@@ -117,17 +117,21 @@ function _save(payload, yar) {
   })
 }
 
-function _savedFilters(yar) {
-  const savedFilters = yar.get('noticesFilter')
+function _savedFilters(payload) {
+  const { clear, get, set, ...noticesFilter } = payload
 
   return {
-    fromDate: null,
+    sentFromDay: null,
+    sentFromMonth: null,
+    sentFromYear: null,
+    sentToDay: null,
+    sentToMonth: null,
+    sentToYear: null,
     noticeTypes: [],
     openFilter: true,
     reference: null,
     sentBy: null,
-    toDate: null,
-    ...savedFilters
+    ...noticesFilter
   }
 }
 

--- a/test/services/notices/submit-index.service.test.js
+++ b/test/services/notices/submit-index.service.test.js
@@ -202,10 +202,9 @@ describe('Notices - Submit Index service', () => {
       beforeEach(() => {
         payload = {
           sentFromDay: '1',
-          sentFromMonth: '4'
+          sentFromMonth: '4',
+          sentBy: 'billing.data@wrls.gov.uk'
         }
-
-        yarStub.get.returns({ sentBy: 'billing.data@wrls.gov.uk' })
 
         notice = NoticesFixture.alertStop()
       })
@@ -213,13 +212,6 @@ describe('Notices - Submit Index service', () => {
       describe('and the results are paginated', () => {
         beforeEach(() => {
           Sinon.stub(FetchNoticesService, 'go').resolves({ results: [notice], total: 70 })
-        })
-
-        it('extracts the previously saved filters', async () => {
-          await SubmitIndexService.go(payload, yarStub)
-
-          expect(yarStub.get.called).to.be.true()
-          expect(yarStub.set.called).to.be.false()
         })
 
         it('returns the page data for the view, including any errors', async () => {
@@ -240,6 +232,10 @@ describe('Notices - Submit Index service', () => {
                 sentBy: 'billing.data@wrls.gov.uk',
                 sentFromDay: payload.sentFromDay,
                 sentFromMonth: payload.sentFromMonth,
+                sentFromYear: null,
+                sentToDay: null,
+                sentToMonth: null,
+                sentToYear: null,
                 toDate: undefined
               },
               notices: [
@@ -268,13 +264,6 @@ describe('Notices - Submit Index service', () => {
           Sinon.stub(FetchNoticesService, 'go').resolves({ results: [notice], total: 1 })
         })
 
-        it('extracts the previously saved filters', async () => {
-          await SubmitIndexService.go(payload, yarStub)
-
-          expect(yarStub.get.called).to.be.true()
-          expect(yarStub.set.called).to.be.false()
-        })
-
         it('returns the page data for the view, including any errors', async () => {
           const result = await SubmitIndexService.go(payload, yarStub)
 
@@ -293,6 +282,10 @@ describe('Notices - Submit Index service', () => {
                 sentBy: 'billing.data@wrls.gov.uk',
                 sentFromDay: payload.sentFromDay,
                 sentFromMonth: payload.sentFromMonth,
+                sentFromYear: null,
+                sentToDay: null,
+                sentToMonth: null,
+                sentToYear: null,
                 toDate: undefined
               },
               notices: [

--- a/test/support/seeders/notices.seeder.js
+++ b/test/support/seeders/notices.seeder.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { generateRandomInteger } = require('../../../app/lib/general.lib.js')
+const { generateUUID } = require('../../../app/lib/general.lib.js')
 const EventHelper = require('../helpers/event.helper.js')
 
 /**
@@ -56,7 +56,7 @@ function _defaults() {
 async function _fromDateEvent() {
   const data = _defaults()
 
-  data.referenceCode = `RINV-${generateRandomInteger(100000, 999999)}`
+  data.referenceCode = `RINV-${generateUUID()}`
   data.createdAt = new Date('2025-04-12')
 
   return EventHelper.add(data)
@@ -65,7 +65,7 @@ async function _fromDateEvent() {
 async function _legacyEvent() {
   const data = _defaults()
 
-  data.referenceCode = `HOF-${generateRandomInteger(100000, 999999)}`
+  data.referenceCode = `HOF-${generateUUID()}`
   data.subtype = 'hof-stop'
 
   return EventHelper.add(data)
@@ -74,7 +74,7 @@ async function _legacyEvent() {
 async function _sentByEvent() {
   const data = _defaults()
 
-  data.referenceCode = `RINV-${generateRandomInteger(100000, 999999)}`
+  data.referenceCode = `RINV-${generateUUID()}`
   data.issuer = 'area.team@wrls.gov.uk'
 
   return EventHelper.add(data)
@@ -83,7 +83,7 @@ async function _sentByEvent() {
 async function _stopAlertEvent() {
   const data = _defaults()
 
-  data.referenceCode = `WAA-${generateRandomInteger(100000, 999999)}`
+  data.referenceCode = `WAA-${generateUUID()}`
   data.subtype = 'waterAbstractionAlerts'
   data.metadata.name = 'Water abstraction alert'
   data.metadata.options.sendingAlertType = 'stop'


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4788

As part of the testing of this ticket QA noticed a couple minor issues. When entering a date, applying the filter but then trying to remove one of the date fields and apply the filter again it would correctly error but it would show the previously saved valid entry. It should show the field that was left empty. 

Also when filtering using Returns invitation and any of the other values there were entries showing up that shouldn't be there. this was caused by a missing set of brackets on one of the where clauses. 