### PR TITLE
Update the contact type page to show the page title caption

### DIFF
--- a/app/presenters/notices/setup/contact-type.presenter.js
+++ b/app/presenters/notices/setup/contact-type.presenter.js
@@ -18,10 +18,14 @@ function go(session) {
   const type = session?.contactType ?? null
 
   return {
-    backLink: `/system/notices/setup/${session.id}/select-recipients`,
+    backLink: {
+      href: `/system/notices/setup/${session.id}/select-recipients`,
+      text: 'Back'
+    },
     email,
     name,
     pageTitle: 'Select how to contact the recipient',
+    pageTitleCaption: `Notice ${session.referenceCode}`,
     type
   }
 }

--- a/app/services/notices/setup/submit-contact-type.service.js
+++ b/app/services/notices/setup/submit-contact-type.service.js
@@ -12,6 +12,7 @@ const ContactTypePresenter = require('../../../presenters/notices/setup/contact-
 const ContactTypeValidator = require('../../../validators/notices/setup/contact-type.validator.js')
 const GeneralLib = require('../../../lib/general.lib.js')
 const SessionModel = require('../../../models/session.model.js')
+const { formatValidationResult } = require('../../../presenters/base.presenter.js')
 
 /**
  * Orchestrates validating the data for `/notices/setup/{sessionId}/contact-type` page
@@ -35,13 +36,10 @@ async function go(sessionId, payload, yar) {
     }
   }
 
-  const submittedData = {
-    id: session.id,
-    contactType: payload?.type ?? null,
-    name: payload?.name ?? null
-  }
+  session.contactType = payload?.type ?? null
+  session.name = payload?.name ?? null
 
-  const pageData = ContactTypePresenter.go(submittedData)
+  const pageData = ContactTypePresenter.go(session)
 
   return {
     activeNavBar: 'manage',
@@ -107,26 +105,9 @@ async function _save(session, payload, yar) {
 }
 
 function _validate(payload) {
-  const validation = ContactTypeValidator.go(payload)
+  const validationResult = ContactTypeValidator.go(payload)
 
-  if (!validation.error) {
-    return null
-  }
-
-  const result = {
-    errorList: []
-  }
-
-  validation.error.details.forEach((detail) => {
-    result.errorList.push({
-      href: `#${detail.context.key}`,
-      text: detail.message
-    })
-
-    result[detail.context.key] = detail.message
-  })
-
-  return result
+  return formatValidationResult(validationResult)
 }
 
 module.exports = {

--- a/app/views/notices/setup/contact-type.njk
+++ b/app/views/notices/setup/contact-type.njk
@@ -1,28 +1,10 @@
 {% extends 'layout.njk' %}
 
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
-{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 
-{% block breadcrumbs %}
-  {{
-  govukBackLink({
-    text: 'Back',
-    href: backLink
-  })
-  }}
-{% endblock %}
-
-{% block content %}
-  {% if error %}
-    {{ govukErrorSummary({
-      titleText: "There is a problem",
-      errorList: error.errorList
-    }) }}
-  {%endif%}
-
+{% block pageContent %}
   {% set emailHtml %}
     {{ govukInput({
       id: "email",
@@ -30,9 +12,7 @@
       value: email,
       autocomplete: "email",
       spellcheck: false,
-      errorMessage: {
-        text: error.email
-      } if error.email,
+      errorMessage: error.email,
       classes: 'govuk-!-width-two-thirds',
       label: {
         classes: 'govuk-!-font-weight-bold govuk-!-width-two-thirds',
@@ -48,19 +28,13 @@
       type: "name",
       value: name,
       classes: 'govuk-!-width-two-thirds',
-      errorMessage: {
-        text: error.name
-      } if error.name,
+      errorMessage: error.name,
       label: {
         classes: 'govuk-!-font-weight-bold',
         text: "Recipients name"
       }
     }) }}
   {% endset -%}
-
-  <h1 class="govuk-form-group govuk-heading-l">
-    {{ pageTitle }}
-  </h1>
 
   <form method="post">
     <input type="hidden" name="wrlsCrumb" value="{{wrlsCrumb}}"/>
@@ -69,6 +43,12 @@
       id: 'type',
       name: 'type',
       value: type,
+      fieldset: {
+        legend: {
+          html: pageHeadingHtml,
+          isPageHeading: true
+        }
+      },
       items: [
         {
           id: 'email',

--- a/test/presenters/notices/setup/contact-type.presenter.test.js
+++ b/test/presenters/notices/setup/contact-type.presenter.test.js
@@ -22,10 +22,14 @@ describe('Contact Type Presenter', () => {
       const result = ContactTypePresenter.go(session)
 
       expect(result).to.equal({
-        backLink: `/system/notices/setup/${session.id}/select-recipients`,
+        backLink: {
+          href: `/system/notices/setup/${session.id}/select-recipients`,
+          text: 'Back'
+        },
         email: null,
         name: null,
         pageTitle: 'Select how to contact the recipient',
+        pageTitleCaption: 'Notice RINV-CPFRQ4',
         type: null
       })
     })
@@ -43,10 +47,14 @@ describe('Contact Type Presenter', () => {
       const result = ContactTypePresenter.go(session)
 
       expect(result).to.equal({
-        backLink: `/system/notices/setup/${session.id}/select-recipients`,
+        backLink: {
+          href: `/system/notices/setup/${session.id}/select-recipients`,
+          text: 'Back'
+        },
         email: 'test@test.gov.uk',
         name: null,
         pageTitle: 'Select how to contact the recipient',
+        pageTitleCaption: 'Notice RINV-CPFRQ4',
         type: 'email'
       })
     })
@@ -56,7 +64,8 @@ describe('Contact Type Presenter', () => {
     beforeEach(() => {
       session = {
         contactName: 'Fake Person',
-        contactType: 'post'
+        contactType: 'post',
+        referenceCode: 'RINV-CPFRQ4'
       }
     })
 
@@ -64,10 +73,14 @@ describe('Contact Type Presenter', () => {
       const result = ContactTypePresenter.go(session)
 
       expect(result).to.equal({
-        backLink: `/system/notices/setup/${session.id}/select-recipients`,
+        backLink: {
+          href: `/system/notices/setup/${session.id}/select-recipients`,
+          text: 'Back'
+        },
         email: null,
         name: 'Fake Person',
         pageTitle: 'Select how to contact the recipient',
+        pageTitleCaption: 'Notice RINV-CPFRQ4',
         type: 'post'
       })
     })

--- a/test/services/notices/setup/contact-type.service.test.js
+++ b/test/services/notices/setup/contact-type.service.test.js
@@ -19,7 +19,7 @@ describe('Notices - Setup - Contact Type Service', () => {
 
   describe('when called with no saved data', () => {
     beforeEach(async () => {
-      sessionData = {}
+      sessionData = { referenceCode: 'RINV-CPFRQ4' }
 
       session = await SessionHelper.add({ data: sessionData })
     })
@@ -29,10 +29,14 @@ describe('Notices - Setup - Contact Type Service', () => {
 
       expect(result).to.equal({
         activeNavBar: 'manage',
-        backLink: `/system/notices/setup/${session.id}/select-recipients`,
+        backLink: {
+          href: `/system/notices/setup/${session.id}/select-recipients`,
+          text: 'Back'
+        },
         email: null,
         name: null,
         pageTitle: 'Select how to contact the recipient',
+        pageTitleCaption: 'Notice RINV-CPFRQ4',
         type: null
       })
     })
@@ -42,7 +46,8 @@ describe('Notices - Setup - Contact Type Service', () => {
     beforeEach(async () => {
       sessionData = {
         contactName: 'Fake Person',
-        contactType: 'post'
+        contactType: 'post',
+        referenceCode: 'RINV-CPFRQ4'
       }
 
       session = await SessionHelper.add({ data: sessionData })
@@ -53,10 +58,14 @@ describe('Notices - Setup - Contact Type Service', () => {
 
       expect(result).to.equal({
         activeNavBar: 'manage',
-        backLink: `/system/notices/setup/${session.id}/select-recipients`,
+        backLink: {
+          href: `/system/notices/setup/${session.id}/select-recipients`,
+          text: 'Back'
+        },
         email: null,
         name: 'Fake Person',
         pageTitle: 'Select how to contact the recipient',
+        pageTitleCaption: 'Notice RINV-CPFRQ4',
         type: 'post'
       })
     })

--- a/test/services/notices/setup/submit-contact-type.service.test.js
+++ b/test/services/notices/setup/submit-contact-type.service.test.js
@@ -266,7 +266,7 @@ describe('Notices - Setup - Submit Contact Type Service', () => {
     describe('when validation fails because no type is selected', () => {
       beforeEach(async () => {
         payload = {}
-        sessionData = {}
+        sessionData = { referenceCode: 'RINV-CPFRQ4' }
 
         session = await SessionHelper.add({ data: sessionData })
       })
@@ -276,7 +276,10 @@ describe('Notices - Setup - Submit Contact Type Service', () => {
 
         expect(result).to.equal({
           activeNavBar: 'manage',
-          backLink: `/system/notices/setup/${session.id}/select-recipients`,
+          backLink: {
+            href: `/system/notices/setup/${session.id}/select-recipients`,
+            text: 'Back'
+          },
           email: null,
           error: {
             errorList: [
@@ -285,10 +288,13 @@ describe('Notices - Setup - Submit Contact Type Service', () => {
                 text: 'Select how to contact the recipient'
               }
             ],
-            type: 'Select how to contact the recipient'
+            type: {
+              text: 'Select how to contact the recipient'
+            }
           },
           name: null,
           pageTitle: 'Select how to contact the recipient',
+          pageTitleCaption: 'Notice RINV-CPFRQ4',
           type: null
         })
       })
@@ -299,7 +305,7 @@ describe('Notices - Setup - Submit Contact Type Service', () => {
         payload = {
           type: 'email'
         }
-        sessionData = {}
+        sessionData = { referenceCode: 'RINV-CPFRQ4' }
 
         session = await SessionHelper.add({ data: sessionData })
       })
@@ -309,7 +315,10 @@ describe('Notices - Setup - Submit Contact Type Service', () => {
 
         expect(result).to.equal({
           activeNavBar: 'manage',
-          backLink: `/system/notices/setup/${session.id}/select-recipients`,
+          backLink: {
+            href: `/system/notices/setup/${session.id}/select-recipients`,
+            text: 'Back'
+          },
           email: null,
           error: {
             errorList: [
@@ -318,10 +327,13 @@ describe('Notices - Setup - Submit Contact Type Service', () => {
                 text: 'Enter an email address'
               }
             ],
-            email: 'Enter an email address'
+            email: {
+              text: 'Enter an email address'
+            }
           },
           name: null,
           pageTitle: 'Select how to contact the recipient',
+          pageTitleCaption: 'Notice RINV-CPFRQ4',
           type: 'email'
         })
       })
@@ -332,7 +344,7 @@ describe('Notices - Setup - Submit Contact Type Service', () => {
         payload = {
           type: 'post'
         }
-        sessionData = {}
+        sessionData = { referenceCode: 'RINV-CPFRQ4' }
 
         session = await SessionHelper.add({ data: sessionData })
       })
@@ -342,7 +354,10 @@ describe('Notices - Setup - Submit Contact Type Service', () => {
 
         expect(result).to.equal({
           activeNavBar: 'manage',
-          backLink: `/system/notices/setup/${session.id}/select-recipients`,
+          backLink: {
+            href: `/system/notices/setup/${session.id}/select-recipients`,
+            text: 'Back'
+          },
           email: null,
           error: {
             errorList: [
@@ -351,10 +366,13 @@ describe('Notices - Setup - Submit Contact Type Service', () => {
                 text: 'Enter the recipients name'
               }
             ],
-            name: 'Enter the recipients name'
+            name: {
+              text: 'Enter the recipients name'
+            }
           },
           name: null,
           pageTitle: 'Select how to contact the recipient',
+          pageTitleCaption: 'Notice RINV-CPFRQ4',
           type: 'post'
         })
       })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5236

We have missed adding the caption to the contact type page.

This change adds the page caption to the contact types page.

We have updated our base layout to provide the error summary and backlink. This change has updated the content block to use this improved layout.

This change also uses the common validator.