### PR TITLE
Fix missing notifications in licence comms tab

### DIFF
--- a/app/presenters/licences/view-licence-communications.presenter.js
+++ b/app/presenters/licences/view-licence-communications.presenter.js
@@ -26,12 +26,14 @@ function go(communications, documentId, licenceId) {
 
 function _communications(communications, documentId, licenceId) {
   return communications.map((communication) => {
+    const sent = formatLongDate(communication.createdAt)
+
     return {
       id: communication.id,
       link: _link(communication.id, documentId, licenceId),
-      type: _type(communication),
+      type: _type(communication, sent),
       sender: communication.event.issuer,
-      sent: _sent(communication),
+      sent,
       method: sentenceCase(communication.messageType)
     }
   })
@@ -45,16 +47,10 @@ function _link(communicationId, documentId, licenceId) {
   return `/licences/${documentId}/communications/${communicationId}`
 }
 
-function _sent(communication) {
-  return communication.sendAfter
-    ? formatLongDate(new Date(communication.sendAfter))
-    : formatLongDate(new Date(communication.createdAt))
-}
-
-function _type(communication) {
+function _type(communication, sent) {
   return {
     label: _typeLabel(communication),
-    sentVia: `sent ${_sent(communication)} via ${communication.messageType}`,
+    sentVia: `sent ${sent} via ${communication.messageType}`,
     pdf: communication.messageRef.includes('pdf')
   }
 }

--- a/app/services/licences/fetch-communications.service.js
+++ b/app/services/licences/fetch-communications.service.js
@@ -27,16 +27,16 @@ async function go(licenceRef, page) {
 
 async function _fetch(licenceRef, page) {
   return NotificationModel.query()
-    .select(['id', 'messageType', 'messageRef', 'createdAt'])
-    .where('licences', '@>', `["${licenceRef}"]`)
-    .andWhere('notifyStatus', 'in', ['delivered', 'received'])
-    .andWhere('eventId', 'is not', null)
+    .select(['createdAt', 'id', 'messageType', 'messageRef'])
+    .where('licences', '?', licenceRef)
+    .where('notifyStatus', 'in', ['delivered', 'received'])
+    .whereNotNull('eventId')
+    .orderBy('notifications.created_at', 'DESC')
     .withGraphFetched('event')
     .modifyGraph('event', (builder) => {
       builder.select(['issuer', 'metadata', 'status', 'subtype', 'type'])
     })
     .page(page - 1, DatabaseConfig.defaultPageSize)
-    .orderBy('notifications.created_at', 'DESC')
 }
 
 module.exports = {

--- a/app/services/licences/fetch-communications.service.js
+++ b/app/services/licences/fetch-communications.service.js
@@ -15,7 +15,7 @@ const DatabaseConfig = require('../../../config/database.config.js')
  * Was built to provide the data needed for the '/licences/{id}/communications' page
  *
  * @param {string} licenceRef - The reference for the licence to fetch
- * @param {number|string} page - The current page for the pagination service
+ * @param {number} page - The current page for the pagination service
  *
  * @returns {Promise<object>} the data needed to populate the view licence page's communications tab
  */

--- a/app/services/licences/fetch-communications.service.js
+++ b/app/services/licences/fetch-communications.service.js
@@ -36,7 +36,7 @@ async function _fetch(licenceRef, page) {
       builder.select(['issuer', 'metadata', 'status', 'subtype', 'type'])
     })
     .page(page - 1, DatabaseConfig.defaultPageSize)
-    .orderByRaw('notifications."created_at" DESC NULLS LAST')
+    .orderBy('notifications.created_at', 'DESC')
 }
 
 module.exports = {

--- a/app/services/licences/fetch-communications.service.js
+++ b/app/services/licences/fetch-communications.service.js
@@ -5,7 +5,7 @@
  * @module FetchCommunicationsService
  */
 
-const ScheduledNotificationModel = require('../../models/scheduled-notification.model.js')
+const NotificationModel = require('../../models/notification.model.js')
 
 const DatabaseConfig = require('../../../config/database.config.js')
 
@@ -26,7 +26,7 @@ async function go(licenceRef, page) {
 }
 
 async function _fetch(licenceRef, page) {
-  return ScheduledNotificationModel.query()
+  return NotificationModel.query()
     .select(['id', 'messageType', 'messageRef', 'createdAt', 'sendAfter'])
     .where('licences', '@>', `["${licenceRef}"]`)
     .andWhere('notifyStatus', 'in', ['delivered', 'received'])

--- a/app/services/licences/fetch-communications.service.js
+++ b/app/services/licences/fetch-communications.service.js
@@ -27,7 +27,7 @@ async function go(licenceRef, page) {
 
 async function _fetch(licenceRef, page) {
   return NotificationModel.query()
-    .select(['id', 'messageType', 'messageRef', 'createdAt', 'sendAfter'])
+    .select(['id', 'messageType', 'messageRef', 'createdAt'])
     .where('licences', '@>', `["${licenceRef}"]`)
     .andWhere('notifyStatus', 'in', ['delivered', 'received'])
     .andWhere('eventId', 'is not', null)
@@ -36,12 +36,7 @@ async function _fetch(licenceRef, page) {
       builder.select(['issuer', 'metadata', 'status', 'subtype', 'type'])
     })
     .page(page - 1, DatabaseConfig.defaultPageSize)
-    .orderByRaw(
-      `
-      scheduled_notifications."created_at" DESC NULLS LAST,
-      scheduled_notifications."send_after" DESC NULLS LAST
-    `
-    )
+    .orderByRaw('notifications."created_at" DESC NULLS LAST')
 }
 
 module.exports = {

--- a/app/services/licences/fetch-communications.service.js
+++ b/app/services/licences/fetch-communications.service.js
@@ -29,7 +29,7 @@ async function _fetch(licenceRef, page) {
   return NotificationModel.query()
     .select(['createdAt', 'id', 'messageType', 'messageRef'])
     .where('licences', '?', licenceRef)
-    .where('notifyStatus', 'in', ['delivered', 'received'])
+    .where('status', 'sent')
     .whereNotNull('eventId')
     .orderBy('notifications.created_at', 'DESC')
     .withGraphFetched('event')

--- a/app/services/licences/view-licence-communications.service.js
+++ b/app/services/licences/view-licence-communications.service.js
@@ -15,14 +15,16 @@ const ViewLicenceCommunicationsPresenter = require('../../presenters/licences/vi
  *
  * @param {string} licenceId - The UUID of the licence
  * @param {object} auth - The auth object taken from `request.auth` containing user details
- * @param {number|string} page - The current page for the pagination service
+ * @param {number|string} [page=1] - The current page for the pagination service
  *
  * @returns {Promise<object>} an object representing the `pageData` needed by the licence communication template.
  */
-async function go(licenceId, auth, page) {
+async function go(licenceId, auth, page = 1) {
+  const selectedPageNumber = Number(page)
+
   const commonData = await ViewLicenceService.go(licenceId, auth)
 
-  const communications = await FetchCommunicationsService.go(commonData.licenceRef, page)
+  const communications = await FetchCommunicationsService.go(commonData.licenceRef, selectedPageNumber)
   const communicationsData = ViewLicenceCommunicationsPresenter.go(
     communications.communications,
     commonData.documentId,
@@ -31,7 +33,7 @@ async function go(licenceId, auth, page) {
 
   const pagination = PaginatorPresenter.go(
     communications.pagination.total,
-    Number(page),
+    selectedPageNumber,
     `/system/licences/${licenceId}/communications`
   )
 

--- a/test/presenters/licences/view-licence-communications.presenter.test.js
+++ b/test/presenters/licences/view-licence-communications.presenter.test.js
@@ -14,28 +14,30 @@ const FeatureFlagsConfig = require('../../../config/feature-flags.config.js')
 // Thing under test
 const ViewLicenceCommunicationsPresenter = require('../../../app/presenters/licences/view-licence-communications.presenter.js')
 
-describe('View Licence Communications presenter', () => {
-  let communications
+describe('Licences - View Licence Communications presenter', () => {
   const licenceId = 'e7aefa9b-b832-41c8-9add-4e3e03cc1331'
   const documentId = 'd5eacebe-ff92-4704-99f7-9e4e6112ab98'
+
+  let communications
 
   beforeEach(() => {
     communications = [
       {
+        createdAt: new Date('2024-05-15T10:27:15.000Z'),
         id: '3ce7d0b6-610f-4cb2-9d4c-9761db797141',
         messageType: 'letter',
         messageRef: 'returns_invitation_licence_holder_letter',
         event: {
+          issuer: 'admin-internal@wrls.gov.uk',
           metadata: {
             name: 'Returns: invitation',
-            options: {}
+            error: 0,
+            options: { excludeLicences: [] }
           },
-          type: 'notification',
+          status: 'completed',
           subtype: 'returnInvitation',
-          status: 'processed',
-          issuer: 'admin-internal@wrls.gov.uk'
-        },
-        sendAfter: '2024-05-15T10:27:15.000Z'
+          type: 'notification'
+        }
       }
     ]
 
@@ -147,47 +149,6 @@ describe('View Licence Communications presenter', () => {
           label: 'Test - Water abstraction alert',
           pdf: false,
           sentVia: 'sent 15 May 2024 via letter'
-        })
-      })
-    })
-
-    describe('the "sent" property', () => {
-      describe('and there is a date for "sendAfter"', () => {
-        it('correctly presents the data', () => {
-          const result = ViewLicenceCommunicationsPresenter.go(communications, documentId, licenceId)
-
-          expect(result.communications[0].sent).to.equal('15 May 2024')
-          expect(result.communications[0].type.sentVia).to.equal('sent 15 May 2024 via letter')
-        })
-      })
-
-      describe('and there is a date for "createdAt"', () => {
-        beforeEach(() => {
-          communications = [
-            {
-              createdAt: '2025-06-06',
-              id: '3ce7d0b6-610f-4cb2-9d4c-9761db797141',
-              messageType: 'letter',
-              messageRef: 'returns_invitation_licence_holder_letter',
-              event: {
-                metadata: {
-                  name: 'Returns: invitation',
-                  options: {}
-                },
-                type: 'notification',
-                subtype: 'returnInvitation',
-                status: 'processed',
-                issuer: 'admin-internal@wrls.gov.uk'
-              }
-            }
-          ]
-        })
-
-        it('correctly presents the data', () => {
-          const result = ViewLicenceCommunicationsPresenter.go(communications, documentId, licenceId)
-
-          expect(result.communications[0].sent).to.equal('6 June 2025')
-          expect(result.communications[0].type.sentVia).to.equal('sent 6 June 2025 via letter')
         })
       })
     })

--- a/test/services/licences/fetch-communications.service.test.js
+++ b/test/services/licences/fetch-communications.service.test.js
@@ -9,7 +9,7 @@ const { expect } = Code
 
 // Test helpers
 const EventHelper = require('../../support/helpers/event.helper.js')
-const ScheduledNotificationModel = require('../../support/helpers/scheduled-notification.helper.js')
+const NotificationModel = require('../../support/helpers/notification.helper.js')
 const { generateLicenceRef } = require('../../support/helpers/licence.helper.js')
 
 // Thing under test
@@ -19,7 +19,7 @@ describe('Fetch Communications service', () => {
   const licenceRef = generateLicenceRef()
 
   let event
-  let scheduledNotification
+  let notification
 
   beforeEach(async () => {
     event = await EventHelper.add({
@@ -31,7 +31,7 @@ describe('Fetch Communications service', () => {
       type: 'notification'
     })
 
-    scheduledNotification = await ScheduledNotificationModel.add({
+    notification = await NotificationModel.add({
       eventId: event.id,
       licences: JSON.stringify([licenceRef]),
       messageRef: 'returns_invitation_licence_holder_letter',
@@ -50,7 +50,7 @@ describe('Fetch Communications service', () => {
 
       expect(result.communications).to.equal([
         {
-          createdAt: scheduledNotification.createdAt,
+          createdAt: notification.createdAt,
           event: {
             issuer: 'test.user@defra.gov.uk',
             metadata: null,
@@ -58,7 +58,7 @@ describe('Fetch Communications service', () => {
             subtype: 'renewal',
             type: 'notification'
           },
-          id: scheduledNotification.id,
+          id: notification.id,
           messageRef: 'returns_invitation_licence_holder_letter',
           messageType: 'letter',
           sendAfter: null

--- a/test/services/licences/fetch-communications.service.test.js
+++ b/test/services/licences/fetch-communications.service.test.js
@@ -9,7 +9,7 @@ const { expect } = Code
 
 // Test helpers
 const EventHelper = require('../../support/helpers/event.helper.js')
-const NotificationModel = require('../../support/helpers/notification.helper.js')
+const NotificationHelper = require('../../support/helpers/notification.helper.js')
 const { generateLicenceRef } = require('../../support/helpers/licence.helper.js')
 
 // Thing under test
@@ -31,7 +31,7 @@ describe('Fetch Communications service', () => {
       type: 'notification'
     })
 
-    notification = await NotificationModel.add({
+    notification = await NotificationHelper.add({
       eventId: event.id,
       licences: JSON.stringify([licenceRef]),
       messageRef: 'returns_invitation_licence_holder_letter',

--- a/test/services/licences/fetch-communications.service.test.js
+++ b/test/services/licences/fetch-communications.service.test.js
@@ -36,7 +36,7 @@ describe('Licences - Fetch Communications service', () => {
       licences: JSON.stringify([licenceRef]),
       messageRef: 'returns_invitation_licence_holder_letter',
       messageType: 'letter',
-      notifyStatus: 'delivered'
+      status: 'sent'
     })
   })
 

--- a/test/services/licences/fetch-communications.service.test.js
+++ b/test/services/licences/fetch-communications.service.test.js
@@ -15,7 +15,7 @@ const { generateLicenceRef } = require('../../support/helpers/licence.helper.js'
 // Thing under test
 const FetchCommunicationsService = require('../../../app/services/licences/fetch-communications.service.js')
 
-describe('Fetch Communications service', () => {
+describe('Licences - Fetch Communications service', () => {
   const licenceRef = generateLicenceRef()
 
   let event
@@ -60,8 +60,7 @@ describe('Fetch Communications service', () => {
           },
           id: notification.id,
           messageRef: 'returns_invitation_licence_holder_letter',
-          messageType: 'letter',
-          sendAfter: null
+          messageType: 'letter'
         }
       ])
     })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5262

We were asked to look into why a water abstraction resume alert that was showing as **SENT** in view notices was [not appearing on the licence's communications tab](https://eaflood.atlassian.net/browse/WATER-5262).

When we looked, we found `FetchCommunicationsService` was looking at the `water.scheduled_notification` table's `notify_status` field, rather than the `status` field, which is what the view notices page uses.

The query was fetching only those where the `notify_status`` was either 'delivered' or 'received'. As far as [GOV.UK Notify](https://docs.notifications.service.gov.uk/rest-api.html#letter-status-descriptions) is concerned:

- **Delivered** means an email was successfully sent
- **Received** means a letter was successfully sent to the printers for sending

So, the query wasn't wrong, just not consistent with how we deem a notification to be successful. In the view notices page, it is when `status` is 'sent'.

[Fix notification-status job for accepted letters](https://github.com/DEFRA/water-abstraction-system/pull/2415) is ensuring we don't set 'accepted' letters to **SENT** going forward. This change updates `FetchCommunicationsService` to use the `status` field instead of `notify_status`, making it consistent with how they are shown in view notices.