### PR TITLE
Add the 'FetchLetterRecipientsService'

### DIFF
--- a/app/presenters/notices/setup/check.presenter.js
+++ b/app/presenters/notices/setup/check.presenter.js
@@ -104,15 +104,16 @@ function _paginateRecipients(recipients, page) {
 }
 
 function _previewLink(noticeType, recipient, sessionId, contact) {
-  // We don't currently support previewing return forms
-  if (noticeType === 'returnForms') {
-    return null
-  }
-
   // If we are sending a letter to the recipient, and the address is invalid, we don't want to display the preview link
   // else it might give a false impression the letter will be sent.
   if (contact.length > 1 && contact[1].startsWith('INVALID ADDRESS')) {
     return null
+  }
+
+  if (noticeType === 'returnForms') {
+    // We need to implement an intermediary page to allow the user to select which return id they want to 'preview'.
+    // For now, we add the 'placeHolder' to highlight this is a temporary measure and needs to change.
+    return `/system/notices/setup/${sessionId}/preview/${recipient.contact_hash_id}/return-forms/placeHolder`
   }
 
   // Returns invitations and reminders can be previewed directly

--- a/app/presenters/notices/setup/prepare-return-forms.presenter.js
+++ b/app/presenters/notices/setup/prepare-return-forms.presenter.js
@@ -5,6 +5,7 @@
  * @module PrepareReturnFormsPresenter
  */
 
+const NotifyAddressPresenter = require('./notify-address.presenter.js')
 const { formatLongDate } = require('../../base.presenter.js')
 const { naldAreaCodes, returnRequirementFrequencies } = require('../../../lib/static-lookups.lib.js')
 
@@ -18,10 +19,11 @@ const { naldAreaCodes, returnRequirementFrequencies } = require('../../../lib/st
  *
  * @param {SessionModel} session - The session instance
  * @param {object} dueReturnLog
+ * @param {object} recipient
  *
  * @returns {object} - The data formatted for the return form
  */
-function go(session, dueReturnLog) {
+function go(session, dueReturnLog, recipient) {
   const { licenceRef } = session
 
   const {
@@ -38,7 +40,7 @@ function go(session, dueReturnLog) {
   } = dueReturnLog
 
   return {
-    address: _address(),
+    address: _address(recipient),
     siteDescription,
     dueDate: formatLongDate(new Date(dueDate)),
     endDate: formatLongDate(new Date(endDate)),
@@ -52,14 +54,8 @@ function go(session, dueReturnLog) {
   }
 }
 
-function _address() {
-  return {
-    addressLine1: 'Sherlock Holmes',
-    addressLine2: '221B Baker Street',
-    addressLine3: 'London',
-    addressLine4: 'NW1 6XE',
-    addressLine5: 'United Kingdom'
-  }
+function _address(recipient) {
+  return NotifyAddressPresenter.go(recipient.contact)
 }
 
 /**

--- a/app/services/notices/setup/prepare-return-forms.service.js
+++ b/app/services/notices/setup/prepare-return-forms.service.js
@@ -14,13 +14,14 @@ const PrepareReturnFormsPresenter = require('../../../presenters/notices/setup/p
  *
  * @param {module:SessionModel} session - The session instance
  * @param {string} returnId - The UUID of the return log
+ * @param {object} recipient
  *
  * @returns {Promise<ArrayBuffer>} - Resolves with the generated form file as an ArrayBuffer.
  */
-async function go(session, returnId) {
+async function go(session, returnId, recipient) {
   const dueReturnLog = _dueReturnLog(session.dueReturns, returnId)
 
-  const pageData = PrepareReturnFormsPresenter.go(session, dueReturnLog)
+  const pageData = PrepareReturnFormsPresenter.go(session, dueReturnLog, recipient)
 
   const requestData = await GenerateReturnFormRequest.send(pageData)
 

--- a/app/services/notices/setup/preview-return-forms.service.js
+++ b/app/services/notices/setup/preview-return-forms.service.js
@@ -7,6 +7,7 @@
  */
 
 const PrepareReturnFormsService = require('./prepare-return-forms.service.js')
+const RecipientsService = require('./recipients.service.js')
 const SessionModel = require('../../../models/session.model.js')
 
 /**
@@ -23,7 +24,21 @@ const SessionModel = require('../../../models/session.model.js')
 async function go(sessionId, contactHashId, returnId) {
   const session = await SessionModel.query().findById(sessionId)
 
-  return PrepareReturnFormsService.go(session, returnId)
+  const [recipient] = await _recipient(session, contactHashId)
+
+  if (returnId === 'placeHolder') {
+    returnId = session.selectedReturns[0]
+  }
+
+  return PrepareReturnFormsService.go(session, returnId, recipient)
+}
+
+async function _recipient(session, contactHashId) {
+  const recipients = await RecipientsService.go(session)
+
+  return recipients.filter((recipient) => {
+    return recipient.contact_hash_id === contactHashId
+  })
 }
 
 module.exports = {

--- a/app/services/notices/setup/recipients.service.js
+++ b/app/services/notices/setup/recipients.service.js
@@ -5,9 +5,10 @@
  * @module RecipientsService
  */
 
-const FetchAbstractionAlertRecipientsService = require('./fetch-abstraction-alert-recipients.service.js')
-const FetchRecipientsService = require('./fetch-recipients.service.js')
 const DetermineRecipientsService = require('./determine-recipients.service.js')
+const FetchAbstractionAlertRecipientsService = require('./fetch-abstraction-alert-recipients.service.js')
+const FetchLetterRecipientsService = require('./fetch-letter-recipients.service.js')
+const FetchRecipientsService = require('./fetch-recipients.service.js')
 
 /**
  * Orchestrates fetching and determining recipients
@@ -44,6 +45,8 @@ function _additionalRecipients(recipientsData, session) {
 async function _recipientsData(session) {
   if (session.journey === 'alerts') {
     return FetchAbstractionAlertRecipientsService.go(session)
+  } else if (session.noticeType === 'returnForms') {
+    return FetchLetterRecipientsService.go(session)
   } else {
     return FetchRecipientsService.go(session)
   }

--- a/app/views/notices/pdfs/pages/cover.njk
+++ b/app/views/notices/pdfs/pages/cover.njk
@@ -1,5 +1,11 @@
 {% extends "layout/page-layout.njk" %}
 
+{% macro addressLine(value) %}
+  {% if value %}
+    {{ value }}<br>
+  {% endif %}
+{% endmacro %}
+
 {% block header %}
   <div class="columns">
     <div class="column">
@@ -23,11 +29,13 @@
   {# This needs to account for missing lines etc #}
   <div id="address-container">
     <div class="address-block">
-      {{ address.addressLine1 }}<br>
-      {{ address.addressLine2 }}<br>
-      {{ address.addressLine3 }}<br>
-      {{ address.addressLine4 }}<br>
-      {{ address.addressLine5 }}
+      {{ addressLine(address.address_line_1) }}
+      {{ addressLine(address.address_line_2) }}
+      {{ addressLine(address.address_line_3) }}
+      {{ addressLine(address.address_line_4) }}
+      {{ addressLine(address.address_line_5) }}
+      {{ addressLine(address.address_line_6) }}
+      {{ addressLine(address.address_line_7) }}
     </div>
   </div>
 

--- a/test/presenters/notices/setup/check.presenter.test.js
+++ b/test/presenters/notices/setup/check.presenter.test.js
@@ -352,7 +352,9 @@ describe('Notices - Setup - Check presenter', () => {
             it('should return null', () => {
               const result = CheckPresenter.go(testInput, page, pagination, session)
 
-              expect(result.recipients[0].previewLink).to.be.null()
+              expect(result.recipients[0].previewLink).to.equal(
+                `/system/notices/setup/${session.id}/preview/${testDuplicateRecipients.duplicateLicenceHolder.contact_hash_id}/return-forms/placeHolder`
+              )
             })
           })
         })

--- a/test/presenters/notices/setup/prepare-return-forms.presenter.test.js
+++ b/test/presenters/notices/setup/prepare-return-forms.presenter.test.js
@@ -7,15 +7,21 @@ const Code = require('@hapi/code')
 const { describe, it, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
+// Test helpers
+const RecipientsFixture = require('../../../fixtures/recipients.fixtures.js')
+
 // Thing under test
 const PrepareReturnFormsPresenter = require('../../../../app/presenters/notices/setup/prepare-return-forms.presenter.js')
 
 describe('Notices - Setup - Prepare Return Forms Presenter', () => {
-  let session
   let dueReturnLog
+  let recipient
+  let session
 
   beforeEach(() => {
     session = { licenceRef: '123' }
+
+    recipient = RecipientsFixture.recipients().licenceHolder
 
     dueReturnLog = {
       dueDate: '2025-07-06',
@@ -33,15 +39,16 @@ describe('Notices - Setup - Prepare Return Forms Presenter', () => {
 
   describe('when called', () => {
     it('returns page data for the view', () => {
-      const result = PrepareReturnFormsPresenter.go(session, dueReturnLog)
+      const result = PrepareReturnFormsPresenter.go(session, dueReturnLog, recipient)
 
       expect(result).to.equal({
         address: {
-          addressLine1: 'Sherlock Holmes',
-          addressLine2: '221B Baker Street',
-          addressLine3: 'London',
-          addressLine4: 'NW1 6XE',
-          addressLine5: 'United Kingdom'
+          address_line_1: 'Mr H J Licence holder',
+          address_line_2: '1',
+          address_line_3: 'Privet Drive',
+          address_line_4: 'Little Whinging',
+          address_line_5: 'Surrey',
+          address_line_6: 'WD25 7LR'
         },
         siteDescription: 'Water park',
         dueDate: '6 July 2025',
@@ -63,7 +70,7 @@ describe('Notices - Setup - Prepare Return Forms Presenter', () => {
         })
 
         it('should return the "regionName" and "naldAreaCode" in the text ', () => {
-          const result = PrepareReturnFormsPresenter.go(session, dueReturnLog)
+          const result = PrepareReturnFormsPresenter.go(session, dueReturnLog, recipient)
 
           expect(result.regionAndArea).to.equal('North West / Lower Trent')
         })
@@ -75,7 +82,7 @@ describe('Notices - Setup - Prepare Return Forms Presenter', () => {
         })
 
         it('should return the "regionName" in the text', () => {
-          const result = PrepareReturnFormsPresenter.go(session, dueReturnLog)
+          const result = PrepareReturnFormsPresenter.go(session, dueReturnLog, recipient)
 
           expect(result.regionAndArea).to.equal('North West')
         })
@@ -89,7 +96,7 @@ describe('Notices - Setup - Prepare Return Forms Presenter', () => {
         })
 
         it('should return the relevant title', () => {
-          const result = PrepareReturnFormsPresenter.go(session, dueReturnLog)
+          const result = PrepareReturnFormsPresenter.go(session, dueReturnLog, recipient)
 
           expect(result.pageTitle).to.equal('Water abstraction daily return')
         })
@@ -101,7 +108,7 @@ describe('Notices - Setup - Prepare Return Forms Presenter', () => {
         })
 
         it('should return the relevant title', () => {
-          const result = PrepareReturnFormsPresenter.go(session, dueReturnLog)
+          const result = PrepareReturnFormsPresenter.go(session, dueReturnLog, recipient)
 
           expect(result.pageTitle).to.equal('Water abstraction monthly return')
         })
@@ -113,7 +120,7 @@ describe('Notices - Setup - Prepare Return Forms Presenter', () => {
         })
 
         it('should return the relevant title', () => {
-          const result = PrepareReturnFormsPresenter.go(session, dueReturnLog)
+          const result = PrepareReturnFormsPresenter.go(session, dueReturnLog, recipient)
 
           expect(result.pageTitle).to.equal('Water abstraction quarterly return')
         })
@@ -125,7 +132,7 @@ describe('Notices - Setup - Prepare Return Forms Presenter', () => {
         })
 
         it('should return the relevant title', () => {
-          const result = PrepareReturnFormsPresenter.go(session, dueReturnLog)
+          const result = PrepareReturnFormsPresenter.go(session, dueReturnLog, recipient)
 
           expect(result.pageTitle).to.equal('Water abstraction weekly return')
         })
@@ -137,7 +144,7 @@ describe('Notices - Setup - Prepare Return Forms Presenter', () => {
         })
 
         it('should return the relevant title', () => {
-          const result = PrepareReturnFormsPresenter.go(session, dueReturnLog)
+          const result = PrepareReturnFormsPresenter.go(session, dueReturnLog, recipient)
 
           expect(result.pageTitle).to.equal('Water abstraction yearly return')
         })

--- a/test/services/notices/setup/prepare-return-forms.service.test.js
+++ b/test/services/notices/setup/prepare-return-forms.service.test.js
@@ -8,6 +8,9 @@ const Sinon = require('sinon')
 const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
+// Test helpers
+const RecipientsFixture = require('../../../fixtures/recipients.fixtures.js')
+
 // Things we need to stub
 const GenerateReturnFormRequest = require('../../../../app/requests/gotenberg/generate-return-form.request.js')
 
@@ -16,11 +19,14 @@ const PrepareReturnFormsService = require('../../../../app/services/notices/setu
 
 describe('Notices - Setup - Prepare Return Forms Service', () => {
   let notifierStub
+  let recipient
   let returnId
   let session
 
   beforeEach(async () => {
     returnId = '1234'
+
+    recipient = RecipientsFixture.recipients().licenceHolder
 
     session = {
       licenceRef: '123',
@@ -60,7 +66,7 @@ describe('Notices - Setup - Prepare Return Forms Service', () => {
 
   describe('when called', () => {
     it('returns generated pdf as an array buffer', async () => {
-      const result = await PrepareReturnFormsService.go(session, returnId)
+      const result = await PrepareReturnFormsService.go(session, returnId, recipient)
 
       expect(result).to.be.instanceOf(ArrayBuffer)
       // The encoded string is 9 chars
@@ -68,18 +74,19 @@ describe('Notices - Setup - Prepare Return Forms Service', () => {
     })
 
     it('should call "GenerateReturnFormRequest" with the page data for the provided "returnId"', async () => {
-      await PrepareReturnFormsService.go(session, returnId)
+      await PrepareReturnFormsService.go(session, returnId, recipient)
 
       expect(GenerateReturnFormRequest.send.calledOnce).to.be.true()
 
       const actualCallArgs = GenerateReturnFormRequest.send.getCall(0).args[0]
       expect(actualCallArgs).to.equal({
         address: {
-          addressLine1: 'Sherlock Holmes',
-          addressLine2: '221B Baker Street',
-          addressLine3: 'London',
-          addressLine4: 'NW1 6XE',
-          addressLine5: 'United Kingdom'
+          address_line_1: 'Mr H J Licence holder',
+          address_line_2: '1',
+          address_line_3: 'Privet Drive',
+          address_line_4: 'Little Whinging',
+          address_line_5: 'Surrey',
+          address_line_6: 'WD25 7LR'
         },
         dueDate: '6 July 2025',
         endDate: '6 June 2025',

--- a/test/services/notices/setup/preview-return-forms.service.test.js
+++ b/test/services/notices/setup/preview-return-forms.service.test.js
@@ -9,24 +9,30 @@ const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
+const RecipientsFixture = require('../../../fixtures/recipients.fixtures.js')
 const SessionHelper = require('../../../support/helpers/session.helper.js')
 
 // Things we need to stub
 const GenerateReturnFormRequest = require('../../../../app/requests/gotenberg/generate-return-form.request.js')
+const RecipientsService = require('../../../../app/services/notices/setup/recipients.service.js')
 
 // Thing under test
 const PreviewReturnFormsService = require('../../../../app/services/notices/setup/preview-return-forms.service.js')
 
 describe('Notices - Setup - Preview Return Forms Service', () => {
-  const contactHashId = '938c2cc0dcc05f2b68c4287040cfcf71'
-
+  let contactHashId
   let notifierStub
+  let recipient
   let returnId
   let session
   let sessionData
 
   beforeEach(async () => {
     returnId = '1234'
+
+    recipient = RecipientsFixture.recipients().licenceHolder
+
+    contactHashId = recipient.contact_hash_id
 
     sessionData = {
       licenceRef: '123',
@@ -57,6 +63,15 @@ describe('Notices - Setup - Preview Return Forms Service', () => {
       }
     })
 
+    Sinon.stub(RecipientsService, 'go').resolves([
+      {
+        ...recipient
+      },
+      {
+        contact_hash_id: '630793a76f7f864fe9e85ae193eba76f'
+      }
+    ])
+
     notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
     global.GlobalNotifier = notifierStub
   })
@@ -84,11 +99,12 @@ describe('Notices - Setup - Preview Return Forms Service', () => {
 
       expect(actualCallArgs).to.equal({
         address: {
-          addressLine1: 'Sherlock Holmes',
-          addressLine2: '221B Baker Street',
-          addressLine3: 'London',
-          addressLine4: 'NW1 6XE',
-          addressLine5: 'United Kingdom'
+          address_line_1: 'Mr H J Licence holder',
+          address_line_2: '1',
+          address_line_3: 'Privet Drive',
+          address_line_4: 'Little Whinging',
+          address_line_5: 'Surrey',
+          address_line_6: 'WD25 7LR'
         },
         dueDate: '6 July 2025',
         endDate: '6 June 2025',

--- a/test/services/notices/setup/recipients.service.test.js
+++ b/test/services/notices/setup/recipients.service.test.js
@@ -14,6 +14,7 @@ const SessionHelper = require('../../../support/helpers/session.helper.js')
 
 // Things we need to stub
 const FetchAbstractionAlertRecipientsService = require('../../../../app/services/notices/setup/fetch-abstraction-alert-recipients.service.js')
+const FetchLetterRecipientsService = require('../../../../app/services/notices/setup/fetch-letter-recipients.service.js')
 const FetchRecipientsService = require('../../../../app/services/notices/setup/fetch-recipients.service.js')
 
 // Thing under test
@@ -235,6 +236,50 @@ describe('Notices - Setup - Recipients service', () => {
           email: recipients.additionalContact.email,
           licence_refs: recipients.additionalContact.licence_refs,
           message_type: 'Email'
+        }
+      ])
+    })
+  })
+
+  describe('and the "noticeType" is "returnForms"', () => {
+    beforeEach(async () => {
+      recipients = RecipientsFixture.recipients()
+
+      session = await SessionHelper.add({
+        data: {
+          noticeType: 'returnForms'
+        }
+      })
+
+      Sinon.stub(FetchLetterRecipientsService, 'go').resolves([recipients.licenceHolder])
+    })
+
+    it('returns only letter recipients', async () => {
+      const result = await RecipientsService.go(session)
+
+      expect(result).to.equal([
+        {
+          contact: {
+            addressLine1: '1',
+            addressLine2: 'Privet Drive',
+            addressLine3: null,
+            addressLine4: null,
+            country: null,
+            county: 'Surrey',
+            forename: 'Harry',
+            initials: 'H J',
+            name: 'Licence holder',
+            postcode: 'WD25 7LR',
+            role: 'Licence holder',
+            salutation: 'Mr',
+            town: 'Little Whinging',
+            type: 'Person'
+          },
+          contact_hash_id: '22f6457b6be9fd63d8a9a8dd2ed61214',
+          contact_type: 'Licence holder',
+          email: null,
+          licence_refs: recipients.licenceHolder.licence_refs,
+          message_type: 'Letter'
         }
       ])
     })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5162

When generating a return forms PDF we need to set the address in the page data to be rendered in the form. This we can get from our existing recipients' logic.

This change adds the 'FetchLetterRecipientsService' into the recipient service. This will now return only letters when the notice type is set to 'returnForms'.

We need to pass the recipient into the prepare return forms service to add the address onto the letters cover page. We use our existing address mapper to turn the recipient into an address.

We have updated the preview link to use the contact hash and return id. We need to implement an intermediary page to allow the user to select which return id they want to 'preview'. For now, we have added a 'placeHolder' into the preview link; to ensure it functionally works, we just pick the first return id from the previously selected returns.