### PR TITLE
Extract repeated GlobalNotifier stub setup into a shared stub file

### DIFF
--- a/test/lib/general.lib.test.js
+++ b/test/lib/general.lib.test.js
@@ -13,6 +13,7 @@ const TransactionHelper = require('../support/helpers/transaction.helper.js')
 
 // Thing under test
 const GeneralLib = require('../../app/lib/general.lib.js')
+const GlobalNotifierStub = require('../support/stubs/global-notifier.stub.js')
 
 describe('GeneralLib', () => {
   let clock
@@ -37,7 +38,7 @@ describe('GeneralLib', () => {
       // app/plugins/global-notifier.plugin.js when the app starts up and the plugin is registered. As we're not
       // creating an instance of Hapi server in this test we recreate the condition by setting it directly with our own
       // stub
-      notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
+      notifierStub = GlobalNotifierStub.build(Sinon)
       global.GlobalNotifier = notifierStub
     })
 

--- a/test/lib/general.lib.test.js
+++ b/test/lib/general.lib.test.js
@@ -11,9 +11,11 @@ const { expect } = Code
 // Test helpers
 const TransactionHelper = require('../support/helpers/transaction.helper.js')
 
+// Things we need to stub
+const GlobalNotifierStub = require('../support/stubs/global-notifier.stub.js')
+
 // Thing under test
 const GeneralLib = require('../../app/lib/general.lib.js')
-const GlobalNotifierStub = require('../support/stubs/global-notifier.stub.js')
 
 describe('GeneralLib', () => {
   let clock

--- a/test/plugins/error-pages.plugin.test.js
+++ b/test/plugins/error-pages.plugin.test.js
@@ -22,6 +22,7 @@ const SessionNotFoundError = require('../../app/errors/session-not-found.error.j
 
 // For running our service
 const { init } = require('../../app/server.js')
+const GlobalNotifierStub = require('../support/stubs/global-notifier.stub.js')
 
 describe('Error Pages plugin', () => {
   let handler
@@ -33,7 +34,7 @@ describe('Error Pages plugin', () => {
     // Create server before running the tests
     server = await init()
 
-    notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
+    notifierStub = GlobalNotifierStub.build(Sinon)
     global.GlobalNotifier = notifierStub
   })
 

--- a/test/plugins/error-pages.plugin.test.js
+++ b/test/plugins/error-pages.plugin.test.js
@@ -20,9 +20,11 @@ const {
 const Boom = require('@hapi/boom')
 const SessionNotFoundError = require('../../app/errors/session-not-found.error.js')
 
+// Things we need to stub
+const GlobalNotifierStub = require('../support/stubs/global-notifier.stub.js')
+
 // For running our service
 const { init } = require('../../app/server.js')
-const GlobalNotifierStub = require('../support/stubs/global-notifier.stub.js')
 
 describe('Error Pages plugin', () => {
   let handler

--- a/test/plugins/keep-yar-alive.plugin.test.js
+++ b/test/plugins/keep-yar-alive.plugin.test.js
@@ -14,6 +14,7 @@ const Hapi = require('@hapi/hapi')
 
 // Thing under test
 const KeepYarAlivePlugin = require('../../app/plugins/keep-yar-alive.plugin.js')
+const GlobalNotifierStub = require('../support/stubs/global-notifier.stub.js')
 
 describe('Keep Yar Alive plugin', () => {
   let notifierStub
@@ -48,7 +49,7 @@ describe('Keep Yar Alive plugin', () => {
       }
     })
 
-    notifierStub = { omfg: Sinon.stub() }
+    notifierStub = GlobalNotifierStub.build(Sinon)
     global.GlobalNotifier = notifierStub
   })
 

--- a/test/plugins/keep-yar-alive.plugin.test.js
+++ b/test/plugins/keep-yar-alive.plugin.test.js
@@ -12,9 +12,11 @@ const { expect } = Code
 const { HTTP_STATUS_OK } = require('node:http2').constants
 const Hapi = require('@hapi/hapi')
 
+// Things we need to stub
+const GlobalNotifierStub = require('../support/stubs/global-notifier.stub.js')
+
 // Thing under test
 const KeepYarAlivePlugin = require('../../app/plugins/keep-yar-alive.plugin.js')
-const GlobalNotifierStub = require('../support/stubs/global-notifier.stub.js')
 
 describe('Keep Yar Alive plugin', () => {
   let notifierStub

--- a/test/requests/base.request.test.js
+++ b/test/requests/base.request.test.js
@@ -13,9 +13,11 @@ const { expect } = Code
 const { HTTP_STATUS_INTERNAL_SERVER_ERROR, HTTP_STATUS_OK } = require('node:http2').constants
 const serverConfig = require('../../config/server.config.js')
 
+// Things we need to stub
+const GlobalNotifierStub = require('../support/stubs/global-notifier.stub.js')
+
 // Thing under test
 const BaseRequest = require('../../app/requests/base.request.js')
-const GlobalNotifierStub = require('../support/stubs/global-notifier.stub.js')
 
 describe('Base Request', () => {
   const testDomain = 'http://example.com'

--- a/test/requests/base.request.test.js
+++ b/test/requests/base.request.test.js
@@ -15,6 +15,7 @@ const serverConfig = require('../../config/server.config.js')
 
 // Thing under test
 const BaseRequest = require('../../app/requests/base.request.js')
+const GlobalNotifierStub = require('../support/stubs/global-notifier.stub.js')
 
 describe('Base Request', () => {
   const testDomain = 'http://example.com'
@@ -44,7 +45,7 @@ describe('Base Request', () => {
     // BaseRequest depends on the GlobalNotifier to have been set. This happens in app/plugins/global-notifier.plugin.js
     // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
     // test we recreate the condition by setting it directly with our own stub
-    notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
+    notifierStub = GlobalNotifierStub.build(Sinon)
     global.GlobalNotifier = notifierStub
   })
 

--- a/test/services/bill-runs/annual/process-bill-run.service.test.js
+++ b/test/services/bill-runs/annual/process-bill-run.service.test.js
@@ -15,6 +15,7 @@ const BillRunModel = require('../../../../app/models/bill-run.model.js')
 const { determineCurrentFinancialYear } = require('../../../../app/lib/general.lib.js')
 
 // Things we need to stub
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 const ChargingModuleGenerateRequest = require('../../../../app/requests/charging-module/generate-bill-run.request.js')
 const FetchBillingAccountsService = require('../../../../app/services/bill-runs/annual/fetch-billing-accounts.service.js')
 const HandleErroredBillRunService = require('../../../../app/services/bill-runs/handle-errored-bill-run.service.js')
@@ -23,7 +24,6 @@ const ProcessBillingPeriodService = require('../../../../app/services/bill-runs/
 
 // Thing under test
 const ProcessBillRunService = require('../../../../app/services/bill-runs/annual/process-bill-run.service.js')
-const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 
 describe('Annual Process Bill Run service', () => {
   const billingPeriod = determineCurrentFinancialYear()

--- a/test/services/bill-runs/annual/process-bill-run.service.test.js
+++ b/test/services/bill-runs/annual/process-bill-run.service.test.js
@@ -23,6 +23,7 @@ const ProcessBillingPeriodService = require('../../../../app/services/bill-runs/
 
 // Thing under test
 const ProcessBillRunService = require('../../../../app/services/bill-runs/annual/process-bill-run.service.js')
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 
 describe('Annual Process Bill Run service', () => {
   const billingPeriod = determineCurrentFinancialYear()
@@ -42,7 +43,7 @@ describe('Annual Process Bill Run service', () => {
     // BaseRequest depends on the GlobalNotifier to have been set. This happens in app/plugins/global-notifier.plugin.js
     // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
     // test we recreate the condition by setting it directly with our own stub
-    notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
+    notifierStub = GlobalNotifierStub.build(Sinon)
     global.GlobalNotifier = notifierStub
   })
 

--- a/test/services/bill-runs/annual/process-bill-run.service.test.js
+++ b/test/services/bill-runs/annual/process-bill-run.service.test.js
@@ -15,9 +15,9 @@ const BillRunModel = require('../../../../app/models/bill-run.model.js')
 const { determineCurrentFinancialYear } = require('../../../../app/lib/general.lib.js')
 
 // Things we need to stub
-const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 const ChargingModuleGenerateRequest = require('../../../../app/requests/charging-module/generate-bill-run.request.js')
 const FetchBillingAccountsService = require('../../../../app/services/bill-runs/annual/fetch-billing-accounts.service.js')
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 const HandleErroredBillRunService = require('../../../../app/services/bill-runs/handle-errored-bill-run.service.js')
 const LegacyRefreshBillRunRequest = require('../../../../app/requests/legacy/refresh-bill-run.request.js')
 const ProcessBillingPeriodService = require('../../../../app/services/bill-runs/annual/process-billing-period.service.js')

--- a/test/services/bill-runs/cancel/delete-bill-run.service.test.js
+++ b/test/services/bill-runs/cancel/delete-bill-run.service.test.js
@@ -22,9 +22,9 @@ const ReviewReturnHelper = require('../../../support/helpers/review-return.helpe
 const TransactionHelper = require('../../../support/helpers/transaction.helper.js')
 
 // Things we need to stub
-const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 const BillLicenceModel = require('../../../../app/models/bill-licence.model.js')
 const ChargingModuleDeleteBillRunRequest = require('../../../../app/requests/charging-module/delete-bill-run.request.js')
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 const ReviewLicenceModel = require('../../../../app/models/review-licence.model.js')
 
 // Thing under test

--- a/test/services/bill-runs/cancel/delete-bill-run.service.test.js
+++ b/test/services/bill-runs/cancel/delete-bill-run.service.test.js
@@ -22,13 +22,13 @@ const ReviewReturnHelper = require('../../../support/helpers/review-return.helpe
 const TransactionHelper = require('../../../support/helpers/transaction.helper.js')
 
 // Things we need to stub
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 const BillLicenceModel = require('../../../../app/models/bill-licence.model.js')
 const ChargingModuleDeleteBillRunRequest = require('../../../../app/requests/charging-module/delete-bill-run.request.js')
 const ReviewLicenceModel = require('../../../../app/models/review-licence.model.js')
 
 // Thing under test
 const DeleteBillBunService = require('../../../../app/services/bill-runs/cancel/delete-bill-run.service.js')
-const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 
 describe('Bill Runs - Delete Bill Run service', () => {
   let billRun

--- a/test/services/bill-runs/cancel/delete-bill-run.service.test.js
+++ b/test/services/bill-runs/cancel/delete-bill-run.service.test.js
@@ -28,6 +28,7 @@ const ReviewLicenceModel = require('../../../../app/models/review-licence.model.
 
 // Thing under test
 const DeleteBillBunService = require('../../../../app/services/bill-runs/cancel/delete-bill-run.service.js')
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 
 describe('Bill Runs - Delete Bill Run service', () => {
   let billRun
@@ -41,7 +42,7 @@ describe('Bill Runs - Delete Bill Run service', () => {
     // app/plugins/global-notifier.plugin.js when the app starts up and the plugin is registered. As we're not
     // creating an instance of Hapi server in this test we recreate the condition by setting it directly with our
     // own stub
-    notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
+    notifierStub = GlobalNotifierStub.build(Sinon)
     global.GlobalNotifier = notifierStub
   })
 

--- a/test/services/bill-runs/handle-errored-bill-run.service.test.js
+++ b/test/services/bill-runs/handle-errored-bill-run.service.test.js
@@ -11,9 +11,11 @@ const { expect } = Code
 // Test helpers
 const BillRunHelper = require('../../support/helpers/bill-run.helper.js')
 
+// Things we need to stub
+const GlobalNotifierStub = require('../../support/stubs/global-notifier.stub.js')
+
 // Thing under test
 const HandleErroredBillRunService = require('../../../app/services/bill-runs/handle-errored-bill-run.service.js')
-const GlobalNotifierStub = require('../../support/stubs/global-notifier.stub.js')
 
 describe('Handle Errored Bill Run service', () => {
   let billRun

--- a/test/services/bill-runs/handle-errored-bill-run.service.test.js
+++ b/test/services/bill-runs/handle-errored-bill-run.service.test.js
@@ -13,6 +13,7 @@ const BillRunHelper = require('../../support/helpers/bill-run.helper.js')
 
 // Thing under test
 const HandleErroredBillRunService = require('../../../app/services/bill-runs/handle-errored-bill-run.service.js')
+const GlobalNotifierStub = require('../../support/stubs/global-notifier.stub.js')
 
 describe('Handle Errored Bill Run service', () => {
   let billRun
@@ -24,7 +25,7 @@ describe('Handle Errored Bill Run service', () => {
     // BaseRequest depends on the GlobalNotifier to have been set. This happens in app/plugins/global-notifier.plugin.js
     // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
     // test we recreate the condition by setting it directly with our own stub
-    notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
+    notifierStub = GlobalNotifierStub.build(Sinon)
     global.GlobalNotifier = notifierStub
   })
 

--- a/test/services/bill-runs/match/fetch-return-logs-for-licence.service.test.js
+++ b/test/services/bill-runs/match/fetch-return-logs-for-licence.service.test.js
@@ -13,9 +13,11 @@ const ReturnLogHelper = require('../../../support/helpers/return-log.helper.js')
 const ReturnSubmissionHelper = require('../../../support/helpers/return-submission.helper.js')
 const ReturnSubmissionLineHelper = require('../../../support/helpers/return-submission-line.helper.js')
 
+// Things we need to stub
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
+
 // Thing under test
 const FetchReturnLogsForLicenceService = require('../../../../app/services/bill-runs/match/fetch-return-logs-for-licence.service.js')
-const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 
 describe('Fetch Return Logs for Licence service', () => {
   const billingPeriod = { startDate: new Date('2022-04-01'), endDate: new Date('2023-03-31') }

--- a/test/services/bill-runs/match/fetch-return-logs-for-licence.service.test.js
+++ b/test/services/bill-runs/match/fetch-return-logs-for-licence.service.test.js
@@ -15,6 +15,7 @@ const ReturnSubmissionLineHelper = require('../../../support/helpers/return-subm
 
 // Thing under test
 const FetchReturnLogsForLicenceService = require('../../../../app/services/bill-runs/match/fetch-return-logs-for-licence.service.js')
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 
 describe('Fetch Return Logs for Licence service', () => {
   const billingPeriod = { startDate: new Date('2022-04-01'), endDate: new Date('2023-03-31') }
@@ -26,7 +27,7 @@ describe('Fetch Return Logs for Licence service', () => {
     // This depends on the GlobalNotifier to have been set. This happens in app/plugins/global-notifier.plugin.js
     // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
     // test we recreate the condition by setting it directly with our own stub
-    notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
+    notifierStub = GlobalNotifierStub.build(Sinon)
     global.GlobalNotifier = notifierStub
   })
 

--- a/test/services/bill-runs/match/match-and-allocate.service.test.js
+++ b/test/services/bill-runs/match/match-and-allocate.service.test.js
@@ -9,6 +9,7 @@ const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Things we need to stub
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 const AllocateReturnsToChargeElementService = require('../../../../app/services/bill-runs/match/allocate-returns-to-charge-element.service.js')
 const DetermineLicenceIssuesService = require('../../../../app/services/bill-runs/match/determine-licence-issues.service.js')
 const FetchLicencesService = require('../../../../app/services/bill-runs/match/fetch-licences.service.js')
@@ -19,7 +20,6 @@ const PersistAllocatedLicenceToResultsService = require('../../../../app/service
 
 // Thing under test
 const MatchAndAllocateService = require('../../../../app/services/bill-runs/match/match-and-allocate.service.js')
-const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 
 describe('Bill Runs - Match - Match And Allocate service', () => {
   let determineLicenceIssuesServiceStub

--- a/test/services/bill-runs/match/match-and-allocate.service.test.js
+++ b/test/services/bill-runs/match/match-and-allocate.service.test.js
@@ -19,6 +19,7 @@ const PersistAllocatedLicenceToResultsService = require('../../../../app/service
 
 // Thing under test
 const MatchAndAllocateService = require('../../../../app/services/bill-runs/match/match-and-allocate.service.js')
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 
 describe('Bill Runs - Match - Match And Allocate service', () => {
   let determineLicenceIssuesServiceStub
@@ -26,7 +27,7 @@ describe('Bill Runs - Match - Match And Allocate service', () => {
   let licences
 
   beforeEach(() => {
-    notifierStub = { omg: Sinon.stub() }
+    notifierStub = GlobalNotifierStub.build(Sinon)
     global.GlobalNotifier = notifierStub
   })
 

--- a/test/services/bill-runs/match/match-and-allocate.service.test.js
+++ b/test/services/bill-runs/match/match-and-allocate.service.test.js
@@ -9,10 +9,10 @@ const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Things we need to stub
-const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 const AllocateReturnsToChargeElementService = require('../../../../app/services/bill-runs/match/allocate-returns-to-charge-element.service.js')
 const DetermineLicenceIssuesService = require('../../../../app/services/bill-runs/match/determine-licence-issues.service.js')
 const FetchLicencesService = require('../../../../app/services/bill-runs/match/fetch-licences.service.js')
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 const MatchReturnsToChargeElementService = require('../../../../app/services/bill-runs/match/match-returns-to-charge-element.service.js')
 const PrepareChargeVersionService = require('../../../../app/services/bill-runs/match/prepare-charge-version.service.js')
 const PrepareReturnLogsService = require('../../../../app/services/bill-runs/match/prepare-return-logs.service.js')

--- a/test/services/bill-runs/reissue/fetch-bills-to-be-reissued.service.test.js
+++ b/test/services/bill-runs/reissue/fetch-bills-to-be-reissued.service.test.js
@@ -16,9 +16,11 @@ const BillRunHelper = require('../../../support/helpers/bill-run.helper.js')
 const { generateUUID } = require('../../../../app/lib/general.lib.js')
 const TransactionHelper = require('../../../support/helpers/transaction.helper.js')
 
+// Things we need to stub
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
+
 // Thing under test
 const FetchBillsToBeReissuedService = require('../../../../app/services/bill-runs/reissue/fetch-bills-to-be-reissued.service.js')
-const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 
 describe('Fetch Bills To Be Reissued service', () => {
   let billRun

--- a/test/services/bill-runs/reissue/fetch-bills-to-be-reissued.service.test.js
+++ b/test/services/bill-runs/reissue/fetch-bills-to-be-reissued.service.test.js
@@ -18,6 +18,7 @@ const TransactionHelper = require('../../../support/helpers/transaction.helper.j
 
 // Thing under test
 const FetchBillsToBeReissuedService = require('../../../../app/services/bill-runs/reissue/fetch-bills-to-be-reissued.service.js')
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 
 describe('Fetch Bills To Be Reissued service', () => {
   let billRun
@@ -109,7 +110,7 @@ describe('Fetch Bills To Be Reissued service', () => {
     let notifierStub
 
     beforeEach(() => {
-      notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
+      notifierStub = GlobalNotifierStub.build(Sinon)
       global.GlobalNotifier = notifierStub
     })
 

--- a/test/services/bill-runs/reissue/reissue-bills.service.test.js
+++ b/test/services/bill-runs/reissue/reissue-bills.service.test.js
@@ -23,6 +23,7 @@ const ReissueBillService = require('../../../../app/services/bill-runs/reissue/r
 
 // Thing under test
 const ReissueBillsService = require('../../../../app/services/bill-runs/reissue/reissue-bills.service.js')
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 
 describe('Reissue Bills service', () => {
   const reissueBillRun = { regionId: generateUUID() }
@@ -34,7 +35,7 @@ describe('Reissue Bills service', () => {
     // The service depends on GlobalNotifier to have been set. This happens in app/plugins/global-notifier.plugin.js
     // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
     // test we recreate the condition by setting it directly with our own stub
-    notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
+    notifierStub = GlobalNotifierStub.build(Sinon)
     global.GlobalNotifier = notifierStub
   })
 

--- a/test/services/bill-runs/reissue/reissue-bills.service.test.js
+++ b/test/services/bill-runs/reissue/reissue-bills.service.test.js
@@ -18,8 +18,8 @@ const TransactionHelper = require('../../../support/helpers/transaction.helper.j
 const TransactionModel = require('../../../../app/models/transaction.model.js')
 
 // Things we need to stub
-const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 const FetchBillsToBeReissuedService = require('../../../../app/services/bill-runs/reissue/fetch-bills-to-be-reissued.service.js')
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 const ReissueBillService = require('../../../../app/services/bill-runs/reissue/reissue-bill.service.js')
 
 // Thing under test

--- a/test/services/bill-runs/reissue/reissue-bills.service.test.js
+++ b/test/services/bill-runs/reissue/reissue-bills.service.test.js
@@ -18,12 +18,12 @@ const TransactionHelper = require('../../../support/helpers/transaction.helper.j
 const TransactionModel = require('../../../../app/models/transaction.model.js')
 
 // Things we need to stub
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 const FetchBillsToBeReissuedService = require('../../../../app/services/bill-runs/reissue/fetch-bills-to-be-reissued.service.js')
 const ReissueBillService = require('../../../../app/services/bill-runs/reissue/reissue-bill.service.js')
 
 // Thing under test
 const ReissueBillsService = require('../../../../app/services/bill-runs/reissue/reissue-bills.service.js')
-const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 
 describe('Reissue Bills service', () => {
   const reissueBillRun = { regionId: generateUUID() }

--- a/test/services/bill-runs/send/update-invoice-numbers.service.test.js
+++ b/test/services/bill-runs/send/update-invoice-numbers.service.test.js
@@ -13,9 +13,9 @@ const BillRunModel = require('../../../../app/models/bill-run.model.js')
 const ExpandedError = require('../../../../app/errors/expanded.error.js')
 
 // Things we need to stub
-const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 const ChargingModuleSendBillRunRequest = require('../../../../app/requests/charging-module/send-bill-run.request.js')
 const ChargingModuleViewBillRunRequest = require('../../../../app/requests/charging-module/view-bill-run.request.js')
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 const UnflagBilledSupplementaryLicencesService = require('../../../../app/services/bill-runs/unflag-billed-supplementary-licences.service.js')
 
 // Thing under test

--- a/test/services/bill-runs/send/update-invoice-numbers.service.test.js
+++ b/test/services/bill-runs/send/update-invoice-numbers.service.test.js
@@ -19,6 +19,7 @@ const UnflagBilledSupplementaryLicencesService = require('../../../../app/servic
 
 // Thing under test
 const UpdateInvoiceNumbersService = require('../../../../app/services/bill-runs/send/update-invoice-numbers.service.js')
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 
 describe('Bill Runs - Send - Update Invoice Numbers service', () => {
   let billRun
@@ -41,7 +42,7 @@ describe('Bill Runs - Send - Update Invoice Numbers service', () => {
     // The service depends on GlobalNotifier to have been set. This happens in app/plugins/global-notifier.plugin.js
     // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
     // test we recreate the condition by setting it directly with our own stub
-    notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
+    notifierStub = GlobalNotifierStub.build(Sinon)
     global.GlobalNotifier = notifierStub
   })
 

--- a/test/services/bill-runs/send/update-invoice-numbers.service.test.js
+++ b/test/services/bill-runs/send/update-invoice-numbers.service.test.js
@@ -13,13 +13,13 @@ const BillRunModel = require('../../../../app/models/bill-run.model.js')
 const ExpandedError = require('../../../../app/errors/expanded.error.js')
 
 // Things we need to stub
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 const ChargingModuleSendBillRunRequest = require('../../../../app/requests/charging-module/send-bill-run.request.js')
 const ChargingModuleViewBillRunRequest = require('../../../../app/requests/charging-module/view-bill-run.request.js')
 const UnflagBilledSupplementaryLicencesService = require('../../../../app/services/bill-runs/unflag-billed-supplementary-licences.service.js')
 
 // Thing under test
 const UpdateInvoiceNumbersService = require('../../../../app/services/bill-runs/send/update-invoice-numbers.service.js')
-const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 
 describe('Bill Runs - Send - Update Invoice Numbers service', () => {
   let billRun

--- a/test/services/bill-runs/supplementary/process-bill-run.service.test.js
+++ b/test/services/bill-runs/supplementary/process-bill-run.service.test.js
@@ -12,6 +12,7 @@ const { expect } = Code
 const BillRunError = require('../../../../app/errors/bill-run.error.js')
 
 // Things we need to stub
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 const BillRunModel = require('../../../../app/models/bill-run.model.js')
 const ChargingModuleGenerateBillRunRequest = require('../../../../app/requests/charging-module/generate-bill-run.request.js')
 const FetchChargeVersionsService = require('../../../../app/services/bill-runs/supplementary/fetch-charge-versions.service.js')
@@ -22,7 +23,6 @@ const UnflagUnbilledSupplementaryLicencesService = require('../../../../app/serv
 
 // Thing under test
 const ProcessBillRunService = require('../../../../app/services/bill-runs/supplementary/process-bill-run.service.js')
-const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 
 describe('Bill Runs - Supplementary - Process Bill Run service', () => {
   const billingPeriods = [

--- a/test/services/bill-runs/supplementary/process-bill-run.service.test.js
+++ b/test/services/bill-runs/supplementary/process-bill-run.service.test.js
@@ -22,6 +22,7 @@ const UnflagUnbilledSupplementaryLicencesService = require('../../../../app/serv
 
 // Thing under test
 const ProcessBillRunService = require('../../../../app/services/bill-runs/supplementary/process-bill-run.service.js')
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 
 describe('Bill Runs - Supplementary - Process Bill Run service', () => {
   const billingPeriods = [
@@ -51,7 +52,7 @@ describe('Bill Runs - Supplementary - Process Bill Run service', () => {
     // The service depends on GlobalNotifier to have been set. This happens in app/plugins/global-notifier.plugin.js
     // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
     // test we recreate the condition by setting it directly with our own stub
-    notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
+    notifierStub = GlobalNotifierStub.build(Sinon)
     global.GlobalNotifier = notifierStub
   })
 

--- a/test/services/bill-runs/supplementary/process-bill-run.service.test.js
+++ b/test/services/bill-runs/supplementary/process-bill-run.service.test.js
@@ -12,10 +12,10 @@ const { expect } = Code
 const BillRunError = require('../../../../app/errors/bill-run.error.js')
 
 // Things we need to stub
-const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 const BillRunModel = require('../../../../app/models/bill-run.model.js')
 const ChargingModuleGenerateBillRunRequest = require('../../../../app/requests/charging-module/generate-bill-run.request.js')
 const FetchChargeVersionsService = require('../../../../app/services/bill-runs/supplementary/fetch-charge-versions.service.js')
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 const HandleErroredBillRunService = require('../../../../app/services/bill-runs/handle-errored-bill-run.service.js')
 const LegacyRefreshBillRunRequest = require('../../../../app/requests/legacy/refresh-bill-run.request.js')
 const ProcessBillingPeriodService = require('../../../../app/services/bill-runs/supplementary/process-billing-period.service.js')

--- a/test/services/bill-runs/tpt-supplementary/generate-bill-run.service.test.js
+++ b/test/services/bill-runs/tpt-supplementary/generate-bill-run.service.test.js
@@ -12,6 +12,7 @@ const { expect } = Code
 const BillRunError = require('../../../../app/errors/bill-run.error.js')
 
 // Things we need to stub
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 const BillRunModel = require('../../../../app/models/bill-run.model.js')
 const ChargingModuleGenerateRequest = require('../../../../app/requests/charging-module/generate-bill-run.request.js')
 const FetchBillingAccountsService = require('../../../../app/services/bill-runs/tpt-supplementary/fetch-billing-accounts.service.js')
@@ -22,7 +23,6 @@ const UnflagUnbilledSupplementaryLicencesService = require('../../../../app/serv
 
 // Thing under test
 const GenerateBillRunService = require('../../../../app/services/bill-runs/tpt-supplementary/generate-bill-run.service.js')
-const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 
 describe('Bill Runs - TPT Supplementary - Generate Bill Run service', () => {
   const billRun = {

--- a/test/services/bill-runs/tpt-supplementary/generate-bill-run.service.test.js
+++ b/test/services/bill-runs/tpt-supplementary/generate-bill-run.service.test.js
@@ -12,10 +12,10 @@ const { expect } = Code
 const BillRunError = require('../../../../app/errors/bill-run.error.js')
 
 // Things we need to stub
-const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 const BillRunModel = require('../../../../app/models/bill-run.model.js')
 const ChargingModuleGenerateRequest = require('../../../../app/requests/charging-module/generate-bill-run.request.js')
 const FetchBillingAccountsService = require('../../../../app/services/bill-runs/tpt-supplementary/fetch-billing-accounts.service.js')
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 const HandleErroredBillRunService = require('../../../../app/services/bill-runs/handle-errored-bill-run.service.js')
 const LegacyRefreshBillRunRequest = require('../../../../app/requests/legacy/refresh-bill-run.request.js')
 const ProcessBillingPeriodService = require('../../../../app/services/bill-runs/tpt-supplementary/process-billing-period.service.js')

--- a/test/services/bill-runs/tpt-supplementary/generate-bill-run.service.test.js
+++ b/test/services/bill-runs/tpt-supplementary/generate-bill-run.service.test.js
@@ -22,6 +22,7 @@ const UnflagUnbilledSupplementaryLicencesService = require('../../../../app/serv
 
 // Thing under test
 const GenerateBillRunService = require('../../../../app/services/bill-runs/tpt-supplementary/generate-bill-run.service.js')
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 
 describe('Bill Runs - TPT Supplementary - Generate Bill Run service', () => {
   const billRun = {
@@ -51,7 +52,7 @@ describe('Bill Runs - TPT Supplementary - Generate Bill Run service', () => {
     // BaseRequest depends on the GlobalNotifier to have been set. This happens in app/plugins/global-notifier.plugin.js
     // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
     // test we recreate the condition by setting it directly with our own stub
-    notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
+    notifierStub = GlobalNotifierStub.build(Sinon)
     global.GlobalNotifier = notifierStub
   })
 

--- a/test/services/bill-runs/tpt-supplementary/process-bill-run.service.test.js
+++ b/test/services/bill-runs/tpt-supplementary/process-bill-run.service.test.js
@@ -9,10 +9,10 @@ const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Things we need to stub
-const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 const AssignBillRunToLicencesService = require('../../../../app/services/bill-runs/assign-bill-run-to-licences.service.js')
 const BillRunModel = require('../../../../app/models/bill-run.model.js')
 const GenerateBillRunService = require('../../../../app/services/bill-runs/tpt-supplementary/generate-bill-run.service.js')
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 const HandleErroredBillRunService = require('../../../../app/services/bill-runs/handle-errored-bill-run.service.js')
 const MatchAndAllocateService = require('../../../../app/services/bill-runs/match/match-and-allocate.service.js')
 

--- a/test/services/bill-runs/tpt-supplementary/process-bill-run.service.test.js
+++ b/test/services/bill-runs/tpt-supplementary/process-bill-run.service.test.js
@@ -9,6 +9,7 @@ const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Things we need to stub
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 const AssignBillRunToLicencesService = require('../../../../app/services/bill-runs/assign-bill-run-to-licences.service.js')
 const BillRunModel = require('../../../../app/models/bill-run.model.js')
 const GenerateBillRunService = require('../../../../app/services/bill-runs/tpt-supplementary/generate-bill-run.service.js')
@@ -17,7 +18,6 @@ const MatchAndAllocateService = require('../../../../app/services/bill-runs/matc
 
 // Thing under test
 const ProcessBillRunService = require('../../../../app/services/bill-runs/tpt-supplementary/process-bill-run.service.js')
-const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 
 describe('Bill Runs - TPT Supplementary - Process Bill Run service', () => {
   const billingPeriods = [{ startDate: new Date('2023-04-01'), endDate: new Date('2024-03-31') }]

--- a/test/services/bill-runs/tpt-supplementary/process-bill-run.service.test.js
+++ b/test/services/bill-runs/tpt-supplementary/process-bill-run.service.test.js
@@ -17,6 +17,7 @@ const MatchAndAllocateService = require('../../../../app/services/bill-runs/matc
 
 // Thing under test
 const ProcessBillRunService = require('../../../../app/services/bill-runs/tpt-supplementary/process-bill-run.service.js')
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 
 describe('Bill Runs - TPT Supplementary - Process Bill Run service', () => {
   const billingPeriods = [{ startDate: new Date('2023-04-01'), endDate: new Date('2024-03-31') }]
@@ -39,7 +40,7 @@ describe('Bill Runs - TPT Supplementary - Process Bill Run service', () => {
     // BaseRequest depends on the GlobalNotifier to have been set. This happens in app/plugins/global-notifier.plugin.js
     // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
     // test we recreate the condition by setting it directly with our own stub
-    notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
+    notifierStub = GlobalNotifierStub.build(Sinon)
     global.GlobalNotifier = notifierStub
   })
 

--- a/test/services/bill-runs/two-part-tariff/generate-bill-run.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/generate-bill-run.service.test.js
@@ -21,6 +21,7 @@ const ProcessBillingPeriodService = require('../../../../app/services/bill-runs/
 
 // Thing under test
 const GenerateBillRunService = require('../../../../app/services/bill-runs/two-part-tariff/generate-bill-run.service.js')
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 
 describe('Bill Runs - Two Part Tariff - Generate Bill Run service', () => {
   const billRun = {
@@ -48,7 +49,7 @@ describe('Bill Runs - Two Part Tariff - Generate Bill Run service', () => {
     // BaseRequest depends on the GlobalNotifier to have been set. This happens in app/plugins/global-notifier.plugin.js
     // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
     // test we recreate the condition by setting it directly with our own stub
-    notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
+    notifierStub = GlobalNotifierStub.build(Sinon)
     global.GlobalNotifier = notifierStub
   })
 

--- a/test/services/bill-runs/two-part-tariff/generate-bill-run.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/generate-bill-run.service.test.js
@@ -12,10 +12,10 @@ const { expect } = Code
 const BillRunError = require('../../../../app/errors/bill-run.error.js')
 
 // Things we need to stub
-const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 const BillRunModel = require('../../../../app/models/bill-run.model.js')
 const ChargingModuleGenerateRequest = require('../../../../app/requests/charging-module/generate-bill-run.request.js')
 const FetchBillingAccountsService = require('../../../../app/services/bill-runs/two-part-tariff/fetch-billing-accounts.service.js')
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 const HandleErroredBillRunService = require('../../../../app/services/bill-runs/handle-errored-bill-run.service.js')
 const LegacyRefreshBillRunRequest = require('../../../../app/requests/legacy/refresh-bill-run.request.js')
 const ProcessBillingPeriodService = require('../../../../app/services/bill-runs/two-part-tariff/process-billing-period.service.js')

--- a/test/services/bill-runs/two-part-tariff/generate-bill-run.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/generate-bill-run.service.test.js
@@ -12,6 +12,7 @@ const { expect } = Code
 const BillRunError = require('../../../../app/errors/bill-run.error.js')
 
 // Things we need to stub
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 const BillRunModel = require('../../../../app/models/bill-run.model.js')
 const ChargingModuleGenerateRequest = require('../../../../app/requests/charging-module/generate-bill-run.request.js')
 const FetchBillingAccountsService = require('../../../../app/services/bill-runs/two-part-tariff/fetch-billing-accounts.service.js')
@@ -21,7 +22,6 @@ const ProcessBillingPeriodService = require('../../../../app/services/bill-runs/
 
 // Thing under test
 const GenerateBillRunService = require('../../../../app/services/bill-runs/two-part-tariff/generate-bill-run.service.js')
-const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 
 describe('Bill Runs - Two Part Tariff - Generate Bill Run service', () => {
   const billRun = {

--- a/test/services/bill-runs/two-part-tariff/process-bill-run.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/process-bill-run.service.test.js
@@ -9,8 +9,8 @@ const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Things we need to stub
-const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 const BillRunModel = require('../../../../app/models/bill-run.model.js')
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 const HandleErroredBillRunService = require('../../../../app/services/bill-runs/handle-errored-bill-run.service.js')
 const MatchAndAllocateService = require('../../../../app/services/bill-runs/match/match-and-allocate.service.js')
 

--- a/test/services/bill-runs/two-part-tariff/process-bill-run.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/process-bill-run.service.test.js
@@ -15,6 +15,7 @@ const MatchAndAllocateService = require('../../../../app/services/bill-runs/matc
 
 // Thing under test
 const ProcessBillRunService = require('../../../../app/services/bill-runs/two-part-tariff/process-bill-run.service.js')
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 
 describe('Bill Runs - Two Part Tariff - Process Bill Run service', () => {
   const billingPeriods = [{ startDate: new Date('2022-04-01'), endDate: new Date('2023-03-31') }]
@@ -34,7 +35,7 @@ describe('Bill Runs - Two Part Tariff - Process Bill Run service', () => {
     // The service depends on GlobalNotifier to have been set. This happens in app/plugins/global-notifier.plugin.js
     // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
     // test we recreate the condition by setting it directly with our own stub
-    notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
+    notifierStub = GlobalNotifierStub.build(Sinon)
     global.GlobalNotifier = notifierStub
   })
 

--- a/test/services/bill-runs/two-part-tariff/process-bill-run.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/process-bill-run.service.test.js
@@ -9,13 +9,13 @@ const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Things we need to stub
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 const BillRunModel = require('../../../../app/models/bill-run.model.js')
 const HandleErroredBillRunService = require('../../../../app/services/bill-runs/handle-errored-bill-run.service.js')
 const MatchAndAllocateService = require('../../../../app/services/bill-runs/match/match-and-allocate.service.js')
 
 // Thing under test
 const ProcessBillRunService = require('../../../../app/services/bill-runs/two-part-tariff/process-bill-run.service.js')
-const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 
 describe('Bill Runs - Two Part Tariff - Process Bill Run service', () => {
   const billingPeriods = [{ startDate: new Date('2022-04-01'), endDate: new Date('2023-03-31') }]

--- a/test/services/data/tear-down/tear-down.service.test.js
+++ b/test/services/data/tear-down/tear-down.service.test.js
@@ -9,8 +9,8 @@ const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Things we need to stub
-const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 const CrmSchemaService = require('../../../../app/services/data/tear-down/crm-schema.service.js')
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 const IdmSchemaService = require('../../../../app/services/data/tear-down/idm-schema.service.js')
 const PermitSchemaService = require('../../../../app/services/data/tear-down/permit-schema.service.js')
 const ReturnsSchemaService = require('../../../../app/services/data/tear-down/returns-schema.service.js')

--- a/test/services/data/tear-down/tear-down.service.test.js
+++ b/test/services/data/tear-down/tear-down.service.test.js
@@ -9,6 +9,7 @@ const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Things we need to stub
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 const CrmSchemaService = require('../../../../app/services/data/tear-down/crm-schema.service.js')
 const IdmSchemaService = require('../../../../app/services/data/tear-down/idm-schema.service.js')
 const PermitSchemaService = require('../../../../app/services/data/tear-down/permit-schema.service.js')
@@ -17,7 +18,6 @@ const WaterSchemaService = require('../../../../app/services/data/tear-down/wate
 
 // Thing under test
 const TearDownService = require('../../../../app/services/data/tear-down/tear-down.service.js')
-const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 
 describe('Tear down service', () => {
   let crmSchemaServiceStub

--- a/test/services/data/tear-down/tear-down.service.test.js
+++ b/test/services/data/tear-down/tear-down.service.test.js
@@ -17,6 +17,7 @@ const WaterSchemaService = require('../../../../app/services/data/tear-down/wate
 
 // Thing under test
 const TearDownService = require('../../../../app/services/data/tear-down/tear-down.service.js')
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 
 describe('Tear down service', () => {
   let crmSchemaServiceStub
@@ -36,7 +37,7 @@ describe('Tear down service', () => {
     // TearDownService depends on the GlobalNotifier being set. This happens in app/plugins/global-notifier.plugin.js
     // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
     // test we recreate the condition by setting it directly with our own stub
-    notifierStub = { omg: Sinon.stub() }
+    notifierStub = GlobalNotifierStub.build(Sinon)
     global.GlobalNotifier = notifierStub
   })
 

--- a/test/services/jobs/clean/clean-empty-bill-runs.service.test.js
+++ b/test/services/jobs/clean/clean-empty-bill-runs.service.test.js
@@ -12,13 +12,13 @@ const { expect } = Code
 const BillRunModel = require('../../../../app/models/bill-run.model.js')
 
 // Things we need to stub
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 const CancelBillRunService = require('../../../../app/services/bill-runs/cancel/cancel-bill-run.service.js')
 const DeleteBillRunService = require('../../../../app/services/bill-runs/cancel/delete-bill-run.service.js')
 const UnassignBillRunToLicencesService = require('../../../../app/services/bill-runs/unassign-bill-run-to-licences.service.js')
 
 // Thing under test
 const CleanEmptyBillRunsService = require('../../../../app/services/jobs/clean/clean-empty-bill-runs.service.js')
-const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 
 describe('Jobs - Clean - Clean Empty Bill Runs service', () => {
   const emptyBillRuns = [{ id: 'b1c10417-77bb-421e-a9ef-15a0d1bc05d8' }, { id: 'ddc7f25f-8b83-4ef1-9b10-bf1d968e2f13' }]

--- a/test/services/jobs/clean/clean-empty-bill-runs.service.test.js
+++ b/test/services/jobs/clean/clean-empty-bill-runs.service.test.js
@@ -12,9 +12,9 @@ const { expect } = Code
 const BillRunModel = require('../../../../app/models/bill-run.model.js')
 
 // Things we need to stub
-const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 const CancelBillRunService = require('../../../../app/services/bill-runs/cancel/cancel-bill-run.service.js')
 const DeleteBillRunService = require('../../../../app/services/bill-runs/cancel/delete-bill-run.service.js')
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 const UnassignBillRunToLicencesService = require('../../../../app/services/bill-runs/unassign-bill-run-to-licences.service.js')
 
 // Thing under test

--- a/test/services/jobs/clean/clean-empty-bill-runs.service.test.js
+++ b/test/services/jobs/clean/clean-empty-bill-runs.service.test.js
@@ -18,6 +18,7 @@ const UnassignBillRunToLicencesService = require('../../../../app/services/bill-
 
 // Thing under test
 const CleanEmptyBillRunsService = require('../../../../app/services/jobs/clean/clean-empty-bill-runs.service.js')
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 
 describe('Jobs - Clean - Clean Empty Bill Runs service', () => {
   const emptyBillRuns = [{ id: 'b1c10417-77bb-421e-a9ef-15a0d1bc05d8' }, { id: 'ddc7f25f-8b83-4ef1-9b10-bf1d968e2f13' }]
@@ -46,7 +47,7 @@ describe('Jobs - Clean - Clean Empty Bill Runs service', () => {
     // The service depends on GlobalNotifier to have been set. This happens in app/plugins/global-notifier.plugin.js
     // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
     // test we recreate the condition by setting it directly with our own stub
-    notifierStub = { omfg: Sinon.stub() }
+    notifierStub = GlobalNotifierStub.build(Sinon)
     global.GlobalNotifier = notifierStub
   })
 

--- a/test/services/jobs/clean/clean-empty-void-return-logs.service.test.js
+++ b/test/services/jobs/clean/clean-empty-void-return-logs.service.test.js
@@ -15,6 +15,7 @@ const ReturnSubmissionHelper = require('../../../support/helpers/return-submissi
 
 // Thing under test
 const CleanEmptyVoidReturnLogsService = require('../../../../app/services/jobs/clean/clean-empty-void-return-logs.service.js')
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 
 describe('Jobs - Clean - Clean Empty Void Return Logs service', () => {
   let returnLog
@@ -24,7 +25,7 @@ describe('Jobs - Clean - Clean Empty Void Return Logs service', () => {
     // The service depends on GlobalNotifier to have been set. This happens in app/plugins/global-notifier.plugin.js
     // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
     // test we recreate the condition by setting it directly with our own stub
-    notifierStub = { omfg: Sinon.stub() }
+    notifierStub = GlobalNotifierStub.build(Sinon)
     global.GlobalNotifier = notifierStub
   })
 

--- a/test/services/jobs/clean/clean-empty-void-return-logs.service.test.js
+++ b/test/services/jobs/clean/clean-empty-void-return-logs.service.test.js
@@ -13,9 +13,11 @@ const ReturnLogHelper = require('../../../support/helpers/return-log.helper.js')
 const ReturnLogModel = require('../../../../app/models/return-log.model.js')
 const ReturnSubmissionHelper = require('../../../support/helpers/return-submission.helper.js')
 
+// Things we need to stub
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
+
 // Thing under test
 const CleanEmptyVoidReturnLogsService = require('../../../../app/services/jobs/clean/clean-empty-void-return-logs.service.js')
-const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 
 describe('Jobs - Clean - Clean Empty Void Return Logs service', () => {
   let returnLog

--- a/test/services/jobs/clean/clean-expired-sessions.service.test.js
+++ b/test/services/jobs/clean/clean-expired-sessions.service.test.js
@@ -13,9 +13,11 @@ const SessionHelper = require('../../../support/helpers/session.helper.js')
 const SessionModel = require('../../../../app/models/session.model.js')
 const { today } = require('../../../../app/lib/general.lib.js')
 
+// Things we need to stub
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
+
 // Thing under test
 const CleanExpiredSessionsService = require('../../../../app/services/jobs/clean/clean-expired-sessions.service.js')
-const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 
 describe('Jobs - Clean - Clean Expired Sessions service', () => {
   const todaysDate = today()

--- a/test/services/jobs/clean/clean-expired-sessions.service.test.js
+++ b/test/services/jobs/clean/clean-expired-sessions.service.test.js
@@ -15,6 +15,7 @@ const { today } = require('../../../../app/lib/general.lib.js')
 
 // Thing under test
 const CleanExpiredSessionsService = require('../../../../app/services/jobs/clean/clean-expired-sessions.service.js')
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 
 describe('Jobs - Clean - Clean Expired Sessions service', () => {
   const todaysDate = today()
@@ -27,7 +28,7 @@ describe('Jobs - Clean - Clean Expired Sessions service', () => {
     // The service depends on GlobalNotifier to have been set. This happens in app/plugins/global-notifier.plugin.js
     // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
     // test we recreate the condition by setting it directly with our own stub
-    notifierStub = { omfg: Sinon.stub() }
+    notifierStub = GlobalNotifierStub.build(Sinon)
     global.GlobalNotifier = notifierStub
   })
 

--- a/test/services/jobs/clean/clean-incomplete-company-contacts.service.test.js
+++ b/test/services/jobs/clean/clean-incomplete-company-contacts.service.test.js
@@ -15,9 +15,11 @@ const CompanyContactHelper = require('../../../support/helpers/company-contact.h
 const CompanyContactModel = require('../../../../app/models/company-contact.model.js')
 const ContactHelper = require('../../../support/helpers/contact.helper.js')
 
+// Things we need to stub
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
+
 // Thing under test
 const CleanIncompleteCompanyContactsService = require('../../../../app/services/jobs/clean/clean-incomplete-company-contacts.service.js')
-const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 
 describe('Jobs - Clean - Clean Incomplete Company Contacts service', () => {
   let companyContact

--- a/test/services/jobs/clean/clean-incomplete-company-contacts.service.test.js
+++ b/test/services/jobs/clean/clean-incomplete-company-contacts.service.test.js
@@ -17,6 +17,7 @@ const ContactHelper = require('../../../support/helpers/contact.helper.js')
 
 // Thing under test
 const CleanIncompleteCompanyContactsService = require('../../../../app/services/jobs/clean/clean-incomplete-company-contacts.service.js')
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 
 describe('Jobs - Clean - Clean Incomplete Company Contacts service', () => {
   let companyContact
@@ -27,7 +28,7 @@ describe('Jobs - Clean - Clean Incomplete Company Contacts service', () => {
     // The service depends on GlobalNotifier to have been set. This happens in app/plugins/global-notifier.plugin.js
     // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
     // test we recreate the condition by setting it directly with our own stub
-    notifierStub = { omfg: Sinon.stub() }
+    notifierStub = GlobalNotifierStub.build(Sinon)
     global.GlobalNotifier = notifierStub
   })
 

--- a/test/services/jobs/clean/clean-orphaned-contacts.service.test.js
+++ b/test/services/jobs/clean/clean-orphaned-contacts.service.test.js
@@ -15,9 +15,11 @@ const ContactHelper = require('../../../support/helpers/contact.helper.js')
 const ContactModel = require('../../../../app/models/contact.model.js')
 const LicenceDocumentRoleHelper = require('../../../support/helpers/licence-document-role.helper.js')
 
+// Things we need to stub
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
+
 // Thing under test
 const CleanOrphanedContactsService = require('../../../../app/services/jobs/clean/clean-orphaned-contacts.service.js')
-const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 
 describe('Jobs - Clean - Clean Orphaned Contacts service', () => {
   let billingAccountAddress

--- a/test/services/jobs/clean/clean-orphaned-contacts.service.test.js
+++ b/test/services/jobs/clean/clean-orphaned-contacts.service.test.js
@@ -17,6 +17,7 @@ const LicenceDocumentRoleHelper = require('../../../support/helpers/licence-docu
 
 // Thing under test
 const CleanOrphanedContactsService = require('../../../../app/services/jobs/clean/clean-orphaned-contacts.service.js')
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 
 describe('Jobs - Clean - Clean Orphaned Contacts service', () => {
   let billingAccountAddress
@@ -29,7 +30,7 @@ describe('Jobs - Clean - Clean Orphaned Contacts service', () => {
     // The service depends on GlobalNotifier to have been set. This happens in app/plugins/global-notifier.plugin.js
     // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
     // test we recreate the condition by setting it directly with our own stub
-    notifierStub = { omfg: Sinon.stub() }
+    notifierStub = GlobalNotifierStub.build(Sinon)
     global.GlobalNotifier = notifierStub
   })
 

--- a/test/services/jobs/clean/process-clean.service.test.js
+++ b/test/services/jobs/clean/process-clean.service.test.js
@@ -9,6 +9,7 @@ const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Things we need to stub
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 const CleanEmptyBillRunsService = require('../../../../app/services/jobs/clean/clean-empty-bill-runs.service.js')
 const CleanEmptyVoidReturnLogsService = require('../../../../app/services/jobs/clean/clean-empty-void-return-logs.service.js')
 const CleanExpiredSessionsService = require('../../../../app/services/jobs/clean/clean-expired-sessions.service.js')
@@ -17,7 +18,6 @@ const CleanOrphanedContactsService = require('../../../../app/services/jobs/clea
 
 // Thing under test
 const ProcessCleanService = require('../../../../app/services/jobs/clean/process-clean.service.js')
-const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 
 describe('Jobs - Clean - Process Clean service', () => {
   const emptyBillRunsCount = 3

--- a/test/services/jobs/clean/process-clean.service.test.js
+++ b/test/services/jobs/clean/process-clean.service.test.js
@@ -17,6 +17,7 @@ const CleanOrphanedContactsService = require('../../../../app/services/jobs/clea
 
 // Thing under test
 const ProcessCleanService = require('../../../../app/services/jobs/clean/process-clean.service.js')
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 
 describe('Jobs - Clean - Process Clean service', () => {
   const emptyBillRunsCount = 3
@@ -44,7 +45,7 @@ describe('Jobs - Clean - Process Clean service', () => {
     // The service depends on GlobalNotifier to have been set. This happens in app/plugins/global-notifier.plugin.js
     // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
     // test we recreate the condition by setting it directly with our own stub
-    notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
+    notifierStub = GlobalNotifierStub.build(Sinon)
     global.GlobalNotifier = notifierStub
   })
 

--- a/test/services/jobs/clean/process-clean.service.test.js
+++ b/test/services/jobs/clean/process-clean.service.test.js
@@ -9,12 +9,12 @@ const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Things we need to stub
-const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 const CleanEmptyBillRunsService = require('../../../../app/services/jobs/clean/clean-empty-bill-runs.service.js')
 const CleanEmptyVoidReturnLogsService = require('../../../../app/services/jobs/clean/clean-empty-void-return-logs.service.js')
 const CleanExpiredSessionsService = require('../../../../app/services/jobs/clean/clean-expired-sessions.service.js')
 const CleanIncompleteCompanyContactsService = require('../../../../app/services/jobs/clean/clean-incomplete-company-contacts.service.js')
 const CleanOrphanedContactsService = require('../../../../app/services/jobs/clean/clean-orphaned-contacts.service.js')
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 
 // Thing under test
 const ProcessCleanService = require('../../../../app/services/jobs/clean/process-clean.service.js')

--- a/test/services/jobs/customer-files/process-customer-files.service.test.js
+++ b/test/services/jobs/customer-files/process-customer-files.service.test.js
@@ -14,8 +14,8 @@ const BillingAccountHelper = require('../../../support/helpers/billing-account.h
 const BillingAccountModel = require('../../../../app/models/billing-account.model.js')
 
 // Things we need to stub
-const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 const ChargingModuleViewCustomerFilesRequest = require('../../../../app/requests/charging-module/view-customer-files.request.js')
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 
 // Thing under test
 const ProcessCustomerFilesService = require('../../../../app/services/jobs/customer-files/process-customer-files.service.js')

--- a/test/services/jobs/customer-files/process-customer-files.service.test.js
+++ b/test/services/jobs/customer-files/process-customer-files.service.test.js
@@ -14,11 +14,11 @@ const BillingAccountHelper = require('../../../support/helpers/billing-account.h
 const BillingAccountModel = require('../../../../app/models/billing-account.model.js')
 
 // Things we need to stub
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 const ChargingModuleViewCustomerFilesRequest = require('../../../../app/requests/charging-module/view-customer-files.request.js')
 
 // Thing under test
 const ProcessCustomerFilesService = require('../../../../app/services/jobs/customer-files/process-customer-files.service.js')
-const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 
 describe('Jobs - Customer Files - Process Customer Files service', () => {
   const days = 7

--- a/test/services/jobs/customer-files/process-customer-files.service.test.js
+++ b/test/services/jobs/customer-files/process-customer-files.service.test.js
@@ -18,6 +18,7 @@ const ChargingModuleViewCustomerFilesRequest = require('../../../../app/requests
 
 // Thing under test
 const ProcessCustomerFilesService = require('../../../../app/services/jobs/customer-files/process-customer-files.service.js')
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 
 describe('Jobs - Customer Files - Process Customer Files service', () => {
   const days = 7
@@ -32,7 +33,7 @@ describe('Jobs - Customer Files - Process Customer Files service', () => {
     // The service depends on GlobalNotifier to have been set. This happens in app/plugins/global-notifier.plugin.js
     // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
     // test we recreate the condition by setting it directly with our own stub
-    notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub(), redAlert: Sinon.stub() }
+    notifierStub = GlobalNotifierStub.build(Sinon)
     global.GlobalNotifier = notifierStub
   })
 

--- a/test/services/jobs/export/delete-files.service.test.js
+++ b/test/services/jobs/export/delete-files.service.test.js
@@ -15,6 +15,7 @@ const mockFs = require('mock-fs')
 
 // Thing under test
 const DeleteFilesService = require('../../../../app/services/jobs/export/delete-files.service.js')
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 
 describe('Delete Files service', () => {
   let filenameWithPath
@@ -24,7 +25,7 @@ describe('Delete Files service', () => {
   beforeEach(() => {
     folderNameWithPath = 'testFolder'
     filenameWithPath = path.join(folderNameWithPath, 'testFile')
-    notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
+    notifierStub = GlobalNotifierStub.build(Sinon)
     global.GlobalNotifier = notifierStub
 
     mockFs({

--- a/test/services/jobs/export/delete-files.service.test.js
+++ b/test/services/jobs/export/delete-files.service.test.js
@@ -13,9 +13,11 @@ const fs = require('fs')
 const path = require('path')
 const mockFs = require('mock-fs')
 
+// Things we need to stub
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
+
 // Thing under test
 const DeleteFilesService = require('../../../../app/services/jobs/export/delete-files.service.js')
-const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 
 describe('Delete Files service', () => {
   let filenameWithPath

--- a/test/services/jobs/export/export.service.test.js
+++ b/test/services/jobs/export/export.service.test.js
@@ -9,11 +9,11 @@ const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Things we need to stub
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 const SchemaExportService = require('../../../../app/services/jobs/export/schema-export.service.js')
 
 // Thing under test
 const ExportService = require('../../../../app/services/jobs/export/export.service.js')
-const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 
 describe('Export Service', () => {
   let SchemaExportServiceStub

--- a/test/services/jobs/export/export.service.test.js
+++ b/test/services/jobs/export/export.service.test.js
@@ -13,6 +13,7 @@ const SchemaExportService = require('../../../../app/services/jobs/export/schema
 
 // Thing under test
 const ExportService = require('../../../../app/services/jobs/export/export.service.js')
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 
 describe('Export Service', () => {
   let SchemaExportServiceStub
@@ -20,7 +21,7 @@ describe('Export Service', () => {
 
   beforeEach(async () => {
     SchemaExportServiceStub = Sinon.stub(SchemaExportService, 'go').resolves()
-    notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
+    notifierStub = GlobalNotifierStub.build(Sinon)
     global.GlobalNotifier = notifierStub
   })
 

--- a/test/services/jobs/export/schema-export.service.test.js
+++ b/test/services/jobs/export/schema-export.service.test.js
@@ -17,6 +17,7 @@ const SendToS3BucketService = require('../../../../app/services/jobs/export/send
 
 // Thing under test
 const SchemaExportService = require('../../../../app/services/jobs/export/schema-export.service.js')
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 
 describe('Schema export service', () => {
   let FetchTableNamesServiceStub
@@ -82,7 +83,7 @@ describe('Schema export service', () => {
       CompressSchemaFolderServiceStub = Sinon.stub(CompressSchemaFolderService, 'go')
       DeleteFilesServiceStub = Sinon.stub(DeleteFilesService, 'go').resolves()
 
-      notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
+      notifierStub = GlobalNotifierStub.build(Sinon)
       global.GlobalNotifier = notifierStub
     })
 

--- a/test/services/jobs/export/schema-export.service.test.js
+++ b/test/services/jobs/export/schema-export.service.test.js
@@ -9,11 +9,11 @@ const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Things we need to stub
-const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 const CompressSchemaFolderService = require('../../../../app/services/jobs/export/compress-schema-folder.service.js')
 const DeleteFilesService = require('../../../../app/services/jobs/export/delete-files.service.js')
 const ExportTableService = require('../../../../app/services/jobs/export/export-table.service.js')
 const FetchTableNamesService = require('../../../../app/services/jobs/export/fetch-table-names.service.js')
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 const SendToS3BucketService = require('../../../../app/services/jobs/export/send-to-s3-bucket.service.js')
 
 // Thing under test

--- a/test/services/jobs/export/schema-export.service.test.js
+++ b/test/services/jobs/export/schema-export.service.test.js
@@ -9,6 +9,7 @@ const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Things we need to stub
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 const CompressSchemaFolderService = require('../../../../app/services/jobs/export/compress-schema-folder.service.js')
 const DeleteFilesService = require('../../../../app/services/jobs/export/delete-files.service.js')
 const ExportTableService = require('../../../../app/services/jobs/export/export-table.service.js')
@@ -17,7 +18,6 @@ const SendToS3BucketService = require('../../../../app/services/jobs/export/send
 
 // Thing under test
 const SchemaExportService = require('../../../../app/services/jobs/export/schema-export.service.js')
-const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 
 describe('Schema export service', () => {
   let FetchTableNamesServiceStub

--- a/test/services/jobs/licence-updates/process-licence-updates.service.test.js
+++ b/test/services/jobs/licence-updates/process-licence-updates.service.test.js
@@ -17,6 +17,7 @@ const FetchLicenceUpdatesService = require('../../../../app/services/jobs/licenc
 
 // Thing under test
 const ProcessLicenceUpdatesService = require('../../../../app/services/jobs/licence-updates/process-licence-updates.service.js')
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 
 describe('Jobs - Licence Updates - Process Licence Updates service', () => {
   let fetchResults
@@ -26,7 +27,7 @@ describe('Jobs - Licence Updates - Process Licence Updates service', () => {
     // The service depends on GlobalNotifier to have been set. This happens in app/plugins/global-notifier.plugin.js
     // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
     // test we recreate the condition by setting it directly with our own stub
-    notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub(), redAlert: Sinon.stub() }
+    notifierStub = GlobalNotifierStub.build(Sinon)
     global.GlobalNotifier = notifierStub
   })
 

--- a/test/services/jobs/licence-updates/process-licence-updates.service.test.js
+++ b/test/services/jobs/licence-updates/process-licence-updates.service.test.js
@@ -13,8 +13,8 @@ const { generateUUID } = require('../../../../app/lib/general.lib.js')
 const WorkflowModel = require('../../../../app/models/workflow.model.js')
 
 // Things we need to stub
-const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 const FetchLicenceUpdatesService = require('../../../../app/services/jobs/licence-updates/fetch-licence-updates.service.js')
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 
 // Thing under test
 const ProcessLicenceUpdatesService = require('../../../../app/services/jobs/licence-updates/process-licence-updates.service.js')

--- a/test/services/jobs/licence-updates/process-licence-updates.service.test.js
+++ b/test/services/jobs/licence-updates/process-licence-updates.service.test.js
@@ -13,11 +13,11 @@ const { generateUUID } = require('../../../../app/lib/general.lib.js')
 const WorkflowModel = require('../../../../app/models/workflow.model.js')
 
 // Things we need to stub
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 const FetchLicenceUpdatesService = require('../../../../app/services/jobs/licence-updates/fetch-licence-updates.service.js')
 
 // Thing under test
 const ProcessLicenceUpdatesService = require('../../../../app/services/jobs/licence-updates/process-licence-updates.service.js')
-const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 
 describe('Jobs - Licence Updates - Process Licence Updates service', () => {
   let fetchResults

--- a/test/services/jobs/notification-status/process-notification-status.service.test.js
+++ b/test/services/jobs/notification-status/process-notification-status.service.test.js
@@ -13,9 +13,9 @@ const NoticesFixture = require('../../../support/fixtures/notices.fixture.js')
 const NotificationsFixture = require('../../../support/fixtures/notifications.fixture.js')
 
 // Things we need to stub
-const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 const CheckNotificationStatusService = require('../../../../app/services/notifications/check-notification-status.service.js')
 const FetchNotificationsService = require('../../../../app/services/jobs/notification-status/fetch-notifications.service.js')
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 const UpdateNoticeService = require('../../../../app/services/notices/update-notice.service.js')
 
 // Thing under test

--- a/test/services/jobs/notification-status/process-notification-status.service.test.js
+++ b/test/services/jobs/notification-status/process-notification-status.service.test.js
@@ -19,6 +19,7 @@ const UpdateNoticeService = require('../../../../app/services/notices/update-not
 
 // Thing under test
 const ProcessNotificationStatusService = require('../../../../app/services/jobs/notification-status/process-notification-status.service.js')
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 
 describe('Job - Notifications - Process Notification Status service', () => {
   let noticeA
@@ -55,7 +56,7 @@ describe('Job - Notifications - Process Notification Status service', () => {
     // The service depends on GlobalNotifier to have been set. This happens in app/plugins/global-notifier.plugin.js
     // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
     // test we recreate the condition by setting it directly with our own stub
-    notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub(), redAlert: Sinon.stub() }
+    notifierStub = GlobalNotifierStub.build(Sinon)
     global.GlobalNotifier = notifierStub
   })
 

--- a/test/services/jobs/notification-status/process-notification-status.service.test.js
+++ b/test/services/jobs/notification-status/process-notification-status.service.test.js
@@ -13,13 +13,13 @@ const NoticesFixture = require('../../../support/fixtures/notices.fixture.js')
 const NotificationsFixture = require('../../../support/fixtures/notifications.fixture.js')
 
 // Things we need to stub
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 const CheckNotificationStatusService = require('../../../../app/services/notifications/check-notification-status.service.js')
 const FetchNotificationsService = require('../../../../app/services/jobs/notification-status/fetch-notifications.service.js')
 const UpdateNoticeService = require('../../../../app/services/notices/update-notice.service.js')
 
 // Thing under test
 const ProcessNotificationStatusService = require('../../../../app/services/jobs/notification-status/process-notification-status.service.js')
-const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 
 describe('Job - Notifications - Process Notification Status service', () => {
   let noticeA

--- a/test/services/jobs/renewal-invitations/process-renewal-invitations.service.test.js
+++ b/test/services/jobs/renewal-invitations/process-renewal-invitations.service.test.js
@@ -13,6 +13,7 @@ const SendRenewalInvitations = require('../../../../app/services/jobs/renewal-in
 
 // Thing under test
 const ProcessRenewalInvitationsService = require('../../../../app/services/jobs/renewal-invitations/process-renewal-invitations.service.js')
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 
 describe('Jobs - Renewal Invitations - Process Renewal Invitations service', () => {
   const days = '300'
@@ -25,7 +26,7 @@ describe('Jobs - Renewal Invitations - Process Renewal Invitations service', () 
     // The service depends on GlobalNotifier to have been set. This happens in app/plugins/global-notifier.plugin.js
     // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
     // test we recreate the condition by setting it directly with our own stub
-    notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
+    notifierStub = GlobalNotifierStub.build(Sinon)
     global.GlobalNotifier = notifierStub
   })
 

--- a/test/services/jobs/renewal-invitations/process-renewal-invitations.service.test.js
+++ b/test/services/jobs/renewal-invitations/process-renewal-invitations.service.test.js
@@ -9,11 +9,11 @@ const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Things we need to stub
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 const SendRenewalInvitations = require('../../../../app/services/jobs/renewal-invitations/send-renewal-invitations.service.js')
 
 // Thing under test
 const ProcessRenewalInvitationsService = require('../../../../app/services/jobs/renewal-invitations/process-renewal-invitations.service.js')
-const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 
 describe('Jobs - Renewal Invitations - Process Renewal Invitations service', () => {
   const days = '300'

--- a/test/services/jobs/return-logs/process-return-logs.service.test.js
+++ b/test/services/jobs/return-logs/process-return-logs.service.test.js
@@ -13,10 +13,10 @@ const ReturnCyclesFixture = require('../../../support/fixtures/return-cycles.fix
 const ReturnRequirementsFixture = require('../../../support/fixtures/return-requirements.fixture.js')
 
 // Things we need to stub
-const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 const CreateReturnLogsService = require('../../../../app/services/return-logs/create-return-logs.service.js')
 const CheckReturnCycleService = require('../../../../app/services/jobs/return-logs/check-return-cycle.service.js')
 const FetchReturnRequirementsService = require('../../../../app/services/jobs/return-logs/fetch-return-requirements.service.js')
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 
 // Thing under test
 const ProcessReturnLogsService = require('../../../../app/services/jobs/return-logs/process-return-logs.service.js')

--- a/test/services/jobs/return-logs/process-return-logs.service.test.js
+++ b/test/services/jobs/return-logs/process-return-logs.service.test.js
@@ -19,6 +19,7 @@ const FetchReturnRequirementsService = require('../../../../app/services/jobs/re
 
 // Thing under test
 const ProcessReturnLogsService = require('../../../../app/services/jobs/return-logs/process-return-logs.service.js')
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 
 describe('Jobs - Return Logs - Process Return Logs service', () => {
   const cycle = 'all-year'
@@ -31,7 +32,7 @@ describe('Jobs - Return Logs - Process Return Logs service', () => {
     // BaseRequest depends on the GlobalNotifier to have been set. This happens in app/plugins/global-notifier.plugin.js
     // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
     // test we recreate the condition by setting it directly with our own stub
-    notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub(), redAlert: Sinon.stub() }
+    notifierStub = GlobalNotifierStub.build(Sinon)
     global.GlobalNotifier = notifierStub
   })
 

--- a/test/services/jobs/return-logs/process-return-logs.service.test.js
+++ b/test/services/jobs/return-logs/process-return-logs.service.test.js
@@ -13,13 +13,13 @@ const ReturnCyclesFixture = require('../../../support/fixtures/return-cycles.fix
 const ReturnRequirementsFixture = require('../../../support/fixtures/return-requirements.fixture.js')
 
 // Things we need to stub
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 const CreateReturnLogsService = require('../../../../app/services/return-logs/create-return-logs.service.js')
 const CheckReturnCycleService = require('../../../../app/services/jobs/return-logs/check-return-cycle.service.js')
 const FetchReturnRequirementsService = require('../../../../app/services/jobs/return-logs/fetch-return-requirements.service.js')
 
 // Thing under test
 const ProcessReturnLogsService = require('../../../../app/services/jobs/return-logs/process-return-logs.service.js')
-const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 
 describe('Jobs - Return Logs - Process Return Logs service', () => {
   const cycle = 'all-year'

--- a/test/services/jobs/time-limited/process-time-limited-licences.service.test.js
+++ b/test/services/jobs/time-limited/process-time-limited-licences.service.test.js
@@ -17,6 +17,7 @@ const FetchTimeLimitedLicencesService = require('../../../../app/services/jobs/t
 
 // Thing under test
 const ProcessTimeLimitedLicencesService = require('../../../../app/services/jobs/time-limited/process-time-limited-licences.service.js')
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 
 describe('Process Time Limited Licences service', () => {
   let fetchResults
@@ -26,7 +27,7 @@ describe('Process Time Limited Licences service', () => {
     // The service depends on GlobalNotifier to have been set. This happens in app/plugins/global-notifier.plugin.js
     // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
     // test we recreate the condition by setting it directly with our own stub
-    notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub(), redAlert: Sinon.stub() }
+    notifierStub = GlobalNotifierStub.build(Sinon)
     global.GlobalNotifier = notifierStub
   })
 

--- a/test/services/jobs/time-limited/process-time-limited-licences.service.test.js
+++ b/test/services/jobs/time-limited/process-time-limited-licences.service.test.js
@@ -13,8 +13,8 @@ const WorkflowModel = require('../../../../app/models/workflow.model.js')
 const { generateUUID } = require('../../../../app/lib/general.lib.js')
 
 // Things we need to stub
-const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 const FetchTimeLimitedLicencesService = require('../../../../app/services/jobs/time-limited/fetch-time-limited-licences.service.js')
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 
 // Thing under test
 const ProcessTimeLimitedLicencesService = require('../../../../app/services/jobs/time-limited/process-time-limited-licences.service.js')

--- a/test/services/jobs/time-limited/process-time-limited-licences.service.test.js
+++ b/test/services/jobs/time-limited/process-time-limited-licences.service.test.js
@@ -13,11 +13,11 @@ const WorkflowModel = require('../../../../app/models/workflow.model.js')
 const { generateUUID } = require('../../../../app/lib/general.lib.js')
 
 // Things we need to stub
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 const FetchTimeLimitedLicencesService = require('../../../../app/services/jobs/time-limited/fetch-time-limited-licences.service.js')
 
 // Thing under test
 const ProcessTimeLimitedLicencesService = require('../../../../app/services/jobs/time-limited/process-time-limited-licences.service.js')
-const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 
 describe('Process Time Limited Licences service', () => {
   let fetchResults

--- a/test/services/licences/end-dates/check-all-licence-end-dates.service.test.js
+++ b/test/services/licences/end-dates/check-all-licence-end-dates.service.test.js
@@ -9,8 +9,8 @@ const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Things we need to stub
-const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 const FetchLicencesService = require('../../../../app/services/licences/end-dates/fetch-licences.service.js')
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 const LicencesConfig = require('../../../../config/licences.config.js')
 const CheckLicenceEndDatesService = require('../../../../app/services/licences/end-dates/check-licence-end-dates.service.js')
 const { generateUUID, pause } = require('../../../../app/lib/general.lib.js')

--- a/test/services/licences/end-dates/check-all-licence-end-dates.service.test.js
+++ b/test/services/licences/end-dates/check-all-licence-end-dates.service.test.js
@@ -9,6 +9,7 @@ const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Things we need to stub
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 const FetchLicencesService = require('../../../../app/services/licences/end-dates/fetch-licences.service.js')
 const LicencesConfig = require('../../../../config/licences.config.js')
 const CheckLicenceEndDatesService = require('../../../../app/services/licences/end-dates/check-licence-end-dates.service.js')
@@ -16,7 +17,6 @@ const { generateUUID, pause } = require('../../../../app/lib/general.lib.js')
 
 // Thing under test
 const CheckAllLicenceEndDatesService = require('../../../../app/services/licences/end-dates/check-all-licence-end-dates.service.js')
-const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 
 describe('Licences - End Dates - Check All Licence End Dates service', () => {
   const batchSize = 10

--- a/test/services/licences/end-dates/check-all-licence-end-dates.service.test.js
+++ b/test/services/licences/end-dates/check-all-licence-end-dates.service.test.js
@@ -16,6 +16,7 @@ const { generateUUID, pause } = require('../../../../app/lib/general.lib.js')
 
 // Thing under test
 const CheckAllLicenceEndDatesService = require('../../../../app/services/licences/end-dates/check-all-licence-end-dates.service.js')
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 
 describe('Licences - End Dates - Check All Licence End Dates service', () => {
   const batchSize = 10
@@ -36,7 +37,7 @@ describe('Licences - End Dates - Check All Licence End Dates service', () => {
     // The service depends on GlobalNotifier to have been set. This happens in app/plugins/global-notifier.plugin.js
     // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
     // test we recreate the condition by setting it directly with our own stub
-    notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
+    notifierStub = GlobalNotifierStub.build(Sinon)
     global.GlobalNotifier = notifierStub
   })
 

--- a/test/services/licences/end-dates/check-licence-end-dates.service.test.js
+++ b/test/services/licences/end-dates/check-licence-end-dates.service.test.js
@@ -12,9 +12,11 @@ const { expect } = Code
 const { generateUUID } = require('../../../../app/lib/general.lib.js')
 const LicenceEndDateChangeModel = require('../../../../app/models/licence-end-date-change.model.js')
 
+// Things we need to stub
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
+
 // Thing under test
 const CheckLicenceEndDatesService = require('../../../../app/services/licences/end-dates/check-licence-end-dates.service.js')
-const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 
 describe('Licences - End Dates - Check Licence End Dates service', () => {
   let licence

--- a/test/services/licences/end-dates/check-licence-end-dates.service.test.js
+++ b/test/services/licences/end-dates/check-licence-end-dates.service.test.js
@@ -14,6 +14,7 @@ const LicenceEndDateChangeModel = require('../../../../app/models/licence-end-da
 
 // Thing under test
 const CheckLicenceEndDatesService = require('../../../../app/services/licences/end-dates/check-licence-end-dates.service.js')
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 
 describe('Licences - End Dates - Check Licence End Dates service', () => {
   let licence
@@ -34,7 +35,7 @@ describe('Licences - End Dates - Check Licence End Dates service', () => {
     // The service depends on GlobalNotifier to have been set. This happens in app/plugins/global-notifier.plugin.js
     // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
     // test we recreate the condition by setting it directly with our own stub
-    notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
+    notifierStub = GlobalNotifierStub.build(Sinon)
     global.GlobalNotifier = notifierStub
   })
 

--- a/test/services/licences/end-dates/process-licence-end-date-changes.service.test.js
+++ b/test/services/licences/end-dates/process-licence-end-date-changes.service.test.js
@@ -12,13 +12,13 @@ const { expect } = Code
 const LicenceEndDateChangeHelper = require('../../../support/helpers/licence-end-date-change.helper.js')
 
 // Things we need to stub
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 const LicenceEndDateChangeModel = require('../../../../app/models/licence-end-date-change.model.js')
 const ProcessBillingFlagService = require('../../../../app/services/licences/supplementary/process-billing-flag.service.js')
 const ProcessLicenceReturnLogsService = require('../../../../app/services/return-logs/process-licence-return-logs.service.js')
 
 // Thing under test
 const ProcessLicenceEndDateChangesService = require('../../../../app/services/licences/end-dates/process-licence-end-date-changes.service.js')
-const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 
 describe('Licences - End Dates - Process Licence End Date Changes service', () => {
   let licenceEndDateChange

--- a/test/services/licences/end-dates/process-licence-end-date-changes.service.test.js
+++ b/test/services/licences/end-dates/process-licence-end-date-changes.service.test.js
@@ -18,6 +18,7 @@ const ProcessLicenceReturnLogsService = require('../../../../app/services/return
 
 // Thing under test
 const ProcessLicenceEndDateChangesService = require('../../../../app/services/licences/end-dates/process-licence-end-date-changes.service.js')
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 
 describe('Licences - End Dates - Process Licence End Date Changes service', () => {
   let licenceEndDateChange
@@ -31,7 +32,7 @@ describe('Licences - End Dates - Process Licence End Date Changes service', () =
     // The service depends on GlobalNotifier to have been set. This happens in app/plugins/global-notifier.plugin.js
     // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
     // test we recreate the condition by setting it directly with our own stub
-    notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
+    notifierStub = GlobalNotifierStub.build(Sinon)
     global.GlobalNotifier = notifierStub
   })
 

--- a/test/services/licences/supplementary/process-billing-flag.service.test.js
+++ b/test/services/licences/supplementary/process-billing-flag.service.test.js
@@ -9,6 +9,7 @@ const { describe, it, before, beforeEach, afterEach } = (exports.lab = Lab.scrip
 const { expect } = Code
 
 // Things we need to stub
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 const DetermineBillLicenceFlagsService = require('../../../../app/services/licences/supplementary/determine-bill-licence-flags.service.js')
 const DetermineChargeVersionFlagsService = require('../../../../app/services/licences/supplementary/determine-charge-version-flags.service.js')
 const DetermineExistingBillRunYearsService = require('../../../../app/services/licences/supplementary/determine-existing-bill-run-years.service.js')
@@ -20,7 +21,6 @@ const PersistSupplementaryBillingFlagsService = require('../../../../app/service
 
 // Thing under test
 const ProcessBillingFlagService = require('../../../../app/services/licences/supplementary/process-billing-flag.service.js')
-const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 
 describe('Licences - Supplementary - Process Billing Flag service', () => {
   let notifierStub

--- a/test/services/licences/supplementary/process-billing-flag.service.test.js
+++ b/test/services/licences/supplementary/process-billing-flag.service.test.js
@@ -20,6 +20,7 @@ const PersistSupplementaryBillingFlagsService = require('../../../../app/service
 
 // Thing under test
 const ProcessBillingFlagService = require('../../../../app/services/licences/supplementary/process-billing-flag.service.js')
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 
 describe('Licences - Supplementary - Process Billing Flag service', () => {
   let notifierStub
@@ -31,7 +32,7 @@ describe('Licences - Supplementary - Process Billing Flag service', () => {
     // The service depends on GlobalNotifier to have been set. This happens in app/plugins/global-notifier.plugin.js
     // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
     // test we recreate the condition by setting it directly with our own stub
-    notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
+    notifierStub = GlobalNotifierStub.build(Sinon)
     global.GlobalNotifier = notifierStub
   })
 

--- a/test/services/licences/supplementary/process-billing-flag.service.test.js
+++ b/test/services/licences/supplementary/process-billing-flag.service.test.js
@@ -9,7 +9,6 @@ const { describe, it, before, beforeEach, afterEach } = (exports.lab = Lab.scrip
 const { expect } = Code
 
 // Things we need to stub
-const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 const DetermineBillLicenceFlagsService = require('../../../../app/services/licences/supplementary/determine-bill-licence-flags.service.js')
 const DetermineChargeVersionFlagsService = require('../../../../app/services/licences/supplementary/determine-charge-version-flags.service.js')
 const DetermineExistingBillRunYearsService = require('../../../../app/services/licences/supplementary/determine-existing-bill-run-years.service.js')
@@ -17,6 +16,7 @@ const DetermineImportedLicenceFlagsService = require('../../../../app/services/l
 const DetermineLicenceFlagsService = require('../../../../app/services/licences/supplementary/determine-licence-flags.service.js')
 const DetermineReturnLogFlagsService = require('../../../../app/services/licences/supplementary/determine-return-log-flags.service.js')
 const DetermineWorkflowFlagsService = require('../../../../app/services/licences/supplementary/determine-workflow-flags.service.js')
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 const PersistSupplementaryBillingFlagsService = require('../../../../app/services/licences/supplementary/persist-supplementary-billing-flags.service.js')
 
 // Thing under test

--- a/test/services/notices/setup/prepare-paper-return.service.test.js
+++ b/test/services/notices/setup/prepare-paper-return.service.test.js
@@ -14,8 +14,8 @@ const { formatLongDate } = require('../../../../app/presenters/base.presenter.js
 const { generateLicenceRef } = require('../../../support/helpers/licence.helper.js')
 
 // Things we need to stub
-const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 const GeneratePaperReturnRequest = require('../../../../app/requests/gotenberg/generate-paper-return.request.js')
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 
 // Thing under test
 const PreparePaperReturnService = require('../../../../app/services/notices/setup/prepare-paper-return.service.js')

--- a/test/services/notices/setup/prepare-paper-return.service.test.js
+++ b/test/services/notices/setup/prepare-paper-return.service.test.js
@@ -14,11 +14,11 @@ const { formatLongDate } = require('../../../../app/presenters/base.presenter.js
 const { generateLicenceRef } = require('../../../support/helpers/licence.helper.js')
 
 // Things we need to stub
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 const GeneratePaperReturnRequest = require('../../../../app/requests/gotenberg/generate-paper-return.request.js')
 
 // Thing under test
 const PreparePaperReturnService = require('../../../../app/services/notices/setup/prepare-paper-return.service.js')
-const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 
 describe('Notices - Setup - Prepare Paper Return service', () => {
   const buffer = new TextEncoder().encode('mock file').buffer

--- a/test/services/notices/setup/prepare-paper-return.service.test.js
+++ b/test/services/notices/setup/prepare-paper-return.service.test.js
@@ -18,6 +18,7 @@ const GeneratePaperReturnRequest = require('../../../../app/requests/gotenberg/g
 
 // Thing under test
 const PreparePaperReturnService = require('../../../../app/services/notices/setup/prepare-paper-return.service.js')
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 
 describe('Notices - Setup - Prepare Paper Return service', () => {
   const buffer = new TextEncoder().encode('mock file').buffer
@@ -67,7 +68,7 @@ describe('Notices - Setup - Prepare Paper Return service', () => {
       }
     })
 
-    notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
+    notifierStub = GlobalNotifierStub.build(Sinon)
     global.GlobalNotifier = notifierStub
   })
 

--- a/test/services/notices/setup/process-preview-paper-return.service.test.js
+++ b/test/services/notices/setup/process-preview-paper-return.service.test.js
@@ -15,10 +15,10 @@ const SessionModelStub = require('../../../support/stubs/session.stub.js')
 const { formatLongDate } = require('../../../../app/presenters/base.presenter.js')
 
 // Things we need to stub
-const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 const FetchRecipientsService = require('../../../../app/services/notices/setup/fetch-recipients.service.js')
 const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 const GeneratePaperReturnRequest = require('../../../../app/requests/gotenberg/generate-paper-return.request.js')
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 
 // Thing under test
 const ProcessPreviewPaperReturnService = require('../../../../app/services/notices/setup/process-preview-paper-return.service.js')

--- a/test/services/notices/setup/process-preview-paper-return.service.test.js
+++ b/test/services/notices/setup/process-preview-paper-return.service.test.js
@@ -15,13 +15,13 @@ const SessionModelStub = require('../../../support/stubs/session.stub.js')
 const { formatLongDate } = require('../../../../app/presenters/base.presenter.js')
 
 // Things we need to stub
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 const FetchRecipientsService = require('../../../../app/services/notices/setup/fetch-recipients.service.js')
 const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 const GeneratePaperReturnRequest = require('../../../../app/requests/gotenberg/generate-paper-return.request.js')
 
 // Thing under test
 const ProcessPreviewPaperReturnService = require('../../../../app/services/notices/setup/process-preview-paper-return.service.js')
-const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 
 describe('Notices - Setup - Process Preview Paper Return service', () => {
   let contactHashId

--- a/test/services/notices/setup/process-preview-paper-return.service.test.js
+++ b/test/services/notices/setup/process-preview-paper-return.service.test.js
@@ -21,6 +21,7 @@ const GeneratePaperReturnRequest = require('../../../../app/requests/gotenberg/g
 
 // Thing under test
 const ProcessPreviewPaperReturnService = require('../../../../app/services/notices/setup/process-preview-paper-return.service.js')
+const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
 
 describe('Notices - Setup - Process Preview Paper Return service', () => {
   let contactHashId
@@ -68,7 +69,7 @@ describe('Notices - Setup - Process Preview Paper Return service', () => {
       }
     ])
 
-    notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
+    notifierStub = GlobalNotifierStub.build(Sinon)
     global.GlobalNotifier = notifierStub
   })
 

--- a/test/services/notices/setup/send/send-notice.service.test.js
+++ b/test/services/notices/setup/send/send-notice.service.test.js
@@ -19,6 +19,7 @@ const UpdateNoticeService = require('../../../../../app/services/notices/update-
 
 // Thing under test
 const SendNoticeService = require('../../../../../app/services/notices/setup/send/send-notice.service.js')
+const GlobalNotifierStub = require('../../../../support/stubs/global-notifier.stub.js')
 
 describe('Notices - Setup - Send - Send Notice service', () => {
   let notice
@@ -35,7 +36,7 @@ describe('Notices - Setup - Send - Send Notice service', () => {
     // The service depends on GlobalNotifier to have been set. This happens in app/plugins/global-notifier.plugin.js
     // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
     // test we recreate the condition by setting it directly with our own stub
-    notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
+    notifierStub = GlobalNotifierStub.build(Sinon)
     global.GlobalNotifier = notifierStub
   })
 

--- a/test/services/notices/setup/send/send-notice.service.test.js
+++ b/test/services/notices/setup/send/send-notice.service.test.js
@@ -13,13 +13,13 @@ const NoticesFixture = require('../../../../support/fixtures/notices.fixture.js'
 const NotificationsFixture = require('../../../../support/fixtures/notifications.fixture.js')
 
 // Things we need to stub
+const GlobalNotifierStub = require('../../../../support/stubs/global-notifier.stub.js')
 const SendAlternateNoticeService = require('../../../../../app/services/notices/setup/send/send-alternate-notice.service.js')
 const SendMainNoticeService = require('../../../../../app/services/notices/setup/send/send-main-notice.service.js')
 const UpdateNoticeService = require('../../../../../app/services/notices/update-notice.service.js')
 
 // Thing under test
 const SendNoticeService = require('../../../../../app/services/notices/setup/send/send-notice.service.js')
-const GlobalNotifierStub = require('../../../../support/stubs/global-notifier.stub.js')
 
 describe('Notices - Setup - Send - Send Notice service', () => {
   let notice

--- a/test/services/notifications/check-notification-status.service.test.js
+++ b/test/services/notifications/check-notification-status.service.test.js
@@ -20,6 +20,7 @@ const ViewMessageDataRequest = require('../../../app/requests/notify/view-messag
 
 // Thing under test
 const CheckNotificationStatusService = require('../../../app/services/notifications/check-notification-status.service.js')
+const GlobalNotifierStub = require('../../support/stubs/global-notifier.stub.js')
 
 describe('Notifications - Check Notification Status service', () => {
   let licenceMonitoringStationPatchStub
@@ -45,7 +46,7 @@ describe('Notifications - Check Notification Status service', () => {
 
     returnLogPatchStub = Sinon.stub().returnsThis()
 
-    notifierStub = { omfg: Sinon.stub() }
+    notifierStub = GlobalNotifierStub.build(Sinon)
     global.GlobalNotifier = notifierStub
   })
 

--- a/test/services/notifications/check-notification-status.service.test.js
+++ b/test/services/notifications/check-notification-status.service.test.js
@@ -13,6 +13,7 @@ const NoticesFixture = require('../../support/fixtures/notices.fixture.js')
 const NotificationsFixture = require('../../support/fixtures/notifications.fixture.js')
 
 // Things we need to stub
+const GlobalNotifierStub = require('../../support/stubs/global-notifier.stub.js')
 const LicenceMonitoringStationModel = require('../../../app/models/licence-monitoring-station.model.js')
 const NotificationModel = require('../../../app/models/notification.model.js')
 const ReturnLogModel = require('../../../app/models/return-log.model.js')
@@ -20,7 +21,6 @@ const ViewMessageDataRequest = require('../../../app/requests/notify/view-messag
 
 // Thing under test
 const CheckNotificationStatusService = require('../../../app/services/notifications/check-notification-status.service.js')
-const GlobalNotifierStub = require('../../support/stubs/global-notifier.stub.js')
 
 describe('Notifications - Check Notification Status service', () => {
   let licenceMonitoringStationPatchStub

--- a/test/services/notifications/process-returned-letter.service.test.js
+++ b/test/services/notifications/process-returned-letter.service.test.js
@@ -19,6 +19,7 @@ const UpdateNoticeService = require('../../../app/services/notices/update-notice
 
 // Thing under test
 const ProcessReturnedLetterService = require('../../../app/services/notifications/process-returned-letter.service.js')
+const GlobalNotifierStub = require('../../support/stubs/global-notifier.stub.js')
 
 describe('Notifications - Process Returned Letter service', () => {
   const todaysDate = today()
@@ -39,7 +40,7 @@ describe('Notifications - Process Returned Letter service', () => {
       status: 'sent'
     })
 
-    notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
+    notifierStub = GlobalNotifierStub.build(Sinon)
     global.GlobalNotifier = notifierStub
   })
 

--- a/test/services/notifications/process-returned-letter.service.test.js
+++ b/test/services/notifications/process-returned-letter.service.test.js
@@ -15,11 +15,11 @@ const NotificationHelper = require('../../support/helpers/notification.helper.js
 const { generateNoticeReferenceCode } = require('../../../app/lib/general.lib.js')
 
 // Things we need to stub
+const GlobalNotifierStub = require('../../support/stubs/global-notifier.stub.js')
 const UpdateNoticeService = require('../../../app/services/notices/update-notice.service.js')
 
 // Thing under test
 const ProcessReturnedLetterService = require('../../../app/services/notifications/process-returned-letter.service.js')
-const GlobalNotifierStub = require('../../support/stubs/global-notifier.stub.js')
 
 describe('Notifications - Process Returned Letter service', () => {
   const todaysDate = today()

--- a/test/services/plugins/error-pages.service.test.js
+++ b/test/services/plugins/error-pages.service.test.js
@@ -21,6 +21,7 @@ const SessionNotFoundError = require('../../../app/errors/session-not-found.erro
 
 // Thing under test
 const ErrorPagesService = require('../../../app/services/plugins/error-pages.service.js')
+const GlobalNotifierStub = require('../../support/stubs/global-notifier.stub.js')
 
 describe('Error pages service', () => {
   const boom403Response = {
@@ -61,7 +62,7 @@ describe('Error pages service', () => {
   let request
 
   beforeEach(() => {
-    notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
+    notifierStub = GlobalNotifierStub.build(Sinon)
     global.GlobalNotifier = notifierStub
   })
 

--- a/test/services/plugins/error-pages.service.test.js
+++ b/test/services/plugins/error-pages.service.test.js
@@ -19,9 +19,11 @@ const { expect } = Code
 // Test helpers
 const SessionNotFoundError = require('../../../app/errors/session-not-found.error.js')
 
+// Things we need to stub
+const GlobalNotifierStub = require('../../support/stubs/global-notifier.stub.js')
+
 // Thing under test
 const ErrorPagesService = require('../../../app/services/plugins/error-pages.service.js')
-const GlobalNotifierStub = require('../../support/stubs/global-notifier.stub.js')
 
 describe('Error pages service', () => {
   const boom403Response = {

--- a/test/services/return-versions/setup/check/submit-check.service.test.js
+++ b/test/services/return-versions/setup/check/submit-check.service.test.js
@@ -12,6 +12,7 @@ const { expect } = Code
 const SessionModelStub = require('../../../../support/stubs/session.stub.js')
 
 // Things we need to stub
+const GlobalNotifierStub = require('../../../../support/stubs/global-notifier.stub.js')
 const CreateReturnVersionService = require('../../../../../app/services/return-versions/setup/check/create-return-version.service.js')
 const DeleteSessionDal = require('../../../../../app/dal/delete-session.dal.js')
 const FetchSessionDal = require('../../../../../app/dal/fetch-session.dal.js')
@@ -23,7 +24,6 @@ const VoidReturnLogsService = require('../../../../../app/services/return-logs/v
 
 // Thing under test
 const SubmitCheckService = require('../../../../../app/services/return-versions/setup/check/submit-check.service.js')
-const GlobalNotifierStub = require('../../../../support/stubs/global-notifier.stub.js')
 
 describe('Return Versions - Setup - Submit Check service', () => {
   let createReturnVersionStub

--- a/test/services/return-versions/setup/check/submit-check.service.test.js
+++ b/test/services/return-versions/setup/check/submit-check.service.test.js
@@ -23,6 +23,7 @@ const VoidReturnLogsService = require('../../../../../app/services/return-logs/v
 
 // Thing under test
 const SubmitCheckService = require('../../../../../app/services/return-versions/setup/check/submit-check.service.js')
+const GlobalNotifierStub = require('../../../../support/stubs/global-notifier.stub.js')
 
 describe('Return Versions - Setup - Submit Check service', () => {
   let createReturnVersionStub
@@ -148,7 +149,7 @@ describe('Return Versions - Setup - Submit Check service', () => {
     // BaseRequest depends on the GlobalNotifier to have been set. This happens in app/plugins/global-notifier.plugin.js
     // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
     // test we recreate the condition by setting it directly with our own stub
-    notifierStub = { omfg: Sinon.stub() }
+    notifierStub = GlobalNotifierStub.build(Sinon)
     global.GlobalNotifier = notifierStub
   })
 

--- a/test/services/return-versions/setup/check/submit-check.service.test.js
+++ b/test/services/return-versions/setup/check/submit-check.service.test.js
@@ -12,11 +12,11 @@ const { expect } = Code
 const SessionModelStub = require('../../../../support/stubs/session.stub.js')
 
 // Things we need to stub
-const GlobalNotifierStub = require('../../../../support/stubs/global-notifier.stub.js')
 const CreateReturnVersionService = require('../../../../../app/services/return-versions/setup/check/create-return-version.service.js')
 const DeleteSessionDal = require('../../../../../app/dal/delete-session.dal.js')
 const FetchSessionDal = require('../../../../../app/dal/fetch-session.dal.js')
 const GenerateReturnVersionService = require('../../../../../app/services/return-versions/setup/check/generate-return-version.service.js')
+const GlobalNotifierStub = require('../../../../support/stubs/global-notifier.stub.js')
 const ProcessExistingReturnVersionsService = require('../../../../../app/services/return-versions/setup/check/process-existing-return-versions.service.js')
 const ProcessLicenceReturnLogsService = require('../../../../../app/services/return-logs/process-licence-return-logs.service.js')
 const UpdateSucceededReturnLogsDal = require('../../../../../app/dal/return-versions/update-succeeded-return-logs.dal.js')

--- a/test/support/stubs/global-notifier.stub.js
+++ b/test/support/stubs/global-notifier.stub.js
@@ -1,0 +1,23 @@
+'use strict'
+
+/**
+ * Creates a stubbed instance of GlobalNotifier for testing purposes.
+ *
+ * GlobalNotifier is set on globalThis in app/plugins/global-notifier.plugin.js when the Hapi server starts. Tests that
+ * exercise code which calls GlobalNotifier need to set it up manually as no Hapi server is created in unit tests.
+ *
+ * @param {object} sinon - The sinon sandbox or instance
+ *
+ * @returns {object} A stubbed GlobalNotifier with omg, omfg and redAlert methods
+ */
+function build(sinon) {
+  return {
+    omg: sinon.stub(),
+    omfg: sinon.stub(),
+    redAlert: sinon.stub()
+  }
+}
+
+module.exports = {
+  build
+}


### PR DESCRIPTION
## Overview

Creates `test/support/stubs/global-notifier.stub.js` to centralise the `GlobalNotifier` test stub, following the same pattern as the existing `session.stub.js`.

The inline stub setup was duplicated across 44 test files in up to three different shapes:

```js
// Previously — inline in each test file
notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub(), redAlert: Sinon.stub() }
notifierStub = { omfg: Sinon.stub() }

// Now — consistent across all files
notifierStub = GlobalNotifierStub.build(Sinon)
```

The shared stub always exposes all three methods (`omg`, `omfg`, `redAlert`) so every test file can use `GlobalNotifierStub.build(Sinon)` regardless of which methods it actually calls.

The require is placed under `// Things we need to stub` in all files, following the established stub pattern. Where that section did not already exist it has been created.

## Files changed

- `test/support/stubs/global-notifier.stub.js` — new stub file
- 44 test files updated to use it

## Test plan

- [x] Lint passes (`npm run lint`)
- [x] Tests run via Docker across a sample of affected files — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)