### PR TITLE
Update tests to stub 'FetchSessionDal'

### DIFF
--- a/test/services/bill-runs/setup/no-licences.service.test.js
+++ b/test/services/bill-runs/setup/no-licences.service.test.js
@@ -33,6 +33,10 @@ describe('Bill Runs - Setup - No Licences service', () => {
       Sinon.stub(FetchSessionDal, 'go').resolves(session)
     })
 
+    afterEach(() => {
+      Sinon.restore()
+    })
+
     it('returns page data for the view', async () => {
       const result = await NoLicencesService.go(session.id)
 

--- a/test/services/bill-runs/setup/no-licences.service.test.js
+++ b/test/services/bill-runs/setup/no-licences.service.test.js
@@ -3,13 +3,17 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
+const Sinon = require('sinon')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
 const RegionHelper = require('../../../support/helpers/region.helper.js')
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const NoLicencesService = require('../../../../app/services/bill-runs/setup/no-licences.service.js')
@@ -17,23 +21,26 @@ const NoLicencesService = require('../../../../app/services/bill-runs/setup/no-l
 describe('Bill Runs - Setup - No Licences service', () => {
   const region = RegionHelper.select(RegionHelper.TEST_REGION_INDEX)
 
-  let sessionId
+  let session
+  let sessionData
 
   describe('when called with a valid session id', () => {
-    beforeEach(async () => {
-      const session = await SessionHelper.add({ data: { region: region.id } })
+    beforeEach(() => {
+      sessionData = { region: region.id }
 
-      sessionId = session.id
+      session = SessionModelStub.build(Sinon, sessionData)
+
+      Sinon.stub(FetchSessionDal, 'go').resolves(session)
     })
 
     it('returns page data for the view', async () => {
-      const result = await NoLicencesService.go(sessionId)
+      const result = await NoLicencesService.go(session.id)
 
       expect(result).to.equal({
         activeNavBar: 'bill-runs',
-        backlink: `/system/bill-runs/setup/${sessionId}/region`,
+        backlink: `/system/bill-runs/setup/${session.id}/region`,
         pageTitle: `There are no licences marked for two-part tariff supplementary billing in the ${region.displayName} region`,
-        sessionId
+        sessionId: session.id
       })
     })
   })

--- a/test/services/bill-runs/setup/region.service.test.js
+++ b/test/services/bill-runs/setup/region.service.test.js
@@ -10,24 +10,30 @@ const { expect } = Code
 
 // Test helpers
 const RegionHelper = require('../../../support/helpers/region.helper.js')
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
 
 // Things we need to stub
 const FetchRegionsService = require('../../../../app/services/bill-runs/setup/fetch-regions.service.js')
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const RegionService = require('../../../../app/services/bill-runs/setup/region.service.js')
 
 describe('Bill Runs - Setup - Region service', () => {
   let session
+  let sessionData
   let regions
   let region
 
-  beforeEach(async () => {
+  beforeEach(() => {
     regions = RegionHelper.data
     region = RegionHelper.select()
 
-    session = await SessionHelper.add({ data: { region: region.id } })
+    sessionData = { region: region.id }
+
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    Sinon.stub(FetchSessionDal, 'go').resolves(session)
 
     Sinon.stub(FetchRegionsService, 'go').resolves(regions)
   })

--- a/test/services/bill-runs/setup/submit-region.service.test.js
+++ b/test/services/bill-runs/setup/submit-region.service.test.js
@@ -10,25 +10,32 @@ const { expect } = Code
 
 // Test helpers
 const RegionHelper = require('../../../support/helpers/region.helper.js')
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
 
 // Things we need to stub
 const FetchRegionsService = require('../../../../app/services/bill-runs/setup/fetch-regions.service.js')
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const SubmitRegionService = require('../../../../app/services/bill-runs/setup/submit-region.service.js')
 
 describe('Bill Runs - Setup - Submit Region service', () => {
+  let fetchSessionStub
   let payload
   let region
   let regions
   let session
+  let sessionData
 
-  beforeEach(async () => {
+  beforeEach(() => {
     regions = RegionHelper.data
     region = RegionHelper.select()
 
-    session = await SessionHelper.add({ data: {} })
+    sessionData = {}
+
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    fetchSessionStub = Sinon.stub(FetchSessionDal, 'go').resolves(session)
 
     Sinon.stub(FetchRegionsService, 'go').resolves(regions)
   })
@@ -46,49 +53,55 @@ describe('Bill Runs - Setup - Submit Region service', () => {
       })
 
       describe('and the bill run type was not two-part tariff', () => {
-        beforeEach(async () => {
-          session = await SessionHelper.add({ data: { type: 'annual' } })
+        beforeEach(() => {
+          sessionData = { type: 'annual' }
+
+          session = SessionModelStub.build(Sinon, sessionData)
+
+          fetchSessionStub.resolves(session)
         })
 
         it('saves the submitted region ID and its name and returns an object confirming setup is complete', async () => {
           const result = await SubmitRegionService.go(session.id, payload)
 
-          const refreshedSession = await session.$query()
-
-          expect(refreshedSession.region).to.equal(region.id)
-          expect(refreshedSession.regionName).to.equal(region.displayName)
+          expect(session.region).to.equal(region.id)
+          expect(session.regionName).to.equal(region.displayName)
           expect(result.setupComplete).to.be.true()
         })
       })
 
       describe('and the bill run type was two-part tariff', () => {
-        beforeEach(async () => {
-          session = await SessionHelper.add({ data: { type: 'two_part_tariff' } })
+        beforeEach(() => {
+          sessionData = { type: 'two_part_tariff' }
+
+          session = SessionModelStub.build(Sinon, sessionData)
+
+          fetchSessionStub.resolves(session)
         })
 
         it('saves the submitted region ID and its name and returns an object confirming setup is not complete', async () => {
           const result = await SubmitRegionService.go(session.id, payload)
 
-          const refreshedSession = await session.$query()
-
-          expect(refreshedSession.region).to.equal(region.id)
-          expect(refreshedSession.regionName).to.equal(region.displayName)
+          expect(session.region).to.equal(region.id)
+          expect(session.regionName).to.equal(region.displayName)
           expect(result.setupComplete).to.be.false()
         })
       })
 
       describe('and the bill run type was two-part tariff supplementary', () => {
-        beforeEach(async () => {
-          session = await SessionHelper.add({ data: { type: 'two_part_supplementary' } })
+        beforeEach(() => {
+          sessionData = { type: 'two_part_supplementary' }
+
+          session = SessionModelStub.build(Sinon, sessionData)
+
+          fetchSessionStub.resolves(session)
         })
 
         it('saves the submitted region ID and its name and returns an object confirming setup is not complete', async () => {
           const result = await SubmitRegionService.go(session.id, payload)
 
-          const refreshedSession = await session.$query()
-
-          expect(refreshedSession.region).to.equal(region.id)
-          expect(refreshedSession.regionName).to.equal(region.displayName)
+          expect(session.region).to.equal(region.id)
+          expect(session.regionName).to.equal(region.displayName)
           expect(result.setupComplete).to.be.false()
         })
       })
@@ -96,10 +109,14 @@ describe('Bill Runs - Setup - Submit Region service', () => {
 
     describe('with an invalid payload', () => {
       describe('because the user has not selected anything', () => {
-        beforeEach(async () => {
+        beforeEach(() => {
           payload = {}
 
-          session = await SessionHelper.add({ data: { type: 'annual' } })
+          sessionData = { type: 'annual' }
+
+          session = SessionModelStub.build(Sinon, sessionData)
+
+          fetchSessionStub.resolves(session)
         })
 
         it('returns page data needed to re-render the view including the validation error', async () => {

--- a/test/services/bill-runs/setup/year.service.test.js
+++ b/test/services/bill-runs/setup/year.service.test.js
@@ -9,10 +9,11 @@ const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
 
 // Things we need to stub
 const FetchLicenceSupplementaryYearsService = require('../../../../app/services/bill-runs/setup/fetch-licence-supplementary-years.service.js')
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const YearService = require('../../../../app/services/bill-runs/setup/year.service.js')
@@ -21,10 +22,15 @@ describe('Bill Runs - Setup - Year service', () => {
   const regionId = 'cff057a0-f3a7-4ae6-bc2b-01183e40fd05'
 
   let session
+  let sessionData
   let yearsStub
 
-  beforeEach(async () => {
-    session = await SessionHelper.add({ data: { region: regionId, type: 'two_part_supplementary', year: 2024 } })
+  beforeEach(() => {
+    sessionData = { region: regionId, type: 'two_part_supplementary', year: 2024 }
+
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    Sinon.stub(FetchSessionDal, 'go').resolves(session)
 
     yearsStub = Sinon.stub(FetchLicenceSupplementaryYearsService, 'go').resolves([{ financialYearEnd: 2024 }])
   })

--- a/test/services/billing-accounts/setup/view-contact.service.test.js
+++ b/test/services/billing-accounts/setup/view-contact.service.test.js
@@ -8,13 +8,14 @@ const Sinon = require('sinon')
 const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
-// Things we need to stub
-const FetchCompanyContactsService = require('../../../../app/services/billing-accounts/setup/fetch-company-contacts.service.js')
-
 // Test helpers
 const BillingAccountsFixture = require('../../../support/fixtures/billing-accounts.fixture.js')
 const CustomersFixture = require('../../../support/fixtures/customers.fixture.js')
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchCompanyContactsService = require('../../../../app/services/billing-accounts/setup/fetch-company-contacts.service.js')
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const ViewContactService = require('../../../../app/services/billing-accounts/setup/view-contact.service.js')
@@ -31,24 +32,25 @@ describe('Billing Accounts - Setup - Contact Service', () => {
   let session
   let sessionData
 
-  beforeEach(async () => {
+  beforeEach(() => {
     Sinon.stub(FetchCompanyContactsService, 'go').resolves(companyContacts)
   })
 
-  afterEach(async () => {
-    await session.$query().delete()
+  afterEach(() => {
     Sinon.restore()
   })
 
   describe('when called', () => {
     describe('and the contact is for the existing account', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         sessionData = {
           accountSelected: billingAccount.company.id,
           billingAccount
         }
 
-        session = await SessionHelper.add({ data: sessionData })
+        session = SessionModelStub.build(Sinon, sessionData)
+
+        Sinon.stub(FetchSessionDal, 'go').resolves(session)
       })
 
       it('returns page data for the view', async () => {
@@ -84,14 +86,16 @@ describe('Billing Accounts - Setup - Contact Service', () => {
     })
 
     describe('and the contact is for a new account', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         sessionData = {
           accountSelected: 'another',
           billingAccount,
           existingAccount: billingAccount.company.id
         }
 
-        session = await SessionHelper.add({ data: sessionData })
+        session = SessionModelStub.build(Sinon, sessionData)
+
+        Sinon.stub(FetchSessionDal, 'go').resolves(session)
       })
 
       it('returns page data for the view', async () => {

--- a/test/services/billing-accounts/setup/view-existing-account.service.test.js
+++ b/test/services/billing-accounts/setup/view-existing-account.service.test.js
@@ -5,37 +5,41 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, before, after } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
 const BillingAccountsFixture = require('../../../support/fixtures/billing-accounts.fixture.js')
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
 const { generateUUID } = require('../../../../app/lib/general.lib.js')
 
 // Things we need to stub
 const FetchExistingCompaniesService = require('../../../../app/services/billing-accounts/setup/fetch-existing-companies.service.js')
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const ViewExistingAccountService = require('../../../../app/services/billing-accounts/setup/view-existing-account.service.js')
 
 describe('Billing Accounts - Setup - View Existing Account service', () => {
   const fetchResults = _companies()
+
   let session
   let sessionData
 
-  before(async () => {
+  beforeEach(() => {
     sessionData = {
       billingAccount: BillingAccountsFixture.billingAccount().billingAccount,
       searchInput: 'Company Name'
     }
 
-    session = await SessionHelper.add({ data: sessionData })
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    Sinon.stub(FetchSessionDal, 'go').resolves(session)
+
     Sinon.stub(FetchExistingCompaniesService, 'go').returns(fetchResults)
   })
 
-  after(async () => {
-    await session.$query().delete()
+  afterEach(() => {
     Sinon.restore()
   })
 

--- a/test/services/billing-accounts/setup/view-existing-address.service.test.js
+++ b/test/services/billing-accounts/setup/view-existing-address.service.test.js
@@ -10,10 +10,11 @@ const { expect } = Code
 
 // Test helpers
 const BillingAccountsFixture = require('../../../support/fixtures/billing-accounts.fixture.js')
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
 
 // Things we need to stub
 const FetchCompanyAddressesService = require('../../../../app/services/billing-accounts/setup/fetch-company-addresses.service.js')
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const ViewExistingAddressService = require('../../../../app/services/billing-accounts/setup/view-existing-address.service.js')
@@ -25,33 +26,37 @@ describe('Billing Accounts - Setup - View Existing Address Service', () => {
     addresses: [billingAccount.billingAccountAddresses[0].address]
   }
 
+  let fetchSessionStub
   let session
   let sessionData
 
-  beforeEach(async () => {
+  beforeEach(() => {
     sessionData = {
       billingAccount
     }
 
-    session = await SessionHelper.add({ data: sessionData })
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    fetchSessionStub = Sinon.stub(FetchSessionDal, 'go').resolves(session)
 
     Sinon.stub(FetchCompanyAddressesService, 'go').returns(companyAddresses)
   })
 
-  afterEach(async () => {
-    await session.$query().delete()
+  afterEach(() => {
     Sinon.restore()
   })
 
   describe('when called', () => {
     describe('and the user has come from the account page', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         sessionData = {
           accountSelected: billingAccount.company.id,
           billingAccount: BillingAccountsFixture.billingAccount().billingAccount
         }
 
-        session = await SessionHelper.add({ data: sessionData })
+        session = SessionModelStub.build(Sinon, sessionData)
+
+        fetchSessionStub.resolves(session)
       })
 
       it('returns page data for the view', async () => {
@@ -84,14 +89,16 @@ describe('Billing Accounts - Setup - View Existing Address Service', () => {
     })
 
     describe('and the user has come from the existing account page', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         sessionData = {
           accountSelected: 'another',
           billingAccount,
           existingAccount: billingAccount.company.id
         }
 
-        session = await SessionHelper.add({ data: sessionData })
+        session = SessionModelStub.build(Sinon, sessionData)
+
+        fetchSessionStub.resolves(session)
       })
 
       it('returns page data for the view', async () => {
@@ -124,7 +131,7 @@ describe('Billing Accounts - Setup - View Existing Address Service', () => {
     })
 
     describe('and the user has come from the account type page', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         sessionData = {
           accountSelected: 'another',
           accountType: 'individual',
@@ -132,7 +139,9 @@ describe('Billing Accounts - Setup - View Existing Address Service', () => {
           existingAccount: 'new'
         }
 
-        session = await SessionHelper.add({ data: sessionData })
+        session = SessionModelStub.build(Sinon, sessionData)
+
+        fetchSessionStub.resolves(session)
       })
 
       it('returns page data for the view', async () => {

--- a/test/services/billing-accounts/setup/view-select-company.service.test.js
+++ b/test/services/billing-accounts/setup/view-select-company.service.test.js
@@ -8,12 +8,15 @@ const Sinon = require('sinon')
 const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
+// Test helpers
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+
 // Things we need to stub
 const FetchCompaniesService = require('../../../../app/services/billing-accounts/setup/fetch-companies.service.js')
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Test helpers
 const BillingAccountsFixture = require('../../../support/fixtures/billing-accounts.fixture.js')
-const SessionHelper = require('../../../support/helpers/session.helper.js')
 
 // Thing under test
 const ViewSelectCompanyService = require('../../../../app/services/billing-accounts/setup/view-select-company.service.js')
@@ -30,17 +33,19 @@ describe('Billing Accounts - Setup - View Select Company Service', () => {
   let session
   let sessionData
 
-  beforeEach(async () => {
+  beforeEach(() => {
     sessionData = {
       billingAccount: BillingAccountsFixture.billingAccount().billingAccount
     }
 
-    session = await SessionHelper.add({ data: sessionData })
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    Sinon.stub(FetchSessionDal, 'go').resolves(session)
+
     Sinon.stub(FetchCompaniesService, 'go').returns(companies)
   })
 
-  afterEach(async () => {
-    await session.$query().delete()
+  afterEach(() => {
     Sinon.restore()
   })
 

--- a/test/services/licence-monitoring-station/setup/check.service.test.js
+++ b/test/services/licence-monitoring-station/setup/check.service.test.js
@@ -9,31 +9,37 @@ const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+
+// Things to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const CheckService = require('../../../../app/services/licence-monitoring-station/setup/check.service.js')
 
 describe('Licence Monitoring Station Setup - Check Service', () => {
   let session
+  let sessionData
 
-  beforeEach(async () => {
-    session = await SessionHelper.add({
-      data: {
-        unit: 'Ml/d',
-        label: 'LABEL',
-        threshold: 100,
-        licenceRef: 'LICENCE_REF',
-        conditionId: 'no_condition',
-        stopOrReduce: 'stop',
-        reduceAtThreshold: null,
-        conditionDisplayText: 'None',
-        abstractionPeriodEndDay: '3',
-        abstractionPeriodEndMonth: '4',
-        abstractionPeriodStartDay: '1',
-        abstractionPeriodStartMonth: '2'
-      }
-    })
+  beforeEach(() => {
+    sessionData = {
+      unit: 'Ml/d',
+      label: 'LABEL',
+      threshold: 100,
+      licenceRef: 'LICENCE_REF',
+      conditionId: 'no_condition',
+      stopOrReduce: 'stop',
+      reduceAtThreshold: null,
+      conditionDisplayText: 'None',
+      abstractionPeriodEndDay: '3',
+      abstractionPeriodEndMonth: '4',
+      abstractionPeriodStartDay: '1',
+      abstractionPeriodStartMonth: '2'
+    }
+
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    Sinon.stub(FetchSessionDal, 'go').resolves(session)
   })
 
   afterEach(() => {
@@ -66,9 +72,8 @@ describe('Licence Monitoring Station Setup - Check Service', () => {
     it('sets the "checkPageVisited" flag to "true"', async () => {
       await CheckService.go(session.id)
 
-      const refreshedSession = await session.$query()
-
-      expect(refreshedSession.checkPageVisited).to.be.true()
+      expect(session.checkPageVisited).to.be.true()
+      expect(session.$update.called).to.be.true()
     })
   })
 })

--- a/test/services/licence-monitoring-station/setup/full-condition.service.test.js
+++ b/test/services/licence-monitoring-station/setup/full-condition.service.test.js
@@ -9,10 +9,11 @@ const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
 
 // Things to stub
 const FetchFullConditionService = require('../../../../app/services/licence-monitoring-station/setup/fetch-full-condition.service.js')
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const FullConditionService = require('../../../../app/services/licence-monitoring-station/setup/full-condition.service.js')
@@ -20,8 +21,9 @@ const FullConditionService = require('../../../../app/services/licence-monitorin
 describe('Licence Monitoring Station Setup - Full Condition Service', () => {
   let condition
   let session
+  let sessionData
 
-  beforeEach(async () => {
+  beforeEach(() => {
     condition = {
       id: 'd5d05f06-b380-4f74-a479-9cbdb81bc279',
       notes: 'NOTES',
@@ -33,13 +35,15 @@ describe('Licence Monitoring Station Setup - Full Condition Service', () => {
 
     Sinon.stub(FetchFullConditionService, 'go').resolves([condition])
 
-    session = await SessionHelper.add({
-      data: {
-        label: 'Monitoring Station',
-        licenceId: 'LICENCE_ID',
-        licenceRef: 'LICENCE_REF'
-      }
-    })
+    sessionData = {
+      label: 'Monitoring Station',
+      licenceId: 'LICENCE_ID',
+      licenceRef: 'LICENCE_REF'
+    }
+
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    Sinon.stub(FetchSessionDal, 'go').resolves(session)
   })
 
   afterEach(() => {

--- a/test/services/licence-monitoring-station/setup/stop-or-reduce.service.test.js
+++ b/test/services/licence-monitoring-station/setup/stop-or-reduce.service.test.js
@@ -3,26 +3,37 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
+const Sinon = require('sinon')
 
-const { describe, it, before } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+
+// Things to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const StopOrReduceService = require('../../../../app/services/licence-monitoring-station/setup/stop-or-reduce.service.js')
 
 describe('Licence Monitoring Station Setup - Stop Or Reduce service', () => {
   let session
+  let sessionData
 
-  before(async () => {
-    session = await SessionHelper.add({
-      data: {
-        monitoringStationId: 'e1c44f9b-51c2-4aee-a518-5509d6f05869',
-        label: 'Monitoring Station Label'
-      }
-    })
+  beforeEach(() => {
+    sessionData = {
+      monitoringStationId: 'e1c44f9b-51c2-4aee-a518-5509d6f05869',
+      label: 'Monitoring Station Label'
+    }
+
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    Sinon.stub(FetchSessionDal, 'go').resolves(session)
+  })
+
+  afterEach(() => {
+    Sinon.restore()
   })
 
   describe('when called', () => {

--- a/test/services/licence-monitoring-station/setup/submit-full-condition.service.test.js
+++ b/test/services/licence-monitoring-station/setup/submit-full-condition.service.test.js
@@ -11,10 +11,11 @@ const { expect } = Code
 // Test helpers
 const LicenceVersionPurposeConditionHelper = require('../../../support/helpers/licence-version-purpose-condition.helper.js')
 const LicenceVersionPurposeHelper = require('../../../support/helpers/licence-version-purpose.helper.js')
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
 
 // Things to stub
 const FetchFullConditionService = require('../../../../app/services/licence-monitoring-station/setup/fetch-full-condition.service.js')
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 const FullConditionService = require('../../../../app/services/licence-monitoring-station/setup/full-condition.service.js')
 
 // Thing under test
@@ -23,13 +24,18 @@ const SubmitFullConditionService = require('../../../../app/services/licence-mon
 describe('Licence Monitoring Station Setup - Submit Full Condition Service', () => {
   let payload
   let session
+  let sessionData
 
   const pageData = {
     pageData: 'PAGE_DATA'
   }
 
   beforeEach(async () => {
-    session = await SessionHelper.add()
+    sessionData = {}
+
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    Sinon.stub(FetchSessionDal, 'go').resolves(session)
 
     const licenceVersionPurpose = await LicenceVersionPurposeHelper.add()
     const licenceVersionPurposeCondition = await LicenceVersionPurposeConditionHelper.add({
@@ -64,28 +70,23 @@ describe('Licence Monitoring Station Setup - Submit Full Condition Service', () 
     it('saves the submitted value', async () => {
       await SubmitFullConditionService.go(session.id, payload)
 
-      const refreshedSession = await session.$query()
-
-      expect(refreshedSession.conditionId).to.equal(payload.condition)
+      expect(session.conditionId).to.equal(payload.condition)
+      expect(session.$update.called).to.be.true()
     })
 
     it('saves the abstraction period', async () => {
       await SubmitFullConditionService.go(session.id, payload)
 
-      const refreshedSession = await session.$query()
-
-      expect(refreshedSession.abstractionPeriodEndDay).to.equal(31)
-      expect(refreshedSession.abstractionPeriodEndMonth).to.equal(3)
-      expect(refreshedSession.abstractionPeriodStartDay).to.equal(1)
-      expect(refreshedSession.abstractionPeriodStartMonth).to.equal(1)
+      expect(session.abstractionPeriodEndDay).to.equal(31)
+      expect(session.abstractionPeriodEndMonth).to.equal(3)
+      expect(session.abstractionPeriodStartDay).to.equal(1)
+      expect(session.abstractionPeriodStartMonth).to.equal(1)
     })
 
     it('saves the condition display text', async () => {
       await SubmitFullConditionService.go(session.id, payload)
 
-      const refreshedSession = await session.$query()
-
-      expect(refreshedSession.conditionDisplayText).to.equal(
+      expect(session.conditionDisplayText).to.equal(
         'LICENCE_VERSION_CONDITION_TYPE_DISPLAY_TITLE 1: NOTES (Additional information 1: PARAM_1) (Additional information 2: PARAM_2)'
       )
     })

--- a/test/services/licence-monitoring-station/setup/threshold-and-unit.service.test.js
+++ b/test/services/licence-monitoring-station/setup/threshold-and-unit.service.test.js
@@ -3,26 +3,34 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
+const Sinon = require('sinon')
 
-const { describe, it, before } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const ThresholdAndUnitService = require('../../../../app/services/licence-monitoring-station/setup/threshold-and-unit.service.js')
 
 describe('Licence Monitoring Station Setup - Threshold and Unit service', () => {
   let session
+  let sessionData
 
-  before(async () => {
-    session = await SessionHelper.add({
-      data: {
-        monitoringStationId: 'e1c44f9b-51c2-4aee-a518-5509d6f05869',
-        label: 'Monitoring Station Label'
-      }
-    })
+  beforeEach(() => {
+    sessionData = { monitoringStationId: 'e1c44f9b-51c2-4aee-a518-5509d6f05869', label: 'Monitoring Station Label' }
+
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    Sinon.stub(FetchSessionDal, 'go').resolves(session)
+  })
+
+  afterEach(() => {
+    Sinon.restore()
   })
 
   describe('when called', () => {

--- a/test/services/notices/setup/process-add-recipient.service.test.js
+++ b/test/services/notices/setup/process-add-recipient.service.test.js
@@ -5,27 +5,31 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
 const AddressHelper = require('../../../support/helpers/address.helper.js')
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
 const { generateLicenceRef } = require('../../../support/helpers/licence.helper.js')
 const { generateUUID } = require('../../../../app/lib/general.lib.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const ProcessAddRecipientService = require('../../../../app/services/notices/setup/process-add-recipient.service.js')
 
 describe('Notices - Setup - Process Add Recipient service', () => {
   let contactHashId
+  let fetchSessionStub
   let licenceRef
   let session
   let sessionData
   let sessionId
   let yarStub
 
-  beforeEach(async () => {
+  beforeEach(() => {
     sessionId = generateUUID()
 
     licenceRef = generateLicenceRef()
@@ -35,6 +39,14 @@ describe('Notices - Setup - Process Add Recipient service', () => {
       licenceRef,
       selectedRecipients: []
     }
+
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    fetchSessionStub = Sinon.stub(FetchSessionDal, 'go').resolves(session)
+  })
+
+  afterEach(() => {
+    Sinon.restore()
   })
 
   describe('when there is an address saved in the session', () => {
@@ -61,29 +73,34 @@ describe('Notices - Setup - Process Add Recipient service', () => {
       })
 
       describe('and this is the first additional contact to be added', () => {
-        beforeEach(async () => {
-          session = await SessionHelper.add({ id: sessionId, data: sessionData })
+        beforeEach(() => {
+          session = SessionModelStub.build(Sinon, {
+            ...sessionData,
+            id: sessionId
+          })
+
+          fetchSessionStub.resolves(session)
+
           yarStub = { flash: Sinon.stub().returns([{ title: 'Updated', text: 'Additional recipient added' }]) }
         })
 
         it('adds an `additionalRecipients` property to the session containing the recipient and pushes its hash ID into `selectedRecipients`', async () => {
           await ProcessAddRecipientService.go(sessionId, yarStub)
 
-          const refreshedSession = await session.$query()
-
           const [flashType, bannerMessage] = yarStub.flash.args[0]
 
           expect(flashType).to.equal('notification')
           expect(bannerMessage).to.equal({ titleText: 'Updated', text: 'Additional recipient added' })
-          expect(refreshedSession.additionalRecipients).equal([
+          expect(session.additionalRecipients).equal([
             {
               contact: {
-                name: sessionData.contactName,
-                address1: sessionData.addressJourney.address.addressLine1,
-                address2: sessionData.addressJourney.address.addressLine2,
-                address3: sessionData.addressJourney.address.addressLine3,
-                address4: sessionData.addressJourney.address.addressLine4,
-                postcode: sessionData.addressJourney.address.postcode
+                address1: 'ENVIRONMENT AGENCY',
+                address2: 'HORIZON HOUSE DEANERY ROAD',
+                address3: 'VILLAGE GREEN',
+                address4: 'BRISTOL',
+                country: undefined,
+                name: 'Fake Person',
+                postcode: 'BS1 5AH'
               },
               contact_hash_id: contactHashId,
               contact_type: 'single use',
@@ -93,13 +110,13 @@ describe('Notices - Setup - Process Add Recipient service', () => {
               message_type: 'Letter'
             }
           ])
-          expect(refreshedSession.selectedRecipients).equal([contactHashId])
-          expect(refreshedSession.addressJourney.redirectUrl).equal(`/system/notices/setup/${sessionId}/add-recipient`)
+          expect(session.selectedRecipients).equal([contactHashId])
+          expect(session.addressJourney.redirectUrl).equal(`/system/notices/setup/${sessionId}/add-recipient`)
         })
       })
 
       describe('and there are existing additional contacts stored in the session', () => {
-        beforeEach(async () => {
+        beforeEach(() => {
           sessionData.additionalRecipients = [
             {
               contact: {
@@ -119,20 +136,24 @@ describe('Notices - Setup - Process Add Recipient service', () => {
           ]
           sessionData.selectedRecipients = ['78de9d5db4c52b66818004e2b0dc4392']
 
-          session = await SessionHelper.add({ id: sessionId, data: sessionData })
+          session = SessionModelStub.build(Sinon, {
+            ...sessionData,
+            id: sessionId
+          })
+
+          fetchSessionStub.resolves(session)
+
           yarStub = { flash: Sinon.stub().returns([{ title: 'Updated', text: 'Additional recipient added' }]) }
         })
 
         it('adds the recipient to `additionalRecipients` and pushes its hash ID into `selectedRecipients`', async () => {
           await ProcessAddRecipientService.go(sessionId, yarStub)
 
-          const refreshedSession = await session.$query()
-
           const [flashType, bannerMessage] = yarStub.flash.args[0]
 
           expect(flashType).to.equal('notification')
           expect(bannerMessage).to.equal({ titleText: 'Updated', text: 'Additional recipient added' })
-          expect(refreshedSession.additionalRecipients).equal([
+          expect(session.additionalRecipients).equal([
             {
               contact: {
                 name: 'Fake Other',
@@ -150,12 +171,13 @@ describe('Notices - Setup - Process Add Recipient service', () => {
             },
             {
               contact: {
-                name: session.contactName,
-                address1: session.addressJourney.address.addressLine1,
-                address2: session.addressJourney.address.addressLine2,
-                address3: session.addressJourney.address.addressLine3,
-                address4: session.addressJourney.address.addressLine4,
-                postcode: session.addressJourney.address.postcode
+                address1: 'ENVIRONMENT AGENCY',
+                address2: 'HORIZON HOUSE DEANERY ROAD',
+                address3: 'VILLAGE GREEN',
+                address4: 'BRISTOL',
+                country: undefined,
+                name: 'Fake Person',
+                postcode: 'BS1 5AH'
               },
               contact_hash_id: contactHashId,
               contact_type: 'single use',
@@ -165,8 +187,8 @@ describe('Notices - Setup - Process Add Recipient service', () => {
               message_type: 'Letter'
             }
           ])
-          expect(refreshedSession.selectedRecipients).equal(['78de9d5db4c52b66818004e2b0dc4392', contactHashId])
-          expect(refreshedSession.addressJourney.redirectUrl).equal(`/system/notices/setup/${sessionId}/add-recipient`)
+          expect(session.selectedRecipients).equal(['78de9d5db4c52b66818004e2b0dc4392', contactHashId])
+          expect(session.addressJourney.redirectUrl).equal(`/system/notices/setup/${sessionId}/add-recipient`)
         })
       })
     })
@@ -191,27 +213,34 @@ describe('Notices - Setup - Process Add Recipient service', () => {
       })
 
       describe('and this is the first additional contact to be added', () => {
-        beforeEach(async () => {
-          session = await SessionHelper.add({ id: sessionId, data: sessionData })
+        beforeEach(() => {
+          session = SessionModelStub.build(Sinon, {
+            ...sessionData,
+            id: sessionId
+          })
+
+          fetchSessionStub.resolves(session)
+
           yarStub = { flash: Sinon.stub().returns([{ title: 'Updated', text: 'Additional recipient added' }]) }
         })
 
         it('adds a `additionalRecipients` property to the session containing the recipient and pushes its hash ID into `selectedRecipients`', async () => {
           await ProcessAddRecipientService.go(sessionId, yarStub)
 
-          const refreshedSession = await session.$query()
-
           const [flashType, bannerMessage] = yarStub.flash.args[0]
 
           expect(flashType).to.equal('notification')
           expect(bannerMessage).to.equal({ titleText: 'Updated', text: 'Additional recipient added' })
-          expect(refreshedSession.additionalRecipients).equal([
+          expect(session.additionalRecipients).equal([
             {
               contact: {
-                name: sessionData.contactName,
-                address1: sessionData.addressJourney.address.addressLine1,
-                address4: sessionData.addressJourney.address.addressLine4,
-                country: sessionData.addressJourney.address.country
+                address1: '1 Faux Ferme',
+                address2: undefined,
+                address3: undefined,
+                address4: 'Faux Ville',
+                country: 'France',
+                name: 'Fake Person',
+                postcode: undefined
               },
               contact_hash_id: contactHashId,
               contact_type: 'single use',
@@ -221,8 +250,8 @@ describe('Notices - Setup - Process Add Recipient service', () => {
               message_type: 'Letter'
             }
           ])
-          expect(refreshedSession.selectedRecipients).equal([contactHashId])
-          expect(refreshedSession.addressJourney.redirectUrl).equal(`/system/notices/setup/${sessionId}/add-recipient`)
+          expect(session.selectedRecipients).equal([contactHashId])
+          expect(session.addressJourney.redirectUrl).equal(`/system/notices/setup/${sessionId}/add-recipient`)
         })
       })
     })

--- a/test/services/notices/setup/process-preview-paper-return.service.test.js
+++ b/test/services/notices/setup/process-preview-paper-return.service.test.js
@@ -11,11 +11,12 @@ const { expect } = Code
 // Test helpers
 const RecipientsFixture = require('../../../support/fixtures/recipients.fixture.js')
 const ReturnLogFixture = require('../../../support/fixtures/return-logs.fixture.js')
-const SessionHelper = require('../../../support/helpers/session.helper.js')
+const SessionModelStub = require('../../../support/stubs/session.stub.js')
 const { formatLongDate } = require('../../../../app/presenters/base.presenter.js')
 
 // Things we need to stub
 const FetchRecipientsService = require('../../../../app/services/notices/setup/fetch-recipients.service.js')
+const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 const GeneratePaperReturnRequest = require('../../../../app/requests/gotenberg/generate-paper-return.request.js')
 
 // Thing under test
@@ -31,7 +32,7 @@ describe('Notices - Setup - Process Preview Paper Return service', () => {
   let session
   let sessionData
 
-  beforeEach(async () => {
+  beforeEach(() => {
     dueReturnLog = ReturnLogFixture.dueReturn()
 
     licenceRef = dueReturnLog.licenceRef
@@ -46,7 +47,9 @@ describe('Notices - Setup - Process Preview Paper Return service', () => {
       dueReturns: [dueReturnLog]
     }
 
-    session = await SessionHelper.add({ data: sessionData })
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    Sinon.stub(FetchSessionDal, 'go').resolves(session)
 
     const buffer = new TextEncoder().encode('mock file').buffer
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5573

We recently refactored how we use fetch and delete session data, we now have a single way of doing each.

We are moving away from using the database in service test.

This change updates some of the tests still using the session helper to stub the 'FetchSessionDal'