### PR TITLE
Highlight all address failures on the check the recipients page

### DIFF
--- a/app/presenters/notices/setup/check.presenter.js
+++ b/app/presenters/notices/setup/check.presenter.js
@@ -6,8 +6,8 @@
  */
 
 const ContactPresenter = require('./contact.presenter.js')
-const { NoticeType, NoticeJourney } = require('../../../lib/static-lookups.lib.js')
 const DatabaseConfig = require('../../../../config/database.config.js')
+const { NoticeType, NoticeJourney } = require('../../../lib/static-lookups.lib.js')
 
 const NOTIFICATION_TYPES = {
   [NoticeType.ABSTRACTION_ALERTS]: 'Abstraction alerts',

--- a/app/presenters/notices/setup/check.presenter.js
+++ b/app/presenters/notices/setup/check.presenter.js
@@ -7,7 +7,7 @@
 
 const ContactPresenter = require('./contact.presenter.js')
 const { NoticeType, NoticeJourney } = require('../../../lib/static-lookups.lib.js')
-const { defaultPageSize } = require('../../../../config/database.config.js')
+const DatabaseConfig = require('../../../../config/database.config.js')
 
 const NOTIFICATION_TYPES = {
   [NoticeType.ABSTRACTION_ALERTS]: 'Abstraction alerts',
@@ -28,7 +28,8 @@ const NOTIFICATION_TYPES = {
 function go(recipients, page, session) {
   const { noticeType, referenceCode } = session
 
-  const formattedRecipients = _recipients(noticeType, page, recipients, session.id)
+  const sortedRecipients = _recipients(noticeType, recipients, session.id)
+  const formattedRecipients = _paginateRecipients(sortedRecipients, page)
   const canSendNotice = _canSendNotice(formattedRecipients)
 
   return {
@@ -38,8 +39,8 @@ function go(recipients, page, session) {
     pageTitleCaption: `Notice ${referenceCode}`,
     readyToSend: _readyToSend(recipients, noticeType, canSendNotice),
     recipients: formattedRecipients,
-    tableCaption: _tableCaption(defaultPageSize, recipients.length),
-    warning: _warning(formattedRecipients)
+    tableCaption: _tableCaption(formattedRecipients.length, recipients.length),
+    warning: _warning(sortedRecipients)
   }
 }
 
@@ -106,9 +107,9 @@ function _links(session) {
  * @private
  */
 function _paginateRecipients(recipients, page) {
-  const pageNumber = Number(page) * defaultPageSize
+  const pageNumber = Number(page) * DatabaseConfig.defaultPageSize
 
-  return recipients.slice(pageNumber - defaultPageSize, pageNumber)
+  return recipients.slice(pageNumber - DatabaseConfig.defaultPageSize, pageNumber)
 }
 
 function _previewLink(noticeType, recipient, sessionId, contact) {
@@ -145,19 +146,17 @@ function _readyToSend(formattedRecipients, noticeType, canSendNotice) {
  * Sorts, maps, and paginates the recipients list.
  *
  * This function first maps over the recipients to transform each recipient object into a new format, then sorts the
- * resulting array of transformed recipients alphabetically by their contact's name. After sorting, it uses pagination
- * to return only the relevant subset of recipients for the given page.
+ * resulting array of transformed recipients alphabetically by their contact's name.
  *
  * The map and sort are performed before pagination, as it is necessary to have the recipients in a defined order before
  * determining which recipients should appear on the page.
  *
  * @private
  */
-function _recipients(noticeType, page, recipients, sessionId) {
+function _recipients(noticeType, recipients, sessionId) {
   const formattedRecipients = _formatRecipients(noticeType, recipients, sessionId)
-  const sortedRecipients = _sortRecipients(formattedRecipients)
 
-  return _paginateRecipients(sortedRecipients, page)
+  return _sortRecipients(formattedRecipients)
 }
 
 function _tableCaption(numberDisplayed, totalNumber) {

--- a/test/presenters/notices/setup/check.presenter.test.js
+++ b/test/presenters/notices/setup/check.presenter.test.js
@@ -3,24 +3,27 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
+const Sinon = require('sinon')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const { generateNoticeReferenceCode } = require('../../../../app/lib/general.lib.js')
-
-// Test helpers
 const RecipientsFixture = require('../../../support/fixtures/recipients.fixture.js')
+const { generateNoticeReferenceCode } = require('../../../../app/lib/general.lib.js')
 const { generateUUID } = require('../../../../app/lib/general.lib.js')
+
+//
+const DatabaseConfig = require('../../../../config/database.config.js')
 
 // Thing under test
 const CheckPresenter = require('../../../../app/presenters/notices/setup/check.presenter.js')
 
 describe('Notices - Setup - Check presenter', () => {
-  let session
+  let defaultPageSizeStub
   let page
   let recipients
+  let session
   let testRecipients
 
   beforeEach(() => {
@@ -36,6 +39,12 @@ describe('Notices - Setup - Check presenter', () => {
     testRecipients = RecipientsFixture.recipients()
 
     recipients = [...Object.values(testRecipients)]
+
+    defaultPageSizeStub = Sinon.stub(DatabaseConfig, 'defaultPageSize').value(25)
+  })
+
+  afterEach(() => {
+    Sinon.restore()
   })
 
   it('correctly presents the data', () => {
@@ -452,19 +461,31 @@ describe('Notices - Setup - Check presenter', () => {
 
     describe('when there are multiple pages of results', () => {
       beforeEach(() => {
-        for (let i = 0; i < 25; i++) {
-          const padding = recipients[0]
-
-          padding.email = `${generateUUID()}@example.com`
-
-          recipients.push({ ...padding })
-        }
+        defaultPageSizeStub.value(1)
       })
 
       it('returns the "tableCaption" with the "Showing x of y" message', () => {
         const result = CheckPresenter.go(recipients, page, session)
 
-        expect(result.tableCaption).to.equal(`Showing 25 of ${recipients.length} recipients`)
+        expect(result.tableCaption).to.equal(`Showing 1 of 5 recipients`)
+      })
+
+      describe('and it is the last page', () => {
+        describe('and there are less recipients than the default page size', () => {
+          beforeEach(() => {
+            // There are 5 recipients, if we set the default page size to 3,
+            // we should see 2 recipients on the last page (in this case page 2)
+            page = '2'
+
+            defaultPageSizeStub.value(3)
+          })
+
+          it('returns the "tableCaption" with the "Showing x of y" message', () => {
+            const result = CheckPresenter.go(recipients, page, session)
+
+            expect(result.tableCaption).to.equal(`Showing 2 of 5 recipients`)
+          })
+        })
       })
     })
   })
@@ -494,16 +515,36 @@ describe('Notices - Setup - Check presenter', () => {
     })
 
     describe('when there are multiple recipients with an invalid addresses', () => {
-      beforeEach(() => {
-        recipients[2].contact.postcode = null
+      describe('on the same page', () => {
+        beforeEach(() => {
+          recipients[2].contact.postcode = null
+        })
+
+        it('returns a warning that lists the recipients', () => {
+          const result = CheckPresenter.go(recipients, page, session)
+
+          expect(result.warning).to.equal({
+            iconFallbackText: 'Warning',
+            text: 'Notifications will not be sent for the following recipients with invalid addresses: Harry Potter, Ronald Weasley'
+          })
+        })
       })
 
-      it('returns a warning that lists the recipients', () => {
-        const result = CheckPresenter.go(recipients, page, session)
+      describe('across multiple pages', () => {
+        beforeEach(() => {
+          recipients[2].contact.postcode = null
 
-        expect(result.warning).to.equal({
-          iconFallbackText: 'Warning',
-          text: 'Notifications will not be sent for the following recipients with invalid addresses: Harry Potter, Ronald Weasley'
+          // This proves we are checking all the recipients across pages
+          defaultPageSizeStub.value(3)
+        })
+
+        it('returns a warning that lists the recipients', () => {
+          const result = CheckPresenter.go(recipients, page, session)
+
+          expect(result.warning).to.equal({
+            iconFallbackText: 'Warning',
+            text: 'Notifications will not be sent for the following recipients with invalid addresses: Harry Potter, Ronald Weasley'
+          })
         })
       })
     })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5361

We currently only show address errors for address within the pagination limit (defaulted to 25). This works for the page the user is on, but we want to show the user all the address failures.

This change refactors the check presenter to provide the existing warning logic with the sorted array (we have to sort in the presenter anyway, so we just pass can just pass that in before paginating the recipients).

This change also fixes the last page pagination issue. When the user was on the last page the 'Showing x' was always showing '25' this is because we provided the default and not the recipients' length.

A test has been added to check the address error across multiple pages, and tests have been added for the pagination edge case.