### PR TITLE
Update notices setup recipients to use additional recipients

### DIFF
--- a/app/controllers/notices-setup.controller.js
+++ b/app/controllers/notices-setup.controller.js
@@ -190,7 +190,7 @@ async function viewCheck(request, h) {
     yar
   } = request
 
-  const pageData = await CheckService.go(sessionId, page, yar)
+  const pageData = await CheckService.go(sessionId, yar, page)
 
   return h.view(`notices/setup/check.njk`, pageData)
 }

--- a/app/controllers/notices-setup.controller.js
+++ b/app/controllers/notices-setup.controller.js
@@ -186,10 +186,11 @@ async function viewReturnsPeriod(request, h) {
 async function viewCheck(request, h) {
   const {
     params: { sessionId },
-    query: { page }
+    query: { page },
+    yar
   } = request
 
-  const pageData = await CheckService.go(sessionId, page)
+  const pageData = await CheckService.go(sessionId, page, yar)
 
   return h.view(`notices/setup/check.njk`, pageData)
 }
@@ -327,11 +328,12 @@ async function submitCheckLicenceMatches(request, h) {
 
 async function submitContactType(request, h) {
   const {
+    params: { sessionId },
     payload,
-    params: { sessionId }
+    yar
   } = request
 
-  const pageData = await SubmitContactTypeService.go(sessionId, payload)
+  const pageData = await SubmitContactTypeService.go(sessionId, payload, yar)
 
   if (pageData.error) {
     return h.view(`notices/setup/contact-type.njk`, pageData)
@@ -341,7 +343,7 @@ async function submitContactType(request, h) {
     return h.redirect(`/system/address/${sessionId}/postcode`)
   }
 
-  return h.redirect(`/system/notices/setup/${sessionId}/select-recipients`)
+  return h.redirect(`/system/notices/setup/${sessionId}/check`)
 }
 
 async function submitLicence(request, h) {

--- a/app/presenters/notices/setup/select-recipients.presenter.js
+++ b/app/presenters/notices/setup/select-recipients.presenter.js
@@ -29,16 +29,10 @@ function go(session, recipients) {
 /**
  * Determines if a recipient should be marked as checked.
  *
- * If no `selectedRecipients` are provided (i.e., it's falsy), then all contacts should be marked as checked (`true`).
- * Otherwise, only recipient whose `contact_hash_id` appears in `selectedRecipients` should be marked as checked.
- *
+ * The 'selectedRecipients' are initialised on the check page, it should always exist.
  * @private
  */
 function _checked(selectedRecipients, recipient) {
-  if (selectedRecipients === undefined) {
-    return true
-  }
-
   return selectedRecipients.includes(recipient.contact_hash_id)
 }
 

--- a/app/services/notices/setup/check.service.js
+++ b/app/services/notices/setup/check.service.js
@@ -15,24 +15,51 @@ const SessionModel = require('../../../models/session.model.js')
  *
  * @param {string} sessionId - The UUID for returns notices session record
  * @param {number|string} [page=1] - The currently selected page (if paginated)
+ * @param {object} yar - The Hapi `request.yar` session manager passed on by the controller
  *
  * @returns {object} The view data for the review page
  */
-async function go(sessionId, page = 1) {
+async function go(sessionId, page = 1, yar) {
   const session = await SessionModel.query().findById(sessionId)
 
   const recipients = await RecipientsService.go(session, false)
+
+  await _initialiseSelectedRecipients(recipients, session)
 
   const pagination = PaginatorPresenter.go(recipients.length, Number(page), `/system/notices/setup/${sessionId}/check`)
 
   const formattedData = CheckPresenter.go(recipients, page, pagination, session)
 
+  const notification = yar.flash('notification')[0]
+
   return {
-    activeNavBar: 'manage',
     ...formattedData,
-    pagination,
-    page
+    activeNavBar: 'manage',
+    notification,
+    page,
+    pagination
   }
+}
+
+/**
+ * Initialises the 'selectedRecipients' array in the session if it doesn't already exist
+ *
+ * If the session doesn't have a 'selectedRecipients' array set, this function will populate it with
+ * all the contact_hash_id values from the provided recipients array. This ensures that
+ * all recipients are initially selected by default.
+ *
+ * This has to be done after the initial 'RecipientsService' call so 'contact_hash_id' is available.
+ *
+ * @private
+ */
+async function _initialiseSelectedRecipients(recipients, session) {
+  if (!session.selectedRecipients) {
+    session.selectedRecipients = recipients.map((recipient) => {
+      return recipient.contact_hash_id
+    })
+  }
+
+  return session.$update()
 }
 
 module.exports = {

--- a/app/services/notices/setup/check.service.js
+++ b/app/services/notices/setup/check.service.js
@@ -21,7 +21,7 @@ const SessionModel = require('../../../models/session.model.js')
 async function go(sessionId, page = 1) {
   const session = await SessionModel.query().findById(sessionId)
 
-  const recipients = await RecipientsService.go(session)
+  const recipients = await RecipientsService.go(session, false)
 
   const pagination = PaginatorPresenter.go(recipients.length, Number(page), `/system/notices/setup/${sessionId}/check`)
 

--- a/app/services/notices/setup/check.service.js
+++ b/app/services/notices/setup/check.service.js
@@ -14,12 +14,12 @@ const SessionModel = require('../../../models/session.model.js')
  * Orchestrates fetching and presenting the data needed for the notices setup check page
  *
  * @param {string} sessionId - The UUID for returns notices session record
- * @param {number|string} [page=1] - The currently selected page (if paginated)
  * @param {object} yar - The Hapi `request.yar` session manager passed on by the controller
+ * @param {number|string} [page=1] - The currently selected page (if paginated)
  *
- * @returns {object} The view data for the review page
+ * @returns {Promise<object>} The view data for the review page
  */
-async function go(sessionId, page = 1, yar) {
+async function go(sessionId, yar, page = 1) {
   const session = await SessionModel.query().findById(sessionId)
 
   const recipients = await RecipientsService.go(session, false)

--- a/app/services/notices/setup/recipients.service.js
+++ b/app/services/notices/setup/recipients.service.js
@@ -15,10 +15,11 @@ const DetermineRecipientsService = require('./determine-recipients.service.js')
  * Fetches the recipients based on the journey type and determines recipients (remove duplicates).
  *
  * @param {module:SessionModel} session - The session instance
+ * @param {boolean} allRecipients - flag to decide if all recipients are required
  *
  * @returns {Promise<object[]>} - recipients
  */
-async function go(session) {
+async function go(session, allRecipients = true) {
   let recipientsData
 
   if (session.journey === 'alerts') {
@@ -27,7 +28,19 @@ async function go(session) {
     recipientsData = await FetchRecipientsService.go(session)
   }
 
-  return DetermineRecipientsService.go(recipientsData)
+  if (allRecipients || !session.selectedRecipients) {
+    return DetermineRecipientsService.go(recipientsData)
+  }
+
+  const selectedRecipientsData = _selectedRecipients(session.selectedRecipients, recipientsData)
+
+  return DetermineRecipientsService.go(selectedRecipientsData)
+}
+
+function _selectedRecipients(selectedRecipients, recipientsData) {
+  return recipientsData.filter((recipient) => {
+    return selectedRecipients.includes(recipient.contact_hash_id)
+  })
 }
 
 module.exports = {

--- a/app/services/notices/setup/recipients.service.js
+++ b/app/services/notices/setup/recipients.service.js
@@ -20,17 +20,9 @@ const DetermineRecipientsService = require('./determine-recipients.service.js')
  * @returns {Promise<object[]>} - recipients
  */
 async function go(session, allRecipients = true) {
-  let recipientsData
+  let recipientsData = await _recipientsData(session)
 
-  if (session.journey === 'alerts') {
-    recipientsData = await FetchAbstractionAlertRecipientsService.go(session)
-  } else {
-    recipientsData = await FetchRecipientsService.go(session)
-  }
-
-  if (session.additionalRecipients) {
-    recipientsData = _additionalRecipients(recipientsData, session)
-  }
+  recipientsData = _additionalRecipients(recipientsData, session)
 
   if (allRecipients || !session.selectedRecipients) {
     return DetermineRecipientsService.go(recipientsData)
@@ -47,6 +39,14 @@ function _additionalRecipients(recipientsData, session) {
   }
 
   return recipientsData
+}
+
+async function _recipientsData(session) {
+  if (session.journey === 'alerts') {
+    return FetchAbstractionAlertRecipientsService.go(session)
+  } else {
+    return FetchRecipientsService.go(session)
+  }
 }
 
 function _selectedRecipients(selectedRecipients, recipientsData) {

--- a/app/services/notices/setup/recipients.service.js
+++ b/app/services/notices/setup/recipients.service.js
@@ -28,6 +28,10 @@ async function go(session, allRecipients = true) {
     recipientsData = await FetchRecipientsService.go(session)
   }
 
+  if (session.additionalRecipients) {
+    recipientsData = _additionalRecipients(recipientsData, session)
+  }
+
   if (allRecipients || !session.selectedRecipients) {
     return DetermineRecipientsService.go(recipientsData)
   }
@@ -35,6 +39,14 @@ async function go(session, allRecipients = true) {
   const selectedRecipientsData = _selectedRecipients(session.selectedRecipients, recipientsData)
 
   return DetermineRecipientsService.go(selectedRecipientsData)
+}
+
+function _additionalRecipients(recipientsData, session) {
+  if (session.additionalRecipients) {
+    return [...recipientsData, ...session.additionalRecipients]
+  }
+
+  return recipientsData
 }
 
 function _selectedRecipients(selectedRecipients, recipientsData) {

--- a/app/services/notices/setup/submit-check.service.js
+++ b/app/services/notices/setup/submit-check.service.js
@@ -25,7 +25,7 @@ const { currentTimeInNanoseconds, calculateAndLogTimeTaken } = require('../../..
 async function go(sessionId, auth) {
   const session = await SessionModel.query().findById(sessionId)
 
-  const recipients = await RecipientsService.go(session)
+  const recipients = await RecipientsService.go(session, false)
 
   const notice = await _notice(session, recipients, auth)
 

--- a/app/services/notices/setup/submit-contact-type.service.js
+++ b/app/services/notices/setup/submit-contact-type.service.js
@@ -55,22 +55,13 @@ function _createMD5Hash(email) {
   return crypto.createHash('md5').update(email).digest('hex')
 }
 
-/**
- * We need to add the recipient to the 'selectedRecipients' array. This is created by the check service and should
- * always exist.
- *
- * This is necessary to simplify the flow of handling 'recipients', 'selectedRecipients' and 'additionalRecipients'
- *
- * @private
- */
 async function _save(session, payload) {
   if (payload.type === 'email') {
     const email = payload.email.toLowerCase()
 
     const recipient = {
       contact_hash_id: _createMD5Hash(email),
-      email,
-      saved: false
+      email
     }
 
     if (Array.isArray(session.additionalRecipients)) {

--- a/app/views/notices/setup/check.njk
+++ b/app/views/notices/setup/check.njk
@@ -2,11 +2,12 @@
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
-{% from 'govuk/components/error-summary/macro.njk' import govukErrorSummary %}
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 {% from "govuk/components/pagination/macro.njk" import govukPagination %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
+{% from 'govuk/components/error-summary/macro.njk' import govukErrorSummary %}
 
 {% from "macros/new-line-array-items.njk" import newLineArrayItems %}
 
@@ -52,6 +53,13 @@
 
 {% block content %}
   <div class="govuk-body">
+    {% if notification %}
+      {{ govukNotificationBanner({
+        titleText: notification.title,
+        text: notification.text
+      }) }}
+    {% endif %}
+
     {% if warning %}
       {{ govukWarningText({
         text: warning,

--- a/test/controllers/notices-setup.controller.test.js
+++ b/test/controllers/notices-setup.controller.test.js
@@ -1215,7 +1215,7 @@ describe('Notices Setup controller', () => {
             const response = await server.inject(postOptions)
 
             expect(response.statusCode).to.equal(302)
-            expect(response.headers.location).to.equal(`/system/notices/setup/${session.id}/select-recipients`)
+            expect(response.headers.location).to.equal(`/system/notices/setup/${session.id}/check`)
           })
         })
       })

--- a/test/presenters/notices/setup/select-recipients.presenter.test.js
+++ b/test/presenters/notices/setup/select-recipients.presenter.test.js
@@ -13,14 +13,24 @@ const RecipientsFixture = require('../../../fixtures/recipients.fixtures.js')
 // Thing under test
 const SelectRecipientsPresenter = require('../../../../app/presenters/notices/setup/select-recipients.presenter.js')
 
-describe('Select Recipients Presenter', () => {
+describe('Notices - Setup - Select Recipients Presenter', () => {
   let recipients
   let session
   let testRecipients
 
   beforeEach(() => {
-    session = { id: 123 }
     recipients = RecipientsFixture.recipients()
+
+    session = {
+      id: 123,
+      selectedRecipients: [
+        recipients.primaryUser.contact_hash_id,
+        recipients.returnsAgent.contact_hash_id,
+        recipients.licenceHolder.contact_hash_id,
+        recipients.returnsTo.contact_hash_id,
+        recipients.licenceHolderWithMultipleLicences.contact_hash_id
+      ]
+    }
 
     testRecipients = [...Object.values(recipients)]
   })
@@ -80,21 +90,9 @@ describe('Select Recipients Presenter', () => {
     beforeEach(() => {
       const recipient = Object.values(recipients)
 
+      session.selectedRecipients = [recipient[0].contact_hash_id]
+
       testRecipients = [recipient[0]]
-    })
-
-    describe('and "selectedRecipients" in not present in the session', () => {
-      it('returns page data for the view with all recipients checked', () => {
-        const result = SelectRecipientsPresenter.go(session, testRecipients)
-
-        expect(result.recipients).to.equal([
-          {
-            checked: true,
-            contact: [recipients.primaryUser.email],
-            contact_hash_id: recipients.primaryUser.contact_hash_id
-          }
-        ])
-      })
     })
 
     describe('and there are no "selectedRecipients"', () => {

--- a/test/services/notices/setup/check.service.test.js
+++ b/test/services/notices/setup/check.service.test.js
@@ -23,6 +23,7 @@ describe('Notices - Setup - Check service', () => {
   let removeLicences
   let session
   let testRecipients
+  let yarStub
 
   beforeEach(async () => {
     removeLicences = ''
@@ -39,6 +40,8 @@ describe('Notices - Setup - Check service', () => {
 
     testRecipients = RecipientsFixture.recipients()
 
+    yarStub = { flash: Sinon.stub().returns([{ title: 'Test', text: 'Notification' }]) }
+
     Sinon.stub(FetchRecipientsService, 'go').resolves([testRecipients.primaryUser])
   })
 
@@ -47,7 +50,7 @@ describe('Notices - Setup - Check service', () => {
   })
 
   it('correctly presents the data', async () => {
-    const result = await CheckService.go(session.id)
+    const result = await CheckService.go(session.id, 1, yarStub)
 
     expect(result).to.equal({
       activeNavBar: 'manage',
@@ -57,6 +60,10 @@ describe('Notices - Setup - Check service', () => {
         cancel: `/system/notices/setup/${session.id}/cancel`,
         download: `/system/notices/setup/${session.id}/download`,
         removeLicences: `/system/notices/setup/${session.id}/remove-licences`
+      },
+      notification: {
+        text: 'Notification',
+        title: 'Test'
       },
       page: 1,
       pagination: {
@@ -78,6 +85,46 @@ describe('Notices - Setup - Check service', () => {
     })
   })
 
+  describe('the "selectedRecipients" property', () => {
+    describe('when there are no "selectedRecipients"', () => {
+      it('adds the "selectedRecipients" array to the session', async () => {
+        await CheckService.go(session.id, 1, yarStub)
+
+        const refreshedSession = await session.$query()
+
+        expect(refreshedSession).to.equal({
+          ...session,
+          data: {
+            ...session.data,
+            selectedRecipients: [testRecipients.primaryUser.contact_hash_id]
+          },
+          selectedRecipients: [testRecipients.primaryUser.contact_hash_id]
+        })
+      })
+    })
+
+    describe('when there are "selectedRecipients"', () => {
+      beforeEach(async () => {
+        session = await SessionHelper.add({
+          data: {
+            returnsPeriod: 'quarterFour',
+            removeLicences,
+            journey: 'standard',
+            noticeType: 'invitations',
+            referenceCode: 'RINV-123',
+            selectedRecipients: [testRecipients.primaryUser.contact_hash_id]
+          }
+        })
+      })
+
+      it('does not affect the "selectedRecipients"', async () => {
+        await CheckService.go(session.id, 1, yarStub)
+
+        const refreshedSession = await session.$query()
+        expect(refreshedSession).to.equal(session)
+      })
+    })
+  })
   describe('when the journey is "alerts"', () => {
     beforeEach(async () => {
       session = await SessionHelper.add({
@@ -95,7 +142,7 @@ describe('Notices - Setup - Check service', () => {
     })
 
     it('correctly presents the data', async () => {
-      const result = await CheckService.go(session.id)
+      const result = await CheckService.go(session.id, 1, yarStub)
 
       expect(result).to.equal({
         activeNavBar: 'manage',
@@ -104,6 +151,10 @@ describe('Notices - Setup - Check service', () => {
           back: `/system/notices/setup/${session.id}/abstraction-alerts/alert-email-address`,
           cancel: `/system/notices/setup/${session.id}/cancel`,
           download: `/system/notices/setup/${session.id}/download`
+        },
+        notification: {
+          text: 'Notification',
+          title: 'Test'
         },
         page: 1,
         pagination: {

--- a/test/services/notices/setup/check.service.test.js
+++ b/test/services/notices/setup/check.service.test.js
@@ -50,7 +50,7 @@ describe('Notices - Setup - Check service', () => {
   })
 
   it('correctly presents the data', async () => {
-    const result = await CheckService.go(session.id, 1, yarStub)
+    const result = await CheckService.go(session.id, yarStub)
 
     expect(result).to.equal({
       activeNavBar: 'manage',
@@ -88,7 +88,7 @@ describe('Notices - Setup - Check service', () => {
   describe('the "selectedRecipients" property', () => {
     describe('when there are no "selectedRecipients"', () => {
       it('adds the "selectedRecipients" array to the session', async () => {
-        await CheckService.go(session.id, 1, yarStub)
+        await CheckService.go(session.id, yarStub)
 
         const refreshedSession = await session.$query()
 
@@ -118,7 +118,7 @@ describe('Notices - Setup - Check service', () => {
       })
 
       it('does not affect the "selectedRecipients"', async () => {
-        await CheckService.go(session.id, 1, yarStub)
+        await CheckService.go(session.id, yarStub)
 
         const refreshedSession = await session.$query()
         expect(refreshedSession).to.equal(session)
@@ -142,7 +142,7 @@ describe('Notices - Setup - Check service', () => {
     })
 
     it('correctly presents the data', async () => {
-      const result = await CheckService.go(session.id, 1, yarStub)
+      const result = await CheckService.go(session.id, yarStub)
 
       expect(result).to.equal({
         activeNavBar: 'manage',

--- a/test/services/notices/setup/recipients.service.test.js
+++ b/test/services/notices/setup/recipients.service.test.js
@@ -23,22 +23,22 @@ describe('Notices - Setup - Recipients service', () => {
   let recipients
   let session
 
+  afterEach(() => {
+    Sinon.restore()
+  })
+
   describe('when getting the recipients', () => {
     describe('and all recipients are required', () => {
       beforeEach(async () => {
+        recipients = RecipientsFixture.recipients()
+
         session = await SessionHelper.add({
           data: {
             journey: 'standard'
           }
         })
 
-        recipients = RecipientsFixture.recipients()
-
         Sinon.stub(FetchRecipientsService, 'go').resolves([recipients.primaryUser, recipients.returnsAgent])
-      })
-
-      afterEach(() => {
-        Sinon.restore()
       })
 
       it('returns all the recipients formatted for display', async () => {
@@ -78,10 +78,6 @@ describe('Notices - Setup - Recipients service', () => {
           })
 
           Sinon.stub(FetchRecipientsService, 'go').resolves([recipients.primaryUser, recipients.licenceHolder])
-        })
-
-        afterEach(() => {
-          Sinon.restore()
         })
 
         it('returns only the selected recipients formatted for display', async () => {
@@ -128,10 +124,6 @@ describe('Notices - Setup - Recipients service', () => {
           Sinon.stub(FetchRecipientsService, 'go').resolves([recipients.primaryUser, recipients.returnsAgent])
         })
 
-        afterEach(() => {
-          Sinon.restore()
-        })
-
         it('returns all the recipients formatted for display', async () => {
           const result = await RecipientsService.go(session, false)
 
@@ -154,6 +146,67 @@ describe('Notices - Setup - Recipients service', () => {
             }
           ])
         })
+      })
+    })
+
+    describe('and there are "additionalRecipients"', () => {
+      beforeEach(async () => {
+        recipients = RecipientsFixture.recipients()
+
+        session = await SessionHelper.add({
+          data: {
+            journey: 'standard',
+            additionalRecipients: [recipients.licenceHolder]
+          }
+        })
+
+        Sinon.stub(FetchRecipientsService, 'go').resolves([recipients.primaryUser, recipients.returnsAgent])
+      })
+
+      it('returns all the recipients formatted for display with the "additionalRecipients"', async () => {
+        const result = await RecipientsService.go(session)
+
+        expect(result).to.equal([
+          {
+            contact: null,
+            contact_hash_id: '90129f6aa5bf2ad50aa3fefd3f8cf86a',
+            contact_type: 'Primary user',
+            email: 'primary.user@important.com',
+            licence_refs: recipients.primaryUser.licence_refs,
+            message_type: 'Email'
+          },
+          {
+            contact: null,
+            contact_hash_id: '2e6918568dfbc1d78e2fbe279aaee990',
+            contact_type: 'Returns agent',
+            email: 'returns.agent@important.com',
+            licence_refs: recipients.returnsAgent.licence_refs,
+            message_type: 'Email'
+          },
+          {
+            contact: {
+              addressLine1: '1',
+              addressLine2: 'Privet Drive',
+              addressLine3: null,
+              addressLine4: null,
+              country: null,
+              county: 'Surrey',
+              forename: 'Harry',
+              initials: 'H J',
+              name: 'Licence holder',
+              postcode: 'WD25 7LR',
+              role: 'Licence holder',
+              salutation: 'Mr',
+              town: 'Little Whinging',
+              type: 'Person'
+            },
+            contact_hash_id: '22f6457b6be9fd63d8a9a8dd2ed61214',
+            contact_type: 'Licence holder',
+            email: null,
+            licence_refs: recipients.licenceHolder.licence_refs,
+            message_type: 'Letter'
+          }
+        ])
       })
     })
   })

--- a/test/services/notices/setup/recipients.service.test.js
+++ b/test/services/notices/setup/recipients.service.test.js
@@ -23,35 +23,139 @@ describe('Notices - Setup - Recipients service', () => {
   let recipients
   let session
 
-  beforeEach(async () => {
-    session = await SessionHelper.add({
-      data: {
-        journey: 'standard'
-      }
+  describe('when getting the recipients', () => {
+    describe('and all recipients are required', () => {
+      beforeEach(async () => {
+        session = await SessionHelper.add({
+          data: {
+            journey: 'standard'
+          }
+        })
+
+        recipients = RecipientsFixture.recipients()
+
+        Sinon.stub(FetchRecipientsService, 'go').resolves([recipients.primaryUser, recipients.returnsAgent])
+      })
+
+      afterEach(() => {
+        Sinon.restore()
+      })
+
+      it('returns all the recipients formatted for display', async () => {
+        const result = await RecipientsService.go(session)
+
+        expect(result).to.equal([
+          {
+            contact: null,
+            contact_hash_id: '90129f6aa5bf2ad50aa3fefd3f8cf86a',
+            contact_type: 'Primary user',
+            email: 'primary.user@important.com',
+            licence_refs: recipients.primaryUser.licence_refs,
+            message_type: 'Email'
+          },
+          {
+            contact: null,
+            contact_hash_id: '2e6918568dfbc1d78e2fbe279aaee990',
+            contact_type: 'Returns agent',
+            email: 'returns.agent@important.com',
+            licence_refs: recipients.returnsAgent.licence_refs,
+            message_type: 'Email'
+          }
+        ])
+      })
     })
 
-    recipients = RecipientsFixture.recipients()
+    describe('and all recipients are not required', () => {
+      describe('when there are selected recipients', () => {
+        beforeEach(async () => {
+          recipients = RecipientsFixture.recipients()
 
-    Sinon.stub(FetchRecipientsService, 'go').resolves([recipients.primaryUser])
-  })
+          session = await SessionHelper.add({
+            data: {
+              journey: 'standard',
+              selectedRecipients: [recipients.licenceHolder.contact_hash_id]
+            }
+          })
 
-  afterEach(() => {
-    Sinon.restore()
-  })
+          Sinon.stub(FetchRecipientsService, 'go').resolves([recipients.primaryUser, recipients.licenceHolder])
+        })
 
-  it('correctly presents the data', async () => {
-    const result = await RecipientsService.go(session)
+        afterEach(() => {
+          Sinon.restore()
+        })
 
-    expect(result).to.equal([
-      {
-        licence_refs: recipients.primaryUser.licence_refs,
-        contact: null,
-        contact_hash_id: '90129f6aa5bf2ad50aa3fefd3f8cf86a',
-        contact_type: 'Primary user',
-        email: 'primary.user@important.com',
-        message_type: 'Email'
-      }
-    ])
+        it('returns only the selected recipients formatted for display', async () => {
+          const result = await RecipientsService.go(session, false)
+
+          expect(result).to.equal([
+            {
+              contact: {
+                addressLine1: '1',
+                addressLine2: 'Privet Drive',
+                addressLine3: null,
+                addressLine4: null,
+                country: null,
+                county: 'Surrey',
+                forename: 'Harry',
+                initials: 'H J',
+                name: 'Licence holder',
+                postcode: 'WD25 7LR',
+                role: 'Licence holder',
+                salutation: 'Mr',
+                town: 'Little Whinging',
+                type: 'Person'
+              },
+              contact_hash_id: '22f6457b6be9fd63d8a9a8dd2ed61214',
+              contact_type: 'Licence holder',
+              email: null,
+              licence_refs: recipients.licenceHolder.licence_refs,
+              message_type: 'Letter'
+            }
+          ])
+        })
+      })
+
+      describe('when there are no selected recipients', () => {
+        beforeEach(async () => {
+          recipients = RecipientsFixture.recipients()
+
+          session = await SessionHelper.add({
+            data: {
+              journey: 'standard'
+            }
+          })
+
+          Sinon.stub(FetchRecipientsService, 'go').resolves([recipients.primaryUser, recipients.returnsAgent])
+        })
+
+        afterEach(() => {
+          Sinon.restore()
+        })
+
+        it('returns all the recipients formatted for display', async () => {
+          const result = await RecipientsService.go(session, false)
+
+          expect(result).to.equal([
+            {
+              contact: null,
+              contact_hash_id: '90129f6aa5bf2ad50aa3fefd3f8cf86a',
+              contact_type: 'Primary user',
+              email: 'primary.user@important.com',
+              licence_refs: recipients.primaryUser.licence_refs,
+              message_type: 'Email'
+            },
+            {
+              contact: null,
+              contact_hash_id: '2e6918568dfbc1d78e2fbe279aaee990',
+              contact_type: 'Returns agent',
+              email: 'returns.agent@important.com',
+              licence_refs: recipients.returnsAgent.licence_refs,
+              message_type: 'Email'
+            }
+          ])
+        })
+      })
+    })
   })
 
   describe('when the journey is "alerts"', () => {

--- a/test/services/notices/setup/recipients.service.test.js
+++ b/test/services/notices/setup/recipients.service.test.js
@@ -163,7 +163,7 @@ describe('Notices - Setup - Recipients service', () => {
         Sinon.stub(FetchRecipientsService, 'go').resolves([recipients.primaryUser, recipients.returnsAgent])
       })
 
-      it('returns all the recipients formatted for display with the "additionalRecipients"', async () => {
+      it('returns all the recipients (including "additionalRecipients") formatted for display', async () => {
         const result = await RecipientsService.go(session)
 
         expect(result).to.equal([

--- a/test/services/notices/setup/select-recipients.service.test.js
+++ b/test/services/notices/setup/select-recipients.service.test.js
@@ -24,11 +24,13 @@ describe('Notices - Setup - Select Recipients Service', () => {
   let recipients
 
   beforeEach(async () => {
-    sessionData = {}
+    recipients = RecipientsFixture.recipients()
+
+    sessionData = {
+      selectedRecipients: [recipients.primaryUser.contact_hash_id]
+    }
 
     session = await SessionHelper.add({ data: sessionData })
-
-    recipients = RecipientsFixture.recipients()
 
     Sinon.stub(RecipientsService, 'go').resolves([recipients.primaryUser])
   })

--- a/test/services/notices/setup/submit-select-recipients.service.test.js
+++ b/test/services/notices/setup/submit-select-recipients.service.test.js
@@ -18,7 +18,7 @@ const RecipientsService = require('../../../../app/services/notices/setup/recipi
 // Thing under test
 const SubmitSelectRecipientsService = require('../../../../app/services/notices/setup/submit-select-recipients.service.js')
 
-describe('Notices - Setup - Select Recipients Service', () => {
+describe('Notices - Setup - Submit Select Recipients Service', () => {
   let payload
   let recipients
   let session

--- a/test/services/notices/setup/submit-select-recipients.service.test.js
+++ b/test/services/notices/setup/submit-select-recipients.service.test.js
@@ -3,6 +3,7 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
+const Sinon = require('sinon')
 
 const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
@@ -16,7 +17,6 @@ const RecipientsService = require('../../../../app/services/notices/setup/recipi
 
 // Thing under test
 const SubmitSelectRecipientsService = require('../../../../app/services/notices/setup/submit-select-recipients.service.js')
-const Sinon = require('sinon')
 
 describe('Notices - Setup - Select Recipients Service', () => {
   let payload


### PR DESCRIPTION

https://eaflood.atlassian.net/browse/WATER-5041

When the user has created an additional recipient, we need to include these additional recipients (could be many) in the shared/ common recipients' logic. 

This change adds the 'additionalRecipients' array to the RecipientsService. Regardless of other consideration the 'additionalRecipients' are always added to the recipients if present. 

When adding additional recipients, we need to handle make sure the selected recipients are updated. We do this in the contact types submit handler to simplify the logic. When a new recipient is added, we add the contact hash id to the selected recipients array.

To make this work, we need to create the selected recipients on the check page. We do this indiscriminately to keep the code flexible (if we allow the 'manage recipients' flow on all journeys). 

we have also changed the logic when a new recipient is added, we redirect them to the check page and show a notification, telling the user a new recipient has been added.

This change ensures our standard recipients array (de duplicated / selected) can be used / reliable in all areas of the code.