### PR TITLE
Fix not using company in view billing account

### DIFF
--- a/app/presenters/billing-accounts/view-billing-account.presenter.js
+++ b/app/presenters/billing-accounts/view-billing-account.presenter.js
@@ -28,7 +28,7 @@ function go(billingAccountData, licenceId, chargeVersionId, companyId) {
 
   return {
     accountNumber: billingAccount.accountNumber,
-    address: _address(billingAccountAddresses[0].address, billingAccountAddresses[0].contact, company),
+    address: _address(billingAccountAddresses[0], company),
     backLink: _backLink(licenceId, chargeVersionId, companyId),
     billingAccountId: id,
     bills: _bills(bills),
@@ -41,20 +41,24 @@ function go(billingAccountData, licenceId, chargeVersionId, companyId) {
 }
 
 /**
- * Formats a company's address for display on the view billing account page.
+ * Formats a billing account's address for display on the view billing account page.
  *
- * Some companies may have fewer populated address lines than others, resulting in `null` values. This function filters
- * out any empty address lines, applies title casing to each one, and appends the postcode in uppercase.
+ * Some billing accounts will have a different company linked to them via the billing account address, then the primary
+ * company against the billing account itself. This happens if a user opts to set a different company that the bills
+ * should be sent to. So we have to handle this when determining the 'company name'.
  *
- * @param {module:AddressModel} address - The address associated with the billing account.
- * @param {module:ContactModel} contact - The contact associated with the billing account.
- * @param {module:CompanyModel} company - The company associated with the billing account.
+ * Also, some billing accounts may have fewer populated address lines than others, resulting in `null` values. This
+ * function filters out any empty address lines, applies title casing to each one, and appends the postcode in
+ * uppercase.
  *
- * @returns {string[]} An array of formatted address lines for display.
+ * @private
  */
-function _address(address, contact, company) {
+function _address(billingAccountAddress, primaryCompany) {
+  const { address, company, contact } = billingAccountAddress
   const contactName = contact ? `FAO ${contact.$name()}` : null
-  const companyName = titleCase(company.name)
+  const addressCompanyName = company ? company.name : primaryCompany.name
+
+  const companyName = titleCase(addressCompanyName)
 
   const addressLines = [
     address['address1'],

--- a/app/services/billing-accounts/fetch-view-billing-account.service.js
+++ b/app/services/billing-accounts/fetch-view-billing-account.service.js
@@ -61,6 +61,10 @@ async function _fetchBillingAccount(id) {
             'postcode'
           ])
         })
+        .withGraphFetched('company')
+        .modifyGraph('company', (companyBuilder) => {
+          companyBuilder.select(['id', 'name'])
+        })
         .withGraphFetched('contact')
         .modifyGraph('contact', (contactBuilder) => {
           contactBuilder.select(['id', 'contactType', 'department', 'firstName', 'lastName'])

--- a/app/services/billing-accounts/fetch-view-billing-account.service.js
+++ b/app/services/billing-accounts/fetch-view-billing-account.service.js
@@ -38,21 +38,33 @@ async function _fetchBillingAccount(id) {
   return BillingAccountModel.query()
     .findById(id)
     .select(['id', 'accountNumber', 'createdAt', 'lastTransactionFile', 'lastTransactionFileCreatedAt'])
-    .withGraphFetched('billingAccountAddresses')
-    .modifyGraph('billingAccountAddresses', (builder) => {
-      builder.select('id').orderBy('createdAt', 'desc').limit(1)
-    })
     .withGraphFetched('company')
-    .modifyGraph('company', (builder) => {
-      builder.select(['id', 'name'])
+    .modifyGraph('company', (companyBuilder) => {
+      companyBuilder.select(['id', 'name'])
     })
-    .withGraphFetched('billingAccountAddresses.address')
-    .modifyGraph('billingAccountAddresses.address', (builder) => {
-      builder.select(['id', 'address1', 'address2', 'address3', 'address4', 'address5', 'address6', 'postcode'])
-    })
-    .withGraphFetched('billingAccountAddresses.contact')
-    .modifyGraph('billingAccountAddresses.contact', (builder) => {
-      builder.select(['id', 'contactType', 'department', 'firstName', 'lastName'])
+    .withGraphFetched('billingAccountAddresses')
+    .modifyGraph('billingAccountAddresses', (billingAccountAddressesBuilder) => {
+      billingAccountAddressesBuilder
+        .select('id')
+        .orderBy('createdAt', 'desc')
+        .limit(1)
+        .withGraphFetched('address')
+        .modifyGraph('address', (addressBuilder) => {
+          addressBuilder.select([
+            'id',
+            'address1',
+            'address2',
+            'address3',
+            'address4',
+            'address5',
+            'address6',
+            'postcode'
+          ])
+        })
+        .withGraphFetched('contact')
+        .modifyGraph('contact', (contactBuilder) => {
+          contactBuilder.select(['id', 'contactType', 'department', 'firstName', 'lastName'])
+        })
     })
 }
 

--- a/test/fixtures/billing-accounts.fixtures.js
+++ b/test/fixtures/billing-accounts.fixtures.js
@@ -36,6 +36,7 @@ function billingAccount() {
             address6: 'Kent',
             postcode: 'ME15 0NE'
           },
+          company: null,
           contact
         }
       ],

--- a/test/presenters/billing-accounts/view-billing-account.presenter.test.js
+++ b/test/presenters/billing-accounts/view-billing-account.presenter.test.js
@@ -164,6 +164,29 @@ describe('Billing Accounts - View Billing Account presenter', () => {
         ])
       })
     })
+
+    describe('when there is a company against the billing account address (send bills to)', () => {
+      beforeEach(() => {
+        billingAccountData.billingAccount.billingAccountAddresses[0].company = {
+          id: 'baef8037-ecde-49dc-b763-9ac75df7121d',
+          name: 'Andy Dufresne Accountants'
+        }
+      })
+
+      it('returns an array of populated address lines title cased, the postcode capitalised, and the "sent to" company name instead of the primary', () => {
+        const result = ViewBillingAccountPresenter.go(billingAccountData, licenceId, chargeVersionId, companyId)
+
+        expect(result.address).to.equal([
+          'Andy Dufresne Accountants',
+          'FAO Test Testingson',
+          'Tutsham Farm',
+          'West Farleigh',
+          'Maidstone',
+          'Kent',
+          'ME15 0NE'
+        ])
+      })
+    })
   })
 
   describe('the "backLink" property', () => {

--- a/test/services/billing-accounts/fetch-view-billing-account.service.test.js
+++ b/test/services/billing-accounts/fetch-view-billing-account.service.test.js
@@ -19,7 +19,7 @@ const CompanyHelper = require('../../support/helpers/company.helper.js')
 // Thing under test
 const FetchViewBillingAccountService = require('../../../app/services/billing-accounts/fetch-view-billing-account.service.js')
 
-describe('Fetch Billing Account service', () => {
+describe('Billing Accounts - Fetch View Billing Account service', () => {
   let address
   let bill1
   let billingAccount
@@ -28,21 +28,24 @@ describe('Fetch Billing Account service', () => {
   let billRun1
   let billRun2
   let billRun3
-  let company
   let contact
+  let sendToCompany
+  let primaryCompany
 
   describe('when a matching billing account exists', () => {
     beforeEach(async () => {
       address = await AddressHelper.add()
       contact = await ContactHelper.add()
-      company = await CompanyHelper.add()
+      primaryCompany = await CompanyHelper.add()
+      sendToCompany = await CompanyHelper.add({ name: 'Send It Here' })
 
-      billingAccount = await BillingAccountHelper.add({ companyId: company.id })
+      billingAccount = await BillingAccountHelper.add({ companyId: primaryCompany.id })
       billingAccountId = billingAccount.id
 
       billingAccountAddress = await BillingAccountAddressHelper.add({
         addressId: address.id,
         billingAccountId,
+        companyId: sendToCompany.id,
         contactId: contact.id
       })
 
@@ -97,6 +100,10 @@ describe('Fetch Billing Account service', () => {
                 address6: null,
                 postcode: 'BS1 5AH'
               },
+              company: {
+                id: sendToCompany.id,
+                name: 'Send It Here'
+              },
               contact: {
                 id: contact.id,
                 contactType: contact.contactType,
@@ -107,7 +114,7 @@ describe('Fetch Billing Account service', () => {
             }
           ],
           company: {
-            id: company.id,
+            id: primaryCompany.id,
             name: 'Example Trading Ltd'
           }
         },


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5198

We have noticed that we are displaying the wrong company name for some billing accounts. It was spotted when testing WATER-5174 (updating changed billing accounts with their customer file reference).

QA were using the change address journey to force a change, and happened to opt to change who the bills should go to. They then proceeded to create a new billing contact.

Against the record, this new company's ID is recorded in the `public.billing_addresses` `company_id` field. But when we fetch the billing account details, we are only getting the linked contact record, not the company. This results in us always displaying the primary billing account company name when the user has opted to send the bills to a different company (and its name should be displayed).

This change fixes the view to use the billing accounts 'billing address company name' if present.

<details>
<summary>Legacy screen (correct)</summary>

<img width="565" height="592" alt="Screenshot 2025-08-13 at 17 35 13" src="https://github.com/user-attachments/assets/2164005f-710c-4aea-8e23-d6e273090aaa" />

</details>

<details>
<summary>New screen (wrong)</summary>

<img width="718" height="455" alt="Screenshot 2025-08-13 at 17 38 26" src="https://github.com/user-attachments/assets/1214ec7b-2e21-4c0c-b562-af572bb27cd6" />

</details>