### PR TITLE
Prevent selecting default abstraction period outside of return period

### DIFF
--- a/app/presenters/return-logs/setup/period-used.presenter.js
+++ b/app/presenters/return-logs/setup/period-used.presenter.js
@@ -5,6 +5,7 @@
  * @module PeriodUsedPresenter
  */
 
+const DetermineAbstractionPeriodService = require('../../../services/bill-runs/determine-abstraction-periods.service.js')
 const { formatAbstractionPeriod } = require('../../base.presenter.js')
 
 /**
@@ -31,6 +32,17 @@ function go(session) {
     periodUsedToYear
   } = session
 
+  // Determine the valid abstraction periods that overlap with the return period - this will be used to decide whether
+  // or not the "default return period" option will be displayed
+  const returnPeriod = { startDate: new Date(session.startDate), endDate: new Date(session.endDate) }
+  const abstractionPeriods = DetermineAbstractionPeriodService.go(
+    returnPeriod,
+    session.periodStartDay,
+    session.periodStartMonth,
+    session.periodEndDay,
+    session.periodEndMonth
+  )
+
   return {
     abstractionPeriod: formatAbstractionPeriod(periodStartDay, periodStartMonth, periodEndDay, periodEndMonth),
     backLink: `/system/return-logs/setup/${sessionId}/single-volume`,
@@ -43,7 +55,8 @@ function go(session) {
     periodUsedToMonth: periodUsedToMonth ?? null,
     periodUsedToYear: periodUsedToYear ?? null,
     returnReference,
-    sessionId
+    sessionId,
+    showDefaultAbstractionPeriod: abstractionPeriods.length > 0
   }
 }
 

--- a/app/views/return-logs/setup/period-used.njk
+++ b/app/views/return-logs/setup/period-used.njk
@@ -100,30 +100,6 @@
         }) }}
       {% endset %}
 
-      {% set defaultItem = {
-          value: "default",
-          text: "Default abstraction period",
-          hint: { text: abstractionPeriod },
-          checked: periodDateUsedOptions === 'default'
-        }
-      %}
-
-      {% set customItem = {
-          value: "custom-dates",
-          text: "Custom dates",
-          checked: periodDateUsedOptions === 'custom-dates',
-          conditional: { html: dateInputHTML }
-        }
-      %}
-
-      {% set radioItems = [] %}
-
-      {% if showDefaultAbstractionPeriod %}
-        {% set radioItems = (radioItems.push(defaultItem), radioItems) %}
-      {% endif %}
-
-      {% set radioItems = (radioItems.push(customItem), radioItems) %}
-
       {{ govukRadios({
         name: "periodDateUsedOptions",
         errorMessage: {
@@ -134,7 +110,22 @@
             classes: "govuk-fieldset__legend--l"
           }
         },
-        items: radioItems
+        items: [
+          {
+            value: "default",
+            text: "Default abstraction period",
+            hint: { text: abstractionPeriod },
+            checked: periodDateUsedOptions === 'default'
+          } if showDefaultAbstractionPeriod,
+          {
+            value: "custom-dates",
+            text: "Custom dates",
+            checked: periodDateUsedOptions === 'custom-dates',
+            conditional: {
+              html: dateInputHTML
+            }
+          }
+        ]
       }) }}
 
       {{ govukButton({ text: "Continue", preventDoubleClick: true }) }}

--- a/app/views/return-logs/setup/period-used.njk
+++ b/app/views/return-logs/setup/period-used.njk
@@ -100,6 +100,30 @@
         }) }}
       {% endset %}
 
+      {% set defaultItem = {
+          value: "default",
+          text: "Default abstraction period",
+          hint: { text: abstractionPeriod },
+          checked: periodDateUsedOptions === 'default'
+        }
+      %}
+
+      {% set customItem = {
+          value: "custom-dates",
+          text: "Custom dates",
+          checked: periodDateUsedOptions === 'custom-dates',
+          conditional: { html: dateInputHTML }
+        }
+      %}
+
+      {% set radioItems = [] %}
+
+      {% if showDefaultAbstractionPeriod %}
+        {% set radioItems = (radioItems.push(defaultItem), radioItems) %}
+      {% endif %}
+
+      {% set radioItems = (radioItems.push(customItem), radioItems) %}
+
       {{ govukRadios({
         name: "periodDateUsedOptions",
         errorMessage: {
@@ -110,22 +134,7 @@
             classes: "govuk-fieldset__legend--l"
           }
         },
-        items: [
-          {
-            value: "default",
-            text: "Default abstraction period",
-            hint: { text: abstractionPeriod },
-            checked: periodDateUsedOptions === 'default'
-          },
-          {
-            value: "custom-dates",
-            text: "Custom dates",
-            checked: periodDateUsedOptions === 'custom-dates',
-            conditional: {
-              html: dateInputHTML
-            }
-          }
-        ]
+        items: radioItems
       }) }}
 
       {{ govukButton({ text: "Continue", preventDoubleClick: true }) }}

--- a/test/presenters/return-logs/setup/period-used.presenter.test.js
+++ b/test/presenters/return-logs/setup/period-used.presenter.test.js
@@ -40,7 +40,8 @@ describe('Return Logs Setup - Period Used presenter', () => {
         periodUsedFromYear: null,
         periodUsedToDay: null,
         periodUsedToMonth: null,
-        periodUsedToYear: null
+        periodUsedToYear: null,
+        showDefaultAbstractionPeriod: true
       })
     })
   })

--- a/test/presenters/return-logs/setup/period-used.presenter.test.js
+++ b/test/presenters/return-logs/setup/period-used.presenter.test.js
@@ -107,4 +107,21 @@ describe('Return Logs Setup - Period Used presenter', () => {
       })
     })
   })
+
+  describe('when the default abstraction period does not overlap with the return period', () => {
+    beforeEach(() => {
+      session.periodStartDay = '01'
+      session.periodStartMonth = '11'
+      session.periodEndDay = '31'
+      session.periodEndMonth = '03'
+      session.startDate = new Date('2023-04-01')
+      session.endDate = new Date('2023-06-26')
+    })
+
+    it('does not show the default abstraction period', () => {
+      const result = PeriodUsedPresenter.go(session)
+
+      expect(result.showDefaultAbstractionPeriod).to.be.false()
+    })
+  })
 })

--- a/test/services/return-logs/setup/period-used.service.test.js
+++ b/test/services/return-logs/setup/period-used.service.test.js
@@ -51,7 +51,8 @@ describe('Return Logs Setup - Period used service', () => {
           periodUsedFromYear: null,
           periodUsedToDay: null,
           periodUsedToMonth: null,
-          periodUsedToYear: null
+          periodUsedToYear: null,
+          showDefaultAbstractionPeriod: true
         },
         { skip: ['sessionId'] }
       )

--- a/test/services/return-logs/setup/submit-period-used.service.test.js
+++ b/test/services/return-logs/setup/submit-period-used.service.test.js
@@ -157,7 +157,8 @@ describe('Return Logs Setup - Submit Period Used service', () => {
             periodUsedFromYear: null,
             periodUsedToDay: null,
             periodUsedToMonth: null,
-            periodUsedToYear: null
+            periodUsedToYear: null,
+            showDefaultAbstractionPeriod: true
           },
           { skip: ['sessionId', 'error'] }
         )


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5277

When a user selects a period for a return, they are presented with a default option, which is the defined return period from the licence for that return, for example 1 November to 31 March.

However, sometimes this falls outside of the period of the return, which may happen when the licence is revoked.

In this case, we should not display this default option - at the moment this then causes an error when the option is submitted.

This change checks to see if there are any abstraction periods that overlap with the return period and if there aren't then it doesn't display the default return period option.