### PR TITLE
Update fetch abstraction alert recipients service

### DIFF
--- a/app/services/notices/setup/fetch-abstraction-alert-recipients.service.js
+++ b/app/services/notices/setup/fetch-abstraction-alert-recipients.service.js
@@ -18,6 +18,17 @@ const { db } = require('../../../../db/db.js')
  *
  * We will receive an array of licence refs in the session for our query. Theses are used to get the recipients.
  *
+ * Recipients can come from three contact types:
+ * - 'additional contact' - an email address
+ * - 'primary user' - an email address
+ * - 'licence holder' - a letter
+ *
+ * Each licence can have multiple additional contacts, regardless of the total number if there is at least one
+ * 'additional contact'. Then this is the recipient.
+ *
+ * Otherwise, we revert to the logic listed below, which is similar to how we get recipients for the ad-hoc and returns
+ * journeys.
+ *
  * For each licence, we extract the contact information, if a licence is _registered_ (more details below), we only care
  * about the email addresses registered against it, all licences should have a 'licence holder' contact to fall back on.
  *
@@ -31,10 +42,6 @@ const { db } = require('../../../../db/db.js')
  *
  * If a licence is registered, we only extract the email contacts. Unregistered licences it's the 'Licence holder'
  * contact from `licence_document_headers.metadata->contacts`.
- *
- * When the licence is registered we can expect an 'additional contact'. This can be created a user and is stored in
- * `crm_v2`. As the 'primary user' is in `crm.document_headers` and the 'additional contact' stored in `crm_v2.document`
- * we need to accommodate this by linking the two 'copies' of the licence together, we do this by the licence ref.
  *
  * Because we are working with `licence_document_header` we get one row per licence. So, the next step is to group the
  * contacts by their contact information.
@@ -65,87 +72,131 @@ async function _fetch(session) {
 
 function _query() {
   return `
+  WITH additional_contacts AS (
+    SELECT
+      DISTINCT
+      ldh.licence_ref,
+      'Additional contact' AS contact_type,
+      con.email,
+      NULL::jsonb AS contact,
+      md5(LOWER(con.email)) AS contact_hash_id
+    FROM
+      public.licence_document_headers ldh
+        INNER JOIN public.licence_documents ld
+                   ON ld.licence_ref = ldh.licence_ref
+        INNER JOIN public.licence_document_roles ldr
+                   ON ldr.licence_document_id = ld.id
+        INNER JOIN public.company_contacts cct
+                   ON cct.company_id = ldr.company_id
+        INNER JOIN public.contacts con
+                   ON con.id = cct.contact_id
+        INNER JOIN public.licence_roles lr
+                   ON lr.id = cct.licence_role_id
+    WHERE
+      ldh.licence_ref = ANY (?)
+    -- <- parameterised
+  ),
+
+       primary_users AS (
+         SELECT
+           ldh.licence_ref,
+           'Primary user' AS contact_type,
+           le.name AS email,
+           NULL::jsonb AS contact,
+           md5(LOWER(le.name)) AS contact_hash_id
+         FROM
+           public.licence_document_headers ldh
+             INNER JOIN public.licence_entity_roles ler
+                        ON ler.company_entity_id = ldh.company_entity_id
+                          AND ler.role = 'primary_user'
+             INNER JOIN public.licence_entities le
+                        ON le.id = ler.licence_entity_id
+         WHERE
+           ldh.licence_ref = ANY (?)
+         -- <- parameterised
+       ),
+
+       licence_holders AS (
+         SELECT
+           ldh.licence_ref,
+           'Licence holder' AS contact_type,
+           NULL AS email,
+           contacts AS contact,
+           md5(LOWER(concat_ws(
+             '',
+             contacts ->> 'salutation', contacts ->> 'forename', contacts ->> 'initials',
+             contacts ->> 'name', contacts ->> 'addressLine1', contacts ->> 'addressLine2',
+             contacts ->> 'addressLine3', contacts ->> 'addressLine4', contacts ->> 'town',
+             contacts ->> 'county', contacts ->> 'postcode', contacts ->> 'country'
+                     ))) AS contact_hash_id
+         FROM
+           public.licence_document_headers ldh
+             INNER JOIN LATERAL jsonb_array_elements(ldh.metadata -> 'contacts') AS contacts
+                        ON TRUE
+         WHERE
+           ldh.licence_ref = ANY (?)
+           -- <- parameterised
+           AND contacts ->> 'role' = 'Licence holder'
+       ),
+
+       all_possible AS (
+         SELECT
+           *
+         FROM
+           additional_contacts
+         UNION ALL
+         SELECT
+           *
+         FROM
+           primary_users
+         UNION ALL
+         SELECT
+           *
+         FROM
+           licence_holders
+       ),
+
+       ranked AS (
+         SELECT
+           *,
+           ROW_NUMBER() OVER (
+             PARTITION BY licence_ref
+             ORDER BY
+               CASE
+                 contact_type
+                 WHEN 'Additional contact' THEN 1
+                 WHEN 'Primary user' THEN 2
+                 WHEN 'Licence holder' THEN 3
+                 END
+             ) AS rn,
+           COUNT(*) FILTER (
+             WHERE
+             contact_type = 'Additional contact'
+             ) OVER (
+             PARTITION BY licence_ref
+             ) AS additional_count
+         FROM
+           all_possible
+       )
+
   SELECT
-    string_agg(licence_ref, ',' ORDER BY licence_ref) AS licence_refs,
+    licence_ref AS licence_refs,
     contact_type,
     email,
     contact,
     contact_hash_id
-  FROM (
-    SELECT DISTINCT
-      ldh.licence_ref,
-      (contacts ->> 'role') AS contact_type,
-      (NULL) AS email,
-      contacts AS contact,
-      (md5(
-        LOWER(
-          concat(
-            contacts ->> 'salutation', contacts ->> 'forename', contacts ->> 'initials',
-            contacts ->> 'name', contacts ->> 'addressLine1', contacts ->> 'addressLine2',
-            contacts ->> 'addressLine3', contacts ->> 'addressLine4', contacts ->> 'town',
-            contacts ->> 'county', contacts ->> 'postcode', contacts ->> 'country')
-          )
-        )
-      ) AS contact_hash_id
-    FROM
-      public.licence_document_headers ldh
-    INNER JOIN LATERAL jsonb_array_elements(ldh.metadata -> 'contacts') AS contacts
-      ON TRUE
-    WHERE
-      ldh.licence_ref = ANY (?)
-      AND contacts ->> 'role' IN ('Licence holder')
-      AND NOT EXISTS (
-        SELECT
-          1
-        FROM
-          public.licence_entity_roles ler
-        WHERE
-          ler.company_entity_id = ldh.company_entity_id
-          AND ler."role" IN ('primary_user')
+  FROM
+    ranked
+  WHERE
+    (
+      contact_type = 'Additional contact'
       )
-    UNION ALL
-    SELECT
-      ldh.licence_ref,
-      ('Primary user') AS contact_type,
-      le."name" AS email,
-      (NULL) AS contact,
-      md5(LOWER(le."name")) AS contact_hash_id
-    FROM
-      public.licence_document_headers ldh
-    INNER JOIN public.licence_entity_roles ler
-      ON ler.company_entity_id = ldh.company_entity_id
-      AND ler."role" = 'primary_user'
-    INNER JOIN public.licence_entities le
-      ON le.id = ler.licence_entity_id
-    WHERE
-      ldh.licence_ref = ANY (?)
-    UNION ALL
-    SELECT DISTINCT
-      ldh.licence_ref,
-      ('Additional contact') AS contact_type,
-      con.email AS email,
-      (NULL::jsonb) AS contact,
-      md5(LOWER(con.email)) AS contact_hash_id
-    FROM
-      public.licence_document_headers ldh
-    INNER JOIN public.licence_documents ld
-      ON ld.licence_ref = ldh.licence_ref
-    INNER JOIN public.licence_document_roles AS ldr
-      ON ldr.licence_document_id = ld.id
-    INNER JOIN public.company_contacts AS cct
-      ON cct.company_id = ldr.company_id
-    INNER JOIN public.contacts AS con
-      ON con.id = cct.contact_id
-    INNER JOIN public.licence_roles AS lr
-      ON lr.id = cct.licence_role_id
-    WHERE
-      ldh.licence_ref = ANY (?)
-  ) contacts
-  GROUP BY
-    contact_type,
-    email,
-    contact,
-    contact_hash_id;
+     OR (
+    additional_count = 0
+      AND rn = 1
+    )
+  ORDER BY
+    licence_ref;
 `
 }
 

--- a/test/fixtures/recipients.fixtures.js
+++ b/test/fixtures/recipients.fixtures.js
@@ -8,12 +8,10 @@ const { generateLicenceRef } = require('../support/helpers/licence.helper.js')
  * @returns {object} - Returns recipients for primaryUser, licenceHolder and additional contact
  */
 function alertsRecipients() {
-  const licenceRef = generateLicenceRef()
-
   return {
-    additionalContact: _addAdditionalContact(licenceRef),
+    additionalContact: _addAdditionalContact(),
     licenceHolder: _addLicenceHolder(),
-    primaryUser: _addPrimaryUser(licenceRef)
+    primaryUser: _addPrimaryUser()
   }
 }
 
@@ -34,9 +32,9 @@ function recipients() {
 }
 
 // an additional contact will always be associated with a primary user or licence holder by the licence ref
-function _addAdditionalContact(licenceRef) {
+function _addAdditionalContact() {
   return {
-    licence_refs: licenceRef,
+    licence_refs: generateLicenceRef(),
     contact: null,
     contact_hash_id: '90129f6aa5b98734aa3fefd3f8cf86a',
     contact_type: 'Additional contact',
@@ -88,9 +86,9 @@ function _addLicenceHolder() {
   }
 }
 
-function _addPrimaryUser(licenceRef) {
+function _addPrimaryUser() {
   return {
-    licence_refs: licenceRef || generateLicenceRef(),
+    licence_refs: generateLicenceRef(),
     contact: null,
     contact_hash_id: '90129f6aa5bf2ad50aa3fefd3f8cf86a',
     contact_type: 'Primary user',

--- a/test/presenters/notices/setup/abstraction-alert-download-recipients.presenter.test.js
+++ b/test/presenters/notices/setup/abstraction-alert-download-recipients.presenter.test.js
@@ -26,7 +26,8 @@ describe('Notices - Setup - Abstraction alert download recipients presenter', ()
 
     const relevantLicenceMonitoringStations = AbstractionAlertSessionData.relevantLicenceMonitoringStations([
       recipients.primaryUser.licence_refs,
-      recipients.licenceHolder.licence_refs
+      recipients.licenceHolder.licence_refs,
+      recipients.additionalContact.licence_refs
     ])
 
     session = {
@@ -41,12 +42,12 @@ describe('Notices - Setup - Abstraction alert download recipients presenter', ()
     expect(result).to.equal(
       // Headers
       'Licence,Abstraction periods,Measure type,Threshold,Notification type,Message type,Contact type,Email,Recipient name,Address line 1,Address line 2,Address line 3,Address line 4,Address line 5,Address line 6,Postcode\n' +
-        // Row - Additional contact
-        `"${recipients.primaryUser.licence_refs}","1 February to 1 January","level","1000 m","Abstraction alert","email","Additional contact","additional.contact@important.com",,,,,,,,\n` +
         // Row - Primary user
         `"${recipients.primaryUser.licence_refs}","1 February to 1 January","level","1000 m","Abstraction alert","email","Primary user","primary.user@important.com",,,,,,,,\n` +
         // Row - Licence holder
-        `"${recipients.licenceHolder.licence_refs}","1 January to 31 March","flow","100 m3/s","Abstraction alert","letter","Licence holder",,"Mr H J Licence holder","1","Privet Drive",,,"Little Whinging",,"WD25 7LR"\n`
+        `"${recipients.licenceHolder.licence_refs}","1 January to 31 March","flow","100 m3/s","Abstraction alert","letter","Licence holder",,"Mr H J Licence holder","1","Privet Drive",,,"Little Whinging",,"WD25 7LR"\n` +
+        // Row - Additional contact
+        `"${recipients.additionalContact.licence_refs}","1 January to 31 March","level","100 m","Abstraction alert","email","Additional contact","additional.contact@important.com",,,,,,,,\n`
     )
   })
 
@@ -78,6 +79,35 @@ describe('Notices - Setup - Abstraction alert download recipients presenter', ()
     )
   })
 
+  describe('when the recipient is an "additional contact"', () => {
+    it('correctly formats the row', () => {
+      const result = AbstractionAlertDownloadRecipientsPresenter.go([recipients.additionalContact], session)
+
+      let [, row] = result.split('\n')
+      // We want to test the row includes the new line
+      row += '\n'
+
+      expect(row).to.equal(
+        `"${recipients.additionalContact.licence_refs}",` + // Licence
+          '"1 January to 31 March",' + // 'Abstraction periods'
+          '"level",' + // 'Measure type'
+          '"100 m",' + // 'Threshold'
+          '"Abstraction alert",' + // 'Notification type'
+          '"email",' + // 'Message type'
+          '"Additional contact",' + // 'Contact type'
+          '"additional.contact@important.com",' + // Email
+          ',' + // 'Recipient name''
+          ',' + // 'Address line 1'
+          ',' + // 'Address line 2'
+          ',' + // 'Address line 3'
+          ',' + // 'Address line 4'
+          ',' + // 'Address line 5'
+          ',' + // 'Address line 6'
+          '\n' // Postcode and End of CSV line
+      )
+    })
+  })
+
   describe('when the recipient is a "primary_user"', () => {
     it('correctly formats the row', () => {
       const result = AbstractionAlertDownloadRecipientsPresenter.go([recipients.primaryUser], session)
@@ -87,7 +117,7 @@ describe('Notices - Setup - Abstraction alert download recipients presenter', ()
       row += '\n'
 
       expect(row).to.equal(
-        `"${recipients.additionalContact.licence_refs}",` + // Licence
+        `"${recipients.primaryUser.licence_refs}",` + // Licence
           '"1 February to 1 January",' + // 'Abstraction periods'
           '"level",' + // 'Measure type'
           '"1000 m",' + // 'Threshold'

--- a/test/presenters/notices/setup/abstraction-alert-notifications.presenter.test.js
+++ b/test/presenters/notices/setup/abstraction-alert-notifications.presenter.test.js
@@ -33,7 +33,8 @@ describe('Notices - Setup - Abstraction alert notifications presenter', () => {
 
     const relevantLicenceMonitoringStations = AbstractionAlertSessionData.relevantLicenceMonitoringStations([
       recipients.primaryUser.licence_refs,
-      recipients.licenceHolder.licence_refs
+      recipients.licenceHolder.licence_refs,
+      recipients.additionalContact.licence_refs
     ])
 
     session = {
@@ -56,26 +57,6 @@ describe('Notices - Setup - Abstraction alert notifications presenter', () => {
     const result = AbstractionAlertsNotificationsPresenter.go(testRecipients, session, eventId)
 
     expect(result).to.equal([
-      {
-        createdAt: '2025-01-01T00:00:00.000Z',
-        eventId: 'c1cae668-3dad-4806-94e2-eb3f27222ed9',
-        reference: 'TEST-123',
-        templateId: '6ec7265d-8ebb-4217-a62b-9bf0216f8c9f',
-        licences: `["${recipients.additionalContact.licence_refs}"]`,
-        messageType: 'email',
-        messageRef: 'water_abstraction_alert_reduce_warning_email',
-        personalisation: {
-          condition_text: '',
-          flow_or_level: 'level',
-          issuer_email_address: 'luke.skywalker@rebelmail.test',
-          licence_ref: recipients.additionalContact.licence_refs,
-          monitoring_station_name: 'Death star',
-          source: '* Source of supply: Meridian Trench',
-          threshold_unit: 'm',
-          threshold_value: 1000
-        },
-        recipient: 'additional.contact@important.com'
-      },
       {
         createdAt: '2025-01-01T00:00:00.000Z',
         eventId: 'c1cae668-3dad-4806-94e2-eb3f27222ed9',
@@ -122,6 +103,26 @@ describe('Notices - Setup - Abstraction alert notifications presenter', () => {
           threshold_unit: 'm3/s',
           threshold_value: 100
         }
+      },
+      {
+        createdAt: '2025-01-01T00:00:00.000Z',
+        eventId: 'c1cae668-3dad-4806-94e2-eb3f27222ed9',
+        reference: 'TEST-123',
+        templateId: '6ec7265d-8ebb-4217-a62b-9bf0216f8c9f',
+        licences: `["${recipients.additionalContact.licence_refs}"]`,
+        messageType: 'email',
+        messageRef: 'water_abstraction_alert_stop_warning_email',
+        personalisation: {
+          condition_text: '',
+          flow_or_level: 'level',
+          issuer_email_address: 'luke.skywalker@rebelmail.test',
+          licence_ref: recipients.additionalContact.licence_refs,
+          monitoring_station_name: 'Death star',
+          source: '* Source of supply: Meridian Trench',
+          threshold_unit: 'm',
+          threshold_value: 100
+        },
+        recipient: 'additional.contact@important.com'
       }
     ])
   })
@@ -135,6 +136,63 @@ describe('Notices - Setup - Abstraction alert notifications presenter', () => {
     })
 
     it('correctly transform the recipients (and associated licence monitoring stations) into notifications for the same recipient', () => {
+      const result = AbstractionAlertsNotificationsPresenter.go(testRecipients, session, eventId)
+
+      expect(result).to.equal([
+        {
+          createdAt: '2025-01-01T00:00:00.000Z',
+          eventId: 'c1cae668-3dad-4806-94e2-eb3f27222ed9',
+          reference: 'TEST-123',
+          templateId: '6ec7265d-8ebb-4217-a62b-9bf0216f8c9f',
+          licences: `["${recipients.primaryUser.licence_refs}"]`,
+          messageType: 'email',
+          messageRef: 'water_abstraction_alert_reduce_warning_email',
+          personalisation: {
+            condition_text: '',
+            flow_or_level: 'level',
+            issuer_email_address: 'luke.skywalker@rebelmail.test',
+            licence_ref: recipients.primaryUser.licence_refs,
+            monitoring_station_name: 'Death star',
+            source: '* Source of supply: Meridian Trench',
+            threshold_unit: 'm',
+            threshold_value: 1000
+          },
+          recipient: 'primary.user@important.com'
+        },
+        {
+          createdAt: '2025-01-01T00:00:00.000Z',
+          eventId: 'c1cae668-3dad-4806-94e2-eb3f27222ed9',
+          licences: `["${recipients.primaryUser.licence_refs}"]`,
+          messageRef: 'water_abstraction_alert_stop_warning_email',
+          messageType: 'email',
+          personalisation: {
+            condition_text: 'Effect of restriction: I have a bad feeling about this',
+            flow_or_level: 'flow',
+            issuer_email_address: 'luke.skywalker@rebelmail.test',
+            licence_ref: recipients.primaryUser.licence_refs,
+            monitoring_station_name: 'Death star',
+            source: '* Source of supply: Meridian Trench',
+            threshold_unit: 'm3/s',
+            threshold_value: 100
+          },
+          recipient: 'primary.user@important.com',
+          reference: 'TEST-123',
+          templateId: '6ec7265d-8ebb-4217-a62b-9bf0216f8c9f'
+        }
+      ])
+    })
+  })
+
+  describe('when a "additional contact" has abstraction alerts', () => {
+    beforeEach(() => {
+      session.relevantLicenceMonitoringStations = AbstractionAlertSessionData.relevantLicenceMonitoringStations([
+        recipients.additionalContact.licence_refs
+      ])
+
+      testRecipients[0].licence_refs = recipients.additionalContact.licence_refs
+    })
+
+    it('correctly transform the recipients (and associated licence monitoring stations) into notifications', () => {
       const result = AbstractionAlertsNotificationsPresenter.go(testRecipients, session, eventId)
 
       expect(result).to.equal([
@@ -157,66 +215,6 @@ describe('Notices - Setup - Abstraction alert notifications presenter', () => {
             threshold_value: 1000
           },
           recipient: 'additional.contact@important.com'
-        },
-        {
-          createdAt: '2025-01-01T00:00:00.000Z',
-          eventId: 'c1cae668-3dad-4806-94e2-eb3f27222ed9',
-          licences: `["${recipients.primaryUser.licence_refs}"]`,
-          messageRef: 'water_abstraction_alert_reduce_warning_email',
-          messageType: 'email',
-          personalisation: {
-            condition_text: '',
-            flow_or_level: 'level',
-            issuer_email_address: 'luke.skywalker@rebelmail.test',
-            licence_ref: recipients.primaryUser.licence_refs,
-            monitoring_station_name: 'Death star',
-            source: '* Source of supply: Meridian Trench',
-            threshold_unit: 'm',
-            threshold_value: 1000
-          },
-          recipient: 'primary.user@important.com',
-          reference: 'TEST-123',
-          templateId: '6ec7265d-8ebb-4217-a62b-9bf0216f8c9f'
-        },
-        {
-          createdAt: '2025-01-01T00:00:00.000Z',
-          eventId: 'c1cae668-3dad-4806-94e2-eb3f27222ed9',
-          reference: 'TEST-123',
-          templateId: '6ec7265d-8ebb-4217-a62b-9bf0216f8c9f',
-          licences: `["${recipients.additionalContact.licence_refs}"]`,
-          messageType: 'email',
-          messageRef: 'water_abstraction_alert_stop_warning_email',
-          personalisation: {
-            condition_text: 'Effect of restriction: I have a bad feeling about this',
-            flow_or_level: 'flow',
-            issuer_email_address: 'luke.skywalker@rebelmail.test',
-            licence_ref: recipients.additionalContact.licence_refs,
-            monitoring_station_name: 'Death star',
-            source: '* Source of supply: Meridian Trench',
-            threshold_unit: 'm3/s',
-            threshold_value: 100
-          },
-          recipient: 'additional.contact@important.com'
-        },
-        {
-          createdAt: '2025-01-01T00:00:00.000Z',
-          eventId: 'c1cae668-3dad-4806-94e2-eb3f27222ed9',
-          licences: `["${recipients.primaryUser.licence_refs}"]`,
-          messageRef: 'water_abstraction_alert_stop_warning_email',
-          messageType: 'email',
-          personalisation: {
-            condition_text: 'Effect of restriction: I have a bad feeling about this',
-            flow_or_level: 'flow',
-            issuer_email_address: 'luke.skywalker@rebelmail.test',
-            licence_ref: recipients.primaryUser.licence_refs,
-            monitoring_station_name: 'Death star',
-            source: '* Source of supply: Meridian Trench',
-            threshold_unit: 'm3/s',
-            threshold_value: 100
-          },
-          recipient: 'primary.user@important.com',
-          reference: 'TEST-123',
-          templateId: '6ec7265d-8ebb-4217-a62b-9bf0216f8c9f'
         }
       ])
     })
@@ -256,61 +254,6 @@ describe('Notices - Setup - Abstraction alert notifications presenter', () => {
           recipient: 'primary.user@important.com'
         }
       ])
-    })
-
-    describe('when there is an "additional contact"', () => {
-      beforeEach(() => {
-        testRecipients[0].licence_refs = recipients.primaryUser.licence_refs
-      })
-
-      it('correctly transform the recipients (and associated licence monitoring stations) into notifications', () => {
-        const result = AbstractionAlertsNotificationsPresenter.go(testRecipients, session, eventId)
-
-        expect(result).to.equal([
-          {
-            createdAt: '2025-01-01T00:00:00.000Z',
-            eventId: 'c1cae668-3dad-4806-94e2-eb3f27222ed9',
-            reference: 'TEST-123',
-            templateId: '6ec7265d-8ebb-4217-a62b-9bf0216f8c9f',
-            licences: `["${recipients.additionalContact.licence_refs}"]`,
-            messageType: 'email',
-            messageRef: 'water_abstraction_alert_reduce_warning_email',
-            personalisation: {
-              condition_text: '',
-              flow_or_level: 'level',
-              issuer_email_address: 'luke.skywalker@rebelmail.test',
-              licence_ref: recipients.additionalContact.licence_refs,
-              monitoring_station_name: 'Death star',
-              source: '* Source of supply: Meridian Trench',
-              threshold_unit: 'm',
-              threshold_value: 1000
-            },
-
-            recipient: 'additional.contact@important.com'
-          },
-          {
-            createdAt: '2025-01-01T00:00:00.000Z',
-            eventId: 'c1cae668-3dad-4806-94e2-eb3f27222ed9',
-            reference: 'TEST-123',
-            templateId: '6ec7265d-8ebb-4217-a62b-9bf0216f8c9f',
-            licences: `["${recipients.primaryUser.licence_refs}"]`,
-            messageType: 'email',
-            messageRef: 'water_abstraction_alert_reduce_warning_email',
-            personalisation: {
-              condition_text: '',
-              flow_or_level: 'level',
-              issuer_email_address: 'luke.skywalker@rebelmail.test',
-              licence_ref: recipients.primaryUser.licence_refs,
-              monitoring_station_name: 'Death star',
-              source: '* Source of supply: Meridian Trench',
-              threshold_unit: 'm',
-              threshold_value: 1000
-            },
-
-            recipient: 'primary.user@important.com'
-          }
-        ])
-      })
     })
   })
 
@@ -352,65 +295,6 @@ describe('Notices - Setup - Abstraction alert notifications presenter', () => {
           }
         }
       ])
-    })
-
-    describe('when there is an "additional contact"', () => {
-      beforeEach(() => {
-        testRecipients[0].licence_refs = recipients.licenceHolder.licence_refs
-      })
-
-      it('correctly transform the recipients (and associated licence monitoring stations) into notifications', () => {
-        const result = AbstractionAlertsNotificationsPresenter.go(testRecipients, session, eventId)
-
-        expect(result).to.equal([
-          {
-            createdAt: '2025-01-01T00:00:00.000Z',
-            eventId: 'c1cae668-3dad-4806-94e2-eb3f27222ed9',
-            reference: 'TEST-123',
-            templateId: '6ec7265d-8ebb-4217-a62b-9bf0216f8c9f',
-            licences: `["${recipients.additionalContact.licence_refs}"]`,
-            messageType: 'email',
-            messageRef: 'water_abstraction_alert_reduce_warning_email',
-            personalisation: {
-              condition_text: '',
-              flow_or_level: 'level',
-              issuer_email_address: 'luke.skywalker@rebelmail.test',
-              licence_ref: recipients.additionalContact.licence_refs,
-              monitoring_station_name: 'Death star',
-              source: '* Source of supply: Meridian Trench',
-              threshold_unit: 'm',
-              threshold_value: 1000
-            },
-            recipient: 'additional.contact@important.com'
-          },
-          {
-            createdAt: '2025-01-01T00:00:00.000Z',
-            eventId: 'c1cae668-3dad-4806-94e2-eb3f27222ed9',
-            reference: 'TEST-123',
-            templateId: '27499bbd-e854-4f13-884e-30e0894526b6',
-            licences: `["${recipients.licenceHolder.licence_refs}"]`,
-            messageType: 'letter',
-            messageRef: 'water_abstraction_alert_reduce_warning',
-            personalisation: {
-              name: 'Mr H J Licence holder',
-              address_line_1: '1',
-              address_line_2: 'Privet Drive',
-              address_line_3: 'Little Whinging',
-              address_line_4: 'Surrey',
-              address_line_5: 'WD25 7LR',
-              // common personalisation
-              condition_text: '',
-              flow_or_level: 'level',
-              issuer_email_address: 'luke.skywalker@rebelmail.test',
-              licence_ref: recipients.licenceHolder.licence_refs,
-              monitoring_station_name: 'Death star',
-              source: '* Source of supply: Meridian Trench',
-              threshold_unit: 'm',
-              threshold_value: 1000
-            }
-          }
-        ])
-      })
     })
   })
 

--- a/test/services/notices/setup/batch-notifications.service.test.js
+++ b/test/services/notices/setup/batch-notifications.service.test.js
@@ -371,7 +371,8 @@ describe('Notices - Setup - Batch notifications service', () => {
 
       const relevantLicenceMonitoringStations = AbstractionAlertSessionData.relevantLicenceMonitoringStations([
         recipients.primaryUser.licence_refs,
-        recipients.licenceHolder.licence_refs
+        recipients.licenceHolder.licence_refs,
+        recipients.additionalContact.licence_refs
       ])
 
       session = {
@@ -416,7 +417,7 @@ describe('Notices - Setup - Batch notifications service', () => {
             flow_or_level: 'level',
             condition_text: '',
             threshold_unit: 'm',
-            threshold_value: 1000,
+            threshold_value: 100,
             issuer_email_address: 'luke.skywalker@rebelmail.test',
             monitoring_station_name: 'Death star'
           },

--- a/test/services/notices/setup/fetch-abstraction-alert-recipients.service.test.js
+++ b/test/services/notices/setup/fetch-abstraction-alert-recipients.service.test.js
@@ -17,6 +17,8 @@ const LicenceRoleHelper = require('../../../support/helpers/licence-role.helper.
 
 // Thing under test
 const FetchAbstractionAlertRecipientsService = require('../../../../app/services/notices/setup/fetch-abstraction-alert-recipients.service.js')
+const LicenceEntityHelper = require('../../../support/helpers/licence-entity.helper.js')
+const LicenceDocumentHeaderHelper = require('../../../support/helpers/licence-document-header.helper.js')
 
 describe('Notices - Setup - Fetch abstraction alert recipients service', () => {
   let recipients
@@ -24,6 +26,71 @@ describe('Notices - Setup - Fetch abstraction alert recipients service', () => {
 
   beforeEach(async () => {
     recipients = await LicenceDocumentHeaderSeeder.seed(false)
+  })
+
+  describe('when there is an "additional contact"', () => {
+    let licenceDocument
+
+    beforeEach(async () => {
+      licenceDocument = await LicenceDocumentHelper.add()
+
+      session = {
+        licenceRefs: [licenceDocument.licenceRef]
+      }
+
+      await _additionalContact(licenceDocument, {
+        firstName: 'Ron',
+        lastName: 'Burgundy',
+        email: 'Ron.Burgundy@news.com'
+      })
+    })
+
+    describe('and there is only one', () => {
+      it('correctly returns the "additional contact"', async () => {
+        const result = await FetchAbstractionAlertRecipientsService.go(session)
+
+        expect(result).to.equal([
+          {
+            contact: null,
+            contact_hash_id: 'c661b771974504933d79ca64249570d0',
+            contact_type: 'Additional contact',
+            email: 'Ron.Burgundy@news.com',
+            licence_refs: licenceDocument.licenceRef
+          }
+        ])
+      })
+    })
+
+    describe('and there are multiple "additional contact"', () => {
+      beforeEach(async () => {
+        await _additionalContact(licenceDocument, {
+          firstName: 'Brick',
+          lastName: 'Tamland',
+          email: 'Brick.Tamland@news.com'
+        })
+      })
+
+      it('correctly returns all the "additional contact"', async () => {
+        const result = await FetchAbstractionAlertRecipientsService.go(session)
+
+        expect(result).to.equal([
+          {
+            contact: null,
+            contact_hash_id: '70d3d94dd27d8b65e96392a85147a4cc',
+            contact_type: 'Additional contact',
+            email: 'Brick.Tamland@news.com',
+            licence_refs: licenceDocument.licenceRef
+          },
+          {
+            contact: null,
+            contact_hash_id: 'c661b771974504933d79ca64249570d0',
+            contact_type: 'Additional contact',
+            email: 'Ron.Burgundy@news.com',
+            licence_refs: licenceDocument.licenceRef
+          }
+        ])
+      })
+    })
   })
 
   describe('when there is a "primary user"', () => {
@@ -64,7 +131,7 @@ describe('Notices - Setup - Fetch abstraction alert recipients service', () => {
         })
       })
 
-      it('correctly returns the "additional contact" and the "primary user"', async () => {
+      it('correctly returns the "additional contact" and not the "primary user"', async () => {
         const result = await FetchAbstractionAlertRecipientsService.go(session)
 
         expect(result).to.equal([
@@ -74,65 +141,6 @@ describe('Notices - Setup - Fetch abstraction alert recipients service', () => {
             contact_type: 'Additional contact',
             email: 'Ron.Burgundy@news.com',
             licence_refs: recipients.primaryUser.licenceRef
-          },
-          {
-            licence_refs: recipients.primaryUser.licenceRef,
-            contact: null,
-            contact_hash_id: '90129f6aa5bf2ad50aa3fefd3f8cf86a',
-            contact_type: 'Primary user',
-            email: 'primary.user@important.com'
-          }
-        ])
-      })
-    })
-
-    describe('and there are multiple "additional contact"', () => {
-      beforeEach(async () => {
-        session = {
-          licenceRefs: [recipients.primaryUser.licenceRef]
-        }
-
-        const licenceDocument = await LicenceDocumentHelper.add({
-          licenceRef: recipients.primaryUser.licenceRef
-        })
-
-        await _additionalContact(licenceDocument, {
-          firstName: 'Ron',
-          lastName: 'Burgundy',
-          email: 'Ron.Burgundy@news.com'
-        })
-
-        await _additionalContact(licenceDocument, {
-          firstName: 'Brick',
-          lastName: 'Tamland',
-          email: 'Brick.Tamland@news.com'
-        })
-      })
-
-      it('correctly returns all the "additional contact" and the "primary user"', async () => {
-        const result = await FetchAbstractionAlertRecipientsService.go(session)
-
-        expect(result).to.equal([
-          {
-            contact: null,
-            contact_hash_id: '70d3d94dd27d8b65e96392a85147a4cc',
-            contact_type: 'Additional contact',
-            email: 'Brick.Tamland@news.com',
-            licence_refs: recipients.primaryUser.licenceRef
-          },
-          {
-            contact: null,
-            contact_hash_id: 'c661b771974504933d79ca64249570d0',
-            contact_type: 'Additional contact',
-            email: 'Ron.Burgundy@news.com',
-            licence_refs: recipients.primaryUser.licenceRef
-          },
-          {
-            licence_refs: recipients.primaryUser.licenceRef,
-            contact: null,
-            contact_hash_id: '90129f6aa5bf2ad50aa3fefd3f8cf86a',
-            contact_type: 'Primary user',
-            email: 'primary.user@important.com'
           }
         ])
       })
@@ -192,7 +200,7 @@ describe('Notices - Setup - Fetch abstraction alert recipients service', () => {
         })
       })
 
-      it('correctly returns the "additional contact" and the "licence holder"', async () => {
+      it('correctly returns the "additional contact" and not the "licence holder"', async () => {
         const result = await FetchAbstractionAlertRecipientsService.go(session)
 
         expect(result).to.equal([
@@ -202,28 +210,6 @@ describe('Notices - Setup - Fetch abstraction alert recipients service', () => {
             contact_type: 'Additional contact',
             email: 'Brian.Fantana@news.com',
             licence_refs: recipients.licenceHolder.licenceRef
-          },
-          {
-            licence_refs: recipients.licenceHolder.licenceRef,
-            contact: {
-              addressLine1: '4',
-              addressLine2: 'Privet Drive',
-              addressLine3: null,
-              addressLine4: null,
-              country: null,
-              county: 'Surrey',
-              forename: 'Harry',
-              initials: 'J',
-              name: 'Licence holder only',
-              postcode: 'WD25 7LR',
-              role: 'Licence holder',
-              salutation: null,
-              town: 'Little Whinging',
-              type: 'Person'
-            },
-            contact_hash_id: '22f6457b6be9fd63d8a9a8dd2ed61214',
-            contact_type: 'Licence holder',
-            email: null
           }
         ])
       })
@@ -231,14 +217,11 @@ describe('Notices - Setup - Fetch abstraction alert recipients service', () => {
   })
 
   describe('and there are recipients related to multiple licence refs', () => {
-    beforeEach(async () => {
-      session = {
-        licenceRefs: [recipients.primaryUser.licenceRef, recipients.licenceHolder.licenceRef]
-      }
+    let licenceDocument
+    let licenceDocument2
 
-      const licenceDocument = await LicenceDocumentHelper.add({
-        licenceRef: recipients.primaryUser.licenceRef
-      })
+    beforeEach(async () => {
+      licenceDocument = await LicenceDocumentHelper.add()
 
       await _additionalContact(licenceDocument, {
         firstName: 'Ron',
@@ -246,32 +229,57 @@ describe('Notices - Setup - Fetch abstraction alert recipients service', () => {
         email: 'Ron.Burgundy@news.com'
       })
 
-      const licenceDocument2 = await LicenceDocumentHelper.add({
-        licenceRef: recipients.licenceHolder.licenceRef
-      })
+      licenceDocument2 = await LicenceDocumentHelper.add()
 
       await _additionalContact(licenceDocument2, {
         firstName: 'Ron',
         lastName: 'Burgundy',
         email: 'Ron.Burgundy@news.com'
       })
+
+      session = {
+        licenceRefs: [licenceDocument.licenceRef, licenceDocument2.licenceRef]
+      }
     })
 
     it('correctly returns the "additional contact" with multiple licence refs', async () => {
       const result = await FetchAbstractionAlertRecipientsService.go(session)
 
-      expect(result[0]).to.equal({
+      const contact = result.find((contact) => {
+        return contact.licence_refs === licenceDocument.licenceRef
+      })
+
+      const contact2 = result.find((contact) => {
+        return contact.licence_refs === licenceDocument2.licenceRef
+      })
+
+      expect(contact).to.equal({
         contact: null,
         contact_hash_id: 'c661b771974504933d79ca64249570d0',
         contact_type: 'Additional contact',
         email: 'Ron.Burgundy@news.com',
-        licence_refs: [recipients.licenceHolder.licenceRef, recipients.primaryUser.licenceRef].sort().join(',')
+        licence_refs: licenceDocument.licenceRef
+      })
+
+      expect(contact2).to.equal({
+        contact: null,
+        contact_hash_id: 'c661b771974504933d79ca64249570d0',
+        contact_type: 'Additional contact',
+        email: 'Ron.Burgundy@news.com',
+        licence_refs: licenceDocument2.licenceRef
       })
     })
   })
 })
 
 async function _additionalContact(licenceDocument, contact) {
+  const companyEntity = await LicenceEntityHelper.add({ type: 'company' })
+
+  await LicenceDocumentHeaderHelper.add({
+    companyEntityId: companyEntity.id,
+    licenceRef: licenceDocument.licenceRef
+  })
+
   const licenceDocumentRole = await LicenceDocumentRoleHelper.add({
     licenceDocumentId: licenceDocument.id
   })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5067

We have previously implemented logic around getting recipients. This was wen a primary user was set then it would have priority over the licence holder, also known as a registered licence taking priority over an unregistered licence.

If either of these had an additional contact then we would also include them.

This is no longer the case.

This change update the existing logic to prioritise the additional contact over the primary user and licence holder.

So when one (or more) additional contacts are found for a licence this recipient/s will receive the notice.

If there are no additional contacts then we fall into our normal registered vs unregistered flow.