### PR TITLE
Void return logs even if no requirements present

### DIFF
--- a/app/services/return-logs/process-licence-return-logs.service.js
+++ b/app/services/return-logs/process-licence-return-logs.service.js
@@ -86,10 +86,6 @@ async function _processReturnCycle(returnCycle, returnRequirements, changeDate, 
     )
   })
 
-  if (requirementsToProcess.length === 0) {
-    return
-  }
-
   const generatedReturnLogIds = []
 
   // If there is no licenceEndDate or if there is a licenceEndDate and the return cycle starts before the licenceEndDate

--- a/test/services/return-logs/process-licence-return-logs.service.test.js
+++ b/test/services/return-logs/process-licence-return-logs.service.test.js
@@ -119,7 +119,7 @@ describe('Process licence return logs service', () => {
           await ProcessLicenceReturnLogsService.go(licenceId, changeDate)
 
           expect(createReturnLogsStub.callCount).to.equal(1)
-          expect(voidReturnLogsStub.callCount).to.equal(2)
+          expect(voidReturnLogsStub.callCount).to.equal(4)
         })
       })
     })
@@ -184,7 +184,7 @@ describe('Process licence return logs service', () => {
         createReturnLogsStub.resolves()
       })
 
-      describe('but the change date means only an "all-year" return cycle needs processing', () => {
+      describe('but an "all-year" return cycle needs processing', () => {
         beforeEach(() => {
           returnCycleModelStub.resolves([ReturnCyclesFixture.returnCycle(false)])
         })
@@ -193,7 +193,7 @@ describe('Process licence return logs service', () => {
           await ProcessLicenceReturnLogsService.go(licenceId, changeDate)
 
           expect(createReturnLogsStub.called).to.be.false()
-          expect(voidReturnLogsStub.called).to.be.false()
+          expect(voidReturnLogsStub.called).to.be.true()
         })
       })
     })
@@ -204,7 +204,7 @@ describe('Process licence return logs service', () => {
         createReturnLogsStub.resolves()
       })
 
-      describe('but the change date means only a "summer" return cycle needs processing', () => {
+      describe('but a "summer" return cycle needs processing', () => {
         beforeEach(() => {
           returnCycleModelStub.resolves([ReturnCyclesFixture.returnCycle(true)])
         })
@@ -213,7 +213,7 @@ describe('Process licence return logs service', () => {
           await ProcessLicenceReturnLogsService.go(licenceId, changeDate)
 
           expect(createReturnLogsStub.called).to.be.false()
-          expect(voidReturnLogsStub.called).to.be.false()
+          expect(voidReturnLogsStub.called).to.be.true()
         })
       })
     })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5302

A user found an issue when making a historic change to a return version. When swapping return cycle type (from summer to all year) it was noticed that we were not voiding the existing return logs for the previous return version. This was due to us exiting the loop early if there were no return requirements to be created for the return cycle.

This PR removes that early exit and allows the void service to be called.