### PR TITLE
Remove tag - Set `deleted_at`

### DIFF
--- a/app/services/licence-monitoring-station/submit-remove.service.js
+++ b/app/services/licence-monitoring-station/submit-remove.service.js
@@ -18,7 +18,7 @@ const LicenceMonitoringStationModel = require('../../models/licence-monitoring-s
  * @param {object} yar - The Hapi `request.yar` session manager passed on by the controller
  */
 async function go(licenceMonitoringStationId, licenceRef, yar) {
-  await LicenceMonitoringStationModel.query().deleteById(licenceMonitoringStationId)
+  await LicenceMonitoringStationModel.query().update({ deletedAt: new Date() }).where('id', licenceMonitoringStationId)
 
   GeneralLib.flashNotification(yar, 'Updated', `Tag removed for ${licenceRef}`)
 }

--- a/app/services/licence-monitoring-station/submit-remove.service.js
+++ b/app/services/licence-monitoring-station/submit-remove.service.js
@@ -1,7 +1,7 @@
 'use strict'
 
 /**
- * Manages removing the licence monitoring station record when remove tag is confirmed
+ * Manages updating the licence monitoring station record as deleted when remove tag is confirmed
  * @module SubmitRemoveService
  */
 
@@ -9,12 +9,13 @@ const GeneralLib = require('../../lib/general.lib.js')
 const LicenceMonitoringStationModel = require('../../models/licence-monitoring-station.model.js')
 
 /**
- * Manages removing the licence monitoring station record when remove tag is confirmed
+ * Manages updating the licence monitoring station record as deleted when remove tag is confirmed
  *
- * The licence monitoring station record is deleted from the database when a user confirms via the "Remove tag" button.
+ * The licence monitoring station record has the "deleteAt" field set to the current date when a user confirms deletion
+ * via the "Remove tag" button.
  *
  * @param {string} licenceMonitoringStationId - The UUID for the licence monitoring station record
- * @param {string} licenceRef - The reference of the licence being removed
+ * @param {string} licenceRef - The reference of the licence
  * @param {object} yar - The Hapi `request.yar` session manager passed on by the controller
  */
 async function go(licenceMonitoringStationId, licenceRef, yar) {

--- a/app/services/licence-monitoring-station/submit-remove.service.js
+++ b/app/services/licence-monitoring-station/submit-remove.service.js
@@ -5,7 +5,7 @@
  * @module SubmitRemoveService
  */
 
-const GeneralLib = require('../../lib/general.lib.js')
+const { flashNotification, timestampForPostgres } = require('../../lib/general.lib.js')
 const LicenceMonitoringStationModel = require('../../models/licence-monitoring-station.model.js')
 
 /**
@@ -19,9 +19,11 @@ const LicenceMonitoringStationModel = require('../../models/licence-monitoring-s
  * @param {object} yar - The Hapi `request.yar` session manager passed on by the controller
  */
 async function go(licenceMonitoringStationId, licenceRef, yar) {
-  await LicenceMonitoringStationModel.query().update({ deletedAt: new Date() }).where('id', licenceMonitoringStationId)
+  await LicenceMonitoringStationModel.query()
+    .update({ deletedAt: timestampForPostgres() })
+    .where('id', licenceMonitoringStationId)
 
-  GeneralLib.flashNotification(yar, 'Updated', `Tag removed for ${licenceRef}`)
+  flashNotification(yar, 'Updated', `Tag removed for ${licenceRef}`)
 }
 
 module.exports = {

--- a/test/services/licence-monitoring-station/submit-remove.service.test.js
+++ b/test/services/licence-monitoring-station/submit-remove.service.test.js
@@ -32,7 +32,7 @@ describe('Licence Monitoring Station - Submit Remove service', () => {
 
       const refreshedSession = await licenceMonitoringStation.$query()
 
-      expect(refreshedSession).not.to.exist()
+      expect(refreshedSession.deletedAt).to.not.be.null()
     })
 
     it('sets the notification message title to "Updated" and the text to "Tag removed for 99/999/9999" ', async () => {

--- a/test/services/licence-monitoring-station/submit-remove.service.test.js
+++ b/test/services/licence-monitoring-station/submit-remove.service.test.js
@@ -27,7 +27,7 @@ describe('Licence Monitoring Station - Submit Remove service', () => {
   })
 
   describe('when a user submits the licence monitoring station to be removed', () => {
-    it('deletes the licence monitoring station record', async () => {
+    it('adds the current date to the "deletedAt" field of the licence monitoring station record', async () => {
       await SubmitRemoveService.go(licenceMonitoringStation.id, licenceRef, yarStub)
 
       const refreshedSession = await licenceMonitoringStation.$query()


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5003

We spotted that the new functionality to remove a monitoring stations' tag from a licence is deleting the `licence_monitoring_stations` record rather than adding a date to the `deleted_at` field.

This PR will fix that.