### PR TITLE
Add migration to add a template id column to notifications

### DIFF
--- a/db/migrations/legacy/20221108007033_water-scheduled-notification.js
+++ b/db/migrations/legacy/20221108007033_water-scheduled-notification.js
@@ -30,6 +30,7 @@ exports.up = function (knex) {
     table.string('job_id')
     table.uuid('licence_gauging_station_id')
     table.jsonb('return_log_ids')
+    table.uuid('template_id')
 
     // Legacy timestamps
     table.timestamp('date_created', { useTz: false }).defaultTo(knex.fn.now())

--- a/db/migrations/public/20250925101514_alter-notifcations.js
+++ b/db/migrations/public/20250925101514_alter-notifcations.js
@@ -1,0 +1,69 @@
+'use strict'
+
+exports.up = function (knex) {
+  return knex.schema.dropViewIfExists('notifications').createView('notifications', (view) => {
+    view.as(
+      knex('scheduled_notification').withSchema('water').select([
+        'id',
+        'recipient',
+        'message_type',
+        'message_ref',
+        'personalisation',
+        // 'send_after',
+        'status',
+        'log AS notify_error',
+        'licences',
+        // 'individual_entity_id AS individual_id',
+        // 'company_entity_id AS company_id',
+        // 'medium',
+        'notify_id',
+        'notify_status',
+        'plaintext',
+        'event_id',
+        // 'metadata',
+        // 'status_checks',
+        // 'next_status_check',
+        // 'notification_type',
+        // 'job_id',
+        'licence_gauging_station_id AS licence_monitoring_station_id',
+        'date_created AS created_at',
+        'return_log_ids',
+        'template_id'
+      ])
+    )
+  })
+}
+
+exports.down = function (knex) {
+  return knex.schema.dropViewIfExists('notifications').createView('notifications', (view) => {
+    // NOTE: We have commented out unused columns from the source table
+    view.as(
+      knex('scheduled_notification').withSchema('water').select([
+        'id',
+        'recipient',
+        'message_type',
+        'message_ref',
+        'personalisation',
+        // 'send_after',
+        'status',
+        'log AS notify_error',
+        'licences',
+        // 'individual_entity_id AS individual_id',
+        // 'company_entity_id AS company_id',
+        // 'medium',
+        'notify_id',
+        'notify_status',
+        'plaintext',
+        'event_id',
+        // 'metadata',
+        // 'status_checks',
+        // 'next_status_check',
+        // 'notification_type',
+        // 'job_id',
+        'licence_gauging_station_id AS licence_monitoring_station_id',
+        'date_created AS created_at',
+        'return_log_ids'
+      ])
+    )
+  })
+}

--- a/test/services/jobs/notification-status/process-notification-status.service.test.js
+++ b/test/services/jobs/notification-status/process-notification-status.service.test.js
@@ -107,7 +107,8 @@ describe('Job - Notifications - Process Notification Status service', () => {
               plaintext: 'Dear Clean Water Limited,\r\n',
               recipient: 'hello@example.com',
               returnLogIds: null,
-              status: 'sent'
+              status: 'sent',
+              templateId: null
             },
             { skip: ['createdAt'] }
           )
@@ -175,7 +176,8 @@ describe('Job - Notifications - Process Notification Status service', () => {
               plaintext: 'Dear licence contact,\r\n',
               recipient: 'hello@example.com',
               returnLogIds: null,
-              status: 'sent'
+              status: 'sent',
+              templateId: null
             },
             { skip: ['createdAt'] }
           )
@@ -233,7 +235,8 @@ describe('Job - Notifications - Process Notification Status service', () => {
               plaintext: 'Dear Clean Water Limited,\r\n',
               recipient: 'hello@example.com',
               returnLogIds: null,
-              status: 'sent'
+              status: 'sent',
+              templateId: null
             },
             { skip: ['createdAt'] }
           )
@@ -304,7 +307,8 @@ describe('Job - Notifications - Process Notification Status service', () => {
             plaintext: 'Dear Clean Water Limited,\r\n',
             recipient: 'hello@example.com',
             returnLogIds: null,
-            status: 'error'
+            status: 'error',
+            templateId: null
           },
           { skip: ['createdAt'] }
         )
@@ -391,7 +395,8 @@ describe('Job - Notifications - Process Notification Status service', () => {
           plaintext: 'Dear Clean Water Limited,\r\n',
           recipient: 'hello@example.com',
           returnLogIds: null,
-          status: 'pending'
+          status: 'pending',
+          templateId: null
         },
         { skip: ['createdAt'] }
       )

--- a/test/services/jobs/notification-status/update-notifications.service.test.js
+++ b/test/services/jobs/notification-status/update-notifications.service.test.js
@@ -68,7 +68,8 @@ describe('Job - Notification Status - Update Notifications service', () => {
         plaintext: null,
         recipient: null,
         returnLogIds: null,
-        status: 'sent'
+        status: 'sent',
+        templateId: null
       })
     })
   })
@@ -116,7 +117,8 @@ describe('Job - Notification Status - Update Notifications service', () => {
         plaintext: null,
         recipient: null,
         returnLogIds: null,
-        status: 'sent'
+        status: 'sent',
+        templateId: null
       })
     })
 
@@ -140,7 +142,8 @@ describe('Job - Notification Status - Update Notifications service', () => {
         plaintext: null,
         recipient: null,
         returnLogIds: null,
-        status: 'sent'
+        status: 'sent',
+        templateId: null
       })
     })
   })

--- a/test/services/notices/setup/batch-notifications.service.test.js
+++ b/test/services/notices/setup/batch-notifications.service.test.js
@@ -101,7 +101,8 @@ describe('Notices - Setup - Batch Notifications service', () => {
           notifyStatus: 'created',
           recipient: 'primary.user@important.com',
           returnLogIds: null,
-          status: 'pending'
+          status: 'pending',
+          templateId: null
         }
       ])
     })
@@ -156,7 +157,8 @@ describe('Notices - Setup - Batch Notifications service', () => {
           plaintext: 'Dear Licence holder,\r\n',
           recipient: null,
           returnLogIds: null,
-          status: 'pending'
+          status: 'pending',
+          templateId: null
         }
       ])
     })
@@ -206,7 +208,8 @@ describe('Notices - Setup - Batch Notifications service', () => {
           notifyStatus: 'created',
           recipient: null,
           returnLogIds: testNotification.pdf.returnLogIds,
-          status: 'pending'
+          status: 'pending',
+          templateId: null
         }
       ])
     })

--- a/test/services/notices/setup/create-notifications.service.test.js
+++ b/test/services/notices/setup/create-notifications.service.test.js
@@ -53,7 +53,8 @@ describe('Notices - Setup - Create notification service', () => {
         plaintext: null,
         recipient: null,
         returnLogIds: null,
-        status: null
+        status: null,
+        templateId: null
       })
     })
   })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5280

The Notify template ids where not previously stored.

This migration adds the column to record the Notify template id.

https://docs.notifications.service.gov.uk/node.html#templateid-required

The water abstraction service was updated here - https://github.com/DEFRA/water-abstraction-service/pull/2725