### PR TITLE
Update scaffold view.njk template to use page content

### DIFF
--- a/templates/presenter.js
+++ b/templates/presenter.js
@@ -11,7 +11,13 @@
  * @returns {object} - The data formatted for the view template
  */
 function go() {
-  return {}
+  return {
+    backLink: {
+      href: '',
+      text: 'Back'
+    },
+    pageTitle: ''
+  }
 }
 
 module.exports = {

--- a/templates/presenter.test.js
+++ b/templates/presenter.test.js
@@ -21,7 +21,13 @@ describe('__DESCRIBE_LABEL__', () => {
     it('returns page data for the view', () => {
       const result = __MODULE_NAME__.go(session)
 
-      expect(result).to.equal({})
+      expect(result).to.equal({
+        backLink: {
+          href: '',
+          text: 'Back'
+        },
+        pageTitle: ''
+      })
     })
   })
 })

--- a/templates/submit.service.test.js
+++ b/templates/submit.service.test.js
@@ -45,7 +45,13 @@ describe('__DESCRIBE_LABEL__', () => {
     it('returns page data for the view, with errors', async () => {
       const result = await __MODULE_NAME__.go(session.id, payload)
 
-      expect(result).to.equal({})
+      expect(result).to.equal({
+        backLink: {
+          href: '',
+          text: 'Back'
+        },
+        pageTitle: ''
+      })
     })
   })
 })

--- a/templates/view.njk
+++ b/templates/view.njk
@@ -1,26 +1,8 @@
 {% extends 'layout.njk' %}
 
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
-{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 
-{% block breadcrumbs %}
-  {{
-  govukBackLink({
-    text: 'Back',
-    href: backLink
-  })
-  }}
-{% endblock %}
-
-{% block content %}
-  {% if error %}
-    {{ govukErrorSummary({
-      titleText: "There is a problem",
-      errorList: error.errorList
-    }) }}
-  {%endif%}
-
+{% block pageContent %}
   <form method="post">
     <input type="hidden" name="wrlsCrumb" value="{{wrlsCrumb}}"/>
 


### PR DESCRIPTION
We recently updated the layout.njk to provide the error summary and backlink to all pages.

To keep the existing pages working, we added the 'pageContent' block inside the content block.

The content block still overrides all the content as before. But when you use the 'pageContent' block, we provide the error summary and backlink.

This change updates the view.njk to use the 'pageContent' block. This means we can remove the error summary and backlink macros from the template.

This change also updates the presenter to provide the backlink and page title as these are common on every page the scaffold is designed to be used for.