### PR TITLE
Update the notice 'PreviewService' to use the common 'RecipientsService'

### DIFF
--- a/app/services/notices/setup/preview/preview.service.js
+++ b/app/services/notices/setup/preview/preview.service.js
@@ -6,11 +6,9 @@
  */
 
 const AbstractionAlertNotificationsPresenter = require('../../../../presenters/notices/setup/abstraction-alert-notifications.presenter.js')
-const DetermineRecipientsService = require('../determine-recipients.service.js')
-const FetchAbstractionAlertRecipientsService = require('../fetch-abstraction-alert-recipients.service.js')
-const FetchRecipientsService = require('../fetch-recipients.service.js')
 const NotificationsPresenter = require('../../../../presenters/notices/setup/notifications.presenter.js')
 const PreviewPresenter = require('../../../../presenters/notices/setup/preview/preview.presenter.js')
+const RecipientsService = require('../recipients.service.js')
 const SessionModel = require('../../../../models/session.model.js')
 
 /**
@@ -61,18 +59,11 @@ function _notification(licenceMonitoringStationId, recipient, session) {
 }
 
 async function _recipient(contactHashId, session) {
-  let recipientsData
-
-  if (session.noticeType === 'abstractionAlerts') {
-    recipientsData = await FetchAbstractionAlertRecipientsService.go(session)
-  } else {
-    recipientsData = await FetchRecipientsService.go(session)
-  }
-
-  const recipients = DetermineRecipientsService.go(recipientsData)
+  const recipients = await RecipientsService.go(session)
 
   // Using `filter` rather than `find` ensures we return an array which makes it simpler to reuse existing logic
   return recipients.filter((recipient) => {
+    k
     return recipient.contact_hash_id === contactHashId
   })
 }

--- a/app/services/notices/setup/preview/preview.service.js
+++ b/app/services/notices/setup/preview/preview.service.js
@@ -63,7 +63,6 @@ async function _recipient(contactHashId, session) {
 
   // Using `filter` rather than `find` ensures we return an array which makes it simpler to reuse existing logic
   return recipients.filter((recipient) => {
-    k
     return recipient.contact_hash_id === contactHashId
   })
 }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5162

This change has been identified when working on the preview for the return forms.

We created a common 'RecipientsService' to be used in all places a recipient array is needed. This change updates the 'PreviewService' to use that logic.