### PR TITLE
Fix SonarCloud code smell issues (S7772, S7755, S7771, S7747, S4326)

### DIFF
--- a/app/lib/dates.lib.js
+++ b/app/lib/dates.lib.js
@@ -121,7 +121,7 @@ function determineLatestDate(dates) {
   })
 
   if (allEmptyValuesRemoved.length === 0) {
-    throw Error('No dates provided to determine earliest')
+    throw new Error('No dates provided to determine earliest')
   }
 
   const valuesAsDates = allEmptyValuesRemoved.map((date) => {

--- a/app/presenters/licence.presenter.js
+++ b/app/presenters/licence.presenter.js
@@ -136,11 +136,7 @@ function _formatAbstractionMethod(licenceVersionPurposePoints) {
     return uniqueAbstractionMethods.join(' and ')
   }
 
-  return (
-    uniqueAbstractionMethods.slice(0, -1).join(', ') +
-    ', and ' +
-    uniqueAbstractionMethods.at(-1)
-  )
+  return uniqueAbstractionMethods.slice(0, -1).join(', ') + ', and ' + uniqueAbstractionMethods.at(-1)
 }
 
 function _formatAbstractionPoints(points) {

--- a/app/presenters/licence.presenter.js
+++ b/app/presenters/licence.presenter.js
@@ -137,9 +137,9 @@ function _formatAbstractionMethod(licenceVersionPurposePoints) {
   }
 
   return (
-    uniqueAbstractionMethods.slice(0, uniqueAbstractionMethods.length - 1).join(', ') +
+    uniqueAbstractionMethods.slice(0, -1).join(', ') +
     ', and ' +
-    uniqueAbstractionMethods[uniqueAbstractionMethods.length - 1]
+    uniqueAbstractionMethods.at(-1)
   )
 }
 

--- a/app/presenters/licence.presenter.js
+++ b/app/presenters/licence.presenter.js
@@ -136,7 +136,10 @@ function _formatAbstractionMethod(licenceVersionPurposePoints) {
     return uniqueAbstractionMethods.join(' and ')
   }
 
-  return uniqueAbstractionMethods.slice(0, -1).join(', ') + ', and ' + uniqueAbstractionMethods.at(-1)
+  const abstractionMethodsExceptLast = uniqueAbstractionMethods.slice(0, -1).join(', ')
+  const lastAbstractionMethod = uniqueAbstractionMethods.at(-1)
+
+  return `${abstractionMethodsExceptLast}, and ${lastAbstractionMethod}`
 }
 
 function _formatAbstractionPoints(points) {

--- a/app/presenters/return-versions/view.presenter.js
+++ b/app/presenters/return-versions/view.presenter.js
@@ -65,9 +65,9 @@ function _agreementsExceptions(returnRequirement) {
   }
 
   return (
-    agreementsExceptions.slice(0, agreementsExceptions.length - 1).join(', ') +
+    agreementsExceptions.slice(0, -1).join(', ') +
     ', and ' +
-    agreementsExceptions[agreementsExceptions.length - 1]
+    agreementsExceptions.at(-1)
   )
 }
 

--- a/app/presenters/return-versions/view.presenter.js
+++ b/app/presenters/return-versions/view.presenter.js
@@ -64,11 +64,7 @@ function _agreementsExceptions(returnRequirement) {
     return agreementsExceptions.join(' and ')
   }
 
-  return (
-    agreementsExceptions.slice(0, -1).join(', ') +
-    ', and ' +
-    agreementsExceptions.at(-1)
-  )
+  return agreementsExceptions.slice(0, -1).join(', ') + ', and ' + agreementsExceptions.at(-1)
 }
 
 function _buildAgreementExceptions(returnRequirement) {

--- a/app/presenters/return-versions/view.presenter.js
+++ b/app/presenters/return-versions/view.presenter.js
@@ -64,7 +64,10 @@ function _agreementsExceptions(returnRequirement) {
     return agreementsExceptions.join(' and ')
   }
 
-  return agreementsExceptions.slice(0, -1).join(', ') + ', and ' + agreementsExceptions.at(-1)
+  const agreementsExceptionsExceptLast = agreementsExceptions.slice(0, -1).join(', ')
+  const lastAgreementsException = agreementsExceptions.at(-1)
+
+  return `${agreementsExceptionsExceptLast}, and ${lastAgreementsException}`
 }
 
 function _buildAgreementExceptions(returnRequirement) {

--- a/app/requests/gotenberg/generate-paper-return.request.js
+++ b/app/requests/gotenberg/generate-paper-return.request.js
@@ -6,7 +6,7 @@
  */
 
 const nunjucks = require('nunjucks')
-const path = require('path')
+const path = require('node:path')
 
 const GotenbergRequest = require('../gotenberg.request.js')
 

--- a/app/requests/resp/token.request.js
+++ b/app/requests/resp/token.request.js
@@ -5,7 +5,7 @@
  * @module TokenRequest
  */
 
-const querystring = require('querystring')
+const querystring = require('node:querystring')
 
 const BaseRequest = require('../base.request.js')
 

--- a/app/services/notices/setup/submit-contact-type.service.js
+++ b/app/services/notices/setup/submit-contact-type.service.js
@@ -6,7 +6,7 @@
  * @module SubmitContactTypeService
  */
 
-const crypto = require('crypto')
+const crypto = require('node:crypto')
 
 const ContactTypePresenter = require('../../../presenters/notices/setup/contact-type.presenter.js')
 const ContactTypeValidator = require('../../../validators/notices/setup/contact-type.validator.js')

--- a/app/services/return-logs/setup/fetch-return-log.service.js
+++ b/app/services/return-logs/setup/fetch-return-log.service.js
@@ -17,7 +17,7 @@ const ReturnLogModel = require('../../../models/return-log.model.js')
  * @returns {Promise<module:ReturnLogModel>} the matching `ReturnLogModel` instance and licence data
  */
 async function go(returnLogId) {
-  return await ReturnLogModel.query()
+  return ReturnLogModel.query()
     .findById(returnLogId)
     .select(
       'licence.id AS licenceId',

--- a/app/services/return-logs/setup/split-multiple-entries.service.js
+++ b/app/services/return-logs/setup/split-multiple-entries.service.js
@@ -34,17 +34,11 @@ function go(multipleEntries) {
   for (const splitEntry of splitEntries) {
     const strippedEntry = splitEntry.replace(/\s/g, '').replace(/,/g, '')
 
-    if (!strippedEntry) {
-      continue
+    if (strippedEntry) {
+      const entry = strippedEntry.toLowerCase() === 'x' ? null : Number(strippedEntry)
+
+      entries.push(entry)
     }
-
-    if (strippedEntry.toLowerCase() === 'x') {
-      entries.push(null)
-
-      continue
-    }
-
-    entries.push(Number(strippedEntry))
   }
 
   return entries

--- a/app/validators/licence-monitoring-station/setup/stop-or-reduce.validator.js
+++ b/app/validators/licence-monitoring-station/setup/stop-or-reduce.validator.js
@@ -21,16 +21,13 @@ function go(payload) {
     'Select if the licence holder needs to stop abstraction when they reach a certain amount'
 
   const schema = Joi.object({
-    stopOrReduce: Joi.string()
-      .required()
-      .valid(...['reduce', 'stop'])
-      .messages({
-        'any.required': stopOrReduceErrorMessage,
-        'any.only': stopOrReduceErrorMessage,
-        'string.empty': stopOrReduceErrorMessage
-      }),
+    stopOrReduce: Joi.string().required().valid('reduce', 'stop').messages({
+      'any.required': stopOrReduceErrorMessage,
+      'any.only': stopOrReduceErrorMessage,
+      'string.empty': stopOrReduceErrorMessage
+    }),
     reduceAtThreshold: Joi.string()
-      .valid(...['yes', 'no'])
+      .valid('yes', 'no')
       .when('stopOrReduce', { is: 'reduce', then: Joi.required() })
       .messages({
         'any.required': reduceAtThresholdError,

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -34,3 +34,9 @@ sonar.sourceEncoding=UTF-8
 
 # Ensure SonarQube knows where to pick up test coverage stats
 sonar.javascript.lcov.reportPaths=coverage/lcov.info
+
+# Suppress S100 (function naming convention) for model files. Objection.js instance methods
+# are conventionally prefixed with $ to distinguish them from static methods and plain properties.
+sonar.issue.ignore.multicriteria=e1
+sonar.issue.ignore.multicriteria.e1.ruleKey=javascript:S100
+sonar.issue.ignore.multicriteria.e1.resourceKey=app/models/**/*.js

--- a/test/validators/licence-monitoring-station/setup/stop-or-reduce.validator.test.js
+++ b/test/validators/licence-monitoring-station/setup/stop-or-reduce.validator.test.js
@@ -29,17 +29,34 @@ describe('Licence Monitoring Station Setup - Stop Or Reduce validator', () => {
     })
 
     describe('because the user selected the "reduce" option', () => {
-      beforeEach(() => {
-        payload = {
-          stopOrReduce: 'reduce',
-          reduceAtThreshold: 'yes'
-        }
+      describe('and selected "yes" for reduce at threshold', () => {
+        beforeEach(() => {
+          payload = {
+            stopOrReduce: 'reduce',
+            reduceAtThreshold: 'yes'
+          }
+        })
+
+        it('confirms the data is valid', () => {
+          const result = StopOrReduceValidator.go(payload)
+
+          expect(result.error).not.to.exist()
+        })
       })
 
-      it('confirms the data is valid', () => {
-        const result = StopOrReduceValidator.go(payload)
+      describe('and selected "no" for reduce at threshold', () => {
+        beforeEach(() => {
+          payload = {
+            stopOrReduce: 'reduce',
+            reduceAtThreshold: 'no'
+          }
+        })
 
-        expect(result.error).not.to.exist()
+        it('confirms the data is valid', () => {
+          const result = StopOrReduceValidator.go(payload)
+
+          expect(result.error).not.to.exist()
+        })
       })
     })
   })


### PR DESCRIPTION
## Overview

Fixes a batch of SonarCloud code smell issues across 11 files, improves code readability in two presenters, expands validator test coverage, and suppresses one rule where the flagged pattern is an intentional project convention.

## Changes

| Rule | Count | Change |
|------|-------|--------|
| S7772 | 3 | Add `node:` prefix to built-in `require()` calls (`path`, `querystring`, `crypto`) |
| S7755 | 2 | Replace `array[array.length - 1]` with `array.at(-1)` for negative indexing |
| S7771 | 2 | Replace `slice(0, array.length - 1)` with `slice(0, -1)` — `slice()` accepts negative indices where `-1` means one from the end, making the manual length reference unnecessary |
| S3512 | 2 | Replace string concatenation with template literals in both presenter functions; expressions extracted into named variables (`abstractionMethodsExceptLast` / `lastAbstractionMethod` and `agreementsExceptionsExceptLast` / `lastAgreementsException`) for readability |
| S7747 | 2 | Remove unnecessary array spread in Joi `.valid(...['a', 'b'])` — values can be passed directly as `.valid('a', 'b')` |
| S4326 | 1 | Remove redundant `await` on a `return` statement in an `async` function |
| S7723 | 1 | Add missing `new` keyword to `Error()` constructor in `dates.lib.js` |
| S135  | 1 | Remove `continue` statements from `split-multiple-entries.service.js` by wrapping the loop body in an `if` block with an extracted `entry` variable |
| S100  | — | Suppressed for `app/models/**/*.js` via `sonar.issue.ignore.multicriteria` — the `$` prefix is an Objection.js instance method convention used intentionally across all model files |

## Test changes

- Added missing test for `reduceAtThreshold: 'no'` in the stop-or-reduce validator to ensure both valid values of the Joi `.valid('yes', 'no')` constraint are exercised

## Files changed

- `app/requests/gotenberg/generate-paper-return.request.js`
- `app/requests/resp/token.request.js`
- `app/services/notices/setup/submit-contact-type.service.js`
- `app/presenters/licence.presenter.js`
- `app/presenters/return-versions/view.presenter.js`
- `app/validators/licence-monitoring-station/setup/stop-or-reduce.validator.js`
- `app/services/return-logs/setup/fetch-return-log.service.js`
- `app/lib/dates.lib.js`
- `app/services/return-logs/setup/split-multiple-entries.service.js`
- `sonar-project.properties`
- `test/validators/licence-monitoring-station/setup/stop-or-reduce.validator.test.js`

## Test plan

- [x] Lint passes (`npm run lint`)
- [x] Tests run via Docker for all affected files — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)