### PR TITLE
View templates standardise - frequency collected view

### DIFF
--- a/app/presenters/return-versions/setup/frequency-collected.presenter.js
+++ b/app/presenters/return-versions/setup/frequency-collected.presenter.js
@@ -23,6 +23,7 @@ function go(session, requirementIndex) {
     licenceId: licence.id,
     licenceRef: licence.licenceRef,
     pageTitle: 'Select how often readings or volumes are collected',
+    pageTitleCaption: `Licence ${licence.licenceRef}`,
     sessionId
   }
 }

--- a/app/views/return-versions/setup/frequency-collected.njk
+++ b/app/views/return-versions/setup/frequency-collected.njk
@@ -4,7 +4,7 @@
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 
-{% from "macros/licence-reference-page-heading.njk" import pageHeading %}
+{% from "macros/page-heading.njk" import pageHeading %}
 
 {% block breadcrumbs %}
   {{
@@ -29,7 +29,7 @@
   {%endif%}
 
   {% set pageHeading %}
-    {{ pageHeading(licenceRef, pageTitle) }}
+    {{ pageHeading(pageTitle, pageTitleCaption) }}
   {% endset %}
 
   <form method="post">

--- a/test/presenters/return-versions/setup/frequency-collected.presenter.test.js
+++ b/test/presenters/return-versions/setup/frequency-collected.presenter.test.js
@@ -44,6 +44,7 @@ describe('Return Versions Setup - Frequency Collected presenter', () => {
         licenceId: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
         licenceRef: '01/ABC',
         pageTitle: 'Select how often readings or volumes are collected',
+        pageTitleCaption: 'Licence 01/ABC',
         sessionId: '61e07498-f309-4829-96a9-72084a54996d'
       })
     })

--- a/test/services/return-versions/setup/frequency-collected.service.test.js
+++ b/test/services/return-versions/setup/frequency-collected.service.test.js
@@ -60,6 +60,7 @@ describe('Return Versions Setup - Frequency Collected service', () => {
         {
           activeNavBar: 'search',
           pageTitle: 'Select how often readings or volumes are collected',
+          pageTitleCaption: 'Licence 01/ABC',
           backLink: `/system/return-versions/setup/${session.id}/site-description/0`,
           frequencyCollected: null,
           licenceId: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',

--- a/test/services/return-versions/setup/submit-frequency-collected.service.test.js
+++ b/test/services/return-versions/setup/submit-frequency-collected.service.test.js
@@ -116,6 +116,7 @@ describe('Return Versions Setup - Submit Frequency Collected service', () => {
           {
             activeNavBar: 'search',
             pageTitle: 'Select how often readings or volumes are collected',
+            pageTitleCaption: 'Licence 01/ABC',
             backLink: `/system/return-versions/setup/${session.id}/site-description/0`,
             frequencyCollected: null,
             licenceId: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5200

As started in https://github.com/DEFRA/water-abstraction-system/pull/2186 we're working our way through the pages to standardise the views.

This PR updates the set up return version frequency collected page.