### PR TITLE
Update tests to stub 'FetchSessionDal'

### DIFF
--- a/app/services/return-logs/setup/submit-note.service.js
+++ b/app/services/return-logs/setup/submit-note.service.js
@@ -52,9 +52,7 @@ async function go(sessionId, payload, user, yar) {
 }
 
 function _notification(session, newNote) {
-  const {
-    data: { note }
-  } = session
+  const { note } = session
 
   if (!note && newNote) {
     return {

--- a/test/services/company-contacts/setup/view-contact-email.service.test.js
+++ b/test/services/company-contacts/setup/view-contact-email.service.test.js
@@ -23,7 +23,7 @@ describe('Company Contacts - Setup - Contact Email Service', () => {
   let session
   let sessionData
 
-  beforeEach(async () => {
+  beforeEach(() => {
     company = CustomersFixtures.company()
 
     sessionData = { company }

--- a/test/services/return-logs/setup/apply-quantities.service.test.js
+++ b/test/services/return-logs/setup/apply-quantities.service.test.js
@@ -3,8 +3,9 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
+const Sinon = require('sinon')
 
-const { describe, it, before } = (exports.lab = Lab.script())
+const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Thing under test
@@ -15,7 +16,7 @@ describe('Return Logs Setup - Update Quantities service', () => {
 
   describe('when called with meter readings', () => {
     describe('and the unit of measurement is cubic metres', () => {
-      before(() => {
+      beforeEach(() => {
         session = {
           lines: [
             {
@@ -76,7 +77,7 @@ describe('Return Logs Setup - Update Quantities service', () => {
       })
 
       describe('and the start reading is 100', () => {
-        before(() => {
+        beforeEach(() => {
           session = {
             lines: [
               {
@@ -139,7 +140,7 @@ describe('Return Logs Setup - Update Quantities service', () => {
     })
 
     describe('and the unit of measurement is gallons', () => {
-      before(() => {
+      beforeEach(() => {
         session = {
           lines: [
             {
@@ -200,7 +201,7 @@ describe('Return Logs Setup - Update Quantities service', () => {
       })
 
       describe('and the meter has a x10 display', () => {
-        before(() => {
+        beforeEach(() => {
           session = {
             lines: [
               {
@@ -265,7 +266,7 @@ describe('Return Logs Setup - Update Quantities service', () => {
 
   describe('when called with volumes', () => {
     describe('and the unit of measurement was previously megalitres but has changed to cubic metres', () => {
-      before(() => {
+      beforeEach(() => {
         session = {
           lines: [
             {

--- a/test/services/return-logs/setup/apply-quantities.service.test.js
+++ b/test/services/return-logs/setup/apply-quantities.service.test.js
@@ -4,7 +4,7 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, before } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Thing under test
@@ -15,7 +15,7 @@ describe('Return Logs Setup - Update Quantities service', () => {
 
   describe('when called with meter readings', () => {
     describe('and the unit of measurement is cubic metres', () => {
-      beforeEach(() => {
+      before(() => {
         session = {
           lines: [
             {
@@ -76,7 +76,7 @@ describe('Return Logs Setup - Update Quantities service', () => {
       })
 
       describe('and the start reading is 100', () => {
-        beforeEach(() => {
+        before(() => {
           session = {
             lines: [
               {
@@ -139,7 +139,7 @@ describe('Return Logs Setup - Update Quantities service', () => {
     })
 
     describe('and the unit of measurement is gallons', () => {
-      beforeEach(() => {
+      before(() => {
         session = {
           lines: [
             {
@@ -200,7 +200,7 @@ describe('Return Logs Setup - Update Quantities service', () => {
       })
 
       describe('and the meter has a x10 display', () => {
-        beforeEach(() => {
+        before(() => {
           session = {
             lines: [
               {
@@ -265,7 +265,7 @@ describe('Return Logs Setup - Update Quantities service', () => {
 
   describe('when called with volumes', () => {
     describe('and the unit of measurement was previously megalitres but has changed to cubic metres', () => {
-      beforeEach(() => {
+      before(() => {
         session = {
           lines: [
             {

--- a/test/services/return-logs/setup/apply-quantities.service.test.js
+++ b/test/services/return-logs/setup/apply-quantities.service.test.js
@@ -4,7 +4,7 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Thing under test

--- a/test/services/return-logs/setup/apply-quantities.service.test.js
+++ b/test/services/return-logs/setup/apply-quantities.service.test.js
@@ -3,7 +3,6 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
-const Sinon = require('sinon')
 
 const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code

--- a/test/services/return-logs/setup/cancel.service.test.js
+++ b/test/services/return-logs/setup/cancel.service.test.js
@@ -8,6 +8,7 @@ const Sinon = require('sinon')
 const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
+// Test helpers
 const SessionModelStub = require('../../../support/stubs/session.stub.js')
 
 // Things we need to stub

--- a/test/services/return-logs/setup/cancel.service.test.js
+++ b/test/services/return-logs/setup/cancel.service.test.js
@@ -5,7 +5,7 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers

--- a/test/services/return-logs/setup/cancel.service.test.js
+++ b/test/services/return-logs/setup/cancel.service.test.js
@@ -3,46 +3,55 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
+const Sinon = require('sinon')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
-// Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const CancelService = require('../../../../app/services/return-logs/setup/cancel.service.js')
 
 describe('Return Logs Setup - Cancel service', () => {
-  let sessionId
+  let session
+  let sessionData
 
-  beforeEach(async () => {
-    const session = await SessionHelper.add({
-      data: {
-        endDate: '2005-03-31T00:00:00.000Z',
-        periodEndDay: 31,
-        periodEndMonth: 12,
-        periodStartDay: 1,
-        periodStartMonth: 1,
-        purposes: 'Evaporative Cooling',
-        receivedDate: '2025-01-31T00:00:00.000Z',
-        returnLogId: '1130dfa0-e8ed-43cb-91db-5f9d79bbef5f',
-        returnReference: '1234',
-        siteDescription: 'POINT A, TEST SITE DESCRIPTION',
-        startDate: '2004-04-01T00:00:00.000Z',
-        twoPartTariff: false
-      }
-    })
-    sessionId = session.id
+  beforeEach(() => {
+    sessionData = {
+      endDate: '2005-03-31T00:00:00.000Z',
+      periodEndDay: 31,
+      periodEndMonth: 12,
+      periodStartDay: 1,
+      periodStartMonth: 1,
+      purposes: 'Evaporative Cooling',
+      receivedDate: '2025-01-31T00:00:00.000Z',
+      returnLogId: '1130dfa0-e8ed-43cb-91db-5f9d79bbef5f',
+      returnReference: '1234',
+      siteDescription: 'POINT A, TEST SITE DESCRIPTION',
+      startDate: '2004-04-01T00:00:00.000Z',
+      twoPartTariff: false
+    }
+
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    Sinon.stub(FetchSessionDal, 'go').resolves(session)
+  })
+
+  afterEach(() => {
+    Sinon.restore()
   })
 
   describe('when called', () => {
     it('fetches the current setup session record and returns page data for the view', async () => {
-      const result = await CancelService.go(sessionId)
+      const result = await CancelService.go(session.id)
 
       expect(result).to.equal({
         abstractionPeriod: '1 January to 31 December',
-        backLink: { href: `/system/return-logs/setup/${sessionId}/check`, text: 'Back' },
+        backLink: { href: `/system/return-logs/setup/${session.id}/check`, text: 'Back' },
         pageTitle: 'You are about to cancel this return submission',
         purposes: 'Evaporative Cooling',
         returnLogId: '1130dfa0-e8ed-43cb-91db-5f9d79bbef5f',

--- a/test/services/return-logs/setup/check.service.test.js
+++ b/test/services/return-logs/setup/check.service.test.js
@@ -8,6 +8,7 @@ const Sinon = require('sinon')
 const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
+// Test helpers
 const SessionModelStub = require('../../../support/stubs/session.stub.js')
 
 // Things we need to stub

--- a/test/services/return-logs/setup/check.service.test.js
+++ b/test/services/return-logs/setup/check.service.test.js
@@ -8,18 +8,27 @@ const Sinon = require('sinon')
 const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
-// Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const CheckService = require('../../../../app/services/return-logs/setup/check.service.js')
 
 describe('Return Logs Setup - Check service', () => {
   let session
+  let sessionData
   let yarStub
 
   beforeEach(() => {
     yarStub = { flash: Sinon.stub().returns([]) }
+
+    sessionData = _sessionData()
+
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    Sinon.stub(FetchSessionDal, 'go').resolves(session)
   })
 
   afterEach(() => {
@@ -27,12 +36,6 @@ describe('Return Logs Setup - Check service', () => {
   })
 
   describe('when called for the first time', () => {
-    beforeEach(async () => {
-      const data = _sessionData()
-
-      session = await SessionHelper.add({ data })
-    })
-
     it('returns page data for the view', async () => {
       const result = await CheckService.go(session.id, yarStub)
 
@@ -109,9 +112,8 @@ describe('Return Logs Setup - Check service', () => {
     it('updates the session record to indicate user has visited the "check" page', async () => {
       await CheckService.go(session.id, yarStub)
 
-      const refreshedSession = await session.$query()
-
-      expect(refreshedSession.checkPageVisited).to.be.true()
+      expect(session.checkPageVisited).to.be.true()
+      expect(session.$update.called).to.be.true()
     })
   })
 })

--- a/test/services/return-logs/setup/delete-note.service.test.js
+++ b/test/services/return-logs/setup/delete-note.service.test.js
@@ -5,41 +5,48 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const DeleteNoteService = require('../../../../app/services/return-logs/setup/delete-note.service.js')
 
 describe('Return Logs Setup - Delete Note service', () => {
   let session
+  let sessionData
   let yarStub
 
-  beforeEach(async () => {
-    session = await SessionHelper.add({
-      data: {
-        returnReference: '1234',
-        note: {
-          content: 'I am not long for this world',
-          userEmail: 'carol.shaw@atari.com'
-        }
+  beforeEach(() => {
+    sessionData = {
+      returnReference: '1234',
+      note: {
+        content: 'I am not long for this world',
+        userEmail: 'carol.shaw@atari.com'
       }
-    })
-
-    yarStub = {
-      flash: Sinon.stub()
     }
+
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    Sinon.stub(FetchSessionDal, 'go').resolves(session)
+
+    yarStub = { flash: Sinon.stub() }
+  })
+
+  afterEach(() => {
+    Sinon.restore()
   })
 
   it('deletes the note from the session', async () => {
     await DeleteNoteService.go(session.id, yarStub)
 
-    const refreshedSession = await session.$query()
-
-    expect(refreshedSession.note).to.be.undefined()
+    expect(session.note).to.be.undefined()
+    expect(session.$update.called).to.be.true()
   })
 
   it('sets the notification message to "Deleted"', async () => {

--- a/test/services/return-logs/setup/meter-details.service.test.js
+++ b/test/services/return-logs/setup/meter-details.service.test.js
@@ -8,6 +8,7 @@ const Sinon = require('sinon')
 const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
+// Test helpers
 const SessionModelStub = require('../../../support/stubs/session.stub.js')
 
 // Things we need to stub

--- a/test/services/return-logs/setup/meter-details.service.test.js
+++ b/test/services/return-logs/setup/meter-details.service.test.js
@@ -5,7 +5,7 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers

--- a/test/services/return-logs/setup/meter-details.service.test.js
+++ b/test/services/return-logs/setup/meter-details.service.test.js
@@ -3,25 +3,35 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
+const Sinon = require('sinon')
 
-const { describe, it, before } = (exports.lab = Lab.script())
+const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
-// Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const MeterDetailsService = require('../../../../app/services/return-logs/setup/meter-details.service.js')
 
 describe('Return Logs Setup - Meter Details service', () => {
   let session
+  let sessionData
 
-  before(async () => {
-    session = await SessionHelper.add({
-      data: {
-        returnReference: '012345'
-      }
-    })
+  beforeEach(() => {
+    sessionData = {
+      returnReference: '012345'
+    }
+
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    Sinon.stub(FetchSessionDal, 'go').resolves(session)
+  })
+
+  afterEach(() => {
+    Sinon.restore()
   })
 
   describe('when called', () => {

--- a/test/services/return-logs/setup/meter-provided.service.test.js
+++ b/test/services/return-logs/setup/meter-provided.service.test.js
@@ -8,6 +8,7 @@ const Sinon = require('sinon')
 const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
+// Test helpers
 const SessionModelStub = require('../../../support/stubs/session.stub.js')
 
 // Things we need to stub

--- a/test/services/return-logs/setup/meter-provided.service.test.js
+++ b/test/services/return-logs/setup/meter-provided.service.test.js
@@ -5,7 +5,7 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers

--- a/test/services/return-logs/setup/meter-provided.service.test.js
+++ b/test/services/return-logs/setup/meter-provided.service.test.js
@@ -3,25 +3,35 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
+const Sinon = require('sinon')
 
-const { describe, it, before } = (exports.lab = Lab.script())
+const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
-// Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const MeterProvidedService = require('../../../../app/services/return-logs/setup/meter-provided.service.js')
 
 describe('Return Logs Setup - Meter Provided service', () => {
   let session
+  let sessionData
 
-  before(async () => {
-    session = await SessionHelper.add({
-      data: {
-        returnReference: '012345'
-      }
-    })
+  beforeEach(() => {
+    sessionData = {
+      returnReference: '012345'
+    }
+
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    Sinon.stub(FetchSessionDal, 'go').resolves(session)
+  })
+
+  afterEach(() => {
+    Sinon.restore()
   })
 
   describe('when called', () => {

--- a/test/services/return-logs/setup/multiple-entries.service.test.js
+++ b/test/services/return-logs/setup/multiple-entries.service.test.js
@@ -8,6 +8,7 @@ const Sinon = require('sinon')
 const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
+// Test helpers
 const SessionModelStub = require('../../../support/stubs/session.stub.js')
 
 // Things we need to stub

--- a/test/services/return-logs/setup/multiple-entries.service.test.js
+++ b/test/services/return-logs/setup/multiple-entries.service.test.js
@@ -5,7 +5,7 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers

--- a/test/services/return-logs/setup/multiple-entries.service.test.js
+++ b/test/services/return-logs/setup/multiple-entries.service.test.js
@@ -3,31 +3,41 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
+const Sinon = require('sinon')
 
-const { describe, it, before } = (exports.lab = Lab.script())
+const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
-// Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const MultipleEntriesService = require('../../../../app/services/return-logs/setup/multiple-entries.service.js')
 
 describe('Return Logs Setup - Multiple Entries service', () => {
   let session
+  let sessionData
 
-  before(async () => {
-    session = await SessionHelper.add({
-      data: {
-        returnReference: '012345',
-        lines: [
-          { startDate: new Date('2023-04-01').toISOString(), endDate: new Date('2023-04-30').toISOString() },
-          { startDate: new Date('2023-05-01').toISOString(), endDate: new Date('2023-05-31').toISOString() }
-        ],
-        returnsFrequency: 'month',
-        reported: 'abstractionVolumes'
-      }
-    })
+  beforeEach(() => {
+    sessionData = {
+      returnReference: '012345',
+      lines: [
+        { startDate: new Date('2023-04-01').toISOString(), endDate: new Date('2023-04-30').toISOString() },
+        { startDate: new Date('2023-05-01').toISOString(), endDate: new Date('2023-05-31').toISOString() }
+      ],
+      returnsFrequency: 'month',
+      reported: 'abstractionVolumes'
+    }
+
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    Sinon.stub(FetchSessionDal, 'go').resolves(session)
+  })
+
+  afterEach(() => {
+    Sinon.restore()
   })
 
   describe('when called', () => {

--- a/test/services/return-logs/setup/note.service.test.js
+++ b/test/services/return-logs/setup/note.service.test.js
@@ -8,6 +8,7 @@ const Sinon = require('sinon')
 const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
+// Test helpers
 const SessionModelStub = require('../../../support/stubs/session.stub.js')
 
 // Things we need to stub

--- a/test/services/return-logs/setup/note.service.test.js
+++ b/test/services/return-logs/setup/note.service.test.js
@@ -5,7 +5,7 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers

--- a/test/services/return-logs/setup/note.service.test.js
+++ b/test/services/return-logs/setup/note.service.test.js
@@ -3,43 +3,54 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
+const Sinon = require('sinon')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
-// Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const NoteService = require('../../../../app/services/return-logs/setup/note.service.js')
 
 describe('Return Logs Setup - Note service', () => {
-  let sessionId
+  let session
+  let sessionData
 
-  beforeEach(async () => {
-    const session = await SessionHelper.add({ data: { returnReference: '1234' } })
-    sessionId = session.id
+  beforeEach(() => {
+    sessionData = { returnReference: '1234' }
+
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    Sinon.stub(FetchSessionDal, 'go').resolves(session)
+  })
+
+  afterEach(() => {
+    Sinon.restore()
   })
 
   describe('when called', () => {
     it('fetches the current setup session record', async () => {
-      const result = await NoteService.go(sessionId)
+      const result = await NoteService.go(session.id)
 
-      expect(result.sessionId).to.equal(sessionId)
+      expect(result.sessionId).to.equal(session.id)
     })
 
     it('returns page data for the view', async () => {
-      const result = await NoteService.go(sessionId)
+      const result = await NoteService.go(session.id)
 
       expect(result).to.equal({
         backLink: {
-          href: `/system/return-logs/setup/${sessionId}/check`,
+          href: `/system/return-logs/setup/${session.id}/check`,
           text: 'Back'
         },
         note: null,
         pageTitle: 'Add a note',
         pageTitleCaption: 'Return reference 1234',
-        sessionId
+        sessionId: session.id
       })
     })
   })

--- a/test/services/return-logs/setup/period-used.service.test.js
+++ b/test/services/return-logs/setup/period-used.service.test.js
@@ -8,6 +8,7 @@ const Sinon = require('sinon')
 const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
+// Test helpers
 const SessionModelStub = require('../../../support/stubs/session.stub.js')
 
 // Things we need to stub

--- a/test/services/return-logs/setup/period-used.service.test.js
+++ b/test/services/return-logs/setup/period-used.service.test.js
@@ -3,29 +3,39 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
+const Sinon = require('sinon')
 
-const { describe, it, before } = (exports.lab = Lab.script())
+const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
-// Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const PeriodUsedService = require('../../../../app/services/return-logs/setup/period-used.service.js')
 
 describe('Return Logs Setup - Period used service', () => {
   let session
+  let sessionData
 
-  before(async () => {
-    session = await SessionHelper.add({
-      data: {
-        returnReference: '012345',
-        periodStartDay: '01',
-        periodStartMonth: '04',
-        periodEndDay: '31',
-        periodEndMonth: '03'
-      }
-    })
+  beforeEach(() => {
+    sessionData = {
+      returnReference: '012345',
+      periodStartDay: '01',
+      periodStartMonth: '04',
+      periodEndDay: '31',
+      periodEndMonth: '03'
+    }
+
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    Sinon.stub(FetchSessionDal, 'go').resolves(session)
+  })
+
+  afterEach(() => {
+    Sinon.restore()
   })
 
   describe('when called', () => {

--- a/test/services/return-logs/setup/period-used.service.test.js
+++ b/test/services/return-logs/setup/period-used.service.test.js
@@ -5,7 +5,7 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers

--- a/test/services/return-logs/setup/readings.service.test.js
+++ b/test/services/return-logs/setup/readings.service.test.js
@@ -8,6 +8,7 @@ const Sinon = require('sinon')
 const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
+// Test helpers
 const SessionModelStub = require('../../../support/stubs/session.stub.js')
 
 // Things we need to stub

--- a/test/services/return-logs/setup/readings.service.test.js
+++ b/test/services/return-logs/setup/readings.service.test.js
@@ -5,7 +5,7 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers

--- a/test/services/return-logs/setup/readings.service.test.js
+++ b/test/services/return-logs/setup/readings.service.test.js
@@ -3,12 +3,15 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
+const Sinon = require('sinon')
 
-const { describe, it, before } = (exports.lab = Lab.script())
+const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
-// Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const ReadingsService = require('../../../../app/services/return-logs/setup/readings.service.js')
@@ -17,25 +20,32 @@ describe('Return Logs Setup - Readings service', () => {
   const yearMonth = '2023-3'
 
   let session
+  let sessionData
 
-  before(async () => {
-    session = await SessionHelper.add({
-      data: {
-        lines: [
-          {
-            endDate: '2023-04-30T00:00:00.000Z',
-            reading: 100,
-            startDate: '2023-04-01T00:00:00.000Z'
-          },
-          {
-            endDate: '2023-05-31T00:00:00.000Z',
-            startDate: '2023-05-01T00:00:00.000Z'
-          }
-        ],
-        returnsFrequency: 'month',
-        returnReference: '1234'
-      }
-    })
+  beforeEach(() => {
+    sessionData = {
+      lines: [
+        {
+          endDate: '2023-04-30T00:00:00.000Z',
+          reading: 100,
+          startDate: '2023-04-01T00:00:00.000Z'
+        },
+        {
+          endDate: '2023-05-31T00:00:00.000Z',
+          startDate: '2023-05-01T00:00:00.000Z'
+        }
+      ],
+      returnsFrequency: 'month',
+      returnReference: '1234'
+    }
+
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    Sinon.stub(FetchSessionDal, 'go').resolves(session)
+  })
+
+  afterEach(() => {
+    Sinon.restore()
   })
 
   describe('when called', () => {

--- a/test/services/return-logs/setup/received.service.test.js
+++ b/test/services/return-logs/setup/received.service.test.js
@@ -3,28 +3,37 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
+const Sinon = require('sinon')
 
-const { describe, it, before } = (exports.lab = Lab.script())
+const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
-// Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const ReceivedService = require('../../../../app/services/return-logs/setup/received.service.js')
 
 describe('Return Logs - Setup - Received service', () => {
   let session
+  let sessionData
 
-  before(async () => {
-    session = await SessionHelper.add({
-      data: {
-        licenceId: '736144f1-203d-46bb-9968-5137ae06a7bd',
-        returnLogId: '8280a3bb-aefb-4603-b71f-a58cef9169f3',
-        returnReference: '012345'
-      },
-      id: 'd958333a-4acd-4add-9e2b-09e14c6b72f3'
-    })
+  beforeEach(() => {
+    sessionData = {
+      licenceId: '736144f1-203d-46bb-9968-5137ae06a7bd',
+      returnLogId: '8280a3bb-aefb-4603-b71f-a58cef9169f3',
+      returnReference: '012345'
+    }
+
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    Sinon.stub(FetchSessionDal, 'go').resolves(session)
+  })
+
+  afterEach(() => {
+    Sinon.restore()
   })
 
   describe('when called', () => {

--- a/test/services/return-logs/setup/received.service.test.js
+++ b/test/services/return-logs/setup/received.service.test.js
@@ -8,6 +8,7 @@ const Sinon = require('sinon')
 const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
+// Test helpers
 const SessionModelStub = require('../../../support/stubs/session.stub.js')
 
 // Things we need to stub

--- a/test/services/return-logs/setup/received.service.test.js
+++ b/test/services/return-logs/setup/received.service.test.js
@@ -5,7 +5,7 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers

--- a/test/services/return-logs/setup/reported.service.test.js
+++ b/test/services/return-logs/setup/reported.service.test.js
@@ -8,6 +8,7 @@ const Sinon = require('sinon')
 const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
+// Test helpers
 const SessionModelStub = require('../../../support/stubs/session.stub.js')
 
 // Things we need to stub

--- a/test/services/return-logs/setup/reported.service.test.js
+++ b/test/services/return-logs/setup/reported.service.test.js
@@ -5,7 +5,7 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers

--- a/test/services/return-logs/setup/reported.service.test.js
+++ b/test/services/return-logs/setup/reported.service.test.js
@@ -3,25 +3,35 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
+const Sinon = require('sinon')
 
-const { describe, it, before } = (exports.lab = Lab.script())
+const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
-// Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const ReportedService = require('../../../../app/services/return-logs/setup/reported.service.js')
 
 describe('Return Logs Setup - Reported service', () => {
   let session
+  let sessionData
 
-  before(async () => {
-    session = await SessionHelper.add({
-      data: {
-        returnReference: '012345'
-      }
-    })
+  beforeEach(() => {
+    sessionData = {
+      returnReference: '012345'
+    }
+
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    Sinon.stub(FetchSessionDal, 'go').resolves(session)
+  })
+
+  afterEach(() => {
+    Sinon.restore()
   })
 
   describe('when called', () => {

--- a/test/services/return-logs/setup/single-volume.service.test.js
+++ b/test/services/return-logs/setup/single-volume.service.test.js
@@ -8,6 +8,7 @@ const Sinon = require('sinon')
 const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
+// Test helpers
 const SessionModelStub = require('../../../support/stubs/session.stub.js')
 
 // Things we need to stub

--- a/test/services/return-logs/setup/single-volume.service.test.js
+++ b/test/services/return-logs/setup/single-volume.service.test.js
@@ -5,7 +5,7 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers

--- a/test/services/return-logs/setup/single-volume.service.test.js
+++ b/test/services/return-logs/setup/single-volume.service.test.js
@@ -3,26 +3,36 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
+const Sinon = require('sinon')
 
-const { describe, it, before } = (exports.lab = Lab.script())
+const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
-// Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const SingleVolumeService = require('../../../../app/services/return-logs/setup/single-volume.service.js')
 
 describe('Return Logs Setup - Single Volume service', () => {
   let session
+  let sessionData
 
-  before(async () => {
-    session = await SessionHelper.add({
-      data: {
-        returnReference: '012345',
-        units: 'cubicMetres'
-      }
-    })
+  beforeEach(() => {
+    sessionData = {
+      returnReference: '012345',
+      units: 'cubicMetres'
+    }
+
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    Sinon.stub(FetchSessionDal, 'go').resolves(session)
+  })
+
+  afterEach(() => {
+    Sinon.restore()
   })
 
   describe('when called', () => {

--- a/test/services/return-logs/setup/split-multiple-entries.service.test.js
+++ b/test/services/return-logs/setup/split-multiple-entries.service.test.js
@@ -4,7 +4,7 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, before } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Thing under test
@@ -15,7 +15,7 @@ describe('Return Logs - Split Multiple Entries Service', () => {
 
   describe('when passed a valid multiple entries string', () => {
     describe('thats been entered using new lines as the split', () => {
-      beforeEach(() => {
+      before(() => {
         multipleEntries = '1.1,\r\n200,000,\r\n3,\r\n4,\r\n200.4,\r\n300,\r\n500,00\r\n6.6'
       })
 
@@ -26,7 +26,7 @@ describe('Return Logs - Split Multiple Entries Service', () => {
       })
 
       describe('that has been entered with "x"s values', () => {
-        beforeEach(() => {
+        before(() => {
           multipleEntries = 'x,\r\nX, \r\nx, \r\nX\r\n'
         })
 
@@ -39,7 +39,7 @@ describe('Return Logs - Split Multiple Entries Service', () => {
     })
 
     describe('thats been entered using commas as the split', () => {
-      beforeEach(() => {
+      before(() => {
         // NOTE: By adding a comma and space at the end of the string when this is split it will create a empty value
         // in the array. This should then be stripped out of the final array as only numbers or null values are allowed
         multipleEntries = '1.1, 2.2, 200, 400.4, 3000, 400, 7.6, '
@@ -52,7 +52,7 @@ describe('Return Logs - Split Multiple Entries Service', () => {
       })
 
       describe('that has been entered with "x"s values', () => {
-        beforeEach(() => {
+        before(() => {
           multipleEntries = 'x, X, x, X'
         })
 
@@ -66,7 +66,7 @@ describe('Return Logs - Split Multiple Entries Service', () => {
   })
 
   describe('when passed an invalid multiple entries string', () => {
-    beforeEach(() => {
+    before(() => {
       multipleEntries = 'invalid multiple entries string'
     })
 

--- a/test/services/return-logs/setup/split-multiple-entries.service.test.js
+++ b/test/services/return-logs/setup/split-multiple-entries.service.test.js
@@ -3,8 +3,9 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
+const Sinon = require('sinon')
 
-const { describe, it, before } = (exports.lab = Lab.script())
+const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Thing under test
@@ -15,7 +16,7 @@ describe('Return Logs - Split Multiple Entries Service', () => {
 
   describe('when passed a valid multiple entries string', () => {
     describe('thats been entered using new lines as the split', () => {
-      before(() => {
+      beforeEach(() => {
         multipleEntries = '1.1,\r\n200,000,\r\n3,\r\n4,\r\n200.4,\r\n300,\r\n500,00\r\n6.6'
       })
 
@@ -26,7 +27,7 @@ describe('Return Logs - Split Multiple Entries Service', () => {
       })
 
       describe('that has been entered with "x"s values', () => {
-        before(() => {
+        beforeEach(() => {
           multipleEntries = 'x,\r\nX, \r\nx, \r\nX\r\n'
         })
 
@@ -39,7 +40,7 @@ describe('Return Logs - Split Multiple Entries Service', () => {
     })
 
     describe('thats been entered using commas as the split', () => {
-      before(() => {
+      beforeEach(() => {
         // NOTE: By adding a comma and space at the end of the string when this is split it will create a empty value
         // in the array. This should then be stripped out of the final array as only numbers or null values are allowed
         multipleEntries = '1.1, 2.2, 200, 400.4, 3000, 400, 7.6, '
@@ -52,7 +53,7 @@ describe('Return Logs - Split Multiple Entries Service', () => {
       })
 
       describe('that has been entered with "x"s values', () => {
-        before(() => {
+        beforeEach(() => {
           multipleEntries = 'x, X, x, X'
         })
 
@@ -66,7 +67,7 @@ describe('Return Logs - Split Multiple Entries Service', () => {
   })
 
   describe('when passed an invalid multiple entries string', () => {
-    before(() => {
+    beforeEach(() => {
       multipleEntries = 'invalid multiple entries string'
     })
 

--- a/test/services/return-logs/setup/split-multiple-entries.service.test.js
+++ b/test/services/return-logs/setup/split-multiple-entries.service.test.js
@@ -3,9 +3,8 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
-const Sinon = require('sinon')
 
-const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Thing under test

--- a/test/services/return-logs/setup/start-reading.service.test.js
+++ b/test/services/return-logs/setup/start-reading.service.test.js
@@ -8,6 +8,7 @@ const Sinon = require('sinon')
 const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
+// Test helpers
 const SessionModelStub = require('../../../support/stubs/session.stub.js')
 
 // Things we need to stub

--- a/test/services/return-logs/setup/start-reading.service.test.js
+++ b/test/services/return-logs/setup/start-reading.service.test.js
@@ -5,7 +5,7 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers

--- a/test/services/return-logs/setup/start-reading.service.test.js
+++ b/test/services/return-logs/setup/start-reading.service.test.js
@@ -3,25 +3,35 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
+const Sinon = require('sinon')
 
-const { describe, it, before } = (exports.lab = Lab.script())
+const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
-// Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const StartReadingService = require('../../../../app/services/return-logs/setup/start-reading.service.js')
 
 describe('Return Logs Setup - Start Reading service', () => {
   let session
+  let sessionData
 
-  before(async () => {
-    session = await SessionHelper.add({
-      data: {
-        returnReference: '012345'
-      }
-    })
+  beforeEach(() => {
+    sessionData = {
+      returnReference: '012345'
+    }
+
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    Sinon.stub(FetchSessionDal, 'go').resolves(session)
+  })
+
+  afterEach(() => {
+    Sinon.restore()
   })
 
   describe('when called', () => {

--- a/test/services/return-logs/setup/submission.service.test.js
+++ b/test/services/return-logs/setup/submission.service.test.js
@@ -8,6 +8,7 @@ const Sinon = require('sinon')
 const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
+// Test helpers
 const SessionModelStub = require('../../../support/stubs/session.stub.js')
 
 // Things we need to stub

--- a/test/services/return-logs/setup/submission.service.test.js
+++ b/test/services/return-logs/setup/submission.service.test.js
@@ -3,30 +3,41 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
+const Sinon = require('sinon')
 
-const { describe, it, before } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
-// Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const SubmissionService = require('../../../../app/services/return-logs/setup/submission.service.js')
 
 describe('Return Logs Setup - Submission service', () => {
-  let sessionId
+  let session
+  let sessionData
 
-  before(async () => {
-    const session = await SessionHelper.add({ data: { beenReceived: false, returnReference: '1234' } })
-    sessionId = session.id
+  beforeEach(() => {
+    sessionData = { beenReceived: false, returnReference: '1234' }
+
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    Sinon.stub(FetchSessionDal, 'go').resolves(session)
+  })
+
+  afterEach(() => {
+    Sinon.restore()
   })
 
   describe('when called', () => {
     it('returns page data for the view', async () => {
-      const result = await SubmissionService.go(sessionId)
+      const result = await SubmissionService.go(session.id)
 
       expect(result).to.equal({
-        backLink: { href: `/system/return-logs/setup/${sessionId}/received`, text: 'Back' },
+        backLink: { href: `/system/return-logs/setup/${session.id}/received`, text: 'Back' },
         beenReceived: false,
         journey: null,
         pageTitle: 'What do you want to do with this return?',

--- a/test/services/return-logs/setup/submit-note.service.test.js
+++ b/test/services/return-logs/setup/submit-note.service.test.js
@@ -9,7 +9,10 @@ const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const SubmitNoteService = require('../../../../app/services/return-logs/setup/submit-note.service.js')
@@ -17,12 +20,18 @@ const SubmitNoteService = require('../../../../app/services/return-logs/setup/su
 describe('Return Logs Setup - Submit Note service', () => {
   const user = { username: 'carol.shaw@atari.com' }
 
+  let fetchSessionStub
   let payload
   let session
+  let sessionData
   let yarStub
 
-  beforeEach(async () => {
-    session = await SessionHelper.add({ data: { returnReference: '1234' } })
+  beforeEach(() => {
+    sessionData = { returnReference: '1234' }
+
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    fetchSessionStub = Sinon.stub(FetchSessionDal, 'go').resolves(session)
 
     yarStub = { flash: Sinon.stub() }
   })
@@ -41,12 +50,11 @@ describe('Return Logs Setup - Submit Note service', () => {
         it('saves the submitted value', async () => {
           await SubmitNoteService.go(session.id, payload, user, yarStub)
 
-          const refreshedSession = await session.$query()
-
-          expect(refreshedSession.note).to.equal({
+          expect(session.note).to.equal({
             content: 'A new note related to return logs',
             userEmail: 'carol.shaw@atari.com'
           })
+          expect(session.$update.called).to.be.true()
         })
 
         it('returns the correct details the controller needs to redirect the journey', async () => {
@@ -66,15 +74,17 @@ describe('Return Logs Setup - Submit Note service', () => {
       })
 
       describe('that is an updated note', () => {
-        beforeEach(async () => {
-          await session.$query().patch({
-            data: {
-              note: {
-                content: 'A old note related to return requirement',
-                userEmail: 'carol.shaw@atari.com'
-              }
+        beforeEach(() => {
+          sessionData = {
+            note: {
+              content: 'A old note related to return requirement',
+              userEmail: 'carol.shaw@atari.com'
             }
-          })
+          }
+
+          session = SessionModelStub.build(Sinon, sessionData)
+
+          fetchSessionStub.resolves(session)
 
           payload = { note: 'An updated note related to return requirement' }
         })
@@ -82,9 +92,7 @@ describe('Return Logs Setup - Submit Note service', () => {
         it('saves the submitted value', async () => {
           await SubmitNoteService.go(session.id, payload, user, yarStub)
 
-          const refreshedSession = await session.$query()
-
-          expect(refreshedSession.note).to.equal({
+          expect(session.note).to.equal({
             content: 'An updated note related to return requirement',
             userEmail: 'carol.shaw@atari.com'
           })

--- a/test/services/return-logs/setup/submit-period-used.service.test.js
+++ b/test/services/return-logs/setup/submit-period-used.service.test.js
@@ -8,6 +8,7 @@ const Sinon = require('sinon')
 const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
+// Test helpers
 const SessionModelStub = require('../../../support/stubs/session.stub.js')
 
 // Things we need to stub

--- a/test/services/return-logs/setup/submit-period-used.service.test.js
+++ b/test/services/return-logs/setup/submit-period-used.service.test.js
@@ -3,12 +3,15 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
+const Sinon = require('sinon')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
-// Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const SubmitPeriodUsedService = require('../../../../app/services/return-logs/setup/submit-period-used.service.js')
@@ -18,78 +21,80 @@ describe('Return Logs Setup - Submit Period Used service', () => {
   let session
   let sessionData
 
-  beforeEach(async () => {
+  beforeEach(() => {
     sessionData = {
-      data: {
-        returnReference: '12345',
-        startDate: '2023-04-01',
-        endDate: '2024-03-31',
-        periodStartDay: '01',
-        periodStartMonth: '04',
-        periodEndDay: '31',
-        periodEndMonth: '03',
-        singleVolumeQuantity: '1200',
-        units: 'cubicMetres',
-        unitSymbol: 'm³',
-        lines: [
-          { startDate: new Date('2023-04-01'), endDate: new Date('2023-04-30') },
-          { startDate: new Date('2023-05-01'), endDate: new Date('2023-05-31') },
-          { startDate: new Date('2023-06-01'), endDate: new Date('2023-06-30') },
-          { startDate: new Date('2023-07-01'), endDate: new Date('2023-07-31') },
-          { startDate: new Date('2023-08-01'), endDate: new Date('2023-08-31') },
-          { startDate: new Date('2023-09-01'), endDate: new Date('2023-09-30') },
-          { startDate: new Date('2023-10-01'), endDate: new Date('2023-10-31') },
-          { startDate: new Date('2023-11-01'), endDate: new Date('2023-11-30') },
-          { startDate: new Date('2023-12-01'), endDate: new Date('2023-12-31') },
-          { startDate: new Date('2024-01-01'), endDate: new Date('2024-01-31') },
-          { startDate: new Date('2024-02-01'), endDate: new Date('2024-02-29') },
-          { startDate: new Date('2024-03-01'), endDate: new Date('2024-03-31') }
-        ]
-      }
+      returnReference: '12345',
+      startDate: '2023-04-01',
+      endDate: '2024-03-31',
+      periodStartDay: '01',
+      periodStartMonth: '04',
+      periodEndDay: '31',
+      periodEndMonth: '03',
+      singleVolumeQuantity: '1200',
+      units: 'cubicMetres',
+      unitSymbol: 'm³',
+      lines: [
+        // The session object will have the dates set as strings, so we need to convert the type here
+        { startDate: new Date('2023-04-01').toISOString(), endDate: new Date('2023-04-30').toISOString() },
+        { startDate: new Date('2023-05-01').toISOString(), endDate: new Date('2023-05-31').toISOString() },
+        { startDate: new Date('2023-06-01').toISOString(), endDate: new Date('2023-06-30').toISOString() },
+        { startDate: new Date('2023-07-01').toISOString(), endDate: new Date('2023-07-31').toISOString() },
+        { startDate: new Date('2023-08-01').toISOString(), endDate: new Date('2023-08-31').toISOString() },
+        { startDate: new Date('2023-09-01').toISOString(), endDate: new Date('2023-09-30').toISOString() },
+        { startDate: new Date('2023-10-01').toISOString(), endDate: new Date('2023-10-31').toISOString() },
+        { startDate: new Date('2023-11-01').toISOString(), endDate: new Date('2023-11-30').toISOString() },
+        { startDate: new Date('2023-12-01').toISOString(), endDate: new Date('2023-12-31').toISOString() },
+        { startDate: new Date('2024-01-01').toISOString(), endDate: new Date('2024-01-31').toISOString() },
+        { startDate: new Date('2024-02-01').toISOString(), endDate: new Date('2024-02-29').toISOString() },
+        { startDate: new Date('2024-03-01').toISOString(), endDate: new Date('2024-03-31').toISOString() }
+      ]
     }
 
-    session = await SessionHelper.add(sessionData)
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    Sinon.stub(FetchSessionDal, 'go').resolves(session)
+  })
+
+  afterEach(() => {
+    Sinon.restore()
   })
 
   describe('when called', () => {
     describe('with a valid payload', () => {
       describe('because the user entered the default abstraction period', () => {
-        beforeEach(async () => {
+        beforeEach(() => {
           payload = { periodDateUsedOptions: 'default' }
         })
 
         it('saves the submitted option', async () => {
           await SubmitPeriodUsedService.go(session.id, payload)
 
-          const refreshedSession = await session.$query()
-
-          expect(refreshedSession.periodDateUsedOptions).to.equal('default')
-          expect(refreshedSession.fromFullDate).to.equal('2023-04-01T00:00:00.000Z')
-          expect(refreshedSession.toFullDate).to.equal('2024-03-31T00:00:00.000Z')
+          expect(session.periodDateUsedOptions).to.equal('default')
+          expect(session.fromFullDate).to.equal('2023-04-01T00:00:00.000Z')
+          expect(session.toFullDate).to.equal('2024-03-31T00:00:00.000Z')
+          expect(session.$update.called).to.be.true()
         })
 
         it('applies the single volume to the applicable lines', async () => {
           await SubmitPeriodUsedService.go(session.id, payload)
 
-          const refreshedSession = await session.$query()
-
-          expect(refreshedSession.lines[0].quantity).to.equal(100)
-          expect(refreshedSession.lines[1].quantity).to.equal(100)
-          expect(refreshedSession.lines[2].quantity).to.equal(100)
-          expect(refreshedSession.lines[3].quantity).to.equal(100)
-          expect(refreshedSession.lines[4].quantity).to.equal(100)
-          expect(refreshedSession.lines[5].quantity).to.equal(100)
-          expect(refreshedSession.lines[6].quantity).to.equal(100)
-          expect(refreshedSession.lines[7].quantity).to.equal(100)
-          expect(refreshedSession.lines[8].quantity).to.equal(100)
-          expect(refreshedSession.lines[9].quantity).to.equal(100)
-          expect(refreshedSession.lines[10].quantity).to.equal(100)
-          expect(refreshedSession.lines[11].quantity).to.equal(100)
+          expect(session.lines[0].quantity).to.equal(100)
+          expect(session.lines[1].quantity).to.equal(100)
+          expect(session.lines[2].quantity).to.equal(100)
+          expect(session.lines[3].quantity).to.equal(100)
+          expect(session.lines[4].quantity).to.equal(100)
+          expect(session.lines[5].quantity).to.equal(100)
+          expect(session.lines[6].quantity).to.equal(100)
+          expect(session.lines[7].quantity).to.equal(100)
+          expect(session.lines[8].quantity).to.equal(100)
+          expect(session.lines[9].quantity).to.equal(100)
+          expect(session.lines[10].quantity).to.equal(100)
+          expect(session.lines[11].quantity).to.equal(100)
         })
       })
 
       describe('because the user entered a custom period', () => {
-        beforeEach(async () => {
+        beforeEach(() => {
           payload = {
             periodDateUsedOptions: 'customDates',
             periodUsedFromDay: '15',
@@ -104,42 +109,39 @@ describe('Return Logs Setup - Submit Period Used service', () => {
         it('saves the submitted option', async () => {
           await SubmitPeriodUsedService.go(session.id, payload)
 
-          const refreshedSession = await session.$query()
-
-          expect(refreshedSession.periodDateUsedOptions).to.equal('customDates')
-          expect(refreshedSession.periodUsedFromDay).to.equal('15')
-          expect(refreshedSession.periodUsedFromMonth).to.equal('08')
-          expect(refreshedSession.periodUsedFromYear).to.equal('2023')
-          expect(refreshedSession.periodUsedToDay).to.equal('20')
-          expect(refreshedSession.periodUsedToMonth).to.equal('01')
-          expect(refreshedSession.periodUsedToYear).to.equal('2024')
-          expect(refreshedSession.fromFullDate).to.equal('2023-08-15T00:00:00.000Z')
-          expect(refreshedSession.toFullDate).to.equal('2024-01-20T00:00:00.000Z')
+          expect(session.periodDateUsedOptions).to.equal('customDates')
+          expect(session.periodUsedFromDay).to.equal('15')
+          expect(session.periodUsedFromMonth).to.equal('08')
+          expect(session.periodUsedFromYear).to.equal('2023')
+          expect(session.periodUsedToDay).to.equal('20')
+          expect(session.periodUsedToMonth).to.equal('01')
+          expect(session.periodUsedToYear).to.equal('2024')
+          expect(session.fromFullDate).to.equal('2023-08-15T00:00:00.000Z')
+          expect(session.toFullDate).to.equal('2024-01-20T00:00:00.000Z')
+          expect(session.$update.called).to.be.true()
         })
 
         it('applies the single volume to the applicable lines', async () => {
           await SubmitPeriodUsedService.go(session.id, payload)
 
-          const refreshedSession = await session.$query()
-
-          expect(refreshedSession.lines[0].quantity).to.not.exist()
-          expect(refreshedSession.lines[1].quantity).to.not.exist()
-          expect(refreshedSession.lines[2].quantity).to.not.exist()
-          expect(refreshedSession.lines[3].quantity).to.not.exist()
-          expect(refreshedSession.lines[4].quantity).to.not.exist()
-          expect(refreshedSession.lines[5].quantity).to.equal(300)
-          expect(refreshedSession.lines[6].quantity).to.equal(300)
-          expect(refreshedSession.lines[7].quantity).to.equal(300)
-          expect(refreshedSession.lines[8].quantity).to.equal(300)
-          expect(refreshedSession.lines[9].quantity).to.not.exist()
-          expect(refreshedSession.lines[10].quantity).to.not.exist()
-          expect(refreshedSession.lines[11].quantity).to.not.exist()
+          expect(session.lines[0].quantity).to.not.exist()
+          expect(session.lines[1].quantity).to.not.exist()
+          expect(session.lines[2].quantity).to.not.exist()
+          expect(session.lines[3].quantity).to.not.exist()
+          expect(session.lines[4].quantity).to.not.exist()
+          expect(session.lines[5].quantity).to.equal(300)
+          expect(session.lines[6].quantity).to.equal(300)
+          expect(session.lines[7].quantity).to.equal(300)
+          expect(session.lines[8].quantity).to.equal(300)
+          expect(session.lines[9].quantity).to.not.exist()
+          expect(session.lines[10].quantity).to.not.exist()
+          expect(session.lines[11].quantity).to.not.exist()
         })
       })
     })
 
     describe('with an invalid payload', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         payload = {}
       })
 

--- a/test/services/return-logs/setup/submit-single-volume.service.test.js
+++ b/test/services/return-logs/setup/submit-single-volume.service.test.js
@@ -8,6 +8,7 @@ const Sinon = require('sinon')
 const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
+// Test helpers
 const SessionModelStub = require('../../../support/stubs/session.stub.js')
 
 // Things we need to stub

--- a/test/services/return-logs/setup/submit-single-volume.service.test.js
+++ b/test/services/return-logs/setup/submit-single-volume.service.test.js
@@ -5,7 +5,7 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers

--- a/test/services/return-logs/setup/submit-single-volume.service.test.js
+++ b/test/services/return-logs/setup/submit-single-volume.service.test.js
@@ -3,12 +3,15 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
+const Sinon = require('sinon')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
-// Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const SubmitSingleVolumeService = require('../../../../app/services/return-logs/setup/submit-single-volume.service.js')
@@ -18,30 +21,34 @@ describe('Return Logs Setup - Submit Single Volume service', () => {
   let session
   let sessionData
 
-  beforeEach(async () => {
+  beforeEach(() => {
     sessionData = {
-      data: {
-        returnReference: '12345',
-        units: 'litres'
-      }
+      returnReference: '12345',
+      units: 'litres'
     }
 
-    session = await SessionHelper.add(sessionData)
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    Sinon.stub(FetchSessionDal, 'go').resolves(session)
+  })
+
+  afterEach(() => {
+    Sinon.restore()
   })
 
   describe('when called', () => {
     describe('with a valid payload', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         payload = { singleVolume: 'yes', singleVolumeQuantity: '1000' }
       })
 
       it('saves the submitted option', async () => {
         await SubmitSingleVolumeService.go(session.id, payload)
 
-        const refreshedSession = await session.$query()
+        expect(session.singleVolume).to.equal('yes')
+        expect(session.singleVolumeQuantity).to.equal(1000)
 
-        expect(refreshedSession.singleVolume).to.equal('yes')
-        expect(refreshedSession.singleVolumeQuantity).to.equal(1000)
+        expect(session.$update.called).to.be.true()
       })
 
       describe('and the user has previously selected "yes" to a single volume being provided', () => {
@@ -53,7 +60,7 @@ describe('Return Logs Setup - Submit Single Volume service', () => {
       })
 
       describe('and the user has previously selected "no" to a single volume being provided', () => {
-        beforeEach(async () => {
+        beforeEach(() => {
           payload = { singleVolume: 'no' }
         })
 
@@ -66,7 +73,7 @@ describe('Return Logs Setup - Submit Single Volume service', () => {
     })
 
     describe('with an invalid payload', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         payload = {}
       })
 

--- a/test/services/return-logs/setup/submit-submission.service.test.js
+++ b/test/services/return-logs/setup/submit-submission.service.test.js
@@ -9,32 +9,41 @@ const { expect } = Code
 const Sinon = require('sinon')
 
 // Test helpers
-const { generateUUID } = require('../../../../app/lib/general.lib.js')
 const ReturnLogHelper = require('../../../support/helpers/return-log.helper.js')
 const ReturnRequirementHelper = require('../../../support/helpers/return-requirement.helper.js')
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+const { generateUUID } = require('../../../../app/lib/general.lib.js')
+
+// Things we need to stub
+const DeleteSessionDal = require('../../../../app/dal/delete-session.dal.js')
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const SubmitSubmissionService = require('../../../../app/services/return-logs/setup/submit-submission.service.js')
 
 describe('Return Logs - Setup - Submit Submission service', () => {
+  let fetchSessionStub
   let payload
   let returnLog
   let returnLogId
   let session
+  let sessionData
 
-  beforeEach(async () => {
+  beforeEach(() => {
     returnLogId = generateUUID()
 
-    session = await SessionHelper.add({
-      data: {
-        beenReceived: false,
-        receivedDateOptions: 'today',
-        receivedDate: new Date('2025-02-14'),
-        returnLogId,
-        returnReference: ReturnRequirementHelper.generateReference()
-      }
-    })
+    sessionData = {
+      beenReceived: false,
+      receivedDateOptions: 'today',
+      receivedDate: new Date('2025-02-14'),
+      returnLogId,
+      returnReference: ReturnRequirementHelper.generateReference()
+    }
+
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    fetchSessionStub = Sinon.stub(FetchSessionDal, 'go').resolves(session)
+    Sinon.stub(DeleteSessionDal, 'go').resolves()
   })
 
   afterEach(() => {
@@ -44,32 +53,30 @@ describe('Return Logs - Setup - Submit Submission service', () => {
   describe('when called', () => {
     describe('with a valid payload', () => {
       describe('and the user has selected "Enter and submit"', () => {
-        beforeEach(async () => {
+        beforeEach(() => {
           payload = { journey: 'enterReturn' }
         })
 
         it('saves the submitted option to the session and returns the redirect as "reported"', async () => {
           const result = await SubmitSubmissionService.go(session.id, payload)
 
-          const refreshedSession = await session.$query()
-
-          expect(refreshedSession.journey).to.equal('enterReturn')
+          expect(session.journey).to.equal('enterReturn')
           expect(result.redirect).to.equal('reported')
+          expect(session.$update.called).to.be.true()
         })
       })
 
       describe('and the user has selected "Enter a nil return"', () => {
-        beforeEach(async () => {
+        beforeEach(() => {
           payload = { journey: 'nilReturn' }
         })
 
         it('saves the submitted option to the session and returns the redirect as "check"', async () => {
           const result = await SubmitSubmissionService.go(session.id, payload)
 
-          const refreshedSession = await session.$query()
-
-          expect(refreshedSession.journey).to.equal('nilReturn')
+          expect(session.journey).to.equal('nilReturn')
           expect(result.redirect).to.equal('check')
+          expect(session.$update.called).to.be.true()
         })
       })
 
@@ -89,15 +96,13 @@ describe('Return Logs - Setup - Submit Submission service', () => {
           expect(refreshedReturnLog.status).to.equal('received')
 
           // Check the received date has been set to what was recorded in the session
-          expect(refreshedReturnLog.receivedDate).to.equal(new Date(session.data.receivedDate))
+          expect(refreshedReturnLog.receivedDate).to.equal(new Date(session.receivedDate))
 
           // Check the updated at timestamp has been set
           expect(refreshedReturnLog.updatedAt).to.be.greaterThan(returnLog.updatedAt)
 
           // Check the session got deleted
-          const refreshedSession = await session.$query()
-
-          expect(refreshedSession).not.to.exist()
+          expect(DeleteSessionDal.go.calledWith(session.id)).to.be.true()
 
           // Check the redirect takes will tell the controller to redirect to the return received confirmation page
           expect(result.redirect).to.equal('confirm-received')
@@ -105,20 +110,21 @@ describe('Return Logs - Setup - Submit Submission service', () => {
       })
 
       describe('and the check page had been visited previously', () => {
-        beforeEach(async () => {
+        beforeEach(() => {
           payload = { journey: 'enterReturn' }
 
-          session = await SessionHelper.add({
-            data: { beenReceived: false, checkPageVisited: true, returnLogId, returnReference: '1234' }
-          })
+          sessionData = { beenReceived: false, checkPageVisited: true, returnLogId, returnReference: '1234' }
+
+          session = SessionModelStub.build(Sinon, sessionData)
+
+          fetchSessionStub.resolves(session)
         })
 
         it('updates "checkPageVisited" to false in the session data', async () => {
           await SubmitSubmissionService.go(session.id, payload)
 
-          const refreshedSession = await session.$query()
-
-          expect(refreshedSession.checkPageVisited).to.be.false()
+          expect(session.checkPageVisited).to.be.false()
+          expect(session.$update.called).to.be.true()
         })
       })
     })

--- a/test/services/return-logs/setup/units.service.test.js
+++ b/test/services/return-logs/setup/units.service.test.js
@@ -3,25 +3,35 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
+const Sinon = require('sinon')
 
-const { describe, it, before } = (exports.lab = Lab.script())
+const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
-// Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const UnitsService = require('../../../../app/services/return-logs/setup/units.service.js')
 
 describe('Return Logs Setup - Units service', () => {
   let session
+  let sessionData
 
-  before(async () => {
-    session = await SessionHelper.add({
-      data: {
-        returnReference: '012345'
-      }
-    })
+  beforeEach(() => {
+    sessionData = {
+      returnReference: '012345'
+    }
+
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    Sinon.stub(FetchSessionDal, 'go').resolves(session)
+  })
+
+  afterEach(() => {
+    Sinon.restore()
   })
 
   describe('when called', () => {

--- a/test/services/return-logs/setup/units.service.test.js
+++ b/test/services/return-logs/setup/units.service.test.js
@@ -8,6 +8,7 @@ const Sinon = require('sinon')
 const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
+// Test helpers
 const SessionModelStub = require('../../../support/stubs/session.stub.js')
 
 // Things we need to stub

--- a/test/services/return-logs/setup/units.service.test.js
+++ b/test/services/return-logs/setup/units.service.test.js
@@ -5,7 +5,7 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers

--- a/test/services/return-logs/setup/volumes.service.test.js
+++ b/test/services/return-logs/setup/volumes.service.test.js
@@ -8,6 +8,7 @@ const Sinon = require('sinon')
 const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
+// Test helpers
 const SessionModelStub = require('../../../support/stubs/session.stub.js')
 
 // Things we need to stub

--- a/test/services/return-logs/setup/volumes.service.test.js
+++ b/test/services/return-logs/setup/volumes.service.test.js
@@ -3,12 +3,15 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
+const Sinon = require('sinon')
 
-const { describe, it, before } = (exports.lab = Lab.script())
+const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
-// Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const VolumesService = require('../../../../app/services/return-logs/setup/volumes.service.js')
@@ -17,26 +20,33 @@ describe('Return Logs Setup - Volumes service', () => {
   const yearMonth = '2023-3'
 
   let session
+  let sessionData
 
-  before(async () => {
-    session = await SessionHelper.add({
-      data: {
-        lines: [
-          {
-            endDate: '2023-04-30T00:00:00.000Z',
-            quantity: 100,
-            startDate: '2023-04-01T00:00:00.000Z'
-          },
-          {
-            endDate: '2023-05-31T00:00:00.000Z',
-            startDate: '2023-05-01T00:00:00.000Z'
-          }
-        ],
-        returnsFrequency: 'month',
-        returnReference: '1234',
-        units: 'cubicMetres'
-      }
-    })
+  beforeEach(() => {
+    sessionData = {
+      lines: [
+        {
+          endDate: '2023-04-30T00:00:00.000Z',
+          quantity: 100,
+          startDate: '2023-04-01T00:00:00.000Z'
+        },
+        {
+          endDate: '2023-05-31T00:00:00.000Z',
+          startDate: '2023-05-01T00:00:00.000Z'
+        }
+      ],
+      returnsFrequency: 'month',
+      returnReference: '1234',
+      units: 'cubicMetres'
+    }
+
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    Sinon.stub(FetchSessionDal, 'go').resolves(session)
+  })
+
+  afterEach(() => {
+    Sinon.restore()
   })
 
   describe('when called', () => {

--- a/test/services/return-logs/setup/volumes.service.test.js
+++ b/test/services/return-logs/setup/volumes.service.test.js
@@ -5,7 +5,7 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5573

We recently refactored how we use fetch and delete session data, we now have a single way of doing each.

We are moving away from using the database in service test.

This change updates some of the tests still using the session helper to stub the 'FetchSessionDal'