### PR TITLE
Fix notice-type options for ad-hoc notices 

### DIFF
--- a/app/presenters/notices/setup/notice-type.presenter.js
+++ b/app/presenters/notices/setup/notice-type.presenter.js
@@ -56,11 +56,13 @@ function _options(noticeType, journey, auth) {
   const options = []
 
   if (journey === NoticeJourney.ADHOC) {
-    options.push({
-      checked: noticeType === NoticeType.PAPER_RETURN,
-      value: NoticeType.PAPER_RETURN,
-      text: 'Paper return'
-    })
+    if (scope.includes('bulk_return_notifications')) {
+      options.push({
+        checked: noticeType === NoticeType.PAPER_RETURN,
+        value: NoticeType.PAPER_RETURN,
+        text: 'Paper return'
+      })
+    }
 
     if (scope.includes('renewal_notifications')) {
       options.push({

--- a/test/presenters/notices/setup/notice-type.presenter.test.js
+++ b/test/presenters/notices/setup/notice-type.presenter.test.js
@@ -254,144 +254,111 @@ describe('Notice - Setup - Notice Type Presenter', () => {
         })
 
         describe('and the journey is the "adhoc" journey', () => {
-          it('returns page data for the view', () => {
-            const result = NoticeTypePresenter.go(session, auth)
+          describe('and the user has both the "bulk_return_notifications" and "renewal_notifications" scopes', () => {
+            it('returns both "returns" and "renewal" based notice types', () => {
+              const result = NoticeTypePresenter.go(session, auth)
 
-            expect(result).to.equal({
-              backLink: {
-                href: '/system/notices',
-                text: 'Back'
-              },
-              options: [
-                {
-                  checked: false,
-                  text: 'Paper return',
-                  value: 'paperReturn'
+              expect(result).to.equal({
+                backLink: {
+                  href: '/system/notices',
+                  text: 'Back'
                 },
-                {
-                  checked: false,
-                  text: 'Renewals invitation',
-                  value: 'renewalInvitations'
-                },
-                {
-                  checked: false,
-                  text: 'Returns invitation',
-                  value: 'invitations'
-                },
-                {
-                  checked: false,
-                  text: 'Returns reminder',
-                  value: 'reminders'
-                }
-              ],
-              pageTitle: 'Select the notice type'
+                options: [
+                  {
+                    checked: false,
+                    text: 'Paper return',
+                    value: 'paperReturn'
+                  },
+                  {
+                    checked: false,
+                    text: 'Renewals invitation',
+                    value: 'renewalInvitations'
+                  },
+                  {
+                    checked: false,
+                    text: 'Returns invitation',
+                    value: 'invitations'
+                  },
+                  {
+                    checked: false,
+                    text: 'Returns reminder',
+                    value: 'reminders'
+                  }
+                ],
+                pageTitle: 'Select the notice type'
+              })
             })
           })
 
-          describe('and scope includes', () => {
-            describe('"bulk_return_notifications"', () => {
-              describe('and the user has the "bulk_return_notifications" scope', () => {
-                beforeEach(() => {
-                  auth.credentials.scope = ['bulk_return_notifications']
-                })
-
-                it('returns page data for the view', () => {
-                  const result = NoticeTypePresenter.go(session, auth)
-
-                  expect(result).to.equal({
-                    backLink: {
-                      href: '/system/notices',
-                      text: 'Back'
-                    },
-                    options: [
-                      {
-                        checked: false,
-                        text: 'Paper return',
-                        value: 'paperReturn'
-                      },
-                      {
-                        checked: false,
-                        text: 'Returns invitation',
-                        value: 'invitations'
-                      },
-                      {
-                        checked: false,
-                        text: 'Returns reminder',
-                        value: 'reminders'
-                      }
-                    ],
-                    pageTitle: 'Select the notice type'
-                  })
-                })
-              })
-
-              describe('and the user does not have the "bulk_return_notifications" scope', () => {
-                beforeEach(() => {
-                  auth.credentials.scope = ['returns']
-                })
-
-                it('returns the appropriate notice option', () => {
-                  const result = NoticeTypePresenter.go(session, auth)
-
-                  expect(result.options).to.equal([
-                    {
-                      checked: false,
-                      text: 'Paper return',
-                      value: 'paperReturn'
-                    }
-                  ])
-                })
-              })
+          describe('and the user only has the "bulk_return_notifications" scope', () => {
+            beforeEach(() => {
+              auth.credentials.scope = ['bulk_return_notifications']
             })
 
-            describe('"renewal_notifications"', () => {
-              describe('and the user has the "renewal_notifications" scope', () => {
-                beforeEach(() => {
-                  auth.credentials.scope = ['renewal_notifications']
-                })
+            it('returns only "returns" based notice types', () => {
+              const result = NoticeTypePresenter.go(session, auth)
 
-                it('returns page data for the view', () => {
-                  const result = NoticeTypePresenter.go(session, auth)
-
-                  expect(result).to.equal({
-                    backLink: {
-                      href: '/system/notices',
-                      text: 'Back'
-                    },
-                    options: [
-                      {
-                        checked: false,
-                        text: 'Paper return',
-                        value: 'paperReturn'
-                      },
-                      {
-                        checked: false,
-                        text: 'Renewals invitation',
-                        value: 'renewalInvitations'
-                      }
-                    ],
-                    pageTitle: 'Select the notice type'
-                  })
-                })
+              expect(result).to.equal({
+                backLink: {
+                  href: '/system/notices',
+                  text: 'Back'
+                },
+                options: [
+                  {
+                    checked: false,
+                    text: 'Paper return',
+                    value: 'paperReturn'
+                  },
+                  {
+                    checked: false,
+                    text: 'Returns invitation',
+                    value: 'invitations'
+                  },
+                  {
+                    checked: false,
+                    text: 'Returns reminder',
+                    value: 'reminders'
+                  }
+                ],
+                pageTitle: 'Select the notice type'
               })
+            })
+          })
 
-              describe('and the user does not have the "renewal_notifications" scope', () => {
-                beforeEach(() => {
-                  auth.credentials.scope = ['returns']
-                })
+          describe('and the user only has the "renewal_notifications" scope', () => {
+            beforeEach(() => {
+              auth.credentials.scope = ['renewal_notifications']
+            })
 
-                it('returns the appropriate notice option', () => {
-                  const result = NoticeTypePresenter.go(session, auth)
+            it('returns only "renewal" based notice types', () => {
+              const result = NoticeTypePresenter.go(session, auth)
 
-                  expect(result.options).to.equal([
-                    {
-                      checked: false,
-                      text: 'Paper return',
-                      value: 'paperReturn'
-                    }
-                  ])
-                })
+              expect(result).to.equal({
+                backLink: {
+                  href: '/system/notices',
+                  text: 'Back'
+                },
+                options: [
+                  {
+                    checked: false,
+                    text: 'Renewals invitation',
+                    value: 'renewalInvitations'
+                  }
+                ],
+                pageTitle: 'Select the notice type'
               })
+            })
+          })
+
+          describe('and the user does not have either the "bulk_return_notifications" or "renewal_notifications" scope', () => {
+            beforeEach(() => {
+              auth.credentials.scope = ['returns']
+            })
+
+            it('returns no options', () => {
+              const result = NoticeTypePresenter.go(session, auth)
+
+              expect(result.options).to.equal([])
             })
           })
         })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5643

We're updating the Create an ad-hoc notice journey to support renewals invitations.

This means we need to add the option to the **Select the notice type** page.

We did that in [Add renewal invitations to the adhoc notice journey](https://github.com/DEFRA/water-abstraction-system/pull/3350), but we got the permissions wrong.

The journey had previously only needed to consider returns notice types: paper, invitations, and reminders. That meant we could simply provide access to the journey to those with 'Billing & Data' permissions, as they were the only ones who managed these notice types.

Because of this, we defaulted to always showing **Paper returns** for the ad-hoc journey, because only 'Billing & Data' users could access the journey, and they are all permitted to send these.

Renewal invitations should only be shown in the ad-hoc journey (not the standard journey) just like paper returns. But it should only be shown to users with the 'renewal_notifications' role. We made sure of that in our change.

But what we overlooked was that we are always showing paper returns, even to users without the 'Billing & Data' permissions.

This change corrects what we show to users on the ad-hoc journey **Select the notice type** page.

- Has `renewal_notifications` role: Show renewal invitations
- Has `bulk_return_notifications` role: Show paper returns