### PR TITLE
Update notice setup check notice type to use change links

### DIFF
--- a/app/controllers/notices-setup.controller.js
+++ b/app/controllers/notices-setup.controller.js
@@ -109,9 +109,12 @@ async function viewCheckLicenceMatches(request, h) {
 }
 
 async function viewCheckNoticeType(request, h) {
-  const { sessionId } = request.params
+  const {
+    params: { sessionId },
+    yar
+  } = request
 
-  const pageData = await CheckNoticeTypeService.go(sessionId)
+  const pageData = await CheckNoticeTypeService.go(sessionId, yar)
 
   return h.view(`notices/setup/check-notice-type.njk`, pageData)
 }
@@ -284,15 +287,18 @@ async function submitCheckLicenceMatches(request, h) {
 }
 
 async function submitLicence(request, h) {
-  const { sessionId } = request.params
+  const {
+    params: { sessionId },
+    yar
+  } = request
 
-  const pageData = await SubmitLicenceService.go(sessionId, request.payload)
+  const pageData = await SubmitLicenceService.go(sessionId, request.payload, yar)
 
   if (pageData.error) {
     return h.view(`${basePath}/licence.njk`, pageData)
   }
 
-  return h.redirect(`/system/${basePath}/${sessionId}/notice-type`)
+  return h.redirect(`/system/${basePath}/${sessionId}/${pageData.redirectUrl}`)
 }
 
 async function submitNoticeType(request, h) {

--- a/app/presenters/notices/setup/check-notice-type.presenter.js
+++ b/app/presenters/notices/setup/check-notice-type.presenter.js
@@ -24,7 +24,7 @@ function go(session) {
     backLink: `/system/notices/setup/${sessionId}/notice-type`,
     continueButton: _continueButton(sessionId),
     pageTitle: 'Check the notice type',
-    summaryList: _summaryList(licenceRef, noticeType)
+    summaryList: _summaryList(licenceRef, noticeType, sessionId)
   }
 }
 
@@ -32,7 +32,7 @@ function _continueButton(sessionId) {
   return { text: 'Continue to check recipients', href: `/system/notices/setup/${sessionId}/check` }
 }
 
-function _summaryList(licenceRef, noticeType) {
+function _summaryList(licenceRef, noticeType, sessionId) {
   return [
     {
       key: {
@@ -40,6 +40,15 @@ function _summaryList(licenceRef, noticeType) {
       },
       value: {
         text: licenceRef
+      },
+      actions: {
+        items: [
+          {
+            href: `/system/notices/setup/${sessionId}/licence`,
+            text: 'Change',
+            visuallyHiddenText: 'licence number'
+          }
+        ]
       }
     },
     {
@@ -48,6 +57,15 @@ function _summaryList(licenceRef, noticeType) {
       },
       value: {
         text: NOTICE_TYPE_TEXT[noticeType]
+      },
+      actions: {
+        items: [
+          {
+            href: `/system/notices/setup/${sessionId}/notice-type`,
+            text: 'Change',
+            visuallyHiddenText: 'notice type'
+          }
+        ]
       }
     }
   ]

--- a/app/services/notices/setup/check-notice-type.service.js
+++ b/app/services/notices/setup/check-notice-type.service.js
@@ -13,17 +13,29 @@ const SessionModel = require('../../../models/session.model.js')
  * Orchestrates fetching and presenting the data for the `/notices/setup/{sessionId}/check-notice-type` page
  *
  * @param {string} sessionId
+ * @param {object} yar - The Hapi `request.yar` session manager passed on by the controller
  *
  * @returns {Promise<object>} - The data formatted for the view template
  */
-async function go(sessionId) {
+async function go(sessionId, yar) {
   const session = await SessionModel.query().findById(sessionId)
+
+  await _markCheckPageVisited(session)
 
   const pageData = CheckNoticeTypePresenter.go(session)
 
+  const notification = yar.flash('notification')[0]
+
   return {
-    ...pageData
+    ...pageData,
+    notification
   }
+}
+
+async function _markCheckPageVisited(session) {
+  session.checkPageVisited = true
+
+  return session.$update()
 }
 
 module.exports = {

--- a/app/services/notices/setup/submit-licence.service.js
+++ b/app/services/notices/setup/submit-licence.service.js
@@ -6,12 +6,12 @@
  */
 
 const DetermineReturnsPeriodService = require('./determine-returns-period.service.js')
+const GeneralLib = require('../../../lib/general.lib.js')
 const LicenceModel = require('../../../models/licence.model.js')
 const LicencePresenter = require('../../../presenters/notices/setup/licence.presenter.js')
 const LicenceValidator = require('../../../validators/notices/setup/licence.validator.js')
 const ReturnLogModel = require('../../../models/return-log.model.js')
 const SessionModel = require('../../../models/session.model.js')
-const GeneralLib = require('../../../lib/general.lib.js')
 
 /**
  * Orchestrates validating the data for `/notices/setup/{sessionId}/licence` page

--- a/app/services/notices/setup/submit-licence.service.js
+++ b/app/services/notices/setup/submit-licence.service.js
@@ -11,6 +11,7 @@ const LicencePresenter = require('../../../presenters/notices/setup/licence.pres
 const LicenceValidator = require('../../../validators/notices/setup/licence.validator.js')
 const ReturnLogModel = require('../../../models/return-log.model.js')
 const SessionModel = require('../../../models/session.model.js')
+const GeneralLib = require('../../../lib/general.lib.js')
 
 /**
  * Orchestrates validating the data for `/notices/setup/{sessionId}/licence` page
@@ -23,11 +24,12 @@ const SessionModel = require('../../../models/session.model.js')
  *
  * @param {string} sessionId - The UUID of the current session
  * @param {object} payload - The submitted form data
+ * @param {object} yar - The Hapi `request.yar` session manager passed on by the controller
  *
  * @returns {Promise<object>} An empty object if there are no errors else the page data for the licence page including
  * the validation error details
  */
-async function go(sessionId, payload) {
+async function go(sessionId, payload, yar) {
   const session = await SessionModel.query().findById(sessionId)
 
   const validationResult = await _validate(payload)
@@ -42,9 +44,15 @@ async function go(sessionId, payload) {
     }
   }
 
+  if (session.checkPageVisited && payload.licenceRef !== session.licenceRef) {
+    GeneralLib.flashNotification(yar, 'Updated', 'Licence number updated')
+  }
+
   await _save(session, payload)
 
-  return {}
+  return {
+    redirectUrl: _redirect(session.checkPageVisited)
+  }
 }
 
 /**
@@ -95,6 +103,14 @@ async function _save(session, payload) {
   session.determinedReturnsPeriod = _determinedReturnsPeriod()
 
   return session.$update()
+}
+
+function _redirect(checkPageVisited) {
+  if (checkPageVisited) {
+    return 'check-notice-type'
+  }
+
+  return 'notice-type'
 }
 
 async function _validate(payload) {

--- a/app/views/notices/setup/check-notice-type.njk
+++ b/app/views/notices/setup/check-notice-type.njk
@@ -2,6 +2,7 @@
 
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 
 {% block breadcrumbs %}
@@ -15,6 +16,13 @@
 
 {% block content %}
     <div class="govuk-body">
+      {% if notification %}
+        {{ govukNotificationBanner({
+          titleText: notification.title,
+          text: notification.text
+        }) }}
+      {% endif %}
+
       <h2 class="govuk-heading-xl">{{ pageTitle }}</h2>
 
       {{ govukSummaryList({

--- a/test/controllers/notices-setup.controller.test.js
+++ b/test/controllers/notices-setup.controller.test.js
@@ -632,7 +632,7 @@ describe('Notices Setup controller', () => {
         beforeEach(async () => {
           postOptions = postRequestOptions(basePath + `/${session.id}/licence`, { licenceRef: '01/115' })
 
-          Sinon.stub(SubmitLicenceService, 'go').resolves({})
+          Sinon.stub(SubmitLicenceService, 'go').resolves({ redirectUrl: 'notice-type' })
         })
 
         it('returns the same page', async () => {

--- a/test/presenters/notices/setup/check-notice-type.presenter.test.js
+++ b/test/presenters/notices/setup/check-notice-type.presenter.test.js
@@ -38,6 +38,15 @@ describe('Notices - Setup - Check Notice Type Presenter', () => {
         pageTitle: 'Check the notice type',
         summaryList: [
           {
+            actions: {
+              items: [
+                {
+                  href: `/system/notices/setup/${session.id}/licence`,
+                  text: 'Change',
+                  visuallyHiddenText: 'licence number'
+                }
+              ]
+            },
             key: {
               text: 'Licence number'
             },
@@ -46,6 +55,15 @@ describe('Notices - Setup - Check Notice Type Presenter', () => {
             }
           },
           {
+            actions: {
+              items: [
+                {
+                  href: `/system/notices/setup/${session.id}/notice-type`,
+                  text: 'Change',
+                  visuallyHiddenText: 'notice type'
+                }
+              ]
+            },
             key: {
               text: 'Returns notice type'
             },
@@ -67,6 +85,15 @@ describe('Notices - Setup - Check Notice Type Presenter', () => {
 
         expect(result.summaryList).to.equal([
           {
+            actions: {
+              items: [
+                {
+                  href: `/system/notices/setup/${session.id}/licence`,
+                  text: 'Change',
+                  visuallyHiddenText: 'licence number'
+                }
+              ]
+            },
             key: {
               text: 'Licence number'
             },
@@ -75,6 +102,15 @@ describe('Notices - Setup - Check Notice Type Presenter', () => {
             }
           },
           {
+            actions: {
+              items: [
+                {
+                  href: `/system/notices/setup/${session.id}/notice-type`,
+                  text: 'Change',
+                  visuallyHiddenText: 'notice type'
+                }
+              ]
+            },
             key: {
               text: 'Returns notice type'
             },
@@ -96,6 +132,15 @@ describe('Notices - Setup - Check Notice Type Presenter', () => {
 
         expect(result.summaryList).to.equal([
           {
+            actions: {
+              items: [
+                {
+                  href: `/system/notices/setup/${session.id}/licence`,
+                  text: 'Change',
+                  visuallyHiddenText: 'licence number'
+                }
+              ]
+            },
             key: {
               text: 'Licence number'
             },
@@ -104,6 +149,15 @@ describe('Notices - Setup - Check Notice Type Presenter', () => {
             }
           },
           {
+            actions: {
+              items: [
+                {
+                  href: `/system/notices/setup/${session.id}/notice-type`,
+                  text: 'Change',
+                  visuallyHiddenText: 'notice type'
+                }
+              ]
+            },
             key: {
               text: 'Returns notice type'
             },

--- a/test/services/notices/setup/check-notice-type.service.test.js
+++ b/test/services/notices/setup/check-notice-type.service.test.js
@@ -3,8 +3,9 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
+const Sinon = require('sinon')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -18,17 +19,24 @@ describe('Notices - Setup - Check Notice Type Service', () => {
   let licenceRef
   let session
   let sessionData
+  let yarStub
 
   beforeEach(async () => {
     licenceRef = generateLicenceRef()
     sessionData = { licenceRef, noticeType: 'invitations' }
 
     session = await SessionHelper.add({ data: sessionData })
+
+    yarStub = { flash: Sinon.stub().resolves() }
+  })
+
+  afterEach(() => {
+    Sinon.restore()
   })
 
   describe('when called', () => {
     it('returns page data for the view', async () => {
-      const result = await CheckNoticeTypeService.go(session.id)
+      const result = await CheckNoticeTypeService.go(session.id, yarStub)
 
       expect(result).to.equal({
         backLink: `/system/notices/setup/${session.id}/notice-type`,
@@ -37,8 +45,18 @@ describe('Notices - Setup - Check Notice Type Service', () => {
           text: 'Continue to check recipients'
         },
         pageTitle: 'Check the notice type',
+        notification: undefined,
         summaryList: [
           {
+            actions: {
+              items: [
+                {
+                  href: `/system/notices/setup/${session.id}/licence`,
+                  text: 'Change',
+                  visuallyHiddenText: 'licence number'
+                }
+              ]
+            },
             key: {
               text: 'Licence number'
             },
@@ -47,6 +65,15 @@ describe('Notices - Setup - Check Notice Type Service', () => {
             }
           },
           {
+            actions: {
+              items: [
+                {
+                  href: `/system/notices/setup/${session.id}/notice-type`,
+                  text: 'Change',
+                  visuallyHiddenText: 'notice type'
+                }
+              ]
+            },
             key: {
               text: 'Returns notice type'
             },
@@ -55,6 +82,26 @@ describe('Notices - Setup - Check Notice Type Service', () => {
             }
           }
         ]
+      })
+    })
+
+    it('should set the "checkPageVisited" flag', async () => {
+      await CheckNoticeTypeService.go(session.id, yarStub)
+
+      const refreshedSession = await session.$query()
+
+      expect(refreshedSession.checkPageVisited).to.be.true()
+    })
+
+    describe('when there is a notification', () => {
+      beforeEach(() => {
+        yarStub = { flash: Sinon.stub().returns(['Test notification']) }
+      })
+
+      it('should set the notification', async () => {
+        const result = await CheckNoticeTypeService.go(session.id, yarStub)
+
+        expect(result.notification).to.equal('Test notification')
       })
     })
   })

--- a/test/services/notices/setup/submit-licence.service.test.js
+++ b/test/services/notices/setup/submit-licence.service.test.js
@@ -71,7 +71,7 @@ describe('Notices - Setup - Submit Licence service', () => {
         })
       })
 
-      it('returns an empty object (no page data is needed for a redirect)', async () => {
+      it('returns the redirect url', async () => {
         const result = await SubmitLicenceService.go(session.id, payload, yarStub)
 
         expect(result).to.equal({ redirectUrl: 'notice-type' })

--- a/test/services/notices/setup/submit-licence.service.test.js
+++ b/test/services/notices/setup/submit-licence.service.test.js
@@ -3,28 +3,35 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
+const Sinon = require('sinon')
 
-const { describe, it, afterEach, before, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
 const LicenceHelper = require('../../../support/helpers/licence.helper.js')
 const SessionHelper = require('../../../support/helpers/session.helper.js')
 const ReturnLogHelper = require('../../../support/helpers/return-log.helper.js')
+const { generateLicenceRef } = require('../../../support/helpers/licence.helper.js')
 
 // Thing under test
 const SubmitLicenceService = require('../../../../app/services/notices/setup/submit-licence.service.js')
-const Sinon = require('sinon')
 
 describe('Notices - Setup - Submit Licence service', () => {
   let clock
+  let licenceRef
   let payload
   let session
+  let yarStub
 
   beforeEach(async () => {
+    licenceRef = generateLicenceRef()
+
     session = await SessionHelper.add({ data: {} })
 
     clock = Sinon.useFakeTimers(new Date('2020-06-06'))
+
+    yarStub = { flash: Sinon.stub() }
   })
 
   afterEach(() => {
@@ -33,25 +40,25 @@ describe('Notices - Setup - Submit Licence service', () => {
 
   describe('when called', () => {
     describe('with a valid payload', () => {
-      before(async () => {
-        await LicenceHelper.add({ licenceRef: '01/111' })
-        await ReturnLogHelper.add({ licenceRef: '01/111' })
+      beforeEach(async () => {
+        await LicenceHelper.add({ licenceRef })
+        await ReturnLogHelper.add({ licenceRef })
 
         payload = {
-          licenceRef: '01/111'
+          licenceRef
         }
       })
 
       it('saves the submitted value', async () => {
-        await SubmitLicenceService.go(session.id, payload)
+        await SubmitLicenceService.go(session.id, payload, yarStub)
 
         const refreshedSession = await session.$query()
 
-        expect(refreshedSession.licenceRef).to.equal('01/111')
+        expect(refreshedSession.licenceRef).to.equal(licenceRef)
       })
 
       it('saves the "determinedReturnsPeriod" with the "dueDate" set 28 days from "today"', async () => {
-        await SubmitLicenceService.go(session.id, payload)
+        await SubmitLicenceService.go(session.id, payload, yarStub)
 
         const refreshedSession = await session.$query()
 
@@ -65,20 +72,53 @@ describe('Notices - Setup - Submit Licence service', () => {
       })
 
       it('returns an empty object (no page data is needed for a redirect)', async () => {
-        const result = await SubmitLicenceService.go(session.id, payload)
+        const result = await SubmitLicenceService.go(session.id, payload, yarStub)
 
-        expect(result).to.equal({})
+        expect(result).to.equal({ redirectUrl: 'notice-type' })
+      })
+
+      describe('and from the check page', () => {
+        describe('and the licence ref has been updated', () => {
+          beforeEach(async () => {
+            session = await SessionHelper.add({ data: { licenceRef: '01/11', checkPageVisited: true } })
+          })
+
+          it('sets a flash message', async () => {
+            await SubmitLicenceService.go(session.id, payload, yarStub)
+
+            // Check we add the flash message
+            const [flashType, bannerMessage] = yarStub.flash.args[0]
+
+            expect(flashType).to.equal('notification')
+            expect(bannerMessage).to.equal({
+              text: 'Licence number updated',
+              title: 'Updated'
+            })
+          })
+        })
+
+        describe('and the licence ref has not been updated', () => {
+          beforeEach(async () => {
+            session = await SessionHelper.add({ data: { licenceRef, checkPageVisited: true } })
+          })
+
+          it('does not set a flash message', async () => {
+            await SubmitLicenceService.go(session.id, payload, yarStub)
+
+            expect(yarStub.flash.args[0]).to.be.undefined()
+          })
+        })
       })
     })
 
     describe('with an invalid payload', () => {
       describe('because the user has not inputted anything', () => {
-        before(() => {
+        beforeEach(() => {
           payload = {}
         })
 
         it('returns page data needed to re-render the view including the validation error', async () => {
-          const result = await SubmitLicenceService.go(session.id, payload)
+          const result = await SubmitLicenceService.go(session.id, payload, yarStub)
 
           expect(result).to.equal({
             activeNavBar: 'manage',
@@ -92,14 +132,14 @@ describe('Notices - Setup - Submit Licence service', () => {
       })
 
       describe('because the user has entered a licence that does not exist', () => {
-        before(() => {
+        beforeEach(() => {
           payload = {
             licenceRef: '1111'
           }
         })
 
         it('returns page data needed to re-render the view including the validation error', async () => {
-          const result = await SubmitLicenceService.go(session.id, payload)
+          const result = await SubmitLicenceService.go(session.id, payload, yarStub)
 
           expect(result).to.equal({
             activeNavBar: 'manage',
@@ -113,7 +153,7 @@ describe('Notices - Setup - Submit Licence service', () => {
       })
 
       describe('because the user has entered a licence that has no due returns', () => {
-        before(async () => {
+        beforeEach(async () => {
           await LicenceHelper.add({ licenceRef: '01/145' })
 
           payload = {
@@ -122,7 +162,7 @@ describe('Notices - Setup - Submit Licence service', () => {
         })
 
         it('returns page data needed to re-render the view including the validation error', async () => {
-          const result = await SubmitLicenceService.go(session.id, payload)
+          const result = await SubmitLicenceService.go(session.id, payload, yarStub)
 
           expect(result).to.equal({
             activeNavBar: 'manage',


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5024

We scaffolded the 'check the notice type' page in a previous change and implemented a basic summary list.

This change adds the change links to the summary list, and implements the logic to handle a check page visited, consistent with the rest of the application.

We have also add flash notifications to be consistent with the rest of the service.