### PR TITLE
Migration - Add `overall_status` and `status_counts` columns to `events`

### DIFF
--- a/app/models/event.model.js
+++ b/app/models/event.model.js
@@ -16,7 +16,7 @@ class EventModel extends BaseModel {
 
   // Defining which fields contain json allows us to insert an object without needing to stringify it first
   static get jsonAttributes() {
-    return ['licences', 'metadata']
+    return ['licences', 'metadata', 'statusCounts']
   }
 
   static get relationMappings() {

--- a/db/migrations/legacy/20221108007004_water-events.js
+++ b/db/migrations/legacy/20221108007004_water-events.js
@@ -17,6 +17,8 @@ exports.up = function (knex) {
     table.string('comment')
     table.jsonb('metadata')
     table.string('status')
+    table.string('overall_status')
+    table.jsonb('status_counts')
 
     // Legacy timestamps
     table.timestamp('created', { precision: 0, useTz: false })

--- a/db/migrations/public/20251007105036_alter-events-view.js
+++ b/db/migrations/public/20251007105036_alter-events-view.js
@@ -1,0 +1,49 @@
+'use strict'
+
+const viewName = 'events'
+
+exports.up = function (knex) {
+  return knex.schema.dropViewIfExists(viewName).createView(viewName, (view) => {
+    // NOTE: We have commented out unused columns from the source table
+    view.as(
+      knex('events').withSchema('water').select([
+        'event_id AS id',
+        'reference_code',
+        'type',
+        'subtype',
+        'issuer',
+        'licences',
+        'entities',
+        // 'comment',
+        'metadata',
+        'status',
+        'overall_status',
+        'status_counts',
+        'created AS created_at',
+        'modified AS updated_at'
+      ])
+    )
+  })
+}
+
+exports.down = function (knex) {
+  return knex.schema.dropViewIfExists(viewName).createView(viewName, (view) => {
+    // NOTE: We have commented out unused columns from the source table
+    view.as(
+      knex('events').withSchema('water').select([
+        'event_id AS id',
+        'reference_code',
+        'type',
+        'subtype',
+        'issuer',
+        'licences',
+        'entities',
+        // 'comment',
+        'metadata',
+        'status',
+        'created AS created_at',
+        'modified AS updated_at'
+      ])
+    )
+  })
+}

--- a/test/services/jobs/notification-status/process-notification-status.service.test.js
+++ b/test/services/jobs/notification-status/process-notification-status.service.test.js
@@ -332,6 +332,8 @@ describe('Job - Notifications - Process Notification Status service', () => {
             metadata: { error: 1 },
             referenceCode: 'RINV-LX4P57',
             status: 'completed',
+            statusCounts: null,
+            overallStatus: null,
             subtype: 'returnInvitation',
             type: 'notification'
           },
@@ -420,8 +422,10 @@ describe('Job - Notifications - Process Notification Status service', () => {
           issuer: 'test.user@defra.gov.uk',
           licences: ['11/111'],
           metadata: {},
+          overallStatus: null,
           referenceCode: 'RINV-402AGB',
           status: 'completed',
+          statusCounts: null,
           subtype: 'returnInvitation',
           type: 'notification'
         },

--- a/test/services/notices/setup/batch-notifications.service.test.js
+++ b/test/services/notices/setup/batch-notifications.service.test.js
@@ -254,8 +254,10 @@ describe('Notices - Setup - Batch Notifications service', () => {
           issuer: 'test.user@defra.gov.uk',
           licences: event.licences,
           metadata: { error: 0 },
+          overallStatus: null,
           referenceCode,
           status: 'completed',
+          statusCounts: null,
           subtype: 'returnInvitation',
           type: 'notification',
           updatedAt: refreshedEvent.updatedAt
@@ -287,8 +289,10 @@ describe('Notices - Setup - Batch Notifications service', () => {
           issuer: 'test.user@defra.gov.uk',
           licences: event.licences,
           metadata: { error: 5 },
+          overallStatus: null,
           referenceCode,
           status: 'completed',
+          statusCounts: null,
           subtype: 'returnInvitation',
           type: 'notification',
           updatedAt: refreshedEvent.updatedAt

--- a/test/services/notices/setup/create-notice.service.test.js
+++ b/test/services/notices/setup/create-notice.service.test.js
@@ -80,8 +80,10 @@ describe('Notices - Setup - Create Notice service', () => {
           },
           sent: 2783
         },
+        overallStatus: null,
         referenceCode,
         status: 'started',
+        statusCounts: null,
         subtype: 'returnInvitation',
         type: 'notification',
         updatedAt: createdResult.updatedAt

--- a/test/services/notices/setup/submit-check.service.test.js
+++ b/test/services/notices/setup/submit-check.service.test.js
@@ -89,6 +89,8 @@ describe('Notices - Setup - Submit Check service', () => {
 
       const event = await EventModel.query().findById(result)
       delete event.entities
+      delete event.overallStatus
+      delete event.statusCounts
 
       const args = BatchNotificationsService.go.firstCall.args
 

--- a/test/services/notices/setup/update-event.service.test.js
+++ b/test/services/notices/setup/update-event.service.test.js
@@ -48,8 +48,10 @@ describe('Notices - Setup - Update event service', () => {
           error: errorCount,
           name: 'some existing data'
         },
+        overallStatus: null,
         referenceCode: null,
         status: 'completed',
+        statusCounts: null,
         subtype: 'returnReminder',
         type: 'notification',
         updatedAt: updatedResult.updatedAt
@@ -87,8 +89,10 @@ describe('Notices - Setup - Update event service', () => {
           error: 10,
           name: 'some existing data'
         },
+        overallStatus: null,
         referenceCode: null,
         status: 'completed',
+        statusCounts: null,
         subtype: 'returnReminder',
         type: 'notification',
         updatedAt: updatedResult.updatedAt


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5306

Following on from PR https://github.com/DEFRA/water-abstraction-service/pull/2728 where columns `overall_status` and `status_counts` were added to the `events` table and populated.

This PR is going to add the new columns to our legacy migration and view.