### PR TITLE
Correct backlink text on unregister licences page 

### DIFF
--- a/app/presenters/users/external/setup/licences.presenter.js
+++ b/app/presenters/users/external/setup/licences.presenter.js
@@ -19,7 +19,7 @@ function go(session) {
 
   return {
     activeNavBar,
-    backLink: { href: `/system/users/external/${user.id}/licences`, text: 'Go back to user' },
+    backLink: { href: `/system/users/external/${user.id}/licences`, text: 'Back' },
     checkBoxItems,
     pageTitle: 'Select licences to unregister',
     pageTitleCaption: user.username,

--- a/test/presenters/users/external/setup/licences.presenter.test.js
+++ b/test/presenters/users/external/setup/licences.presenter.test.js
@@ -27,7 +27,7 @@ describe('Users - External - Setup - Licences Presenter', () => {
       activeNavBar: 'users',
       backLink: {
         href: `/system/users/external/${session.user.id}/licences`,
-        text: 'Go back to user'
+        text: 'Back'
       },
       checkBoxItems: [
         {

--- a/test/services/users/external/setup/submit-licences.service.test.js
+++ b/test/services/users/external/setup/submit-licences.service.test.js
@@ -194,7 +194,7 @@ describe('Users - External - Setup - Submit Licences Service', () => {
         activeNavBar: 'users',
         backLink: {
           href: `/system/users/external/${sessionData.user.id}/licences`,
-          text: 'Go back to user'
+          text: 'Back'
         },
         checkBoxItems: [
           {

--- a/test/services/users/external/setup/view-licences.service.test.js
+++ b/test/services/users/external/setup/view-licences.service.test.js
@@ -42,7 +42,7 @@ describe('Users - External - Setup - View Licences Service', () => {
         activeNavBar: 'users',
         backLink: {
           href: `/system/users/external/${sessionData.user.id}/licences`,
-          text: 'Go back to user'
+          text: 'Back'
         },
         checkBoxItems: [
           {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5627

During testing, our QA team has spotted an issue with the backlink on the external user **Select licences to unregister** page.

The link says 'Go back to user'. Our pattern for setup journeys is that the back link just says 'Back'.

This corrects the text.