### PR TITLE
Update missing 'activeNavBar'

### DIFF
--- a/app/services/notices/setup/check-notice-type.service.js
+++ b/app/services/notices/setup/check-notice-type.service.js
@@ -28,6 +28,7 @@ async function go(sessionId, yar) {
 
   return {
     ...pageData,
+    activeNavBar: 'manage',
     notification
   }
 }

--- a/app/services/notices/setup/notice-type.service.js
+++ b/app/services/notices/setup/notice-type.service.js
@@ -22,6 +22,7 @@ async function go(sessionId) {
   const pageData = NoticeTypePresenter.go(session)
 
   return {
+    activeNavBar: 'manage',
     ...pageData
   }
 }

--- a/app/services/notices/setup/return-forms.service.js
+++ b/app/services/notices/setup/return-forms.service.js
@@ -22,6 +22,7 @@ async function go(sessionId) {
   const pageData = ReturnFormsPresenter.go(session)
 
   return {
+    activeNavBar: 'manage',
     ...pageData
   }
 }

--- a/app/services/notices/setup/submit-notice-type.service.js
+++ b/app/services/notices/setup/submit-notice-type.service.js
@@ -41,6 +41,7 @@ async function go(sessionId, payload, yar) {
   const pageData = NoticeTypePresenter.go(session)
 
   return {
+    activeNavBar: 'manage',
     error: validationResult,
     ...pageData
   }

--- a/app/services/notices/setup/submit-return-forms.service.js
+++ b/app/services/notices/setup/submit-return-forms.service.js
@@ -42,6 +42,7 @@ async function go(sessionId, payload, yar) {
   const pageData = ReturnFormsPresenter.go(session)
 
   return {
+    activeNavBar: 'manage',
     error: validationResult,
     ...pageData
   }

--- a/test/services/notices/setup/check-notice-type.service.test.js
+++ b/test/services/notices/setup/check-notice-type.service.test.js
@@ -39,6 +39,7 @@ describe('Notices - Setup - Check Notice Type Service', () => {
       const result = await CheckNoticeTypeService.go(session.id, yarStub)
 
       expect(result).to.equal({
+        activeNavBar: 'manage',
         continueButton: {
           href: `/system/notices/setup/${session.id}/check`,
           text: 'Continue to check recipients'

--- a/test/services/notices/setup/notice-type.service.test.js
+++ b/test/services/notices/setup/notice-type.service.test.js
@@ -28,6 +28,7 @@ describe('Notice Type Service', () => {
       const result = await NoticeTypeService.go(session.id)
 
       expect(result).to.equal({
+        activeNavBar: 'manage',
         backLink: `/system/notices/setup/${session.id}/licence`,
         options: [
           {

--- a/test/services/notices/setup/returns-for-paper-forms.service.test.js
+++ b/test/services/notices/setup/returns-for-paper-forms.service.test.js
@@ -42,6 +42,7 @@ describe('Notices - Setup - Returns For Paper Forms service', () => {
       const result = await ReturnFormsService.go(session.id)
 
       expect(result).to.equal({
+        activeNavBar: 'manage',
         backLink: `/system/notices/setup/${session.id}/notice-type`,
         pageTitle: 'Select the returns for the paper forms',
         returns: [

--- a/test/services/notices/setup/submit-notice-type.service.test.js
+++ b/test/services/notices/setup/submit-notice-type.service.test.js
@@ -144,6 +144,7 @@ describe('Notice Type Service', () => {
       const result = await SubmitNoticeTypeService.go(session.id, payload, yarStub)
 
       expect(result).to.equal({
+        activeNavBar: 'manage',
         backLink: `/system/notices/setup/${session.id}/licence`,
         error: { text: 'Select the notice type' },
         options: [

--- a/test/services/notices/setup/submit-returns-for-paper-forms.service.test.js
+++ b/test/services/notices/setup/submit-returns-for-paper-forms.service.test.js
@@ -127,6 +127,7 @@ describe('Notices - Setup - Submit Returns For Paper Forms service', () => {
       const result = await SubmitReturnFormsService.go(session.id, payload, yarStub)
 
       expect(result).to.equal({
+        activeNavBar: 'manage',
         backLink: `/system/notices/setup/${session.id}/notice-type`,
         error: {
           text: 'Select the returns for the paper forms'
@@ -156,6 +157,7 @@ describe('Notices - Setup - Submit Returns For Paper Forms service', () => {
         const result = await SubmitReturnFormsService.go(session.id, payload, yarStub)
 
         expect(result).to.equal({
+          activeNavBar: 'manage',
           backLink: `/system/notices/setup/${session.id}/notice-type`,
           error: {
             text: 'Select the returns for the paper forms'


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5143

Some of the notices services do not set the 'activeNavBar'.

This change adds the missing 'activeNavBar' property to the services and updates the tests.