### PR TITLE
Fix abstraction alerts multiple licence refs

### DIFF
--- a/app/presenters/notices/setup/abstraction-alerts-notifications.presenter.js
+++ b/app/presenters/notices/setup/abstraction-alerts-notifications.presenter.js
@@ -248,9 +248,12 @@ function _licences(licenceRefs) {
 }
 
 /**
- * Each licence monitoring station has a licence ref. Multiple stations could have the licence ref.
+ * Matches a recipient to a licence monitoring station by the licence ref.
  *
- * When finding the recipients for the station we do so by the licence ref.
+ * 'recipient.licence_refs' will be a comma seperated string: 'licenceOne,licenceTwo'.
+ *
+ * To match a recipient to a licence monitoring station we use the licence monitoring stations licenceRef and check if
+ * the licence ref is present in the 'recipient.licence_refs' string.
  *
  * This does mean that a recipient can / will receive multiple notifications from different licence monitoring stations.
  *
@@ -258,7 +261,7 @@ function _licences(licenceRefs) {
  */
 function _matchingRecipients(recipients, station) {
   return recipients.filter((recipient) => {
-    return recipient.licence_refs === station.licence.licenceRef
+    return recipient.licence_refs.split(',').includes(station.licence.licenceRef)
   })
 }
 

--- a/test/presenters/notices/setup/abstraction-alert-notifications.presenter.test.js
+++ b/test/presenters/notices/setup/abstraction-alert-notifications.presenter.test.js
@@ -198,6 +198,43 @@ describe('Notices - Setup - Abstraction alert notifications presenter', () => {
     })
   })
 
+  describe('when a "recipient" has multiple licence refs', () => {
+    beforeEach(() => {
+      testRecipients = [
+        { ...recipients.additionalContact, licence_refs: `${recipients.additionalContact.licence_refs},12/345` }
+      ]
+    })
+
+    it('correctly transform the recipients (and associated licence monitoring stations) into notifications for the same recipient', () => {
+      const result = AbstractionAlertsNotificationsPresenter.go(testRecipients, session, eventId)
+
+      expect(result).to.equal([
+        {
+          createdAt: '2025-01-01T00:00:00.000Z',
+          eventId: 'c1cae668-3dad-4806-94e2-eb3f27222ed9',
+          reference: 'TEST-123',
+          templateId: 'a51ace39-3224-4c18-bbb8-c803a6da9a21',
+          licences: `["${recipients.additionalContact.licence_refs}","12/345"]`,
+          messageType: 'email',
+          messageRef: 'water_abstraction_alert_stop_warning_email',
+          personalisation: {
+            alertType: 'warning',
+            licenceMonitoringStationId: licenceMonitoringStations.three.id,
+            condition_text: '',
+            flow_or_level: 'level',
+            issuer_email_address: 'luke.skywalker@rebelmail.test',
+            licence_ref: recipients.additionalContact.licence_refs,
+            monitoring_station_name: 'Death star',
+            source: '* Source of supply: Meridian Trench',
+            threshold_unit: 'm',
+            threshold_value: 100
+          },
+          recipient: 'additional.contact@important.com'
+        }
+      ])
+    })
+  })
+
   describe('when a "additional contact" has abstraction alerts', () => {
     beforeEach(() => {
       session.relevantLicenceMonitoringStations = AbstractionAlertSessionData.relevantLicenceMonitoringStations(


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5067

When we get the 'recipients', we receive the associated licence refs in a comma separate string e.g 'AB12,BC,56'.

When this occurred we were not handling this a comma seperated string but as a licence ref. The download logic had already solved this problem but the implementation was missed in the notices.

This change updates the abstraction alert presenter to check if the licence monitoring stations licence ref is in the recipients  licence refs.