### PR TITLE
Remove united kingdom from international list

### DIFF
--- a/app/lib/static-lookups.lib.js
+++ b/app/lib/static-lookups.lib.js
@@ -203,7 +203,6 @@ const countries = [
   'Uganda',
   'Ukraine',
   'United Arab Emirates',
-  'United Kingdom',
   'United States',
   'Uruguay',
   'Uzbekistan',


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5047

As part of the testing for this ticket QA discovered that we have the united kingdom in the list of countries we use for international addresses. 

This PR removes it from the list as the user should be using the UK pages for addresses