### PR TITLE
Edit internal user

### DIFF
--- a/app/controllers/users.controller.js
+++ b/app/controllers/users.controller.js
@@ -5,10 +5,14 @@
  * @module UsersController
  */
 
+const Boom = require('@hapi/boom')
+
 const FetchLegacyIdService = require('../services/users/fetch-legacy-id.service.js')
 const IndexUsersService = require('../services/users/index-users.service.js')
+const SubmitEditUserInternalService = require('../services/users/internal/submit-edit-user.service.js')
 const SubmitIndexUsersService = require('../services/users/submit-index-users.service.js')
 const SubmitProfileDetailsService = require('../services/users/submit-profile-details.service.js')
+const ViewEditUserInternalService = require('../services/users/internal/view-edit-user.service.js')
 const ViewProfileDetailsService = require('../services/users/view-profile-details.service.js')
 const ViewUserExternalService = require('../services/users/external/view-user.service.js')
 const ViewUserInternalService = require('../services/users/internal/view-user.service.js')
@@ -25,6 +29,26 @@ async function index(request, h) {
   const pageData = await IndexUsersService.go(yar, auth, page)
 
   return h.view('users/index.njk', pageData)
+}
+
+async function submitEditUserInternal(request, h) {
+  const {
+    auth,
+    params: { id },
+    payload
+  } = request
+
+  const pageData = await SubmitEditUserInternalService.go(id, payload, auth)
+
+  if (Boom.isBoom(pageData)) {
+    return pageData
+  }
+
+  if (pageData.error) {
+    return h.view(`users/internal/edit-user.njk`, pageData)
+  }
+
+  return h.redirect(`/system/users/internal/${id}`)
 }
 
 async function submitIndex(request, h) {
@@ -63,6 +87,27 @@ async function submitViewUserExternal(request, h) {
   return _redirectToLegacy(id, h)
 }
 
+async function submitViewUserInternal(request, h) {
+  const { id } = request.params
+
+  return h.redirect(`/system/users/internal/${id}/edit`)
+}
+
+async function viewEditUserInternal(request, h) {
+  const {
+    auth,
+    params: { id }
+  } = request
+
+  const pageData = await ViewEditUserInternalService.go(id, auth)
+
+  if (Boom.isBoom(pageData)) {
+    return pageData
+  }
+
+  return h.view(`users/internal/edit-user.njk`, pageData)
+}
+
 async function viewProfileDetails(request, h) {
   const { userId } = request.auth.credentials.user
 
@@ -89,6 +134,7 @@ async function viewUserExternal(request, h) {
 
 async function viewUserInternal(request, h) {
   const {
+    auth,
     params: { id }
   } = request
 
@@ -96,7 +142,7 @@ async function viewUserInternal(request, h) {
     return _redirectToLegacy(id, h)
   }
 
-  const pageData = await ViewUserInternalService.go(id)
+  const pageData = await ViewUserInternalService.go(id, auth)
 
   return h.view('users/internal/view-user.njk', pageData)
 }
@@ -109,9 +155,12 @@ async function _redirectToLegacy(id, h) {
 
 module.exports = {
   index,
+  submitEditUserInternal,
   submitIndex,
   submitProfileDetails,
   submitViewUserExternal,
+  submitViewUserInternal,
+  viewEditUserInternal,
   viewProfileDetails,
   viewUserExternal,
   viewUserInternal

--- a/app/presenters/users/internal/edit-user.presenter.js
+++ b/app/presenters/users/internal/edit-user.presenter.js
@@ -1,50 +1,40 @@
 'use strict'
 
 /**
- * Formats data for internal users on the `/users/internal/{id}` page
- * @module UserPresenter
+ * Formats data for users on the `/users/internal/{userId}/edit` page
+ * @module EditUserPresenter
  */
 
 const { formatLongDateTime, sentenceCase } = require('../../base.presenter.js')
 
-const FeatureFlagsConfig = require('../../../../config/feature-flags.config.js')
-
 /**
- * Formats data for internal users on the `/users/internal/{id}` page
+ * Formats data for users on the `/users/internal/{userId}/edit` page
  *
  * @param {module:UserModel} user - The user instance
- * @param {boolean} canEdit - Whether the current user can edit the user being viewed, used to determine whether to show
- * the edit button on the page
+ * @param {object} allPermissionsDetails - All possible permissions details for internal users
+ * @param {string} permissions - The key of the user's current permissions
  *
  * @returns {object} The data formatted for the view template
  */
-function go(user, canEdit) {
+function go(user, allPermissionsDetails, permissions) {
   const { id, username } = user
 
   return {
-    backLink: _backLink(),
+    cancelLink: _cancelLink(id),
     id,
     lastSignedIn: _lastSignedIn(user),
     pageTitle: `User ${username}`,
     pageTitleCaption: 'Internal',
-    permissions: user.$permissions().label,
-    roles: _roles(user),
-    showEditButton: canEdit,
+    permissionOptions: _permissionOptions(allPermissionsDetails, permissions),
+    permissions,
     status: user.$status()
   }
 }
 
-function _backLink() {
-  if (FeatureFlagsConfig.enableUsersView) {
-    return {
-      href: '/system/users',
-      text: 'Go back to users'
-    }
-  }
-
+function _cancelLink(id) {
   return {
-    href: '/',
-    text: 'Go back to search'
+    href: `/system/users/internal/${id}`,
+    text: 'Cancel'
   }
 }
 
@@ -73,10 +63,26 @@ function _lastSignedIn(user) {
   return formatLongDateTime(lastLogin)
 }
 
-function _roles(user) {
+function _permissionOptions(allPermissionsDetails, permissions) {
+  return Object.entries(allPermissionsDetails)
+    .filter(([_key, { application }]) => {
+      return application === 'water_admin' || application === 'both'
+    })
+    .map(([key, { groups, label, roles }]) => {
+      const rolesHint = _rolesHint({ groups, roles })
+      return {
+        checked: key === permissions,
+        hint: { text: rolesHint },
+        text: label,
+        value: key
+      }
+    })
+}
+
+function _roles(groupsAndRoles) {
   const roles = []
 
-  for (const group of user.groups) {
+  for (const group of groupsAndRoles.groups) {
     for (const role of group.roles) {
       const { description, role: name } = role
 
@@ -84,7 +90,7 @@ function _roles(user) {
     }
   }
 
-  for (const role of user.roles) {
+  for (const role of groupsAndRoles.roles) {
     const { description, role: name } = role
 
     roles.push({ description, name: _convertToSentenceCase(name) })
@@ -95,6 +101,22 @@ function _roles(user) {
   })
 
   return roles
+}
+
+function _rolesHint(groupsAndRoles) {
+  const roles = _roles(groupsAndRoles)
+
+  if (roles.length === 0) {
+    return 'Grants no additional roles'
+  }
+
+  const roleList = roles
+    .map((role) => {
+      return role.name
+    })
+    .join(', ')
+
+  return `Grants: ${roleList}`
 }
 
 module.exports = {

--- a/app/routes/users.routes.js
+++ b/app/routes/users.routes.js
@@ -54,6 +54,42 @@ const routes = [
     }
   },
   {
+    method: 'POST',
+    path: '/users/internal/{id}',
+    options: {
+      handler: UsersController.submitViewUserInternal,
+      auth: {
+        access: {
+          scope: ['manage_accounts']
+        }
+      }
+    }
+  },
+  {
+    method: 'GET',
+    path: '/users/internal/{id}/edit',
+    options: {
+      handler: UsersController.viewEditUserInternal,
+      auth: {
+        access: {
+          scope: ['manage_accounts']
+        }
+      }
+    }
+  },
+  {
+    method: 'POST',
+    path: '/users/internal/{id}/edit',
+    options: {
+      handler: UsersController.submitEditUserInternal,
+      auth: {
+        access: {
+          scope: ['manage_accounts']
+        }
+      }
+    }
+  },
+  {
     method: 'GET',
     path: '/users/me/profile-details',
     options: {

--- a/app/services/users/internal/determine-user-editable.service.js
+++ b/app/services/users/internal/determine-user-editable.service.js
@@ -1,0 +1,45 @@
+'use strict'
+
+/**
+ * Determines whether a user can be edited for the `/users/internal/{id}` page and its edit page at
+ * `/users/internal/{id}/edit`
+ *
+ * @module DetermineUserEditableService
+ */
+
+const FetchUserService = require('./fetch-user.service.js')
+
+/**
+ * Determines whether a user can be edited for the `/users/internal/{id}` page and its edit page at
+ * `/users/internal/{id}/edit`
+ *
+ * These routes are scoped to the `manage_accounts` role, so only those users can access them.
+ *
+ * However, there is an additional check to determine whether the current user can edit the user being viewed.
+ *
+ * This is because only a user with the `super` permissions can edit another user with `super` permissions.
+ *
+ * @param {number} id - The ID of the user to edit
+ * @param {object} auth - The current user's authentication details from `request.auth`, used to determine what actions
+ * the user can take, i.e. whether they can edit the user or not
+ * @param {object} payload - The submitted form data (only relevant for the edit page)
+ *
+ * @returns {Promise<object>} The user being viewed and whether the current user can edit them
+ */
+async function go(id, auth, payload = { permissions: '' }) {
+  const currentUser = await FetchUserService.go(auth.credentials.user.id)
+  const user = await FetchUserService.go(id)
+
+  const existingPermissions = user.$permissions().key
+  const { permissions: newPermissions } = payload
+
+  const isSuper = currentUser.$permissions().key === 'super'
+
+  const canEdit = isSuper || (existingPermissions !== 'super' && newPermissions !== 'super')
+
+  return { canEdit, isSuper, user }
+}
+
+module.exports = {
+  go
+}

--- a/app/services/users/internal/fetch-all-permissions-details.service.js
+++ b/app/services/users/internal/fetch-all-permissions-details.service.js
@@ -1,0 +1,105 @@
+'use strict'
+
+/**
+ * Fetches all the possible permissions for a user for display on the /users/internal/{id}/edit page
+ * @module FetchAllPermissionsDetailsService
+ */
+
+const GroupModel = require('../../../models/group.model.js')
+const RoleModel = require('../../../models/role.model.js')
+
+const { userPermissions } = require('../../../lib/static-lookups.lib.js')
+
+/**
+ * Fetches all the possible permissions for a user for display on the /users/internal/{id}/edit page
+ *
+ * This allows us to display the full description of each permission, group and role on the edit page, giving the user
+ * sufficient information to enable them to select the correct permission.
+ *
+ * Currently only the role names are used as a hint, to keep the interface clean, but future enhancements could include
+ * the descriptions as well.
+ *
+ * @param {boolean} includeSuper - Whether to include the `super` permissions in the results. This is used when fetching
+ * permissions for a user with `super` permissions, as they are the only ones where it should be included in the option
+ * list on the edit page. For any other user, this should be false and the `super` permissions will not be included in
+ * the results.
+ *
+ * @returns {Promise<object>} the full set of permissions, groups and roles for display on the internal user edit page
+ */
+async function go(includeSuper = false) {
+  const uniqueGroupNames = _uniqueGroupNames()
+  const uniqueRoleNames = _uniqueRoleNames()
+
+  const allGroups = await GroupModel.query()
+    .select(['description', 'group', 'id'])
+    .whereIn('group', uniqueGroupNames)
+    .orderBy('group')
+    .withGraphFetched('roles')
+    .modifyGraph('roles', (rolesBuilder) => {
+      rolesBuilder.select(['description', 'roles.id', 'role']).orderBy('role')
+    })
+
+  const allRoles = await RoleModel.query()
+    .select(['description', 'id', 'role'])
+    .whereIn('role', uniqueRoleNames)
+    .orderBy('role')
+
+  return _userPermissions(allGroups, allRoles, includeSuper)
+}
+
+function _uniqueGroupNames() {
+  const allGroupNames = Object.values(userPermissions)
+    .map(({ groups }) => {
+      return groups
+    })
+    .flat()
+
+  return [...new Set(allGroupNames)]
+}
+
+function _uniqueRoleNames() {
+  const allRoleNames = Object.values(userPermissions)
+    .map(({ roles }) => {
+      return roles
+    })
+    .flat()
+
+  return [...new Set(allRoleNames)]
+}
+
+function _userPermission(userPermission, allGroups, allRoles) {
+  const groups = allGroups.filter((group) => {
+    return userPermission.groups.includes(group.group)
+  })
+
+  const roles = allRoles.filter((role) => {
+    return userPermission.roles.includes(role.role)
+  })
+
+  return {
+    ...userPermission,
+    groups,
+    roles
+  }
+}
+
+/**
+ * Makes a copy of the static userPermissions object, augmenting the `groups` and `roles` string values with the
+ * corresponding IDs and descriptions from the database
+ * @private
+ */
+function _userPermissions(allGroups, allRoles, includeSuper) {
+  return Object.entries(userPermissions).reduce((decoratedValues, [key, value]) => {
+    if (!includeSuper && key === 'super') {
+      return decoratedValues
+    }
+
+    decoratedValues[key] = _userPermission(value, allGroups, allRoles)
+
+    return decoratedValues
+  }, {})
+}
+
+module.exports = {
+  go
+}

--- a/app/services/users/internal/fetch-permissions-details.service.js
+++ b/app/services/users/internal/fetch-permissions-details.service.js
@@ -1,0 +1,86 @@
+'use strict'
+
+/**
+ * Fetches the details of the groups and roles for a specific permission for the `/users/internal/{id}/edit` page
+ * @module FetchPermissionsDetailsService
+ */
+
+const GroupModel = require('../../../models/group.model.js')
+const RoleModel = require('../../../models/role.model.js')
+
+const { userPermissions } = require('../../../lib/static-lookups.lib.js')
+
+/**
+ * Fetches the details of the groups and roles for a specific permission for the `/users/internal/{id}/edit` page
+ *
+ * This service just augments the static userPermissions object with the relevant group and role IDs from the database,
+ * as that is what is required to update the permissions.
+ *
+ * So for a permission of `nps_ar_user`, the return value is transformed from the original static permission object:
+ *
+ * ```
+ * {
+ *   application: 'water_admin',
+ *   groups: ['nps'],
+ *   key: 'nps_ar_user',
+ *   label: 'National Permitting Service and Digitise! editor',
+ *   roles: ['ar_user']
+ * }
+ * ```
+ *
+ * to something like this:
+ *
+ * ```
+ * {
+ *   application: 'water_admin',
+ *   groups: [{ group: 'nps', id: '1234-1234-1234-1234' }],
+ *   key: 'nps_ar_user',
+ *   label: 'National Permitting Service and Digitise! editor',
+ *   roles: [{ role: 'ar_user', id: '5678-5678-5678-5678' }]
+ * }
+ * ```
+ *
+ * This is needed because the database has randomly-generated UUIDs as keys for groups and roles, which we need to
+ * look up in order to update the permissions correctly.
+ *
+ * These could be done individually for each group and role insertion when updating the permissions, but it is more
+ * efficient to do it all in one go here and the update service already has quite a lot to do, dealing with transactions
+ * and multiple deletes/inserts.
+ *
+ * @param {string} permission - The permission to fetch the details for
+ *
+ * @returns {Promise<object>} the relevant permission but with the database details of its groups and roles instead of
+ * just the names
+ */
+async function go(permission) {
+  const userPermission = userPermissions[permission]
+  const { groups: groupNames, roles: roleNames } = userPermission
+
+  const [groups, roles] = await Promise.all([_groups(groupNames), _roles(roleNames)])
+
+  return {
+    ...userPermission,
+    groups,
+    roles
+  }
+}
+
+async function _groups(groupNames) {
+  if (groupNames.length === 0) {
+    return []
+  }
+
+  return GroupModel.query().select(['group', 'id']).whereIn('group', groupNames)
+}
+
+async function _roles(roleNames) {
+  if (roleNames.length === 0) {
+    return []
+  }
+
+  return RoleModel.query().select(['id', 'role']).whereIn('role', roleNames)
+}
+
+module.exports = {
+  go
+}

--- a/app/services/users/internal/submit-edit-user.service.js
+++ b/app/services/users/internal/submit-edit-user.service.js
@@ -1,0 +1,77 @@
+'use strict'
+
+/**
+ * Orchestrates validating and updating the data for the `/users/internal/{id}/edit` page
+ *
+ * @module SubmitEditUserService
+ */
+
+const Boom = require('@hapi/boom')
+
+const DetermineUserEditableService = require('./determine-user-editable.service.js')
+const EditUserPresenter = require('../../../presenters/users/internal/edit-user.presenter.js')
+const EditUserValidator = require('../../../validators/users/internal/edit-user.validator.js')
+const FetchAllPermissionsDetailsService = require('./fetch-all-permissions-details.service.js')
+const FetchLegacyIdService = require('../fetch-legacy-id.service.js')
+const FetchPermissionsDetailsService = require('./fetch-permissions-details.service.js')
+const UpdateUserService = require('./update-user.service.js')
+
+const { formatValidationResult } = require('../../../presenters/base.presenter.js')
+
+/**
+ * Orchestrates validating and updating the data for the `/users/internal/{id}/edit` page
+ *
+ * This route is scoped to the `manage_accounts` role, so only those users can access it.
+ *
+ * However, there is an additional check to determine whether the user can edit the user being viewed.
+ *
+ * This is because only a user with the `super` permissions can edit another user with `super` permissions.
+ *
+ * @param {number} id - The ID of the user to edit
+ * @param {object} payload - The submitted form data
+ * @param {object} auth - The current user's authentication details from `request.auth`, used to determine what actions
+ * the user can take, i.e. whether they can edit the user or not
+ *
+ * @returns {Promise<object>} The data formatted for the view template
+ */
+async function go(id, payload, auth) {
+  const validationResult = _validate(payload)
+  const { permissions: newPermissions } = payload
+  const { canEdit, isSuper, user } = await DetermineUserEditableService.go(id, auth, payload)
+
+  if (!canEdit) {
+    return Boom.forbidden()
+  }
+
+  if (validationResult) {
+    const allPermissionsDetails = await FetchAllPermissionsDetailsService.go(isSuper)
+    const pageData = EditUserPresenter.go(user, allPermissionsDetails, newPermissions)
+
+    return {
+      error: validationResult,
+      ...pageData
+    }
+  }
+
+  const userId = await FetchLegacyIdService.go(id)
+
+  await _save(id, userId, newPermissions)
+
+  return {}
+}
+
+async function _save(id, userId, permissions) {
+  const { groups, roles } = await FetchPermissionsDetailsService.go(permissions)
+
+  return UpdateUserService.go({ id, groups, roles, userId })
+}
+
+function _validate(payload) {
+  const validationResult = EditUserValidator.go(payload)
+
+  return formatValidationResult(validationResult)
+}
+
+module.exports = {
+  go
+}

--- a/app/services/users/internal/update-user.service.js
+++ b/app/services/users/internal/update-user.service.js
@@ -1,0 +1,98 @@
+'use strict'
+
+/**
+ * Update the user data for the `/users/internal/{id}/edit` page
+ *
+ * @module UpdateUserService
+ */
+
+const { raw } = require('objection')
+
+const UserModel = require('../../../models/user.model.js')
+const UserGroupModel = require('../../../models/user-group.model.js')
+const UserRoleModel = require('../../../models/user-role.model.js')
+
+/**
+ * Update the user data for the `/users/internal/{id}/edit` page
+ *
+ * The user data is updated by deleting the existing `user_groups` and `user_roles` records, before inserting new ones.
+ *
+ * There are a few issues with these tables that make this approach necessary:
+ *
+ * - They have a unique ID field, which is not really needed as the combination of `userId` and `groupId` / `roleId`
+ * should be unique
+ * - Their unique ID field is not automatically generated, which means that values have to be generated manually when
+ * inserting records
+ * - They have no unique constraint on the combination of `userId` and `groupId` / `roleId`, which means that duplicate
+ * records could be inserted
+ * - They use the old numeric `user_id` field for the user rather than the new user UUID, so we have to use the
+ * `userId` field instead of the `id` field for the user
+ * - Groups and Roles have to have a unique name, but they are linked by their UUID, so we have to query the database to
+ * get the UUIDs for the groups and roles based on their names (these things really don't need to exist in the database,
+ * they could just be hardcoded in the codebase as they are unlikely to change and are not really data - we have already
+ * introduced the concept of a "permissions" value that encapsulates the user's scopes, so we could eventually just use
+ * that instead of all these tables)
+ *
+ * Hence, for now, the approach of just deleting all the existing records and inserting new ones, which is how the
+ * legacy application handles it.
+ *
+ * The best solution would be to replace all this with a simple `permissions` value on the user record - once the
+ * migration of all user functionality from the legacy systems has been completed that would probably be the approach to
+ * take.
+ *
+ * @param {module:UserModel} user - The user, with its new `groups` and `roles` relations, to update
+ *
+ * @returns {Promise<Array>} The results from all the deletes and inserts
+ */
+async function go(user) {
+  return _update(user)
+}
+
+async function _update(user) {
+  return UserModel.transaction(async (trx) => {
+    const deleteResults = await Promise.all([
+      UserGroupModel.query(trx).delete().where('userId', user.userId),
+      UserRoleModel.query(trx).delete().where('userId', user.userId)
+    ])
+
+    const userGroups = _userGroups(user)
+    const userRoles = _userRoles(user)
+    const inserts = []
+
+    if (userGroups.length) {
+      inserts.push(UserGroupModel.query(trx).insert(userGroups))
+    }
+
+    if (userRoles.length) {
+      inserts.push(UserRoleModel.query(trx).insert(userRoles))
+    }
+
+    const insertResults = await Promise.all(inserts)
+
+    return [...deleteResults, ...insertResults]
+  })
+}
+
+function _userGroups(user) {
+  return user.groups.map((group) => {
+    return {
+      groupId: group.id,
+      id: raw('gen_random_uuid()'),
+      userId: user.userId
+    }
+  })
+}
+
+function _userRoles(user) {
+  return user.roles.map((role) => {
+    return {
+      id: raw('gen_random_uuid()'),
+      roleId: role.id,
+      userId: user.userId
+    }
+  })
+}
+
+module.exports = {
+  go
+}

--- a/app/services/users/internal/view-edit-user.service.js
+++ b/app/services/users/internal/view-edit-user.service.js
@@ -1,0 +1,51 @@
+'use strict'
+
+/**
+ * Orchestrates fetching and presenting the data for the `/users/internal/{id}/edit` page
+ *
+ * @module ViewEditUserService
+ */
+
+const Boom = require('@hapi/boom')
+
+const DetermineUserEditableService = require('./determine-user-editable.service.js')
+const EditUserPresenter = require('../../../presenters/users/internal/edit-user.presenter.js')
+const FetchAllPermissionsDetailsService = require('./fetch-all-permissions-details.service.js')
+
+const FeatureFlagsConfig = require('../../../../config/feature-flags.config.js')
+
+/**
+ * Orchestrates fetching and presenting the data for the `/users/internal/{id}/edit` page
+ *
+ * This route is scoped to the `manage_accounts` role, so only those users can access it.
+ *
+ * However, there is an additional check to determine whether the user can edit the user being viewed.
+ *
+ * This is because only a user with the `super` permissions can edit another user with `super` permissions.
+ *
+ * @param {number} id - The ID of the user to edit
+ * @param {object} auth - The current user's authentication details from `request.auth`, used to determine what actions
+ * the user can take, i.e. whether they can edit the user or not
+ *
+ * @returns {Promise<object>} The data formatted for the view template
+ */
+async function go(id, auth) {
+  const { canEdit, isSuper, user } = await DetermineUserEditableService.go(id, auth)
+
+  if (!canEdit) {
+    return Boom.forbidden()
+  }
+
+  const allPermissionsDetails = await FetchAllPermissionsDetailsService.go(isSuper)
+
+  const pageData = EditUserPresenter.go(user, allPermissionsDetails, user.$permissions().key)
+
+  return {
+    activeNavBar: FeatureFlagsConfig.enableUsersView ? 'users' : 'search',
+    ...pageData
+  }
+}
+
+module.exports = {
+  go
+}

--- a/app/services/users/internal/view-user.service.js
+++ b/app/services/users/internal/view-user.service.js
@@ -5,7 +5,7 @@
  * @module ViewUserService
  */
 
-const FetchUserService = require('./fetch-user.service.js')
+const DetermineUserEditableService = require('./determine-user-editable.service.js')
 const UserPresenter = require('../../../presenters/users/internal/user.presenter.js')
 
 const FeatureFlagsConfig = require('../../../../config/feature-flags.config.js')
@@ -14,12 +14,15 @@ const FeatureFlagsConfig = require('../../../../config/feature-flags.config.js')
  * Orchestrates fetching and presenting internal user data for `/users/internal/{id}` page
  *
  * @param {number} id - The user's ID
+ * @param {object} auth - The current user's authentication details from `request.auth`, used to determine what actions
+ * the user can take, i.e. whether they can edit the user or not
  *
  * @returns {Promise<object>} The view data for the internal user page
  */
-async function go(id) {
-  const internalUser = await FetchUserService.go(id)
-  const pageData = UserPresenter.go(internalUser)
+async function go(id, auth) {
+  const { user, canEdit } = await DetermineUserEditableService.go(id, auth)
+
+  const pageData = UserPresenter.go(user, canEdit)
 
   return {
     activeNavBar: FeatureFlagsConfig.enableUsersView ? 'users' : 'search',

--- a/app/validators/users/internal/edit-user.validator.js
+++ b/app/validators/users/internal/edit-user.validator.js
@@ -1,0 +1,40 @@
+'use strict'
+
+/**
+ * Validates data submitted for the `/users/internal/{id}/edit` page
+ *
+ * @module EditUserValidator
+ */
+
+const Joi = require('joi')
+
+const { userPermissions } = require('../../../lib/static-lookups.lib.js')
+
+const ERROR_MESSAGE = 'Select a valid permission'
+
+/**
+ * Validates data submitted for the `/users/internal/{id}/edit` page
+ *
+ * @param {object} payload - The payload from the request to be validated
+ *
+ * @returns {object} the result from calling Joi's schema.validate(). It will be an object with a `value:` property. If
+ * any errors are found the `error:` property will also exist detailing what the issues were
+ */
+function go(payload) {
+  const schema = Joi.object({
+    permissions: Joi.string()
+      .valid(...Object.keys(userPermissions))
+      .required()
+      .messages({
+        'any.required': ERROR_MESSAGE,
+        'any.only': ERROR_MESSAGE,
+        'string.empty': ERROR_MESSAGE
+      })
+  })
+
+  return schema.validate(payload, { abortEarly: false })
+}
+
+module.exports = {
+  go
+}

--- a/app/views/users/internal/edit-user.njk
+++ b/app/views/users/internal/edit-user.njk
@@ -1,0 +1,32 @@
+{% extends 'layout.njk' %}
+
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+
+{% from "macros/user-status-tag.njk" import statusTag %}
+
+{% block pageContent %}
+  <form method="post">
+    <input type="hidden" name="wrlsCrumb" value="{{wrlsCrumb}}"/>
+
+    {{ govukRadios({
+      name: 'permissions',
+      errorMessage: error.permissions,
+      fieldset: {
+        legend: {
+          text: 'Permissions',
+          isPageHeading: false,
+          classes: 'govuk-fieldset__legend--l'
+        }
+      },
+      items: permissionOptions,
+      value: permissions
+    }) }}
+
+    <div class="govuk-button-group">
+      {{ govukButton({ text: "Update", preventDoubleClick: true }) }}
+
+      <a class="govuk-link" href="{{ cancelLink.href }}">{{ cancelLink.text }}</a>
+    </div>
+  </form>
+{% endblock %}

--- a/app/views/users/internal/view-user.njk
+++ b/app/views/users/internal/view-user.njk
@@ -24,11 +24,13 @@
     ]
   }) }}
 
-  <form method="post">
-    <input type="hidden" name="wrlsCrumb" value="{{wrlsCrumb}}"/>
+  {% if showEditButton %}
+    <form method="post">
+      <input type="hidden" name="wrlsCrumb" value="{{wrlsCrumb}}"/>
 
-    {{ govukButton({ text: "Edit", preventDoubleClick: true }) }}
-  </form>
+      {{ govukButton({ text: "Edit", preventDoubleClick: true }) }}
+    </form>
+  {% endif %}
 
   <h3 class="govuk-heading-m">Roles</h3>
 

--- a/test/controllers/users.controller.test.js
+++ b/test/controllers/users.controller.test.js
@@ -4,21 +4,24 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
+const Boom = require('@hapi/boom')
 
 const { describe, it, before, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
 const FeatureFlagsConfig = require('../../config/feature-flags.config.js')
-const { HTTP_STATUS_FOUND, HTTP_STATUS_OK } = require('node:http2').constants
+const { HTTP_STATUS_FOUND, HTTP_STATUS_NOT_FOUND, HTTP_STATUS_OK } = require('node:http2').constants
 const { generateUUID } = require('../../app/lib/general.lib.js')
 const { postRequestOptions } = require('../support/general.js')
 
 // Things we need to stub
 const FetchLegacyIdService = require('../../app/services/users/fetch-legacy-id.service.js')
 const IndexUsersService = require('../../app/services/users/index-users.service.js')
+const SubmitEditUserInternalService = require('../../app/services/users/internal/submit-edit-user.service.js')
 const SubmitIndexUsersService = require('../../app/services/users/submit-index-users.service.js')
 const SubmitProfileDetailsService = require('../../app/services/users/submit-profile-details.service.js')
+const ViewEditUserInternalService = require('../../app/services/users/internal/view-edit-user.service.js')
 const ViewProfileDetailsService = require('../../app/services/users/view-profile-details.service.js')
 const ViewUserExternalService = require('../../app/services/users/external/view-user.service.js')
 const ViewUserInternalService = require('../../app/services/users/internal/view-user.service.js')
@@ -231,6 +234,122 @@ describe('Users controller', () => {
 
         expect(response.statusCode).to.equal(HTTP_STATUS_OK)
         expect(response.payload).to.contain('Internal')
+      })
+    })
+
+    describe('POST', () => {
+      beforeEach(() => {
+        id = generateUUID()
+        postOptions = postRequestOptions(`/users/internal/${id}`, {}, ['manage_accounts'])
+      })
+
+      describe('when the request succeeds', () => {
+        beforeEach(() => {
+          Sinon.stub(FetchLegacyIdService, 'go').returns({ userId: 123 })
+        })
+
+        it('redirects to the edit internal user page', async () => {
+          const response = await server.inject(postOptions)
+
+          expect(response.statusCode).to.equal(HTTP_STATUS_FOUND)
+          expect(response.headers.location).to.equal(`/system/users/internal/${id}/edit`)
+        })
+      })
+    })
+  })
+
+  describe('/users/internal/{id}/edit', () => {
+    describe('GET', () => {
+      beforeEach(() => {
+        id = generateUUID()
+        options = _getOptions(`/users/internal/${id}/edit`, { scope: ['manage_accounts'] })
+      })
+
+      describe('when the request succeeds', () => {
+        beforeEach(async () => {
+          Sinon.stub(ViewEditUserInternalService, 'go').resolves({
+            activeNavBar: 'users',
+            cancelLink: { href: `/system/users/internal/${id}`, text: 'Cancel' },
+            id,
+            lastSignedIn: '6 October 2022 at 10:00:00',
+            pageTitle: 'User basic.access@wrls.gov.uk',
+            pageTitleCaption: 'Internal',
+            permissionOptions: [],
+            permissions: 'basic',
+            roles: [],
+            status: 'enabled'
+          })
+        })
+
+        it('returns the edit internal user page successfully', async () => {
+          const response = await server.inject(options)
+
+          expect(response.statusCode).to.equal(HTTP_STATUS_OK)
+          expect(response.payload).to.contain('Internal')
+        })
+      })
+
+      describe('when the request fails', () => {
+        describe('because the current user does not have permission to edit the selected user', () => {
+          beforeEach(async () => {
+            Sinon.stub(ViewEditUserInternalService, 'go').resolves(Boom.forbidden())
+          })
+
+          it('returns a "not found" response', async () => {
+            const response = await server.inject(options)
+
+            expect(response.statusCode).to.equal(HTTP_STATUS_NOT_FOUND)
+          })
+        })
+      })
+    })
+
+    describe('POST', () => {
+      beforeEach(() => {
+        id = generateUUID()
+        postOptions = postRequestOptions(`/users/internal/${id}/edit`, {}, ['manage_accounts'])
+      })
+
+      describe('when the request succeeds', () => {
+        describe('and is valid', () => {
+          beforeEach(() => {
+            Sinon.stub(SubmitEditUserInternalService, 'go').resolves({})
+          })
+
+          it('redirects to the view internal user page', async () => {
+            const response = await server.inject(postOptions)
+
+            expect(response.statusCode).to.equal(HTTP_STATUS_FOUND)
+            expect(response.headers.location).to.equal(`/system/users/internal/${id}`)
+          })
+        })
+
+        describe('and the validation fails', () => {
+          beforeEach(() => {
+            Sinon.stub(SubmitEditUserInternalService, 'go').resolves({ error: { details: [] } })
+          })
+
+          it('returns the page successfully with the error summary banner', async () => {
+            const response = await server.inject(postOptions)
+
+            expect(response.statusCode).to.equal(HTTP_STATUS_OK)
+            expect(response.payload).to.contain('There is a problem')
+          })
+        })
+      })
+
+      describe('when the request fails', () => {
+        describe('because the current user does not have permission to make the edit to the selected user', () => {
+          beforeEach(async () => {
+            Sinon.stub(SubmitEditUserInternalService, 'go').resolves(Boom.forbidden())
+          })
+
+          it('returns a "not found" response', async () => {
+            const response = await server.inject(postOptions)
+
+            expect(response.statusCode).to.equal(HTTP_STATUS_NOT_FOUND)
+          })
+        })
       })
     })
   })

--- a/test/presenters/users/internal/edit-user.presenter.test.js
+++ b/test/presenters/users/internal/edit-user.presenter.test.js
@@ -1,0 +1,179 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Test helpers
+const UsersFixture = require('../../../support/fixtures/users.fixture.js')
+
+// Thing under test
+const EditUserPresenter = require('../../../../app/presenters/users/internal/edit-user.presenter.js')
+
+describe('Users - Internal - Edit User Presenter', () => {
+  let allPermissionsDetails
+  let permissions
+  let user
+
+  beforeEach(() => {
+    user = UsersFixture.basicAccess()
+    allPermissionsDetails = {}
+    permissions = 'basic'
+  })
+
+  describe('when called', () => {
+    it('returns page data for the view', () => {
+      const result = EditUserPresenter.go(user, allPermissionsDetails, permissions)
+
+      expect(result).to.equal({
+        cancelLink: { href: `/system/users/internal/${user.id}`, text: 'Cancel' },
+        id: user.id,
+        lastSignedIn: '6 October 2022 at 10:00:00',
+        pageTitle: 'User basic.access@wrls.gov.uk',
+        pageTitleCaption: 'Internal',
+        permissionOptions: [],
+        permissions: 'basic',
+        status: 'enabled'
+      })
+    })
+  })
+
+  describe('the "lastSignedIn" property', () => {
+    describe('when the lastLogin is "null"', () => {
+      beforeEach(() => {
+        user.lastLogin = null
+      })
+
+      it('returns "Never signed in"', () => {
+        const result = EditUserPresenter.go(user, allPermissionsDetails, permissions)
+
+        expect(result.lastSignedIn).to.equal('Never signed in')
+      })
+    })
+  })
+
+  describe('the "permissionOptions" property', () => {
+    describe('when a permission has no group or roles', () => {
+      beforeEach(() => {
+        allPermissionsDetails = {
+          basic: {
+            application: 'both',
+            groups: [],
+            key: 'basic',
+            label: 'Basic access',
+            roles: []
+          }
+        }
+      })
+
+      it('returns an option that "Grants no additional roles"', () => {
+        const result = EditUserPresenter.go(user, allPermissionsDetails, permissions)
+
+        expect(result.permissionOptions[0]).to.equal({
+          checked: true,
+          hint: { text: 'Grants no additional roles' },
+          text: 'Basic access',
+          value: 'basic'
+        })
+      })
+    })
+
+    describe('when a permission has only a group', () => {
+      beforeEach(() => {
+        allPermissionsDetails = {
+          environment_officer: {
+            application: 'water_admin',
+            groups: [
+              {
+                description: 'Environment officer',
+                group: 'environment_officer',
+                roles: [
+                  {
+                    description: 'Send HoF notifications',
+                    role: 'hof_notifications'
+                  },
+                  {
+                    description: 'Manage linkages between gauging stations and licences',
+                    role: 'manage_gauging_station_licence_links'
+                  }
+                ]
+              }
+            ],
+            key: 'environment_officer',
+            label: 'Environment Officer',
+            roles: []
+          }
+        }
+      })
+
+      it('returns an option that grants the roles for the group', () => {
+        const result = EditUserPresenter.go(user, allPermissionsDetails, permissions)
+
+        expect(result.permissionOptions[0]).to.equal({
+          checked: false,
+          hint: { text: 'Grants: HOF notifications, Manage gauging station licence links' },
+          text: 'Environment Officer',
+          value: 'environment_officer'
+        })
+      })
+    })
+
+    describe('when a permission has a group and additional roles', () => {
+      beforeEach(() => {
+        allPermissionsDetails = {
+          nps_ar_approver: {
+            application: 'water_admin',
+            groups: [
+              {
+                description: 'National Permitting Service',
+                group: 'nps',
+                roles: [
+                  {
+                    description: 'Manage linkages between gauging stations and licences',
+                    role: 'manage_gauging_station_licence_links'
+                  },
+                  {
+                    description: 'Send renewal notifications',
+                    role: 'renewal_notifications'
+                  },
+                  {
+                    description: 'Remove licences registered to a company',
+                    role: 'unlink_licences'
+                  },
+                  {
+                    description: 'View charge information',
+                    role: 'view_charge_versions'
+                  }
+                ]
+              }
+            ],
+            key: 'nps_ar_approver',
+            label: 'National Permitting Service and Digitise! approver',
+            roles: [
+              {
+                description: 'Approve licence data in Digitise! tool',
+                role: 'ar_approver'
+              }
+            ]
+          }
+        }
+      })
+
+      it('returns an option that grants the roles for the group and the additional roles', () => {
+        const result = EditUserPresenter.go(user, allPermissionsDetails, permissions)
+
+        expect(result.permissionOptions[0]).to.equal({
+          checked: false,
+          hint: {
+            text: 'Grants: AR approver, Manage gauging station licence links, Renewal notifications, Unlink licences, View charge versions'
+          },
+          text: 'National Permitting Service and Digitise! approver',
+          value: 'nps_ar_approver'
+        })
+      })
+    })
+  })
+})

--- a/test/presenters/users/internal/user.presenter.test.js
+++ b/test/presenters/users/internal/user.presenter.test.js
@@ -18,12 +18,14 @@ const FeatureFlagsConfig = require('../../../../config/feature-flags.config.js')
 const UserPresenter = require('../../../../app/presenters/users/internal/user.presenter.js')
 
 describe('Users - Internal - User Presenter', () => {
+  let canEdit
   let user
 
   beforeEach(() => {
     Sinon.stub(FeatureFlagsConfig, 'enableUsersView').value(true)
 
     user = UsersFixture.basicAccess()
+    canEdit = true
   })
 
   afterEach(() => {
@@ -31,7 +33,7 @@ describe('Users - Internal - User Presenter', () => {
   })
 
   it('correctly presents the data', () => {
-    const result = UserPresenter.go(user)
+    const result = UserPresenter.go(user, canEdit)
 
     expect(result).to.equal({
       backLink: {
@@ -44,6 +46,7 @@ describe('Users - Internal - User Presenter', () => {
       pageTitleCaption: 'Internal',
       permissions: 'Basic access',
       roles: [],
+      showEditButton: true,
       status: 'enabled'
     })
   })
@@ -51,7 +54,7 @@ describe('Users - Internal - User Presenter', () => {
   describe('the "lastSignedIn" property', () => {
     describe('when the lastLogin is not "null"', () => {
       it('returns the date and time of the last login', () => {
-        const result = UserPresenter.go(user)
+        const result = UserPresenter.go(user, canEdit)
 
         expect(result.lastSignedIn).to.equal('6 October 2022 at 10:00:00')
       })
@@ -63,7 +66,7 @@ describe('Users - Internal - User Presenter', () => {
       })
 
       it('returns "Never signed in"', () => {
-        const result = UserPresenter.go(user)
+        const result = UserPresenter.go(user, canEdit)
 
         expect(result.lastSignedIn).to.equal('Never signed in')
       })
@@ -73,7 +76,7 @@ describe('Users - Internal - User Presenter', () => {
   describe('the "roles" property', () => {
     describe('when the user has no group or user roles', () => {
       it('returns an empty array', () => {
-        const result = UserPresenter.go(user)
+        const result = UserPresenter.go(user, canEdit)
 
         expect(result.roles).to.equal([])
       })
@@ -87,7 +90,7 @@ describe('Users - Internal - User Presenter', () => {
       })
 
       it('returns the "roles" for the group in sentence case, sorted by name', () => {
-        const result = UserPresenter.go(user)
+        const result = UserPresenter.go(user, canEdit)
 
         expect(result.roles).to.equal([
           {
@@ -110,7 +113,7 @@ describe('Users - Internal - User Presenter', () => {
       })
 
       it('returns all "roles" in sentence case, sorted by name', () => {
-        const result = UserPresenter.go(user)
+        const result = UserPresenter.go(user, canEdit)
 
         expect(result.roles).to.equal([
           {

--- a/test/services/users/internal/determine-user-editable.service.test.js
+++ b/test/services/users/internal/determine-user-editable.service.test.js
@@ -1,0 +1,135 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Test helpers
+const UsersFixture = require('../../../support/fixtures/users.fixture.js')
+
+// Things to stub
+const FetchUserService = require('../../../../app/services/users/internal/fetch-user.service.js')
+
+// Thing under test
+const DetermineUserEditableService = require('../../../../app/services/users/internal/determine-user-editable.service.js')
+
+describe('Users - Internal - Determine User Editable service', () => {
+  const auth = {
+    credentials: { scope: ['manage_accounts'], user: { id: 'dummy-id' } }
+  }
+
+  let currentUserPermissions
+  let payload
+  let user
+
+  beforeEach(() => {
+    user = UsersFixture.basicAccess()
+    currentUserPermissions = 'super'
+
+    Sinon.stub(FetchUserService, 'go')
+      .resolves(user)
+      .onFirstCall()
+      .resolves({
+        $permissions: () => {
+          return { key: currentUserPermissions }
+        }
+      })
+  })
+
+  afterEach(() => {
+    Sinon.restore()
+  })
+
+  describe('when called', () => {
+    beforeEach(() => {
+      payload = { permissions: 'super' }
+    })
+
+    it('returns the correctly determined editable status', async () => {
+      const result = await DetermineUserEditableService.go(user.id, auth, payload)
+
+      expect(result).to.equal({
+        canEdit: true,
+        isSuper: true,
+        user
+      })
+    })
+  })
+
+  describe('when the current user is not a super user', () => {
+    beforeEach(() => {
+      currentUserPermissions = 'billing_and_data'
+      payload = { permissions: 'basic' }
+    })
+
+    describe('and the user being edited is not a super user', () => {
+      it('determines that the user can be edited', async () => {
+        const result = await DetermineUserEditableService.go(user.id, auth, payload)
+
+        expect(result.canEdit).to.be.true()
+      })
+    })
+
+    describe('and the user being edited is a super user', () => {
+      beforeEach(() => {
+        user.$permissions = () => {
+          return { key: 'super' }
+        }
+      })
+
+      it('determines that the user cannot be edited', async () => {
+        const result = await DetermineUserEditableService.go(user.id, auth, payload)
+
+        expect(result.canEdit).to.be.false()
+      })
+    })
+
+    describe('and the current user is trying to make them a super user', () => {
+      beforeEach(() => {
+        payload = { permissions: 'super' }
+      })
+
+      it('determines that the user cannot be edited', async () => {
+        const result = await DetermineUserEditableService.go(user.id, auth, payload)
+
+        expect(result.canEdit).to.be.false()
+      })
+    })
+  })
+
+  describe('when the current user is a super user', () => {
+    beforeEach(() => {
+      payload = { permissions: 'basic' }
+    })
+
+    describe('and the user being edited is a super user', () => {
+      beforeEach(() => {
+        user.$permissions = () => {
+          return { key: 'super' }
+        }
+      })
+
+      it('determines that the user can be edited', async () => {
+        const result = await DetermineUserEditableService.go(user.id, auth, payload)
+
+        expect(result.canEdit).to.be.true()
+      })
+    })
+
+    describe('and the current user is trying to make them a super user', () => {
+      beforeEach(() => {
+        payload = { permissions: 'super' }
+      })
+
+      it('determines that the user can be edited', async () => {
+        const result = await DetermineUserEditableService.go(user.id, auth, payload)
+
+        expect(result.canEdit).to.be.true()
+      })
+    })
+  })
+})

--- a/test/services/users/internal/fetch-all-permissions-details.service.test.js
+++ b/test/services/users/internal/fetch-all-permissions-details.service.test.js
@@ -1,0 +1,463 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Test helpers
+const GroupHelper = require('../../../support/helpers/group.helper.js')
+const RoleHelper = require('../../../support/helpers/role.helper.js')
+
+// Thing under test
+const FetchAllPermissionsDetailsService = require('../../../../app/services/users/internal/fetch-all-permissions-details.service.js')
+
+describe('Users - Internal - Fetch All Permissions Details service', () => {
+  let includeSuper
+
+  const seededGroupIds = GroupHelper.data.reduce((groupIds, { id, group }) => {
+    groupIds[group] = id
+    return groupIds
+  }, {})
+
+  const seededRoleIds = RoleHelper.data.reduce((roleIds, { id, role }) => {
+    roleIds[role] = id
+    return roleIds
+  }, {})
+
+  beforeEach(() => {
+    includeSuper = false
+  })
+
+  describe('when called', () => {
+    it('returns all permissions with the correct group and role IDs and descriptions', async () => {
+      const result = await FetchAllPermissionsDetailsService.go(includeSuper)
+
+      expect(result).to.equal({
+        admin: {
+          application: 'water_vml',
+          groups: [],
+          key: 'admin',
+          label: 'Admin',
+          roles: []
+        },
+        basic: {
+          application: 'both',
+          groups: [],
+          key: 'basic',
+          label: 'Basic access',
+          roles: []
+        },
+        billing_and_data: {
+          application: 'water_admin',
+          groups: [
+            {
+              description: 'Water Resources Billing & Data',
+              group: 'billing_and_data',
+              id: seededGroupIds.billing_and_data,
+              roles: [
+                {
+                  description: 'Administer billing',
+                  id: seededRoleIds.billing,
+                  role: 'billing'
+                },
+                {
+                  description: 'Send bulk return invitations and reminder notifications',
+                  id: seededRoleIds.bulk_return_notifications,
+                  role: 'bulk_return_notifications'
+                },
+                {
+                  description: 'Create and edit charge information workflow data',
+                  id: seededRoleIds.charge_version_workflow_editor,
+                  role: 'charge_version_workflow_editor'
+                },
+                {
+                  description: 'Approve charge information workflow data',
+                  id: seededRoleIds.charge_version_workflow_reviewer,
+                  role: 'charge_version_workflow_reviewer'
+                },
+                {
+                  description: 'Delete licence agreements',
+                  id: seededRoleIds.delete_agreements,
+                  role: 'delete_agreements'
+                },
+                {
+                  description: 'Create and manage internal user accounts',
+                  id: seededRoleIds.manage_accounts,
+                  role: 'manage_accounts'
+                },
+                {
+                  description: 'Create and edit licence agreements',
+                  id: seededRoleIds.manage_agreements,
+                  role: 'manage_agreements'
+                },
+                {
+                  description: 'View invoice accounts and change invoice account address',
+                  id: seededRoleIds.manage_billing_accounts,
+                  role: 'manage_billing_accounts'
+                },
+                {
+                  description: 'Submit and edit returns',
+                  id: seededRoleIds.returns,
+                  role: 'returns'
+                },
+                {
+                  description: 'Remove licences registered to a company',
+                  id: seededRoleIds.unlink_licences,
+                  role: 'unlink_licences'
+                },
+                {
+                  description: 'View charge information',
+                  id: seededRoleIds.view_charge_versions,
+                  role: 'view_charge_versions'
+                }
+              ]
+            }
+          ],
+          key: 'billing_and_data',
+          label: 'Billing and Data',
+          roles: []
+        },
+        environment_officer: {
+          application: 'water_admin',
+          groups: [
+            {
+              description: 'Environment officer',
+              group: 'environment_officer',
+              id: seededGroupIds.environment_officer,
+              roles: [
+                {
+                  description: 'Send HoF notifications',
+                  id: seededRoleIds.hof_notifications,
+                  role: 'hof_notifications'
+                },
+                {
+                  description: 'Manage linkages between gauging stations and licences',
+                  id: seededRoleIds.manage_gauging_station_licence_links,
+                  role: 'manage_gauging_station_licence_links'
+                }
+              ]
+            }
+          ],
+          key: 'environment_officer',
+          label: 'Environment Officer',
+          roles: []
+        },
+        none: {
+          application: 'water_vml',
+          groups: [],
+          key: 'none',
+          label: 'None',
+          roles: []
+        },
+        nps: {
+          application: 'water_admin',
+          groups: [
+            {
+              description: 'National Permitting Service',
+              group: 'nps',
+              id: seededGroupIds.nps,
+              roles: [
+                {
+                  description: 'Manage linkages between gauging stations and licences',
+                  id: seededRoleIds.manage_gauging_station_licence_links,
+                  role: 'manage_gauging_station_licence_links'
+                },
+                {
+                  description: 'Send renewal notifications',
+                  id: seededRoleIds.renewal_notifications,
+                  role: 'renewal_notifications'
+                },
+                {
+                  description: 'Remove licences registered to a company',
+                  id: seededRoleIds.unlink_licences,
+                  role: 'unlink_licences'
+                },
+                {
+                  description: 'View charge information',
+                  id: seededRoleIds.view_charge_versions,
+                  role: 'view_charge_versions'
+                }
+              ]
+            }
+          ],
+          key: 'nps',
+          label: 'National Permitting Service',
+          roles: []
+        },
+        nps_ar_approver: {
+          application: 'water_admin',
+          groups: [
+            {
+              description: 'National Permitting Service',
+              group: 'nps',
+              id: seededGroupIds.nps,
+              roles: [
+                {
+                  description: 'Manage linkages between gauging stations and licences',
+                  id: seededRoleIds.manage_gauging_station_licence_links,
+                  role: 'manage_gauging_station_licence_links'
+                },
+                {
+                  description: 'Send renewal notifications',
+                  id: seededRoleIds.renewal_notifications,
+                  role: 'renewal_notifications'
+                },
+                {
+                  description: 'Remove licences registered to a company',
+                  id: seededRoleIds.unlink_licences,
+                  role: 'unlink_licences'
+                },
+                {
+                  description: 'View charge information',
+                  id: seededRoleIds.view_charge_versions,
+                  role: 'view_charge_versions'
+                }
+              ]
+            }
+          ],
+          key: 'nps_ar_approver',
+          label: 'National Permitting Service and Digitise! approver',
+          roles: [
+            {
+              description: 'Approve licence data in Digitise! tool',
+              id: seededRoleIds.ar_approver,
+              role: 'ar_approver'
+            }
+          ]
+        },
+        nps_ar_user: {
+          application: 'water_admin',
+          groups: [
+            {
+              description: 'National Permitting Service',
+              group: 'nps',
+              id: seededGroupIds.nps,
+              roles: [
+                {
+                  description: 'Manage linkages between gauging stations and licences',
+                  id: seededRoleIds.manage_gauging_station_licence_links,
+                  role: 'manage_gauging_station_licence_links'
+                },
+                {
+                  description: 'Send renewal notifications',
+                  id: seededRoleIds.renewal_notifications,
+                  role: 'renewal_notifications'
+                },
+                {
+                  description: 'Remove licences registered to a company',
+                  id: seededRoleIds.unlink_licences,
+                  role: 'unlink_licences'
+                },
+                {
+                  description: 'View charge information',
+                  id: seededRoleIds.view_charge_versions,
+                  role: 'view_charge_versions'
+                }
+              ]
+            }
+          ],
+          key: 'nps_ar_user',
+          label: 'National Permitting Service and Digitise! editor',
+          roles: [
+            {
+              description: 'Edit licence data in Digitise! tool',
+              id: seededRoleIds.ar_user,
+              role: 'ar_user'
+            }
+          ]
+        },
+        primary_user: {
+          application: 'water_vml',
+          groups: [],
+          key: 'primary_user',
+          label: 'Primary user',
+          roles: []
+        },
+        psc: {
+          application: 'water_admin',
+          groups: [
+            {
+              description: 'Permitting & Support Centre',
+              group: 'psc',
+              id: seededGroupIds.psc,
+              roles: [
+                {
+                  description: 'Manage linkages between gauging stations and licences',
+                  id: seededRoleIds.manage_gauging_station_licence_links,
+                  role: 'manage_gauging_station_licence_links'
+                },
+                {
+                  description: 'Send renewal notifications',
+                  id: seededRoleIds.renewal_notifications,
+                  role: 'renewal_notifications'
+                },
+                {
+                  description: 'Remove licences registered to a company',
+                  id: seededRoleIds.unlink_licences,
+                  role: 'unlink_licences'
+                },
+                {
+                  description: 'View charge information',
+                  id: seededRoleIds.view_charge_versions,
+                  role: 'view_charge_versions'
+                }
+              ]
+            }
+          ],
+          key: 'psc',
+          label: 'Permitting and Support Centre',
+          roles: []
+        },
+        returns_user: {
+          application: 'water_vml',
+          groups: [],
+          key: 'returns_user',
+          label: 'Returns user',
+          roles: []
+        },
+        wirs: {
+          application: 'water_admin',
+          groups: [
+            {
+              description: 'Waste Industry Regulatory Services',
+              group: 'wirs',
+              id: seededGroupIds.wirs,
+              roles: [
+                {
+                  description: 'Submit and edit returns',
+                  id: seededRoleIds.returns,
+                  role: 'returns'
+                }
+              ]
+            }
+          ],
+          key: 'wirs',
+          label: 'Waste and Industry Regulatory Service',
+          roles: []
+        }
+      })
+    })
+  })
+
+  describe('when including super permissions', () => {
+    beforeEach(() => {
+      includeSuper = true
+    })
+
+    it('returns the "super" permissions with the correct group and role IDs and descriptions', async () => {
+      const result = await FetchAllPermissionsDetailsService.go(includeSuper)
+
+      expect(result.super).to.exist()
+      expect(result.super).to.equal({
+        application: 'water_admin',
+        groups: [
+          {
+            description: 'Super user',
+            group: 'super',
+            id: seededGroupIds.super,
+            roles: [
+              {
+                description: 'Approve licence data in Digitise! tool',
+                id: seededRoleIds.ar_approver,
+                role: 'ar_approver'
+              },
+              {
+                description: 'Edit licence data in Digitise! tool',
+                id: seededRoleIds.ar_user,
+                role: 'ar_user'
+              },
+              {
+                description: 'Administer billing',
+                id: seededRoleIds.billing,
+                role: 'billing'
+              },
+              {
+                description: 'Send bulk return invitations and reminder notifications',
+                id: seededRoleIds.bulk_return_notifications,
+                role: 'bulk_return_notifications'
+              },
+              {
+                description: 'Create and edit charge information workflow data',
+                id: seededRoleIds.charge_version_workflow_editor,
+                role: 'charge_version_workflow_editor'
+              },
+              {
+                description: 'Approve charge information workflow data',
+                id: seededRoleIds.charge_version_workflow_reviewer,
+                role: 'charge_version_workflow_reviewer'
+              },
+              {
+                description: 'Delete licence agreements',
+                id: seededRoleIds.delete_agreements,
+                role: 'delete_agreements'
+              },
+              {
+                description: 'Send HoF notifications',
+                id: seededRoleIds.hof_notifications,
+                role: 'hof_notifications'
+              },
+              {
+                description: 'Create and manage internal user accounts',
+                id: seededRoleIds.manage_accounts,
+                role: 'manage_accounts'
+              },
+              {
+                description: 'Create and edit licence agreements',
+                id: seededRoleIds.manage_agreements,
+                role: 'manage_agreements'
+              },
+              {
+                description: 'View invoice accounts and change invoice account address',
+                id: seededRoleIds.manage_billing_accounts,
+                role: 'manage_billing_accounts'
+              },
+              {
+                description: 'Manage linkages between gauging stations and licences',
+                id: seededRoleIds.manage_gauging_station_licence_links,
+                role: 'manage_gauging_station_licence_links'
+              },
+              {
+                description: 'Send renewal notifications',
+                id: seededRoleIds.renewal_notifications,
+                role: 'renewal_notifications'
+              },
+              {
+                description: 'Submit and edit returns',
+                id: seededRoleIds.returns,
+                role: 'returns'
+              },
+              {
+                description: 'Remove licences registered to a company',
+                id: seededRoleIds.unlink_licences,
+                role: 'unlink_licences'
+              },
+              {
+                description: 'View charge information',
+                id: seededRoleIds.view_charge_versions,
+                role: 'view_charge_versions'
+              }
+            ]
+          }
+        ],
+        key: 'super',
+        label: 'Super user',
+        roles: []
+      })
+    })
+  })
+
+  describe('when excluding super permissions', () => {
+    beforeEach(() => {
+      includeSuper = false
+    })
+
+    it('does not include super permissions in the returned value', async () => {
+      const result = await FetchAllPermissionsDetailsService.go(includeSuper)
+
+      expect(result.super).to.not.exist()
+    })
+  })
+})

--- a/test/services/users/internal/fetch-permissions-details.service.test.js
+++ b/test/services/users/internal/fetch-permissions-details.service.test.js
@@ -1,0 +1,93 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Test helpers
+const GroupHelper = require('../../../support/helpers/group.helper.js')
+const RoleHelper = require('../../../support/helpers/role.helper.js')
+
+// Thing under test
+const FetchPermissionsDetailsService = require('../../../../app/services/users/internal/fetch-permissions-details.service.js')
+
+describe('Users - Internal - Fetch Permissions Details service', () => {
+  const seededGroupIds = GroupHelper.data.reduce((groupIds, { id, group }) => {
+    groupIds[group] = id
+    return groupIds
+  }, {})
+
+  const seededRoleIds = RoleHelper.data.reduce((roleIds, { id, role }) => {
+    roleIds[role] = id
+    return roleIds
+  }, {})
+
+  describe('when called', () => {
+    let permissions
+
+    beforeEach(() => {
+      permissions = 'nps_ar_approver'
+    })
+
+    it('returns the correct group and role IDs', async () => {
+      const result = await FetchPermissionsDetailsService.go(permissions)
+
+      expect(result).to.equal({
+        application: 'water_admin',
+        groups: [
+          {
+            group: 'nps',
+            id: seededGroupIds.nps
+          }
+        ],
+        key: 'nps_ar_approver',
+        label: 'National Permitting Service and Digitise! approver',
+        roles: [
+          {
+            id: seededRoleIds.ar_approver,
+            role: 'ar_approver'
+          }
+        ]
+      })
+    })
+
+    describe('for a permission that has no groups or roles', () => {
+      beforeEach(() => {
+        permissions = 'basic'
+      })
+
+      it('returns empty group and role arrays', async () => {
+        const result = await FetchPermissionsDetailsService.go(permissions)
+
+        expect(result).to.equal({
+          application: 'both',
+          groups: [],
+          key: 'basic',
+          label: 'Basic access',
+          roles: []
+        })
+      })
+    })
+
+    describe('for a permission that represents external permissions', () => {
+      beforeEach(() => {
+        permissions = 'admin'
+      })
+
+      it('returns empty group and role arrays', async () => {
+        const result = await FetchPermissionsDetailsService.go(permissions)
+
+        expect(result).to.equal({
+          application: 'water_vml',
+          groups: [],
+          key: 'admin',
+          label: 'Admin',
+          roles: []
+        })
+      })
+    })
+  })
+})

--- a/test/services/users/internal/submit-edit-user.service.test.js
+++ b/test/services/users/internal/submit-edit-user.service.test.js
@@ -1,0 +1,125 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+const Boom = require('@hapi/boom')
+
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Test helpers
+const UsersFixture = require('../../../support/fixtures/users.fixture.js')
+
+// Things to stub
+const DetermineUserEditableService = require('../../../../app/services/users/internal/determine-user-editable.service.js')
+const FeatureFlagsConfig = require('../../../../config/feature-flags.config.js')
+const FetchAllPermissionsDetailsService = require('../../../../app/services/users/internal/fetch-all-permissions-details.service.js')
+const FetchLegacyIdService = require('../../../../app/services/users/fetch-legacy-id.service.js')
+const FetchPermissionsDetailsService = require('../../../../app/services/users/internal/fetch-permissions-details.service.js')
+const UpdateUserService = require('../../../../app/services/users/internal/update-user.service.js')
+
+// Thing under test
+const SubmitEditUserService = require('../../../../app/services/users/internal/submit-edit-user.service.js')
+
+describe('Users - Internal - Submit Edit User service', () => {
+  const auth = {
+    credentials: { scope: ['manage_accounts'], user: { id: 'dummy-id' } }
+  }
+
+  let payload
+  let user
+  let updateUserServiceStub
+
+  beforeEach(() => {
+    user = UsersFixture.basicAccess()
+
+    Sinon.stub(FeatureFlagsConfig, 'enableUsersView').value(true)
+    Sinon.stub(FetchLegacyIdService, 'go').resolves(user.userId)
+    Sinon.stub(FetchAllPermissionsDetailsService, 'go').resolves({})
+    Sinon.stub(FetchPermissionsDetailsService, 'go').resolves({
+      groups: [{ group: 'group-1', id: 'group-id-1' }],
+      roles: [{ id: 'role-id-1', role: 'role-1' }]
+    })
+    updateUserServiceStub = Sinon.stub(UpdateUserService, 'go').resolves()
+  })
+
+  afterEach(() => {
+    Sinon.restore()
+  })
+
+  describe('when called', () => {
+    beforeEach(() => {
+      Sinon.stub(DetermineUserEditableService, 'go').resolves({ canEdit: true, isSuper: true, user })
+
+      payload = { permissions: 'super' }
+    })
+
+    it('calls the update service with the correct parameters', async () => {
+      await SubmitEditUserService.go(user.id, payload, auth)
+
+      expect(updateUserServiceStub.calledOnce).to.be.true()
+      expect(updateUserServiceStub.firstCall.args[0]).to.equal({
+        groups: [{ group: 'group-1', id: 'group-id-1' }],
+        id: user.id,
+        roles: [{ id: 'role-id-1', role: 'role-1' }],
+        userId: user.userId
+      })
+    })
+
+    it('continues the journey', async () => {
+      const result = await SubmitEditUserService.go(user.id, payload, auth)
+
+      expect(result).to.equal({})
+    })
+  })
+
+  describe('when validation fails', () => {
+    beforeEach(() => {
+      Sinon.stub(DetermineUserEditableService, 'go').resolves({ canEdit: true, isSuper: true, user })
+
+      payload = { permissions: 'an-invalid-value' }
+    })
+
+    it('returns page data for the view, with errors', async () => {
+      const result = await SubmitEditUserService.go(user.id, payload, auth)
+
+      expect(result).to.equal({
+        cancelLink: { href: `/system/users/internal/${user.id}`, text: 'Cancel' },
+        error: {
+          errorList: [
+            {
+              href: '#permissions',
+              text: 'Select a valid permission'
+            }
+          ],
+          permissions: {
+            text: 'Select a valid permission'
+          }
+        },
+        id: user.id,
+        lastSignedIn: '6 October 2022 at 10:00:00',
+        pageTitle: 'User basic.access@wrls.gov.uk',
+        pageTitleCaption: 'Internal',
+        permissionOptions: [],
+        permissions: 'an-invalid-value',
+        status: 'enabled'
+      })
+    })
+  })
+
+  describe('when the edit action is not allowed', () => {
+    beforeEach(() => {
+      Sinon.stub(DetermineUserEditableService, 'go').resolves({ canEdit: false, isSuper: true, user })
+
+      payload = { permissions: 'super' }
+    })
+
+    it('returns a "forbidden" error', async () => {
+      const result = await SubmitEditUserService.go(user.id, payload, auth)
+
+      expect(result).to.equal(Boom.forbidden())
+    })
+  })
+})

--- a/test/services/users/internal/update-user.service.test.js
+++ b/test/services/users/internal/update-user.service.test.js
@@ -1,0 +1,80 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Test helpers
+const GroupHelper = require('../../../support/helpers/group.helper.js')
+const RoleHelper = require('../../../support/helpers/role.helper.js')
+const UserGroupHelper = require('../../../support/helpers/user-group.helper.js')
+const UserGroupModel = require('../../../../app/models/user-group.model.js')
+const UserHelper = require('../../../support/helpers/user.helper.js')
+const UserRoleHelper = require('../../../support/helpers/user-role.helper.js')
+const UserRoleModel = require('../../../../app/models/user-role.model.js')
+
+// Thing under test
+const UpdateUserService = require('../../../../app/services/users/internal/update-user.service.js')
+
+describe('Users - Internal - Update User service', () => {
+  let user
+  let group
+  let role
+
+  beforeEach(async () => {
+    user = await UserHelper.add()
+  })
+
+  afterEach(async () => {
+    // Cascading deletes are inconsistently implemented in the database, so we need to manually delete any user groups
+    // and roles that were created during the tests before deleting the user itself
+    await UserGroupModel.query().delete().where('userId', user.userId)
+    await UserRoleModel.query().delete().where('userId', user.userId)
+
+    await user.$query().delete()
+  })
+
+  describe('when called', () => {
+    beforeEach(() => {
+      group = GroupHelper.select(0)
+      role = RoleHelper.select(0)
+      user.groups = [group]
+      user.roles = [role]
+    })
+
+    it('correctly sets the groups and roles', async () => {
+      await UpdateUserService.go(user)
+
+      const userGroups = await UserGroupModel.query().where('userId', user.userId).select(['groupId', 'id', 'userId'])
+      const userRoles = await UserRoleModel.query().where('userId', user.userId).select(['id', 'roleId', 'userId'])
+
+      expect(userGroups).to.equal([{ groupId: group.id, userId: user.userId }], { skip: ['id'] })
+      expect(userRoles).to.equal([{ roleId: role.id, userId: user.userId }], { skip: ['id'] })
+    })
+  })
+
+  describe('when the user has existing groups and roles', () => {
+    beforeEach(async () => {
+      group = GroupHelper.select(1)
+      role = RoleHelper.select(1)
+      await UserGroupHelper.add({ groupId: group.id, userId: user.userId })
+      await UserRoleHelper.add({ roleId: role.id, userId: user.userId })
+
+      user.groups = []
+      user.roles = []
+    })
+
+    it('removes the existing groups and roles', async () => {
+      await UpdateUserService.go(user)
+
+      const userGroups = await UserGroupModel.query().where('userId', user.userId)
+      const userRoles = await UserRoleModel.query().where('userId', user.userId)
+
+      expect(userGroups).to.equal([])
+      expect(userRoles).to.equal([])
+    })
+  })
+})

--- a/test/services/users/internal/view-edit-user.service.test.js
+++ b/test/services/users/internal/view-edit-user.service.test.js
@@ -1,0 +1,74 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+const Boom = require('@hapi/boom')
+
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Things to stub
+const DetermineUserEditableService = require('../../../../app/services/users/internal/determine-user-editable.service.js')
+const FeatureFlagsConfig = require('../../../../config/feature-flags.config.js')
+const FetchAllPermissionsDetailsService = require('../../../../app/services/users/internal/fetch-all-permissions-details.service.js')
+
+// Test helpers
+const UsersFixture = require('../../../support/fixtures/users.fixture.js')
+
+// Thing under test
+const ViewEditUserService = require('../../../../app/services/users/internal/view-edit-user.service.js')
+
+describe('Users - Internal - View Edit User service', () => {
+  const auth = {
+    credentials: { scope: ['manage_accounts'], user: { id: 'dummy-id' } }
+  }
+
+  let user
+
+  beforeEach(() => {
+    user = UsersFixture.basicAccess()
+
+    Sinon.stub(FeatureFlagsConfig, 'enableUsersView').value(true)
+    Sinon.stub(FetchAllPermissionsDetailsService, 'go').resolves({})
+  })
+
+  afterEach(() => {
+    Sinon.restore()
+  })
+
+  describe('when called', () => {
+    beforeEach(() => {
+      Sinon.stub(DetermineUserEditableService, 'go').resolves({ canEdit: true, isSuper: true, user })
+    })
+
+    it('returns page data for the view', async () => {
+      const result = await ViewEditUserService.go(user.id, auth)
+
+      expect(result).to.equal({
+        activeNavBar: 'users',
+        cancelLink: { href: `/system/users/internal/${user.id}`, text: 'Cancel' },
+        id: user.id,
+        lastSignedIn: '6 October 2022 at 10:00:00',
+        pageTitle: 'User basic.access@wrls.gov.uk',
+        pageTitleCaption: 'Internal',
+        permissionOptions: [],
+        permissions: 'basic',
+        status: 'enabled'
+      })
+    })
+  })
+
+  describe('when the user cannot be edited', () => {
+    beforeEach(() => {
+      Sinon.stub(DetermineUserEditableService, 'go').resolves({ canEdit: false, isSuper: true, user })
+    })
+
+    it('returns a "forbidden" error', async () => {
+      const result = await ViewEditUserService.go(user.id, auth)
+
+      expect(result).to.equal(Boom.forbidden())
+    })
+  })
+})

--- a/test/services/users/internal/view-user.service.test.js
+++ b/test/services/users/internal/view-user.service.test.js
@@ -5,25 +5,28 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
 const UsersFixture = require('../../../support/fixtures/users.fixture.js')
 
 // Things we want to stub
+const DetermineUserEditableService = require('../../../../app/services/users/internal/determine-user-editable.service.js')
 const FeatureFlagsConfig = require('../../../../config/feature-flags.config.js')
-const FetchUserService = require('../../../../app/services/users/internal/fetch-user.service.js')
 
 // Thing under test
 const ViewUserService = require('../../../../app/services/users/internal/view-user.service.js')
 
 describe('Users - Internal - View User service', () => {
+  const auth = {
+    credentials: { scope: ['manage_accounts'], user: { id: 'dummy-id' } }
+  }
   const user = UsersFixture.basicAccess()
 
   beforeEach(() => {
     Sinon.stub(FeatureFlagsConfig, 'enableUsersView').value(true)
-    Sinon.stub(FetchUserService, 'go').resolves(user)
+    Sinon.stub(DetermineUserEditableService, 'go').resolves({ canEdit: true, isSuper: true, user })
   })
 
   afterEach(() => {
@@ -32,7 +35,7 @@ describe('Users - Internal - View User service', () => {
 
   describe('when called', () => {
     it('returns page data for the internal user view', async () => {
-      const result = await ViewUserService.go(user.id)
+      const result = await ViewUserService.go(user.id, auth)
 
       expect(result).to.equal({
         activeNavBar: 'users',
@@ -46,6 +49,7 @@ describe('Users - Internal - View User service', () => {
         pageTitleCaption: 'Internal',
         permissions: 'Basic access',
         roles: [],
+        showEditButton: true,
         status: 'enabled'
       })
     })

--- a/test/validators/users/internal/edit-internal-user.validator.test.js
+++ b/test/validators/users/internal/edit-internal-user.validator.test.js
@@ -1,0 +1,60 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Thing under test
+const EditUserValidator = require('../../../../app/validators/users/internal/edit-user.validator.js')
+
+describe('Users - Internal - Edit User Validator', () => {
+  let payload
+
+  beforeEach(() => {
+    payload = { permissions: 'basic' }
+  })
+
+  describe('when valid data is provided', () => {
+    it('confirms the data is valid', () => {
+      const result = EditUserValidator.go(payload)
+
+      expect(result.value).to.exist()
+      expect(result.error).not.to.exist()
+    })
+  })
+
+  describe('when invalid data is provided', () => {
+    describe('because the "permissions" value is missing', () => {
+      beforeEach(() => {
+        payload = {}
+      })
+
+      it('fails validation', () => {
+        const result = EditUserValidator.go(payload)
+
+        expect(result.value).to.exist()
+        expect(result.error).to.exist()
+        expect(result.error.details[0].message).to.equal('Select a valid permission')
+        expect(result.error.details[0].path[0]).to.equal('permissions')
+      })
+    })
+
+    describe('because the "permissions" value is not in the allowed list', () => {
+      beforeEach(() => {
+        payload.permissions = 'an-invalid-value'
+      })
+
+      it('fails validation', () => {
+        const result = EditUserValidator.go(payload)
+
+        expect(result.value).to.exist()
+        expect(result.error).to.exist()
+        expect(result.error.details[0].message).to.equal('Select a valid permission')
+        expect(result.error.details[0].path[0]).to.equal('permissions')
+      })
+    })
+  })
+})


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5514

We have implemented pages for viewing users and now are adding the corresponding pages for editing users.

This change is to implement the page for editing an internal user's permissions.

There are some complications in that only a super user can apply or remove super user permissions, but otherwise it's just a case of a simple edit page to select the required permission level.

The main issue is how the permissions are stored in the database - as a set of roles and groups that are linked to the user record by its old numeric ID rather than the new UUID.

Depending on what happens about all this permissions stuff in the future, we may amend the way this is stored altogether.