### PR TITLE
Ad-hoc Notice - submit manual address

### DIFF
--- a/app/controllers/address.controller.js
+++ b/app/controllers/address.controller.js
@@ -37,8 +37,9 @@ async function submitManual(request, h) {
     return h.view('address/manual.njk', pageData)
   }
 
-  // TODO: return to calling service
-  return h.redirect(`/system/address/${sessionId}/check`)
+  await AddAdditionalRecipientService.go(sessionId)
+
+  return h.redirect(pageData.redirect)
 }
 
 async function submitPostcode(request, h) {

--- a/app/services/address/submit-manual.service.js
+++ b/app/services/address/submit-manual.service.js
@@ -26,17 +26,19 @@ async function go(sessionId, payload) {
   if (!validationResult) {
     await _save(session, payload)
 
-    return {}
+    return {
+      redirect: session.address.redirectUrl
+    }
   }
 
-  const _submittedData = {
+  const submittedData = {
     id: session.id,
     address: {
       ...payload
     }
   }
 
-  const pageData = ManualAddressPresenter.go(_submittedData)
+  const pageData = ManualAddressPresenter.go(submittedData)
 
   return {
     error: validationResult,

--- a/test/controllers/address.controller.test.js
+++ b/test/controllers/address.controller.test.js
@@ -224,6 +224,7 @@ describe('Address controller', () => {
       describe('when addresses are found', () => {
         beforeEach(() => {
           Sinon.stub(ManualAddressService, 'go').returns({})
+          Sinon.stub(AddAdditionalRecipientService, 'go')
         })
 
         it('returns the page successfully', async () => {
@@ -241,14 +242,17 @@ describe('Address controller', () => {
 
       describe('when the request succeeds', () => {
         beforeEach(() => {
-          Sinon.stub(SubmitManualAddressService, 'go').returns({})
+          Sinon.stub(SubmitManualAddressService, 'go').returns({
+            redirect: '/system/notices/setup/fecd5f15-bacf-4b3d-bdcd-ef279a97b061/check'
+          })
+          Sinon.stub(AddAdditionalRecipientService, 'go')
         })
 
         it('redirects to the check page', async () => {
           const response = await server.inject(postOptions)
 
           expect(response.statusCode).to.equal(302)
-          expect(response.headers.location).to.equal(`/system/address/fecd5f15-bacf-4b3d-bdcd-ef279a97b061/check`)
+          expect(response.headers.location).to.equal(`/system/notices/setup/fecd5f15-bacf-4b3d-bdcd-ef279a97b061/check`)
         })
       })
 

--- a/test/services/address/submit-manual.service.test.js
+++ b/test/services/address/submit-manual.service.test.js
@@ -24,6 +24,10 @@ describe('Address - Submit Manual Service', () => {
     }
 
     session = await SessionHelper.add({ data: sessionData })
+
+    session.address.redirectUrl = `/system/notices/setup/${session.id}/check`
+
+    await session.$update()
   })
 
   describe('when called', () => {
@@ -44,11 +48,12 @@ describe('Address - Submit Manual Service', () => {
 
       expect(refreshedSession.data).to.equal({
         address: {
-          addressLine1: '1 Fake Farm',
-          addressLine2: '1 Fake street',
-          addressLine3: 'Fake Village',
-          addressLine4: 'Fake City',
-          postcode: 'SW1A 1AA'
+          addressLine1: payload.addressLine1,
+          addressLine2: payload.addressLine2,
+          addressLine3: payload.addressLine3,
+          addressLine4: payload.addressLine4,
+          postcode: payload.postcode,
+          redirectUrl: session.address.redirectUrl
         }
       })
     })
@@ -65,11 +70,12 @@ describe('Address - Submit Manual Service', () => {
 
       expect(refreshedSession.data).to.equal({
         address: {
-          addressLine1: '1 Fake Farm',
+          addressLine1: payload.addressLine1,
           addressLine2: null,
           addressLine3: null,
           addressLine4: null,
-          postcode: 'SW1A 1AA'
+          postcode: payload.postcode,
+          redirectUrl: session.address.redirectUrl
         }
       })
     })
@@ -77,7 +83,9 @@ describe('Address - Submit Manual Service', () => {
     it('continues the journey', async () => {
       const result = await SubmitManualService.go(session.id, payload)
 
-      expect(result).to.equal({})
+      expect(result).to.equal({
+        redirect: `/system/notices/setup/${session.id}/check`
+      })
     })
   })
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5046

As part of sending out notifications to users we need to be able to manually enter an address if the user was not able to find their address listed in the returned lookup or if the lookup failed.

When submitted the information will then be converted into a recipient matching the existing structure retrieved from the database. It is then added to an array to be displayed to the user on the check page. It then returns the user to that check page.