### PR TITLE
Remove the backlink for the abstraction alerts check recipients page

### DIFF
--- a/app/presenters/notices/setup/check.presenter.js
+++ b/app/presenters/notices/setup/check.presenter.js
@@ -55,15 +55,8 @@ function go(recipients, page, pagination, session) {
 function _backLink(session) {
   const { id, journey } = session
 
-  if (journey === 'adhoc') {
+  if (journey === 'adhoc' || journey === 'alerts') {
     return null
-  }
-
-  if (journey === 'alerts') {
-    return {
-      href: `/system/notices/setup/${id}/abstraction-alerts/alert-email-address`,
-      text: 'Back'
-    }
   }
 
   return {

--- a/app/services/notices/setup/abstraction-alerts/submit-check-licence-matches.service.js
+++ b/app/services/notices/setup/abstraction-alerts/submit-check-licence-matches.service.js
@@ -38,17 +38,6 @@ async function _save(session) {
   session.licenceRefs = Array.from(new Set(relevantLicenceRefs))
   session.relevantLicenceMonitoringStations = relevantLicenceMonitoringStations
 
-  // This is needed for users who have gone through the journey as far as the 'Check recipients' page, then clicked
-  // back and made a change that alters which recipients are applicable.
-  //
-  // When you hit the 'Check recipients' page, if `selectedRecipients` does not exist it will initialise it with all
-  // recipients. Certain journeys can then alter which recipients will receive a notification, which will change the
-  // content of `selectedRecipients`, and what gets displayed on the page.
-  //
-  // Should a user go back though, what was previously 'selected' becomes void because of changes made, hence we need
-  // to delete it so the 'Check recipients' page can re-initialise with all recipients.
-  delete session.selectedRecipients
-
   return session.$update()
 }
 

--- a/test/presenters/notices/setup/check.presenter.test.js
+++ b/test/presenters/notices/setup/check.presenter.test.js
@@ -163,13 +163,10 @@ describe('Notices - Setup - Check presenter', () => {
           session.monitoringStationId = '345'
         })
 
-        it('should return the links for "alerts" journey', () => {
+        it('should return null to not show the back link', () => {
           const result = CheckPresenter.go(testInput, page, pagination, session)
 
-          expect(result.backLink).to.equal({
-            href: `/system/notices/setup/${session.id}/abstraction-alerts/alert-email-address`,
-            text: 'Back'
-          })
+          expect(result.backLink).to.be.null()
         })
       })
 

--- a/test/services/notices/setup/abstraction-alerts/submit-check-licence-matches.service.test.js
+++ b/test/services/notices/setup/abstraction-alerts/submit-check-licence-matches.service.test.js
@@ -120,20 +120,5 @@ describe('Notices Setup - Abstraction Alerts - Submit Check Licence Matches Serv
         expect(refreshedSession.relevantLicenceMonitoringStations).to.equal([licenceMonitoringStations.three])
       })
     })
-
-    describe('and "selectedRecipients" is present in the session (the user has gone back in the journey from the check page)', () => {
-      beforeEach(async () => {
-        sessionData.selectedRecipients = ['fc5748c8-ce0e-4d17-bd23-d230cdba7b72']
-        session = await SessionHelper.add({ data: sessionData })
-      })
-
-      it('deletes "selectedRecipients" from the session', async () => {
-        await SubmitCheckLicenceMatchesService.go(session.id)
-
-        const refreshedSession = await session.$query()
-
-        expect(refreshedSession.selectedRecipients).not.to.exist()
-      })
-    })
   })
 })

--- a/test/services/notices/setup/check.service.test.js
+++ b/test/services/notices/setup/check.service.test.js
@@ -149,10 +149,7 @@ describe('Notices - Setup - Check service', () => {
 
       expect(result).to.equal({
         activeNavBar: 'manage',
-        backLink: {
-          href: `/system/notices/setup/${session.id}/abstraction-alerts/alert-email-address`,
-          text: 'Back'
-        },
+        backLink: null,
         defaultPageSize: 25,
         links: {
           cancel: `/system/notices/setup/${session.id}/cancel`,


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5240

The check page for the abstraction alerts journey has some unexpected bugs when using the backlink.

We put in a workaround, but we do not have backlinks on check pages. So we need to remove it.

This change removes the backlink for the abstraction alerts check recipients page.