### PR TITLE
Update notices abstraction alerts status update

### DIFF
--- a/app/presenters/notices/setup/abstraction-alerts-notifications.presenter.js
+++ b/app/presenters/notices/setup/abstraction-alerts-notifications.presenter.js
@@ -50,7 +50,8 @@ function go(recipients, session, eventId) {
       station,
       monitoringStationName,
       alertEmailAddress,
-      monitoringStationRiverName
+      monitoringStationRiverName,
+      alertType
     )
 
     const matchingRecipients = _matchingRecipients(recipients, station)
@@ -108,6 +109,9 @@ function _addressLines(contact) {
  *
  * In the case of a letter, the address is also required.
  *
+ * The 'licenceMonitoringStationId' and 'alertType' are not required for Notify, we use them to update the licence
+ * monitoring 'status_updated_at' and 'status' field.
+ *
  * @private
  */
 
@@ -115,9 +119,12 @@ function _commonPersonalisation(
   licenceMonitoringStation,
   monitoringStationName,
   alertEmailAddress,
-  monitoringStationRiverName
+  monitoringStationRiverName,
+  alertType
 ) {
   return {
+    alertType,
+    licenceMonitoringStationId: licenceMonitoringStation.id,
     condition_text: _conditionText(licenceMonitoringStation.notes),
     flow_or_level: licenceMonitoringStation.measureType,
     issuer_email_address: alertEmailAddress,

--- a/test/fixtures/abstraction-alert-session-data.fixture.js
+++ b/test/fixtures/abstraction-alert-session-data.fixture.js
@@ -75,7 +75,7 @@ function licenceMonitoringStations() {
  *
  * We do not use the fetch service for the fixture as we format the data to be in a usable state for the session
  *
- * @param {object[]} [_licenceMonitoringStations] - override the default licenceMonitoringStations
+ * @param {object} [_licenceMonitoringStations] - override the default licenceMonitoringStations
  *
  * @returns {object} an object representing the monitoring stations service
  */
@@ -100,17 +100,20 @@ function get(_licenceMonitoringStations) {
  * We mainly need to map licence monitoring stations to recipients. This is done through matching the licence ref.
  *
  * @param {string[]} licenceRefs
+ * @param {object} [_licenceMonitoringStations] - override the default licenceMonitoringStations
  *
  * @returns {object[]} an array of the licence monitoring station
  */
-function relevantLicenceMonitoringStations(licenceRefs) {
-  const lms = [...Object.values(licenceMonitoringStations())]
+function relevantLicenceMonitoringStations(licenceRefs, _licenceMonitoringStations) {
+  const lms = _licenceMonitoringStations || licenceMonitoringStations()
+
+  const lmsArray = [...Object.values(lms)]
 
   for (let i = 0; i < licenceRefs.length; i++) {
-    lms[i].licence.licenceRef = licenceRefs[i]
+    lmsArray[i].licence.licenceRef = licenceRefs[i]
   }
 
-  return lms
+  return lmsArray
 }
 
 module.exports = {

--- a/test/presenters/notices/setup/abstraction-alert-notifications.presenter.test.js
+++ b/test/presenters/notices/setup/abstraction-alert-notifications.presenter.test.js
@@ -20,6 +20,7 @@ describe('Notices - Setup - Abstraction alert notifications presenter', () => {
   const referenceCode = 'TEST-123'
 
   let clock
+  let licenceMonitoringStations
   let recipients
   let session
   let testRecipients
@@ -29,13 +30,18 @@ describe('Notices - Setup - Abstraction alert notifications presenter', () => {
 
     testRecipients = [...Object.values(recipients)]
 
-    const abstractionAlertSessionData = AbstractionAlertSessionData.get()
+    licenceMonitoringStations = AbstractionAlertSessionData.licenceMonitoringStations()
 
-    const relevantLicenceMonitoringStations = AbstractionAlertSessionData.relevantLicenceMonitoringStations([
-      recipients.primaryUser.licence_refs,
-      recipients.licenceHolder.licence_refs,
-      recipients.additionalContact.licence_refs
-    ])
+    const abstractionAlertSessionData = AbstractionAlertSessionData.get(licenceMonitoringStations)
+
+    const relevantLicenceMonitoringStations = AbstractionAlertSessionData.relevantLicenceMonitoringStations(
+      [
+        recipients.primaryUser.licence_refs,
+        recipients.licenceHolder.licence_refs,
+        recipients.additionalContact.licence_refs
+      ],
+      licenceMonitoringStations
+    )
 
     session = {
       ...abstractionAlertSessionData,
@@ -64,6 +70,8 @@ describe('Notices - Setup - Abstraction alert notifications presenter', () => {
         messageType: 'email',
         messageRef: 'water_abstraction_alert_reduce_warning_email',
         personalisation: {
+          alertType: 'warning',
+          licenceMonitoringStationId: licenceMonitoringStations.one.id,
           condition_text: '',
           flow_or_level: 'level',
           issuer_email_address: 'luke.skywalker@rebelmail.test',
@@ -84,6 +92,8 @@ describe('Notices - Setup - Abstraction alert notifications presenter', () => {
         messageRef: 'water_abstraction_alert_stop_warning',
         messageType: 'letter',
         personalisation: {
+          alertType: 'warning',
+          licenceMonitoringStationId: licenceMonitoringStations.two.id,
           name: 'Mr H J Licence holder',
           address_line_1: '1',
           address_line_2: 'Privet Drive',
@@ -109,8 +119,9 @@ describe('Notices - Setup - Abstraction alert notifications presenter', () => {
         licences: `["${recipients.additionalContact.licence_refs}"]`,
         messageRef: 'water_abstraction_alert_stop_warning_email',
         messageType: 'email',
-
         personalisation: {
+          alertType: 'warning',
+          licenceMonitoringStationId: licenceMonitoringStations.three.id,
           condition_text: '',
           flow_or_level: 'level',
           issuer_email_address: 'luke.skywalker@rebelmail.test',
@@ -129,10 +140,10 @@ describe('Notices - Setup - Abstraction alert notifications presenter', () => {
 
   describe('when a licence has more than one licence monitoring stations to send alerts to', () => {
     beforeEach(() => {
-      session.relevantLicenceMonitoringStations = AbstractionAlertSessionData.relevantLicenceMonitoringStations([
-        recipients.primaryUser.licence_refs,
-        recipients.primaryUser.licence_refs
-      ])
+      session.relevantLicenceMonitoringStations = AbstractionAlertSessionData.relevantLicenceMonitoringStations(
+        [recipients.primaryUser.licence_refs, recipients.primaryUser.licence_refs],
+        { one: licenceMonitoringStations.one, two: licenceMonitoringStations.two }
+      )
     })
 
     it('correctly transform the recipients (and associated licence monitoring stations) into notifications for the same recipient', () => {
@@ -148,6 +159,8 @@ describe('Notices - Setup - Abstraction alert notifications presenter', () => {
           messageType: 'email',
           messageRef: 'water_abstraction_alert_reduce_warning_email',
           personalisation: {
+            alertType: 'warning',
+            licenceMonitoringStationId: licenceMonitoringStations.one.id,
             condition_text: '',
             flow_or_level: 'level',
             issuer_email_address: 'luke.skywalker@rebelmail.test',
@@ -166,6 +179,8 @@ describe('Notices - Setup - Abstraction alert notifications presenter', () => {
           messageRef: 'water_abstraction_alert_stop_warning_email',
           messageType: 'email',
           personalisation: {
+            alertType: 'warning',
+            licenceMonitoringStationId: licenceMonitoringStations.two.id,
             condition_text: 'Effect of restriction: I have a bad feeling about this',
             flow_or_level: 'flow',
             issuer_email_address: 'luke.skywalker@rebelmail.test',
@@ -185,9 +200,10 @@ describe('Notices - Setup - Abstraction alert notifications presenter', () => {
 
   describe('when a "additional contact" has abstraction alerts', () => {
     beforeEach(() => {
-      session.relevantLicenceMonitoringStations = AbstractionAlertSessionData.relevantLicenceMonitoringStations([
-        recipients.additionalContact.licence_refs
-      ])
+      session.relevantLicenceMonitoringStations = AbstractionAlertSessionData.relevantLicenceMonitoringStations(
+        [recipients.additionalContact.licence_refs],
+        { one: licenceMonitoringStations.one }
+      )
 
       testRecipients[0].licence_refs = recipients.additionalContact.licence_refs
     })
@@ -205,6 +221,8 @@ describe('Notices - Setup - Abstraction alert notifications presenter', () => {
           messageType: 'email',
           messageRef: 'water_abstraction_alert_reduce_warning_email',
           personalisation: {
+            alertType: 'warning',
+            licenceMonitoringStationId: licenceMonitoringStations.one.id,
             condition_text: '',
             flow_or_level: 'level',
             issuer_email_address: 'luke.skywalker@rebelmail.test',
@@ -222,9 +240,10 @@ describe('Notices - Setup - Abstraction alert notifications presenter', () => {
 
   describe('when a "primaryUser" has abstraction alerts', () => {
     beforeEach(() => {
-      session.relevantLicenceMonitoringStations = AbstractionAlertSessionData.relevantLicenceMonitoringStations([
-        recipients.primaryUser.licence_refs
-      ])
+      session.relevantLicenceMonitoringStations = AbstractionAlertSessionData.relevantLicenceMonitoringStations(
+        [recipients.primaryUser.licence_refs],
+        { one: licenceMonitoringStations.one }
+      )
 
       testRecipients[0].licence_refs = recipients.licenceHolder.licence_refs
     })
@@ -242,6 +261,8 @@ describe('Notices - Setup - Abstraction alert notifications presenter', () => {
           messageType: 'email',
           messageRef: 'water_abstraction_alert_reduce_warning_email',
           personalisation: {
+            alertType: 'warning',
+            licenceMonitoringStationId: licenceMonitoringStations.one.id,
             condition_text: '',
             flow_or_level: 'level',
             issuer_email_address: 'luke.skywalker@rebelmail.test',
@@ -259,9 +280,10 @@ describe('Notices - Setup - Abstraction alert notifications presenter', () => {
 
   describe('when a "licenceHolder" has abstraction alerts', () => {
     beforeEach(() => {
-      session.relevantLicenceMonitoringStations = AbstractionAlertSessionData.relevantLicenceMonitoringStations([
-        recipients.licenceHolder.licence_refs
-      ])
+      session.relevantLicenceMonitoringStations = AbstractionAlertSessionData.relevantLicenceMonitoringStations(
+        [recipients.licenceHolder.licence_refs],
+        { one: licenceMonitoringStations.one }
+      )
     })
 
     it('correctly transform the recipients (and associated licence monitoring stations) into notifications', () => {
@@ -284,6 +306,8 @@ describe('Notices - Setup - Abstraction alert notifications presenter', () => {
             address_line_4: 'Surrey',
             address_line_5: 'WD25 7LR',
             // common personalisation
+            alertType: 'warning',
+            licenceMonitoringStationId: licenceMonitoringStations.one.id,
             condition_text: '',
             flow_or_level: 'level',
             issuer_email_address: 'luke.skywalker@rebelmail.test',
@@ -307,6 +331,8 @@ describe('Notices - Setup - Abstraction alert notifications presenter', () => {
       const [result] = AbstractionAlertsNotificationsPresenter.go(testRecipients, session, eventId)
 
       expect(result.personalisation).to.equal({
+        alertType: 'warning',
+        licenceMonitoringStationId: licenceMonitoringStations.one.id,
         condition_text: '',
         flow_or_level: 'level',
         issuer_email_address: 'luke.skywalker@rebelmail.test',

--- a/test/services/notices/setup/batch-notifications.service.test.js
+++ b/test/services/notices/setup/batch-notifications.service.test.js
@@ -353,6 +353,8 @@ describe('Notices - Setup - Batch notifications service', () => {
   })
 
   describe('when the journey is "abstraction-alert"', () => {
+    let licenceMonitoringStations
+
     beforeEach(async () => {
       recipients = RecipientsFixture.alertsRecipients()
 
@@ -367,13 +369,18 @@ describe('Notices - Setup - Batch notifications service', () => {
 
       eventId = event.id
 
-      const abstractionAlertSessionData = AbstractionAlertSessionData.get()
+      licenceMonitoringStations = AbstractionAlertSessionData.licenceMonitoringStations()
 
-      const relevantLicenceMonitoringStations = AbstractionAlertSessionData.relevantLicenceMonitoringStations([
-        recipients.primaryUser.licence_refs,
-        recipients.licenceHolder.licence_refs,
-        recipients.additionalContact.licence_refs
-      ])
+      const abstractionAlertSessionData = AbstractionAlertSessionData.get(licenceMonitoringStations)
+
+      const relevantLicenceMonitoringStations = AbstractionAlertSessionData.relevantLicenceMonitoringStations(
+        [
+          recipients.primaryUser.licence_refs,
+          recipients.licenceHolder.licence_refs,
+          recipients.additionalContact.licence_refs
+        ],
+        licenceMonitoringStations
+      )
 
       session = {
         ...abstractionAlertSessionData,
@@ -412,6 +419,8 @@ describe('Notices - Setup - Batch notifications service', () => {
           messageType: 'email',
           messageRef: 'water_abstraction_alert_reduce_email',
           personalisation: {
+            alertType: 'reduce',
+            licenceMonitoringStationId: licenceMonitoringStations.three.id,
             source: '* Source of supply: Meridian Trench',
             licence_ref: recipients.additionalContact.licence_refs,
             flow_or_level: 'level',
@@ -436,6 +445,8 @@ describe('Notices - Setup - Batch notifications service', () => {
           messageType: 'letter',
           messageRef: 'water_abstraction_alert_reduce',
           personalisation: {
+            alertType: 'reduce',
+            licenceMonitoringStationId: licenceMonitoringStations.two.id,
             name: 'Mr H J Licence holder',
             source: '* Source of supply: Meridian Trench',
             licence_ref: recipients.licenceHolder.licence_refs,
@@ -466,6 +477,8 @@ describe('Notices - Setup - Batch notifications service', () => {
           messageType: 'email',
           messageRef: 'water_abstraction_alert_reduce_email',
           personalisation: {
+            alertType: 'reduce',
+            licenceMonitoringStationId: licenceMonitoringStations.one.id,
             source: '* Source of supply: Meridian Trench',
             licence_ref: recipients.primaryUser.licence_refs,
             flow_or_level: 'level',


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5100

We have a requirement to update the licence monitoring stations 'Last type of alert sent and date issued'. To do this and keep the exising notification code / logic generic we need to add the licence monitoring station id and the users chosen alert type into the personalisation.

This will not be shown in the template. We initially built the notices functionality around the legacy code. This mean we store the personalisation data as json for each notice we send.

This change adds the licence monitoring station id and the users chosen alert type into the personalisation and saves it in the database.

We need to make another change (in a separate code change) to the notification job, which currently updates the status from notify, to also check if the notification is a water abstraction alert. And if so we need to update the licence monitoring stations 'status_updated_at' and 'status' fields, with the data added by this change.