### PR TITLE
Initiate company contacts session with licences

### DIFF
--- a/app/dal/company-contacts/fetch-company-licences.dal.js
+++ b/app/dal/company-contacts/fetch-company-licences.dal.js
@@ -1,0 +1,30 @@
+'use strict'
+
+/**
+ * Fetch all licences linked to the given company via their licence version holders
+ * @module FetchCompanyLicencesDal
+ */
+
+const LicenceModel = require('../../models/licence.model.js')
+
+/**
+ * Fetch all licences linked to the given company via their licence version holders
+ *
+ * @param {string} companyId - The UUID of the company to fetch licences for
+ *
+ * @returns {Promise<object[]>} An array of licence objects with `id` and `licenceRef`, sorted by `licenceRef`
+ */
+async function go(companyId) {
+  return LicenceModel.query()
+    .select(['licences.id', 'licences.licenceRef'])
+    .whereExists(
+      LicenceModel.relatedQuery('licenceVersions')
+        .innerJoinRelated('licenceVersionHolder')
+        .where('licenceVersionHolder.companyId', companyId)
+    )
+    .orderBy([{ column: 'licenceRef', order: 'asc' }])
+}
+
+module.exports = {
+  go
+}

--- a/app/dal/company-contacts/fetch-company-licences.dal.js
+++ b/app/dal/company-contacts/fetch-company-licences.dal.js
@@ -24,9 +24,9 @@ async function go(companyId) {
   FROM licences l
   ${currentLicenceVersionsJoin}
   WHERE
-    (l.expired_date IS NULL OR l.expired_date >= ?)
-    AND (l.lapsed_date IS NULL OR l.lapsed_date >= ?)
-    AND (l.revoked_date IS NULL OR l.revoked_date >= ?)
+    (l.expired_date IS NULL OR l.expired_date > ?)
+    AND (l.lapsed_date IS NULL OR l.lapsed_date > ?)
+    AND (l.revoked_date IS NULL OR l.revoked_date > ?)
     AND llv.company_id = ?
   ORDER BY l.licence_ref ASC
   `

--- a/app/dal/company-contacts/fetch-company-licences.dal.js
+++ b/app/dal/company-contacts/fetch-company-licences.dal.js
@@ -17,6 +17,9 @@ const LicenceModel = require('../../models/licence.model.js')
 async function go(companyId) {
   return LicenceModel.query()
     .select(['licences.id', 'licences.licenceRef'])
+    .whereNull('licences.expiredDate')
+    .whereNull('licences.lapsedDate')
+    .whereNull('licences.revokedDate')
     .whereExists(
       LicenceModel.relatedQuery('licenceVersions')
         .innerJoinRelated('licenceVersionHolder')

--- a/app/dal/company-contacts/fetch-company-licences.dal.js
+++ b/app/dal/company-contacts/fetch-company-licences.dal.js
@@ -6,6 +6,7 @@
  */
 
 const LicenceModel = require('../../models/licence.model.js')
+const { timestampForPostgres } = require('../../lib/general.lib.js')
 
 /**
  * Fetch all licences linked to the given company via their licence version holders
@@ -15,17 +16,40 @@ const LicenceModel = require('../../models/licence.model.js')
  * @returns {Promise<object[]>} An array of licence objects with `id` and `licenceRef`, sorted by `licenceRef`
  */
 async function go(companyId) {
+  const licences = await _fetch(companyId)
+
+  return _data(licences)
+}
+
+async function _fetch(companyId) {
   return LicenceModel.query()
-    .select(['licences.id', 'licences.licenceRef'])
-    .whereNull('licences.expiredDate')
-    .whereNull('licences.lapsedDate')
-    .whereNull('licences.revokedDate')
-    .whereExists(
-      LicenceModel.relatedQuery('licenceVersions')
-        .innerJoinRelated('licenceVersionHolder')
-        .where('licenceVersionHolder.companyId', companyId)
-    )
+    .select(['id', 'licenceRef'])
+    .where((expiredDateBuilder) => {
+      expiredDateBuilder.whereNull('expiredDate').orWhere('expiredDate', '>=', timestampForPostgres())
+    })
+    .where((lapsedDateBuilder) => {
+      lapsedDateBuilder.whereNull('lapsedDate').orWhere('lapsedDate', '>=', timestampForPostgres())
+    })
+    .where((revokedDateBuilder) => {
+      revokedDateBuilder.whereNull('revokedDate').orWhere('revokedDate', '>=', timestampForPostgres())
+    })
+    .whereExists(LicenceModel.relatedQuery('licenceVersions').where('companyId', companyId))
+    .modify('currentVersion')
     .orderBy([{ column: 'licenceRef', order: 'asc' }])
+}
+
+/**
+ * We only need to return the licence ID and licence reference.
+ *
+ * @private
+ */
+function _data(licences) {
+  return licences.map((licence) => {
+    return {
+      id: licence.id,
+      licenceRef: licence.licenceRef
+    }
+  })
 }
 
 module.exports = {

--- a/app/dal/company-contacts/fetch-company-licences.dal.js
+++ b/app/dal/company-contacts/fetch-company-licences.dal.js
@@ -5,7 +5,8 @@
  * @module FetchCompanyLicencesDal
  */
 
-const LicenceModel = require('../../models/licence.model.js')
+const { currentLicenceVersionsJoin } = require('../notices/recipient-queries.dal.js')
+const { db } = require('../../../db/db.js')
 const { timestampForPostgres } = require('../../lib/general.lib.js')
 
 /**
@@ -16,40 +17,25 @@ const { timestampForPostgres } = require('../../lib/general.lib.js')
  * @returns {Promise<object[]>} An array of licence objects with `id` and `licenceRef`, sorted by `licenceRef`
  */
 async function go(companyId) {
-  const licences = await _fetch(companyId)
+  const query = `
+  SELECT
+    l.id,
+    l.licence_ref as "licenceRef"
+  FROM licences l
+  ${currentLicenceVersionsJoin}
+  WHERE
+    (l.expired_date IS NULL OR l.expired_date >= ?)
+    AND (l.lapsed_date IS NULL OR l.lapsed_date >= ?)
+    AND (l.revoked_date IS NULL OR l.revoked_date >= ?)
+    AND llv.company_id = ?
+  ORDER BY l.licence_ref ASC
+  `
 
-  return _data(licences)
-}
+  const today = timestampForPostgres()
 
-async function _fetch(companyId) {
-  return LicenceModel.query()
-    .select(['id', 'licenceRef'])
-    .where((expiredDateBuilder) => {
-      expiredDateBuilder.whereNull('expiredDate').orWhere('expiredDate', '>=', timestampForPostgres())
-    })
-    .where((lapsedDateBuilder) => {
-      lapsedDateBuilder.whereNull('lapsedDate').orWhere('lapsedDate', '>=', timestampForPostgres())
-    })
-    .where((revokedDateBuilder) => {
-      revokedDateBuilder.whereNull('revokedDate').orWhere('revokedDate', '>=', timestampForPostgres())
-    })
-    .whereExists(LicenceModel.relatedQuery('licenceVersions').where('companyId', companyId))
-    .modify('currentVersion')
-    .orderBy([{ column: 'licenceRef', order: 'asc' }])
-}
+  const { rows } = await db.raw(query, [today, today, today, companyId])
 
-/**
- * We only need to return the licence ID and licence reference.
- *
- * @private
- */
-function _data(licences) {
-  return licences.map((licence) => {
-    return {
-      id: licence.id,
-      licenceRef: licence.licenceRef
-    }
-  })
+  return rows
 }
 
 module.exports = {

--- a/app/dal/company-contacts/setup/fetch-company-contact.dal.js
+++ b/app/dal/company-contacts/setup/fetch-company-contact.dal.js
@@ -2,7 +2,7 @@
 
 /**
  * Fetches the company contact data needed for the '/company-contacts/setup/{id}/edit'
- * @module FetchCompanyContactService
+ * @module FetchCompanyContactDal
  */
 
 const CompanyContactModel = require('../../../models/company-contact.model.js')

--- a/app/services/company-contacts/setup/initiate-edit-session.service.js
+++ b/app/services/company-contacts/setup/initiate-edit-session.service.js
@@ -6,7 +6,7 @@
  */
 
 const FetchCompanyContactDal = require('../../../dal/company-contacts/setup/fetch-company-contact.dal.js')
-const FetchCompanyLicencesService = require('../../../dal/company-contacts/fetch-company-licences.dal.js')
+const FetchCompanyLicencesDal = require('../../../dal/company-contacts/fetch-company-licences.dal.js')
 const SessionModel = require('../../../models/session.model.js')
 const { formatEmail } = require('../../../presenters/base.presenter.js')
 
@@ -20,7 +20,7 @@ const { formatEmail } = require('../../../presenters/base.presenter.js')
 async function go(companyContactId) {
   const companyContact = await FetchCompanyContactDal.go(companyContactId)
 
-  const licences = await FetchCompanyLicencesService.go(companyContact.company.id)
+  const licences = await FetchCompanyLicencesDal.go(companyContact.company.id)
 
   return SessionModel.query()
     .insert({

--- a/app/services/company-contacts/setup/initiate-edit-session.service.js
+++ b/app/services/company-contacts/setup/initiate-edit-session.service.js
@@ -5,7 +5,8 @@
  * @module InitiateEditSessionService
  */
 
-const FetchCompanyContactService = require('./fetch-company-contact.service.js')
+const FetchCompanyContactDal = require('../../../dal/company-contacts/setup/fetch-company-contact.dal.js')
+const FetchCompanyLicencesService = require('../../../dal/company-contacts/fetch-company-licences.dal.js')
 const SessionModel = require('../../../models/session.model.js')
 const { formatEmail } = require('../../../presenters/base.presenter.js')
 
@@ -17,11 +18,16 @@ const { formatEmail } = require('../../../presenters/base.presenter.js')
  * @returns {Promise<module:SessionModel>} the newly created session record
  */
 async function go(companyContactId) {
-  const companyContact = await FetchCompanyContactService.go(companyContactId)
+  const companyContact = await FetchCompanyContactDal.go(companyContactId)
+
+  const licences = await FetchCompanyLicencesService.go(companyContact.company.id)
 
   return SessionModel.query()
     .insert({
-      data: _formatDataForJourney(companyContact)
+      data: {
+        ..._formatDataForJourney(companyContact),
+        licences
+      }
     })
     .returning('id')
 }

--- a/app/services/company-contacts/setup/initiate-session.service.js
+++ b/app/services/company-contacts/setup/initiate-session.service.js
@@ -5,7 +5,7 @@
  * @module InitiateSessionService
  */
 
-const FetchCompanyLicencesService = require('../../../dal/company-contacts/fetch-company-licences.dal.js')
+const FetchCompanyLicencesDal = require('../../../dal/company-contacts/fetch-company-licences.dal.js')
 const FetchCompanyService = require('../../companies/fetch-company.service.js')
 const SessionModel = require('../../../models/session.model.js')
 
@@ -19,7 +19,7 @@ const SessionModel = require('../../../models/session.model.js')
 async function go(companyId) {
   const company = await FetchCompanyService.go(companyId)
 
-  const licences = await FetchCompanyLicencesService.go(companyId)
+  const licences = await FetchCompanyLicencesDal.go(companyId)
 
   return SessionModel.query()
     .insert({

--- a/app/services/company-contacts/setup/initiate-session.service.js
+++ b/app/services/company-contacts/setup/initiate-session.service.js
@@ -5,8 +5,9 @@
  * @module InitiateSessionService
  */
 
-const SessionModel = require('../../../models/session.model.js')
+const FetchCompanyLicencesService = require('../../../dal/company-contacts/fetch-company-licences.dal.js')
 const FetchCompanyService = require('../../companies/fetch-company.service.js')
+const SessionModel = require('../../../models/session.model.js')
 
 /**
  * Initiates the session record used for setting up a new company contact
@@ -18,10 +19,13 @@ const FetchCompanyService = require('../../companies/fetch-company.service.js')
 async function go(companyId) {
   const company = await FetchCompanyService.go(companyId)
 
+  const licences = await FetchCompanyLicencesService.go(companyId)
+
   return SessionModel.query()
     .insert({
       data: {
-        company
+        company,
+        licences
       }
     })
     .returning('id')

--- a/test/dal/company-contacts/fetch-company-licences.dal.test.js
+++ b/test/dal/company-contacts/fetch-company-licences.dal.test.js
@@ -37,10 +37,10 @@ describe('Company Contacts - Fetch Company Licences Dal', () => {
   })
 
   after(async () => {
-    await company.$query().delete()
-    await licence.$query().delete()
-    await licenceVersion.$query().delete()
     await licenceVersionHolder.$query().delete()
+    await licenceVersion.$query().delete()
+    await licence.$query().delete()
+    await company.$query().delete()
   })
 
   describe('when there are licences linked to the company', () => {

--- a/test/dal/company-contacts/fetch-company-licences.dal.test.js
+++ b/test/dal/company-contacts/fetch-company-licences.dal.test.js
@@ -1,0 +1,61 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, before, after } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Test helpers
+const CompanyHelper = require('../../support/helpers/company.helper.js')
+const LicenceHelper = require('../../support/helpers/licence.helper.js')
+const LicenceVersionHelper = require('../../support/helpers/licence-version.helper.js')
+const LicenceVersionHolderHelper = require('../../support/helpers/licence-version-holder.helper.js')
+const { generateUUID } = require('../../../app/lib/general.lib.js')
+
+// Thing under test
+const FetchCompanyLicencesDal = require('../../../app/dal/company-contacts/fetch-company-licences.dal.js')
+
+describe('Company Contacts - Fetch Company Licences Dal', () => {
+  let company
+  let licence
+  let licenceVersion
+  let licenceVersionHolder
+
+  before(async () => {
+    company = await CompanyHelper.add()
+
+    licence = await LicenceHelper.add()
+
+    licenceVersion = await LicenceVersionHelper.add({ licenceId: licence.id })
+
+    licenceVersionHolder = await LicenceVersionHolderHelper.add({
+      licenceVersionId: licenceVersion.id,
+      companyId: company.id
+    })
+  })
+
+  after(async () => {
+    await company.$query().delete()
+    await licence.$query().delete()
+    await licenceVersion.$query().delete()
+    await licenceVersionHolder.$query().delete()
+  })
+
+  describe('when there are licences linked to the company', () => {
+    it('returns the matching licences', async () => {
+      const result = await FetchCompanyLicencesDal.go(company.id)
+
+      expect(result).to.equal([{ id: licence.id, licenceRef: licence.licenceRef }])
+    })
+  })
+
+  describe('when there are no licences linked to the company', () => {
+    it('returns an empty array', async () => {
+      const result = await FetchCompanyLicencesDal.go(generateUUID())
+
+      expect(result).to.equal([])
+    })
+  })
+})

--- a/test/dal/company-contacts/fetch-company-licences.dal.test.js
+++ b/test/dal/company-contacts/fetch-company-licences.dal.test.js
@@ -11,98 +11,173 @@ const { expect } = Code
 const CompanyHelper = require('../../support/helpers/company.helper.js')
 const LicenceHelper = require('../../support/helpers/licence.helper.js')
 const LicenceVersionHelper = require('../../support/helpers/licence-version.helper.js')
-const LicenceVersionHolderHelper = require('../../support/helpers/licence-version-holder.helper.js')
 const { generateUUID } = require('../../../app/lib/general.lib.js')
 
 // Thing under test
 const FetchCompanyLicencesDal = require('../../../app/dal/company-contacts/fetch-company-licences.dal.js')
 
 describe('Company Contacts - Fetch Company Licences Dal', () => {
-  let company
-  let licence
-  let licenceVersion
-  let licenceVersionHolder
+  let scenarios
 
   before(async () => {
-    company = await CompanyHelper.add()
+    scenarios = {}
 
-    licence = await LicenceHelper.add()
-    licenceVersion = await LicenceVersionHelper.add({ licenceId: licence.id })
-    licenceVersionHolder = await LicenceVersionHolderHelper.add({
-      licenceVersionId: licenceVersion.id,
-      companyId: company.id
+    scenarios.licence = await _scenario()
+    scenarios.expiredPast = await _scenario({ expiredDate: new Date('2020-01-01') })
+    scenarios.lapsedPast = await _scenario({ lapsedDate: new Date('2020-01-01') })
+    scenarios.revokedPast = await _scenario({ revokedDate: new Date('2020-01-01') })
+    scenarios.mixedDates = await _scenario({
+      expiredDate: new Date('2099-01-01'),
+      lapsedDate: new Date('2020-01-01')
     })
+    scenarios.expiredFuture = await _scenario({ expiredDate: new Date('2099-01-01') })
+    scenarios.lapsedFuture = await _scenario({ lapsedDate: new Date('2099-01-01') })
+    scenarios.revokedFuture = await _scenario({ revokedDate: new Date('2099-01-01') })
   })
 
   after(async () => {
-    await licenceVersionHolder.$query().delete()
-    await licenceVersion.$query().delete()
-    await licence.$query().delete()
-    await company.$query().delete()
+    for (const scenario of Object.values(scenarios)) {
+      await scenario.scenarioLinkedLicence.licenceVersion.$query().delete()
+      await scenario.scenarioLinkedLicence.licence.$query().delete()
+      await scenario.activeLinkedLicence.licenceVersion.$query().delete()
+      await scenario.activeLinkedLicence.licence.$query().delete()
+      await scenario.company.$query().delete()
+    }
   })
 
   describe('when there are licences linked to the company', () => {
     it('returns the matching licences', async () => {
-      const result = await FetchCompanyLicencesDal.go(company.id)
+      const result = await FetchCompanyLicencesDal.go(scenarios.licence.company.id)
 
-      expect(result).to.equal([{ id: licence.id, licenceRef: licence.licenceRef }])
+      const expectedLicences = [
+        {
+          id: scenarios.licence.activeLinkedLicence.licence.id,
+          licenceRef: scenarios.licence.activeLinkedLicence.licence.licenceRef
+        },
+        {
+          id: scenarios.licence.scenarioLinkedLicence.licence.id,
+          licenceRef: scenarios.licence.scenarioLinkedLicence.licence.licenceRef
+        }
+      ].sort((a, b) => {
+        return a.licenceRef.localeCompare(b.licenceRef)
+      })
+
+      expect(result).to.equal(expectedLicences)
     })
   })
 
-  describe('when there are licences linked to the company that have ended', () => {
-    let endedLicence
-    let endedLicenceVersion
-    let endedLicenceVersionHolder
+  describe('when a licence linked to the company has an expiredDate in the past', () => {
+    it('returns only the active licence', async () => {
+      const result = await FetchCompanyLicencesDal.go(scenarios.expiredPast.company.id)
 
-    before(async () => {
-      endedLicence = await LicenceHelper.add()
-      endedLicenceVersion = await LicenceVersionHelper.add({ licenceId: endedLicence.id })
-      endedLicenceVersionHolder = await LicenceVersionHolderHelper.add({
-        licenceVersionId: endedLicenceVersion.id,
-        companyId: company.id
-      })
+      expect(result).to.equal([
+        {
+          id: scenarios.expiredPast.activeLinkedLicence.licence.id,
+          licenceRef: scenarios.expiredPast.activeLinkedLicence.licence.licenceRef
+        }
+      ])
     })
+  })
 
-    after(async () => {
-      await endedLicenceVersionHolder.$query().delete()
-      await endedLicenceVersion.$query().delete()
-      await endedLicence.$query().delete()
+  describe('when a licence linked to the company has a lapsedDate in the past', () => {
+    it('returns only the active licence', async () => {
+      const result = await FetchCompanyLicencesDal.go(scenarios.lapsedPast.company.id)
+
+      expect(result).to.equal([
+        {
+          id: scenarios.lapsedPast.activeLinkedLicence.licence.id,
+          licenceRef: scenarios.lapsedPast.activeLinkedLicence.licence.licenceRef
+        }
+      ])
     })
+  })
 
-    describe('because they are expired', () => {
-      before(async () => {
-        await endedLicence.$query().patch({ expiredDate: new Date('2020-01-01'), lapsedDate: null, revokedDate: null })
-      })
+  describe('when a licence linked to the company has a revokedDate in the past', () => {
+    it('returns only the active licence', async () => {
+      const result = await FetchCompanyLicencesDal.go(scenarios.revokedPast.company.id)
 
-      it('returns only the active licence', async () => {
-        const result = await FetchCompanyLicencesDal.go(company.id)
-
-        expect(result).to.equal([{ id: licence.id, licenceRef: licence.licenceRef }])
-      })
+      expect(result).to.equal([
+        {
+          id: scenarios.revokedPast.activeLinkedLicence.licence.id,
+          licenceRef: scenarios.revokedPast.activeLinkedLicence.licence.licenceRef
+        }
+      ])
     })
+  })
 
-    describe('because they are lapsed', () => {
-      before(async () => {
-        await endedLicence.$query().patch({ expiredDate: null, lapsedDate: new Date('2020-01-01'), revokedDate: null })
-      })
+  describe('when a licence linked to the company has one end date in the past and another in the future', () => {
+    it('returns only the active licence', async () => {
+      const result = await FetchCompanyLicencesDal.go(scenarios.mixedDates.company.id)
 
-      it('returns only the active licence', async () => {
-        const result = await FetchCompanyLicencesDal.go(company.id)
-
-        expect(result).to.equal([{ id: licence.id, licenceRef: licence.licenceRef }])
-      })
+      expect(result).to.equal([
+        {
+          id: scenarios.mixedDates.activeLinkedLicence.licence.id,
+          licenceRef: scenarios.mixedDates.activeLinkedLicence.licence.licenceRef
+        }
+      ])
     })
+  })
 
-    describe('because they are revoked', () => {
-      before(async () => {
-        await endedLicence.$query().patch({ expiredDate: null, lapsedDate: null, revokedDate: new Date('2020-01-01') })
+  describe('when a licence linked to the company has an expiredDate in the future', () => {
+    it('returns both licences', async () => {
+      const result = await FetchCompanyLicencesDal.go(scenarios.expiredFuture.company.id)
+
+      const expectedLicences = [
+        {
+          id: scenarios.expiredFuture.activeLinkedLicence.licence.id,
+          licenceRef: scenarios.expiredFuture.activeLinkedLicence.licence.licenceRef
+        },
+        {
+          id: scenarios.expiredFuture.scenarioLinkedLicence.licence.id,
+          licenceRef: scenarios.expiredFuture.scenarioLinkedLicence.licence.licenceRef
+        }
+      ].sort((a, b) => {
+        return a.licenceRef.localeCompare(b.licenceRef)
       })
 
-      it('returns only the active licence', async () => {
-        const result = await FetchCompanyLicencesDal.go(company.id)
+      expect(result).to.equal(expectedLicences)
+    })
+  })
 
-        expect(result).to.equal([{ id: licence.id, licenceRef: licence.licenceRef }])
+  describe('when a licence linked to the company has a lapsedDate in the future', () => {
+    it('returns both licences', async () => {
+      const result = await FetchCompanyLicencesDal.go(scenarios.lapsedFuture.company.id)
+
+      const expectedLicences = [
+        {
+          id: scenarios.lapsedFuture.activeLinkedLicence.licence.id,
+          licenceRef: scenarios.lapsedFuture.activeLinkedLicence.licence.licenceRef
+        },
+        {
+          id: scenarios.lapsedFuture.scenarioLinkedLicence.licence.id,
+          licenceRef: scenarios.lapsedFuture.scenarioLinkedLicence.licence.licenceRef
+        }
+      ].sort((a, b) => {
+        return a.licenceRef.localeCompare(b.licenceRef)
       })
+
+      expect(result).to.equal(expectedLicences)
+    })
+  })
+
+  describe('when a licence linked to the company has a revokedDate in the future', () => {
+    it('returns both licences', async () => {
+      const result = await FetchCompanyLicencesDal.go(scenarios.revokedFuture.company.id)
+
+      const expectedLicences = [
+        {
+          id: scenarios.revokedFuture.activeLinkedLicence.licence.id,
+          licenceRef: scenarios.revokedFuture.activeLinkedLicence.licence.licenceRef
+        },
+        {
+          id: scenarios.revokedFuture.scenarioLinkedLicence.licence.id,
+          licenceRef: scenarios.revokedFuture.scenarioLinkedLicence.licence.licenceRef
+        }
+      ].sort((a, b) => {
+        return a.licenceRef.localeCompare(b.licenceRef)
+      })
+
+      expect(result).to.equal(expectedLicences)
     })
   })
 
@@ -114,3 +189,18 @@ describe('Company Contacts - Fetch Company Licences Dal', () => {
     })
   })
 })
+
+async function _scenario(data = {}) {
+  const company = await CompanyHelper.add()
+  const activeLinkedLicence = await _createLinkedLicence(company.id)
+  const scenarioLinkedLicence = await _createLinkedLicence(company.id, data)
+
+  return { activeLinkedLicence, company, scenarioLinkedLicence }
+}
+
+async function _createLinkedLicence(companyId, data = {}) {
+  const licence = await LicenceHelper.add(data)
+  const licenceVersion = await LicenceVersionHelper.add({ licenceId: licence.id, companyId })
+
+  return { licence, licenceVersion }
+}

--- a/test/dal/company-contacts/fetch-company-licences.dal.test.js
+++ b/test/dal/company-contacts/fetch-company-licences.dal.test.js
@@ -35,26 +35,34 @@ describe('Company Contacts - Fetch Company Licences Dal', () => {
     scenarios.revokedFuture = await _scenario({ revokedDate: new Date('2099-01-01') })
 
     const scenario = await _scenario()
+
+    const newerLicenceVersion = await LicenceVersionHelper.add({
+      licenceId: scenario.licence.id,
+      issue: 2,
+      companyId: generateUUID()
+    })
+
     scenarios.licenceCurrentVersion = {
       ...scenario,
-      newerLicenceVersion: await LicenceVersionHelper.add({
-        licenceId: scenario.scenarioLinkedLicence.licence.id,
-        issue: 2,
-        companyId: generateUUID()
-      })
+      newerLicenceVersion
     }
+
+    scenarios.multpleLicences = await _scenarioWithMultipleLicences()
   })
 
   after(async () => {
     for (const scenario of Object.values(scenarios)) {
-      await scenario.scenarioLinkedLicence.licenceVersion.$query().delete()
-      await scenario.scenarioLinkedLicence.licence.$query().delete()
-      await scenario.activeLinkedLicence.licenceVersion.$query().delete()
-      await scenario.activeLinkedLicence.licence.$query().delete()
-      await scenario.company.$query().delete()
+      await scenario.licenceVersion?.$query().delete()
+      await scenario.licence?.$query().delete()
+      await scenario.company?.$query().delete()
 
-      if (scenario.newerLicenceVersion) {
-        await scenario.newerLicenceVersion.$query().delete()
+      await scenario.newerLicenceVersion?.$query().delete()
+
+      if (scenario.multpleLicences) {
+        await scenario.licenceOne.licence.$query().delete()
+        await scenario.licenceTwo.licence.$query().delete()
+        await scenario.licenceOne.licenceVersion.$query().delete()
+        await scenario.licenceTwo.licenceVersion.$query().delete()
       }
     }
   })
@@ -63,61 +71,44 @@ describe('Company Contacts - Fetch Company Licences Dal', () => {
     it('returns the matching licences', async () => {
       const result = await FetchCompanyLicencesDal.go(scenarios.licence.company.id)
 
-      const expectedLicences = _expectedLicence(scenarios.licence)
-
-      expect(result).to.equal(expectedLicences)
+      expect(result).to.equal([
+        {
+          id: scenarios.licence.licence.id,
+          licenceRef: scenarios.licence.licence.licenceRef
+        }
+      ])
     })
   })
 
   describe('when a licence linked to the company has an expiredDate in the past', () => {
-    it('returns only the active licence', async () => {
+    it('returns an empty array', async () => {
       const result = await FetchCompanyLicencesDal.go(scenarios.expiredPast.company.id)
 
-      expect(result).to.equal([
-        {
-          id: scenarios.expiredPast.activeLinkedLicence.licence.id,
-          licenceRef: scenarios.expiredPast.activeLinkedLicence.licence.licenceRef
-        }
-      ])
+      expect(result).to.equal([])
     })
   })
 
   describe('when a licence linked to the company has a lapsedDate in the past', () => {
-    it('returns only the active licence', async () => {
+    it('returns an empty array', async () => {
       const result = await FetchCompanyLicencesDal.go(scenarios.lapsedPast.company.id)
 
-      expect(result).to.equal([
-        {
-          id: scenarios.lapsedPast.activeLinkedLicence.licence.id,
-          licenceRef: scenarios.lapsedPast.activeLinkedLicence.licence.licenceRef
-        }
-      ])
+      expect(result).to.equal([])
     })
   })
 
   describe('when a licence linked to the company has a revokedDate in the past', () => {
-    it('returns only the active licence', async () => {
+    it('returns an empty array', async () => {
       const result = await FetchCompanyLicencesDal.go(scenarios.revokedPast.company.id)
 
-      expect(result).to.equal([
-        {
-          id: scenarios.revokedPast.activeLinkedLicence.licence.id,
-          licenceRef: scenarios.revokedPast.activeLinkedLicence.licence.licenceRef
-        }
-      ])
+      expect(result).to.equal([])
     })
   })
 
   describe('when a licence linked to the company has one end date in the past and another in the future', () => {
-    it('returns only the active licence', async () => {
+    it('returns an empty array', async () => {
       const result = await FetchCompanyLicencesDal.go(scenarios.mixedDates.company.id)
 
-      expect(result).to.equal([
-        {
-          id: scenarios.mixedDates.activeLinkedLicence.licence.id,
-          licenceRef: scenarios.mixedDates.activeLinkedLicence.licence.licenceRef
-        }
-      ])
+      expect(result).to.equal([])
     })
   })
 
@@ -125,9 +116,12 @@ describe('Company Contacts - Fetch Company Licences Dal', () => {
     it('returns both licences', async () => {
       const result = await FetchCompanyLicencesDal.go(scenarios.expiredFuture.company.id)
 
-      const expectedLicences = _expectedLicence(scenarios.expiredFuture)
-
-      expect(result).to.equal(expectedLicences)
+      expect(result).to.equal([
+        {
+          id: scenarios.expiredFuture.licence.id,
+          licenceRef: scenarios.expiredFuture.licence.licenceRef
+        }
+      ])
     })
   })
 
@@ -135,9 +129,12 @@ describe('Company Contacts - Fetch Company Licences Dal', () => {
     it('returns both licences', async () => {
       const result = await FetchCompanyLicencesDal.go(scenarios.lapsedFuture.company.id)
 
-      const expectedLicences = _expectedLicence(scenarios.lapsedFuture)
-
-      expect(result).to.equal(expectedLicences)
+      expect(result).to.equal([
+        {
+          id: scenarios.lapsedFuture.licence.id,
+          licenceRef: scenarios.lapsedFuture.licence.licenceRef
+        }
+      ])
     })
   })
 
@@ -145,9 +142,12 @@ describe('Company Contacts - Fetch Company Licences Dal', () => {
     it('returns both licences', async () => {
       const result = await FetchCompanyLicencesDal.go(scenarios.revokedFuture.company.id)
 
-      const expectedLicences = _expectedLicence(scenarios.revokedFuture)
-
-      expect(result).to.equal(expectedLicences)
+      expect(result).to.equal([
+        {
+          id: scenarios.revokedFuture.licence.id,
+          licenceRef: scenarios.revokedFuture.licence.licenceRef
+        }
+      ])
     })
   })
 
@@ -160,45 +160,58 @@ describe('Company Contacts - Fetch Company Licences Dal', () => {
   })
 
   describe('when a current version is not linked to the company id', () => {
-    it('returns only the active licence', async () => {
+    it('returns an empty array', async () => {
       const result = await FetchCompanyLicencesDal.go(scenarios.licenceCurrentVersion.company.id)
 
-      expect(result).to.equal([
+      expect(result).to.equal([])
+    })
+  })
+
+  describe('when there are multiple licences linked to the company', () => {
+    it('returns the licences ordered by licence ref', async () => {
+      const result = await FetchCompanyLicencesDal.go(scenarios.multpleLicences.company.id)
+
+      const expectedLicences = [
         {
-          id: scenarios.licenceCurrentVersion.activeLinkedLicence.licence.id,
-          licenceRef: scenarios.licenceCurrentVersion.activeLinkedLicence.licence.licenceRef
+          id: scenarios.multpleLicences.licenceOne.licence.id,
+          licenceRef: scenarios.multpleLicences.licenceOne.licence.licenceRef
+        },
+        {
+          id: scenarios.multpleLicences.licenceTwo.licence.id,
+          licenceRef: scenarios.multpleLicences.licenceTwo.licence.licenceRef
         }
-      ])
+      ].sort((a, b) => {
+        return a.licenceRef.localeCompare(b.licenceRef)
+      })
+
+      expect(result).to.equal(expectedLicences)
     })
   })
 })
 
 async function _scenario(data = {}) {
   const company = await CompanyHelper.add()
-  const activeLinkedLicence = await _createLinkedLicence(company.id)
-  const scenarioLinkedLicence = await _createLinkedLicence(company.id, data)
 
-  return { activeLinkedLicence, company, scenarioLinkedLicence }
-}
-
-async function _createLinkedLicence(companyId, data = {}) {
   const licence = await LicenceHelper.add(data)
-  const licenceVersion = await LicenceVersionHelper.add({ licenceId: licence.id, companyId })
+  const licenceVersion = await LicenceVersionHelper.add({ licenceId: licence.id, companyId: company.id })
 
-  return { licence, licenceVersion }
+  return { company, licence, licenceVersion }
 }
 
-function _expectedLicence(scenario) {
-  return [
-    {
-      id: scenario.activeLinkedLicence.licence.id,
-      licenceRef: scenario.activeLinkedLicence.licence.licenceRef
+async function _scenarioWithMultipleLicences() {
+  const scenario = await _scenario()
+  const licence = await LicenceHelper.add()
+  const licenceVersion = await LicenceVersionHelper.add({ licenceId: licence.id, companyId: scenario.company.id })
+
+  return {
+    company: scenario.company,
+    licenceOne: {
+      licence: scenario.licence,
+      licenceVersion: scenario.licenceVersion
     },
-    {
-      id: scenario.scenarioLinkedLicence.licence.id,
-      licenceRef: scenario.scenarioLinkedLicence.licence.licenceRef
+    licenceTwo: {
+      licence,
+      licenceVersion
     }
-  ].sort((a, b) => {
-    return a.licenceRef.localeCompare(b.licenceRef)
-  })
+  }
 }

--- a/test/dal/company-contacts/fetch-company-licences.dal.test.js
+++ b/test/dal/company-contacts/fetch-company-licences.dal.test.js
@@ -12,6 +12,7 @@ const CompanyHelper = require('../../support/helpers/company.helper.js')
 const LicenceHelper = require('../../support/helpers/licence.helper.js')
 const LicenceVersionHelper = require('../../support/helpers/licence-version.helper.js')
 const { generateUUID } = require('../../../app/lib/general.lib.js')
+const { tomorrow, yesterday } = require('../../support/general.js')
 
 // Thing under test
 const FetchCompanyLicencesDal = require('../../../app/dal/company-contacts/fetch-company-licences.dal.js')
@@ -23,16 +24,16 @@ describe('Company Contacts - Fetch Company Licences Dal', () => {
     scenarios = {}
 
     scenarios.licence = await _scenario()
-    scenarios.expiredPast = await _scenario({ expiredDate: new Date('2020-01-01') })
-    scenarios.lapsedPast = await _scenario({ lapsedDate: new Date('2020-01-01') })
-    scenarios.revokedPast = await _scenario({ revokedDate: new Date('2020-01-01') })
+    scenarios.expiredPast = await _scenario({ expiredDate: yesterday() })
+    scenarios.lapsedPast = await _scenario({ lapsedDate: yesterday() })
+    scenarios.revokedPast = await _scenario({ revokedDate: yesterday() })
     scenarios.mixedDates = await _scenario({
-      expiredDate: new Date('2099-01-01'),
-      lapsedDate: new Date('2020-01-01')
+      expiredDate: tomorrow(),
+      lapsedDate: yesterday()
     })
-    scenarios.expiredFuture = await _scenario({ expiredDate: new Date('2099-01-01') })
-    scenarios.lapsedFuture = await _scenario({ lapsedDate: new Date('2099-01-01') })
-    scenarios.revokedFuture = await _scenario({ revokedDate: new Date('2099-01-01') })
+    scenarios.expiredFuture = await _scenario({ expiredDate: tomorrow() })
+    scenarios.lapsedFuture = await _scenario({ lapsedDate: tomorrow() })
+    scenarios.revokedFuture = await _scenario({ revokedDate: tomorrow() })
 
     // Add a newer licence version to the scenario with a different company id, so that we can test that the licence
     // is not returned (the company id is not linked to the current licence version)

--- a/test/dal/company-contacts/fetch-company-licences.dal.test.js
+++ b/test/dal/company-contacts/fetch-company-licences.dal.test.js
@@ -33,6 +33,16 @@ describe('Company Contacts - Fetch Company Licences Dal', () => {
     scenarios.expiredFuture = await _scenario({ expiredDate: new Date('2099-01-01') })
     scenarios.lapsedFuture = await _scenario({ lapsedDate: new Date('2099-01-01') })
     scenarios.revokedFuture = await _scenario({ revokedDate: new Date('2099-01-01') })
+
+    const scenario = await _scenario()
+    scenarios.licenceCurrentVersion = {
+      ...scenario,
+      newerLicenceVersion: await LicenceVersionHelper.add({
+        licenceId: scenario.scenarioLinkedLicence.licence.id,
+        issue: 2,
+        companyId: generateUUID()
+      })
+    }
   })
 
   after(async () => {
@@ -42,6 +52,10 @@ describe('Company Contacts - Fetch Company Licences Dal', () => {
       await scenario.activeLinkedLicence.licenceVersion.$query().delete()
       await scenario.activeLinkedLicence.licence.$query().delete()
       await scenario.company.$query().delete()
+
+      if (scenario.newerLicenceVersion) {
+        await scenario.newerLicenceVersion.$query().delete()
+      }
     }
   })
 
@@ -49,18 +63,7 @@ describe('Company Contacts - Fetch Company Licences Dal', () => {
     it('returns the matching licences', async () => {
       const result = await FetchCompanyLicencesDal.go(scenarios.licence.company.id)
 
-      const expectedLicences = [
-        {
-          id: scenarios.licence.activeLinkedLicence.licence.id,
-          licenceRef: scenarios.licence.activeLinkedLicence.licence.licenceRef
-        },
-        {
-          id: scenarios.licence.scenarioLinkedLicence.licence.id,
-          licenceRef: scenarios.licence.scenarioLinkedLicence.licence.licenceRef
-        }
-      ].sort((a, b) => {
-        return a.licenceRef.localeCompare(b.licenceRef)
-      })
+      const expectedLicences = _expectedLicence(scenarios.licence)
 
       expect(result).to.equal(expectedLicences)
     })
@@ -122,18 +125,7 @@ describe('Company Contacts - Fetch Company Licences Dal', () => {
     it('returns both licences', async () => {
       const result = await FetchCompanyLicencesDal.go(scenarios.expiredFuture.company.id)
 
-      const expectedLicences = [
-        {
-          id: scenarios.expiredFuture.activeLinkedLicence.licence.id,
-          licenceRef: scenarios.expiredFuture.activeLinkedLicence.licence.licenceRef
-        },
-        {
-          id: scenarios.expiredFuture.scenarioLinkedLicence.licence.id,
-          licenceRef: scenarios.expiredFuture.scenarioLinkedLicence.licence.licenceRef
-        }
-      ].sort((a, b) => {
-        return a.licenceRef.localeCompare(b.licenceRef)
-      })
+      const expectedLicences = _expectedLicence(scenarios.expiredFuture)
 
       expect(result).to.equal(expectedLicences)
     })
@@ -143,18 +135,7 @@ describe('Company Contacts - Fetch Company Licences Dal', () => {
     it('returns both licences', async () => {
       const result = await FetchCompanyLicencesDal.go(scenarios.lapsedFuture.company.id)
 
-      const expectedLicences = [
-        {
-          id: scenarios.lapsedFuture.activeLinkedLicence.licence.id,
-          licenceRef: scenarios.lapsedFuture.activeLinkedLicence.licence.licenceRef
-        },
-        {
-          id: scenarios.lapsedFuture.scenarioLinkedLicence.licence.id,
-          licenceRef: scenarios.lapsedFuture.scenarioLinkedLicence.licence.licenceRef
-        }
-      ].sort((a, b) => {
-        return a.licenceRef.localeCompare(b.licenceRef)
-      })
+      const expectedLicences = _expectedLicence(scenarios.lapsedFuture)
 
       expect(result).to.equal(expectedLicences)
     })
@@ -164,18 +145,7 @@ describe('Company Contacts - Fetch Company Licences Dal', () => {
     it('returns both licences', async () => {
       const result = await FetchCompanyLicencesDal.go(scenarios.revokedFuture.company.id)
 
-      const expectedLicences = [
-        {
-          id: scenarios.revokedFuture.activeLinkedLicence.licence.id,
-          licenceRef: scenarios.revokedFuture.activeLinkedLicence.licence.licenceRef
-        },
-        {
-          id: scenarios.revokedFuture.scenarioLinkedLicence.licence.id,
-          licenceRef: scenarios.revokedFuture.scenarioLinkedLicence.licence.licenceRef
-        }
-      ].sort((a, b) => {
-        return a.licenceRef.localeCompare(b.licenceRef)
-      })
+      const expectedLicences = _expectedLicence(scenarios.revokedFuture)
 
       expect(result).to.equal(expectedLicences)
     })
@@ -186,6 +156,19 @@ describe('Company Contacts - Fetch Company Licences Dal', () => {
       const result = await FetchCompanyLicencesDal.go(generateUUID())
 
       expect(result).to.equal([])
+    })
+  })
+
+  describe('when a current version is not linked to the company id', () => {
+    it('returns only the active licence', async () => {
+      const result = await FetchCompanyLicencesDal.go(scenarios.licenceCurrentVersion.company.id)
+
+      expect(result).to.equal([
+        {
+          id: scenarios.licenceCurrentVersion.activeLinkedLicence.licence.id,
+          licenceRef: scenarios.licenceCurrentVersion.activeLinkedLicence.licence.licenceRef
+        }
+      ])
     })
   })
 })
@@ -203,4 +186,19 @@ async function _createLinkedLicence(companyId, data = {}) {
   const licenceVersion = await LicenceVersionHelper.add({ licenceId: licence.id, companyId })
 
   return { licence, licenceVersion }
+}
+
+function _expectedLicence(scenario) {
+  return [
+    {
+      id: scenario.activeLinkedLicence.licence.id,
+      licenceRef: scenario.activeLinkedLicence.licence.licenceRef
+    },
+    {
+      id: scenario.scenarioLinkedLicence.licence.id,
+      licenceRef: scenario.scenarioLinkedLicence.licence.licenceRef
+    }
+  ].sort((a, b) => {
+    return a.licenceRef.localeCompare(b.licenceRef)
+  })
 }

--- a/test/dal/company-contacts/fetch-company-licences.dal.test.js
+++ b/test/dal/company-contacts/fetch-company-licences.dal.test.js
@@ -34,8 +34,9 @@ describe('Company Contacts - Fetch Company Licences Dal', () => {
     scenarios.lapsedFuture = await _scenario({ lapsedDate: new Date('2099-01-01') })
     scenarios.revokedFuture = await _scenario({ revokedDate: new Date('2099-01-01') })
 
+    // Add a newer licence version to the scenario with a different company id, so that we can test that the licence
+    // is not returned (the company id is not linked to the current licence version)
     const scenario = await _scenario()
-
     const newerLicenceVersion = await LicenceVersionHelper.add({
       licenceId: scenario.licence.id,
       issue: 2,
@@ -113,7 +114,7 @@ describe('Company Contacts - Fetch Company Licences Dal', () => {
   })
 
   describe('when a licence linked to the company has an expiredDate in the future', () => {
-    it('returns both licences', async () => {
+    it('returns the licences', async () => {
       const result = await FetchCompanyLicencesDal.go(scenarios.expiredFuture.company.id)
 
       expect(result).to.equal([
@@ -126,7 +127,7 @@ describe('Company Contacts - Fetch Company Licences Dal', () => {
   })
 
   describe('when a licence linked to the company has a lapsedDate in the future', () => {
-    it('returns both licences', async () => {
+    it('returns the licences', async () => {
       const result = await FetchCompanyLicencesDal.go(scenarios.lapsedFuture.company.id)
 
       expect(result).to.equal([
@@ -139,7 +140,7 @@ describe('Company Contacts - Fetch Company Licences Dal', () => {
   })
 
   describe('when a licence linked to the company has a revokedDate in the future', () => {
-    it('returns both licences', async () => {
+    it('returns the licences', async () => {
       const result = await FetchCompanyLicencesDal.go(scenarios.revokedFuture.company.id)
 
       expect(result).to.equal([

--- a/test/dal/company-contacts/fetch-company-licences.dal.test.js
+++ b/test/dal/company-contacts/fetch-company-licences.dal.test.js
@@ -27,9 +27,7 @@ describe('Company Contacts - Fetch Company Licences Dal', () => {
     company = await CompanyHelper.add()
 
     licence = await LicenceHelper.add()
-
     licenceVersion = await LicenceVersionHelper.add({ licenceId: licence.id })
-
     licenceVersionHolder = await LicenceVersionHolderHelper.add({
       licenceVersionId: licenceVersion.id,
       companyId: company.id
@@ -48,6 +46,63 @@ describe('Company Contacts - Fetch Company Licences Dal', () => {
       const result = await FetchCompanyLicencesDal.go(company.id)
 
       expect(result).to.equal([{ id: licence.id, licenceRef: licence.licenceRef }])
+    })
+  })
+
+  describe('when there are licences linked to the company that have ended', () => {
+    let endedLicence
+    let endedLicenceVersion
+    let endedLicenceVersionHolder
+
+    before(async () => {
+      endedLicence = await LicenceHelper.add()
+      endedLicenceVersion = await LicenceVersionHelper.add({ licenceId: endedLicence.id })
+      endedLicenceVersionHolder = await LicenceVersionHolderHelper.add({
+        licenceVersionId: endedLicenceVersion.id,
+        companyId: company.id
+      })
+    })
+
+    after(async () => {
+      await endedLicenceVersionHolder.$query().delete()
+      await endedLicenceVersion.$query().delete()
+      await endedLicence.$query().delete()
+    })
+
+    describe('because they are expired', () => {
+      before(async () => {
+        await endedLicence.$query().patch({ expiredDate: new Date('2020-01-01'), lapsedDate: null, revokedDate: null })
+      })
+
+      it('returns only the active licence', async () => {
+        const result = await FetchCompanyLicencesDal.go(company.id)
+
+        expect(result).to.equal([{ id: licence.id, licenceRef: licence.licenceRef }])
+      })
+    })
+
+    describe('because they are lapsed', () => {
+      before(async () => {
+        await endedLicence.$query().patch({ expiredDate: null, lapsedDate: new Date('2020-01-01'), revokedDate: null })
+      })
+
+      it('returns only the active licence', async () => {
+        const result = await FetchCompanyLicencesDal.go(company.id)
+
+        expect(result).to.equal([{ id: licence.id, licenceRef: licence.licenceRef }])
+      })
+    })
+
+    describe('because they are revoked', () => {
+      before(async () => {
+        await endedLicence.$query().patch({ expiredDate: null, lapsedDate: null, revokedDate: new Date('2020-01-01') })
+      })
+
+      it('returns only the active licence', async () => {
+        const result = await FetchCompanyLicencesDal.go(company.id)
+
+        expect(result).to.equal([{ id: licence.id, licenceRef: licence.licenceRef }])
+      })
     })
   })
 

--- a/test/dal/company-contacts/fetch-company-licences.dal.test.js
+++ b/test/dal/company-contacts/fetch-company-licences.dal.test.js
@@ -8,9 +8,11 @@ const { describe, it, before, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const CompanyHelper = require('../../support/helpers/company.helper.js')
-const LicenceHelper = require('../../support/helpers/licence.helper.js')
-const LicenceVersionHelper = require('../../support/helpers/licence-version.helper.js')
+const {
+  exLicenceHolderWithSingleLicences,
+  licenceHolderWithMultipleLicences,
+  licenceHolderWithSingleLicence
+} = require('../../support/seeders/licence.seeder.js')
 const { generateUUID } = require('../../../app/lib/general.lib.js')
 const { tomorrow, yesterday } = require('../../support/general.js')
 
@@ -23,49 +25,24 @@ describe('Company Contacts - Fetch Company Licences Dal', () => {
   before(async () => {
     scenarios = {}
 
-    scenarios.licence = await _scenario()
-    scenarios.expiredPast = await _scenario({ expiredDate: yesterday() })
-    scenarios.lapsedPast = await _scenario({ lapsedDate: yesterday() })
-    scenarios.revokedPast = await _scenario({ revokedDate: yesterday() })
-    scenarios.mixedDates = await _scenario({
+    scenarios.licence = await licenceHolderWithSingleLicence()
+    scenarios.expiredPast = await licenceHolderWithSingleLicence({ expiredDate: yesterday() })
+    scenarios.lapsedPast = await licenceHolderWithSingleLicence({ lapsedDate: yesterday() })
+    scenarios.revokedPast = await licenceHolderWithSingleLicence({ revokedDate: yesterday() })
+    scenarios.mixedDates = await licenceHolderWithSingleLicence({
       expiredDate: tomorrow(),
       lapsedDate: yesterday()
     })
-    scenarios.expiredFuture = await _scenario({ expiredDate: tomorrow() })
-    scenarios.lapsedFuture = await _scenario({ lapsedDate: tomorrow() })
-    scenarios.revokedFuture = await _scenario({ revokedDate: tomorrow() })
-
-    // Add a newer licence version to the scenario with a different company id, so that we can test that the licence
-    // is not returned (the company id is not linked to the current licence version)
-    const scenario = await _scenario()
-    const newerLicenceVersion = await LicenceVersionHelper.add({
-      licenceId: scenario.licence.id,
-      issue: 2,
-      companyId: generateUUID()
-    })
-
-    scenarios.licenceCurrentVersion = {
-      ...scenario,
-      newerLicenceVersion
-    }
-
-    scenarios.multpleLicences = await _scenarioWithMultipleLicences()
+    scenarios.expiredFuture = await licenceHolderWithSingleLicence({ expiredDate: tomorrow() })
+    scenarios.lapsedFuture = await licenceHolderWithSingleLicence({ lapsedDate: tomorrow() })
+    scenarios.revokedFuture = await licenceHolderWithSingleLicence({ revokedDate: tomorrow() })
+    scenarios.licenceCurrentVersion = await exLicenceHolderWithSingleLicences()
+    scenarios.multpleLicences = await licenceHolderWithMultipleLicences()
   })
 
   after(async () => {
     for (const scenario of Object.values(scenarios)) {
-      await scenario.licenceVersion?.$query().delete()
-      await scenario.licence?.$query().delete()
-      await scenario.company?.$query().delete()
-
-      await scenario.newerLicenceVersion?.$query().delete()
-
-      if (scenario.multpleLicences) {
-        await scenario.licenceOne.licence.$query().delete()
-        await scenario.licenceTwo.licence.$query().delete()
-        await scenario.licenceOne.licenceVersion.$query().delete()
-        await scenario.licenceTwo.licenceVersion.$query().delete()
-      }
+      await scenario.clean()
     }
   })
 
@@ -190,30 +167,3 @@ describe('Company Contacts - Fetch Company Licences Dal', () => {
     })
   })
 })
-
-async function _scenario(data = {}) {
-  const company = await CompanyHelper.add()
-
-  const licence = await LicenceHelper.add(data)
-  const licenceVersion = await LicenceVersionHelper.add({ licenceId: licence.id, companyId: company.id })
-
-  return { company, licence, licenceVersion }
-}
-
-async function _scenarioWithMultipleLicences() {
-  const scenario = await _scenario()
-  const licence = await LicenceHelper.add()
-  const licenceVersion = await LicenceVersionHelper.add({ licenceId: licence.id, companyId: scenario.company.id })
-
-  return {
-    company: scenario.company,
-    licenceOne: {
-      licence: scenario.licence,
-      licenceVersion: scenario.licenceVersion
-    },
-    licenceTwo: {
-      licence,
-      licenceVersion
-    }
-  }
-}

--- a/test/dal/company-contacts/fetch-company-licences.dal.test.js
+++ b/test/dal/company-contacts/fetch-company-licences.dal.test.js
@@ -13,7 +13,7 @@ const {
   licenceHolderWithMultipleLicences,
   licenceHolderWithSingleLicence
 } = require('../../support/seeders/licence.seeder.js')
-const { generateUUID } = require('../../../app/lib/general.lib.js')
+const { generateUUID, today } = require('../../../app/lib/general.lib.js')
 const { tomorrow, yesterday } = require('../../support/general.js')
 
 // Thing under test
@@ -29,6 +29,7 @@ describe('Company Contacts - Fetch Company Licences Dal', () => {
     scenarios.expiredPast = await licenceHolderWithSingleLicence({ expiredDate: yesterday() })
     scenarios.lapsedPast = await licenceHolderWithSingleLicence({ lapsedDate: yesterday() })
     scenarios.revokedPast = await licenceHolderWithSingleLicence({ revokedDate: yesterday() })
+    scenarios.endedToday = await licenceHolderWithSingleLicence({ expiredDate: today() })
     scenarios.mixedDates = await licenceHolderWithSingleLicence({
       expiredDate: tomorrow(),
       lapsedDate: yesterday()
@@ -78,6 +79,14 @@ describe('Company Contacts - Fetch Company Licences Dal', () => {
   describe('when a licence linked to the company has a revokedDate in the past', () => {
     it('returns an empty array', async () => {
       const result = await FetchCompanyLicencesDal.go(scenarios.revokedPast.company.id)
+
+      expect(result).to.equal([])
+    })
+  })
+
+  describe('when a licence linked to the company has "ended" today', () => {
+    it('returns an empty array', async () => {
+      const result = await FetchCompanyLicencesDal.go(scenarios.endedToday.company.id)
 
       expect(result).to.equal([])
     })

--- a/test/dal/company-contacts/setup/fetch-company-contact.dal.test.js
+++ b/test/dal/company-contacts/setup/fetch-company-contact.dal.test.js
@@ -13,9 +13,9 @@ const CompanyHelper = require('../../../support/helpers/company.helper.js')
 const ContactHelper = require('../../../support/helpers/contact.helper.js')
 
 // Thing under test
-const FetchCompanyContactService = require('../../../../app/services/company-contacts/setup/fetch-company-contact.service.js')
+const FetchCompanyContactDal = require('../../../../app/dal/company-contacts/setup/fetch-company-contact.dal.js')
 
-describe('Company Contacts - Setup - Fetch Company Contact service', () => {
+describe('Company Contacts - Setup - Fetch Company Contact Dal', () => {
   let company
   let companyContact
   let contact
@@ -39,7 +39,7 @@ describe('Company Contacts - Setup - Fetch Company Contact service', () => {
 
   describe('when there is a company contact', () => {
     it('returns the matching company contact', async () => {
-      const result = await FetchCompanyContactService.go(companyContact.id)
+      const result = await FetchCompanyContactDal.go(companyContact.id)
 
       expect(result).to.equal({
         abstractionAlerts: false,

--- a/test/services/company-contacts/setup/initiate-edit-session.service.test.js
+++ b/test/services/company-contacts/setup/initiate-edit-session.service.test.js
@@ -11,10 +11,12 @@ const { expect } = Code
 // Test helpers
 const CustomersFixtures = require('../../../support/fixtures/customers.fixture.js')
 const SessionModel = require('../../../../app/models/session.model.js')
+const { generateLicenceRef } = require('../../../support/helpers/licence.helper.js')
 const { generateUUID } = require('../../../../app/lib/general.lib.js')
 
 // Things we need to stub
-const FetchCompanyContactService = require('../../../../app/services/company-contacts/setup/fetch-company-contact.service.js')
+const FetchCompanyContactService = require('../../../../app/dal/company-contacts/setup/fetch-company-contact.dal.js')
+const FetchCompanyLicencesService = require('../../../../app/dal/company-contacts/fetch-company-licences.dal.js')
 
 // Thing under test
 const InitiateEditSessionService = require('../../../../app/services/company-contacts/setup/initiate-edit-session.service.js')
@@ -23,10 +25,14 @@ describe('Company Contacts - Setup - Initiate edit Session service', () => {
   let company
   let companyContact
   let contact
+  let licences
+  let stubFetchCompanyContactService
 
-  beforeEach(async () => {
+  beforeEach(() => {
     company = CustomersFixtures.company()
     contact = CustomersFixtures.contact()
+
+    licences = [{ id: generateUUID(), licenceRef: generateLicenceRef() }]
 
     companyContact = {
       id: generateUUID(),
@@ -34,6 +40,10 @@ describe('Company Contacts - Setup - Initiate edit Session service', () => {
       company,
       contact
     }
+
+    stubFetchCompanyContactService = Sinon.stub(FetchCompanyContactService, 'go').returns(companyContact)
+
+    Sinon.stub(FetchCompanyLicencesService, 'go').returns(licences)
   })
 
   afterEach(() => {
@@ -41,16 +51,12 @@ describe('Company Contacts - Setup - Initiate edit Session service', () => {
   })
 
   describe('when called', () => {
-    beforeEach(() => {
-      Sinon.stub(FetchCompanyContactService, 'go').returns(companyContact)
-    })
-
     it('creates a new session record with the "company contact" saved', async () => {
       const result = await InitiateEditSessionService.go(companyContact.id)
 
       const matchingSession = await SessionModel.query().findById(result.id)
 
-      const expectedSessionData = _expectedSessionData(companyContact, company, contact)
+      const expectedSessionData = _expectedSessionData(companyContact, company, contact, licences)
 
       expect(matchingSession).to.equal({
         ...expectedSessionData,
@@ -67,7 +73,7 @@ describe('Company Contacts - Setup - Initiate edit Session service', () => {
       beforeEach(() => {
         companyContact.abstractionAlerts = true
 
-        Sinon.stub(FetchCompanyContactService, 'go').returns(companyContact)
+        stubFetchCompanyContactService.resolves(companyContact)
       })
 
       it('converts false to "yes"', async () => {
@@ -80,10 +86,6 @@ describe('Company Contacts - Setup - Initiate edit Session service', () => {
     })
 
     describe('when the "abstractionAlerts" property is false', () => {
-      beforeEach(() => {
-        Sinon.stub(FetchCompanyContactService, 'go').returns(companyContact)
-      })
-
       it('converts false to "no"', async () => {
         const result = await InitiateEditSessionService.go(companyContact.id)
 
@@ -95,10 +97,6 @@ describe('Company Contacts - Setup - Initiate edit Session service', () => {
   })
 
   describe('the "name" property', () => {
-    beforeEach(() => {
-      Sinon.stub(FetchCompanyContactService, 'go').returns(companyContact)
-    })
-
     it('formats the name', async () => {
       const result = await InitiateEditSessionService.go(companyContact.id)
 
@@ -109,7 +107,7 @@ describe('Company Contacts - Setup - Initiate edit Session service', () => {
   })
 })
 
-function _expectedSessionData(companyContact, company, contact) {
+function _expectedSessionData(companyContact, company, contact, licences) {
   return {
     abstractionAlerts: 'no',
     companyContact: {
@@ -123,6 +121,7 @@ function _expectedSessionData(companyContact, company, contact) {
     },
     company,
     email: 'rachael.tyrell@tyrellcorp.com',
+    licences,
     name: 'Rachael Tyrell'
   }
 }

--- a/test/services/company-contacts/setup/initiate-edit-session.service.test.js
+++ b/test/services/company-contacts/setup/initiate-edit-session.service.test.js
@@ -11,12 +11,12 @@ const { expect } = Code
 // Test helpers
 const CustomersFixtures = require('../../../support/fixtures/customers.fixture.js')
 const SessionModel = require('../../../../app/models/session.model.js')
-const { generateLicenceRef } = require('../../../support/helpers/licence.helper.js')
 const { generateUUID } = require('../../../../app/lib/general.lib.js')
+const { generateLicenceRef } = require('../../../support/helpers/licence.helper.js')
 
 // Things we need to stub
-const FetchCompanyContactService = require('../../../../app/dal/company-contacts/setup/fetch-company-contact.dal.js')
-const FetchCompanyLicencesService = require('../../../../app/dal/company-contacts/fetch-company-licences.dal.js')
+const FetchCompanyContactDal = require('../../../../app/dal/company-contacts/setup/fetch-company-contact.dal.js')
+const FetchCompanyLicencesDal = require('../../../../app/dal/company-contacts/fetch-company-licences.dal.js')
 
 // Thing under test
 const InitiateEditSessionService = require('../../../../app/services/company-contacts/setup/initiate-edit-session.service.js')
@@ -26,7 +26,7 @@ describe('Company Contacts - Setup - Initiate edit Session service', () => {
   let companyContact
   let contact
   let licences
-  let stubFetchCompanyContactService
+  let stubFetchCompanyContactDal
 
   beforeEach(() => {
     company = CustomersFixtures.company()
@@ -41,9 +41,9 @@ describe('Company Contacts - Setup - Initiate edit Session service', () => {
       contact
     }
 
-    stubFetchCompanyContactService = Sinon.stub(FetchCompanyContactService, 'go').returns(companyContact)
+    stubFetchCompanyContactDal = Sinon.stub(FetchCompanyContactDal, 'go').returns(companyContact)
 
-    Sinon.stub(FetchCompanyLicencesService, 'go').returns(licences)
+    Sinon.stub(FetchCompanyLicencesDal, 'go').returns(licences)
   })
 
   afterEach(() => {
@@ -73,7 +73,7 @@ describe('Company Contacts - Setup - Initiate edit Session service', () => {
       beforeEach(() => {
         companyContact.abstractionAlerts = true
 
-        stubFetchCompanyContactService.resolves(companyContact)
+        stubFetchCompanyContactDal.resolves(companyContact)
       })
 
       it('converts false to "yes"', async () => {

--- a/test/services/company-contacts/setup/initiate-session.service.test.js
+++ b/test/services/company-contacts/setup/initiate-session.service.test.js
@@ -11,8 +11,11 @@ const { expect } = Code
 // Test helpers
 const SessionModel = require('../../../../app/models/session.model.js')
 const CustomersFixtures = require('../../../support/fixtures/customers.fixture.js')
+const { generateLicenceRef } = require('../../../support/helpers/licence.helper.js')
+const { generateUUID } = require('../../../../app/lib/general.lib.js')
 
 // Things we need to stub
+const FetchCompanyLicencesService = require('../../../../app/dal/company-contacts/fetch-company-licences.dal.js')
 const FetchCompanyService = require('../../../../app/services/companies/fetch-company.service.js')
 
 // Thing under test
@@ -20,11 +23,14 @@ const InitiateSessionService = require('../../../../app/services/company-contact
 
 describe('Company Contacts - Setup - Initiate Session service', () => {
   let company
+  let licences
 
-  beforeEach(async () => {
+  beforeEach(() => {
     company = CustomersFixtures.company()
+    licences = [{ id: generateUUID(), licenceRef: generateLicenceRef() }]
 
     Sinon.stub(FetchCompanyService, 'go').returns(company)
+    Sinon.stub(FetchCompanyLicencesService, 'go').returns(licences)
   })
 
   afterEach(() => {
@@ -41,9 +47,11 @@ describe('Company Contacts - Setup - Initiate Session service', () => {
         company,
         createdAt: matchingSession.createdAt,
         data: {
-          company
+          company,
+          licences
         },
         id: result.id,
+        licences,
         updatedAt: matchingSession.updatedAt
       })
     })

--- a/test/services/company-contacts/setup/initiate-session.service.test.js
+++ b/test/services/company-contacts/setup/initiate-session.service.test.js
@@ -9,13 +9,13 @@ const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const SessionModel = require('../../../../app/models/session.model.js')
 const CustomersFixtures = require('../../../support/fixtures/customers.fixture.js')
-const { generateLicenceRef } = require('../../../support/helpers/licence.helper.js')
+const SessionModel = require('../../../../app/models/session.model.js')
 const { generateUUID } = require('../../../../app/lib/general.lib.js')
+const { generateLicenceRef } = require('../../../support/helpers/licence.helper.js')
 
 // Things we need to stub
-const FetchCompanyLicencesService = require('../../../../app/dal/company-contacts/fetch-company-licences.dal.js')
+const FetchCompanyLicencesDal = require('../../../../app/dal/company-contacts/fetch-company-licences.dal.js')
 const FetchCompanyService = require('../../../../app/services/companies/fetch-company.service.js')
 
 // Thing under test
@@ -30,7 +30,7 @@ describe('Company Contacts - Setup - Initiate Session service', () => {
     licences = [{ id: generateUUID(), licenceRef: generateLicenceRef() }]
 
     Sinon.stub(FetchCompanyService, 'go').returns(company)
-    Sinon.stub(FetchCompanyLicencesService, 'go').returns(licences)
+    Sinon.stub(FetchCompanyLicencesDal, 'go').returns(licences)
   })
 
   afterEach(() => {

--- a/test/support/seeders/licence.seeder.js
+++ b/test/support/seeders/licence.seeder.js
@@ -1,0 +1,99 @@
+'use strict'
+
+/**
+ * @module LicenceSeeder
+ */
+
+const CompanyHelper = require('../helpers/company.helper.js')
+const LicenceHelper = require('../helpers/licence.helper.js')
+const LicenceVersionHelper = require('../helpers/licence-version.helper.js')
+const { generateUUID } = require('../../../app/lib/general.lib.js')
+
+/**
+ * Seeds a licence holder that is the current licence version holder for two licences
+ *
+ * @returns {Promise<object>} an object containing the company, both licences and their versions, and a clean function
+ */
+async function licenceHolderWithMultipleLicences() {
+  const { company, licence, licenceVersion } = await licenceHolderWithSingleLicence()
+
+  const licenceTwo = await LicenceHelper.add()
+  const licenceVersionTwo = await LicenceVersionHelper.add({ licenceId: licenceTwo.id, companyId: company.id })
+
+  return {
+    company,
+    licenceOne: {
+      licence,
+      licenceVersion
+    },
+    licenceTwo: {
+      licence: licenceTwo,
+      licenceVersion: licenceVersionTwo
+    },
+    clean: async () => {
+      await company.$query().delete()
+      await licenceVersion.$query().delete()
+      await licenceVersionTwo.$query().delete()
+      await licence.$query().delete()
+      await licenceTwo.$query().delete()
+    }
+  }
+}
+
+/**
+ * Seeds a licence holder that was once the licence version holder for a licence but no longer is
+ *
+ * A second, more recent licence version is added to the same licence but with a different company ID, making the
+ * seeded company an ex-holder rather than the current holder.
+ *
+ * @returns {Promise<object>} an object containing the company, the licence, both licence versions, and a clean function
+ */
+async function exLicenceHolderWithSingleLicences() {
+  const { clean, ...licenceHolder } = await licenceHolderWithSingleLicence()
+
+  const newerLicenceVersion = await LicenceVersionHelper.add({
+    licenceId: licenceHolder.licence.id,
+    issue: 2,
+    companyId: generateUUID()
+  })
+
+  return {
+    ...licenceHolder,
+    newerLicenceVersion,
+    clean: async () => {
+      await newerLicenceVersion.$query().delete()
+      await clean()
+    }
+  }
+}
+
+/**
+ * Seeds a licence holder that is the current licence version holder for a single licence
+ *
+ * @param {object} [data={}] - Additional data to pass to the licence helper when creating the licence
+ *
+ * @returns {Promise<object>} an object containing the company, licence, licence version, and a clean function
+ */
+async function licenceHolderWithSingleLicence(data = {}) {
+  const company = await CompanyHelper.add()
+
+  const licence = await LicenceHelper.add(data)
+  const licenceVersion = await LicenceVersionHelper.add({ licenceId: licence.id, companyId: company.id })
+
+  return {
+    company,
+    licence,
+    licenceVersion,
+    clean: async () => {
+      await licenceVersion.$query().delete()
+      await licence.$query().delete()
+      await company.$query().delete()
+    }
+  }
+}
+
+module.exports = {
+  exLicenceHolderWithSingleLicences,
+  licenceHolderWithMultipleLicences,
+  licenceHolderWithSingleLicence
+}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5630

We need to seed the licences for the company when we intiate the session so we can display (and use) the licences in the company contact journey.

This change adds logic to fetch licences for a company and populates the company contact session with the licences.

---------

Co-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>