### PR TITLE
Refactor Gotenberg health check to status request 

### DIFF
--- a/app/requests/gotenberg.request.js
+++ b/app/requests/gotenberg.request.js
@@ -10,6 +10,19 @@ const BaseRequest = require('./base.request.js')
 const gotenbergConfig = require('../../config/gotenberg.config.js')
 
 /**
+ * Sends a GET request to Gotenberg
+ *
+ * @param {string} path - The path to send the request to (do not include the starting /)
+ *
+ * @returns {Promise<object>} An object representing the result of the request
+ */
+async function get(path) {
+  const result = await _sendRequest(path, BaseRequest.get)
+
+  return _parseResult(result)
+}
+
+/**
  * Make a http requests to Gotenberg to convert HTML into a PDF
  *
  * @param {string} path - The path to send the request to (do not include the starting /)
@@ -59,5 +72,6 @@ function _parseResult(result) {
 }
 
 module.exports = {
+  get,
   post
 }

--- a/app/requests/gotenberg/view-health.request.js
+++ b/app/requests/gotenberg/view-health.request.js
@@ -1,0 +1,23 @@
+'use strict'
+
+/**
+ * View the health of Gotenberg service
+ * @module GenerateReturnFormRequest
+ */
+
+const GotenbergRequest = require('../gotenberg.request.js')
+
+/**
+ * View the health of Gotenberg service
+ *
+ * @returns {Promise<object>} The result of the request; whether it succeeded and the response or error returned
+ */
+async function send() {
+  const path = 'health'
+
+  return GotenbergRequest.get(path)
+}
+
+module.exports = {
+  send
+}

--- a/app/services/health/info.service.js
+++ b/app/services/health/info.service.js
@@ -15,10 +15,10 @@ const ChargingModuleRequest = require('../../requests/charging-module.request.js
 const CreateRedisClientService = require('./create-redis-client.service.js')
 const FetchSystemInfoService = require('./fetch-system-info.service.js')
 const LegacyRequest = require('../../requests/legacy.request.js')
+const GotenbergViewHealthRequest = require('../../requests/gotenberg/view-health.request.js')
 const { sentenceCase } = require('../../presenters/base.presenter.js')
 
 const addressFacadeConfig = require('../../../config/address-facade.config.js')
-const gotenbergConfig = require('../../../config/gotenberg.config.js')
 
 /**
  * Checks status and gathers info for each of the services which make up WRLS
@@ -70,8 +70,7 @@ async function _getAddressFacadeData() {
 }
 
 async function _getGotenbergData() {
-  const statusUrl = new URL('/health', gotenbergConfig.url)
-  const result = await BaseRequest.get(statusUrl.href)
+  const result = await GotenbergViewHealthRequest.send()
 
   if (result.succeeded) {
     const response = JSON.parse(result.response.body)

--- a/test/requests/gotenberg.request.test.js
+++ b/test/requests/gotenberg.request.test.js
@@ -39,6 +39,84 @@ describe('Gotenberg Request', () => {
     Sinon.restore()
   })
 
+  describe('#get', () => {
+    describe('when the request succeeds', () => {
+      beforeEach(async () => {
+        Sinon.stub(BaseRequest, 'get').resolves({
+          succeeded: true,
+          response: {
+            statusCode: 200,
+            body: { testObject: { test: 'yes' } }
+          }
+        })
+      })
+
+      it('calls Gotenberg with the required options', async () => {
+        await GotenbergRequest.get(testRoute)
+
+        const requestArgs = BaseRequest.get.firstCall.args
+
+        expect(requestArgs[0]).to.endWith('TEST_ROUTE')
+      })
+
+      it('uses the Gotenberg timeout', async () => {
+        await GotenbergRequest.get(testRoute)
+
+        const requestArgs = BaseRequest.get.firstCall.args
+
+        expect(requestArgs[1].timeout).to.equal({ request: 1234 })
+      })
+
+      it('returns a "true" success status', async () => {
+        const result = await GotenbergRequest.get(testRoute)
+
+        expect(result.succeeded).to.be.true()
+      })
+
+      it('returns the response body as an object', async () => {
+        const result = await GotenbergRequest.get(testRoute)
+
+        expect(result.response.body.testObject.test).to.equal('yes')
+      })
+
+      it('returns the status code', async () => {
+        const result = await GotenbergRequest.get(testRoute)
+
+        expect(result.response.statusCode).to.equal(200)
+      })
+    })
+
+    describe('when the request fails', () => {
+      beforeEach(async () => {
+        Sinon.stub(BaseRequest, 'get').resolves({
+          succeeded: false,
+          response: {
+            statusCode: 404,
+            body: 'Not Found'
+          }
+        })
+      })
+
+      it('returns a "false" success status', async () => {
+        const result = await GotenbergRequest.get(testRoute)
+
+        expect(result.succeeded).to.be.false()
+      })
+
+      it('returns the error response', async () => {
+        const result = await GotenbergRequest.get(testRoute)
+
+        expect(result.response.body).to.equal('Not Found')
+      })
+
+      it('returns the status code', async () => {
+        const result = await GotenbergRequest.get(testRoute)
+
+        expect(result.response.statusCode).to.equal(404)
+      })
+    })
+  })
+
   describe('#post', () => {
     describe('when the request succeeds', () => {
       beforeEach(async () => {

--- a/test/requests/gotenberg/view-health.request.test.js
+++ b/test/requests/gotenberg/view-health.request.test.js
@@ -1,0 +1,61 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Things we need to stub
+const GotenbergRequest = require('../../../app/requests/gotenberg.request.js')
+
+// Thing under test
+const ViewHealthRequest = require('../../../app/requests/gotenberg/view-health.request.js')
+
+describe('Gotenberg - View Health request', () => {
+  let response
+
+  afterEach(() => {
+    Sinon.restore()
+  })
+
+  describe('when the request succeeds', () => {
+    beforeEach(() => {
+      response = {
+        statusCode: 200,
+        body: {
+          status: 'up',
+          details: {
+            chromium: {
+              status: 'up',
+              timestamp: '2025-08-26T23:21:08.772604834Z'
+            },
+            libreoffice: {
+              status: 'up',
+              timestamp: '2025-08-26T23:21:08.772586125Z'
+            }
+          }
+        }
+      }
+
+      Sinon.stub(GotenbergRequest, 'get').resolves({
+        succeeded: true,
+        response
+      })
+    })
+
+    it('returns a "true" success status', async () => {
+      const result = await ViewHealthRequest.send()
+
+      expect(result.succeeded).to.be.true()
+    })
+
+    it('returns the result from Gotenberg in the "response"', async () => {
+      const result = await ViewHealthRequest.send()
+
+      expect(result.response.body).to.equal(response.body)
+    })
+  })
+})


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/150

We recently added [Gotenberg](https://gotenberg.dev/), a "containerized API for seamless PDF conversion". This is our solution for generating the PDF return forms, which are sent from the service and currently handled via the legacy apps.

When we did add it, like all our dependent services, we [added Gotenberg to health check](https://github.com/DEFRA/water-abstraction-system/pull/2177).

However, when we made that change, we coded the 'status' request directly into `app/services/health/info.service.js` using the `BaseRequest` module. This was understandable, as our 'proper' requests only required using the POST method. With no GET, there was no way to use `GotenbergRequest`.

Where an external service requires making GET requests, we bring in their corresponding base request module. Either way, as we continue to add external services, it means `app/services/health/info.service.js` has to do a lot of work.

Ideally, these 'status' requests should be treated as any other request to the service, and therefore have their own corresponding 'request' module. This change marks the first step in refactoring `InfoService` and its requests to 'external-service' specific requests.