### PR TITLE
View templates standardise - Remove licences view

### DIFF
--- a/app/presenters/notices/setup/remove-licences.presenter.js
+++ b/app/presenters/notices/setup/remove-licences.presenter.js
@@ -10,13 +10,16 @@
  *
  * @param {string[]} removeLicences - List of licences to remove from the recipients list
  * @param {string} referenceCode - the unique generated reference code
+ * @param {string} sessionId - The UUID of the current session
  *
  * @returns {object} - The data formatted for the view template
  */
-function go(removeLicences, referenceCode) {
+function go(removeLicences, referenceCode, sessionId) {
   return {
+    backLink: `/system/notices/setup/${sessionId}/check`,
     hint: 'Separate the licences numbers with a comma or new line.',
     pageTitle: 'Enter the licence numbers to remove from the mailing list',
+    pageTitleCaption: `Notice ${referenceCode}`,
     referenceCode,
     removeLicences
   }

--- a/app/services/notices/setup/remove-licences.service.js
+++ b/app/services/notices/setup/remove-licences.service.js
@@ -20,7 +20,7 @@ async function go(sessionId) {
 
   const { removeLicences = [] } = session
 
-  const formattedData = RemoveLicencesPresenter.go(removeLicences, session.referenceCode)
+  const formattedData = RemoveLicencesPresenter.go(removeLicences, session.referenceCode, sessionId)
 
   return {
     activeNavBar: 'manage',

--- a/app/services/notices/setup/submit-remove-licences.service.js
+++ b/app/services/notices/setup/submit-remove-licences.service.js
@@ -28,7 +28,7 @@ async function go(sessionId, payload) {
   const validationResult = _validate(payload, validLicences)
 
   if (validationResult) {
-    const formattedData = RemoveLicencesPresenter.go(payload.removeLicences, session.referenceCode)
+    const formattedData = RemoveLicencesPresenter.go(payload.removeLicences, session.referenceCode, sessionId)
 
     return {
       activeNavBar: 'manage',

--- a/app/views/notices/setup/remove-licences.njk
+++ b/app/views/notices/setup/remove-licences.njk
@@ -4,48 +4,41 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from 'govuk/components/error-summary/macro.njk' import govukErrorSummary %}
 
+{% from "macros/page-heading.njk" import pageHeading %}
+
 {% block breadcrumbs %}
-  {{ govukBackLink({
-    text: 'Back',
-    href: "check"
-  }) }}
+  {{ govukBackLink({ text: 'Back', href: backLink }) }}
 {% endblock %}
 
 {% block content %}
-  <div class="govuk-body">
-    {% if error %}
-      {{ govukErrorSummary({
-        titleText: "There is a problem",
-        errorList: [
-          {
-            text: error.text,
-            href: "#removeLicences-error"
-          }
-        ]
-      }) }}
-    {% endif %}
+  {% if error %}
+    {{ govukErrorSummary({
+      titleText: "There is a problem",
+      errorList: [
+        {
+          text: error.text,
+          href: "#removeLicences-error"
+        }
+      ]
+    }) }}
+  {% endif %}
 
-    <form method="post">
-      <input type="hidden" name="wrlsCrumb" value="{{ wrlsCrumb }}" />
+  <form method="post">
+    <input type="hidden" name="wrlsCrumb" value="{{ wrlsCrumb }}" />
 
-      <span class="govuk-caption-l">Notice {{referenceCode}} </span>
+    {{ govukTextarea({
+      name: "removeLicences",
+      id: "remove-licences",
+      errorMessage: error,
+      label: {
+        html: pageHeading(pageTitle, pageTitleCaption)
+      },
+      hint: {
+        text: hint
+      },
+      value: removeLicences
+    }) }}
 
-      {{ govukTextarea({
-        name: "removeLicences",
-        id: "remove-licences",
-        errorMessage: error,
-        label: {
-          text: pageTitle,
-          classes: "govuk-label--l",
-          isPageHeading: true
-        },
-        hint: {
-          text: hint
-        },
-        value: removeLicences
-      }) }}
-
-      {{ govukButton({ text: "Continue", preventDoubleClick: true }) }}
-    </form>
-  </div>
+    {{ govukButton({ text: "Continue", preventDoubleClick: true }) }}
+  </form>
 {% endblock %}

--- a/test/presenters/notices/setup/remove-licences.presenter.test.js
+++ b/test/presenters/notices/setup/remove-licences.presenter.test.js
@@ -13,13 +13,16 @@ const RemoveLicencesPresenter = require('../../../../app/presenters/notices/setu
 describe('Notices - Setup - Remove licences presenter', () => {
   const licences = []
   const referenceCode = 'RINV-1234'
+  const sessionId = '123'
 
   it('correctly presents the data', () => {
-    const result = RemoveLicencesPresenter.go(licences, referenceCode)
+    const result = RemoveLicencesPresenter.go(licences, referenceCode, sessionId)
 
     expect(result).to.equal({
+      backLink: '/system/notices/setup/123/check',
       hint: 'Separate the licences numbers with a comma or new line.',
       pageTitle: 'Enter the licence numbers to remove from the mailing list',
+      pageTitleCaption: 'Notice RINV-1234',
       referenceCode,
       removeLicences: []
     })

--- a/test/services/notices/setup/remove-licences.service.test.js
+++ b/test/services/notices/setup/remove-licences.service.test.js
@@ -27,8 +27,10 @@ describe('Notices - Setup - Remove licences service', () => {
 
     expect(result).to.equal({
       activeNavBar: 'manage',
+      backLink: `/system/notices/setup/${session.id}/check`,
       hint: 'Separate the licences numbers with a comma or new line.',
       pageTitle: 'Enter the licence numbers to remove from the mailing list',
+      pageTitleCaption: 'Notice RINV-1234',
       referenceCode: 'RINV-1234',
       removeLicences: []
     })

--- a/test/services/notices/setup/submit-remove-licences.services.test.js
+++ b/test/services/notices/setup/submit-remove-licences.services.test.js
@@ -84,13 +84,15 @@ describe('Notices - Setup - Submit Remove licences service', () => {
 
         expect(result).to.equal({
           activeNavBar: 'manage',
+          backLink: `/system/notices/setup/${session.id}/check`,
           error: {
             text: 'There are no returns due for licence 789'
           },
           hint: 'Separate the licences numbers with a comma or new line.',
           removeLicences: '789',
           referenceCode: 'RINV-123',
-          pageTitle: 'Enter the licence numbers to remove from the mailing list'
+          pageTitle: 'Enter the licence numbers to remove from the mailing list',
+          pageTitleCaption: 'Notice RINV-123'
         })
       })
     })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5200

As started in #2186 we're working our way through the pages to standardise the views.

This PR updates the Notice - Setup - Remove licences page.