### PR TITLE
Fix notices reminders returns period page title

### DIFF
--- a/app/presenters/notices/setup/returns-period/returns-period.presenter.js
+++ b/app/presenters/notices/setup/returns-period/returns-period.presenter.js
@@ -17,12 +17,13 @@ const { formatLongDate } = require('../../../base.presenter.js')
  * @returns {object} - The data formatted for the view template
  */
 function go(session) {
-  const { referenceCode } = session
+  const { referenceCode, journey } = session
 
   const savedReturnsPeriod = session.returnsPeriod ?? null
 
   return {
     backLink: '/manage',
+    pageTitle: `Select the returns periods for the ${journey}`,
     referenceCode,
     returnsPeriod: _returnsPeriod(savedReturnsPeriod)
   }

--- a/app/services/notices/setup/returns-period/returns-period.service.js
+++ b/app/services/notices/setup/returns-period/returns-period.service.js
@@ -22,7 +22,6 @@ async function go(sessionId) {
 
   return {
     activeNavBar: 'manage',
-    pageTitle: 'Select the returns periods for the invitations',
     ...formattedData
   }
 }

--- a/app/services/notices/setup/returns-period/submit-returns-period.service.js
+++ b/app/services/notices/setup/returns-period/submit-returns-period.service.js
@@ -30,7 +30,6 @@ async function go(sessionId, payload) {
     return {
       activeNavBar: 'manage',
       error: validationResult,
-      pageTitle: 'Select the returns periods for the invitations',
       ...formattedData
     }
   }

--- a/test/presenters/notices/setup/returns-period/returns-period.presenter.test.js
+++ b/test/presenters/notices/setup/returns-period/returns-period.presenter.test.js
@@ -27,7 +27,7 @@ describe('Notices - Setup - Returns Period presenter', () => {
 
   describe('the data', () => {
     beforeEach(() => {
-      session = { referenceCode: 'RINV-123' }
+      session = { referenceCode: 'RINV-123', journey: 'invitations' }
       testDate = new Date(`${currentYear}-01-15`)
       clock = Sinon.useFakeTimers(testDate)
     })
@@ -38,10 +38,39 @@ describe('Notices - Setup - Returns Period presenter', () => {
       expect(result).to.equal(
         {
           backLink: '/manage',
+          pageTitle: 'Select the returns periods for the invitations',
           referenceCode: 'RINV-123'
         },
         { skip: ['returnsPeriod'] }
       )
+    })
+  })
+
+  describe('the "pageTitle" property', () => {
+    beforeEach(() => {
+      session = { referenceCode: 'RINV-123', journey: 'invitations' }
+      testDate = new Date(`${currentYear}-01-15`)
+      clock = Sinon.useFakeTimers(testDate)
+    })
+
+    describe('when the journey is "invitations"', () => {
+      it('correctly presents the data', () => {
+        const result = ReturnsPeriodPresenter.go(session)
+
+        expect(result.pageTitle).to.equal('Select the returns periods for the invitations')
+      })
+    })
+
+    describe('when the journey is "reminders"', () => {
+      beforeEach(() => {
+        session.journey = 'reminders'
+      })
+
+      it('correctly presents the data', () => {
+        const result = ReturnsPeriodPresenter.go(session)
+
+        expect(result.pageTitle).to.equal('Select the returns periods for the reminders')
+      })
     })
   })
 

--- a/test/services/notices/setup/returns-period/returns-period.service.test.js
+++ b/test/services/notices/setup/returns-period/returns-period.service.test.js
@@ -19,7 +19,7 @@ describe('Notices - Setup - Returns Period service', () => {
   let session
 
   before(async () => {
-    session = await SessionHelper.add({ data: { referenceCode: 'RINV-123' } })
+    session = await SessionHelper.add({ data: { referenceCode: 'RINV-123', journey: 'invitations' } })
 
     const testDate = new Date('2024-12-01')
 

--- a/test/services/notices/setup/returns-period/submit-returns-period.services.test.js
+++ b/test/services/notices/setup/returns-period/submit-returns-period.services.test.js
@@ -69,9 +69,10 @@ describe('Notices - Setup - Submit Returns Period service', () => {
 
     describe('fails validation', () => {
       beforeEach(async () => {
-        session = await SessionHelper.add({ data: { referenceCode: 'RINV-1234' } })
+        session = await SessionHelper.add({ data: { referenceCode: 'RINV-1234', journey: 'invitations' } })
         payload = {}
       })
+
       it('correctly presents the data with the error', async () => {
         const result = await SubmitReturnsPeriodService.go(session.id, payload)
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4780

We have accidentally hardcoded the page title to 'invitations'. When we are on the reminders page we should show 'Select the returns periods for the reminders'

This change updates the page title to use the session to show the correct text.

This change also lift the page title out of the services and into the presenter. This reduces duplicate logic.