### PR TITLE
Fix select financial year for 2PT supplementary p2

### DIFF
--- a/app/services/bill-runs/setup/submit-year.service.js
+++ b/app/services/bill-runs/setup/submit-year.service.js
@@ -38,7 +38,7 @@ async function go(sessionId, payload) {
   if (!validationResult) {
     await _save(session, payload)
 
-    return { setupComplete: ['2025'].includes(session.year) }
+    return { setupComplete: ['2025', '2024', '2023'].includes(session.year) }
   }
 
   const regionId = session.region


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5091

In [Fix invalid fin year in 2PT annual bill run setup](https://github.com/DEFRA/water-abstraction-system/pull/2056), we made a change to the bill run `YearValidator` to fix an issue with the annual two-part tariff bill run journey.

However, we were only considering the annual journey when we made the change. We didn't stop to think that the page is also used in the two-part tariff supplementary journey.

Doh!

We thought we'd fixed the journey in [Fix select financial year for 2PT supplementary](https://github.com/DEFRA/water-abstraction-system/pull/2064), but we'd only fixed the validator.

Double-doh!

This change ensures that if a user picks an SROC year they are taken to the check details page, and not the pre-sroc page to pick the season.