### PR TITLE
Hide the Edit button for disabled internal users

### DIFF
--- a/app/views/users/internal/details.njk
+++ b/app/views/users/internal/details.njk
@@ -24,11 +24,13 @@
     ]
   }) }}
 
-  <form method="post">
-    <input type="hidden" name="wrlsCrumb" value="{{wrlsCrumb}}"/>
+  {% if status !== 'disabled' %}
+    <form method="post">
+      <input type="hidden" name="wrlsCrumb" value="{{wrlsCrumb}}"/>
 
-    {{ govukButton({ text: "Edit", preventDoubleClick: true }) }}
-  </form>
+      {{ govukButton({ text: "Edit", preventDoubleClick: true }) }}
+    </form>
+  {% endif %}
 
   <h3 class="govuk-heading-m">Roles</h3>
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5616

We have migrated the view internal user page, but have not yet completed the migration of editing a user. So, the legacy service still needs to handle that.

But when an edit is complete, we need to return the user to our new page, not the legacy view internal user page.

We [updated water-abstraction-ui to do this](https://github.com/DEFRA/water-abstraction-ui/pull/2817), but when testing, realised that if a user is disabled, the legacy UI does not allow any further changes.

We do intend to allow further changes, for example, re-enabling a user. But until we control user management, there is no point in showing the edit button for`DISABLED` users, as clicking it takes you to a legacy page that allows no changes.