### PR TITLE
Update teardown to remove a 'bad' primary user

### DIFF
--- a/app/services/data/tear-down/crm-schema.service.js
+++ b/app/services/data/tear-down/crm-schema.service.js
@@ -115,8 +115,15 @@ async function _deleteAllTestData() {
   DELETE
   FROM
     "crm"."entity_roles"
+      USING "crm"."entity" AS "e"
   WHERE
-    "created_by" = 'acceptance-test-setup';
+    "created_by" = 'acceptance-test-setup'
+    OR "e"."entity_nm" LIKE 'acceptance-test.%'
+    OR "e"."entity_nm" LIKE '%@example.com'
+    OR "e"."entity_nm" LIKE '%@e'
+    OR "e"."entity_nm" LIKE 'regression.tests.%'
+    OR "e"."entity_nm" LIKE 'Big Farm Co Ltd%'
+    OR "e"."source" = 'acceptance-test-setup';
 
   DELETE
   FROM
@@ -124,6 +131,7 @@ async function _deleteAllTestData() {
   WHERE
     "entity_nm" LIKE 'acceptance-test.%'
     OR "entity_nm" LIKE '%@example.com'
+    OR "entity_nm" LIKE '%@e'
     OR "entity_nm" LIKE 'regression.tests.%'
     OR "entity_nm" LIKE 'Big Farm Co Ltd%'
     OR "source" = 'acceptance-test-setup';
@@ -137,7 +145,7 @@ async function _deleteAllTestData() {
       '$.dataType'
     ) #>> '{}' = 'acceptance-test-setup';
 
-    ALTER TABLE crm.document_header ENABLE TRIGGER ALL;
+  ALTER TABLE crm.document_header ENABLE TRIGGER ALL;
   ALTER TABLE crm_v2.addresses ENABLE TRIGGER ALL;
   ALTER TABLE crm_v2.companies ENABLE TRIGGER ALL;
   ALTER TABLE crm_v2.company_addresses ENABLE TRIGGER ALL;

--- a/app/services/data/tear-down/idm-schema.service.js
+++ b/app/services/data/tear-down/idm-schema.service.js
@@ -27,6 +27,7 @@ async function _deleteAllTestData() {
       '$.source'
     ) #>> '{}' = 'acceptance-test-setup'
     OR "user_name" LIKE '%@example.com'
+    OR "user_name" LIKE '%@e'
     OR "user_name" LIKE 'regression.tests%';
   `)
 }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5659

Our users identified an issue with our returns notice 'fallback' logic.

When we send a returns invitation, if the email to the primary user fails, we automatically generate another notice to the licence holder's address. That part is working fine.

When we then get confirmation from [GOV.UK Notify](https://www.notifications.service.gov.uk/) that the letter has been 'received' (meaning successfully sent to their mail provider), not only do we update the notification status, but we should be setting the 'due date' on the associated return logs.

It is this part that had the bug. We fixed it in [Fix not setting due date for alt. returns notices](https://github.com/DEFRA/water-abstraction-system/pull/3363).

To ensure we don't make the same mistake again, we're adding an acceptance test to cover this scenario. But to do that, we need to set up a test user with an email address that will fail when we try to send the notification.

Because we use Notify's test API key in our non-prod environments, any email address will be accepted. So, to simulate a failure, we have to create a primary user with an invalid email address: `iwill-fail@e`.

This means we need to update our teardown job to ensure the new 'bad' primary user is removed after the test runs.