### PR TITLE
set isUpload from return version flag

### DIFF
--- a/app/services/jobs/return-logs/fetch-return-requirements.service.js
+++ b/app/services/jobs/return-logs/fetch-return-requirements.service.js
@@ -37,8 +37,7 @@ async function _fetch(returnCycle) {
       'returnVersionId',
       'siteDescription',
       'summer',
-      'twoPartTariff',
-      'upload'
+      'twoPartTariff'
     ])
     .where('returnRequirements.summer', summer)
     .whereNotExists(
@@ -71,7 +70,7 @@ async function _fetch(returnCycle) {
     .withGraphFetched('returnVersion')
     .modifyGraph('returnVersion', (returnVersionBuilder) => {
       returnVersionBuilder
-        .select(['endDate', 'id', 'reason', 'startDate', 'quarterlyReturns'])
+        .select(['endDate', 'id', 'reason', 'startDate', 'quarterlyReturns', 'multipleUpload'])
         .withGraphFetched('licence')
         .modifyGraph('licence', (licenceBuilder) => {
           licenceBuilder

--- a/app/services/return-logs/fetch-licence-return-requirements.service.js
+++ b/app/services/return-logs/fetch-licence-return-requirements.service.js
@@ -35,8 +35,7 @@ async function _fetch(licenceId, changeDate) {
       'returnVersionId',
       'siteDescription',
       'summer',
-      'twoPartTariff',
-      'upload'
+      'twoPartTariff'
     ])
     .whereExists(
       ReturnVersionModel.query()
@@ -60,7 +59,7 @@ async function _fetch(licenceId, changeDate) {
     .withGraphFetched('returnVersion')
     .modifyGraph('returnVersion', (returnVersionBuilder) => {
       returnVersionBuilder
-        .select(['endDate', 'id', 'reason', 'startDate', 'quarterlyReturns'])
+        .select(['endDate', 'id', 'reason', 'startDate', 'quarterlyReturns', 'multipleUpload'])
         .withGraphFetched('licence')
         .modifyGraph('licence', (licenceBuilder) => {
           licenceBuilder

--- a/app/services/return-logs/generate-return-log.service.js
+++ b/app/services/return-logs/generate-return-log.service.js
@@ -87,8 +87,6 @@ function _id(returnVersion, reference, startDate, endDate) {
 }
 
 function _metadata(returnRequirement, endDate) {
-  console.log('returnRequirement')
-  console.log(returnRequirement)
   const {
     abstractionPeriodEndDay,
     abstractionPeriodEndMonth,

--- a/app/services/return-logs/generate-return-log.service.js
+++ b/app/services/return-logs/generate-return-log.service.js
@@ -87,6 +87,8 @@ function _id(returnVersion, reference, startDate, endDate) {
 }
 
 function _metadata(returnRequirement, endDate) {
+  console.log('returnRequirement')
+  console.log(returnRequirement)
   const {
     abstractionPeriodEndDay,
     abstractionPeriodEndMonth,
@@ -98,8 +100,7 @@ function _metadata(returnRequirement, endDate) {
     returnVersion,
     siteDescription,
     summer,
-    twoPartTariff,
-    upload
+    twoPartTariff
   } = returnRequirement
 
   return {
@@ -108,7 +109,7 @@ function _metadata(returnRequirement, endDate) {
     isFinal: endDate < determineCycleEndDate(summer),
     isSummer: summer,
     isTwoPartTariff: twoPartTariff,
-    isUpload: upload,
+    isUpload: returnVersion.multipleUpload,
     nald: {
       regionCode: returnVersion.licence.region.naldRegionId,
       areaCode: returnVersion.licence.areacode,

--- a/app/services/return-versions/setup/check/generate-return-version.service.js
+++ b/app/services/return-versions/setup/check/generate-return-version.service.js
@@ -59,7 +59,8 @@ async function _generateReturnVersion(nextVersionNumber, sessionData, userId) {
   if (isQuarterlyReturnSubmissions(sessionData.returnVersionStartDate)) {
     quarterlyReturns = sessionData.quarterlyReturns
   }
-
+console.log('gerateReturnVersion')
+console.log(sessionData)
   return {
     createdBy: userId,
     endDate,

--- a/app/services/return-versions/setup/check/generate-return-version.service.js
+++ b/app/services/return-versions/setup/check/generate-return-version.service.js
@@ -59,8 +59,7 @@ async function _generateReturnVersion(nextVersionNumber, sessionData, userId) {
   if (isQuarterlyReturnSubmissions(sessionData.returnVersionStartDate)) {
     quarterlyReturns = sessionData.quarterlyReturns
   }
-console.log('gerateReturnVersion')
-console.log(sessionData)
+
   return {
     createdBy: userId,
     endDate,

--- a/test/fixtures/return-requirements.fixture.js
+++ b/test/fixtures/return-requirements.fixture.js
@@ -37,12 +37,12 @@ function returnRequirements() {
       siteDescription: 'PUMP AT TINTAGEL',
       summer: true,
       twoPartTariff: false,
-      upload: false,
       returnVersion: {
         endDate: null,
         id: '5a077661-05fc-4fc4-a2c6-d84ec908f093',
         reason: 'new-licence',
         startDate: new Date('2022-04-01'),
+        multipleUpload: false,
         licence: {
           expiredDate: null,
           id: '3acf7d80-cf74-4e86-8128-13ef687ea091',
@@ -101,7 +101,6 @@ function returnRequirements() {
       siteDescription: 'BOREHOLE AT AVALON',
       summer: false,
       twoPartTariff: false,
-      upload: false,
       returnVersion: {
         endDate: null,
         id: '5a077661-05fc-4fc4-a2c6-d84ec908f093',
@@ -119,7 +118,8 @@ function returnRequirements() {
             naldRegionId: 4
           }
         },
-        quarterlyReturns: true
+        quarterlyReturns: true,
+        multipleUpload: false
       },
       points: [
         {
@@ -178,12 +178,12 @@ function returnRequirementsAcrossReturnVersions() {
       siteDescription: 'PUMP AT TINTAGEL',
       summer: true,
       twoPartTariff: false,
-      upload: false,
       returnVersion: {
         endDate: new Date('2024-05-26'),
         id: '5a077661-05fc-4fc4-a2c6-d84ec908f093',
         reason: 'new-licence',
         startDate: new Date('2022-04-01'),
+        multipleUpload: false,
         licence: {
           expiredDate: null,
           id: '3acf7d80-cf74-4e86-8128-13ef687ea091',
@@ -242,12 +242,12 @@ function returnRequirementsAcrossReturnVersions() {
       siteDescription: 'BOREHOLE AT AVALON',
       summer: false,
       twoPartTariff: false,
-      upload: false,
       returnVersion: {
         endDate: null,
         id: '5a077661-05fc-4fc4-a2c6-d84ec908f094',
         reason: 'new-licence',
         startDate: new Date('2024-05-27'),
+        multipleUpload: false,
         licence: {
           expiredDate: null,
           id: '3acf7d80-cf74-4e86-8128-13ef687ea091',
@@ -306,7 +306,6 @@ function returnRequirementsAcrossReturnVersions() {
       siteDescription: 'BOREHOLE AT AVALON',
       summer: false,
       twoPartTariff: false,
-      upload: false,
       returnVersion: {
         endDate: new Date('2025-05-26'),
         id: '5a077661-05fc-4fc4-a2c6-d84ec908f095',
@@ -324,7 +323,8 @@ function returnRequirementsAcrossReturnVersions() {
             naldRegionId: 4
           }
         },
-        quarterlyReturns: true
+        quarterlyReturns: true,
+        multipleUpload: false
       },
       points: [
         {
@@ -371,7 +371,6 @@ function returnRequirementsAcrossReturnVersions() {
       siteDescription: 'BOREHOLE AT AVALON',
       summer: false,
       twoPartTariff: false,
-      upload: false,
       returnVersion: {
         endDate: null,
         id: '5a077661-05fc-4fc4-a2c6-d84ec908f095',
@@ -389,7 +388,8 @@ function returnRequirementsAcrossReturnVersions() {
             naldRegionId: 4
           }
         },
-        quarterlyReturns: true
+        quarterlyReturns: true,
+        multipleUpload: false
       },
       points: [
         {

--- a/test/services/jobs/return-logs/fetch-return-requirements.service.test.js
+++ b/test/services/jobs/return-logs/fetch-return-requirements.service.test.js
@@ -522,7 +522,6 @@ function _expectedResult() {
     siteDescription: returnRequirement.siteDescription,
     summer: returnRequirement.summer,
     twoPartTariff: returnRequirement.twoPartTariff,
-    upload: returnRequirement.upload,
     returnVersion: {
       endDate: returnVersion.endDate,
       id: returnVersion.id,
@@ -540,7 +539,8 @@ function _expectedResult() {
           naldRegionId: region.naldRegionId
         }
       },
-      quarterlyReturns: returnVersion.quarterlyReturns
+      quarterlyReturns: returnVersion.quarterlyReturns,
+      multipleUpload: returnVersion.multipleUpload
     },
     points: [
       {

--- a/test/services/return-logs/fetch-licence-return-requirements.service.test.js
+++ b/test/services/return-logs/fetch-licence-return-requirements.service.test.js
@@ -291,7 +291,6 @@ function _expectedResult(
     siteDescription: _returnRequirement.siteDescription,
     summer: _returnRequirement.summer,
     twoPartTariff: _returnRequirement.twoPartTariff,
-    upload: _returnRequirement.upload,
     returnVersion: {
       endDate: _returnVersion.endDate,
       id: _returnVersion.id,
@@ -309,7 +308,8 @@ function _expectedResult(
           naldRegionId: region.naldRegionId
         }
       },
-      quarterlyReturns: _returnVersion.quarterlyReturns
+      quarterlyReturns: _returnVersion.quarterlyReturns,
+      multipleUpload: returnVersion.multipleUpload
     },
     points: [
       {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5117

A bug was found in production where external users were not able to see their due return logs if they were set up to use multiple upload. This was due to the code looking at the return requirement level at the `is_upload` column when it should be looking at the `multiple_upload` column on the return version.

This PR introduces a fix to use the correct place.