### PR TITLE
Refactor Address Facade health check to request

### DIFF
--- a/app/requests/address-facade/view-status.request.js
+++ b/app/requests/address-facade/view-status.request.js
@@ -1,0 +1,31 @@
+'use strict'
+
+/**
+ * View the status of the address facade
+ * @module ViewStatusRequest
+ */
+
+const BaseRequest = require('../base.request.js')
+
+const addressFacadeConfig = require('../../../config/address-facade.config.js')
+
+/**
+ * View the status of the address facade
+ *
+ * Normally, we would use the relevant service's base request object, for example, `address-facade.request.js`. However,
+ * the Address facade for reasons only it knows (!!) returns a plain text response when you hit it's status endpoint.
+ *
+ * The rest of the time it returns JSON. We chose not to overcomplicate `address-facade.request.js` and try and handle
+ * both just for this one request. So, instead we call `BaseRequest` directly.
+ *
+ * @returns {Promise<object>} The result of the request; whether it succeeded and the response or error returned
+ */
+async function send() {
+  const statusUrl = new URL('/address-service/hola', addressFacadeConfig.url)
+
+  return BaseRequest.get(statusUrl.href)
+}
+
+module.exports = {
+  send
+}

--- a/app/services/health/info.service.js
+++ b/app/services/health/info.service.js
@@ -10,15 +10,13 @@ const ChildProcess = require('child_process')
 const util = require('util')
 const exec = util.promisify(ChildProcess.exec)
 
-const BaseRequest = require('../../requests/base.request.js')
+const AddressFacadeViewStatusRequest = require('../../requests/address-facade/view-status.request.js')
 const ChargingModuleRequest = require('../../requests/charging-module.request.js')
 const CreateRedisClientService = require('./create-redis-client.service.js')
 const FetchSystemInfoService = require('./fetch-system-info.service.js')
 const LegacyRequest = require('../../requests/legacy.request.js')
 const GotenbergViewHealthRequest = require('../../requests/gotenberg/view-health.request.js')
 const { sentenceCase } = require('../../presenters/base.presenter.js')
-
-const addressFacadeConfig = require('../../../config/address-facade.config.js')
 
 /**
  * Checks status and gathers info for each of the services which make up WRLS
@@ -59,8 +57,7 @@ async function _addSystemInfoToLegacyAppData(appData) {
 }
 
 async function _getAddressFacadeData() {
-  const statusUrl = new URL('/address-service/hola', addressFacadeConfig.url)
-  const result = await BaseRequest.get(statusUrl.href)
+  const result = await AddressFacadeViewStatusRequest.send()
 
   if (result.succeeded) {
     return result.response.body

--- a/test/requests/gotenberg/view-health.request.test.js
+++ b/test/requests/gotenberg/view-health.request.test.js
@@ -58,4 +58,32 @@ describe('Gotenberg - View Health request', () => {
       expect(result.response.body).to.equal(response.body)
     })
   })
+
+  describe('when the request fails', () => {
+    describe('because the request did not return a 2xx/3xx response', () => {
+      beforeEach(async () => {
+        response = {
+          statusCode: 404,
+          body: 'Not Found'
+        }
+
+        Sinon.stub(GotenbergRequest, 'get').resolves({
+          succeeded: false,
+          response
+        })
+      })
+
+      it('returns a "false" success status', async () => {
+        const result = await ViewHealthRequest.send()
+
+        expect(result.succeeded).to.be.false()
+      })
+
+      it('returns the error in the "response"', async () => {
+        const result = await ViewHealthRequest.send()
+
+        expect(result.response.body).to.equal(response.body)
+      })
+    })
+  })
 })


### PR DESCRIPTION
We recently added [Gotenberg](https://gotenberg.dev/), a "containerized API for seamless PDF conversion". This is our solution for generating the PDF return forms, which are sent from the service and currently handled via the legacy apps.

When we did add it, like all our dependent services, we [added Gotenberg to health check](https://github.com/DEFRA/water-abstraction-system/pull/2177).

However, when we made that change, we coded the 'status' request directly into `app/services/health/info.service.js` using the `BaseRequest` module. This was understandable, as our 'proper' requests only required using the POST method. With no GET, there was no way to use `GotenbergRequest`.

Where an external service requires making GET requests, we bring in their corresponding base request module. Either way, as we continue to add external services, it means `app/services/health/info.service.js` has to do a lot of work.

Ideally, these 'status' requests should be treated as any other request to the service, and therefore have their own corresponding 'request' module.

In [Refactor Gotenberg health check to status request](https://github.com/DEFRA/water-abstraction-system/pull/2325). This change does the same for the [Address Facade](https://github.com/DEFRA/ea-address-facade).
