### PR TITLE
Fix notifications `view.njk` formatting

### DIFF
--- a/app/views/notifications/view.njk
+++ b/app/views/notifications/view.njk
@@ -29,11 +29,11 @@
   </div>
 
   <div class="message-preview govuk-body">
-    <div class="govuk-!-margin-bottom-5">
-      {% if messageType === 'letter' %}
+    {% if messageType === 'letter' %}
+      <div class="govuk-!-margin-bottom-5">
         {{ newLineArrayItems(address) }}
-      {% endif %}
-    </div>
+      </div>
+    {% endif %}
 
     {{ contents | markdown | safe }}
   </div>


### PR DESCRIPTION
It has been noticed during review of another PR https://github.com/DEFRA/water-abstraction-system/pull/2105 that in the view the `div` was in the wrong place. As that view was mostly a copy of `app/views/notifications/view.njk`. The issue also exists in this view.

This PR will fix the issue in `app/views/notifications/view.njk`.