### PR TITLE
Remove 'current' filter on FetchOtherPurposesDal

### DIFF
--- a/app/dal/return-versions/fetch-other-purpose-ids.dal.js
+++ b/app/dal/return-versions/fetch-other-purpose-ids.dal.js
@@ -1,14 +1,14 @@
 'use strict'
 
 /**
- * Fetch the primary and secondary purpose ids from the 'current' version for a licence
+ * Fetch the primary and secondary purpose ids from the latest matching licence version with the same purpose
  * @module FetchOtherPurposeIdsDal
  */
 
-const LicenceVersionModel = require('../../models/licence-version.model.js')
+const LicenceVersionPurposeModel = require('../../models/licence-version-purpose.model.js')
 
 /**
- * Fetch the primary and secondary purpose ids from the 'current' version for a licence
+ * Fetch the primary and secondary purpose ids from the latest matching licence version with the same purpose
  *
  * When creating a new return version, users must create at least one return requirement with at least one purpose.
  *
@@ -26,8 +26,9 @@ const LicenceVersionModel = require('../../models/licence-version.model.js')
  * But we don't store the primary and secondary purposes against the requirement, nor in the session. This means when
  * generating the return logs, we need to know what primary and secondary purposes were assigned for _this_ licence.
  *
- * We do this by fetching the first `licence_version_purpose` for the licence's 'current' version, where the purpose id
- * matches the one selected for the return requirement. From it we fetch the primary and secondary purpose IDs.
+ * We do this by fetching the first `licence_version_purpose` for the licence's latest matching version, where the
+ * purpose id matches the one selected for the return requirement. From it we fetch the primary and secondary purpose
+ * IDs.
  *
  * @param {string} licenceId - The UUID of the licence to identify the primary and secondary purpose IDs
  * @param {string} purposeId - The UUID of the purpose to identify the primary and secondary purpose IDs
@@ -35,12 +36,16 @@ const LicenceVersionModel = require('../../models/licence-version.model.js')
  * @returns {Promise<object>} An object containing the fetched primary and secondary purpose IDs
  */
 async function go(licenceId, purposeId) {
-  const { primaryPurposeId, secondaryPurposeId } = await LicenceVersionModel.query()
+  const { primaryPurposeId, secondaryPurposeId } = await LicenceVersionPurposeModel.query()
     .select('primaryPurposeId', 'secondaryPurposeId')
-    .innerJoinRelated('licenceVersionPurposes')
-    .where('licenceId', licenceId)
-    .andWhere('status', 'current')
+    .innerJoinRelated('licenceVersion')
+    .where('licenceVersion.licenceId', licenceId)
     .andWhere('purposeId', purposeId)
+    .orderBy([
+      { column: 'licenceVersion.status', order: 'asc' }, // current before superseded
+      { column: 'licenceVersion.startDate', order: 'desc' } // newer before older
+    ])
+    .limit(1)
     .first()
 
   return {

--- a/test/dal/return-versions/fetch-other-purpose-ids.dal.test.js
+++ b/test/dal/return-versions/fetch-other-purpose-ids.dal.test.js
@@ -19,36 +19,63 @@ const { generateUUID } = require('../../../app/lib/general.lib.js')
 const FetchOtherPurposeIdsDal = require('../../../app/dal/return-versions/fetch-other-purpose-ids.dal.js')
 
 describe('DAL - Return Versions - Fetch Other Purpose Ids dal', () => {
+  let currentPurposeDetails
+  let historicPurposeDetails
   let licenceId
   let licenceVersions
   let licenceVersionPurposes
-  let primaryPurposeId
-  let purposeId
-  let secondaryPurposeId
+  let otherLicencePurposeDetails
+  let otherPurposeDetails
+  let supersededPurposeDetails
 
   before(async () => {
     licenceId = generateUUID()
 
-    purposeId = PurposeHelper.select(0).id
-    primaryPurposeId = PrimaryPurposeHelper.select(0).id
-    secondaryPurposeId = SecondaryPurposeHelper.select(0).id
+    // NOTE: We use the different primary and secondary purpose IDs to confirm we are fetching the correct ones when the
+    // service is executed. Having each of them different means we can trace the result back to the licence version
+    // purpose we created.
+    currentPurposeDetails = {
+      purposeId: PurposeHelper.select(0).id,
+      primaryPurposeId: PrimaryPurposeHelper.select(0).id,
+      secondaryPurposeId: SecondaryPurposeHelper.select(0).id
+    }
+    supersededPurposeDetails = {
+      purposeId: PurposeHelper.select(0).id,
+      primaryPurposeId: PrimaryPurposeHelper.select(1).id,
+      secondaryPurposeId: SecondaryPurposeHelper.select(1).id
+    }
+    otherLicencePurposeDetails = {
+      purposeId: PurposeHelper.select(0).id,
+      primaryPurposeId: PrimaryPurposeHelper.select(2).id,
+      secondaryPurposeId: SecondaryPurposeHelper.select(2).id
+    }
+    historicPurposeDetails = {
+      purposeId: PurposeHelper.select(1).id,
+      primaryPurposeId: PrimaryPurposeHelper.select(3).id,
+      secondaryPurposeId: SecondaryPurposeHelper.select(3).id
+    }
+    otherPurposeDetails = {
+      purposeId: PurposeHelper.select(2).id,
+      primaryPurposeId: PrimaryPurposeHelper.select(4).id,
+      secondaryPurposeId: SecondaryPurposeHelper.select(4).id
+    }
 
-    // 0 - A current licence version linked to a different licence
-    // 1 - A superseded licence version linked to the licence
-    // 2 - A current licence version linked to the licence. Only purposes linked to this should be fetched
     licenceVersions = [
+      // 0 - A current licence version linked to a different licence
       await LicenceVersionHelper.add({
         endDate: null,
         licenceId: generateUUID(),
         startDate: new Date('2024-04-01'),
         status: 'current'
       }),
+      // 1 - A superseded licence version linked to the licence
       await LicenceVersionHelper.add({
         endDate: new Date('2024-03-31'),
         licenceId,
         startDate: new Date('2022-04-01'),
         status: 'superseded'
       }),
+      // 2 - A current licence version linked to the licence
       await LicenceVersionHelper.add({
         endDate: null,
         licenceId,
@@ -57,34 +84,41 @@ describe('DAL - Return Versions - Fetch Other Purpose Ids dal', () => {
       })
     ]
 
-    // 0 - Matches our purpose but linked to a different licence
-    // 1 - Matches our purpose and licence, but is linked to the superseded licence version
-    // 2 - Matches our licence and is linked to the current licence version, but has a different purpose
-    // 3 - Matches our purpose and licence, and is linked to the current licence version
     licenceVersionPurposes = [
+      // 0 - Matches our purpose but linked to a different licence
       await LicenceVersionPurposeHelper.add({
         licenceVersionId: licenceVersions[0].id,
-        primaryPurposeId,
-        purposeId,
-        secondaryPurposeId
+        primaryPurposeId: otherLicencePurposeDetails.primaryPurposeId,
+        purposeId: otherLicencePurposeDetails.purposeId,
+        secondaryPurposeId: otherLicencePurposeDetails.secondaryPurposeId
       }),
+      // 1 - Matches our purpose and licence, and is linked to the superseded licence version
       await LicenceVersionPurposeHelper.add({
         licenceVersionId: licenceVersions[1].id,
-        primaryPurposeId: PrimaryPurposeHelper.select(1).id,
-        purposeId,
-        secondaryPurposeId: SecondaryPurposeHelper.select(1).id
+        primaryPurposeId: supersededPurposeDetails.primaryPurposeId,
+        purposeId: supersededPurposeDetails.purposeId,
+        secondaryPurposeId: supersededPurposeDetails.secondaryPurposeId
       }),
+      // 2 - Matches our historic purpose and licence, and is linked to the superseded licence version
+      await LicenceVersionPurposeHelper.add({
+        licenceVersionId: licenceVersions[1].id,
+        primaryPurposeId: historicPurposeDetails.primaryPurposeId,
+        purposeId: historicPurposeDetails.purposeId,
+        secondaryPurposeId: historicPurposeDetails.secondaryPurposeId
+      }),
+      // 3 - Matches our licence and is linked to the current licence version, but has a different purpose
       await LicenceVersionPurposeHelper.add({
         licenceVersionId: licenceVersions[2].id,
-        primaryPurposeId,
-        purposeId: PurposeHelper.select(1).id,
-        secondaryPurposeId
+        primaryPurposeId: otherPurposeDetails.primaryPurposeId,
+        purposeId: otherPurposeDetails.purposeId,
+        secondaryPurposeId: otherPurposeDetails.secondaryPurposeId
       }),
+      // 4 - Matches our purpose and licence, and is linked to the current licence version
       await LicenceVersionPurposeHelper.add({
         licenceVersionId: licenceVersions[2].id,
-        primaryPurposeId,
-        purposeId,
-        secondaryPurposeId
+        primaryPurposeId: currentPurposeDetails.primaryPurposeId,
+        purposeId: currentPurposeDetails.purposeId,
+        secondaryPurposeId: currentPurposeDetails.secondaryPurposeId
       })
     ]
   })
@@ -100,10 +134,26 @@ describe('DAL - Return Versions - Fetch Other Purpose Ids dal', () => {
   })
 
   describe('when called', () => {
-    it('returns the matching primary and secondary purpose IDs for the specified licence and purpose', async () => {
-      const result = await FetchOtherPurposeIdsDal.go(licenceId, purposeId)
+    describe("and the purpose matches to one linked to the licences's 'current' licence version", () => {
+      it('returns the matching primary and secondary purpose IDs', async () => {
+        const result = await FetchOtherPurposeIdsDal.go(licenceId, currentPurposeDetails.purposeId)
 
-      expect(result).to.equal({ primaryPurposeId, secondaryPurposeId })
+        expect(result).to.equal({
+          primaryPurposeId: currentPurposeDetails.primaryPurposeId,
+          secondaryPurposeId: currentPurposeDetails.secondaryPurposeId
+        })
+      })
+    })
+
+    describe("and the purpose matches to one linked to a licences's historic licence versions", () => {
+      it('still returns the matching primary and secondary purpose IDs', async () => {
+        const result = await FetchOtherPurposeIdsDal.go(licenceId, historicPurposeDetails.purposeId)
+
+        expect(result).to.equal({
+          primaryPurposeId: historicPurposeDetails.primaryPurposeId,
+          secondaryPurposeId: historicPurposeDetails.secondaryPurposeId
+        })
+      })
     })
   })
 })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5539

We just completed [wrapping the create return version process in a transaction](https://github.com/DEFRA/water-abstraction-system/pull/3245). We took advantage of this to split some of the services involved into a service layer and a data access layer (DAL).

One of the queries we extracted and moved into the DAL was to fetch the primary and secondary purpose IDs for a purpose selected for the new return version.

The query is looking for a match on the purpose ID against the 'current' licence version's purposes. When it finds one, it returns the primary and secondary ID against the matching record.

But that got us thinking. What if the user chooses to add a historical return version as a correction? If they did this, the journey could present a purpose that is no longer present on the 'current' licence version. In this case, the query would return no results, and the user could be presented with an error message.

Or we think this is the case! The reason for wrapping the process is that users have reported an error, for which we can currently find no root cause. When they try to recreate the return version, it works. In our scenario, the creation process would always error, so we're not sure these are related.

Either way, we think it is worth removing the 'current' filter from the query. The primary and secondary IDs are only needed to populate any generated return logs in the same manner as the legacy service did. They have no impact on any functionality we have built into the service.