### PR TITLE
Add status to notification presenters

### DIFF
--- a/app/presenters/notices/setup/abstraction-alert-notifications.presenter.js
+++ b/app/presenters/notices/setup/abstraction-alert-notifications.presenter.js
@@ -170,6 +170,7 @@ function _email(recipient, eventId, commonPersonalisation, alertType, restrictio
     messageType,
     personalisation: commonPersonalisation,
     recipient: recipient.email,
+    status: 'pending',
     templateId: _templateId(alertType, restrictionType, 'email')
   }
 }
@@ -219,6 +220,7 @@ function _letter(recipient, eventId, commonPersonalisation, alertType, restricti
       // NOTE: Address line 1 is always set to the recipient's name
       name: address.address_line_1
     },
+    status: 'pending',
     templateId: _templateId(alertType, restrictionType, 'letter')
   }
 }

--- a/app/presenters/notices/setup/notifications.presenter.js
+++ b/app/presenters/notices/setup/notifications.presenter.js
@@ -114,7 +114,8 @@ function _email(recipient, returnsPeriod, journey, eventId, noticeType) {
     personalisation: {
       ..._returnsPeriods(returnsPeriod, messageType)
     },
-    recipient: recipient.email
+    recipient: recipient.email,
+    status: 'pending'
   }
 }
 
@@ -169,7 +170,8 @@ function _letter(recipient, returnsPeriod, journey, eventId, noticeType) {
       ..._returnsPeriods(returnsPeriod, messageType),
       // NOTE: Address line 1 is always set to the recipient's name
       name: address.address_line_1
-    }
+    },
+    status: 'pending'
   }
 }
 

--- a/app/presenters/notices/setup/return-forms-notification.presenter.js
+++ b/app/presenters/notices/setup/return-forms-notification.presenter.js
@@ -30,7 +30,8 @@ function go(recipient, licenceRef, eventId, dueReturnLog) {
     messageRef: 'pdf.return_form',
     messageType: 'letter',
     personalisation: _personalisation(dueReturnLog, recipient, licenceRef),
-    returnLogIds: [dueReturnLog.returnId]
+    returnLogIds: [dueReturnLog.returnId],
+    status: 'pending'
   }
 }
 

--- a/test/presenters/notices/setup/abstraction-alert-notifications.presenter.test.js
+++ b/test/presenters/notices/setup/abstraction-alert-notifications.presenter.test.js
@@ -84,6 +84,7 @@ describe('Notices - Setup - Abstraction Alert Notifications presenter', () => {
           thresholdValue: 1000
         },
         recipient: 'primary.user@important.com',
+        status: 'pending',
         templateId: '6ec7265d-8ebb-4217-a62b-9bf0216f8c9f'
       },
       {
@@ -115,6 +116,7 @@ describe('Notices - Setup - Abstraction Alert Notifications presenter', () => {
           thresholdUnit: 'm3/s',
           thresholdValue: 100
         },
+        status: 'pending',
         templateId: '7ab10c86-2c23-4376-8c72-9419e7f982bb'
       },
       {
@@ -140,6 +142,7 @@ describe('Notices - Setup - Abstraction Alert Notifications presenter', () => {
           thresholdValue: 100
         },
         recipient: 'additional.contact@important.com',
+        status: 'pending',
         templateId: 'bf32327a-f170-4854-8abb-3068aee9cdec'
       }
     ])
@@ -180,6 +183,7 @@ describe('Notices - Setup - Abstraction Alert Notifications presenter', () => {
             thresholdValue: 1000
           },
           recipient: 'primary.user@important.com',
+          status: 'pending',
           templateId: '6ec7265d-8ebb-4217-a62b-9bf0216f8c9f'
         },
         {
@@ -205,6 +209,7 @@ describe('Notices - Setup - Abstraction Alert Notifications presenter', () => {
             thresholdValue: 100
           },
           recipient: 'primary.user@important.com',
+          status: 'pending',
           templateId: 'a51ace39-3224-4c18-bbb8-c803a6da9a21'
         }
       ])
@@ -245,6 +250,7 @@ describe('Notices - Setup - Abstraction Alert Notifications presenter', () => {
             thresholdValue: 100
           },
           recipient: 'additional.contact@important.com',
+          status: 'pending',
           templateId: 'bf32327a-f170-4854-8abb-3068aee9cdec'
         }
       ])
@@ -288,6 +294,7 @@ describe('Notices - Setup - Abstraction Alert Notifications presenter', () => {
             thresholdValue: 1000
           },
           recipient: 'additional.contact@important.com',
+          status: 'pending',
           templateId: '6ec7265d-8ebb-4217-a62b-9bf0216f8c9f'
         }
       ])
@@ -331,6 +338,7 @@ describe('Notices - Setup - Abstraction Alert Notifications presenter', () => {
             thresholdValue: 1000
           },
           recipient: 'primary.user@important.com',
+          status: 'pending',
           templateId: '6ec7265d-8ebb-4217-a62b-9bf0216f8c9f'
         }
       ])
@@ -378,6 +386,7 @@ describe('Notices - Setup - Abstraction Alert Notifications presenter', () => {
             thresholdUnit: 'm',
             thresholdValue: 1000
           },
+          status: 'pending',
           templateId: '27499bbd-e854-4f13-884e-30e0894526b6'
         }
       ])

--- a/test/presenters/notices/setup/notifications.presenter.test.js
+++ b/test/presenters/notices/setup/notifications.presenter.test.js
@@ -67,6 +67,7 @@ describe('Notices - Setup - Notifications Presenter', () => {
           returnDueDate: '28 April 2025'
         },
         recipient: 'primary.user@important.com',
+        status: 'pending',
         templateId: '2fa7fc83-4df1-4f52-bccf-ff0faeb12b6f'
       },
       {
@@ -81,6 +82,7 @@ describe('Notices - Setup - Notifications Presenter', () => {
           returnDueDate: '28 April 2025'
         },
         recipient: 'returns.agent@important.com',
+        status: 'pending',
         templateId: '41c45bd4-8225-4d7e-a175-b48b613b5510'
       },
       {
@@ -101,6 +103,7 @@ describe('Notices - Setup - Notifications Presenter', () => {
           periodStartDate: '1 January 2025',
           returnDueDate: '28 April 2025'
         },
+        status: 'pending',
         templateId: '4fe80aed-c5dd-44c3-9044-d0289d635019'
       },
       {
@@ -121,6 +124,7 @@ describe('Notices - Setup - Notifications Presenter', () => {
           periodStartDate: '1 January 2025',
           returnDueDate: '28 April 2025'
         },
+        status: 'pending',
         templateId: '0e535549-99a2-44a9-84a7-589b12d00879'
       },
       {
@@ -141,6 +145,7 @@ describe('Notices - Setup - Notifications Presenter', () => {
           periodStartDate: '1 January 2025',
           returnDueDate: '28 April 2025'
         },
+        status: 'pending',
         templateId: '4fe80aed-c5dd-44c3-9044-d0289d635019'
       }
     ])
@@ -174,6 +179,7 @@ describe('Notices - Setup - Notifications Presenter', () => {
                   returnDueDate: '28 April 2025'
                 },
                 recipient: 'primary.user@important.com',
+                status: 'pending',
                 templateId: '2fa7fc83-4df1-4f52-bccf-ff0faeb12b6f'
               }
             ])
@@ -201,6 +207,7 @@ describe('Notices - Setup - Notifications Presenter', () => {
                   returnDueDate: '28 April 2025'
                 },
                 recipient: 'returns.agent@important.com',
+                status: 'pending',
                 templateId: '41c45bd4-8225-4d7e-a175-b48b613b5510'
               }
             ])
@@ -228,6 +235,7 @@ describe('Notices - Setup - Notifications Presenter', () => {
                   returnDueDate: '28 April 2025'
                 },
                 recipient: 'primary.user@important.com',
+                status: 'pending',
                 templateId: '2fa7fc83-4df1-4f52-bccf-ff0faeb12b6f'
               }
             ])
@@ -263,6 +271,7 @@ describe('Notices - Setup - Notifications Presenter', () => {
                   periodStartDate: '1 January 2025',
                   returnDueDate: '28 April 2025'
                 },
+                status: 'pending',
                 templateId: '4fe80aed-c5dd-44c3-9044-d0289d635019'
               }
             ])
@@ -296,6 +305,7 @@ describe('Notices - Setup - Notifications Presenter', () => {
                   periodStartDate: '1 January 2025',
                   returnDueDate: '28 April 2025'
                 },
+                status: 'pending',
                 templateId: '0e535549-99a2-44a9-84a7-589b12d00879'
               }
             ])
@@ -329,6 +339,7 @@ describe('Notices - Setup - Notifications Presenter', () => {
                   periodStartDate: '1 January 2025',
                   returnDueDate: '28 April 2025'
                 },
+                status: 'pending',
                 templateId: '4fe80aed-c5dd-44c3-9044-d0289d635019'
               }
             ])
@@ -364,6 +375,7 @@ describe('Notices - Setup - Notifications Presenter', () => {
                   returnDueDate: '28 April 2025'
                 },
                 recipient: 'primary.user@important.com',
+                status: 'pending',
                 templateId: 'f1144bc7-8bdc-4e82-87cb-1a6c69445836'
               }
             ])
@@ -391,6 +403,7 @@ describe('Notices - Setup - Notifications Presenter', () => {
                   returnDueDate: '28 April 2025'
                 },
                 recipient: 'returns.agent@important.com',
+                status: 'pending',
                 templateId: '038e1807-d1b5-4f09-a5a6-d7eee9030a7a'
               }
             ])
@@ -418,6 +431,7 @@ describe('Notices - Setup - Notifications Presenter', () => {
                   returnDueDate: '28 April 2025'
                 },
                 recipient: 'primary.user@important.com',
+                status: 'pending',
                 templateId: 'f1144bc7-8bdc-4e82-87cb-1a6c69445836'
               }
             ])
@@ -453,6 +467,7 @@ describe('Notices - Setup - Notifications Presenter', () => {
                   periodStartDate: '1 January 2025',
                   returnDueDate: '28 April 2025'
                 },
+                status: 'pending',
                 templateId: 'c01c808b-094b-4a3a-ab9f-a6e86bad36ba'
               }
             ])
@@ -486,6 +501,7 @@ describe('Notices - Setup - Notifications Presenter', () => {
                   periodStartDate: '1 January 2025',
                   returnDueDate: '28 April 2025'
                 },
+                status: 'pending',
                 templateId: 'e9f132c7-a550-4e18-a5c1-78375f07aa2d'
               }
             ])
@@ -519,6 +535,7 @@ describe('Notices - Setup - Notifications Presenter', () => {
                   periodStartDate: '1 January 2025',
                   returnDueDate: '28 April 2025'
                 },
+                status: 'pending',
                 templateId: 'c01c808b-094b-4a3a-ab9f-a6e86bad36ba'
               }
             ])
@@ -559,6 +576,7 @@ describe('Notices - Setup - Notifications Presenter', () => {
                   returnDueDate: '29 January 2025'
                 },
                 recipient: 'primary.user@important.com',
+                status: 'pending',
                 templateId: '7bb89469-1dbc-458a-9526-fad8ab71285f'
               }
             ])
@@ -586,6 +604,7 @@ describe('Notices - Setup - Notifications Presenter', () => {
                   returnDueDate: '29 January 2025'
                 },
                 recipient: 'returns.agent@important.com',
+                status: 'pending',
                 templateId: 'cbc4efe2-f3b5-4642-8f6d-3532df73ee94'
               }
             ])
@@ -613,6 +632,7 @@ describe('Notices - Setup - Notifications Presenter', () => {
                   returnDueDate: '29 January 2025'
                 },
                 recipient: 'primary.user@important.com',
+                status: 'pending',
                 templateId: '7bb89469-1dbc-458a-9526-fad8ab71285f'
               }
             ])
@@ -660,6 +680,7 @@ describe('Notices - Setup - Notifications Presenter', () => {
                   periodEndDate: null,
                   periodStartDate: null
                 },
+                status: 'pending',
                 templateId: '4b47cf1c-043c-4a0c-8659-5be06cb2b860'
               }
             ])
@@ -693,6 +714,7 @@ describe('Notices - Setup - Notifications Presenter', () => {
                   periodEndDate: null,
                   periodStartDate: null
                 },
+                status: 'pending',
                 templateId: '73b4c395-4423-4976-8ab4-c82e2cb6beee'
               }
             ])
@@ -726,6 +748,7 @@ describe('Notices - Setup - Notifications Presenter', () => {
                   periodStartDate: null,
                   returnDueDate: '30 January 2025'
                 },
+                status: 'pending',
                 templateId: '4b47cf1c-043c-4a0c-8659-5be06cb2b860'
               }
             ])

--- a/test/presenters/notices/setup/return-forms-notification.presenter.test.js
+++ b/test/presenters/notices/setup/return-forms-notification.presenter.test.js
@@ -61,7 +61,8 @@ describe('Notices - Setup - Return Forms Notification Presenter', () => {
           site_description: 'BOREHOLE AT AVALON',
           start_date: '1 April 2022'
         },
-        returnLogIds: [dueReturnLog.returnId]
+        returnLogIds: [dueReturnLog.returnId],
+        status: 'pending'
       })
     })
   })

--- a/test/services/notices/setup/batch-notifications.service.test.js
+++ b/test/services/notices/setup/batch-notifications.service.test.js
@@ -362,6 +362,7 @@ function _notifications(eventId, licences) {
         periodStartDate: '1 April 2022'
       },
       recipient: 'primary.user@important.com',
+      status: 'pending',
       templateId: '2fa7fc83-4df1-4f52-bccf-ff0faeb12b6f'
     },
     letter: {
@@ -383,6 +384,7 @@ function _notifications(eventId, licences) {
         periodStartDate: '1 April 2022'
       },
       recipient: null,
+      status: 'pending',
       templateId: '2fa7fc83-4df1-4f52-bccf-ff0faeb12b6f'
     },
     pdf: {
@@ -392,7 +394,8 @@ function _notifications(eventId, licences) {
       messageType: 'letter',
       pdf: Buffer.from('mock file'),
       personalisation: { name: 'Red 5' },
-      returnLogIds: [generateUUID()]
+      returnLogIds: [generateUUID()],
+      status: 'pending'
     }
   }
 }

--- a/test/services/notices/setup/determine-notifications.service.test.js
+++ b/test/services/notices/setup/determine-notifications.service.test.js
@@ -77,6 +77,7 @@ describe('Notices - Setup - Determine Notifications service', () => {
             periodStartDate: '1 April 2022'
           },
           recipient: 'primary.user@important.com',
+          status: 'pending',
           templateId: '2fa7fc83-4df1-4f52-bccf-ff0faeb12b6f'
         }
       ])
@@ -167,6 +168,7 @@ describe('Notices - Setup - Determine Notifications service', () => {
             thresholdValue: 500
           },
           recipient: 'primary.user@important.com',
+          status: 'pending',
           templateId: notifyTemplates.alerts.email.stopWarning
         }
       ])

--- a/test/services/notices/setup/determine-return-forms.service.test.js
+++ b/test/services/notices/setup/determine-return-forms.service.test.js
@@ -85,7 +85,8 @@ describe('Notices - Setup - Determine Return Forms Service', () => {
               site_description: 'BOREHOLE AT AVALON',
               start_date: '1 April 2022'
             },
-            returnLogIds: [dueReturnLog.returnId]
+            returnLogIds: [dueReturnLog.returnId],
+            status: 'pending'
           },
           {
             eventId,
@@ -113,7 +114,8 @@ describe('Notices - Setup - Determine Return Forms Service', () => {
               site_description: 'BOREHOLE AT AVALON',
               start_date: '1 April 2022'
             },
-            returnLogIds: [dueReturnLog.returnId]
+            returnLogIds: [dueReturnLog.returnId],
+            status: 'pending'
           }
         ])
       })
@@ -154,7 +156,8 @@ describe('Notices - Setup - Determine Return Forms Service', () => {
               site_description: 'BOREHOLE AT AVALON',
               start_date: '1 April 2022'
             },
-            returnLogIds: [dueReturnLog.returnId]
+            returnLogIds: [dueReturnLog.returnId],
+            status: 'pending'
           },
           {
             eventId,
@@ -182,7 +185,8 @@ describe('Notices - Setup - Determine Return Forms Service', () => {
               site_description: 'BOREHOLE AT AVALON',
               start_date: '1 April 2022'
             },
-            returnLogIds: [dueReturnLog.returnId]
+            returnLogIds: [dueReturnLog.returnId],
+            status: 'pending'
           },
           {
             eventId,
@@ -210,7 +214,8 @@ describe('Notices - Setup - Determine Return Forms Service', () => {
               site_description: 'BOREHOLE AT AVALON',
               start_date: '1 April 2022'
             },
-            returnLogIds: [additionalDueReturn.returnId]
+            returnLogIds: [additionalDueReturn.returnId],
+            status: 'pending'
           },
           {
             eventId,
@@ -238,7 +243,8 @@ describe('Notices - Setup - Determine Return Forms Service', () => {
               site_description: 'BOREHOLE AT AVALON',
               start_date: '1 April 2022'
             },
-            returnLogIds: [additionalDueReturn.returnId]
+            returnLogIds: [additionalDueReturn.returnId],
+            status: 'pending'
           }
         ])
       })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5280

When we create a notification and save it, we need to set the initial status value to 'pending'.

This was missed in the recent refactor and was producing a bug of an empty status on the notice page.

This change updates the notification presenters to set the status to pending.

We need to leave the existing status in the notify update presenter. This is due to the way we are batch inserting (upserting). If this is not present it will set it to null.