### PR TITLE
Add data-test tags for acceptance tests

### DIFF
--- a/app/presenters/licences/view-licence-set-up.presenter.js
+++ b/app/presenters/licences/view-licence-set-up.presenter.js
@@ -218,10 +218,11 @@ function _recalculateBills(agreements, auth, commonData, enableTwoPartSupplement
 }
 
 function _returnVersions(returnVersions = [{}]) {
-  return returnVersions.map((returnVersion) => {
+  return returnVersions.map((returnVersion, index) => {
     return {
       action: [
         {
+          dataTest: `return-version-${index}`,
           text: 'View',
           link: `/system/return-versions/${returnVersion.id}`
         }

--- a/app/views/licences/tabs/set-up.njk
+++ b/app/views/licences/tabs/set-up.njk
@@ -7,7 +7,10 @@
 {% macro createLink(data) %}
   {% for linkItem in data.action %}
     {% if not loop.first %} | {% endif %}
-    <a href="{{ linkItem.link }}" class="govuk-link">
+    <a href="{{ linkItem.link }}"
+      class="govuk-link"
+      {% if linkItem.dataTest %} data-test="{{ linkItem.dataTest }}" {% endif %}
+    >
       {{ linkItem.text }} </a>
   {% endfor %}
 {% endmacro %}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4892

As part of the work refactoring the acceptance tests for the return logs and return version journeys it was noticed that we're not checking the summary page. Adding that page onto the end of some of the journeys requires some additional data-test tags so the acceptance tests can correctly identify which areas to verify. 