### PR TITLE
Update renewal invitations multiple licence refs

### DIFF
--- a/app/presenters/notices/setup/renewal-invitation-notice-notifications.presenter.js
+++ b/app/presenters/notices/setup/renewal-invitation-notice-notifications.presenter.js
@@ -86,7 +86,7 @@ function _personalisation(recipient, noticeData) {
   }
 
   if (recipient.licence_refs.length > 1) {
-    personalisation.licenceRefs = recipient.licence_refs.join(',')
+    personalisation.licenceRefs = recipient.licence_refs.join(', ')
   } else {
     personalisation.licenceRef = recipient.licence_refs[0]
   }

--- a/test/presenters/notices/setup/renewal-invitation-notifications.presenter.test.js
+++ b/test/presenters/notices/setup/renewal-invitation-notifications.presenter.test.js
@@ -87,7 +87,7 @@ describe('Notices - Setup - Renewal Invitation Notifications presenter', () => {
 
           expect(result[0].personalisation).to.equal({
             expiryDate: '1 January 2022',
-            licenceRefs: recipients[0].licence_refs.join(','),
+            licenceRefs: recipients[0].licence_refs.join(', '),
             renewalDate: '3 November 2021'
           })
         })
@@ -123,7 +123,7 @@ describe('Notices - Setup - Renewal Invitation Notifications presenter', () => {
             address_line_5: 'Surrey',
             address_line_6: 'WD25 7LR',
             expiryDate: '1 January 2022',
-            licenceRefs: recipients[1].licence_refs.join(','),
+            licenceRefs: recipients[1].licence_refs.join(', '),
             name: 'Renewal licence holder',
             renewalDate: '3 November 2021'
           })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5614

The renewal invitations multiple licences template has been updated to show the licence refs as a comma separate string.

The bullet points for licence refs could be 50+ and would span multiple pages.

This change adds a space after the comma separate string.