### PR TITLE
Fix date filter in view notices excluding records

### DIFF
--- a/app/services/notices/fetch-notices.service.js
+++ b/app/services/notices/fetch-notices.service.js
@@ -57,7 +57,14 @@ function _applyFilters(query, filters) {
   }
 
   if (toDate) {
-    query.where('events.createdAt', '<=', new Date(toDate))
+    // NOTE: createdAt is a timestamp, which means it will include a time element. For example, 2025-09-19 13:47:53.859.
+    // But `toDate` will just be the date part. This means when we create a date object from it, its time will be set
+    // to minute. This means if we don't shift toDate to 23:59:99 it will exclude any notices created on the toDate
+    // specified.
+    const toDateForQuery = new Date(toDate)
+
+    toDateForQuery.setHours(23, 59, 59, 999)
+    query.where('events.createdAt', '<=', toDateForQuery.toISOString())
   }
 
   _applyNoticeTypeFilters(query, noticeTypes)

--- a/test/services/notices/fetch-notices.service.test.js
+++ b/test/services/notices/fetch-notices.service.test.js
@@ -30,7 +30,7 @@ describe('Notices - Fetch Notices service', () => {
 
   before(async () => {
     returnsInvitationNotice = await EventHelper.add({
-      createdAt: new Date('2025-07-01'),
+      createdAt: new Date('2025-07-01T15:01:47.023Z'),
       issuer: 'billing.data@wrls.gov.uk',
       metadata: {
         name: 'Returns: invitation',
@@ -57,7 +57,7 @@ describe('Notices - Fetch Notices service', () => {
     await _addNotification(notifications, returnsInvitationNotice.id, 'sent')
 
     legacyNotice = await EventHelper.add({
-      createdAt: new Date('2024-09-01'),
+      createdAt: new Date('2024-09-01T18:42:59.659Z'),
       issuer: 'legacy.alerts@wrls.gov.uk',
       metadata: {
         name: 'Hands off flow: resume abstraction',
@@ -76,7 +76,7 @@ describe('Notices - Fetch Notices service', () => {
     await _addNotification(notifications, legacyNotice.id, 'sent')
 
     abstractionAlertNotice = await EventHelper.add({
-      createdAt: new Date('2025-09-17'),
+      createdAt: new Date('2025-09-17T09:13:26.924Z'),
       issuer: 'abstraction.alerts@wrls.gov.uk',
       metadata: {
         name: 'Water abstraction alert',
@@ -276,6 +276,18 @@ describe('Notices - Fetch Notices service', () => {
         expect(result.results).not.contains(_transformNoticeToResult(returnsInvitationNotice, 'error'))
         expect(result.results).not.contains(_transformNoticeToResult(legacyNotice, 'sent'))
       })
+
+      describe('and when "From Date" is the same as a notice "Created At"', () => {
+        beforeEach(() => {
+          filters.fromDate = new Date('2025-07-01')
+        })
+
+        it('returns the matching notice', async () => {
+          const result = await FetchNoticesService.go(filters, pageNumber)
+
+          expect(result.results).contains(_transformNoticeToResult(returnsInvitationNotice, 'error'))
+        })
+      })
     })
 
     describe('and "To Date" has been set', () => {
@@ -294,6 +306,18 @@ describe('Notices - Fetch Notices service', () => {
 
         expect(result.results).not.contains(_transformNoticeToResult(returnsInvitationNotice, 'error'))
         expect(result.results).not.contains(_transformNoticeToResult(abstractionAlertNotice, 'pending'))
+      })
+
+      describe('and when "To Date" is the same as a notice "Created At"', () => {
+        beforeEach(() => {
+          filters.toDate = new Date('2025-07-01')
+        })
+
+        it('returns the matching notice', async () => {
+          const result = await FetchNoticesService.go(filters, pageNumber)
+
+          expect(result.results).contains(_transformNoticeToResult(returnsInvitationNotice, 'error'))
+        })
       })
     })
   })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5271

The view notices page has a Sent dates filter that allows users to filter notices by

- Date from
- Date to

An issue has been identified when using the 'Date to' filter: any notices matching the entered date are excluded from the results.

The problem is that we are filtering by a date against a datetime field.

Specifically, `created_at` stores both the date and time the record was created, for example, '2025-09-12T09:13:26.924Z'.

The date we are using to filter by does not have a time element. So, it is essentially '2025-09-12T00:00:00.000Z'.

The `WHERE` clause is `WHERE created_at <= toDate`, which means those created on the filter date are being excluded.

It's a relatively simple fix. We need to alter `toDate` to be '2025-09-12T23:59:59.999Z' i.e. the very last point in the day.