### PR TITLE
Use new standard for abstraction periods

### DIFF
--- a/app/presenters/return-versions/setup/check/returns-requirements.presenter.js
+++ b/app/presenters/return-versions/setup/check/returns-requirements.presenter.js
@@ -34,14 +34,10 @@ function go(requirements, points, journey) {
 }
 
 function _abstractionPeriod(abstractionPeriod) {
-  const {
-    'abstraction-period-start-day': startDay,
-    'abstraction-period-start-month': startMonth,
-    'abstraction-period-end-day': endDay,
-    'abstraction-period-end-month': endMonth
-  } = abstractionPeriod
-  const startDate = formatAbstractionDate(startDay, startMonth)
-  const endDate = formatAbstractionDate(endDay, endMonth)
+  const { abstractionPeriodStartDay, abstractionPeriodStartMonth, abstractionPeriodEndDay, abstractionPeriodEndMonth } =
+    abstractionPeriod
+  const startDate = formatAbstractionDate(abstractionPeriodStartDay, abstractionPeriodStartMonth)
+  const endDate = formatAbstractionDate(abstractionPeriodEndDay, abstractionPeriodEndMonth)
 
   return `From ${startDate} to ${endDate}`
 }

--- a/app/services/return-versions/setup/existing/generate-from-existing-requirements.service.js
+++ b/app/services/return-versions/setup/existing/generate-from-existing-requirements.service.js
@@ -111,10 +111,10 @@ function _transformForSetup(returnVersion) {
       returnsCycle: summer ? 'summer' : 'winter-and-all-year',
       siteDescription: _siteDescription(siteDescription, points),
       abstractionPeriod: {
-        'abstraction-period-end-day': abstractionPeriodEndDay,
-        'abstraction-period-end-month': abstractionPeriodEndMonth,
-        'abstraction-period-start-day': abstractionPeriodStartDay,
-        'abstraction-period-start-month': abstractionPeriodStartMonth
+        abstractionPeriodEndDay,
+        abstractionPeriodEndMonth,
+        abstractionPeriodStartDay,
+        abstractionPeriodStartMonth
       },
       frequencyReported: reportingFrequency,
       frequencyCollected: collectionFrequency,

--- a/app/services/return-versions/setup/method/generate-from-abstraction-data.service.js
+++ b/app/services/return-versions/setup/method/generate-from-abstraction-data.service.js
@@ -235,10 +235,10 @@ function _transformForSetup(licence) {
 
   return licenceVersionPurposes.map((licenceVersionPurpose) => {
     const {
-      abstractionPeriodEndDay: endDay,
-      abstractionPeriodEndMonth: endMonth,
-      abstractionPeriodStartDay: startDay,
-      abstractionPeriodStartMonth: startMonth,
+      abstractionPeriodEndDay,
+      abstractionPeriodEndMonth,
+      abstractionPeriodStartDay,
+      abstractionPeriodStartMonth,
       points,
       purpose
     } = licenceVersionPurpose
@@ -246,13 +246,13 @@ function _transformForSetup(licence) {
     return {
       points: _points(points),
       purposes: [{ alias: '', description: purpose.description, id: purpose.id }],
-      returnsCycle: _returnsCycle(startMonth, endMonth),
+      returnsCycle: _returnsCycle(abstractionPeriodStartMonth, abstractionPeriodEndMonth),
       siteDescription: _siteDescription(points),
       abstractionPeriod: {
-        'abstraction-period-end-day': endDay,
-        'abstraction-period-end-month': endMonth,
-        'abstraction-period-start-day': startDay,
-        'abstraction-period-start-month': startMonth
+        abstractionPeriodStartDay,
+        abstractionPeriodStartMonth,
+        abstractionPeriodEndDay,
+        abstractionPeriodEndMonth
       },
       frequencyReported: _frequencyReported(licence, licenceVersionPurpose),
       frequencyCollected: _frequencyCollected(licence, licenceVersionPurpose),

--- a/test/presenters/return-versions/setup/abstraction-period.presenter.test.js
+++ b/test/presenters/return-versions/setup/abstraction-period.presenter.test.js
@@ -57,10 +57,10 @@ describe('Return Versions Setup - Abstraction Period presenter', () => {
     describe('when the user has previously submitted an abstraction period', () => {
       beforeEach(() => {
         session.requirements[0].abstractionPeriod = {
-          'abstraction-period-start-day': '07',
-          'abstraction-period-start-month': '12',
-          'abstraction-period-end-day': '22',
-          'abstraction-period-end-month': '07'
+          abstractionPeriodStartDay: '07',
+          abstractionPeriodStartMonth: '12',
+          abstractionPeriodEndDay: '22',
+          abstractionPeriodEndMonth: '07'
         }
       })
 
@@ -68,10 +68,10 @@ describe('Return Versions Setup - Abstraction Period presenter', () => {
         const result = AbstractionPeriodPresenter.go(session, requirementIndex)
 
         expect(result.abstractionPeriod).to.equal({
-          'abstraction-period-start-day': '07',
-          'abstraction-period-start-month': '12',
-          'abstraction-period-end-day': '22',
-          'abstraction-period-end-month': '07'
+          abstractionPeriodStartDay: '07',
+          abstractionPeriodStartMonth: '12',
+          abstractionPeriodEndDay: '22',
+          abstractionPeriodEndMonth: '07'
         })
       })
     })

--- a/test/presenters/return-versions/setup/cancel.presenter.test.js
+++ b/test/presenters/return-versions/setup/cancel.presenter.test.js
@@ -33,10 +33,10 @@ describe('Return Versions Setup - Cancel presenter', () => {
           returnsCycle: 'winter-and-all-year',
           siteDescription: 'Bore hole in rear field',
           abstractionPeriod: {
-            'abstraction-period-end-day': '31',
-            'abstraction-period-end-month': '10',
-            'abstraction-period-start-day': '1',
-            'abstraction-period-start-month': '4'
+            abstractionPeriodEndDay: '31',
+            abstractionPeriodEndMonth: '10',
+            abstractionPeriodStartDay: '1',
+            abstractionPeriodStartMonth: '4'
           },
           frequencyReported: 'month',
           frequencyCollected: 'month',

--- a/test/presenters/return-versions/setup/check/returns-requirements.presenter.test.js
+++ b/test/presenters/return-versions/setup/check/returns-requirements.presenter.test.js
@@ -218,10 +218,10 @@ function _point() {
 function _requirement() {
   return {
     abstractionPeriod: {
-      'abstraction-period-end-day': '01',
-      'abstraction-period-end-month': '03',
-      'abstraction-period-start-day': '01',
-      'abstraction-period-start-month': '06'
+      abstractionPeriodEndDay: '01',
+      abstractionPeriodEndMonth: '03',
+      abstractionPeriodStartDay: '01',
+      abstractionPeriodStartMonth: '06'
     },
     agreementsExceptions: ['gravity-fill'],
     frequencyCollected: 'day',

--- a/test/presenters/return-versions/setup/remove.presenter.test.js
+++ b/test/presenters/return-versions/setup/remove.presenter.test.js
@@ -35,10 +35,10 @@ describe('Return Versions Setup - Remove presenter', () => {
           returnsCycle: 'winter-and-all-year',
           siteDescription: 'Bore hole in rear field',
           abstractionPeriod: {
-            'abstraction-period-end-day': '31',
-            'abstraction-period-end-month': '10',
-            'abstraction-period-start-day': '1',
-            'abstraction-period-start-month': '4'
+            abstractionPeriodEndDay: '31',
+            abstractionPeriodEndMonth: '10',
+            abstractionPeriodStartDay: '1',
+            abstractionPeriodStartMonth: '4'
           },
           frequencyReported: 'month',
           frequencyCollected: 'month',
@@ -90,10 +90,10 @@ describe('Return Versions Setup - Remove presenter', () => {
           returnsCycle: 'summer',
           siteDescription: 'This is a valid return requirements description',
           abstractionPeriod: {
-            'abstraction-period-end-day': '12',
-            'abstraction-period-end-month': '09',
-            'abstraction-period-start-day': '12',
-            'abstraction-period-start-month': '07'
+            abstractionPeriodEndDay: '12',
+            abstractionPeriodEndMonth: '09',
+            abstractionPeriodStartDay: '12',
+            abstractionPeriodStartMonth: '07'
           },
           frequencyReported: 'month',
           frequencyCollected: 'week',

--- a/test/services/return-versions/setup/cancel.service.test.js
+++ b/test/services/return-versions/setup/cancel.service.test.js
@@ -38,10 +38,10 @@ describe('Return Versions Setup - Cancel service', () => {
             returnsCycle: 'winter-and-all-year',
             siteDescription: 'Bore hole in rear field',
             abstractionPeriod: {
-              'abstraction-period-end-day': '31',
-              'abstraction-period-end-month': '10',
-              'abstraction-period-start-day': '1',
-              'abstraction-period-start-month': '4'
+              abstractionPeriodEndDay: '31',
+              abstractionPeriodEndMonth: '10',
+              abstractionPeriodStartDay: '01',
+              abstractionPeriodStartMonth: '04'
             },
             frequencyReported: 'month',
             frequencyCollected: 'month',

--- a/test/services/return-versions/setup/check/generate-return-version-requirements.service.test.js
+++ b/test/services/return-versions/setup/check/generate-return-version-requirements.service.test.js
@@ -162,10 +162,10 @@ function _generateRequirements(purposeOneId, purposeTwoId) {
       returnsCycle: 'winter-and-all-year',
       siteDescription: 'Site Number One',
       abstractionPeriod: {
-        'abstraction-period-end-day': 31,
-        'abstraction-period-end-month': 3,
-        'abstraction-period-start-day': 1,
-        'abstraction-period-start-month': 4
+        abstractionPeriodEndDay: '31',
+        abstractionPeriodEndMonth: '3',
+        abstractionPeriodStartDay: '1',
+        abstractionPeriodStartMonth: '4'
       },
       frequencyReported: 'month',
       frequencyCollected: 'week',
@@ -190,10 +190,10 @@ function _generateRequirements(purposeOneId, purposeTwoId) {
     // NOTE: When abstraction periods are manually entered they are saved in the session as strings rather than integers
     // The ORM isn't fussy and correctly converts the strings to integers when writing the data to the database
     abstractionPeriod: {
-      'abstraction-period-end-day': '31',
-      'abstraction-period-end-month': '8',
-      'abstraction-period-start-day': '1',
-      'abstraction-period-start-month': '6'
+      abstractionPeriodEndDay: '31',
+      abstractionPeriodEndMonth: '8',
+      abstractionPeriodStartDay: '1',
+      abstractionPeriodStartMonth: '6'
     },
     frequencyReported: 'day',
     frequencyCollected: 'day',

--- a/test/services/return-versions/setup/existing/generate-from-existing-requirements.service.test.js
+++ b/test/services/return-versions/setup/existing/generate-from-existing-requirements.service.test.js
@@ -75,10 +75,10 @@ describe('Return Versions Setup - Generate From Existing Requirements service', 
             returnsCycle: 'winter-and-all-year',
             siteDescription: 'FIRST BOREHOLE AT AVALON',
             abstractionPeriod: {
-              'abstraction-period-end-day': 31,
-              'abstraction-period-end-month': 3,
-              'abstraction-period-start-day': 1,
-              'abstraction-period-start-month': 4
+              abstractionPeriodEndDay: 31,
+              abstractionPeriodEndMonth: 3,
+              abstractionPeriodStartDay: 1,
+              abstractionPeriodStartMonth: 4
             },
             frequencyReported: 'week',
             frequencyCollected: 'week',
@@ -96,10 +96,10 @@ describe('Return Versions Setup - Generate From Existing Requirements service', 
             returnsCycle: 'summer',
             siteDescription: 'SECOND BOREHOLE AT AVALON',
             abstractionPeriod: {
-              'abstraction-period-end-day': 31,
-              'abstraction-period-end-month': 3,
-              'abstraction-period-start-day': 1,
-              'abstraction-period-start-month': 4
+              abstractionPeriodEndDay: 31,
+              abstractionPeriodEndMonth: 3,
+              abstractionPeriodStartDay: 1,
+              abstractionPeriodStartMonth: 4
             },
             frequencyReported: 'month',
             frequencyCollected: 'week',
@@ -138,10 +138,10 @@ describe('Return Versions Setup - Generate From Existing Requirements service', 
             returnsCycle: 'winter-and-all-year',
             siteDescription: 'FIRST BOREHOLE AT AVALON',
             abstractionPeriod: {
-              'abstraction-period-end-day': 31,
-              'abstraction-period-end-month': 3,
-              'abstraction-period-start-day': 1,
-              'abstraction-period-start-month': 4
+              abstractionPeriodEndDay: 31,
+              abstractionPeriodEndMonth: 3,
+              abstractionPeriodStartDay: 1,
+              abstractionPeriodStartMonth: 4
             },
             frequencyReported: 'week',
             frequencyCollected: 'week',
@@ -159,10 +159,10 @@ describe('Return Versions Setup - Generate From Existing Requirements service', 
             returnsCycle: 'summer',
             siteDescription: 'WELL AT WELLINGTON',
             abstractionPeriod: {
-              'abstraction-period-end-day': 31,
-              'abstraction-period-end-month': 3,
-              'abstraction-period-start-day': 1,
-              'abstraction-period-start-month': 4
+              abstractionPeriodEndDay: 31,
+              abstractionPeriodEndMonth: 3,
+              abstractionPeriodStartDay: 1,
+              abstractionPeriodStartMonth: 4
             },
             frequencyReported: 'month',
             frequencyCollected: 'week',

--- a/test/services/return-versions/setup/existing/submit-existing.service.test.js
+++ b/test/services/return-versions/setup/existing/submit-existing.service.test.js
@@ -167,10 +167,10 @@ function _transformedReturnRequirement() {
     returnsCycle: 'winter-and-all-year',
     siteDescription: 'FIRST BOREHOLE AT AVALON',
     abstractionPeriod: {
-      'abstraction-period-end-day': 31,
-      'abstraction-period-end-month': 3,
-      'abstraction-period-start-day': 1,
-      'abstraction-period-start-month': 4
+      abstractionPeriodEndDay: '31',
+      abstractionPeriodEndMonth: '3',
+      abstractionPeriodStartDay: '1',
+      abstractionPeriodStartMonth: '4'
     },
     frequencyReported: 'week',
     frequencyCollected: 'week',

--- a/test/services/return-versions/setup/method/generate-from-abstraction-data.service.test.js
+++ b/test/services/return-versions/setup/method/generate-from-abstraction-data.service.test.js
@@ -57,10 +57,10 @@ describe('Return Versions - Setup - Generate From Abstraction Data service', () 
             returnsCycle: 'summer',
             siteDescription: 'INTAKE POINT',
             abstractionPeriod: {
-              'abstraction-period-end-day': 31,
-              'abstraction-period-end-month': 10,
-              'abstraction-period-start-day': 1,
-              'abstraction-period-start-month': 4
+              abstractionPeriodEndDay: 31,
+              abstractionPeriodEndMonth: 10,
+              abstractionPeriodStartDay: 1,
+              abstractionPeriodStartMonth: 4
             },
             frequencyReported: 'day',
             frequencyCollected: 'day',
@@ -78,10 +78,10 @@ describe('Return Versions - Setup - Generate From Abstraction Data service', () 
             returnsCycle: 'winter-and-all-year',
             siteDescription: 'MAIN INTAKE',
             abstractionPeriod: {
-              'abstraction-period-end-day': 31,
-              'abstraction-period-end-month': 12,
-              'abstraction-period-start-day': 1,
-              'abstraction-period-start-month': 5
+              abstractionPeriodEndDay: 31,
+              abstractionPeriodEndMonth: 12,
+              abstractionPeriodStartDay: 1,
+              abstractionPeriodStartMonth: 5
             },
             frequencyReported: 'month',
             frequencyCollected: 'month',
@@ -99,10 +99,10 @@ describe('Return Versions - Setup - Generate From Abstraction Data service', () 
             returnsCycle: 'winter-and-all-year',
             siteDescription: 'SOUTH BOREHOLE',
             abstractionPeriod: {
-              'abstraction-period-end-day': 31,
-              'abstraction-period-end-month': 3,
-              'abstraction-period-start-day': 1,
-              'abstraction-period-start-month': 11
+              abstractionPeriodEndDay: 31,
+              abstractionPeriodEndMonth: 3,
+              abstractionPeriodStartDay: 1,
+              abstractionPeriodStartMonth: 11
             },
             frequencyReported: 'week',
             frequencyCollected: 'week',

--- a/test/services/return-versions/setup/method/submit-method.service.test.js
+++ b/test/services/return-versions/setup/method/submit-method.service.test.js
@@ -184,10 +184,10 @@ function _generatedReturnRequirements() {
       returnsCycle: 'summer',
       siteDescription: 'BOREHOLE IN FIELD',
       abstractionPeriod: {
-        'abstraction-period-end-day': 31,
-        'abstraction-period-end-month': 12,
-        'abstraction-period-start-day': 1,
-        'abstraction-period-start-month': 4
+        abstractionPeriodEndDay: '31',
+        abstractionPeriodEndMonth: '12',
+        abstractionPeriodStartDay: '1',
+        abstractionPeriodStartMonth: '4'
       },
       frequencyReported: 'month',
       frequencyCollected: 'week',

--- a/test/services/return-versions/setup/remove.service.test.js
+++ b/test/services/return-versions/setup/remove.service.test.js
@@ -48,10 +48,10 @@ describe('Return Versions Setup - Remove service', () => {
             returnsCycle: 'winter-and-all-year',
             siteDescription: 'Bore hole in rear field',
             abstractionPeriod: {
-              'abstraction-period-end-day': '31',
-              'abstraction-period-end-month': '10',
-              'abstraction-period-start-day': '1',
-              'abstraction-period-start-month': '4'
+              abstractionPeriodEndDay: '31',
+              abstractionPeriodEndMonth: '10',
+              abstractionPeriodStartDay: '01',
+              abstractionPeriodStartMonth: '04'
             },
             frequencyReported: 'month',
             frequencyCollected: 'month',

--- a/test/services/return-versions/setup/submit-cancel.service.test.js
+++ b/test/services/return-versions/setup/submit-cancel.service.test.js
@@ -46,10 +46,10 @@ describe('Return Versions Setup - Submit Cancel service', () => {
             returnsCycle: 'winter-and-all-year',
             siteDescription: 'Bore hole in rear field',
             abstractionPeriod: {
-              'abstraction-period-end-day': '31',
-              'abstraction-period-end-month': '10',
-              'abstraction-period-start-day': '1',
-              'abstraction-period-start-month': '4'
+              abstractionPeriodEndDay: '31',
+              abstractionPeriodEndMonth: '10',
+              abstractionPeriodStartDay: '01',
+              abstractionPeriodStartMonth: '04'
             },
             frequencyReported: 'month',
             frequencyCollected: 'month',

--- a/test/services/return-versions/setup/submit-remove.service.test.js
+++ b/test/services/return-versions/setup/submit-remove.service.test.js
@@ -50,10 +50,10 @@ describe('Return Versions Setup - Submit Remove service', () => {
             returnsCycle: 'winter-and-all-year',
             siteDescription: 'Bore hole in rear field',
             abstractionPeriod: {
-              'abstraction-period-end-day': '31',
-              'abstraction-period-end-month': '10',
-              'abstraction-period-start-day': '1',
-              'abstraction-period-start-month': '4'
+              abstractionPeriodEndDay: '31',
+              abstractionPeriodEndMonth: '10',
+              abstractionPeriodStartDay: '01',
+              abstractionPeriodStartMonth: '04'
             },
             frequencyReported: 'month',
             frequencyCollected: 'month',


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5200

This PR continues our tech debt of standardising how we use the layouts and views. This PR updates the abstraction period pages to use the new standard. This involves moving the back link into the presenter and updating the relevant tests.