### PR TITLE
Add submit manual address service

### DIFF
--- a/app/presenters/address/manual.presenter.js
+++ b/app/presenters/address/manual.presenter.js
@@ -18,11 +18,11 @@ function go(session) {
   return {
     addressLine1: address.addressLine1 ?? null,
     addressLine2: address.addressLine2 ?? null,
+    addressLine3: address.addressLine3 ?? null,
+    addressLine4: address.addressLine4 ?? null,
     backLink: _backLink(address, id),
-    county: address.county ?? null,
     pageTitle: 'Enter the address',
-    postcode: address.postcode ?? null,
-    town: address.town ?? null
+    postcode: address.postcode ?? null
   }
 }
 

--- a/app/services/address/submit-manual.service.js
+++ b/app/services/address/submit-manual.service.js
@@ -29,7 +29,14 @@ async function go(sessionId, payload) {
     return {}
   }
 
-  const pageData = ManualAddressPresenter.go(session)
+  const _submittedData = {
+    id: session.id,
+    address: {
+      ...payload
+    }
+  }
+
+  const pageData = ManualAddressPresenter.go(_submittedData)
 
   return {
     error: validationResult,
@@ -38,6 +45,12 @@ async function go(sessionId, payload) {
 }
 
 async function _save(session, payload) {
+  session.address.addressLine1 = payload.addressLine1
+  session.address.addressLine2 = payload.addressLine2 ?? null
+  session.address.addressLine3 = payload.addressLine3 ?? null
+  session.address.addressLine4 = payload.addressLine4 ?? null
+  session.address.postcode = payload.postcode
+
   return session.$update()
 }
 
@@ -48,11 +61,20 @@ function _validate(payload) {
     return null
   }
 
-  const { message } = validation.error.details[0]
-
-  return {
-    text: message
+  const result = {
+    errorList: []
   }
+
+  validation.error.details.forEach((detail) => {
+    result.errorList.push({
+      href: `#${detail.context.key}`,
+      text: detail.message
+    })
+
+    result[detail.context.key] = detail.message
+  })
+
+  return result
 }
 
 module.exports = {

--- a/app/services/address/submit-select.service.js
+++ b/app/services/address/submit-select.service.js
@@ -59,13 +59,20 @@ async function go(sessionId, payload) {
 
 async function _save(session, address) {
   session.address.uprn = address.uprn
-  session.address.addressLine1 = address.organisation
-  session.address.addressLine2 = address.premises
-  session.address.addressLine3 = address.street_address
-  session.address.addressLine4 = address.locality
-  session.address.town = address.city
+
+  const premiseseStreetAddress = address.premises + ' ' + address.street_address
+
+  if (!address.organisation) {
+    session.address.addressLine1 = premiseseStreetAddress.trim()
+    session.address.addressLine2 = null
+  } else {
+    session.address.addressLine1 = address.organisation
+    session.address.addressLine2 = premiseseStreetAddress.trim()
+  }
+
+  session.address.addressLine3 = address.locality ?? null
+  session.address.addressLine4 = address.city
   session.address.postcode = address.postcode
-  session.address.country = address.country
 
   return session.$update()
 }

--- a/app/validators/address/manual.validator.js
+++ b/app/validators/address/manual.validator.js
@@ -6,6 +6,8 @@
  * @module ManualAddressValidator
  */
 
+const { postcodeValidator } = require('postcode-validator')
+
 const Joi = require('joi')
 
 /**
@@ -18,12 +20,74 @@ const Joi = require('joi')
  */
 function go(payload) {
   const schema = Joi.object({
-    addressLine1: Joi.string().required().messages({
-      'any.required': 'Enter addresss line 1'
-    })
+    addressLine1: Joi.string()
+      .required()
+      .custom((value, helper) => {
+        if (_invalidStartCharacters(value)) {
+          return helper.error('string.custom')
+        }
+        return value
+      })
+      .messages({
+        'any.required': 'Enter address line 1',
+        'string.custom': 'Address line 1 cannont start with a special character'
+      }),
+    addressLine2: Joi.string()
+      .optional()
+      .custom((value, helper) => {
+        if (_invalidStartCharacters(value)) {
+          return helper.error('string.custom')
+        }
+        return value
+      })
+      .messages({
+        'string.custom': 'Address line 2 cannont start with a special character'
+      }),
+    addressLine3: Joi.string()
+      .optional()
+      .custom((value, helper) => {
+        if (_invalidStartCharacters(value)) {
+          return helper.error('string.custom')
+        }
+        return value
+      })
+      .messages({
+        'string.custom': 'Address line 3 cannont start with a special character'
+      }),
+    addressLine4: Joi.string()
+      .optional()
+      .custom((value, helper) => {
+        if (_invalidStartCharacters(value)) {
+          return helper.error('string.custom')
+        }
+        return value
+      })
+      .messages({
+        'string.custom': 'Address line 4 cannont start with a special character'
+      }),
+    postcode: Joi.string()
+      .required()
+      .custom((value, helper) => {
+        if (!postcodeValidator(value, 'GB')) {
+          return helper.error('string.custom')
+        }
+        return value
+      })
+      .messages({
+        'any.required': 'Enter a UK postcode',
+        'string.custom': 'Enter a valid UK postcode'
+      })
   })
 
   return schema.validate(payload, { abortEarly: false })
+}
+
+function _invalidStartCharacters(value) {
+  const startCharacters = ['@', '(', ')', '=', '[', ']', '”', '\\', '/', '<', '>']
+
+  return startCharacters.some((character) => {
+    return value.startsWith(character)
+  })
 }
 
 module.exports = {

--- a/app/views/address/manual.njk
+++ b/app/views/address/manual.njk
@@ -54,28 +54,28 @@
 
     {{ govukInput({
       label: {
-        text: "Town or city"
+        text: "Address line 3 (optional)"
       },
-      classes: "govuk-input--width-20",
-      value: town,
-      id: "town",
-      name: "town",
+      classes: "govuk-input--width-30",
+      value: addressLine3,
+      id: "addressLine3",
+      name: "addressLine3",
       errorMessage: {
-          text: error.town
-        } if error.town
+          text: error.addressLine3
+        } if error.addressLine3
     }) }}
 
     {{ govukInput({
       label: {
-        text: "County (optional)"
+        text: "Address line 4 (optional)"
       },
-      classes: "govuk-input--width-20",
-      value: county,
-      id: "county",
-      name: "county",
+      classes: "govuk-input--width-30",
+      value: addressLine4,
+      id: "addressLine4",
+      name: "addressLine4",
       errorMessage: {
-          text: error.county
-        } if error.county
+          text: error.addressLine4
+        } if error.addressLine4
     }) }}
 
     {{ govukInput({

--- a/test/presenters/address/manual.presenter.test.js
+++ b/test/presenters/address/manual.presenter.test.js
@@ -27,11 +27,11 @@ describe('Address - Manual Presenter', () => {
       expect(result).to.equal({
         addressLine1: null,
         addressLine2: null,
+        addressLine3: null,
+        addressLine4: null,
         backLink: `/system/address/${session.id}/postcode`,
-        county: null,
         pageTitle: 'Enter the address',
-        postcode: null,
-        town: null
+        postcode: null
       })
     })
   })
@@ -42,10 +42,10 @@ describe('Address - Manual Presenter', () => {
         id: 'fecd5f15-bacf-4b3d-bdcd-ef279a97b061',
         address: {
           uprn: '123456789',
-          addressLine1: '1 Fake appartment',
+          addressLine1: '1 Fake Farm',
           addressLine2: '1 Fake street',
-          town: 'Fake Town',
-          county: 'Fake County',
+          addressLine3: 'Fake Village',
+          addressLine4: 'Fake City',
           postcode: 'SW1A 1AA'
         }
       }
@@ -54,13 +54,13 @@ describe('Address - Manual Presenter', () => {
       const result = ManualPresenter.go(session)
 
       expect(result).to.equal({
-        addressLine1: '1 Fake appartment',
+        addressLine1: '1 Fake Farm',
         addressLine2: '1 Fake street',
+        addressLine3: 'Fake Village',
+        addressLine4: 'Fake City',
         backLink: `/system/address/${session.id}/select`,
-        county: 'Fake County',
         pageTitle: 'Enter the address',
-        postcode: 'SW1A 1AA',
-        town: 'Fake Town'
+        postcode: 'SW1A 1AA'
       })
     })
   })

--- a/test/services/address/manual.service.test.js
+++ b/test/services/address/manual.service.test.js
@@ -33,11 +33,11 @@ describe('Address - Manual Service', () => {
         activeNavBar: 'search',
         addressLine1: null,
         addressLine2: null,
+        addressLine3: null,
+        addressLine4: null,
         backLink: `/system/address/${session.id}/postcode`,
-        county: null,
         pageTitle: 'Enter the address',
-        postcode: null,
-        town: null
+        postcode: null
       })
     })
   })
@@ -60,11 +60,11 @@ describe('Address - Manual Service', () => {
         activeNavBar: 'search',
         addressLine1: null,
         addressLine2: null,
+        addressLine3: null,
+        addressLine4: null,
         backLink: `/system/address/${session.id}/postcode`,
-        county: null,
         pageTitle: 'Enter the address',
-        postcode: 'SW1A 1AA',
-        town: null
+        postcode: 'SW1A 1AA'
       })
     })
   })
@@ -74,10 +74,10 @@ describe('Address - Manual Service', () => {
       sessionData = {
         address: {
           uprn: '123456789',
-          addressLine1: '1 Fake appartment',
+          addressLine1: '1 Fake Farm',
           addressLine2: '1 Fake street',
-          town: 'Fake Town',
-          county: 'Fake County',
+          addressLine3: 'Fake Village',
+          addressLine4: 'Fake City',
           postcode: 'SW1A 1AA'
         }
       }
@@ -90,13 +90,13 @@ describe('Address - Manual Service', () => {
 
       expect(result).to.equal({
         activeNavBar: 'search',
-        addressLine1: '1 Fake appartment',
+        addressLine1: '1 Fake Farm',
         addressLine2: '1 Fake street',
+        addressLine3: 'Fake Village',
+        addressLine4: 'Fake City',
         backLink: `/system/address/${session.id}/select`,
-        county: 'Fake County',
         pageTitle: 'Enter the address',
-        postcode: 'SW1A 1AA',
-        town: 'Fake Town'
+        postcode: 'SW1A 1AA'
       })
     })
   })

--- a/test/services/address/submit-manual.service.test.js
+++ b/test/services/address/submit-manual.service.test.js
@@ -13,15 +13,12 @@ const SessionHelper = require('../../support/helpers/session.helper.js')
 // Thing under test
 const SubmitManualService = require('../../../app/services/address/submit-manual.service.js')
 
-describe.skip('Address - Manual Service', () => {
+describe('Address - Submit Manual Service', () => {
   let payload
   let session
   let sessionData
 
   beforeEach(async () => {
-    payload = {
-      addressLine1: '1 Fake street'
-    }
     sessionData = {
       address: {}
     }
@@ -32,7 +29,11 @@ describe.skip('Address - Manual Service', () => {
   describe('when called', () => {
     beforeEach(async () => {
       payload = {
-        addressLine1: '1 Fake street'
+        addressLine1: '1 Fake Farm',
+        addressLine2: '1 Fake street',
+        addressLine3: 'Fake Village',
+        addressLine4: 'Fake City',
+        postcode: 'SW1A 1AA'
       }
     })
 
@@ -41,7 +42,36 @@ describe.skip('Address - Manual Service', () => {
 
       const refreshedSession = await session.$query()
 
-      expect(refreshedSession).to.equal(session)
+      expect(refreshedSession.data).to.equal({
+        address: {
+          addressLine1: '1 Fake Farm',
+          addressLine2: '1 Fake street',
+          addressLine3: 'Fake Village',
+          addressLine4: 'Fake City',
+          postcode: 'SW1A 1AA'
+        }
+      })
+    })
+
+    it('saves the submitted value', async () => {
+      const minPayload = {
+        addressLine1: '1 Fake Farm',
+        postcode: 'SW1A 1AA'
+      }
+
+      await SubmitManualService.go(session.id, minPayload)
+
+      const refreshedSession = await session.$query()
+
+      expect(refreshedSession.data).to.equal({
+        address: {
+          addressLine1: '1 Fake Farm',
+          addressLine2: null,
+          addressLine3: null,
+          addressLine4: null,
+          postcode: 'SW1A 1AA'
+        }
+      })
     })
 
     it('continues the journey', async () => {
@@ -60,10 +90,27 @@ describe.skip('Address - Manual Service', () => {
       const result = await SubmitManualService.go(session.id, payload)
 
       expect(result).to.equal({
+        addressLine1: null,
+        addressLine2: null,
+        addressLine3: null,
+        addressLine4: null,
+        backLink: `/system/address/${session.id}/postcode`,
         error: {
-          text: 'Enter addresss line 1'
+          addressLine1: 'Enter address line 1',
+          errorList: [
+            {
+              href: '#addressLine1',
+              text: 'Enter address line 1'
+            },
+            {
+              href: '#postcode',
+              text: 'Enter a UK postcode'
+            }
+          ],
+          postcode: 'Enter a UK postcode'
         },
-        pageTitle: 'Enter the address'
+        pageTitle: 'Enter the address',
+        postcode: null
       })
     })
   })

--- a/test/validators/address/manual.validator.test.js
+++ b/test/validators/address/manual.validator.test.js
@@ -13,11 +13,17 @@ const ManualAddressValidator = require('../../../app/validators/address/manual.v
 describe('Address - Manual Validator', () => {
   let payload
 
-  beforeEach(() => {
-    payload = { addressLine1: '1 Fake street' }
-  })
-
   describe('when called with valid data', () => {
+    beforeEach(() => {
+      payload = {
+        addressLine1: '1 Fake Farm',
+        addressLine2: '1 Fake street',
+        addressLine3: 'Fake Village',
+        addressLine4: 'Fake City',
+        postcode: 'SW1A 1AA'
+      }
+    })
+
     it('returns with no errors', () => {
       const result = ManualAddressValidator.go(payload)
 
@@ -26,7 +32,7 @@ describe('Address - Manual Validator', () => {
     })
   })
 
-  describe('when called with invalid data', () => {
+  describe('when called with no data', () => {
     beforeEach(() => {
       payload = {}
     })
@@ -35,8 +41,73 @@ describe('Address - Manual Validator', () => {
       const result = ManualAddressValidator.go(payload)
 
       expect(result.value).to.exist()
-      expect(result.error).to.exist()
-      expect(result.error.details[0].message).to.equal('Enter addresss line 1')
+      expect(result.error.details[0].message).to.equal('Enter address line 1')
+      expect(result.error.details[1].message).to.equal('Enter a UK postcode')
+    })
+  })
+
+  describe('when called with an invalid addressLine1', () => {
+    beforeEach(() => {
+      payload = { addressLine1: '<', postcode: 'SW1A 1AA' }
+    })
+
+    it('returns with errors', () => {
+      const result = ManualAddressValidator.go(payload)
+
+      expect(result.value).to.exist()
+      expect(result.error.details[0].message).to.equal('Address line 1 cannont start with a special character')
+    })
+  })
+
+  describe('when called with an invalid addressLine2', () => {
+    beforeEach(() => {
+      payload = { addressLine1: '1 Fake street', addressLine2: '@', postcode: 'SW1A 1AA' }
+    })
+
+    it('returns with errors', () => {
+      const result = ManualAddressValidator.go(payload)
+
+      expect(result.value).to.exist()
+      expect(result.error.details[0].message).to.equal('Address line 2 cannont start with a special character')
+    })
+  })
+
+  describe('when called with an invalid addressLine3', () => {
+    beforeEach(() => {
+      payload = { addressLine1: '1 Fake street', addressLine3: '(', postcode: 'SW1A 1AA' }
+    })
+
+    it('returns with errors', () => {
+      const result = ManualAddressValidator.go(payload)
+
+      expect(result.value).to.exist()
+      expect(result.error.details[0].message).to.equal('Address line 3 cannont start with a special character')
+    })
+  })
+
+  describe('when called with an invalid addressLine4', () => {
+    beforeEach(() => {
+      payload = { addressLine1: '1 Fake street', addressLine4: ')', postcode: 'SW1A 1AA' }
+    })
+
+    it('returns with errors', () => {
+      const result = ManualAddressValidator.go(payload)
+
+      expect(result.value).to.exist()
+      expect(result.error.details[0].message).to.equal('Address line 4 cannont start with a special character')
+    })
+  })
+
+  describe('when called with an invalid postcode', () => {
+    beforeEach(() => {
+      payload = { addressLine1: '1 Fake street', postcode: 'notapostcode' }
+    })
+
+    it('returns with errors', () => {
+      const result = ManualAddressValidator.go(payload)
+
+      expect(result.value).to.exist()
+      expect(result.error.details[0].message).to.equal('Enter a valid UK postcode')
     })
   })
 })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5046

As part of the journey to create ad-hoc letters to be sent out to users we need to be able to select an address.

This PR adds in the functionality to submit the manual address page, validate it and save the information if validated, or display an error if not. 