### PR TITLE
Ensure stubbed global notifier is deleted in tests

### DIFF
--- a/test/lib/general.lib.test.js
+++ b/test/lib/general.lib.test.js
@@ -34,6 +34,10 @@ describe('GeneralLib', () => {
       global.GlobalNotifier = notifierStub
     })
 
+    afterEach(() => {
+      delete global.GlobalNotifier
+    })
+
     describe('when no additional data is provided', () => {
       it('logs the message and time taken in milliseconds and seconds', () => {
         GeneralLib.calculateAndLogTimeTaken(startTime, 'I am the test with no data')

--- a/test/plugins/error-pages.plugin.test.js
+++ b/test/plugins/error-pages.plugin.test.js
@@ -5,7 +5,7 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, before, beforeEach, afterEach } = (exports.lab = Lab.script())
+const { describe, it, before, beforeEach, afterEach, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -30,6 +30,9 @@ describe('Error Pages plugin', () => {
 
   afterEach(() => {
     Sinon.restore()
+  })
+
+  after(() => {
     delete global.GlobalNotifier
   })
 

--- a/test/plugins/error-pages.plugin.test.js
+++ b/test/plugins/error-pages.plugin.test.js
@@ -30,6 +30,7 @@ describe('Error Pages plugin', () => {
 
   afterEach(() => {
     Sinon.restore()
+    delete global.GlobalNotifier
   })
 
   describe('When the response is a Boom error', () => {

--- a/test/services/bill-runs/cancel/delete-bill-run.service.test.js
+++ b/test/services/bill-runs/cancel/delete-bill-run.service.test.js
@@ -47,6 +47,7 @@ describe('Bill Runs - Delete Bill Run service', () => {
 
   afterEach(() => {
     Sinon.restore()
+    delete global.GlobalNotifier
   })
 
   describe('when the bill run exists', () => {

--- a/test/services/bill-runs/handle-errored-bill-run.service.test.js
+++ b/test/services/bill-runs/handle-errored-bill-run.service.test.js
@@ -19,17 +19,18 @@ describe('Handle Errored Bill Run service', () => {
   let notifierStub
 
   beforeEach(async () => {
+    billRun = await BillRunHelper.add()
+
     // BaseRequest depends on the GlobalNotifier to have been set. This happens in app/plugins/global-notifier.plugin.js
     // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
     // test we recreate the condition by setting it directly with our own stub
     notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
     global.GlobalNotifier = notifierStub
-
-    billRun = await BillRunHelper.add()
   })
 
   afterEach(() => {
     Sinon.restore()
+    delete global.GlobalNotifier
   })
 
   describe('when the service is called successfully', () => {

--- a/test/services/bill-runs/match/fetch-return-logs-for-licence.service.test.js
+++ b/test/services/bill-runs/match/fetch-return-logs-for-licence.service.test.js
@@ -32,6 +32,7 @@ describe('Fetch Return Logs for Licence service', () => {
 
   afterEach(() => {
     Sinon.restore()
+    delete global.GlobalNotifier
   })
 
   describe('when there are valid return logs that should be considered', () => {

--- a/test/services/bill-runs/match/match-and-allocate.service.test.js
+++ b/test/services/bill-runs/match/match-and-allocate.service.test.js
@@ -31,8 +31,8 @@ describe('Bill Runs - Match - Match And Allocate service', () => {
   })
 
   afterEach(async () => {
-    delete global.GlobalNotifier
     Sinon.restore()
+    delete global.GlobalNotifier
   })
 
   describe('with a given billRun and billingPeriods', () => {

--- a/test/services/bill-runs/reissue/fetch-bills-to-be-reissued.service.test.js
+++ b/test/services/bill-runs/reissue/fetch-bills-to-be-reissued.service.test.js
@@ -114,8 +114,8 @@ describe('Fetch Bills To Be Reissued service', () => {
     })
 
     afterEach(() => {
-      delete global.GlobalNotifier
       Sinon.restore()
+      delete global.GlobalNotifier
     })
 
     it('logs an error', async () => {

--- a/test/services/bill-runs/send/update-invoice-numbers.service.test.js
+++ b/test/services/bill-runs/send/update-invoice-numbers.service.test.js
@@ -47,6 +47,7 @@ describe('Bill Runs - Send - Update Invoice Numbers service', () => {
 
   afterEach(() => {
     Sinon.restore()
+    delete global.GlobalNotifier
   })
 
   describe('when the bill run exists', () => {

--- a/test/services/data/tear-down/tear-down.service.test.js
+++ b/test/services/data/tear-down/tear-down.service.test.js
@@ -27,21 +27,22 @@ describe('Tear down service', () => {
   let waterSchemaServiceStub
 
   beforeEach(async () => {
-    // TearDownService depends on the GlobalNotifier being set. This happens in app/plugins/global-notifier.plugin.js
-    // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
-    // test we recreate the condition by setting it directly with our own stub
-    notifierStub = { omg: Sinon.stub() }
-    global.GlobalNotifier = notifierStub
-
     crmSchemaServiceStub = Sinon.stub(CrmSchemaService, 'go').resolves()
     idmSchemaServiceStub = Sinon.stub(IdmSchemaService, 'go').resolves()
     permitSchemaServiceStub = Sinon.stub(PermitSchemaService, 'go').resolves()
     returnsSchemaServiceStub = Sinon.stub(ReturnsSchemaService, 'go').resolves()
     waterSchemaServiceStub = Sinon.stub(WaterSchemaService, 'go').resolves()
+
+    // TearDownService depends on the GlobalNotifier being set. This happens in app/plugins/global-notifier.plugin.js
+    // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
+    // test we recreate the condition by setting it directly with our own stub
+    notifierStub = { omg: Sinon.stub() }
+    global.GlobalNotifier = notifierStub
   })
 
   afterEach(() => {
     Sinon.restore()
+    delete global.GlobalNotifier
   })
 
   it('tears down the schemas', async () => {

--- a/test/services/jobs/clean/clean-empty-bill-runs.service.test.js
+++ b/test/services/jobs/clean/clean-empty-bill-runs.service.test.js
@@ -52,6 +52,7 @@ describe('Jobs - Clean - Clean Empty Bill Runs service', () => {
 
   afterEach(() => {
     Sinon.restore()
+    delete global.GlobalNotifier
   })
 
   describe('when no bill runs are flagged as "empty"', () => {

--- a/test/services/jobs/clean/clean-empty-void-return-logs.service.test.js
+++ b/test/services/jobs/clean/clean-empty-void-return-logs.service.test.js
@@ -30,6 +30,7 @@ describe('Jobs - Clean - Clean Empty Void Return Logs service', () => {
 
   afterEach(() => {
     Sinon.restore()
+    delete global.GlobalNotifier
   })
 
   describe('when the clean is successful', () => {

--- a/test/services/jobs/clean/clean-expired-sessions.service.test.js
+++ b/test/services/jobs/clean/clean-expired-sessions.service.test.js
@@ -31,6 +31,7 @@ describe('Jobs - Clean - Clean Expired Sessions service', () => {
 
   afterEach(() => {
     Sinon.restore()
+    delete global.GlobalNotifier
   })
 
   describe('when the clean is successful', () => {

--- a/test/services/jobs/clean/process-clean.service.test.js
+++ b/test/services/jobs/clean/process-clean.service.test.js
@@ -40,6 +40,7 @@ describe('Jobs - Clean - Process Clean service', () => {
 
   afterEach(() => {
     Sinon.restore()
+    delete global.GlobalNotifier
   })
 
   describe('when all clean tasks succeed', () => {

--- a/test/services/jobs/customer-files/process-customer-files.service.test.js
+++ b/test/services/jobs/customer-files/process-customer-files.service.test.js
@@ -37,6 +37,7 @@ describe('Jobs - Customer Files - Process Customer Files service', () => {
 
   afterEach(() => {
     Sinon.restore()
+    delete global.GlobalNotifier
   })
 
   describe('when the Charging Module API response has customer files', () => {

--- a/test/services/jobs/export/schema-export.service.test.js
+++ b/test/services/jobs/export/schema-export.service.test.js
@@ -77,13 +77,13 @@ describe('Schema export service', () => {
     let notifierStub
 
     beforeEach(() => {
-      notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
-      global.GlobalNotifier = notifierStub
-
       FetchTableNamesServiceStub = Sinon.stub(FetchTableNamesService, 'go')
       SendToS3BucketServiceStub = Sinon.stub(SendToS3BucketService, 'go')
       CompressSchemaFolderServiceStub = Sinon.stub(CompressSchemaFolderService, 'go')
       DeleteFilesServiceStub = Sinon.stub(DeleteFilesService, 'go').resolves()
+
+      notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
+      global.GlobalNotifier = notifierStub
     })
 
     afterEach(() => {

--- a/test/services/jobs/licence-updates/process-licence-updates.service.test.js
+++ b/test/services/jobs/licence-updates/process-licence-updates.service.test.js
@@ -32,6 +32,7 @@ describe('Jobs - Licence Updates - Process Licence Updates service', () => {
 
   afterEach(() => {
     Sinon.restore()
+    delete global.GlobalNotifier
   })
 
   describe('when there are licence updates', () => {

--- a/test/services/jobs/return-logs/process-return-logs.service.test.js
+++ b/test/services/jobs/return-logs/process-return-logs.service.test.js
@@ -29,6 +29,7 @@ describe('Jobs - Return Logs - Process return logs service', () => {
 
   beforeEach(() => {
     createReturnLogsStub = Sinon.stub(CreateReturnLogsService, 'go').resolves()
+
     // BaseRequest depends on the GlobalNotifier to have been set. This happens in app/plugins/global-notifier.plugin.js
     // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
     // test we recreate the condition by setting it directly with our own stub

--- a/test/services/jobs/time-limited/process-time-limited-licences.service.test.js
+++ b/test/services/jobs/time-limited/process-time-limited-licences.service.test.js
@@ -32,6 +32,7 @@ describe('Process Time Limited Licences service', () => {
 
   afterEach(() => {
     Sinon.restore()
+    delete global.GlobalNotifier
   })
 
   describe('when there are licences with time limited charge elements', () => {

--- a/test/services/licences/supplementary/process-billing-flag.service.test.js
+++ b/test/services/licences/supplementary/process-billing-flag.service.test.js
@@ -26,17 +26,18 @@ describe('Licences - Supplementary - Process Billing Flag service', () => {
   let payload
 
   beforeEach(() => {
+    Sinon.stub(PersistSupplementaryBillingFlagsService, 'go').resolves()
+
     // The service depends on GlobalNotifier to have been set. This happens in app/plugins/global-notifier.plugin.js
     // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
     // test we recreate the condition by setting it directly with our own stub
     notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
     global.GlobalNotifier = notifierStub
-
-    Sinon.stub(PersistSupplementaryBillingFlagsService, 'go').resolves()
   })
 
   afterEach(() => {
     Sinon.restore()
+    delete global.GlobalNotifier
   })
 
   describe('when given a valid payload', () => {

--- a/test/services/notices/setup/submit-check.service.test.js
+++ b/test/services/notices/setup/submit-check.service.test.js
@@ -31,9 +31,6 @@ describe('Notices - Setup - Submit Check service', () => {
   let testRecipients
 
   beforeEach(() => {
-    notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
-    global.GlobalNotifier = notifierStub
-
     auth = {
       credentials: {
         user: {
@@ -43,6 +40,9 @@ describe('Notices - Setup - Submit Check service', () => {
     }
 
     Sinon.stub(BatchNotificationsService, 'go').resolves({ sent: 1, error: 0 })
+
+    notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
+    global.GlobalNotifier = notifierStub
   })
 
   afterEach(() => {

--- a/test/services/plugins/error-pages.service.test.js
+++ b/test/services/plugins/error-pages.service.test.js
@@ -47,8 +47,8 @@ describe('Error pages service', () => {
   })
 
   afterEach(() => {
-    delete global.GlobalNotifier
     Sinon.restore()
+    delete global.GlobalNotifier
   })
 
   describe('when the response is a boom 500 error', () => {


### PR DESCRIPTION
We noticed, while working on the unit tests, that we are inconsistent about deleting the stub for `global.GlobalNotifier` in the `afterEach()` method.

This is a housekeeping change to ensure we do so consistently, and to be clear about when we set the stub and delete it.