### PR TITLE
Update tests to stub 'FetchSessionDal'

### DIFF
--- a/test/services/billing-accounts/setup/submit-contact.service.test.js
+++ b/test/services/billing-accounts/setup/submit-contact.service.test.js
@@ -8,13 +8,14 @@ const Sinon = require('sinon')
 const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
-// Things we need to stub
-const FetchCompanyContactsService = require('../../../../app/services/billing-accounts/setup/fetch-company-contacts.service.js')
-
 // Test helpers
 const BillingAccountsFixture = require('../../../support/fixtures/billing-accounts.fixture.js')
 const CustomersFixture = require('../../../support/fixtures/customers.fixture.js')
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchCompanyContactsService = require('../../../../app/services/billing-accounts/setup/fetch-company-contacts.service.js')
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const SubmitContactService = require('../../../../app/services/billing-accounts/setup/submit-contact.service.js')
@@ -29,19 +30,21 @@ describe('Billing Accounts - Setup - Contact Service', () => {
     contacts: [contact]
   }
 
+  let fetchSessionStub
   let payload
   let session
   let sessionData
 
-  beforeEach(async () => {})
+  beforeEach(() => {
+    fetchSessionStub = Sinon.stub(FetchSessionDal, 'go').resolves()
+  })
 
-  afterEach(async () => {
-    await session.$query().delete()
+  afterEach(() => {
     Sinon.restore()
   })
 
   describe('when the user picks to set up a "new" contact with an existing address', () => {
-    beforeEach(async () => {
+    beforeEach(() => {
       payload = {
         contactSelected: 'new'
       }
@@ -51,21 +54,22 @@ describe('Billing Accounts - Setup - Contact Service', () => {
         billingAccount
       }
 
-      session = await SessionHelper.add({ data: sessionData })
+      session = SessionModelStub.build(Sinon, sessionData)
+
+      fetchSessionStub.resolves(session)
     })
 
     it('saves the submitted value', async () => {
       await SubmitContactService.go(session.id, payload)
 
-      const refreshedSession = await session.$query()
-
-      expect(refreshedSession.data).to.equal(
+      expect(session).to.equal(
         {
           addressSelected: billingAccountAddress.id,
           contactSelected: payload.contactSelected
         },
-        { skip: ['billingAccount'] }
+        { skip: ['billingAccount', 'id'] }
       )
+      expect(session.$update.called).to.be.true()
     })
 
     it('continues the journey', async () => {
@@ -77,27 +81,27 @@ describe('Billing Accounts - Setup - Contact Service', () => {
     })
 
     describe('and the user has returned to the page and made the same choice', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         sessionData = {
           addressSelected: billingAccountAddress.id,
           billingAccount,
           contactSelected: 'new'
         }
 
-        session = await SessionHelper.add({ data: sessionData })
+        session = SessionModelStub.build(Sinon, sessionData)
+
+        fetchSessionStub.resolves(session)
       })
 
       it('saves the submitted value', async () => {
         await SubmitContactService.go(session.id, payload)
 
-        const refreshedSession = await session.$query()
-
-        expect(refreshedSession.data).to.equal(
+        expect(session).to.equal(
           {
             addressSelected: billingAccountAddress.id,
             contactSelected: payload.contactSelected
           },
-          { skip: ['billingAccount'] }
+          { skip: ['billingAccount', 'id'] }
         )
       })
 
@@ -111,7 +115,7 @@ describe('Billing Accounts - Setup - Contact Service', () => {
     })
 
     describe('and the user has returned to the page from the check and made the same choice', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         sessionData = {
           addressSelected: billingAccountAddress.id,
           billingAccount,
@@ -119,21 +123,21 @@ describe('Billing Accounts - Setup - Contact Service', () => {
           contactSelected: 'new'
         }
 
-        session = await SessionHelper.add({ data: sessionData })
+        session = SessionModelStub.build(Sinon, sessionData)
+
+        fetchSessionStub.resolves(session)
       })
 
       it('saves the submitted value', async () => {
         await SubmitContactService.go(session.id, payload)
 
-        const refreshedSession = await session.$query()
-
-        expect(refreshedSession.data).to.equal(
+        expect(session).to.equal(
           {
             addressSelected: billingAccountAddress.id,
             checkPageVisited: true,
             contactSelected: payload.contactSelected
           },
-          { skip: ['billingAccount'] }
+          { skip: ['billingAccount', 'id'] }
         )
       })
 
@@ -148,7 +152,7 @@ describe('Billing Accounts - Setup - Contact Service', () => {
   })
 
   describe('when the user picks an existing contact with a new address', () => {
-    beforeEach(async () => {
+    beforeEach(() => {
       payload = {
         contactSelected: contact.id
       }
@@ -158,22 +162,23 @@ describe('Billing Accounts - Setup - Contact Service', () => {
         billingAccount
       }
 
-      session = await SessionHelper.add({ data: sessionData })
+      session = SessionModelStub.build(Sinon, sessionData)
+
+      fetchSessionStub.resolves(session)
     })
 
     it('saves the submitted value', async () => {
       await SubmitContactService.go(session.id, payload)
 
-      const refreshedSession = await session.$query()
-
-      expect(refreshedSession.data).to.equal(
+      expect(session).to.equal(
         {
-          addressJourney: _addressJourney(refreshedSession),
+          addressJourney: _addressJourney(session),
           addressSelected: 'new',
           contactSelected: payload.contactSelected
         },
-        { skip: ['billingAccount'] }
+        { skip: ['billingAccount', 'id'] }
       )
+      expect(session.$update.called).to.be.true()
     })
 
     it('continues the journey', async () => {
@@ -185,7 +190,7 @@ describe('Billing Accounts - Setup - Contact Service', () => {
     })
 
     describe('and the user has returned to the page and made the same choice', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         payload = {
           contactSelected: contact.id
         }
@@ -197,21 +202,21 @@ describe('Billing Accounts - Setup - Contact Service', () => {
           contactSelected: contact.id
         }
 
-        session = await SessionHelper.add({ data: sessionData })
+        session = SessionModelStub.build(Sinon, sessionData)
+
+        fetchSessionStub.resolves(session)
       })
 
       it('saves the submitted value', async () => {
         await SubmitContactService.go(session.id, payload)
 
-        const refreshedSession = await session.$query()
-
-        expect(refreshedSession.data).to.equal(
+        expect(session).to.equal(
           {
             addressJourney: sessionData.addressJourney,
             addressSelected: 'new',
             contactSelected: payload.contactSelected
           },
-          { skip: ['billingAccount'] }
+          { skip: ['billingAccount', 'id'] }
         )
       })
 
@@ -225,7 +230,7 @@ describe('Billing Accounts - Setup - Contact Service', () => {
     })
 
     describe('and the user has returned from the check page and made the same choice', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         payload = {
           contactSelected: contact.id
         }
@@ -238,22 +243,22 @@ describe('Billing Accounts - Setup - Contact Service', () => {
           contactSelected: contact.id
         }
 
-        session = await SessionHelper.add({ data: sessionData })
+        session = SessionModelStub.build(Sinon, sessionData)
+
+        fetchSessionStub.resolves(session)
       })
 
       it('saves the submitted value', async () => {
         await SubmitContactService.go(session.id, payload)
 
-        const refreshedSession = await session.$query()
-
-        expect(refreshedSession.data).to.equal(
+        expect(session).to.equal(
           {
             addressJourney: sessionData.addressJourney,
             addressSelected: 'new',
             checkPageVisited: true,
             contactSelected: payload.contactSelected
           },
-          { skip: ['billingAccount'] }
+          { skip: ['billingAccount', 'id'] }
         )
       })
 
@@ -267,7 +272,7 @@ describe('Billing Accounts - Setup - Contact Service', () => {
     })
 
     describe('and the user had previously completed the "new" journey', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         payload = {
           contactSelected: contact.id
         }
@@ -280,23 +285,23 @@ describe('Billing Accounts - Setup - Contact Service', () => {
           contactName: 'Contact Name'
         }
 
-        session = await SessionHelper.add({ data: sessionData })
+        session = SessionModelStub.build(Sinon, sessionData)
+
+        fetchSessionStub.resolves(session)
       })
 
       it('saves the submitted value', async () => {
         await SubmitContactService.go(session.id, payload)
 
-        const refreshedSession = await session.$query()
-
-        expect(refreshedSession.data).to.equal(
+        expect(session).to.equal(
           {
-            addressJourney: _addressJourney(refreshedSession),
+            addressJourney: _addressJourney(session),
             addressSelected: 'new',
             checkPageVisited: false,
             contactSelected: payload.contactSelected,
             contactName: null
           },
-          { skip: ['billingAccount'] }
+          { skip: ['billingAccount', 'id'] }
         )
       })
 
@@ -313,8 +318,9 @@ describe('Billing Accounts - Setup - Contact Service', () => {
   describe('when validation fails', () => {
     describe('because the user did not select an option', () => {
       describe('and the user had chosen the current customer', () => {
-        beforeEach(async () => {
+        beforeEach(() => {
           payload = {}
+
           sessionData = {
             accountSelected: billingAccount.company.id,
             billingAccount,
@@ -322,7 +328,9 @@ describe('Billing Accounts - Setup - Contact Service', () => {
             contactName: 'Contact Name'
           }
 
-          session = await SessionHelper.add({ data: sessionData })
+          session = SessionModelStub.build(Sinon, sessionData)
+
+          fetchSessionStub.resolves(session)
 
           Sinon.stub(FetchCompanyContactsService, 'go').resolves(companyContacts)
         })
@@ -345,8 +353,9 @@ describe('Billing Accounts - Setup - Contact Service', () => {
       })
 
       describe('and the user had chosen another customer', () => {
-        beforeEach(async () => {
+        beforeEach(() => {
           payload = {}
+
           sessionData = {
             accountSelected: 'another',
             billingAccount,
@@ -355,7 +364,9 @@ describe('Billing Accounts - Setup - Contact Service', () => {
             existingAccount: billingAccount.company.id
           }
 
-          session = await SessionHelper.add({ data: sessionData })
+          session = SessionModelStub.build(Sinon, sessionData)
+
+          fetchSessionStub.resolves(session)
 
           Sinon.stub(FetchCompanyContactsService, 'go').resolves(companyContacts)
         })

--- a/test/services/billing-accounts/setup/submit-existing-address.service.test.js
+++ b/test/services/billing-accounts/setup/submit-existing-address.service.test.js
@@ -298,7 +298,7 @@ describe('Billing Accounts - Setup - Submit Existing Address Service', () => {
             ..._commonSessionData(session.billingAccount),
             addressSelected: payload.addressSelected
           },
-          { skip: ['accountSelected', 'billingAccount', 'existingAccount', 'id', 'id'] }
+          { skip: ['accountSelected', 'billingAccount', 'existingAccount', 'id'] }
         )
       })
 

--- a/test/services/billing-accounts/setup/submit-existing-address.service.test.js
+++ b/test/services/billing-accounts/setup/submit-existing-address.service.test.js
@@ -10,11 +10,12 @@ const { expect } = Code
 
 // Test helpers
 const BillingAccountsFixture = require('../../../support/fixtures/billing-accounts.fixture.js')
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
 const { generateUUID } = require('../../../../app/lib/general.lib.js')
 
 // Things to stub
 const FetchCompanyAddressesService = require('../../../../app/services/billing-accounts/setup/fetch-company-addresses.service.js')
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const SubmitExistingAddressService = require('../../../../app/services/billing-accounts/setup/submit-existing-address.service.js')
@@ -26,27 +27,35 @@ describe('Billing Accounts - Setup - Submit Existing Address Service', () => {
     addresses: _addresses()
   }
 
+  let fetchSessionStub
   let payload
   let session
   let sessionData
 
-  beforeEach(async () => {
+  beforeEach(() => {
     Sinon.stub(FetchCompanyAddressesService, 'go').returns(companyAddresses)
+
+    sessionData = {}
+
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    fetchSessionStub = Sinon.stub(FetchSessionDal, 'go').resolves(session)
   })
 
-  afterEach(async () => {
-    await session.$query().delete()
+  afterEach(() => {
     Sinon.restore()
   })
 
   describe('when the user picks an existing address', () => {
-    beforeEach(async () => {
+    beforeEach(() => {
       sessionData = {
         accountSelected: billingAccount.company.id,
         billingAccount
       }
 
-      session = await SessionHelper.add({ data: sessionData })
+      session = SessionModelStub.build(Sinon, sessionData)
+
+      fetchSessionStub.resolves(session)
 
       payload = {
         addressSelected: companyAddresses.addresses[0].id
@@ -56,14 +65,13 @@ describe('Billing Accounts - Setup - Submit Existing Address Service', () => {
     it('saves the submitted value', async () => {
       await SubmitExistingAddressService.go(session.id, payload)
 
-      const refreshedSession = await session.$query()
-
-      expect(refreshedSession.data).to.equal(
+      expect(session).to.equal(
         {
           addressSelected: payload.addressSelected
         },
-        { skip: ['accountSelected', 'billingAccount'] }
+        { skip: ['accountSelected', 'billingAccount', 'id'] }
       )
+      expect(session.$update.called).to.be.true()
     })
 
     it('continues the journey', async () => {
@@ -75,25 +83,25 @@ describe('Billing Accounts - Setup - Submit Existing Address Service', () => {
     })
 
     describe('and the user has returned to the page and made the same choice', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         sessionData = {
           addressSelected: companyAddresses.addresses[0].id,
           billingAccount
         }
 
-        session = await SessionHelper.add({ data: sessionData })
+        session = SessionModelStub.build(Sinon, sessionData)
+
+        fetchSessionStub.resolves(session)
       })
 
       it('saves the submitted value', async () => {
         await SubmitExistingAddressService.go(session.id, payload)
 
-        const refreshedSession = await session.$query()
-
-        expect(refreshedSession.data).to.equal(
+        expect(session).to.equal(
           {
             addressSelected: payload.addressSelected
           },
-          { skip: ['accountSelected', 'billingAccount'] }
+          { skip: ['accountSelected', 'billingAccount', 'id'] }
         )
       })
 
@@ -107,27 +115,27 @@ describe('Billing Accounts - Setup - Submit Existing Address Service', () => {
     })
 
     describe('and the user has returned to the page from the check page and made the same choice', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         sessionData = {
           addressSelected: companyAddresses.addresses[0].id,
           billingAccount,
           checkPageVisited: true
         }
 
-        session = await SessionHelper.add({ data: sessionData })
+        session = SessionModelStub.build(Sinon, sessionData)
+
+        fetchSessionStub.resolves(session)
       })
 
       it('saves the submitted value', async () => {
         await SubmitExistingAddressService.go(session.id, payload)
 
-        const refreshedSession = await session.$query()
-
-        expect(refreshedSession.data).to.equal(
+        expect(session).to.equal(
           {
             addressSelected: payload.addressSelected,
             checkPageVisited: true
           },
-          { skip: ['accountSelected', 'billingAccount'] }
+          { skip: ['accountSelected', 'billingAccount', 'id'] }
         )
       })
 
@@ -141,23 +149,23 @@ describe('Billing Accounts - Setup - Submit Existing Address Service', () => {
     })
 
     describe('and the user selects an existing address after already having set up a new address', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         sessionData = _newAddressSessionData(session)
 
-        session = await SessionHelper.add({ data: sessionData })
+        session = SessionModelStub.build(Sinon, sessionData)
+
+        fetchSessionStub.resolves(session)
       })
 
       it('saves the submitted value', async () => {
         await SubmitExistingAddressService.go(session.id, payload)
 
-        const refreshedSession = await session.$query()
-
-        expect(refreshedSession.data).to.equal(
+        expect(session).to.equal(
           {
             ..._newAddressExpectedValues(session),
             addressSelected: payload.addressSelected
           },
-          { skip: ['accountSelected', 'billingAccount'] }
+          { skip: ['accountSelected', 'billingAccount', 'id'] }
         )
       })
 
@@ -172,14 +180,16 @@ describe('Billing Accounts - Setup - Submit Existing Address Service', () => {
   })
 
   describe('when the user picks to set up a new address', () => {
-    beforeEach(async () => {
+    beforeEach(() => {
       sessionData = {
         accountSelected: 'another',
         existingAccount: billingAccount.company.id,
         billingAccount
       }
 
-      session = await SessionHelper.add({ data: sessionData })
+      session = SessionModelStub.build(Sinon, sessionData)
+
+      fetchSessionStub.resolves(session)
 
       payload = {
         addressSelected: 'new'
@@ -189,13 +199,11 @@ describe('Billing Accounts - Setup - Submit Existing Address Service', () => {
     it('saves the submitted value', async () => {
       await SubmitExistingAddressService.go(session.id, payload)
 
-      const refreshedSession = await session.$query()
-
-      expect(refreshedSession.data).to.equal(
+      expect(session).to.equal(
         {
           addressSelected: 'new'
         },
-        { skip: ['accountSelected', 'billingAccount', 'existingAccount'] }
+        { skip: ['accountSelected', 'billingAccount', 'existingAccount', 'id'] }
       )
     })
 
@@ -208,25 +216,25 @@ describe('Billing Accounts - Setup - Submit Existing Address Service', () => {
     })
 
     describe('and the user has returned to the page and made the same choice', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         sessionData = {
           addressSelected: 'new',
           billingAccount: BillingAccountsFixture.billingAccount().billingAccount
         }
 
-        session = await SessionHelper.add({ data: sessionData })
+        session = SessionModelStub.build(Sinon, sessionData)
+
+        fetchSessionStub.resolves(session)
       })
 
       it('saves the submitted value', async () => {
         await SubmitExistingAddressService.go(session.id, payload)
 
-        const refreshedSession = await session.$query()
-
-        expect(refreshedSession.data).to.equal(
+        expect(session).to.equal(
           {
             addressSelected: 'new'
           },
-          { skip: ['accountSelected', 'billingAccount', 'existingAccount'] }
+          { skip: ['accountSelected', 'billingAccount', 'existingAccount', 'id'] }
         )
       })
 
@@ -240,27 +248,27 @@ describe('Billing Accounts - Setup - Submit Existing Address Service', () => {
     })
 
     describe('and the user has returned to the page from the check page and made the same choice', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         sessionData = {
           addressSelected: 'new',
           billingAccount: BillingAccountsFixture.billingAccount().billingAccount,
           checkPageVisited: true
         }
 
-        session = await SessionHelper.add({ data: sessionData })
+        session = SessionModelStub.build(Sinon, sessionData)
+
+        fetchSessionStub.resolves(session)
       })
 
       it('saves the submitted value', async () => {
         await SubmitExistingAddressService.go(session.id, payload)
 
-        const refreshedSession = await session.$query()
-
-        expect(refreshedSession.data).to.equal(
+        expect(session).to.equal(
           {
             addressSelected: 'new',
             checkPageVisited: true
           },
-          { skip: ['accountSelected', 'billingAccount', 'existingAccount'] }
+          { skip: ['accountSelected', 'billingAccount', 'existingAccount', 'id'] }
         )
       })
 
@@ -274,23 +282,23 @@ describe('Billing Accounts - Setup - Submit Existing Address Service', () => {
     })
 
     describe('when the user selects a new address after already having chosen an existing address', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         sessionData = _commonSessionData(session.billingAccount)
 
-        session = await SessionHelper.add({ data: sessionData })
+        session = SessionModelStub.build(Sinon, sessionData)
+
+        fetchSessionStub.resolves(session)
       })
 
       it('saves the submitted value', async () => {
         await SubmitExistingAddressService.go(session.id, payload)
 
-        const refreshedSession = await session.$query()
-
-        expect(refreshedSession.data).to.equal(
+        expect(session).to.equal(
           {
             ..._commonSessionData(session.billingAccount),
             addressSelected: payload.addressSelected
           },
-          { skip: ['accountSelected', 'billingAccount', 'existingAccount'] }
+          { skip: ['accountSelected', 'billingAccount', 'existingAccount', 'id', 'id'] }
         )
       })
 
@@ -305,14 +313,16 @@ describe('Billing Accounts - Setup - Submit Existing Address Service', () => {
   })
 
   describe('when validation fails', () => {
-    beforeEach(async () => {
+    beforeEach(() => {
       sessionData = {
         accountSelected: 'another',
         existingAccount: billingAccount.company.id,
         billingAccount
       }
 
-      session = await SessionHelper.add({ data: sessionData })
+      session = SessionModelStub.build(Sinon, sessionData)
+
+      fetchSessionStub.resolves(session)
 
       payload = {}
     })

--- a/test/services/notices/setup/submit-cancel.service.test.js
+++ b/test/services/notices/setup/submit-cancel.service.test.js
@@ -9,17 +9,28 @@ const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
-const SessionModel = require('../../../../app/models/session.model.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const DeleteSessionDal = require('../../../../app/dal/delete-session.dal.js')
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const SubmitCancelService = require('../../../../app/services/notices/setup/submit-cancel.service.js')
 
 describe('Notices - Setup - Submit Cancel service', () => {
+  let fetchSessionStub
   let session
+  let sessionData
 
-  beforeEach(async () => {
-    session = await SessionHelper.add({ data: { licenceRef: '01/111', referenceCode: 'RNIV-1234' } })
+  beforeEach(() => {
+    sessionData = { licenceRef: '01/111', referenceCode: 'RNIV-1234' }
+
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    fetchSessionStub = Sinon.stub(FetchSessionDal, 'go').resolves(session)
+
+    Sinon.stub(DeleteSessionDal, 'go').resolves(session)
   })
 
   afterEach(() => {
@@ -30,9 +41,7 @@ describe('Notices - Setup - Submit Cancel service', () => {
     it('clears the session', async () => {
       await SubmitCancelService.go(session.id)
 
-      const noSession = await SessionModel.query().where('id', session.id)
-
-      expect(noSession).to.equal([])
+      expect(DeleteSessionDal.go.calledWith(session.id)).to.be.true()
     })
 
     describe('when the journey is for a return', () => {
@@ -44,15 +53,16 @@ describe('Notices - Setup - Submit Cancel service', () => {
     })
 
     describe('when the journey is for "alerts"', () => {
-      beforeEach(async () => {
-        session = await SessionHelper.add({
-          data: {
-            alertType: 'stop',
-            journey: 'alerts',
-            monitoringStationId: '123',
-            referenceCode: 'WAA-1234'
-          }
-        })
+      beforeEach(() => {
+        sessionData = {
+          alertType: 'stop',
+          journey: 'alerts',
+          monitoringStationId: '123',
+          referenceCode: 'WAA-1234'
+        }
+        session = SessionModelStub.build(Sinon, sessionData)
+
+        fetchSessionStub.resolves(session)
       })
 
       it('returns the redirect url', async () => {

--- a/test/services/notices/setup/submit-contact-type.service.test.js
+++ b/test/services/notices/setup/submit-contact-type.service.test.js
@@ -10,12 +10,16 @@ const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const SubmitContactTypeService = require('../../../../app/services/notices/setup/submit-contact-type.service.js')
 
 describe('Notices - Setup - Submit Contact Type service', () => {
+  let fetchSessionStub
   let payload
   let session
   let sessionData
@@ -24,6 +28,17 @@ describe('Notices - Setup - Submit Contact Type service', () => {
   const testEmailHash = _createMD5Hash('test@test.gov.uk')
 
   beforeEach(() => {
+    payload = {}
+
+    sessionData = {
+      licenceRef: '12345',
+      selectedRecipients: ['123']
+    }
+
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    fetchSessionStub = Sinon.stub(FetchSessionDal, 'go').resolves(session)
+
     yarStub = { flash: Sinon.stub() }
   })
 
@@ -32,33 +47,21 @@ describe('Notices - Setup - Submit Contact Type service', () => {
   })
 
   describe('when called with a valid', () => {
-    beforeEach(() => {
-      sessionData = {
-        licenceRef: '12345',
-        selectedRecipients: ['123']
-      }
-    })
+    beforeEach(() => {})
 
     describe('email payload', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         payload = {
           contactType: 'email',
           contactEmail: 'test@test.gov.uk'
-        }
-
-        session = await SessionHelper.add({ data: sessionData })
-        yarStub = {
-          flash: Sinon.stub().returns([{ titleText: 'Updated', text: 'Additional recipient added' }])
         }
       })
 
       it('saves the submitted value', async () => {
         await SubmitContactTypeService.go(session.id, payload, yarStub)
 
-        const refreshedSession = await session.$query()
-
-        expect(refreshedSession.contactType).to.equal(undefined)
-        expect(refreshedSession.additionalRecipients).to.equal([
+        expect(session.contactType).to.equal(undefined)
+        expect(session.additionalRecipients).to.equal([
           {
             contact: null,
             contact_hash_id: _createMD5Hash(payload.contactEmail),
@@ -69,14 +72,13 @@ describe('Notices - Setup - Submit Contact Type service', () => {
             message_type: 'Email'
           }
         ])
+        expect(session.$update.called).to.be.true()
       })
 
       it('saves the recipients "contact_hash_id" to the sessions "selectedRecipients" array', async () => {
         await SubmitContactTypeService.go(session.id, payload, yarStub)
 
-        const refreshedSession = await session.$query()
-
-        expect(refreshedSession.selectedRecipients).to.equal(['123', _createMD5Hash(payload.contactEmail)])
+        expect(session.selectedRecipients).to.equal(['123', _createMD5Hash(payload.contactEmail)])
       })
 
       it('continues the journey', async () => {
@@ -94,25 +96,22 @@ describe('Notices - Setup - Submit Contact Type service', () => {
     })
 
     describe('email payload with no existing additionalRecipients', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         payload = {
           contactType: 'email',
           contactEmail: 'test@test.gov.uk'
         }
 
-        session = await SessionHelper.add({ data: sessionData })
-        yarStub = {
-          flash: Sinon.stub().returns([{ titleText: 'Updated', text: 'Additional recipient added' }])
-        }
+        session = SessionModelStub.build(Sinon, sessionData)
+
+        fetchSessionStub.resolves(session)
       })
 
       it('saves the submitted value', async () => {
         await SubmitContactTypeService.go(session.id, payload, yarStub)
 
-        const refreshedSession = await session.$query()
-
-        expect(refreshedSession.contactType).to.equal(undefined)
-        expect(refreshedSession.additionalRecipients).to.equal([
+        expect(session.contactType).to.equal(undefined)
+        expect(session.additionalRecipients).to.equal([
           {
             contact: null,
             contact_hash_id: _createMD5Hash(payload.contactEmail),
@@ -140,25 +139,22 @@ describe('Notices - Setup - Submit Contact Type service', () => {
     })
 
     describe('email payload with no existing additionalRecipients with the address capitalised', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         payload = {
           contactType: 'email',
           contactEmail: 'TEST@TEST.GOV.UK'
         }
 
-        session = await SessionHelper.add({ data: sessionData })
-        yarStub = {
-          flash: Sinon.stub().returns([{ titleText: 'Updated', text: 'Additional recipient added' }])
-        }
+        session = SessionModelStub.build(Sinon, sessionData)
+
+        fetchSessionStub.resolves(session)
       })
 
       it('saves the submitted value with the email address in lowercase', async () => {
         await SubmitContactTypeService.go(session.id, payload, yarStub)
 
-        const refreshedSession = await session.$query()
-
-        expect(refreshedSession.contactType).to.equal(undefined)
-        expect(refreshedSession.additionalRecipients).to.equal([
+        expect(session.contactType).to.equal(undefined)
+        expect(session.additionalRecipients).to.equal([
           {
             contact: null,
             contact_hash_id: testEmailHash,
@@ -186,7 +182,7 @@ describe('Notices - Setup - Submit Contact Type service', () => {
     })
 
     describe('email payload with an existing additionalRecipients', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         payload = {
           contactType: 'email',
           contactEmail: 'other.test@test.gov.uk'
@@ -204,19 +200,16 @@ describe('Notices - Setup - Submit Contact Type service', () => {
           }
         ]
 
-        session = await SessionHelper.add({ data: sessionData })
-        yarStub = {
-          flash: Sinon.stub().returns([{ titleText: 'Updated', text: 'Additional recipient added' }])
-        }
+        session = SessionModelStub.build(Sinon, sessionData)
+
+        fetchSessionStub.resolves(session)
       })
 
       it('saves the submitted value', async () => {
         await SubmitContactTypeService.go(session.id, payload, yarStub)
 
-        const refreshedSession = await session.$query()
-
-        expect(refreshedSession.contactType).to.equal(undefined)
-        expect(refreshedSession.additionalRecipients).to.equal([
+        expect(session.contactType).to.equal(undefined)
+        expect(session.additionalRecipients).to.equal([
           {
             contact: null,
             contact_hash_id: testEmailHash,
@@ -253,22 +246,22 @@ describe('Notices - Setup - Submit Contact Type service', () => {
     })
 
     describe('post payload', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         payload = {
           contactType: 'post',
           contactName: 'Fake Name'
         }
 
-        session = await SessionHelper.add({ data: sessionData })
+        session = SessionModelStub.build(Sinon, sessionData)
+
+        fetchSessionStub.resolves(session)
       })
 
       it('saves the submitted value', async () => {
         await SubmitContactTypeService.go(session.id, payload, yarStub)
 
-        const refreshedSession = await session.$query()
-
-        expect(refreshedSession.contactType).to.equal(payload.contactType)
-        expect(refreshedSession.contactName).to.equal(payload.contactName)
+        expect(session.contactType).to.equal(payload.contactType)
+        expect(session.contactName).to.equal(payload.contactName)
       })
 
       it('continues the journey', async () => {
@@ -284,11 +277,12 @@ describe('Notices - Setup - Submit Contact Type service', () => {
 
   describe('when validation fails', () => {
     describe('when validation fails because no type is selected', () => {
-      beforeEach(async () => {
-        payload = {}
+      beforeEach(() => {
         sessionData = { referenceCode: 'RINV-CPFRQ4' }
 
-        session = await SessionHelper.add({ data: sessionData })
+        session = SessionModelStub.build(Sinon, sessionData)
+
+        fetchSessionStub.resolves(session)
       })
 
       it('returns page data for the view, with errors', async () => {
@@ -321,13 +315,16 @@ describe('Notices - Setup - Submit Contact Type service', () => {
     })
 
     describe('when validation fails because type is email but no email is entered', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         payload = {
           contactType: 'email'
         }
+
         sessionData = { referenceCode: 'RINV-CPFRQ4' }
 
-        session = await SessionHelper.add({ data: sessionData })
+        session = SessionModelStub.build(Sinon, sessionData)
+
+        fetchSessionStub.resolves(session)
       })
 
       it('returns page data for the view, with errors', async () => {
@@ -360,13 +357,16 @@ describe('Notices - Setup - Submit Contact Type service', () => {
     })
 
     describe('when validation fails because type is post but no name is entered', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         payload = {
           contactType: 'post'
         }
+
         sessionData = { referenceCode: 'RINV-CPFRQ4' }
 
-        session = await SessionHelper.add({ data: sessionData })
+        session = SessionModelStub.build(Sinon, sessionData)
+
+        fetchSessionStub.resolves(session)
       })
 
       it('returns page data for the view, with errors', async () => {

--- a/test/services/notices/setup/submit-licence.service.test.js
+++ b/test/services/notices/setup/submit-licence.service.test.js
@@ -10,32 +10,42 @@ const { expect } = Code
 
 // Test helpers
 const LicenceHelper = require('../../../support/helpers/licence.helper.js')
-const SessionHelper = require('../../../support/helpers/session.helper.js')
 const ReturnLogHelper = require('../../../support/helpers/return-log.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
 const { generateLicenceRef } = require('../../../support/helpers/licence.helper.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const SubmitLicenceService = require('../../../../app/services/notices/setup/submit-licence.service.js')
 
 describe('Notices - Setup - Submit Licence service', () => {
   let clock
+  let fetchSessionStub
   let licenceRef
   let payload
   let session
+  let sessionData
   let yarStub
 
-  beforeEach(async () => {
+  beforeEach(() => {
     licenceRef = generateLicenceRef()
 
-    session = await SessionHelper.add({ data: {} })
-
     clock = Sinon.useFakeTimers(new Date('2020-06-06'))
+
+    sessionData = {}
+
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    fetchSessionStub = Sinon.stub(FetchSessionDal, 'go').resolves(session)
 
     yarStub = { flash: Sinon.stub() }
   })
 
   afterEach(() => {
     clock.restore()
+    Sinon.restore()
   })
 
   describe('when called', () => {
@@ -52,9 +62,8 @@ describe('Notices - Setup - Submit Licence service', () => {
       it('saves the submitted value', async () => {
         await SubmitLicenceService.go(session.id, payload, yarStub)
 
-        const refreshedSession = await session.$query()
-
-        expect(refreshedSession.licenceRef).to.equal(licenceRef)
+        expect(session.licenceRef).to.equal(licenceRef)
+        expect(session.$update.called).to.be.true()
       })
 
       it('returns the redirect url', async () => {
@@ -65,8 +74,12 @@ describe('Notices - Setup - Submit Licence service', () => {
 
       describe('from the check page', () => {
         describe('and the licence ref has been updated', () => {
-          beforeEach(async () => {
-            session = await SessionHelper.add({ data: { licenceRef: '01/11', checkPageVisited: true } })
+          beforeEach(() => {
+            sessionData = { licenceRef: '01/11', checkPageVisited: true }
+
+            session = SessionModelStub.build(Sinon, sessionData)
+
+            fetchSessionStub.resolves(session)
           })
 
           it('redirects to the notice type page', async () => {
@@ -78,9 +91,7 @@ describe('Notices - Setup - Submit Licence service', () => {
           it('updates the sessions "checkPageVisited" flag', async () => {
             await SubmitLicenceService.go(session.id, payload, yarStub)
 
-            const refreshedSession = await session.$query()
-
-            expect(refreshedSession.checkPageVisited).to.be.false()
+            expect(session.checkPageVisited).to.be.false()
           })
 
           it('sets a flash message', async () => {
@@ -98,8 +109,12 @@ describe('Notices - Setup - Submit Licence service', () => {
         })
 
         describe('and the licence ref has not been updated', () => {
-          beforeEach(async () => {
-            session = await SessionHelper.add({ data: { licenceRef, checkPageVisited: true } })
+          beforeEach(() => {
+            sessionData = { licenceRef, checkPageVisited: true }
+
+            session = SessionModelStub.build(Sinon, sessionData)
+
+            fetchSessionStub.resolves(session)
           })
 
           it('redirects to the check notice type page', async () => {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5573

We recently refactored how we use fetch and delete session data, we now have a single way of doing each.

We are moving away from using the database in service test.

This change updates some of the tests still using the session helper to stub the 'FetchSessionDal'