### PR TITLE
Fix "Enter licence number" error message

### DIFF
--- a/app/validators/licence-monitoring-station/setup/licence-number.validator.js
+++ b/app/validators/licence-monitoring-station/setup/licence-number.validator.js
@@ -27,7 +27,7 @@ function go(payload, licenceExists) {
         return _licenceExists(value, helpers, licenceExists)
       }, 'Custom Licence Validation')
       .messages({
-        invalidLicence: 'Enter a valid licence number',
+        invalidLicence: 'Licence could not be found',
         'any.required': ENTER_A_LICENCE_NUMBER_ERROR,
         'any.only': ENTER_A_LICENCE_NUMBER_ERROR,
         'string.empty': ENTER_A_LICENCE_NUMBER_ERROR

--- a/test/services/licence-monitoring-station/setup/submit-licence-number.service.test.js
+++ b/test/services/licence-monitoring-station/setup/submit-licence-number.service.test.js
@@ -79,7 +79,7 @@ describe('Licence Monitoring Station Setup - Licence Number Service', () => {
 
       expect(result).to.equal({
         activeNavBar: 'search',
-        error: { text: 'Enter a valid licence number' },
+        error: { text: 'Licence could not be found' },
         backLink: `/system/licence-monitoring-station/setup/${session.id}/stop-or-reduce`,
         monitoringStationLabel: 'LABEL',
         pageTitle: 'Enter the licence number this threshold applies to'

--- a/test/validators/licence-monitoring-station/setup/licence-number.validator.test.js
+++ b/test/validators/licence-monitoring-station/setup/licence-number.validator.test.js
@@ -74,7 +74,7 @@ describe('Licence Monitoring Station Setup - Licence Number Validator', () => {
 
         expect(result.value).to.exist()
         expect(result.error).to.exist()
-        expect(result.error.details[0].message).to.equal('Enter a valid licence number')
+        expect(result.error.details[0].message).to.equal('Licence could not be found')
       })
     })
   })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4995

It was spotted during testing that the error message shown when entering a non-existant licence number is wrong. We therefore correct this.