### PR TITLE
Change the use of 'meter readings' to 'entries' to reduce confusion

### DIFF
--- a/app/presenters/notices/setup/prepare-return-forms.presenter.js
+++ b/app/presenters/notices/setup/prepare-return-forms.presenter.js
@@ -60,7 +60,7 @@ function go(session, dueReturnLog, recipient) {
     dueDate: formatLongDate(new Date(dueDate)),
     endDate: formatLongDate(new Date(endDate)),
     licenceRef,
-    meterReadings: _meterReadings(startDate, endDate, returnsFrequency),
+    pageEntries: _entries(startDate, endDate, returnsFrequency),
     pageTitle: _pageTitle(returnsFrequency),
     purpose,
     regionAndArea: _regionAndArea(regionName, naldAreaCode),
@@ -77,7 +77,7 @@ function _address(recipient) {
 }
 
 /**
- * Day meter readings are structured differently to 'month' and 'week'
+ * Day entries are structured differently to 'month' and 'week'
  *
  * The 'days' will take up three columns per page, with the month and year at the top of each column - 'June 2024'
  * and with the day next to the checkbox. It will look something like this:
@@ -92,7 +92,7 @@ function _address(recipient) {
  *
  * @private
  */
-function _dayMeterReadings(startDate, endDate) {
+function _dayEntries(startDate, endDate) {
   const periodStartDate = new Date(startDate)
   const periodEndDate = new Date(endDate)
 
@@ -179,9 +179,9 @@ function _regionAndArea(regionName, naldAreaCode) {
   return regionName
 }
 
-function _meterReadings(startDate, endDate, returnsFrequency) {
+function _entries(startDate, endDate, returnsFrequency) {
   if (returnsFrequency === 'day') {
-    return _dayMeterReadings(startDate, endDate)
+    return _dayEntries(startDate, endDate)
   }
 
   const { columns, columnSize } = RETURN_TYPE[returnsFrequency]
@@ -194,7 +194,7 @@ function _meterReadings(startDate, endDate, returnsFrequency) {
 }
 
 /**
- * The meter readings use boxes to allow the user to fill in the reading.
+ * The entries use boxes to allow the user to fill in the number.
  *
  * These boxes can span multiple pages, we need to handle this use case.
  *

--- a/app/views/notices/pdfs/pages/data-collection.njk
+++ b/app/views/notices/pdfs/pages/data-collection.njk
@@ -27,8 +27,8 @@
   <div class="columns">
     <div class="column">
       <div class="block">
-          <div class="block-head">{{ meterReading[firstColumn].period }}</div>
-          {% for day in meterReading[firstColumn].days %}
+          <div class="block-head">{{ entries[firstColumn].period }}</div>
+          {% for day in entries[firstColumn].days %}
             <div class="daily-input">
               <div class="day-label">{{ day }}</div>
               {{ boxes(12, isSmall = true) }}
@@ -38,9 +38,9 @@
     </div>
     <div class="column">
       <div class="block">
-        {% if meterReading[secondColumn] %}
-          <div class="block-head">{{ meterReading[secondColumn].period }}</div>
-          {% for day in meterReading[secondColumn].days %}
+        {% if entries[secondColumn] %}
+          <div class="block-head">{{ entries[secondColumn].period }}</div>
+          {% for day in entries[secondColumn].days %}
             <div class="daily-input">
               <div class="day-label">{{ day }}</div>
               {{ boxes(12, isSmall = true) }}
@@ -51,9 +51,9 @@
     </div>
     <div class="column">
       <div class="block">
-        {% if meterReading[thirdColumn] %}
-          <div class="block-head">{{ meterReading[thirdColumn].period }}</div>
-          {% for day in meterReading[thirdColumn].days %}
+        {% if entries[thirdColumn] %}
+          <div class="block-head">{{ entries[thirdColumn].period }}</div>
+          {% for day in entries[thirdColumn].days %}
             <div class="daily-input">
               <div class="day-label">{{ day }}</div>
               {{ boxes(12, isSmall = true) }}
@@ -68,21 +68,21 @@
       <div class="columns">
         <div class="column">
           <div class="block">
-            {% for reading in meterReading[firstColumn] %}
+            {% for entry in entries[firstColumn] %}
               <p>
-                {{ reading }}
+                {{ entry }}
                 {{ boxes(12) }}
               </p>
             {% endfor %}
           </div>
         </div>
 
-        {% if meterReading[secondColumn] %}
+        {% if entries[secondColumn] %}
           <div class="column">
             <div class="block">
-              {% for reading in meterReading[secondColumn] %}
+              {% for entry in entries[secondColumn] %}
                 <p>
-                  {{ reading }}
+                  {{ entry }}
                   {{ boxes(12) }}
                 </p>
               {% endfor %}

--- a/app/views/notices/pdfs/preview-return-forms.njk
+++ b/app/views/notices/pdfs/preview-return-forms.njk
@@ -11,7 +11,7 @@
   {% include 'pages/guidance.njk' %}
   {% include 'pages/initial-questions.njk' %}
 
-  {% for meterReading in meterReadings %}
+  {% for entries in pageEntries %}
     {% set showHeading = loop.first %}
     {% include 'pages/data-collection.njk' %}
   {% endfor %}

--- a/test/presenters/notices/setup/prepare-return-forms.presenter.test.js
+++ b/test/presenters/notices/setup/prepare-return-forms.presenter.test.js
@@ -54,7 +54,7 @@ describe('Notices - Setup - Prepare Return Forms Presenter', () => {
         dueDate: '6 July 2025',
         endDate: '6 June 2025',
         licenceRef: '123',
-        meterReadings: result.meterReadings,
+        pageEntries: result.pageEntries,
         purpose: 'A purpose',
         regionAndArea: 'North West / Lower Trent',
         returnReference: '123456',
@@ -133,16 +133,16 @@ describe('Notices - Setup - Prepare Return Forms Presenter', () => {
       })
     })
 
-    describe('the "meterReadings" property', () => {
+    describe('the "pageEntries" property', () => {
       describe('when the "returnsFrequency" is "day"', () => {
         beforeEach(() => {
           dueReturnLog.returnsFrequency = 'day'
         })
 
-        it('should return meter readings', () => {
+        it('should return entries', () => {
           const result = PrepareReturnFormsPresenter.go(session, dueReturnLog, recipient)
 
-          expect(result.meterReadings).to.equal([
+          expect(result.pageEntries).to.equal([
             // Page
             [
               // Column
@@ -203,10 +203,10 @@ describe('Notices - Setup - Prepare Return Forms Presenter', () => {
         })
 
         describe('and the start and end are 6 months apart', () => {
-          it('should return meter readings', () => {
+          it('should return entries', () => {
             const result = PrepareReturnFormsPresenter.go(session, dueReturnLog, recipient)
 
-            expect(result.meterReadings).to.equal([
+            expect(result.pageEntries).to.equal([
               // Page
               [
                 // Column
@@ -231,10 +231,10 @@ describe('Notices - Setup - Prepare Return Forms Presenter', () => {
             dueReturnLog.endDate = '2021-12-31'
           })
 
-          it('should return meter readings', () => {
+          it('should return entries', () => {
             const result = PrepareReturnFormsPresenter.go(session, dueReturnLog, recipient)
 
-            expect(result.meterReadings).to.equal([
+            expect(result.pageEntries).to.equal([
               // Page
               [
                 // Column
@@ -266,11 +266,11 @@ describe('Notices - Setup - Prepare Return Forms Presenter', () => {
         })
 
         describe('and the period fits onto one page', () => {
-          it('should return meter readings', () => {
+          it('should return entries', () => {
             const result = PrepareReturnFormsPresenter.go(session, dueReturnLog, recipient)
 
-            expect(result.meterReadings.length).to.equal(1)
-            expect(result.meterReadings).to.equal([
+            expect(result.pageEntries.length).to.equal(1)
+            expect(result.pageEntries).to.equal([
               // Page
               [
                 // Column
@@ -312,11 +312,12 @@ describe('Notices - Setup - Prepare Return Forms Presenter', () => {
             dueReturnLog.endDate = '2021-12-31'
           })
 
-          it('should return meter readings', () => {
+          it('should return entries', () => {
             const result = PrepareReturnFormsPresenter.go(session, dueReturnLog, recipient)
 
-            expect(result.meterReadings.length).to.equal(2)
-            expect(result.meterReadings).to.equal([
+            expect(result.pageEntries.length).to.equal(2)
+            expect(result.pageEntries.length).to.equal(2)
+            expect(result.pageEntries).to.equal([
               // Page 1
               [
                 // Column

--- a/test/services/notices/setup/prepare-return-forms.service.test.js
+++ b/test/services/notices/setup/prepare-return-forms.service.test.js
@@ -91,7 +91,7 @@ describe('Notices - Setup - Prepare Return Forms Service', () => {
         dueDate: '6 July 2025',
         endDate: '6 June 2025',
         licenceRef: '123',
-        meterReadings: actualCallArgs.meterReadings,
+        pageEntries: actualCallArgs.pageEntries,
         pageTitle: 'Water abstraction daily return',
         purpose: 'A purpose',
         regionAndArea: 'North West / Lower Trent',

--- a/test/services/notices/setup/preview-return-forms.service.test.js
+++ b/test/services/notices/setup/preview-return-forms.service.test.js
@@ -109,7 +109,7 @@ describe('Notices - Setup - Preview Return Forms Service', () => {
         dueDate: '6 July 2025',
         endDate: '6 June 2025',
         licenceRef: '123',
-        meterReadings: actualCallArgs.meterReadings,
+        pageEntries: actualCallArgs.pageEntries,
         pageTitle: 'Water abstraction daily return',
         purpose: 'A purpose',
         regionAndArea: 'North West / Lower Trent',


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5162

We have implemented the return forms PDF, an assumption was made to call the data used for part '9.  Meter readings or abstraction volumes' 'meterReadings'.

This is not correct, it should be entries.

This change updates the use of 'meter readings' and 'readings' to 'entires' and 'entry' for this context.