### PR TITLE
Remove confusing notes in NotifyTokenCache test

### DIFF
--- a/test/plugins/notify-token-cache.plugin.test.js
+++ b/test/plugins/notify-token-cache.plugin.test.js
@@ -25,11 +25,6 @@ describe('Notify Token Cache plugin', () => {
   let testDate
 
   beforeEach(async () => {
-    // NOTE: We stub the UserModel `findById().select()` query to avoid hitting the DB as part of the test. It is
-    // sufficiently simple running it would just be testing Objection.js and not our logic.
-    // Sinon.stub(NotifyConfig, 'apiKey').value(
-    //   'my_test_key-26785a09-ab16-4eb0-8407-a37497a57506-3d844edf-8d35-48ac-975b-e847b4f122b0'
-    // )
     jwtSignSpy = Sinon.spy(jwt, 'sign')
 
     testDate = new Date('2025-08-19T11:03:00.000Z')
@@ -38,8 +33,6 @@ describe('Notify Token Cache plugin', () => {
     // Create server before each test
     server = await init()
 
-    // NOTE: We stub the UserModel `findById().select()` query to avoid hitting the DB as part of the test. It is
-    // sufficiently simple running it would just be testing Objection.js and not our logic.
     Sinon.stub(notifyConfig, 'apiKey').value(
       'my_test_key-26785a09-ab16-4eb0-8407-a37497a57506-3d844edf-8d35-48ac-975b-e847b4f122b0'
     )


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4781

We added these comments when we moved from using the GOV.UK Notification package to just call the GOV.UK Notify API directly.

However, we can't tell you why, as they make no sense in the context in which they are placed!

However, they are being flagged by GitHub security, which thinks we have production keys in our code. So, we're fixing the problem rather than just ignoring the warnings.