### PR TITLE
Update tests to stub 'FetchSessionDal'

### DIFF
--- a/app/services/return-versions/setup/check/submit-check.service.js
+++ b/app/services/return-versions/setup/check/submit-check.service.js
@@ -39,25 +39,21 @@ async function go(sessionId, userId) {
 }
 
 async function _processReturnVersion(session, userId) {
-  const returnVersionData = await GenerateReturnVersionService.go(session.data, userId)
+  const returnVersionData = await GenerateReturnVersionService.go(session, userId)
 
   const newReturnVersion = await CreateReturnVersionService.go(returnVersionData)
 
   const changeDate = new Date(newReturnVersion.startDate)
   changeDate.setTime(changeDate.getTime() - ONE_DAY_IN_MILLISECONDS)
 
-  if (session.data.journey === 'no-returns-required') {
-    await VoidReturnLogsService.go(
-      session.data.licence.licenceRef,
-      newReturnVersion.startDate,
-      newReturnVersion.endDate
-    )
+  if (session.journey === 'no-returns-required') {
+    await VoidReturnLogsService.go(session.licence.licenceRef, newReturnVersion.startDate, newReturnVersion.endDate)
   }
 
   await ProcessLicenceReturnLogsService.go(newReturnVersion.licenceId, changeDate, newReturnVersion.endDate)
 
   if (newReturnVersion.reason === 'succession-or-transfer-of-licence') {
-    await _updateSucceededReturnLogs(session.data.licence.licenceRef)
+    await _updateSucceededReturnLogs(session.licence.licenceRef)
   }
 }
 

--- a/test/services/company-contacts/setup/submit-contact-name.service.test.js
+++ b/test/services/company-contacts/setup/submit-contact-name.service.test.js
@@ -26,7 +26,7 @@ describe('Company Contacts - Setup - Contact Name Service', () => {
   let sessionData
   let yarStub
 
-  beforeEach(async () => {
+  beforeEach(() => {
     company = CustomersFixtures.company()
 
     sessionData = { company }
@@ -65,7 +65,7 @@ describe('Company Contacts - Setup - Contact Name Service', () => {
 
     describe('when the check page has', () => {
       describe('been visited', () => {
-        beforeEach(async () => {
+        beforeEach(() => {
           session = SessionModelStub.build(Sinon, {
             ...sessionData,
             checkPageVisited: true,

--- a/test/services/notices/setup/process-remove-threshold.service.test.js
+++ b/test/services/notices/setup/process-remove-threshold.service.test.js
@@ -10,12 +10,16 @@ const { expect } = Code
 
 // Test helpers
 const AbstractionAlertSessionData = require('../../../support/fixtures/abstraction-alert-session-data.fixture.js')
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const ProcessRemoveThresholdService = require('../../../../app/services/notices/setup/process-remove-threshold.service.js')
 
 describe('Notices - Setup - Process Remove Threshold service', () => {
+  let fetchSessionStub
   let licenceMonitoringStations
   let session
   let sessionData
@@ -26,6 +30,10 @@ describe('Notices - Setup - Process Remove Threshold service', () => {
 
     sessionData = AbstractionAlertSessionData.get(licenceMonitoringStations)
 
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    fetchSessionStub = Sinon.stub(FetchSessionDal, 'go').resolves(session)
+
     yarStub = { flash: Sinon.stub() }
   })
 
@@ -35,51 +43,37 @@ describe('Notices - Setup - Process Remove Threshold service', () => {
 
   describe('when called', () => {
     describe('and there are no thresholds currently removed', () => {
-      beforeEach(async () => {
-        session = await SessionHelper.add({
-          data: sessionData
-        })
-      })
-
       it('saves the "licenceMonitoringStationId" to the session to be excluded from the list', async () => {
         await ProcessRemoveThresholdService.go(session.id, licenceMonitoringStations.one.id, yarStub)
 
-        const refreshedSession = await session.$query()
-
-        expect(refreshedSession.removedThresholds).to.equal([licenceMonitoringStations.one.id])
+        expect(session.removedThresholds).to.equal([licenceMonitoringStations.one.id])
+        expect(session.$update.called).to.be.true()
       })
     })
 
     describe('and there are existing "removedThresholds"', () => {
-      beforeEach(async () => {
-        session = await SessionHelper.add({
-          data: {
-            ...sessionData,
-            removedThresholds: [licenceMonitoringStations.one.id]
-          }
-        })
+      beforeEach(() => {
+        sessionData.removedThresholds = [licenceMonitoringStations.one.id]
+
+        session = SessionModelStub.build(Sinon, sessionData)
+
+        fetchSessionStub.resolves(session)
       })
 
       it('saves the "licenceMonitoringStationId" to the session with the existing "removedThresholds"', async () => {
         await ProcessRemoveThresholdService.go(session.id, licenceMonitoringStations.one.id, yarStub)
 
-        const refreshedSession = await session.$query()
-
-        expect(refreshedSession.removedThresholds).to.equal([
-          licenceMonitoringStations.one.id,
-          licenceMonitoringStations.one.id
-        ])
+        expect(session.removedThresholds).to.equal([licenceMonitoringStations.one.id, licenceMonitoringStations.one.id])
       })
     })
 
     describe('and there is a notification', () => {
-      beforeEach(async () => {
-        session = await SessionHelper.add({
-          data: {
-            ...sessionData,
-            removedThresholds: [licenceMonitoringStations.one.id]
-          }
-        })
+      beforeEach(() => {
+        sessionData.removedThresholds = [licenceMonitoringStations.one.id]
+
+        session = SessionModelStub.build(Sinon, sessionData)
+
+        fetchSessionStub.resolves(session)
       })
       it('sets a flash message', async () => {
         await ProcessRemoveThresholdService.go(session.id, licenceMonitoringStations.one.id, yarStub)

--- a/test/services/notices/setup/submit-alert-thresholds.service.test.js
+++ b/test/services/notices/setup/submit-alert-thresholds.service.test.js
@@ -18,12 +18,15 @@ const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 // Thing under test
 const SubmitAlertThresholdsService = require('../../../../app/services/notices/setup/submit-alert-thresholds.service.js')
 
-describe.skip('Notices - Setup - Submit Alert Thresholds service', () => {
-  let fetchSessionStub
+describe('Notices - Setup - Submit Alert Thresholds service', () => {
   let licenceMonitoringStations
   let payload
   let session
   let sessionData
+
+  afterEach(() => {
+    Sinon.restore()
+  })
 
   describe('when called', () => {
     beforeEach(() => {
@@ -40,11 +43,7 @@ describe.skip('Notices - Setup - Submit Alert Thresholds service', () => {
 
       session = SessionModelStub.build(Sinon, sessionData)
 
-      fetchSessionStub = Sinon.stub(FetchSessionDal, 'go').resolves(session)
-    })
-
-    afterEach(() => {
-      Sinon.restore()
+      Sinon.stub(FetchSessionDal, 'go').resolves(session)
     })
 
     it('continues the journey', async () => {
@@ -97,7 +96,7 @@ describe.skip('Notices - Setup - Submit Alert Thresholds service', () => {
 
         session = SessionModelStub.build(Sinon, sessionData)
 
-        fetchSessionStub.resolves(session)
+        Sinon.stub(FetchSessionDal, 'go').resolves(session)
 
         payload = {}
       })
@@ -146,7 +145,7 @@ describe.skip('Notices - Setup - Submit Alert Thresholds service', () => {
 
         session = SessionModelStub.build(Sinon, sessionData)
 
-        fetchSessionStub.resolves(session)
+        Sinon.stub(FetchSessionDal, 'go').resolves(session)
 
         payload = {}
       })

--- a/test/services/notices/setup/submit-alert-thresholds.service.test.js
+++ b/test/services/notices/setup/submit-alert-thresholds.service.test.js
@@ -3,25 +3,30 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
+const Sinon = require('sinon')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
 const AbstractionAlertSessionData = require('../../../support/fixtures/abstraction-alert-session-data.fixture.js')
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const SubmitAlertThresholdsService = require('../../../../app/services/notices/setup/submit-alert-thresholds.service.js')
 
-describe('Notices - Setup - Submit Alert Thresholds service', () => {
+describe.skip('Notices - Setup - Submit Alert Thresholds service', () => {
+  let fetchSessionStub
   let licenceMonitoringStations
   let payload
   let session
   let sessionData
 
   describe('when called', () => {
-    beforeEach(async () => {
+    beforeEach(() => {
       licenceMonitoringStations = AbstractionAlertSessionData.licenceMonitoringStations()
 
       sessionData = {
@@ -33,7 +38,13 @@ describe('Notices - Setup - Submit Alert Thresholds service', () => {
         alertThresholds: [licenceMonitoringStations.one.thresholdGroup, licenceMonitoringStations.two.thresholdGroup]
       }
 
-      session = await SessionHelper.add({ data: sessionData })
+      session = SessionModelStub.build(Sinon, sessionData)
+
+      fetchSessionStub = Sinon.stub(FetchSessionDal, 'go').resolves(session)
+    })
+
+    afterEach(() => {
+      Sinon.restore()
     })
 
     it('continues the journey', async () => {
@@ -53,9 +64,8 @@ describe('Notices - Setup - Submit Alert Thresholds service', () => {
         it('saves the submitted value as an array', async () => {
           await SubmitAlertThresholdsService.go(session.id, payload)
 
-          const refreshedSession = await session.$query()
-
-          expect(refreshedSession.alertThresholds).to.equal([licenceMonitoringStations.one.thresholdGroup])
+          expect(session.alertThresholds).to.equal([licenceMonitoringStations.one.thresholdGroup])
+          expect(session.$update.called).to.be.true()
         })
       })
 
@@ -63,12 +73,12 @@ describe('Notices - Setup - Submit Alert Thresholds service', () => {
         it('saves the submitted values as an array', async () => {
           await SubmitAlertThresholdsService.go(session.id, payload)
 
-          const refreshedSession = await session.$query()
-
-          expect(refreshedSession.alertThresholds).to.equal([
+          expect(session.alertThresholds).to.equal([
             licenceMonitoringStations.one.thresholdGroup,
             licenceMonitoringStations.two.thresholdGroup
           ])
+
+          expect(session.$update.called).to.be.true()
         })
       })
     })
@@ -76,7 +86,7 @@ describe('Notices - Setup - Submit Alert Thresholds service', () => {
 
   describe('when validation fails', () => {
     describe('and there are no previous "alertThresholds"', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         const abstractionAlertSessionData = AbstractionAlertSessionData.get()
 
         sessionData = {
@@ -85,9 +95,11 @@ describe('Notices - Setup - Submit Alert Thresholds service', () => {
           alertType: 'stop'
         }
 
-        payload = {}
+        session = SessionModelStub.build(Sinon, sessionData)
 
-        session = await SessionHelper.add({ data: sessionData })
+        fetchSessionStub.resolves(session)
+
+        payload = {}
       })
 
       it('returns page data for the view, with errors', async () => {
@@ -123,7 +135,7 @@ describe('Notices - Setup - Submit Alert Thresholds service', () => {
     })
 
     describe('and there are previous "alertThresholds"', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         const abstractionAlertSessionData = AbstractionAlertSessionData.get()
 
         sessionData = {
@@ -132,9 +144,11 @@ describe('Notices - Setup - Submit Alert Thresholds service', () => {
           alertType: 'stop'
         }
 
-        payload = {}
+        session = SessionModelStub.build(Sinon, sessionData)
 
-        session = await SessionHelper.add({ data: sessionData })
+        fetchSessionStub.resolves(session)
+
+        payload = {}
       })
 
       it('returns page data for the view, with errors, and all the thresholds unselected', async () => {

--- a/test/services/notices/setup/submit-cancel-alerts.service.test.js
+++ b/test/services/notices/setup/submit-cancel-alerts.service.test.js
@@ -3,44 +3,51 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
+const Sinon = require('sinon')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
-const SessionModel = require('../../../../app/models/session.model.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+
 const { generateUUID } = require('../../../../app/lib/general.lib.js')
+
+// Things we need to stub
+const DeleteSessionDal = require('../../../../app/dal/delete-session.dal.js')
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const SubmitCancelAlertsService = require('../../../../app/services/notices/setup/submit-cancel-alerts.service.js')
 
 describe('Notices - Setup - Submit Cancel Alerts service', () => {
-  const monitoringStationId = generateUUID()
-
   let session
+  let sessionData
 
-  beforeEach(async () => {
-    session = await SessionHelper.add({
-      data: {
-        monitoringStationId
-      }
-    })
+  beforeEach(() => {
+    sessionData = { monitoringStationId: generateUUID() }
+
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    Sinon.stub(FetchSessionDal, 'go').resolves(session)
+    Sinon.stub(DeleteSessionDal, 'go').resolves()
+  })
+
+  afterEach(() => {
+    Sinon.restore()
   })
 
   describe('when called', () => {
     it('returns the monitoring station id', async () => {
       const result = await SubmitCancelAlertsService.go(session.id)
 
-      expect(result).to.equal({ monitoringStationId })
+      expect(result).to.equal({ monitoringStationId: sessionData.monitoringStationId })
     })
 
     it('clears the session', async () => {
       await SubmitCancelAlertsService.go(session.id)
 
-      const noSession = await SessionModel.query().where('id', session.id)
-
-      expect(noSession).to.equal([])
+      expect(DeleteSessionDal.go.calledWith(session.id)).to.be.true()
     })
   })
 })

--- a/test/services/notices/setup/submit-check-licence-matches.service.test.js
+++ b/test/services/notices/setup/submit-check-licence-matches.service.test.js
@@ -3,24 +3,29 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
+const Sinon = require('sinon')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
 const AbstractionAlertSessionData = require('../../../support/fixtures/abstraction-alert-session-data.fixture.js')
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const SubmitCheckLicenceMatchesService = require('../../../../app/services/notices/setup/submit-check-licence-matches.service.js')
 
 describe('Notices - Setup - Submit Check Licence Matches service', () => {
+  let fetchSessionStub
   let licenceMonitoringStationDuplicate
   let licenceMonitoringStations
   let session
   let sessionData
 
-  beforeEach(async () => {
+  beforeEach(() => {
     licenceMonitoringStations = AbstractionAlertSessionData.licenceMonitoringStations()
 
     const abstractionAlertSessionData = AbstractionAlertSessionData.get(licenceMonitoringStations)
@@ -37,32 +42,34 @@ describe('Notices - Setup - Submit Check Licence Matches service', () => {
         licenceMonitoringStations.three.thresholdGroup
       ]
     }
+
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    fetchSessionStub = Sinon.stub(FetchSessionDal, 'go').resolves(session)
+  })
+
+  afterEach(() => {
+    Sinon.restore()
   })
 
   describe('when called', () => {
     describe('and there are no licence monitoring stations removed', () => {
-      beforeEach(async () => {
-        session = await SessionHelper.add({ data: sessionData })
-      })
-
       it('saves the "licenceRefs" to the session', async () => {
         await SubmitCheckLicenceMatchesService.go(session.id)
 
-        const refreshedSession = await session.$query()
-
-        expect(refreshedSession.licenceRefs).to.equal([
+        expect(session.licenceRefs).to.equal([
           licenceMonitoringStations.one.licence.licenceRef,
           licenceMonitoringStations.two.licence.licenceRef,
           licenceMonitoringStations.three.licence.licenceRef
         ])
+
+        expect(session.$update.called).to.be.true()
       })
 
       it('saves the "relevantLicenceMonitoringStations" to the session', async () => {
         await SubmitCheckLicenceMatchesService.go(session.id)
 
-        const refreshedSession = await session.$query()
-
-        expect(refreshedSession.relevantLicenceMonitoringStations).to.equal([
+        expect(session.relevantLicenceMonitoringStations).to.equal([
           licenceMonitoringStations.one,
           licenceMonitoringStations.two,
           licenceMonitoringStations.three
@@ -71,26 +78,24 @@ describe('Notices - Setup - Submit Check Licence Matches service', () => {
     })
 
     describe('and there are duplicate licence refs', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         sessionData.licenceMonitoringStations = [licenceMonitoringStations.one, licenceMonitoringStationDuplicate]
 
-        session = await SessionHelper.add({ data: sessionData })
+        session = SessionModelStub.build(Sinon, sessionData)
+
+        fetchSessionStub.resolves(session)
       })
 
       it('saves the "licenceRefs" to the session with duplicates removed', async () => {
         await SubmitCheckLicenceMatchesService.go(session.id)
 
-        const refreshedSession = await session.$query()
-
-        expect(refreshedSession.licenceRefs).to.equal([licenceMonitoringStations.one.licence.licenceRef])
+        expect(session.licenceRefs).to.equal([licenceMonitoringStations.one.licence.licenceRef])
       })
 
       it('saves the "relevantLicenceMonitoringStations" to the session', async () => {
         await SubmitCheckLicenceMatchesService.go(session.id)
 
-        const refreshedSession = await session.$query()
-
-        expect(refreshedSession.relevantLicenceMonitoringStations).to.equal([
+        expect(session.relevantLicenceMonitoringStations).to.equal([
           licenceMonitoringStations.one,
           licenceMonitoringStationDuplicate
         ])
@@ -98,26 +103,24 @@ describe('Notices - Setup - Submit Check Licence Matches service', () => {
     })
 
     describe('and there are no licence monitoring stations removed', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         sessionData.removedThresholds = [licenceMonitoringStations.one.id, licenceMonitoringStations.two.id]
 
-        session = await SessionHelper.add({ data: sessionData })
+        session = SessionModelStub.build(Sinon, sessionData)
+
+        fetchSessionStub.resolves(session)
       })
 
       it('saves the "licenceRefs" to the session without the removed thresholds', async () => {
         await SubmitCheckLicenceMatchesService.go(session.id)
 
-        const refreshedSession = await session.$query()
-
-        expect(refreshedSession.licenceRefs).to.equal([licenceMonitoringStations.three.licence.licenceRef])
+        expect(session.licenceRefs).to.equal([licenceMonitoringStations.three.licence.licenceRef])
       })
 
       it('saves the "relevantLicenceMonitoringStations" to the session', async () => {
         await SubmitCheckLicenceMatchesService.go(session.id)
 
-        const refreshedSession = await session.$query()
-
-        expect(refreshedSession.relevantLicenceMonitoringStations).to.equal([licenceMonitoringStations.three])
+        expect(session.relevantLicenceMonitoringStations).to.equal([licenceMonitoringStations.three])
       })
     })
   })

--- a/test/services/notices/setup/submit-check-notice-type.service.test.js
+++ b/test/services/notices/setup/submit-check-notice-type.service.test.js
@@ -3,13 +3,17 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
+const Sinon = require('sinon')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
 const { generateUUID } = require('../../../../app/lib/general.lib.js')
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const SubmitCheckNoticeTypeService = require('../../../../app/services/notices/setup/submit-check-notice-type.service.js')
@@ -29,25 +33,32 @@ describe('Notices - Setup - Submit Check Notice Type service', () => {
     }
   })
 
+  afterEach(() => {
+    Sinon.restore()
+  })
+
   describe('when called', () => {
     describe('and the notice type is not "paperReturn"', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         sessionData.name = 'Returns: invitation'
         sessionData.noticeType = 'invitations'
         sessionData.notificationType = 'Returns invitation'
         sessionData.referenceCode = `RINV-${Math.floor(1000 + Math.random() * 9000).toString()}`
         sessionData.subType = 'returnInvitation'
 
-        session = await SessionHelper.add({ id: sessionId, data: sessionData })
+        sessionData.id = sessionId
+
+        session = SessionModelStub.build(Sinon, sessionData)
+
+        Sinon.stub(FetchSessionDal, 'go').resolves(session)
       })
 
       it('adds the "addressJourney" property to the session configured for going back to contact-type', async () => {
         await SubmitCheckNoticeTypeService.go(sessionId)
 
-        const refreshedSession = await session.$query()
-
-        expect(refreshedSession.data).to.equal({
+        expect(session).to.equal({
           dueReturns: [],
+          id: sessionId,
           licenceRef: '01/123',
           journey: 'adhoc',
           name: 'Returns: invitation',
@@ -70,23 +81,26 @@ describe('Notices - Setup - Submit Check Notice Type service', () => {
     })
 
     describe('and the notice type is "paperReturn"', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         sessionData.name = 'Paper returns'
         sessionData.noticeType = 'paperReturn'
         sessionData.notificationType = 'Paper returns'
         sessionData.referenceCode = `PRTF-${Math.floor(1000 + Math.random() * 9000).toString()}`
         sessionData.subType = 'paperReturnForms'
 
-        session = await SessionHelper.add({ id: sessionId, data: sessionData })
+        sessionData.id = sessionId
+
+        session = SessionModelStub.build(Sinon, sessionData)
+
+        Sinon.stub(FetchSessionDal, 'go').resolves(session)
       })
 
       it('adds the "addressJourney" property to the session configured for going back to recipient-name', async () => {
         await SubmitCheckNoticeTypeService.go(sessionId)
 
-        const refreshedSession = await session.$query()
-
-        expect(refreshedSession.data).to.equal({
+        expect(session).to.equal({
           dueReturns: [],
+          id: sessionId,
           licenceRef: '01/123',
           journey: 'adhoc',
           name: 'Paper returns',

--- a/test/services/notices/setup/submit-paper-return.service.test.js
+++ b/test/services/notices/setup/submit-paper-return.service.test.js
@@ -9,22 +9,26 @@ const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
 const { generateLicenceRef } = require('../../../support/helpers/licence.helper.js')
 const { generateUUID } = require('../../../../app/lib/general.lib.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const SubmitPaperReturnService = require('../../../../app/services/notices/setup/submit-paper-return.service.js')
 
 describe('Notices - Setup - Submit Paper Return service', () => {
   let dueReturn
+  let fetchSessionStub
   let licenceRef
   let payload
   let session
   let sessionData
   let yarStub
 
-  beforeEach(async () => {
+  beforeEach(() => {
     licenceRef = generateLicenceRef()
 
     dueReturn = {
@@ -39,7 +43,9 @@ describe('Notices - Setup - Submit Paper Return service', () => {
 
     sessionData = { licenceRef }
 
-    session = await SessionHelper.add({ data: sessionData })
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    fetchSessionStub = Sinon.stub(FetchSessionDal, 'go').resolves(session)
 
     yarStub = { flash: Sinon.stub() }
   })
@@ -52,9 +58,8 @@ describe('Notices - Setup - Submit Paper Return service', () => {
     it('saves the selected returns', async () => {
       await SubmitPaperReturnService.go(session.id, payload, yarStub)
 
-      const refreshedSession = await session.$query()
-
-      expect(refreshedSession.selectedReturns).to.equal([dueReturn.returnLogId])
+      expect(session.selectedReturns).to.equal([dueReturn.returnLogId])
+      expect(session.$update.called).to.be.true()
     })
 
     it('continues the journey', async () => {
@@ -64,26 +69,30 @@ describe('Notices - Setup - Submit Paper Return service', () => {
     })
 
     describe('and the payload has one item (is not an array)', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         payload = { returns: dueReturn.returnLogId }
         sessionData = {}
 
-        session = await SessionHelper.add({ data: sessionData })
+        session = SessionModelStub.build(Sinon, sessionData)
+
+        fetchSessionStub.resolves(session)
       })
 
       it('saves the selected returns', async () => {
         await SubmitPaperReturnService.go(session.id, payload, yarStub)
 
-        const refreshedSession = await session.$query()
-
-        expect(refreshedSession.selectedReturns).to.equal([dueReturn.returnLogId])
+        expect(session.selectedReturns).to.equal([dueReturn.returnLogId])
       })
     })
 
     describe('from the check page', () => {
       describe('and the returns have been updated', () => {
-        beforeEach(async () => {
-          session = await SessionHelper.add({ data: { checkPageVisited: true, selectedReturns: [generateUUID()] } })
+        beforeEach(() => {
+          sessionData = { checkPageVisited: true, selectedReturns: [generateUUID()] }
+
+          session = SessionModelStub.build(Sinon, sessionData)
+
+          fetchSessionStub.resolves(session)
         })
 
         it('sets a flash message', async () => {
@@ -101,10 +110,12 @@ describe('Notices - Setup - Submit Paper Return service', () => {
       })
 
       describe('and the returns have not been updated', () => {
-        beforeEach(async () => {
-          session = await SessionHelper.add({
-            data: { checkPageVisited: true, selectedReturns: [dueReturn.returnLogId] }
-          })
+        beforeEach(() => {
+          sessionData = { checkPageVisited: true, selectedReturns: [dueReturn.returnLogId] }
+
+          session = SessionModelStub.build(Sinon, sessionData)
+
+          fetchSessionStub.resolves(session)
         })
 
         it('does not set a flash message', async () => {
@@ -117,12 +128,14 @@ describe('Notices - Setup - Submit Paper Return service', () => {
   })
 
   describe('when validation fails', () => {
-    beforeEach(async () => {
+    beforeEach(() => {
       payload = {}
 
       sessionData = { licenceRef, dueReturns: [dueReturn] }
 
-      session = await SessionHelper.add({ data: sessionData })
+      session = SessionModelStub.build(Sinon, sessionData)
+
+      fetchSessionStub.resolves(session)
     })
 
     it('returns page data for the view, with errors', async () => {
@@ -160,10 +173,12 @@ describe('Notices - Setup - Submit Paper Return service', () => {
     })
 
     describe('and there are already "selectedReturns"', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         sessionData = { licenceRef, dueReturns: [dueReturn], selectedReturns: [dueReturn.returnLogId] }
 
-        session = await SessionHelper.add({ data: sessionData })
+        session = SessionModelStub.build(Sinon, sessionData)
+
+        fetchSessionStub.resolves(session)
       })
 
       it('returns page data for the view, with errors, and no options selected', async () => {

--- a/test/services/notices/setup/submit-remove-licences.services.test.js
+++ b/test/services/notices/setup/submit-remove-licences.services.test.js
@@ -9,39 +9,43 @@ const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
-const { generateNoticeReferenceCode } = require('../../../../app/lib/general.lib.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
 const { generateLicenceRef } = require('../../../support/helpers/licence.helper.js')
+const { generateNoticeReferenceCode } = require('../../../../app/lib/general.lib.js')
 
 // Things we need to stub
 const FetchLicenceRefsWithDueReturnsService = require('../../../../app/services/notices/setup/fetch-licence-refs-with-due-returns.service.js')
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const SubmitRemoveLicencesService = require('../../../../app/services/notices/setup/submit-remove-licences.service.js')
 
 describe('Notices - Setup - Submit Remove Licences service', () => {
   let fetchLicenceRefsWithDueReturnsStub
+  let licenceRefWithDueReturns
   let payload
   let referenceCode
   let session
-  let licenceRefWithDueReturns
+  let sessionData
 
-  beforeEach(async () => {
+  beforeEach(() => {
     referenceCode = generateNoticeReferenceCode('RINV-')
 
-    session = await SessionHelper.add({
-      data: {
-        returnsPeriod: 'allYear',
-        referenceCode,
-        determinedReturnsPeriod: {
-          name: 'allYear',
-          dueDate: '2024-04-28',
-          endDate: '2024-03-31',
-          summer: false,
-          startDate: '2023-04-01'
-        }
+    sessionData = {
+      returnsPeriod: 'allYear',
+      referenceCode,
+      determinedReturnsPeriod: {
+        name: 'allYear',
+        dueDate: '2024-04-28',
+        endDate: '2024-03-31',
+        summer: false,
+        startDate: '2023-04-01'
       }
-    })
+    }
+
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    Sinon.stub(FetchSessionDal, 'go').resolves(session)
 
     licenceRefWithDueReturns = generateLicenceRef()
 
@@ -49,12 +53,12 @@ describe('Notices - Setup - Submit Remove Licences service', () => {
   })
 
   afterEach(() => {
-    fetchLicenceRefsWithDueReturnsStub.restore()
+    Sinon.restore()
   })
 
   describe('when submitting licences to remove ', () => {
     describe('is successful', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         payload = { removeLicences: licenceRefWithDueReturns }
 
         fetchLicenceRefsWithDueReturnsStub.resolves([licenceRefWithDueReturns])
@@ -63,9 +67,8 @@ describe('Notices - Setup - Submit Remove Licences service', () => {
       it('saves the submitted value', async () => {
         await SubmitRemoveLicencesService.go(session.id, payload)
 
-        const refreshedSession = await session.$query()
-
-        expect(refreshedSession.removeLicences).to.equal(licenceRefWithDueReturns)
+        expect(session.removeLicences).to.equal(licenceRefWithDueReturns)
+        expect(session.$update.called).to.be.true()
       })
 
       it('returns the redirect route', async () => {
@@ -78,7 +81,7 @@ describe('Notices - Setup - Submit Remove Licences service', () => {
     })
 
     describe('fails validation', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         payload = { removeLicences: '789' }
 
         licenceRefWithDueReturns = []

--- a/test/services/notices/setup/submit-returns-period.services.test.js
+++ b/test/services/notices/setup/submit-returns-period.services.test.js
@@ -5,24 +5,29 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, after, before, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, before, beforeEach, after, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
 const { generateNoticeReferenceCode } = require('../../../../app/lib/general.lib.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const SubmitReturnsPeriodService = require('../../../../app/services/notices/setup/submit-returns-period.service.js')
 
 describe('Notices - Setup - Submit Returns Period service', () => {
   let clock
+  let fetchSessionStub
   let payload
   let referenceCode
   let session
+  let sessionData
   let yarStub
 
-  before(async () => {
+  before(() => {
     referenceCode = generateNoticeReferenceCode('RINV-')
 
     const testDate = new Date('2024-12-01')
@@ -32,36 +37,44 @@ describe('Notices - Setup - Submit Returns Period service', () => {
     yarStub = { flash: Sinon.stub() }
   })
 
+  beforeEach(() => {
+    sessionData = { referenceCode, noticeType: 'invitations' }
+
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    fetchSessionStub = Sinon.stub(FetchSessionDal, 'go').resolves(session)
+  })
+
   after(() => {
     clock.restore()
   })
 
+  afterEach(() => {
+    fetchSessionStub.restore()
+  })
+
   describe('when submitting as returns period ', () => {
     describe('is successful', () => {
-      beforeEach(async () => {
-        session = await SessionHelper.add({ data: { referenceCode, noticeType: 'invitations' } })
-
+      beforeEach(() => {
         payload = { returnsPeriod: 'quarterFour' }
       })
 
       it('saves the submitted value', async () => {
         await SubmitReturnsPeriodService.go(session.id, payload, yarStub)
 
-        const refreshedSession = await session.$query()
-
-        expect(refreshedSession.returnsPeriod).to.equal('quarterFour')
+        expect(session.returnsPeriod).to.equal('quarterFour')
+        expect(session.$update.called).to.be.true()
       })
 
       it('saves the determined returns period', async () => {
         await SubmitReturnsPeriodService.go(session.id, payload, yarStub)
 
-        const refreshedSession = await session.$query()
-
-        expect(refreshedSession.determinedReturnsPeriod).to.equal({
-          dueDate: '2025-04-28T00:00:00.000Z',
-          endDate: '2025-03-31T00:00:00.000Z',
+        expect(session.determinedReturnsPeriod).to.equal({
+          // The dates would be strings and not date objects when saved to the database
+          dueDate: new Date('2025-04-28'),
+          endDate: new Date('2025-03-31'),
           name: 'quarterFour',
-          startDate: '2025-01-01T00:00:00.000Z',
+          startDate: new Date('2025-01-01'),
           summer: 'false',
           quarterly: true
         })
@@ -77,10 +90,12 @@ describe('Notices - Setup - Submit Returns Period service', () => {
     })
 
     describe('and the user comes from the check page', () => {
-      beforeEach(async () => {
-        session = await SessionHelper.add({
-          data: { referenceCode, noticeType: 'invitations', checkPageVisited: true }
-        })
+      beforeEach(() => {
+        sessionData = { referenceCode, noticeType: 'invitations', checkPageVisited: true }
+
+        session = SessionModelStub.build(Sinon, sessionData)
+
+        fetchSessionStub.resolves(session)
       })
 
       it('sets a flash message', async () => {
@@ -98,10 +113,13 @@ describe('Notices - Setup - Submit Returns Period service', () => {
     })
 
     describe('fails validation', () => {
-      beforeEach(async () => {
-        session = await SessionHelper.add({
-          data: { referenceCode, journey: 'invitations', noticeType: 'invitations' }
-        })
+      beforeEach(() => {
+        sessionData = { referenceCode, journey: 'invitations', noticeType: 'invitations' }
+
+        session = SessionModelStub.build(Sinon, sessionData)
+
+        fetchSessionStub.resolves(session)
+
         payload = {}
       })
 

--- a/test/services/notices/setup/submit-select-recipients.service.test.js
+++ b/test/services/notices/setup/submit-select-recipients.service.test.js
@@ -10,11 +10,12 @@ const { expect } = Code
 
 // Test helpers
 const RecipientsFixture = require('../../../support/fixtures/recipients.fixture.js')
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
 const { generateNoticeReferenceCode } = require('../../../../app/lib/general.lib.js')
 
 // Things we need to stub
 const FetchRecipientsService = require('../../../../app/services/notices/setup/fetch-recipients.service.js')
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const SubmitSelectRecipientsService = require('../../../../app/services/notices/setup/submit-select-recipients.service.js')
@@ -27,14 +28,16 @@ describe('Notices - Setup - Submit Select Recipients service', () => {
   let sessionData
   let yarStub
 
-  beforeEach(async () => {
+  beforeEach(() => {
     payload = { recipients: ['123'] }
 
     referenceCode = generateNoticeReferenceCode('RINV-')
 
     sessionData = { referenceCode }
 
-    session = await SessionHelper.add({ data: sessionData })
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    Sinon.stub(FetchSessionDal, 'go').resolves(session)
 
     recipients = RecipientsFixture.recipients()
 
@@ -51,9 +54,8 @@ describe('Notices - Setup - Submit Select Recipients service', () => {
     it('saves the submitted value', async () => {
       await SubmitSelectRecipientsService.go(session.id, payload, yarStub)
 
-      const refreshedSession = await session.$query()
-
-      expect(refreshedSession.selectedRecipients).to.equal(['123'])
+      expect(session.selectedRecipients).to.equal(['123'])
+      expect(session.$update.called).to.be.true()
     })
 
     it('sets a flash message', async () => {
@@ -78,7 +80,7 @@ describe('Notices - Setup - Submit Select Recipients service', () => {
 
   describe('when validation fails', () => {
     describe('because there are no recipients', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         payload = {}
       })
 

--- a/test/services/notices/setup/view-cancel.service.test.js
+++ b/test/services/notices/setup/view-cancel.service.test.js
@@ -3,24 +3,35 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
+const Sinon = require('sinon')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
 const { generateNoticeReferenceCode } = require('../../../../app/lib/general.lib.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const ViewCancelService = require('../../../../app/services/notices/setup/view-cancel.service.js')
 
 describe('Notices - Setup - View Cancel service', () => {
   let session
+  let sessionData
 
-  beforeEach(async () => {
-    session = await SessionHelper.add({
-      data: { licenceRef: '01/111', referenceCode: generateNoticeReferenceCode('RINV-') }
-    })
+  beforeEach(() => {
+    sessionData = { licenceRef: '01/111', referenceCode: generateNoticeReferenceCode('RINV-') }
+
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    Sinon.stub(FetchSessionDal, 'go').resolves(session)
+  })
+
+  afterEach(() => {
+    Sinon.restore()
   })
 
   describe('when called', () => {

--- a/test/services/notices/setup/view-check-licence-matches.service.test.js
+++ b/test/services/notices/setup/view-check-licence-matches.service.test.js
@@ -10,7 +10,10 @@ const { expect } = Code
 
 // Test helpers
 const AbstractionAlertSessionData = require('../../../support/fixtures/abstraction-alert-session-data.fixture.js')
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const ViewCheckLicenceMatchesService = require('../../../../app/services/notices/setup/view-check-licence-matches.service.js')
@@ -21,7 +24,7 @@ describe('Notices - Setup - View Check Licence Matches service', () => {
   let sessionData
   let yarStub
 
-  beforeEach(async () => {
+  beforeEach(() => {
     licenceMonitoringStations = AbstractionAlertSessionData.licenceMonitoringStations()
 
     const abstractionAlertSessionData = AbstractionAlertSessionData.get(licenceMonitoringStations)
@@ -35,7 +38,9 @@ describe('Notices - Setup - View Check Licence Matches service', () => {
       ]
     }
 
-    session = await SessionHelper.add({ data: sessionData })
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    Sinon.stub(FetchSessionDal, 'go').resolves(session)
 
     yarStub = { flash: Sinon.stub().resolves() }
   })

--- a/test/services/notices/setup/view-check-notice-type.service.test.js
+++ b/test/services/notices/setup/view-check-notice-type.service.test.js
@@ -9,8 +9,11 @@ const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
 const { generateLicenceRef } = require('../../../support/helpers/licence.helper.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const ViewCheckNoticeTypeService = require('../../../../app/services/notices/setup/view-check-notice-type.service.js')
@@ -21,11 +24,13 @@ describe('Notices - Setup - View Check Notice Type service', () => {
   let sessionData
   let yarStub
 
-  beforeEach(async () => {
+  beforeEach(() => {
     licenceRef = generateLicenceRef()
     sessionData = { licenceRef, noticeType: 'invitations' }
 
-    session = await SessionHelper.add({ data: sessionData })
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    Sinon.stub(FetchSessionDal, 'go').resolves(session)
 
     yarStub = { flash: Sinon.stub().resolves() }
   })
@@ -57,9 +62,8 @@ describe('Notices - Setup - View Check Notice Type service', () => {
     it('should set the "checkPageVisited" flag', async () => {
       await ViewCheckNoticeTypeService.go(session.id, yarStub)
 
-      const refreshedSession = await session.$query()
-
-      expect(refreshedSession.checkPageVisited).to.be.true()
+      expect(session.checkPageVisited).to.be.true()
+      expect(session.$update.called).to.be.true()
     })
 
     describe('when there is a notification', () => {

--- a/test/services/notices/setup/view-contact-type.service.test.js
+++ b/test/services/notices/setup/view-contact-type.service.test.js
@@ -3,12 +3,16 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
+const Sinon = require('sinon')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const ViewContactTypeService = require('../../../../app/services/notices/setup/view-contact-type.service.js')
@@ -17,11 +21,17 @@ describe('Notices - Setup - View Contact Type service', () => {
   let session
   let sessionData
 
+  afterEach(() => {
+    Sinon.restore()
+  })
+
   describe('when called with no saved data', () => {
-    beforeEach(async () => {
+    beforeEach(() => {
       sessionData = { referenceCode: 'RINV-CPFRQ4' }
 
-      session = await SessionHelper.add({ data: sessionData })
+      session = SessionModelStub.build(Sinon, sessionData)
+
+      Sinon.stub(FetchSessionDal, 'go').resolves(session)
     })
 
     it('returns page data for the view', async () => {
@@ -43,14 +53,16 @@ describe('Notices - Setup - View Contact Type service', () => {
   })
 
   describe('when called with a saved name', () => {
-    beforeEach(async () => {
+    beforeEach(() => {
       sessionData = {
         contactName: 'Fake Person',
         contactType: 'post',
         referenceCode: 'RINV-CPFRQ4'
       }
 
-      session = await SessionHelper.add({ data: sessionData })
+      session = SessionModelStub.build(Sinon, sessionData)
+
+      Sinon.stub(FetchSessionDal, 'go').resolves(session)
     })
 
     it('returns page data for the view', async () => {
@@ -72,14 +84,16 @@ describe('Notices - Setup - View Contact Type service', () => {
   })
 
   describe('when called with a saved email', () => {
-    beforeEach(async () => {
+    beforeEach(() => {
       sessionData = {
         contactEmail: 'fake@person.com',
         contactType: 'email',
         referenceCode: 'RINV-CPFRQ4'
       }
 
-      session = await SessionHelper.add({ data: sessionData })
+      session = SessionModelStub.build(Sinon, sessionData)
+
+      Sinon.stub(FetchSessionDal, 'go').resolves(session)
     })
 
     it('returns page data for the view', async () => {

--- a/test/services/notices/setup/view-licence.service.test.js
+++ b/test/services/notices/setup/view-licence.service.test.js
@@ -9,8 +9,11 @@ const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
 const { generateLicenceRef } = require('../../../support/helpers/licence.helper.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const ViewLicenceService = require('../../../../app/services/notices/setup/view-licence.service.js')
@@ -18,11 +21,16 @@ const ViewLicenceService = require('../../../../app/services/notices/setup/view-
 describe('Notices - Setup - View Licence service', () => {
   let licenceRef
   let session
+  let sessionData
 
-  beforeEach(async () => {
+  beforeEach(() => {
     licenceRef = generateLicenceRef()
 
-    session = await SessionHelper.add({ data: { licenceRef } })
+    sessionData = { licenceRef }
+
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    Sinon.stub(FetchSessionDal, 'go').resolves(session)
   })
 
   afterEach(() => {

--- a/test/services/return-versions/setup/check/submit-check.service.test.js
+++ b/test/services/return-versions/setup/check/submit-check.service.test.js
@@ -9,11 +9,12 @@ const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const SessionHelper = require('../../../../support/helpers/session.helper.js')
-const { generateUUID, generateRandomInteger } = require('../../../../../app/lib/general.lib.js')
+const SessionModelStub = require('../../../../support/stubs/session.stub.js')
 const { generateLicenceRef } = require('../../../../support/helpers/licence.helper.js')
+const { generateUUID, generateRandomInteger } = require('../../../../../app/lib/general.lib.js')
 
 // Things we need to stub
+const FetchSessionDal = require('../../../../../app/dal/fetch-session.dal.js')
 const GenerateReturnVersionService = require('../../../../../app/services/return-versions/setup/check/generate-return-version.service.js')
 const PersistReturnVersionService = require('../../../../../app/services/return-versions/setup/check/create-return-version.service.js')
 const ProcessLicenceReturnLogsService = require('../../../../../app/services/return-logs/process-licence-return-logs.service.js')
@@ -90,9 +91,12 @@ describe('Return Versions Setup - Submit Check service', () => {
     })
 
     describe('and the reason is NOT "succession-or-transfer-of-licence"', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         sessionData.reason = 'minor-change'
-        session = await SessionHelper.add({ data: sessionData })
+
+        session = SessionModelStub.build(Sinon, sessionData)
+
+        Sinon.stub(FetchSessionDal, 'go').resolves(session)
 
         generateReturnVersionStub = Sinon.stub(GenerateReturnVersionService, 'go').resolves({
           returnVersion: {
@@ -137,9 +141,12 @@ describe('Return Versions Setup - Submit Check service', () => {
     })
 
     describe('and the reason is "succession-or-transfer-of-licence"', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         sessionData.reason = 'succession-or-transfer-of-licence'
-        session = await SessionHelper.add({ data: sessionData })
+
+        session = SessionModelStub.build(Sinon, sessionData)
+
+        Sinon.stub(FetchSessionDal, 'go').resolves(session)
 
         generateReturnVersionStub = Sinon.stub(GenerateReturnVersionService, 'go').resolves({
           returnVersion: {
@@ -185,7 +192,7 @@ describe('Return Versions Setup - Submit Check service', () => {
   })
 
   describe('when the "no-returns-required" journey is used', () => {
-    beforeEach(async () => {
+    beforeEach(() => {
       sessionData = {
         checkPageVisited: false,
         licence: { ...licenceData },
@@ -198,7 +205,9 @@ describe('Return Versions Setup - Submit Check service', () => {
         startDateOptions: 'licenceStartDate'
       }
 
-      session = await SessionHelper.add({ data: sessionData })
+      session = SessionModelStub.build(Sinon, sessionData)
+
+      Sinon.stub(FetchSessionDal, 'go').resolves(session)
 
       generateReturnVersionStub = Sinon.stub(GenerateReturnVersionService, 'go').resolves({
         returnVersion: {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5573

We recently refactored how we use fetch and delete session data, we now have a single way of doing each.

We are moving away from using the database in service test.

This change updates some of the tests still using the session helper to stub the 'FetchSessionDal'