### PR TITLE
Return logs - Persist zero quantities

### DIFF
--- a/app/services/return-logs/setup/create-return-lines.service.js
+++ b/app/services/return-logs/setup/create-return-lines.service.js
@@ -111,7 +111,7 @@ function _returnLines(returnSubmissionId, session, timestamp) {
       ...restOfLine,
       id: generateUUID(),
       createdAt: timestamp,
-      quantity: rawQuantity ? _convertToCubicMetres(rawQuantity, session.units) : undefined,
+      quantity: rawQuantity ? _convertToCubicMetres(rawQuantity, session.units) : rawQuantity,
       readingType: session.meterProvided === 'yes' ? 'measured' : 'estimated',
       returnSubmissionId,
       timePeriod: session.returnsFrequency,

--- a/app/services/return-logs/setup/initiate-session.service.js
+++ b/app/services/return-logs/setup/initiate-session.service.js
@@ -211,7 +211,8 @@ function _submissionLines(returnSubmissionLines) {
   return returnSubmissionLines.map((returnSubmissionLine) => {
     const { endDate, quantity, reading, startDate, userUnit } = returnSubmissionLine
 
-    let convertedQuantity
+    let convertedQuantity = quantity
+
     if (quantity) {
       convertedQuantity = quantity * returnUnits[userUnit].multiplier
     }

--- a/test/services/return-logs/setup/create-return-lines.service.test.js
+++ b/test/services/return-logs/setup/create-return-lines.service.test.js
@@ -35,13 +35,12 @@ describe('Return Logs Setup - Create New Return Lines service', () => {
             startDate: '2024-11-02T00:00:00.000Z',
             endDate: '2024-11-08T00:00:00.000Z',
             reading: 2345,
-            quantity: 32
+            quantity: 0
           },
           {
             startDate: '2024-11-09T00:00:00.000Z',
             endDate: '2024-11-15T00:00:00.000Z',
-            reading: 3456,
-            quantity: 64
+            reading: 3456
           }
         ],
         meter10TimesDisplay: 'no',
@@ -56,16 +55,18 @@ describe('Return Logs Setup - Create New Return Lines service', () => {
     it('inserts the lines', async () => {
       await CreateReturnLinesService.go(returnSubmissionId, session, timestamp)
 
-      const [result] = await ReturnSubmissionLineModel.query().where('returnSubmissionId', returnSubmissionId)
+      const result = await ReturnSubmissionLineModel.query().where('returnSubmissionId', returnSubmissionId)
 
-      expect(result.createdAt).to.equal(new Date(timestamp))
-      expect(result.endDate).to.equal(new Date('2024-11-01T00:00:00.000Z'))
-      expect(result.quantity).to.equal(16)
-      expect(result.readingType).to.equal('estimated')
-      expect(result.returnSubmissionId).to.equal(returnSubmissionId)
-      expect(result.startDate).to.equal(new Date('2024-10-26T00:00:00.000Z'))
-      expect(result.timePeriod).to.equal('week')
-      expect(result.userUnit).to.equal('m³')
+      expect(result[0].createdAt).to.equal(new Date(timestamp))
+      expect(result[0].endDate).to.equal(new Date('2024-11-01T00:00:00.000Z'))
+      expect(result[0].quantity).to.equal(16)
+      expect(result[1].quantity).to.equal(0)
+      expect(result[2].quantity).to.be.null()
+      expect(result[0].readingType).to.equal('estimated')
+      expect(result[0].returnSubmissionId).to.equal(returnSubmissionId)
+      expect(result[0].startDate).to.equal(new Date('2024-10-26T00:00:00.000Z'))
+      expect(result[0].timePeriod).to.equal('week')
+      expect(result[0].userUnit).to.equal('m³')
     })
 
     describe('when the unit of measurement is megalitres', () => {

--- a/test/services/return-logs/setup/initiate-session.service.test.js
+++ b/test/services/return-logs/setup/initiate-session.service.test.js
@@ -129,6 +129,33 @@ describe('Return Logs - Setup - Initiate Session service', () => {
       })
     })
 
+    describe('and a zero quantity is specified', () => {
+      before(async () => {
+        returnLog = await ReturnLogHelper.add({
+          licenceRef: licence.licenceRef,
+          metadata,
+          receivedDate: new Date('2025-03-06'),
+          endDate: new Date('2022-06-01')
+        })
+
+        returnSubmission = await ReturnSubmissionHelper.add({
+          returnLogId: returnLog.id,
+          metadata: { method: 'abstractionVolumes' }
+        })
+        await ReturnSubmissionLineHelper.add({ quantity: 0, returnSubmissionId: returnSubmission.id })
+      })
+
+      it('returns the quantity as expected', async () => {
+        const result = await InitiateSessionService.go(returnLog.id)
+
+        const sessionId = _getSessionId(result)
+
+        const matchingSession = await SessionModel.query().findById(sessionId)
+
+        expect(matchingSession.data.lines[0].quantity).to.equal(0)
+      })
+    })
+
     describe('and a unit is specified', () => {
       before(async () => {
         returnLog = await ReturnLogHelper.add({


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5279

When submitting a return. If the line quantity is entered as zero it is not being saved to the DB when the return is submitted. Instead it is being recorded as `null`. Also zeros are not being persisted to the session when editing a return.

This was happening because if the quantity was `null`, `undefined` or zero, undefined was being returned. This has been fixed in this PR by just returning the quantity instead of `undefined` if the quantity is not truthy.