### PR TITLE
Add logic to process a renewal licence submission

### DIFF
--- a/app/services/notices/setup/renewal-notice/process-licence-submission.service.js
+++ b/app/services/notices/setup/renewal-notice/process-licence-submission.service.js
@@ -1,0 +1,45 @@
+'use strict'
+
+/**
+ * Orchestrates validating renewal notice types for the `/notices/setup/{sessionId}/licence` page
+ * @module ProcessRenewalsNoticeLicenceSubmission
+ */
+
+const CheckLicenceExistsDal = require('../../../../dal/notices/setup/check-licence-exists.dal.js')
+const LicenceRenewalValidator = require('../../../../validators/notices/setup/renewal-notice/licence-renewal.validator.js')
+const { formatValidationResult } = require('../../../../presenters/base.presenter.js')
+
+/**
+ * Orchestrates validating the renewal notice types for the `/notices/setup/{sessionId}/licence` page
+ *
+ * It first checks if the licence user has entered a licenceRef. If they haven't entered a licenceRef we return an
+ * error. If they have we check if it exists in the database. If it doesn't exist we return the same error.
+ *
+ * @param {object} payload - The submitted form data
+ *
+ * @returns {Promise<object>} The due returns fetched alongside the validation result (null if valid)
+ */
+async function go(payload) {
+  const validationResult = await _validate(payload)
+
+  return {
+    additionalSessionData: {},
+    validationResult
+  }
+}
+
+async function _validate(payload) {
+  let licenceExists = false
+
+  if (payload.licenceRef) {
+    licenceExists = await CheckLicenceExistsDal.go(payload.licenceRef)
+  }
+
+  const validationResult = LicenceRenewalValidator.go(payload, licenceExists)
+
+  return formatValidationResult(validationResult)
+}
+
+module.exports = {
+  go
+}

--- a/app/services/notices/setup/renewal-notice/process-licence-submission.service.js
+++ b/app/services/notices/setup/renewal-notice/process-licence-submission.service.js
@@ -17,7 +17,7 @@ const { formatValidationResult } = require('../../../../presenters/base.presente
  *
  * @param {object} payload - The submitted form data
  *
- * @returns {Promise<object>} The due returns fetched alongside the validation result (null if valid)
+ * @returns {Promise<object>} The validation result (null if valid)
  */
 async function go(payload) {
   const validationResult = await _validate(payload)

--- a/app/services/notices/setup/returns-notice/process-licence-submission.service.js
+++ b/app/services/notices/setup/returns-notice/process-licence-submission.service.js
@@ -7,7 +7,7 @@
 
 const FetchDueReturnsForLicenceService = require('../returns-notice/fetch-due-returns-for-licence.service.js')
 const CheckLicenceExistsDal = require('../../../../dal/notices/setup/check-licence-exists.dal.js')
-const LicenceDueReturnsValidator = require('../../../../validators/notices/setup/licence-due-returns.validator.js')
+const LicenceDueReturnsValidator = require('../../../../validators/notices/setup/returns-notice/licence-due-returns.validator.js')
 const { formatValidationResult } = require('../../../../presenters/base.presenter.js')
 
 /**

--- a/app/services/notices/setup/submit-licence.service.js
+++ b/app/services/notices/setup/submit-licence.service.js
@@ -7,9 +7,10 @@
 
 const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const LicencePresenter = require('../../../presenters/notices/setup/licence.presenter.js')
+const ProcessRenewalsNoticeLicenceSubmission = require('./renewal-notice/process-licence-submission.service.js')
 const ProcessReturnsNoticeLicenceSubmission = require('./returns-notice/process-licence-submission.service.js')
-const { flashNotification } = require('../../../lib/general.lib.js')
 const { NoticeJourney, NoticeType } = require('../../../lib/static-lookups.lib.js')
+const { flashNotification } = require('../../../lib/general.lib.js')
 
 /**
  * Orchestrates validating the data for `/notices/setup/{sessionId}/licence` page
@@ -28,7 +29,7 @@ const { NoticeJourney, NoticeType } = require('../../../lib/static-lookups.lib.j
 async function go(sessionId, payload, yar) {
   const session = await FetchSessionDal.go(sessionId)
 
-  const { additionalSessionData, validationResult } = await ProcessReturnsNoticeLicenceSubmission.go(payload)
+  const { additionalSessionData, validationResult } = await _processedLicenceSubmission(session.noticeType, payload)
 
   if (!validationResult) {
     const hasBeenVisited = session.checkPageVisited
@@ -53,6 +54,14 @@ async function go(sessionId, payload, yar) {
     error: validationResult,
     ...pageData
   }
+}
+
+async function _processedLicenceSubmission(noticeType, payload) {
+  if (noticeType === NoticeType.RENEWAL_INVITATIONS) {
+    return ProcessRenewalsNoticeLicenceSubmission.go(payload)
+  }
+
+  return ProcessReturnsNoticeLicenceSubmission.go(payload)
 }
 
 /**

--- a/app/services/notices/setup/submit-licence.service.js
+++ b/app/services/notices/setup/submit-licence.service.js
@@ -9,8 +9,8 @@ const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const LicencePresenter = require('../../../presenters/notices/setup/licence.presenter.js')
 const ProcessRenewalsNoticeLicenceSubmission = require('./renewal-notice/process-licence-submission.service.js')
 const ProcessReturnsNoticeLicenceSubmission = require('./returns-notice/process-licence-submission.service.js')
-const { NoticeJourney, NoticeType } = require('../../../lib/static-lookups.lib.js')
 const { flashNotification } = require('../../../lib/general.lib.js')
+const { NoticeJourney, NoticeType } = require('../../../lib/static-lookups.lib.js')
 
 /**
  * Orchestrates validating the data for `/notices/setup/{sessionId}/licence` page

--- a/app/validators/notices/setup/renewal-notice/licence-renewal.validator.js
+++ b/app/validators/notices/setup/renewal-notice/licence-renewal.validator.js
@@ -1,7 +1,7 @@
 'use strict'
 
 /**
- * Validates the licence and that it has due returns, for the returns notice types, submitted for the `/notices/setup/{sessionId}/licence` page
+ * Validates the licence ref submitted for the `/notices/setup/{sessionId}/licence` page for renewal notice types
  * @module LicenceRenewalValidator
  */
 
@@ -10,7 +10,7 @@ const Joi = require('joi')
 const { licenceRefSchema } = require('../../../schemas/licence-ref.schema.js')
 
 /**
- * Validates the licence and that it has due returns, for the returns notice types, submitted for the `/notices/setup/{sessionId}/licence` page
+ * Validates the licence ref submitted for the `/notices/setup/{sessionId}/licence` page for renewal notice types
  *
  * @param {object} payload - The payload from the request to be validated
  * @param {boolean} licenceExists - the result of checking if the licence ref is present in the database

--- a/app/validators/notices/setup/renewal-notice/licence-renewal.validator.js
+++ b/app/validators/notices/setup/renewal-notice/licence-renewal.validator.js
@@ -1,0 +1,31 @@
+'use strict'
+
+/**
+ * Validates the licence and that it has due returns, for the returns notice types, submitted for the `/notices/setup/{sessionId}/licence` page
+ * @module LicenceRenewalValidator
+ */
+
+const Joi = require('joi')
+
+const { licenceRefSchema } = require('../../../schemas/licence-ref.schema.js')
+
+/**
+ * Validates the licence and that it has due returns, for the returns notice types, submitted for the `/notices/setup/{sessionId}/licence` page
+ *
+ * @param {object} payload - The payload from the request to be validated
+ * @param {boolean} licenceExists - the result of checking if the licence ref is present in the database
+ *
+ * @returns {object} the result from calling Joi's schema.validate(). It will be an object with a `value:` property. If
+ * any errors are found the `error:` property will also exist detailing what the issues were
+ */
+function go(payload, licenceExists) {
+  const schema = Joi.object({
+    licenceRef: licenceRefSchema(licenceExists)
+  })
+
+  return schema.validate(payload, { abortEarly: false })
+}
+
+module.exports = {
+  go
+}

--- a/app/validators/notices/setup/returns-notice/licence-due-returns.validator.js
+++ b/app/validators/notices/setup/returns-notice/licence-due-returns.validator.js
@@ -7,7 +7,7 @@
 
 const Joi = require('joi')
 
-const { licenceRefSchema } = require('../../schemas/licence-ref.schema.js')
+const { licenceRefSchema } = require('../../../schemas/licence-ref.schema.js')
 
 /**
  * Validates the licence and that it has due returns, for the returns notice types, submitted for the `/notices/setup/{sessionId}/licence` page

--- a/test/services/notices/setup/submit-licence.service.test.js
+++ b/test/services/notices/setup/submit-licence.service.test.js
@@ -14,6 +14,7 @@ const { generateLicenceRef } = require('../../../support/helpers/licence.helper.
 
 // Things we need to stub
 const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
+const ProcessRenewalsNoticeLicenceSubmission = require('../../../../app/services/notices/setup/renewal-notice/process-licence-submission.service.js')
 const ProcessReturnsNoticeLicenceSubmission = require('../../../../app/services/notices/setup/returns-notice/process-licence-submission.service.js')
 
 // Thing under test
@@ -24,9 +25,10 @@ describe('Notices - Setup - Submit Licence service', () => {
   let fetchSessionStub
   let licenceRef
   let payload
+  let processRenewalsNoticeLicenceSubmissionStub
+  let processReturnsNoticeLicenceSubmissionStub
   let session
   let sessionData
-  let processReturnsNoticeLicenceSubmissionStub
   let yarStub
 
   beforeEach(() => {
@@ -42,6 +44,11 @@ describe('Notices - Setup - Submit Licence service', () => {
 
     processReturnsNoticeLicenceSubmissionStub = Sinon.stub(ProcessReturnsNoticeLicenceSubmission, 'go').resolves({
       additionalSessionData: { dueReturns: [] },
+      validationResult: null
+    })
+
+    processRenewalsNoticeLicenceSubmissionStub = Sinon.stub(ProcessRenewalsNoticeLicenceSubmission, 'go').resolves({
+      additionalSessionData: {},
       validationResult: null
     })
 
@@ -92,6 +99,46 @@ describe('Notices - Setup - Submit Licence service', () => {
         describe('and the check page has been visited', () => {
           beforeEach(() => {
             sessionData = { noticeType: 'paperReturn', licenceRef, checkPageVisited: true }
+
+            session = SessionModelStub.build(Sinon, sessionData)
+
+            fetchSessionStub.resolves(session)
+          })
+
+          it('returns a redirect to the "check-notice-type" page', async () => {
+            const result = await SubmitLicenceService.go(session.id, payload, yarStub)
+
+            expect(result).to.equal({ redirectUrl: 'check-notice-type' })
+          })
+        })
+      })
+
+      describe('for a "renewal invitation" notice type', () => {
+        beforeEach(() => {
+          sessionData = { noticeType: 'renewalInvitations', checkPageVisited: false }
+
+          session = SessionModelStub.build(Sinon, sessionData)
+
+          fetchSessionStub.resolves(session)
+        })
+
+        it('calls the "processRenewalsNoticeLicenceSubmissionStub"', async () => {
+          await SubmitLicenceService.go(session.id, payload, yarStub)
+
+          expect(processRenewalsNoticeLicenceSubmissionStub.calledOnceWithExactly(payload)).to.be.true()
+        })
+
+        describe('and the check page has not been visited', () => {
+          it('returns a redirect to the "check-notice-type" page', async () => {
+            const result = await SubmitLicenceService.go(session.id, payload, yarStub)
+
+            expect(result).to.equal({ redirectUrl: 'check-notice-type' })
+          })
+        })
+
+        describe('and the check page has been visited', () => {
+          beforeEach(() => {
+            sessionData = { noticeType: 'renewalInvitations', licenceRef, checkPageVisited: true }
 
             session = SessionModelStub.build(Sinon, sessionData)
 

--- a/test/services/notices/setup/submit-licence.service.test.js
+++ b/test/services/notices/setup/submit-licence.service.test.js
@@ -115,7 +115,7 @@ describe('Notices - Setup - Submit Licence service', () => {
 
       describe('for a "renewal invitation" notice type', () => {
         beforeEach(() => {
-          sessionData = { noticeType: 'renewalInvitations', checkPageVisited: false }
+          sessionData = { checkPageVisited: false, noticeType: 'renewalInvitations' }
 
           session = SessionModelStub.build(Sinon, sessionData)
 
@@ -138,7 +138,7 @@ describe('Notices - Setup - Submit Licence service', () => {
 
         describe('and the check page has been visited', () => {
           beforeEach(() => {
-            sessionData = { noticeType: 'renewalInvitations', licenceRef, checkPageVisited: true }
+            sessionData = { checkPageVisited: true, licenceRef, noticeType: 'renewalInvitations' }
 
             session = SessionModelStub.build(Sinon, sessionData)
 

--- a/test/validators/notices/setup/renewal-notice/licence-due-returns.validator.test.js
+++ b/test/validators/notices/setup/renewal-notice/licence-due-returns.validator.test.js
@@ -1,0 +1,59 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Thing under test
+const LicenceRenewalValidator = require('../../../../../app/validators/notices/setup/renewal-notice/licence-renewal.validator.js')
+
+describe('Notices - Setup - Returns Notice - licence renewal validator', () => {
+  let licenceExists
+  let payload
+
+  beforeEach(() => {
+    licenceExists = true
+    payload = { licenceRef: '123/67' }
+  })
+
+  it('confirms the data is valid', () => {
+    const result = LicenceRenewalValidator.go(payload, licenceExists)
+
+    expect(result.value).to.exist()
+    expect(result.error).not.to.exist()
+  })
+
+  describe('when invalid data is provided', () => {
+    describe('because a "licenceRef" has not been provided', () => {
+      beforeEach(() => {
+        licenceExists = false
+        payload = { licenceRef: '' }
+      })
+
+      it('confirms the data is invalid', () => {
+        const result = LicenceRenewalValidator.go(payload, licenceExists)
+
+        expect(result.value).to.exist()
+        expect(result.error).to.exist()
+        expect(result.error.details[0].message).to.equal('Enter a licence number')
+      })
+    })
+
+    describe('because the "licenceRef" does not exist', () => {
+      beforeEach(() => {
+        licenceExists = false
+      })
+
+      it('confirms the data is invalid', () => {
+        const result = LicenceRenewalValidator.go(payload, licenceExists)
+
+        expect(result.value).to.exist()
+        expect(result.error).to.exist()
+        expect(result.error.details[0].message).to.equal('Enter a valid licence number')
+      })
+    })
+  })
+})

--- a/test/validators/notices/setup/renewal-notice/licence-renewal.validator.test.js
+++ b/test/validators/notices/setup/renewal-notice/licence-renewal.validator.test.js
@@ -10,7 +10,7 @@ const { expect } = Code
 // Thing under test
 const LicenceRenewalValidator = require('../../../../../app/validators/notices/setup/renewal-notice/licence-renewal.validator.js')
 
-describe('Notices - Setup - Returns Notice - licence renewal validator', () => {
+describe('Notices - Setup - Renewal Notice - licence renewal validator', () => {
   let licenceExists
   let payload
 

--- a/test/validators/notices/setup/returns-notice/licence-due-returns.validator.test.js
+++ b/test/validators/notices/setup/returns-notice/licence-due-returns.validator.test.js
@@ -8,9 +8,9 @@ const { describe, it, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Thing under test
-const LicenceDueReturnsValidator = require('../../../../app/validators/notices/setup/licence-due-returns.validator.js')
+const LicenceDueReturnsValidator = require('../../../../../app/validators/notices/setup/returns-notice/licence-due-returns.validator.js')
 
-describe('Notices - Setup - licence due returns validator', () => {
+describe('Notices - Setup - Returns Notice - licence due returns validator', () => {
   let dueReturnsExist
   let licenceExists
   let payload


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5646

When a user selects the renewal invitations option, we need to check the licence is valid for renewal (this involved checking expiry dates etc.).

This change set the groundwork for checking a renewal notice licence ref is suitable for a renewal invitation.

This change adds a check to see if the notice type is 'renewalInvitations', when it is we use the 'ProcessRenewalsNoticeLicenceSubmission' service.

The licence renewal check is complicated and will be added in another change.