### PR TITLE
Fix not setting due date for alt. returns notices

### DIFF
--- a/app/services/notifications/check-notification-status.service.js
+++ b/app/services/notifications/check-notification-status.service.js
@@ -125,7 +125,14 @@ async function _recordReturnLogs(notification, status, trx) {
   }
 
   // We only apply the due date for certain notice types
-  if (!['paper return', 'returns invitation', 'returns invitation ad-hoc'].includes(messageRef)) {
+  const dueDateApplicableMessageRefs = [
+    'paper return',
+    'returns invitation',
+    'returns invitation ad-hoc',
+    'returns invitation alternate'
+  ]
+
+  if (!dueDateApplicableMessageRefs.includes(messageRef)) {
     return
   }
 

--- a/test/services/notifications/check-notification-status.service.test.js
+++ b/test/services/notifications/check-notification-status.service.test.js
@@ -1026,6 +1026,154 @@ describe('Notifications - Check Notification Status service', () => {
     })
   })
 
+  describe.only('when the notification is a "returns invitation alternate"', () => {
+    beforeEach(() => {
+      notice = NoticesFixture.returnsInvitation()
+
+      returnLogWhereInStub = Sinon.stub().resolves()
+      Sinon.stub(ReturnLogModel, 'query').returns({
+        patch: returnLogPatchStub,
+        where: Sinon.stub().returnsThis(),
+        whereIn: returnLogWhereInStub
+      })
+
+      // NOTE: We only create letters for return invitations alternate, so we skip splitting the tests into 'letter' and
+      // 'email'
+      notification = NotificationsFixture.returnsInvitationAlternateLetter(notice)
+      notification.status = 'pending'
+    })
+
+    describe('and Notify returns a "pending" status', () => {
+      beforeEach(() => {
+        // NOTE: The service only uses the `status` field from the Notify result. If you want to see a full
+        // representation look at test/requests/notify/view-message-data.request.test.js
+        Sinon.stub(ViewMessageDataRequest, 'send').resolves({
+          succeeded: true,
+          response: {
+            statusCode: 200,
+            body: {
+              status: 'sending'
+            }
+          }
+        })
+      })
+
+      it('does nothing', async () => {
+        await CheckNotificationStatusService.go(notification)
+
+        expect(notificationPatchStub.called).to.be.false()
+        expect(licenceMonitoringStationPatchStub.called).to.be.false()
+        expect(returnLogPatchStub.called).to.be.false()
+      })
+    })
+
+    describe('and Notify returns a "received" status', () => {
+      beforeEach(() => {
+        // NOTE: The service only uses the `status` field from the Notify result. If you want to see a full
+        // representation look at test/requests/notify/view-message-data.request.test.js
+        Sinon.stub(ViewMessageDataRequest, 'send').resolves({
+          succeeded: true,
+          response: {
+            statusCode: 200,
+            body: {
+              status: 'received'
+            }
+          }
+        })
+      })
+
+      it('updates the status of the notification to "sent"', async () => {
+        await CheckNotificationStatusService.go(notification)
+
+        expect(notificationPatchStub.called).to.be.true()
+        expect(notificationPatchStub.firstCall.args[0]).to.equal(
+          { notifyStatus: 'received', status: 'sent' },
+          { skip: ['updatedAt'] }
+        )
+      })
+
+      it('does not attempt to update anything in licence monitoring stations', async () => {
+        await CheckNotificationStatusService.go(notification)
+
+        expect(licenceMonitoringStationPatchStub.called).to.be.false()
+      })
+
+      describe('and the contact type was "licence holder" or "single use"', () => {
+        it('attempts to set the due date for the linked return log records', async () => {
+          await CheckNotificationStatusService.go(notification)
+
+          expect(returnLogPatchStub.called).to.be.true()
+          expect(returnLogPatchStub.firstCall.args[0]).to.equal(
+            { dueDate: notification.dueDate, sentDate: notification.createdAt },
+            { skip: ['updatedAt'] }
+          )
+
+          expect(returnLogWhereInStub.called).to.be.true()
+          expect(returnLogWhereInStub.firstCall.args[0]).to.equal('id')
+          expect(returnLogWhereInStub.firstCall.args[1]).to.equal(notification.returnLogIds)
+        })
+      })
+
+      describe('and the contact type was NOT "licence holder" or "single use"', () => {
+        beforeEach(() => {
+          notification.contactType = 'returns to'
+        })
+
+        it('does not attempt to set the due date for the linked return log records.', async () => {
+          await CheckNotificationStatusService.go(notification)
+
+          expect(returnLogPatchStub.called).to.be.false()
+        })
+      })
+    })
+
+    describe('and Notify returns a "failed" status', () => {
+      beforeEach(() => {
+        Sinon.stub(ViewMessageDataRequest, 'send').resolves({
+          succeeded: true,
+          response: {
+            statusCode: 200,
+            body: {
+              status: 'temporary-failure'
+            }
+          }
+        })
+      })
+
+      it('updates the status of the notification to "error"', async () => {
+        await CheckNotificationStatusService.go(notification)
+
+        expect(notificationPatchStub.called).to.be.true()
+        expect(notificationPatchStub.firstCall.args[0]).to.equal(
+          { notifyStatus: 'temporary-failure', status: 'error' },
+          { skip: ['updatedAt'] }
+        )
+      })
+    })
+
+    describe('and Notify returns an "unknown" status', () => {
+      beforeEach(() => {
+        Sinon.stub(ViewMessageDataRequest, 'send').resolves({
+          succeeded: true,
+          response: {
+            statusCode: 200,
+            body: {
+              status: 'unrecognised'
+            }
+          }
+        })
+      })
+
+      it('does nothing', async () => {
+        await CheckNotificationStatusService.go(notification)
+
+        expect(notificationPatchStub.called).to.be.false()
+        expect(licenceMonitoringStationPatchStub.called).to.be.false()
+        expect(returnLogPatchStub.called).to.be.false()
+      })
+    })
+  })
+
   describe('when the notification is a "returns reminder"', () => {
     beforeEach(() => {
       notice = NoticesFixture.returnsReminder()

--- a/test/services/notifications/check-notification-status.service.test.js
+++ b/test/services/notifications/check-notification-status.service.test.js
@@ -1026,7 +1026,7 @@ describe('Notifications - Check Notification Status service', () => {
     })
   })
 
-  describe.only('when the notification is a "returns invitation alternate"', () => {
+  describe('when the notification is a "returns invitation alternate"', () => {
     beforeEach(() => {
       notice = NoticesFixture.returnsInvitation()
 

--- a/test/services/notifications/check-notification-status.service.test.js
+++ b/test/services/notifications/check-notification-status.service.test.js
@@ -743,6 +743,289 @@ describe('Notifications - Check Notification Status service', () => {
     })
   })
 
+  describe('when the notification is a "returns invitation ad-hoc"', () => {
+    beforeEach(() => {
+      notice = NoticesFixture.returnsInvitation()
+
+      returnLogWhereInStub = Sinon.stub().resolves()
+      Sinon.stub(ReturnLogModel, 'query').returns({
+        patch: returnLogPatchStub,
+        where: Sinon.stub().returnsThis(),
+        whereIn: returnLogWhereInStub
+      })
+    })
+
+    describe('and is a letter', () => {
+      beforeEach(() => {
+        notification = NotificationsFixture.returnsInvitationLetter(notice, 'ad-hoc')
+        notification.status = 'pending'
+      })
+
+      describe('and Notify returns a "pending" status', () => {
+        beforeEach(() => {
+          // NOTE: The service only uses the `status` field from the Notify result. If you want to see a full
+          // representation look at test/requests/notify/view-message-data.request.test.js
+          Sinon.stub(ViewMessageDataRequest, 'send').resolves({
+            succeeded: true,
+            response: {
+              statusCode: 200,
+              body: {
+                status: 'sending'
+              }
+            }
+          })
+        })
+
+        it('does nothing', async () => {
+          await CheckNotificationStatusService.go(notification)
+
+          expect(notificationPatchStub.called).to.be.false()
+          expect(licenceMonitoringStationPatchStub.called).to.be.false()
+          expect(returnLogPatchStub.called).to.be.false()
+        })
+      })
+
+      describe('and Notify returns a "received" status', () => {
+        beforeEach(() => {
+          // NOTE: The service only uses the `status` field from the Notify result. If you want to see a full
+          // representation look at test/requests/notify/view-message-data.request.test.js
+          Sinon.stub(ViewMessageDataRequest, 'send').resolves({
+            succeeded: true,
+            response: {
+              statusCode: 200,
+              body: {
+                status: 'received'
+              }
+            }
+          })
+        })
+
+        it('updates the status of the notification to "sent"', async () => {
+          await CheckNotificationStatusService.go(notification)
+
+          expect(notificationPatchStub.called).to.be.true()
+          expect(notificationPatchStub.firstCall.args[0]).to.equal(
+            { notifyStatus: 'received', status: 'sent' },
+            { skip: ['updatedAt'] }
+          )
+        })
+
+        it('does not attempt to update anything in licence monitoring stations', async () => {
+          await CheckNotificationStatusService.go(notification)
+
+          expect(licenceMonitoringStationPatchStub.called).to.be.false()
+        })
+
+        describe('and the contact type was "licence holder" or "single use"', () => {
+          it('attempts to set the due date for the linked return log records', async () => {
+            await CheckNotificationStatusService.go(notification)
+
+            expect(returnLogPatchStub.called).to.be.true()
+            expect(returnLogPatchStub.firstCall.args[0]).to.equal(
+              { dueDate: notification.dueDate, sentDate: notification.createdAt },
+              { skip: ['updatedAt'] }
+            )
+
+            expect(returnLogWhereInStub.called).to.be.true()
+            expect(returnLogWhereInStub.firstCall.args[0]).to.equal('id')
+            expect(returnLogWhereInStub.firstCall.args[1]).to.equal(notification.returnLogIds)
+          })
+        })
+
+        describe('and the contact type was NOT "licence holder" or "single use"', () => {
+          beforeEach(() => {
+            notification.contactType = 'returns to'
+          })
+
+          it('does not attempt to set the due date for the linked return log records.', async () => {
+            await CheckNotificationStatusService.go(notification)
+
+            expect(returnLogPatchStub.called).to.be.false()
+          })
+        })
+      })
+
+      describe('and Notify returns a "failed" status', () => {
+        beforeEach(() => {
+          Sinon.stub(ViewMessageDataRequest, 'send').resolves({
+            succeeded: true,
+            response: {
+              statusCode: 200,
+              body: {
+                status: 'temporary-failure'
+              }
+            }
+          })
+        })
+
+        it('updates the status of the notification to "error"', async () => {
+          await CheckNotificationStatusService.go(notification)
+
+          expect(notificationPatchStub.called).to.be.true()
+          expect(notificationPatchStub.firstCall.args[0]).to.equal(
+            { notifyStatus: 'temporary-failure', status: 'error' },
+            { skip: ['updatedAt'] }
+          )
+        })
+      })
+
+      describe('and Notify returns an "unknown" status', () => {
+        beforeEach(() => {
+          Sinon.stub(ViewMessageDataRequest, 'send').resolves({
+            succeeded: true,
+            response: {
+              statusCode: 200,
+              body: {
+                status: 'unrecognised'
+              }
+            }
+          })
+        })
+
+        it('does nothing', async () => {
+          await CheckNotificationStatusService.go(notification)
+
+          expect(notificationPatchStub.called).to.be.false()
+          expect(licenceMonitoringStationPatchStub.called).to.be.false()
+          expect(returnLogPatchStub.called).to.be.false()
+        })
+      })
+    })
+
+    describe('and is an email', () => {
+      beforeEach(() => {
+        notification = NotificationsFixture.returnsInvitationEmail(notice)
+        notification.status = 'pending'
+      })
+
+      describe('and Notify returns a "pending" status', () => {
+        beforeEach(() => {
+          Sinon.stub(ViewMessageDataRequest, 'send').resolves({
+            succeeded: true,
+            response: {
+              statusCode: 200,
+              body: {
+                status: 'created'
+              }
+            }
+          })
+        })
+
+        it('does nothing', async () => {
+          await CheckNotificationStatusService.go(notification)
+
+          expect(notificationPatchStub.called).to.be.false()
+          expect(licenceMonitoringStationPatchStub.called).to.be.false()
+          expect(returnLogPatchStub.called).to.be.false()
+        })
+      })
+
+      describe('and Notify returns a "sent" status', () => {
+        beforeEach(() => {
+          Sinon.stub(ViewMessageDataRequest, 'send').resolves({
+            succeeded: true,
+            response: {
+              statusCode: 200,
+              body: {
+                status: 'delivered'
+              }
+            }
+          })
+        })
+
+        it('updates the status of the notification to "sent"', async () => {
+          await CheckNotificationStatusService.go(notification)
+
+          expect(notificationPatchStub.called).to.be.true()
+          expect(notificationPatchStub.firstCall.args[0]).to.equal(
+            { notifyStatus: 'delivered', status: 'sent' },
+            { skip: ['updatedAt'] }
+          )
+        })
+
+        it('does not attempt to update anything in licence monitoring stations', async () => {
+          await CheckNotificationStatusService.go(notification)
+
+          expect(licenceMonitoringStationPatchStub.called).to.be.false()
+        })
+
+        describe('and the contact type was "primary user" or "single use"', () => {
+          it('attempts to set the due date for the linked return log records', async () => {
+            await CheckNotificationStatusService.go(notification)
+
+            expect(returnLogPatchStub.called).to.be.true()
+            expect(returnLogPatchStub.firstCall.args[0]).to.equal(
+              { dueDate: notification.dueDate, sentDate: notification.createdAt },
+              { skip: ['updatedAt'] }
+            )
+
+            expect(returnLogWhereInStub.called).to.be.true()
+            expect(returnLogWhereInStub.firstCall.args[0]).to.equal('id')
+            expect(returnLogWhereInStub.firstCall.args[1]).to.equal(notification.returnLogIds)
+          })
+        })
+
+        describe('and the contact type was NOT "primary user" or "single use"', () => {
+          beforeEach(() => {
+            notification.contactType = 'returns user'
+          })
+
+          it('does not attempt to set the due date for the linked return log records.', async () => {
+            await CheckNotificationStatusService.go(notification)
+
+            expect(returnLogPatchStub.called).to.be.false()
+          })
+        })
+      })
+
+      describe('and Notify returns a "failed" status', () => {
+        beforeEach(() => {
+          Sinon.stub(ViewMessageDataRequest, 'send').resolves({
+            succeeded: true,
+            response: {
+              statusCode: 200,
+              body: {
+                status: 'permanent-failure'
+              }
+            }
+          })
+        })
+
+        it('updates the status of the notification to "error"', async () => {
+          await CheckNotificationStatusService.go(notification)
+
+          expect(notificationPatchStub.called).to.be.true()
+          expect(notificationPatchStub.firstCall.args[0]).to.equal(
+            { notifyStatus: 'permanent-failure', status: 'error' },
+            { skip: ['updatedAt'] }
+          )
+        })
+      })
+
+      describe('and Notify returns an "unknown" status', () => {
+        beforeEach(() => {
+          Sinon.stub(ViewMessageDataRequest, 'send').resolves({
+            succeeded: true,
+            response: {
+              statusCode: 200,
+              body: {
+                status: 'unrecognised'
+              }
+            }
+          })
+        })
+
+        it('does nothing', async () => {
+          await CheckNotificationStatusService.go(notification)
+
+          expect(notificationPatchStub.called).to.be.false()
+          expect(licenceMonitoringStationPatchStub.called).to.be.false()
+          expect(returnLogPatchStub.called).to.be.false()
+        })
+      })
+    })
+  })
+
   describe('when the notification is a "returns reminder"', () => {
     beforeEach(() => {
       notice = NoticesFixture.returnsReminder()

--- a/test/services/notifications/check-notification-status.service.test.js
+++ b/test/services/notifications/check-notification-status.service.test.js
@@ -757,7 +757,7 @@ describe('Notifications - Check Notification Status service', () => {
 
     describe('and is a letter', () => {
       beforeEach(() => {
-        notification = NotificationsFixture.returnsInvitationLetter(notice, 'ad-hoc')
+        notification = NotificationsFixture.returnsInvitationAdHocLetter(notice)
         notification.status = 'pending'
       })
 
@@ -894,7 +894,7 @@ describe('Notifications - Check Notification Status service', () => {
 
     describe('and is an email', () => {
       beforeEach(() => {
-        notification = NotificationsFixture.returnsInvitationEmail(notice)
+        notification = NotificationsFixture.returnsInvitationAdHocEmail(notice)
         notification.status = 'pending'
       })
 

--- a/test/services/notifications/check-notification-status.service.test.js
+++ b/test/services/notifications/check-notification-status.service.test.js
@@ -55,6 +55,411 @@ describe('Notifications - Check Notification Status service', () => {
     delete globalThis.GlobalNotifier
   })
 
+  describe('when the notification is an abstraction alert', () => {
+    beforeEach(() => {
+      notice = NoticesFixture.alertStop()
+    })
+
+    describe('and is a letter', () => {
+      beforeEach(() => {
+        notification = NotificationsFixture.abstractionAlertLetter(notice)
+        notification.status = 'pending'
+      })
+
+      describe('and Notify returns a "pending" status', () => {
+        beforeEach(() => {
+          Sinon.stub(ViewMessageDataRequest, 'send').resolves({
+            succeeded: true,
+            response: {
+              statusCode: 200,
+              body: {
+                status: 'accepted'
+              }
+            }
+          })
+        })
+
+        it('does nothing', async () => {
+          await CheckNotificationStatusService.go(notification)
+
+          expect(notificationPatchStub.called).to.be.false()
+          expect(licenceMonitoringStationPatchStub.called).to.be.false()
+          expect(returnLogPatchStub.called).to.be.false()
+        })
+      })
+
+      describe('and Notify returns "sent" status', () => {
+        beforeEach(() => {
+          Sinon.stub(ViewMessageDataRequest, 'send').resolves({
+            succeeded: true,
+            response: {
+              statusCode: 200,
+              body: {
+                status: 'received'
+              }
+            }
+          })
+        })
+
+        it('updates the status of the notification to "sent"', async () => {
+          await CheckNotificationStatusService.go(notification)
+
+          expect(notificationPatchStub.called).to.be.true()
+          expect(notificationPatchStub.firstCall.args[0]).to.equal(
+            { notifyStatus: 'received', status: 'sent' },
+            { skip: ['updatedAt'] }
+          )
+        })
+
+        it('updates the linked licence monitoring station record', async () => {
+          await CheckNotificationStatusService.go(notification)
+
+          expect(licenceMonitoringStationPatchStub.called).to.be.true()
+          expect(licenceMonitoringStationPatchStub.firstCall.args[0]).to.equal({
+            status: notification.personalisation.sending_alert_type,
+            statusUpdatedAt: notification.createdAt
+          })
+        })
+      })
+
+      describe('and Notify returns "failed" status', () => {
+        beforeEach(() => {
+          Sinon.stub(ViewMessageDataRequest, 'send').resolves({
+            succeeded: true,
+            response: {
+              statusCode: 200,
+              body: {
+                status: 'validation-failed'
+              }
+            }
+          })
+        })
+
+        it('updates the status of the notification to "error"', async () => {
+          await CheckNotificationStatusService.go(notification)
+
+          expect(notificationPatchStub.called).to.be.true()
+          expect(notificationPatchStub.firstCall.args[0]).to.equal(
+            { notifyStatus: 'validation-failed', status: 'error' },
+            { skip: ['updatedAt'] }
+          )
+        })
+
+        it('does not update the linked licence monitoring station record', async () => {
+          await CheckNotificationStatusService.go(notification)
+
+          expect(licenceMonitoringStationPatchStub.called).to.be.false()
+        })
+      })
+
+      describe('and Notify returns an "unknown" status', () => {
+        beforeEach(() => {
+          Sinon.stub(ViewMessageDataRequest, 'send').resolves({
+            succeeded: true,
+            response: {
+              statusCode: 200,
+              body: {
+                status: 'unrecognised'
+              }
+            }
+          })
+        })
+
+        it('does nothing', async () => {
+          await CheckNotificationStatusService.go(notification)
+
+          expect(notificationPatchStub.called).to.be.false()
+          expect(licenceMonitoringStationPatchStub.called).to.be.false()
+          expect(returnLogPatchStub.called).to.be.false()
+        })
+      })
+    })
+
+    describe('and is an email', () => {
+      beforeEach(() => {
+        notification = NotificationsFixture.abstractionAlertEmail(notice)
+        notification.status = 'pending'
+      })
+
+      describe('and Notify returns a "pending" status', () => {
+        beforeEach(() => {
+          Sinon.stub(ViewMessageDataRequest, 'send').resolves({
+            succeeded: true,
+            response: {
+              statusCode: 200,
+              body: {
+                status: 'accepted'
+              }
+            }
+          })
+        })
+
+        it('does nothing', async () => {
+          await CheckNotificationStatusService.go(notification)
+
+          expect(notificationPatchStub.called).to.be.false()
+          expect(licenceMonitoringStationPatchStub.called).to.be.false()
+          expect(returnLogPatchStub.called).to.be.false()
+        })
+      })
+
+      describe('and Notify returns "sent" status', () => {
+        beforeEach(() => {
+          Sinon.stub(ViewMessageDataRequest, 'send').resolves({
+            succeeded: true,
+            response: {
+              statusCode: 200,
+              body: {
+                status: 'delivered'
+              }
+            }
+          })
+        })
+
+        it('updates the status of the notification to "sent"', async () => {
+          await CheckNotificationStatusService.go(notification)
+
+          expect(notificationPatchStub.called).to.be.true()
+          expect(notificationPatchStub.firstCall.args[0]).to.equal(
+            { notifyStatus: 'delivered', status: 'sent' },
+            { skip: ['updatedAt'] }
+          )
+        })
+
+        it('updates the linked licence monitoring station record', async () => {
+          await CheckNotificationStatusService.go(notification)
+
+          expect(licenceMonitoringStationPatchStub.called).to.be.true()
+          expect(licenceMonitoringStationPatchStub.firstCall.args[0]).to.equal({
+            status: notification.personalisation.sending_alert_type,
+            statusUpdatedAt: notification.createdAt
+          })
+        })
+      })
+
+      describe('and Notify returns "failed" status', () => {
+        beforeEach(() => {
+          Sinon.stub(ViewMessageDataRequest, 'send').resolves({
+            succeeded: true,
+            response: {
+              statusCode: 200,
+              body: {
+                status: 'technical-failure'
+              }
+            }
+          })
+        })
+
+        it('updates the status of the notification to "error"', async () => {
+          await CheckNotificationStatusService.go(notification)
+
+          expect(notificationPatchStub.called).to.be.true()
+          expect(notificationPatchStub.firstCall.args[0]).to.equal(
+            { notifyStatus: 'technical-failure', status: 'error' },
+            { skip: ['updatedAt'] }
+          )
+        })
+
+        it('does not update the linked licence monitoring station record', async () => {
+          await CheckNotificationStatusService.go(notification)
+
+          expect(licenceMonitoringStationPatchStub.called).to.be.false()
+        })
+      })
+
+      describe('and Notify returns an "unknown" status', () => {
+        beforeEach(() => {
+          Sinon.stub(ViewMessageDataRequest, 'send').resolves({
+            succeeded: true,
+            response: {
+              statusCode: 200,
+              body: {
+                status: 'unrecognised'
+              }
+            }
+          })
+        })
+
+        it('does nothing', async () => {
+          await CheckNotificationStatusService.go(notification)
+
+          expect(notificationPatchStub.called).to.be.false()
+          expect(licenceMonitoringStationPatchStub.called).to.be.false()
+          expect(returnLogPatchStub.called).to.be.false()
+        })
+      })
+    })
+  })
+
+  describe('when the notification is a paper return', () => {
+    beforeEach(() => {
+      notice = NoticesFixture.returnsPaperForm()
+      notification = NotificationsFixture.paperReturn(notice)
+      notification.status = 'pending'
+
+      returnLogWhereInStub = Sinon.stub().resolves()
+      Sinon.stub(ReturnLogModel, 'query').returns({
+        patch: returnLogPatchStub,
+        where: Sinon.stub().returnsThis(),
+        whereIn: returnLogWhereInStub
+      })
+    })
+
+    describe('and Notify returns a "pending" status', () => {
+      beforeEach(() => {
+        // NOTE: The service only uses the `status` field from the Notify result. If you want to see a full
+        // representation look at test/requests/notify/view-message-data.request.test.js
+        Sinon.stub(ViewMessageDataRequest, 'send').resolves({
+          succeeded: true,
+          response: {
+            statusCode: 200,
+            body: {
+              status: 'pending-virus-check'
+            }
+          }
+        })
+      })
+
+      it('does nothing', async () => {
+        await CheckNotificationStatusService.go(notification)
+
+        expect(notificationPatchStub.called).to.be.false()
+        expect(licenceMonitoringStationPatchStub.called).to.be.false()
+        expect(returnLogPatchStub.called).to.be.false()
+      })
+    })
+
+    describe('and Notify returns a "sent" status', () => {
+      beforeEach(() => {
+        // NOTE: The service only uses the `status` field from the Notify result. If you want to see a full
+        // representation look at test/requests/notify/view-message-data.request.test.js
+        Sinon.stub(ViewMessageDataRequest, 'send').resolves({
+          succeeded: true,
+          response: {
+            statusCode: 200,
+            body: {
+              status: 'received'
+            }
+          }
+        })
+      })
+
+      it('updates the status of the notification to "sent"', async () => {
+        await CheckNotificationStatusService.go(notification)
+
+        expect(notificationPatchStub.called).to.be.true()
+        expect(notificationPatchStub.firstCall.args[0]).to.equal(
+          { notifyStatus: 'received', status: 'sent' },
+          { skip: ['updatedAt'] }
+        )
+      })
+
+      it('does not attempt to update anything in licence monitoring stations', async () => {
+        await CheckNotificationStatusService.go(notification)
+
+        expect(licenceMonitoringStationPatchStub.called).to.be.false()
+      })
+
+      describe('and the contact type was "licence holder" or "single use"', () => {
+        it('attempts to set the due date for the linked return log records', async () => {
+          await CheckNotificationStatusService.go(notification)
+
+          expect(returnLogPatchStub.called).to.be.true()
+          expect(returnLogPatchStub.firstCall.args[0]).to.equal(
+            { dueDate: notification.dueDate, sentDate: notification.createdAt },
+            { skip: ['updatedAt'] }
+          )
+
+          expect(returnLogWhereInStub.called).to.be.true()
+          expect(returnLogWhereInStub.firstCall.args[0]).to.equal('id')
+          expect(returnLogWhereInStub.firstCall.args[1]).to.equal(notification.returnLogIds)
+        })
+      })
+
+      describe('and the contact type was NOT "licence holder" or "single use"', () => {
+        beforeEach(() => {
+          notification.contactType = 'returns to'
+        })
+
+        it('does not attempt to set the due date for the linked return log records.', async () => {
+          await CheckNotificationStatusService.go(notification)
+
+          expect(returnLogPatchStub.called).to.be.false()
+        })
+      })
+    })
+
+    describe('and Notify returns a "failed" status', () => {
+      beforeEach(() => {
+        Sinon.stub(ViewMessageDataRequest, 'send').resolves({
+          succeeded: true,
+          response: {
+            statusCode: 200,
+            body: {
+              status: 'temporary-failure'
+            }
+          }
+        })
+      })
+
+      it('updates the status of the notification to "error"', async () => {
+        await CheckNotificationStatusService.go(notification)
+
+        expect(notificationPatchStub.called).to.be.true()
+        expect(notificationPatchStub.firstCall.args[0]).to.equal(
+          { notifyStatus: 'temporary-failure', status: 'error' },
+          { skip: ['updatedAt'] }
+        )
+      })
+    })
+
+    describe('and Notify returns a "cancelled" status', () => {
+      beforeEach(() => {
+        Sinon.stub(ViewMessageDataRequest, 'send').resolves({
+          succeeded: true,
+          response: {
+            statusCode: 200,
+            body: {
+              status: 'cancelled'
+            }
+          }
+        })
+      })
+
+      it('updates the status of the notification to "cancelled"', async () => {
+        await CheckNotificationStatusService.go(notification)
+
+        expect(notificationPatchStub.called).to.be.true()
+        expect(notificationPatchStub.firstCall.args[0]).to.equal(
+          { notifyStatus: 'cancelled', status: 'cancelled' },
+          { skip: ['updatedAt'] }
+        )
+      })
+    })
+
+    describe('and Notify returns an "unknown" status', () => {
+      beforeEach(() => {
+        Sinon.stub(ViewMessageDataRequest, 'send').resolves({
+          succeeded: true,
+          response: {
+            statusCode: 200,
+            body: {
+              status: 'unrecognised'
+            }
+          }
+        })
+      })
+
+      it('does nothing', async () => {
+        await CheckNotificationStatusService.go(notification)
+
+        expect(notificationPatchStub.called).to.be.false()
+        expect(licenceMonitoringStationPatchStub.called).to.be.false()
+        expect(returnLogPatchStub.called).to.be.false()
+      })
+    })
+  })
+
   describe('when the notification is a returns invitation', () => {
     beforeEach(() => {
       notice = NoticesFixture.returnsInvitation()
@@ -542,411 +947,6 @@ describe('Notifications - Check Notification Status service', () => {
           expect(licenceMonitoringStationPatchStub.called).to.be.false()
           expect(returnLogPatchStub.called).to.be.false()
         })
-      })
-    })
-  })
-
-  describe('when the notification is an abstraction alert', () => {
-    beforeEach(() => {
-      notice = NoticesFixture.alertStop()
-    })
-
-    describe('and is a letter', () => {
-      beforeEach(() => {
-        notification = NotificationsFixture.abstractionAlertLetter(notice)
-        notification.status = 'pending'
-      })
-
-      describe('and Notify returns a "pending" status', () => {
-        beforeEach(() => {
-          Sinon.stub(ViewMessageDataRequest, 'send').resolves({
-            succeeded: true,
-            response: {
-              statusCode: 200,
-              body: {
-                status: 'accepted'
-              }
-            }
-          })
-        })
-
-        it('does nothing', async () => {
-          await CheckNotificationStatusService.go(notification)
-
-          expect(notificationPatchStub.called).to.be.false()
-          expect(licenceMonitoringStationPatchStub.called).to.be.false()
-          expect(returnLogPatchStub.called).to.be.false()
-        })
-      })
-
-      describe('and Notify returns "sent" status', () => {
-        beforeEach(() => {
-          Sinon.stub(ViewMessageDataRequest, 'send').resolves({
-            succeeded: true,
-            response: {
-              statusCode: 200,
-              body: {
-                status: 'received'
-              }
-            }
-          })
-        })
-
-        it('updates the status of the notification to "sent"', async () => {
-          await CheckNotificationStatusService.go(notification)
-
-          expect(notificationPatchStub.called).to.be.true()
-          expect(notificationPatchStub.firstCall.args[0]).to.equal(
-            { notifyStatus: 'received', status: 'sent' },
-            { skip: ['updatedAt'] }
-          )
-        })
-
-        it('updates the linked licence monitoring station record', async () => {
-          await CheckNotificationStatusService.go(notification)
-
-          expect(licenceMonitoringStationPatchStub.called).to.be.true()
-          expect(licenceMonitoringStationPatchStub.firstCall.args[0]).to.equal({
-            status: notification.personalisation.sending_alert_type,
-            statusUpdatedAt: notification.createdAt
-          })
-        })
-      })
-
-      describe('and Notify returns "failed" status', () => {
-        beforeEach(() => {
-          Sinon.stub(ViewMessageDataRequest, 'send').resolves({
-            succeeded: true,
-            response: {
-              statusCode: 200,
-              body: {
-                status: 'validation-failed'
-              }
-            }
-          })
-        })
-
-        it('updates the status of the notification to "error"', async () => {
-          await CheckNotificationStatusService.go(notification)
-
-          expect(notificationPatchStub.called).to.be.true()
-          expect(notificationPatchStub.firstCall.args[0]).to.equal(
-            { notifyStatus: 'validation-failed', status: 'error' },
-            { skip: ['updatedAt'] }
-          )
-        })
-
-        it('does not update the linked licence monitoring station record', async () => {
-          await CheckNotificationStatusService.go(notification)
-
-          expect(licenceMonitoringStationPatchStub.called).to.be.false()
-        })
-      })
-
-      describe('and Notify returns an "unknown" status', () => {
-        beforeEach(() => {
-          Sinon.stub(ViewMessageDataRequest, 'send').resolves({
-            succeeded: true,
-            response: {
-              statusCode: 200,
-              body: {
-                status: 'unrecognised'
-              }
-            }
-          })
-        })
-
-        it('does nothing', async () => {
-          await CheckNotificationStatusService.go(notification)
-
-          expect(notificationPatchStub.called).to.be.false()
-          expect(licenceMonitoringStationPatchStub.called).to.be.false()
-          expect(returnLogPatchStub.called).to.be.false()
-        })
-      })
-    })
-
-    describe('and is an email', () => {
-      beforeEach(() => {
-        notification = NotificationsFixture.abstractionAlertEmail(notice)
-        notification.status = 'pending'
-      })
-
-      describe('and Notify returns a "pending" status', () => {
-        beforeEach(() => {
-          Sinon.stub(ViewMessageDataRequest, 'send').resolves({
-            succeeded: true,
-            response: {
-              statusCode: 200,
-              body: {
-                status: 'accepted'
-              }
-            }
-          })
-        })
-
-        it('does nothing', async () => {
-          await CheckNotificationStatusService.go(notification)
-
-          expect(notificationPatchStub.called).to.be.false()
-          expect(licenceMonitoringStationPatchStub.called).to.be.false()
-          expect(returnLogPatchStub.called).to.be.false()
-        })
-      })
-
-      describe('and Notify returns "sent" status', () => {
-        beforeEach(() => {
-          Sinon.stub(ViewMessageDataRequest, 'send').resolves({
-            succeeded: true,
-            response: {
-              statusCode: 200,
-              body: {
-                status: 'delivered'
-              }
-            }
-          })
-        })
-
-        it('updates the status of the notification to "sent"', async () => {
-          await CheckNotificationStatusService.go(notification)
-
-          expect(notificationPatchStub.called).to.be.true()
-          expect(notificationPatchStub.firstCall.args[0]).to.equal(
-            { notifyStatus: 'delivered', status: 'sent' },
-            { skip: ['updatedAt'] }
-          )
-        })
-
-        it('updates the linked licence monitoring station record', async () => {
-          await CheckNotificationStatusService.go(notification)
-
-          expect(licenceMonitoringStationPatchStub.called).to.be.true()
-          expect(licenceMonitoringStationPatchStub.firstCall.args[0]).to.equal({
-            status: notification.personalisation.sending_alert_type,
-            statusUpdatedAt: notification.createdAt
-          })
-        })
-      })
-
-      describe('and Notify returns "failed" status', () => {
-        beforeEach(() => {
-          Sinon.stub(ViewMessageDataRequest, 'send').resolves({
-            succeeded: true,
-            response: {
-              statusCode: 200,
-              body: {
-                status: 'technical-failure'
-              }
-            }
-          })
-        })
-
-        it('updates the status of the notification to "error"', async () => {
-          await CheckNotificationStatusService.go(notification)
-
-          expect(notificationPatchStub.called).to.be.true()
-          expect(notificationPatchStub.firstCall.args[0]).to.equal(
-            { notifyStatus: 'technical-failure', status: 'error' },
-            { skip: ['updatedAt'] }
-          )
-        })
-
-        it('does not update the linked licence monitoring station record', async () => {
-          await CheckNotificationStatusService.go(notification)
-
-          expect(licenceMonitoringStationPatchStub.called).to.be.false()
-        })
-      })
-
-      describe('and Notify returns an "unknown" status', () => {
-        beforeEach(() => {
-          Sinon.stub(ViewMessageDataRequest, 'send').resolves({
-            succeeded: true,
-            response: {
-              statusCode: 200,
-              body: {
-                status: 'unrecognised'
-              }
-            }
-          })
-        })
-
-        it('does nothing', async () => {
-          await CheckNotificationStatusService.go(notification)
-
-          expect(notificationPatchStub.called).to.be.false()
-          expect(licenceMonitoringStationPatchStub.called).to.be.false()
-          expect(returnLogPatchStub.called).to.be.false()
-        })
-      })
-    })
-  })
-
-  describe('when the notification is a paper return', () => {
-    beforeEach(() => {
-      notice = NoticesFixture.returnsPaperForm()
-      notification = NotificationsFixture.paperReturn(notice)
-      notification.status = 'pending'
-
-      returnLogWhereInStub = Sinon.stub().resolves()
-      Sinon.stub(ReturnLogModel, 'query').returns({
-        patch: returnLogPatchStub,
-        where: Sinon.stub().returnsThis(),
-        whereIn: returnLogWhereInStub
-      })
-    })
-
-    describe('and Notify returns a "pending" status', () => {
-      beforeEach(() => {
-        // NOTE: The service only uses the `status` field from the Notify result. If you want to see a full
-        // representation look at test/requests/notify/view-message-data.request.test.js
-        Sinon.stub(ViewMessageDataRequest, 'send').resolves({
-          succeeded: true,
-          response: {
-            statusCode: 200,
-            body: {
-              status: 'pending-virus-check'
-            }
-          }
-        })
-      })
-
-      it('does nothing', async () => {
-        await CheckNotificationStatusService.go(notification)
-
-        expect(notificationPatchStub.called).to.be.false()
-        expect(licenceMonitoringStationPatchStub.called).to.be.false()
-        expect(returnLogPatchStub.called).to.be.false()
-      })
-    })
-
-    describe('and Notify returns a "sent" status', () => {
-      beforeEach(() => {
-        // NOTE: The service only uses the `status` field from the Notify result. If you want to see a full
-        // representation look at test/requests/notify/view-message-data.request.test.js
-        Sinon.stub(ViewMessageDataRequest, 'send').resolves({
-          succeeded: true,
-          response: {
-            statusCode: 200,
-            body: {
-              status: 'received'
-            }
-          }
-        })
-      })
-
-      it('updates the status of the notification to "sent"', async () => {
-        await CheckNotificationStatusService.go(notification)
-
-        expect(notificationPatchStub.called).to.be.true()
-        expect(notificationPatchStub.firstCall.args[0]).to.equal(
-          { notifyStatus: 'received', status: 'sent' },
-          { skip: ['updatedAt'] }
-        )
-      })
-
-      it('does not attempt to update anything in licence monitoring stations', async () => {
-        await CheckNotificationStatusService.go(notification)
-
-        expect(licenceMonitoringStationPatchStub.called).to.be.false()
-      })
-
-      describe('and the contact type was "licence holder" or "single use"', () => {
-        it('attempts to set the due date for the linked return log records', async () => {
-          await CheckNotificationStatusService.go(notification)
-
-          expect(returnLogPatchStub.called).to.be.true()
-          expect(returnLogPatchStub.firstCall.args[0]).to.equal(
-            { dueDate: notification.dueDate, sentDate: notification.createdAt },
-            { skip: ['updatedAt'] }
-          )
-
-          expect(returnLogWhereInStub.called).to.be.true()
-          expect(returnLogWhereInStub.firstCall.args[0]).to.equal('id')
-          expect(returnLogWhereInStub.firstCall.args[1]).to.equal(notification.returnLogIds)
-        })
-      })
-
-      describe('and the contact type was NOT "licence holder" or "single use"', () => {
-        beforeEach(() => {
-          notification.contactType = 'returns to'
-        })
-
-        it('does not attempt to set the due date for the linked return log records.', async () => {
-          await CheckNotificationStatusService.go(notification)
-
-          expect(returnLogPatchStub.called).to.be.false()
-        })
-      })
-    })
-
-    describe('and Notify returns a "failed" status', () => {
-      beforeEach(() => {
-        Sinon.stub(ViewMessageDataRequest, 'send').resolves({
-          succeeded: true,
-          response: {
-            statusCode: 200,
-            body: {
-              status: 'temporary-failure'
-            }
-          }
-        })
-      })
-
-      it('updates the status of the notification to "error"', async () => {
-        await CheckNotificationStatusService.go(notification)
-
-        expect(notificationPatchStub.called).to.be.true()
-        expect(notificationPatchStub.firstCall.args[0]).to.equal(
-          { notifyStatus: 'temporary-failure', status: 'error' },
-          { skip: ['updatedAt'] }
-        )
-      })
-    })
-
-    describe('and Notify returns a "cancelled" status', () => {
-      beforeEach(() => {
-        Sinon.stub(ViewMessageDataRequest, 'send').resolves({
-          succeeded: true,
-          response: {
-            statusCode: 200,
-            body: {
-              status: 'cancelled'
-            }
-          }
-        })
-      })
-
-      it('updates the status of the notification to "cancelled"', async () => {
-        await CheckNotificationStatusService.go(notification)
-
-        expect(notificationPatchStub.called).to.be.true()
-        expect(notificationPatchStub.firstCall.args[0]).to.equal(
-          { notifyStatus: 'cancelled', status: 'cancelled' },
-          { skip: ['updatedAt'] }
-        )
-      })
-    })
-
-    describe('and Notify returns an "unknown" status', () => {
-      beforeEach(() => {
-        Sinon.stub(ViewMessageDataRequest, 'send').resolves({
-          succeeded: true,
-          response: {
-            statusCode: 200,
-            body: {
-              status: 'unrecognised'
-            }
-          }
-        })
-      })
-
-      it('does nothing', async () => {
-        await CheckNotificationStatusService.go(notification)
-
-        expect(notificationPatchStub.called).to.be.false()
-        expect(licenceMonitoringStationPatchStub.called).to.be.false()
-        expect(returnLogPatchStub.called).to.be.false()
       })
     })
   })

--- a/test/services/notifications/check-notification-status.service.test.js
+++ b/test/services/notifications/check-notification-status.service.test.js
@@ -97,7 +97,7 @@ describe('Notifications - Check Notification Status service', () => {
         })
       })
 
-      describe('and Notify returns a "sent" status', () => {
+      describe('and Notify returns a "received" status', () => {
         beforeEach(() => {
           // NOTE: The service only uses the `status` field from the Notify result. If you want to see a full
           // representation look at test/requests/notify/view-message-data.request.test.js

--- a/test/services/notifications/check-notification-status.service.test.js
+++ b/test/services/notifications/check-notification-status.service.test.js
@@ -55,7 +55,7 @@ describe('Notifications - Check Notification Status service', () => {
     delete globalThis.GlobalNotifier
   })
 
-  describe('when the notification is an abstraction alert', () => {
+  describe('when the notification is an "abstraction alert"', () => {
     beforeEach(() => {
       notice = NoticesFixture.alertStop()
     })
@@ -291,7 +291,7 @@ describe('Notifications - Check Notification Status service', () => {
     })
   })
 
-  describe('when the notification is a paper return', () => {
+  describe('when the notification is a "paper return"', () => {
     beforeEach(() => {
       notice = NoticesFixture.returnsPaperForm()
       notification = NotificationsFixture.paperReturn(notice)
@@ -460,7 +460,7 @@ describe('Notifications - Check Notification Status service', () => {
     })
   })
 
-  describe('when the notification is a returns invitation', () => {
+  describe('when the notification is a "returns invitation"', () => {
     beforeEach(() => {
       notice = NoticesFixture.returnsInvitation()
 
@@ -743,7 +743,7 @@ describe('Notifications - Check Notification Status service', () => {
     })
   })
 
-  describe('when the notification is a returns reminder', () => {
+  describe('when the notification is a "returns reminder"', () => {
     beforeEach(() => {
       notice = NoticesFixture.returnsReminder()
     })

--- a/test/support/fixtures/notifications.fixture.js
+++ b/test/support/fixtures/notifications.fixture.js
@@ -471,6 +471,23 @@ function returnsInvitationAdHocLetter(notice) {
     templateId: NOTIFY_TEMPLATES.invitations.adhoc.letter['licence holder']
   }
 }
+
+/**
+ * Generates an alternate returns invitation letter notification object associated to the provided notice
+ *
+ * > There is no alternate email notification, as these are generated and sent when the email fails.
+ *
+ * @param {object} notice - The notice to associate with the returns invitation letter notification
+ *
+ * @returns {object} The generated returns invitation letter object
+ */
+function returnsInvitationAlternateLetter(notice) {
+  const notification = _returnsInvitationDefaults(notice)
+
+  return {
+    ...notification,
+    contactType: 'licence holder',
+    messageRef: 'returns invitation alternate',
     messageType: 'letter',
     notifyStatus: 'received',
     plaintext:
@@ -803,6 +820,7 @@ module.exports = {
   renewalInvitationLetter,
   returnsInvitationAdHocEmail,
   returnsInvitationAdHocLetter,
+  returnsInvitationAlternateLetter,
   returnsInvitationEmail,
   returnsInvitationLetter,
   returnsReminderEmail,

--- a/test/support/fixtures/notifications.fixture.js
+++ b/test/support/fixtures/notifications.fixture.js
@@ -422,10 +422,14 @@ function renewalInvitationLetter(notice) {
  * Generates a returns invitation email notification object associated to the provided notice
  *
  * @param {object} notice - The notice to associate with the returns invitation email notification
+ * @param {string} [successor=null] - Specify a successor notice: 'ad-hoc' or 'alternate'. This will be added to the
+ * message ref for the notification, allowing us to test the handling of different returns invitation types
  *
  * @returns {object} The generated returns invitation email object
  */
-function returnsInvitationEmail(notice) {
+function returnsInvitationEmail(notice, successor = null) {
+  const messageRef = `returns invitation${successor ? ` ${successor}` : ''}`
+
   const notification = {
     contactType: 'primary user',
     createdAt: new Date('2025-04-02'),
@@ -434,7 +438,7 @@ function returnsInvitationEmail(notice) {
     id: generateUUID(),
     licenceMonitoringStationId: null,
     licences: notice.licences,
-    messageRef: 'returns invitation',
+    messageRef,
     messageType: 'email',
     notifyId: generateUUID(),
     notifyStatus: 'delivered',

--- a/test/support/fixtures/notifications.fixture.js
+++ b/test/support/fixtures/notifications.fixture.js
@@ -419,35 +419,21 @@ function renewalInvitationLetter(notice) {
 }
 
 /**
- * Generates a returns invitation email notification object associated to the provided notice
+ * Generates an ad-hoc returns invitation email notification object associated to the provided notice
  *
  * @param {object} notice - The notice to associate with the returns invitation email notification
- * @param {string} [successor=null] - Specify a successor notice: 'ad-hoc' or 'alternate'. This will be added to the
- * message ref for the notification, allowing us to test the handling of different returns invitation types
  *
  * @returns {object} The generated returns invitation email object
  */
-function returnsInvitationEmail(notice, successor = null) {
-  const messageRef = `returns invitation${successor ? ` ${successor}` : ''}`
+function returnsInvitationAdHocEmail(notice) {
+  const notification = _returnsInvitationDefaults(notice)
 
-  const notification = {
+  return {
+    ...notification,
     contactType: 'primary user',
-    createdAt: new Date('2025-04-02'),
-    dueDate: new Date('2025-04-28'),
-    eventId: notice.id,
-    id: generateUUID(),
-    licenceMonitoringStationId: null,
-    licences: notice.licences,
-    messageRef,
+    messageRef: 'returns invitation ad-hoc',
     messageType: 'email',
-    notifyId: generateUUID(),
     notifyStatus: 'delivered',
-    pdf: null,
-    personalisation: {
-      periodEndDate: '31 March 2025',
-      returnDueDate: '28 April 2025',
-      periodStartDate: '1 April 2024'
-    },
     plaintext:
       'Dear licence holder\n' +
       '\n' +
@@ -455,13 +441,74 @@ function returnsInvitationEmail(notice, successor = null) {
       '\n' +
       '^ You’ll need to submit your returns by 1 April 2025.\n',
     recipient: 'grace.hopper@acme.co.uk',
-    returnedAt: null,
-    returnLogIds: [generateUUID(), generateUUID()],
-    status: 'sent',
+    templateId: NOTIFY_TEMPLATES.invitations.adhoc.email['primary user']
+  }
+}
+
+/**
+ * Generates an ad-hoc returns invitation letter notification object associated to the provided notice
+ *
+ * @param {object} notice - The notice to associate with the returns invitation letter notification
+ *
+ * @returns {object} The generated returns invitation letter object
+ */
+function returnsInvitationAdHocLetter(notice) {
+  const notification = _returnsInvitationDefaults(notice)
+
+  return {
+    ...notification,
+    contactType: 'licence holder',
+    messageRef: 'returns invitation ad-hoc',
+    messageType: 'letter',
+    notifyStatus: 'received',
+    plaintext:
+      'Dear ACME Services Ltd\n' +
+      '\n' +
+      '^ You must submit a record of your water abstraction from 1 April 2024 to 31 March 2025. \n' +
+      '\n' +
+      '^ You’ll need to submit your returns by 1 April 2025.\n',
+    recipient: null,
+    templateId: NOTIFY_TEMPLATES.invitations.adhoc.letter['licence holder']
+  }
+}
+    messageType: 'letter',
+    notifyStatus: 'received',
+    plaintext:
+      'Dear ACME Services Ltd\n' +
+      '\n' +
+      '^ You must submit a record of your water abstraction from 1 April 2024 to 31 March 2025. \n' +
+      '\n' +
+      '^ You’ll need to submit your returns by 1 April 2025.\n',
+    recipient: null,
+    templateId: NOTIFY_TEMPLATES.invitations.standard.letter['licence holder']
+  }
+}
+
+/**
+ * Generates a returns invitation email notification object associated to the provided notice
+ *
+ * @param {object} notice - The notice to associate with the returns invitation email notification
+ *
+ * @returns {object} The generated returns invitation email object
+ */
+function returnsInvitationEmail(notice) {
+  const notification = _returnsInvitationDefaults(notice)
+
+  return {
+    ...notification,
+    contactType: 'primary user',
+    messageRef: 'returns invitation',
+    messageType: 'email',
+    notifyStatus: 'delivered',
+    plaintext:
+      'Dear licence holder\n' +
+      '\n' +
+      '^ You must submit a record of your water abstraction from 1 April 2024 to 31 March 2025. \n' +
+      '\n' +
+      '^ You’ll need to submit your returns by 1 April 2025.\n',
+    recipient: 'grace.hopper@acme.co.uk',
     templateId: NOTIFY_TEMPLATES.invitations.standard.email['primary user']
   }
-
-  return notification
 }
 
 /**
@@ -472,26 +519,14 @@ function returnsInvitationEmail(notice, successor = null) {
  * @returns {object} The generated returns invitation letter object
  */
 function returnsInvitationLetter(notice) {
-  const notification = {
+  const notification = _returnsInvitationDefaults(notice)
+
+  return {
+    ...notification,
     contactType: 'licence holder',
-    createdAt: new Date('2025-04-02'),
-    dueDate: new Date('2025-04-28'),
-    eventId: notice.id,
-    id: generateUUID(),
-    licenceMonitoringStationId: null,
-    licences: notice.licences,
     messageRef: 'returns invitation',
     messageType: 'letter',
-    notifyId: generateUUID(),
     notifyStatus: 'received',
-    pdf: null,
-    personalisation: {
-      ...ADDRESS,
-      name: 'ACME Services Ltd',
-      periodEndDate: '31 March 2025',
-      returnDueDate: '28 April 2025',
-      periodStartDate: '1 April 2024'
-    },
     plaintext:
       'Dear ACME Services Ltd\n' +
       '\n' +
@@ -499,13 +534,8 @@ function returnsInvitationLetter(notice) {
       '\n' +
       '^ You’ll need to submit your returns by 1 April 2025.\n',
     recipient: null,
-    returnedAt: null,
-    returnLogIds: [generateUUID(), generateUUID()],
-    status: 'sent',
     templateId: NOTIFY_TEMPLATES.invitations.standard.letter['licence holder']
   }
-
-  return notification
 }
 
 /**
@@ -705,6 +735,27 @@ function userNewInternalEmail(recipient, overrides = {}) {
   return { ...notification, ...overrides }
 }
 
+function _returnsInvitationDefaults(notice) {
+  return {
+    createdAt: new Date('2025-04-02'),
+    dueDate: new Date('2025-04-28'),
+    eventId: notice.id,
+    id: generateUUID(),
+    licenceMonitoringStationId: null,
+    licences: notice.licences,
+    notifyId: generateUUID(),
+    pdf: null,
+    personalisation: {
+      periodEndDate: '31 March 2025',
+      returnDueDate: '28 April 2025',
+      periodStartDate: '1 April 2024'
+    },
+    returnedAt: null,
+    returnLogIds: [generateUUID(), generateUUID()],
+    status: 'sent'
+  }
+}
+
 function _userPasswordResetEmail(recipient, internal, overrides) {
   const domain = internal ? domains.internal : domains.external
 
@@ -750,6 +801,8 @@ module.exports = {
   paperReturn,
   renewalInvitationEmail,
   renewalInvitationLetter,
+  returnsInvitationAdHocEmail,
+  returnsInvitationAdHocLetter,
   returnsInvitationEmail,
   returnsInvitationLetter,
   returnsReminderEmail,

--- a/test/support/fixtures/notifications.fixture.js
+++ b/test/support/fixtures/notifications.fixture.js
@@ -434,6 +434,11 @@ function returnsInvitationAdHocEmail(notice) {
     messageRef: 'returns invitation ad-hoc',
     messageType: 'email',
     notifyStatus: 'delivered',
+    personalisation: {
+      periodEndDate: '31 March 2025',
+      returnDueDate: '28 April 2025',
+      periodStartDate: '1 April 2024'
+    },
     plaintext:
       'Dear licence holder\n' +
       '\n' +
@@ -461,6 +466,13 @@ function returnsInvitationAdHocLetter(notice) {
     messageRef: 'returns invitation ad-hoc',
     messageType: 'letter',
     notifyStatus: 'received',
+    personalisation: {
+      ...ADDRESS,
+      expiryDate: '28 April 2026',
+      licenceRef: notice.licences[0],
+      name: 'ACME Services Ltd',
+      renewalDate: '28 January 2026'
+    },
     plaintext:
       'Dear ACME Services Ltd\n' +
       '\n' +
@@ -490,6 +502,13 @@ function returnsInvitationAlternateLetter(notice) {
     messageRef: 'returns invitation alternate',
     messageType: 'letter',
     notifyStatus: 'received',
+    personalisation: {
+      ...ADDRESS,
+      expiryDate: '28 April 2026',
+      licenceRef: notice.licences[0],
+      name: 'ACME Services Ltd',
+      renewalDate: '28 January 2026'
+    },
     plaintext:
       'Dear ACME Services Ltd\n' +
       '\n' +
@@ -517,6 +536,11 @@ function returnsInvitationEmail(notice) {
     messageRef: 'returns invitation',
     messageType: 'email',
     notifyStatus: 'delivered',
+    personalisation: {
+      periodEndDate: '31 March 2025',
+      returnDueDate: '28 April 2025',
+      periodStartDate: '1 April 2024'
+    },
     plaintext:
       'Dear licence holder\n' +
       '\n' +
@@ -544,6 +568,13 @@ function returnsInvitationLetter(notice) {
     messageRef: 'returns invitation',
     messageType: 'letter',
     notifyStatus: 'received',
+    personalisation: {
+      ...ADDRESS,
+      expiryDate: '28 April 2026',
+      licenceRef: notice.licences[0],
+      name: 'ACME Services Ltd',
+      renewalDate: '28 January 2026'
+    },
     plaintext:
       'Dear ACME Services Ltd\n' +
       '\n' +
@@ -762,11 +793,6 @@ function _returnsInvitationDefaults(notice) {
     licences: notice.licences,
     notifyId: generateUUID(),
     pdf: null,
-    personalisation: {
-      periodEndDate: '31 March 2025',
-      returnDueDate: '28 April 2025',
-      periodStartDate: '1 April 2024'
-    },
     returnedAt: null,
     returnLogIds: [generateUUID(), generateUUID()],
     status: 'sent'


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5659

Our users identified an issue with our returns notice 'fallback' logic.

When we send a returns invitation, if the email to the primary user fails, we automatically generate another notice to the licence holder's address. That part is working fine.

When we then get confirmation from [GOV.UK Notify](https://www.notifications.service.gov.uk/) that the letter has been 'received' (meaning successfully sent to their mail provider), not only do we update the notification status, but we should be setting the 'due date' on the associated return logs.

It is this part that has the bug.

The cause is something we overlooked when introducing the logic for [dynamic due dates](https://eaflood.atlassian.net/browse/WATER-4991). People became concerned that we should make every effort to contact the external user to ensure they submit their returns on time. So, as part of dynamic dues dates, we implemented this fallback (alternate notice) logic.

To distinguish between the 'original' returns notice and the 'alternate' notice, we set a different `message_ref` on the notification (initially `return invitation failed` but changed to `return invitation alternate` in [Fix issues with alternate returns invitation](https://github.com/DEFRA/water-abstraction-system/pull/2759)).

The bit we overlooked was the logic that determines when to apply the 'due date' when a notification is successful.

```javascript
  // app/services/notifications/check-notification-status.service.js

  // We only apply the due date for certain notice types
  if (!['paper return', 'returns invitation', 'returns invitation ad-hoc'].includes(messageRef)) {
    return
  }
```

We never updated it to include `return invitation alternate`!