### PR TITLE
Set returned at date on returned letters

### DIFF
--- a/app/controllers/notifications.controller.js
+++ b/app/controllers/notifications.controller.js
@@ -5,6 +5,7 @@
  * @module NotificationsController
  */
 
+const SubmitReturnedLetterService = require('../services/notifications/submit-returned-letter.service.js')
 const ViewNotificationService = require('../services/notifications/view-notification.service.js')
 
 const NO_CONTENT_STATUS_CODE = 204
@@ -21,6 +22,8 @@ async function returnedLetter(request, h) {
   const { notification_id: notificationId, reference } = request.payload
 
   global.GlobalNotifier.omg('Return letter callback triggered', { notificationId, reference })
+
+  await SubmitReturnedLetterService.go(notificationId)
 
   return h.response().code(NO_CONTENT_STATUS_CODE)
 }

--- a/app/services/notifications/submit-returned-letter.service.js
+++ b/app/services/notifications/submit-returned-letter.service.js
@@ -1,0 +1,24 @@
+'use strict'
+
+/**
+ * Orchestrates updating the returnedAt date for a letter
+ *
+ * @module SubmitReturnedLetterService
+ */
+
+const NotificationModel = require('../../models/notification.model.js')
+
+/**
+ * Orchestrates updating the returnedAt date for a letter
+ *
+ * @param {string} notifyId - The id of the notification
+ *
+ * @returns {Promise<object>} - The returned database object
+ */
+async function go(notifyId) {
+  await NotificationModel.query().patch({ returnedAt: new Date() }).where('notifyId', notifyId)
+}
+
+module.exports = {
+  go
+}

--- a/test/services/notifications/submit-returned-letter.service.test.js
+++ b/test/services/notifications/submit-returned-letter.service.test.js
@@ -1,0 +1,46 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { expect } = Code
+
+const { generateUUID, timestampForPostgres, today } = require('../../../app/lib/general.lib.js')
+
+// Test helpers
+const EventHelper = require('../../support/helpers/event.helper.js')
+const NotificationHelper = require('../../support/helpers/notification.helper.js')
+const NotificationModel = require('../../../app/models/notification.model.js')
+
+// Thing under test
+const SubmitReturnedLetterService = require('../../../app/services/notifications/submit-returned-letter.service.js')
+
+describe('Submit Returned Letter Service', () => {
+  let eventId
+  let notifyId
+  const todaysDate = today()
+
+  beforeEach(async () => {
+    const event = await EventHelper.add({
+      type: 'notification',
+      subtype: 'returnsInvitation'
+    })
+
+    eventId = event.id
+    notifyId = generateUUID()
+
+    await NotificationHelper.add({ eventId, notifyId, createdAt: timestampForPostgres() })
+  })
+
+  describe('when called with a valid notifyId', () => {
+    it('updates the returnedAt date for the provided notification id', async () => {
+      await SubmitReturnedLetterService.go(notifyId)
+
+      const updatedResult = await NotificationModel.query().where('notifyId', notifyId)
+
+      expect(updatedResult[0].returnedAt).to.equal(todaysDate)
+    })
+  })
+})


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5296

As part of the work to send out letters to licence holders we need a way to be able to know when a letter has been returned. GovNotify allows you to set up a callback url: https://docs.notifications.service.gov.uk/node.html#returned-letters

When this happens we want to be able to register when we were notified that the letter was returned so this PR sets the returned at date when we receive a request from GovNotify on the callback url.