### PR TITLE
Add return id migration for return logs view

### DIFF
--- a/db/migrations/legacy/20221108006001_returns-returns.js
+++ b/db/migrations/legacy/20221108006001_returns-returns.js
@@ -8,6 +8,7 @@ exports.up = function (knex) {
     table.string('return_id').primary()
 
     // Data
+    table.uuid('id')
     table.string('regime').notNullable().defaultTo('water')
     table.string('licence_type').notNullable().defaultTo('abstraction')
     table.string('licence_ref').notNullable()

--- a/db/migrations/public/20250630132940_alter-returns-logs-view.js
+++ b/db/migrations/public/20250630132940_alter-returns-logs-view.js
@@ -1,0 +1,62 @@
+'use strict'
+
+const viewName = 'return_logs'
+
+exports.up = function (knex) {
+  return knex.schema.dropViewIfExists(viewName).createView(viewName, (view) => {
+    // NOTE: We have commented out unused columns from the source table
+    view.as(
+      knex('returns').withSchema('returns').select([
+        'return_id AS id',
+        'id AS return_id',
+        // 'regime', // always 'water'
+        // 'licence_type', // always 'abstraction'
+        'licence_ref',
+        'start_date',
+        'end_date',
+        'returns_frequency',
+        'status',
+        'source',
+        'metadata',
+        'received_date',
+        'return_requirement as return_reference',
+        'due_date',
+        'under_query',
+        // 'under_query_comment',
+        // 'is_test',
+        'return_cycle_id',
+        'created_at',
+        'updated_at'
+      ])
+    )
+  })
+}
+
+exports.down = function (knex) {
+  return knex.schema.dropViewIfExists(viewName).createView(viewName, (view) => {
+    // NOTE: We have commented out unused columns from the source table
+    view.as(
+      knex('returns').withSchema('returns').select([
+        'return_id AS id',
+        // 'regime', // always 'water'
+        // 'licence_type', // always 'abstraction'
+        'licence_ref',
+        'start_date',
+        'end_date',
+        'returns_frequency',
+        'status',
+        'source',
+        'metadata',
+        'received_date',
+        'return_requirement as return_reference',
+        'due_date',
+        'under_query',
+        // 'under_query_comment',
+        // 'is_test',
+        'return_cycle_id',
+        'created_at',
+        'updated_at'
+      ])
+    )
+  })
+}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5023

We have a need for a unique id that is not based on the return.

A change has been made to returns to introduce this id here - https://github.com/DEFRA/water-abstraction-returns/pull/427

This change updates the public view for returns which id 'return_logs'. This id will be called 'return_id' with the intention of switching the columns / logic around in a later change.