### PR TITLE
Fix bill run check page back link

### DIFF
--- a/app/presenters/bill-runs/setup/check/base-check.presenter.js
+++ b/app/presenters/bill-runs/setup/check/base-check.presenter.js
@@ -14,7 +14,8 @@ function checkPageBackLink(session) {
     return `/system/bill-runs/setup/${id}/region`
   }
 
-  if (type === 'two_part_supplementary' || ['2024', '2023'].includes(year)) {
+  // 2023 is the first year of SROC. No season is selected for SROC two-part tariff bill runs.
+  if (type === 'two_part_supplementary' || year >= 2023) {
     return `/system/bill-runs/setup/${id}/year`
   }
 

--- a/app/presenters/bill-runs/setup/check/base-check.presenter.js
+++ b/app/presenters/bill-runs/setup/check/base-check.presenter.js
@@ -9,13 +9,13 @@
  */
 function checkPageBackLink(session) {
   const { id, type, year } = session
+  const srocStartYear = 2023
 
   if (!type.startsWith('two_part')) {
     return `/system/bill-runs/setup/${id}/region`
   }
 
-  // 2023 is the first year of SROC. No season is selected for SROC two-part tariff bill runs.
-  if (type === 'two_part_supplementary' || year >= 2023) {
+  if (type === 'two_part_supplementary' || year >= srocStartYear) {
     return `/system/bill-runs/setup/${id}/year`
   }
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5193

When on the check page for a two-part tariff bill run that is for financial year 2025. The back button takes you back to the "Select the season" page instead of the "Select the financial year" page.

This will be fixed in this PR by amending the logic that determines the backlink.