### PR TITLE
Update notice setup journey alerts

### DIFF
--- a/app/presenters/monitoring-stations/view.presenter.js
+++ b/app/presenters/monitoring-stations/view.presenter.js
@@ -93,7 +93,7 @@ function _licenceVersionPurpose(licenceVersionPurposeCondition) {
 }
 
 function _links(monitoringStationId) {
-  let createAlert = `/system/notices/setup/abstraction-alert?noticeType=abstraction-alert&monitoringStationId=${monitoringStationId}`
+  let createAlert = `/system/notices/setup/alerts?monitoringStationId=${monitoringStationId}`
 
   if (!FeatureFlagsConfig.enableMonitoringStationsAlertNotifications) {
     createAlert = '/monitoring-stations/' + monitoringStationId + '/send-alert/alert-type'

--- a/app/presenters/notices/setup/abstraction-alerts-download-recipients.presenter.js
+++ b/app/presenters/notices/setup/abstraction-alerts-download-recipients.presenter.js
@@ -1,7 +1,7 @@
 'use strict'
 
 /**
- * Formats data for the `/notices/setup/download` link when the journey is for 'abstraction-alert'
+ * Formats data for the `/notices/setup/download` link when the journey is for 'alerts'
  * @module AbstractionAlertDownloadRecipientsPresenter
  */
 
@@ -29,7 +29,7 @@ const HEADERS = [
 ]
 
 /**
- * Formats data for the `/notices/setup/download` link when the journey is for 'abstraction-alert'
+ * Formats data for the `/notices/setup/download` link when the journey is for 'alerts'
  *
  * A licence monitoring station can share the same licence reference as other stations. As a result, recipients may
  * receive multiple notifications for the same licence but from different monitoring stations. This leads to duplicate

--- a/app/presenters/notices/setup/cancel.presenter.js
+++ b/app/presenters/notices/setup/cancel.presenter.js
@@ -26,7 +26,7 @@ function go(session) {
 }
 
 function _summaryList(session) {
-  if (session.journey === 'abstraction-alert') {
+  if (session.journey === 'alerts') {
     return {
       text: 'Alert type',
       value: `${sentenceCase(session.alertType)}`

--- a/app/presenters/notices/setup/check.presenter.js
+++ b/app/presenters/notices/setup/check.presenter.js
@@ -9,7 +9,7 @@ const { contactName, contactAddress } = require('../../crm.presenter.js')
 const { defaultPageSize } = require('../../../../config/database.config.js')
 
 const NOTIFICATION_TYPES = {
-  'abstraction-alert': 'Abstraction alerts',
+  abstractionAlerts: 'Abstraction alerts',
   'paper-forms': 'Paper invitations',
   invitations: 'Returns invitations',
   reminders: 'Returns reminders'
@@ -30,7 +30,7 @@ function go(recipients, page, pagination, session) {
 
   return {
     defaultPageSize,
-    displayPreviewLink: noticeType !== 'abstraction-alert' && noticeType !== 'paper-forms',
+    displayPreviewLink: noticeType !== 'abstractionAlerts' && noticeType !== 'paper-forms',
     links: _links(session),
     pageTitle: _pageTitle(page, pagination),
     readyToSend: `${NOTIFICATION_TYPES[noticeType]} are ready to send.`,
@@ -78,7 +78,7 @@ function _links(session) {
 
   if (licenceRef) {
     back = `/system/notices/setup/${id}/check-notice-type`
-  } else if (journey === 'abstraction-alert') {
+  } else if (journey === 'alerts') {
     back = `/system/notices/setup/${id}/abstraction-alerts/alert-email-address`
   } else {
     back = `/system/notices/setup/${id}/returns-period`

--- a/app/presenters/notices/setup/create-notice.presenter.js
+++ b/app/presenters/notices/setup/create-notice.presenter.js
@@ -35,7 +35,7 @@ function go(session, recipients, auth) {
     subtype: subType
   }
 
-  if (session.journey === 'abstraction-alert') {
+  if (session.journey === 'alerts') {
     notice.metadata.options = { sendingAlertType: session.alertType, monitoringStationId: session.monitoringStationId }
   } else {
     notice.metadata.options = { excludeLicences: session.removeLicences ? session.removeLicences : [] }

--- a/app/services/notices/setup/batch-notifications.service.js
+++ b/app/services/notices/setup/batch-notifications.service.js
@@ -56,7 +56,7 @@ async function go(recipients, session, eventId) {
 async function _batch(recipients, session, eventId) {
   let notifications
 
-  if (session.journey === 'abstraction-alert') {
+  if (session.journey === 'alerts') {
     notifications = AbstractionAlertsNotificationsPresenter.go(recipients, session, eventId)
   } else {
     notifications = NotificationsPresenter.go(recipients, session, eventId)

--- a/app/services/notices/setup/check.service.js
+++ b/app/services/notices/setup/check.service.js
@@ -25,7 +25,7 @@ async function go(sessionId, page = 1) {
 
   let recipientsData
 
-  if (session.journey === 'abstraction-alert') {
+  if (session.journey === 'alerts') {
     recipientsData = await FetchAbstractionAlertRecipientsService.go(session)
   } else {
     recipientsData = await FetchRecipientsService.go(session)

--- a/app/services/notices/setup/determine-notice-type.service.js
+++ b/app/services/notices/setup/determine-notice-type.service.js
@@ -20,7 +20,7 @@ const { generateRandomInteger } = require('../../../lib/general.lib.js')
  * @private
  */
 const NOTICE_TYPES = {
-  'abstraction-alert': {
+  abstractionAlerts: {
     name: 'Water abstraction alert',
     prefix: 'WAA-',
     subType: 'waterAbstractionAlerts',

--- a/app/services/notices/setup/download-recipients.service.js
+++ b/app/services/notices/setup/download-recipients.service.js
@@ -28,7 +28,7 @@ async function go(sessionId) {
 
   let formattedData
 
-  if (session.journey === 'abstraction-alert') {
+  if (session.journey === 'alerts') {
     const recipients = await FetchAbstractionAlertRecipientsService.go(session)
 
     formattedData = AbstractionAlertDownloadRecipientsPresenter.go(recipients, session)

--- a/app/services/notices/setup/initiate-session.service.js
+++ b/app/services/notices/setup/initiate-session.service.js
@@ -23,7 +23,7 @@ const SessionModel = require('../../../models/session.model.js')
  * This session will be used for all types of notifications (invitations, reminders). We set the prefix and type
  * for the upstream services to use e.g. the prefix and code are used in the filename of a csv file.
  *
- * @param {string} journey - A string of 'adhoc', 'standard' or 'abstraction-alerts'
+ * @param {string} journey - A string of 'adhoc', 'standard' or 'alerts'
  * @param {string} [noticeType=null] - A string relating to one of the keys for `NOTIFICATION_TYPES`
  * @param {string} [monitoringStationId=null] - The UUID of the monitoring station we are creating an alert for
  *
@@ -31,6 +31,10 @@ const SessionModel = require('../../../models/session.model.js')
  */
 async function go(journey, noticeType = null, monitoringStationId = null) {
   let notice
+
+  if (journey === 'alerts') {
+    noticeType = 'abstractionAlerts'
+  }
 
   if (noticeType) {
     notice = DetermineNoticeTypeService.go(noticeType)
@@ -67,7 +71,7 @@ function _redirect(journey) {
     return 'returns-period'
   }
 
-  if (journey === 'abstraction-alert') {
+  if (journey === 'alerts') {
     return 'abstraction-alerts/alert-type'
   }
 

--- a/app/services/notices/setup/submit-cancel.service.js
+++ b/app/services/notices/setup/submit-cancel.service.js
@@ -21,7 +21,7 @@ async function go(sessionId) {
 
   await SessionModel.query().delete().where('id', sessionId)
 
-  if (session.journey === 'abstraction-alert') {
+  if (session.journey === 'alerts') {
     return `/system/monitoring-stations/${session.monitoringStationId}`
   }
 

--- a/app/services/notices/setup/submit-check.service.js
+++ b/app/services/notices/setup/submit-check.service.js
@@ -61,7 +61,7 @@ async function _processNotifications(session, recipients, notice) {
 async function _recipients(session) {
   let recipientsData
 
-  if (session.journey === 'abstraction-alert') {
+  if (session.journey === 'alerts') {
     recipientsData = await FetchAbstractionAlertRecipientsService.go(session)
   } else {
     recipientsData = await FetchRecipientsService.go(session)

--- a/test/presenters/monitoring-stations/view.presenter.test.js
+++ b/test/presenters/monitoring-stations/view.presenter.test.js
@@ -69,7 +69,7 @@ describe('Monitoring Stations - View presenter', () => {
         catchmentName: null,
         enableLicenceMonitoringStationsSetup: true,
         links: {
-          createAlert: `/system/notices/setup/abstraction-alert?noticeType=abstraction-alert&monitoringStationId=${monitoringStation.id}`
+          createAlert: `/system/notices/setup/alerts?monitoringStationId=${monitoringStation.id}`
         },
         gridReference: 'TL2664640047',
         monitoringStationId: 'f122d4bb-42bd-4af9-a081-1656f5a30b63',
@@ -130,7 +130,7 @@ describe('Monitoring Stations - View presenter', () => {
           const result = ViewPresenter.go(auth, monitoringStation)
 
           expect(result.links.createAlert).to.equal(
-            `/system/notices/setup/abstraction-alert?noticeType=abstraction-alert&monitoringStationId=${monitoringStation.id}`
+            `/system/notices/setup/alerts?monitoringStationId=${monitoringStation.id}`
           )
         })
       })

--- a/test/presenters/notices/setup/abstraction-alert-notifications.presenter.test.js
+++ b/test/presenters/notices/setup/abstraction-alert-notifications.presenter.test.js
@@ -47,7 +47,7 @@ describe('Notices - Setup - Abstraction alert notifications presenter', () => {
       ...abstractionAlertSessionData,
       alertEmailAddress: 'luke.skywalker@rebelmail.test',
       alertType: 'warning',
-      journey: 'abstraction-alerts',
+      journey: 'alerts',
       referenceCode,
       relevantLicenceMonitoringStations
     }

--- a/test/presenters/notices/setup/cancel.presenter.test.js
+++ b/test/presenters/notices/setup/cancel.presenter.test.js
@@ -53,11 +53,11 @@ describe('Notices - Setup - Cancel presenter', () => {
     })
   })
 
-  describe('when the journey is "abstraction-alerts"', () => {
+  describe('when the journey is "alerts"', () => {
     beforeEach(() => {
       session = {
         alertType: 'stop',
-        journey: 'abstraction-alert',
+        journey: 'alerts',
         monitoringStationId: '123',
         referenceCode: 'WAA-1234'
       }
@@ -73,58 +73,8 @@ describe('Notices - Setup - Cancel presenter', () => {
     })
   })
 
-  describe('and the journey is "invitations"', () => {
-    beforeEach(() => {
-      session = {
-        determinedReturnsPeriod: {
-          name: 'quarterOne',
-          dueDate: '2025-07-28',
-          endDate: '2025-06-30',
-          summer: 'false',
-          startDate: '2025-04-01'
-        },
-        journey: 'invitations',
-        referenceCode
-      }
-    })
-
-    it('correctly formats the summary list', () => {
-      const result = CancelPresenter.go(session)
-
-      expect(result.summaryList).to.equal({
-        text: 'Returns period',
-        value: 'Quarterly 1 April 2025 to 30 June 2025'
-      })
-    })
-  })
-
-  describe('and the journey is "reminders"', () => {
-    beforeEach(() => {
-      session = {
-        determinedReturnsPeriod: {
-          name: 'quarterOne',
-          dueDate: '2025-07-28',
-          endDate: '2025-06-30',
-          summer: 'false',
-          startDate: '2025-04-01'
-        },
-        journey: 'reminders',
-        referenceCode
-      }
-    })
-
-    it('correctly formats the summary list', () => {
-      const result = CancelPresenter.go(session)
-
-      expect(result.summaryList).to.equal({
-        text: 'Returns period',
-        value: 'Quarterly 1 April 2025 to 30 June 2025'
-      })
-    })
-  })
-
-  describe('when the journey has a "returnsPeriod"', () => {
-    describe('and the "returnsPeriod" is for a "quarter"', () => {
+  describe('when the journey is "standard"', () => {
+    describe('and the "noticeType" is "invitations"', () => {
       beforeEach(() => {
         session = {
           determinedReturnsPeriod: {
@@ -149,17 +99,17 @@ describe('Notices - Setup - Cancel presenter', () => {
       })
     })
 
-    describe('and the "returnsPeriod" is "summer"', () => {
+    describe('and the "noticeType" is "reminders"', () => {
       beforeEach(() => {
         session = {
           determinedReturnsPeriod: {
-            name: 'summer',
-            dueDate: '2025-11-28',
-            endDate: '2025-10-31',
-            summer: true,
-            startDate: '2024-11-01'
+            name: 'quarterOne',
+            dueDate: '2025-07-28',
+            endDate: '2025-06-30',
+            summer: 'false',
+            startDate: '2025-04-01'
           },
-          journey: 'invitations',
+          journey: 'reminders',
           referenceCode
         }
       })
@@ -169,32 +119,84 @@ describe('Notices - Setup - Cancel presenter', () => {
 
         expect(result.summaryList).to.equal({
           text: 'Returns period',
-          value: 'Summer annual 1 November 2024 to 31 October 2025'
+          value: 'Quarterly 1 April 2025 to 30 June 2025'
         })
       })
     })
 
-    describe('and the "returnsPeriod" is "allYear"', () => {
-      beforeEach(() => {
-        session = {
-          determinedReturnsPeriod: {
-            name: 'allYear',
-            dueDate: '2025-04-28',
-            endDate: '2025-03-31',
-            summer: true,
-            startDate: '2024-04-01'
-          },
-          journey: 'invitations',
-          referenceCode
-        }
+    describe('when the journey has a "returnsPeriod"', () => {
+      describe('and the "returnsPeriod" is for a "quarter"', () => {
+        beforeEach(() => {
+          session = {
+            determinedReturnsPeriod: {
+              name: 'quarterOne',
+              dueDate: '2025-07-28',
+              endDate: '2025-06-30',
+              summer: 'false',
+              startDate: '2025-04-01'
+            },
+            journey: 'invitations',
+            referenceCode
+          }
+        })
+
+        it('correctly formats the summary list', () => {
+          const result = CancelPresenter.go(session)
+
+          expect(result.summaryList).to.equal({
+            text: 'Returns period',
+            value: 'Quarterly 1 April 2025 to 30 June 2025'
+          })
+        })
       })
 
-      it('correctly formats the summary list', () => {
-        const result = CancelPresenter.go(session)
+      describe('and the "returnsPeriod" is "summer"', () => {
+        beforeEach(() => {
+          session = {
+            determinedReturnsPeriod: {
+              name: 'summer',
+              dueDate: '2025-11-28',
+              endDate: '2025-10-31',
+              summer: true,
+              startDate: '2024-11-01'
+            },
+            journey: 'invitations',
+            referenceCode
+          }
+        })
 
-        expect(result.summaryList).to.equal({
-          text: 'Returns period',
-          value: 'Winter and all year annual 1 April 2024 to 31 March 2025'
+        it('correctly formats the summary list', () => {
+          const result = CancelPresenter.go(session)
+
+          expect(result.summaryList).to.equal({
+            text: 'Returns period',
+            value: 'Summer annual 1 November 2024 to 31 October 2025'
+          })
+        })
+      })
+
+      describe('and the "returnsPeriod" is "allYear"', () => {
+        beforeEach(() => {
+          session = {
+            determinedReturnsPeriod: {
+              name: 'allYear',
+              dueDate: '2025-04-28',
+              endDate: '2025-03-31',
+              summer: true,
+              startDate: '2024-04-01'
+            },
+            journey: 'invitations',
+            referenceCode
+          }
+        })
+
+        it('correctly formats the summary list', () => {
+          const result = CancelPresenter.go(session)
+
+          expect(result.summaryList).to.equal({
+            text: 'Returns period',
+            value: 'Winter and all year annual 1 April 2024 to 31 March 2025'
+          })
         })
       })
     })

--- a/test/presenters/notices/setup/check.presenter.test.js
+++ b/test/presenters/notices/setup/check.presenter.test.js
@@ -369,10 +369,10 @@ describe('Notices - Setup - Check presenter', () => {
       })
     })
 
-    describe('when the journey is for "abstraction-alert"', () => {
+    describe('when the journey is for "alerts"', () => {
       beforeEach(() => {
-        session.journey = 'abstraction-alert'
-        session.noticeType = 'abstraction-alert'
+        session.journey = 'alerts'
+        session.noticeType = 'abstractionAlerts'
         session.referenceCode = 'WAA-123'
         session.monitoringStationId = '345'
       })
@@ -385,7 +385,7 @@ describe('Notices - Setup - Check presenter', () => {
       })
 
       describe('the "links" property', () => {
-        it('should return the links for "abstraction-alert"', () => {
+        it('should return the links for "alerts"', () => {
           const result = CheckPresenter.go(testInput, page, pagination, session)
           expect(result.links).to.equal({
             back: `/system/notices/setup/${session.id}/abstraction-alerts/alert-email-address`,

--- a/test/presenters/notices/setup/create-notice.presenter.test.js
+++ b/test/presenters/notices/setup/create-notice.presenter.test.js
@@ -29,7 +29,7 @@ describe('Notices - Setup - Create Notice presenter', () => {
     }
   })
 
-  describe('when the journey is a return journey', () => {
+  describe('when the journey is not for "alerts"', () => {
     beforeEach(() => {
       recipients = RecipientsFixture.recipients()
       testRecipients = [...Object.values(recipients)]
@@ -181,14 +181,14 @@ describe('Notices - Setup - Create Notice presenter', () => {
     })
   })
 
-  describe('when the journey is "abstraction-alert', () => {
+  describe('when the journey is for "alerts', () => {
     beforeEach(() => {
       recipients = RecipientsFixture.alertsRecipients()
       testRecipients = [...Object.values(recipients)]
 
       session = {
         alertType: 'stop',
-        journey: 'abstraction-alert',
+        journey: 'alerts',
         monitoringStationId: '123',
         name: 'Water abstraction alert',
         referenceCode: 'WAA-123',

--- a/test/services/monitoring-stations/view.service.test.js
+++ b/test/services/monitoring-stations/view.service.test.js
@@ -80,7 +80,7 @@ describe('Monitoring Stations - View service', () => {
         enableLicenceMonitoringStationsSetup: true,
         gridReference: 'TL2664640047',
         links: {
-          createAlert: `/system/notices/setup/abstraction-alert?noticeType=abstraction-alert&monitoringStationId=${monitoringStation.id}`
+          createAlert: `/system/notices/setup/alerts?monitoringStationId=${monitoringStation.id}`
         },
         monitoringStationId: 'f122d4bb-42bd-4af9-a081-1656f5a30b63',
         notification: 'Tag removed for 99/999/9999',

--- a/test/services/notices/setup/batch-notifications.service.test.js
+++ b/test/services/notices/setup/batch-notifications.service.test.js
@@ -353,7 +353,7 @@ describe('Notices - Setup - Batch notifications service', () => {
     })
   })
 
-  describe('when the journey is "abstraction-alert"', () => {
+  describe('when the journey is "alerts"', () => {
     let licenceMonitoringStations
 
     beforeEach(async () => {
@@ -387,7 +387,7 @@ describe('Notices - Setup - Batch notifications service', () => {
         ...abstractionAlertSessionData,
         alertEmailAddress: 'luke.skywalker@rebelmail.test',
         alertType: 'reduce',
-        journey: 'abstraction-alert',
+        journey: 'alerts',
         name: 'Water abstraction alert',
         referenceCode: 'WAA-123',
         relevantLicenceMonitoringStations,

--- a/test/services/notices/setup/check.service.test.js
+++ b/test/services/notices/setup/check.service.test.js
@@ -76,13 +76,13 @@ describe('Notices - Setup - Check service', () => {
     })
   })
 
-  describe('when the journey is "abstraction-alert"', () => {
+  describe('when the journey is "alerts"', () => {
     beforeEach(async () => {
       session = await SessionHelper.add({
         data: {
-          journey: 'abstraction-alert',
+          journey: 'alerts',
           monitoringStationId: '456',
-          noticeType: 'abstraction-alert',
+          noticeType: 'abstractionAlerts',
           referenceCode: 'WAA-123'
         }
       })

--- a/test/services/notices/setup/determine-notice-type.service.test.js
+++ b/test/services/notices/setup/determine-notice-type.service.test.js
@@ -81,13 +81,13 @@ describe('Notices - Setup - Determine Notice Type service', () => {
       })
     })
 
-    describe('when the "notificationType" is "abstraction-alert"', () => {
+    describe('when the "notificationType" is "abstractionAlerts"', () => {
       it('creates a new session record', () => {
-        const result = DetermineNoticeTypeService.go('abstraction-alert')
+        const result = DetermineNoticeTypeService.go('abstractionAlerts')
 
         expect(result).to.equal({
           name: 'Water abstraction alert',
-          noticeType: 'abstraction-alert',
+          noticeType: 'abstractionAlerts',
           notificationType: 'Abstraction alert',
           referenceCode: result.referenceCode, // randomly generated
           subType: 'waterAbstractionAlerts'
@@ -95,8 +95,8 @@ describe('Notices - Setup - Determine Notice Type service', () => {
       })
 
       describe('the "referenceCode" property', () => {
-        it('returns a reference code for an "abstraction-alert" notification', () => {
-          const result = DetermineNoticeTypeService.go('abstraction-alert')
+        it('returns a reference code for an "abstractionAlerts" notification', () => {
+          const result = DetermineNoticeTypeService.go('abstractionAlerts')
 
           expect(result.referenceCode).to.include('WAA-')
           expect(result.referenceCode.length).to.equal(10)

--- a/test/services/notices/setup/download-recipients.service.test.js
+++ b/test/services/notices/setup/download-recipients.service.test.js
@@ -27,7 +27,7 @@ describe('Notices - Setup - Download recipients service', () => {
     Sinon.restore()
   })
 
-  describe('when the journey is for returns ', () => {
+  describe('when the journey is for returns', () => {
     let removeLicences
 
     before(async () => {
@@ -57,7 +57,7 @@ describe('Notices - Setup - Download recipients service', () => {
     })
   })
 
-  describe('when the journey is "abstraction-alerts"', () => {
+  describe('when the journey is "alerts"', () => {
     let recipients
 
     describe('and there are recipients', () => {
@@ -75,7 +75,7 @@ describe('Notices - Setup - Download recipients service', () => {
         session = await SessionHelper.add({
           data: {
             notificationType: 'Abstraction alert',
-            journey: 'abstraction-alert',
+            journey: 'alerts',
             referenceCode,
             relevantLicenceMonitoringStations
           }
@@ -138,7 +138,7 @@ describe('Notices - Setup - Download recipients service', () => {
         session = await SessionHelper.add({
           data: {
             notificationType: 'Abstraction alert',
-            journey: 'abstraction-alert',
+            journey: 'alerts',
             referenceCode,
             relevantLicenceMonitoringStations
           }

--- a/test/services/notices/setup/initiate-session.service.test.js
+++ b/test/services/notices/setup/initiate-session.service.test.js
@@ -82,12 +82,12 @@ describe('Notices - Setup - Initiate Session service', () => {
       })
     })
 
-    describe('when the "notificationType" is "abstraction-alert"', () => {
+    describe('when the journey is "alerts"', () => {
       let monitoringStationData
 
       beforeEach(() => {
-        journey = 'abstraction-alert'
-        noticeType = 'abstraction-alert'
+        journey = 'alerts'
+        noticeType = 'abstractionAlerts'
         monitoringStationId = '1234'
 
         monitoringStationData = AbstractionAlertSessionData.get()
@@ -101,9 +101,9 @@ describe('Notices - Setup - Initiate Session service', () => {
         const matchingSession = await SessionModel.query().findById(result.sessionId)
 
         expect(matchingSession.data).to.equal({
-          journey: 'abstraction-alert',
+          journey: 'alerts',
           name: 'Water abstraction alert',
-          noticeType: 'abstraction-alert',
+          noticeType: 'abstractionAlerts',
           notificationType: 'Abstraction alert',
           referenceCode: matchingSession.referenceCode, // randomly generated
           subType: 'waterAbstractionAlerts',

--- a/test/services/notices/setup/submit-cancel.service.test.js
+++ b/test/services/notices/setup/submit-cancel.service.test.js
@@ -43,12 +43,12 @@ describe('Notices - Setup - Submit Cancel service', () => {
       })
     })
 
-    describe('when the journey is for "abstraction-alerts"', () => {
+    describe('when the journey is for "alerts"', () => {
       beforeEach(async () => {
         session = await SessionHelper.add({
           data: {
             alertType: 'stop',
-            journey: 'abstraction-alert',
+            journey: 'alerts',
             monitoringStationId: '123',
             referenceCode: 'WAA-1234'
           }

--- a/test/services/notices/setup/submit-check.service.test.js
+++ b/test/services/notices/setup/submit-check.service.test.js
@@ -117,13 +117,13 @@ describe('Notices - Setup - Submit Check service', () => {
     })
   })
 
-  describe('when the journey is "abstraction-alert', () => {
+  describe('when the journey is "alerts"', () => {
     beforeEach(async () => {
       referenceCode = `WAA-${Math.floor(1000 + Math.random() * 9000).toString()}`
 
       session = await SessionHelper.add({
         data: {
-          journey: 'abstraction-alert',
+          journey: 'alerts',
           referenceCode
         }
       })
@@ -153,7 +153,7 @@ describe('Notices - Setup - Submit Check service', () => {
           Sinon.match({
             id: session.id,
             data: session.data,
-            journey: 'abstraction-alert',
+            journey: 'alerts',
             referenceCode
           }),
           result


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5143

We need to refactor the existing notice setup journey structure to accommodate the coming adHoc invitations and paper forms.

This change updates the previous 'journey' of 'abstraction-alert' to be 'alerts'

The previously known journey of 'abstraction-alert' is now a notice type.