### PR TITLE
Show all purposes in return log pages

### DIFF
--- a/app/presenters/base.presenter.js
+++ b/app/presenters/base.presenter.js
@@ -219,6 +219,43 @@ function formatPounds(valueInPence) {
 }
 
 /**
+ * Format the purposes for display on screen
+ *
+ * This function assumes that when provided the purposes are in the format:
+ *
+ * ```javascript
+ * [{
+ *  alias: 'manual description',
+ *  primary: { code: 'A', description: 'Agriculture' },
+ *  tertiary: { code: '400', description: 'Spray Irrigation - Direct' },
+ *  secondary: { code: 'AGR', description: 'General Agriculture' }
+ * }]
+ * ```
+ *
+ * It is possible that a return log has zero or more purposes associated it. If this is the case we need the description
+ * of each purpose from the array of purposes to be concatenated into a single comma separated string ready to present.
+ *
+ * @param {Array} purposes - the purposes taken from the return logs metadata
+ *
+ * @returns {string} the purpose descriptions as a string, separated by commas if more than one description exists
+ */
+function formatPurposes(purposes) {
+  if (!purposes || purposes.length === 0) {
+    return ''
+  }
+
+  const purposeDescriptionArray = purposes.map((purpose) => {
+    if (purpose.alias) {
+      return `${purpose.tertiary.description} (${purpose.alias})`
+    }
+
+    return purpose.tertiary.description
+  })
+
+  return purposeDescriptionArray
+}
+
+/**
  * Formats a value and unit to be displayed without a space, as per the GOV UK style guide
  *
  * For example, a value of 100 and a unit of Ml/d will be formatted as '100Ml/d'.
@@ -297,6 +334,7 @@ module.exports = {
   formatMoney,
   formatNumber,
   formatPounds,
+  formatPurposes,
   formatQuantity,
   formatValueUnit,
   leftPadZeroes,

--- a/app/presenters/bill-runs/review/base-review.presenter.js
+++ b/app/presenters/bill-runs/review/base-review.presenter.js
@@ -202,24 +202,6 @@ function formatIssues(issues) {
 }
 
 /**
- * Format the purposes for a review return
- *
- * It is possible that a return log has more than one purpose associated it. If this is the case we need the description
- * of each purpose from the array of purposes to be concatenated into a single comma separated string ready to present.
- *
- * @param {Array} purposes - the purposes taken from the return logs metadata
- *
- * @returns {string} the purpose descriptions as a string, separated by commas if more than one description exists
- */
-function formatPurposes(purposes) {
-  const purposeDescriptionArray = purposes.map((purpose) => {
-    return purpose.tertiary.description
-  })
-
-  return purposeDescriptionArray.join(', ')
-}
-
-/**
  * Format the status for a review return, for example, 'overdue'
  *
  * We cannot just return the status from the DB for a return because of the disparity between what we show and how the
@@ -278,7 +260,6 @@ module.exports = {
   formatChargePeriod,
   formatChargePeriods,
   formatIssues,
-  formatPurposes,
   formatReturnStatus,
   formatReturnTotals
 }

--- a/app/presenters/bill-runs/review/review-licence.presenter.js
+++ b/app/presenters/bill-runs/review/review-licence.presenter.js
@@ -5,7 +5,12 @@
  * @module ReviewLicencePresenter
  */
 
-const { formatAbstractionPeriod, formatFinancialYear, formatLongDate } = require('../../base.presenter.js')
+const {
+  formatAbstractionPeriod,
+  formatFinancialYear,
+  formatLongDate,
+  formatPurposes
+} = require('../../base.presenter.js')
 const { generateBillRunTitle } = require('../../billing.presenter.js')
 const {
   calculateTotalBillableReturns,
@@ -13,7 +18,6 @@ const {
   formatChargePeriod,
   formatChargePeriods,
   formatIssues,
-  formatPurposes,
   formatReturnStatus,
   formatReturnTotals
 } = require('./base-review.presenter.js')
@@ -182,7 +186,7 @@ function _formatReviewReturns(reviewReturns) {
       abstractionPeriod: formatAbstractionPeriod(periodStartDay, periodStartMonth, periodEndDay, periodEndMonth),
       description,
       issues: formatIssues(issues),
-      purpose: formatPurposes(purposes),
+      purpose: formatPurposes(purposes).join(', '),
       reference: returnReference,
       returnId,
       returnLink: determineReturnLink(reviewReturn),

--- a/app/presenters/licences/view-licence-returns.presenter.js
+++ b/app/presenters/licences/view-licence-returns.presenter.js
@@ -6,8 +6,7 @@
  */
 
 const FeatureFlagsConfig = require('../../../config/feature-flags.config.js')
-const { formatLongDate } = require('../base.presenter.js')
-const { formatPurpose } = require('../return-logs/base-return-logs.presenter.js')
+const { formatLongDate, formatPurposes } = require('../base.presenter.js')
 
 const DUE_PERIOD_DAYS = 27
 
@@ -69,7 +68,7 @@ function _returns(returns, canManageReturns) {
       description: metadata.description === 'null' ? '' : metadata.description,
       dueDate: formatLongDate(new Date(dueDate)),
       link: _link(status, returnLogId, canManageReturns),
-      purpose: formatPurpose(metadata.purposes),
+      purpose: formatPurposes(metadata.purposes),
       reference: returnReference,
       returnLogId,
       status: _status(returnLog)

--- a/app/presenters/return-logs/base-return-logs.presenter.js
+++ b/app/presenters/return-logs/base-return-logs.presenter.js
@@ -44,32 +44,6 @@ function formatMeterDetails(meter) {
 }
 
 /**
- * Formats a return log's purposes into a string for display in the UI
- *
- * 99.999% of return logs the `metadata` field's `purposes` property is set. But there are 38 that we know of where
- * the return version information was deleted yet.
- *
- * The water-abstraction-import service still created return logs in WRLS, but they are missing key details like
- * purposes, points and the abstraction period.
- *
- * We don't want these few to block access to other returns for a licence. So, we have to handle them in code.
- *
- * @param {string[]} purposes - the list of purposes taken from the return log's metadata field
- *
- * @returns {string|null} The first purpose's alias, else tertiary description of the first purpose else an empty string
- * if purposes is empty
- */
-function formatPurpose(purposes) {
-  if (!purposes || purposes.length === 0) {
-    return ''
-  }
-
-  const [firstPurpose] = purposes
-
-  return firstPurpose.alias ? firstPurpose.alias : firstPurpose.tertiary.description
-}
-
-/**
  * Formats the status for a return log, adjusting for specific conditions.
  *
  * If the return log's status is 'completed', it will be displayed as 'complete'. If the status is 'due', but there are
@@ -277,7 +251,6 @@ function _linkDetails(id, method, frequency, endDate, rootPath) {
 module.exports = {
   convertToCubicMetres,
   formatMeterDetails,
-  formatPurpose,
   formatStatus,
   generateSummaryTableHeaders,
   generateSummaryTableRows

--- a/app/presenters/return-logs/view-return-log.presenter.js
+++ b/app/presenters/return-logs/view-return-log.presenter.js
@@ -5,10 +5,9 @@
  * @module ViewReturnLogPresenter
  */
 
-const { formatAbstractionPeriod, formatLongDate, formatNumber } = require('../base.presenter.js')
+const { formatAbstractionPeriod, formatLongDate, formatNumber, formatPurposes } = require('../base.presenter.js')
 const {
   formatMeterDetails,
-  formatPurpose,
   formatStatus,
   generateSummaryTableHeaders,
   generateSummaryTableRows
@@ -62,7 +61,7 @@ function go(returnLog, auth) {
     method,
     nilReturn: selectedReturnSubmission ? selectedReturnSubmission.nilReturn : false,
     pageTitle: 'Abstraction return',
-    purpose: formatPurpose(purposes),
+    purpose: formatPurposes(purposes),
     receivedDate: receivedDate ? formatLongDate(receivedDate) : null,
     returnReference,
     returnPeriod: `${formatLongDate(startDate)} to ${formatLongDate(endDate)}`,

--- a/app/views/licences/tabs/returns.njk
+++ b/app/views/licences/tabs/returns.njk
@@ -1,6 +1,7 @@
 {% from "govuk/components/pagination/macro.njk" import govukPagination %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
 
+{% from "macros/new-line-array-items.njk" import newLineArrayItems %}
 {% from "macros/return-status-tag.njk" import statusTag %}
 
 {% macro referenceColumn(return) %}
@@ -39,7 +40,7 @@
         attributes: { 'data-test': 'return-reference-' + rowIndex }
       },
       {
-        html:  purpose +  "<p class=\"govuk-body-s\">" + returnItem.description + "</p>",
+        html:  newLineArrayItems(purpose) +  "<p class=\"govuk-body-s\">" + returnItem.description + "</p>",
         attributes: { 'data-test': 'return-purpose-' + rowIndex }
       },
       {

--- a/app/views/return-logs/view.njk
+++ b/app/views/return-logs/view.njk
@@ -9,6 +9,7 @@
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 
+{% from "macros/new-line-array-items.njk" import newLineArrayItems %}
 {% from "macros/return-status-tag.njk" import statusTag %}
 
 {% block breadcrumbs %}
@@ -68,7 +69,7 @@
             },
             {
               key: { text: "Purpose", classes: "meta-data__label" },
-              value: { html: '<span data-test="purpose">' + purpose + '</span>', classes: "meta-data__value" }
+              value: { html: '<span data-test="purpose">' + newLineArrayItems(purpose) + '</span>', classes: "meta-data__value" }
             },
             {
               key: { text: "Return period", classes: "meta-data__label" },

--- a/test/presenters/base.presenter.test.js
+++ b/test/presenters/base.presenter.test.js
@@ -248,6 +248,74 @@ describe('Base presenter', () => {
     })
   })
 
+  describe('#formatPurposes()', () => {
+    let purposes
+
+    describe('when there is a single purpose', () => {
+      beforeEach(() => {
+        purposes = [{ tertiary: { description: 'Spray Irrigation - Direct' } }]
+      })
+
+      it('returns the purpose description', () => {
+        const result = BasePresenter.formatPurposes(purposes)
+
+        expect(result).to.equal(['Spray Irrigation - Direct'])
+      })
+    })
+
+    describe('when there is a single purpose with an alias', () => {
+      beforeEach(() => {
+        purposes = [{ alias: 'This is an alias', tertiary: { description: 'Spray Irrigation - Direct' } }]
+      })
+
+      it('returns the purpose description', () => {
+        const result = BasePresenter.formatPurposes(purposes)
+
+        expect(result).to.equal(['Spray Irrigation - Direct (This is an alias)'])
+      })
+    })
+
+    describe('when there is more than one purpose', () => {
+      beforeEach(() => {
+        purposes = [
+          { tertiary: { description: 'Spray Irrigation - Direct' } },
+          { tertiary: { description: 'Spray Irrigation - Anti Frost' } },
+          { tertiary: { description: 'Spray Irrigation - Storage' } }
+        ]
+      })
+
+      it('returns the purpose descriptions as a comma separated string', () => {
+        const result = BasePresenter.formatPurposes(purposes)
+
+        expect(result).to.equal([
+          'Spray Irrigation - Direct',
+          'Spray Irrigation - Anti Frost',
+          'Spray Irrigation - Storage'
+        ])
+      })
+    })
+
+    describe('when there is more than one purpose with some having aliases', () => {
+      beforeEach(() => {
+        purposes = [
+          { alias: 'This is an alias', tertiary: { description: 'Spray Irrigation - Direct' } },
+          { tertiary: { description: 'Spray Irrigation - Anti Frost' } },
+          { tertiary: { description: 'Spray Irrigation - Storage' } }
+        ]
+      })
+
+      it('returns the purpose descriptions as a comma separated string', () => {
+        const result = BasePresenter.formatPurposes(purposes)
+
+        expect(result).to.equal([
+          'Spray Irrigation - Direct (This is an alias)',
+          'Spray Irrigation - Anti Frost',
+          'Spray Irrigation - Storage'
+        ])
+      })
+    })
+  })
+
   describe('#formatValueUnit()', () => {
     it('correctly formats the given value and unit, for example, 100 and Ml/d is formatted as 100Ml/d', () => {
       const result = BasePresenter.formatValueUnit(100, 'Ml/d')

--- a/test/presenters/bill-runs/review/base-review.presenter.test.js
+++ b/test/presenters/bill-runs/review/base-review.presenter.test.js
@@ -330,38 +330,6 @@ describe('Bill Runs Review - Base Review presenter', () => {
     })
   })
 
-  describe('#formatPurposes()', () => {
-    let purposes
-
-    describe('when there is a single purpose', () => {
-      beforeEach(() => {
-        purposes = [{ tertiary: { description: 'Spray Irrigation - Direct' } }]
-      })
-
-      it('returns the purpose description', () => {
-        const result = BaseReviewPresenter.formatPurposes(purposes)
-
-        expect(result).to.equal('Spray Irrigation - Direct')
-      })
-    })
-
-    describe('when there is more than one purpose', () => {
-      beforeEach(() => {
-        purposes = [
-          { tertiary: { description: 'Spray Irrigation - Direct' } },
-          { tertiary: { description: 'Spray Irrigation - Anti Frost' } },
-          { tertiary: { description: 'Spray Irrigation - Storage' } }
-        ]
-      })
-
-      it('returns the purpose descriptions as a comma separated string', () => {
-        const result = BaseReviewPresenter.formatPurposes(purposes)
-
-        expect(result).to.equal('Spray Irrigation - Direct, Spray Irrigation - Anti Frost, Spray Irrigation - Storage')
-      })
-    })
-  })
-
   describe('#formatReturnStatus()', () => {
     let reviewReturn
 

--- a/test/presenters/licences/view-licence-returns.presenter.test.js
+++ b/test/presenters/licences/view-licence-returns.presenter.test.js
@@ -53,7 +53,7 @@ describe('Licences - View Licence Returns presenter', () => {
             description: 'empty description',
             dueDate: '28 November 2012',
             link: '/system/return-logs?id=v1:1:01/123:10046821:2020-01-02:2020-02-01',
-            purpose: 'SPRAY IRRIGATION',
+            purpose: ['Spray Irrigation - Direct (SPRAY IRRIGATION)'],
             reference: '10046821',
             returnLogId: 'v1:1:01/123:10046821:2020-01-02:2020-02-01',
             status: 'complete'
@@ -63,7 +63,7 @@ describe('Licences - View Licence Returns presenter', () => {
             description: 'empty description',
             dueDate: '28 November 2012',
             link: '/system/return-logs?id=v1:1:01/123:10046820:2020-01-02:2020-02-01',
-            purpose: 'SPRAY IRRIGATION',
+            purpose: ['Spray Irrigation - Direct (SPRAY IRRIGATION)'],
             reference: '10046820',
             returnLogId: 'v1:1:01/123:10046820:2020-01-02:2020-02-01',
             status: 'overdue'

--- a/test/presenters/return-logs/base-return-logs.presenter.test.js
+++ b/test/presenters/return-logs/base-return-logs.presenter.test.js
@@ -125,61 +125,6 @@ describe('Base Return Logs presenter', () => {
     })
   })
 
-  describe('#formatPurpose()', () => {
-    let purposes
-
-    beforeEach(() => {
-      purposes = [
-        { alias: null, tertiary: { description: 'Mineral Washing' } },
-        { alias: null, tertiary: { description: 'Spray irrigation' } }
-      ]
-    })
-
-    describe('when the first purpose has an alias', () => {
-      beforeEach(() => {
-        purposes[0].alias = 'Mineral Washing alias'
-      })
-
-      it('returns the alias', () => {
-        const result = BaseReturnLogsPresenter.formatPurpose(purposes)
-
-        expect(result).to.equal('Mineral Washing alias')
-      })
-    })
-
-    describe('when the first purpose has no alias', () => {
-      it('returns the tertiary description', () => {
-        const result = BaseReturnLogsPresenter.formatPurpose(purposes)
-
-        expect(result).to.equal('Mineral Washing')
-      })
-    })
-
-    describe('when there are no purposes', () => {
-      beforeEach(() => {
-        purposes = []
-      })
-
-      it('returns an empty string', () => {
-        const result = BaseReturnLogsPresenter.formatPurpose(purposes)
-
-        expect(result).to.equal('')
-      })
-    })
-
-    describe('when purposes is undefined', () => {
-      beforeEach(() => {
-        purposes = undefined
-      })
-
-      it('returns an empty string', () => {
-        const result = BaseReturnLogsPresenter.formatPurpose(purposes)
-
-        expect(result).to.equal('')
-      })
-    })
-  })
-
   describe('#formatStatus()', () => {
     const testReturnLog = { dueDate: new Date() }
 

--- a/test/presenters/return-logs/view-return-log.presenter.test.js
+++ b/test/presenters/return-logs/view-return-log.presenter.test.js
@@ -64,7 +64,7 @@ describe('Return Logs - View Return Log presenter', () => {
       method: 'abstractionVolumes',
       nilReturn: false,
       pageTitle: 'Abstraction return',
-      purpose: 'Mineral Washing alias',
+      purpose: ['Mineral Washing (Mineral Washing alias)'],
       receivedDate: '12 April 2023',
       returnReference: returnLog.returnReference,
       returnPeriod: '1 April 2022 to 31 March 2023',

--- a/test/services/return-logs/view-return-log.service.test.js
+++ b/test/services/return-logs/view-return-log.service.test.js
@@ -24,7 +24,10 @@ describe('View Return Log service', () => {
   beforeEach(() => {
     const mockReturnLog = ReturnLogModel.fromJson({
       ...ReturnLogHelper.defaults({
-        purposes: [{ alias: 'PURPOSE_ALIAS' }]
+        metadata: {
+          ...ReturnLogHelper.defaults().metadata,
+          purposes: [{ alias: 'PURPOSE_ALIAS', description: 'PURPOSE_DESCRIPTION' }]
+        }
       }),
       licence: LicenceModel.fromJson(LicenceHelper.defaults())
     })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5150

A user pointed out that we're not displaying the full list of purposes in two places but did point out where it was displayed correctly. Having dug into the code and looking at where else we show the purposes I noticed we're doing it in two places already so I've pulled the code for it out of both of those places, combined it so it includes the break clause for being handed an empty array and then started calling it from the various places it needs to be seen so we are consistent across the site.   