### PR TITLE
Fix duplicate points in return versions setup

### DIFF
--- a/test/services/return-versions/setup/fetch-points.service.test.js
+++ b/test/services/return-versions/setup/fetch-points.service.test.js
@@ -18,11 +18,13 @@ const RegionHelper = require('../../../support/helpers/region.helper.js')
 // Thing under test
 const FetchPointsService = require('../../../../app/services/return-versions/setup/fetch-points.service.js')
 
-describe('Return Versions Setup - Fetch Points service', () => {
+describe('Return Versions - Setup - Fetch Points service', () => {
   let licence
   let points
 
   before(async () => {
+    points = await _points()
+
     const region = RegionHelper.select()
 
     // Create the initial licenceId
@@ -30,45 +32,60 @@ describe('Return Versions Setup - Fetch Points service', () => {
       regionId: region.id
     })
 
+    // Add a licence version to it
     const licenceVersion = await LicenceVersionHelper.add({ licenceId: licence.id })
 
-    points = []
-    for (let i = 0; i < 2; i++) {
-      // To demonstrate that we are fetching the points from _all_ purposes we add two purposes each with their own
-      // point
+    // To demonstrate that we are fetching the points from _all_ purposes we add two purposes each with their own
+    // point
+    for (let i = 1; i < 3; i++) {
       const licenceVersionPurpose = await LicenceVersionPurposeHelper.add({ licenceVersionId: licenceVersion.id })
-      const point = await PointHelper.add({ description: `I am point ${i + 1}` })
 
+      // Create a link between the purpose and the point created just for it
       await LicenceVersionPurposePointHelper.add({
         licenceVersionPurposeId: licenceVersionPurpose.id,
-        pointId: point.id
+        pointId: points[i].id
       })
 
-      points.push(point)
+      // Create a link between the purpose and the shared point
+      await LicenceVersionPurposePointHelper.add({
+        licenceVersionPurposeId: licenceVersionPurpose.id,
+        pointId: points[0].id
+      })
     }
   })
 
-  describe('when the matching licence exists', () => {
+  describe.only('when the matching licence exists', () => {
     it('returns the licence version purpose points for the licence', async () => {
       const results = await FetchPointsService.go(licence.id)
 
-      expect(results[0]).to.equal({
-        id: points[0].id,
-        description: points[0].description,
-        ngr1: points[0].ngr1,
-        ngr2: points[0].ngr2,
-        ngr3: points[0].ngr3,
-        ngr4: points[0].ngr4
-      })
+      expect(results).to.have.length(3)
 
-      expect(results[1]).to.equal({
-        id: points[1].id,
-        description: points[1].description,
-        ngr1: points[1].ngr1,
-        ngr2: points[1].ngr2,
-        ngr3: points[1].ngr3,
-        ngr4: points[1].ngr4
-      })
+      expect(results).to.equal([
+        {
+          id: points[2].id,
+          description: 'I am point 2',
+          ngr1: points[2].ngr1,
+          ngr2: null,
+          ngr3: null,
+          ngr4: null
+        },
+        {
+          id: points[0].id,
+          description: 'I am the shared point',
+          ngr1: points[0].ngr1,
+          ngr2: null,
+          ngr3: null,
+          ngr4: null
+        },
+        {
+          id: points[1].id,
+          description: 'I am point 1',
+          ngr1: points[1].ngr1,
+          ngr2: null,
+          ngr3: null,
+          ngr4: null
+        }
+      ])
     })
   })
 
@@ -78,3 +95,44 @@ describe('Return Versions Setup - Fetch Points service', () => {
     })
   })
 })
+
+/**
+ * Creates the points that will be assigned to the licence version purposes
+ *
+ * This function generates three points: one shared point that is expected to appear only once in the
+ * service results, and two additional points each uniquely assigned to the different purposes.
+ *
+ * It also generates the first NGR for them so we can assert that the results are ordered by NGR1.
+ *
+ * @private
+ */
+async function _points() {
+  const points = []
+
+  // To demonstrate that the service returns a an array of unique points, we create one that all purposes will share. We
+  // expect to see it only listed once in the results from the service.
+  const sharedPoint = await PointHelper.add({
+    description: `I am the shared point`,
+    ngr1: `SU${PointHelper.generateNationalGridReference().slice(2)}`
+  })
+
+  points.push(sharedPoint)
+
+  // This point will only be assigned to the first of the two purposes we'll add
+  const point1 = await PointHelper.add({
+    description: 'I am point 1',
+    ngr1: `TQ${PointHelper.generateNationalGridReference().slice(2)}`
+  })
+
+  points.push(point1)
+
+  // This point will only be assigned to the second of the two purposes we'll add
+  const point2 = await PointHelper.add({
+    description: 'I am point 2',
+    ngr1: `SE${PointHelper.generateNationalGridReference().slice(2)}`
+  })
+
+  points.push(point2)
+
+  return points
+}

--- a/test/services/return-versions/setup/fetch-points.service.test.js
+++ b/test/services/return-versions/setup/fetch-points.service.test.js
@@ -54,7 +54,7 @@ describe('Return Versions - Setup - Fetch Points service', () => {
     }
   })
 
-  describe.only('when the matching licence exists', () => {
+  describe('when the matching licence exists', () => {
     it('returns the licence version purpose points for the licence', async () => {
       const results = await FetchPointsService.go(licence.id)
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5069

During the UAT of the manual return version setup journey, it was noted that duplicate points can be listed on the "Select the points for the requirements for returns" screen.

The reason is a licence that has more than one purpose linked to the same point. The current fetch is compiling a list of every point linked to each purpose against the licence's current version. But if Point A is linked to purposes 1 and 2, it results in Point A being listed twice.

This change updates the `FetchPointsService` to ensure a point is only added once to the list it compiles.

We also found that sometimes the unit test would fail because the order in which the points were returned was inconsistent, yet the tests assumed it would be consistent. So, we also order the points by their `ngr1` property, which we know will always be populated.