### PR TITLE
Set return logs `updatedAt` when received or submitted

### DIFF
--- a/app/services/return-logs/setup/submit-check.service.js
+++ b/app/services/return-logs/setup/submit-check.service.js
@@ -7,6 +7,7 @@
 
 const CreateReturnLinesService = require('./create-return-lines.service.js')
 const CreateReturnSubmissionService = require('./create-return-submission.service.js')
+const { timestampForPostgres } = require('../../../lib/general.lib.js')
 const GenerateReturnSubmissionMetadata = require('./generate-return-submission-metadata.service.js')
 const ReturnLogModel = require('../../../models/return-log.model.js')
 const SessionModel = require('../../../models/session.model.js')
@@ -60,7 +61,9 @@ async function go(sessionId, user) {
 }
 
 async function _markReturnLogAsSubmitted(returnLogId, receivedDate, trx) {
-  await ReturnLogModel.query(trx).patch({ status: 'completed', receivedDate }).where({ id: returnLogId })
+  await ReturnLogModel.query(trx)
+    .patch({ status: 'completed', receivedDate, updatedAt: timestampForPostgres() })
+    .where({ id: returnLogId })
 }
 
 async function _cleanupSession(sessionId, trx) {

--- a/test/services/return-logs/setup/submit-check.service.test.js
+++ b/test/services/return-logs/setup/submit-check.service.test.js
@@ -117,6 +117,13 @@ describe('Return Logs Setup - Submit Check service', () => {
       expect(updatedReturnLog.receivedDate).to.equal(new Date('2024-01-01'))
     })
 
+    it('updates the return log updatedAt date', async () => {
+      await SubmitCheckService.go(session.id, user)
+
+      const updatedReturnLog = await ReturnLogModel.query().findById(returnLog.id)
+      expect(updatedReturnLog.updatedAt).to.not.equal(returnLog.updatedAt)
+    })
+
     it('calls CreateReturnSubmissionService with correct parameters', async () => {
       it('deletes the session', async () => {
         await SubmitCheckService.go(session.id, user)


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5256

It has been noticed that a return logs `updatedAt` field is not being updated when a return log is recorded as being received or submitted.

This PR will fix this issue by ensuring that the `updatedAt` field gets updated when a return log is recorded as received or submitted.

No work was required to fix the `updatedAt` field when the return log was recorded as being received as this was actually working (see line 52 in `app/services/return-logs/setup/submit-submission.service.js`). It just wasn't working when the return was submitted.