### PR TITLE
Fix instantaneous abstraction amount measure text

### DIFF
--- a/app/presenters/licences/view-licence-purposes.presenter.js
+++ b/app/presenters/licences/view-licence-purposes.presenter.js
@@ -57,7 +57,7 @@ function _formatAbstractionAmounts(licenceVersionPurpose) {
   }
 
   if (instantQuantity) {
-    details.push(`${parseFloat(instantQuantity).toFixed(2)} cubic metres per second`)
+    details.push(`${parseFloat(instantQuantity).toFixed(2)} litres per second`)
   }
 
   return details

--- a/app/views/licences/tabs/summary.njk
+++ b/app/views/licences/tabs/summary.njk
@@ -162,7 +162,7 @@
       <dd class="govuk-summary-list__value">
         {% if purposesCount > 1 %}
           <div>Multiple abstractions</div>
-          <a href="/licences/{{ documentId }}/purposes">View details of the amounts</a>
+          <a href="/system/licences/{{ licenceId }}/purposes">View details of the amounts</a>
         {% else %}
           <ul class="govuk-list govuk-!-margin-bottom-0">
             {% for quantity in abstractionAmounts %}

--- a/test/presenters/licences/view-licence-purposes.presenter.test.js
+++ b/test/presenters/licences/view-licence-purposes.presenter.test.js
@@ -14,7 +14,7 @@ const PointModel = require('../../../app/models/point.model.js')
 // Thing under test
 const ViewLicencePurposePresenter = require('../../../app/presenters/licences/view-licence-purposes.presenter.js')
 
-describe('View Licence Purpose presenter', () => {
+describe('Licences - View Licence Purpose presenter', () => {
   let licence
 
   beforeEach(() => {
@@ -33,7 +33,7 @@ describe('View Licence Purpose presenter', () => {
               '180000.00 cubic metres per year',
               '720.00 cubic metres per day',
               '144.00 cubic metres per hour',
-              '40.00 cubic metres per second'
+              '40.00 litres per second'
             ],
             abstractionAmountsTitle: 'Abstraction amounts',
             abstractionMethods: 'Unspecified Pump',
@@ -75,7 +75,7 @@ describe('View Licence Purpose presenter', () => {
             '180000.00 cubic metres per year',
             '720.00 cubic metres per day',
             '144.00 cubic metres per hour',
-            '40.00 cubic metres per second'
+            '40.00 litres per second'
           ])
         })
       })

--- a/test/services/licences/view-licence-purposes.service.test.js
+++ b/test/services/licences/view-licence-purposes.service.test.js
@@ -35,7 +35,7 @@ describe('View Licence Purposes service', () => {
               '180000.00 cubic metres per year',
               '720.00 cubic metres per day',
               '144.00 cubic metres per hour',
-              '40.00 cubic metres per second'
+              '40.00 litres per second'
             ],
             abstractionAmountsTitle: 'Abstraction amounts',
             abstractionMethods: 'Unspecified Pump',


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5068

The users have highlighted that the measure we display next to the instantaneous abstraction amount in the view licence purposes page is wrong.

We say '9.80 cubic metres per second' when it should be '9.80 litres per second'.

As part of this, we've also noticed that if a licence has multiple purposes, and therefore multiple abstraction amounts, the link displayed on the summary tab next to **Abstraction amounts** directs you to the legacy view licence purposes page.

In this update, we also change the link to direct you to our now fixed purposes page.