### PR TITLE
Make 'Total' text on return log pages consistent

### DIFF
--- a/app/views/return-logs/setup/check.njk
+++ b/app/views/return-logs/setup/check.njk
@@ -220,7 +220,7 @@
 
     {% set tableRow = [
       {
-        text: "Total volume of water abstracted",
+        text: "Total amount of water abstracted",
         classes: "govuk-table__header"
       }
     ] %}

--- a/app/views/return-submissions/view.njk
+++ b/app/views/return-submissions/view.njk
@@ -77,10 +77,10 @@
       {% endfor %}
 
       {# Create the final total row. We set the first cell to span 2 columns if we are displaying meter readings in
-      order to correctly align the cubmic metres total. #}
+      order to correctly align the cubic metres total. #}
       {% set totalRow = [
         {
-          html: '<strong>Total volume of water abstracted</strong>',
+          html: '<strong>Total amount of water abstracted</strong>',
           attributes: { 'data-test': 'total-row-text' },
           colspan: 2 if displayReadings else 1
         }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4806

Our beady-eyed QA team have spotted an inconsistency in the text used on return log pages.

When we have a return log with a return submission, we include text that states "Total amount of water abstracted".

However, adding a return submission, the text we use states "Total volume of water abstracted". This is inconsistent, and we should use the same text in both places.

In this change, we update the return submission page to be consistent with the return log page; we will use "Total amount of water abstracted" as the phrase.