### PR TITLE
Update notice setup fetch download recipients

### DIFF
--- a/app/services/notices/setup/fetch-download-recipients.service.js
+++ b/app/services/notices/setup/fetch-download-recipients.service.js
@@ -6,7 +6,7 @@
  */
 
 const { db } = require('../../../../db/db.js')
-const { transformStringOfLicencesToArray } = require('../../../lib/general.lib.js')
+const { transformStringOfLicencesToArray, timestampForPostgres } = require('../../../lib/general.lib.js')
 
 /**
  * Fetches the recipients data for the `/notices/setup/download` CSV file
@@ -66,6 +66,7 @@ async function _fetchRecipient(session) {
 
   const where = `
     AND ldh.licence_ref = ?
+    AND rl.end_date <= '${timestampForPostgres()}'
   `
 
   const bindings = [licenceRef, licenceRef]

--- a/test/services/notices/setup/fetch-download-recipients.service.test.js
+++ b/test/services/notices/setup/fetch-download-recipients.service.test.js
@@ -26,7 +26,7 @@ describe('Notices - Setup - Fetch Download Recipients service', () => {
   before(async () => {
     dueDate = `${year}-04-28` // This needs to differ from any other returns log tests
 
-    testRecipients = await LicenceDocumentHeaderSeeder.seed(true, dueDate)
+    testRecipients = await LicenceDocumentHeaderSeeder.seed(true, dueDate, endDate)
   })
 
   describe('when the "journey" is for notifications', () => {
@@ -356,6 +356,20 @@ describe('Notices - Setup - Fetch Download Recipients service', () => {
               start_date: startDate
             }
           ])
+        })
+      })
+
+      describe('when the end date is greater than today', () => {
+        beforeEach(async () => {
+          testRecipients = await LicenceDocumentHeaderSeeder.seed(true, dueDate, '3000-01-01')
+
+          session = { licenceRef: testRecipients.primaryUser.licenceRef }
+        })
+
+        it('correctly an empty array - no return logs found', async () => {
+          const result = await FetchDownloadRecipientsService.go(session)
+
+          expect(result).to.equal([])
         })
       })
     })

--- a/test/support/seeders/licence-document-header.seeder.js
+++ b/test/support/seeders/licence-document-header.seeder.js
@@ -15,19 +15,24 @@ const ReturnLogHelper = require('../helpers/return-log.helper.js')
  * @param {boolean} enableReturnLog - defaulted to true, this needs to be false if you do not want the `licenceDocumentHeader`
  * to be included in the recipients list
  * @param {string} returnLogDueDate - defaulted to the same due date set by the returnsLogHelper
+ * @param {string} returnLogEndDate - defaulted to the same due date set by the returnsLogHelper
  *
  * @returns {Promise<object>} an object containing different licence document header instances and related entities
  * representing different scenarios
  */
-async function seed(enableReturnLog = true, returnLogDueDate = '2023-04-28') {
+async function seed(enableReturnLog = true, returnLogDueDate = '2023-04-28', returnLogEndDate = '2023-01-31') {
   return {
-    licenceHolder: await _addLicenceHolder(enableReturnLog, returnLogDueDate),
-    licenceHolderAndReturnTo: await _addLicenceHolderAndReturnToSameRef(enableReturnLog, returnLogDueDate),
-    primaryUser: await _addLicenceEntityRoles(enableReturnLog, returnLogDueDate)
+    licenceHolder: await _addLicenceHolder(enableReturnLog, returnLogDueDate, returnLogEndDate),
+    licenceHolderAndReturnTo: await _addLicenceHolderAndReturnToSameRef(
+      enableReturnLog,
+      returnLogDueDate,
+      returnLogEndDate
+    ),
+    primaryUser: await _addLicenceEntityRoles(enableReturnLog, returnLogDueDate, returnLogEndDate)
   }
 }
 
-async function _addLicenceEntityRoles(enableReturnLog, returnLogDueDate) {
+async function _addLicenceEntityRoles(enableReturnLog, returnLogDueDate, returnLogEndDate) {
   const primaryUser = {
     name: 'Primary User test',
     email: 'primary.user@important.com',
@@ -74,15 +79,16 @@ async function _addLicenceEntityRoles(enableReturnLog, returnLogDueDate) {
 
   if (enableReturnLog) {
     returnLog = await ReturnLogHelper.add({
-      licenceRef: licenceDocumentHeader.licenceRef,
-      dueDate: returnLogDueDate
+      dueDate: returnLogDueDate,
+      endDate: returnLogEndDate,
+      licenceRef: licenceDocumentHeader.licenceRef
     })
   }
 
   return { ...licenceDocumentHeader, returnLog }
 }
 
-async function _addLicenceHolder(enableReturnLog, returnLogDueDate) {
+async function _addLicenceHolder(enableReturnLog, returnLogDueDate, returnLogEndDate) {
   const name = 'Licence holder only'
   const licenceDocumentHeader = await LicenceDocumentHeaderHelper.add({
     metadata: {
@@ -95,15 +101,16 @@ async function _addLicenceHolder(enableReturnLog, returnLogDueDate) {
 
   if (enableReturnLog) {
     returnLog = await ReturnLogHelper.add({
-      licenceRef: licenceDocumentHeader.licenceRef,
-      dueDate: returnLogDueDate
+      dueDate: returnLogDueDate,
+      endDate: returnLogEndDate,
+      licenceRef: licenceDocumentHeader.licenceRef
     })
   }
 
   return { ...licenceDocumentHeader, returnLog }
 }
 
-async function _addLicenceHolderAndReturnToSameRef(enableReturnLog, returnLogDueDate) {
+async function _addLicenceHolderAndReturnToSameRef(enableReturnLog, returnLogDueDate, returnLogEndDate) {
   const name = 'Licence holder and returns to'
   const licenceDocumentHeader = await LicenceDocumentHeaderHelper.add({
     metadata: {
@@ -116,8 +123,9 @@ async function _addLicenceHolderAndReturnToSameRef(enableReturnLog, returnLogDue
 
   if (enableReturnLog) {
     returnLog = await ReturnLogHelper.add({
-      licenceRef: licenceDocumentHeader.licenceRef,
-      dueDate: returnLogDueDate
+      dueDate: returnLogDueDate,
+      endDate: returnLogEndDate,
+      licenceRef: licenceDocumentHeader.licenceRef
     })
   }
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5143

We previously implemented an update ad-hoc journey allowing the user to select a return to send the notice for.

This has highlighted an issue with our logic where we did not limit the returns logs due to 'today'. This means we were getting all the return logs due even future return logs.

This change update the 'FetchDownloadRecipientsService' to only return recipients where return logs are due and the endDate is in the pass.

To get to the page where this logic is due there is already a check on the return logs 'endDate'. This change aligns the two.