### PR TITLE
Update tests to stub 'FetchSessionDal'

### DIFF
--- a/app/services/return-versions/setup/submit-note.service.js
+++ b/app/services/return-versions/setup/submit-note.service.js
@@ -53,9 +53,7 @@ async function go(sessionId, payload, user, yar) {
 }
 
 function _notification(session, newNote) {
-  const {
-    data: { note }
-  } = session
+  const { note } = session
 
   if (!note && newNote) {
     return {

--- a/app/validators/return-versions/setup/additional-submission-options.validator.js
+++ b/app/validators/return-versions/setup/additional-submission-options.validator.js
@@ -42,11 +42,11 @@ function go(payload, session) {
 function _noQuarterlyReturnsForSummerCycle(value, helpers, session) {
   const { additionalSubmissionOptions } = value
 
-  const hasSummerCycle = session.data.requirements?.some((requirement) => {
+  const hasSummerCycle = session.requirements?.some((requirement) => {
     return requirement.returnsCycle === 'summer'
   })
 
-  const checkPageVisited = session.data.checkPageVisited === true
+  const checkPageVisited = session.checkPageVisited === true
   const includesQuarterly = additionalSubmissionOptions?.includes('quarterly-returns')
 
   if (checkPageVisited && hasSummerCycle && includesQuarterly) {

--- a/test/services/return-versions/setup/abstraction-period.service.test.js
+++ b/test/services/return-versions/setup/abstraction-period.service.test.js
@@ -3,12 +3,16 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
+const Sinon = require('sinon')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const AbstractionPeriodService = require('../../../../app/services/return-versions/setup/abstraction-period.service.js')
@@ -17,25 +21,32 @@ describe('Return Versions Setup - Abstraction Period service', () => {
   const requirementIndex = 0
 
   let session
+  let sessionData
 
-  beforeEach(async () => {
-    session = await SessionHelper.add({
-      data: {
-        checkPageVisited: false,
-        licence: {
-          id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
-          currentVersionStartDate: '2023-01-01T00:00:00.000Z',
-          endDate: null,
-          licenceRef: '01/ABC',
-          licenceHolder: 'Turbo Kid',
-          startDate: '2022-04-01T00:00:00.000Z'
-        },
-        journey: 'returns-required',
-        requirements: [{}],
-        startDateOptions: 'licenceStartDate',
-        reason: 'major-change'
-      }
-    })
+  beforeEach(() => {
+    sessionData = {
+      checkPageVisited: false,
+      licence: {
+        id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
+        currentVersionStartDate: '2023-01-01T00:00:00.000Z',
+        endDate: null,
+        licenceRef: '01/ABC',
+        licenceHolder: 'Turbo Kid',
+        startDate: '2022-04-01T00:00:00.000Z'
+      },
+      journey: 'returns-required',
+      requirements: [{}],
+      startDateOptions: 'licenceStartDate',
+      reason: 'major-change'
+    }
+
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    Sinon.stub(FetchSessionDal, 'go').resolves(session)
+  })
+
+  afterEach(() => {
+    Sinon.restore()
   })
 
   describe('when called', () => {

--- a/test/services/return-versions/setup/add.service.test.js
+++ b/test/services/return-versions/setup/add.service.test.js
@@ -3,47 +3,57 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
+const Sinon = require('sinon')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const AddService = require('../../../../app/services/return-versions/setup/add.service.js')
 
 describe('Return Versions Setup - Add service', () => {
   let session
+  let sessionData
 
-  beforeEach(async () => {
-    session = await SessionHelper.add({
-      data: {
-        checkPageVisited: false,
-        licence: {
-          id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
-          currentVersionStartDate: '2023-01-01T00:00:00.000Z',
-          endDate: null,
-          licenceRef: '01/ABC',
-          licenceHolder: 'Turbo Kid',
-          startDate: '2022-04-01T00:00:00.000Z'
-        },
-        journey: 'returns-required',
-        requirements: [{}],
-        startDateOptions: 'licenceStartDate',
-        reason: 'major-change'
-      }
-    })
+  beforeEach(() => {
+    sessionData = {
+      checkPageVisited: false,
+      licence: {
+        id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
+        currentVersionStartDate: '2023-01-01T00:00:00.000Z',
+        endDate: null,
+        licenceRef: '01/ABC',
+        licenceHolder: 'Turbo Kid',
+        startDate: '2022-04-01T00:00:00.000Z'
+      },
+      journey: 'returns-required',
+      requirements: [{}],
+      startDateOptions: 'licenceStartDate',
+      reason: 'major-change'
+    }
+
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    Sinon.stub(FetchSessionDal, 'go').resolves(session)
+  })
+
+  afterEach(() => {
+    Sinon.restore()
   })
 
   describe('when called', () => {
     it('adds another empty object to the requirement array in the current setup session record', async () => {
       await AddService.go(session.id)
 
-      const refreshedSession = await session.$query()
-
-      expect(refreshedSession.data.requirements.length).to.equal(2)
-      expect(refreshedSession.data.requirements).to.equal([{}, {}])
+      expect(session.requirements.length).to.equal(2)
+      expect(session.requirements).to.equal([{}, {}])
+      expect(session.$update.called).to.be.true()
     })
 
     it('returns the index of the new requirement', async () => {

--- a/test/services/return-versions/setup/additional-submission-options.service.test.js
+++ b/test/services/return-versions/setup/additional-submission-options.service.test.js
@@ -3,39 +3,50 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
+const Sinon = require('sinon')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const AdditionalSubmissionOptionsService = require('../../../../app/services/return-versions/setup/additional-submission-options.service.js')
 
 describe('Return Versions Setup - Additional Submission Options service', () => {
   let session
+  let sessionData
 
-  beforeEach(async () => {
-    session = await SessionHelper.add({
-      data: {
-        checkPageVisited: false,
-        licence: {
-          id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
-          currentVersionStartDate: '2023-01-01T00:00:00.000Z',
-          endDate: null,
-          licenceRef: '01/ABC',
-          licenceHolder: 'Turbo Kid',
-          startDate: '2022-04-01T00:00:00.000Z'
-        },
-        multipleUpload: false,
-        noAdditionalOptions: undefined,
-        journey: 'returns-required',
-        requirements: [{}],
-        startDateOptions: 'licenceStartDate',
-        reason: 'major-change'
-      }
-    })
+  beforeEach(() => {
+    sessionData = {
+      checkPageVisited: false,
+      licence: {
+        id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
+        currentVersionStartDate: '2023-01-01T00:00:00.000Z',
+        endDate: null,
+        licenceRef: '01/ABC',
+        licenceHolder: 'Turbo Kid',
+        startDate: '2022-04-01T00:00:00.000Z'
+      },
+      multipleUpload: false,
+      noAdditionalOptions: undefined,
+      journey: 'returns-required',
+      requirements: [{}],
+      startDateOptions: 'licenceStartDate',
+      reason: 'major-change'
+    }
+
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    Sinon.stub(FetchSessionDal, 'go').resolves(session)
+  })
+
+  afterEach(() => {
+    Sinon.restore()
   })
 
   describe('when called', () => {

--- a/test/services/return-versions/setup/agreements-exceptions.service.test.js
+++ b/test/services/return-versions/setup/agreements-exceptions.service.test.js
@@ -3,12 +3,16 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
+const Sinon = require('sinon')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const AgreementsExceptionsService = require('../../../../app/services/return-versions/setup/agreements-exceptions.service.js')
@@ -17,25 +21,32 @@ describe('Return Versions Setup - Agreements Exceptions service', () => {
   const requirementIndex = 0
 
   let session
+  let sessionData
 
-  beforeEach(async () => {
-    session = await SessionHelper.add({
-      data: {
-        checkPageVisited: false,
-        licence: {
-          id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
-          currentVersionStartDate: '2023-01-01T00:00:00.000Z',
-          endDate: null,
-          licenceRef: '01/ABC',
-          licenceHolder: 'Turbo Kid',
-          startDate: '2022-04-01T00:00:00.000Z'
-        },
-        journey: 'returns-required',
-        requirements: [{}],
-        startDateOptions: 'licenceStartDate',
-        reason: 'major-change'
-      }
-    })
+  beforeEach(() => {
+    sessionData = {
+      checkPageVisited: false,
+      licence: {
+        id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
+        currentVersionStartDate: '2023-01-01T00:00:00.000Z',
+        endDate: null,
+        licenceRef: '01/ABC',
+        licenceHolder: 'Turbo Kid',
+        startDate: '2022-04-01T00:00:00.000Z'
+      },
+      journey: 'returns-required',
+      requirements: [{}],
+      startDateOptions: 'licenceStartDate',
+      reason: 'major-change'
+    }
+
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    Sinon.stub(FetchSessionDal, 'go').resolves(session)
+  })
+
+  afterEach(() => {
+    Sinon.restore()
   })
 
   describe('when called', () => {

--- a/test/services/return-versions/setup/cancel.service.test.js
+++ b/test/services/return-versions/setup/cancel.service.test.js
@@ -3,55 +3,63 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
+const Sinon = require('sinon')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
-const { generateUUID } = require('../../../../app/lib/general.lib.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
 
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 // Thing under test
 const CancelService = require('../../../../app/services/return-versions/setup/cancel.service.js')
 
 describe('Return Versions Setup - Cancel service', () => {
   let session
+  let sessionData
 
-  beforeEach(async () => {
-    session = await SessionHelper.add({
-      id: generateUUID(),
-      data: {
-        checkPageVisited: false,
-        licence: {
-          id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
-          currentVersionStartDate: '2023-01-01T00:00:00.000Z',
-          endDate: null,
-          licenceRef: '01/ABC',
-          licenceHolder: 'Turbo Kid',
-          startDate: '2022-04-01T00:00:00.000Z'
-        },
-        journey: 'returns-required',
-        requirements: [
-          {
-            points: ['At National Grid Reference TQ 6520 5937 (POINT A, ADDINGTON SANDPITS)'],
-            purposes: [{ alias: '', description: 'Mineral Washing', id: '3a865331-d2f3-4acc-ac85-527fa2b0d2dd' }],
-            returnsCycle: 'winter-and-all-year',
-            siteDescription: 'Bore hole in rear field',
-            abstractionPeriod: {
-              abstractionPeriodEndDay: '31',
-              abstractionPeriodEndMonth: '10',
-              abstractionPeriodStartDay: '01',
-              abstractionPeriodStartMonth: '04'
-            },
-            frequencyReported: 'month',
-            frequencyCollected: 'month',
-            agreementsExceptions: ['none']
-          }
-        ],
-        startDateOptions: 'licenceStartDate',
-        reason: 'major-change'
-      }
-    })
+  beforeEach(() => {
+    sessionData = {
+      checkPageVisited: false,
+      licence: {
+        id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
+        currentVersionStartDate: '2023-01-01T00:00:00.000Z',
+        endDate: null,
+        licenceRef: '01/ABC',
+        licenceHolder: 'Turbo Kid',
+        startDate: '2022-04-01T00:00:00.000Z'
+      },
+      journey: 'returns-required',
+      requirements: [
+        {
+          points: ['At National Grid Reference TQ 6520 5937 (POINT A, ADDINGTON SANDPITS)'],
+          purposes: [{ alias: '', description: 'Mineral Washing', id: '3a865331-d2f3-4acc-ac85-527fa2b0d2dd' }],
+          returnsCycle: 'winter-and-all-year',
+          siteDescription: 'Bore hole in rear field',
+          abstractionPeriod: {
+            abstractionPeriodEndDay: '31',
+            abstractionPeriodEndMonth: '10',
+            abstractionPeriodStartDay: '01',
+            abstractionPeriodStartMonth: '04'
+          },
+          frequencyReported: 'month',
+          frequencyCollected: 'month',
+          agreementsExceptions: ['none']
+        }
+      ],
+      startDateOptions: 'licenceStartDate',
+      reason: 'major-change'
+    }
+
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    Sinon.stub(FetchSessionDal, 'go').resolves(session)
+  })
+
+  afterEach(() => {
+    Sinon.restore()
   })
 
   describe('when called', () => {

--- a/test/services/return-versions/setup/delete-note.service.test.js
+++ b/test/services/return-versions/setup/delete-note.service.test.js
@@ -5,53 +5,60 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const DeleteNoteService = require('../../../../app/services/return-versions/setup/delete-note.service.js')
 
 describe('Return Versions Setup - Delete Note service', () => {
   let session
+  let sessionData
   let yarStub
 
-  beforeEach(async () => {
-    session = await SessionHelper.add({
-      data: {
-        checkPageVisited: false,
-        licence: {
-          id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
-          currentVersionStartDate: '2023-01-01T00:00:00.000Z',
-          endDate: null,
-          licenceRef: '01/ABC',
-          licenceHolder: 'Turbo Kid',
-          startDate: '2022-04-01T00:00:00.000Z'
-        },
-        journey: 'returns-required',
-        requirements: [{}],
-        startDateOptions: 'licenceStartDate',
-        reason: 'major-change',
-        note: {
-          content: 'I am not long for this world',
-          userEmail: 'carol.shaw@atari.com'
-        }
+  beforeEach(() => {
+    sessionData = {
+      checkPageVisited: false,
+      licence: {
+        id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
+        currentVersionStartDate: '2023-01-01T00:00:00.000Z',
+        endDate: null,
+        licenceRef: '01/ABC',
+        licenceHolder: 'Turbo Kid',
+        startDate: '2022-04-01T00:00:00.000Z'
+      },
+      journey: 'returns-required',
+      requirements: [{}],
+      startDateOptions: 'licenceStartDate',
+      reason: 'major-change',
+      note: {
+        content: 'I am not long for this world',
+        userEmail: 'carol.shaw@atari.com'
       }
-    })
-
-    yarStub = {
-      flash: Sinon.stub()
     }
+
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    Sinon.stub(FetchSessionDal, 'go').resolves(session)
+
+    yarStub = { flash: Sinon.stub() }
+  })
+
+  afterEach(() => {
+    Sinon.restore()
   })
 
   it('deletes the note from the session', async () => {
     await DeleteNoteService.go(session.id, yarStub)
 
-    const refreshedSession = await session.$query()
-
-    expect(refreshedSession.note).to.be.undefined()
+    expect(session.note).to.be.undefined()
+    expect(session.$update.called).to.be.true()
   })
 
   it('sets the notification message to "Deleted"', async () => {

--- a/test/services/return-versions/setup/existing/existing.service.test.js
+++ b/test/services/return-versions/setup/existing/existing.service.test.js
@@ -3,61 +3,72 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
+const Sinon = require('sinon')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const SessionHelper = require('../../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const ExistingService = require('../../../../../app/services/return-versions/setup/existing/existing.service.js')
 
 describe('Return Versions - Setup - Existing service', () => {
   let session
+  let sessionData
 
-  beforeEach(async () => {
-    session = await SessionHelper.add({
-      data: {
-        checkPageVisited: false,
-        licence: {
-          id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
-          currentVersionStartDate: '2023-01-01T00:00:00.000Z',
-          endDate: null,
-          licenceRef: '01/ABC',
-          licenceHolder: 'Turbo Kid',
-          returnVersions: [
-            {
-              id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
-              startDate: '2023-01-01T00:00:00.000Z',
-              reason: null,
-              modLogs: []
-            }
-          ],
-          startDate: '2022-04-01T00:00:00.000Z',
-          waterUndertaker: false
-        },
-        multipleUpload: false,
-        journey: 'returns-required',
-        requirements: [{}],
-        startDateOptions: 'licenceStartDate',
-        returnVersionStartDate: '2023-01-01T00:00:00.000Z',
-        licenceVersion: {
-          id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
-          endDate: null,
-          startDate: '2022-04-01T00:00:00.000Z',
-          copyableReturnVersions: [
-            {
-              id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
-              startDate: '2023-01-01T00:00:00.000Z',
-              reason: null,
-              modLogs: []
-            }
-          ]
-        },
-        reason: 'major-change'
-      }
-    })
+  beforeEach(() => {
+    sessionData = {
+      checkPageVisited: false,
+      licence: {
+        id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
+        currentVersionStartDate: '2023-01-01T00:00:00.000Z',
+        endDate: null,
+        licenceRef: '01/ABC',
+        licenceHolder: 'Turbo Kid',
+        returnVersions: [
+          {
+            id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
+            startDate: '2023-01-01T00:00:00.000Z',
+            reason: null,
+            modLogs: []
+          }
+        ],
+        startDate: '2022-04-01T00:00:00.000Z',
+        waterUndertaker: false
+      },
+      multipleUpload: false,
+      journey: 'returns-required',
+      requirements: [{}],
+      startDateOptions: 'licenceStartDate',
+      returnVersionStartDate: '2023-01-01T00:00:00.000Z',
+      licenceVersion: {
+        id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
+        endDate: null,
+        startDate: '2022-04-01T00:00:00.000Z',
+        copyableReturnVersions: [
+          {
+            id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
+            startDate: '2023-01-01T00:00:00.000Z',
+            reason: null,
+            modLogs: []
+          }
+        ]
+      },
+      reason: 'major-change'
+    }
+
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    Sinon.stub(FetchSessionDal, 'go').resolves(session)
+  })
+
+  afterEach(() => {
+    Sinon.restore()
   })
 
   describe('when called', () => {

--- a/test/services/return-versions/setup/frequency-collected.service.test.js
+++ b/test/services/return-versions/setup/frequency-collected.service.test.js
@@ -3,12 +3,16 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
+const Sinon = require('sinon')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const FrequencyCollectedService = require('../../../../app/services/return-versions/setup/frequency-collected.service.js')
@@ -17,33 +21,40 @@ describe('Return Versions Setup - Frequency Collected service', () => {
   const requirementIndex = 0
 
   let session
+  let sessionData
 
-  beforeEach(async () => {
-    session = await SessionHelper.add({
-      data: {
-        checkPageVisited: false,
-        licence: {
-          id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
-          currentVersionStartDate: '2023-01-01T00:00:00.000Z',
-          endDate: null,
-          licenceRef: '01/ABC',
-          licenceHolder: 'Turbo Kid',
-          returnVersions: [
-            {
-              id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
-              startDate: '2023-01-01T00:00:00.000Z',
-              reason: null,
-              modLogs: []
-            }
-          ],
-          startDate: '2022-04-01T00:00:00.000Z'
-        },
-        journey: 'returns-required',
-        requirements: [{}],
-        startDateOptions: 'licenceStartDate',
-        reason: 'major-change'
-      }
-    })
+  beforeEach(() => {
+    sessionData = {
+      checkPageVisited: false,
+      licence: {
+        id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
+        currentVersionStartDate: '2023-01-01T00:00:00.000Z',
+        endDate: null,
+        licenceRef: '01/ABC',
+        licenceHolder: 'Turbo Kid',
+        returnVersions: [
+          {
+            id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
+            startDate: '2023-01-01T00:00:00.000Z',
+            reason: null,
+            modLogs: []
+          }
+        ],
+        startDate: '2022-04-01T00:00:00.000Z'
+      },
+      journey: 'returns-required',
+      requirements: [{}],
+      startDateOptions: 'licenceStartDate',
+      reason: 'major-change'
+    }
+
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    Sinon.stub(FetchSessionDal, 'go').resolves(session)
+  })
+
+  afterEach(() => {
+    Sinon.restore()
   })
 
   describe('when called', () => {

--- a/test/services/return-versions/setup/frequency-reported.service.test.js
+++ b/test/services/return-versions/setup/frequency-reported.service.test.js
@@ -3,12 +3,16 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
+const Sinon = require('sinon')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const FrequencyReportedService = require('../../../../app/services/return-versions/setup/frequency-reported.service.js')
@@ -17,33 +21,39 @@ describe('Return Versions Setup - Frequency Reported service', () => {
   const requirementIndex = 0
 
   let session
+  let sessionData
+  beforeEach(() => {
+    sessionData = {
+      checkPageVisited: false,
+      licence: {
+        id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
+        currentVersionStartDate: '2023-01-01T00:00:00.000Z',
+        endDate: null,
+        licenceRef: '01/ABC',
+        licenceHolder: 'Turbo Kid',
+        returnVersions: [
+          {
+            id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
+            startDate: '2023-01-01T00:00:00.000Z',
+            reason: null,
+            modLogs: []
+          }
+        ],
+        startDate: '2022-04-01T00:00:00.000Z'
+      },
+      journey: 'returns-required',
+      requirements: [{}],
+      startDateOptions: 'licenceStartDate',
+      reason: 'major-change'
+    }
 
-  beforeEach(async () => {
-    session = await SessionHelper.add({
-      data: {
-        checkPageVisited: false,
-        licence: {
-          id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
-          currentVersionStartDate: '2023-01-01T00:00:00.000Z',
-          endDate: null,
-          licenceRef: '01/ABC',
-          licenceHolder: 'Turbo Kid',
-          returnVersions: [
-            {
-              id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
-              startDate: '2023-01-01T00:00:00.000Z',
-              reason: null,
-              modLogs: []
-            }
-          ],
-          startDate: '2022-04-01T00:00:00.000Z'
-        },
-        journey: 'returns-required',
-        requirements: [{}],
-        startDateOptions: 'licenceStartDate',
-        reason: 'major-change'
-      }
-    })
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    Sinon.stub(FetchSessionDal, 'go').resolves(session)
+  })
+
+  afterEach(() => {
+    Sinon.restore()
   })
 
   describe('when called', () => {

--- a/test/services/return-versions/setup/method/method.service.test.js
+++ b/test/services/return-versions/setup/method/method.service.test.js
@@ -3,61 +3,72 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
+const Sinon = require('sinon')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const SessionHelper = require('../../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const MethodService = require('../../../../../app/services/return-versions/setup/method/method.service.js')
 
 describe('Return Versions - Setup - Method service', () => {
   let session
+  let sessionData
 
-  beforeEach(async () => {
-    session = await SessionHelper.add({
-      data: {
-        checkPageVisited: false,
-        licence: {
-          id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
-          currentVersionStartDate: '2023-01-01T00:00:00.000Z',
-          endDate: null,
-          licenceRef: '01/ABC',
-          licenceHolder: 'Turbo Kid',
-          returnVersions: [
-            {
-              id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
-              startDate: '2023-01-01T00:00:00.000Z',
-              reason: null,
-              modLogs: []
-            }
-          ],
-          startDate: '2022-04-01T00:00:00.000Z',
-          waterUndertaker: false
-        },
-        multipleUpload: false,
-        journey: 'returns-required',
-        requirements: [{}],
-        startDateOptions: 'licenceStartDate',
-        returnVersionStartDate: '2023-01-01T00:00:00.000Z',
-        licenceVersion: {
-          id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
-          endDate: null,
-          startDate: '2022-04-01T00:00:00.000Z',
-          copyableReturnVersions: [
-            {
-              id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
-              startDate: '2023-01-01T00:00:00.000Z',
-              reason: null,
-              modLogs: []
-            }
-          ]
-        },
-        reason: 'major-change'
-      }
-    })
+  beforeEach(() => {
+    sessionData = {
+      checkPageVisited: false,
+      licence: {
+        id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
+        currentVersionStartDate: '2023-01-01T00:00:00.000Z',
+        endDate: null,
+        licenceRef: '01/ABC',
+        licenceHolder: 'Turbo Kid',
+        returnVersions: [
+          {
+            id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
+            startDate: '2023-01-01T00:00:00.000Z',
+            reason: null,
+            modLogs: []
+          }
+        ],
+        startDate: '2022-04-01T00:00:00.000Z',
+        waterUndertaker: false
+      },
+      multipleUpload: false,
+      journey: 'returns-required',
+      requirements: [{}],
+      startDateOptions: 'licenceStartDate',
+      returnVersionStartDate: '2023-01-01T00:00:00.000Z',
+      licenceVersion: {
+        id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
+        endDate: null,
+        startDate: '2022-04-01T00:00:00.000Z',
+        copyableReturnVersions: [
+          {
+            id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
+            startDate: '2023-01-01T00:00:00.000Z',
+            reason: null,
+            modLogs: []
+          }
+        ]
+      },
+      reason: 'major-change'
+    }
+
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    Sinon.stub(FetchSessionDal, 'go').resolves(session)
+  })
+
+  afterEach(() => {
+    Sinon.restore()
   })
 
   describe('when called', () => {

--- a/test/services/return-versions/setup/method/submit-method.service.test.js
+++ b/test/services/return-versions/setup/method/submit-method.service.test.js
@@ -9,9 +9,10 @@ const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const SessionHelper = require('../../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../../support/stubs/session.stub.js')
 
 // Things we need to stub
+const FetchSessionDal = require('../../../../../app/dal/fetch-session.dal.js')
 const GenerateFromAbstractionDataService = require('../../../../../app/services/return-versions/setup/method/generate-from-abstraction-data.service.js')
 
 // Thing under test
@@ -20,49 +21,52 @@ const SubmitMethodService = require('../../../../../app/services/return-versions
 describe('Return Versions - Setup - Submit Method service', () => {
   let payload
   let session
+  let sessionData
 
-  beforeEach(async () => {
-    session = await SessionHelper.add({
-      data: {
-        checkPageVisited: false,
-        licence: {
-          id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
-          currentVersionStartDate: '2023-01-01T00:00:00.000Z',
-          endDate: null,
-          licenceRef: '01/ABC',
-          licenceHolder: 'Turbo Kid',
-          returnVersions: [
-            {
-              id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
-              startDate: '2023-01-01T00:00:00.000Z',
-              reason: null,
-              modLogs: []
-            }
-          ],
-          startDate: '2022-04-01T00:00:00.000Z',
-          waterUndertaker: false
-        },
-        multipleUpload: false,
-        journey: 'returns-required',
-        requirements: [{}],
-        startDateOptions: 'licenceStartDate',
-        returnVersionStartDate: '2023-01-01T00:00:00.000Z',
-        licenceVersion: {
-          id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
-          endDate: null,
-          startDate: '2022-04-01T00:00:00.000Z',
-          copyableReturnVersions: [
-            {
-              id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
-              startDate: '2023-01-01T00:00:00.000Z',
-              reason: null,
-              modLogs: []
-            }
-          ]
-        },
-        reason: 'major-change'
-      }
-    })
+  beforeEach(() => {
+    sessionData = {
+      checkPageVisited: false,
+      licence: {
+        id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
+        currentVersionStartDate: '2023-01-01T00:00:00.000Z',
+        endDate: null,
+        licenceRef: '01/ABC',
+        licenceHolder: 'Turbo Kid',
+        returnVersions: [
+          {
+            id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
+            startDate: '2023-01-01T00:00:00.000Z',
+            reason: null,
+            modLogs: []
+          }
+        ],
+        startDate: '2022-04-01T00:00:00.000Z',
+        waterUndertaker: false
+      },
+      multipleUpload: false,
+      journey: 'returns-required',
+      requirements: [{}],
+      startDateOptions: 'licenceStartDate',
+      returnVersionStartDate: '2023-01-01T00:00:00.000Z',
+      licenceVersion: {
+        id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
+        endDate: null,
+        startDate: '2022-04-01T00:00:00.000Z',
+        copyableReturnVersions: [
+          {
+            id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
+            startDate: '2023-01-01T00:00:00.000Z',
+            reason: null,
+            modLogs: []
+          }
+        ]
+      },
+      reason: 'major-change'
+    }
+
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    Sinon.stub(FetchSessionDal, 'go').resolves(session)
   })
 
   afterEach(() => {
@@ -82,9 +86,8 @@ describe('Return Versions - Setup - Submit Method service', () => {
       it('saves the submitted value', async () => {
         await SubmitMethodService.go(session.id, payload)
 
-        const refreshedSession = await session.$query()
-
-        expect(refreshedSession.method).to.equal('useAbstractionData')
+        expect(session.method).to.equal('useAbstractionData')
+        expect(session.$update.called).to.be.true()
       })
 
       describe('and the user has selected to use abstraction data', () => {
@@ -97,9 +100,8 @@ describe('Return Versions - Setup - Submit Method service', () => {
         it('returns the route to check page', async () => {
           await SubmitMethodService.go(session.id, payload)
 
-          const refreshedSession = await session.$query()
-
-          expect(refreshedSession.requirements).to.equal(_generatedReturnRequirements())
+          expect(session.requirements).to.equal(_generatedReturnRequirements())
+          expect(session.$update.called).to.be.true()
         })
       })
 

--- a/test/services/return-versions/setup/no-returns-required.service.test.js
+++ b/test/services/return-versions/setup/no-returns-required.service.test.js
@@ -3,44 +3,55 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
+const Sinon = require('sinon')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const NoReturnsRequiredService = require('../../../../app/services/return-versions/setup/no-returns-required.service.js')
 
 describe('Return Versions Setup - No Returns Required service', () => {
   let session
+  let sessionData
 
-  beforeEach(async () => {
-    session = await SessionHelper.add({
-      data: {
-        checkPageVisited: false,
-        licence: {
-          id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
-          currentVersionStartDate: '2023-01-01T00:00:00.000Z',
-          endDate: null,
-          licenceRef: '01/ABC',
-          licenceHolder: 'Turbo Kid',
-          returnVersions: [
-            {
-              id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
-              startDate: '2023-01-01T00:00:00.000Z',
-              reason: null,
-              modLogs: []
-            }
-          ],
-          startDate: '2022-04-01T00:00:00.000Z'
-        },
-        journey: 'no-returns-required',
-        requirements: [{}],
-        startDateOptions: 'licenceStartDate'
-      }
-    })
+  beforeEach(() => {
+    sessionData = {
+      checkPageVisited: false,
+      licence: {
+        id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
+        currentVersionStartDate: '2023-01-01T00:00:00.000Z',
+        endDate: null,
+        licenceRef: '01/ABC',
+        licenceHolder: 'Turbo Kid',
+        returnVersions: [
+          {
+            id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
+            startDate: '2023-01-01T00:00:00.000Z',
+            reason: null,
+            modLogs: []
+          }
+        ],
+        startDate: '2022-04-01T00:00:00.000Z'
+      },
+      journey: 'no-returns-required',
+      requirements: [{}],
+      startDateOptions: 'licenceStartDate'
+    }
+
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    Sinon.stub(FetchSessionDal, 'go').resolves(session)
+  })
+
+  afterEach(() => {
+    Sinon.restore()
   })
 
   describe('when called', () => {

--- a/test/services/return-versions/setup/note.service.test.js
+++ b/test/services/return-versions/setup/note.service.test.js
@@ -3,45 +3,56 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
+const Sinon = require('sinon')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const NoteService = require('../../../../app/services/return-versions/setup/note.service.js')
 
 describe('Return Versions Setup - Note service', () => {
   let session
+  let sessionData
 
-  beforeEach(async () => {
-    session = await SessionHelper.add({
-      data: {
-        checkPageVisited: false,
-        licence: {
-          id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
-          currentVersionStartDate: '2023-01-01T00:00:00.000Z',
-          endDate: null,
-          licenceRef: '01/ABC',
-          licenceHolder: 'Turbo Kid',
-          returnVersions: [
-            {
-              id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
-              startDate: '2023-01-01T00:00:00.000Z',
-              reason: null,
-              modLogs: []
-            }
-          ],
-          startDate: '2022-04-01T00:00:00.000Z'
-        },
-        journey: 'returns-required',
-        requirements: [{}],
-        startDateOptions: 'licenceStartDate',
-        reason: 'major-change'
-      }
-    })
+  beforeEach(() => {
+    sessionData = {
+      checkPageVisited: false,
+      licence: {
+        id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
+        currentVersionStartDate: '2023-01-01T00:00:00.000Z',
+        endDate: null,
+        licenceRef: '01/ABC',
+        licenceHolder: 'Turbo Kid',
+        returnVersions: [
+          {
+            id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
+            startDate: '2023-01-01T00:00:00.000Z',
+            reason: null,
+            modLogs: []
+          }
+        ],
+        startDate: '2022-04-01T00:00:00.000Z'
+      },
+      journey: 'returns-required',
+      requirements: [{}],
+      startDateOptions: 'licenceStartDate',
+      reason: 'major-change'
+    }
+
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    Sinon.stub(FetchSessionDal, 'go').resolves(session)
+  })
+
+  afterEach(() => {
+    Sinon.restore()
   })
 
   describe('when called', () => {

--- a/test/services/return-versions/setup/points.service.test.js
+++ b/test/services/return-versions/setup/points.service.test.js
@@ -10,7 +10,10 @@ const { expect } = Code
 
 // Test helpers
 const PointModel = require('../../../../app/models/point.model.js')
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Things we need to stub
 const FetchPointsService = require('../../../../app/services/return-versions/setup/fetch-points.service.js')
@@ -22,49 +25,52 @@ describe('Return Versions - Setup - Points service', () => {
   const requirementIndex = 0
 
   let session
+  let sessionData
 
-  beforeEach(async () => {
-    session = await SessionHelper.add({
-      data: {
-        checkPageVisited: false,
-        licence: {
-          id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
-          currentVersionStartDate: '2023-01-01T00:00:00.000Z',
-          endDate: null,
-          licenceRef: '01/ABC',
-          licenceHolder: 'Turbo Kid',
-          returnVersions: [
-            {
-              id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
-              startDate: '2023-01-01T00:00:00.000Z',
-              reason: null,
-              modLogs: []
-            }
-          ],
-          startDate: '2022-04-01T00:00:00.000Z',
-          waterUndertaker: false
-        },
-        multipleUpload: false,
-        journey: 'returns-required',
-        requirements: [{}],
-        startDateOptions: 'licenceStartDate',
-        returnVersionStartDate: '2023-01-01T00:00:00.000Z',
-        licenceVersion: {
-          id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
-          endDate: null,
-          startDate: '2022-04-01T00:00:00.000Z',
-          copyableReturnVersions: [
-            {
-              id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
-              startDate: '2023-01-01T00:00:00.000Z',
-              reason: null,
-              modLogs: []
-            }
-          ]
-        },
-        reason: 'major-change'
-      }
-    })
+  beforeEach(() => {
+    sessionData = {
+      checkPageVisited: false,
+      licence: {
+        id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
+        currentVersionStartDate: '2023-01-01T00:00:00.000Z',
+        endDate: null,
+        licenceRef: '01/ABC',
+        licenceHolder: 'Turbo Kid',
+        returnVersions: [
+          {
+            id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
+            startDate: '2023-01-01T00:00:00.000Z',
+            reason: null,
+            modLogs: []
+          }
+        ],
+        startDate: '2022-04-01T00:00:00.000Z',
+        waterUndertaker: false
+      },
+      multipleUpload: false,
+      journey: 'returns-required',
+      requirements: [{}],
+      startDateOptions: 'licenceStartDate',
+      returnVersionStartDate: '2023-01-01T00:00:00.000Z',
+      licenceVersion: {
+        id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
+        endDate: null,
+        startDate: '2022-04-01T00:00:00.000Z',
+        copyableReturnVersions: [
+          {
+            id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
+            startDate: '2023-01-01T00:00:00.000Z',
+            reason: null,
+            modLogs: []
+          }
+        ]
+      },
+      reason: 'major-change'
+    }
+
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    Sinon.stub(FetchSessionDal, 'go').resolves(session)
 
     const point = PointModel.fromJson({
       description: 'RIVER MEDWAY AT YALDING INTAKE',

--- a/test/services/return-versions/setup/purpose.service.test.js
+++ b/test/services/return-versions/setup/purpose.service.test.js
@@ -9,7 +9,10 @@ const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Things we need to stub
 const FetchPurposesService = require('../../../../app/services/return-versions/setup/fetch-purposes.service.js')
@@ -21,54 +24,57 @@ describe('Return Versions - Setup - Purpose service', () => {
   const requirementIndex = 0
 
   let session
+  let sessionData
 
-  beforeEach(async () => {
+  beforeEach(() => {
     Sinon.stub(FetchPurposesService, 'go').resolves([
       { id: '14794d57-1acf-4c91-8b48-4b1ec68bfd6f', description: 'Heat Pump' },
       { id: '49088608-ee9f-491a-8070-6831240945ac', description: 'Horticultural Watering' }
     ])
 
-    session = await SessionHelper.add({
-      data: {
-        checkPageVisited: false,
-        licence: {
-          id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
-          currentVersionStartDate: '2023-01-01T00:00:00.000Z',
-          endDate: null,
-          licenceRef: '01/ABC',
-          licenceHolder: 'Turbo Kid',
-          returnVersions: [
-            {
-              id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
-              startDate: '2023-01-01T00:00:00.000Z',
-              reason: null,
-              modLogs: []
-            }
-          ],
-          startDate: '2022-04-01T00:00:00.000Z',
-          waterUndertaker: false
-        },
-        multipleUpload: false,
-        journey: 'returns-required',
-        requirements: [{}],
-        startDateOptions: 'licenceStartDate',
-        returnVersionStartDate: '2023-01-01T00:00:00.000Z',
-        licenceVersion: {
-          id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
-          endDate: null,
-          startDate: '2022-04-01T00:00:00.000Z',
-          copyableReturnVersions: [
-            {
-              id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
-              startDate: '2023-01-01T00:00:00.000Z',
-              reason: null,
-              modLogs: []
-            }
-          ]
-        },
-        reason: 'major-change'
-      }
-    })
+    sessionData = {
+      checkPageVisited: false,
+      licence: {
+        id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
+        currentVersionStartDate: '2023-01-01T00:00:00.000Z',
+        endDate: null,
+        licenceRef: '01/ABC',
+        licenceHolder: 'Turbo Kid',
+        returnVersions: [
+          {
+            id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
+            startDate: '2023-01-01T00:00:00.000Z',
+            reason: null,
+            modLogs: []
+          }
+        ],
+        startDate: '2022-04-01T00:00:00.000Z',
+        waterUndertaker: false
+      },
+      multipleUpload: false,
+      journey: 'returns-required',
+      requirements: [{}],
+      startDateOptions: 'licenceStartDate',
+      returnVersionStartDate: '2023-01-01T00:00:00.000Z',
+      licenceVersion: {
+        id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
+        endDate: null,
+        startDate: '2022-04-01T00:00:00.000Z',
+        copyableReturnVersions: [
+          {
+            id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
+            startDate: '2023-01-01T00:00:00.000Z',
+            reason: null,
+            modLogs: []
+          }
+        ]
+      },
+      reason: 'major-change'
+    }
+
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    Sinon.stub(FetchSessionDal, 'go').resolves(session)
   })
 
   afterEach(() => {

--- a/test/services/return-versions/setup/reason.service.test.js
+++ b/test/services/return-versions/setup/reason.service.test.js
@@ -3,44 +3,54 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
+const Sinon = require('sinon')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const ReasonService = require('../../../../app/services/return-versions/setup/reason.service.js')
 
 describe('Return Versions Setup - Reason service', () => {
   let session
+  let sessionData
+  beforeEach(() => {
+    sessionData = {
+      checkPageVisited: false,
+      licence: {
+        id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
+        currentVersionStartDate: '2023-01-01T00:00:00.000Z',
+        endDate: null,
+        licenceRef: '01/ABC',
+        licenceHolder: 'Turbo Kid',
+        returnVersions: [
+          {
+            id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
+            startDate: '2023-01-01T00:00:00.000Z',
+            reason: null,
+            modLogs: []
+          }
+        ],
+        startDate: '2022-04-01T00:00:00.000Z'
+      },
+      journey: 'returns-required',
+      requirements: [{}],
+      startDateOptions: 'licenceStartDate'
+    }
 
-  beforeEach(async () => {
-    session = await SessionHelper.add({
-      data: {
-        checkPageVisited: false,
-        licence: {
-          id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
-          currentVersionStartDate: '2023-01-01T00:00:00.000Z',
-          endDate: null,
-          licenceRef: '01/ABC',
-          licenceHolder: 'Turbo Kid',
-          returnVersions: [
-            {
-              id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
-              startDate: '2023-01-01T00:00:00.000Z',
-              reason: null,
-              modLogs: []
-            }
-          ],
-          startDate: '2022-04-01T00:00:00.000Z'
-        },
-        journey: 'returns-required',
-        requirements: [{}],
-        startDateOptions: 'licenceStartDate'
-      }
-    })
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    Sinon.stub(FetchSessionDal, 'go').resolves(session)
+  })
+
+  afterEach(() => {
+    Sinon.restore()
   })
 
   describe('when called', () => {

--- a/test/services/return-versions/setup/remove.service.test.js
+++ b/test/services/return-versions/setup/remove.service.test.js
@@ -3,13 +3,16 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
+const Sinon = require('sinon')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
-const { generateUUID } = require('../../../../app/lib/general.lib.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const RemoveService = require('../../../../app/services/return-versions/setup/remove.service.js')
@@ -18,49 +21,55 @@ describe('Return Versions Setup - Remove service', () => {
   const requirementIndex = 0
 
   let session
+  let sessionData
 
-  beforeEach(async () => {
-    session = await SessionHelper.add({
-      id: generateUUID(),
-      data: {
-        checkPageVisited: false,
-        licence: {
-          id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
-          currentVersionStartDate: '2023-01-01T00:00:00.000Z',
-          endDate: null,
-          licenceRef: '01/ABC',
-          licenceHolder: 'Turbo Kid',
-          returnVersions: [
-            {
-              id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
-              startDate: '2023-01-01T00:00:00.000Z',
-              reason: null,
-              modLogs: []
-            }
-          ],
-          startDate: '2022-04-01T00:00:00.000Z'
-        },
-        journey: 'returns-required',
-        requirements: [
+  beforeEach(() => {
+    sessionData = {
+      checkPageVisited: false,
+      licence: {
+        id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
+        currentVersionStartDate: '2023-01-01T00:00:00.000Z',
+        endDate: null,
+        licenceRef: '01/ABC',
+        licenceHolder: 'Turbo Kid',
+        returnVersions: [
           {
-            points: ['At National Grid Reference TQ 6520 5937 (POINT A, ADDINGTON SANDPITS)'],
-            purposes: [{ alias: '', description: 'Mineral Washing', id: '3a865331-d2f3-4acc-ac85-527fa2b0d2dd' }],
-            returnsCycle: 'winter-and-all-year',
-            siteDescription: 'Bore hole in rear field',
-            abstractionPeriod: {
-              abstractionPeriodEndDay: '31',
-              abstractionPeriodEndMonth: '10',
-              abstractionPeriodStartDay: '01',
-              abstractionPeriodStartMonth: '04'
-            },
-            frequencyReported: 'month',
-            frequencyCollected: 'month',
-            agreementsExceptions: ['none']
+            id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
+            startDate: '2023-01-01T00:00:00.000Z',
+            reason: null,
+            modLogs: []
           }
         ],
-        startDateOptions: 'licenceStartDate'
-      }
-    })
+        startDate: '2022-04-01T00:00:00.000Z'
+      },
+      journey: 'returns-required',
+      requirements: [
+        {
+          points: ['At National Grid Reference TQ 6520 5937 (POINT A, ADDINGTON SANDPITS)'],
+          purposes: [{ alias: '', description: 'Mineral Washing', id: '3a865331-d2f3-4acc-ac85-527fa2b0d2dd' }],
+          returnsCycle: 'winter-and-all-year',
+          siteDescription: 'Bore hole in rear field',
+          abstractionPeriod: {
+            abstractionPeriodEndDay: '31',
+            abstractionPeriodEndMonth: '10',
+            abstractionPeriodStartDay: '01',
+            abstractionPeriodStartMonth: '04'
+          },
+          frequencyReported: 'month',
+          frequencyCollected: 'month',
+          agreementsExceptions: ['none']
+        }
+      ],
+      startDateOptions: 'licenceStartDate'
+    }
+
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    Sinon.stub(FetchSessionDal, 'go').resolves(session)
+  })
+
+  afterEach(() => {
+    Sinon.restore()
   })
 
   describe('when called', () => {

--- a/test/services/return-versions/setup/returns-cycle.service.test.js
+++ b/test/services/return-versions/setup/returns-cycle.service.test.js
@@ -3,12 +3,16 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
+const Sinon = require('sinon')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const ReturnsCycleService = require('../../../../app/services/return-versions/setup/returns-cycle.service.js')
@@ -17,33 +21,40 @@ describe('Return Versions Setup - Returns Cycle service', () => {
   const requirementIndex = 0
 
   let session
+  let sessionData
 
-  beforeEach(async () => {
-    session = await SessionHelper.add({
-      data: {
-        checkPageVisited: false,
-        licence: {
-          id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
-          currentVersionStartDate: '2023-01-01T00:00:00.000Z',
-          endDate: null,
-          licenceRef: '01/ABC',
-          licenceHolder: 'Turbo Kid',
-          returnVersions: [
-            {
-              id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
-              startDate: '2023-01-01T00:00:00.000Z',
-              reason: null,
-              modLogs: []
-            }
-          ],
-          startDate: '2022-04-01T00:00:00.000Z'
-        },
-        journey: 'returns-required',
-        requirements: [{}],
-        startDateOptions: 'licenceStartDate',
-        reason: 'major-change'
-      }
-    })
+  beforeEach(() => {
+    sessionData = {
+      checkPageVisited: false,
+      licence: {
+        id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
+        currentVersionStartDate: '2023-01-01T00:00:00.000Z',
+        endDate: null,
+        licenceRef: '01/ABC',
+        licenceHolder: 'Turbo Kid',
+        returnVersions: [
+          {
+            id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
+            startDate: '2023-01-01T00:00:00.000Z',
+            reason: null,
+            modLogs: []
+          }
+        ],
+        startDate: '2022-04-01T00:00:00.000Z'
+      },
+      journey: 'returns-required',
+      requirements: [{}],
+      startDateOptions: 'licenceStartDate',
+      reason: 'major-change'
+    }
+
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    Sinon.stub(FetchSessionDal, 'go').resolves(session)
+  })
+
+  afterEach(() => {
+    Sinon.restore()
   })
 
   describe('when called', () => {

--- a/test/services/return-versions/setup/site-description.service.test.js
+++ b/test/services/return-versions/setup/site-description.service.test.js
@@ -3,12 +3,16 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
+const Sinon = require('sinon')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Things under test
 const SiteDescriptionService = require('../../../../app/services/return-versions/setup/site-description.service.js')
@@ -17,33 +21,40 @@ describe('Return Versions Setup - Site Description service', () => {
   const requirementIndex = 0
 
   let session
+  let sessionData
 
-  beforeEach(async () => {
-    session = await SessionHelper.add({
-      data: {
-        checkPageVisited: false,
-        licence: {
-          id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
-          currentVersionStartDate: '2023-01-01T00:00:00.000Z',
-          endDate: null,
-          licenceRef: '01/ABC',
-          licenceHolder: 'Turbo Kid',
-          returnVersions: [
-            {
-              id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
-              startDate: '2023-01-01T00:00:00.000Z',
-              reason: null,
-              modLogs: []
-            }
-          ],
-          startDate: '2022-04-01T00:00:00.000Z'
-        },
-        journey: 'returns-required',
-        requirements: [{}],
-        startDateOptions: 'licenceStartDate',
-        reason: 'major-change'
-      }
-    })
+  beforeEach(() => {
+    sessionData = {
+      checkPageVisited: false,
+      licence: {
+        id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
+        currentVersionStartDate: '2023-01-01T00:00:00.000Z',
+        endDate: null,
+        licenceRef: '01/ABC',
+        licenceHolder: 'Turbo Kid',
+        returnVersions: [
+          {
+            id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
+            startDate: '2023-01-01T00:00:00.000Z',
+            reason: null,
+            modLogs: []
+          }
+        ],
+        startDate: '2022-04-01T00:00:00.000Z'
+      },
+      journey: 'returns-required',
+      requirements: [{}],
+      startDateOptions: 'licenceStartDate',
+      reason: 'major-change'
+    }
+
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    Sinon.stub(FetchSessionDal, 'go').resolves(session)
+  })
+
+  afterEach(() => {
+    Sinon.restore()
   })
 
   describe('when called', () => {

--- a/test/services/return-versions/setup/start-date.service.test.js
+++ b/test/services/return-versions/setup/start-date.service.test.js
@@ -3,43 +3,53 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
+const Sinon = require('sinon')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const StartDateService = require('../../../../app/services/return-versions/setup/start-date.service.js')
 
 describe('Return Versions Setup - Start Date service', () => {
   let session
+  let sessionData
+  beforeEach(() => {
+    sessionData = {
+      checkPageVisited: false,
+      licence: {
+        id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
+        currentVersionStartDate: '2023-01-01T00:00:00.000Z',
+        endDate: null,
+        licenceRef: '01/ABC',
+        licenceHolder: 'Turbo Kid',
+        returnVersions: [
+          {
+            id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
+            startDate: '2023-01-01T00:00:00.000Z',
+            reason: null,
+            modLogs: []
+          }
+        ],
+        startDate: '2022-04-01T00:00:00.000Z'
+      },
+      journey: 'returns-required',
+      requirements: [{}]
+    }
 
-  beforeEach(async () => {
-    session = await SessionHelper.add({
-      data: {
-        checkPageVisited: false,
-        licence: {
-          id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
-          currentVersionStartDate: '2023-01-01T00:00:00.000Z',
-          endDate: null,
-          licenceRef: '01/ABC',
-          licenceHolder: 'Turbo Kid',
-          returnVersions: [
-            {
-              id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
-              startDate: '2023-01-01T00:00:00.000Z',
-              reason: null,
-              modLogs: []
-            }
-          ],
-          startDate: '2022-04-01T00:00:00.000Z'
-        },
-        journey: 'returns-required',
-        requirements: [{}]
-      }
-    })
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    Sinon.stub(FetchSessionDal, 'go').resolves(session)
+  })
+
+  afterEach(() => {
+    Sinon.restore()
   })
 
   describe('when called', () => {

--- a/test/services/return-versions/setup/submit-additional-submission-options.service.test.js
+++ b/test/services/return-versions/setup/submit-additional-submission-options.service.test.js
@@ -9,7 +9,10 @@ const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const SubmitAdditionalSubmissionOptionsService = require('../../../../app/services/return-versions/setup/submit-additional-submission-options.service.js')
@@ -17,22 +20,25 @@ const SubmitAdditionalSubmissionOptionsService = require('../../../../app/servic
 describe('Return Versions Setup - Submit Additional Submission Options service', () => {
   let payload
   let session
+  let sessionData
   let yarStub
 
-  beforeEach(async () => {
-    session = await SessionHelper.add({
-      data: {
-        checkPageVisited: false,
-        journey: 'returns-required',
-        licence: {
-          id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
-          endDate: null,
-          licenceRef: '01/ABC',
-          licenceHolder: 'Turbo Kid'
-        },
-        multipleUpload: false
-      }
-    })
+  beforeEach(() => {
+    sessionData = {
+      checkPageVisited: false,
+      journey: 'returns-required',
+      licence: {
+        id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
+        endDate: null,
+        licenceRef: '01/ABC',
+        licenceHolder: 'Turbo Kid'
+      },
+      multipleUpload: false
+    }
+
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    Sinon.stub(FetchSessionDal, 'go').resolves(session)
 
     yarStub = { flash: Sinon.stub() }
   })
@@ -52,9 +58,8 @@ describe('Return Versions Setup - Submit Additional Submission Options service',
       it('saves the submitted value', async () => {
         await SubmitAdditionalSubmissionOptionsService.go(session.id, payload, yarStub)
 
-        const refreshedSession = await session.$query()
-
-        expect(refreshedSession.noAdditionalOptions).to.be.true()
+        expect(session.noAdditionalOptions).to.be.true()
+        expect(session.$update.called).to.be.true()
       })
 
       it('sets the notification message to "Updated"', async () => {
@@ -80,9 +85,7 @@ describe('Return Versions Setup - Submit Additional Submission Options service',
       it('saves the submitted value', async () => {
         await SubmitAdditionalSubmissionOptionsService.go(session.id, payload, yarStub)
 
-        const refreshedSession = await session.$query()
-
-        expect(refreshedSession.multipleUpload).to.be.true()
+        expect(session.multipleUpload).to.be.true()
       })
 
       it('sets the notification message to "Updated"', async () => {
@@ -108,9 +111,7 @@ describe('Return Versions Setup - Submit Additional Submission Options service',
       it('saves the submitted value', async () => {
         await SubmitAdditionalSubmissionOptionsService.go(session.id, payload, yarStub)
 
-        const refreshedSession = await session.$query()
-
-        expect(refreshedSession.quarterlyReturns).to.be.true()
+        expect(session.quarterlyReturns).to.be.true()
       })
 
       it('sets the notification message to "Updated"', async () => {

--- a/test/services/return-versions/setup/submit-note.service.test.js
+++ b/test/services/return-versions/setup/submit-note.service.test.js
@@ -9,7 +9,10 @@ const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const SubmitNoteService = require('../../../../app/services/return-versions/setup/submit-note.service.js')
@@ -17,36 +20,40 @@ const SubmitNoteService = require('../../../../app/services/return-versions/setu
 describe('Return Versions Setup - Submit Note service', () => {
   const user = { username: 'carol.shaw@atari.com' }
 
+  let fetchSessionStub
   let payload
   let session
+  let sessionData
   let yarStub
 
-  beforeEach(async () => {
-    session = await SessionHelper.add({
-      data: {
-        checkPageVisited: false,
-        licence: {
-          id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
-          currentVersionStartDate: '2023-01-01T00:00:00.000Z',
-          endDate: null,
-          licenceRef: '01/ABC',
-          licenceHolder: 'Turbo Kid',
-          returnVersions: [
-            {
-              id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
-              startDate: '2023-01-01T00:00:00.000Z',
-              reason: null,
-              modLogs: []
-            }
-          ],
-          startDate: '2022-04-01T00:00:00.000Z'
-        },
-        journey: 'returns-required',
-        requirements: [{}],
-        startDateOptions: 'licenceStartDate',
-        reason: 'major-change'
-      }
-    })
+  beforeEach(() => {
+    sessionData = {
+      checkPageVisited: false,
+      licence: {
+        id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
+        currentVersionStartDate: '2023-01-01T00:00:00.000Z',
+        endDate: null,
+        licenceRef: '01/ABC',
+        licenceHolder: 'Turbo Kid',
+        returnVersions: [
+          {
+            id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
+            startDate: '2023-01-01T00:00:00.000Z',
+            reason: null,
+            modLogs: []
+          }
+        ],
+        startDate: '2022-04-01T00:00:00.000Z'
+      },
+      journey: 'returns-required',
+      requirements: [{}],
+      startDateOptions: 'licenceStartDate',
+      reason: 'major-change'
+    }
+
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    fetchSessionStub = Sinon.stub(FetchSessionDal, 'go').resolves(session)
 
     yarStub = { flash: Sinon.stub() }
   })
@@ -67,12 +74,11 @@ describe('Return Versions Setup - Submit Note service', () => {
         it('saves the submitted value', async () => {
           await SubmitNoteService.go(session.id, payload, user, yarStub)
 
-          const refreshedSession = await session.$query()
-
-          expect(refreshedSession.note).to.equal({
+          expect(session.note).to.equal({
             content: 'A new note related to return requirement',
             userEmail: 'carol.shaw@atari.com'
           })
+          expect(session.$update.called).to.be.true()
         })
 
         it('returns the correct details the controller needs to redirect the journey', async () => {
@@ -92,28 +98,30 @@ describe('Return Versions Setup - Submit Note service', () => {
       })
 
       describe('that is an updated note', () => {
-        beforeEach(async () => {
-          await session.$query().patch({
-            data: {
-              checkPageVisited: false,
-              licence: {
-                id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
-                currentVersionStartDate: '2023-01-01T00:00:00.000Z',
-                endDate: null,
-                licenceRef: '01/ABC',
-                licenceHolder: 'Turbo Kid',
-                startDate: '2022-04-01T00:00:00.000Z'
-              },
-              journey: 'returns-required',
-              requirements: [{}],
-              startDateOptions: 'licenceStartDate',
-              reason: 'major-change',
-              note: {
-                content: 'A old note related to return requirement',
-                userEmail: 'carol.shaw@atari.com'
-              }
+        beforeEach(() => {
+          sessionData = {
+            checkPageVisited: false,
+            licence: {
+              id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
+              currentVersionStartDate: '2023-01-01T00:00:00.000Z',
+              endDate: null,
+              licenceRef: '01/ABC',
+              licenceHolder: 'Turbo Kid',
+              startDate: '2022-04-01T00:00:00.000Z'
+            },
+            journey: 'returns-required',
+            requirements: [{}],
+            startDateOptions: 'licenceStartDate',
+            reason: 'major-change',
+            note: {
+              content: 'A old note related to return requirement',
+              userEmail: 'carol.shaw@atari.com'
             }
-          })
+          }
+
+          session = SessionModelStub.build(Sinon, sessionData)
+
+          fetchSessionStub.resolves(session)
 
           payload = {
             note: 'An updated note related to return requirement'
@@ -123,12 +131,11 @@ describe('Return Versions Setup - Submit Note service', () => {
         it('saves the submitted value', async () => {
           await SubmitNoteService.go(session.id, payload, user, yarStub)
 
-          const refreshedSession = await session.$query()
-
-          expect(refreshedSession.note).to.equal({
+          expect(session.note).to.equal({
             content: 'An updated note related to return requirement',
             userEmail: 'carol.shaw@atari.com'
           })
+          expect(session.$update.called).to.be.true()
         })
 
         it('returns the journey to redirect the page', async () => {

--- a/test/services/return-versions/setup/submit-purpose.service.test.js
+++ b/test/services/return-versions/setup/submit-purpose.service.test.js
@@ -9,10 +9,11 @@ const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
 
 // Things we need to stub
 const FetchPurposesService = require('../../../../app/services/return-versions/setup/fetch-purposes.service.js')
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const SubmitPurposeService = require('../../../../app/services/return-versions/setup/submit-purpose.service.js')
@@ -20,55 +21,56 @@ const SubmitPurposeService = require('../../../../app/services/return-versions/s
 describe('Return Versions - Setup - Submit Purpose service', () => {
   const requirementIndex = 0
 
+  let fetchSessionStub
   let payload
   let session
   let sessionData
   let yarStub
 
-  beforeEach(async () => {
+  beforeEach(() => {
     sessionData = {
-      data: {
-        checkPageVisited: false,
-        licence: {
-          id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
-          currentVersionStartDate: '2023-01-01T00:00:00.000Z',
-          endDate: null,
-          licenceRef: '01/ABC',
-          licenceHolder: 'Turbo Kid',
-          returnVersions: [
-            {
-              id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
-              startDate: '2023-01-01T00:00:00.000Z',
-              reason: null,
-              modLogs: []
-            }
-          ],
-          startDate: '2022-04-01T00:00:00.000Z',
-          waterUndertaker: false
-        },
-        multipleUpload: false,
-        journey: 'returns-required',
-        requirements: [{}],
-        startDateOptions: 'licenceStartDate',
-        returnVersionStartDate: '2023-01-01T00:00:00.000Z',
-        licenceVersion: {
-          id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
-          endDate: null,
-          startDate: '2022-04-01T00:00:00.000Z',
-          copyableReturnVersions: [
-            {
-              id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
-              startDate: '2023-01-01T00:00:00.000Z',
-              reason: null,
-              modLogs: []
-            }
-          ]
-        },
-        reason: 'major-change'
-      }
+      checkPageVisited: false,
+      licence: {
+        id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
+        currentVersionStartDate: '2023-01-01T00:00:00.000Z',
+        endDate: null,
+        licenceRef: '01/ABC',
+        licenceHolder: 'Turbo Kid',
+        returnVersions: [
+          {
+            id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
+            startDate: '2023-01-01T00:00:00.000Z',
+            reason: null,
+            modLogs: []
+          }
+        ],
+        startDate: '2022-04-01T00:00:00.000Z',
+        waterUndertaker: false
+      },
+      multipleUpload: false,
+      journey: 'returns-required',
+      requirements: [{}],
+      startDateOptions: 'licenceStartDate',
+      returnVersionStartDate: '2023-01-01T00:00:00.000Z',
+      licenceVersion: {
+        id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
+        endDate: null,
+        startDate: '2022-04-01T00:00:00.000Z',
+        copyableReturnVersions: [
+          {
+            id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
+            startDate: '2023-01-01T00:00:00.000Z',
+            reason: null,
+            modLogs: []
+          }
+        ]
+      },
+      reason: 'major-change'
     }
 
-    session = await SessionHelper.add(sessionData)
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    fetchSessionStub = Sinon.stub(FetchSessionDal, 'go').resolves(session)
 
     yarStub = { flash: Sinon.stub() }
 
@@ -84,7 +86,7 @@ describe('Return Versions - Setup - Submit Purpose service', () => {
 
   describe('when called', () => {
     describe('with a valid payload', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         payload = {
           purposes: ['14794d57-1acf-4c91-8b48-4b1ec68bfd6f'],
           'alias-14794d57-1acf-4c91-8b48-4b1ec68bfd6f': 'great warm machine'
@@ -94,11 +96,10 @@ describe('Return Versions - Setup - Submit Purpose service', () => {
       it('saves the submitted value', async () => {
         await SubmitPurposeService.go(session.id, requirementIndex, payload, yarStub)
 
-        const refreshedSession = await session.$query()
-
-        expect(refreshedSession.requirements[0].purposes).to.equal([
+        expect(session.requirements[0].purposes).to.equal([
           { alias: 'great warm machine', description: 'Heat Pump', id: '14794d57-1acf-4c91-8b48-4b1ec68bfd6f' }
         ])
+        expect(session.$update.called).to.be.true()
       })
 
       describe('and the page has been not been visited', () => {
@@ -113,7 +114,9 @@ describe('Return Versions - Setup - Submit Purpose service', () => {
 
       describe('and the page has been visited', () => {
         beforeEach(async () => {
-          session = await SessionHelper.add({ data: { ...sessionData.data, checkPageVisited: true } })
+          session = SessionModelStub.build(Sinon, { ...sessionData, checkPageVisited: true })
+
+          fetchSessionStub.resolves(session)
         })
 
         it('returns the correct details the controller needs to redirect the journey to the check page', async () => {
@@ -140,7 +143,7 @@ describe('Return Versions - Setup - Submit Purpose service', () => {
 
     describe('with an invalid payload', () => {
       describe('because it is empty', () => {
-        beforeEach(async () => {
+        beforeEach(() => {
           payload = {}
         })
 
@@ -180,7 +183,7 @@ describe('Return Versions - Setup - Submit Purpose service', () => {
       })
 
       describe('because they entered an alias that is too long', () => {
-        beforeEach(async () => {
+        beforeEach(() => {
           payload = {
             purposes: '14794d57-1acf-4c91-8b48-4b1ec68bfd6f',
             'alias-14794d57-1acf-4c91-8b48-4b1ec68bfd6f':

--- a/test/services/return-versions/setup/submit-remove.service.test.js
+++ b/test/services/return-versions/setup/submit-remove.service.test.js
@@ -24,7 +24,7 @@ describe('Return Versions Setup - Submit Remove service', () => {
   let sessionData
   let yarStub
 
-  beforeEach(async () => {
+  beforeEach(() => {
     sessionData = {
       checkPageVisited: false,
       licence: {

--- a/test/services/return-versions/setup/submit-remove.service.test.js
+++ b/test/services/return-versions/setup/submit-remove.service.test.js
@@ -5,12 +5,14 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
-const { generateUUID } = require('../../../../app/lib/general.lib.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const SubmitRemoveService = require('../../../../app/services/return-versions/setup/submit-remove.service.js')
@@ -19,64 +21,69 @@ describe('Return Versions Setup - Submit Remove service', () => {
   const requirementIndex = 0
 
   let session
+  let sessionData
   let yarStub
 
   beforeEach(async () => {
-    session = await SessionHelper.add({
-      id: generateUUID(),
-      data: {
-        checkPageVisited: false,
-        licence: {
-          id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
-          currentVersionStartDate: '2023-01-01T00:00:00.000Z',
-          endDate: null,
-          licenceRef: '01/ABC',
-          licenceHolder: 'Turbo Kid',
-          returnVersions: [
-            {
-              id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
-              startDate: '2023-01-01T00:00:00.000Z',
-              reason: null,
-              modLogs: []
-            }
-          ],
-          startDate: '2022-04-01T00:00:00.000Z'
-        },
-        journey: 'returns-required',
-        requirements: [
+    sessionData = {
+      checkPageVisited: false,
+      licence: {
+        id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
+        currentVersionStartDate: '2023-01-01T00:00:00.000Z',
+        endDate: null,
+        licenceRef: '01/ABC',
+        licenceHolder: 'Turbo Kid',
+        returnVersions: [
           {
-            points: ['At National Grid Reference TQ 6520 5937 (POINT A, ADDINGTON SANDPITS)'],
-            purposes: [{ alias: '', description: 'Mineral Washing', id: '3a865331-d2f3-4acc-ac85-527fa2b0d2dd' }],
-            returnsCycle: 'winter-and-all-year',
-            siteDescription: 'Bore hole in rear field',
-            abstractionPeriod: {
-              abstractionPeriodEndDay: '31',
-              abstractionPeriodEndMonth: '10',
-              abstractionPeriodStartDay: '01',
-              abstractionPeriodStartMonth: '04'
-            },
-            frequencyReported: 'month',
-            frequencyCollected: 'month',
-            agreementsExceptions: ['none']
+            id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
+            startDate: '2023-01-01T00:00:00.000Z',
+            reason: null,
+            modLogs: []
           }
         ],
-        startDateOptions: 'licenceStartDate',
-        reason: 'major-change'
-      }
-    })
+        startDate: '2022-04-01T00:00:00.000Z'
+      },
+      journey: 'returns-required',
+      requirements: [
+        {
+          points: ['At National Grid Reference TQ 6520 5937 (POINT A, ADDINGTON SANDPITS)'],
+          purposes: [{ alias: '', description: 'Mineral Washing', id: '3a865331-d2f3-4acc-ac85-527fa2b0d2dd' }],
+          returnsCycle: 'winter-and-all-year',
+          siteDescription: 'Bore hole in rear field',
+          abstractionPeriod: {
+            abstractionPeriodEndDay: '31',
+            abstractionPeriodEndMonth: '10',
+            abstractionPeriodStartDay: '01',
+            abstractionPeriodStartMonth: '04'
+          },
+          frequencyReported: 'month',
+          frequencyCollected: 'month',
+          agreementsExceptions: ['none']
+        }
+      ],
+      startDateOptions: 'licenceStartDate',
+      reason: 'major-change'
+    }
+
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    Sinon.stub(FetchSessionDal, 'go').resolves(session)
 
     yarStub = {
       flash: Sinon.stub()
     }
   })
 
+  afterEach(() => {
+    Sinon.restore()
+  })
+
   describe('when a user submits the return requirements to be removed', () => {
     it('deletes the selected requirement from the session data', async () => {
       await SubmitRemoveService.go(session.id, requirementIndex, yarStub)
 
-      const refreshedSession = await session.$query()
-
-      expect(refreshedSession.requirements[requirementIndex]).not.to.exist()
+      expect(session.requirements[requirementIndex]).not.to.exist()
+      expect(session.$update.called).to.be.true()
     })
 
     it('sets the notification message to "Requirements removed"', async () => {

--- a/test/validators/return-versions/setup/additional-submission-options.validator.test.js
+++ b/test/validators/return-versions/setup/additional-submission-options.validator.test.js
@@ -51,7 +51,7 @@ describe('Return Versions Setup - Additional Submission Options validator', () =
 
   describe('when quarterly return submission is selected but requirements have a return cycle of summer', () => {
     before(() => {
-      session.data.requirements[0].returnsCycle = 'summer'
+      session.requirements[0].returnsCycle = 'summer'
 
       payload = {
         additionalSubmissionOptions: ['quarterly-returns']
@@ -89,40 +89,38 @@ describe('Return Versions Setup - Additional Submission Options validator', () =
 function _testSession() {
   return {
     id: 'bbfb8568-cd71-4ca1-b56b-2d50dae2b2b9',
-    data: {
-      method: 'use-existing-requirements',
-      reason: 'new-licence',
-      journey: 'returns-required',
-      licence: {
-        id: '91aff99a-3204-4727-86bd-7bdf3ef24533',
-        endDate: null,
-        startDate: '1992-08-19T00:00:00.000Z',
-        licenceRef: '01/117',
-        licenceHolder: 'Ferns Surfacing Limited',
-        returnVersions: [],
-        waterUndertaker: false,
-        currentVersionStartDate: '2019-05-13T00:00:00.000Z'
-      },
-      requirements: [
-        {
-          points: [],
-          purposes: [],
-          returnsCycle: 'winter-and-all-year',
-          siteDescription: 'POINT A, ADDINGTON SANDPITS',
-          abstractionPeriod: [],
-          frequencyReported: 'month',
-          frequencyCollected: 'month',
-          agreementsExceptions: []
-        }
-      ],
-      startDateDay: '28',
-      startDateYear: '2025',
-      multipleUpload: false,
-      startDateMonth: '12',
-      checkPageVisited: true,
-      quarterlyReturns: true,
-      startDateOptions: 'anotherStartDate',
-      returnVersionStartDate: '2025-12-28T00:00:00.000Z'
-    }
+    method: 'use-existing-requirements',
+    reason: 'new-licence',
+    journey: 'returns-required',
+    licence: {
+      id: '91aff99a-3204-4727-86bd-7bdf3ef24533',
+      endDate: null,
+      startDate: '1992-08-19T00:00:00.000Z',
+      licenceRef: '01/117',
+      licenceHolder: 'Ferns Surfacing Limited',
+      returnVersions: [],
+      waterUndertaker: false,
+      currentVersionStartDate: '2019-05-13T00:00:00.000Z'
+    },
+    requirements: [
+      {
+        points: [],
+        purposes: [],
+        returnsCycle: 'winter-and-all-year',
+        siteDescription: 'POINT A, ADDINGTON SANDPITS',
+        abstractionPeriod: [],
+        frequencyReported: 'month',
+        frequencyCollected: 'month',
+        agreementsExceptions: []
+      }
+    ],
+    startDateDay: '28',
+    startDateYear: '2025',
+    multipleUpload: false,
+    startDateMonth: '12',
+    checkPageVisited: true,
+    quarterlyReturns: true,
+    startDateOptions: 'anotherStartDate',
+    returnVersionStartDate: '2025-12-28T00:00:00.000Z'
   }
 }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5573

We recently refactored how we use fetch and delete session data, we now have a single way of doing each.

We are moving away from using the database in service test.

This change updates some of the tests still using the session helper to stub the 'FetchSessionDal'