### PR TITLE
Fix WAA being sent to old/removed contacts

### DIFF
--- a/app/services/notices/setup/fetch-abstraction-alert-recipients.service.js
+++ b/app/services/notices/setup/fetch-abstraction-alert-recipients.service.js
@@ -74,15 +74,13 @@ function _query() {
   WITH additional_contacts AS (
     SELECT
       DISTINCT
-      ldh.licence_ref,
+      ld.licence_ref,
       'Additional contact' AS contact_type,
       con.email,
       NULL::jsonb AS contact,
       md5(LOWER(con.email)) AS contact_hash_id
     FROM
-      public.licence_document_headers ldh
-      INNER JOIN public.licence_documents ld
-        ON ld.licence_ref = ldh.licence_ref
+      public.licence_documents ld
       INNER JOIN public.licence_document_roles ldr
         ON ldr.licence_document_id = ld.id
       INNER JOIN public.company_contacts cct
@@ -92,7 +90,11 @@ function _query() {
       INNER JOIN public.licence_roles lr
         ON lr.id = cct.licence_role_id
     WHERE
-      ldh.licence_ref = ANY (?)
+      ld.licence_ref = ANY (?)
+      AND (
+      ldr.end_date IS NULL
+        OR ldr.end_date >= CURRENT_DATE
+      )
       AND cct.abstraction_alerts = true
   ),
 

--- a/test/services/notices/setup/fetch-abstraction-alert-recipients.service.test.js
+++ b/test/services/notices/setup/fetch-abstraction-alert-recipients.service.test.js
@@ -17,8 +17,6 @@ const LicenceRoleHelper = require('../../../support/helpers/licence-role.helper.
 
 // Thing under test
 const FetchAbstractionAlertRecipientsService = require('../../../../app/services/notices/setup/fetch-abstraction-alert-recipients.service.js')
-const LicenceEntityHelper = require('../../../support/helpers/licence-entity.helper.js')
-const LicenceDocumentHeaderHelper = require('../../../support/helpers/licence-document-header.helper.js')
 
 describe('Notices - Setup - Fetch abstraction alert recipients service', () => {
   let recipients
@@ -298,18 +296,57 @@ describe('Notices - Setup - Fetch abstraction alert recipients service', () => {
       })
     })
   })
+
+  describe('and there are multiple licence document roles', () => {
+    let licenceDocument
+
+    beforeEach(async () => {
+      licenceDocument = await LicenceDocumentHelper.add()
+
+      session = {
+        licenceRefs: [licenceDocument.licenceRef]
+      }
+
+      await _additionalContact(licenceDocument, {
+        firstName: 'Brick',
+        lastName: 'Tamland',
+        email: 'Brick.Tamland@news.com'
+      })
+
+      const endDate = new Date('2023-01-01')
+
+      await _additionalContact(
+        licenceDocument,
+        {
+          firstName: 'Champ',
+          lastName: 'Kind',
+          email: 'Champ.Kind@news.com'
+        },
+        true,
+        endDate
+      )
+    })
+
+    it('correctly only the "current" "additional contact"', async () => {
+      const result = await FetchAbstractionAlertRecipientsService.go(session)
+
+      expect(result).to.equal([
+        {
+          contact: null,
+          contact_hash_id: '70d3d94dd27d8b65e96392a85147a4cc',
+          contact_type: 'Additional contact',
+          email: 'Brick.Tamland@news.com',
+          licence_refs: licenceDocument.licenceRef
+        }
+      ])
+    })
+  })
 })
 
-async function _additionalContact(licenceDocument, contact, abstractionAlerts = true) {
-  const companyEntity = await LicenceEntityHelper.add({ type: 'company' })
-
-  await LicenceDocumentHeaderHelper.add({
-    companyEntityId: companyEntity.id,
-    licenceRef: licenceDocument.licenceRef
-  })
-
+async function _additionalContact(licenceDocument, contact, abstractionAlerts = true, endDate = null) {
   const licenceDocumentRole = await LicenceDocumentRoleHelper.add({
-    licenceDocumentId: licenceDocument.id
+    licenceDocumentId: licenceDocument.id,
+    endDate
   })
 
   const licenceRole = await LicenceRoleHelper.select('additionalContact')

--- a/test/services/notices/setup/fetch-abstraction-alert-recipients.service.test.js
+++ b/test/services/notices/setup/fetch-abstraction-alert-recipients.service.test.js
@@ -327,7 +327,7 @@ describe('Notices - Setup - Fetch abstraction alert recipients service', () => {
       )
     })
 
-    it('correctly only the "current" "additional contact"', async () => {
+    it('fetches only the "current" "additional contact"', async () => {
       const result = await FetchAbstractionAlertRecipientsService.go(session)
 
       expect(result).to.equal([


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5260

When sending abstraction alerts we were still sending the alerts to previous licence owners.

We missed some logic where we needed to check the licence document role was the current role.

---

So, we thought customer contacts, being managed in WRLS, were their own thing linked directly to the licence.

Our logic fetches all customer contacts flagged for abstraction alerts for the licence.

We now understand that they are linked to the ‘current’ licence version by way of the company.

For example, we have a new licence and therefore one licence version. That version’s licence holder is ACME Ltd.

This gets imported to WRLS in various places. The critical one is `crm_v2.document_roles` (it was always going to be CRM messing things up!)

|Document role Id|Licence|Role          |Company   |Start date|End date  |
|----------------|-------|--------------|----------|----------|----------|
|12345           |01/123| Licence holder|ACME Ltd  |2025-04-01|          |

When you add a customer contact in WRLS, a `crm_v2.company_contacts` record is created (I’ve simplified things for the example!)

|Company contact Id|Company |Email                  |
|------------------|--------|-----------------------|
|98765             |ACME Ltd|uma.leggerts@acme.co.uk|

Now, let's say you issue a new licence version in NALD, because something has changed on the licence. This will result in a new `crm_v2.document_roles` record from the overnight import. An end date will also be applied to the existing one.

|Document role Id|Licence|Role          |Company   |Start date|End date  |
|----------------|-------|--------------|----------|----------|----------|
|12345           |01/123 |Licence holder|ACME Ltd  |2025-04-01|2025-05-31|
|54321           |01/123 |Licence holder|ACME Ltd  |2025-06-01|          |

You don’t have to do anything with customer contacts. They will continue to show because they are linked to ACME Ltd, not the licence! And because the ‘current’ licence holder is still connected to ACME Ltd, they and Uma Leggerts will show in the contact details tab.

Now, the licence is to be transferred to a new licence holder. This will result in a new version being issued in NALD, so a new `crm_v2.document_roles` record.

|Document role Id|Licence|Role          |Company   |Start date|End date  |
|----------------|-------|--------------|----------|----------|----------|
|12345           |01/123 |Licence holder|ACME Ltd  |2025-04-01|2025-05-31|
|54321           |01/123 |Licence holder|ACME Ltd  |2025-06-01|2025-07-31|
|876123          |01/123 |Licence holder|FOOBAR Inc|2025-08-01|          |

This means when you view the licence’s contact details, you will see FOOBAR Inc only. Uma Leggerts will no longer be shown as a customer contact.

---

This change updates the abstraction alerts fetch recipients to check if the licence document role is the 'current'. This is done by the end date being set to a date in the future or the end date being null.