### PR TITLE
Address lookup - handle null premises and street address

### DIFF
--- a/app/services/address/submit-select.service.js
+++ b/app/services/address/submit-select.service.js
@@ -65,14 +65,14 @@ async function _save(session, address) {
   const premises = address.premises ?? ''
   const streetAddress = address.street_address ?? ''
 
-  const premisesStreetAddress = premises + ' ' + streetAddress
+  const premisesStreetAddress = `${premises} ${streetAddress}`.trim()
 
   if (!address.organisation) {
-    session.address.addressLine1 = premisesStreetAddress.trim()
+    session.address.addressLine1 = premisesStreetAddress
     session.address.addressLine2 = null
   } else {
     session.address.addressLine1 = address.organisation
-    session.address.addressLine2 = premisesStreetAddress.trim()
+    session.address.addressLine2 = premisesStreetAddress
   }
 
   session.address.addressLine3 = address.locality ?? null

--- a/app/services/address/submit-select.service.js
+++ b/app/services/address/submit-select.service.js
@@ -62,14 +62,17 @@ async function go(sessionId, payload) {
 async function _save(session, address) {
   session.address.uprn = address.uprn
 
-  const premiseseStreetAddress = address.premises + ' ' + address.street_address
+  const premises = address.premises ?? ''
+  const streetAddress = address.street_address ?? ''
+
+  const premisesStreetAddress = premises + ' ' + streetAddress
 
   if (!address.organisation) {
-    session.address.addressLine1 = premiseseStreetAddress.trim()
+    session.address.addressLine1 = premisesStreetAddress.trim()
     session.address.addressLine2 = null
   } else {
     session.address.addressLine1 = address.organisation
-    session.address.addressLine2 = premiseseStreetAddress.trim()
+    session.address.addressLine2 = premisesStreetAddress.trim()
   }
 
   session.address.addressLine3 = address.locality ?? null

--- a/test/services/address/submit-select.service.test.js
+++ b/test/services/address/submit-select.service.test.js
@@ -152,6 +152,102 @@ describe('Address - Submit Select Service', () => {
     })
   })
 
+  describe('when an address has been selected without a premises', () => {
+    beforeEach(async () => {
+      payload = {
+        addresses: '340116'
+      }
+
+      const noPremises = {
+        ...matchWithoutOrganisation,
+        premises: null
+      }
+
+      getByUPRNStub.resolves({
+        succeeded: true,
+        response: {
+          statusCode: 200,
+          body: {
+            results: [noPremises]
+          }
+        },
+        matches: [noPremises]
+      })
+    })
+
+    it('saves the submitted value', async () => {
+      await SubmitSelectService.go(session.id, payload)
+
+      const refreshedSession = await session.$query()
+
+      expect(refreshedSession.data.address).to.equal({
+        uprn: 340116,
+        addressLine1: 'DEANERY ROAD',
+        addressLine2: null,
+        addressLine3: 'VILLAGE GREEN',
+        addressLine4: 'BRISTOL',
+        postcode: 'BS1 5AH',
+        redirectUrl: '/system/notices/setup/0793ca8d-9a30-4ce6-92d8-6149b44a1b1d/add-recipient'
+      })
+    })
+
+    it('continues on the journey', async () => {
+      const result = await SubmitSelectService.go(session.id, payload)
+
+      expect(result).to.equal({
+        redirect: '/system/notices/setup/0793ca8d-9a30-4ce6-92d8-6149b44a1b1d/add-recipient'
+      })
+    })
+  })
+
+  describe('when an address has been selected without a street_address', () => {
+    beforeEach(async () => {
+      payload = {
+        addresses: '340116'
+      }
+
+      const noPremises = {
+        ...matchWithoutOrganisation,
+        street_address: null
+      }
+
+      getByUPRNStub.resolves({
+        succeeded: true,
+        response: {
+          statusCode: 200,
+          body: {
+            results: [noPremises]
+          }
+        },
+        matches: [noPremises]
+      })
+    })
+
+    it('saves the submitted value', async () => {
+      await SubmitSelectService.go(session.id, payload)
+
+      const refreshedSession = await session.$query()
+
+      expect(refreshedSession.data.address).to.equal({
+        uprn: 340116,
+        addressLine1: 'HORIZON HOUSE',
+        addressLine2: null,
+        addressLine3: 'VILLAGE GREEN',
+        addressLine4: 'BRISTOL',
+        postcode: 'BS1 5AH',
+        redirectUrl: '/system/notices/setup/0793ca8d-9a30-4ce6-92d8-6149b44a1b1d/add-recipient'
+      })
+    })
+
+    it('continues on the journey', async () => {
+      const result = await SubmitSelectService.go(session.id, payload)
+
+      expect(result).to.equal({
+        redirect: '/system/notices/setup/0793ca8d-9a30-4ce6-92d8-6149b44a1b1d/add-recipient'
+      })
+    })
+  })
+
   describe('when an address has not been selected', () => {
     beforeEach(async () => {
       payload = {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5046

As part of the testing for the select address page QA found some addresses that had no premises or street_address which the current code didn't handle correctly. 

This PR adds logic to check for null values for those fields. 