### PR TITLE
Fix permissions for view notices page

### DIFF
--- a/app/routes/notices.routes.js
+++ b/app/routes/notices.routes.js
@@ -10,7 +10,7 @@ const routes = [
       handler: NoticesController.index,
       auth: {
         access: {
-          scope: ['returns']
+          scope: ['bulk_return_notifications', 'hof_notifications', 'renewal_notifications', 'returns']
         }
       }
     }
@@ -22,7 +22,7 @@ const routes = [
       handler: NoticesController.submitIndex,
       auth: {
         access: {
-          scope: ['returns']
+          scope: ['bulk_return_notifications', 'hof_notifications', 'renewal_notifications', 'returns']
         }
       }
     }
@@ -34,7 +34,7 @@ const routes = [
       handler: NoticesController.view,
       auth: {
         access: {
-          scope: ['returns']
+          scope: ['bulk_return_notifications', 'hof_notifications', 'renewal_notifications', 'returns']
         }
       }
     }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5132

As part of switching returns management from NALD to WRLS, we needed to take control of sending return invitations and reminders.

Additionally, we needed to make changes to the View notices page (Notices page), which is why it was migrated.

Unfortunately, we didn't pay proper attention to which 'roles' had access to the legacy page, so users who used to be able to access the page can no longer.

This change updates the route's scope to match the legacy version of the page.