### PR TITLE
Fix renewal invitations day param from string to number

### DIFF
--- a/app/services/jobs/renewal-invitations/send-renewal-invitations.service.js
+++ b/app/services/jobs/renewal-invitations/send-renewal-invitations.service.js
@@ -30,7 +30,7 @@ async function go(days) {
 function _expiryDate(futureExpiredDate) {
   const targetDate = new Date()
 
-  targetDate.setDate(targetDate.getDate() + futureExpiredDate)
+  targetDate.setDate(targetDate.getDate() + Number(futureExpiredDate))
 
   targetDate.setHours(0, 0, 0, 0)
 

--- a/test/services/jobs/renewal-invitations/process-renewal-invitations.service.test.js
+++ b/test/services/jobs/renewal-invitations/process-renewal-invitations.service.test.js
@@ -15,7 +15,7 @@ const SendRenewalInvitations = require('../../../../app/services/jobs/renewal-in
 const ProcessRenewalInvitationsService = require('../../../../app/services/jobs/renewal-invitations/process-renewal-invitations.service.js')
 
 describe('Jobs - Renewal Invitations - Process Renewal Invitations service', () => {
-  const days = 300
+  const days = '300'
 
   let notifierStub
 

--- a/test/services/jobs/renewal-invitations/send-renewal-invitations.service.test.js
+++ b/test/services/jobs/renewal-invitations/send-renewal-invitations.service.test.js
@@ -15,7 +15,7 @@ const FetchRenewalRecipients = require('../../../../app/services/jobs/renewal-in
 const SendRenewalInvitations = require('../../../../app/services/jobs/renewal-invitations/send-renewal-invitations.service.js')
 
 describe('Jobs - Renewal Invitations - Send Renewal Invitations service', () => {
-  const days = 300
+  const days = '300'
 
   let clock
   let expiredDate


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5589

When the renewal invitations job processed the 'days' arg from the query params we where not converting this to a number.

This was causing the wrong date to be used.

This change cast the 'days' from a string to a number, the tests have been updated to reflect this behaviour.