### PR TITLE
View templates standardise - check view

### DIFF
--- a/app/presenters/return-versions/setup/check/check.presenter.js
+++ b/app/presenters/return-versions/setup/check/check.presenter.js
@@ -35,6 +35,7 @@ function go(session) {
     multipleUpload,
     note: _note(note),
     pageTitle: `Check the requirements for returns for ${licence.licenceHolder}`,
+    pageTitleCaption: `Licence ${licence.licenceRef}`,
     quarterlyReturnSubmissions: isQuarterlyReturnSubmissions(returnVersionStartDate),
     quarterlyReturns,
     reason: returnRequirementReasons[reason],

--- a/app/views/return-versions/setup/check.njk
+++ b/app/views/return-versions/setup/check.njk
@@ -5,7 +5,7 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "macros/new-line-array-items.njk" import newLineArrayItems %}
 
-{% from "macros/licence-reference-page-heading.njk" import pageHeading %}
+{% from "macros/page-heading.njk" import pageHeading %}
 
 {% block content %}
   {% if notification %}
@@ -15,7 +15,7 @@
     }) }}
   {% endif %}
 
-  {{ pageHeading(licenceRef, pageTitle) }}
+  {{ pageHeading(pageTitle, pageTitleCaption) }}
 
   <hr class="govuk-section-break govuk-!-margin-bottom-2 govuk-section-break--visible">
 

--- a/test/presenters/return-versions/setup/check/check.presenter.test.js
+++ b/test/presenters/return-versions/setup/check/check.presenter.test.js
@@ -50,6 +50,7 @@ describe('Return Versions Setup - Check presenter', () => {
           text: 'No notes added'
         },
         pageTitle: 'Check the requirements for returns for Turbo Kid',
+        pageTitleCaption: 'Licence 01/ABC',
         quarterlyReturnSubmissions: false,
         quarterlyReturns: undefined,
         reason: 'Major change',
@@ -191,6 +192,7 @@ describe('Return Versions Setup - Check presenter', () => {
       const result = CheckPresenter.go(session)
 
       expect(result.pageTitle).to.equal('Check the requirements for returns for Turbo Kid')
+      expect(result.pageTitleCaption).to.equal('Licence 01/ABC')
     })
   })
 

--- a/test/services/return-versions/setup/check/check.service.test.js
+++ b/test/services/return-versions/setup/check/check.service.test.js
@@ -97,6 +97,7 @@ describe('Return Versions - Setup - Check service', () => {
           },
           notification: undefined,
           pageTitle: 'Check the requirements for returns for Turbo Kid',
+          pageTitleCaption: 'Licence 01/ABC',
           quarterlyReturnSubmissions: false,
           quarterlyReturns: undefined,
           reason: 'Major change',


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5200

As started in https://github.com/DEFRA/water-abstraction-system/pull/2186 we're working our way through the pages to standardise the views.

This PR updates the set up return version check page.