### PR TITLE
Remove 'allRecipients' flag from recipients service

### DIFF
--- a/app/presenters/notices/setup/select-recipients.presenter.js
+++ b/app/presenters/notices/setup/select-recipients.presenter.js
@@ -12,11 +12,12 @@ const ContactPresenter = require('./contact.presenter.js')
  *
  * @param {module:SessionModel} session - The session instance
  * @param {object[]} recipients
+ * @param {string[]} selectedRecipients - an array of 'contact_hash_id' selected by the user
  *
  * @returns {object} - The data formatted for the view template
  */
-function go(session, recipients) {
-  const { id: sessionId, selectedRecipients } = session
+function go(session, recipients, selectedRecipients) {
+  const { id: sessionId } = session
 
   return {
     backLink: `/system/notices/setup/${sessionId}/check`,

--- a/app/services/notices/setup/check.service.js
+++ b/app/services/notices/setup/check.service.js
@@ -22,7 +22,7 @@ const SessionModel = require('../../../models/session.model.js')
 async function go(sessionId, yar, page = 1) {
   const session = await SessionModel.query().findById(sessionId)
 
-  const recipients = await FetchRecipientsService.go(session, false)
+  const recipients = await FetchRecipientsService.go(session)
 
   await _initialiseSelectedRecipients(recipients, session)
 

--- a/app/services/notices/setup/download-recipients.service.js
+++ b/app/services/notices/setup/download-recipients.service.js
@@ -46,7 +46,7 @@ async function _formattedDate(session) {
 
   const downloadRecipients = await FetchDownloadRecipientsService.go(session)
 
-  const recipients = RecipientsService.go(session, downloadRecipients, false)
+  const recipients = RecipientsService.go(session, downloadRecipients)
 
   if (session.journey === 'adhoc' && session.noticeType !== 'returnForms') {
     return DownloadAdHocRecipientsPresenter.go(recipients, session)

--- a/app/services/notices/setup/fetch-recipients.service.js
+++ b/app/services/notices/setup/fetch-recipients.service.js
@@ -17,14 +17,13 @@ const RecipientsService = require('./recipients.service.js')
  * Fetches the recipients based on the journey type and determines recipients (remove duplicates).
  *
  * @param {module:SessionModel} session - The session instance
- * @param {boolean} allRecipients - flag to decide if all recipients are required
  *
  * @returns {Promise<object[]>} - recipients
  */
-async function go(session, allRecipients = true) {
+async function go(session) {
   const recipientsData = await _recipientsData(session)
 
-  const recipients = RecipientsService.go(session, recipientsData, allRecipients)
+  const recipients = RecipientsService.go(session, recipientsData)
 
   return DetermineRecipientsService.go(recipients)
 }

--- a/app/services/notices/setup/recipients.service.js
+++ b/app/services/notices/setup/recipients.service.js
@@ -10,14 +10,13 @@
  *
  * @param {module:SessionModel} session - The session instance
  * @param {object[]} recipientsData
- * @param {boolean} allRecipients - flag to decide if all recipients are required
  *
  * @returns {object[]} - recipients
  */
-function go(session, recipientsData, allRecipients = true) {
+function go(session, recipientsData) {
   const recipients = _additionalRecipients(recipientsData, session)
 
-  if (allRecipients || !session.selectedRecipients) {
+  if (!session.selectedRecipients) {
     return recipients
   }
 

--- a/app/services/notices/setup/select-recipients.service.js
+++ b/app/services/notices/setup/select-recipients.service.js
@@ -20,13 +20,30 @@ const SessionModel = require('../../../models/session.model.js')
 async function go(sessionId) {
   const session = await SessionModel.query().findById(sessionId)
 
+  const selectedRecipients = _selectedRecipients(session)
+
   const recipients = await FetchRecipientsService.go(session)
 
-  const pageData = SelectRecipientsPresenter.go(session, recipients)
+  const pageData = SelectRecipientsPresenter.go(session, recipients, selectedRecipients)
 
   return {
     ...pageData
   }
+}
+
+/**
+ * Clear the 'selectedRecipients' from the session to fetch all the recipients
+ *
+ * Return the current selected recipients to mark as 'checked' on the page
+ *
+ * @private
+ */
+function _selectedRecipients(session) {
+  const selectedRecipients = session.selectedRecipients
+
+  delete session.selectedRecipients
+
+  return selectedRecipients
 }
 
 module.exports = {

--- a/app/services/notices/setup/submit-select-recipients.service.js
+++ b/app/services/notices/setup/submit-select-recipients.service.js
@@ -40,11 +40,13 @@ async function go(sessionId, payload, yar) {
     return {}
   }
 
-  session.selectedRecipients = payload.recipients || []
+  const selectedRecipients = payload.recipients || []
+
+  _clearSelectedRecipients(session)
 
   const recipients = await FetchRecipientsService.go(session)
 
-  const pageData = SelectRecipientsPresenter.go(session, recipients)
+  const pageData = SelectRecipientsPresenter.go(session, recipients, selectedRecipients)
 
   return {
     error: validationResult,
@@ -62,6 +64,15 @@ async function _save(session, payload) {
   session.selectedRecipients = payload.recipients
 
   return session.$update()
+}
+
+/**
+ * Clear the 'selectedRecipients' from the session to fetch all the recipients
+ *
+ * @private
+ */
+function _clearSelectedRecipients(session) {
+  delete session.selectedRecipients
 }
 
 function _validate(payload) {

--- a/test/presenters/notices/setup/select-recipients.presenter.test.js
+++ b/test/presenters/notices/setup/select-recipients.presenter.test.js
@@ -15,28 +15,30 @@ const SelectRecipientsPresenter = require('../../../../app/presenters/notices/se
 
 describe('Notices - Setup - Select Recipients Presenter', () => {
   let recipients
+  let selectedRecipients
   let session
   let testRecipients
 
   beforeEach(() => {
     recipients = RecipientsFixture.recipients()
 
+    selectedRecipients = [
+      recipients.primaryUser.contact_hash_id,
+      recipients.returnsAgent.contact_hash_id,
+      recipients.licenceHolder.contact_hash_id,
+      recipients.returnsTo.contact_hash_id,
+      recipients.licenceHolderWithMultipleLicences.contact_hash_id
+    ]
+
     session = {
-      id: 123,
-      selectedRecipients: [
-        recipients.primaryUser.contact_hash_id,
-        recipients.returnsAgent.contact_hash_id,
-        recipients.licenceHolder.contact_hash_id,
-        recipients.returnsTo.contact_hash_id,
-        recipients.licenceHolderWithMultipleLicences.contact_hash_id
-      ]
+      id: 123
     }
 
     testRecipients = [...Object.values(recipients)]
   })
 
   it('returns page data for the view', () => {
-    const result = SelectRecipientsPresenter.go(session, testRecipients)
+    const result = SelectRecipientsPresenter.go(session, testRecipients, selectedRecipients)
 
     expect(result).to.equal({
       backLink: `/system/notices/setup/${session.id}/check`,
@@ -90,18 +92,18 @@ describe('Notices - Setup - Select Recipients Presenter', () => {
     beforeEach(() => {
       const recipient = Object.values(recipients)
 
-      session.selectedRecipients = [recipient[0].contact_hash_id]
+      selectedRecipients = [recipient[0].contact_hash_id]
 
       testRecipients = [recipient[0]]
     })
 
     describe('and there are no "selectedRecipients"', () => {
       beforeEach(() => {
-        session.selectedRecipients = []
+        selectedRecipients = []
       })
 
       it('returns page data for the view with relevant recipients not checked', () => {
-        const result = SelectRecipientsPresenter.go(session, testRecipients)
+        const result = SelectRecipientsPresenter.go(session, testRecipients, selectedRecipients)
 
         expect(result.recipients).to.equal([
           {
@@ -115,7 +117,7 @@ describe('Notices - Setup - Select Recipients Presenter', () => {
 
     describe('and there are "selectedRecipients"', () => {
       beforeEach(() => {
-        session.selectedRecipients = [recipients.primaryUser.contact_hash_id]
+        selectedRecipients = [recipients.primaryUser.contact_hash_id]
 
         const recipient = Object.values(recipients)
 
@@ -123,7 +125,7 @@ describe('Notices - Setup - Select Recipients Presenter', () => {
       })
 
       it('returns page data for the view with relevant recipients checked', () => {
-        const result = SelectRecipientsPresenter.go(session, testRecipients)
+        const result = SelectRecipientsPresenter.go(session, testRecipients, selectedRecipients)
 
         expect(result.recipients).to.equal([
           {

--- a/test/services/notices/setup/recipients.service.test.js
+++ b/test/services/notices/setup/recipients.service.test.js
@@ -84,7 +84,7 @@ describe('Notices - Setup - Recipients service', () => {
         })
 
         it('returns only the selected recipients formatted for display', () => {
-          const result = RecipientsService.go(session, recipients, false)
+          const result = RecipientsService.go(session, recipients)
 
           expect(result).to.equal([
             {
@@ -118,7 +118,7 @@ describe('Notices - Setup - Recipients service', () => {
         })
 
         it('returns all the recipients formatted for display', () => {
-          const result = RecipientsService.go(session, recipients, false)
+          const result = RecipientsService.go(session, recipients)
 
           expect(result).to.equal([
             {
@@ -150,7 +150,7 @@ describe('Notices - Setup - Recipients service', () => {
       })
 
       it('returns all the recipients (including "additionalRecipients") formatted for display', () => {
-        const result = RecipientsService.go(session, recipients, false)
+        const result = RecipientsService.go(session, recipients)
 
         expect(result).to.equal([
           {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5233

We previously implemented an 'allRecipients' flag for the recipients service to know to render all the recipients. This was only needed for the selected recipients (and the check and downloaded service subsequently need to set this).

This change removes the 'allRecipients' flag.

We now just temporarily remove the 'session.selectedRecipients' when we pass it into the session and pass in the selected recipients as an additional arg.

This allows the view to take a copy of the 'selectedRecipients' and pass it in, and the submit service to pass in the user's payload of selected recipients.