### PR TITLE
Update the notice setup ad-hoc journey to handle paper forms

### DIFF
--- a/app/presenters/notices/setup/check.presenter.js
+++ b/app/presenters/notices/setup/check.presenter.js
@@ -10,6 +10,7 @@ const { defaultPageSize } = require('../../../../config/database.config.js')
 
 const NOTIFICATION_TYPES = {
   'abstraction-alert': 'Abstraction alerts',
+  'paper-invitation': 'Paper invitations',
   invitations: 'Returns invitations',
   reminders: 'Returns reminders'
 }

--- a/app/presenters/notices/setup/confirmation.presenter.js
+++ b/app/presenters/notices/setup/confirmation.presenter.js
@@ -42,6 +42,10 @@ function _pageTitle(subType) {
     return 'Water abstraction alerts sent'
   }
 
+  if (subType === 'paperReturnForms') {
+    return 'Paper return forms sent'
+  }
+
   const subTypes = {
     returnInvitation: 'invitations',
     returnReminder: 'reminders'

--- a/app/services/notices/setup/determine-notice-type.service.js
+++ b/app/services/notices/setup/determine-notice-type.service.js
@@ -20,13 +20,28 @@ const { generateRandomInteger } = require('../../../lib/general.lib.js')
  * @private
  */
 const NOTICE_TYPES = {
+  'abstraction-alert': {
+    journey: 'abstraction-alert',
+    name: 'Water abstraction alert',
+    prefix: 'WAA-',
+    redirectPath: 'abstraction-alerts/alert-type',
+    subType: 'waterAbstractionAlerts',
+    notificationType: 'Abstraction alert'
+  },
   invitations: {
     journey: 'invitations',
     name: 'Returns: invitation',
     prefix: 'RINV-',
     redirectPath: 'returns-period',
     subType: 'returnInvitation',
-    type: 'Returns invitation'
+    notificationType: 'Returns invitation'
+  },
+  'paper-invitation': {
+    journey: 'paper-invitation',
+    name: 'Paper returns',
+    prefix: 'PRTF-',
+    subType: 'paperReturnForms',
+    notificationType: 'Paper invitation'
   },
   reminders: {
     journey: 'reminders',
@@ -34,15 +49,7 @@ const NOTICE_TYPES = {
     prefix: 'RREM-',
     redirectPath: 'returns-period',
     subType: 'returnReminder',
-    type: 'Returns reminder'
-  },
-  'abstraction-alert': {
-    journey: 'abstraction-alert',
-    name: 'Water abstraction alert',
-    prefix: 'WAA-',
-    redirectPath: 'abstraction-alerts/alert-type',
-    subType: 'waterAbstractionAlerts',
-    type: 'Abstraction alert'
+    notificationType: 'Returns reminder'
   }
 }
 
@@ -60,12 +67,12 @@ const NOTICE_TYPES = {
  * @returns {object} - data specific to the notice type
  */
 function go(noticeType) {
-  const { journey, name, prefix, redirectPath, subType, type } = NOTICE_TYPES[noticeType]
+  const { journey, name, prefix, redirectPath, subType, notificationType } = NOTICE_TYPES[noticeType]
 
   return {
     journey,
     name,
-    notificationType: type,
+    notificationType,
     redirectPath,
     referenceCode: _generateReferenceCode(prefix),
     subType

--- a/test/presenters/notices/setup/check.presenter.test.js
+++ b/test/presenters/notices/setup/check.presenter.test.js
@@ -9,11 +9,11 @@ const { expect } = Code
 
 // Test helpers
 const RecipientsFixture = require('../../../fixtures/recipients.fixtures.js')
+const { generateLicenceRef } = require('../../../support/helpers/licence.helper.js')
 const { generateUUID } = require('../../../../app/lib/general.lib.js')
 
 // Thing under test
 const CheckPresenter = require('../../../../app/presenters/notices/setup/check.presenter.js')
-const { generateLicenceRef } = require('../../../support/helpers/licence.helper.js')
 
 describe('Notices - Setup - Check presenter', () => {
   let session
@@ -398,6 +398,19 @@ describe('Notices - Setup - Check presenter', () => {
         it('should return the correct message', () => {
           const result = CheckPresenter.go(testInput, page, pagination, session)
           expect(result.readyToSend).to.equal('Returns reminders are ready to send.')
+        })
+      })
+    })
+
+    describe('when the journey is for "paper-invitation"', () => {
+      beforeEach(() => {
+        session.journey = 'paper-invitation'
+      })
+
+      describe('the "readyToSend" property', () => {
+        it('should return the correct message', () => {
+          const result = CheckPresenter.go(testInput, page, pagination, session)
+          expect(result.readyToSend).to.equal('Paper invitations are ready to send.')
         })
       })
     })

--- a/test/presenters/notices/setup/confirmation.presenter.test.js
+++ b/test/presenters/notices/setup/confirmation.presenter.test.js
@@ -87,4 +87,21 @@ describe('Notices - Setup - Confirmation presenter', () => {
       })
     })
   })
+
+  describe('and the journey is "paper-invitations"', () => {
+    beforeEach(() => {
+      event.subtype = 'paperReturnForms'
+    })
+
+    it('correctly presents the data', () => {
+      const result = ConfirmationPresenter.go(event)
+
+      expect(result).to.equal({
+        forwardLink: '/notifications/report/123',
+        monitoringStationLink: null,
+        pageTitle: 'Paper return forms sent',
+        referenceCode: 'RNIV-1234'
+      })
+    })
+  })
 })

--- a/test/services/notices/setup/determine-notice-type.service.test.js
+++ b/test/services/notices/setup/determine-notice-type.service.test.js
@@ -36,6 +36,30 @@ describe('Notices - Setup - Determine Notice Type service', () => {
       })
     })
 
+    describe('and the "notificationType" is "paper-invitation"', () => {
+      it('creates a new session record', () => {
+        const result = DetermineNoticeTypeService.go('paper-invitation')
+
+        expect(result).to.equal({
+          journey: 'paper-invitation',
+          name: 'Paper returns',
+          notificationType: 'Paper invitation',
+          redirectPath: undefined,
+          referenceCode: result.referenceCode, // randomly generated
+          subType: 'paperReturnForms'
+        })
+      })
+
+      describe('the "referenceCode" property', () => {
+        it('returns a reference code for "invitations" notifications', () => {
+          const result = DetermineNoticeTypeService.go('paper-invitation')
+
+          expect(result.referenceCode).to.include('PRTF-')
+          expect(result.referenceCode.length).to.equal(11)
+        })
+      })
+    })
+
     describe('and the "notificationType" is "reminders"', () => {
       it('creates a new session record', () => {
         const result = DetermineNoticeTypeService.go('reminders')


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5024

This change does not implement paper forms.

It implements the basic changes to the notices journey to allow an individual licence to be entered and the notice type selected and the journey to be progressed.

A standard single licence will work as before.

But a paper form will 'appear' to work in the UI based on the set metadata. So it looks and feels like it works but nothing is sent.

This is required to allow the 'check the notice type' page to work and route correctly.