### PR TITLE
Refactor the reference code to only be used by the batch notification service

### DIFF
--- a/app/presenters/notices/setup/abstraction-alert-notifications.presenter.js
+++ b/app/presenters/notices/setup/abstraction-alert-notifications.presenter.js
@@ -41,7 +41,6 @@ function go(recipients, session, eventId) {
     alertType,
     monitoringStationName,
     monitoringStationRiverName,
-    referenceCode,
     relevantLicenceMonitoringStations
   } = session
 
@@ -59,11 +58,11 @@ function go(recipients, session, eventId) {
     for (const matchingRecipient of matchingRecipients) {
       if (matchingRecipient.email) {
         notifications.push(
-          _email(matchingRecipient, referenceCode, eventId, commonPersonalisation, alertType, station.restrictionType)
+          _email(matchingRecipient, eventId, commonPersonalisation, alertType, station.restrictionType)
         )
       } else {
         notifications.push(
-          _letter(matchingRecipient, referenceCode, eventId, commonPersonalisation, alertType, station.restrictionType)
+          _letter(matchingRecipient, eventId, commonPersonalisation, alertType, station.restrictionType)
         )
       }
     }
@@ -157,7 +156,7 @@ function _conditionText(notes) {
  *
  * @private
  */
-function _email(recipient, referenceCode, eventId, commonPersonalisation, alertType, restrictionType) {
+function _email(recipient, eventId, commonPersonalisation, alertType, restrictionType) {
   const createdAt = timestampForPostgres()
 
   const messageType = 'email'
@@ -171,7 +170,6 @@ function _email(recipient, referenceCode, eventId, commonPersonalisation, alertT
     messageType,
     personalisation: commonPersonalisation,
     recipient: recipient.email,
-    reference: referenceCode,
     templateId: _templateId(alertType, restrictionType, 'email')
   }
 }
@@ -203,7 +201,7 @@ function _emailMessageRef(alertType, restrictionType) {
  *
  * @private
  */
-function _letter(recipient, referenceCode, eventId, commonPersonalisation, alertType, restrictionType) {
+function _letter(recipient, eventId, commonPersonalisation, alertType, restrictionType) {
   const createdAt = timestampForPostgres()
   const messageType = 'letter'
   const address = NotifyAddressPresenter.go(recipient.contact)
@@ -221,7 +219,6 @@ function _letter(recipient, referenceCode, eventId, commonPersonalisation, alert
       // NOTE: Address line 1 is always set to the recipient's name
       name: address.address_line_1
     },
-    reference: referenceCode,
     templateId: _templateId(alertType, restrictionType, 'letter')
   }
 }

--- a/app/presenters/notices/setup/notifications.presenter.js
+++ b/app/presenters/notices/setup/notifications.presenter.js
@@ -57,26 +57,25 @@ const MESSAGE_REFS = {
 function go(recipients, session, eventId) {
   const notifications = []
 
-  const { determinedReturnsPeriod, referenceCode, journey, noticeType } = session
+  const { determinedReturnsPeriod, journey, noticeType } = session
 
   for (const recipient of recipients) {
     if (recipient.email) {
-      notifications.push(_email(recipient, determinedReturnsPeriod, referenceCode, journey, eventId, noticeType))
+      notifications.push(_email(recipient, determinedReturnsPeriod, journey, eventId, noticeType))
     } else {
-      notifications.push(_letter(recipient, determinedReturnsPeriod, referenceCode, journey, eventId, noticeType))
+      notifications.push(_letter(recipient, determinedReturnsPeriod, journey, eventId, noticeType))
     }
   }
 
   return notifications
 }
 
-function _common(referenceCode, templateId, eventId) {
+function _common(templateId, eventId) {
   const createdAt = timestampForPostgres()
 
   return {
     createdAt,
     eventId,
-    reference: referenceCode,
     templateId
   }
 }
@@ -102,13 +101,13 @@ function _common(referenceCode, templateId, eventId) {
  *
  * @private
  */
-function _email(recipient, returnsPeriod, referenceCode, journey, eventId, noticeType) {
+function _email(recipient, returnsPeriod, journey, eventId, noticeType) {
   const templateId = _emailTemplate(recipient.contact_type, journey, noticeType)
 
   const messageType = 'email'
 
   return {
-    ..._common(referenceCode, templateId, eventId),
+    ..._common(templateId, eventId),
     licences: transformStringOfLicencesToArray(recipient.licence_refs),
     messageType,
     messageRef: _messageRef(noticeType, messageType, recipient.contact_type),
@@ -155,13 +154,13 @@ function _emailTemplate(contactType, journey, noticeType) {
  *
  * @private
  */
-function _letter(recipient, returnsPeriod, referenceCode, journey, eventId, noticeType) {
+function _letter(recipient, returnsPeriod, journey, eventId, noticeType) {
   const templateId = _letterTemplate(recipient.contact_type, journey, noticeType)
   const messageType = 'letter'
   const address = NotifyAddressPresenter.go(recipient.contact)
 
   return {
-    ..._common(referenceCode, templateId, eventId),
+    ..._common(templateId, eventId),
     licences: transformStringOfLicencesToArray(recipient.licence_refs),
     messageType,
     messageRef: _messageRef(noticeType, messageType, recipient.contact_type),

--- a/app/presenters/notices/setup/preview/preview.presenter.js
+++ b/app/presenters/notices/setup/preview/preview.presenter.js
@@ -18,16 +18,17 @@ const { sentenceCase } = require('../../../base.presenter.js')
  * @param {string} sessionId - The UUID for returns notices session record
  * @param {string} [licenceMonitoringStationId=null] - The UUID of the licence monitoring station record (This is only
  * populated for abstraction alerts)
+ * @param {string} referenceCode - the unique generated reference code
  *
  * @returns {Promise<object>} The data formatted for the preview page
  */
-async function go(contactHashId, noticeType, notification, sessionId, licenceMonitoringStationId) {
-  const { messageRef, messageType, personalisation, recipient, reference, templateId } = notification
+async function go(contactHashId, noticeType, notification, sessionId, licenceMonitoringStationId, referenceCode) {
+  const { messageRef, messageType, personalisation, recipient, templateId } = notification
 
   return {
     address: messageType === 'letter' ? _address(personalisation) : recipient,
     backLink: _backLink(contactHashId, noticeType, sessionId),
-    caption: `Notice ${reference}`,
+    caption: `Notice ${referenceCode}`,
     contents: await _notifyPreview(personalisation, templateId),
     messageType,
     pageTitle: sentenceCase(messageRef.replace(/_/g, ' ')),

--- a/app/presenters/notices/setup/return-forms-notification.presenter.js
+++ b/app/presenters/notices/setup/return-forms-notification.presenter.js
@@ -16,12 +16,11 @@
  * @param {{ArrayBuffer}} returnForm - The return forms PDF file
  * @param {object} pageData - The data formatted for the return form
  * @param {string} licenceRef - The reference of the licence that the return log relates to
- * @param {string} referenceCode - the unique generated reference code
  * @param {string} eventId - The event if that joins all the notifications
  *
  * @returns {object} The data formatted persisting as a `notice` record
  */
-function go(returnForm, pageData, licenceRef, referenceCode, eventId) {
+function go(returnForm, pageData, licenceRef, eventId) {
   return {
     content: returnForm,
     eventId,
@@ -29,7 +28,6 @@ function go(returnForm, pageData, licenceRef, referenceCode, eventId) {
     messageRef: 'pdf.return_form',
     messageType: 'letter',
     personalisation: _personalisation(pageData),
-    reference: referenceCode,
     returnLogIds: [pageData.returnId]
   }
 }

--- a/app/services/notices/setup/determine-return-forms.service.js
+++ b/app/services/notices/setup/determine-return-forms.service.js
@@ -19,7 +19,7 @@ const ReturnFormsNotificationPresenter = require('../../../presenters/notices/se
  * @returns {Promise<object[]>} - Resolves an array of return forms notifications
  */
 async function go(session, recipients, eventId) {
-  const { licenceRef, dueReturns, selectedReturns, referenceCode } = session
+  const { licenceRef, dueReturns, selectedReturns } = session
 
   const dueReturnLogs = _dueReturnLog(dueReturns, selectedReturns)
 
@@ -31,7 +31,7 @@ async function go(session, recipients, eventId) {
 
       const pageData = PrepareReturnFormsPresenter.go(licenceRef, dueReturn, recipient)
 
-      const notification = ReturnFormsNotificationPresenter.go(returnForm, pageData, licenceRef, referenceCode, eventId)
+      const notification = ReturnFormsNotificationPresenter.go(returnForm, pageData, licenceRef, eventId)
 
       notifications.push(notification)
     }

--- a/app/services/notices/setup/preview/preview.service.js
+++ b/app/services/notices/setup/preview/preview.service.js
@@ -32,7 +32,8 @@ async function go(contactHashId, sessionId, licenceMonitoringStationId) {
     session.noticeType,
     notification,
     sessionId,
-    licenceMonitoringStationId
+    licenceMonitoringStationId,
+    session.referenceCode
   )
 
   return {

--- a/app/services/notices/setup/submit-check.service.js
+++ b/app/services/notices/setup/submit-check.service.js
@@ -36,7 +36,7 @@ async function go(sessionId, auth) {
 
   const notifications = await DetermineNotificationsService.go(sessionCopy, recipients, notice.id)
 
-  _processNotifications(notifications, notice)
+  _processNotifications(notifications, notice, sessionCopy.referenceCode)
 
   return notice.id
 }
@@ -47,11 +47,11 @@ async function _notice(session, recipients, auth) {
   return CreateNoticeService.go(event)
 }
 
-async function _processNotifications(notifications, notice) {
+async function _processNotifications(notifications, notice, referenceCode) {
   try {
     const startTime = currentTimeInNanoseconds()
 
-    await BatchNotificationsService.go(notifications, notice.id)
+    await BatchNotificationsService.go(notifications, notice.id, referenceCode)
 
     calculateAndLogTimeTaken(startTime, 'Send notifications complete', {})
   } catch (error) {

--- a/test/presenters/notices/setup/abstraction-alert-notifications.presenter.test.js
+++ b/test/presenters/notices/setup/abstraction-alert-notifications.presenter.test.js
@@ -11,14 +11,12 @@ const { expect } = Code
 // Test helpers
 const AbstractionAlertSessionData = require('../../../fixtures/abstraction-alert-session-data.fixture.js')
 const RecipientsFixture = require('../../../fixtures/recipients.fixtures.js')
-const { generateReferenceCode } = require('../../../support/helpers/notification.helper.js')
 
 // Thing under test
 const AbstractionAlertNotificationsPresenter = require('../../../../app/presenters/notices/setup/abstraction-alert-notifications.presenter.js')
 
 describe('Notices - Setup - Abstraction Alert Notifications presenter', () => {
   const eventId = 'c1cae668-3dad-4806-94e2-eb3f27222ed9'
-  const referenceCode = generateReferenceCode()
 
   let clock
   let licenceMonitoringStations
@@ -49,7 +47,6 @@ describe('Notices - Setup - Abstraction Alert Notifications presenter', () => {
       alertEmailAddress: 'luke.skywalker@rebelmail.test',
       alertType: 'warning',
       journey: 'alerts',
-      referenceCode,
       relevantLicenceMonitoringStations
     }
 
@@ -87,7 +84,6 @@ describe('Notices - Setup - Abstraction Alert Notifications presenter', () => {
           thresholdValue: 1000
         },
         recipient: 'primary.user@important.com',
-        reference: referenceCode,
         templateId: '6ec7265d-8ebb-4217-a62b-9bf0216f8c9f'
       },
       {
@@ -119,7 +115,6 @@ describe('Notices - Setup - Abstraction Alert Notifications presenter', () => {
           thresholdUnit: 'm3/s',
           thresholdValue: 100
         },
-        reference: referenceCode,
         templateId: '7ab10c86-2c23-4376-8c72-9419e7f982bb'
       },
       {
@@ -145,7 +140,6 @@ describe('Notices - Setup - Abstraction Alert Notifications presenter', () => {
           thresholdValue: 100
         },
         recipient: 'additional.contact@important.com',
-        reference: referenceCode,
         templateId: 'bf32327a-f170-4854-8abb-3068aee9cdec'
       }
     ])
@@ -186,7 +180,6 @@ describe('Notices - Setup - Abstraction Alert Notifications presenter', () => {
             thresholdValue: 1000
           },
           recipient: 'primary.user@important.com',
-          reference: referenceCode,
           templateId: '6ec7265d-8ebb-4217-a62b-9bf0216f8c9f'
         },
         {
@@ -212,7 +205,6 @@ describe('Notices - Setup - Abstraction Alert Notifications presenter', () => {
             thresholdValue: 100
           },
           recipient: 'primary.user@important.com',
-          reference: referenceCode,
           templateId: 'a51ace39-3224-4c18-bbb8-c803a6da9a21'
         }
       ])
@@ -253,7 +245,6 @@ describe('Notices - Setup - Abstraction Alert Notifications presenter', () => {
             thresholdValue: 100
           },
           recipient: 'additional.contact@important.com',
-          reference: referenceCode,
           templateId: 'bf32327a-f170-4854-8abb-3068aee9cdec'
         }
       ])
@@ -297,7 +288,6 @@ describe('Notices - Setup - Abstraction Alert Notifications presenter', () => {
             thresholdValue: 1000
           },
           recipient: 'additional.contact@important.com',
-          reference: referenceCode,
           templateId: '6ec7265d-8ebb-4217-a62b-9bf0216f8c9f'
         }
       ])
@@ -341,7 +331,6 @@ describe('Notices - Setup - Abstraction Alert Notifications presenter', () => {
             thresholdValue: 1000
           },
           recipient: 'primary.user@important.com',
-          reference: referenceCode,
           templateId: '6ec7265d-8ebb-4217-a62b-9bf0216f8c9f'
         }
       ])
@@ -389,7 +378,6 @@ describe('Notices - Setup - Abstraction Alert Notifications presenter', () => {
             thresholdUnit: 'm',
             thresholdValue: 1000
           },
-          reference: referenceCode,
           templateId: '27499bbd-e854-4f13-884e-30e0894526b6'
         }
       ])

--- a/test/presenters/notices/setup/notifications.presenter.test.js
+++ b/test/presenters/notices/setup/notifications.presenter.test.js
@@ -10,13 +10,11 @@ const { expect } = Code
 
 // Test helpers
 const RecipientsFixture = require('../../../fixtures/recipients.fixtures.js')
-const { generateReferenceCode } = require('../../../support/helpers/notification.helper.js')
 
 // Thing under test
 const NotificationsPresenter = require('../../../../app/presenters/notices/setup/notifications.presenter.js')
 
 describe('Notices - Setup - Notifications Presenter', () => {
-  const referenceCode = generateReferenceCode()
   const eventId = 'c1cae668-3dad-4806-94e2-eb3f27222ed9'
 
   let clock
@@ -41,8 +39,7 @@ describe('Notices - Setup - Notifications Presenter', () => {
     session = {
       determinedReturnsPeriod,
       journey: 'standard',
-      noticeType: 'invitations',
-      referenceCode
+      noticeType: 'invitations'
     }
 
     clock = Sinon.useFakeTimers(new Date(`2025-01-01`))
@@ -70,7 +67,6 @@ describe('Notices - Setup - Notifications Presenter', () => {
           returnDueDate: '28 April 2025'
         },
         recipient: 'primary.user@important.com',
-        reference: referenceCode,
         templateId: '2fa7fc83-4df1-4f52-bccf-ff0faeb12b6f'
       },
       {
@@ -84,7 +80,6 @@ describe('Notices - Setup - Notifications Presenter', () => {
           periodStartDate: '1 January 2025',
           returnDueDate: '28 April 2025'
         },
-        reference: referenceCode,
         recipient: 'returns.agent@important.com',
         templateId: '41c45bd4-8225-4d7e-a175-b48b613b5510'
       },
@@ -106,7 +101,6 @@ describe('Notices - Setup - Notifications Presenter', () => {
           periodStartDate: '1 January 2025',
           returnDueDate: '28 April 2025'
         },
-        reference: referenceCode,
         templateId: '4fe80aed-c5dd-44c3-9044-d0289d635019'
       },
       {
@@ -127,7 +121,6 @@ describe('Notices - Setup - Notifications Presenter', () => {
           periodStartDate: '1 January 2025',
           returnDueDate: '28 April 2025'
         },
-        reference: referenceCode,
         templateId: '0e535549-99a2-44a9-84a7-589b12d00879'
       },
       {
@@ -148,7 +141,6 @@ describe('Notices - Setup - Notifications Presenter', () => {
           periodStartDate: '1 January 2025',
           returnDueDate: '28 April 2025'
         },
-        reference: referenceCode,
         templateId: '4fe80aed-c5dd-44c3-9044-d0289d635019'
       }
     ])
@@ -182,7 +174,6 @@ describe('Notices - Setup - Notifications Presenter', () => {
                   returnDueDate: '28 April 2025'
                 },
                 recipient: 'primary.user@important.com',
-                reference: referenceCode,
                 templateId: '2fa7fc83-4df1-4f52-bccf-ff0faeb12b6f'
               }
             ])
@@ -210,7 +201,6 @@ describe('Notices - Setup - Notifications Presenter', () => {
                   returnDueDate: '28 April 2025'
                 },
                 recipient: 'returns.agent@important.com',
-                reference: referenceCode,
                 templateId: '41c45bd4-8225-4d7e-a175-b48b613b5510'
               }
             ])
@@ -238,7 +228,6 @@ describe('Notices - Setup - Notifications Presenter', () => {
                   returnDueDate: '28 April 2025'
                 },
                 recipient: 'primary.user@important.com',
-                reference: referenceCode,
                 templateId: '2fa7fc83-4df1-4f52-bccf-ff0faeb12b6f'
               }
             ])
@@ -274,7 +263,6 @@ describe('Notices - Setup - Notifications Presenter', () => {
                   periodStartDate: '1 January 2025',
                   returnDueDate: '28 April 2025'
                 },
-                reference: referenceCode,
                 templateId: '4fe80aed-c5dd-44c3-9044-d0289d635019'
               }
             ])
@@ -308,7 +296,6 @@ describe('Notices - Setup - Notifications Presenter', () => {
                   periodStartDate: '1 January 2025',
                   returnDueDate: '28 April 2025'
                 },
-                reference: referenceCode,
                 templateId: '0e535549-99a2-44a9-84a7-589b12d00879'
               }
             ])
@@ -342,7 +329,6 @@ describe('Notices - Setup - Notifications Presenter', () => {
                   periodStartDate: '1 January 2025',
                   returnDueDate: '28 April 2025'
                 },
-                reference: referenceCode,
                 templateId: '4fe80aed-c5dd-44c3-9044-d0289d635019'
               }
             ])
@@ -378,7 +364,6 @@ describe('Notices - Setup - Notifications Presenter', () => {
                   returnDueDate: '28 April 2025'
                 },
                 recipient: 'primary.user@important.com',
-                reference: referenceCode,
                 templateId: 'f1144bc7-8bdc-4e82-87cb-1a6c69445836'
               }
             ])
@@ -406,7 +391,6 @@ describe('Notices - Setup - Notifications Presenter', () => {
                   returnDueDate: '28 April 2025'
                 },
                 recipient: 'returns.agent@important.com',
-                reference: referenceCode,
                 templateId: '038e1807-d1b5-4f09-a5a6-d7eee9030a7a'
               }
             ])
@@ -434,7 +418,6 @@ describe('Notices - Setup - Notifications Presenter', () => {
                   returnDueDate: '28 April 2025'
                 },
                 recipient: 'primary.user@important.com',
-                reference: referenceCode,
                 templateId: 'f1144bc7-8bdc-4e82-87cb-1a6c69445836'
               }
             ])
@@ -470,7 +453,6 @@ describe('Notices - Setup - Notifications Presenter', () => {
                   periodStartDate: '1 January 2025',
                   returnDueDate: '28 April 2025'
                 },
-                reference: referenceCode,
                 templateId: 'c01c808b-094b-4a3a-ab9f-a6e86bad36ba'
               }
             ])
@@ -504,7 +486,6 @@ describe('Notices - Setup - Notifications Presenter', () => {
                   periodStartDate: '1 January 2025',
                   returnDueDate: '28 April 2025'
                 },
-                reference: referenceCode,
                 templateId: 'e9f132c7-a550-4e18-a5c1-78375f07aa2d'
               }
             ])
@@ -538,7 +519,6 @@ describe('Notices - Setup - Notifications Presenter', () => {
                   periodStartDate: '1 January 2025',
                   returnDueDate: '28 April 2025'
                 },
-                reference: referenceCode,
                 templateId: 'c01c808b-094b-4a3a-ab9f-a6e86bad36ba'
               }
             ])
@@ -579,7 +559,6 @@ describe('Notices - Setup - Notifications Presenter', () => {
                   returnDueDate: '29 January 2025'
                 },
                 recipient: 'primary.user@important.com',
-                reference: referenceCode,
                 templateId: '7bb89469-1dbc-458a-9526-fad8ab71285f'
               }
             ])
@@ -607,7 +586,6 @@ describe('Notices - Setup - Notifications Presenter', () => {
                   returnDueDate: '29 January 2025'
                 },
                 recipient: 'returns.agent@important.com',
-                reference: referenceCode,
                 templateId: 'cbc4efe2-f3b5-4642-8f6d-3532df73ee94'
               }
             ])
@@ -635,7 +613,6 @@ describe('Notices - Setup - Notifications Presenter', () => {
                   returnDueDate: '29 January 2025'
                 },
                 recipient: 'primary.user@important.com',
-                reference: referenceCode,
                 templateId: '7bb89469-1dbc-458a-9526-fad8ab71285f'
               }
             ])
@@ -683,7 +660,6 @@ describe('Notices - Setup - Notifications Presenter', () => {
                   periodEndDate: null,
                   periodStartDate: null
                 },
-                reference: referenceCode,
                 templateId: '4b47cf1c-043c-4a0c-8659-5be06cb2b860'
               }
             ])
@@ -717,7 +693,6 @@ describe('Notices - Setup - Notifications Presenter', () => {
                   periodEndDate: null,
                   periodStartDate: null
                 },
-                reference: referenceCode,
                 templateId: '73b4c395-4423-4976-8ab4-c82e2cb6beee'
               }
             ])
@@ -751,7 +726,6 @@ describe('Notices - Setup - Notifications Presenter', () => {
                   periodStartDate: null,
                   returnDueDate: '30 January 2025'
                 },
-                reference: referenceCode,
                 templateId: '4b47cf1c-043c-4a0c-8659-5be06cb2b860'
               }
             ])

--- a/test/presenters/notices/setup/preview/preview.presenter.test.js
+++ b/test/presenters/notices/setup/preview/preview.presenter.test.js
@@ -8,13 +8,16 @@ const Sinon = require('sinon')
 const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
+// Test helpers
+const { generateReferenceCode } = require('../../../../support/helpers/notification.helper.js')
+
 // Things we need to stub
 const GeneratePreviewRequest = require('../../../../../app/requests/notify/generate-preview.request.js')
 
 // Thing under test
 const PreviewPresenter = require('../../../../../app/presenters/notices/setup/preview/preview.presenter.js')
 
-describe('Notices - Setup - Preview - Preview presenter', () => {
+describe.only('Notices - Setup - Preview - Preview presenter', () => {
   const contactHashId = '9df5923f179a0ed55c13173c16651ed9'
   const licenceMonitoringStationId = 'a4d15f69-5005-4b6e-ab50-3fbae2deec9c'
   const sessionId = '7334a25e-9723-4732-a6e1-8e30c5f3732e'
@@ -22,6 +25,11 @@ describe('Notices - Setup - Preview - Preview presenter', () => {
   let noticeType
   let notification
   let response
+  let referenceCode
+
+  beforeEach(() => {
+    referenceCode = generateReferenceCode()
+  })
 
   afterEach(() => {
     Sinon.restore()
@@ -52,7 +60,6 @@ describe('Notices - Setup - Preview - Preview presenter', () => {
               periodStartDate: '1st January 2025',
               returnDueDate: '28th April 2025'
             },
-            reference: 'RINV-0Q7AD8',
             templateId: '4fe80aed-c5dd-44c3-9044-d0289d635019'
           }
 
@@ -81,7 +88,8 @@ describe('Notices - Setup - Preview - Preview presenter', () => {
             noticeType,
             notification,
             sessionId,
-            licenceMonitoringStationId
+            licenceMonitoringStationId,
+            referenceCode
           )
 
           expect(result).to.equal({
@@ -95,7 +103,7 @@ describe('Notices - Setup - Preview - Preview presenter', () => {
               'CB23 1ZZ'
             ],
             backLink: `/system/notices/setup/${sessionId}/check`,
-            caption: 'Notice RINV-0Q7AD8',
+            caption: `Notice ${referenceCode}`,
             contents: 'Dear Clean Water Limited,\r\n',
             messageType: 'letter',
             pageTitle: 'Returns invitation licence holder letter',
@@ -116,7 +124,6 @@ describe('Notices - Setup - Preview - Preview presenter', () => {
               returnDueDate: '28th April 2025'
             },
             recipient: 'hello@example.com',
-            reference: 'RINV-H1EZR5',
             templateId: '4fe80aed-c5dd-44c3-9044-d0289d635019'
           }
 
@@ -145,13 +152,14 @@ describe('Notices - Setup - Preview - Preview presenter', () => {
             noticeType,
             notification,
             sessionId,
-            licenceMonitoringStationId
+            licenceMonitoringStationId,
+            referenceCode
           )
 
           expect(result).to.equal({
             address: 'hello@example.com',
             backLink: `/system/notices/setup/${sessionId}/check`,
-            caption: 'Notice RINV-H1EZR5',
+            caption: `Notice ${referenceCode}`,
             contents: 'Dear licence holder,\r\n',
             messageType: 'email',
             pageTitle: 'Returns invitation primary user email',
@@ -164,6 +172,8 @@ describe('Notices - Setup - Preview - Preview presenter', () => {
     describe('and the notice type is "abstractionAlerts"', () => {
       beforeEach(() => {
         noticeType = 'abstractionAlerts'
+
+        referenceCode = generateReferenceCode('WAA')
       })
 
       describe('and the notification is a letter', () => {
@@ -191,7 +201,6 @@ describe('Notices - Setup - Preview - Preview presenter', () => {
               threshold_unit: 'm3/s',
               threshold_value: 100
             },
-            reference: 'WAA-DLT1YN',
             templateId: '7ab10c86-2c23-4376-8c72-9419e7f982bb'
           }
 
@@ -220,7 +229,8 @@ describe('Notices - Setup - Preview - Preview presenter', () => {
             noticeType,
             notification,
             sessionId,
-            licenceMonitoringStationId
+            licenceMonitoringStationId,
+            referenceCode
           )
 
           expect(result).to.equal({
@@ -233,7 +243,7 @@ describe('Notices - Setup - Preview - Preview presenter', () => {
               'CB23 1ZZ'
             ],
             backLink: `/system/notices/setup/${sessionId}/preview/${contactHashId}/check-alert`,
-            caption: 'Notice WAA-DLT1YN',
+            caption: `Notice ${referenceCode}`,
             contents: 'Dear licence contact,\r\n',
             messageType: 'letter',
             pageTitle: 'Water abstraction alert stop warning',
@@ -261,7 +271,6 @@ describe('Notices - Setup - Preview - Preview presenter', () => {
               threshold_value: 100
             },
             recipient: 'hello@example.com',
-            reference: 'WAA-WFB4LB',
             templateId: 'bf32327a-f170-4854-8abb-3068aee9cdec'
           }
 
@@ -290,13 +299,14 @@ describe('Notices - Setup - Preview - Preview presenter', () => {
             noticeType,
             notification,
             sessionId,
-            licenceMonitoringStationId
+            licenceMonitoringStationId,
+            referenceCode
           )
 
           expect(result).to.equal({
             address: 'hello@example.com',
             backLink: `/system/notices/setup/${sessionId}/preview/${contactHashId}/check-alert`,
-            caption: 'Notice WAA-WFB4LB',
+            caption: `Notice ${referenceCode}`,
             contents: 'Dear licence contact,\r\n',
             messageType: 'email',
             pageTitle: 'Water abstraction alert reduce or stop warning email',
@@ -321,7 +331,6 @@ describe('Notices - Setup - Preview - Preview presenter', () => {
           returnDueDate: '28th April 2025'
         },
         recipient: 'hello@example.com',
-        reference: 'RINV-H1EZR5',
         templateId: '4fe80aed-c5dd-44c3-9044-d0289d635019'
       }
 
@@ -350,13 +359,14 @@ describe('Notices - Setup - Preview - Preview presenter', () => {
         noticeType,
         notification,
         sessionId,
-        licenceMonitoringStationId
+        licenceMonitoringStationId,
+        referenceCode
       )
 
       expect(result).to.equal({
         address: 'hello@example.com',
         backLink: `/system/notices/setup/${sessionId}/check`,
-        caption: 'Notice RINV-H1EZR5',
+        caption: `Notice ${referenceCode}`,
         contents: 'error',
         messageType: 'email',
         pageTitle: 'Returns invitation primary user email',

--- a/test/presenters/notices/setup/preview/preview.presenter.test.js
+++ b/test/presenters/notices/setup/preview/preview.presenter.test.js
@@ -17,7 +17,7 @@ const GeneratePreviewRequest = require('../../../../../app/requests/notify/gener
 // Thing under test
 const PreviewPresenter = require('../../../../../app/presenters/notices/setup/preview/preview.presenter.js')
 
-describe.only('Notices - Setup - Preview - Preview presenter', () => {
+describe('Notices - Setup - Preview - Preview presenter', () => {
   const contactHashId = '9df5923f179a0ed55c13173c16651ed9'
   const licenceMonitoringStationId = 'a4d15f69-5005-4b6e-ab50-3fbae2deec9c'
   const sessionId = '7334a25e-9723-4732-a6e1-8e30c5f3732e'

--- a/test/presenters/notices/setup/return-forms-notification.presenter.test.js
+++ b/test/presenters/notices/setup/return-forms-notification.presenter.test.js
@@ -9,7 +9,6 @@ const { expect } = Code
 
 // Test helpers
 const { generateLicenceRef } = require('../../../support/helpers/licence.helper.js')
-const { generateReferenceCode } = require('../../../support/helpers/notification.helper.js')
 const { generateReturnLogId } = require('../../../support/helpers/return-log.helper.js')
 const { generateUUID } = require('../../../../app/lib/general.lib.js')
 
@@ -21,7 +20,6 @@ describe('Notices - Setup - Return Forms Notification Presenter', () => {
 
   let licenceRef
   let pageData
-  let referenceCode
   let returnForm
   let returnId
   let returnLogId
@@ -32,8 +30,6 @@ describe('Notices - Setup - Return Forms Notification Presenter', () => {
     returnId = generateUUID()
 
     returnLogId = generateReturnLogId()
-
-    referenceCode = generateReferenceCode('PRTF')
 
     returnForm = new TextEncoder().encode('mock file').buffer
 
@@ -67,7 +63,7 @@ describe('Notices - Setup - Return Forms Notification Presenter', () => {
 
   describe('when called', () => {
     it('returns the data re-formatted as a notification', () => {
-      const result = ReturnFormsNotificationPresenter.go(returnForm, pageData, licenceRef, referenceCode, eventId)
+      const result = ReturnFormsNotificationPresenter.go(returnForm, pageData, licenceRef, eventId)
 
       expect(result).to.equal({
         content: returnForm,
@@ -96,7 +92,6 @@ describe('Notices - Setup - Return Forms Notification Presenter', () => {
           site_description: 'Water park',
           start_date: '1 January 2025'
         },
-        reference: referenceCode,
         returnLogIds: [returnId]
       })
     })

--- a/test/services/notices/setup/determine-notifications.service.test.js
+++ b/test/services/notices/setup/determine-notifications.service.test.js
@@ -10,7 +10,6 @@ const { expect } = Code
 
 // Test helpers
 const RecipientsFixture = require('../../../fixtures/recipients.fixtures.js')
-const { generateReferenceCode } = require('../../../support/helpers/notification.helper.js')
 const { generateUUID } = require('../../../../app/lib/general.lib.js')
 const { notifyTemplates } = require('../../../../app/lib/notify-templates.lib.js')
 
@@ -25,7 +24,6 @@ describe('Notices - Setup - Determine Notifications service', () => {
   let event
   let recipients
   let recipientsFixture
-  let reference
   let session
   let testDate
 
@@ -42,8 +40,6 @@ describe('Notices - Setup - Determine Notifications service', () => {
 
   describe('when sending return invitations or reminders', () => {
     beforeEach(async () => {
-      reference = generateReferenceCode()
-
       recipientsFixture = RecipientsFixture.recipients()
       recipients = [recipientsFixture.primaryUser]
 
@@ -61,8 +57,7 @@ describe('Notices - Setup - Determine Notifications service', () => {
           startDate: '2022-04-01'
         },
         journey: 'standard',
-        noticeType: 'invitations',
-        referenceCode: reference
+        noticeType: 'invitations'
       }
     })
 
@@ -82,7 +77,6 @@ describe('Notices - Setup - Determine Notifications service', () => {
             periodStartDate: '1 April 2022'
           },
           recipient: 'primary.user@important.com',
-          reference,
           templateId: '2fa7fc83-4df1-4f52-bccf-ff0faeb12b6f'
         }
       ])
@@ -91,8 +85,6 @@ describe('Notices - Setup - Determine Notifications service', () => {
 
   describe('when sending abstraction alerts', () => {
     beforeEach(async () => {
-      reference = generateReferenceCode('WAA')
-
       recipientsFixture = RecipientsFixture.alertsRecipients()
       recipients = [recipientsFixture.primaryUser]
 
@@ -141,7 +133,6 @@ describe('Notices - Setup - Determine Notifications service', () => {
         name: 'Water abstraction alert',
         noticeType: 'abstractionAlerts',
         notificationType: 'Abstraction alert',
-        referenceCode: reference,
         relevantLicenceMonitoringStations: [...licenceMonitoringStations],
         removedThresholds: [],
         selectedRecipients: [],
@@ -176,7 +167,6 @@ describe('Notices - Setup - Determine Notifications service', () => {
             thresholdValue: 500
           },
           recipient: 'primary.user@important.com',
-          reference,
           templateId: notifyTemplates.alerts.email.stopWarning
         }
       ])
@@ -188,8 +178,6 @@ describe('Notices - Setup - Determine Notifications service', () => {
     let returnId
 
     beforeEach(async () => {
-      reference = generateReferenceCode('PRTF')
-
       returnId = generateUUID()
 
       recipientsFixture = RecipientsFixture.recipients()
@@ -201,8 +189,7 @@ describe('Notices - Setup - Determine Notifications service', () => {
       }
 
       session = {
-        noticeType: 'returnForms',
-        referenceCode: reference
+        noticeType: 'returnForms'
       }
 
       buffer = new TextEncoder().encode('mock file').buffer
@@ -213,7 +200,6 @@ describe('Notices - Setup - Determine Notifications service', () => {
         licences: [recipientsFixture.licenceHolder.licence_refs],
         messageRef: 'pdf.return_form',
         messageType: 'letter',
-        reference,
         returnLogIds: [returnId]
       }
 
@@ -238,7 +224,6 @@ describe('Notices - Setup - Determine Notifications service', () => {
           personalisation: {
             name: 'Red 5'
           },
-          reference,
           returnLogIds: [returnId]
         }
       ])

--- a/test/services/notices/setup/determine-return-forms.service.test.js
+++ b/test/services/notices/setup/determine-return-forms.service.test.js
@@ -13,7 +13,6 @@ const RecipientsFixture = require('../../../fixtures/recipients.fixtures.js')
 const ReturnLogFixture = require('../../../fixtures/return-logs.fixture.js')
 const SessionHelper = require('../../../support/helpers/session.helper.js')
 const { generateLicenceRef } = require('../../../support/helpers/licence.helper.js')
-const { generateReferenceCode } = require('../../../support/helpers/notification.helper.js')
 const { generateUUID } = require('../../../../app/lib/general.lib.js')
 
 // Things we need to stub
@@ -30,15 +29,12 @@ describe('Notices - Setup - Determine Return Forms Service', () => {
   let dueReturnLog
   let licenceRef
   let recipients
-  let referenceCode
   let session
   let sessionData
   let testRecipients
 
   beforeEach(async () => {
     licenceRef = generateLicenceRef()
-
-    referenceCode = generateReferenceCode('PRTF')
 
     recipients = RecipientsFixture.recipients()
     testRecipients = [recipients.licenceHolder, recipients.returnsTo]
@@ -56,7 +52,6 @@ describe('Notices - Setup - Determine Return Forms Service', () => {
     sessionData = {
       licenceRef,
       dueReturns: [dueReturnLog, additionalDueReturn],
-      referenceCode,
       selectedReturns: [dueReturnLog.returnId]
     }
 
@@ -104,7 +99,6 @@ describe('Notices - Setup - Determine Return Forms Service', () => {
               site_description: 'BOREHOLE AT AVALON',
               start_date: '1 April 2022'
             },
-            reference: referenceCode,
             returnLogIds: [dueReturnLog.returnId]
           },
           {
@@ -134,7 +128,6 @@ describe('Notices - Setup - Determine Return Forms Service', () => {
               site_description: 'BOREHOLE AT AVALON',
               start_date: '1 April 2022'
             },
-            reference: referenceCode,
             returnLogIds: [dueReturnLog.returnId]
           }
         ])
@@ -177,7 +170,6 @@ describe('Notices - Setup - Determine Return Forms Service', () => {
               site_description: 'BOREHOLE AT AVALON',
               start_date: '1 April 2022'
             },
-            reference: referenceCode,
             returnLogIds: [dueReturnLog.returnId]
           },
           {
@@ -207,7 +199,6 @@ describe('Notices - Setup - Determine Return Forms Service', () => {
               site_description: 'BOREHOLE AT AVALON',
               start_date: '1 April 2022'
             },
-            reference: referenceCode,
             returnLogIds: [dueReturnLog.returnId]
           },
           {
@@ -237,7 +228,6 @@ describe('Notices - Setup - Determine Return Forms Service', () => {
               site_description: 'BOREHOLE AT AVALON',
               start_date: '1 April 2022'
             },
-            reference: referenceCode,
             returnLogIds: [additionalDueReturn.returnId]
           },
           {
@@ -267,7 +257,6 @@ describe('Notices - Setup - Determine Return Forms Service', () => {
               site_description: 'BOREHOLE AT AVALON',
               start_date: '1 April 2022'
             },
-            reference: referenceCode,
             returnLogIds: [additionalDueReturn.returnId]
           }
         ])


### PR DESCRIPTION

https://eaflood.atlassian.net/browse/WATER-5280

We are refactoring the batch notification.

As part of this refactor, we have identified an improvement to the way we compose notifications.

Previously every notification was setting the reference itself (also known as 'referenceCode').

This is uniquely generated to link all the records in Notify. We do not use this locally other for than display. We link notations to a notice through the notice id (even id).

So we can remove the need for notifications to 'know' about it.

This change removes setting the reference code in the various notification presenters. The batch service now has the responsibility of setting the reference code.

This was found as we were previously deleting the reference before saving a new notification. As we are currently in the process of making changes to save the notification data before sending to notify.