### PR TITLE
Clean up notice logic before adding return forms

### DIFF
--- a/app/presenters/notices/setup/notify-update.presenter.js
+++ b/app/presenters/notices/setup/notify-update.presenter.js
@@ -26,7 +26,7 @@ function go(notifyResult) {
     return {
       notifyId: response.body.id,
       notifyStatus: 'created',
-      plaintext: response.body.content.body,
+      plaintext: response.body.content?.body,
       status: 'pending'
     }
   }

--- a/app/services/notices/setup/fetch-returns-due-by-licence-ref.service.js
+++ b/app/services/notices/setup/fetch-returns-due-by-licence-ref.service.js
@@ -24,6 +24,7 @@ async function go(licenceRef) {
 async function _fetch(licenceRef) {
   const query = `
     SELECT
+      rl.id as id,
       rl.due_date AS "dueDate",
       rl.end_date AS "endDate",
       rl.return_id AS "returnId",

--- a/app/services/notices/setup/submit-check.service.js
+++ b/app/services/notices/setup/submit-check.service.js
@@ -25,7 +25,7 @@ const { currentTimeInNanoseconds, calculateAndLogTimeTaken } = require('../../..
 async function go(sessionId, auth) {
   const session = await SessionModel.query().findById(sessionId)
 
-  const recipients = await FetchRecipientsService.go(session, false)
+  const recipients = await FetchRecipientsService.go(session)
 
   const notice = await _notice(session, recipients, auth)
 

--- a/test/services/notices/setup/fetch-recipients.service.test.js
+++ b/test/services/notices/setup/fetch-recipients.service.test.js
@@ -82,7 +82,7 @@ describe('Notices - Setup - Fetch recipients service', () => {
         })
 
         it('returns only the selected recipients formatted for display', async () => {
-          const result = await FetchRecipientsService.go(session, false)
+          const result = await FetchRecipientsService.go(session)
 
           expect(result).to.equal([
             {
@@ -126,7 +126,7 @@ describe('Notices - Setup - Fetch recipients service', () => {
         })
 
         it('returns all the recipients formatted for display', async () => {
-          const result = await FetchRecipientsService.go(session, false)
+          const result = await FetchRecipientsService.go(session)
 
           expect(result).to.equal([
             {

--- a/test/services/notices/setup/fetch-returns-due-by-licence-ref.service.test.js
+++ b/test/services/notices/setup/fetch-returns-due-by-licence-ref.service.test.js
@@ -63,6 +63,7 @@ describe('Notices - Setup - Fetch Returns Due By Licence Ref service', () => {
         {
           dueDate: new Date('2023-04-28'),
           endDate: new Date('2023-03-31'),
+          id: returnLog.id,
           naldAreaCode: 'SE',
           purpose: 'Potable Water Supply - Direct',
           regionName: region.displayName,


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5226

We have spotted a few issues when developing the return forms notice journey.

This change updates the Notify update presenter to all the body content to be empty. This is because the return forms letter does not return any content.

This change also adds the return log id for the 'FetchReturnsDueByLicenceRefService'. This id will be used in the saving of the notification.

This change also removes some straggling 'false' flags we previously used in 'FetchRecipientsService'. This is no longer needed.