### PR TITLE
Update notices abstraction alerts status update

### DIFF
--- a/app/services/jobs/notifications/fetch-notifications.service.js
+++ b/app/services/jobs/notifications/fetch-notifications.service.js
@@ -24,7 +24,17 @@ async function go() {
   sevenDaysAgo.setDate(today.getDate() - SEVEN_DAYS)
 
   return NotificationModel.query()
-    .select(['id', 'notifyId', 'status', 'notifyStatus', 'notify_error', 'eventId', 'createdAt', 'personalisation'])
+    .select([
+      'createdAt',
+      'eventId',
+      'id',
+      'messageRef',
+      'notifyId',
+      'notifyStatus',
+      'notify_error',
+      'personalisation',
+      'status'
+    ])
     .where('status', 'pending')
     .andWhere('createdAt', '>=', sevenDaysAgo)
 }

--- a/app/services/jobs/notifications/fetch-notifications.service.js
+++ b/app/services/jobs/notifications/fetch-notifications.service.js
@@ -24,7 +24,7 @@ async function go() {
   sevenDaysAgo.setDate(today.getDate() - SEVEN_DAYS)
 
   return NotificationModel.query()
-    .select(['id', 'notifyId', 'status', 'notifyStatus', 'notify_error', 'eventId', 'createdAt'])
+    .select(['id', 'notifyId', 'status', 'notifyStatus', 'notify_error', 'eventId', 'createdAt', 'personalisation'])
     .where('status', 'pending')
     .andWhere('createdAt', '>=', sevenDaysAgo)
 }

--- a/app/services/jobs/notifications/notifications-status-updates.service.js
+++ b/app/services/jobs/notifications/notifications-status-updates.service.js
@@ -11,6 +11,7 @@ const FetchNotificationsService = require('./fetch-notifications.service.js')
 const NotifyConfig = require('../../../../config/notify.config.js')
 const NotifyStatusPresenter = require('../../../presenters/jobs/notifications/notify-status.presenter.js')
 const NotifyStatusRequest = require('../../../requests/notify/notify-status.request.js')
+const UpdateAbstractionAlertsService = require('./update-abstraction-alerts.service.js')
 const UpdateEventErrorCountService = require('./update-event-error-count.service.js')
 const UpdateNotificationsService = require('./update-notifications.service.js')
 
@@ -38,7 +39,9 @@ async function go() {
   for (let i = 0; i < notifications.length; i += batchSize) {
     const batchNotifications = notifications.slice(i, i + batchSize)
 
-    await _batch(batchNotifications)
+    const updatedNotifications = await _batch(batchNotifications)
+
+    await UpdateAbstractionAlertsService.go(updatedNotifications)
 
     await _delay(delay)
   }
@@ -52,6 +55,8 @@ async function _batch(notifications) {
   const updatedNotifications = await _updateNotifications(toUpdateNotifications)
 
   await UpdateNotificationsService.go(updatedNotifications)
+
+  return toUpdateNotifications
 }
 
 async function _delay(delay) {

--- a/app/services/jobs/notifications/notifications-status-updates.service.js
+++ b/app/services/jobs/notifications/notifications-status-updates.service.js
@@ -56,7 +56,7 @@ async function _batch(notifications) {
 
   await UpdateNotificationsService.go(updatedNotifications)
 
-  return toUpdateNotifications
+  return updatedNotifications
 }
 
 async function _delay(delay) {

--- a/app/services/jobs/notifications/update-abstraction-alerts.service.js
+++ b/app/services/jobs/notifications/update-abstraction-alerts.service.js
@@ -19,7 +19,7 @@ const { timestampForPostgres } = require('../../../lib/general.lib.js')
  */
 async function go(notifications) {
   for (const notification of notifications) {
-    if (notification.messageRef?.includes('water_abstraction_alert'))
+    if (notification.messageRef?.includes('water_abstraction_alert') && notification.status !== 'error')
       await _update(notification.personalisation.licenceMonitoringStationId, notification.personalisation.alertType)
   }
 }

--- a/app/services/jobs/notifications/update-abstraction-alerts.service.js
+++ b/app/services/jobs/notifications/update-abstraction-alerts.service.js
@@ -5,8 +5,8 @@
  * @module UpdateAbstractionAlertsService
  */
 
-const LicenceMonitoringStationModel = require('../../../models/licence-monitoring-station.model.js')
 const { timestampForPostgres } = require('../../../lib/general.lib.js')
+const LicenceMonitoringStationModel = require('../../../models/licence-monitoring-station.model.js')
 
 /**
  * Orchestrates the process of updating the licence monitoring stations last abstraction alert.

--- a/app/services/jobs/notifications/update-abstraction-alerts.service.js
+++ b/app/services/jobs/notifications/update-abstraction-alerts.service.js
@@ -1,0 +1,36 @@
+'use strict'
+
+/**
+ * Orchestrates the process of updating the licence monitoring stations last abstraction alert.
+ * @module UpdateAbstractionAlertsService
+ */
+
+const LicenceMonitoringStationModel = require('../../../models/licence-monitoring-station.model.js')
+const { timestampForPostgres } = require('../../../lib/general.lib.js')
+
+/**
+ * Orchestrates the process of updating the licence monitoring stations last abstraction alert.
+ *
+ * When a notification is for water abstraction alerts it will have the 'messageRef' set as something like:
+ * water_abstraction_alert_resume_email. When this is present we need to update the licence monitoring stations 'status'
+ * and 'statusUpdatedAt'. This signifies the last abstraction alert sent.
+ *
+ * @param {object[]} notifications
+ */
+async function go(notifications) {
+  for (const notification of notifications) {
+    if (notification.messageRef?.includes('water_abstraction_alert'))
+      await _update(notification.personalisation.licenceMonitoringStationId, notification.personalisation.alertType)
+  }
+}
+
+async function _update(id, status) {
+  await LicenceMonitoringStationModel.query().findById(id).patch({
+    status,
+    statusUpdatedAt: timestampForPostgres()
+  })
+}
+
+module.exports = {
+  go
+}

--- a/app/services/jobs/notifications/update-abstraction-alerts.service.js
+++ b/app/services/jobs/notifications/update-abstraction-alerts.service.js
@@ -25,15 +25,8 @@ async function go(notifications) {
   await Promise.all(toUpdateStations)
 }
 
-async function _update(id, status) {
-  await LicenceMonitoringStationModel.query().findById(id).patch({
-    status,
-    statusUpdatedAt: timestampForPostgres()
-  })
-}
-
 /**
- * Determine which notification are for the water abstraction alerts and have not failed to send.
+ * Determine which notifications are for the water abstraction alerts and have not failed to send.
  * @private
  */
 function _stations(notifications) {
@@ -43,6 +36,13 @@ function _stations(notifications) {
 
   return stationsToUpdate.map((notification) => {
     return _update(notification.personalisation.licenceMonitoringStationId, notification.personalisation.alertType)
+  })
+}
+
+async function _update(id, status) {
+  await LicenceMonitoringStationModel.query().findById(id).patch({
+    status,
+    statusUpdatedAt: timestampForPostgres()
   })
 }
 

--- a/app/services/jobs/notifications/update-abstraction-alerts.service.js
+++ b/app/services/jobs/notifications/update-abstraction-alerts.service.js
@@ -12,22 +12,37 @@ const { timestampForPostgres } = require('../../../lib/general.lib.js')
  * Orchestrates the process of updating the licence monitoring stations last abstraction alert.
  *
  * When a notification is for water abstraction alerts it will have the 'messageRef' set as something like:
- * water_abstraction_alert_resume_email. When this is present we need to update the licence monitoring stations 'status'
+ * 'water_abstraction_alert_resume_email'. When this is present we need to update the licence monitoring stations 'status'
  * and 'statusUpdatedAt'. This signifies the last abstraction alert sent.
+ *
+ * If a notification has failed to send (Notify has sent an error) then we do not update.
  *
  * @param {object[]} notifications
  */
 async function go(notifications) {
-  for (const notification of notifications) {
-    if (notification.messageRef?.includes('water_abstraction_alert') && notification.status !== 'error')
-      await _update(notification.personalisation.licenceMonitoringStationId, notification.personalisation.alertType)
-  }
+  const toUpdateStations = _stations(notifications)
+
+  await Promise.all(toUpdateStations)
 }
 
 async function _update(id, status) {
   await LicenceMonitoringStationModel.query().findById(id).patch({
     status,
     statusUpdatedAt: timestampForPostgres()
+  })
+}
+
+/**
+ * Determine which notification are for the water abstraction alerts and have not failed to send.
+ * @private
+ */
+function _stations(notifications) {
+  const stationsToUpdate = notifications.filter((notification) => {
+    return notification.messageRef?.includes('water_abstraction_alert') && notification.status !== 'error'
+  })
+
+  return stationsToUpdate.map((notification) => {
+    return _update(notification.personalisation.licenceMonitoringStationId, notification.personalisation.alertType)
   })
 }
 

--- a/app/views/licence-monitoring-station/remove.njk
+++ b/app/views/licence-monitoring-station/remove.njk
@@ -67,7 +67,7 @@
     <input type="hidden" name="monitoringStationId" value="{{monitoringStationId}}"/>
     <input type="hidden" name="wrlsCrumb" value="{{wrlsCrumb}}"/>
       {{ govukButton({
-        text: "Remove tag",
+        text: "Continue",
         preventDoubleClick: true
       }) }}
   </form>

--- a/test/services/jobs/notifications/fetch-notifications.service.test.js
+++ b/test/services/jobs/notifications/fetch-notifications.service.test.js
@@ -28,6 +28,7 @@ describe('Job - Notifications - Fetch notifications service', () => {
 
     notification = await NotificationHelper.add({
       eventId: event.id,
+      messageRef: 'returns_invitation_licence_holder_letter',
       status: 'pending'
     })
 
@@ -71,6 +72,7 @@ describe('Job - Notifications - Fetch notifications service', () => {
         createdAt: notification.createdAt,
         eventId: event.id,
         id: notification.id,
+        messageRef: 'returns_invitation_licence_holder_letter',
         notifyError: null,
         notifyId: null,
         notifyStatus: null,

--- a/test/services/jobs/notifications/fetch-notifications.service.test.js
+++ b/test/services/jobs/notifications/fetch-notifications.service.test.js
@@ -71,9 +71,10 @@ describe('Job - Notifications - Fetch notifications service', () => {
         createdAt: notification.createdAt,
         eventId: event.id,
         id: notification.id,
+        notifyError: null,
         notifyId: null,
         notifyStatus: null,
-        notifyError: null,
+        personalisation: null,
         status: 'pending'
       })
     })

--- a/test/services/jobs/notifications/notifications-status-updates.service.test.js
+++ b/test/services/jobs/notifications/notifications-status-updates.service.test.js
@@ -10,6 +10,7 @@ const { expect } = Code
 
 // Test helpers
 const EventHelper = require('../../../support/helpers/event.helper.js')
+const LicenceMonitoringStationHelper = require('../../../support/helpers/licence-monitoring-station.helper.js')
 const NotificationHelper = require('../../../support/helpers/notification.helper.js')
 const { timestampForPostgres } = require('../../../../app/lib/general.lib.js')
 
@@ -19,7 +20,6 @@ const { NotifyClient } = require('notifications-node-client')
 
 // Thing under test
 const ProcessNotificationsStatusUpdatesService = require('../../../../app/services/jobs/notifications/notifications-status-updates.service.js')
-const LicenceMonitoringStationHelper = require('../../../support/helpers/licence-monitoring-station.helper.js')
 
 describe('Job - Notifications - Process notifications status updates service', () => {
   const ONE_HUNDRED_MILLISECONDS = 100

--- a/test/services/jobs/notifications/notifications-status-updates.service.test.js
+++ b/test/services/jobs/notifications/notifications-status-updates.service.test.js
@@ -39,10 +39,6 @@ describe('Job - Notifications - Process notifications status updates service', (
     // correctly, we do not want increase the timeout for the test as we want them to fail if a timeout occurs
     Sinon.stub(NotifyConfig, 'delay').value(ONE_HUNDRED_MILLISECONDS)
 
-    if (NotifyClient.prototype.getNotificationById.restore) {
-      NotifyClient.prototype.getNotificationById.restore()
-    }
-
     event = await EventHelper.add({
       metadata: {},
       status: 'completed',

--- a/test/services/jobs/notifications/notifications-status-updates.service.test.js
+++ b/test/services/jobs/notifications/notifications-status-updates.service.test.js
@@ -21,9 +21,11 @@ const { NotifyClient } = require('notifications-node-client')
 const ProcessNotificationsStatusUpdatesService = require('../../../../app/services/jobs/notifications/notifications-status-updates.service.js')
 const LicenceMonitoringStationHelper = require('../../../support/helpers/licence-monitoring-station.helper.js')
 
-describe.only('Job - Notifications - Process notifications status updates service', () => {
+describe('Job - Notifications - Process notifications status updates service', () => {
   const ONE_HUNDRED_MILLISECONDS = 100
 
+  let clock
+  let date
   let event
   let notification
   let notification2
@@ -63,10 +65,14 @@ describe.only('Job - Notifications - Process notifications status updates servic
 
     notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
     global.GlobalNotifier = notifierStub
+
+    date = new Date(`2025-01-01`)
+    clock = Sinon.useFakeTimers(date)
   })
 
   afterEach(() => {
     Sinon.restore()
+    clock.restore()
     delete global.GlobalNotifier
   })
 
@@ -180,7 +186,7 @@ describe.only('Job - Notifications - Process notifications status updates servic
         const updatedResult = await licenceMonitoringStation.$query()
 
         expect(updatedResult.status).to.equal('resume')
-        expect(updatedResult.statusUpdatedAt).to.equal(null)
+        expect(updatedResult.statusUpdatedAt).to.equal(date)
       })
     })
   })

--- a/test/services/jobs/notifications/update-abstraction-alerts.service.test.js
+++ b/test/services/jobs/notifications/update-abstraction-alerts.service.test.js
@@ -1,0 +1,64 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Test helpers
+const LicenceMonitoringStationHelper = require('../../../support/helpers/licence-monitoring-station.helper.js')
+
+// Thing under test
+const UpdateAbstractionAlertsService = require('../../../../app/services/jobs/notifications/update-abstraction-alerts.service.js')
+
+describe('Job - Notifications - Update abstraction alerts service', () => {
+  let clock
+  let date
+  let licenceMonitoringStation
+  let licenceMonitoringStationUnTouched
+  let notifications
+
+  beforeEach(async () => {
+    licenceMonitoringStation = await LicenceMonitoringStationHelper.add()
+
+    licenceMonitoringStationUnTouched = await LicenceMonitoringStationHelper.add()
+
+    notifications = [
+      {
+        messageRef: 'water_abstraction_alert_resume_email',
+        personalisation: {
+          alertType: 'resume',
+          licenceMonitoringStationId: licenceMonitoringStation.id
+        }
+      }
+    ]
+
+    date = new Date(`2025-01-01`)
+    clock = Sinon.useFakeTimers(date)
+  })
+
+  afterEach(() => {
+    Sinon.restore()
+    clock.restore()
+  })
+
+  it('updates the "status" and "statusUpdatedAt"', async () => {
+    await UpdateAbstractionAlertsService.go(notifications)
+
+    const updatedResult = await licenceMonitoringStation.$query()
+
+    expect(updatedResult.status).to.equal('resume')
+    expect(updatedResult.statusUpdatedAt).to.equal(date)
+  })
+
+  it('does nto update ', async () => {
+    await UpdateAbstractionAlertsService.go(notifications)
+
+    const updatedResult = await licenceMonitoringStationUnTouched.$query()
+
+    expect(updatedResult).to.equal(licenceMonitoringStationUnTouched)
+  })
+})

--- a/test/services/jobs/notifications/update-notifications.service.test.js
+++ b/test/services/jobs/notifications/update-notifications.service.test.js
@@ -15,7 +15,7 @@ const { timestampForPostgres } = require('../../../../app/lib/general.lib.js')
 // Thing under test
 const UpdateNotificationsService = require('../../../../app/services/jobs/notifications/update-notifications.service.js')
 
-describe('NJob - Notifications - Update Notifications service', () => {
+describe('Job - Notifications - Update Notifications service', () => {
   let eventId
   let notifications
   let notification


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5100

We have a requirement to update the licence monitoring stations 'Last type of alert sent and date issued'. To do this and keep the exising notification code / logic generic we need to add the licence monitoring station id and the users chosen alert type into the personalisation.

This will not be shown in the template. We initially built the notices functionality around the legacy code. This mean we store the personalisation data as json for each notice we send.

This change updates the notification job to check if the notifications id for an abstraction alert. When it is we update licence monitoring stations 'status_updated_at' and 'status' fields.

This is known as the 'Last alert sent'