### PR TITLE
Add renewal invitations to the adhoc notice journey

### DIFF
--- a/app/presenters/notices/setup/check-notice-type.presenter.js
+++ b/app/presenters/notices/setup/check-notice-type.presenter.js
@@ -9,6 +9,13 @@ const { NoticeType, NoticeTypes } = require('../../../lib/static-lookups.lib.js'
 const { formatLongDate } = require('../../base.presenter.js')
 const { returnsPeriodText } = require('../base.presenter.js')
 
+const NOTICE_TYPE_TEXT = {
+  [NoticeType.INVITATIONS]: NoticeTypes[NoticeType.INVITATIONS].notificationType,
+  [NoticeType.PAPER_RETURN]: 'Paper return',
+  [NoticeType.REMINDERS]: NoticeTypes[NoticeType.REMINDERS].notificationType,
+  [NoticeType.RENEWAL_INVITATIONS]: NoticeTypes[NoticeType.RENEWAL_INVITATIONS].notificationType
+}
+
 /**
  * Formats data for the `/notices/setup/{sessionId}/check-notice-type` page
  *
@@ -51,13 +58,6 @@ function _links(sessionId) {
 }
 
 function _noticeType(noticeType) {
-  const NOTICE_TYPE_TEXT = {
-    [NoticeType.INVITATIONS]: NoticeTypes[NoticeType.INVITATIONS].notificationType,
-    [NoticeType.PAPER_RETURN]: 'Paper return',
-    [NoticeType.REMINDERS]: NoticeTypes[NoticeType.REMINDERS].notificationType,
-    [NoticeType.RENEWAL_INVITATIONS]: NoticeTypes[NoticeType.RENEWAL_INVITATIONS].notificationType
-  }
-
   return NOTICE_TYPE_TEXT[noticeType]
 }
 

--- a/app/presenters/notices/setup/check-notice-type.presenter.js
+++ b/app/presenters/notices/setup/check-notice-type.presenter.js
@@ -5,15 +5,9 @@
  * @module CheckNoticeTypePresenter
  */
 
-const { NoticeType } = require('../../../lib/static-lookups.lib.js')
+const { NoticeType, NoticeTypes } = require('../../../lib/static-lookups.lib.js')
 const { formatLongDate } = require('../../base.presenter.js')
 const { returnsPeriodText } = require('../base.presenter.js')
-
-const NOTICE_TYPE_TEXT = {
-  [NoticeType.INVITATIONS]: 'Returns invitation',
-  [NoticeType.REMINDERS]: 'Returns reminder',
-  [NoticeType.PAPER_RETURN]: 'Paper return'
-}
 
 /**
  * Formats data for the `/notices/setup/{sessionId}/check-notice-type` page
@@ -35,7 +29,7 @@ function go(session) {
   return {
     links: _links(sessionId),
     pageTitle: 'Check the notice type',
-    returnNoticeType: NOTICE_TYPE_TEXT[noticeType],
+    noticeType: _noticeType(noticeType),
     sessionId,
     ..._returns(selectedReturns, dueReturns, noticeType),
     ..._licence(licenceRef),
@@ -54,6 +48,17 @@ function _links(sessionId) {
     noticeType: `/system/notices/setup/${sessionId}/notice-type`,
     returns: `/system/notices/setup/${sessionId}/paper-return`
   }
+}
+
+function _noticeType(noticeType) {
+  const NOTICE_TYPE_TEXT = {
+    [NoticeType.INVITATIONS]: NoticeTypes[NoticeType.INVITATIONS].notificationType,
+    [NoticeType.PAPER_RETURN]: 'Paper return',
+    [NoticeType.REMINDERS]: NoticeTypes[NoticeType.REMINDERS].notificationType,
+    [NoticeType.RENEWAL_INVITATIONS]: NoticeTypes[NoticeType.RENEWAL_INVITATIONS].notificationType
+  }
+
+  return NOTICE_TYPE_TEXT[noticeType]
 }
 
 function _returns(selectedReturns, dueReturns, noticeType) {

--- a/app/presenters/notices/setup/notice-type.presenter.js
+++ b/app/presenters/notices/setup/notice-type.presenter.js
@@ -71,19 +71,19 @@ function _options(noticeType, journey, auth) {
   }
 
   if (journey === NoticeJourney.ADHOC) {
-    options = [
-      ...options,
-      {
-        checked: noticeType === NoticeType.PAPER_RETURN,
-        value: NoticeType.PAPER_RETURN,
-        text: 'Paper return'
-      },
-      {
+    options.push({
+      checked: noticeType === NoticeType.PAPER_RETURN,
+      value: NoticeType.PAPER_RETURN,
+      text: 'Paper return'
+    })
+
+    if (scope.includes('renewal_notifications')) {
+      options.push({
         checked: noticeType === NoticeType.RENEWAL_INVITATIONS,
         value: NoticeType.RENEWAL_INVITATIONS,
         text: NoticeTypes[NoticeType.RENEWAL_INVITATIONS].notificationType
-      }
-    ]
+      })
+    }
   }
 
   return options

--- a/app/presenters/notices/setup/notice-type.presenter.js
+++ b/app/presenters/notices/setup/notice-type.presenter.js
@@ -5,7 +5,7 @@
  * @module NoticeTypePresenter
  */
 
-const { NoticeType, NoticeJourney } = require('../../../lib/static-lookups.lib.js')
+const { NoticeType, NoticeJourney, NoticeTypes } = require('../../../lib/static-lookups.lib.js')
 
 /**
  * Formats data for the `/notices/setup/{sessionId}/notice-type` page
@@ -60,12 +60,12 @@ function _options(noticeType, journey, auth) {
       {
         checked: noticeType === NoticeType.INVITATIONS,
         value: NoticeType.INVITATIONS,
-        text: 'Returns invitation'
+        text: NoticeTypes[NoticeType.INVITATIONS].notificationType
       },
       {
         checked: noticeType === NoticeType.REMINDERS,
         value: NoticeType.REMINDERS,
-        text: 'Returns reminder'
+        text: NoticeTypes[NoticeType.REMINDERS].notificationType
       }
     ]
   }
@@ -77,6 +77,11 @@ function _options(noticeType, journey, auth) {
         checked: noticeType === NoticeType.PAPER_RETURN,
         value: NoticeType.PAPER_RETURN,
         text: 'Paper return'
+      },
+      {
+        checked: noticeType === NoticeType.RENEWAL_INVITATIONS,
+        value: NoticeType.RENEWAL_INVITATIONS,
+        text: NoticeTypes[NoticeType.RENEWAL_INVITATIONS].notificationType
       }
     ]
   }

--- a/app/views/notices/setup/check-notice-type.njk
+++ b/app/views/notices/setup/check-notice-type.njk
@@ -27,10 +27,10 @@
       } if licenceRef,
       {
         key: {
-          text: 'Returns notice type'
+          text: 'Notice type'
         },
         value: {
-          html: '<span data-test="returns-notice-type">' + returnNoticeType + '</span>'
+          html: '<span data-test="notice-type">' + noticeType + '</span>'
         },
         actions: {
           items: [

--- a/test/presenters/notices/setup/check-notice-type.presenter.test.js
+++ b/test/presenters/notices/setup/check-notice-type.presenter.test.js
@@ -16,14 +16,12 @@ const CheckNoticeTypePresenter = require('../../../../app/presenters/notices/set
 
 describe('Notices - Setup - Check Notice Type presenter', () => {
   let licenceRef
-  let noticeType
   let session
 
   beforeEach(() => {
     licenceRef = generateLicenceRef()
-    noticeType = 'invitations'
 
-    session = { id: generateUUID(), noticeType }
+    session = { id: generateUUID(), noticeType: 'invitations' }
   })
 
   describe('when called', () => {
@@ -31,72 +29,45 @@ describe('Notices - Setup - Check Notice Type presenter', () => {
       const result = CheckNoticeTypePresenter.go(session)
 
       expect(result).to.equal({
-        links: {
-          licenceNumber: `/system/notices/setup/${session.id}/licence`,
-          noticeType: `/system/notices/setup/${session.id}/notice-type`,
-          returns: `/system/notices/setup/${session.id}/paper-return`,
-          returnsPeriod: `/system/notices/setup/${session.id}/returns-period`
-        },
-        pageTitle: 'Check the notice type',
-        returnNoticeType: 'Returns invitation',
-        sessionId: session.id
+        ..._expectedPageData(session),
+        noticeType: 'Returns invitation'
       })
     })
 
-    describe('and the notice type is "invitations"', () => {
+    describe('and "licenceRef" is set', () => {
       beforeEach(() => {
-        session.noticeType = 'invitations'
+        session.licenceRef = licenceRef
       })
 
-      describe('and it is for the "adhoc" journey', () => {
-        beforeEach(() => {
-          session.licenceRef = licenceRef
-        })
+      it('returns page data including "licenceRef"', () => {
+        const result = CheckNoticeTypePresenter.go(session)
 
-        it('returns page data', () => {
-          const result = CheckNoticeTypePresenter.go(session)
-
-          expect(result).to.equal({
-            licenceRef,
-            links: {
-              licenceNumber: `/system/notices/setup/${session.id}/licence`,
-              noticeType: `/system/notices/setup/${session.id}/notice-type`,
-              returns: `/system/notices/setup/${session.id}/paper-return`,
-              returnsPeriod: `/system/notices/setup/${session.id}/returns-period`
-            },
-            pageTitle: 'Check the notice type',
-            returnNoticeType: 'Returns invitation',
-            sessionId: session.id
-          })
+        expect(result).to.equal({
+          ..._expectedPageData(session),
+          licenceRef,
+          noticeType: 'Returns invitation'
         })
       })
+    })
 
-      describe('and it is for the "standard" journey', () => {
-        beforeEach(() => {
-          session.determinedReturnsPeriod = {
-            name: 'summer',
-            summer: 'true',
-            dueDate: '2025-11-28T00:00:00.000Z',
-            endDate: '2025-10-31T00:00:00.000Z',
-            startDate: '2024-11-01T00:00:00.000Z'
-          }
-        })
+    describe('and "determinedReturnsPeriod" is set', () => {
+      beforeEach(() => {
+        session.determinedReturnsPeriod = {
+          name: 'summer',
+          summer: 'true',
+          dueDate: '2025-11-28T00:00:00.000Z',
+          endDate: '2025-10-31T00:00:00.000Z',
+          startDate: '2024-11-01T00:00:00.000Z'
+        }
+      })
 
-        it('returns page data', () => {
-          const result = CheckNoticeTypePresenter.go(session)
+      it('returns page data including "returnsPeriodText"', () => {
+        const result = CheckNoticeTypePresenter.go(session)
 
-          expect(result).to.equal({
-            links: {
-              licenceNumber: `/system/notices/setup/${session.id}/licence`,
-              noticeType: `/system/notices/setup/${session.id}/notice-type`,
-              returns: `/system/notices/setup/${session.id}/paper-return`,
-              returnsPeriod: `/system/notices/setup/${session.id}/returns-period`
-            },
-            pageTitle: 'Check the notice type',
-            returnNoticeType: 'Returns invitation',
-            returnsPeriodText: 'Summer annual 1 November 2024 to 31 October 2025',
-            sessionId: session.id
-          })
+        expect(result).to.equal({
+          ..._expectedPageData(session),
+          noticeType: 'Returns invitation',
+          returnsPeriodText: 'Summer annual 1 November 2024 to 31 October 2025'
         })
       })
     })
@@ -106,124 +77,96 @@ describe('Notices - Setup - Check Notice Type presenter', () => {
         session.noticeType = 'reminders'
       })
 
-      describe('and it is for the "adhoc" journey', () => {
-        beforeEach(() => {
-          session.licenceRef = licenceRef
-        })
+      it('returns page data', () => {
+        const result = CheckNoticeTypePresenter.go(session)
 
-        it('returns page data', () => {
-          const result = CheckNoticeTypePresenter.go(session)
-
-          expect(result).to.equal({
-            licenceRef,
-            links: {
-              licenceNumber: `/system/notices/setup/${session.id}/licence`,
-              noticeType: `/system/notices/setup/${session.id}/notice-type`,
-              returns: `/system/notices/setup/${session.id}/paper-return`,
-              returnsPeriod: `/system/notices/setup/${session.id}/returns-period`
-            },
-            pageTitle: 'Check the notice type',
-            returnNoticeType: 'Returns reminder',
-            sessionId: session.id
-          })
-        })
-      })
-
-      describe('and it is for the "standard" journey', () => {
-        beforeEach(() => {
-          session.determinedReturnsPeriod = {
-            name: 'summer',
-            summer: 'true',
-            dueDate: '2025-11-28T00:00:00.000Z',
-            endDate: '2025-10-31T00:00:00.000Z',
-            startDate: '2024-11-01T00:00:00.000Z'
-          }
-        })
-
-        it('returns page data', () => {
-          const result = CheckNoticeTypePresenter.go(session)
-
-          expect(result).to.equal({
-            links: {
-              licenceNumber: `/system/notices/setup/${session.id}/licence`,
-              noticeType: `/system/notices/setup/${session.id}/notice-type`,
-              returns: `/system/notices/setup/${session.id}/paper-return`,
-              returnsPeriod: `/system/notices/setup/${session.id}/returns-period`
-            },
-            pageTitle: 'Check the notice type',
-            returnNoticeType: 'Returns reminder',
-            returnsPeriodText: 'Summer annual 1 November 2024 to 31 October 2025',
-            sessionId: session.id
-          })
+        expect(result).to.equal({
+          ..._expectedPageData(session),
+          noticeType: 'Returns reminder'
         })
       })
     })
 
     describe('and the notice type is "paperReturn"', () => {
+      let dueReturnOne
+      let dueReturnTwo
+
       beforeEach(() => {
+        dueReturnOne = {
+          description: 'Potable Water Supply - Direct',
+          endDate: '2003-03-31',
+          returnLogId: generateUUID(),
+          returnReference: '3135',
+          startDate: '2002-04-01'
+        }
+
+        dueReturnTwo = {
+          description: 'Potable Water Supply - Direct',
+          endDate: '2004-03-31',
+          returnLogId: generateUUID(),
+          returnReference: '3135',
+          startDate: '2003-04-01'
+        }
+
+        session.dueReturns = [dueReturnOne, dueReturnTwo]
         session.licenceRef = licenceRef
         session.noticeType = 'paperReturn'
+        session.selectedReturns = [dueReturnOne.returnLogId]
       })
 
-      describe('and it is for the "adhoc" journey', () => {
-        let dueReturnOne
-        let dueReturnTwo
+      it('returns the page data', () => {
+        const result = CheckNoticeTypePresenter.go(session)
 
+        expect(result).to.equal({
+          ..._expectedPageData(session),
+          licenceRef,
+          noticeType: 'Paper return',
+          returns: ['3135 - 1 April 2002 to 31 March 2003']
+        })
+      })
+
+      describe('and there are more than one "selectedReturns"', () => {
         beforeEach(() => {
-          dueReturnOne = {
-            description: 'Potable Water Supply - Direct',
-            endDate: '2003-03-31',
-            returnLogId: generateUUID(),
-            returnReference: '3135',
-            startDate: '2002-04-01'
-          }
-
-          dueReturnTwo = {
-            description: 'Potable Water Supply - Direct',
-            endDate: '2004-03-31',
-            returnLogId: generateUUID(),
-            returnReference: '3135',
-            startDate: '2003-04-01'
-          }
-
-          session.dueReturns = [dueReturnOne, dueReturnTwo]
-
-          session.selectedReturns = [dueReturnOne.returnLogId]
+          session.selectedReturns = [dueReturnOne.returnLogId, dueReturnTwo.returnLogId]
         })
 
-        it('returns the page data', () => {
+        it('returns an array of "selectedDueReturns"', () => {
           const result = CheckNoticeTypePresenter.go(session)
 
-          expect(result).to.equal({
-            licenceRef,
-            links: {
-              licenceNumber: `/system/notices/setup/${session.id}/licence`,
-              noticeType: `/system/notices/setup/${session.id}/notice-type`,
-              returns: `/system/notices/setup/${session.id}/paper-return`,
-              returnsPeriod: `/system/notices/setup/${session.id}/returns-period`
-            },
-            pageTitle: 'Check the notice type',
-            returnNoticeType: 'Paper return',
-            returns: ['3135 - 1 April 2002 to 31 March 2003'],
-            sessionId: session.id
-          })
+          expect(result.returns).to.equal([
+            '3135 - 1 April 2002 to 31 March 2003',
+            '3135 - 1 April 2003 to 31 March 2004'
+          ])
         })
+      })
+    })
 
-        describe('and there are more than one "selectedReturns"', () => {
-          beforeEach(() => {
-            session.selectedReturns = [dueReturnOne.returnLogId, dueReturnTwo.returnLogId]
-          })
+    describe('and the notice type is "renewalInvitations"', () => {
+      beforeEach(() => {
+        session.noticeType = 'renewalInvitations'
+      })
 
-          it('returns an array of "selectedDueReturns"', () => {
-            const result = CheckNoticeTypePresenter.go(session)
+      it('returns page data', () => {
+        const result = CheckNoticeTypePresenter.go(session)
 
-            expect(result.returns).to.equal([
-              '3135 - 1 April 2002 to 31 March 2003',
-              '3135 - 1 April 2003 to 31 March 2004'
-            ])
-          })
+        expect(result).to.equal({
+          ..._expectedPageData(session),
+          noticeType: 'Renewals invitation'
         })
       })
     })
   })
 })
+
+function _expectedPageData(session) {
+  return {
+    links: {
+      licenceNumber: `/system/notices/setup/${session.id}/licence`,
+      noticeType: `/system/notices/setup/${session.id}/notice-type`,
+      returns: `/system/notices/setup/${session.id}/paper-return`,
+      returnsPeriod: `/system/notices/setup/${session.id}/returns-period`
+    },
+    pageTitle: 'Check the notice type',
+    sessionId: session.id
+  }
+}

--- a/test/presenters/notices/setup/notice-type.presenter.test.js
+++ b/test/presenters/notices/setup/notice-type.presenter.test.js
@@ -19,7 +19,7 @@ describe('Notice - Setup - Notice Type Presenter', () => {
 
   beforeEach(() => {
     auth = {
-      credentials: { scope: ['bulk_return_notifications'] }
+      credentials: { scope: ['bulk_return_notifications', 'renewal_notifications'] }
     }
 
     session = { id: generateUUID(), journey: 'adhoc' }
@@ -288,66 +288,110 @@ describe('Notice - Setup - Notice Type Presenter', () => {
             })
           })
 
-          describe('and the user has the "bulk_return_notifications" scope', () => {
-            beforeEach(() => {
-              auth.credentials.scope = ['bulk_return_notifications']
-            })
+          describe('and scope includes', () => {
+            describe('"bulk_return_notifications"', () => {
+              describe('and the user has the "bulk_return_notifications" scope', () => {
+                beforeEach(() => {
+                  auth.credentials.scope = ['bulk_return_notifications']
+                })
 
-            it('returns page data for the view', () => {
-              const result = NoticeTypePresenter.go(session, auth)
+                it('returns page data for the view', () => {
+                  const result = NoticeTypePresenter.go(session, auth)
 
-              expect(result).to.equal({
-                backLink: {
-                  href: '/system/notices',
-                  text: 'Back'
-                },
-                options: [
-                  {
-                    checked: false,
-                    text: 'Returns invitation',
-                    value: 'invitations'
-                  },
-                  {
-                    checked: false,
-                    text: 'Returns reminder',
-                    value: 'reminders'
-                  },
-                  {
-                    checked: false,
-                    text: 'Paper return',
-                    value: 'paperReturn'
-                  },
-                  {
-                    checked: false,
-                    text: 'Renewals invitation',
-                    value: 'renewalInvitations'
-                  }
-                ],
-                pageTitle: 'Select the notice type'
+                  expect(result).to.equal({
+                    backLink: {
+                      href: '/system/notices',
+                      text: 'Back'
+                    },
+                    options: [
+                      {
+                        checked: false,
+                        text: 'Returns invitation',
+                        value: 'invitations'
+                      },
+                      {
+                        checked: false,
+                        text: 'Returns reminder',
+                        value: 'reminders'
+                      },
+                      {
+                        checked: false,
+                        text: 'Paper return',
+                        value: 'paperReturn'
+                      }
+                    ],
+                    pageTitle: 'Select the notice type'
+                  })
+                })
+              })
+
+              describe('and the user does not have the "bulk_return_notifications" scope', () => {
+                beforeEach(() => {
+                  auth.credentials.scope = ['returns']
+                })
+
+                it('returns the appropriate notice option', () => {
+                  const result = NoticeTypePresenter.go(session, auth)
+
+                  expect(result.options).to.equal([
+                    {
+                      checked: false,
+                      text: 'Paper return',
+                      value: 'paperReturn'
+                    }
+                  ])
+                })
               })
             })
-          })
 
-          describe('and the user does not have the "bulk_return_notifications" scope', () => {
-            beforeEach(() => {
-              auth.credentials.scope = ['returns']
-            })
+            describe('"renewal_notifications"', () => {
+              describe('and the user has the "renewal_notifications" scope', () => {
+                beforeEach(() => {
+                  auth.credentials.scope = ['renewal_notifications']
+                })
 
-            it('returns the appropriate notice option', () => {
-              const result = NoticeTypePresenter.go(session, auth)
+                it('returns page data for the view', () => {
+                  const result = NoticeTypePresenter.go(session, auth)
 
-              expect(result.options).to.equal([
-                {
-                  checked: false,
-                  text: 'Paper return',
-                  value: 'paperReturn'
-                },
-                {
-                  checked: false,
-                  text: 'Renewals invitation',
-                  value: 'renewalInvitations'
-                }
-              ])
+                  expect(result).to.equal({
+                    backLink: {
+                      href: '/system/notices',
+                      text: 'Back'
+                    },
+                    options: [
+                      {
+                        checked: false,
+                        text: 'Paper return',
+                        value: 'paperReturn'
+                      },
+                      {
+                        checked: false,
+                        text: 'Renewals invitation',
+                        value: 'renewalInvitations'
+                      }
+                    ],
+                    pageTitle: 'Select the notice type'
+                  })
+                })
+              })
+
+              describe('and the user does not have the "renewal_notifications" scope', () => {
+                beforeEach(() => {
+                  auth.credentials.scope = ['returns']
+                })
+
+                it('returns the appropriate notice option', () => {
+                  const result = NoticeTypePresenter.go(session, auth)
+
+                  expect(result.options).to.equal([
+                    {
+                      checked: false,
+                      text: 'Paper return',
+                      value: 'paperReturn'
+                    }
+                  ])
+                })
+              })
             })
           })
         })

--- a/test/presenters/notices/setup/notice-type.presenter.test.js
+++ b/test/presenters/notices/setup/notice-type.presenter.test.js
@@ -49,6 +49,11 @@ describe('Notice - Setup - Notice Type Presenter', () => {
             checked: false,
             text: 'Paper return',
             value: 'paperReturn'
+          },
+          {
+            checked: false,
+            text: 'Renewals invitation',
+            value: 'renewalInvitations'
           }
         ],
         pageTitle: 'Select the notice type'
@@ -112,6 +117,11 @@ describe('Notice - Setup - Notice Type Presenter', () => {
                 checked: false,
                 text: 'Paper return',
                 value: 'paperReturn'
+              },
+              {
+                checked: false,
+                text: 'Renewals invitation',
+                value: 'renewalInvitations'
               }
             ])
           })
@@ -140,6 +150,11 @@ describe('Notice - Setup - Notice Type Presenter', () => {
                 checked: false,
                 text: 'Paper return',
                 value: 'paperReturn'
+              },
+              {
+                checked: false,
+                text: 'Renewals invitation',
+                value: 'renewalInvitations'
               }
             ])
           })
@@ -168,6 +183,11 @@ describe('Notice - Setup - Notice Type Presenter', () => {
                 checked: true,
                 text: 'Paper return',
                 value: 'paperReturn'
+              },
+              {
+                checked: false,
+                text: 'Renewals invitation',
+                value: 'renewalInvitations'
               }
             ])
           })
@@ -257,6 +277,11 @@ describe('Notice - Setup - Notice Type Presenter', () => {
                   checked: false,
                   text: 'Paper return',
                   value: 'paperReturn'
+                },
+                {
+                  checked: false,
+                  text: 'Renewals invitation',
+                  value: 'renewalInvitations'
                 }
               ],
               pageTitle: 'Select the notice type'
@@ -291,6 +316,11 @@ describe('Notice - Setup - Notice Type Presenter', () => {
                     checked: false,
                     text: 'Paper return',
                     value: 'paperReturn'
+                  },
+                  {
+                    checked: false,
+                    text: 'Renewals invitation',
+                    value: 'renewalInvitations'
                   }
                 ],
                 pageTitle: 'Select the notice type'
@@ -311,6 +341,11 @@ describe('Notice - Setup - Notice Type Presenter', () => {
                   checked: false,
                   text: 'Paper return',
                   value: 'paperReturn'
+                },
+                {
+                  checked: false,
+                  text: 'Renewals invitation',
+                  value: 'renewalInvitations'
                 }
               ])
             })

--- a/test/services/notices/setup/view-check-notice-type.service.test.js
+++ b/test/services/notices/setup/view-check-notice-type.service.test.js
@@ -54,7 +54,7 @@ describe('Notices - Setup - View Check Notice Type service', () => {
         },
         notification: undefined,
         pageTitle: 'Check the notice type',
-        returnNoticeType: 'Returns invitation',
+        noticeType: 'Returns invitation',
         sessionId: session.id
       })
     })

--- a/test/services/notices/setup/view-notice-type.service.test.js
+++ b/test/services/notices/setup/view-notice-type.service.test.js
@@ -65,6 +65,11 @@ describe('Notices - Setup - View Notice Type service', () => {
             checked: false,
             text: 'Paper return',
             value: 'paperReturn'
+          },
+          {
+            checked: false,
+            text: 'Renewals invitation',
+            value: 'renewalInvitations'
           }
         ],
         pageTitle: 'Select the notice type'

--- a/test/services/notices/setup/view-notice-type.service.test.js
+++ b/test/services/notices/setup/view-notice-type.service.test.js
@@ -24,7 +24,7 @@ describe('Notices - Setup - View Notice Type service', () => {
 
   beforeEach(() => {
     auth = {
-      credentials: { scope: ['bulk_return_notifications'] }
+      credentials: { scope: ['bulk_return_notifications', 'renewal_notifications'] }
     }
 
     sessionData = {


### PR DESCRIPTION
This change adds the renewal invitations to the adhoc notice journey; the notice type is added as an option to select.

This logic to check for a valid licence will be updated in a later change.