### PR TITLE
Add dynamic meter readings to the return forms PDF for days

### DIFF
--- a/app/presenters/notices/setup/prepare-return-forms.presenter.js
+++ b/app/presenters/notices/setup/prepare-return-forms.presenter.js
@@ -79,7 +79,7 @@ function _address(recipient) {
 /**
  * Day meter readings are structured differently to 'month' and 'week'
  *
- * The 'days' will take up three columns per page, with the month and year are at the top of each column - 'June 2024'
+ * The 'days' will take up three columns per page, with the month and year at the top of each column - 'June 2024'
  * and with the day next to the checkbox. It will look something like this:
  *
  * ```

--- a/app/presenters/notices/setup/prepare-return-forms.presenter.js
+++ b/app/presenters/notices/setup/prepare-return-forms.presenter.js
@@ -147,8 +147,8 @@ function _groupDaysIntoMonths(dates) {
   return dates.reduce((acc, date) => {
     const key = date.toLocaleString('default', { month: 'long', year: 'numeric' })
 
-    let group = acc.find((group) => {
-      return group.period === key
+    let group = acc.find((existingGroup) => {
+      return existingGroup.period === key
     })
 
     if (!group) {

--- a/app/presenters/notices/setup/prepare-return-forms.presenter.js
+++ b/app/presenters/notices/setup/prepare-return-forms.presenter.js
@@ -6,10 +6,10 @@
  */
 
 const NotifyAddressPresenter = require('./notify-address.presenter.js')
+const { daysFromPeriod, monthsFromPeriod, weeksFromPeriod } = require('../../../lib/dates.lib.js')
 const { formatLongDate } = require('../../base.presenter.js')
 const { naldAreaCodes, returnRequirementFrequencies } = require('../../../lib/static-lookups.lib.js')
 const { splitArrayIntoGroups } = require('../../../lib/general.lib.js')
-const { weeksFromPeriod, monthsFromPeriod } = require('../../../lib/dates.lib.js')
 
 const RETURN_TYPE = {
   week: {
@@ -21,8 +21,7 @@ const RETURN_TYPE = {
     columnSize: 12
   },
   day: {
-    columns: 3,
-    columnSize: 1
+    columns: 3
   }
 }
 
@@ -78,6 +77,37 @@ function _address(recipient) {
 }
 
 /**
+ * Day meter readings are structured differently to 'month' and 'week'
+ *
+ * The 'days' will take up three columns per page, with the month and year are at the top of each column - 'June 2024'
+ * and with the day next to the checkbox. It will look something like this:
+ *
+ * ```
+ * June 2024                July 2024                 August 2024
+ *
+ * 1 [][][][][][][][][][]   1 [][][][][][][][][][]    1 [][][][][][][][][][]
+ * 2 [][][][][][][][][][]   2 [][][][][][][][][][]    2 [][][][][][][][][][]
+ * 3 [][][][][][][][][][]   3 [][][][][][][][][][]    3 [][][][][][][][][][]
+ * ```
+ *
+ * @private
+ */
+function _dayMeterReadings(startDate, endDate) {
+  const periodStartDate = new Date(startDate)
+  const periodEndDate = new Date(endDate)
+
+  const periodDates = daysFromPeriod(periodStartDate, periodEndDate)
+
+  const dates = periodDates.map((date) => {
+    return new Date(date.endDate)
+  })
+
+  const groupedDates = _groupDaysIntoMonths(dates)
+
+  return splitArrayIntoGroups(groupedDates, RETURN_TYPE.day.columns)
+}
+
+/**
  * Splits a list of page items into up to columns
  *
  * If the number of items exceeds the specified `columnSize`, the overflow is placed in the second column. If there are
@@ -105,6 +135,37 @@ function _formatPeriodsToLongDate(periods) {
 }
 
 /**
+ * Group an array of dates by the date's month and year.
+ *
+ * The group key (period) will be the month and the year of the date 'June 2024'.
+ *
+ * The date will be added to the 'days' array for the group as the day only (no leading 0).
+ *
+ * @private
+ */
+function _groupDaysIntoMonths(dates) {
+  return dates.reduce((acc, date) => {
+    const key = date.toLocaleString('default', { month: 'long', year: 'numeric' })
+
+    let group = acc.find((group) => {
+      return group.period === key
+    })
+
+    if (!group) {
+      group = {
+        period: key,
+        days: []
+      }
+      acc.push(group)
+    }
+
+    group.days.push(date.getDate())
+
+    return acc
+  }, [])
+}
+
+/**
  * The legacy code accounts for the 'nald.areaCode' not being set in the metadata. This logic replicates the legacy
  * logic.
  *
@@ -119,6 +180,10 @@ function _regionAndArea(regionName, naldAreaCode) {
 }
 
 function _meterReadings(startDate, endDate, returnsFrequency) {
+  if (returnsFrequency === 'day') {
+    return _dayMeterReadings(startDate, endDate)
+  }
+
   const { columns, columnSize } = RETURN_TYPE[returnsFrequency]
 
   const dates = _generateDates(startDate, endDate, returnsFrequency)

--- a/app/views/notices/pdfs/pages/data-collection.njk
+++ b/app/views/notices/pdfs/pages/data-collection.njk
@@ -1,34 +1,18 @@
 {% extends "layout/page-layout.njk" %}
 
-{% macro boxes(count = 12) %}
+{% macro boxes(count = 12, isSmall = false) %}
   {#
   Creates a line of boxes for data entry.
   count: The number of horizontal boxes
   #}
   {% for i in range(0, count) -%}
-    <div class="number-input {{ ' last-digit' if loop.last }}"></div>
+    <div class="{{ 'small-number-input' if isSmall else 'number-input'}}{{ ' last-digit' if loop.last }}"></div>
   {%- endfor %}
-{% endmacro %}
-
-{% macro rowItem(item) %}
-
-  {% if returnsFrequency === 'month' %}
-    <p class="month-label">
-      {{ item }}
-      {{ boxes(12) }}
-    </p>
-  {% endif %}
-
-  {% if returnsFrequency === 'week' %}
-    <p class="week-label">
-      {{ item }}
-      {{ boxes(12) }}
-    </p>
-  {% endif %}
 {% endmacro %}
 
 {% set firstColumn = 0 %}
 {% set secondColumn = 1 %}
+{% set thirdColumn = 2 %}
 
 {% block header %}
   {% include 'layout/header.njk' %}
@@ -39,24 +23,74 @@
     <div class="block-head bold">9. Meter readings or abstraction volumes</div>
   {% endif %}
 
+  {% if returnsFrequency === 'day' %}
   <div class="columns">
     <div class="column">
       <div class="block">
-      {% for reading in meterReading[firstColumn] %}
-            {{ rowItem(reading) }}
-      {% endfor %}
+          <div class="block-head">{{ meterReading[firstColumn].period }}</div>
+          {% for day in meterReading[firstColumn].days %}
+            <div class="daily-input">
+              <div class="day-label">{{ day }}</div>
+              {{ boxes(12, isSmall = true) }}
+            </div>
+        {% endfor %}
       </div>
     </div>
-
-    {% if meterReading[secondColumn] %}
     <div class="column">
       <div class="block">
-      {% for reading in meterReading[secondColumn] %}
-          {{ rowItem(reading) }}
-      {% endfor %}
+        {% if meterReading[secondColumn] %}
+          <div class="block-head">{{ meterReading[secondColumn].period }}</div>
+          {% for day in meterReading[secondColumn].days %}
+            <div class="daily-input">
+              <div class="day-label">{{ day }}</div>
+              {{ boxes(12, isSmall = true) }}
+            </div>
+          {% endfor %}
+        {% endif %}
       </div>
     </div>
-    {% endif %}
+    <div class="column">
+      <div class="block">
+        {% if meterReading[thirdColumn] %}
+          <div class="block-head">{{ meterReading[thirdColumn].period }}</div>
+          {% for day in meterReading[thirdColumn].days %}
+            <div class="daily-input">
+              <div class="day-label">{{ day }}</div>
+              {{ boxes(12, isSmall = true) }}
+            </div>
+          {% endfor %}
+        {% endif %}
+      </div>
+    </div>
   </div>
+
+    {% else %}
+      <div class="columns">
+        <div class="column">
+          <div class="block">
+            {% for reading in meterReading[firstColumn] %}
+              <p>
+                {{ reading }}
+                {{ boxes(12) }}
+              </p>
+            {% endfor %}
+          </div>
+        </div>
+
+        {% if meterReading[secondColumn] %}
+          <div class="column">
+            <div class="block">
+              {% for reading in meterReading[secondColumn] %}
+                <p>
+                  {{ reading }}
+                  {{ boxes(12) }}
+                </p>
+              {% endfor %}
+            </div>
+          </div>
+        {% endif %}
+      </div>
+  {% endif %}
+
 {% endblock %}
 

--- a/test/presenters/notices/setup/prepare-return-forms.presenter.test.js
+++ b/test/presenters/notices/setup/prepare-return-forms.presenter.test.js
@@ -134,6 +134,69 @@ describe('Notices - Setup - Prepare Return Forms Presenter', () => {
     })
 
     describe('the "meterReadings" property', () => {
+      describe('when the "returnsFrequency" is "day"', () => {
+        beforeEach(() => {
+          dueReturnLog.returnsFrequency = 'day'
+        })
+
+        it('should return meter readings', () => {
+          const result = PrepareReturnFormsPresenter.go(session, dueReturnLog, recipient)
+
+          expect(result.meterReadings).to.equal([
+            // Page
+            [
+              // Column
+              {
+                days: [
+                  1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28,
+                  29, 30, 31
+                ],
+                period: 'January 2025'
+              },
+              // Column
+              {
+                days: [
+                  1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28
+                ],
+                period: 'February 2025'
+              },
+              // Column
+              {
+                days: [
+                  1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28,
+                  29, 30, 31
+                ],
+                period: 'March 2025'
+              }
+            ],
+            // Page
+            [
+              // Column
+              {
+                days: [
+                  1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28,
+                  29, 30
+                ],
+                period: 'April 2025'
+              },
+              // Column
+              {
+                days: [
+                  1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28,
+                  29, 30, 31
+                ],
+                period: 'May 2025'
+              },
+              // Column
+              {
+                days: [1, 2, 3, 4, 5, 6],
+                period: 'June 2025'
+              }
+            ]
+          ])
+        })
+      })
+
       describe('when the "returnsFrequency" is "month"', () => {
         beforeEach(() => {
           dueReturnLog.returnsFrequency = 'month'


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5162

We previously implemented the month and week meter readings.

This change adds the meter readings for the 'days' frequency.

When the return frequency is 'days', we show three columns (and set three columns in the HTML dues to the way the CSS works).

The day meter readings show the Month and Year at the top of each column, and each cell has the day and then the boxes. it looks something like this

June 2024
1 [][][][][][][][][][]
2 [][][][][][][][][][]

This differs from out established logic, so it has been implemented on its own within the presenter.

This change uses (and follows) the previously established calculation for the number of dates we put on a single page, and when this limit is reached, a new page will be added below the existing, and this continues.

We use the legacy codes CSS and some of the HTML to show the pages correctly, legacy code has stipulated the columns and rows as the expected format when rendering the PDF.