### PR TITLE
Save return log ids for the return forms journey

### DIFF
--- a/app/models/notification.model.js
+++ b/app/models/notification.model.js
@@ -16,7 +16,7 @@ class NotificationModel extends BaseModel {
 
   // Defining which fields contain json allows us to insert an object without needing to stringify it first
   static get jsonAttributes() {
-    return ['licences', 'personalisation']
+    return ['licences', 'personalisation', 'returnLogIds']
   }
 
   static get relationMappings() {

--- a/app/presenters/notices/setup/prepare-return-forms.presenter.js
+++ b/app/presenters/notices/setup/prepare-return-forms.presenter.js
@@ -51,6 +51,7 @@ function go(licenceRef, dueReturnLog, recipient) {
     purpose,
     regionCode,
     regionName,
+    returnId,
     returnLogId,
     returnReference,
     returnsFrequency,
@@ -61,7 +62,6 @@ function go(licenceRef, dueReturnLog, recipient) {
 
   return {
     address: _address(recipient),
-
     licenceRef,
     naldAreaCode,
     pageEntries: _entries(startDate, endDate, returnsFrequency),
@@ -69,6 +69,7 @@ function go(licenceRef, dueReturnLog, recipient) {
     purpose,
     regionAndArea: _regionAndArea(regionName, naldAreaCode),
     regionCode,
+    returnId,
     returnLogId,
     returnReference,
     returnsFrequency,

--- a/app/presenters/notices/setup/return-forms-notification.presenter.js
+++ b/app/presenters/notices/setup/return-forms-notification.presenter.js
@@ -29,7 +29,8 @@ function go(returnForm, pageData, licenceRef, referenceCode, eventId) {
     messageRef: 'pdf.return_form',
     messageType: 'letter',
     personalisation: _personalisation(pageData),
-    reference: referenceCode
+    reference: referenceCode,
+    returnLogIds: [pageData.returnId]
   }
 }
 

--- a/test/presenters/notices/setup/prepare-return-forms.presenter.test.js
+++ b/test/presenters/notices/setup/prepare-return-forms.presenter.test.js
@@ -59,6 +59,7 @@ describe('Notices - Setup - Prepare Return Forms Presenter', () => {
         purpose: 'Mineral Washing',
         regionAndArea: 'North West / Lower Trent',
         regionCode: '1',
+        returnId: dueReturnLog.returnId,
         returnLogId: dueReturnLog.returnLogId,
         returnReference: dueReturnLog.returnReference,
         returnsFrequency: 'month',

--- a/test/presenters/notices/setup/return-forms-notification.presenter.test.js
+++ b/test/presenters/notices/setup/return-forms-notification.presenter.test.js
@@ -23,10 +23,13 @@ describe('Notices - Setup - Return Forms Notification Presenter', () => {
   let pageData
   let referenceCode
   let returnForm
+  let returnId
   let returnLogId
 
   beforeEach(async () => {
     licenceRef = generateLicenceRef()
+
+    returnId = generateUUID()
 
     returnLogId = generateReturnLogId()
 
@@ -57,7 +60,8 @@ describe('Notices - Setup - Return Forms Notification Presenter', () => {
       siteDescription: 'Water park',
       startDate: '1 January 2025',
       twoPartTariff: false,
-      returnLogId
+      returnLogId,
+      returnId
     }
   })
 
@@ -92,7 +96,8 @@ describe('Notices - Setup - Return Forms Notification Presenter', () => {
           site_description: 'Water park',
           start_date: '1 January 2025'
         },
-        reference: referenceCode
+        reference: referenceCode,
+        returnLogIds: [returnId]
       })
     })
   })

--- a/test/services/notices/setup/batch-notifications.service.test.js
+++ b/test/services/notices/setup/batch-notifications.service.test.js
@@ -13,6 +13,7 @@ const EventHelper = require('../../../support/helpers/event.helper.js')
 const NotificationModel = require('../../../../app/models/notification.model.js')
 const RecipientsFixture = require('../../../fixtures/recipients.fixtures.js')
 const { generateReferenceCode } = require('../../../support/helpers/notification.helper.js')
+const { generateUUID } = require('../../../../app/lib/general.lib.js')
 const { notifyTemplates } = require('../../../../app/lib/notify-templates.lib.js')
 
 // Things we need to stub
@@ -659,9 +660,12 @@ describe('Notices - Setup - Batch Notifications service', () => {
   })
 
   describe('when sending return forms', () => {
+    let returnId
+
     beforeEach(async () => {
       reference = generateReferenceCode('PRTF')
 
+      returnId = generateUUID()
       recipientsFixture = RecipientsFixture.recipients()
       recipients = [recipientsFixture.licenceHolder]
 
@@ -687,7 +691,8 @@ describe('Notices - Setup - Batch Notifications service', () => {
         licences: JSON.stringify([recipientsFixture.licenceHolder.licence_refs]),
         messageRef: 'pdf.return_form',
         messageType: 'letter',
-        reference
+        reference,
+        returnLogIds: [returnId]
       }
 
       Sinon.stub(DetermineReturnFormsService, 'go').resolves([
@@ -791,7 +796,7 @@ describe('Notices - Setup - Batch Notifications service', () => {
               },
               plaintext: null,
               recipient: null,
-              returnLogIds: null,
+              returnLogIds: [returnId],
               status: 'pending'
             },
             { skip: ['id', 'createdAt'] }
@@ -814,7 +819,7 @@ describe('Notices - Setup - Batch Notifications service', () => {
               },
               plaintext: null,
               recipient: null,
-              returnLogIds: null,
+              returnLogIds: [returnId],
               status: 'error'
             },
             { skip: ['id', 'createdAt'] }
@@ -836,7 +841,7 @@ describe('Notices - Setup - Batch Notifications service', () => {
               },
               plaintext: null,
               recipient: null,
-              returnLogIds: null,
+              returnLogIds: [returnId],
               status: 'pending'
             },
             { skip: ['id', 'createdAt'] }

--- a/test/services/notices/setup/determine-return-forms.service.test.js
+++ b/test/services/notices/setup/determine-return-forms.service.test.js
@@ -104,7 +104,8 @@ describe('Notices - Setup - Determine Return Forms Service', () => {
               site_description: 'BOREHOLE AT AVALON',
               start_date: '1 April 2022'
             },
-            reference: referenceCode
+            reference: referenceCode,
+            returnLogIds: [dueReturnLog.returnId]
           },
           {
             content: buffer,
@@ -133,7 +134,8 @@ describe('Notices - Setup - Determine Return Forms Service', () => {
               site_description: 'BOREHOLE AT AVALON',
               start_date: '1 April 2022'
             },
-            reference: referenceCode
+            reference: referenceCode,
+            returnLogIds: [dueReturnLog.returnId]
           }
         ])
       })
@@ -175,7 +177,8 @@ describe('Notices - Setup - Determine Return Forms Service', () => {
               site_description: 'BOREHOLE AT AVALON',
               start_date: '1 April 2022'
             },
-            reference: referenceCode
+            reference: referenceCode,
+            returnLogIds: [dueReturnLog.returnId]
           },
           {
             content: buffer,
@@ -204,7 +207,8 @@ describe('Notices - Setup - Determine Return Forms Service', () => {
               site_description: 'BOREHOLE AT AVALON',
               start_date: '1 April 2022'
             },
-            reference: referenceCode
+            reference: referenceCode,
+            returnLogIds: [dueReturnLog.returnId]
           },
           {
             content: buffer,
@@ -233,7 +237,8 @@ describe('Notices - Setup - Determine Return Forms Service', () => {
               site_description: 'BOREHOLE AT AVALON',
               start_date: '1 April 2022'
             },
-            reference: referenceCode
+            reference: referenceCode,
+            returnLogIds: [additionalDueReturn.returnId]
           },
           {
             content: buffer,
@@ -262,7 +267,8 @@ describe('Notices - Setup - Determine Return Forms Service', () => {
               site_description: 'BOREHOLE AT AVALON',
               start_date: '1 April 2022'
             },
-            reference: referenceCode
+            reference: referenceCode,
+            returnLogIds: [additionalDueReturn.returnId]
           }
         ])
       })

--- a/test/services/notices/setup/prepare-return-forms.service.test.js
+++ b/test/services/notices/setup/prepare-return-forms.service.test.js
@@ -81,6 +81,7 @@ describe('Notices - Setup - Prepare Return Forms Service', () => {
         purpose: 'Mineral Washing',
         regionAndArea: 'North West / Lower Trent',
         regionCode: '1',
+        returnId: dueReturnLog.returnId,
         returnLogId: dueReturnLog.returnLogId,
         returnsFrequency: 'month',
         returnReference: dueReturnLog.returnReference,

--- a/test/services/notices/setup/preview-return-forms.service.test.js
+++ b/test/services/notices/setup/preview-return-forms.service.test.js
@@ -107,6 +107,7 @@ describe('Notices - Setup - Preview Return Forms Service', () => {
         purpose: 'Mineral Washing',
         regionAndArea: 'North West / Lower Trent',
         regionCode: '1',
+        returnId: dueReturnLog.returnId,
         returnLogId: dueReturnLog.returnLogId,
         returnsFrequency: 'month',
         returnReference: dueReturnLog.returnReference,


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5226

We recently added a migration to add a return log ids column to notification view.

The returns log ids are currently stored in the metadata column.

We want to make these easily accessible so we are adding a 'return_log_ids' column.

This will store the return log ids for a notification as a json array e.g ["a82c1a23-d7ac-4410-8534-acccab16b850"].

Some notifications are linked to only one return log id (such as the paper forms) but others are linked to multiple return log ids. This is why we use the jsonb field and saved the ids in an array.

We only want to store the return ids for the return forms at the moment.

We will be making an effort in the future to save the return ids for invitations and reminders.