### PR TITLE
Update continue btn to confirm in remove tag page

### DIFF
--- a/app/views/licence-monitoring-station/remove.njk
+++ b/app/views/licence-monitoring-station/remove.njk
@@ -67,7 +67,7 @@
     <input type="hidden" name="monitoringStationId" value="{{monitoringStationId}}"/>
     <input type="hidden" name="wrlsCrumb" value="{{wrlsCrumb}}"/>
       {{ govukButton({
-        text: "Continue",
+        text: "Confirm",
         preventDoubleClick: true
       }) }}
   </form>


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5003

When we migrated the 'Remove licence tag' (related to monitoring stations and abstraction alerts), we built a 'check' page to allow the user to check they are removing the correct tag.

As this is the final action in the 'journey', and we are asking them to _confirm_ the action, the button text should have been `Confirm`. However, it was `Continue`, which infers the journey is not yet complete.

This small change fixes it.