### PR TITLE
Add recipient download specific variables to additional contacts

### DIFF
--- a/app/services/notices/setup/add-recipient.service.js
+++ b/app/services/notices/setup/add-recipient.service.js
@@ -34,7 +34,8 @@ async function go(sessionId, yar) {
       postcode: session.address.postcode
     },
     contact_hash_id: _contactHashId(session),
-    licence_refs: session.licenceRef
+    licence_refs: session.licenceRef,
+    ..._addDownloadRecipientData(session.licenceRef)
   }
 
   _addRecipient(session, additionalRecipient)
@@ -44,6 +45,25 @@ async function go(sessionId, yar) {
   await _resetGenericAddressSupport(session)
 
   GeneralLib.flashNotification(yar, 'Updated', 'Additional recipient added')
+}
+
+/**
+ * This logic is implemented as a function to illustrate the additional data required for the download link.
+ *
+ * We set the 'contact_type' to 'Single use'. This will be shown in the download for the recipient. This does not
+ * affect the contact type used to send the notice. This is because the 'DetermineRecipientsService' sets the
+ * default 'contact_type' to 'Returns agent' when prior conditions are not met.
+ *
+ * We set the 'licence_ref' the same as the 'licence_refs' to allow the download to render each recipient (it fetches
+ * all possible recipients without deduping).
+ *
+ * @private
+ */
+function _addDownloadRecipientData(licenceRef) {
+  return {
+    contact_type: 'Single use',
+    licence_ref: licenceRef
+  }
 }
 
 function _addRecipient(session, additionalRecipient) {

--- a/app/services/notices/setup/submit-contact-type.service.js
+++ b/app/services/notices/setup/submit-contact-type.service.js
@@ -50,6 +50,25 @@ async function go(sessionId, payload, yar) {
   }
 }
 
+/**
+ * This logic is implemented as a function to illustrate the additional data required for the download link.
+ *
+ * We set the 'contact_type' to 'Single use'. This will be shown in the download for the recipient. This does not
+ * affect the contact type used to send the notice. This is because the 'DetermineRecipientsService' sets the
+ * default 'contact_type' to 'Returns to' when prior conditions are not met.
+ *
+ * We set the 'licence_ref' the same as the 'licence_refs' to allow the download to render each recipient (it fetches
+ * all possible recipients without deduping).
+ *
+ * @private
+ */
+function _addDownloadRecipientData(licenceRef) {
+  return {
+    contact_type: 'Single use',
+    licence_ref: licenceRef
+  }
+}
+
 function _createMD5Hash(email) {
   return crypto.createHash('md5').update(email).digest('hex')
 }
@@ -61,7 +80,8 @@ async function _save(session, payload, yar) {
     const recipient = {
       contact_hash_id: _createMD5Hash(email),
       email,
-      licence_refs: session.licenceRef
+      licence_refs: session.licenceRef,
+      ..._addDownloadRecipientData(session.licenceRef)
     }
 
     if (Array.isArray(session.additionalRecipients)) {

--- a/test/services/notices/setup/add-recipient.service.test.js
+++ b/test/services/notices/setup/add-recipient.service.test.js
@@ -69,6 +69,8 @@ describe('Notices - Setup - Add Recipient service', () => {
                 postcode: session.address.postcode
               },
               contact_hash_id: contactHashId,
+              contact_type: 'Single use',
+              licence_ref: session.licenceRef,
               licence_refs: session.licenceRef
             }
           ])
@@ -131,6 +133,8 @@ describe('Notices - Setup - Add Recipient service', () => {
                 postcode: session.address.postcode
               },
               contact_hash_id: contactHashId,
+              contact_type: 'Single use',
+              licence_ref: session.licenceRef,
               licence_refs: session.licenceRef
             }
           ])
@@ -175,6 +179,8 @@ describe('Notices - Setup - Add Recipient service', () => {
                 country: session.address.country
               },
               contact_hash_id: contactHashId,
+              contact_type: 'Single use',
+              licence_ref: session.licenceRef,
               licence_refs: session.licenceRef
             }
           ])

--- a/test/services/notices/setup/submit-contact-type.service.test.js
+++ b/test/services/notices/setup/submit-contact-type.service.test.js
@@ -59,7 +59,9 @@ describe('Notices - Setup - Submit Contact Type Service', () => {
         expect(refreshedSession.additionalRecipients).to.equal([
           {
             contact_hash_id: _createMD5Hash(payload.email),
+            contact_type: 'Single use',
             email: payload.email,
+            licence_ref: session.licenceRef,
             licence_refs: session.licenceRef
           }
         ])
@@ -107,7 +109,9 @@ describe('Notices - Setup - Submit Contact Type Service', () => {
         expect(refreshedSession.additionalRecipients).to.equal([
           {
             contact_hash_id: _createMD5Hash(payload.email),
+            contact_type: 'Single use',
             email: payload.email,
+            licence_ref: session.licenceRef,
             licence_refs: session.licenceRef
           }
         ])
@@ -147,7 +151,9 @@ describe('Notices - Setup - Submit Contact Type Service', () => {
         expect(refreshedSession.additionalRecipients).to.equal([
           {
             contact_hash_id: testEmailHash,
+            contact_type: 'Single use',
             email: 'test@test.gov.uk',
+            licence_ref: session.licenceRef,
             licence_refs: session.licenceRef
           }
         ])
@@ -177,7 +183,9 @@ describe('Notices - Setup - Submit Contact Type Service', () => {
         sessionData.additionalRecipients = [
           {
             contact_hash_id: testEmailHash,
+            contact_type: 'Single use',
             email: 'test@test.gov.uk',
+            licence_ref: session.licenceRef,
             licence_refs: session.licenceRef
           }
         ]
@@ -195,12 +203,16 @@ describe('Notices - Setup - Submit Contact Type Service', () => {
         expect(refreshedSession.additionalRecipients).to.equal([
           {
             contact_hash_id: testEmailHash,
+            contact_type: 'Single use',
             email: 'test@test.gov.uk',
+            licence_ref: session.licenceRef,
             licence_refs: session.licenceRef
           },
           {
             contact_hash_id: _createMD5Hash(payload.email),
+            contact_type: 'Single use',
             email: payload.email,
+            licence_ref: session.licenceRef,
             licence_refs: session.licenceRef
           }
         ])


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5215

We have added a change to allow the user to add additional recipients. We have implemented the logic to render and send these additional recipients a notice.

Theses additional recipients are shown in the download CSV. But they are missing the 'Licence' and 'Contact Type' fields (they are blank).

This change adds the relevant fields when the additional licence is saved.

This allows the existing logic to remain the same and still open to extension.

This does result in us setting the licence ref twice in the additional recipient. Once on 'licence_refs' and then on 'licence_ref'. This is because the rendering and sending of recipients share the same logic with the other journeys which can have multiple licence refs per recipients.

We set the 'contact_type' as 'Single use' for the download only. This will only be rendered in the CSV.

We have the 'DetermineRecipientsService' which has logic to check the contact types, if these prior conditions are not met, then the default will be 'Returns agent' (for an email) and 'Returns to' (for a letter).

This implied logic has been highlighted by creating the '_addDownloadRecipientData' function. This has JSDocs added to further illustrate the implied logic.