### PR TITLE
Bump `nock` a major version to 14.0.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,7 @@
         "jsdoc": "~4.0.3",
         "mock-fs": "^5.2.0",
         "neostandard": "^0.12.0",
-        "nock": "^13.3.2",
+        "nock": "^14.0.12",
         "pino-pretty": "^13.1.1",
         "prettier": "3.3.3",
         "proxyquire": "^2.1.3",
@@ -2106,6 +2106,24 @@
       "integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
       "license": "MIT"
     },
+    "node_modules/@mswjs/interceptors": {
+      "version": "0.41.3",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.3.tgz",
+      "integrity": "sha512-cXu86tF4VQVfwz8W1SPbhoRyHJkti6mjH/XJIxp40jhO4j2k1m4KYrEykxqWPkFF3vrK4rgQppBh//AwyGSXPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "strict-event-emitter": "^0.5.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.11.tgz",
@@ -2171,6 +2189,31 @@
       "engines": {
         "node": ">=12.4.0"
       }
+    },
+    "node_modules/@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@open-draft/logger": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.0"
+      }
+    },
+    "node_modules/@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@parcel/watcher": {
       "version": "2.5.0",
@@ -6866,6 +6909,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -7793,17 +7843,18 @@
       }
     },
     "node_modules/nock": {
-      "version": "13.5.6",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-13.5.6.tgz",
-      "integrity": "sha512-o2zOYiCpzRqSzPj0Zt/dQ/DqZeYoaQ7TUonc/xUPjCGl9WeHpNbxgVvOquXYAaJzI0M9BXV3HTzG0p8IUAbBTQ==",
+      "version": "14.0.12",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-14.0.12.tgz",
+      "integrity": "sha512-kZM3bHV0KzhHH6E2eRszHyML/w87AUzLBwupNTHohtYWP9fZYgUPmCbSKq6ITfEEmHqN4/p0MscvUipT4P5Qsg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "debug": "^4.1.0",
+        "@mswjs/interceptors": "^0.41.0",
         "json-stringify-safe": "^5.0.1",
         "propagate": "^2.0.0"
       },
       "engines": {
-        "node": ">= 10.13"
+        "node": ">=18.20.0 <20 || >=20.12.1"
       }
     },
     "node_modules/node-addon-api": {
@@ -8057,6 +8108,13 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/outvariant": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
+      "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/own-keys": {
       "version": "1.0.1",
@@ -9368,6 +9426,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/strict-event-emitter": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string.prototype.matchall": {
       "version": "4.0.12",
@@ -11811,6 +11876,20 @@
       "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
       "integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA=="
     },
+    "@mswjs/interceptors": {
+      "version": "0.41.3",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.3.tgz",
+      "integrity": "sha512-cXu86tF4VQVfwz8W1SPbhoRyHJkti6mjH/XJIxp40jhO4j2k1m4KYrEykxqWPkFF3vrK4rgQppBh//AwyGSXPA==",
+      "dev": true,
+      "requires": {
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "strict-event-emitter": "^0.5.1"
+      }
+    },
     "@napi-rs/wasm-runtime": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.11.tgz",
@@ -11862,6 +11941,28 @@
       "version": "1.0.39",
       "resolved": "https://registry.npmjs.org/@nolyfill/is-core-module/-/is-core-module-1.0.39.tgz",
       "integrity": "sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==",
+      "dev": true
+    },
+    "@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "dev": true
+    },
+    "@open-draft/logger": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+      "dev": true,
+      "requires": {
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.0"
+      }
+    },
+    "@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
       "dev": true
     },
     "@parcel/watcher": {
@@ -14964,6 +15065,12 @@
       "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
       "dev": true
     },
+    "is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "dev": true
+    },
     "is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -15617,12 +15724,12 @@
       }
     },
     "nock": {
-      "version": "13.5.6",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-13.5.6.tgz",
-      "integrity": "sha512-o2zOYiCpzRqSzPj0Zt/dQ/DqZeYoaQ7TUonc/xUPjCGl9WeHpNbxgVvOquXYAaJzI0M9BXV3HTzG0p8IUAbBTQ==",
+      "version": "14.0.12",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-14.0.12.tgz",
+      "integrity": "sha512-kZM3bHV0KzhHH6E2eRszHyML/w87AUzLBwupNTHohtYWP9fZYgUPmCbSKq6ITfEEmHqN4/p0MscvUipT4P5Qsg==",
       "dev": true,
       "requires": {
-        "debug": "^4.1.0",
+        "@mswjs/interceptors": "^0.41.0",
         "json-stringify-safe": "^5.0.1",
         "propagate": "^2.0.0"
       }
@@ -15798,6 +15905,12 @@
         "prelude-ls": "^1.2.1",
         "type-check": "^0.4.0"
       }
+    },
+    "outvariant": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
+      "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
+      "dev": true
     },
     "own-keys": {
       "version": "1.0.1",
@@ -16716,6 +16829,12 @@
         "es-errors": "^1.3.0",
         "internal-slot": "^1.1.0"
       }
+    },
+    "strict-event-emitter": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+      "dev": true
     },
     "string.prototype.matchall": {
       "version": "4.0.12",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "jsdoc": "~4.0.3",
     "mock-fs": "^5.2.0",
     "neostandard": "^0.12.0",
-    "nock": "^13.3.2",
+    "nock": "^14.0.12",
     "pino-pretty": "^13.1.1",
     "prettier": "3.3.3",
     "proxyquire": "^2.1.3",

--- a/test/lib/got-wrapper.lib.test.js
+++ b/test/lib/got-wrapper.lib.test.js
@@ -17,11 +17,16 @@ describe('GotWrapperLib', () => {
   let request
 
   beforeEach(async () => {
+    if (!Nock.isActive()) {
+      Nock.activate()
+    }
+
     request = await gotWrapper()
   })
 
   afterEach(() => {
     Nock.cleanAll()
+    Nock.restore()
   })
 
   describe('when called with a string URL for a GET request', () => {

--- a/test/requests/base.request.test.js
+++ b/test/requests/base.request.test.js
@@ -37,6 +37,10 @@ describe('Base Request', () => {
   let notifierStub
 
   beforeEach(() => {
+    if (!Nock.isActive()) {
+      Nock.activate()
+    }
+
     // BaseRequest depends on the GlobalNotifier to have been set. This happens in app/plugins/global-notifier.plugin.js
     // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
     // test we recreate the condition by setting it directly with our own stub
@@ -47,6 +51,7 @@ describe('Base Request', () => {
   afterEach(() => {
     Sinon.restore()
     Nock.cleanAll()
+    Nock.restore()
     delete global.GlobalNotifier
   })
 
@@ -119,7 +124,7 @@ describe('Base Request', () => {
               .delete(() => {
                 return true
               })
-              .replyWithError({ code: 'ECONNRESET' })
+              .replyWithError(_connectionResetError())
               .persist()
           })
 
@@ -167,7 +172,7 @@ describe('Base Request', () => {
               .delete(() => {
                 return true
               })
-              .replyWithError({ code: 'ECONNRESET' })
+              .replyWithError(_connectionResetError())
               .delete(() => {
                 return true
               })
@@ -399,7 +404,7 @@ describe('Base Request', () => {
               .get(() => {
                 return true
               })
-              .replyWithError({ code: 'ECONNRESET' })
+              .replyWithError(_connectionResetError())
               .persist()
           })
 
@@ -447,7 +452,7 @@ describe('Base Request', () => {
               .get(() => {
                 return true
               })
-              .replyWithError({ code: 'ECONNRESET' })
+              .replyWithError(_connectionResetError())
               .get(() => {
                 return true
               })
@@ -679,7 +684,7 @@ describe('Base Request', () => {
               .patch(() => {
                 return true
               })
-              .replyWithError({ code: 'ECONNRESET' })
+              .replyWithError(_connectionResetError())
               .persist()
           })
 
@@ -727,7 +732,7 @@ describe('Base Request', () => {
               .patch(() => {
                 return true
               })
-              .replyWithError({ code: 'ECONNRESET' })
+              .replyWithError(_connectionResetError())
               .patch(() => {
                 return true
               })
@@ -959,7 +964,7 @@ describe('Base Request', () => {
               .post(() => {
                 return true
               })
-              .replyWithError({ code: 'ECONNRESET' })
+              .replyWithError(_connectionResetError())
               .persist()
           })
 
@@ -1007,7 +1012,7 @@ describe('Base Request', () => {
               .post(() => {
                 return true
               })
-              .replyWithError({ code: 'ECONNRESET' })
+              .replyWithError(_connectionResetError())
               .post(() => {
                 return true
               })
@@ -1170,3 +1175,7 @@ describe('Base Request', () => {
     })
   })
 })
+
+function _connectionResetError() {
+  return Object.assign(new Error('Connection reset by peer'), { code: 'ECONNRESET' })
+}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5576

Bump `nock` one major version and fix anything that breaks.

The changelog is available here: https://github.com/nock/nock/releases?page=3

There were some unexpected test failures following this major version bump. The only breaking changes listed were "drop support for Node < 18", but this doesn't appear to be the case.

---
The `got-wrapper.lib.test.js` failed so was updated to explicitly manage nock interceptor lifecycle per test under nock v14:

- Added a guard in `beforeEach` to call `Nock.activate()` when nock is inactive.
- Kept existing `Nock.cleanAll()` in `afterEach` and added `Nock.restore()` afterwards.

Why this change:

- nock v14 introduces interceptor-related global Symbols while active.
- Without restoring nock, Lab can report global leaks at the end of a run.
- Explicit activate/restore keeps tests isolated and deterministic, and avoids needing global leak exceptions in config.

---
The `base.request.test.js` failed for the same reasons as `got-wrapper.lib.test.js` and required the same fixes. An additonal change was also made:

- Replaced network error mocks to use real Error instances (via helper returning Error + ECONNRESET) for all replyWithError cases, instead of plain objects.