### PR TITLE
Add a callback url for GovNotify

### DIFF
--- a/app/controllers/callbacks.controller.js
+++ b/app/controllers/callbacks.controller.js
@@ -1,0 +1,33 @@
+'use strict'
+
+/**
+ * Controller for /callbacks endpoints
+ * @module CallbacksController
+ */
+
+const NO_CONTENT_STATUS_CODE = 204
+
+/**
+ * If a letter has been returned to notify this end point will be called
+ *
+ * @param request - the hapi request object
+ * @param h - the hapi response object
+ *
+ * @returns {Promise<object>} - A promise that resolves to an HTTP response object with a 204 status code
+ */
+async function returnedLetter(request, h) {
+  console.log('AUTH DEBUG:', request.auth)
+  try {
+    console.log(request.payload)
+    const { notification_id: notificationId, reference } = request.payload
+    global.GlobalNotifier.omg('Return letter callback triggered', { notificationId, reference })
+  } catch (error) {
+    console.log(error)
+  }
+
+  return h.response().code(NO_CONTENT_STATUS_CODE)
+}
+
+module.exports = {
+  returnedLetter
+}

--- a/app/plugins/router.plugin.js
+++ b/app/plugins/router.plugin.js
@@ -19,6 +19,7 @@ const BillRunRoutes = require('../routes/bill-runs.routes.js')
 const BillRunReviewRoutes = require('../routes/bill-runs-review.routes.js')
 const BillRunSetupRoutes = require('../routes/bill-runs-setup.routes.js')
 const BillingAccountRoutes = require('../routes/billing-accounts.routes.js')
+const CallbackRoutes = require('../routes/callbacks.routes.js')
 const CheckRoutes = require('../routes/check.routes.js')
 const DataRoutes = require('../routes/data.routes.js')
 const FilterRoutesService = require('../services/plugins/filter-routes.service.js')
@@ -53,6 +54,7 @@ const routes = [
   ...BillRunReviewRoutes,
   ...BillRunSetupRoutes,
   ...BillingAccountRoutes,
+  ...CallbackRoutes,
   ...CheckRoutes,
   ...NotificationRoutes,
   ...LicenceRoutes,

--- a/app/routes/callbacks.routes.js
+++ b/app/routes/callbacks.routes.js
@@ -1,0 +1,22 @@
+'use strict'
+
+const CallbackController = require('../controllers/callbacks.controller.js')
+
+const routes = [
+  {
+    method: 'POST',
+    path: '/callback/returned-letter',
+    options: {
+      app: {
+        plainOutput: true
+      },
+      auth: { strategy: 'callback' },
+      handler: CallbackController.returnedLetter,
+      plugins: {
+        crumb: false
+      }
+    }
+  }
+]
+
+module.exports = routes

--- a/app/server.js
+++ b/app/server.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const Hapi = require('@hapi/hapi')
+const Bearer = require('hapi-auth-bearer-token')
 
 const AirbrakePlugin = require('./plugins/airbrake.plugin.js')
 const AuthPlugin = require('./plugins/auth.plugin.js')
@@ -27,6 +28,7 @@ const registerPlugins = async (server) => {
   await server.register(require('@hapi/inert'))
   await server.register(require('@hapi/cookie'))
   await server.register(YarPlugin)
+  await server.register(Bearer)
   await server.register(AuthPlugin)
   await server.register(RouterPlugin)
   await server.register(HapiPinoPlugin())

--- a/config/notify.config.js
+++ b/config/notify.config.js
@@ -16,6 +16,7 @@ const config = {
   // of the two limitations, which in this case is the 250-message status retrieval limit from Notify.
   // https://docs.notifications.service.gov.uk/node.html#get-the-status-of-multiple-messages
   batchSize: parseInt(process.env.NOTIFICATIONS_BATCH_SIZE) || 250,
+  callbackToken: process.env.GOV_UK_NOTIFY_AUTH_TOKEN,
   // In conjunction with the rate limit mentioned above, we have set a delay between requests to notify. This is
   // defaulted to 10 seconds.
   delay: parseInt(process.env.NOTIFICATIONS_BATCH_DELAY) || 10000,

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "dotenv": "^17.2.1",
         "got": "^14.4.7",
         "govuk-frontend": "^4.7.0",
+        "hapi-auth-bearer-token": "^8.0.0",
         "hapi-pino": "^12.1.0",
         "hpagent": "^1.2.0",
         "ioredis": "^5.3.2",
@@ -6869,6 +6870,27 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/hapi-auth-bearer-token": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/hapi-auth-bearer-token/-/hapi-auth-bearer-token-8.0.0.tgz",
+      "integrity": "sha512-1YeUlwhhky8tnNx9bOQPB/TvsEwbgcYwAZ6DAvHlK+tHRiMbXU+2HNE8qpRia+oj21W2K/omaxyZIB5dOzTPoA==",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "peerDependencies": {
+        "@hapi/boom": ">=7.x.x",
+        "@hapi/hapi": ">=19.x.x",
+        "joi": ">=17.x.x"
+      }
+    },
+    "node_modules/hapi-auth-bearer-token/node_modules/@hapi/hoek": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
     },
     "node_modules/hapi-pino": {
       "version": "12.1.0",
@@ -15756,6 +15778,21 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
+        }
+      }
+    },
+    "hapi-auth-bearer-token": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/hapi-auth-bearer-token/-/hapi-auth-bearer-token-8.0.0.tgz",
+      "integrity": "sha512-1YeUlwhhky8tnNx9bOQPB/TvsEwbgcYwAZ6DAvHlK+tHRiMbXU+2HNE8qpRia+oj21W2K/omaxyZIB5dOzTPoA==",
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "9.3.0",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+          "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "dotenv": "^17.2.1",
     "got": "^14.4.7",
     "govuk-frontend": "^4.7.0",
+    "hapi-auth-bearer-token": "^8.0.0",
     "hapi-pino": "^12.1.0",
     "hpagent": "^1.2.0",
     "ioredis": "^5.3.2",

--- a/test/controllers/callbacks.controller.test.js
+++ b/test/controllers/callbacks.controller.test.js
@@ -1,0 +1,92 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { describe, it, before, beforeEach, afterEach } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// For running our service
+const { init } = require('../../app/server.js')
+
+describe.only('Callbacks controller', () => {
+  let notifierStub
+  let options
+  let server
+
+  // Create server before running the tests
+  before(async () => {
+    server = await init()
+  })
+
+  beforeEach(async () => {
+    // We silence any calls to server.logger.error and info to try and keep the test output as clean as possible
+    Sinon.stub(server.logger, 'error')
+    Sinon.stub(server.logger, 'info')
+
+    // We silence sending a notification to our Errbit instance using Airbrake
+    Sinon.stub(server.app.airbrake, 'notify').resolvesThis()
+
+    notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
+    global.GlobalNotifier = notifierStub
+  })
+
+  afterEach(() => {
+    Sinon.restore()
+  })
+
+  describe('/callback/returned-letter', () => {
+    describe('POST', () => {
+      describe('when the request has valid authorization', () => {
+        beforeEach(() => {
+          options = {
+            headers: {
+              authorization: `Bearer ${process.env.GOV_UK_NOTIFY_AUTH_TOKEN}`
+            },
+            method: 'POST',
+            payload: {
+              notification_id: '506c20c7-7741-4c95-85c1-de3fe87314f3',
+              reference: 'reference'
+            },
+            url: '/callback/returned-letter'
+          }
+        })
+
+        it('returns a 204 response', async () => {
+          const response = await server.inject(options)
+
+          const logDataArg = notifierStub.omg.args[0][1]
+
+          expect(response.statusCode).to.equal(204)
+          expect(notifierStub.omg.calledWith('Return letter callback triggered')).to.be.true()
+          expect(logDataArg.notificationId).to.equal('506c20c7-7741-4c95-85c1-de3fe87314f3')
+          expect(logDataArg.reference).to.equal('reference')
+        })
+      })
+
+      describe('when the request has an invalid authorization', () => {
+        beforeEach(() => {
+          options = {
+            headers: {
+              authorization: 'Bearer wrong'
+            },
+            method: 'POST',
+            payload: {
+              notification_id: '506c20c7-7741-4c95-85c1-de3fe87314f3',
+              reference: 'reference'
+            },
+            url: '/callback/returned-letter'
+          }
+        })
+
+        it('returns a 404 response', async () => {
+          const response = await server.inject(options)
+
+          expect(response.statusCode).to.equal(404)
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5241

As part of the service for printing and sending letters GovNoitfy also enables you to be notified when a letter has been returned to them due to failure to deliver or return to sender. This PR is creating the callback end point to be used by GovNotify. At first it will just log a message to our logging system to prove connectivity. 