### PR TITLE
Updated sending notification to save / fetch and update

### DIFF
--- a/app/presenters/notices/setup/return-forms-notification.presenter.js
+++ b/app/presenters/notices/setup/return-forms-notification.presenter.js
@@ -22,7 +22,7 @@
  */
 function go(returnForm, pageData, licenceRef, eventId) {
   return {
-    content: returnForm,
+    pdf: returnForm,
     eventId,
     licences: [licenceRef],
     messageRef: 'pdf.return_form',

--- a/app/services/notices/setup/create-notifications.service.js
+++ b/app/services/notices/setup/create-notifications.service.js
@@ -14,11 +14,11 @@ const NotificationModel = require('../../../../app/models/notification.model.js'
  * https://www.postgresql.org/docs/current/postgres-fdw.html#POSTGRES-FDW-OPTIONS-REMOTE-EXECUTION. The calling
  * service will handle the batch process.
  *
- * > By using the batch insert we need the upstream service to set the 'createdAt' field.
+ * > By using the batch insert, we need the upstream service to set the 'createdAt' field.
  *
  * @param {object} notifications
  *
- * @returns {object} - the created notifications
+ * @returns {Promise<object>} - the created notifications
  */
 async function go(notifications) {
   return NotificationModel.query().insert(notifications)

--- a/app/services/notices/setup/submit-check.service.js
+++ b/app/services/notices/setup/submit-check.service.js
@@ -51,6 +51,8 @@ async function go(sessionId, auth) {
  * Return the saved notifications with the notification id (this will be used to update the status of the notification
  * during the batch process).
  *
+ * @returns {Promise<object>} an array of saved notifications
+ *
  * @private
  */
 async function _notifications(sessionCopy, recipients, eventId) {

--- a/app/services/notices/setup/submit-check.service.js
+++ b/app/services/notices/setup/submit-check.service.js
@@ -8,7 +8,9 @@
 const BatchNotificationsService = require('./batch-notifications.service.js')
 const CreateNoticePresenter = require('../../../presenters/notices/setup/create-notice.presenter.js')
 const CreateNoticeService = require('./create-notice.service.js')
+const CreateNotificationsService = require('./create-notifications.service.js')
 const DetermineNotificationsService = require('./determine-notifications.service.js')
+const FetchNotificationsService = require('./fetch-notifications.service.js')
 const FetchRecipientsService = require('./fetch-recipients.service.js')
 const SessionModel = require('../../../models/session.model.js')
 const { currentTimeInNanoseconds, calculateAndLogTimeTaken } = require('../../../lib/general.lib.js')
@@ -34,11 +36,29 @@ async function go(sessionId, auth) {
 
   const notice = await _notice(sessionCopy, recipients, auth)
 
-  const notifications = await DetermineNotificationsService.go(sessionCopy, recipients, notice.id)
+  const notifications = await _notifications(sessionCopy, recipients, notice.id)
 
   _processNotifications(notifications, notice, sessionCopy.referenceCode)
 
   return notice.id
+}
+
+/**
+ * Determine the notifications to send for the recipients.
+ *
+ * Save the notifications as 'pending' (we are about to start batching).
+ *
+ * Return the saved notifications with the notification id (this will be used to update the status of the notification
+ * during the batch process).
+ *
+ * @private
+ */
+async function _notifications(sessionCopy, recipients, eventId) {
+  const notifications = await DetermineNotificationsService.go(sessionCopy, recipients, eventId)
+
+  await CreateNotificationsService.go(notifications)
+
+  return FetchNotificationsService.go(eventId)
 }
 
 async function _notice(session, recipients, auth) {

--- a/app/services/notices/setup/submit-check.service.js
+++ b/app/services/notices/setup/submit-check.service.js
@@ -51,8 +51,6 @@ async function go(sessionId, auth) {
  * Return the saved notifications with the notification id (this will be used to update the status of the notification
  * during the batch process).
  *
- * @returns {Promise<object>} an array of saved notifications
- *
  * @private
  */
 async function _notifications(sessionCopy, recipients, eventId) {

--- a/test/presenters/notices/setup/return-forms-notification.presenter.test.js
+++ b/test/presenters/notices/setup/return-forms-notification.presenter.test.js
@@ -66,7 +66,7 @@ describe('Notices - Setup - Return Forms Notification Presenter', () => {
       const result = ReturnFormsNotificationPresenter.go(returnForm, pageData, licenceRef, eventId)
 
       expect(result).to.equal({
-        content: returnForm,
+        pdf: returnForm,
         eventId,
         licences: [licenceRef],
         messageRef: 'pdf.return_form',

--- a/test/services/notices/setup/determine-return-forms.service.test.js
+++ b/test/services/notices/setup/determine-return-forms.service.test.js
@@ -73,7 +73,7 @@ describe('Notices - Setup - Determine Return Forms Service', () => {
 
         expect(result).to.equal([
           {
-            content: buffer,
+            pdf: buffer,
             eventId,
             licences: [licenceRef],
             messageRef: 'pdf.return_form',
@@ -102,7 +102,7 @@ describe('Notices - Setup - Determine Return Forms Service', () => {
             returnLogIds: [dueReturnLog.returnId]
           },
           {
-            content: buffer,
+            pdf: buffer,
             eventId,
             licences: [licenceRef],
             messageRef: 'pdf.return_form',
@@ -144,7 +144,7 @@ describe('Notices - Setup - Determine Return Forms Service', () => {
 
         expect(result).to.equal([
           {
-            content: buffer,
+            pdf: buffer,
             eventId,
             licences: [licenceRef],
             messageRef: 'pdf.return_form',
@@ -173,7 +173,7 @@ describe('Notices - Setup - Determine Return Forms Service', () => {
             returnLogIds: [dueReturnLog.returnId]
           },
           {
-            content: buffer,
+            pdf: buffer,
             eventId,
             licences: [licenceRef],
             messageRef: 'pdf.return_form',
@@ -202,7 +202,7 @@ describe('Notices - Setup - Determine Return Forms Service', () => {
             returnLogIds: [dueReturnLog.returnId]
           },
           {
-            content: buffer,
+            pdf: buffer,
             eventId,
             licences: [licenceRef],
             messageRef: 'pdf.return_form',
@@ -231,7 +231,7 @@ describe('Notices - Setup - Determine Return Forms Service', () => {
             returnLogIds: [additionalDueReturn.returnId]
           },
           {
-            content: buffer,
+            pdf: buffer,
             eventId,
             licences: [licenceRef],
             messageRef: 'pdf.return_form',

--- a/test/services/notices/setup/submit-check.service.test.js
+++ b/test/services/notices/setup/submit-check.service.test.js
@@ -10,22 +10,21 @@ const { expect } = Code
 
 // Test helpers
 const EventModel = require('../../../../app/models/event.model.js')
+const NotificationModel = require('../../../../app/models/notification.model.js')
 const RecipientsFixture = require('../../../fixtures/recipients.fixtures.js')
 const SessionHelper = require('../../../support/helpers/session.helper.js')
+const { generateReferenceCode } = require('../../../support/helpers/notification.helper.js')
 
 // Things we need to stub
 const BatchNotificationsService = require('../../../../app/services/notices/setup/batch-notifications.service.js')
-const DetermineNotificationsService = require('../../../../app/services/notices/setup/determine-notifications.service.js')
 const DetermineRecipientsService = require('../../../../app/services/notices/setup/determine-recipients.service.js')
 const FetchReturnsRecipientsService = require('../../../../app/services/notices/setup/fetch-returns-recipients.service.js')
-const { generateReferenceCode } = require('../../../support/helpers/notification.helper.js')
 
 // Thing under test
 const SubmitCheckService = require('../../../../app/services/notices/setup/submit-check.service.js')
 
 describe('Notices - Setup - Submit Check service', () => {
   let auth
-  let mockNotifications
   let notifierStub
   let referenceCode
   let session
@@ -40,8 +39,6 @@ describe('Notices - Setup - Submit Check service', () => {
       }
     }
 
-    mockNotifications = [{ text: 'mock notification' }]
-
     const recipients = RecipientsFixture.recipients()
 
     testRecipients = [recipients.primaryUser]
@@ -50,7 +47,7 @@ describe('Notices - Setup - Submit Check service', () => {
 
     session = await SessionHelper.add({
       data: {
-        journey: 'invitations',
+        journey: 'standard',
         referenceCode,
         returnsPeriod: 'quarterFour',
         determinedReturnsPeriod: {
@@ -59,11 +56,11 @@ describe('Notices - Setup - Submit Check service', () => {
           endDate: '2023-03-31',
           summer: 'false',
           startDate: '2022-04-01'
-        }
+        },
+        noticeType: 'invitations'
       }
     })
 
-    Sinon.stub(DetermineNotificationsService, 'go').resolves(mockNotifications)
     Sinon.stub(DetermineRecipientsService, 'go').returns(testRecipients)
     Sinon.stub(FetchReturnsRecipientsService, 'go').resolves(testRecipients)
 
@@ -81,29 +78,40 @@ describe('Notices - Setup - Submit Check service', () => {
       Sinon.stub(BatchNotificationsService, 'go').resolves({ sent: 1, error: 0 })
     })
 
-    it('should determine notifications', async () => {
-      const result = await SubmitCheckService.go(session.id, auth)
-
-      const args = DetermineNotificationsService.go.firstCall.args
-
-      expect(args[0]).to.equal(session)
-      expect(args[1]).to.equal(testRecipients)
-      expect(args[2]).to.equal(result)
-    })
-
     it('should batch notifications', async () => {
       const result = await SubmitCheckService.go(session.id, auth)
 
+      const notifications = await NotificationModel.query().where({
+        eventId: result
+      })
+
       const args = BatchNotificationsService.go.firstCall.args
 
-      expect(args[0]).to.equal(mockNotifications)
+      expect(args[0]).to.equal([
+        {
+          id: notifications[0].id,
+          messageRef: 'returns_invitation_primary_user_email',
+          messageType: 'email',
+          pdf: null,
+          personalisation: {
+            periodEndDate: '31 March 2023',
+            returnDueDate: '28 April 2025',
+            periodStartDate: '1 April 2022'
+          },
+          recipient: 'primary.user@important.com',
+          templateId: '2fa7fc83-4df1-4f52-bccf-ff0faeb12b6f'
+        }
+      ])
+
       expect(args[1]).to.equal(result)
+
+      expect(args[2]).to.equal(referenceCode)
     })
 
     it('correctly returns the event id', async () => {
       const result = await SubmitCheckService.go(session.id, auth)
 
-      const event = await EventModel.query().where('reference_code', referenceCode).first()
+      const event = await EventModel.query().findById(result)
 
       expect(result).to.equal(event.id)
     })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5280

Currently, when a user clicks Confirm on the check-recipients page, as part of sending a notice, we follow this process.

- Convert the notice setup and recipient data into package to be sent to Notify
- We send the package to Notify
- We insert the result and the data into the DB as a ‘notification’.

Because there may be many notifications to send, or in the case of return forms, each can take some time to process, we do this behind the scenes to avoid users seeing any spinning wheels.

So, they will be immediately taken to the ‘Confirmation’ page, which includes a link to view the notice.

If the user is keen, and the process is going to take a moment to complete, when they view the notice and its notifications, the page will be empty. If they were to wait a moment and refresh, then the records would appear. However, we do not consider this a reasonable workaround.

This change updates the notification flow to save a notification, then fetch the notifications and then update the notifications.

We create and fetch the notifications before batching and pass the notifications into the batch process (they will now have a notification id).

The batch process iterates over the notifications and updates (upserts) the saved notification record with Notifies responses.