### PR TITLE
Update tests to stub 'FetchSessionDal'

### DIFF
--- a/test/services/address/international.service.test.js
+++ b/test/services/address/international.service.test.js
@@ -12,7 +12,10 @@ const { expect } = Code
 const { countryLookup } = require('../../../app/presenters/address/base-address.presenter.js')
 
 // Things we need to stub
-const SessionModel = require('../../../app/models/session.model.js')
+const SessionModelStub = require('../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const InternationalService = require('../../../app/services/address/international.service.js')
@@ -20,21 +23,26 @@ const InternationalService = require('../../../app/services/address/internationa
 describe('Address - International Service', () => {
   const sessionId = 'dba48385-9fc8-454b-8ec8-3832d3b9e323'
 
-  beforeEach(async () => {
-    Sinon.stub(SessionModel, 'query').returns({
-      findById: Sinon.stub().resolves({
-        id: sessionId,
-        addressJourney: {
-          activeNavBar: 'manage',
-          address: {},
-          backLink: {
-            href: `/system/notices/setup/${sessionId}/contact-type`,
-            text: 'Back'
-          },
-          redirectUrl: `/system/notices/setup/${sessionId}/add-recipient`
-        }
-      })
-    })
+  let session
+  let sessionData
+
+  beforeEach(() => {
+    sessionData = {
+      id: sessionId,
+      addressJourney: {
+        activeNavBar: 'manage',
+        address: {},
+        backLink: {
+          href: `/system/notices/setup/${sessionId}/contact-type`,
+          text: 'Back'
+        },
+        redirectUrl: `/system/notices/setup/${sessionId}/add-recipient`
+      }
+    }
+
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    Sinon.stub(FetchSessionDal, 'go').resolves(session)
   })
 
   afterEach(() => {

--- a/test/services/address/international.service.test.js
+++ b/test/services/address/international.service.test.js
@@ -10,8 +10,6 @@ const { expect } = Code
 
 // Test helpers
 const { countryLookup } = require('../../../app/presenters/address/base-address.presenter.js')
-
-// Things we need to stub
 const SessionModelStub = require('../../support/stubs/session.stub.js')
 
 // Things we need to stub

--- a/test/services/address/manual.service.test.js
+++ b/test/services/address/manual.service.test.js
@@ -9,7 +9,10 @@ const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Things we need to stub
-const SessionModel = require('../../../app/models/session.model.js')
+const SessionModelStub = require('../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const ManualService = require('../../../app/services/address/manual.service.js')
@@ -17,21 +20,26 @@ const ManualService = require('../../../app/services/address/manual.service.js')
 describe('Address - Manual Service', () => {
   const sessionId = 'dba48385-9fc8-454b-8ec8-3832d3b9e323'
 
-  beforeEach(async () => {
-    Sinon.stub(SessionModel, 'query').returns({
-      findById: Sinon.stub().resolves({
-        id: sessionId,
-        addressJourney: {
-          activeNavBar: 'manage',
-          address: { postcode: 'SW1A 1AA' },
-          backLink: {
-            href: `/system/notices/setup/${sessionId}/contact-type`,
-            text: 'Back'
-          },
-          redirectUrl: `/system/notices/setup/${sessionId}/add-recipient`
-        }
-      })
-    })
+  let session
+  let sessionData
+
+  beforeEach(() => {
+    sessionData = {
+      id: sessionId,
+      addressJourney: {
+        activeNavBar: 'manage',
+        address: { postcode: 'SW1A 1AA' },
+        backLink: {
+          href: `/system/notices/setup/${sessionId}/contact-type`,
+          text: 'Back'
+        },
+        redirectUrl: `/system/notices/setup/${sessionId}/add-recipient`
+      }
+    }
+
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    Sinon.stub(FetchSessionDal, 'go').resolves(session)
   })
 
   afterEach(() => {

--- a/test/services/address/manual.service.test.js
+++ b/test/services/address/manual.service.test.js
@@ -8,7 +8,7 @@ const Sinon = require('sinon')
 const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
-// Things we need to stub
+// Test helpers
 const SessionModelStub = require('../../support/stubs/session.stub.js')
 
 // Things we need to stub

--- a/test/services/address/postcode.service.test.js
+++ b/test/services/address/postcode.service.test.js
@@ -9,7 +9,10 @@ const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Things we need to stub
-const SessionModel = require('../../../app/models/session.model.js')
+const SessionModelStub = require('../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const PostcodeService = require('../../../app/services/address/postcode.service.js')
@@ -17,21 +20,26 @@ const PostcodeService = require('../../../app/services/address/postcode.service.
 describe('Address - Postcode Service', () => {
   const sessionId = 'dba48385-9fc8-454b-8ec8-3832d3b9e323'
 
-  beforeEach(async () => {
-    Sinon.stub(SessionModel, 'query').returns({
-      findById: Sinon.stub().resolves({
-        id: sessionId,
-        addressJourney: {
-          activeNavBar: 'manage',
-          address: {},
-          backLink: {
-            href: `/system/notices/setup/${sessionId}/contact-type`,
-            text: 'Back'
-          },
-          redirectUrl: `/system/notices/setup/${sessionId}/add-recipient`
-        }
-      })
-    })
+  let session
+  let sessionData
+
+  beforeEach(() => {
+    sessionData = {
+      id: sessionId,
+      addressJourney: {
+        activeNavBar: 'manage',
+        address: {},
+        backLink: {
+          href: `/system/notices/setup/${sessionId}/contact-type`,
+          text: 'Back'
+        },
+        redirectUrl: `/system/notices/setup/${sessionId}/add-recipient`
+      }
+    }
+
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    Sinon.stub(FetchSessionDal, 'go').resolves(session)
   })
 
   afterEach(() => {

--- a/test/services/address/postcode.service.test.js
+++ b/test/services/address/postcode.service.test.js
@@ -8,7 +8,7 @@ const Sinon = require('sinon')
 const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
-// Things we need to stub
+// Test helpers
 const SessionModelStub = require('../../support/stubs/session.stub.js')
 
 // Things we need to stub

--- a/test/services/address/select.service.test.js
+++ b/test/services/address/select.service.test.js
@@ -11,11 +11,11 @@ const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Things to stub
-const LookupPostcodeRequest = require('../../../app/requests/address-facade/lookup-postcode.request.js')
 const SessionModelStub = require('../../support/stubs/session.stub.js')
 
 // Things we need to stub
 const FetchSessionDal = require('../../../app/dal/fetch-session.dal.js')
+const LookupPostcodeRequest = require('../../../app/requests/address-facade/lookup-postcode.request.js')
 
 // Thing under test
 const SelectService = require('../../../app/services/address/select.service.js')

--- a/test/services/address/select.service.test.js
+++ b/test/services/address/select.service.test.js
@@ -12,7 +12,10 @@ const { expect } = Code
 
 // Things to stub
 const LookupPostcodeRequest = require('../../../app/requests/address-facade/lookup-postcode.request.js')
-const SessionModel = require('../../../app/models/session.model.js')
+const SessionModelStub = require('../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const SelectService = require('../../../app/services/address/select.service.js')
@@ -32,22 +35,26 @@ describe('Address - Select service', () => {
   const sessionId = 'dba48385-9fc8-454b-8ec8-3832d3b9e323'
 
   let lookupPostcodeRequestStub
+  let session
+  let sessionData
 
-  beforeEach(async () => {
-    Sinon.stub(SessionModel, 'query').returns({
-      findById: Sinon.stub().resolves({
-        id: sessionId,
-        addressJourney: {
-          activeNavBar: 'manage',
-          address: { postcode: 'BS1 5AH' },
-          backLink: {
-            href: `/system/notices/setup/${sessionId}/contact-type`,
-            text: 'Back'
-          },
-          redirectUrl: `/system/notices/setup/${sessionId}/add-recipient`
-        }
-      })
-    })
+  beforeEach(() => {
+    sessionData = {
+      id: sessionId,
+      addressJourney: {
+        activeNavBar: 'manage',
+        address: { postcode: 'BS1 5AH' },
+        backLink: {
+          href: `/system/notices/setup/${sessionId}/contact-type`,
+          text: 'Back'
+        },
+        redirectUrl: `/system/notices/setup/${sessionId}/add-recipient`
+      }
+    }
+
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    Sinon.stub(FetchSessionDal, 'go').resolves(session)
 
     lookupPostcodeRequestStub = Sinon.stub(LookupPostcodeRequest, 'send')
   })
@@ -100,7 +107,7 @@ describe('Address - Select service', () => {
     })
 
     describe('and the postcode lookup returns no matches', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         lookupPostcodeRequestStub.resolves({
           succeeded: true,
           response: {
@@ -121,7 +128,7 @@ describe('Address - Select service', () => {
     })
 
     describe('and the postcode lookup fails', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         lookupPostcodeRequestStub.resolves({
           succeeded: false,
           response: {

--- a/test/services/address/select.service.test.js
+++ b/test/services/address/select.service.test.js
@@ -10,7 +10,7 @@ const Sinon = require('sinon')
 const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
-// Things to stub
+// Test helpers
 const SessionModelStub = require('../../support/stubs/session.stub.js')
 
 // Things we need to stub

--- a/test/services/address/submit-international.service.test.js
+++ b/test/services/address/submit-international.service.test.js
@@ -3,14 +3,18 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
+const Sinon = require('sinon')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
 const { generateUUID } = require('../../../app/lib/general.lib.js')
 const { countryLookup } = require('../../../app/presenters/address/base-address.presenter.js')
-const SessionHelper = require('../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const SubmitInternationalService = require('../../../app/services/address/submit-international.service.js')
@@ -18,30 +22,37 @@ const SubmitInternationalService = require('../../../app/services/address/submit
 describe('Address - Submit International Service', () => {
   let payload
   let session
+  let sessionData
   let sessionId
 
-  beforeEach(async () => {
+  beforeEach(() => {
     sessionId = generateUUID()
 
-    session = await SessionHelper.add({
+    sessionData = {
       id: sessionId,
-      data: {
-        addressJourney: {
-          activeNavBar: 'manage',
-          address: {},
-          backLink: {
-            href: `/system/notices/setup/${sessionId}/contact-type`,
-            text: 'Back'
-          },
-          redirectUrl: `/system/notices/setup/${sessionId}/add-recipient`
-        }
+      addressJourney: {
+        activeNavBar: 'manage',
+        address: {},
+        backLink: {
+          href: `/system/notices/setup/${sessionId}/contact-type`,
+          text: 'Back'
+        },
+        redirectUrl: `/system/notices/setup/${sessionId}/add-recipient`
       }
-    })
+    }
+
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    Sinon.stub(FetchSessionDal, 'go').resolves(session)
+  })
+
+  afterEach(() => {
+    Sinon.restore()
   })
 
   describe('when called', () => {
     describe('with a valid payload', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         payload = {
           addressLine1: 'Falsches Unternehmen',
           addressLine2: '1 Fake-Straße',
@@ -57,9 +68,7 @@ describe('Address - Submit International Service', () => {
 
         expect(result).to.equal({ redirect: `/system/notices/setup/${sessionId}/add-recipient` })
 
-        const refreshedSession = await session.$query()
-
-        expect(refreshedSession.addressJourney.address).to.equal({
+        expect(session.addressJourney.address).to.equal({
           addressLine1: 'Falsches Unternehmen',
           addressLine2: '1 Fake-Straße',
           addressLine3: 'Falsches Dorf',
@@ -67,7 +76,8 @@ describe('Address - Submit International Service', () => {
           country: 'Germany',
           postcode: '80802'
         })
-        expect(refreshedSession.addressJourney.backUrl).to.equal(`/system/address/${session.id}/international`)
+        expect(session.addressJourney.backUrl).to.equal(`/system/address/${session.id}/international`)
+        expect(session.$update.called).to.be.true()
       })
     })
 

--- a/test/services/address/submit-international.service.test.js
+++ b/test/services/address/submit-international.service.test.js
@@ -9,9 +9,9 @@ const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const { generateUUID } = require('../../../app/lib/general.lib.js')
-const { countryLookup } = require('../../../app/presenters/address/base-address.presenter.js')
 const SessionModelStub = require('../../support/stubs/session.stub.js')
+const { countryLookup } = require('../../../app/presenters/address/base-address.presenter.js')
+const { generateUUID } = require('../../../app/lib/general.lib.js')
 
 // Things we need to stub
 const FetchSessionDal = require('../../../app/dal/fetch-session.dal.js')

--- a/test/services/address/submit-manual.service.test.js
+++ b/test/services/address/submit-manual.service.test.js
@@ -9,8 +9,8 @@ const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const { generateUUID } = require('../../../app/lib/general.lib.js')
 const SessionModelStub = require('../../support/stubs/session.stub.js')
+const { generateUUID } = require('../../../app/lib/general.lib.js')
 
 // Things we need to stub
 const FetchSessionDal = require('../../../app/dal/fetch-session.dal.js')

--- a/test/services/address/submit-manual.service.test.js
+++ b/test/services/address/submit-manual.service.test.js
@@ -3,13 +3,17 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
+const Sinon = require('sinon')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
 const { generateUUID } = require('../../../app/lib/general.lib.js')
-const SessionHelper = require('../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const SubmitManualService = require('../../../app/services/address/submit-manual.service.js')
@@ -17,30 +21,38 @@ const SubmitManualService = require('../../../app/services/address/submit-manual
 describe('Address - Submit Manual Service', () => {
   let payload
   let session
+  let sessionData
   let sessionId
 
-  beforeEach(async () => {
+  beforeEach(() => {
     sessionId = generateUUID()
 
-    session = await SessionHelper.add({
+    sessionData = {
       id: sessionId,
-      data: {
-        addressJourney: {
-          activeNavBar: 'manage',
-          address: { postcode: 'SW1A 1AA' },
-          backLink: {
-            href: `/system/notices/setup/${sessionId}/contact-type`,
-            text: 'Back'
-          },
-          redirectUrl: `/system/notices/setup/${sessionId}/add-recipient`
-        }
+
+      addressJourney: {
+        activeNavBar: 'manage',
+        address: { postcode: 'SW1A 1AA' },
+        backLink: {
+          href: `/system/notices/setup/${sessionId}/contact-type`,
+          text: 'Back'
+        },
+        redirectUrl: `/system/notices/setup/${sessionId}/add-recipient`
       }
-    })
+    }
+
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    Sinon.stub(FetchSessionDal, 'go').resolves(session)
+  })
+
+  afterEach(() => {
+    Sinon.restore()
   })
 
   describe('when called', () => {
     describe('with a valid payload', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         payload = {
           addressLine1: 'Fake Farm',
           addressLine2: '1 Fake street',
@@ -55,16 +67,15 @@ describe('Address - Submit Manual Service', () => {
 
         expect(result).to.equal({ redirect: `/system/notices/setup/${sessionId}/add-recipient` })
 
-        const refreshedSession = await session.$query()
-
-        expect(refreshedSession.addressJourney.address).to.equal({
+        expect(session.addressJourney.address).to.equal({
           addressLine1: 'Fake Farm',
           addressLine2: '1 Fake street',
           addressLine3: 'Fake Village',
           addressLine4: 'Fake City',
           postcode: 'SW1A 1AA'
         })
-        expect(refreshedSession.addressJourney.backUrl).to.equal(`/system/address/${session.id}/manual`)
+        expect(session.addressJourney.backUrl).to.equal(`/system/address/${session.id}/manual`)
+        expect(session.$update.called).to.be.true()
       })
     })
 

--- a/test/services/address/submit-postcode.service.test.js
+++ b/test/services/address/submit-postcode.service.test.js
@@ -9,8 +9,8 @@ const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const { generateUUID } = require('../../../app/lib/general.lib.js')
 const SessionModelStub = require('../../support/stubs/session.stub.js')
+const { generateUUID } = require('../../../app/lib/general.lib.js')
 
 // Things we need to stub
 const FetchSessionDal = require('../../../app/dal/fetch-session.dal.js')

--- a/test/services/address/submit-postcode.service.test.js
+++ b/test/services/address/submit-postcode.service.test.js
@@ -3,13 +3,17 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
+const Sinon = require('sinon')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
 const { generateUUID } = require('../../../app/lib/general.lib.js')
-const SessionHelper = require('../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const SubmitPostcodeService = require('../../../app/services/address/submit-postcode.service.js')
@@ -17,25 +21,32 @@ const SubmitPostcodeService = require('../../../app/services/address/submit-post
 describe('Address - Submit Postcode Service', () => {
   let payload
   let session
+  let sessionData
   let sessionId
 
-  beforeEach(async () => {
+  beforeEach(() => {
     sessionId = generateUUID()
 
-    session = await SessionHelper.add({
+    sessionData = {
       id: sessionId,
-      data: {
-        addressJourney: {
-          activeNavBar: 'manage',
-          address: {},
-          backLink: {
-            href: `/system/notices/setup/${sessionId}/contact-type`,
-            text: 'Back'
-          },
-          redirectUrl: `/system/notices/setup/${sessionId}/add-recipient`
-        }
+      addressJourney: {
+        activeNavBar: 'manage',
+        address: {},
+        backLink: {
+          href: `/system/notices/setup/${sessionId}/contact-type`,
+          text: 'Back'
+        },
+        redirectUrl: `/system/notices/setup/${sessionId}/add-recipient`
       }
-    })
+    }
+
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    Sinon.stub(FetchSessionDal, 'go').resolves(session)
+  })
+
+  afterEach(() => {
+    Sinon.restore()
   })
 
   describe('when called', () => {
@@ -49,9 +60,8 @@ describe('Address - Submit Postcode Service', () => {
 
         expect(result).to.equal({})
 
-        const refreshedSession = await session.$query()
-
-        expect(refreshedSession.addressJourney.address.postcode).to.equal('SW1A 1AA')
+        expect(session.addressJourney.address.postcode).to.equal('SW1A 1AA')
+        expect(session.$update.called).to.be.true()
       })
     })
 

--- a/test/services/address/submit-select.service.test.js
+++ b/test/services/address/submit-select.service.test.js
@@ -11,9 +11,10 @@ const { expect } = Code
 // Test helpers
 const { HTTP_STATUS_NOT_FOUND, HTTP_STATUS_OK } = require('node:http2').constants
 const { generateUUID } = require('../../../app/lib/general.lib.js')
-const SessionHelper = require('../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../support/stubs/session.stub.js')
 
-// Things to stub
+// Things we need to stub
+const FetchSessionDal = require('../../../app/dal/fetch-session.dal.js')
 const LookupPostcodeRequest = require('../../../app/requests/address-facade/lookup-postcode.request.js')
 const LookupUPRNRequest = require('../../../app/requests/address-facade/lookup-uprn.request.js')
 
@@ -37,28 +38,32 @@ describe('Address - Submit Select Service', () => {
   let lookupUPRNRequestStub
   let payload
   let session
+  let sessionData
   let sessionId
 
-  beforeEach(async () => {
+  beforeEach(() => {
     sessionId = generateUUID()
 
-    session = await SessionHelper.add({
+    sessionData = {
       id: sessionId,
-      data: {
-        addressJourney: {
-          activeNavBar: 'manage',
-          address: { postcode: 'BS1 5AH' },
-          backLink: {
-            href: `/system/notices/setup/${sessionId}/contact-type`,
-            text: 'Back'
-          },
-          redirectUrl: `/system/notices/setup/${sessionId}/add-recipient`
-        }
+
+      addressJourney: {
+        activeNavBar: 'manage',
+        address: { postcode: 'BS1 5AH' },
+        backLink: {
+          href: `/system/notices/setup/${sessionId}/contact-type`,
+          text: 'Back'
+        },
+        redirectUrl: `/system/notices/setup/${sessionId}/add-recipient`
       }
-    })
+    }
 
     lookupPostcodeRequestStub = Sinon.stub(LookupPostcodeRequest, 'send')
     lookupUPRNRequestStub = Sinon.stub(LookupUPRNRequest, 'send')
+
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    Sinon.stub(FetchSessionDal, 'go').resolves(session)
   })
 
   afterEach(() => {
@@ -68,7 +73,7 @@ describe('Address - Submit Select Service', () => {
   describe('when called', () => {
     describe('with a valid payload', () => {
       describe('and the selected address has an "organisation"', () => {
-        beforeEach(async () => {
+        beforeEach(() => {
           payload = { addresses: '340116' }
 
           lookupUPRNRequestStub.resolves({
@@ -88,9 +93,7 @@ describe('Address - Submit Select Service', () => {
 
           expect(result).to.equal({ redirect: `/system/notices/setup/${sessionId}/add-recipient` })
 
-          const refreshedSession = await session.$query()
-
-          expect(refreshedSession.addressJourney.address).to.equal({
+          expect(session.addressJourney.address).to.equal({
             uprn: 340116,
             addressLine1: 'ENVIRONMENT AGENCY',
             addressLine2: 'HORIZON HOUSE DEANERY ROAD',
@@ -98,12 +101,13 @@ describe('Address - Submit Select Service', () => {
             addressLine4: 'BRISTOL',
             postcode: 'BS1 5AH'
           })
-          expect(refreshedSession.addressJourney.backUrl).to.equal(`/system/address/${session.id}/select`)
+          expect(session.addressJourney.backUrl).to.equal(`/system/address/${session.id}/select`)
+          expect(session.$update.called).to.be.true()
         })
       })
 
       describe('and the selected address does not have an "organisation"', () => {
-        beforeEach(async () => {
+        beforeEach(() => {
           payload = {
             addresses: '340116'
           }
@@ -130,9 +134,7 @@ describe('Address - Submit Select Service', () => {
 
           expect(result).to.equal({ redirect: `/system/notices/setup/${sessionId}/add-recipient` })
 
-          const refreshedSession = await session.$query()
-
-          expect(refreshedSession.addressJourney.address).to.equal({
+          expect(session.addressJourney.address).to.equal({
             uprn: 340116,
             addressLine1: 'HORIZON HOUSE DEANERY ROAD',
             addressLine2: null,
@@ -140,12 +142,13 @@ describe('Address - Submit Select Service', () => {
             addressLine4: 'BRISTOL',
             postcode: 'BS1 5AH'
           })
-          expect(refreshedSession.addressJourney.backUrl).to.equal(`/system/address/${session.id}/select`)
+          expect(session.addressJourney.backUrl).to.equal(`/system/address/${session.id}/select`)
+          expect(session.$update.called).to.be.true()
         })
       })
 
       describe('and the selected address does not have a "premises"', () => {
-        beforeEach(async () => {
+        beforeEach(() => {
           payload = {
             addresses: '340116'
           }
@@ -172,9 +175,7 @@ describe('Address - Submit Select Service', () => {
 
           expect(result).to.equal({ redirect: `/system/notices/setup/${sessionId}/add-recipient` })
 
-          const refreshedSession = await session.$query()
-
-          expect(refreshedSession.addressJourney.address).to.equal({
+          expect(session.addressJourney.address).to.equal({
             uprn: 340116,
             addressLine1: 'ENVIRONMENT AGENCY',
             addressLine2: 'DEANERY ROAD',
@@ -182,12 +183,13 @@ describe('Address - Submit Select Service', () => {
             addressLine4: 'BRISTOL',
             postcode: 'BS1 5AH'
           })
-          expect(refreshedSession.addressJourney.backUrl).to.equal(`/system/address/${session.id}/select`)
+          expect(session.addressJourney.backUrl).to.equal(`/system/address/${session.id}/select`)
+          expect(session.$update.called).to.be.true()
         })
       })
 
       describe('and the selected address does not have a "premises"', () => {
-        beforeEach(async () => {
+        beforeEach(() => {
           payload = {
             addresses: '340116'
           }
@@ -214,9 +216,7 @@ describe('Address - Submit Select Service', () => {
 
           expect(result).to.equal({ redirect: `/system/notices/setup/${sessionId}/add-recipient` })
 
-          const refreshedSession = await session.$query()
-
-          expect(refreshedSession.addressJourney.address).to.equal({
+          expect(session.addressJourney.address).to.equal({
             uprn: 340116,
             addressLine1: 'ENVIRONMENT AGENCY',
             addressLine2: 'HORIZON HOUSE',
@@ -224,12 +224,13 @@ describe('Address - Submit Select Service', () => {
             addressLine4: 'BRISTOL',
             postcode: 'BS1 5AH'
           })
-          expect(refreshedSession.addressJourney.backUrl).to.equal(`/system/address/${session.id}/select`)
+          expect(session.addressJourney.backUrl).to.equal(`/system/address/${session.id}/select`)
+          expect(session.$update.called).to.be.true()
         })
       })
 
       describe('and the selected address does not have a "locality"', () => {
-        beforeEach(async () => {
+        beforeEach(() => {
           payload = {
             addresses: '340116'
           }
@@ -256,9 +257,7 @@ describe('Address - Submit Select Service', () => {
 
           expect(result).to.equal({ redirect: `/system/notices/setup/${sessionId}/add-recipient` })
 
-          const refreshedSession = await session.$query()
-
-          expect(refreshedSession.addressJourney.address).to.equal({
+          expect(session.addressJourney.address).to.equal({
             uprn: 340116,
             addressLine1: 'ENVIRONMENT AGENCY',
             addressLine2: 'HORIZON HOUSE DEANERY ROAD',
@@ -266,7 +265,8 @@ describe('Address - Submit Select Service', () => {
             addressLine4: 'BRISTOL',
             postcode: 'BS1 5AH'
           })
-          expect(refreshedSession.addressJourney.backUrl).to.equal(`/system/address/${session.id}/select`)
+          expect(session.addressJourney.backUrl).to.equal(`/system/address/${session.id}/select`)
+          expect(session.$update.called).to.be.true()
         })
       })
 
@@ -326,14 +326,14 @@ describe('Address - Submit Select Service', () => {
 
     describe('with an invalid payload', () => {
       describe('because the user has not selected an address', () => {
-        beforeEach(async () => {
+        beforeEach(() => {
           payload = {
             addresses: 'select'
           }
         })
 
         describe('and the postcode lookup succeeds', () => {
-          beforeEach(async () => {
+          beforeEach(() => {
             lookupPostcodeRequestStub.resolves({
               succeeded: true,
               response: {

--- a/test/services/address/submit-select.service.test.js
+++ b/test/services/address/submit-select.service.test.js
@@ -10,8 +10,8 @@ const { expect } = Code
 
 // Test helpers
 const { HTTP_STATUS_NOT_FOUND, HTTP_STATUS_OK } = require('node:http2').constants
-const { generateUUID } = require('../../../app/lib/general.lib.js')
 const SessionModelStub = require('../../support/stubs/session.stub.js')
+const { generateUUID } = require('../../../app/lib/general.lib.js')
 
 // Things we need to stub
 const FetchSessionDal = require('../../../app/dal/fetch-session.dal.js')

--- a/test/services/address/submit-select.service.test.js
+++ b/test/services/address/submit-select.service.test.js
@@ -9,8 +9,8 @@ const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const { HTTP_STATUS_NOT_FOUND, HTTP_STATUS_OK } = require('node:http2').constants
 const SessionModelStub = require('../../support/stubs/session.stub.js')
+const { HTTP_STATUS_NOT_FOUND, HTTP_STATUS_OK } = require('node:http2').constants
 const { generateUUID } = require('../../../app/lib/general.lib.js')
 
 // Things we need to stub


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5573

We recently refactored how we use fetch and delete session data, we now have a single way of doing each.

We are moving away from using the database in service test.

This change updates some of the tests still using the session helper to stub the 'FetchSessionDal'