### PR TITLE
Drop LicenceVersionHolder from ext. user licences

### DIFF
--- a/app/dal/users/external/fetch-licences.dal.js
+++ b/app/dal/users/external/fetch-licences.dal.js
@@ -50,19 +50,7 @@ async function _fetch(licenceEntityId, page) {
     )
     .orderBy('licences.licenceRef', 'asc')
     .page(Number(page) - 1, DatabaseConfig.defaultPageSize)
-    .withGraphFetched('licenceVersions')
-    .modifyGraph('licenceVersions', (licenceVersionsBuilder) => {
-      licenceVersionsBuilder
-        .select(['id', 'licenceId'])
-        .distinctOn('licenceId')
-        .orderBy('licenceId')
-        .orderBy('issue', 'desc')
-        .orderBy('increment', 'desc')
-        .withGraphFetched('licenceVersionHolder')
-        .modifyGraph('licenceVersionHolder', (licenceVersionHolderBuilder) => {
-          licenceVersionHolderBuilder.select(['derivedName', 'id', 'licenceVersionId'])
-        })
-    })
+    .modify('licenceHolder')
     .withGraphFetched('licenceDocumentHeader')
     .modifyGraph('licenceDocumentHeader', (licenceDocumentHeaderBuilder) => {
       licenceDocumentHeaderBuilder

--- a/app/presenters/users/external/licences.presenter.js
+++ b/app/presenters/users/external/licences.presenter.js
@@ -49,7 +49,7 @@ function _userLicences(licences) {
     const licenceEndDetails = licence.$ends()
 
     return {
-      currentLicenceHolder: licenceVersions[0].licenceVersionHolder.derivedName,
+      currentLicenceHolder: licenceVersions[0].company.name,
       id,
       licenceRef,
       link: `/system/licences/${id}/summary`,

--- a/test/dal/users/external/fetch-licences.dal.test.js
+++ b/test/dal/users/external/fetch-licences.dal.test.js
@@ -8,12 +8,12 @@ const { describe, it, before, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
+const CompanyHelper = require('../../../support/helpers/company.helper.js')
 const LicenceDocumentHeaderHelper = require('../../../support/helpers/licence-document-header.helper.js')
 const LicenceEntityHelper = require('../../../support/helpers/licence-entity.helper.js')
 const LicenceEntityRoleHelper = require('../../../support/helpers/licence-entity-role.helper.js')
 const LicenceHelper = require('../../../support/helpers/licence.helper.js')
 const LicenceVersionHelper = require('../../../support/helpers/licence-version.helper.js')
-const LicenceVersionHolderHelper = require('../../../support/helpers/licence-version-holder.helper.js')
 const { generateUUID } = require('../../../../app/lib/general.lib.js')
 
 // Thing under test
@@ -64,12 +64,11 @@ describe('Users - External - Fetch Licences DAL', () => {
             licenceVersions: [
               {
                 id: licenceData1.licenceVersion.id,
+                issueDate: null,
                 licenceId: licenceData1.licence.id,
-                licenceVersionHolder: {
-                  derivedName: licenceData1.licenceVersionHolder.derivedName,
-                  id: licenceData1.licenceVersionHolder.id,
-                  licenceVersionId: licenceData1.licenceVersionHolder.licenceVersionId
-                }
+                startDate: licenceData1.licenceVersion.startDate,
+                status: 'current',
+                company: { id: licenceData1.company.id, name: licenceData1.company.name, type: 'organisation' }
               }
             ],
             licenceDocumentHeader: {
@@ -92,12 +91,11 @@ describe('Users - External - Fetch Licences DAL', () => {
             licenceVersions: [
               {
                 id: licenceData3.licenceVersion.id,
+                issueDate: null,
                 licenceId: licenceData3.licence.id,
-                licenceVersionHolder: {
-                  derivedName: licenceData3.licenceVersionHolder.derivedName,
-                  id: licenceData3.licenceVersionHolder.id,
-                  licenceVersionId: licenceData3.licenceVersionHolder.licenceVersionId
-                }
+                startDate: licenceData3.licenceVersion.startDate,
+                status: 'current',
+                company: { id: licenceData3.company.id, name: licenceData3.company.name, type: 'organisation' }
               }
             ],
             licenceDocumentHeader: {
@@ -120,12 +118,11 @@ describe('Users - External - Fetch Licences DAL', () => {
             licenceVersions: [
               {
                 id: licenceData4.licenceVersion.id,
+                issueDate: null,
                 licenceId: licenceData4.licence.id,
-                licenceVersionHolder: {
-                  derivedName: licenceData4.licenceVersionHolder.derivedName,
-                  id: licenceData4.licenceVersionHolder.id,
-                  licenceVersionId: licenceData4.licenceVersionHolder.licenceVersionId
-                }
+                startDate: licenceData4.licenceVersion.startDate,
+                status: 'current',
+                company: { id: licenceData4.company.id, name: licenceData4.company.name, type: 'organisation' }
               }
             ],
             licenceDocumentHeader: {
@@ -160,34 +157,34 @@ async function _licenceData(userEntity, licenceRef, role) {
 
   const licenceEntityRoles = await _licenceEntityRoles(userEntity.id, companyEntityId, role)
 
-  const licenceVersionSuperseded = await LicenceVersionHelper.add({ licenceId: licence.id, status: 'superseded' })
-  const licenceVersionHolderSuperseded = await LicenceVersionHolderHelper.add({
-    derivedName: 'Superseded Holder',
-    licenceVersionId: licenceVersionSuperseded.id
+  const supersededCompany = await CompanyHelper.add({ name: 'Superseded Holder' })
+  const licenceVersionSuperseded = await LicenceVersionHelper.add({
+    companyId: supersededCompany.id,
+    licenceId: licence.id,
+    status: 'superseded'
   })
 
+  const currentCompany = await CompanyHelper.add({ name: 'Current Holder' })
   const licenceVersionCurrent = await LicenceVersionHelper.add({
+    companyId: currentCompany.id,
     issue: licenceVersionSuperseded.issue + 1,
     licenceId: licence.id
   })
-  const licenceVersionHolderCurrent = await LicenceVersionHolderHelper.add({
-    derivedName: 'Current Holder',
-    licenceVersionId: licenceVersionCurrent.id
-  })
 
   return {
+    company: currentCompany,
     licence,
     licenceEntityRoles,
     licenceDocumentHeader,
     licenceVersion: licenceVersionCurrent,
-    licenceVersionHolder: licenceVersionHolderCurrent,
     clean: async () => {
+      await supersededCompany.$query().delete()
+      await currentCompany.$query().delete()
       await licence.$query().delete()
       await licenceDocumentHeader.$query().delete()
       await licenceVersionSuperseded.$query().delete()
-      await licenceVersionHolderSuperseded.$query().delete()
+      await licenceVersionSuperseded.$query().delete()
       await licenceVersionCurrent.$query().delete()
-      await licenceVersionHolderCurrent.$query().delete()
 
       for (const licenceEntityRole of licenceEntityRoles) {
         await licenceEntityRole.$query().delete()

--- a/test/presenters/users/external/licences.presenter.test.js
+++ b/test/presenters/users/external/licences.presenter.test.js
@@ -48,7 +48,7 @@ describe('Users - External - Licences Presenter', () => {
       pageTitleCaption: user.username,
       licences: [
         {
-          currentLicenceHolder: licences[0].licenceVersions[0].licenceVersionHolder.derivedName,
+          currentLicenceHolder: licences[0].licenceVersions[0].company.name,
           id: licences[0].id,
           licenceRef: licences[0].licenceRef,
           link: `/system/licences/${licences[0].id}/summary`,
@@ -56,7 +56,7 @@ describe('Users - External - Licences Presenter', () => {
           status: 'expired'
         },
         {
-          currentLicenceHolder: licences[1].licenceVersions[0].licenceVersionHolder.derivedName,
+          currentLicenceHolder: licences[1].licenceVersions[0].company.name,
           id: licences[1].id,
           licenceRef: licences[1].licenceRef,
           link: `/system/licences/${licences[1].id}/summary`,
@@ -64,7 +64,7 @@ describe('Users - External - Licences Presenter', () => {
           status: null
         },
         {
-          currentLicenceHolder: licences[2].licenceVersions[0].licenceVersionHolder.derivedName,
+          currentLicenceHolder: licences[2].licenceVersions[0].company.name,
           id: licences[2].id,
           licenceRef: licences[2].licenceRef,
           link: `/system/licences/${licences[2].id}/summary`,
@@ -138,12 +138,11 @@ function _licence(licenceRef, expiredDate, role) {
   licence.licenceVersions = [
     {
       id: licenceVersionId,
+      issueDate: null,
       licenceId: licence.id,
-      licenceVersionHolder: {
-        derivedName: 'Current Holder',
-        id: generateUUID(),
-        licenceVersionId
-      }
+      startDate: new Date('2022-04-01'),
+      status: 'current',
+      company: { id: generateUUID(), name: 'Current Holder', type: 'organisation' }
     }
   ]
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5625

Whilst [moving external user licences to a split-page](https://github.com/DEFRA/water-abstraction-system/pull/3309), we noticed that the query to fetch the licences was still using `LicenceVersionHolder`. This was an initial solution to ensure we knew who the licence holder was for each licence version. As we learnt more, we realised we could just hold the relevant `Company` ID directly in the `LicenceVersion` record itself.

We've been updating any queries that referred to `LicenceVersionHolder`, but clearly didn't spot this one.

This change updates it.
