### PR TITLE
Add copilot workspace instructions to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ docs/
 
 # ignore husky config
 .husky/
+
+# ignore local copilot workspace instruction file
+.github/copilot-instructions.md


### PR DESCRIPTION
We are currently experimenting with adding various instructions for copilot that we can potentially share between the devs.

Whilst we are experimenting with this we do not want the `.github/copilot-instructions.md` to be pushed up to GitHub.