### PR TITLE
Fix select financial year for 2PT supplementary

### DIFF
--- a/app/validators/bill-runs/setup/year.validator.js
+++ b/app/validators/bill-runs/setup/year.validator.js
@@ -7,7 +7,7 @@
 
 const Joi = require('joi')
 
-const VALID_VALUES = ['2025', '2022', '2021']
+const VALID_VALUES = ['2025', '2024', '2023', '2022', '2021']
 
 /**
  * Validates data submitted for the `/bill-runs/setup/{sessionId}/year` page


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5091

In [Fix invalid fin year in 2PT annual bill run setup](https://github.com/DEFRA/water-abstraction-system/pull/2056), we made a change to the bill run `YearValidator` to fix an issue with the annual two-part tariff bill run journey.

However, we were only considering the annual journey when we made the change. We didn't stop to think that the page is also used in the two-part tariff supplementary journey.

Doh!

This change fixes the validator to handle both journeys.