### PR TITLE
Revert abstraction alerts to send to licence holder as well as the additional contacts

### DIFF
--- a/test/services/notices/setup/fetch-abstraction-alert-recipients.service.test.js
+++ b/test/services/notices/setup/fetch-abstraction-alert-recipients.service.test.js
@@ -157,7 +157,7 @@ describe('Notices - Setup - Fetch abstraction alert recipients service', () => {
         })
       })
 
-      it('correctly returns the "additional contact" and not the "primary user"', async () => {
+      it('correctly returns the "additional contact" and the "primary user"', async () => {
         const result = await FetchAbstractionAlertRecipientsService.go(session)
 
         expect(result).to.equal([
@@ -167,6 +167,13 @@ describe('Notices - Setup - Fetch abstraction alert recipients service', () => {
             contact_type: 'Additional contact',
             email: 'Ron.Burgundy@news.com',
             licence_refs: recipients.primaryUser.licenceRef
+          },
+          {
+            licence_refs: recipients.primaryUser.licenceRef,
+            contact: null,
+            contact_hash_id: '90129f6aa5bf2ad50aa3fefd3f8cf86a',
+            contact_type: 'Primary user',
+            email: 'primary.user@important.com'
           }
         ])
       })
@@ -226,7 +233,7 @@ describe('Notices - Setup - Fetch abstraction alert recipients service', () => {
         })
       })
 
-      it('correctly returns the "additional contact" and not the "licence holder"', async () => {
+      it('correctly returns the "additional contact" and the "licence holder"', async () => {
         const result = await FetchAbstractionAlertRecipientsService.go(session)
 
         expect(result).to.equal([
@@ -236,6 +243,28 @@ describe('Notices - Setup - Fetch abstraction alert recipients service', () => {
             contact_type: 'Additional contact',
             email: 'Brian.Fantana@news.com',
             licence_refs: recipients.licenceHolder.licenceRef
+          },
+          {
+            licence_refs: recipients.licenceHolder.licenceRef,
+            contact: {
+              addressLine1: '4',
+              addressLine2: 'Privet Drive',
+              addressLine3: null,
+              addressLine4: null,
+              country: null,
+              county: 'Surrey',
+              forename: 'Harry',
+              initials: 'J',
+              name: 'Licence holder only',
+              postcode: 'WD25 7LR',
+              role: 'Licence holder',
+              salutation: null,
+              town: 'Little Whinging',
+              type: 'Person'
+            },
+            contact_hash_id: '22f6457b6be9fd63d8a9a8dd2ed61214',
+            contact_type: 'Licence holder',
+            email: null
           }
         ])
       })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5283

We initially implemented alerts to send a notice to the licence holder and additional contacts, this resembled the legacy codes implementation. We were then told this is wrong... so we updated the logic to only send to an additional contact if present, this was done here - https://github.com/DEFRA/water-abstraction-system/pull/2077.

We have told again that the first implementation was correct and the change made to only send to additional contacts should be changed back.

This change does that. We can not straight up revert the commit and some things have been changed in other places.

So this change re-implements the original logic.