### PR TITLE
Add `activeNavBar` to full condition page

### DIFF
--- a/app/services/licence-monitoring-station/setup/submit-full-condition.service.js
+++ b/app/services/licence-monitoring-station/setup/submit-full-condition.service.js
@@ -39,6 +39,7 @@ async function go(sessionId, payload) {
   const pageData = await FullConditionService.go(sessionId)
 
   return {
+    activeNavBar: 'search',
     error: validationResult,
     ...pageData
   }

--- a/test/services/licence-monitoring-station/setup/submit-full-condition.service.test.js
+++ b/test/services/licence-monitoring-station/setup/submit-full-condition.service.test.js
@@ -23,7 +23,10 @@ describe('Submit Full Condition Service', () => {
   let payload
   let session
 
-  const pageData = { pageData: 'PAGE_DATA' }
+  const pageData = {
+    activeNavBar: 'search',
+    pageData: 'PAGE_DATA'
+  }
 
   beforeEach(async () => {
     session = await SessionHelper.add()


### PR DESCRIPTION
We notice that we are missing the `activeNavBar` property for the tag a licence `/full-condition` page when an error occurs. We therefore add this.