### PR TITLE
Split ProcessExistingReturnVersions into SRV & DAL

### DIFF
--- a/app/dal/return-versions/fetch-current-return-versions.dal.js
+++ b/app/dal/return-versions/fetch-current-return-versions.dal.js
@@ -1,0 +1,29 @@
+'use strict'
+
+/**
+ * Fetches the 'current' return versions for a licence
+ * @module FetchCurrentReturnVersionsDal
+ */
+
+const ReturnVersionModel = require('../../models/return-version.model.js')
+
+/**
+ * Fetches the 'current' return versions for a licence
+ *
+ * @param {string} licenceId - The UUID of the licence to fetch return versions for
+ * @param {object} trx - Database transaction object to ensure all DB changes are applied, or none at all
+ *
+ * @returns {Promise<module:ReturnVersionModel[]>} The 'current' return versions for the licence ordered by `startDate`
+ * descending
+ */
+async function go(licenceId, trx) {
+  return ReturnVersionModel.query(trx)
+    .select(['endDate', 'id', 'startDate'])
+    .where('licenceId', licenceId)
+    .where('status', 'current')
+    .orderBy('startDate', 'desc')
+}
+
+module.exports = {
+  go
+}

--- a/app/dal/return-versions/update-return-version-end-date.dal.js
+++ b/app/dal/return-versions/update-return-version-end-date.dal.js
@@ -1,0 +1,23 @@
+'use strict'
+
+/**
+ * Updates the end date for a return version
+ * @module UpdateReturnVersionEndDateDal
+ */
+
+const ReturnVersionModel = require('../../models/return-version.model.js')
+
+/**
+ * Updates the end date for a return version
+ *
+ * @param {string} returnVersionId - The UUID of the return version to update
+ * @param {Date} endDate - The new end date for the return version
+ * @param {object} trx - Database transaction object to ensure all DB changes are applied, or none at all
+ */
+async function go(returnVersionId, endDate, trx) {
+  await ReturnVersionModel.query(trx).findById(returnVersionId).patch({ endDate })
+}
+
+module.exports = {
+  go
+}

--- a/app/dal/return-versions/update-return-version-status.dal.js
+++ b/app/dal/return-versions/update-return-version-status.dal.js
@@ -1,0 +1,23 @@
+'use strict'
+
+/**
+ * Updates the status of a return version
+ * @module UpdateReturnVersionStatusDal
+ */
+
+const ReturnVersionModel = require('../../models/return-version.model.js')
+
+/**
+ * Updates the status of a return version
+ *
+ * @param {string} returnVersionId - The UUID of the return version to update
+ * @param {string} status - The new status for the return version
+ * @param {object} trx - Database transaction object to ensure all DB changes are applied, or none at all
+ */
+async function go(returnVersionId, status, trx) {
+  await ReturnVersionModel.query(trx).findById(returnVersionId).patch({ status })
+}
+
+module.exports = {
+  go
+}

--- a/app/services/return-versions/setup/check/process-existing-return-versions.service.js
+++ b/app/services/return-versions/setup/check/process-existing-return-versions.service.js
@@ -5,7 +5,9 @@
  * @module ProcessExistingReturnVersionsService
  */
 
-const ReturnVersionModel = require('../../../../models/return-version.model.js')
+const FetchCurrentReturnVersionsDal = require('../../../../dal/return-versions/fetch-current-return-versions.dal.js')
+const UpdateReturnVersionEndDateDal = require('../../../../dal/return-versions/update-return-version-end-date.dal.js')
+const UpdateReturnVersionStatusDal = require('../../../../dal/return-versions/update-return-version-status.dal.js')
 const { sameDate } = require('../../../../lib/dates.lib.js')
 
 /**
@@ -23,7 +25,7 @@ const { sameDate } = require('../../../../lib/dates.lib.js')
  * if there is no `endDate`
  */
 async function go(licenceId, newVersionStartDate, trx) {
-  const previousVersions = await _previousVersions(licenceId)
+  const previousVersions = await FetchCurrentReturnVersionsDal.go(licenceId, trx)
   const previousVersionEndDate = _calculateEndDate(newVersionStartDate)
 
   let result
@@ -90,7 +92,9 @@ async function _endLatestVersion(previousVersions, newVersionStartDate, endDate,
     return null
   }
 
-  return matchedReturnVersion.$query(trx).patch({ endDate })
+  await UpdateReturnVersionEndDateDal.go(matchedReturnVersion.id, endDate, trx)
+
+  return endDate
 }
 
 /**
@@ -164,7 +168,7 @@ async function _insertBetweenVersions(previousVersions, newVersionStartDate, end
 
   const newVersionEndDate = matchedReturnVersion.endDate
 
-  await matchedReturnVersion.$query(trx).patch({ endDate })
+  await UpdateReturnVersionEndDateDal.go(matchedReturnVersion.id, endDate, trx)
 
   return newVersionEndDate
 }
@@ -176,14 +180,6 @@ function _calculateEndDate(changeDate) {
   newEndDate.setDate(newEndDate.getDate() - 1)
 
   return newEndDate
-}
-
-function _previousVersions(licenceId) {
-  return ReturnVersionModel.query()
-    .select(['endDate', 'id', 'startDate'])
-    .where('licenceId', licenceId)
-    .where('status', 'current')
-    .orderBy('startDate', 'desc')
 }
 
 /**
@@ -220,7 +216,9 @@ async function _replaceLatestVersion(previousVersions, newVersionStartDate, trx)
     return null
   }
 
-  return matchedReturnVersion.$query(trx).patch({ status: 'superseded' })
+  await UpdateReturnVersionStatusDal.go(matchedReturnVersion.id, 'superseded', trx)
+
+  return true
 }
 
 /**
@@ -260,7 +258,7 @@ async function _replacePreviousVersion(previousVersions, newVersionStartDate, tr
 
   const newVersionEndDate = matchedReturnVersion.endDate
 
-  await matchedReturnVersion.$query(trx).patch({ status: 'superseded' })
+  await UpdateReturnVersionStatusDal.go(matchedReturnVersion.id, 'superseded', trx)
 
   return newVersionEndDate
 }

--- a/test/dal/return-versions/fetch-current-return-versions.dal.test.js
+++ b/test/dal/return-versions/fetch-current-return-versions.dal.test.js
@@ -1,0 +1,70 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Test helpers
+const ReturnVersionHelper = require('../../support/helpers/return-version.helper.js')
+const ReturnVersionModel = require('../../../app/models/return-version.model.js')
+const { generateUUID } = require('../../../app/lib/general.lib.js')
+
+// Things under test
+const FetchCurrentReturnVersionsDal = require('../../../app/dal/return-versions/fetch-current-return-versions.dal.js')
+
+describe('DAL - Return Versions - Fetch Current Return Versions dal', () => {
+  let licenceId
+  let returnVersions
+  let trx
+
+  beforeEach(async () => {
+    licenceId = generateUUID()
+
+    // We add two that are current for the licence to confirm the ordering.
+    // We then add one for a different licence and one that has a status of 'superseded' to confirm these are not
+    // returned.
+    returnVersions = [
+      await ReturnVersionHelper.add({ licenceId, startDate: new Date('2024-01-01'), status: 'current' }),
+      await ReturnVersionHelper.add({ licenceId, startDate: new Date('2025-04-01'), status: 'current' }),
+      await ReturnVersionHelper.add({ licenceId: generateUUID(), status: 'current' }),
+      await ReturnVersionHelper.add({ licenceId, status: 'superseded' })
+    ]
+  })
+
+  afterEach(async () => {
+    for (const returnVersion of returnVersions) {
+      await returnVersion.$query().delete()
+    }
+  })
+
+  describe('when called without a transaction', () => {
+    it('fetches the current return versions for the specified licence', async () => {
+      const result = await FetchCurrentReturnVersionsDal.go(licenceId)
+
+      expect(result).to.have.length(2)
+      expect(result[0].startDate).to.be.above(result[1].startDate)
+    })
+  })
+
+  describe('when called with a transaction', () => {
+    beforeEach(async () => {
+      trx = await ReturnVersionModel.startTransaction()
+    })
+
+    afterEach(async () => {
+      if (trx && !trx.isCompleted()) {
+        await trx.rollback()
+      }
+    })
+
+    it('fetches the current return versions for the specified licence', async () => {
+      const result = await FetchCurrentReturnVersionsDal.go(licenceId, trx)
+
+      expect(result).to.have.length(2)
+      expect(result[0].startDate).to.be.above(result[1].startDate)
+    })
+  })
+})

--- a/test/dal/return-versions/update-return-version-end-date.dal.test.js
+++ b/test/dal/return-versions/update-return-version-end-date.dal.test.js
@@ -1,0 +1,62 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Test helpers
+const ReturnVersionHelper = require('../../support/helpers/return-version.helper.js')
+const ReturnVersionModel = require('../../../app/models/return-version.model.js')
+
+// Things under test
+const UpdateReturnVersionEndDateDal = require('../../../app/dal/return-versions/update-return-version-end-date.dal.js')
+
+describe('DAL - Return Versions - Update Return Version End Date dal', () => {
+  let endDate
+  let returnVersion
+  let trx
+
+  beforeEach(async () => {
+    returnVersion = await ReturnVersionHelper.add({ endDate: null })
+
+    endDate = new Date('2026-04-30')
+  })
+
+  afterEach(async () => {
+    await returnVersion.$query().delete()
+  })
+
+  describe('when called without a transaction', () => {
+    it('updates the end date for the specified return version', async () => {
+      await UpdateReturnVersionEndDateDal.go(returnVersion.$id(), endDate)
+
+      const result = await returnVersion.$query()
+
+      expect(result.endDate.toISOString()).to.equal(endDate.toISOString())
+    })
+  })
+
+  describe('when called with a transaction', () => {
+    beforeEach(async () => {
+      trx = await ReturnVersionModel.startTransaction()
+    })
+
+    afterEach(async () => {
+      if (trx && !trx.isCompleted()) {
+        await trx.rollback()
+      }
+    })
+
+    it('updates the end date for the specified return version', async () => {
+      await UpdateReturnVersionEndDateDal.go(returnVersion.$id(), endDate, trx)
+      await trx.commit()
+
+      const result = await returnVersion.$query()
+
+      expect(result.endDate.toISOString()).to.equal(endDate.toISOString())
+    })
+  })
+})

--- a/test/dal/return-versions/update-return-version-status.dal.test.js
+++ b/test/dal/return-versions/update-return-version-status.dal.test.js
@@ -1,0 +1,62 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Test helpers
+const ReturnVersionHelper = require('../../support/helpers/return-version.helper.js')
+const ReturnVersionModel = require('../../../app/models/return-version.model.js')
+
+// Things under test
+const UpdateReturnVersionStatusDal = require('../../../app/dal/return-versions/update-return-version-status.dal.js')
+
+describe('DAL - Return Versions - Update Return Version Status dal', () => {
+  let status
+  let returnVersion
+  let trx
+
+  beforeEach(async () => {
+    returnVersion = await ReturnVersionHelper.add({ status: 'current' })
+
+    status = 'superseded'
+  })
+
+  afterEach(async () => {
+    await returnVersion.$query().delete()
+  })
+
+  describe('when called without a transaction', () => {
+    it('updates the status for the specified return version', async () => {
+      await UpdateReturnVersionStatusDal.go(returnVersion.$id(), status)
+
+      const result = await returnVersion.$query()
+
+      expect(result.status).to.equal(status)
+    })
+  })
+
+  describe('when called with a transaction', () => {
+    beforeEach(async () => {
+      trx = await ReturnVersionModel.startTransaction()
+    })
+
+    afterEach(async () => {
+      if (trx && !trx.isCompleted()) {
+        await trx.rollback()
+      }
+    })
+
+    it('updates the status for the specified return version', async () => {
+      await UpdateReturnVersionStatusDal.go(returnVersion.$id(), status, trx)
+      await trx.commit()
+
+      const result = await returnVersion.$query()
+
+      expect(result.status).to.equal(status)
+    })
+  })
+})

--- a/test/services/return-versions/setup/check/process-existing-return-versions.service.test.js
+++ b/test/services/return-versions/setup/check/process-existing-return-versions.service.test.js
@@ -3,174 +3,198 @@
 // Test framework dependencies
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
+const Sinon = require('sinon')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
-// Test helpers
-const { generateUUID } = require('../../../../../app/lib/general.lib.js')
-const ReturnVersionHelper = require('../../../../support/helpers/return-version.helper.js')
-const ReturnVersionModel = require('../../../../../app/models/return-version.model.js')
+// Things we need to stub
+const FetchCurrentReturnVersionsDal = require('../../../../../app/dal/return-versions/fetch-current-return-versions.dal.js')
+const UpdateReturnVersionEndDateDal = require('../../../../../app/dal/return-versions/update-return-version-end-date.dal.js')
+const UpdateReturnVersionStatusDal = require('../../../../../app/dal/return-versions/update-return-version-status.dal.js')
 
 // Thing under test
 const ProcessExistingReturnVersionsService = require('../../../../../app/services/return-versions/setup/check/process-existing-return-versions.service.js')
 
 describe('Return Versions Setup - Process Existing Return Versions service', () => {
-  let existingReturnVersionId
+  let fetchCurrentReturnVersionsStub
+  let updateReturnVersionEndDateStub
+  let updateReturnVersionStatusStub
+
   let licenceId
   let newVersionStartDate
 
+  beforeEach(() => {
+    licenceId = '7cf4a46b-1375-42c8-bfe7-24c1bfff765c'
+
+    fetchCurrentReturnVersionsStub = Sinon.stub(FetchCurrentReturnVersionsDal, 'go')
+
+    updateReturnVersionEndDateStub = Sinon.stub(UpdateReturnVersionEndDateDal, 'go').resolves()
+    updateReturnVersionStatusStub = Sinon.stub(UpdateReturnVersionStatusDal, 'go').resolves()
+  })
+
+  afterEach(() => {
+    Sinon.restore()
+  })
+
   describe('When a "current" return version has a "startDate" < "newVersionStartDate" and no "endDate"', () => {
-    beforeEach(async () => {
-      existingReturnVersionId = generateUUID()
-      licenceId = generateUUID()
+    beforeEach(() => {
       newVersionStartDate = new Date('2024-06-01')
 
-      await ReturnVersionHelper.add({
-        id: existingReturnVersionId,
-        licenceId,
-        startDate: new Date('2024-04-01'),
-        endDate: null
-      })
+      fetchCurrentReturnVersionsStub.resolves([
+        {
+          id: '46c0fef8-70bb-41c8-bfa1-ace5c21ef739',
+          licenceId,
+          startDate: new Date('2024-04-01'),
+          endDate: null
+        }
+      ])
     })
 
     it('sets the "endDate" of the existing record, a null "endDate" is returned for the new return version', async () => {
       const result = await ProcessExistingReturnVersionsService.go(licenceId, newVersionStartDate)
-      const existingReturnVersion = await ReturnVersionModel.query().findById(existingReturnVersionId)
 
       expect(result).to.be.null()
-      expect(existingReturnVersion.endDate).to.equal(new Date('2024-05-31'))
+
+      expect(updateReturnVersionEndDateStub.calledOnce).to.be.true()
+      expect(updateReturnVersionEndDateStub.firstCall.args[0]).to.equal('46c0fef8-70bb-41c8-bfa1-ace5c21ef739')
+      expect(updateReturnVersionEndDateStub.firstCall.args[1]).to.equal(new Date('2024-05-31'))
     })
   })
 
   describe('When a "current" return version has a "startDate" < "newVersionStartDate" and an "endDate" greater', () => {
-    beforeEach(async () => {
-      existingReturnVersionId = generateUUID()
-      licenceId = generateUUID()
+    beforeEach(() => {
       newVersionStartDate = new Date('2024-06-01')
 
-      await ReturnVersionHelper.add({
-        id: existingReturnVersionId,
-        licenceId,
-        startDate: new Date('2024-04-01'),
-        endDate: new Date('2024-07-01')
-      })
+      fetchCurrentReturnVersionsStub.resolves([
+        {
+          id: '46c0fef8-70bb-41c8-bfa1-ace5c21ef739',
+          licenceId,
+          startDate: new Date('2024-04-01'),
+          endDate: new Date('2024-07-01')
+        }
+      ])
     })
 
     it('sets the "endDate" of the existing record and an "endDate" is returned for the new return version', async () => {
       const result = await ProcessExistingReturnVersionsService.go(licenceId, newVersionStartDate)
-      const existingReturnVersion = await ReturnVersionModel.query().findById(existingReturnVersionId)
 
       expect(result).to.equal(new Date('2024-07-01'))
-      expect(existingReturnVersion.endDate).to.equal(new Date('2024-05-31'))
+
+      expect(updateReturnVersionEndDateStub.calledOnce).to.be.true()
+      expect(updateReturnVersionEndDateStub.firstCall.args[0]).to.equal('46c0fef8-70bb-41c8-bfa1-ace5c21ef739')
+      expect(updateReturnVersionEndDateStub.firstCall.args[1]).to.equal(new Date('2024-05-31'))
     })
   })
 
   describe('When a "current" return version has a "startDate" > "newVersionStartDate" and no "endDate"', () => {
-    beforeEach(async () => {
-      existingReturnVersionId = generateUUID()
-      licenceId = generateUUID()
+    beforeEach(() => {
       newVersionStartDate = new Date('2024-04-01')
 
-      await ReturnVersionHelper.add({
-        id: existingReturnVersionId,
-        licenceId,
-        startDate: new Date('2024-04-21')
-      })
+      fetchCurrentReturnVersionsStub.resolves([
+        {
+          id: '46c0fef8-70bb-41c8-bfa1-ace5c21ef739',
+          licenceId,
+          startDate: new Date('2024-04-21'),
+          endDate: null
+        }
+      ])
     })
 
-    it('an "endDate" is returned for the new return version', async () => {
+    it('an "endDate" is returned for the new return version and no changes are made', async () => {
       const result = await ProcessExistingReturnVersionsService.go(licenceId, newVersionStartDate)
-      const existingReturnVersion = await ReturnVersionModel.query().findById(existingReturnVersionId)
 
       expect(result).to.equal(new Date('2024-04-20'))
-      expect(existingReturnVersion.endDate).to.equal(null)
+
+      expect(updateReturnVersionEndDateStub.called).to.be.false()
+      expect(updateReturnVersionStatusStub.called).to.be.false()
     })
   })
 
   describe('When a "current" return version has a "startDate" === "newVersionStartDate" and no "endDate"', () => {
     beforeEach(async () => {
-      existingReturnVersionId = generateUUID()
-      licenceId = generateUUID()
       newVersionStartDate = new Date('2024-04-01')
 
-      await ReturnVersionHelper.add({
-        id: existingReturnVersionId,
-        licenceId,
-        startDate: new Date('2024-04-01'),
-        endDate: null
-      })
+      fetchCurrentReturnVersionsStub.resolves([
+        {
+          id: '46c0fef8-70bb-41c8-bfa1-ace5c21ef739',
+          licenceId,
+          startDate: new Date('2024-04-01'),
+          endDate: null
+        }
+      ])
     })
 
     it('sets the "status" of the existing record, a null end date is returned for the new return version', async () => {
       const result = await ProcessExistingReturnVersionsService.go(licenceId, newVersionStartDate)
-      const existingReturnVersion = await ReturnVersionModel.query().findById(existingReturnVersionId)
 
       expect(result).to.be.null()
-      expect(existingReturnVersion.status).to.equal('superseded')
+
+      expect(updateReturnVersionStatusStub.calledOnce).to.be.true()
+      expect(updateReturnVersionStatusStub.firstCall.args[0]).to.equal('46c0fef8-70bb-41c8-bfa1-ace5c21ef739')
+      expect(updateReturnVersionStatusStub.firstCall.args[1]).to.equal('superseded')
     })
   })
 
   describe('When a "current" return version has a "startDate" === "newVersionStartDate" and an "endDate"', () => {
-    beforeEach(async () => {
-      existingReturnVersionId = generateUUID()
-      licenceId = generateUUID()
+    beforeEach(() => {
       newVersionStartDate = new Date('2024-04-01')
 
-      await ReturnVersionHelper.add({
-        id: existingReturnVersionId,
-        licenceId,
-        startDate: new Date('2024-04-01'),
-        endDate: new Date('2024-07-01')
-      })
+      fetchCurrentReturnVersionsStub.resolves([
+        {
+          id: '46c0fef8-70bb-41c8-bfa1-ace5c21ef739',
+          licenceId,
+          startDate: new Date('2024-04-01'),
+          endDate: new Date('2024-07-01')
+        }
+      ])
     })
 
     it('sets the "status" of the existing record and an "endDate" is returned for the new return version', async () => {
       const result = await ProcessExistingReturnVersionsService.go(licenceId, newVersionStartDate)
-      const existingReturnVersion = await ReturnVersionModel.query().findById(existingReturnVersionId)
 
       expect(result).to.equal(new Date('2024-07-01'))
-      expect(existingReturnVersion.status).to.equal('superseded')
+
+      expect(updateReturnVersionStatusStub.calledOnce).to.be.true()
+      expect(updateReturnVersionStatusStub.firstCall.args[0]).to.equal('46c0fef8-70bb-41c8-bfa1-ace5c21ef739')
+      expect(updateReturnVersionStatusStub.firstCall.args[1]).to.equal('superseded')
     })
   })
 
   describe('When a return version is inserted in between two existing return versions', () => {
-    beforeEach(async () => {
-      existingReturnVersionId = generateUUID()
-      licenceId = generateUUID()
+    beforeEach(() => {
       newVersionStartDate = new Date('2025-04-01')
 
-      await ReturnVersionHelper.add({
-        id: generateUUID(),
-        licenceId,
-        startDate: new Date('1993-04-27'),
-        endDate: new Date('2008-03-31')
-      })
-      await ReturnVersionHelper.add({
-        id: existingReturnVersionId,
-        licenceId,
-        startDate: new Date('2008-04-01'),
-        endDate: new Date('2025-05-11')
-      })
-      await ReturnVersionHelper.add({
-        id: generateUUID(),
-        licenceId,
-        startDate: new Date('2025-05-12')
-      })
-      await ReturnVersionHelper.add({
-        id: generateUUID(),
-        licenceId,
-        status: 'superseded',
-        startDate: new Date('2025-05-12')
-      })
+      fetchCurrentReturnVersionsStub.resolves([
+        {
+          id: 'c4738c45-f43c-440d-a353-823cc0148d68',
+          licenceId,
+          startDate: new Date('1993-04-27'),
+          endDate: new Date('2008-03-31')
+        },
+        {
+          id: '46c0fef8-70bb-41c8-bfa1-ace5c21ef739',
+          licenceId,
+          startDate: new Date('2008-04-01'),
+          endDate: new Date('2025-05-11')
+        },
+        {
+          id: '670d1781-4071-4010-ab80-56ddc525faff',
+          licenceId,
+          startDate: new Date('2025-05-12'),
+          endDate: null
+        }
+      ])
     })
 
     it('the correct "endDate" is returned for the existing return version and the previous ones endDate is updated', async () => {
       const result = await ProcessExistingReturnVersionsService.go(licenceId, newVersionStartDate)
-      const existingReturnVersion = await ReturnVersionModel.query().findById(existingReturnVersionId)
 
       expect(result).to.equal(new Date('2025-05-11'))
-      expect(existingReturnVersion.endDate).to.equal(new Date('2025-03-31'))
+
+      expect(updateReturnVersionEndDateStub.calledOnce).to.be.true()
+      expect(updateReturnVersionEndDateStub.firstCall.args[0]).to.equal('46c0fef8-70bb-41c8-bfa1-ace5c21ef739')
+      expect(updateReturnVersionEndDateStub.firstCall.args[1]).to.equal(new Date('2025-03-31'))
     })
   })
 })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5539

We just completed [wrapping the create return version process in a transaction](https://github.com/DEFRA/water-abstraction-system/pull/3245). We took advantage of this to split some of the services involved into a service layer and a data access layer (DAL).

This is why we have agreed to set out our services going forward. It should make testing easier and isolate any database access, both in the code and the tests, to the DAL modules.

Though `ProcessExistingReturnVersionsService` was a candidate for splitting as part of the wrap change, it was already very large, and splitting was not necessary to achieve the wrap.

So, this is a follow-up change to split `ProcessExistingReturnVersionsService` into a service and a DAL.
