### PR TITLE
Fix scope for create ad-hoc btn and journey 

### DIFF
--- a/app/presenters/notices/index-notices.presenter.js
+++ b/app/presenters/notices/index-notices.presenter.js
@@ -48,11 +48,7 @@ function _helperText(scope) {
 function _links(scope) {
   const links = {}
 
-  if (
-    scope.includes('returns') ||
-    scope.includes('bulk_return_notifications') ||
-    scope.includes('renewal_notifications')
-  ) {
+  if (scope.includes('bulk_return_notifications') || scope.includes('renewal_notifications')) {
     links.adhoc = {
       text: 'Create an ad-hoc notice',
       href: '/system/notices/setup/adhoc'

--- a/app/routes/notices-setup.routes.js
+++ b/app/routes/notices-setup.routes.js
@@ -10,7 +10,7 @@ const routes = [
       handler: NoticesSetupController.setup,
       auth: {
         access: {
-          scope: ['hof_notifications', 'renewal_notifications', 'returns']
+          scope: ['bulk_return_notifications', 'hof_notifications', 'renewal_notifications']
         }
       }
     }
@@ -154,7 +154,7 @@ const routes = [
       handler: NoticesSetupController.processAddRecipient,
       auth: {
         access: {
-          scope: ['hof_notifications', 'renewal_notifications', 'returns']
+          scope: ['bulk_return_notifications', 'hof_notifications', 'renewal_notifications']
         }
       }
     }
@@ -166,7 +166,7 @@ const routes = [
       handler: NoticesSetupController.viewCancel,
       auth: {
         access: {
-          scope: ['hof_notifications', 'renewal_notifications', 'returns']
+          scope: ['bulk_return_notifications', 'hof_notifications', 'renewal_notifications']
         }
       }
     }
@@ -178,7 +178,7 @@ const routes = [
       handler: NoticesSetupController.submitCancel,
       auth: {
         access: {
-          scope: ['hof_notifications', 'renewal_notifications', 'returns']
+          scope: ['bulk_return_notifications', 'hof_notifications', 'renewal_notifications']
         }
       }
     }
@@ -190,7 +190,7 @@ const routes = [
       handler: NoticesSetupController.viewCheck,
       auth: {
         access: {
-          scope: ['hof_notifications', 'renewal_notifications', 'returns']
+          scope: ['bulk_return_notifications', 'hof_notifications', 'renewal_notifications']
         }
       }
     }
@@ -202,7 +202,7 @@ const routes = [
       handler: NoticesSetupController.submitCheck,
       auth: {
         access: {
-          scope: ['hof_notifications', 'renewal_notifications', 'returns']
+          scope: ['bulk_return_notifications', 'hof_notifications', 'renewal_notifications']
         }
       }
     }
@@ -214,7 +214,7 @@ const routes = [
       handler: NoticesSetupController.viewCheckNoticeType,
       auth: {
         access: {
-          scope: ['renewal_notifications', 'returns']
+          scope: ['bulk_return_notifications', 'renewal_notifications']
         }
       }
     }
@@ -226,7 +226,7 @@ const routes = [
       handler: NoticesSetupController.submitCheckNoticeType,
       auth: {
         access: {
-          scope: ['renewal_notifications', 'returns']
+          scope: ['bulk_return_notifications', 'renewal_notifications']
         }
       }
     }
@@ -238,7 +238,7 @@ const routes = [
       handler: NoticesSetupController.viewConfirmation,
       auth: {
         access: {
-          scope: ['hof_notifications', 'renewal_notifications', 'returns']
+          scope: ['bulk_return_notifications', 'renewal_notifications', 'hof_notifications']
         }
       }
     }
@@ -250,7 +250,7 @@ const routes = [
       handler: NoticesSetupController.viewContactType,
       auth: {
         access: {
-          scope: ['renewal_notifications', 'returns']
+          scope: ['bulk_return_notifications', 'renewal_notifications']
         }
       }
     }
@@ -262,7 +262,7 @@ const routes = [
       handler: NoticesSetupController.submitContactType,
       auth: {
         access: {
-          scope: ['renewal_notifications', 'returns']
+          scope: ['bulk_return_notifications', 'renewal_notifications']
         }
       }
     }
@@ -274,7 +274,7 @@ const routes = [
       handler: NoticesSetupController.processDownloadRecipients,
       auth: {
         access: {
-          scope: ['hof_notifications', 'renewal_notifications', 'returns']
+          scope: ['bulk_return_notifications', 'hof_notifications', 'renewal_notifications']
         }
       }
     }
@@ -286,7 +286,7 @@ const routes = [
       handler: NoticesSetupController.viewLicence,
       auth: {
         access: {
-          scope: ['renewal_notifications', 'returns']
+          scope: ['bulk_return_notifications', 'renewal_notifications']
         }
       }
     }
@@ -298,7 +298,7 @@ const routes = [
       handler: NoticesSetupController.submitLicence,
       auth: {
         access: {
-          scope: ['renewal_notifications', 'returns']
+          scope: ['bulk_return_notifications', 'renewal_notifications']
         }
       }
     }
@@ -310,7 +310,7 @@ const routes = [
       handler: NoticesSetupController.viewNoticeType,
       auth: {
         access: {
-          scope: ['renewal_notifications', 'returns']
+          scope: ['bulk_return_notifications', 'renewal_notifications']
         }
       }
     }
@@ -322,7 +322,7 @@ const routes = [
       handler: NoticesSetupController.submitNoticeType,
       auth: {
         access: {
-          scope: ['renewal_notifications', 'returns']
+          scope: ['bulk_return_notifications', 'renewal_notifications']
         }
       }
     }
@@ -334,7 +334,7 @@ const routes = [
       handler: NoticesSetupController.viewPaperReturn,
       auth: {
         access: {
-          scope: ['returns']
+          scope: ['bulk_return_notifications']
         }
       }
     }
@@ -346,7 +346,7 @@ const routes = [
       handler: NoticesSetupController.submitPaperReturn,
       auth: {
         access: {
-          scope: ['returns']
+          scope: ['bulk_return_notifications']
         }
       }
     }
@@ -358,7 +358,7 @@ const routes = [
       handler: NoticesSetupController.viewPreview,
       auth: {
         access: {
-          scope: ['renewal_notifications', 'returns']
+          scope: ['bulk_return_notifications', 'renewal_notifications']
         }
       }
     }
@@ -394,7 +394,7 @@ const routes = [
       handler: NoticesSetupController.viewPreviewCheckPaperReturn,
       auth: {
         access: {
-          scope: ['returns']
+          scope: ['bulk_return_notifications']
         }
       }
     }
@@ -406,7 +406,7 @@ const routes = [
       handler: NoticesSetupController.processPreviewPaperReturn,
       auth: {
         access: {
-          scope: ['returns']
+          scope: ['bulk_return_notifications']
         }
       }
     }
@@ -418,7 +418,7 @@ const routes = [
       handler: NoticesSetupController.viewRecipientName,
       auth: {
         access: {
-          scope: ['returns']
+          scope: ['bulk_return_notifications']
         }
       }
     }
@@ -430,7 +430,7 @@ const routes = [
       handler: NoticesSetupController.submitRecipientName,
       auth: {
         access: {
-          scope: ['returns']
+          scope: ['bulk_return_notifications']
         }
       }
     }
@@ -442,7 +442,7 @@ const routes = [
       handler: NoticesSetupController.viewRemoveLicences,
       auth: {
         access: {
-          scope: ['returns']
+          scope: ['bulk_return_notifications']
         }
       }
     }
@@ -454,7 +454,7 @@ const routes = [
       handler: NoticesSetupController.submitRemoveLicences,
       auth: {
         access: {
-          scope: ['returns']
+          scope: ['bulk_return_notifications']
         }
       }
     }
@@ -466,7 +466,7 @@ const routes = [
       handler: NoticesSetupController.viewReturnsPeriod,
       auth: {
         access: {
-          scope: ['returns']
+          scope: ['bulk_return_notifications']
         }
       }
     }
@@ -478,7 +478,7 @@ const routes = [
       handler: NoticesSetupController.submitReturnsPeriod,
       auth: {
         access: {
-          scope: ['returns']
+          scope: ['bulk_return_notifications']
         }
       }
     }
@@ -490,7 +490,7 @@ const routes = [
       handler: NoticesSetupController.viewSelectRecipients,
       auth: {
         access: {
-          scope: ['hof_notifications', 'renewal_notifications', 'returns']
+          scope: ['bulk_return_notifications', 'hof_notifications', 'renewal_notifications']
         }
       }
     }
@@ -502,7 +502,7 @@ const routes = [
       handler: NoticesSetupController.submitSelectRecipients,
       auth: {
         access: {
-          scope: ['hof_notifications', 'renewal_notifications', 'returns']
+          scope: ['bulk_return_notifications', 'hof_notifications', 'renewal_notifications']
         }
       }
     }

--- a/test/controllers/notices-setup.controller.test.js
+++ b/test/controllers/notices-setup.controller.test.js
@@ -125,7 +125,7 @@ describe('Notices Setup controller', () => {
             url: '/notices/setup/standard',
             auth: {
               strategy: 'session',
-              credentials: { scope: ['returns'] }
+              credentials: { scope: ['bulk_return_notifications'] }
             }
           }
 
@@ -153,7 +153,7 @@ describe('Notices Setup controller', () => {
             url: '/notices/setup/adhoc',
             auth: {
               strategy: 'session',
-              credentials: { scope: ['returns'] }
+              credentials: { scope: ['bulk_return_notifications'] }
             }
           }
 
@@ -184,7 +184,7 @@ describe('Notices Setup controller', () => {
           url: basePath + `/${session.id}/cancel`,
           auth: {
             strategy: 'session',
-            credentials: { scope: ['returns'] }
+            credentials: { scope: ['bulk_return_notifications'] }
           }
         }
       })
@@ -210,7 +210,7 @@ describe('Notices Setup controller', () => {
       describe('when the request succeeds', () => {
         beforeEach(async () => {
           Sinon.stub(SubmitCancelService, 'go').returns('/system/notices')
-          postOptions = postRequestOptions(basePath + `/${session.id}/cancel`, {})
+          postOptions = postRequestOptions(basePath + `/${session.id}/cancel`, {}, ['bulk_return_notifications'])
         })
 
         it('redirects the to the next page', async () => {
@@ -231,7 +231,7 @@ describe('Notices Setup controller', () => {
           url: basePath + `/${session.id}/check`,
           auth: {
             strategy: 'session',
-            credentials: { scope: ['returns'] }
+            credentials: { scope: ['bulk_return_notifications'] }
           }
         }
       })
@@ -260,7 +260,7 @@ describe('Notices Setup controller', () => {
           eventId = '1233'
 
           Sinon.stub(SubmitCheckService, 'go').returns(eventId)
-          postOptions = postRequestOptions(basePath + `/${session.id}/check`, {})
+          postOptions = postRequestOptions(basePath + `/${session.id}/check`, {}, ['bulk_return_notifications'])
         })
 
         it('redirects the to the next page', async () => {
@@ -281,7 +281,7 @@ describe('Notices Setup controller', () => {
           url: basePath + `/${session.id}/check-notice-type`,
           auth: {
             strategy: 'session',
-            credentials: { scope: ['returns'] }
+            credentials: { scope: ['bulk_return_notifications'] }
           }
         }
       })
@@ -304,7 +304,9 @@ describe('Notices Setup controller', () => {
 
     describe('POST', () => {
       beforeEach(async () => {
-        postOptions = postRequestOptions(basePath + `/${session.id}/check-notice-type`, {})
+        postOptions = postRequestOptions(basePath + `/${session.id}/check-notice-type`, {}, [
+          'bulk_return_notifications'
+        ])
 
         Sinon.stub(SubmitCheckNoticeTypeService, 'go').resolves({ redirectUrl: 'check' })
       })
@@ -330,7 +332,7 @@ describe('Notices Setup controller', () => {
           url: basePath + `/${eventId}/confirmation`,
           auth: {
             strategy: 'session',
-            credentials: { scope: ['returns'] }
+            credentials: { scope: ['bulk_return_notifications'] }
           }
         }
       })
@@ -360,7 +362,7 @@ describe('Notices Setup controller', () => {
           url: basePath + `/${session.id}/download`,
           auth: {
             strategy: 'session',
-            credentials: { scope: ['returns'] }
+            credentials: { scope: ['bulk_return_notifications'] }
           }
         }
       })
@@ -732,7 +734,7 @@ describe('Notices Setup controller', () => {
           url: basePath + `/${session.id}/licence`,
           auth: {
             strategy: 'session',
-            credentials: { scope: ['returns'] }
+            credentials: { scope: ['bulk_return_notifications'] }
           }
         }
 
@@ -754,7 +756,9 @@ describe('Notices Setup controller', () => {
     describe('POST', () => {
       describe('when a request is valid', () => {
         beforeEach(async () => {
-          postOptions = postRequestOptions(basePath + `/${session.id}/licence`, { licenceRef: '01/115' })
+          postOptions = postRequestOptions(basePath + `/${session.id}/licence`, { licenceRef: '01/115' }, [
+            'bulk_return_notifications'
+          ])
 
           Sinon.stub(SubmitLicenceService, 'go').resolves({ redirectUrl: 'notice-type' })
         })
@@ -769,7 +773,9 @@ describe('Notices Setup controller', () => {
 
       describe('when a request is invalid', () => {
         beforeEach(async () => {
-          postOptions = postRequestOptions(basePath + `/${session.id}/licence`, { licenceRef: '' })
+          postOptions = postRequestOptions(basePath + `/${session.id}/licence`, { licenceRef: '' }, [
+            'bulk_return_notifications'
+          ])
 
           Sinon.stub(SubmitLicenceService, 'go').resolves({
             licenceRef: null,
@@ -808,7 +814,7 @@ describe('Notices Setup controller', () => {
           url: basePath + `/${session.id}/preview/${contactHashId}`,
           auth: {
             strategy: 'session',
-            credentials: { scope: ['returns'] }
+            credentials: { scope: ['bulk_return_notifications'] }
           }
         }
 
@@ -899,7 +905,7 @@ describe('Notices Setup controller', () => {
           url: basePath + `/${session.id}/preview/${contactHashId}/check-paper-return`,
           auth: {
             strategy: 'session',
-            credentials: { scope: ['returns'] }
+            credentials: { scope: ['bulk_return_notifications'] }
           }
         }
 
@@ -931,7 +937,7 @@ describe('Notices Setup controller', () => {
             `/${session.id}/preview/938c2cc0dcc05f2b68c4287040cfcf71/paper-return/95b54f97-fefb-46e7-aae8-ebf40ecb8b50`,
           auth: {
             strategy: 'session',
-            credentials: { scope: ['returns'] }
+            credentials: { scope: ['bulk_return_notifications'] }
           }
         }
 
@@ -963,7 +969,7 @@ describe('Notices Setup controller', () => {
           url: basePath + `/${session.id}/notice-type`,
           auth: {
             strategy: 'session',
-            credentials: { scope: ['returns'] }
+            credentials: { scope: ['bulk_return_notifications'] }
           }
         }
 
@@ -985,7 +991,9 @@ describe('Notices Setup controller', () => {
     describe('POST', () => {
       describe('when a request is valid', () => {
         beforeEach(async () => {
-          postOptions = postRequestOptions(basePath + `/${session.id}/notice-type`, { noticeType: 'returns' })
+          postOptions = postRequestOptions(basePath + `/${session.id}/notice-type`, { noticeType: 'returns' }, [
+            'bulk_return_notifications'
+          ])
 
           Sinon.stub(SubmitNoticeTypeService, 'go').resolves({ redirectUrl: 'check-notice-type' })
         })
@@ -1000,7 +1008,9 @@ describe('Notices Setup controller', () => {
 
       describe('when a request is invalid', () => {
         beforeEach(async () => {
-          postOptions = postRequestOptions(basePath + `/${session.id}/notice-type`, { noticeType: '' })
+          postOptions = postRequestOptions(basePath + `/${session.id}/notice-type`, { noticeType: '' }, [
+            'bulk_return_notifications'
+          ])
 
           Sinon.stub(SubmitNoticeTypeService, 'go').resolves({
             error: { text: 'Select the notice type' },
@@ -1027,7 +1037,7 @@ describe('Notices Setup controller', () => {
           url: basePath + `/${session.id}/recipient-name`,
           auth: {
             strategy: 'session',
-            credentials: { scope: ['returns'] }
+            credentials: { scope: ['bulk_return_notifications'] }
           }
         }
       })
@@ -1054,7 +1064,9 @@ describe('Notices Setup controller', () => {
               error: 'Something went wrong'
             })
 
-            postOptions = postRequestOptions(basePath + `/${session.id}/recipient-name`, {})
+            postOptions = postRequestOptions(basePath + `/${session.id}/recipient-name`, {}, [
+              'bulk_return_notifications'
+            ])
           })
 
           it('returns the page successfully with the error summary banner', async () => {
@@ -1070,7 +1082,9 @@ describe('Notices Setup controller', () => {
             Sinon.stub(SubmitRecipientNameService, 'go').returns({
               pageTile: 'Select recipients'
             })
-            postOptions = postRequestOptions(basePath + `/${session.id}/recipient-name`, {})
+            postOptions = postRequestOptions(basePath + `/${session.id}/recipient-name`, {}, [
+              'bulk_return_notifications'
+            ])
           })
 
           it('redirects the to the next page', async () => {
@@ -1092,7 +1106,7 @@ describe('Notices Setup controller', () => {
           url: basePath + `/${session.id}/remove-licences`,
           auth: {
             strategy: 'session',
-            credentials: { scope: ['returns'] }
+            credentials: { scope: ['bulk_return_notifications'] }
           }
         }
       })
@@ -1123,7 +1137,9 @@ describe('Notices Setup controller', () => {
               ..._viewRemoveLicence(),
               error: 'Something went wrong'
             })
-            postOptions = postRequestOptions(basePath + `/${session.id}/remove-licences`, {})
+            postOptions = postRequestOptions(basePath + `/${session.id}/remove-licences`, {}, [
+              'bulk_return_notifications'
+            ])
           })
 
           it('returns the page successfully with the error summary banner', async () => {
@@ -1137,7 +1153,9 @@ describe('Notices Setup controller', () => {
         describe('and the validation succeeds', () => {
           beforeEach(async () => {
             Sinon.stub(SubmitRemoveLicencesService, 'go').returns({ redirect: 'check' })
-            postOptions = postRequestOptions(basePath + `/${session.id}/remove-licences`, {})
+            postOptions = postRequestOptions(basePath + `/${session.id}/remove-licences`, {}, [
+              'bulk_return_notifications'
+            ])
           })
 
           it('redirects the to the next page', async () => {
@@ -1159,7 +1177,7 @@ describe('Notices Setup controller', () => {
           url: basePath + `/${session.id}/returns-period`,
           auth: {
             strategy: 'session',
-            credentials: { scope: ['returns'] }
+            credentials: { scope: ['bulk_return_notifications'] }
           }
         }
       })
@@ -1189,7 +1207,9 @@ describe('Notices Setup controller', () => {
               ..._viewReturnsPeriod(),
               error: 'Something went wrong'
             })
-            postOptions = postRequestOptions(basePath + `/${session.id}/returns-period`, {})
+            postOptions = postRequestOptions(basePath + `/${session.id}/returns-period`, {}, [
+              'bulk_return_notifications'
+            ])
           })
 
           it('returns the page successfully with the error summary banner', async () => {
@@ -1203,7 +1223,9 @@ describe('Notices Setup controller', () => {
         describe('and the validation succeeds', () => {
           beforeEach(async () => {
             Sinon.stub(SubmitReturnsPeriodService, 'go').returns({ redirect: 'send-notice' })
-            postOptions = postRequestOptions(basePath + `/${session.id}/returns-period`, {})
+            postOptions = postRequestOptions(basePath + `/${session.id}/returns-period`, {}, [
+              'bulk_return_notifications'
+            ])
           })
 
           it('redirects the to the next page', async () => {
@@ -1225,7 +1247,7 @@ describe('Notices Setup controller', () => {
           url: basePath + `/${session.id}/paper-return`,
           auth: {
             strategy: 'session',
-            credentials: { scope: ['returns'] }
+            credentials: { scope: ['bulk_return_notifications'] }
           }
         }
       })
@@ -1253,7 +1275,9 @@ describe('Notices Setup controller', () => {
             Sinon.stub(SubmitPaperReturnService, 'go').returns({
               error: 'Something went wrong'
             })
-            postOptions = postRequestOptions(basePath + `/${session.id}/paper-return`, {})
+            postOptions = postRequestOptions(basePath + `/${session.id}/paper-return`, {}, [
+              'bulk_return_notifications'
+            ])
           })
 
           it('returns the page successfully with the error summary banner', async () => {
@@ -1269,7 +1293,9 @@ describe('Notices Setup controller', () => {
             Sinon.stub(SubmitPaperReturnService, 'go').returns({
               pageTile: 'Select the returns for the paper forms'
             })
-            postOptions = postRequestOptions(basePath + `/${session.id}/paper-return`, {})
+            postOptions = postRequestOptions(basePath + `/${session.id}/paper-return`, {}, [
+              'bulk_return_notifications'
+            ])
           })
 
           it('redirects the to the next page', async () => {
@@ -1291,7 +1317,7 @@ describe('Notices Setup controller', () => {
           url: basePath + `/${session.id}/select-recipients`,
           auth: {
             strategy: 'session',
-            credentials: { scope: ['returns'] }
+            credentials: { scope: ['bulk_return_notifications'] }
           }
         }
       })
@@ -1317,7 +1343,9 @@ describe('Notices Setup controller', () => {
             Sinon.stub(SubmitSelectRecipientsService, 'go').returns({
               error: 'Something went wrong'
             })
-            postOptions = postRequestOptions(basePath + `/${session.id}/select-recipients`, {})
+            postOptions = postRequestOptions(basePath + `/${session.id}/select-recipients`, {}, [
+              'bulk_return_notifications'
+            ])
           })
 
           it('returns the page successfully with the error summary banner', async () => {
@@ -1333,7 +1361,9 @@ describe('Notices Setup controller', () => {
             Sinon.stub(SubmitSelectRecipientsService, 'go').returns({
               pageTile: 'Select recipients'
             })
-            postOptions = postRequestOptions(basePath + `/${session.id}/select-recipients`, {})
+            postOptions = postRequestOptions(basePath + `/${session.id}/select-recipients`, {}, [
+              'bulk_return_notifications'
+            ])
           })
 
           it('redirects the to the next page', async () => {
@@ -1355,7 +1385,7 @@ describe('Notices Setup controller', () => {
           url: basePath + `/${session.id}/contact-type`,
           auth: {
             strategy: 'session',
-            credentials: { scope: ['returns'] }
+            credentials: { scope: ['bulk_return_notifications'] }
           }
         }
       })
@@ -1383,7 +1413,9 @@ describe('Notices Setup controller', () => {
             Sinon.stub(SubmitContactTypeService, 'go').returns({
               error: 'Something went wrong'
             })
-            postOptions = postRequestOptions(basePath + `/${session.id}/contact-type`, {})
+            postOptions = postRequestOptions(basePath + `/${session.id}/contact-type`, {}, [
+              'bulk_return_notifications'
+            ])
           })
 
           it('returns the page successfully with the error summary banner', async () => {
@@ -1400,7 +1432,9 @@ describe('Notices Setup controller', () => {
               contactType: 'post',
               pageTile: 'Select how to contact the recipient'
             })
-            postOptions = postRequestOptions(basePath + `/${session.id}/contact-type`, {})
+            postOptions = postRequestOptions(basePath + `/${session.id}/contact-type`, {}, [
+              'bulk_return_notifications'
+            ])
           })
 
           it('redirects the to the next page', async () => {
@@ -1417,7 +1451,9 @@ describe('Notices Setup controller', () => {
               contactType: 'email',
               pageTile: 'Select how to contact the recipient'
             })
-            postOptions = postRequestOptions(basePath + `/${session.id}/contact-type`, {})
+            postOptions = postRequestOptions(basePath + `/${session.id}/contact-type`, {}, [
+              'bulk_return_notifications'
+            ])
           })
 
           it('redirects the to the next page', async () => {
@@ -1439,7 +1475,7 @@ describe('Notices Setup controller', () => {
           url: basePath + `/${session.id}/add-recipient`,
           auth: {
             strategy: 'session',
-            credentials: { scope: ['returns'] }
+            credentials: { scope: ['bulk_return_notifications'] }
           }
         }
       })

--- a/test/presenters/notices/index-notices.presenter.test.js
+++ b/test/presenters/notices/index-notices.presenter.test.js
@@ -21,7 +21,7 @@ describe('Notices - Index Notices presenter', () => {
     notices = NoticesFixture.mapToFetchNoticesResult(NoticesFixture.notices())
 
     auth = {
-      credentials: { scope: ['bulk_return_notifications', 'returns'] }
+      credentials: { scope: ['bulk_return_notifications'] }
     }
   })
 
@@ -138,7 +138,7 @@ describe('Notices - Index Notices presenter', () => {
   })
 
   describe('the "helperText" property', () => {
-    describe('when the user has both the "bulk_notifications" and "renewal_notifications" roles', () => {
+    describe('when the user has both the "bulk_return_notifications" and "renewal_notifications" roles', () => {
       beforeEach(() => {
         auth.credentials.scope = ['bulk_return_notifications', 'renewal_notifications']
       })
@@ -152,7 +152,7 @@ describe('Notices - Index Notices presenter', () => {
       })
     })
 
-    describe('when the user has only the "bulk_notifications" role', () => {
+    describe('when the user has only the "bulk_return_notifications" role', () => {
       beforeEach(() => {
         auth.credentials.scope = ['bulk_return_notifications']
       })
@@ -220,7 +220,7 @@ describe('Notices - Index Notices presenter', () => {
   describe('the "links" property', () => {
     describe('when the user has permissions', () => {
       beforeEach(() => {
-        auth.credentials.scope = ['bulk_return_notifications', 'returns', 'renewal_notifications']
+        auth.credentials.scope = ['bulk_return_notifications', 'renewal_notifications']
       })
 
       it('returns all of the links', () => {
@@ -267,23 +267,6 @@ describe('Notices - Index Notices presenter', () => {
           notice: {
             href: '/system/notices/setup/standard',
             text: 'Create a standard notice'
-          }
-        })
-      })
-    })
-
-    describe('when the user has the "returns" permission', () => {
-      beforeEach(() => {
-        auth.credentials.scope = ['returns']
-      })
-
-      it('returns only the "adhoc" link', () => {
-        const result = IndexNoticesPresenter.go(notices, auth)
-
-        expect(result.links).to.equal({
-          adhoc: {
-            href: '/system/notices/setup/adhoc',
-            text: 'Create an ad-hoc notice'
           }
         })
       })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5642

We're updating the Create an ad-hoc notice journey to support renewals invitations.

This means we need to add the option to the **Select the notice type** page.

We did that in [Add renewal invitations to the adhoc notice journey](https://github.com/DEFRA/water-abstraction-system/pull/3350), but we got the permissions wrong.

We fixed its permissions in [Fix notice-type options for ad-hoc notices](https://github.com/DEFRA/water-abstraction-system/pull/3388) but that led to our QA team probably digging into the feature using all the permissions we have.

That led them to spot that users with 'Waste and Industry Regulatory Service' (WIRS) permissions could see the create ad-hoc notice button.

This was not meant to be the case, and we now realise it's due to the wrong application of scope. Some of the routes, and the logic for displaying the button, look for `returns` in the user's scope. However, it should be looking for `bulk_return_notifications`.

WIRS users have `returns` in their scope, but not `bulk_return_notifications`, so they should not be able to see the button or access the journey.

This change corrects the scope being used, so both access to the button and the journey are sorted.