### PR TITLE
Fix typo in link on manage page

### DIFF
--- a/app/views/manage/manage.njk
+++ b/app/views/manage/manage.njk
@@ -9,7 +9,7 @@
     <ul class="govuk-list">
       {% if viewReports.links.notices %}<li><a class="govuk-link" href="/system/notices">Notices</a></li>{% endif %}
       {% if viewReports.links.returnsCycles %}<li><a class="govuk-link" href="/returns-reports">Returns cycles</a></li>{% endif %}
-      {% if viewReports.links.digitise %}<li><a class="govuk-link" href="/digitise/report'">Digitise!</a></li>{% endif %}
+      {% if viewReports.links.digitise %}<li><a class="govuk-link" href="/digitise/report">Digitise!</a></li>{% endif %}
       {% if viewReports.links.kpis %}<li><a class="govuk-link" href="/reporting/kpi-reporting">Key performance indicators</a></li>{% endif %}
     </ul>
   {% endif %}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5206

When moving the `/manage` page, over from `water-abstraction-ui` we accidentally added a rogue apostrophe into a link, this change removes it.