### PR TITLE
Update submit cancels to use 'DeleteSessionDal'

### DIFF
--- a/app/services/return-logs/setup/submit-cancel.service.js
+++ b/app/services/return-logs/setup/submit-cancel.service.js
@@ -5,7 +5,7 @@
  * @module SubmitCancelService
  */
 
-const SessionModel = require('../../../models/session.model.js')
+const DeleteSessionDal = require('../../../dal/delete-session.dal.js')
 
 /**
  * Manages cancelling the return submission session when cancel is confirmed
@@ -15,7 +15,7 @@ const SessionModel = require('../../../models/session.model.js')
  * @param {string} sessionId - The UUID for the return submission setup session record
  */
 async function go(sessionId) {
-  await SessionModel.query().deleteById(sessionId)
+  await DeleteSessionDal.go(sessionId)
 }
 
 module.exports = {

--- a/app/services/return-versions/setup/submit-cancel.service.js
+++ b/app/services/return-versions/setup/submit-cancel.service.js
@@ -5,7 +5,7 @@
  * @module SubmitCancelService
  */
 
-const SessionModel = require('../../../models/session.model.js')
+const DeleteSessionDal = require('../../../dal/delete-session.dal.js')
 
 /**
  * Manages deleting the return requirement session when cancel is confirmed
@@ -16,7 +16,7 @@ const SessionModel = require('../../../models/session.model.js')
  * @param {string} sessionId - The UUID for the return requirement setup session record
  */
 async function go(sessionId) {
-  await SessionModel.query().deleteById(sessionId)
+  await DeleteSessionDal.go(sessionId)
 }
 
 module.exports = {

--- a/test/services/return-logs/setup/submit-cancel.service.test.js
+++ b/test/services/return-logs/setup/submit-cancel.service.test.js
@@ -23,7 +23,7 @@ describe('Return Logs Setup - Submit Cancel service', () => {
   beforeEach(async () => {
     session = SessionModelStub.build(Sinon, {})
 
-    Sinon.stub(DeleteSessionDal, 'go').resolves(session)
+    Sinon.stub(DeleteSessionDal, 'go').resolves()
   })
 
   afterEach(() => {

--- a/test/services/return-logs/setup/submit-cancel.service.test.js
+++ b/test/services/return-logs/setup/submit-cancel.service.test.js
@@ -3,12 +3,16 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
+const Sinon = require('sinon')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const DeleteSessionDal = require('../../../../app/dal/delete-session.dal.js')
 
 // Thing under test
 const SubmitCancelService = require('../../../../app/services/return-logs/setup/submit-cancel.service.js')
@@ -17,31 +21,20 @@ describe('Return Logs Setup - Submit Cancel service', () => {
   let session
 
   beforeEach(async () => {
-    session = await SessionHelper.add({
-      data: {
-        endDate: '2005-03-31T00:00:00.000Z',
-        periodEndDay: 31,
-        periodEndMonth: 12,
-        periodStartDay: 1,
-        periodStartMonth: 1,
-        purposes: 'Evaporative Cooling',
-        receivedDate: '2025-01-31T00:00:00.000Z',
-        returnLogId: '610ac214-03c2-4b25-a89a-65bb81d1624f',
-        returnReference: '1234',
-        siteDescription: 'POINT A, TEST SITE DESCRIPTION',
-        startDate: '2004-04-01T00:00:00.000Z',
-        twoPartTariff: false
-      }
-    })
+    session = SessionModelStub.build(Sinon, {})
+
+    Sinon.stub(DeleteSessionDal, 'go').resolves(session)
+  })
+
+  afterEach(() => {
+    Sinon.restore()
   })
 
   describe('when a user submits the return submission to be cancelled', () => {
     it('deletes the session data', async () => {
       await SubmitCancelService.go(session.id)
 
-      const refreshedSession = await session.$query()
-
-      expect(refreshedSession).not.to.exist()
+      expect(DeleteSessionDal.go.calledWith(session.id)).to.be.true()
     })
   })
 })

--- a/test/services/return-versions/setup/submit-cancel.service.test.js
+++ b/test/services/return-versions/setup/submit-cancel.service.test.js
@@ -3,13 +3,16 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
+const Sinon = require('sinon')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
-const { generateUUID } = require('../../../../app/lib/general.lib.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const DeleteSessionDal = require('../../../../app/dal/delete-session.dal.js')
 
 // Thing under test
 const SubmitCancelService = require('../../../../app/services/return-versions/setup/submit-cancel.service.js')
@@ -18,57 +21,20 @@ describe('Return Versions Setup - Submit Cancel service', () => {
   let session
 
   beforeEach(async () => {
-    session = await SessionHelper.add({
-      id: generateUUID(),
-      data: {
-        checkPageVisited: false,
-        licence: {
-          id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
-          currentVersionStartDate: '2023-01-01T00:00:00.000Z',
-          endDate: null,
-          licenceRef: '01/ABC',
-          licenceHolder: 'Turbo Kid',
-          returnVersions: [
-            {
-              id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
-              startDate: '2023-01-01T00:00:00.000Z',
-              reason: null,
-              modLogs: []
-            }
-          ],
-          startDate: '2022-04-01T00:00:00.000Z'
-        },
-        journey: 'returns-required',
-        requirements: [
-          {
-            points: ['At National Grid Reference TQ 6520 5937 (POINT A, ADDINGTON SANDPITS)'],
-            purposes: [{ alias: '', description: 'Mineral Washing', id: '3a865331-d2f3-4acc-ac85-527fa2b0d2dd' }],
-            returnsCycle: 'winter-and-all-year',
-            siteDescription: 'Bore hole in rear field',
-            abstractionPeriod: {
-              abstractionPeriodEndDay: '31',
-              abstractionPeriodEndMonth: '10',
-              abstractionPeriodStartDay: '01',
-              abstractionPeriodStartMonth: '04'
-            },
-            frequencyReported: 'month',
-            frequencyCollected: 'month',
-            agreementsExceptions: ['none']
-          }
-        ],
-        startDateOptions: 'licenceStartDate',
-        reason: 'major-change'
-      }
-    })
+    session = SessionModelStub.build(Sinon, {})
+
+    Sinon.stub(DeleteSessionDal, 'go').resolves(session)
+  })
+
+  afterEach(() => {
+    Sinon.restore()
   })
 
   describe('when a user submits the return requirements to be cancelled', () => {
     it('deletes the session data', async () => {
       await SubmitCancelService.go(session.id)
 
-      const refreshedSession = await session.$query()
-
-      expect(refreshedSession).not.to.exist()
+      expect(DeleteSessionDal.go.calledWith(session.id)).to.be.true()
     })
   })
 })

--- a/test/services/return-versions/setup/submit-cancel.service.test.js
+++ b/test/services/return-versions/setup/submit-cancel.service.test.js
@@ -23,7 +23,7 @@ describe('Return Versions Setup - Submit Cancel service', () => {
   beforeEach(async () => {
     session = SessionModelStub.build(Sinon, {})
 
-    Sinon.stub(DeleteSessionDal, 'go').resolves(session)
+    Sinon.stub(DeleteSessionDal, 'go').resolves()
   })
 
   afterEach(() => {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5573

We recently refactored how we use fetch and delete session data, we now have a single way of doing each.

We are moving away from using the database in service test.

This change updates the remaining two places where we delete the session using the session model, they have been updated to use the 'DeleteSessionDal'.

The tests have been updated to stub the 'DeleteSessionDal' and check it has been called. We understand this can be seen as a futile test, but we do this to maintain consistency with the rest of the test suite, where we have more complicated logic surrounding deleting the session.