### PR TITLE
Add editor config standards to SKILL.md

### DIFF
--- a/.agents/skills/standards/SKILL.md
+++ b/.agents/skills/standards/SKILL.md
@@ -22,6 +22,10 @@ This document defines the standards an agent must apply when reviewing or writin
 - Check for existing utilities before writing new ones
 - Use `grep` / search to find all usages of a symbol before renaming or removing it
 
+## Editor config
+
+All files must comply with `.editorconfig`. When creating new files, verify compliance before committing — CI will fail on violations.
+
 ## Writing code
 
 - Match the style and conventions of the surrounding code


### PR DESCRIPTION
When the CI runs we have an 'editorconfig' check. Sometime our local text editors / IDE's fail to make the change. 

This change updates the standards skill to check the code meets the 'editorconfig' check.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>