### PR TITLE
Determine relevant lic vers where start date same

### DIFF
--- a/app/services/return-versions/setup/fetch-relevant-licence-version.service.js
+++ b/app/services/return-versions/setup/fetch-relevant-licence-version.service.js
@@ -2,7 +2,7 @@
 
 /**
  * Fetches the relevant licence version to extract data from for the start date selected by the user
- * @module FetchRelevantLicenceVersionIdService
+ * @module FetchRelevantLicenceVersionService
  */
 
 const LicenceVersionModel = require('../../../models/licence-version.model.js')
@@ -24,9 +24,17 @@ const LicenceVersionModel = require('../../../models/licence-version.model.js')
  * Else the first licence version with an end date equal to or greater than our start date is the version that will be
  * used.
  *
+ * > Check out `_manageSameStartDate()` for the exception to this!
+ *
  * This also means we can support someone entering a historic return version prior to when the first licence version
  * starts (possible, because many licences have a start date before their first licence version's start date). We just
  * take our data from that first licence version.
+ *
+ * ## The same start date problem
+ *
+ *
+ *
+ * > We're demonstrating one that is superseded and one that current. But both could be superseded with end dates
  *
  * @param {string} licenceId - The UUID of the licence we're creating a return version for
  * @param {Date} startDate - The start date the user has selected for the new return version
@@ -34,15 +42,93 @@ const LicenceVersionModel = require('../../../models/licence-version.model.js')
  * @returns {Promise<module:LicenceVersionModel>} the relevant licence version
  */
 async function go(licenceId, startDate) {
+  const licenceVersions = await _fetch(licenceId, startDate)
+
+  if (licenceVersions.length === 0) {
+    return null
+  }
+
+  if (licenceVersions.length === 1) {
+    return licenceVersions[0]
+  }
+
+  return _manageSameStartDate(licenceVersions)
+}
+
+async function _fetch(licenceId, startDate) {
   return LicenceVersionModel.query()
     .select(['endDate', 'id', 'startDate'])
     .where('licenceId', licenceId)
     .where((builder) => {
       builder.whereNull('licenceVersions.endDate').orWhere('licenceVersions.endDate', '>=', startDate)
     })
-    .orderBy('endDate', 'ASC')
-    .limit(1)
-    .first()
+    .orderBy([
+      { column: 'endDate', order: 'asc' },
+      { column: 'issue', order: 'desc' },
+      { column: 'increment', order: 'desc' }
+    ])
+}
+
+/**
+ * The same start date problem
+ *
+ * We have encountered licences that have two licence versions with the same start date. When this is the case, the
+ * earliest would have been setup wrong in NALD, so the users have created a second that starts the same day.
+ *
+ * Because we don't know where they will come in the history, or just how many times a user my have tried to correct
+ * their error (!!) we fetch all licence versions.
+ *
+ * We grab the start date of the first record and then test if there are any others. If there aren't, great! We can just
+ * return that first result.
+ *
+ * If there are more than one with the same start date, we have to dig a bit deeper. :-(
+ *
+ * ### Both superseded
+ *
+ * |Issue|Increment|Start date|End data  |Status    |
+ * |-----|---------|----------|----------|----------|
+ * |100  |0        |2025-04-01|2025-04-01|superseded|
+ * |101  |0        |2025-04-01|2025-06-30|superseded|
+ *
+ * In this example, both licence versions are superseded, so both have an end date. If the selected start date is
+ * _after_ 2024-04-01, then issue 100 would not be in the results, and we'll use issue 101 as the first record.
+ *
+ * However, if the selected start date is 2025-04-01, both would be returned because the filter is 'end date >= selected
+ * start date'.
+ *
+ * Our results are sorted by end date in ascending order, which means issue 100 will be the first result. But as it is
+ * replaced by issue 101, that's the 'relevant' licence version we want to return. In this case, we return the last
+ * record of those with the same date.
+ *
+ * ### One current, one superseded
+ *
+ * |Issue|Increment|Start date|End data  |Status    |
+ * |-----|---------|----------|----------|----------|
+ * |100  |0        |2025-04-01|2025-04-01|superseded|
+ * |101  |0        |2025-04-01|          |current   |
+ *
+ * In this example, we have a current licence version and a superseded one. Again, if the selected start date is _after_
+ * 2024-04-01, then * issue 100 would not be in the results, and we'll take issue 101 as the first record.
+ *
+ * However, if the selected start date is 2025-04-01, both would be returned.
+ *
+ * When you sort in ascending order, null values come last. So again, the record we want to return is now the last one,
+ * not the first.
+ *
+ * @private
+ */
+function _manageSameStartDate(licenceVersions) {
+  const firstStartDateTime = licenceVersions[0].startDate.getTime()
+
+  const withSameStartDate = licenceVersions.filter((licenceVersion) => {
+    return licenceVersion.startDate.getTime() === firstStartDateTime
+  })
+
+  if (withSameStartDate.length === 1) {
+    return licenceVersions[0]
+  }
+
+  return withSameStartDate[withSameStartDate.length - 1]
 }
 
 module.exports = {

--- a/test/services/return-versions/setup/fetch-relevant-licence-version.service.test.js
+++ b/test/services/return-versions/setup/fetch-relevant-licence-version.service.test.js
@@ -29,16 +29,32 @@ describe('Return Versions - Setup - Fetch Relevant Licence Version service', () 
       status: 'superseded'
     })
 
-    licenceVersions.secondLicenceVersion = await LicenceVersionHelper.add({
+    licenceVersions.oopsSecondLicenceVersion = await LicenceVersionHelper.add({
       endDate: new Date('2019-05-12'),
       issue: 101,
+      licenceId,
+      startDate: new Date('2019-05-12'),
+      status: 'superseded'
+    })
+
+    licenceVersions.secondLicenceVersion = await LicenceVersionHelper.add({
+      endDate: new Date('2019-05-12'),
+      issue: 102,
       licenceId,
       startDate: new Date('2012-08-13'),
       status: 'superseded'
     })
 
+    licenceVersions.oopsCurrentLicenceVersion = await LicenceVersionHelper.add({
+      endDate: new Date('2019-05-13'),
+      issue: 103,
+      licenceId,
+      startDate: new Date('2019-05-13'),
+      status: 'superseded'
+    })
+
     licenceVersions.currentLicence = await LicenceVersionHelper.add({
-      issue: 102,
+      issue: 104,
       licenceId,
       startDate: new Date('2019-05-13'),
       status: 'current'
@@ -93,15 +109,54 @@ describe('Return Versions - Setup - Fetch Relevant Licence Version service', () 
     })
   })
 
+  // NOTE: WATER-5251 was an issue with a licence that had two licence versions. The first covered a single day: 1 April
+  // 2025 and originally had the wrong purposes linked to it. Rather than delete it, the users created a second licence
+  // version that also started on 1 April 2025 (hence the previous only covering a single day). The issue exposed that
+  // when this is the case, we select the earlier (single day) rather than later licence version. We fixed it, but we
+  // these tests to ensure we handle these exceptions.
+  describe('when the selected start date is the same as the start date of multiple licence versions', () => {
+    describe('and both have end dates (they are both superseded)', () => {
+      before(() => {
+        startDate = new Date('2019-05-12')
+      })
+
+      it.only('returns the licence version with the latest end date', async () => {
+        const result = await FetchRelevantLicenceVersionService.go(licenceId, startDate)
+
+        expect(result).to.equal({
+          endDate: licenceVersions.secondLicenceVersion.endDate,
+          id: licenceVersions.secondLicenceVersion.id,
+          startDate: licenceVersions.secondLicenceVersion.startDate
+        })
+      })
+    })
+
+    describe('and one has an end date and the other is the "current" licence version', () => {
+      before(() => {
+        startDate = new Date('2019-05-13')
+      })
+
+      it('returns the "current" licence version', async () => {
+        const result = await FetchRelevantLicenceVersionService.go(licenceId, startDate)
+
+        expect(result).to.equal({
+          endDate: licenceVersions.currentLicence.endDate,
+          id: licenceVersions.currentLicence.id,
+          startDate: licenceVersions.currentLicence.startDate
+        })
+      })
+    })
+  })
+
   describe('when the licence ID is unknown', () => {
     before(() => {
       startDate = new Date('2024-04-01')
     })
 
-    it('returns "undefined"', async () => {
+    it('returns "null"', async () => {
       const result = await FetchRelevantLicenceVersionService.go('1d7f6806-43b1-4cce-9ab1-adb28448aef2', startDate)
 
-      expect(result).to.be.undefined()
+      expect(result).to.be.null()
     })
   })
 })

--- a/test/services/return-versions/setup/fetch-relevant-licence-version.service.test.js
+++ b/test/services/return-versions/setup/fetch-relevant-licence-version.service.test.js
@@ -120,7 +120,7 @@ describe('Return Versions - Setup - Fetch Relevant Licence Version service', () 
         startDate = new Date('2019-05-12')
       })
 
-      it.only('returns the licence version with the latest end date', async () => {
+      it('returns the licence version with the latest end date', async () => {
         const result = await FetchRelevantLicenceVersionService.go(licenceId, startDate)
 
         expect(result).to.equal({


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5251

The issue raised was a licence that had two licence versions with the same start date. The first covered a single day: 1 April 2025, and originally had the wrong purposes linked to it.

Rather than delete it, the users created a second licence version that also started on 1 April 2025 (hence the previous only covered a single day).

When setting up the return version, the user selected 1 April 2025 as the start date to use. This resulted in `FetchRelevantLicenceVersionService` returning the earlier (single-day) licence version rather than the later one. This is because the results are ordered by `end date DESC`, and before this change, the service returned the first result.

> If they had selected 2 April 2025, we wouldn't have an issue! 😩

The following examples provide further detail on the problem.

**Both superseded**

|Issue|Increment|Start date|End data  |Status    |
|-----|---------|----------|----------|----------|
|100  |0        |2025-04-01|2025-04-01|superseded|
|101  |0        |2025-04-01|2025-06-30|superseded|

In this example, both licence versions are superseded, so both have an end date. If the selected start date is _after_ 2024-04-01, then issue 100 would not be in the results, and we'll use issue 101 as the first record.

However, if the selected start date is 2025-04-01, both would be returned because the filter is 'end date >= selected start date'.

Our results are sorted by end date in ascending order, which means issue 100 will be the first result. But as it is replaced by issue 101, that's the 'relevant' licence version we want to return. In this case, we return the last record of those with the same date.

**One current, one superseded**

|Issue|Increment|Start date|End data  |Status    |
|-----|---------|----------|----------|----------|
|100  |0        |2025-04-01|2025-04-01|superseded|
|101  |0        |2025-04-01|          |current   |

In this example, we have a current licence version and a superseded one. Again, if the selected start date is _after_ 2024-04-01, then issue 100 would not be in the results, and we'll take issue 101 as the first record.

However, if the selected start date is 2025-04-01, both would be returned.

When you sort in ascending order, null values come last. So again, the record we want to return is now the last one, not the first.

---

This change updates the logic in the fetch to return all records (doing this all in SQL resulted in a gnarly script!) and then performs extra processing if we are dealing with a 'same start date' problem.