### PR TITLE
Update renewal invitations notice type

### DIFF
--- a/app/lib/static-lookups.lib.js
+++ b/app/lib/static-lookups.lib.js
@@ -360,8 +360,8 @@ const NoticeTypes = Object.freeze({
   [NoticeType.RENEWAL_INVITATIONS]: {
     name: 'Renewals: invitation',
     prefix: 'REIN-',
-    subType: 'renewalInvitations',
-    notificationType: 'Renewal invitations'
+    subType: 'renewalInvitation',
+    notificationType: 'Renewals invitation'
   }
 })
 

--- a/test/services/jobs/renewal-invitations/send-renewal-invitations.service.test.js
+++ b/test/services/jobs/renewal-invitations/send-renewal-invitations.service.test.js
@@ -57,7 +57,7 @@ describe('Jobs - Renewal Invitations - Send Renewal Invitations service', () => 
       // Argument 1: Notice type
       expect(createNoticeStub.firstCall.args[0]).to.contain({
         name: 'Renewals: invitation',
-        subType: 'renewalInvitations'
+        subType: 'renewalInvitation'
       })
 
       expect(createNoticeStub.firstCall.args[0].referenceCode).to.startWith('REIN-')


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5589

This change makes the renewal invitations notice type consistent with the other notice types.