### PR TITLE
Do not run snyk check in CI for dependabot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,7 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }} # This needs to be set in your repo; settings -> secrets
 
       - name: Run Snyk to check for vulnerabilities
+        if: github.actor != 'dependabot[bot]'
         uses: snyk/actions/node@master
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5191

We recently updated our use of [Snyk](https://snyk.io/) to prevent packages with vulnerabilities from being added to the project. Previously, we had **Snyk** as a required check, connecting to the repo whenever changes were made.

For reasons outlined in [this team issue](https://github.com/DEFRA/water-abstraction-team/issues/144), we needed to change it to [run the check from GitHub as part of our CI workflow](https://github.com/DEFRA/water-abstraction-system/pull/2250).

This method relies on access to a secret token stored in the repo settings. Unfortunately, as an external party, [Dependabot](https://github.com/dependabot) is not permitted access to these secret tokens. This is the same issue we spotted with SonarQube and were never able to resolve.

So, this change applies the same clause we use for **SonarQube** to the **Snyk** step in our CI.