### PR TITLE
Add standard journey notice types

### DIFF
--- a/app/presenters/notices/setup/notice-type.presenter.js
+++ b/app/presenters/notices/setup/notice-type.presenter.js
@@ -13,16 +13,20 @@
  * @returns {object} - The data formatted for the view template
  */
 function go(session) {
-  const { checkPageVisited, id: sessionId, noticeType } = session
+  const { checkPageVisited, id: sessionId, noticeType, journey } = session
 
   return {
-    backLink: _backLink(sessionId, checkPageVisited),
-    options: _options(noticeType),
+    backLink: _backLink(sessionId, checkPageVisited, journey),
+    options: _options(noticeType, journey),
     pageTitle: 'Select the notice type'
   }
 }
 
-function _backLink(sessionId, checkPageVisited) {
+function _backLink(sessionId, checkPageVisited, journey) {
+  if (journey === 'standard') {
+    return `/system/notices`
+  }
+
   if (checkPageVisited) {
     return `/system/notices/setup/${sessionId}/check-notice-type`
   }
@@ -30,7 +34,22 @@ function _backLink(sessionId, checkPageVisited) {
   return `/system/notices/setup/${sessionId}/licence`
 }
 
-function _options(noticeType) {
+function _options(noticeType, journey) {
+  if (journey === 'standard') {
+    return [
+      {
+        checked: noticeType === 'invitations',
+        value: 'invitations',
+        text: 'Returns invitation'
+      },
+      {
+        checked: noticeType === 'reminders',
+        value: 'reminders',
+        text: 'Returns reminder'
+      }
+    ]
+  }
+
   return [
     {
       checked: noticeType === 'invitations',

--- a/app/services/notices/setup/submit-notice-type.service.js
+++ b/app/services/notices/setup/submit-notice-type.service.js
@@ -35,7 +35,7 @@ async function go(sessionId, payload, yar) {
 
     await _save(session, payload)
 
-    return _redirect(payload.noticeType, session.checkPageVisited)
+    return _redirect(payload.noticeType, session.checkPageVisited, session.journey)
   }
 
   const pageData = NoticeTypePresenter.go(session)
@@ -47,10 +47,16 @@ async function go(sessionId, payload, yar) {
   }
 }
 
-function _redirect(noticeType, checkPageVisited) {
+function _redirect(noticeType, checkPageVisited, journey) {
   if (noticeType === 'returnForms' && !checkPageVisited) {
     return {
       redirectUrl: 'return-forms'
+    }
+  }
+
+  if (journey === 'standard') {
+    return {
+      redirectUrl: 'returns-period'
     }
   }
 

--- a/test/presenters/notices/setup/notice-type.presenter.test.js
+++ b/test/presenters/notices/setup/notice-type.presenter.test.js
@@ -18,83 +18,164 @@ describe('Notice Type Presenter', () => {
   })
 
   describe('when called', () => {
-    it('returns page data for the view', () => {
-      const result = NoticeTypePresenter.go(session)
+    describe('and the journey is for "adhoc"', () => {
+      beforeEach(() => {
+        session.journey = 'adhoc'
+      })
 
-      expect(result).to.equal({
-        backLink: '/system/notices/setup/123/licence',
-        options: [
-          {
-            checked: false,
-            text: 'Standard returns invitation',
-            value: 'invitations'
-          },
-          {
-            checked: false,
-            text: 'Submit using a paper form invitation',
-            value: 'returnForms'
-          }
-        ],
-        pageTitle: 'Select the notice type'
+      it('returns page data for the view', () => {
+        const result = NoticeTypePresenter.go(session)
+
+        expect(result).to.equal({
+          backLink: '/system/notices/setup/123/licence',
+          options: [
+            {
+              checked: false,
+              text: 'Standard returns invitation',
+              value: 'invitations'
+            },
+            {
+              checked: false,
+              text: 'Submit using a paper form invitation',
+              value: 'returnForms'
+            }
+          ],
+          pageTitle: 'Select the notice type'
+        })
+      })
+
+      describe('when a previous "noticeType" has been selected', () => {
+        describe('and the selected notice type was "invitations"', () => {
+          beforeEach(() => {
+            session.noticeType = 'invitations'
+          })
+
+          it('returns the invitations checked', () => {
+            const result = NoticeTypePresenter.go(session)
+
+            expect(result.options).to.equal([
+              {
+                checked: true,
+                text: 'Standard returns invitation',
+                value: 'invitations'
+              },
+              {
+                checked: false,
+                text: 'Submit using a paper form invitation',
+                value: 'returnForms'
+              }
+            ])
+          })
+        })
+
+        describe('and the selected notice type was "returnForms"', () => {
+          beforeEach(() => {
+            session.noticeType = 'returnForms'
+          })
+
+          it('returns the Return forms checked', () => {
+            const result = NoticeTypePresenter.go(session)
+
+            expect(result.options).to.equal([
+              {
+                checked: false,
+                text: 'Standard returns invitation',
+                value: 'invitations'
+              },
+              {
+                checked: true,
+                text: 'Submit using a paper form invitation',
+                value: 'returnForms'
+              }
+            ])
+          })
+        })
+
+        describe('and the page has been visited', () => {
+          beforeEach(() => {
+            session.checkPageVisited = true
+          })
+
+          it('correctly set the back link to the check page', () => {
+            const result = NoticeTypePresenter.go(session)
+
+            expect(result.backLink).to.equal('/system/notices/setup/123/check-notice-type')
+          })
+        })
       })
     })
 
-    describe('when a previous "noticeType" has been selected', () => {
-      describe('and the selected notice type was "invitations"', () => {
-        beforeEach(() => {
-          session.noticeType = 'invitations'
-        })
+    describe('and the journey is for "standard"', () => {
+      beforeEach(() => {
+        session.journey = 'standard'
+      })
 
-        it('returns the invitations checked', () => {
-          const result = NoticeTypePresenter.go(session)
+      it('returns page data for the view', () => {
+        const result = NoticeTypePresenter.go(session)
 
-          expect(result.options).to.equal([
+        expect(result).to.equal({
+          backLink: '/system/notices',
+          options: [
             {
-              checked: true,
-              text: 'Standard returns invitation',
+              checked: false,
+              text: 'Returns invitation',
               value: 'invitations'
             },
             {
               checked: false,
-              text: 'Submit using a paper form invitation',
-              value: 'returnForms'
+              text: 'Returns reminder',
+              value: 'reminders'
             }
-          ])
+          ],
+          pageTitle: 'Select the notice type'
         })
       })
 
-      describe('and the selected notice type was "returnForms"', () => {
-        beforeEach(() => {
-          session.noticeType = 'returnForms'
+      describe('when a previous "noticeType" has been selected', () => {
+        describe('and the selected notice type was "invitations"', () => {
+          beforeEach(() => {
+            session.noticeType = 'invitations'
+          })
+
+          it('returns the invitations checked', () => {
+            const result = NoticeTypePresenter.go(session)
+
+            expect(result.options).to.equal([
+              {
+                checked: true,
+                text: 'Returns invitation',
+                value: 'invitations'
+              },
+              {
+                checked: false,
+                text: 'Returns reminder',
+                value: 'reminders'
+              }
+            ])
+          })
         })
 
-        it('returns the Return forms checked', () => {
-          const result = NoticeTypePresenter.go(session)
+        describe('and the selected notice type was "reminders"', () => {
+          beforeEach(() => {
+            session.noticeType = 'reminders'
+          })
 
-          expect(result.options).to.equal([
-            {
-              checked: false,
-              text: 'Standard returns invitation',
-              value: 'invitations'
-            },
-            {
-              checked: true,
-              text: 'Submit using a paper form invitation',
-              value: 'returnForms'
-            }
-          ])
-        })
-      })
+          it('returns the Return forms checked', () => {
+            const result = NoticeTypePresenter.go(session)
 
-      describe('and the page has been visited', () => {
-        beforeEach(() => {
-          session.checkPageVisited = true
-        })
-
-        it('correctly set the back link to the check page', () => {
-          const result = NoticeTypePresenter.go(session)
-
-          expect(result.backLink).to.equal('/system/notices/setup/123/check-notice-type')
+            expect(result.options).to.equal([
+              {
+                checked: false,
+                text: 'Returns invitation',
+                value: 'invitations'
+              },
+              {
+                checked: true,
+                text: 'Returns reminder',
+                value: 'reminders'
+              }
+            ])
+          })
         })
       })
     })

--- a/test/services/notices/setup/submit-notice-type.service.test.js
+++ b/test/services/notices/setup/submit-notice-type.service.test.js
@@ -133,6 +133,34 @@ describe('Notice Type Service', () => {
         })
       })
     })
+
+    describe('and the journey is for "standard"', () => {
+      beforeEach(async () => {
+        sessionData.journey = 'standard'
+
+        session = await SessionHelper.add({ data: sessionData })
+      })
+
+      it('should return', async () => {
+        const result = await SubmitNoticeTypeService.go(session.id, payload, yarStub)
+
+        expect(result).to.equal({ redirectUrl: 'returns-period' })
+      })
+    })
+
+    describe('and the journey is for "adhoc"', () => {
+      beforeEach(async () => {
+        sessionData.journey = 'adhoc'
+
+        session = await SessionHelper.add({ data: sessionData })
+      })
+
+      it('should return', async () => {
+        const result = await SubmitNoticeTypeService.go(session.id, payload, yarStub)
+
+        expect(result).to.equal({ redirectUrl: 'check-notice-type' })
+      })
+    })
   })
 
   describe('when validation fails', () => {


### PR DESCRIPTION
We are updating the 'standard' journey to allow the user to select the notice type. This is replacing the existing two links on the manage page.

A new button will be added in later changes to redirect the use to this page, where they can select the notice type.

The backlink had been added to redirect to the previous page (where the button will be added)