### PR TITLE
Update the preview returns route to use the contact hash id

### DIFF
--- a/app/controllers/notices-setup.controller.js
+++ b/app/controllers/notices-setup.controller.js
@@ -205,9 +205,9 @@ async function viewNoticeType(request, h) {
 }
 
 async function viewPreviewReturnForms(request, h) {
-  const { sessionId, returnId } = request.params
+  const { contactHashId, sessionId, returnId } = request.params
 
-  const fileBuffer = await PreviewReturnFormsService.go(sessionId, returnId)
+  const fileBuffer = await PreviewReturnFormsService.go(sessionId, contactHashId, returnId)
 
   return h.response(fileBuffer).type('application/pdf').header('Content-Disposition', 'inline; filename="example.pdf"')
 }

--- a/app/routes/notices-setup.routes.js
+++ b/app/routes/notices-setup.routes.js
@@ -281,7 +281,7 @@ const routes = [
   },
   {
     method: 'GET',
-    path: '/notices/setup/{sessionId}/preview-return-forms/{returnId}',
+    path: '/notices/setup/{sessionId}/preview/{contactHashId}/return-forms/{returnId}',
     options: {
       handler: NoticesSetupController.viewPreviewReturnForms,
       auth: {

--- a/app/services/notices/setup/prepare-return-forms.service.js
+++ b/app/services/notices/setup/prepare-return-forms.service.js
@@ -8,19 +8,16 @@
 
 const GenerateReturnFormRequest = require('../../../requests/gotenberg/generate-return-form.request.js')
 const PrepareReturnFormsPresenter = require('../../../presenters/notices/setup/prepare-return-forms.presenter.js')
-const SessionModel = require('../../../models/session.model.js')
 
 /**
  * Orchestrates fetching and presenting the data for the return form
  *
- * @param {string} sessionId - The UUID of the current session
+ * @param {module:SessionModel} session - The session instance
  * @param {string} returnId - The UUID of the return log
  *
  * @returns {Promise<ArrayBuffer>} - Resolves with the generated form file as an ArrayBuffer.
  */
-async function go(sessionId, returnId) {
-  const session = await SessionModel.query().findById(sessionId)
-
+async function go(session, returnId) {
   const dueReturnLog = _dueReturnLog(session.dueReturns, returnId)
 
   const pageData = PrepareReturnFormsPresenter.go(session, dueReturnLog)

--- a/app/services/notices/setup/preview-return-forms.service.js
+++ b/app/services/notices/setup/preview-return-forms.service.js
@@ -1,25 +1,29 @@
 'use strict'
 
 /**
- * Orchestrates fetching and presenting the data for the '/notices/setup/{sessionId}/preview-return-forms' page
+ * Orchestrates fetching and presenting the data for the '/notices/setup/{sessionId}/preview/{contactHashId}/return-forms/{returnId}' page
  *
  * @module PreviewReturnFormsService
  */
 
 const PrepareReturnFormsService = require('./prepare-return-forms.service.js')
+const SessionModel = require('../../../models/session.model.js')
 
 /**
- * Orchestrates fetching and presenting the data for the '/notices/setup/{sessionId}/preview-return-forms' page
+ * Orchestrates fetching and presenting the data for the '/notices/setup/{sessionId}/preview/{contactHashId}/return-forms/{returnId}' page
  *
  * This service returns the file to be display in the browser. This will likely be the built-in pdf viewer.
  *
  * @param {string} sessionId - The UUID of the current session
+ * @param {string} contactHashId - The recipients unique identifier
  * @param {string} returnId - The UUID of the return log
  *
  * @returns {Promise<ArrayBuffer>} - Resolves with the generated form file as an ArrayBuffer.
  */
-async function go(sessionId, returnId) {
-  return PrepareReturnFormsService.go(sessionId, returnId)
+async function go(sessionId, contactHashId, returnId) {
+  const session = await SessionModel.query().findById(sessionId)
+
+  return PrepareReturnFormsService.go(session, returnId)
 }
 
 module.exports = {

--- a/test/controllers/notices-setup.controller.test.js
+++ b/test/controllers/notices-setup.controller.test.js
@@ -810,14 +810,16 @@ describe('Notices Setup controller', () => {
     })
   })
 
-  describe('notices/setup/{sessionId}/preview-return-forms', () => {
+  describe('/notices/setup/{sessionId}/preview/{contactHashId}/return-forms/{returnId}', () => {
     describe('GET', () => {
       let buffer
 
       beforeEach(() => {
         getOptions = {
           method: 'GET',
-          url: basePath + `/${session.id}/preview-return-forms/95b54f97-fefb-46e7-aae8-ebf40ecb8b50`,
+          url:
+            basePath +
+            `/${session.id}/preview/938c2cc0dcc05f2b68c4287040cfcf71/return-forms/95b54f97-fefb-46e7-aae8-ebf40ecb8b50`,
           auth: {
             strategy: 'session',
             credentials: { scope: ['returns'] }

--- a/test/services/notices/setup/prepare-return-forms.service.test.js
+++ b/test/services/notices/setup/prepare-return-forms.service.test.js
@@ -8,9 +8,6 @@ const Sinon = require('sinon')
 const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
-// Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
-
 // Things we need to stub
 const GenerateReturnFormRequest = require('../../../../app/requests/gotenberg/generate-return-form.request.js')
 
@@ -21,12 +18,11 @@ describe('Notices - Setup - Prepare Return Forms Service', () => {
   let notifierStub
   let returnId
   let session
-  let sessionData
 
   beforeEach(async () => {
     returnId = '1234'
 
-    sessionData = {
+    session = {
       licenceRef: '123',
       dueReturns: [
         {
@@ -44,8 +40,6 @@ describe('Notices - Setup - Prepare Return Forms Service', () => {
         }
       ]
     }
-
-    session = await SessionHelper.add({ data: sessionData })
 
     const buffer = new TextEncoder().encode('mock file').buffer
 
@@ -66,7 +60,7 @@ describe('Notices - Setup - Prepare Return Forms Service', () => {
 
   describe('when called', () => {
     it('returns generated pdf as an array buffer', async () => {
-      const result = await PrepareReturnFormsService.go(session.id, returnId)
+      const result = await PrepareReturnFormsService.go(session, returnId)
 
       expect(result).to.be.instanceOf(ArrayBuffer)
       // The encoded string is 9 chars
@@ -74,7 +68,7 @@ describe('Notices - Setup - Prepare Return Forms Service', () => {
     })
 
     it('should call "GenerateReturnFormRequest" with the page data for the provided "returnId"', async () => {
-      await PrepareReturnFormsService.go(session.id, returnId)
+      await PrepareReturnFormsService.go(session, returnId)
 
       expect(GenerateReturnFormRequest.send.calledOnce).to.be.true()
 

--- a/test/services/notices/setup/preview-return-forms.service.test.js
+++ b/test/services/notices/setup/preview-return-forms.service.test.js
@@ -18,6 +18,8 @@ const GenerateReturnFormRequest = require('../../../../app/requests/gotenberg/ge
 const PreviewReturnFormsService = require('../../../../app/services/notices/setup/preview-return-forms.service.js')
 
 describe('Notices - Setup - Preview Return Forms Service', () => {
+  const contactHashId = '938c2cc0dcc05f2b68c4287040cfcf71'
+
   let notifierStub
   let returnId
   let session
@@ -66,7 +68,7 @@ describe('Notices - Setup - Preview Return Forms Service', () => {
 
   describe('when called', () => {
     it('returns generated pdf as an array buffer', async () => {
-      const result = await PreviewReturnFormsService.go(session.id, returnId)
+      const result = await PreviewReturnFormsService.go(session.id, contactHashId, returnId)
 
       expect(result).to.be.instanceOf(ArrayBuffer)
       // The encoded string is 9 chars
@@ -74,7 +76,7 @@ describe('Notices - Setup - Preview Return Forms Service', () => {
     })
 
     it('should call "GenerateReturnFormRequest"', async () => {
-      await PreviewReturnFormsService.go(session.id, returnId)
+      await PreviewReturnFormsService.go(session.id, contactHashId, returnId)
 
       expect(GenerateReturnFormRequest.send.calledOnce).to.be.true()
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5162

We need to pass the contact hash id into the preview service to query the recipients (implemented the upcoming change to reduce complexity).

This will be used to find one recipient and will be passed into the prepare return form service. This will align with our end goal of the 'PrepareReturnFormsService' receiving a recipient to extract the address from.

This change is prep work for the upcoming change.