### PR TITLE
Add an email alert when jobs fail

### DIFF
--- a/app/lib/base-notifier.lib.js
+++ b/app/lib/base-notifier.lib.js
@@ -9,6 +9,9 @@ const { Notifier } = require('@airbrake/node')
 const Pino = require('pino')
 
 const AirbrakeConfig = require('../../config/airbrake.config.js')
+const CreateEmailRequest = require('../requests/notify/create-email.request.js')
+const NotifyConfig = require('../../config/notify.config.js')
+const { NOTIFY_TEMPLATES } = require('./notify-templates.lib.js')
 
 /**
  * Based class for combined logging and Airbrake (Errbit) notification managers
@@ -107,6 +110,29 @@ class BaseNotifierLib {
       .catch((err) => {
         this._logger.error(err, `${this.constructor.name} - Airbrake errored`)
       })
+  }
+
+  /**
+   * Send an email to the team about an error
+   *
+   * When most services fail the user is able to see and get in touch with the team to resolve the issue. For jobs
+   * ran in the evening or other background processes it might not be picked up immediatly that they have failed. This
+   * function is a way to notify the team immediately that something has failed so we can be proactive in fixing it.
+   *
+   * @param {string} message - A message that indicates which service has failed
+   * @param {string} error - Any error messages that can help identify the issue
+   */
+  redAlert(message, error = null) {
+    const now = new Date().toISOString()
+    const content = `At ${now}: ${message} failed`
+
+    const options = {
+      personalisation: {
+        content: error ? content + ` with: ${error}` : content
+      }
+    }
+
+    CreateEmailRequest.send(NOTIFY_TEMPLATES.system.statusAlert, NotifyConfig.alertEmailAddress, options)
   }
 
   /**

--- a/app/lib/base-notifier.lib.js
+++ b/app/lib/base-notifier.lib.js
@@ -135,7 +135,9 @@ class BaseNotifierLib {
     const emails = NotifyConfig.alertEmailAddresses.split(',')
 
     for (const email of emails) {
-      CreateEmailRequest.send(NOTIFY_TEMPLATES.system.statusAlert, email, options)
+      CreateEmailRequest.send(NOTIFY_TEMPLATES.system.statusAlert, email, options).catch((err) => {
+        this._logger.error(err, `${this.constructor.name} - CreateEmailRequest errored`)
+      })
     }
   }
 

--- a/app/lib/base-notifier.lib.js
+++ b/app/lib/base-notifier.lib.js
@@ -124,7 +124,7 @@ class BaseNotifierLib {
    */
   redAlert(message, error = null) {
     const now = new Date().toISOString()
-    const content = `At ${now}: ${message} failed`
+    const content = `At ${now}: ${message}`
 
     const options = {
       personalisation: {
@@ -132,7 +132,11 @@ class BaseNotifierLib {
       }
     }
 
-    CreateEmailRequest.send(NOTIFY_TEMPLATES.system.statusAlert, NotifyConfig.alertEmailAddress, options)
+    const emails = NotifyConfig.alertEmailAddresses.split(',')
+
+    for (const email of emails) {
+      CreateEmailRequest.send(NOTIFY_TEMPLATES.system.statusAlert, email, options)
+    }
   }
 
   /**

--- a/app/lib/notify-templates.lib.js
+++ b/app/lib/notify-templates.lib.js
@@ -84,6 +84,9 @@ const NOTIFY_TEMPLATES = Object.freeze({
       stop: 'c2635893-0dd7-4fff-a152-774707e2175e',
       stopWarning: '7ab10c86-2c23-4376-8c72-9419e7f982bb'
     }
+  },
+  system: {
+    statusAlert: 'c34d1b16-694b-4364-8e7e-83e9dbd34a62'
   }
 })
 

--- a/app/services/jobs/customer-files/process-customer-files.service.js
+++ b/app/services/jobs/customer-files/process-customer-files.service.js
@@ -53,7 +53,10 @@ async function go(days) {
 
     calculateAndLogTimeTaken(startTime, 'Customer files job complete', { count: billingAccounts.length })
   } catch (error) {
-    global.GlobalNotifier.omfg('Customer files job failed', null, error)
+    const message = 'Customer files job failed'
+
+    global.GlobalNotifier.omfg(message, null, error)
+    global.GlobalNotifier.redAlert(message)
   }
 }
 

--- a/app/services/jobs/licence-updates/process-licence-updates.service.js
+++ b/app/services/jobs/licence-updates/process-licence-updates.service.js
@@ -44,7 +44,10 @@ async function go() {
 
     calculateAndLogTimeTaken(startTime, 'Licence updates job complete', { count: licenceUpdateResults.length })
   } catch (error) {
-    global.GlobalNotifier.omfg('Licence updates job failed', null, error)
+    const message = 'Licence updates job failed'
+
+    global.GlobalNotifier.omfg(message, null, error)
+    global.GlobalNotifier.redAlert(message)
   }
 }
 

--- a/app/services/jobs/notification-status/process-notification-status.service.js
+++ b/app/services/jobs/notification-status/process-notification-status.service.js
@@ -48,7 +48,10 @@ async function go() {
 
     calculateAndLogTimeTaken(startTime, 'Notification status job complete', { count: notifications.length })
   } catch (error) {
-    global.GlobalNotifier.omfg('Notification status job failed', null, error)
+    const message = 'Notification status job failed'
+
+    global.GlobalNotifier.omfg(message, null, error)
+    global.GlobalNotifier.redAlert(message)
   }
 }
 

--- a/app/services/jobs/return-logs/process-return-logs.service.js
+++ b/app/services/jobs/return-logs/process-return-logs.service.js
@@ -48,6 +48,7 @@ async function go(cycle) {
     calculateAndLogTimeTaken(startTime, 'Return logs job complete', { count: returnRequirements.length, cycle })
   } catch (error) {
     const message = 'Return logs job failed'
+
     global.GlobalNotifier.omfg(message, { cycle }, error)
     global.GlobalNotifier.redAlert(message)
   }

--- a/app/services/jobs/return-logs/process-return-logs.service.js
+++ b/app/services/jobs/return-logs/process-return-logs.service.js
@@ -47,7 +47,9 @@ async function go(cycle) {
 
     calculateAndLogTimeTaken(startTime, 'Return logs job complete', { count: returnRequirements.length, cycle })
   } catch (error) {
-    global.GlobalNotifier.omfg('Return logs job failed', { cycle }, error)
+    const message = 'Return logs job failed'
+    global.GlobalNotifier.omfg(message, { cycle }, error)
+    global.GlobalNotifier.redAlert(message)
   }
 }
 

--- a/app/services/jobs/time-limited/process-time-limited-licences.service.js
+++ b/app/services/jobs/time-limited/process-time-limited-licences.service.js
@@ -26,7 +26,10 @@ async function go() {
 
     calculateAndLogTimeTaken(startTime, 'Time limited job complete', { count: timeLimitedResults.length })
   } catch (error) {
-    global.GlobalNotifier.omfg('Time limited job failed', null, error)
+    const message = 'Time limited job failed'
+
+    global.GlobalNotifier.omfg(message, null, error)
+    global.GlobalNotifier.redAlert(message)
   }
 }
 

--- a/config/notify.config.js
+++ b/config/notify.config.js
@@ -10,7 +10,7 @@
 require('dotenv').config()
 
 const config = {
-  alertEmailAddress: process.env.ALERT_EMAIL_ADDRESS,
+  alertEmailAddresses: process.env.ALERT_EMAIL_ADDRESSES,
   apiKey: process.env.GOV_UK_NOTIFY_API_KEY,
   // The Notify service imposes a rate limit of 3,000 requests per minute and restricts the number of statuses returned
   // per API call to a maximum of 250. Given these constraints, our batch processing mechanism should handle the lowest

--- a/config/notify.config.js
+++ b/config/notify.config.js
@@ -10,6 +10,7 @@
 require('dotenv').config()
 
 const config = {
+  alertEmailAddress: process.env.ALERT_EMAIL_ADDRESS,
   apiKey: process.env.GOV_UK_NOTIFY_API_KEY,
   // The Notify service imposes a rate limit of 3,000 requests per minute and restricts the number of statuses returned
   // per API call to a maximum of 250. Given these constraints, our batch processing mechanism should handle the lowest

--- a/test/lib/base-notifier.lib.test.js
+++ b/test/lib/base-notifier.lib.test.js
@@ -273,60 +273,87 @@ describe('BaseNotifierLib class', () => {
   })
 
   describe('#redAlert()', () => {
-    beforeEach(async () => {
-      Sinon.stub(BaseNotifierLib.prototype, '_setNotifier').returns(airbrakeFake)
-      Sinon.stub(BaseNotifierLib.prototype, '_setLogger').returns(pinoFake)
-      Sinon.stub(CreateEmailRequest, 'send').callsFake(createEmailRequestFake.send)
-      Sinon.stub(NotifyConfig, 'alertEmailAddresses').value('admin-internal@wrls.gov.uk')
+    describe('when create email request service suceeds', () => {
+      beforeEach(async () => {
+        Sinon.stub(BaseNotifierLib.prototype, '_setNotifier').returns(airbrakeFake)
+        Sinon.stub(BaseNotifierLib.prototype, '_setLogger').returns(pinoFake)
+        Sinon.stub(CreateEmailRequest, 'send').callsFake(createEmailRequestFake.send)
+        Sinon.stub(NotifyConfig, 'alertEmailAddresses').value('admin-internal@wrls.gov.uk')
+      })
+
+      describe('when just a message is sent', () => {
+        it('sends a request to the create email request service with the correct parameters', async () => {
+          const testNotifier = new BaseNotifierLib()
+
+          testNotifier.redAlert(message)
+
+          const args = createEmailRequestFake.send.firstCall.args
+
+          expect(args[0]).to.equal(NOTIFY_TEMPLATES.system.statusAlert)
+          expect(args[1]).to.equal(NotifyConfig.alertEmailAddresses)
+          expect(args[2].personalisation.content).to.endWith(message)
+        })
+      })
+
+      describe('when a message is sent with an error', () => {
+        it('sends a request to the create email request service with the correct parameters', () => {
+          const testNotifier = new BaseNotifierLib()
+
+          testNotifier.redAlert(message, error)
+
+          const args = createEmailRequestFake.send.firstCall.args
+
+          expect(args[0]).to.equal(NOTIFY_TEMPLATES.system.statusAlert)
+          expect(args[1]).to.equal(NotifyConfig.alertEmailAddresses)
+          expect(args[2].personalisation.content).to.endWith(`${message} with: ${error}`)
+        })
+      })
+
+      describe('and there are multiple email addresses in the config', () => {
+        beforeEach(async () => {
+          Sinon.stub(NotifyConfig, 'alertEmailAddresses').value('admin-internal@wrls.gov.uk,admin@wrls.gov.uk')
+        })
+
+        it('sends a request to the create email request service with the correct parameters for each email', () => {
+          const testNotifier = new BaseNotifierLib()
+
+          testNotifier.redAlert(message, error)
+
+          const firstArgs = createEmailRequestFake.send.firstCall.args
+          const secondArgs = createEmailRequestFake.send.secondCall.args
+
+          expect(firstArgs[0]).to.equal(NOTIFY_TEMPLATES.system.statusAlert)
+          expect(firstArgs[1]).to.equal('admin-internal@wrls.gov.uk')
+          expect(firstArgs[2].personalisation.content).to.endWith(`${message} with: ${error}`)
+          expect(secondArgs[0]).to.equal(NOTIFY_TEMPLATES.system.statusAlert)
+          expect(secondArgs[1]).to.equal('admin@wrls.gov.uk')
+          expect(secondArgs[2].personalisation.content).to.endWith(`${message} with: ${error}`)
+        })
+      })
     })
 
-    describe('when just a message is sent', () => {
-      it('sends a request to the create email request service with the correct parameters', async () => {
+    describe('when the create email request service errors', () => {
+      beforeEach(async () => {
+        Sinon.stub(BaseNotifierLib.prototype, '_setNotifier').returns(airbrakeFake)
+        Sinon.stub(NotifyConfig, 'alertEmailAddresses').value('admin-internal@wrls.gov.uk')
+
+        pinoFake = { info: Sinon.fake(), error: Sinon.stub() }
+        Sinon.stub(BaseNotifierLib.prototype, '_setLogger').returns(pinoFake)
+        Sinon.stub(CreateEmailRequest, 'send').rejects(new Error('CreateEmailRequest errored'))
+      })
+
+      it('logs the error', async () => {
         const testNotifier = new BaseNotifierLib()
 
         testNotifier.redAlert(message)
 
-        const args = createEmailRequestFake.send.firstCall.args
+        pinoFake.error.callsFake(async () => {
+          const firstCallArgs = pinoFake.error.firstCall.args
 
-        expect(args[0]).to.equal(NOTIFY_TEMPLATES.system.statusAlert)
-        expect(args[1]).to.equal(NotifyConfig.alertEmailAddresses)
-        expect(args[2].personalisation.content).to.endWith(message)
-      })
-    })
-
-    describe('when a message is sent with an error', () => {
-      it('sends a request to the create email request service with the correct parameters', () => {
-        const testNotifier = new BaseNotifierLib()
-
-        testNotifier.redAlert(message, error)
-
-        const args = createEmailRequestFake.send.firstCall.args
-
-        expect(args[0]).to.equal(NOTIFY_TEMPLATES.system.statusAlert)
-        expect(args[1]).to.equal(NotifyConfig.alertEmailAddresses)
-        expect(args[2].personalisation.content).to.endWith(`${message} with: ${error}`)
-      })
-    })
-
-    describe('when there are multiple email addresses in the config', () => {
-      beforeEach(async () => {
-        Sinon.stub(NotifyConfig, 'alertEmailAddresses').value('admin-internal@wrls.gov.uk,admin@wrls.gov.uk')
-      })
-
-      it('sends a request to the create email request service with the correct parameters', () => {
-        const testNotifier = new BaseNotifierLib()
-
-        testNotifier.redAlert(message, error)
-
-        const firstArgs = createEmailRequestFake.send.firstCall.args
-        const secondArgs = createEmailRequestFake.send.secondCall.args
-
-        expect(firstArgs[0]).to.equal(NOTIFY_TEMPLATES.system.statusAlert)
-        expect(firstArgs[1]).to.equal('admin-internal@wrls.gov.uk')
-        expect(firstArgs[2].personalisation.content).to.endWith(`${message} with: ${error}`)
-        expect(secondArgs[0]).to.equal(NOTIFY_TEMPLATES.system.statusAlert)
-        expect(secondArgs[1]).to.equal('admin@wrls.gov.uk')
-        expect(secondArgs[2].personalisation.content).to.endWith(`${message} with: ${error}`)
+          expect(firstCallArgs[0]).to.be.an.error()
+          expect(firstCallArgs[0].message).to.equal('CreateEmailRequest errored')
+          expect(firstCallArgs[1]).to.equal('BaseNotifierLib - CreateEmailRequest errored')
+        })
       })
     })
   })

--- a/test/lib/base-notifier.lib.test.js
+++ b/test/lib/base-notifier.lib.test.js
@@ -8,23 +8,31 @@ const Sinon = require('sinon')
 const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
+// Test helpers
+const { NOTIFY_TEMPLATES } = require('../../app/lib/notify-templates.lib.js')
+
 // Things we need to stub
 const AirbrakeModule = require('@airbrake/node')
 const AirbrakeConfig = require('../../config/airbrake.config.js')
+const CreateEmailRequest = require('../../app/requests/notify/create-email.request.js')
+const NotifyConfig = require('../../config/notify.config.js')
 
 // Thing under test
 const BaseNotifierLib = require('../../app/lib/base-notifier.lib.js')
 
 describe('BaseNotifierLib class', () => {
   const id = '1234567890'
+  const error = 'test error'
   const message = 'say what test'
 
   let airbrakeFake
+  let createEmailRequestFake
   let pinoFake
 
   beforeEach(async () => {
     // We use these fakes and the stubs in the tests to avoid Pino or Airbrake being instantiated during the test
     airbrakeFake = { notify: Sinon.fake.resolves({ id: 1 }), flush: Sinon.fake() }
+    createEmailRequestFake = { send: Sinon.fake.resolves() }
     pinoFake = { info: Sinon.fake(), error: Sinon.fake() }
   })
 
@@ -260,6 +268,65 @@ describe('BaseNotifierLib class', () => {
           expect(secondCallArgs[0].message).to.equal(airbrakeError.message)
           expect(secondCallArgs[1]).to.equal('BaseNotifierLib - Airbrake errored')
         })
+      })
+    })
+  })
+
+  describe('#redAlert()', () => {
+    beforeEach(async () => {
+      Sinon.stub(BaseNotifierLib.prototype, '_setNotifier').returns(airbrakeFake)
+      Sinon.stub(BaseNotifierLib.prototype, '_setLogger').returns(pinoFake)
+      Sinon.stub(CreateEmailRequest, 'send').callsFake(createEmailRequestFake.send)
+      Sinon.stub(NotifyConfig, 'alertEmailAddresses').value('admin-internal@wrls.gov.uk')
+    })
+
+    describe('when just a message is sent', () => {
+      it('sends a request to the create email request service with the correct parameters', async () => {
+        const testNotifier = new BaseNotifierLib()
+
+        testNotifier.redAlert(message)
+
+        const args = createEmailRequestFake.send.firstCall.args
+
+        expect(args[0]).to.equal(NOTIFY_TEMPLATES.system.statusAlert)
+        expect(args[1]).to.equal(NotifyConfig.alertEmailAddresses)
+        expect(args[2].personalisation.content).to.endWith(message)
+      })
+    })
+
+    describe('when a message is sent with an error', () => {
+      it('sends a request to the create email request service with the correct parameters', () => {
+        const testNotifier = new BaseNotifierLib()
+
+        testNotifier.redAlert(message, error)
+
+        const args = createEmailRequestFake.send.firstCall.args
+
+        expect(args[0]).to.equal(NOTIFY_TEMPLATES.system.statusAlert)
+        expect(args[1]).to.equal(NotifyConfig.alertEmailAddresses)
+        expect(args[2].personalisation.content).to.endWith(`${message} with: ${error}`)
+      })
+    })
+
+    describe('when there are multiple email addresses in the config', () => {
+      beforeEach(async () => {
+        Sinon.stub(NotifyConfig, 'alertEmailAddresses').value('admin-internal@wrls.gov.uk,admin@wrls.gov.uk')
+      })
+
+      it('sends a request to the create email request service with the correct parameters', () => {
+        const testNotifier = new BaseNotifierLib()
+
+        testNotifier.redAlert(message, error)
+
+        const firstArgs = createEmailRequestFake.send.firstCall.args
+        const secondArgs = createEmailRequestFake.send.secondCall.args
+
+        expect(firstArgs[0]).to.equal(NOTIFY_TEMPLATES.system.statusAlert)
+        expect(firstArgs[1]).to.equal('admin-internal@wrls.gov.uk')
+        expect(firstArgs[2].personalisation.content).to.endWith(`${message} with: ${error}`)
+        expect(secondArgs[0]).to.equal(NOTIFY_TEMPLATES.system.statusAlert)
+        expect(secondArgs[1]).to.equal('admin@wrls.gov.uk')
+        expect(secondArgs[2].personalisation.content).to.endWith(`${message} with: ${error}`)
       })
     })
   })

--- a/test/services/jobs/customer-files/process-customer-files.service.test.js
+++ b/test/services/jobs/customer-files/process-customer-files.service.test.js
@@ -32,7 +32,7 @@ describe('Jobs - Customer Files - Process Customer Files service', () => {
     // The service depends on GlobalNotifier to have been set. This happens in app/plugins/global-notifier.plugin.js
     // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
     // test we recreate the condition by setting it directly with our own stub
-    notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
+    notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub(), redAlert: Sinon.stub() }
     global.GlobalNotifier = notifierStub
   })
 
@@ -173,7 +173,7 @@ describe('Jobs - Customer Files - Process Customer Files service', () => {
       })
     })
 
-    it('handles the error', async () => {
+    it('omfg handles the error', async () => {
       await ProcessCustomerFilesService.go()
 
       const args = notifierStub.omfg.firstCall.args
@@ -181,6 +181,14 @@ describe('Jobs - Customer Files - Process Customer Files service', () => {
       expect(args[0]).to.equal('Customer files job failed')
       expect(args[1]).to.be.null()
       expect(args[2]).to.be.an.error()
+    })
+
+    it('redAlert is called', async () => {
+      await ProcessCustomerFilesService.go()
+
+      const args = notifierStub.redAlert.firstCall.args
+
+      expect(args[0]).to.equal('Customer files job failed')
     })
   })
 })

--- a/test/services/jobs/customer-files/process-customer-files.service.test.js
+++ b/test/services/jobs/customer-files/process-customer-files.service.test.js
@@ -173,7 +173,7 @@ describe('Jobs - Customer Files - Process Customer Files service', () => {
       })
     })
 
-    it('omfg handles the error', async () => {
+    it('records the error by calling "omfg()"', async () => {
       await ProcessCustomerFilesService.go()
 
       const args = notifierStub.omfg.firstCall.args
@@ -183,12 +183,16 @@ describe('Jobs - Customer Files - Process Customer Files service', () => {
       expect(args[2]).to.be.an.error()
     })
 
-    it('redAlert is called', async () => {
+    it('notifies the team by calling "redAlert()"', async () => {
       await ProcessCustomerFilesService.go()
 
       const args = notifierStub.redAlert.firstCall.args
 
       expect(args[0]).to.equal('Customer files job failed')
+    })
+
+    it('does not throw an error', async () => {
+      await expect(ProcessCustomerFilesService.go()).not.to.reject()
     })
   })
 })

--- a/test/services/jobs/licence-updates/process-licence-updates.service.test.js
+++ b/test/services/jobs/licence-updates/process-licence-updates.service.test.js
@@ -119,7 +119,7 @@ describe('Jobs - Licence Updates - Process Licence Updates service', () => {
       Sinon.stub(FetchLicenceUpdatesService, 'go').rejects()
     })
 
-    it('omfg handles the error', async () => {
+    it('records the error by calling "omfg()"', async () => {
       await ProcessLicenceUpdatesService.go()
 
       const args = notifierStub.omfg.firstCall.args
@@ -129,12 +129,16 @@ describe('Jobs - Licence Updates - Process Licence Updates service', () => {
       expect(args[2]).to.be.an.error()
     })
 
-    it('redAlert is called', async () => {
+    it('notifies the team by calling "redAlert()"', async () => {
       await ProcessLicenceUpdatesService.go()
 
       const args = notifierStub.redAlert.firstCall.args
 
       expect(args[0]).to.equal('Licence updates job failed')
+    })
+
+    it('does not throw an error', async () => {
+      await expect(ProcessLicenceUpdatesService.go()).not.to.reject()
     })
   })
 })

--- a/test/services/jobs/licence-updates/process-licence-updates.service.test.js
+++ b/test/services/jobs/licence-updates/process-licence-updates.service.test.js
@@ -26,7 +26,7 @@ describe('Jobs - Licence Updates - Process Licence Updates service', () => {
     // The service depends on GlobalNotifier to have been set. This happens in app/plugins/global-notifier.plugin.js
     // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
     // test we recreate the condition by setting it directly with our own stub
-    notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
+    notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub(), redAlert: Sinon.stub() }
     global.GlobalNotifier = notifierStub
   })
 
@@ -119,7 +119,7 @@ describe('Jobs - Licence Updates - Process Licence Updates service', () => {
       Sinon.stub(FetchLicenceUpdatesService, 'go').rejects()
     })
 
-    it('handles the error', async () => {
+    it('omfg handles the error', async () => {
       await ProcessLicenceUpdatesService.go()
 
       const args = notifierStub.omfg.firstCall.args
@@ -127,6 +127,14 @@ describe('Jobs - Licence Updates - Process Licence Updates service', () => {
       expect(args[0]).to.equal('Licence updates job failed')
       expect(args[1]).to.be.null()
       expect(args[2]).to.be.an.error()
+    })
+
+    it('redAlert is called', async () => {
+      await ProcessLicenceUpdatesService.go()
+
+      const args = notifierStub.redAlert.firstCall.args
+
+      expect(args[0]).to.equal('Licence updates job failed')
     })
   })
 })

--- a/test/services/jobs/notification-status/process-notification-status.service.test.js
+++ b/test/services/jobs/notification-status/process-notification-status.service.test.js
@@ -99,7 +99,7 @@ describe('Job - Notifications - Process Notification Status service', () => {
       expect(updateEventStub.called).to.be.false()
     })
 
-    it('omfg handles the error', async () => {
+    it('records the error by calling "omfg()"', async () => {
       await ProcessNotificationStatusService.go()
 
       const args = notifierStub.omfg.firstCall.args
@@ -109,12 +109,16 @@ describe('Job - Notifications - Process Notification Status service', () => {
       expect(args[2]).to.be.an.error()
     })
 
-    it('redAlert is called', async () => {
+    it('notifies the team by calling "redAlert()"', async () => {
       await ProcessNotificationStatusService.go()
 
       const args = notifierStub.redAlert.firstCall.args
 
       expect(args[0]).to.equal('Notification status job failed')
+    })
+
+    it('does not throw an error', async () => {
+      await expect(ProcessNotificationStatusService.go()).not.to.reject()
     })
   })
 })

--- a/test/services/jobs/notification-status/process-notification-status.service.test.js
+++ b/test/services/jobs/notification-status/process-notification-status.service.test.js
@@ -55,7 +55,7 @@ describe('Job - Notifications - Process Notification Status service', () => {
     // The service depends on GlobalNotifier to have been set. This happens in app/plugins/global-notifier.plugin.js
     // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
     // test we recreate the condition by setting it directly with our own stub
-    notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
+    notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub(), redAlert: Sinon.stub() }
     global.GlobalNotifier = notifierStub
   })
 
@@ -99,7 +99,7 @@ describe('Job - Notifications - Process Notification Status service', () => {
       expect(updateEventStub.called).to.be.false()
     })
 
-    it('handles the error', async () => {
+    it('omfg handles the error', async () => {
       await ProcessNotificationStatusService.go()
 
       const args = notifierStub.omfg.firstCall.args
@@ -107,6 +107,14 @@ describe('Job - Notifications - Process Notification Status service', () => {
       expect(args[0]).to.equal('Notification status job failed')
       expect(args[1]).to.be.null()
       expect(args[2]).to.be.an.error()
+    })
+
+    it('redAlert is called', async () => {
+      await ProcessNotificationStatusService.go()
+
+      const args = notifierStub.redAlert.firstCall.args
+
+      expect(args[0]).to.equal('Notification status job failed')
     })
   })
 })

--- a/test/services/jobs/return-logs/process-return-logs.service.test.js
+++ b/test/services/jobs/return-logs/process-return-logs.service.test.js
@@ -112,7 +112,7 @@ describe('Jobs - Return Logs - Process Return Logs service', () => {
       Sinon.stub(CheckReturnCycleService, 'go').rejects()
     })
 
-    it('omfg handles the error', async () => {
+    it('records the error by calling "omfg()"', async () => {
       await ProcessReturnLogsService.go(cycle)
 
       const args = notifierStub.omfg.firstCall.args
@@ -122,12 +122,16 @@ describe('Jobs - Return Logs - Process Return Logs service', () => {
       expect(args[2]).to.be.an.error()
     })
 
-    it('redAlert is called', async () => {
+    it('notifies the team by calling "redAlert()"', async () => {
       await ProcessReturnLogsService.go(cycle)
 
       const args = notifierStub.redAlert.firstCall.args
 
       expect(args[0]).to.equal('Return logs job failed')
+    })
+
+    it('does not throw an error', async () => {
+      await expect(ProcessReturnLogsService.go()).not.to.reject()
     })
   })
 })

--- a/test/services/jobs/return-logs/process-return-logs.service.test.js
+++ b/test/services/jobs/return-logs/process-return-logs.service.test.js
@@ -33,7 +33,7 @@ describe('Jobs - Return Logs - Process Return Logs service', () => {
     // BaseRequest depends on the GlobalNotifier to have been set. This happens in app/plugins/global-notifier.plugin.js
     // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
     // test we recreate the condition by setting it directly with our own stub
-    notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
+    notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub(), redAlert: Sinon.stub() }
     global.GlobalNotifier = notifierStub
   })
 
@@ -112,7 +112,7 @@ describe('Jobs - Return Logs - Process Return Logs service', () => {
       Sinon.stub(CheckReturnCycleService, 'go').rejects()
     })
 
-    it('handles the error', async () => {
+    it('omfg handles the error', async () => {
       await ProcessReturnLogsService.go(cycle)
 
       const args = notifierStub.omfg.firstCall.args
@@ -120,6 +120,14 @@ describe('Jobs - Return Logs - Process Return Logs service', () => {
       expect(args[0]).to.equal('Return logs job failed')
       expect(args[1]).to.equal({ cycle })
       expect(args[2]).to.be.an.error()
+    })
+
+    it('redAlert is called', async () => {
+      await ProcessReturnLogsService.go(cycle)
+
+      const args = notifierStub.redAlert.firstCall.args
+
+      expect(args[0]).to.equal('Return logs job failed')
     })
   })
 })

--- a/test/services/jobs/time-limited/process-time-limited-licences.service.test.js
+++ b/test/services/jobs/time-limited/process-time-limited-licences.service.test.js
@@ -26,7 +26,7 @@ describe('Process Time Limited Licences service', () => {
     // The service depends on GlobalNotifier to have been set. This happens in app/plugins/global-notifier.plugin.js
     // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
     // test we recreate the condition by setting it directly with our own stub
-    notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
+    notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub(), redAlert: Sinon.stub() }
     global.GlobalNotifier = notifierStub
   })
 
@@ -126,7 +126,7 @@ describe('Process Time Limited Licences service', () => {
       Sinon.stub(FetchTimeLimitedLicencesService, 'go').rejects()
     })
 
-    it('handles the error', async () => {
+    it('omfg handles the error', async () => {
       await ProcessTimeLimitedLicencesService.go()
 
       const args = notifierStub.omfg.firstCall.args
@@ -134,6 +134,14 @@ describe('Process Time Limited Licences service', () => {
       expect(args[0]).to.equal('Time limited job failed')
       expect(args[1]).to.be.null()
       expect(args[2]).to.be.an.error()
+    })
+
+    it('redAlert is called', async () => {
+      await ProcessTimeLimitedLicencesService.go()
+
+      const args = notifierStub.redAlert.firstCall.args
+
+      expect(args[0]).to.equal('Time limited job failed')
     })
   })
 })

--- a/test/services/jobs/time-limited/process-time-limited-licences.service.test.js
+++ b/test/services/jobs/time-limited/process-time-limited-licences.service.test.js
@@ -126,7 +126,7 @@ describe('Process Time Limited Licences service', () => {
       Sinon.stub(FetchTimeLimitedLicencesService, 'go').rejects()
     })
 
-    it('omfg handles the error', async () => {
+    it('records the error by calling "omfg()"', async () => {
       await ProcessTimeLimitedLicencesService.go()
 
       const args = notifierStub.omfg.firstCall.args
@@ -136,12 +136,16 @@ describe('Process Time Limited Licences service', () => {
       expect(args[2]).to.be.an.error()
     })
 
-    it('redAlert is called', async () => {
+    it('notifies the team by calling "redAlert()"', async () => {
       await ProcessTimeLimitedLicencesService.go()
 
       const args = notifierStub.redAlert.firstCall.args
 
       expect(args[0]).to.equal('Time limited job failed')
+    })
+
+    it('does not throw an error', async () => {
+      await expect(ProcessTimeLimitedLicencesService.go()).not.to.reject()
     })
   })
 })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5600

We are about to create a job that scans the db and sends an email/letter if certain conditions are met. However we have no way in the service to know if this job ran successfully or not as it could be a day when no one is notified. We'd have to run db queries which is burdensome but we still need to know if the job failed so we can make sure people are contacted. 

This PR adds an email alert to the team as part of the notifier lib. We then call this in the catches for the jobs. 