### PR TITLE
Fix notification-status job for accepted letters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,8 @@ jobs:
       ENVIRONMENT: dev
       COOKIE_SECRET: 1a1028df-a2af-468a-929b-e3a274be1208
       DEFAULT_USER_PASSWORD: P@55word
+      # Shut up dot env!
+      DOTENV_CONFIG_QUIET: true
 
     # Service containers to run with `runner-job`
     services:

--- a/app/presenters/jobs/notifications/notify-status.presenter.js
+++ b/app/presenters/jobs/notifications/notify-status.presenter.js
@@ -90,7 +90,7 @@ function _emailStatus(notifyStatus) {
  */
 function _letterStatus(notifyStatus) {
   const letterStatuses = {
-    accepted: NOTIFICATIONS_STATUS.sent,
+    accepted: NOTIFICATIONS_STATUS.pending,
     created: NOTIFICATIONS_STATUS.pending,
     sending: NOTIFICATIONS_STATUS.pending,
     received: NOTIFICATIONS_STATUS.sent,

--- a/app/presenters/jobs/notifications/notify-status.presenter.js
+++ b/app/presenters/jobs/notifications/notify-status.presenter.js
@@ -93,7 +93,6 @@ function _letterStatus(notifyStatus) {
     accepted: NOTIFICATIONS_STATUS.sent,
     created: NOTIFICATIONS_STATUS.pending,
     sending: NOTIFICATIONS_STATUS.pending,
-    delivered: NOTIFICATIONS_STATUS.sent,
     received: NOTIFICATIONS_STATUS.sent,
     'permanent-failure': NOTIFICATIONS_STATUS.error,
     'technical-failure': NOTIFICATIONS_STATUS.error,

--- a/app/services/jobs/notification-status/fetch-notifications.service.js
+++ b/app/services/jobs/notification-status/fetch-notifications.service.js
@@ -30,6 +30,7 @@ async function go() {
       'id',
       'licenceMonitoringStationId',
       'messageRef',
+      'messageType',
       'notifyId',
       'notifyStatus',
       'notify_error',

--- a/test/presenters/jobs/notifications/notify-status.presenter.test.js
+++ b/test/presenters/jobs/notifications/notify-status.presenter.test.js
@@ -10,7 +10,7 @@ const { expect } = Code
 // Thing under test
 const NotifyStatusPresenter = require('../../../../app/presenters/jobs/notifications/notify-status.presenter.js')
 
-describe('Notifications Setup - Notify status presenter', () => {
+describe('Jobs - Notifications - Notify Status presenter', () => {
   let notifyStatus
   let notification
 
@@ -179,21 +179,6 @@ describe('Notifications Setup - Notify status presenter', () => {
         expect(result).to.equal({
           notifyStatus: 'sending',
           status: 'pending'
-        })
-      })
-    })
-
-    describe('and the "notifyStatus" is "delivered"', () => {
-      beforeEach(() => {
-        notifyStatus = 'delivered'
-      })
-
-      it('correctly returns status to update', () => {
-        const result = NotifyStatusPresenter.go(notifyStatus, notification)
-
-        expect(result).to.equal({
-          notifyStatus: 'delivered',
-          status: 'sent'
         })
       })
     })

--- a/test/presenters/jobs/notifications/notify-status.presenter.test.js
+++ b/test/presenters/jobs/notifications/notify-status.presenter.test.js
@@ -148,7 +148,7 @@ describe('Jobs - Notifications - Notify Status presenter', () => {
 
         expect(result).to.equal({
           notifyStatus: 'accepted',
-          status: 'sent'
+          status: 'pending'
         })
       })
     })

--- a/test/services/jobs/notification-status/fetch-notifications.service.test.js
+++ b/test/services/jobs/notification-status/fetch-notifications.service.test.js
@@ -29,6 +29,7 @@ describe('Job - Notification Status - Fetch Notifications service', () => {
     notification = await NotificationHelper.add({
       eventId: event.id,
       messageRef: 'returns_invitation_licence_holder_letter',
+      messageType: 'letter',
       status: 'pending'
     })
 
@@ -74,6 +75,7 @@ describe('Job - Notification Status - Fetch Notifications service', () => {
         id: notification.id,
         licenceMonitoringStationId: null,
         messageRef: 'returns_invitation_licence_holder_letter',
+        messageType: 'letter',
         notifyError: null,
         notifyId: null,
         notifyStatus: null,


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5266

We were asked to look into why a water abstraction resume alert that was showing as SENT in view notices was [not appearing on the licence's communications tab](https://eaflood.atlassian.net/browse/WATER-5262).

When we looked, we found the query was looking at the `water.scheduled_notification` table's `notify_status` field, rather than the `status` field, which is what the view notices page uses.

The query was fetching only those where the notify_status was either 'delivered' or 'received'. As far as [GOV.UK Notify](https://docs.notifications.service.gov.uk/rest-api.html#letter-status-descriptions) is concerned:

- **Delivered** means an email was successfully sent
- **Received** means a letter was successfully sent to the printers for sending

So, the query wasn't wrong, just not consistent with how we deem a notification to be successful. In the view notices page, it is when `status` is 'sent'.

In the case of the missing alert

- `notify_status` was 'accepted'
- `status` was 'sent

This is why it was showing in one place, but not in the communications tab.

The notification-status job, when it gets the status from **Notify** is deeming 'accepted' for letters as they have been successful. However, there is still a chance **Notify** can report a 'permanent-failure'.

> The provider cannot print the letter. Your letter will not be dispatched.

We should only be updating the status of letters to 'sent' when Notify reports that their status is 'received'.

---

Whilst making this change, we also spotted that `app/services/jobs/notification-status/fetch-notifications.service.js` was never selecting `messageType`. This gets passed to `app/presenters/jobs/notifications/notify-status.presenter.js`, which uses the value to determine how to map the response from Notify.

This means since we put the job live, it's interpreted _every_ notification as a letter!

We've fixed that now 😁 