### PR TITLE
Fix licence submission service

### DIFF
--- a/test/services/notices/setup/renewal-notice/process-licence-submission.service.test.js
+++ b/test/services/notices/setup/renewal-notice/process-licence-submission.service.test.js
@@ -20,12 +20,13 @@ const FetchRenewalLicenceDal = require('../../../../../app/dal/notices/setup/fet
 const ProcessRenewalsNoticeLicenceSubmission = require('../../../../../app/services/notices/setup/renewal-notice/process-licence-submission.service.js')
 
 describe('Notices - Setup - Renewal Notice - Process Renewals Notice Licence Submission', () => {
+  let clock
+  let fetchRenewalLicenceDalStub
   let licenceExpiryDate
   let licenceRef
+  let licenceRenewal
   let payload
   let renewalDate
-  let fetchRenewalLicenceDalStub
-  let licenceRenewal
 
   beforeEach(() => {
     licenceExpiryDate = new Date('2026-09-01')
@@ -41,10 +42,13 @@ describe('Notices - Setup - Renewal Notice - Process Renewals Notice Licence Sub
       revokedDate: null
     })
 
+    clock = Sinon.useFakeTimers(new Date('2026-05-21'))
+
     fetchRenewalLicenceDalStub = Sinon.stub(FetchRenewalLicenceDal, 'go').resolves(licenceRenewal)
   })
 
   afterEach(() => {
+    clock.restore()
     Sinon.restore()
   })
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5642

The change adds a sinon clock stub to the 'ProcessRenewalsNoticeLicenceSubmission' test.

This has been done in the validator, but was missed for the service.

The dates where hard coded and the date range started to fail.