### PR TITLE
Rename "Remove tag" button to "Continue"

### DIFF
--- a/app/views/licence-monitoring-station/remove.njk
+++ b/app/views/licence-monitoring-station/remove.njk
@@ -67,7 +67,7 @@
     <input type="hidden" name="monitoringStationId" value="{{monitoringStationId}}"/>
     <input type="hidden" name="wrlsCrumb" value="{{wrlsCrumb}}"/>
       {{ govukButton({
-        text: "Remove tag",
+        text: "Continue",
         preventDoubleClick: true
       }) }}
   </form>


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5003

During QA an issue has been found with the button name to remove a maonitoring station tag from a licence. In the prototype and the screenshot in the ticket, the button is called "Remove tag". However, in the ACs the button is referred to as the "Continue" button.

After checking with the BA it has been confirmed that to be consistent with similar pages the button should be called "Continue". So in this PR the button will be renamed.