### PR TITLE
Move licences to split page from view ext. user

### DIFF
--- a/app/controllers/users.controller.js
+++ b/app/controllers/users.controller.js
@@ -10,6 +10,7 @@ const IndexUsersService = require('../services/users/index-users.service.js')
 const SubmitIndexUsersService = require('../services/users/submit-index-users.service.js')
 const SubmitProfileDetailsService = require('../services/users/submit-profile-details.service.js')
 const ViewExternalDetailsService = require('../services/users/external/view-details.service.js')
+const ViewExternalLicencesService = require('../services/users/external/view-licences.service.js')
 const ViewExternalVerificationsService = require('../services/users/external/view-verifications.service.js')
 const ViewInternalCommunicationsService = require('../services/users/internal/view-communications.service.js')
 const ViewInternalDetailsService = require('../services/users/internal/view-details.service.js')
@@ -88,6 +89,18 @@ async function viewExternalDetails(request, h) {
   return h.view('users/external/details.njk', pageData)
 }
 
+async function viewExternalLicences(request, h) {
+  const {
+    auth,
+    params: { id },
+    query: { back, page }
+  } = request
+
+  const pageData = await ViewExternalLicencesService.go(id, auth, page, back)
+
+  return h.view('users/external/licences.njk', pageData)
+}
+
 async function viewExternalVerifications(request, h) {
   const {
     auth,
@@ -157,6 +170,7 @@ module.exports = {
   submitProfileDetails,
   submitInternalDetails,
   viewExternalDetails,
+  viewExternalLicences,
   viewExternalVerifications,
   viewNotification,
   viewProfileDetails,

--- a/app/controllers/users.controller.js
+++ b/app/controllers/users.controller.js
@@ -31,7 +31,7 @@ async function index(request, h) {
   return h.view('users/index.njk', pageData)
 }
 
-async function submitExternalDetails(request, h) {
+async function submitExternalLicences(request, h) {
   const { id } = request.params
 
   return _redirectToLegacy(id, h)
@@ -165,7 +165,7 @@ async function _redirectToLegacy(id, h) {
 
 module.exports = {
   index,
-  submitExternalDetails,
+  submitExternalLicences,
   submitIndex,
   submitProfileDetails,
   submitInternalDetails,

--- a/app/dal/users/external/fetch-licences.dal.js
+++ b/app/dal/users/external/fetch-licences.dal.js
@@ -1,22 +1,31 @@
 'use strict'
 
 /**
- * Fetches licences linked to a user for display on the `/users/external/{id}/details` page
+ * Fetches licences linked to a user for display on the `/users/external/{id}/licences` page
  * @module FetchLicencesDal
  */
 
 const LicenceModel = require('../../../models/licence.model.js')
 
+const DatabaseConfig = require('../../../../config/database.config.js')
+
 /**
- * Fetches licences linked to a user for display on the `/users/external/{id}/details` page
+ * Fetches licences linked to a user for display on the `/users/external/{id}/licences` page
  *
  * This includes their related roles and current licence holder, so we can display these alongside the licence.
  *
  * @param {number} licenceEntityId - The licence entity ID of the requested user
+ * @param {string} [page=1] - The current page for the pagination service
  *
  * @returns {Promise<module:LicenceModel[]>} the requested user licences
  */
-async function go(licenceEntityId) {
+async function go(licenceEntityId, page = '1') {
+  const { results: licences, total: totalNumber } = await _fetch(licenceEntityId, page)
+
+  return { licences, totalNumber }
+}
+
+async function _fetch(licenceEntityId, page) {
   return LicenceModel.query()
     .select([
       'licences.expiredDate',
@@ -40,6 +49,7 @@ async function go(licenceEntityId) {
       [licenceEntityId]
     )
     .orderBy('licences.licenceRef', 'asc')
+    .page(Number(page) - 1, DatabaseConfig.defaultPageSize)
     .withGraphFetched('licenceVersions')
     .modifyGraph('licenceVersions', (licenceVersionsBuilder) => {
       licenceVersionsBuilder

--- a/app/dal/users/external/fetch-verifications.dal.js
+++ b/app/dal/users/external/fetch-verifications.dal.js
@@ -6,6 +6,7 @@
  */
 
 const UserVerificationModel = require('../../../models/user-verification.model.js')
+
 const DatabaseConfig = require('../../../../config/database.config.js')
 
 /**

--- a/app/presenters/users/external/details.presenter.js
+++ b/app/presenters/users/external/details.presenter.js
@@ -7,7 +7,6 @@
 
 const { formatLongDateTime } = require('../../base.presenter.js')
 const { sourceNavigation } = require('../base-users.presenter.js')
-const { today } = require('../../../lib/general.lib.js')
 
 const EXTERNAL_ROLES = {
   primary_user: {
@@ -25,21 +24,14 @@ const EXTERNAL_ROLES = {
  *
  * @param {module:UserModel} user - The user, including their related companies and the licence document headers that
  * are attached to those companies
- * @param {module:LicenceModel[]} licences - The licences linked to the user, including their related roles and current
- * licence
  * @param {string[]} viewingUserScope - The 'scope' taken off the `request.auth` object passed to the
  * `ViewDetailsService`
  * @param {string} back - The 'back' query parameter, used to indicate what back link should be shown on the page
  *
  * @returns {object} The data formatted for the view template
  */
-function go(user, licences, viewingUserScope, back) {
+function go(user, viewingUserScope, back) {
   const permissions = user.$permissions()
-
-  const formattedLicences = _userLicences(licences)
-  const displayLicenceEndedMessage = formattedLicences.some((formattedLicence) => {
-    return formattedLicence.status
-  })
 
   const canManageAccounts = viewingUserScope.includes('manage_accounts')
   const sourceNavigationDetails = sourceNavigation(back, canManageAccounts)
@@ -48,62 +40,13 @@ function go(user, licences, viewingUserScope, back) {
     activeNavBar: sourceNavigationDetails.activeNavBar,
     backLink: sourceNavigationDetails.backLink,
     backQueryString: sourceNavigationDetails.backQueryString,
-    displayLicenceEndedMessage,
     lastSignedIn: _lastSignedIn(user),
-    licences: formattedLicences,
     pageTitle: 'User details',
     pageTitleCaption: user.username,
     permissions: permissions.label,
     roles: _roles(permissions),
-    showEditButton: canManageAccounts,
     status: user.$status()
   }
-}
-
-function _userLicences(licences) {
-  return licences.map((licence) => {
-    const { id, licenceRef, licenceVersions } = licence
-    const licenceEndDetails = licence.$ends()
-
-    return {
-      currentLicenceHolder: licenceVersions[0].licenceVersionHolder.derivedName,
-      id,
-      licenceLink: `/system/licences/${id}/summary`,
-      licenceRef,
-      permissions: _licencePermissions(licence),
-      status: _status(licenceEndDetails)
-    }
-  })
-}
-
-function _licencePermissions(licence) {
-  const { licenceEntityRoles } = licence.licenceDocumentHeader
-
-  let role = licenceEntityRoles.some((licenceEntityRole) => {
-    return licenceEntityRole.role === 'primary_user'
-  })
-
-  if (role) {
-    return 'Primary user'
-  }
-
-  role = licenceEntityRoles.some((licenceEntityRole) => {
-    return licenceEntityRole.role === 'user_returns'
-  })
-
-  if (role) {
-    return 'Returns user'
-  }
-
-  return 'Basic access'
-}
-
-function _status(licenceEndDetails) {
-  if (licenceEndDetails && licenceEndDetails.date <= today()) {
-    return licenceEndDetails.reason
-  }
-
-  return null
 }
 
 function _roles(permissions) {

--- a/app/presenters/users/external/licences.presenter.js
+++ b/app/presenters/users/external/licences.presenter.js
@@ -51,8 +51,8 @@ function _userLicences(licences) {
     return {
       currentLicenceHolder: licenceVersions[0].licenceVersionHolder.derivedName,
       id,
-      licenceLink: `/system/licences/${id}/summary`,
       licenceRef,
+      link: `/system/licences/${id}/summary`,
       permissions: _licencePermissions(licence),
       status: _status(licenceEndDetails)
     }

--- a/app/presenters/users/external/licences.presenter.js
+++ b/app/presenters/users/external/licences.presenter.js
@@ -1,0 +1,94 @@
+'use strict'
+
+/**
+ * Formats data for external users on the `/users/external/{id}/licences` page
+ * @module LicencesPresenter
+ */
+
+const { sourceNavigation } = require('../base-users.presenter.js')
+const { today } = require('../../../lib/general.lib.js')
+
+/**
+ * Formats data for external users on the `/users/external/{id}/licences` page
+ *
+ * @param {module:UserModel} user - The user and associated details
+ * @param {module:LicenceModel[]} licences - All licences linked to the user
+ * @param {string[]} viewingUserScope - The 'scope' taken off the `request.auth` object passed to the
+ * `ViewVerificationsService`
+ * @param {string} back - The 'back' query parameter, used to indicate what back link should be shown on the page
+ *
+ * @returns {object} The data formatted for the view template
+ */
+function go(user, licences, viewingUserScope, back) {
+  const { username } = user
+
+  const formattedLicences = _userLicences(licences)
+
+  const displayLicenceEndedMessage = formattedLicences.some((formattedLicence) => {
+    return formattedLicence.status
+  })
+
+  const canManageAccounts = viewingUserScope.includes('manage_accounts')
+  const sourceNavigationDetails = sourceNavigation(back, canManageAccounts)
+
+  return {
+    activeNavBar: sourceNavigationDetails.activeNavBar,
+    backLink: sourceNavigationDetails.backLink,
+    backQueryString: sourceNavigationDetails.backQueryString,
+    displayLicenceEndedMessage,
+    licences: formattedLicences,
+    pageTitle: 'Licences',
+    pageTitleCaption: username,
+    showUnlinkButton: canManageAccounts
+  }
+}
+
+function _userLicences(licences) {
+  return licences.map((licence) => {
+    const { id, licenceRef, licenceVersions } = licence
+    const licenceEndDetails = licence.$ends()
+
+    return {
+      currentLicenceHolder: licenceVersions[0].licenceVersionHolder.derivedName,
+      id,
+      licenceLink: `/system/licences/${id}/summary`,
+      licenceRef,
+      permissions: _licencePermissions(licence),
+      status: _status(licenceEndDetails)
+    }
+  })
+}
+
+function _licencePermissions(licence) {
+  const { licenceEntityRoles } = licence.licenceDocumentHeader
+
+  let role = licenceEntityRoles.some((licenceEntityRole) => {
+    return licenceEntityRole.role === 'primary_user'
+  })
+
+  if (role) {
+    return 'Primary user'
+  }
+
+  role = licenceEntityRoles.some((licenceEntityRole) => {
+    return licenceEntityRole.role === 'user_returns'
+  })
+
+  if (role) {
+    return 'Returns user'
+  }
+
+  return 'Basic access'
+}
+
+function _status(licenceEndDetails) {
+  if (licenceEndDetails && licenceEndDetails.date <= today()) {
+    return licenceEndDetails.reason
+  }
+
+  return null
+}
+
+module.exports = {
+  go
+}

--- a/app/routes/users.routes.js
+++ b/app/routes/users.routes.js
@@ -35,17 +35,17 @@ const routes = [
     }
   },
   {
-    method: 'POST',
-    path: '/users/external/{id}/details',
-    options: {
-      handler: UsersController.submitExternalDetails
-    }
-  },
-  {
     method: 'GET',
     path: '/users/external/{id}/licences',
     options: {
       handler: UsersController.viewExternalLicences
+    }
+  },
+  {
+    method: 'POST',
+    path: '/users/external/{id}/licences',
+    options: {
+      handler: UsersController.submitExternalLicences
     }
   },
   {

--- a/app/routes/users.routes.js
+++ b/app/routes/users.routes.js
@@ -43,6 +43,13 @@ const routes = [
   },
   {
     method: 'GET',
+    path: '/users/external/{id}/licences',
+    options: {
+      handler: UsersController.viewExternalLicences
+    }
+  },
+  {
+    method: 'GET',
     path: '/users/external/{id}/verifications',
     options: {
       handler: UsersController.viewExternalVerifications

--- a/app/services/users/external/view-details.service.js
+++ b/app/services/users/external/view-details.service.js
@@ -5,7 +5,6 @@
  * @module ViewDetailsService
  */
 
-const FetchLicencesDal = require('../../../dal/users/external/fetch-licences.dal.js')
 const FetchUserDetailsDal = require('../../../dal/users/external/fetch-user-details.dal.js')
 const DetailsPresenter = require('../../../presenters/users/external/details.presenter.js')
 
@@ -21,13 +20,7 @@ const DetailsPresenter = require('../../../presenters/users/external/details.pre
 async function go(id, auth, back = 'users') {
   const user = await FetchUserDetailsDal.go(id)
 
-  let licences = []
-
-  if (user.licenceEntity) {
-    licences = await FetchLicencesDal.go(user.licenceEntity.id)
-  }
-
-  const pageData = DetailsPresenter.go(user, licences, auth.credentials.scope, back)
+  const pageData = DetailsPresenter.go(user, auth.credentials.scope, back)
 
   return {
     activeSecondaryNav: 'details',

--- a/app/services/users/external/view-licences.service.js
+++ b/app/services/users/external/view-licences.service.js
@@ -1,0 +1,48 @@
+'use strict'
+
+/**
+ * Orchestrates fetching and presenting external user data for `/users/external/{id}/licences` page
+ * @module ViewLicencesService
+ */
+
+const FetchLicencesDal = require('../../../dal/users/external/fetch-licences.dal.js')
+const FetchUserDal = require('../../../dal/users/fetch-user.dal.js')
+const PaginatorPresenter = require('../../../presenters/paginator.presenter.js')
+const LicencesPresenter = require('../../../presenters/users/external/licences.presenter.js')
+
+/**
+ * Orchestrates fetching and presenting external user data for `/users/external/{id}/licences` page
+ *
+ * @param {number} id - The user's ID
+ * @param {object} auth - The auth object taken from `request.auth` containing user details
+ * @param {string} page - The current page for the pagination service
+ * @param {string} back - The 'back' query parameter, used to indicate what back link should be shown on the page
+ *
+ * @returns {Promise<object>} The view data for the external user page
+ */
+async function go(id, auth, page, back = 'users') {
+  const user = await FetchUserDal.go(id)
+
+  const { licences, totalNumber } = await FetchLicencesDal.go(user.licenceEntityId, page)
+
+  const pageData = LicencesPresenter.go(user, licences, auth.credentials.scope, back)
+
+  const pagination = PaginatorPresenter.go(
+    totalNumber,
+    page,
+    `/system/users/external/${id}/licences`,
+    licences.length,
+    'licences',
+    { back }
+  )
+
+  return {
+    activeSecondaryNav: 'licences',
+    pagination,
+    ...pageData
+  }
+}
+
+module.exports = {
+  go
+}

--- a/app/services/users/external/view-licences.service.js
+++ b/app/services/users/external/view-licences.service.js
@@ -7,8 +7,8 @@
 
 const FetchLicencesDal = require('../../../dal/users/external/fetch-licences.dal.js')
 const FetchUserDal = require('../../../dal/users/fetch-user.dal.js')
-const PaginatorPresenter = require('../../../presenters/paginator.presenter.js')
 const LicencesPresenter = require('../../../presenters/users/external/licences.presenter.js')
+const PaginatorPresenter = require('../../../presenters/paginator.presenter.js')
 
 /**
  * Orchestrates fetching and presenting external user data for `/users/external/{id}/licences` page

--- a/app/views/layout-users-external.njk
+++ b/app/views/layout-users-external.njk
@@ -19,6 +19,14 @@
         </li>
 
         <li
+          class="x-govuk-sub-navigation__section-item {% if activeSecondaryNav === 'licences' %}x-govuk-sub-navigation__section-item--current{% endif %}">
+            <a class="x-govuk-sub-navigation__link" href="licences{{ backQueryString }}"
+              {% if activeSecondaryNav === 'licences' %}aria-current="page"{% endif %}>
+            Licences
+          </a>
+        </li>
+
+        <li
           class="x-govuk-sub-navigation__section-item {% if activeSecondaryNav === 'verifications' %}x-govuk-sub-navigation__section-item--current{% endif %}">
             <a class="x-govuk-sub-navigation__link" href="verifications{{ backQueryString }}"
               {% if activeSecondaryNav === 'verifications' %}aria-current="page"{% endif %}>

--- a/app/views/users/external/details.njk
+++ b/app/views/users/external/details.njk
@@ -1,11 +1,9 @@
 {% extends 'layout-users-external.njk' %}
 
 {% from "govuk/components/button/macro.njk" import govukButton %}
-{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
 
-{% from "macros/licence-status-tag.njk" import statusTag as licenceStatusTag %}
 {% from "macros/user-status-tag.njk" import statusTag as userStatusTag %}
 
 {% block pageContent %}
@@ -68,69 +66,6 @@
         },
         {
           text: "Description"
-        }
-      ],
-      rows: rows
-    }) }}
-  {% endif %}
-
-  <h3 class="govuk-heading-m">Licences</h3>
-  {% if licences.length === 0 %}
-    <p data-test='no-licences-msg'>No licences found.</p>
-  {% else %}
-    {% set rows = [] %}
-
-    {% for licence in licences %}
-      {% set rowIndex = loop.index0 %}
-      {% set tableRow = []%}
-
-      {% set licenceLink %}
-        <a class="govuk-link" href="{{ licence.link }}">{{ licence.licenceRef }}</a>
-      {% endset %}
-
-      {% set row = [
-        {
-          attributes: { 'data-test': 'licence-name-' + rowIndex },
-          html: licenceLink
-        },
-        {
-          attributes: { 'data-test': 'licence-status-' + rowIndex },
-          html: licenceStatusTag(licence.status, true)
-        },
-        {
-          attributes: { 'data-test': 'licence-current-licence-holder-' + rowIndex },
-          text: licence.currentLicenceHolder
-        },
-        {
-          attributes: { 'data-test': 'licence-permissions-' + rowIndex },
-          text: licence.permissions
-        }
-      ] %}
-
-      {% set rows = (rows.push(row), rows) %}
-    {% endfor %}
-
-    {% if displayLicenceEndedMessage %}
-      {{ govukInsetText({
-        text: 'Licences that have ended will not be visible to the user.'
-      }) }}
-    {% endif %}
-
-    {{ govukTable({
-      attributes: { 'data-test': 'licences-table' },
-      firstCellIsHeader: false,
-      head: [
-        {
-          text: "Licence"
-        },
-        {
-          text: "Status"
-        },
-        {
-          text: "Current licence holder"
-        },
-        {
-          text: "Permissions"
         }
       ],
       rows: rows

--- a/app/views/users/external/licences.njk
+++ b/app/views/users/external/licences.njk
@@ -1,0 +1,85 @@
+{% extends 'layout-users-external.njk' %}
+
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+{% from "govuk/components/pagination/macro.njk" import govukPagination %}
+{% from "govuk/components/table/macro.njk" import govukTable %}
+
+{% from "macros/licence-status-tag.njk" import statusTag as licenceStatusTag %}
+
+{% block pageContent %}
+  {% if licences.length === 0 %}
+    <p data-test='no-licences-msg'>This user has no linked licences.</p>
+  {% else %}
+    {% set rows = [] %}
+
+    {% for licence in licences %}
+      {% set rowIndex = loop.index0 %}
+      {% set tableRow = []%}
+
+      {% set licenceLink %}
+        <a class="govuk-link" href="{{ licence.link }}">{{ licence.licenceRef }}</a>
+      {% endset %}
+
+      {% set row = [
+        {
+          attributes: { 'data-test': 'licence-name-' + rowIndex },
+          html: licenceLink
+        },
+        {
+          attributes: { 'data-test': 'licence-status-' + rowIndex },
+          html: licenceStatusTag(licence.status, true)
+        },
+        {
+          attributes: { 'data-test': 'licence-current-licence-holder-' + rowIndex },
+          text: licence.currentLicenceHolder
+        },
+        {
+          attributes: { 'data-test': 'licence-permissions-' + rowIndex },
+          text: licence.permissions
+        }
+      ] %}
+
+      {% set rows = (rows.push(row), rows) %}
+    {% endfor %}
+
+    {% if displayLicenceEndedMessage %}
+      {{ govukInsetText({
+        text: 'Licences that have ended will not be visible to the user.'
+      }) }}
+    {% endif %}
+
+    {% if showUnlinkButton %}
+    <form method="post">
+      <input type="hidden" name="wrlsCrumb" value="{{wrlsCrumb}}"/>
+
+      {{ govukButton({ text: "Unlink licences", preventDoubleClick: true }) }}
+    </form>
+  {% endif %}
+
+    {{ govukTable({
+      attributes: { 'data-test': 'licences-table' },
+      caption: pagination.showingMessage,
+      firstCellIsHeader: false,
+      head: [
+        {
+          text: "Licence"
+        },
+        {
+          text: "Status"
+        },
+        {
+          text: "Current licence holder"
+        },
+        {
+          text: "Permissions"
+        }
+      ],
+      rows: rows
+    }) }}
+
+    {% if pagination.numberOfPages > 1 %}
+      {{ govukPagination(pagination.component) }}
+    {% endif %}
+  {% endif %}
+{% endblock %}

--- a/app/views/users/external/verifications.njk
+++ b/app/views/users/external/verifications.njk
@@ -5,7 +5,7 @@
 
 {% block pageContent %}
   {% if verifications.length === 0 %}
-    <p data-test='no-licences-msg'>This user has no associated verifications.</p>
+    <p data-test='no-verifications-msg'>This user has no associated verifications.</p>
   {% else %}
     {% set rows = [] %}
 

--- a/test/controllers/users.controller.test.js
+++ b/test/controllers/users.controller.test.js
@@ -20,6 +20,7 @@ const IndexUsersService = require('../../app/services/users/index-users.service.
 const SubmitIndexUsersService = require('../../app/services/users/submit-index-users.service.js')
 const SubmitProfileDetailsService = require('../../app/services/users/submit-profile-details.service.js')
 const ViewExternalDetailsService = require('../../app/services/users/external/view-details.service.js')
+const ViewExternalLicencesService = require('../../app/services/users/external/view-licences.service.js')
 const ViewExternalVerificationsService = require('../../app/services/users/external/view-verifications.service.js')
 const ViewInternalCommunicationsService = require('../../app/services/users/internal/view-communications.service.js')
 const ViewInternalDetailsService = require('../../app/services/users/internal/view-details.service.js')
@@ -212,6 +213,42 @@ describe('Users controller', () => {
           expect(response.statusCode).to.equal(HTTP_STATUS_FOUND)
           expect(response.headers.location).to.equal(`/user/456/status`)
         })
+      })
+    })
+  })
+
+  describe('/users/external/{id}/licences', () => {
+    describe('GET', () => {
+      beforeEach(async () => {
+        id = generateUUID()
+        options = _getOptions(`/users/external/${id}/licences`, { scope: [], user: { id } })
+
+        Sinon.stub(ViewExternalLicencesService, 'go').resolves({
+          activeNavBar: 'users',
+          activeSecondaryNav: 'licences',
+          pagination: {
+            currentPageNumber: 1,
+            numberOfPages: 0,
+            showingMessage: 'Showing all 0 licences'
+          },
+          backLink: {
+            href: '/system/users',
+            text: 'Go back to users'
+          },
+          backQueryString: '?back=users',
+          displayLicenceEndedMessage: false,
+          pageTitle: 'Licences',
+          pageTitleCaption: 'external@example.co.uk',
+          licences: [],
+          showUnlinkButton: true
+        })
+      })
+
+      it('returns the external user page successfully', async () => {
+        const response = await server.inject(options)
+
+        expect(response.statusCode).to.equal(HTTP_STATUS_OK)
+        expect(response.payload).to.contain('Licences')
       })
     })
   })

--- a/test/controllers/users.controller.test.js
+++ b/test/controllers/users.controller.test.js
@@ -192,26 +192,6 @@ describe('Users controller', () => {
         expect(response.payload).to.contain('User details')
       })
     })
-
-    describe('POST', () => {
-      beforeEach(() => {
-        id = generateUUID()
-        postOptions = postRequestOptions(`/users/external/${id}/details`, {})
-      })
-
-      describe('when the request succeeds', () => {
-        beforeEach(() => {
-          Sinon.stub(FetchLegacyIdDal, 'go').returns(456)
-        })
-
-        it('redirects to the legacy user page', async () => {
-          const response = await server.inject(postOptions)
-
-          expect(response.statusCode).to.equal(HTTP_STATUS_FOUND)
-          expect(response.headers.location).to.equal(`/user/456/status`)
-        })
-      })
-    })
   })
 
   describe('/users/external/{id}/licences', () => {
@@ -246,6 +226,26 @@ describe('Users controller', () => {
 
         expect(response.statusCode).to.equal(HTTP_STATUS_OK)
         expect(response.payload).to.contain('Licences')
+      })
+    })
+
+    describe('POST', () => {
+      beforeEach(() => {
+        id = generateUUID()
+        postOptions = postRequestOptions(`/users/external/${id}/licences`, {})
+      })
+
+      describe('when the request succeeds', () => {
+        beforeEach(() => {
+          Sinon.stub(FetchLegacyIdDal, 'go').returns(456)
+        })
+
+        it('redirects to the legacy user page', async () => {
+          const response = await server.inject(postOptions)
+
+          expect(response.statusCode).to.equal(HTTP_STATUS_FOUND)
+          expect(response.headers.location).to.equal(`/user/456/status`)
+        })
       })
     })
   })

--- a/test/controllers/users.controller.test.js
+++ b/test/controllers/users.controller.test.js
@@ -176,14 +176,11 @@ describe('Users controller', () => {
             text: 'Go back to users'
           },
           backQueryString: '?back=users',
-          displayLicenceEndedMessage: false,
           lastSignedIn: 'Last signed in 6 October 2022 at 10:00:00',
-          licences: [],
           pageTitle: 'User details',
           pageTitleCaption: 'external@example.co.uk',
           permissions: 'None',
           roles: [],
-          showEditButton: true,
           status: 'enabled'
         })
       })

--- a/test/dal/users/external/fetch-licences.dal.test.js
+++ b/test/dal/users/external/fetch-licences.dal.test.js
@@ -50,99 +50,102 @@ describe('Users - External - Fetch Licences DAL', () => {
   })
 
   describe('when called', () => {
-    it('returns the requested user', async () => {
+    it('returns the matching licences and the total', async () => {
       const result = await FetchLicencesDal.go(userEntity.id)
 
-      expect(result).to.equal([
-        {
-          expiredDate: licenceData1.licence.expiredDate,
-          id: licenceData1.licence.id,
-          lapsedDate: licenceData1.licence.lapsedDate,
-          licenceRef: licenceData1.licence.licenceRef,
-          revokedDate: licenceData1.licence.revokedDate,
-          licenceVersions: [
-            {
-              id: licenceData1.licenceVersion.id,
-              licenceId: licenceData1.licence.id,
-              licenceVersionHolder: {
-                derivedName: licenceData1.licenceVersionHolder.derivedName,
-                id: licenceData1.licenceVersionHolder.id,
-                licenceVersionId: licenceData1.licenceVersionHolder.licenceVersionId
-              }
-            }
-          ],
-          licenceDocumentHeader: {
-            id: licenceData1.licenceDocumentHeader.id,
-            licenceEntityRoles: [
+      expect(result).to.equal({
+        licences: [
+          {
+            expiredDate: licenceData1.licence.expiredDate,
+            id: licenceData1.licence.id,
+            lapsedDate: licenceData1.licence.lapsedDate,
+            licenceRef: licenceData1.licence.licenceRef,
+            revokedDate: licenceData1.licence.revokedDate,
+            licenceVersions: [
               {
-                id: licenceData1.licenceEntityRoles[0].id,
-                role: licenceData1.licenceEntityRoles[0].role
+                id: licenceData1.licenceVersion.id,
+                licenceId: licenceData1.licence.id,
+                licenceVersionHolder: {
+                  derivedName: licenceData1.licenceVersionHolder.derivedName,
+                  id: licenceData1.licenceVersionHolder.id,
+                  licenceVersionId: licenceData1.licenceVersionHolder.licenceVersionId
+                }
               }
             ],
-            licenceRef: licenceData1.licenceDocumentHeader.licenceRef
-          }
-        },
-        {
-          expiredDate: licenceData3.licence.expiredDate,
-          id: licenceData3.licence.id,
-          lapsedDate: licenceData3.licence.lapsedDate,
-          licenceRef: licenceData3.licence.licenceRef,
-          revokedDate: licenceData3.licence.revokedDate,
-          licenceVersions: [
-            {
-              id: licenceData3.licenceVersion.id,
-              licenceId: licenceData3.licence.id,
-              licenceVersionHolder: {
-                derivedName: licenceData3.licenceVersionHolder.derivedName,
-                id: licenceData3.licenceVersionHolder.id,
-                licenceVersionId: licenceData3.licenceVersionHolder.licenceVersionId
-              }
+            licenceDocumentHeader: {
+              id: licenceData1.licenceDocumentHeader.id,
+              licenceEntityRoles: [
+                {
+                  id: licenceData1.licenceEntityRoles[0].id,
+                  role: licenceData1.licenceEntityRoles[0].role
+                }
+              ],
+              licenceRef: licenceData1.licenceDocumentHeader.licenceRef
             }
-          ],
-          licenceDocumentHeader: {
-            id: licenceData3.licenceDocumentHeader.id,
-            licenceEntityRoles: [
+          },
+          {
+            expiredDate: licenceData3.licence.expiredDate,
+            id: licenceData3.licence.id,
+            lapsedDate: licenceData3.licence.lapsedDate,
+            licenceRef: licenceData3.licence.licenceRef,
+            revokedDate: licenceData3.licence.revokedDate,
+            licenceVersions: [
               {
-                id: licenceData3.licenceEntityRoles[0].id,
-                role: licenceData3.licenceEntityRoles[0].role
+                id: licenceData3.licenceVersion.id,
+                licenceId: licenceData3.licence.id,
+                licenceVersionHolder: {
+                  derivedName: licenceData3.licenceVersionHolder.derivedName,
+                  id: licenceData3.licenceVersionHolder.id,
+                  licenceVersionId: licenceData3.licenceVersionHolder.licenceVersionId
+                }
               }
             ],
-            licenceRef: licenceData3.licenceDocumentHeader.licenceRef
-          }
-        },
-        {
-          expiredDate: licenceData4.licence.expiredDate,
-          id: licenceData4.licence.id,
-          lapsedDate: licenceData4.licence.lapsedDate,
-          licenceRef: licenceData4.licence.licenceRef,
-          revokedDate: licenceData4.licence.revokedDate,
-          licenceVersions: [
-            {
-              id: licenceData4.licenceVersion.id,
-              licenceId: licenceData4.licence.id,
-              licenceVersionHolder: {
-                derivedName: licenceData4.licenceVersionHolder.derivedName,
-                id: licenceData4.licenceVersionHolder.id,
-                licenceVersionId: licenceData4.licenceVersionHolder.licenceVersionId
-              }
+            licenceDocumentHeader: {
+              id: licenceData3.licenceDocumentHeader.id,
+              licenceEntityRoles: [
+                {
+                  id: licenceData3.licenceEntityRoles[0].id,
+                  role: licenceData3.licenceEntityRoles[0].role
+                }
+              ],
+              licenceRef: licenceData3.licenceDocumentHeader.licenceRef
             }
-          ],
-          licenceDocumentHeader: {
-            id: licenceData4.licenceDocumentHeader.id,
-            licenceEntityRoles: [
+          },
+          {
+            expiredDate: licenceData4.licence.expiredDate,
+            id: licenceData4.licence.id,
+            lapsedDate: licenceData4.licence.lapsedDate,
+            licenceRef: licenceData4.licence.licenceRef,
+            revokedDate: licenceData4.licence.revokedDate,
+            licenceVersions: [
               {
-                id: licenceData4.licenceEntityRoles[1].id,
-                role: licenceData4.licenceEntityRoles[1].role
-              },
-              {
-                id: licenceData4.licenceEntityRoles[0].id,
-                role: licenceData4.licenceEntityRoles[0].role
+                id: licenceData4.licenceVersion.id,
+                licenceId: licenceData4.licence.id,
+                licenceVersionHolder: {
+                  derivedName: licenceData4.licenceVersionHolder.derivedName,
+                  id: licenceData4.licenceVersionHolder.id,
+                  licenceVersionId: licenceData4.licenceVersionHolder.licenceVersionId
+                }
               }
             ],
-            licenceRef: licenceData4.licenceDocumentHeader.licenceRef
+            licenceDocumentHeader: {
+              id: licenceData4.licenceDocumentHeader.id,
+              licenceEntityRoles: [
+                {
+                  id: licenceData4.licenceEntityRoles[1].id,
+                  role: licenceData4.licenceEntityRoles[1].role
+                },
+                {
+                  id: licenceData4.licenceEntityRoles[0].id,
+                  role: licenceData4.licenceEntityRoles[0].role
+                }
+              ],
+              licenceRef: licenceData4.licenceDocumentHeader.licenceRef
+            }
           }
-        }
-      ])
+        ],
+        totalNumber: 3
+      })
     })
   })
 })

--- a/test/presenters/users/external/details.presenter.test.js
+++ b/test/presenters/users/external/details.presenter.test.js
@@ -8,33 +8,24 @@ const { describe, it, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const LicenceModel = require('../../../../app/models/licence.model.js')
 const UsersFixture = require('../../../support/fixtures/users.fixture.js')
-const { generateUUID, today } = require('../../../../app/lib/general.lib.js')
-const { tomorrow } = require('../../../support/general.js')
 
 // Thing under test
 const DetailsPresenter = require('../../../../app/presenters/users/external/details.presenter.js')
 
 describe('Users - External - Details Presenter', () => {
   let back
-  let licences
   let user
   let viewingUserScope
 
   beforeEach(() => {
     back = 'users'
-    licences = [
-      _licence('FE/TC/H/US/ER/01', today(), 'user'),
-      _licence('FE/TC/H/US/ER/02', tomorrow(), 'user_returns'),
-      _licence('FE/TC/H/US/ER/03', null, 'primary_user')
-    ]
     user = UsersFixture.external()
     viewingUserScope = ['manage_accounts']
   })
 
   it('correctly presents the data', () => {
-    const result = DetailsPresenter.go(user, licences, viewingUserScope, back)
+    const result = DetailsPresenter.go(user, viewingUserScope, back)
 
     expect(result).to.equal({
       activeNavBar: 'users',
@@ -43,71 +34,19 @@ describe('Users - External - Details Presenter', () => {
         text: 'Go back to users'
       },
       backQueryString: '?back=users',
-      displayLicenceEndedMessage: true,
       lastSignedIn: '6 October 2022 at 10:00:00',
-      licences: [
-        {
-          currentLicenceHolder: licences[0].licenceVersions[0].licenceVersionHolder.derivedName,
-          id: licences[0].id,
-          licenceLink: `/system/licences/${licences[0].id}/summary`,
-          licenceRef: licences[0].licenceRef,
-          permissions: 'Basic access',
-          status: 'expired'
-        },
-        {
-          currentLicenceHolder: licences[1].licenceVersions[0].licenceVersionHolder.derivedName,
-          id: licences[1].id,
-          licenceLink: `/system/licences/${licences[1].id}/summary`,
-          licenceRef: licences[1].licenceRef,
-          permissions: 'Returns user',
-          status: null
-        },
-        {
-          currentLicenceHolder: licences[2].licenceVersions[0].licenceVersionHolder.derivedName,
-          id: licences[2].id,
-          licenceLink: `/system/licences/${licences[2].id}/summary`,
-          licenceRef: licences[2].licenceRef,
-          permissions: 'Primary user',
-          status: null
-        }
-      ],
       pageTitle: 'User details',
       pageTitleCaption: user.username,
       permissions: 'None',
       roles: [],
-      showEditButton: true,
       status: 'enabled'
-    })
-  })
-
-  describe('the "displayLicenceEndedMessage" property', () => {
-    describe('when at least one licence has a status of "expired", "revoked" or "lapsed"', () => {
-      it('returns "true"', () => {
-        const result = DetailsPresenter.go(user, licences, viewingUserScope, back)
-
-        expect(result.displayLicenceEndedMessage).to.be.true()
-      })
-    })
-
-    describe('when no licences have a status of "expired", "revoked" or "lapsed"', () => {
-      beforeEach(() => {
-        for (const licence of licences) {
-          licence.expiredDate = null
-        }
-      })
-
-      it('returns "false"', () => {
-        const result = DetailsPresenter.go(user, licences, viewingUserScope, back)
-
-        expect(result.displayLicenceEndedMessage).to.be.false()
-      })
     })
   })
 
   describe('the "lastSignedIn" property', () => {
     describe('when the lastLogin is set', () => {
       it('returns the last signed in date and time', () => {
-        const result = DetailsPresenter.go(user, licences, viewingUserScope, back)
+        const result = DetailsPresenter.go(user, viewingUserScope, back)
 
         expect(result.lastSignedIn).to.equal('6 October 2022 at 10:00:00')
       })
@@ -119,7 +58,7 @@ describe('Users - External - Details Presenter', () => {
       })
 
       it('returns "Never signed in"', () => {
-        const result = DetailsPresenter.go(user, licences, viewingUserScope, back)
+        const result = DetailsPresenter.go(user, viewingUserScope, back)
 
         expect(result.lastSignedIn).to.equal('Never signed in')
       })
@@ -133,7 +72,7 @@ describe('Users - External - Details Presenter', () => {
       })
 
       it('returns an empty array', () => {
-        const result = DetailsPresenter.go(user, licences, viewingUserScope, back)
+        const result = DetailsPresenter.go(user, viewingUserScope, back)
 
         expect(result.roles).to.be.empty()
       })
@@ -145,7 +84,7 @@ describe('Users - External - Details Presenter', () => {
       })
 
       it('returns the correct roles for a "Returns user"', () => {
-        const result = DetailsPresenter.go(user, licences, viewingUserScope, back)
+        const result = DetailsPresenter.go(user, viewingUserScope, back)
 
         expect(result.roles).to.equal([
           {
@@ -162,7 +101,7 @@ describe('Users - External - Details Presenter', () => {
       })
 
       it('returns the correct roles for a "Primary user"', () => {
-        const result = DetailsPresenter.go(user, licences, viewingUserScope, back)
+        const result = DetailsPresenter.go(user, viewingUserScope, back)
 
         expect(result.roles).to.equal([
           {
@@ -177,69 +116,4 @@ describe('Users - External - Details Presenter', () => {
       })
     })
   })
-
-  describe('the "showEditButton" property', () => {
-    describe('when the viewing user has "manage_accounts" in their scope', () => {
-      it('returns "true"', () => {
-        const result = DetailsPresenter.go(user, licences, viewingUserScope, back)
-
-        expect(result.showEditButton).to.be.true()
-      })
-    })
-
-    describe('when the viewing user does not have "manage_accounts" in their scope', () => {
-      beforeEach(() => {
-        viewingUserScope = []
-      })
-
-      it('returns "false"', () => {
-        const result = DetailsPresenter.go(user, licences, viewingUserScope, back)
-
-        expect(result.showEditButton).to.be.false()
-      })
-    })
-  })
 })
-
-function _licence(licenceRef, expiredDate, role) {
-  const licenceVersionId = generateUUID()
-  const licenceDocumentHeaderId = generateUUID()
-
-  const licence = LicenceModel.fromJson({
-    expiredDate,
-    id: generateUUID(),
-    lapsedDate: null,
-    licenceRef,
-    revokedDate: null
-  })
-
-  licence.licenceVersions = [
-    {
-      id: licenceVersionId,
-      licenceId: licence.id,
-      licenceVersionHolder: {
-        derivedName: 'Current Holder',
-        id: generateUUID(),
-        licenceVersionId
-      }
-    }
-  ]
-
-  licence.licenceDocumentHeader = {
-    id: licenceDocumentHeaderId,
-    licenceEntityRoles: _licenceEntityRoles(role),
-    licenceRef: licence.licenceRef
-  }
-
-  return licence
-}
-
-function _licenceEntityRoles(role) {
-  const licenceEntityRoles = [{ id: generateUUID(), role }]
-
-  if (role === 'user_returns') {
-    licenceEntityRoles.push({ id: generateUUID(), role })
-  }
-
-  return licenceEntityRoles
-}

--- a/test/presenters/users/external/licences.presenter.test.js
+++ b/test/presenters/users/external/licences.presenter.test.js
@@ -50,24 +50,24 @@ describe('Users - External - Licences Presenter', () => {
         {
           currentLicenceHolder: licences[0].licenceVersions[0].licenceVersionHolder.derivedName,
           id: licences[0].id,
-          licenceLink: `/system/licences/${licences[0].id}/summary`,
           licenceRef: licences[0].licenceRef,
+          link: `/system/licences/${licences[0].id}/summary`,
           permissions: 'Basic access',
           status: 'expired'
         },
         {
           currentLicenceHolder: licences[1].licenceVersions[0].licenceVersionHolder.derivedName,
           id: licences[1].id,
-          licenceLink: `/system/licences/${licences[1].id}/summary`,
           licenceRef: licences[1].licenceRef,
+          link: `/system/licences/${licences[1].id}/summary`,
           permissions: 'Returns user',
           status: null
         },
         {
           currentLicenceHolder: licences[2].licenceVersions[0].licenceVersionHolder.derivedName,
           id: licences[2].id,
-          licenceLink: `/system/licences/${licences[2].id}/summary`,
           licenceRef: licences[2].licenceRef,
+          link: `/system/licences/${licences[2].id}/summary`,
           permissions: 'Primary user',
           status: null
         }

--- a/test/presenters/users/external/licences.presenter.test.js
+++ b/test/presenters/users/external/licences.presenter.test.js
@@ -1,0 +1,167 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Test helpers
+const LicenceModel = require('../../../../app/models/licence.model.js')
+const UsersFixture = require('../../../support/fixtures/users.fixture.js')
+const { generateUUID, today } = require('../../../../app/lib/general.lib.js')
+const { tomorrow } = require('../../../support/general.js')
+
+// Thing under test
+const LicencesPresenter = require('../../../../app/presenters/users/external/licences.presenter.js')
+
+describe('Users - External - Licences Presenter', () => {
+  let back
+  let user
+  let licences
+  let viewingUserScope
+
+  beforeEach(() => {
+    back = 'users'
+    licences = [
+      _licence('FE/TC/H/US/ER/01', today(), 'user'),
+      _licence('FE/TC/H/US/ER/02', tomorrow(), 'user_returns'),
+      _licence('FE/TC/H/US/ER/03', null, 'primary_user')
+    ]
+    user = UsersFixture.external()
+    viewingUserScope = ['manage_accounts']
+  })
+
+  it('correctly presents the data', () => {
+    const result = LicencesPresenter.go(user, licences, viewingUserScope, back)
+
+    expect(result).to.equal({
+      activeNavBar: 'users',
+      backLink: {
+        href: '/system/users',
+        text: 'Go back to users'
+      },
+      backQueryString: '?back=users',
+      displayLicenceEndedMessage: true,
+      pageTitle: 'Licences',
+      pageTitleCaption: user.username,
+      licences: [
+        {
+          currentLicenceHolder: licences[0].licenceVersions[0].licenceVersionHolder.derivedName,
+          id: licences[0].id,
+          licenceLink: `/system/licences/${licences[0].id}/summary`,
+          licenceRef: licences[0].licenceRef,
+          permissions: 'Basic access',
+          status: 'expired'
+        },
+        {
+          currentLicenceHolder: licences[1].licenceVersions[0].licenceVersionHolder.derivedName,
+          id: licences[1].id,
+          licenceLink: `/system/licences/${licences[1].id}/summary`,
+          licenceRef: licences[1].licenceRef,
+          permissions: 'Returns user',
+          status: null
+        },
+        {
+          currentLicenceHolder: licences[2].licenceVersions[0].licenceVersionHolder.derivedName,
+          id: licences[2].id,
+          licenceLink: `/system/licences/${licences[2].id}/summary`,
+          licenceRef: licences[2].licenceRef,
+          permissions: 'Primary user',
+          status: null
+        }
+      ],
+      showUnlinkButton: true
+    })
+  })
+
+  describe('the "displayLicenceEndedMessage" property', () => {
+    describe('when at least one licence has a status of "expired", "revoked" or "lapsed"', () => {
+      it('returns "true"', () => {
+        const result = LicencesPresenter.go(user, licences, viewingUserScope, back)
+
+        expect(result.displayLicenceEndedMessage).to.be.true()
+      })
+    })
+
+    describe('when no licences have a status of "expired", "revoked" or "lapsed"', () => {
+      beforeEach(() => {
+        for (const licence of licences) {
+          licence.expiredDate = null
+        }
+      })
+
+      it('returns "false"', () => {
+        const result = LicencesPresenter.go(user, licences, viewingUserScope, back)
+
+        expect(result.displayLicenceEndedMessage).to.be.false()
+      })
+    })
+  })
+
+  describe('the "showUnlinkButton" property', () => {
+    describe('when the viewing user has "manage_accounts" in their scope', () => {
+      it('returns "true"', () => {
+        const result = LicencesPresenter.go(user, licences, viewingUserScope, back)
+
+        expect(result.showUnlinkButton).to.be.true()
+      })
+    })
+
+    describe('when the viewing user does not have "manage_accounts" in their scope', () => {
+      beforeEach(() => {
+        viewingUserScope = []
+      })
+
+      it('returns "false"', () => {
+        const result = LicencesPresenter.go(user, licences, viewingUserScope, back)
+
+        expect(result.showUnlinkButton).to.be.false()
+      })
+    })
+  })
+})
+
+function _licence(licenceRef, expiredDate, role) {
+  const licenceVersionId = generateUUID()
+  const licenceDocumentHeaderId = generateUUID()
+
+  const licence = LicenceModel.fromJson({
+    expiredDate,
+    id: generateUUID(),
+    lapsedDate: null,
+    licenceRef,
+    revokedDate: null
+  })
+
+  licence.licenceVersions = [
+    {
+      id: licenceVersionId,
+      licenceId: licence.id,
+      licenceVersionHolder: {
+        derivedName: 'Current Holder',
+        id: generateUUID(),
+        licenceVersionId
+      }
+    }
+  ]
+
+  licence.licenceDocumentHeader = {
+    id: licenceDocumentHeaderId,
+    licenceEntityRoles: _licenceEntityRoles(role),
+    licenceRef: licence.licenceRef
+  }
+
+  return licence
+}
+
+function _licenceEntityRoles(role) {
+  const licenceEntityRoles = [{ id: generateUUID(), role }]
+
+  if (role === 'user_returns') {
+    licenceEntityRoles.push({ id: generateUUID(), role })
+  }
+
+  return licenceEntityRoles
+}

--- a/test/services/users/external/view-details.service.test.js
+++ b/test/services/users/external/view-details.service.test.js
@@ -12,7 +12,6 @@ const { expect } = Code
 const UsersFixture = require('../../../support/fixtures/users.fixture.js')
 
 // Things we want to stub
-const FetchLicencesDal = require('../../../../app/dal/users/external/fetch-licences.dal.js')
 const FetchUserDetailsDal = require('../../../../app/dal/users/external/fetch-user-details.dal.js')
 
 // Thing under test
@@ -28,7 +27,6 @@ describe('Users - External - View Details service', () => {
 
   beforeEach(() => {
     Sinon.stub(FetchUserDetailsDal, 'go').resolves(user)
-    Sinon.stub(FetchLicencesDal, 'go').resolves([])
   })
 
   afterEach(() => {
@@ -47,14 +45,11 @@ describe('Users - External - View Details service', () => {
           text: 'Go back to users'
         },
         backQueryString: '?back=users',
-        displayLicenceEndedMessage: false,
         lastSignedIn: '6 October 2022 at 10:00:00',
-        licences: [],
         pageTitle: 'User details',
         pageTitleCaption: user.username,
         permissions: 'None',
         roles: [],
-        showEditButton: true,
         status: 'enabled'
       })
     })

--- a/test/services/users/external/view-licences.service.test.js
+++ b/test/services/users/external/view-licences.service.test.js
@@ -1,0 +1,71 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Test helpers
+const UsersFixture = require('../../../support/fixtures/users.fixture.js')
+
+// Things we want to stub
+const FetchUserDal = require('../../../../app/dal/users/fetch-user.dal.js')
+const FetchLicencesDal = require('../../../../app/dal/users/external/fetch-licences.dal.js')
+
+// Thing under test
+const ViewLicencesService = require('../../../../app/services/users/external/view-licences.service.js')
+
+describe('Users - External - View Licences service', () => {
+  const auth = {
+    credentials: { scope: ['manage_accounts'] }
+  }
+  const page = '1'
+
+  let back
+  let user
+
+  beforeEach(() => {
+    const { id, username } = UsersFixture.external()
+
+    user = { id, licenceEntityId: 'b2c55396-9bbb-448d-85e7-2be1dbefc02b', username }
+
+    Sinon.stub(FetchUserDal, 'go').resolves(user)
+    Sinon.stub(FetchLicencesDal, 'go').resolves({
+      licences: [],
+      totalNumber: 0
+    })
+  })
+
+  afterEach(() => {
+    Sinon.restore()
+  })
+
+  describe('when called', () => {
+    it('returns page data for the view', async () => {
+      const result = await ViewLicencesService.go(user.id, auth, page, back)
+
+      expect(result).to.equal({
+        activeNavBar: 'users',
+        activeSecondaryNav: 'licences',
+        pagination: {
+          currentPageNumber: 1,
+          numberOfPages: 0,
+          showingMessage: 'Showing all 0 licences'
+        },
+        backLink: {
+          href: '/system/users',
+          text: 'Go back to users'
+        },
+        backQueryString: '?back=users',
+        displayLicenceEndedMessage: false,
+        pageTitle: 'Licences',
+        pageTitleCaption: user.username,
+        licences: [],
+        showUnlinkButton: true
+      })
+    })
+  })
+})


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5625

After first adding a [view user page](https://github.com/DEFRA/water-abstraction-system/pull/2908), we split it into external and internal [and updated the external page to our conventions](https://github.com/DEFRA/water-abstraction-system/pull/3117).

The view external user page originally displayed details about the user, their roles, any outstanding verifications, and all licences associated with them. It has also been our intention to make user-related notifications visible.

Realising that there is too much going on on the page, communications will be added as a split-page. To get ready for this, we [Split view external user page into details & verification codes](https://github.com/DEFRA/water-abstraction-system/pull/3299).

Next, we're further simplifying the page by moving licences to their own split page.