### PR TITLE
show customer name on check page

### DIFF
--- a/app/presenters/billing-accounts/setup/check.presenter.js
+++ b/app/presenters/billing-accounts/setup/check.presenter.js
@@ -81,8 +81,8 @@ function _contactSelected(session, companyContacts) {
     return 'New contact'
   }
 
-  if (!companyContacts?.contacts?.length) {
-    return ''
+  if (session.fao === 'no' || !companyContacts?.contacts?.length) {
+    return null
   }
 
   const selectedContact = contacts.find((contact) => {

--- a/app/presenters/billing-accounts/setup/check.presenter.js
+++ b/app/presenters/billing-accounts/setup/check.presenter.js
@@ -19,7 +19,7 @@ function go(session, companyContacts, existingAddress, companysHouseResult) {
   const { billingAccount } = session
 
   return {
-    accountSelected: session.accountSelected === 'customer' ? billingAccount.company.name : 'Another billing account',
+    accountSelected: session.accountSelected !== 'another' ? billingAccount.company.name : 'Another billing account',
     accountType: session.accountType ?? '',
     address: _address(session),
     addressSelected: _existingAddress(existingAddress),

--- a/test/presenters/billing-accounts/setup/check.presenter.test.js
+++ b/test/presenters/billing-accounts/setup/check.presenter.test.js
@@ -399,12 +399,29 @@ describe('Billing Accounts - Setup - Check Presenter', () => {
       companyContacts.contacts.push(contact)
     })
 
+    describe('when "fao" was "no', () => {
+      it('returns string for display', () => {
+        const result = CheckPresenter.go(
+          {
+            ...session,
+            fao: 'no'
+          },
+          companyContacts,
+          address,
+          companysHouseResult
+        )
+
+        expect(result.contactSelected).to.equal(null)
+      })
+    })
+
     describe('when "new" was selected', () => {
       it('returns string for display', () => {
         const result = CheckPresenter.go(
           {
             ...session,
-            contactSelected: 'new'
+            contactSelected: 'new',
+            fao: 'yes'
           },
           companyContacts,
           address,
@@ -420,7 +437,8 @@ describe('Billing Accounts - Setup - Check Presenter', () => {
         const result = CheckPresenter.go(
           {
             ...session,
-            contactSelected: contact.id
+            contactSelected: contact.id,
+            fao: 'yes'
           },
           companyContacts,
           address,

--- a/test/presenters/billing-accounts/setup/check.presenter.test.js
+++ b/test/presenters/billing-accounts/setup/check.presenter.test.js
@@ -75,12 +75,12 @@ describe('Billing Accounts - Setup - Check Presenter', () => {
   })
 
   describe('the "accountSelected" property', () => {
-    describe('when called with the "accountSelected" set to "customer"', () => {
+    describe('when called with the "accountSelected" set to a UUID', () => {
       it('returns the name from the billing account', () => {
         const result = CheckPresenter.go(
           {
             ...session,
-            accountSelected: 'customer'
+            accountSelected: generateUUID()
           },
           companyContacts,
           address,

--- a/test/presenters/billing-accounts/setup/check.presenter.test.js
+++ b/test/presenters/billing-accounts/setup/check.presenter.test.js
@@ -44,14 +44,14 @@ describe('Billing Accounts - Setup - Check Presenter', () => {
       const result = CheckPresenter.go(session, companyContacts, [], null)
 
       expect(result).to.equal({
-        accountSelected: 'Another billing account',
+        accountSelected: 'Ferns Surfacing Limited',
         accountType: '',
         address: [],
         addressSelected: ['New'],
         companiesHouseName: '',
         companySearch: '',
         contactName: '',
-        contactSelected: '',
+        contactSelected: null,
         existingAccount: '',
         fao: 'no',
         links: {

--- a/test/services/billing-accounts/setup/view-check.service.test.js
+++ b/test/services/billing-accounts/setup/view-check.service.test.js
@@ -33,13 +33,13 @@ describe('Billing Accounts - Setup - View Check Service', () => {
       const result = await ViewCheckService.go(session.id)
 
       expect(result).to.equal({
-        accountSelected: 'Another billing account',
+        accountSelected: 'Ferns Surfacing Limited',
         accountType: '',
         address: [],
         addressSelected: ['New'],
         companiesHouseName: '',
         companySearch: '',
-        contactSelected: '',
+        contactSelected: null,
         contactName: '',
         existingAccount: '',
         fao: 'no',


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5466

As part of our ongoing work to decommission our legacy UI we identify journeys that are small enough to be ported over in discreet chunks of work. This is part of the change billing address journey.

This PR fixes a couple of issues found on the check page. We weren't showing the customer name when selected and when a user chose no for an fao it was erroring when there was a contact found.