### PR TITLE
Update notice setup check notice type

### DIFF
--- a/app/presenters/notices/setup/check-notice-type.presenter.js
+++ b/app/presenters/notices/setup/check-notice-type.presenter.js
@@ -5,6 +5,11 @@
  * @module CheckNoticeTypePresenter
  */
 
+const NOTICE_TYPE_TEXT = {
+  invitations: 'Standard returns invitation',
+  'paper-forms': 'Submit using a paper form invitation'
+}
+
 /**
  * Formats data for the `/notices/setup/{sessionId}/check-notice-type` page
  *
@@ -13,17 +18,39 @@
  * @returns {object} - The data formatted for the view template
  */
 function go(session) {
-  const { id: sessionId } = session
+  const { licenceRef, noticeType, id: sessionId } = session
 
   return {
     backLink: `/system/notices/setup/${sessionId}/notice-type`,
     continueButton: _continueButton(sessionId),
-    pageTitle: 'Check the notice type'
+    pageTitle: 'Check the notice type',
+    summaryList: _summaryList(licenceRef, noticeType)
   }
 }
 
 function _continueButton(sessionId) {
   return { text: 'Continue to check recipients', href: `/system/notices/setup/${sessionId}/check` }
+}
+
+function _summaryList(licenceRef, noticeType) {
+  return [
+    {
+      key: {
+        text: 'Licence number'
+      },
+      value: {
+        text: licenceRef
+      }
+    },
+    {
+      key: {
+        text: 'Returns notice type'
+      },
+      value: {
+        text: NOTICE_TYPE_TEXT[noticeType]
+      }
+    }
+  ]
 }
 
 module.exports = {

--- a/app/views/notices/setup/check-notice-type.njk
+++ b/app/views/notices/setup/check-notice-type.njk
@@ -2,6 +2,7 @@
 
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 
 {% block breadcrumbs %}
   {{
@@ -15,6 +16,10 @@
 {% block content %}
     <div class="govuk-body">
       <h2 class="govuk-heading-xl">{{ pageTitle }}</h2>
+
+      {{ govukSummaryList({
+        rows: summaryList
+      }) }}
 
       {{ govukButton(continueButton) }}
   </div>

--- a/test/presenters/notices/setup/check-notice-type.presenter.test.js
+++ b/test/presenters/notices/setup/check-notice-type.presenter.test.js
@@ -7,14 +7,22 @@ const Code = require('@hapi/code')
 const { describe, it, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
+// Test helpers
+const { generateLicenceRef } = require('../../../support/helpers/licence.helper.js')
+
 // Thing under test
 const CheckNoticeTypePresenter = require('../../../../app/presenters/notices/setup/check-notice-type.presenter.js')
 
-describe('Check Notice Type Presenter', () => {
+describe('Notices - Setup - Check Notice Type Presenter', () => {
+  let licenceRef
+  let noticeType
   let session
 
   beforeEach(() => {
-    session = { id: '123' }
+    licenceRef = generateLicenceRef()
+    noticeType = 'invitations'
+
+    session = { id: '123', licenceRef, noticeType }
   })
 
   describe('when called', () => {
@@ -27,7 +35,83 @@ describe('Check Notice Type Presenter', () => {
           href: `/system/notices/setup/${session.id}/check`,
           text: 'Continue to check recipients'
         },
-        pageTitle: 'Check the notice type'
+        pageTitle: 'Check the notice type',
+        summaryList: [
+          {
+            key: {
+              text: 'Licence number'
+            },
+            value: {
+              text: licenceRef
+            }
+          },
+          {
+            key: {
+              text: 'Returns notice type'
+            },
+            value: {
+              text: 'Standard returns invitation'
+            }
+          }
+        ]
+      })
+    })
+
+    describe('and the notice type is "invitations"', () => {
+      beforeEach(() => {
+        session.noticeType = 'invitations'
+      })
+
+      it('returns the summary list', () => {
+        const result = CheckNoticeTypePresenter.go(session)
+
+        expect(result.summaryList).to.equal([
+          {
+            key: {
+              text: 'Licence number'
+            },
+            value: {
+              text: licenceRef
+            }
+          },
+          {
+            key: {
+              text: 'Returns notice type'
+            },
+            value: {
+              text: 'Standard returns invitation'
+            }
+          }
+        ])
+      })
+    })
+
+    describe('and the notice type is "paper-forms"', () => {
+      beforeEach(() => {
+        session.noticeType = 'paper-forms'
+      })
+
+      it('returns the summary list', () => {
+        const result = CheckNoticeTypePresenter.go(session)
+
+        expect(result.summaryList).to.equal([
+          {
+            key: {
+              text: 'Licence number'
+            },
+            value: {
+              text: licenceRef
+            }
+          },
+          {
+            key: {
+              text: 'Returns notice type'
+            },
+            value: {
+              text: 'Submit using a paper form invitation'
+            }
+          }
+        ])
       })
     })
   })

--- a/test/services/notices/setup/check-notice-type.service.test.js
+++ b/test/services/notices/setup/check-notice-type.service.test.js
@@ -9,16 +9,19 @@ const { expect } = Code
 
 // Test helpers
 const SessionHelper = require('../../../support/helpers/session.helper.js')
+const { generateLicenceRef } = require('../../../support/helpers/licence.helper.js')
 
 // Thing under test
 const CheckNoticeTypeService = require('../../../../app/services/notices/setup/check-notice-type.service.js')
 
-describe('Check Notice Type Service', () => {
+describe('Notices - Setup - Check Notice Type Service', () => {
+  let licenceRef
   let session
   let sessionData
 
   beforeEach(async () => {
-    sessionData = {}
+    licenceRef = generateLicenceRef()
+    sessionData = { licenceRef, noticeType: 'invitations' }
 
     session = await SessionHelper.add({ data: sessionData })
   })
@@ -33,7 +36,25 @@ describe('Check Notice Type Service', () => {
           href: `/system/notices/setup/${session.id}/check`,
           text: 'Continue to check recipients'
         },
-        pageTitle: 'Check the notice type'
+        pageTitle: 'Check the notice type',
+        summaryList: [
+          {
+            key: {
+              text: 'Licence number'
+            },
+            value: {
+              text: licenceRef
+            }
+          },
+          {
+            key: {
+              text: 'Returns notice type'
+            },
+            value: {
+              text: 'Standard returns invitation'
+            }
+          }
+        ]
       })
     })
   })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5024

We scaffolded the 'check the notice type' page in a previous change.

This change adds the basic summary list for the page.

The change links will be added in another change.