### PR TITLE
Add communications to external user as split page

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,7 +13,9 @@ POSTGRES_DB_TEST=wabs_system_test
 DEFAULT_USER_PASSWORD=P@55word
 
 # Server config
+EXTERNAL_DOMAIN=http://localhost:8000
 http_proxy=http://myproxy:8080
+INTERNAL_DOMAIN=http://localhost:8008
 PORT=3000
 REQUEST_TIMEOUT=5000
 

--- a/.env.example
+++ b/.env.example
@@ -14,8 +14,8 @@ DEFAULT_USER_PASSWORD=P@55word
 
 # Server config
 http_proxy=http://myproxy:8080
-REQUEST_TIMEOUT=5000
 PORT=3000
+REQUEST_TIMEOUT=5000
 
 # Log config
 LOG_ASSET_REQUESTS=false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,8 @@ jobs:
       DEFAULT_USER_PASSWORD: P@55word
       # Shut up dot env!
       DOTENV_CONFIG_QUIET: true
+      EXTERNAL_DOMAIN: http://localhost:8000
+      INTERNAL_DOMAIN: http://localhost:8008
 
     # Service containers to run with `runner-job`
     services:

--- a/app/controllers/users.controller.js
+++ b/app/controllers/users.controller.js
@@ -9,6 +9,7 @@ const FetchLegacyIdDal = require('../dal/users/fetch-legacy-id.dal.js')
 const IndexUsersService = require('../services/users/index-users.service.js')
 const SubmitIndexUsersService = require('../services/users/submit-index-users.service.js')
 const SubmitProfileDetailsService = require('../services/users/submit-profile-details.service.js')
+const ViewExternalCommunicationsService = require('../services/users/external/view-communications.service.js')
 const ViewExternalDetailsService = require('../services/users/external/view-details.service.js')
 const ViewExternalLicencesService = require('../services/users/external/view-licences.service.js')
 const ViewExternalVerificationsService = require('../services/users/external/view-verifications.service.js')
@@ -71,6 +72,18 @@ async function submitProfileDetails(request, h) {
   }
 
   return h.redirect('/system/users/me/profile-details')
+}
+
+async function viewExternalCommunications(request, h) {
+  const {
+    auth,
+    params: { id },
+    query: { back, page }
+  } = request
+
+  const pageData = await ViewExternalCommunicationsService.go(id, auth, page, back)
+
+  return h.view('users/external/communications.njk', pageData)
 }
 
 async function viewExternalDetails(request, h) {
@@ -169,6 +182,7 @@ module.exports = {
   submitIndex,
   submitProfileDetails,
   submitInternalDetails,
+  viewExternalCommunications,
   viewExternalDetails,
   viewExternalLicences,
   viewExternalVerifications,

--- a/app/dal/users/external/fetch-notifications.dal.js
+++ b/app/dal/users/external/fetch-notifications.dal.js
@@ -1,0 +1,58 @@
+'use strict'
+
+/**
+ * Fetches data needed for the view '/system/users/external/{id}/communications' page
+ * @module FetchNotificationsDal
+ */
+
+const NotificationModel = require('../../../models/notification.model.js')
+const { userNotificationTypes } = require('../../../lib/static-lookups.lib.js')
+
+const DatabaseConfig = require('../../../../config/database.config.js')
+const ServerConfig = require('../../../../config/server.config.js')
+
+/**
+ * Fetches data needed for the view '/system/users/external/{id}/communications' page
+ *
+ * @param {string} username - The username (email) of the user
+ * @param {string} [page=1] - The current page for the pagination service
+ *
+ * @returns {Promise<object[]>} the notifications linked to the user
+ */
+async function go(username, page = '1') {
+  const { results: notifications, total: totalNumber } = await _fetch(username, page)
+
+  return { notifications, totalNumber }
+}
+
+async function _fetch(username, page) {
+  return NotificationModel.query()
+    .select(['createdAt', 'id', 'messageRef', 'messageType', 'status'])
+    .whereNull('eventId')
+    .where('recipient', username)
+    .whereIn('messageRef', _messageRefs())
+    .whereRaw(
+      `(
+  notifications.personalisation->>'reset_url' IS NULL
+  OR notifications.personalisation->>'reset_url' LIKE '${ServerConfig.domains.external}%'
+)`
+    )
+    .orderBy('createdAt', 'DESC')
+    .page(Number(page) - 1, DatabaseConfig.defaultPageSize)
+}
+
+function _messageRefs() {
+  const messageRefs = []
+
+  for (const [key, value] of Object.entries(userNotificationTypes)) {
+    if (['both', 'external'].includes(value.type)) {
+      messageRefs.push(key)
+    }
+  }
+
+  return messageRefs
+}
+
+module.exports = {
+  go
+}

--- a/app/dal/users/internal/fetch-notifications.dal.js
+++ b/app/dal/users/internal/fetch-notifications.dal.js
@@ -30,6 +30,12 @@ async function _fetch(username, page) {
     .whereNull('eventId')
     .where('recipient', username)
     .whereIn('messageRef', _messageRefs())
+    .whereRaw(
+      `(
+  notifications.personalisation->>'reset_url' IS NULL
+  OR notifications.personalisation->>'reset_url' LIKE 'https://admin.%'
+)`
+    )
     .orderBy('createdAt', 'DESC')
     .page(Number(page) - 1, DatabaseConfig.defaultPageSize)
 }

--- a/app/dal/users/internal/fetch-notifications.dal.js
+++ b/app/dal/users/internal/fetch-notifications.dal.js
@@ -9,6 +9,7 @@ const NotificationModel = require('../../../models/notification.model.js')
 const { userNotificationTypes } = require('../../../lib/static-lookups.lib.js')
 
 const DatabaseConfig = require('../../../../config/database.config.js')
+const ServerConfig = require('../../../../config/server.config.js')
 
 /**
  * Fetches data needed for the view '/system/users/internal/{id}/communications' page
@@ -33,7 +34,7 @@ async function _fetch(username, page) {
     .whereRaw(
       `(
   notifications.personalisation->>'reset_url' IS NULL
-  OR notifications.personalisation->>'reset_url' LIKE 'https://admin.%'
+  OR notifications.personalisation->>'reset_url' LIKE '${ServerConfig.domains.internal}%'
 )`
     )
     .orderBy('createdAt', 'DESC')

--- a/app/dal/users/internal/fetch-notifications.dal.js
+++ b/app/dal/users/internal/fetch-notifications.dal.js
@@ -6,6 +6,7 @@
  */
 
 const NotificationModel = require('../../../models/notification.model.js')
+const { userNotificationTypes } = require('../../../lib/static-lookups.lib.js')
 
 const DatabaseConfig = require('../../../../config/database.config.js')
 
@@ -28,8 +29,21 @@ async function _fetch(username, page) {
     .select(['createdAt', 'id', 'messageRef', 'messageType', 'status'])
     .whereNull('eventId')
     .where('recipient', username)
+    .whereIn('messageRef', _messageRefs())
     .orderBy('createdAt', 'DESC')
     .page(Number(page) - 1, DatabaseConfig.defaultPageSize)
+}
+
+function _messageRefs() {
+  const messageRefs = []
+
+  for (const [key, value] of Object.entries(userNotificationTypes)) {
+    if (['both', 'internal'].includes(value.type)) {
+      messageRefs.push(key)
+    }
+  }
+
+  return messageRefs
 }
 
 module.exports = {

--- a/app/lib/static-lookups.lib.js
+++ b/app/lib/static-lookups.lib.js
@@ -686,47 +686,58 @@ const userPermissions = Object.freeze({
 const userNotificationTypes = Object.freeze({
   email_change_email_in_use_email: {
     label: 'Change email address - email already in use',
-    protected: false
+    protected: false,
+    type: 'external'
   },
   email_change_verification_code_email: {
     label: 'Change email address - verification code',
-    protected: false
+    protected: false,
+    type: 'external'
   },
   existing_user_verification_email: {
     label: 'Existing user verification',
-    protected: true
+    protected: true,
+    type: 'external'
   },
   expiry_notification_email: {
     label: 'Expiry notification',
-    protected: false
+    protected: false,
+    type: 'external'
   },
   new_internal_user_email: {
     label: 'New internal user',
-    protected: true
+    protected: true,
+    type: 'internal'
   },
   new_user_verification_email: {
     label: 'New user verification',
-    protected: true
+    protected: true,
+    type: 'external'
   },
   password_locked_email: {
     label: 'Password locked',
-    protected: true
+    protected: true,
+    type: 'both'
   },
   password_reset_email: {
     label: 'Password reset',
-    protected: true
+    protected: true,
+    type: 'both'
   },
   security_code_letter: {
     label: 'Security code letter',
-    protected: false
+    protected: false,
+    type: 'external'
   },
   share_existing_user: {
     label: 'Share existing user',
-    protected: false
+    protected: false,
+    type: 'external'
   },
   share_new_user: {
     label: 'Share new user',
-    protected: true
+    protected: true,
+    type: 'external'
   }
 })
 

--- a/app/presenters/users/external/communications.presenter.js
+++ b/app/presenters/users/external/communications.presenter.js
@@ -14,7 +14,7 @@ const { sourceNavigation } = require('../base-users.presenter.js')
  * @param {module:UserModel} user - The user and associated details
  * @param {module:NotificationModel[]} notifications - All notifications linked to the user
  * @param {string[]} viewingUserScope - The 'scope' taken off the `request.auth` object passed to the
- * `ViewVerificationsService`
+ * `ViewCommunicationsService`
  * @param {string} back - The 'back' query parameter, used to indicate what back link should be shown on the page
  *
  * @returns {object} The data formatted for the view template

--- a/app/presenters/users/external/communications.presenter.js
+++ b/app/presenters/users/external/communications.presenter.js
@@ -1,0 +1,40 @@
+'use strict'
+
+/**
+ * Formats data for the '/users/external/{id}/communications' page
+ * @module CommunicationsPresenter
+ */
+
+const NotificationsTablePresenter = require('../notifications-table.presenter.js')
+const { sourceNavigation } = require('../base-users.presenter.js')
+
+/**
+ * Formats data for the '/users/external/{id}/communications' page
+ *
+ * @param {module:UserModel} user - The user and associated details
+ * @param {module:NotificationModel[]} notifications - All notifications linked to the user
+ * @param {string[]} viewingUserScope - The 'scope' taken off the `request.auth` object passed to the
+ * `ViewVerificationsService`
+ * @param {string} back - The 'back' query parameter, used to indicate what back link should be shown on the page
+ *
+ * @returns {object} The data formatted for the view template
+ */
+function go(user, notifications, viewingUserScope, back) {
+  const { id, username } = user
+
+  const canManageAccounts = viewingUserScope.includes('manage_accounts')
+  const sourceNavigationDetails = sourceNavigation(back, canManageAccounts)
+
+  return {
+    activeNavBar: sourceNavigationDetails.activeNavBar,
+    backLink: sourceNavigationDetails.backLink,
+    backQueryString: sourceNavigationDetails.backQueryString,
+    notifications: NotificationsTablePresenter.go(notifications, id, 'external'),
+    pageTitle: 'Communications',
+    pageTitleCaption: username
+  }
+}
+
+module.exports = {
+  go
+}

--- a/app/presenters/users/internal/communications.presenter.js
+++ b/app/presenters/users/internal/communications.presenter.js
@@ -23,7 +23,7 @@ function go(user, notifications) {
       href: '/system/users',
       text: 'Go back to users'
     },
-    notifications: NotificationsTablePresenter.go(notifications, id),
+    notifications: NotificationsTablePresenter.go(notifications, id, 'internal'),
     pageTitle: 'Communications',
     pageTitleCaption: username
   }

--- a/app/presenters/users/notifications-table.presenter.js
+++ b/app/presenters/users/notifications-table.presenter.js
@@ -13,16 +13,17 @@ const { userNotificationTypes } = require('../../lib/static-lookups.lib.js')
  *
  * @param {module:NotificationModel[]} notifications - All notifications linked to the user
  * @param {string} userId - The id of the user to go back to from the notification details page
+ * @param {string} type - The type of user ('internal' or 'external')
  *
  * @returns {object} The data formatted for the view template
  */
-function go(notifications, userId) {
+function go(notifications, userId, type) {
   return notifications.map((notification) => {
     const { createdAt, messageType, status } = notification
     const sentDate = formatLongDate(createdAt)
 
     return {
-      link: _link(notification, sentDate, userId),
+      link: _link(notification, sentDate, userId, type),
       method: sentenceCase(messageType),
       sentDate,
       status
@@ -30,14 +31,14 @@ function go(notifications, userId) {
   })
 }
 
-function _link(notification, sentDate, userId) {
+function _link(notification, sentDate, userId, type) {
   const { id: notificationId, messageRef, messageType } = notification
 
   const hiddenText = `sent ${sentDate} via ${messageType}`
 
   return {
     hiddenText,
-    href: `/system/users/internal/${userId}/notifications/${notificationId}`,
+    href: `/system/users/${type}/${userId}/notifications/${notificationId}`,
     text: userNotificationTypes[messageRef].label
   }
 }

--- a/app/routes/users.routes.js
+++ b/app/routes/users.routes.js
@@ -29,6 +29,13 @@ const routes = [
   },
   {
     method: 'GET',
+    path: '/users/external/{id}/communications',
+    options: {
+      handler: UsersController.viewExternalCommunications
+    }
+  },
+  {
+    method: 'GET',
     path: '/users/external/{id}/details',
     options: {
       handler: UsersController.viewExternalDetails

--- a/app/services/users/external/view-communications.service.js
+++ b/app/services/users/external/view-communications.service.js
@@ -1,7 +1,7 @@
 'use strict'
 
 /**
- * Orchestrates fetching and presenting internal user data for `/users/external/{id}/communications` page
+ * Orchestrates fetching and presenting external user data for `/users/external/{id}/communications` page
  *
  * @module ViewCommunicationsService
  */
@@ -12,7 +12,7 @@ const FetchUserDal = require('../../../dal/users/fetch-user.dal.js')
 const PaginatorPresenter = require('../../../presenters/paginator.presenter.js')
 
 /**
- * Orchestrates fetching and presenting internal user data for `/users/external/{id}/communications` page
+ * Orchestrates fetching and presenting external user data for `/users/external/{id}/communications` page
  *
  * @param {number} id - The user's ID
  * @param {object} auth - The auth object taken from `request.auth` containing user details

--- a/app/services/users/external/view-communications.service.js
+++ b/app/services/users/external/view-communications.service.js
@@ -1,0 +1,49 @@
+'use strict'
+
+/**
+ * Orchestrates fetching and presenting internal user data for `/users/external/{id}/communications` page
+ *
+ * @module ViewCommunicationsService
+ */
+
+const CommunicationsPresenter = require('../../../presenters/users/external/communications.presenter.js')
+const FetchNotificationsDal = require('../../../dal/users/external/fetch-notifications.dal.js')
+const FetchUserDal = require('../../../dal/users/fetch-user.dal.js')
+const PaginatorPresenter = require('../../../presenters/paginator.presenter.js')
+
+/**
+ * Orchestrates fetching and presenting internal user data for `/users/external/{id}/communications` page
+ *
+ * @param {number} id - The user's ID
+ * @param {object} auth - The auth object taken from `request.auth` containing user details
+ * @param {string} page - The current page for the pagination service
+ * @param {string} back - The 'back' query parameter, used to indicate what back link should be shown on the page
+ *
+ * @returns {Promise<object>} The data formatted for the view template
+ */
+async function go(id, auth, page, back = 'users') {
+  const user = await FetchUserDal.go(id)
+
+  const { notifications, totalNumber } = await FetchNotificationsDal.go(user.username, page)
+
+  const pageData = CommunicationsPresenter.go(user, notifications, auth.credentials.scope, back)
+
+  const pagination = PaginatorPresenter.go(
+    totalNumber,
+    page,
+    `/system/users/external/${id}/communications`,
+    notifications.length,
+    'communications',
+    { back }
+  )
+
+  return {
+    activeSecondaryNav: 'communications',
+    pagination,
+    ...pageData
+  }
+}
+
+module.exports = {
+  go
+}

--- a/app/services/users/internal/view-communications.service.js
+++ b/app/services/users/internal/view-communications.service.js
@@ -1,7 +1,7 @@
 'use strict'
 
 /**
- * Orchestrates fetching and presenting the data for the '/return-logs/{id}/communications' page
+ * Orchestrates fetching and presenting internal user data for `/users/internal/{id}/communications` page
  *
  * @module ViewCommunicationsService
  */
@@ -12,7 +12,7 @@ const FetchUserDal = require('../../../dal/users/fetch-user.dal.js')
 const PaginatorPresenter = require('../../../presenters/paginator.presenter.js')
 
 /**
- * Orchestrates fetching and presenting the data for the '/users/internal/{id}/communications' page
+ * Orchestrates fetching and presenting internal user data for `/users/internal/{id}/communications` page
  *
  * @param {string} id - the UUID of the user
  * @param {string} page - The current page for the pagination service

--- a/app/views/layout-users-external.njk
+++ b/app/views/layout-users-external.njk
@@ -27,6 +27,14 @@
         </li>
 
         <li
+          class="x-govuk-sub-navigation__section-item {% if activeSecondaryNav === 'communications' %}x-govuk-sub-navigation__section-item--current{% endif %}">
+            <a class="x-govuk-sub-navigation__link" href="communications{{ backQueryString }}"
+              {% if activeSecondaryNav === 'communications' %}aria-current="page"{% endif %}>
+            Communications
+          </a>
+        </li>
+
+        <li
           class="x-govuk-sub-navigation__section-item {% if activeSecondaryNav === 'verifications' %}x-govuk-sub-navigation__section-item--current{% endif %}">
             <a class="x-govuk-sub-navigation__link" href="verifications{{ backQueryString }}"
               {% if activeSecondaryNav === 'verifications' %}aria-current="page"{% endif %}>

--- a/app/views/users/external/communications.njk
+++ b/app/views/users/external/communications.njk
@@ -1,0 +1,18 @@
+{% extends 'layout-users-external.njk' %}
+
+{% from "govuk/components/pagination/macro.njk" import govukPagination %}
+
+{% from "macros/user-communications-table.njk" import userCommunicationsTable %}
+{% from "macros/notification-status-tag.njk" import statusTag as notificationStatusTag %}
+
+{% block pageContent %}
+  {% if notifications.length === 0 %}
+    <p data-test='no-notifications-msg'>This user has no associated communications.</p>
+  {% else %}
+    {{ userCommunicationsTable(notifications, pagination) }}
+
+    {% if pagination.numberOfPages > 1 %}
+      {{ govukPagination(pagination.component) }}
+    {% endif %}
+  {% endif %}
+{% endblock %}

--- a/config/server.config.js
+++ b/config/server.config.js
@@ -10,6 +10,10 @@
 require('dotenv').config()
 
 const config = {
+  domains: {
+    external: process.env.EXTERNAL_DOMAIN,
+    internal: process.env.INTERNAL_DOMAIN
+  },
   environment: process.env.NODE_ENV || 'development',
   hapi: {
     port: process.env.PORT,

--- a/test/controllers/users.controller.test.js
+++ b/test/controllers/users.controller.test.js
@@ -19,6 +19,7 @@ const FetchLegacyIdDal = require('../../app/dal/users/fetch-legacy-id.dal.js')
 const IndexUsersService = require('../../app/services/users/index-users.service.js')
 const SubmitIndexUsersService = require('../../app/services/users/submit-index-users.service.js')
 const SubmitProfileDetailsService = require('../../app/services/users/submit-profile-details.service.js')
+const ViewExternalCommunicationsService = require('../../app/services/users/external/view-communications.service.js')
 const ViewExternalDetailsService = require('../../app/services/users/external/view-details.service.js')
 const ViewExternalLicencesService = require('../../app/services/users/external/view-licences.service.js')
 const ViewExternalVerificationsService = require('../../app/services/users/external/view-verifications.service.js')
@@ -158,6 +159,40 @@ describe('Users controller', () => {
             expect(response.payload).to.contain('Showing 25 of 70 users')
           })
         })
+      })
+    })
+  })
+
+  describe('/users/external/{id}/communications', () => {
+    describe('GET', () => {
+      beforeEach(async () => {
+        id = generateUUID()
+        options = _getOptions(`/users/external/${id}/communications`, { scope: [], user: { id } })
+
+        Sinon.stub(ViewExternalCommunicationsService, 'go').resolves({
+          activeNavBar: 'users',
+          activeSecondaryNav: 'communications',
+          pagination: {
+            currentPageNumber: 1,
+            numberOfPages: 0,
+            showingMessage: 'Showing all 0 communications'
+          },
+          backLink: {
+            href: '/system/users',
+            text: 'Go back to users'
+          },
+          backQueryString: '?back=users',
+          notifications: [],
+          pageTitle: 'Communications',
+          pageTitleCaption: 'external@example.co.uk'
+        })
+      })
+
+      it('returns the external user page successfully', async () => {
+        const response = await server.inject(options)
+
+        expect(response.statusCode).to.equal(HTTP_STATUS_OK)
+        expect(response.payload).to.contain('Communications')
       })
     })
   })

--- a/test/controllers/users.controller.test.js
+++ b/test/controllers/users.controller.test.js
@@ -11,7 +11,7 @@ const { expect } = Code
 // Test helpers
 const FeatureFlagsConfig = require('../../config/feature-flags.config.js')
 const { HTTP_STATUS_FOUND, HTTP_STATUS_OK } = require('node:http2').constants
-const { generateUUID } = require('../../app/lib/general.lib.js')
+const { generateUUID, today } = require('../../app/lib/general.lib.js')
 const { postRequestOptions } = require('../support/general.js')
 
 // Things we need to stub
@@ -35,6 +35,7 @@ describe('Users controller', () => {
   let id
   let options
   let notificationId
+  let pageData
   let postOptions
   let server
 
@@ -59,16 +60,35 @@ describe('Users controller', () => {
   })
 
   describe('/users', () => {
+    beforeEach(() => {
+      pageData = {
+        filters: {
+          email: null,
+          openFilter: true,
+          permissions: null,
+          status: null,
+          type: null
+        },
+        links: {
+          user: {
+            href: '/account/create-user',
+            text: 'Create a user'
+          }
+        },
+        pageTitle: 'Users',
+        users: [],
+        pagination: { currentPageNumber: 1, numberOfPages: 1, showingMessage: 'Showing all 0 users' }
+      }
+    })
+
     describe('GET', () => {
       beforeEach(() => {
         options = _getOptions('/users', { scope: ['manage_accounts'] })
       })
 
-      describe('with no pagination', () => {
-        beforeEach(() => {
-          const pageData = _usersPageData()
-
-          Sinon.stub(IndexUsersService, 'go').returns(pageData)
+      describe('with no results', () => {
+        beforeEach(async () => {
+          Sinon.stub(IndexUsersService, 'go').resolves(pageData)
         })
 
         it('returns the page successfully', async () => {
@@ -76,28 +96,57 @@ describe('Users controller', () => {
 
           expect(response.statusCode).to.equal(HTTP_STATUS_OK)
           expect(response.payload).to.contain('Users')
-          expect(response.payload).to.contain('Showing all 1 users')
+          expect(response.payload).to.contain('No users found.')
         })
       })
 
-      describe('with pagination', () => {
-        beforeEach(() => {
-          options.url = '/users?page=2'
-
-          const pageData = _usersPageData()
-
-          pageData.pageTitle = 'Users'
-          pageData.pagination.showingMessage = 'Showing 25 of 70 users'
-
-          Sinon.stub(IndexUsersService, 'go').returns(pageData)
+      describe('with results', () => {
+        beforeEach(async () => {
+          pageData.users = [
+            {
+              email: 'basic.access@wrls.gov.uk',
+              link: '/user/10016/status',
+              permissions: 'Basic access',
+              status: 'enabled',
+              type: 'Internal'
+            }
+          ]
         })
 
-        it('returns the page successfully', async () => {
-          const response = await server.inject(options)
+        describe('and no pagination', () => {
+          beforeEach(() => {
+            pageData.pagination.showingMessage = 'Showing all 1 users'
 
-          expect(response.statusCode).to.equal(HTTP_STATUS_OK)
-          expect(response.payload).to.contain('Users')
-          expect(response.payload).to.contain('Showing 25 of 70 users')
+            Sinon.stub(IndexUsersService, 'go').returns(pageData)
+          })
+
+          it('returns the page successfully', async () => {
+            const response = await server.inject(options)
+
+            expect(response.statusCode).to.equal(HTTP_STATUS_OK)
+            expect(response.payload).to.contain('Users')
+            expect(response.payload).to.contain('Showing all 1 users')
+          })
+        })
+
+        describe('and pagination', () => {
+          beforeEach(() => {
+            options.url = `${options.url}?page=2`
+
+            pageData.pagination.currentPageNumber = 2
+            pageData.pagination.numberOfPages = 3
+            pageData.pagination.showingMessage = 'Showing 25 of 70 users'
+
+            Sinon.stub(IndexUsersService, 'go').returns(pageData)
+          })
+
+          it('returns the page successfully', async () => {
+            const response = await server.inject(options)
+
+            expect(response.statusCode).to.equal(HTTP_STATUS_OK)
+            expect(response.payload).to.contain('Users')
+            expect(response.payload).to.contain('Showing 25 of 70 users')
+          })
         })
       })
     })
@@ -109,7 +158,9 @@ describe('Users controller', () => {
 
       describe('when the request succeeds', () => {
         beforeEach(() => {
-          Sinon.stub(SubmitIndexUsersService, 'go').returns({})
+          pageData = {}
+
+          Sinon.stub(SubmitIndexUsersService, 'go').returns(pageData)
         })
 
         it('redirects back to the index page', async () => {
@@ -121,10 +172,23 @@ describe('Users controller', () => {
       })
 
       describe('when the request fails', () => {
-        describe('with no pagination', () => {
-          beforeEach(() => {
-            const pageData = _usersPageData(true)
+        beforeEach(() => {
+          pageData.filters.type = 'foo'
+          pageData.error = {
+            errorList: [
+              {
+                href: '#type',
+                text: 'Select a valid type'
+              }
+            ],
+            type: {
+              text: 'Select a valid type'
+            }
+          }
+        })
 
+        describe('with no results', () => {
+          beforeEach(() => {
             Sinon.stub(SubmitIndexUsersService, 'go').returns(pageData)
           })
 
@@ -135,28 +199,61 @@ describe('Users controller', () => {
 
             expect(response.payload).to.contain('There is a problem')
             expect(response.payload).to.contain('Users')
-            expect(response.payload).to.contain('Showing all 1 users')
+            expect(response.payload).to.contain('No users found.')
           })
         })
 
-        describe('with pagination', () => {
+        describe('with results', () => {
           beforeEach(async () => {
-            const pageData = _usersPageData(true)
-
-            pageData.pageTitle = 'Users'
-            pageData.pagination.showingMessage = 'Showing 25 of 70 users'
-
-            Sinon.stub(SubmitIndexUsersService, 'go').returns(pageData)
+            pageData.users = [
+              {
+                email: 'basic.access@wrls.gov.uk',
+                link: '/user/10016/status',
+                permissions: 'Basic access',
+                status: 'enabled',
+                type: 'Internal'
+              }
+            ]
           })
 
-          it('re-renders the index page with pagination and an error', async () => {
-            const response = await server.inject(postOptions)
+          describe('and no pagination', () => {
+            beforeEach(() => {
+              pageData.pagination.showingMessage = 'Showing all 1 users'
 
-            expect(response.statusCode).to.equal(HTTP_STATUS_OK)
+              Sinon.stub(SubmitIndexUsersService, 'go').returns(pageData)
+            })
 
-            expect(response.payload).to.contain('There is a problem')
-            expect(response.payload).to.contain('Users')
-            expect(response.payload).to.contain('Showing 25 of 70 users')
+            it('re-renders the index page with no pagination and an error', async () => {
+              const response = await server.inject(postOptions)
+
+              expect(response.statusCode).to.equal(HTTP_STATUS_OK)
+
+              expect(response.payload).to.contain('There is a problem')
+              expect(response.payload).to.contain('Users')
+              expect(response.payload).to.contain('Showing all 1 users')
+            })
+          })
+
+          describe('and pagination', () => {
+            beforeEach(async () => {
+              options.url = `${options.url}?page=2`
+
+              pageData.pagination.currentPageNumber = 2
+              pageData.pagination.numberOfPages = 3
+              pageData.pagination.showingMessage = 'Showing 25 of 70 users'
+
+              Sinon.stub(SubmitIndexUsersService, 'go').returns(pageData)
+            })
+
+            it('re-renders the index page with pagination and an error', async () => {
+              const response = await server.inject(postOptions)
+
+              expect(response.statusCode).to.equal(HTTP_STATUS_OK)
+
+              expect(response.payload).to.contain('There is a problem')
+              expect(response.payload).to.contain('Users')
+              expect(response.payload).to.contain('Showing 25 of 70 users')
+            })
           })
         })
       })
@@ -165,11 +262,11 @@ describe('Users controller', () => {
 
   describe('/users/external/{id}/communications', () => {
     describe('GET', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         id = generateUUID()
         options = _getOptions(`/users/external/${id}/communications`, { scope: [], user: { id } })
 
-        Sinon.stub(ViewExternalCommunicationsService, 'go').resolves({
+        pageData = {
           activeNavBar: 'users',
           activeSecondaryNav: 'communications',
           pagination: {
@@ -185,14 +282,71 @@ describe('Users controller', () => {
           notifications: [],
           pageTitle: 'Communications',
           pageTitleCaption: 'external@example.co.uk'
+        }
+      })
+
+      describe('with no results', () => {
+        beforeEach(async () => {
+          Sinon.stub(ViewExternalCommunicationsService, 'go').resolves(pageData)
+        })
+
+        it('returns the external user page successfully', async () => {
+          const response = await server.inject(options)
+
+          expect(response.statusCode).to.equal(HTTP_STATUS_OK)
+          expect(response.payload).to.contain('Communications')
+          expect(response.payload).to.contain('This user has no associated communications.')
         })
       })
 
-      it('returns the external user page successfully', async () => {
-        const response = await server.inject(options)
+      describe('with results', () => {
+        beforeEach(async () => {
+          pageData.notifications = [
+            {
+              createdAt: today(),
+              id: generateUUID(),
+              messageRef: 'password_reset_email',
+              messageType: 'email',
+              status: 'sent'
+            }
+          ]
+        })
 
-        expect(response.statusCode).to.equal(HTTP_STATUS_OK)
-        expect(response.payload).to.contain('Communications')
+        describe('and no pagination', () => {
+          beforeEach(async () => {
+            pageData.pagination.showingMessage = 'Showing all 1 communications'
+
+            Sinon.stub(ViewExternalCommunicationsService, 'go').resolves(pageData)
+          })
+
+          it('returns the external user page successfully', async () => {
+            const response = await server.inject(options)
+
+            expect(response.statusCode).to.equal(HTTP_STATUS_OK)
+            expect(response.payload).to.contain('Communications')
+            expect(response.payload).to.contain('Showing all 1 communications')
+          })
+        })
+
+        describe('and pagination', () => {
+          beforeEach(async () => {
+            options.url = `${options.url}?page=2`
+
+            pageData.pagination.currentPageNumber = 2
+            pageData.pagination.numberOfPages = 3
+            pageData.pagination.showingMessage = 'Showing 25 of 70 communications'
+
+            Sinon.stub(ViewExternalCommunicationsService, 'go').resolves(pageData)
+          })
+
+          it('returns the external user page successfully', async () => {
+            const response = await server.inject(options)
+
+            expect(response.statusCode).to.equal(HTTP_STATUS_OK)
+            expect(response.payload).to.contain('Communications')
+            expect(response.payload).to.contain('Showing 25 of 70 communications')
+          })
+        })
       })
     })
   })
@@ -235,7 +389,7 @@ describe('Users controller', () => {
         id = generateUUID()
         options = _getOptions(`/users/external/${id}/licences`, { scope: [], user: { id } })
 
-        Sinon.stub(ViewExternalLicencesService, 'go').resolves({
+        pageData = {
           activeNavBar: 'users',
           activeSecondaryNav: 'licences',
           pagination: {
@@ -252,15 +406,93 @@ describe('Users controller', () => {
           pageTitle: 'Licences',
           pageTitleCaption: 'external@example.co.uk',
           licences: [],
-          showUnlinkButton: true
+          showUnlinkButton: false
+        }
+      })
+
+      describe('with no results', () => {
+        beforeEach(async () => {
+          Sinon.stub(ViewExternalLicencesService, 'go').resolves(pageData)
+        })
+
+        it('returns the external user page successfully', async () => {
+          const response = await server.inject(options)
+
+          expect(response.statusCode).to.equal(HTTP_STATUS_OK)
+          expect(response.payload).to.contain('Licences')
+          expect(response.payload).to.contain('This user has no linked licences.')
         })
       })
 
-      it('returns the external user page successfully', async () => {
-        const response = await server.inject(options)
+      describe('with results', () => {
+        beforeEach(async () => {
+          pageData.licences = [
+            {
+              expiredDate: null,
+              id: generateUUID(),
+              lapsedDate: null,
+              licenceRef: '01/123',
+              revokedDate: null,
+              licenceDocumentHeader: {
+                id: generateUUID(),
+                licenceRef: '01/123',
+                licenceEntityRoles: [
+                  {
+                    id: generateUUID(),
+                    role: 'primary_user'
+                  }
+                ]
+              },
+              licenceVersions: [
+                {
+                  id: generateUUID(),
+                  licenceId: generateUUID(),
+                  licenceVersionHolder: {
+                    derivedName: 'Between Two Ferns Surfacing Limited',
+                    id: generateUUID(),
+                    licenceVersionId: generateUUID()
+                  }
+                }
+              ]
+            }
+          ]
+        })
 
-        expect(response.statusCode).to.equal(HTTP_STATUS_OK)
-        expect(response.payload).to.contain('Licences')
+        describe('and no pagination', () => {
+          beforeEach(async () => {
+            pageData.pagination.showingMessage = 'Showing all 1 licences'
+
+            Sinon.stub(ViewExternalLicencesService, 'go').resolves(pageData)
+          })
+
+          it('returns the external user page successfully', async () => {
+            const response = await server.inject(options)
+
+            expect(response.statusCode).to.equal(HTTP_STATUS_OK)
+            expect(response.payload).to.contain('Licences')
+            expect(response.payload).to.contain('Showing all 1 licences')
+          })
+        })
+
+        describe('and pagination', () => {
+          beforeEach(async () => {
+            options.url = `${options.url}?page=2`
+
+            pageData.pagination.currentPageNumber = 2
+            pageData.pagination.numberOfPages = 3
+            pageData.pagination.showingMessage = 'Showing 25 of 70 licences'
+
+            Sinon.stub(ViewExternalLicencesService, 'go').resolves(pageData)
+          })
+
+          it('returns the external user page successfully', async () => {
+            const response = await server.inject(options)
+
+            expect(response.statusCode).to.equal(HTTP_STATUS_OK)
+            expect(response.payload).to.contain('Licences')
+            expect(response.payload).to.contain('Showing 25 of 70 licences')
+          })
+        })
       })
     })
 
@@ -291,7 +523,7 @@ describe('Users controller', () => {
         id = generateUUID()
         options = _getOptions(`/users/external/${id}/verifications`, { scope: [], user: { id } })
 
-        Sinon.stub(ViewExternalVerificationsService, 'go').resolves({
+        pageData = {
           activeNavBar: 'users',
           activeSecondaryNav: 'verifications',
           pagination: {
@@ -307,14 +539,94 @@ describe('Users controller', () => {
           pageTitle: 'Verifications',
           pageTitleCaption: 'external@example.co.uk',
           verifications: []
+        }
+      })
+
+      describe('with no results', () => {
+        beforeEach(async () => {
+          Sinon.stub(ViewExternalVerificationsService, 'go').resolves(pageData)
+        })
+
+        it('returns the external user page successfully', async () => {
+          const response = await server.inject(options)
+
+          expect(response.statusCode).to.equal(HTTP_STATUS_OK)
+          expect(response.payload).to.contain('Verifications')
+          expect(response.payload).to.contain('This user has no associated verifications.')
         })
       })
 
-      it('returns the external user page successfully', async () => {
-        const response = await server.inject(options)
+      describe('with results', () => {
+        beforeEach(async () => {
+          pageData.verifications = [
+            {
+              createdAt: new Date('2025-07-02T19:22:46.000Z'),
+              id: generateUUID(),
+              verifiedAt: new Date('2025-07-02T19:22:51.000Z'),
+              verificationCode: 'A7vdJ',
+              licenceDocumentHeaders: [
+                {
+                  id: generateUUID(),
+                  licenceRef: 'AN/033/0053/130',
+                  licence: {
+                    id: generateUUID(),
+                    licenceRef: 'AN/033/0053/130',
+                    licenceVersions: [
+                      {
+                        id: generateUUID(),
+                        issueDate: new Date('2013-04-01'),
+                        licenceId: generateUUID(),
+                        startDate: new Date('2025-04-01'),
+                        status: 'current',
+                        company: {
+                          id: generateUUID(),
+                          name: 'Rochester Farm Limited',
+                          type: 'organisation'
+                        }
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          ]
+        })
 
-        expect(response.statusCode).to.equal(HTTP_STATUS_OK)
-        expect(response.payload).to.contain('Verifications')
+        describe('and no pagination', () => {
+          beforeEach(async () => {
+            pageData.pagination.showingMessage = 'Showing all 1 verifications'
+
+            Sinon.stub(ViewExternalVerificationsService, 'go').resolves(pageData)
+          })
+
+          it('returns the external user page successfully', async () => {
+            const response = await server.inject(options)
+
+            expect(response.statusCode).to.equal(HTTP_STATUS_OK)
+            expect(response.payload).to.contain('Verifications')
+            expect(response.payload).to.contain('Showing all 1 verifications')
+          })
+        })
+
+        describe('and pagination', () => {
+          beforeEach(async () => {
+            options.url = `${options.url}?page=2`
+
+            pageData.pagination.currentPageNumber = 2
+            pageData.pagination.numberOfPages = 3
+            pageData.pagination.showingMessage = 'Showing 25 of 70 verifications'
+
+            Sinon.stub(ViewExternalVerificationsService, 'go').resolves(pageData)
+          })
+
+          it('returns the external user page successfully', async () => {
+            const response = await server.inject(options)
+
+            expect(response.statusCode).to.equal(HTTP_STATUS_OK)
+            expect(response.payload).to.contain('Verifications')
+            expect(response.payload).to.contain('Showing 25 of 70 verifications')
+          })
+        })
       })
     })
   })
@@ -325,7 +637,7 @@ describe('Users controller', () => {
         id = generateUUID()
         options = _getOptions(`/users/internal/${id}/communications`, { scope: ['manage_accounts'], user: { id } })
 
-        Sinon.stub(ViewInternalCommunicationsService, 'go').resolves({
+        pageData = {
           activeNavBar: 'users',
           activeSecondaryNav: 'communications',
           pagination: {
@@ -340,14 +652,71 @@ describe('Users controller', () => {
           notifications: [],
           pageTitle: 'Communications',
           pageTitleCaption: 'carol.shaw@wrls.gov.uk'
+        }
+      })
+
+      describe('with no results', () => {
+        beforeEach(async () => {
+          Sinon.stub(ViewInternalCommunicationsService, 'go').resolves(pageData)
+        })
+
+        it('returns the internal user page successfully', async () => {
+          const response = await server.inject(options)
+
+          expect(response.statusCode).to.equal(HTTP_STATUS_OK)
+          expect(response.payload).to.contain('Communications')
+          expect(response.payload).to.contain('This user has no associated communications.')
         })
       })
 
-      it('returns the internal user page successfully', async () => {
-        const response = await server.inject(options)
+      describe('with results', () => {
+        beforeEach(async () => {
+          pageData.notifications = [
+            {
+              createdAt: today(),
+              id: generateUUID(),
+              messageRef: 'password_reset_email',
+              messageType: 'email',
+              status: 'sent'
+            }
+          ]
+        })
 
-        expect(response.statusCode).to.equal(HTTP_STATUS_OK)
-        expect(response.payload).to.contain('Communications')
+        describe('and no pagination', () => {
+          beforeEach(async () => {
+            pageData.pagination.showingMessage = 'Showing all 1 communications'
+
+            Sinon.stub(ViewInternalCommunicationsService, 'go').resolves(pageData)
+          })
+
+          it('returns the internal user page successfully', async () => {
+            const response = await server.inject(options)
+
+            expect(response.statusCode).to.equal(HTTP_STATUS_OK)
+            expect(response.payload).to.contain('Communications')
+            expect(response.payload).to.contain('Showing all 1 communications')
+          })
+        })
+
+        describe('and pagination', () => {
+          beforeEach(async () => {
+            options.url = `${options.url}?page=2`
+
+            pageData.pagination.currentPageNumber = 2
+            pageData.pagination.numberOfPages = 3
+            pageData.pagination.showingMessage = 'Showing 25 of 70 communications'
+
+            Sinon.stub(ViewInternalCommunicationsService, 'go').resolves(pageData)
+          })
+
+          it('returns the internal user page successfully', async () => {
+            const response = await server.inject(options)
+
+            expect(response.statusCode).to.equal(HTTP_STATUS_OK)
+            expect(response.payload).to.contain('Communications')
+            expect(response.payload).to.contain('Showing 25 of 70 communications')
+          })
+        })
       })
     })
   })
@@ -505,50 +874,4 @@ function _getOptions(url, credentials) {
       credentials
     }
   }
-}
-
-function _usersPageData(error = false) {
-  const pageData = {
-    filters: {
-      email: null,
-      openFilter: true,
-      permissions: null,
-      status: null,
-      type: null
-    },
-    links: {
-      user: {
-        href: '/account/create-user',
-        text: 'Create a user'
-      }
-    },
-    pageTitle: 'Users',
-    users: [
-      {
-        email: 'basic.access@wrls.gov.uk',
-        link: '/user/10016/status',
-        permissions: 'Basic access',
-        status: 'enabled',
-        type: 'Internal'
-      }
-    ],
-    pagination: { currentPageNumber: 1, numberOfPages: 1, showingMessage: 'Showing all 1 users' }
-  }
-
-  if (error) {
-    pageData.filters.type = 'foo'
-    pageData.error = {
-      errorList: [
-        {
-          href: '#type',
-          text: 'Select a valid type'
-        }
-      ],
-      type: {
-        text: 'Select a valid type'
-      }
-    }
-  }
-
-  return pageData
 }

--- a/test/dal/users/external/fetch-notifications.dal.test.js
+++ b/test/dal/users/external/fetch-notifications.dal.test.js
@@ -1,0 +1,89 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach, after } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Test helpers
+const NotificationHelper = require('../../../support/helpers/notification.helper.js')
+const NotificationsFixture = require('../../../support/fixtures/notifications.fixture.js')
+const UsersFixture = require('../../../support/fixtures/users.fixture.js')
+const { today } = require('../../../../app/lib/general.lib.js')
+const { yesterday } = require('../../../support/general.js')
+
+// Thing under test
+const FetchNotificationsDal = require('../../../../app/dal/users/external/fetch-notifications.dal.js')
+
+describe('Users - External - Fetch Notifications DAL', () => {
+  let notifications
+  let user
+
+  beforeEach(async () => {
+    user = UsersFixture.external()
+
+    // NOTE: Password resets can be sent to both internal and external accounts. We create both in this test to ensure
+    // only the external ones are returned by the DAL. We also set createdAt to ensure the results are ordered as
+    // expected.
+    notifications = [
+      // Should NOT be returned as is 'external' only
+      await NotificationHelper.add(
+        NotificationsFixture.userNewInternalEmail(user.username, { createdAt: yesterday() })
+      ),
+      // Should be returned, but below the external password reset
+      await NotificationHelper.add(
+        NotificationsFixture.userExternalShareExistingEmail(user.username, { createdAt: yesterday() })
+      ),
+      // Should be returned as the first result because it has the latest createdAt date
+      await NotificationHelper.add(
+        NotificationsFixture.userExternalPasswordResetEmail(user.username, { createdAt: today() })
+      ),
+      // Should NOT be returned, even though `password_reset_email` are set to both user types
+      await NotificationHelper.add(
+        NotificationsFixture.userInternalPasswordResetEmail(user.username, { createdAt: today() })
+      )
+    ]
+  })
+
+  after(async () => {
+    for (const notification of notifications) {
+      await notification.$query().delete()
+    }
+  })
+
+  describe('when the user has notifications', () => {
+    it('returns the matching notifications and the total', async () => {
+      const result = await FetchNotificationsDal.go(user.username)
+
+      expect(result).to.equal({
+        notifications: [
+          {
+            createdAt: notifications[2].createdAt,
+            id: notifications[2].id,
+            messageRef: 'password_reset_email',
+            messageType: notifications[2].messageType,
+            status: notifications[2].status
+          },
+          {
+            createdAt: notifications[1].createdAt,
+            id: notifications[1].id,
+            messageRef: 'share_existing_user',
+            messageType: notifications[1].messageType,
+            status: notifications[1].status
+          }
+        ],
+        totalNumber: 2
+      })
+    })
+  })
+
+  describe('when the user has no notifications', () => {
+    it('returns an empty array and zero', async () => {
+      const result = await FetchNotificationsDal.go('mystery.user@example.co.uk')
+
+      expect(result).to.equal({ notifications: [], totalNumber: 0 })
+    })
+  })
+})

--- a/test/dal/users/internal/fetch-notifications.dal.test.js
+++ b/test/dal/users/internal/fetch-notifications.dal.test.js
@@ -11,22 +11,46 @@ const { expect } = Code
 const NotificationHelper = require('../../../support/helpers/notification.helper.js')
 const NotificationsFixture = require('../../../support/fixtures/notifications.fixture.js')
 const UsersFixture = require('../../../support/fixtures/users.fixture.js')
+const { today } = require('../../../../app/lib/general.lib.js')
+const { yesterday } = require('../../../support/general.js')
 
 // Thing under test
 const FetchNotificationsDal = require('../../../../app/dal/users/internal/fetch-notifications.dal.js')
 
 describe('Users - Internal - Fetch Notifications DAL', () => {
-  let notification
+  let notifications
   let user
 
   beforeEach(async () => {
     user = UsersFixture.billingAndData()
 
-    notification = await NotificationHelper.add(NotificationsFixture.userInternalPasswordResetEmail(user.username))
+    // NOTE: Password resets can be sent to both internal and external accounts. We create both in this test to ensure
+    // only the internal ones are returned by the DAL. We also set createdAt to ensure the results are ordered as
+    // expected.
+    notifications = [
+      // Should be returned, but below the internal password reset
+      await NotificationHelper.add(
+        NotificationsFixture.userNewInternalEmail(user.username, { createdAt: yesterday() })
+      ),
+      // Should NOT be returned as is 'external' only
+      await NotificationHelper.add(
+        NotificationsFixture.userExternalShareExistingEmail(user.username, { createdAt: yesterday() })
+      ),
+      // Should NOT be returned, even though `password_reset_email` are set to both user types
+      await NotificationHelper.add(
+        NotificationsFixture.userExternalPasswordResetEmail(user.username, { createdAt: yesterday() })
+      ),
+      // Should be returned as the first result because it has the latest createdAt date
+      await NotificationHelper.add(
+        NotificationsFixture.userInternalPasswordResetEmail(user.username, { createdAt: today() })
+      )
+    ]
   })
 
   after(async () => {
-    notification.$query().delete()
+    for (const notification of notifications) {
+      await notification.$query().delete()
+    }
   })
 
   describe('when the user has notifications', () => {
@@ -36,14 +60,21 @@ describe('Users - Internal - Fetch Notifications DAL', () => {
       expect(result).to.equal({
         notifications: [
           {
-            createdAt: notification.createdAt,
-            id: notification.id,
+            createdAt: notifications[3].createdAt,
+            id: notifications[3].id,
             messageRef: 'password_reset_email',
-            messageType: notification.messageType,
-            status: notification.status
+            messageType: notifications[3].messageType,
+            status: notifications[3].status
+          },
+          {
+            createdAt: notifications[0].createdAt,
+            id: notifications[0].id,
+            messageRef: 'new_internal_user_email',
+            messageType: notifications[0].messageType,
+            status: notifications[0].status
           }
         ],
-        totalNumber: 1
+        totalNumber: 2
       })
     })
   })

--- a/test/presenters/users/external/communications.presenter.test.js
+++ b/test/presenters/users/external/communications.presenter.test.js
@@ -1,0 +1,57 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Test helpers
+const NotificationsFixture = require('../../../support/fixtures/notifications.fixture.js')
+const UsersFixture = require('../../../support/fixtures/users.fixture.js')
+
+// Thing under test
+const CommunicationsPresenter = require('../../../../app/presenters/users/external/communications.presenter.js')
+
+describe('Users - External - Communications presenter', () => {
+  let back
+  let notifications
+  let user
+  let viewingUserScope
+
+  beforeEach(() => {
+    back = 'users'
+    user = UsersFixture.billingAndData()
+
+    notifications = [NotificationsFixture.userExternalShareExistingEmail(user.username)]
+    viewingUserScope = ['manage_accounts']
+  })
+
+  it('correctly presents the data', () => {
+    const result = CommunicationsPresenter.go(user, notifications, viewingUserScope, back)
+
+    expect(result).to.equal({
+      activeNavBar: 'users',
+      backLink: {
+        href: '/system/users',
+        text: 'Go back to users'
+      },
+      backQueryString: '?back=users',
+      notifications: [
+        {
+          link: {
+            hiddenText: 'sent 18 April 2025 via email',
+            href: `/system/users/external/${user.id}/notifications/${notifications[0].id}`,
+            text: 'Share existing user'
+          },
+          method: 'Email',
+          sentDate: '18 April 2025',
+          status: 'sent'
+        }
+      ],
+      pageTitle: 'Communications',
+      pageTitleCaption: user.username
+    })
+  })
+})

--- a/test/presenters/users/notifications-table.presenter.test.js
+++ b/test/presenters/users/notifications-table.presenter.test.js
@@ -16,10 +16,12 @@ const NotificationsTablePresenter = require('../../../app/presenters/users/notif
 
 describe('Users - Notifications Table presenter', () => {
   let notifications
+  let type
   let user
 
   beforeEach(() => {
     user = UsersFixture.billingAndData()
+    type = 'internal'
 
     notifications = [
       NotificationsFixture.userNewInternalEmail(user.username),
@@ -28,7 +30,7 @@ describe('Users - Notifications Table presenter', () => {
   })
 
   it('correctly presents the data', () => {
-    const result = NotificationsTablePresenter.go(notifications, user.id)
+    const result = NotificationsTablePresenter.go(notifications, user.id, type)
 
     expect(result).to.equal([
       {
@@ -54,9 +56,29 @@ describe('Users - Notifications Table presenter', () => {
     ])
   })
 
+  describe('the "link" property', () => {
+    describe('the "href" property', () => {
+      describe('when the "type" is "internal"', () => {
+        it('links to the internal user notification details page', () => {
+          const result = NotificationsTablePresenter.go(notifications, user.id, 'internal')
+
+          expect(result[0].link.href).to.equal(`/system/users/internal/${user.id}/notifications/${notifications[0].id}`)
+        })
+      })
+
+      describe('when the "type" is "external"', () => {
+        it('links to the external user notification details page', () => {
+          const result = NotificationsTablePresenter.go(notifications, user.id, 'external')
+
+          expect(result[0].link.href).to.equal(`/system/users/external/${user.id}/notifications/${notifications[0].id}`)
+        })
+      })
+    })
+  })
+
   describe('when there are no notifications', () => {
     it('returns an empty array', () => {
-      const result = NotificationsTablePresenter.go([], user.id)
+      const result = NotificationsTablePresenter.go([], user.id, type)
 
       expect(result).to.equal([])
     })

--- a/test/services/users/external/view-communications.service.test.js
+++ b/test/services/users/external/view-communications.service.test.js
@@ -1,0 +1,69 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Test helpers
+const UsersFixture = require('../../../support/fixtures/users.fixture.js')
+
+// Things we want to stub
+const FetchNotificationsDal = require('../../../../app/dal/users/external/fetch-notifications.dal.js')
+const FetchUserDal = require('../../../../app/dal/users/fetch-user.dal.js')
+
+// Thing under test
+const ViewCommunicationsService = require('../../../../app/services/users/external/view-communications.service.js')
+
+describe('Users - External - View Communications service', () => {
+  const auth = {
+    credentials: { scope: ['manage_accounts'] }
+  }
+  const page = '1'
+
+  let back
+  let user
+
+  beforeEach(() => {
+    const { id, username } = UsersFixture.external()
+
+    user = { id, licenceEntityId: 'b2c55396-9bbb-448d-85e7-2be1dbefc02b', username }
+
+    Sinon.stub(FetchUserDal, 'go').resolves(user)
+    Sinon.stub(FetchNotificationsDal, 'go').resolves({
+      notifications: [],
+      totalNumber: 0
+    })
+  })
+
+  afterEach(() => {
+    Sinon.restore()
+  })
+
+  describe('when called', () => {
+    it('returns page data for the view', async () => {
+      const result = await ViewCommunicationsService.go(user.id, auth, page, back)
+
+      expect(result).to.equal({
+        activeNavBar: 'users',
+        activeSecondaryNav: 'communications',
+        pagination: {
+          currentPageNumber: 1,
+          numberOfPages: 0,
+          showingMessage: 'Showing all 0 communications'
+        },
+        backLink: {
+          href: '/system/users',
+          text: 'Go back to users'
+        },
+        backQueryString: '?back=users',
+        notifications: [],
+        pageTitle: 'Communications',
+        pageTitleCaption: user.username
+      })
+    })
+  })
+})

--- a/test/services/users/external/view-licences.service.test.js
+++ b/test/services/users/external/view-licences.service.test.js
@@ -12,8 +12,8 @@ const { expect } = Code
 const UsersFixture = require('../../../support/fixtures/users.fixture.js')
 
 // Things we want to stub
-const FetchUserDal = require('../../../../app/dal/users/fetch-user.dal.js')
 const FetchLicencesDal = require('../../../../app/dal/users/external/fetch-licences.dal.js')
+const FetchUserDal = require('../../../../app/dal/users/fetch-user.dal.js')
 
 // Thing under test
 const ViewLicencesService = require('../../../../app/services/users/external/view-licences.service.js')

--- a/test/support/fixtures/notifications.fixture.js
+++ b/test/support/fixtures/notifications.fixture.js
@@ -508,11 +508,12 @@ function returnsReminderLetter(notice) {
  * Generates a new user external password reset email notification object
  *
  * @param {string} recipient - The email of the recipient
+ * @param {object} overrides - An object of properties to override in the generated notification object
  *
  * @returns {object} The generated user external email object
  */
-function userExternalPasswordResetEmail(recipient) {
-  return _userPasswordResetEmail(recipient, false)
+function userExternalPasswordResetEmail(recipient, overrides = {}) {
+  return _userPasswordResetEmail(recipient, false, overrides)
 }
 
 /**
@@ -520,10 +521,11 @@ function userExternalPasswordResetEmail(recipient) {
  *
  * @param {string} recipient - The email of the recipient
  * @param {string} sender - The email of the sender
+ * @param {object} overrides - An object of properties to override in the generated notification object
  *
  * @returns {object} The generated user external email object
  */
-function userExternalShareExistingEmail(recipient, sender) {
+function userExternalShareExistingEmail(recipient, sender, overrides = {}) {
   const notification = {
     contactType: null,
     createdAt: new Date('2025-04-18'),
@@ -555,28 +557,30 @@ function userExternalShareExistingEmail(recipient, sender) {
     templateId: null
   }
 
-  return notification
+  return { ...notification, ...overrides }
 }
 
 /**
  * Generates a new user internal password reset email notification object
  *
  * @param {string} recipient - The email of the recipient
+ * @param {object} overrides - An object of properties to override in the generated notification object
  *
  * @returns {object} The generated user internal email object
  */
-function userInternalPasswordResetEmail(recipient) {
-  return _userPasswordResetEmail(recipient, true)
+function userInternalPasswordResetEmail(recipient, overrides = {}) {
+  return _userPasswordResetEmail(recipient, true, overrides)
 }
 
 /**
  * Generates a new internal user email notification object
  *
  * @param {string} recipient - The email of the recipient
+ * @param {object} overrides - An object of properties to override in the generated notification object
  *
  * @returns {object} The generated user new internal email object
  */
-function userNewInternalEmail(recipient) {
+function userNewInternalEmail(recipient, overrides = {}) {
   const notification = {
     contactType: null,
     createdAt: new Date('2025-04-18'),
@@ -606,10 +610,10 @@ function userNewInternalEmail(recipient) {
     templateId: null
   }
 
-  return notification
+  return { ...notification, ...overrides }
 }
 
-function _userPasswordResetEmail(recipient, internal) {
+function _userPasswordResetEmail(recipient, internal, overrides) {
   const adminPrefix = internal ? 'admin.' : ''
 
   const notification = {
@@ -642,7 +646,7 @@ function _userPasswordResetEmail(recipient, internal) {
     templateId: null
   }
 
-  return notification
+  return { ...notification, ...overrides }
 }
 
 module.exports = {

--- a/test/support/fixtures/notifications.fixture.js
+++ b/test/support/fixtures/notifications.fixture.js
@@ -6,6 +6,8 @@ const NotificationModel = require('../../../app/models/notification.model.js')
 const { generateUUID } = require('../../../app/lib/general.lib.js')
 const { NOTIFY_TEMPLATES } = require('../../../app/lib/notify-templates.lib.js')
 
+const { domains } = require('../../../config/server.config.js')
+
 const ADDRESS = {
   address_line_1: 'ACME Services Ltd',
   address_line_2: 'ACME Operations Centre',
@@ -540,7 +542,7 @@ function userExternalShareExistingEmail(recipient, sender, overrides = {}) {
     notifyStatus: 'delivered',
     pdf: null,
     personalisation: {
-      link: 'https://manage-water-abstraction-impoundment-licence.service.gov.uk',
+      link: domains.external,
       email: recipient,
       sender
     },
@@ -595,7 +597,7 @@ function userNewInternalEmail(recipient, overrides = {}) {
     notifyStatus: 'delivered',
     pdf: null,
     personalisation: {
-      unique_create_password_link: `https://admin.manage-water-abstraction-impoundment-licence.service.gov.uk/reset_password_change_password?resetGuid=${generateUUID()}`
+      unique_create_password_link: `${domains.internal}/reset_password_change_password?resetGuid=${generateUUID()}`
     },
     plaintext:
       'Hello\n' +
@@ -614,7 +616,7 @@ function userNewInternalEmail(recipient, overrides = {}) {
 }
 
 function _userPasswordResetEmail(recipient, internal, overrides) {
-  const adminPrefix = internal ? 'admin.' : ''
+  const domain = internal ? domains.internal : domains.external
 
   const notification = {
     contactType: null,
@@ -631,7 +633,7 @@ function _userPasswordResetEmail(recipient, internal, overrides) {
     pdf: null,
     personalisation: {
       firstname: '(User)',
-      reset_url: `https://${adminPrefix}manage-water-abstraction-impoundment-licence.service.gov.uk/reset_password_change_password?resetGuid=${generateUUID()}`
+      reset_url: `${domain}/reset_password_change_password?resetGuid=${generateUUID()}`
     },
     plaintext:
       'Hello\n' +

--- a/test/support/fixtures/notifications.fixture.js
+++ b/test/support/fixtures/notifications.fixture.js
@@ -505,6 +505,17 @@ function returnsReminderLetter(notice) {
 }
 
 /**
+ * Generates a new user external password reset email notification object
+ *
+ * @param {string} recipient - The email of the recipient
+ *
+ * @returns {object} The generated user external email object
+ */
+function userExternalPasswordResetEmail(recipient) {
+  return _userPasswordResetEmail(recipient, false)
+}
+
+/**
  * Generates a user external share existing email notification object
  *
  * @param {string} recipient - The email of the recipient
@@ -555,37 +566,7 @@ function userExternalShareExistingEmail(recipient, sender) {
  * @returns {object} The generated user internal email object
  */
 function userInternalPasswordResetEmail(recipient) {
-  const notification = {
-    contactType: null,
-    createdAt: new Date('2025-04-18'),
-    dueDate: null,
-    eventId: null,
-    id: generateUUID(),
-    licenceMonitoringStationId: null,
-    licences: [],
-    messageRef: 'password_reset_email',
-    messageType: 'email',
-    notifyId: generateUUID(),
-    notifyStatus: 'delivered',
-    pdf: null,
-    personalisation: {
-      firstname: '(User)',
-      reset_url: `https://admin.manage-water-abstraction-impoundment-licence.service.gov.uk/reset_password_change_password?resetGuid=${generateUUID()}`
-    },
-    plaintext:
-      'Hello\n' +
-      '\n' +
-      'You requested a password reset to view your water abstraction or impoundment licence(s). No changes have been made to your account yet.\n' +
-      '\n' +
-      'You can reset your password using the link below (this link will only work once):\n',
-    recipient,
-    returnedAt: null,
-    returnLogIds: null,
-    status: 'sent',
-    templateId: null
-  }
-
-  return notification
+  return _userPasswordResetEmail(recipient, true)
 }
 
 /**
@@ -628,6 +609,42 @@ function userNewInternalEmail(recipient) {
   return notification
 }
 
+function _userPasswordResetEmail(recipient, internal) {
+  const adminPrefix = internal ? 'admin.' : ''
+
+  const notification = {
+    contactType: null,
+    createdAt: new Date('2025-04-18'),
+    dueDate: null,
+    eventId: null,
+    id: generateUUID(),
+    licenceMonitoringStationId: null,
+    licences: [],
+    messageRef: 'password_reset_email',
+    messageType: 'email',
+    notifyId: generateUUID(),
+    notifyStatus: 'delivered',
+    pdf: null,
+    personalisation: {
+      firstname: '(User)',
+      reset_url: `https://${adminPrefix}manage-water-abstraction-impoundment-licence.service.gov.uk/reset_password_change_password?resetGuid=${generateUUID()}`
+    },
+    plaintext:
+      'Hello\n' +
+      '\n' +
+      'You requested a password reset to view your water abstraction or impoundment licence(s). No changes have been made to your account yet.\n' +
+      '\n' +
+      'You can reset your password using the link below (this link will only work once):\n',
+    recipient,
+    returnedAt: null,
+    returnLogIds: null,
+    status: 'sent',
+    templateId: null
+  }
+
+  return notification
+}
+
 module.exports = {
   abstractionAlertEmail,
   abstractionAlertLetter,
@@ -639,6 +656,7 @@ module.exports = {
   returnsInvitationLetter,
   returnsReminderEmail,
   returnsReminderLetter,
+  userExternalPasswordResetEmail,
   userExternalShareExistingEmail,
   userInternalPasswordResetEmail,
   userNewInternalEmail


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5607

To aid those who manage external users, we want to display the notifications (communications) sent to a user account by the service. These will include things like the invitation and password reset.

Often, external users will query whether an email has been sent. We have records of everything the service has sent, plus their status with [GOV.UK Notify](https://www.notifications.service.gov.uk/). So, instead of account managers having to separately log into Notify and search through emails to check, we can display the information directly within the service.

We're following the lessons learned from licence holder contacts and return logs, and adding the communications as a split page, rather than a table within the existing page.

Unfortunately, notifications are stored in a single table that is not optimised for storing and searching the number of records it holds. We're working on fixing that, but in the meantime, queries against it can be slower than we'd like. From the user's point of view, it can add a noticeable delay to the page loading, which is not ideal.

Hence, communications go to a split page, so the user can choose to load it when they want, without impacting the performance of the main external user page.
