### PR TITLE
Scaffold notice setup recipient name

### DIFF
--- a/app/controllers/notices-setup.controller.js
+++ b/app/controllers/notices-setup.controller.js
@@ -24,11 +24,12 @@ const LicenceService = require('../services/notices/setup/licence.service.js')
 const NoticeTypeService = require('../services/notices/setup/notice-type.service.js')
 const PreviewReturnFormsService = require('../services/notices/setup/preview-return-forms.service.js')
 const PreviewService = require('../services/notices/setup/preview/preview.service.js')
+const RecipientNameService = require('../services/notices/setup/recipient-name.service.js')
 const RemoveLicencesService = require('../services/notices/setup/remove-licences.service.js')
 const RemoveThresholdService = require('../services/notices/setup/abstraction-alerts/remove-threshold.service.js')
 const ReturnFormsService = require('../services/notices/setup/return-forms.service.js')
-const SelectRecipientsService = require('../services/notices/setup/select-recipients.service.js')
 const ReturnsPeriodService = require('../services/notices/setup/returns-period/returns-period.service.js')
+const SelectRecipientsService = require('../services/notices/setup/select-recipients.service.js')
 const SubmitAlertEmailAddressService = require('../services/notices/setup/abstraction-alerts/submit-alert-email-address.service.js')
 const SubmitAlertThresholdsService = require('../services/notices/setup/abstraction-alerts/submit-alert-thresholds.service.js')
 const SubmitAlertTypeService = require('../services/notices/setup/abstraction-alerts/submit-alert-type.service.js')
@@ -39,6 +40,7 @@ const SubmitCheckService = require('../services/notices/setup/submit-check.servi
 const SubmitContactTypeService = require('../services/notices/setup/submit-contact-type.service.js')
 const SubmitLicenceService = require('../services/notices/setup/submit-licence.service.js')
 const SubmitNoticeTypeService = require('../services/notices/setup/submit-notice-type.service.js')
+const SubmitRecipientNameService = require('../services/notices/setup/submit-recipient-name.service.js')
 const SubmitRemoveLicencesService = require('../services/notices/setup/submit-remove-licences.service.js')
 const SubmitReturnFormsService = require('../services/notices/setup/submit-return-forms.service.js')
 const SubmitReturnsPeriodService = require('../services/notices/setup/returns-period/submit-returns-period.service.js')
@@ -233,6 +235,14 @@ async function viewPreviewReturnForms(request, h) {
   return h.response(fileBuffer).type('application/pdf').header('Content-Disposition', 'inline; filename="example.pdf"')
 }
 
+async function viewRecipientName(request, h) {
+  const { sessionId } = request.params
+
+  const pageData = await RecipientNameService.go(sessionId)
+
+  return h.view(`notices/setup/recipient-name.njk`, pageData)
+}
+
 async function viewRemoveThreshold(request, h) {
   const {
     params: { sessionId, licenceMonitoringStationId },
@@ -407,6 +417,21 @@ async function submitNoticeType(request, h) {
   return h.redirect(`/system/notices/setup/${sessionId}/${pageData.redirectUrl}`)
 }
 
+async function submitRecipientName(request, h) {
+  const {
+    payload,
+    params: { sessionId }
+  } = request
+
+  const pageData = await SubmitRecipientNameService.go(sessionId, payload)
+
+  if (pageData.error) {
+    return h.view(`notices/setup/recipient-name.njk`, pageData)
+  }
+
+  return h.redirect(`/system/address/${sessionId}/postcode`)
+}
+
 async function submitRemoveLicences(request, h) {
   const {
     payload,
@@ -488,6 +513,7 @@ module.exports = {
   viewLicence,
   viewNoticeType,
   viewPreviewReturnForms,
+  viewRecipientName,
   viewRemoveLicences,
   viewRemoveThreshold,
   viewReturnForms,
@@ -504,6 +530,7 @@ module.exports = {
   submitContactType,
   submitLicence,
   submitNoticeType,
+  submitRecipientName,
   submitRemoveLicences,
   submitReturnForms,
   submitReturnsPeriod,

--- a/app/presenters/notices/setup/recipient-name.presenter.js
+++ b/app/presenters/notices/setup/recipient-name.presenter.js
@@ -1,0 +1,19 @@
+'use strict'
+
+/**
+ * Formats data for the '/notices/setup/{sessionId}/recipient-name' page
+ * @module RecipientNamePresenter
+ */
+
+/**
+ * Formats data for the '/notices/setup/{sessionId}/recipient-name' page
+ *
+ * @returns {object} - The data formatted for the view template
+ */
+function go() {
+  return {}
+}
+
+module.exports = {
+  go
+}

--- a/app/routes/notices-setup.routes.js
+++ b/app/routes/notices-setup.routes.js
@@ -341,6 +341,30 @@ const routes = [
   },
   {
     method: 'GET',
+    path: '/notices/setup/{sessionId}/recipient-name',
+    options: {
+      handler: NoticesSetupController.viewRecipientName,
+      auth: {
+        access: {
+          scope: ['returns']
+        }
+      }
+    }
+  },
+  {
+    method: 'POST',
+    path: '/notices/setup/{sessionId}/recipient-name',
+    options: {
+      handler: NoticesSetupController.submitRecipientName,
+      auth: {
+        access: {
+          scope: ['returns']
+        }
+      }
+    }
+  },
+  {
+    method: 'GET',
     path: '/notices/setup/{sessionId}/remove-licences',
     options: {
       handler: NoticesSetupController.viewRemoveLicences,

--- a/app/services/notices/setup/recipient-name.service.js
+++ b/app/services/notices/setup/recipient-name.service.js
@@ -1,0 +1,31 @@
+'use strict'
+
+/**
+ * Orchestrates fetching and presenting the data for the '/notices/setup/{sessionId}/recipient-name' page
+ *
+ * @module RecipientNameService
+ */
+
+const RecipientNamePresenter = require('../../../presenters/notices/setup/recipient-name.presenter.js')
+const SessionModel = require('../../../models/session.model.js')
+
+/**
+ * Orchestrates fetching and presenting the data for the '/notices/setup/{sessionId}/recipient-name' page
+ *
+ * @param {string} sessionId
+ *
+ * @returns {Promise<object>} - The data formatted for the view template
+ */
+async function go(sessionId) {
+  const session = await SessionModel.query().findById(sessionId)
+
+  const pageData = RecipientNamePresenter.go(session)
+
+  return {
+    ...pageData
+  }
+}
+
+module.exports = {
+  go
+}

--- a/app/services/notices/setup/submit-recipient-name.service.js
+++ b/app/services/notices/setup/submit-recipient-name.service.js
@@ -1,0 +1,60 @@
+'use strict'
+
+/**
+ * Orchestrates validating the data for the '/notices/setup/{sessionId}/recipient-name' page
+ *
+ * @module SubmitRecipientNameService
+ */
+
+const RecipientNamePresenter = require('../../../presenters/notices/setup/recipient-name.presenter.js')
+const RecipientNameValidator = require('../../../validators/notices/setup/recipient-name.validator.js')
+const SessionModel = require('../../../models/session.model.js')
+
+/**
+ * Orchestrates validating the data for the '/notices/setup/{sessionId}/recipient-name' page
+ *
+ * @param {string} sessionId
+ * @param {object} payload - The submitted form data
+ *
+ * @returns {Promise<object>} - The data formatted for the view template
+ */
+async function go(sessionId, payload) {
+  const session = await SessionModel.query().findById(sessionId)
+
+  const validationResult = _validate(payload)
+
+  if (!validationResult) {
+    await _save(session, payload)
+
+    return {}
+  }
+
+  const pageData = RecipientNamePresenter.go(session)
+
+  return {
+    error: validationResult,
+    ...pageData
+  }
+}
+
+async function _save(session, _payload) {
+  return session.$update()
+}
+
+function _validate(payload) {
+  const validation = RecipientNameValidator.go(payload)
+
+  if (!validation.error) {
+    return null
+  }
+
+  const { message } = validation.error.details[0]
+
+  return {
+    text: message
+  }
+}
+
+module.exports = {
+  go
+}

--- a/app/validators/notices/setup/recipient-name.validator.js
+++ b/app/validators/notices/setup/recipient-name.validator.js
@@ -1,0 +1,33 @@
+'use strict'
+
+/**
+ * Validates data submitted for the '/notices/setup/{sessionId}/recipient-name' page
+ *
+ * @module RecipientNameValidator
+ */
+
+const Joi = require('joi')
+
+const errorMessage = 'Enter the recipients name'
+
+/**
+ * Validates data submitted for the '/notices/setup/{sessionId}/recipient-name' page
+ *
+ * @param {object} payload - The payload from the request to be validated
+ *
+ * @returns {object} the result from calling Joi's schema.validate(). It will be an object with a `value:` property. If
+ * any errors are found the `error:` property will also exist detailing what the issues were
+ */
+function go(payload) {
+  const schema = Joi.object({
+    name: Joi.string().required()
+  }).messages({
+    'any.required': errorMessage
+  })
+
+  return schema.validate(payload, { abortEarly: false })
+}
+
+module.exports = {
+  go
+}

--- a/app/views/notices/setup/recipient-name.njk
+++ b/app/views/notices/setup/recipient-name.njk
@@ -1,0 +1,29 @@
+{% extends 'layout.njk' %}
+
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+
+{% block breadcrumbs %}
+  {{
+  govukBackLink({
+    text: 'Back',
+    href: backLink
+  })
+  }}
+{% endblock %}
+
+{% block content %}
+  {% if error %}
+    {{ govukErrorSummary({
+      titleText: "There is a problem",
+      errorList: error.errorList
+    }) }}
+  {%endif%}
+
+  <form method="post">
+    <input type="hidden" name="wrlsCrumb" value="{{wrlsCrumb}}"/>
+
+    {{ govukButton({ text: "Continue", preventDoubleClick: true }) }}
+  </form>
+{% endblock %}

--- a/test/controllers/notices-setup.controller.test.js
+++ b/test/controllers/notices-setup.controller.test.js
@@ -30,6 +30,7 @@ const LicenceService = require('../../app/services/notices/setup/licence.service
 const NoticeTypeService = require('../../app/services/notices/setup/notice-type.service.js')
 const PreviewReturnFormsService = require('../../app/services/notices/setup/preview-return-forms.service.js')
 const PreviewService = require('../../app/services/notices/setup/preview/preview.service.js')
+const RecipientNameService = require('../../app/services/notices/setup/recipient-name.service.js')
 const RemoveLicencesService = require('../../app/services/notices/setup/remove-licences.service.js')
 const RemoveThresholdService = require('../../app/services/notices/setup/abstraction-alerts/remove-threshold.service.js')
 const ReturnFormsService = require('../../app/services/notices/setup/return-forms.service.js')
@@ -45,6 +46,7 @@ const SubmitCheckService = require('../../app/services/notices/setup/submit-chec
 const SubmitContactTypeService = require('../../app/services/notices/setup/submit-contact-type.service.js')
 const SubmitLicenceService = require('../../app/services/notices/setup/submit-licence.service.js')
 const SubmitNoticeTypeService = require('../../app/services/notices/setup/submit-notice-type.service.js')
+const SubmitRecipientNameService = require('../../app/services/notices/setup/submit-recipient-name.service.js')
 const SubmitRemoveLicencesService = require('../../app/services/notices/setup/submit-remove-licences.service.js')
 const SubmitReturnFormsService = require('../../app/services/notices/setup/submit-return-forms.service.js')
 const SubmitReturnsPeriodService = require('../../app/services/notices/setup/returns-period/submit-returns-period.service.js')
@@ -983,6 +985,71 @@ describe('Notices Setup controller', () => {
           expect(response.statusCode).to.equal(200)
           expect(response.payload).to.contain('Select the notice type')
           expect(response.payload).to.contain('There is a problem')
+        })
+      })
+    })
+  })
+
+  describe('notices/setup/recipient-name', () => {
+    describe('GET', () => {
+      beforeEach(async () => {
+        getOptions = {
+          method: 'GET',
+          url: basePath + `/${session.id}/recipient-name`,
+          auth: {
+            strategy: 'session',
+            credentials: { scope: ['returns'] }
+          }
+        }
+      })
+
+      describe('when a request is valid', () => {
+        beforeEach(async () => {
+          Sinon.stub(RecipientNameService, 'go').returns({ pageTitle: 'Recipients name' })
+        })
+
+        it('returns the page successfully', async () => {
+          const response = await server.inject(getOptions)
+
+          expect(response.statusCode).to.equal(200)
+          expect(response.payload).to.contain('Recipients name')
+        })
+      })
+    })
+
+    describe('POST', () => {
+      describe('when the request succeeds', () => {
+        describe('and the validation fails', () => {
+          beforeEach(async () => {
+            Sinon.stub(SubmitRecipientNameService, 'go').returns({
+              error: 'Something went wrong'
+            })
+
+            postOptions = postRequestOptions(basePath + `/${session.id}/recipient-name`, {})
+          })
+
+          it('returns the page successfully with the error summary banner', async () => {
+            const response = await server.inject(postOptions)
+
+            expect(response.statusCode).to.equal(200)
+            expect(response.payload).to.contain('There is a problem')
+          })
+        })
+
+        describe('and the validation succeeds', () => {
+          beforeEach(async () => {
+            Sinon.stub(SubmitRecipientNameService, 'go').returns({
+              pageTile: 'Select recipients'
+            })
+            postOptions = postRequestOptions(basePath + `/${session.id}/recipient-name`, {})
+          })
+
+          it('redirects the to the next page', async () => {
+            const response = await server.inject(postOptions)
+
+            expect(response.statusCode).to.equal(302)
+            expect(response.headers.location).to.equal(`/system/address/${session.id}/postcode`)
+          })
         })
       })
     })

--- a/test/presenters/notices/setup/recipient-name.presenter.test.js
+++ b/test/presenters/notices/setup/recipient-name.presenter.test.js
@@ -1,0 +1,27 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Thing under test
+const RecipientNamePresenter = require('../../../../app/presenters/notices/setup/recipient-name.presenter.js')
+
+describe('Notices - Setup - Recipient Name Presenter', () => {
+  let session
+
+  beforeEach(() => {
+    session = {}
+  })
+
+  describe('when called', () => {
+    it('returns page data for the view', () => {
+      const result = RecipientNamePresenter.go(session)
+
+      expect(result).to.equal({})
+    })
+  })
+})

--- a/test/services/notices/setup/recipient-name.service.test.js
+++ b/test/services/notices/setup/recipient-name.service.test.js
@@ -1,0 +1,33 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Test helpers
+const SessionHelper = require('../../../support/helpers/session.helper.js')
+
+// Thing under test
+const RecipientNameService = require('../../../../app/services/notices/setup/recipient-name.service.js')
+
+describe('Notices - Setup - Recipient Name Service', () => {
+  let session
+  let sessionData
+
+  beforeEach(async () => {
+    sessionData = {}
+
+    session = await SessionHelper.add({ data: sessionData })
+  })
+
+  describe('when called', () => {
+    it('returns page data for the view', async () => {
+      const result = await RecipientNameService.go(session.id)
+
+      expect(result).to.equal({})
+    })
+  })
+})

--- a/test/services/notices/setup/submit-recipient-name.service.test.js
+++ b/test/services/notices/setup/submit-recipient-name.service.test.js
@@ -1,0 +1,59 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Test helpers
+const SessionHelper = require('../../../support/helpers/session.helper.js')
+
+// Thing under test
+const SubmitRecipientNameService = require('../../../../app/services/notices/setup/submit-recipient-name.service.js')
+
+describe('Notices - Setup - Recipient Name Service', () => {
+  let payload
+  let session
+  let sessionData
+
+  beforeEach(async () => {
+    payload = { name: 'Ronald Weasley' }
+    sessionData = {}
+
+    session = await SessionHelper.add({ data: sessionData })
+  })
+
+  describe('when called', () => {
+    it('saves the submitted value', async () => {
+      await SubmitRecipientNameService.go(session.id, payload)
+
+      const refreshedSession = await session.$query()
+
+      expect(refreshedSession).to.equal(session)
+    })
+
+    it('continues the journey', async () => {
+      const result = await SubmitRecipientNameService.go(session.id, payload)
+
+      expect(result).to.equal({})
+    })
+  })
+
+  describe('when validation fails', () => {
+    beforeEach(() => {
+      payload = {}
+    })
+
+    it('returns page data for the view, with errors', async () => {
+      const result = await SubmitRecipientNameService.go(session.id, payload)
+
+      expect(result).to.equal({
+        error: {
+          text: 'Enter the recipients name'
+        }
+      })
+    })
+  })
+})

--- a/test/validators/notices/setup/recipient-name.validator.test.js
+++ b/test/validators/notices/setup/recipient-name.validator.test.js
@@ -1,0 +1,42 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Thing under test
+const RecipientNameValidator = require('../../../../app/validators/notices/setup/recipient-name.validator.js')
+
+describe('Notices - Setup - Recipient Name Validator', () => {
+  let payload
+
+  beforeEach(() => {
+    payload = { name: 'Ronald Weasley' }
+  })
+
+  describe('when called with valid data', () => {
+    it('returns with no errors', () => {
+      const result = RecipientNameValidator.go(payload)
+
+      expect(result.value).to.exist()
+      expect(result.error).not.to.exist()
+    })
+  })
+
+  describe('when called with invalid data', () => {
+    beforeEach(() => {
+      payload = {}
+    })
+
+    it('returns with errors', () => {
+      const result = RecipientNameValidator.go(payload)
+
+      expect(result.value).to.exist()
+      expect(result.error).to.exist()
+      expect(result.error.details[0].message).to.equal('Enter the recipients name')
+    })
+  })
+})


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5234

When sending a paper form, we want to allow the user to send the form to an additional recipient.

Our existing page offers a choice between email and post (a letter). We do not want to show the email option to the user.

The simplest way we can do this is by adding a standalone page to enter the recipient name. This will redirect to the generic address service the same as the existing screen.

This change adds the scaffolded code for the recipient name page, the view and submit.