### PR TITLE
Handle decimal rules service charge values

### DIFF
--- a/app/services/bill-licences/fetch-bill-licence.service.js
+++ b/app/services/bill-licences/fetch-bill-licence.service.js
@@ -63,13 +63,13 @@ async function _fetchBillLicence(id) {
           'startDate',
           'supportedSourceName',
           'volume',
-          ref('grossValuesCalculated:baselineCharge').castInt().as('baselineCharge'),
+          ref('grossValuesCalculated:baselineCharge').castDecimal().as('baselineCharge'),
           ref('abstractionPeriod:startDay').castInt().as('abstractionPeriodStartDay'),
           ref('abstractionPeriod:startMonth').castInt().as('abstractionPeriodStartMonth'),
           ref('abstractionPeriod:endDay').castInt().as('abstractionPeriodEndDay'),
           ref('abstractionPeriod:endMonth').castInt().as('abstractionPeriodEndMonth'),
-          ref('grossValuesCalculated:supportedSourceCharge').castInt().as('supportedSourceChargeValue'),
-          ref('grossValuesCalculated:waterCompanyCharge').castInt().as('waterCompanyChargeValue')
+          ref('grossValuesCalculated:supportedSourceCharge').castDecimal().as('supportedSourceChargeValue'),
+          ref('grossValuesCalculated:waterCompanyCharge').castDecimal().as('waterCompanyChargeValue')
         ])
         .orderBy([
           { column: 'chargeCategoryCode', order: 'desc' },


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5275

It started with our acceptance tests failing, and then B&D created a bill run and saw an error when trying to view the transactions.

We tracked the problem down to the values the **Rules Service** was returning to the [Charging Module](https://github.com/DEFRA/sroc-charging-module-api).

To add a transaction to a bill run, we determine the various values for it, such as billable days, actual volume, and loss factor, among others. We then send a request to the **Charging Module**. It, in turn, forwards these details to the **Rules Service**, a system managed by finance that holds the 'rules' for how to calculate a charge for various regimes.

Part of these rules are 'set charge values'. Once the **Rules Service** has determined the charge for the transaction, it returns the result to the **Charging Module**. Included in the response is a copy of all the information used to determine the charge, including the set charge values. The **Charging Module** records the complete response for audit purposes.

Back to WRLS, once all the transactions have been created and the bill run has been generated, our service then retrieves all the 'bills' the **Charging Module** has created, including each transaction's charge value. When we _were_ the **Charging Module** team, we didn't know that WRLS also extracts some of those set charge values from the saved **Rules Service** response.

If we'd have known, we would have made them top-level properties in the API response and done a bit more work to understand what they were. On the WRLS side, they may then have also held them in the table, rather than in a JSONB blob. But no problem, stuff has worked anyway... till now!

Those values were always integer values. In all previous years, when the values were increased, they were always rounded to the nearest pound. For the first year since WRLS has handled charging, the business has decided _not_ to round the values.

The problem is that our query to fetch them converts the values from text to integers, thereby avoiding our code from having to do the same. Now that the query is hitting decimal values, it is breaking.

This change updates the query to cast them to numeric instead.