### PR TITLE
Submit international address

### DIFF
--- a/app/services/address/submit-international.service.js
+++ b/app/services/address/submit-international.service.js
@@ -29,7 +29,16 @@ async function go(sessionId, payload) {
     return {}
   }
 
-  const pageData = InternationalPresenter.go(session)
+  const _submittedData = {
+    id: session.id,
+    address: {
+      international: {
+        ...payload
+      }
+    }
+  }
+
+  const pageData = InternationalPresenter.go(_submittedData)
 
   return {
     error: validationResult,
@@ -38,6 +47,14 @@ async function go(sessionId, payload) {
 }
 
 async function _save(session, payload) {
+  session.address.international = {}
+  session.address.international.addressLine1 = payload.addressLine1
+  session.address.international.addressLine2 = payload.addressLine2 ?? null
+  session.address.international.addressLine3 = payload.addressLine3 ?? null
+  session.address.international.addressLine4 = payload.addressLine4 ?? null
+  session.address.international.country = payload.country
+  session.address.international.postcode = payload.postcode ?? null
+
   return session.$update()
 }
 
@@ -48,11 +65,20 @@ function _validate(payload) {
     return null
   }
 
-  const { message } = validation.error.details[0]
-
-  return {
-    text: message
+  const result = {
+    errorList: []
   }
+
+  validation.error.details.forEach((detail) => {
+    result.errorList.push({
+      href: `#${detail.context.key}`,
+      text: detail.message
+    })
+
+    result[detail.context.key] = detail.message
+  })
+
+  return result
 }
 
 module.exports = {

--- a/app/validators/address/international.validator.js
+++ b/app/validators/address/international.validator.js
@@ -25,7 +25,8 @@ function go(payload) {
       .required()
       .valid(...countries)
       .messages({
-        'any.required': 'Select a country'
+        'any.required': 'Select a country',
+        'any.only': 'Select a country'
       }),
     postcode: Joi.string().optional()
   })

--- a/test/services/address/submit-manual.service.test.js
+++ b/test/services/address/submit-manual.service.test.js
@@ -37,7 +37,7 @@ describe('Address - Submit Manual Service', () => {
       }
     })
 
-    it('saves the submitted value', async () => {
+    it('with a full payload it saves the submitted values', async () => {
       await SubmitManualService.go(session.id, payload)
 
       const refreshedSession = await session.$query()
@@ -53,7 +53,7 @@ describe('Address - Submit Manual Service', () => {
       })
     })
 
-    it('saves the submitted value', async () => {
+    it('with a min payload saves the submitted values', async () => {
       const minPayload = {
         addressLine1: '1 Fake Farm',
         postcode: 'SW1A 1AA'


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5047

As part of the journey to create ad-hoc letters to be sent out to users we need to be able to provide an address.

This PR adds in the functionality to submit the international address page. This is for when an address is outside the uk and a country must be provided.