### PR TITLE
Reorder tear down for acceptance tests

### DIFF
--- a/app/services/data/tear-down/tear-down.service.js
+++ b/app/services/data/tear-down/tear-down.service.js
@@ -18,13 +18,9 @@ const WaterSchemaService = require('./water-schema.service.js')
 async function go() {
   const startTime = currentTimeInNanoseconds()
 
-  await Promise.all([
-    CrmSchemaService.go(),
-    IdmSchemaService.go(),
-    PermitSchemaService.go(),
-    ReturnsSchemaService.go(),
-    WaterSchemaService.go()
-  ])
+  await Promise.all([CrmSchemaService.go(), IdmSchemaService.go(), PermitSchemaService.go(), ReturnsSchemaService.go()])
+
+  await WaterSchemaService.go()
 
   calculateAndLogTimeTaken(startTime, 'Tear down complete')
 }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4892

While creating the acceptance tests for the quarterly returns it was noticed that in some of the tests the newly created return longs were not being deleted. As these were created by the system and not injected into the tests they did not have their is_test flag set. The tear down functions do have a join on the licence table to delete even those ones however it is possible for the licence table to be deleted before the returns table which leads to return logs being there the next time the tests are ran. 

This change pulls out the tear down of the water schema until after all the other schemas have been processed so the licence details will still be there when the returns schema is deleted. 