### PR TITLE
Fix not ignoring incomplete return reqs on submit

### DIFF
--- a/app/services/return-versions/setup/check/generate-return-version-requirements.service.js
+++ b/app/services/return-versions/setup/check/generate-return-version-requirements.service.js
@@ -22,6 +22,12 @@ async function go(licenceId, requirements) {
   const returnRequirements = []
 
   for (const requirement of requirements) {
+    // NOTE: We determine a requirement is complete because agreement exceptions is populated and it is the last step in
+    // the journey
+    if (!requirement.agreementsExceptions) {
+      continue
+    }
+
     const returnRequirementPurposes = await _generateReturnRequirementPurposes(licenceId, requirement.purposes)
 
     const returnRequirement = {

--- a/test/services/return-versions/setup/check/generate-return-version-requirements.service.test.js
+++ b/test/services/return-versions/setup/check/generate-return-version-requirements.service.test.js
@@ -43,6 +43,8 @@ describe('Return Versions - Setup - Generate Return Version Requirements service
         frequencyCollected: 'week',
         agreementsExceptions: ['none']
       },
+      // Invalid 1 - a return requirement because user clicked 'Add', but then immediately hit back
+      {},
       {
         points: ['30070341-ef94-4df8-87dd-31d51a046b8b', '916a1320-0f57-43b2-bddc-b609218abf1c'],
         purposes: [
@@ -73,6 +75,17 @@ describe('Return Versions - Setup - Generate Return Version Requirements service
           'two-part-tariff',
           '56-returns-exception'
         ]
+      },
+      // Invalid 2 - a return requirement because user clicked 'Add', but then clicked back from the 'Enter abstraction'
+      // page
+      {
+        purposes: [
+          {
+            id: 'ff7cecd5-96ef-4625-b232-54ef7e50ab8e',
+            alias: ''
+          }
+        ],
+        points: ['796f83bb-d50d-446f-bc47-28daff6bcb78']
       }
     ]
 
@@ -162,7 +175,7 @@ describe('Return Versions - Setup - Generate Return Version Requirements service
       ])
 
       // Because the two session data requirements share the same purpose, but the second has an additional one, we
-      // expect the FetchOtherPurposeIdsService to be called three times - once for each purpose
+      // expect the FetchOtherPurposeIdsService to be called three times - once for each 'valid' purpose
       expect(fetchOtherPurposeIdsStub.callCount).to.equal(3)
       expect(fetchOtherPurposeIdsStub.getCall(0).args).to.equal([licenceId, 'ff7cecd5-96ef-4625-b232-54ef7e50ab8e'])
       expect(fetchOtherPurposeIdsStub.getCall(1).args).to.equal([licenceId, 'ff7cecd5-96ef-4625-b232-54ef7e50ab8e'])


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5536

A while ago, it was reported that a user encountered an error when submitting a return version. When we tried in non-prod with the same licence, it worked. When we retried in production, it worked as well.

We could see that an error had been thrown, but it stated that the new return version was missing data. We could see the licence data was fine, and when running through the journey with the same data, it was all there.

The one issue we did see was after the fact. _If_ an error is thrown, it leaves things in an incomplete state. The existing return version history was being updated, but no new return version was created, nor were the return logs processed.

We flagged it as a blip and added a TODO to wrap the creation in a transaction.

It then got reported again. And again, we saw no obvious issue with the licence or with the return requirement data being submitted. But we got cracking on [Wrapping the return version submission in a transaction](https://github.com/DEFRA/water-abstraction-system/pull/3245).

Our QA team then regression-tested the logic to make sure our wrapping hadn't caused a problem, and they found one.

They were editing all existing return requirements (copied either from abstraction data or from an existing requirement) and adding new ones. When they hit submit, they got an error about missing data. And again, the reported missing data was inconsistent.

We tried to recreate it locally and in the same non-prod environments, but failed to. So, we then tracked down the log entries from the QA attempt, and that is when we spotted it: incomplete or empty return requirements in the session!

So, we then tested the QA team!

We asked them to retry one that had failed before. Now it worked. We then asked them to try a new licence they had not tested before, which is when we observed the behaviour causing the error.

When they added new return requirements, it was to duplicate one of the existing ones. Because it was a new test, they did not have the existing ones' setups to hand. So, after hitting **Add return requirement**, they _went back_ to `/check`, having not completed the setup, to retrieve some information.

As soon as they did this, we knew the submission would fail. Depending on where they were when adding a new return requirement, the missing data message we would see in the logs would differ.

We _strongly_ suspect this is what users who encountered an error in production were doing: going back to the `/check` page from the 'add return requirement' sub-journey.

We did know this could happen. We have logic on the `/check` page to ensure that we don't display incomplete return requirements. But somewhere along the way, we have stopped checking for them when submitting.

This fix ensures incomplete return requirements are ignored when submitting a new return version.