### PR TITLE
Create internal user - Cancel page

### DIFF
--- a/app/controllers/users-setup.controller.js
+++ b/app/controllers/users-setup.controller.js
@@ -98,9 +98,9 @@ async function submitInternalCheck(request, h) {
     yar
   } = request
 
-  await SubmitInternalCheckService.go(auth, sessionId, yar)
+  const { redirectUrl } = await SubmitInternalCheckService.go(auth, sessionId, yar)
 
-  return h.redirect('/system/users')
+  return h.redirect(redirectUrl)
 }
 
 async function submitInternalEmail(request, h) {

--- a/app/controllers/users-setup.controller.js
+++ b/app/controllers/users-setup.controller.js
@@ -10,12 +10,14 @@ const InitiateInternalSessionService = require('../services/users/internal/setup
 const SubmitExternalCancelService = require('../services/users/external/setup/submit-cancel.service.js')
 const SubmitExternalCheckService = require('../services/users/external/setup/submit-check.service.js')
 const SubmitExternalLicencesService = require('../services/users/external/setup/submit-licences.service.js')
+const SubmitInternalCancelService = require('../services/users/internal/setup/submit-cancel.service.js')
 const SubmitInternalCheckService = require('../services/users/internal/setup/submit-check.service.js')
 const SubmitInternalEmailService = require('../services/users/internal/setup/submit-email.service.js')
 const SubmitInternalPermissionsService = require('../services/users/internal/setup/submit-permissions.service.js')
 const ViewExternalCancelService = require('../services/users/external/setup/view-cancel.service.js')
 const ViewExternalCheckService = require('../services/users/external/setup/view-check.service.js')
 const ViewExternalLicencesService = require('../services/users/external/setup/view-licences.service.js')
+const ViewInternalCancelService = require('../services/users/internal/setup/view-cancel.service.js')
 const ViewInternalCheckService = require('../services/users/internal/setup/view-check.service.js')
 const ViewInternalEmailService = require('../services/users/internal/setup/view-email.service.js')
 const ViewInternalPermissionsService = require('../services/users/internal/setup/view-permissions.service.js')
@@ -77,6 +79,16 @@ async function submitExternalLicences(request, h) {
   }
 
   return h.redirect(pageData.redirectUrl)
+}
+
+async function submitInternalCancel(request, h) {
+  const {
+    params: { sessionId }
+  } = request
+
+  const { redirectUrl } = await SubmitInternalCancelService.go(sessionId)
+
+  return h.redirect(redirectUrl)
 }
 
 async function submitInternalCheck(request, h) {
@@ -151,6 +163,14 @@ async function viewExternalLicences(request, h) {
   return h.view('users/external/setup/licences.njk', pageData)
 }
 
+async function viewInternalCancel(request, h) {
+  const { sessionId } = request.params
+
+  const pageData = await ViewInternalCancelService.go(sessionId)
+
+  return h.view('users/internal/setup/cancel.njk', pageData)
+}
+
 async function viewInternalCheck(request, h) {
   const {
     params: { sessionId },
@@ -187,12 +207,14 @@ module.exports = {
   submitExternalCancel,
   submitExternalCheck,
   submitExternalLicences,
+  submitInternalCancel,
   submitInternalCheck,
   submitInternalEmail,
   submitInternalPermissions,
   viewExternalCancel,
   viewExternalCheck,
   viewExternalLicences,
+  viewInternalCancel,
   viewInternalCheck,
   viewInternalEmail,
   viewInternalPermissions

--- a/app/presenters/users/internal/setup/cancel.presenter.js
+++ b/app/presenters/users/internal/setup/cancel.presenter.js
@@ -1,0 +1,31 @@
+'use strict'
+
+/**
+ * Formats data for the '/users/internal/setup/{sessionId}/cancel' page
+ * @module CancelPresenter
+ */
+
+const { userPermissions } = require('../../../../lib/static-lookups.lib.js')
+
+/**
+ * Formats data for the '/users/internal/setup/{sessionId}/cancel' page
+ *
+ * @param {object} session - The session instance
+ *
+ * @returns {object} The data formatted for the view template
+ */
+function go(session) {
+  const { email, id: sessionId, permission } = session
+
+  return {
+    activeNavBar: 'users',
+    email,
+    pageTitle: 'You are about to cancel this user',
+    pageTitleCaption: 'Internal',
+    permission: userPermissions[permission].label
+  }
+}
+
+module.exports = {
+  go
+}

--- a/app/presenters/users/internal/setup/cancel.presenter.js
+++ b/app/presenters/users/internal/setup/cancel.presenter.js
@@ -15,7 +15,7 @@ const { userPermissions } = require('../../../../lib/static-lookups.lib.js')
  * @returns {object} The data formatted for the view template
  */
 function go(session) {
-  const { email, id: sessionId, permission } = session
+  const { email, permission } = session
 
   return {
     activeNavBar: 'users',

--- a/app/presenters/users/internal/setup/check.presenter.js
+++ b/app/presenters/users/internal/setup/check.presenter.js
@@ -21,6 +21,7 @@ function go(session) {
     activeNavBar: 'users',
     email,
     links: {
+      cancel: `/system/users/internal/setup/${sessionId}/cancel`,
       email: `/system/users/internal/setup/${sessionId}/email`,
       permissions: `/system/users/internal/setup/${sessionId}/permissions`
     },

--- a/app/routes/users-setup.routes.js
+++ b/app/routes/users-setup.routes.js
@@ -101,6 +101,30 @@ const routes = [
   },
   {
     method: 'GET',
+    path: '/users/internal/setup/{sessionId}/cancel',
+    options: {
+      handler: UsersSetupController.viewInternalCancel,
+      auth: {
+        access: {
+          scope: ['manage_accounts']
+        }
+      }
+    }
+  },
+  {
+    method: 'POST',
+    path: '/users/internal/setup/{sessionId}/cancel',
+    options: {
+      handler: UsersSetupController.submitInternalCancel,
+      auth: {
+        access: {
+          scope: ['manage_accounts']
+        }
+      }
+    }
+  },
+  {
+    method: 'GET',
     path: '/users/internal/setup/{sessionId}/check',
     options: {
       handler: UsersSetupController.viewInternalCheck,

--- a/app/services/users/internal/setup/submit-cancel.service.js
+++ b/app/services/users/internal/setup/submit-cancel.service.js
@@ -1,0 +1,27 @@
+'use strict'
+
+/**
+ * Orchestrates handling the data for `/users/internal/setup/{sessionId}/cancel` page
+ * @module SubmitCancelService
+ */
+
+const DeleteSessionDal = require('../../../../dal/delete-session.dal.js')
+
+/**
+ * Orchestrates handling the data for `/users/internal/setup/{sessionId}/cancel` page
+ *
+ * This service will delete the session record and provide the redirect url.
+ *
+ * @param {string} sessionId - The UUID of the current session
+ *
+ * @returns {Promise<string>} - The redirect url
+ */
+async function go(sessionId) {
+  await DeleteSessionDal.go(sessionId)
+
+  return '/system/users'
+}
+
+module.exports = {
+  go
+}

--- a/app/services/users/internal/setup/submit-cancel.service.js
+++ b/app/services/users/internal/setup/submit-cancel.service.js
@@ -14,12 +14,14 @@ const DeleteSessionDal = require('../../../../dal/delete-session.dal.js')
  *
  * @param {string} sessionId - The UUID of the current session
  *
- * @returns {Promise<string>} - The redirect url
+ * @returns {Promise<object>} An object containing the URL to redirect the user to after cancelling
  */
 async function go(sessionId) {
   await DeleteSessionDal.go(sessionId)
 
-  return '/system/users'
+  return {
+    redirectUrl: '/system/users'
+  }
 }
 
 module.exports = {

--- a/app/services/users/internal/setup/submit-check.service.js
+++ b/app/services/users/internal/setup/submit-check.service.js
@@ -19,6 +19,8 @@ const { flashNotification } = require('../../../../lib/general.lib.js')
  * @param {object} auth - The current user's authentication details from `request.auth`
  * @param {string} sessionId - The UUID of the current session
  * @param {object} yar - The Hapi `request.yar` session manager passed on by the controller
+ *
+ * @returns {Promise<object>} An object containing the URL to redirect the user to after confirming
  */
 async function go(auth, sessionId, yar) {
   const session = await FetchSessionDal.go(sessionId)
@@ -34,6 +36,10 @@ async function go(auth, sessionId, yar) {
 
   // Intentionally not awaited — fire-and-forget with internal error handling
   SendVerificationEmailService.go(notification)
+
+  return {
+    redirectUrl: '/system/users'
+  }
 }
 
 module.exports = {

--- a/app/services/users/internal/setup/view-cancel.service.js
+++ b/app/services/users/internal/setup/view-cancel.service.js
@@ -1,0 +1,30 @@
+'use strict'
+
+/**
+ * Orchestrates presenting the data for `/users/internal/setup/{sessionId}/cancel` page
+ * @module ViewCancelService
+ */
+
+const CancelPresenter = require('../../../../presenters/users/internal/setup/cancel.presenter.js')
+const FetchSessionDal = require('../../../../dal/fetch-session.dal.js')
+
+/**
+ * Orchestrates presenting the data for `/users/internal/setup/{sessionId}/cancel` page
+ *
+ * @param {string} sessionId - The UUID of the current session
+ *
+ * @returns {Promise<object>} The view data for the cancel page
+ */
+async function go(sessionId) {
+  const session = await FetchSessionDal.go(sessionId)
+
+  const pageData = CancelPresenter.go(session)
+
+  return {
+    ...pageData
+  }
+}
+
+module.exports = {
+  go
+}

--- a/app/services/users/internal/setup/view-cancel.service.js
+++ b/app/services/users/internal/setup/view-cancel.service.js
@@ -20,9 +20,7 @@ async function go(sessionId) {
 
   const pageData = CancelPresenter.go(session)
 
-  return {
-    ...pageData
-  }
+  return pageData
 }
 
 module.exports = {

--- a/app/views/users/internal/setup/cancel.njk
+++ b/app/views/users/internal/setup/cancel.njk
@@ -1,0 +1,28 @@
+{% extends 'layout.njk' %}
+
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+
+{% block pageContent %}
+  {{ govukSummaryList({
+    rows: [
+      {
+        key: { text: "Email address" },
+        value: { text: email },
+      },
+      {
+        key: { text: "Permissions" },
+        value: { text: permission },
+      }
+    ]
+  }) }}
+
+  <form method="post">
+    <input type="hidden" name="wrlsCrumb" value="{{wrlsCrumb}}"/>
+
+    {{ govukButton({
+      text: "Confirm cancel",
+      preventDoubleClick: true
+    }) }}
+  </form>
+{% endblock %}

--- a/app/views/users/internal/setup/cancel.njk
+++ b/app/views/users/internal/setup/cancel.njk
@@ -8,11 +8,11 @@
     rows: [
       {
         key: { text: "Email address" },
-        value: { text: email },
+        value: { text: email }
       },
       {
         key: { text: "Permissions" },
-        value: { text: permission },
+        value: { text: permission }
       }
     ]
   }) }}

--- a/app/views/users/internal/setup/check.njk
+++ b/app/views/users/internal/setup/check.njk
@@ -38,6 +38,18 @@
   <form method="post">
     <input type="hidden" name="wrlsCrumb" value="{{wrlsCrumb}}"/>
 
-    {{ govukButton({ text: "Confirm", preventDoubleClick: true }) }}
+    <div class="govuk-button-group">
+      {{ govukButton({
+        text: "Confirm",
+        preventDoubleClick: true
+      }) }}
+
+      {{ govukButton({
+        text: "Cancel",
+        classes: "govuk-button--secondary",
+        href: links.cancel,
+        preventDoubleClick: true
+      }) }}
+    </div>
   </form>
 {% endblock %}

--- a/test/controllers/users-setup.controller.test.js
+++ b/test/controllers/users-setup.controller.test.js
@@ -303,7 +303,9 @@ describe('Users Setup controller', () => {
 
       describe('when a request is valid', () => {
         beforeEach(() => {
-          Sinon.stub(SubmitInternalCheckService, 'go').resolves()
+          Sinon.stub(SubmitInternalCheckService, 'go').resolves({
+            redirectUrl: '/system/users'
+          })
         })
 
         it('redirects to the Users page', async () => {

--- a/test/controllers/users-setup.controller.test.js
+++ b/test/controllers/users-setup.controller.test.js
@@ -18,12 +18,14 @@ const InitiateInternalSessionService = require('../../app/services/users/interna
 const SubmitExternalCancelService = require('../../app/services/users/external/setup/submit-cancel.service.js')
 const SubmitExternalCheckService = require('../../app/services/users/external/setup/submit-check.service.js')
 const SubmitExternalLicencesService = require('../../app/services/users/external/setup/submit-licences.service.js')
+const SubmitInternalCancelService = require('../../app/services/users/internal/setup/submit-cancel.service.js')
 const SubmitInternalCheckService = require('../../app/services/users/internal/setup/submit-check.service.js')
 const SubmitInternalEmailService = require('../../app/services/users/internal/setup/submit-email.service.js')
 const SubmitInternalPermissionsService = require('../../app/services/users/internal/setup/submit-permissions.service.js')
 const ViewExternalCancelService = require('../../app/services/users/external/setup/view-cancel.service.js')
 const ViewExternalCheckService = require('../../app/services/users/external/setup/view-check.service.js')
 const ViewExternalLicencesService = require('../../app/services/users/external/setup/view-licences.service.js')
+const ViewInternalCancelService = require('../../app/services/users/internal/setup/view-cancel.service.js')
 const ViewInternalCheckService = require('../../app/services/users/internal/setup/view-check.service.js')
 const ViewInternalEmailService = require('../../app/services/users/internal/setup/view-email.service.js')
 const ViewInternalPermissionsService = require('../../app/services/users/internal/setup/view-permissions.service.js')
@@ -228,6 +230,48 @@ describe('Users Setup controller', () => {
 
         expect(response.statusCode).to.equal(HTTP_STATUS_FOUND)
         expect(response.headers.location).to.equal(`/system/users/internal/setup/${id}/email`)
+      })
+    })
+  })
+
+  describe('/users/internal/setup/{sessionId}/cancel', () => {
+    describe('GET', () => {
+      beforeEach(() => {
+        options = _getOptions(`/users/internal/setup/${sessionId}/cancel`, { scope: ['manage_accounts'] })
+
+        Sinon.stub(ViewInternalCancelService, 'go').resolves({
+          pageTitle: 'You are about to cancel this user'
+        })
+      })
+
+      describe('when the request succeeds', () => {
+        it('returns the page successfully', async () => {
+          const response = await server.inject(options)
+
+          expect(response.statusCode).to.equal(HTTP_STATUS_OK)
+          expect(response.payload).to.contain('You are about to cancel this user')
+        })
+      })
+    })
+
+    describe('POST', () => {
+      beforeEach(() => {
+        postOptions = postRequestOptions(`/users/internal/setup/${sessionId}/cancel`, {}, ['manage_accounts'])
+      })
+
+      describe('when a request is valid', () => {
+        beforeEach(() => {
+          Sinon.stub(SubmitInternalCancelService, 'go').resolves({
+            redirectUrl: '/system/users'
+          })
+        })
+
+        it('redirects to the Users page', async () => {
+          const response = await server.inject(postOptions)
+
+          expect(response.statusCode).to.equal(HTTP_STATUS_FOUND)
+          expect(response.headers.location).to.equal('/system/users')
+        })
       })
     })
   })

--- a/test/presenters/users/internal/setup/cancel.presenter.test.js
+++ b/test/presenters/users/internal/setup/cancel.presenter.test.js
@@ -1,0 +1,36 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Test helpers
+const { generateUUID } = require('../../../../../app/lib/general.lib.js')
+
+// Thing under test
+const CancelPresenter = require('../../../../../app/presenters/users/internal/setup/cancel.presenter.js')
+
+describe('Users - Internal - Setup - Cancel Presenter', () => {
+  let session
+
+  beforeEach(() => {
+    session = { email: 'bob.bobbles@environment-agency.gov.uk', id: generateUUID(), permission: 'billing_and_data' }
+  })
+
+  describe('when called', () => {
+    it('returns page data for the view', () => {
+      const result = CancelPresenter.go(session)
+
+      expect(result).to.equal({
+        activeNavBar: 'users',
+        email: session.email,
+        pageTitle: 'You are about to cancel this user',
+        pageTitleCaption: 'Internal',
+        permission: 'Billing and Data'
+      })
+    })
+  })
+})

--- a/test/presenters/users/internal/setup/check.presenter.test.js
+++ b/test/presenters/users/internal/setup/check.presenter.test.js
@@ -28,6 +28,7 @@ describe('Users - Internal - Setup - Check Presenter', () => {
         activeNavBar: 'users',
         email: session.email,
         links: {
+          cancel: `/system/users/internal/setup/${session.id}/cancel`,
           email: `/system/users/internal/setup/${session.id}/email`,
           permissions: `/system/users/internal/setup/${session.id}/permissions`
         },

--- a/test/services/users/internal/setup/submit-cancel.service.test.js
+++ b/test/services/users/internal/setup/submit-cancel.service.test.js
@@ -46,7 +46,9 @@ describe('Users - Internal - Setup - Submit Cancel service', () => {
     it('returns the redirect url', async () => {
       const result = await SubmitCancelService.go(session.id)
 
-      expect(result).to.equal('/system/users')
+      expect(result).to.equal({
+        redirectUrl: '/system/users'
+      })
     })
   })
 })

--- a/test/services/users/internal/setup/submit-cancel.service.test.js
+++ b/test/services/users/internal/setup/submit-cancel.service.test.js
@@ -12,12 +12,12 @@ const { expect } = Code
 const SessionModelStub = require('../../../../support/stubs/session.stub.js')
 
 // Things we need to stub
-const FetchSessionDal = require('../../../../../app/dal/fetch-session.dal.js')
+const DeleteSessionDal = require('../../../../../app/dal/delete-session.dal.js')
 
 // Thing under test
-const ViewCancelService = require('../../../../../app/services/users/internal/setup/view-cancel.service.js')
+const SubmitCancelService = require('../../../../../app/services/users/internal/setup/submit-cancel.service.js')
 
-describe('Users - Internal - Setup - View Cancel Service', () => {
+describe('Users - Internal - Setup - Submit Cancel service', () => {
   let session
   let sessionData
 
@@ -29,7 +29,7 @@ describe('Users - Internal - Setup - View Cancel Service', () => {
 
     session = SessionModelStub.build(Sinon, sessionData)
 
-    Sinon.stub(FetchSessionDal, 'go').resolves(session)
+    Sinon.stub(DeleteSessionDal, 'go').resolves(session)
   })
 
   afterEach(() => {
@@ -37,16 +37,16 @@ describe('Users - Internal - Setup - View Cancel Service', () => {
   })
 
   describe('when called', () => {
-    it('returns page data for the view', async () => {
-      const result = await ViewCancelService.go(session.id)
+    it('clears the session', async () => {
+      await SubmitCancelService.go(session.id)
 
-      expect(result).to.equal({
-        activeNavBar: 'users',
-        email: session.email,
-        pageTitle: 'You are about to cancel this user',
-        pageTitleCaption: 'Internal',
-        permission: 'Billing and Data'
-      })
+      expect(DeleteSessionDal.go.calledWith(session.id)).to.be.true()
+    })
+
+    it('returns the redirect url', async () => {
+      const result = await SubmitCancelService.go(session.id)
+
+      expect(result).to.equal('/system/users')
     })
   })
 })

--- a/test/services/users/internal/setup/submit-check.service.test.js
+++ b/test/services/users/internal/setup/submit-check.service.test.js
@@ -98,5 +98,13 @@ describe('Users - Internal - Setup - Submit Check Service', () => {
 
       expect(SendVerificationEmailService.go.calledWith(notification)).to.be.true()
     })
+
+    it('returns the redirect url', async () => {
+      const result = await SubmitCheckService.go(auth, session.id, yarStub)
+
+      expect(result).to.equal({
+        redirectUrl: '/system/users'
+      })
+    })
   })
 })

--- a/test/services/users/internal/setup/view-cancel.service.test.js
+++ b/test/services/users/internal/setup/view-cancel.service.test.js
@@ -1,0 +1,52 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Test helpers
+const SessionModelStub = require('../../../../support/stubs/session.stub.js')
+
+// Things we need to stub
+const FetchSessionDal = require('../../../../../app/dal/fetch-session.dal.js')
+
+// Thing under test
+const ViewCancelService = require('../../../../../app/services/users/internal/setup/view-cancel.service.js')
+
+describe('Users - Internal - Setup - Cancel Service', () => {
+  let session
+  let sessionData
+
+  beforeEach(() => {
+    sessionData = {
+      email: 'bob.bobbles@environment-agency.gov.uk',
+      permission: 'billing_and_data'
+    }
+
+    session = SessionModelStub.build(Sinon, sessionData)
+
+    Sinon.stub(FetchSessionDal, 'go').resolves(session)
+  })
+
+  afterEach(() => {
+    Sinon.restore()
+  })
+
+  describe('when called', () => {
+    it('returns page data for the view', async () => {
+      const result = await ViewCancelService.go(session.id)
+
+      expect(result).to.equal({
+        activeNavBar: 'users',
+        email: session.email,
+        pageTitle: 'You are about to cancel this user',
+        pageTitleCaption: 'Internal',
+        permission: 'Billing and Data'
+      })
+    })
+  })
+})

--- a/test/services/users/internal/setup/view-check.service.test.js
+++ b/test/services/users/internal/setup/view-check.service.test.js
@@ -47,6 +47,7 @@ describe('Users - Internal - Setup - Check Service', () => {
         activeNavBar: 'users',
         email: session.email,
         links: {
+          cancel: `/system/users/internal/setup/${session.id}/cancel`,
           email: `/system/users/internal/setup/${session.id}/email`,
           permissions: `/system/users/internal/setup/${session.id}/permissions`
         },


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5605

Implement a mechanism to create an internal user, which initially will just allow setting their permission level.

This PR will focus on giving the user the ability to cancel the creation of a new user via a Cancel button on the check page.