### PR TITLE
Update notices setup notice type

### DIFF
--- a/app/presenters/notices/setup/check.presenter.js
+++ b/app/presenters/notices/setup/check.presenter.js
@@ -75,7 +75,7 @@ function _links(session) {
   let removeLicences = ''
 
   if (journey === 'ad-hoc') {
-    back = `/system/notices/setup/${id}/ad-hoc-licence`
+    back = `/system/notices/setup/${id}/licence`
   } else if (journey === 'abstraction-alert') {
     back = `/system/notices/setup/${id}/abstraction-alerts/alert-email-address`
   } else {

--- a/app/presenters/notices/setup/notice-type.presenter.js
+++ b/app/presenters/notices/setup/notice-type.presenter.js
@@ -8,12 +8,32 @@
 /**
  * Formats data for the `/notices/setup/{sessionId}/notice-type` page
  *
+ * @param session
  * @returns {object} - The data formatted for the view template
  */
-function go() {
+function go(session) {
+  const { noticeType, id: sessionId } = session
+
   return {
+    backLink: `/system/notices/setup/${sessionId}/licence`,
+    options: _options(noticeType),
     pageTitle: 'Select the notice type'
   }
+}
+
+function _options(noticeType) {
+  return [
+    {
+      checked: noticeType === 'invitations',
+      value: 'invitations',
+      text: 'Standard returns invitation'
+    },
+    {
+      checked: noticeType === 'paper-invitation',
+      value: 'paper-invitation',
+      text: 'Submit using a paper form invitation'
+    }
+  ]
 }
 
 module.exports = {

--- a/app/services/notices/setup/submit-notice-type.service.js
+++ b/app/services/notices/setup/submit-notice-type.service.js
@@ -37,7 +37,9 @@ async function go(sessionId, payload) {
   }
 }
 
-async function _save(session, _payload) {
+async function _save(session, payload) {
+  session.noticeType = payload.noticeType
+
   return session.$update()
 }
 

--- a/app/validators/notices/setup/notice-type.validator.js
+++ b/app/validators/notices/setup/notice-type.validator.js
@@ -8,6 +8,8 @@
 
 const Joi = require('joi')
 
+const errorMessage = 'Select the notice type'
+
 /**
  * Validates data submitted for the `/notices/setup/{sessionId}/notice-type` page
  *
@@ -17,7 +19,9 @@ const Joi = require('joi')
  * any errors are found the `error:` property will also exist detailing what the issues were
  */
 function go(payload) {
-  const schema = Joi.object({ noticeType: Joi.required() })
+  const schema = Joi.object({ noticeType: Joi.required() }).messages({
+    'any.required': errorMessage
+  })
 
   return schema.validate(payload, { abortEarly: false })
 }

--- a/app/views/notices/setup/notice-type.njk
+++ b/app/views/notices/setup/notice-type.njk
@@ -1,5 +1,6 @@
 {% extends 'layout.njk' %}
 
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
@@ -17,13 +18,31 @@
   {% if error %}
     {{ govukErrorSummary({
       titleText: "There is a problem",
-      errorList: error.errorList
+      errorList: [
+        {
+          text: error.text,
+          href: "#noticeType"
+        }
+      ]
     }) }}
   {%endif%}
 
   <div>
     <form method="post">
       <input type="hidden" name="wrlsCrumb" value="{{wrlsCrumb}}"/>
+
+      {{ govukRadios({
+        name: "noticeType",
+        errorMessage: error,
+        fieldset: {
+          legend: {
+            text: pageTitle,
+            isPageHeading: true,
+            classes: "govuk-fieldset__legend--l"
+          }
+        },
+        items: options
+      }) }}
 
       {{ govukButton({ text: "Continue", preventDoubleClick: true }) }}
     </form>

--- a/test/presenters/notices/setup/check.presenter.test.js
+++ b/test/presenters/notices/setup/check.presenter.test.js
@@ -329,7 +329,7 @@ describe('Notices - Setup - Check presenter', () => {
         it('should return the links for "invitations"', () => {
           const result = CheckPresenter.go(testInput, page, pagination, session)
           expect(result.links).to.equal({
-            back: `/system/notices/setup/${session.id}/ad-hoc-licence`,
+            back: `/system/notices/setup/${session.id}/licence`,
             cancel: `/system/notices/setup/${session.id}/cancel`,
             download: `/system/notices/setup/${session.id}/download`,
             removeLicences: ``

--- a/test/presenters/notices/setup/notice-type.presenter.test.js
+++ b/test/presenters/notices/setup/notice-type.presenter.test.js
@@ -14,14 +14,77 @@ describe('Notice Type Presenter', () => {
   let session
 
   beforeEach(() => {
-    session = {}
+    session = { id: '123' }
   })
 
   describe('when called', () => {
     it('returns page data for the view', () => {
       const result = NoticeTypePresenter.go(session)
 
-      expect(result).to.equal({ pageTitle: 'Select the notice type' })
+      expect(result).to.equal({
+        backLink: '/system/notices/setup/123/licence',
+        options: [
+          {
+            checked: false,
+            text: 'Standard returns invitation',
+            value: 'invitations'
+          },
+          {
+            checked: false,
+            text: 'Submit using a paper form invitation',
+            value: 'paper-invitation'
+          }
+        ],
+        pageTitle: 'Select the notice type'
+      })
+    })
+
+    describe('when the a previous "noticeType" has been selected', () => {
+      describe('and the selected notice type was "invitations"', () => {
+        beforeEach(() => {
+          session.noticeType = 'invitations'
+        })
+
+        it('returns the invitations checked', () => {
+          const result = NoticeTypePresenter.go(session)
+
+          expect(result.options).to.equal([
+            {
+              checked: true,
+              text: 'Standard returns invitation',
+              value: 'invitations'
+            },
+            {
+              checked: false,
+              text: 'Submit using a paper form invitation',
+              value: 'paper-invitation'
+            }
+          ])
+        })
+      })
+
+      describe('and the selected notice type was "paper-invitations"', () => {
+        beforeEach(() => {
+          session.noticeType = 'paper-invitation'
+        })
+
+        it('returns the paper invitation checked', () => {
+          const result = NoticeTypePresenter.go(session)
+
+          expect(result.options).to.equal([
+            {
+              checked: false,
+              text: 'Standard returns invitation',
+              value: 'invitations'
+            },
+            {
+              checked: true,
+              text: 'Submit using a paper form invitation',
+              value: 'paper-invitation'
+            }
+          ])
+        })
+      })
     })
   })
 })

--- a/test/services/notices/setup/notice-type.service.test.js
+++ b/test/services/notices/setup/notice-type.service.test.js
@@ -27,7 +27,22 @@ describe('Notice Type Service', () => {
     it('returns page data for the view', async () => {
       const result = await NoticeTypeService.go(session.id)
 
-      expect(result).to.equal({ pageTitle: 'Select the notice type' })
+      expect(result).to.equal({
+        backLink: `/system/notices/setup/${session.id}/licence`,
+        options: [
+          {
+            checked: false,
+            text: 'Standard returns invitation',
+            value: 'invitations'
+          },
+          {
+            checked: false,
+            text: 'Submit using a paper form invitation',
+            value: 'paper-invitation'
+          }
+        ],
+        pageTitle: 'Select the notice type'
+      })
     })
   })
 })

--- a/test/services/notices/setup/submit-notice-type.service.test.js
+++ b/test/services/notices/setup/submit-notice-type.service.test.js
@@ -17,21 +17,23 @@ describe('Notice Type Service', () => {
   let payload
   let session
   let sessionData
+  let noticeType
 
   beforeEach(async () => {
-    payload = { noticeType: 'returns' }
+    noticeType = 'invitations'
+    payload = { noticeType }
     sessionData = {}
 
     session = await SessionHelper.add({ data: sessionData })
   })
 
   describe('when called', () => {
-    it('saves the submitted value', async () => {
+    it('saves the submitted "noticeType"', async () => {
       await SubmitNoticeTypeService.go(session.id, payload)
 
       const refreshedSession = await session.$query()
 
-      expect(refreshedSession).to.equal(session)
+      expect(refreshedSession.noticeType).to.equal(noticeType)
     })
 
     it('continues the journey', async () => {
@@ -49,7 +51,23 @@ describe('Notice Type Service', () => {
     it('returns page data for the view, with errors', async () => {
       const result = await SubmitNoticeTypeService.go(session.id, payload)
 
-      expect(result).to.equal({ error: { text: '"noticeType" is required' }, pageTitle: 'Select the notice type' })
+      expect(result).to.equal({
+        backLink: `/system/notices/setup/${session.id}/licence`,
+        error: { text: 'Select the notice type' },
+        options: [
+          {
+            checked: false,
+            text: 'Standard returns invitation',
+            value: 'invitations'
+          },
+          {
+            checked: false,
+            text: 'Submit using a paper form invitation',
+            value: 'paper-invitation'
+          }
+        ],
+        pageTitle: 'Select the notice type'
+      })
     })
   })
 })

--- a/test/validators/notices/setup/notice-type.validator.test.js
+++ b/test/validators/notices/setup/notice-type.validator.test.js
@@ -36,7 +36,7 @@ describe('Notice Type Validator', () => {
 
       expect(result.value).to.exist()
       expect(result.error).to.exist()
-      expect(result.error.details[0].message).to.equal('"noticeType" is required')
+      expect(result.error.details[0].message).to.equal('Select the notice type')
     })
   })
 })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5011

We previously scaffolded the select a notice type page.

This change adds the logic to render the options for a notice type and captures the users input.

We will need to determine the notice type using the previously created 'DetermineNoticeTypeService'. This will be done in another change.