### PR TITLE
Add some licences to company contacts

### DIFF
--- a/app/dal/company-contacts/setup/fetch-company-contact.dal.js
+++ b/app/dal/company-contacts/setup/fetch-company-contact.dal.js
@@ -20,7 +20,7 @@ async function go(companyContactId) {
 
 async function _fetch(companyContactId) {
   return CompanyContactModel.query()
-    .select(['id', 'abstractionAlerts'])
+    .select(['id', 'abstractionAlerts', 'abstractionAlertLicences'])
     .where('companyContacts.id', companyContactId)
     .withGraphFetched('company')
     .modifyGraph('company', (companyBuilder) => {

--- a/app/presenters/company-contacts/setup/abstraction-alerts.presenter.js
+++ b/app/presenters/company-contacts/setup/abstraction-alerts.presenter.js
@@ -24,7 +24,7 @@ function go(session) {
     },
     pageTitle: 'Should the contact get abstraction alerts?',
     pageTitleCaption: company.name,
-    abstractionAlerts: session.abstractionAlerts ?? null
+    abstractionAlerts: session.abstractionAlerts || null
   }
 }
 

--- a/app/presenters/company-contacts/setup/abstraction-alerts.presenter.js
+++ b/app/presenters/company-contacts/setup/abstraction-alerts.presenter.js
@@ -24,7 +24,7 @@ function go(session) {
     },
     pageTitle: 'Should the contact get abstraction alerts?',
     pageTitleCaption: company.name,
-    abstractionAlerts: session.abstractionAlerts || null
+    abstractionAlerts: session.abstractionAlerts ?? null
   }
 }
 

--- a/app/presenters/company-contacts/setup/check.presenter.js
+++ b/app/presenters/company-contacts/setup/check.presenter.js
@@ -5,8 +5,6 @@
  * @module CheckPresenter
  */
 
-const { titleCase } = require('../../base.presenter.js')
-
 /**
  * Formats data for the '/company-contacts/setup/{sessionId}/check' page
  *
@@ -23,7 +21,7 @@ function go(session, savedCompanyContacts, sentNotification) {
   const matchingContact = _matchingContact(email, name, savedCompanyContacts)
 
   return {
-    abstractionAlerts: titleCase(abstractionAlerts),
+    abstractionAlerts: _abstractionAlerts(abstractionAlerts),
     email,
     emailInUse: _emailInUse(sentNotification, companyContact),
     name,
@@ -39,6 +37,16 @@ function go(session, savedCompanyContacts, sentNotification) {
     matchingContact,
     warning: _warning(matchingContact)
   }
+}
+
+function _abstractionAlerts(abstractionAlerts) {
+  const abstractionAlertsText = {
+    no: 'No',
+    some: 'Yes, for some licences',
+    yes: 'Yes, for all licences'
+  }
+
+  return abstractionAlertsText[abstractionAlerts]
 }
 
 /**

--- a/app/services/company-contacts/setup/initiate-edit-session.service.js
+++ b/app/services/company-contacts/setup/initiate-edit-session.service.js
@@ -45,15 +45,35 @@ async function go(companyContactId) {
  * @private
  */
 function _formatDataForJourney(companyContact) {
-  const { abstractionAlerts, company, contact } = companyContact
+  const { abstractionAlertLicences, abstractionAlerts, company, contact } = companyContact
 
   return {
-    abstractionAlerts: abstractionAlerts === true ? 'yes' : 'no',
+    abstractionAlertLicences,
+    abstractionAlerts: _abstractionAlerts(abstractionAlerts, abstractionAlertLicences),
     company,
     companyContact,
     email: formatEmail(contact.email),
     name: contact.$name()
   }
+}
+
+/**
+ * Determines the abstraction alerts value for the session
+ *
+ * Maps the boolean `abstractionAlerts` flag from the company contact record to the string value used in the journey.
+ * If the contact has alerts enabled and abstraction alert licences linked, they receive alerts for some licences only.
+ * If no licences are linked, they receive alerts for all licences.
+ *
+ * @returns {string} 'yes', 'some', or 'no'
+ *
+ * @private
+ */
+function _abstractionAlerts(abstractionAlerts, abstractionAlertLicences) {
+  if (!abstractionAlerts) {
+    return 'no'
+  }
+
+  return abstractionAlertLicences ? 'some' : 'yes'
 }
 
 module.exports = {

--- a/app/services/company-contacts/setup/submit-check.service.js
+++ b/app/services/company-contacts/setup/submit-check.service.js
@@ -38,7 +38,7 @@ async function go(sessionId, yar, auth) {
 }
 
 function _abstractionAlerts(session) {
-  return session.abstractionAlerts === 'yes'
+  return session.abstractionAlerts === 'yes' || session.abstractionAlerts === 'some'
 }
 
 function _email(session) {

--- a/app/views/company-contacts/setup/abstraction-alerts.njk
+++ b/app/views/company-contacts/setup/abstraction-alerts.njk
@@ -14,8 +14,16 @@
       items: [
         {
           value: "yes",
-          text: "Yes",
+          text: "Yes, for all licences",
           checked: abstractionAlerts === 'yes'
+        },
+        {
+          value: "some",
+          text: "Yes, for some licences",
+          checked: abstractionAlerts === 'some'
+        },
+        {
+          divider: "or"
         },
         {
           value: "no",

--- a/test/dal/company-contacts/setup/fetch-company-contact.dal.test.js
+++ b/test/dal/company-contacts/setup/fetch-company-contact.dal.test.js
@@ -42,6 +42,7 @@ describe('Company Contacts - Setup - Fetch Company Contact Dal', () => {
       const result = await FetchCompanyContactDal.go(companyContact.id)
 
       expect(result).to.equal({
+        abstractionAlertLicences: null,
         abstractionAlerts: false,
         company: {
           id: company.id,

--- a/test/presenters/company-contacts/setup/abstraction-alerts.presenter.test.js
+++ b/test/presenters/company-contacts/setup/abstraction-alerts.presenter.test.js
@@ -40,12 +40,12 @@ describe('Company Contacts - Setup - Abstraction Alerts Presenter', () => {
     })
 
     describe('the "abstractionAlerts" property', () => {
-      describe('when the "abstractionAlerts" has previously been saved', () => {
+      describe('when "abstractionAlerts" property is set on the session', () => {
         beforeEach(() => {
           session.abstractionAlerts = 'yes'
         })
 
-        it('returns the "abstractionAlerts" from the session', () => {
+        it('returns the "abstractionAlerts" value', () => {
           const result = AbstractionAlertsPresenter.go(session)
 
           expect(result.abstractionAlerts).to.equal('yes')

--- a/test/presenters/company-contacts/setup/check.presenter.test.js
+++ b/test/presenters/company-contacts/setup/check.presenter.test.js
@@ -45,7 +45,7 @@ describe('Company Contacts - Setup - Check Presenter', () => {
       const result = CheckPresenter.go(session, savedCompanyContacts, sentNotification)
 
       expect(result).to.equal({
-        abstractionAlerts: 'Yes',
+        abstractionAlerts: 'Yes, for all licences',
         email,
         emailInUse: null,
         links: {
@@ -60,6 +60,40 @@ describe('Company Contacts - Setup - Check Presenter', () => {
         pageTitle: 'Check contact',
         pageTitleCaption: 'Tyrell Corporation',
         warning: null
+      })
+    })
+
+    describe('the "abstractionAlerts" property', () => {
+      describe('when "abstractionAlerts" is "yes"', () => {
+        it('returns "Yes, for all licences"', () => {
+          const result = CheckPresenter.go(session, savedCompanyContacts, sentNotification)
+
+          expect(result.abstractionAlerts).to.equal('Yes, for all licences')
+        })
+      })
+
+      describe('when "abstractionAlerts" is "some"', () => {
+        beforeEach(() => {
+          session.abstractionAlerts = 'some'
+        })
+
+        it('returns "Yes, for some licences"', () => {
+          const result = CheckPresenter.go(session, savedCompanyContacts, sentNotification)
+
+          expect(result.abstractionAlerts).to.equal('Yes, for some licences')
+        })
+      })
+
+      describe('when "abstractionAlerts" is "no"', () => {
+        beforeEach(() => {
+          session.abstractionAlerts = 'no'
+        })
+
+        it('returns "No"', () => {
+          const result = CheckPresenter.go(session, savedCompanyContacts, sentNotification)
+
+          expect(result.abstractionAlerts).to.equal('No')
+        })
       })
     })
 

--- a/test/services/company-contacts/setup/initiate-edit-session.service.test.js
+++ b/test/services/company-contacts/setup/initiate-edit-session.service.test.js
@@ -37,6 +37,7 @@ describe('Company Contacts - Setup - Initiate edit Session service', () => {
     companyContact = {
       id: generateUUID(),
       abstractionAlerts: false,
+      abstractionAlertLicences: null,
       company,
       contact
     }
@@ -76,17 +77,35 @@ describe('Company Contacts - Setup - Initiate edit Session service', () => {
         stubFetchCompanyContactDal.resolves(companyContact)
       })
 
-      it('converts false to "yes"', async () => {
-        const result = await InitiateEditSessionService.go(companyContact.id)
+      describe('and abstraction alert licences exist', () => {
+        beforeEach(() => {
+          companyContact.abstractionAlertLicences = [{ id: generateUUID(), licenceRef: generateLicenceRef() }]
 
-        const matchingSession = await SessionModel.query().findById(result.id)
+          stubFetchCompanyContactDal.resolves(companyContact)
+        })
 
-        expect(matchingSession.abstractionAlerts).to.equal('yes')
+        it('returns "some"', async () => {
+          const result = await InitiateEditSessionService.go(companyContact.id)
+
+          const matchingSession = await SessionModel.query().findById(result.id)
+
+          expect(matchingSession.abstractionAlerts).to.equal('some')
+        })
+      })
+
+      describe('and no abstraction alert licences exist', () => {
+        it('returns "yes"', async () => {
+          const result = await InitiateEditSessionService.go(companyContact.id)
+
+          const matchingSession = await SessionModel.query().findById(result.id)
+
+          expect(matchingSession.abstractionAlerts).to.equal('yes')
+        })
       })
     })
 
     describe('when the "abstractionAlerts" property is false', () => {
-      it('converts false to "no"', async () => {
+      it('returns "no"', async () => {
         const result = await InitiateEditSessionService.go(companyContact.id)
 
         const matchingSession = await SessionModel.query().findById(result.id)
@@ -110,8 +129,10 @@ describe('Company Contacts - Setup - Initiate edit Session service', () => {
 function _expectedSessionData(companyContact, company, contact, licences) {
   return {
     abstractionAlerts: 'no',
+    abstractionAlertLicences: null,
     companyContact: {
       abstractionAlerts: false,
+      abstractionAlertLicences: null,
       company: {
         id: company.id,
         name: 'Tyrell Corporation'

--- a/test/services/company-contacts/setup/submit-check.service.test.js
+++ b/test/services/company-contacts/setup/submit-check.service.test.js
@@ -110,7 +110,23 @@ describe('Company Contacts - Setup - Check Service', () => {
         })
       })
 
-      describe(' is "no"', () => {
+      describe('is "some"', () => {
+        beforeEach(() => {
+          session = SessionModelStub.build(Sinon, { ...sessionData, abstractionAlerts: 'some' })
+
+          fetchSessionStub.resolves(session)
+        })
+
+        it('persists the "abstractionAlerts" as "true"', async () => {
+          await SubmitCheckService.go(session.id, yarStub, auth)
+
+          const actualContact = CreateCompanyContactService.go.args[0][1]
+
+          expect(actualContact.abstractionAlerts).to.be.true()
+        })
+      })
+
+      describe('is "no"', () => {
         beforeEach(async () => {
           session = SessionModelStub.build(Sinon, { ...sessionData, abstractionAlerts: 'no' })
 
@@ -198,7 +214,23 @@ describe('Company Contacts - Setup - Check Service', () => {
         })
       })
 
-      describe(' is "no"', () => {
+      describe('is "some"', () => {
+        beforeEach(() => {
+          session = SessionModelStub.build(Sinon, { ...sessionData, abstractionAlerts: 'some' })
+
+          fetchSessionStub.resolves(session)
+        })
+
+        it('persists the "abstractionAlerts" as "true"', async () => {
+          await SubmitCheckService.go(session.id, yarStub, auth)
+
+          const [actualContact] = UpdateCompanyContactService.go.args[0]
+
+          expect(actualContact.abstractionAlerts).to.be.true()
+        })
+      })
+
+      describe('is "no"', () => {
         beforeEach(async () => {
           session = SessionModelStub.build(Sinon, { ...sessionData, abstractionAlerts: 'no' })
 

--- a/test/services/company-contacts/setup/view-check.service.test.js
+++ b/test/services/company-contacts/setup/view-check.service.test.js
@@ -56,7 +56,7 @@ describe('Company Contacts - Setup - Check Service', () => {
         const result = await ViewCheckService.go(session.id, yarStub)
 
         expect(result).to.equal({
-          abstractionAlerts: 'Yes',
+          abstractionAlerts: 'Yes, for all licences',
           email: 'eric@test.com',
           emailInUse: null,
           links: {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5629

Add a "Yes, for some licences" option to abstraction alerts

  - New radio option on the abstraction alerts page
  - _abstractionAlerts in check presenter maps all three values ('yes', 'some', 'no') to display text
  - Initiate edit session derives 'some' when the contact has abstractionAlertLicences, 'yes' when alerts are on but no specific licences, 'no' when alerts are off
  - Submit check service persists both 'yes' and 'some' as true to the database

  More changes will be done in another PR to add the licences to the view and persist. These changes are needed before we build the licences functionality out.