### PR TITLE
Return generated return log ids

### DIFF
--- a/app/services/return-logs/create-return-logs.service.js
+++ b/app/services/return-logs/create-return-logs.service.js
@@ -71,16 +71,13 @@ async function _persistReturnLogs(returnLogs) {
   for (const returnLog of returnLogs) {
     const timestamp = timestampForPostgres()
 
-    const insertedRow = await db('returnLogs')
+    await db('returnLogs')
       .withSchema('public')
       .insert({ ...returnLog, createdAt: timestamp, updatedAt: timestamp })
       .onConflict('id')
       .ignore()
-      .returning('id')
 
-    if (insertedRow.length > 0) {
-      createdIds.push(insertedRow[0].id)
-    }
+    createdIds.push(returnLog.id)
   }
 
   return createdIds

--- a/test/services/return-logs/create-return-logs.service.test.js
+++ b/test/services/return-logs/create-return-logs.service.test.js
@@ -209,10 +209,10 @@ describe('Return Logs - Create Return Logs service', () => {
       })
     })
 
-    it('returns an empty array', async () => {
+    it('returns one return log for the year', async () => {
       const results = await CreateReturnLogsService.go(testReturnRequirement, testReturnCycle)
 
-      expect(results).to.equal([])
+      expect(results).to.equal(['v1:4:01/25/90/3242:16999651:2023-04-01:2024-03-31'])
     })
   })
 })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5099

As part of the testing of this ticket QA have found that when inserting a new return version before an existing one that already has return logs created for it those return logs were incorrectly being voided. 

This was due to the code around the on conflict not working as expected. This PR removes that logic and just returns all of the id's that were attempted to be inserted so that any other return logs will be correctly voided. 