### PR TITLE
View templates standardise - abstraction period view

### DIFF
--- a/app/presenters/return-versions/setup/abstraction-period.presenter.js
+++ b/app/presenters/return-versions/setup/abstraction-period.presenter.js
@@ -23,6 +23,7 @@ function go(session, requirementIndex) {
     licenceId: licence.id,
     licenceRef: licence.licenceRef,
     pageTitle: 'Enter the abstraction period for the requirements for returns',
+    pageTitleCaption: `Licence ${licence.licenceRef}`,
     sessionId
   }
 }

--- a/app/views/return-versions/setup/abstraction-period.njk
+++ b/app/views/return-versions/setup/abstraction-period.njk
@@ -4,7 +4,7 @@
 {% from "govuk/components/date-input/macro.njk" import govukDateInput %}
 {% from 'govuk/components/error-summary/macro.njk' import govukErrorSummary %}
 
-{% from "macros/licence-reference-page-heading.njk" import pageHeading %}
+{% from "macros/page-heading.njk" import pageHeading %}
 
 {% block breadcrumbs %}
   {{
@@ -32,7 +32,7 @@
     }) }}
   {%endif%}
 
-  {{ pageHeading(licenceRef, pageTitle) }}
+  {{ pageHeading(pageTitle, pageTitleCaption) }}
 
   <form method="post">
     <input type="hidden" name="wrlsCrumb" value="{{wrlsCrumb}}"/>

--- a/test/presenters/return-versions/setup/abstraction-period.presenter.test.js
+++ b/test/presenters/return-versions/setup/abstraction-period.presenter.test.js
@@ -44,6 +44,7 @@ describe('Return Versions Setup - Abstraction Period presenter', () => {
         licenceId: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
         licenceRef: '01/ABC',
         pageTitle: 'Enter the abstraction period for the requirements for returns',
+        pageTitleCaption: 'Licence 01/ABC',
         sessionId: '61e07498-f309-4829-96a9-72084a54996d'
       })
     })

--- a/test/services/return-versions/setup/abstraction-period.service.test.js
+++ b/test/services/return-versions/setup/abstraction-period.service.test.js
@@ -52,6 +52,7 @@ describe('Return Versions Setup - Abstraction Period service', () => {
         {
           activeNavBar: 'search',
           pageTitle: 'Enter the abstraction period for the requirements for returns',
+          pageTitleCaption: 'Licence 01/ABC',
           abstractionPeriod: null,
           backLink: `/system/return-versions/setup/${session.id}/points/0`,
           licenceId: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',

--- a/test/services/return-versions/setup/submit-abstraction-period.service.test.js
+++ b/test/services/return-versions/setup/submit-abstraction-period.service.test.js
@@ -124,6 +124,7 @@ describe('Return Versions Setup - Submit Abstraction Period service', () => {
           {
             activeNavBar: 'search',
             pageTitle: 'Enter the abstraction period for the requirements for returns',
+            pageTitleCaption: 'Licence 01/ABC',
             abstractionPeriod: null,
             backLink: `/system/return-versions/setup/${session.id}/points/0`,
             licenceId: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5200

As started in https://github.com/DEFRA/water-abstraction-system/pull/2186 we're working our way through the pages to standardise the views.

This PR updates the set up return version abstraction period page.