### PR TITLE
Update setup initiate session to use determine notice type

### DIFF
--- a/app/services/notices/setup/determine-notice-type.service.js
+++ b/app/services/notices/setup/determine-notice-type.service.js
@@ -8,7 +8,7 @@
 const { generateRandomInteger } = require('../../../lib/general.lib.js')
 
 /**
- * Defines the configuration for supported notification types.
+ * Defines the configuration for supported notice types.
  *
  * This structure enables consistent handling and display of different notification types
  * across the system. Each type includes legacy fields (`name` and `subType`) required for backwards compatibility.
@@ -19,7 +19,7 @@ const { generateRandomInteger } = require('../../../lib/general.lib.js')
  *
  * @private
  */
-const NOTIFICATION_TYPES = {
+const NOTICE_TYPES = {
   invitations: {
     journey: 'invitations',
     name: 'Returns: invitation',
@@ -63,12 +63,12 @@ const NOTIFICATION_TYPES = {
  * The notice type data is saved directly to the database and is used raw in the UI. For example the 'name' is used on
  * the reports page.
  *
- * @param notificationType
+ * @param {string} noticeType
  *
- * @returns {object}
+ * @returns {object} - data specific to the notice type
  */
-function go(notificationType) {
-  const { journey, name, prefix, redirectPath, subType, type } = NOTIFICATION_TYPES[notificationType]
+function go(noticeType) {
+  const { journey, name, prefix, redirectPath, subType, type } = NOTICE_TYPES[noticeType]
 
   return {
     journey,
@@ -81,7 +81,7 @@ function go(notificationType) {
 }
 
 /**
- * A function to generate a pseudo-unique reference code for recipients notifications
+ * A function to generate a pseudo-unique reference code for recipients notices
  *
  * @param {string} prefix
  *

--- a/app/services/notices/setup/determine-notice-type.service.js
+++ b/app/services/notices/setup/determine-notice-type.service.js
@@ -1,0 +1,104 @@
+'use strict'
+
+/**
+ * Determine the notice type
+ * @module DetermineNoticeTypeService
+ */
+
+const { generateRandomInteger } = require('../../../lib/general.lib.js')
+
+/**
+ * Defines the configuration for supported notification types.
+ *
+ * This structure enables consistent handling and display of different notification types
+ * across the system. Each type includes legacy fields (`name` and `subType`) required for backwards compatibility.
+ *
+ * Legacy context:
+ * - `name` is used in the legacy UI to render the notification type on `/notifications/report`
+ * - `subType` is used when querying notifications in the legacy system
+ *
+ * @private
+ */
+const NOTIFICATION_TYPES = {
+  invitations: {
+    journey: 'invitations',
+    name: 'Returns: invitation',
+    prefix: 'RINV-',
+    redirectPath: 'returns-period',
+    subType: 'returnInvitation',
+    type: 'Returns invitation'
+  },
+  reminders: {
+    journey: 'reminders',
+    name: 'Returns: reminder',
+    prefix: 'RREM-',
+    redirectPath: 'returns-period',
+    subType: 'returnReminder',
+    type: 'Returns reminder'
+  },
+  'ad-hoc': {
+    journey: 'ad-hoc',
+    name: 'Returns: ad-hoc',
+    prefix: 'ADHC-',
+    redirectPath: 'licence',
+    subType: 'adHocReminder',
+    type: 'Ad hoc'
+  },
+  'abstraction-alert': {
+    journey: 'abstraction-alert',
+    name: 'Water abstraction alert',
+    prefix: 'WAA-',
+    redirectPath: 'abstraction-alerts/alert-type',
+    subType: 'waterAbstractionAlerts',
+    type: 'Abstraction alert'
+  }
+}
+
+/**
+ * Determine the notice type
+ *
+ * A notice can be for multiple things. This function is the single place to determine the logic / data need for each
+ * notice type.
+ *
+ * The notice type data is saved directly to the database and is used raw in the UI. For example the 'name' is used on
+ * the reports page.
+ *
+ * @param notificationType
+ *
+ * @returns {object}
+ */
+function go(notificationType) {
+  const { journey, name, prefix, redirectPath, subType, type } = NOTIFICATION_TYPES[notificationType]
+
+  return {
+    journey,
+    name,
+    notificationType: type,
+    redirectPath,
+    referenceCode: _generateReferenceCode(prefix),
+    subType
+  }
+}
+
+/**
+ * A function to generate a pseudo-unique reference code for recipients notifications
+ *
+ * @param {string} prefix
+ *
+ * @returns {string} A reference code with a prefix and random string (RINV-A14GB8)
+ */
+function _generateReferenceCode(prefix) {
+  const possible = 'ABCDEFGHJKLMNPQRTUVWXYZ0123456789'
+  const length = 6
+
+  let text = ''
+
+  for (let i = 0; i < length; i++) {
+    text += possible.charAt(generateRandomInteger(0, possible.length))
+  }
+  return prefix + text
+}
+
+module.exports = {
+  go
+}

--- a/app/services/notices/setup/initiate-session.service.js
+++ b/app/services/notices/setup/initiate-session.service.js
@@ -5,56 +5,9 @@
  * @module InitiateSessionService
  */
 
-const { generateRandomInteger } = require('../../../lib/general.lib.js')
 const DetermineLicenceMonitoringStationsService = require('./abstraction-alerts/determine-licence-monitoring-stations.service.js')
+const DetermineNoticeTypeService = require('./determine-notice-type.service.js')
 const SessionModel = require('../../../models/session.model.js')
-
-/**
- * Defines the configuration for supported notification types.
- *
- * This structure enables consistent handling and display of different notification types
- * across the system. Each type includes legacy fields (`name` and `subType`) required for backwards compatibility.
- *
- * Legacy context:
- * - `name` is used in the legacy UI to render the notification type on `/notifications/report`
- * - `subType` is used when querying notifications in the legacy system
- *
- * @private
- */
-const NOTIFICATION_TYPES = {
-  invitations: {
-    journey: 'invitations',
-    name: 'Returns: invitation',
-    prefix: 'RINV-',
-    redirectPath: 'returns-period',
-    subType: 'returnInvitation',
-    type: 'Returns invitation'
-  },
-  reminders: {
-    journey: 'reminders',
-    name: 'Returns: reminder',
-    prefix: 'RREM-',
-    redirectPath: 'returns-period',
-    subType: 'returnReminder',
-    type: 'Returns reminder'
-  },
-  'ad-hoc': {
-    journey: 'ad-hoc',
-    name: 'Returns: ad-hoc',
-    prefix: 'ADHC-',
-    redirectPath: 'licence',
-    subType: 'adHocReminder',
-    type: 'Ad hoc'
-  },
-  'abstraction-alert': {
-    journey: 'abstraction-alert',
-    name: 'Water abstraction alert',
-    prefix: 'WAA-',
-    redirectPath: 'abstraction-alerts/alert-type',
-    subType: 'waterAbstractionAlerts',
-    type: 'Abstraction alert'
-  }
-}
 
 /**
  * Initiates the session record used for setting up a new returns notification
@@ -76,7 +29,7 @@ const NOTIFICATION_TYPES = {
  * @returns {Promise<module:SessionModel>} the newly created session record
  */
 async function go(notificationType, monitoringStationId = null) {
-  const { journey, name, prefix, redirectPath, subType, type } = NOTIFICATION_TYPES[notificationType]
+  const { redirectPath, ...noticeType } = DetermineNoticeTypeService.go(notificationType)
 
   let additionalData = {}
 
@@ -88,11 +41,7 @@ async function go(notificationType, monitoringStationId = null) {
     .insert({
       data: {
         ...additionalData,
-        journey,
-        name,
-        notificationType: type,
-        referenceCode: _generateReferenceCode(prefix),
-        subType
+        ...noticeType
       }
     })
     .returning('id')
@@ -101,25 +50,6 @@ async function go(notificationType, monitoringStationId = null) {
     sessionId: session.id,
     path: `${redirectPath}`
   }
-}
-
-/**
- * A function to generate a pseudo-unique reference code for recipients notifications
- *
- * @param {string} prefix
- *
- * @returns {string} A reference code with a prefix and random string (RINV-A14GB8)
- */
-function _generateReferenceCode(prefix) {
-  const possible = 'ABCDEFGHJKLMNPQRTUVWXYZ0123456789'
-  const length = 6
-
-  let text = ''
-
-  for (let i = 0; i < length; i++) {
-    text += possible.charAt(generateRandomInteger(0, possible.length))
-  }
-  return prefix + text
 }
 
 module.exports = {

--- a/test/services/notices/setup/determine-notice-type.service.test.js
+++ b/test/services/notices/setup/determine-notice-type.service.test.js
@@ -36,7 +36,7 @@ describe('Notices - Setup - Determine Notice Type service', () => {
       })
     })
 
-    describe('when the "notificationType" is "reminders"', () => {
+    describe('and the "notificationType" is "reminders"', () => {
       it('creates a new session record', () => {
         const result = DetermineNoticeTypeService.go('reminders')
 

--- a/test/services/notices/setup/determine-notice-type.service.test.js
+++ b/test/services/notices/setup/determine-notice-type.service.test.js
@@ -84,7 +84,7 @@ describe('Notices - Setup - Initiate Session service', () => {
       })
     })
 
-    describe('when the "notificationType" is "abstraction-alert"', () => {
+    describe.only('when the "notificationType" is "abstraction-alert"', () => {
       it('creates a new session record', () => {
         const result = DetermineNoticeTypeService.go('abstraction-alert')
 
@@ -95,6 +95,15 @@ describe('Notices - Setup - Initiate Session service', () => {
           redirectPath: 'abstraction-alerts/alert-type',
           referenceCode: result.referenceCode, // randomly generated
           subType: 'waterAbstractionAlerts'
+        })
+      })
+
+      describe('the "referenceCode" property', () => {
+        it('returns a reference code for an "abstraction-alert" notification', () => {
+          const result = DetermineNoticeTypeService.go('abstraction-alert')
+
+          expect(result.referenceCode).to.include('WAA-')
+          expect(result.referenceCode.length).to.equal(10)
         })
       })
     })

--- a/test/services/notices/setup/determine-notice-type.service.test.js
+++ b/test/services/notices/setup/determine-notice-type.service.test.js
@@ -84,7 +84,7 @@ describe('Notices - Setup - Initiate Session service', () => {
       })
     })
 
-    describe.only('when the "notificationType" is "abstraction-alert"', () => {
+    describe('when the "notificationType" is "abstraction-alert"', () => {
       it('creates a new session record', () => {
         const result = DetermineNoticeTypeService.go('abstraction-alert')
 

--- a/test/services/notices/setup/determine-notice-type.service.test.js
+++ b/test/services/notices/setup/determine-notice-type.service.test.js
@@ -1,0 +1,102 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Thing under test
+const DetermineNoticeTypeService = require('../../../../app/services/notices/setup/determine-notice-type.service.js')
+
+describe('Notices - Setup - Initiate Session service', () => {
+  describe('when called', () => {
+    describe('when the "notificationType" is "invitations"', () => {
+      it('creates a new session record', () => {
+        const result = DetermineNoticeTypeService.go('invitations')
+
+        expect(result).to.equal({
+          journey: 'invitations',
+          name: 'Returns: invitation',
+          notificationType: 'Returns invitation',
+          redirectPath: 'returns-period',
+          referenceCode: result.referenceCode, // randomly generated
+          subType: 'returnInvitation'
+        })
+      })
+
+      describe('the "referenceCode" property', () => {
+        it('returns a reference code for "invitations" notifications', () => {
+          const result = DetermineNoticeTypeService.go('invitations')
+
+          expect(result.referenceCode).to.include('RINV-')
+          expect(result.referenceCode.length).to.equal(11)
+        })
+      })
+    })
+
+    describe('when the "notificationType" is "reminders"', () => {
+      it('creates a new session record', () => {
+        const result = DetermineNoticeTypeService.go('reminders')
+
+        expect(result).to.equal({
+          journey: 'reminders',
+          name: 'Returns: reminder',
+          notificationType: 'Returns reminder',
+          redirectPath: 'returns-period',
+          referenceCode: result.referenceCode, // randomly generated
+          subType: 'returnReminder'
+        })
+      })
+
+      describe('the "referenceCode" property', () => {
+        it('returns a reference code for "reminders" notifications', () => {
+          const result = DetermineNoticeTypeService.go('reminders')
+
+          expect(result.referenceCode).to.include('RREM-')
+          expect(result.referenceCode.length).to.equal(11)
+        })
+      })
+    })
+
+    describe('when the "notificationType" is "ad-hoc"', () => {
+      it('creates a new session record', () => {
+        const result = DetermineNoticeTypeService.go('ad-hoc')
+
+        expect(result).to.equal({
+          journey: 'ad-hoc',
+          name: 'Returns: ad-hoc',
+          notificationType: 'Ad hoc',
+          redirectPath: 'licence',
+          referenceCode: result.referenceCode, // randomly generated
+          subType: 'adHocReminder'
+        })
+      })
+
+      describe('the "referenceCode" property', () => {
+        it('returns a reference code for an "ad-hoc" notification', () => {
+          const result = DetermineNoticeTypeService.go('ad-hoc')
+
+          expect(result.referenceCode).to.include('ADHC-')
+          expect(result.referenceCode.length).to.equal(11)
+        })
+      })
+    })
+
+    describe('when the "notificationType" is "abstraction-alert"', () => {
+      it('creates a new session record', () => {
+        const result = DetermineNoticeTypeService.go('abstraction-alert')
+
+        expect(result).to.equal({
+          journey: 'abstraction-alert',
+          name: 'Water abstraction alert',
+          notificationType: 'Abstraction alert',
+          redirectPath: 'abstraction-alerts/alert-type',
+          referenceCode: result.referenceCode, // randomly generated
+          subType: 'waterAbstractionAlerts'
+        })
+      })
+    })
+  })
+})

--- a/test/services/notices/setup/determine-notice-type.service.test.js
+++ b/test/services/notices/setup/determine-notice-type.service.test.js
@@ -10,7 +10,7 @@ const { expect } = Code
 // Thing under test
 const DetermineNoticeTypeService = require('../../../../app/services/notices/setup/determine-notice-type.service.js')
 
-describe('Notices - Setup - Initiate Session service', () => {
+describe('Notices - Setup - Determine Notice Type service', () => {
   describe('when called', () => {
     describe('when the "notificationType" is "invitations"', () => {
       it('creates a new session record', () => {

--- a/test/services/notices/setup/determine-notice-type.service.test.js
+++ b/test/services/notices/setup/determine-notice-type.service.test.js
@@ -60,7 +60,7 @@ describe('Notices - Setup - Determine Notice Type service', () => {
       })
     })
 
-    describe('when the "notificationType" is "ad-hoc"', () => {
+    describe('and the "notificationType" is "ad-hoc"', () => {
       it('creates a new session record', () => {
         const result = DetermineNoticeTypeService.go('ad-hoc')
 

--- a/test/services/notices/setup/determine-notice-type.service.test.js
+++ b/test/services/notices/setup/determine-notice-type.service.test.js
@@ -12,7 +12,7 @@ const DetermineNoticeTypeService = require('../../../../app/services/notices/set
 
 describe('Notices - Setup - Determine Notice Type service', () => {
   describe('when called', () => {
-    describe('when the "notificationType" is "invitations"', () => {
+    describe('and the "notificationType" is "invitations"', () => {
       it('creates a new session record', () => {
         const result = DetermineNoticeTypeService.go('invitations')
 

--- a/test/services/notices/setup/initiate-session.service.test.js
+++ b/test/services/notices/setup/initiate-session.service.test.js
@@ -24,120 +24,26 @@ describe('Notices - Setup - Initiate Session service', () => {
   })
 
   describe('when called', () => {
+    it('creates a new session record', async () => {
+      const result = await InitiateSessionService.go('invitations')
+
+      const matchingSession = await SessionModel.query().findById(result.sessionId)
+
+      expect(matchingSession.data).to.equal({
+        journey: 'invitations',
+        name: 'Returns: invitation',
+        notificationType: 'Returns invitation',
+        referenceCode: matchingSession.referenceCode, // randomly generated
+        subType: 'returnInvitation'
+      })
+    })
+
     it('correctly returns the redirect path and session id', async () => {
       const result = await InitiateSessionService.go('invitations')
 
       expect(result).to.equal({
         sessionId: result.sessionId,
         path: 'returns-period'
-      })
-    })
-
-    describe('when the "notificationType" is "invitations"', () => {
-      it('creates a new session record', async () => {
-        const result = await InitiateSessionService.go('invitations')
-
-        const matchingSession = await SessionModel.query().findById(result.sessionId)
-
-        expect(matchingSession.data).to.equal({
-          journey: 'invitations',
-          name: 'Returns: invitation',
-          notificationType: 'Returns invitation',
-          referenceCode: matchingSession.referenceCode, // randomly generated
-          subType: 'returnInvitation'
-        })
-      })
-
-      it('correctly returns the redirect path and session id', async () => {
-        const result = await InitiateSessionService.go('invitations')
-
-        expect(result).to.equal({
-          sessionId: result.sessionId,
-          path: 'returns-period'
-        })
-      })
-
-      describe('the "referenceCode" property', () => {
-        it('returns a reference code for "invitations" notifications', async () => {
-          const result = await InitiateSessionService.go('invitations')
-
-          const matchingSession = await SessionModel.query().findById(result.sessionId)
-
-          expect(matchingSession.referenceCode).to.include('RINV-')
-          expect(matchingSession.referenceCode.length).to.equal(11)
-        })
-      })
-    })
-
-    describe('when the "notificationType" is "reminders"', () => {
-      it('creates a new session record', async () => {
-        const result = await InitiateSessionService.go('reminders')
-
-        const matchingSession = await SessionModel.query().findById(result.sessionId)
-
-        expect(matchingSession.data).to.equal({
-          journey: 'reminders',
-          name: 'Returns: reminder',
-          notificationType: 'Returns reminder',
-          referenceCode: matchingSession.referenceCode, // randomly generated
-          subType: 'returnReminder'
-        })
-      })
-
-      it('correctly returns the redirect path and session id', async () => {
-        const result = await InitiateSessionService.go('reminders')
-
-        expect(result).to.equal({
-          sessionId: result.sessionId,
-          path: 'returns-period'
-        })
-      })
-
-      describe('the "referenceCode" property', () => {
-        it('returns a reference code for "reminders" notifications', async () => {
-          const result = await InitiateSessionService.go('reminders')
-
-          const matchingSession = await SessionModel.query().findById(result.sessionId)
-
-          expect(matchingSession.referenceCode).to.include('RREM-')
-          expect(matchingSession.referenceCode.length).to.equal(11)
-        })
-      })
-    })
-
-    describe('when the "notificationType" is "ad-hoc"', () => {
-      it('creates a new session record', async () => {
-        const result = await InitiateSessionService.go('ad-hoc')
-
-        const matchingSession = await SessionModel.query().findById(result.sessionId)
-
-        expect(matchingSession.data).to.equal({
-          journey: 'ad-hoc',
-          name: 'Returns: ad-hoc',
-          notificationType: 'Ad hoc',
-          referenceCode: matchingSession.referenceCode, // randomly generated
-          subType: 'adHocReminder'
-        })
-      })
-
-      it('correctly returns the redirect path and session id', async () => {
-        const result = await InitiateSessionService.go('ad-hoc')
-
-        expect(result).to.equal({
-          sessionId: result.sessionId,
-          path: 'licence'
-        })
-      })
-
-      describe('the "referenceCode" property', () => {
-        it('returns a reference code for an "ad-hoc" notification', async () => {
-          const result = await InitiateSessionService.go('ad-hoc')
-
-          const matchingSession = await SessionModel.query().findById(result.sessionId)
-
-          expect(matchingSession.referenceCode).to.include('ADHC-')
-          expect(matchingSession.referenceCode.length).to.equal(11)
-        })
       })
     })
 
@@ -181,17 +87,6 @@ describe('Notices - Setup - Initiate Session service', () => {
         expect(result).to.equal({
           sessionId: result.sessionId,
           path: 'abstraction-alerts/alert-type'
-        })
-      })
-
-      describe('the "referenceCode" property', () => {
-        it('returns a reference code for an "ad-hoc" notification', async () => {
-          const result = await InitiateSessionService.go('abstraction-alert', monitoringStationId)
-
-          const matchingSession = await SessionModel.query().findById(result.sessionId)
-
-          expect(matchingSession.referenceCode).to.include('WAA-')
-          expect(matchingSession.referenceCode.length).to.equal(10)
         })
       })
     })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5101

We previously implemented 'ad-hoc' returns as a journey for notices. This is going to change.

We will introduce a page to allow the user to select a notice type when they have chosen a licence for notices.

As part of this upcoming page we need to extract our existing journey logic into a reusable function.

This change introduces the Determine Notice Type Service. This function will set the notice type for all journeys.

Our initial entry to setting up the session data is still based on the query string, but this may change.