### PR TITLE
View return log - fix status when no due date

### DIFF
--- a/app/presenters/return-logs/base-return-logs.presenter.js
+++ b/app/presenters/return-logs/base-return-logs.presenter.js
@@ -57,10 +57,6 @@ function formatMeterDetails(meter) {
 function formatStatus(returnLog) {
   const { status, dueDate } = returnLog
 
-  if (!dueDate) {
-    return 'not due yet'
-  }
-
   // If the return is completed we are required to display it as 'complete'. This also takes priority over the other
   // statues
   if (status === 'completed') {
@@ -75,6 +71,10 @@ function formatStatus(returnLog) {
   today.setHours(0, 0, 0, 0)
 
   if (status === 'due') {
+    if (!dueDate) {
+      return 'not due yet'
+    }
+
     if (dueDate < today) {
       return 'overdue'
     }

--- a/app/presenters/return-logs/base-return-logs.presenter.js
+++ b/app/presenters/return-logs/base-return-logs.presenter.js
@@ -57,6 +57,10 @@ function formatMeterDetails(meter) {
 function formatStatus(returnLog) {
   const { status, dueDate } = returnLog
 
+  if (!dueDate) {
+    return 'not due yet'
+  }
+
   // If the return is completed we are required to display it as 'complete'. This also takes priority over the other
   // statues
   if (status === 'completed') {

--- a/test/presenters/return-logs/base-return-logs.presenter.test.js
+++ b/test/presenters/return-logs/base-return-logs.presenter.test.js
@@ -126,7 +126,7 @@ describe('Base Return Logs presenter', () => {
   })
 
   describe('#formatStatus()', () => {
-    const testReturnLog = { dueDate: new Date() }
+    const testReturnLog = { dueDate: null }
 
     describe('when status is completed', () => {
       before(() => {
@@ -137,6 +137,30 @@ describe('Base Return Logs presenter', () => {
         const result = BaseReturnLogsPresenter.formatStatus(testReturnLog)
 
         expect(result).to.equal('complete')
+      })
+    })
+
+    describe('when status is received', () => {
+      before(() => {
+        testReturnLog.status = 'received'
+      })
+
+      it('returns received', () => {
+        const result = BaseReturnLogsPresenter.formatStatus(testReturnLog)
+
+        expect(result).to.equal('received')
+      })
+    })
+
+    describe('when status is void', () => {
+      before(() => {
+        testReturnLog.status = 'void'
+      })
+
+      it('returns void', () => {
+        const result = BaseReturnLogsPresenter.formatStatus(testReturnLog)
+
+        expect(result).to.equal('void')
       })
     })
 
@@ -196,30 +220,6 @@ describe('Base Return Logs presenter', () => {
           const result = BaseReturnLogsPresenter.formatStatus(testReturnLog)
 
           expect(result).to.equal('not due yet')
-        })
-      })
-    })
-
-    describe('when status is none of these', () => {
-      before(() => {
-        testReturnLog.status = 'STATUS'
-      })
-
-      it('returns the status', () => {
-        const result = BaseReturnLogsPresenter.formatStatus(testReturnLog)
-
-        expect(result).to.equal('STATUS')
-      })
-
-      describe('and the due date is null', () => {
-        before(() => {
-          testReturnLog.dueDate = null
-        })
-
-        it('returns the status', () => {
-          const result = BaseReturnLogsPresenter.formatStatus(testReturnLog)
-
-          expect(result).to.equal('STATUS')
         })
       })
     })

--- a/test/presenters/return-logs/base-return-logs.presenter.test.js
+++ b/test/presenters/return-logs/base-return-logs.presenter.test.js
@@ -210,6 +210,18 @@ describe('Base Return Logs presenter', () => {
 
         expect(result).to.equal('STATUS')
       })
+
+      describe('and the due date is null', () => {
+        before(() => {
+          testReturnLog.dueDate = null
+        })
+
+        it('returns the status', () => {
+          const result = BaseReturnLogsPresenter.formatStatus(testReturnLog)
+
+          expect(result).to.equal('STATUS')
+        })
+      })
     })
   })
 

--- a/test/presenters/return-logs/base-return-logs.presenter.test.js
+++ b/test/presenters/return-logs/base-return-logs.presenter.test.js
@@ -140,30 +140,6 @@ describe('Base Return Logs presenter', () => {
       })
     })
 
-    describe('when status is received', () => {
-      before(() => {
-        testReturnLog.status = 'received'
-      })
-
-      it('returns received', () => {
-        const result = BaseReturnLogsPresenter.formatStatus(testReturnLog)
-
-        expect(result).to.equal('received')
-      })
-    })
-
-    describe('when status is void', () => {
-      before(() => {
-        testReturnLog.status = 'void'
-      })
-
-      it('returns void', () => {
-        const result = BaseReturnLogsPresenter.formatStatus(testReturnLog)
-
-        expect(result).to.equal('void')
-      })
-    })
-
     describe('when the status is due', () => {
       beforeEach(() => {
         testReturnLog.status = 'due'
@@ -221,6 +197,30 @@ describe('Base Return Logs presenter', () => {
 
           expect(result).to.equal('not due yet')
         })
+      })
+    })
+
+    describe('when status is received', () => {
+      before(() => {
+        testReturnLog.status = 'received'
+      })
+
+      it('returns received', () => {
+        const result = BaseReturnLogsPresenter.formatStatus(testReturnLog)
+
+        expect(result).to.equal('received')
+      })
+    })
+
+    describe('when status is void', () => {
+      before(() => {
+        testReturnLog.status = 'void'
+      })
+
+      it('returns void', () => {
+        const result = BaseReturnLogsPresenter.formatStatus(testReturnLog)
+
+        expect(result).to.equal('void')
       })
     })
   })

--- a/test/presenters/return-logs/base-return-logs.presenter.test.js
+++ b/test/presenters/return-logs/base-return-logs.presenter.test.js
@@ -145,6 +145,18 @@ describe('Base Return Logs presenter', () => {
         testReturnLog.status = 'due'
       })
 
+      describe('and the due date is null', () => {
+        before(() => {
+          testReturnLog.dueDate = null
+        })
+
+        it('returns not due yet', () => {
+          const result = BaseReturnLogsPresenter.formatStatus(testReturnLog)
+
+          expect(result).to.equal('not due yet')
+        })
+      })
+
       describe('and the due date is in the past', () => {
         before(() => {
           const lastWeek = new Date()


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5214

Currently when a return log is created it is automatically pre-populated with a due date. However, the process of assigning a due date to a return log is being updated so that the due date is not set on creation. Instead, it is set when the reminders are sent out.

This means that some new return logs will now have a null due date where previously the due date would always have been populated.

At the moment when viewing a return log that has no due date the status is incorrectly shown as "Overdue", when it should actually be "Not due yet".

This PR will update how the status is determined when there is no due date.