### PR TITLE
Add 'abstractionAlertLicences' jsonb column company contacts view

### DIFF
--- a/db/migrations/legacy/20221108003009_crm-v2-company-contacts.js
+++ b/db/migrations/legacy/20221108003009_crm-v2-company-contacts.js
@@ -17,6 +17,8 @@ exports.up = function (knex) {
     table.date('end_date')
     table.boolean('is_test').notNullable().defaultTo(false)
     table.boolean('water_abstraction_alerts_enabled').defaultTo(false)
+    table.jsonb('abstraction_alert_licences').defaultTo(null)
+
     table.uuid('created_by')
     table.uuid('updated_by')
     table.timestamp('deleted_at').defaultTo(null)

--- a/db/migrations/public/20260605113548_alter-company-contacts-view.js
+++ b/db/migrations/public/20260605113548_alter-company-contacts-view.js
@@ -1,0 +1,54 @@
+'use strict'
+
+const viewName = 'company_contacts'
+
+exports.up = function (knex) {
+  return knex.schema.dropViewIfExists(viewName).createView(viewName, (view) => {
+    // NOTE: We have commented out unused columns from the source table
+    view.as(
+      knex('company_contacts').withSchema('crm_v2').select([
+        'company_contact_id AS id',
+        'company_id',
+        'contact_id',
+        'role_id AS licence_role_id',
+        'is_default AS default',
+        'start_date',
+        'water_abstraction_alerts_enabled AS abstraction_alerts',
+        'abstraction_alert_licences as abstractionAlertLicences',
+        // email_address
+        // end_date
+        // is_test
+        'date_created AS created_at',
+        'date_updated AS updated_at',
+        'created_by',
+        'updated_by',
+        'deleted_at'
+      ])
+    )
+  })
+}
+
+exports.down = function (knex) {
+  return knex.schema.dropViewIfExists(viewName).createView(viewName, (view) => {
+    // NOTE: We have commented out unused columns from the source table
+    view.as(
+      knex('company_contacts').withSchema('crm_v2').select([
+        'company_contact_id AS id',
+        'company_id',
+        'contact_id',
+        'role_id AS licence_role_id',
+        'is_default AS default',
+        'start_date',
+        'water_abstraction_alerts_enabled AS abstraction_alerts',
+        // email_address
+        // end_date
+        // is_test
+        'date_created AS created_at',
+        'date_updated AS updated_at',
+        'created_by',
+        'updated_by',
+        'deleted_at'
+      ])
+    )
+  })
+}

--- a/test/services/company-contacts/setup/create-company-contact.service.test.js
+++ b/test/services/company-contacts/setup/create-company-contact.service.test.js
@@ -52,6 +52,7 @@ describe('Company Contacts - Create Company Contact service', () => {
 
       expect(newCompanyContact).to.equal(
         {
+          abstractionAlertLicences: null,
           abstractionAlerts: true,
           createdBy: companyContact.createdBy,
           companyId: company.id,

--- a/test/services/company-contacts/setup/update-company-contact.service.test.js
+++ b/test/services/company-contacts/setup/update-company-contact.service.test.js
@@ -81,6 +81,7 @@ describe('Company Contacts - Update Company Contact service', () => {
         {
           id: companyContact.id,
           abstractionAlerts: true,
+          abstractionAlertLicences: null,
           companyId: companyContact.companyId,
           contactId: contact.id,
           createdAt: seedDate,


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5633

This change adds a 'abstractionAlertLicences' column to the company contacts view.

This is intended to store the licence id's for a company contact for abstraction alerts.