### PR TITLE
Fix failing tests which have temporarily been skipped

### DIFF
--- a/test/services/notices/setup/fetch-abstraction-alert-recipients.service.test.js
+++ b/test/services/notices/setup/fetch-abstraction-alert-recipients.service.test.js
@@ -18,7 +18,7 @@ const LicenceRoleHelper = require('../../../support/helpers/licence-role.helper.
 // Thing under test
 const FetchAbstractionAlertRecipientsService = require('../../../../app/services/notices/setup/fetch-abstraction-alert-recipients.service.js')
 
-describe.skip('Notices - Setup - Fetch abstraction alert recipients service', () => {
+describe('Notices - Setup - Fetch abstraction alert recipients service', () => {
   let recipients
   let session
 
@@ -265,7 +265,7 @@ describe.skip('Notices - Setup - Fetch abstraction alert recipients service', ()
         contact_hash_id: 'c661b771974504933d79ca64249570d0',
         contact_type: 'Additional contact',
         email: 'Ron.Burgundy@news.com',
-        licence_refs: `${recipients.primaryUser.licenceRef},${recipients.licenceHolder.licenceRef}`
+        licence_refs: [recipients.licenceHolder.licenceRef, recipients.primaryUser.licenceRef].sort().join(',')
       })
     })
   })


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/139

'Notices - Setup - Fetch abstraction alert recipients service' has an inconsistently failing test. We think this is due to the licence refs being randomly generated and then expected to be in the same order each time.

This change sorts the licence refs and puts them into the correct format.