### PR TITLE
Update notice setup returns paper forms

### DIFF
--- a/app/presenters/notices/setup/returns-for-paper-forms.presenter.js
+++ b/app/presenters/notices/setup/returns-for-paper-forms.presenter.js
@@ -15,36 +15,23 @@ const { formatLongDate } = require('../../base.presenter.js')
  * @returns {object} - The data formatted for the view template
  */
 function go(session) {
+  const { dueReturns, selectedReturns } = session
+
   return {
     pageTitle: 'Select the returns for the paper forms',
-    returns: _returns(session.selectedReturns)
+    returns: _returns(dueReturns, selectedReturns)
   }
 }
 
-function _returns(selectedReturns = []) {
-  const mock = [
-    {
-      returnReference: '1',
-      description: 'Potable Water Supply - Direct',
-      startDate: new Date('2025-01-01'),
-      endDate: new Date('2026-01-01')
-    },
-    {
-      returnReference: '2',
-      description: 'Potable Water Supply - Direct',
-      startDate: new Date('2025-01-01'),
-      endDate: new Date('2026-01-01')
-    }
-  ]
-
-  return mock.map((returnItem) => {
+function _returns(returns, selectedReturns = []) {
+  return returns.map((returnItem) => {
     return {
-      checked: selectedReturns.includes(returnItem.returnReference),
+      checked: selectedReturns.includes(returnItem.returnId),
       hint: {
-        text: `${formatLongDate(returnItem.startDate)} to ${formatLongDate(returnItem.endDate)}`
+        text: `${formatLongDate(new Date(returnItem.startDate))} to ${formatLongDate(new Date(returnItem.endDate))}`
       },
       text: `${returnItem.returnReference} ${returnItem.description}`,
-      value: returnItem.returnReference
+      value: returnItem.returnId
     }
   })
 }

--- a/app/services/notices/setup/fetch-returns-due-by-licence-ref.service.js
+++ b/app/services/notices/setup/fetch-returns-due-by-licence-ref.service.js
@@ -13,7 +13,7 @@ const ReturnLogModel = require('../../../models/return-log.model.js')
  *
  * @param {string} licenceRef
  *
- * @returns {Promise<object[]>}
+ * @returns {Promise<module:ReturnLogModel[]>}
  */
 async function go(licenceRef) {
   return _fetch(licenceRef)

--- a/app/services/notices/setup/fetch-returns-due-by-licence-ref.service.js
+++ b/app/services/notices/setup/fetch-returns-due-by-licence-ref.service.js
@@ -5,8 +5,8 @@
  * @module FetchReturnsDueByLicenceRefService
  */
 
-const ReturnLogModel = require('../../../models/return-log.model.js')
 const { db } = require('../../../../db/db.js')
+const ReturnLogModel = require('../../../models/return-log.model.js')
 
 /**
  * Fetches the returns due for `/notices/setup/{sessionId}/returns-for-paper-forms` page

--- a/app/services/notices/setup/fetch-returns-due-by-licence-ref.service.js
+++ b/app/services/notices/setup/fetch-returns-due-by-licence-ref.service.js
@@ -1,0 +1,41 @@
+'use strict'
+
+/**
+ * Fetches the returns due for `/notices/setup/{sessionId}/returns-for-paper-forms` page
+ * @module FetchReturnsDueByLicenceRefService
+ */
+
+const ReturnLogModel = require('../../../models/return-log.model.js')
+const { db } = require('../../../../db/db.js')
+
+/**
+ * Fetches the returns due for `/notices/setup/{sessionId}/returns-for-paper-forms` page
+ *
+ * @param {string} licenceRef
+ *
+ * @returns {Promise<object[]>}
+ */
+async function go(licenceRef) {
+  return _fetch(licenceRef)
+}
+
+async function _fetch(licenceRef) {
+  return ReturnLogModel.query()
+    .select([
+      'returnId',
+      'startDate',
+      'endDate',
+      'returnReference',
+      db.raw(`metadata->'purposes'->0->'tertiary'->>'description' as description`)
+    ])
+    .where('licenceRef', licenceRef)
+    .where('status', 'due')
+    .orderBy([
+      { column: 'startDate', order: 'desc' },
+      { column: 'returnReference', order: 'asc' }
+    ])
+}
+
+module.exports = {
+  go
+}

--- a/app/services/notices/setup/fetch-returns-due-by-licence-ref.service.js
+++ b/app/services/notices/setup/fetch-returns-due-by-licence-ref.service.js
@@ -11,7 +11,7 @@ const ReturnLogModel = require('../../../models/return-log.model.js')
 /**
  * Fetches the returns due for `/notices/setup/{sessionId}/returns-for-paper-forms` page
  *
- * @param {string} licenceRef
+ * @param {string} licenceRef - The licence reference to fetch 'due' return logs for
  *
  * @returns {Promise<module:ReturnLogModel[]>}
  */

--- a/app/services/notices/setup/submit-licence.service.js
+++ b/app/services/notices/setup/submit-licence.service.js
@@ -6,11 +6,11 @@
  */
 
 const DetermineReturnsPeriodService = require('./determine-returns-period.service.js')
+const FetchReturnsDueByLicenceRefService = require('./fetch-returns-due-by-licence-ref.service.js')
 const GeneralLib = require('../../../lib/general.lib.js')
 const LicenceModel = require('../../../models/licence.model.js')
 const LicencePresenter = require('../../../presenters/notices/setup/licence.presenter.js')
 const LicenceValidator = require('../../../validators/notices/setup/licence.validator.js')
-const ReturnLogModel = require('../../../models/return-log.model.js')
 const SessionModel = require('../../../models/session.model.js')
 
 /**
@@ -86,9 +86,9 @@ function _determinedReturnsPeriod() {
 }
 
 async function _dueReturnsExist(licenceRef) {
-  const dueReturns = await ReturnLogModel.query().where('licenceRef', licenceRef).where('status', 'due').first()
+  const dueReturns = await FetchReturnsDueByLicenceRefService.go(licenceRef)
 
-  return !!dueReturns
+  return dueReturns.length > 0
 }
 
 async function _licenceExists(licenceRef) {
@@ -101,6 +101,8 @@ async function _save(session, payload) {
   session.licenceRef = payload.licenceRef
 
   session.determinedReturnsPeriod = _determinedReturnsPeriod()
+
+  session.dueReturns = await FetchReturnsDueByLicenceRefService.go(payload.licenceRef)
 
   return session.$update()
 }

--- a/app/services/notices/setup/submit-licence.service.js
+++ b/app/services/notices/setup/submit-licence.service.js
@@ -111,7 +111,7 @@ function _redirect(checkPageVisited) {
   if (checkPageVisited) {
     return 'check-notice-type'
   }
-  k
+
   return 'notice-type'
 }
 

--- a/app/services/notices/setup/submit-licence.service.js
+++ b/app/services/notices/setup/submit-licence.service.js
@@ -111,7 +111,7 @@ function _redirect(checkPageVisited) {
   if (checkPageVisited) {
     return 'check-notice-type'
   }
-
+  k
   return 'notice-type'
 }
 

--- a/test/presenters/notices/setup/returns-for-paper-forms.presenter.test.js
+++ b/test/presenters/notices/setup/returns-for-paper-forms.presenter.test.js
@@ -7,14 +7,28 @@ const Code = require('@hapi/code')
 const { describe, it, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
+// Test helpers
+const { generateUUID } = require('../../../../app/lib/general.lib.js')
+
 // Thing under test
 const ReturnsForPaperFormsPresenter = require('../../../../app/presenters/notices/setup/returns-for-paper-forms.presenter.js')
 
-describe('Returns For Paper Forms Presenter', () => {
+describe('Notices - Setup - Returns For Paper Forms Presenter', () => {
+  let dueReturn
   let session
 
   beforeEach(() => {
-    session = {}
+    dueReturn = {
+      description: 'Potable Water Supply - Direct',
+      endDate: '2003-03-31',
+      returnId: generateUUID(),
+      returnReference: '3135',
+      startDate: '2002-04-01'
+    }
+
+    session = {
+      dueReturns: [dueReturn]
+    }
   })
 
   describe('when called', () => {
@@ -26,19 +40,9 @@ describe('Returns For Paper Forms Presenter', () => {
         returns: [
           {
             checked: false,
-            hint: {
-              text: '1 January 2025 to 1 January 2026'
-            },
-            text: '1 Potable Water Supply - Direct',
-            value: '1'
-          },
-          {
-            checked: false,
-            hint: {
-              text: '1 January 2025 to 1 January 2026'
-            },
-            text: '2 Potable Water Supply - Direct',
-            value: '2'
+            hint: { text: '1 April 2002 to 31 March 2003' },
+            text: `${dueReturn.returnReference} Potable Water Supply - Direct`,
+            value: dueReturn.returnId
           }
         ]
       })
@@ -46,7 +50,7 @@ describe('Returns For Paper Forms Presenter', () => {
 
     describe('and returns have previously been selected', () => {
       beforeEach(() => {
-        session.selectedReturns = ['1']
+        session.selectedReturns = [dueReturn.returnId]
       })
 
       it('returns the "returns" previously selected as checked', () => {
@@ -54,20 +58,10 @@ describe('Returns For Paper Forms Presenter', () => {
 
         expect(result.returns).to.equal([
           {
-            hint: {
-              text: '1 January 2025 to 1 January 2026'
-            },
-            text: '1 Potable Water Supply - Direct',
-            value: '1',
-            checked: true
-          },
-          {
-            checked: false,
-            hint: {
-              text: '1 January 2025 to 1 January 2026'
-            },
-            text: '2 Potable Water Supply - Direct',
-            value: '2'
+            checked: true,
+            hint: { text: '1 April 2002 to 31 March 2003' },
+            text: `${dueReturn.returnReference} Potable Water Supply - Direct`,
+            value: dueReturn.returnId
           }
         ])
       })

--- a/test/presenters/notices/setup/returns-for-paper-forms.presenter.test.js
+++ b/test/presenters/notices/setup/returns-for-paper-forms.presenter.test.js
@@ -13,7 +13,7 @@ const { generateUUID } = require('../../../../app/lib/general.lib.js')
 // Thing under test
 const ReturnsForPaperFormsPresenter = require('../../../../app/presenters/notices/setup/returns-for-paper-forms.presenter.js')
 
-describe('Notices - Setup - Returns For Paper Forms Presenter', () => {
+describe('Notices - Setup - Returns For Paper Forms presenter', () => {
   let dueReturn
   let session
 

--- a/test/services/notices/setup/fetch-returns-due-by-licence-ref.service.test.js
+++ b/test/services/notices/setup/fetch-returns-due-by-licence-ref.service.test.js
@@ -40,7 +40,7 @@ describe('Notices - Setup - Fetch Returns Due By Licence Ref service', () => {
   })
 
   describe('when called', () => {
-    it('returns the data', async () => {
+    it('returns the "due" returns for the licence', async () => {
       const result = await FetchReturnsDueByLicenceRefService.go(licenceRef)
 
       expect(result).to.equal([

--- a/test/services/notices/setup/fetch-returns-due-by-licence-ref.service.test.js
+++ b/test/services/notices/setup/fetch-returns-due-by-licence-ref.service.test.js
@@ -1,0 +1,57 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Test helpers
+const ReturnLogHelper = require('../../../support/helpers/return-log.helper.js')
+const { generateLicenceRef } = require('../../../support/helpers/licence.helper.js')
+
+// Thing under test
+const FetchReturnsDueByLicenceRefService = require('../../../../app/services/notices/setup/fetch-returns-due-by-licence-ref.service.js')
+
+describe('Notices - Setup - Fetch returns due by licence ref service', () => {
+  let licenceRef
+  let returnLog
+
+  beforeEach(async () => {
+    licenceRef = generateLicenceRef()
+
+    returnLog = await ReturnLogHelper.add({
+      licenceRef,
+      metadata: {
+        purposes: [
+          {
+            tertiary: { description: 'Potable Water Supply - Direct' }
+          }
+        ]
+      }
+    })
+
+    // Add a record not due
+    await ReturnLogHelper.add({
+      licenceRef,
+      status: 'not due'
+    })
+  })
+
+  describe('when called', () => {
+    it('returns the data', async () => {
+      const result = await FetchReturnsDueByLicenceRefService.go(licenceRef)
+
+      expect(result).to.equal([
+        {
+          description: 'Potable Water Supply - Direct',
+          endDate: new Date('2023-03-31'),
+          returnId: returnLog.returnId,
+          returnReference: returnLog.returnReference,
+          startDate: new Date('2022-04-01')
+        }
+      ])
+    })
+  })
+})

--- a/test/services/notices/setup/fetch-returns-due-by-licence-ref.service.test.js
+++ b/test/services/notices/setup/fetch-returns-due-by-licence-ref.service.test.js
@@ -35,7 +35,7 @@ describe('Notices - Setup - Fetch Returns Due By Licence Ref service', () => {
     // Add a record not due
     await ReturnLogHelper.add({
       licenceRef,
-      status: 'not due'
+      status: 'void'
     })
   })
 

--- a/test/services/notices/setup/fetch-returns-due-by-licence-ref.service.test.js
+++ b/test/services/notices/setup/fetch-returns-due-by-licence-ref.service.test.js
@@ -14,7 +14,7 @@ const { generateLicenceRef } = require('../../../support/helpers/licence.helper.
 // Thing under test
 const FetchReturnsDueByLicenceRefService = require('../../../../app/services/notices/setup/fetch-returns-due-by-licence-ref.service.js')
 
-describe('Notices - Setup - Fetch returns due by licence ref service', () => {
+describe('Notices - Setup - Fetch Returns Due By Licence Ref service', () => {
   let licenceRef
   let returnLog
 

--- a/test/services/notices/setup/returns-for-paper-forms.service.test.js
+++ b/test/services/notices/setup/returns-for-paper-forms.service.test.js
@@ -15,7 +15,7 @@ const { generateUUID } = require('../../../../app/lib/general.lib.js')
 // Thing under test
 const ReturnsForPaperFormsService = require('../../../../app/services/notices/setup/returns-for-paper-forms.service.js')
 
-describe('Notices - Setup - Returns For Paper Forms Service', () => {
+describe('Notices - Setup - Returns For Paper Forms service', () => {
   let dueReturn
   let licenceRef
   let session

--- a/test/services/notices/setup/returns-for-paper-forms.service.test.js
+++ b/test/services/notices/setup/returns-for-paper-forms.service.test.js
@@ -9,16 +9,30 @@ const { expect } = Code
 
 // Test helpers
 const SessionHelper = require('../../../support/helpers/session.helper.js')
+const { generateLicenceRef } = require('../../../support/helpers/licence.helper.js')
+const { generateUUID } = require('../../../../app/lib/general.lib.js')
 
 // Thing under test
 const ReturnsForPaperFormsService = require('../../../../app/services/notices/setup/returns-for-paper-forms.service.js')
 
-describe('Returns For Paper Forms Service', () => {
+describe('Notices - Setup - Returns For Paper Forms Service', () => {
+  let dueReturn
+  let licenceRef
   let session
   let sessionData
 
   beforeEach(async () => {
-    sessionData = {}
+    licenceRef = generateLicenceRef()
+
+    dueReturn = {
+      description: 'Potable Water Supply - Direct',
+      endDate: '2003-03-31',
+      returnId: generateUUID(),
+      returnReference: '3135',
+      startDate: '2002-04-01'
+    }
+
+    sessionData = { licenceRef, dueReturns: [dueReturn] }
 
     session = await SessionHelper.add({ data: sessionData })
   })
@@ -33,18 +47,10 @@ describe('Returns For Paper Forms Service', () => {
           {
             checked: false,
             hint: {
-              text: '1 January 2025 to 1 January 2026'
+              text: '1 April 2002 to 31 March 2003'
             },
-            text: '1 Potable Water Supply - Direct',
-            value: '1'
-          },
-          {
-            checked: false,
-            hint: {
-              text: '1 January 2025 to 1 January 2026'
-            },
-            text: '2 Potable Water Supply - Direct',
-            value: '2'
+            text: `${dueReturn.returnReference} Potable Water Supply - Direct`,
+            value: dueReturn.returnId
           }
         ]
       })

--- a/test/services/notices/setup/submit-returns-for-paper-forms.service.test.js
+++ b/test/services/notices/setup/submit-returns-for-paper-forms.service.test.js
@@ -15,7 +15,7 @@ const { generateLicenceRef } = require('../../../support/helpers/licence.helper.
 const SubmitReturnsForPaperFormsService = require('../../../../app/services/notices/setup/submit-returns-for-paper-forms.service.js')
 const { generateUUID } = require('../../../../app/lib/general.lib.js')
 
-describe('Notices - Setup - Submit Returns For Paper Forms Service', () => {
+describe('Notices - Setup - Submit Returns For Paper Forms service', () => {
   let dueReturn
   let licenceRef
   let payload

--- a/test/services/notices/setup/submit-returns-for-paper-forms.service.test.js
+++ b/test/services/notices/setup/submit-returns-for-paper-forms.service.test.js
@@ -9,18 +9,33 @@ const { expect } = Code
 
 // Test helpers
 const SessionHelper = require('../../../support/helpers/session.helper.js')
+const { generateLicenceRef } = require('../../../support/helpers/licence.helper.js')
 
 // Thing under test
 const SubmitReturnsForPaperFormsService = require('../../../../app/services/notices/setup/submit-returns-for-paper-forms.service.js')
+const { generateUUID } = require('../../../../app/lib/general.lib.js')
 
-describe('Returns For Paper Forms Service', () => {
+describe('Notices - Setup - Submit Returns For Paper Forms Service', () => {
+  let dueReturn
+  let licenceRef
   let payload
   let session
   let sessionData
 
   beforeEach(async () => {
-    payload = { returns: ['1'] }
-    sessionData = {}
+    licenceRef = generateLicenceRef()
+
+    dueReturn = {
+      description: 'Potable Water Supply - Direct',
+      endDate: '2003-03-31',
+      returnId: generateUUID(),
+      returnReference: '3135',
+      startDate: '2002-04-01'
+    }
+
+    payload = { returns: [dueReturn.returnId] }
+
+    sessionData = { licenceRef }
 
     session = await SessionHelper.add({ data: sessionData })
   })
@@ -31,7 +46,7 @@ describe('Returns For Paper Forms Service', () => {
 
       const refreshedSession = await session.$query()
 
-      expect(refreshedSession.selectedReturns).to.equal(['1'])
+      expect(refreshedSession.selectedReturns).to.equal([dueReturn.returnId])
     })
 
     it('continues the journey', async () => {
@@ -42,7 +57,7 @@ describe('Returns For Paper Forms Service', () => {
 
     describe('and the payload has one item (is not an array)', () => {
       beforeEach(async () => {
-        payload = { returns: '1' }
+        payload = { returns: dueReturn.returnId }
         sessionData = {}
 
         session = await SessionHelper.add({ data: sessionData })
@@ -53,14 +68,18 @@ describe('Returns For Paper Forms Service', () => {
 
         const refreshedSession = await session.$query()
 
-        expect(refreshedSession.selectedReturns).to.equal(['1'])
+        expect(refreshedSession.selectedReturns).to.equal([dueReturn.returnId])
       })
     })
   })
 
   describe('when validation fails', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       payload = {}
+
+      sessionData = { licenceRef, dueReturns: [dueReturn] }
+
+      session = await SessionHelper.add({ data: sessionData })
     })
 
     it('returns page data for the view, with errors', async () => {
@@ -76,18 +95,10 @@ describe('Returns For Paper Forms Service', () => {
           {
             checked: false,
             hint: {
-              text: '1 January 2025 to 1 January 2026'
+              text: '1 April 2002 to 31 March 2003'
             },
-            text: '1 Potable Water Supply - Direct',
-            value: '1'
-          },
-          {
-            checked: false,
-            hint: {
-              text: '1 January 2025 to 1 January 2026'
-            },
-            text: '2 Potable Water Supply - Direct',
-            value: '2'
+            text: `${dueReturn.returnReference} Potable Water Supply - Direct`,
+            value: dueReturn.returnId
           }
         ]
       })

--- a/test/support/helpers/return-log.helper.js
+++ b/test/support/helpers/return-log.helper.js
@@ -4,11 +4,11 @@
  * @module ReturnLogHelper
  */
 
-const ReturnLogModel = require('../../../app/models/return-log.model.js')
 const { formatDateObjectToISO } = require('../../../app/lib/dates.lib.js')
+const { generateUUID, timestampForPostgres } = require('../../../app/lib/general.lib.js')
 const { generateLicenceRef } = require('./licence.helper.js')
+const ReturnLogModel = require('../../../app/models/return-log.model.js')
 const { generateReference } = require('./return-requirement.helper.js')
-const { timestampForPostgres, generateUUID } = require('../../../app/lib/general.lib.js')
 
 /**
  * Add a new return log
@@ -61,7 +61,6 @@ function defaults(data = {}) {
 
   const defaults = {
     id: generateReturnLogId(startDate, endDate, 1, licenceRef, returnReference),
-    returnId: generateUUID(),
     createdAt: timestamp,
     dueDate,
     endDate,
@@ -87,6 +86,7 @@ function defaults(data = {}) {
       version: 1
     },
     receivedDate,
+    returnId: generateUUID(),
     returnReference,
     returnsFrequency: 'month',
     startDate,

--- a/test/support/helpers/return-log.helper.js
+++ b/test/support/helpers/return-log.helper.js
@@ -4,11 +4,11 @@
  * @module ReturnLogHelper
  */
 
-const { formatDateObjectToISO } = require('../../../app/lib/dates.lib.js')
-const { timestampForPostgres } = require('../../../app/lib/general.lib.js')
-const { generateLicenceRef } = require('./licence.helper.js')
 const ReturnLogModel = require('../../../app/models/return-log.model.js')
+const { formatDateObjectToISO } = require('../../../app/lib/dates.lib.js')
+const { generateLicenceRef } = require('./licence.helper.js')
 const { generateReference } = require('./return-requirement.helper.js')
+const { timestampForPostgres, generateUUID } = require('../../../app/lib/general.lib.js')
 
 /**
  * Add a new return log
@@ -61,6 +61,7 @@ function defaults(data = {}) {
 
   const defaults = {
     id: generateReturnLogId(startDate, endDate, 1, licenceRef, returnReference),
+    returnId: generateUUID(),
     createdAt: timestamp,
     dueDate,
     endDate,


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5023

This change adds the fetch returns due service for the returns paper forms page.

This service will check the return logs for any return logs due that match the provided licence ref.

We currently use the 'returnReference' for to know which option the user has selected. As this can be duplicated we need to change this to a unique value. This will be done in another change.