### PR TITLE
Update scaffolding to use the 'FetchSessionDal'

### DIFF
--- a/scaffold.sh
+++ b/scaffold.sh
@@ -245,9 +245,11 @@ render_source_and_test() {
 
   # Render test file
   if [ -n "$TEST_TEMPLATE" ]; then
-     DESCRIBE_BASE="${REL_DIR:+${REL_DIR}/}${RAW_NAME}"
-     DESCRIBE_LABEL="$(path_to_describe_label "$DESCRIBE_BASE") $TYPE" # Test describe block
-     REQUIRE_PATH="${RELATIVE_UP_PATH}../app/${SUBFOLDER}/${REL_DIR}/${SOURCE_FILE}"
+    DESCRIBE_BASE="${REL_DIR:+${REL_DIR}/}${RAW_NAME}"
+    DESCRIBE_LABEL="$(path_to_describe_label "$DESCRIBE_BASE") $TYPE" # Test describe block
+    REQUIRE_PATH="${RELATIVE_UP_PATH}../app/${SUBFOLDER}/${REL_DIR}/${SOURCE_FILE}"
+
+    render_test_file "$TEST_TEMPLATE" "$TEST_OUTPUT" "$MODULE_NAME" "$REQUIRE_PATH" "$DESCRIBE_LABEL"
 
     render_test_file "$TEST_TEMPLATE" "$TEST_OUTPUT" "$MODULE_NAME" "$REQUIRE_PATH" "$DESCRIBE_LABEL"
   fi

--- a/scaffold.sh
+++ b/scaffold.sh
@@ -96,17 +96,13 @@ render_file() {
     return
   fi
 
-  sed -e "s/__MODULE_NAME__/${module_name}/g" \
-      -e "s#{{APP_ROOT}}#${RELATIVE_UP_PATH%/}/#g" \
-      -e "s#{{NAME}}#${PASCAL_NAME}#g" \
-      -e "s#{{REL_DIR}}#${rel_dir}#g" \
-      -e "s#{{RAW_NAME}}#${raw_name}#g" \
+  sed -e "s#__BASE_PRESENTER_PATH__#${RELATIVE_UP_PATH}presenters/base.presenter.js#g" \
+      -e "s#__FETCH_SESSION_DAL_PATH__#${RELATIVE_UP_PATH}dal/fetch-session.dal.js#g" \
       -e "s#__PRESENTER_PATH__#${RELATIVE_UP_PATH}presenters/${REL_DIR}/${RAW_NAME}.presenter.js#g" \
       -e "s#__VALIDATOR_PATH__#${RELATIVE_UP_PATH}validators/${REL_DIR}/${RAW_NAME}.validator.js#g" \
-      -e "s#__FETCH_SESSION_DAL_PATH__#${RELATIVE_UP_PATH}dal/fetch-session.dal.js#g" \
-      -e "s#__BASE_PRESENTER_PATH__#${RELATIVE_UP_PATH}presenters/base.presenter.js#g" \
-      -e "s/__VALIDATOR_NAME__/${PASCAL_NAME}Validator/g" \
       -e "s/__PRESENTER_NAME__/${PASCAL_NAME}Presenter/g" \
+      -e "s/__VALIDATOR_NAME__/${PASCAL_NAME}Validator/g" \
+      -e "s/__MODULE_NAME__/${module_name}/g" \
       "$template" > "$output_path"
 
   echo "✅ Created $output_path"
@@ -128,13 +124,13 @@ render_test_file() {
     return
   fi
 
-  sed -e "s/__MODULE_NAME__/${module_name}/g" \
-      -e "s/__DESCRIBE_LABEL__/${describe_label}/g" \
-      -e "s#__PRESENTER_PATH__#${presenter_path}#g" \
-      -e "s/__PRESENTER_NAME__/${PASCAL_NAME}Presenter/g" \
-      -e "s#__FETCH_SESSION_DAL_TEST_PATH__#${RELATIVE_UP_PATH}../app/dal/fetch-session.dal.js#g" \
-      -e "s#__STUBS_SESSION_PATH__#${RELATIVE_UP_PATH}support/stubs/session.stub.js#g" \
+  sed -e "s#__FETCH_SESSION_DAL_TEST_PATH__#${RELATIVE_UP_PATH}../app/dal/fetch-session.dal.js#g" \
       -e "s#__REQUIRE_PATH__#${require_path}#g" \
+      -e "s#__STUBS_SESSION_PATH__#${RELATIVE_UP_PATH}support/stubs/session.stub.js#g" \
+      -e "s#__PRESENTER_PATH__#${presenter_path}#g" \
+      -e "s/__DESCRIBE_LABEL__/${describe_label}/g" \
+      -e "s/__PRESENTER_NAME__/${PASCAL_NAME}Presenter/g" \
+      -e "s/__MODULE_NAME__/${module_name}/g" \
       "$template" > "$output_path"
 
   echo "✅ Created $output_path"
@@ -153,14 +149,14 @@ generate_helper_snippet() {
     local view_path="${REL_DIR}/${RAW_NAME}.njk"
 
     sed -e "s|__CONTROLLER_NAME__|${PASCAL_NAME}Controller|g" \
-        -e "s|__NAME__|${PASCAL_NAME}|g" \
-        -e "s|__SUBMIT_NAME__|Submit${PASCAL_NAME}Service|g" \
-        -e "s|__SUBMIT_SERVICE_NAME__|submit${PASCAL_NAME}Service|g" \
-        -e "s|__VIEW_SERVICE_NAME__|view${PASCAL_NAME}Service|g" \
         -e "s|__SERVICE_NAME__|View${PASCAL_NAME}Service|g" \
         -e "s|__SERVICE_PATH__|${service_path}|g" \
         -e "s|__SUBMIT_PATH__|${submit_service_path}|g" \
+        -e "s|__SUBMIT_SERVICE_NAME__|submit${PASCAL_NAME}Service|g" \
         -e "s|__VIEW_PATH__|${view_path}|g" \
+        -e "s|__VIEW_SERVICE_NAME__|view${PASCAL_NAME}Service|g" \
+        -e "s|__SUBMIT_NAME__|Submit${PASCAL_NAME}Service|g" \
+        -e "s|__NAME__|${PASCAL_NAME}|g" \
         "$snippet_template"
 
     echo ""

--- a/scaffold.sh
+++ b/scaffold.sh
@@ -84,10 +84,6 @@ render_file() {
   local template="$1"
   local output_path="$2"
   local module_name="$3"
-  local relative_path="$4"
-  local rel_dir="$5"
-  local raw_name="$6"
-
 
   mkdir -p "$(dirname "$output_path")"
 
@@ -114,8 +110,6 @@ render_test_file() {
   local module_name="$3"
   local require_path="$4"
   local describe_label="$5"
-  local rel_dir="$6"
-  local raw_name="$7"
 
   mkdir -p "$(dirname "$output_path")"
 
@@ -127,9 +121,7 @@ render_test_file() {
   sed -e "s#__FETCH_SESSION_DAL_TEST_PATH__#${RELATIVE_UP_PATH}../app/dal/fetch-session.dal.js#g" \
       -e "s#__REQUIRE_PATH__#${require_path}#g" \
       -e "s#__STUBS_SESSION_PATH__#${RELATIVE_UP_PATH}support/stubs/session.stub.js#g" \
-      -e "s#__PRESENTER_PATH__#${presenter_path}#g" \
       -e "s/__DESCRIBE_LABEL__/${describe_label}/g" \
-      -e "s/__PRESENTER_NAME__/${PASCAL_NAME}Presenter/g" \
       -e "s/__MODULE_NAME__/${module_name}/g" \
       "$template" > "$output_path"
 
@@ -249,7 +241,7 @@ render_source_and_test() {
   generate_paths "$type" "$service_variant"
 
   # Render source file
-  render_file "$SOURCE_TEMPLATE" "$SOURCE_OUTPUT" "$MODULE_NAME" "$RELATIVE_UP_PATH" "$REL_DIR" "$RAW_NAME"
+  render_file "$SOURCE_TEMPLATE" "$SOURCE_OUTPUT" "$MODULE_NAME"
 
   # Render test file
   if [ -n "$TEST_TEMPLATE" ]; then
@@ -257,7 +249,7 @@ render_source_and_test() {
      DESCRIBE_LABEL="$(path_to_describe_label "$DESCRIBE_BASE") $TYPE" # Test describe block
      REQUIRE_PATH="${RELATIVE_UP_PATH}../app/${SUBFOLDER}/${REL_DIR}/${SOURCE_FILE}"
 
-    render_test_file "$TEST_TEMPLATE" "$TEST_OUTPUT" "$MODULE_NAME" "$REQUIRE_PATH" "$DESCRIBE_LABEL" "$REL_DIR" "$RAW_NAME"
+    render_test_file "$TEST_TEMPLATE" "$TEST_OUTPUT" "$MODULE_NAME" "$REQUIRE_PATH" "$DESCRIBE_LABEL"
   fi
 }
 

--- a/scaffold.sh
+++ b/scaffold.sh
@@ -84,10 +84,10 @@ render_file() {
   local template="$1"
   local output_path="$2"
   local module_name="$3"
-  local presenter_path="$4"
-  local session_model_path="$5"
-  local validator_path="$6"
-  local format_validator_path="$7"
+  local relative_path="$4"
+  local rel_dir="$5"
+  local raw_name="$6"
+
 
   mkdir -p "$(dirname "$output_path")"
 
@@ -96,17 +96,17 @@ render_file() {
     return
   fi
 
-  sed -e "s#__PRESENTER_PATH__#${presenter_path}#g" \
-      -e "s#__SESSION_MODEL_PATH__#${session_model_path}#g" \
-      -e "s#__VALIDATOR_PATH__#${validator_path}#g" \
-      -e "s#__FORMAT_VALIDATOR_PATH__#${format_validator_path}#g" \
-      -e "s/__CONTROLLER_NAME__/${PASCAL_NAME}Controller/g" \
-      -e "s/__NAME__/${PASCAL_NAME}/g" \
-      -e "s/__PRESENTER_NAME__/${PASCAL_NAME}Presenter/g" \
-      -e "s/__SERVICE_NAME__/${PASCAL_NAME}Service/g" \
-      -e "s/__SUBMIT_NAME__/Submit${PASCAL_NAME}Service/g" \
+  sed -e "s/__MODULE_NAME__/${module_name}/g" \
+      -e "s#{{APP_ROOT}}#${RELATIVE_UP_PATH%/}/#g" \
+      -e "s#{{NAME}}#${PASCAL_NAME}#g" \
+      -e "s#{{REL_DIR}}#${rel_dir}#g" \
+      -e "s#{{RAW_NAME}}#${raw_name}#g" \
+      -e "s#__PRESENTER_PATH__#${RELATIVE_UP_PATH}presenters/${REL_DIR}/${RAW_NAME}.presenter.js#g" \
+      -e "s#__VALIDATOR_PATH__#${RELATIVE_UP_PATH}validators/${REL_DIR}/${RAW_NAME}.validator.js#g" \
+      -e "s#__FETCH_SESSION_DAL_PATH__#${RELATIVE_UP_PATH}dal/fetch-session.dal.js#g" \
+      -e "s#__BASE_PRESENTER_PATH__#${RELATIVE_UP_PATH}presenters/base.presenter.js#g" \
       -e "s/__VALIDATOR_NAME__/${PASCAL_NAME}Validator/g" \
-      -e "s/__MODULE_NAME__/${module_name}/g" \
+      -e "s/__PRESENTER_NAME__/${PASCAL_NAME}Presenter/g" \
       "$template" > "$output_path"
 
   echo "✅ Created $output_path"
@@ -118,8 +118,8 @@ render_test_file() {
   local module_name="$3"
   local require_path="$4"
   local describe_label="$5"
-  local presenter_path="$6"
-  local session_helper_path="$7"
+  local rel_dir="$6"
+  local raw_name="$7"
 
   mkdir -p "$(dirname "$output_path")"
 
@@ -129,12 +129,12 @@ render_test_file() {
   fi
 
   sed -e "s/__MODULE_NAME__/${module_name}/g" \
-      -e "s#__REQUIRE_PATH__#${require_path}#g" \
       -e "s/__DESCRIBE_LABEL__/${describe_label}/g" \
       -e "s#__PRESENTER_PATH__#${presenter_path}#g" \
       -e "s/__PRESENTER_NAME__/${PASCAL_NAME}Presenter/g" \
-      -e "s/__FETCH_NAME__/Fetch${PASCAL_NAME}Service/g" \
-      -e "s#__SESSION_HELPER_PATH__#${session_helper_path}#g" \
+      -e "s#__FETCH_SESSION_DAL_TEST_PATH__#${RELATIVE_UP_PATH}../app/dal/fetch-session.dal.js#g" \
+      -e "s#__STUBS_SESSION_PATH__#${RELATIVE_UP_PATH}support/stubs/session.stub.js#g" \
+      -e "s#__REQUIRE_PATH__#${require_path}#g" \
       "$template" > "$output_path"
 
   echo "✅ Created $output_path"
@@ -152,13 +152,15 @@ generate_helper_snippet() {
     local submit_service_path="../services/${REL_DIR}/submit-${RAW_NAME}.service.js"
     local view_path="${REL_DIR}/${RAW_NAME}.njk"
 
-    sed -e "s|__SERVICE_NAME__|View${PASCAL_NAME}Service|g" \
-        -e "s|__SUBMIT_NAME__|Submit${PASCAL_NAME}Service|g" \
-        -e "s|__SERVICE_PATH__|${service_path}|g" \
+    sed -e "s|__CONTROLLER_NAME__|${PASCAL_NAME}Controller|g" \
         -e "s|__NAME__|${PASCAL_NAME}|g" \
-        -e "s|__VIEW_PATH__|${view_path}|g" \
-        -e "s|__CONTROLLER_NAME__|${PASCAL_NAME}Controller|g" \
+        -e "s|__SUBMIT_NAME__|Submit${PASCAL_NAME}Service|g" \
+        -e "s|__SUBMIT_SERVICE_NAME__|submit${PASCAL_NAME}Service|g" \
+        -e "s|__VIEW_SERVICE_NAME__|view${PASCAL_NAME}Service|g" \
+        -e "s|__SERVICE_NAME__|View${PASCAL_NAME}Service|g" \
+        -e "s|__SERVICE_PATH__|${service_path}|g" \
         -e "s|__SUBMIT_PATH__|${submit_service_path}|g" \
+        -e "s|__VIEW_PATH__|${view_path}|g" \
         "$snippet_template"
 
     echo ""
@@ -242,19 +244,6 @@ generate_paths() {
 
   # Helper
   RELATIVE_UP_PATH=$(build_up_path)
-
-  DESCRIBE_BASE="${REL_DIR:+${REL_DIR}/}${RAW_NAME}"
-  DESCRIBE_LABEL="$(path_to_describe_label "$DESCRIBE_BASE") $TYPE" # Test describe block
-
-  REQUIRE_PATH="${RELATIVE_UP_PATH}../app/${SUBFOLDER}/${REL_DIR}/${SOURCE_FILE}"
-  SESSION_HELPER_PATH="${RELATIVE_UP_PATH}support/helpers/session.helper.js"
-
-  # Additional paths
-  PRESENTER_PATH="${RELATIVE_UP_PATH}presenters/${REL_DIR}/${RAW_NAME}.presenter.js"
-  VALIDATOR_PATH="${RELATIVE_UP_PATH}validators/${REL_DIR}/${RAW_NAME}.validator.js"
-  SESSION_MODEL_PATH="${RELATIVE_UP_PATH}models/session.model.js"
-  FORMAT_VALIDATOR_PATH="${RELATIVE_UP_PATH}presenters/base.presenter.js"
-
 }
 
 render_source_and_test() {
@@ -264,11 +253,15 @@ render_source_and_test() {
   generate_paths "$type" "$service_variant"
 
   # Render source file
-  render_file "$SOURCE_TEMPLATE" "$SOURCE_OUTPUT" "$MODULE_NAME" "$PRESENTER_PATH" "$SESSION_MODEL_PATH" "$VALIDATOR_PATH" "$FORMAT_VALIDATOR_PATH"
+  render_file "$SOURCE_TEMPLATE" "$SOURCE_OUTPUT" "$MODULE_NAME" "$RELATIVE_UP_PATH" "$REL_DIR" "$RAW_NAME"
 
   # Render test file
   if [ -n "$TEST_TEMPLATE" ]; then
-    render_test_file "$TEST_TEMPLATE" "$TEST_OUTPUT" "$MODULE_NAME" "$REQUIRE_PATH" "$DESCRIBE_LABEL" "$PRESENTER_PATH" "$SESSION_HELPER_PATH"
+     DESCRIBE_BASE="${REL_DIR:+${REL_DIR}/}${RAW_NAME}"
+     DESCRIBE_LABEL="$(path_to_describe_label "$DESCRIBE_BASE") $TYPE" # Test describe block
+     REQUIRE_PATH="${RELATIVE_UP_PATH}../app/${SUBFOLDER}/${REL_DIR}/${SOURCE_FILE}"
+
+    render_test_file "$TEST_TEMPLATE" "$TEST_OUTPUT" "$MODULE_NAME" "$REQUIRE_PATH" "$DESCRIBE_LABEL" "$REL_DIR" "$RAW_NAME"
   fi
 }
 

--- a/templates/helper.js
+++ b/templates/helper.js
@@ -1,10 +1,10 @@
-/* eslint-disable camelcase, no-unused-vars, strict, no-undef */
+/* eslint-disable no-unused-vars, strict, no-undef */
 
 // Controller code
 const __SERVICE_NAME__ = require('__SERVICE_PATH__')
 const __SUBMIT_NAME__ = require('__SUBMIT_PATH__')
 
-async function view__NAME__(request, h) {
+async function __VIEW_SERVICE_NAME__(request, h) {
   const { sessionId } = request.params
 
   const pageData = await __SERVICE_NAME__.go(sessionId)
@@ -12,7 +12,7 @@ async function view__NAME__(request, h) {
   return h.view(`__VIEW_PATH__`, pageData)
 }
 
-async function submit__NAME__(request, h) {
+async function __SUBMIT_SERVICE_NAME__(request, h) {
   const {
     payload,
     params: { sessionId }
@@ -34,7 +34,7 @@ const routes = [
     method: 'GET',
     path: '',
     options: {
-      handler: __CONTROLLER_NAME__.view__NAME__,
+      handler: __CONTROLLER_NAME__.__VIEW_SERVICE_NAME__,
       auth: {
         access: {
           scope: ['']
@@ -46,7 +46,7 @@ const routes = [
     method: 'POST',
     path: '',
     options: {
-      handler: __CONTROLLER_NAME__.submit__NAME__,
+      handler: __CONTROLLER_NAME__.__SUBMIT_SERVICE_NAME__,
       auth: {
         access: {
           scope: ['']

--- a/templates/presenter.js
+++ b/templates/presenter.js
@@ -1,12 +1,12 @@
 'use strict'
 
 /**
- * Formats data for the `` page
+ * Formats data for the '' page
  * @module __MODULE_NAME__
  */
 
 /**
- * Formats data for the `` page
+ * Formats data for the '' page
  *
  * @param {object} session - The session instance
  *

--- a/templates/submit.service.js
+++ b/templates/submit.service.js
@@ -1,18 +1,18 @@
 'use strict'
 
 /**
- * Orchestrates validating the data for the `` page
+ * Orchestrates validating the data for the '' page
  *
  * @module __MODULE_NAME__
  */
 
 const __PRESENTER_NAME__ = require('__PRESENTER_PATH__')
 const __VALIDATOR_NAME__ = require('__VALIDATOR_PATH__')
-const SessionModel = require('__SESSION_MODEL_PATH__')
-const { formatValidationResult } = require('__FORMAT_VALIDATOR_PATH__')
+const FetchSessionDal = require('__FETCH_SESSION_DAL_PATH__')
+const { formatValidationResult } = require('__BASE_PRESENTER_PATH__')
 
 /**
- * Orchestrates validating the data for the `` page
+ * Orchestrates validating the data for the '' page
  *
  * @param {string} sessionId - The UUID of the current session
  * @param {object} payload - The submitted form data
@@ -20,7 +20,7 @@ const { formatValidationResult } = require('__FORMAT_VALIDATOR_PATH__')
  * @returns {Promise<object>} The data formatted for the view template
  */
 async function go(sessionId, payload) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const validationResult = _validate(payload)
 

--- a/templates/submit.service.test.js
+++ b/templates/submit.service.test.js
@@ -3,12 +3,16 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
+const Sinon = require('sinon')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const SessionHelper = require('__SESSION_HELPER_PATH__')
+const SessionModelStub = require('__STUBS_SESSION_PATH__')
+
+// Things we need to stub
+const FetchSessionDal = require('__FETCH_SESSION_DAL_TEST_PATH__')
 
 // Thing under test
 const __MODULE_NAME__ = require('__REQUIRE_PATH__')
@@ -22,16 +26,21 @@ describe('__DESCRIBE_LABEL__', () => {
     payload = { placeholder: 'change me' }
     sessionData = {}
 
-    session = await SessionHelper.add({ data: sessionData })
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    Sinon.stub(FetchSessionDal, 'go').resolves(session)
+  })
+
+  afterEach(() => {
+    Sinon.restore()
   })
 
   describe('when called', () => {
     it('saves the submitted value', async () => {
       await __MODULE_NAME__.go(session.id, payload)
 
-      const refreshedSession = await session.$query()
-
-      expect(refreshedSession).to.equal(session)
+      expect(session).to.equal(session)
+      expect(session.$update.called).to.be.true()
     })
 
     it('continues the journey', async () => {

--- a/templates/validator.js
+++ b/templates/validator.js
@@ -1,7 +1,7 @@
 'use strict'
 
 /**
- * Validates data submitted for the `` page
+ * Validates data submitted for the '' page
  *
  * @module __MODULE_NAME__
  */
@@ -9,7 +9,7 @@
 const Joi = require('joi')
 
 /**
- * Validates data submitted for the `` page
+ * Validates data submitted for the '' page
  *
  * @param {object} payload - The payload from the request to be validated
  *

--- a/templates/view-service.js
+++ b/templates/view-service.js
@@ -1,23 +1,23 @@
 'use strict'
 
 /**
- * Orchestrates fetching and presenting the data for the `` page
+ * Orchestrates fetching and presenting the data for the '' page
  *
  * @module __MODULE_NAME__
  */
 
 const __PRESENTER_NAME__ = require('__PRESENTER_PATH__')
-const SessionModel = require('__SESSION_MODEL_PATH__')
+const FetchSessionDal = require('__FETCH_SESSION_DAL_PATH__')
 
 /**
- * Orchestrates fetching and presenting the data for the `` page
+ * Orchestrates fetching and presenting the data for the '' page
  *
  * @param {string} sessionId - The UUID of the current session
  *
  * @returns {Promise<object>} The data formatted for the view template
  */
 async function go(sessionId) {
-  const session = await SessionModel.query().findById(sessionId)
+  const session = await FetchSessionDal.go(sessionId)
 
   const pageData = __PRESENTER_NAME__.go(session)
 

--- a/templates/view-service.test.js
+++ b/templates/view-service.test.js
@@ -3,12 +3,16 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
+const Sinon = require('sinon')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const SessionHelper = require('__SESSION_HELPER_PATH__')
+const SessionModelStub = require('__STUBS_SESSION_PATH__')
+
+// Things we need to stub
+const FetchSessionDal = require('__FETCH_SESSION_DAL_TEST_PATH__')
 
 // Thing under test
 const __MODULE_NAME__ = require('__REQUIRE_PATH__')
@@ -20,7 +24,13 @@ describe('__DESCRIBE_LABEL__', () => {
   beforeEach(async () => {
     sessionData = {}
 
-    session = await SessionHelper.add({ data: sessionData })
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    Sinon.stub(FetchSessionDal, 'go').resolves(session)
+  })
+
+  afterEach(() => {
+    Sinon.restore()
   })
 
   describe('when called', () => {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5573

We recently added an updated way to fetch a session using the 'FetchSessionDal' method, this throws a specific error which we catch and display to the user, this is shown when a session does not exist (through timeout or deleted).

This change updates the scaffolding to use this updated way of working.

Tests for the view and submit service will stub the 'FetchSessionDal' rather than using the real thing as before.

We have taken this chance to refactor the scaffolding to simplify changes by pushing the path building in to the relevant render functions, this is now extendable to any file we need to add into the templates.