### PR TITLE
Allow ended 'Not due yet' returns to be submitted

### DIFF
--- a/app/presenters/return-logs/view-return-log.presenter.js
+++ b/app/presenters/return-logs/view-return-log.presenter.js
@@ -17,6 +17,7 @@ const {
   generateSummaryTableHeaders,
   generateSummaryTableRows
 } = require('./base-return-logs.presenter.js')
+const { today } = require('../../lib/general.lib.js')
 const { returnRequirementFrequencies, unitNames } = require('../../lib/static-lookups.lib.js')
 
 /**
@@ -54,7 +55,7 @@ function go(returnLog, auth) {
 
   return {
     abstractionPeriod: _abstractionPeriod(returnLog),
-    actionButton: _actionButton(latest, auth, returnLog.id, formattedStatus),
+    actionButton: _actionButton(latest, auth, returnLog, formattedStatus),
     backLink: _backLink(returnLog.id, licence.id, latest),
     displayReadings: method !== 'abstractionVolumes',
     displayTable: _displayTable(selectedReturnSubmission),
@@ -111,14 +112,16 @@ function _abstractionPeriod(returnLog) {
   return formatAbstractionPeriod(periodStartDay, periodStartMonth, periodEndDay, periodEndMonth)
 }
 
-function _actionButton(latest, auth, returnLogId, formattedStatus) {
+function _actionButton(latest, auth, returnLog, formattedStatus) {
+  const { endDate, id: returnLogId } = returnLog
+
   // You cannot edit a previous version
   if (!latest) {
     return null
   }
 
-  // You cannot edit a void return or a return not due yet
-  if (formattedStatus === 'void' || formattedStatus === 'not due yet') {
+  // You cannot edit a void return or a return that hasn't ended
+  if (formattedStatus === 'void' || today() <= endDate) {
     return null
   }
 

--- a/test/presenters/return-logs/view-return-log.presenter.test.js
+++ b/test/presenters/return-logs/view-return-log.presenter.test.js
@@ -161,10 +161,11 @@ describe('Return Logs - View Return Log presenter', () => {
       })
     })
 
-    describe('when the return is "not due yet"', () => {
+    describe('when the return has not ended', () => {
       beforeEach(() => {
-        const notDueUntilDate = today()
-        returnLog.dueDate = new Date(notDueUntilDate.setDate(notDueUntilDate.getDate() + 28))
+        const endDate = today()
+
+        returnLog.endDate = new Date(endDate.setDate(endDate.getDate() + 1))
         returnLog.status = 'due'
       })
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5144

The business has needed to revoke a licence, which results in a split return log. Basically, its return period was the whole cycle (2025-04-01 to 2026-03-31), which means its due date was set 28 days after both the period and the cycle end (2026-04-28).

When the licence gets revoked, the return log is replaced with one whose end date matches the licence end date, for example, 2025-09-19.

However, the return log will still be linked to the same cycle, so that the due date will remain calculated as 2026-04-28.

In the service, it will display as **NOT DUE YET**. When we added this status and took over returns management, the business decision was that it should not be possible to submit these return logs.

But now they have realised they need to. They want to capture the return submission data now and not have to wait till April 2026!

This change amends the logic for the action button. Rather than only showing the **Submit** button when we hit 28 days before the due date, we'll make it available as soon as the current date is greater than the return log's end date.