### PR TITLE
Update water abstraction alerts confirmation page to include the monitoring stations link

### DIFF
--- a/app/presenters/notices/setup/confirmation.presenter.js
+++ b/app/presenters/notices/setup/confirmation.presenter.js
@@ -13,13 +13,20 @@
  * @returns {object} - The data formatted for the view template
  */
 function go(event) {
-  const { referenceCode, subtype, id: eventId } = event
+  const { referenceCode, subtype, id: eventId, metadata } = event
 
   return {
     forwardLink: `/notifications/report/${eventId}`,
+    monitoringStationLink: _monitoringStationLink(metadata),
     pageTitle: _pageTitle(subtype),
     referenceCode
   }
+}
+
+function _monitoringStationLink(metadata) {
+  return metadata.options?.monitoringStationId
+    ? `/system/monitoring-stations/${metadata.options?.monitoringStationId}`
+    : null
 }
 
 /**

--- a/app/presenters/notices/setup/create-notice.presenter.js
+++ b/app/presenters/notices/setup/create-notice.presenter.js
@@ -36,7 +36,7 @@ function go(session, recipients, auth) {
   }
 
   if (session.journey === 'abstraction-alert') {
-    notice.metadata.options = { sendingAlertType: session.alertType }
+    notice.metadata.options = { sendingAlertType: session.alertType, monitoringStationId: session.monitoringStationId }
   } else {
     notice.metadata.options = { excludeLicences: session.removeLicences ? session.removeLicences : [] }
     notice.metadata.returnCycle = _returnCycle(session.determinedReturnsPeriod)

--- a/app/views/notices/setup/confirmation.njk
+++ b/app/views/notices/setup/confirmation.njk
@@ -9,6 +9,16 @@
       html: "Your reference number is <br><strong>" + referenceCode + "</strong>"
     }) }}
 
-    <a class="govuk-link" href="{{ forwardLink }}">View notifications report</a>
+    <p class="govuk-body">
+      <a class="govuk-link" href="{{ forwardLink }}">View notifications report</a>
+    </p>
+
+    {% if monitoringStationLink %}
+      <p class="govuk-body">or</p>
+
+      <p class="govuk-body">
+        <a class="govuk-link" href="{{ monitoringStationLink }}">Return to monitoring station</a>
+      </p>
+    {% endif %}
   </div>
 {% endblock %}

--- a/test/presenters/notices/setup/confirmation.presenter.test.js
+++ b/test/presenters/notices/setup/confirmation.presenter.test.js
@@ -19,7 +19,8 @@ describe('Notices - Setup - Confirmation presenter', () => {
     event = {
       id: '123',
       subtype: 'adHocReminder',
-      referenceCode
+      referenceCode,
+      metadata: {}
     }
   })
 
@@ -28,6 +29,7 @@ describe('Notices - Setup - Confirmation presenter', () => {
 
     expect(result).to.equal({
       forwardLink: '/notifications/report/123',
+      monitoringStationLink: null,
       pageTitle: `Returns ad-hoc sent`,
       referenceCode: 'ADHC-1234'
     })
@@ -39,6 +41,7 @@ describe('Notices - Setup - Confirmation presenter', () => {
 
       expect(result).to.equal({
         forwardLink: '/notifications/report/123',
+        monitoringStationLink: null,
         pageTitle: `Returns ad-hoc sent`,
         referenceCode: 'ADHC-1234'
       })
@@ -55,6 +58,7 @@ describe('Notices - Setup - Confirmation presenter', () => {
 
       expect(result).to.equal({
         forwardLink: '/notifications/report/123',
+        monitoringStationLink: null,
         pageTitle: `Returns invitations sent`,
         referenceCode: 'ADHC-1234'
       })
@@ -71,6 +75,7 @@ describe('Notices - Setup - Confirmation presenter', () => {
 
       expect(result).to.equal({
         forwardLink: '/notifications/report/123',
+        monitoringStationLink: null,
         pageTitle: `Returns reminders sent`,
         referenceCode: 'ADHC-1234'
       })
@@ -80,6 +85,8 @@ describe('Notices - Setup - Confirmation presenter', () => {
   describe('and the journey is "waterAbstractionAlerts"', () => {
     beforeEach(() => {
       event.subtype = 'waterAbstractionAlerts'
+
+      event.metadata = { options: { monitoringStationId: '123' } }
     })
 
     it('correctly presents the data', () => {
@@ -87,6 +94,7 @@ describe('Notices - Setup - Confirmation presenter', () => {
 
       expect(result).to.equal({
         forwardLink: '/notifications/report/123',
+        monitoringStationLink: '/system/monitoring-stations/123',
         pageTitle: 'Water abstraction alerts sent',
         referenceCode: 'ADHC-1234'
       })

--- a/test/presenters/notices/setup/create-notice.presenter.test.js
+++ b/test/presenters/notices/setup/create-notice.presenter.test.js
@@ -187,11 +187,12 @@ describe('Notices - Setup - Create Notice presenter', () => {
       testRecipients = [...Object.values(recipients)]
 
       session = {
+        alertType: 'stop',
         journey: 'abstraction-alert',
-        referenceCode: 'WAA-123',
-        subType: 'waterAbstractionAlerts',
+        monitoringStationId: '123',
         name: 'Water abstraction alert',
-        alertType: 'stop'
+        referenceCode: 'WAA-123',
+        subType: 'waterAbstractionAlerts'
       }
     })
 
@@ -206,6 +207,7 @@ describe('Notices - Setup - Create Notice presenter', () => {
         metadata: {
           name: 'Water abstraction alert',
           options: {
+            monitoringStationId: '123',
             sendingAlertType: 'stop'
           },
           recipients: 3
@@ -245,6 +247,24 @@ describe('Notices - Setup - Create Notice presenter', () => {
           const result = CreateNoticePresenter.go(session, testRecipients, auth)
 
           expect(result.metadata.recipients).to.equal(3)
+        })
+      })
+
+      describe('the "options" property', () => {
+        describe('the "sendingAlertType" property', () => {
+          it('return the sessions value', () => {
+            const result = CreateNoticePresenter.go(session, testRecipients, auth)
+
+            expect(result.metadata.options.sendingAlertType).to.equal('stop')
+          })
+        })
+
+        describe('the "monitoringStationId" property', () => {
+          it('correctly returns the length of recipients', () => {
+            const result = CreateNoticePresenter.go(session, testRecipients, auth)
+
+            expect(result.metadata.options.monitoringStationId).to.equal('123')
+          })
         })
       })
     })


### PR DESCRIPTION


https://eaflood.atlassian.net/browse/WATER-5103

This change adds the monitoring stations id to the event metadata. This is used on the confirmation page to create a link to the monitoring stations page. The link is added in this change.