### PR TITLE
Simplify titles in view internal user pages

### DIFF
--- a/app/presenters/users/internal/communications.presenter.js
+++ b/app/presenters/users/internal/communications.presenter.js
@@ -24,8 +24,8 @@ function go(user, notifications) {
       text: 'Go back to users'
     },
     notifications: NotificationsTablePresenter.go(notifications, id),
-    pageTitle: `Communications for ${username}`,
-    pageTitleCaption: 'Internal'
+    pageTitle: 'Communications',
+    pageTitleCaption: username
   }
 }
 

--- a/app/presenters/users/internal/details.presenter.js
+++ b/app/presenters/users/internal/details.presenter.js
@@ -24,8 +24,8 @@ function go(user) {
     },
     id,
     lastSignedIn: _lastSignedIn(user),
-    pageTitle: `User details for ${username}`,
-    pageTitleCaption: 'Internal',
+    pageTitle: 'User details',
+    pageTitleCaption: username,
     permissions: user.$permissions().label,
     roles: _roles(user),
     status: user.$status()

--- a/test/presenters/users/internal/communications.presenter.test.js
+++ b/test/presenters/users/internal/communications.presenter.test.js
@@ -44,8 +44,8 @@ describe('Users - Internal - Communications presenter', () => {
           status: 'sent'
         }
       ],
-      pageTitle: `Communications for ${user.username}`,
-      pageTitleCaption: 'Internal'
+      pageTitle: 'Communications',
+      pageTitleCaption: user.username
     })
   })
 })

--- a/test/presenters/users/internal/details.presenter.test.js
+++ b/test/presenters/users/internal/details.presenter.test.js
@@ -30,8 +30,8 @@ describe('Users - Internal - Details Presenter', () => {
       },
       id: user.id,
       lastSignedIn: '6 October 2022 at 10:00:00',
-      pageTitle: 'User details for basic.access@wrls.gov.uk',
-      pageTitleCaption: 'Internal',
+      pageTitle: 'User details',
+      pageTitleCaption: user.username,
       permissions: 'Basic access',
       roles: [],
       status: 'enabled'

--- a/test/services/users/internal/view-communications.service.test.js
+++ b/test/services/users/internal/view-communications.service.test.js
@@ -57,8 +57,8 @@ describe('Users - Internal - View Communications Service', () => {
           text: 'Go back to users'
         },
         notifications: [],
-        pageTitle: `Communications for ${user.username}`,
-        pageTitleCaption: 'Internal'
+        pageTitle: 'Communications',
+        pageTitleCaption: user.username
       })
     })
   })

--- a/test/services/users/internal/view-details.service.test.js
+++ b/test/services/users/internal/view-details.service.test.js
@@ -43,8 +43,8 @@ describe('Users - Internal - View Details service', () => {
         },
         id: user.id,
         lastSignedIn: '6 October 2022 at 10:00:00',
-        pageTitle: 'User details for basic.access@wrls.gov.uk',
-        pageTitleCaption: 'Internal',
+        pageTitle: 'User details',
+        pageTitleCaption: user.username,
         permissions: 'Basic access',
         roles: [],
         status: 'enabled'


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5616

Unfortunately, '@environment-agency.gov.uk' is already a long email tail. Add people's names to it, and it can make for a lengthy string!

This means the page title can get lost. We think that, thanks to the changes we've made, it is pretty clear whether you are viewing an internal or external user page.

So, we can simplify the titles by moving the username into the page title caption instead. This also makes it consistent with what we do in the view return log pages.