### PR TITLE
Add preview return form to the communications tab

### DIFF
--- a/app/controllers/notifications.controller.js
+++ b/app/controllers/notifications.controller.js
@@ -5,8 +5,8 @@
  * @module NotificationsController
  */
 
-const ViewNotificationService = require('../services/notifications/view-notification.service.js')
 const DownloadNotificationService = require('../services/notifications/download-notification.service.js')
+const ViewNotificationService = require('../services/notifications/view-notification.service.js')
 
 const NO_CONTENT_STATUS_CODE = 204
 

--- a/app/controllers/notifications.controller.js
+++ b/app/controllers/notifications.controller.js
@@ -6,8 +6,17 @@
  */
 
 const ViewNotificationService = require('../services/notifications/view-notification.service.js')
+const DownloadNotificationService = require('../services/notifications/download-notification.service.js')
 
 const NO_CONTENT_STATUS_CODE = 204
+
+async function download(request, h) {
+  const { id: notificationId } = request.params
+
+  const fileBuffer = await DownloadNotificationService.go(notificationId)
+
+  return h.response(fileBuffer).type('application/pdf').header('Content-Disposition', 'inline; filename="letter.pdf"')
+}
 
 /**
  * If a letter has been returned to notify this end point will be called
@@ -35,6 +44,7 @@ async function view(request, h) {
 }
 
 module.exports = {
+  download,
   returnedLetter,
   view
 }

--- a/app/presenters/licences/view-licence-communications.presenter.js
+++ b/app/presenters/licences/view-licence-communications.presenter.js
@@ -50,8 +50,7 @@ function _link(communicationId, documentId, licenceId) {
 function _type(communication, sent) {
   return {
     label: _typeLabel(communication),
-    sentVia: `sent ${sent} via ${communication.messageType}`,
-    pdf: communication.messageRef.includes('pdf')
+    sentVia: `sent ${sent} via ${communication.messageType}`
   }
 }
 

--- a/app/presenters/notifications/view-notification.presenter.js
+++ b/app/presenters/notifications/view-notification.presenter.js
@@ -10,12 +10,12 @@ const { formatLongDate, sentenceCase } = require('../base.presenter.js')
 /**
  * Formats notification data ready for presenting in the view notification page
  *
- * @param {module:ScheduledNotificationModel} notificationData - The scheduled notification and related licence data
+ * @param {module:NotificationModel} notificationData - The notification and related licence data
  *
  * @returns {object} The data formatted for the view template
  */
 function go(notificationData) {
-  const { createdAt, messageType, personalisation, plaintext, recipient, sendAfter } = notificationData.notification
+  const { createdAt, messageType, personalisation, plaintext, recipient, id, pdf } = notificationData.notification
   const { id: licenceId, licenceRef } = notificationData.licence
 
   return {
@@ -25,7 +25,8 @@ function go(notificationData) {
     licenceRef,
     messageType,
     pageTitle: _pageTitle(notificationData.notification),
-    sentDate: sendAfter ? formatLongDate(sendAfter) : formatLongDate(createdAt)
+    returnForm: _returnForm(id, pdf),
+    sentDate: formatLongDate(createdAt)
   }
 }
 
@@ -42,6 +43,19 @@ function _address(personalisation) {
   return addressLines.filter((addressLine) => {
     return addressLine
   })
+}
+
+function _returnForm(id, pdf) {
+  if (pdf) {
+    return {
+      link: `/system/notifications/${id}/download`,
+      text: 'Preview paper return'
+    }
+  }
+
+  return {
+    text: 'No preview available'
+  }
 }
 
 function _pageTitle(notification) {

--- a/app/routes/notifications.routes.js
+++ b/app/routes/notifications.routes.js
@@ -5,6 +5,13 @@ const NotificationsController = require('../controllers/notifications.controller
 const routes = [
   {
     method: 'GET',
+    path: '/notifications/{id}/download',
+    options: {
+      handler: NotificationsController.download
+    }
+  },
+  {
+    method: 'GET',
     path: '/notifications/{id}',
     options: {
       handler: NotificationsController.view

--- a/app/services/notifications/download-notification.service.js
+++ b/app/services/notifications/download-notification.service.js
@@ -1,0 +1,25 @@
+'use strict'
+
+/**
+ * Orchestrates fetching and presenting the data needed for the view notification page
+ * @module DownloadNotificationService
+ */
+
+const FetchDownloadNotificationService = require('./fetch-notification-download.service.js')
+
+/**
+ * Orchestrates fetching and presenting the data needed for the view notification page
+ *
+ * @param {string} notificationId - The UUID of the notification
+ *
+ * @returns {Promise<object>} an object representing the `pageData` needed by the view notification template.
+ */
+async function go(notificationId) {
+  const notificationData = await FetchDownloadNotificationService.go(notificationId)
+
+  return notificationData.pdf
+}
+
+module.exports = {
+  go
+}

--- a/app/services/notifications/download-notification.service.js
+++ b/app/services/notifications/download-notification.service.js
@@ -1,18 +1,18 @@
 'use strict'
 
 /**
- * Orchestrates fetching and presenting the data needed for the view notification page
+ * Orchestrates fetching and returning the PDF data for a notification
  * @module DownloadNotificationService
  */
 
 const FetchDownloadNotificationService = require('./fetch-notification-download.service.js')
 
 /**
- * Orchestrates fetching and presenting the data needed for the view notification page
+ * Orchestrates fetching and returning the PDF data for a notification
  *
  * @param {string} notificationId - The UUID of the notification
  *
- * @returns {Promise<object>} an object representing the `pageData` needed by the view notification template.
+ * @returns {Promise<ArrayBuffer>} - Resolves with the saved PDF data
  */
 async function go(notificationId) {
   const notificationData = await FetchDownloadNotificationService.go(notificationId)

--- a/app/services/notifications/fetch-notification-download.service.js
+++ b/app/services/notifications/fetch-notification-download.service.js
@@ -1,0 +1,24 @@
+'use strict'
+
+/**
+ * Fetches the matching notification and licence data needed for the view
+ * @module FetchDownloadNotificationService
+ */
+
+const NotificationModel = require('../../models/notification.model.js')
+
+/**
+ * Fetches the matching notification and licence data needed for the view
+ *
+ * @param {string} notificationId - The UUID for the notifications
+ *
+ * @returns {Promise<module:NotificationModel>} the matching `NotificationModel` instance and
+ * licence data
+ */
+async function go(notificationId) {
+  return NotificationModel.query().findById(notificationId).select(['pdf'])
+}
+
+module.exports = {
+  go
+}

--- a/app/services/notifications/fetch-notification-download.service.js
+++ b/app/services/notifications/fetch-notification-download.service.js
@@ -1,19 +1,18 @@
 'use strict'
 
 /**
- * Fetches the matching notification and licence data needed for the view
+ * Fetches the PDF data for a notification
  * @module FetchDownloadNotificationService
  */
 
 const NotificationModel = require('../../models/notification.model.js')
 
 /**
- * Fetches the matching notification and licence data needed for the view
+ * Fetches the PDF data for a notification
  *
  * @param {string} notificationId - The UUID for the notifications
  *
- * @returns {Promise<module:NotificationModel>} the matching `NotificationModel` instance and
- * licence data
+ * @returns {Promise<module:NotificationModel>} the PDF for the notification
  */
 async function go(notificationId) {
   return NotificationModel.query().findById(notificationId).select(['pdf'])

--- a/app/services/notifications/fetch-notification.service.js
+++ b/app/services/notifications/fetch-notification.service.js
@@ -6,7 +6,7 @@
  */
 
 const LicenceModel = require('../../models/licence.model.js')
-const ScheduledNotificationsModel = require('../../models/scheduled-notification.model.js')
+const NotificationModel = require('../../models/notification.model.js')
 
 /**
  * Fetches the matching notification and licence data needed for the view
@@ -14,7 +14,7 @@ const ScheduledNotificationsModel = require('../../models/scheduled-notification
  * @param {string} notificationId - The UUID for the scheduledNotification
  * @param {string} licenceId - The UUID for the related licence
  *
- * @returns {Promise<module:ScheduledNotificationsModel>} the matching `ScheduledNotificationsModel` instance and
+ * @returns {Promise<module:NotificationModel>} the matching `ScheduledNotificationsModel` instance and
  * licence data
  */
 async function go(notificationId, licenceId) {
@@ -29,9 +29,9 @@ async function _fetchLicence(licenceId) {
 }
 
 async function _fetchNotification(notificationId) {
-  return ScheduledNotificationsModel.query()
+  return NotificationModel.query()
     .findById(notificationId)
-    .select(['messageType', 'personalisation', 'plaintext', 'recipient', 'sendAfter', 'createdAt'])
+    .select(['id', 'messageType', 'personalisation', 'plaintext', 'recipient', 'createdAt', 'createdAt', 'pdf'])
     .withGraphFetched('event')
     .modifyGraph('event', (builder) => {
       builder.select(['metadata'])

--- a/app/views/licences/tabs/communications.njk
+++ b/app/views/licences/tabs/communications.njk
@@ -2,13 +2,9 @@
 {% from "govuk/components/table/macro.njk" import govukTable %}
 
 {% macro communicationType(communication) %}
-  {% if communication.type.pdf %}
-    <p class="govuk-body govuk-!-margin-bottom-0">{{ communication.type.label }}<span class="govuk-visually-hidden"> {{ communication.type.sentVia }}</span></p>
-  {% else %}
     <a href={{communication.link}} class="govuk-link">{{ communication.type.label }}
       <span class="govuk-visually-hidden"> {{ communication.type.sentVia }}</span>
     </a>
-  {% endif %}
 {% endmacro %}
 
 <h2 class="govuk-heading-l">Communications</h2>

--- a/app/views/notifications/view.njk
+++ b/app/views/notifications/view.njk
@@ -4,12 +4,10 @@
 {% from "macros/new-line-array-items.njk" import newLineArrayItems %}
 
 {% block breadcrumbs %}
-  {{
-    govukBackLink({
-      text: 'Go back to communications',
-      href: backLink
-    })
-  }}
+  {{ govukBackLink({
+    text: 'Go back to communications',
+    href: backLink
+  }) }}
 {% endblock %}
 
 {% block content %}
@@ -21,13 +19,23 @@
     text: "Sent " + sentDate
   }) }}
 
-  <div class="govuk-body message-preview">
-    {% if messageType === 'letter' %}
-      <p>{{ newLineArrayItems(address) }}</p>
-    {% else %}
-      <p>Sent to: {{ address }}</p>
-    {% endif %}
+  {% if contents %}
+    <div class="govuk-body message-preview">
+      {% if messageType === 'letter' %}
+        <p>{{ newLineArrayItems(address) }}</p>
+      {% else %}
+        <p>Sent to: {{ address }}</p>
+      {% endif %}
 
-    {{ contents | markdown | safe }}
-  </div>
+      {{ contents | markdown | safe }}
+
+    </div>
+
+  {% else %}
+    {% if returnForm.link %}
+      <a href="{{ returnForm.link }}" target="_blank" rel="noopener noreferrer"> {{ returnForm.text }} </a>
+    {% else %}
+      <p> {{ returnForm.text }} </p>
+    {% endif %}
+  {% endif %}
 {% endblock %}

--- a/test/fixtures/notifications.fixture.js
+++ b/test/fixtures/notifications.fixture.js
@@ -2,7 +2,7 @@
 
 const EventModel = require('../../app/models/event.model.js')
 const LicenceModel = require('../../app/models/licence.model.js')
-const ScheduledNotificationsModel = require('../../app/models/scheduled-notification.model.js')
+const NotificationModel = require('../../app/models/notification.model.js')
 
 /**
  * Represents a complete response from `FetchNotificationsService`
@@ -29,7 +29,7 @@ function notification() {
     }
   })
 
-  const notification = ScheduledNotificationsModel.fromJson({
+  const notification = NotificationModel.fromJson({
     id: '4222e93e-6798-40ea-82d2-d5decbb01dac',
     messageType: 'letter',
     personalisation: {
@@ -50,7 +50,7 @@ function notification() {
       '\n' +
       '# Why you are receiving this notification\n' +
       '\n',
-    sendAfter: new Date('2024-07-02T16:52:17.000Z'),
+    createdAt: new Date('2024-07-02T16:52:17.000Z'),
     event
   })
 

--- a/test/presenters/licences/view-licence-communications.presenter.test.js
+++ b/test/presenters/licences/view-licence-communications.presenter.test.js
@@ -58,7 +58,6 @@ describe('Licences - View Licence Communications presenter', () => {
             sent: '15 May 2024',
             type: {
               label: 'Returns: invitation',
-              pdf: false,
               sentVia: 'sent 15 May 2024 via letter'
             }
           }
@@ -93,31 +92,12 @@ describe('Licences - View Licence Communications presenter', () => {
     })
 
     describe('the "messageRef" property', () => {
-      describe('when the message ref contains pdf', () => {
-        beforeEach(() => {
-          communications[0].messageRef = 'pdf.return_form'
-        })
+      it('returns that communication type', () => {
+        const result = ViewLicenceCommunicationsPresenter.go(communications, documentId, licenceId)
 
-        it('returns that communication type', () => {
-          const result = ViewLicenceCommunicationsPresenter.go(communications, documentId, licenceId)
-
-          expect(result.communications[0].type).to.equal({
-            label: 'Returns: invitation',
-            pdf: true,
-            sentVia: 'sent 15 May 2024 via letter'
-          })
-        })
-      })
-
-      describe('when the message ref does not contain pdf', () => {
-        it('returns that communication type', () => {
-          const result = ViewLicenceCommunicationsPresenter.go(communications, documentId, licenceId)
-
-          expect(result.communications[0].type).to.equal({
-            label: 'Returns: invitation',
-            pdf: false,
-            sentVia: 'sent 15 May 2024 via letter'
-          })
+        expect(result.communications[0].type).to.equal({
+          label: 'Returns: invitation',
+          sentVia: 'sent 15 May 2024 via letter'
         })
       })
     })
@@ -147,7 +127,6 @@ describe('Licences - View Licence Communications presenter', () => {
 
         expect(result.communications[0].type).to.equal({
           label: 'Test - Water abstraction alert',
-          pdf: false,
           sentVia: 'sent 15 May 2024 via letter'
         })
       })

--- a/test/presenters/notifications/view-notification.presenter.test.js
+++ b/test/presenters/notifications/view-notification.presenter.test.js
@@ -88,7 +88,7 @@ describe('View Notification presenter', () => {
         })
       })
 
-      describe('when there is no pdf data', () => {
+      describe('when there is pdf data', () => {
         beforeEach(() => {
           testNotification.notification.pdf = Buffer.from('mock file')
         })

--- a/test/presenters/notifications/view-notification.presenter.test.js
+++ b/test/presenters/notifications/view-notification.presenter.test.js
@@ -4,7 +4,7 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, before } = (exports.lab = Lab.script())
+const { describe, it, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -16,7 +16,7 @@ const ViewNotificationPresenter = require('../../../app/presenters/notifications
 describe('View Notification presenter', () => {
   let testNotification
 
-  before(() => {
+  beforeEach(() => {
     testNotification = NotificationsFixture.notification()
   })
 
@@ -40,6 +40,9 @@ describe('View Notification presenter', () => {
         licenceRef: '01/117',
         messageType: 'letter',
         pageTitle: 'Hands off flow: levels warning',
+        returnForm: {
+          text: 'No preview available'
+        },
         sentDate: '2 July 2024'
       })
     })
@@ -47,7 +50,7 @@ describe('View Notification presenter', () => {
     describe('the "address" property', () => {
       describe('when the "messageType" is "letter"', () => {
         describe('when only some of the address values in the "notifications.personalisation" property are filled', () => {
-          before(() => {
+          beforeEach(() => {
             testNotification.notification.personalisation.address_line_1 = ''
             testNotification.notification.personalisation.address_line_3 = ''
           })
@@ -61,7 +64,7 @@ describe('View Notification presenter', () => {
       })
 
       describe('when the "messageType" is "email"', () => {
-        before(() => {
+        beforeEach(() => {
           testNotification.notification.messageType = 'email'
           testNotification.notification.recipient = 'bob@bobbins.co.uk'
         })
@@ -70,6 +73,33 @@ describe('View Notification presenter', () => {
           const result = ViewNotificationPresenter.go(testNotification)
 
           expect(result.address).to.equal('bob@bobbins.co.uk')
+        })
+      })
+    })
+
+    describe('the "returnForm" property', () => {
+      describe('when there is no pdf data', () => {
+        it('correctly returns the text', () => {
+          const result = ViewNotificationPresenter.go(testNotification)
+
+          expect(result.returnForm).to.equal({
+            text: 'No preview available'
+          })
+        })
+      })
+
+      describe('when there is no pdf data', () => {
+        beforeEach(() => {
+          testNotification.notification.pdf = Buffer.from('mock file')
+        })
+
+        it('correctly returns the text', () => {
+          const result = ViewNotificationPresenter.go(testNotification)
+
+          expect(result.returnForm).to.equal({
+            link: `/system/notifications/${testNotification.notification.id}/download`,
+            text: 'Preview paper return'
+          })
         })
       })
     })
@@ -84,7 +114,7 @@ describe('View Notification presenter', () => {
       })
 
       describe('when the "event.metadata.name" is "Water abstraction alert"', () => {
-        before(() => {
+        beforeEach(() => {
           testNotification.notification.event.metadata = {
             name: 'Water abstraction alert',
             options: { sendingAlertType: 'warning' }

--- a/test/services/notifications/download-notification.service.test.js
+++ b/test/services/notifications/download-notification.service.test.js
@@ -26,7 +26,7 @@ describe('Notifications - Download Notification service', () => {
   })
 
   describe('when called', () => {
-    it('returns the page data for the view', async () => {
+    it('returns pdf data', async () => {
       const result = await DownloadNotificationService.go(notification.id)
 
       expect(result).to.equal(pdf)

--- a/test/services/notifications/download-notification.service.test.js
+++ b/test/services/notifications/download-notification.service.test.js
@@ -1,0 +1,35 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Test helpers
+const NotificationHelper = require('../../support/helpers/notification.helper.js')
+
+// Thing under test
+const DownloadNotificationService = require('../../../app/services/notifications/download-notification.service.js')
+
+describe('Notifications - Download Notification service', () => {
+  let notification
+  let pdf
+
+  beforeEach(async () => {
+    pdf = Buffer.from('mock file')
+
+    notification = await NotificationHelper.add({
+      pdf
+    })
+  })
+
+  describe('when called', () => {
+    it('returns the page data for the view', async () => {
+      const result = await DownloadNotificationService.go(notification.id)
+
+      expect(result).to.equal(pdf)
+    })
+  })
+})

--- a/test/services/notifications/download-notification.service.test.js
+++ b/test/services/notifications/download-notification.service.test.js
@@ -3,31 +3,37 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
+const Sinon = require('sinon')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
-// Test helpers
-const NotificationHelper = require('../../support/helpers/notification.helper.js')
+// Things we need to stub
+const FetchDownloadNotificationService = require('../../../app/services/notifications/fetch-notification-download.service.js')
 
 // Thing under test
 const DownloadNotificationService = require('../../../app/services/notifications/download-notification.service.js')
+const { generateUUID } = require('../../../app/lib/general.lib.js')
 
 describe('Notifications - Download Notification service', () => {
-  let notification
+  let notificationId
   let pdf
 
   beforeEach(async () => {
+    notificationId = generateUUID()
+
     pdf = Buffer.from('mock file')
 
-    notification = await NotificationHelper.add({
-      pdf
-    })
+    Sinon.stub(FetchDownloadNotificationService, 'go').resolves({ pdf })
+  })
+
+  afterEach(() => {
+    Sinon.restore()
   })
 
   describe('when called', () => {
     it('returns pdf data', async () => {
-      const result = await DownloadNotificationService.go(notification.id)
+      const result = await DownloadNotificationService.go(notificationId)
 
       expect(result).to.equal(pdf)
     })

--- a/test/services/notifications/fetch-notification-download.service.test.js
+++ b/test/services/notifications/fetch-notification-download.service.test.js
@@ -1,0 +1,35 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Test helpers
+const NotificationHelper = require('../../support/helpers/notification.helper.js')
+
+// Thing under test
+const FetchDownloadNotificationService = require('../../../app/services/notifications/fetch-notification-download.service.js')
+
+describe('Notifications - Fetch Download Notification service', () => {
+  let notification
+  let pdf
+
+  beforeEach(async () => {
+    pdf = Buffer.from('mock file')
+
+    notification = await NotificationHelper.add({
+      pdf
+    })
+  })
+
+  it('returns the PDF file for the notification', async () => {
+    const result = await FetchDownloadNotificationService.go(notification.id)
+
+    expect(result).to.equal({
+      pdf
+    })
+  })
+})

--- a/test/services/notifications/fetch-notification.service.test.js
+++ b/test/services/notifications/fetch-notification.service.test.js
@@ -11,7 +11,7 @@ const { expect } = Code
 const EventHelper = require('../../support/helpers/event.helper.js')
 const LicenceHelper = require('../../support/helpers/licence.helper.js')
 const NotificationsFixture = require('../../fixtures/notifications.fixture.js')
-const ScheduledNotificationsHelper = require('../../support/helpers/scheduled-notification.helper.js')
+const NotificationHelper = require('../../support/helpers/notification.helper.js')
 
 // Thing under test
 const FetchNotificationService = require('../../../app/services/notifications/fetch-notification.service.js')
@@ -27,7 +27,7 @@ describe('Fetch Notification service', () => {
     licence = await LicenceHelper.add()
     testNotification = NotificationsFixture.notification()
 
-    notification = await ScheduledNotificationsHelper.add({
+    notification = await NotificationHelper.add({
       ...testNotification.notification,
       eventId: event.id
     })
@@ -44,6 +44,19 @@ describe('Fetch Notification service', () => {
         },
         notification: {
           createdAt: notification.createdAt,
+          event: {
+            metadata: {
+              batch: {
+                id: event.metadata.batch.id,
+                region: {
+                  id: event.metadata.batch.region.id
+                },
+                scheme: event.metadata.batch.scheme,
+                type: event.metadata.batch.type
+              }
+            }
+          },
+          id: notification.id,
           messageType: 'letter',
           personalisation: {
             postcode: 'ME15 0NE',
@@ -64,19 +77,7 @@ describe('Fetch Notification service', () => {
             '# Why you are receiving this notification\n' +
             '\n',
           recipient: null,
-          sendAfter: new Date('2024-07-02T16:52:17.000Z'),
-          event: {
-            metadata: {
-              batch: {
-                id: event.metadata.batch.id,
-                region: {
-                  id: event.metadata.batch.region.id
-                },
-                scheme: event.metadata.batch.scheme,
-                type: event.metadata.batch.type
-              }
-            }
-          }
+          pdf: null
         }
       })
     })

--- a/test/services/notifications/view-notification.service.test.js
+++ b/test/services/notifications/view-notification.service.test.js
@@ -51,6 +51,9 @@ describe('View Notification service', () => {
         licenceRef: '01/117',
         messageType: 'letter',
         pageTitle: 'Hands off flow: levels warning',
+        returnForm: {
+          text: 'No preview available'
+        },
         sentDate: '2 July 2024'
       })
     })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5295

The legacy code did not save a copy of the return form (paper form) sent to the user. We have updated our notification process to save PDF's sent to Notify, this includes the return form.

We only have return forms as PDF's currently.

This change updates the communications tab to link to the notification page when the notification is a return form.

The notification page has been updated to show a download preview link when the notification PDF has content.

A new service has been added to download the PDF file.