### PR TITLE
Refactor the recipient scenario seeder licenceRefs

### DIFF
--- a/test/services/jobs/renewal-invitations/generate-renewal-recipients-query.service.test.js
+++ b/test/services/jobs/renewal-invitations/generate-renewal-recipients-query.service.test.js
@@ -126,7 +126,7 @@ WHERE
           scenarios.primaryUserMultipleLicences
         )
 
-        expect(rows).to.contain(expectedResults[2])
+        expect(rows).to.contain(expectedResults[1])
 
         // NOTE: When a licence is registered, expectedResults[0] will always reference the licence holder
         expect(rows).not.to.contain(expectedResults[0])

--- a/test/services/notices/setup/abstraction-alerts/fetch-abstraction-alert-recipients.service.test.js
+++ b/test/services/notices/setup/abstraction-alerts/fetch-abstraction-alert-recipients.service.test.js
@@ -8,10 +8,7 @@ const { describe, it, before, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const CRMContactsSeeder = require('../../../../support/seeders/crm-contacts.seeder.js')
-const EmptyLicence = require('../../../../support/seeders/empty-licence.seeder.js')
 const RecipientScenariosSeeder = require('../../../../support/seeders/recipient-scenarios.seeder.js')
-const RecipientsSeeder = require('../../../../support/seeders/recipients.seeder.js')
 
 // Thing under test
 const FetchAbstractionAlertRecipientsService = require('../../../../../app/services/notices/setup/abstraction-alerts/fetch-abstraction-alert-recipients.service.js')
@@ -24,11 +21,9 @@ describe('Notices - Setup - Abstraction Alerts - Fetch Abstraction Alert Recipie
     scenarios = {}
 
     // 1) Licence holder only
-    const licenceHolder = await _licenceHolder()
-    const licenceHolderRecipient = await _licenceHolderRecipient(licenceHolder.licence, licenceHolder.licenceHolder)
-    scenarios.licenceHolder = { licenceHolderRecipient }
+    scenarios.licenceHolder = await RecipientScenariosSeeder.licenceHolderOnly()
 
-    session = { licenceRefs: [scenarios.licenceHolder.licenceHolderRecipient.licenceRef] }
+    session = { licenceRefs: scenarios.licenceHolder.licenceHolderRecipient.licenceRefs }
   })
 
   after(async () => {
@@ -39,29 +34,9 @@ describe('Notices - Setup - Abstraction Alerts - Fetch Abstraction Alert Recipie
     it('fetches the correct recipient data', async () => {
       const result = await FetchAbstractionAlertRecipientsService.go(session)
 
-      const expectedResults = RecipientScenariosSeeder.transformToSendingResults([
-        scenarios.licenceHolder.licenceHolderRecipient
-      ])
+      const expectedResults = RecipientScenariosSeeder.transformToSendingResults(scenarios.licenceHolder)
 
       expect(result).to.equal(expectedResults)
     })
   })
 })
-
-async function _licenceHolder() {
-  const licence = await EmptyLicence.seed()
-  const licenceHolder = await CRMContactsSeeder.licenceHolder(licence, 'Holderwithadditionalcontact')
-
-  return {
-    licence,
-    licenceHolder
-  }
-}
-
-async function _licenceHolderRecipient(licence, licenceHolder) {
-  const licenceHolderRecipient = await RecipientsSeeder.licenceHolder(licence, licenceHolder)
-
-  licenceHolderRecipient.licenceRefs = [licence.licence.licenceRef]
-
-  return licenceHolderRecipient
-}

--- a/test/services/notices/setup/abstraction-alerts/generate-abstraction-alert-recipients-query.service.test.js
+++ b/test/services/notices/setup/abstraction-alerts/generate-abstraction-alert-recipients-query.service.test.js
@@ -27,13 +27,9 @@ describe('Notices - Setup - Abstraction Alerts - Generate Abstraction Alert Reci
     let additionalContactRecipient
     let licenceHolder
     let licenceHolderRecipient
-    let primaryUser
-    let primaryUserRecipient
 
     // 1) Licence holder only
-    licenceHolder = await _licenceHolder()
-    licenceHolderRecipient = await _licenceHolderRecipient(licenceHolder.licence, licenceHolder.licenceHolder)
-    scenarios.licenceHolder = { licenceHolderRecipient }
+    scenarios.licenceHolder = await RecipientScenariosSeeder.licenceHolderOnly()
 
     // 2) Licence holder, and an additional contact
     licenceHolder = await _licenceHolder()
@@ -43,18 +39,14 @@ describe('Notices - Setup - Abstraction Alerts - Generate Abstraction Alert Reci
 
     // 3) Primary user only. All licences have a licence holder record, but when 'registered' the query will only
     // return the primary user recipient.
-    licenceHolder = await _licenceHolder()
-    licenceHolderRecipient = await _licenceHolderRecipient(licenceHolder.licence, licenceHolder.licenceHolder)
-    primaryUser = await _primaryUser(licenceHolder.licence)
-    primaryUserRecipient = await _primaryUserRecipient(licenceHolder.licence, primaryUser.primaryUser)
-    scenarios.primaryUser = { licenceHolderRecipient, primaryUserRecipient }
+    scenarios.primaryUser = await RecipientScenariosSeeder.primaryUserOnly()
 
     // 4) Primary user with an additional contact. Similar to scenario 3 - when registered, we expect the primary user
     // and additional contact but not the licence holder.
     licenceHolder = await _licenceHolder()
     licenceHolderRecipient = await _licenceHolderRecipient(licenceHolder.licence, licenceHolder.licenceHolder)
-    primaryUser = await _primaryUser(licenceHolder.licence)
-    primaryUserRecipient = await _primaryUserRecipient(licenceHolder.licence, primaryUser.primaryUser)
+    const primaryUser = await _primaryUser(licenceHolder.licence)
+    const primaryUserRecipient = await _primaryUserRecipient(licenceHolder.licence, primaryUser.primaryUser)
     additionalContactRecipient = await _additionalContactRecipient(licenceHolder.licence)
     scenarios.primaryUserWithAdditionalContact = {
       licenceHolderRecipient,
@@ -175,7 +167,7 @@ describe('Notices - Setup - Abstraction Alerts - Generate Abstraction Alert Reci
   describe('when executed', () => {
     describe('and only the licence holder is present for an unregistered licence (Scenario 1)', () => {
       it('returns the expected recipients', async () => {
-        const licenceRefs = [scenarios.licenceHolder.licenceHolderRecipient.licenceRef]
+        const licenceRefs = scenarios.licenceHolder.licenceHolderRecipient.licenceRefs
         const { bindings, query } = GenerateAbstractionAlertRecipientsQueryService.go(licenceRefs)
         const { rows } = await db.raw(query, bindings)
 
@@ -189,7 +181,7 @@ describe('Notices - Setup - Abstraction Alerts - Generate Abstraction Alert Reci
 
     describe('and both the "additional contact" and the "licence holder" are present for an unregistered licence (Scenario 2)', () => {
       it('returns the expected recipients', async () => {
-        const licenceRefs = [scenarios.licenceHolderWithAdditionalContact.licenceHolderRecipient.licenceRef]
+        const licenceRefs = scenarios.licenceHolderWithAdditionalContact.licenceHolderRecipient.licenceRefs
         const { bindings, query } = GenerateAbstractionAlertRecipientsQueryService.go(licenceRefs)
         const { rows } = await db.raw(query, bindings)
 
@@ -204,7 +196,7 @@ describe('Notices - Setup - Abstraction Alerts - Generate Abstraction Alert Reci
 
     describe('and only the "primary user" is present for a registered licence (Scenario 3)', () => {
       it('returns the expected recipients', async () => {
-        const licenceRefs = [scenarios.primaryUser.primaryUserRecipient.licenceRef]
+        const licenceRefs = scenarios.primaryUser.primaryUserRecipient.licenceRefs
         const { bindings, query } = GenerateAbstractionAlertRecipientsQueryService.go(licenceRefs)
         const { rows } = await db.raw(query, bindings)
 
@@ -218,7 +210,7 @@ describe('Notices - Setup - Abstraction Alerts - Generate Abstraction Alert Reci
 
     describe('and both the "primary user" and "additional contact" are present for a registered licence, but not the licence holder (Scenario 4)', () => {
       it('returns the expected recipients', async () => {
-        const licenceRefs = [scenarios.primaryUserWithAdditionalContact.primaryUserRecipient.licenceRef]
+        const licenceRefs = scenarios.primaryUserWithAdditionalContact.primaryUserRecipient.licenceRefs
         const { bindings, query } = GenerateAbstractionAlertRecipientsQueryService.go(licenceRefs)
         const { rows } = await db.raw(query, bindings)
 
@@ -234,8 +226,8 @@ describe('Notices - Setup - Abstraction Alerts - Generate Abstraction Alert Reci
     describe('and the same "additional contact" is associated with multiple licence documents (Scenario 5)', () => {
       it('returns the expected recipients', async () => {
         const licenceRefs = [
-          scenarios.additionalContactMultipleLicences.licenceHolderRecipient.licenceRef,
-          scenarios.additionalContactMultipleLicences.licenceHolderRecipientTwo.licenceRef
+          ...scenarios.additionalContactMultipleLicences.licenceHolderRecipient.licenceRefs,
+          ...scenarios.additionalContactMultipleLicences.licenceHolderRecipientTwo.licenceRefs
         ].sort(compareStrings)
 
         const { bindings, query } = GenerateAbstractionAlertRecipientsQueryService.go(licenceRefs)
@@ -256,7 +248,7 @@ describe('Notices - Setup - Abstraction Alerts - Generate Abstraction Alert Reci
 
     describe('and an additional contact is present but abstractionAlerts is false (Scenario 6)', () => {
       it('returns only the "licence holder" and not the additional contact', async () => {
-        const licenceRefs = [scenarios.additionalContactNoAlerts.licenceHolderRecipient.licenceRef]
+        const licenceRefs = scenarios.additionalContactNoAlerts.licenceHolderRecipient.licenceRefs
         const { bindings, query } = GenerateAbstractionAlertRecipientsQueryService.go(licenceRefs)
         const { rows } = await db.raw(query, bindings)
 
@@ -271,8 +263,8 @@ describe('Notices - Setup - Abstraction Alerts - Generate Abstraction Alert Reci
     describe('and different "licence holders" and "additional contacts" are present for different licences (Scenario 7)', () => {
       it('returns the expected recipients', async () => {
         const licenceRefs = [
-          scenarios.differentHoldersAndContacts.firstLicenceHolderRecipient.licenceRef,
-          scenarios.differentHoldersAndContacts.secondLicenceHolderRecipient.licenceRef
+          ...scenarios.differentHoldersAndContacts.firstLicenceHolderRecipient.licenceRefs,
+          ...scenarios.differentHoldersAndContacts.secondLicenceHolderRecipient.licenceRefs
         ].sort(compareStrings)
 
         const { bindings, query } = GenerateAbstractionAlertRecipientsQueryService.go(licenceRefs)
@@ -295,8 +287,8 @@ describe('Notices - Setup - Abstraction Alerts - Generate Abstraction Alert Reci
     describe('and one of the "additional contacts" has abstractionAlerts set to false across multiple licences (Scenario 8)', () => {
       it('returns both "licence holders" but only the "additional contact" with abstractionAlerts set to true', async () => {
         const licenceRefs = [
-          scenarios.mixedAlerts.licenceHolderRecipientWithAlert.licenceRef,
-          scenarios.mixedAlerts.licenceHolderRecipientWithoutAlert.licenceRef
+          ...scenarios.mixedAlerts.licenceHolderRecipientWithAlert.licenceRefs,
+          ...scenarios.mixedAlerts.licenceHolderRecipientWithoutAlert.licenceRefs
         ].sort(compareStrings)
 
         const { bindings, query } = GenerateAbstractionAlertRecipientsQueryService.go(licenceRefs)
@@ -317,7 +309,7 @@ describe('Notices - Setup - Abstraction Alerts - Generate Abstraction Alert Reci
 
     describe('and the additional contact end date has passed (Scenario 9)', () => {
       it('returns only the "licence holder" and not the expired additional contact', async () => {
-        const licenceRefs = [scenarios.expiredAdditionalContact.licenceHolderRecipient.licenceRef]
+        const licenceRefs = scenarios.expiredAdditionalContact.licenceHolderRecipient.licenceRefs
         const { bindings, query } = GenerateAbstractionAlertRecipientsQueryService.go(licenceRefs)
         const { rows } = await db.raw(query, bindings)
 
@@ -336,7 +328,7 @@ async function _additionalContactRecipient(licence, abstractionAlerts = true, co
 
   const additionalContactRecipient = await RecipientsSeeder.additionalContact(licence, additionalContact)
 
-  additionalContactRecipient.licenceRefs = [licence.licence.licenceRef]
+  additionalContactRecipient.licenceRefss = [licence.licence.licenceRefs]
 
   return additionalContactRecipient
 }
@@ -354,7 +346,7 @@ async function _licenceHolder(name = 'Holderwithadditionalcontact') {
 async function _licenceHolderRecipient(licence, licenceHolder) {
   const licenceHolderRecipient = await RecipientsSeeder.licenceHolder(licence, licenceHolder)
 
-  licenceHolderRecipient.licenceRefs = [licence.licence.licenceRef]
+  licenceHolderRecipient.licenceRefss = [licence.licence.licenceRefs]
 
   return licenceHolderRecipient
 }
@@ -364,7 +356,7 @@ async function _primaryUser(licence) {
 
   const primaryUserRecipient = await RecipientsSeeder.primaryUser(licence, primaryUser)
 
-  primaryUserRecipient.licenceRefs = [licence.licence.licenceRef]
+  primaryUserRecipient.licenceRefss = [licence.licence.licenceRefs]
 
   return { primaryUser }
 }
@@ -372,7 +364,7 @@ async function _primaryUser(licence) {
 async function _primaryUserRecipient(licence, primaryUser) {
   const primaryUserRecipient = await RecipientsSeeder.primaryUser(licence, primaryUser)
 
-  primaryUserRecipient.licenceRefs = [licence.licence.licenceRef]
+  primaryUserRecipient.licenceRefss = [licence.licence.licenceRefs]
 
   return primaryUserRecipient
 }

--- a/test/services/notices/setup/abstraction-alerts/generate-abstraction-alert-recipients-query.service.test.js
+++ b/test/services/notices/setup/abstraction-alerts/generate-abstraction-alert-recipients-query.service.test.js
@@ -11,7 +11,7 @@ const { expect } = Code
 const CRMContactsSeeder = require('../../../../support/seeders/crm-contacts.seeder.js')
 const EmptyLicence = require('../../../../support/seeders/empty-licence.seeder.js')
 const RecipientScenariosSeeder = require('../../../../support/seeders/recipient-scenarios.seeder.js')
-const RecipientsSeeder = require('../../../../support/seeders/recipients.seeder.js')
+const RecipientsFormatter = require('../../../../support/seeders/recipients.formatter.js')
 const { compareStrings } = require('../../../../../app/lib/general.lib.js')
 const { db } = require('../../../../../db/db.js')
 
@@ -33,7 +33,7 @@ describe('Notices - Setup - Abstraction Alerts - Generate Abstraction Alert Reci
 
     // 2) Licence holder, and an additional contact
     licenceHolder = await _licenceHolder()
-    licenceHolderRecipient = await RecipientsSeeder.licenceHolder(licenceHolder.licence, licenceHolder.licenceHolder)
+    licenceHolderRecipient = await RecipientsFormatter.licenceHolder(licenceHolder.licence, licenceHolder.licenceHolder)
     additionalContactRecipient = await _additionalContactRecipient(licenceHolder.licence)
     scenarios.licenceHolderWithAdditionalContact = { licenceHolderRecipient, additionalContactRecipient }
 
@@ -44,9 +44,9 @@ describe('Notices - Setup - Abstraction Alerts - Generate Abstraction Alert Reci
     // 4) Primary user with an additional contact. Similar to scenario 3 - when registered, we expect the primary user
     // and additional contact but not the licence holder.
     licenceHolder = await _licenceHolder()
-    licenceHolderRecipient = await RecipientsSeeder.licenceHolder(licenceHolder.licence, licenceHolder.licenceHolder)
+    licenceHolderRecipient = await RecipientsFormatter.licenceHolder(licenceHolder.licence, licenceHolder.licenceHolder)
     const primaryUser = await _primaryUser(licenceHolder.licence)
-    const primaryUserRecipient = await RecipientsSeeder.primaryUser(licenceHolder.licence, primaryUser.primaryUser)
+    const primaryUserRecipient = await RecipientsFormatter.primaryUser(licenceHolder.licence, primaryUser.primaryUser)
     additionalContactRecipient = await _additionalContactRecipient(licenceHolder.licence)
     scenarios.primaryUserWithAdditionalContact = {
       licenceHolderRecipient,
@@ -56,12 +56,12 @@ describe('Notices - Setup - Abstraction Alerts - Generate Abstraction Alert Reci
 
     // 5) Additional contact multiple licence refs
     licenceHolder = await _licenceHolder()
-    licenceHolderRecipient = await RecipientsSeeder.licenceHolder(licenceHolder.licence, licenceHolder.licenceHolder)
+    licenceHolderRecipient = await RecipientsFormatter.licenceHolder(licenceHolder.licence, licenceHolder.licenceHolder)
     additionalContactRecipient = await _additionalContactRecipient(licenceHolder.licence)
 
     // Second licence
     const licenceHolderTwo = await _licenceHolder()
-    const licenceHolderRecipientTwo = await RecipientsSeeder.licenceHolder(
+    const licenceHolderRecipientTwo = await RecipientsFormatter.licenceHolder(
       licenceHolderTwo.licence,
       licenceHolderTwo.licenceHolder
     )
@@ -76,7 +76,7 @@ describe('Notices - Setup - Abstraction Alerts - Generate Abstraction Alert Reci
     // 6) Licence holder with an additional contact where abstractionAlerts = false. The additional contact should NOT
     // appear in results.
     licenceHolder = await _licenceHolder()
-    licenceHolderRecipient = await RecipientsSeeder.licenceHolder(licenceHolder.licence, licenceHolder.licenceHolder)
+    licenceHolderRecipient = await RecipientsFormatter.licenceHolder(licenceHolder.licence, licenceHolder.licenceHolder)
     const additionalContactNoAlerts = await _additionalContactRecipient(licenceHolder.licence, false)
     scenarios.additionalContactNoAlerts = { licenceHolderRecipient, additionalContactNoAlerts }
 
@@ -84,14 +84,14 @@ describe('Notices - Setup - Abstraction Alerts - Generate Abstraction Alert Reci
     // the same contact spans multiple licences and is combined into one row, here each licence has unique contacts so
     // all four recipients are returned separately.
     const firstLicenceHolder = await _licenceHolder('HolderWithUniqueContactA')
-    const firstLicenceHolderRecipient = await RecipientsSeeder.licenceHolder(
+    const firstLicenceHolderRecipient = await RecipientsFormatter.licenceHolder(
       firstLicenceHolder.licence,
       firstLicenceHolder.licenceHolder
     )
     const firstAdditionalContact = await _additionalContactRecipient(firstLicenceHolder.licence)
 
     const secondLicenceHolder = await _licenceHolder('HolderWithUniqueContactB')
-    const secondLicenceHolderRecipient = await RecipientsSeeder.licenceHolder(
+    const secondLicenceHolderRecipient = await RecipientsFormatter.licenceHolder(
       secondLicenceHolder.licence,
       secondLicenceHolder.licenceHolder
     )
@@ -111,14 +111,14 @@ describe('Notices - Setup - Abstraction Alerts - Generate Abstraction Alert Reci
     // 8) Two licences with different licence holders and additional contacts, but one additional contact has
     // abstractionAlerts = false and should NOT appear in results.
     const licenceHolderWithAlert = await _licenceHolder('HolderWithMixedAlertsA')
-    const licenceHolderRecipientWithAlert = await RecipientsSeeder.licenceHolder(
+    const licenceHolderRecipientWithAlert = await RecipientsFormatter.licenceHolder(
       licenceHolderWithAlert.licence,
       licenceHolderWithAlert.licenceHolder
     )
     const additionalContactWithAlert = await _additionalContactRecipient(licenceHolderWithAlert.licence)
 
     const licenceHolderWithoutAlert = await _licenceHolder('HolderWithMixedAlertsB')
-    const licenceHolderRecipientWithoutAlert = await RecipientsSeeder.licenceHolder(
+    const licenceHolderRecipientWithoutAlert = await RecipientsFormatter.licenceHolder(
       licenceHolderWithoutAlert.licence,
       licenceHolderWithoutAlert.licenceHolder
     )
@@ -138,7 +138,7 @@ describe('Notices - Setup - Abstraction Alerts - Generate Abstraction Alert Reci
     // 9) Licence holder with an additional contact where the end date has passed. The expired contact should NOT
     // appear in results.
     licenceHolder = await _licenceHolder()
-    licenceHolderRecipient = await RecipientsSeeder.licenceHolder(licenceHolder.licence, licenceHolder.licenceHolder)
+    licenceHolderRecipient = await RecipientsFormatter.licenceHolder(licenceHolder.licence, licenceHolder.licenceHolder)
     const expiredAdditionalContact = await _additionalContactRecipient(
       licenceHolder.licence,
       true,
@@ -323,7 +323,7 @@ describe('Notices - Setup - Abstraction Alerts - Generate Abstraction Alert Reci
 async function _additionalContactRecipient(licence, abstractionAlerts = true, contactData = null, endDate = null) {
   const additionalContact = await CRMContactsSeeder.additionalContact(licence, contactData, abstractionAlerts, endDate)
 
-  return RecipientsSeeder.additionalContact(licence, additionalContact)
+  return RecipientsFormatter.additionalContact(licence, additionalContact)
 }
 
 async function _licenceHolder(name = 'Holderwithadditionalcontact') {

--- a/test/services/notices/setup/abstraction-alerts/generate-abstraction-alert-recipients-query.service.test.js
+++ b/test/services/notices/setup/abstraction-alerts/generate-abstraction-alert-recipients-query.service.test.js
@@ -33,7 +33,7 @@ describe('Notices - Setup - Abstraction Alerts - Generate Abstraction Alert Reci
 
     // 2) Licence holder, and an additional contact
     licenceHolder = await _licenceHolder()
-    licenceHolderRecipient = await _licenceHolderRecipient(licenceHolder.licence, licenceHolder.licenceHolder)
+    licenceHolderRecipient = await RecipientsSeeder.licenceHolder(licenceHolder.licence, licenceHolder.licenceHolder)
     additionalContactRecipient = await _additionalContactRecipient(licenceHolder.licence)
     scenarios.licenceHolderWithAdditionalContact = { licenceHolderRecipient, additionalContactRecipient }
 
@@ -44,9 +44,9 @@ describe('Notices - Setup - Abstraction Alerts - Generate Abstraction Alert Reci
     // 4) Primary user with an additional contact. Similar to scenario 3 - when registered, we expect the primary user
     // and additional contact but not the licence holder.
     licenceHolder = await _licenceHolder()
-    licenceHolderRecipient = await _licenceHolderRecipient(licenceHolder.licence, licenceHolder.licenceHolder)
+    licenceHolderRecipient = await RecipientsSeeder.licenceHolder(licenceHolder.licence, licenceHolder.licenceHolder)
     const primaryUser = await _primaryUser(licenceHolder.licence)
-    const primaryUserRecipient = await _primaryUserRecipient(licenceHolder.licence, primaryUser.primaryUser)
+    const primaryUserRecipient = await RecipientsSeeder.primaryUser(licenceHolder.licence, primaryUser.primaryUser)
     additionalContactRecipient = await _additionalContactRecipient(licenceHolder.licence)
     scenarios.primaryUserWithAdditionalContact = {
       licenceHolderRecipient,
@@ -56,12 +56,12 @@ describe('Notices - Setup - Abstraction Alerts - Generate Abstraction Alert Reci
 
     // 5) Additional contact multiple licence refs
     licenceHolder = await _licenceHolder()
-    licenceHolderRecipient = await _licenceHolderRecipient(licenceHolder.licence, licenceHolder.licenceHolder)
+    licenceHolderRecipient = await RecipientsSeeder.licenceHolder(licenceHolder.licence, licenceHolder.licenceHolder)
     additionalContactRecipient = await _additionalContactRecipient(licenceHolder.licence)
 
     // Second licence
     const licenceHolderTwo = await _licenceHolder()
-    const licenceHolderRecipientTwo = await _licenceHolderRecipient(
+    const licenceHolderRecipientTwo = await RecipientsSeeder.licenceHolder(
       licenceHolderTwo.licence,
       licenceHolderTwo.licenceHolder
     )
@@ -76,7 +76,7 @@ describe('Notices - Setup - Abstraction Alerts - Generate Abstraction Alert Reci
     // 6) Licence holder with an additional contact where abstractionAlerts = false. The additional contact should NOT
     // appear in results.
     licenceHolder = await _licenceHolder()
-    licenceHolderRecipient = await _licenceHolderRecipient(licenceHolder.licence, licenceHolder.licenceHolder)
+    licenceHolderRecipient = await RecipientsSeeder.licenceHolder(licenceHolder.licence, licenceHolder.licenceHolder)
     const additionalContactNoAlerts = await _additionalContactRecipient(licenceHolder.licence, false)
     scenarios.additionalContactNoAlerts = { licenceHolderRecipient, additionalContactNoAlerts }
 
@@ -84,14 +84,14 @@ describe('Notices - Setup - Abstraction Alerts - Generate Abstraction Alert Reci
     // the same contact spans multiple licences and is combined into one row, here each licence has unique contacts so
     // all four recipients are returned separately.
     const firstLicenceHolder = await _licenceHolder('HolderWithUniqueContactA')
-    const firstLicenceHolderRecipient = await _licenceHolderRecipient(
+    const firstLicenceHolderRecipient = await RecipientsSeeder.licenceHolder(
       firstLicenceHolder.licence,
       firstLicenceHolder.licenceHolder
     )
     const firstAdditionalContact = await _additionalContactRecipient(firstLicenceHolder.licence)
 
     const secondLicenceHolder = await _licenceHolder('HolderWithUniqueContactB')
-    const secondLicenceHolderRecipient = await _licenceHolderRecipient(
+    const secondLicenceHolderRecipient = await RecipientsSeeder.licenceHolder(
       secondLicenceHolder.licence,
       secondLicenceHolder.licenceHolder
     )
@@ -111,14 +111,14 @@ describe('Notices - Setup - Abstraction Alerts - Generate Abstraction Alert Reci
     // 8) Two licences with different licence holders and additional contacts, but one additional contact has
     // abstractionAlerts = false and should NOT appear in results.
     const licenceHolderWithAlert = await _licenceHolder('HolderWithMixedAlertsA')
-    const licenceHolderRecipientWithAlert = await _licenceHolderRecipient(
+    const licenceHolderRecipientWithAlert = await RecipientsSeeder.licenceHolder(
       licenceHolderWithAlert.licence,
       licenceHolderWithAlert.licenceHolder
     )
     const additionalContactWithAlert = await _additionalContactRecipient(licenceHolderWithAlert.licence)
 
     const licenceHolderWithoutAlert = await _licenceHolder('HolderWithMixedAlertsB')
-    const licenceHolderRecipientWithoutAlert = await _licenceHolderRecipient(
+    const licenceHolderRecipientWithoutAlert = await RecipientsSeeder.licenceHolder(
       licenceHolderWithoutAlert.licence,
       licenceHolderWithoutAlert.licenceHolder
     )
@@ -138,7 +138,7 @@ describe('Notices - Setup - Abstraction Alerts - Generate Abstraction Alert Reci
     // 9) Licence holder with an additional contact where the end date has passed. The expired contact should NOT
     // appear in results.
     licenceHolder = await _licenceHolder()
-    licenceHolderRecipient = await _licenceHolderRecipient(licenceHolder.licence, licenceHolder.licenceHolder)
+    licenceHolderRecipient = await RecipientsSeeder.licenceHolder(licenceHolder.licence, licenceHolder.licenceHolder)
     const expiredAdditionalContact = await _additionalContactRecipient(
       licenceHolder.licence,
       true,
@@ -171,9 +171,7 @@ describe('Notices - Setup - Abstraction Alerts - Generate Abstraction Alert Reci
         const { bindings, query } = GenerateAbstractionAlertRecipientsQueryService.go(licenceRefs)
         const { rows } = await db.raw(query, bindings)
 
-        const expectedResults = RecipientScenariosSeeder.transformToSendingResults([
-          scenarios.licenceHolder.licenceHolderRecipient
-        ])
+        const expectedResults = RecipientScenariosSeeder.transformToSendingResults(scenarios.licenceHolder)
 
         expect(rows).to.equal(expectedResults)
       })
@@ -185,10 +183,9 @@ describe('Notices - Setup - Abstraction Alerts - Generate Abstraction Alert Reci
         const { bindings, query } = GenerateAbstractionAlertRecipientsQueryService.go(licenceRefs)
         const { rows } = await db.raw(query, bindings)
 
-        const expectedResults = RecipientScenariosSeeder.transformToSendingResults([
-          scenarios.licenceHolderWithAdditionalContact.licenceHolderRecipient,
-          scenarios.licenceHolderWithAdditionalContact.additionalContactRecipient
-        ])
+        const expectedResults = RecipientScenariosSeeder.transformToSendingResults(
+          scenarios.licenceHolderWithAdditionalContact
+        )
 
         expect(rows).to.equal(expectedResults)
       })
@@ -200,9 +197,9 @@ describe('Notices - Setup - Abstraction Alerts - Generate Abstraction Alert Reci
         const { bindings, query } = GenerateAbstractionAlertRecipientsQueryService.go(licenceRefs)
         const { rows } = await db.raw(query, bindings)
 
-        const expectedResults = RecipientScenariosSeeder.transformToSendingResults([
-          scenarios.primaryUser.primaryUserRecipient
-        ])
+        const expectedResults = RecipientScenariosSeeder.transformToSendingResults({
+          primaryUserRecipient: scenarios.primaryUser.primaryUserRecipient
+        })
 
         expect(rows).to.equal(expectedResults)
       })
@@ -214,10 +211,10 @@ describe('Notices - Setup - Abstraction Alerts - Generate Abstraction Alert Reci
         const { bindings, query } = GenerateAbstractionAlertRecipientsQueryService.go(licenceRefs)
         const { rows } = await db.raw(query, bindings)
 
-        const expectedResults = RecipientScenariosSeeder.transformToSendingResults([
-          scenarios.primaryUserWithAdditionalContact.primaryUserRecipient,
-          scenarios.primaryUserWithAdditionalContact.additionalContactRecipient
-        ])
+        const expectedResults = RecipientScenariosSeeder.transformToSendingResults({
+          primaryUserRecipient: scenarios.primaryUserWithAdditionalContact.primaryUserRecipient,
+          additionalContactRecipient: scenarios.primaryUserWithAdditionalContact.additionalContactRecipient
+        })
 
         expect(rows).to.equal(expectedResults)
       })
@@ -233,10 +230,10 @@ describe('Notices - Setup - Abstraction Alerts - Generate Abstraction Alert Reci
         const { bindings, query } = GenerateAbstractionAlertRecipientsQueryService.go(licenceRefs)
         const { rows } = await db.raw(query, bindings)
 
-        const transformedResults = RecipientScenariosSeeder.transformToSendingResults([
-          scenarios.additionalContactMultipleLicences.licenceHolderRecipient,
-          scenarios.additionalContactMultipleLicences.additionalContactRecipient
-        ])
+        const transformedResults = RecipientScenariosSeeder.transformToSendingResults({
+          licenceHolderRecipient: scenarios.additionalContactMultipleLicences.licenceHolderRecipient,
+          additionalContactRecipient: scenarios.additionalContactMultipleLicences.additionalContactRecipient
+        })
         const expectedResults = [
           { ...transformedResults[0], licence_refs: licenceRefs },
           { ...transformedResults[1], licence_refs: licenceRefs }
@@ -252,9 +249,9 @@ describe('Notices - Setup - Abstraction Alerts - Generate Abstraction Alert Reci
         const { bindings, query } = GenerateAbstractionAlertRecipientsQueryService.go(licenceRefs)
         const { rows } = await db.raw(query, bindings)
 
-        const expectedResults = RecipientScenariosSeeder.transformToSendingResults([
-          scenarios.additionalContactNoAlerts.licenceHolderRecipient
-        ])
+        const expectedResults = RecipientScenariosSeeder.transformToSendingResults({
+          licenceHolderRecipient: scenarios.additionalContactNoAlerts.licenceHolderRecipient
+        })
 
         expect(rows).to.equal(expectedResults)
       })
@@ -270,12 +267,12 @@ describe('Notices - Setup - Abstraction Alerts - Generate Abstraction Alert Reci
         const { bindings, query } = GenerateAbstractionAlertRecipientsQueryService.go(licenceRefs)
         const { rows } = await db.raw(query, bindings)
 
-        const transformedResults = RecipientScenariosSeeder.transformToSendingResults([
-          scenarios.differentHoldersAndContacts.firstLicenceHolderRecipient,
-          scenarios.differentHoldersAndContacts.secondLicenceHolderRecipient,
-          scenarios.differentHoldersAndContacts.firstAdditionalContact,
-          scenarios.differentHoldersAndContacts.secondAdditionalContact
-        ])
+        const transformedResults = RecipientScenariosSeeder.transformToSendingResults({
+          firstLicenceHolderRecipient: scenarios.differentHoldersAndContacts.firstLicenceHolderRecipient,
+          secondLicenceHolderRecipient: scenarios.differentHoldersAndContacts.secondLicenceHolderRecipient,
+          firstAdditionalContact: scenarios.differentHoldersAndContacts.firstAdditionalContact,
+          secondAdditionalContact: scenarios.differentHoldersAndContacts.secondAdditionalContact
+        })
         const expectedResults = transformedResults.sort((a, b) => {
           return compareStrings(a.licence_refs[0], b.licence_refs[0])
         })
@@ -294,11 +291,11 @@ describe('Notices - Setup - Abstraction Alerts - Generate Abstraction Alert Reci
         const { bindings, query } = GenerateAbstractionAlertRecipientsQueryService.go(licenceRefs)
         const { rows } = await db.raw(query, bindings)
 
-        const transformedResults = RecipientScenariosSeeder.transformToSendingResults([
-          scenarios.mixedAlerts.licenceHolderRecipientWithAlert,
-          scenarios.mixedAlerts.licenceHolderRecipientWithoutAlert,
-          scenarios.mixedAlerts.additionalContactWithAlert
-        ])
+        const transformedResults = RecipientScenariosSeeder.transformToSendingResults({
+          licenceHolderRecipientWithAlert: scenarios.mixedAlerts.licenceHolderRecipientWithAlert,
+          licenceHolderRecipientWithoutAlert: scenarios.mixedAlerts.licenceHolderRecipientWithoutAlert,
+          additionalContactWithAlert: scenarios.mixedAlerts.additionalContactWithAlert
+        })
         const expectedResults = transformedResults.sort((a, b) => {
           return compareStrings(a.licence_refs[0], b.licence_refs[0])
         })
@@ -313,9 +310,9 @@ describe('Notices - Setup - Abstraction Alerts - Generate Abstraction Alert Reci
         const { bindings, query } = GenerateAbstractionAlertRecipientsQueryService.go(licenceRefs)
         const { rows } = await db.raw(query, bindings)
 
-        const expectedResults = RecipientScenariosSeeder.transformToSendingResults([
-          scenarios.expiredAdditionalContact.licenceHolderRecipient
-        ])
+        const expectedResults = RecipientScenariosSeeder.transformToSendingResults({
+          licenceHolderRecipient: scenarios.expiredAdditionalContact.licenceHolderRecipient
+        })
 
         expect(rows).to.equal(expectedResults)
       })
@@ -326,11 +323,7 @@ describe('Notices - Setup - Abstraction Alerts - Generate Abstraction Alert Reci
 async function _additionalContactRecipient(licence, abstractionAlerts = true, contactData = null, endDate = null) {
   const additionalContact = await CRMContactsSeeder.additionalContact(licence, contactData, abstractionAlerts, endDate)
 
-  const additionalContactRecipient = await RecipientsSeeder.additionalContact(licence, additionalContact)
-
-  additionalContactRecipient.licenceRefss = [licence.licence.licenceRefs]
-
-  return additionalContactRecipient
+  return RecipientsSeeder.additionalContact(licence, additionalContact)
 }
 
 async function _licenceHolder(name = 'Holderwithadditionalcontact') {
@@ -343,28 +336,8 @@ async function _licenceHolder(name = 'Holderwithadditionalcontact') {
   }
 }
 
-async function _licenceHolderRecipient(licence, licenceHolder) {
-  const licenceHolderRecipient = await RecipientsSeeder.licenceHolder(licence, licenceHolder)
-
-  licenceHolderRecipient.licenceRefss = [licence.licence.licenceRefs]
-
-  return licenceHolderRecipient
-}
-
 async function _primaryUser(licence) {
   const primaryUser = await CRMContactsSeeder.primaryUser(licence, 'primaryuser@pura.com')
 
-  const primaryUserRecipient = await RecipientsSeeder.primaryUser(licence, primaryUser)
-
-  primaryUserRecipient.licenceRefss = [licence.licence.licenceRefs]
-
   return { primaryUser }
-}
-
-async function _primaryUserRecipient(licence, primaryUser) {
-  const primaryUserRecipient = await RecipientsSeeder.primaryUser(licence, primaryUser)
-
-  primaryUserRecipient.licenceRefss = [licence.licence.licenceRefs]
-
-  return primaryUserRecipient
 }

--- a/test/services/notices/setup/renewal-notice/fetch-alternate-renewal-recipients.service.test.js
+++ b/test/services/notices/setup/renewal-notice/fetch-alternate-renewal-recipients.service.test.js
@@ -8,43 +8,33 @@ const { describe, it, before, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const CRMContactsSeeder = require('../../../../support/seeders/crm-contacts.seeder.js')
-const EmptyLicenceSeeder = require('../../../../support/seeders/empty-licence.seeder.js')
-const RecipientsSeeder = require('../../../../support/seeders/recipients.seeder.js')
+const RecipientScenariosSeeder = require('../../../../support/seeders/recipient-scenarios.seeder.js')
 
 // Thing under test
 const FetchAlternateRenewalRecipientsService = require('../../../../../app/services/notices/setup/renewal-notice/fetch-alternate-renewal-recipients.service.js')
 
 describe('Notices - Setup - Renewal Notice - Fetch Alternate Renewal Recipients service', () => {
-  let licenceHolder
-  let licenceHolderSeedData
-  let licenceRef
-  let licenceSeedData
+  let scenarios
 
   before(async () => {
-    licenceSeedData = await EmptyLicenceSeeder.seed()
+    scenarios = {}
 
-    licenceRef = licenceSeedData.licence.licenceRef
-
-    licenceHolderSeedData = await CRMContactsSeeder.licenceHolder(licenceSeedData, 'Test Licence Holder')
-
-    licenceHolder = await RecipientsSeeder.licenceHolder(licenceSeedData, licenceHolderSeedData)
-    licenceHolder.licenceRefs = [licenceRef]
+    // 1) Licence holder only
+    scenarios.licenceHolder = await RecipientScenariosSeeder.licenceHolderOnly()
   })
 
   after(async () => {
-    await licenceSeedData.clean()
-    await licenceHolderSeedData.clean()
-    await RecipientsSeeder.clean(licenceHolder)
+    await RecipientScenariosSeeder.clean(scenarios)
   })
 
   describe('when service is called for sending the "alternate notice"', () => {
     it('fetches the correct recipient data for sending the notice', async () => {
-      const results = await FetchAlternateRenewalRecipientsService.go([licenceRef])
+      const licenceRefs = scenarios.licenceHolder.licenceHolderRecipient.licenceRefs
+      const results = await FetchAlternateRenewalRecipientsService.go(licenceRefs)
 
-      const expectedResult = RecipientsSeeder.transformToSendingResult(licenceHolder)
+      const expectedResult = RecipientScenariosSeeder.transformToSendingResults(scenarios.licenceHolder)
 
-      expect(results).to.equal([expectedResult])
+      expect(results).to.equal(expectedResult)
     })
   })
 })

--- a/test/services/notices/setup/returns-notice/fetch-alternate-returns-recipients.service.test.js
+++ b/test/services/notices/setup/returns-notice/fetch-alternate-returns-recipients.service.test.js
@@ -8,9 +8,7 @@ const { describe, it, before, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const CRMContactsSeeder = require('../../../../support/seeders/crm-contacts.seeder.js')
-const EmptyLicenceSeeder = require('../../../../support/seeders/empty-licence.seeder.js')
-const RecipientsSeeder = require('../../../../support/seeders/recipients.seeder.js')
+const RecipientScenariosSeeder = require('../../../../support/seeders/recipient-scenarios.seeder.js')
 const ReturnLogHelper = require('../../../../support/helpers/return-log.helper.js')
 
 // Thing under test
@@ -19,42 +17,31 @@ const FetchAlternateReturnsRecipients = require('../../../../../app/services/not
 describe('Notices - Setup - Returns Notice - Fetch Alternate Returns Recipients service', () => {
   const notificationDueDate = new Date('2025-12-24')
 
-  let licenceHolder
-  let licenceHolderSeedData
-  let licenceRef
-  let licenceSeedData
   let returnLog
+  let scenarios
 
   before(async () => {
-    licenceSeedData = await EmptyLicenceSeeder.seed(licenceRef)
+    scenarios = {}
 
-    licenceRef = licenceSeedData.licence.licenceRef
+    // 1) Licence holder only
+    returnLog = await ReturnLogHelper.add({ dueDate: null })
 
-    returnLog = await ReturnLogHelper.add({ dueDate: null, licenceRef })
-
-    licenceHolderSeedData = await CRMContactsSeeder.licenceHolder(licenceSeedData, 'Test Licence Holder')
-
-    licenceHolder = await RecipientsSeeder.licenceHolder(licenceSeedData, licenceHolderSeedData)
-    licenceHolder.licenceRefs = [licenceRef]
-    licenceHolder.returnLogIds = [returnLog.id]
+    scenarios.licenceHolder = await RecipientScenariosSeeder.licenceHolderOnly([returnLog])
   })
 
   after(async () => {
-    await returnLog.$query().delete()
-
-    await licenceSeedData.clean()
-    await licenceHolderSeedData.clean()
-    await RecipientsSeeder.clean(licenceHolder)
+    await RecipientScenariosSeeder.clean(scenarios)
   })
 
   describe('when service is called for sending the "alternate notice"', () => {
     it('fetches the correct recipient data for sending the notice', async () => {
       const results = await FetchAlternateReturnsRecipients.go([returnLog.id], notificationDueDate)
 
-      const sendingResult = RecipientsSeeder.transformToSendingResult(licenceHolder)
-      sendingResult.notificationDueDate = notificationDueDate
+      const sendingResult = RecipientScenariosSeeder.transformToSendingResults(scenarios.licenceHolder)
 
-      expect(results).to.equal([sendingResult])
+      sendingResult[0].notificationDueDate = notificationDueDate
+
+      expect(results).to.equal(sendingResult)
     })
   })
 })

--- a/test/services/notices/setup/returns-notice/fetch-paper-returns-recipients.service.test.js
+++ b/test/services/notices/setup/returns-notice/fetch-paper-returns-recipients.service.test.js
@@ -8,10 +8,8 @@ const { describe, it, before, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const CRMContactsSeeder = require('../../../../support/seeders/crm-contacts.seeder.js')
-const EmptyLicenceSeeder = require('../../../../support/seeders/empty-licence.seeder.js')
 const NoticeSessionFixture = require('../../../../support/fixtures/notice-session.fixture.js')
-const RecipientsSeeder = require('../../../../support/seeders/recipients.seeder.js')
+const RecipientScenariosSeeder = require('../../../../support/seeders/recipient-scenarios.seeder.js')
 const ReturnLogHelper = require('../../../../support/helpers/return-log.helper.js')
 
 // Thing under test
@@ -19,36 +17,29 @@ const FetchPaperReturnsRecipientsService = require('../../../../../app/services/
 
 describe('Notices - Setup - Returns Notice - Fetch Paper Returns Recipients service', () => {
   let download
-  let licenceHolder
-  let licenceHolderSeedData
-  let licenceRef
-  let licenceSeedData
   let session
   let setDueDateReturnLog
+  let scenarios
 
   before(async () => {
-    licenceSeedData = await EmptyLicenceSeeder.seed(licenceRef)
+    scenarios = {}
 
-    licenceRef = licenceSeedData.licence.licenceRef
-
+    // 1) Licence holder only
     // Create a return log with a populated `dueDate`.
-    setDueDateReturnLog = await ReturnLogHelper.add({ dueDate: new Date('2025-04-28'), licenceRef })
+    setDueDateReturnLog = await ReturnLogHelper.add({ dueDate: new Date('2025-04-28') })
 
-    session = NoticeSessionFixture.paperReturn(licenceRef, setDueDateReturnLog)
+    scenarios.licenceHolder = await RecipientScenariosSeeder.licenceHolderOnly([setDueDateReturnLog])
 
-    licenceHolderSeedData = await CRMContactsSeeder.licenceHolder(licenceSeedData, 'Test Licence Holder')
-
-    licenceHolder = await RecipientsSeeder.licenceHolder(licenceSeedData, licenceHolderSeedData)
-    licenceHolder.licenceRefs = [licenceRef]
-    licenceHolder.returnLogIds = [setDueDateReturnLog.id]
+    session = NoticeSessionFixture.paperReturn(
+      scenarios.licenceHolder.licenceHolderRecipient.licenceRefs[0],
+      setDueDateReturnLog
+    )
   })
 
   after(async () => {
     await setDueDateReturnLog.$query().delete()
 
-    await licenceSeedData.clean()
-    await licenceHolderSeedData.clean()
-    await RecipientsSeeder.clean(licenceHolder)
+    await RecipientScenariosSeeder.clean(scenarios)
   })
 
   describe('when service is called for sending or checking recipients', () => {
@@ -64,13 +55,13 @@ describe('Notices - Setup - Returns Notice - Fetch Paper Returns Recipients serv
       // combination, and the notification due date is determined based on the selected return log. So, the
       // PaperReturnNotificationsPresenter handles it. But the service sets it to null to return an object consistent
       // with FetchReturnsInvitationRecipients and FetchReturnsReminderRecipients.
-      const sendingResult = RecipientsSeeder.transformToSendingResult(licenceHolder)
+      const sendingResult = RecipientScenariosSeeder.transformToSendingResults(scenarios.licenceHolder)
 
-      sendingResult.due_date_status = 'all populated'
-      sendingResult.latest_due_date = setDueDateReturnLog.dueDate
-      sendingResult.notificationDueDate = null
+      sendingResult[0].due_date_status = 'all populated'
+      sendingResult[0].latest_due_date = setDueDateReturnLog.dueDate
+      sendingResult[0].notificationDueDate = null
 
-      expect(results).to.equal([sendingResult])
+      expect(results).to.equal(sendingResult)
     })
   })
 
@@ -84,11 +75,11 @@ describe('Notices - Setup - Returns Notice - Fetch Paper Returns Recipients serv
 
       // NOTE: When fetching data for the download, the service _can_ determine the notification due date because each
       // row is distinct to a recipient and return log combination.
-      const downloadingResult = RecipientsSeeder.transformToDownloadingResult(licenceHolder, setDueDateReturnLog)
+      const downloadingResult = RecipientScenariosSeeder.transformToDownloadingResults(scenarios.licenceHolder)
 
-      downloadingResult.notificationDueDate = new Date('2025-04-28')
+      downloadingResult[0].notificationDueDate = new Date('2025-04-28')
 
-      expect(results).to.equal([downloadingResult])
+      expect(results).to.equal(downloadingResult)
     })
   })
 })

--- a/test/services/notices/setup/returns-notice/fetch-returns-invitation-recipients.service.test.js
+++ b/test/services/notices/setup/returns-notice/fetch-returns-invitation-recipients.service.test.js
@@ -52,7 +52,10 @@ describe('Notices - Setup - Returns Notice - Fetch Returns Invitation Recipients
       startDate: new Date('2024-04-01')
     })
 
-    scenarios.licenceHolder = await RecipientScenariosSeeder.licenceHolderOnly([nullDueDateReturnLog, setDueDateReturnLog])
+    scenarios.licenceHolder = await RecipientScenariosSeeder.licenceHolderOnly([
+      nullDueDateReturnLog,
+      setDueDateReturnLog
+    ])
   })
 
   after(async () => {

--- a/test/services/notices/setup/returns-notice/fetch-returns-invitation-recipients.service.test.js
+++ b/test/services/notices/setup/returns-notice/fetch-returns-invitation-recipients.service.test.js
@@ -11,7 +11,7 @@ const { expect } = Code
 const CRMContactsSeeder = require('../../../../support/seeders/crm-contacts.seeder.js')
 const EmptyLicenceSeeder = require('../../../../support/seeders/empty-licence.seeder.js')
 const NoticeSessionFixture = require('../../../../support/fixtures/notice-session.fixture.js')
-const RecipientsSeeder = require('../../../../support/seeders/recipients.seeder.js')
+const RecipientsFormatter = require('../../../../support/seeders/recipients.formatter.js')
 const ReturnLogHelper = require('../../../../support/helpers/return-log.helper.js')
 const { compareStrings, generateUUID } = require('../../../../../app/lib/general.lib.js')
 const { futureDueDate } = require('../../../../../app/presenters/notices/base.presenter.js')
@@ -63,7 +63,7 @@ describe('Notices - Setup - Returns Notice - Fetch Returns Invitation Recipients
 
     licenceHolderSeedData = await CRMContactsSeeder.licenceHolder(licenceSeedData, 'Test Licence Holder')
 
-    licenceHolder = await RecipientsSeeder.licenceHolder(licenceSeedData, licenceHolderSeedData)
+    licenceHolder = await RecipientsFormatter.licenceHolder(licenceSeedData, licenceHolderSeedData)
     licenceHolder.licenceRefs = [licenceRef]
   })
 
@@ -73,7 +73,7 @@ describe('Notices - Setup - Returns Notice - Fetch Returns Invitation Recipients
 
     await licenceSeedData.clean()
     await licenceHolderSeedData.clean()
-    await RecipientsSeeder.clean(licenceHolder)
+    await RecipientsFormatter.clean(licenceHolder)
   })
 
   describe('when the set up journey is "ad-hoc"', () => {
@@ -91,7 +91,7 @@ describe('Notices - Setup - Returns Notice - Fetch Returns Invitation Recipients
 
         // NOTE: We know GenerateReturnLogsByLicenceQueryService when called for a returns invitation will generate a
         // query that will fetch any due return logs
-        const sendingResult = RecipientsSeeder.transformToSendingResult({
+        const sendingResult = RecipientsFormatter.transformToSendingResult({
           ...licenceHolder,
           returnLogIds: [nullDueDateReturnLog.id, setDueDateReturnLog.id].sort((referenceString, compareString) => {
             return compareStrings(referenceString, compareString)
@@ -119,13 +119,13 @@ describe('Notices - Setup - Returns Notice - Fetch Returns Invitation Recipients
       it('fetches the correct recipient data for the download', async () => {
         const results = await FetchReturnsInvitationRecipients.go(session, download)
 
-        const downloadingResult1 = RecipientsSeeder.transformToDownloadingResult(licenceHolder, nullDueDateReturnLog)
+        const downloadingResult1 = RecipientsFormatter.transformToDownloadingResult(licenceHolder, nullDueDateReturnLog)
 
         downloadingResult1.due_date_status = 'some nulls'
         downloadingResult1.latest_due_date = setDueDateReturnLog.dueDate
         downloadingResult1.notificationDueDate = futureDueDate('letter')
 
-        const downloadingResult2 = RecipientsSeeder.transformToDownloadingResult(licenceHolder, setDueDateReturnLog)
+        const downloadingResult2 = RecipientsFormatter.transformToDownloadingResult(licenceHolder, setDueDateReturnLog)
 
         downloadingResult2.due_date_status = 'some nulls'
         downloadingResult2.notificationDueDate = futureDueDate('letter')
@@ -151,7 +151,7 @@ describe('Notices - Setup - Returns Notice - Fetch Returns Invitation Recipients
         // NOTE: We know GenerateReturnLogsByPeriodQueryService when called for a returns invitation will generate a
         // query that will only fetch return logs without due dates. So, we know only the return log with a null due
         // date will feature in the `return_log_ids` property of the result
-        const sendingResult = RecipientsSeeder.transformToSendingResult({
+        const sendingResult = RecipientsFormatter.transformToSendingResult({
           ...licenceHolder,
           returnLogIds: [nullDueDateReturnLog.id]
         })
@@ -177,7 +177,7 @@ describe('Notices - Setup - Returns Notice - Fetch Returns Invitation Recipients
       it('fetches the correct recipient data for the download', async () => {
         const results = await FetchReturnsInvitationRecipients.go(session, download)
 
-        const downloadingResult = RecipientsSeeder.transformToDownloadingResult(licenceHolder, nullDueDateReturnLog)
+        const downloadingResult = RecipientsFormatter.transformToDownloadingResult(licenceHolder, nullDueDateReturnLog)
 
         downloadingResult.notificationDueDate = futureDueDate('letter')
 

--- a/test/services/notices/setup/returns-notice/fetch-returns-invitation-recipients.service.test.js
+++ b/test/services/notices/setup/returns-notice/fetch-returns-invitation-recipients.service.test.js
@@ -8,10 +8,8 @@ const { describe, it, before, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const CRMContactsSeeder = require('../../../../support/seeders/crm-contacts.seeder.js')
-const EmptyLicenceSeeder = require('../../../../support/seeders/empty-licence.seeder.js')
 const NoticeSessionFixture = require('../../../../support/fixtures/notice-session.fixture.js')
-const RecipientsFormatter = require('../../../../support/seeders/recipients.formatter.js')
+const RecipientScenariosSeeder = require('../../../../support/seeders/recipient-scenarios.seeder.js')
 const ReturnLogHelper = require('../../../../support/helpers/return-log.helper.js')
 const { compareStrings, generateUUID } = require('../../../../../app/lib/general.lib.js')
 const { futureDueDate } = require('../../../../../app/presenters/notices/base.presenter.js')
@@ -21,64 +19,51 @@ const FetchReturnsInvitationRecipients = require('../../../../../app/services/no
 
 describe('Notices - Setup - Returns Notice - Fetch Returns Invitation Recipients service', () => {
   let download
-  let licenceHolder
-  let licenceHolderSeedData
-  let licenceRef
-  let licenceSeedData
   let nullDueDateReturnLog
   let session
   let setDueDateReturnLog
+  let scenarios
 
   before(async () => {
-    licenceSeedData = await EmptyLicenceSeeder.seed(licenceRef)
+    scenarios = {}
 
-    licenceRef = licenceSeedData.licence.licenceRef
-
+    // 1) Licence holder only
     // NOTE: GenerateRecipientsQueryService for downloads will order by return ID (it has to because of the distinct
     // clause). So, we generate two IDs, sort them, and then use them when creating the return logs to ensure our
     // expectations match the order of the results.
-    const returnLogIds = [generateUUID(), generateUUID()].sort((referenceString, compareString) => {
-      return compareStrings(referenceString, compareString)
-    })
+    const [nullDueDateReturnLogId, setDueDateReturnLogId] = [generateUUID(), generateUUID()].sort(compareStrings)
 
     // Create a return log with a null `dueDate`.
     nullDueDateReturnLog = await ReturnLogHelper.add({
-      id: returnLogIds[0],
+      id: nullDueDateReturnLogId,
       dueDate: null,
       endDate: new Date('2025-03-01'),
-      licenceRef,
       quarterly: false,
       startDate: new Date('2024-04-01')
     })
 
-    // Create a return log with a populated `dueDate`.
+    // Create a return log with a populated `dueDate` for the same licence.
     setDueDateReturnLog = await ReturnLogHelper.add({
-      id: returnLogIds[1],
+      id: setDueDateReturnLogId,
       dueDate: '2025-04-28',
       endDate: new Date('2025-03-01'),
-      licenceRef,
+      licenceRef: nullDueDateReturnLog.licenceRef,
       quarterly: false,
       startDate: new Date('2024-04-01')
     })
 
-    licenceHolderSeedData = await CRMContactsSeeder.licenceHolder(licenceSeedData, 'Test Licence Holder')
-
-    licenceHolder = await RecipientsFormatter.licenceHolder(licenceSeedData, licenceHolderSeedData)
-    licenceHolder.licenceRefs = [licenceRef]
+    scenarios.licenceHolder = await RecipientScenariosSeeder.licenceHolderOnly([nullDueDateReturnLog, setDueDateReturnLog])
   })
 
   after(async () => {
     await nullDueDateReturnLog.$query().delete()
     await setDueDateReturnLog.$query().delete()
-
-    await licenceSeedData.clean()
-    await licenceHolderSeedData.clean()
-    await RecipientsFormatter.clean(licenceHolder)
+    await RecipientScenariosSeeder.clean(scenarios)
   })
 
   describe('when the set up journey is "ad-hoc"', () => {
     before(() => {
-      session = NoticeSessionFixture.adHocInvitation(licenceRef)
+      session = NoticeSessionFixture.adHocInvitation(scenarios.licenceHolder.licenceHolderRecipient.licenceRefs[0])
     })
 
     describe('and the query is NOT for generating a download', () => {
@@ -91,23 +76,18 @@ describe('Notices - Setup - Returns Notice - Fetch Returns Invitation Recipients
 
         // NOTE: We know GenerateReturnLogsByLicenceQueryService when called for a returns invitation will generate a
         // query that will fetch any due return logs
-        const sendingResult = RecipientsFormatter.transformToSendingResult({
-          ...licenceHolder,
-          returnLogIds: [nullDueDateReturnLog.id, setDueDateReturnLog.id].sort((referenceString, compareString) => {
-            return compareStrings(referenceString, compareString)
-          })
-        })
+        const sendingResults = RecipientScenariosSeeder.transformToSendingResults(scenarios.licenceHolder)
 
         // In our scenario we have a mix of return logs with and without due dates, so the query will return a
         // `due_date_status` of 'some nulls', but the latest due date will be set to that of setDueDateReturnLog
-        sendingResult.due_date_status = 'some nulls'
-        sendingResult.latest_due_date = setDueDateReturnLog.dueDate
+        sendingResults[0].due_date_status = 'some nulls'
+        sendingResults[0].latest_due_date = setDueDateReturnLog.dueDate
 
         // Finally, in the case of returns invitations, the service will set the notificationDueDate for each recipient
         // based on the due date status. If there are any nulls, it will calculate the date (today + 28/29 days).
-        sendingResult.notificationDueDate = futureDueDate('letter')
+        sendingResults[0].notificationDueDate = futureDueDate('letter')
 
-        expect(results).to.equal([sendingResult])
+        expect(results).to.equal(sendingResults)
       })
     })
 
@@ -119,25 +99,23 @@ describe('Notices - Setup - Returns Notice - Fetch Returns Invitation Recipients
       it('fetches the correct recipient data for the download', async () => {
         const results = await FetchReturnsInvitationRecipients.go(session, download)
 
-        const downloadingResult1 = RecipientsFormatter.transformToDownloadingResult(licenceHolder, nullDueDateReturnLog)
+        const downloadingResults = RecipientScenariosSeeder.transformToDownloadingResults(scenarios.licenceHolder)
 
-        downloadingResult1.due_date_status = 'some nulls'
-        downloadingResult1.latest_due_date = setDueDateReturnLog.dueDate
-        downloadingResult1.notificationDueDate = futureDueDate('letter')
+        downloadingResults[0].due_date_status = 'some nulls'
+        downloadingResults[0].latest_due_date = setDueDateReturnLog.dueDate
+        downloadingResults[0].notificationDueDate = futureDueDate('letter')
 
-        const downloadingResult2 = RecipientsFormatter.transformToDownloadingResult(licenceHolder, setDueDateReturnLog)
+        downloadingResults[1].due_date_status = 'some nulls'
+        downloadingResults[1].notificationDueDate = futureDueDate('letter')
 
-        downloadingResult2.due_date_status = 'some nulls'
-        downloadingResult2.notificationDueDate = futureDueDate('letter')
-
-        expect(results).to.equal([downloadingResult1, downloadingResult2])
+        expect(results).to.equal(downloadingResults)
       })
     })
   })
 
   describe('when the set up journey is "standard"', () => {
     before(() => {
-      session = NoticeSessionFixture.standardInvitation(licenceRef)
+      session = NoticeSessionFixture.standardInvitation(scenarios.licenceHolder.licenceHolderRecipient.licenceRefs[0])
     })
 
     describe('and the query is NOT for generating a download', () => {
@@ -151,21 +129,20 @@ describe('Notices - Setup - Returns Notice - Fetch Returns Invitation Recipients
         // NOTE: We know GenerateReturnLogsByPeriodQueryService when called for a returns invitation will generate a
         // query that will only fetch return logs without due dates. So, we know only the return log with a null due
         // date will feature in the `return_log_ids` property of the result
-        const sendingResult = RecipientsFormatter.transformToSendingResult({
-          ...licenceHolder,
-          returnLogIds: [nullDueDateReturnLog.id]
-        })
+        const sendingResults = RecipientScenariosSeeder.transformToSendingResults(scenarios.licenceHolder)
+
+        sendingResults[0].return_log_ids = [nullDueDateReturnLog.id]
 
         // And we know the query will _always_ return a `due_date_status` of 'all nulls', and the latest due date
         // will therefore be null.
-        sendingResult.due_date_status = 'all nulls'
-        sendingResult.latest_due_date = null
+        sendingResults[0].due_date_status = 'all nulls'
+        sendingResults[0].latest_due_date = null
 
         // Because this is a standard notice, only return logs with null due dates will have been selected so it will
         // calculate the date (today + 28/29 days).
-        sendingResult.notificationDueDate = futureDueDate('letter')
+        sendingResults[0].notificationDueDate = futureDueDate('letter')
 
-        expect(results).to.equal([sendingResult])
+        expect(results).to.equal(sendingResults)
       })
     })
 
@@ -177,11 +154,17 @@ describe('Notices - Setup - Returns Notice - Fetch Returns Invitation Recipients
       it('fetches the correct recipient data for the download', async () => {
         const results = await FetchReturnsInvitationRecipients.go(session, download)
 
-        const downloadingResult = RecipientsFormatter.transformToDownloadingResult(licenceHolder, nullDueDateReturnLog)
+        // NOTE: Standard invitations only fetch return logs with null due dates, so only nullDueDateReturnLog features
+        const downloadingResults = RecipientScenariosSeeder.transformToDownloadingResults({
+          licenceHolderRecipient: {
+            ...scenarios.licenceHolder.licenceHolderRecipient,
+            returnLogs: [nullDueDateReturnLog]
+          }
+        })
 
-        downloadingResult.notificationDueDate = futureDueDate('letter')
+        downloadingResults[0].notificationDueDate = futureDueDate('letter')
 
-        expect(results).to.equal([downloadingResult])
+        expect(results).to.equal(downloadingResults)
       })
     })
   })

--- a/test/services/notices/setup/returns-notice/fetch-returns-reminder-recipients.service.test.js
+++ b/test/services/notices/setup/returns-notice/fetch-returns-reminder-recipients.service.test.js
@@ -8,76 +8,53 @@ const { describe, it, before, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const CRMContactsSeeder = require('../../../../support/seeders/crm-contacts.seeder.js')
-const EmptyLicenceSeeder = require('../../../../support/seeders/empty-licence.seeder.js')
 const NoticeSessionFixture = require('../../../../support/fixtures/notice-session.fixture.js')
-const RecipientsFormatter = require('../../../../support/seeders/recipients.formatter.js')
+const RecipientScenariosSeeder = require('../../../../support/seeders/recipient-scenarios.seeder.js')
 const ReturnLogHelper = require('../../../../support/helpers/return-log.helper.js')
-const { compareStrings, generateUUID } = require('../../../../../app/lib/general.lib.js')
 
 // Thing under test
 const FetchReturnsReminderRecipients = require('../../../../../app/services/notices/setup/returns-notice/fetch-returns-reminder-recipients.service.js')
 
 describe('Notices - Setup - Returns Notice - Fetch Returns Reminder Recipients service', () => {
   let download
-  let licenceHolder
-  let licenceHolderSeedData
-  let licenceRef
-  let licenceSeedData
   let nullDueDateReturnLog
   let session
   let setDueDateReturnLog
+  let scenarios
 
   before(async () => {
-    licenceSeedData = await EmptyLicenceSeeder.seed(licenceRef)
+    scenarios = {}
 
-    licenceRef = licenceSeedData.licence.licenceRef
-
-    // NOTE: GenerateRecipientsQueryService for downloads will order by return ID (it has to because of the distinct
-    // clause). So, we generate two IDs, sort them, and then use them when creating the return logs to ensure our
-    // expectations match the order of the results.
-    const returnLogIds = [generateUUID(), generateUUID()].sort((referenceString, compareString) => {
-      return compareStrings(referenceString, compareString)
-    })
-
-    // Create a return log with a null `dueDate`.
-    nullDueDateReturnLog = await ReturnLogHelper.add({
-      dueDate: null,
-      endDate: new Date('2025-03-01'),
-      id: returnLogIds[0],
-      licenceRef,
-      quarterly: false,
-      startDate: new Date('2024-04-01')
-    })
-
+    // 1) Licence holder only
     // Create a return log with a populated `dueDate`.
     setDueDateReturnLog = await ReturnLogHelper.add({
       dueDate: '2025-04-28',
       endDate: new Date('2025-03-01'),
-      id: returnLogIds[1],
-      licenceRef,
       quarterly: false,
       startDate: new Date('2024-04-01')
     })
 
-    licenceHolderSeedData = await CRMContactsSeeder.licenceHolder(licenceSeedData, 'Test Licence Holder')
+    scenarios.licenceHolder = await RecipientScenariosSeeder.licenceHolderOnly([setDueDateReturnLog])
 
-    licenceHolder = await RecipientsFormatter.licenceHolder(licenceSeedData, licenceHolderSeedData)
-    licenceHolder.licenceRefs = [licenceRef]
+    // NOTE: Create a null due date return log for the same licence to verify the reminder query filters these out
+    nullDueDateReturnLog = await ReturnLogHelper.add({
+      dueDate: null,
+      endDate: new Date('2025-03-01'),
+      licenceRef: setDueDateReturnLog.licenceRef,
+      quarterly: false,
+      startDate: new Date('2024-04-01')
+    })
   })
 
   after(async () => {
     await nullDueDateReturnLog.$query().delete()
     await setDueDateReturnLog.$query().delete()
-
-    await licenceSeedData.clean()
-    await licenceHolderSeedData.clean()
-    await RecipientsFormatter.clean(licenceHolder)
+    await RecipientScenariosSeeder.clean(scenarios)
   })
 
   describe('when the set up journey is "ad-hoc"', () => {
     before(() => {
-      session = NoticeSessionFixture.adHocReminder(licenceRef)
+      session = NoticeSessionFixture.adHocReminder(scenarios.licenceHolder.licenceHolderRecipient.licenceRefs[0])
     })
 
     describe('and the query is NOT for generating a download', () => {
@@ -91,21 +68,18 @@ describe('Notices - Setup - Returns Notice - Fetch Returns Reminder Recipients s
         // NOTE: We know GenerateReturnLogsByLicenceQueryService when called for a returns reminder will generate a
         // query that will only fetch return logs with due dates. So, we know only the return log with the due date will
         // feature in the `return_log_ids` property of the result
-        const sendingResult = RecipientsFormatter.transformToSendingResult({
-          ...licenceHolder,
-          returnLogIds: [setDueDateReturnLog.id]
-        })
+        const sendingResults = RecipientScenariosSeeder.transformToSendingResults(scenarios.licenceHolder)
 
         // And we know the query will _always_ return a `due_date_status` of 'all populated', and the latest due date
         // to that of our return log.
-        sendingResult.due_date_status = 'all populated'
-        sendingResult.latest_due_date = setDueDateReturnLog.dueDate
+        sendingResults[0].due_date_status = 'all populated'
+        sendingResults[0].latest_due_date = setDueDateReturnLog.dueDate
 
         // Finally, in the case of returns reminders, the service will set the notificationDueDate for each recipient
         // to be the latest due date.
-        sendingResult.notificationDueDate = setDueDateReturnLog.dueDate
+        sendingResults[0].notificationDueDate = setDueDateReturnLog.dueDate
 
-        expect(results).to.equal([sendingResult])
+        expect(results).to.equal(sendingResults)
       })
     })
 
@@ -117,18 +91,18 @@ describe('Notices - Setup - Returns Notice - Fetch Returns Reminder Recipients s
       it('fetches the correct recipient data for the download', async () => {
         const results = await FetchReturnsReminderRecipients.go(session, download)
 
-        const downloadingResult = RecipientsFormatter.transformToDownloadingResult(licenceHolder, setDueDateReturnLog)
+        const downloadingResults = RecipientScenariosSeeder.transformToDownloadingResults(scenarios.licenceHolder)
 
-        downloadingResult.notificationDueDate = setDueDateReturnLog.dueDate
+        downloadingResults[0].notificationDueDate = setDueDateReturnLog.dueDate
 
-        expect(results).to.equal([downloadingResult])
+        expect(results).to.equal(downloadingResults)
       })
     })
   })
 
   describe('when the set up journey is "standard"', () => {
     before(() => {
-      session = NoticeSessionFixture.standardReminder(licenceRef)
+      session = NoticeSessionFixture.standardReminder(scenarios.licenceHolder.licenceHolderRecipient.licenceRefs[0])
     })
 
     describe('and the query is NOT for generating a download', () => {
@@ -142,21 +116,18 @@ describe('Notices - Setup - Returns Notice - Fetch Returns Reminder Recipients s
         // NOTE: We know GenerateReturnLogsByPeriodQueryService when called for a returns reminder will generate a
         // query that will only fetch return logs with due dates. So, we know only the return log with the due date will
         // feature in the `return_log_ids` property of the result
-        const sendingResult = RecipientsFormatter.transformToSendingResult({
-          ...licenceHolder,
-          returnLogIds: [setDueDateReturnLog.id]
-        })
+        const sendingResults = RecipientScenariosSeeder.transformToSendingResults(scenarios.licenceHolder)
 
         // And we know the query will _always_ return a `due_date_status` of 'all populated', and the latest due date
         // to that of our return log.
-        sendingResult.due_date_status = 'all populated'
-        sendingResult.latest_due_date = setDueDateReturnLog.dueDate
+        sendingResults[0].due_date_status = 'all populated'
+        sendingResults[0].latest_due_date = setDueDateReturnLog.dueDate
 
         // Finally, in the case of returns reminders, the service will set the notificationDueDate for each recipient
         // to be the latest due date.
-        sendingResult.notificationDueDate = setDueDateReturnLog.dueDate
+        sendingResults[0].notificationDueDate = setDueDateReturnLog.dueDate
 
-        expect(results).to.equal([sendingResult])
+        expect(results).to.equal(sendingResults)
       })
     })
 
@@ -168,11 +139,11 @@ describe('Notices - Setup - Returns Notice - Fetch Returns Reminder Recipients s
       it('fetches the correct recipient data for the download', async () => {
         const results = await FetchReturnsReminderRecipients.go(session, download)
 
-        const downloadingResult = RecipientsFormatter.transformToDownloadingResult(licenceHolder, setDueDateReturnLog)
+        const downloadingResults = RecipientScenariosSeeder.transformToDownloadingResults(scenarios.licenceHolder)
 
-        downloadingResult.notificationDueDate = setDueDateReturnLog.dueDate
+        downloadingResults[0].notificationDueDate = setDueDateReturnLog.dueDate
 
-        expect(results).to.equal([downloadingResult])
+        expect(results).to.equal(downloadingResults)
       })
     })
   })

--- a/test/services/notices/setup/returns-notice/fetch-returns-reminder-recipients.service.test.js
+++ b/test/services/notices/setup/returns-notice/fetch-returns-reminder-recipients.service.test.js
@@ -11,7 +11,7 @@ const { expect } = Code
 const CRMContactsSeeder = require('../../../../support/seeders/crm-contacts.seeder.js')
 const EmptyLicenceSeeder = require('../../../../support/seeders/empty-licence.seeder.js')
 const NoticeSessionFixture = require('../../../../support/fixtures/notice-session.fixture.js')
-const RecipientsSeeder = require('../../../../support/seeders/recipients.seeder.js')
+const RecipientsFormatter = require('../../../../support/seeders/recipients.formatter.js')
 const ReturnLogHelper = require('../../../../support/helpers/return-log.helper.js')
 const { compareStrings, generateUUID } = require('../../../../../app/lib/general.lib.js')
 
@@ -62,7 +62,7 @@ describe('Notices - Setup - Returns Notice - Fetch Returns Reminder Recipients s
 
     licenceHolderSeedData = await CRMContactsSeeder.licenceHolder(licenceSeedData, 'Test Licence Holder')
 
-    licenceHolder = await RecipientsSeeder.licenceHolder(licenceSeedData, licenceHolderSeedData)
+    licenceHolder = await RecipientsFormatter.licenceHolder(licenceSeedData, licenceHolderSeedData)
     licenceHolder.licenceRefs = [licenceRef]
   })
 
@@ -72,7 +72,7 @@ describe('Notices - Setup - Returns Notice - Fetch Returns Reminder Recipients s
 
     await licenceSeedData.clean()
     await licenceHolderSeedData.clean()
-    await RecipientsSeeder.clean(licenceHolder)
+    await RecipientsFormatter.clean(licenceHolder)
   })
 
   describe('when the set up journey is "ad-hoc"', () => {
@@ -91,7 +91,7 @@ describe('Notices - Setup - Returns Notice - Fetch Returns Reminder Recipients s
         // NOTE: We know GenerateReturnLogsByLicenceQueryService when called for a returns reminder will generate a
         // query that will only fetch return logs with due dates. So, we know only the return log with the due date will
         // feature in the `return_log_ids` property of the result
-        const sendingResult = RecipientsSeeder.transformToSendingResult({
+        const sendingResult = RecipientsFormatter.transformToSendingResult({
           ...licenceHolder,
           returnLogIds: [setDueDateReturnLog.id]
         })
@@ -117,7 +117,7 @@ describe('Notices - Setup - Returns Notice - Fetch Returns Reminder Recipients s
       it('fetches the correct recipient data for the download', async () => {
         const results = await FetchReturnsReminderRecipients.go(session, download)
 
-        const downloadingResult = RecipientsSeeder.transformToDownloadingResult(licenceHolder, setDueDateReturnLog)
+        const downloadingResult = RecipientsFormatter.transformToDownloadingResult(licenceHolder, setDueDateReturnLog)
 
         downloadingResult.notificationDueDate = setDueDateReturnLog.dueDate
 
@@ -142,7 +142,7 @@ describe('Notices - Setup - Returns Notice - Fetch Returns Reminder Recipients s
         // NOTE: We know GenerateReturnLogsByPeriodQueryService when called for a returns reminder will generate a
         // query that will only fetch return logs with due dates. So, we know only the return log with the due date will
         // feature in the `return_log_ids` property of the result
-        const sendingResult = RecipientsSeeder.transformToSendingResult({
+        const sendingResult = RecipientsFormatter.transformToSendingResult({
           ...licenceHolder,
           returnLogIds: [setDueDateReturnLog.id]
         })
@@ -168,7 +168,7 @@ describe('Notices - Setup - Returns Notice - Fetch Returns Reminder Recipients s
       it('fetches the correct recipient data for the download', async () => {
         const results = await FetchReturnsReminderRecipients.go(session, download)
 
-        const downloadingResult = RecipientsSeeder.transformToDownloadingResult(licenceHolder, setDueDateReturnLog)
+        const downloadingResult = RecipientsFormatter.transformToDownloadingResult(licenceHolder, setDueDateReturnLog)
 
         downloadingResult.notificationDueDate = setDueDateReturnLog.dueDate
 

--- a/test/services/notices/setup/returns-notice/generate-recipients-query.service.test.js
+++ b/test/services/notices/setup/returns-notice/generate-recipients-query.service.test.js
@@ -575,17 +575,17 @@ describe('Notices - Setup - Returns Notice - Generate Recipients Query service',
             scenarios.primaryUserWithMultipleLicences
           )
 
-          expect(rows).to.contain(sendingResults[2])
+          expect(rows).to.contain(sendingResults[1])
 
-          // sendingResults[2] and [3] reference the two primary users, with the same details. This means the
+          // sendingResults[1] and [3] reference the two primary users, with the same details. This means the
           // sendingResults for each are the same, which we prove here.
-          expect(sendingResults[2]).to.equal(sendingResults[3])
+          expect(sendingResults[1]).to.equal(sendingResults[3])
 
           // NOTE: Because we created two return logs with different licence refs, we have to create two licence
           // document headers with the same 'licence holder' to recreate linking the same primary user across multiple
-          // licences. This means sendingResults[0] references the first licence holder, and [1] the second.
+          // licences. This means sendingResults[0] references the first licence holder, and [2] the second.
           expect(rows).not.to.contain(sendingResults[0])
-          expect(rows).not.to.contain(sendingResults[1])
+          expect(rows).not.to.contain(sendingResults[2])
         })
 
         it('(Scenario 8) returns only the primary user when it and the returns user are the same for a registered licence', async () => {
@@ -719,22 +719,22 @@ describe('Notices - Setup - Returns Notice - Generate Recipients Query service',
 
           // Unlike sending, because we want the return log information it means though the recipient details are the
           // same, the return logs are not. So, we get a row per return log for the primary user.
-          expect(rows).to.contain(downloadingResults[4])
-          expect(rows).to.contain(downloadingResults[5])
+          expect(rows).to.contain(downloadingResults[2])
+          expect(rows).to.contain(downloadingResults[3])
 
-          // downloadingResults[4] & [5], and [6] & [7] reference the two primary users, with the same details. This
+          // downloadingResults[2] & [3], and [6] & [7] reference the two primary users, with the same details. This
           // means the downloadingResults for each are the same, which we prove here.
-          expect(downloadingResults[4]).to.equal(downloadingResults[6])
-          expect(downloadingResults[5]).to.equal(downloadingResults[7])
+          expect(downloadingResults[2]).to.equal(downloadingResults[6])
+          expect(downloadingResults[3]).to.equal(downloadingResults[7])
 
           // NOTE: Because we created two return logs with different licence refs, we have to create two licence
           // document headers with the same 'licence holder' to recreate linking the same primary user across multiple
-          // licences. This means downloadingResults[0] and [1] reference the first licence holder, and [2] and [3] the
+          // licences. This means downloadingResults[0] and [1] reference the first licence holder, and [4] and [5] the
           // second.
           expect(rows).not.to.contain(downloadingResults[0])
           expect(rows).not.to.contain(downloadingResults[1])
-          expect(rows).not.to.contain(downloadingResults[2])
-          expect(rows).not.to.contain(downloadingResults[3])
+          expect(rows).not.to.contain(downloadingResults[4])
+          expect(rows).not.to.contain(downloadingResults[5])
         })
 
         it('(Scenario 8) returns only the primary user when it and the returns user are the same for a registered licence', async () => {
@@ -865,14 +865,14 @@ describe('Notices - Setup - Returns Notice - Generate Recipients Query service',
 
           // NOTE: Because we created two return logs with different licence refs, we have to create two licence
           // document headers with the same 'licence holder' to recreate linking the same primary user across multiple
-          // licences. This means sendingResults[0] references the first licence holder, and [1] the second. For paper
+          // licences. This means sendingResults[0] references the first licence holder, and [2] the second. For paper
           // returns it's one of these we expect to see in the results. Either will do as they are both the same.
           expect(rows).to.contain(sendingResults[0])
-          expect(sendingResults[0]).to.equal(sendingResults[1])
+          expect(sendingResults[0]).to.equal(sendingResults[2])
 
-          // sendingResults[2] and [3] reference the two primary users, with the same details. We don't send paper
+          // sendingResults[1] and [3] reference the two primary users, with the same details. We don't send paper
           // returns via email so they should not be included
-          expect(rows).not.to.contain(sendingResults[2])
+          expect(rows).not.to.contain(sendingResults[1])
           expect(rows).not.to.contain(sendingResults[3])
         })
 
@@ -1009,17 +1009,17 @@ describe('Notices - Setup - Returns Notice - Generate Recipients Query service',
 
           // Because we created two return logs with different licence refs, we have to create two licence
           // document headers with the same 'licence holder' to recreate linking the same primary user across multiple
-          // licences. This means downloadingResults[0] and [1] reference the first licence holder, and [2] and [3] the
+          // licences. This means downloadingResults[0] and [1] reference the first licence holder, and [4] and [5] the
           // second.
           // However, as the licence holder details are the same, the downloadingResults will be the same, though the
           // query will just return one set
-          expect(downloadingResults[0]).to.equal(downloadingResults[2])
-          expect(downloadingResults[1]).to.equal(downloadingResults[3])
+          expect(downloadingResults[0]).to.equal(downloadingResults[4])
+          expect(downloadingResults[1]).to.equal(downloadingResults[5])
 
-          // downloadingResults[4] & [5], and [6] & [7] reference the two primary users, with the same details. We don't
+          // downloadingResults[2] & [3], and [6] & [7] reference the two primary users, with the same details. We don't
           // send paper returns via email so they should not be included
-          expect(rows).not.to.contain(downloadingResults[4])
-          expect(rows).not.to.contain(downloadingResults[5])
+          expect(rows).not.to.contain(downloadingResults[2])
+          expect(rows).not.to.contain(downloadingResults[3])
           expect(rows).not.to.contain(downloadingResults[6])
           expect(rows).not.to.contain(downloadingResults[7])
         })
@@ -1149,14 +1149,14 @@ describe('Notices - Setup - Returns Notice - Generate Recipients Query service',
 
         // NOTE: Because we created two return logs with different licence refs, we have to create two licence
         // document headers with the same 'licence holder' to recreate linking the same primary user across multiple
-        // licences. This means sendingResults[0] references the first licence holder, and [1] the second. For paper
+        // licences. This means sendingResults[0] references the first licence holder, and [2] the second. For paper
         // returns it's one of these we expect to see in the results. Either will do as they are both the same.
         expect(rows).to.contain(sendingResults[0])
-        expect(sendingResults[0]).to.equal(sendingResults[1])
+        expect(sendingResults[0]).to.equal(sendingResults[2])
 
-        // sendingResults[2] and [3] reference the two primary users, with the same details. We don't send paper
+        // sendingResults[1] and [3] reference the two primary users, with the same details. We don't send paper
         // returns via email so they should not be included
-        expect(rows).not.to.contain(sendingResults[2])
+        expect(rows).not.to.contain(sendingResults[1])
         expect(rows).not.to.contain(sendingResults[3])
       })
 

--- a/test/support/seeders/crm-contacts.seeder.js
+++ b/test/support/seeders/crm-contacts.seeder.js
@@ -210,7 +210,6 @@ async function returnsTo(licenceSeedData, licenceHolderSeedData, name) {
       await company.$query().delete()
       await licenceDocumentRole.$query().delete()
       await licenceHolderSeedData.clean()
-      await licenceRole.$query().delete()
     }
   }
 }

--- a/test/support/seeders/recipient-scenarios.seeder.js
+++ b/test/support/seeders/recipient-scenarios.seeder.js
@@ -36,11 +36,11 @@ async function clean(scenarios) {
  * It then creates a licence document header record using the first licence ref and populates it with a licence holder
  * contact. The aggregated data is assigned to the recipient object to make testing easier.
  *
- * @param {object[]} returnLogs - One or more returns logs sharing the same licence reference tha will be assigned to
+ * @param {object[]} [returnLogs] - One or more returns logs sharing the same licence reference tha will be assigned to
  * the recipient
  * @param {Date} [expiredDate] - The date the licence should expire
  *
- * @returns {Promise<object[]>} The recipients generated for the scenario. In this case there is only the licence holder
+ * @returns {Promise<object>} The recipients generated for the scenario. In this case there is only the licence holder
  */
 async function licenceHolderOnly(returnLogs = [], expiredDate = null) {
   const { licenceRefs, returnLogIds } = _aggregatedData(returnLogs)
@@ -71,7 +71,7 @@ async function licenceHolderOnly(returnLogs = [], expiredDate = null) {
  * @param {object[]} returnLogs - One or more returns logs sharing the same licence reference that will be assigned to
  * the recipients
  *
- * @returns {Promise<object[]>} The recipients generated for the scenario. In this case both the licence holder and
+ * @returns {Promise<object>} The recipients generated for the scenario. In this case both the licence holder and
  * returns to recipients
  */
 async function licenceHolderWithDifferentReturnsTo(returnLogs) {
@@ -92,7 +92,7 @@ async function licenceHolderWithDifferentReturnsTo(returnLogs) {
   returnsToRecipient.returnLogIds = returnLogIds
   returnsToRecipient.returnLogs = returnLogs
 
-  return [licenceHolderRecipient, returnsToRecipient]
+  return { licenceHolderRecipient, returnsToRecipient }
 }
 
 /**
@@ -114,7 +114,7 @@ async function licenceHolderWithDifferentReturnsTo(returnLogs) {
  * the recipients
  * @param {Date} [expiredDate] - The date the licence should expire.
  *
- * @returns {Promise<object[]>} The recipients generated for the scenario. In this case both licence holder recipients
+ * @returns {Promise<object>} The recipients generated for the scenario. In this case both licence holder recipients
  */
 async function licenceHolderWithMultipleLicences(returnLogs, expiredDate) {
   const { licenceRefs, returnLogIds } = _aggregatedData(returnLogs)
@@ -146,7 +146,7 @@ async function licenceHolderWithMultipleLicences(returnLogs, expiredDate) {
   secondLicenceHolderRecipient.returnLogIds = returnLogIds
   secondLicenceHolderRecipient.returnLogs = returnLogs
 
-  return [licenceHolderRecipient, secondLicenceHolderRecipient]
+  return { licenceHolderRecipient, secondLicenceHolderRecipient }
 }
 
 /**
@@ -163,7 +163,7 @@ async function licenceHolderWithMultipleLicences(returnLogs, expiredDate) {
  * @param {object[]} returnLogs - One or more returns logs sharing the same licence reference that will be assigned to
  * the recipient
  *
- * @returns {Promise<object[]>} The recipients generated for the scenario. In this case both the licence holder and
+ * @returns {Promise<object>} The recipients generated for the scenario. In this case both the licence holder and
  * returns to recipients, though the query should only fetch the licence holder
  */
 async function licenceHolderWithSameReturnsTo(returnLogs) {
@@ -184,7 +184,7 @@ async function licenceHolderWithSameReturnsTo(returnLogs) {
   returnsToRecipient.returnLogIds = returnLogIds
   returnsToRecipient.returnLogs = returnLogs
 
-  return [licenceHolderRecipient, returnsToRecipient]
+  return { licenceHolderRecipient, returnsToRecipient }
 }
 
 /**
@@ -204,11 +204,11 @@ async function licenceHolderWithSameReturnsTo(returnLogs) {
  *
  * The aggregated data is assigned to the recipient object to make testing easier.
  *
- * @param {object[]} returnLogs - One or more returns logs sharing the same licence reference that will be assigned to
+ * @param {object[]} [returnLogs] - One or more returns logs sharing the same licence reference that will be assigned to
  * the recipient
  * @param {Date} [expiredDate] - The date the licence should expire.
  *
- * @returns {object} The recipients generated for the scenario. This includes the licence holder and
+ * @returns {Promise<object>} The recipients generated for the scenario. This includes the licence holder and
  * primary user
  */
 async function primaryUserOnly(returnLogs = [], expiredDate = null) {
@@ -255,7 +255,7 @@ async function primaryUserOnly(returnLogs = [], expiredDate = null) {
  * @param {object[]} returnLogs - One or more returns logs sharing the same licence reference that will be assigned to
  * the recipients
  *
- * @returns {Promise<object[]>} The recipients generated for the scenario. In this case both the primary user and
+ * @returns {Promise<object>} The recipients generated for the scenario. In this case both the primary user and
  * returns user recipients, plus the licence holder
  */
 async function primaryUserWithDifferentReturnsAgent(returnLogs) {
@@ -283,7 +283,7 @@ async function primaryUserWithDifferentReturnsAgent(returnLogs) {
   returnsUserRecipient.returnLogIds = returnLogIds
   returnsUserRecipient.returnLogs = returnLogs
 
-  return [licenceHolderRecipient, primaryUserRecipient, returnsUserRecipient]
+  return { licenceHolderRecipient, primaryUserRecipient, returnsUserRecipient }
 }
 
 /**
@@ -308,7 +308,7 @@ async function primaryUserWithDifferentReturnsAgent(returnLogs) {
  * the recipients
  * @param {Date} [expiredDate] - The date the licence should expire.
  *
- * @returns {Promise<object[]>} The recipients generated for the scenario. In this case both primary user recipients
+ * @returns {Promise<object>} The recipients generated for the scenario. In this case both primary user recipients
  * and both licence holders
  */
 async function primaryUserWithMultipleLicences(returnLogs, expiredDate) {
@@ -351,7 +351,7 @@ async function primaryUserWithMultipleLicences(returnLogs, expiredDate) {
   primaryUserRecipient.licenceRefs = allLicenceRefs
   secondPrimaryUserRecipient.licenceRefs = allLicenceRefs
 
-  return [licenceHolderRecipient, secondLicenceHolderRecipient, primaryUserRecipient, secondPrimaryUserRecipient]
+  return { licenceHolderRecipient, primaryUserRecipient, secondLicenceHolderRecipient, secondPrimaryUserRecipient }
 }
 
 /**
@@ -377,7 +377,7 @@ async function primaryUserWithMultipleLicences(returnLogs, expiredDate) {
  * @param {object[]} returnLogs - One or more returns logs sharing the same licence reference that will be assigned to
  * the recipient
  *
- * @returns {Promise<object[]>} The recipients generated for the scenario. In this case both the primary user and
+ * @returns {Promise<object>} The recipients generated for the scenario. In this case both the primary user and
  * returns user recipients, though the query should only fetch the primary user
  */
 async function primaryUserWithSameReturnsAgent(returnLogs) {
@@ -405,7 +405,7 @@ async function primaryUserWithSameReturnsAgent(returnLogs) {
   returnsUserRecipient.returnLogIds = returnLogIds
   returnsUserRecipient.returnLogs = returnLogs
 
-  return [licenceHolderRecipient, primaryUserRecipient, returnsUserRecipient]
+  return { licenceHolderRecipient, primaryUserRecipient, returnsUserRecipient }
 }
 
 /**
@@ -414,14 +414,12 @@ async function primaryUserWithSameReturnsAgent(returnLogs) {
  * Use when you need to verify the result of executing the `GenerateRecipientsQueryService` with the `download` flag
  * set to false.
  *
- * @param {object[]|object} scenarios - The scenarios created by a test suite to be transformed
+ * @param {object} scenarios - The scenarios created by a test suite to be transformed
  *
- * @returns {object[]} The transformed downloading result objects
+ * @returns {object[]} The transformed sending result objects
  */
 function transformToSendingResults(scenarios) {
-  const recipients = Array.isArray(scenarios) ? scenarios : Object.values(scenarios)
-
-  return recipients.map((recipient) => {
+  return Object.values(scenarios).map((recipient) => {
     return RecipientsSeeder.transformToSendingResult(recipient)
   })
 }
@@ -432,15 +430,14 @@ function transformToSendingResults(scenarios) {
  * Use when you need to verify the result of executing the `GenerateRecipientsQueryService` with the `download` flag
  * set to true.
  *
- * @param {object[]|object} scenarios - The scenarios created by a test suite to be transformed
+ * @param {object} scenarios - The scenarios created by a test suite to be transformed
  *
  * @returns {object[]} The transformed downloading result objects
  */
 function transformToDownloadingResults(scenarios) {
-  const recipients = Array.isArray(scenarios) ? scenarios : Object.values(scenarios)
   const downloadResults = []
 
-  for (const recipient of recipients) {
+  for (const recipient of Object.values(scenarios)) {
     for (const returnLog of recipient.returnLogs) {
       const downloadResult = RecipientsSeeder.transformToDownloadingResult(recipient, returnLog)
 

--- a/test/support/seeders/recipient-scenarios.seeder.js
+++ b/test/support/seeders/recipient-scenarios.seeder.js
@@ -42,7 +42,7 @@ async function clean(scenarios) {
  *
  * @returns {Promise<object[]>} The recipients generated for the scenario. In this case there is only the licence holder
  */
-async function licenceHolderOnly(returnLogs, expiredDate = null) {
+async function licenceHolderOnly(returnLogs = [], expiredDate = null) {
   const { licenceRefs, returnLogIds } = _aggregatedData(returnLogs)
 
   const licence = await EmptyLicence.seed(licenceRefs[0], null, expiredDate)
@@ -50,13 +50,12 @@ async function licenceHolderOnly(returnLogs, expiredDate = null) {
 
   const licenceHolderRecipient = await RecipientsSeeder.licenceHolder(licence, licenceHolder)
 
-  const allLicenceRefs = expiredDate ? [licence.licence.licenceRef] : licenceRefs
-
-  licenceHolderRecipient.licenceRefs = allLicenceRefs
   licenceHolderRecipient.returnLogIds = returnLogIds
   licenceHolderRecipient.returnLogs = returnLogs
 
-  return [licenceHolderRecipient]
+  return {
+    licenceHolderRecipient
+  }
 }
 
 /**
@@ -83,7 +82,6 @@ async function licenceHolderWithDifferentReturnsTo(returnLogs) {
 
   const licenceHolderRecipient = await RecipientsSeeder.licenceHolder(licence, licenceHolder)
 
-  licenceHolderRecipient.licenceRefs = licenceRefs
   licenceHolderRecipient.returnLogIds = returnLogIds
   licenceHolderRecipient.returnLogs = returnLogs
 
@@ -91,7 +89,6 @@ async function licenceHolderWithDifferentReturnsTo(returnLogs) {
 
   const returnsToRecipient = await RecipientsSeeder.returnsTo(licence, returnsToHolder)
 
-  returnsToRecipient.licenceRefs = licenceRefs
   returnsToRecipient.returnLogIds = returnLogIds
   returnsToRecipient.returnLogs = returnLogs
 
@@ -177,7 +174,6 @@ async function licenceHolderWithSameReturnsTo(returnLogs) {
 
   const licenceHolderRecipient = await RecipientsSeeder.licenceHolder(licence, licenceHolder)
 
-  licenceHolderRecipient.licenceRefs = licenceRefs
   licenceHolderRecipient.returnLogIds = returnLogIds
   licenceHolderRecipient.returnLogs = returnLogs
 
@@ -185,7 +181,6 @@ async function licenceHolderWithSameReturnsTo(returnLogs) {
 
   const returnsToRecipient = await RecipientsSeeder.returnsTo(licence, returnsToHolder)
 
-  returnsToRecipient.licenceRefs = licenceRefs
   returnsToRecipient.returnLogIds = returnLogIds
   returnsToRecipient.returnLogs = returnLogs
 
@@ -213,10 +208,10 @@ async function licenceHolderWithSameReturnsTo(returnLogs) {
  * the recipient
  * @param {Date} [expiredDate] - The date the licence should expire.
  *
- * @returns {Promise<object[]>} The recipients generated for the scenario. This includes the licence holder and
+ * @returns {object} The recipients generated for the scenario. This includes the licence holder and
  * primary user
  */
-async function primaryUserOnly(returnLogs, expiredDate = null) {
+async function primaryUserOnly(returnLogs = [], expiredDate = null) {
   const { licenceRefs, returnLogIds } = _aggregatedData(returnLogs)
 
   const licence = await EmptyLicence.seed(licenceRefs[0], null, expiredDate)
@@ -224,7 +219,6 @@ async function primaryUserOnly(returnLogs, expiredDate = null) {
 
   const licenceHolderRecipient = await RecipientsSeeder.licenceHolder(licence, licenceHolder)
 
-  licenceHolderRecipient.licenceRefs = expiredDate ? [licence.licence.licenceRef] : licenceRefs
   licenceHolderRecipient.returnLogIds = returnLogIds
   licenceHolderRecipient.returnLogs = returnLogs
 
@@ -232,11 +226,10 @@ async function primaryUserOnly(returnLogs, expiredDate = null) {
 
   const primaryUserRecipient = await RecipientsSeeder.primaryUser(licence, primaryUser)
 
-  primaryUserRecipient.licenceRefs = expiredDate ? [licence.licence.licenceRef] : licenceRefs
   primaryUserRecipient.returnLogIds = returnLogIds
   primaryUserRecipient.returnLogs = returnLogs
 
-  return [licenceHolderRecipient, primaryUserRecipient]
+  return { licenceHolderRecipient, primaryUserRecipient }
 }
 
 /**
@@ -273,7 +266,6 @@ async function primaryUserWithDifferentReturnsAgent(returnLogs) {
 
   const licenceHolderRecipient = await RecipientsSeeder.licenceHolder(licence, licenceHolder)
 
-  licenceHolderRecipient.licenceRefs = licenceRefs
   licenceHolderRecipient.returnLogIds = returnLogIds
   licenceHolderRecipient.returnLogs = returnLogs
 
@@ -281,7 +273,6 @@ async function primaryUserWithDifferentReturnsAgent(returnLogs) {
 
   const primaryUserRecipient = await RecipientsSeeder.primaryUser(licence, primaryUser)
 
-  primaryUserRecipient.licenceRefs = licenceRefs
   primaryUserRecipient.returnLogIds = returnLogIds
   primaryUserRecipient.returnLogs = returnLogs
 
@@ -289,7 +280,6 @@ async function primaryUserWithDifferentReturnsAgent(returnLogs) {
 
   const returnsUserRecipient = await RecipientsSeeder.returnsUser(licence, returnsUser)
 
-  returnsUserRecipient.licenceRefs = licenceRefs
   returnsUserRecipient.returnLogIds = returnLogIds
   returnsUserRecipient.returnLogs = returnLogs
 
@@ -398,7 +388,6 @@ async function primaryUserWithSameReturnsAgent(returnLogs) {
 
   const licenceHolderRecipient = await RecipientsSeeder.licenceHolder(licence, licenceHolder)
 
-  licenceHolderRecipient.licenceRefs = licenceRefs
   licenceHolderRecipient.returnLogIds = returnLogIds
   licenceHolderRecipient.returnLogs = returnLogs
 
@@ -406,7 +395,6 @@ async function primaryUserWithSameReturnsAgent(returnLogs) {
 
   const primaryUserRecipient = await RecipientsSeeder.primaryUser(licence, primaryUser)
 
-  primaryUserRecipient.licenceRefs = licenceRefs
   primaryUserRecipient.returnLogIds = returnLogIds
   primaryUserRecipient.returnLogs = returnLogs
 
@@ -414,7 +402,6 @@ async function primaryUserWithSameReturnsAgent(returnLogs) {
 
   const returnsUserRecipient = await RecipientsSeeder.returnsUser(licence, returnsUser)
 
-  returnsUserRecipient.licenceRefs = licenceRefs
   returnsUserRecipient.returnLogIds = returnLogIds
   returnsUserRecipient.returnLogs = returnLogs
 
@@ -427,12 +414,14 @@ async function primaryUserWithSameReturnsAgent(returnLogs) {
  * Use when you need to verify the result of executing the `GenerateRecipientsQueryService` with the `download` flag
  * set to false.
  *
- * @param {object[]} scenarios - The scenarios created by a test suite to be transformed
+ * @param {object[]|object} scenarios - The scenarios created by a test suite to be transformed
  *
  * @returns {object[]} The transformed downloading result objects
  */
 function transformToSendingResults(scenarios) {
-  return scenarios.map((recipient) => {
+  const recipients = Array.isArray(scenarios) ? scenarios : Object.values(scenarios)
+
+  return recipients.map((recipient) => {
     return RecipientsSeeder.transformToSendingResult(recipient)
   })
 }
@@ -443,14 +432,15 @@ function transformToSendingResults(scenarios) {
  * Use when you need to verify the result of executing the `GenerateRecipientsQueryService` with the `download` flag
  * set to true.
  *
- * @param {object[]} scenarios - The scenarios created by a test suite to be transformed
+ * @param {object[]|object} scenarios - The scenarios created by a test suite to be transformed
  *
  * @returns {object[]} The transformed downloading result objects
  */
 function transformToDownloadingResults(scenarios) {
+  const recipients = Array.isArray(scenarios) ? scenarios : Object.values(scenarios)
   const downloadResults = []
 
-  for (const recipient of scenarios) {
+  for (const recipient of recipients) {
     for (const returnLog of recipient.returnLogs) {
       const downloadResult = RecipientsSeeder.transformToDownloadingResult(recipient, returnLog)
 

--- a/test/support/seeders/recipient-scenarios.seeder.js
+++ b/test/support/seeders/recipient-scenarios.seeder.js
@@ -6,7 +6,7 @@
 
 const CRMContactsSeeder = require('./crm-contacts.seeder.js')
 const EmptyLicence = require('./empty-licence.seeder.js')
-const RecipientsSeeder = require('./recipients.seeder.js')
+const RecipientsFormatter = require('./recipients.formatter.js')
 const LicenceVersionHelper = require('../helpers/licence-version.helper.js')
 const { compareStrings } = require('../../../app/lib/general.lib.js')
 
@@ -21,7 +21,7 @@ const { compareStrings } = require('../../../app/lib/general.lib.js')
 async function clean(scenarios) {
   for (const recipients of Object.values(scenarios)) {
     for (const recipient of Object.values(recipients)) {
-      await RecipientsSeeder.clean(recipient)
+      await RecipientsFormatter.clean(recipient)
     }
   }
 }
@@ -48,7 +48,7 @@ async function licenceHolderOnly(returnLogs = [], expiredDate = null) {
   const licence = await EmptyLicence.seed(licenceRefs[0], null, expiredDate)
   const licenceHolder = await CRMContactsSeeder.licenceHolder(licence, 'Licenceonlyholder')
 
-  const licenceHolderRecipient = await RecipientsSeeder.licenceHolder(licence, licenceHolder)
+  const licenceHolderRecipient = await RecipientsFormatter.licenceHolder(licence, licenceHolder)
 
   licenceHolderRecipient.returnLogIds = returnLogIds
   licenceHolderRecipient.returnLogs = returnLogs
@@ -80,14 +80,14 @@ async function licenceHolderWithDifferentReturnsTo(returnLogs) {
   const licence = await EmptyLicence.seed(licenceRefs[0])
   const licenceHolder = await CRMContactsSeeder.licenceHolder(licence, 'Holderandreturnsto')
 
-  const licenceHolderRecipient = await RecipientsSeeder.licenceHolder(licence, licenceHolder)
+  const licenceHolderRecipient = await RecipientsFormatter.licenceHolder(licence, licenceHolder)
 
   licenceHolderRecipient.returnLogIds = returnLogIds
   licenceHolderRecipient.returnLogs = returnLogs
 
   const returnsToHolder = await CRMContactsSeeder.returnsTo(licence, licenceHolder, 'Returnstoandholder')
 
-  const returnsToRecipient = await RecipientsSeeder.returnsTo(licence, returnsToHolder)
+  const returnsToRecipient = await RecipientsFormatter.returnsTo(licence, returnsToHolder)
 
   returnsToRecipient.returnLogIds = returnLogIds
   returnsToRecipient.returnLogs = returnLogs
@@ -122,7 +122,7 @@ async function licenceHolderWithMultipleLicences(returnLogs, expiredDate) {
   const licence = await EmptyLicence.seed(licenceRefs[0], null, expiredDate)
   const licenceHolder = await CRMContactsSeeder.licenceHolder(licence, 'Multiplelicenceholder')
 
-  const licenceHolderRecipient = await RecipientsSeeder.licenceHolder(licence, licenceHolder)
+  const licenceHolderRecipient = await RecipientsFormatter.licenceHolder(licence, licenceHolder)
 
   licenceHolderRecipient.returnLogIds = returnLogIds
   licenceHolderRecipient.returnLogs = returnLogs
@@ -137,7 +137,7 @@ async function licenceHolderWithMultipleLicences(returnLogs, expiredDate) {
     licenceId: secondLicence.licence.id
   })
 
-  const secondLicenceHolderRecipient = await RecipientsSeeder.licenceHolder(secondLicence, licenceHolder)
+  const secondLicenceHolderRecipient = await RecipientsFormatter.licenceHolder(secondLicence, licenceHolder)
 
   const allLicenceRefs = expiredDate ? [licence.licence.licenceRef, secondLicence.licence.licenceRef] : licenceRefs
 
@@ -172,14 +172,14 @@ async function licenceHolderWithSameReturnsTo(returnLogs) {
   const licence = await EmptyLicence.seed(licenceRefs[0])
   const licenceHolder = await CRMContactsSeeder.licenceHolder(licence, 'Samelicenceholderreturnsto')
 
-  const licenceHolderRecipient = await RecipientsSeeder.licenceHolder(licence, licenceHolder)
+  const licenceHolderRecipient = await RecipientsFormatter.licenceHolder(licence, licenceHolder)
 
   licenceHolderRecipient.returnLogIds = returnLogIds
   licenceHolderRecipient.returnLogs = returnLogs
 
   const returnsToHolder = await CRMContactsSeeder.returnsTo(licence, licenceHolder)
 
-  const returnsToRecipient = await RecipientsSeeder.returnsTo(licence, returnsToHolder)
+  const returnsToRecipient = await RecipientsFormatter.returnsTo(licence, returnsToHolder)
 
   returnsToRecipient.returnLogIds = returnLogIds
   returnsToRecipient.returnLogs = returnLogs
@@ -217,14 +217,14 @@ async function primaryUserOnly(returnLogs = [], expiredDate = null) {
   const licence = await EmptyLicence.seed(licenceRefs[0], null, expiredDate)
   const licenceHolder = await CRMContactsSeeder.licenceHolder(licence, 'Primaryonlyholder')
 
-  const licenceHolderRecipient = await RecipientsSeeder.licenceHolder(licence, licenceHolder)
+  const licenceHolderRecipient = await RecipientsFormatter.licenceHolder(licence, licenceHolder)
 
   licenceHolderRecipient.returnLogIds = returnLogIds
   licenceHolderRecipient.returnLogs = returnLogs
 
   const primaryUser = await CRMContactsSeeder.primaryUser(licence, 'primaryuseronly@puonly.com')
 
-  const primaryUserRecipient = await RecipientsSeeder.primaryUser(licence, primaryUser)
+  const primaryUserRecipient = await RecipientsFormatter.primaryUser(licence, primaryUser)
 
   primaryUserRecipient.returnLogIds = returnLogIds
   primaryUserRecipient.returnLogs = returnLogs
@@ -264,21 +264,21 @@ async function primaryUserWithDifferentReturnsAgent(returnLogs) {
   const licence = await EmptyLicence.seed(licenceRefs[0])
   const licenceHolder = await CRMContactsSeeder.licenceHolder(licence, 'Primaryandreturnsuser')
 
-  const licenceHolderRecipient = await RecipientsSeeder.licenceHolder(licence, licenceHolder)
+  const licenceHolderRecipient = await RecipientsFormatter.licenceHolder(licence, licenceHolder)
 
   licenceHolderRecipient.returnLogIds = returnLogIds
   licenceHolderRecipient.returnLogs = returnLogs
 
   const primaryUser = await CRMContactsSeeder.primaryUser(licence, 'primaryuser@pura.com')
 
-  const primaryUserRecipient = await RecipientsSeeder.primaryUser(licence, primaryUser)
+  const primaryUserRecipient = await RecipientsFormatter.primaryUser(licence, primaryUser)
 
   primaryUserRecipient.returnLogIds = returnLogIds
   primaryUserRecipient.returnLogs = returnLogs
 
   const returnsUser = await CRMContactsSeeder.returnsUser(licence, 'returnsuser@pura.com')
 
-  const returnsUserRecipient = await RecipientsSeeder.returnsUser(licence, returnsUser)
+  const returnsUserRecipient = await RecipientsFormatter.returnsUser(licence, returnsUser)
 
   returnsUserRecipient.returnLogIds = returnLogIds
   returnsUserRecipient.returnLogs = returnLogs
@@ -317,14 +317,14 @@ async function primaryUserWithMultipleLicences(returnLogs, expiredDate) {
   const licence = await EmptyLicence.seed(licenceRefs[0], null, expiredDate)
   const licenceHolder = await CRMContactsSeeder.licenceHolder(licence, 'Multipleprimary')
 
-  const licenceHolderRecipient = await RecipientsSeeder.licenceHolder(licence, licenceHolder)
+  const licenceHolderRecipient = await RecipientsFormatter.licenceHolder(licence, licenceHolder)
 
   licenceHolderRecipient.returnLogIds = returnLogIds
   licenceHolderRecipient.returnLogs = returnLogs
 
   const primaryUser = await CRMContactsSeeder.primaryUser(licence, 'primaryuser@pumulti.com')
 
-  const primaryUserRecipient = await RecipientsSeeder.primaryUser(licence, primaryUser)
+  const primaryUserRecipient = await RecipientsFormatter.primaryUser(licence, primaryUser)
 
   primaryUserRecipient.returnLogIds = returnLogIds
   primaryUserRecipient.returnLogs = returnLogs
@@ -332,14 +332,14 @@ async function primaryUserWithMultipleLicences(returnLogs, expiredDate) {
   const secondLicence = await EmptyLicence.seed(licenceRefs[1], null, expiredDate)
   const secondLicenceHolder = await CRMContactsSeeder.licenceHolder(secondLicence, 'Multipleprimary')
 
-  const secondLicenceHolderRecipient = await RecipientsSeeder.licenceHolder(secondLicence, secondLicenceHolder)
+  const secondLicenceHolderRecipient = await RecipientsFormatter.licenceHolder(secondLicence, secondLicenceHolder)
 
   secondLicenceHolderRecipient.returnLogIds = returnLogIds
   secondLicenceHolderRecipient.returnLogs = returnLogs
 
   const secondPrimaryUser = await CRMContactsSeeder.primaryUser(secondLicence, 'primaryuser@pumulti.com')
 
-  const secondPrimaryUserRecipient = await RecipientsSeeder.primaryUser(secondLicence, secondPrimaryUser)
+  const secondPrimaryUserRecipient = await RecipientsFormatter.primaryUser(secondLicence, secondPrimaryUser)
 
   secondPrimaryUserRecipient.returnLogIds = returnLogIds
   secondPrimaryUserRecipient.returnLogs = returnLogs
@@ -386,21 +386,21 @@ async function primaryUserWithSameReturnsAgent(returnLogs) {
   const licence = await EmptyLicence.seed(licenceRefs[0])
   const licenceHolder = await CRMContactsSeeder.licenceHolder(licence, 'Sameprimaryuserreturnsuser')
 
-  const licenceHolderRecipient = await RecipientsSeeder.licenceHolder(licence, licenceHolder)
+  const licenceHolderRecipient = await RecipientsFormatter.licenceHolder(licence, licenceHolder)
 
   licenceHolderRecipient.returnLogIds = returnLogIds
   licenceHolderRecipient.returnLogs = returnLogs
 
   const primaryUser = await CRMContactsSeeder.primaryUser(licence, 'same@pura.com')
 
-  const primaryUserRecipient = await RecipientsSeeder.primaryUser(licence, primaryUser)
+  const primaryUserRecipient = await RecipientsFormatter.primaryUser(licence, primaryUser)
 
   primaryUserRecipient.returnLogIds = returnLogIds
   primaryUserRecipient.returnLogs = returnLogs
 
   const returnsUser = await CRMContactsSeeder.returnsUser(licence, 'same@pura.com')
 
-  const returnsUserRecipient = await RecipientsSeeder.returnsUser(licence, returnsUser)
+  const returnsUserRecipient = await RecipientsFormatter.returnsUser(licence, returnsUser)
 
   returnsUserRecipient.returnLogIds = returnLogIds
   returnsUserRecipient.returnLogs = returnLogs
@@ -420,7 +420,7 @@ async function primaryUserWithSameReturnsAgent(returnLogs) {
  */
 function transformToSendingResults(scenarios) {
   return Object.values(scenarios).map((recipient) => {
-    return RecipientsSeeder.transformToSendingResult(recipient)
+    return RecipientsFormatter.transformToSendingResult(recipient)
   })
 }
 
@@ -439,7 +439,7 @@ function transformToDownloadingResults(scenarios) {
 
   for (const recipient of Object.values(scenarios)) {
     for (const returnLog of recipient.returnLogs) {
-      const downloadResult = RecipientsSeeder.transformToDownloadingResult(recipient, returnLog)
+      const downloadResult = RecipientsFormatter.transformToDownloadingResult(recipient, returnLog)
 
       downloadResults.push(downloadResult)
     }

--- a/test/support/seeders/recipients.formatter.js
+++ b/test/support/seeders/recipients.formatter.js
@@ -1,7 +1,7 @@
 'use strict'
 
 /**
- * @module NoticeRecipientsSeeder
+ * @module RecipientsFormatter
  */
 
 const crypto = require('node:crypto')
@@ -157,6 +157,7 @@ async function returnsUser(licenceSeedData, returnsUserSeedData) {
     licenceRefs: [licenceSeedData.licence.licenceRef],
     messageType: 'Email',
     clean: async () => {
+      await licenceSeedData.clean()
       await returnsUserSeedData.clean()
     }
   }
@@ -193,7 +194,11 @@ async function returnsTo(licenceSeedData, returnsToHolderSeedData) {
     contactType: 'returns to',
     email: null,
     licenceRefs: [licenceSeedData.licence.licenceRef],
-    messageType: 'Letter'
+    messageType: 'Letter',
+    clean: async () => {
+      await licenceSeedData.clean()
+      await returnsToHolderSeedData.clean()
+    }
   }
 }
 

--- a/test/support/seeders/recipients.seeder.js
+++ b/test/support/seeders/recipients.seeder.js
@@ -27,7 +27,7 @@ async function additionalContact(licenceSeedData, additionalContact) {
     contactHashId: _emailHashId(email),
     contactType: 'additional contact',
     email,
-    licenceRef: licenceSeedData.licence.licenceRef,
+    licenceRefs: [licenceSeedData.licence.licenceRef],
     messageType: 'Email',
     clean: async () => {
       await additionalContact.clean()
@@ -90,7 +90,7 @@ async function licenceHolder(licenceSeedData, licenceHolderSeedData) {
     contactHashId: _contactHashId(contact),
     contactType: 'licence holder',
     email: null,
-    licenceRef: licenceSeedData.licence.licenceRef,
+    licenceRefs: [licenceSeedData.licence.licenceRef],
     messageType: 'Letter',
     clean: async () => {
       await licenceSeedData.clean()
@@ -119,7 +119,7 @@ async function primaryUser(licenceSeedData, primaryUserSeedData) {
     contactHashId: _emailHashId(email),
     contactType: 'primary user',
     email,
-    licenceRef: licenceSeedData.licence.licenceRef,
+    licenceRefs: [licenceSeedData.licence.licenceRef],
     messageType: 'Email',
     clean: async () => {
       await licenceSeedData.clean()
@@ -154,7 +154,7 @@ async function returnsUser(licenceSeedData, returnsUserSeedData) {
     contactHashId: _emailHashId(email),
     contactType: 'returns user',
     email,
-    licenceRef: licenceSeedData.licence.licenceRef,
+    licenceRefs: [licenceSeedData.licence.licenceRef],
     messageType: 'Email',
     clean: async () => {
       await returnsUserSeedData.clean()
@@ -192,7 +192,7 @@ async function returnsTo(licenceSeedData, returnsToHolderSeedData) {
     contactHashId: _contactHashId(contact),
     contactType: 'returns to',
     email: null,
-    licenceRef: licenceSeedData.licence.licenceRef,
+    licenceRefs: [licenceSeedData.licence.licenceRef],
     messageType: 'Letter'
   }
 }


### PR DESCRIPTION
The initial recipient seeder was returning 'licenceRef' and not 'licencRefs', after some recent refactoring we can support the use of licenceRefs (this is actually how the query will respond).

This change updates the recipient scenario seeder to support and use 'licenceRefs' directly from the recipients (no need for this `licenceHolderRecipient.licenceRefs = licenceRefs` logic any more).