### PR TITLE
Update recipient cancel for abstraction journey

### DIFF
--- a/app/controllers/notices-setup.controller.js
+++ b/app/controllers/notices-setup.controller.js
@@ -218,9 +218,9 @@ async function submitAlertType(request, h) {
 async function submitCancel(request, h) {
   const { sessionId } = request.params
 
-  await SubmitCancelService.go(sessionId)
+  const redirectURl = await SubmitCancelService.go(sessionId)
 
-  return h.redirect(`/manage`)
+  return h.redirect(redirectURl)
 }
 
 async function submitCancelAlerts(request, h) {

--- a/app/presenters/notices/setup/cancel.presenter.js
+++ b/app/presenters/notices/setup/cancel.presenter.js
@@ -5,7 +5,7 @@
  * @module CancelPresenter
  */
 
-const { formatLongDate } = require('../../base.presenter.js')
+const { formatLongDate, sentenceCase } = require('../../base.presenter.js')
 
 /**
  * Formats data for the `/notices/setup/{sessionId}/cancel` page
@@ -15,12 +15,36 @@ const { formatLongDate } = require('../../base.presenter.js')
  * @returns {object} - The data formatted for the view template
  */
 function go(session) {
-  const { referenceCode } = session
+  const { referenceCode, journey } = session
+
+  let pageData
+
+  if (journey === 'abstraction-alert') {
+    pageData = _alerts(session)
+  } else {
+    pageData = _returns(session)
+  }
 
   return {
     backLink: `/system/notices/setup/${session.id}/check`,
-    pageTitle: 'You are about to cancel this notice',
     referenceCode,
+    ...pageData
+  }
+}
+
+function _alerts(session) {
+  return {
+    pageTitle: 'You are about to cancel this alert',
+    summaryList: {
+      text: 'Alert type',
+      value: `${sentenceCase(session.alertType)}`
+    }
+  }
+}
+
+function _returns(session) {
+  return {
+    pageTitle: 'You are about to cancel this notice',
     summaryList: _summaryList(session)
   }
 }

--- a/app/services/notices/setup/submit-cancel.service.js
+++ b/app/services/notices/setup/submit-cancel.service.js
@@ -10,12 +10,24 @@ const SessionModel = require('../../../models/session.model.js')
 /**
  * Orchestrates handling the data for `/notices/setup/{sessionId}/cancel` page
  *
- * This service will delete the session record.
+ * This service will delete the session record and provide the redirect url.
  *
  * @param {string} sessionId - The UUID for the notification setup session record
+ *
+ * @returns {Promise<string>} - returns the redirect url, which can contain some session data that needs to be deleted
  */
 async function go(sessionId) {
+  const session = await SessionModel.query().findById(sessionId)
+
   await SessionModel.query().delete().where('id', sessionId)
+
+  let redirectURl = '/manage'
+
+  if (session.journey === 'abstraction-alert') {
+    redirectURl = `/system/monitoring-stations/${session.monitoringStationId}`
+  }
+
+  return redirectURl
 }
 
 module.exports = {

--- a/test/controllers/notices-setup.controller.test.js
+++ b/test/controllers/notices-setup.controller.test.js
@@ -663,7 +663,7 @@ describe('Notices Setup controller', () => {
     describe('POST', () => {
       describe('when the request succeeds', () => {
         beforeEach(async () => {
-          Sinon.stub(SubmitCancelService, 'go').returns()
+          Sinon.stub(SubmitCancelService, 'go').returns('/manage')
           postOptions = postRequestOptions(basePath + `/${session.id}/cancel`, {})
         })
 

--- a/test/presenters/notices/setup/cancel.presenter.test.js
+++ b/test/presenters/notices/setup/cancel.presenter.test.js
@@ -44,12 +44,44 @@ describe('Notices - Setup - Cancel presenter', () => {
   })
 
   describe('when the journey is "ad-hoc"', () => {
+    it('correctly formats the page title', () => {
+      const result = CancelPresenter.go(session)
+
+      expect(result.pageTitle).to.equal('You are about to cancel this notice')
+    })
+
     it('correctly formats the summary list', () => {
       const result = CancelPresenter.go(session)
 
       expect(result.summaryList).to.equal({
         text: 'Licence number',
         value: licenceRef
+      })
+    })
+  })
+
+  describe('when the journey is "abstraction-alerts"', () => {
+    beforeEach(() => {
+      session = {
+        alertType: 'stop',
+        journey: 'abstraction-alert',
+        monitoringStationId: '123',
+        referenceCode: 'WAA-1234'
+      }
+    })
+
+    it('correctly formats the page title', () => {
+      const result = CancelPresenter.go(session)
+
+      expect(result.pageTitle).to.equal('You are about to cancel this alert')
+    })
+
+    it('correctly formats the summary list', () => {
+      const result = CancelPresenter.go(session)
+
+      expect(result.summaryList).to.equal({
+        text: 'Alert type',
+        value: 'Stop'
       })
     })
   })
@@ -64,6 +96,12 @@ describe('Notices - Setup - Cancel presenter', () => {
         summer: 'false',
         startDate: '2025-04-01'
       }
+    })
+
+    it('correctly formats the page title', () => {
+      const result = CancelPresenter.go(session)
+
+      expect(result.pageTitle).to.equal('You are about to cancel this notice')
     })
 
     it('correctly formats the summary list', () => {
@@ -88,6 +126,12 @@ describe('Notices - Setup - Cancel presenter', () => {
       }
     })
 
+    it('correctly formats the page title', () => {
+      const result = CancelPresenter.go(session)
+
+      expect(result.pageTitle).to.equal('You are about to cancel this notice')
+    })
+
     it('correctly formats the summary list', () => {
       const result = CancelPresenter.go(session)
 
@@ -109,6 +153,12 @@ describe('Notices - Setup - Cancel presenter', () => {
           summer: 'false',
           startDate: '2025-04-01'
         }
+      })
+
+      it('correctly formats the page title', () => {
+        const result = CancelPresenter.go(session)
+
+        expect(result.pageTitle).to.equal('You are about to cancel this notice')
       })
 
       it('correctly formats the summary list', () => {

--- a/test/services/notices/setup/submit-cancel.service.test.js
+++ b/test/services/notices/setup/submit-cancel.service.test.js
@@ -34,5 +34,32 @@ describe('Notices - Setup - Submit Cancel service', () => {
 
       expect(noSession).to.equal([])
     })
+
+    describe('when the journey is for a return', () => {
+      it('returns the redirect url', async () => {
+        const result = await SubmitCancelService.go(session.id)
+
+        expect(result).to.equal('/manage')
+      })
+    })
+
+    describe('when the journey is for "abstraction-alerts"', () => {
+      beforeEach(async () => {
+        session = await SessionHelper.add({
+          data: {
+            alertType: 'stop',
+            journey: 'abstraction-alert',
+            monitoringStationId: '123',
+            referenceCode: 'WAA-1234'
+          }
+        })
+      })
+
+      it('returns the redirect url', async () => {
+        const result = await SubmitCancelService.go(session.id)
+
+        expect(result).to.equal('/system/monitoring-stations/123')
+      })
+    })
   })
 })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5067

There is existing logic to allow a user to cancel the notice on the recipients page. There is also a cancel option earlier in the abstraction alerts journey on the select licence matches page.

We need to allow the user to cancel the notice on for an abstraction alert on the recipients cancel page.

This change updates the existing cancel recipients  logic to handle the abstraction alerts journey.

It would have been more complicated to redirect to the existing alerts cancel page and set the correct back link navigation etc. So we have updated the existing logic to accommodate this.

Doing the change this way allows us to adapt to the potential design change in the future.

This cancel page uses the notice reference code the same as the other to signify we are pass the journey specific pages.