### PR TITLE
Fix adhoc renewal invitations validation

### DIFF
--- a/app/presenters/notices/index-notices.presenter.js
+++ b/app/presenters/notices/index-notices.presenter.js
@@ -31,7 +31,11 @@ function go(notices, auth) {
 function _links(scope) {
   const links = {}
 
-  if (scope.includes('returns') || scope.includes('bulk_return_notifications')) {
+  if (
+    scope.includes('returns') ||
+    scope.includes('bulk_return_notifications') ||
+    scope.includes('renewal_notifications')
+  ) {
     links.adhoc = {
       text: 'Create an ad-hoc notice',
       href: '/system/notices/setup/adhoc'

--- a/app/services/notices/setup/renewal-notice/process-licence-submission.service.js
+++ b/app/services/notices/setup/renewal-notice/process-licence-submission.service.js
@@ -21,7 +21,7 @@ const { formatValidationResult } = require('../../../../presenters/base.presente
  * @returns {Promise<object>} The validation result (null if valid)
  */
 async function go(payload) {
-  const licenceRenewal = await FetchRenewalLicenceDal.go(payload.licenceRef)
+  const licenceRenewal = await _licenceRenewal(payload)
 
   const validationResult = _validate(payload, licenceRenewal)
 
@@ -40,6 +40,14 @@ function _additionalSessionData(licenceRenewal) {
   }
 
   return {}
+}
+
+async function _licenceRenewal(payload) {
+  if (!payload.licenceRef) {
+    return null
+  }
+
+  return await FetchRenewalLicenceDal.go(payload.licenceRef)
 }
 
 function _validate(payload, licenceRenewal) {

--- a/app/services/notices/setup/renewal-notice/process-licence-submission.service.js
+++ b/app/services/notices/setup/renewal-notice/process-licence-submission.service.js
@@ -47,7 +47,7 @@ async function _licenceRenewal(payload) {
     return null
   }
 
-  return await FetchRenewalLicenceDal.go(payload.licenceRef)
+  return FetchRenewalLicenceDal.go(payload.licenceRef)
 }
 
 function _validate(payload, licenceRenewal) {

--- a/test/presenters/notices/index-notices.presenter.test.js
+++ b/test/presenters/notices/index-notices.presenter.test.js
@@ -167,7 +167,7 @@ describe('Notices - Index Notices presenter', () => {
   describe('the "links" property', () => {
     describe('when the user has permissions', () => {
       beforeEach(() => {
-        auth.credentials.scope = ['bulk_return_notifications', 'returns']
+        auth.credentials.scope = ['bulk_return_notifications', 'returns', 'renewal_notifications']
       })
 
       it('returns all of the links', () => {

--- a/test/presenters/notices/index-notices.presenter.test.js
+++ b/test/presenters/notices/index-notices.presenter.test.js
@@ -165,7 +165,7 @@ describe('Notices - Index Notices presenter', () => {
   })
 
   describe('the "links" property', () => {
-    describe('when the user has both permissions', () => {
+    describe('when the user has permissions', () => {
       beforeEach(() => {
         auth.credentials.scope = ['bulk_return_notifications', 'returns']
       })
@@ -225,6 +225,23 @@ describe('Notices - Index Notices presenter', () => {
       })
 
       it('returns only the "adhoc" link', () => {
+        const result = IndexNoticesPresenter.go(notices, auth)
+
+        expect(result.links).to.equal({
+          adhoc: {
+            href: '/system/notices/setup/adhoc',
+            text: 'Create an ad-hoc notice'
+          }
+        })
+      })
+    })
+
+    describe('when the user has the "renewal_notifications" permission', () => {
+      beforeEach(() => {
+        auth.credentials.scope = ['renewal_notifications']
+      })
+
+      it('returns all of the links', () => {
         const result = IndexNoticesPresenter.go(notices, auth)
 
         expect(result.links).to.equal({

--- a/test/services/notices/setup/renewal-notice/process-licence-submission.service.test.js
+++ b/test/services/notices/setup/renewal-notice/process-licence-submission.service.test.js
@@ -65,8 +65,6 @@ describe('Notices - Setup - Renewal Notice - Process Renewals Notice Licence Sub
         describe('because no licence ref was entered', () => {
           beforeEach(() => {
             payload = {}
-
-            fetchRenewalLicenceDalStub.resolves(undefined)
           })
 
           it('returns a validation error', async () => {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5646

When implementing the adhoc renewal invitation, we missed a validation when the licence ref was not provided; this was causing a service error.

This change updates the adhoc renewal invitations to guard against no licence ref provided.

We also missed a permission issue where the 'Create an ad-hoc notice' was not showing for users with renewal-based permissions. This has also been fixed.