### PR TITLE
Select how to contact recipient view page

### DIFF
--- a/app/presenters/notices/setup/contact-type.presenter.js
+++ b/app/presenters/notices/setup/contact-type.presenter.js
@@ -1,17 +1,31 @@
 'use strict'
 
 /**
- * Formats data for the `/notices/setup/{sessionId}/abstraction-alerts/contact-type` page
+ * Formats data for the `/notices/setup/{sessionId}/contact-type` page
  * @module ContactTypePresenter
  */
 
 /**
- * Formats data for the `/notices/setup/{sessionId}/abstraction-alerts/contact-type` page
+ * Formats data for the `/notices/setup/{sessionId}/contact-type` page
+ *
+ * @param {SessionModel} session - The session instance
  *
  * @returns {object} - The data formatted for the view template
  */
-function go() {
-  return {}
+function go(session) {
+  const { contactType, id } = session
+
+  const email = contactType?.email ?? null
+  const name = contactType?.name ?? null
+  const type = contactType?.type ?? null
+
+  return {
+    backLink: `/system/notices/setup/${id}/select-recipients`,
+    email,
+    name,
+    pageTitle: 'Select how to contact the recipient',
+    type
+  }
 }
 
 module.exports = {

--- a/app/services/notices/setup/contact-type.service.js
+++ b/app/services/notices/setup/contact-type.service.js
@@ -10,7 +10,7 @@ const ContactTypePresenter = require('../../../presenters/notices/setup/contact-
 const SessionModel = require('../../../models/session.model.js')
 
 /**
- * Orchestrates fetching and presenting the data for the `` page
+ * Orchestrates fetching and presenting the data for the `/notices/setup/{sessionId}/contact-type` page
  *
  * @param {string} sessionId
  *
@@ -22,6 +22,7 @@ async function go(sessionId) {
   const pageData = ContactTypePresenter.go(session)
 
   return {
+    activeNavBar: 'manage',
     ...pageData
   }
 }

--- a/app/services/notices/setup/submit-contact-type.service.js
+++ b/app/services/notices/setup/submit-contact-type.service.js
@@ -11,7 +11,7 @@ const ContactTypeValidator = require('../../../validators/notices/setup/contact-
 const SessionModel = require('../../../models/session.model.js')
 
 /**
- * Orchestrates validating the data for `` page
+ * Orchestrates validating the data for `/notices/setup/{sessionId}/contact-type` page
  *
  * @param {string} sessionId
  * @param {object} payload - The submitted form data

--- a/app/views/notices/setup/contact-type.njk
+++ b/app/views/notices/setup/contact-type.njk
@@ -3,6 +3,8 @@
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
 
 {% block breadcrumbs %}
   {{
@@ -21,12 +23,65 @@
     }) }}
   {%endif%}
 
+  {% set emailHtml %}
+    {{ govukInput({
+      id: "email",
+      name: "email",
+      type: "email",
+      autocomplete: "email",
+      spellcheck: false,
+      errorMessage: error.email,
+      classes: 'govuk-!-width-two-thirds',
+      label: {
+        classes: 'govuk-!-font-weight-bold govuk-!-width-two-thirds',
+        text: "Email address"
+      }
+    }) }}
+  {% endset -%}
+
+  {% set nameHtml %}
+    {{ govukInput({
+      id: "name",
+      name: "name",
+      type: "name",
+      classes: 'govuk-!-width-two-thirds',
+      errorMessage: error.name,
+      label: {
+        classes: 'govuk-!-font-weight-bold',
+        text: "Recipients name"
+      }
+    }) }}
+  {% endset -%}
+
   <h1 class="govuk-form-group govuk-heading-l">
     {{ pageTitle }}
   </h1>
 
   <form method="post">
     <input type="hidden" name="wrlsCrumb" value="{{wrlsCrumb}}"/>
+
+    {{ govukRadios({
+      id: 'type',
+      name: 'type',
+      items: [
+        {
+          id: 'email',
+          value: 'email',
+          text: 'Email',
+          conditional: {
+            html: emailHtml
+          }
+        },{
+          id: 'post',
+          value: 'post',
+          text: 'Post',
+          conditional: {
+            html: nameHtml
+          }
+        }
+      ],
+      errorMessage: error.type
+    }) }}
 
     {{ govukButton({ text: "Continue", preventDoubleClick: true }) }}
   </form>

--- a/test/presenters/notices/setup/contact-type.presenter.test.js
+++ b/test/presenters/notices/setup/contact-type.presenter.test.js
@@ -13,15 +13,67 @@ const ContactTypePresenter = require('../../../../app/presenters/notices/setup/c
 describe('Contact Type Presenter', () => {
   let session
 
-  beforeEach(() => {
-    session = {}
-  })
+  describe('when called with no session data', () => {
+    beforeEach(() => {
+      session = {}
+    })
 
-  describe('when called', () => {
     it('returns page data for the view', () => {
       const result = ContactTypePresenter.go(session)
 
-      expect(result).to.equal({})
+      expect(result).to.equal({
+        backLink: `/system/notices/setup/${session.id}/select-recipients`,
+        email: null,
+        name: null,
+        pageTitle: 'Select how to contact the recipient',
+        type: null
+      })
+    })
+  })
+
+  describe('when called with an email address', () => {
+    beforeEach(() => {
+      session = {
+        contactType: {
+          email: 'test@test.gov.uk',
+          type: 'email'
+        }
+      }
+    })
+
+    it('returns page data for the view', () => {
+      const result = ContactTypePresenter.go(session)
+
+      expect(result).to.equal({
+        backLink: `/system/notices/setup/${session.id}/select-recipients`,
+        email: 'test@test.gov.uk',
+        name: null,
+        pageTitle: 'Select how to contact the recipient',
+        type: 'email'
+      })
+    })
+  })
+
+  describe('when called with a name', () => {
+    beforeEach(() => {
+      session = {
+        contactType: {
+          name: 'Fake Person',
+          type: 'post'
+        }
+      }
+    })
+
+    it('returns page data for the view', () => {
+      const result = ContactTypePresenter.go(session)
+
+      expect(result).to.equal({
+        backLink: `/system/notices/setup/${session.id}/select-recipients`,
+        email: null,
+        name: 'Fake Person',
+        pageTitle: 'Select how to contact the recipient',
+        type: 'post'
+      })
     })
   })
 })

--- a/test/services/notices/setup/contact-type.service.test.js
+++ b/test/services/notices/setup/contact-type.service.test.js
@@ -17,17 +17,76 @@ describe('Contact Type Service', () => {
   let session
   let sessionData
 
-  beforeEach(async () => {
-    sessionData = {}
+  describe('when called with no saved data', () => {
+    beforeEach(async () => {
+      sessionData = {}
 
-    session = await SessionHelper.add({ data: sessionData })
-  })
+      session = await SessionHelper.add({ data: sessionData })
+    })
 
-  describe('when called', () => {
     it('returns page data for the view', async () => {
       const result = await ContactTypeService.go(session.id)
 
-      expect(result).to.equal({})
+      expect(result).to.equal({
+        activeNavBar: 'manage',
+        backLink: `/system/notices/setup/${session.id}/select-recipients`,
+        email: null,
+        name: null,
+        pageTitle: 'Select how to contact the recipient',
+        type: null
+      })
+    })
+  })
+
+  describe('when called with a saved email address', () => {
+    beforeEach(async () => {
+      sessionData = {
+        contactType: {
+          email: 'test@test.gov.uk',
+          type: 'email'
+        }
+      }
+
+      session = await SessionHelper.add({ data: sessionData })
+    })
+
+    it('returns page data for the view', async () => {
+      const result = await ContactTypeService.go(session.id)
+
+      expect(result).to.equal({
+        activeNavBar: 'manage',
+        backLink: `/system/notices/setup/${session.id}/select-recipients`,
+        email: 'test@test.gov.uk',
+        name: null,
+        pageTitle: 'Select how to contact the recipient',
+        type: 'email'
+      })
+    })
+  })
+
+  describe('when called with a saved name', () => {
+    beforeEach(async () => {
+      sessionData = {
+        contactType: {
+          name: 'Fake Person',
+          type: 'post'
+        }
+      }
+
+      session = await SessionHelper.add({ data: sessionData })
+    })
+
+    it('returns page data for the view', async () => {
+      const result = await ContactTypeService.go(session.id)
+
+      expect(result).to.equal({
+        activeNavBar: 'manage',
+        backLink: `/system/notices/setup/${session.id}/select-recipients`,
+        email: null,
+        name: 'Fake Person',
+        pageTitle: 'Select how to contact the recipient',
+        type: 'post'
+      })
     })
   })
 })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5043

When a licence version has been changed either by conditions or someone else taking it over we some times need to send out ad hoc notifications to users. This page is part of the journey to create those notification and send them.

This PR sets up the select a recipient contact type for viewing page.