### PR TITLE
Add `return_requirement_id` to returns

### DIFF
--- a/app/models/return-log.model.js
+++ b/app/models/return-log.model.js
@@ -29,20 +29,28 @@ class ReturnLogModel extends BaseModel {
           to: 'licences.licenceRef'
         }
       },
-      returnSubmissions: {
-        relation: Model.HasManyRelation,
-        modelClass: 'return-submission.model',
-        join: {
-          from: 'returnLogs.id',
-          to: 'returnSubmissions.returnLogId'
-        }
-      },
       returnCycle: {
         relation: Model.HasOneRelation,
         modelClass: 'return-cycle.model',
         join: {
           from: 'returnLogs.returnCycleId',
           to: 'returnCycles.id'
+        }
+      },
+      returnRequirement: {
+        relation: Model.HasOneRelation,
+        modelClass: 'return-requirement.model',
+        join: {
+          from: 'returnLogs.returnRequirementId',
+          to: 'returnRequirements.id'
+        }
+      },
+      returnSubmissions: {
+        relation: Model.HasManyRelation,
+        modelClass: 'return-submission.model',
+        join: {
+          from: 'returnLogs.id',
+          to: 'returnSubmissions.returnLogId'
         }
       }
     }

--- a/app/models/return-requirement.model.js
+++ b/app/models/return-requirement.model.js
@@ -28,6 +28,14 @@ class ReturnRequirementModel extends BaseModel {
           to: 'points.id'
         }
       },
+      returnLogs: {
+        relation: Model.HasManyRelation,
+        modelClass: 'return-log.model',
+        join: {
+          from: 'returnRequirements.id',
+          to: 'returnLogs.returnRequirementId'
+        }
+      },
       returnRequirementPurposes: {
         relation: Model.HasManyRelation,
         modelClass: 'return-requirement-purpose.model',

--- a/app/services/return-logs/generate-return-log.service.js
+++ b/app/services/return-logs/generate-return-log.service.js
@@ -19,7 +19,7 @@ const featureFlagsConfig = require('../../../config/feature-flags.config.js')
  * @returns {object} the generated return log data
  */
 function go(returnRequirement, returnCycle) {
-  const { reference, reportingFrequency, returnVersion } = returnRequirement
+  const { id: returnRequirementId, reference, reportingFrequency, returnVersion } = returnRequirement
   const { dueDate, endDate: returnCycleEndDate, id: returnCycleId, startDate: returnCycleStartDate } = returnCycle
 
   const startDate = _startDate(returnVersion, returnCycleStartDate)
@@ -34,6 +34,7 @@ function go(returnRequirement, returnCycle) {
     returnCycleId,
     returnsFrequency: reportingFrequency,
     returnReference: reference.toString(),
+    returnRequirementId,
     source: 'WRLS',
     startDate,
     status: 'due'

--- a/db/migrations/legacy/20221108006001_returns-returns.js
+++ b/db/migrations/legacy/20221108006001_returns-returns.js
@@ -20,6 +20,7 @@ exports.up = function (knex) {
     table.jsonb('metadata')
     table.date('received_date')
     table.string('return_requirement').notNullable()
+    table.uuid('return_requirement_id')
     table.date('due_date')
     table.boolean('under_query').notNullable().defaultTo(false)
     table.string('under_query_comment')

--- a/db/migrations/public/20251002093242_alter-return-logs-view.js
+++ b/db/migrations/public/20251002093242_alter-return-logs-view.js
@@ -1,0 +1,64 @@
+'use strict'
+
+const viewName = 'return_logs'
+
+exports.up = function (knex) {
+  return knex.schema.dropViewIfExists(viewName).createView(viewName, (view) => {
+    // NOTE: We have commented out unused columns from the source table
+    view.as(
+      knex('returns').withSchema('returns').select([
+        'return_id AS id',
+        'id AS return_id',
+        // 'regime', // always 'water'
+        // 'licence_type', // always 'abstraction'
+        'licence_ref',
+        'start_date',
+        'end_date',
+        'returns_frequency',
+        'status',
+        'source',
+        'metadata',
+        'received_date',
+        'return_requirement as return_reference',
+        'return_requirement_id',
+        'due_date',
+        'under_query',
+        // 'under_query_comment',
+        // 'is_test',
+        'return_cycle_id',
+        'created_at',
+        'updated_at'
+      ])
+    )
+  })
+}
+
+exports.down = function (knex) {
+  return knex.schema.dropViewIfExists(viewName).createView(viewName, (view) => {
+    // NOTE: We have commented out unused columns from the source table
+    view.as(
+      knex('returns').withSchema('returns').select([
+        'return_id AS id',
+        'id AS return_id',
+        // 'regime', // always 'water'
+        // 'licence_type', // always 'abstraction'
+        'licence_ref',
+        'start_date',
+        'end_date',
+        'returns_frequency',
+        'status',
+        'source',
+        'metadata',
+        'received_date',
+        'return_requirement as return_reference',
+        'due_date',
+        'under_query',
+        // 'under_query_comment',
+        // 'is_test',
+        'return_cycle_id',
+        'created_at',
+        'updated_at'
+      ])
+    )
+  })
+}

--- a/test/models/return-log.model.test.js
+++ b/test/models/return-log.model.test.js
@@ -4,7 +4,7 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, beforeEach, before } = (exports.lab = Lab.script())
+const { describe, it, before } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -24,11 +24,11 @@ const ReturnLogModel = require('../../app/models/return-log.model.js')
 describe('Return Log model', () => {
   let testRecord
 
-  beforeEach(async () => {
-    testRecord = await ReturnLogHelper.add()
-  })
-
   describe('Basic query', () => {
+    before(async () => {
+      testRecord = await ReturnLogHelper.add()
+    })
+
     it('can successfully run a basic query', async () => {
       const result = await ReturnLogModel.query().findById(testRecord.id)
 
@@ -41,7 +41,7 @@ describe('Return Log model', () => {
     describe('when linking to licence', () => {
       let testLicence
 
-      beforeEach(async () => {
+      before(async () => {
         testLicence = await LicenceHelper.add()
 
         const { licenceRef } = testLicence
@@ -68,7 +68,6 @@ describe('Return Log model', () => {
 
     describe('when linking to return cycles', () => {
       let returnCycle
-      let testRecord
 
       before(async () => {
         returnCycle = await ReturnCycleHelper.select()
@@ -95,7 +94,7 @@ describe('Return Log model', () => {
     describe('when linking to return requirements', () => {
       let testReturnRequirements
 
-      beforeEach(async () => {
+      before(async () => {
         testReturnRequirements = await ReturnRequirementHelper.add()
 
         testRecord = await ReturnLogHelper.add({ returnRequirementId: testReturnRequirements.id })
@@ -121,7 +120,9 @@ describe('Return Log model', () => {
     describe('when linking to return submissions', () => {
       let returnSubmissions
 
-      beforeEach(async () => {
+      before(async () => {
+        testRecord = await ReturnLogHelper.add()
+
         const { id: returnLogId } = testRecord
 
         returnSubmissions = []

--- a/test/models/return-log.model.test.js
+++ b/test/models/return-log.model.test.js
@@ -101,7 +101,7 @@ describe('Return Log model', () => {
         expect(query).to.exist()
       })
 
-      it('can eager load the return requirement', async () => {
+      it('can eager load the return requirements', async () => {
         const result = await ReturnLogModel.query().findById(testRecord.id).withGraphFetched('returnRequirement')
 
         expect(result).to.be.instanceOf(ReturnLogModel)

--- a/test/models/return-log.model.test.js
+++ b/test/models/return-log.model.test.js
@@ -42,9 +42,9 @@ describe('Return Log model', () => {
     testReturnSubmissions = []
     for (let i = 0; i < 2; i++) {
       const version = i
-      const testReturnSubmission = await ReturnSubmissionHelper.add({ returnLogId: testRecord.id, version })
+      const returnSubmission = await ReturnSubmissionHelper.add({ returnLogId: testRecord.id, version })
 
-      testReturnSubmissions.push(testReturnSubmission)
+      testReturnSubmissions.push(returnSubmission)
     }
   })
 

--- a/test/models/return-requirement.model.test.js
+++ b/test/models/return-requirement.model.test.js
@@ -25,6 +25,7 @@ const ReturnRequirementModel = require('../../app/models/return-requirement.mode
 describe('Return Requirement model', () => {
   let testPoint
   let testRecord
+  let testReturnLogs
   let testReturnRequirementPurposes
   let testReturnVersion
 
@@ -44,6 +45,13 @@ describe('Return Requirement model', () => {
       })
 
       testReturnRequirementPurposes.push(returnRequirementPurpose)
+    }
+
+    testReturnLogs = []
+    for (let i = 0; i < 2; i++) {
+      const returnLog = await ReturnLogHelper.add({ returnRequirementId: testRecord.id })
+
+      testReturnLogs.push(returnLog)
     }
   })
 
@@ -78,19 +86,6 @@ describe('Return Requirement model', () => {
     })
 
     describe('when linking to return logs', () => {
-      let returnLogs
-
-      before(async () => {
-        const { id: returnRequirementId } = testRecord
-
-        returnLogs = []
-        for (let i = 0; i < 2; i++) {
-          const returnLog = await ReturnLogHelper.add({ returnRequirementId })
-
-          returnLogs.push(returnLog)
-        }
-      })
-
       it('can successfully run a related query', async () => {
         const query = await ReturnRequirementModel.query().innerJoinRelated('returnLogs')
 
@@ -105,8 +100,8 @@ describe('Return Requirement model', () => {
 
         expect(result.returnLogs).to.be.an.array()
         expect(result.returnLogs[0]).to.be.an.instanceOf(ReturnLogModel)
-        expect(result.returnLogs).to.include(returnLogs[0])
-        expect(result.returnLogs).to.include(returnLogs[1])
+        expect(result.returnLogs).to.include(testReturnLogs[0])
+        expect(result.returnLogs).to.include(testReturnLogs[1])
       })
     })
 

--- a/test/models/return-requirement.model.test.js
+++ b/test/models/return-requirement.model.test.js
@@ -10,6 +10,8 @@ const { expect } = Code
 // Test helpers
 const PointHelper = require('../support/helpers/point.helper.js')
 const PointModel = require('../../app/models/point.model.js')
+const ReturnLogHelper = require('../support/helpers/return-log.helper.js')
+const ReturnLogModel = require('../../app/models/return-log.model.js')
 const ReturnRequirementHelper = require('../support/helpers/return-requirement.helper.js')
 const ReturnRequirementPointHelper = require('../support/helpers/return-requirement-point.helper.js')
 const ReturnRequirementPurposeHelper = require('../support/helpers/return-requirement-purpose.helper.js')
@@ -72,6 +74,39 @@ describe('Return Requirement model', () => {
         expect(result.points).to.have.length(1)
         expect(result.points[0]).to.be.an.instanceOf(PointModel)
         expect(result.points[0]).to.equal(testPoint, { skip: ['createdAt', 'updatedAt'] })
+      })
+    })
+
+    describe('when linking to return logs', () => {
+      let returnLogs
+
+      before(async () => {
+        const { id: returnRequirementId } = testRecord
+
+        returnLogs = []
+        for (let i = 0; i < 2; i++) {
+          const returnLog = await ReturnLogHelper.add({ returnRequirementId })
+
+          returnLogs.push(returnLog)
+        }
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await ReturnRequirementModel.query().innerJoinRelated('returnLogs')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the return logs', async () => {
+        const result = await ReturnRequirementModel.query().findById(testRecord.id).withGraphFetched('returnLogs')
+
+        expect(result).to.be.instanceOf(ReturnRequirementModel)
+        expect(result.id).to.equal(testRecord.id)
+
+        expect(result.returnLogs).to.be.an.array()
+        expect(result.returnLogs[0]).to.be.an.instanceOf(ReturnLogModel)
+        expect(result.returnLogs).to.include(returnLogs[0])
+        expect(result.returnLogs).to.include(returnLogs[1])
       })
     })
 

--- a/test/services/return-logs/generate-return-log.service.test.js
+++ b/test/services/return-logs/generate-return-log.service.test.js
@@ -87,6 +87,7 @@ describe('Return Logs - Generate Return Log service', () => {
         },
         returnCycleId: '6889b98d-964f-4966-b6d6-bf511d6526a9',
         returnReference: '16999651',
+        returnRequirementId: '4bc1efa7-10af-4958-864e-32acae5c6fa4',
         returnsFrequency: 'day',
         source: 'WRLS',
         startDate: new Date('2025-04-01'),


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5254

Update the legacy and public migrations to include the `return_requirement_id` field, and update both models to add the relationship between the return logs and the return requirements, plus unit tests.

Then update the logic where return logs are created from return requirements to ensure the `return_requirement_id` is assigned.