### PR TITLE
Add condition text to abstraction alerts notifications

### DIFF
--- a/app/presenters/notices/setup/abstraction-alerts-notifications.presenter.js
+++ b/app/presenters/notices/setup/abstraction-alerts-notifications.presenter.js
@@ -97,7 +97,7 @@ function _addressLines(contact) {
 
 function _commonPersonalisation(licenceMonitoringStation, monitoringStationName, alertEmailAddress) {
   return {
-    condition_text: '',
+    condition_text: _conditionText(licenceMonitoringStation.notes),
     flow_or_level: licenceMonitoringStation.measureType,
     issuer_email_address: alertEmailAddress,
     licence_ref: licenceMonitoringStation.licence.licenceRef,
@@ -106,6 +106,10 @@ function _commonPersonalisation(licenceMonitoringStation, monitoringStationName,
     threshold_unit: licenceMonitoringStation.thresholdUnit,
     threshold_value: licenceMonitoringStation.thresholdValue
   }
+}
+
+function _conditionText(notes) {
+  return notes ? `Effect of restriction: ${notes}` : ''
 }
 
 /**

--- a/app/services/notices/setup/abstraction-alerts/determine-licence-monitoring-stations.service.js
+++ b/app/services/notices/setup/abstraction-alerts/determine-licence-monitoring-stations.service.js
@@ -30,6 +30,7 @@ function _licenceMonitoringStations(licenceMonitoringStations) {
     return {
       ...rest,
       ..._licenceVersionPurpose(licenceVersionPurposeCondition),
+      notes: _notes(licenceVersionPurposeCondition),
       thresholdGroup: _thresholdGroup(rest.measureType, rest.thresholdValue, rest.thresholdUnit)
     }
   })
@@ -41,6 +42,26 @@ function _licenceVersionPurpose(licenceVersionPurposeCondition) {
   } else {
     return {}
   }
+}
+
+/**
+ * Notes are used in the personalisation for notify.
+ *
+ * Nots can be:
+ *  - a string
+ *  - null
+ *
+ * Here are some examples from NALD where the notes are set (they may not look 'correct' but we still set them):
+ * - `"                   "             "                    "`
+ * - '\n'
+ * - '-'
+ *
+ * @private
+ */
+function _notes(licenceVersionPurposeCondition) {
+  return licenceVersionPurposeCondition?.notes && licenceVersionPurposeCondition?.notes.length > 0
+    ? licenceVersionPurposeCondition.notes
+    : null
 }
 
 /**

--- a/app/services/notices/setup/abstraction-alerts/fetch-monitoring-station.service.js
+++ b/app/services/notices/setup/abstraction-alerts/fetch-monitoring-station.service.js
@@ -52,7 +52,7 @@ async function _fetch(monitoringStationId) {
         .withGraphFetched('licenceVersionPurposeCondition')
         .modifyGraph('licenceVersionPurposeCondition', (licenceVersionPurposeConditionBuilder) => {
           licenceVersionPurposeConditionBuilder
-            .select(['id'])
+            .select(['id', 'notes'])
             .withGraphFetched('licenceVersionPurpose')
             .modifyGraph('licenceVersionPurpose', (licenceVersionPurposeBuilder) => {
               licenceVersionPurposeBuilder.select([

--- a/test/fixtures/abstraction-alert-session-data.fixture.js
+++ b/test/fixtures/abstraction-alert-session-data.fixture.js
@@ -21,6 +21,7 @@ function licenceMonitoringStations() {
         id: generateUUID()
       },
       measureType: 'level',
+      notes: null,
       restrictionType: 'reduce',
       status: 'resume',
       statusUpdatedAt: null,
@@ -39,6 +40,7 @@ function licenceMonitoringStations() {
         id: generateUUID()
       },
       measureType: 'flow',
+      notes: 'I have a bad feeling about this',
       restrictionType: 'stop',
       status: 'resume',
       statusUpdatedAt: null,
@@ -57,6 +59,7 @@ function licenceMonitoringStations() {
         id: generateUUID()
       },
       measureType: 'level',
+      notes: null,
       restrictionType: 'stop',
       status: 'resume',
       statusUpdatedAt: null,

--- a/test/presenters/notices/setup/abstraction-alert-notifications.presenter.test.js
+++ b/test/presenters/notices/setup/abstraction-alert-notifications.presenter.test.js
@@ -115,7 +115,7 @@ describe('Notices - Setup - Abstraction alert notifications presenter', () => {
           address_line_4: 'Surrey',
           address_line_5: 'WD25 7LR',
           // common personalisation
-          condition_text: '',
+          condition_text: 'Effect of restriction: I have a bad feeling about this',
           flow_or_level: 'flow',
           issuer_email_address: 'luke.skywalker@rebelmail.test',
           licence_ref: recipients.licenceHolder.licence_refs,
@@ -189,7 +189,7 @@ describe('Notices - Setup - Abstraction alert notifications presenter', () => {
           messageType: 'email',
           messageRef: 'water_abstraction_alert_reduce_warning_email',
           personalisation: {
-            condition_text: '',
+            condition_text: 'Effect of restriction: I have a bad feeling about this',
             flow_or_level: 'flow',
             issuer_email_address: 'luke.skywalker@rebelmail.test',
             licence_ref: recipients.additionalContact.licence_refs,
@@ -207,7 +207,7 @@ describe('Notices - Setup - Abstraction alert notifications presenter', () => {
           messageRef: 'water_abstraction_alert_reduce_warning_email',
           messageType: 'email',
           personalisation: {
-            condition_text: '',
+            condition_text: 'Effect of restriction: I have a bad feeling about this',
             flow_or_level: 'flow',
             issuer_email_address: 'luke.skywalker@rebelmail.test',
             licence_ref: recipients.primaryUser.licence_refs,

--- a/test/services/notices/setup/abstraction-alerts/determine-licence-monitoring-stations.service.test.js
+++ b/test/services/notices/setup/abstraction-alerts/determine-licence-monitoring-stations.service.test.js
@@ -18,11 +18,11 @@ const FetchMonitoringStationService = require('../../../../../app/services/notic
 const DetermineLicenceMonitoringStationsService = require('../../../../../app/services/notices/setup/abstraction-alerts/determine-licence-monitoring-stations.service.js')
 
 describe('Notices Setup - Abstraction Alerts - Determine Licence Monitoring Stations service', () => {
-  const monitoringStation = generateUUID()
+  const monitoringStationId = generateUUID()
 
   beforeEach(async () => {
     Sinon.stub(FetchMonitoringStationService, 'go').resolves({
-      id: monitoringStation.id,
+      id: monitoringStationId,
       label: 'MONITOR PLACE',
       licenceMonitoringStations: [
         {
@@ -66,7 +66,35 @@ describe('Notices Setup - Abstraction Alerts - Determine Licence Monitoring Stat
               abstractionPeriodEndMonth: 3,
               abstractionPeriodStartMonth: 1,
               abstractionPeriodStartDay: 1
-            }
+            },
+            notes: 'I have a bad feeling about this'
+          }
+        },
+        {
+          abstractionPeriodEndDay: null,
+          abstractionPeriodEndMonth: null,
+          abstractionPeriodStartDay: null,
+          abstractionPeriodStartMonth: null,
+          measureType: 'level',
+          restrictionType: 'reduce',
+          status: 'resume',
+          statusUpdatedAt: null,
+          thresholdUnit: 'm3/s',
+          thresholdValue: 100,
+          id: '0cfcfcb0-989e-481f-9cc1-10a69d8434',
+          licence: {
+            id: '456',
+            licenceRef: '02/02/02/3116'
+          },
+          licenceVersionPurposeCondition: {
+            id: '3f01d2d9-d23b-4697-b215-2ee3836feabb',
+            licenceVersionPurpose: {
+              abstractionPeriodEndDay: 31,
+              abstractionPeriodEndMonth: 3,
+              abstractionPeriodStartMonth: 1,
+              abstractionPeriodStartDay: 1
+            },
+            notes: '"                   "             "                    "'
           }
         }
       ]
@@ -78,7 +106,7 @@ describe('Notices Setup - Abstraction Alerts - Determine Licence Monitoring Stat
   })
 
   it('correctly returns the data', async () => {
-    const result = await DetermineLicenceMonitoringStationsService.go(monitoringStation.id)
+    const result = await DetermineLicenceMonitoringStationsService.go(monitoringStationId)
 
     expect(result).to.equal({
       licenceMonitoringStations: [
@@ -89,6 +117,7 @@ describe('Notices Setup - Abstraction Alerts - Determine Licence Monitoring Stat
           abstractionPeriodStartMonth: 2,
           id: 'c4f6d976-3b18-44bc-b2b4-a649421faf2e',
           measureType: 'flow',
+          notes: null,
           restrictionType: 'reduce',
           status: 'resume',
           statusUpdatedAt: null,
@@ -107,6 +136,7 @@ describe('Notices Setup - Abstraction Alerts - Determine Licence Monitoring Stat
           abstractionPeriodStartMonth: 1,
           id: '0cfcfcb0-989e-481f-9cc1-10a69d82ff3f',
           measureType: 'level',
+          notes: 'I have a bad feeling about this',
           restrictionType: 'reduce',
           status: 'resume',
           statusUpdatedAt: null,
@@ -117,24 +147,71 @@ describe('Notices Setup - Abstraction Alerts - Determine Licence Monitoring Stat
             licenceRef: '02/02/02/3116'
           },
           thresholdGroup: 'level-100-m3/s'
+        },
+        {
+          abstractionPeriodEndDay: 31,
+          abstractionPeriodEndMonth: 3,
+          abstractionPeriodStartDay: 1,
+          abstractionPeriodStartMonth: 1,
+          id: '0cfcfcb0-989e-481f-9cc1-10a69d8434',
+          licence: {
+            id: '456',
+            licenceRef: '02/02/02/3116'
+          },
+          measureType: 'level',
+          notes: '"                   "             "                    "',
+          restrictionType: 'reduce',
+          status: 'resume',
+          statusUpdatedAt: null,
+          thresholdGroup: 'level-100-m3/s',
+          thresholdUnit: 'm3/s',
+          thresholdValue: 100
         }
       ],
-      monitoringStationId: monitoringStation.id,
+      monitoringStationId,
       monitoringStationName: 'MONITOR PLACE'
     })
   })
 
   describe('the "licenceMonitoringStations" property', () => {
     it('should add a "thresholdGroup" to the licence station', async () => {
-      const result = await DetermineLicenceMonitoringStationsService.go(monitoringStation.id)
+      const result = await DetermineLicenceMonitoringStationsService.go(monitoringStationId)
 
       expect(result.licenceMonitoringStations[0].thresholdGroup).to.equal('flow-100-m3/s')
     })
   })
 
+  describe('the "notes" property', () => {
+    describe('when there are "notes"', () => {
+      it('should set the "notes"', async () => {
+        const result = await DetermineLicenceMonitoringStationsService.go(monitoringStationId)
+
+        expect(result.licenceMonitoringStations[1].notes).to.equal('I have a bad feeling about this')
+      })
+    })
+
+    describe('when "notes" is null', () => {
+      it('should default the "notes" to null when no notes is null', async () => {
+        const result = await DetermineLicenceMonitoringStationsService.go(monitoringStationId)
+
+        expect(result.licenceMonitoringStations[0].notes).to.equal(null)
+      })
+    })
+
+    describe('when the "notes" is `"                   "             "                    "`', () => {
+      it('should set the "notes"', async () => {
+        const result = await DetermineLicenceMonitoringStationsService.go(monitoringStationId)
+
+        expect(result.licenceMonitoringStations[2].notes).to.equal(
+          '"                   "             "                    "'
+        )
+      })
+    })
+  })
+
   describe('the "monitoringStationName" property', () => {
     it('should return the monitoring station name', async () => {
-      const result = await DetermineLicenceMonitoringStationsService.go(monitoringStation.id)
+      const result = await DetermineLicenceMonitoringStationsService.go(monitoringStationId)
 
       expect(result.monitoringStationName).to.equal('MONITOR PLACE')
     })

--- a/test/services/notices/setup/abstraction-alerts/fetch-monitoring-station.service.test.js
+++ b/test/services/notices/setup/abstraction-alerts/fetch-monitoring-station.service.test.js
@@ -48,7 +48,8 @@ describe('Notices Setup - Abstraction Alerts - Fetch Monitoring Station service'
     licenceVersionPurpose = await LicenceVersionPurposesHelper.add()
 
     licenceVersionPurposeCondition = await LicenceVersionPurposeConditionHelper.add({
-      licenceVersionPurposeId: licenceVersionPurpose.id
+      licenceVersionPurposeId: licenceVersionPurpose.id,
+      notes: 'I have a bad feeling about this'
     })
 
     licenceMonitoringStationWithVersionPurpose = await LicenceMonitoringStationHelper.add({
@@ -100,7 +101,8 @@ describe('Notices Setup - Abstraction Alerts - Fetch Monitoring Station service'
               abstractionPeriodEndMonth: 3,
               abstractionPeriodStartDay: 1,
               abstractionPeriodStartMonth: 1
-            }
+            },
+            notes: 'I have a bad feeling about this'
           },
           measureType: 'flow',
           restrictionType: 'reduce',
@@ -134,7 +136,8 @@ describe('Notices Setup - Abstraction Alerts - Fetch Monitoring Station service'
             abstractionPeriodEndMonth: 3,
             abstractionPeriodStartDay: 1,
             abstractionPeriodStartMonth: 1
-          }
+          },
+          notes: 'I have a bad feeling about this'
         },
         measureType: 'flow',
         restrictionType: 'reduce',

--- a/test/services/notices/setup/batch-notifications.service.test.js
+++ b/test/services/notices/setup/batch-notifications.service.test.js
@@ -444,7 +444,7 @@ describe('Notices - Setup - Batch notifications service', () => {
             address_line_3: 'Little Whinging',
             address_line_4: 'Surrey',
             address_line_5: 'WD25 7LR',
-            condition_text: '',
+            condition_text: 'Effect of restriction: I have a bad feeling about this',
             threshold_unit: 'm3/s',
             threshold_value: 100,
             issuer_email_address: 'luke.skywalker@rebelmail.test',


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5067

We have previously implemented part of the notification presenter. We left out some of the personalisation to be done in later changes.

This is one of those changes.

This change adds the 'condition_text' to the personalisation. This is conditional logic when the monitoring station has a licence version purpose and that purpose has notes.

The notes could be a string, an empty sting or null.