### PR TITLE
Add Gotenberg services

### DIFF
--- a/app/requests/gotenberg.request.js
+++ b/app/requests/gotenberg.request.js
@@ -1,0 +1,63 @@
+'use strict'
+
+/**
+ * Make a http requests to Gotenberg to convert HTML into a PDF
+ * @module GotenbergRequest
+ */
+
+const BaseRequest = require('./base.request.js')
+const requestConfig = require('../../config/request.config.js')
+const servicesConfig = require('../../config/services.config.js')
+
+/**
+ * Make a http requests to Gotenberg to convert HTML into a PDF
+ *
+ * @param {string} path - The path to send the request to (do not include the starting /)
+ * @param {object} formData - The formData of the request
+ *
+ * @returns {Promise<object>} An object representing the result of the request
+ */
+async function post(path, formData) {
+  const result = await _sendRequest(path, BaseRequest.post, formData)
+
+  return _parseResult(result)
+}
+
+async function _sendRequest(path, method, formData) {
+  const options = _requestOptions(formData)
+
+  const result = await method(path, options)
+
+  return result
+}
+
+function _requestOptions(formData) {
+  return {
+    prefixUrl: servicesConfig.gotenberg.url,
+    responseType: 'buffer',
+    timeout: {
+      request: requestConfig.gotenbergTimeout
+    },
+    body: formData
+  }
+}
+
+function _parseResult(result) {
+  const { body, statusCode } = result.response
+
+  if (body) {
+    return {
+      succeeded: result.succeeded,
+      response: {
+        statusCode,
+        body
+      }
+    }
+  }
+
+  return result
+}
+
+module.exports = {
+  post
+}

--- a/app/requests/gotenberg/generate-return-form.request.js
+++ b/app/requests/gotenberg/generate-return-form.request.js
@@ -1,0 +1,58 @@
+'use strict'
+
+/**
+ * Sends multipart/form-data to Gotenberg for generating a PDF document
+ * @module GenerateReturnFormRequest
+ */
+
+const nunjucks = require('nunjucks')
+const path = require('path')
+
+const GotenbergRequest = require('../gotenberg.request.js')
+
+/**
+ * Sends multipart/form-data to Gotenberg for generating a PDF document
+ *
+ * > Important - 'preferCssPageSize' tells Goetnberg to rely on our styling and to not add any default margin / padding.
+ * > This is required in conjunction with setting 'marginTop' etc.
+ *
+ * @param {object} pageData - The data needed to populate and generate the PDF return form
+ *
+ * @returns {Promise<object>} An object representing the result of the request, including an ArrayBuffer as the 'body'
+ */
+async function send(pageData) {
+  const htmlContent = await _generateHtmlContent(pageData)
+
+  const formData = _generateFormData(htmlContent)
+
+  return GotenbergRequest.post('forms/chromium/convert/html', formData)
+}
+
+function _generateFormData(htmlContent) {
+  const formData = new FormData()
+
+  formData.append('index.html', new Blob([Buffer.from(htmlContent)]), 'index.html')
+  formData.append('marginTop', '0')
+  formData.append('marginBottom', '0')
+  formData.append('marginLeft', '0')
+  formData.append('marginRight', '0')
+  formData.append('preferCssPageSize', 'true')
+
+  return formData
+}
+
+function _generateHtmlContent(data) {
+  const view = 'preview-return-forms.njk'
+
+  const nunjucksEnv = nunjucks.configure(path.resolve(__dirname, '../../views/notices/pdfs/'), { autoescape: true })
+
+  return new Promise((resolve, reject) => {
+    nunjucksEnv.render(view, data, (err, result) => {
+      return err ? reject(err) : resolve(result)
+    })
+  })
+}
+
+module.exports = {
+  send
+}

--- a/app/views/notices/pdfs/preview-return-forms.njk
+++ b/app/views/notices/pdfs/preview-return-forms.njk
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>{{ title }}</title>
+</head>
+<body>
+<h1>{{ cover.title }}</h1>
+<p>This is a Nunjucks-rendered HTML page.</p>
+</body>
+</html>

--- a/test/requests/gotenberg.request.test.js
+++ b/test/requests/gotenberg.request.test.js
@@ -1,0 +1,123 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Things we need to stub
+const BaseRequest = require('../../app/requests/base.request.js')
+const requestConfig = require('../../config/request.config.js')
+
+// Thing under test
+const GotenbergRequest = require('../../app/requests/gotenberg.request.js')
+
+describe('Gotenberg Request', () => {
+  const headers = {}
+  const testRoute = 'TEST_ROUTE'
+
+  let formData
+  let pdfBytes
+
+  beforeEach(() => {
+    // Set the timeout value to 1234ms for these tests. We don't trigger a timeout but we do test that the module
+    // uses it when making a request to the charging module, rather than the default request timeout config value
+    Sinon.replace(requestConfig, 'gotenbergTimeout', 1234)
+    Sinon.replace(requestConfig, 'timeout', 1000)
+
+    formData = new FormData()
+    formData.append('index.html', new Blob([Buffer.from('<p>Test</p>')]), 'index.html')
+
+    pdfBytes = new TextEncoder().encode('%PDF-1.4\n%âãÏÓ\n').buffer
+  })
+
+  afterEach(() => {
+    Sinon.restore()
+  })
+
+  describe('#post', () => {
+    describe('when the request succeeds', () => {
+      beforeEach(async () => {
+        Sinon.stub(BaseRequest, 'post').resolves({
+          succeeded: true,
+          response: {
+            headers,
+            statusCode: 200,
+            body: pdfBytes
+          }
+        })
+      })
+
+      it('calls Gotenberg with the required options', async () => {
+        await GotenbergRequest.post(testRoute, formData)
+
+        const requestArgs = BaseRequest.post.firstCall.args
+
+        expect(requestArgs[0]).to.endWith('TEST_ROUTE')
+        expect(requestArgs[1].responseType).to.equal('buffer')
+        expect(requestArgs[1].body).to.equal(formData)
+      })
+
+      it('uses the Gotenberg timeout', async () => {
+        await GotenbergRequest.post(testRoute, formData)
+
+        const requestArgs = BaseRequest.post.firstCall.args
+
+        expect(requestArgs[1].timeout).to.equal({ request: 1234 })
+      })
+
+      it('returns a "true" success status', async () => {
+        const result = await GotenbergRequest.post(testRoute, formData)
+
+        expect(result.succeeded).to.be.true()
+      })
+
+      it('returns the response body as an array buffer', async () => {
+        const result = await GotenbergRequest.post(testRoute, formData)
+
+        expect(result.response.body).to.equal(pdfBytes)
+      })
+
+      it('returns the status code', async () => {
+        const result = await GotenbergRequest.post(testRoute, formData)
+
+        expect(result.response.statusCode).to.equal(200)
+      })
+    })
+
+    describe('when the request fails', () => {
+      beforeEach(async () => {
+        Sinon.stub(BaseRequest, 'post').resolves({
+          succeeded: false,
+          response: {
+            headers,
+            statusCode: 404,
+            statusMessage: 'Not Found',
+            body: { statusCode: 404, error: 'Not Found', message: 'Not Found' }
+          }
+        })
+      })
+
+      it('returns a "false" success status', async () => {
+        const result = await GotenbergRequest.post(testRoute, formData)
+
+        expect(result.succeeded).to.be.false()
+      })
+
+      it('returns the error response', async () => {
+        const result = await GotenbergRequest.post(testRoute, formData)
+
+        expect(result.response.body.message).to.equal('Not Found')
+      })
+
+      it('returns the status code', async () => {
+        const result = await GotenbergRequest.post(testRoute, formData)
+
+        expect(result.response.statusCode).to.equal(404)
+      })
+    })
+  })
+})

--- a/test/requests/gotenberg/generate-return-form.request.test.js
+++ b/test/requests/gotenberg/generate-return-form.request.test.js
@@ -1,0 +1,87 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Things we need to stub
+const GotenbergRequest = require('../../../app/requests/gotenberg.request.js')
+
+// Thing under test
+const GenerateReturnFormRequest = require('../../../app/requests/gotenberg/generate-return-form.request.js')
+
+describe('Gotenberg - Generate Return Form Request', () => {
+  let gotenbergRequestStub
+  let pageData
+  let pdfBytes
+
+  beforeEach(() => {
+    gotenbergRequestStub = Sinon.stub(GotenbergRequest, 'post')
+
+    pdfBytes = new TextEncoder().encode('%PDF-1.4\n%âãÏÓ\n').buffer
+
+    pageData = {
+      title: 'test file'
+    }
+
+    Sinon.spy(FormData.prototype, 'append')
+  })
+
+  afterEach(() => {
+    Sinon.restore()
+  })
+
+  describe('when the request can create a file', () => {
+    beforeEach(async () => {
+      gotenbergRequestStub.resolves({
+        succeeded: true,
+        response: {
+          statusCode: 204,
+          body: pdfBytes
+        }
+      })
+    })
+
+    it('returns a "true" success status', async () => {
+      const result = await GenerateReturnFormRequest.send(pageData)
+
+      expect(result.succeeded).to.be.true()
+    })
+
+    it('returns the data', async () => {
+      const result = await GenerateReturnFormRequest.send(pageData)
+
+      expect(result.response).to.equal({
+        statusCode: 204,
+        body: pdfBytes
+      })
+    })
+
+    it('calls "GotenbergRequest.post" with FormData containing the expected fields', async () => {
+      await GenerateReturnFormRequest.send(pageData)
+
+      expect(
+        GotenbergRequest.post.calledWithMatch('forms/chromium/convert/html', Sinon.match.instanceOf(FormData))
+      ).to.be.true()
+
+      // Check the html has been added to the form data
+      const appendCall = FormData.prototype.append.getCall(0)
+      expect(appendCall).to.exist()
+      const blob = appendCall.args[1]
+      expect(blob).to.be.instanceOf(Blob)
+      const content = await blob.text()
+      expect(content).to.include('<!DOCTYPE html>')
+
+      // Check all append calls
+      expect(FormData.prototype.append.calledWith('marginTop', '0')).to.be.true()
+      expect(FormData.prototype.append.calledWith('marginBottom', '0')).to.be.true()
+      expect(FormData.prototype.append.calledWith('marginLeft', '0')).to.be.true()
+      expect(FormData.prototype.append.calledWith('marginRight', '0')).to.be.true()
+      expect(FormData.prototype.append.calledWith('preferCssPageSize', 'true')).to.be.true()
+    })
+  })
+})


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5162

We recently introduced Gotenberg to handle converting html into a pdf.

This change adds the requests services to make the api call to Gotenberg.

This change also introduces the logic to convert nunjucks into a html string.