### PR TITLE
Remove use of title filter in return forms PDF

### DIFF
--- a/app/views/notices/pdfs/pages/cover.njk
+++ b/app/views/notices/pdfs/pages/cover.njk
@@ -107,12 +107,12 @@
 
         <div class="item">
           <p class="label">Site description</p>
-          <p class="bold">{{ siteDescription | title }}</p>
+          <p class="bold">{{ siteDescription }}</p>
         </div>
 
         <div class="item">
           <p class="label">Purpose</p>
-          <p class="bold">{{ purpose | title }}</p>
+          <p class="bold">{{ purpose }}</p>
         </div>
 
         <div class="item">


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5162

It was spotted during testing that the PDF return forms we are generating were not displaying the return's site description as shown in the UI.

When we examined the PDF view, we found that it was using the [Nunjucks title() filter](https://mozilla.github.io/nunjucks/templating.html#title). Admittedly, we obtained the HTML from the legacy system, but that does not make this behaviour right.

For both the purpose and the site description, we should be including them in the form 'as is'.

This removes the `title()` filter from the cover view.