### PR TITLE
Replace global with globalThis across all app files (S7764)

### DIFF
--- a/app/controllers/check.controller.js
+++ b/app/controllers/check.controller.js
@@ -20,7 +20,7 @@ const { HTTP_STATUS_NO_CONTENT } = require('node:http2').constants
 async function placeholder(request, h) {
   const { id } = request.payload
 
-  global.GlobalNotifier.omg('Placeholder endpoint called', { id })
+  globalThis.GlobalNotifier.omg('Placeholder endpoint called', { id })
 
   return h.response().code(HTTP_STATUS_NO_CONTENT)
 }

--- a/app/lib/general.lib.js
+++ b/app/lib/general.lib.js
@@ -47,7 +47,7 @@ function calculateAndLogTimeTaken(startTime, message, data = {}) {
     ...data
   }
 
-  global.GlobalNotifier.omg(message, logData)
+  globalThis.GlobalNotifier.omg(message, logData)
 }
 
 /**

--- a/app/plugins/global-hapi-server-methods.plugin.js
+++ b/app/plugins/global-hapi-server-methods.plugin.js
@@ -4,8 +4,8 @@
  * Plugin to add Hapi server methods to the global object
  *
  * The advantage of server methods is that their output can be cached. From our tests we have seen that accessing them
- * via `server.methods` and `global.HapiServerMethods` makes use of the same cache. Nevertheless, for consistency we
- * should only access them via `global.HapiServerMethods` even when the server object is available to us.
+ * via `server.methods` and `globalThis.HapiServerMethods` makes use of the same cache. Nevertheless, for consistency we
+ * should only access them via `globalThis.HapiServerMethods` even when the server object is available to us.
  *
  * @module GlobalHapiServerMethods
  */
@@ -13,7 +13,7 @@
 const GlobalHapiServerMethods = {
   name: 'global-hapi-server-methods',
   register: (server, _options) => {
-    global.HapiServerMethods = server.methods
+    globalThis.HapiServerMethods = server.methods
   }
 }
 

--- a/app/plugins/global-notifier.plugin.js
+++ b/app/plugins/global-notifier.plugin.js
@@ -10,7 +10,7 @@ const GlobalNotifierLib = require('../lib/global-notifier.lib.js')
 const GlobalNotifierPlugin = {
   name: 'global-notifier',
   register: (server, _options) => {
-    global.GlobalNotifier = new GlobalNotifierLib(server.logger, server.app.airbrake)
+    globalThis.GlobalNotifier = new GlobalNotifierLib(server.logger, server.app.airbrake)
   }
 }
 

--- a/app/plugins/keep-yar-alive.plugin.js
+++ b/app/plugins/keep-yar-alive.plugin.js
@@ -15,7 +15,7 @@ const KeepYarAlivePlugin = {
         // with a refreshed TTL.
         request.yar.touch()
       } catch (error) {
-        global.GlobalNotifier.omfg('Failed to keep session alive', {}, error)
+        globalThis.GlobalNotifier.omfg('Failed to keep session alive', {}, error)
       }
 
       return h.continue

--- a/app/plugins/notify-token-cache.plugin.js
+++ b/app/plugins/notify-token-cache.plugin.js
@@ -28,7 +28,7 @@ const NotifyTokenCachePlugin = {
     // > The first way to call server.method() is with the signature `server.method(name, method, [options])`.
     //
     // This plugin is adding a server method called `getNotifyToken()` which we can then access from anywhere in our
-    // app using `await global.HapiServerMethods.getNotifyToken()`.
+    // app using `await globalThis.HapiServerMethods.getNotifyToken()`.
     //
     // The function we're adding will generate a signed JWT token using the GOV.UK Notify API key provided in our
     // config.

--- a/app/plugins/views.plugin.js
+++ b/app/plugins/views.plugin.js
@@ -33,7 +33,7 @@ const ServerConfig = require('../../config/server.config.js')
 // the plugin is loaded), and then make it available to the filter by storing it in the global scope. The filter can
 // remain synchronous and we avoid doing some gnarly stuff to Nunjucks and Vision.
 import('marked').then((mod) => {
-  global.GlobalMarked = mod.marked
+  globalThis.GlobalMarked = mod.marked
 })
 
 const { enableBillingAccountChangeAddress } = require('../../config/feature-flags.config.js')

--- a/app/requests/base.request.js
+++ b/app/requests/base.request.js
@@ -159,7 +159,7 @@ async function post(url, additionalOptions = {}) {
 }
 
 function _beforeRetryHook(error, retryCount) {
-  global.GlobalNotifier.omg('Retrying HTTP request', { error, retryCount })
+  globalThis.GlobalNotifier.omg('Retrying HTTP request', { error, retryCount })
 }
 
 async function _importGot() {
@@ -198,7 +198,7 @@ function _logFailure(method, result, url, additionalOptions) {
 
   if (result.response instanceof Error) {
     data.result = result
-    global.GlobalNotifier.omfg(`${method} request errored`, data)
+    globalThis.GlobalNotifier.omfg(`${method} request errored`, data)
 
     return
   }
@@ -211,7 +211,7 @@ function _logFailure(method, result, url, additionalOptions) {
     }
   }
 
-  global.GlobalNotifier.omg(`${method} request failed`, data)
+  globalThis.GlobalNotifier.omg(`${method} request failed`, data)
 }
 
 /**

--- a/app/requests/charging-module.request.js
+++ b/app/requests/charging-module.request.js
@@ -70,7 +70,7 @@ async function post(path, body = {}) {
  * @private
  */
 async function _sendRequest(path, method, body) {
-  const authentication = await global.HapiServerMethods.getChargingModuleToken()
+  const authentication = await globalThis.HapiServerMethods.getChargingModuleToken()
   const options = _requestOptions(authentication.accessToken, body)
 
   const result = await method(path, options)

--- a/app/requests/notify.request.js
+++ b/app/requests/notify.request.js
@@ -57,7 +57,7 @@ async function post(path, body = {}) {
  * @private
  */
 async function _sendRequest(path, method, body) {
-  const accessToken = await global.HapiServerMethods.getNotifyToken()
+  const accessToken = await globalThis.HapiServerMethods.getNotifyToken()
   const options = _requestOptions(accessToken, body)
 
   const result = await method(path, options)

--- a/app/requests/resp.request.js
+++ b/app/requests/resp.request.js
@@ -28,7 +28,7 @@ async function get(path) {
  * @private
  */
 async function _sendRequest(path, method) {
-  const authentication = await global.HapiServerMethods.getRespToken()
+  const authentication = await globalThis.HapiServerMethods.getRespToken()
   const options = _requestOptions(authentication.accessToken)
 
   const result = await method(path, options)

--- a/app/services/bill-runs/annual/process-bill-run.service.js
+++ b/app/services/bill-runs/annual/process-bill-run.service.js
@@ -50,7 +50,7 @@ async function go(billRun, billingPeriods) {
     calculateAndLogTimeTaken(startTime, 'Process bill run complete', { billRunId, batchType })
   } catch (error) {
     await HandleErroredBillRunService.go(billRunId, error.code)
-    global.GlobalNotifier.omfg('Bill run process errored', { billRun }, error)
+    globalThis.GlobalNotifier.omfg('Bill run process errored', { billRun }, error)
   }
 }
 

--- a/app/services/bill-runs/cancel/delete-bill-run.service.js
+++ b/app/services/bill-runs/cancel/delete-bill-run.service.js
@@ -57,7 +57,7 @@ async function go(billRun) {
 
     _logResult(startTime, billRun, results)
   } catch (error) {
-    global.GlobalNotifier.omfg('Delete bill run failed', billRun, error)
+    globalThis.GlobalNotifier.omfg('Delete bill run failed', billRun, error)
   }
 }
 
@@ -225,7 +225,7 @@ function _logResult(startTime, billRun, results) {
     return
   }
 
-  global.GlobalNotifier.omfg('Delete bill run failed', billRun, firstError.reason)
+  globalThis.GlobalNotifier.omfg('Delete bill run failed', billRun, firstError.reason)
 }
 
 module.exports = {

--- a/app/services/bill-runs/handle-errored-bill-run.service.js
+++ b/app/services/bill-runs/handle-errored-bill-run.service.js
@@ -23,7 +23,7 @@ async function go(billRunId, errorCode = null) {
   try {
     await _updateBillRun(billRunId, errorCode)
   } catch (error) {
-    global.GlobalNotifier.omfg('Failed to set error status on bill run', { billRunId, errorCode }, error)
+    globalThis.GlobalNotifier.omfg('Failed to set error status on bill run', { billRunId, errorCode }, error)
   }
 }
 

--- a/app/services/bill-runs/match/fetch-return-logs-for-licence.service.js
+++ b/app/services/bill-runs/match/fetch-return-logs-for-licence.service.js
@@ -25,7 +25,7 @@ async function go(licenceRef, billingPeriod) {
     // NOTE: The try/catch was added after we found out that it is possible to set up return requirements in NALD with
     // empty abstraction periods. This then causes the return log to also be missing abstraction period data. Our
     // CAST() in the query then causes an error.
-    global.GlobalNotifier.omfg(
+    globalThis.GlobalNotifier.omfg(
       'Bill run process fetch return logs for licence failed',
       { licenceRef, billingPeriod },
       error

--- a/app/services/bill-runs/reissue/fetch-bills-to-be-reissued.service.js
+++ b/app/services/bill-runs/reissue/fetch-bills-to-be-reissued.service.js
@@ -39,7 +39,7 @@ async function go(regionId) {
     // If getting bills errors then we log the error and return an empty array; the db hasn't yet been modified at
     // this stage so we can simply move on to the next stage of processing the bill run.
 
-    global.GlobalNotifier.omfg('Could not fetch reissue bills', { region: regionId }, error)
+    globalThis.GlobalNotifier.omfg('Could not fetch reissue bills', { region: regionId }, error)
 
     return []
   }

--- a/app/services/bill-runs/send/update-invoice-numbers.service.js
+++ b/app/services/bill-runs/send/update-invoice-numbers.service.js
@@ -46,7 +46,7 @@ async function go(billRun) {
 
     calculateAndLogTimeTaken(startTime, 'Send bill run complete', { billRun })
   } catch (error) {
-    global.GlobalNotifier.omfg('Send bill run failed', billRun, error)
+    globalThis.GlobalNotifier.omfg('Send bill run failed', billRun, error)
   }
 }
 

--- a/app/services/bill-runs/supplementary/process-bill-run.service.js
+++ b/app/services/bill-runs/supplementary/process-bill-run.service.js
@@ -104,7 +104,7 @@ async function _finaliseBillRun(billRun, accumulatedLicenceIds, resultsOfProcess
 }
 
 function _logError(billRun, error) {
-  global.GlobalNotifier.omfg('Bill run process errored', { billRun }, error)
+  globalThis.GlobalNotifier.omfg('Bill run process errored', { billRun }, error)
 }
 
 async function _updateStatus(billRunId, status) {

--- a/app/services/bill-runs/tpt-supplementary/generate-bill-run.service.js
+++ b/app/services/bill-runs/tpt-supplementary/generate-bill-run.service.js
@@ -56,7 +56,7 @@ async function go(billRun) {
     calculateAndLogTimeTaken(startTime, 'Generate supplementary two-part tariff bill run complete', { billRunId })
   } catch (error) {
     await HandleErroredBillRunService.go(billRunId, error.code)
-    global.GlobalNotifier.omfg('Generate supplementary two-part tariff bill run failed', { billRun }, error)
+    globalThis.GlobalNotifier.omfg('Generate supplementary two-part tariff bill run failed', { billRun }, error)
   }
 }
 

--- a/app/services/bill-runs/tpt-supplementary/process-bill-run.service.js
+++ b/app/services/bill-runs/tpt-supplementary/process-bill-run.service.js
@@ -63,7 +63,7 @@ async function go(billRun, billingPeriods) {
     calculateAndLogTimeTaken(startTime, 'Process bill run complete', { billRunId, type: 'two_part_supplementary' })
   } catch (error) {
     await HandleErroredBillRunService.go(billRunId)
-    global.GlobalNotifier.omfg('Process bill run failed', { billRun }, error)
+    globalThis.GlobalNotifier.omfg('Process bill run failed', { billRun }, error)
   }
 }
 

--- a/app/services/bill-runs/two-part-tariff/generate-bill-run.service.js
+++ b/app/services/bill-runs/two-part-tariff/generate-bill-run.service.js
@@ -55,7 +55,7 @@ async function go(billRun) {
     calculateAndLogTimeTaken(startTime, 'Generate annual two-part tariff bill run complete', { billRunId })
   } catch (error) {
     await HandleErroredBillRunService.go(billRunId, error.code)
-    global.GlobalNotifier.omfg('Generate annual two-part tariff bill run failed', { billRun }, error)
+    globalThis.GlobalNotifier.omfg('Generate annual two-part tariff bill run failed', { billRun }, error)
   }
 }
 

--- a/app/services/bill-runs/two-part-tariff/process-bill-run.service.js
+++ b/app/services/bill-runs/two-part-tariff/process-bill-run.service.js
@@ -42,7 +42,7 @@ async function go(billRun, billingPeriods) {
     calculateAndLogTimeTaken(startTime, 'Process bill run complete', { billRunId, type: 'two_part_tariff' })
   } catch (error) {
     await HandleErroredBillRunService.go(billRunId)
-    global.GlobalNotifier.omfg('Process bill run failed', { billRun }, error)
+    globalThis.GlobalNotifier.omfg('Process bill run failed', { billRun }, error)
   }
 }
 

--- a/app/services/data/load/load.service.js
+++ b/app/services/data/load/load.service.js
@@ -397,7 +397,7 @@ async function _selector(schema, table, select, where, value) {
 
     return result[select]
   } catch (error) {
-    global.GlobalNotifier.omg('Load service failed to apply lookup', { schema, table, select, where, value })
+    globalThis.GlobalNotifier.omg('Load service failed to apply lookup', { schema, table, select, where, value })
 
     throw error
   }

--- a/app/services/jobs/clean/clean-empty-bill-runs.service.js
+++ b/app/services/jobs/clean/clean-empty-bill-runs.service.js
@@ -39,7 +39,7 @@ async function go() {
       deletedCount = deleted ? deletedCount + 1 : deletedCount
     }
   } catch (error) {
-    global.GlobalNotifier.omfg('Clean job failed', { billRunId, job: 'clean-empty-bill-runs' }, error)
+    globalThis.GlobalNotifier.omfg('Clean job failed', { billRunId, job: 'clean-empty-bill-runs' }, error)
   }
 
   return deletedCount

--- a/app/services/jobs/clean/clean-empty-void-return-logs.service.js
+++ b/app/services/jobs/clean/clean-empty-void-return-logs.service.js
@@ -25,7 +25,7 @@ async function go() {
         ReturnSubmissionModel.query().select(1).whereColumn('returnSubmissions.returnLogId', 'returnLogs.id')
       )
   } catch (error) {
-    global.GlobalNotifier.omfg('Clean job failed', { job: 'clean-empty-void-return-logs' }, error)
+    globalThis.GlobalNotifier.omfg('Clean job failed', { job: 'clean-empty-void-return-logs' }, error)
   }
 
   return deletedCount

--- a/app/services/jobs/clean/clean-expired-sessions.service.js
+++ b/app/services/jobs/clean/clean-expired-sessions.service.js
@@ -21,7 +21,7 @@ async function go() {
 
     deletedCount = await SessionModel.query().delete().where('created_at', '<', maxSessionAge)
   } catch (error) {
-    global.GlobalNotifier.omfg('Clean job failed', { job: 'clean-expired-sessions' }, error)
+    globalThis.GlobalNotifier.omfg('Clean job failed', { job: 'clean-expired-sessions' }, error)
   }
 
   return deletedCount

--- a/app/services/jobs/clean/clean-incomplete-company-contacts.service.js
+++ b/app/services/jobs/clean/clean-incomplete-company-contacts.service.js
@@ -23,7 +23,7 @@ async function go() {
       .where('licenceRole.name', 'additionalContact')
       .whereNull('contact.email')
   } catch (error) {
-    global.GlobalNotifier.omfg('Clean job failed', { job: 'clean-incomplete-company-contacts' }, error)
+    globalThis.GlobalNotifier.omfg('Clean job failed', { job: 'clean-incomplete-company-contacts' }, error)
   }
 
   return deletedCount

--- a/app/services/jobs/clean/clean-orphaned-contacts.service.js
+++ b/app/services/jobs/clean/clean-orphaned-contacts.service.js
@@ -42,7 +42,7 @@ AND NOT EXISTS (
     ldr.contact_id = contacts.id
 )`)
   } catch (error) {
-    global.GlobalNotifier.omfg('Clean job failed', { job: 'clean-orphaned-contacts' }, error)
+    globalThis.GlobalNotifier.omfg('Clean job failed', { job: 'clean-orphaned-contacts' }, error)
   }
 
   return deletedCount

--- a/app/services/jobs/clean/process-clean.service.js
+++ b/app/services/jobs/clean/process-clean.service.js
@@ -39,7 +39,7 @@ async function go() {
       }
     })
   } catch (error) {
-    global.GlobalNotifier.omfg('Clean job failed', {}, error)
+    globalThis.GlobalNotifier.omfg('Clean job failed', {}, error)
   }
 }
 

--- a/app/services/jobs/customer-files/process-customer-files.service.js
+++ b/app/services/jobs/customer-files/process-customer-files.service.js
@@ -55,8 +55,8 @@ async function go(days) {
   } catch (error) {
     const message = 'Customer files job failed'
 
-    global.GlobalNotifier.omfg(message, null, error)
-    global.GlobalNotifier.redAlert(message)
+    globalThis.GlobalNotifier.omfg(message, null, error)
+    globalThis.GlobalNotifier.redAlert(message)
   }
 }
 

--- a/app/services/jobs/export/delete-files.service.js
+++ b/app/services/jobs/export/delete-files.service.js
@@ -16,7 +16,7 @@ async function go(path) {
   try {
     await fsPromises.rm(path, { recursive: true, force: true })
   } catch (error) {
-    global.GlobalNotifier.omfg('Delete file service errored', { path }, error)
+    globalThis.GlobalNotifier.omfg('Delete file service errored', { path }, error)
   }
 }
 

--- a/app/services/jobs/export/schema-export.service.js
+++ b/app/services/jobs/export/schema-export.service.js
@@ -35,7 +35,7 @@ async function go(schemaName) {
     compressedSchemaPath = await CompressSchemaFolderService.go(schemaFolderPath)
     await SendToS3BucketService.go(compressedSchemaPath)
   } catch (error) {
-    global.GlobalNotifier.omfg(`Error: Failed to export schema ${schemaName}`, null, error)
+    globalThis.GlobalNotifier.omfg(`Error: Failed to export schema ${schemaName}`, null, error)
   } finally {
     await DeleteFilesService.go(schemaFolderPath)
     await DeleteFilesService.go(compressedSchemaPath)

--- a/app/services/jobs/licence-updates/process-licence-updates.service.js
+++ b/app/services/jobs/licence-updates/process-licence-updates.service.js
@@ -46,8 +46,8 @@ async function go() {
   } catch (error) {
     const message = 'Licence updates job failed'
 
-    global.GlobalNotifier.omfg(message, null, error)
-    global.GlobalNotifier.redAlert(message)
+    globalThis.GlobalNotifier.omfg(message, null, error)
+    globalThis.GlobalNotifier.redAlert(message)
   }
 }
 

--- a/app/services/jobs/notification-status/process-notification-status.service.js
+++ b/app/services/jobs/notification-status/process-notification-status.service.js
@@ -50,8 +50,8 @@ async function go() {
   } catch (error) {
     const message = 'Notification status job failed'
 
-    global.GlobalNotifier.omfg(message, null, error)
-    global.GlobalNotifier.redAlert(message)
+    globalThis.GlobalNotifier.omfg(message, null, error)
+    globalThis.GlobalNotifier.redAlert(message)
   }
 }
 

--- a/app/services/jobs/renewal-invitations/process-renewal-invitations.service.js
+++ b/app/services/jobs/renewal-invitations/process-renewal-invitations.service.js
@@ -21,7 +21,7 @@ async function go(days) {
 
     calculateAndLogTimeTaken(startTime, 'Renewals invitation status job complete', { count: recipients.length })
   } catch (error) {
-    global.GlobalNotifier.omfg('Notification status job failed', null, error)
+    globalThis.GlobalNotifier.omfg('Notification status job failed', null, error)
   }
 }
 

--- a/app/services/jobs/return-logs/process-return-logs.service.js
+++ b/app/services/jobs/return-logs/process-return-logs.service.js
@@ -45,7 +45,7 @@ async function go(cycle) {
       try {
         await CreateReturnLogsService.go(returnRequirement, returnCycle, licenceEndDate)
       } catch (error) {
-        global.GlobalNotifier.omfg('Return logs creation errored', { returnRequirement, returnCycle }, error)
+        globalThis.GlobalNotifier.omfg('Return logs creation errored', { returnRequirement, returnCycle }, error)
       }
     }
 
@@ -53,8 +53,8 @@ async function go(cycle) {
   } catch (error) {
     const message = 'Return logs job failed'
 
-    global.GlobalNotifier.omfg(message, { cycle }, error)
-    global.GlobalNotifier.redAlert(message)
+    globalThis.GlobalNotifier.omfg(message, { cycle }, error)
+    globalThis.GlobalNotifier.redAlert(message)
   }
 }
 

--- a/app/services/jobs/time-limited/process-time-limited-licences.service.js
+++ b/app/services/jobs/time-limited/process-time-limited-licences.service.js
@@ -28,8 +28,8 @@ async function go() {
   } catch (error) {
     const message = 'Time limited job failed'
 
-    global.GlobalNotifier.omfg(message, null, error)
-    global.GlobalNotifier.redAlert(message)
+    globalThis.GlobalNotifier.omfg(message, null, error)
+    globalThis.GlobalNotifier.redAlert(message)
   }
 }
 

--- a/app/services/licences/end-dates/check-all-licence-end-dates.service.js
+++ b/app/services/licences/end-dates/check-all-licence-end-dates.service.js
@@ -49,7 +49,7 @@ async function go() {
     calculateAndLogTimeTaken(startTime, 'Check all licence end dates complete', { count: licences.length })
   } catch (error) {
     // Log any errors that occur
-    global.GlobalNotifier.omfg('Check all licence end dates failed', null, error)
+    globalThis.GlobalNotifier.omfg('Check all licence end dates failed', null, error)
   }
 }
 

--- a/app/services/licences/end-dates/check-licence-end-dates.service.js
+++ b/app/services/licences/end-dates/check-licence-end-dates.service.js
@@ -31,7 +31,7 @@ async function go(licence) {
       .onConflict(['licenceId', 'dateType'])
       .merge(['changeDate', 'naldDate', 'wrlsDate', 'updatedAt'])
   } catch (error) {
-    global.GlobalNotifier.omfg('Check licence end dates failed', { id: licence.id, changedDateDetails }, error)
+    globalThis.GlobalNotifier.omfg('Check licence end dates failed', { id: licence.id, changedDateDetails }, error)
   }
 }
 

--- a/app/services/licences/end-dates/process-licence-end-date-changes.service.js
+++ b/app/services/licences/end-dates/process-licence-end-date-changes.service.js
@@ -43,7 +43,7 @@ async function go() {
     })
   } catch (error) {
     // Log any errors that occur
-    global.GlobalNotifier.omfg('Process licence end date changes failed', null, error)
+    globalThis.GlobalNotifier.omfg('Process licence end date changes failed', null, error)
   }
 }
 
@@ -61,10 +61,10 @@ async function _processLicenceEndDateChanges(licenceEndDateChange) {
 
     await licenceEndDateChange.$query().delete()
 
-    global.GlobalNotifier.omg('Process licence end date change complete', { ...licenceEndDateChange })
+    globalThis.GlobalNotifier.omg('Process licence end date change complete', { ...licenceEndDateChange })
   } catch (error) {
     // Log any errors that occur
-    global.GlobalNotifier.omfg('Process licence end date change failed', { ...licenceEndDateChange }, error)
+    globalThis.GlobalNotifier.omfg('Process licence end date change failed', { ...licenceEndDateChange }, error)
   }
 }
 

--- a/app/services/licences/supplementary/process-billing-flag.service.js
+++ b/app/services/licences/supplementary/process-billing-flag.service.js
@@ -45,7 +45,7 @@ async function go(payload) {
 
     calculateAndLogTimeTaken(startTime, 'Supplementary Billing Flag complete', { licenceId: result.licenceId })
   } catch (error) {
-    global.GlobalNotifier.omfg('Supplementary Billing Flag failed', payload, error)
+    globalThis.GlobalNotifier.omfg('Supplementary Billing Flag failed', payload, error)
   }
 }
 

--- a/app/services/notices/setup/send/send-notice.service.js
+++ b/app/services/notices/setup/send/send-notice.service.js
@@ -44,7 +44,7 @@ async function go(notice, notifications) {
 
     calculateAndLogTimeTaken(startTime, 'Send notice complete', { count: notifications.length, noticeId })
   } catch (error) {
-    global.GlobalNotifier.omfg('Send notice failed', { notice }, error)
+    globalThis.GlobalNotifier.omfg('Send notice failed', { notice }, error)
   }
 }
 

--- a/app/services/notifications/check-notification-status.service.js
+++ b/app/services/notifications/check-notification-status.service.js
@@ -94,7 +94,7 @@ async function _notifyStatus(notifyId) {
     return response.body.status
   }
 
-  global.GlobalNotifier.omfg('Check notification status failed', { notifyId, response })
+  globalThis.GlobalNotifier.omfg('Check notification status failed', { notifyId, response })
 
   return null
 }
@@ -164,7 +164,7 @@ async function _recordStatus(notification, notifyStatus, status) {
       await _recordReturnLogs(notification, status, trx)
     })
   } catch (error) {
-    global.GlobalNotifier.omfg('Check notification status failed', notification, error)
+    globalThis.GlobalNotifier.omfg('Check notification status failed', notification, error)
   }
 }
 

--- a/app/services/notifications/process-returned-letter.service.js
+++ b/app/services/notifications/process-returned-letter.service.js
@@ -41,7 +41,7 @@ async function go(payload) {
       notification: { ...updatedNotifications[0] }
     })
   } catch (error) {
-    global.GlobalNotifier.omfg('Returned letter failed', payload, error)
+    globalThis.GlobalNotifier.omfg('Returned letter failed', payload, error)
   }
 }
 

--- a/app/services/plugins/error-pages.service.js
+++ b/app/services/plugins/error-pages.service.js
@@ -70,13 +70,13 @@ function _logError(statusCode, request) {
   const { response } = request
 
   if (statusCode === HTTP_STATUS_NOT_FOUND) {
-    global.GlobalNotifier.omg('Page not found', { path: request.path })
+    globalThis.GlobalNotifier.omg('Page not found', { path: request.path })
   } else if (statusCode === HTTP_STATUS_FORBIDDEN) {
-    global.GlobalNotifier.omg('Not authorised', { path: request.path })
+    globalThis.GlobalNotifier.omg('Not authorised', { path: request.path })
   } else if (statusCode === HTTP_STATUS_GONE) {
-    global.GlobalNotifier.omg('Session not found', { path: request.path })
+    globalThis.GlobalNotifier.omg('Session not found', { path: request.path })
   } else if (response.isBoom) {
-    global.GlobalNotifier.omfg(response.message, {}, response)
+    globalThis.GlobalNotifier.omfg(response.message, {}, response)
   }
 }
 

--- a/app/services/return-versions/setup/check/submit-check.service.js
+++ b/app/services/return-versions/setup/check/submit-check.service.js
@@ -74,7 +74,7 @@ async function go(sessionId, userId) {
 
     return licence.id
   } catch (error) {
-    global.GlobalNotifier.omfg('Failed to create return version', session, error)
+    globalThis.GlobalNotifier.omfg('Failed to create return version', session, error)
 
     throw error
   }

--- a/app/views/filters/markdown.filter.js
+++ b/app/views/filters/markdown.filter.js
@@ -30,11 +30,11 @@ function markdown(input = '') {
   const replacedCaret = input.replace(/\^/gm, '>')
 
   // NOTE: See app/plugins/views.plugin.js for details why marked is in the global scope rather than just required().
-  if (!global.GlobalMarked) {
+  if (!globalThis.GlobalMarked) {
     return input
   }
 
-  return global.GlobalMarked.parse(replacedCaret)
+  return globalThis.GlobalMarked.parse(replacedCaret)
 }
 
 module.exports = {

--- a/test/lib/general.lib.test.js
+++ b/test/lib/general.lib.test.js
@@ -38,11 +38,11 @@ describe('GeneralLib', () => {
       // creating an instance of Hapi server in this test we recreate the condition by setting it directly with our own
       // stub
       notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
-      global.GlobalNotifier = notifierStub
+      globalThis.GlobalNotifier = notifierStub
     })
 
     afterEach(() => {
-      delete global.GlobalNotifier
+      delete globalThis.GlobalNotifier
     })
 
     describe('when no additional data is provided', () => {

--- a/test/plugins/error-pages.plugin.test.js
+++ b/test/plugins/error-pages.plugin.test.js
@@ -34,7 +34,7 @@ describe('Error Pages plugin', () => {
     server = await init()
 
     notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
-    global.GlobalNotifier = notifierStub
+    globalThis.GlobalNotifier = notifierStub
   })
 
   afterEach(() => {
@@ -42,7 +42,7 @@ describe('Error Pages plugin', () => {
   })
 
   after(() => {
-    delete global.GlobalNotifier
+    delete globalThis.GlobalNotifier
   })
 
   describe('When the response is a Boom error', () => {

--- a/test/plugins/global-notifier.plugin.test.js
+++ b/test/plugins/global-notifier.plugin.test.js
@@ -22,7 +22,7 @@ describe('Global Notifier plugin', () => {
   describe('Global Notifier Plugin', () => {
     describe('when the server is initialised', () => {
       it('makes an instance of GlobalNotifierLib available globally', async () => {
-        const result = global.GlobalNotifier
+        const result = globalThis.GlobalNotifier
 
         expect(result).to.be.an.instanceOf(GlobalNotifierLib)
       })

--- a/test/plugins/keep-yar-alive.plugin.test.js
+++ b/test/plugins/keep-yar-alive.plugin.test.js
@@ -49,12 +49,12 @@ describe('Keep Yar Alive plugin', () => {
     })
 
     notifierStub = { omfg: Sinon.stub() }
-    global.GlobalNotifier = notifierStub
+    globalThis.GlobalNotifier = notifierStub
   })
 
   afterEach(() => {
     Sinon.restore()
-    delete global.GlobalNotifier
+    delete globalThis.GlobalNotifier
   })
 
   it('registers successfully', () => {
@@ -78,7 +78,7 @@ describe('Keep Yar Alive plugin', () => {
 
       expect(yarStub.touch.called).to.be.true()
 
-      expect(global.GlobalNotifier.omfg.called).to.be.false()
+      expect(globalThis.GlobalNotifier.omfg.called).to.be.false()
     })
   })
 
@@ -99,7 +99,7 @@ describe('Keep Yar Alive plugin', () => {
 
       expect(yarStub.touch.called).to.be.false()
 
-      expect(global.GlobalNotifier.omfg.called).to.be.false()
+      expect(globalThis.GlobalNotifier.omfg.called).to.be.false()
     })
   })
 
@@ -112,7 +112,7 @@ describe('Keep Yar Alive plugin', () => {
 
       expect(yarStub.touch.called).to.be.false()
 
-      expect(global.GlobalNotifier.omfg.called).to.be.false()
+      expect(globalThis.GlobalNotifier.omfg.called).to.be.false()
     })
   })
 
@@ -131,7 +131,7 @@ describe('Keep Yar Alive plugin', () => {
       expect(response.statusCode).to.equal(HTTP_STATUS_OK)
       expect(response.result).to.equal('ok')
 
-      expect(global.GlobalNotifier.omfg.firstCall.args[0]).to.include('Failed to keep session alive')
+      expect(globalThis.GlobalNotifier.omfg.firstCall.args[0]).to.include('Failed to keep session alive')
     })
   })
 })

--- a/test/requests/base.request.test.js
+++ b/test/requests/base.request.test.js
@@ -45,14 +45,14 @@ describe('Base Request', () => {
     // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
     // test we recreate the condition by setting it directly with our own stub
     notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
-    global.GlobalNotifier = notifierStub
+    globalThis.GlobalNotifier = notifierStub
   })
 
   afterEach(() => {
     Sinon.restore()
     Nock.cleanAll()
     Nock.restore()
-    delete global.GlobalNotifier
+    delete globalThis.GlobalNotifier
   })
 
   describe('#delete()', () => {

--- a/test/requests/charging-module.request.test.js
+++ b/test/requests/charging-module.request.test.js
@@ -28,7 +28,7 @@ describe('Charging Module Request', () => {
   before(async () => {
     // ChargingModuleRequest makes use of the getChargingModuleToken() server method, which we therefore need to stub
     // Note that we only need to do this once as it is unaffected by the Sinon.restore() in our afterEach()
-    global.HapiServerMethods = {
+    globalThis.HapiServerMethods = {
       getChargingModuleToken: Sinon.stub().resolves({
         accessToken: 'ACCESS_TOKEN',
         expiresIn: 3600
@@ -49,7 +49,7 @@ describe('Charging Module Request', () => {
 
   after(() => {
     // Tidy up our global server methods stub once done
-    delete global.HapiServerMethods
+    delete globalThis.HapiServerMethods
   })
 
   describe('#delete', () => {

--- a/test/requests/notify.request.test.js
+++ b/test/requests/notify.request.test.js
@@ -25,7 +25,7 @@ describe('Notify Request', () => {
   before(async () => {
     // NotifyRequest makes use of the getNotifyToken() server method, which we therefore need to stub.
     // Note that we only need to do this once as it is unaffected by the Sinon.restore() in our afterEach()
-    global.HapiServerMethods = {
+    globalThis.HapiServerMethods = {
       getNotifyToken: Sinon.stub().resolves('ACCESS_TOKEN')
     }
   })
@@ -45,7 +45,7 @@ describe('Notify Request', () => {
 
   after(() => {
     // Tidy up our global server methods stub once done
-    delete global.HapiServerMethods
+    delete globalThis.HapiServerMethods
   })
 
   describe('#get', () => {

--- a/test/requests/resp.request.test.js
+++ b/test/requests/resp.request.test.js
@@ -22,7 +22,7 @@ describe('ReSP API Request', () => {
   before(() => {
     // RespRequest makes use of the getRespToken() server method, which we therefore need to stub
     // Note that we only need to do this once as it is unaffected by the Sinon.restore() in our afterEach()
-    global.HapiServerMethods = {
+    globalThis.HapiServerMethods = {
       getRespToken: Sinon.stub().resolves({
         accessToken: 'ACCESS_TOKEN',
         expiresIn: 3600
@@ -36,7 +36,7 @@ describe('ReSP API Request', () => {
 
   after(() => {
     // Tidy up our global server methods stub once done
-    delete global.HapiServerMethods
+    delete globalThis.HapiServerMethods
   })
 
   describe('#get', () => {

--- a/test/services/bill-runs/annual/process-bill-run.service.test.js
+++ b/test/services/bill-runs/annual/process-bill-run.service.test.js
@@ -43,12 +43,12 @@ describe('Annual Process Bill Run service', () => {
     // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
     // test we recreate the condition by setting it directly with our own stub
     notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
-    global.GlobalNotifier = notifierStub
+    globalThis.GlobalNotifier = notifierStub
   })
 
   afterEach(() => {
     Sinon.restore()
-    delete global.GlobalNotifier
+    delete globalThis.GlobalNotifier
   })
 
   describe('when the service is called', () => {

--- a/test/services/bill-runs/cancel/delete-bill-run.service.test.js
+++ b/test/services/bill-runs/cancel/delete-bill-run.service.test.js
@@ -42,12 +42,12 @@ describe('Bill Runs - Delete Bill Run service', () => {
     // creating an instance of Hapi server in this test we recreate the condition by setting it directly with our
     // own stub
     notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
-    global.GlobalNotifier = notifierStub
+    globalThis.GlobalNotifier = notifierStub
   })
 
   afterEach(() => {
     Sinon.restore()
-    delete global.GlobalNotifier
+    delete globalThis.GlobalNotifier
   })
 
   describe('when the bill run exists', () => {

--- a/test/services/bill-runs/generate-two-part-tariff-bill-run.service.test.js
+++ b/test/services/bill-runs/generate-two-part-tariff-bill-run.service.test.js
@@ -48,7 +48,7 @@ describe('Bill Runs - Generate Two Part Tariff Bill Run service', () => {
 
   afterEach(() => {
     Sinon.restore()
-    delete global.GlobalNotifier
+    delete globalThis.GlobalNotifier
   })
 
   describe('when called', () => {

--- a/test/services/bill-runs/handle-errored-bill-run.service.test.js
+++ b/test/services/bill-runs/handle-errored-bill-run.service.test.js
@@ -25,12 +25,12 @@ describe('Handle Errored Bill Run service', () => {
     // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
     // test we recreate the condition by setting it directly with our own stub
     notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
-    global.GlobalNotifier = notifierStub
+    globalThis.GlobalNotifier = notifierStub
   })
 
   afterEach(() => {
     Sinon.restore()
-    delete global.GlobalNotifier
+    delete globalThis.GlobalNotifier
   })
 
   describe('when the service is called successfully', () => {

--- a/test/services/bill-runs/match/fetch-return-logs-for-licence.service.test.js
+++ b/test/services/bill-runs/match/fetch-return-logs-for-licence.service.test.js
@@ -27,12 +27,12 @@ describe('Fetch Return Logs for Licence service', () => {
     // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
     // test we recreate the condition by setting it directly with our own stub
     notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
-    global.GlobalNotifier = notifierStub
+    globalThis.GlobalNotifier = notifierStub
   })
 
   afterEach(() => {
     Sinon.restore()
-    delete global.GlobalNotifier
+    delete globalThis.GlobalNotifier
   })
 
   describe('when there are valid return logs that should be considered', () => {

--- a/test/services/bill-runs/match/match-and-allocate.service.test.js
+++ b/test/services/bill-runs/match/match-and-allocate.service.test.js
@@ -27,12 +27,12 @@ describe('Bill Runs - Match - Match And Allocate service', () => {
 
   beforeEach(() => {
     notifierStub = { omg: Sinon.stub() }
-    global.GlobalNotifier = notifierStub
+    globalThis.GlobalNotifier = notifierStub
   })
 
   afterEach(async () => {
     Sinon.restore()
-    delete global.GlobalNotifier
+    delete globalThis.GlobalNotifier
   })
 
   describe('with a given billRun and billingPeriods', () => {

--- a/test/services/bill-runs/reissue/fetch-bills-to-be-reissued.service.test.js
+++ b/test/services/bill-runs/reissue/fetch-bills-to-be-reissued.service.test.js
@@ -110,12 +110,12 @@ describe('Fetch Bills To Be Reissued service', () => {
 
     beforeEach(() => {
       notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
-      global.GlobalNotifier = notifierStub
+      globalThis.GlobalNotifier = notifierStub
     })
 
     afterEach(() => {
       Sinon.restore()
-      delete global.GlobalNotifier
+      delete globalThis.GlobalNotifier
     })
 
     it('logs an error', async () => {

--- a/test/services/bill-runs/reissue/reissue-bills.service.test.js
+++ b/test/services/bill-runs/reissue/reissue-bills.service.test.js
@@ -35,12 +35,12 @@ describe('Reissue Bills service', () => {
     // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
     // test we recreate the condition by setting it directly with our own stub
     notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
-    global.GlobalNotifier = notifierStub
+    globalThis.GlobalNotifier = notifierStub
   })
 
   afterEach(() => {
     Sinon.restore()
-    delete global.GlobalNotifier
+    delete globalThis.GlobalNotifier
   })
 
   describe('when the service is called', () => {

--- a/test/services/bill-runs/send/update-invoice-numbers.service.test.js
+++ b/test/services/bill-runs/send/update-invoice-numbers.service.test.js
@@ -42,12 +42,12 @@ describe('Bill Runs - Send - Update Invoice Numbers service', () => {
     // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
     // test we recreate the condition by setting it directly with our own stub
     notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
-    global.GlobalNotifier = notifierStub
+    globalThis.GlobalNotifier = notifierStub
   })
 
   afterEach(() => {
     Sinon.restore()
-    delete global.GlobalNotifier
+    delete globalThis.GlobalNotifier
   })
 
   describe('when the bill run exists', () => {

--- a/test/services/bill-runs/supplementary/process-bill-run.service.test.js
+++ b/test/services/bill-runs/supplementary/process-bill-run.service.test.js
@@ -52,12 +52,12 @@ describe('Bill Runs - Supplementary - Process Bill Run service', () => {
     // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
     // test we recreate the condition by setting it directly with our own stub
     notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
-    global.GlobalNotifier = notifierStub
+    globalThis.GlobalNotifier = notifierStub
   })
 
   afterEach(() => {
     Sinon.restore()
-    delete global.GlobalNotifier
+    delete globalThis.GlobalNotifier
   })
 
   describe('when the service is called', () => {

--- a/test/services/bill-runs/tpt-supplementary/generate-bill-run.service.test.js
+++ b/test/services/bill-runs/tpt-supplementary/generate-bill-run.service.test.js
@@ -52,12 +52,12 @@ describe('Bill Runs - TPT Supplementary - Generate Bill Run service', () => {
     // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
     // test we recreate the condition by setting it directly with our own stub
     notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
-    global.GlobalNotifier = notifierStub
+    globalThis.GlobalNotifier = notifierStub
   })
 
   afterEach(() => {
     Sinon.restore()
-    delete global.GlobalNotifier
+    delete globalThis.GlobalNotifier
   })
 
   describe('when called', () => {

--- a/test/services/bill-runs/tpt-supplementary/process-bill-run.service.test.js
+++ b/test/services/bill-runs/tpt-supplementary/process-bill-run.service.test.js
@@ -40,12 +40,12 @@ describe('Bill Runs - TPT Supplementary - Process Bill Run service', () => {
     // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
     // test we recreate the condition by setting it directly with our own stub
     notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
-    global.GlobalNotifier = notifierStub
+    globalThis.GlobalNotifier = notifierStub
   })
 
   afterEach(() => {
     Sinon.restore()
-    delete global.GlobalNotifier
+    delete globalThis.GlobalNotifier
   })
 
   describe('when the service is called', () => {

--- a/test/services/bill-runs/two-part-tariff/generate-bill-run.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/generate-bill-run.service.test.js
@@ -49,12 +49,12 @@ describe('Bill Runs - Two Part Tariff - Generate Bill Run service', () => {
     // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
     // test we recreate the condition by setting it directly with our own stub
     notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
-    global.GlobalNotifier = notifierStub
+    globalThis.GlobalNotifier = notifierStub
   })
 
   afterEach(() => {
     Sinon.restore()
-    delete global.GlobalNotifier
+    delete globalThis.GlobalNotifier
   })
 
   describe('when called', () => {

--- a/test/services/bill-runs/two-part-tariff/process-bill-run.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/process-bill-run.service.test.js
@@ -35,12 +35,12 @@ describe('Bill Runs - Two Part Tariff - Process Bill Run service', () => {
     // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
     // test we recreate the condition by setting it directly with our own stub
     notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
-    global.GlobalNotifier = notifierStub
+    globalThis.GlobalNotifier = notifierStub
   })
 
   afterEach(() => {
     Sinon.restore()
-    delete global.GlobalNotifier
+    delete globalThis.GlobalNotifier
   })
 
   describe('when the service is called', () => {

--- a/test/services/data/tear-down/tear-down.service.test.js
+++ b/test/services/data/tear-down/tear-down.service.test.js
@@ -37,12 +37,12 @@ describe('Tear down service', () => {
     // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
     // test we recreate the condition by setting it directly with our own stub
     notifierStub = { omg: Sinon.stub() }
-    global.GlobalNotifier = notifierStub
+    globalThis.GlobalNotifier = notifierStub
   })
 
   afterEach(() => {
     Sinon.restore()
-    delete global.GlobalNotifier
+    delete globalThis.GlobalNotifier
   })
 
   it('tears down the schemas', async () => {

--- a/test/services/jobs/clean/clean-empty-bill-runs.service.test.js
+++ b/test/services/jobs/clean/clean-empty-bill-runs.service.test.js
@@ -47,12 +47,12 @@ describe('Jobs - Clean - Clean Empty Bill Runs service', () => {
     // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
     // test we recreate the condition by setting it directly with our own stub
     notifierStub = { omfg: Sinon.stub() }
-    global.GlobalNotifier = notifierStub
+    globalThis.GlobalNotifier = notifierStub
   })
 
   afterEach(() => {
     Sinon.restore()
-    delete global.GlobalNotifier
+    delete globalThis.GlobalNotifier
   })
 
   describe('when no bill runs are flagged as "empty"', () => {

--- a/test/services/jobs/clean/clean-empty-void-return-logs.service.test.js
+++ b/test/services/jobs/clean/clean-empty-void-return-logs.service.test.js
@@ -25,12 +25,12 @@ describe('Jobs - Clean - Clean Empty Void Return Logs service', () => {
     // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
     // test we recreate the condition by setting it directly with our own stub
     notifierStub = { omfg: Sinon.stub() }
-    global.GlobalNotifier = notifierStub
+    globalThis.GlobalNotifier = notifierStub
   })
 
   afterEach(() => {
     Sinon.restore()
-    delete global.GlobalNotifier
+    delete globalThis.GlobalNotifier
   })
 
   describe('when the clean is successful', () => {

--- a/test/services/jobs/clean/clean-expired-sessions.service.test.js
+++ b/test/services/jobs/clean/clean-expired-sessions.service.test.js
@@ -28,12 +28,12 @@ describe('Jobs - Clean - Clean Expired Sessions service', () => {
     // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
     // test we recreate the condition by setting it directly with our own stub
     notifierStub = { omfg: Sinon.stub() }
-    global.GlobalNotifier = notifierStub
+    globalThis.GlobalNotifier = notifierStub
   })
 
   afterEach(() => {
     Sinon.restore()
-    delete global.GlobalNotifier
+    delete globalThis.GlobalNotifier
   })
 
   describe('when the clean is successful', () => {

--- a/test/services/jobs/clean/clean-incomplete-company-contacts.service.test.js
+++ b/test/services/jobs/clean/clean-incomplete-company-contacts.service.test.js
@@ -28,12 +28,12 @@ describe('Jobs - Clean - Clean Incomplete Company Contacts service', () => {
     // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
     // test we recreate the condition by setting it directly with our own stub
     notifierStub = { omfg: Sinon.stub() }
-    global.GlobalNotifier = notifierStub
+    globalThis.GlobalNotifier = notifierStub
   })
 
   afterEach(async () => {
     Sinon.restore()
-    delete global.GlobalNotifier
+    delete globalThis.GlobalNotifier
 
     await contact.$query().delete()
     await companyContact.$query().delete()

--- a/test/services/jobs/clean/clean-orphaned-contacts.service.test.js
+++ b/test/services/jobs/clean/clean-orphaned-contacts.service.test.js
@@ -30,12 +30,12 @@ describe('Jobs - Clean - Clean Orphaned Contacts service', () => {
     // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
     // test we recreate the condition by setting it directly with our own stub
     notifierStub = { omfg: Sinon.stub() }
-    global.GlobalNotifier = notifierStub
+    globalThis.GlobalNotifier = notifierStub
   })
 
   afterEach(async () => {
     Sinon.restore()
-    delete global.GlobalNotifier
+    delete globalThis.GlobalNotifier
 
     await contact.$query().delete()
 

--- a/test/services/jobs/clean/process-clean.service.test.js
+++ b/test/services/jobs/clean/process-clean.service.test.js
@@ -45,12 +45,12 @@ describe('Jobs - Clean - Process Clean service', () => {
     // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
     // test we recreate the condition by setting it directly with our own stub
     notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
-    global.GlobalNotifier = notifierStub
+    globalThis.GlobalNotifier = notifierStub
   })
 
   afterEach(() => {
     Sinon.restore()
-    delete global.GlobalNotifier
+    delete globalThis.GlobalNotifier
   })
 
   describe('when all clean tasks succeed', () => {

--- a/test/services/jobs/customer-files/process-customer-files.service.test.js
+++ b/test/services/jobs/customer-files/process-customer-files.service.test.js
@@ -33,12 +33,12 @@ describe('Jobs - Customer Files - Process Customer Files service', () => {
     // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
     // test we recreate the condition by setting it directly with our own stub
     notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub(), redAlert: Sinon.stub() }
-    global.GlobalNotifier = notifierStub
+    globalThis.GlobalNotifier = notifierStub
   })
 
   afterEach(() => {
     Sinon.restore()
-    delete global.GlobalNotifier
+    delete globalThis.GlobalNotifier
   })
 
   describe('when the Charging Module API response has customer files', () => {

--- a/test/services/jobs/export/delete-files.service.test.js
+++ b/test/services/jobs/export/delete-files.service.test.js
@@ -25,7 +25,7 @@ describe('Delete Files service', () => {
     folderNameWithPath = 'testFolder'
     filenameWithPath = path.join(folderNameWithPath, 'testFile')
     notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
-    global.GlobalNotifier = notifierStub
+    globalThis.GlobalNotifier = notifierStub
 
     mockFs({
       testFolder: {
@@ -37,7 +37,7 @@ describe('Delete Files service', () => {
   afterEach(() => {
     mockFs.restore()
     Sinon.restore()
-    delete global.GlobalNotifier
+    delete globalThis.GlobalNotifier
   })
 
   describe('When a valid folder is specified', () => {

--- a/test/services/jobs/export/export.service.test.js
+++ b/test/services/jobs/export/export.service.test.js
@@ -21,12 +21,12 @@ describe('Export Service', () => {
   beforeEach(async () => {
     SchemaExportServiceStub = Sinon.stub(SchemaExportService, 'go').resolves()
     notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
-    global.GlobalNotifier = notifierStub
+    globalThis.GlobalNotifier = notifierStub
   })
 
   afterEach(() => {
     Sinon.restore()
-    delete global.GlobalNotifier
+    delete globalThis.GlobalNotifier
   })
 
   it('calls the SchemaExportService with the different schema names', async () => {

--- a/test/services/jobs/export/schema-export.service.test.js
+++ b/test/services/jobs/export/schema-export.service.test.js
@@ -83,12 +83,12 @@ describe('Schema export service', () => {
       DeleteFilesServiceStub = Sinon.stub(DeleteFilesService, 'go').resolves()
 
       notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
-      global.GlobalNotifier = notifierStub
+      globalThis.GlobalNotifier = notifierStub
     })
 
     afterEach(() => {
       Sinon.restore()
-      delete global.GlobalNotifier
+      delete globalThis.GlobalNotifier
     })
 
     it('catches the error', async () => {

--- a/test/services/jobs/licence-updates/process-licence-updates.service.test.js
+++ b/test/services/jobs/licence-updates/process-licence-updates.service.test.js
@@ -27,12 +27,12 @@ describe('Jobs - Licence Updates - Process Licence Updates service', () => {
     // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
     // test we recreate the condition by setting it directly with our own stub
     notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub(), redAlert: Sinon.stub() }
-    global.GlobalNotifier = notifierStub
+    globalThis.GlobalNotifier = notifierStub
   })
 
   afterEach(() => {
     Sinon.restore()
-    delete global.GlobalNotifier
+    delete globalThis.GlobalNotifier
   })
 
   describe('when there are licence updates', () => {

--- a/test/services/jobs/notification-status/process-notification-status.service.test.js
+++ b/test/services/jobs/notification-status/process-notification-status.service.test.js
@@ -56,12 +56,12 @@ describe('Job - Notifications - Process Notification Status service', () => {
     // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
     // test we recreate the condition by setting it directly with our own stub
     notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub(), redAlert: Sinon.stub() }
-    global.GlobalNotifier = notifierStub
+    globalThis.GlobalNotifier = notifierStub
   })
 
   afterEach(() => {
     Sinon.restore()
-    delete global.GlobalNotifier
+    delete globalThis.GlobalNotifier
   })
 
   describe('when the notification status check does not error', () => {

--- a/test/services/jobs/renewal-invitations/process-renewal-invitations.service.test.js
+++ b/test/services/jobs/renewal-invitations/process-renewal-invitations.service.test.js
@@ -26,12 +26,12 @@ describe('Jobs - Renewal Invitations - Process Renewal Invitations service', () 
     // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
     // test we recreate the condition by setting it directly with our own stub
     notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
-    global.GlobalNotifier = notifierStub
+    globalThis.GlobalNotifier = notifierStub
   })
 
   afterEach(() => {
     Sinon.restore()
-    delete global.GlobalNotifier
+    delete globalThis.GlobalNotifier
   })
 
   it('calls the "SendRenewalInvitations"', async () => {

--- a/test/services/jobs/return-logs/process-return-logs.service.test.js
+++ b/test/services/jobs/return-logs/process-return-logs.service.test.js
@@ -32,12 +32,12 @@ describe('Jobs - Return Logs - Process Return Logs service', () => {
     // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
     // test we recreate the condition by setting it directly with our own stub
     notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub(), redAlert: Sinon.stub() }
-    global.GlobalNotifier = notifierStub
+    globalThis.GlobalNotifier = notifierStub
   })
 
   afterEach(() => {
     Sinon.restore()
-    delete global.GlobalNotifier
+    delete globalThis.GlobalNotifier
   })
 
   describe('when the requested return cycle exists', () => {

--- a/test/services/jobs/time-limited/process-time-limited-licences.service.test.js
+++ b/test/services/jobs/time-limited/process-time-limited-licences.service.test.js
@@ -27,12 +27,12 @@ describe('Process Time Limited Licences service', () => {
     // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
     // test we recreate the condition by setting it directly with our own stub
     notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub(), redAlert: Sinon.stub() }
-    global.GlobalNotifier = notifierStub
+    globalThis.GlobalNotifier = notifierStub
   })
 
   afterEach(() => {
     Sinon.restore()
-    delete global.GlobalNotifier
+    delete globalThis.GlobalNotifier
   })
 
   describe('when there are licences with time limited charge elements', () => {

--- a/test/services/licences/end-dates/check-all-licence-end-dates.service.test.js
+++ b/test/services/licences/end-dates/check-all-licence-end-dates.service.test.js
@@ -37,12 +37,12 @@ describe('Licences - End Dates - Check All Licence End Dates service', () => {
     // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
     // test we recreate the condition by setting it directly with our own stub
     notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
-    global.GlobalNotifier = notifierStub
+    globalThis.GlobalNotifier = notifierStub
   })
 
   afterEach(() => {
     Sinon.restore()
-    delete global.GlobalNotifier
+    delete globalThis.GlobalNotifier
   })
 
   describe('when processing the licences', () => {

--- a/test/services/licences/end-dates/check-licence-end-dates.service.test.js
+++ b/test/services/licences/end-dates/check-licence-end-dates.service.test.js
@@ -35,12 +35,12 @@ describe('Licences - End Dates - Check Licence End Dates service', () => {
     // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
     // test we recreate the condition by setting it directly with our own stub
     notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
-    global.GlobalNotifier = notifierStub
+    globalThis.GlobalNotifier = notifierStub
   })
 
   afterEach(async () => {
     Sinon.restore()
-    delete global.GlobalNotifier
+    delete globalThis.GlobalNotifier
 
     if (licenceEndDateChanges) {
       await licenceEndDateChanges.$query().delete()

--- a/test/services/licences/end-dates/process-licence-end-date-changes.service.test.js
+++ b/test/services/licences/end-dates/process-licence-end-date-changes.service.test.js
@@ -32,12 +32,12 @@ describe('Licences - End Dates - Process Licence End Date Changes service', () =
     // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
     // test we recreate the condition by setting it directly with our own stub
     notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
-    global.GlobalNotifier = notifierStub
+    globalThis.GlobalNotifier = notifierStub
   })
 
   afterEach(() => {
     Sinon.restore()
-    delete global.GlobalNotifier
+    delete globalThis.GlobalNotifier
   })
 
   describe('when processing the licence end date changes', () => {

--- a/test/services/licences/supplementary/process-billing-flag.service.test.js
+++ b/test/services/licences/supplementary/process-billing-flag.service.test.js
@@ -32,12 +32,12 @@ describe('Licences - Supplementary - Process Billing Flag service', () => {
     // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
     // test we recreate the condition by setting it directly with our own stub
     notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
-    global.GlobalNotifier = notifierStub
+    globalThis.GlobalNotifier = notifierStub
   })
 
   afterEach(() => {
     Sinon.restore()
-    delete global.GlobalNotifier
+    delete globalThis.GlobalNotifier
   })
 
   describe('when given a valid payload', () => {

--- a/test/services/notices/setup/prepare-paper-return.service.test.js
+++ b/test/services/notices/setup/prepare-paper-return.service.test.js
@@ -68,12 +68,12 @@ describe('Notices - Setup - Prepare Paper Return service', () => {
     })
 
     notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
-    global.GlobalNotifier = notifierStub
+    globalThis.GlobalNotifier = notifierStub
   })
 
   afterEach(() => {
     Sinon.restore()
-    delete global.GlobalNotifier
+    delete globalThis.GlobalNotifier
   })
 
   describe('when called', () => {

--- a/test/services/notices/setup/process-preview-paper-return.service.test.js
+++ b/test/services/notices/setup/process-preview-paper-return.service.test.js
@@ -69,12 +69,12 @@ describe('Notices - Setup - Process Preview Paper Return service', () => {
     ])
 
     notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
-    global.GlobalNotifier = notifierStub
+    globalThis.GlobalNotifier = notifierStub
   })
 
   afterEach(() => {
     Sinon.restore()
-    delete global.GlobalNotifier
+    delete globalThis.GlobalNotifier
   })
 
   describe('when called', () => {

--- a/test/services/notices/setup/send/send-notice.service.test.js
+++ b/test/services/notices/setup/send/send-notice.service.test.js
@@ -36,7 +36,7 @@ describe('Notices - Setup - Send - Send Notice service', () => {
     // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
     // test we recreate the condition by setting it directly with our own stub
     notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
-    global.GlobalNotifier = notifierStub
+    globalThis.GlobalNotifier = notifierStub
   })
 
   afterEach(() => {

--- a/test/services/notifications/check-notification-status.service.test.js
+++ b/test/services/notifications/check-notification-status.service.test.js
@@ -46,12 +46,12 @@ describe('Notifications - Check Notification Status service', () => {
     returnLogPatchStub = Sinon.stub().returnsThis()
 
     notifierStub = { omfg: Sinon.stub() }
-    global.GlobalNotifier = notifierStub
+    globalThis.GlobalNotifier = notifierStub
   })
 
   afterEach(() => {
     Sinon.restore()
-    delete global.GlobalNotifier
+    delete globalThis.GlobalNotifier
   })
 
   describe('when the notification is a returns invitation', () => {

--- a/test/services/notifications/process-returned-letter.service.test.js
+++ b/test/services/notifications/process-returned-letter.service.test.js
@@ -40,12 +40,12 @@ describe('Notifications - Process Returned Letter service', () => {
     })
 
     notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
-    global.GlobalNotifier = notifierStub
+    globalThis.GlobalNotifier = notifierStub
   })
 
   afterEach(() => {
     Sinon.restore()
-    delete global.GlobalNotifier
+    delete globalThis.GlobalNotifier
 
     if (notification) {
       notification.$query().delete()

--- a/test/services/plugins/error-pages.service.test.js
+++ b/test/services/plugins/error-pages.service.test.js
@@ -62,12 +62,12 @@ describe('Error pages service', () => {
 
   beforeEach(() => {
     notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
-    global.GlobalNotifier = notifierStub
+    globalThis.GlobalNotifier = notifierStub
   })
 
   afterEach(() => {
     Sinon.restore()
-    delete global.GlobalNotifier
+    delete globalThis.GlobalNotifier
   })
 
   describe('when the response is a boom 500 error', () => {

--- a/test/services/return-versions/setup/check/submit-check.service.test.js
+++ b/test/services/return-versions/setup/check/submit-check.service.test.js
@@ -149,12 +149,12 @@ describe('Return Versions - Setup - Submit Check service', () => {
     // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
     // test we recreate the condition by setting it directly with our own stub
     notifierStub = { omfg: Sinon.stub() }
-    global.GlobalNotifier = notifierStub
+    globalThis.GlobalNotifier = notifierStub
   })
 
   afterEach(() => {
     Sinon.restore()
-    delete global.GlobalNotifier
+    delete globalThis.GlobalNotifier
   })
 
   describe('when called to create a new return version', () => {


### PR DESCRIPTION
## Overview

Replaces all usages of the Node.js `global` object with `globalThis` across app and test files, resolving SonarCloud rule S7764.

`globalThis` is the standard cross-environment way to reference the global object in modern JavaScript (Node.js 12+). The three globals set by this app's plugins are all updated:

- `global.GlobalNotifier` → `globalThis.GlobalNotifier`
- `global.GlobalMarked` → `globalThis.GlobalMarked`
- `global.HapiServerMethods` → `globalThis.HapiServerMethods`

## Notes

`global` and `globalThis` are the same object in Node.js so there is no behavioural change. Test files that mock these globals via `globalThis.GlobalNotifier = stub` / `delete globalThis.GlobalNotifier` continue to work correctly and have been updated for consistency.

## Files changed

- 47 app files updated
- 49 test files updated

## Test plan

- [x] Lint passes (`npm run lint`)
- [x] Tests run via Docker across a broad sample of changed files — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)