### PR TITLE
Update return forms PDF to use real return data

### DIFF
--- a/app/controllers/notices-setup.controller.js
+++ b/app/controllers/notices-setup.controller.js
@@ -205,9 +205,9 @@ async function viewNoticeType(request, h) {
 }
 
 async function viewPreviewReturnForms(request, h) {
-  const { sessionId } = request.params
+  const { sessionId, returnId } = request.params
 
-  const fileBuffer = await PreviewReturnFormsService.go(sessionId)
+  const fileBuffer = await PreviewReturnFormsService.go(sessionId, returnId)
 
   return h.response(fileBuffer).type('application/pdf').header('Content-Disposition', 'inline; filename="example.pdf"')
 }

--- a/app/presenters/notices/setup/prepare-return-forms.presenter.js
+++ b/app/presenters/notices/setup/prepare-return-forms.presenter.js
@@ -15,22 +15,29 @@ const { formatLongDate } = require('../../base.presenter.js')
  * Each page will be assigned a corresponding object to isolate the data to each page where possible. Those pages are:
  * - The "cover" page, this is the first page. The address is on this page.
  *
+ * @param {SessionModel} session - The session instance
+ * @param {object} dueReturn
+ *
  * @returns {object} - The data formatted for the return form
  */
-function go() {
+function go(session, dueReturn) {
+  const { licenceRef } = session
+
+  const { dueDate, endDate, purpose, returnsFrequency, returnReference, siteDescription, startDate, twoPartTariff } =
+    dueReturn
+
   return {
     address: _address(),
-    description: 'mock site',
-    dueDate: formatLongDate(new Date('2023-10-01')),
-    endDate: formatLongDate(new Date('2023-09-30')),
-    licenceRef: '123',
-    purpose: 'a purpose',
+    siteDescription,
+    dueDate: formatLongDate(new Date(dueDate)),
+    endDate: formatLongDate(new Date(endDate)),
+    licenceRef,
+    purpose,
     regionAndArea: 'A place / in the sun',
-    returnRef: '7646',
-    startDate: formatLongDate(new Date('2023-09-01')),
-    title: _title(),
-    twoPartTariff: true,
-    formatId: 'format id 123'
+    returnReference,
+    startDate: formatLongDate(new Date(startDate)),
+    pageTitle: _pageTitle(returnsFrequency),
+    twoPartTariff
   }
 }
 
@@ -43,15 +50,17 @@ function _address() {
     addressLine5: 'United Kingdom'
   }
 }
-/*
- * {{ 'Water abstraction daily return ' if frequency === 'day' }}
- * {{ 'Water abstraction weekly return ' if frequency === 'week' }}
- * {{ 'Water abstraction monthly return ' if frequency === 'month' }}
- * {{ 'Water abstraction quarterly return ' if frequency === 'quarter' }}
- * {{ 'Water abstraction yearly return ' if frequency === 'year' }}
- */
-function _title() {
-  return 'Water abstraction daily return'
+
+function _pageTitle(returnsFrequency) {
+  const mapper = {
+    day: 'daily',
+    month: 'monthly',
+    quarter: 'quarterly',
+    week: 'weekly',
+    year: 'yearly'
+  }
+
+  return `Water abstraction ${mapper[returnsFrequency]} return`
 }
 
 module.exports = {

--- a/app/presenters/notices/setup/return-forms.presenter.js
+++ b/app/presenters/notices/setup/return-forms.presenter.js
@@ -39,7 +39,7 @@ function _returns(returns, selectedReturns = []) {
       hint: {
         text: `${formatLongDate(new Date(returnItem.startDate))} to ${formatLongDate(new Date(returnItem.endDate))}`
       },
-      text: `${returnItem.returnReference} ${returnItem.description}`,
+      text: `${returnItem.returnReference} ${returnItem.siteDescription}`,
       value: returnItem.returnId
     }
   })

--- a/app/routes/notices-setup.routes.js
+++ b/app/routes/notices-setup.routes.js
@@ -281,7 +281,7 @@ const routes = [
   },
   {
     method: 'GET',
-    path: '/notices/setup/{sessionId}/preview-return-forms',
+    path: '/notices/setup/{sessionId}/preview-return-forms/{returnId}',
     options: {
       handler: NoticesSetupController.viewPreviewReturnForms,
       auth: {

--- a/app/services/notices/setup/fetch-returns-due-by-licence-ref.service.js
+++ b/app/services/notices/setup/fetch-returns-due-by-licence-ref.service.js
@@ -23,11 +23,15 @@ async function go(licenceRef) {
 async function _fetch(licenceRef) {
   return ReturnLogModel.query()
     .select([
-      'returnId',
-      'startDate',
+      'dueDate',
       'endDate',
+      'returnId',
       'returnReference',
-      db.raw(`metadata->'purposes'->0->'tertiary'->>'description' as description`)
+      'returnsFrequency',
+      'startDate',
+      db.raw(`metadata->'purposes'->0->'tertiary'->>'description' as purpose`),
+      db.raw(`metadata->'isTwoPartTariff' as two_part_tariff`),
+      db.raw(`metadata->'description' as site_description`)
     ])
     .where('licenceRef', licenceRef)
     .where('endDate', '<=', timestampForPostgres())

--- a/app/services/notices/setup/prepare-return-forms.service.js
+++ b/app/services/notices/setup/prepare-return-forms.service.js
@@ -13,18 +13,27 @@ const SessionModel = require('../../../models/session.model.js')
 /**
  * Orchestrates fetching and presenting the data for the return form
  *
- * @param {string} sessionId
+ * @param {string} sessionId - The UUID of the current session
+ * @param {string} returnId - The UUID of the return id
  *
  * @returns {Promise<ArrayBuffer>} - Resolves with the generated form file as an ArrayBuffer.
  */
-async function go(sessionId) {
+async function go(sessionId, returnId) {
   const session = await SessionModel.query().findById(sessionId)
 
-  const pageData = PrepareReturnFormsPresenter.go(session)
+  const dueReturn = _dueReturn(session.dueReturns, returnId)
+
+  const pageData = PrepareReturnFormsPresenter.go(session, dueReturn)
 
   const requestData = await GenerateReturnFormRequest.send(pageData)
 
   return requestData.response.body
+}
+
+function _dueReturn(dueReturns, returnId) {
+  return dueReturns.find((dueReturn) => {
+    return dueReturn.returnId === returnId
+  })
 }
 
 module.exports = {

--- a/app/services/notices/setup/preview-return-forms.service.js
+++ b/app/services/notices/setup/preview-return-forms.service.js
@@ -13,12 +13,13 @@ const PrepareReturnFormsService = require('./prepare-return-forms.service.js')
  *
  * This service returns the file to be display in the browser. This will likely be the built-in pdf viewer.
  *
- * @param {string} sessionId
+ * @param {string} sessionId - The UUID of the current session
+ * @param {string} returnId - The UUID of the return id
  *
  * @returns {Promise<ArrayBuffer>} - Resolves with the generated form file as an ArrayBuffer.
  */
-async function go(sessionId) {
-  return PrepareReturnFormsService.go(sessionId)
+async function go(sessionId, returnId) {
+  return PrepareReturnFormsService.go(sessionId, returnId)
 }
 
 module.exports = {

--- a/app/views/notices/pdfs/layout/header.njk
+++ b/app/views/notices/pdfs/layout/header.njk
@@ -5,7 +5,7 @@
         <div class="licence">
           <p class="smaller">
             Return reference&nbsp;
-            <span class="bold">{{ formatId }}</span>
+            <span class="bold">{{ returnReference }}</span>
           </p>
           <p class="smaller">
             Licence number&nbsp;

--- a/app/views/notices/pdfs/pages/cover.njk
+++ b/app/views/notices/pdfs/pages/cover.njk
@@ -94,12 +94,12 @@
 
         <div class="item">
           <p class="label">Return reference</p>
-          <p class="bold">{{ returnRef }}</p>
+          <p class="bold">{{ returnReference }}</p>
         </div>
 
         <div class="item">
           <p class="label">Site description</p>
-          <p class="bold">{{ description | title }}</p>
+          <p class="bold">{{ siteDescription | title }}</p>
         </div>
 
         <div class="item">

--- a/app/views/notices/pdfs/pages/declaration.njk
+++ b/app/views/notices/pdfs/pages/declaration.njk
@@ -42,7 +42,7 @@
           <p class="label">
             If you need to explain an entry or give more information send this on a
             separate sheet. Write the return reference
-            <span class="bold">{{ formatId }}</span>
+            <span class="bold">{{ returnReference }}</span>
             and licence number
             <span class="bold">{{ licenceRef }}</span>
             on each sheet.

--- a/test/controllers/notices-setup.controller.test.js
+++ b/test/controllers/notices-setup.controller.test.js
@@ -817,7 +817,7 @@ describe('Notices Setup controller', () => {
       beforeEach(() => {
         getOptions = {
           method: 'GET',
-          url: basePath + `/${session.id}/preview-return-forms`,
+          url: basePath + `/${session.id}/preview-return-forms/1234`,
           auth: {
             strategy: 'session',
             credentials: { scope: ['returns'] }

--- a/test/presenters/notices/setup/prepare-return-forms.presenter.test.js
+++ b/test/presenters/notices/setup/prepare-return-forms.presenter.test.js
@@ -12,14 +12,26 @@ const PrepareReturnFormsPresenter = require('../../../../app/presenters/notices/
 
 describe('Notices - Setup - Prepare Return Forms Presenter', () => {
   let session
+  let dueReturn
 
   beforeEach(() => {
-    session = {}
+    session = { licenceRef: '123' }
+
+    dueReturn = {
+      dueDate: '2025-07-06',
+      endDate: '2025-06-06',
+      purpose: 'A purpose',
+      returnsFrequency: 'day',
+      returnReference: '123456',
+      siteDescription: 'Water park',
+      startDate: '2025-01-01',
+      twoPartTariff: false
+    }
   })
 
   describe('when called', () => {
     it('returns page data for the view', () => {
-      const result = PrepareReturnFormsPresenter.go(session)
+      const result = PrepareReturnFormsPresenter.go(session, dueReturn)
 
       expect(result).to.equal({
         address: {
@@ -29,17 +41,78 @@ describe('Notices - Setup - Prepare Return Forms Presenter', () => {
           addressLine4: 'NW1 6XE',
           addressLine5: 'United Kingdom'
         },
-        description: 'mock site',
-        dueDate: '1 October 2023',
-        endDate: '30 September 2023',
-        formatId: 'format id 123',
+        siteDescription: 'Water park',
+        dueDate: '6 July 2025',
+        endDate: '6 June 2025',
         licenceRef: '123',
-        purpose: 'a purpose',
+        purpose: 'A purpose',
         regionAndArea: 'A place / in the sun',
-        returnRef: '7646',
-        startDate: '1 September 2023',
-        title: 'Water abstraction daily return',
-        twoPartTariff: true
+        returnReference: '123456',
+        startDate: '1 January 2025',
+        pageTitle: 'Water abstraction daily return',
+        twoPartTariff: false
+      })
+    })
+
+    describe('the "pageTitle" property', () => {
+      describe('when the "returnsFrequency" is "day"', () => {
+        beforeEach(() => {
+          dueReturn.returnsFrequency = 'day'
+        })
+
+        it('should return the relevant title', () => {
+          const result = PrepareReturnFormsPresenter.go(session, dueReturn)
+
+          expect(result.pageTitle).to.equal('Water abstraction daily return')
+        })
+      })
+
+      describe('when the "returnsFrequency" is "month"', () => {
+        beforeEach(() => {
+          dueReturn.returnsFrequency = 'month'
+        })
+
+        it('should return the relevant title', () => {
+          const result = PrepareReturnFormsPresenter.go(session, dueReturn)
+
+          expect(result.pageTitle).to.equal('Water abstraction monthly return')
+        })
+      })
+
+      describe('when the "returnsFrequency" is "quarter"', () => {
+        beforeEach(() => {
+          dueReturn.returnsFrequency = 'quarter'
+        })
+
+        it('should return the relevant title', () => {
+          const result = PrepareReturnFormsPresenter.go(session, dueReturn)
+
+          expect(result.pageTitle).to.equal('Water abstraction quarterly return')
+        })
+      })
+
+      describe('when the "returnsFrequency" is "week"', () => {
+        beforeEach(() => {
+          dueReturn.returnsFrequency = 'week'
+        })
+
+        it('should return the relevant title', () => {
+          const result = PrepareReturnFormsPresenter.go(session, dueReturn)
+
+          expect(result.pageTitle).to.equal('Water abstraction weekly return')
+        })
+      })
+
+      describe('when the "returnsFrequency" is "year"', () => {
+        beforeEach(() => {
+          dueReturn.returnsFrequency = 'year'
+        })
+
+        it('should return the relevant title', () => {
+          const result = PrepareReturnFormsPresenter.go(session, dueReturn)
+
+          expect(result.pageTitle).to.equal('Water abstraction yearly return')
+        })
       })
     })
   })

--- a/test/presenters/notices/setup/returns-for-paper-forms.presenter.test.js
+++ b/test/presenters/notices/setup/returns-for-paper-forms.presenter.test.js
@@ -19,7 +19,7 @@ describe('Notices - Setup - Returns For Paper Forms presenter', () => {
 
   beforeEach(() => {
     dueReturn = {
-      description: 'Potable Water Supply - Direct',
+      siteDescription: 'Potable Water Supply - Direct',
       endDate: '2003-03-31',
       returnId: generateUUID(),
       returnReference: '3135',

--- a/test/services/notices/setup/fetch-returns-due-by-licence-ref.service.test.js
+++ b/test/services/notices/setup/fetch-returns-due-by-licence-ref.service.test.js
@@ -24,6 +24,7 @@ describe('Notices - Setup - Fetch Returns Due By Licence Ref service', () => {
     returnLog = await ReturnLogHelper.add({
       licenceRef,
       metadata: {
+        description: 'Water park',
         purposes: [
           {
             tertiary: { description: 'Potable Water Supply - Direct' }
@@ -51,11 +52,15 @@ describe('Notices - Setup - Fetch Returns Due By Licence Ref service', () => {
 
       expect(result).to.equal([
         {
-          description: 'Potable Water Supply - Direct',
+          dueDate: new Date('2023-04-28'),
           endDate: new Date('2023-03-31'),
+          purpose: 'Potable Water Supply - Direct',
           returnId: returnLog.returnId,
           returnReference: returnLog.returnReference,
-          startDate: new Date('2022-04-01')
+          returnsFrequency: 'month',
+          siteDescription: 'Water park',
+          startDate: new Date('2022-04-01'),
+          twoPartTariff: null
         }
       ])
     })

--- a/test/services/notices/setup/preview-return-forms.service.test.js
+++ b/test/services/notices/setup/preview-return-forms.service.test.js
@@ -19,11 +19,29 @@ const PreviewReturnFormsService = require('../../../../app/services/notices/setu
 
 describe('Notices - Setup - Preview Return Forms Service', () => {
   let notifierStub
+  let returnId
   let session
   let sessionData
 
   beforeEach(async () => {
-    sessionData = {}
+    returnId = '1234'
+
+    sessionData = {
+      licenceRef: '123',
+      dueReturns: [
+        {
+          returnId,
+          dueDate: '2025-07-06',
+          endDate: '2025-06-06',
+          purpose: 'A purpose',
+          returnsFrequency: 'day',
+          returnReference: '123456',
+          siteDescription: 'Water park',
+          startDate: '2025-01-01',
+          twoPartTariff: false
+        }
+      ]
+    }
 
     session = await SessionHelper.add({ data: sessionData })
 
@@ -46,7 +64,7 @@ describe('Notices - Setup - Preview Return Forms Service', () => {
 
   describe('when called', () => {
     it('returns generated pdf as an array buffer', async () => {
-      const result = await PreviewReturnFormsService.go(session.id)
+      const result = await PreviewReturnFormsService.go(session.id, returnId)
 
       expect(result).to.be.instanceOf(ArrayBuffer)
       // The encoded string is 9 chars
@@ -54,7 +72,7 @@ describe('Notices - Setup - Preview Return Forms Service', () => {
     })
 
     it('should call "GenerateReturnFormRequest"', async () => {
-      await PreviewReturnFormsService.go(session.id)
+      await PreviewReturnFormsService.go(session.id, returnId)
 
       expect(GenerateReturnFormRequest.send.called).to.be.true()
     })

--- a/test/services/notices/setup/returns-for-paper-forms.service.test.js
+++ b/test/services/notices/setup/returns-for-paper-forms.service.test.js
@@ -25,7 +25,7 @@ describe('Notices - Setup - Returns For Paper Forms service', () => {
     licenceRef = generateLicenceRef()
 
     dueReturn = {
-      description: 'Potable Water Supply - Direct',
+      siteDescription: 'Potable Water Supply - Direct',
       endDate: '2003-03-31',
       returnId: generateUUID(),
       returnReference: '3135',

--- a/test/services/notices/setup/submit-returns-for-paper-forms.service.test.js
+++ b/test/services/notices/setup/submit-returns-for-paper-forms.service.test.js
@@ -28,7 +28,7 @@ describe('Notices - Setup - Submit Returns For Paper Forms service', () => {
     licenceRef = generateLicenceRef()
 
     dueReturn = {
-      description: 'Potable Water Supply - Direct',
+      siteDescription: 'Potable Water Supply - Direct',
       endDate: '2003-03-31',
       returnId: generateUUID(),
       returnReference: '3135',


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5162

This change updates the return forms PDF to use data from the selected return.

This change adds the return id to the path / controller. This allows the preview to be specific to the return selected on the selected returns page. When we implement the sending of the notice, we can pass in the return id to generate the PDF per return id (and recipient if required).

We needed to update the exciting fetch logic to return the additional data and check the return passed in has been selected from the journey.

Some general renaming has been done to update a previous assumption, The main one being the removal of the 'formatId' this is guaranteed to be the same as the 'returnReference' and has been removed.

The 'regionAndArea' will be updated in another change. This has some additional complexity to big for this change.