### PR TITLE
Update the standard layout to provide the error summary, back link and page heading html.

### DIFF
--- a/app/views/layout.njk
+++ b/app/views/layout.njk
@@ -1,5 +1,10 @@
 {% extends "govuk/template.njk" %}
+
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
+{% from 'govuk/components/error-summary/macro.njk' import govukErrorSummary %}
+
+{% from "macros/page-heading.njk" import pageHeading %}
 
 {% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}
 
@@ -46,11 +51,29 @@
 
   {# Place holder section for things like back links or breadcrumbs #}
   {% block breadcrumbs %}
+    {#  The back link should provide an object like this: { text: 'Back', herf: '/link/to/previous/page'  #}
+    {% if backLink %}
+      {{ govukBackLink(backLink) }}
+    {% endif %}
   {% endblock %}
 {% endblock %}
 
 {% block content %}
-  <h1 class="govuk-heading-xl">Default page template</h1>
+  {# Pages can provide an 'errorList' to show the error summary. It should look like this:
+    [{ text: 'An error', href: "#link-to-form-item"}]  #}
+  {% if errorList %}
+    {{ govukErrorSummary({
+      titleText: "There is a problem",
+      errorList: errorList
+    }) }}
+  {% endif %}
+
+  {# We set the page heading as a variable in the view to ensure all pages are consistent use this in your form field
+    when setting 'isPageHeading: true' #}
+  {% set pageHeadingHtml = pageHeading(pageTitle, pageTitleCaption) %}
+
+  {% block pageContent %}
+  {% endblock %}
 {% endblock %}
 
 {% block footer %}

--- a/app/views/layout.njk
+++ b/app/views/layout.njk
@@ -10,7 +10,7 @@
 
 {% block head %}
   <!--[if !IE 8]><!-->
-    <link href="{{ assetPath }}/stylesheets/application.css" rel="stylesheet" />
+  <link href="{{ assetPath }}/stylesheets/application.css" rel="stylesheet" />
   <!--<![endif]-->
 
   {# For Internet Explorer 8, you need to compile specific stylesheet #}
@@ -21,7 +21,7 @@
 
   {# For older browsers to allow them to recognise HTML5 elements such as `<header>` #}
   <!--[if lt IE 9]>
-    <script src="/html5-shiv/html5shiv.js"></script>
+  <script src="/html5-shiv/html5shiv.js"></script>
   <![endif]-->
 {% endblock %}
 
@@ -37,21 +37,15 @@
 {% endblock %}
 
 {% block beforeContent %}
-  {{
-    govukPhaseBanner({
-      tag: {
-        text: "Beta"
-      },
-      html: 'This is a new service - your <a class="govuk-link" href="/feedback">feedback</a> will help us to improve it.'
-    })
-  }}
+  {{ govukPhaseBanner({
+    tag: { text: "Beta" },
+    html: 'This is a new service - your <a class="govuk-link" href="/feedback">feedback</a> will help us to improve it.'
+  }) }}
   {% if auth.authenticated %}
     {% include "includes/nav-bar.njk" %}
   {% endif %}
 
-  {# Place holder section for things like back links or breadcrumbs #}
   {% block breadcrumbs %}
-    {#  The back link should provide an object like this: { text: 'Back', herf: '/link/to/previous/page'  #}
     {% if backLink %}
       {{ govukBackLink(backLink) }}
     {% endif %}
@@ -59,17 +53,10 @@
 {% endblock %}
 
 {% block content %}
-  {# Pages can provide an 'errorList' to show the error summary. It should look like this:
-    [{ text: 'An error', href: "#link-to-form-item"}]  #}
   {% if errorList %}
-    {{ govukErrorSummary({
-      titleText: "There is a problem",
-      errorList: errorList
-    }) }}
+    {{ govukErrorSummary({ titleText: "There is a problem", errorList: errorList }) }}
   {% endif %}
 
-  {# We set the page heading as a variable in the view to ensure all pages are consistent use this in your form field
-    when setting 'isPageHeading: true' #}
   {% set pageHeadingHtml = pageHeading(pageTitle, pageTitleCaption) %}
 
   {% block pageContent %}
@@ -80,25 +67,15 @@
   {{ govukFooter({
     meta: {
       items: [
-        {
-          href: "/cookies",
-          text: "Cookies"
-        },
-        {
-          href: "/privacy-policy",
-          text: "Privacy"
-        },
-        {
-          href: "/accessibility",
-          text: "Accessibility"
-        }
+        { href: "/cookies", text: "Cookies" },
+        { href: "/privacy-policy", text: "Privacy" },
+        { href: "/accessibility", text: "Accessibility" }
       ]
     }
   }) }}
 {% endblock %}
 
 {% block bodyEnd %}
-  {# Run JavaScript at end of the <body>, to avoid blocking the initial render. #}
   <script src="{{ assetPath }}/all.js"></script>
   <script>window.GOVUKFrontend.initAll()</script>
 {% endblock %}


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/149

To use the updated layout and keep the old pages working, we have introduced a new block called 'pageContent'. This should generally be used to show the form content of a page.

If a page needs to control the entire content, then the 'content' block can still be used. This also allows existing pages to still function as expected.

The backlink works on the same principle where the current pages will override the 'breadcrumbs' block. When the new 'pageContent' block is used, the override can be removed, but the backlink must now provide an object with the text and href.

The error messages will be provided by the submit logic for a page, and they will provide the 'errorList'.