### PR TITLE
View templates standardise - agreements view

### DIFF
--- a/app/presenters/return-versions/setup/agreements-exceptions.presenter.js
+++ b/app/presenters/return-versions/setup/agreements-exceptions.presenter.js
@@ -23,6 +23,7 @@ function go(session, requirementIndex) {
     licenceId: licence.id,
     licenceRef: licence.licenceRef,
     pageTitle: 'Select agreements and exceptions for the requirements for returns',
+    pageTitleCaption: `Licence ${licence.licenceRef}`,
     sessionId
   }
 }

--- a/app/views/return-versions/setup/agreements-exceptions.njk
+++ b/app/views/return-versions/setup/agreements-exceptions.njk
@@ -5,7 +5,7 @@
 {% from "govuk/components/error-message/macro.njk" import govukErrorMessage %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 
-{% from "macros/licence-reference-page-heading.njk" import pageHeading %}
+{% from "macros/page-heading.njk" import pageHeading %}
 
 {% block breadcrumbs %}
   {{
@@ -30,7 +30,7 @@
   {%endif%}
 
   {% set pageHeading %}
-    {{ pageHeading(licenceRef, pageTitle) }}
+    {{ pageHeading(pageTitle, pageTitleCaption) }}
   {% endset %}
 
   <form method="post">

--- a/test/presenters/return-versions/setup/agreements-exceptions.presenter.test.js
+++ b/test/presenters/return-versions/setup/agreements-exceptions.presenter.test.js
@@ -44,6 +44,7 @@ describe('Return Versions Setup - Agreements Exceptions presenter', () => {
         licenceId: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
         licenceRef: '01/ABC',
         pageTitle: 'Select agreements and exceptions for the requirements for returns',
+        pageTitleCaption: 'Licence 01/ABC',
         sessionId: '61e07498-f309-4829-96a9-72084a54996d'
       })
     })

--- a/test/services/return-versions/setup/agreements-exceptions.service.test.js
+++ b/test/services/return-versions/setup/agreements-exceptions.service.test.js
@@ -52,6 +52,7 @@ describe('Return Versions Setup - Agreements Exceptions service', () => {
         {
           activeNavBar: 'search',
           pageTitle: 'Select agreements and exceptions for the requirements for returns',
+          pageTitleCaption: 'Licence 01/ABC',
           agreementsExceptions: null,
           backLink: `/system/return-versions/setup/${session.id}/frequency-reported/0`,
           licenceId: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',

--- a/test/services/return-versions/setup/submit-agreements-exceptions.service.test.js
+++ b/test/services/return-versions/setup/submit-agreements-exceptions.service.test.js
@@ -130,6 +130,7 @@ describe('Return Versions Setup - Submit Agreements and Exceptions service', () 
         {
           activeNavBar: 'search',
           pageTitle: 'Select agreements and exceptions for the requirements for returns',
+          pageTitleCaption: 'Licence 01/ABC',
           agreementsExceptions: null,
           backLink: `/system/return-versions/setup/${session.id}/frequency-reported/0`,
           licenceId: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5200

As started in https://github.com/DEFRA/water-abstraction-system/pull/2186 we're working our way through the pages to standardise the views.

This PR updates the set up return version agreements page.