### PR TITLE
Update create notifications test

### DIFF
--- a/test/services/notices/setup/create-notifications.service.test.js
+++ b/test/services/notices/setup/create-notifications.service.test.js
@@ -26,27 +26,30 @@ describe('Notices - Setup - Create notification service', () => {
     })
 
     eventId = event.id
+
+    notifications = [
+      { eventId, createdAt: timestampForPostgres() },
+      { eventId, createdAt: timestampForPostgres() }
+    ]
   })
 
-  describe('when inserting a single notification', () => {
-    beforeEach(async () => {
-      notifications = [{ eventId, createdAt: timestampForPostgres() }]
+  it('should return the saved notifications', async () => {
+    const result = await CreateNotificationsService.go(notifications)
+
+    const createdNotifications = await NotificationModel.query().where({
+      event_id: eventId
     })
 
-    it('should create a single notification (and only set the required values)', async () => {
-      const result = await CreateNotificationsService.go(notifications)
-
-      const createdResult = await NotificationModel.query().findById(result[0].id)
-
-      expect(createdResult).equal({
-        createdAt: createdResult.createdAt,
+    expect(createdNotifications).equal([
+      {
+        createdAt: createdNotifications[0].createdAt,
         eventId,
         id: result[0].id,
         licenceMonitoringStationId: null,
         licences: null,
-        notifyError: null,
         messageRef: null,
         messageType: null,
+        notifyError: null,
         notifyId: null,
         notifyStatus: null,
         pdf: null,
@@ -56,33 +59,26 @@ describe('Notices - Setup - Create notification service', () => {
         returnLogIds: null,
         status: null,
         templateId: null
-      })
-    })
-  })
-
-  describe('when inserting multiple notifications', () => {
-    beforeEach(() => {
-      notifications = [
-        { eventId, createdAt: timestampForPostgres() },
-        { eventId, createdAt: timestampForPostgres() }
-      ]
-    })
-
-    it('should return the saved notifications', async () => {
-      const result = await CreateNotificationsService.go(notifications)
-
-      expect(result).equal([
-        {
-          createdAt: result[0].createdAt,
-          eventId,
-          id: result[0].id
-        },
-        {
-          createdAt: result[1].createdAt,
-          eventId,
-          id: result[1].id
-        }
-      ])
-    })
+      },
+      {
+        createdAt: createdNotifications[1].createdAt,
+        eventId,
+        id: result[1].id,
+        licenceMonitoringStationId: null,
+        licences: null,
+        messageRef: null,
+        messageType: null,
+        notifyError: null,
+        notifyId: null,
+        notifyStatus: null,
+        pdf: null,
+        personalisation: null,
+        plaintext: null,
+        recipient: null,
+        returnLogIds: null,
+        status: null,
+        templateId: null
+      }
+    ])
   })
 })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5280

We currently create notifications after sending them to Notify. This allowed us to save the notification and the Notify response in one query.

We are changing this approach after seeing some delays in showing a notification on the notice page.

We want to create the notification and mark them as 'pending', and then update the notification with the Notify response.

The update logic will be implemented in another change.

This change updates the create notifications tests to only test multiple inserts (this was raised when working on https://github.com/DEFRA/water-abstraction-system/pull/2451).