### PR TITLE
Add notice setup returns for paper forms

### DIFF
--- a/app/controllers/notices-setup.controller.js
+++ b/app/controllers/notices-setup.controller.js
@@ -19,6 +19,7 @@ const LicenceService = require('../services/notices/setup/licence.service.js')
 const NoticeTypeService = require('../services/notices/setup/notice-type.service.js')
 const RemoveLicencesService = require('../services/notices/setup/remove-licences.service.js')
 const RemoveThresholdService = require('../services/notices/setup/abstraction-alerts/remove-threshold.service.js')
+const ReturnsForPaperFormsService = require('../services/notices/setup/returns-for-paper-forms.service.js')
 const ReturnsPeriodService = require('../services/notices/setup/returns-period/returns-period.service.js')
 const SubmitAlertEmailAddressService = require('../services/notices/setup/abstraction-alerts/submit-alert-email-address.service.js')
 const SubmitAlertThresholdsService = require('../services/notices/setup/abstraction-alerts/submit-alert-thresholds.service.js')
@@ -30,6 +31,7 @@ const SubmitCheckService = require('../services/notices/setup/submit-check.servi
 const SubmitLicenceService = require('../services/notices/setup/submit-licence.service.js')
 const SubmitNoticeTypeService = require('../services/notices/setup/submit-notice-type.service.js')
 const SubmitRemoveLicencesService = require('../services/notices/setup/submit-remove-licences.service.js')
+const SubmitReturnsForPaperFormsService = require('../services/notices/setup/submit-returns-for-paper-forms.service.js')
 const SubmitReturnsPeriodService = require('../services/notices/setup/returns-period/submit-returns-period.service.js')
 
 const basePath = 'notices/setup'
@@ -169,6 +171,14 @@ async function viewRemoveThreshold(request, h) {
   await RemoveThresholdService.go(sessionId, licenceMonitoringStationId, yar)
 
   return h.redirect(`/system/notices/setup/${sessionId}/abstraction-alerts/check-licence-matches`)
+}
+
+async function viewReturnsForPaperForms(request, h) {
+  const { sessionId } = request.params
+
+  const pageData = await ReturnsForPaperFormsService.go(sessionId)
+
+  return h.view(`notices/setup/returns-for-paper-forms.njk`, pageData)
 }
 
 async function setup(request, h) {
@@ -321,6 +331,21 @@ async function submitReturnsPeriod(request, h) {
   return h.redirect(`/system/${basePath}/${pageData.redirect}`)
 }
 
+async function submitReturnsForPaperForms(request, h) {
+  const {
+    payload,
+    params: { sessionId }
+  } = request
+
+  const pageData = await SubmitReturnsForPaperFormsService.go(sessionId, payload)
+
+  if (pageData.error) {
+    return h.view(`notices/setup/returns-for-paper-forms.njk`, pageData)
+  }
+
+  return h.redirect(`/system/notices/setup/${sessionId}/check-notice-type`)
+}
+
 module.exports = {
   downloadRecipients,
   viewAlertEmailAddress,
@@ -335,6 +360,7 @@ module.exports = {
   viewNoticeType,
   viewRemoveLicences,
   viewRemoveThreshold,
+  viewReturnsForPaperForms,
   viewReturnsPeriod,
   setup,
   submitAlertEmailAddress,
@@ -347,5 +373,6 @@ module.exports = {
   submitLicence,
   submitNoticeType,
   submitRemoveLicences,
+  submitReturnsForPaperForms,
   submitReturnsPeriod
 }

--- a/app/presenters/notices/setup/returns-for-paper-forms.presenter.js
+++ b/app/presenters/notices/setup/returns-for-paper-forms.presenter.js
@@ -1,0 +1,21 @@
+'use strict'
+
+/**
+ * Formats data for the `/notices/setup/{sessionId}/returns-for-paper-forms` page
+ * @module ReturnsForPaperFormsPresenter
+ */
+
+/**
+ * Formats data for the `/notices/setup/{sessionId}/returns-for-paper-forms` page
+ *
+ * @returns {object} - The data formatted for the view template
+ */
+function go() {
+  return {
+    pageTile: 'Select the returns for the paper forms'
+  }
+}
+
+module.exports = {
+  go
+}

--- a/app/routes/notices-setup.routes.js
+++ b/app/routes/notices-setup.routes.js
@@ -271,18 +271,6 @@ const routes = [
   },
   {
     method: 'GET',
-    path: basePath + '/{sessionId}/returns-period',
-    options: {
-      handler: NoticesSetupController.viewReturnsPeriod,
-      auth: {
-        access: {
-          scope: ['returns']
-        }
-      }
-    }
-  },
-  {
-    method: 'GET',
     path: basePath + '/{sessionId}/remove-licences',
     options: {
       handler: NoticesSetupController.viewRemoveLicences,
@@ -306,10 +294,46 @@ const routes = [
     }
   },
   {
+    method: 'GET',
+    path: basePath + '/{sessionId}/returns-period',
+    options: {
+      handler: NoticesSetupController.viewReturnsPeriod,
+      auth: {
+        access: {
+          scope: ['returns']
+        }
+      }
+    }
+  },
+  {
     method: 'POST',
     path: basePath + '/{sessionId}/returns-period',
     options: {
       handler: NoticesSetupController.submitReturnsPeriod,
+      auth: {
+        access: {
+          scope: ['returns']
+        }
+      }
+    }
+  },
+  {
+    method: 'GET',
+    path: basePath + '/{sessionId}/returns-for-paper-forms',
+    options: {
+      handler: NoticesSetupController.viewReturnsForPaperForms,
+      auth: {
+        access: {
+          scope: ['returns']
+        }
+      }
+    }
+  },
+  {
+    method: 'POST',
+    path: basePath + '/{sessionId}/returns-for-paper-forms',
+    options: {
+      handler: NoticesSetupController.submitReturnsForPaperForms,
       auth: {
         access: {
           scope: ['returns']

--- a/app/services/notices/setup/returns-for-paper-forms.service.js
+++ b/app/services/notices/setup/returns-for-paper-forms.service.js
@@ -1,0 +1,31 @@
+'use strict'
+
+/**
+ * Orchestrates fetching and presenting the data for the `/notices/setup/{sessionId}/returns-for-paper-forms` page
+ *
+ * @module ReturnsForPaperFormsService
+ */
+
+const ReturnsForPaperFormsPresenter = require('../../../presenters/notices/setup/returns-for-paper-forms.presenter.js')
+const SessionModel = require('../../../models/session.model.js')
+
+/**
+ * Orchestrates fetching and presenting the data for the `/notices/setup/{sessionId}/returns-for-paper-forms` page
+ *
+ * @param {string} sessionId
+ *
+ * @returns {Promise<object>} - The data formatted for the view template
+ */
+async function go(sessionId) {
+  const session = await SessionModel.query().findById(sessionId)
+
+  const pageData = ReturnsForPaperFormsPresenter.go(session)
+
+  return {
+    ...pageData
+  }
+}
+
+module.exports = {
+  go
+}

--- a/app/services/notices/setup/submit-returns-for-paper-forms.service.js
+++ b/app/services/notices/setup/submit-returns-for-paper-forms.service.js
@@ -1,0 +1,60 @@
+'use strict'
+
+/**
+ * Orchestrates validating the data for `/notices/setup/{sessionId}/returns-for-paper-forms` page
+ *
+ * @module SubmitReturnsForPaperFormsService
+ */
+
+const ReturnsForPaperFormsPresenter = require('../../../presenters/notices/setup/returns-for-paper-forms.presenter.js')
+const ReturnsForPaperFormsValidator = require('../../../validators/notices/setup/returns-for-paper-forms.validator.js')
+const SessionModel = require('../../../models/session.model.js')
+
+/**
+ * Orchestrates validating the data for `/notices/setup/{sessionId}/returns-for-paper-forms` page
+ *
+ * @param {string} sessionId
+ * @param {object} payload - The submitted form data
+ *
+ * @returns {Promise<object>} - The data formatted for the view template
+ */
+async function go(sessionId, payload) {
+  const session = await SessionModel.query().findById(sessionId)
+
+  const validationResult = _validate(payload)
+
+  if (!validationResult) {
+    await _save(session, payload)
+
+    return {}
+  }
+
+  const pageData = ReturnsForPaperFormsPresenter.go(session)
+
+  return {
+    error: validationResult,
+    ...pageData
+  }
+}
+
+async function _save(session, payload) {
+  return session.$update()
+}
+
+function _validate(payload) {
+  const validation = ReturnsForPaperFormsValidator.go(payload)
+
+  if (!validation.error) {
+    return null
+  }
+
+  const { message } = validation.error.details[0]
+
+  return {
+    text: message
+  }
+}
+
+module.exports = {
+  go
+}

--- a/app/services/notices/setup/submit-returns-for-paper-forms.service.js
+++ b/app/services/notices/setup/submit-returns-for-paper-forms.service.js
@@ -37,7 +37,7 @@ async function go(sessionId, payload) {
   }
 }
 
-async function _save(session, payload) {
+async function _save(session, _payload) {
   return session.$update()
 }
 

--- a/app/validators/notices/setup/returns-for-paper-forms.validator.js
+++ b/app/validators/notices/setup/returns-for-paper-forms.validator.js
@@ -1,0 +1,29 @@
+'use strict'
+
+/**
+ * Validates data submitted for the `/notices/setup/{sessionId}/returns-for-paper-forms` page
+ *
+ * @module ReturnsForPaperFormsValidator
+ */
+
+const Joi = require('joi')
+
+/**
+ * Validates data submitted for the `/notices/setup/{sessionId}/returns-for-paper-forms` page
+ *
+ * @param {object} payload - The payload from the request to be validated
+ *
+ * @returns {object} the result from calling Joi's schema.validate(). It will be an object with a `value:` property. If
+ * any errors are found the `error:` property will also exist detailing what the issues were
+ */
+function go(payload) {
+  const schema = Joi.object({
+    returns: Joi.array().required()
+  })
+
+  return schema.validate(payload, { abortEarly: false })
+}
+
+module.exports = {
+  go
+}

--- a/app/views/notices/setup/returns-for-paper-forms.njk
+++ b/app/views/notices/setup/returns-for-paper-forms.njk
@@ -1,0 +1,31 @@
+{% extends 'layout.njk' %}
+
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+
+{% block breadcrumbs %}
+  {{
+  govukBackLink({
+    text: 'Back',
+    href: backLink
+  })
+  }}
+{% endblock %}
+
+{% block content %}
+  {% if error %}
+    {{ govukErrorSummary({
+      titleText: "There is a problem",
+      errorList: error.errorList
+    }) }}
+  {%endif%}
+
+  <div>
+    <form method="post">
+      <input type="hidden" name="wrlsCrumb" value="{{wrlsCrumb}}"/>
+
+      {{ govukButton({ text: "Continue", preventDoubleClick: true }) }}
+    </form>
+  </div>
+{% endblock %}

--- a/test/controllers/notices-setup.controller.test.js
+++ b/test/controllers/notices-setup.controller.test.js
@@ -25,6 +25,7 @@ const LicenceService = require('../../app/services/notices/setup/licence.service
 const NoticeTypeService = require('../../app/services/notices/setup/notice-type.service.js')
 const RemoveLicencesService = require('../../app/services/notices/setup/remove-licences.service.js')
 const RemoveThresholdService = require('../../app/services/notices/setup/abstraction-alerts/remove-threshold.service.js')
+const ReturnsForPaperFormsService = require('../../app/services/notices/setup/returns-for-paper-forms.service.js')
 const ReturnsPeriodService = require('../../app/services/notices/setup/returns-period/returns-period.service.js')
 const SubmitAlertEmailAddressService = require('../../app/services/notices/setup/abstraction-alerts/submit-alert-email-address.service.js')
 const SubmitAlertThresholdsService = require('../../app/services/notices/setup/abstraction-alerts/submit-alert-thresholds.service.js')
@@ -36,6 +37,7 @@ const SubmitCheckService = require('../../app/services/notices/setup/submit-chec
 const SubmitLicenceService = require('../../app/services/notices/setup/submit-licence.service.js')
 const SubmitNoticeTypeService = require('../../app/services/notices/setup/submit-notice-type.service.js')
 const SubmitRemoveLicencesService = require('../../app/services/notices/setup/submit-remove-licences.service.js')
+const SubmitReturnsForPaperFormsService = require('../../app/services/notices/setup/submit-returns-for-paper-forms.service.js')
 const SubmitReturnsPeriodService = require('../../app/services/notices/setup/returns-period/submit-returns-period.service.js')
 
 // For running our service
@@ -872,6 +874,72 @@ describe('Notices Setup controller', () => {
 
             expect(response.statusCode).to.equal(302)
             expect(response.headers.location).to.equal('/system/notices/setup/send-notice')
+          })
+        })
+      })
+    })
+  })
+
+  describe('notices/setup/returns-for-paper-forms', () => {
+    describe('GET', () => {
+      beforeEach(async () => {
+        getOptions = {
+          method: 'GET',
+          url: basePath + `/${session.id}/returns-for-paper-forms`,
+          auth: {
+            strategy: 'session',
+            credentials: { scope: ['returns'] }
+          }
+        }
+      })
+
+      describe('when a request is valid', () => {
+        beforeEach(async () => {
+          Sinon.stub(InitiateSessionService, 'go').resolves(session)
+          Sinon.stub(ReturnsForPaperFormsService, 'go').returns({ pageTitle: 'Select the returns for the paper forms' })
+        })
+
+        it('returns the page successfully', async () => {
+          const response = await server.inject(getOptions)
+
+          expect(response.statusCode).to.equal(200)
+          expect(response.payload).to.contain('Select the returns for the paper forms')
+        })
+      })
+    })
+
+    describe('POST', () => {
+      describe('when the request succeeds', () => {
+        describe('and the validation fails', () => {
+          beforeEach(async () => {
+            Sinon.stub(InitiateSessionService, 'go').resolves(session)
+            Sinon.stub(SubmitReturnsForPaperFormsService, 'go').returns({
+              error: 'Something went wrong'
+            })
+            postOptions = postRequestOptions(basePath + `/${session.id}/returns-for-paper-forms`, {})
+          })
+
+          it('returns the page successfully with the error summary banner', async () => {
+            const response = await server.inject(postOptions)
+
+            expect(response.statusCode).to.equal(200)
+            expect(response.payload).to.contain('There is a problem')
+          })
+        })
+
+        describe('and the validation succeeds', () => {
+          beforeEach(async () => {
+            Sinon.stub(SubmitReturnsForPaperFormsService, 'go').returns({
+              pageTile: 'Select the returns for the paper forms'
+            })
+            postOptions = postRequestOptions(basePath + `/${session.id}/returns-for-paper-forms`, {})
+          })
+
+          it('redirects the to the next page', async () => {
+            const response = await server.inject(postOptions)
+
+            expect(response.statusCode).to.equal(302)
+            expect(response.headers.location).to.equal(`/system/notices/setup/${session.id}/check-notice-type`)
           })
         })
       })

--- a/test/presenters/notices/setup/returns-for-paper-forms.presenter.test.js
+++ b/test/presenters/notices/setup/returns-for-paper-forms.presenter.test.js
@@ -1,0 +1,27 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Thing under test
+const ReturnsForPaperFormsPresenter = require('../../../../app/presenters/notices/setup/returns-for-paper-forms.presenter.js')
+
+describe('Returns For Paper Forms Presenter', () => {
+  let session
+
+  beforeEach(() => {
+    session = {}
+  })
+
+  describe('when called', () => {
+    it('returns page data for the view', () => {
+      const result = ReturnsForPaperFormsPresenter.go(session)
+
+      expect(result).to.equal({ pageTile: 'Select the returns for the paper forms' })
+    })
+  })
+})

--- a/test/services/notices/setup/returns-for-paper-forms.service.test.js
+++ b/test/services/notices/setup/returns-for-paper-forms.service.test.js
@@ -1,0 +1,33 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Test helpers
+const SessionHelper = require('../../../support/helpers/session.helper.js')
+
+// Thing under test
+const ReturnsForPaperFormsService = require('../../../../app/services/notices/setup/returns-for-paper-forms.service.js')
+
+describe('Returns For Paper Forms Service', () => {
+  let session
+  let sessionData
+
+  beforeEach(async () => {
+    sessionData = {}
+
+    session = await SessionHelper.add({ data: sessionData })
+  })
+
+  describe('when called', () => {
+    it('returns page data for the view', async () => {
+      const result = await ReturnsForPaperFormsService.go(session.id)
+
+      expect(result).to.equal({ pageTile: 'Select the returns for the paper forms' })
+    })
+  })
+})

--- a/test/services/notices/setup/submit-returns-for-paper-forms.service.test.js
+++ b/test/services/notices/setup/submit-returns-for-paper-forms.service.test.js
@@ -1,0 +1,60 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Test helpers
+const SessionHelper = require('../../../support/helpers/session.helper.js')
+
+// Thing under test
+const SubmitReturnsForPaperFormsService = require('../../../../app/services/notices/setup/submit-returns-for-paper-forms.service.js')
+
+describe('Returns For Paper Forms Service', () => {
+  let payload
+  let session
+  let sessionData
+
+  beforeEach(async () => {
+    payload = { returns: [] }
+    sessionData = {}
+
+    session = await SessionHelper.add({ data: sessionData })
+  })
+
+  describe('when called', () => {
+    it('saves the submitted value', async () => {
+      await SubmitReturnsForPaperFormsService.go(session.id, payload)
+
+      const refreshedSession = await session.$query()
+
+      expect(refreshedSession).to.equal(session)
+    })
+
+    it('continues the journey', async () => {
+      const result = await SubmitReturnsForPaperFormsService.go(session.id, payload)
+
+      expect(result).to.equal({})
+    })
+  })
+
+  describe('when validation fails', () => {
+    beforeEach(() => {
+      payload = {}
+    })
+
+    it('returns page data for the view, with errors', async () => {
+      const result = await SubmitReturnsForPaperFormsService.go(session.id, payload)
+
+      expect(result).to.equal({
+        error: {
+          text: '"returns" is required'
+        },
+        pageTile: 'Select the returns for the paper forms'
+      })
+    })
+  })
+})

--- a/test/validators/notices/setup/returns-for-paper-forms.validator.test.js
+++ b/test/validators/notices/setup/returns-for-paper-forms.validator.test.js
@@ -1,0 +1,42 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Thing under test
+const ReturnsForPaperFormsValidator = require('../../../../app/validators/notices/setup/returns-for-paper-forms.validator.js')
+
+describe('Returns For Paper Forms Validator', () => {
+  let payload
+
+  beforeEach(() => {
+    payload = { returns: [] }
+  })
+
+  describe('when called with valid data', () => {
+    it('returns with no errors', () => {
+      const result = ReturnsForPaperFormsValidator.go(payload)
+
+      expect(result.value).to.exist()
+      expect(result.error).not.to.exist()
+    })
+  })
+
+  describe('when called with invalid data', () => {
+    beforeEach(() => {
+      payload = {}
+    })
+
+    it('returns with errors', () => {
+      const result = ReturnsForPaperFormsValidator.go(payload)
+
+      expect(result.value).to.exist()
+      expect(result.error).to.exist()
+      expect(result.error.details[0].message).to.equal('"returns" is required')
+    })
+  })
+})


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5023

As part of the update to the ad-hoc journey the user can select a notice type of for a paper for invitation.

This change adds the scaffolded code for returns for paper forms page.

We have not mentioned invitations, because of this changes in the future we want the code to flexible. We are concerned about the paper forms. If it is an invitation or changes to a reminder in the future it should have no relevance to the logic.