### PR TITLE
Refactor 'end' process in setup notice journey - create notifications before batching

### DIFF
--- a/app/models/event.model.js
+++ b/app/models/event.model.js
@@ -14,6 +14,11 @@ class EventModel extends BaseModel {
     return 'events'
   }
 
+  // Defining which fields contain json allows us to insert an object without needing to stringify it first
+  static get jsonAttributes() {
+    return ['licences']
+  }
+
   static get relationMappings() {
     return {
       scheduledNotifications: {

--- a/app/presenters/notices/setup/create-notice.presenter.js
+++ b/app/presenters/notices/setup/create-notice.presenter.js
@@ -48,19 +48,15 @@ function go(session, recipients, auth) {
 
 /**
  * All the licences associated with an event (licences that will receive notifications) are stored in
- * `water.events.licences`. It is not clear where these are used. But to be consistent we follow the established
+ * `water.events.licences`. It is not clear where these are used. But to be consistent, we follow the established
  * pattern.
- *
- * These licences are stored as 'jsonb' so we need to stringify the array to match the schema.
  *
  * @private
  */
 function _licences(recipients) {
-  const formattedRecipients = recipients.flatMap((recipient) => {
+  return recipients.flatMap((recipient) => {
     return transformStringOfLicencesToArray(recipient.licence_refs)
   })
-
-  return JSON.stringify(formattedRecipients)
 }
 
 /**

--- a/app/services/notices/setup/determine-notifications.service.js
+++ b/app/services/notices/setup/determine-notifications.service.js
@@ -19,17 +19,17 @@ const NotificationsPresenter = require('../../../presenters/notices/setup/notifi
  * @returns {Promise<object[]>} An array of notification formatted to persist and send
  */
 async function go(session, recipients, eventId) {
-  let notifications
+  const { journey, noticeType } = session
 
-  if (session.journey === 'alerts') {
-    notifications = AbstractionAlertNotificationsPresenter.go(recipients, session, eventId)
-  } else if (session.noticeType === 'returnForms') {
-    notifications = await DetermineReturnFormsService.go(session, recipients, eventId)
-  } else {
-    notifications = NotificationsPresenter.go(recipients, session, eventId)
+  if (journey === 'alerts') {
+    return AbstractionAlertNotificationsPresenter.go(recipients, session, eventId)
   }
 
-  return notifications
+  if (noticeType === 'returnForms') {
+    return await DetermineReturnFormsService.go(session, recipients, eventId)
+  }
+
+  return NotificationsPresenter.go(recipients, session, eventId)
 }
 
 module.exports = {

--- a/app/services/notices/setup/determine-notifications.service.js
+++ b/app/services/notices/setup/determine-notifications.service.js
@@ -1,0 +1,37 @@
+'use strict'
+
+/**
+ * Orchestrates creating the notifications for Notify and saving the notification to 'water.notifications'
+ * @module DetermineNotificationsService
+ */
+
+const AbstractionAlertNotificationsPresenter = require('../../../presenters/notices/setup/abstraction-alert-notifications.presenter.js')
+const DetermineReturnFormsService = require('./determine-return-forms.service.js')
+const NotificationsPresenter = require('../../../presenters/notices/setup/notifications.presenter.js')
+
+/**
+ * Orchestrates creating the notifications for Notify and saving the notification to 'water.notifications'
+ *
+ * @param {SessionModel} session - The session instance
+ * @param {object[]} recipients - The recipients to create notifications for
+ * @param {string} eventId - the event UUID to link all the notifications to
+ *
+ * @returns {Promise<object[]>} An array of notification formatted to persist and send
+ */
+async function go(session, recipients, eventId) {
+  let notifications
+
+  if (session.journey === 'alerts') {
+    notifications = AbstractionAlertNotificationsPresenter.go(recipients, session, eventId)
+  } else if (session.noticeType === 'returnForms') {
+    notifications = await DetermineReturnFormsService.go(session, recipients, eventId)
+  } else {
+    notifications = NotificationsPresenter.go(recipients, session, eventId)
+  }
+
+  return notifications
+}
+
+module.exports = {
+  go
+}

--- a/app/services/notices/setup/determine-notifications.service.js
+++ b/app/services/notices/setup/determine-notifications.service.js
@@ -26,7 +26,7 @@ async function go(session, recipients, eventId) {
   }
 
   if (noticeType === 'returnForms') {
-    return await DetermineReturnFormsService.go(session, recipients, eventId)
+    return DetermineReturnFormsService.go(session, recipients, eventId)
   }
 
   return NotificationsPresenter.go(recipients, session, eventId)

--- a/app/services/notices/setup/submit-check.service.js
+++ b/app/services/notices/setup/submit-check.service.js
@@ -36,7 +36,7 @@ async function go(sessionId, auth) {
 
   const notifications = await DetermineNotificationsService.go(sessionCopy, recipients, notice.id)
 
-  _processNotifications(sessionCopy, notifications, notice)
+  _processNotifications(notifications, notice)
 
   return notice.id
 }
@@ -47,7 +47,7 @@ async function _notice(session, recipients, auth) {
   return CreateNoticeService.go(event)
 }
 
-async function _processNotifications(session, notifications, notice) {
+async function _processNotifications(notifications, notice) {
   try {
     const startTime = currentTimeInNanoseconds()
 

--- a/test/presenters/notices/setup/create-notice.presenter.test.js
+++ b/test/presenters/notices/setup/create-notice.presenter.test.js
@@ -65,10 +65,14 @@ describe('Notices - Setup - Create Notice presenter', () => {
 
       expect(result).to.equal({
         issuer: 'hello@world.com',
-        licences:
-          `["${recipients.primaryUser.licence_refs}","${recipients.returnsAgent.licence_refs}",` +
-          `"${recipients.licenceHolder.licence_refs}","${recipients.returnsTo.licence_refs}",` +
-          `"${firstMultiple}","${secondMultiple}"]`,
+        licences: [
+          recipients.primaryUser.licence_refs,
+          recipients.returnsAgent.licence_refs,
+          recipients.licenceHolder.licence_refs,
+          recipients.returnsTo.licence_refs,
+          firstMultiple,
+          secondMultiple
+        ],
         metadata: {
           name: 'Returns: invitation',
           options: {
@@ -102,11 +106,14 @@ describe('Notices - Setup - Create Notice presenter', () => {
 
         const [firstMultiple, secondMultiple] = recipients.licenceHolderWithMultipleLicences.licence_refs.split(',')
 
-        expect(result.licences).to.equal(
-          `["${recipients.primaryUser.licence_refs}","${recipients.returnsAgent.licence_refs}",` +
-            `"${recipients.licenceHolder.licence_refs}","${recipients.returnsTo.licence_refs}",` +
-            `"${firstMultiple}","${secondMultiple}"]`
-        )
+        expect(result.licences).to.equal([
+          recipients.primaryUser.licence_refs,
+          recipients.returnsAgent.licence_refs,
+          recipients.licenceHolder.licence_refs,
+          recipients.returnsTo.licence_refs,
+          firstMultiple,
+          secondMultiple
+        ])
       })
     })
 
@@ -227,9 +234,11 @@ describe('Notices - Setup - Create Notice presenter', () => {
 
       expect(result).to.equal({
         issuer: 'hello@world.com',
-        licences:
-          `["${recipients.additionalContact.licence_refs}","${recipients.licenceHolder.licence_refs}",` +
-          `"${recipients.primaryUser.licence_refs}"]`,
+        licences: [
+          recipients.additionalContact.licence_refs,
+          recipients.licenceHolder.licence_refs,
+          recipients.primaryUser.licence_refs
+        ],
         metadata: {
           name: 'Water abstraction alert',
           options: {
@@ -248,10 +257,11 @@ describe('Notices - Setup - Create Notice presenter', () => {
       it('correctly return a JSON string containing an array of all licences from all recipients', () => {
         const result = CreateNoticePresenter.go(session, testRecipients, auth)
 
-        expect(result.licences).to.equal(
-          `["${recipients.additionalContact.licence_refs}","${recipients.licenceHolder.licence_refs}",` +
-            `"${recipients.primaryUser.licence_refs}"]`
-        )
+        expect(result.licences).to.equal([
+          recipients.additionalContact.licence_refs,
+          recipients.licenceHolder.licence_refs,
+          recipients.primaryUser.licence_refs
+        ])
       })
     })
 

--- a/test/services/notices/setup/batch-notifications.service.test.js
+++ b/test/services/notices/setup/batch-notifications.service.test.js
@@ -18,10 +18,9 @@ const { notifyTemplates } = require('../../../../app/lib/notify-templates.lib.js
 
 // Things we need to stub
 const CreateEmailRequest = require('../../../../app/requests/notify/create-email.request.js')
+const CreateLetterRequest = require('../../../../app/requests/notify/create-letter.request.js')
 const CreatePrecompiledFileRequest = require('../../../../app/requests/notify/create-precompiled-file.request.js')
-const DetermineReturnFormsService = require('../../../../app/services/notices/setup/determine-return-forms.service.js')
 const NotifyConfig = require('../../../../config/notify.config.js')
-const NotifyLetterRequest = require('../../../../app/requests/notify/create-letter.request.js')
 const ProcessNotificationStatusService = require('../../../../app/services/jobs/notification-status/process-notification-status.service.js')
 
 // Thing under test
@@ -31,851 +30,372 @@ describe('Notices - Setup - Batch Notifications service', () => {
   const ONE_HUNDRED_MILLISECONDS = 100
 
   let event
-  let recipients
+  let notifications
   let recipientsFixture
   let reference
-  let session
+  let testNotification
 
   beforeEach(async () => {
+    recipientsFixture = RecipientsFixture.recipients()
+
+    reference = generateReferenceCode()
+
+    const notifyResponse = successfulNotifyResponses(reference)
+
+    Sinon.stub(CreateEmailRequest, 'send').onCall(0).resolves(notifyResponse.email)
+    Sinon.stub(CreateLetterRequest, 'send').onCall(0).resolves(notifyResponse.letter)
+
+    Sinon.stub(ProcessNotificationStatusService, 'go')
+
     // By setting the batch size to 1 we can prove that all the batches are run, as we should have all the notifications
     // still saved in the database regardless of batch size
     Sinon.stub(NotifyConfig, 'batchSize').value(1)
     // By setting the delay to 100ms we can keep the tests fast whilst assuring our batch mechanism is delaying
-    // correctly, we do not want increase the timeout for the test as we want them to fail if a timeout occurs
+    // correctly, we do not want to increase the timeout for the test as we want them to fail if a timeout occurs
     Sinon.stub(NotifyConfig, 'delay').value(ONE_HUNDRED_MILLISECONDS)
-
-    Sinon.stub(ProcessNotificationStatusService, 'go')
   })
 
   afterEach(() => {
     Sinon.restore()
   })
 
-  describe('when sending return invitations or reminders', () => {
+  describe('when sending emails', () => {
     beforeEach(async () => {
-      reference = generateReferenceCode()
-
-      recipientsFixture = RecipientsFixture.recipients()
-      recipients = [...Object.values(recipientsFixture)]
-
       event = await EventHelper.add({
         metadata: {},
-        licences: _licences(recipients),
+        licences: [recipientsFixture.primaryUser],
         referenceCode: reference,
         status: 'completed',
         subtype: 'returnInvitation',
         type: 'notification'
       })
 
-      session = {
-        determinedReturnsPeriod: {
-          name: 'allYear',
-          dueDate: '2025-04-28',
-          endDate: '2023-03-31',
-          summer: 'false',
-          startDate: '2022-04-01'
-        },
-        journey: 'standard',
-        noticeType: 'invitations',
-        referenceCode: reference
-      }
+      const testNotification = _notifications(event.id, [recipientsFixture.primaryUser.licence_refs], reference)
+
+      notifications = [testNotification.email]
     })
 
-    describe('that contains letters and emails', () => {
-      describe('and the requests to Notify in the batch are a mix of successes and failures', () => {
-        beforeEach(() => {
-          Sinon.stub(CreateEmailRequest, 'send')
-            .onCall(0)
-            .resolves({
-              succeeded: false,
-              response: {
-                statusCode: 400,
-                body: {
-                  errors: [
-                    {
-                      error: 'ValidationError',
-                      message: 'email_address Not a valid email address'
-                    }
-                  ],
-                  status_code: 400
-                }
-              }
-            })
-            .onCall(1)
-            .resolves({
-              succeeded: true,
-              response: {
-                statusCode: 200,
-                body: {
-                  content: {
-                    body: 'Dear licence holder,\r\n',
-                    from_email: 'environment.agency.water.resources.licensing.service@notifications.service.gov.uk',
-                    one_click_unsubscribe_url: null,
-                    subject: 'Submit your water abstraction returns by 28th April 2025'
-                  },
-                  id: '9a0a0ba0-9dc7-4322-9a68-cb370220d0c9',
-                  reference,
-                  scheduled_for: null,
-                  template: {
-                    id: notifyTemplates.standard.invitations.returnsAgentEmail,
-                    uri: `https://api.notifications.service.gov.uk/services/2232718f-fc58-4413-9e41-135496648da7/templates/${notifyTemplates.standard.invitations.returnsAgentEmail}`,
-                    version: 40
-                  },
-                  uri: 'https://api.notifications.service.gov.uk/v2/notifications/9a0a0ba0-9dc7-4322-9a68-cb370220d0c9'
-                }
-              }
-            })
+    it('should send and then save the notification', async () => {
+      await BatchNotificationsService.go(notifications, event.id)
 
-          Sinon.stub(NotifyLetterRequest, 'send')
-            .onCall(0)
-            .resolves({
-              succeeded: true,
-              response: {
-                statusCode: 200,
-                body: {
-                  content: {
-                    body: 'Dear Licence holder,\r\n',
-                    subject: 'Submit your water abstraction returns by 28th April 2025'
-                  },
-                  id: 'fff6c2a9-77fc-4553-8265-546109a45044',
-                  reference,
-                  scheduled_for: null,
-                  template: {
-                    id: notifyTemplates.standard.invitations.licenceHolderLetter,
-                    uri: `https://api.notifications.service.gov.uk/services/2232718f-fc58-4413-9e41-135496648da7/templates/${notifyTemplates.standard.invitations.licenceHolderLetter}`,
-                    version: 32
-                  },
-                  uri: 'https://api.notifications.service.gov.uk/v2/notifications/fff6c2a9-77fc-4553-8265-546109a45044'
-                }
-              }
-            })
-            .onCall(1)
-            .resolves({
-              succeeded: false,
-              response: {
-                statusCode: 400,
-                body: {
-                  errors: [
-                    {
-                      error: 'BadRequestError',
-                      message: 'Missing personalisation: returnDueDate'
-                    }
-                  ],
-                  status_code: 400
-                }
-              }
-            })
-            .onCall(2)
-            .resolves({
-              succeeded: true,
-              response: {
-                statusCode: 200,
-                body: {
-                  content: {
-                    body: 'Dear Licence holder with multiple licences,\r\n',
-                    subject: 'Submit your water abstraction returns by 28th April 2025'
-                  },
-                  id: '997a76c7-7866-4bd3-b199-ca69eef31a41',
-                  reference,
-                  scheduled_for: null,
-                  template: {
-                    id: notifyTemplates.standard.invitations.licenceHolderLetter,
-                    uri: `https://api.notifications.service.gov.uk/services/2232718f-fc58-4413-9e41-135496648da7/templates/${notifyTemplates.standard.invitations.licenceHolderLetter}`,
-                    version: 32
-                  },
-                  uri: 'https://api.notifications.service.gov.uk/v2/notifications/997a76c7-7866-4bd3-b199-ca69eef31a41'
-                }
-              }
-            })
-        })
+      // Confirm the notifications are created and Notify request recorded as expected
+      const createdNotifications = await NotificationModel.query().where('eventId', event.id)
 
-        it("always creates the notifications including the result of the request to Notify, and updates the Event's error count", async () => {
-          await BatchNotificationsService.go(recipients, session, event.id)
-
-          // Confirm the event is updated with the error count
-          const refreshedEvent = await event.$query()
-
-          expect(refreshedEvent).to.equal({
-            id: event.id,
-            referenceCode: reference,
-            type: 'notification',
-            subtype: 'returnInvitation',
-            issuer: 'test.user@defra.gov.uk',
-            licences: event.licences,
-            entities: null,
-            metadata: { error: 2 },
-            status: 'completed',
-            createdAt: event.createdAt,
-            updatedAt: refreshedEvent.updatedAt
-          })
-
-          // Confirm the notifications are created and Notify request recorded as expected
-          const createdNotifications = await NotificationModel.query().where('eventId', event.id)
-
-          expect(createdNotifications).to.have.length(5)
-          expect(createdNotifications[0]).to.equal(
-            {
-              eventId: event.id,
-              licenceMonitoringStationId: null,
-              licences: recipients[0].licence_refs.split(','),
-              messageRef: 'returns_invitation_primary_user_email',
-              messageType: 'email',
-              plaintext: null,
-              personalisation: {
-                periodEndDate: '31 March 2023',
-                returnDueDate: '28 April 2025',
-                periodStartDate: '1 April 2022'
-              },
-              notifyError:
-                '{"status":400,"message":"Request failed with status code 400","errors":[{"error":"ValidationError","message":"email_address Not a valid email address"}]}',
-              notifyId: null,
-              notifyStatus: null,
-              recipient: 'primary.user@important.com',
-              returnLogIds: null,
-              status: 'error'
-            },
-            { skip: ['id', 'createdAt'] }
-          )
-
-          expect(createdNotifications[1]).to.equal(
-            {
-              eventId: event.id,
-              licenceMonitoringStationId: null,
-              licences: recipients[1].licence_refs.split(','),
-              messageRef: 'returns_invitation_returns_agent_email',
-              messageType: 'email',
-              plaintext: 'Dear licence holder,\r\n',
-              personalisation: {
-                periodEndDate: '31 March 2023',
-                returnDueDate: '28 April 2025',
-                periodStartDate: '1 April 2022'
-              },
-              notifyError: null,
-              notifyId: '9a0a0ba0-9dc7-4322-9a68-cb370220d0c9',
-              notifyStatus: 'created',
-              recipient: 'returns.agent@important.com',
-              returnLogIds: null,
-              status: 'pending'
-            },
-            { skip: ['id', 'createdAt'] }
-          )
-
-          expect(createdNotifications[2]).to.equal(
-            {
-              eventId: event.id,
-              licenceMonitoringStationId: null,
-              licences: recipients[2].licence_refs.split(','),
-              messageRef: 'returns_invitation_licence_holder_letter',
-              messageType: 'letter',
-              plaintext: 'Dear Licence holder,\r\n',
-              personalisation: {
-                name: 'Mr H J Licence holder',
-                periodEndDate: '31 March 2023',
-                returnDueDate: '28 April 2025',
-                address_line_1: 'Mr H J Licence holder',
-                address_line_2: '1',
-                address_line_3: 'Privet Drive',
-                address_line_4: 'Little Whinging',
-                address_line_5: 'Surrey',
-                address_line_6: 'WD25 7LR',
-                periodStartDate: '1 April 2022'
-              },
-              notifyError: null,
-              notifyId: 'fff6c2a9-77fc-4553-8265-546109a45044',
-              notifyStatus: 'created',
-              recipient: null,
-              returnLogIds: null,
-              status: 'pending'
-            },
-            { skip: ['id', 'createdAt'] }
-          )
-
-          expect(createdNotifications[3]).to.equal(
-            {
-              eventId: event.id,
-              licenceMonitoringStationId: null,
-              licences: recipients[3].licence_refs.split(','),
-              messageRef: 'returns_invitation_returns_to_letter',
-              messageType: 'letter',
-              plaintext: null,
-              personalisation: {
-                name: 'Mr H J Returns to',
-                periodEndDate: '31 March 2023',
-                returnDueDate: '28 April 2025',
-                address_line_1: 'Mr H J Returns to',
-                address_line_2: 'INVALID ADDRESS - Needs a valid postcode or country outside the UK',
-                address_line_3: '2',
-                address_line_4: 'Privet Drive',
-                address_line_5: 'Little Whinging',
-                address_line_6: 'Surrey',
-                periodStartDate: '1 April 2022'
-              },
-              notifyError:
-                '{"status":400,"message":"Request failed with status code 400","errors":[{"error":"BadRequestError","message":"Missing personalisation: returnDueDate"}]}',
-              notifyId: null,
-              notifyStatus: null,
-              recipient: null,
-              returnLogIds: null,
-              status: 'error'
-            },
-            { skip: ['id', 'createdAt'] }
-          )
-
-          expect(createdNotifications[4]).to.equal(
-            {
-              eventId: event.id,
-              licenceMonitoringStationId: null,
-              licences: recipients[4].licence_refs.split(','),
-              messageRef: 'returns_invitation_licence_holder_letter',
-              messageType: 'letter',
-              plaintext: 'Dear Licence holder with multiple licences,\r\n',
-              personalisation: {
-                name: 'Mr H J Licence holder with multiple licences',
-                periodEndDate: '31 March 2023',
-                returnDueDate: '28 April 2025',
-                address_line_1: 'Mr H J Licence holder with multiple licences',
-                address_line_2: '3',
-                address_line_3: 'Privet Drive',
-                address_line_4: 'Little Whinging',
-                address_line_5: 'Surrey',
-                address_line_6: 'WD25 7LR',
-                periodStartDate: '1 April 2022'
-              },
-              notifyError: null,
-              notifyId: '997a76c7-7866-4bd3-b199-ca69eef31a41',
-              notifyStatus: 'created',
-              recipient: null,
-              returnLogIds: null,
-              status: 'pending'
-            },
-            { skip: ['id', 'createdAt'] }
-          )
-        })
-
-        it('should call the ProcessNotificationStatusService with the event id', async () => {
-          await BatchNotificationsService.go(recipients, session, event.id)
-
-          const args = ProcessNotificationStatusService.go.getCall(0).args
-
-          expect(args[0]).to.equal(event.id)
-        })
-      })
+      expect(createdNotifications).to.equal([
+        {
+          createdAt: createdNotifications[0].createdAt,
+          eventId: event.id,
+          id: createdNotifications[0].id,
+          licenceMonitoringStationId: null,
+          licences: [recipientsFixture.primaryUser.licence_refs],
+          messageRef: 'returns_invitation_primary_user_email',
+          messageType: 'email',
+          plaintext: 'Dear licence holder,\r\n',
+          personalisation: {
+            periodEndDate: '31 March 2023',
+            returnDueDate: '28 April 2025',
+            periodStartDate: '1 April 2022'
+          },
+          notifyError: null,
+          notifyId: '9a0a0ba0-9dc7-4322-9a68-cb370220d0c9',
+          notifyStatus: 'created',
+          recipient: 'primary.user@important.com',
+          returnLogIds: null,
+          status: 'pending'
+        }
+      ])
     })
   })
 
-  describe('when sending abstraction alerts', () => {
+  describe('when sending letters', () => {
     beforeEach(async () => {
-      reference = generateReferenceCode('WAA')
-
-      recipientsFixture = RecipientsFixture.alertsRecipients()
-      recipients = [...Object.values(recipientsFixture)]
-
       event = await EventHelper.add({
         metadata: {},
-        licences: _licences(recipients),
+        licences: [recipientsFixture.licenceHolder],
         referenceCode: reference,
         status: 'completed',
-        subtype: 'waterAbstractionAlerts',
+        subtype: 'returnInvitation',
         type: 'notification'
       })
 
-      const licenceMonitoringStations = [
-        {
-          id: '4a87cf86-76ff-4059-9b74-924ab19c1367',
-          notes: null,
-          status: null,
-          licence: {
-            id: 'f9a0fdad-9608-4559-a8f1-d680fec25c9a',
-            licenceRef: recipients[0].licence_refs
-          },
-          measureType: 'flow',
-          thresholdUnit: 'Ml/d',
-          thresholdGroup: 'flow-500-Ml/d',
-          thresholdValue: 500,
-          restrictionType: 'stop',
-          statusUpdatedAt: null,
-          abstractionPeriodEndDay: 31,
-          abstractionPeriodEndMonth: 3,
-          abstractionPeriodStartDay: 1,
-          abstractionPeriodStartMonth: 4
-        },
-        {
-          id: 'cf52778d-bc21-46a0-87de-4643c7961309',
-          notes: null,
-          status: 'warning',
-          licence: {
-            id: '1f933cf4-f6cf-49a9-bfc7-fdf91e935c57',
-            licenceRef: recipients[1].licence_refs
-          },
-          measureType: 'flow',
-          thresholdUnit: 'Ml/d',
-          thresholdGroup: 'flow-750-Ml/d',
-          thresholdValue: 750,
-          restrictionType: 'stop',
-          statusUpdatedAt: '2025-08-14T22:47:52.981Z',
-          abstractionPeriodEndDay: 31,
-          abstractionPeriodEndMonth: 3,
-          abstractionPeriodStartDay: 1,
-          abstractionPeriodStartMonth: 11
-        },
-        {
-          id: '0cd06c03-d15a-45c6-87ac-6cfb1e2d3db6',
-          notes: null,
-          status: 'warning',
-          licence: {
-            id: '5f79267d-5e37-45c5-b783-deccf571c307',
-            licenceRef: recipients[2].licence_refs
-          },
-          measureType: 'flow',
-          thresholdUnit: 'Ml/d',
-          thresholdGroup: 'flow-1000-Ml/d',
-          thresholdValue: 1000,
-          restrictionType: 'stop',
-          statusUpdatedAt: '2025-07-09T15:56:45.979Z',
-          abstractionPeriodEndDay: 31,
-          abstractionPeriodEndMonth: 3,
-          abstractionPeriodStartDay: 1,
-          abstractionPeriodStartMonth: 4
-        }
-      ]
+      testNotification = _notifications(event.id, [recipientsFixture.licenceHolder.licence_refs], reference)
 
-      session = {
-        address: {
-          redirectUrl: '/system/notices/setup/22dd7d17-41f1-4b56-bbdb-b7e35364bf24/add-recipient'
-        },
-        alertEmailAddress: 'admin-internal@wrls.gov.uk',
-        alertEmailAddressType: 'username',
-        alertThresholds: ['flow-1000-Ml/d', 'flow-750-Ml/d', 'flow-500-Ml/d'],
-        alertType: 'warning',
-        id: '22dd7d17-41f1-4b56-bbdb-b7e35364bf24',
-        journey: 'alerts',
-        licenceRefs: event.licences,
-        licenceMonitoringStations,
-        monitoringStationId: '7195f45e-6597-4771-85dc-e223cb55bc63',
-        monitoringStationName: 'FRENCHAY',
-        monitoringStationRiverName: '',
-        name: 'Water abstraction alert',
-        noticeType: 'abstractionAlerts',
-        notificationType: 'Abstraction alert',
-        referenceCode: reference,
-        relevantLicenceMonitoringStations: [...licenceMonitoringStations],
-        removedThresholds: [],
-        selectedRecipients: [],
-        subType: 'waterAbstractionAlerts'
-      }
+      notifications = [testNotification.letter]
     })
 
-    describe('that contains letters and emails', () => {
-      describe('and the requests to Notify in the batch are a mix of successes and failures', () => {
-        beforeEach(() => {
-          Sinon.stub(CreateEmailRequest, 'send')
-            .onCall(0)
-            .resolves({
-              succeeded: false,
-              response: {
-                statusCode: 400,
-                body: {
-                  errors: [
-                    {
-                      error: 'BadRequestError',
-                      message: 'Missing personalisation: monitoring_station_name'
-                    }
-                  ],
-                  status_code: 400
-                }
-              }
-            })
-            .onCall(1)
-            .resolves({
-              succeeded: true,
-              response: {
-                statusCode: 200,
-                body: {
-                  content: {
-                    body: 'Dear licence contact,\r\n',
-                    from_email: 'environment.agency.water.resources.licensing.service@notifications.service.gov.uk',
-                    one_click_unsubscribe_url: null,
-                    subject: 'Water abstraction alert: You may need to reduce or stop water abstraction soon'
-                  },
-                  id: 'a5488243-9c8d-4c2b-95df-d65f7c9a5f41',
-                  reference,
-                  scheduled_for: null,
-                  template: {
-                    id: notifyTemplates.alerts.email.reduceOrStopWarning,
-                    uri: `https://api.notifications.service.gov.uk/services/2232718f-fc58-4413-9e41-135496648da7/templates/${notifyTemplates.alerts.email.reduceOrStopWarning}`,
-                    version: 1
-                  },
-                  uri: 'https://api.notifications.service.gov.uk/v2/notifications/a5488243-9c8d-4c2b-95df-d65f7c9a5f41'
-                }
-              }
-            })
+    it('should send and then save the notification', async () => {
+      await BatchNotificationsService.go(notifications, event.id)
 
-          Sinon.stub(NotifyLetterRequest, 'send')
-            .onCall(0)
-            .resolves({
-              succeeded: true,
-              response: {
-                statusCode: 200,
-                body: {
-                  content: {
-                    body: 'Dear licence contact,\r\n',
-                    subject: 'Water abstraction alert: You may need to reduce or stop water abstraction soon'
-                  },
-                  id: '797cfc1e-0699-4006-985d-10f4219a280a',
-                  reference,
-                  scheduled_for: null,
-                  template: {
-                    id: notifyTemplates.alerts.letter.reduceOrStopWarning,
-                    uri: `https://api.notifications.service.gov.uk/services/2232718f-fc58-4413-9e41-135496648da7/templates/${notifyTemplates.alerts.letter.reduceOrStopWarning}`,
-                    version: 5
-                  },
-                  uri: 'https://api.notifications.service.gov.uk/v2/notifications/797cfc1e-0699-4006-985d-10f4219a280a'
-                }
-              }
-            })
-        })
+      // Confirm the notifications are created and Notify request recorded as expected
+      const createdNotifications = await NotificationModel.query().where('eventId', event.id)
 
-        it("always creates the notifications including the result of the request to Notify, and updates the Event's error count", async () => {
-          await BatchNotificationsService.go(recipients, session, event.id)
-
-          // Confirm the event is updated with the error count
-          const refreshedEvent = await event.$query()
-
-          expect(refreshedEvent).to.equal({
-            id: event.id,
-            referenceCode: reference,
-            type: 'notification',
-            subtype: 'waterAbstractionAlerts',
-            issuer: 'test.user@defra.gov.uk',
-            licences: event.licences,
-            entities: null,
-            metadata: { error: 1 },
-            status: 'completed',
-            createdAt: event.createdAt,
-            updatedAt: refreshedEvent.updatedAt
-          })
-
-          // Confirm the notifications are created and Notify request recorded as expected
-          const createdNotifications = await NotificationModel.query().where('eventId', event.id)
-
-          expect(createdNotifications).to.have.length(3)
-          expect(createdNotifications[0]).to.equal(
-            {
-              eventId: event.id,
-              licenceMonitoringStationId: session.licenceMonitoringStations[0].id,
-              licences: recipients[0].licence_refs.split(','),
-              messageRef: 'water_abstraction_alert_stop_warning_email',
-              messageType: 'email',
-              plaintext: null,
-              personalisation: {
-                alertType: 'stop',
-                condition_text: '',
-                flow_or_level: 'flow',
-                issuer_email_address: 'admin-internal@wrls.gov.uk',
-                label: 'FRENCHAY',
-                licenceGaugingStationId: '4a87cf86-76ff-4059-9b74-924ab19c1367',
-                licenceId: session.licenceMonitoringStations[0].licence.id,
-                licenceRef: recipients[0].licence_refs,
-                monitoring_station_name: 'FRENCHAY',
-                sending_alert_type: 'warning',
-                source: '',
-                thresholdUnit: 'Ml/d',
-                thresholdValue: 500
-              },
-              notifyError:
-                '{"status":400,"message":"Request failed with status code 400","errors":[{"error":"BadRequestError","message":"Missing personalisation: monitoring_station_name"}]}',
-              notifyId: null,
-              notifyStatus: null,
-              recipient: 'additional.contact@important.com',
-              returnLogIds: null,
-              status: 'error'
-            },
-            { skip: ['id', 'createdAt'] }
-          )
-
-          expect(createdNotifications[1]).to.equal(
-            {
-              eventId: event.id,
-              licenceMonitoringStationId: session.licenceMonitoringStations[1].id,
-              licences: recipients[1].licence_refs.split(','),
-              messageRef: 'water_abstraction_alert_stop_warning',
-              messageType: 'letter',
-              plaintext: 'Dear licence contact,\r\n',
-              personalisation: {
-                address_line_1: 'Mr H J Licence holder',
-                address_line_2: '1',
-                address_line_3: 'Privet Drive',
-                address_line_4: 'Little Whinging',
-                address_line_5: 'Surrey',
-                address_line_6: 'WD25 7LR',
-                alertType: 'stop',
-                condition_text: '',
-                flow_or_level: 'flow',
-                issuer_email_address: 'admin-internal@wrls.gov.uk',
-                label: 'FRENCHAY',
-                licenceGaugingStationId: 'cf52778d-bc21-46a0-87de-4643c7961309',
-                licenceId: session.licenceMonitoringStations[1].licence.id,
-                licenceRef: recipients[1].licence_refs,
-                monitoring_station_name: 'FRENCHAY',
-                name: 'Mr H J Licence holder',
-                sending_alert_type: 'warning',
-                source: '',
-                thresholdUnit: 'Ml/d',
-                thresholdValue: 750
-              },
-              notifyError: null,
-              notifyId: '797cfc1e-0699-4006-985d-10f4219a280a',
-              notifyStatus: 'created',
-              recipient: null,
-              returnLogIds: null,
-              status: 'pending'
-            },
-            { skip: ['id', 'createdAt'] }
-          )
-
-          expect(createdNotifications[2]).to.equal(
-            {
-              eventId: event.id,
-              licenceMonitoringStationId: session.licenceMonitoringStations[2].id,
-              licences: recipients[2].licence_refs.split(','),
-              messageRef: 'water_abstraction_alert_stop_warning_email',
-              messageType: 'email',
-              plaintext: 'Dear licence contact,\r\n',
-              personalisation: {
-                alertType: 'stop',
-                flow_or_level: 'flow',
-                condition_text: '',
-                issuer_email_address: 'admin-internal@wrls.gov.uk',
-                label: 'FRENCHAY',
-                licenceGaugingStationId: '0cd06c03-d15a-45c6-87ac-6cfb1e2d3db6',
-                licenceId: session.licenceMonitoringStations[2].licence.id,
-                licenceRef: recipients[2].licence_refs,
-                monitoring_station_name: 'FRENCHAY',
-                sending_alert_type: 'warning',
-                source: '',
-                thresholdUnit: 'Ml/d',
-                thresholdValue: 1000
-              },
-              notifyError: null,
-              notifyId: 'a5488243-9c8d-4c2b-95df-d65f7c9a5f41',
-              notifyStatus: 'created',
-              recipient: 'primary.user@important.com',
-              returnLogIds: null,
-              status: 'pending'
-            },
-            { skip: ['id', 'createdAt'] }
-          )
-        })
-      })
+      expect(createdNotifications).to.equal([
+        {
+          createdAt: createdNotifications[0].createdAt,
+          eventId: event.id,
+          id: createdNotifications[0].id,
+          licenceMonitoringStationId: null,
+          licences: [recipientsFixture.licenceHolder.licence_refs],
+          messageRef: 'returns_invitation_licence_holder_letter',
+          messageType: 'letter',
+          notifyError: null,
+          notifyId: 'fff6c2a9-77fc-4553-8265-546109a45044',
+          notifyStatus: 'created',
+          personalisation: {
+            address_line_1: 'Mr H J Licence holder',
+            address_line_2: '1',
+            address_line_3: 'Privet Drive',
+            address_line_4: 'Little Whinging',
+            address_line_5: 'Surrey',
+            address_line_6: 'WD25 7LR',
+            name: 'Mr H J Licence holder',
+            periodEndDate: '31 March 2023',
+            periodStartDate: '1 April 2022',
+            returnDueDate: '28 April 2025'
+          },
+          plaintext: 'Dear Licence holder,\r\n',
+          recipient: null,
+          returnLogIds: null,
+          status: 'pending'
+        }
+      ])
     })
   })
 
-  describe('when sending return forms', () => {
-    let returnId
-
+  describe('when sending PDFs', () => {
     beforeEach(async () => {
       reference = generateReferenceCode('PRTF')
 
-      returnId = generateUUID()
-      recipientsFixture = RecipientsFixture.recipients()
-      recipients = [recipientsFixture.licenceHolder]
-
       event = await EventHelper.add({
         metadata: {},
-        licences: _licences(recipients),
+        licences: [recipientsFixture.licenceHolder],
         referenceCode: reference,
         status: 'completed',
         subtype: 'paperReturnForms',
         type: 'notification'
       })
 
-      session = {
-        noticeType: 'returnForms',
-        referenceCode: reference
-      }
+      testNotification = _notifications(event.id, [recipientsFixture.licenceHolder.licence_refs], reference)
 
-      const buffer = new TextEncoder().encode('mock file').buffer
+      notifications = [testNotification.pdf]
 
-      const notification = {
-        content: buffer,
-        eventId: event.id,
-        licences: JSON.stringify([recipientsFixture.licenceHolder.licence_refs]),
-        messageRef: 'pdf.return_form',
-        messageType: 'letter',
-        reference,
-        returnLogIds: [returnId]
-      }
+      const notifyResponse = successfulNotifyResponses(reference)
 
-      Sinon.stub(DetermineReturnFormsService, 'go').resolves([
+      Sinon.stub(CreatePrecompiledFileRequest, 'send').onCall(0).resolves(notifyResponse.pdf)
+    })
+
+    it('should send and then save the notification', async () => {
+      await BatchNotificationsService.go(notifications, event.id)
+
+      // Confirm the notifications are created and Notify request recorded as expected
+      const createdNotifications = await NotificationModel.query().where('eventId', event.id)
+
+      expect(createdNotifications).to.equal([
         {
-          ...notification,
-          personalisation: { name: 'Red 5' }
-        },
-        {
-          ...notification,
-          personalisation: { name: 'Rouge One' }
-        },
-        {
-          ...notification,
-          personalisation: { name: 'Gold leader' }
+          createdAt: createdNotifications[0].createdAt,
+          eventId: event.id,
+          id: createdNotifications[0].id,
+          licenceMonitoringStationId: null,
+          licences: [recipientsFixture.licenceHolder.licence_refs],
+          messageRef: 'pdf.return_form',
+          messageType: 'letter',
+          plaintext: null,
+          personalisation: { name: 'Red 5' },
+          notifyError: null,
+          notifyId: 'fff6c2a9-77fc-4553-8265-546109a45044',
+          notifyStatus: 'created',
+          recipient: null,
+          returnLogIds: testNotification.pdf.returnLogIds,
+          status: 'pending'
         }
       ])
     })
+  })
 
-    describe('that contains PDF files', () => {
-      describe('and the requests to Notify in the batch are a mix of successes and failures', () => {
-        beforeEach(() => {
-          Sinon.stub(CreatePrecompiledFileRequest, 'send')
-            .onCall(0)
-            .resolves({
-              succeeded: true,
-              response: {
-                statusCode: 200,
-                body: {
-                  id: 'fff6c2a9-77fc-4553-8265-546109a45044',
-                  reference
-                }
-              }
-            })
-            .onCall(1)
-            .resolves({
-              succeeded: false,
-              response: {
-                statusCode: 400,
-                body: {
-                  errors: [
-                    {
-                      error: 'BadRequestError',
-                      message: 'File is not a PDF'
-                    }
-                  ],
-                  status_code: 400
-                }
-              }
-            })
-            .onCall(2)
-            .resolves({
-              succeeded: true,
-              response: {
-                statusCode: 200,
-                body: {
-                  id: '997a76c7-7866-4bd3-b199-ca69eef31a41',
-                  reference
-                }
-              }
-            })
+  describe('when a the batch process has finished', () => {
+    beforeEach(() => {
+      const testNotification = _notifications(event.id, [recipientsFixture.primaryUser.licence_refs], reference)
+
+      notifications = [testNotification.email]
+    })
+
+    describe('and there are no errors', () => {
+      beforeEach(async () => {
+        event = await EventHelper.add({
+          metadata: {},
+          licences: [recipientsFixture.primaryUser],
+          referenceCode: reference,
+          status: 'completed',
+          subtype: 'returnInvitation',
+          type: 'notification'
         })
+      })
 
-        it("always creates the notifications including the result of the request to Notify, and updates the Event's error count", async () => {
-          await BatchNotificationsService.go(recipients, session, event.id)
+      it('should not affect the error count', async () => {
+        await BatchNotificationsService.go(notifications, event.id)
 
-          // Confirm the event is updated with the error count
-          const refreshedEvent = await event.$query()
+        const refreshedEvent = await event.$query()
 
-          expect(refreshedEvent).to.equal({
-            id: event.id,
-            referenceCode: reference,
-            type: 'notification',
-            subtype: 'paperReturnForms',
-            issuer: 'test.user@defra.gov.uk',
-            licences: event.licences,
-            entities: null,
-            metadata: { error: 1 },
-            status: 'completed',
-            createdAt: event.createdAt,
-            updatedAt: refreshedEvent.updatedAt
-          })
+        expect(refreshedEvent).to.equal({
+          createdAt: event.createdAt,
+          entities: null,
+          id: event.id,
+          issuer: 'test.user@defra.gov.uk',
+          licences: event.licences,
+          metadata: { error: 0 },
+          referenceCode: reference,
+          status: 'completed',
+          subtype: 'returnInvitation',
+          type: 'notification',
+          updatedAt: refreshedEvent.updatedAt
+        })
+      })
+    })
 
-          // Confirm the notifications are created and Notify request recorded as expected
-          const createdNotifications = await NotificationModel.query().where('eventId', event.id)
+    describe('and there are existing errors', () => {
+      beforeEach(async () => {
+        event = await EventHelper.add({
+          metadata: { error: 5 },
+          licences: [recipientsFixture.primaryUser],
+          referenceCode: reference,
+          status: 'completed',
+          subtype: 'returnInvitation',
+          type: 'notification'
+        })
+      })
 
-          expect(createdNotifications).to.have.length(3)
+      it('should increment the error count', async () => {
+        await BatchNotificationsService.go(notifications, event.id)
 
-          // A successful notification
-          expect(createdNotifications[0]).to.equal(
-            {
-              eventId: event.id,
-              licenceMonitoringStationId: null,
-              licences: [recipientsFixture.licenceHolder.licence_refs],
-              messageRef: 'pdf.return_form',
-              messageType: 'letter',
-              notifyError: null,
-              notifyId: 'fff6c2a9-77fc-4553-8265-546109a45044',
-              notifyStatus: 'created',
-              personalisation: {
-                name: 'Red 5'
-              },
-              plaintext: null,
-              recipient: null,
-              returnLogIds: [returnId],
-              status: 'pending'
-            },
-            { skip: ['id', 'createdAt'] }
-          )
+        const refreshedEvent = await event.$query()
 
-          // An unsuccessful notification
-          expect(createdNotifications[1]).to.equal(
-            {
-              eventId: event.id,
-              licenceMonitoringStationId: null,
-              licences: [recipientsFixture.licenceHolder.licence_refs],
-              messageRef: 'pdf.return_form',
-              messageType: 'letter',
-              notifyError:
-                '{"status":400,"message":"Request failed with status code 400","errors":[{"error":"BadRequestError","message":"File is not a PDF"}]}',
-              notifyId: null,
-              notifyStatus: null,
-              personalisation: {
-                name: 'Rouge One'
-              },
-              plaintext: null,
-              recipient: null,
-              returnLogIds: [returnId],
-              status: 'error'
-            },
-            { skip: ['id', 'createdAt'] }
-          )
-
-          // A successful notification
-          expect(createdNotifications[2]).to.equal(
-            {
-              eventId: event.id,
-              licenceMonitoringStationId: null,
-              licences: [recipientsFixture.licenceHolder.licence_refs],
-              messageRef: 'pdf.return_form',
-              messageType: 'letter',
-              notifyError: null,
-              notifyId: '997a76c7-7866-4bd3-b199-ca69eef31a41',
-              notifyStatus: 'created',
-              personalisation: {
-                name: 'Gold leader'
-              },
-              plaintext: null,
-              recipient: null,
-              returnLogIds: [returnId],
-              status: 'pending'
-            },
-            { skip: ['id', 'createdAt'] }
-          )
+        expect(refreshedEvent).to.equal({
+          createdAt: event.createdAt,
+          entities: null,
+          id: event.id,
+          issuer: 'test.user@defra.gov.uk',
+          licences: event.licences,
+          metadata: { error: 5 },
+          referenceCode: reference,
+          status: 'completed',
+          subtype: 'returnInvitation',
+          type: 'notification',
+          updatedAt: refreshedEvent.updatedAt
         })
       })
     })
   })
 })
 
-function _licences(recipients) {
-  const allLicenceRefs = []
+function successfulNotifyResponses(reference) {
+  return {
+    email: {
+      succeeded: true,
+      response: {
+        statusCode: 200,
+        body: {
+          content: {
+            body: 'Dear licence holder,\r\n',
+            from_email: 'environment.agency.water.resources.licensing.service@notifications.service.gov.uk',
+            one_click_unsubscribe_url: null,
+            subject: 'Submit your water abstraction returns by 28th April 2025'
+          },
+          id: '9a0a0ba0-9dc7-4322-9a68-cb370220d0c9',
+          reference,
+          scheduled_for: null,
+          template: {
+            id: notifyTemplates.standard.invitations.returnsAgentEmail,
+            uri: `https://api.notifications.service.gov.uk/services/2232718f-fc58-4413-9e41-135496648da7/templates/${notifyTemplates.standard.invitations.returnsAgentEmail}`,
+            version: 40
+          },
+          uri: 'https://api.notifications.service.gov.uk/v2/notifications/9a0a0ba0-9dc7-4322-9a68-cb370220d0c9'
+        }
+      }
+    },
+    letter: {
+      succeeded: true,
+      response: {
+        statusCode: 200,
+        body: {
+          content: {
+            body: 'Dear Licence holder,\r\n',
+            subject: 'Submit your water abstraction returns by 28th April 2025'
+          },
+          id: 'fff6c2a9-77fc-4553-8265-546109a45044',
+          reference,
+          scheduled_for: null,
+          template: {
+            id: notifyTemplates.standard.invitations.licenceHolderLetter,
+            uri: `https://api.notifications.service.gov.uk/services/2232718f-fc58-4413-9e41-135496648da7/templates/${notifyTemplates.standard.invitations.licenceHolderLetter}`,
+            version: 32
+          },
+          uri: 'https://api.notifications.service.gov.uk/v2/notifications/fff6c2a9-77fc-4553-8265-546109a45044'
+        }
+      }
+    },
+    pdf: {
+      succeeded: true,
+      response: {
+        statusCode: 200,
+        body: {
+          id: 'fff6c2a9-77fc-4553-8265-546109a45044',
+          reference
+        }
+      }
+    }
+  }
+}
 
-  recipients.forEach((recipient) => {
-    const licenceRefs = recipient.licence_refs.split(',')
+function _notifications(eventId, licences, referenceCode) {
+  const date = new Date('2024-01-01')
 
-    allLicenceRefs.push(...licenceRefs)
-  })
-
-  const uniqueLicenceRefs = [...new Set(allLicenceRefs)]
-
-  // Sort them alphabetically
-  uniqueLicenceRefs.sort()
-
-  return JSON.stringify(uniqueLicenceRefs)
+  return {
+    email: {
+      createdAt: date,
+      eventId,
+      licences,
+      messageRef: 'returns_invitation_primary_user_email',
+      messageType: 'email',
+      personalisation: {
+        periodEndDate: '31 March 2023',
+        returnDueDate: '28 April 2025',
+        periodStartDate: '1 April 2022'
+      },
+      recipient: 'primary.user@important.com',
+      reference: referenceCode,
+      templateId: '2fa7fc83-4df1-4f52-bccf-ff0faeb12b6f'
+    },
+    letter: {
+      createdAt: date,
+      eventId,
+      licences,
+      messageRef: 'returns_invitation_licence_holder_letter',
+      messageType: 'letter',
+      personalisation: {
+        name: 'Mr H J Licence holder',
+        periodEndDate: '31 March 2023',
+        returnDueDate: '28 April 2025',
+        address_line_1: 'Mr H J Licence holder',
+        address_line_2: '1',
+        address_line_3: 'Privet Drive',
+        address_line_4: 'Little Whinging',
+        address_line_5: 'Surrey',
+        address_line_6: 'WD25 7LR',
+        periodStartDate: '1 April 2022'
+      },
+      recipient: null,
+      reference: referenceCode,
+      templateId: '2fa7fc83-4df1-4f52-bccf-ff0faeb12b6f'
+    },
+    pdf: {
+      content: new TextEncoder().encode('mock file').buffer,
+      eventId,
+      licences,
+      messageRef: 'pdf.return_form',
+      messageType: 'letter',
+      personalisation: { name: 'Red 5' },
+      reference: referenceCode,
+      returnLogIds: [generateUUID()]
+    }
+  }
 }

--- a/test/services/notices/setup/determine-notifications.service.test.js
+++ b/test/services/notices/setup/determine-notifications.service.test.js
@@ -1,0 +1,247 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Test helpers
+const RecipientsFixture = require('../../../fixtures/recipients.fixtures.js')
+const { generateReferenceCode } = require('../../../support/helpers/notification.helper.js')
+const { generateUUID } = require('../../../../app/lib/general.lib.js')
+const { notifyTemplates } = require('../../../../app/lib/notify-templates.lib.js')
+
+// Things we need to stub
+const DetermineReturnFormsService = require('../../../../app/services/notices/setup/determine-return-forms.service.js')
+
+// Thing under test
+const DetermineNotificationsService = require('../../../../app/services/notices/setup/determine-notifications.service.js')
+
+describe('Notices - Setup - Determine Notifications service', () => {
+  let clock
+  let event
+  let recipients
+  let recipientsFixture
+  let reference
+  let session
+  let testDate
+
+  beforeEach(async () => {
+    testDate = new Date('2024-12-01')
+
+    clock = Sinon.useFakeTimers(testDate)
+  })
+
+  afterEach(() => {
+    Sinon.restore()
+    clock.restore()
+  })
+
+  describe('when sending return invitations or reminders', () => {
+    beforeEach(async () => {
+      reference = generateReferenceCode()
+
+      recipientsFixture = RecipientsFixture.recipients()
+      recipients = [recipientsFixture.primaryUser]
+
+      event = {
+        id: generateUUID(),
+        licences: [recipientsFixture.primaryUser.licence_refs]
+      }
+
+      session = {
+        determinedReturnsPeriod: {
+          name: 'allYear',
+          dueDate: '2025-04-28',
+          endDate: '2023-03-31',
+          summer: 'false',
+          startDate: '2022-04-01'
+        },
+        journey: 'standard',
+        noticeType: 'invitations',
+        referenceCode: reference
+      }
+    })
+
+    it('should return standard notifications', async () => {
+      const notifications = await DetermineNotificationsService.go(session, recipients, event.id)
+
+      expect(notifications).to.equal([
+        {
+          createdAt: testDate.toISOString(),
+          eventId: event.id,
+          licences: recipients[0].licence_refs.split(','),
+          messageRef: 'returns_invitation_primary_user_email',
+          messageType: 'email',
+          personalisation: {
+            periodEndDate: '31 March 2023',
+            returnDueDate: '28 April 2025',
+            periodStartDate: '1 April 2022'
+          },
+          recipient: 'primary.user@important.com',
+          reference,
+          templateId: '2fa7fc83-4df1-4f52-bccf-ff0faeb12b6f'
+        }
+      ])
+    })
+  })
+
+  describe('when sending abstraction alerts', () => {
+    beforeEach(async () => {
+      reference = generateReferenceCode('WAA')
+
+      recipientsFixture = RecipientsFixture.alertsRecipients()
+      recipients = [recipientsFixture.primaryUser]
+
+      event = {
+        id: generateUUID(),
+        licences: [recipientsFixture.primaryUser.licence_refs]
+      }
+
+      const licenceMonitoringStations = [
+        {
+          id: '4a87cf86-76ff-4059-9b74-924ab19c1367',
+          notes: null,
+          status: null,
+          licence: {
+            id: 'f9a0fdad-9608-4559-a8f1-d680fec25c9a',
+            licenceRef: recipientsFixture.primaryUser.licence_refs
+          },
+          measureType: 'flow',
+          thresholdUnit: 'Ml/d',
+          thresholdGroup: 'flow-500-Ml/d',
+          thresholdValue: 500,
+          restrictionType: 'stop',
+          statusUpdatedAt: null,
+          abstractionPeriodEndDay: 31,
+          abstractionPeriodEndMonth: 3,
+          abstractionPeriodStartDay: 1,
+          abstractionPeriodStartMonth: 4
+        }
+      ]
+
+      session = {
+        address: {
+          redirectUrl: '/system/notices/setup/22dd7d17-41f1-4b56-bbdb-b7e35364bf24/add-recipient'
+        },
+        alertEmailAddress: 'admin-internal@wrls.gov.uk',
+        alertEmailAddressType: 'username',
+        alertThresholds: ['flow-1000-Ml/d', 'flow-750-Ml/d', 'flow-500-Ml/d'],
+        alertType: 'warning',
+        id: '22dd7d17-41f1-4b56-bbdb-b7e35364bf24',
+        journey: 'alerts',
+        licenceRefs: event.licences,
+        licenceMonitoringStations,
+        monitoringStationId: '7195f45e-6597-4771-85dc-e223cb55bc63',
+        monitoringStationName: 'FRENCHAY',
+        monitoringStationRiverName: '',
+        name: 'Water abstraction alert',
+        noticeType: 'abstractionAlerts',
+        notificationType: 'Abstraction alert',
+        referenceCode: reference,
+        relevantLicenceMonitoringStations: [...licenceMonitoringStations],
+        removedThresholds: [],
+        selectedRecipients: [],
+        subType: 'waterAbstractionAlerts'
+      }
+    })
+
+    it('should return abstraction alerts notifications', async () => {
+      const notifications = await DetermineNotificationsService.go(session, recipients, event.id)
+
+      expect(notifications).to.equal([
+        {
+          createdAt: testDate.toISOString(),
+          eventId: event.id,
+          licenceMonitoringStationId: session.licenceMonitoringStations[0].id,
+          licences: recipientsFixture.primaryUser.licence_refs.split(','),
+          messageRef: 'water_abstraction_alert_stop_warning_email',
+          messageType: 'email',
+          personalisation: {
+            alertType: 'stop',
+            condition_text: '',
+            flow_or_level: 'flow',
+            issuer_email_address: 'admin-internal@wrls.gov.uk',
+            label: 'FRENCHAY',
+            licenceGaugingStationId: '4a87cf86-76ff-4059-9b74-924ab19c1367',
+            licenceId: session.licenceMonitoringStations[0].licence.id,
+            licenceRef: recipientsFixture.primaryUser.licence_refs,
+            monitoring_station_name: 'FRENCHAY',
+            sending_alert_type: 'warning',
+            source: '',
+            thresholdUnit: 'Ml/d',
+            thresholdValue: 500
+          },
+          recipient: 'primary.user@important.com',
+          reference,
+          templateId: notifyTemplates.alerts.email.stopWarning
+        }
+      ])
+    })
+  })
+
+  describe('when sending return forms', () => {
+    let buffer
+    let returnId
+
+    beforeEach(async () => {
+      reference = generateReferenceCode('PRTF')
+
+      returnId = generateUUID()
+
+      recipientsFixture = RecipientsFixture.recipients()
+      recipients = [recipientsFixture.licenceHolder]
+
+      event = {
+        id: generateUUID(),
+        licences: [recipientsFixture.licenceHolder.licence_refs]
+      }
+
+      session = {
+        noticeType: 'returnForms',
+        referenceCode: reference
+      }
+
+      buffer = new TextEncoder().encode('mock file').buffer
+
+      const notification = {
+        content: buffer,
+        eventId: event.id,
+        licences: [recipientsFixture.licenceHolder.licence_refs],
+        messageRef: 'pdf.return_form',
+        messageType: 'letter',
+        reference,
+        returnLogIds: [returnId]
+      }
+
+      Sinon.stub(DetermineReturnFormsService, 'go').resolves([
+        {
+          ...notification,
+          personalisation: { name: 'Red 5' }
+        }
+      ])
+    })
+
+    it('should return "return forms" notifications', async () => {
+      const notifications = await DetermineNotificationsService.go(session, recipients, event.id)
+
+      expect(notifications).to.equal([
+        {
+          content: buffer,
+          eventId: event.id,
+          licences: [recipientsFixture.licenceHolder.licence_refs],
+          messageRef: 'pdf.return_form',
+          messageType: 'letter',
+          personalisation: {
+            name: 'Red 5'
+          },
+          reference,
+          returnLogIds: [returnId]
+        }
+      ])
+    })
+  })
+})

--- a/test/services/notices/setup/submit-check.service.test.js
+++ b/test/services/notices/setup/submit-check.service.test.js
@@ -15,22 +15,23 @@ const SessionHelper = require('../../../support/helpers/session.helper.js')
 
 // Things we need to stub
 const BatchNotificationsService = require('../../../../app/services/notices/setup/batch-notifications.service.js')
+const DetermineNotificationsService = require('../../../../app/services/notices/setup/determine-notifications.service.js')
 const DetermineRecipientsService = require('../../../../app/services/notices/setup/determine-recipients.service.js')
-const FetchAbstractionAlertRecipientsService = require('../../../../app/services/notices/setup/fetch-abstraction-alert-recipients.service.js')
 const FetchReturnsRecipientsService = require('../../../../app/services/notices/setup/fetch-returns-recipients.service.js')
+const { generateReferenceCode } = require('../../../support/helpers/notification.helper.js')
 
 // Thing under test
 const SubmitCheckService = require('../../../../app/services/notices/setup/submit-check.service.js')
 
 describe('Notices - Setup - Submit Check service', () => {
   let auth
+  let mockNotifications
   let notifierStub
-  let recipients
   let referenceCode
   let session
   let testRecipients
 
-  beforeEach(() => {
+  beforeEach(async () => {
     auth = {
       credentials: {
         user: {
@@ -39,7 +40,32 @@ describe('Notices - Setup - Submit Check service', () => {
       }
     }
 
-    Sinon.stub(BatchNotificationsService, 'go').resolves({ sent: 1, error: 0 })
+    mockNotifications = [{ text: 'mock notification' }]
+
+    const recipients = RecipientsFixture.recipients()
+
+    testRecipients = [recipients.primaryUser]
+
+    referenceCode = generateReferenceCode()
+
+    session = await SessionHelper.add({
+      data: {
+        journey: 'invitations',
+        referenceCode,
+        returnsPeriod: 'quarterFour',
+        determinedReturnsPeriod: {
+          name: 'allYear',
+          dueDate: '2025-04-28',
+          endDate: '2023-03-31',
+          summer: 'false',
+          startDate: '2022-04-01'
+        }
+      }
+    })
+
+    Sinon.stub(DetermineNotificationsService, 'go').resolves(mockNotifications)
+    Sinon.stub(DetermineRecipientsService, 'go').returns(testRecipients)
+    Sinon.stub(FetchReturnsRecipientsService, 'go').resolves(testRecipients)
 
     notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
     global.GlobalNotifier = notifierStub
@@ -50,31 +76,28 @@ describe('Notices - Setup - Submit Check service', () => {
     delete global.GlobalNotifier
   })
 
-  describe('when the journey is a return journey', () => {
-    beforeEach(async () => {
-      referenceCode = `RINV-${Math.floor(1000 + Math.random() * 9000).toString()}`
+  describe('when a successful batch process has been triggered', () => {
+    beforeEach(() => {
+      Sinon.stub(BatchNotificationsService, 'go').resolves({ sent: 1, error: 0 })
+    })
 
-      session = await SessionHelper.add({
-        data: {
-          journey: 'invitations',
-          referenceCode,
-          returnsPeriod: 'quarterFour',
-          determinedReturnsPeriod: {
-            name: 'allYear',
-            dueDate: '2025-04-28',
-            endDate: '2023-03-31',
-            summer: 'false',
-            startDate: '2022-04-01'
-          }
-        }
-      })
+    it('should determine notifications', async () => {
+      const result = await SubmitCheckService.go(session.id, auth)
 
-      recipients = RecipientsFixture.recipients()
+      const args = DetermineNotificationsService.go.firstCall.args
 
-      testRecipients = [recipients.primaryUser]
+      expect(args[0]).to.equal(session)
+      expect(args[1]).to.equal(testRecipients)
+      expect(args[2]).to.equal(result)
+    })
 
-      Sinon.stub(DetermineRecipientsService, 'go').returns(testRecipients)
-      Sinon.stub(FetchReturnsRecipientsService, 'go').resolves(testRecipients)
+    it('should batch notifications', async () => {
+      const result = await SubmitCheckService.go(session.id, auth)
+
+      const args = BatchNotificationsService.go.firstCall.args
+
+      expect(args[0]).to.equal(mockNotifications)
+      expect(args[1]).to.equal(result)
     })
 
     it('correctly returns the event id', async () => {
@@ -83,31 +106,6 @@ describe('Notices - Setup - Submit Check service', () => {
       const event = await EventModel.query().where('reference_code', referenceCode).first()
 
       expect(result).to.equal(event.id)
-    })
-
-    it('should call the batch notification service', async () => {
-      const result = await SubmitCheckService.go(session.id, auth)
-
-      expect(
-        BatchNotificationsService.go.calledWithMatch(
-          testRecipients,
-          Sinon.match({
-            id: session.id,
-            data: session.data,
-            journey: 'invitations',
-            referenceCode,
-            returnsPeriod: 'quarterFour',
-            determinedReturnsPeriod: {
-              name: 'allYear',
-              dueDate: '2025-04-28',
-              endDate: '2023-03-31',
-              summer: 'false',
-              startDate: '2022-04-01'
-            }
-          }),
-          result
-        )
-      ).to.be.true()
     })
 
     it('should not throw an error', async () => {
@@ -117,54 +115,19 @@ describe('Notices - Setup - Submit Check service', () => {
     })
   })
 
-  describe('when the journey is "alerts"', () => {
-    beforeEach(async () => {
-      referenceCode = `WAA-${Math.floor(1000 + Math.random() * 9000).toString()}`
+  describe('when a batch process fails', { timeout: 1000000 }, () => {
+    beforeEach(() => {
+      const specificError = new Error('Batch failed due to XYZ reason')
 
-      session = await SessionHelper.add({
-        data: {
-          journey: 'alerts',
-          referenceCode
-        }
-      })
-
-      recipients = RecipientsFixture.alertsRecipients()
-
-      testRecipients = [recipients.primaryUser]
-
-      Sinon.stub(DetermineRecipientsService, 'go').returns(testRecipients)
-      Sinon.stub(FetchAbstractionAlertRecipientsService, 'go').resolves(testRecipients)
+      Sinon.stub(BatchNotificationsService, 'go').rejects(specificError)
     })
 
-    it('correctly returns the event id', async () => {
-      const result = await SubmitCheckService.go(session.id, auth)
-
-      const event = await EventModel.query().where('reference_code', referenceCode).first()
-
-      expect(result).to.equal(event.id)
-    })
-
-    it('should call the batch notification service', async () => {
-      const result = await SubmitCheckService.go(session.id, auth)
-
-      expect(
-        BatchNotificationsService.go.calledWithMatch(
-          testRecipients,
-          Sinon.match({
-            id: session.id,
-            data: session.data,
-            journey: 'alerts',
-            referenceCode
-          }),
-          result
-        )
-      ).to.be.true()
-    })
-
-    it('should not throw an error', async () => {
+    it('should throw an error', async () => {
       await SubmitCheckService.go(session.id, auth)
 
-      expect(notifierStub.omfg.called).to.be.false()
+      expect(notifierStub.omfg.called).to.be.true()
+
+      expect(notifierStub.omfg.calledWith('Send notifications failed')).to.be.true()
     })
   })
 })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5280

Currently, when a user clicks Confirm on the check-recipients page, as part of sending a notice, we follow this process.

Convert the notice setup and recipient data into package to be sent to Notify

We send the package to Notify

We insert the result and the data into the DB as a ‘notification’.

Because there may be many notifications to send, or in the case of return forms, each can take some time to process, we do this behind the scenes to avoid users seeing any spinning wheels.

So, they will be immediately taken to the ‘Confirmation’ page, which includes a link to view the notice.

If the user is keen, and the process is going to take a moment to complete, when they view the notice and its notifications, the page will be empty. If they were to wait a moment and refresh, then the records would appear. However, we do not consider this a reasonable workaround.

This change is the initial refactored to fix this problem.

We have lifted out creating the notifications into the submit check service (in preparation to save them before batching, which we will do in another change).

This affects the tests leading to a complete rewrite. We can remove any concept of a journey / session and focus purley on sending and saving notifications.

We have also updated the event model to process the 'licences' column as JSON. This simplifies both logic and tests.