### PR TITLE
Update notice setup returns navigation

### DIFF
--- a/app/presenters/notices/setup/returns-for-paper-forms.presenter.js
+++ b/app/presenters/notices/setup/returns-for-paper-forms.presenter.js
@@ -15,12 +15,21 @@ const { formatLongDate } = require('../../base.presenter.js')
  * @returns {object} - The data formatted for the view template
  */
 function go(session) {
-  const { dueReturns, selectedReturns } = session
+  const { checkPageVisited, dueReturns, id: sessionId, selectedReturns } = session
 
   return {
+    backLink: _backLink(sessionId, checkPageVisited),
     pageTitle: 'Select the returns for the paper forms',
     returns: _returns(dueReturns, selectedReturns)
   }
+}
+
+function _backLink(sessionId, checkPageVisited) {
+  if (checkPageVisited) {
+    return `/system/notices/setup/${sessionId}/check-notice-type`
+  }
+
+  return `/system/notices/setup/${sessionId}/notice-type`
 }
 
 function _returns(returns, selectedReturns = []) {

--- a/test/presenters/notices/setup/returns-for-paper-forms.presenter.test.js
+++ b/test/presenters/notices/setup/returns-for-paper-forms.presenter.test.js
@@ -27,6 +27,7 @@ describe('Notices - Setup - Returns For Paper Forms presenter', () => {
     }
 
     session = {
+      id: '123',
       dueReturns: [dueReturn]
     }
   })
@@ -36,6 +37,7 @@ describe('Notices - Setup - Returns For Paper Forms presenter', () => {
       const result = ReturnsForPaperFormsPresenter.go(session)
 
       expect(result).to.equal({
+        backLink: '/system/notices/setup/123/notice-type',
         pageTitle: 'Select the returns for the paper forms',
         returns: [
           {
@@ -64,6 +66,18 @@ describe('Notices - Setup - Returns For Paper Forms presenter', () => {
             value: dueReturn.returnId
           }
         ])
+      })
+
+      describe('and the page has been visited', () => {
+        beforeEach(() => {
+          session.checkPageVisited = true
+        })
+
+        it('correctly set the back link to the check page', () => {
+          const result = ReturnsForPaperFormsPresenter.go(session)
+
+          expect(result.backLink).to.equal('/system/notices/setup/123/check-notice-type')
+        })
       })
     })
   })

--- a/test/services/notices/setup/returns-for-paper-forms.service.test.js
+++ b/test/services/notices/setup/returns-for-paper-forms.service.test.js
@@ -42,6 +42,7 @@ describe('Notices - Setup - Returns For Paper Forms service', () => {
       const result = await ReturnsForPaperFormsService.go(session.id)
 
       expect(result).to.equal({
+        backLink: `/system/notices/setup/${session.id}/notice-type`,
         pageTitle: 'Select the returns for the paper forms',
         returns: [
           {

--- a/test/services/notices/setup/submit-returns-for-paper-forms.service.test.js
+++ b/test/services/notices/setup/submit-returns-for-paper-forms.service.test.js
@@ -50,7 +50,7 @@ describe('Notices - Setup - Submit Returns For Paper Forms service', () => {
 
   describe('when called', () => {
     it('saves the selected returns', async () => {
-      await SubmitReturnsForPaperFormsService.go(session.id, payload)
+      await SubmitReturnsForPaperFormsService.go(session.id, payload, yarStub)
 
       const refreshedSession = await session.$query()
 
@@ -58,7 +58,7 @@ describe('Notices - Setup - Submit Returns For Paper Forms service', () => {
     })
 
     it('continues the journey', async () => {
-      const result = await SubmitReturnsForPaperFormsService.go(session.id, payload)
+      const result = await SubmitReturnsForPaperFormsService.go(session.id, payload, yarStub)
 
       expect(result).to.equal({})
     })
@@ -72,7 +72,7 @@ describe('Notices - Setup - Submit Returns For Paper Forms service', () => {
       })
 
       it('saves the selected returns', async () => {
-        await SubmitReturnsForPaperFormsService.go(session.id, payload)
+        await SubmitReturnsForPaperFormsService.go(session.id, payload, yarStub)
 
         const refreshedSession = await session.$query()
 
@@ -124,9 +124,10 @@ describe('Notices - Setup - Submit Returns For Paper Forms service', () => {
     })
 
     it('returns page data for the view, with errors', async () => {
-      const result = await SubmitReturnsForPaperFormsService.go(session.id, payload)
+      const result = await SubmitReturnsForPaperFormsService.go(session.id, payload, yarStub)
 
       expect(result).to.equal({
+        backLink: `/system/notices/setup/${session.id}/notice-type`,
         error: {
           text: 'Select the returns for the paper forms'
         },


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5024

This change updates the navigation for the ad-hoc journey for the returns page to align with our established patterns.

The back link will go back to the previous page, unless the user has completed the journey up to the check notice type page, then they will be redirected back that page.