### PR TITLE
Update explanatory text on the Notices page 

### DIFF
--- a/app/presenters/notices/index-notices.presenter.js
+++ b/app/presenters/notices/index-notices.presenter.js
@@ -21,11 +21,28 @@ function go(notices, auth) {
   } = auth
 
   return {
+    helperText: _helperText(scope),
     links: _links(scope),
     notices: _noticeRowData(notices),
     pageSubHeading: 'View a notice',
     pageTitle: 'Notices'
   }
+}
+
+function _helperText(scope) {
+  if (scope.includes('bulk_return_notifications') && scope.includes('renewal_notifications')) {
+    return 'Create a renewals invitation, returns invitation, reminder or paper return notice'
+  }
+
+  if (scope.includes('bulk_return_notifications')) {
+    return 'Create a returns invitation, reminder or paper return notice'
+  }
+
+  if (scope.includes('renewal_notifications')) {
+    return 'Create a renewals invitation'
+  }
+
+  return null
 }
 
 function _links(scope) {

--- a/app/views/notices/index.njk
+++ b/app/views/notices/index.njk
@@ -12,7 +12,9 @@
 
 {% block pageContent %}
   {% if links.notice or links.adhoc %}
-    <p> Create a returns invitation, reminder or paper return notice</p>
+    {% if helperText %}
+      <p>{{ helperText }}</p>
+    {% endif %}
 
     <div class="govuk-button-group">
       {% if links.notice %}

--- a/test/presenters/notices/index-notices.presenter.test.js
+++ b/test/presenters/notices/index-notices.presenter.test.js
@@ -29,6 +29,7 @@ describe('Notices - Index Notices presenter', () => {
     const result = IndexNoticesPresenter.go(notices, auth)
 
     expect(result).to.equal({
+      helperText: 'Create a returns invitation, reminder or paper return notice',
       links: {
         adhoc: {
           href: '/system/notices/setup/adhoc',
@@ -133,6 +134,58 @@ describe('Notices - Index Notices presenter', () => {
       ],
       pageSubHeading: 'View a notice',
       pageTitle: 'Notices'
+    })
+  })
+
+  describe('the "helperText" property', () => {
+    describe('when the user has both the "bulk_notifications" and "renewal_notifications" roles', () => {
+      beforeEach(() => {
+        auth.credentials.scope = ['bulk_return_notifications', 'renewal_notifications']
+      })
+
+      it('returns the correct helper text', () => {
+        const result = IndexNoticesPresenter.go(notices, auth)
+
+        expect(result.helperText).to.equal(
+          'Create a renewals invitation, returns invitation, reminder or paper return notice'
+        )
+      })
+    })
+
+    describe('when the user has only the "bulk_notifications" role', () => {
+      beforeEach(() => {
+        auth.credentials.scope = ['bulk_return_notifications']
+      })
+
+      it('returns the correct helper text', () => {
+        const result = IndexNoticesPresenter.go(notices, auth)
+
+        expect(result.helperText).to.equal('Create a returns invitation, reminder or paper return notice')
+      })
+    })
+
+    describe('when the user has only the "renewal_notifications" role', () => {
+      beforeEach(() => {
+        auth.credentials.scope = ['renewal_notifications']
+      })
+
+      it('returns the correct helper text', () => {
+        const result = IndexNoticesPresenter.go(notices, auth)
+
+        expect(result.helperText).to.equal('Create a renewals invitation')
+      })
+    })
+
+    describe('when the user has neither role', () => {
+      beforeEach(() => {
+        auth.credentials.scope = ['returns']
+      })
+
+      it('returns null', () => {
+        const result = IndexNoticesPresenter.go(notices, auth)
+
+        expect(result.helperText).to.be.null()
+      })
     })
   })
 

--- a/test/services/notices/index-notices.service.test.js
+++ b/test/services/notices/index-notices.service.test.js
@@ -60,6 +60,7 @@ describe('Notices - Index Notices service', () => {
           statuses: [],
           toDate: null
         },
+        helperText: 'Create a returns invitation, reminder or paper return notice',
         links: {
           adhoc: {
             href: '/system/notices/setup/adhoc',

--- a/test/services/notices/submit-index-notices.service.test.js
+++ b/test/services/notices/submit-index-notices.service.test.js
@@ -246,6 +246,7 @@ describe('Notices - Submit Index Notices service', () => {
               statuses: [],
               toDate: undefined
             },
+            helperText: 'Create a returns invitation, reminder or paper return notice',
             links: {
               adhoc: {
                 href: '/system/notices/setup/adhoc',
@@ -335,6 +336,7 @@ describe('Notices - Submit Index Notices service', () => {
               statuses: [],
               toDate: undefined
             },
+            helperText: 'Create a returns invitation, reminder or paper return notice',
             links: {
               adhoc: {
                 href: '/system/notices/setup/adhoc',


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5643

We're updating the Create an ad-hoc notice journey to support renewals invitations.

This means users will have the option to create a renewal invitation.

We did that in [Add renewal invitations to the adhoc notice journey](https://github.com/DEFRA/water-abstraction-system/pull/3350).

One of the things we've needed to cater for is that users with the role `renewal_notifications` can only create renewal invitations, and not other types of ad-hoc notice.

And those with `bulk_notifications` can only create paper return, return invitations, and return reminders.

What we overlooked was the explanatory text we show above the 'Create' buttons on the Notices page.

It still assumes the only notice types we support are paper return, return invitations and return reminders.

We can't just add renewal invitations to the list due to differences in permissions.

So, we need to make the text dynamic based on the user's permissions.