### PR TITLE
Update notifications 4 auto-populated created_at

### DIFF
--- a/db/migrations/legacy/20221108007033_water-scheduled-notification.js
+++ b/db/migrations/legacy/20221108007033_water-scheduled-notification.js
@@ -30,7 +30,7 @@ exports.up = function (knex) {
     table.string('job_id')
 
     // Legacy timestamps
-    table.timestamp('date_created', { useTz: false })
+    table.timestamp('date_created', { useTz: false }).defaultTo(knex.fn.now())
 
     // Constraints
     table.unique(['job_id'], { useConstraint: true })

--- a/db/migrations/legacy/20221108007033_water-scheduled-notification.js
+++ b/db/migrations/legacy/20221108007033_water-scheduled-notification.js
@@ -30,7 +30,7 @@ exports.up = function (knex) {
     table.string('job_id')
 
     // Legacy timestamps
-    table.timestamp('date_created', { useTz: false }).notNullable()
+    table.timestamp('date_created', { useTz: false })
 
     // Constraints
     table.unique(['job_id'], { useConstraint: true })

--- a/test/support/helpers/notification.helper.js
+++ b/test/support/helpers/notification.helper.js
@@ -4,15 +4,12 @@
  * @module NotificationHelper
  */
 
-const { timestampForPostgres } = require('../../../app/lib/general.lib.js')
 const NotificationModel = require('../../../app/models/notification.model.js')
 
 /**
  * Add a new notification
  *
- * If no `data` is provided, default values will be used. These are
- *
- * - `createdAt` - new Date()
+ * If no `data` is provided, default values will be used.
  *
  * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  *
@@ -37,10 +34,7 @@ function add(data = {}) {
  * @returns {object} - Returns the set defaults with the override data spread
  */
 function defaults(data = {}) {
-  const defaults = {
-    // INFO: The table does not have a default for the createdAt column.
-    createdAt: timestampForPostgres()
-  }
+  const defaults = {}
 
   return {
     ...defaults,

--- a/test/support/helpers/scheduled-notification.helper.js
+++ b/test/support/helpers/scheduled-notification.helper.js
@@ -4,15 +4,12 @@
  * @module ScheduledNotificationHelper
  */
 
-const { timestampForPostgres } = require('../../../app/lib/general.lib.js')
 const ScheduledNotificationModel = require('../../../app/models/scheduled-notification.model.js')
 
 /**
  * Add a new scheduled notification
  *
- * If no `data` is provided, default values will be used. These are
- *
- * - `createdAt` - new Date()
+ * If no `data` is provided, default values will be used.
  *
  * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  *
@@ -37,10 +34,7 @@ function add(data = {}) {
  * @returns {object} - Returns the set defaults with the override data spread
  */
 function defaults(data = {}) {
-  const defaults = {
-    // INFO: The table does not have a default for the createdAt column.
-    createdAt: timestampForPostgres()
-  }
+  const defaults = {}
 
   return {
     ...defaults,


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5229

The legacy code always populates the `send_after` field with the current time when creating a notification, and only sometimes the `date_created` field.

The new code in [water-abstraction-system](https://github.com/DEFRA/water-abstraction-system) always populates `date_created`, and never populates `send_after`. We now consider it a redundant field.

Our issue is that our acceptance tests rely on an endpoint that returns the last notification created for a specified email address. But the disparity between how the two systems create notifications means it can no longer find the last email, which has broken some of the tests.

We need to fix it so it can!

In [Auto-populate scheduled_notification date_created](https://github.com/DEFRA/water-abstraction-service/pull/2716) we added a migration to

- update the `water.scheduled_notification` table so that `date_created` will now automatically populate when a new record is inserted
- update existing records setting `date_created` to `send_after` where `date_created` is null and `send_after` isn't

Now that change has been made, we need to update our legacy migrations accordingly. We can also eliminate the need to manually set the value in our helper.