### PR TITLE
Fix broken notice legacy links

### DIFF
--- a/app/controllers/notices-setup.controller.js
+++ b/app/controllers/notices-setup.controller.js
@@ -266,10 +266,10 @@ async function viewReturnForms(request, h) {
 async function setup(request, h) {
   const {
     params: { journey },
-    query: { monitoringStationId }
+    query: { monitoringStationId, noticeType }
   } = request
 
-  const { sessionId, path } = await InitiateSessionService.go(journey, monitoringStationId)
+  const { sessionId, path } = await InitiateSessionService.go(journey, noticeType, monitoringStationId)
 
   return h.redirect(`/system/notices/setup/${sessionId}/${path}`)
 }

--- a/test/services/notices/setup/initiate-session.service.test.js
+++ b/test/services/notices/setup/initiate-session.service.test.js
@@ -20,6 +20,7 @@ const InitiateSessionService = require('../../../../app/services/notices/setup/i
 
 describe('Notices - Setup - Initiate Session service', () => {
   let journey
+  let noticeType
   let monitoringStationId
 
   afterEach(() => {
@@ -30,16 +31,21 @@ describe('Notices - Setup - Initiate Session service', () => {
     describe('and the journey is "standard"', () => {
       beforeEach(() => {
         journey = 'standard'
+        noticeType = null
         monitoringStationId = undefined
       })
 
-      it('initiates the session for the return invitations setup journey and returns the session ID and redirect path', async () => {
-        const result = await InitiateSessionService.go(journey, monitoringStationId)
+      it('returns the session Id and redirect path', async () => {
+        const result = await InitiateSessionService.go(journey, noticeType, monitoringStationId)
 
         expect(result).to.equal({
           sessionId: result.sessionId,
           path: 'notice-type'
         })
+      })
+
+      it('initiates the session for the standard journey ', async () => {
+        const result = await InitiateSessionService.go(journey, noticeType, monitoringStationId)
 
         const matchingSession = await SessionModel.query().findById(result.sessionId)
 
@@ -47,16 +53,49 @@ describe('Notices - Setup - Initiate Session service', () => {
           journey: 'standard'
         })
       })
+
+      describe('and there is a "noticeType"', () => {
+        beforeEach(() => {
+          noticeType = 'invitations'
+        })
+
+        it('returns the session Id and redirect path', async () => {
+          const result = await InitiateSessionService.go(journey, noticeType, monitoringStationId)
+
+          expect(result).to.equal({
+            sessionId: result.sessionId,
+            path: 'returns-period'
+          })
+        })
+
+        it('initiates the session for the standard journey for the "noticeType"', async () => {
+          const result = await InitiateSessionService.go(journey, noticeType, monitoringStationId)
+
+          const matchingSession = await SessionModel.query().findById(result.sessionId)
+
+          expect(matchingSession.data).to.equal(
+            {
+              journey: 'standard',
+              name: 'Returns: invitation',
+              noticeType: 'invitations',
+              notificationType: 'Returns invitation',
+              subType: 'returnInvitation'
+            },
+            { skip: ['referenceCode'] }
+          )
+        })
+      })
     })
 
     describe('and the journey is "adhoc"', () => {
       beforeEach(() => {
         journey = 'adhoc'
+        noticeType = null
         monitoringStationId = undefined
       })
 
       it('initiates the session for the ad-hoc notice setup journey and returns the session ID and redirect path', async () => {
-        const result = await InitiateSessionService.go(journey, monitoringStationId)
+        const result = await InitiateSessionService.go(journey, noticeType, monitoringStationId)
 
         expect(result).to.equal({
           sessionId: result.sessionId,
@@ -78,13 +117,14 @@ describe('Notices - Setup - Initiate Session service', () => {
         monitoringStationData = AbstractionAlertSessionData.get()
 
         journey = 'alerts'
+        noticeType = null
         monitoringStationId = monitoringStationData.monitoringStationId
 
         Sinon.stub(DetermineLicenceMonitoringStationsService, 'go').resolves(monitoringStationData)
       })
 
       it('initiates the session for the abstraction alerts setup journey and returns the session ID and redirect path', async () => {
-        const result = await InitiateSessionService.go(journey, monitoringStationId)
+        const result = await InitiateSessionService.go(journey, noticeType, monitoringStationId)
 
         expect(result).to.equal({
           sessionId: result.sessionId,


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5308

When the user is on the manage page, they click a link to start a notice journey. We updated the initiate session to work with buttons from the manage page.

This broke these links. For the time being we need to support multiple entires into the journeys.

This change puts the 'noticeType' back in the initiate session logic.

We are aware the back links will not function as expected. Other changes are being made to make this not an issue.