### PR TITLE
Update tests to stub 'FetchSessionDal'

### DIFF
--- a/app/validators/return-versions/setup/returns-cycle.validator.js
+++ b/app/validators/return-versions/setup/returns-cycle.validator.js
@@ -43,7 +43,7 @@ function _noSummerCycleWithQuarterlyReturns(value, helpers, session) {
   const { returnsCycle } = value
 
   const isSummer = returnsCycle === 'summer'
-  const hasQuarterlyReturns = session.data.quarterlyReturns === true
+  const hasQuarterlyReturns = session.quarterlyReturns === true
 
   if (hasQuarterlyReturns && isSummer) {
     return helpers.error('any.invalid')

--- a/test/services/notices/setup/submit-alert-type.service.test.js
+++ b/test/services/notices/setup/submit-alert-type.service.test.js
@@ -3,18 +3,23 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
+const Sinon = require('sinon')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
 const AbstractionAlertSessionData = require('../../../support/fixtures/abstraction-alert-session-data.fixture.js')
-const SessionHelper = require('../../../../test/support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const SubmitAlertTypeService = require('../../../../app/services/notices/setup/submit-alert-type.service.js')
 
 describe('Notices - Setup - Submit Alert Type service', () => {
+  let fetchSessionStub
   let payload
   let session
   let sessionData
@@ -22,20 +27,23 @@ describe('Notices - Setup - Submit Alert Type service', () => {
   beforeEach(() => {
     payload = { alertType: 'stop' }
     sessionData = AbstractionAlertSessionData.get()
+
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    fetchSessionStub = Sinon.stub(FetchSessionDal, 'go').resolves(session)
+  })
+
+  afterEach(() => {
+    Sinon.restore()
   })
 
   describe('when called', () => {
     describe('when the "alertType" has not been previously set', () => {
-      beforeEach(async () => {
-        session = await SessionHelper.add({ data: sessionData })
-      })
-
       it('saves the submitted value', async () => {
         await SubmitAlertTypeService.go(session.id, payload)
 
-        const refreshedSession = await session.$query()
-
-        expect(refreshedSession.alertType).to.equal('stop')
+        expect(session.alertType).to.equal('stop')
+        expect(session.$update.called).to.be.true()
       })
 
       it('returns an empty object (no page data is needed for a redirect)', async () => {
@@ -46,54 +54,53 @@ describe('Notices - Setup - Submit Alert Type service', () => {
     })
 
     describe('when the user selects a different "alertType" to a previous selection', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         sessionData.alertType = 'resume'
         sessionData.removedThresholds = ['123']
 
-        session = await SessionHelper.add({ data: sessionData })
+        session = SessionModelStub.build(Sinon, sessionData)
+
+        fetchSessionStub.resolves(session)
       })
 
       it('sets the "alertThresholds" to an empty array', async () => {
         await SubmitAlertTypeService.go(session.id, payload)
 
-        const refreshedSession = await session.$query()
-
-        expect(refreshedSession.alertThresholds).to.equal([])
+        expect(session.alertThresholds).to.equal([])
+        expect(session.$update.called).to.be.true()
       })
 
       it('sets the "removedThresholds" to an empty array', async () => {
         await SubmitAlertTypeService.go(session.id, payload)
 
-        const refreshedSession = await session.$query()
-
-        expect(refreshedSession.removedThresholds).to.equal([])
+        expect(session.removedThresholds).to.equal([])
+        expect(session.$update.called).to.be.true()
       })
     })
 
     describe('when the user selects the same "alertType" they previously selected', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         sessionData.alertType = 'stop'
         sessionData.alertThresholds = ['100-flow']
 
-        session = await SessionHelper.add({ data: sessionData })
+        session = SessionModelStub.build(Sinon, sessionData)
+
+        fetchSessionStub.resolves(session)
       })
 
       it('does not change the existing "alertThresholds"', async () => {
         await SubmitAlertTypeService.go(session.id, payload)
 
-        const refreshedSession = await session.$query()
-
-        expect(refreshedSession.alertThresholds).to.equal(['100-flow'])
+        expect(session.alertThresholds).to.equal(['100-flow'])
+        expect(session.$update.called).to.be.true()
       })
     })
   })
 
   describe('when validation fails', () => {
     describe('and no option has been selected', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         payload = {}
-
-        session = await SessionHelper.add({ data: sessionData })
       })
 
       it('returns page data for the view, with errors', async () => {
@@ -154,7 +161,7 @@ describe('Notices - Setup - Submit Alert Type service', () => {
     })
 
     describe('and "stop" or "reduce" have been selected but no thresholds have that alert type', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         payload = { alertType: 'stop' }
 
         sessionData.licenceMonitoringStations = [
@@ -164,7 +171,9 @@ describe('Notices - Setup - Submit Alert Type service', () => {
           }
         ]
 
-        session = await SessionHelper.add({ data: sessionData })
+        session = SessionModelStub.build(Sinon, sessionData)
+
+        fetchSessionStub.resolves(session)
       })
 
       it('returns page data for the view, with errors (and the selected alert type checked)', async () => {

--- a/test/services/notices/setup/submit-notice-type.service.test.js
+++ b/test/services/notices/setup/submit-notice-type.service.test.js
@@ -9,20 +9,24 @@ const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const SubmitNoticeTypeService = require('../../../../app/services/notices/setup/submit-notice-type.service.js')
 
 describe('Notices - Setup - Submit Notice Type service', () => {
   let auth
+  let fetchSessionStub
   let payload
   let session
   let sessionData
   let noticeType
   let yarStub
 
-  beforeEach(async () => {
+  beforeEach(() => {
     auth = {
       credentials: { scope: ['bulk_return_notifications'] }
     }
@@ -31,7 +35,9 @@ describe('Notices - Setup - Submit Notice Type service', () => {
     payload = { noticeType }
     sessionData = {}
 
-    session = await SessionHelper.add({ data: sessionData })
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    fetchSessionStub = Sinon.stub(FetchSessionDal, 'go').resolves(session)
 
     yarStub = { flash: Sinon.stub() }
   })
@@ -44,31 +50,14 @@ describe('Notices - Setup - Submit Notice Type service', () => {
     it('saves the notice type session data', async () => {
       await SubmitNoticeTypeService.go(session.id, payload, yarStub, auth)
 
-      const refreshedSession = await session.$query()
-
-      expect(refreshedSession).to.equal({
-        ...session,
-        data: {
-          name: 'Returns: invitation',
-          noticeType: 'invitations',
-          notificationType: 'Returns invitation',
-          referenceCode: refreshedSession.referenceCode,
-          subType: 'returnInvitation'
-        },
-        name: 'Returns: invitation',
-        noticeType: 'invitations',
-        notificationType: 'Returns invitation',
-        referenceCode: refreshedSession.referenceCode,
-        subType: 'returnInvitation'
-      })
+      expect(session).to.equal(session)
+      expect(session.$update.called).to.be.true()
     })
 
     it('saves the submitted "noticeType"', async () => {
       await SubmitNoticeTypeService.go(session.id, payload, yarStub, auth)
 
-      const refreshedSession = await session.$query()
-
-      expect(refreshedSession.noticeType).to.equal('invitations')
+      expect(session.noticeType).to.equal('invitations')
     })
 
     it('returns a redirect to the "/check-notice-type" page', async () => {
@@ -79,13 +68,15 @@ describe('Notices - Setup - Submit Notice Type service', () => {
 
     describe('and the notice types is "paperReturn"', () => {
       describe('and the check page has been visited', () => {
-        beforeEach(async () => {
+        beforeEach(() => {
           sessionData.checkPageVisited = true
 
           noticeType = 'paperReturn'
           payload = { noticeType }
 
-          session = await SessionHelper.add({ data: sessionData })
+          session = SessionModelStub.build(Sinon, sessionData)
+
+          fetchSessionStub.resolves(session)
         })
 
         it('continues the journey', async () => {
@@ -96,13 +87,15 @@ describe('Notices - Setup - Submit Notice Type service', () => {
       })
 
       describe('and the check page has not been visited', () => {
-        beforeEach(async () => {
+        beforeEach(() => {
           sessionData.checkPageVisited = false
 
           noticeType = 'paperReturn'
           payload = { noticeType }
 
-          session = await SessionHelper.add({ data: sessionData })
+          session = SessionModelStub.build(Sinon, sessionData)
+
+          fetchSessionStub.resolves(session)
         })
 
         it('continues the journey', async () => {
@@ -115,16 +108,20 @@ describe('Notices - Setup - Submit Notice Type service', () => {
 
     describe('and the user comes from the check page', () => {
       describe('and the notice type has been updated', () => {
-        beforeEach(async () => {
-          session = await SessionHelper.add({ data: { noticeType: 'test', checkPageVisited: true } })
+        beforeEach(() => {
+          session = SessionModelStub.build(Sinon, {
+            checkPageVisited: true,
+            noticeType: 'test'
+          })
+
+          fetchSessionStub.resolves(session)
         })
 
         it('updates the sessions "checkPageVisited" flag', async () => {
           await SubmitNoticeTypeService.go(session.id, payload, yarStub, auth)
 
-          const refreshedSession = await session.$query()
-
-          expect(refreshedSession.checkPageVisited).to.be.false()
+          expect(session.checkPageVisited).to.be.false()
+          expect(session.$update.called).to.be.true()
         })
 
         it('sets a flash message', async () => {
@@ -142,16 +139,20 @@ describe('Notices - Setup - Submit Notice Type service', () => {
       })
 
       describe('and the notice type has not been updated', () => {
-        beforeEach(async () => {
-          session = await SessionHelper.add({ data: { noticeType, checkPageVisited: true } })
+        beforeEach(() => {
+          session = SessionModelStub.build(Sinon, {
+            noticeType,
+            checkPageVisited: true
+          })
+
+          fetchSessionStub.resolves(session)
         })
 
         it('does not update the session "checkPageVisited" flag', async () => {
           await SubmitNoticeTypeService.go(session.id, payload, yarStub, auth)
 
-          const refreshedSession = await session.$query()
-
-          expect(refreshedSession.checkPageVisited).to.be.true()
+          expect(session.checkPageVisited).to.be.true()
+          expect(session.$update.called).to.be.true()
         })
 
         it('does not set a flash message', async () => {
@@ -164,11 +165,13 @@ describe('Notices - Setup - Submit Notice Type service', () => {
 
     describe('and the journey is for "standard"', () => {
       describe('and the check page has been visited', () => {
-        beforeEach(async () => {
+        beforeEach(() => {
           sessionData.journey = 'standard'
           sessionData.checkPageVisited = true
 
-          session = await SessionHelper.add({ data: sessionData })
+          session = SessionModelStub.build(Sinon, sessionData)
+
+          fetchSessionStub.resolves(session)
         })
 
         it('returns a redirect to the "/check-notice-type" page', async () => {
@@ -179,11 +182,13 @@ describe('Notices - Setup - Submit Notice Type service', () => {
       })
 
       describe('and the check page has not been visited', () => {
-        beforeEach(async () => {
+        beforeEach(() => {
           sessionData.journey = 'standard'
           sessionData.checkPageVisited = false
 
-          session = await SessionHelper.add({ data: sessionData })
+          session = SessionModelStub.build(Sinon, sessionData)
+
+          fetchSessionStub.resolves(session)
         })
 
         it('returns a redirect to the "/returns-period" page', async () => {
@@ -196,11 +201,13 @@ describe('Notices - Setup - Submit Notice Type service', () => {
 
     describe('and the journey is "adhoc"', () => {
       describe('and the check page has been visited', () => {
-        beforeEach(async () => {
+        beforeEach(() => {
           sessionData.journey = 'adhoc'
           sessionData.checkPageVisited = true
 
-          session = await SessionHelper.add({ data: sessionData })
+          session = SessionModelStub.build(Sinon, sessionData)
+
+          fetchSessionStub.resolves(session)
         })
 
         it('returns a redirect to the "/check-notice-type" page', async () => {
@@ -215,7 +222,9 @@ describe('Notices - Setup - Submit Notice Type service', () => {
           sessionData.journey = 'adhoc'
           sessionData.checkPageVisited = false
 
-          session = await SessionHelper.add({ data: sessionData })
+          session = SessionModelStub.build(Sinon, sessionData)
+
+          fetchSessionStub.resolves(session)
         })
 
         it('returns a redirect to the "/check-notice-type" page', async () => {

--- a/test/services/return-logs/setup/submit-meter-details.service.test.js
+++ b/test/services/return-logs/setup/submit-meter-details.service.test.js
@@ -5,16 +5,20 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const SubmitMeterDetailsService = require('../../../../app/services/return-logs/setup/submit-meter-details.service.js')
 
 describe('Return Logs Setup - Submit Meter Details service', () => {
+  let fetchSessionStub
   let payload
   let session
   let sessionData
@@ -22,20 +26,24 @@ describe('Return Logs Setup - Submit Meter Details service', () => {
 
   beforeEach(async () => {
     sessionData = {
-      data: {
-        returnReference: '12345',
-        reported: 'meterReadings'
-      }
+      returnReference: '12345',
+      reported: 'meterReadings'
     }
 
-    session = await SessionHelper.add(sessionData)
+    session = SessionModelStub.build(Sinon, sessionData)
 
-    yarStub = { flash: Sinon.stub() }
+    fetchSessionStub = Sinon.stub(FetchSessionDal, 'go').resolves(session)
+
+    yarStub = { flash: Sinon.stub().returns([]) }
+  })
+
+  afterEach(() => {
+    Sinon.restore()
   })
 
   describe('when called', () => {
     describe('with a valid payload', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         payload = {
           meterMake: 'WATER',
           meterSerialNumber: '123',
@@ -46,11 +54,11 @@ describe('Return Logs Setup - Submit Meter Details service', () => {
       it('saves the submitted option', async () => {
         await SubmitMeterDetailsService.go(session.id, payload, yarStub)
 
-        const refreshedSession = await session.$query()
+        expect(session.meterMake).to.equal('WATER')
+        expect(session.meterSerialNumber).to.equal('123')
+        expect(session.meter10TimesDisplay).to.equal('yes')
 
-        expect(refreshedSession.meterMake).to.equal('WATER')
-        expect(refreshedSession.meterSerialNumber).to.equal('123')
-        expect(refreshedSession.meter10TimesDisplay).to.equal('yes')
+        expect(session.$update.called).to.be.true()
       })
     })
 
@@ -66,8 +74,13 @@ describe('Return Logs Setup - Submit Meter Details service', () => {
     })
 
     describe('and the page has been visited', () => {
-      beforeEach(async () => {
-        session = await SessionHelper.add({ data: { ...sessionData.data, checkPageVisited: true } })
+      beforeEach(() => {
+        session = SessionModelStub.build(Sinon, {
+          ...sessionData,
+          checkPageVisited: true
+        })
+
+        fetchSessionStub.resolves(session)
       })
 
       it('returns the correct details the controller needs to redirect the journey to the check page', async () => {
@@ -90,7 +103,7 @@ describe('Return Logs Setup - Submit Meter Details service', () => {
     })
 
     describe('with an invalid payload', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         payload = {}
       })
 
@@ -131,7 +144,7 @@ describe('Return Logs Setup - Submit Meter Details service', () => {
       })
 
       describe('because the user has not entered the "make"', () => {
-        beforeEach(async () => {
+        beforeEach(() => {
           payload = {
             meterSerialNumber: '123',
             meter10TimesDisplay: 'yes'
@@ -149,7 +162,7 @@ describe('Return Logs Setup - Submit Meter Details service', () => {
       })
 
       describe('because the user has not entered the "serial number"', () => {
-        beforeEach(async () => {
+        beforeEach(() => {
           payload = {
             meterMake: 'WATER',
             meter10TimesDisplay: 'yes'
@@ -167,7 +180,7 @@ describe('Return Logs Setup - Submit Meter Details service', () => {
       })
 
       describe('because the user has not selected the "times 10 display"', () => {
-        beforeEach(async () => {
+        beforeEach(() => {
           payload = {
             meterMake: 'WATER',
             meterSerialNumber: '123'

--- a/test/services/return-logs/setup/submit-meter-provided.service.test.js
+++ b/test/services/return-logs/setup/submit-meter-provided.service.test.js
@@ -5,32 +5,40 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const SubmitMeterProvidedService = require('../../../../app/services/return-logs/setup/submit-meter-provided.service.js')
 
 describe('Return Logs Setup - Submit Meter Provided service', () => {
+  let fetchSessionStub
   let payload
   let session
   let sessionData
   let yarStub
 
-  beforeEach(async () => {
+  beforeEach(() => {
     sessionData = {
-      data: {
-        returnReference: '12345',
-        reported: 'abstractionVolumes'
-      }
+      returnReference: '12345',
+      reported: 'abstractionVolumes'
     }
 
-    session = await SessionHelper.add(sessionData)
+    session = SessionModelStub.build(Sinon, sessionData)
 
-    yarStub = { flash: Sinon.stub() }
+    fetchSessionStub = Sinon.stub(FetchSessionDal, 'go').resolves(session)
+
+    yarStub = { flash: Sinon.stub().returns([]) }
+  })
+
+  afterEach(() => {
+    Sinon.restore()
   })
 
   describe('when called', () => {
@@ -42,9 +50,8 @@ describe('Return Logs Setup - Submit Meter Provided service', () => {
       it('saves the submitted option', async () => {
         await SubmitMeterProvidedService.go(session.id, payload, yarStub)
 
-        const refreshedSession = await session.$query()
-
-        expect(refreshedSession.meterProvided).to.equal('yes')
+        expect(session.meterProvided).to.equal('yes')
+        expect(session.$update.called).to.be.true()
       })
 
       describe('and the user has selected "yes" to a meter being provided', () => {
@@ -76,7 +83,7 @@ describe('Return Logs Setup - Submit Meter Provided service', () => {
           })
 
           describe('and meter details had previously been saved to the session', () => {
-            beforeEach(async () => {
+            beforeEach(() => {
               payload = { meterProvided: 'no' }
               sessionData = {
                 data: {
@@ -89,25 +96,31 @@ describe('Return Logs Setup - Submit Meter Provided service', () => {
                 }
               }
 
-              session = await SessionHelper.add(sessionData)
+              session = SessionModelStub.build(Sinon, sessionData)
+
+              fetchSessionStub.resolves(session)
             })
 
             it('removes the previously entered meter details from the session data', async () => {
               await SubmitMeterProvidedService.go(session.id, payload, yarStub)
 
-              const refreshedSession = await session.$query()
-
-              expect(refreshedSession.meterProvided).to.equal('no')
-              expect(refreshedSession.meterMake).to.be.null()
-              expect(refreshedSession.meterSerialNumber).to.be.null()
-              expect(refreshedSession.meter10TimesDisplay).to.be.null()
+              expect(session.meterProvided).to.equal('no')
+              expect(session.meterMake).to.be.null()
+              expect(session.meterSerialNumber).to.be.null()
+              expect(session.meter10TimesDisplay).to.be.null()
+              expect(session.$update.called).to.be.true()
             })
           })
         })
 
         describe('and the page has been been visited', () => {
-          beforeEach(async () => {
-            session = await SessionHelper.add({ data: { ...sessionData.data, checkPageVisited: true } })
+          beforeEach(() => {
+            session = SessionModelStub.build(Sinon, {
+              ...sessionData,
+              checkPageVisited: true
+            })
+
+            fetchSessionStub.resolves(session)
           })
 
           it('returns the correct details the controller needs to redirect the journey', async () => {

--- a/test/services/return-logs/setup/submit-multiple-entries.service.test.js
+++ b/test/services/return-logs/setup/submit-multiple-entries.service.test.js
@@ -5,43 +5,51 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const SubmitMultipleEntriesService = require('../../../../app/services/return-logs/setup/submit-multiple-entries.service.js')
 
 describe('Return Logs Setup - Submit Multiple Entries service', () => {
+  let fetchSessionStub
   let payload
   let session
   let sessionData
   let yarStub
 
-  beforeEach(async () => {
+  beforeEach(() => {
     sessionData = {
-      data: {
-        returnReference: '12345',
-        lines: [
-          { startDate: new Date('2023-04-01').toISOString(), endDate: new Date('2023-04-30').toISOString() },
-          { startDate: new Date('2023-05-01').toISOString(), endDate: new Date('2023-05-31').toISOString() }
-        ],
-        returnsFrequency: 'month',
-        reported: 'abstractionVolumes',
-        unitSymbol: 'Ml'
-      }
+      returnReference: '12345',
+      lines: [
+        { startDate: new Date('2023-04-01').toISOString(), endDate: new Date('2023-04-30').toISOString() },
+        { startDate: new Date('2023-05-01').toISOString(), endDate: new Date('2023-05-31').toISOString() }
+      ],
+      returnsFrequency: 'month',
+      reported: 'abstractionVolumes',
+      unitSymbol: 'Ml'
     }
 
-    session = await SessionHelper.add(sessionData)
+    session = SessionModelStub.build(Sinon, sessionData)
 
-    yarStub = { flash: Sinon.stub() }
+    fetchSessionStub = Sinon.stub(FetchSessionDal, 'go').resolves(session)
+
+    yarStub = { flash: Sinon.stub().returns([]) }
+  })
+
+  afterEach(() => {
+    Sinon.restore()
   })
 
   describe('when called', () => {
     describe('with a valid payload', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         payload = { multipleEntries: '100, 200' }
       })
 
@@ -49,12 +57,11 @@ describe('Return Logs Setup - Submit Multiple Entries service', () => {
         it('saves the submitted option', async () => {
           await SubmitMultipleEntriesService.go(session.id, payload, yarStub)
 
-          const refreshedSession = await session.$query()
-
-          expect(refreshedSession.lines[0].quantity).to.equal(100)
-          expect(refreshedSession.lines[0].quantityCubicMetres).to.equal(100000)
-          expect(refreshedSession.lines[1].quantity).to.equal(200)
-          expect(refreshedSession.lines[1].quantityCubicMetres).to.equal(200000)
+          expect(session.lines[0].quantity).to.equal(100)
+          expect(session.lines[0].quantityCubicMetres).to.equal(100000)
+          expect(session.lines[1].quantity).to.equal(200)
+          expect(session.lines[1].quantityCubicMetres).to.equal(200000)
+          expect(session.$update.called).to.be.true()
         })
 
         it('sets the notification message title to "Updated" and the text to "2 monthly volumes have been updated" ', async () => {
@@ -71,29 +78,28 @@ describe('Return Logs Setup - Submit Multiple Entries service', () => {
       })
 
       describe('and the user has previously selected "meterReadings" as the reported type', () => {
-        beforeEach(async () => {
+        beforeEach(() => {
           sessionData = {
-            data: {
-              returnReference: '12345',
-              lines: [
-                { startDate: new Date('2023-04-01').toISOString(), endDate: new Date('2023-04-30').toISOString() },
-                { startDate: new Date('2023-05-01').toISOString(), endDate: new Date('2023-05-31').toISOString() }
-              ],
-              returnsFrequency: 'month',
-              reported: 'meterReadings'
-            }
+            returnReference: '12345',
+            lines: [
+              { startDate: new Date('2023-04-01').toISOString(), endDate: new Date('2023-04-30').toISOString() },
+              { startDate: new Date('2023-05-01').toISOString(), endDate: new Date('2023-05-31').toISOString() }
+            ],
+            returnsFrequency: 'month',
+            reported: 'meterReadings'
           }
 
-          session = await SessionHelper.add(sessionData)
+          session = SessionModelStub.build(Sinon, sessionData)
+
+          fetchSessionStub.resolves(session)
         })
 
         it('saves the submitted option', async () => {
           await SubmitMultipleEntriesService.go(session.id, payload, yarStub)
 
-          const refreshedSession = await session.$query()
-
-          expect(refreshedSession.lines[0].reading).to.equal(100)
-          expect(refreshedSession.lines[1].reading).to.equal(200)
+          expect(session.lines[0].reading).to.equal(100)
+          expect(session.lines[1].reading).to.equal(200)
+          expect(session.$update.called).to.be.true()
         })
 
         it('sets the notification message title to "Updated" and the text to "2 monthly meter readings have been updated" ', async () => {
@@ -111,7 +117,7 @@ describe('Return Logs Setup - Submit Multiple Entries service', () => {
     })
 
     describe('with an invalid payload', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         payload = {}
       })
 

--- a/test/services/return-logs/setup/submit-readings.service.test.js
+++ b/test/services/return-logs/setup/submit-readings.service.test.js
@@ -5,11 +5,14 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const SubmitReadingsService = require('../../../../app/services/return-logs/setup/submit-readings.service.js')
@@ -21,33 +24,37 @@ describe('Return Logs Setup - Submit Readings service', () => {
   let yarStub
   let yearMonth
 
-  beforeEach(async () => {
+  beforeEach(() => {
     sessionData = {
-      data: {
-        lines: [
-          {
-            endDate: '2023-04-30T00:00:00.000Z',
-            reading: 100,
-            startDate: '2023-04-01T00:00:00.000Z'
-          },
-          {
-            endDate: '2023-05-31T00:00:00.000Z',
-            startDate: '2023-05-01T00:00:00.000Z'
-          },
-          {
-            endDate: '2023-06-30T00:00:00.000Z',
-            reading: 300,
-            startDate: '2023-06-01T00:00:00.000Z'
-          }
-        ],
-        returnsFrequency: 'month',
-        returnReference: '1234'
-      }
+      lines: [
+        {
+          endDate: '2023-04-30T00:00:00.000Z',
+          reading: 100,
+          startDate: '2023-04-01T00:00:00.000Z'
+        },
+        {
+          endDate: '2023-05-31T00:00:00.000Z',
+          startDate: '2023-05-01T00:00:00.000Z'
+        },
+        {
+          endDate: '2023-06-30T00:00:00.000Z',
+          reading: 300,
+          startDate: '2023-06-01T00:00:00.000Z'
+        }
+      ],
+      returnsFrequency: 'month',
+      returnReference: '1234'
     }
 
-    session = await SessionHelper.add(sessionData)
+    session = SessionModelStub.build(Sinon, sessionData)
 
-    yarStub = { flash: Sinon.stub() }
+    Sinon.stub(FetchSessionDal, 'go').resolves(session)
+
+    yarStub = { flash: Sinon.stub().returns([]) }
+  })
+
+  afterEach(() => {
+    Sinon.restore()
   })
 
   describe('when called', () => {
@@ -61,9 +68,7 @@ describe('Return Logs Setup - Submit Readings service', () => {
         it('saves the reading for May as null', async () => {
           await SubmitReadingsService.go(session.id, payload, yarStub, yearMonth)
 
-          const refreshedSession = await session.$query()
-
-          expect(refreshedSession.lines).to.equal([
+          expect(session.lines).to.equal([
             {
               endDate: '2023-04-30T00:00:00.000Z',
               reading: 100,
@@ -80,6 +85,7 @@ describe('Return Logs Setup - Submit Readings service', () => {
               startDate: '2023-06-01T00:00:00.000Z'
             }
           ])
+          expect(session.$update.called).to.be.true()
         })
 
         it('sets the notification message title to "Updated" and the text to "Readings have been updated" ', async () => {
@@ -101,9 +107,7 @@ describe('Return Logs Setup - Submit Readings service', () => {
         it('saves the reading for June as 200', async () => {
           await SubmitReadingsService.go(session.id, payload, yarStub, yearMonth)
 
-          const refreshedSession = await session.$query()
-
-          expect(refreshedSession.lines).to.equal([
+          expect(session.lines).to.equal([
             {
               endDate: '2023-04-30T00:00:00.000Z',
               reading: 100,
@@ -119,6 +123,7 @@ describe('Return Logs Setup - Submit Readings service', () => {
               startDate: '2023-06-01T00:00:00.000Z'
             }
           ])
+          expect(session.$update.called).to.be.true()
         })
 
         it('sets the notification message title to "Updated" and the text to "Readings have been updated" ', async () => {

--- a/test/services/return-logs/setup/submit-received.service.test.js
+++ b/test/services/return-logs/setup/submit-received.service.test.js
@@ -5,41 +5,49 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
 const { today } = require('../../../../app/lib/general.lib.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const SubmitReceivedService = require('../../../../app/services/return-logs/setup/submit-received.service.js')
 
 describe('Return Logs - Setup - Submit Received service', () => {
+  let fetchSessionStub
   let payload
   let session
   let sessionData
   let testDate
   let yarStub
 
-  beforeEach(async () => {
+  beforeEach(() => {
     sessionData = {
-      data: {
-        licenceId: 'cd190dc7-912a-46a5-9421-2750fb1c7ac8',
-        returnLogId: '8280a3bb-aefb-4603-b71f-a58cef9169f3',
-        returnReference: '12345',
-        startDate: '2023-04-01T00:00:00.000Z'
-      }
+      licenceId: 'cd190dc7-912a-46a5-9421-2750fb1c7ac8',
+      returnLogId: '8280a3bb-aefb-4603-b71f-a58cef9169f3',
+      returnReference: '12345',
+      startDate: '2023-04-01T00:00:00.000Z'
     }
 
-    session = await SessionHelper.add(sessionData)
+    session = SessionModelStub.build(Sinon, sessionData)
 
-    yarStub = { flash: Sinon.stub() }
+    fetchSessionStub = Sinon.stub(FetchSessionDal, 'go').resolves(session)
+
+    yarStub = { flash: Sinon.stub().returns([]) }
+  })
+
+  afterEach(() => {
+    Sinon.restore()
   })
 
   describe('when called', () => {
     describe('with a valid payload (todays date)', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         testDate = today()
         payload = {
           receivedDateOptions: 'today'
@@ -49,10 +57,9 @@ describe('Return Logs - Setup - Submit Received service', () => {
       it('saves the submitted option', async () => {
         await SubmitReceivedService.go(session.id, payload, yarStub)
 
-        const refreshedSession = await session.$query()
-
-        expect(refreshedSession.receivedDateOptions).to.equal('today')
-        expect(new Date(refreshedSession.receivedDate)).to.equal(testDate)
+        expect(session.receivedDateOptions).to.equal('today')
+        expect(new Date(session.receivedDate)).to.equal(testDate)
+        expect(session.$update.called).to.be.true()
       })
 
       describe('and the page has been not been visited', () => {
@@ -66,8 +73,10 @@ describe('Return Logs - Setup - Submit Received service', () => {
       })
 
       describe('and the page has been visited', () => {
-        beforeEach(async () => {
-          session = await SessionHelper.add({ data: { ...sessionData.data, checkPageVisited: true } })
+        beforeEach(() => {
+          session = SessionModelStub.build(Sinon, { ...sessionData, checkPageVisited: true })
+
+          fetchSessionStub.resolves(session)
         })
 
         it('returns the correct details the controller needs to redirect the journey to the check page', async () => {
@@ -90,7 +99,7 @@ describe('Return Logs - Setup - Submit Received service', () => {
     })
 
     describe('with a valid payload (yesterdays date)', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         testDate = today()
         testDate.setDate(testDate.getDate() - 1)
         payload = {
@@ -101,15 +110,14 @@ describe('Return Logs - Setup - Submit Received service', () => {
       it('saves the submitted option', async () => {
         await SubmitReceivedService.go(session.id, payload, yarStub)
 
-        const refreshedSession = await session.$query()
-
-        expect(refreshedSession.receivedDateOptions).to.equal('yesterday')
-        expect(new Date(refreshedSession.receivedDate)).to.equal(testDate)
+        expect(session.receivedDateOptions).to.equal('yesterday')
+        expect(new Date(session.receivedDate)).to.equal(testDate)
+        expect(session.$update.called).to.be.true()
       })
     })
 
     describe('with a valid payload (custom received date)', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         payload = {
           receivedDateOptions: 'customDate',
           receivedDateDay: '26',
@@ -121,13 +129,12 @@ describe('Return Logs - Setup - Submit Received service', () => {
       it('saves the submitted values', async () => {
         await SubmitReceivedService.go(session.id, payload, yarStub)
 
-        const refreshedSession = await session.$query()
-
-        expect(refreshedSession.receivedDateOptions).to.equal('customDate')
-        expect(refreshedSession.receivedDateDay).to.equal('26')
-        expect(refreshedSession.receivedDateMonth).to.equal('11')
-        expect(refreshedSession.receivedDateYear).to.equal('2023')
-        expect(new Date(refreshedSession.receivedDate)).to.equal(new Date('2023-11-26'))
+        expect(session.receivedDateOptions).to.equal('customDate')
+        expect(session.receivedDateDay).to.equal('26')
+        expect(session.receivedDateMonth).to.equal('11')
+        expect(session.receivedDateYear).to.equal('2023')
+        expect(new Date(session.receivedDate)).to.equal(new Date('2023-11-26'))
+        expect(session.$update.called).to.be.true()
       })
 
       it('returns the correct details the controller needs to redirect the journey', async () => {
@@ -138,7 +145,7 @@ describe('Return Logs - Setup - Submit Received service', () => {
     })
 
     describe('with an invalid payload', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         payload = {}
       })
 
@@ -179,7 +186,7 @@ describe('Return Logs - Setup - Submit Received service', () => {
       })
 
       describe('because the user has selected custom received date and entered invalid data', () => {
-        beforeEach(async () => {
+        beforeEach(() => {
           payload = {
             receivedDateOptions: 'customDate',
             receivedDateDay: 'a',

--- a/test/services/return-logs/setup/submit-reported.service.test.js
+++ b/test/services/return-logs/setup/submit-reported.service.test.js
@@ -5,45 +5,52 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const SubmitReportedService = require('../../../../app/services/return-logs/setup/submit-reported.service.js')
 
 describe('Return Logs Setup - Submit Reported service', () => {
+  let fetchSessionStub
   let payload
   let session
   let sessionData
   let yarStub
 
-  beforeEach(async () => {
+  beforeEach(() => {
     sessionData = {
-      data: {
-        returnReference: '12345'
-      }
+      returnReference: '12345'
     }
 
-    session = await SessionHelper.add(sessionData)
+    session = SessionModelStub.build(Sinon, sessionData)
 
-    yarStub = { flash: Sinon.stub() }
+    fetchSessionStub = Sinon.stub(FetchSessionDal, 'go').resolves(session)
+
+    yarStub = { flash: Sinon.stub().returns([]) }
+  })
+
+  afterEach(() => {
+    Sinon.restore()
   })
 
   describe('when called', () => {
     describe('with a valid payload', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         payload = { reported: 'meterReadings' }
       })
 
       it('saves the submitted option', async () => {
         await SubmitReportedService.go(session.id, payload, yarStub)
 
-        const refreshedSession = await session.$query()
-
-        expect(refreshedSession.reported).to.equal('meterReadings')
+        expect(session.reported).to.equal('meterReadings')
+        expect(session.$update.called).to.be.true()
       })
 
       describe('and the page has been not been visited', () => {
@@ -58,8 +65,10 @@ describe('Return Logs Setup - Submit Reported service', () => {
       })
 
       describe('and the page has been visited', () => {
-        beforeEach(async () => {
-          session = await SessionHelper.add({ data: { ...sessionData.data, checkPageVisited: true } })
+        beforeEach(() => {
+          session = SessionModelStub.build(Sinon, { ...sessionData, checkPageVisited: true })
+
+          fetchSessionStub.resolves(session)
         })
 
         it('returns the correct details the controller needs to redirect the journey to the check page', async () => {
@@ -83,7 +92,7 @@ describe('Return Logs Setup - Submit Reported service', () => {
     })
 
     describe('with an invalid payload', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         payload = {}
       })
 

--- a/test/services/return-logs/setup/submit-start-reading.service.test.js
+++ b/test/services/return-logs/setup/submit-start-reading.service.test.js
@@ -5,41 +5,49 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const SubmitStartReadingService = require('../../../../app/services/return-logs/setup/submit-start-reading.service.js')
 
 describe('Return Logs Setup - Submit Start Reading service', () => {
+  let fetchSessionStub
   let payload
   let session
   let sessionData
   let yarStub
 
-  beforeEach(async () => {
+  beforeEach(() => {
     sessionData = {
-      data: {
-        returnReference: '12345',
-        lines: [
-          {
-            endDate: '2019-04-30T00:00:00.000Z',
-            startDate: '2019-04-01T00:00:00.000Z'
-          },
-          {
-            endDate: '2019-05-31T00:00:00.000Z',
-            startDate: '2019-05-01T00:00:00.000Z'
-          }
-        ]
-      }
+      returnReference: '12345',
+      lines: [
+        {
+          endDate: '2019-04-30T00:00:00.000Z',
+          startDate: '2019-04-01T00:00:00.000Z'
+        },
+        {
+          endDate: '2019-05-31T00:00:00.000Z',
+          startDate: '2019-05-01T00:00:00.000Z'
+        }
+      ]
     }
 
-    session = await SessionHelper.add(sessionData)
+    session = SessionModelStub.build(Sinon, sessionData)
 
-    yarStub = { flash: Sinon.stub() }
+    fetchSessionStub = Sinon.stub(FetchSessionDal, 'go').resolves(session)
+
+    yarStub = { flash: Sinon.stub().returns([]) }
+  })
+
+  afterEach(() => {
+    Sinon.restore()
   })
 
   describe('when called', () => {
@@ -51,9 +59,8 @@ describe('Return Logs Setup - Submit Start Reading service', () => {
       it('saves the submitted option', async () => {
         await SubmitStartReadingService.go(session.id, payload, yarStub)
 
-        const refreshedSession = await session.$query()
-
-        expect(refreshedSession.startReading).to.equal(15600)
+        expect(session.startReading).to.equal(15600)
+        expect(session.$update.called).to.be.true()
       })
 
       describe('and the page has been not been visited', () => {
@@ -67,8 +74,10 @@ describe('Return Logs Setup - Submit Start Reading service', () => {
       })
 
       describe('and the page has been visited', () => {
-        beforeEach(async () => {
-          session = await SessionHelper.add({ data: { ...sessionData.data, checkPageVisited: true } })
+        beforeEach(() => {
+          session = SessionModelStub.build(Sinon, { ...sessionData, checkPageVisited: true })
+
+          fetchSessionStub.resolves(session)
         })
 
         it('returns the correct details the controller needs to redirect the journey to the check page', async () => {

--- a/test/services/return-logs/setup/submit-units.service.test.js
+++ b/test/services/return-logs/setup/submit-units.service.test.js
@@ -5,46 +5,53 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const SubmitUnitsService = require('../../../../app/services/return-logs/setup/submit-units.service.js')
 
 describe('Return Logs Setup - Submit Units service', () => {
+  let fetchSessionStub
   let payload
   let session
   let sessionData
   let yarStub
 
-  beforeEach(async () => {
+  beforeEach(() => {
     sessionData = {
-      data: {
-        returnReference: '12345'
-      }
+      returnReference: '12345'
     }
 
-    session = await SessionHelper.add(sessionData)
+    session = SessionModelStub.build(Sinon, sessionData)
 
-    yarStub = { flash: Sinon.stub() }
+    fetchSessionStub = Sinon.stub(FetchSessionDal, 'go').resolves(session)
+
+    yarStub = { flash: Sinon.stub().returns([]) }
+  })
+
+  afterEach(() => {
+    Sinon.restore()
   })
 
   describe('when called', () => {
     describe('with a valid payload', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         payload = { units: 'litres' }
       })
 
       it('saves the submitted option', async () => {
         await SubmitUnitsService.go(session.id, payload, yarStub)
 
-        const refreshedSession = await session.$query()
-
-        expect(refreshedSession.units).to.equal('litres')
-        expect(refreshedSession.unitSymbol).to.equal('l')
+        expect(session.units).to.equal('litres')
+        expect(session.unitSymbol).to.equal('l')
+        expect(session.$update.called).to.be.true()
       })
 
       describe('and the page has been not been visited', () => {
@@ -58,8 +65,10 @@ describe('Return Logs Setup - Submit Units service', () => {
       })
 
       describe('and the page has been visited', () => {
-        beforeEach(async () => {
-          session = await SessionHelper.add({ data: { ...sessionData.data, checkPageVisited: true } })
+        beforeEach(() => {
+          session = SessionModelStub.build(Sinon, { ...sessionData, checkPageVisited: true })
+
+          fetchSessionStub.resolves(session)
         })
 
         it('returns the correct details the controller needs to redirect the journey to the check page', async () => {
@@ -82,7 +91,7 @@ describe('Return Logs Setup - Submit Units service', () => {
     })
 
     describe('with an invalid payload', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         payload = {}
       })
 

--- a/test/services/return-logs/setup/submit-volumes.service.test.js
+++ b/test/services/return-logs/setup/submit-volumes.service.test.js
@@ -5,11 +5,14 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const SubmitVolumesService = require('../../../../app/services/return-logs/setup/submit-volumes.service.js')
@@ -21,37 +24,41 @@ describe('Return Logs Setup - Submit Volumes service', () => {
   let yarStub
   let yearMonth
 
-  beforeEach(async () => {
+  beforeEach(() => {
     sessionData = {
-      data: {
-        lines: [
-          {
-            endDate: '2023-04-30T00:00:00.000Z',
-            quantity: 100,
-            quantityCubicMetres: 100000,
-            startDate: '2023-04-01T00:00:00.000Z'
-          },
-          {
-            endDate: '2023-05-31T00:00:00.000Z',
-            startDate: '2023-05-01T00:00:00.000Z'
-          },
-          {
-            endDate: '2023-06-30T00:00:00.000Z',
-            quantity: 300,
-            quantityCubicMetres: 300000,
-            startDate: '2023-06-01T00:00:00.000Z'
-          }
-        ],
-        returnsFrequency: 'month',
-        returnReference: '1234',
-        units: 'megalitres',
-        unitSymbol: 'Ml'
-      }
+      lines: [
+        {
+          endDate: '2023-04-30T00:00:00.000Z',
+          quantity: 100,
+          quantityCubicMetres: 100000,
+          startDate: '2023-04-01T00:00:00.000Z'
+        },
+        {
+          endDate: '2023-05-31T00:00:00.000Z',
+          startDate: '2023-05-01T00:00:00.000Z'
+        },
+        {
+          endDate: '2023-06-30T00:00:00.000Z',
+          quantity: 300,
+          quantityCubicMetres: 300000,
+          startDate: '2023-06-01T00:00:00.000Z'
+        }
+      ],
+      returnsFrequency: 'month',
+      returnReference: '1234',
+      units: 'megalitres',
+      unitSymbol: 'Ml'
     }
 
-    session = await SessionHelper.add(sessionData)
+    session = SessionModelStub.build(Sinon, sessionData)
 
-    yarStub = { flash: Sinon.stub() }
+    Sinon.stub(FetchSessionDal, 'go').resolves(session)
+
+    yarStub = { flash: Sinon.stub().returns([]) }
+  })
+
+  afterEach(() => {
+    Sinon.restore()
   })
 
   describe('when called', () => {
@@ -65,9 +72,7 @@ describe('Return Logs Setup - Submit Volumes service', () => {
         it('saves the volume for May as null', async () => {
           await SubmitVolumesService.go(session.id, payload, yarStub, yearMonth)
 
-          const refreshedSession = await session.$query()
-
-          expect(refreshedSession.lines).to.equal([
+          expect(session.lines).to.equal([
             {
               endDate: '2023-04-30T00:00:00.000Z',
               quantity: 100,
@@ -87,6 +92,7 @@ describe('Return Logs Setup - Submit Volumes service', () => {
               startDate: '2023-06-01T00:00:00.000Z'
             }
           ])
+          expect(session.$update.called).to.be.true()
         })
 
         it('sets the notification message title to "Updated" and the text to "Volumes have been updated" ', async () => {
@@ -108,9 +114,7 @@ describe('Return Logs Setup - Submit Volumes service', () => {
         it('saves the volume for June as 200', async () => {
           await SubmitVolumesService.go(session.id, payload, yarStub, yearMonth)
 
-          const refreshedSession = await session.$query()
-
-          expect(refreshedSession.lines).to.equal([
+          expect(session.lines).to.equal([
             {
               endDate: '2023-04-30T00:00:00.000Z',
               quantity: 100,

--- a/test/services/return-versions/setup/check/check.service.test.js
+++ b/test/services/return-versions/setup/check/check.service.test.js
@@ -10,59 +10,65 @@ const { expect } = Code
 
 // Test helpers
 const FetchPointsService = require('../../../../../app/services/return-versions/setup/fetch-points.service.js')
-const SessionHelper = require('../../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const CheckService = require('../../../../../app/services/return-versions/setup/check/check.service.js')
 
 describe('Return Versions - Setup - Check service', () => {
   let session
+  let sessionData
   let yarStub
 
-  beforeEach(async () => {
+  beforeEach(() => {
     Sinon.stub(FetchPointsService, 'go').resolves([])
 
-    session = await SessionHelper.add({
-      data: {
-        checkPageVisited: false,
-        licence: {
-          id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
-          currentVersionStartDate: '2023-01-01T00:00:00.000Z',
-          endDate: null,
-          licenceRef: '01/ABC',
-          licenceHolder: 'Turbo Kid',
-          returnVersions: [
-            {
-              id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
-              startDate: '2023-01-01T00:00:00.000Z',
-              reason: null,
-              modLogs: []
-            }
-          ],
-          startDate: '2022-04-01T00:00:00.000Z',
-          waterUndertaker: false
-        },
-        multipleUpload: false,
-        journey: 'returns-required',
-        requirements: [{}],
-        startDateOptions: 'licenceStartDate',
-        returnVersionStartDate: '2023-01-01T00:00:00.000Z',
-        licenceVersion: {
-          id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
-          endDate: null,
-          startDate: '2022-04-01T00:00:00.000Z',
-          copyableReturnVersions: [
-            {
-              id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
-              startDate: '2023-01-01T00:00:00.000Z',
-              reason: null,
-              modLogs: []
-            }
-          ]
-        },
-        reason: 'major-change'
-      }
-    })
+    sessionData = {
+      checkPageVisited: false,
+      licence: {
+        id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
+        currentVersionStartDate: '2023-01-01T00:00:00.000Z',
+        endDate: null,
+        licenceRef: '01/ABC',
+        licenceHolder: 'Turbo Kid',
+        returnVersions: [
+          {
+            id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
+            startDate: '2023-01-01T00:00:00.000Z',
+            reason: null,
+            modLogs: []
+          }
+        ],
+        startDate: '2022-04-01T00:00:00.000Z',
+        waterUndertaker: false
+      },
+      multipleUpload: false,
+      journey: 'returns-required',
+      requirements: [{}],
+      startDateOptions: 'licenceStartDate',
+      returnVersionStartDate: '2023-01-01T00:00:00.000Z',
+      licenceVersion: {
+        id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
+        endDate: null,
+        startDate: '2022-04-01T00:00:00.000Z',
+        copyableReturnVersions: [
+          {
+            id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
+            startDate: '2023-01-01T00:00:00.000Z',
+            reason: null,
+            modLogs: []
+          }
+        ]
+      },
+      reason: 'major-change'
+    }
+
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    Sinon.stub(FetchSessionDal, 'go').resolves(session)
 
     yarStub = { flash: Sinon.stub().returns([]) }
   })
@@ -112,9 +118,8 @@ describe('Return Versions - Setup - Check service', () => {
     it('updates the session record to indicate user has visited the "check" page', async () => {
       await CheckService.go(session.id, yarStub)
 
-      const refreshedSession = await session.$query()
-
-      expect(refreshedSession.checkPageVisited).to.be.true()
+      expect(session.checkPageVisited).to.be.true()
+      expect(session.$update.called).to.be.true()
     })
   })
 })

--- a/test/services/return-versions/setup/submit-abstraction-period.service.test.js
+++ b/test/services/return-versions/setup/submit-abstraction-period.service.test.js
@@ -5,11 +5,14 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const SubmitAbstractionPeriodService = require('../../../../app/services/return-versions/setup/submit-abstraction-period.service.js')
@@ -17,41 +20,46 @@ const SubmitAbstractionPeriodService = require('../../../../app/services/return-
 describe('Return Versions Setup - Submit Abstraction Period service', () => {
   const requirementIndex = 0
 
+  let fetchSessionStub
   let payload
   let session
   let sessionData
   let yarStub
 
-  beforeEach(async () => {
+  beforeEach(() => {
     sessionData = {
-      data: {
-        checkPageVisited: false,
-        licence: {
-          id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
-          currentVersionStartDate: '2023-01-01T00:00:00.000Z',
-          endDate: null,
-          licenceRef: '01/ABC',
-          licenceHolder: 'Turbo Kid',
-          returnVersions: [
-            {
-              id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
-              startDate: '2023-01-01T00:00:00.000Z',
-              reason: null,
-              modLogs: []
-            }
-          ],
-          startDate: '2022-04-01T00:00:00.000Z'
-        },
-        journey: 'returns-required',
-        requirements: [{}],
-        startDateOptions: 'licenceStartDate',
-        reason: 'major-change'
-      }
+      checkPageVisited: false,
+      licence: {
+        id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
+        currentVersionStartDate: '2023-01-01T00:00:00.000Z',
+        endDate: null,
+        licenceRef: '01/ABC',
+        licenceHolder: 'Turbo Kid',
+        returnVersions: [
+          {
+            id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
+            startDate: '2023-01-01T00:00:00.000Z',
+            reason: null,
+            modLogs: []
+          }
+        ],
+        startDate: '2022-04-01T00:00:00.000Z'
+      },
+      journey: 'returns-required',
+      requirements: [{}],
+      startDateOptions: 'licenceStartDate',
+      reason: 'major-change'
     }
 
-    session = await SessionHelper.add(sessionData)
+    session = SessionModelStub.build(Sinon, sessionData)
 
-    yarStub = { flash: Sinon.stub() }
+    fetchSessionStub = Sinon.stub(FetchSessionDal, 'go').resolves(session)
+
+    yarStub = { flash: Sinon.stub().returns([]) }
+  })
+
+  afterEach(() => {
+    Sinon.restore()
   })
 
   describe('when called', () => {
@@ -68,14 +76,14 @@ describe('Return Versions Setup - Submit Abstraction Period service', () => {
       it('saves the submitted value', async () => {
         await SubmitAbstractionPeriodService.go(session.id, requirementIndex, payload, yarStub)
 
-        const refreshedSession = await session.$query()
-
-        expect(refreshedSession.requirements[0].abstractionPeriod).to.equal({
+        expect(session.requirements[0].abstractionPeriod).to.equal({
           abstractionPeriodStartDay: '01',
           abstractionPeriodStartMonth: '12',
           abstractionPeriodEndDay: '02',
           abstractionPeriodEndMonth: '7'
         })
+
+        expect(session.$update.called).to.be.true()
       })
 
       describe('and the page has been not been visited', () => {
@@ -89,8 +97,10 @@ describe('Return Versions Setup - Submit Abstraction Period service', () => {
       })
 
       describe('and the page has been visited', () => {
-        beforeEach(async () => {
-          session = await SessionHelper.add({ data: { ...sessionData.data, checkPageVisited: true } })
+        beforeEach(() => {
+          session = SessionModelStub.build(Sinon, { ...sessionData, checkPageVisited: true })
+
+          fetchSessionStub.resolves(session)
         })
 
         it('returns the correct details the controller needs to redirect the journey to the check page', async () => {

--- a/test/services/return-versions/setup/submit-agreements-exceptions.service.test.js
+++ b/test/services/return-versions/setup/submit-agreements-exceptions.service.test.js
@@ -5,11 +5,14 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const SubmitAgreementsExceptionsService = require('../../../../app/services/return-versions/setup/submit-agreements-exceptions.service.js')
@@ -17,41 +20,46 @@ const SubmitAgreementsExceptionsService = require('../../../../app/services/retu
 describe('Return Versions Setup - Submit Agreements and Exceptions service', () => {
   const requirementIndex = 0
 
+  let fetchSessionStub
   let payload
   let session
   let sessionData
   let yarStub
 
-  beforeEach(async () => {
+  beforeEach(() => {
     sessionData = {
-      data: {
-        checkPageVisited: false,
-        licence: {
-          id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
-          currentVersionStartDate: '2023-01-01T00:00:00.000Z',
-          endDate: null,
-          licenceRef: '01/ABC',
-          licenceHolder: 'Turbo Kid',
-          returnVersions: [
-            {
-              id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
-              startDate: '2023-01-01T00:00:00.000Z',
-              reason: null,
-              modLogs: []
-            }
-          ],
-          startDate: '2022-04-01T00:00:00.000Z'
-        },
-        journey: 'returns-required',
-        requirements: [{}],
-        startDateOptions: 'licenceStartDate',
-        reason: 'major-change'
-      }
+      checkPageVisited: false,
+      licence: {
+        id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
+        currentVersionStartDate: '2023-01-01T00:00:00.000Z',
+        endDate: null,
+        licenceRef: '01/ABC',
+        licenceHolder: 'Turbo Kid',
+        returnVersions: [
+          {
+            id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
+            startDate: '2023-01-01T00:00:00.000Z',
+            reason: null,
+            modLogs: []
+          }
+        ],
+        startDate: '2022-04-01T00:00:00.000Z'
+      },
+      journey: 'returns-required',
+      requirements: [{}],
+      startDateOptions: 'licenceStartDate',
+      reason: 'major-change'
     }
 
-    session = await SessionHelper.add(sessionData)
+    session = SessionModelStub.build(Sinon, sessionData)
 
-    yarStub = { flash: Sinon.stub() }
+    fetchSessionStub = Sinon.stub(FetchSessionDal, 'go').resolves(session)
+
+    yarStub = { flash: Sinon.stub().returns([]) }
+  })
+
+  afterEach(() => {
+    Sinon.restore()
   })
 
   describe('when called', () => {
@@ -65,13 +73,12 @@ describe('Return Versions Setup - Submit Agreements and Exceptions service', () 
       it('saves the submitted value', async () => {
         await SubmitAgreementsExceptionsService.go(session.id, requirementIndex, payload, yarStub)
 
-        const refreshedSession = await session.$query()
-
-        expect(refreshedSession.requirements[0].agreementsExceptions).to.equal([
+        expect(session.requirements[0].agreementsExceptions).to.equal([
           'gravity-fill',
           'two-part-tariff',
           '56-returns-exception'
         ])
+        expect(session.$update.called).to.be.true()
       })
 
       describe('and the page has been not been visited', () => {
@@ -94,8 +101,13 @@ describe('Return Versions Setup - Submit Agreements and Exceptions service', () 
       })
 
       describe('and the page has been visited', () => {
-        beforeEach(async () => {
-          session = await SessionHelper.add({ data: { ...sessionData.data, checkPageVisited: true } })
+        beforeEach(() => {
+          session = SessionModelStub.build(Sinon, {
+            ...sessionData,
+            checkPageVisited: true
+          })
+
+          fetchSessionStub.resolves(session)
         })
 
         it('returns the correct details the controller needs to redirect the journey to the check page', async () => {

--- a/test/services/return-versions/setup/submit-frequency-collected.service.test.js
+++ b/test/services/return-versions/setup/submit-frequency-collected.service.test.js
@@ -5,11 +5,14 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const SubmitFrequencyCollectedService = require('../../../../app/services/return-versions/setup/submit-frequency-collected.service.js')
@@ -17,41 +20,46 @@ const SubmitFrequencyCollectedService = require('../../../../app/services/return
 describe('Return Versions Setup - Submit Frequency Collected service', () => {
   const requirementIndex = 0
 
+  let fetchSessionStub
   let payload
   let session
   let sessionData
   let yarStub
 
-  beforeEach(async () => {
+  beforeEach(() => {
     sessionData = {
-      data: {
-        checkPageVisited: false,
-        licence: {
-          id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
-          currentVersionStartDate: '2023-01-01T00:00:00.000Z',
-          endDate: null,
-          licenceRef: '01/ABC',
-          licenceHolder: 'Turbo Kid',
-          returnVersions: [
-            {
-              id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
-              startDate: '2023-01-01T00:00:00.000Z',
-              reason: null,
-              modLogs: []
-            }
-          ],
-          startDate: '2022-04-01T00:00:00.000Z'
-        },
-        journey: 'returns-required',
-        requirements: [{}],
-        startDateOptions: 'licenceStartDate',
-        reason: 'major-change'
-      }
+      checkPageVisited: false,
+      licence: {
+        id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
+        currentVersionStartDate: '2023-01-01T00:00:00.000Z',
+        endDate: null,
+        licenceRef: '01/ABC',
+        licenceHolder: 'Turbo Kid',
+        returnVersions: [
+          {
+            id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
+            startDate: '2023-01-01T00:00:00.000Z',
+            reason: null,
+            modLogs: []
+          }
+        ],
+        startDate: '2022-04-01T00:00:00.000Z'
+      },
+      journey: 'returns-required',
+      requirements: [{}],
+      startDateOptions: 'licenceStartDate',
+      reason: 'major-change'
     }
 
-    session = await SessionHelper.add(sessionData)
+    session = SessionModelStub.build(Sinon, sessionData)
 
-    yarStub = { flash: Sinon.stub() }
+    fetchSessionStub = Sinon.stub(FetchSessionDal, 'go').resolves(session)
+
+    yarStub = { flash: Sinon.stub().returns([]) }
+  })
+
+  afterEach(() => {
+    Sinon.restore()
   })
 
   describe('when called', () => {
@@ -65,9 +73,8 @@ describe('Return Versions Setup - Submit Frequency Collected service', () => {
       it('saves the submitted value', async () => {
         await SubmitFrequencyCollectedService.go(session.id, requirementIndex, payload, yarStub)
 
-        const refreshedSession = await session.$query()
-
-        expect(refreshedSession.requirements[0].frequencyCollected).to.equal('week')
+        expect(session.requirements[0].frequencyCollected).to.equal('week')
+        expect(session.$update.called).to.be.true()
       })
 
       describe('and the page has been not been visited', () => {
@@ -81,8 +88,13 @@ describe('Return Versions Setup - Submit Frequency Collected service', () => {
       })
 
       describe('and the page has been visited', () => {
-        beforeEach(async () => {
-          session = await SessionHelper.add({ data: { ...sessionData.data, checkPageVisited: true } })
+        beforeEach(() => {
+          session = SessionModelStub.build(Sinon, {
+            ...sessionData,
+            checkPageVisited: true
+          })
+
+          fetchSessionStub.resolves(session)
         })
 
         it('returns the correct details the controller needs to redirect the journey to the check page', async () => {

--- a/test/services/return-versions/setup/submit-frequency-reported.service.test.js
+++ b/test/services/return-versions/setup/submit-frequency-reported.service.test.js
@@ -5,11 +5,14 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const SubmitFrequencyReportedService = require('../../../../app/services/return-versions/setup/submit-frequency-reported.service.js')
@@ -17,41 +20,46 @@ const SubmitFrequencyReportedService = require('../../../../app/services/return-
 describe('Return Versions Setup - Submit Frequency Reported service', () => {
   const requirementIndex = 0
 
+  let fetchSessionStub
   let payload
   let session
   let sessionData
   let yarStub
 
-  beforeEach(async () => {
+  beforeEach(() => {
     sessionData = {
-      data: {
-        checkPageVisited: false,
-        licence: {
-          id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
-          currentVersionStartDate: '2023-01-01T00:00:00.000Z',
-          endDate: null,
-          licenceRef: '01/ABC',
-          licenceHolder: 'Turbo Kid',
-          returnVersions: [
-            {
-              id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
-              startDate: '2023-01-01T00:00:00.000Z',
-              reason: null,
-              modLogs: []
-            }
-          ],
-          startDate: '2022-04-01T00:00:00.000Z'
-        },
-        journey: 'returns-required',
-        requirements: [{}],
-        startDateOptions: 'licenceStartDate',
-        reason: 'major-change'
-      }
+      checkPageVisited: false,
+      licence: {
+        id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
+        currentVersionStartDate: '2023-01-01T00:00:00.000Z',
+        endDate: null,
+        licenceRef: '01/ABC',
+        licenceHolder: 'Turbo Kid',
+        returnVersions: [
+          {
+            id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
+            startDate: '2023-01-01T00:00:00.000Z',
+            reason: null,
+            modLogs: []
+          }
+        ],
+        startDate: '2022-04-01T00:00:00.000Z'
+      },
+      journey: 'returns-required',
+      requirements: [{}],
+      startDateOptions: 'licenceStartDate',
+      reason: 'major-change'
     }
 
-    session = await SessionHelper.add(sessionData)
+    session = SessionModelStub.build(Sinon, sessionData)
 
-    yarStub = { flash: Sinon.stub() }
+    fetchSessionStub = Sinon.stub(FetchSessionDal, 'go').resolves(session)
+
+    yarStub = { flash: Sinon.stub().returns([]) }
+  })
+
+  afterEach(() => {
+    Sinon.restore()
   })
 
   describe('when called', () => {
@@ -65,9 +73,8 @@ describe('Return Versions Setup - Submit Frequency Reported service', () => {
       it('saves the submitted value', async () => {
         await SubmitFrequencyReportedService.go(session.id, requirementIndex, payload, yarStub)
 
-        const refreshedSession = await session.$query()
-
-        expect(refreshedSession.requirements[0].frequencyReported).to.equal('week')
+        expect(session.requirements[0].frequencyReported).to.equal('week')
+        expect(session.$update.called).to.be.true()
       })
 
       describe('and the page has been not been visited', () => {
@@ -81,8 +88,13 @@ describe('Return Versions Setup - Submit Frequency Reported service', () => {
       })
 
       describe('and the page has been visited', () => {
-        beforeEach(async () => {
-          session = await SessionHelper.add({ data: { ...sessionData.data, checkPageVisited: true } })
+        beforeEach(() => {
+          session = SessionModelStub.build(Sinon, {
+            ...sessionData,
+            checkPageVisited: true
+          })
+
+          fetchSessionStub.resolves(session)
         })
 
         it('returns the correct details the controller needs to redirect the journey to the check page', async () => {

--- a/test/services/return-versions/setup/submit-points.service.test.js
+++ b/test/services/return-versions/setup/submit-points.service.test.js
@@ -10,10 +10,11 @@ const { expect } = Code
 
 // Test helpers
 const PointModel = require('../../../../app/models/point.model.js')
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
 
 // Things we need to stub
 const FetchPointsService = require('../../../../app/services/return-versions/setup/fetch-points.service.js')
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const SubmitPointsService = require('../../../../app/services/return-versions/setup/submit-points.service.js')
@@ -21,6 +22,7 @@ const SubmitPointsService = require('../../../../app/services/return-versions/se
 describe('Return Versions - Setup - Submit Points service', () => {
   const requirementIndex = 0
 
+  let fetchSessionStub
   let payload
   let session
   let sessionData
@@ -28,50 +30,50 @@ describe('Return Versions - Setup - Submit Points service', () => {
 
   beforeEach(async () => {
     sessionData = {
-      data: {
-        checkPageVisited: false,
-        licence: {
-          id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
-          currentVersionStartDate: '2023-01-01T00:00:00.000Z',
-          endDate: null,
-          licenceRef: '01/ABC',
-          licenceHolder: 'Turbo Kid',
-          returnVersions: [
-            {
-              id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
-              startDate: '2023-01-01T00:00:00.000Z',
-              reason: null,
-              modLogs: []
-            }
-          ],
-          startDate: '2022-04-01T00:00:00.000Z',
-          waterUndertaker: false
-        },
-        multipleUpload: false,
-        journey: 'returns-required',
-        requirements: [{}],
-        startDateOptions: 'licenceStartDate',
-        returnVersionStartDate: '2023-01-01T00:00:00.000Z',
-        licenceVersion: {
-          id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
-          endDate: null,
-          startDate: '2022-04-01T00:00:00.000Z',
-          copyableReturnVersions: [
-            {
-              id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
-              startDate: '2023-01-01T00:00:00.000Z',
-              reason: null,
-              modLogs: []
-            }
-          ]
-        },
-        reason: 'major-change'
-      }
+      checkPageVisited: false,
+      licence: {
+        id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
+        currentVersionStartDate: '2023-01-01T00:00:00.000Z',
+        endDate: null,
+        licenceRef: '01/ABC',
+        licenceHolder: 'Turbo Kid',
+        returnVersions: [
+          {
+            id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
+            startDate: '2023-01-01T00:00:00.000Z',
+            reason: null,
+            modLogs: []
+          }
+        ],
+        startDate: '2022-04-01T00:00:00.000Z',
+        waterUndertaker: false
+      },
+      multipleUpload: false,
+      journey: 'returns-required',
+      requirements: [{}],
+      startDateOptions: 'licenceStartDate',
+      returnVersionStartDate: '2023-01-01T00:00:00.000Z',
+      licenceVersion: {
+        id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
+        endDate: null,
+        startDate: '2022-04-01T00:00:00.000Z',
+        copyableReturnVersions: [
+          {
+            id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
+            startDate: '2023-01-01T00:00:00.000Z',
+            reason: null,
+            modLogs: []
+          }
+        ]
+      },
+      reason: 'major-change'
     }
 
-    session = await SessionHelper.add(sessionData)
+    session = SessionModelStub.build(Sinon, sessionData)
 
-    yarStub = { flash: Sinon.stub() }
+    fetchSessionStub = Sinon.stub(FetchSessionDal, 'go').resolves(session)
+
+    yarStub = { flash: Sinon.stub().returns([]) }
   })
 
   afterEach(() => {
@@ -91,9 +93,8 @@ describe('Return Versions - Setup - Submit Points service', () => {
       it('saves the submitted value', async () => {
         await SubmitPointsService.go(session.id, requirementIndex, payload, yarStub)
 
-        const refreshedSession = await session.$query()
-
-        expect(refreshedSession.requirements[0].points).to.equal(['d03d7d7c-4e33-4b4d-ac9b-6ebac9a5e5f6'])
+        expect(session.requirements[0].points).to.equal(['d03d7d7c-4e33-4b4d-ac9b-6ebac9a5e5f6'])
+        expect(session.$update.called).to.be.true()
       })
 
       describe('and the page has been not been visited', () => {
@@ -107,8 +108,13 @@ describe('Return Versions - Setup - Submit Points service', () => {
       })
 
       describe('and the page has been visited', () => {
-        beforeEach(async () => {
-          session = await SessionHelper.add({ data: { ...sessionData.data, checkPageVisited: true } })
+        beforeEach(() => {
+          session = SessionModelStub.build(Sinon, {
+            ...sessionData,
+            checkPageVisited: true
+          })
+
+          fetchSessionStub.resolves(session)
         })
 
         it('returns the correct details the controller needs to redirect the journey to the check page', async () => {

--- a/test/services/return-versions/setup/submit-reason.service.test.js
+++ b/test/services/return-versions/setup/submit-reason.service.test.js
@@ -9,46 +9,50 @@ const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const SubmitReasonService = require('../../../../app/services/return-versions/setup/submit-reason.service.js')
 
 describe('Return Versions Setup - Submit Reason service', () => {
+  let fetchSessionStub
   let payload
   let session
   let sessionData
   let yarStub
 
-  beforeEach(async () => {
+  beforeEach(() => {
     sessionData = {
-      data: {
-        checkPageVisited: false,
-        licence: {
-          id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
-          currentVersionStartDate: '2023-01-01T00:00:00.000Z',
-          endDate: null,
-          licenceRef: '01/ABC',
-          licenceHolder: 'Turbo Kid',
-          returnVersions: [
-            {
-              id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
-              startDate: '2023-01-01T00:00:00.000Z',
-              reason: null,
-              modLogs: []
-            }
-          ],
-          startDate: '2022-04-01T00:00:00.000Z'
-        },
-        journey: 'returns-required',
-        requirements: [{}],
-        startDateOptions: 'licenceStartDate'
-      }
+      checkPageVisited: false,
+      licence: {
+        id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
+        currentVersionStartDate: '2023-01-01T00:00:00.000Z',
+        endDate: null,
+        licenceRef: '01/ABC',
+        licenceHolder: 'Turbo Kid',
+        returnVersions: [
+          {
+            id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
+            startDate: '2023-01-01T00:00:00.000Z',
+            reason: null,
+            modLogs: []
+          }
+        ],
+        startDate: '2022-04-01T00:00:00.000Z'
+      },
+      journey: 'returns-required',
+      requirements: [{}],
+      startDateOptions: 'licenceStartDate'
     }
 
-    session = await SessionHelper.add(sessionData)
+    session = SessionModelStub.build(Sinon, sessionData)
 
-    yarStub = { flash: Sinon.stub() }
+    fetchSessionStub = Sinon.stub(FetchSessionDal, 'go').resolves(session)
+
+    yarStub = { flash: Sinon.stub().returns([]) }
   })
 
   afterEach(() => {
@@ -66,9 +70,7 @@ describe('Return Versions Setup - Submit Reason service', () => {
       it('saves the submitted value', async () => {
         await SubmitReasonService.go(session.id, payload, yarStub)
 
-        const refreshedSession = await session.$query()
-
-        expect(refreshedSession.reason).to.equal('new-licence')
+        expect(session.reason).to.equal('new-licence')
       })
 
       describe('and the page has been not been visited', () => {
@@ -82,8 +84,10 @@ describe('Return Versions Setup - Submit Reason service', () => {
       })
 
       describe('and the page has been visited', () => {
-        beforeEach(async () => {
-          session = await SessionHelper.add({ data: { ...sessionData.data, checkPageVisited: true } })
+        beforeEach(() => {
+          session = SessionModelStub.build(Sinon, { ...sessionData, checkPageVisited: true })
+
+          fetchSessionStub.resolves(session)
         })
 
         it('returns the correct details the controller needs to redirect the journey to the check page', async () => {

--- a/test/services/return-versions/setup/submit-returns-cycle.service.test.js
+++ b/test/services/return-versions/setup/submit-returns-cycle.service.test.js
@@ -5,11 +5,14 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const SubmitReturnsCycleService = require('../../../../app/services/return-versions/setup/submit-returns-cycle.service.js')
@@ -17,41 +20,46 @@ const SubmitReturnsCycleService = require('../../../../app/services/return-versi
 describe('Return Versions Setup - Submit Returns Cycle service', () => {
   const requirementIndex = 0
 
+  let fetchSessionStub
   let payload
   let session
   let sessionData
   let yarStub
 
-  beforeEach(async () => {
+  beforeEach(() => {
     sessionData = {
-      data: {
-        checkPageVisited: false,
-        licence: {
-          id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
-          currentVersionStartDate: '2023-01-01T00:00:00.000Z',
-          endDate: null,
-          licenceRef: '01/ABC',
-          licenceHolder: 'Turbo Kid',
-          returnVersions: [
-            {
-              id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
-              startDate: '2023-01-01T00:00:00.000Z',
-              reason: null,
-              modLogs: []
-            }
-          ],
-          startDate: '2022-04-01T00:00:00.000Z'
-        },
-        journey: 'returns-required',
-        requirements: [{}],
-        startDateOptions: 'licenceStartDate',
-        reason: 'major-change'
-      }
+      checkPageVisited: false,
+      licence: {
+        id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
+        currentVersionStartDate: '2023-01-01T00:00:00.000Z',
+        endDate: null,
+        licenceRef: '01/ABC',
+        licenceHolder: 'Turbo Kid',
+        returnVersions: [
+          {
+            id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
+            startDate: '2023-01-01T00:00:00.000Z',
+            reason: null,
+            modLogs: []
+          }
+        ],
+        startDate: '2022-04-01T00:00:00.000Z'
+      },
+      journey: 'returns-required',
+      requirements: [{}],
+      startDateOptions: 'licenceStartDate',
+      reason: 'major-change'
     }
 
-    session = await SessionHelper.add(sessionData)
+    session = SessionModelStub.build(Sinon, sessionData)
 
-    yarStub = { flash: Sinon.stub() }
+    fetchSessionStub = Sinon.stub(FetchSessionDal, 'go').resolves(session)
+
+    yarStub = { flash: Sinon.stub().returns([]) }
+  })
+
+  afterEach(() => {
+    Sinon.restore()
   })
 
   describe('when called', () => {
@@ -65,9 +73,8 @@ describe('Return Versions Setup - Submit Returns Cycle service', () => {
       it('saves the submitted value', async () => {
         await SubmitReturnsCycleService.go(session.id, requirementIndex, payload, yarStub)
 
-        const refreshedSession = await session.$query()
-
-        expect(refreshedSession.requirements[0].returnsCycle).to.equal('summer')
+        expect(session.requirements[0].returnsCycle).to.equal('summer')
+        expect(session.$update.called).to.be.true()
       })
 
       describe('and the page has been not been visited', () => {
@@ -81,8 +88,10 @@ describe('Return Versions Setup - Submit Returns Cycle service', () => {
       })
 
       describe('and the page has been visited', () => {
-        beforeEach(async () => {
-          session = await SessionHelper.add({ data: { ...sessionData.data, checkPageVisited: true } })
+        beforeEach(() => {
+          session = SessionModelStub.build(Sinon, { ...sessionData, checkPageVisited: true })
+
+          fetchSessionStub.resolves(session)
         })
 
         it('returns the correct details the controller needs to redirect the journey to the check page', async () => {

--- a/test/services/return-versions/setup/submit-site-description.service.test.js
+++ b/test/services/return-versions/setup/submit-site-description.service.test.js
@@ -5,11 +5,14 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Things under test
 const SubmitSiteDescriptionService = require('../../../../app/services/return-versions/setup/submit-site-description.service.js')
@@ -17,41 +20,46 @@ const SubmitSiteDescriptionService = require('../../../../app/services/return-ve
 describe('Return Versions Setup - Submit Site Description service', () => {
   const requirementIndex = 0
 
+  let fetchSessionStub
   let payload
   let session
   let sessionData
   let yarStub
 
-  beforeEach(async () => {
+  beforeEach(() => {
     sessionData = {
-      data: {
-        checkPageVisited: false,
-        licence: {
-          id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
-          currentVersionStartDate: '2023-01-01T00:00:00.000Z',
-          endDate: null,
-          licenceRef: '01/ABC',
-          licenceHolder: 'Turbo Kid',
-          returnVersions: [
-            {
-              id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
-              startDate: '2023-01-01T00:00:00.000Z',
-              reason: null,
-              modLogs: []
-            }
-          ],
-          startDate: '2022-04-01T00:00:00.000Z'
-        },
-        journey: 'returns-required',
-        requirements: [{}],
-        startDateOptions: 'licenceStartDate',
-        reason: 'major-change'
-      }
+      checkPageVisited: false,
+      licence: {
+        id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
+        currentVersionStartDate: '2023-01-01T00:00:00.000Z',
+        endDate: null,
+        licenceRef: '01/ABC',
+        licenceHolder: 'Turbo Kid',
+        returnVersions: [
+          {
+            id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
+            startDate: '2023-01-01T00:00:00.000Z',
+            reason: null,
+            modLogs: []
+          }
+        ],
+        startDate: '2022-04-01T00:00:00.000Z'
+      },
+      journey: 'returns-required',
+      requirements: [{}],
+      startDateOptions: 'licenceStartDate',
+      reason: 'major-change'
     }
 
-    session = await SessionHelper.add(sessionData)
+    session = SessionModelStub.build(Sinon, sessionData)
 
-    yarStub = { flash: Sinon.stub() }
+    fetchSessionStub = Sinon.stub(FetchSessionDal, 'go').resolves(session)
+
+    yarStub = { flash: Sinon.stub().returns([]) }
+  })
+
+  afterEach(() => {
+    Sinon.restore()
   })
 
   describe('when called', () => {
@@ -65,11 +73,8 @@ describe('Return Versions Setup - Submit Site Description service', () => {
       it('saves the submitted value', async () => {
         await SubmitSiteDescriptionService.go(session.id, requirementIndex, payload, yarStub)
 
-        const refreshedSession = await session.$query()
-
-        expect(refreshedSession.requirements[0].siteDescription).to.equal(
-          'This is a valid return requirement description'
-        )
+        expect(session.requirements[0].siteDescription).to.equal('This is a valid return requirement description')
+        expect(session.$update.called).to.be.true()
       })
 
       describe('and the page has been not been visited', () => {
@@ -83,8 +88,10 @@ describe('Return Versions Setup - Submit Site Description service', () => {
       })
 
       describe('and the page has been visited', () => {
-        beforeEach(async () => {
-          session = await SessionHelper.add({ data: { ...sessionData.data, checkPageVisited: true } })
+        beforeEach(() => {
+          session = SessionModelStub.build(Sinon, { ...sessionData, checkPageVisited: true })
+
+          fetchSessionStub.resolves(session)
         })
 
         it('returns the correct details the controller needs to redirect the journey to the check page', async () => {

--- a/test/services/return-versions/setup/submit-start-date.service.test.js
+++ b/test/services/return-versions/setup/submit-start-date.service.test.js
@@ -356,7 +356,7 @@ describe('Return Versions - Setup - Submit Start Date service', () => {
             startDateMonth: null,
             startDateYear: null,
             backLink: {
-              href: `/system/licences/8b7f78ba-f3ad-4cb6-a058-78abc4d1383d/set-up`,
+              href: '/system/licences/8b7f78ba-f3ad-4cb6-a058-78abc4d1383d/set-up',
               text: 'Back'
             },
             licenceId: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',

--- a/test/services/return-versions/setup/submit-start-date.service.test.js
+++ b/test/services/return-versions/setup/submit-start-date.service.test.js
@@ -9,7 +9,10 @@ const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Things we need to stub
 const DetermineRelevantLicenceVersionService = require('../../../../app/services/return-versions/setup/determine-relevant-licence-version.service.js')
@@ -18,36 +21,40 @@ const DetermineRelevantLicenceVersionService = require('../../../../app/services
 const SubmitStartDateService = require('../../../../app/services/return-versions/setup/submit-start-date.service.js')
 
 describe('Return Versions - Setup - Submit Start Date service', () => {
+  let fetchSessionStub
   let payload
   let relevantLicenceVersion
   let session
+  let sessionData
   let yarStub
 
-  beforeEach(async () => {
-    session = await SessionHelper.add()
-
-    session.checkPageVisited = false
-    session.licence = {
-      id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
-      currentVersionStartDate: '2023-01-01',
-      endDate: null,
-      licenceRef: '01/ABC',
-      licenceHolder: 'Turbo Kid',
-      returnVersions: [
-        {
-          id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
-          startDate: '2023-01-01',
-          reason: null,
-          modLogs: []
-        }
-      ],
-      startDate: '2019-04-01',
-      waterUndertaker: false
+  beforeEach(() => {
+    sessionData = {
+      checkPageVisited: false,
+      licence: {
+        id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
+        currentVersionStartDate: '2023-01-01',
+        endDate: null,
+        licenceRef: '01/ABC',
+        licenceHolder: 'Turbo Kid',
+        returnVersions: [
+          {
+            id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
+            startDate: '2023-01-01',
+            reason: null,
+            modLogs: []
+          }
+        ],
+        startDate: '2019-04-01',
+        waterUndertaker: false
+      },
+      journey: 'returns-required',
+      requirements: [{}]
     }
-    session.journey = 'returns-required'
-    session.requirements = [{}]
 
-    await session.$update()
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    fetchSessionStub = Sinon.stub(FetchSessionDal, 'go').resolves(session)
 
     yarStub = { flash: Sinon.stub() }
   })
@@ -90,25 +97,25 @@ describe('Return Versions - Setup - Submit Start Date service', () => {
           it('saves the submitted date details and the relevant licence version', async () => {
             await SubmitStartDateService.go(session.id, payload, yarStub)
 
-            const refreshedSession = await session.$query()
+            expect(session.startDateOptions).to.equal('licenceStartDate')
+            expect(session.startDateDay).not.to.exist()
+            expect(session.startDateMonth).not.to.exist()
+            expect(session.startDateYear).not.to.exist()
+            expect(new Date(session.returnVersionStartDate)).to.equal(new Date('2023-01-01'))
 
-            expect(refreshedSession.startDateOptions).to.equal('licenceStartDate')
-            expect(refreshedSession.startDateDay).not.to.exist()
-            expect(refreshedSession.startDateMonth).not.to.exist()
-            expect(refreshedSession.startDateYear).not.to.exist()
-            expect(new Date(refreshedSession.returnVersionStartDate)).to.equal(new Date('2023-01-01'))
-
-            expect(refreshedSession.licenceVersion).to.equal({
+            expect(session.licenceVersion).to.equal({
               copyableReturnVersions: relevantLicenceVersion.copyableReturnVersions,
               endDate: relevantLicenceVersion.endDate,
               id: relevantLicenceVersion.id,
-              startDate: '2023-01-01T00:00:00.000Z'
+              startDate: new Date('2023-01-01')
             })
+
+            expect(session.$update.called).to.be.true()
           })
         })
 
         describe('and the user selected "another start date"', () => {
-          beforeEach(async () => {
+          beforeEach(() => {
             payload = {
               startDateOptions: 'anotherStartDate',
               startDateDay: '26',
@@ -120,37 +127,38 @@ describe('Return Versions - Setup - Submit Start Date service', () => {
           it('saves the submitted date details and the relevant licence version', async () => {
             await SubmitStartDateService.go(session.id, payload, yarStub)
 
-            const refreshedSession = await session.$query()
+            expect(session.startDateOptions).to.equal('anotherStartDate')
+            expect(session.startDateDay).to.equal('26')
+            expect(session.startDateMonth).to.equal('11')
+            expect(session.startDateYear).to.equal('2023')
+            expect(new Date(session.returnVersionStartDate)).to.equal(new Date('2023-11-26'))
 
-            expect(refreshedSession.startDateOptions).to.equal('anotherStartDate')
-            expect(refreshedSession.startDateDay).to.equal('26')
-            expect(refreshedSession.startDateMonth).to.equal('11')
-            expect(refreshedSession.startDateYear).to.equal('2023')
-            expect(new Date(refreshedSession.returnVersionStartDate)).to.equal(new Date('2023-11-26'))
-
-            expect(refreshedSession.licenceVersion).to.equal({
+            expect(session.licenceVersion).to.equal({
               copyableReturnVersions: relevantLicenceVersion.copyableReturnVersions,
               endDate: relevantLicenceVersion.endDate,
               id: relevantLicenceVersion.id,
-              startDate: '2023-01-01T00:00:00.000Z'
+              startDate: new Date('2023-01-01')
             })
+
+            expect(session.$update.called).to.be.true()
           })
         })
 
         describe('and when the licence is a water company', () => {
-          beforeEach(async () => {
-            session.licence.waterUndertaker = true
+          beforeEach(() => {
+            sessionData.licence.waterUndertaker = true
 
-            await session.$update()
+            session = SessionModelStub.build(Sinon, sessionData)
+
+            fetchSessionStub.resolves(session)
           })
 
           describe('and the selected start date is before 1 April 2025', () => {
             it('does not set the "quarterly returns" flag in the session', async () => {
               await SubmitStartDateService.go(session.id, payload, yarStub)
 
-              const refreshedSession = await session.$query()
-
-              expect(refreshedSession.quarterlyReturns).not.to.exist()
+              expect(session.quarterlyReturns).not.to.exist()
+              expect(session.$update.called).to.be.true()
             })
           })
 
@@ -167,9 +175,7 @@ describe('Return Versions - Setup - Submit Start Date service', () => {
             it('sets the "quarterly returns" flag to "true" in the session', async () => {
               await SubmitStartDateService.go(session.id, payload, yarStub)
 
-              const refreshedSession = await session.$query()
-
-              expect(refreshedSession.quarterlyReturns).to.be.true()
+              expect(session.quarterlyReturns).to.be.true()
             })
           })
         })
@@ -178,29 +184,29 @@ describe('Return Versions - Setup - Submit Start Date service', () => {
           it('does not set the "quarterly returns" flag in the session', async () => {
             await SubmitStartDateService.go(session.id, payload, yarStub)
 
-            const refreshedSession = await session.$query()
-
-            expect(refreshedSession.quarterlyReturns).not.to.exist()
+            expect(session.quarterlyReturns).not.to.exist()
           })
         })
       })
 
       describe('and the page has been visited previously (we are coming from the "check" page)', () => {
-        beforeEach(async () => {
+        beforeEach(() => {
           relevantLicenceVersion = {
-            copyableReturnVersions: session.licence.returnVersions,
+            copyableReturnVersions: sessionData.licence.returnVersions,
             endDate: null,
             id: 'c0e59520-3164-43ac-8f64-e1d38dfb90c4',
             startDate: new Date('2023-01-01')
           }
 
-          session.checkPageVisited = true
-          session.licenceVersion = relevantLicenceVersion
-          session.returnVersionStartDate = new Date('2023-01-01')
-          session.requirements = [{ index: 1, name: 'foo' }]
-          session.method = 'existing'
+          sessionData.checkPageVisited = true
+          sessionData.licenceVersion = relevantLicenceVersion
+          sessionData.returnVersionStartDate = new Date('2023-01-01')
+          sessionData.requirements = [{ index: 1, name: 'foo' }]
+          sessionData.method = 'existing'
 
-          await session.$update()
+          session = SessionModelStub.build(Sinon, sessionData)
+
+          fetchSessionStub.resolves(session)
         })
 
         describe('and the start date is not changed (user just clicks continue)', () => {
@@ -232,13 +238,11 @@ describe('Return Versions - Setup - Submit Start Date service', () => {
           it('does not change the relevant licence version for the session', async () => {
             await SubmitStartDateService.go(session.id, payload, yarStub)
 
-            const refreshedSession = await session.$query()
-
-            expect(refreshedSession.licenceVersion).to.equal({
+            expect(session.licenceVersion).to.equal({
               copyableReturnVersions: relevantLicenceVersion.copyableReturnVersions,
               endDate: relevantLicenceVersion.endDate,
               id: relevantLicenceVersion.id,
-              startDate: '2023-01-01T00:00:00.000Z'
+              startDate: new Date('2023-01-01')
             })
           })
         })
@@ -276,13 +280,11 @@ describe('Return Versions - Setup - Submit Start Date service', () => {
           it('does not change the relevant licence version for the session', async () => {
             await SubmitStartDateService.go(session.id, payload, yarStub)
 
-            const refreshedSession = await session.$query()
-
-            expect(refreshedSession.licenceVersion).to.equal({
+            expect(session.licenceVersion).to.equal({
               copyableReturnVersions: relevantLicenceVersion.copyableReturnVersions,
               endDate: relevantLicenceVersion.endDate,
               id: relevantLicenceVersion.id,
-              startDate: '2023-01-01T00:00:00.000Z'
+              startDate: new Date('2023-01-01')
             })
           })
         })
@@ -323,25 +325,23 @@ describe('Return Versions - Setup - Submit Start Date service', () => {
           it('updates the relevant licence version for the session and resets the session', async () => {
             await SubmitStartDateService.go(session.id, payload, yarStub)
 
-            const refreshedSession = await session.$query()
-
-            expect(refreshedSession.licenceVersion).to.equal({
+            expect(session.licenceVersion).to.equal({
               copyableReturnVersions: [],
-              endDate: '2022-12-31T00:00:00.000Z',
+              endDate: new Date('2022-12-31'),
               id: newRelevantLicenceVersion.id,
-              startDate: '2020-04-01T00:00:00.000Z'
+              startDate: new Date('2020-04-01')
             })
 
-            expect(refreshedSession.method).not.to.exist()
-            expect(refreshedSession.checkPageVisited).to.be.false()
-            expect(refreshedSession.requirements).to.equal([{}])
+            expect(session.method).not.to.exist()
+            expect(session.checkPageVisited).to.be.false()
+            expect(session.requirements).to.equal([{}])
           })
         })
       })
     })
 
     describe('with an invalid payload', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         payload = {}
       })
 
@@ -356,7 +356,7 @@ describe('Return Versions - Setup - Submit Start Date service', () => {
             startDateMonth: null,
             startDateYear: null,
             backLink: {
-              href: '/system/licences/8b7f78ba-f3ad-4cb6-a058-78abc4d1383d/set-up',
+              href: `/system/licences/8b7f78ba-f3ad-4cb6-a058-78abc4d1383d/set-up`,
               text: 'Back'
             },
             licenceId: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
@@ -385,7 +385,7 @@ describe('Return Versions - Setup - Submit Start Date service', () => {
       })
 
       describe('because the user has selected another start date and entered invalid data', () => {
-        beforeEach(async () => {
+        beforeEach(() => {
           payload = {
             startDateOptions: 'anotherStartDate',
             startDateDay: 'a',

--- a/test/validators/return-versions/setup/returns-cycle.validator.test.js
+++ b/test/validators/return-versions/setup/returns-cycle.validator.test.js
@@ -50,7 +50,7 @@ describe('Return Versions Setup - Returns Cycle validator', () => {
         returnsCycle: 'summer'
       }
 
-      session.data.quarterlyReturns = true
+      session.quarterlyReturns = true
     })
 
     it('fails validation with the error message "Quarterly returns submissions cannot be set for returns requirements in the summer cycle"', () => {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5573

We recently refactored how we use fetch and delete session data, we now have a single way of doing each.

We are moving away from using the database in service test.

This change updates some of the tests still using the session helper to stub the 'FetchSessionDal'