### PR TITLE
Create a notice for the renewal invitations job

### DIFF
--- a/app/lib/static-lookups.lib.js
+++ b/app/lib/static-lookups.lib.js
@@ -324,7 +324,8 @@ const NoticeType = Object.freeze({
   ALTERNATE_INVITATION: 'alternateInvitations',
   INVITATIONS: 'invitations',
   PAPER_RETURN: 'paperReturn',
-  REMINDERS: 'reminders'
+  REMINDERS: 'reminders',
+  RENEWAL_INVITATIONS: 'renewalInvitations'
 })
 
 /**
@@ -355,6 +356,12 @@ const NoticeTypes = Object.freeze({
     prefix: 'RREM-',
     subType: 'returnReminder',
     notificationType: 'Returns reminder'
+  },
+  [NoticeType.RENEWAL_INVITATIONS]: {
+    name: 'Invitations: renewal',
+    prefix: 'REIN-',
+    subType: 'renewalInvitations',
+    notificationType: 'Renewal invitations'
   }
 })
 

--- a/app/lib/static-lookups.lib.js
+++ b/app/lib/static-lookups.lib.js
@@ -358,7 +358,7 @@ const NoticeTypes = Object.freeze({
     notificationType: 'Returns reminder'
   },
   [NoticeType.RENEWAL_INVITATIONS]: {
-    name: 'Invitations: renewal',
+    name: 'Renewals: invitation',
     prefix: 'REIN-',
     subType: 'renewalInvitations',
     notificationType: 'Renewal invitations'

--- a/app/presenters/notices/setup/create-notice.presenter.js
+++ b/app/presenters/notices/setup/create-notice.presenter.js
@@ -15,14 +15,14 @@ const { NoticeJourney } = require('../../../lib/static-lookups.lib.js')
  * We set the notice 'status' to 'complete' to allow the report to show on the 'notifications/report' page. This is
  * dictated by the legacy code.
  *
- * @param {SessionModel} session - The session instance
+ * @param {object} noticeData - The notice data
  * @param {object[]} recipients - List of recipient objects, each containing recipient details like email or name.
  * @param {string} issuer - The username of the person issuing the notice
  *
  * @returns {object} The data formatted for persisting as a `notice` record
  */
-function go(session, recipients, issuer) {
-  const { referenceCode, subType, name } = session
+function go(noticeData, recipients, issuer) {
+  const { referenceCode, subType, name } = noticeData
 
   const notice = {
     issuer,
@@ -39,11 +39,14 @@ function go(session, recipients, issuer) {
     type: 'notification'
   }
 
-  if (session.journey === NoticeJourney.ALERTS) {
-    notice.metadata.options = { sendingAlertType: session.alertType, monitoringStationId: session.monitoringStationId }
+  if (noticeData.journey === NoticeJourney.ALERTS) {
+    notice.metadata.options = {
+      sendingAlertType: noticeData.alertType,
+      monitoringStationId: noticeData.monitoringStationId
+    }
   } else {
-    notice.metadata.options = { excludeLicences: session.removeLicences ? session.removeLicences : [] }
-    notice.metadata.returnCycle = _returnCycle(session.determinedReturnsPeriod)
+    notice.metadata.options = { excludeLicences: noticeData.removeLicences ? noticeData.removeLicences : [] }
+    notice.metadata.returnCycle = _returnCycle(noticeData.determinedReturnsPeriod)
   }
 
   return notice

--- a/app/services/jobs/renewal-invitations/process-renewal-invitations.service.js
+++ b/app/services/jobs/renewal-invitations/process-renewal-invitations.service.js
@@ -17,9 +17,9 @@ async function go(days) {
   try {
     const startTime = currentTimeInNanoseconds()
 
-    const invitations = await SendRenewalInvitations.go(days)
+    const recipients = await SendRenewalInvitations.go(days)
 
-    calculateAndLogTimeTaken(startTime, 'Renewal invitations status job complete', { count: invitations.length })
+    calculateAndLogTimeTaken(startTime, 'Renewal invitations status job complete', { count: recipients.length })
   } catch (error) {
     global.GlobalNotifier.omfg('Notification status job failed', null, error)
   }

--- a/app/services/jobs/renewal-invitations/process-renewal-invitations.service.js
+++ b/app/services/jobs/renewal-invitations/process-renewal-invitations.service.js
@@ -17,9 +17,9 @@ async function go(days) {
   try {
     const startTime = currentTimeInNanoseconds()
 
-    await SendRenewalInvitations.go(days)
+    const invitations = await SendRenewalInvitations.go(days)
 
-    calculateAndLogTimeTaken(startTime, 'Renewal invitations status job complete')
+    calculateAndLogTimeTaken(startTime, 'Renewal invitations status job complete', { count: invitations.length })
   } catch (error) {
     global.GlobalNotifier.omfg('Notification status job failed', null, error)
   }

--- a/app/services/jobs/renewal-invitations/send-renewal-invitations.service.js
+++ b/app/services/jobs/renewal-invitations/send-renewal-invitations.service.js
@@ -43,7 +43,7 @@ function _expiryDate(futureExpiredDate) {
 }
 
 async function _notice(recipients) {
-  const { name, prefix, subType } = NoticeTypes[NoticeType.INVITATIONS]
+  const { name, prefix, subType } = NoticeTypes[NoticeType.RENEWAL_INVITATIONS]
 
   const noticeData = {
     referenceCode: generateNoticeReferenceCode(prefix),

--- a/app/services/jobs/renewal-invitations/send-renewal-invitations.service.js
+++ b/app/services/jobs/renewal-invitations/send-renewal-invitations.service.js
@@ -51,7 +51,7 @@ async function _notice(recipients) {
     name
   }
 
-  return CreateNoticeService.go(noticeType, recipients, 'water_abstractiondigital@environment-agency.gov.uk')
+  return CreateNoticeService.go(noticeData, recipients, 'water_abstractiondigital@environment-agency.gov.uk')
 }
 
 module.exports = {

--- a/app/services/jobs/renewal-invitations/send-renewal-invitations.service.js
+++ b/app/services/jobs/renewal-invitations/send-renewal-invitations.service.js
@@ -45,7 +45,7 @@ function _expiryDate(futureExpiredDate) {
 async function _notice(recipients) {
   const { name, prefix, subType } = NoticeTypes[NoticeType.INVITATIONS]
 
-  const noticeType = {
+  const noticeData = {
     referenceCode: generateNoticeReferenceCode(prefix),
     subType,
     name

--- a/app/services/jobs/renewal-invitations/send-renewal-invitations.service.js
+++ b/app/services/jobs/renewal-invitations/send-renewal-invitations.service.js
@@ -5,7 +5,10 @@
  * @module SendRenewalInvitations
  */
 
+const CreateNoticeService = require('../../notices/setup/create-notice.service.js')
 const FetchRenewalRecipients = require('./fetch-renewal-recipients.service.js')
+const { NoticeTypes, NoticeType } = require('../../../lib/static-lookups.lib.js')
+const { generateNoticeReferenceCode } = require('../../../lib/general.lib.js')
 
 /**
  * Orchestrates fetching, sending, and updating renewal invitations notifications
@@ -19,6 +22,8 @@ async function go(days) {
 
   const recipients = await FetchRenewalRecipients.go(expiryDate)
 
+  await _notice(recipients)
+
   return recipients
 }
 
@@ -30,11 +35,23 @@ async function go(days) {
 function _expiryDate(futureExpiredDate) {
   const targetDate = new Date()
 
-  targetDate.setDate(targetDate.getDate() + futureExpiredDate)
+  targetDate.setDate(targetDate.getDate() + Number(futureExpiredDate))
 
   targetDate.setHours(0, 0, 0, 0)
 
   return targetDate
+}
+
+async function _notice(recipients) {
+  const { name, prefix, subType } = NoticeTypes[NoticeType.INVITATIONS]
+
+  const data = {
+    referenceCode: generateNoticeReferenceCode(prefix),
+    subType,
+    name
+  }
+
+  return CreateNoticeService.go(data, recipients, 'water_abstractiondigital@environment-agency.gov.uk')
 }
 
 module.exports = {

--- a/app/services/jobs/renewal-invitations/send-renewal-invitations.service.js
+++ b/app/services/jobs/renewal-invitations/send-renewal-invitations.service.js
@@ -45,13 +45,13 @@ function _expiryDate(futureExpiredDate) {
 async function _notice(recipients) {
   const { name, prefix, subType } = NoticeTypes[NoticeType.INVITATIONS]
 
-  const data = {
+  const noticeType = {
     referenceCode: generateNoticeReferenceCode(prefix),
     subType,
     name
   }
 
-  return CreateNoticeService.go(data, recipients, 'water_abstractiondigital@environment-agency.gov.uk')
+  return CreateNoticeService.go(noticeType, recipients, 'water_abstractiondigital@environment-agency.gov.uk')
 }
 
 module.exports = {

--- a/app/services/notices/setup/create-notice.service.js
+++ b/app/services/notices/setup/create-notice.service.js
@@ -15,14 +15,14 @@ const { timestampForPostgres } = require('../../../lib/general.lib.js')
  * > Notices are event records with a type as `notification`. In the future we intend to move them to their own
  * > `water.notices` table. But for now this explains why the `EventModel` suddenly makes an appearance!
  *
- * @param {object} session - The session instance, or a session-like object with the expected notice data
+ * @param {object} noticeData - The notice data
  * @param {object[]} recipients - List of recipients, each containing details like email or address of the recipient
  * @param {string} issuer - The username of the person issuing the notice
  *
  * @returns {Promise<module:EventModel>} the new `EventModel` (Notice) instance
  */
-async function go(session, recipients, issuer) {
-  const notice = CreateNoticePresenter.go(session, recipients, issuer)
+async function go(noticeData, recipients, issuer) {
+  const notice = CreateNoticePresenter.go(noticeData, recipients, issuer)
   const timestamp = timestampForPostgres()
 
   return EventModel.query().insert({ ...notice, createdAt: timestamp, updatedAt: timestamp })

--- a/app/services/notices/setup/create-notice.service.js
+++ b/app/services/notices/setup/create-notice.service.js
@@ -15,7 +15,7 @@ const { timestampForPostgres } = require('../../../lib/general.lib.js')
  * > Notices are event records with a type as `notification`. In the future we intend to move them to their own
  * > `water.notices` table. But for now this explains why the `EventModel` suddenly makes an appearance!
  *
- * @param {SessionModel} session - The session instance
+ * @param {object} session - The session instance, or a session-like object with the expected notice data
  * @param {object[]} recipients - List of recipients, each containing details like email or address of the recipient
  * @param {string} issuer - The username of the person issuing the notice
  *

--- a/test/lib/static-lookups.lib.test.js
+++ b/test/lib/static-lookups.lib.test.js
@@ -42,7 +42,8 @@ describe('Static Lookups', () => {
         ALTERNATE_INVITATION: 'alternateInvitations',
         INVITATIONS: 'invitations',
         PAPER_RETURN: 'paperReturn',
-        REMINDERS: 'reminders'
+        REMINDERS: 'reminders',
+        RENEWAL_INVITATIONS: 'renewalInvitations'
       })
     })
 

--- a/test/presenters/notices/setup/create-notice.presenter.test.js
+++ b/test/presenters/notices/setup/create-notice.presenter.test.js
@@ -18,8 +18,8 @@ const CreateNoticePresenter = require('../../../../app/presenters/notices/setup/
 describe('Notices - Setup - Create Notice presenter', () => {
   const issuer = 'hello@world.com'
 
+  let noticeData
   let recipients
-  let session
 
   describe('when the journey is not for "alerts"', () => {
     beforeEach(() => {
@@ -33,7 +33,7 @@ describe('Notices - Setup - Create Notice presenter', () => {
         fixtureData.licenceHolderWithMultipleLicences
       ]
 
-      session = {
+      noticeData = {
         returnsPeriod: 'quarterFour',
         removeLicences: [],
         journey: 'invitations',
@@ -50,7 +50,7 @@ describe('Notices - Setup - Create Notice presenter', () => {
     })
 
     it('correctly presents the data', () => {
-      const result = CreateNoticePresenter.go(session, recipients, issuer)
+      const result = CreateNoticePresenter.go(noticeData, recipients, issuer)
 
       expect(result).to.equal({
         issuer: 'hello@world.com',
@@ -85,7 +85,7 @@ describe('Notices - Setup - Create Notice presenter', () => {
 
     describe('the "licences" property', () => {
       it('correctly return a JSON string containing an array of all licences from all recipients', () => {
-        const result = CreateNoticePresenter.go(session, recipients, issuer)
+        const result = CreateNoticePresenter.go(noticeData, recipients, issuer)
 
         expect(result.licences).to.equal([
           ...recipients[0].licence_refs,
@@ -100,7 +100,7 @@ describe('Notices - Setup - Create Notice presenter', () => {
     describe('the "metadata" property', () => {
       describe('the "name" property', () => {
         it('correctly returns the "name"', () => {
-          const result = CreateNoticePresenter.go(session, recipients, issuer)
+          const result = CreateNoticePresenter.go(noticeData, recipients, issuer)
 
           expect(result.metadata.name).to.equal('Returns: invitation')
         })
@@ -109,11 +109,11 @@ describe('Notices - Setup - Create Notice presenter', () => {
       describe('the "options.excludeLicences" property', () => {
         describe('when there licences excluded from the recipients list', () => {
           beforeEach(() => {
-            session.removeLicences = ['123', '456']
+            noticeData.removeLicences = ['123', '456']
           })
 
           it('correctly returns the exclude licences', () => {
-            const result = CreateNoticePresenter.go(session, recipients, issuer)
+            const result = CreateNoticePresenter.go(noticeData, recipients, issuer)
 
             expect(result.metadata.options.excludeLicences).to.equal(['123', '456'])
           })
@@ -121,11 +121,11 @@ describe('Notices - Setup - Create Notice presenter', () => {
 
         describe('when there are no licences excluded from the recipients list', () => {
           beforeEach(() => {
-            session.removeLicences = []
+            noticeData.removeLicences = []
           })
 
           it('correctly returns the exclude licences', () => {
-            const result = CreateNoticePresenter.go(session, recipients, issuer)
+            const result = CreateNoticePresenter.go(noticeData, recipients, issuer)
 
             expect(result.metadata.options.excludeLicences).to.equal([])
           })
@@ -134,11 +134,11 @@ describe('Notices - Setup - Create Notice presenter', () => {
 
       describe('the "recipients" property', () => {
         beforeEach(() => {
-          session.recipients = [...Object.values(recipients)]
+          noticeData.recipients = [...Object.values(recipients)]
         })
 
         it('correctly returns the length of recipients', () => {
-          const result = CreateNoticePresenter.go(session, recipients, issuer)
+          const result = CreateNoticePresenter.go(noticeData, recipients, issuer)
 
           expect(result.metadata.recipients).to.equal(5)
         })
@@ -147,7 +147,7 @@ describe('Notices - Setup - Create Notice presenter', () => {
       describe('the "returnCycle" property', () => {
         describe('when there are "determinedReturnsPeriod"', () => {
           beforeEach(() => {
-            session.determinedReturnsPeriod = {
+            noticeData.determinedReturnsPeriod = {
               dueDate: new Date(`2025-07-28`),
               endDate: new Date(`2025-06-30`),
               startDate: new Date(`2025-04-01`),
@@ -156,7 +156,7 @@ describe('Notices - Setup - Create Notice presenter', () => {
           })
 
           it('correctly returns the return cycle', () => {
-            const result = CreateNoticePresenter.go(session, recipients, issuer)
+            const result = CreateNoticePresenter.go(noticeData, recipients, issuer)
 
             expect(result.metadata.returnCycle).to.equal({
               dueDate: '2025-07-28',
@@ -169,11 +169,11 @@ describe('Notices - Setup - Create Notice presenter', () => {
 
         describe('when there are NO "determinedReturnsPeriod"', () => {
           beforeEach(() => {
-            delete session.determinedReturnsPeriod
+            delete noticeData.determinedReturnsPeriod
           })
 
           it('correctly returns the return cycle', () => {
-            const result = CreateNoticePresenter.go(session, recipients, issuer)
+            const result = CreateNoticePresenter.go(noticeData, recipients, issuer)
 
             expect(result.metadata.returnCycle).to.equal({
               dueDate: formatDateObjectToISO(futureDueDate()),
@@ -187,7 +187,7 @@ describe('Notices - Setup - Create Notice presenter', () => {
 
     describe('the "subType" property', () => {
       it('correctly returns the "subType"', () => {
-        const result = CreateNoticePresenter.go(session, recipients, issuer)
+        const result = CreateNoticePresenter.go(noticeData, recipients, issuer)
 
         expect(result.subtype).to.equal('returnInvitation')
       })
@@ -200,7 +200,7 @@ describe('Notices - Setup - Create Notice presenter', () => {
 
       recipients = [fixtureData.additionalContact, fixtureData.licenceHolder, fixtureData.primaryUser]
 
-      session = {
+      noticeData = {
         alertType: 'stop',
         journey: 'alerts',
         monitoringStationId: '123',
@@ -211,7 +211,7 @@ describe('Notices - Setup - Create Notice presenter', () => {
     })
 
     it('correctly presents the data', () => {
-      const result = CreateNoticePresenter.go(session, recipients, issuer)
+      const result = CreateNoticePresenter.go(noticeData, recipients, issuer)
 
       expect(result).to.equal({
         issuer: 'hello@world.com',
@@ -235,7 +235,7 @@ describe('Notices - Setup - Create Notice presenter', () => {
 
     describe('the "licences" property', () => {
       it('correctly return a JSON string containing an array of all licences from all recipients', () => {
-        const result = CreateNoticePresenter.go(session, recipients, issuer)
+        const result = CreateNoticePresenter.go(noticeData, recipients, issuer)
 
         expect(result.licences).to.equal([
           ...recipients[0].licence_refs,
@@ -248,7 +248,7 @@ describe('Notices - Setup - Create Notice presenter', () => {
     describe('the "metadata" property', () => {
       describe('the "name" property', () => {
         it('correctly returns the "name"', () => {
-          const result = CreateNoticePresenter.go(session, recipients, issuer)
+          const result = CreateNoticePresenter.go(noticeData, recipients, issuer)
 
           expect(result.metadata.name).to.equal('Water abstraction alert')
         })
@@ -256,11 +256,11 @@ describe('Notices - Setup - Create Notice presenter', () => {
 
       describe('the "recipients" property', () => {
         beforeEach(() => {
-          session.recipients = [...Object.values(recipients)]
+          noticeData.recipients = [...Object.values(recipients)]
         })
 
         it('correctly returns the length of recipients', () => {
-          const result = CreateNoticePresenter.go(session, recipients, issuer)
+          const result = CreateNoticePresenter.go(noticeData, recipients, issuer)
 
           expect(result.metadata.recipients).to.equal(3)
         })
@@ -268,8 +268,8 @@ describe('Notices - Setup - Create Notice presenter', () => {
 
       describe('the "options" property', () => {
         describe('the "sendingAlertType" property', () => {
-          it('return the sessions value', () => {
-            const result = CreateNoticePresenter.go(session, recipients, issuer)
+          it('return the noticeDatas value', () => {
+            const result = CreateNoticePresenter.go(noticeData, recipients, issuer)
 
             expect(result.metadata.options.sendingAlertType).to.equal('stop')
           })
@@ -277,7 +277,7 @@ describe('Notices - Setup - Create Notice presenter', () => {
 
         describe('the "monitoringStationId" property', () => {
           it('correctly returns the length of recipients', () => {
-            const result = CreateNoticePresenter.go(session, recipients, issuer)
+            const result = CreateNoticePresenter.go(noticeData, recipients, issuer)
 
             expect(result.metadata.options.monitoringStationId).to.equal('123')
           })
@@ -287,7 +287,7 @@ describe('Notices - Setup - Create Notice presenter', () => {
 
     describe('the "subType" property', () => {
       it('correctly returns the "subType"', () => {
-        const result = CreateNoticePresenter.go(session, recipients, issuer)
+        const result = CreateNoticePresenter.go(noticeData, recipients, issuer)
 
         expect(result.subtype).to.equal('waterAbstractionAlerts')
       })

--- a/test/services/jobs/renewal-invitations/process-renewal-invitations.service.test.js
+++ b/test/services/jobs/renewal-invitations/process-renewal-invitations.service.test.js
@@ -20,7 +20,7 @@ describe('Jobs - Renewal Invitations - Process Renewal Invitations service', () 
   let notifierStub
 
   beforeEach(() => {
-    Sinon.stub(SendRenewalInvitations, 'go').resolves([])
+    Sinon.stub(SendRenewalInvitations, 'go').resolves(['mock invitation'])
 
     // The service depends on GlobalNotifier to have been set. This happens in app/plugins/global-notifier.plugin.js
     // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
@@ -48,5 +48,6 @@ describe('Jobs - Renewal Invitations - Process Renewal Invitations service', () 
     expect(notifierStub.omg.calledWith('Renewal invitations status job complete')).to.be.true()
     expect(logDataArg.timeTakenMs).to.exist()
     expect(logDataArg.timeTakenSs).to.exist()
+    expect(logDataArg.count).to.equal(1)
   })
 })

--- a/test/services/jobs/renewal-invitations/send-renewal-invitations.service.test.js
+++ b/test/services/jobs/renewal-invitations/send-renewal-invitations.service.test.js
@@ -56,7 +56,7 @@ describe('Jobs - Renewal Invitations - Send Renewal Invitations service', () => 
 
       // Argument 1: Notice type
       expect(createNoticeStub.firstCall.args[0]).to.contain({
-        name: 'Invitations: renewal',
+        name: 'Renewals: invitation',
         subType: 'renewalInvitations'
       })
 

--- a/test/services/jobs/renewal-invitations/send-renewal-invitations.service.test.js
+++ b/test/services/jobs/renewal-invitations/send-renewal-invitations.service.test.js
@@ -8,7 +8,11 @@ const Sinon = require('sinon')
 const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
+// Test helpers
+const { generateLicenceRef } = require('../../../support/helpers/licence.helper.js')
+
 // Things we need to stub
+const CreateNoticeService = require('../../../../app/services/notices/setup/create-notice.service.js')
 const FetchRenewalRecipients = require('../../../../app/services/jobs/renewal-invitations/fetch-renewal-recipients.service.js')
 
 // Thing under test
@@ -16,13 +20,15 @@ const SendRenewalInvitations = require('../../../../app/services/jobs/renewal-in
 
 describe('Jobs - Renewal Invitations - Send Renewal Invitations service', () => {
   const days = 300
+  const recipients = [{ licenceRefs: generateLicenceRef() }]
 
   let clock
   let expiredDate
   let todayDate
 
   beforeEach(() => {
-    Sinon.stub(FetchRenewalRecipients, 'go').resolves([])
+    Sinon.stub(FetchRenewalRecipients, 'go').resolves(recipients)
+    Sinon.stub(CreateNoticeService, 'go').resolves()
 
     todayDate = new Date('2026-04-15')
 
@@ -41,7 +47,25 @@ describe('Jobs - Renewal Invitations - Send Renewal Invitations service', () => 
     it('returns the recipients', async () => {
       const result = await SendRenewalInvitations.go(days)
 
-      expect(result).to.equal([])
+      expect(result).to.equal(recipients)
+    })
+
+    it('creates a notice for invitations', async () => {
+      await SendRenewalInvitations.go(days)
+
+      const args = CreateNoticeService.go.getCall(0).args
+
+      // Argument 1: Notice type
+      const config = args[0]
+      expect(config.name).to.equal('Returns: invitation')
+      expect(config.subType).to.equal('returnInvitation')
+      expect(config.referenceCode).to.startWith('RINV-')
+
+      // Argument 2: The Recipients List
+      expect(args[1]).to.equal(recipients)
+
+      // Argument 3: The issuer email
+      expect(args[2]).to.equal('water_abstractiondigital@environment-agency.gov.uk')
     })
 
     describe('the "expiredDate"', () => {

--- a/test/services/jobs/renewal-invitations/send-renewal-invitations.service.test.js
+++ b/test/services/jobs/renewal-invitations/send-renewal-invitations.service.test.js
@@ -28,7 +28,7 @@ describe('Jobs - Renewal Invitations - Send Renewal Invitations service', () => 
 
   beforeEach(() => {
     Sinon.stub(FetchRenewalRecipients, 'go').resolves(recipients)
-    Sinon.stub(CreateNoticeService, 'go').resolves()
+    createNoticeStub = Sinon.stub(CreateNoticeService, 'go').resolves()
 
     todayDate = new Date('2026-04-15')
 
@@ -65,7 +65,18 @@ describe('Jobs - Renewal Invitations - Send Renewal Invitations service', () => 
       expect(args[1]).to.equal(recipients)
 
       // Argument 3: The issuer email
-      expect(args[2]).to.equal('water_abstractiondigital@environment-agency.gov.uk')
+      // Argument 1: Notice type
+      expect(createNoticeStub.firstCall.args[0]).to.equal({
+        name: 'Returns: invitation',
+        referenceCode: 'RINV-',
+        subType: 'returnInvitation'
+      })
+
+      // Argument 2: The Recipients List
+      expect(createNoticeStub.firstCall.args[1]).to.equal(recipients)
+
+      // Argument 3: The issuer email
+      expect(createNoticeStub.firstCall.args[2]).to.equal('water_abstractiondigital@environment-agency.gov.uk')
     })
 
     describe('the "expiredDate"', () => {

--- a/test/services/jobs/renewal-invitations/send-renewal-invitations.service.test.js
+++ b/test/services/jobs/renewal-invitations/send-renewal-invitations.service.test.js
@@ -23,6 +23,7 @@ describe('Jobs - Renewal Invitations - Send Renewal Invitations service', () => 
   const recipients = [{ licenceRefs: generateLicenceRef() }]
 
   let clock
+  let createNoticeStub
   let expiredDate
   let todayDate
 
@@ -55,22 +56,15 @@ describe('Jobs - Renewal Invitations - Send Renewal Invitations service', () => 
 
       const args = CreateNoticeService.go.getCall(0).args
 
-      // Argument 1: Notice type
-      const config = args[0]
-      expect(config.name).to.equal('Returns: invitation')
-      expect(config.subType).to.equal('returnInvitation')
-      expect(config.referenceCode).to.startWith('RINV-')
+      expect(args[0].referenceCode).to.startWith('RINV-')
 
-      // Argument 2: The Recipients List
-      expect(args[1]).to.equal(recipients)
-
-      // Argument 3: The issuer email
       // Argument 1: Notice type
-      expect(createNoticeStub.firstCall.args[0]).to.equal({
+      expect(createNoticeStub.firstCall.args[0]).to.contain({
         name: 'Returns: invitation',
-        referenceCode: 'RINV-',
         subType: 'returnInvitation'
       })
+
+      expect(createNoticeStub.firstCall.args[0].referenceCode).to.startWith('RINV-')
 
       // Argument 2: The Recipients List
       expect(createNoticeStub.firstCall.args[1]).to.equal(recipients)

--- a/test/services/jobs/renewal-invitations/send-renewal-invitations.service.test.js
+++ b/test/services/jobs/renewal-invitations/send-renewal-invitations.service.test.js
@@ -54,17 +54,13 @@ describe('Jobs - Renewal Invitations - Send Renewal Invitations service', () => 
     it('creates a notice for invitations', async () => {
       await SendRenewalInvitations.go(days)
 
-      const args = CreateNoticeService.go.getCall(0).args
-
-      expect(args[0].referenceCode).to.startWith('RINV-')
-
       // Argument 1: Notice type
       expect(createNoticeStub.firstCall.args[0]).to.contain({
-        name: 'Returns: invitation',
-        subType: 'returnInvitation'
+        name: 'Invitations: renewal',
+        subType: 'renewalInvitations'
       })
 
-      expect(createNoticeStub.firstCall.args[0].referenceCode).to.startWith('RINV-')
+      expect(createNoticeStub.firstCall.args[0].referenceCode).to.startWith('REIN-')
 
       // Argument 2: The Recipients List
       expect(createNoticeStub.firstCall.args[1]).to.equal(recipients)

--- a/test/services/notices/setup/create-notice.service.test.js
+++ b/test/services/notices/setup/create-notice.service.test.js
@@ -19,14 +19,14 @@ describe('Notices - Setup - Create Notice service', () => {
   const issuer = 'hello@world.com'
 
   let recipients
-  let session
+  let noticeData
 
   beforeEach(() => {
     const fixtureData = RecipientsFixture.recipients()
 
     recipients = [fixtureData.primaryUser, fixtureData.returnsUser]
 
-    session = {
+    noticeData = {
       returnsPeriod: 'quarterFour',
       removeLicences: [],
       journey: 'invitations',
@@ -43,7 +43,7 @@ describe('Notices - Setup - Create Notice service', () => {
   })
 
   it('creates the notice', async () => {
-    const result = await CreateNoticeService.go(session, recipients, issuer)
+    const result = await CreateNoticeService.go(noticeData, recipients, issuer)
 
     expect(result).to.be.instanceOf(EventModel)
     expect(result).equal(
@@ -62,7 +62,7 @@ describe('Notices - Setup - Create Notice service', () => {
           }
         },
         overallStatus: 'pending',
-        referenceCode: session.referenceCode,
+        referenceCode: noticeData.referenceCode,
         status: 'completed',
         statusCounts: { cancelled: 0, error: 0, pending: 2, returned: 0, sent: 0 },
         subtype: 'returnInvitation',


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5589

When sending a renewal invitations, we need to create a notice and send the notifications.

This change creates a notice, this will be an invitation notice type.

We also want to display the 'count' in the log we display when the job completes, this has also been added.

Sending notifications will be implemented in later changes.