### PR TITLE
Update PDF batching to 1 per batch

### DIFF
--- a/app/services/notices/setup/submit-check.service.js
+++ b/app/services/notices/setup/submit-check.service.js
@@ -71,7 +71,7 @@ async function _processNotifications(notifications, notice, referenceCode) {
   try {
     const startTime = currentTimeInNanoseconds()
 
-    await BatchNotificationsService.go(notifications, notice.id, referenceCode)
+    await BatchNotificationsService.go(notifications, notice, referenceCode)
 
     calculateAndLogTimeTaken(startTime, 'Send notifications complete', {})
   } catch (error) {

--- a/test/services/notices/setup/batch-notifications.service.test.js
+++ b/test/services/notices/setup/batch-notifications.service.test.js
@@ -77,7 +77,7 @@ describe('Notices - Setup - Batch Notifications service', () => {
     })
 
     it('should send and then save the notification', async () => {
-      await BatchNotificationsService.go(notifications, event.id, referenceCode)
+      await BatchNotificationsService.go(notifications, event, referenceCode)
 
       // Confirm the notifications are updated and Notify request recorded as expected
       const updatedNotifications = await NotificationModel.query().where('eventId', event.id)
@@ -121,7 +121,7 @@ describe('Notices - Setup - Batch Notifications service', () => {
     })
 
     it('should send and then save the notification', async () => {
-      await BatchNotificationsService.go(notifications, event.id, referenceCode)
+      await BatchNotificationsService.go(notifications, event, referenceCode)
 
       // Confirm the notifications are updated and Notify request recorded as expected
       const updatedNotifications = await NotificationModel.query().where('eventId', event.id)
@@ -162,10 +162,15 @@ describe('Notices - Setup - Batch Notifications service', () => {
     })
   })
 
-  describe('when sending PDFs', () => {
+  describe('when sending PDFs', { timeout: 5000 }, () => {
     let notification
 
     beforeEach(async () => {
+      event = await EventHelper.add({
+        referenceCode,
+        subtype: 'paperReturnForms'
+      })
+
       referenceCode = generateReferenceCode('PRTF')
 
       notification = _notifications(event.id, [recipientsFixture.licenceHolder.licence_refs])
@@ -183,7 +188,7 @@ describe('Notices - Setup - Batch Notifications service', () => {
     })
 
     it('should send and then save the notification', async () => {
-      await BatchNotificationsService.go(notifications, event.id, referenceCode)
+      await BatchNotificationsService.go(notifications, event, referenceCode)
 
       // Confirm the notifications are updated and Notify request recorded as expected
       const updatedNotifications = await NotificationModel.query().where('eventId', event.id)
@@ -235,7 +240,7 @@ describe('Notices - Setup - Batch Notifications service', () => {
       })
 
       it('should not affect the error count', async () => {
-        await BatchNotificationsService.go(notifications, event.id, referenceCode)
+        await BatchNotificationsService.go(notifications, event, referenceCode)
 
         const refreshedEvent = await event.$query()
 
@@ -268,7 +273,7 @@ describe('Notices - Setup - Batch Notifications service', () => {
       })
 
       it('should increment the error count', async () => {
-        await BatchNotificationsService.go(notifications, event.id, referenceCode)
+        await BatchNotificationsService.go(notifications, event, referenceCode)
 
         const refreshedEvent = await event.$query()
 

--- a/test/services/notices/setup/submit-check.service.test.js
+++ b/test/services/notices/setup/submit-check.service.test.js
@@ -57,7 +57,9 @@ describe('Notices - Setup - Submit Check service', () => {
           summer: 'false',
           startDate: '2022-04-01'
         },
-        noticeType: 'invitations'
+        noticeType: 'invitations',
+        subType: 'returnInvitation',
+        name: 'A person'
       }
     })
 
@@ -85,6 +87,9 @@ describe('Notices - Setup - Submit Check service', () => {
         eventId: result
       })
 
+      const event = await EventModel.query().findById(result)
+      delete event.entities
+
       const args = BatchNotificationsService.go.firstCall.args
 
       expect(args[0]).to.equal([
@@ -104,7 +109,7 @@ describe('Notices - Setup - Submit Check service', () => {
         }
       ])
 
-      expect(args[1]).to.equal(result)
+      expect(args[1]).to.equal(event, { skip: ['createdAt', 'updatedAt'] })
 
       expect(args[2]).to.equal(referenceCode)
     })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5280

We have some resource constraint on our deployed environments where we are seeing some timeout failures, mostly when creating PDF with Gutenberg.

We could increase the resources in the environments, but we are going to handle this programmatically.

When we batch, we follow the same process for all notifications. As we have built / tested this logic, we do not want to create a separate process for the PDF's. So we will just reduce the batch size to 1.

This means we generate and send a PDF to Notify one at a time.

We have reduced the delay to 2 seconds. This equates to 30 requests a minute way below the constraints imposed by Notify.