### PR TITLE
Allow zero when submitting a start reading

### DIFF
--- a/app/validators/return-logs/setup/start-reading.validator.js
+++ b/app/validators/return-logs/setup/start-reading.validator.js
@@ -26,16 +26,16 @@ function go(payload, lines) {
 
   const schema = Joi.object({
     startReading: Joi.number()
-      .positive()
+      .min(0)
       .integer()
       .required()
       .max(maxMeterReading)
       .messages({
         'any.required': 'Enter a start meter reading',
-        'number.base': 'Start meter reading must be a positive number',
+        'number.base': 'Start meter reading must 0 or higher',
         'number.max': maxValidationMessage,
         'number.unsafe': `Start meter reading exceeds the maximum of ${MAX_ALLOWED_READING}`,
-        'number.positive': 'Start meter reading must be a positive number',
+        'number.min': 'Start meter reading must not be negative',
         'number.integer': 'Start meter reading must be a whole number'
       })
   })

--- a/test/validators/return-logs/setup/start-reading.validator.test.js
+++ b/test/validators/return-logs/setup/start-reading.validator.test.js
@@ -41,6 +41,18 @@ describe('Return Logs Setup - Start Reading validator', () => {
         })
       })
 
+      describe('and the value is 0', () => {
+        beforeEach(() => {
+          payload = { startReading: '0' }
+        })
+
+        it('confirms the payload is valid', () => {
+          const result = StartReadingValidator.go(payload, lines)
+
+          expect(result.error).not.to.exist()
+        })
+      })
+
       describe('and the return lines do have an initial reading', () => {
         beforeEach(() => {
           payload = { startReading: '156000' }
@@ -75,11 +87,11 @@ describe('Return Logs Setup - Start Reading validator', () => {
         payload = { startReading: 'Test' }
       })
 
-      it('fails validation with the message "Start meter reading must be a positive number"', () => {
+      it('fails validation with the message "Start meter reading must 0 or higher"', () => {
         const result = StartReadingValidator.go(payload, lines)
 
         expect(result.error).to.exist()
-        expect(result.error.details[0].message).to.equal('Start meter reading must be a positive number')
+        expect(result.error.details[0].message).to.equal('Start meter reading must 0 or higher')
       })
     })
 
@@ -88,11 +100,11 @@ describe('Return Logs Setup - Start Reading validator', () => {
         payload = { startReading: '-1' }
       })
 
-      it('fails validation with the message "Start meter reading must be a positive number"', () => {
+      it('fails validation with the message "Start meter reading must not be negative"', () => {
         const result = StartReadingValidator.go(payload, lines)
 
         expect(result.error).to.exist()
-        expect(result.error.details[0].message).to.equal('Start meter reading must be a positive number')
+        expect(result.error.details[0].message).to.equal('Start meter reading must not be negative')
       })
     })
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5167

An issue was found in production where a user wanted to put in a starting reading of 0 but we only allow positive numbers. This was due to assuming that all users already have a meter and thus the reading should always be positive however it is possible for new meters to be provided and they will start at zero.

This PR updates the validation for the start reading page to allow for 0.