### PR TITLE
Update notice setup recipient name to show name and error

### DIFF
--- a/app/presenters/notices/setup/check.presenter.js
+++ b/app/presenters/notices/setup/check.presenter.js
@@ -56,7 +56,7 @@ function _formatRecipients(noticeType, recipients, sessionId) {
 }
 
 function _links(session) {
-  const { id, journey } = session
+  const { id, journey, noticeType } = session
 
   const links = {
     cancel: `/system/notices/setup/${id}/cancel`,
@@ -64,6 +64,14 @@ function _links(session) {
   }
 
   if (journey === 'adhoc') {
+    if (noticeType === 'returnForms') {
+      return {
+        ...links,
+        back: `/system/notices/setup/${id}/check-notice-type`,
+        manage: `/system/notices/setup/${id}/recipient-name`
+      }
+    }
+
     return {
       ...links,
       back: `/system/notices/setup/${id}/check-notice-type`,

--- a/app/presenters/notices/setup/recipient-name.presenter.js
+++ b/app/presenters/notices/setup/recipient-name.presenter.js
@@ -8,10 +8,18 @@
 /**
  * Formats data for the '/notices/setup/{sessionId}/recipient-name' page
  *
+ * @param {SessionModel} session - The session instance
+ *
  * @returns {object} - The data formatted for the view template
  */
-function go() {
-  return {}
+function go(session) {
+  const { id: sessionId, contactName: name } = session
+
+  return {
+    backLink: { text: 'Back', href: `/system/notices/setup/${sessionId}/check` },
+    name,
+    pageTitle: 'Enter recipient name'
+  }
 }
 
 module.exports = {

--- a/app/services/notices/setup/submit-contact-type.service.js
+++ b/app/services/notices/setup/submit-contact-type.service.js
@@ -103,6 +103,11 @@ async function _save(session, payload, yar) {
   session.contactName = payload.name
   session.contactType = payload.type
 
+  session.backLink = {
+    href: `/system/notices/setup/${session.id}/contact-type`,
+    text: 'Back'
+  }
+
   return session.$update()
 }
 

--- a/app/services/notices/setup/submit-recipient-name.service.js
+++ b/app/services/notices/setup/submit-recipient-name.service.js
@@ -29,6 +29,8 @@ async function go(sessionId, payload) {
     return {}
   }
 
+  session.contactName = payload.name
+
   const pageData = RecipientNamePresenter.go(session)
 
   return {
@@ -37,7 +39,14 @@ async function go(sessionId, payload) {
   }
 }
 
-async function _save(session, _payload) {
+async function _save(session, payload) {
+  session.contactName = payload.name
+
+  session.backLink = {
+    href: `/system/notices/setup/${session.id}/recipient-name`,
+    text: 'Back'
+  }
+
   return session.$update()
 }
 
@@ -51,7 +60,8 @@ function _validate(payload) {
   const { message } = validation.error.details[0]
 
   return {
-    text: message
+    text: message,
+    href: '#name'
   }
 }
 

--- a/app/views/notices/setup/recipient-name.njk
+++ b/app/views/notices/setup/recipient-name.njk
@@ -1,28 +1,24 @@
 {% extends 'layout.njk' %}
 
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
-{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
 
-{% block breadcrumbs %}
-  {{
-  govukBackLink({
-    text: 'Back',
-    href: backLink
-  })
-  }}
-{% endblock %}
-
-{% block content %}
-  {% if error %}
-    {{ govukErrorSummary({
-      titleText: "There is a problem",
-      errorList: error.errorList
-    }) }}
-  {%endif%}
-
+{% block pageContent %}
   <form method="post">
     <input type="hidden" name="wrlsCrumb" value="{{wrlsCrumb}}"/>
+
+    {{ govukInput({
+      classes: 'govuk-!-width-one-third',
+      errorMessage: error,
+      label: {
+        text: pageTitle,
+        classes: 'govuk-label--l',
+        isPageHeading: true
+      },
+      id: 'name',
+      name: 'name',
+      value: name
+    }) }}
 
     {{ govukButton({ text: "Continue", preventDoubleClick: true }) }}
   </form>

--- a/test/presenters/notices/setup/recipient-name.presenter.test.js
+++ b/test/presenters/notices/setup/recipient-name.presenter.test.js
@@ -14,14 +14,30 @@ describe('Notices - Setup - Recipient Name Presenter', () => {
   let session
 
   beforeEach(() => {
-    session = {}
+    session = { id: '123' }
   })
 
   describe('when called', () => {
     it('returns page data for the view', () => {
       const result = RecipientNamePresenter.go(session)
 
-      expect(result).to.equal({})
+      expect(result).to.equal({
+        backLink: { text: 'Back', href: `/system/notices/setup/${session.id}/check` },
+        name: undefined,
+        pageTitle: 'Enter recipient name'
+      })
+    })
+
+    describe('and the name has previously been set', () => {
+      beforeEach(() => {
+        session.contactName = 'Ronald Weasley'
+      })
+
+      it('returns previously set name', () => {
+        const result = RecipientNamePresenter.go(session)
+
+        expect(result.name).to.equal('Ronald Weasley')
+      })
     })
   })
 })

--- a/test/services/notices/setup/recipient-name.service.test.js
+++ b/test/services/notices/setup/recipient-name.service.test.js
@@ -27,7 +27,14 @@ describe('Notices - Setup - Recipient Name Service', () => {
     it('returns page data for the view', async () => {
       const result = await RecipientNameService.go(session.id)
 
-      expect(result).to.equal({})
+      expect(result).to.equal({
+        backLink: {
+          href: `/system/notices/setup/${session.id}/check`,
+          text: 'Back'
+        },
+        name: undefined,
+        pageTitle: 'Enter recipient name'
+      })
     })
   })
 })

--- a/test/services/notices/setup/submit-recipient-name.service.test.js
+++ b/test/services/notices/setup/submit-recipient-name.service.test.js
@@ -50,9 +50,16 @@ describe('Notices - Setup - Recipient Name Service', () => {
       const result = await SubmitRecipientNameService.go(session.id, payload)
 
       expect(result).to.equal({
+        backLink: {
+          href: `/system/notices/setup/${session.id}/check`,
+          text: 'Back'
+        },
         error: {
+          href: '#name',
           text: 'Enter the recipients name'
-        }
+        },
+        name: undefined,
+        pageTitle: 'Enter recipient name'
       })
     })
   })


### PR DESCRIPTION
When sending a paper form, we want to allow the user to send the form to an additional recipient.

Our existing page offers a choice between email and post (a letter). We do not want to show the email option to the user.

The simplest way we can do this is by adding a standalone page to enter the recipient name. This will redirect to the generic address service the same as the existing screen.

This change updates the previously scaffolded code to function as expected.

The view will render the name if filled in and error accordingly.

The submit will redirect to the existing generic address journey. It sets the backlink so the journey knows where to come back to.