### PR TITLE
Add renewal invitations to submit logic

### DIFF
--- a/app/dal/notices/setup/generate-renewal-invitation-licence-query.dal.js
+++ b/app/dal/notices/setup/generate-renewal-invitation-licence-query.dal.js
@@ -1,0 +1,27 @@
+'use strict'
+
+/**
+ * Generates the query and bindings to select a single licence ref for use in renewal invitation recipient queries
+ * @module GenerateRenewalInvitationLicenceQueryDal
+ */
+
+/**
+ * Generates the query and bindings to select a single licence ref for use in renewal invitation recipient queries
+ *
+ * Returns the query fragment and its binding used as the `expiring_licences` CTE when building the renewal invitation
+ * recipients query for the adhoc journey.
+ *
+ * @param {string} licenceRef - The licence reference to fetch recipients for
+ *
+ * @returns {object} An object containing the SQL `query` string and its `bindings`
+ */
+function go(licenceRef) {
+  return {
+    bindings: [licenceRef],
+    query: `SELECT l.licence_ref FROM public.licences l WHERE l.licence_ref = ?`
+  }
+}
+
+module.exports = {
+  go
+}

--- a/app/lib/notify-templates.lib.js
+++ b/app/lib/notify-templates.lib.js
@@ -40,6 +40,16 @@ const NOTIFY_TEMPLATES = Object.freeze({
     }
   },
   renewalInvitations: {
+    adhoc: {
+      email: {
+        'multiple licences': '9ba5065b-6c09-4ca6-8c84-2e68610e3f6e',
+        'single licence': '53c34f21-4f2e-43f7-97c6-7a7828079665'
+      },
+      letter: {
+        'single licence': 'c7538f40-2c9e-4b09-b539-4869b1cef2db',
+        'multiple licences': '9d1b5d2d-4374-4f62-8393-b8fda12dcc36'
+      }
+    },
     standard: {
       email: {
         'multiple licences': '9ba5065b-6c09-4ca6-8c84-2e68610e3f6e',

--- a/app/lib/notify-templates.lib.js
+++ b/app/lib/notify-templates.lib.js
@@ -42,12 +42,10 @@ const NOTIFY_TEMPLATES = Object.freeze({
   renewalInvitations: {
     adhoc: {
       email: {
-        'multiple licences': '9ba5065b-6c09-4ca6-8c84-2e68610e3f6e',
         'single licence': '53c34f21-4f2e-43f7-97c6-7a7828079665'
       },
       letter: {
-        'single licence': 'c7538f40-2c9e-4b09-b539-4869b1cef2db',
-        'multiple licences': '9d1b5d2d-4374-4f62-8393-b8fda12dcc36'
+        'single licence': 'c7538f40-2c9e-4b09-b539-4869b1cef2db'
       }
     },
     standard: {

--- a/app/presenters/notices/setup/check.presenter.js
+++ b/app/presenters/notices/setup/check.presenter.js
@@ -12,9 +12,10 @@ const { NoticeType, NoticeJourney } = require('../../../lib/static-lookups.lib.j
 
 const NOTIFICATION_TYPES = {
   [NoticeType.ABSTRACTION_ALERTS]: 'Abstraction alerts',
-  [NoticeType.PAPER_RETURN]: 'Return forms',
   [NoticeType.INVITATIONS]: 'Returns invitations',
-  [NoticeType.REMINDERS]: 'Returns reminders'
+  [NoticeType.PAPER_RETURN]: 'Return forms',
+  [NoticeType.REMINDERS]: 'Returns reminders',
+  [NoticeType.RENEWAL_INVITATIONS]: 'Renewal invitations'
 }
 
 /**

--- a/app/presenters/notices/setup/confirmation.presenter.js
+++ b/app/presenters/notices/setup/confirmation.presenter.js
@@ -5,6 +5,8 @@
  * @module ConfirmationPresenter
  */
 
+const { NoticeType, NoticeTypes } = require('../../../lib/static-lookups.lib.js')
+
 /**
  * Formats data for the `/notices/setup/{eventId}/confirmation` page
  *
@@ -38,17 +40,21 @@ function _monitoringStationLink(metadata) {
  * @private
  */
 function _pageTitle(subType) {
-  if (subType === 'waterAbstractionAlerts') {
+  if (subType === NoticeTypes[NoticeType.ABSTRACTION_ALERTS].subType) {
     return 'Water abstraction alerts sent'
   }
 
-  if (subType === 'paperReturnForms') {
+  if (subType === NoticeTypes[NoticeType.PAPER_RETURN].subType) {
     return 'Paper returns sent'
   }
 
+  if (subType === NoticeTypes[NoticeType.RENEWAL_INVITATIONS].subType) {
+    return 'Renewal invitations sent'
+  }
+
   const subTypes = {
-    returnInvitation: 'invitations',
-    returnReminder: 'reminders'
+    [NoticeTypes[NoticeType.INVITATIONS].subType]: 'invitations',
+    [NoticeTypes[NoticeType.REMINDERS].subType]: 'reminders'
   }
 
   return `Returns ${subTypes[subType]} sent`

--- a/app/services/notices/setup/fetch-recipients.service.js
+++ b/app/services/notices/setup/fetch-recipients.service.js
@@ -7,6 +7,7 @@
 
 const FetchAbstractionAlertRecipientsService = require('./abstraction-alerts/fetch-abstraction-alert-recipients.service.js')
 const FetchPaperReturnsRecipientsService = require('./returns-notice/fetch-paper-returns-recipients.service.js')
+const FetchRenewalInvitationRecipientsService = require('./renewal-notice/fetch-renewal-invitation-recipients.service.js')
 const FetchReturnsInvitationRecipientsService = require('./returns-notice/fetch-returns-invitation-recipients.service.js')
 const FetchReturnsReminderRecipientsService = require('./returns-notice/fetch-returns-reminder-recipients.service.js')
 const MergeRecipientsService = require('./merge-recipients.service.js')
@@ -40,6 +41,10 @@ async function _recipientsData(session, download) {
 
   if (session.noticeType === NoticeType.INVITATIONS) {
     return FetchReturnsInvitationRecipientsService.go(session, download)
+  }
+
+  if (session.noticeType === NoticeType.RENEWAL_INVITATIONS) {
+    return FetchRenewalInvitationRecipientsService.go(session)
   }
 
   return FetchReturnsReminderRecipientsService.go(session, download)

--- a/app/services/notices/setup/renewal-notice/fetch-renewal-invitation-recipients.service.js
+++ b/app/services/notices/setup/renewal-notice/fetch-renewal-invitation-recipients.service.js
@@ -1,0 +1,37 @@
+'use strict'
+
+/**
+ * Fetches recipient data for an adhoc renewal invitation notice
+ * @module FetchRenewalInvitationRecipientsService
+ */
+
+const GenerateRenewalInvitationLicenceQueryDal = require('../../../../dal/notices/setup/generate-renewal-invitation-licence-query.dal.js')
+const GenerateRenewalRecipientsQueryService = require('../../../jobs/renewal-invitations/generate-renewal-recipients-query.service.js')
+const { db } = require('../../../../../db/db.js')
+
+/**
+ * Fetches recipient data for an adhoc renewal invitation notice
+ *
+ * For the adhoc renewal journey a single licence reference is stored in the session. This service fetches the
+ * primary user (if the licence is registered) or falls back to the licence holder — the same logic used by the
+ * scheduled renewal invitations job.
+ *
+ * @param {module:SessionModel} session - The notice setup session instance
+ *
+ * @returns {Promise<object[]>} The recipient data for the renewal invitation notice
+ */
+async function go(session) {
+  const { licenceRef } = session
+
+  const { bindings, query: licenceQuery } = GenerateRenewalInvitationLicenceQueryDal.go(licenceRef)
+
+  const query = GenerateRenewalRecipientsQueryService.go(licenceQuery)
+
+  const { rows } = await db.raw(query, bindings)
+
+  return rows
+}
+
+module.exports = {
+  go
+}

--- a/app/services/notices/setup/view-preview.service.js
+++ b/app/services/notices/setup/view-preview.service.js
@@ -9,6 +9,7 @@ const AbstractionAlertNotificationsPresenter = require('../../../presenters/noti
 const FetchRecipientsService = require('./fetch-recipients.service.js')
 const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const PreviewPresenter = require('../../../presenters/notices/setup/preview.presenter.js')
+const RenewalInvitationNotificationsPresenter = require('../../../presenters/notices/setup/renewal-invitation-notice-notifications.presenter.js')
 const ReturnsNoticeNotificationsPresenter = require('../../../presenters/notices/setup/returns-notice-notifications.presenter.js')
 const { NoticeType } = require('../../../lib/static-lookups.lib.js')
 
@@ -52,6 +53,8 @@ function _notification(recipient, session, licenceMonitoringStationId) {
     notification = unfilteredNotifications.find((unfilteredNotification) => {
       return unfilteredNotification.personalisation.licenceGaugingStationId === licenceMonitoringStationId
     })
+  } else if (session.noticeType === NoticeType.RENEWAL_INVITATIONS) {
+    notification = RenewalInvitationNotificationsPresenter.go(session, [recipient], null)[0]
   } else {
     notification = ReturnsNoticeNotificationsPresenter.go(session, [recipient], null)[0]
   }

--- a/test/dal/notices/setup/generate-renewal-invitation-licence-query.dal.test.js
+++ b/test/dal/notices/setup/generate-renewal-invitation-licence-query.dal.test.js
@@ -1,0 +1,28 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Test helpers
+const { generateLicenceRef } = require('../../../support/helpers/licence.helper.js')
+
+// Thing under test
+const GenerateRenewalInvitationLicenceQueryDal = require('../../../../app/dal/notices/setup/generate-renewal-invitation-licence-query.dal.js')
+
+describe('Notices - Setup - Generate Renewal Invitation Licence Query DAL', () => {
+  describe('when called with a licence reference', () => {
+    it('returns the query and binding for that licence ref', () => {
+      const licenceRef = generateLicenceRef()
+      const result = GenerateRenewalInvitationLicenceQueryDal.go(licenceRef)
+
+      expect(result).to.equal({
+        bindings: [licenceRef],
+        query: `SELECT l.licence_ref FROM public.licences l WHERE l.licence_ref = ?`
+      })
+    })
+  })
+})

--- a/test/dal/notices/setup/generate-renewal-invitation-licence-query.dal.test.js
+++ b/test/dal/notices/setup/generate-renewal-invitation-licence-query.dal.test.js
@@ -4,25 +4,44 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it } = (exports.lab = Lab.script())
+const { describe, it, before, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const { generateLicenceRef } = require('../../../support/helpers/licence.helper.js')
+const LicenceHelper = require('../../../support/helpers/licence.helper.js')
+const { db } = require('../../../../db/db.js')
 
 // Thing under test
 const GenerateRenewalInvitationLicenceQueryDal = require('../../../../app/dal/notices/setup/generate-renewal-invitation-licence-query.dal.js')
 
 describe('Notices - Setup - Generate Renewal Invitation Licence Query DAL', () => {
-  describe('when called with a licence reference', () => {
-    it('returns the query and binding for that licence ref', () => {
-      const licenceRef = generateLicenceRef()
-      const result = GenerateRenewalInvitationLicenceQueryDal.go(licenceRef)
+  let licence
+
+  before(async () => {
+    licence = await LicenceHelper.add()
+  })
+
+  after(async () => {
+    await licence.$query().delete()
+  })
+
+  describe('when called', () => {
+    it('returns the expected query and bindings', () => {
+      const result = GenerateRenewalInvitationLicenceQueryDal.go(licence.licenceRef)
 
       expect(result).to.equal({
-        bindings: [licenceRef],
+        bindings: [licence.licenceRef],
         query: `SELECT l.licence_ref FROM public.licences l WHERE l.licence_ref = ?`
       })
+    })
+  })
+
+  describe('when executed', () => {
+    it('returns the expected licence', async () => {
+      const { bindings, query } = GenerateRenewalInvitationLicenceQueryDal.go(licence.licenceRef)
+      const { rows } = await db.raw(query, bindings)
+
+      expect(rows).to.equal([{ licence_ref: licence.licenceRef }])
     })
   })
 })

--- a/test/presenters/notices/setup/check.presenter.test.js
+++ b/test/presenters/notices/setup/check.presenter.test.js
@@ -226,6 +226,18 @@ describe('Notices - Setup - Check presenter', () => {
           expect(result.readyToSend).to.equal('Returns invitations are ready to send.')
         })
       })
+
+      describe('and the notice type is "renewalInvitations"', () => {
+        beforeEach(() => {
+          session.noticeType = 'renewalInvitations'
+        })
+
+        it('returns the message that the notifications "are ready to send."', () => {
+          const result = CheckPresenter.go(recipients, page, session)
+
+          expect(result.readyToSend).to.equal('Renewal invitations are ready to send.')
+        })
+      })
     })
   })
 

--- a/test/presenters/notices/setup/confirmation.presenter.test.js
+++ b/test/presenters/notices/setup/confirmation.presenter.test.js
@@ -8,7 +8,7 @@ const { describe, it, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const { generateNoticeReferenceCode } = require('../../../../app/lib/general.lib.js')
+const { generateNoticeReferenceCode, generateUUID } = require('../../../../app/lib/general.lib.js')
 
 // Thing under test
 const ConfirmationPresenter = require('../../../../app/presenters/notices/setup/confirmation.presenter.js')
@@ -20,7 +20,7 @@ describe('Notices - Setup - Confirmation presenter', () => {
 
   beforeEach(() => {
     event = {
-      id: 'ca6a7546-2365-45a1-9f07-ab9338577e2a',
+      id: generateUUID(),
       subtype: 'returnInvitation',
       referenceCode,
       metadata: {}
@@ -31,14 +31,14 @@ describe('Notices - Setup - Confirmation presenter', () => {
     const result = ConfirmationPresenter.go(event)
 
     expect(result).to.equal({
-      forwardLink: '/system/notices/ca6a7546-2365-45a1-9f07-ab9338577e2a',
+      forwardLink: `/system/notices/${event.id}`,
       monitoringStationLink: null,
       pageTitle: `Returns invitations sent`,
       referenceCode
     })
   })
 
-  describe('and the journey is "invitations"', () => {
+  describe('and the notice type is "returnInvitation"', () => {
     beforeEach(() => {
       event.subtype = 'returnInvitation'
     })
@@ -47,7 +47,7 @@ describe('Notices - Setup - Confirmation presenter', () => {
       const result = ConfirmationPresenter.go(event)
 
       expect(result).to.equal({
-        forwardLink: '/system/notices/ca6a7546-2365-45a1-9f07-ab9338577e2a',
+        forwardLink: `/system/notices/${event.id}`,
         monitoringStationLink: null,
         pageTitle: `Returns invitations sent`,
         referenceCode
@@ -55,7 +55,7 @@ describe('Notices - Setup - Confirmation presenter', () => {
     })
   })
 
-  describe('and the journey is "reminders"', () => {
+  describe('and the notice type is "returnReminder"', () => {
     beforeEach(() => {
       event.subtype = 'returnReminder'
     })
@@ -64,7 +64,7 @@ describe('Notices - Setup - Confirmation presenter', () => {
       const result = ConfirmationPresenter.go(event)
 
       expect(result).to.equal({
-        forwardLink: '/system/notices/ca6a7546-2365-45a1-9f07-ab9338577e2a',
+        forwardLink: `/system/notices/${event.id}`,
         monitoringStationLink: null,
         pageTitle: `Returns reminders sent`,
         referenceCode
@@ -72,7 +72,7 @@ describe('Notices - Setup - Confirmation presenter', () => {
     })
   })
 
-  describe('and the journey is "waterAbstractionAlerts"', () => {
+  describe('and the notice type is "waterAbstractionAlerts"', () => {
     beforeEach(() => {
       event.subtype = 'waterAbstractionAlerts'
 
@@ -83,7 +83,7 @@ describe('Notices - Setup - Confirmation presenter', () => {
       const result = ConfirmationPresenter.go(event)
 
       expect(result).to.equal({
-        forwardLink: '/system/notices/ca6a7546-2365-45a1-9f07-ab9338577e2a',
+        forwardLink: `/system/notices/${event.id}`,
         monitoringStationLink: '/system/monitoring-stations/123',
         pageTitle: 'Water abstraction alerts sent',
         referenceCode
@@ -100,9 +100,26 @@ describe('Notices - Setup - Confirmation presenter', () => {
       const result = ConfirmationPresenter.go(event)
 
       expect(result).to.equal({
-        forwardLink: '/system/notices/ca6a7546-2365-45a1-9f07-ab9338577e2a',
+        forwardLink: `/system/notices/${event.id}`,
         monitoringStationLink: null,
         pageTitle: 'Paper returns sent',
+        referenceCode
+      })
+    })
+  })
+
+  describe('and the notice type is "renewalInvitation"', () => {
+    beforeEach(() => {
+      event.subtype = 'renewalInvitation'
+    })
+
+    it('correctly presents the data', () => {
+      const result = ConfirmationPresenter.go(event)
+
+      expect(result).to.equal({
+        forwardLink: `/system/notices/${event.id}`,
+        monitoringStationLink: null,
+        pageTitle: 'Renewal invitations sent',
         referenceCode
       })
     })

--- a/test/presenters/notices/setup/renewal-invitation-notifications.presenter.test.js
+++ b/test/presenters/notices/setup/renewal-invitation-notifications.presenter.test.js
@@ -204,22 +204,18 @@ describe('Notices - Setup - Renewal Invitation Notifications presenter', () => {
       })
 
       describe('when the notification is an email', () => {
-        describe('and there is only one licence ref', () => {
-          it('returns the expected "templateId"', () => {
-            const result = RenewalInvitationNotificationsPresenter.go(noticeData, recipients, noticeId)
+        it('returns the expected "templateId"', () => {
+          const result = RenewalInvitationNotificationsPresenter.go(noticeData, recipients, noticeId)
 
-            expect(result[0].templateId).to.equal(NOTIFY_TEMPLATES.renewalInvitations.adhoc.email['single licence'])
-          })
+          expect(result[0].templateId).to.equal(NOTIFY_TEMPLATES.renewalInvitations.adhoc.email['single licence'])
         })
       })
 
       describe('when the notification is a letter', () => {
-        describe('and there is only one licence ref', () => {
-          it('returns the expected "templateId"', () => {
-            const result = RenewalInvitationNotificationsPresenter.go(noticeData, recipients, noticeId)
+        it('returns the expected "templateId"', () => {
+          const result = RenewalInvitationNotificationsPresenter.go(noticeData, recipients, noticeId)
 
-            expect(result[1].templateId).to.equal(NOTIFY_TEMPLATES.renewalInvitations.adhoc.letter['single licence'])
-          })
+          expect(result[1].templateId).to.equal(NOTIFY_TEMPLATES.renewalInvitations.adhoc.letter['single licence'])
         })
       })
     })

--- a/test/presenters/notices/setup/renewal-invitation-notifications.presenter.test.js
+++ b/test/presenters/notices/setup/renewal-invitation-notifications.presenter.test.js
@@ -204,18 +204,6 @@ describe('Notices - Setup - Renewal Invitation Notifications presenter', () => {
       })
 
       describe('when the notification is an email', () => {
-        describe('and there are multiple licence refs', () => {
-          beforeEach(() => {
-            recipients[0].licence_refs.push(generateLicenceRef())
-          })
-
-          it('returns the expected "templateId"', () => {
-            const result = RenewalInvitationNotificationsPresenter.go(noticeData, recipients, noticeId)
-
-            expect(result[0].templateId).to.equal(NOTIFY_TEMPLATES.renewalInvitations.adhoc.email['multiple licences'])
-          })
-        })
-
         describe('and there is only one licence ref', () => {
           it('returns the expected "templateId"', () => {
             const result = RenewalInvitationNotificationsPresenter.go(noticeData, recipients, noticeId)
@@ -226,18 +214,6 @@ describe('Notices - Setup - Renewal Invitation Notifications presenter', () => {
       })
 
       describe('when the notification is a letter', () => {
-        describe('and there are multiple licence refs', () => {
-          beforeEach(() => {
-            recipients[1].licence_refs.push(generateLicenceRef())
-          })
-
-          it('returns the expected "templateId"', () => {
-            const result = RenewalInvitationNotificationsPresenter.go(noticeData, recipients, noticeId)
-
-            expect(result[1].templateId).to.equal(NOTIFY_TEMPLATES.renewalInvitations.adhoc.letter['multiple licences'])
-          })
-        })
-
         describe('and there is only one licence ref', () => {
           it('returns the expected "templateId"', () => {
             const result = RenewalInvitationNotificationsPresenter.go(noticeData, recipients, noticeId)

--- a/test/presenters/notices/setup/renewal-invitation-notifications.presenter.test.js
+++ b/test/presenters/notices/setup/renewal-invitation-notifications.presenter.test.js
@@ -234,9 +234,7 @@ describe('Notices - Setup - Renewal Invitation Notifications presenter', () => {
           it('returns the expected "templateId"', () => {
             const result = RenewalInvitationNotificationsPresenter.go(noticeData, recipients, noticeId)
 
-            expect(result[1].templateId).to.equal(
-              NOTIFY_TEMPLATES.renewalInvitations.adhoc.letter['multiple licences']
-            )
+            expect(result[1].templateId).to.equal(NOTIFY_TEMPLATES.renewalInvitations.adhoc.letter['multiple licences'])
           })
         })
 

--- a/test/presenters/notices/setup/renewal-invitation-notifications.presenter.test.js
+++ b/test/presenters/notices/setup/renewal-invitation-notifications.presenter.test.js
@@ -197,5 +197,57 @@ describe('Notices - Setup - Renewal Invitation Notifications presenter', () => {
         })
       })
     })
+
+    describe('when the journey is "adhoc"', () => {
+      beforeEach(() => {
+        noticeData.journey = 'adhoc'
+      })
+
+      describe('when the notification is an email', () => {
+        describe('and there are multiple licence refs', () => {
+          beforeEach(() => {
+            recipients[0].licence_refs.push(generateLicenceRef())
+          })
+
+          it('returns the expected "templateId"', () => {
+            const result = RenewalInvitationNotificationsPresenter.go(noticeData, recipients, noticeId)
+
+            expect(result[0].templateId).to.equal(NOTIFY_TEMPLATES.renewalInvitations.adhoc.email['multiple licences'])
+          })
+        })
+
+        describe('and there is only one licence ref', () => {
+          it('returns the expected "templateId"', () => {
+            const result = RenewalInvitationNotificationsPresenter.go(noticeData, recipients, noticeId)
+
+            expect(result[0].templateId).to.equal(NOTIFY_TEMPLATES.renewalInvitations.adhoc.email['single licence'])
+          })
+        })
+      })
+
+      describe('when the notification is a letter', () => {
+        describe('and there are multiple licence refs', () => {
+          beforeEach(() => {
+            recipients[1].licence_refs.push(generateLicenceRef())
+          })
+
+          it('returns the expected "templateId"', () => {
+            const result = RenewalInvitationNotificationsPresenter.go(noticeData, recipients, noticeId)
+
+            expect(result[1].templateId).to.equal(
+              NOTIFY_TEMPLATES.renewalInvitations.adhoc.letter['multiple licences']
+            )
+          })
+        })
+
+        describe('and there is only one licence ref', () => {
+          it('returns the expected "templateId"', () => {
+            const result = RenewalInvitationNotificationsPresenter.go(noticeData, recipients, noticeId)
+
+            expect(result[1].templateId).to.equal(NOTIFY_TEMPLATES.renewalInvitations.adhoc.letter['single licence'])
+          })
+        })
+      })
+    })
   })
 })

--- a/test/services/notices/setup/fetch-recipients.service.test.js
+++ b/test/services/notices/setup/fetch-recipients.service.test.js
@@ -15,6 +15,7 @@ const { NoticeJourney, NoticeType } = require('../../../../app/lib/static-lookup
 // Things we need to stub
 const FetchAbstractionAlertRecipientsService = require('../../../../app/services/notices/setup/abstraction-alerts/fetch-abstraction-alert-recipients.service.js')
 const FetchPaperReturnsRecipientsService = require('../../../../app/services/notices/setup/returns-notice/fetch-paper-returns-recipients.service.js')
+const FetchRenewalInvitationRecipientsService = require('../../../../app/services/notices/setup/renewal-notice/fetch-renewal-invitation-recipients.service.js')
 const FetchReturnsInvitationRecipientsService = require('../../../../app/services/notices/setup/returns-notice/fetch-returns-invitation-recipients.service.js')
 const FetchReturnsReminderRecipientsService = require('../../../../app/services/notices/setup/returns-notice/fetch-returns-reminder-recipients.service.js')
 
@@ -25,10 +26,19 @@ describe('Notices - Setup - Fetch Recipients service', () => {
   let download
   let fetchAbstractionAlertRecipientsStub
   let fetchPaperReturnsRecipientsStub
+  let fetchRenewalInvitationRecipientsStub
   let fetchReturnsInvitationRecipientsStub
   let fetchReturnsReminderRecipientsStub
   let recipients
   let session
+
+  beforeEach(() => {
+    fetchAbstractionAlertRecipientsStub = Sinon.stub(FetchAbstractionAlertRecipientsService, 'go').resolves()
+    fetchPaperReturnsRecipientsStub = Sinon.stub(FetchPaperReturnsRecipientsService, 'go').resolves()
+    fetchRenewalInvitationRecipientsStub = Sinon.stub(FetchRenewalInvitationRecipientsService, 'go').resolves()
+    fetchReturnsInvitationRecipientsStub = Sinon.stub(FetchReturnsInvitationRecipientsService, 'go').resolves()
+    fetchReturnsReminderRecipientsStub = Sinon.stub(FetchReturnsReminderRecipientsService, 'go').resolves()
+  })
 
   afterEach(() => {
     Sinon.restore()
@@ -42,19 +52,13 @@ describe('Notices - Setup - Fetch Recipients service', () => {
       }
 
       download = false
-
-      fetchPaperReturnsRecipientsStub = Sinon.stub(FetchPaperReturnsRecipientsService, 'go').resolves()
-      fetchReturnsInvitationRecipientsStub = Sinon.stub(FetchReturnsInvitationRecipientsService, 'go').resolves()
-      fetchReturnsReminderRecipientsStub = Sinon.stub(FetchReturnsReminderRecipientsService, 'go').resolves()
     })
 
     describe('and fetching recipients for checking or sending', () => {
       beforeEach(() => {
         recipients = [RecipientsFixture.alertNoticePrimaryUser(), RecipientsFixture.alertNoticeAdditionalContact()]
 
-        fetchAbstractionAlertRecipientsStub = Sinon.stub(FetchAbstractionAlertRecipientsService, 'go').resolves(
-          recipients
-        )
+        fetchAbstractionAlertRecipientsStub.resolves(recipients)
       })
 
       it('determines the appropriate fetch service to call and returns the recipient data', async () => {
@@ -63,6 +67,7 @@ describe('Notices - Setup - Fetch Recipients service', () => {
         expect(fetchAbstractionAlertRecipientsStub.calledOnceWith(session)).to.be.true()
 
         expect(fetchReturnsInvitationRecipientsStub.called).to.be.false()
+        expect(fetchRenewalInvitationRecipientsStub.called).to.be.false()
         expect(fetchPaperReturnsRecipientsStub.called).to.be.false()
         expect(fetchReturnsReminderRecipientsStub.called).to.be.false()
 
@@ -77,10 +82,6 @@ describe('Notices - Setup - Fetch Recipients service', () => {
         journey: NoticeJourney.ADHOC,
         noticeType: NoticeType.PAPER_RETURN
       }
-
-      fetchAbstractionAlertRecipientsStub = Sinon.stub(FetchAbstractionAlertRecipientsService, 'go').resolves()
-      fetchReturnsInvitationRecipientsStub = Sinon.stub(FetchReturnsInvitationRecipientsService, 'go').resolves()
-      fetchReturnsReminderRecipientsStub = Sinon.stub(FetchReturnsReminderRecipientsService, 'go').resolves()
     })
 
     describe('and fetching recipients for checking or sending', () => {
@@ -92,7 +93,7 @@ describe('Notices - Setup - Fetch Recipients service', () => {
           RecipientsFixture.returnsNoticeReturnsAgent(download)
         ]
 
-        fetchPaperReturnsRecipientsStub = Sinon.stub(FetchPaperReturnsRecipientsService, 'go').resolves(recipients)
+        fetchPaperReturnsRecipientsStub.resolves(recipients)
       })
 
       it('determines the appropriate fetch service to call and returns the recipient data', async () => {
@@ -101,6 +102,7 @@ describe('Notices - Setup - Fetch Recipients service', () => {
         expect(fetchPaperReturnsRecipientsStub.calledOnceWith(session, download)).to.be.true()
 
         expect(fetchAbstractionAlertRecipientsStub.called).to.be.false()
+        expect(fetchRenewalInvitationRecipientsStub.called).to.be.false()
         expect(fetchReturnsInvitationRecipientsStub.called).to.be.false()
         expect(fetchReturnsReminderRecipientsStub.called).to.be.false()
 
@@ -117,7 +119,7 @@ describe('Notices - Setup - Fetch Recipients service', () => {
           RecipientsFixture.returnsNoticeReturnsAgent(download)
         ]
 
-        fetchPaperReturnsRecipientsStub = Sinon.stub(FetchPaperReturnsRecipientsService, 'go').resolves(recipients)
+        fetchPaperReturnsRecipientsStub.resolves(recipients)
       })
 
       it('determines the appropriate fetch service to call and returns the recipient data', async () => {
@@ -126,6 +128,39 @@ describe('Notices - Setup - Fetch Recipients service', () => {
         expect(fetchPaperReturnsRecipientsStub.calledOnceWith(session, download)).to.be.true()
 
         expect(fetchAbstractionAlertRecipientsStub.called).to.be.false()
+        expect(fetchRenewalInvitationRecipientsStub.called).to.be.false()
+        expect(fetchReturnsInvitationRecipientsStub.called).to.be.false()
+        expect(fetchReturnsReminderRecipientsStub.called).to.be.false()
+
+        expect(results).to.equal(recipients)
+      })
+    })
+  })
+
+  describe('when setting up a renewal invitation', () => {
+    beforeEach(() => {
+      session = {
+        journey: NoticeJourney.ADHOC,
+        noticeType: NoticeType.RENEWAL_INVITATIONS
+      }
+
+      download = false
+    })
+
+    describe('and fetching recipients for checking or sending', () => {
+      beforeEach(() => {
+        recipients = [RecipientsFixture.renewalInvitationPrimaryUser()]
+
+        fetchRenewalInvitationRecipientsStub.resolves(recipients)
+      })
+
+      it('determines the appropriate fetch service to call and returns the recipient data', async () => {
+        const results = await FetchRecipientsService.go(session, download)
+
+        expect(fetchRenewalInvitationRecipientsStub.calledOnceWith(session)).to.be.true()
+
+        expect(fetchAbstractionAlertRecipientsStub.called).to.be.false()
+        expect(fetchPaperReturnsRecipientsStub.called).to.be.false()
         expect(fetchReturnsInvitationRecipientsStub.called).to.be.false()
         expect(fetchReturnsReminderRecipientsStub.called).to.be.false()
 
@@ -140,10 +175,6 @@ describe('Notices - Setup - Fetch Recipients service', () => {
         journey: NoticeJourney.ADHOC,
         noticeType: NoticeType.INVITATIONS
       }
-
-      fetchAbstractionAlertRecipientsStub = Sinon.stub(FetchAbstractionAlertRecipientsService, 'go').resolves()
-      fetchPaperReturnsRecipientsStub = Sinon.stub(FetchPaperReturnsRecipientsService, 'go').resolves()
-      fetchReturnsReminderRecipientsStub = Sinon.stub(FetchReturnsReminderRecipientsService, 'go').resolves()
     })
 
     describe('and fetching recipients for checking or sending', () => {
@@ -155,9 +186,7 @@ describe('Notices - Setup - Fetch Recipients service', () => {
           RecipientsFixture.returnsNoticeReturnsAgent(download)
         ]
 
-        fetchReturnsInvitationRecipientsStub = Sinon.stub(FetchReturnsInvitationRecipientsService, 'go').resolves(
-          recipients
-        )
+        fetchReturnsInvitationRecipientsStub.resolves(recipients)
       })
 
       it('determines the appropriate fetch service to call and returns the recipient data', async () => {
@@ -167,6 +196,7 @@ describe('Notices - Setup - Fetch Recipients service', () => {
 
         expect(fetchAbstractionAlertRecipientsStub.called).to.be.false()
         expect(fetchPaperReturnsRecipientsStub.called).to.be.false()
+        expect(fetchRenewalInvitationRecipientsStub.called).to.be.false()
         expect(fetchReturnsReminderRecipientsStub.called).to.be.false()
 
         expect(results).to.equal(recipients)
@@ -182,9 +212,7 @@ describe('Notices - Setup - Fetch Recipients service', () => {
           RecipientsFixture.returnsNoticeReturnsAgent(download)
         ]
 
-        fetchReturnsInvitationRecipientsStub = Sinon.stub(FetchReturnsInvitationRecipientsService, 'go').resolves(
-          recipients
-        )
+        fetchReturnsInvitationRecipientsStub.resolves(recipients)
       })
 
       it('determines the appropriate fetch service to call and returns the recipient data', async () => {
@@ -194,6 +222,7 @@ describe('Notices - Setup - Fetch Recipients service', () => {
 
         expect(fetchAbstractionAlertRecipientsStub.called).to.be.false()
         expect(fetchPaperReturnsRecipientsStub.called).to.be.false()
+        expect(fetchRenewalInvitationRecipientsStub.called).to.be.false()
         expect(fetchReturnsReminderRecipientsStub.called).to.be.false()
 
         expect(results).to.equal(recipients)
@@ -207,10 +236,6 @@ describe('Notices - Setup - Fetch Recipients service', () => {
         journey: NoticeJourney.STANDARD,
         noticeType: NoticeType.REMINDERS
       }
-
-      fetchAbstractionAlertRecipientsStub = Sinon.stub(FetchAbstractionAlertRecipientsService, 'go').resolves()
-      fetchReturnsInvitationRecipientsStub = Sinon.stub(FetchReturnsInvitationRecipientsService, 'go').resolves()
-      fetchPaperReturnsRecipientsStub = Sinon.stub(FetchPaperReturnsRecipientsService, 'go').resolves()
     })
 
     describe('and fetching recipients for checking or sending', () => {
@@ -222,9 +247,7 @@ describe('Notices - Setup - Fetch Recipients service', () => {
           RecipientsFixture.returnsNoticeReturnsAgent(download)
         ]
 
-        fetchReturnsReminderRecipientsStub = Sinon.stub(FetchReturnsReminderRecipientsService, 'go').resolves(
-          recipients
-        )
+        fetchReturnsReminderRecipientsStub.resolves(recipients)
       })
 
       it('determines the appropriate fetch service to call and returns the recipient data', async () => {
@@ -233,8 +256,9 @@ describe('Notices - Setup - Fetch Recipients service', () => {
         expect(fetchReturnsReminderRecipientsStub.calledOnceWith(session, download)).to.be.true()
 
         expect(fetchAbstractionAlertRecipientsStub.called).to.be.false()
-        expect(fetchReturnsInvitationRecipientsStub.called).to.be.false()
         expect(fetchPaperReturnsRecipientsStub.called).to.be.false()
+        expect(fetchRenewalInvitationRecipientsStub.called).to.be.false()
+        expect(fetchReturnsInvitationRecipientsStub.called).to.be.false()
 
         expect(results).to.equal(recipients)
       })
@@ -249,9 +273,7 @@ describe('Notices - Setup - Fetch Recipients service', () => {
           RecipientsFixture.returnsNoticeReturnsAgent(download)
         ]
 
-        fetchReturnsReminderRecipientsStub = Sinon.stub(FetchReturnsReminderRecipientsService, 'go').resolves(
-          recipients
-        )
+        fetchReturnsReminderRecipientsStub.resolves(recipients)
       })
 
       it('determines the appropriate fetch service to call and returns the recipient data', async () => {
@@ -260,8 +282,9 @@ describe('Notices - Setup - Fetch Recipients service', () => {
         expect(fetchReturnsReminderRecipientsStub.calledOnceWith(session, download)).to.be.true()
 
         expect(fetchAbstractionAlertRecipientsStub.called).to.be.false()
-        expect(fetchReturnsInvitationRecipientsStub.called).to.be.false()
         expect(fetchPaperReturnsRecipientsStub.called).to.be.false()
+        expect(fetchRenewalInvitationRecipientsStub.called).to.be.false()
+        expect(fetchReturnsInvitationRecipientsStub.called).to.be.false()
 
         expect(results).to.equal(recipients)
       })

--- a/test/services/notices/setup/renewal-notice/fetch-renewal-invitation-recipients.service.test.js
+++ b/test/services/notices/setup/renewal-notice/fetch-renewal-invitation-recipients.service.test.js
@@ -1,0 +1,55 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, before, after } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Test helpers
+const RecipientScenariosSeeder = require('../../../../support/seeders/recipient-scenarios.seeder.js')
+
+// Thing under test
+const FetchRenewalInvitationRecipientsService = require('../../../../../app/services/notices/setup/renewal-notice/fetch-renewal-invitation-recipients.service.js')
+
+describe('Notices - Setup - Renewal Notice - Fetch Renewal Invitation Recipients service', () => {
+  let scenarios
+
+  before(async () => {
+    scenarios = {}
+
+    scenarios.licenceHolder = await RecipientScenariosSeeder.licenceHolderOnly()
+    scenarios.primaryUser = await RecipientScenariosSeeder.primaryUserOnly()
+  })
+
+  after(async () => {
+    await RecipientScenariosSeeder.clean(scenarios)
+  })
+
+  describe('when the licence is unregistered (no primary user)', () => {
+    it('returns the licence holder as the recipient', async () => {
+      const licenceRef = scenarios.licenceHolder.licenceHolderRecipient.licenceRefs[0]
+
+      const results = await FetchRenewalInvitationRecipientsService.go({ licenceRef })
+
+      const expectedResult = RecipientScenariosSeeder.transformToSendingResults(scenarios.licenceHolder)
+
+      expect(results).to.equal(expectedResult)
+    })
+  })
+
+  describe('when the licence is registered (has a primary user)', () => {
+    it('returns the primary user as the recipient (not the licence holder)', async () => {
+      const licenceRef = scenarios.primaryUser.primaryUserRecipient.licenceRefs[0]
+
+      const results = await FetchRenewalInvitationRecipientsService.go({ licenceRef })
+
+      const expectedResult = RecipientScenariosSeeder.transformToSendingResults({
+        primaryUserRecipient: scenarios.primaryUser.primaryUserRecipient
+      })
+
+      expect(results).to.equal(expectedResult)
+    })
+  })
+})

--- a/test/services/notices/setup/view-preview.service.test.js
+++ b/test/services/notices/setup/view-preview.service.test.js
@@ -222,4 +222,70 @@ describe('Notices - Setup - View Preview service', () => {
       })
     })
   })
+
+  describe('when previewing a renewal invitation notification', () => {
+    beforeEach(() => {
+      recipients = [RecipientsFixture.renewalInvitationPrimaryUser()]
+
+      const referenceCode = generateNoticeReferenceCode('REIN-')
+      const sessionId = generateUUID()
+
+      sessionData = {
+        id: sessionId,
+        checkPageVisited: true,
+        expiryDate: '2025-09-30T00:00:00.000Z',
+        journey: 'adhoc',
+        licenceRef: recipients[0].licence_refs[0],
+        name: 'Renewals: invitation',
+        noticeType: 'renewalInvitations',
+        notificationType: 'Renewals invitation',
+        referenceCode,
+        renewalDate: '2025-07-31T00:00:00.000Z',
+        subType: 'renewalInvitation'
+      }
+
+      session = SessionModelStub.build(Sinon, sessionData)
+
+      Sinon.stub(FetchSessionDal, 'go').resolves(session)
+
+      licenceMonitoringStationId = null
+
+      Sinon.stub(FetchRecipientsService, 'go').resolves([{ ...recipients[0] }])
+
+      // The Preview Presenter uses Notify to generate the template preview contents, so we need to stub the request.
+      Sinon.stub(GeneratePreviewRequest, 'send').resolves({
+        succeeded: true,
+        response: {
+          statusCode: HTTP_STATUS_OK,
+          body: {
+            body: 'Dear licence holder,\r\n',
+            html: '"<p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">Dear licence holder,</p>',
+            id: '53c34f21-4f2e-43f7-97c6-7a7828079665',
+            postage: null,
+            subject: 'Your water abstraction licence is due to expire',
+            type: 'email',
+            version: 40
+          }
+        }
+      })
+    })
+
+    it('returns page data for the view', async () => {
+      const result = await ViewPreviewService.go(session.id, recipients[0].contact_hash_id, licenceMonitoringStationId)
+
+      expect(result).to.equal({
+        activeNavBar: 'notices',
+        address: recipients[0].email,
+        backLink: {
+          href: `/system/notices/setup/${session.id}/check`,
+          text: 'Back'
+        },
+        contents: 'Dear licence holder,\r\n',
+        messageType: 'email',
+        pageTitle: 'Renewal invitation',
+        pageTitleCaption: `Notice ${session.referenceCode}`,
+        refreshPageLink: `/system/notices/setup/${session.id}/preview/${recipients[0].contact_hash_id}`
+      })
+    })
+  })
 })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5646

This change adds the renewal invitation to the check/submit check for notices.