### PR TITLE
Refactor additional contact to use licence versions 

### DIFF
--- a/app/dal/notices/recipient-queries.dal.js
+++ b/app/dal/notices/recipient-queries.dal.js
@@ -1,5 +1,22 @@
 'use strict'
 
+const currentLicenceVersionsQuery = `
+  SELECT DISTINCT ON (lv.licence_id)
+    lv.licence_id,
+    lv.company_id,
+    lv.address_id,
+    lv.end_date
+  FROM
+    public.licence_versions lv
+  WHERE
+    lv.start_date <= CURRENT_DATE
+  ORDER BY
+    lv.licence_id ASC,
+    lv."issue" DESC,
+    lv."increment" DESC,
+    lv.end_date DESC NULLS FIRST
+`
+
 /**
  * SQL query fragment for fetching additional contact recipient
  *
@@ -8,30 +25,34 @@
 const additionalContactRecipientQuery = `
     SELECT
       DISTINCT
-      ld.licence_ref,
+      l.licence_ref,
       'additional contact' AS contact_type,
       con.email,
       NULL::jsonb AS contact,
       md5(LOWER(con.email)) AS contact_hash_id,
       ('Email') as message_type
     FROM
-      public.licence_documents ld
-        INNER JOIN public.licence_document_roles ldr
-          ON ldr.licence_document_id = ld.id
+      public.licences l
+        INNER JOIN (
+       ${currentLicenceVersionsQuery}
+      ) AS llv ON llv.licence_id = l.id
+        INNER JOIN public.companies c ON c.id = llv.company_id
         INNER JOIN public.company_contacts cct
-          ON cct.company_id = ldr.company_id
+          ON cct.company_id = llv.company_id
         INNER JOIN public.contacts con
           ON con.id = cct.contact_id
-        INNER JOIN public.licence_roles lr
-          ON lr.id = cct.licence_role_id
     WHERE
-      ld.licence_ref = ANY (?)
+      l.licence_ref = ANY (?)
       AND (
-      ldr.end_date IS NULL
-        OR ldr.end_date >= CURRENT_DATE
+      llv.end_date IS NULL
+        OR llv.end_date >= CURRENT_DATE
       )
       AND cct.abstraction_alerts = true
       AND cct.deleted_at IS NULL
+      AND (
+      cct.licences IS NULL
+        OR cct.licences @> jsonb_build_array(l.id::text)
+      )
   `
 
 /**
@@ -70,19 +91,7 @@ const licenceHolderRecipientQuery = `
     FROM
       public.licences l
     INNER JOIN (
-      SELECT DISTINCT ON (lv.licence_id)
-        lv.licence_id,
-        lv.company_id,
-        lv.address_id
-      FROM
-        public.licence_versions lv
-      WHERE
-        lv.start_date <= CURRENT_DATE
-      ORDER BY
-        lv.licence_id ASC,
-        lv."issue" DESC,
-        lv."increment" DESC,
-        lv.end_date DESC NULLS FIRST
+      ${currentLicenceVersionsQuery}
     ) AS llv ON llv.licence_id = l.id
     INNER JOIN public.companies c ON c.id = llv.company_id
     INNER JOIN public.addresses a ON a.id = llv.address_id

--- a/app/dal/notices/recipient-queries.dal.js
+++ b/app/dal/notices/recipient-queries.dal.js
@@ -1,20 +1,30 @@
 'use strict'
 
-const currentLicenceVersionsQuery = `
-  SELECT DISTINCT ON (lv.licence_id)
-    lv.licence_id,
-    lv.company_id,
-    lv.address_id,
-    lv.end_date
-  FROM
-    public.licence_versions lv
-  WHERE
-    lv.start_date <= CURRENT_DATE
-  ORDER BY
-    lv.licence_id ASC,
-    lv."issue" DESC,
-    lv."increment" DESC,
-    lv.end_date DESC NULLS FIRST
+/**
+ * SQL join fragment for fetching the current licence version
+ *
+ * Selects the most recent licence version per licence where start_date <= CURRENT_DATE,
+ * ordered by issue DESC, increment DESC, end_date DESC NULLS FIRST.
+ *
+ * Consumers must include `FROM public.licences l` before this fragment.
+ */
+const currentLicenceVersionsJoin = `
+  INNER JOIN (
+    SELECT DISTINCT ON (lv.licence_id)
+      lv.licence_id,
+      lv.company_id,
+      lv.address_id,
+      lv.end_date
+    FROM
+      public.licence_versions lv
+    WHERE
+      lv.start_date <= CURRENT_DATE
+    ORDER BY
+      lv.licence_id ASC,
+      lv."issue" DESC,
+      lv."increment" DESC,
+      lv.end_date DESC NULLS FIRST
+  ) AS llv ON llv.licence_id = l.id
 `
 
 /**
@@ -23,36 +33,27 @@ const currentLicenceVersionsQuery = `
  * Requires 1 binding: licenceRefs
  */
 const additionalContactRecipientQuery = `
-    SELECT
-      DISTINCT
-      l.licence_ref,
-      'additional contact' AS contact_type,
-      con.email,
-      NULL::jsonb AS contact,
-      md5(LOWER(con.email)) AS contact_hash_id,
-      ('Email') as message_type
-    FROM
-      public.licences l
-        INNER JOIN (
-       ${currentLicenceVersionsQuery}
-      ) AS llv ON llv.licence_id = l.id
-        INNER JOIN public.companies c ON c.id = llv.company_id
-        INNER JOIN public.company_contacts cct
-          ON cct.company_id = llv.company_id
-        INNER JOIN public.contacts con
-          ON con.id = cct.contact_id
-    WHERE
-      l.licence_ref = ANY (?)
-      AND (
+  SELECT DISTINCT
+    l.licence_ref,
+    'additional contact' AS contact_type,
+    con.email,
+    NULL::jsonb AS contact,
+    md5(LOWER(con.email)) AS contact_hash_id,
+    ('Email') as message_type
+  FROM
+    public.licences l
+    ${currentLicenceVersionsJoin}
+    INNER JOIN public.companies c ON c.id = llv.company_id
+    INNER JOIN public.company_contacts cct ON cct.company_id = llv.company_id
+    INNER JOIN public.contacts con ON con.id = cct.contact_id
+  WHERE
+    l.licence_ref = ANY (?)
+    AND (
       llv.end_date IS NULL
-        OR llv.end_date >= CURRENT_DATE
-      )
-      AND cct.abstraction_alerts = true
-      AND cct.deleted_at IS NULL
-      AND (
-      cct.licences IS NULL
-        OR cct.licences @> jsonb_build_array(l.id::text)
-      )
+      OR llv.end_date >= CURRENT_DATE
+    )
+    AND cct.abstraction_alerts = true
+    AND cct.deleted_at IS NULL
   `
 
 /**
@@ -60,41 +61,39 @@ const additionalContactRecipientQuery = `
  *
  */
 const licenceHolderRecipientQuery = `
-    SELECT
-      ('licence holder') AS contact_type,
-      2 AS priority,
-      jsonb_build_object(
-        'name', c.name,
-        'address1', a.address_1,
-        'address2', a.address_2,
-        'address3', a.address_3,
-        'address4', a.address_4,
-        'address5', a.address_5,
-        'address6', a.address_6,
-        'postcode', a.postcode,
-        'country', a.country
-      ) AS contact,
-      MD5(LOWER(CONCAT(
-        c.name,
-        a.address_1,
-        a.address_2,
-        a.address_3,
-        a.address_4,
-        a.address_5,
-        a.address_6,
-        a.postcode,
-        a.country
-      ))) AS contact_hash_id,
-      NULL::TEXT AS email,
-      l.licence_ref,
-      ('Letter') AS message_type
-    FROM
-      public.licences l
-    INNER JOIN (
-      ${currentLicenceVersionsQuery}
-    ) AS llv ON llv.licence_id = l.id
-    INNER JOIN public.companies c ON c.id = llv.company_id
-    INNER JOIN public.addresses a ON a.id = llv.address_id
+  SELECT
+    ('licence holder') AS contact_type,
+    2 AS priority,
+    jsonb_build_object(
+      'name', c.name,
+      'address1', a.address_1,
+      'address2', a.address_2,
+      'address3', a.address_3,
+      'address4', a.address_4,
+      'address5', a.address_5,
+      'address6', a.address_6,
+      'postcode', a.postcode,
+      'country', a.country
+    ) AS contact,
+    MD5(LOWER(CONCAT(
+      c.name,
+      a.address_1,
+      a.address_2,
+      a.address_3,
+      a.address_4,
+      a.address_5,
+      a.address_6,
+      a.postcode,
+      a.country
+    ))) AS contact_hash_id,
+    NULL::TEXT AS email,
+    l.licence_ref,
+    ('Letter') AS message_type
+  FROM
+    public.licences l
+    ${currentLicenceVersionsJoin}
+  INNER JOIN public.companies c ON c.id = llv.company_id
+  INNER JOIN public.addresses a ON a.id = llv.address_id
 `
 
 /**
@@ -102,23 +101,24 @@ const licenceHolderRecipientQuery = `
  *
  */
 const primaryUserRecipientQuery = `
-    SELECT
-      ('primary user') AS contact_type,
-      1 AS priority,
-      NULL::jsonb AS contact,
-      md5(LOWER(le."name")) AS contact_hash_id,
-      le."name" AS email,
-      ldh.licence_ref,
-      ('Email') AS message_type
-    FROM public.licence_document_headers ldh
-    INNER JOIN public.licence_entity_roles ler
-      ON ler.company_entity_id = ldh.company_entity_id AND ler."role" = 'primary_user'
-    INNER JOIN public.licence_entities le
-      ON le.id = ler.licence_entity_id
+  SELECT
+    ('primary user') AS contact_type,
+    1 AS priority,
+    NULL::jsonb AS contact,
+    md5(LOWER(le."name")) AS contact_hash_id,
+    le."name" AS email,
+    ldh.licence_ref,
+    ('Email') AS message_type
+  FROM public.licence_document_headers ldh
+  INNER JOIN public.licence_entity_roles ler
+    ON ler.company_entity_id = ldh.company_entity_id AND ler."role" = 'primary_user'
+  INNER JOIN public.licence_entities le
+    ON le.id = ler.licence_entity_id
 `
 
 module.exports = {
   additionalContactRecipientQuery,
+  currentLicenceVersionsJoin,
   licenceHolderRecipientQuery,
   primaryUserRecipientQuery
 }

--- a/app/dal/notices/recipient-queries.dal.js
+++ b/app/dal/notices/recipient-queries.dal.js
@@ -3,9 +3,6 @@
 /**
  * SQL join fragment for fetching the current licence version
  *
- * Selects the most recent licence version per licence where start_date <= CURRENT_DATE,
- * ordered by issue DESC, increment DESC, end_date DESC NULLS FIRST.
- *
  * Consumers must include `FROM public.licences l` before this fragment.
  */
 const currentLicenceVersionsJoin = `

--- a/app/dal/notices/recipient-queries.dal.js
+++ b/app/dal/notices/recipient-queries.dal.js
@@ -89,8 +89,8 @@ const licenceHolderRecipientQuery = `
   FROM
     public.licences l
     ${currentLicenceVersionsJoin}
-  INNER JOIN public.companies c ON c.id = llv.company_id
-  INNER JOIN public.addresses a ON a.id = llv.address_id
+    INNER JOIN public.companies c ON c.id = llv.company_id
+    INNER JOIN public.addresses a ON a.id = llv.address_id
 `
 
 /**

--- a/test/dal/notices/recipient-queries.dal.test.js
+++ b/test/dal/notices/recipient-queries.dal.test.js
@@ -8,13 +8,131 @@ const { describe, it, before, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
+const CRMContactsSeeder = require('../../support/seeders/crm-contacts.seeder.js')
+const EmptyLicence = require('../../support/seeders/empty-licence.seeder.js')
 const RecipientScenariosSeeder = require('../../support/seeders/recipient-scenarios.seeder.js')
+const LicenceVersionHelper = require('../../support/helpers/licence-version.helper.js')
 const { db } = require('../../../db/db.js')
 
 // Thing under test
 const RecipientQueriesDal = require('../../../app/dal/notices/recipient-queries.dal.js')
 
 describe('Notices - Recipient Queries DAL', () => {
+  describe('#currentLicenceVersionsJoin', () => {
+    const query = RecipientQueriesDal.currentLicenceVersionsJoin
+
+    // The currentLicenceVersionsJoin is a join, to test we need to wrap the query
+    const wrappedQuery = `
+      SELECT
+        l.licence_ref,
+        llv.company_id,
+        llv.address_id,
+        llv.end_date
+      FROM public.licences l
+        ${query}
+      WHERE l.licence_ref = ANY (?)
+    `
+
+    let scenarios
+
+    before(async () => {
+      scenarios = {}
+
+      let licence
+      let licenceHolder
+
+      // 1) Licence with a current version (start_date <= CURRENT_DATE)
+      licence = await EmptyLicence.seed()
+      licenceHolder = await CRMContactsSeeder.licenceHolder(licence, 'CurrentVersionHolder')
+
+      scenarios.currentVersion = { licence, licenceHolder }
+
+      // 2) Licence with multiple versions. Only the most recent (highest issue) should be returned.
+      licence = await EmptyLicence.seed()
+      licenceHolder = await CRMContactsSeeder.licenceHolder(licence, 'MultipleVersionOldHolder')
+      const newLicenceHolder = await CRMContactsSeeder.licenceHolder(licence, 'MultipleVersionNewHolder')
+      await newLicenceHolder.licenceVersion.$query().patch({ issue: 2 })
+
+      scenarios.multipleVersions = { licence, licenceHolder, newLicenceHolder }
+
+      // 3) Licence with only a future-dated version (start_date > CURRENT_DATE). The licence should NOT appear in results.
+      licence = await EmptyLicence.seed()
+      const licenceVersionRecord = await LicenceVersionHelper.add({
+        licenceId: licence.licence.id,
+        startDate: new Date('2099-01-01')
+      })
+
+      scenarios.futureVersion = {
+        licence,
+        licenceVersion: {
+          clean: async () => {
+            await licenceVersionRecord.$query().delete()
+          }
+        }
+      }
+    })
+
+    after(async () => {
+      await RecipientScenariosSeeder.clean(scenarios)
+    })
+
+    describe('when called', () => {
+      it('returns the expected query', () => {
+        expect(query).to.startWith(`
+  INNER JOIN (`)
+      })
+    })
+
+    describe('when executed', () => {
+      describe('and the licence has a current version (Scenario 1)', () => {
+        it('returns the expected recipients', async () => {
+          const { licence, licenceHolder } = scenarios.currentVersion
+          const licenceRefs = [licence.licence.licenceRef]
+
+          const { rows } = await db.raw(wrappedQuery, [licenceRefs])
+
+          expect(rows).to.equal([
+            {
+              licence_ref: licence.licence.licenceRef,
+              company_id: licenceHolder.company.id,
+              address_id: licenceHolder.address.id,
+              end_date: null
+            }
+          ])
+        })
+      })
+
+      describe('and the licence has multiple versions (Scenario 2)', () => {
+        it('returns only the most recent version', async () => {
+          const { licence, newLicenceHolder } = scenarios.multipleVersions
+          const licenceRefs = [licence.licence.licenceRef]
+
+          const { rows } = await db.raw(wrappedQuery, [licenceRefs])
+
+          expect(rows).to.equal([
+            {
+              licence_ref: licence.licence.licenceRef,
+              company_id: newLicenceHolder.company.id,
+              address_id: newLicenceHolder.address.id,
+              end_date: null
+            }
+          ])
+        })
+      })
+
+      describe('and the licence only has a future-dated version (Scenario 3)', () => {
+        it('does not return the licence', async () => {
+          const { licence } = scenarios.futureVersion
+          const licenceRefs = [licence.licence.licenceRef]
+
+          const { rows } = await db.raw(wrappedQuery, [licenceRefs])
+
+          expect(rows).to.equal([])
+        })
+      })
+    })
+  })
+
   describe('#additionalContactRecipientQuery', () => {
     const query = RecipientQueriesDal.additionalContactRecipientQuery
 
@@ -43,24 +161,6 @@ describe('Notices - Recipient Queries DAL', () => {
         null,
         new Date('2023-01-01')
       )
-
-      // 5) Additional contact where there are licences
-      scenarios.additionalContactWithMatchingLicences = await RecipientScenariosSeeder.additionalContactRecipient(
-        true,
-        null,
-        null,
-        null,
-        true
-      )
-
-      // 6) Additional contact where there are bad licences
-      scenarios.additionalContactWithNoMatchingLicences = await RecipientScenariosSeeder.additionalContactRecipient(
-        true,
-        null,
-        null,
-        null,
-        false
-      )
     })
 
     after(async () => {
@@ -72,63 +172,51 @@ describe('Notices - Recipient Queries DAL', () => {
         const query = RecipientQueriesDal.additionalContactRecipientQuery
 
         expect(query).to.startWith(`
-    SELECT`)
+  SELECT DISTINCT`)
       })
     })
 
     describe('when executed', () => {
-      it('(Scenario 1) returns the additional contact when it is present', async () => {
-        const licenceRefs = scenarios.withAdditionalContact.licenceHolderRecipient.licenceRefs
+      describe('and the additional contact is present (Scenario 1)', () => {
+        it('returns the expected recipients', async () => {
+          const licenceRefs = scenarios.withAdditionalContact.licenceHolderRecipient.licenceRefs
 
-        const { rows } = await db.raw(query, [licenceRefs])
+          const { rows } = await db.raw(query, [licenceRefs])
 
-        const expectedResult = _transformToRecipient(scenarios.withAdditionalContact.additionalContactRecipient)
+          const expectedResult = _transformToRecipient(scenarios.withAdditionalContact.additionalContactRecipient)
 
-        expect(rows).to.equal([expectedResult])
+          expect(rows).to.equal([expectedResult])
+        })
       })
 
-      it('(Scenario 2) does not return the additional contact when abstractionAlerts is false', async () => {
-        const licenceRefs = scenarios.additionalContactNoAlerts.additionalContactRecipient.licenceRefs
+      describe('and abstractionAlerts is false for the additional contact (Scenario 2)', () => {
+        it('does not return the additional contact', async () => {
+          const licenceRefs = scenarios.additionalContactNoAlerts.additionalContactRecipient.licenceRefs
 
-        const { rows } = await db.raw(query, [licenceRefs])
+          const { rows } = await db.raw(query, [licenceRefs])
 
-        expect(rows).to.equal([])
+          expect(rows).to.equal([])
+        })
       })
 
-      it('(Scenario 3) does not return the additional contact when the end date has passed', async () => {
-        const licenceRefs = scenarios.expiredAdditionalContact.licenceHolderRecipient.licenceRefs
+      describe('and the additional contact end date has passed (Scenario 3)', () => {
+        it('does not return the additional contact', async () => {
+          const licenceRefs = scenarios.expiredAdditionalContact.licenceHolderRecipient.licenceRefs
 
-        const { rows } = await db.raw(query, [licenceRefs])
+          const { rows } = await db.raw(query, [licenceRefs])
 
-        expect(rows).to.equal([])
+          expect(rows).to.equal([])
+        })
       })
 
-      it('(Scenario 4) does not return the additional contact when the contact has been soft-deleted', async () => {
-        const licenceRefs = scenarios.deletedAdditionalContact.licenceHolderRecipient.licenceRefs
+      describe('and the additional contact has been soft-deleted (Scenario 4)', () => {
+        it('does not return the additional contact', async () => {
+          const licenceRefs = scenarios.deletedAdditionalContact.licenceHolderRecipient.licenceRefs
 
-        const { rows } = await db.raw(query, [licenceRefs])
+          const { rows } = await db.raw(query, [licenceRefs])
 
-        expect(rows).to.equal([])
-      })
-
-      it('(Scenario 5)', async () => {
-        const licenceRefs = scenarios.additionalContactWithMatchingLicences.licenceHolderRecipient.licenceRefs
-
-        const { rows } = await db.raw(query, [licenceRefs])
-
-        const expectedResult = _transformToRecipient(
-          scenarios.additionalContactWithMatchingLicences.additionalContactRecipient
-        )
-
-        expect(rows).to.equal([expectedResult])
-      })
-
-      it('(Scenario 6) ', async () => {
-        const licenceRefs = scenarios.additionalContactWithNoMatchingLicences.licenceHolderRecipient.licenceRefs
-
-        const { rows } = await db.raw(query, [licenceRefs])
-
-        expect(rows).to.equal([])
+          expect(rows).to.equal([])
+        })
       })
     })
   })
@@ -152,21 +240,23 @@ describe('Notices - Recipient Queries DAL', () => {
         const query = RecipientQueriesDal.licenceHolderRecipientQuery
 
         expect(query).to.startWith(`
-    SELECT`)
+  SELECT`)
       })
     })
 
     describe('when executed', () => {
-      it('(Scenario 1) returns the licence holder when it is present', async () => {
-        const licenceRefs = scenarios.withLicenceHolder.licenceHolderRecipient.licenceRefs
+      describe('and the licence holder is present (Scenario 1)', () => {
+        it('returns the expected recipients', async () => {
+          const licenceRefs = scenarios.withLicenceHolder.licenceHolderRecipient.licenceRefs
 
-        const query = RecipientQueriesDal.licenceHolderRecipientQuery
+          const query = RecipientQueriesDal.licenceHolderRecipientQuery
 
-        const { rows } = await db.raw(`${query} WHERE l.licence_ref = ANY (?)`, [licenceRefs])
+          const { rows } = await db.raw(`${query} WHERE l.licence_ref = ANY (?)`, [licenceRefs])
 
-        const expectedResult = _transformToRecipient(scenarios.withLicenceHolder.licenceHolderRecipient, 2)
+          const expectedResult = _transformToRecipient(scenarios.withLicenceHolder.licenceHolderRecipient, 2)
 
-        expect(rows).to.equal([expectedResult])
+          expect(rows).to.equal([expectedResult])
+        })
       })
     })
   })
@@ -193,31 +283,35 @@ describe('Notices - Recipient Queries DAL', () => {
         const query = RecipientQueriesDal.primaryUserRecipientQuery
 
         expect(query).to.startWith(`
-    SELECT`)
+  SELECT`)
       })
     })
 
     describe('when executed', () => {
-      it('(Scenario 1) returns the primary user when it is present', async () => {
-        const licenceRefs = scenarios.withPrimaryUser.primaryUserRecipient.licenceRefs
+      describe('and the primary user is present (Scenario 1)', () => {
+        it('returns the expected recipients', async () => {
+          const licenceRefs = scenarios.withPrimaryUser.primaryUserRecipient.licenceRefs
 
-        const query = RecipientQueriesDal.primaryUserRecipientQuery
+          const query = RecipientQueriesDal.primaryUserRecipientQuery
 
-        const { rows } = await db.raw(`${query} WHERE ldh.licence_ref = ANY (?)`, [licenceRefs])
+          const { rows } = await db.raw(`${query} WHERE ldh.licence_ref = ANY (?)`, [licenceRefs])
 
-        const expectedResult = _transformToRecipient(scenarios.withPrimaryUser.primaryUserRecipient, 1)
+          const expectedResult = _transformToRecipient(scenarios.withPrimaryUser.primaryUserRecipient, 1)
 
-        expect(rows).to.equal([expectedResult])
+          expect(rows).to.equal([expectedResult])
+        })
       })
 
-      it('(Scenario 2) does not return when there is no primary user', async () => {
-        const licenceRefs = scenarios.noPrimaryUser.licenceHolderRecipient.licenceRefs
+      describe('and there is no primary user (Scenario 2)', () => {
+        it('does not return the primary user', async () => {
+          const licenceRefs = scenarios.noPrimaryUser.licenceHolderRecipient.licenceRefs
 
-        const query = RecipientQueriesDal.primaryUserRecipientQuery
+          const query = RecipientQueriesDal.primaryUserRecipientQuery
 
-        const { rows } = await db.raw(`${query} WHERE ldh.licence_ref = ANY (?)`, [licenceRefs])
+          const { rows } = await db.raw(`${query} WHERE ldh.licence_ref = ANY (?)`, [licenceRefs])
 
-        expect(rows).to.equal([])
+          expect(rows).to.equal([])
+        })
       })
     })
   })

--- a/test/dal/notices/recipient-queries.dal.test.js
+++ b/test/dal/notices/recipient-queries.dal.test.js
@@ -150,7 +150,6 @@ describe('Notices - Recipient Queries DAL', () => {
       // 3) Additional contact where the end date has passed. The expired contact should NOT appear in results.
       scenarios.expiredAdditionalContact = await RecipientScenariosSeeder.additionalContactRecipient(
         true,
-        null,
         new Date('2023-01-01')
       )
 
@@ -158,8 +157,7 @@ describe('Notices - Recipient Queries DAL', () => {
       scenarios.deletedAdditionalContact = await RecipientScenariosSeeder.additionalContactRecipient(
         true,
         null,
-        null,
-        new Date('2023-01-01')
+        new Date('2023-06-01')
       )
     })
 

--- a/test/dal/notices/recipient-queries.dal.test.js
+++ b/test/dal/notices/recipient-queries.dal.test.js
@@ -8,7 +8,6 @@ const { describe, it, before, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const EmptyLicence = require('../../support/seeders/empty-licence.seeder.js')
 const RecipientScenariosSeeder = require('../../support/seeders/recipient-scenarios.seeder.js')
 const { db } = require('../../../db/db.js')
 
@@ -17,36 +16,50 @@ const RecipientQueriesDal = require('../../../app/dal/notices/recipient-queries.
 
 describe('Notices - Recipient Queries DAL', () => {
   describe('#additionalContactRecipientQuery', () => {
+    const query = RecipientQueriesDal.additionalContactRecipientQuery
+
     let scenarios
 
     before(async () => {
       scenarios = {}
 
       // 1) Additional contact present
-      let licence = await EmptyLicence.seed()
-      scenarios.withAdditionalContact = await RecipientScenariosSeeder.additionalContactRecipient(licence)
+      scenarios.withAdditionalContact = await RecipientScenariosSeeder.additionalContactRecipient()
 
       // 2) Additional contact where abstractionAlerts = false. The contact should NOT appear in results.
-      licence = await EmptyLicence.seed()
-      scenarios.additionalContactNoAlerts = await RecipientScenariosSeeder.additionalContactRecipient(licence, false)
+      scenarios.additionalContactNoAlerts = await RecipientScenariosSeeder.additionalContactRecipient(false)
 
       // 3) Additional contact where the end date has passed. The expired contact should NOT appear in results.
-      licence = await EmptyLicence.seed()
       scenarios.expiredAdditionalContact = await RecipientScenariosSeeder.additionalContactRecipient(
-        licence,
         true,
         null,
         new Date('2023-01-01')
       )
 
       // 4) Additional contact where the contact has been soft-deleted. The contact should NOT appear in results.
-      licence = await EmptyLicence.seed()
       scenarios.deletedAdditionalContact = await RecipientScenariosSeeder.additionalContactRecipient(
-        licence,
         true,
         null,
         null,
         new Date('2023-01-01')
+      )
+
+      // 5) Additional contact where there are licences
+      scenarios.additionalContactWithMatchingLicences = await RecipientScenariosSeeder.additionalContactRecipient(
+        true,
+        null,
+        null,
+        null,
+        true
+      )
+
+      // 6) Additional contact where there are bad licences
+      scenarios.additionalContactWithNoMatchingLicences = await RecipientScenariosSeeder.additionalContactRecipient(
+        true,
+        null,
+        null,
+        null,
+        false
       )
     })
 
@@ -65,9 +78,7 @@ describe('Notices - Recipient Queries DAL', () => {
 
     describe('when executed', () => {
       it('(Scenario 1) returns the additional contact when it is present', async () => {
-        const licenceRefs = scenarios.withAdditionalContact.additionalContactRecipient.licenceRefs
-
-        const query = RecipientQueriesDal.additionalContactRecipientQuery
+        const licenceRefs = scenarios.withAdditionalContact.licenceHolderRecipient.licenceRefs
 
         const { rows } = await db.raw(query, [licenceRefs])
 
@@ -79,17 +90,13 @@ describe('Notices - Recipient Queries DAL', () => {
       it('(Scenario 2) does not return the additional contact when abstractionAlerts is false', async () => {
         const licenceRefs = scenarios.additionalContactNoAlerts.additionalContactRecipient.licenceRefs
 
-        const query = RecipientQueriesDal.additionalContactRecipientQuery
-
         const { rows } = await db.raw(query, [licenceRefs])
 
         expect(rows).to.equal([])
       })
 
       it('(Scenario 3) does not return the additional contact when the end date has passed', async () => {
-        const licenceRefs = scenarios.expiredAdditionalContact.additionalContactRecipient.licenceRefs
-
-        const query = RecipientQueriesDal.additionalContactRecipientQuery
+        const licenceRefs = scenarios.expiredAdditionalContact.licenceHolderRecipient.licenceRefs
 
         const { rows } = await db.raw(query, [licenceRefs])
 
@@ -97,9 +104,27 @@ describe('Notices - Recipient Queries DAL', () => {
       })
 
       it('(Scenario 4) does not return the additional contact when the contact has been soft-deleted', async () => {
-        const licenceRefs = scenarios.deletedAdditionalContact.additionalContactRecipient.licenceRefs
+        const licenceRefs = scenarios.deletedAdditionalContact.licenceHolderRecipient.licenceRefs
 
-        const query = RecipientQueriesDal.additionalContactRecipientQuery
+        const { rows } = await db.raw(query, [licenceRefs])
+
+        expect(rows).to.equal([])
+      })
+
+      it('(Scenario 5)', async () => {
+        const licenceRefs = scenarios.additionalContactWithMatchingLicences.licenceHolderRecipient.licenceRefs
+
+        const { rows } = await db.raw(query, [licenceRefs])
+
+        const expectedResult = _transformToRecipient(
+          scenarios.additionalContactWithMatchingLicences.additionalContactRecipient
+        )
+
+        expect(rows).to.equal([expectedResult])
+      })
+
+      it('(Scenario 6) ', async () => {
+        const licenceRefs = scenarios.additionalContactWithNoMatchingLicences.licenceHolderRecipient.licenceRefs
 
         const { rows } = await db.raw(query, [licenceRefs])
 

--- a/test/dal/notices/recipient-queries.dal.test.js
+++ b/test/dal/notices/recipient-queries.dal.test.js
@@ -10,8 +10,8 @@ const { expect } = Code
 // Test helpers
 const CRMContactsSeeder = require('../../support/seeders/crm-contacts.seeder.js')
 const EmptyLicence = require('../../support/seeders/empty-licence.seeder.js')
-const RecipientScenariosSeeder = require('../../support/seeders/recipient-scenarios.seeder.js')
 const LicenceVersionHelper = require('../../support/helpers/licence-version.helper.js')
+const RecipientScenariosSeeder = require('../../support/seeders/recipient-scenarios.seeder.js')
 const { db } = require('../../../db/db.js')
 
 // Thing under test

--- a/test/dal/notices/setup/abstraction-alerts/abstraction-alert-recipients-query.dal.test.js
+++ b/test/dal/notices/setup/abstraction-alerts/abstraction-alert-recipients-query.dal.test.js
@@ -59,7 +59,7 @@ describe('Notices - Setup - Abstraction Alerts - Abstraction Alert Recipients Qu
       additionalContactRecipient: scenario5AdditionalContactRecipient
     }
 
-    // 6) Additional contact multiple licence refs. Two calls with the same default company name and contact email means
+    // 6) Additional contact multiple licence refs. Two contacts with the same default company name and contact email means
     // the query combines them into a single row per contact (same contact_hash_id).
     const scenario6a = await RecipientScenariosSeeder.additionalContactRecipient()
     const scenario6b = await RecipientScenariosSeeder.additionalContactRecipient()

--- a/test/dal/notices/setup/abstraction-alerts/abstraction-alert-recipients-query.dal.test.js
+++ b/test/dal/notices/setup/abstraction-alerts/abstraction-alert-recipients-query.dal.test.js
@@ -42,18 +42,21 @@ describe('Notices - Setup - Abstraction Alerts - Abstraction Alert Recipients Qu
 
     // 5) Primary user with an additional contact. Similar to scenario 4 - when registered, we expect the primary user
     // and additional contact but not the licence holder. All three must share one licence, so we build this manually.
-    const s5Licence = await EmptyLicence.seed()
-    const s5LicenceHolder = await CRMContactsSeeder.licenceHolder(s5Licence, 'PrimaryWithAdditional')
-    const s5LicenceHolderRecipient = await RecipientsFormatter.licenceHolder(s5Licence, s5LicenceHolder)
-    const s5PrimaryUser = await CRMContactsSeeder.primaryUser(s5Licence, 'primary.withcontact@test.com')
-    const s5PrimaryUserRecipient = await RecipientsFormatter.primaryUser(s5Licence, s5PrimaryUser)
-    const s5AdditionalContact = await CRMContactsSeeder.additionalContact(s5LicenceHolder)
-    const s5AdditionalContactRecipient = await RecipientsFormatter.additionalContact(s5Licence, s5AdditionalContact)
+    const licence = await EmptyLicence.seed()
+    const licenceHolder = await CRMContactsSeeder.licenceHolder(licence, 'PrimaryWithAdditional')
+    const scenario5LicenceHolderRecipient = await RecipientsFormatter.licenceHolder(licence, licenceHolder)
+    const scenario5PrimaryUser = await CRMContactsSeeder.primaryUser(licence, 'primary.withcontact@test.com')
+    const scenario5PrimaryUserRecipient = await RecipientsFormatter.primaryUser(licence, scenario5PrimaryUser)
+    const scenario5AdditionalContact = await CRMContactsSeeder.additionalContact(licenceHolder)
+    const scenario5AdditionalContactRecipient = await RecipientsFormatter.additionalContact(
+      licence,
+      scenario5AdditionalContact
+    )
 
     scenarios.primaryUserWithAdditionalContact = {
-      licenceHolderRecipient: s5LicenceHolderRecipient,
-      primaryUserRecipient: s5PrimaryUserRecipient,
-      additionalContactRecipient: s5AdditionalContactRecipient
+      licenceHolderRecipient: scenario5LicenceHolderRecipient,
+      primaryUserRecipient: scenario5PrimaryUserRecipient,
+      additionalContactRecipient: scenario5AdditionalContactRecipient
     }
 
     // 6) Additional contact multiple licence refs. Two calls with the same default company name and contact email means
@@ -71,8 +74,13 @@ describe('Notices - Setup - Abstraction Alerts - Abstraction Alert Recipients Qu
     // 7) Different licence holders and different additional contacts for different licences. Unlike scenario 6 where
     // the same contact spans multiple licences and is combined into one row, here each licence has unique contacts so
     // all four recipients are returned separately.
-    const s7a = await RecipientScenariosSeeder.additionalContactRecipient(true, null, null, 'HolderWithUniqueContactA')
-    const s7b = await RecipientScenariosSeeder.additionalContactRecipient(
+    const scenario7a = await RecipientScenariosSeeder.additionalContactRecipient(
+      true,
+      null,
+      null,
+      'HolderWithUniqueContactA'
+    )
+    const scenario7b = await RecipientScenariosSeeder.additionalContactRecipient(
       true,
       null,
       null,
@@ -85,27 +93,38 @@ describe('Notices - Setup - Abstraction Alerts - Abstraction Alert Recipients Qu
     )
 
     scenarios.differentHoldersAndContacts = {
-      firstLicenceHolderRecipient: s7a.licenceHolderRecipient,
-      secondLicenceHolderRecipient: s7b.licenceHolderRecipient,
-      firstAdditionalContact: s7a.additionalContactRecipient,
-      secondAdditionalContact: s7b.additionalContactRecipient
+      firstLicenceHolderRecipient: scenario7a.licenceHolderRecipient,
+      secondLicenceHolderRecipient: scenario7b.licenceHolderRecipient,
+      firstAdditionalContact: scenario7a.additionalContactRecipient,
+      secondAdditionalContact: scenario7b.additionalContactRecipient
     }
 
     // 8) Two licences with different licence holders and additional contacts, but one additional contact has
     // abstractionAlerts = false and should NOT appear in results.
-    const s8a = await RecipientScenariosSeeder.additionalContactRecipient(true, null, null, 'HolderWithMixedAlertsA')
+    const scenario8a = await RecipientScenariosSeeder.additionalContactRecipient(
+      true,
+      null,
+      null,
+      'HolderWithMixedAlertsA'
+    )
 
-    const s8b = await RecipientScenariosSeeder.additionalContactRecipient(false, null, null, 'HolderWithMixedAlertsB', {
-      firstName: 'Champ',
-      lastName: 'Kind',
-      email: 'champ.kind@news.com'
-    })
+    const scenario8b = await RecipientScenariosSeeder.additionalContactRecipient(
+      false,
+      null,
+      null,
+      'HolderWithMixedAlertsB',
+      {
+        firstName: 'Champ',
+        lastName: 'Kind',
+        email: 'champ.kind@news.com'
+      }
+    )
 
     scenarios.mixedAlerts = {
-      licenceHolderRecipientWithAlert: s8a.licenceHolderRecipient,
-      licenceHolderRecipientWithoutAlert: s8b.licenceHolderRecipient,
-      additionalContactWithAlert: s8a.additionalContactRecipient,
-      additionalContactWithoutAlert: s8b.additionalContactRecipient
+      licenceHolderRecipientWithAlert: scenario8a.licenceHolderRecipient,
+      licenceHolderRecipientWithoutAlert: scenario8b.licenceHolderRecipient,
+      additionalContactWithAlert: scenario8a.additionalContactRecipient,
+      additionalContactWithoutAlert: scenario8b.additionalContactRecipient
     }
   })
 
@@ -269,13 +288,3 @@ describe('Notices - Setup - Abstraction Alerts - Abstraction Alert Recipients Qu
     })
   })
 })
-
-async function _additionalContact(name, contactData = null, abstractionAlerts = true) {
-  const licence = await EmptyLicence.seed()
-  const licenceHolder = await CRMContactsSeeder.licenceHolder(licence, name)
-  const licenceHolderRecipient = await RecipientsFormatter.licenceHolder(licence, licenceHolder)
-  const additionalContact = await CRMContactsSeeder.additionalContact(licenceHolder, contactData, abstractionAlerts)
-  const additionalContactRecipient = await RecipientsFormatter.additionalContact(licence, additionalContact)
-
-  return { licenceHolderRecipient, additionalContactRecipient }
-}

--- a/test/dal/notices/setup/abstraction-alerts/abstraction-alert-recipients-query.dal.test.js
+++ b/test/dal/notices/setup/abstraction-alerts/abstraction-alert-recipients-query.dal.test.js
@@ -43,7 +43,7 @@ describe('Notices - Setup - Abstraction Alerts - Abstraction Alert Recipients Qu
     const s4LicenceHolderRecipient = await RecipientsFormatter.licenceHolder(s4Licence, s4LicenceHolder)
     const s4PrimaryUser = await CRMContactsSeeder.primaryUser(s4Licence, 'primary.withcontact@test.com')
     const s4PrimaryUserRecipient = await RecipientsFormatter.primaryUser(s4Licence, s4PrimaryUser)
-    const s4AdditionalContact = await CRMContactsSeeder.additionalContact(s4Licence, s4LicenceHolder)
+    const s4AdditionalContact = await CRMContactsSeeder.additionalContact(s4LicenceHolder)
     const s4AdditionalContactRecipient = await RecipientsFormatter.additionalContact(s4Licence, s4AdditionalContact)
     scenarios.primaryUserWithAdditionalContact = {
       licenceHolderRecipient: s4LicenceHolderRecipient,
@@ -267,12 +267,7 @@ async function _additionalContact(name, contactData = null, abstractionAlerts = 
   const licence = await EmptyLicence.seed()
   const licenceHolder = await CRMContactsSeeder.licenceHolder(licence, name)
   const licenceHolderRecipient = await RecipientsFormatter.licenceHolder(licence, licenceHolder)
-  const additionalContact = await CRMContactsSeeder.additionalContact(
-    licence,
-    licenceHolder,
-    contactData,
-    abstractionAlerts
-  )
+  const additionalContact = await CRMContactsSeeder.additionalContact(licenceHolder, contactData, abstractionAlerts)
   const additionalContactRecipient = await RecipientsFormatter.additionalContact(licence, additionalContact)
 
   return { licenceHolderRecipient, additionalContactRecipient }

--- a/test/dal/notices/setup/abstraction-alerts/abstraction-alert-recipients-query.dal.test.js
+++ b/test/dal/notices/setup/abstraction-alerts/abstraction-alert-recipients-query.dal.test.js
@@ -26,137 +26,80 @@ describe('Notices - Setup - Abstraction Alerts - Abstraction Alert Recipients Qu
   before(async () => {
     scenarios = {}
 
-    let licenceHolder
-    let licenceHolderRecipient
-
     // 1) Licence holder only
     scenarios.licenceHolder = await RecipientScenariosSeeder.licenceHolderOnly()
 
     // 2) Licence holder, and an additional contact
-    licenceHolder = await _licenceHolder()
-    licenceHolderRecipient = await RecipientsFormatter.licenceHolder(licenceHolder.licence, licenceHolder.licenceHolder)
-    scenarios.licenceHolderWithAdditionalContact = {
-      licenceHolderRecipient,
-      ...(await RecipientScenariosSeeder.additionalContactRecipient(licenceHolder.licence))
-    }
+    scenarios.licenceHolderWithAdditionalContact = await RecipientScenariosSeeder.additionalContactRecipient()
 
     // 3) Primary user only. All licences have a licence holder record, but when 'registered' the query will only
     // return the primary user recipient.
     scenarios.primaryUser = await RecipientScenariosSeeder.primaryUserOnly()
 
     // 4) Primary user with an additional contact. Similar to scenario 3 - when registered, we expect the primary user
-    // and additional contact but not the licence holder.
-    licenceHolder = await _licenceHolder()
-    licenceHolderRecipient = await RecipientsFormatter.licenceHolder(licenceHolder.licence, licenceHolder.licenceHolder)
-    const primaryUser = await _primaryUser(licenceHolder.licence)
-    const primaryUserRecipient = await RecipientsFormatter.primaryUser(licenceHolder.licence, primaryUser.primaryUser)
+    // and additional contact but not the licence holder. All three must share one licence, so we build this manually.
+    const s4Licence = await EmptyLicence.seed()
+    const s4LicenceHolder = await CRMContactsSeeder.licenceHolder(s4Licence, 'PrimaryWithAdditional')
+    const s4LicenceHolderRecipient = await RecipientsFormatter.licenceHolder(s4Licence, s4LicenceHolder)
+    const s4PrimaryUser = await CRMContactsSeeder.primaryUser(s4Licence, 'primary.withcontact@test.com')
+    const s4PrimaryUserRecipient = await RecipientsFormatter.primaryUser(s4Licence, s4PrimaryUser)
+    const s4AdditionalContact = await CRMContactsSeeder.additionalContact(s4Licence, s4LicenceHolder)
+    const s4AdditionalContactRecipient = await RecipientsFormatter.additionalContact(s4Licence, s4AdditionalContact)
     scenarios.primaryUserWithAdditionalContact = {
-      licenceHolderRecipient,
-      primaryUserRecipient,
-      ...(await RecipientScenariosSeeder.additionalContactRecipient(licenceHolder.licence))
+      licenceHolderRecipient: s4LicenceHolderRecipient,
+      primaryUserRecipient: s4PrimaryUserRecipient,
+      additionalContactRecipient: s4AdditionalContactRecipient
     }
 
-    // 5) Additional contact multiple licence refs
-    licenceHolder = await _licenceHolder()
-    licenceHolderRecipient = await RecipientsFormatter.licenceHolder(licenceHolder.licence, licenceHolder.licenceHolder)
-    const { additionalContactRecipient } = await RecipientScenariosSeeder.additionalContactRecipient(
-      licenceHolder.licence
-    )
-
-    // Second licence
-    const licenceHolderTwo = await _licenceHolder()
-    const licenceHolderRecipientTwo = await RecipientsFormatter.licenceHolder(
-      licenceHolderTwo.licence,
-      licenceHolderTwo.licenceHolder
-    )
-    const { additionalContactRecipient: additionalContactRecipientTwo } =
-      await RecipientScenariosSeeder.additionalContactRecipient(licenceHolderTwo.licence)
+    // 5) Additional contact multiple licence refs. Two calls with the same default company name and contact email means
+    // the query combines them into a single row per contact (same contact_hash_id).
+    const scenario5a = await RecipientScenariosSeeder.additionalContactRecipient()
+    const scenario5b = await RecipientScenariosSeeder.additionalContactRecipient()
     scenarios.additionalContactMultipleLicences = {
-      licenceHolderRecipient,
-      licenceHolderRecipientTwo,
-      additionalContactRecipient,
-      additionalContactRecipientTwo
+      licenceHolderRecipient: scenario5a.licenceHolderRecipient,
+      licenceHolderRecipientTwo: scenario5b.licenceHolderRecipient,
+      additionalContactRecipient: scenario5a.additionalContactRecipient,
+      additionalContactRecipientTwo: scenario5b.additionalContactRecipient
     }
 
     // 6) Licence holder with an additional contact where abstractionAlerts = false. The additional contact should NOT
     // appear in results.
-    licenceHolder = await _licenceHolder()
-    licenceHolderRecipient = await RecipientsFormatter.licenceHolder(licenceHolder.licence, licenceHolder.licenceHolder)
-    const { additionalContactRecipient: additionalContactNoAlerts } =
-      await RecipientScenariosSeeder.additionalContactRecipient(licenceHolder.licence, false)
-    scenarios.additionalContactNoAlerts = { licenceHolderRecipient, additionalContactNoAlerts }
+    scenarios.additionalContactNoAlerts = await RecipientScenariosSeeder.additionalContactRecipient(false)
 
     // 7) Different licence holders and different additional contacts for different licences. Unlike scenario 5 where
     // the same contact spans multiple licences and is combined into one row, here each licence has unique contacts so
     // all four recipients are returned separately.
-    const firstLicenceHolder = await _licenceHolder('HolderWithUniqueContactA')
-    const firstLicenceHolderRecipient = await RecipientsFormatter.licenceHolder(
-      firstLicenceHolder.licence,
-      firstLicenceHolder.licenceHolder
-    )
-    const { additionalContactRecipient: firstAdditionalContact } =
-      await RecipientScenariosSeeder.additionalContactRecipient(firstLicenceHolder.licence)
-
-    const secondLicenceHolder = await _licenceHolder('HolderWithUniqueContactB')
-    const secondLicenceHolderRecipient = await RecipientsFormatter.licenceHolder(
-      secondLicenceHolder.licence,
-      secondLicenceHolder.licenceHolder
-    )
-    const { additionalContactRecipient: secondAdditionalContact } =
-      await RecipientScenariosSeeder.additionalContactRecipient(secondLicenceHolder.licence, true, {
-        firstName: 'Champ',
-        lastName: 'Kind',
-        email: 'champ.kind@news.com'
-      })
-
+    const s7a = await _additionalContact('HolderWithUniqueContactA')
+    const s7b = await _additionalContact('HolderWithUniqueContactB', {
+      firstName: 'Champ',
+      lastName: 'Kind',
+      email: 'champ.kind@news.com'
+    })
     scenarios.differentHoldersAndContacts = {
-      firstLicenceHolderRecipient,
-      secondLicenceHolderRecipient,
-      firstAdditionalContact,
-      secondAdditionalContact
+      firstLicenceHolderRecipient: s7a.licenceHolderRecipient,
+      secondLicenceHolderRecipient: s7b.licenceHolderRecipient,
+      firstAdditionalContact: s7a.additionalContactRecipient,
+      secondAdditionalContact: s7b.additionalContactRecipient
     }
 
     // 8) Two licences with different licence holders and additional contacts, but one additional contact has
     // abstractionAlerts = false and should NOT appear in results.
-    const licenceHolderWithAlert = await _licenceHolder('HolderWithMixedAlertsA')
-    const licenceHolderRecipientWithAlert = await RecipientsFormatter.licenceHolder(
-      licenceHolderWithAlert.licence,
-      licenceHolderWithAlert.licenceHolder
-    )
-    const { additionalContactRecipient: additionalContactWithAlert } =
-      await RecipientScenariosSeeder.additionalContactRecipient(licenceHolderWithAlert.licence)
-
-    const licenceHolderWithoutAlert = await _licenceHolder('HolderWithMixedAlertsB')
-    const licenceHolderRecipientWithoutAlert = await RecipientsFormatter.licenceHolder(
-      licenceHolderWithoutAlert.licence,
-      licenceHolderWithoutAlert.licenceHolder
-    )
-    const { additionalContactRecipient: additionalContactWithoutAlert } =
-      await RecipientScenariosSeeder.additionalContactRecipient(licenceHolderWithoutAlert.licence, false, {
+    const s8a = await _additionalContact('HolderWithMixedAlertsA')
+    const s8b = await _additionalContact(
+      'HolderWithMixedAlertsB',
+      {
         firstName: 'Champ',
         lastName: 'Kind',
         email: 'champ.kind@news.com'
-      })
-
+      },
+      false
+    )
     scenarios.mixedAlerts = {
-      licenceHolderRecipientWithAlert,
-      licenceHolderRecipientWithoutAlert,
-      additionalContactWithAlert,
-      additionalContactWithoutAlert
+      licenceHolderRecipientWithAlert: s8a.licenceHolderRecipient,
+      licenceHolderRecipientWithoutAlert: s8b.licenceHolderRecipient,
+      additionalContactWithAlert: s8a.additionalContactRecipient,
+      additionalContactWithoutAlert: s8b.additionalContactRecipient
     }
-
-    // 9) Licence holder with an additional contact where the end date has passed. The expired contact should NOT
-    // appear in results.
-    licenceHolder = await _licenceHolder()
-    licenceHolderRecipient = await RecipientsFormatter.licenceHolder(licenceHolder.licence, licenceHolder.licenceHolder)
-    const { additionalContactRecipient: expiredAdditionalContact } =
-      await RecipientScenariosSeeder.additionalContactRecipient(
-        licenceHolder.licence,
-        true,
-        null,
-        new Date('2023-01-01')
-      )
-    scenarios.expiredAdditionalContact = { licenceHolderRecipient, expiredAdditionalContact }
   })
 
   after(async () => {
@@ -190,11 +133,16 @@ describe('Notices - Setup - Abstraction Alerts - Abstraction Alert Recipients Qu
 
         const { rows } = await db.raw(query, [licenceRefs, licenceRefs, licenceRefs])
 
+        const sortedRows = [...rows].sort((a, b) => {
+          return compareStrings(a.contact_type, b.contact_type)
+        })
         const expectedResults = RecipientScenariosSeeder.transformToSendingResults(
           scenarios.licenceHolderWithAdditionalContact
-        )
+        ).sort((a, b) => {
+          return compareStrings(a.contact_type, b.contact_type)
+        })
 
-        expect(rows).to.equal(expectedResults)
+        expect(sortedRows).to.equal(expectedResults)
       })
     })
 
@@ -240,12 +188,17 @@ describe('Notices - Setup - Abstraction Alerts - Abstraction Alert Recipients Qu
           licenceHolderRecipient: scenarios.additionalContactMultipleLicences.licenceHolderRecipient,
           additionalContactRecipient: scenarios.additionalContactMultipleLicences.additionalContactRecipient
         })
+        const sortedRows = [...rows].sort((a, b) => {
+          return compareStrings(a.contact_type, b.contact_type)
+        })
         const expectedResults = [
           { ...transformedResults[0], licence_refs: licenceRefs },
           { ...transformedResults[1], licence_refs: licenceRefs }
-        ]
+        ].sort((a, b) => {
+          return compareStrings(a.contact_type, b.contact_type)
+        })
 
-        expect(rows).to.equal(expectedResults)
+        expect(sortedRows).to.equal(expectedResults)
       })
     })
 
@@ -307,35 +260,20 @@ describe('Notices - Setup - Abstraction Alerts - Abstraction Alert Recipients Qu
         expect(rows).to.equal(expectedResults)
       })
     })
-
-    describe('and the additional contact end date has passed (Scenario 9)', () => {
-      it('returns only the "licence holder" and not the expired additional contact', async () => {
-        const licenceRefs = scenarios.expiredAdditionalContact.licenceHolderRecipient.licenceRefs
-
-        const { rows } = await db.raw(query, [licenceRefs, licenceRefs, licenceRefs])
-
-        const expectedResults = RecipientScenariosSeeder.transformToSendingResults({
-          licenceHolderRecipient: scenarios.expiredAdditionalContact.licenceHolderRecipient
-        })
-
-        expect(rows).to.equal(expectedResults)
-      })
-    })
   })
 })
 
-async function _licenceHolder(name = 'Holderwithadditionalcontact') {
+async function _additionalContact(name, contactData = null, abstractionAlerts = true) {
   const licence = await EmptyLicence.seed()
   const licenceHolder = await CRMContactsSeeder.licenceHolder(licence, name)
-
-  return {
+  const licenceHolderRecipient = await RecipientsFormatter.licenceHolder(licence, licenceHolder)
+  const additionalContact = await CRMContactsSeeder.additionalContact(
     licence,
-    licenceHolder
-  }
-}
+    licenceHolder,
+    contactData,
+    abstractionAlerts
+  )
+  const additionalContactRecipient = await RecipientsFormatter.additionalContact(licence, additionalContact)
 
-async function _primaryUser(licence) {
-  const primaryUser = await CRMContactsSeeder.primaryUser(licence, 'primaryuser@pura.com')
-
-  return { primaryUser }
+  return { licenceHolderRecipient, additionalContactRecipient }
 }

--- a/test/dal/notices/setup/abstraction-alerts/abstraction-alert-recipients-query.dal.test.js
+++ b/test/dal/notices/setup/abstraction-alerts/abstraction-alert-recipients-query.dal.test.js
@@ -32,49 +32,58 @@ describe('Notices - Setup - Abstraction Alerts - Abstraction Alert Recipients Qu
     // 2) Licence holder, and an additional contact
     scenarios.licenceHolderWithAdditionalContact = await RecipientScenariosSeeder.additionalContactRecipient()
 
-    // 3) Primary user only. All licences have a licence holder record, but when 'registered' the query will only
-    // return the primary user recipient.
-    scenarios.primaryUser = await RecipientScenariosSeeder.primaryUserOnly()
-
-    // 4) Primary user with an additional contact. Similar to scenario 3 - when registered, we expect the primary user
-    // and additional contact but not the licence holder. All three must share one licence, so we build this manually.
-    const s4Licence = await EmptyLicence.seed()
-    const s4LicenceHolder = await CRMContactsSeeder.licenceHolder(s4Licence, 'PrimaryWithAdditional')
-    const s4LicenceHolderRecipient = await RecipientsFormatter.licenceHolder(s4Licence, s4LicenceHolder)
-    const s4PrimaryUser = await CRMContactsSeeder.primaryUser(s4Licence, 'primary.withcontact@test.com')
-    const s4PrimaryUserRecipient = await RecipientsFormatter.primaryUser(s4Licence, s4PrimaryUser)
-    const s4AdditionalContact = await CRMContactsSeeder.additionalContact(s4LicenceHolder)
-    const s4AdditionalContactRecipient = await RecipientsFormatter.additionalContact(s4Licence, s4AdditionalContact)
-    scenarios.primaryUserWithAdditionalContact = {
-      licenceHolderRecipient: s4LicenceHolderRecipient,
-      primaryUserRecipient: s4PrimaryUserRecipient,
-      additionalContactRecipient: s4AdditionalContactRecipient
-    }
-
-    // 5) Additional contact multiple licence refs. Two calls with the same default company name and contact email means
-    // the query combines them into a single row per contact (same contact_hash_id).
-    const scenario5a = await RecipientScenariosSeeder.additionalContactRecipient()
-    const scenario5b = await RecipientScenariosSeeder.additionalContactRecipient()
-    scenarios.additionalContactMultipleLicences = {
-      licenceHolderRecipient: scenario5a.licenceHolderRecipient,
-      licenceHolderRecipientTwo: scenario5b.licenceHolderRecipient,
-      additionalContactRecipient: scenario5a.additionalContactRecipient,
-      additionalContactRecipientTwo: scenario5b.additionalContactRecipient
-    }
-
-    // 6) Licence holder with an additional contact where abstractionAlerts = false. The additional contact should NOT
+    // 3) Licence holder with an additional contact where abstractionAlerts = false. The additional contact should NOT
     // appear in results.
     scenarios.additionalContactNoAlerts = await RecipientScenariosSeeder.additionalContactRecipient(false)
 
-    // 7) Different licence holders and different additional contacts for different licences. Unlike scenario 5 where
+    // 4) Primary user only. All licences have a licence holder record, but when 'registered' the query will only
+    // return the primary user recipient.
+    scenarios.primaryUser = await RecipientScenariosSeeder.primaryUserOnly()
+
+    // 5) Primary user with an additional contact. Similar to scenario 4 - when registered, we expect the primary user
+    // and additional contact but not the licence holder. All three must share one licence, so we build this manually.
+    const s5Licence = await EmptyLicence.seed()
+    const s5LicenceHolder = await CRMContactsSeeder.licenceHolder(s5Licence, 'PrimaryWithAdditional')
+    const s5LicenceHolderRecipient = await RecipientsFormatter.licenceHolder(s5Licence, s5LicenceHolder)
+    const s5PrimaryUser = await CRMContactsSeeder.primaryUser(s5Licence, 'primary.withcontact@test.com')
+    const s5PrimaryUserRecipient = await RecipientsFormatter.primaryUser(s5Licence, s5PrimaryUser)
+    const s5AdditionalContact = await CRMContactsSeeder.additionalContact(s5LicenceHolder)
+    const s5AdditionalContactRecipient = await RecipientsFormatter.additionalContact(s5Licence, s5AdditionalContact)
+
+    scenarios.primaryUserWithAdditionalContact = {
+      licenceHolderRecipient: s5LicenceHolderRecipient,
+      primaryUserRecipient: s5PrimaryUserRecipient,
+      additionalContactRecipient: s5AdditionalContactRecipient
+    }
+
+    // 6) Additional contact multiple licence refs. Two calls with the same default company name and contact email means
+    // the query combines them into a single row per contact (same contact_hash_id).
+    const scenario6a = await RecipientScenariosSeeder.additionalContactRecipient()
+    const scenario6b = await RecipientScenariosSeeder.additionalContactRecipient()
+
+    scenarios.additionalContactMultipleLicences = {
+      licenceHolderRecipient: scenario6a.licenceHolderRecipient,
+      licenceHolderRecipientTwo: scenario6b.licenceHolderRecipient,
+      additionalContactRecipient: scenario6a.additionalContactRecipient,
+      additionalContactRecipientTwo: scenario6b.additionalContactRecipient
+    }
+
+    // 7) Different licence holders and different additional contacts for different licences. Unlike scenario 6 where
     // the same contact spans multiple licences and is combined into one row, here each licence has unique contacts so
     // all four recipients are returned separately.
-    const s7a = await _additionalContact('HolderWithUniqueContactA')
-    const s7b = await _additionalContact('HolderWithUniqueContactB', {
-      firstName: 'Champ',
-      lastName: 'Kind',
-      email: 'champ.kind@news.com'
-    })
+    const s7a = await RecipientScenariosSeeder.additionalContactRecipient(true, null, null, 'HolderWithUniqueContactA')
+    const s7b = await RecipientScenariosSeeder.additionalContactRecipient(
+      true,
+      null,
+      null,
+      'HolderWithUniqueContactB',
+      {
+        firstName: 'Champ',
+        lastName: 'Kind',
+        email: 'champ.kind@news.com'
+      }
+    )
+
     scenarios.differentHoldersAndContacts = {
       firstLicenceHolderRecipient: s7a.licenceHolderRecipient,
       secondLicenceHolderRecipient: s7b.licenceHolderRecipient,
@@ -84,16 +93,14 @@ describe('Notices - Setup - Abstraction Alerts - Abstraction Alert Recipients Qu
 
     // 8) Two licences with different licence holders and additional contacts, but one additional contact has
     // abstractionAlerts = false and should NOT appear in results.
-    const s8a = await _additionalContact('HolderWithMixedAlertsA')
-    const s8b = await _additionalContact(
-      'HolderWithMixedAlertsB',
-      {
-        firstName: 'Champ',
-        lastName: 'Kind',
-        email: 'champ.kind@news.com'
-      },
-      false
-    )
+    const s8a = await RecipientScenariosSeeder.additionalContactRecipient(true, null, null, 'HolderWithMixedAlertsA')
+
+    const s8b = await RecipientScenariosSeeder.additionalContactRecipient(false, null, null, 'HolderWithMixedAlertsB', {
+      firstName: 'Champ',
+      lastName: 'Kind',
+      email: 'champ.kind@news.com'
+    })
+
     scenarios.mixedAlerts = {
       licenceHolderRecipientWithAlert: s8a.licenceHolderRecipient,
       licenceHolderRecipientWithoutAlert: s8b.licenceHolderRecipient,
@@ -146,7 +153,21 @@ describe('Notices - Setup - Abstraction Alerts - Abstraction Alert Recipients Qu
       })
     })
 
-    describe('and only the "primary user" is present for a registered licence (Scenario 3)', () => {
+    describe('and an additional contact is present but abstractionAlerts is false (Scenario 3)', () => {
+      it('returns only the "licence holder" and not the additional contact', async () => {
+        const licenceRefs = scenarios.additionalContactNoAlerts.licenceHolderRecipient.licenceRefs
+
+        const { rows } = await db.raw(query, [licenceRefs, licenceRefs, licenceRefs])
+
+        const expectedResults = RecipientScenariosSeeder.transformToSendingResults({
+          licenceHolderRecipient: scenarios.additionalContactNoAlerts.licenceHolderRecipient
+        })
+
+        expect(rows).to.equal(expectedResults)
+      })
+    })
+
+    describe('and only the "primary user" is present for a registered licence (Scenario 4)', () => {
       it('returns the expected recipients', async () => {
         const licenceRefs = scenarios.primaryUser.primaryUserRecipient.licenceRefs
 
@@ -160,7 +181,7 @@ describe('Notices - Setup - Abstraction Alerts - Abstraction Alert Recipients Qu
       })
     })
 
-    describe('and both the "primary user" and "additional contact" are present for a registered licence, but not the licence holder (Scenario 4)', () => {
+    describe('and both the "primary user" and "additional contact" are present for a registered licence, but not the licence holder (Scenario 5)', () => {
       it('returns the expected recipients', async () => {
         const licenceRefs = scenarios.primaryUserWithAdditionalContact.primaryUserRecipient.licenceRefs
 
@@ -175,7 +196,7 @@ describe('Notices - Setup - Abstraction Alerts - Abstraction Alert Recipients Qu
       })
     })
 
-    describe('and the same "additional contact" is associated with multiple licence documents (Scenario 5)', () => {
+    describe('and the same "additional contact" is associated with multiple licence documents (Scenario 6)', () => {
       it('returns the expected recipients', async () => {
         const licenceRefs = [
           ...scenarios.additionalContactMultipleLicences.licenceHolderRecipient.licenceRefs,
@@ -199,20 +220,6 @@ describe('Notices - Setup - Abstraction Alerts - Abstraction Alert Recipients Qu
         })
 
         expect(sortedRows).to.equal(expectedResults)
-      })
-    })
-
-    describe('and an additional contact is present but abstractionAlerts is false (Scenario 6)', () => {
-      it('returns only the "licence holder" and not the additional contact', async () => {
-        const licenceRefs = scenarios.additionalContactNoAlerts.licenceHolderRecipient.licenceRefs
-
-        const { rows } = await db.raw(query, [licenceRefs, licenceRefs, licenceRefs])
-
-        const expectedResults = RecipientScenariosSeeder.transformToSendingResults({
-          licenceHolderRecipient: scenarios.additionalContactNoAlerts.licenceHolderRecipient
-        })
-
-        expect(rows).to.equal(expectedResults)
       })
     })
 

--- a/test/support/seeders/crm-contacts.seeder.js
+++ b/test/support/seeders/crm-contacts.seeder.js
@@ -19,7 +19,7 @@ const LicenceVersionHelper = require('../helpers/licence-version.helper.js')
  *
  * An additional contact is
  *
- * @param licenceHolderSeedData
+ * @param {object} licenceHolderSeedData - Licence holder (company, address, and licence version) data
  * @param {object} additionalContactSeedData - The additional contact seed data
  * @param {boolean} [abstractionAlerts=true] - Whether the contact has abstraction alerts enabled
  * @param {Date|null} [deletedAt=null] - Whether the contact has been soft deleted

--- a/test/support/seeders/crm-contacts.seeder.js
+++ b/test/support/seeders/crm-contacts.seeder.js
@@ -19,24 +19,18 @@ const LicenceVersionHelper = require('../helpers/licence-version.helper.js')
  *
  * An additional contact is
  *
- * @param {object} licenceSeedData - The licence seed data
  * @param licenceHolderSeedData
  * @param {object} additionalContactSeedData - The additional contact seed data
  * @param {boolean} [abstractionAlerts=true] - Whether the contact has abstraction alerts enabled
- * @param {Date|null} [endDate=null] - Optional end date for the licence document role
- * @param {boolean|null} [deletedAt=null] - Whether the contact has been soft deleted
- * @param {object|null} [licences] - Optional licences for the company contact
+ * @param {Date|null} [deletedAt=null] - Whether the contact has been soft deleted
  *
  * @returns {Promise<object>} an object containing all records related to an additional contact
  */
 async function additionalContact(
-  licenceSeedData,
   licenceHolderSeedData,
   additionalContactSeedData = null,
   abstractionAlerts = true,
-  endDate = null,
-  deletedAt = null,
-  licences = null
+  deletedAt = null
 ) {
   const additionalContact = additionalContactSeedData || {
     firstName: 'Ron',
@@ -50,11 +44,7 @@ async function additionalContact(
     companyId: licenceHolderSeedData.company.id,
     licenceRoleId: licenceRole.id,
     abstractionAlerts,
-    deletedAt,
-    licences:
-      licences === null
-        ? null
-        : JSON.stringify(licences ? [licenceSeedData.licence.id] : ['00000000-0000-0000-0000-000000000000'])
+    deletedAt
   })
 
   const contact = await ContactHelper.add({
@@ -80,7 +70,7 @@ async function additionalContact(
  *
  * @param {object} licenceSeedData - The licence seed data
  * @param {string} name - The company name
- * @param {string} [existingRegionId] - The id of the region to assign to the company that will be created
+ * @param {string|null} [existingRegionId] - The id of the region to assign to the company that will be created
  *
  * @param licenceVersionEndDate
  * @returns {Promise<object>} an object containing all records related to a licence holder

--- a/test/support/seeders/crm-contacts.seeder.js
+++ b/test/support/seeders/crm-contacts.seeder.js
@@ -20,19 +20,23 @@ const LicenceVersionHelper = require('../helpers/licence-version.helper.js')
  * An additional contact is
  *
  * @param {object} licenceSeedData - The licence seed data
+ * @param licenceHolderSeedData
  * @param {object} additionalContactSeedData - The additional contact seed data
  * @param {boolean} [abstractionAlerts=true] - Whether the contact has abstraction alerts enabled
  * @param {Date|null} [endDate=null] - Optional end date for the licence document role
  * @param {boolean|null} [deletedAt=null] - Whether the contact has been soft deleted
+ * @param {object|null} [licences] - Optional licences for the company contact
  *
  * @returns {Promise<object>} an object containing all records related to an additional contact
  */
 async function additionalContact(
   licenceSeedData,
+  licenceHolderSeedData,
   additionalContactSeedData = null,
   abstractionAlerts = true,
   endDate = null,
-  deletedAt = null
+  deletedAt = null,
+  licences = null
 ) {
   const additionalContact = additionalContactSeedData || {
     firstName: 'Ron',
@@ -40,18 +44,17 @@ async function additionalContact(
     email: 'Ron.Burgundy@news.com'
   }
 
-  const licenceDocumentRole = await LicenceDocumentRoleHelper.add({
-    licenceDocumentId: licenceSeedData.licenceDocument.id,
-    endDate
-  })
-
   const licenceRole = await LicenceRoleHelper.select('additionalContact')
 
   const companyContact = await CompanyContactHelper.add({
-    companyId: licenceDocumentRole.companyId,
+    companyId: licenceHolderSeedData.company.id,
     licenceRoleId: licenceRole.id,
     abstractionAlerts,
-    deletedAt
+    deletedAt,
+    licences:
+      licences === null
+        ? null
+        : JSON.stringify(licences ? [licenceSeedData.licence.id] : ['00000000-0000-0000-0000-000000000000'])
   })
 
   const contact = await ContactHelper.add({
@@ -62,12 +65,10 @@ async function additionalContact(
   return {
     companyContact,
     contact,
-    licenceDocumentRole,
     licenceRole,
     clean: async () => {
       await companyContact.$query().delete()
       await contact.$query().delete()
-      await licenceDocumentRole.$query().delete()
     }
   }
 }
@@ -81,9 +82,10 @@ async function additionalContact(
  * @param {string} name - The company name
  * @param {string} [existingRegionId] - The id of the region to assign to the company that will be created
  *
+ * @param licenceVersionEndDate
  * @returns {Promise<object>} an object containing all records related to a licence holder
  */
-async function licenceHolder(licenceSeedData, name, existingRegionId = null) {
+async function licenceHolder(licenceSeedData, name, existingRegionId = null, licenceVersionEndDate = null) {
   const regionId = existingRegionId || licenceSeedData.licence.regionId
 
   const company = await CompanyHelper.add({
@@ -106,7 +108,7 @@ async function licenceHolder(licenceSeedData, name, existingRegionId = null) {
   const licenceVersion = await LicenceVersionHelper.add({
     addressId: address.id,
     companyId: company.id,
-    endDate: null,
+    endDate: licenceVersionEndDate,
     licenceId: licenceSeedData.licence.id
   })
 

--- a/test/support/seeders/recipient-scenarios.seeder.js
+++ b/test/support/seeders/recipient-scenarios.seeder.js
@@ -16,7 +16,7 @@ const { compareStrings } = require('../../../app/lib/general.lib.js')
  * @param {boolean} [abstractionAlerts] - Whether the contact has abstraction alerts enabled
  * @param {Date|null} [licenceVersionEndDate] - Optional licence version end date
  * @param {Date|null} [deletedAt] - Optional soft-delete date for the company contact
- * @param name
+ * @param {string} [name] - The company name for the licence holder
  * @param {object|null} [contactData] - Optional contact data overrides
  *
  * @returns {Promise<object>} An object representing the recipient and its properties for easier testing

--- a/test/support/seeders/recipient-scenarios.seeder.js
+++ b/test/support/seeders/recipient-scenarios.seeder.js
@@ -16,6 +16,7 @@ const { compareStrings } = require('../../../app/lib/general.lib.js')
  * @param {boolean} [abstractionAlerts] - Whether the contact has abstraction alerts enabled
  * @param {Date|null} [licenceVersionEndDate] - Optional licence version end date
  * @param {Date|null} [deletedAt] - Optional soft-delete date for the company contact
+ * @param name
  * @param {object|null} [contactData] - Optional contact data overrides
  *
  * @returns {Promise<object>} An object representing the recipient and its properties for easier testing
@@ -24,15 +25,11 @@ async function additionalContactRecipient(
   abstractionAlerts = true,
   licenceVersionEndDate = null,
   deletedAt = null,
+  name = 'LicenceHolderForAdditonalContact',
   contactData = null
 ) {
   const licence = await EmptyLicence.seed()
-  const licenceHolder = await CRMContactsSeeder.licenceHolder(
-    licence,
-    'LicenceHolderForAdditonalContact',
-    null,
-    licenceVersionEndDate
-  )
+  const licenceHolder = await CRMContactsSeeder.licenceHolder(licence, name, null, licenceVersionEndDate)
 
   const licenceHolderRecipient = await RecipientsFormatter.licenceHolder(licence, licenceHolder)
 

--- a/test/support/seeders/recipient-scenarios.seeder.js
+++ b/test/support/seeders/recipient-scenarios.seeder.js
@@ -18,27 +18,35 @@ const { compareStrings } = require('../../../app/lib/general.lib.js')
  * @param {object|null} [contactData] - Optional contact data overrides
  * @param {Date|null} [endDate] - Optional end date for the licence document role
  * @param {Date|null} [deletedAt] - Optional soft-delete date for the company contact
+ * @param {object|null} [licences] - Optional licences for the company contact
  *
  * @returns {Promise<object>} An object representing the recipient and its properties for easier testing
  */
 async function additionalContactRecipient(
-  licence,
   abstractionAlerts = true,
   contactData = null,
   endDate = null,
-  deletedAt = null
+  deletedAt = null,
+  licences = null
 ) {
+  const licence = await EmptyLicence.seed()
+  const licenceHolder = await CRMContactsSeeder.licenceHolder(licence, 'Primaryonlyholder', null, endDate)
+
+  const licenceHolderRecipient = await RecipientsFormatter.licenceHolder(licence, licenceHolder)
+
   const additionalContact = await CRMContactsSeeder.additionalContact(
     licence,
+    licenceHolder,
     contactData,
     abstractionAlerts,
     endDate,
-    deletedAt
+    deletedAt,
+    licences
   )
 
   const additionalContactRecipient = await RecipientsFormatter.additionalContact(licence, additionalContact)
 
-  return { additionalContactRecipient }
+  return { licenceHolderRecipient, additionalContactRecipient }
 }
 
 /**

--- a/test/support/seeders/recipient-scenarios.seeder.js
+++ b/test/support/seeders/recipient-scenarios.seeder.js
@@ -13,35 +13,34 @@ const { compareStrings } = require('../../../app/lib/general.lib.js')
 /**
  * Seeds an additional contact recipient for an existing licence
  *
- * @param {object} licence - The licence seed data
  * @param {boolean} [abstractionAlerts] - Whether the contact has abstraction alerts enabled
- * @param {object|null} [contactData] - Optional contact data overrides
- * @param {Date|null} [endDate] - Optional end date for the licence document role
+ * @param {Date|null} [licenceVersionEndDate] - Optional licence version end date
  * @param {Date|null} [deletedAt] - Optional soft-delete date for the company contact
- * @param {object|null} [licences] - Optional licences for the company contact
+ * @param {object|null} [contactData] - Optional contact data overrides
  *
  * @returns {Promise<object>} An object representing the recipient and its properties for easier testing
  */
 async function additionalContactRecipient(
   abstractionAlerts = true,
-  contactData = null,
-  endDate = null,
+  licenceVersionEndDate = null,
   deletedAt = null,
-  licences = null
+  contactData = null
 ) {
   const licence = await EmptyLicence.seed()
-  const licenceHolder = await CRMContactsSeeder.licenceHolder(licence, 'Primaryonlyholder', null, endDate)
+  const licenceHolder = await CRMContactsSeeder.licenceHolder(
+    licence,
+    'LicenceHolderForAdditonalContact',
+    null,
+    licenceVersionEndDate
+  )
 
   const licenceHolderRecipient = await RecipientsFormatter.licenceHolder(licence, licenceHolder)
 
   const additionalContact = await CRMContactsSeeder.additionalContact(
-    licence,
     licenceHolder,
     contactData,
     abstractionAlerts,
-    endDate,
-    deletedAt,
-    licences
+    deletedAt
   )
 
   const additionalContactRecipient = await RecipientsFormatter.additionalContact(licence, additionalContact)


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5633

This change refactors the additional contact query to use the licence versions instead of the licence document roles. 

This aligns with previous changes to the licence holder. 

This has affected the test setup, so we have updated the additional contact crm seeder and recipient scenario helper. 

We have added a test for the 'currentLicenceVersionsJoin' query so we do not need to test it through the parent queries. 

---------

Co-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>