### PR TITLE
Update notices setup recipients

### DIFF
--- a/app/presenters/notices/setup/check.presenter.js
+++ b/app/presenters/notices/setup/check.presenter.js
@@ -5,7 +5,7 @@
  * @module CheckPresenter
  */
 
-const NotifyAddressPresenter = require('./notify-address.presenter.js')
+const ContactPresenter = require('./contact.presenter.js')
 const { defaultPageSize } = require('../../../../config/database.config.js')
 
 const NOTIFICATION_TYPES = {
@@ -42,27 +42,9 @@ function go(recipients, page, pagination, session) {
   }
 }
 
-/**
- * Contact can be an email or an address (letter)
- *
- * If it is an address then we convert the contact CSV string to an array. If it is an email we return the email in
- * array for the UI to have consistent formatting.
- *
- * @private
- */
-function _contact(recipient) {
-  if (recipient.email) {
-    return [recipient.email]
-  }
-
-  const notifyAddress = NotifyAddressPresenter.go(recipient.contact)
-
-  return Object.values(notifyAddress)
-}
-
 function _formatRecipients(noticeType, recipients, sessionId) {
   return recipients.map((recipient) => {
-    const contact = _contact(recipient)
+    const contact = ContactPresenter.go(recipient)
 
     return {
       contact,

--- a/app/presenters/notices/setup/contact.presenter.js
+++ b/app/presenters/notices/setup/contact.presenter.js
@@ -1,0 +1,31 @@
+'use strict'
+
+/**
+ * Formats a recipient into a contact
+ * @module ContactPresenter
+ */
+
+const NotifyAddressPresenter = require('./notify-address.presenter.js')
+
+/**
+ * Formats a recipient into a contact
+ *
+ * Contact can be an email or an address (letter)
+ *
+ * If it is an address then we convert the contact CSV string to an array. If it is an email we return the email in
+ * array for the UI to have consistent formatting.
+ * @param recipient
+ *
+ * @returns {object} - a contact
+ */
+function go(recipient) {
+  if (recipient.email) {
+    return [recipient.email]
+  }
+
+  const notifyAddress = NotifyAddressPresenter.go(recipient.contact)
+
+  return Object.values(notifyAddress)
+}
+
+module.exports = { go }

--- a/app/presenters/notices/setup/contact.presenter.js
+++ b/app/presenters/notices/setup/contact.presenter.js
@@ -14,7 +14,8 @@ const NotifyAddressPresenter = require('./notify-address.presenter.js')
  *
  * If it is an address then we convert the contact CSV string to an array. If it is an email we return the email in
  * array for the UI to have consistent formatting.
- * @param recipient
+ *
+ * @param {object} recipient
  *
  * @returns {object} - a contact
  */

--- a/app/services/notices/setup/check.service.js
+++ b/app/services/notices/setup/check.service.js
@@ -6,10 +6,8 @@
  */
 
 const CheckPresenter = require('../../../presenters/notices/setup/check.presenter.js')
-const DetermineRecipientsService = require('./determine-recipients.service.js')
-const FetchAbstractionAlertRecipientsService = require('./fetch-abstraction-alert-recipients.service.js')
-const FetchRecipientsService = require('./fetch-recipients.service.js')
 const PaginatorPresenter = require('../../../presenters/paginator.presenter.js')
+const RecipientsService = require('./recipients.service.js')
 const SessionModel = require('../../../models/session.model.js')
 
 /**
@@ -23,15 +21,7 @@ const SessionModel = require('../../../models/session.model.js')
 async function go(sessionId, page = 1) {
   const session = await SessionModel.query().findById(sessionId)
 
-  let recipientsData
-
-  if (session.journey === 'alerts') {
-    recipientsData = await FetchAbstractionAlertRecipientsService.go(session)
-  } else {
-    recipientsData = await FetchRecipientsService.go(session)
-  }
-
-  const recipients = DetermineRecipientsService.go(recipientsData)
+  const recipients = await RecipientsService.go(session)
 
   const pagination = PaginatorPresenter.go(recipients.length, Number(page), `/system/notices/setup/${sessionId}/check`)
 

--- a/app/services/notices/setup/recipients.service.js
+++ b/app/services/notices/setup/recipients.service.js
@@ -1,0 +1,35 @@
+'use strict'
+
+/**
+ * Orchestrates fetching and determining recipients
+ * @module RecipientsService
+ */
+
+const FetchAbstractionAlertRecipientsService = require('./fetch-abstraction-alert-recipients.service.js')
+const FetchRecipientsService = require('./fetch-recipients.service.js')
+const DetermineRecipientsService = require('./determine-recipients.service.js')
+
+/**
+ * Orchestrates fetching and determining recipients
+ *
+ * Fetches the recipients based on the journey type and determines recipients (remove duplicates).
+ *
+ * @param session
+ *
+ * @returns {Promise<object[]>} - recipients
+ */
+async function go(session) {
+  let recipientsData
+
+  if (session.journey === 'alerts') {
+    recipientsData = await FetchAbstractionAlertRecipientsService.go(session)
+  } else {
+    recipientsData = await FetchRecipientsService.go(session)
+  }
+
+  return DetermineRecipientsService.go(recipientsData)
+}
+
+module.exports = {
+  go
+}

--- a/app/services/notices/setup/recipients.service.js
+++ b/app/services/notices/setup/recipients.service.js
@@ -14,7 +14,7 @@ const DetermineRecipientsService = require('./determine-recipients.service.js')
  *
  * Fetches the recipients based on the journey type and determines recipients (remove duplicates).
  *
- * @param session
+ * @param {module:SessionModel} session - The session instance
  *
  * @returns {Promise<object[]>} - recipients
  */

--- a/app/services/notices/setup/submit-check.service.js
+++ b/app/services/notices/setup/submit-check.service.js
@@ -8,9 +8,7 @@
 const BatchNotificationsService = require('./batch-notifications.service.js')
 const CreateNoticePresenter = require('../../../presenters/notices/setup/create-notice.presenter.js')
 const CreateNoticeService = require('./create-notice.service.js')
-const DetermineRecipientsService = require('./determine-recipients.service.js')
-const FetchAbstractionAlertRecipientsService = require('./fetch-abstraction-alert-recipients.service.js')
-const FetchRecipientsService = require('./fetch-recipients.service.js')
+const RecipientsService = require('./recipients.service.js')
 const SessionModel = require('../../../models/session.model.js')
 const { currentTimeInNanoseconds, calculateAndLogTimeTaken } = require('../../../lib/general.lib.js')
 
@@ -27,7 +25,7 @@ const { currentTimeInNanoseconds, calculateAndLogTimeTaken } = require('../../..
 async function go(sessionId, auth) {
   const session = await SessionModel.query().findById(sessionId)
 
-  const recipients = await _recipients(session)
+  const recipients = await RecipientsService.go(session)
 
   const notice = await _notice(session, recipients, auth)
 
@@ -56,18 +54,6 @@ async function _processNotifications(session, recipients, notice) {
   } catch (error) {
     global.GlobalNotifier.omfg('Send notifications failed', { notice }, error)
   }
-}
-
-async function _recipients(session) {
-  let recipientsData
-
-  if (session.journey === 'alerts') {
-    recipientsData = await FetchAbstractionAlertRecipientsService.go(session)
-  } else {
-    recipientsData = await FetchRecipientsService.go(session)
-  }
-
-  return DetermineRecipientsService.go(recipientsData)
 }
 
 module.exports = {

--- a/test/presenters/notices/setup/contact.presenter.test.js
+++ b/test/presenters/notices/setup/contact.presenter.test.js
@@ -1,0 +1,59 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Test helpers
+const RecipientsFixture = require('../../../fixtures/recipients.fixtures.js')
+
+// Thing under test
+const ContactPresenter = require('../../../../app/presenters/notices/setup/contact.presenter.js')
+
+describe('Notices - Setup - Contact presenter', () => {
+  let recipients
+
+  beforeEach(() => {
+    recipients = RecipientsFixture.recipients()
+  })
+
+  describe('when the recipient is an email', () => {
+    it('should return the email address', () => {
+      const result = ContactPresenter.go(recipients.primaryUser)
+
+      expect(result).to.equal(['primary.user@important.com'])
+    })
+  })
+
+  describe('when the recipient is an address', () => {
+    describe('and it is valid', () => {
+      it('should return the postal address', () => {
+        const result = ContactPresenter.go(recipients.licenceHolder)
+
+        expect(result).to.equal(['Mr H J Licence holder', '1', 'Privet Drive', 'Little Whinging', 'Surrey', 'WD25 7LR'])
+      })
+    })
+
+    describe('and it is invalid', () => {
+      beforeEach(() => {
+        recipients.licenceHolder.contact.postcode = null
+      })
+
+      it('should return the postal address flagged as INVALID', () => {
+        const result = ContactPresenter.go(recipients.licenceHolder)
+
+        expect(result).to.equal([
+          'Mr H J Licence holder',
+          'INVALID ADDRESS - Needs a valid postcode or country outside the UK',
+          '1',
+          'Privet Drive',
+          'Little Whinging',
+          'Surrey'
+        ])
+      })
+    })
+  })
+})

--- a/test/services/notices/setup/check.service.test.js
+++ b/test/services/notices/setup/check.service.test.js
@@ -9,10 +9,12 @@ const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const FetchAbstractionAlertRecipientsService = require('../../../../app/services/notices/setup/fetch-abstraction-alert-recipients.service.js')
-const FetchRecipientsService = require('../../../../app/services/notices/setup/fetch-recipients.service.js')
 const RecipientsFixture = require('../../../fixtures/recipients.fixtures.js')
 const SessionHelper = require('../../../support/helpers/session.helper.js')
+
+// Things we need to stub
+const FetchAbstractionAlertRecipientsService = require('../../../../app/services/notices/setup/fetch-abstraction-alert-recipients.service.js')
+const FetchRecipientsService = require('../../../../app/services/notices/setup/fetch-recipients.service.js')
 
 // Thing under test
 const CheckService = require('../../../../app/services/notices/setup/check.service.js')

--- a/test/services/notices/setup/recipients.service.test.js
+++ b/test/services/notices/setup/recipients.service.test.js
@@ -1,0 +1,83 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Test helpers
+const FetchAbstractionAlertRecipientsService = require('../../../../app/services/notices/setup/fetch-abstraction-alert-recipients.service.js')
+const FetchRecipientsService = require('../../../../app/services/notices/setup/fetch-recipients.service.js')
+const RecipientsFixture = require('../../../fixtures/recipients.fixtures.js')
+const SessionHelper = require('../../../support/helpers/session.helper.js')
+
+// Thing under test
+const RecipientsService = require('../../../../app/services/notices/setup/recipients.service.js')
+
+describe('Notices - Setup - Recipients service', () => {
+  let recipients
+  let session
+
+  beforeEach(async () => {
+    session = await SessionHelper.add({
+      data: {
+        journey: 'standard'
+      }
+    })
+
+    recipients = RecipientsFixture.recipients()
+
+    Sinon.stub(FetchRecipientsService, 'go').resolves([recipients.primaryUser])
+  })
+
+  afterEach(() => {
+    Sinon.restore()
+  })
+
+  it('correctly presents the data', async () => {
+    const result = await RecipientsService.go(session)
+
+    expect(result).to.equal([
+      {
+        licence_refs: recipients.primaryUser.licence_refs,
+        contact: null,
+        contact_hash_id: '90129f6aa5bf2ad50aa3fefd3f8cf86a',
+        contact_type: 'Primary user',
+        email: 'primary.user@important.com',
+        message_type: 'Email'
+      }
+    ])
+  })
+
+  describe('when the journey is "alerts"', () => {
+    beforeEach(async () => {
+      session = await SessionHelper.add({
+        data: {
+          journey: 'alerts'
+        }
+      })
+
+      recipients = RecipientsFixture.alertsRecipients()
+
+      Sinon.stub(FetchAbstractionAlertRecipientsService, 'go').resolves([recipients.additionalContact])
+    })
+
+    it('correctly presents the data', async () => {
+      const result = await RecipientsService.go(session)
+
+      expect(result).to.equal([
+        {
+          contact: null,
+          contact_hash_id: '90129f6aa5b98734aa3fefd3f8cf86a',
+          contact_type: 'Additional contact',
+          email: recipients.additionalContact.email,
+          licence_refs: recipients.additionalContact.licence_refs,
+          message_type: 'Email'
+        }
+      ])
+    })
+  })
+})

--- a/test/services/notices/setup/recipients.service.test.js
+++ b/test/services/notices/setup/recipients.service.test.js
@@ -9,10 +9,12 @@ const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const FetchAbstractionAlertRecipientsService = require('../../../../app/services/notices/setup/fetch-abstraction-alert-recipients.service.js')
-const FetchRecipientsService = require('../../../../app/services/notices/setup/fetch-recipients.service.js')
 const RecipientsFixture = require('../../../fixtures/recipients.fixtures.js')
 const SessionHelper = require('../../../support/helpers/session.helper.js')
+
+// Things we need to stub
+const FetchAbstractionAlertRecipientsService = require('../../../../app/services/notices/setup/fetch-abstraction-alert-recipients.service.js')
+const FetchRecipientsService = require('../../../../app/services/notices/setup/fetch-recipients.service.js')
 
 // Thing under test
 const RecipientsService = require('../../../../app/services/notices/setup/recipients.service.js')


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5041

This change adds a new 'RecipientsService' to handle the fetching and de duplication of the recipients.

Future changes will need to use this logic, so it has been deemed suitable extra this logic into a single service.

As part of this refactor we have identified the 'contacts' will be need in coming changes and so has been updated as part of this change.