### PR TITLE
Fix communications notifications

### DIFF
--- a/app/presenters/licences/view-licence-communications.presenter.js
+++ b/app/presenters/licences/view-licence-communications.presenter.js
@@ -31,7 +31,7 @@ function _communications(communications, documentId, licenceId) {
       link: _link(communication.id, documentId, licenceId),
       type: _type(communication),
       sender: communication.event.issuer,
-      sent: formatLongDate(new Date(communication.event.createdAt)),
+      sent: _sent(communication),
       method: sentenceCase(communication.messageType)
     }
   })
@@ -45,10 +45,16 @@ function _link(communicationId, documentId, licenceId) {
   return `/licences/${documentId}/communications/${communicationId}`
 }
 
+function _sent(communication) {
+  return communication.sendAfter
+    ? formatLongDate(new Date(communication.sendAfter))
+    : formatLongDate(new Date(communication.createdAt))
+}
+
 function _type(communication) {
   return {
     label: _typeLabel(communication),
-    sentVia: `sent ${formatLongDate(new Date(communication.event.createdAt))} via ${communication.messageType}`,
+    sentVia: `sent ${_sent(communication)} via ${communication.messageType}`,
     pdf: communication.messageRef.includes('pdf')
   }
 }

--- a/app/presenters/notifications/view-notification.presenter.js
+++ b/app/presenters/notifications/view-notification.presenter.js
@@ -15,7 +15,7 @@ const { formatLongDate, sentenceCase } = require('../base.presenter.js')
  * @returns {object} The data formatted for the view template
  */
 function go(notificationData) {
-  const { messageType, plaintext, personalisation, sendAfter, createdAt } = notificationData.notification
+  const { createdAt, messageType, personalisation, plaintext, sendAfter } = notificationData.notification
   const { id: licenceId, licenceRef } = notificationData.licence
 
   return {

--- a/app/presenters/notifications/view-notification.presenter.js
+++ b/app/presenters/notifications/view-notification.presenter.js
@@ -15,7 +15,7 @@ const { formatLongDate, sentenceCase } = require('../base.presenter.js')
  * @returns {object} The data formatted for the view template
  */
 function go(notificationData) {
-  const { messageType, plaintext, personalisation, sendAfter } = notificationData.notification
+  const { messageType, plaintext, personalisation, sendAfter, createdAt } = notificationData.notification
   const { id: licenceId, licenceRef } = notificationData.licence
 
   return {
@@ -25,7 +25,7 @@ function go(notificationData) {
     licenceRef,
     messageType,
     pageTitle: _pageTitle(notificationData.notification),
-    sentDate: formatLongDate(sendAfter)
+    sentDate: sendAfter ? formatLongDate(sendAfter) : formatLongDate(createdAt)
   }
 }
 

--- a/app/services/notifications/fetch-notification.service.js
+++ b/app/services/notifications/fetch-notification.service.js
@@ -31,7 +31,7 @@ async function _fetchLicence(licenceId) {
 async function _fetchNotification(notificationId) {
   return ScheduledNotificationsModel.query()
     .findById(notificationId)
-    .select(['messageType', 'personalisation', 'plaintext', 'sendAfter'])
+    .select(['messageType', 'personalisation', 'plaintext', 'sendAfter', 'createdAt'])
     .withGraphFetched('event')
     .modifyGraph('event', (builder) => {
       builder.select(['metadata'])

--- a/test/presenters/licences/view-licence-communications.presenter.test.js
+++ b/test/presenters/licences/view-licence-communications.presenter.test.js
@@ -26,7 +26,6 @@ describe('View Licence Communications presenter', () => {
         messageType: 'letter',
         messageRef: 'returns_invitation_licence_holder_letter',
         event: {
-          createdAt: '2024-05-15T10:27:15.000Z',
           metadata: {
             name: 'Returns: invitation',
             options: {}
@@ -35,7 +34,8 @@ describe('View Licence Communications presenter', () => {
           subtype: 'returnInvitation',
           status: 'processed',
           issuer: 'admin-internal@wrls.gov.uk'
-        }
+        },
+        sendAfter: '2024-05-15T10:27:15.000Z'
       }
     ]
 
@@ -147,6 +147,47 @@ describe('View Licence Communications presenter', () => {
           label: 'Test - Water abstraction alert',
           pdf: false,
           sentVia: 'sent 15 May 2024 via letter'
+        })
+      })
+    })
+
+    describe('the "sent" property', () => {
+      describe('and there is a date for "sendAfter"', () => {
+        it('correctly presents the data', () => {
+          const result = ViewLicenceCommunicationsPresenter.go(communications, documentId, licenceId)
+
+          expect(result.communications[0].sent).to.equal('15 May 2024')
+          expect(result.communications[0].type.sentVia).to.equal('sent 15 May 2024 via letter')
+        })
+      })
+
+      describe('and there is a date for "createdAt"', () => {
+        beforeEach(() => {
+          communications = [
+            {
+              createdAt: '2025-06-06',
+              id: '3ce7d0b6-610f-4cb2-9d4c-9761db797141',
+              messageType: 'letter',
+              messageRef: 'returns_invitation_licence_holder_letter',
+              event: {
+                metadata: {
+                  name: 'Returns: invitation',
+                  options: {}
+                },
+                type: 'notification',
+                subtype: 'returnInvitation',
+                status: 'processed',
+                issuer: 'admin-internal@wrls.gov.uk'
+              }
+            }
+          ]
+        })
+
+        it('correctly presents the data', () => {
+          const result = ViewLicenceCommunicationsPresenter.go(communications, documentId, licenceId)
+
+          expect(result.communications[0].sent).to.equal('6 June 2025')
+          expect(result.communications[0].type.sentVia).to.equal('sent 6 June 2025 via letter')
         })
       })
     })

--- a/test/services/licences/fetch-communications.service.test.js
+++ b/test/services/licences/fetch-communications.service.test.js
@@ -50,8 +50,8 @@ describe('Fetch Communications service', () => {
 
       expect(result.communications).to.equal([
         {
+          createdAt: scheduledNotification.createdAt,
           event: {
-            createdAt: new Date('2024-06-01'),
             issuer: 'test.user@defra.gov.uk',
             metadata: null,
             status: 'sent',
@@ -60,7 +60,8 @@ describe('Fetch Communications service', () => {
           },
           id: scheduledNotification.id,
           messageRef: 'returns_invitation_licence_holder_letter',
-          messageType: 'letter'
+          messageType: 'letter',
+          sendAfter: null
         }
       ])
     })

--- a/test/services/notifications/fetch-notification.service.test.js
+++ b/test/services/notifications/fetch-notification.service.test.js
@@ -43,6 +43,7 @@ describe('Fetch Notification service', () => {
           licenceRef: licence.licenceRef
         },
         notification: {
+          createdAt: notification.createdAt,
           messageType: 'letter',
           personalisation: {
             postcode: 'ME15 0NE',


### PR DESCRIPTION
Fix communications notifications

https://eaflood.atlassian.net/browse/WATER-5188

There is a bug introduced by the new notices work we have done. We recently migrated the legacy notifications logic into 'system'. 

When the legacy notifications where sent they used a delayed sending mechanism which used a 'sendAfter' date to track when a notification was sent. 

When we migrated this logic we did not use this delayed mechanism (or an overly complicated message queue system). We instead send the notification when it has been submitted and save it in the database with the created date set (legacy notification do not have a created at date).

So we have two dates used to show notification sent. 

This change updates the logic to use both of these dates. We determined that a 'sendAfter' should be used in place of the 'createdAt' date when showing the date. 

And as the new way of sending notifications use the 'createdAt' we sort by 'createdAt' then 'sendAfter' to show the user the latest notifications (we have handled null dates in the updated query).

Another change required was updating the communications tab to use these two dates instead of the 'event.createdAt' date. This was a carry over from the legacy code.