### PR TITLE
Amend error in layout and add new error formatter

### DIFF
--- a/app/presenters/base.presenter.js
+++ b/app/presenters/base.presenter.js
@@ -344,8 +344,8 @@ function formatPurposes(purposes) {
  *     { href: '#fromDate', text: 'Enter a valid from date' },
  *     { href: '#reference', text: 'Reference must be 11 characters or less' }
  *   ],
- *   fromDate: { message: 'Enter a valid from date' },
- *   reference: { message: 'Reference must be 11 characters or less' }
+ *   fromDate: { text: 'Enter a valid from date' },
+ *   reference: { text: 'Reference must be 11 characters or less' }
  * }
  * ```
  *
@@ -371,7 +371,7 @@ function formatValidationResult(validationResult) {
 
     formattedResult.errorList.push({ href: `#${path}`, text: detail.message })
 
-    formattedResult[path] = { message: detail.message }
+    formattedResult[path] = { text: detail.message }
   })
 
   return formattedResult

--- a/app/presenters/base.presenter.js
+++ b/app/presenters/base.presenter.js
@@ -338,6 +338,17 @@ function formatPurposes(purposes) {
  * - a property on the `error` object against which we will assign the message to be display in the component
  * - the href to use in the error summary, to allow a user to click an error and be taken to the correct component
  *
+ * ```javascript
+ * {
+ *   errorList: [
+ *     { href: '#fromDate', text: 'Enter a valid from date' },
+ *     { href: '#reference', text: 'Reference must be 11 characters or less' }
+ *   ],
+ *   fromDate: { message: 'Enter a valid from date' },
+ *   reference: { message: 'Reference must be 11 characters or less' }
+ * }
+ * ```
+ *
  * This is how we link back the right errors to the right components, and ensure that the error summary behaves as
  * expected.
  *

--- a/app/views/layout.njk
+++ b/app/views/layout.njk
@@ -53,8 +53,8 @@
 {% endblock %}
 
 {% block content %}
-  {% if errorList %}
-    {{ govukErrorSummary({ titleText: "There is a problem", errorList: errorList }) }}
+  {% if error %}
+    {{ govukErrorSummary({ titleText: "There is a problem", errorList: error.errorList }) }}
   {% endif %}
 
   {% set pageHeadingHtml = pageHeading(pageTitle, pageTitleCaption) %}

--- a/test/presenters/base.presenter.test.js
+++ b/test/presenters/base.presenter.test.js
@@ -7,6 +7,9 @@ const Code = require('@hapi/code')
 const { describe, it, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
+// Test helpers
+const { ValidationError } = require('joi')
+
 // Thing under test
 const BasePresenter = require('../../app/presenters/base.presenter.js')
 
@@ -312,6 +315,145 @@ describe('Base presenter', () => {
           'Spray Irrigation - Anti Frost',
           'Spray Irrigation - Storage'
         ])
+      })
+    })
+  })
+
+  describe('#formatValidationResult()', () => {
+    let validationResult
+
+    describe('when the validation result has no errors', () => {
+      beforeEach(() => {
+        validationResult = {
+          value: {
+            noticeTypes: ['returnReminder', 'returnInvitation'],
+            reference: 'RREM-VB9EFA',
+            sentFromDay: '01',
+            sentFromMonth: '09',
+            sentFromYear: '2025',
+            fromDate: new Date('2025-09-01'),
+            toDate: undefined
+          }
+        }
+      })
+
+      it('returns null', () => {
+        const result = BasePresenter.formatValidationResult(validationResult)
+
+        expect(result).to.be.null()
+      })
+    })
+
+    describe('when the validation result contains a single failure', () => {
+      beforeEach(() => {
+        const error = new ValidationError('Enter an email address in the correct format, like name@example.com', [
+          {
+            message: 'Enter an email address in the correct format, like name@example.com',
+            path: ['email'],
+            type: 'string.email',
+            context: {
+              value: 'fudge',
+              invalids: ['fudge'],
+              label: 'email',
+              key: 'email'
+            }
+          }
+        ])
+
+        validationResult = {
+          value: { type: 'email', email: 'fudge' },
+          error
+        }
+      })
+
+      it('returns the validation result formatted for our view pages', () => {
+        const result = BasePresenter.formatValidationResult(validationResult)
+
+        expect(result).to.equal({
+          errorList: [
+            {
+              href: '#email',
+              text: 'Enter an email address in the correct format, like name@example.com'
+            }
+          ],
+          email: {
+            message: 'Enter an email address in the correct format, like name@example.com'
+          }
+        })
+      })
+    })
+
+    describe('when the validation result contains multiple failures', () => {
+      beforeEach(() => {
+        const error = new ValidationError(
+          'Enter a valid from date. Reference must be 11 characters or less. Enter a valid to date',
+          [
+            {
+              message: 'Enter a valid from date',
+              path: ['fromDate'],
+              type: 'date.format',
+              context: {
+                format: ['YYYY-MM-DD'],
+                label: 'fromDate',
+                value: '--01',
+                key: 'fromDate'
+              }
+            },
+            {
+              message: 'Reference must be 11 characters or less',
+              path: ['reference'],
+              type: 'string.max',
+              context: {
+                limit: 11,
+                value: 'jkdfshfhkfhsdjkfsdjkfghadshj',
+                encoding: undefined,
+                label: 'reference',
+                key: 'reference'
+              }
+            },
+            {
+              message: 'Enter a valid to date',
+              path: ['toDate'],
+              type: 'date.format',
+              context: {
+                format: ['YYYY-MM-DD'],
+                label: 'toDate',
+                value: '-04-',
+                key: 'toDate'
+              }
+            }
+          ]
+        )
+
+        validationResult = {
+          value: {
+            reference: 'jkdfshfhkfhsdjkfsdjkfghadshj',
+            sentFromDay: '01',
+            sentToMonth: '04',
+            noticeTypes: [],
+            fromDate: '--01',
+            toDate: '-04-'
+          },
+          error
+        }
+      })
+
+      it('returns the validation result formatted for our view pages', () => {
+        const result = BasePresenter.formatValidationResult(validationResult)
+
+        expect(result).to.equal({
+          errorList: [
+            { href: '#fromDate', text: 'Enter a valid from date' },
+            {
+              href: '#reference',
+              text: 'Reference must be 11 characters or less'
+            },
+            { href: '#toDate', text: 'Enter a valid to date' }
+          ],
+          fromDate: { message: 'Enter a valid from date' },
+          reference: { message: 'Reference must be 11 characters or less' },
+          toDate: { message: 'Enter a valid to date' }
+        })
       })
     })
   })

--- a/test/presenters/base.presenter.test.js
+++ b/test/presenters/base.presenter.test.js
@@ -377,7 +377,7 @@ describe('Base presenter', () => {
             }
           ],
           email: {
-            message: 'Enter an email address in the correct format, like name@example.com'
+            text: 'Enter an email address in the correct format, like name@example.com'
           }
         })
       })
@@ -450,9 +450,9 @@ describe('Base presenter', () => {
             },
             { href: '#toDate', text: 'Enter a valid to date' }
           ],
-          fromDate: { message: 'Enter a valid from date' },
-          reference: { message: 'Reference must be 11 characters or less' },
-          toDate: { message: 'Enter a valid to date' }
+          fromDate: { text: 'Enter a valid from date' },
+          reference: { text: 'Reference must be 11 characters or less' },
+          toDate: { text: 'Enter a valid to date' }
         })
       })
     })


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/149

We've been working on how to be more consistent with our views and the way we apply them. As part of this, we've amended the base `app/views/layout.njk` to include an [Error summary](https://design-system.service.gov.uk/components/error-summary/) component. This will avoid the need to add the component into every view that needs it, with the risk that brings of folks implementing it differently!

The GDS component has an `errorList:` property which expects an array of objects.

```javascript
{{ govukErrorSummary({
  titleText: "There is a problem",
  errorList: [
    {
      text: "Enter your full name",
      href: "#name"
    },
    {
      text: "Enter your alias",
      href: "#alias"
    }
  ]
}) }}
```

We intended to start generating this 'error list' in our submit services and pass it through to the view as `errorList`.

```nunjucks
{% if errorList %}
  {{ govukErrorSummary({ titleText: "There is a problem", errorList: errorList }) }}
{% endif %}
```

What we've realised is that, in some cases, we would need to provide this in _addition_ to our existing `error:` property, rather than _instead of_. This is because the input components still need to know the following.

- Whether to display an error
- What message to display

For a page with a single component that often looks like this.

```nunjucks
  {% if error %}
    {{ govukErrorSummary({
      titleText: "There is a problem",
      errorList: [
        { text: error.text, href: "#frequencyCollected" }
      ]
    }) }}
  {%endif%}

  {{ govukRadios({
    name: "frequencyCollected",
    errorMessage: error,
    fieldset: {
      legend: {  html: pageHeading }
    },
    items: [
      { value: "day", text: "Daily", checked: "day" === frequencyCollected },
      { value: "week", text: "Weekly", checked: "week" === frequencyCollected },
      { value: "month", text: "Monthly", checked: "month" === frequencyCollected }
    ]
  }) }}
```

Here, switching out `error` with `errorList` would work because in the view, we could refer to `errorList[0].text`.

The problem is pages that feature multiple components. For those, the `error` object we pass in has properties we can directly reference in each component.

```nunjucks
  {% if error %}
    {{ govukErrorSummary({
      titleText: "There is a problem",
      errorList: error.errorList
    }) }}
  {% endif %}

  {{ govukInput({
    label: { text: "Name", isPageHeading: false },
    id: "name",
    name: "name",
    value: name,
    attributes: { 'data-test': 'name' },
    errorMessage: {
      text: error.name.message
    } if error.name
  }) }}

  {{ govukInput({
    label: { text: "Alias", isPageHeading: false },
    id: "alias",
    name: "alias",
    value: alias,
    attributes: { 'data-test': 'alias' },
    errorMessage: {
      text: error.alias.message
    } if error.alias
  }) }}
```

This supports only one of the components having a validation error, or both. We can't switch `error` for `errorList` because we need the named properties. `error` has an `errorList:` property, but for `layout.njk` to see it, we need to pass it in separately.

😩😢 

The good news is we believe we have a solution that works for both types of pages, and avoids needing to pass `error` and `errorList` separately.

The way we generate the `error` object from the [Joi](https://joi.dev/api/?v=17.13.3) validation result for pages with multiple components is actually generic. It can be moved to a shared helper function that all submit services could then use, regardless of whether they are validating input from one component or multiple.

This would mean `error` would have a consistent format, as well as contain an `error.errorList` property.

This change tweaks `layout.njk` and adds the helper function in preparation for new pages, and those we refactor to use this shared functionality.