### PR TITLE
Address lookup requests

### DIFF
--- a/app/requests/address-lookup/lookup-postcode.request.js
+++ b/app/requests/address-lookup/lookup-postcode.request.js
@@ -1,0 +1,53 @@
+'use strict'
+
+/**
+ * Use for making http requests to the address facade
+ * @module LookupPostcodeRequest
+ */
+
+const BaseRequest = require('../base.request.js')
+
+const requestConfig = require('../../../config/request.config.js')
+const servicesConfig = require('../../../config/services.config.js')
+
+/**
+ * Sends a request to the address facade for the provided postcode
+ *
+ * @param {string} postcode - The postcode to look up addresses for
+ *
+ * @returns {Promise<object[]>} An array of found addresses
+ */
+async function send(postcode) {
+  const uri = `address-service/v1/addresses/postcode?query-string=${postcode}&key=client1`
+  const result = await BaseRequest.get(uri, _requestOptions())
+
+  return {
+    succeeded: result.succeeded,
+    results: result?.response?.body?.results || []
+  }
+}
+
+/**
+ * Additional options that will be added to the default options used by BaseRequest
+ *
+ * We use it to set
+ *
+ * - the base address facade URL for all requests
+ * - the option to tell Got that we expect JSON responses. This means Got will automatically handle parsing the
+ *   response to a JSON object for us
+ *
+ * @private
+ */
+function _requestOptions() {
+  return {
+    prefixUrl: servicesConfig.addressFacade.url,
+    responseType: 'json',
+    timeout: {
+      request: requestConfig.timeout
+    }
+  }
+}
+
+module.exports = {
+  send
+}

--- a/app/requests/address-lookup/lookup-postcode.request.js
+++ b/app/requests/address-lookup/lookup-postcode.request.js
@@ -1,7 +1,7 @@
 'use strict'
 
 /**
- * Use for making http requests to the address facade
+ * Sends a request to the address facade for the provided postcode
  * @module LookupPostcodeRequest
  */
 

--- a/app/requests/address-lookup/lookup-uprn.request.js
+++ b/app/requests/address-lookup/lookup-uprn.request.js
@@ -1,0 +1,53 @@
+'use strict'
+
+/**
+ * Use for making http requests to the address facade
+ * @module LookupUPRNRequest
+ */
+
+const BaseRequest = require('../base.request.js')
+
+const requestConfig = require('../../../config/request.config.js')
+const servicesConfig = require('../../../config/services.config.js')
+
+/**
+ * Sends a request to the address facade for the provided uprn
+ *
+ * @param {string} uprn - The UPRN to look up
+ *
+ * @returns {Promise<object>} An array with the address information
+ */
+async function send(uprn) {
+  const uri = `address-service/v1/addresses/${uprn}?key=client1`
+  const result = await BaseRequest.get(uri, _requestOptions())
+
+  return {
+    succeeded: result.succeeded,
+    results: result?.response?.body?.results || []
+  }
+}
+
+/**
+ * Additional options that will be added to the default options used by BaseRequest
+ *
+ * We use it to set
+ *
+ * - the base address facade URL for all requests
+ * - the option to tell Got that we expect JSON responses. This means Got will automatically handle parsing the
+ *   response to a JSON object for us
+ *
+ * @private
+ */
+function _requestOptions() {
+  return {
+    prefixUrl: servicesConfig.addressFacade.url,
+    responseType: 'json',
+    timeout: {
+      request: requestConfig.timeout
+    }
+  }
+}
+
+module.exports = {
+  send
+}

--- a/app/requests/address-lookup/lookup-uprn.request.js
+++ b/app/requests/address-lookup/lookup-uprn.request.js
@@ -1,7 +1,7 @@
 'use strict'
 
 /**
- * Use for making http requests to the address facade
+ * Sends a request to the address facade for the provided uprn
  * @module LookupUPRNRequest
  */
 

--- a/test/requests/address-lookup/lookup-postcode.request.test.js
+++ b/test/requests/address-lookup/lookup-postcode.request.test.js
@@ -1,0 +1,78 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Test helpers
+const servicesConfig = require('../../../config/services.config.js')
+
+// Things we need to stub
+const BaseRequest = require('../../../app/requests/base.request.js')
+
+// Thing under test
+const LookupPostcodeRequest = require('../../../app/requests/address-lookup/lookup-postcode.request.js')
+
+describe('Lookup Postcode Request', () => {
+  const postcode = 'SW1A 1AA'
+  const postcodePath = `address-service/v1/addresses/postcode?query-string=${postcode}&key=client1`
+
+  afterEach(() => {
+    Sinon.restore()
+  })
+
+  describe('when the request succeeds', () => {
+    beforeEach(async () => {
+      Sinon.stub(BaseRequest, 'get').resolves({
+        succeeded: true,
+        response: {
+          statusCode: 200,
+          body: {
+            results: []
+          }
+        }
+      })
+    })
+
+    it('calls the address lookup url with the required options', async () => {
+      await LookupPostcodeRequest.send(postcode)
+
+      const requestArgs = BaseRequest.get.firstCall.args
+
+      expect(requestArgs[0]).to.equal(postcodePath)
+      expect(requestArgs[1].prefixUrl).to.equal(`${servicesConfig.addressFacade.url}`)
+      expect(requestArgs[1].responseType).to.equal('json')
+    })
+
+    it('returns a valid repsonse', async () => {
+      const result = await LookupPostcodeRequest.send(postcode)
+
+      expect(result.succeeded).to.be.true()
+      expect(result.results).to.equal([])
+    })
+  })
+
+  describe('when the request fails', () => {
+    beforeEach(async () => {
+      Sinon.stub(BaseRequest, 'get').resolves({
+        succeeded: false,
+        response: {
+          statusCode: 404,
+          statusMessage: 'Not Found',
+          body: { statusCode: 404, error: 'Not Found', message: 'Not Found' }
+        }
+      })
+    })
+
+    it('returns a "false" success status and an empty array', async () => {
+      const result = await LookupPostcodeRequest.send(postcode)
+
+      expect(result.succeeded).to.be.false()
+      expect(result.results).to.equal([])
+    })
+  })
+})

--- a/test/requests/address-lookup/lookup-uprn.request.test.js
+++ b/test/requests/address-lookup/lookup-uprn.request.test.js
@@ -1,0 +1,78 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Test helpers
+const servicesConfig = require('../../../config/services.config.js')
+
+// Things we need to stub
+const BaseRequest = require('../../../app/requests/base.request.js')
+
+// Thing under test
+const LookupUPRNRequest = require('../../../app/requests/address-lookup/lookup-uprn.request.js')
+
+describe('Lookup UPRN Request', () => {
+  const uprn = '123456789'
+  const uprnPath = `address-service/v1/addresses/${uprn}?key=client1`
+
+  afterEach(() => {
+    Sinon.restore()
+  })
+
+  describe('when the request succeeds', () => {
+    beforeEach(async () => {
+      Sinon.stub(BaseRequest, 'get').resolves({
+        succeeded: true,
+        response: {
+          statusCode: 200,
+          body: {
+            results: []
+          }
+        }
+      })
+    })
+
+    it('calls the address lookup url with the required options', async () => {
+      await LookupUPRNRequest.send(uprn)
+
+      const requestArgs = BaseRequest.get.firstCall.args
+
+      expect(requestArgs[0]).to.equal(uprnPath)
+      expect(requestArgs[1].prefixUrl).to.equal(`${servicesConfig.addressFacade.url}`)
+      expect(requestArgs[1].responseType).to.equal('json')
+    })
+
+    it('returns a valid repsonse', async () => {
+      const result = await LookupUPRNRequest.send(uprn)
+
+      expect(result.succeeded).to.be.true()
+      expect(result.results).to.equal([])
+    })
+  })
+
+  describe('when the request fails', () => {
+    beforeEach(async () => {
+      Sinon.stub(BaseRequest, 'get').resolves({
+        succeeded: false,
+        response: {
+          statusCode: 404,
+          statusMessage: 'Not Found',
+          body: { statusCode: 404, error: 'Not Found', message: 'Not Found' }
+        }
+      })
+    })
+
+    it('returns a "false" success status and an empty array', async () => {
+      const result = await LookupUPRNRequest.send(uprn)
+
+      expect(result.succeeded).to.be.false()
+      expect(result.results).to.equal([])
+    })
+  })
+})


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5045

As part of the journey to create ad-hoc letters to be sent out to users we need to be able to select an address.

This PR adds in the functionality to query OS places by either postcode or an individual UPRN.