### PR TITLE
Ad-hoc notice - enter postcode

### DIFF
--- a/app/controllers/notices-setup.controller.js
+++ b/app/controllers/notices-setup.controller.js
@@ -332,12 +332,12 @@ async function submitContactType(request, h) {
   } = request
 
   const pageData = await SubmitContactTypeService.go(sessionId, payload)
-
+console.log(pageData)
   if (pageData.error) {
     return h.view(`notices/setup/contact-type.njk`, pageData)
   }
 
-  if (pageData.contactType === 'post') {
+  if (pageData.type === 'post') {
     return h.redirect(`/system/address/${sessionId}/postcode`)
   }
 

--- a/app/controllers/notices-setup.controller.js
+++ b/app/controllers/notices-setup.controller.js
@@ -332,7 +332,7 @@ async function submitContactType(request, h) {
   } = request
 
   const pageData = await SubmitContactTypeService.go(sessionId, payload)
-console.log(pageData)
+
   if (pageData.error) {
     return h.view(`notices/setup/contact-type.njk`, pageData)
   }

--- a/app/presenters/address/postcode.presenter.js
+++ b/app/presenters/address/postcode.presenter.js
@@ -21,8 +21,8 @@ function go(session) {
 }
 
 function _backLink(session) {
-  if (session.contactType) {
-    return `/system/notices/setup/${session.id}/select-recipients`
+  if (session.name) {
+    return `/system/notices/setup/${session.id}/contact-type`
   }
 
   return `/system/address/${session.id}/postcode`

--- a/app/presenters/address/postcode.presenter.js
+++ b/app/presenters/address/postcode.presenter.js
@@ -1,0 +1,33 @@
+'use strict'
+
+/**
+ * Formats data for the `address/{sessionId}/postcode` page
+ * @module ManualAddressPresenter
+ */
+
+/**
+ * Formats data for the `address/{sessionId}/postcode` page
+ *
+ * @param {SessionModel} session - The session instance
+ *
+ * @returns {object} - The data formatted for the view template
+ */
+function go(session) {
+  return {
+    backLink: _backLink(session),
+    pageTitle: 'Enter a UK postcode',
+    postcode: session?.address?.postcode ?? null
+  }
+}
+
+function _backLink(session) {
+  if (session.contactType) {
+    return `/system/notices/setup/${session.id}/select-recipients`
+  }
+
+  return `/system/address/${session.id}/postcode`
+}
+
+module.exports = {
+  go
+}

--- a/app/presenters/notices/setup/contact-type.presenter.js
+++ b/app/presenters/notices/setup/contact-type.presenter.js
@@ -13,9 +13,9 @@
  * @returns {object} - The data formatted for the view template
  */
 function go(session) {
-  const email = session?.contactType?.email ?? null
-  const name = session?.contactType?.name ?? null
-  const type = session?.contactType?.type ?? null
+  const email = session?.email ?? null
+  const name = session?.name ?? null
+  const type = session?.contactType ?? null
 
   return {
     backLink: `/system/notices/setup/${session.id}/select-recipients`,

--- a/app/services/address/postcode.service.js
+++ b/app/services/address/postcode.service.js
@@ -6,6 +6,7 @@
  * @module PostcodeService
  */
 
+const PostcodePresenter = require('../../presenters/address/postcode.presenter.js')
 const SessionModel = require('../../models/session.model.js')
 
 /**
@@ -18,11 +19,11 @@ const SessionModel = require('../../models/session.model.js')
 async function go(sessionId) {
   const session = await SessionModel.query().findById(sessionId)
 
+  const pageData = PostcodePresenter.go(session)
+
   return {
-    activeNavBar: 'search',
-    pageTitle: 'Enter a UK postcode',
-    ...(session.address?.postcode && { postcode: session.address.postcode }),
-    sessionId: session.id
+    activeNavBar: 'manage',
+    ...pageData
   }
 }
 

--- a/app/services/address/submit-postcode.service.js
+++ b/app/services/address/submit-postcode.service.js
@@ -6,6 +6,7 @@
  * @module SubmitPostcodeService
  */
 
+const PostcodePresenter = require('../../presenters/address/postcode.presenter.js')
 const PostcodeValidator = require('../../validators/address/postcode.validator.js')
 const SessionModel = require('../../models/session.model.js')
 
@@ -28,12 +29,19 @@ async function go(sessionId, payload) {
     return {}
   }
 
+  const _submittedData = {
+    ...session,
+    address: {
+      ...payload
+    }
+  }
+
+  const pageData = PostcodePresenter.go(_submittedData)
+
   return {
-    activeNavBar: 'search',
+    activeNavBar: 'manage',
     error: validationResult,
-    pageTitle: 'Enter a UK postcode',
-    ...(payload.postcode && { postcode: payload.postcode }),
-    sessionId: session.id
+    ...pageData
   }
 }
 

--- a/app/services/notices/setup/submit-contact-type.service.js
+++ b/app/services/notices/setup/submit-contact-type.service.js
@@ -35,9 +35,7 @@ async function go(sessionId, payload) {
 
   const _submittedData = {
     id: session.id,
-    contactType: {
-      ...payload
-    }
+    contactType: payload?.type ?? null
   }
 
   const pageData = ContactTypePresenter.go(_submittedData)
@@ -68,16 +66,15 @@ async function _save(session, payload) {
       session.additionalRecipients = [recipient]
     }
 
+    delete session.name
     delete session.contactType
+
     return session.$update()
   }
 
-  const _contactType = {
-    name: payload.name,
-    type: payload.type
-  }
+  session.name = payload.name
+  session.contactType = payload.type
 
-  session.contactType = _contactType
   return session.$update()
 }
 

--- a/app/services/notices/setup/submit-contact-type.service.js
+++ b/app/services/notices/setup/submit-contact-type.service.js
@@ -28,7 +28,9 @@ async function go(sessionId, payload) {
   if (!validationResult) {
     await _save(session, payload)
 
-    return {}
+    return {
+      type: payload.type
+    }
   }
 
   const _submittedData = {

--- a/test/controllers/notices-setup.controller.test.js
+++ b/test/controllers/notices-setup.controller.test.js
@@ -1188,8 +1188,8 @@ describe('Notices Setup controller', () => {
         describe('and the validation succeeds and they chose the post option', () => {
           beforeEach(async () => {
             Sinon.stub(SubmitContactTypeService, 'go').returns({
-              contactType: 'post',
-              pageTile: 'Select the returns for the paper forms'
+              type: 'post',
+              pageTile: 'Select how to contact the recipient'
             })
             postOptions = postRequestOptions(basePath + `/${session.id}/contact-type`, {})
           })
@@ -1205,8 +1205,8 @@ describe('Notices Setup controller', () => {
         describe('and the validation succeeds and they chose the email option', () => {
           beforeEach(async () => {
             Sinon.stub(SubmitContactTypeService, 'go').returns({
-              contactType: 'email',
-              pageTile: 'Select the returns for the paper forms'
+              type: 'email',
+              pageTile: 'Select how to contact the recipient'
             })
             postOptions = postRequestOptions(basePath + `/${session.id}/contact-type`, {})
           })

--- a/test/presenters/address/postcode.presenter.test.js
+++ b/test/presenters/address/postcode.presenter.test.js
@@ -31,13 +31,11 @@ describe('Address - Postcode Presenter', () => {
     })
   })
 
-  describe('when called with an contactType object', () => {
+  describe('when called with a name saved in the session', () => {
     beforeEach(async () => {
       session = {
         id: 'fecd5f15-bacf-4b3d-bdcd-ef279a97b061',
-        contactType: {
-          type: 'post'
-        }
+        name: 'Fake Person'
       }
     })
 
@@ -45,7 +43,7 @@ describe('Address - Postcode Presenter', () => {
       const result = PostcodePresenter.go(session)
 
       expect(result).to.equal({
-        backLink: `/system/notices/setup/${session.id}/select-recipients`,
+        backLink: `/system/notices/setup/${session.id}/contact-type`,
         pageTitle: 'Enter a UK postcode',
         postcode: null
       })
@@ -59,16 +57,15 @@ describe('Address - Postcode Presenter', () => {
         address: {
           postcode: 'SW1A 1AA'
         },
-        contactType: {
-          type: 'post'
-        }
+        name: 'Fake Person'
       }
     })
+
     it('returns page data for the view', () => {
       const result = PostcodePresenter.go(session)
 
       expect(result).to.equal({
-        backLink: `/system/notices/setup/${session.id}/select-recipients`,
+        backLink: `/system/notices/setup/${session.id}/contact-type`,
         pageTitle: 'Enter a UK postcode',
         postcode: 'SW1A 1AA'
       })

--- a/test/presenters/address/postcode.presenter.test.js
+++ b/test/presenters/address/postcode.presenter.test.js
@@ -1,0 +1,77 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Thing under test
+const PostcodePresenter = require('../../../app/presenters/address/postcode.presenter.js')
+
+describe('Address - Postcode Presenter', () => {
+  let session
+
+  describe('when called with an empty session object', () => {
+    beforeEach(async () => {
+      session = {
+        id: 'fecd5f15-bacf-4b3d-bdcd-ef279a97b061'
+      }
+    })
+
+    it('returns page data for the view', () => {
+      const result = PostcodePresenter.go(session)
+
+      expect(result).to.equal({
+        backLink: `/system/address/${session.id}/postcode`,
+        pageTitle: 'Enter a UK postcode',
+        postcode: null
+      })
+    })
+  })
+
+  describe('when called with an contactType object', () => {
+    beforeEach(async () => {
+      session = {
+        id: 'fecd5f15-bacf-4b3d-bdcd-ef279a97b061',
+        contactType: {
+          type: 'post'
+        }
+      }
+    })
+
+    it('returns page data for the view', () => {
+      const result = PostcodePresenter.go(session)
+
+      expect(result).to.equal({
+        backLink: `/system/notices/setup/${session.id}/select-recipients`,
+        pageTitle: 'Enter a UK postcode',
+        postcode: null
+      })
+    })
+  })
+
+  describe('when called with a contactType object and a saved postcode', () => {
+    beforeEach(async () => {
+      session = {
+        id: 'fecd5f15-bacf-4b3d-bdcd-ef279a97b061',
+        address: {
+          postcode: 'SW1A 1AA'
+        },
+        contactType: {
+          type: 'post'
+        }
+      }
+    })
+    it('returns page data for the view', () => {
+      const result = PostcodePresenter.go(session)
+
+      expect(result).to.equal({
+        backLink: `/system/notices/setup/${session.id}/select-recipients`,
+        pageTitle: 'Enter a UK postcode',
+        postcode: 'SW1A 1AA'
+      })
+    })
+  })
+})

--- a/test/presenters/notices/setup/contact-type.presenter.test.js
+++ b/test/presenters/notices/setup/contact-type.presenter.test.js
@@ -34,10 +34,8 @@ describe('Contact Type Presenter', () => {
   describe('when called with an email address', () => {
     beforeEach(() => {
       session = {
-        contactType: {
-          email: 'test@test.gov.uk',
-          type: 'email'
-        }
+        email: 'test@test.gov.uk',
+        contactType: 'email'
       }
     })
 
@@ -57,10 +55,8 @@ describe('Contact Type Presenter', () => {
   describe('when called with a name', () => {
     beforeEach(() => {
       session = {
-        contactType: {
-          name: 'Fake Person',
-          type: 'post'
-        }
+        name: 'Fake Person',
+        contactType: 'post'
       }
     })
 

--- a/test/services/address/postcode.service.test.js
+++ b/test/services/address/postcode.service.test.js
@@ -39,9 +39,7 @@ describe('Address - Postcode Service', () => {
   describe('when called and there is session data', () => {
     beforeEach(async () => {
       sessionData = {
-        contactType: {
-          type: 'post'
-        },
+        name: 'Fake Person',
         address: {
           postcode: 'SW1A 1AA'
         }
@@ -55,7 +53,7 @@ describe('Address - Postcode Service', () => {
 
       expect(result).to.equal({
         activeNavBar: 'manage',
-        backLink: `/system/notices/setup/${session.id}/select-recipients`,
+        backLink: `/system/notices/setup/${session.id}/contact-type`,
         pageTitle: 'Enter a UK postcode',
         postcode: 'SW1A 1AA'
       })

--- a/test/services/address/postcode.service.test.js
+++ b/test/services/address/postcode.service.test.js
@@ -19,9 +19,7 @@ describe('Address - Postcode Service', () => {
 
   describe('when called and there is no session data', () => {
     beforeEach(async () => {
-      sessionData = {
-        address: {}
-      }
+      sessionData = {}
 
       session = await SessionHelper.add({ data: sessionData })
     })
@@ -30,9 +28,10 @@ describe('Address - Postcode Service', () => {
       const result = await PostcodeService.go(session.id)
 
       expect(result).to.equal({
-        activeNavBar: 'search',
+        activeNavBar: 'manage',
+        backLink: `/system/address/${session.id}/postcode`,
         pageTitle: 'Enter a UK postcode',
-        sessionId: session.id
+        postcode: null
       })
     })
   })
@@ -40,6 +39,9 @@ describe('Address - Postcode Service', () => {
   describe('when called and there is session data', () => {
     beforeEach(async () => {
       sessionData = {
+        contactType: {
+          type: 'post'
+        },
         address: {
           postcode: 'SW1A 1AA'
         }
@@ -52,10 +54,10 @@ describe('Address - Postcode Service', () => {
       const result = await PostcodeService.go(session.id)
 
       expect(result).to.equal({
-        activeNavBar: 'search',
+        activeNavBar: 'manage',
+        backLink: `/system/notices/setup/${session.id}/select-recipients`,
         pageTitle: 'Enter a UK postcode',
-        postcode: 'SW1A 1AA',
-        sessionId: session.id
+        postcode: 'SW1A 1AA'
       })
     })
   })

--- a/test/services/address/submit-postcode.service.test.js
+++ b/test/services/address/submit-postcode.service.test.js
@@ -18,27 +18,12 @@ describe('Address - Submit Postcode Service', () => {
   let session
   let sessionData
 
-  beforeEach(async () => {
-    payload = {
-      address: {
-        postcode: 'SW1A 1AA'
-      }
-    }
-    sessionData = {
-      address: {}
-    }
-
-    session = await SessionHelper.add({ data: sessionData })
-  })
-
   describe('when called with a valid payload', () => {
     beforeEach(async () => {
       payload = {
         postcode: 'SW1A 1AA'
       }
-      sessionData = {
-        address: {}
-      }
+      sessionData = {}
 
       session = await SessionHelper.add({ data: sessionData })
     })
@@ -63,7 +48,9 @@ describe('Address - Submit Postcode Service', () => {
       beforeEach(async () => {
         payload = {}
         sessionData = {
-          address: {}
+          contactType: {
+            type: 'post'
+          }
         }
 
         session = await SessionHelper.add({ data: sessionData })
@@ -73,10 +60,11 @@ describe('Address - Submit Postcode Service', () => {
         const result = await SubmitPostcodeService.go(session.id, payload)
 
         expect(result).to.equal({
-          activeNavBar: 'search',
+          activeNavBar: 'manage',
+          backLink: `/system/notices/setup/${session.id}/select-recipients`,
           pageTitle: 'Enter a UK postcode',
-          error: { text: 'Enter a UK postcode' },
-          sessionId: session.id
+          postcode: null,
+          error: { text: 'Enter a UK postcode' }
         })
       })
     })
@@ -85,7 +73,9 @@ describe('Address - Submit Postcode Service', () => {
       beforeEach(async () => {
         payload = { postcode: 'notapostcode' }
         sessionData = {
-          address: {}
+          contactType: {
+            type: 'post'
+          }
         }
 
         session = await SessionHelper.add({ data: sessionData })
@@ -95,11 +85,11 @@ describe('Address - Submit Postcode Service', () => {
         const result = await SubmitPostcodeService.go(session.id, payload)
 
         expect(result).to.equal({
-          activeNavBar: 'search',
+          activeNavBar: 'manage',
+          backLink: `/system/notices/setup/${session.id}/select-recipients`,
           pageTitle: 'Enter a UK postcode',
           postcode: 'notapostcode',
-          error: { text: 'Enter a valid UK postcode' },
-          sessionId: session.id
+          error: { text: 'Enter a valid UK postcode' }
         })
       })
     })

--- a/test/services/address/submit-postcode.service.test.js
+++ b/test/services/address/submit-postcode.service.test.js
@@ -48,9 +48,7 @@ describe('Address - Submit Postcode Service', () => {
       beforeEach(async () => {
         payload = {}
         sessionData = {
-          contactType: {
-            type: 'post'
-          }
+          name: 'Fake Person'
         }
 
         session = await SessionHelper.add({ data: sessionData })
@@ -61,7 +59,7 @@ describe('Address - Submit Postcode Service', () => {
 
         expect(result).to.equal({
           activeNavBar: 'manage',
-          backLink: `/system/notices/setup/${session.id}/select-recipients`,
+          backLink: `/system/notices/setup/${session.id}/contact-type`,
           pageTitle: 'Enter a UK postcode',
           postcode: null,
           error: { text: 'Enter a UK postcode' }
@@ -73,9 +71,7 @@ describe('Address - Submit Postcode Service', () => {
       beforeEach(async () => {
         payload = { postcode: 'notapostcode' }
         sessionData = {
-          contactType: {
-            type: 'post'
-          }
+          name: 'Fake Person'
         }
 
         session = await SessionHelper.add({ data: sessionData })
@@ -86,7 +82,7 @@ describe('Address - Submit Postcode Service', () => {
 
         expect(result).to.equal({
           activeNavBar: 'manage',
-          backLink: `/system/notices/setup/${session.id}/select-recipients`,
+          backLink: `/system/notices/setup/${session.id}/contact-type`,
           pageTitle: 'Enter a UK postcode',
           postcode: 'notapostcode',
           error: { text: 'Enter a valid UK postcode' }

--- a/test/services/notices/setup/contact-type.service.test.js
+++ b/test/services/notices/setup/contact-type.service.test.js
@@ -38,39 +38,11 @@ describe('Notices - Setup - Contact Type Service', () => {
     })
   })
 
-  describe('when called with a saved email address', () => {
-    beforeEach(async () => {
-      sessionData = {
-        contactType: {
-          email: 'test@test.gov.uk',
-          type: 'email'
-        }
-      }
-
-      session = await SessionHelper.add({ data: sessionData })
-    })
-
-    it('returns page data for the view', async () => {
-      const result = await ContactTypeService.go(session.id)
-
-      expect(result).to.equal({
-        activeNavBar: 'manage',
-        backLink: `/system/notices/setup/${session.id}/select-recipients`,
-        email: 'test@test.gov.uk',
-        name: null,
-        pageTitle: 'Select how to contact the recipient',
-        type: 'email'
-      })
-    })
-  })
-
   describe('when called with a saved name', () => {
     beforeEach(async () => {
       sessionData = {
-        contactType: {
-          name: 'Fake Person',
-          type: 'post'
-        }
+        name: 'Fake Person',
+        contactType: 'post'
       }
 
       session = await SessionHelper.add({ data: sessionData })

--- a/test/services/notices/setup/submit-contact-type.service.test.js
+++ b/test/services/notices/setup/submit-contact-type.service.test.js
@@ -149,8 +149,8 @@ describe('Notices - Setup - Submit Contact Type Service', () => {
 
       const refreshedSession = await session.$query()
 
-      expect(refreshedSession.contactType.type).to.equal(payload.type)
-      expect(refreshedSession.contactType.name).to.equal(payload.name)
+      expect(refreshedSession.contactType).to.equal(payload.type)
+      expect(refreshedSession.name).to.equal(payload.name)
     })
 
     it('continues the journey', async () => {

--- a/test/services/notices/setup/submit-contact-type.service.test.js
+++ b/test/services/notices/setup/submit-contact-type.service.test.js
@@ -48,7 +48,9 @@ describe('Notices - Setup - Submit Contact Type Service', () => {
     it('continues the journey', async () => {
       const result = await SubmitContactTypeService.go(session.id, payload)
 
-      expect(result).to.equal({})
+      expect(result).to.equal({
+        type: 'email'
+      })
     })
   })
 
@@ -80,7 +82,9 @@ describe('Notices - Setup - Submit Contact Type Service', () => {
     it('continues the journey', async () => {
       const result = await SubmitContactTypeService.go(session.id, payload)
 
-      expect(result).to.equal({})
+      expect(result).to.equal({
+        type: 'email'
+      })
     })
   })
 
@@ -123,7 +127,9 @@ describe('Notices - Setup - Submit Contact Type Service', () => {
     it('continues the journey', async () => {
       const result = await SubmitContactTypeService.go(session.id, payload)
 
-      expect(result).to.equal({})
+      expect(result).to.equal({
+        type: 'email'
+      })
     })
   })
 
@@ -150,7 +156,9 @@ describe('Notices - Setup - Submit Contact Type Service', () => {
     it('continues the journey', async () => {
       const result = await SubmitContactTypeService.go(session.id, payload)
 
-      expect(result).to.equal({})
+      expect(result).to.equal({
+        type: 'post'
+      })
     })
   })
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5044

As part of sending out ad-hoc notifications to users we need to be able to add a contact that is not already associated to the licence.

This PR allows the user to enter a postcode which will be used in the address lookup service.