### PR TITLE
Update method page to use new header macro

### DIFF
--- a/app/presenters/return-versions/setup/method.presenter.js
+++ b/app/presenters/return-versions/setup/method.presenter.js
@@ -21,6 +21,7 @@ function go(session) {
     licenceRef: licence.licenceRef,
     method: method ?? null,
     pageTitle: 'How do you want to set up the requirements for returns?',
+    pageTitleCaption: `Licence ${licence.licenceRef}`,
     sessionId
   }
 }

--- a/test/presenters/return-versions/setup/method.presenter.test.js
+++ b/test/presenters/return-versions/setup/method.presenter.test.js
@@ -65,6 +65,7 @@ describe('Return Versions - Setup - Method presenter', () => {
         displayCopyExisting: true,
         licenceRef: '01/ABC',
         pageTitle: 'How do you want to set up the requirements for returns?',
+        pageTitleCaption: 'Licence 01/ABC',
         sessionId: '61e07498-f309-4829-96a9-72084a54996d',
         method: null
       })

--- a/test/services/return-versions/setup/method/method.service.test.js
+++ b/test/services/return-versions/setup/method/method.service.test.js
@@ -74,6 +74,7 @@ describe('Return Versions - Setup - Method service', () => {
         {
           activeNavBar: 'search',
           pageTitle: 'How do you want to set up the requirements for returns?',
+          pageTitleCaption: 'Licence 01/ABC',
           backLink: `/system/return-versions/setup/${session.id}/reason`,
           displayCopyExisting: true,
           licenceRef: '01/ABC',

--- a/test/services/return-versions/setup/method/submit-method.service.test.js
+++ b/test/services/return-versions/setup/method/submit-method.service.test.js
@@ -144,6 +144,7 @@ describe('Return Versions - Setup - Submit Method service', () => {
           {
             activeNavBar: 'search',
             pageTitle: 'How do you want to set up the requirements for returns?',
+            pageTitleCaption: 'Licence 01/ABC',
             backLink: `/system/return-versions/setup/${session.id}/reason`,
             displayCopyExisting: true,
             licenceRef: '01/ABC',


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5200

As started in https://github.com/DEFRA/water-abstraction-system/pull/2186 we're working our way through the pages to standardise the views.

This PR updates the set up return version method page.