### PR TITLE
Update abstraction alerts notice licence ref

### DIFF
--- a/app/presenters/notices/setup/abstraction-alerts-notifications.presenter.js
+++ b/app/presenters/notices/setup/abstraction-alerts-notifications.presenter.js
@@ -174,7 +174,7 @@ function _email(recipient, referenceCode, eventId, commonPersonalisation, alertT
   return {
     createdAt,
     eventId,
-    licences: _licences(recipient.licence_refs),
+    licences: _licences(commonPersonalisation.licence_ref),
     messageRef: _emailMessageRef(alertType, restrictionType),
     messageType,
     personalisation: commonPersonalisation,
@@ -221,7 +221,7 @@ function _letter(recipient, referenceCode, eventId, commonPersonalisation, alert
   return {
     createdAt,
     eventId,
-    licences: _licences(recipient.licence_refs),
+    licences: _licences(commonPersonalisation.licence_ref),
     messageRef: _messageRef(alertType, restrictionType),
     messageType,
     personalisation: {

--- a/test/presenters/notices/setup/abstraction-alert-notifications.presenter.test.js
+++ b/test/presenters/notices/setup/abstraction-alert-notifications.presenter.test.js
@@ -214,7 +214,7 @@ describe('Notices - Setup - Abstraction alert notifications presenter', () => {
           eventId: 'c1cae668-3dad-4806-94e2-eb3f27222ed9',
           reference: 'TEST-123',
           templateId: 'a51ace39-3224-4c18-bbb8-c803a6da9a21',
-          licences: `["${recipients.additionalContact.licence_refs}","12/345"]`,
+          licences: `["${recipients.additionalContact.licence_refs}"]`,
           messageType: 'email',
           messageRef: 'water_abstraction_alert_stop_warning_email',
           personalisation: {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5067

We have previously implemented the abstraction alerts notices to save all the licence refs relevant to the notice from all licence monitoring stations.

This change updates the saved licence refs for an abstraction alert to be specific to the licence monitoring station.