### PR TITLE
Fix when 'Unlink licences' button is shown

### DIFF
--- a/app/presenters/users/external/licences.presenter.js
+++ b/app/presenters/users/external/licences.presenter.js
@@ -39,7 +39,7 @@ function go(user, licences, viewingUserScope, back) {
     licences: formattedLicences,
     pageTitle: 'Licences',
     pageTitleCaption: username,
-    showUnlinkButton: canManageAccounts
+    showUnlinkButton: _showUnlinkButton(viewingUserScope, formattedLicences)
   }
 }
 
@@ -63,6 +63,18 @@ function _licencePermissions(licence) {
   }
 
   return 'Basic access'
+}
+
+function _showUnlinkButton(viewingUserScope, formattedLicences) {
+  const canUnlinkLicences = viewingUserScope.includes('unlink_licences')
+
+  if (!canUnlinkLicences) {
+    return false
+  }
+
+  return formattedLicences.some((formattedLicence) => {
+    return formattedLicence.permissions === 'Primary user'
+  })
 }
 
 function _status(licenceEndDetails) {

--- a/app/presenters/users/external/licences.presenter.js
+++ b/app/presenters/users/external/licences.presenter.js
@@ -43,22 +43,6 @@ function go(user, licences, viewingUserScope, back) {
   }
 }
 
-function _userLicences(licences) {
-  return licences.map((licence) => {
-    const { id, licenceRef, licenceVersions } = licence
-    const licenceEndDetails = licence.$ends()
-
-    return {
-      currentLicenceHolder: licenceVersions[0].company.name,
-      id,
-      licenceRef,
-      link: `/system/licences/${id}/summary`,
-      permissions: _licencePermissions(licence),
-      status: _status(licenceEndDetails)
-    }
-  })
-}
-
 function _licencePermissions(licence) {
   const { licenceEntityRoles } = licence.licenceDocumentHeader
 
@@ -87,6 +71,22 @@ function _status(licenceEndDetails) {
   }
 
   return null
+}
+
+function _userLicences(licences) {
+  return licences.map((licence) => {
+    const { id, licenceRef, licenceVersions } = licence
+    const licenceEndDetails = licence.$ends()
+
+    return {
+      currentLicenceHolder: licenceVersions[0].company.name,
+      id,
+      licenceRef,
+      link: `/system/licences/${id}/summary`,
+      permissions: _licencePermissions(licence),
+      status: _status(licenceEndDetails)
+    }
+  })
 }
 
 module.exports = {

--- a/test/presenters/users/external/licences.presenter.test.js
+++ b/test/presenters/users/external/licences.presenter.test.js
@@ -30,7 +30,7 @@ describe('Users - External - Licences Presenter', () => {
       _licence('FE/TC/H/US/ER/03', null, 'primary_user')
     ]
     user = UsersFixture.external()
-    viewingUserScope = ['manage_accounts']
+    viewingUserScope = ['manage_accounts', 'unlink_licences']
   })
 
   it('correctly presents the data', () => {
@@ -101,15 +101,41 @@ describe('Users - External - Licences Presenter', () => {
   })
 
   describe('the "showUnlinkButton" property', () => {
-    describe('when the viewing user has "manage_accounts" in their scope', () => {
-      it('returns "true"', () => {
-        const result = LicencesPresenter.go(user, licences, viewingUserScope, back)
+    describe('when the viewing user has "unlink_licences" in their scope', () => {
+      describe('and the external user is the "primary user" on at least one licence', () => {
+        it('returns "true"', () => {
+          const result = LicencesPresenter.go(user, licences, viewingUserScope, back)
 
-        expect(result.showUnlinkButton).to.be.true()
+          expect(result.showUnlinkButton).to.be.true()
+        })
+      })
+
+      describe('and the external user is NOT the "primary user" on at least one licence', () => {
+        beforeEach(() => {
+          licences = [licences[0], licences[1]]
+        })
+
+        it('returns "false"', () => {
+          const result = LicencesPresenter.go(user, licences, viewingUserScope, back)
+
+          expect(result.showUnlinkButton).to.be.false()
+        })
+      })
+
+      describe('and the external user is not linked to any licences', () => {
+        beforeEach(() => {
+          licences = []
+        })
+
+        it('returns "false"', () => {
+          const result = LicencesPresenter.go(user, licences, viewingUserScope, back)
+
+          expect(result.showUnlinkButton).to.be.false()
+        })
       })
     })
 
-    describe('when the viewing user does not have "manage_accounts" in their scope', () => {
+    describe('when the viewing user does not have "unlink_licences" in their scope', () => {
       beforeEach(() => {
         viewingUserScope = []
       })

--- a/test/services/users/external/view-licences.service.test.js
+++ b/test/services/users/external/view-licences.service.test.js
@@ -20,7 +20,7 @@ const ViewLicencesService = require('../../../../app/services/users/external/vie
 
 describe('Users - External - View Licences service', () => {
   const auth = {
-    credentials: { scope: ['manage_accounts'] }
+    credentials: { scope: ['manage_accounts', 'unlink_licences'] }
   }
   const page = '1'
 
@@ -64,7 +64,7 @@ describe('Users - External - View Licences service', () => {
         pageTitle: 'Licences',
         pageTitleCaption: user.username,
         licences: [],
-        showUnlinkButton: true
+        showUnlinkButton: false
       })
     })
   })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5625

We've made the wrong assumption of what the legacy service means by 'unlinking' a licence. Since it is accessed from the User page, we've assumed it was used to unlink the user from a licence.

But after looking, we've realised it is unregistering the licence, essentially freeing it up to be registered again.

Ideally, it should be licence-centric: you find the licence and then opt to unregister it. We'd provide you with a list of the users affected.

But we also learnt unlinking a licence is a separate role from `manage_accounts`, accessible to a larger group of users. And those users are not permitted to access **Users**, the one place we could find a home for it right now.

So, we need to stick with the current user-centric approach, but make two key changes.

- Show the button to those with the `unlink-licences` role, not just `manage_accounts`
- Only show the button when the user is the 'primary user' for at least one of their licences