### PR TITLE
Fix invalid fin year in 2PT annual bill run setup

### DIFF
--- a/app/services/bill-runs/setup/submit-year.service.js
+++ b/app/services/bill-runs/setup/submit-year.service.js
@@ -38,7 +38,7 @@ async function go(sessionId, payload) {
   if (!validationResult) {
     await _save(session, payload)
 
-    return { setupComplete: ['2024', '2023'].includes(session.year) }
+    return { setupComplete: ['2025'].includes(session.year) }
   }
 
   const regionId = session.region

--- a/app/validators/bill-runs/setup/year.validator.js
+++ b/app/validators/bill-runs/setup/year.validator.js
@@ -7,7 +7,7 @@
 
 const Joi = require('joi')
 
-const VALID_VALUES = ['2024', '2023', '2022', '2021']
+const VALID_VALUES = ['2025', '2022', '2021']
 
 /**
  * Validates data submitted for the `/bill-runs/setup/{sessionId}/year` page

--- a/test/services/bill-runs/setup/submit-year.service.test.js
+++ b/test/services/bill-runs/setup/submit-year.service.test.js
@@ -34,7 +34,7 @@ describe('Bill Runs - Setup - Submit Year service', () => {
       describe('and the year is in the SROC period', () => {
         beforeEach(() => {
           payload = {
-            year: '2023'
+            year: '2025'
           }
         })
 
@@ -43,7 +43,7 @@ describe('Bill Runs - Setup - Submit Year service', () => {
 
           const refreshedSession = await session.$query()
 
-          expect(refreshedSession.year).to.equal('2023')
+          expect(refreshedSession.year).to.equal('2025')
           expect(result.setupComplete).to.be.true()
         })
       })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5064

In [Update Two-part tariff annual years for 2024-25](https://github.com/DEFRA/water-abstraction-system/pull/2002), we updated the years shown in the bill run setup journey's "Select the financial year" page to reflect that the SROC 2PT bill runs have been run for 2022/23 and 2023/24. On the backlog are just 2020/21 and 2021/22. For future years, it will just be the previous financial year (currently 2024/25).

The problem is that, though we updated the page, we never updated the validation to match. If you select the top year, the validation says you haven't. Major oversight! 🤦

This change fixes the issue.