### PR TITLE
Add `preventDoubleClick` to cancel bill run button

### DIFF
--- a/app/views/bill-runs/cancel.njk
+++ b/app/views/bill-runs/cancel.njk
@@ -63,6 +63,6 @@
   <form method="post">
     <input type="hidden" name="wrlsCrumb" value="{{wrlsCrumb}}"/>
 
-    {{ govukButton({ text: "Cancel bill run" }) }}
+    {{ govukButton({ text: "Cancel bill run", preventDoubleClick: true }) }}
   </form>
 {% endblock %}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5154

We have spotted that Cancel bill run button does not have the `preventDoubleClick` attribute set. This PR will fix that.