### PR TITLE
Add renewal invitation ad-hoc messageRef

### DIFF
--- a/app/presenters/notices/setup/renewal-invitation-notice-notifications.presenter.js
+++ b/app/presenters/notices/setup/renewal-invitation-notice-notifications.presenter.js
@@ -9,6 +9,11 @@ const NotifyAddressPresenter = require('./notify-address.presenter.js')
 const { NOTIFY_TEMPLATES } = require('../../../lib/notify-templates.lib.js')
 const { formatLongDate } = require('../../base.presenter.js')
 
+const MESSAGE_REFS = {
+  adhoc: 'renewal invitation ad-hoc',
+  standard: 'renewal invitation'
+}
+
 /**
  * Formats recipients into notifications for a renewal invitation
  *
@@ -46,7 +51,7 @@ function _email(recipient, noticeId, noticeData) {
     eventId: noticeId,
     licences: recipient.licence_refs,
     messageType,
-    messageRef: 'renewal invitation',
+    messageRef: MESSAGE_REFS[journey],
     personalisation: {
       ..._personalisation(recipient, noticeData)
     },
@@ -67,7 +72,7 @@ function _letter(recipient, noticeId, noticeData) {
     eventId: noticeId,
     licences: recipient.licence_refs,
     messageType,
-    messageRef: 'renewal invitation',
+    messageRef: MESSAGE_REFS[journey],
     personalisation: {
       ...address,
       // NOTE: Address line 1 is always set to the recipient's name

--- a/test/presenters/notices/setup/renewal-invitation-notifications.presenter.test.js
+++ b/test/presenters/notices/setup/renewal-invitation-notifications.presenter.test.js
@@ -75,6 +75,48 @@ describe('Notices - Setup - Renewal Invitation Notifications presenter', () => {
     ])
   })
 
+  describe('the "messageRef" property', () => {
+    describe('when the journey is "standard"', () => {
+      describe('and the notification is an email', () => {
+        it('returns the correct "messageRef"', () => {
+          const result = RenewalInvitationNotificationsPresenter.go(noticeData, recipients, noticeId)
+
+          expect(result[0].messageRef).to.equal('renewal invitation')
+        })
+      })
+
+      describe('when the notification is a letter', () => {
+        it('returns the correct "messageRef"', () => {
+          const result = RenewalInvitationNotificationsPresenter.go(noticeData, recipients, noticeId)
+
+          expect(result[1].messageRef).to.equal('renewal invitation')
+        })
+      })
+    })
+
+    describe('when the journey is "adhoc"', () => {
+      beforeEach(() => {
+        noticeData.journey = 'adhoc'
+      })
+
+      describe('and the notification is an email', () => {
+        it('returns the correct "messageRef"', () => {
+          const result = RenewalInvitationNotificationsPresenter.go(noticeData, recipients, noticeId)
+
+          expect(result[0].messageRef).to.equal('renewal invitation ad-hoc')
+        })
+      })
+
+      describe('when the notification is a letter', () => {
+        it('returns the correct "messageRef"', () => {
+          const result = RenewalInvitationNotificationsPresenter.go(noticeData, recipients, noticeId)
+
+          expect(result[1].messageRef).to.equal('renewal invitation ad-hoc')
+        })
+      })
+    })
+  })
+
   describe('the "personalisation" property', () => {
     describe('when the notification is an email', () => {
       describe('and there are multiple licence refs', () => {

--- a/test/services/notices/setup/view-preview.service.test.js
+++ b/test/services/notices/setup/view-preview.service.test.js
@@ -282,7 +282,7 @@ describe('Notices - Setup - View Preview service', () => {
         },
         contents: 'Dear licence holder,\r\n',
         messageType: 'email',
-        pageTitle: 'Renewal invitation',
+        pageTitle: 'Renewal invitation ad-hoc',
         pageTitleCaption: `Notice ${session.referenceCode}`,
         refreshPageLink: `/system/notices/setup/${session.id}/preview/${recipients[0].contact_hash_id}`
       })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5650

This change adds the 'ad-hoc' suffix to the message ref.