### PR TITLE
Refactor the recipient scenario seeder

### DIFF
--- a/test/services/jobs/renewal-invitations/fetch-renewal-recipients.service.test.js
+++ b/test/services/jobs/renewal-invitations/fetch-renewal-recipients.service.test.js
@@ -18,12 +18,11 @@ describe('Jobs - Renewal Invitations - Fetch Renewal recipients service', () => 
   let scenarios
 
   before(async () => {
-    scenarios = []
+    scenarios = {}
 
     // 1) Licence holder only
     expiredDate = new Date('2027-02-09')
-    const scenario = await RecipientScenariosSeeder.licenceHolderOnly([], expiredDate)
-    scenarios.push(scenario)
+    scenarios.licenceHolder = await RecipientScenariosSeeder.licenceHolderOnly([], expiredDate)
   })
 
   after(async () => {
@@ -34,7 +33,7 @@ describe('Jobs - Renewal Invitations - Fetch Renewal recipients service', () => 
     it('fetches the correct recipient data', async () => {
       const result = await FetchRenewalRecipients.go(new Date('2027-02-09'))
 
-      const expectedResults = _transformToResult(scenarios[0])
+      const expectedResults = _transformToResult(scenarios.licenceHolder)
 
       expect(result).to.equal(expectedResults)
     })

--- a/test/services/jobs/renewal-invitations/generate-renewal-recipients-query.service.test.js
+++ b/test/services/jobs/renewal-invitations/generate-renewal-recipients-query.service.test.js
@@ -27,32 +27,32 @@ WHERE
   let scenarios
 
   before(async () => {
-    scenarios = []
-
-    let scenario
+    scenarios = {}
 
     // 1) Licence holder only
     expiredDate = new Date('2027-02-09')
-    scenario = await RecipientScenariosSeeder.licenceHolderOnly([], expiredDate)
-    scenarios.push(scenario)
+    scenarios.licenceHolder = await RecipientScenariosSeeder.licenceHolderOnly([], expiredDate)
 
     // 2) Same licence holder, but is linked to multiple licences with due return logs - only one recipient record
     // will be returned with multiple licence refs
     expiredDate = new Date('2027-02-10')
-    scenario = await RecipientScenariosSeeder.licenceHolderWithMultipleLicences([], expiredDate)
-    scenarios.push(scenario)
+    scenarios.licenceHolderMultipleLicences = await RecipientScenariosSeeder.licenceHolderWithMultipleLicences(
+      [],
+      expiredDate
+    )
 
     // 3) Primary user only. All licences have a licence holder record, but when 'registered' the query will only
     // return the primary user recipient.
     expiredDate = new Date('2027-02-11')
-    scenario = await RecipientScenariosSeeder.primaryUserOnly([], expiredDate)
-    scenarios.push(scenario)
+    scenarios.primaryUser = await RecipientScenariosSeeder.primaryUserOnly([], expiredDate)
 
-    // 7) Same primary user, but is linked to multiple licences - only one recipient record will be returned with
+    // 4) Same primary user, but is linked to multiple licences - only one recipient record will be returned with
     // multiple licence refs
     expiredDate = new Date('2027-02-12')
-    scenario = await RecipientScenariosSeeder.primaryUserWithMultipleLicences([], expiredDate)
-    scenarios.push(scenario)
+    scenarios.primaryUserMultipleLicences = await RecipientScenariosSeeder.primaryUserWithMultipleLicences(
+      [],
+      expiredDate
+    )
   })
 
   after(async () => {
@@ -78,7 +78,7 @@ WHERE
 
         const { rows } = await db.raw(query, [new Date('2027-02-09')])
 
-        const expectedResults = RecipientScenariosSeeder.transformToSendingResults(scenarios[0])
+        const expectedResults = RecipientScenariosSeeder.transformToSendingResults(scenarios.licenceHolder)
 
         expect(rows).to.equal(expectedResults)
       })
@@ -90,7 +90,9 @@ WHERE
 
         const { rows } = await db.raw(query, [new Date('2027-02-10')])
 
-        const expectedResults = RecipientScenariosSeeder.transformToSendingResults(scenarios[1])
+        const expectedResults = RecipientScenariosSeeder.transformToSendingResults(
+          scenarios.licenceHolderMultipleLicences
+        )
 
         expect(rows).to.contain(expectedResults[0])
         // We could test rows contains the second licence holder recipient recorded in the scenario, but they are the
@@ -105,7 +107,7 @@ WHERE
 
         const { rows } = await db.raw(query, [new Date('2027-02-11')])
 
-        const expectedResults = RecipientScenariosSeeder.transformToSendingResults(scenarios[2])
+        const expectedResults = RecipientScenariosSeeder.transformToSendingResults(scenarios.primaryUser)
 
         expect(rows).to.contain(expectedResults[1])
 
@@ -120,7 +122,9 @@ WHERE
 
         const { rows } = await db.raw(query, [new Date('2027-02-12')])
 
-        const expectedResults = RecipientScenariosSeeder.transformToSendingResults(scenarios[3])
+        const expectedResults = RecipientScenariosSeeder.transformToSendingResults(
+          scenarios.primaryUserMultipleLicences
+        )
 
         expect(rows).to.contain(expectedResults[2])
 

--- a/test/services/notices/setup/abstraction-alerts/fetch-abstraction-alert-recipients.service.test.js
+++ b/test/services/notices/setup/abstraction-alerts/fetch-abstraction-alert-recipients.service.test.js
@@ -21,14 +21,14 @@ describe('Notices - Setup - Abstraction Alerts - Fetch Abstraction Alert Recipie
   let session
 
   before(async () => {
-    scenarios = []
+    scenarios = {}
 
     // 1) Licence holder only
     const licenceHolder = await _licenceHolder()
     const licenceHolderRecipient = await _licenceHolderRecipient(licenceHolder.licence, licenceHolder.licenceHolder)
-    scenarios.push([licenceHolderRecipient])
+    scenarios.licenceHolder = { licenceHolderRecipient }
 
-    session = { licenceRefs: [scenarios[0][0].licenceRef] }
+    session = { licenceRefs: [scenarios.licenceHolder.licenceHolderRecipient.licenceRef] }
   })
 
   after(async () => {
@@ -39,7 +39,9 @@ describe('Notices - Setup - Abstraction Alerts - Fetch Abstraction Alert Recipie
     it('fetches the correct recipient data', async () => {
       const result = await FetchAbstractionAlertRecipientsService.go(session)
 
-      const expectedResults = RecipientScenariosSeeder.transformToSendingResults(scenarios[0])
+      const expectedResults = RecipientScenariosSeeder.transformToSendingResults([
+        scenarios.licenceHolder.licenceHolderRecipient
+      ])
 
       expect(result).to.equal(expectedResults)
     })

--- a/test/services/notices/setup/abstraction-alerts/generate-abstraction-alert-recipients-query.service.test.js
+++ b/test/services/notices/setup/abstraction-alerts/generate-abstraction-alert-recipients-query.service.test.js
@@ -22,7 +22,7 @@ describe('Notices - Setup - Abstraction Alerts - Generate Abstraction Alert Reci
   let scenarios
 
   before(async () => {
-    scenarios = []
+    scenarios = {}
 
     let additionalContactRecipient
     let licenceHolder
@@ -33,13 +33,13 @@ describe('Notices - Setup - Abstraction Alerts - Generate Abstraction Alert Reci
     // 1) Licence holder only
     licenceHolder = await _licenceHolder()
     licenceHolderRecipient = await _licenceHolderRecipient(licenceHolder.licence, licenceHolder.licenceHolder)
-    scenarios.push([licenceHolderRecipient])
+    scenarios.licenceHolder = { licenceHolderRecipient }
 
     // 2) Licence holder, and an additional contact
     licenceHolder = await _licenceHolder()
     licenceHolderRecipient = await _licenceHolderRecipient(licenceHolder.licence, licenceHolder.licenceHolder)
     additionalContactRecipient = await _additionalContactRecipient(licenceHolder.licence)
-    scenarios.push([licenceHolderRecipient, additionalContactRecipient])
+    scenarios.licenceHolderWithAdditionalContact = { licenceHolderRecipient, additionalContactRecipient }
 
     // 3) Primary user only. All licences have a licence holder record, but when 'registered' the query will only
     // return the primary user recipient.
@@ -47,7 +47,7 @@ describe('Notices - Setup - Abstraction Alerts - Generate Abstraction Alert Reci
     licenceHolderRecipient = await _licenceHolderRecipient(licenceHolder.licence, licenceHolder.licenceHolder)
     primaryUser = await _primaryUser(licenceHolder.licence)
     primaryUserRecipient = await _primaryUserRecipient(licenceHolder.licence, primaryUser.primaryUser)
-    scenarios.push([licenceHolderRecipient, primaryUserRecipient])
+    scenarios.primaryUser = { licenceHolderRecipient, primaryUserRecipient }
 
     // 4) Primary user with an additional contact. Similar to scenario 3 - when registered, we expect the primary user
     // and additional contact but not the licence holder.
@@ -56,7 +56,11 @@ describe('Notices - Setup - Abstraction Alerts - Generate Abstraction Alert Reci
     primaryUser = await _primaryUser(licenceHolder.licence)
     primaryUserRecipient = await _primaryUserRecipient(licenceHolder.licence, primaryUser.primaryUser)
     additionalContactRecipient = await _additionalContactRecipient(licenceHolder.licence)
-    scenarios.push([licenceHolderRecipient, primaryUserRecipient, additionalContactRecipient])
+    scenarios.primaryUserWithAdditionalContact = {
+      licenceHolderRecipient,
+      primaryUserRecipient,
+      additionalContactRecipient
+    }
 
     // 5) Additional contact multiple licence refs
     licenceHolder = await _licenceHolder()
@@ -70,19 +74,19 @@ describe('Notices - Setup - Abstraction Alerts - Generate Abstraction Alert Reci
       licenceHolderTwo.licenceHolder
     )
     const additionalContactRecipientTwo = await _additionalContactRecipient(licenceHolderTwo.licence)
-    scenarios.push([
+    scenarios.additionalContactMultipleLicences = {
       licenceHolderRecipient,
       licenceHolderRecipientTwo,
       additionalContactRecipient,
       additionalContactRecipientTwo
-    ])
+    }
 
     // 6) Licence holder with an additional contact where abstractionAlerts = false. The additional contact should NOT
     // appear in results.
     licenceHolder = await _licenceHolder()
     licenceHolderRecipient = await _licenceHolderRecipient(licenceHolder.licence, licenceHolder.licenceHolder)
     const additionalContactNoAlerts = await _additionalContactRecipient(licenceHolder.licence, false)
-    scenarios.push([licenceHolderRecipient, additionalContactNoAlerts])
+    scenarios.additionalContactNoAlerts = { licenceHolderRecipient, additionalContactNoAlerts }
 
     // 7) Different licence holders and different additional contacts for different licences. Unlike scenario 5 where
     // the same contact spans multiple licences and is combined into one row, here each licence has unique contacts so
@@ -105,12 +109,12 @@ describe('Notices - Setup - Abstraction Alerts - Generate Abstraction Alert Reci
       email: 'champ.kind@news.com'
     })
 
-    scenarios.push([
+    scenarios.differentHoldersAndContacts = {
       firstLicenceHolderRecipient,
       secondLicenceHolderRecipient,
       firstAdditionalContact,
       secondAdditionalContact
-    ])
+    }
 
     // 8) Two licences with different licence holders and additional contacts, but one additional contact has
     // abstractionAlerts = false and should NOT appear in results.
@@ -132,12 +136,12 @@ describe('Notices - Setup - Abstraction Alerts - Generate Abstraction Alert Reci
       email: 'champ.kind@news.com'
     })
 
-    scenarios.push([
+    scenarios.mixedAlerts = {
       licenceHolderRecipientWithAlert,
       licenceHolderRecipientWithoutAlert,
       additionalContactWithAlert,
       additionalContactWithoutAlert
-    ])
+    }
 
     // 9) Licence holder with an additional contact where the end date has passed. The expired contact should NOT
     // appear in results.
@@ -149,7 +153,7 @@ describe('Notices - Setup - Abstraction Alerts - Generate Abstraction Alert Reci
       null,
       new Date('2023-01-01')
     )
-    scenarios.push([licenceHolderRecipient, expiredAdditionalContact])
+    scenarios.expiredAdditionalContact = { licenceHolderRecipient, expiredAdditionalContact }
   })
 
   after(async () => {
@@ -171,11 +175,13 @@ describe('Notices - Setup - Abstraction Alerts - Generate Abstraction Alert Reci
   describe('when executed', () => {
     describe('and only the licence holder is present for an unregistered licence (Scenario 1)', () => {
       it('returns the expected recipients', async () => {
-        const licenceRefs = [scenarios[0][0].licenceRef]
+        const licenceRefs = [scenarios.licenceHolder.licenceHolderRecipient.licenceRef]
         const { bindings, query } = GenerateAbstractionAlertRecipientsQueryService.go(licenceRefs)
         const { rows } = await db.raw(query, bindings)
 
-        const expectedResults = RecipientScenariosSeeder.transformToSendingResults([scenarios[0][0]])
+        const expectedResults = RecipientScenariosSeeder.transformToSendingResults([
+          scenarios.licenceHolder.licenceHolderRecipient
+        ])
 
         expect(rows).to.equal(expectedResults)
       })
@@ -183,11 +189,14 @@ describe('Notices - Setup - Abstraction Alerts - Generate Abstraction Alert Reci
 
     describe('and both the "additional contact" and the "licence holder" are present for an unregistered licence (Scenario 2)', () => {
       it('returns the expected recipients', async () => {
-        const licenceRefs = [scenarios[1][0].licenceRef]
+        const licenceRefs = [scenarios.licenceHolderWithAdditionalContact.licenceHolderRecipient.licenceRef]
         const { bindings, query } = GenerateAbstractionAlertRecipientsQueryService.go(licenceRefs)
         const { rows } = await db.raw(query, bindings)
 
-        const expectedResults = RecipientScenariosSeeder.transformToSendingResults([scenarios[1][0], scenarios[1][1]])
+        const expectedResults = RecipientScenariosSeeder.transformToSendingResults([
+          scenarios.licenceHolderWithAdditionalContact.licenceHolderRecipient,
+          scenarios.licenceHolderWithAdditionalContact.additionalContactRecipient
+        ])
 
         expect(rows).to.equal(expectedResults)
       })
@@ -195,11 +204,13 @@ describe('Notices - Setup - Abstraction Alerts - Generate Abstraction Alert Reci
 
     describe('and only the "primary user" is present for a registered licence (Scenario 3)', () => {
       it('returns the expected recipients', async () => {
-        const licenceRefs = [scenarios[2][1].licenceRef]
+        const licenceRefs = [scenarios.primaryUser.primaryUserRecipient.licenceRef]
         const { bindings, query } = GenerateAbstractionAlertRecipientsQueryService.go(licenceRefs)
         const { rows } = await db.raw(query, bindings)
 
-        const expectedResults = RecipientScenariosSeeder.transformToSendingResults([scenarios[2][1]])
+        const expectedResults = RecipientScenariosSeeder.transformToSendingResults([
+          scenarios.primaryUser.primaryUserRecipient
+        ])
 
         expect(rows).to.equal(expectedResults)
       })
@@ -207,11 +218,14 @@ describe('Notices - Setup - Abstraction Alerts - Generate Abstraction Alert Reci
 
     describe('and both the "primary user" and "additional contact" are present for a registered licence, but not the licence holder (Scenario 4)', () => {
       it('returns the expected recipients', async () => {
-        const licenceRefs = [scenarios[3][1].licenceRef]
+        const licenceRefs = [scenarios.primaryUserWithAdditionalContact.primaryUserRecipient.licenceRef]
         const { bindings, query } = GenerateAbstractionAlertRecipientsQueryService.go(licenceRefs)
         const { rows } = await db.raw(query, bindings)
 
-        const expectedResults = RecipientScenariosSeeder.transformToSendingResults([scenarios[3][1], scenarios[3][2]])
+        const expectedResults = RecipientScenariosSeeder.transformToSendingResults([
+          scenarios.primaryUserWithAdditionalContact.primaryUserRecipient,
+          scenarios.primaryUserWithAdditionalContact.additionalContactRecipient
+        ])
 
         expect(rows).to.equal(expectedResults)
       })
@@ -219,14 +233,17 @@ describe('Notices - Setup - Abstraction Alerts - Generate Abstraction Alert Reci
 
     describe('and the same "additional contact" is associated with multiple licence documents (Scenario 5)', () => {
       it('returns the expected recipients', async () => {
-        const licenceRefs = [scenarios[4][0].licenceRef, scenarios[4][1].licenceRef].sort(compareStrings)
+        const licenceRefs = [
+          scenarios.additionalContactMultipleLicences.licenceHolderRecipient.licenceRef,
+          scenarios.additionalContactMultipleLicences.licenceHolderRecipientTwo.licenceRef
+        ].sort(compareStrings)
 
         const { bindings, query } = GenerateAbstractionAlertRecipientsQueryService.go(licenceRefs)
         const { rows } = await db.raw(query, bindings)
 
         const transformedResults = RecipientScenariosSeeder.transformToSendingResults([
-          scenarios[4][0],
-          scenarios[4][2]
+          scenarios.additionalContactMultipleLicences.licenceHolderRecipient,
+          scenarios.additionalContactMultipleLicences.additionalContactRecipient
         ])
         const expectedResults = [
           { ...transformedResults[0], licence_refs: licenceRefs },
@@ -239,11 +256,13 @@ describe('Notices - Setup - Abstraction Alerts - Generate Abstraction Alert Reci
 
     describe('and an additional contact is present but abstractionAlerts is false (Scenario 6)', () => {
       it('returns only the "licence holder" and not the additional contact', async () => {
-        const licenceRefs = [scenarios[5][0].licenceRef]
+        const licenceRefs = [scenarios.additionalContactNoAlerts.licenceHolderRecipient.licenceRef]
         const { bindings, query } = GenerateAbstractionAlertRecipientsQueryService.go(licenceRefs)
         const { rows } = await db.raw(query, bindings)
 
-        const expectedResults = RecipientScenariosSeeder.transformToSendingResults([scenarios[5][0]])
+        const expectedResults = RecipientScenariosSeeder.transformToSendingResults([
+          scenarios.additionalContactNoAlerts.licenceHolderRecipient
+        ])
 
         expect(rows).to.equal(expectedResults)
       })
@@ -251,16 +270,19 @@ describe('Notices - Setup - Abstraction Alerts - Generate Abstraction Alert Reci
 
     describe('and different "licence holders" and "additional contacts" are present for different licences (Scenario 7)', () => {
       it('returns the expected recipients', async () => {
-        const licenceRefs = [scenarios[6][0].licenceRef, scenarios[6][1].licenceRef].sort(compareStrings)
+        const licenceRefs = [
+          scenarios.differentHoldersAndContacts.firstLicenceHolderRecipient.licenceRef,
+          scenarios.differentHoldersAndContacts.secondLicenceHolderRecipient.licenceRef
+        ].sort(compareStrings)
 
         const { bindings, query } = GenerateAbstractionAlertRecipientsQueryService.go(licenceRefs)
         const { rows } = await db.raw(query, bindings)
 
         const transformedResults = RecipientScenariosSeeder.transformToSendingResults([
-          scenarios[6][0],
-          scenarios[6][1],
-          scenarios[6][2],
-          scenarios[6][3]
+          scenarios.differentHoldersAndContacts.firstLicenceHolderRecipient,
+          scenarios.differentHoldersAndContacts.secondLicenceHolderRecipient,
+          scenarios.differentHoldersAndContacts.firstAdditionalContact,
+          scenarios.differentHoldersAndContacts.secondAdditionalContact
         ])
         const expectedResults = transformedResults.sort((a, b) => {
           return compareStrings(a.licence_refs[0], b.licence_refs[0])
@@ -272,15 +294,18 @@ describe('Notices - Setup - Abstraction Alerts - Generate Abstraction Alert Reci
 
     describe('and one of the "additional contacts" has abstractionAlerts set to false across multiple licences (Scenario 8)', () => {
       it('returns both "licence holders" but only the "additional contact" with abstractionAlerts set to true', async () => {
-        const licenceRefs = [scenarios[7][0].licenceRef, scenarios[7][1].licenceRef].sort(compareStrings)
+        const licenceRefs = [
+          scenarios.mixedAlerts.licenceHolderRecipientWithAlert.licenceRef,
+          scenarios.mixedAlerts.licenceHolderRecipientWithoutAlert.licenceRef
+        ].sort(compareStrings)
 
         const { bindings, query } = GenerateAbstractionAlertRecipientsQueryService.go(licenceRefs)
         const { rows } = await db.raw(query, bindings)
 
         const transformedResults = RecipientScenariosSeeder.transformToSendingResults([
-          scenarios[7][0],
-          scenarios[7][1],
-          scenarios[7][2]
+          scenarios.mixedAlerts.licenceHolderRecipientWithAlert,
+          scenarios.mixedAlerts.licenceHolderRecipientWithoutAlert,
+          scenarios.mixedAlerts.additionalContactWithAlert
         ])
         const expectedResults = transformedResults.sort((a, b) => {
           return compareStrings(a.licence_refs[0], b.licence_refs[0])
@@ -292,11 +317,13 @@ describe('Notices - Setup - Abstraction Alerts - Generate Abstraction Alert Reci
 
     describe('and the additional contact end date has passed (Scenario 9)', () => {
       it('returns only the "licence holder" and not the expired additional contact', async () => {
-        const licenceRefs = [scenarios[8][0].licenceRef]
+        const licenceRefs = [scenarios.expiredAdditionalContact.licenceHolderRecipient.licenceRef]
         const { bindings, query } = GenerateAbstractionAlertRecipientsQueryService.go(licenceRefs)
         const { rows } = await db.raw(query, bindings)
 
-        const expectedResults = RecipientScenariosSeeder.transformToSendingResults([scenarios[8][0]])
+        const expectedResults = RecipientScenariosSeeder.transformToSendingResults([
+          scenarios.expiredAdditionalContact.licenceHolderRecipient
+        ])
 
         expect(rows).to.equal(expectedResults)
       })

--- a/test/services/notices/setup/returns-notice/generate-recipients-query.service.test.js
+++ b/test/services/notices/setup/returns-notice/generate-recipients-query.service.test.js
@@ -394,11 +394,10 @@ describe('Notices - Setup - Returns Notice - Generate Recipients Query service',
 
   describe('when executed', () => {
     before(async () => {
-      scenarios = []
+      scenarios = {}
       returnLogs = []
 
       let returnLog
-      let scenario
 
       // SCENARIOS
 
@@ -406,57 +405,55 @@ describe('Notices - Setup - Returns Notice - Generate Recipients Query service',
       // record with the one licence ref
       await _addReturnLog(returnLogs)
       await _addReturnLog(returnLogs, { licenceRef: returnLogs[0].licenceRef })
-      scenario = await RecipientScenariosSeeder.licenceHolderOnly([returnLogs[0], returnLogs[1]])
-      scenarios.push(scenario)
+      scenarios.licenceHolderOnly = await RecipientScenariosSeeder.licenceHolderOnly([returnLogs[0], returnLogs[1]])
 
       // 2) Licence holder and returns to - all versions of the query will return the licence holder. When the notice
       // type is ALTERNATE_INVITATION, only the licence holder will be returned
       returnLog = await _addReturnLog(returnLogs)
-      scenario = await RecipientScenariosSeeder.licenceHolderWithDifferentReturnsTo([returnLog])
-      scenarios.push(scenario)
+      scenarios.licenceHolderWithDifferentReturnsTo =
+        await RecipientScenariosSeeder.licenceHolderWithDifferentReturnsTo([returnLog])
 
       // 3) Same licence holder, but is linked to multiple licences with due return logs - only one recipient record
       // will be returned with multiple licence refs
       await _addReturnLog(returnLogs)
       await _addReturnLog(returnLogs)
-      scenario = await RecipientScenariosSeeder.licenceHolderWithMultipleLicences([
+      scenarios.licenceHolderWithMultipleLicences = await RecipientScenariosSeeder.licenceHolderWithMultipleLicences([
         returnLogs[returnLogs.length - 2],
         returnLogs[returnLogs.length - 1]
       ])
-      scenarios.push(scenario)
 
       // 4) Licence holder and returns to where they have the same contact details - only one recipient record will be
       // returned
       returnLog = await _addReturnLog(returnLogs)
-      scenario = await RecipientScenariosSeeder.licenceHolderWithSameReturnsTo([returnLog])
-      scenarios.push(scenario)
+      scenarios.licenceHolderWithSameReturnsTo = await RecipientScenariosSeeder.licenceHolderWithSameReturnsTo([
+        returnLog
+      ])
 
       // 5) Primary user only. All licences have a licence holder record, but when 'registered' the query will only
       // return the primary user recipient.
       returnLog = await _addReturnLog(returnLogs)
-      scenario = await RecipientScenariosSeeder.primaryUserOnly([returnLog])
-      scenarios.push(scenario)
+      scenarios.primaryUserOnly = await RecipientScenariosSeeder.primaryUserOnly([returnLog])
 
       // 6) Primary user and returns user. Just like with 5), the query will return the primary user details and not
       // the licence holder. But as a returns user has also been added, it will be returned as well.
       returnLog = await _addReturnLog(returnLogs)
-      scenario = await RecipientScenariosSeeder.primaryUserWithDifferentReturnsAgent([returnLog])
-      scenarios.push(scenario)
+      scenarios.primaryUserWithDifferentReturnsAgent =
+        await RecipientScenariosSeeder.primaryUserWithDifferentReturnsAgent([returnLog])
 
       // 7) Same primary user, but is linked to multiple licences with due return logs - only one recipient record
       // will be returned with multiple licence refs
       await _addReturnLog(returnLogs)
       await _addReturnLog(returnLogs)
-      scenario = await RecipientScenariosSeeder.primaryUserWithMultipleLicences([
+      scenarios.primaryUserWithMultipleLicences = await RecipientScenariosSeeder.primaryUserWithMultipleLicences([
         returnLogs[returnLogs.length - 2],
         returnLogs[returnLogs.length - 1]
       ])
-      scenarios.push(scenario)
 
       // 8) Primary user and returns user with the same email address - only one recipient record will be returned
       returnLog = await _addReturnLog(returnLogs)
-      scenario = await RecipientScenariosSeeder.primaryUserWithSameReturnsAgent([returnLog])
-      scenarios.push(scenario)
+      scenarios.primaryUserWithSameReturnsAgent = await RecipientScenariosSeeder.primaryUserWithSameReturnsAgent([
+        returnLog
+      ])
 
       // Prepare the array of returnLogIds for the query parameter
       returnLogIds = returnLogs.map((returnLog) => {
@@ -494,7 +491,7 @@ describe('Notices - Setup - Returns Notice - Generate Recipients Query service',
 
           const { rows } = await db.raw(query, [returnLogIds])
 
-          const sendingResults = RecipientScenariosSeeder.transformToSendingResults(scenarios[0])
+          const sendingResults = RecipientScenariosSeeder.transformToSendingResults(scenarios.licenceHolderOnly)
 
           expect(rows).to.contain(sendingResults[0])
         })
@@ -504,7 +501,9 @@ describe('Notices - Setup - Returns Notice - Generate Recipients Query service',
 
           const { rows } = await db.raw(query, [returnLogIds])
 
-          const sendingResults = RecipientScenariosSeeder.transformToSendingResults(scenarios[1])
+          const sendingResults = RecipientScenariosSeeder.transformToSendingResults(
+            scenarios.licenceHolderWithDifferentReturnsTo
+          )
 
           expect(rows).to.contain(sendingResults[0])
           expect(rows).to.contain(sendingResults[1])
@@ -515,7 +514,9 @@ describe('Notices - Setup - Returns Notice - Generate Recipients Query service',
 
           const { rows } = await db.raw(query, [returnLogIds])
 
-          const sendingResults = RecipientScenariosSeeder.transformToSendingResults(scenarios[2])
+          const sendingResults = RecipientScenariosSeeder.transformToSendingResults(
+            scenarios.licenceHolderWithMultipleLicences
+          )
 
           expect(rows).to.contain(sendingResults[0])
           // We could test rows contains the second licence holder recipient recorded in the scenario, but they are the
@@ -528,7 +529,9 @@ describe('Notices - Setup - Returns Notice - Generate Recipients Query service',
 
           const { rows } = await db.raw(query, [returnLogIds])
 
-          const sendingResults = RecipientScenariosSeeder.transformToSendingResults(scenarios[3])
+          const sendingResults = RecipientScenariosSeeder.transformToSendingResults(
+            scenarios.licenceHolderWithSameReturnsTo
+          )
 
           expect(rows).to.contain(sendingResults[0])
 
@@ -540,7 +543,7 @@ describe('Notices - Setup - Returns Notice - Generate Recipients Query service',
 
           const { rows } = await db.raw(query, [returnLogIds])
 
-          const sendingResults = RecipientScenariosSeeder.transformToSendingResults(scenarios[4])
+          const sendingResults = RecipientScenariosSeeder.transformToSendingResults(scenarios.primaryUserOnly)
 
           expect(rows).to.contain(sendingResults[1])
 
@@ -553,7 +556,9 @@ describe('Notices - Setup - Returns Notice - Generate Recipients Query service',
 
           const { rows } = await db.raw(query, [returnLogIds])
 
-          const sendingResults = RecipientScenariosSeeder.transformToSendingResults(scenarios[5])
+          const sendingResults = RecipientScenariosSeeder.transformToSendingResults(
+            scenarios.primaryUserWithDifferentReturnsAgent
+          )
 
           expect(rows).to.contain(sendingResults[1])
           expect(rows).to.contain(sendingResults[2])
@@ -566,7 +571,9 @@ describe('Notices - Setup - Returns Notice - Generate Recipients Query service',
 
           const { rows } = await db.raw(query, [returnLogIds])
 
-          const sendingResults = RecipientScenariosSeeder.transformToSendingResults(scenarios[6])
+          const sendingResults = RecipientScenariosSeeder.transformToSendingResults(
+            scenarios.primaryUserWithMultipleLicences
+          )
 
           expect(rows).to.contain(sendingResults[2])
 
@@ -586,7 +593,9 @@ describe('Notices - Setup - Returns Notice - Generate Recipients Query service',
 
           const { rows } = await db.raw(query, [returnLogIds])
 
-          const sendingResults = RecipientScenariosSeeder.transformToSendingResults(scenarios[7])
+          const sendingResults = RecipientScenariosSeeder.transformToSendingResults(
+            scenarios.primaryUserWithSameReturnsAgent
+          )
 
           expect(rows).to.contain(sendingResults[1])
 
@@ -616,7 +625,7 @@ describe('Notices - Setup - Returns Notice - Generate Recipients Query service',
 
           const { rows } = await db.raw(query, [returnLogIds])
 
-          const downloadingResults = RecipientScenariosSeeder.transformToDownloadingResults(scenarios[0])
+          const downloadingResults = RecipientScenariosSeeder.transformToDownloadingResults(scenarios.licenceHolderOnly)
 
           // We created two return logs for the same licence  and licence holder. So we expect two results: one for each
           // return log
@@ -629,7 +638,9 @@ describe('Notices - Setup - Returns Notice - Generate Recipients Query service',
 
           const { rows } = await db.raw(query, [returnLogIds])
 
-          const downloadingResults = RecipientScenariosSeeder.transformToDownloadingResults(scenarios[1])
+          const downloadingResults = RecipientScenariosSeeder.transformToDownloadingResults(
+            scenarios.licenceHolderWithDifferentReturnsTo
+          )
 
           expect(rows).to.contain(downloadingResults[0])
           expect(rows).to.contain(downloadingResults[1])
@@ -640,7 +651,9 @@ describe('Notices - Setup - Returns Notice - Generate Recipients Query service',
 
           const { rows } = await db.raw(query, [returnLogIds])
 
-          const downloadingResults = RecipientScenariosSeeder.transformToDownloadingResults(scenarios[2])
+          const downloadingResults = RecipientScenariosSeeder.transformToDownloadingResults(
+            scenarios.licenceHolderWithMultipleLicences
+          )
 
           // Unlike sending, because we want the return log information it means though the recipient details are the
           // same, the return logs are not. So, we get a row per return log for the licence holder.
@@ -658,7 +671,9 @@ describe('Notices - Setup - Returns Notice - Generate Recipients Query service',
 
           const { rows } = await db.raw(query, [returnLogIds])
 
-          const downloadingResults = RecipientScenariosSeeder.transformToDownloadingResults(scenarios[3])
+          const downloadingResults = RecipientScenariosSeeder.transformToDownloadingResults(
+            scenarios.licenceHolderWithSameReturnsTo
+          )
 
           expect(rows).to.contain(downloadingResults[0])
 
@@ -670,7 +685,7 @@ describe('Notices - Setup - Returns Notice - Generate Recipients Query service',
 
           const { rows } = await db.raw(query, [returnLogIds])
 
-          const downloadingResults = RecipientScenariosSeeder.transformToDownloadingResults(scenarios[4])
+          const downloadingResults = RecipientScenariosSeeder.transformToDownloadingResults(scenarios.primaryUserOnly)
 
           expect(rows).to.contain(downloadingResults[1])
 
@@ -683,7 +698,9 @@ describe('Notices - Setup - Returns Notice - Generate Recipients Query service',
 
           const { rows } = await db.raw(query, [returnLogIds])
 
-          const downloadingResults = RecipientScenariosSeeder.transformToDownloadingResults(scenarios[5])
+          const downloadingResults = RecipientScenariosSeeder.transformToDownloadingResults(
+            scenarios.primaryUserWithDifferentReturnsAgent
+          )
 
           expect(rows).to.contain(downloadingResults[1])
           expect(rows).to.contain(downloadingResults[2])
@@ -696,7 +713,9 @@ describe('Notices - Setup - Returns Notice - Generate Recipients Query service',
 
           const { rows } = await db.raw(query, [returnLogIds])
 
-          const downloadingResults = RecipientScenariosSeeder.transformToDownloadingResults(scenarios[6])
+          const downloadingResults = RecipientScenariosSeeder.transformToDownloadingResults(
+            scenarios.primaryUserWithMultipleLicences
+          )
 
           // Unlike sending, because we want the return log information it means though the recipient details are the
           // same, the return logs are not. So, we get a row per return log for the primary user.
@@ -723,7 +742,9 @@ describe('Notices - Setup - Returns Notice - Generate Recipients Query service',
 
           const { rows } = await db.raw(query, [returnLogIds])
 
-          const downloadingResults = RecipientScenariosSeeder.transformToDownloadingResults(scenarios[7])
+          const downloadingResults = RecipientScenariosSeeder.transformToDownloadingResults(
+            scenarios.primaryUserWithSameReturnsAgent
+          )
 
           expect(rows).to.contain(downloadingResults[1])
 
@@ -759,7 +780,7 @@ describe('Notices - Setup - Returns Notice - Generate Recipients Query service',
 
           const { rows } = await db.raw(query, [returnLogIds])
 
-          const sendingResults = RecipientScenariosSeeder.transformToSendingResults(scenarios[0])
+          const sendingResults = RecipientScenariosSeeder.transformToSendingResults(scenarios.licenceHolderOnly)
 
           expect(rows).to.contain(sendingResults[0])
         })
@@ -769,7 +790,9 @@ describe('Notices - Setup - Returns Notice - Generate Recipients Query service',
 
           const { rows } = await db.raw(query, [returnLogIds])
 
-          const sendingResults = RecipientScenariosSeeder.transformToSendingResults(scenarios[1])
+          const sendingResults = RecipientScenariosSeeder.transformToSendingResults(
+            scenarios.licenceHolderWithDifferentReturnsTo
+          )
 
           expect(rows).to.contain(sendingResults[0])
           expect(rows).to.contain(sendingResults[1])
@@ -780,7 +803,9 @@ describe('Notices - Setup - Returns Notice - Generate Recipients Query service',
 
           const { rows } = await db.raw(query, [returnLogIds])
 
-          const sendingResults = RecipientScenariosSeeder.transformToSendingResults(scenarios[2])
+          const sendingResults = RecipientScenariosSeeder.transformToSendingResults(
+            scenarios.licenceHolderWithMultipleLicences
+          )
 
           expect(rows).to.contain(sendingResults[0])
           // We could test rows contains the second licence holder recipient recorded in the scenario, but they are the
@@ -793,7 +818,9 @@ describe('Notices - Setup - Returns Notice - Generate Recipients Query service',
 
           const { rows } = await db.raw(query, [returnLogIds])
 
-          const sendingResults = RecipientScenariosSeeder.transformToSendingResults(scenarios[3])
+          const sendingResults = RecipientScenariosSeeder.transformToSendingResults(
+            scenarios.licenceHolderWithSameReturnsTo
+          )
 
           expect(rows).to.contain(sendingResults[0])
 
@@ -805,7 +832,7 @@ describe('Notices - Setup - Returns Notice - Generate Recipients Query service',
 
           const { rows } = await db.raw(query, [returnLogIds])
 
-          const sendingResults = RecipientScenariosSeeder.transformToSendingResults(scenarios[4])
+          const sendingResults = RecipientScenariosSeeder.transformToSendingResults(scenarios.primaryUserOnly)
 
           expect(rows).to.contain(sendingResults[0])
 
@@ -817,7 +844,9 @@ describe('Notices - Setup - Returns Notice - Generate Recipients Query service',
 
           const { rows } = await db.raw(query, [returnLogIds])
 
-          const sendingResults = RecipientScenariosSeeder.transformToSendingResults(scenarios[5])
+          const sendingResults = RecipientScenariosSeeder.transformToSendingResults(
+            scenarios.primaryUserWithDifferentReturnsAgent
+          )
 
           expect(rows).to.contain(sendingResults[0])
 
@@ -830,7 +859,9 @@ describe('Notices - Setup - Returns Notice - Generate Recipients Query service',
 
           const { rows } = await db.raw(query, [returnLogIds])
 
-          const sendingResults = RecipientScenariosSeeder.transformToSendingResults(scenarios[6])
+          const sendingResults = RecipientScenariosSeeder.transformToSendingResults(
+            scenarios.primaryUserWithMultipleLicences
+          )
 
           // NOTE: Because we created two return logs with different licence refs, we have to create two licence
           // document headers with the same 'licence holder' to recreate linking the same primary user across multiple
@@ -850,7 +881,9 @@ describe('Notices - Setup - Returns Notice - Generate Recipients Query service',
 
           const { rows } = await db.raw(query, [returnLogIds])
 
-          const sendingResults = RecipientScenariosSeeder.transformToSendingResults(scenarios[7])
+          const sendingResults = RecipientScenariosSeeder.transformToSendingResults(
+            scenarios.primaryUserWithSameReturnsAgent
+          )
 
           expect(rows).to.contain(sendingResults[0])
 
@@ -880,7 +913,7 @@ describe('Notices - Setup - Returns Notice - Generate Recipients Query service',
 
           const { rows } = await db.raw(query, [returnLogIds])
 
-          const downloadingResults = RecipientScenariosSeeder.transformToDownloadingResults(scenarios[0])
+          const downloadingResults = RecipientScenariosSeeder.transformToDownloadingResults(scenarios.licenceHolderOnly)
 
           // We created two return logs for the same licence  and licence holder. So we expect two results: one for each
           // return log
@@ -893,7 +926,7 @@ describe('Notices - Setup - Returns Notice - Generate Recipients Query service',
 
           const { rows } = await db.raw(query, [returnLogIds])
 
-          const downloadingResults = RecipientScenariosSeeder.transformToDownloadingResults(scenarios[1])
+          const downloadingResults = RecipientScenariosSeeder.transformToDownloadingResults(scenarios.licenceHolderOnly)
 
           expect(rows).to.contain(downloadingResults[0])
           expect(rows).to.contain(downloadingResults[1])
@@ -904,7 +937,9 @@ describe('Notices - Setup - Returns Notice - Generate Recipients Query service',
 
           const { rows } = await db.raw(query, [returnLogIds])
 
-          const downloadingResults = RecipientScenariosSeeder.transformToDownloadingResults(scenarios[2])
+          const downloadingResults = RecipientScenariosSeeder.transformToDownloadingResults(
+            scenarios.licenceHolderWithMultipleLicences
+          )
 
           // Unlike sending, because we want the return log information it means though the recipient details are the
           // same, the return logs are not. So, we get a row per return log for the licence holder.
@@ -922,7 +957,9 @@ describe('Notices - Setup - Returns Notice - Generate Recipients Query service',
 
           const { rows } = await db.raw(query, [returnLogIds])
 
-          const downloadingResults = RecipientScenariosSeeder.transformToDownloadingResults(scenarios[3])
+          const downloadingResults = RecipientScenariosSeeder.transformToDownloadingResults(
+            scenarios.licenceHolderWithSameReturnsTo
+          )
 
           expect(rows).to.contain(downloadingResults[0])
 
@@ -934,7 +971,7 @@ describe('Notices - Setup - Returns Notice - Generate Recipients Query service',
 
           const { rows } = await db.raw(query, [returnLogIds])
 
-          const downloadingResults = RecipientScenariosSeeder.transformToDownloadingResults(scenarios[4])
+          const downloadingResults = RecipientScenariosSeeder.transformToDownloadingResults(scenarios.primaryUserOnly)
 
           expect(rows).to.contain(downloadingResults[0])
 
@@ -946,7 +983,9 @@ describe('Notices - Setup - Returns Notice - Generate Recipients Query service',
 
           const { rows } = await db.raw(query, [returnLogIds])
 
-          const downloadingResults = RecipientScenariosSeeder.transformToDownloadingResults(scenarios[5])
+          const downloadingResults = RecipientScenariosSeeder.transformToDownloadingResults(
+            scenarios.primaryUserWithDifferentReturnsAgent
+          )
 
           expect(rows).to.contain(downloadingResults[0])
 
@@ -959,7 +998,9 @@ describe('Notices - Setup - Returns Notice - Generate Recipients Query service',
 
           const { rows } = await db.raw(query, [returnLogIds])
 
-          const downloadingResults = RecipientScenariosSeeder.transformToDownloadingResults(scenarios[6])
+          const downloadingResults = RecipientScenariosSeeder.transformToDownloadingResults(
+            scenarios.primaryUserWithMultipleLicences
+          )
 
           // Unlike sending, because we want the return log information it means though the recipient details are the
           // same, the return logs are not. So, we get a row per return log for the licence holder.
@@ -988,7 +1029,9 @@ describe('Notices - Setup - Returns Notice - Generate Recipients Query service',
 
           const { rows } = await db.raw(query, [returnLogIds])
 
-          const downloadingResults = RecipientScenariosSeeder.transformToDownloadingResults(scenarios[7])
+          const downloadingResults = RecipientScenariosSeeder.transformToDownloadingResults(
+            scenarios.primaryUserWithSameReturnsAgent
+          )
 
           expect(rows).to.contain(downloadingResults[0])
 
@@ -1020,7 +1063,7 @@ describe('Notices - Setup - Returns Notice - Generate Recipients Query service',
 
         const { rows } = await db.raw(query, [returnLogIds])
 
-        const sendingResults = RecipientScenariosSeeder.transformToSendingResults(scenarios[0])
+        const sendingResults = RecipientScenariosSeeder.transformToSendingResults(scenarios.licenceHolderOnly)
 
         expect(rows).to.contain(sendingResults[0])
       })
@@ -1030,7 +1073,9 @@ describe('Notices - Setup - Returns Notice - Generate Recipients Query service',
 
         const { rows } = await db.raw(query, [returnLogIds])
 
-        const sendingResults = RecipientScenariosSeeder.transformToSendingResults(scenarios[1])
+        const sendingResults = RecipientScenariosSeeder.transformToSendingResults(
+          scenarios.licenceHolderWithDifferentReturnsTo
+        )
 
         expect(rows).to.contain(sendingResults[0])
 
@@ -1042,7 +1087,9 @@ describe('Notices - Setup - Returns Notice - Generate Recipients Query service',
 
         const { rows } = await db.raw(query, [returnLogIds])
 
-        const sendingResults = RecipientScenariosSeeder.transformToSendingResults(scenarios[2])
+        const sendingResults = RecipientScenariosSeeder.transformToSendingResults(
+          scenarios.licenceHolderWithMultipleLicences
+        )
 
         expect(rows).to.contain(sendingResults[0])
         // We could test rows contains the second licence holder recipient recorded in the scenario, but they are the
@@ -1055,7 +1102,9 @@ describe('Notices - Setup - Returns Notice - Generate Recipients Query service',
 
         const { rows } = await db.raw(query, [returnLogIds])
 
-        const sendingResults = RecipientScenariosSeeder.transformToSendingResults(scenarios[3])
+        const sendingResults = RecipientScenariosSeeder.transformToSendingResults(
+          scenarios.licenceHolderWithSameReturnsTo
+        )
 
         expect(rows).to.contain(sendingResults[0])
 
@@ -1067,7 +1116,7 @@ describe('Notices - Setup - Returns Notice - Generate Recipients Query service',
 
         const { rows } = await db.raw(query, [returnLogIds])
 
-        const sendingResults = RecipientScenariosSeeder.transformToSendingResults(scenarios[4])
+        const sendingResults = RecipientScenariosSeeder.transformToSendingResults(scenarios.primaryUserOnly)
 
         expect(rows).to.contain(sendingResults[0])
 
@@ -1079,7 +1128,9 @@ describe('Notices - Setup - Returns Notice - Generate Recipients Query service',
 
         const { rows } = await db.raw(query, [returnLogIds])
 
-        const sendingResults = RecipientScenariosSeeder.transformToSendingResults(scenarios[5])
+        const sendingResults = RecipientScenariosSeeder.transformToSendingResults(
+          scenarios.primaryUserWithDifferentReturnsAgent
+        )
 
         expect(rows).to.contain(sendingResults[0])
 
@@ -1092,7 +1143,9 @@ describe('Notices - Setup - Returns Notice - Generate Recipients Query service',
 
         const { rows } = await db.raw(query, [returnLogIds])
 
-        const sendingResults = RecipientScenariosSeeder.transformToSendingResults(scenarios[6])
+        const sendingResults = RecipientScenariosSeeder.transformToSendingResults(
+          scenarios.primaryUserWithMultipleLicences
+        )
 
         // NOTE: Because we created two return logs with different licence refs, we have to create two licence
         // document headers with the same 'licence holder' to recreate linking the same primary user across multiple
@@ -1112,7 +1165,9 @@ describe('Notices - Setup - Returns Notice - Generate Recipients Query service',
 
         const { rows } = await db.raw(query, [returnLogIds])
 
-        const sendingResults = RecipientScenariosSeeder.transformToSendingResults(scenarios[7])
+        const sendingResults = RecipientScenariosSeeder.transformToSendingResults(
+          scenarios.primaryUserWithSameReturnsAgent
+        )
 
         expect(rows).to.contain(sendingResults[0])
 

--- a/test/support/seeders/recipient-scenarios.seeder.js
+++ b/test/support/seeders/recipient-scenarios.seeder.js
@@ -19,8 +19,8 @@ const { compareStrings } = require('../../../app/lib/general.lib.js')
  * @param {object[]} scenarios - The scenarios created by a test suite
  */
 async function clean(scenarios) {
-  for (const recipients of scenarios) {
-    for (const recipient of recipients) {
+  for (const recipients of Object.values(scenarios)) {
+    for (const recipient of Object.values(recipients)) {
       await RecipientsSeeder.clean(recipient)
     }
   }


### PR DESCRIPTION
This change refactors the scenarios from an array to an object, this is easier on the developer to understand (we can read the scenarios).