### PR TITLE
Update notices setup select recipients to handle selected recipients

### DIFF
--- a/app/presenters/notices/setup/select-recipients.presenter.js
+++ b/app/presenters/notices/setup/select-recipients.presenter.js
@@ -26,10 +26,10 @@ function go(session, recipients) {
 }
 
 /**
- * Determines if a contact should be marked as checked.
+ * Determines if a recipient should be marked as checked.
  *
  * If no `selectedRecipients` are provided (i.e., it's falsy), then all contacts should be marked as checked (`true`).
- * Otherwise, only contacts whose `contact_hash_id` appears in `selectedRecipients` should be marked as checked.
+ * Otherwise, only recipient whose `contact_hash_id` appears in `selectedRecipients` should be marked as checked.
  *
  * @private
  */

--- a/app/presenters/notices/setup/select-recipients.presenter.js
+++ b/app/presenters/notices/setup/select-recipients.presenter.js
@@ -16,23 +16,39 @@ const ContactPresenter = require('./contact.presenter.js')
  * @returns {object} - The data formatted for the view template
  */
 function go(session, recipients) {
-  const { id: sessionId } = session
+  const { id: sessionId, selectedRecipients } = session
 
   return {
     backLink: `/system/notices/setup/${sessionId}/check`,
     pageTitle: 'Select Recipients',
-    recipients: _recipients(recipients)
+    recipients: _recipients(recipients, selectedRecipients)
   }
 }
 
-function _recipients(recipients) {
+/**
+ * Determines if a contact should be marked as checked.
+ *
+ * If no `selectedRecipients` are provided (i.e., it's falsy), then all contacts should be marked as checked (`true`).
+ * Otherwise, only contacts whose `contact_hash_id` appears in `selectedRecipients` should be marked as checked.
+ *
+ * @private
+ */
+function _checked(selectedRecipients, recipient) {
+  if (selectedRecipients === undefined) {
+    return true
+  }
+
+  return selectedRecipients.includes(recipient.contact_hash_id)
+}
+
+function _recipients(recipients, selectedRecipients) {
   return recipients.map((recipient) => {
     const contact = ContactPresenter.go(recipient)
 
     return {
+      checked: _checked(selectedRecipients, recipient),
       contact,
-      contact_hash_id: recipient.contact_hash_id,
-      checked: true
+      contact_hash_id: recipient.contact_hash_id
     }
   })
 }

--- a/app/services/notices/setup/submit-select-recipients.service.js
+++ b/app/services/notices/setup/submit-select-recipients.service.js
@@ -22,6 +22,8 @@ const SessionModel = require('../../../models/session.model.js')
 async function go(sessionId, payload) {
   const session = await SessionModel.query().findById(sessionId)
 
+  _handleOneOptionSelected(payload)
+
   const validationResult = _validate(payload)
 
   if (!validationResult) {
@@ -29,6 +31,8 @@ async function go(sessionId, payload) {
 
     return {}
   }
+
+  session.selectedRecipients = payload.recipients || []
 
   const recipients = await RecipientsService.go(session)
 
@@ -40,7 +44,15 @@ async function go(sessionId, payload) {
   }
 }
 
-async function _save(session, _payload) {
+function _handleOneOptionSelected(payload) {
+  if (payload.recipients && !Array.isArray(payload?.recipients)) {
+    payload.recipients = [payload?.recipients]
+  }
+}
+
+async function _save(session, payload) {
+  session.selectedRecipients = payload.recipients
+
   return session.$update()
 }
 

--- a/test/presenters/notices/setup/select-recipients.presenter.test.js
+++ b/test/presenters/notices/setup/select-recipients.presenter.test.js
@@ -7,9 +7,11 @@ const Code = require('@hapi/code')
 const { describe, it, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
+// Test helpers
+const RecipientsFixture = require('../../../fixtures/recipients.fixtures.js')
+
 // Thing under test
 const SelectRecipientsPresenter = require('../../../../app/presenters/notices/setup/select-recipients.presenter.js')
-const RecipientsFixture = require('../../../fixtures/recipients.fixtures.js')
 
 describe('Select Recipients Presenter', () => {
   let recipients
@@ -23,54 +25,119 @@ describe('Select Recipients Presenter', () => {
     testRecipients = [...Object.values(recipients)]
   })
 
-  describe('when called', () => {
-    it('returns page data for the view', () => {
-      const result = SelectRecipientsPresenter.go(session, testRecipients)
+  it('returns page data for the view', () => {
+    const result = SelectRecipientsPresenter.go(session, testRecipients)
 
-      expect(result).to.equal({
-        backLink: `/system/notices/setup/${session.id}/check`,
-        pageTitle: 'Select Recipients',
-        recipients: [
+    expect(result).to.equal({
+      backLink: `/system/notices/setup/${session.id}/check`,
+      pageTitle: 'Select Recipients',
+      recipients: [
+        {
+          checked: true,
+          contact: [recipients.primaryUser.email],
+          contact_hash_id: recipients.primaryUser.contact_hash_id
+        },
+        {
+          checked: true,
+          contact: [recipients.returnsAgent.email],
+          contact_hash_id: recipients.returnsAgent.contact_hash_id
+        },
+        {
+          checked: true,
+          contact: ['Mr H J Licence holder', '1', 'Privet Drive', 'Little Whinging', 'Surrey', 'WD25 7LR'],
+          contact_hash_id: recipients.licenceHolder.contact_hash_id
+        },
+        {
+          checked: true,
+          contact: [
+            'Mr H J Returns to',
+            'INVALID ADDRESS - Needs a valid postcode or country outside the UK',
+            '2',
+            'Privet Drive',
+            'Little Whinging',
+            'Surrey'
+          ],
+          contact_hash_id: recipients.returnsTo.contact_hash_id
+        },
+        {
+          checked: true,
+          contact: [
+            'Mr H J Licence holder with multiple licences',
+            '3',
+            'Privet Drive',
+            'Little Whinging',
+            'Surrey',
+            'WD25 7LR'
+          ],
+          contact_hash_id: recipients.licenceHolderWithMultipleLicences.contact_hash_id
+        }
+      ]
+    })
+  })
+
+  describe('the "recipients" property', () => {
+    beforeEach(() => {
+      const recipient = Object.values(recipients)
+
+      testRecipients = [recipient[0]]
+    })
+
+    describe('and "selectedRecipients" in not present in the session', () => {
+      it('returns page data for the view with all recipients checked', () => {
+        const result = SelectRecipientsPresenter.go(session, testRecipients)
+
+        expect(result.recipients).to.equal([
+          {
+            checked: true,
+            contact: [recipients.primaryUser.email],
+            contact_hash_id: recipients.primaryUser.contact_hash_id
+          }
+        ])
+      })
+    })
+
+    describe('and there are no "selectedRecipients"', () => {
+      beforeEach(() => {
+        session.selectedRecipients = []
+      })
+
+      it('returns page data for the view with relevant recipients not checked', () => {
+        const result = SelectRecipientsPresenter.go(session, testRecipients)
+
+        expect(result.recipients).to.equal([
+          {
+            checked: false,
+            contact: [recipients.primaryUser.email],
+            contact_hash_id: recipients.primaryUser.contact_hash_id
+          }
+        ])
+      })
+    })
+
+    describe('and there are "selectedRecipients"', () => {
+      beforeEach(() => {
+        session.selectedRecipients = [recipients.primaryUser.contact_hash_id]
+
+        const recipient = Object.values(recipients)
+
+        testRecipients.push(recipient[1])
+      })
+
+      it('returns page data for the view with relevant recipients checked', () => {
+        const result = SelectRecipientsPresenter.go(session, testRecipients)
+
+        expect(result.recipients).to.equal([
           {
             checked: true,
             contact: [recipients.primaryUser.email],
             contact_hash_id: recipients.primaryUser.contact_hash_id
           },
           {
-            checked: true,
+            checked: false,
             contact: [recipients.returnsAgent.email],
             contact_hash_id: recipients.returnsAgent.contact_hash_id
-          },
-          {
-            checked: true,
-            contact: ['Mr H J Licence holder', '1', 'Privet Drive', 'Little Whinging', 'Surrey', 'WD25 7LR'],
-            contact_hash_id: recipients.licenceHolder.contact_hash_id
-          },
-          {
-            checked: true,
-            contact: [
-              'Mr H J Returns to',
-              'INVALID ADDRESS - Needs a valid postcode or country outside the UK',
-              '2',
-              'Privet Drive',
-              'Little Whinging',
-              'Surrey'
-            ],
-            contact_hash_id: recipients.returnsTo.contact_hash_id
-          },
-          {
-            checked: true,
-            contact: [
-              'Mr H J Licence holder with multiple licences',
-              '3',
-              'Privet Drive',
-              'Little Whinging',
-              'Surrey',
-              'WD25 7LR'
-            ],
-            contact_hash_id: recipients.licenceHolderWithMultipleLicences.contact_hash_id
           }
-        ]
+        ])
       })
     })
   })

--- a/test/services/notices/setup/submit-select-recipients.service.test.js
+++ b/test/services/notices/setup/submit-select-recipients.service.test.js
@@ -45,7 +45,7 @@ describe('Notices - Setup - Select Recipients Service', () => {
 
       const refreshedSession = await session.$query()
 
-      expect(refreshedSession).to.equal(session)
+      expect(refreshedSession.selectedRecipients).to.equal(['123'])
     })
 
     it('continues the journey', async () => {
@@ -56,26 +56,28 @@ describe('Notices - Setup - Select Recipients Service', () => {
   })
 
   describe('when validation fails', () => {
-    beforeEach(async () => {
-      payload = { recipients: [] }
-    })
+    describe('because there are no recipients', () => {
+      beforeEach(async () => {
+        payload = {}
+      })
 
-    it('returns page data for the view, with errors', async () => {
-      const result = await SubmitSelectRecipientsService.go(session.id, payload)
+      it('returns page data for the view, with errors', async () => {
+        const result = await SubmitSelectRecipientsService.go(session.id, payload)
 
-      expect(result).to.equal({
-        backLink: `/system/notices/setup/${session.id}/check`,
-        error: {
-          text: 'Select at least one recipient'
-        },
-        pageTitle: 'Select Recipients',
-        recipients: [
-          {
-            checked: true,
-            contact: [recipients.primaryUser.email],
-            contact_hash_id: recipients.primaryUser.contact_hash_id
-          }
-        ]
+        expect(result).to.equal({
+          backLink: `/system/notices/setup/${session.id}/check`,
+          error: {
+            text: 'Select at least one recipient'
+          },
+          pageTitle: 'Select Recipients',
+          recipients: [
+            {
+              checked: false,
+              contact: [recipients.primaryUser.email],
+              contact_hash_id: recipients.primaryUser.contact_hash_id
+            }
+          ]
+        })
       })
     })
   })


### PR DESCRIPTION

https://eaflood.atlassian.net/browse/WATER-5041

This change adds the selected recipients to the session and marks them as checked in the presenter. 

All recipients are initially set to 'checked'. When the user has unselected any recipients they will not be 'checked' until updated by the user again. 

This change does not update the common service to remove the unselected recipients from the relevant recipients. This will be done in another change.