### PR TITLE
Fix broken links to view external user page 

### DIFF
--- a/app/dal/users/external/fetch-user-details.dal.js
+++ b/app/dal/users/external/fetch-user-details.dal.js
@@ -1,14 +1,14 @@
 'use strict'
 
 /**
- * Fetches an external user for display on the `/users/external/{id}` page
+ * Fetches an external user for display on the `/users/external/{id}/details` page
  * @module FetchUserDetailsDal
  */
 
 const UserModel = require('../../../models/user.model.js')
 
 /**
- * Fetches an external user for display on the `/users/external/{id}` page
+ * Fetches an external user for display on the `/users/external/{id}/details` page
  *
  * @param {string} id - The ID of the requested user
  *

--- a/app/presenters/crm.presenter.js
+++ b/app/presenters/crm.presenter.js
@@ -33,7 +33,7 @@ function _contactLink(contact, billingQueryArgs) {
   }
 
   if (userTypes.includes(contact.contactType)) {
-    return `/system/users/external/${contact.id}`
+    return `/system/users/external/${contact.id}/details?back=search`
   }
 
   if (contact.addressId) {

--- a/app/views/licences/summary.njk
+++ b/app/views/licences/summary.njk
@@ -7,7 +7,7 @@
   <h2 class="govuk-body-l"> {{ currentVersion }} </h2>
 
   {% if primaryUser %}
-    <p>Registered to <a href="/system/users/external/{{ primaryUser.id }}">{{ primaryUser.username }}</a></p>
+    <p>Registered to <a href="/system/users/external/{{ primaryUser.id }}/details?back=search">{{ primaryUser.username }}</a></p>
   {% endif %}
 
 <dl class="govuk-summary-list">

--- a/test/presenters/companies/contacts.presenter.test.js
+++ b/test/presenters/companies/contacts.presenter.test.js
@@ -143,7 +143,7 @@ describe('Companies - Contacts presenter', () => {
 
           expect(result.contacts).to.equal([
             {
-              link: `/system/users/external/${contacts[0].id}`,
+              link: `/system/users/external/${contacts[0].id}/details?back=search`,
               type: 'Basic user',
               name: 'user@test.com'
             }
@@ -167,7 +167,7 @@ describe('Companies - Contacts presenter', () => {
 
           expect(result.contacts).to.equal([
             {
-              link: `/system/users/external/${contacts[0].id}`,
+              link: `/system/users/external/${contacts[0].id}/details?back=search`,
               type: 'Primary user',
               name: 'user@test.com'
             }
@@ -191,7 +191,7 @@ describe('Companies - Contacts presenter', () => {
 
           expect(result.contacts).to.equal([
             {
-              link: `/system/users/external/${contacts[0].id}`,
+              link: `/system/users/external/${contacts[0].id}/details?back=search`,
               type: 'Returns user',
               name: 'user@test.com'
             }

--- a/test/presenters/crm.presenter.test.js
+++ b/test/presenters/crm.presenter.test.js
@@ -99,7 +99,7 @@ describe('CRM presenter', () => {
           const result = CRMPresenter.formatContact(contact)
 
           expect(result).to.equal({
-            link: `/system/users/external/${contact.id}`,
+            link: `/system/users/external/${contact.id}/details?back=search`,
             type: 'Basic user',
             name: 'user@test.com'
           })
@@ -119,7 +119,7 @@ describe('CRM presenter', () => {
           const result = CRMPresenter.formatContact(contact)
 
           expect(result).to.equal({
-            link: `/system/users/external/${contact.id}`,
+            link: `/system/users/external/${contact.id}/details?back=search`,
             type: 'Primary user',
             name: 'user@test.com'
           })
@@ -139,7 +139,7 @@ describe('CRM presenter', () => {
           const result = CRMPresenter.formatContact(contact)
 
           expect(result).to.equal({
-            link: `/system/users/external/${contact.id}`,
+            link: `/system/users/external/${contact.id}/details?back=search`,
             type: 'Returns user',
             name: 'user@test.com'
           })

--- a/test/presenters/licences/contact-details.presenter.test.js
+++ b/test/presenters/licences/contact-details.presenter.test.js
@@ -179,7 +179,7 @@ describe('Licences - Contact Details presenter', () => {
 
           expect(result.contacts).to.equal([
             {
-              link: `/system/users/external/${contacts[0].id}`,
+              link: `/system/users/external/${contacts[0].id}/details?back=search`,
               type: 'Basic user',
               name: 'user@test.com'
             }
@@ -203,7 +203,7 @@ describe('Licences - Contact Details presenter', () => {
 
           expect(result.contacts).to.equal([
             {
-              link: `/system/users/external/${contacts[0].id}`,
+              link: `/system/users/external/${contacts[0].id}/details?back=search`,
               type: 'Primary user',
               name: 'user@test.com'
             }
@@ -227,7 +227,7 @@ describe('Licences - Contact Details presenter', () => {
 
           expect(result.contacts).to.equal([
             {
-              link: `/system/users/external/${contacts[0].id}`,
+              link: `/system/users/external/${contacts[0].id}/details?back=search`,
               type: 'Returns user',
               name: 'user@test.com'
             }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5618

When we [split the view external user page](https://github.com/DEFRA/water-abstraction-system/pull/3299), we also bit the bullet and started pointing all our links to the new page.

Or we thought we did!

This change fixes those we missed in the licence summary and licence contact details.