### PR TITLE
Fix tear down of notifications test data

### DIFF
--- a/app/services/data/load/load.service.js
+++ b/app/services/data/load/load.service.js
@@ -213,7 +213,7 @@ const LOAD_HELPERS = {
  *   "licences": [
  *     {
  *       "id": "f8702a6a-f61d-4b0a-9af3-9a53768ee516",
- *       "licenceRef": "AT/TEST/01",
+ *       "licenceRef": "AT/TE/ST/01/01",
  *       "regionId": "d0a4123d-1e19-480d-9dd4-f70f3387c4b9",
  *       "regions": {
  *         "historicalAreaCode": "SAAR",

--- a/app/services/data/tear-down/water-schema.service.js
+++ b/app/services/data/tear-down/water-schema.service.js
@@ -484,7 +484,7 @@ async function _deleteAllTestData() {
       OR EXISTS (
         SELECT 1
         FROM jsonb_array_elements_text("e"."licences") AS l
-        WHERE l = ANY(array['AT/TEST/01', 'AT/TEST/02', 'AT/TEST/03', 'AT/TEST/04'])
+        WHERE l = ANY(array['AT/TE/ST/01/01', 'AT/TE/ST/01/02', 'AT/TE/ST/01/03', 'AT/TE/ST/01/04'])
       )
     )
     AND "sn"."event_id" = "e"."event_id";
@@ -499,7 +499,7 @@ async function _deleteAllTestData() {
       OR EXISTS (
         SELECT 1
         FROM jsonb_array_elements_text("licences") AS l
-        WHERE l = ANY(array['AT/TEST/01', 'AT/TEST/02', 'AT/TEST/03', 'AT/TEST/04'])
+        WHERE l = ANY(array['AT/TE/ST/01/01', 'AT/TE/ST/01/02', 'AT/TE/ST/01/03', 'AT/TE/ST/01/04'])
       )
   );
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5292

Whilst working on the migration of the search feature, we noticed that the existing acceptance test data used licence numbers that did not meet our expectations for what a licence reference should look like.

So, [we updated the acceptance test seeding](https://github.com/DEFRA/water-abstraction-acceptance-tests/pull/215) to use licence references in the format `AT/TE/ST/01/01` instead of `AT/TEST/01`.

What we didn't do was update our teardown logic to match. This specifically applies to notices, where the licence ref is the only indicator we have that the notice and its notifications are test data that should be deleted.

Since this change, anyone who has run the acceptance tests has been creating 'test' notices that are not deleted. This means they have been building up over time.

This correction to the teardown logic will ensure that all test notices and their associated notifications are deleted.