### PR TITLE
Refactor 'return-forms' to 'paper-return' notice type page

### DIFF
--- a/app/presenters/notices/setup/notice-type.presenter.js
+++ b/app/presenters/notices/setup/notice-type.presenter.js
@@ -5,6 +5,8 @@
  * @module NoticeTypePresenter
  */
 
+const { NoticeType, NoticeJourney } = require('../../../lib/static-lookups.lib.js')
+
 /**
  * Formats data for the `/notices/setup/{sessionId}/notice-type` page
  *
@@ -23,28 +25,37 @@ function go(session) {
 }
 
 function _backLink(sessionId, checkPageVisited, journey) {
-  if (journey === 'standard') {
-    return `/system/notices`
+  if (journey === NoticeJourney.STANDARD) {
+    return {
+      href: `/system/notices`,
+      text: 'Back'
+    }
   }
 
   if (checkPageVisited) {
-    return `/system/notices/setup/${sessionId}/check-notice-type`
+    return {
+      href: `/system/notices/setup/${sessionId}/check-notice-type`,
+      text: 'Back'
+    }
   }
 
-  return `/system/notices/setup/${sessionId}/licence`
+  return {
+    href: `/system/notices/setup/${sessionId}/licence`,
+    text: 'Back'
+  }
 }
 
 function _options(noticeType, journey) {
-  if (journey === 'standard') {
+  if (journey === NoticeJourney.STANDARD) {
     return [
       {
-        checked: noticeType === 'invitations',
-        value: 'invitations',
+        checked: noticeType === NoticeType.INVITATIONS,
+        value: NoticeType.INVITATIONS,
         text: 'Returns invitation'
       },
       {
-        checked: noticeType === 'reminders',
-        value: 'reminders',
+        checked: noticeType === NoticeType.REMINDERS,
+        value: NoticeType.REMINDERS,
         text: 'Returns reminder'
       }
     ]
@@ -52,13 +63,13 @@ function _options(noticeType, journey) {
 
   return [
     {
-      checked: noticeType === 'invitations',
-      value: 'invitations',
+      checked: noticeType === NoticeType.INVITATIONS,
+      value: NoticeType.INVITATIONS,
       text: 'Standard returns invitation'
     },
     {
-      checked: noticeType === 'returnForms',
-      value: 'returnForms',
+      checked: noticeType === NoticeType.PAPER_RETURN,
+      value: NoticeType.PAPER_RETURN,
       text: 'Submit using a paper form invitation'
     }
   ]

--- a/app/services/notices/setup/submit-notice-type.service.js
+++ b/app/services/notices/setup/submit-notice-type.service.js
@@ -1,7 +1,7 @@
 'use strict'
 
 /**
- * Orchestrates validating the data for `/notices/setup/{sessionId}/notice-type` page
+ * Orchestrates validating the data for the `/notices/setup/{sessionId}/notice-type` page
  *
  * @module SubmitNoticeTypeService
  */
@@ -11,11 +11,13 @@ const GeneralLib = require('../../../lib/general.lib.js')
 const NoticeTypePresenter = require('../../../presenters/notices/setup/notice-type.presenter.js')
 const NoticeTypeValidator = require('../../../validators/notices/setup/notice-type.validator.js')
 const SessionModel = require('../../../models/session.model.js')
+const { NoticeJourney, NoticeType } = require('../../../lib/static-lookups.lib.js')
+const { formatValidationResult } = require('../../../presenters/base.presenter.js')
 
 /**
- * Orchestrates validating the data for `/notices/setup/{sessionId}/notice-type` page
+ * Orchestrates validating the data for the `/notices/setup/{sessionId}/notice-type` page
  *
- * @param {string} sessionId
+ * @param {string} sessionId - The UUID for setup returns notice session record
  * @param {object} payload - The submitted form data
  * @param {object} yar - The Hapi `request.yar` session manager passed on by the controller
  *
@@ -48,13 +50,13 @@ async function go(sessionId, payload, yar) {
 }
 
 function _redirect(noticeType, checkPageVisited, journey) {
-  if (noticeType === 'returnForms' && !checkPageVisited) {
+  if (noticeType === NoticeType.PAPER_RETURN && !checkPageVisited) {
     return {
       redirectUrl: 'paper-return'
     }
   }
 
-  if (journey === 'standard') {
+  if (journey === NoticeJourney.STANDARD) {
     return {
       redirectUrl: 'returns-period'
     }
@@ -81,17 +83,9 @@ async function _save(session, payload) {
 }
 
 function _validate(payload) {
-  const validation = NoticeTypeValidator.go(payload)
+  const validationResult = NoticeTypeValidator.go(payload)
 
-  if (!validation.error) {
-    return null
-  }
-
-  const { message } = validation.error.details[0]
-
-  return {
-    text: message
-  }
+  return formatValidationResult(validationResult)
 }
 
 module.exports = {

--- a/app/views/notices/setup/notice-type.njk
+++ b/app/views/notices/setup/notice-type.njk
@@ -1,39 +1,15 @@
 {% extends 'layout.njk' %}
 
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
-{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 
-{% block breadcrumbs %}
-  {{
-  govukBackLink({
-    text: 'Back',
-    href: backLink
-  })
-  }}
-{% endblock %}
 
-{% block content %}
-  {% if error %}
-    {{ govukErrorSummary({
-      titleText: "There is a problem",
-      errorList: [
-        {
-          text: error.text,
-          href: "#noticeType"
-        }
-      ]
-    }) }}
-  {%endif%}
-
-  <div>
+{% block pageContent %}
     <form method="post">
       <input type="hidden" name="wrlsCrumb" value="{{wrlsCrumb}}"/>
-
       {{ govukRadios({
         name: "noticeType",
-        errorMessage: error,
+        errorMessage: error.noticeType,
         fieldset: {
           legend: {
             text: pageTitle,
@@ -46,5 +22,4 @@
 
       {{ govukButton({ text: "Continue", preventDoubleClick: true }) }}
     </form>
-  </div>
 {% endblock %}

--- a/test/presenters/notices/setup/notice-type.presenter.test.js
+++ b/test/presenters/notices/setup/notice-type.presenter.test.js
@@ -18,16 +18,15 @@ describe('Notice Type Presenter', () => {
   })
 
   describe('when called', () => {
-    describe('and the journey is for "adhoc"', () => {
-      beforeEach(() => {
-        session.journey = 'adhoc'
-      })
-
+    describe('and the journey is not "standard"', () => {
       it('returns page data for the view', () => {
         const result = NoticeTypePresenter.go(session)
 
         expect(result).to.equal({
-          backLink: '/system/notices/setup/123/licence',
+          backLink: {
+            href: '/system/notices/setup/123/licence',
+            text: 'Back'
+          },
           options: [
             {
               checked: false,
@@ -99,7 +98,10 @@ describe('Notice Type Presenter', () => {
           it('correctly set the back link to the check page', () => {
             const result = NoticeTypePresenter.go(session)
 
-            expect(result.backLink).to.equal('/system/notices/setup/123/check-notice-type')
+            expect(result.backLink).to.equal({
+              href: '/system/notices/setup/123/check-notice-type',
+              text: 'Back'
+            })
           })
         })
       })
@@ -114,7 +116,10 @@ describe('Notice Type Presenter', () => {
         const result = NoticeTypePresenter.go(session)
 
         expect(result).to.equal({
-          backLink: '/system/notices',
+          backLink: {
+            href: '/system/notices',
+            text: 'Back'
+          },
           options: [
             {
               checked: false,

--- a/test/services/notices/setup/notice-type.service.test.js
+++ b/test/services/notices/setup/notice-type.service.test.js
@@ -29,7 +29,10 @@ describe('Notice Type Service', () => {
 
       expect(result).to.equal({
         activeNavBar: 'manage',
-        backLink: `/system/notices/setup/${session.id}/licence`,
+        backLink: {
+          href: `/system/notices/setup/${session.id}/licence`,
+          text: 'Back'
+        },
         options: [
           {
             checked: false,

--- a/test/services/notices/setup/submit-notice-type.service.test.js
+++ b/test/services/notices/setup/submit-notice-type.service.test.js
@@ -148,10 +148,8 @@ describe('Notice Type Service', () => {
       })
     })
 
-    describe('and the journey is for "adhoc"', () => {
+    describe('and the journey is not "standard"', () => {
       beforeEach(async () => {
-        sessionData.journey = 'adhoc'
-
         session = await SessionHelper.add({ data: sessionData })
       })
 
@@ -173,8 +171,21 @@ describe('Notice Type Service', () => {
 
       expect(result).to.equal({
         activeNavBar: 'manage',
-        backLink: `/system/notices/setup/${session.id}/licence`,
-        error: { text: 'Select the notice type' },
+        backLink: {
+          href: `/system/notices/setup/${session.id}/licence`,
+          text: 'Back'
+        },
+        error: {
+          errorList: [
+            {
+              href: '#noticeType',
+              text: 'Select the notice type'
+            }
+          ],
+          noticeType: {
+            text: 'Select the notice type'
+          }
+        },
         options: [
           {
             checked: false,


### PR DESCRIPTION
We have implemented a 'return-forms' journey for notices on the adhoc journey. This needs to be updated to 'paper-forms'.

This change updates the notice type page.

This is part of a series of changes to refactor any use of 'return-forms' to 'paper-return'. 

Updated to template standard. 