### PR TITLE
Update tests to use generated reference codes

### DIFF
--- a/test/fixtures/notices.fixture.js
+++ b/test/fixtures/notices.fixture.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const { generateRandomInteger, generateUUID } = require('../../app/lib/general.lib.js')
+const { generateReferenceCode } = require('../support/helpers/notification.helper.js')
 
 /**
  * Represents a notice of type 'alert reduce'
@@ -12,7 +13,7 @@ function alertReduce() {
 
   data.alertType = 'reduce'
   data.name = 'Water abstraction alert'
-  data.referenceCode = `WAA-${generateRandomInteger(100000, 999999)}`
+  data.referenceCode = generateReferenceCode('WAA')
   data.subtype = 'waterAbstractionAlerts'
 
   return data
@@ -28,7 +29,7 @@ function alertResume() {
 
   data.alertType = 'resume'
   data.name = 'Water abstraction alert'
-  data.referenceCode = `WAA-${generateRandomInteger(100000, 999999)}`
+  data.referenceCode = generateReferenceCode('WAA')
   data.subtype = 'waterAbstractionAlerts'
 
   return data
@@ -44,7 +45,7 @@ function alertStop() {
 
   data.alertType = 'stop'
   data.name = 'Water abstraction alert'
-  data.referenceCode = `WAA-${generateRandomInteger(100000, 999999)}`
+  data.referenceCode = generateReferenceCode('WAA')
   data.subtype = 'waterAbstractionAlerts'
 
   return data
@@ -60,7 +61,7 @@ function alertWarning() {
 
   data.alertType = 'warning'
   data.name = 'Water abstraction alert'
-  data.referenceCode = `WAA-${generateRandomInteger(100000, 999999)}`
+  data.referenceCode = generateReferenceCode('WAA')
   data.subtype = 'waterAbstractionAlerts'
 
   return data
@@ -75,7 +76,7 @@ function legacyNotification() {
   const data = _defaults()
 
   data.name = 'Hands off flow: levels warning'
-  data.referenceCode = `HOF-${generateRandomInteger(100000, 999999)}`
+  data.referenceCode = generateReferenceCode('HOF')
   data.subtype = 'hof-warning'
 
   return data
@@ -107,7 +108,7 @@ function notices() {
 function returnsInvitation() {
   const data = _defaults()
 
-  data.referenceCode = `RINV-${generateRandomInteger(100000, 999999)}`
+  data.referenceCode = generateReferenceCode('RINV')
 
   return data
 }
@@ -121,7 +122,7 @@ function returnsPaperForm() {
   const data = _defaults()
 
   data.name = 'Paper returns'
-  data.referenceCode = `PRTF-${generateRandomInteger(100000, 999999)}`
+  data.referenceCode = generateReferenceCode('PRTF')
   data.subtype = 'paperReturnForms'
 
   return data
@@ -136,7 +137,7 @@ function returnsReminder() {
   const data = _defaults()
 
   data.name = 'Returns: reminder'
-  data.referenceCode = `RREM-${generateRandomInteger(100000, 999999)}`
+  data.referenceCode = generateReferenceCode('RREM')
   data.subtype = 'returnReminder'
 
   return data

--- a/test/presenters/notices/setup/abstraction-alert-notifications.presenter.test.js
+++ b/test/presenters/notices/setup/abstraction-alert-notifications.presenter.test.js
@@ -11,13 +11,14 @@ const { expect } = Code
 // Test helpers
 const AbstractionAlertSessionData = require('../../../fixtures/abstraction-alert-session-data.fixture.js')
 const RecipientsFixture = require('../../../fixtures/recipients.fixtures.js')
+const { generateReferenceCode } = require('../../../support/helpers/notification.helper.js')
 
 // Thing under test
 const AbstractionAlertNotificationsPresenter = require('../../../../app/presenters/notices/setup/abstraction-alert-notifications.presenter.js')
 
 describe('Notices - Setup - Abstraction Alert Notifications presenter', () => {
   const eventId = 'c1cae668-3dad-4806-94e2-eb3f27222ed9'
-  const referenceCode = 'TEST-123'
+  const referenceCode = generateReferenceCode()
 
   let clock
   let licenceMonitoringStations
@@ -85,7 +86,7 @@ describe('Notices - Setup - Abstraction Alert Notifications presenter', () => {
           thresholdValue: 1000
         },
         recipient: 'primary.user@important.com',
-        reference: 'TEST-123',
+        reference: referenceCode,
         templateId: '6ec7265d-8ebb-4217-a62b-9bf0216f8c9f'
       },
       {
@@ -116,7 +117,7 @@ describe('Notices - Setup - Abstraction Alert Notifications presenter', () => {
           thresholdUnit: 'm3/s',
           thresholdValue: 100
         },
-        reference: 'TEST-123',
+        reference: referenceCode,
         templateId: '7ab10c86-2c23-4376-8c72-9419e7f982bb'
       },
       {
@@ -141,7 +142,7 @@ describe('Notices - Setup - Abstraction Alert Notifications presenter', () => {
           thresholdValue: 100
         },
         recipient: 'additional.contact@important.com',
-        reference: 'TEST-123',
+        reference: referenceCode,
         templateId: 'bf32327a-f170-4854-8abb-3068aee9cdec'
       }
     ])
@@ -162,7 +163,7 @@ describe('Notices - Setup - Abstraction Alert Notifications presenter', () => {
         {
           createdAt: '2025-01-01T00:00:00.000Z',
           eventId: 'c1cae668-3dad-4806-94e2-eb3f27222ed9',
-          reference: 'TEST-123',
+          reference: referenceCode,
           templateId: '6ec7265d-8ebb-4217-a62b-9bf0216f8c9f',
           licences: `["${recipients.primaryUser.licence_refs}"]`,
           messageType: 'email',
@@ -206,7 +207,7 @@ describe('Notices - Setup - Abstraction Alert Notifications presenter', () => {
             thresholdValue: 100
           },
           recipient: 'primary.user@important.com',
-          reference: 'TEST-123',
+          reference: referenceCode,
           templateId: 'a51ace39-3224-4c18-bbb8-c803a6da9a21'
         }
       ])
@@ -227,7 +228,7 @@ describe('Notices - Setup - Abstraction Alert Notifications presenter', () => {
         {
           createdAt: '2025-01-01T00:00:00.000Z',
           eventId: 'c1cae668-3dad-4806-94e2-eb3f27222ed9',
-          reference: 'TEST-123',
+          reference: referenceCode,
           templateId: 'bf32327a-f170-4854-8abb-3068aee9cdec',
           licences: `["${recipients.additionalContact.licence_refs}"]`,
           messageType: 'email',
@@ -270,7 +271,7 @@ describe('Notices - Setup - Abstraction Alert Notifications presenter', () => {
         {
           createdAt: '2025-01-01T00:00:00.000Z',
           eventId: 'c1cae668-3dad-4806-94e2-eb3f27222ed9',
-          reference: 'TEST-123',
+          reference: referenceCode,
           templateId: '6ec7265d-8ebb-4217-a62b-9bf0216f8c9f',
           licences: `["${recipients.additionalContact.licence_refs}"]`,
           messageType: 'email',
@@ -313,7 +314,7 @@ describe('Notices - Setup - Abstraction Alert Notifications presenter', () => {
         {
           createdAt: '2025-01-01T00:00:00.000Z',
           eventId: 'c1cae668-3dad-4806-94e2-eb3f27222ed9',
-          reference: 'TEST-123',
+          reference: referenceCode,
           templateId: '6ec7265d-8ebb-4217-a62b-9bf0216f8c9f',
           licences: `["${recipients.primaryUser.licence_refs}"]`,
           messageType: 'email',
@@ -354,7 +355,7 @@ describe('Notices - Setup - Abstraction Alert Notifications presenter', () => {
         {
           createdAt: '2025-01-01T00:00:00.000Z',
           eventId: 'c1cae668-3dad-4806-94e2-eb3f27222ed9',
-          reference: 'TEST-123',
+          reference: referenceCode,
           templateId: '27499bbd-e854-4f13-884e-30e0894526b6',
           licences: `["${recipients.licenceHolder.licence_refs}"]`,
           messageType: 'letter',

--- a/test/presenters/notices/setup/cancel.presenter.test.js
+++ b/test/presenters/notices/setup/cancel.presenter.test.js
@@ -9,12 +9,13 @@ const { expect } = Code
 
 // Test helpers
 const { generateLicenceRef } = require('../../../support/helpers/licence.helper.js')
+const { generateReferenceCode } = require('../../../support/helpers/notification.helper.js')
 
 // Thing under test
 const CancelPresenter = require('../../../../app/presenters/notices/setup/cancel.presenter.js')
 
 describe('Notices - Setup - Cancel presenter', () => {
-  const referenceCode = 'RNIV-1234'
+  const referenceCode = generateReferenceCode()
 
   let licenceRef
   let session
@@ -34,7 +35,7 @@ describe('Notices - Setup - Cancel presenter', () => {
     expect(result).to.equal({
       backLink: `/system/notices/setup/${session.id}/check`,
       pageTitle: 'You are about to cancel this notice',
-      referenceCode: 'RNIV-1234',
+      referenceCode,
       summaryList: {
         text: 'Licence number',
         value: licenceRef
@@ -59,7 +60,7 @@ describe('Notices - Setup - Cancel presenter', () => {
         alertType: 'stop',
         journey: 'alerts',
         monitoringStationId: '123',
-        referenceCode: 'WAA-1234'
+        referenceCode: generateReferenceCode('WAA')
       }
     })
 

--- a/test/presenters/notices/setup/check.presenter.test.js
+++ b/test/presenters/notices/setup/check.presenter.test.js
@@ -8,6 +8,9 @@ const { describe, it, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
+const { generateReferenceCode } = require('../../../support/helpers/notification.helper.js')
+
+// Test helpers
 const RecipientsFixture = require('../../../fixtures/recipients.fixtures.js')
 const { generateUUID } = require('../../../../app/lib/general.lib.js')
 
@@ -28,7 +31,12 @@ describe('Notices - Setup - Check presenter', () => {
       numberOfPages: 1
     }
 
-    session = { id: generateUUID(), journey: 'standard', noticeType: 'invitations', referenceCode: 'RINV-123' }
+    session = {
+      id: generateUUID(),
+      journey: 'standard',
+      noticeType: 'invitations',
+      referenceCode: generateReferenceCode('RINV')
+    }
 
     testRecipients = RecipientsFixture.recipients()
     // This data is used to ensure the recipients are grouped when they have the same licence ref / name.
@@ -63,7 +71,7 @@ describe('Notices - Setup - Check presenter', () => {
           removeLicences: `/system/notices/setup/${session.id}/remove-licences`
         },
         pageTitle: 'Check the recipients',
-        pageTitleCaption: 'Notice RINV-123',
+        pageTitleCaption: `Notice ${session.referenceCode}`,
         readyToSend: 'Returns invitations are ready to send.',
         recipients: [
           {
@@ -159,7 +167,7 @@ describe('Notices - Setup - Check presenter', () => {
         beforeEach(() => {
           session.journey = 'alerts'
           session.noticeType = 'abstractionAlerts'
-          session.referenceCode = 'WAA-123'
+          session.referenceCode = generateReferenceCode('WAA')
           session.monitoringStationId = '345'
         })
 
@@ -201,7 +209,7 @@ describe('Notices - Setup - Check presenter', () => {
         beforeEach(() => {
           session.journey = 'alerts'
           session.noticeType = 'abstractionAlerts'
-          session.referenceCode = 'WAA-123'
+          session.referenceCode = generateReferenceCode('WAA')
           session.monitoringStationId = '345'
         })
 
@@ -244,7 +252,7 @@ describe('Notices - Setup - Check presenter', () => {
         describe('and the "noticeType" is "returnForms"', () => {
           beforeEach(() => {
             session.noticeType = 'returnForms'
-            session.referenceCode = 'PRTF-123'
+            session.referenceCode = generateReferenceCode('PRTF')
           })
 
           it('should return the correct message', () => {
@@ -259,7 +267,7 @@ describe('Notices - Setup - Check presenter', () => {
         beforeEach(() => {
           session.journey = 'alerts'
           session.noticeType = 'abstractionAlerts'
-          session.referenceCode = 'WAA-123'
+          session.referenceCode = generateReferenceCode('WAA')
           session.monitoringStationId = '345'
         })
 
@@ -387,7 +395,7 @@ describe('Notices - Setup - Check presenter', () => {
           describe('and the "noticeType" is "returnForms"', () => {
             beforeEach(() => {
               session.noticeType = 'returnForms'
-              session.referenceCode = 'PRTF-123'
+              session.referenceCode = generateReferenceCode('PRTF')
             })
 
             it('should return null', () => {
@@ -404,7 +412,7 @@ describe('Notices - Setup - Check presenter', () => {
           beforeEach(() => {
             session.journey = 'alerts'
             session.noticeType = 'abstractionAlerts'
-            session.referenceCode = 'WAA-123'
+            session.referenceCode = generateReferenceCode('WAA')
             session.monitoringStationId = '345'
           })
 
@@ -455,7 +463,7 @@ describe('Notices - Setup - Check presenter', () => {
           describe('and the "noticeType" is "reminders"', () => {
             beforeEach(() => {
               session.noticeType = 'reminders'
-              session.referenceCode = 'RREM-123'
+              session.referenceCode = generateReferenceCode('RREM')
             })
 
             describe('and the method is "letter"', () => {

--- a/test/presenters/notices/setup/confirmation.presenter.test.js
+++ b/test/presenters/notices/setup/confirmation.presenter.test.js
@@ -7,11 +7,14 @@ const Code = require('@hapi/code')
 const { describe, it, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
+// Test helpers
+const { generateReferenceCode } = require('../../../support/helpers/notification.helper.js')
+
 // Thing under test
 const ConfirmationPresenter = require('../../../../app/presenters/notices/setup/confirmation.presenter.js')
 
 describe('Notices - Setup - Confirmation presenter', () => {
-  const referenceCode = 'RNIV-1234'
+  const referenceCode = generateReferenceCode()
 
   let event
 
@@ -31,7 +34,7 @@ describe('Notices - Setup - Confirmation presenter', () => {
       forwardLink: '/notifications/report/123',
       monitoringStationLink: null,
       pageTitle: `Returns invitations sent`,
-      referenceCode: 'RNIV-1234'
+      referenceCode
     })
   })
 
@@ -47,7 +50,7 @@ describe('Notices - Setup - Confirmation presenter', () => {
         forwardLink: '/notifications/report/123',
         monitoringStationLink: null,
         pageTitle: `Returns invitations sent`,
-        referenceCode: 'RNIV-1234'
+        referenceCode
       })
     })
   })
@@ -64,7 +67,7 @@ describe('Notices - Setup - Confirmation presenter', () => {
         forwardLink: '/notifications/report/123',
         monitoringStationLink: null,
         pageTitle: `Returns reminders sent`,
-        referenceCode: 'RNIV-1234'
+        referenceCode
       })
     })
   })
@@ -83,7 +86,7 @@ describe('Notices - Setup - Confirmation presenter', () => {
         forwardLink: '/notifications/report/123',
         monitoringStationLink: '/system/monitoring-stations/123',
         pageTitle: 'Water abstraction alerts sent',
-        referenceCode: 'RNIV-1234'
+        referenceCode
       })
     })
   })
@@ -100,7 +103,7 @@ describe('Notices - Setup - Confirmation presenter', () => {
         forwardLink: '/notifications/report/123',
         monitoringStationLink: null,
         pageTitle: 'Paper return forms sent',
-        referenceCode: 'RNIV-1234'
+        referenceCode
       })
     })
   })

--- a/test/presenters/notices/setup/notifications.presenter.test.js
+++ b/test/presenters/notices/setup/notifications.presenter.test.js
@@ -10,12 +10,13 @@ const { expect } = Code
 
 // Test helpers
 const RecipientsFixture = require('../../../fixtures/recipients.fixtures.js')
+const { generateReferenceCode } = require('../../../support/helpers/notification.helper.js')
 
 // Thing under test
 const NotificationsPresenter = require('../../../../app/presenters/notices/setup/notifications.presenter.js')
 
 describe('Notices - Setup - Notifications Presenter', () => {
-  const referenceCode = 'TEST-123'
+  const referenceCode = generateReferenceCode()
   const eventId = 'c1cae668-3dad-4806-94e2-eb3f27222ed9'
 
   let clock
@@ -69,7 +70,7 @@ describe('Notices - Setup - Notifications Presenter', () => {
           returnDueDate: '28 April 2025'
         },
         recipient: 'primary.user@important.com',
-        reference: 'TEST-123',
+        reference: referenceCode,
         templateId: '2fa7fc83-4df1-4f52-bccf-ff0faeb12b6f'
       },
       {
@@ -83,7 +84,7 @@ describe('Notices - Setup - Notifications Presenter', () => {
           periodStartDate: '1 January 2025',
           returnDueDate: '28 April 2025'
         },
-        reference: 'TEST-123',
+        reference: referenceCode,
         recipient: 'returns.agent@important.com',
         templateId: '41c45bd4-8225-4d7e-a175-b48b613b5510'
       },
@@ -105,7 +106,7 @@ describe('Notices - Setup - Notifications Presenter', () => {
           periodStartDate: '1 January 2025',
           returnDueDate: '28 April 2025'
         },
-        reference: 'TEST-123',
+        reference: referenceCode,
         templateId: '4fe80aed-c5dd-44c3-9044-d0289d635019'
       },
       {
@@ -126,7 +127,7 @@ describe('Notices - Setup - Notifications Presenter', () => {
           periodStartDate: '1 January 2025',
           returnDueDate: '28 April 2025'
         },
-        reference: 'TEST-123',
+        reference: referenceCode,
         templateId: '0e535549-99a2-44a9-84a7-589b12d00879'
       },
       {
@@ -147,7 +148,7 @@ describe('Notices - Setup - Notifications Presenter', () => {
           periodStartDate: '1 January 2025',
           returnDueDate: '28 April 2025'
         },
-        reference: 'TEST-123',
+        reference: referenceCode,
         templateId: '4fe80aed-c5dd-44c3-9044-d0289d635019'
       }
     ])
@@ -181,7 +182,7 @@ describe('Notices - Setup - Notifications Presenter', () => {
                   returnDueDate: '28 April 2025'
                 },
                 recipient: 'primary.user@important.com',
-                reference: 'TEST-123',
+                reference: referenceCode,
                 templateId: '2fa7fc83-4df1-4f52-bccf-ff0faeb12b6f'
               }
             ])
@@ -209,7 +210,7 @@ describe('Notices - Setup - Notifications Presenter', () => {
                   returnDueDate: '28 April 2025'
                 },
                 recipient: 'returns.agent@important.com',
-                reference: 'TEST-123',
+                reference: referenceCode,
                 templateId: '41c45bd4-8225-4d7e-a175-b48b613b5510'
               }
             ])
@@ -237,7 +238,7 @@ describe('Notices - Setup - Notifications Presenter', () => {
                   returnDueDate: '28 April 2025'
                 },
                 recipient: 'primary.user@important.com',
-                reference: 'TEST-123',
+                reference: referenceCode,
                 templateId: '2fa7fc83-4df1-4f52-bccf-ff0faeb12b6f'
               }
             ])
@@ -273,7 +274,7 @@ describe('Notices - Setup - Notifications Presenter', () => {
                   periodStartDate: '1 January 2025',
                   returnDueDate: '28 April 2025'
                 },
-                reference: 'TEST-123',
+                reference: referenceCode,
                 templateId: '4fe80aed-c5dd-44c3-9044-d0289d635019'
               }
             ])
@@ -307,7 +308,7 @@ describe('Notices - Setup - Notifications Presenter', () => {
                   periodStartDate: '1 January 2025',
                   returnDueDate: '28 April 2025'
                 },
-                reference: 'TEST-123',
+                reference: referenceCode,
                 templateId: '0e535549-99a2-44a9-84a7-589b12d00879'
               }
             ])
@@ -341,7 +342,7 @@ describe('Notices - Setup - Notifications Presenter', () => {
                   periodStartDate: '1 January 2025',
                   returnDueDate: '28 April 2025'
                 },
-                reference: 'TEST-123',
+                reference: referenceCode,
                 templateId: '4fe80aed-c5dd-44c3-9044-d0289d635019'
               }
             ])
@@ -377,7 +378,7 @@ describe('Notices - Setup - Notifications Presenter', () => {
                   returnDueDate: '28 April 2025'
                 },
                 recipient: 'primary.user@important.com',
-                reference: 'TEST-123',
+                reference: referenceCode,
                 templateId: 'f1144bc7-8bdc-4e82-87cb-1a6c69445836'
               }
             ])
@@ -405,7 +406,7 @@ describe('Notices - Setup - Notifications Presenter', () => {
                   returnDueDate: '28 April 2025'
                 },
                 recipient: 'returns.agent@important.com',
-                reference: 'TEST-123',
+                reference: referenceCode,
                 templateId: '038e1807-d1b5-4f09-a5a6-d7eee9030a7a'
               }
             ])
@@ -433,7 +434,7 @@ describe('Notices - Setup - Notifications Presenter', () => {
                   returnDueDate: '28 April 2025'
                 },
                 recipient: 'primary.user@important.com',
-                reference: 'TEST-123',
+                reference: referenceCode,
                 templateId: 'f1144bc7-8bdc-4e82-87cb-1a6c69445836'
               }
             ])
@@ -469,7 +470,7 @@ describe('Notices - Setup - Notifications Presenter', () => {
                   periodStartDate: '1 January 2025',
                   returnDueDate: '28 April 2025'
                 },
-                reference: 'TEST-123',
+                reference: referenceCode,
                 templateId: 'c01c808b-094b-4a3a-ab9f-a6e86bad36ba'
               }
             ])
@@ -503,7 +504,7 @@ describe('Notices - Setup - Notifications Presenter', () => {
                   periodStartDate: '1 January 2025',
                   returnDueDate: '28 April 2025'
                 },
-                reference: 'TEST-123',
+                reference: referenceCode,
                 templateId: 'e9f132c7-a550-4e18-a5c1-78375f07aa2d'
               }
             ])
@@ -537,7 +538,7 @@ describe('Notices - Setup - Notifications Presenter', () => {
                   periodStartDate: '1 January 2025',
                   returnDueDate: '28 April 2025'
                 },
-                reference: 'TEST-123',
+                reference: referenceCode,
                 templateId: 'c01c808b-094b-4a3a-ab9f-a6e86bad36ba'
               }
             ])
@@ -576,7 +577,7 @@ describe('Notices - Setup - Notifications Presenter', () => {
                   returnDueDate: '28 April 2025'
                 },
                 recipient: 'primary.user@important.com',
-                reference: 'TEST-123',
+                reference: referenceCode,
                 templateId: '7bb89469-1dbc-458a-9526-fad8ab71285f'
               }
             ])
@@ -604,7 +605,7 @@ describe('Notices - Setup - Notifications Presenter', () => {
                   returnDueDate: '28 April 2025'
                 },
                 recipient: 'returns.agent@important.com',
-                reference: 'TEST-123',
+                reference: referenceCode,
                 templateId: 'cbc4efe2-f3b5-4642-8f6d-3532df73ee94'
               }
             ])
@@ -632,7 +633,7 @@ describe('Notices - Setup - Notifications Presenter', () => {
                   returnDueDate: '28 April 2025'
                 },
                 recipient: 'primary.user@important.com',
-                reference: 'TEST-123',
+                reference: referenceCode,
                 templateId: '7bb89469-1dbc-458a-9526-fad8ab71285f'
               }
             ])
@@ -668,7 +669,7 @@ describe('Notices - Setup - Notifications Presenter', () => {
                   periodStartDate: '1 January 2025',
                   returnDueDate: '28 April 2025'
                 },
-                reference: 'TEST-123',
+                reference: referenceCode,
                 templateId: '4b47cf1c-043c-4a0c-8659-5be06cb2b860'
               }
             ])
@@ -702,7 +703,7 @@ describe('Notices - Setup - Notifications Presenter', () => {
                   periodStartDate: '1 January 2025',
                   returnDueDate: '28 April 2025'
                 },
-                reference: 'TEST-123',
+                reference: referenceCode,
                 templateId: '73b4c395-4423-4976-8ab4-c82e2cb6beee'
               }
             ])
@@ -736,7 +737,7 @@ describe('Notices - Setup - Notifications Presenter', () => {
                   periodStartDate: '1 January 2025',
                   returnDueDate: '28 April 2025'
                 },
-                reference: 'TEST-123',
+                reference: referenceCode,
                 templateId: '4b47cf1c-043c-4a0c-8659-5be06cb2b860'
               }
             ])

--- a/test/presenters/notices/setup/remove-licences.presenter.test.js
+++ b/test/presenters/notices/setup/remove-licences.presenter.test.js
@@ -7,12 +7,15 @@ const Code = require('@hapi/code')
 const { describe, it } = (exports.lab = Lab.script())
 const { expect } = Code
 
+// Test helpers
+const { generateReferenceCode } = require('../../../support/helpers/notification.helper.js')
+
 // Thing under test
 const RemoveLicencesPresenter = require('../../../../app/presenters/notices/setup/remove-licences.presenter.js')
 
 describe('Notices - Setup - Remove licences presenter', () => {
   const licences = []
-  const referenceCode = 'RINV-1234'
+  const referenceCode = generateReferenceCode()
 
   it('correctly presents the data', () => {
     const result = RemoveLicencesPresenter.go(licences, referenceCode)

--- a/test/presenters/notices/setup/select-recipients.presenter.test.js
+++ b/test/presenters/notices/setup/select-recipients.presenter.test.js
@@ -9,6 +9,7 @@ const { expect } = Code
 
 // Test helpers
 const RecipientsFixture = require('../../../fixtures/recipients.fixtures.js')
+const { generateReferenceCode } = require('../../../support/helpers/notification.helper.js')
 
 // Thing under test
 const SelectRecipientsPresenter = require('../../../../app/presenters/notices/setup/select-recipients.presenter.js')
@@ -23,7 +24,7 @@ describe('Notices - Setup - Select Recipients Presenter', () => {
   beforeEach(() => {
     recipients = RecipientsFixture.recipients()
 
-    referenceCode = 'RINV-CPFRQ4'
+    referenceCode = generateReferenceCode()
 
     selectedRecipients = [
       recipients.primaryUser.contact_hash_id,

--- a/test/requests/notify/create-precompiled-file.request.test.js
+++ b/test/requests/notify/create-precompiled-file.request.test.js
@@ -8,6 +8,9 @@ const Sinon = require('sinon')
 const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
+// Test helpers
+const { generateReferenceCode } = require('../../support/helpers/notification.helper.js')
+
 // Things we need to stub
 const NotifyRequest = require('../../../app/requests/notify.request.js')
 
@@ -16,7 +19,7 @@ const CreatePrecompiledFileRequest = require('../../../app/requests/notify/creat
 
 describe('Notify - Create precompiled file request', () => {
   let response
-  let reference
+  let referenceCode
   let content
 
   afterEach(() => {
@@ -25,7 +28,7 @@ describe('Notify - Create precompiled file request', () => {
 
   describe('when the request succeeds', () => {
     beforeEach(() => {
-      reference = 'test-123'
+      referenceCode = generateReferenceCode()
       content = new TextEncoder().encode('Test data').buffer
 
       response = {
@@ -33,7 +36,7 @@ describe('Notify - Create precompiled file request', () => {
         body: {
           id: 'f39a18b7-f12a-4149-9aad-da18d6972b48',
           postage: 'second',
-          reference: 'test-123'
+          reference: referenceCode
         }
       }
 
@@ -44,23 +47,23 @@ describe('Notify - Create precompiled file request', () => {
     })
 
     it('returns a "true" success status', async () => {
-      const result = await CreatePrecompiledFileRequest.send(content, reference)
+      const result = await CreatePrecompiledFileRequest.send(content, referenceCode)
 
       expect(result.succeeded).to.be.true()
     })
 
     it('returns the result from Notify in the "response"', async () => {
-      const result = await CreatePrecompiledFileRequest.send(content, reference)
+      const result = await CreatePrecompiledFileRequest.send(content, referenceCode)
 
       expect(result.response.body).to.equal(response.body)
     })
 
     it('calls NotifyRequest.post with the correct arguments', async () => {
-      await CreatePrecompiledFileRequest.send(content, reference)
+      await CreatePrecompiledFileRequest.send(content, referenceCode)
 
       expect(NotifyRequest.post.calledOnce).to.be.true()
       expect(NotifyRequest.post.firstCall.args[0]).to.equal('v2/notifications/letter')
-      expect(NotifyRequest.post.firstCall.args[1]).to.equal({ content: 'VGVzdCBkYXRh', reference: 'test-123' })
+      expect(NotifyRequest.post.firstCall.args[1]).to.equal({ content: 'VGVzdCBkYXRh', reference: referenceCode })
     })
   })
 
@@ -87,13 +90,13 @@ describe('Notify - Create precompiled file request', () => {
       })
 
       it('returns a "false" success status', async () => {
-        const result = await CreatePrecompiledFileRequest.send(content, reference)
+        const result = await CreatePrecompiledFileRequest.send(content, referenceCode)
 
         expect(result.succeeded).to.be.false()
       })
 
       it('returns the error in the "response"', async () => {
-        const result = await CreatePrecompiledFileRequest.send(content, reference)
+        const result = await CreatePrecompiledFileRequest.send(content, referenceCode)
 
         expect(result.response.body).to.equal(response.body)
       })

--- a/test/services/notices/setup/confirmation.service.test.js
+++ b/test/services/notices/setup/confirmation.service.test.js
@@ -10,12 +10,13 @@ const { expect } = Code
 
 // Test helpers
 const EventHelper = require('../../../support/helpers/event.helper.js')
+const { generateReferenceCode } = require('../../../support/helpers/notification.helper.js')
 
 // Thing under test
 const ConfirmationService = require('../../../../app/services/notices/setup/confirmation.service.js')
 
 describe('Notices - Setup - Confirmation service', () => {
-  const referenceCode = 'RINV-123'
+  const referenceCode = generateReferenceCode()
 
   let event
 
@@ -40,7 +41,7 @@ describe('Notices - Setup - Confirmation service', () => {
         forwardLink: `/notifications/report/${event.id}`,
         monitoringStationLink: null,
         pageTitle: 'Returns invitations sent',
-        referenceCode: 'RINV-123'
+        referenceCode
       })
     })
   })

--- a/test/services/notices/setup/create-notice.service.test.js
+++ b/test/services/notices/setup/create-notice.service.test.js
@@ -9,6 +9,7 @@ const { expect } = Code
 
 // Test helpers
 const EventModel = require('../../../../app/models/event.model.js')
+const { generateReferenceCode } = require('../../../support/helpers/notification.helper.js')
 
 // Thing under test
 const CreateNoticeService = require('../../../../app/services/notices/setup/create-notice.service.js')
@@ -34,7 +35,7 @@ describe('Notices - Setup - Create Notice service', () => {
   })
 
   describe('when the notice is for a returns notification', () => {
-    const referenceCode = 'ABC-123'
+    const referenceCode = generateReferenceCode()
 
     beforeEach(() => {
       event = {
@@ -79,7 +80,7 @@ describe('Notices - Setup - Create Notice service', () => {
           },
           sent: 2783
         },
-        referenceCode: 'ABC-123',
+        referenceCode,
         status: 'started',
         subtype: 'returnInvitation',
         type: 'notification',

--- a/test/services/notices/setup/download-recipients.service.test.js
+++ b/test/services/notices/setup/download-recipients.service.test.js
@@ -9,14 +9,15 @@ const { describe, it, afterEach, before } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
+const AbstractionAlertSessionData = require('../../../fixtures/abstraction-alert-session-data.fixture.js')
 const FetchAbstractionAlertRecipientsService = require('../../../../app/services/notices/setup/fetch-abstraction-alert-recipients.service.js')
 const FetchDownloadRecipientsService = require('../../../../app/services/notices/setup/fetch-download-recipients.service.js')
+const RecipientsFixture = require('../../../fixtures/recipients.fixtures.js')
 const SessionHelper = require('../../../support/helpers/session.helper.js')
+const { generateReferenceCode } = require('../../../support/helpers/notification.helper.js')
 
 // Thing under test
 const DownloadRecipientsService = require('../../../../app/services/notices/setup/download-recipients.service.js')
-const AbstractionAlertSessionData = require('../../../fixtures/abstraction-alert-session-data.fixture.js')
-const RecipientsFixture = require('../../../fixtures/recipients.fixtures.js')
 
 describe('Notices - Setup - Download Recipients service', () => {
   let referenceCode
@@ -32,7 +33,7 @@ describe('Notices - Setup - Download Recipients service', () => {
 
     before(async () => {
       removeLicences = ''
-      referenceCode = 'RREM-00R1MQ'
+      referenceCode = generateReferenceCode('RREM')
 
       session = await SessionHelper.add({
         data: { returnsPeriod: 'quarterFour', referenceCode, notificationType: 'Returns reminder', removeLicences }
@@ -62,7 +63,7 @@ describe('Notices - Setup - Download Recipients service', () => {
 
     before(async () => {
       removeLicences = ''
-      referenceCode = 'RREM-00R1MQ'
+      referenceCode = generateReferenceCode('RREM')
 
       session = await SessionHelper.add({
         data: {
@@ -106,7 +107,7 @@ describe('Notices - Setup - Download Recipients service', () => {
           recipients.licenceHolder.licence_refs
         ])
 
-        referenceCode = 'WAA-123'
+        referenceCode = generateReferenceCode('WAA')
 
         session = await SessionHelper.add({
           data: {
@@ -169,7 +170,7 @@ describe('Notices - Setup - Download Recipients service', () => {
           }
         ]
 
-        referenceCode = 'WAA-123'
+        referenceCode = generateReferenceCode('WAA')
 
         session = await SessionHelper.add({
           data: {

--- a/test/services/notices/setup/select-recipients.service.test.js
+++ b/test/services/notices/setup/select-recipients.service.test.js
@@ -11,6 +11,7 @@ const { expect } = Code
 // Test helpers
 const RecipientsFixture = require('../../../fixtures/recipients.fixtures.js')
 const SessionHelper = require('../../../support/helpers/session.helper.js')
+const { generateReferenceCode } = require('../../../support/helpers/notification.helper.js')
 
 // Things we need to stub
 const FetchRecipientsService = require('../../../../app/services/notices/setup/fetch-recipients.service.js')
@@ -27,7 +28,7 @@ describe('Notices - Setup - Select Recipients Service', () => {
   beforeEach(async () => {
     recipients = RecipientsFixture.recipients()
 
-    referenceCode = 'RINV-CPFRQ4'
+    referenceCode = generateReferenceCode()
 
     sessionData = {
       referenceCode,
@@ -53,7 +54,7 @@ describe('Notices - Setup - Select Recipients Service', () => {
           text: 'Back'
         },
         pageTitle: 'Select Recipients',
-        pageTitleCaption: `Notice RINV-CPFRQ4`,
+        pageTitleCaption: `Notice ${referenceCode}`,
         recipients: [
           {
             checked: true,

--- a/test/services/notices/setup/submit-select-recipients.service.test.js
+++ b/test/services/notices/setup/submit-select-recipients.service.test.js
@@ -11,6 +11,7 @@ const { expect } = Code
 // Test helpers
 const RecipientsFixture = require('../../../fixtures/recipients.fixtures.js')
 const SessionHelper = require('../../../support/helpers/session.helper.js')
+const { generateReferenceCode } = require('../../../support/helpers/notification.helper.js')
 
 // Things we need to stub
 const FetchRecipientsService = require('../../../../app/services/notices/setup/fetch-recipients.service.js')
@@ -29,7 +30,7 @@ describe('Notices - Setup - Submit Select Recipients Service', () => {
   beforeEach(async () => {
     payload = { recipients: ['123'] }
 
-    referenceCode = 'RINV-CPFRQ4'
+    referenceCode = generateReferenceCode()
 
     sessionData = { referenceCode }
 
@@ -102,7 +103,7 @@ describe('Notices - Setup - Submit Select Recipients Service', () => {
           },
 
           pageTitle: 'Select Recipients',
-          pageTitleCaption: `Notice RINV-CPFRQ4`,
+          pageTitleCaption: `Notice ${referenceCode}`,
           recipients: [
             {
               checked: false,

--- a/test/support/helpers/notification.helper.js
+++ b/test/support/helpers/notification.helper.js
@@ -5,6 +5,7 @@
  */
 
 const NotificationModel = require('../../../app/models/notification.model.js')
+const { generateRandomInteger } = require('../../../app/lib/general.lib.js')
 
 /**
  * Add a new notification
@@ -50,7 +51,7 @@ function defaults(data = {}) {
  * @returns {string} - A randomly generated reference code
  */
 function generateReferenceCode(prefix = 'RINV') {
-  return `${prefix}-${Math.floor(1000 + Math.random() * 9000).toString()}`
+  return `${prefix}-${generateRandomInteger(100000, 999999)}`
 }
 
 module.exports = {


### PR DESCRIPTION
We have been hard coding the notice reference code.

We previously introduced a 'generateReferenceCode' helper.

This change updates the notice tests to use the 'generateReferenceCode' function.