### PR TITLE
Reorder which return version end date to use

### DIFF
--- a/app/services/return-versions/setup/check/process-existing-return-versions.service.js
+++ b/app/services/return-versions/setup/check/process-existing-return-versions.service.js
@@ -36,12 +36,12 @@ async function go(licenceId, newVersionStartDate) {
     return null
   }
 
-  result = await _insertBeforeVersions(previousVersions, newVersionStartDate)
+  result = await _insertBetweenVersions(previousVersions, newVersionStartDate, previousVersionEndDate)
   if (result) {
     return result
   }
 
-  result = await _insertBetweenVersions(previousVersions, newVersionStartDate, previousVersionEndDate)
+  result = await _insertBeforeVersions(previousVersions, newVersionStartDate)
   if (result) {
     return result
   }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5099

This issue was found in production when users created new return versions for water companies that need quarterly returns enabled. When inserting a new return version between other existing return version it is setting the end date of one of the return versions incorrectly.  This was due to the the order of the functions that determine which end date to use. This fix reorders the function calls with the more specific one higher in the order. 