### PR TITLE
Update session with data after insert

### DIFF
--- a/app/models/session.model.js
+++ b/app/models/session.model.js
@@ -51,6 +51,23 @@ class SessionModel extends BaseModel {
   }
 
   /**
+   * Called after a session instance is created. It calls $afterFind() to elevate the properties of `data` to the top
+   * level of the instance
+   *
+   * > We do not expect modules to call this function directly. It is a named hook for use with Objection.js
+   *
+   * Because we usually fetch a session within code rather than create one, this is most likely to be of use within unit
+   * tests; if we create a session with specific data in a unit test and then wish to refer to that data we can directly
+   * refer to it at the top level of `session` instead of within `session.data`, allowing us to be consistent with how
+   * we would refer to the session properties within code.
+   *
+   * @param {object} _queryContext - Objection.js query context which we do not use
+   */
+  $afterInsert(_queryContext) {
+    this.$afterFind()
+  }
+
+  /**
    * Update the session instance's `data` property with the current properties of the instance
    *
    * Added to avoid callers having to repeatedly implement this pattern.

--- a/test/models/session.model.test.js
+++ b/test/models/session.model.test.js
@@ -40,7 +40,7 @@ describe('Session model', () => {
       it('adds nothing to the session instance properties', async () => {
         const result = await SessionModel.query().findById(testRecord.id)
 
-        expect(Object.keys(result)).to.equal(['id', 'data', 'createdAt', 'updatedAt'])
+        expect(result).to.only.include(['id', 'data', 'createdAt', 'updatedAt'])
       })
     })
 
@@ -61,7 +61,7 @@ describe('Session model', () => {
       it('adds its properties to the session instance properties', async () => {
         const result = await SessionModel.query().findById(testRecord.id)
 
-        expect(Object.keys(result)).to.equal(['id', 'data', 'createdAt', 'updatedAt', 'reason', 'licence', 'purposes'])
+        expect(result).to.only.include(['id', 'data', 'createdAt', 'updatedAt', 'reason', 'licence', 'purposes'])
 
         expect(result.licence).to.equal({ licenceRef: '01/123/01', startDate: '2017-05-07T00:00:00.000Z' })
         expect(result.purposes).to.equal(['foo', 'bar'])

--- a/test/models/session.model.test.js
+++ b/test/models/session.model.test.js
@@ -71,7 +71,7 @@ describe('Session model', () => {
   })
 
   // NOTE: this is also an Objection.js hook and not intended to be called directly
-  describe('$afterQuery', () => {
+  describe('$afterInsert', () => {
     describe('when "data" is empty', () => {
       it('adds nothing to the session instance properties', async () => {
         const result = await SessionHelper.add()

--- a/test/models/session.model.test.js
+++ b/test/models/session.model.test.js
@@ -70,6 +70,44 @@ describe('Session model', () => {
     })
   })
 
+  // NOTE: this is also an Objection.js hook and not intended to be called directly
+  describe('$afterQuery', () => {
+    describe('when "data" is empty', () => {
+      it('adds nothing to the session instance properties', async () => {
+        const result = await SessionHelper.add()
+
+        expect(result).to.only.include(['id', 'data', 'createdAt', 'updatedAt'])
+      })
+    })
+
+    describe('when "data" is populated', () => {
+      let testData
+
+      beforeEach(async () => {
+        testData = {
+          data: {
+            licence: {
+              licenceRef: '01/123/01',
+              startDate: new Date('2017-05-07')
+            },
+            purposes: ['foo', 'bar'],
+            reason: 'major-change'
+          }
+        }
+      })
+
+      it('adds its properties to the session instance properties', async () => {
+        const result = await SessionHelper.add(testData)
+
+        expect(result).to.only.include(['id', 'data', 'createdAt', 'updatedAt', 'reason', 'licence', 'purposes'])
+
+        expect(result.licence).to.equal({ licenceRef: '01/123/01', startDate: '2017-05-07T00:00:00.000Z' })
+        expect(result.purposes).to.equal(['foo', 'bar'])
+        expect(result.reason).to.equal('major-change')
+      })
+    })
+  })
+
   describe('$update', () => {
     let recordToUpdate
 

--- a/test/services/licence-monitoring-station/setup/licence-number.service.test.js
+++ b/test/services/licence-monitoring-station/setup/licence-number.service.test.js
@@ -21,7 +21,6 @@ describe('Licence Monitoring Station Setup - Licence Number Service', () => {
     sessionData = {
       label: 'MONITORING_STATION_LABEL',
       licenceRef: 'LICENCE_REF',
-      id: 'd9afac37-9754-4bfa-95f7-87ab26824423',
       checkPageVisited: false
     }
 
@@ -34,7 +33,7 @@ describe('Licence Monitoring Station Setup - Licence Number Service', () => {
 
       expect(result).to.equal({
         activeNavBar: 'search',
-        backLink: '/system/licence-monitoring-station/setup/d9afac37-9754-4bfa-95f7-87ab26824423/stop-or-reduce',
+        backLink: `/system/licence-monitoring-station/setup/${session.id}/stop-or-reduce`,
         licenceRef: 'LICENCE_REF',
         monitoringStationLabel: 'MONITORING_STATION_LABEL',
         pageTitle: 'Enter the licence number this threshold applies to'

--- a/test/services/licence-monitoring-station/setup/submit-check.service.test.js
+++ b/test/services/licence-monitoring-station/setup/submit-check.service.test.js
@@ -76,7 +76,7 @@ describe('Licence Monitoring Station Setup - Submit Check Service', () => {
       const [flashType, notification] = yarStub.flash.args[0]
 
       expect(flashType).to.equal('notification')
-      expect(notification).to.equal({ title: 'Success', text: `Tag for licence ${session.data.licenceRef} added` })
+      expect(notification).to.equal({ title: 'Success', text: `Tag for licence ${session.licenceRef} added` })
     })
 
     describe('and the session unit is a flow unit', () => {
@@ -182,7 +182,7 @@ describe('Licence Monitoring Station Setup - Submit Check Service', () => {
           .where('monitoringStationId', sessionData.monitoringStationId)
           .first()
 
-        expect(result.licenceVersionPurposeConditionId).to.equal(session.data.conditionId)
+        expect(result.licenceVersionPurposeConditionId).to.equal(session.conditionId)
       })
 
       it('does not persist abstraction period', async () => {

--- a/test/services/return-logs/setup/submit-submission.service.test.js
+++ b/test/services/return-logs/setup/submit-submission.service.test.js
@@ -143,7 +143,7 @@ describe('Return Logs - Setup - Submit Submission service', () => {
           error: { text: 'Select what you want to do with this return' },
           journey: null,
           pageTitle: 'What do you want to do with this return?',
-          returnReference: session.data.returnReference
+          returnReference: session.returnReference
         })
       })
     })

--- a/test/services/return-versions/setup/check/submit-check.service.test.js
+++ b/test/services/return-versions/setup/check/submit-check.service.test.js
@@ -62,7 +62,7 @@ describe('Return Versions Setup - Submit Check service', () => {
       it('returns a valid licence', async () => {
         const result = await SubmitCheckService.go(session.id)
 
-        expect(result).to.equal(session.data.licence.id)
+        expect(result).to.equal(session.licence.id)
       })
     })
 
@@ -70,7 +70,7 @@ describe('Return Versions Setup - Submit Check service', () => {
       it('returns a valid licence', async () => {
         const result = await SubmitCheckService.go(session.id)
 
-        expect(result).to.equal(session.data.licence.id)
+        expect(result).to.equal(session.licence.id)
       })
     })
   })
@@ -111,7 +111,7 @@ describe('Return Versions Setup - Submit Check service', () => {
       it('returns a valid licence', async () => {
         const result = await SubmitCheckService.go(session.id)
 
-        expect(result).to.equal(session.data.licence.id)
+        expect(result).to.equal(session.licence.id)
       })
     })
   })


### PR DESCRIPTION
Currently, when we retrieve a session we update the returned object so that the content of `session.data` is elevated to the top level. However we don't do this when a session is inserted, so if we create a session and want to read from the returned session object, we must refer to the properties within `session.data` rather than the top level.

In a unit test for example, we may use `SessionHelper` to create a session containing a random condition id, which we later want to refer to in an assertion. We would have to refer to `session.data.conditionId` which is not consistent with the way we would refer to it in the actual code `session.conditionId`.

Elevating the properties within `session.data` is done by the method `SessionModel.$afterFind()`; we create an additional `SessionModel.$afterInsert()` which also does this, so that the session object returned after creating it will also have the properties elevated from `session.data` to the top level.