### PR TITLE
Fix user notification protected content status

### DIFF
--- a/app/lib/static-lookups.lib.js
+++ b/app/lib/static-lookups.lib.js
@@ -691,7 +691,7 @@ const userNotificationTypes = Object.freeze({
   },
   email_change_verification_code_email: {
     label: 'Change email address - verification code',
-    protected: false,
+    protected: true,
     type: 'external'
   },
   existing_user_verification_email: {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5617

We spotted this while testing: `email_change_verification_code_email` notifications don't contain a reset guid, but they do contain a verification code. So, we mistakenly set this as unprotected.

This change fixes its protected status.