### PR TITLE
Update all pages to use the 'FetchSessionDal'

### DIFF
--- a/app/services/address/international.service.js
+++ b/app/services/address/international.service.js
@@ -6,8 +6,8 @@
  * @module InternationalService
  */
 
+const FetchSessionDal = require('../../dal/fetch-session.dal.js')
 const InternationalPresenter = require('../../presenters/address/international.presenter.js')
-const SessionModel = require('../../models/session.model.js')
 
 /**
  * Orchestrates fetching and presenting the data for the `address/{sessionId}/international` page
@@ -17,7 +17,7 @@ const SessionModel = require('../../models/session.model.js')
  * @returns {Promise<object>} - The data formatted for the view template
  */
 async function go(sessionId) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const pageData = InternationalPresenter.go(session)
 

--- a/app/services/address/manual.service.js
+++ b/app/services/address/manual.service.js
@@ -6,8 +6,8 @@
  * @module ManualService
  */
 
+const FetchSessionDal = require('../../dal/fetch-session.dal.js')
 const ManualAddressPresenter = require('../../presenters/address/manual.presenter.js')
-const SessionModel = require('../../models/session.model.js')
 
 /**
  * Orchestrates fetching and presenting the data for the `address/{sessionId}/manual` page
@@ -17,7 +17,7 @@ const SessionModel = require('../../models/session.model.js')
  * @returns {Promise<object>} - The data formatted for the view template
  */
 async function go(sessionId) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const pageData = ManualAddressPresenter.go(session)
 

--- a/app/services/address/postcode.service.js
+++ b/app/services/address/postcode.service.js
@@ -6,8 +6,8 @@
  * @module PostcodeService
  */
 
+const FetchSessionDal = require('../../dal/fetch-session.dal.js')
 const PostcodePresenter = require('../../presenters/address/postcode.presenter.js')
-const SessionModel = require('../../models/session.model.js')
 
 /**
  * Orchestrates fetching and presenting the data for the `address/{sessionId}/postcode` page
@@ -17,7 +17,7 @@ const SessionModel = require('../../models/session.model.js')
  * @returns {Promise<object>} - The data formatted for the view template
  */
 async function go(sessionId) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const pageData = PostcodePresenter.go(session)
 

--- a/app/services/address/select.service.js
+++ b/app/services/address/select.service.js
@@ -6,9 +6,9 @@
  * @module SelectAddressService
  */
 
+const FetchSessionDal = require('../../dal/fetch-session.dal.js')
 const LookupPostcodeRequest = require('../../requests/address-facade/lookup-postcode.request.js')
 const SelectPresenter = require('../../presenters/address/select.presenter.js')
-const SessionModel = require('../../models/session.model.js')
 
 /**
  * Orchestrates fetching and presenting the data for the `address/{sessionId}/select` page
@@ -18,7 +18,7 @@ const SessionModel = require('../../models/session.model.js')
  * @returns {Promise<object>} - The data formatted for the view template
  */
 async function go(sessionId) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const result = await LookupPostcodeRequest.send(session.addressJourney.address.postcode)
 

--- a/app/services/address/submit-international.service.js
+++ b/app/services/address/submit-international.service.js
@@ -8,7 +8,7 @@
 
 const InternationalPresenter = require('../../presenters/address/international.presenter.js')
 const InternationalValidator = require('../../validators/address/international.validator.js')
-const SessionModel = require('../../models/session.model.js')
+const FetchSessionDal = require('../../dal/fetch-session.dal.js')
 const { formatValidationResult } = require('../../presenters/base.presenter.js')
 
 /**
@@ -20,7 +20,7 @@ const { formatValidationResult } = require('../../presenters/base.presenter.js')
  * @returns {Promise<object>} - The data formatted for the view template
  */
 async function go(sessionId, payload) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   _applyPayload(session, payload)
 

--- a/app/services/address/submit-manual.service.js
+++ b/app/services/address/submit-manual.service.js
@@ -6,9 +6,9 @@
  * @module SubmitManualService
  */
 
+const FetchSessionDal = require('../../dal/fetch-session.dal.js')
 const ManualAddressPresenter = require('../../presenters/address/manual.presenter.js')
 const ManualAddressValidator = require('../../validators/address/manual.validator.js')
-const SessionModel = require('../../models/session.model.js')
 const { formatValidationResult } = require('../../presenters/base.presenter.js')
 
 /**
@@ -20,7 +20,7 @@ const { formatValidationResult } = require('../../presenters/base.presenter.js')
  * @returns {Promise<object>} - The data formatted for the view template
  */
 async function go(sessionId, payload) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   _applyPayload(session, payload)
 

--- a/app/services/address/submit-postcode.service.js
+++ b/app/services/address/submit-postcode.service.js
@@ -6,9 +6,9 @@
  * @module SubmitPostcodeService
  */
 
+const FetchSessionDal = require('../../dal/fetch-session.dal.js')
 const PostcodePresenter = require('../../presenters/address/postcode.presenter.js')
 const PostcodeValidator = require('../../validators/address/postcode.validator.js')
-const SessionModel = require('../../models/session.model.js')
 const { formatValidationResult } = require('../../presenters/base.presenter.js')
 
 /**
@@ -20,7 +20,7 @@ const { formatValidationResult } = require('../../presenters/base.presenter.js')
  * @returns {Promise<object>} - The data formatted for the view template
  */
 async function go(sessionId, payload) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   _applyPayload(session, payload)
 

--- a/app/services/address/submit-select.service.js
+++ b/app/services/address/submit-select.service.js
@@ -6,11 +6,11 @@
  * @module SubmitSelectService
  */
 
+const FetchSessionDal = require('../../dal/fetch-session.dal.js')
 const LookupPostcodeRequest = require('../../requests/address-facade/lookup-postcode.request.js')
 const LookupUPRNRequest = require('../../requests/address-facade/lookup-uprn.request.js')
 const SelectPresenter = require('../../presenters/address/select.presenter.js')
 const SelectValidator = require('../../validators/address/select.validator.js')
-const SessionModel = require('../../models/session.model.js')
 const { formatValidationResult } = require('../../presenters/base.presenter.js')
 
 /**
@@ -22,7 +22,7 @@ const { formatValidationResult } = require('../../presenters/base.presenter.js')
  * @returns {Promise<object>} - The data formatted for the view template
  */
 async function go(sessionId, payload) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const error = _validate(payload)
 

--- a/app/services/bill-runs/setup/check.service.js
+++ b/app/services/bill-runs/setup/check.service.js
@@ -8,8 +8,8 @@
 const AllowedBillRunPresenter = require('../../../presenters/bill-runs/setup/check/allowed-bill-run.presenter.js')
 const BlockedBillRunPresenter = require('../../../../app/presenters/bill-runs/setup/check/blocked-bill-run.presenter.js')
 const DetermineBlockingBillRunService = require('./determine-blocking-bill-run.service.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const NoAnnualBillRunPresenter = require('../../../presenters/bill-runs/setup/check/no-annual-bill-run.presenter.js')
-const SessionModel = require('../../../models/session.model.js')
 const { engineTriggers } = require('../../../../app/lib/static-lookups.lib.js')
 
 /**
@@ -20,7 +20,7 @@ const { engineTriggers } = require('../../../../app/lib/static-lookups.lib.js')
  * @returns {Promise<object>} The view data for the check page
  */
 async function go(sessionId) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
   const blockingResults = await DetermineBlockingBillRunService.go(session)
 
   const formattedData = _formattedData(session, blockingResults)

--- a/app/services/bill-runs/setup/no-licences.service.js
+++ b/app/services/bill-runs/setup/no-licences.service.js
@@ -5,8 +5,8 @@
  * @module NoLicencesService
  */
 
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const RegionModel = require('../../../models/region.model.js')
-const SessionModel = require('../../../models/session.model.js')
 
 /**
  * Handles fetching the region name for `/bill-runs/setup/{sessionId}/no-licences` page
@@ -19,7 +19,7 @@ const SessionModel = require('../../../models/session.model.js')
  * @returns {Promise<string>} The display name of the region
  */
 async function go(sessionId) {
-  const { region: regionId } = await SessionModel.query().findById(sessionId)
+  const { region: regionId } = await FetchSessionDal.go(sessionId)
   const { displayName: regionName } = await RegionModel.query().findById(regionId).select('displayName')
 
   return {

--- a/app/services/bill-runs/setup/region.service.js
+++ b/app/services/bill-runs/setup/region.service.js
@@ -6,8 +6,8 @@
  */
 
 const FetchRegionsService = require('./fetch-regions.service.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const RegionPresenter = require('../../../presenters/bill-runs/setup/region.presenter.js')
-const SessionModel = require('../../../models/session.model.js')
 
 /**
  * Orchestrates fetching and presenting the data for `/bill-runs/setup/{sessionId}/region` page
@@ -20,7 +20,7 @@ const SessionModel = require('../../../models/session.model.js')
  * @returns {Promise<object>} The view data for the region page
  */
 async function go(sessionId) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
   const regions = await FetchRegionsService.go()
 
   const formattedData = RegionPresenter.go(session, regions)

--- a/app/services/bill-runs/setup/season.service.js
+++ b/app/services/bill-runs/setup/season.service.js
@@ -5,7 +5,7 @@
  * @module BillRunsCreateSeasonService
  */
 
-const SessionModel = require('../../../models/session.model.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const SeasonPresenter = require('../../../presenters/bill-runs/setup/season.presenter.js')
 
 /**
@@ -19,7 +19,7 @@ const SeasonPresenter = require('../../../presenters/bill-runs/setup/season.pres
  * @returns {Promise<object>} The view data for the season page
  */
 async function go(sessionId) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const formattedData = SeasonPresenter.go(session)
 

--- a/app/services/bill-runs/setup/submit-check.service.js
+++ b/app/services/bill-runs/setup/submit-check.service.js
@@ -9,8 +9,8 @@ const AllowedBillRunPresenter = require('../../../presenters/bill-runs/setup/che
 const BlockedBillRunPresenter = require('../../../../app/presenters/bill-runs/setup/check/blocked-bill-run.presenter.js')
 const CreateService = require('./create.service.js')
 const DetermineBlockingBillRunService = require('./determine-blocking-bill-run.service.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const NoAnnualBillRunPresenter = require('../../../presenters/bill-runs/setup/check/no-annual-bill-run.presenter.js')
-const SessionModel = require('../../../models/session.model.js')
 const { engineTriggers } = require('../../../lib/static-lookups.lib.js')
 
 /**
@@ -40,7 +40,7 @@ const { engineTriggers } = require('../../../lib/static-lookups.lib.js')
  * '/exists' page.
  */
 async function go(sessionId, auth) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const blockingResults = await DetermineBlockingBillRunService.go(session)
 

--- a/app/services/bill-runs/setup/submit-region.service.js
+++ b/app/services/bill-runs/setup/submit-region.service.js
@@ -6,9 +6,9 @@
  */
 
 const FetchRegionsService = require('./fetch-regions.service.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const RegionPresenter = require('../../../presenters/bill-runs/setup/region.presenter.js')
 const RegionValidator = require('../../../validators/bill-runs/setup/region.validator.js')
-const SessionModel = require('../../../models/session.model.js')
 
 /**
  * Handles the user submission for the `/bill-runs/setup/{sessionId}/region` page
@@ -31,7 +31,7 @@ const SessionModel = require('../../../models/session.model.js')
  * the region page including the validation error details
  */
 async function go(sessionId, payload) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
   const regions = await FetchRegionsService.go()
 
   const validationResult = _validate(payload, regions)

--- a/app/services/bill-runs/setup/submit-season.service.js
+++ b/app/services/bill-runs/setup/submit-season.service.js
@@ -5,7 +5,7 @@
  * @module SubmitSeasonService
  */
 
-const SessionModel = require('../../../models/session.model.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const SeasonPresenter = require('../../../presenters/bill-runs/setup/season.presenter.js')
 const SeasonValidator = require('../../../validators/bill-runs/setup/season.validator.js')
 
@@ -29,7 +29,7 @@ const SeasonValidator = require('../../../validators/bill-runs/setup/season.vali
  * validation error details
  */
 async function go(sessionId, payload) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const validationResult = _validate(payload)
 

--- a/app/services/bill-runs/setup/submit-type.service.js
+++ b/app/services/bill-runs/setup/submit-type.service.js
@@ -5,7 +5,7 @@
  * @module SubmitTypeService
  */
 
-const SessionModel = require('../../../models/session.model.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const TypePresenter = require('../../../presenters/bill-runs/setup/type.presenter.js')
 const TypeValidator = require('../../../validators/bill-runs/setup/type.validator.js')
 
@@ -29,7 +29,7 @@ const TypeValidator = require('../../../validators/bill-runs/setup/type.validato
  * validation error details
  */
 async function go(sessionId, payload) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const validationResult = _validate(payload)
 

--- a/app/services/bill-runs/setup/submit-year.service.js
+++ b/app/services/bill-runs/setup/submit-year.service.js
@@ -6,7 +6,7 @@
  */
 
 const FetchLicenceSupplementaryYearsService = require('./fetch-licence-supplementary-years.service.js')
-const SessionModel = require('../../../models/session.model.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const YearPresenter = require('../../../presenters/bill-runs/setup/year.presenter.js')
 const YearValidator = require('../../../validators/bill-runs/setup/year.validator.js')
 
@@ -31,7 +31,7 @@ const YearValidator = require('../../../validators/bill-runs/setup/year.validato
  * the year page including the validation error details
  */
 async function go(sessionId, payload) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const validationResult = _validate(payload)
 

--- a/app/services/bill-runs/setup/type.service.js
+++ b/app/services/bill-runs/setup/type.service.js
@@ -5,7 +5,7 @@
  * @module TypeService
  */
 
-const SessionModel = require('../../../models/session.model.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const TypePresenter = require('../../../presenters/bill-runs/setup/type.presenter.js')
 
 /**
@@ -19,7 +19,7 @@ const TypePresenter = require('../../../presenters/bill-runs/setup/type.presente
  * @returns {Promise<object>} The view data for the type page
  */
 async function go(sessionId) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const pageData = TypePresenter.go(session)
 

--- a/app/services/bill-runs/setup/year.service.js
+++ b/app/services/bill-runs/setup/year.service.js
@@ -6,7 +6,7 @@
  */
 
 const FetchLicenceSupplementaryYearsService = require('./fetch-licence-supplementary-years.service.js')
-const SessionModel = require('../../../models/session.model.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const YearPresenter = require('../../../presenters/bill-runs/setup/year.presenter.js')
 
 /**
@@ -20,7 +20,7 @@ const YearPresenter = require('../../../presenters/bill-runs/setup/year.presente
  * @returns {Promise<object>} The view data for the year page
  */
 async function go(sessionId) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const regionId = session.region
   const twoPartTariffSupplementary = session.type === 'two_part_supplementary'

--- a/app/services/billing-accounts/setup/submit-account-type.service.js
+++ b/app/services/billing-accounts/setup/submit-account-type.service.js
@@ -8,7 +8,7 @@
 
 const AccountTypePresenter = require('../../../presenters/billing-accounts/setup/account-type.presenter.js')
 const AccountTypeValidator = require('../../../validators/billing-accounts/setup/account-type.validator.js')
-const SessionModel = require('../../../models/session.model.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const { formatValidationResult } = require('../../../presenters/base.presenter.js')
 
 /**
@@ -20,7 +20,7 @@ const { formatValidationResult } = require('../../../presenters/base.presenter.j
  * @returns {Promise<object>} The data formatted for the view template
  */
 async function go(sessionId, payload) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const validationResult = _validate(payload)
 

--- a/app/services/billing-accounts/setup/submit-account.service.js
+++ b/app/services/billing-accounts/setup/submit-account.service.js
@@ -6,9 +6,9 @@
  * @module SubmitAccountService
  */
 
-const SessionModel = require('../../../models/session.model.js')
 const AccountPresenter = require('../../../presenters/billing-accounts/setup/account.presenter.js')
 const AccountValidator = require('../../../validators/billing-accounts/setup/account.validator.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 
 const { formatValidationResult } = require('../../../presenters/base.presenter.js')
 
@@ -21,7 +21,7 @@ const { formatValidationResult } = require('../../../presenters/base.presenter.j
  * @returns {Promise<object>} The data formatted for the view template
  */
 async function go(sessionId, payload) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const validationResult = _validate(payload)
 

--- a/app/services/billing-accounts/setup/submit-check.service.js
+++ b/app/services/billing-accounts/setup/submit-check.service.js
@@ -6,7 +6,7 @@
  * @module SubmitCheckService
  */
 
-const SessionModel = require('../../../models/session.model.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 
 /**
  * Orchestrates validating the data for `/billing-accounts/setup/{sessionId}/check` page
@@ -16,7 +16,7 @@ const SessionModel = require('../../../models/session.model.js')
  * @returns {Promise<object>} The data formatted for the view template
  */
 async function go(sessionId) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   await _save(session)
 

--- a/app/services/billing-accounts/setup/submit-company-search.service.js
+++ b/app/services/billing-accounts/setup/submit-company-search.service.js
@@ -8,7 +8,7 @@
 
 const CompanySearchPresenter = require('../../../presenters/billing-accounts/setup/company-search.presenter.js')
 const CompanySearchValidator = require('../../../validators/billing-accounts/setup/company-search.validator.js')
-const SessionModel = require('../../../models/session.model.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const { formatValidationResult } = require('../../../presenters/base.presenter.js')
 
 /**
@@ -20,7 +20,7 @@ const { formatValidationResult } = require('../../../presenters/base.presenter.j
  * @returns {Promise<object>} The data formatted for the view template
  */
 async function go(sessionId, payload) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const validationResult = _validate(payload)
 

--- a/app/services/billing-accounts/setup/submit-contact-name.service.js
+++ b/app/services/billing-accounts/setup/submit-contact-name.service.js
@@ -8,7 +8,7 @@
 
 const ContactNamePresenter = require('../../../presenters/billing-accounts/setup/contact-name.presenter.js')
 const ContactNameValidator = require('../../../validators/billing-accounts/setup/contact-name.validator.js')
-const SessionModel = require('../../../models/session.model.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const { formatValidationResult } = require('../../../presenters/base.presenter.js')
 
 /**
@@ -20,7 +20,7 @@ const { formatValidationResult } = require('../../../presenters/base.presenter.j
  * @returns {Promise<object>} The data formatted for the view template
  */
 async function go(sessionId, payload) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const validationResult = _validate(payload)
 

--- a/app/services/billing-accounts/setup/submit-contact.service.js
+++ b/app/services/billing-accounts/setup/submit-contact.service.js
@@ -9,7 +9,7 @@
 const ContactPresenter = require('../../../presenters/billing-accounts/setup/contact.presenter.js')
 const ContactValidator = require('../../../validators/billing-accounts/setup/contact.validator.js')
 const FetchCompanyContactsService = require('./fetch-company-contacts.service.js')
-const SessionModel = require('../../../models/session.model.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const { formatValidationResult } = require('../../../presenters/base.presenter.js')
 
 /**
@@ -21,7 +21,7 @@ const { formatValidationResult } = require('../../../presenters/base.presenter.j
  * @returns {Promise<object>} The data formatted for the view template
  */
 async function go(sessionId, payload) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const validationResult = _validate(payload)
 

--- a/app/services/billing-accounts/setup/submit-existing-account.service.js
+++ b/app/services/billing-accounts/setup/submit-existing-account.service.js
@@ -9,7 +9,7 @@
 const ExistingAccountPresenter = require('../../../presenters/billing-accounts/setup/existing-account.presenter.js')
 const ExistingAccountValidator = require('../../../validators/billing-accounts/setup/existing-account.validator.js')
 const FetchExistingCompaniesService = require('./fetch-existing-companies.service.js')
-const SessionModel = require('../../../models/session.model.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const { formatValidationResult } = require('../../../presenters/base.presenter.js')
 
 /**
@@ -21,7 +21,7 @@ const { formatValidationResult } = require('../../../presenters/base.presenter.j
  * @returns {Promise<object>} The data formatted for the view template
  */
 async function go(sessionId, payload) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const validationResult = _validate(payload)
 

--- a/app/services/billing-accounts/setup/submit-existing-address.service.js
+++ b/app/services/billing-accounts/setup/submit-existing-address.service.js
@@ -6,10 +6,10 @@
  * @module SubmitExistingAddressService
  */
 
-const FetchCompanyAddressesService = require('./fetch-company-addresses.service.js')
 const ExistingAddressPresenter = require('../../../presenters/billing-accounts/setup/existing-address.presenter.js')
 const ExistingAddressValidator = require('../../../validators/billing-accounts/setup/existing-address.validator.js')
-const SessionModel = require('../../../models/session.model.js')
+const FetchCompanyAddressesService = require('./fetch-company-addresses.service.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 
 const { formatValidationResult } = require('../../../presenters/base.presenter.js')
 
@@ -22,7 +22,7 @@ const { formatValidationResult } = require('../../../presenters/base.presenter.j
  * @returns {Promise<object>} The data formatted for the view template
  */
 async function go(sessionId, payload) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
   const companyAddresses = await _fetchCompanyAddresses(session)
 
   const validationResult = _validate(payload, companyAddresses.company.name)

--- a/app/services/billing-accounts/setup/submit-fao.service.js
+++ b/app/services/billing-accounts/setup/submit-fao.service.js
@@ -8,7 +8,7 @@
 
 const FAOPresenter = require('../../../presenters/billing-accounts/setup/fao.presenter.js')
 const FAOValidator = require('../../../validators/billing-accounts/setup/fao.validator.js')
-const SessionModel = require('../../../models/session.model.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const { formatValidationResult } = require('../../../presenters/base.presenter.js')
 
 /**
@@ -20,7 +20,7 @@ const { formatValidationResult } = require('../../../presenters/base.presenter.j
  * @returns {Promise<object>} The data formatted for the view template
  */
 async function go(sessionId, payload) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const validationResult = _validate(payload)
 

--- a/app/services/billing-accounts/setup/submit-select-company.service.js
+++ b/app/services/billing-accounts/setup/submit-select-company.service.js
@@ -7,9 +7,9 @@
  */
 
 const FetchCompaniesService = require('./fetch-companies.service.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const SelectCompanyPresenter = require('../../../presenters/billing-accounts/setup/select-company.presenter.js')
 const SelectCompanyValidator = require('../../../validators/billing-accounts/setup/select-company.validator.js')
-const SessionModel = require('../../../models/session.model.js')
 const { formatValidationResult } = require('../../../presenters/base.presenter.js')
 
 /**
@@ -21,7 +21,7 @@ const { formatValidationResult } = require('../../../presenters/base.presenter.j
  * @returns {Promise<object>} The data formatted for the view template
  */
 async function go(sessionId, payload) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const validationResult = _validate(payload)
 

--- a/app/services/billing-accounts/setup/view-account-type.service.js
+++ b/app/services/billing-accounts/setup/view-account-type.service.js
@@ -7,7 +7,7 @@
  */
 
 const AccountTypePresenter = require('../../../presenters/billing-accounts/setup/account-type.presenter.js')
-const SessionModel = require('../../../models/session.model.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 
 /**
  * Orchestrates fetching and presenting the data for the `/billing-accounts/setup/{billingAccountId}/account-type` page
@@ -17,7 +17,7 @@ const SessionModel = require('../../../models/session.model.js')
  * @returns {Promise<object>} The data formatted for the view template
  */
 async function go(sessionId) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const pageData = AccountTypePresenter.go(session)
 

--- a/app/services/billing-accounts/setup/view-account.service.js
+++ b/app/services/billing-accounts/setup/view-account.service.js
@@ -7,7 +7,7 @@
  */
 
 const AccountPresenter = require('../../../presenters/billing-accounts/setup/account.presenter.js')
-const SessionModel = require('../../../models/session.model.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 
 /**
  * Orchestrates fetching and presenting the data for the `/billing-accounts/setup/{sessionId}/account` page
@@ -17,7 +17,7 @@ const SessionModel = require('../../../models/session.model.js')
  * @returns {Promise<object>} The data formatted for the view template
  */
 async function go(sessionId) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const pageData = AccountPresenter.go(session)
 

--- a/app/services/billing-accounts/setup/view-check.service.js
+++ b/app/services/billing-accounts/setup/view-check.service.js
@@ -8,9 +8,9 @@
 
 const AddressModel = require('../../../models/address.model.js')
 const CheckPresenter = require('../../../presenters/billing-accounts/setup/check.presenter.js')
-const FetchCompanyService = require('./fetch-company.service.js')
 const FetchCompanyContactsService = require('./fetch-company-contacts.service.js')
-const SessionModel = require('../../../models/session.model.js')
+const FetchCompanyService = require('./fetch-company.service.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const { markCheckPageVisited } = require('../../../lib/check-page.lib.js')
 
 /**
@@ -21,7 +21,7 @@ const { markCheckPageVisited } = require('../../../lib/check-page.lib.js')
  * @returns {Promise<object>} The data formatted for the view template
  */
 async function go(sessionId) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
   const existingAddress = await _fetchExistingAddress(session)
   const companyContacts = await _fetchCompanyContacts(session)
   const companysHouseResult = await FetchCompanyService.go(session.companiesHouseNumber)

--- a/app/services/billing-accounts/setup/view-company-search.service.js
+++ b/app/services/billing-accounts/setup/view-company-search.service.js
@@ -7,7 +7,7 @@
  */
 
 const CompanySearchPresenter = require('../../../presenters/billing-accounts/setup/company-search.presenter.js')
-const SessionModel = require('../../../models/session.model.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 
 /**
  * Orchestrates fetching and presenting the data for the '/billing-accounts/setup/{sessionId}/company-search' page
@@ -17,7 +17,7 @@ const SessionModel = require('../../../models/session.model.js')
  * @returns {Promise<object>} The data formatted for the view template
  */
 async function go(sessionId) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const pageData = CompanySearchPresenter.go(session)
 

--- a/app/services/billing-accounts/setup/view-contact-name.service.js
+++ b/app/services/billing-accounts/setup/view-contact-name.service.js
@@ -7,7 +7,7 @@
  */
 
 const ContactNamePresenter = require('../../../presenters/billing-accounts/setup/contact-name.presenter.js')
-const SessionModel = require('../../../models/session.model.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 
 /**
  * Orchestrates fetching and presenting the data for the `/billing-accounts/setup/{sessionId}/contact-name` page
@@ -17,7 +17,7 @@ const SessionModel = require('../../../models/session.model.js')
  * @returns {Promise<object>} The data formatted for the view template
  */
 async function go(sessionId) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const pageData = ContactNamePresenter.go(session)
 

--- a/app/services/billing-accounts/setup/view-contact.service.js
+++ b/app/services/billing-accounts/setup/view-contact.service.js
@@ -8,7 +8,7 @@
 
 const ContactPresenter = require('../../../presenters/billing-accounts/setup/contact.presenter.js')
 const FetchCompanyContactsService = require('./fetch-company-contacts.service.js')
-const SessionModel = require('../../../models/session.model.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 
 /**
  * Orchestrates fetching and presenting the data for the `/billing-accounts/setup/{billingAccountId}/contact` page
@@ -18,7 +18,7 @@ const SessionModel = require('../../../models/session.model.js')
  * @returns {Promise<object>} The data formatted for the view template
  */
 async function go(sessionId) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
   const companyContacts = await _fetchCompanyContacts(session)
 
   const pageData = ContactPresenter.go(session, companyContacts)

--- a/app/services/billing-accounts/setup/view-existing-account.service.js
+++ b/app/services/billing-accounts/setup/view-existing-account.service.js
@@ -6,9 +6,9 @@
  * @module ExistingAccountService
  */
 
-const FetchExistingCompaniesService = require('./fetch-existing-companies.service.js')
 const ExistingAccountPresenter = require('../../../presenters/billing-accounts/setup/existing-account.presenter.js')
-const SessionModel = require('../../../models/session.model.js')
+const FetchExistingCompaniesService = require('./fetch-existing-companies.service.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 
 /**
  * Orchestrates fetching and presenting the data for the `/billing-accounts/setup/{sessionId}/existing-account` page
@@ -18,7 +18,7 @@ const SessionModel = require('../../../models/session.model.js')
  * @returns {Promise<object>} The data formatted for the view template
  */
 async function go(sessionId) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
   const companySearchResults = await FetchExistingCompaniesService.go(session.searchInput)
 
   const pageData = ExistingAccountPresenter.go(session, companySearchResults)

--- a/app/services/billing-accounts/setup/view-existing-address.service.js
+++ b/app/services/billing-accounts/setup/view-existing-address.service.js
@@ -6,9 +6,9 @@
  * @module ExistingAddressService
  */
 
-const FetchCompanyAddressesService = require('./fetch-company-addresses.service.js')
 const ExistingAddressPresenter = require('../../../presenters/billing-accounts/setup/existing-address.presenter.js')
-const SessionModel = require('../../../models/session.model.js')
+const FetchCompanyAddressesService = require('./fetch-company-addresses.service.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 
 /**
  * Orchestrates fetching and presenting the data for the `/billing-accounts/setup/{sessionId}/existing-address` page
@@ -18,7 +18,7 @@ const SessionModel = require('../../../models/session.model.js')
  * @returns {Promise<object>} The data formatted for the view template
  */
 async function go(sessionId) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
   const companyAddresses = await _fetchCompanyAddresses(session)
 
   const pageData = ExistingAddressPresenter.go(session, companyAddresses)

--- a/app/services/billing-accounts/setup/view-fao.service.js
+++ b/app/services/billing-accounts/setup/view-fao.service.js
@@ -7,7 +7,7 @@
  */
 
 const FAOPresenter = require('../../../presenters/billing-accounts/setup/fao.presenter.js')
-const SessionModel = require('../../../models/session.model.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 
 /**
  * Orchestrates fetching and presenting the data for the `/billing-accounts/setup/{sessionId}/fao` page
@@ -17,7 +17,7 @@ const SessionModel = require('../../../models/session.model.js')
  * @returns {Promise<object>} The data formatted for the view template
  */
 async function go(sessionId) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const pageData = FAOPresenter.go(session)
 

--- a/app/services/billing-accounts/setup/view-select-company.service.js
+++ b/app/services/billing-accounts/setup/view-select-company.service.js
@@ -7,8 +7,8 @@
  */
 
 const FetchCompaniesService = require('./fetch-companies.service.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const SelectCompanyPresenter = require('../../../presenters/billing-accounts/setup/select-company.presenter.js')
-const SessionModel = require('../../../models/session.model.js')
 
 /**
  * Orchestrates fetching and presenting the data for the '/billing-accounts/setup/{sessionId}/select-company' page
@@ -18,7 +18,7 @@ const SessionModel = require('../../../models/session.model.js')
  * @returns {Promise<object>} The data formatted for the view template
  */
 async function go(sessionId) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
   const companies = await FetchCompaniesService.go(session.companySearch)
 
   const pageData = SelectCompanyPresenter.go(session, companies)

--- a/app/services/licence-monitoring-station/setup/abstraction-period.service.js
+++ b/app/services/licence-monitoring-station/setup/abstraction-period.service.js
@@ -7,7 +7,7 @@
  */
 
 const AbstractionPeriodPresenter = require('../../../presenters/licence-monitoring-station/setup/abstraction-period.presenter.js')
-const SessionModel = require('../../../models/session.model.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 
 /**
  * Orchestrates fetching and presenting the data for `/licence-monitoring-station/setup/{sessionId}/abstraction-period`
@@ -17,7 +17,7 @@ const SessionModel = require('../../../models/session.model.js')
  * @returns {Promise<object>} - The data formatted for the view template
  */
 async function go(sessionId) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const pageData = AbstractionPeriodPresenter.go(session)
 

--- a/app/services/licence-monitoring-station/setup/check.service.js
+++ b/app/services/licence-monitoring-station/setup/check.service.js
@@ -7,7 +7,7 @@
  */
 
 const CheckPresenter = require('../../../presenters/licence-monitoring-station/setup/check.presenter.js')
-const SessionModel = require('../../../models/session.model.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 
 /**
  * Orchestrates fetching and presenting the data for `/licence-monitoring-station/setup/{sessionId}/check`
@@ -17,7 +17,7 @@ const SessionModel = require('../../../models/session.model.js')
  * @returns {Promise<object>} - The data formatted for the view template
  */
 async function go(sessionId) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   await _markCheckPageVisited(session)
 

--- a/app/services/licence-monitoring-station/setup/full-condition.service.js
+++ b/app/services/licence-monitoring-station/setup/full-condition.service.js
@@ -7,8 +7,8 @@
  */
 
 const FetchFullConditionService = require('./fetch-full-condition.service.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const FullConditionPresenter = require('../../../presenters/licence-monitoring-station/setup/full-condition.presenter.js')
-const SessionModel = require('../../../models/session.model.js')
 
 /**
  * Orchestrates fetching and presenting the data for `/licence-monitoring-station/setup/{sessionId}/full-condition`
@@ -18,7 +18,7 @@ const SessionModel = require('../../../models/session.model.js')
  * @returns {Promise<object>} The data formatted for the view template
  */
 async function go(sessionId) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const conditions = await FetchFullConditionService.go(session.licenceId)
 

--- a/app/services/licence-monitoring-station/setup/licence-number.service.js
+++ b/app/services/licence-monitoring-station/setup/licence-number.service.js
@@ -7,8 +7,8 @@
  * @module LicenceNumberService
  */
 
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const LicenceNumberPresenter = require('../../../presenters/licence-monitoring-station/setup/licence-number.presenter.js')
-const SessionModel = require('../../../models/session.model.js')
 
 /**
  * Orchestrates fetching and presenting the data for the `/licence-monitoring-station/setup/{sessionId}/licence-number` page
@@ -18,7 +18,7 @@ const SessionModel = require('../../../models/session.model.js')
  * @returns {Promise<object>} - The data formatted for the view template
  */
 async function go(sessionId) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const pageData = LicenceNumberPresenter.go(session)
 

--- a/app/services/licence-monitoring-station/setup/stop-or-reduce.service.js
+++ b/app/services/licence-monitoring-station/setup/stop-or-reduce.service.js
@@ -5,7 +5,7 @@
  * @module StopOrReduceService
  */
 
-const SessionModel = require('../../../models/session.model.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const StopOrReducePresenter = require('../../../presenters/licence-monitoring-station/setup/stop-or-reduce.presenter.js')
 
 /**
@@ -16,7 +16,7 @@ const StopOrReducePresenter = require('../../../presenters/licence-monitoring-st
  * @returns {Promise<object>} - The data formatted for the view template
  */
 async function go(sessionId) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const pageData = StopOrReducePresenter.go(session)
 

--- a/app/services/licence-monitoring-station/setup/submit-abstraction-period.service.js
+++ b/app/services/licence-monitoring-station/setup/submit-abstraction-period.service.js
@@ -10,7 +10,7 @@ const { formatValidationResult } = require('../../../presenters/base.presenter.j
 
 const AbstractionPeriodPresenter = require('../../../presenters/licence-monitoring-station/setup/abstraction-period.presenter.js')
 const AbstractionPeriodValidator = require('../../../validators/abstraction-period.validator.js')
-const SessionModel = require('../../../models/session.model.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 
 /**
  * Orchestrates validating the data for `/licence-monitoring-station/setup/{sessionId}/abstraction-period`
@@ -21,7 +21,7 @@ const SessionModel = require('../../../models/session.model.js')
  * @returns {Promise<object>} - The data formatted for the view template
  */
 async function go(sessionId, payload) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const validationResult = _validate(payload)
 

--- a/app/services/licence-monitoring-station/setup/submit-check.service.js
+++ b/app/services/licence-monitoring-station/setup/submit-check.service.js
@@ -6,9 +6,9 @@
  * @module SubmitCheckService
  */
 
-const { flashNotification, timestampForPostgres } = require('../../../lib/general.lib.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const LicenceMonitoringStationModel = require('../../../models/licence-monitoring-station.model.js')
-const SessionModel = require('../../../models/session.model.js')
+const { flashNotification, timestampForPostgres } = require('../../../lib/general.lib.js')
 const { flowUnits } = require('../../../lib/static-lookups.lib.js')
 
 /**
@@ -21,7 +21,7 @@ const { flowUnits } = require('../../../lib/static-lookups.lib.js')
  * @returns {Promise<string>} The monitoring station id used to redirect back to the monitoring station page
  */
 async function go(sessionId, userId, yar) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   await _createTag(session, userId)
 

--- a/app/services/licence-monitoring-station/setup/submit-full-condition.service.js
+++ b/app/services/licence-monitoring-station/setup/submit-full-condition.service.js
@@ -7,9 +7,9 @@
  */
 
 const FetchFullConditionService = require('../../../services/licence-monitoring-station/setup/fetch-full-condition.service.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const FullConditionService = require('../../../services/licence-monitoring-station/setup/full-condition.service.js')
 const FullConditionValidator = require('../../../validators/licence-monitoring-station/setup/full-condition.validator.js')
-const SessionModel = require('../../../models/session.model.js')
 
 /**
  * Orchestrates validating the data for `/licence-monitoring-station/setup/{sessionId}/full-condition`
@@ -23,7 +23,7 @@ async function go(sessionId, payload) {
   const validationResult = _validate(payload)
 
   if (!validationResult) {
-    const session = await SessionModel.query().findById(sessionId)
+    const session = await FetchSessionDal.go(sessionId)
 
     // On the check page we want to display the exact text of the chosen condition (including the condition number) plus
     // its abstraction period. To do this we need to re-fetch the condition. We can then save the info in the session.

--- a/app/services/licence-monitoring-station/setup/submit-licence-number.service.js
+++ b/app/services/licence-monitoring-station/setup/submit-licence-number.service.js
@@ -6,10 +6,10 @@
  * @module SubmitLicenceNumberService
  */
 
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const LicenceModel = require('../../../models/licence.model.js')
 const LicenceNumberPresenter = require('../../../presenters/licence-monitoring-station/setup/licence-number.presenter.js')
 const LicenceNumberValidator = require('../../../validators/licence-monitoring-station/setup/licence-number.validator.js')
-const SessionModel = require('../../../models/session.model.js')
 
 /**
  * Orchestrates validating the data for `/licence-monitoring-station/setup/{sessionId}/licence-number` page
@@ -20,7 +20,7 @@ const SessionModel = require('../../../models/session.model.js')
  * @returns {Promise<object>} - The data formatted for the view template
  */
 async function go(sessionId, payload) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const licence = payload.licenceRef ? await _fetchLicence(payload.licenceRef) : null
 

--- a/app/services/licence-monitoring-station/setup/submit-stop-or-reduce.service.js
+++ b/app/services/licence-monitoring-station/setup/submit-stop-or-reduce.service.js
@@ -5,7 +5,7 @@
  * @module SubmitStopOrReduceService
  */
 
-const SessionModel = require('../../../models/session.model.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const StopOrReducePresenter = require('../../../presenters/licence-monitoring-station/setup/stop-or-reduce.presenter.js')
 const StopOrReduceValidator = require('../../../validators/licence-monitoring-station/setup/stop-or-reduce.validator.js')
 
@@ -18,7 +18,7 @@ const StopOrReduceValidator = require('../../../validators/licence-monitoring-st
  * @returns {Promise<object>} - The data formatted for the view template
  */
 async function go(sessionId, payload) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const validationResult = _validate(payload)
 

--- a/app/services/licence-monitoring-station/setup/submit-threshold-and-unit.service.js
+++ b/app/services/licence-monitoring-station/setup/submit-threshold-and-unit.service.js
@@ -5,7 +5,7 @@
  * @module SubmitThresholdAndUnitService
  */
 
-const SessionModel = require('../../../models/session.model.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const ThresholdAndUnitPresenter = require('../../../presenters/licence-monitoring-station/setup/threshold-and-unit.presenter.js')
 const ThresholdAndUnitValidator = require('../../../validators/licence-monitoring-station/setup/threshold-and-unit.validator.js')
 
@@ -25,7 +25,7 @@ const ThresholdAndUnitValidator = require('../../../validators/licence-monitorin
  * details
  */
 async function go(sessionId, payload) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const validationResult = _validate(payload)
 

--- a/app/services/licence-monitoring-station/setup/threshold-and-unit.service.js
+++ b/app/services/licence-monitoring-station/setup/threshold-and-unit.service.js
@@ -6,7 +6,7 @@
  * @module ThresholdAndUnitService
  */
 
-const SessionModel = require('../../../models/session.model.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const ThresholdAndUnitPresenter = require('../../../presenters/licence-monitoring-station/setup/threshold-and-unit.presenter.js')
 
 /**
@@ -21,7 +21,7 @@ const ThresholdAndUnitPresenter = require('../../../presenters/licence-monitorin
  * @returns {Promise<object>} The view data for the threshold and unit page
  */
 async function go(sessionId) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const formattedData = ThresholdAndUnitPresenter.go(session)
 

--- a/app/services/notices/setup/process-add-recipient.service.js
+++ b/app/services/notices/setup/process-add-recipient.service.js
@@ -7,7 +7,7 @@
 
 const crypto = require('node:crypto')
 
-const SessionModel = require('../../../models/session.model.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const { flashNotification } = require('../../../lib/general.lib.js')
 
 /**
@@ -21,7 +21,7 @@ const { flashNotification } = require('../../../lib/general.lib.js')
  * @param {object} yar - The Hapi `request.yar` session manager passed on by the controller
  */
 async function go(sessionId, yar) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
   const { address } = session.addressJourney
 
   const additionalRecipient = {

--- a/app/services/notices/setup/process-download-recipients.service.js
+++ b/app/services/notices/setup/process-download-recipients.service.js
@@ -8,9 +8,8 @@
 const DownloadAbstractionAlertPresenter = require('../../../presenters/notices/setup/download-abstraction-alert.presenter.js')
 const DownloadReturnsNoticePresenter = require('../../../presenters/notices/setup/download-returns-notice.presenter.js')
 const FetchRecipientsService = require('./fetch-recipients.service.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const { NoticeJourney } = require('../../../lib/static-lookups.lib.js')
-
-const SessionModel = require('../../../models/session.model.js')
 
 /**
  * Orchestrates fetching and formatting the data needed for the notices setup download link
@@ -23,7 +22,7 @@ const SessionModel = require('../../../models/session.model.js')
  * @returns {Promise<object>} The data for the download link (csv string, filename and type)
  */
 async function go(sessionId) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const { notificationType, referenceCode } = session
 

--- a/app/services/notices/setup/process-preview-paper-return.service.js
+++ b/app/services/notices/setup/process-preview-paper-return.service.js
@@ -7,9 +7,9 @@
  */
 
 const FetchRecipientsService = require('./fetch-recipients.service.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const PaperReturnNotificationsPresenter = require('../../../presenters/notices/setup/paper-return-notifications.presenter.js')
 const PreparePaperReturnService = require('./prepare-paper-return.service.js')
-const SessionModel = require('../../../models/session.model.js')
 
 /**
  * Orchestrates fetching and presenting the data for previewing a paper return
@@ -24,7 +24,7 @@ const SessionModel = require('../../../models/session.model.js')
  * @returns {Promise<ArrayBuffer>} - Resolves with the generated form file as an ArrayBuffer.
  */
 async function go(sessionId, contactHashId, returnLogId) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   // NOTE: The notifications the presenter generates are based on the combination of recipients and selected return logs
   // that have been set during setup. We're using the same presenter to generate our preview notification, so for this

--- a/app/services/notices/setup/process-remove-threshold.service.js
+++ b/app/services/notices/setup/process-remove-threshold.service.js
@@ -6,8 +6,8 @@
  * @module ProcessRemoveThresholdService
  */
 
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const GeneralLib = require('../../../lib/general.lib.js')
-const SessionModel = require('../../../models/session.model.js')
 const { formatRestrictionType, formatValueUnit } = require('../../../presenters/base.presenter.js')
 
 /**
@@ -19,7 +19,7 @@ const { formatRestrictionType, formatValueUnit } = require('../../../presenters/
  *
  */
 async function go(sessionId, licenceMonitoringStationId, yar) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   await _save(session, licenceMonitoringStationId)
 

--- a/app/services/notices/setup/submit-alert-email-address.service.js
+++ b/app/services/notices/setup/submit-alert-email-address.service.js
@@ -8,7 +8,7 @@
 
 const AlertEmailAddressPresenter = require('../../../presenters/notices/setup/alert-email-address.presenter.js')
 const AlertEmailAddressValidator = require('../../../validators/notices/setup/alert-email-address.validator.js')
-const SessionModel = require('../../../models/session.model.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const { formatValidationResult } = require('../../../presenters/base.presenter.js')
 
 /**
@@ -21,7 +21,7 @@ const { formatValidationResult } = require('../../../presenters/base.presenter.j
  * @returns {Promise<object>} - The data formatted for the view template
  */
 async function go(sessionId, payload, auth) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const validationResult = _validate(payload)
 

--- a/app/services/notices/setup/submit-alert-thresholds.service.js
+++ b/app/services/notices/setup/submit-alert-thresholds.service.js
@@ -8,7 +8,7 @@
 
 const AlertThresholdsPresenter = require('../../../presenters/notices/setup/alert-thresholds.presenter.js')
 const AlertThresholdsValidator = require('../../../validators/notices/setup/alert-thresholds.validator.js')
-const SessionModel = require('../../../models/session.model.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const { formatValidationResult } = require('../../../presenters/base.presenter.js')
 const { handleOneOptionSelected } = require('../../../lib/submit-page.lib.js')
 
@@ -21,7 +21,7 @@ const { handleOneOptionSelected } = require('../../../lib/submit-page.lib.js')
  * @returns {Promise<object>} - The data formatted for the view template
  */
 async function go(sessionId, payload) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   handleOneOptionSelected(payload, 'alertThresholds')
 

--- a/app/services/notices/setup/submit-alert-type.service.js
+++ b/app/services/notices/setup/submit-alert-type.service.js
@@ -8,7 +8,7 @@
 
 const AlertTypePresenter = require('../../../presenters/notices/setup/alert-type.presenter.js')
 const AlertTypeValidator = require('../../../validators/notices/setup/alert-type.validator.js')
-const SessionModel = require('../../../models/session.model.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const { formatValidationResult } = require('../../../presenters/base.presenter.js')
 
 /**
@@ -20,7 +20,7 @@ const { formatValidationResult } = require('../../../presenters/base.presenter.j
  * @returns {Promise<object>} - The data formatted for the view template
  */
 async function go(sessionId, payload) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const validationResult = _validate(payload, session.licenceMonitoringStations)
 

--- a/app/services/notices/setup/submit-cancel-alerts.service.js
+++ b/app/services/notices/setup/submit-cancel-alerts.service.js
@@ -6,7 +6,8 @@
  * @module SubmitCancelAlertsService
  */
 
-const SessionModel = require('../../../models/session.model.js')
+const DeleteSessionDal = require('../../../dal/delete-session.dal.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 
 /**
  * Orchestrates cancelling the data for `/notices/setup/{sessionId}/abstraction-alerts/` journey
@@ -16,14 +17,12 @@ const SessionModel = require('../../../models/session.model.js')
  * @returns {Promise<object>} - The data formatted for the view template
  */
 async function go(sessionId) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
-  const { monitoringStationId } = session
-
-  await SessionModel.query().delete().where('id', sessionId)
+  await DeleteSessionDal.go(sessionId)
 
   return {
-    monitoringStationId
+    monitoringStationId: session.monitoringStationId
   }
 }
 

--- a/app/services/notices/setup/submit-cancel.service.js
+++ b/app/services/notices/setup/submit-cancel.service.js
@@ -5,7 +5,8 @@
  * @module SubmitCancelService
  */
 
-const SessionModel = require('../../../models/session.model.js')
+const DeleteSessionDal = require('../../../dal/delete-session.dal.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const { NoticeJourney } = require('../../../lib/static-lookups.lib.js')
 
 /**
@@ -18,9 +19,9 @@ const { NoticeJourney } = require('../../../lib/static-lookups.lib.js')
  * @returns {Promise<string>} - returns the redirect url, which can contain some session data that needs to be deleted
  */
 async function go(sessionId) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
-  await SessionModel.query().delete().where('id', sessionId)
+  await DeleteSessionDal.go(sessionId)
 
   if (session.journey === NoticeJourney.ALERTS) {
     return `/system/monitoring-stations/${session.monitoringStationId}`

--- a/app/services/notices/setup/submit-check-licence-matches.service.js
+++ b/app/services/notices/setup/submit-check-licence-matches.service.js
@@ -7,7 +7,7 @@
  */
 
 const DetermineRelevantLicenceMonitoringStationsService = require('./abstraction-alerts/determine-relevant-licence-monitoring-stations.service.js')
-const SessionModel = require('../../../models/session.model.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 
 /**
  * Orchestrates saving the data for the `/notices/setup/{sessionId}/abstraction-alerts/check-licence-matches` page
@@ -16,7 +16,7 @@ const SessionModel = require('../../../models/session.model.js')
  *
  */
 async function go(sessionId) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   await _save(session)
 }

--- a/app/services/notices/setup/submit-check-notice-type.service.js
+++ b/app/services/notices/setup/submit-check-notice-type.service.js
@@ -6,7 +6,7 @@
  * @module SubmitCheckNoticeTypeService
  */
 
-const SessionModel = require('../../../models/session.model.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const { NoticeType } = require('../../../lib/static-lookups.lib.js')
 
 /**
@@ -20,7 +20,7 @@ const { NoticeType } = require('../../../lib/static-lookups.lib.js')
  * @param {string} sessionId - The UUID of the current session
  */
 async function go(sessionId) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   session.addressJourney = {
     activeNavBar: 'notices',

--- a/app/services/notices/setup/submit-check.service.js
+++ b/app/services/notices/setup/submit-check.service.js
@@ -8,8 +8,8 @@
 const CreateNoticeService = require('./create-notice.service.js')
 const CreateNotificationsService = require('./create-notifications.service.js')
 const FetchRecipientsService = require('./fetch-recipients.service.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const SendNoticeService = require('./send/send-notice.service.js')
-const SessionModel = require('../../../models/session.model.js')
 
 /**
  * Orchestrates creating the notice and sending the notifications when `/notices/setup/{sessionId}/check` page submitted
@@ -22,7 +22,7 @@ const SessionModel = require('../../../models/session.model.js')
  * @returns {Promise<string>} - the created notice Id
  */
 async function go(sessionId, auth) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const recipients = await FetchRecipientsService.go(session)
 

--- a/app/services/notices/setup/submit-contact-type.service.js
+++ b/app/services/notices/setup/submit-contact-type.service.js
@@ -10,7 +10,7 @@ const crypto = require('crypto')
 
 const ContactTypePresenter = require('../../../presenters/notices/setup/contact-type.presenter.js')
 const ContactTypeValidator = require('../../../validators/notices/setup/contact-type.validator.js')
-const SessionModel = require('../../../models/session.model.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const { formatValidationResult } = require('../../../presenters/base.presenter.js')
 const { flashNotification } = require('../../../lib/general.lib.js')
 
@@ -24,7 +24,7 @@ const { flashNotification } = require('../../../lib/general.lib.js')
  * @returns {Promise<object>} - The data formatted for the view template
  */
 async function go(sessionId, payload, yar) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const validationResult = _validate(payload)
 

--- a/app/services/notices/setup/submit-licence.service.js
+++ b/app/services/notices/setup/submit-licence.service.js
@@ -6,12 +6,12 @@
  */
 
 const FetchDueReturnsForLicenceService = require('./returns-notice/fetch-due-returns-for-licence.service.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const LicenceModel = require('../../../models/licence.model.js')
 const LicencePresenter = require('../../../presenters/notices/setup/licence.presenter.js')
 const LicenceValidator = require('../../../validators/notices/setup/licence.validator.js')
-const SessionModel = require('../../../models/session.model.js')
-const { formatValidationResult } = require('../../../presenters/base.presenter.js')
 const { flashNotification } = require('../../../lib/general.lib.js')
+const { formatValidationResult } = require('../../../presenters/base.presenter.js')
 
 /**
  * Orchestrates validating the data for `/notices/setup/{sessionId}/licence` page
@@ -30,7 +30,7 @@ const { flashNotification } = require('../../../lib/general.lib.js')
  * the validation error details
  */
 async function go(sessionId, payload, yar) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const dueReturns = await _dueReturns(payload)
 

--- a/app/services/notices/setup/submit-notice-type.service.js
+++ b/app/services/notices/setup/submit-notice-type.service.js
@@ -6,11 +6,11 @@
  * @module SubmitNoticeTypeService
  */
 
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const NoticeTypePresenter = require('../../../presenters/notices/setup/notice-type.presenter.js')
 const NoticeTypeValidator = require('../../../validators/notices/setup/notice-type.validator.js')
-const SessionModel = require('../../../models/session.model.js')
-const { flashNotification, generateNoticeReferenceCode } = require('../../../lib/general.lib.js')
 const { NoticeJourney, NoticeType, NoticeTypes } = require('../../../lib/static-lookups.lib.js')
+const { flashNotification, generateNoticeReferenceCode } = require('../../../lib/general.lib.js')
 const { formatValidationResult } = require('../../../presenters/base.presenter.js')
 
 /**
@@ -24,7 +24,7 @@ const { formatValidationResult } = require('../../../presenters/base.presenter.j
  * @returns {Promise<object>} - The data formatted for the view template
  */
 async function go(sessionId, payload, yar, auth) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const validationResult = _validate(payload)
 

--- a/app/services/notices/setup/submit-paper-return.service.js
+++ b/app/services/notices/setup/submit-paper-return.service.js
@@ -6,11 +6,11 @@
  * @module SubmitPaperReturnService
  */
 
-const { formatValidationResult } = require('../../../presenters/base.presenter.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const GeneralLib = require('../../../lib/general.lib.js')
 const PaperReturnPresenter = require('../../../presenters/notices/setup/paper-return.presenter.js')
 const PaperReturnValidator = require('../../../validators/notices/setup/paper-return.validator.js')
-const SessionModel = require('../../../models/session.model.js')
+const { formatValidationResult } = require('../../../presenters/base.presenter.js')
 const { handleOneOptionSelected } = require('../../../lib/submit-page.lib.js')
 
 /**
@@ -23,7 +23,7 @@ const { handleOneOptionSelected } = require('../../../lib/submit-page.lib.js')
  * @returns {Promise<object>} - The data formatted for the view template
  */
 async function go(sessionId, payload, yar) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   handleOneOptionSelected(payload, 'returns')
 

--- a/app/services/notices/setup/submit-recipient-name.service.js
+++ b/app/services/notices/setup/submit-recipient-name.service.js
@@ -6,9 +6,9 @@
  * @module SubmitRecipientNameService
  */
 
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const RecipientNamePresenter = require('../../../presenters/notices/setup/recipient-name.presenter.js')
 const RecipientNameValidator = require('../../../validators/notices/setup/recipient-name.validator.js')
-const SessionModel = require('../../../models/session.model.js')
 const { formatValidationResult } = require('../../../presenters/base.presenter.js')
 
 /**
@@ -20,7 +20,7 @@ const { formatValidationResult } = require('../../../presenters/base.presenter.j
  * @returns {Promise<object>} - The data formatted for the view template
  */
 async function go(sessionId, payload) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const validationResult = _validate(payload)
 

--- a/app/services/notices/setup/submit-remove-licences.service.js
+++ b/app/services/notices/setup/submit-remove-licences.service.js
@@ -6,9 +6,9 @@
  */
 
 const FetchLicenceRefsWithDueReturnsService = require('./fetch-licence-refs-with-due-returns.service.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const RemoveLicencesPresenter = require('../../../presenters/notices/setup/remove-licences.presenter.js')
 const RemoveLicencesValidator = require('../../../validators/notices/setup/remove-licences.validator.js')
-const SessionModel = require('../../../models/session.model.js')
 const { formatValidationResult } = require('../../../presenters/base.presenter.js')
 
 /**
@@ -21,7 +21,7 @@ const { formatValidationResult } = require('../../../presenters/base.presenter.j
  * including the validation error details
  */
 async function go(sessionId, payload) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const licenceRefsWithDueReturns = await _fetchLicenceRefsWithDueReturns(session)
 

--- a/app/services/notices/setup/submit-returns-period.service.js
+++ b/app/services/notices/setup/submit-returns-period.service.js
@@ -6,9 +6,9 @@
  */
 
 const DetermineReturnsPeriodService = require('./determine-returns-period.service.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const ReturnsPeriodPresenter = require('../../../presenters/notices/setup/returns-period.presenter.js')
 const ReturnsPeriodValidator = require('../../../validators/notices/setup/returns-periods.validator.js')
-const SessionModel = require('../../../models/session.model.js')
 const { flashNotification } = require('../../../lib/general.lib.js')
 const { formatValidationResult } = require('../../../presenters/base.presenter.js')
 
@@ -23,7 +23,7 @@ const { formatValidationResult } = require('../../../presenters/base.presenter.j
  * including the validation error details
  */
 async function go(sessionId, payload, yar) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const validationResult = _validate(payload, session.noticeType)
 

--- a/app/services/notices/setup/submit-select-recipients.service.js
+++ b/app/services/notices/setup/submit-select-recipients.service.js
@@ -6,12 +6,12 @@
  * @module SubmitSelectRecipientsService
  */
 
-const { formatValidationResult } = require('../../../presenters/base.presenter.js')
 const FetchRecipientsService = require('./fetch-recipients.service.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const GeneralLib = require('../../../lib/general.lib.js')
 const SelectRecipientsPresenter = require('../../../presenters/notices/setup/select-recipients.presenter.js')
 const SelectRecipientsValidator = require('../../../validators/notices/setup/select-recipients.validator.js')
-const SessionModel = require('../../../models/session.model.js')
+const { formatValidationResult } = require('../../../presenters/base.presenter.js')
 const { handleOneOptionSelected } = require('../../../lib/submit-page.lib.js')
 
 /**
@@ -24,7 +24,7 @@ const { handleOneOptionSelected } = require('../../../lib/submit-page.lib.js')
  * @returns {Promise<object>} - The data formatted for the view template
  */
 async function go(sessionId, payload, yar) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   handleOneOptionSelected(payload, 'recipients')
 

--- a/app/services/notices/setup/view-alert-email-address.service.js
+++ b/app/services/notices/setup/view-alert-email-address.service.js
@@ -7,7 +7,7 @@
  */
 
 const AlertEmailAddressPresenter = require('../../../presenters/notices/setup/alert-email-address.presenter.js')
-const SessionModel = require('../../../models/session.model.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 
 /**
  * Orchestrates fetching and presenting the data for the `/notices/setup/{sessionId}/abstraction-alerts/alert-email-address` page
@@ -18,7 +18,7 @@ const SessionModel = require('../../../models/session.model.js')
  * @returns {Promise<object>} - The data formatted for the view template
  */
 async function go(sessionId, auth) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const pageData = AlertEmailAddressPresenter.go(session, auth)
 

--- a/app/services/notices/setup/view-alert-thresholds.service.js
+++ b/app/services/notices/setup/view-alert-thresholds.service.js
@@ -7,7 +7,7 @@
  */
 
 const AlertThresholdsPresenter = require('../../../presenters/notices/setup/alert-thresholds.presenter.js')
-const SessionModel = require('../../../models/session.model.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 
 /**
  * Orchestrates presenting the data for `/notices/setup/{sessionId}/abstraction-alerts/alert-thresholds` page
@@ -17,7 +17,7 @@ const SessionModel = require('../../../models/session.model.js')
  * @returns {Promise<object>} - The data formatted for the view template
  */
 async function go(sessionId) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const pageData = AlertThresholdsPresenter.go(session)
 

--- a/app/services/notices/setup/view-alert-type.service.js
+++ b/app/services/notices/setup/view-alert-type.service.js
@@ -7,7 +7,7 @@
  */
 
 const AlertTypePresenter = require('../../../presenters/notices/setup/alert-type.presenter.js')
-const SessionModel = require('../../../models/session.model.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 
 /**
  * Orchestrates presenting the data for `/notices/setup/{sessionId}/abstraction-alerts/alert-type` page
@@ -17,7 +17,7 @@ const SessionModel = require('../../../models/session.model.js')
  * @returns {Promise<{object}>} - The data formatted for the view template
  */
 async function go(sessionId) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const pageData = AlertTypePresenter.go(session)
 

--- a/app/services/notices/setup/view-cancel-alerts.service.js
+++ b/app/services/notices/setup/view-cancel-alerts.service.js
@@ -7,7 +7,7 @@
  */
 
 const CancelAlertsPresenter = require('../../../presenters/notices/setup/cancel-alerts.presenter.js')
-const SessionModel = require('../../../models/session.model.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 
 /**
  * Orchestrates fetching and presenting the data for the `/notices/setup/{sessionId}/abstraction-alerts/cancel` page
@@ -17,7 +17,7 @@ const SessionModel = require('../../../models/session.model.js')
  * @returns {Promise<object>} - The data formatted for the view template
  */
 async function go(sessionId) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const pageData = CancelAlertsPresenter.go(session)
 

--- a/app/services/notices/setup/view-cancel.service.js
+++ b/app/services/notices/setup/view-cancel.service.js
@@ -6,7 +6,7 @@
  */
 
 const CancelPresenter = require('../../../presenters/notices/setup/cancel.presenter.js')
-const SessionModel = require('../../../models/session.model.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 
 /**
  * Orchestrates presenting the data for `/notices/setup/{sessionId}/cancel` page
@@ -16,7 +16,7 @@ const SessionModel = require('../../../models/session.model.js')
  * @returns {Promise<object>} The view data for the cancel page
  */
 async function go(sessionId) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const formattedData = CancelPresenter.go(session)
 

--- a/app/services/notices/setup/view-check-licence-matches.service.js
+++ b/app/services/notices/setup/view-check-licence-matches.service.js
@@ -7,7 +7,7 @@
  */
 
 const CheckLicenceMatchesPresenter = require('../../../presenters/notices/setup/check-licence-matches.presenter.js')
-const SessionModel = require('../../../models/session.model.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const { readFlashNotification } = require('../../../lib/general.lib.js')
 
 /**
@@ -19,7 +19,7 @@ const { readFlashNotification } = require('../../../lib/general.lib.js')
  * @returns {Promise<object>} - The data formatted for the view template
  */
 async function go(sessionId, yar) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const pageData = CheckLicenceMatchesPresenter.go(session)
 

--- a/app/services/notices/setup/view-check-notice-type.service.js
+++ b/app/services/notices/setup/view-check-notice-type.service.js
@@ -7,7 +7,7 @@
  */
 
 const CheckNoticeTypePresenter = require('../../../presenters/notices/setup/check-notice-type.presenter.js')
-const SessionModel = require('../../../models/session.model.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const { readFlashNotification } = require('../../../lib/general.lib.js')
 
 /**
@@ -19,7 +19,7 @@ const { readFlashNotification } = require('../../../lib/general.lib.js')
  * @returns {Promise<object>} - The data formatted for the view template
  */
 async function go(sessionId, yar) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   await _markCheckPageVisited(session)
 

--- a/app/services/notices/setup/view-check.service.js
+++ b/app/services/notices/setup/view-check.service.js
@@ -7,8 +7,8 @@
 
 const CheckPresenter = require('../../../presenters/notices/setup/check.presenter.js')
 const FetchRecipientsService = require('./fetch-recipients.service.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const PaginatorPresenter = require('../../../presenters/paginator.presenter.js')
-const SessionModel = require('../../../models/session.model.js')
 const { readFlashNotification } = require('../../../lib/general.lib.js')
 
 /**
@@ -21,7 +21,7 @@ const { readFlashNotification } = require('../../../lib/general.lib.js')
  * @returns {Promise<object>} The view data for the review page
  */
 async function go(sessionId, yar, page) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const recipients = await FetchRecipientsService.go(session, false)
 

--- a/app/services/notices/setup/view-contact-type.service.js
+++ b/app/services/notices/setup/view-contact-type.service.js
@@ -7,7 +7,7 @@
  */
 
 const ContactTypePresenter = require('../../../presenters/notices/setup/contact-type.presenter.js')
-const SessionModel = require('../../../models/session.model.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 
 /**
  * Orchestrates fetching and presenting the data for the `/notices/setup/{sessionId}/contact-type` page
@@ -17,7 +17,7 @@ const SessionModel = require('../../../models/session.model.js')
  * @returns {Promise<object>} - The data formatted for the view template
  */
 async function go(sessionId) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const pageData = ContactTypePresenter.go(session)
 

--- a/app/services/notices/setup/view-licence.service.js
+++ b/app/services/notices/setup/view-licence.service.js
@@ -5,8 +5,8 @@
  * @module ViewLicenceService
  */
 
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const LicencePresenter = require('../../../presenters/notices/setup/licence.presenter.js')
-const SessionModel = require('../../../models/session.model.js')
 
 /**
  * Orchestrates fetching and presenting the data for `/notices/setup/{sessionId}/licence` page
@@ -19,7 +19,7 @@ const SessionModel = require('../../../models/session.model.js')
  * @returns {Promise<object>} The view data for the licence page
  */
 async function go(sessionId) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const formattedData = LicencePresenter.go(session)
 

--- a/app/services/notices/setup/view-notice-type.service.js
+++ b/app/services/notices/setup/view-notice-type.service.js
@@ -6,8 +6,8 @@
  * @module ViewNoticeTypeService
  */
 
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const NoticeTypePresenter = require('../../../presenters/notices/setup/notice-type.presenter.js')
-const SessionModel = require('../../../models/session.model.js')
 
 /**
  * Orchestrates fetching and presenting the data for the `/notices/setup/{sessionId}/notice-type` page
@@ -18,7 +18,7 @@ const SessionModel = require('../../../models/session.model.js')
  * @returns {Promise<object>} - The data formatted for the view template
  */
 async function go(sessionId, auth) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const pageData = NoticeTypePresenter.go(session, auth)
 

--- a/app/services/notices/setup/view-paper-return.service.js
+++ b/app/services/notices/setup/view-paper-return.service.js
@@ -6,8 +6,8 @@
  * @module ViewPaperReturnService
  */
 
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const PaperReturnPresenter = require('../../../presenters/notices/setup/paper-return.presenter.js')
-const SessionModel = require('../../../models/session.model.js')
 
 /**
  * Orchestrates fetching and presenting the data for the `/notices/setup/{sessionId}/paper-return` page
@@ -17,7 +17,7 @@ const SessionModel = require('../../../models/session.model.js')
  * @returns {Promise<object>} - The data formatted for the view template
  */
 async function go(sessionId) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const pageData = PaperReturnPresenter.go(session)
 

--- a/app/services/notices/setup/view-preview-check-alert.service.js
+++ b/app/services/notices/setup/view-preview-check-alert.service.js
@@ -8,7 +8,7 @@
 
 const CheckAlertPresenter = require('../../../presenters/notices/setup/preview-check-alert.presenter.js')
 const FetchAbstractionAlertRecipientsService = require('./abstraction-alerts/fetch-abstraction-alert-recipients.service.js')
-const SessionModel = require('../../../models/session.model.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 
 /**
  * Orchestrates presenting the data for the `/notices/setup/{sessionId}/preview/{contactHashId}/check-alert` page
@@ -19,7 +19,7 @@ const SessionModel = require('../../../models/session.model.js')
  * @returns {Promise<object>} - The data formatted for the view template
  */
 async function go(contactHashId, sessionId) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const recipientLicenceRefs = await _recipientLicenceRefs(contactHashId, session)
 

--- a/app/services/notices/setup/view-preview-check-paper-return.service.js
+++ b/app/services/notices/setup/view-preview-check-paper-return.service.js
@@ -7,7 +7,7 @@
  */
 
 const CheckPaperReturnPresenter = require('../../../presenters/notices/setup/preview-check-paper-return.presenter.js')
-const SessionModel = require('../../../models/session.model.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 
 /**
  * Orchestrates fetching and presenting the data for the `/notices/setup/{sessionId}/preview/{contactHashId}/check-paper-return` page
@@ -18,7 +18,7 @@ const SessionModel = require('../../../models/session.model.js')
  * @returns {Promise<object>} - The data formatted for the view template
  */
 async function go(sessionId, contactHashId) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const pageData = CheckPaperReturnPresenter.go(session, contactHashId)
 

--- a/app/services/notices/setup/view-preview.service.js
+++ b/app/services/notices/setup/view-preview.service.js
@@ -7,9 +7,9 @@
 
 const AbstractionAlertNotificationsPresenter = require('../../../presenters/notices/setup/abstraction-alert-notifications.presenter.js')
 const FetchRecipientsService = require('./fetch-recipients.service.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const PreviewPresenter = require('../../../presenters/notices/setup/preview.presenter.js')
 const ReturnsNoticeNotificationsPresenter = require('../../../presenters/notices/setup/returns-notice-notifications.presenter.js')
-const SessionModel = require('../../../models/session.model.js')
 const { NoticeType } = require('../../../lib/static-lookups.lib.js')
 
 /**
@@ -23,7 +23,7 @@ const { NoticeType } = require('../../../lib/static-lookups.lib.js')
  * @returns {Promise<object>} The view data for the preview page
  */
 async function go(sessionId, contactHashId, licenceMonitoringStationId = null) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const recipient = await _recipient(contactHashId, session)
   const notification = _notification(recipient, session, licenceMonitoringStationId)

--- a/app/services/notices/setup/view-recipient-name.service.js
+++ b/app/services/notices/setup/view-recipient-name.service.js
@@ -6,8 +6,8 @@
  * @module ViewRecipientNameService
  */
 
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const RecipientNamePresenter = require('../../../presenters/notices/setup/recipient-name.presenter.js')
-const SessionModel = require('../../../models/session.model.js')
 
 /**
  * Orchestrates fetching and presenting the data for the '/notices/setup/{sessionId}/recipient-name' page
@@ -17,7 +17,7 @@ const SessionModel = require('../../../models/session.model.js')
  * @returns {Promise<object>} - The data formatted for the view template
  */
 async function go(sessionId) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const pageData = RecipientNamePresenter.go(session)
 

--- a/app/services/notices/setup/view-remove-licences.service.js
+++ b/app/services/notices/setup/view-remove-licences.service.js
@@ -5,8 +5,8 @@
  * @module ViewRemoveLicencesService
  */
 
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const RemoveLicencesPresenter = require('../../../presenters/notices/setup/remove-licences.presenter.js')
-const SessionModel = require('../../../models/session.model.js')
 
 /**
  * Orchestrates fetching and presenting the licences to remove for the notices setup remove licences page
@@ -16,7 +16,7 @@ const SessionModel = require('../../../models/session.model.js')
  * @returns {Promise<object>} The view data for the remove licences page
  */
 async function go(sessionId) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const { removeLicences = [] } = session
 

--- a/app/services/notices/setup/view-returns-period.service.js
+++ b/app/services/notices/setup/view-returns-period.service.js
@@ -5,8 +5,8 @@
  * @module ViewReturnsPeriodService
  */
 
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const ReturnsPeriodPresenter = require('../../../presenters/notices/setup/returns-period.presenter.js')
-const SessionModel = require('../../../models/session.model.js')
 
 /**
  * Orchestrates fetching and presenting the data needed for the notices setup returns period page
@@ -16,7 +16,7 @@ const SessionModel = require('../../../models/session.model.js')
  * @returns {Promise<object>} The view data for the returns period page
  */
 async function go(sessionId) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const formattedData = ReturnsPeriodPresenter.go(session)
 

--- a/app/services/notices/setup/view-select-recipients.service.js
+++ b/app/services/notices/setup/view-select-recipients.service.js
@@ -7,8 +7,8 @@
  */
 
 const FetchRecipientsService = require('./fetch-recipients.service.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const SelectRecipientsPresenter = require('../../../presenters/notices/setup/select-recipients.presenter.js')
-const SessionModel = require('../../../models/session.model.js')
 
 /**
  * Orchestrates fetching and presenting the data for the '/notices/setup/{sessionId}/select-recipients' page
@@ -18,7 +18,7 @@ const SessionModel = require('../../../models/session.model.js')
  * @returns {Promise<object>} - The data formatted for the view template
  */
 async function go(sessionId) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const selectedRecipients = _selectedRecipients(session)
 

--- a/app/services/return-logs/setup/cancel.service.js
+++ b/app/services/return-logs/setup/cancel.service.js
@@ -6,7 +6,7 @@
  */
 
 const CancelPresenter = require('../../../presenters/return-logs/setup/cancel.presenter.js')
-const SessionModel = require('../../../models/session.model.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 
 /**
  * Orchestrates fetching and presenting the data for `/return-logs/setup/{sessionId}/cancel` page
@@ -16,7 +16,7 @@ const SessionModel = require('../../../models/session.model.js')
  * @returns {Promise<object>} The page data needed by the view template
  */
 async function go(sessionId) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const formattedData = CancelPresenter.go(session)
 

--- a/app/services/return-logs/setup/check.service.js
+++ b/app/services/return-logs/setup/check.service.js
@@ -7,7 +7,7 @@
 
 const ApplyQuantitiesService = require('../../../services/return-logs/setup/apply-quantities.service.js')
 const CheckPresenter = require('../../../presenters/return-logs/setup/check.presenter.js')
-const SessionModel = require('../../../models/session.model.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const { readFlashNotification } = require('../../../lib/general.lib.js')
 
 /**
@@ -19,7 +19,7 @@ const { readFlashNotification } = require('../../../lib/general.lib.js')
  * @returns {Promise<object>} page data needed by the view template
  */
 async function go(sessionId, yar) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   await _updateSession(session)
 

--- a/app/services/return-logs/setup/delete-note.service.js
+++ b/app/services/return-logs/setup/delete-note.service.js
@@ -5,8 +5,8 @@
  * @module DeleteNoteService
  */
 
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const GeneralLib = require('../../../lib/general.lib.js')
-const SessionModel = require('../../../models/session.model.js')
 
 /**
  * Deletes the note from the return log currently being setup
@@ -18,7 +18,7 @@ const SessionModel = require('../../../models/session.model.js')
  * @param {object} yar - The Hapi `request.yar` session manager passed on by the controller
  */
 async function go(sessionId, yar) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   GeneralLib.flashNotification(yar, 'Deleted', 'Note deleted')
 

--- a/app/services/return-logs/setup/meter-details.service.js
+++ b/app/services/return-logs/setup/meter-details.service.js
@@ -5,8 +5,8 @@
  * @module MeterDetailsService
  */
 
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const MeterDetailsPresenter = require('../../../presenters/return-logs/setup/meter-details.presenter.js')
-const SessionModel = require('../../../models/session.model.js')
 
 /**
  * Orchestrates fetching and presenting the data for `/return-logs/setup/{sessionId}/meter-details` page
@@ -19,7 +19,7 @@ const SessionModel = require('../../../models/session.model.js')
  * @returns {Promise<object>} The view data for the meter details page
  */
 async function go(sessionId) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const pageData = MeterDetailsPresenter.go(session)
 

--- a/app/services/return-logs/setup/meter-provided.service.js
+++ b/app/services/return-logs/setup/meter-provided.service.js
@@ -5,8 +5,8 @@
  * @module MeterProvidedService
  */
 
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const MeterProvidedPresenter = require('../../../presenters/return-logs/setup/meter-provided.presenter.js')
-const SessionModel = require('../../../models/session.model.js')
 
 /**
  * Orchestrates fetching and presenting the data for `/return-logs/setup/{sessionId}/meter-provided` page
@@ -19,7 +19,7 @@ const SessionModel = require('../../../models/session.model.js')
  * @returns {Promise<object>} The view data for the meter provided page
  */
 async function go(sessionId) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const pageData = MeterProvidedPresenter.go(session)
 

--- a/app/services/return-logs/setup/multiple-entries.service.js
+++ b/app/services/return-logs/setup/multiple-entries.service.js
@@ -5,8 +5,8 @@
  * @module MultipleEntriesService
  */
 
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const MultipleEntriesPresenter = require('../../../presenters/return-logs/setup/multiple-entries.presenter.js')
-const SessionModel = require('../../../models/session.model.js')
 
 /**
  * Orchestrates fetching and presenting the data for `/return-logs/setup/{sessionId}/multiple-entries` page
@@ -19,7 +19,7 @@ const SessionModel = require('../../../models/session.model.js')
  * @returns {Promise<object>} The view data for the multiple entries page
  */
 async function go(sessionId) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const pageData = MultipleEntriesPresenter.go(session)
 

--- a/app/services/return-logs/setup/note.service.js
+++ b/app/services/return-logs/setup/note.service.js
@@ -5,8 +5,8 @@
  * @module NoteService
  */
 
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const NotePresenter = require('../../../presenters/return-logs/setup/note.presenter.js')
-const SessionModel = require('../../../models/session.model.js')
 
 /**
  * Orchestrates fetching and presenting the data for `/return-logs/setup/{sessionId}/note` page
@@ -19,7 +19,7 @@ const SessionModel = require('../../../models/session.model.js')
  * @returns {Promise<object>} The view data for the note page
  */
 async function go(sessionId) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const formattedData = NotePresenter.go(session)
 

--- a/app/services/return-logs/setup/period-used.service.js
+++ b/app/services/return-logs/setup/period-used.service.js
@@ -5,8 +5,8 @@
  * @module PeriodUsedService
  */
 
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const PeriodUsedPresenter = require('../../../presenters/return-logs/setup/period-used.presenter.js')
-const SessionModel = require('../../../models/session.model.js')
 
 /**
  * Orchestrates fetching and presenting the data for `/return-logs/setup/{sessionId}/period-used` page
@@ -19,7 +19,7 @@ const SessionModel = require('../../../models/session.model.js')
  * @returns {Promise<object>} The view data for the period used page
  */
 async function go(sessionId) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const pageData = PeriodUsedPresenter.go(session)
 

--- a/app/services/return-logs/setup/readings.service.js
+++ b/app/services/return-logs/setup/readings.service.js
@@ -6,8 +6,8 @@
  * @module ReadingsService
  */
 
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const ReadingsPresenter = require('../../../presenters/return-logs/setup/readings.presenter.js')
-const SessionModel = require('../../../models/session.model.js')
 
 /**
  * Orchestrates fetching and presenting the data needed for the `/return-logs/setup/{sessionId}/readings/{yearMonth}`
@@ -19,7 +19,7 @@ const SessionModel = require('../../../models/session.model.js')
  * @returns {Promise<object>} The view data for the readings page
  */
 async function go(sessionId, yearMonth) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const formattedData = ReadingsPresenter.go(session, yearMonth)
 

--- a/app/services/return-logs/setup/received.service.js
+++ b/app/services/return-logs/setup/received.service.js
@@ -5,8 +5,8 @@
  * @module ReceivedService
  */
 
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const ReceivedPresenter = require('../../../presenters/return-logs/setup/received.presenter.js')
-const SessionModel = require('../../../models/session.model.js')
 
 /**
  * Orchestrates fetching and presenting the data for `/return-logs/setup/{sessionId}/received` page
@@ -19,7 +19,7 @@ const SessionModel = require('../../../models/session.model.js')
  * @returns {Promise<object>} The view data for the received page
  */
 async function go(sessionId) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const formattedData = ReceivedPresenter.go(session)
 

--- a/app/services/return-logs/setup/reported.service.js
+++ b/app/services/return-logs/setup/reported.service.js
@@ -5,8 +5,8 @@
  * @module ReportedService
  */
 
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const ReportedPresenter = require('../../../presenters/return-logs/setup/reported.presenter.js')
-const SessionModel = require('../../../models/session.model.js')
 
 /**
  * Orchestrates fetching and presenting the data for `/return-logs/setup/{sessionId}/reported` page
@@ -19,7 +19,7 @@ const SessionModel = require('../../../models/session.model.js')
  * @returns {Promise<object>} The view data for the reported page
  */
 async function go(sessionId) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const pageData = ReportedPresenter.go(session)
 

--- a/app/services/return-logs/setup/single-volume.service.js
+++ b/app/services/return-logs/setup/single-volume.service.js
@@ -5,7 +5,7 @@
  * @module SingleVolumeService
  */
 
-const SessionModel = require('../../../models/session.model.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const SingleVolumePresenter = require('../../../presenters/return-logs/setup/single-volume.presenter.js')
 
 /**
@@ -19,7 +19,7 @@ const SingleVolumePresenter = require('../../../presenters/return-logs/setup/sin
  * @returns {Promise<object>} The view data for the single volume page
  */
 async function go(sessionId) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const pageData = SingleVolumePresenter.go(session)
 

--- a/app/services/return-logs/setup/start-reading.service.js
+++ b/app/services/return-logs/setup/start-reading.service.js
@@ -5,7 +5,7 @@
  * @module StartReadingService
  */
 
-const SessionModel = require('../../../models/session.model.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const StartReadingPresenter = require('../../../presenters/return-logs/setup/start-reading.presenter.js')
 
 /**
@@ -16,7 +16,7 @@ const StartReadingPresenter = require('../../../presenters/return-logs/setup/sta
  * @returns {Promise<object>} page data needed by the view template
  */
 async function go(sessionId) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const pageData = StartReadingPresenter.go(session)
 

--- a/app/services/return-logs/setup/submission.service.js
+++ b/app/services/return-logs/setup/submission.service.js
@@ -5,7 +5,7 @@
  * @module SubmissionService
  */
 
-const SessionModel = require('../../../models/session.model.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const SubmissionPresenter = require('../../../presenters/return-logs/setup/submission.presenter.js')
 
 /**
@@ -16,7 +16,7 @@ const SubmissionPresenter = require('../../../presenters/return-logs/setup/submi
  * @returns {Promise<object>} page data needed by the view template
  */
 async function go(sessionId) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const formattedData = SubmissionPresenter.go(session)
 

--- a/app/services/return-logs/setup/submit-check.service.js
+++ b/app/services/return-logs/setup/submit-check.service.js
@@ -9,6 +9,7 @@ const CheckPresenter = require('../../../presenters/return-logs/setup/check.pres
 const CheckValidator = require('../../../validators/return-logs/setup/check.validator.js')
 const CreateReturnLinesService = require('./create-return-lines.service.js')
 const CreateReturnSubmissionService = require('./create-return-submission.service.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const GenerateReturnSubmissionMetadata = require('./generate-return-submission-metadata.service.js')
 const ReturnLogModel = require('../../../models/return-log.model.js')
 const SessionModel = require('../../../models/session.model.js')
@@ -29,7 +30,7 @@ const { timestampForPostgres } = require('../../../lib/general.lib.js')
  * @returns {Promise<string>} - The ID of the submitted return log
  */
 async function go(sessionId, user) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const error = _validate(session)
 

--- a/app/services/return-logs/setup/submit-meter-details.service.js
+++ b/app/services/return-logs/setup/submit-meter-details.service.js
@@ -5,10 +5,10 @@
  * @module SubmitMeterDetailsService
  */
 
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const GeneralLib = require('../../../lib/general.lib.js')
 const MeterDetailsPresenter = require('../../../presenters/return-logs/setup/meter-details.presenter.js')
 const MeterDetailsValidator = require('../../../validators/return-logs/setup/meter-details.validator.js')
-const SessionModel = require('../../../models/session.model.js')
 const { formatValidationResult } = require('../../../presenters/base.presenter.js')
 
 /**
@@ -27,7 +27,7 @@ const { formatValidationResult } = require('../../../presenters/base.presenter.j
  * @returns {Promise<object>} If no errors the page data for the meter-details page else the validation error details
  */
 async function go(sessionId, payload, yar) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const error = _validate(payload)
 

--- a/app/services/return-logs/setup/submit-meter-provided.service.js
+++ b/app/services/return-logs/setup/submit-meter-provided.service.js
@@ -5,10 +5,10 @@
  * @module SubmitMeterProvidedService
  */
 
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const GeneralLib = require('../../../lib/general.lib.js')
 const MeterProvidedPresenter = require('../../../presenters/return-logs/setup/meter-provided.presenter.js')
 const MeterProvidedValidator = require('../../../validators/return-logs/setup/meter-provided.validator.js')
-const SessionModel = require('../../../models/session.model.js')
 const { formatValidationResult } = require('../../../presenters/base.presenter.js')
 
 /**
@@ -27,7 +27,7 @@ const { formatValidationResult } = require('../../../presenters/base.presenter.j
  * @returns {Promise<object>} If no errors the page data for the meter-provided page else the validation error details
  */
 async function go(sessionId, payload, yar) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const error = _validate(payload)
 

--- a/app/services/return-logs/setup/submit-multiple-entries.service.js
+++ b/app/services/return-logs/setup/submit-multiple-entries.service.js
@@ -5,12 +5,12 @@
  * @module SubmitMultipleEntriesService
  */
 
-const { formatValidationResult } = require('../../../presenters/base.presenter.js')
-const { convertFromCubicMetres, convertToCubicMetres } = require('../../../lib/general.lib.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const MultipleEntriesPresenter = require('../../../presenters/return-logs/setup/multiple-entries.presenter.js')
 const MultipleEntriesValidator = require('../../../validators/return-logs/setup/multiple-entries.validator.js')
-const SessionModel = require('../../../models/session.model.js')
 const SplitMultipleEntriesService = require('../../../services/return-logs/setup/split-multiple-entries.service.js')
+const { convertFromCubicMetres, convertToCubicMetres } = require('../../../lib/general.lib.js')
+const { formatValidationResult } = require('../../../presenters/base.presenter.js')
 const { returnRequirementFrequencies } = require('../../../lib/static-lookups.lib.js')
 
 /**
@@ -30,7 +30,7 @@ const { returnRequirementFrequencies } = require('../../../lib/static-lookups.li
  * including the validation error details
  */
 async function go(sessionId, payload, yar) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const measurementType = session.reported === 'abstractionVolumes' ? 'volumes' : 'meter readings'
   const frequency = returnRequirementFrequencies[session.returnsFrequency]

--- a/app/services/return-logs/setup/submit-note.service.js
+++ b/app/services/return-logs/setup/submit-note.service.js
@@ -5,9 +5,9 @@
  * @module SubmitNoteService
  */
 
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const NotePresenter = require('../../../presenters/return-logs/setup/note.presenter.js')
 const NoteValidator = require('../../../validators/return-logs/setup/note.validator.js')
-const SessionModel = require('../../../models/session.model.js')
 const { formatValidationResult } = require('../../../presenters/base.presenter.js')
 
 /**
@@ -28,7 +28,7 @@ const { formatValidationResult } = require('../../../presenters/base.presenter.j
  * validation error details
  */
 async function go(sessionId, payload, user, yar) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
   const error = _validate(payload)
 
   if (!error) {

--- a/app/services/return-logs/setup/submit-period-used.service.js
+++ b/app/services/return-logs/setup/submit-period-used.service.js
@@ -6,9 +6,9 @@
  */
 
 const AllocateSingleVolumeToLinesService = require('./allocate-single-volume-to-lines.service.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const PeriodUsedPresenter = require('../../../presenters/return-logs/setup/period-used.presenter.js')
 const PeriodUsedValidator = require('../../../validators/return-logs/setup/period-used.validator.js')
-const SessionModel = require('../../../models/session.model.js')
 const { determineAbstractionPeriods } = require('../../../lib/abstraction-period.lib.js')
 const { formatValidationResult } = require('../../../presenters/base.presenter.js')
 
@@ -28,7 +28,7 @@ const { formatValidationResult } = require('../../../presenters/base.presenter.j
  * @returns {Promise<object>} If no errors the page data for the period-used page else the validation error details
  */
 async function go(sessionId, payload) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const error = _validate(payload, session)
 

--- a/app/services/return-logs/setup/submit-readings.service.js
+++ b/app/services/return-logs/setup/submit-readings.service.js
@@ -5,10 +5,10 @@
  * @module SubmitReadingsService
  */
 
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const GeneralLib = require('../../../lib/general.lib.js')
 const ReadingsPresenter = require('../../../presenters/return-logs/setup/readings.presenter.js')
 const ReadingsValidator = require('../../../validators/return-logs/setup/readings.validator.js')
-const SessionModel = require('../../../models/session.model.js')
 const { formatValidationResult } = require('../../../presenters/base.presenter.js')
 
 /**
@@ -23,7 +23,7 @@ const { formatValidationResult } = require('../../../presenters/base.presenter.j
  * the validation error details
  */
 async function go(sessionId, payload, yar, yearMonth) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const [requestedYear, requestedMonth] = _determineRequestedYearAndMonth(yearMonth)
 

--- a/app/services/return-logs/setup/submit-received.service.js
+++ b/app/services/return-logs/setup/submit-received.service.js
@@ -5,11 +5,11 @@
  * @module SubmitReceivedService
  */
 
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const ReceivedDateValidator = require('../../../validators/return-logs/setup/received-date.validator.js')
 const ReceivedPresenter = require('../../../presenters/return-logs/setup/received.presenter.js')
-const SessionModel = require('../../../models/session.model.js')
-const { formatValidationResult } = require('../../../presenters/base.presenter.js')
 const { flashNotification, today } = require('../../../lib/general.lib.js')
+const { formatValidationResult } = require('../../../presenters/base.presenter.js')
 
 /**
  * Orchestrates validating the data for `/return-logs/setup/{sessionId}/received` page
@@ -28,7 +28,7 @@ const { flashNotification, today } = require('../../../lib/general.lib.js')
  * @returns {Promise<object>} If no errors the page data for the received page else the validation error details
  */
 async function go(sessionId, payload, yar) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const { startDate } = session
   const error = _validate(payload, startDate)

--- a/app/services/return-logs/setup/submit-reported.service.js
+++ b/app/services/return-logs/setup/submit-reported.service.js
@@ -5,10 +5,10 @@
  * @module SubmitReportedService
  */
 
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const GeneralLib = require('../../../lib/general.lib.js')
 const ReportedPresenter = require('../../../presenters/return-logs/setup/reported.presenter.js')
 const ReportedValidator = require('../../../validators/return-logs/setup/reported.validator.js')
-const SessionModel = require('../../../models/session.model.js')
 const { formatValidationResult } = require('../../../presenters/base.presenter.js')
 
 /**
@@ -27,7 +27,7 @@ const { formatValidationResult } = require('../../../presenters/base.presenter.j
  * @returns {Promise<object>} If no errors the page data for the reported page else the validation error details
  */
 async function go(sessionId, payload, yar) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const error = _validate(payload)
 

--- a/app/services/return-logs/setup/submit-single-volume.service.js
+++ b/app/services/return-logs/setup/submit-single-volume.service.js
@@ -5,7 +5,7 @@
  * @module SubmitSingleVolumeService
  */
 
-const SessionModel = require('../../../models/session.model.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const SingleVolumePresenter = require('../../../presenters/return-logs/setup/single-volume.presenter.js')
 const SingleVolumeValidator = require('../../../validators/return-logs/setup/single-volume.validator.js')
 const { formatValidationResult } = require('../../../presenters/base.presenter.js')
@@ -26,7 +26,7 @@ const { formatValidationResult } = require('../../../presenters/base.presenter.j
  * @returns {Promise<object>} If no errors the page data for the single-volume page else the validation error details
  */
 async function go(sessionId, payload) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const error = _validate(payload)
 

--- a/app/services/return-logs/setup/submit-start-reading.service.js
+++ b/app/services/return-logs/setup/submit-start-reading.service.js
@@ -5,8 +5,8 @@
  * @module SubmitStartReadingService
  */
 
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const GeneralLib = require('../../../lib/general.lib.js')
-const SessionModel = require('../../../models/session.model.js')
 const StartReadingPresenter = require('../../../presenters/return-logs/setup/start-reading.presenter.js')
 const StartReadingValidator = require('../../../validators/return-logs/setup/start-reading.validator.js')
 const { formatValidationResult } = require('../../../presenters/base.presenter.js')
@@ -27,7 +27,7 @@ const { formatValidationResult } = require('../../../presenters/base.presenter.j
  * @returns {Promise<object>} If no errors the page data for the start reading page else the validation error details
  */
 async function go(sessionId, payload, yar) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const error = _validate(payload, session)
 

--- a/app/services/return-logs/setup/submit-submission.service.js
+++ b/app/services/return-logs/setup/submit-submission.service.js
@@ -5,8 +5,9 @@
  * @module SubmitSubmissionService
  */
 
+const DeleteSessionDal = require('../../../dal/delete-session.dal.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const ReturnLogModel = require('../../../models/return-log.model.js')
-const SessionModel = require('../../../models/session.model.js')
 const SubmissionPresenter = require('../../../presenters/return-logs/setup/submission.presenter.js')
 const SubmissionValidator = require('../../../validators/return-logs/setup/submission.validator.js')
 const { formatValidationResult } = require('../../../presenters/base.presenter.js')
@@ -22,7 +23,7 @@ const { timestampForPostgres } = require('../../../lib/general.lib.js')
  * the abstraction return page including the validation error details
  */
 async function go(sessionId, payload) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
   const error = _validate(payload)
 
   const { returnLogId } = session
@@ -51,7 +52,7 @@ async function _confirmReceipt(session) {
     .findById(session.returnLogId)
     .patch({ receivedDate: session.receivedDate, status: 'received', updatedAt: timestampForPostgres() })
 
-  await SessionModel.query().deleteById(session.id)
+  await DeleteSessionDal.go(session.id)
 }
 
 async function _redirect(journey, session) {

--- a/app/services/return-logs/setup/submit-units.service.js
+++ b/app/services/return-logs/setup/submit-units.service.js
@@ -5,12 +5,12 @@
  * @module SubmitUnitsService
  */
 
-const { formatValidationResult } = require('../../../presenters/base.presenter.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const GeneralLib = require('../../../lib/general.lib.js')
-const SessionModel = require('../../../models/session.model.js')
-const { returnUnits } = require('../../../lib/static-lookups.lib.js')
 const UnitsPresenter = require('../../../presenters/return-logs/setup/units.presenter.js')
 const UnitsValidator = require('../../../validators/return-logs/setup/units.validator.js')
+const { formatValidationResult } = require('../../../presenters/base.presenter.js')
+const { returnUnits } = require('../../../lib/static-lookups.lib.js')
 
 /**
  * Orchestrates validating the data for `/return-logs/setup/{sessionId}/units` page
@@ -28,7 +28,7 @@ const UnitsValidator = require('../../../validators/return-logs/setup/units.vali
  * @returns {Promise<object>} If no errors the page data for the units page else the validation error details
  */
 async function go(sessionId, payload, yar) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const error = _validate(payload)
 

--- a/app/services/return-logs/setup/submit-volumes.service.js
+++ b/app/services/return-logs/setup/submit-volumes.service.js
@@ -5,8 +5,8 @@
  * @module SubmitVolumesService
  */
 
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const GeneralLib = require('../../../lib/general.lib.js')
-const SessionModel = require('../../../models/session.model.js')
 const VolumesPresenter = require('../../../presenters/return-logs/setup/volumes.presenter.js')
 const VolumesValidator = require('../../../validators/return-logs/setup/volumes.validator.js')
 const { convertFromCubicMetres, convertToCubicMetres } = require('../../../lib/general.lib.js')
@@ -24,7 +24,7 @@ const { formatValidationResult } = require('../../../presenters/base.presenter.j
  * the validation error details
  */
 async function go(sessionId, payload, yar, yearMonth) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const [requestedYear, requestedMonth] = _determineRequestedYearAndMonth(yearMonth)
 

--- a/app/services/return-logs/setup/units.service.js
+++ b/app/services/return-logs/setup/units.service.js
@@ -5,7 +5,7 @@
  * @module UnitsService
  */
 
-const SessionModel = require('../../../models/session.model.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const UnitsPresenter = require('../../../presenters/return-logs/setup/units.presenter.js')
 
 /**
@@ -19,7 +19,7 @@ const UnitsPresenter = require('../../../presenters/return-logs/setup/units.pres
  * @returns {Promise<object>} The view data for the units page
  */
 async function go(sessionId) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const pageData = UnitsPresenter.go(session)
 

--- a/app/services/return-logs/setup/volumes.service.js
+++ b/app/services/return-logs/setup/volumes.service.js
@@ -5,7 +5,7 @@
  * @module VolumesService
  */
 
-const SessionModel = require('../../../models/session.model.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const VolumesPresenter = require('../../../presenters/return-logs/setup/volumes.presenter.js')
 
 /**
@@ -17,7 +17,7 @@ const VolumesPresenter = require('../../../presenters/return-logs/setup/volumes.
  * @returns {Promise<object>} The view data for the volumes page
  */
 async function go(sessionId, yearMonth) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const formattedData = VolumesPresenter.go(session, yearMonth)
 

--- a/app/services/return-versions/setup/abstraction-period.service.js
+++ b/app/services/return-versions/setup/abstraction-period.service.js
@@ -6,7 +6,7 @@
  */
 
 const AbstractionPeriodPresenter = require('../../../presenters/return-versions/setup/abstraction-period.presenter.js')
-const SessionModel = require('../../../models/session.model.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 
 /**
  * Orchestrates fetching and presenting the data for `/return-versions/setup/{sessionId}/abstraction-period` page
@@ -20,7 +20,7 @@ const SessionModel = require('../../../models/session.model.js')
  * @returns {Promise<object>} The view data for the abstraction period page
  */
 async function go(sessionId, requirementIndex) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const formattedData = AbstractionPeriodPresenter.go(session, requirementIndex)
 

--- a/app/services/return-versions/setup/add.service.js
+++ b/app/services/return-versions/setup/add.service.js
@@ -5,7 +5,7 @@
  * @module AddService
  */
 
-const SessionModel = require('../../../models/session.model.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 
 /**
  * Orchestrates adding an empty object to the requirements array in the session
@@ -19,7 +19,7 @@ const SessionModel = require('../../../models/session.model.js')
  * to display and update
  */
 async function go(sessionId) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   await _save(session)
 

--- a/app/services/return-versions/setup/additional-submission-options.service.js
+++ b/app/services/return-versions/setup/additional-submission-options.service.js
@@ -7,7 +7,7 @@
  */
 
 const AdditionalSubmissionOptionsPresenter = require('../../../presenters/return-versions/setup/additional-submission-options.presenter.js')
-const SessionModel = require('../../../models/session.model.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 
 /**
  * Orchestrates fetching and presenting the data for
@@ -21,7 +21,7 @@ const SessionModel = require('../../../models/session.model.js')
  * @returns {Promise<object>} The view data for the points page
  */
 async function go(sessionId) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const formattedData = AdditionalSubmissionOptionsPresenter.go(session)
 

--- a/app/services/return-versions/setup/agreements-exceptions.service.js
+++ b/app/services/return-versions/setup/agreements-exceptions.service.js
@@ -6,7 +6,7 @@
  */
 
 const AgreementsExceptionsPresenter = require('../../../presenters/return-versions/setup/agreements-exceptions.presenter.js')
-const SessionModel = require('../../../models/session.model.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 
 /**
  * Orchestrates fetching and presenting the data for `/return-versions/setup/{sessionId}/agreements-exceptions` page
@@ -20,7 +20,7 @@ const SessionModel = require('../../../models/session.model.js')
  * @returns {Promise<object>} The view data for the agreements and exceptions page
  */
 async function go(sessionId, requirementIndex) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const formattedData = AgreementsExceptionsPresenter.go(session, requirementIndex)
 

--- a/app/services/return-versions/setup/cancel.service.js
+++ b/app/services/return-versions/setup/cancel.service.js
@@ -6,7 +6,7 @@
  */
 
 const CancelPresenter = require('../../../presenters/return-versions/setup/cancel.presenter.js')
-const SessionModel = require('../../../models/session.model.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 
 /**
  * Orchestrates fetching and presenting the data for `/return-versions/setup/{sessionId}/cancel` page
@@ -19,7 +19,7 @@ const SessionModel = require('../../../models/session.model.js')
  * @returns {Promise<object>} The view data for the cancel requirements page
  */
 async function go(sessionId) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const formattedData = CancelPresenter.go(session)
 

--- a/app/services/return-versions/setup/check/check.service.js
+++ b/app/services/return-versions/setup/check/check.service.js
@@ -7,8 +7,8 @@
 
 const CheckPresenter = require('../../../../presenters/return-versions/setup/check/check.presenter.js')
 const FetchPointsService = require('../fetch-points.service.js')
+const FetchSessionDal = require('../../../../dal/fetch-session.dal.js')
 const ReturnRequirementsPresenter = require('../../../../presenters/return-versions/setup/check/returns-requirements.presenter.js')
-const SessionModel = require('../../../../models/session.model.js')
 const { readFlashNotification } = require('../../../../lib/general.lib.js')
 
 /**
@@ -20,7 +20,7 @@ const { readFlashNotification } = require('../../../../lib/general.lib.js')
  * @returns {Promise<object>} page data needed by the view template
  */
 async function go(sessionId, yar) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   await _markCheckPageVisited(session)
 

--- a/app/services/return-versions/setup/check/submit-check.service.js
+++ b/app/services/return-versions/setup/check/submit-check.service.js
@@ -5,10 +5,11 @@
  * @module SubmitCheckService
  */
 
-const GenerateReturnVersionService = require('./generate-return-version.service.js')
 const CreateReturnVersionService = require('./create-return-version.service.js')
+const DeleteSessionDal = require('../../../../dal/delete-session.dal.js')
+const FetchSessionDal = require('../../../../dal/fetch-session.dal.js')
+const GenerateReturnVersionService = require('./generate-return-version.service.js')
 const ProcessLicenceReturnLogsService = require('../../../return-logs/process-licence-return-logs.service.js')
-const SessionModel = require('../../../../models/session.model.js')
 const VoidReturnLogsService = require('../../../return-logs/void-return-logs.service.js')
 const { db } = require('../../../../../db/db.js')
 
@@ -28,11 +29,11 @@ const ONE_DAY_IN_MILLISECONDS = 24 * 60 * 60 * 1000
  * @returns {Promise<string>} The licence Id
  */
 async function go(sessionId, userId) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   await _processReturnVersion(session, userId)
 
-  await SessionModel.query().deleteById(sessionId)
+  await DeleteSessionDal.go(sessionId)
 
   return session.licence.id
 }

--- a/app/services/return-versions/setup/delete-note.service.js
+++ b/app/services/return-versions/setup/delete-note.service.js
@@ -5,7 +5,7 @@
  * @module DeleteNoteService
  */
 
-const SessionModel = require('../../../models/session.model.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 
 /**
  * Deletes the note from the return version currently being setup
@@ -17,7 +17,7 @@ const SessionModel = require('../../../models/session.model.js')
  * @param {object} yar - The Hapi `request.yar` session manager passed on by the controller
  */
 async function go(sessionId, yar) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
   const notification = {
     title: 'Deleted',
     text: 'Note deleted'

--- a/app/services/return-versions/setup/existing/existing.service.js
+++ b/app/services/return-versions/setup/existing/existing.service.js
@@ -6,7 +6,7 @@
  */
 
 const ExistingPresenter = require('../../../../presenters/return-versions/setup/existing.presenter.js')
-const SessionModel = require('../../../../models/session.model.js')
+const FetchSessionDal = require('../../../../dal/fetch-session.dal.js')
 
 /**
  * Orchestrates fetching and presenting the data for `/return-versions/setup/{sessionId}/existing` page
@@ -19,7 +19,7 @@ const SessionModel = require('../../../../models/session.model.js')
  * @returns {Promise<object>} The view data for the purpose page
  */
 async function go(sessionId) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const formattedData = ExistingPresenter.go(session)
 

--- a/app/services/return-versions/setup/existing/submit-existing.service.js
+++ b/app/services/return-versions/setup/existing/submit-existing.service.js
@@ -9,8 +9,8 @@ const { formatValidationResult } = require('../../../../presenters/base.presente
 
 const ExistingPresenter = require('../../../../presenters/return-versions/setup/existing.presenter.js')
 const ExistingValidator = require('../../../../validators/return-versions/setup/existing.validator.js')
+const FetchSessionDal = require('../../../../dal/fetch-session.dal.js')
 const GenerateFromExistingRequirementsService = require('./generate-from-existing-requirements.service.js')
-const SessionModel = require('../../../../models/session.model.js')
 
 /**
  * Orchestrates validating the data for `/return-versions/setup/{sessionId}/existing` page
@@ -29,7 +29,7 @@ const SessionModel = require('../../../../models/session.model.js')
  * validation error details
  */
 async function go(sessionId, payload) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const validationResult = _validate(payload, session)
 

--- a/app/services/return-versions/setup/frequency-collected.service.js
+++ b/app/services/return-versions/setup/frequency-collected.service.js
@@ -5,8 +5,8 @@
  * @module FrequencyCollectedService
  */
 
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const FrequencyCollectedPresenter = require('../../../presenters/return-versions/setup/frequency-collected.presenter.js')
-const SessionModel = require('../../../models/session.model.js')
 
 /**
  * Orchestrates fetching and presenting the data for `/return-versions/setup/{sessionId}/frequency-collected` page
@@ -20,7 +20,7 @@ const SessionModel = require('../../../models/session.model.js')
  * @returns {Promise<object>} The view data for the frequency collected page
  */
 async function go(sessionId, requirementIndex) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const formattedData = FrequencyCollectedPresenter.go(session, requirementIndex)
 

--- a/app/services/return-versions/setup/frequency-reported.service.js
+++ b/app/services/return-versions/setup/frequency-reported.service.js
@@ -5,8 +5,8 @@
  * @module FrequencyReportedService
  */
 
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const FrequencyReportedPresenter = require('../../../presenters/return-versions/setup/frequency-reported.presenter.js')
-const SessionModel = require('../../../models/session.model.js')
 
 /**
  * Orchestrates fetching and presenting the data for `/return-versions/setup/{sessionId}/frequency-reported` page
@@ -20,7 +20,7 @@ const SessionModel = require('../../../models/session.model.js')
  * @returns {Promise<object>} The view data for the frequency reported page
  */
 async function go(sessionId, requirementIndex) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const formattedData = FrequencyReportedPresenter.go(session, requirementIndex)
 

--- a/app/services/return-versions/setup/method/method.service.js
+++ b/app/services/return-versions/setup/method/method.service.js
@@ -5,8 +5,8 @@
  * @module MethodService
  */
 
+const FetchSessionDal = require('../../../../dal/fetch-session.dal.js')
 const MethodPresenter = require('../../../../presenters/return-versions/setup/method.presenter.js')
-const SessionModel = require('../../../../models/session.model.js')
 
 /**
  * Orchestrates fetching and presenting the data for `/return-versions/setup/{sessionId}/method` page
@@ -19,7 +19,7 @@ const SessionModel = require('../../../../models/session.model.js')
  * @returns {Promise<object>} page data needed by the view template
  */
 async function go(sessionId) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const formattedData = MethodPresenter.go(session)
 

--- a/app/services/return-versions/setup/method/submit-method.service.js
+++ b/app/services/return-versions/setup/method/submit-method.service.js
@@ -7,8 +7,8 @@
 
 const { formatValidationResult } = require('../../../../presenters/base.presenter.js')
 
+const FetchSessionDal = require('../../../../dal/fetch-session.dal.js')
 const GenerateFromAbstractionDataService = require('./generate-from-abstraction-data.service.js')
-const SessionModel = require('../../../../models/session.model.js')
 const MethodPresenter = require('../../../../presenters/return-versions/setup/method.presenter.js')
 const MethodValidator = require('../../../../validators/return-versions/setup/method.validator.js')
 
@@ -28,7 +28,7 @@ const MethodValidator = require('../../../../validators/return-versions/setup/me
  * setup page including the validation error details
  */
 async function go(sessionId, payload) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const validationResult = _validate(payload)
 

--- a/app/services/return-versions/setup/no-returns-required.service.js
+++ b/app/services/return-versions/setup/no-returns-required.service.js
@@ -5,8 +5,8 @@
  * @module NoReturnsRequiredService
  */
 
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const NoReturnsRequiredPresenter = require('../../../presenters/return-versions/setup/no-returns-required.presenter.js')
-const SessionModel = require('../../../models/session.model.js')
 
 /**
  * Orchestrates fetching and presenting the data for `/return-versions/setup/{sessionId}/no-returns-required` page
@@ -19,7 +19,7 @@ const SessionModel = require('../../../models/session.model.js')
  * @returns {Promise<object>} The view data for the no returns required page
  */
 async function go(sessionId) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const formattedData = NoReturnsRequiredPresenter.go(session)
 

--- a/app/services/return-versions/setup/note.service.js
+++ b/app/services/return-versions/setup/note.service.js
@@ -5,8 +5,8 @@
  * @module NoteService
  */
 
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const NotePresenter = require('../../../presenters/return-versions/setup/note.presenter.js')
-const SessionModel = require('../../../models/session.model.js')
 
 /**
  * Orchestrates fetching and presenting the data for `/return-versions/setup/{sessionId}/note` page
@@ -19,7 +19,7 @@ const SessionModel = require('../../../models/session.model.js')
  * @returns {Promise<object>} The view data for the note page
  */
 async function go(sessionId) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const formattedData = NotePresenter.go(session)
 

--- a/app/services/return-versions/setup/points.service.js
+++ b/app/services/return-versions/setup/points.service.js
@@ -6,8 +6,8 @@
  */
 
 const FetchPointsService = require('./fetch-points.service.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const PointsPresenter = require('../../../presenters/return-versions/setup/points.presenter.js')
-const SessionModel = require('../../../models/session.model.js')
 
 /**
  * Orchestrates fetching and presenting the data for `/return-versions/setup/{sessionId}/points` page
@@ -21,7 +21,7 @@ const SessionModel = require('../../../models/session.model.js')
  * @returns {Promise<object>} The view data for the points page
  */
 async function go(sessionId, requirementIndex) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
   const points = await FetchPointsService.go(session.licenceVersion.id)
 
   const formattedData = PointsPresenter.go(session, requirementIndex, points)

--- a/app/services/return-versions/setup/purpose.service.js
+++ b/app/services/return-versions/setup/purpose.service.js
@@ -6,8 +6,8 @@
  */
 
 const FetchPurposesService = require('./fetch-purposes.service.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const SelectPurposePresenter = require('../../../presenters/return-versions/setup/purpose.presenter.js')
-const SessionModel = require('../../../models/session.model.js')
 
 /**
  * Orchestrates fetching and presenting the data for `/return-versions/setup/{sessionId}/purpose` page
@@ -21,7 +21,7 @@ const SessionModel = require('../../../models/session.model.js')
  * @returns {Promise<object>} The view data for the purpose page
  */
 async function go(sessionId, requirementIndex) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
   const purposesData = await FetchPurposesService.go(session.licenceVersion.id)
 
   const formattedData = SelectPurposePresenter.go(session, requirementIndex, purposesData)

--- a/app/services/return-versions/setup/reason.service.js
+++ b/app/services/return-versions/setup/reason.service.js
@@ -5,8 +5,8 @@
  * @module SelectReasonService
  */
 
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const SelectReasonPresenter = require('../../../presenters/return-versions/setup/reason.presenter.js')
-const SessionModel = require('../../../models/session.model.js')
 
 /**
  * Orchestrates fetching and presenting the data for `/return-versions/setup/{sessionId}/reason` page
@@ -19,7 +19,7 @@ const SessionModel = require('../../../models/session.model.js')
  * @returns {Promise<object>} page data needed by the view template
  */
 async function go(sessionId) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const formattedData = SelectReasonPresenter.go(session)
 

--- a/app/services/return-versions/setup/remove.service.js
+++ b/app/services/return-versions/setup/remove.service.js
@@ -6,8 +6,8 @@
  * @module RemoveService
  */
 
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const RemovePresenter = require('../../../presenters/return-versions/setup/remove.presenter.js')
-const SessionModel = require('../../../models/session.model.js')
 
 /**
  * Orchestrates fetching and presenting the data for
@@ -22,7 +22,7 @@ const SessionModel = require('../../../models/session.model.js')
  * @returns {Promise<object>} The view data for the remove requirements page
  */
 async function go(sessionId, requirementIndex) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
   const formattedData = RemovePresenter.go(session, requirementIndex)
 
   return {

--- a/app/services/return-versions/setup/returns-cycle.service.js
+++ b/app/services/return-versions/setup/returns-cycle.service.js
@@ -5,8 +5,8 @@
  * @module ReturnsCycleService
  */
 
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const ReturnsCyclePresenter = require('../../../presenters/return-versions/setup/returns-cycle.presenter.js')
-const SessionModel = require('../../../models/session.model.js')
 
 /**
  * Orchestrates fetching and presenting the data for `/return-versions/setup/{sessionId}/returns-cycle` page
@@ -20,7 +20,7 @@ const SessionModel = require('../../../models/session.model.js')
  * @returns {Promise<object>} The view data for the returns cycle page
  */
 async function go(sessionId, requirementIndex) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const formattedData = ReturnsCyclePresenter.go(session, requirementIndex)
 

--- a/app/services/return-versions/setup/site-description.service.js
+++ b/app/services/return-versions/setup/site-description.service.js
@@ -5,7 +5,7 @@
  * @module SiteDescriptionService
  */
 
-const SessionModel = require('../../../models/session.model.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const SiteDescriptionPresenter = require('../../../presenters/return-versions/setup/site-description.presenter.js')
 
 /**
@@ -20,7 +20,7 @@ const SiteDescriptionPresenter = require('../../../presenters/return-versions/se
  * @returns {Promise<object>} The view data for the site description page
  */
 async function go(sessionId, requirementIndex) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const formattedData = SiteDescriptionPresenter.go(session, requirementIndex)
 

--- a/app/services/return-versions/setup/start-date.service.js
+++ b/app/services/return-versions/setup/start-date.service.js
@@ -5,7 +5,7 @@
  * @module StartDateService
  */
 
-const SessionModel = require('../../../models/session.model.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const StartDatePresenter = require('../../../presenters/return-versions/setup/start-date.presenter.js')
 
 /**
@@ -19,7 +19,7 @@ const StartDatePresenter = require('../../../presenters/return-versions/setup/st
  * @returns {Promise<object>} The view data for the start date page
  */
 async function go(sessionId) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const formattedData = StartDatePresenter.go(session)
 

--- a/app/services/return-versions/setup/submit-abstraction-period.service.js
+++ b/app/services/return-versions/setup/submit-abstraction-period.service.js
@@ -9,8 +9,8 @@ const { formatValidationResult } = require('../../../presenters/base.presenter.j
 
 const AbstractionPeriodPresenter = require('../../../presenters/return-versions/setup/abstraction-period.presenter.js')
 const AbstractionPeriodValidator = require('../../../validators/abstraction-period.validator.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const GeneralLib = require('../../../lib/general.lib.js')
-const SessionModel = require('../../../models/session.model.js')
 
 /**
  * Orchestrates validating the data for `/return-versions/setup/{sessionId}/abstraction-period` page
@@ -30,7 +30,7 @@ const SessionModel = require('../../../models/session.model.js')
  * the page data for the abstraction period page including the validation error details
  */
 async function go(sessionId, requirementIndex, payload, yar) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const validationResult = _validate(payload)
 

--- a/app/services/return-versions/setup/submit-additional-submission-options.service.js
+++ b/app/services/return-versions/setup/submit-additional-submission-options.service.js
@@ -7,8 +7,8 @@
 
 const AdditionalSubmissionOptionsPresenter = require('../../../presenters/return-versions/setup/additional-submission-options.presenter.js')
 const AdditionalSubmissionOptionsValidator = require('../../../validators/return-versions/setup/additional-submission-options.validator.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const { formatValidationResult } = require('../../../presenters/base.presenter.js')
-const SessionModel = require('../../../models/session.model.js')
 const { handleOneOptionSelected } = require('../../../lib/submit-page.lib.js')
 
 /**
@@ -28,7 +28,7 @@ const { handleOneOptionSelected } = require('../../../lib/submit-page.lib.js')
  * validation error details
  */
 async function go(sessionId, payload, yar) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   handleOneOptionSelected(payload, 'additionalSubmissionOptions')
 

--- a/app/services/return-versions/setup/submit-agreements-exceptions.service.js
+++ b/app/services/return-versions/setup/submit-agreements-exceptions.service.js
@@ -7,9 +7,9 @@
 
 const AgreementsExceptionsPresenter = require('../../../presenters/return-versions/setup/agreements-exceptions.presenter.js')
 const AgreementsExceptionsValidator = require('../../../validators/return-versions/setup/agreements-exceptions.validator.js')
-const { formatValidationResult } = require('../../../presenters/base.presenter.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const GeneralLib = require('../../../lib/general.lib.js')
-const SessionModel = require('../../../models/session.model.js')
+const { formatValidationResult } = require('../../../presenters/base.presenter.js')
 const { handleOneOptionSelected } = require('../../../lib/submit-page.lib.js')
 
 /**
@@ -30,7 +30,7 @@ const { handleOneOptionSelected } = require('../../../lib/submit-page.lib.js')
  * the page data for the agreements exceptions page including the validation error details
  */
 async function go(sessionId, requirementIndex, payload, yar) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   handleOneOptionSelected(payload, 'agreementsExceptions')
 

--- a/app/services/return-versions/setup/submit-frequency-collected.service.js
+++ b/app/services/return-versions/setup/submit-frequency-collected.service.js
@@ -7,10 +7,10 @@
 
 const { formatValidationResult } = require('../../../presenters/base.presenter.js')
 
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const FrequencyCollectedPresenter = require('../../../presenters/return-versions/setup/frequency-collected.presenter.js')
 const FrequencyCollectedValidator = require('../../../validators/return-versions/setup/frequency-collected.validator.js')
 const GeneralLib = require('../../../lib/general.lib.js')
-const SessionModel = require('../../../models/session.model.js')
 
 /**
  * Orchestrates validating the data for `/return-versions/setup/{sessionId}/frequency-collected` page
@@ -30,7 +30,7 @@ const SessionModel = require('../../../models/session.model.js')
  * the page data for the frequency collected page including the validation error details
  */
 async function go(sessionId, requirementIndex, payload, yar) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const validationResult = _validate(payload)
 

--- a/app/services/return-versions/setup/submit-frequency-reported.service.js
+++ b/app/services/return-versions/setup/submit-frequency-reported.service.js
@@ -7,10 +7,10 @@
 
 const { formatValidationResult } = require('../../../presenters/base.presenter.js')
 
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const FrequencyReportedPresenter = require('../../../presenters/return-versions/setup/frequency-reported.presenter.js')
 const FrequencyReportedValidator = require('../../../validators/return-versions/setup/frequency-reported.validator.js')
 const GeneralLib = require('../../../lib/general.lib.js')
-const SessionModel = require('../../../models/session.model.js')
 
 /**
  * Orchestrates validating the data for `/return-versions/setup/{sessionId}/frequency-reported` page
@@ -30,7 +30,7 @@ const SessionModel = require('../../../models/session.model.js')
  * the page data for the frequency reported page including the validation error details
  */
 async function go(sessionId, requirementIndex, payload, yar) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const validationResult = _validate(payload)
 

--- a/app/services/return-versions/setup/submit-no-returns-required.service.js
+++ b/app/services/return-versions/setup/submit-no-returns-required.service.js
@@ -7,10 +7,10 @@
 
 const { formatValidationResult } = require('../../../presenters/base.presenter.js')
 
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
+const GeneralLib = require('../../../lib/general.lib.js')
 const NoReturnsRequiredPresenter = require('../../../presenters/return-versions/setup/no-returns-required.presenter.js')
 const NoReturnsRequiredValidator = require('../../../validators/return-versions/setup/no-returns-required.validator.js')
-const SessionModel = require('../../../models/session.model.js')
-const GeneralLib = require('../../../lib/general.lib.js')
 
 /**
  * Orchestrates validating the data for `/return-versions/setup/{sessionId}/no-returns-required` page
@@ -28,7 +28,7 @@ const GeneralLib = require('../../../lib/general.lib.js')
  * @returns {Promise<object>} The page data for the no returns required page
  */
 async function go(sessionId, payload, yar) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
   const validationResult = _validate(payload)
 
   if (!validationResult) {

--- a/app/services/return-versions/setup/submit-note.service.js
+++ b/app/services/return-versions/setup/submit-note.service.js
@@ -7,9 +7,9 @@
 
 const { formatValidationResult } = require('../../../presenters/base.presenter.js')
 
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const NotePresenter = require('../../../presenters/return-versions/setup/note.presenter.js')
 const NoteValidator = require('../../../validators/return-versions/setup/note.validator.js')
-const SessionModel = require('../../../models/session.model.js')
 
 /**
  * Orchestrates validating the data for `/return-versions/setup/{sessionId}/note` page
@@ -29,7 +29,7 @@ const SessionModel = require('../../../models/session.model.js')
  * validation error details
  */
 async function go(sessionId, payload, user, yar) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
   const validationResult = _validate(payload)
 
   if (!validationResult) {

--- a/app/services/return-versions/setup/submit-points.service.js
+++ b/app/services/return-versions/setup/submit-points.service.js
@@ -8,10 +8,10 @@
 const { formatValidationResult } = require('../../../presenters/base.presenter.js')
 
 const FetchPointsService = require('./fetch-points.service.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const GeneralLib = require('../../../lib/general.lib.js')
 const PointsPresenter = require('../../../presenters/return-versions/setup/points.presenter.js')
 const PointsValidator = require('../../../validators/return-versions/setup/points.validator.js')
-const SessionModel = require('../../../models/session.model.js')
 const { handleOneOptionSelected } = require('../../../lib/submit-page.lib.js')
 
 /**
@@ -32,7 +32,7 @@ const { handleOneOptionSelected } = require('../../../lib/submit-page.lib.js')
  * the page data for the points page including the validation error details
  */
 async function go(sessionId, requirementIndex, payload, yar) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   handleOneOptionSelected(payload, 'points')
 

--- a/app/services/return-versions/setup/submit-purpose.service.js
+++ b/app/services/return-versions/setup/submit-purpose.service.js
@@ -5,12 +5,12 @@
  * @module SubmitPurposeService
  */
 
-const { formatValidationResult } = require('../../../presenters/base.presenter.js')
 const FetchPurposesService = require('./fetch-purposes.service.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const GeneralLib = require('../../../lib/general.lib.js')
 const PurposePresenter = require('../../../presenters/return-versions/setup/purpose.presenter.js')
 const PurposeValidation = require('../../../validators/return-versions/setup/purpose.validator.js')
-const SessionModel = require('../../../models/session.model.js')
+const { formatValidationResult } = require('../../../presenters/base.presenter.js')
 const { handleOneOptionSelected } = require('../../../lib/submit-page.lib.js')
 
 /**
@@ -31,7 +31,7 @@ const { handleOneOptionSelected } = require('../../../lib/submit-page.lib.js')
  * the page data for the purpose page including the validation error details
  */
 async function go(sessionId, requirementIndex, payload, yar) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
   const licencePurposes = await FetchPurposesService.go(session.licenceVersion.id)
 
   handleOneOptionSelected(payload, 'purposes')

--- a/app/services/return-versions/setup/submit-reason.service.js
+++ b/app/services/return-versions/setup/submit-reason.service.js
@@ -7,10 +7,10 @@
 
 const { formatValidationResult } = require('../../../presenters/base.presenter.js')
 
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const GeneralLib = require('../../../lib/general.lib.js')
 const ReasonPresenter = require('../../../presenters/return-versions/setup/reason.presenter.js')
 const ReasonValidator = require('../../../validators/return-versions/setup/reason.validator.js')
-const SessionModel = require('../../../models/session.model.js')
 
 /**
  * Orchestrates validating the data for `/return-versions/setup/{sessionId}/reason` page
@@ -29,7 +29,7 @@ const SessionModel = require('../../../models/session.model.js')
  * the page data for the reason page including the validation error details
  */
 async function go(sessionId, payload, yar) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const validationResult = _validate(payload)
 

--- a/app/services/return-versions/setup/submit-remove.service.js
+++ b/app/services/return-versions/setup/submit-remove.service.js
@@ -5,7 +5,7 @@
  * @module SubmitRemoveService
  */
 
-const SessionModel = require('../../../models/session.model.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 
 /**
  * Manages deleting the selected requirement in the session when remove is confirmed
@@ -18,7 +18,7 @@ const SessionModel = require('../../../models/session.model.js')
  * @param {object} yar - The Hapi `request.yar` session manager passed on by the controller
  */
 async function go(sessionId, requirementIndex, yar) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const notification = {
     title: 'Removed',

--- a/app/services/return-versions/setup/submit-returns-cycle.service.js
+++ b/app/services/return-versions/setup/submit-returns-cycle.service.js
@@ -7,10 +7,10 @@
 
 const { formatValidationResult } = require('../../../presenters/base.presenter.js')
 
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const GeneralLib = require('../../../lib/general.lib.js')
 const ReturnsCyclePresenter = require('../../../presenters/return-versions/setup/returns-cycle.presenter.js')
 const ReturnsCycleValidator = require('../../../validators/return-versions/setup/returns-cycle.validator.js')
-const SessionModel = require('../../../models/session.model.js')
 
 /**
  * Orchestrates validating the data for `/return-versions/setup/{sessionId}/returns-cycle` page
@@ -30,7 +30,7 @@ const SessionModel = require('../../../models/session.model.js')
  * the page data for the returns cycle page including the validation error details
  */
 async function go(sessionId, requirementIndex, payload, yar) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const validationResult = _validate(payload, session)
 

--- a/app/services/return-versions/setup/submit-site-description.service.js
+++ b/app/services/return-versions/setup/submit-site-description.service.js
@@ -7,8 +7,8 @@
 
 const { formatValidationResult } = require('../../../presenters/base.presenter.js')
 
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const GeneralLib = require('../../../lib/general.lib.js')
-const SessionModel = require('../../../models/session.model.js')
 const SiteDescriptionPresenter = require('../../../presenters/return-versions/setup/site-description.presenter.js')
 const SiteDescriptionValidator = require('../../../validators/return-versions/setup/site-description.validator.js')
 
@@ -30,7 +30,7 @@ const SiteDescriptionValidator = require('../../../validators/return-versions/se
  * the page data for the site description page including the validation error details
  */
 async function go(sessionId, requirementIndex, payload, yar) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const validationResult = _validate(payload)
 

--- a/app/services/return-versions/setup/submit-start-date.service.js
+++ b/app/services/return-versions/setup/submit-start-date.service.js
@@ -9,8 +9,8 @@ const { isQuarterlyReturnSubmissions, sameDate } = require('../../../lib/dates.l
 const { formatValidationResult } = require('../../../presenters/base.presenter.js')
 
 const DetermineRelevantLicenceVersionService = require('./determine-relevant-licence-version.service.js')
+const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const GeneralLib = require('../../../lib/general.lib.js')
-const SessionModel = require('../../../models/session.model.js')
 const StartDatePresenter = require('../../../presenters/return-versions/setup/start-date.presenter.js')
 const StartDateValidator = require('../../../validators/return-versions/setup/start-date.validator.js')
 
@@ -40,7 +40,7 @@ const StartDateValidator = require('../../../validators/return-versions/setup/st
  * next page in the journey else the page data for the start date page including the validation error details
  */
 async function go(sessionId, payload, yar) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const { endDate, startDate } = session.licence
   const validationResult = _validate(payload, startDate, endDate)


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5573

We recently added an updated way to fetch a session using the 'FetchSessionDal' method, this throws a specific error which we catch and display to the user, this is shown when a session does not exist (through timeout or deleted).

This change updates all uses of 'const session = await SessionModel.query().findById(sessionId)' to 'const session = await FetchSessionDal.go(sessionId)'

Where the session is deleted, we have added a 'DeleteSessionDal' this has also been updated in places where code similar to 'await SessionModel.query().delete().where('id', sessionId)' is used.

This is a big change, and we expect the established tests to pass (they are using the real session), work will be done in later changes (to save our sanity) to stub the 'FetchSessionDal' and 'DeleteSessionDal'