### PR TITLE
Fix teardown deleting manually registered licences

### DIFF
--- a/app/services/data/tear-down/crm-schema.service.js
+++ b/app/services/data/tear-down/crm-schema.service.js
@@ -114,16 +114,19 @@ async function _deleteAllTestData() {
 
   DELETE
   FROM
-    "crm"."entity_roles"
+    "crm"."entity_roles" AS "er"
       USING "crm"."entity" AS "e"
   WHERE
-    "created_by" = 'acceptance-test-setup'
-    OR "e"."entity_nm" LIKE 'acceptance-test.%'
-    OR "e"."entity_nm" LIKE '%@example.com'
-    OR "e"."entity_nm" LIKE '%@e'
-    OR "e"."entity_nm" LIKE 'regression.tests.%'
-    OR "e"."entity_nm" LIKE 'Big Farm Co Ltd%'
-    OR "e"."source" = 'acceptance-test-setup';
+    "er".entity_id = "e".entity_id
+    AND (
+      "er"."created_by" = 'acceptance-test-setup'
+      OR "e"."entity_nm" LIKE 'acceptance-test.%'
+      OR "e"."entity_nm" LIKE '%@example.com'
+      OR "e"."entity_nm" LIKE '%@e'
+      OR "e"."entity_nm" LIKE 'regression.tests.%'
+      OR "e"."entity_nm" LIKE 'Big Farm Co Ltd%'
+      OR "e"."source" = 'acceptance-test-setup'
+    );
 
   DELETE
   FROM


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5659

After spotting an issue with our automated alternate returns invitation functionality, we fixed it in [Fix not setting due date for alt. returns notices](https://github.com/DEFRA/water-abstraction-system/pull/3363).

We then added an acceptance test to cover the functionality and catch any future changes that might break it.

It required us to seed a 'bad' primary user, which meant we [updated the teardown to remove it](https://github.com/DEFRA/water-abstraction-system/pull/3367).

However, that change introduced a bad SQL statement. A missing `WHERE` condition meant we were clearing the `crm.entity_roles` table completely, rather than just those records linked to the acceptance tests.

This change fixes the SQL statement.