### PR TITLE
View templates standardise - page title macro

### DIFF
--- a/app/presenters/return-versions/setup/start-date.presenter.js
+++ b/app/presenters/return-versions/setup/start-date.presenter.js
@@ -27,6 +27,7 @@ function go(session) {
     licenceRef: licence.licenceRef,
     licenceVersionStartDate: _licenceVersionStartDate(licence),
     pageTitle: 'Select the start date for the requirements for returns',
+    pageTitleCaption: `Licence ${licence.licenceRef}`,
     sessionId,
     startDateOption: startDateOptions ?? null
   }

--- a/app/views/macros/page-heading.njk
+++ b/app/views/macros/page-heading.njk
@@ -1,0 +1,8 @@
+{% macro pageHeading(pageTitle, caption, classes='govuk-heading-l') -%}
+  {% if caption %}
+    <span class="govuk-caption-l">{{ caption }}</span>
+  {% endif %}
+  <h1 class="{{ classes }}">
+    {{ pageTitle }}
+  </h1>
+{%- endmacro %}

--- a/app/views/return-versions/setup/start-date.njk
+++ b/app/views/return-versions/setup/start-date.njk
@@ -5,7 +5,7 @@
 {% from 'govuk/components/error-summary/macro.njk' import govukErrorSummary %}
 {% from 'govuk/components/radios/macro.njk' import govukRadios %}
 
-{% from "macros/licence-reference-page-heading.njk" import pageHeading %}
+{% from "macros/page-heading.njk" import pageHeading %}
 
 {% block breadcrumbs %}
   {{
@@ -61,7 +61,7 @@
   {% endif %}
 
   {% set pageHeading %}
-    {{ pageHeading(licenceRef, pageTitle) }}
+    {{ pageHeading(pageTitle, pageTitleCaption) }}
   {% endset %}
 
   <form method="post">

--- a/test/presenters/return-versions/setup/start-date.presenter.test.js
+++ b/test/presenters/return-versions/setup/start-date.presenter.test.js
@@ -47,6 +47,7 @@ describe('Return Versions Setup - Start Date presenter', () => {
         licenceRef: '01/ABC',
         licenceVersionStartDate: '1 January 2023',
         pageTitle: 'Select the start date for the requirements for returns',
+        pageTitleCaption: 'Licence 01/ABC',
         sessionId: '61e07498-f309-4829-96a9-72084a54996d',
         startDateOption: null
       })

--- a/test/services/return-versions/setup/start-date.service.test.js
+++ b/test/services/return-versions/setup/start-date.service.test.js
@@ -60,6 +60,7 @@ describe('Return Versions Setup - Start Date service', () => {
         {
           activeNavBar: 'search',
           pageTitle: 'Select the start date for the requirements for returns',
+          pageTitleCaption: 'Licence 01/ABC',
           anotherStartDateDay: null,
           anotherStartDateMonth: null,
           anotherStartDateYear: null,

--- a/test/services/return-versions/setup/submit-start-date.service.test.js
+++ b/test/services/return-versions/setup/submit-start-date.service.test.js
@@ -355,6 +355,7 @@ describe('Return Versions - Setup - Submit Start Date service', () => {
           {
             activeNavBar: 'search',
             pageTitle: 'Select the start date for the requirements for returns',
+            pageTitleCaption: 'Licence 01/ABC',
             anotherStartDateDay: null,
             anotherStartDateMonth: null,
             anotherStartDateYear: null,


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5200

As started in https://github.com/DEFRA/water-abstraction-system/pull/2186 we're working our way through the pages to standardise the views.

This PR creates a page heading macro that will standardise how titles appear across the site while updating the set up return version start date page. 