### PR TITLE
Refactor Charging Module health check to request 

### DIFF
--- a/app/requests/address-facade/view-health.request.js
+++ b/app/requests/address-facade/view-health.request.js
@@ -1,8 +1,8 @@
 'use strict'
 
 /**
- * View the status of the address facade
- * @module ViewStatusRequest
+ * View the health of the Address Facade
+ * @module ViewHealthRequest
  */
 
 const BaseRequest = require('../base.request.js')
@@ -10,7 +10,7 @@ const BaseRequest = require('../base.request.js')
 const addressFacadeConfig = require('../../../config/address-facade.config.js')
 
 /**
- * View the status of the address facade
+ * View the health of the Address Facade
  *
  * Normally, we would use the relevant service's base request object, for example, `address-facade.request.js`. However,
  * the Address facade for reasons only it knows (!!) returns a plain text response when you hit it's status endpoint.

--- a/app/requests/charging-module/view-health.request.js
+++ b/app/requests/charging-module/view-health.request.js
@@ -1,0 +1,23 @@
+'use strict'
+
+/**
+ * View the health of Charging Module service
+ * @module GenerateReturnFormRequest
+ */
+
+const ChargingModuleRequest = require('../charging-module.request.js')
+
+/**
+ * View the health of Charging Module service
+ *
+ * @returns {Promise<object>} The result of the request; whether it succeeded and the response or error returned
+ */
+async function send() {
+  const path = 'status'
+
+  return ChargingModuleRequest.get(path)
+}
+
+module.exports = {
+  send
+}

--- a/app/requests/gotenberg/view-health.request.js
+++ b/app/requests/gotenberg/view-health.request.js
@@ -2,7 +2,7 @@
 
 /**
  * View the health of Gotenberg service
- * @module GenerateReturnFormRequest
+ * @module ViewHealthRequest
  */
 
 const GotenbergRequest = require('../gotenberg.request.js')

--- a/app/services/health/info.service.js
+++ b/app/services/health/info.service.js
@@ -11,7 +11,7 @@ const util = require('util')
 const exec = util.promisify(ChildProcess.exec)
 
 const AddressFacadeViewStatusRequest = require('../../requests/address-facade/view-status.request.js')
-const ChargingModuleRequest = require('../../requests/charging-module.request.js')
+const ChargingModuleViewHealthRequest = require('../../requests/charging-module/view-health.request.js')
 const CreateRedisClientService = require('./create-redis-client.service.js')
 const FetchSystemInfoService = require('./fetch-system-info.service.js')
 const LegacyRequest = require('../../requests/legacy.request.js')
@@ -108,7 +108,7 @@ async function _getLegacyAppData() {
 }
 
 async function _getChargingModuleData() {
-  const result = await ChargingModuleRequest.get('status')
+  const result = await ChargingModuleViewHealthRequest.send()
 
   if (result.succeeded) {
     return result.response.info.dockerTag

--- a/app/services/health/info.service.js
+++ b/app/services/health/info.service.js
@@ -10,7 +10,7 @@ const ChildProcess = require('child_process')
 const util = require('util')
 const exec = util.promisify(ChildProcess.exec)
 
-const AddressFacadeViewStatusRequest = require('../../requests/address-facade/view-status.request.js')
+const AddressFacadeViewHealthRequest = require('../../requests/address-facade/view-health.request.js')
 const ChargingModuleViewHealthRequest = require('../../requests/charging-module/view-health.request.js')
 const CreateRedisClientService = require('./create-redis-client.service.js')
 const FetchSystemInfoService = require('./fetch-system-info.service.js')
@@ -57,7 +57,7 @@ async function _addSystemInfoToLegacyAppData(appData) {
 }
 
 async function _getAddressFacadeData() {
-  const result = await AddressFacadeViewStatusRequest.send()
+  const result = await AddressFacadeViewHealthRequest.send()
 
   if (result.succeeded) {
     return result.response.body

--- a/test/requests/address-facade/view-health.request.test.js
+++ b/test/requests/address-facade/view-health.request.test.js
@@ -12,9 +12,9 @@ const { expect } = Code
 const BaseRequest = require('../../../app/requests/base.request.js')
 
 // Thing under test
-const ViewStatusRequest = require('../../../app/requests/address-facade/view-status.request.js')
+const ViewHealthRequest = require('../../../app/requests/address-facade/view-health.request.js')
 
-describe('Address Facade - View Status request', () => {
+describe('Address Facade - View Health request', () => {
   let response
 
   afterEach(() => {
@@ -35,13 +35,13 @@ describe('Address Facade - View Status request', () => {
     })
 
     it('returns a "true" success status', async () => {
-      const result = await ViewStatusRequest.send()
+      const result = await ViewHealthRequest.send()
 
       expect(result.succeeded).to.be.true()
     })
 
-    it('returns the result from Gotenberg in the "response"', async () => {
-      const result = await ViewStatusRequest.send()
+    it('returns the result from the Address Facade in the "response"', async () => {
+      const result = await ViewHealthRequest.send()
 
       expect(result.response.body).to.equal(response.body)
     })
@@ -69,13 +69,13 @@ describe('Address Facade - View Status request', () => {
       })
 
       it('returns a "false" success status', async () => {
-        const result = await ViewStatusRequest.send()
+        const result = await ViewHealthRequest.send()
 
         expect(result.succeeded).to.be.false()
       })
 
       it('returns the error in the "response"', async () => {
-        const result = await ViewStatusRequest.send()
+        const result = await ViewHealthRequest.send()
 
         expect(result.response.body).to.equal(response.body)
       })

--- a/test/requests/charging-module/view-health.request.test.js
+++ b/test/requests/charging-module/view-health.request.test.js
@@ -1,0 +1,81 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Things we need to stub
+const ChargingModuleRequest = require('../../../app/requests/charging-module.request.js')
+
+// Thing under test
+const ViewHealthRequest = require('../../../app/requests/charging-module/view-health.request.js')
+
+describe('Charging Module - View Health request', () => {
+  let response
+
+  afterEach(() => {
+    Sinon.restore()
+  })
+
+  describe('when the request succeeds', () => {
+    beforeEach(() => {
+      response = {
+        statusCode: 200,
+        body: { status: 'alive' }
+      }
+
+      Sinon.stub(ChargingModuleRequest, 'get').resolves({
+        succeeded: true,
+        response
+      })
+    })
+
+    it('returns a "true" success status', async () => {
+      const result = await ViewHealthRequest.send()
+
+      expect(result.succeeded).to.be.true()
+    })
+
+    it('returns the result from the Charging Module in the "response"', async () => {
+      const result = await ViewHealthRequest.send()
+
+      expect(result.response.body).to.equal(response.body)
+    })
+  })
+
+  describe('when the request fails', () => {
+    describe('because the request did not return a 2xx/3xx response', () => {
+      beforeEach(async () => {
+        response = {
+          statusCode: 404,
+          body: {
+            statusCode: 404,
+            error: 'Not Found',
+            message: 'Not Found'
+          }
+        }
+
+        Sinon.stub(ChargingModuleRequest, 'get').resolves({
+          succeeded: false,
+          response
+        })
+      })
+
+      it('returns a "false" success status', async () => {
+        const result = await ViewHealthRequest.send()
+
+        expect(result.succeeded).to.be.false()
+      })
+
+      it('returns the error in the "response"', async () => {
+        const result = await ViewHealthRequest.send()
+
+        expect(result.response.body).to.equal(response.body)
+      })
+    })
+  })
+})

--- a/test/services/health/info.service.test.js
+++ b/test/services/health/info.service.test.js
@@ -10,7 +10,7 @@ const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Things we need to stub
-const AddressFacadeViewStatusRequest = require('../../../app/requests/address-facade/view-status.request.js')
+const AddressFacadeViewHealthRequest = require('../../../app/requests/address-facade/view-health.request.js')
 const ChargingModuleViewHealthRequest = require('../../../app/requests/charging-module/view-health.request.js')
 const CreateRedisClientService = require('../../../app/services/health/create-redis-client.service.js')
 const LegacyRequest = require('../../../app/requests/legacy.request.js')
@@ -49,7 +49,7 @@ describe('Health - Info service', () => {
   let redisStub
 
   beforeEach(() => {
-    addressFacadeViewStatusRequestStub = Sinon.stub(AddressFacadeViewStatusRequest, 'send')
+    addressFacadeViewStatusRequestStub = Sinon.stub(AddressFacadeViewHealthRequest, 'send')
     chargingModuleViewHealthRequestStub = Sinon.stub(ChargingModuleViewHealthRequest, 'send')
     gotenbergViewHealthRequestStub = Sinon.stub(GotenbergViewHealthRequest, 'send')
     legacyRequestStub = Sinon.stub(LegacyRequest, 'get')

--- a/test/services/health/info.service.test.js
+++ b/test/services/health/info.service.test.js
@@ -11,7 +11,7 @@ const { expect } = Code
 
 // Things we need to stub
 const AddressFacadeViewStatusRequest = require('../../../app/requests/address-facade/view-status.request.js')
-const ChargingModuleRequest = require('../../../app/requests/charging-module.request.js')
+const ChargingModuleViewHealthRequest = require('../../../app/requests/charging-module/view-health.request.js')
 const CreateRedisClientService = require('../../../app/services/health/create-redis-client.service.js')
 const LegacyRequest = require('../../../app/requests/legacy.request.js')
 const GotenbergViewHealthRequest = require('../../../app/requests/gotenberg/view-health.request.js')
@@ -31,7 +31,8 @@ describe('Health - Info service', () => {
         info: {
           gitCommit: '273604040a47e0977b0579a0fef0f09726d95e39',
           dockerTag: 'v0.19.1'
-        }
+        },
+        body: { status: 'alive' }
       }
     },
     gotenberg: {
@@ -42,14 +43,14 @@ describe('Health - Info service', () => {
   }
 
   let addressFacadeViewStatusRequestStub
-  let chargingModuleRequestStub
+  let chargingModuleViewHealthRequestStub
   let gotenbergViewHealthRequestStub
   let legacyRequestStub
   let redisStub
 
   beforeEach(() => {
     addressFacadeViewStatusRequestStub = Sinon.stub(AddressFacadeViewStatusRequest, 'send')
-    chargingModuleRequestStub = Sinon.stub(ChargingModuleRequest, 'get')
+    chargingModuleViewHealthRequestStub = Sinon.stub(ChargingModuleViewHealthRequest, 'send')
     gotenbergViewHealthRequestStub = Sinon.stub(GotenbergViewHealthRequest, 'send')
     legacyRequestStub = Sinon.stub(LegacyRequest, 'get')
     redisStub = Sinon.stub(CreateRedisClientService, 'go')
@@ -66,7 +67,7 @@ describe('Health - Info service', () => {
     legacyRequestStub.withArgs('permits', 'health/info', null, false).resolves(goodRequestResults.app)
     legacyRequestStub.withArgs('returns', 'health/info', null, false).resolves(goodRequestResults.app)
 
-    chargingModuleRequestStub.withArgs('status').resolves(goodRequestResults.chargingModule)
+    chargingModuleViewHealthRequestStub.resolves(goodRequestResults.chargingModule)
     gotenbergViewHealthRequestStub.resolves(goodRequestResults.gotenberg)
   })
 


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/150

We recently added [Gotenberg](https://gotenberg.dev/), a "containerized API for seamless PDF conversion". This is our solution for generating the PDF return forms, which are sent from the service and currently handled via the legacy apps.

When we did add it, like all our dependent services, we [added Gotenberg to health check](https://github.com/DEFRA/water-abstraction-system/pull/2177).

However, when we made that change, we coded the 'status' request directly into `app/services/health/info.service.js` using the `BaseRequest` module. This was understandable, as our 'proper' requests only required using the POST method. With no GET, there was no way to use `GotenbergRequest`.

Where an external service requires making GET requests, we bring in their corresponding base request module. Either way, as we continue to add external services, it means `app/services/health/info.service.js` has to do a lot of work.

Ideally, these 'status' requests should be treated as any other request to the service, and therefore have their own corresponding 'request' module.

So far, we have done

- [Gotenberg](https://github.com/DEFRA/water-abstraction-system/pull/2325)
- [Address Facade](https://github.com/DEFRA/water-abstraction-system/pull/2326)

This change refactors the [Charging Module](https://github.com/DEFRA/scro-charging-module-api).
