### PR TITLE
Add clean empty void return logs task to clean job

### DIFF
--- a/app/services/jobs/clean/clean-empty-void-return-logs.service.js
+++ b/app/services/jobs/clean/clean-empty-void-return-logs.service.js
@@ -1,0 +1,28 @@
+'use strict'
+
+/**
+ * Deletes voided return logs which have not been received and have no return submissions
+ * @module CleanEmptyVoidReturnLogsService
+ */
+
+const ReturnLogModel = require('../../../models/return-log.model.js')
+const ReturnSubmissionModel = require('../../../models/return-submission.model.js')
+
+/**
+ * Deletes voided return logs which have not been received and have no return submissions
+ *
+ * @returns {Promise<number>} The number of rows deleted
+ */
+async function go() {
+  return ReturnLogModel.query()
+    .delete()
+    .where('status', 'void')
+    .whereNull('receivedDate')
+    .whereNotExists(
+      ReturnSubmissionModel.query().select(1).whereColumn('returnSubmissions.returnLogId', 'returnLogs.id')
+    )
+}
+
+module.exports = {
+  go
+}

--- a/app/services/jobs/clean/process-clean.service.js
+++ b/app/services/jobs/clean/process-clean.service.js
@@ -6,6 +6,7 @@
  */
 
 const CleanExpiredSessionsService = require('./clean-expired-sessions.service.js')
+const CleanEmptyVoidReturnLogsService = require('./clean-empty-void-return-logs.service.js')
 const { calculateAndLogTimeTaken, currentTimeInNanoseconds } = require('../../../lib/general.lib.js')
 
 /**
@@ -15,10 +16,11 @@ async function go() {
   try {
     const startTime = currentTimeInNanoseconds()
 
+    const emptyVoidReturnLogsCount = await CleanEmptyVoidReturnLogsService.go()
     const expiredSessionsCount = await CleanExpiredSessionsService.go()
 
     calculateAndLogTimeTaken(startTime, 'Clean job complete', {
-      counts: { expiredSessions: expiredSessionsCount }
+      counts: { emptyVoidReturnLogs: emptyVoidReturnLogsCount, expiredSessions: expiredSessionsCount }
     })
   } catch (error) {
     global.GlobalNotifier.omfg('Clean job failed', {}, error)

--- a/app/services/jobs/clean/process-clean.service.js
+++ b/app/services/jobs/clean/process-clean.service.js
@@ -5,8 +5,8 @@
  * @module ProcessCleanService
  */
 
-const CleanExpiredSessionsService = require('./clean-expired-sessions.service.js')
 const CleanEmptyVoidReturnLogsService = require('./clean-empty-void-return-logs.service.js')
+const CleanExpiredSessionsService = require('./clean-expired-sessions.service.js')
 const { calculateAndLogTimeTaken, currentTimeInNanoseconds } = require('../../../lib/general.lib.js')
 
 /**

--- a/test/services/jobs/clean/clean-empty-void-return-logs.service.test.js
+++ b/test/services/jobs/clean/clean-empty-void-return-logs.service.test.js
@@ -1,0 +1,87 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Test helpers
+const ReturnLogHelper = require('../../../support/helpers/return-log.helper.js')
+const ReturnLogModel = require('../../../../app/models/return-log.model.js')
+const ReturnSubmissionHelper = require('../../../support/helpers/return-submission.helper.js')
+
+// Thing under test
+const CleanEmptyVoidReturnLogsService = require('../../../../app/services/jobs/clean/clean-empty-void-return-logs.service.js')
+
+describe('Jobs - Clean - Clean Empty Void Return Logs service', () => {
+  let returnLog
+
+  afterEach(() => {
+    Sinon.restore()
+  })
+
+  describe('when the clean is successful', () => {
+    describe('and there is a void return without a submission', () => {
+      describe('and it was not marked as "received" before being voided', () => {
+        beforeEach(async () => {
+          returnLog = await ReturnLogHelper.add({ status: 'void' })
+        })
+
+        it('removes the return log', async () => {
+          await CleanEmptyVoidReturnLogsService.go()
+
+          const results = await ReturnLogModel.query().whereIn('id', [returnLog.id])
+
+          expect(results).to.have.length(0)
+        })
+      })
+
+      describe('but it was marked as "received" before being voided', () => {
+        beforeEach(async () => {
+          returnLog = await ReturnLogHelper.add({ status: 'void', receivedDate: new Date() })
+        })
+
+        it('does not remove the return log', async () => {
+          await CleanEmptyVoidReturnLogsService.go()
+
+          const results = await ReturnLogModel.query().whereIn('id', [returnLog.id])
+
+          expect(results).to.have.length(1)
+        })
+      })
+    })
+
+    describe('when there is a void return with a submission', () => {
+      beforeEach(async () => {
+        returnLog = await ReturnLogHelper.add({ status: 'void' })
+        await ReturnSubmissionHelper.add({ returnLogId: returnLog.id })
+      })
+
+      it('does not remove the return log', async () => {
+        await CleanEmptyVoidReturnLogsService.go()
+
+        const results = await ReturnLogModel.query().whereIn('id', [returnLog.id])
+
+        expect(results).to.have.length(1)
+      })
+    })
+  })
+
+  describe('when the clean errors', () => {
+    beforeEach(() => {
+      Sinon.stub(ReturnLogModel, 'query').returns({
+        delete: Sinon.stub().returnsThis(),
+        where: Sinon.stub().returnsThis(),
+        whereNotNull: Sinon.stub().returnsThis(),
+        whereNotExists: Sinon.stub().rejects()
+      })
+    })
+
+    it('throws an error', async () => {
+      await expect(CleanEmptyVoidReturnLogsService.go()).to.reject()
+    })
+  })
+})


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5075

With WRLS taking over management of returns, plus the new quarterly returns functionality, there is likely to be an increase in the number of VOID returns generated.

In NALD, the return logs were only generated at the point where the business would send out invites to customers to submit them. In WRLS, we are generating for the current cycle, ahead of when we send the invite. Should a user need to make a change, for example, due to an error in NALD, nothing would need to be voided. In WRLS, at least one return log will need to be. If it's a licence with a quarterly requirement, it could be four.

Knowing this, we don't want the voids to become 'noise' and start swamping the actual return logs within the service.

In [Refactor session cleanup job to be general clean](https://github.com/DEFRA/water-abstraction-system/pull/2080), we refactored an existing job to enable the addition of further cleaning tasks.

This change adds the key task that initiated these changes: deleting 'empty' `VOID` return logs.

By empty, we mean

- The return log has not been marked as received before it was made `void`
- The return log has no submissions against, including 'nil returns'
