### PR TITLE
Add the return forms preview page

### DIFF
--- a/app/controllers/notices-setup.controller.js
+++ b/app/controllers/notices-setup.controller.js
@@ -14,6 +14,7 @@ const CancelService = require('../services/notices/setup/cancel.service.js')
 const CheckAlertService = require('../services/notices/setup/preview/check-alert.service.js')
 const CheckLicenceMatchesService = require('../services/notices/setup/abstraction-alerts/check-licence-matches.service.js')
 const CheckNoticeTypeService = require('../services/notices/setup/check-notice-type.service.js')
+const CheckReturnFormsService = require('../services/notices/setup/preview/check-return-forms.service.js')
 const CheckService = require('../services/notices/setup/check.service.js')
 const ConfirmationService = require('../services/notices/setup/confirmation.service.js')
 const ContactTypeService = require('../services/notices/setup/contact-type.service.js')
@@ -60,6 +61,14 @@ async function checkAlert(request, h) {
   const pageData = await CheckAlertService.go(contactHashId, sessionId)
 
   return h.view('notices/setup/preview/check-alert.njk', pageData)
+}
+
+async function viewCheckReturnForms(request, h) {
+  const { contactHashId, sessionId } = request.params
+
+  const pageData = await CheckReturnFormsService.go(sessionId, contactHashId)
+
+  return h.view(`notices/setup/preview/check-return-forms.njk`, pageData)
 }
 
 async function downloadRecipients(request, h) {
@@ -473,6 +482,7 @@ module.exports = {
   viewCheck,
   viewCheckLicenceMatches,
   viewCheckNoticeType,
+  viewCheckReturnForms,
   viewConfirmation,
   viewContactType,
   viewLicence,

--- a/app/presenters/notices/setup/check.presenter.js
+++ b/app/presenters/notices/setup/check.presenter.js
@@ -111,9 +111,7 @@ function _previewLink(noticeType, recipient, sessionId, contact) {
   }
 
   if (noticeType === 'returnForms') {
-    // We need to implement an intermediary page to allow the user to select which return id they want to 'preview'.
-    // For now, we add the 'placeHolder' to highlight this is a temporary measure and needs to change.
-    return `/system/notices/setup/${sessionId}/preview/${recipient.contact_hash_id}/return-forms/placeHolder`
+    return `/system/notices/setup/${sessionId}/preview/${recipient.contact_hash_id}/check-return-forms`
   }
 
   // Returns invitations and reminders can be previewed directly

--- a/app/presenters/notices/setup/preview/check-return-forms.presenter.js
+++ b/app/presenters/notices/setup/preview/check-return-forms.presenter.js
@@ -32,13 +32,13 @@ function _returnLogs(dueReturns, selectedReturns, sessionId, contactHashId) {
 
   return returnLogs.map((dueReturn) => {
     return {
-      returnReference: dueReturn.returnReference,
-      siteDescription: dueReturn.siteDescription,
-      returnPeriod: `${formatLongDate(new Date(dueReturn.startDate))} to ${formatLongDate(new Date(dueReturn.endDate))}`,
       action: {
         link: `/system/notices/setup/${sessionId}/preview/${contactHashId}/return-forms/${dueReturn.returnId}`,
         text: 'Preview'
-      }
+      },
+      returnPeriod: `${formatLongDate(new Date(dueReturn.startDate))} to ${formatLongDate(new Date(dueReturn.endDate))}`,
+      returnReference: dueReturn.returnReference,
+      siteDescription: dueReturn.siteDescription
     }
   })
 }

--- a/app/presenters/notices/setup/preview/check-return-forms.presenter.js
+++ b/app/presenters/notices/setup/preview/check-return-forms.presenter.js
@@ -9,6 +9,7 @@ const { formatLongDate } = require('../../../base.presenter.js')
 
 /**
  * Formats data for the `/notices/setup/{sessionId}/preview/{contactHashId}/check-return-forms` page
+ *
  * @param {module:SessionModel} session - The session instance
  * @param {string} contactHashId - The recipients unique identifier
  *

--- a/app/presenters/notices/setup/preview/check-return-forms.presenter.js
+++ b/app/presenters/notices/setup/preview/check-return-forms.presenter.js
@@ -1,0 +1,48 @@
+'use strict'
+
+/**
+ * Formats data for the `/notices/setup/{sessionId}/preview/{contactHashId}/check-return-forms` page
+ * @module CheckReturnFormsPresenter
+ */
+
+const { formatLongDate } = require('../../../base.presenter.js')
+
+/**
+ * Formats data for the `/notices/setup/{sessionId}/preview/{contactHashId}/check-return-forms` page
+ * @param {module:SessionModel} session - The session instance
+ * @param {string} contactHashId - The recipients unique identifier
+ *
+ * @returns {object} - The data formatted for the view template
+ */
+function go(session, contactHashId) {
+  const { dueReturns, referenceCode, selectedReturns, id: sessionId } = session
+
+  return {
+    backLink: `/system/notices/setup/${sessionId}/check`,
+    caption: `Notice ${referenceCode}`,
+    pageTitle: 'Check the recipient previews',
+    returnLogs: _returnLogs(dueReturns, selectedReturns, sessionId, contactHashId)
+  }
+}
+
+function _returnLogs(dueReturns, selectedReturns, sessionId, contactHashId) {
+  const returnLogs = dueReturns.filter((dueReturn) => {
+    return selectedReturns.includes(dueReturn.returnId)
+  })
+
+  return returnLogs.map((dueReturn) => {
+    return {
+      returnReference: dueReturn.returnReference,
+      siteDescription: dueReturn.siteDescription,
+      returnPeriod: `${formatLongDate(new Date(dueReturn.startDate))} to ${formatLongDate(new Date(dueReturn.endDate))}`,
+      action: {
+        link: `/system/notices/setup/${sessionId}/preview/${contactHashId}/return-forms/${dueReturn.returnId}`,
+        text: 'Preview'
+      }
+    }
+  })
+}
+
+module.exports = {
+  go
+}

--- a/app/routes/notices-setup.routes.js
+++ b/app/routes/notices-setup.routes.js
@@ -281,6 +281,18 @@ const routes = [
   },
   {
     method: 'GET',
+    path: '/notices/setup/{sessionId}/preview/{contactHashId}/check-return-forms',
+    options: {
+      handler: NoticesSetupController.viewCheckReturnForms,
+      auth: {
+        access: {
+          scope: ['returns']
+        }
+      }
+    }
+  },
+  {
+    method: 'GET',
     path: '/notices/setup/{sessionId}/preview/{contactHashId}/return-forms/{returnId}',
     options: {
       handler: NoticesSetupController.viewPreviewReturnForms,

--- a/app/services/notices/setup/preview-return-forms.service.js
+++ b/app/services/notices/setup/preview-return-forms.service.js
@@ -26,12 +26,6 @@ async function go(sessionId, contactHashId, returnId) {
 
   const [recipient] = await _recipient(session, contactHashId)
 
-  // We need to implement an intermediary page to allow the user to select which return id they want to 'preview'.
-  // For now, we add the 'placeHolder' to highlight this is a temporary measure and needs to change.
-  if (returnId === 'placeHolder') {
-    returnId = session.selectedReturns[0]
-  }
-
   return PrepareReturnFormsService.go(session, returnId, recipient)
 }
 

--- a/app/services/notices/setup/preview/check-return-forms.service.js
+++ b/app/services/notices/setup/preview/check-return-forms.service.js
@@ -12,7 +12,7 @@ const SessionModel = require('../../../../models/session.model.js')
 /**
  * Orchestrates fetching and presenting the data for the `/notices/setup/{sessionId}/preview/{contactHashId}/check-return-forms` page
  *
- * @param {string} sessionId
+ * @param {string} sessionId - The UUID of the current session
  * @param {string} contactHashId - The recipients unique identifier
  *
  * @returns {Promise<object>} - The data formatted for the view template

--- a/app/services/notices/setup/preview/check-return-forms.service.js
+++ b/app/services/notices/setup/preview/check-return-forms.service.js
@@ -1,0 +1,33 @@
+'use strict'
+
+/**
+ * Orchestrates fetching and presenting the data for the `/notices/setup/{sessionId}/preview/{contactHashId}/check-return-forms` page
+ *
+ * @module CheckReturnFormsService
+ */
+
+const CheckReturnFormsPresenter = require('../../../../presenters/notices/setup/preview/check-return-forms.presenter.js')
+const SessionModel = require('../../../../models/session.model.js')
+
+/**
+ * Orchestrates fetching and presenting the data for the `/notices/setup/{sessionId}/preview/{contactHashId}/check-return-forms` page
+ *
+ * @param {string} sessionId
+ * @param {string} contactHashId - The recipients unique identifier
+ *
+ * @returns {Promise<object>} - The data formatted for the view template
+ */
+async function go(sessionId, contactHashId) {
+  const session = await SessionModel.query().findById(sessionId)
+
+  const pageData = CheckReturnFormsPresenter.go(session, contactHashId)
+
+  return {
+    activeNavBar: 'manage',
+    ...pageData
+  }
+}
+
+module.exports = {
+  go
+}

--- a/app/views/notices/setup/preview/check-return-forms.njk
+++ b/app/views/notices/setup/preview/check-return-forms.njk
@@ -1,0 +1,81 @@
+{% extends 'layout.njk' %}
+
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/table/macro.njk" import govukTable %}
+
+{% block breadcrumbs %}
+  {{ govukBackLink({
+    text: 'Back',
+    href: backLink
+  }) }}
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-body">
+    <span class="govuk-caption-l">{{ caption }}</span>
+    <h1 class="govuk-heading-l govuk-!-margin-bottom-3">{{ pageTitle }}</h1>
+  </div>
+
+  {% set tableRows = [] %}
+
+  {% for returnLog in returnLogs %}
+    {# Set an easier to use index #}
+    {% set rowIndex = loop.index0 %}
+
+    {% set tableRow = [] %}
+
+    {% set returnReferenceCell =
+      {
+        text: returnLog.returnReference,
+        attributes: { 'data-test': 'return-reference-' + rowIndex }
+      } %}
+    {% set tableRow = (tableRow.push(returnReferenceCell), tableRow) %}
+
+    {% set siteDescriptionCell =
+      {
+        text: returnLog.siteDescription,
+        attributes: { 'data-test': 'site-description' + rowIndex }
+      } %}
+    {% set tableRow = (tableRow.push(siteDescriptionCell), tableRow) %}
+
+    {% set returnPeriodCell =
+      {
+        text: returnLog.returnPeriod,
+        attributes: { 'data-test': 'return-period' + rowIndex }
+      } %}
+    {% set tableRow = (tableRow.push(returnPeriodCell), tableRow) %}
+
+
+    {% set actionCell =
+      {
+
+        html: '<a href="'+ returnLog.action.link +'" class="govuk-link" rel="noreferrer noopener" target="_blank">'
+          + returnLog.action.text + '</a>',
+        attributes: { 'data-test': 'action-' + rowIndex }
+      } %}
+    {% set tableRow = (tableRow.push(actionCell), tableRow) %}
+
+    {% set tableRows = (tableRows.push(tableRow), tableRows) %}
+  {% endfor %}
+
+  {# Recipient previews table #}
+  {{ govukTable({
+    firstCellIsHeader: false,
+    head: [
+      {
+        text: "Return reference"
+      },
+      {
+        text: "Site Description"
+      },
+      {
+        text: "Return period"
+      },
+      {
+        text: "Action"
+      }
+    ],
+    rows: tableRows
+  }) }}
+{% endblock %}

--- a/app/views/notices/setup/preview/check-return-forms.njk
+++ b/app/views/notices/setup/preview/check-return-forms.njk
@@ -4,6 +4,8 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
 
+{% from "macros/page-heading.njk" import pageHeading %}
+
 {% block breadcrumbs %}
   {{ govukBackLink({
     text: 'Back',
@@ -12,10 +14,7 @@
 {% endblock %}
 
 {% block content %}
-  <div class="govuk-body">
-    <span class="govuk-caption-l">{{ caption }}</span>
-    <h1 class="govuk-heading-l govuk-!-margin-bottom-3">{{ pageTitle }}</h1>
-  </div>
+  {{ pageHeading(pageTitle, caption, "govuk-heading-l govuk-!-margin-bottom-3") }}
 
   {% set tableRows = [] %}
 

--- a/test/controllers/notices-setup.controller.test.js
+++ b/test/controllers/notices-setup.controller.test.js
@@ -20,6 +20,7 @@ const CancelService = require('../../app/services/notices/setup/cancel.service.j
 const CheckAlert = require('../../app/services/notices/setup/preview/check-alert.service.js')
 const CheckLicenceMatchesService = require('../../app/services/notices/setup/abstraction-alerts/check-licence-matches.service.js')
 const CheckNoticeTypeService = require('../../app/services/notices/setup/check-notice-type.service.js')
+const CheckReturnFormsService = require('../../app/services/notices/setup/preview/check-return-forms.service.js')
 const CheckService = require('../../app/services/notices/setup/check.service.js')
 const ConfirmationService = require('../../app/services/notices/setup/confirmation.service.js')
 const ContactTypeService = require('../../app/services/notices/setup/contact-type.service.js')
@@ -852,6 +853,36 @@ describe('Notices Setup controller', () => {
 
           expect(response.statusCode).to.equal(200)
           expect(response.payload).to.contain('Check the recipient previews')
+        })
+      })
+    })
+  })
+
+  describe('notices/setup/{sessionId}/preview/{contactHashId}/check-return-forms', () => {
+    describe('GET', () => {
+      const contactHashId = '28da6d3a09af3794959b6906de5ec81a'
+
+      beforeEach(async () => {
+        getOptions = {
+          method: 'GET',
+          url: basePath + `/${session.id}/preview/${contactHashId}/check-return-forms`,
+          auth: {
+            strategy: 'session',
+            credentials: { scope: ['returns'] }
+          }
+        }
+
+        Sinon.stub(CheckReturnFormsService, 'go').resolves({
+          pageTitle: 'Preview notice'
+        })
+      })
+
+      describe('when a request is valid', () => {
+        it('returns the page successfully', async () => {
+          const response = await server.inject(getOptions)
+
+          expect(response.statusCode).to.equal(200)
+          expect(response.payload).to.contain('Preview notice')
         })
       })
     })

--- a/test/presenters/notices/setup/check.presenter.test.js
+++ b/test/presenters/notices/setup/check.presenter.test.js
@@ -353,7 +353,7 @@ describe('Notices - Setup - Check presenter', () => {
               const result = CheckPresenter.go(testInput, page, pagination, session)
 
               expect(result.recipients[0].previewLink).to.equal(
-                `/system/notices/setup/${session.id}/preview/${testDuplicateRecipients.duplicateLicenceHolder.contact_hash_id}/return-forms/placeHolder`
+                `/system/notices/setup/${session.id}/preview/${testDuplicateRecipients.duplicateLicenceHolder.contact_hash_id}/check-return-forms`
               )
             })
           })

--- a/test/presenters/notices/setup/preview/check-return-forms.presenter.test.js
+++ b/test/presenters/notices/setup/preview/check-return-forms.presenter.test.js
@@ -1,0 +1,133 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Test helpers
+const { generateUUID } = require('../../../../../app/lib/general.lib.js')
+
+// Thing under test
+const CheckReturnFormsPresenter = require('../../../../../app/presenters/notices/setup/preview/check-return-forms.presenter.js')
+
+describe('Notices - Setup - Preview - Check Return Forms Presenter', () => {
+  const contactHashId = '9df5923f179a0ed55c13173c16651ed9'
+  const sessionId = '7334a25e-9723-4732-a6e1-8e30c5f3732e'
+
+  let dueReturn
+  let session
+
+  beforeEach(() => {
+    dueReturn = {
+      siteDescription: 'Potable Water Supply - Direct',
+      endDate: '2003-03-31',
+      returnId: generateUUID(),
+      returnReference: '3135',
+      startDate: '2002-04-01'
+    }
+
+    session = {
+      id: sessionId,
+      dueReturns: [dueReturn],
+      referenceCode: 'PRTF-WJUKBX',
+      selectedReturns: [dueReturn.returnId]
+    }
+  })
+
+  describe('when called', () => {
+    it('returns page data for the view', () => {
+      const result = CheckReturnFormsPresenter.go(session, contactHashId)
+
+      expect(result).to.equal({
+        backLink: `/system/notices/setup/${sessionId}/check`,
+        caption: 'Notice PRTF-WJUKBX',
+        pageTitle: 'Check the recipient previews',
+        returnLogs: [
+          {
+            action: {
+              link: `/system/notices/setup/${sessionId}/preview/${contactHashId}/return-forms/${dueReturn.returnId}`,
+              text: 'Preview'
+            },
+            returnPeriod: '1 April 2002 to 31 March 2003',
+            returnReference: '3135',
+            siteDescription: 'Potable Water Supply - Direct'
+          }
+        ]
+      })
+    })
+
+    describe('the "returnLogs" property', () => {
+      describe('when there are multiple "dueReturns"', () => {
+        let additionalDueReturn
+
+        beforeEach(() => {
+          additionalDueReturn = {
+            siteDescription: 'Not a moon',
+            endDate: '2003-05-04',
+            returnId: generateUUID(),
+            returnReference: '5653',
+            startDate: '2002-04-01'
+          }
+        })
+
+        describe('and they are all "selectedReturns"', () => {
+          beforeEach(() => {
+            session.dueReturns = [dueReturn, additionalDueReturn]
+            session.selectedReturns = [dueReturn.returnId, additionalDueReturn.returnId]
+          })
+
+          it('returns page data for the view', () => {
+            const result = CheckReturnFormsPresenter.go(session, contactHashId)
+
+            expect(result.returnLogs).to.equal([
+              {
+                action: {
+                  link: `/system/notices/setup/${sessionId}/preview/${contactHashId}/return-forms/${dueReturn.returnId}`,
+                  text: 'Preview'
+                },
+                returnPeriod: '1 April 2002 to 31 March 2003',
+                returnReference: '3135',
+                siteDescription: 'Potable Water Supply - Direct'
+              },
+              {
+                action: {
+                  link: `/system/notices/setup/${sessionId}/preview/${contactHashId}/return-forms/${additionalDueReturn.returnId}`,
+                  text: 'Preview'
+                },
+                returnPeriod: '1 April 2002 to 4 May 2003',
+                returnReference: '5653',
+                siteDescription: 'Not a moon'
+              }
+            ])
+          })
+        })
+
+        describe('and there are some "selectedReturns"', () => {
+          beforeEach(() => {
+            session.dueReturns = [dueReturn, additionalDueReturn]
+            session.selectedReturns = [dueReturn.returnId]
+          })
+
+          it('returns page data for the view - with only the selected returns', () => {
+            const result = CheckReturnFormsPresenter.go(session, contactHashId)
+
+            expect(result.returnLogs).to.equal([
+              {
+                action: {
+                  link: `/system/notices/setup/${sessionId}/preview/${contactHashId}/return-forms/${dueReturn.returnId}`,
+                  text: 'Preview'
+                },
+                returnPeriod: '1 April 2002 to 31 March 2003',
+                returnReference: '3135',
+                siteDescription: 'Potable Water Supply - Direct'
+              }
+            ])
+          })
+        })
+      })
+    })
+  })
+})

--- a/test/services/notices/setup/preview/check-return-forms.service.test.js
+++ b/test/services/notices/setup/preview/check-return-forms.service.test.js
@@ -1,0 +1,65 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Test helpers
+const SessionHelper = require('../../../../support/helpers/session.helper.js')
+const { generateUUID } = require('../../../../../app/lib/general.lib.js')
+
+// Thing under test
+const CheckReturnFormsService = require('../../../../../app/services/notices/setup/preview/check-return-forms.service.js')
+
+describe('Notices - Setup - Preview - Check Return Forms Service', () => {
+  const contactHashId = '9df5923f179a0ed55c13173c16651ed9'
+
+  let dueReturn
+  let session
+  let sessionData
+
+  beforeEach(async () => {
+    dueReturn = {
+      siteDescription: 'Potable Water Supply - Direct',
+      endDate: '2003-03-31',
+      returnId: generateUUID(),
+      returnReference: '3135',
+      startDate: '2002-04-01'
+    }
+
+    sessionData = {
+      dueReturns: [dueReturn],
+      referenceCode: 'PRTF-WJUKBX',
+      selectedReturns: [dueReturn.returnId]
+    }
+
+    session = await SessionHelper.add({ data: sessionData })
+  })
+
+  describe('when called', () => {
+    it('returns page data for the view', async () => {
+      const result = await CheckReturnFormsService.go(session.id, contactHashId)
+
+      expect(result).to.equal({
+        activeNavBar: 'manage',
+        backLink: `/system/notices/setup/${session.id}/check`,
+        caption: 'Notice PRTF-WJUKBX',
+        pageTitle: 'Check the recipient previews',
+        returnLogs: [
+          {
+            action: {
+              link: `/system/notices/setup/${session.id}/preview/${contactHashId}/return-forms/${dueReturn.returnId}`,
+              text: 'Preview'
+            },
+            returnPeriod: '1 April 2002 to 31 March 2003',
+            returnReference: '3135',
+            siteDescription: 'Potable Water Supply - Direct'
+          }
+        ]
+      })
+    })
+  })
+})


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5162

We previously had a placeholder to render just the first due return when the preview link was pressed.

This change adds a new page to allow the user to choose to preview any previously selected return log. This page follows a similar pattern to the check alerts preview page.

We show a table with some relevant data to the return log and a preview link. This preview link opens a new tab and sends a PDF. This will default to the browser PDF viewer.