### PR TITLE
Bump `marked` a major version to 18.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "joi": "^18.0.0",
         "jsonwebtoken": "^9.0.2",
         "knex": "^3.1.0",
-        "marked": "^17.0.5",
+        "marked": "^18.0.0",
         "nunjucks": "^3.2.4",
         "objection": "^3.1.1",
         "p-map": "^7.0.2",
@@ -7552,9 +7552,10 @@
       }
     },
     "node_modules/marked": {
-      "version": "17.0.6",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.6.tgz",
-      "integrity": "sha512-gB0gkNafnonOw0obSTEGZTT86IuhILt2Wfx0mWH/1Au83kybTayroZ/V6nS25mN7u8ASy+5fMhgB3XPNrOZdmA==",
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.0.tgz",
+      "integrity": "sha512-2e7Qiv/HJSXj8rDEpgTvGKsP8yYtI9xXHKDnrftrmnrJPaFNM7VRb2YCzWaX4BP1iCJ/XPduzDJZMFoqTCcIMA==",
+      "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -15453,9 +15454,9 @@
       "requires": {}
     },
     "marked": {
-      "version": "17.0.6",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.6.tgz",
-      "integrity": "sha512-gB0gkNafnonOw0obSTEGZTT86IuhILt2Wfx0mWH/1Au83kybTayroZ/V6nS25mN7u8ASy+5fMhgB3XPNrOZdmA=="
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.0.tgz",
+      "integrity": "sha512-2e7Qiv/HJSXj8rDEpgTvGKsP8yYtI9xXHKDnrftrmnrJPaFNM7VRb2YCzWaX4BP1iCJ/XPduzDJZMFoqTCcIMA=="
     },
     "math-intrinsics": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "joi": "^18.0.0",
     "jsonwebtoken": "^9.0.2",
     "knex": "^3.1.0",
-    "marked": "^17.0.5",
+    "marked": "^18.0.0",
     "nunjucks": "^3.2.4",
     "objection": "^3.1.1",
     "p-map": "^7.0.2",


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5576

Bump `marked` one major version and fix anything that breaks.

The changelog is available here: https://github.com/markedjs/marked/releases/tag/v18.0.0