### PR TITLE
Fix digitise user role seeding and update tests

### DIFF
--- a/test/models/role.model.test.js
+++ b/test/models/role.model.test.js
@@ -24,7 +24,8 @@ const RoleModel = require('../../app/models/role.model.js')
 const GROUP_ROLE_SUPER_AR_USER_INDEX = 16
 const GROUP_SUPER_INDEX = 5
 const ROLE_AR_USER_INDEX = 6
-const USER_SUPER_INDEX = 1
+const USER_DIGITISE_EDITOR_INDEX = 11
+const USER_ROLE_AR_USER_INDEX = 0
 
 const { SKIP_COMPARE_LIST: skip } = UserHelper
 
@@ -40,8 +41,8 @@ describe('Role model', () => {
     testRecord = RoleHelper.select(ROLE_AR_USER_INDEX)
     testGroup = GroupHelper.select(GROUP_SUPER_INDEX)
     testGroupRole = GroupRoleHelper.select(GROUP_ROLE_SUPER_AR_USER_INDEX)
-    testUser = UserHelper.select(USER_SUPER_INDEX)
-    testUserRole = await UserRoleHelper.add({ roleId: testRecord.id, userId: testUser.id })
+    testUser = UserHelper.select(USER_DIGITISE_EDITOR_INDEX)
+    testUserRole = UserRoleHelper.select(USER_ROLE_AR_USER_INDEX)
   })
 
   describe('Basic query', () => {
@@ -90,7 +91,7 @@ describe('Role model', () => {
         expect(result.userRoles).to.be.an.array()
         expect(result.userRoles).to.have.length(1)
         expect(result.userRoles[0]).to.be.an.instanceOf(UserRoleModel)
-        expect(result.userRoles[0]).to.equal(testUserRole)
+        expect(result.userRoles[0]).to.equal(testUserRole, { skip: ['createdAt', 'updatedAt'] })
       })
     })
 

--- a/test/models/user-role.model.test.js
+++ b/test/models/user-role.model.test.js
@@ -17,8 +17,9 @@ const UserHelper = require('../support/helpers/user.helper.js')
 // Thing under test
 const UserRoleModel = require('../../app/models/user-role.model.js')
 
-const ROLE_RENEWAL_NOTIFICATIONS_INDEX = 5
-const USER_NPS_INDEX = 6
+const ROLE_AR_USER_INDEX = 6
+const USER_DIGITISE_EDITOR_INDEX = 11
+const USER_ROLE_AR_USER_INDEX = 0
 
 const { SKIP_COMPARE_LIST: skip } = UserHelper
 
@@ -27,10 +28,10 @@ describe('User Role model', () => {
   let testRole
   let testUser
 
-  before(async () => {
-    testRole = RoleHelper.select(ROLE_RENEWAL_NOTIFICATIONS_INDEX)
-    testUser = UserHelper.select(USER_NPS_INDEX)
-    testRecord = await UserRoleHelper.add({ roleId: testRole.id, userId: testUser.id })
+  before(() => {
+    testRole = RoleHelper.select(ROLE_AR_USER_INDEX)
+    testUser = UserHelper.select(USER_DIGITISE_EDITOR_INDEX)
+    testRecord = UserRoleHelper.select(USER_ROLE_AR_USER_INDEX)
   })
 
   describe('Basic query', () => {

--- a/test/models/user.model.test.js
+++ b/test/models/user.model.test.js
@@ -29,10 +29,11 @@ const UserRoleModel = require('../../app/models/user-role.model.js')
 // Thing under test
 const UserModel = require('../../app/models/user.model.js')
 
-const GROUP_WIRS_INDEX = 2
-const ROLE_RETURNS_INDEX = 0
-const USER_GROUP_WIRS_INDEX = 3
-const USER_WIRS_INDEX = 3
+const GROUP_NPS_INDEX = 3
+const ROLE_AR_USER_INDEX = 6
+const USER_DIGITISE_EDITOR_INDEX = 11
+const USER_GROUP_NPS_INDEX = 7
+const USER_ROLE_AR_USER_INDEX = 0
 
 describe('User model', () => {
   let testChargeVersionNoteOne
@@ -44,15 +45,15 @@ describe('User model', () => {
   let testUserGroup
 
   before(async () => {
-    testRecord = UserHelper.select(USER_WIRS_INDEX)
+    testRecord = UserHelper.select(USER_DIGITISE_EDITOR_INDEX)
 
-    testRole = RoleHelper.select(ROLE_RETURNS_INDEX)
-    testGroup = GroupHelper.select(GROUP_WIRS_INDEX)
-    testUserGroup = UserGroupHelper.select(USER_GROUP_WIRS_INDEX)
+    testRole = RoleHelper.select(ROLE_AR_USER_INDEX)
+    testGroup = GroupHelper.select(GROUP_NPS_INDEX)
+    testUserGroup = UserGroupHelper.select(USER_GROUP_NPS_INDEX)
 
     testChargeVersionNoteOne = await ChargeVersionNoteHelper.add({ userId: testRecord.id, note: '1st test note' })
     testChargeVersionNoteTwo = await ChargeVersionNoteHelper.add({ userId: testRecord.id, note: '2nd test note' })
-    testUserRole = await UserRoleHelper.add({ userId: testRecord.id, roleId: testRole.id })
+    testUserRole = UserRoleHelper.select(USER_ROLE_AR_USER_INDEX)
   })
 
   describe('Basic query', () => {
@@ -264,7 +265,7 @@ describe('User model', () => {
         expect(result.userRoles).to.be.an.array()
         expect(result.userRoles).to.have.length(1)
         expect(result.userRoles[0]).to.be.an.instanceOf(UserRoleModel)
-        expect(result.userRoles[0]).to.equal(testUserRole)
+        expect(result.userRoles[0]).to.equal(testUserRole, { skip: ['createdAt', 'updatedAt'] })
       })
     })
   })

--- a/test/services/idm/fetch-user-roles-and-groups.service.test.js
+++ b/test/services/idm/fetch-user-roles-and-groups.service.test.js
@@ -11,6 +11,7 @@ const { expect } = Code
 const GroupHelper = require('../../support/helpers/group.helper.js')
 const RoleHelper = require('../../support/helpers/role.helper.js')
 const UserHelper = require('../../support/helpers/user.helper.js')
+const UserGroupHelper = require('../../support/helpers/user-group.helper.js')
 const UserRoleHelper = require('../../support/helpers/user-role.helper.js')
 
 // Thing under test
@@ -19,7 +20,6 @@ const FetchUserRolesAndGroupsService = require('../../../app/services/idm/fetch-
 const GROUP_ENV_OFFICER_INDEX = 0
 const ROLE_RETURNS_INDEX = 0
 const ROLE_HOF_NOTIFICATIONS_INDEX = 0
-const USER_ENV_OFFICER_INDEX = 2
 
 const { SKIP_COMPARE_LIST: skip } = UserHelper
 
@@ -30,7 +30,7 @@ describe('Fetch User Roles And Groups service', () => {
   let user
 
   before(async () => {
-    user = UserHelper.select(USER_ENV_OFFICER_INDEX)
+    user = await UserHelper.add({ application: 'water_admin', enabled: true, username: 'unit.test@wrls.gov.uk' })
 
     // Select a role and assign it directly to the user
     roleForUser = RoleHelper.select(ROLE_RETURNS_INDEX)
@@ -38,6 +38,7 @@ describe('Fetch User Roles And Groups service', () => {
 
     // Select a group and assign it to the user via a group
     groupForUser = GroupHelper.select(GROUP_ENV_OFFICER_INDEX)
+    await UserGroupHelper.add({ userId: user.id, groupId: groupForUser.id })
 
     // The result will be the users has 3 roles; 1 directly via user roles and 2 via the user group
   })
@@ -61,7 +62,7 @@ describe('Fetch User Roles And Groups service', () => {
       // 1 via the user role
       expect(roles).to.include('returns')
 
-      // 2 via the user group (environment officer has 2 roles in group_roles)
+      // 2 via the user group
       expect(roles).to.include('hof_notifications')
       expect(roles).to.include('manage_gauging_station_licence_links')
     })

--- a/test/support/database.js
+++ b/test/support/database.js
@@ -25,6 +25,7 @@ const RolesSeeder = require('../../db/seeds/07-roles.seed.js')
 const SecondaryPurposesSeeder = require('../../db/seeds/04-secondary-purposes.seed.js')
 const SourcesSeeder = require('../../db/seeds/15-sources.seed.js')
 const UserGroupsSeeder = require('../../db/seeds/10-user-groups.seed.js')
+const UserRolesSeeder = require('../../db/seeds/17-user-roles.seed.js')
 const UsersSeeder = require('../../db/seeds/09-users.seed.js')
 
 const LEGACY_SCHEMAS = ['crm', 'crm_v2', 'idm', 'permit', 'returns', 'water']
@@ -99,6 +100,7 @@ async function _seed() {
   await GroupRolesSeeder.seed()
   await UsersSeeder.seed()
   await UserGroupsSeeder.seed()
+  await UserRolesSeeder.seed()
   await FinancialAgreementsSeeder.seed()
   await ChangeReasonsSeeder.seed()
   await ChargeCategoriesSeeder.seed()

--- a/test/support/helpers/user-role.helper.js
+++ b/test/support/helpers/user-role.helper.js
@@ -5,9 +5,11 @@
  */
 
 const { generateUUID } = require('../../../app/lib/general.lib.js')
+const { selectRandomEntry } = require('../general.js')
 const { generateUserId } = require('./user.helper.js')
 const RoleHelper = require('./role.helper.js')
 const UserRoleModel = require('../../../app/models/user-role.model.js')
+const { data: userRoles } = require('../../../db/seeds/data/user-roles.js')
 
 /**
  * Add a new user role
@@ -55,7 +57,30 @@ function defaults(data = {}) {
   }
 }
 
+/**
+ * Select an entry from the reference data entries seeded at the start of testing
+ *
+ * Because this helper is linked to a reference record instead of a transaction, we don't expect these to be created
+ * when using the service.
+ *
+ * So, they are seeded automatically when tests are run. Tests that need to link to a record can use this method to
+ * select a specific entry, or have it return one at random.
+ *
+ * @param {number} [index=-1] - The reference entry to select. Defaults to -1 which means an entry will be returned at
+ * random from the reference data
+ *
+ * @returns {object} The selected reference entry or one picked at random
+ */
+function select(index = -1) {
+  if (index > -1) {
+    return userRoles[index]
+  }
+
+  return selectRandomEntry(userRoles)
+}
+
 module.exports = {
   add,
-  defaults
+  defaults,
+  select
 }


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/115

In [Seed missing digitise users](https://github.com/DEFRA/water-abstraction-system/pull/2435), we added some test users to cover two permission sets we had missed.

However, we did a 'Doh!' and missed actually calling it when running the unit tests as part of the test DB setup. 🤦

Now that we have user role records, we should also review our unit tests and update them to select the existing records rather than adding new ones.

This change applies the fix and updates the tests.