### PR TITLE
View templates standardise - purpose view

### DIFF
--- a/app/presenters/return-versions/setup/purpose.presenter.js
+++ b/app/presenters/return-versions/setup/purpose.presenter.js
@@ -23,6 +23,7 @@ function go(session, requirementIndex, licencePurposes) {
     licenceId: licence.id,
     licenceRef: licence.licenceRef,
     pageTitle: 'Select the purpose for the requirements for returns',
+    pageTitleCaption: `Licence ${licence.licenceRef}`,
     purposes: _purposes(licencePurposes, requirement.purposes),
     sessionId
   }

--- a/app/views/return-versions/setup/purpose.njk
+++ b/app/views/return-versions/setup/purpose.njk
@@ -6,7 +6,7 @@
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 
-{% from "macros/licence-reference-page-heading.njk" import pageHeading %}
+{% from "macros/page-heading.njk" import pageHeading %}
 
 {% block breadcrumbs %}
   {{
@@ -31,7 +31,7 @@
   {%endif%}
 
   {% set pageHeading %}
-    {{ pageHeading(licenceRef, pageTitle) }}
+    {{ pageHeading(pageTitle, pageTitleCaption) }}
   {% endset %}
 
   <form method="post">

--- a/test/presenters/return-versions/setup/purpose.presenter.test.js
+++ b/test/presenters/return-versions/setup/purpose.presenter.test.js
@@ -75,6 +75,7 @@ describe('Return Versions - Setup - Purpose presenter', () => {
         licenceId: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
         licenceRef: '01/ABC',
         pageTitle: 'Select the purpose for the requirements for returns',
+        pageTitleCaption: 'Licence 01/ABC',
         purposes: [
           { alias: '', checked: false, description: 'Heat Pump', id: '14794d57-1acf-4c91-8b48-4b1ec68bfd6f' },
           {

--- a/test/services/return-versions/setup/purpose.service.test.js
+++ b/test/services/return-versions/setup/purpose.service.test.js
@@ -88,6 +88,7 @@ describe('Return Versions - Setup - Purpose service', () => {
       expect(result).to.equal({
         activeNavBar: 'search',
         pageTitle: 'Select the purpose for the requirements for returns',
+        pageTitleCaption: 'Licence 01/ABC',
         backLink: `/system/return-versions/setup/${session.id}/method`,
         licenceId: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
         licenceRef: '01/ABC',

--- a/test/services/return-versions/setup/submit-purpose.service.test.js
+++ b/test/services/return-versions/setup/submit-purpose.service.test.js
@@ -150,6 +150,7 @@ describe('Return Versions - Setup - Submit Purpose service', () => {
               text: 'Select any purpose for the requirements for returns'
             },
             pageTitle: 'Select the purpose for the requirements for returns',
+            pageTitleCaption: 'Licence 01/ABC',
             backLink: `/system/return-versions/setup/${session.id}/method`,
             licenceId: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
             licenceRef: '01/ABC',
@@ -185,6 +186,7 @@ describe('Return Versions - Setup - Submit Purpose service', () => {
               text: 'Purpose description must be 100 characters or less'
             },
             pageTitle: 'Select the purpose for the requirements for returns',
+            pageTitleCaption: 'Licence 01/ABC',
             backLink: `/system/return-versions/setup/${session.id}/method`,
             licenceId: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
             licenceRef: '01/ABC',


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5200

As started in https://github.com/DEFRA/water-abstraction-system/pull/2186 we're working our way through the pages to standardise the views.

This PR updates the set up return version purpose page.