### PR TITLE
Rename user unlink licences to unregister

### DIFF
--- a/app/presenters/users/external/licences.presenter.js
+++ b/app/presenters/users/external/licences.presenter.js
@@ -39,7 +39,7 @@ function go(user, licences, viewingUserScope, back) {
     licences: formattedLicences,
     pageTitle: 'Licences',
     pageTitleCaption: username,
-    showUnlinkButton: _showUnlinkButton(viewingUserScope, formattedLicences)
+    showUnregisterButton: _showUnregisterButton(viewingUserScope, formattedLicences)
   }
 }
 
@@ -65,10 +65,10 @@ function _licencePermissions(licence) {
   return 'Basic access'
 }
 
-function _showUnlinkButton(viewingUserScope, formattedLicences) {
-  const canUnlinkLicences = viewingUserScope.includes('unlink_licences')
+function _showUnregisterButton(viewingUserScope, formattedLicences) {
+  const canUnregisterLicences = viewingUserScope.includes('unlink_licences')
 
-  if (!canUnlinkLicences) {
+  if (!canUnregisterLicences) {
     return false
   }
 

--- a/app/presenters/users/internal/details.presenter.js
+++ b/app/presenters/users/internal/details.presenter.js
@@ -65,14 +65,14 @@ function _roles(user) {
     for (const role of group.roles) {
       const { description, role: name } = role
 
-      roles.push({ description, name: _convertToSentenceCase(name) })
+      roles.push(_mapRole({ description, role: name }))
     }
   }
 
   for (const role of user.roles) {
     const { description, role: name } = role
 
-    roles.push({ description, name: _convertToSentenceCase(name) })
+    roles.push(_mapRole({ description, role: name }))
   }
 
   roles.sort((first, second) => {
@@ -80,6 +80,24 @@ function _roles(user) {
   })
 
   return roles
+}
+
+/**
+ * This is a hack until such time as we are ready to update the mapped roles and descriptions in the DB, or adopt the
+ * {@link https://github.com/DEFRA/water-abstraction-system/pull/3186 | simplified permissions}.
+ *
+ * > See also {@link https://eaflood.atlassian.net/browse/WATER-5562 | WATER-5562}
+ *
+ * @private
+ */
+function _mapRole(role) {
+  const { description, role: name } = role
+
+  if (name === 'unlink_licences') {
+    return { description: 'Unregister licences registered to users', name: 'Unregister licences' }
+  }
+
+  return { description, name: _convertToSentenceCase(name) }
 }
 
 module.exports = {

--- a/app/views/users/external/licences.njk
+++ b/app/views/users/external/licences.njk
@@ -49,11 +49,11 @@
       }) }}
     {% endif %}
 
-    {% if showUnlinkButton %}
+    {% if showUnregisterButton %}
     <form method="post">
       <input type="hidden" name="wrlsCrumb" value="{{wrlsCrumb}}"/>
 
-      {{ govukButton({ text: "Unlink licences", preventDoubleClick: true }) }}
+      {{ govukButton({ text: "Unregister licences", preventDoubleClick: true }) }}
     </form>
   {% endif %}
 

--- a/test/presenters/users/external/licences.presenter.test.js
+++ b/test/presenters/users/external/licences.presenter.test.js
@@ -72,7 +72,7 @@ describe('Users - External - Licences Presenter', () => {
           status: null
         }
       ],
-      showUnlinkButton: true
+      showUnregisterButton: true
     })
   })
 
@@ -100,13 +100,13 @@ describe('Users - External - Licences Presenter', () => {
     })
   })
 
-  describe('the "showUnlinkButton" property', () => {
+  describe('the "showUnregisterButton" property', () => {
     describe('when the viewing user has "unlink_licences" in their scope', () => {
       describe('and the external user is the "primary user" on at least one licence', () => {
         it('returns "true"', () => {
           const result = LicencesPresenter.go(user, licences, viewingUserScope, back)
 
-          expect(result.showUnlinkButton).to.be.true()
+          expect(result.showUnregisterButton).to.be.true()
         })
       })
 
@@ -118,7 +118,7 @@ describe('Users - External - Licences Presenter', () => {
         it('returns "false"', () => {
           const result = LicencesPresenter.go(user, licences, viewingUserScope, back)
 
-          expect(result.showUnlinkButton).to.be.false()
+          expect(result.showUnregisterButton).to.be.false()
         })
       })
 
@@ -130,7 +130,7 @@ describe('Users - External - Licences Presenter', () => {
         it('returns "false"', () => {
           const result = LicencesPresenter.go(user, licences, viewingUserScope, back)
 
-          expect(result.showUnlinkButton).to.be.false()
+          expect(result.showUnregisterButton).to.be.false()
         })
       })
     })
@@ -143,7 +143,7 @@ describe('Users - External - Licences Presenter', () => {
       it('returns "false"', () => {
         const result = LicencesPresenter.go(user, licences, viewingUserScope, back)
 
-        expect(result.showUnlinkButton).to.be.false()
+        expect(result.showUnregisterButton).to.be.false()
       })
     })
   })

--- a/test/presenters/users/internal/details.presenter.test.js
+++ b/test/presenters/users/internal/details.presenter.test.js
@@ -116,8 +116,39 @@ describe('Users - Internal - Details Presenter', () => {
             name: 'Renewal notifications'
           },
           {
-            description: 'Remove licences registered to a company',
-            name: 'Unlink licences'
+            description: 'Unregister licences registered to users',
+            name: 'Unregister licences'
+          },
+          {
+            description: 'View charge information',
+            name: 'View charge versions'
+          }
+        ])
+      })
+    })
+
+    describe('when the user is part of a group linked to the role "unlink_licences"', () => {
+      beforeEach(() => {
+        user = UsersFixture.nationalPermittingService()
+
+        UsersFixture.transformToFetchUserInternalResult(user)
+      })
+
+      it('returns the "roles" for the group in sentence case, sorted by name, with "unlink" mapped to "unregister"', () => {
+        const result = DetailsPresenter.go(user)
+
+        expect(result.roles).to.equal([
+          {
+            description: 'Manage linkages between gauging stations and licences',
+            name: 'Manage gauging station licence links'
+          },
+          {
+            description: 'Send renewal notifications',
+            name: 'Renewal notifications'
+          },
+          {
+            description: 'Unregister licences registered to users',
+            name: 'Unregister licences'
           },
           {
             description: 'View charge information',

--- a/test/services/users/external/view-licences.service.test.js
+++ b/test/services/users/external/view-licences.service.test.js
@@ -64,7 +64,7 @@ describe('Users - External - View Licences service', () => {
         pageTitle: 'Licences',
         pageTitleCaption: user.username,
         licences: [],
-        showUnlinkButton: false
+        showUnregisterButton: false
       })
     })
   })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5627

We just had to [updated the logic](https://github.com/DEFRA/water-abstraction-system/pull/3322) for when we display the 'Unlink licences' button on the licences page for external users.

This was because we completely misunderstood what 'Unlink' meant in the context in which it was used.

Having the button on an external user's licences page gives the impression we are unlinking a licence from _this_ user.

In fact, that is not the case. We learnt that we should only show the button when the external user is the primary user for one of the displayed licences. This explains why the legacy service showed an 'Unlink' link next to each applicable licence, even though they all always seemed to be applicable!

The change is needed because of what the legacy service is _actually_ doing. It's not touching the user records. Instead, it is wiping the fields in `LicenceDocumentHeader` that mark the licence as registered. This breaks the link to all users' licence entity roles because `company_entity_id` is wiped in `LicenceDocumentHeader`. It's this value that links a licence (`LicenceDocumentHeader`) to a user (`LicenceEntityRole`).

So, we are unregistering the licence and making it available for another user to re-register.

We feel it is important to be clear both in the UI and in our code about what the behaviour and action are, and the term 'unregister' is much clearer than 'unlink' in this context.

> For reference, we considered 'unregister' vs 'deregister' and felt 'unregister' was more appropriate. "Deregister" and "unregister" both mean to remove or reverse a registration, but "deregister" implies an official or formal process (e.g., for vehicles or licenses), while "unregister" is more common for digital/informal actions (e.g., apps or accounts).