### PR TITLE
Add issue email address to abstraction alerts notifications

### DIFF
--- a/app/presenters/notices/setup/abstraction-alerts-notifications.presenter.js
+++ b/app/presenters/notices/setup/abstraction-alerts-notifications.presenter.js
@@ -36,10 +36,10 @@ const { contactName, contactAddress } = require('../../crm.presenter.js')
 function go(recipients, session, eventId) {
   const notifications = []
 
-  const { referenceCode, relevantLicenceMonitoringStations, monitoringStationName } = session
+  const { alertEmailAddress, monitoringStationName, referenceCode, relevantLicenceMonitoringStations } = session
 
   for (const station of relevantLicenceMonitoringStations) {
-    const commonPersonalisation = _commonPersonalisation(station, monitoringStationName)
+    const commonPersonalisation = _commonPersonalisation(station, monitoringStationName, alertEmailAddress)
 
     const matchingRecipients = _matchingRecipients(recipients, station)
 
@@ -95,11 +95,11 @@ function _addressLines(contact) {
  * @private
  */
 
-function _commonPersonalisation(licenceMonitoringStation, monitoringStationName) {
+function _commonPersonalisation(licenceMonitoringStation, monitoringStationName, alertEmailAddress) {
   return {
     condition_text: '',
     flow_or_level: licenceMonitoringStation.measureType,
-    issuer_email_address: '',
+    issuer_email_address: alertEmailAddress,
     licence_ref: licenceMonitoringStation.licence.licenceRef,
     monitoring_station_name: monitoringStationName,
     source: '',

--- a/test/presenters/notices/setup/abstraction-alert-notifications.presenter.test.js
+++ b/test/presenters/notices/setup/abstraction-alert-notifications.presenter.test.js
@@ -16,8 +16,8 @@ const RecipientsFixture = require('../../../fixtures/recipients.fixtures.js')
 const AbstractionAlertsNotificationsPresenter = require('../../../../app/presenters/notices/setup/abstraction-alerts-notifications.presenter.js')
 
 describe('Notices - Setup - Abstraction alert notifications presenter', () => {
-  const referenceCode = 'TEST-123'
   const eventId = 'c1cae668-3dad-4806-94e2-eb3f27222ed9'
+  const referenceCode = 'TEST-123'
 
   let clock
   let monitoringStationName
@@ -43,7 +43,8 @@ describe('Notices - Setup - Abstraction alert notifications presenter', () => {
       journey: 'abstraction-alerts',
       referenceCode,
       monitoringStationName,
-      relevantLicenceMonitoringStations
+      relevantLicenceMonitoringStations,
+      alertEmailAddress: 'luke.skywalker@rebelmail.test'
     }
 
     clock = Sinon.useFakeTimers(new Date(`2025-01-01`))
@@ -68,7 +69,7 @@ describe('Notices - Setup - Abstraction alert notifications presenter', () => {
         personalisation: {
           condition_text: '',
           flow_or_level: 'level',
-          issuer_email_address: '',
+          issuer_email_address: 'luke.skywalker@rebelmail.test',
           licence_ref: recipients.additionalContact.licence_refs,
           monitoring_station_name: 'Death star',
           source: '',
@@ -88,7 +89,7 @@ describe('Notices - Setup - Abstraction alert notifications presenter', () => {
         personalisation: {
           condition_text: '',
           flow_or_level: 'level',
-          issuer_email_address: '',
+          issuer_email_address: 'luke.skywalker@rebelmail.test',
           licence_ref: recipients.primaryUser.licence_refs,
           monitoring_station_name: 'Death star',
           source: '',
@@ -116,7 +117,7 @@ describe('Notices - Setup - Abstraction alert notifications presenter', () => {
           // common personalisation
           condition_text: '',
           flow_or_level: 'flow',
-          issuer_email_address: '',
+          issuer_email_address: 'luke.skywalker@rebelmail.test',
           licence_ref: recipients.licenceHolder.licence_refs,
           monitoring_station_name: 'Death star',
           source: '',
@@ -129,17 +130,10 @@ describe('Notices - Setup - Abstraction alert notifications presenter', () => {
 
   describe('when a licence has more than one licence monitoring stations to send alerts to', () => {
     beforeEach(() => {
-      const relevantLicenceMonitoringStations = AbstractionAlertSessionData.relevantLicenceMonitoringStations([
+      session.relevantLicenceMonitoringStations = AbstractionAlertSessionData.relevantLicenceMonitoringStations([
         recipients.primaryUser.licence_refs,
         recipients.primaryUser.licence_refs
       ])
-
-      session = {
-        journey: 'abstraction-alerts',
-        referenceCode,
-        monitoringStationName,
-        relevantLicenceMonitoringStations
-      }
     })
 
     it('correctly transform the recipients (and associated licence monitoring stations) into notifications for the same recipient', () => {
@@ -157,7 +151,7 @@ describe('Notices - Setup - Abstraction alert notifications presenter', () => {
           personalisation: {
             condition_text: '',
             flow_or_level: 'level',
-            issuer_email_address: '',
+            issuer_email_address: 'luke.skywalker@rebelmail.test',
             licence_ref: recipients.additionalContact.licence_refs,
             monitoring_station_name: 'Death star',
             source: '',
@@ -175,7 +169,7 @@ describe('Notices - Setup - Abstraction alert notifications presenter', () => {
           personalisation: {
             condition_text: '',
             flow_or_level: 'level',
-            issuer_email_address: '',
+            issuer_email_address: 'luke.skywalker@rebelmail.test',
             licence_ref: recipients.primaryUser.licence_refs,
             monitoring_station_name: 'Death star',
             source: '',
@@ -197,7 +191,7 @@ describe('Notices - Setup - Abstraction alert notifications presenter', () => {
           personalisation: {
             condition_text: '',
             flow_or_level: 'flow',
-            issuer_email_address: '',
+            issuer_email_address: 'luke.skywalker@rebelmail.test',
             licence_ref: recipients.additionalContact.licence_refs,
             monitoring_station_name: 'Death star',
             source: '',
@@ -215,7 +209,7 @@ describe('Notices - Setup - Abstraction alert notifications presenter', () => {
           personalisation: {
             condition_text: '',
             flow_or_level: 'flow',
-            issuer_email_address: '',
+            issuer_email_address: 'luke.skywalker@rebelmail.test',
             licence_ref: recipients.primaryUser.licence_refs,
             monitoring_station_name: 'Death star',
             source: '',
@@ -254,7 +248,7 @@ describe('Notices - Setup - Abstraction alert notifications presenter', () => {
           personalisation: {
             condition_text: '',
             flow_or_level: 'level',
-            issuer_email_address: '',
+            issuer_email_address: 'luke.skywalker@rebelmail.test',
             licence_ref: recipients.primaryUser.licence_refs,
             monitoring_station_name: 'Death star',
             source: '',
@@ -286,7 +280,7 @@ describe('Notices - Setup - Abstraction alert notifications presenter', () => {
             personalisation: {
               condition_text: '',
               flow_or_level: 'level',
-              issuer_email_address: '',
+              issuer_email_address: 'luke.skywalker@rebelmail.test',
               licence_ref: recipients.additionalContact.licence_refs,
               monitoring_station_name: 'Death star',
               source: '',
@@ -307,7 +301,7 @@ describe('Notices - Setup - Abstraction alert notifications presenter', () => {
             personalisation: {
               condition_text: '',
               flow_or_level: 'level',
-              issuer_email_address: '',
+              issuer_email_address: 'luke.skywalker@rebelmail.test',
               licence_ref: recipients.primaryUser.licence_refs,
               monitoring_station_name: 'Death star',
               source: '',
@@ -351,7 +345,7 @@ describe('Notices - Setup - Abstraction alert notifications presenter', () => {
             // common personalisation
             condition_text: '',
             flow_or_level: 'level',
-            issuer_email_address: '',
+            issuer_email_address: 'luke.skywalker@rebelmail.test',
             licence_ref: recipients.licenceHolder.licence_refs,
             monitoring_station_name: 'Death star',
             source: '',
@@ -382,7 +376,7 @@ describe('Notices - Setup - Abstraction alert notifications presenter', () => {
             personalisation: {
               condition_text: '',
               flow_or_level: 'level',
-              issuer_email_address: '',
+              issuer_email_address: 'luke.skywalker@rebelmail.test',
               licence_ref: recipients.additionalContact.licence_refs,
               monitoring_station_name: 'Death star',
               source: '',
@@ -409,7 +403,7 @@ describe('Notices - Setup - Abstraction alert notifications presenter', () => {
               // common personalisation
               condition_text: '',
               flow_or_level: 'level',
-              issuer_email_address: '',
+              issuer_email_address: 'luke.skywalker@rebelmail.test',
               licence_ref: recipients.licenceHolder.licence_refs,
               monitoring_station_name: 'Death star',
               source: '',


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5067

We have previously implemented part of the notification presenter. We left out some of the personalisation to be done in later changes.

This is one of those changes.

This change adds the issuers email address to the abstraction alert notifications' personalisation. This email is used in all the templates.

This email address is set in the session from the previous page. So there is no other logic needed.