### PR TITLE
Update Two-part tariff billing to support 2025-26

### DIFF
--- a/app/presenters/bill-runs/setup/year.presenter.js
+++ b/app/presenters/bill-runs/setup/year.presenter.js
@@ -57,6 +57,7 @@ function _financialYearsData(licenceSupplementaryYears, selectedYear) {
 
 function _tptAnnualFinancialYearsData(selectedYear) {
   return [
+    { text: '2025 to 2026', value: 2026, checked: selectedYear === '2026' },
     { text: '2024 to 2025', value: 2025, checked: selectedYear === '2025' },
     { text: '2021 to 2022', value: 2022, checked: selectedYear === '2022' },
     { text: '2020 to 2021', value: 2021, checked: selectedYear === '2021' }

--- a/app/services/bill-runs/setup/submit-year.service.js
+++ b/app/services/bill-runs/setup/submit-year.service.js
@@ -38,7 +38,7 @@ async function go(sessionId, payload) {
   if (!validationResult) {
     await _save(session, payload)
 
-    return { setupComplete: ['2025', '2024', '2023'].includes(session.year) }
+    return { setupComplete: ['2026', '2025', '2024', '2023'].includes(session.year) }
   }
 
   const regionId = session.region

--- a/app/validators/bill-runs/setup/year.validator.js
+++ b/app/validators/bill-runs/setup/year.validator.js
@@ -7,7 +7,7 @@
 
 const Joi = require('joi')
 
-const VALID_VALUES = ['2025', '2024', '2023', '2022', '2021']
+const VALID_VALUES = ['2026', '2025', '2024', '2023', '2022', '2021']
 
 /**
  * Validates data submitted for the `/bill-runs/setup/{sessionId}/year` page

--- a/test/presenters/bill-runs/setup/year.presenter.test.js
+++ b/test/presenters/bill-runs/setup/year.presenter.test.js
@@ -125,6 +125,11 @@ describe('Bill Runs - Setup - Year presenter', () => {
 function _financialYearsData(selectedYear) {
   return [
     {
+      text: '2025 to 2026',
+      value: 2026,
+      checked: selectedYear === '2026'
+    },
+    {
       text: '2024 to 2025',
       value: 2025,
       checked: selectedYear === '2025'

--- a/test/services/bill-runs/setup/submit-year.service.test.js
+++ b/test/services/bill-runs/setup/submit-year.service.test.js
@@ -34,7 +34,7 @@ describe('Bill Runs - Setup - Submit Year service', () => {
       describe('and the year is in the SROC period', () => {
         beforeEach(() => {
           payload = {
-            year: '2025'
+            year: '2026'
           }
         })
 
@@ -43,7 +43,7 @@ describe('Bill Runs - Setup - Submit Year service', () => {
 
           const refreshedSession = await session.$query()
 
-          expect(refreshedSession.year).to.equal('2025')
+          expect(refreshedSession.year).to.equal('2026')
           expect(result.setupComplete).to.be.true()
         })
       })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5578

Currently, when you create a two-part tariff annual bill run, the journey presents a screen where you select the financial year for which you are creating it.

This is because, for 'reasons', a backlog of two-part tariff annual bill runs has built up. Ordinarily, they would be processed yearly, so it behaves like a standard annual. Users don't select a year because the 'current' year (and for 2PT, 'current' means the previous financial year) is assumed.

Since this page in the annual year is only temporary, we decided to hard-code the years presented rather than waste resources on being 'clever'.

This ticket would have been for the 'drop the page'; however, some of the older two-part tariff bill runs are still in the backlog for processing.

This change updates the page to display the following options

- 2025 to 2026
- 2024 to 2025
- 2021 to 2022
- 2020 to 2021

We've also learnt from our previous attempt (see below)! So, this time, we ensure we cover the supplementary two-part tariff and the validation as well.

- [Update Two-part tariff annual years for 2024-25](https://github.com/DEFRA/water-abstraction-system/pull/2002)
- [Fix invalid fin year in 2PT annual bill run setup](https://github.com/DEFRA/water-abstraction-system/pull/2056)
- [Fix select financial year for 2PT supplementary](https://github.com/DEFRA/water-abstraction-system/pull/2064)
- [Fix select financial year for 2PT supplementary p2](https://github.com/DEFRA/water-abstraction-system/pull/2065)

<img width="636" height="621" alt="water-5578_all-years" src="https://github.com/user-attachments/assets/f0e49dea-1300-4879-a25d-5b4b409ee6b9" />
