### PR TITLE
Amend return version migration to exclude ended

### DIFF
--- a/app/services/jobs/return-version-migration/fetch-water-undertakers.service.js
+++ b/app/services/jobs/return-version-migration/fetch-water-undertakers.service.js
@@ -40,6 +40,9 @@ async function go() {
         .where('returnVersions.status', 'current')
         .where('quarterlyReturns', false)
         .where('startDate', '<', quarterlyStartDate)
+        .where((returnVersionEndDateBuilder) => {
+          returnVersionEndDateBuilder.whereNull('endDate').orWhere('endDate', '>=', quarterlyStartDate)
+        })
         .whereColumn('returnVersions.licenceId', 'licences.id')
     )
     .orderBy([


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4881

As part of our work in setting up quarterly returns for water companies, we need to run a one-off migration for each of them to create a new return version.

It was identified during testing that we are not handling a specific scenario.

There are a handful of cases where a licence has a return version, but the latest 'active' one ends before 1 April 2025 (when quarterly returns go live). In this case, we should not be migrating the return version record to a quarterly one.

This change excludes water company licences in this state from the migration.