### PR TITLE
Add new today() helper to GeneralLib

### DIFF
--- a/app/lib/general.lib.js
+++ b/app/lib/general.lib.js
@@ -257,6 +257,27 @@ function timestampForPostgres() {
 }
 
 /**
+ * Returns today's date with the time set to midnight, for example '2023-01-13T00:00:00.000Z'.
+ *
+ * A number of dates in our data are held as date-only, and we have to make decisions based on comparing them to
+ * today's date. If we don't strip the time when comparing, we get issues where a date is equal to the current date.
+ *
+ * For example, the return log 'due date' is held in the record as date-only. If we compare it against 'today' without
+ * stripping the time, then any return due 'today' would be flagged as overdue when it is still due (just!)
+ *
+ * This is a handy helper to return 'today' as a date-only value.
+ *
+ * @returns {Date}
+ */
+function today() {
+  const today = new Date()
+
+  today.setHours(0, 0, 0, 0)
+
+  return today
+}
+
+/**
  * Compare key properties of 2 transactions and determine if they are a 'match'
  *
  * We compare those properties which determine the charge value calculated by the charging module. If the properties are
@@ -366,6 +387,7 @@ module.exports = {
   periodsOverlap,
   splitArrayIntoGroups,
   timestampForPostgres,
+  today,
   transactionsMatch,
   transformStringOfLicencesToArray
 }

--- a/app/lib/general.lib.js
+++ b/app/lib/general.lib.js
@@ -270,11 +270,11 @@ function timestampForPostgres() {
  * @returns {Date}
  */
 function today() {
-  const today = new Date()
+  const todaysDate = new Date()
 
-  today.setHours(0, 0, 0, 0)
+  todaysDate.setHours(0, 0, 0, 0)
 
-  return today
+  return todaysDate
 }
 
 /**

--- a/app/presenters/base.presenter.js
+++ b/app/presenters/base.presenter.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { today } = require('../lib/general.lib.js')
 const { returnUnits } = require('../lib/static-lookups.lib.js')
 
 const DUE_PERIOD_DAYS = 27
@@ -293,13 +294,9 @@ function formatReturnLogStatus(returnLog) {
   }
 
   // Work out if the return is overdue (status is still 'due' and it is past the due date)
-  const today = new Date()
+  const todaysDate = today()
 
-  // The due date held in the record is date-only. If we compared it against 'today' without this step any return due
-  // 'today' would be flagged as overdue when it is still due (just!)
-  today.setHours(0, 0, 0, 0)
-
-  if (dueDate < today) {
+  if (dueDate < todaysDate) {
     return 'overdue'
   }
 
@@ -311,7 +308,7 @@ function formatReturnLogStatus(returnLog) {
   notDueUntil.setDate(notDueUntil.getDate() - DUE_PERIOD_DAYS)
 
   // If today is before the "due" period starts, the return is "not due yet"
-  if (today < notDueUntil) {
+  if (todaysDate < notDueUntil) {
     return 'not due yet'
   }
 

--- a/app/presenters/licences/view-licence.presenter.js
+++ b/app/presenters/licences/view-licence.presenter.js
@@ -6,6 +6,7 @@
  */
 
 const { formatLongDate } = require('../base.presenter.js')
+const { today } = require('../../lib/general.lib.js')
 
 /**
  * Formats data for common licence data `/licences/{id}` page's
@@ -96,9 +97,7 @@ function _tptNotification(baseMessage, includeInPresrocBilling, includeInSrocBil
 }
 
 function _warning(ends) {
-  const today = new Date()
-
-  if (!ends || ends.date > today) {
+  if (!ends || ends.date > today()) {
     return null
   }
 

--- a/app/presenters/notices/setup/returns-period/returns-period.presenter.js
+++ b/app/presenters/notices/setup/returns-period/returns-period.presenter.js
@@ -5,8 +5,9 @@
  * @module ReturnsPeriodPresenter
  */
 
-const { determineUpcomingReturnPeriods } = require('../../../../lib/return-periods.lib.js')
 const { formatLongDate } = require('../../../base.presenter.js')
+const { today } = require('../../../../lib/general.lib.js')
+const { determineUpcomingReturnPeriods } = require('../../../../lib/return-periods.lib.js')
 
 /**
  * Formats data for the `/notices/setup/returns-period` page
@@ -30,9 +31,7 @@ function go(session) {
 }
 
 function _returnsPeriod(savedReturnsPeriod) {
-  const today = new Date()
-
-  const [firstReturnPeriod, secondReturnPeriod] = determineUpcomingReturnPeriods(today)
+  const [firstReturnPeriod, secondReturnPeriod] = determineUpcomingReturnPeriods(today())
 
   const currentReturnPeriod = _formatReturnPeriod(firstReturnPeriod, savedReturnsPeriod)
   const nextReturnPeriod = _formatReturnPeriod(secondReturnPeriod, savedReturnsPeriod)

--- a/app/presenters/return-logs/setup/received.presenter.js
+++ b/app/presenters/return-logs/setup/received.presenter.js
@@ -6,6 +6,7 @@
  */
 
 const { formatLongDate } = require('../../base.presenter.js')
+const { today } = require('../../../lib/general.lib.js')
 
 /**
  * Format data for the `/return-log/setup/{sessionId}/received` page
@@ -33,7 +34,7 @@ function go(session) {
     receivedDateYear: receivedDateYear ?? null,
     returnReference,
     sessionId,
-    todaysDate: formatLongDate(new Date()),
+    todaysDate: formatLongDate(today()),
     yesterdaysDate: _yesterdaysDate()
   }
 }

--- a/app/services/jobs/licence-updates/fetch-licence-updates.service.js
+++ b/app/services/jobs/licence-updates/fetch-licence-updates.service.js
@@ -6,6 +6,7 @@
  */
 
 const { db } = require('../../../../db/db.js')
+const { today } = require('../../../lib/general.lib.js')
 
 /**
  * Fetches licence versions that were created in last two months that have no matching workflow record
@@ -60,11 +61,11 @@ async function go() {
 }
 
 function _twoMonthsAgo() {
-  const today = new Date()
+  const todaysDate = today()
 
-  today.setMonth(today.getMonth() - 2)
+  todaysDate.setMonth(todaysDate.getMonth() - 2)
 
-  return today
+  return todaysDate
 }
 
 module.exports = {

--- a/app/services/jobs/notification-status/fetch-notifications.service.js
+++ b/app/services/jobs/notification-status/fetch-notifications.service.js
@@ -6,6 +6,7 @@
  */
 
 const NotificationModel = require('../../../models/notification.model.js')
+const { today } = require('../../../lib/general.lib.js')
 
 const SEVEN_DAYS = 7
 
@@ -19,9 +20,10 @@ const SEVEN_DAYS = 7
  * @returns {Promise<object[]>} - an array of 'notifications'
  */
 async function go() {
-  const today = new Date()
-  const sevenDaysAgo = new Date()
-  sevenDaysAgo.setDate(today.getDate() - SEVEN_DAYS)
+  const todaysDate = today()
+  const sevenDaysAgo = today()
+
+  sevenDaysAgo.setDate(todaysDate.getDate() - SEVEN_DAYS)
 
   return NotificationModel.query()
     .select([

--- a/app/services/return-logs/setup/submit-received.service.js
+++ b/app/services/return-logs/setup/submit-received.service.js
@@ -5,10 +5,10 @@
  * @module SubmitReceivedService
  */
 
-const GeneralLib = require('../../../lib/general.lib.js')
 const ReceivedDateValidator = require('../../../validators/return-logs/setup/received-date.validator.js')
 const ReceivedPresenter = require('../../../presenters/return-logs/setup/received.presenter.js')
 const SessionModel = require('../../../models/session.model.js')
+const { flashNotification, today } = require('../../../lib/general.lib.js')
 
 /**
  * Orchestrates validating the data for `/return-logs/setup/{sessionId}/received` page
@@ -36,7 +36,7 @@ async function go(sessionId, payload, yar) {
     await _save(session, payload)
 
     if (session.checkPageVisited) {
-      GeneralLib.flashNotification(yar, 'Updated', 'Reporting details changed')
+      flashNotification(yar, 'Updated', 'Reporting details changed')
     }
 
     return {
@@ -55,8 +55,9 @@ async function go(sessionId, payload, yar) {
 
 async function _save(session, payload) {
   const selectedOption = payload['received-date-options']
+  const todaysDate = today()
+
   session.receivedDateOptions = selectedOption
-  const todaysDate = new Date(new Date().setHours(0, 0, 0, 0))
 
   if (selectedOption === 'today') {
     session.receivedDate = todaysDate

--- a/test/lib/general.lib.test.js
+++ b/test/lib/general.lib.test.js
@@ -324,6 +324,21 @@ describe('GeneralLib', () => {
     })
   })
 
+  describe('#today', () => {
+    beforeEach(() => {
+      testDate = new Date(2025, 9, 19, 20, 31, 57, 234)
+
+      clock = Sinon.useFakeTimers(testDate)
+    })
+
+    it('returns the current date and time as date-only (time set to midnight)', () => {
+      const result = GeneralLib.today()
+
+      // We compare ISO strings as its a clearer way of ensuring the result is as expected
+      expect(result.toISOString()).to.equal('2025-10-19T00:00:00.000Z')
+    })
+  })
+
   describe('#splitArrayIntoGroups', () => {
     let testArray
     let testGroupSize

--- a/test/lib/general.lib.test.js
+++ b/test/lib/general.lib.test.js
@@ -15,8 +15,15 @@ const TransactionHelper = require('../support/helpers/transaction.helper.js')
 const GeneralLib = require('../../app/lib/general.lib.js')
 
 describe('GeneralLib', () => {
+  let clock
+  let testDate
+
   afterEach(() => {
     Sinon.restore()
+
+    if (clock) {
+      clock.restore()
+    }
   })
 
   describe('#calculateAndLogTimeTaken', () => {
@@ -80,13 +87,6 @@ describe('GeneralLib', () => {
   })
 
   describe('#determineCurrentFinancialYear', () => {
-    let clock
-    let testDate
-
-    afterEach(() => {
-      clock.restore()
-    })
-
     describe('when the current financial year is 2023 to 2024', () => {
       describe('and the current date is between April and December', () => {
         beforeEach(() => {
@@ -311,17 +311,10 @@ describe('GeneralLib', () => {
   })
 
   describe('#timestampForPostgres', () => {
-    let clock
-    let testDate
-
     beforeEach(() => {
       testDate = new Date(2015, 9, 21, 20, 31, 57)
 
       clock = Sinon.useFakeTimers(testDate)
-    })
-
-    afterEach(() => {
-      clock.restore()
     })
 
     it('returns the current date and time as an ISO string', () => {

--- a/test/lib/return-cycle-dates.lib.test.js
+++ b/test/lib/return-cycle-dates.lib.test.js
@@ -8,14 +8,16 @@ const Sinon = require('sinon')
 const { afterEach, describe, it, before, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
+// Test helpers
+const { today } = require('../../app/lib/general.lib.js')
 const { returnCycleDates } = require('../../app/lib/static-lookups.lib.js')
 
 // Thing under test
 const ReturnCycleDatesLib = require('../../app/lib/return-cycle-dates.lib.js')
 
 describe('Return Cycle Dates lib', () => {
-  const today = new Date()
-  const year = today.getFullYear()
+  const todaysDate = today()
+  const year = todaysDate.getFullYear()
 
   let clock
   let expectedDate

--- a/test/presenters/licences/view-licence-summary.presenter.test.js
+++ b/test/presenters/licences/view-licence-summary.presenter.test.js
@@ -12,6 +12,7 @@ const { expect } = Code
 const FeatureFlagsConfig = require('../../../config/feature-flags.config.js')
 const LicenceModel = require('../../../app/models/licence.model.js')
 const PointModel = require('../../../app/models/point.model.js')
+const { today } = require('../../../app/lib/general.lib.js')
 
 // Thing under test
 const ViewLicenceSummaryPresenter = require('../../../app/presenters/licences/view-licence-summary.presenter.js')
@@ -753,11 +754,7 @@ describe('Licences - View Licence Summary presenter', () => {
         // NOTE: The date we get back from the DB is without time. If we just assigned new Date() to expiredDate
         // there is a chance the test could fail depending on how quickly this is compared to the logic in the
         // presenter
-        const today = new Date()
-
-        today.setHours(0, 0, 0, 0)
-
-        licence.expiredDate = today
+        licence.expiredDate = today()
       })
 
       it('returns null', () => {

--- a/test/presenters/licences/view-licence.presenter.test.js
+++ b/test/presenters/licences/view-licence.presenter.test.js
@@ -13,7 +13,7 @@ const LicenceModel = require('../../../app/models/licence.model.js')
 // Thing under test
 const ViewLicencePresenter = require('../../../app/presenters/licences/view-licence.presenter.js')
 
-describe('View Licence presenter', () => {
+describe('Licences - View Licence presenter', () => {
   let auth
   let licence
 

--- a/test/presenters/return-logs/setup/received.presenter.test.js
+++ b/test/presenters/return-logs/setup/received.presenter.test.js
@@ -9,6 +9,7 @@ const { expect } = Code
 
 // Test helpers
 const { formatLongDate } = require('../../../../app/presenters/base.presenter.js')
+const { today } = require('../../../../app/lib/general.lib.js')
 
 // Thing under test
 const ReceivedPresenter = require('../../../../app/presenters/return-logs/setup/received.presenter.js')
@@ -38,7 +39,7 @@ describe('Return Logs - Setup - Received presenter', () => {
         receivedDateMonth: null,
         receivedDateYear: null,
         backLink: '/system/return-logs?id=v1:1:01/12/123:10065476:2025-01-06:2025-10-31',
-        todaysDate: formatLongDate(new Date()),
+        todaysDate: formatLongDate(today()),
         yesterdaysDate: _yesterdaysDate()
       })
     })

--- a/test/presenters/return-logs/view-return-log.presenter.test.js
+++ b/test/presenters/return-logs/view-return-log.presenter.test.js
@@ -11,8 +11,9 @@ const { expect } = Code
 const ViewReturnLogPresenter = require('../../../app/presenters/return-logs/view-return-log.presenter.js')
 
 // Test helpers
-const { formatNumber } = require('../../../app/presenters/base.presenter.js')
 const ReturnLogsFixture = require('../../fixtures/return-logs.fixture.js')
+const { formatNumber } = require('../../../app/presenters/base.presenter.js')
+const { today } = require('../../../app/lib/general.lib.js')
 const { unitNames } = require('../../../app/lib/static-lookups.lib.js')
 
 describe('Return Logs - View Return Log presenter', () => {
@@ -162,8 +163,8 @@ describe('Return Logs - View Return Log presenter', () => {
 
     describe('when the return is "not due yet"', () => {
       beforeEach(() => {
-        const notDueUntilDate = new Date()
-        returnLog.dueDate = new Date(notDueUntilDate.setDate(notDueUntilDate.getDate() + 27))
+        const notDueUntilDate = today()
+        returnLog.dueDate = new Date(notDueUntilDate.setDate(notDueUntilDate.getDate() + 28))
         returnLog.status = 'due'
       })
 

--- a/test/services/jobs/clean/clean-expired-sessions.service.test.js
+++ b/test/services/jobs/clean/clean-expired-sessions.service.test.js
@@ -11,12 +11,14 @@ const { expect } = Code
 // Test helpers
 const SessionHelper = require('../../../support/helpers/session.helper.js')
 const SessionModel = require('../../../../app/models/session.model.js')
+const { today } = require('../../../../app/lib/general.lib.js')
 
 // Thing under test
 const CleanExpiredSessionsService = require('../../../../app/services/jobs/clean/clean-expired-sessions.service.js')
 
 describe('Jobs - Clean - Clean Expired Sessions service', () => {
-  const todayMinusOneDay = new Date(new Date().setDate(new Date().getDate() - 1)).toISOString()
+  const todaysDate = today()
+  const todayMinusOneDay = new Date(todaysDate.setDate(todaysDate.getDate() - 1)).toISOString()
 
   let notifierStub
   let session

--- a/test/services/jobs/licence-updates/fetch-licence-updates.service.test.js
+++ b/test/services/jobs/licence-updates/fetch-licence-updates.service.test.js
@@ -18,7 +18,7 @@ const WorkflowHelper = require('../../../support/helpers/workflow.helper.js')
 // Thing under test
 const FetchLicenceUpdatesService = require('../../../../app/services/jobs/licence-updates/fetch-licence-updates.service.js')
 
-describe('Fetch Licence Updates service', () => {
+describe('Jobs - Licence Updates - Fetch Licence Updates service', () => {
   let licence
   let licenceVersion
 

--- a/test/services/jobs/notification-status/fetch-notifications.service.test.js
+++ b/test/services/jobs/notification-status/fetch-notifications.service.test.js
@@ -10,6 +10,7 @@ const { expect } = Code
 // Test helpers
 const EventHelper = require('../../../support/helpers/event.helper.js')
 const NotificationHelper = require('../../../support/helpers/notification.helper.js')
+const { today } = require('../../../../app/lib/general.lib.js')
 
 // Thing under test
 const FetchNotificationsService = require('../../../../app/services/jobs/notification-status/fetch-notifications.service.js')
@@ -50,9 +51,9 @@ describe('Job - Notification Status - Fetch Notifications service', () => {
       type: 'notification'
     })
 
-    const today = new Date()
-    const eightDaysAgo = new Date()
-    eightDaysAgo.setDate(today.getDate() - 8)
+    const todaysDate = today()
+    const eightDaysAgo = today()
+    eightDaysAgo.setDate(todaysDate.getDate() - 8)
 
     await NotificationHelper.add({
       eventId: olderThanRetentionEvent.id,

--- a/test/services/return-logs/create-return-logs.service.test.js
+++ b/test/services/return-logs/create-return-logs.service.test.js
@@ -12,6 +12,7 @@ const { expect } = Code
 const ReturnCyclesFixture = require('../../fixtures/return-cycles.fixture.js')
 const ReturnLogHelper = require('../../support/helpers/return-log.helper.js')
 const ReturnRequirementsFixture = require('../../fixtures/return-requirements.fixture.js')
+const { today } = require('../../../app/lib/general.lib.js')
 
 // Things we need to stub
 const GenerateReturnLogService = require('../../../app/services/return-logs/generate-return-log.service.js')
@@ -20,8 +21,8 @@ const GenerateReturnLogService = require('../../../app/services/return-logs/gene
 const CreateReturnLogsService = require('../../../app/services/return-logs/create-return-logs.service.js')
 
 describe('Return Logs - Create Return Logs service', () => {
-  const today = new Date()
-  const year = today.getFullYear()
+  const todaysDate = today()
+  const year = todaysDate.getFullYear()
 
   let clock
   let notifierStub

--- a/test/services/return-logs/generate-return-log.service.test.js
+++ b/test/services/return-logs/generate-return-log.service.test.js
@@ -11,6 +11,7 @@ const { expect } = Code
 // Test helpers
 const ReturnCyclesFixture = require('../../fixtures/return-cycles.fixture.js')
 const ReturnRequirementsFixture = require('../../fixtures/return-requirements.fixture.js')
+const { today } = require('../../../app/lib/general.lib.js')
 
 // Things we need to stub
 const FeatureFlagsConfig = require('../../../config/feature-flags.config.js')
@@ -19,8 +20,8 @@ const FeatureFlagsConfig = require('../../../config/feature-flags.config.js')
 const GenerateReturnLogService = require('../../../app/services/return-logs/generate-return-log.service.js')
 
 describe('Return Logs - Generate Return Log service', () => {
-  const today = new Date()
-  const year = today.getFullYear()
+  const todaysDate = today()
+  const year = todaysDate.getFullYear()
 
   let clock
   let testReturnCycle

--- a/test/services/return-logs/setup/submit-received.service.test.js
+++ b/test/services/return-logs/setup/submit-received.service.test.js
@@ -10,6 +10,7 @@ const { expect } = Code
 
 // Test helpers
 const SessionHelper = require('../../../support/helpers/session.helper.js')
+const { today } = require('../../../../app/lib/general.lib.js')
 
 // Thing under test
 const SubmitReceivedService = require('../../../../app/services/return-logs/setup/submit-received.service.js')
@@ -39,8 +40,7 @@ describe('Return Logs - Setup - Submit Received service', () => {
   describe('when called', () => {
     describe('with a valid payload (todays date)', () => {
       beforeEach(async () => {
-        testDate = new Date()
-        testDate.setHours(0, 0, 0, 0)
+        testDate = today()
         payload = {
           'received-date-options': 'today'
         }
@@ -91,9 +91,8 @@ describe('Return Logs - Setup - Submit Received service', () => {
 
     describe('with a valid payload (yesterdays date)', () => {
       beforeEach(async () => {
-        testDate = new Date()
+        testDate = today()
         testDate.setDate(testDate.getDate() - 1)
-        testDate.setHours(0, 0, 0, 0)
         payload = {
           'received-date-options': 'yesterday'
         }

--- a/test/validators/notices/index.validator.test.js
+++ b/test/validators/notices/index.validator.test.js
@@ -7,6 +7,9 @@ const Code = require('@hapi/code')
 const { describe, it, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
+// Test helpers
+const { today } = require('../../../app/lib/general.lib.js')
+
 // Thing under test
 const IndexValidator = require('../../../app/validators/notices/index.validator.js')
 
@@ -158,9 +161,9 @@ describe('Notices - Index validator', () => {
 
     describe('because "Sent from" is in the future', () => {
       beforeEach(() => {
-        const today = new Date()
+        const todaysDate = today()
 
-        payload.sentFromYear = (today.getFullYear() + 1).toString()
+        payload.sentFromYear = (todaysDate.getFullYear() + 1).toString()
       })
 
       it('fails validation', () => {

--- a/test/validators/return-logs/setup/received-date.validator.test.js
+++ b/test/validators/return-logs/setup/received-date.validator.test.js
@@ -7,6 +7,9 @@ const Code = require('@hapi/code')
 const { describe, it, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
+// Test helpers
+const { today } = require('../../../../app/lib/general.lib.js')
+
 // Thing under test
 const ReceivedDateValidator = require('../../../../app/validators/return-logs/setup/received-date.validator.js')
 
@@ -176,7 +179,7 @@ describe('Return Logs Setup - Received Date validator', () => {
       describe('but entered a future date', () => {
         beforeEach(() => {
           // Get today's date and add 1 day
-          const futureDate = new Date()
+          const futureDate = today()
           futureDate.setDate(futureDate.getDate() + 1) // Set to tomorrow
 
           // Update the payload with the future date values


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5144

We got started on a change to the service that would [Allow ended 'Not due yet' returns to be submitted](https://github.com/DEFRA/water-abstraction-system/pull/2418).

As is often the case, we needed to compare a date from the return log to the current date, but the current date without the time.

This is something we frequently have to do to ensure we are comparing 'date-to-date' rather than 'date-to-datetime'.

If not, we hit edge-case errors when the date we're comparing matches the current date.

We were going to do it as some housekeeping within the original ticket, but then we clocked how often we've needed to do this, so the change became something in its own right.