### PR TITLE
Update abstraction alerts show all recipients to have a data tag

### DIFF
--- a/app/views/notices/setup/check.njk
+++ b/app/views/notices/setup/check.njk
@@ -75,9 +75,9 @@
     </div>
 
     {% if pagination.numberOfPages > 1 %}
-      <p> Showing {{ defaultPageSize }} of {{ recipientsAmount }} recipients </p>
+      <p data-test="recipients-count"> Showing {{ defaultPageSize }} of {{ recipientsAmount }} recipients </p>
     {% else %}
-      <p> Showing all {{ recipientsAmount }} recipients </p>
+      <p data-test="recipients-count"> Showing all {{ recipientsAmount }} recipients </p>
     {% endif %}
 
     {{ govukTable({


### PR DESCRIPTION
We recently updated our layout to provide another block 'pageContent'. When this was done, we did a little clean-up of stray (and necessary) '.govuk-body' divs.

This change updates the <p> tag to have the 'data-test="recipients-count"' data attribute.