### PR TITLE
Add logic to create return forms notifications

### DIFF
--- a/app/services/notices/setup/determine-return-forms.service.js
+++ b/app/services/notices/setup/determine-return-forms.service.js
@@ -1,0 +1,59 @@
+'use strict'
+
+/**
+ * Determines the PDF return forms data to send to notify and save to the database
+ * @module DetermineReturnFormsService
+ */
+
+const PrepareReturnFormsPresenter = require('../../../presenters/notices/setup/prepare-return-forms.presenter.js')
+const PrepareReturnFormsService = require('./prepare-return-forms.service.js')
+
+/**
+ * Determines the PDF return forms data to send to notify and save to the database
+ *
+ * @param {object} session - The session instance
+ * @param {object[]} recipients - List of recipient objects, each containing recipient details like email / address.
+ * @param {string} eventId - the event id to link all the notifications to an event
+ *
+ * @returns {Promise<{}>} - Resolves an array of return forms notifications
+ */
+async function go(session, recipients, eventId) {
+  const { licenceRef, dueReturns, selectedReturns } = session
+
+  const dueReturnLogs = _dueReturnLog(dueReturns, selectedReturns)
+
+  const notifications = []
+
+  for (const dueReturn of dueReturnLogs) {
+    for (const recipient of recipients) {
+      const returnForm = await PrepareReturnFormsService.go(licenceRef, dueReturn, recipient)
+
+      const pageData = PrepareReturnFormsPresenter.go(licenceRef, dueReturn, recipient)
+
+      notifications.push({
+        content: returnForm,
+        personalisation: pageData,
+        eventId
+      })
+    }
+  }
+
+  return notifications
+}
+
+/**
+ * The user has to select at least one return. This will be set in the 'selectedReturns' array as the return id.
+ *
+ * So we will always expect this to work.
+ *
+ * @private
+ */
+function _dueReturnLog(dueReturns, selectedReturns) {
+  return dueReturns.filter((dueReturn) => {
+    return selectedReturns.includes(dueReturn.returnId)
+  })
+}
+
+module.exports = {
+  go
+}

--- a/app/services/notices/setup/determine-return-forms.service.js
+++ b/app/services/notices/setup/determine-return-forms.service.js
@@ -15,7 +15,7 @@ const PrepareReturnFormsService = require('./prepare-return-forms.service.js')
  * @param {object[]} recipients - List of recipient objects, each containing recipient details like email / address.
  * @param {string} eventId - the event id to link all the notifications to an event
  *
- * @returns {Promise<{}>} - Resolves an array of return forms notifications
+ * @returns {Promise<object[]>} - Resolves an array of return forms notifications
  */
 async function go(session, recipients, eventId) {
   const { licenceRef, dueReturns, selectedReturns } = session

--- a/test/services/notices/setup/determine-return-forms.service.test.js
+++ b/test/services/notices/setup/determine-return-forms.service.test.js
@@ -146,7 +146,7 @@ describe('Notices - Setup - Determine Return Forms Service', () => {
         session.selectedReturns.push(additionalDueReturn.returnId)
       })
 
-      it('returns notifications with all the recipient for multiple due return log', async () => {
+      it('returns a notification for each combination of recipient and selected due return log', async () => {
         const result = await DetermineReturnFormsService.go(session, testRecipients, eventId)
 
         expect(result).to.equal([

--- a/test/services/notices/setup/determine-return-forms.service.test.js
+++ b/test/services/notices/setup/determine-return-forms.service.test.js
@@ -81,7 +81,7 @@ describe('Notices - Setup - Determine Return Forms Service', () => {
 
   describe('when called', () => {
     describe('and there is one due return log selected', () => {
-      it('returns notifications with all the recipient for the due return log', async () => {
+      it('returns a notification for each combination of recipient and selected due return log', async () => {
         const result = await DetermineReturnFormsService.go(session, testRecipients, eventId)
 
         expect(result).to.equal([

--- a/test/services/notices/setup/determine-return-forms.service.test.js
+++ b/test/services/notices/setup/determine-return-forms.service.test.js
@@ -19,7 +19,7 @@ const PrepareReturnFormsService = require('../../../../app/services/notices/setu
 // Thing under test
 const DetermineReturnFormsService = require('../../../../app/services/notices/setup/determine-return-forms.service.js')
 
-describe.only('Notices - Setup - Determine Return Forms Service', () => {
+describe('Notices - Setup - Determine Return Forms Service', () => {
   const eventId = generateUUID()
 
   let additionalDueReturn

--- a/test/services/notices/setup/determine-return-forms.service.test.js
+++ b/test/services/notices/setup/determine-return-forms.service.test.js
@@ -1,0 +1,261 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Test helpers
+const RecipientsFixture = require('../../../fixtures/recipients.fixtures.js')
+const SessionHelper = require('../../../support/helpers/session.helper.js')
+const { generateUUID } = require('../../../../app/lib/general.lib.js')
+
+// Things we need to stub
+const PrepareReturnFormsService = require('../../../../app/services/notices/setup/prepare-return-forms.service.js')
+
+// Thing under test
+const DetermineReturnFormsService = require('../../../../app/services/notices/setup/determine-return-forms.service.js')
+
+describe.only('Notices - Setup - Determine Return Forms Service', () => {
+  const eventId = generateUUID()
+
+  let additionalDueReturn
+  let buffer
+  let dueReturnLog
+  let recipients
+  let session
+  let sessionData
+  let testRecipients
+
+  beforeEach(async () => {
+    recipients = RecipientsFixture.recipients()
+    testRecipients = [recipients.licenceHolder, recipients.returnsTo]
+
+    dueReturnLog = {
+      dueDate: '2025-07-06',
+      endDate: '2025-06-06',
+      naldAreaCode: 'MIDLT',
+      purpose: 'A purpose',
+      regionName: 'North West',
+      returnId: '1234',
+      returnReference: '123456',
+      returnsFrequency: 'day',
+      siteDescription: 'Water park',
+      startDate: '2025-01-01',
+      twoPartTariff: false
+    }
+
+    additionalDueReturn = {
+      dueDate: '2025-07-06',
+      endDate: '2025-06-06',
+      naldAreaCode: 'MIDLT',
+      purpose: 'A purpose',
+      regionName: 'North West',
+      returnId: '5678',
+      returnReference: '568907',
+      returnsFrequency: 'day',
+      siteDescription: 'Water park',
+      startDate: '2025-01-01',
+      twoPartTariff: false
+    }
+
+    sessionData = {
+      licenceRef: '123',
+      dueReturns: [dueReturnLog, additionalDueReturn],
+      selectedReturns: [dueReturnLog.returnId]
+    }
+
+    session = await SessionHelper.add({ data: sessionData })
+
+    buffer = new TextEncoder().encode('mock file').buffer
+
+    Sinon.stub(PrepareReturnFormsService, 'go').resolves(buffer)
+  })
+
+  afterEach(() => {
+    Sinon.restore()
+  })
+
+  describe('when called', () => {
+    describe('and there is one due return log selected', () => {
+      it('returns notifications with all the recipient for the due return log', async () => {
+        const result = await DetermineReturnFormsService.go(session, testRecipients, eventId)
+
+        expect(result).to.equal([
+          {
+            content: buffer,
+            personalisation: {
+              address: {
+                address_line_1: 'Mr H J Licence holder',
+                address_line_2: '1',
+                address_line_3: 'Privet Drive',
+                address_line_4: 'Little Whinging',
+                address_line_5: 'Surrey',
+                address_line_6: 'WD25 7LR'
+              },
+              dueDate: '6 July 2025',
+              endDate: '6 June 2025',
+              licenceRef: '123',
+              pageEntries: result[0].personalisation.pageEntries,
+              pageTitle: 'Water abstraction daily return',
+              purpose: 'A purpose',
+              regionAndArea: 'North West / Lower Trent',
+              returnReference: '123456',
+              returnsFrequency: 'day',
+              siteDescription: 'Water park',
+              startDate: '1 January 2025',
+              twoPartTariff: false
+            },
+            eventId
+          },
+          {
+            content: buffer,
+            personalisation: {
+              address: {
+                address_line_1: 'Mr H J Returns to',
+                address_line_2: 'INVALID ADDRESS - Needs a valid postcode or country outside the UK',
+                address_line_3: '2',
+                address_line_4: 'Privet Drive',
+                address_line_5: 'Little Whinging',
+                address_line_6: 'Surrey'
+              },
+              dueDate: '6 July 2025',
+              endDate: '6 June 2025',
+              licenceRef: '123',
+              pageEntries: result[1].personalisation.pageEntries,
+              pageTitle: 'Water abstraction daily return',
+              purpose: 'A purpose',
+              regionAndArea: 'North West / Lower Trent',
+              returnReference: '123456',
+              returnsFrequency: 'day',
+              siteDescription: 'Water park',
+              startDate: '1 January 2025',
+              twoPartTariff: false
+            },
+            eventId
+          }
+        ])
+      })
+    })
+
+    describe('and there are multiple due return log selected', () => {
+      beforeEach(() => {
+        session.selectedReturns.push(additionalDueReturn.returnId)
+      })
+
+      it('returns notifications with all the recipient for multiple due return log', async () => {
+        const result = await DetermineReturnFormsService.go(session, testRecipients, eventId)
+
+        expect(result).to.equal([
+          {
+            content: buffer,
+            personalisation: {
+              address: {
+                address_line_1: 'Mr H J Licence holder',
+                address_line_2: '1',
+                address_line_3: 'Privet Drive',
+                address_line_4: 'Little Whinging',
+                address_line_5: 'Surrey',
+                address_line_6: 'WD25 7LR'
+              },
+              dueDate: '6 July 2025',
+              endDate: '6 June 2025',
+              licenceRef: '123',
+              pageEntries: result[0].personalisation.pageEntries,
+              pageTitle: 'Water abstraction daily return',
+              purpose: 'A purpose',
+              regionAndArea: 'North West / Lower Trent',
+              returnReference: '123456',
+              returnsFrequency: 'day',
+              siteDescription: 'Water park',
+              startDate: '1 January 2025',
+              twoPartTariff: false
+            },
+            eventId
+          },
+          {
+            content: buffer,
+            personalisation: {
+              address: {
+                address_line_1: 'Mr H J Returns to',
+                address_line_2: 'INVALID ADDRESS - Needs a valid postcode or country outside the UK',
+                address_line_3: '2',
+                address_line_4: 'Privet Drive',
+                address_line_5: 'Little Whinging',
+                address_line_6: 'Surrey'
+              },
+              dueDate: '6 July 2025',
+              endDate: '6 June 2025',
+              licenceRef: '123',
+              pageEntries: result[1].personalisation.pageEntries,
+              pageTitle: 'Water abstraction daily return',
+              purpose: 'A purpose',
+              regionAndArea: 'North West / Lower Trent',
+              returnReference: '123456',
+              returnsFrequency: 'day',
+              siteDescription: 'Water park',
+              startDate: '1 January 2025',
+              twoPartTariff: false
+            },
+            eventId
+          },
+          {
+            content: buffer,
+            personalisation: {
+              address: {
+                address_line_1: 'Mr H J Licence holder',
+                address_line_2: '1',
+                address_line_3: 'Privet Drive',
+                address_line_4: 'Little Whinging',
+                address_line_5: 'Surrey',
+                address_line_6: 'WD25 7LR'
+              },
+              dueDate: '6 July 2025',
+              endDate: '6 June 2025',
+              licenceRef: '123',
+              pageEntries: result[2].personalisation.pageEntries,
+              pageTitle: 'Water abstraction daily return',
+              purpose: 'A purpose',
+              regionAndArea: 'North West / Lower Trent',
+              returnReference: '568907',
+              returnsFrequency: 'day',
+              siteDescription: 'Water park',
+              startDate: '1 January 2025',
+              twoPartTariff: false
+            },
+            eventId
+          },
+          {
+            content: buffer,
+            personalisation: {
+              address: {
+                address_line_1: 'Mr H J Returns to',
+                address_line_2: 'INVALID ADDRESS - Needs a valid postcode or country outside the UK',
+                address_line_3: '2',
+                address_line_4: 'Privet Drive',
+                address_line_5: 'Little Whinging',
+                address_line_6: 'Surrey'
+              },
+              dueDate: '6 July 2025',
+              endDate: '6 June 2025',
+              licenceRef: '123',
+              pageEntries: result[3].personalisation.pageEntries,
+              pageTitle: 'Water abstraction daily return',
+              purpose: 'A purpose',
+              regionAndArea: 'North West / Lower Trent',
+              returnReference: '568907',
+              returnsFrequency: 'day',
+              siteDescription: 'Water park',
+              startDate: '1 January 2025',
+              twoPartTariff: false
+            },
+            eventId
+          }
+        ])
+      })
+    })
+  })
+})


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5226

We have previously added the ability to preview the return forms. When we implemented this, we added the service cal to gutenberg and returned the file (buffer) to the preview service to display.

We are now ready to start sending the PDF file to notify.

To send the PDF file, we need to generate the file for every recipient (this could be many), we need to do this per due return log (that the user has selected).

So we first need to iterate over the selected due return logs and then the recipients to create the notification data.

This change implements this logic only.

We will add the specific notification data in a later change, in the form of a presenter.

This will allow us to use our existing batch notification service.