### PR TITLE
Add returned at date to scheduled notifications view

### DIFF
--- a/db/migrations/legacy/20221108007033_water-scheduled-notification.js
+++ b/db/migrations/legacy/20221108007033_water-scheduled-notification.js
@@ -32,6 +32,7 @@ exports.up = function (knex) {
     table.jsonb('return_log_ids')
     table.uuid('template_id')
     table.binary('pdf')
+    table.date('returned_at')
 
     // Legacy timestamps
     table.timestamp('date_created', { useTz: false }).defaultTo(knex.fn.now())

--- a/db/migrations/public/20251001102349_scheduled-notification-add-returned-at-column.js
+++ b/db/migrations/public/20251001102349_scheduled-notification-add-returned-at-column.js
@@ -1,0 +1,73 @@
+'use strict'
+
+exports.up = function (knex) {
+  return knex.schema.dropViewIfExists('notifications').createView('notifications', (view) => {
+    view.as(
+      knex('scheduled_notification').withSchema('water').select([
+        'id',
+        'recipient',
+        'message_type',
+        'message_ref',
+        'personalisation',
+        // 'send_after',
+        'status',
+        'log AS notify_error',
+        'licences',
+        // 'individual_entity_id AS individual_id',
+        // 'company_entity_id AS company_id',
+        // 'medium',
+        'notify_id',
+        'notify_status',
+        'plaintext',
+        'event_id',
+        // 'metadata',
+        // 'status_checks',
+        // 'next_status_check',
+        // 'notification_type',
+        // 'job_id',
+        'licence_gauging_station_id AS licence_monitoring_station_id',
+        'date_created AS created_at',
+        'return_log_ids',
+        'template_id',
+        'pdf',
+        'returned_at'
+      ])
+    )
+  })
+}
+
+exports.down = function (knex) {
+  return knex.schema.dropViewIfExists('notifications').createView('notifications', (view) => {
+    // NOTE: We have commented out unused columns from the source table
+    view.as(
+      knex('scheduled_notification').withSchema('water').select([
+        'id',
+        'recipient',
+        'message_type',
+        'message_ref',
+        'personalisation',
+        // 'send_after',
+        'status',
+        'log AS notify_error',
+        'licences',
+        // 'individual_entity_id AS individual_id',
+        // 'company_entity_id AS company_id',
+        // 'medium',
+        'notify_id',
+        'notify_status',
+        'plaintext',
+        'event_id',
+        // 'metadata',
+        // 'status_checks',
+        // 'next_status_check',
+        // 'notification_type',
+        // 'job_id',
+        'licence_gauging_station_id AS licence_monitoring_station_id',
+        'date_created AS created_at',
+        'return_log_ids',
+        'template_id',
+        'pdf'
+      ])
+    )
+  })
+}

--- a/test/services/jobs/notification-status/process-notification-status.service.test.js
+++ b/test/services/jobs/notification-status/process-notification-status.service.test.js
@@ -107,6 +107,7 @@ describe('Job - Notifications - Process Notification Status service', () => {
               personalisation: null,
               plaintext: 'Dear Clean Water Limited,\r\n',
               recipient: 'hello@example.com',
+              returnedAt: null,
               returnLogIds: null,
               status: 'sent',
               templateId: null
@@ -177,6 +178,7 @@ describe('Job - Notifications - Process Notification Status service', () => {
               },
               plaintext: 'Dear licence contact,\r\n',
               recipient: 'hello@example.com',
+              returnedAt: null,
               returnLogIds: null,
               status: 'sent',
               templateId: null
@@ -238,6 +240,7 @@ describe('Job - Notifications - Process Notification Status service', () => {
               plaintext: 'Dear Clean Water Limited,\r\n',
               recipient: 'hello@example.com',
               returnLogIds: null,
+              returnedAt: null,
               status: 'sent',
               templateId: null
             },
@@ -311,6 +314,7 @@ describe('Job - Notifications - Process Notification Status service', () => {
             plaintext: 'Dear Clean Water Limited,\r\n',
             recipient: 'hello@example.com',
             returnLogIds: null,
+            returnedAt: null,
             status: 'error',
             templateId: null
           },
@@ -400,6 +404,7 @@ describe('Job - Notifications - Process Notification Status service', () => {
           plaintext: 'Dear Clean Water Limited,\r\n',
           recipient: 'hello@example.com',
           returnLogIds: null,
+          returnedAt: null,
           status: 'pending',
           templateId: null
         },

--- a/test/services/jobs/notification-status/update-notifications.service.test.js
+++ b/test/services/jobs/notification-status/update-notifications.service.test.js
@@ -68,6 +68,7 @@ describe('Job - Notification Status - Update Notifications service', () => {
         personalisation: null,
         plaintext: null,
         recipient: null,
+        returnedAt: null,
         returnLogIds: null,
         status: 'sent',
         templateId: null
@@ -118,6 +119,7 @@ describe('Job - Notification Status - Update Notifications service', () => {
         personalisation: null,
         plaintext: null,
         recipient: null,
+        returnedAt: null,
         returnLogIds: null,
         status: 'sent',
         templateId: null
@@ -144,6 +146,7 @@ describe('Job - Notification Status - Update Notifications service', () => {
         personalisation: null,
         plaintext: null,
         recipient: null,
+        returnedAt: null,
         returnLogIds: null,
         status: 'sent',
         templateId: null

--- a/test/services/notices/setup/batch-notifications.service.test.js
+++ b/test/services/notices/setup/batch-notifications.service.test.js
@@ -102,6 +102,7 @@ describe('Notices - Setup - Batch Notifications service', () => {
           notifyStatus: 'created',
           pdf: null,
           recipient: 'primary.user@important.com',
+          returnedAt: null,
           returnLogIds: null,
           status: 'pending',
           templateId: testNotification.templateId
@@ -152,6 +153,7 @@ describe('Notices - Setup - Batch Notifications service', () => {
           },
           plaintext: 'Dear Licence holder,\r\n',
           recipient: null,
+          returnedAt: null,
           returnLogIds: null,
           status: 'pending',
           templateId: testNotification.templateId
@@ -202,6 +204,7 @@ describe('Notices - Setup - Batch Notifications service', () => {
           notifyStatus: 'created',
           pdf: Buffer.from(notification.pdf.pdf),
           recipient: null,
+          returnedAt: null,
           returnLogIds: testNotification.returnLogIds,
           status: 'pending',
           templateId: null

--- a/test/services/notices/setup/create-notifications.service.test.js
+++ b/test/services/notices/setup/create-notifications.service.test.js
@@ -56,6 +56,7 @@ describe('Notices - Setup - Create notification service', () => {
         personalisation: null,
         plaintext: null,
         recipient: null,
+        returnedAt: null,
         returnLogIds: null,
         status: null,
         templateId: null
@@ -75,6 +76,7 @@ describe('Notices - Setup - Create notification service', () => {
         personalisation: null,
         plaintext: null,
         recipient: null,
+        returnedAt: null,
         returnLogIds: null,
         status: null,
         templateId: null

--- a/test/services/notices/setup/record-notify-send-results.service.test.js
+++ b/test/services/notices/setup/record-notify-send-results.service.test.js
@@ -85,6 +85,7 @@ describe('Notices - Setup - Record notify send results service', () => {
           personalisation: null,
           plaintext: 'some text',
           recipient: null,
+          returnedAt: null,
           returnLogIds: null,
           status: 'pending',
           templateId: null
@@ -104,6 +105,7 @@ describe('Notices - Setup - Record notify send results service', () => {
           personalisation: null,
           plaintext: 'some text',
           recipient: null,
+          returnedAt: null,
           returnLogIds: null,
           status: 'pending',
           templateId: null
@@ -150,6 +152,7 @@ describe('Notices - Setup - Record notify send results service', () => {
           personalisation: null,
           plaintext: null,
           recipient: null,
+          returnedAt: null,
           returnLogIds: null,
           status: 'error',
           templateId: null
@@ -169,6 +172,7 @@ describe('Notices - Setup - Record notify send results service', () => {
           personalisation: null,
           plaintext: null,
           recipient: null,
+          returnedAt: null,
           returnLogIds: null,
           status: 'error',
           templateId: null


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5296

As part of the work to send out letters to licence holders we need a way to be able to know when a letter has been returned. GovNotify allows you to set up a callback url: https://docs.notifications.service.gov.uk/node.html#returned-letters

When this happens we want to be able to register when we were notified that the letter was returned so this PR adds a column that we will use to register when the most recent letter for a notification was returned.