### PR TITLE
Remove the backlink on the notice setup check page when the journey is 'adhoc'

### DIFF
--- a/app/presenters/notices/setup/check.presenter.js
+++ b/app/presenters/notices/setup/check.presenter.js
@@ -31,14 +31,42 @@ function go(recipients, page, pagination, session) {
   const formattedRecipients = _recipients(noticeType, page, recipients, session.id)
 
   return {
+    backLink: _backLink(session),
     defaultPageSize,
     links: _links(session),
     pageTitle: _pageTitle(page, pagination),
+    pageTitleCaption: `Notice ${referenceCode}`,
     readyToSend: `${NOTIFICATION_TYPES[noticeType]} are ready to send.`,
     recipients: formattedRecipients,
     recipientsAmount: recipients.length,
-    referenceCode,
     warning: _warning(formattedRecipients)
+  }
+}
+
+/**
+ * Check pages should not have backlinks.
+ *
+ * This page has them as some journeys do not have a prior check page.
+ *
+ * The ad hoc journey has a check notice type and so does not require a backlink.
+ *
+ * @private
+ */
+function _backLink(session) {
+  const { id, journey } = session
+
+  if (journey === 'adhoc') {
+    return null
+  } else if (journey === 'alerts') {
+    return {
+      href: `/system/notices/setup/${id}/abstraction-alerts/alert-email-address`,
+      text: 'Back'
+    }
+  } else {
+    return {
+      href: `/system/notices/setup/${id}/returns-period`,
+      text: 'Back'
+    }
   }
 }
 
@@ -66,18 +94,15 @@ function _links(session) {
   if (journey === 'adhoc') {
     return {
       ...links,
-      back: `/system/notices/setup/${id}/check-notice-type`,
       manage: `/system/notices/setup/${id}/select-recipients`
     }
   } else if (journey === 'alerts') {
     return {
-      ...links,
-      back: `/system/notices/setup/${id}/abstraction-alerts/alert-email-address`
+      ...links
     }
   } else {
     return {
       ...links,
-      back: `/system/notices/setup/${id}/returns-period`,
       removeLicences: `/system/notices/setup/${id}/remove-licences`
     }
   }

--- a/app/views/layout.njk
+++ b/app/views/layout.njk
@@ -1,7 +1,9 @@
 {% extends "govuk/template.njk" %}
 
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 {% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
+{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 {% from 'govuk/components/error-summary/macro.njk' import govukErrorSummary %}
 
 {% from "macros/page-heading.njk" import pageHeading %}
@@ -55,6 +57,20 @@
 {% block content %}
   {% if error %}
     {{ govukErrorSummary({ titleText: "There is a problem", errorList: error.errorList }) }}
+  {% endif %}
+
+  {% if notification %}
+    {{ govukNotificationBanner({
+      titleText: notification.title,
+      text: notification.text
+    }) }}
+  {% endif %}
+
+  {% if warning %}
+    {{ govukWarningText({
+      text: warning,
+      iconFallbackText: "Warning"
+    }) }}
   {% endif %}
 
   {% set pageHeadingHtml = pageHeading(pageTitle, pageTitleCaption) %}

--- a/app/views/notices/setup/check.njk
+++ b/app/views/notices/setup/check.njk
@@ -1,22 +1,12 @@
 {% extends 'layout.njk' %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
-{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 {% from "govuk/components/pagination/macro.njk" import govukPagination %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
-{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
-{% from 'govuk/components/error-summary/macro.njk' import govukErrorSummary %}
 
 {% from "macros/new-line-array-items.njk" import newLineArrayItems %}
-
-{% block breadcrumbs %}
-  {{ govukBackLink({
-    text: 'Back',
-    href: links.back
-  }) }}
-{% endblock %}
 
 {% set rows = [] %}
 
@@ -51,25 +41,10 @@
   ]), rows) %}
 {% endfor %}
 
-{% block content %}
+{% block pageContent %}
   <div class="govuk-body">
-    {% if notification %}
-      {{ govukNotificationBanner({
-        titleText: notification.title,
-        text: notification.text
-      }) }}
-    {% endif %}
 
-    {% if warning %}
-      {{ govukWarningText({
-        text: warning,
-        iconFallbackText: "Warning"
-      }) }}
-    {% endif %}
-
-    <span class="govuk-caption-l">Notice {{referenceCode}} </span>
-
-    <h1 class="govuk-heading-l"> {{ pageTitle }} </h1>
+    {{ pageHeadingHtml }}
 
     <p> {{ readyToSend }}</p>
 

--- a/test/presenters/notices/setup/check.presenter.test.js
+++ b/test/presenters/notices/setup/check.presenter.test.js
@@ -53,13 +53,17 @@ describe('Notices - Setup - Check presenter', () => {
 
       expect(result).to.equal({
         defaultPageSize: 25,
+        backLink: {
+          href: `/system/notices/setup/${session.id}/returns-period`,
+          text: 'Back'
+        },
         links: {
-          back: `/system/notices/setup/${session.id}/returns-period`,
           cancel: `/system/notices/setup/${session.id}/cancel`,
           download: `/system/notices/setup/${session.id}/download`,
           removeLicences: `/system/notices/setup/${session.id}/remove-licences`
         },
         pageTitle: 'Check the recipients',
+        pageTitleCaption: 'Notice RINV-123',
         readyToSend: 'Returns invitations are ready to send.',
         recipients: [
           {
@@ -132,8 +136,48 @@ describe('Notices - Setup - Check presenter', () => {
           }
         ],
         recipientsAmount: 9,
-        referenceCode: 'RINV-123',
         warning: 'A notification will not be sent for Mr H J Returns to because the address is invalid.'
+      })
+    })
+
+    describe('the "backLink" property', () => {
+      describe('when the journey is for "adhoc"', () => {
+        beforeEach(() => {
+          session.journey = 'adhoc'
+        })
+
+        it('should return null to not show the back link', () => {
+          const result = CheckPresenter.go(testInput, page, pagination, session)
+          expect(result.backLink).to.equal(null)
+        })
+      })
+
+      describe('when the journey is for "alerts"', () => {
+        beforeEach(() => {
+          session.journey = 'alerts'
+          session.noticeType = 'abstractionAlerts'
+          session.referenceCode = 'WAA-123'
+          session.monitoringStationId = '345'
+        })
+
+        it('should return the links for "alerts" journey', () => {
+          const result = CheckPresenter.go(testInput, page, pagination, session)
+
+          expect(result.backLink).to.equal({
+            href: `/system/notices/setup/${session.id}/abstraction-alerts/alert-email-address`,
+            text: 'Back'
+          })
+        })
+      })
+
+      describe('when the journey is for "standard"', () => {
+        it('should return the links for the "standard" journey', () => {
+          const result = CheckPresenter.go(testInput, page, pagination, session)
+          expect(result.backLink).to.equal({
+            href: `/system/notices/setup/${session.id}/returns-period`,
+            text: 'Back'
+          })
+        })
       })
     })
 
@@ -146,7 +190,6 @@ describe('Notices - Setup - Check presenter', () => {
         it('should return the links for the "adhoc" journey', () => {
           const result = CheckPresenter.go(testInput, page, pagination, session)
           expect(result.links).to.equal({
-            back: `/system/notices/setup/${session.id}/check-notice-type`,
             cancel: `/system/notices/setup/${session.id}/cancel`,
             download: `/system/notices/setup/${session.id}/download`,
             manage: `/system/notices/setup/${session.id}/select-recipients`
@@ -166,7 +209,6 @@ describe('Notices - Setup - Check presenter', () => {
           const result = CheckPresenter.go(testInput, page, pagination, session)
 
           expect(result.links).to.equal({
-            back: `/system/notices/setup/${session.id}/abstraction-alerts/alert-email-address`,
             cancel: `/system/notices/setup/${session.id}/cancel`,
             download: `/system/notices/setup/${session.id}/download`
           })
@@ -177,7 +219,6 @@ describe('Notices - Setup - Check presenter', () => {
         it('should return the links for the "standard" journey', () => {
           const result = CheckPresenter.go(testInput, page, pagination, session)
           expect(result.links).to.equal({
-            back: `/system/notices/setup/${session.id}/returns-period`,
             cancel: `/system/notices/setup/${session.id}/cancel`,
             download: `/system/notices/setup/${session.id}/download`,
             removeLicences: `/system/notices/setup/${session.id}/remove-licences`

--- a/test/services/notices/setup/check.service.test.js
+++ b/test/services/notices/setup/check.service.test.js
@@ -54,9 +54,12 @@ describe('Notices - Setup - Check service', () => {
 
     expect(result).to.equal({
       activeNavBar: 'manage',
+      backLink: {
+        href: `/system/notices/setup/${session.id}/returns-period`,
+        text: 'Back'
+      },
       defaultPageSize: 25,
       links: {
-        back: `/system/notices/setup/${session.id}/returns-period`,
         cancel: `/system/notices/setup/${session.id}/cancel`,
         download: `/system/notices/setup/${session.id}/download`,
         removeLicences: `/system/notices/setup/${session.id}/remove-licences`
@@ -70,6 +73,7 @@ describe('Notices - Setup - Check service', () => {
         numberOfPages: 1
       },
       pageTitle: 'Check the recipients',
+      pageTitleCaption: 'Notice RINV-123',
       readyToSend: 'Returns invitations are ready to send.',
       recipients: [
         {
@@ -80,7 +84,6 @@ describe('Notices - Setup - Check service', () => {
         }
       ],
       recipientsAmount: 1,
-      referenceCode: 'RINV-123',
       warning: null
     })
   })
@@ -146,9 +149,12 @@ describe('Notices - Setup - Check service', () => {
 
       expect(result).to.equal({
         activeNavBar: 'manage',
+        backLink: {
+          href: `/system/notices/setup/${session.id}/abstraction-alerts/alert-email-address`,
+          text: 'Back'
+        },
         defaultPageSize: 25,
         links: {
-          back: `/system/notices/setup/${session.id}/abstraction-alerts/alert-email-address`,
           cancel: `/system/notices/setup/${session.id}/cancel`,
           download: `/system/notices/setup/${session.id}/download`
         },
@@ -161,6 +167,7 @@ describe('Notices - Setup - Check service', () => {
           numberOfPages: 1
         },
         pageTitle: 'Check the recipients',
+        pageTitleCaption: 'Notice WAA-123',
         readyToSend: 'Abstraction alerts are ready to send.',
         recipients: [
           {
@@ -171,7 +178,6 @@ describe('Notices - Setup - Check service', () => {
           }
         ],
         recipientsAmount: 1,
-        referenceCode: 'WAA-123',
         warning: null
       })
     })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5234

We are seeing a few journey issues for the adhoc journey when a goes back from the check recipients page.

We have an established pattern of not having backlinks on the check page. We have the backlink on this page for the invitation and reminders journey, as they do not have their own check pages.

This change conditionally renders the backlink based on the journey.

This change also updates the nunjucks to use our new layout.