### PR TITLE
Update tests to stub 'FetchSessionDal'

### DIFF
--- a/test/services/bill-runs/setup/season.service.test.js
+++ b/test/services/bill-runs/setup/season.service.test.js
@@ -3,21 +3,34 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
+const Sinon = require('sinon')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const SeasonService = require('../../../../app/services/bill-runs/setup/season.service.js')
 
 describe('Bill Runs - Setup - Type service', () => {
   let session
+  let sessionData
 
-  beforeEach(async () => {
-    session = await SessionHelper.add({ data: { season: 'summer' } })
+  beforeEach(() => {
+    sessionData = { season: 'summer' }
+
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    Sinon.stub(FetchSessionDal, 'go').resolves(session)
+  })
+
+  afterEach(() => {
+    Sinon.restore()
   })
 
   describe('when called', () => {

--- a/test/services/bill-runs/setup/season.service.test.js
+++ b/test/services/bill-runs/setup/season.service.test.js
@@ -5,7 +5,7 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers

--- a/test/services/bill-runs/setup/submit-season.service.test.js
+++ b/test/services/bill-runs/setup/submit-season.service.test.js
@@ -5,7 +5,7 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers

--- a/test/services/bill-runs/setup/submit-season.service.test.js
+++ b/test/services/bill-runs/setup/submit-season.service.test.js
@@ -3,12 +3,16 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
+const Sinon = require('sinon')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const SubmitSeasonService = require('../../../../app/services/bill-runs/setup/submit-season.service.js')
@@ -16,9 +20,18 @@ const SubmitSeasonService = require('../../../../app/services/bill-runs/setup/su
 describe('Bill Runs - Setup - Submit Season service', () => {
   let payload
   let session
+  let sessionData
 
-  beforeEach(async () => {
-    session = await SessionHelper.add({ data: {} })
+  beforeEach(() => {
+    sessionData = {}
+
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    Sinon.stub(FetchSessionDal, 'go').resolves(session)
+  })
+
+  afterEach(() => {
+    Sinon.restore()
   })
 
   describe('when called', () => {
@@ -32,9 +45,8 @@ describe('Bill Runs - Setup - Submit Season service', () => {
       it('saves the submitted value', async () => {
         await SubmitSeasonService.go(session.id, payload)
 
-        const refreshedSession = await session.$query()
-
-        expect(refreshedSession.season).to.equal('summer')
+        expect(session.season).to.equal('summer')
+        expect(session.$update.called).to.be.true()
       })
 
       it('returns an empty object (no page data is needed for a redirect)', async () => {

--- a/test/services/bill-runs/setup/submit-type.service.test.js
+++ b/test/services/bill-runs/setup/submit-type.service.test.js
@@ -5,7 +5,7 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers

--- a/test/services/bill-runs/setup/submit-type.service.test.js
+++ b/test/services/bill-runs/setup/submit-type.service.test.js
@@ -3,12 +3,16 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
+const Sinon = require('sinon')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const SubmitTypeService = require('../../../../app/services/bill-runs/setup/submit-type.service.js')
@@ -16,9 +20,18 @@ const SubmitTypeService = require('../../../../app/services/bill-runs/setup/subm
 describe('Bill Runs - Setup - Submit Type service', () => {
   let payload
   let session
+  let sessionData
 
-  beforeEach(async () => {
-    session = await SessionHelper.add({ data: {} })
+  beforeEach(() => {
+    sessionData = {}
+
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    Sinon.stub(FetchSessionDal, 'go').resolves(session)
+  })
+
+  afterEach(() => {
+    Sinon.restore()
   })
 
   describe('when called', () => {
@@ -32,15 +45,14 @@ describe('Bill Runs - Setup - Submit Type service', () => {
       it('saves the submitted value', async () => {
         await SubmitTypeService.go(session.id, payload)
 
-        const refreshedSession = await session.$query()
-
-        expect(refreshedSession.type).to.equal('annual')
+        expect(session.type).to.equal('annual')
       })
 
       it('returns an empty object (no page data is needed for a redirect)', async () => {
         const result = await SubmitTypeService.go(session.id, payload)
 
         expect(result).to.equal({})
+        expect(session.$update.called).to.be.true()
       })
     })
 

--- a/test/services/bill-runs/setup/submit-year.service.test.js
+++ b/test/services/bill-runs/setup/submit-year.service.test.js
@@ -9,20 +9,27 @@ const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
 
 // Things we need to stub
 const FetchLicenceSupplementaryYearsService = require('../../../../app/services/bill-runs/setup/fetch-licence-supplementary-years.service.js')
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const SubmitYearService = require('../../../../app/services/bill-runs/setup/submit-year.service.js')
 
 describe('Bill Runs - Setup - Submit Year service', () => {
+  let fetchSessionStub
   let payload
   let session
+  let sessionData
 
-  beforeEach(async () => {
-    session = await SessionHelper.add({ data: {} })
+  beforeEach(() => {
+    sessionData = {}
+
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    fetchSessionStub = Sinon.stub(FetchSessionDal, 'go').resolves(session)
   })
 
   afterEach(() => {
@@ -41,10 +48,9 @@ describe('Bill Runs - Setup - Submit Year service', () => {
         it('saves the submitted value and returns an object confirming setup is complete', async () => {
           const result = await SubmitYearService.go(session.id, payload)
 
-          const refreshedSession = await session.$query()
-
-          expect(refreshedSession.year).to.equal('2026')
+          expect(session.year).to.equal('2026')
           expect(result.setupComplete).to.be.true()
+          expect(session.$update.called).to.be.true()
         })
       })
 
@@ -58,10 +64,10 @@ describe('Bill Runs - Setup - Submit Year service', () => {
         it('saves the submitted value and returns an object confirming setup is not complete', async () => {
           const result = await SubmitYearService.go(session.id, payload)
 
-          const refreshedSession = await session.$query()
-
-          expect(refreshedSession.year).to.equal('2022')
+          expect(session.year).to.equal('2022')
           expect(result.setupComplete).to.be.false()
+
+          expect(session.$update.called).to.be.true()
         })
       })
     })
@@ -72,8 +78,12 @@ describe('Bill Runs - Setup - Submit Year service', () => {
 
         let yearsStub
 
-        beforeEach(async () => {
-          session = await SessionHelper.add({ data: { region: regionId, type: 'two_part_supplementary' } })
+        beforeEach(() => {
+          sessionData = { region: regionId, type: 'two_part_supplementary' }
+
+          session = SessionModelStub.build(Sinon, sessionData)
+
+          fetchSessionStub.resolves(session)
           payload = {}
           yearsStub = Sinon.stub(FetchLicenceSupplementaryYearsService, 'go').resolves([{ financialYearEnd: 2024 }])
         })

--- a/test/services/bill-runs/setup/type.service.test.js
+++ b/test/services/bill-runs/setup/type.service.test.js
@@ -5,7 +5,7 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers

--- a/test/services/bill-runs/setup/type.service.test.js
+++ b/test/services/bill-runs/setup/type.service.test.js
@@ -3,21 +3,33 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
+const Sinon = require('sinon')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const TypeService = require('../../../../app/services/bill-runs/setup/type.service.js')
 
 describe('Bill Runs - Setup - Type service', () => {
   let session
+  let sessionData
 
-  beforeEach(async () => {
-    session = await SessionHelper.add({ data: { type: 'annual' } })
+  beforeEach(() => {
+    sessionData = { type: 'annual' }
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    Sinon.stub(FetchSessionDal, 'go').resolves(session)
+  })
+
+  afterEach(() => {
+    Sinon.restore()
   })
 
   describe('when called', () => {

--- a/test/services/company-contacts/setup/view-cancel.service.test.js
+++ b/test/services/company-contacts/setup/view-cancel.service.test.js
@@ -5,7 +5,7 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, afterEach, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers

--- a/test/services/company-contacts/setup/view-cancel.service.test.js
+++ b/test/services/company-contacts/setup/view-cancel.service.test.js
@@ -23,7 +23,7 @@ describe('Company Contacts - Setup - Cancel Service', () => {
   let session
   let sessionData
 
-  beforeEach(async () => {
+  beforeEach(() => {
     company = CustomersFixtures.company()
 
     sessionData = { company, abstractionAlerts: 'yes', name: 'Eric', email: 'eric@test.com' }

--- a/test/services/licence-monitoring-station/setup/submit-stop-or-reduce.service.test.js
+++ b/test/services/licence-monitoring-station/setup/submit-stop-or-reduce.service.test.js
@@ -3,45 +3,53 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
+const Sinon = require('sinon')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const SubmitStopOrReduceService = require('../../../../app/services/licence-monitoring-station/setup/submit-stop-or-reduce.service.js')
 
 describe('Licence Monitoring Station Setup - Stop Or Reduce service', () => {
+  let fetchSessionStub
   let payload
   let session
   let sessionData
 
-  beforeEach(async () => {
+  beforeEach(() => {
     sessionData = {
-      data: {
-        label: 'Monitoring Station Label',
-        monitoringStationId: 'e1c44f9b-51c2-4aee-a518-5509d6f05869'
-      }
+      label: 'Monitoring Station Label',
+      monitoringStationId: 'e1c44f9b-51c2-4aee-a518-5509d6f05869'
     }
 
-    session = await SessionHelper.add(sessionData)
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    fetchSessionStub = Sinon.stub(FetchSessionDal, 'go').resolves(session)
+  })
+
+  afterEach(() => {
+    Sinon.restore()
   })
 
   describe('when called', () => {
     describe('with a valid payload', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         payload = { stopOrReduce: 'stop' }
       })
 
       it('saves the submitted option', async () => {
         await SubmitStopOrReduceService.go(session.id, payload)
 
-        const refreshedSession = await session.$query()
-
-        expect(refreshedSession.stopOrReduce).to.equal('stop')
-        expect(refreshedSession.reduceAtThreshold).to.equal(null)
+        expect(session.stopOrReduce).to.equal('stop')
+        expect(session.reduceAtThreshold).to.equal(null)
+        expect(session.$update.called).to.be.true()
       })
 
       describe('and the page has been not been visited', () => {
@@ -55,8 +63,12 @@ describe('Licence Monitoring Station Setup - Stop Or Reduce service', () => {
       })
 
       describe('and the page has been visited', () => {
-        beforeEach(async () => {
-          session = await SessionHelper.add({ data: { ...sessionData.data, checkPageVisited: true } })
+        beforeEach(() => {
+          sessionData = { ...sessionData, checkPageVisited: true }
+
+          session = SessionModelStub.build(Sinon, sessionData)
+
+          fetchSessionStub.resolves(session)
         })
 
         it('returns the correct details the controller needs to redirect the journey to the check page', async () => {
@@ -65,12 +77,13 @@ describe('Licence Monitoring Station Setup - Stop Or Reduce service', () => {
           expect(result).to.equal({
             checkPageVisited: true
           })
+          expect(session.$update.called).to.be.true()
         })
       })
     })
 
     describe('with an invalid payload', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         payload = {}
       })
 
@@ -104,7 +117,7 @@ describe('Licence Monitoring Station Setup - Stop Or Reduce service', () => {
       })
 
       describe('because the user has not entered the "reduceAtThreshold"', () => {
-        beforeEach(async () => {
+        beforeEach(() => {
           payload = {
             stopOrReduce: 'reduce'
           }

--- a/test/services/licence-monitoring-station/setup/submit-threshold-and-unit.service.test.js
+++ b/test/services/licence-monitoring-station/setup/submit-threshold-and-unit.service.test.js
@@ -3,45 +3,53 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
+const Sinon = require('sinon')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const SubmitThresholdAndUnitService = require('../../../../app/services/licence-monitoring-station/setup/submit-threshold-and-unit.service.js')
 
 describe('Licence Monitoring Station Setup - Threshold and Unit service', () => {
+  let fetchSessionStub
   let payload
   let session
   let sessionData
 
-  beforeEach(async () => {
+  beforeEach(() => {
     sessionData = {
-      data: {
-        label: 'Monitoring Station Label',
-        monitoringStationId: 'e1c44f9b-51c2-4aee-a518-5509d6f05869'
-      }
+      label: 'Monitoring Station Label',
+      monitoringStationId: 'e1c44f9b-51c2-4aee-a518-5509d6f05869'
     }
 
-    session = await SessionHelper.add(sessionData)
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    fetchSessionStub = Sinon.stub(FetchSessionDal, 'go').resolves(session)
+  })
+
+  afterEach(() => {
+    Sinon.restore()
   })
 
   describe('when called', () => {
     describe('with a valid payload', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         payload = { unit: 'Ml/d', 'threshold-Ml/d': '1000' }
       })
 
       it('saves the submitted option', async () => {
         await SubmitThresholdAndUnitService.go(session.id, payload)
 
-        const refreshedSession = await session.$query()
-
-        expect(refreshedSession.threshold).to.equal(1000)
-        expect(refreshedSession.unit).to.equal('Ml/d')
+        expect(session.threshold).to.equal(1000)
+        expect(session.unit).to.equal('Ml/d')
+        expect(session.$update.called).to.be.true()
       })
 
       describe('and the page has been not been visited', () => {
@@ -55,8 +63,12 @@ describe('Licence Monitoring Station Setup - Threshold and Unit service', () => 
       })
 
       describe('and the page has been visited', () => {
-        beforeEach(async () => {
-          session = await SessionHelper.add({ data: { ...sessionData.data, checkPageVisited: true } })
+        beforeEach(() => {
+          sessionData = { ...sessionData.data, checkPageVisited: true }
+
+          session = SessionModelStub.build(Sinon, sessionData)
+
+          fetchSessionStub.resolves(session)
         })
 
         it('returns the correct details the controller needs to redirect the journey to the check page', async () => {
@@ -70,7 +82,7 @@ describe('Licence Monitoring Station Setup - Threshold and Unit service', () => 
     })
 
     describe('with an invalid payload', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         payload = {}
       })
 
@@ -118,7 +130,7 @@ describe('Licence Monitoring Station Setup - Threshold and Unit service', () => 
       })
 
       describe('because the user has not entered the "threshold"', () => {
-        beforeEach(async () => {
+        beforeEach(() => {
           payload = {
             unit: 'Ml/d'
           }

--- a/test/services/return-logs/setup/submit-check.service.test.js
+++ b/test/services/return-logs/setup/submit-check.service.test.js
@@ -14,12 +14,13 @@ const ReturnLogHelper = require('../../../support/helpers/return-log.helper.js')
 const ReturnLogModel = require('../../../../app/models/return-log.model.js')
 const ReturnSubmissionHelper = require('../../../support/helpers/return-submission.helper.js')
 const SessionModel = require('../../../../app/models/session.model.js')
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
 const UserHelper = require('../../../support/helpers/user.helper.js')
 
 // Things we need to stub
 const CreateReturnLinesService = require('../../../../app/services/return-logs/setup/create-return-lines.service.js')
 const CreateReturnSubmissionService = require('../../../../app/services/return-logs/setup/create-return-submission.service.js')
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 const GenerateReturnSubmissionMetadata = require('../../../../app/services/return-logs/setup/generate-return-submission-metadata.service.js')
 
 // Thing under test
@@ -32,9 +33,10 @@ describe('Return Logs Setup - Submit Check service', () => {
   let sessionData
   let user
 
-  let generateReturnSubmissionMetadataStub
-  let createReturnSubmissionServiceStub
   let createReturnLinesServiceStub
+  let createReturnSubmissionServiceStub
+  let fetchSessionStub
+  let generateReturnSubmissionMetadataStub
 
   const mockGeneratedMetadata = {
     generated: 'metadata',
@@ -56,38 +58,36 @@ describe('Return Logs Setup - Submit Check service', () => {
     })
 
     sessionData = {
-      data: {
-        licenceId: licence.id,
-        licenceRef: licence.licenceRef,
-        purposes: ['test purpose'],
-        reported: 'abstractionVolumes',
-        returnId: returnLog.returnId,
-        returnReference: returnLog.returnReference,
-        returnLogId: returnLog.id,
-        returnSubmissionId: initialReturnSubmission.id,
-        startDate: '2023-01-01',
-        endDate: '2023-12-31',
-        receivedDate: '2024-01-01',
-        journey: 'enterReturn',
-        lines: [
-          {
-            startDate: '2023-01-01T00:00:00.000Z',
-            endDate: '2023-01-31T00:00:00.000Z',
-            quantity: 100,
-            reading: null
-          },
-          {
-            startDate: '2023-02-01T00:00:00.000Z',
-            endDate: '2023-02-28T00:00:00.000Z',
-            quantity: 200,
-            reading: null
-          }
-        ],
-        returnsFrequency: 'month',
-        units: 'cubicMetres',
-        unitSymbol: 'm³',
-        meterProvided: false
-      }
+      licenceId: licence.id,
+      licenceRef: licence.licenceRef,
+      purposes: ['test purpose'],
+      reported: 'abstractionVolumes',
+      returnId: returnLog.returnId,
+      returnReference: returnLog.returnReference,
+      returnLogId: returnLog.id,
+      returnSubmissionId: initialReturnSubmission.id,
+      startDate: '2023-01-01',
+      endDate: '2023-12-31',
+      receivedDate: '2024-01-01',
+      journey: 'enterReturn',
+      lines: [
+        {
+          startDate: '2023-01-01T00:00:00.000Z',
+          endDate: '2023-01-31T00:00:00.000Z',
+          quantity: 100,
+          reading: null
+        },
+        {
+          startDate: '2023-02-01T00:00:00.000Z',
+          endDate: '2023-02-28T00:00:00.000Z',
+          quantity: 200,
+          reading: null
+        }
+      ],
+      returnsFrequency: 'month',
+      units: 'cubicMetres',
+      unitSymbol: 'm³',
+      meterProvided: false
     }
 
     generateReturnSubmissionMetadataStub = Sinon.stub(GenerateReturnSubmissionMetadata, 'go').returns(
@@ -99,6 +99,10 @@ describe('Return Logs Setup - Submit Check service', () => {
     })
 
     createReturnLinesServiceStub = Sinon.stub(CreateReturnLinesService, 'go').resolves([])
+
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    fetchSessionStub = Sinon.stub(FetchSessionDal, 'go').resolves(session)
   })
 
   afterEach(() => {
@@ -106,10 +110,6 @@ describe('Return Logs Setup - Submit Check service', () => {
   })
 
   describe('when called with valid data', () => {
-    beforeEach(async () => {
-      session = await SessionHelper.add(sessionData)
-    })
-
     it('updates the return log status to completed', async () => {
       await SubmitCheckService.go(session.id, user)
 
@@ -175,9 +175,9 @@ describe('Return Logs Setup - Submit Check service', () => {
     })
 
     describe('and it is a nil return', () => {
-      beforeEach(async () => {
-        sessionData.data.journey = 'nilReturn'
-        sessionData.data.lines = [
+      beforeEach(() => {
+        sessionData.journey = 'nilReturn'
+        sessionData.lines = [
           {
             startDate: '2023-01-01T00:00:00.000Z',
             endDate: '2023-01-31T00:00:00.000Z',
@@ -190,7 +190,9 @@ describe('Return Logs Setup - Submit Check service', () => {
           }
         ]
 
-        session = await SessionHelper.add(sessionData)
+        session = SessionModelStub.build(Sinon, sessionData)
+
+        fetchSessionStub.resolves(session)
       })
 
       it('returns the original returnLogId', async () => {
@@ -202,8 +204,8 @@ describe('Return Logs Setup - Submit Check service', () => {
   })
 
   describe('when called with invalid data as the lines are blank', () => {
-    beforeEach(async () => {
-      sessionData.data.lines = [
+    beforeEach(() => {
+      sessionData.lines = [
         {
           startDate: '2023-01-01T00:00:00.000Z',
           endDate: '2023-01-31T00:00:00.000Z',
@@ -216,7 +218,9 @@ describe('Return Logs Setup - Submit Check service', () => {
         }
       ]
 
-      session = await SessionHelper.add(sessionData)
+      session = SessionModelStub.build(Sinon, sessionData)
+
+      fetchSessionStub.resolves(session)
     })
 
     it('returns the page data including a validation error', async () => {

--- a/test/services/return-versions/setup/existing/submit-existing.service.test.js
+++ b/test/services/return-versions/setup/existing/submit-existing.service.test.js
@@ -9,9 +9,10 @@ const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const SessionHelper = require('../../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../../support/stubs/session.stub.js')
 
 // Things we need to stub
+const FetchSessionDal = require('../../../../../app/dal/fetch-session.dal.js')
 const GenerateFromExistingRequirementsService = require('../../../../../app/services/return-versions/setup/existing/generate-from-existing-requirements.service.js')
 
 // Thing under test
@@ -22,50 +23,50 @@ describe('Return Versions - Setup - Submit Existing service', () => {
   let session
   let sessionData
 
-  beforeEach(async () => {
+  beforeEach(() => {
     sessionData = {
-      data: {
-        checkPageVisited: false,
-        licence: {
-          id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
-          currentVersionStartDate: '2023-01-01T00:00:00.000Z',
-          endDate: null,
-          licenceRef: '01/ABC',
-          licenceHolder: 'Turbo Kid',
-          returnVersions: [
-            {
-              id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
-              startDate: '2023-01-01T00:00:00.000Z',
-              reason: null,
-              modLogs: []
-            }
-          ],
-          startDate: '2022-04-01T00:00:00.000Z',
-          waterUndertaker: false
-        },
-        multipleUpload: false,
-        journey: 'returns-required',
-        requirements: [{}],
-        startDateOptions: 'licenceStartDate',
-        returnVersionStartDate: '2023-01-01T00:00:00.000Z',
-        licenceVersion: {
-          id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
-          endDate: null,
-          startDate: '2022-04-01T00:00:00.000Z',
-          copyableReturnVersions: [
-            {
-              id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
-              startDate: '2023-01-01T00:00:00.000Z',
-              reason: null,
-              modLogs: []
-            }
-          ]
-        },
-        reason: 'major-change'
-      }
+      checkPageVisited: false,
+      licence: {
+        id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
+        currentVersionStartDate: '2023-01-01T00:00:00.000Z',
+        endDate: null,
+        licenceRef: '01/ABC',
+        licenceHolder: 'Turbo Kid',
+        returnVersions: [
+          {
+            id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
+            startDate: '2023-01-01T00:00:00.000Z',
+            reason: null,
+            modLogs: []
+          }
+        ],
+        startDate: '2022-04-01T00:00:00.000Z',
+        waterUndertaker: false
+      },
+      multipleUpload: false,
+      journey: 'returns-required',
+      requirements: [{}],
+      startDateOptions: 'licenceStartDate',
+      returnVersionStartDate: '2023-01-01T00:00:00.000Z',
+      licenceVersion: {
+        id: '8b7f78ba-f3ad-4cb6-a058-78abc4d1383d',
+        endDate: null,
+        startDate: '2022-04-01T00:00:00.000Z',
+        copyableReturnVersions: [
+          {
+            id: '60b5d10d-1372-4fb2-b222-bfac81da69ab',
+            startDate: '2023-01-01T00:00:00.000Z',
+            reason: null,
+            modLogs: []
+          }
+        ]
+      },
+      reason: 'major-change'
     }
 
-    session = await SessionHelper.add(sessionData)
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    Sinon.stub(FetchSessionDal, 'go').resolves(session)
   })
 
   afterEach(() => {
@@ -95,25 +96,20 @@ describe('Return Versions - Setup - Submit Existing service', () => {
       it('saves the selected existing return requirements', async () => {
         await SubmitExistingService.go(session.id, payload)
 
-        const refreshedSession = await session.$query()
-
-        expect(refreshedSession.requirements).to.equal([_transformedReturnRequirement()])
+        expect(session.requirements).to.equal([_transformedReturnRequirement()])
+        expect(session.$update.called).to.be.true()
       })
 
       it('saves the return versions "multipleUpload" state', async () => {
         await SubmitExistingService.go(session.id, payload)
 
-        const refreshedSession = await session.$query()
-
-        expect(refreshedSession.multipleUpload).to.equal(false)
+        expect(session.multipleUpload).to.equal(false)
       })
 
       it('saves the return versions "quarterlyReturns" state', async () => {
         await SubmitExistingService.go(session.id, payload)
 
-        const refreshedSession = await session.$query()
-
-        expect(refreshedSession.quarterlyReturns).to.equal(false)
+        expect(session.quarterlyReturns).to.equal(false)
       })
     })
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5573

We recently refactored how we use fetch and delete session data, we now have a single way of doing each.

We are moving away from using the database in service test.

This change updates some of the tests still using the session helper to stub the 'FetchSessionDal'