### PR TITLE
Set role for seeded external users

### DIFF
--- a/db/seeds/data/users.js
+++ b/db/seeds/data/users.js
@@ -95,7 +95,6 @@ const data = [
     badLogins: 0,
     application: 'water_vml',
     resetGuidCreatedAt: null,
-    role: '{"scopes": ["external"]}',
     enabled: true
   },
   {
@@ -108,7 +107,6 @@ const data = [
     badLogins: 0,
     application: 'water_vml',
     resetGuidCreatedAt: null,
-    role: '{"scopes": ["external"]}',
     enabled: true
   },
   {
@@ -121,7 +119,6 @@ const data = [
     badLogins: 0,
     application: 'water_vml',
     resetGuidCreatedAt: null,
-    role: '{"scopes": ["external"]}',
     enabled: true
   },
   {

--- a/db/seeds/data/users.js
+++ b/db/seeds/data/users.js
@@ -95,6 +95,7 @@ const data = [
     badLogins: 0,
     application: 'water_vml',
     resetGuidCreatedAt: null,
+    role: '{"scopes": ["external"]}',
     enabled: true
   },
   {
@@ -107,6 +108,7 @@ const data = [
     badLogins: 0,
     application: 'water_vml',
     resetGuidCreatedAt: null,
+    role: '{"scopes": ["external"]}',
     enabled: true
   },
   {
@@ -119,6 +121,7 @@ const data = [
     badLogins: 0,
     application: 'water_vml',
     resetGuidCreatedAt: null,
+    role: '{"scopes": ["external"]}',
     enabled: true
   },
   {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5129

The linked item was a request to add a disclaimer to the bulk returns upload submit page for external users.

It's linked to this change because we wasted an afternoon trying to track down what was causing an upload that we were confident had no issues with to fail.

We needed the upload to succeed to have a chance of figuring out which page we were being asked to put the disclaimer on. The joys of working with the legacy code! 😩🤦

We finally identified the issue to a piece of logic in the legacy code. A request is made to get a user's details that hits one of the [hapi-pg-rest-api](https://github.com/DEFRA/hapi-pg-rest-api) routes, where an additional prequery was being run.

In [src/controllers/user.js](https://github.com/DEFRA/water-abstraction-tactical-idm/blob/main/src/controllers/user.js), if the property `role` is in the data object, this kicks in.

```javascript
  if ('role' in request.data && typeof request.data.role !== 'string') {
    request.data.role = JSON.stringify(request.data.role)
  }
```

As far as we could see, this field is meaningless (it still is for external users!), so we didn't bother to seed it with anything. Until now, that wasn't an issue. But for this specific route [water-abstraction-service](https://github.com/DEFRA/water-abstraction-service/blob/87ddfb7475fbd93ab003a26cc066ae877f9d0b7c/src/lib/connectors/idm.js#L35) is making a call that doesn't specify any `select`, which means **hapi-pg-rest-api** will grab all columns. That means `role` is included in the result, and our null `role` field causes the legacy prequery to go pop!

The fix we're most confident in making is ensuring the external users we seed match better with how the service would create them. Therefore, this change ensures that the `role` field is set correctly in the future.