### PR TITLE
Add licences to company contact journey

### DIFF
--- a/app/presenters/company-contacts/setup/licences.presenter.js
+++ b/app/presenters/company-contacts/setup/licences.presenter.js
@@ -15,15 +15,27 @@ const { checkUrl } = require('../../../lib/check-page.lib.js')
  * @returns {object} The data formatted for the view template
  */
 function go(session) {
-  const { id: sessionId } = session
+  const { company, id: sessionId, licences, abstractionAlertLicences } = session
 
   return {
     backLink: {
       href: checkUrl(session, `/system/company-contacts/setup/${sessionId}/abstraction-alerts`),
       text: 'Back'
     },
-    pageTitle: 'Select the licences they should get water abstraction alerts emails for'
+    licences: _licences(licences, abstractionAlertLicences),
+    pageTitle: 'Select the licences they should get water abstraction alerts emails for',
+    pageTitleCaption: company.name
   }
+}
+
+function _licences(licences, abstractionAlertLicences) {
+  return licences.map((licence) => {
+    return {
+      value: licence.id,
+      text: licence.licenceRef,
+      checked: abstractionAlertLicences?.includes(licence.id) || false
+    }
+  })
 }
 
 module.exports = {

--- a/app/services/company-contacts/setup/create-company-contact.service.js
+++ b/app/services/company-contacts/setup/create-company-contact.service.js
@@ -28,6 +28,7 @@ async function _create(companyId, companyContact) {
     companyId,
     startDate: today(),
     licenceRoleId: LicenceRoleModel.query().where('name', 'additionalContact').select('id'),
+    abstractionAlertLicences: companyContact.abstractionAlertLicences,
     abstractionAlerts: companyContact.abstractionAlerts,
     createdBy: companyContact.createdBy,
     contact: {

--- a/app/services/company-contacts/setup/submit-abstraction-alerts.service.js
+++ b/app/services/company-contacts/setup/submit-abstraction-alerts.service.js
@@ -33,7 +33,7 @@ async function go(sessionId, payload, yar) {
     await _save(session, payload)
 
     return {
-      redirectUrl: checkUrl(session, `/system/company-contacts/setup/${sessionId}/check`)
+      redirectUrl: _redirectUrl(sessionId, payload)
     }
   }
 
@@ -51,6 +51,14 @@ function _notification(session, payload, yar) {
   if (session.checkPageVisited && session.abstractionAlerts !== payload.abstractionAlerts) {
     flashNotification(yar, 'Updated', 'Water abstraction alerts updated')
   }
+}
+
+function _redirectUrl(sessionId, payload) {
+  if (payload.abstractionAlerts === 'some') {
+    return `/system/company-contacts/setup/${sessionId}/licences`
+  }
+
+  return `/system/company-contacts/setup/${sessionId}/check`
 }
 
 async function _save(session, payload) {

--- a/app/services/company-contacts/setup/submit-abstraction-alerts.service.js
+++ b/app/services/company-contacts/setup/submit-abstraction-alerts.service.js
@@ -9,7 +9,6 @@
 const AbstractionAlertsPresenter = require('../../../presenters/company-contacts/setup/abstraction-alerts.presenter.js')
 const AbstractionAlertsValidator = require('../../../validators/company-contacts/setup/abstraction-alerts.validator.js')
 const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
-const { checkUrl } = require('../../../lib/check-page.lib.js')
 const { flashNotification } = require('../../../lib/general.lib.js')
 const { formatValidationResult } = require('../../../presenters/base.presenter.js')
 

--- a/app/services/company-contacts/setup/submit-check.service.js
+++ b/app/services/company-contacts/setup/submit-check.service.js
@@ -41,6 +41,14 @@ function _abstractionAlerts(session) {
   return session.abstractionAlerts === 'yes' || session.abstractionAlerts === 'some'
 }
 
+function _abstractionAlertLicences(session) {
+  if (session.abstractionAlerts === 'some') {
+    return JSON.stringify(session.abstractionAlertLicences)
+  }
+
+  return null
+}
+
 function _email(session) {
   return session.email.toLowerCase()
 }
@@ -48,6 +56,7 @@ function _email(session) {
 async function _createCompanyContact(session, auth, yar) {
   const companyContact = {
     createdBy: auth.credentials.user.id,
+    abstractionAlertLicences: _abstractionAlertLicences(session),
     abstractionAlerts: _abstractionAlerts(session),
     email: _email(session),
     name: session.name
@@ -61,6 +70,7 @@ async function _createCompanyContact(session, auth, yar) {
 async function _updateCompanyContact(session, auth, yar) {
   const companyContact = {
     id: session.companyContact.id,
+    abstractionAlertLicences: _abstractionAlertLicences(session),
     abstractionAlerts: _abstractionAlerts(session),
     contactId: session.companyContact.contact.id,
     email: _email(session),

--- a/app/services/company-contacts/setup/submit-licences.service.js
+++ b/app/services/company-contacts/setup/submit-licences.service.js
@@ -11,6 +11,7 @@ const LicencesPresenter = require('../../../presenters/company-contacts/setup/li
 const LicencesValidator = require('../../../validators/company-contacts/setup/licences.validator.js')
 const { checkUrl } = require('../../../lib/check-page.lib.js')
 const { formatValidationResult } = require('../../../presenters/base.presenter.js')
+const { handleOneOptionSelected } = require('../../../lib/submit-page.lib.js')
 
 /**
  * Orchestrates validating the data for the '/company-contacts/setup/{sessionId}/licences' page
@@ -22,6 +23,8 @@ const { formatValidationResult } = require('../../../presenters/base.presenter.j
  */
 async function go(sessionId, payload) {
   const session = await FetchSessionDal.go(sessionId)
+
+  handleOneOptionSelected(payload, 'licences')
 
   const validationResult = _validate(payload)
 
@@ -42,6 +45,8 @@ async function go(sessionId, payload) {
 }
 
 async function _save(session, payload) {
+  session.abstractionAlertLicences = payload.licences
+
   return session.$update()
 }
 

--- a/app/services/company-contacts/setup/update-company-contact.service.js
+++ b/app/services/company-contacts/setup/update-company-contact.service.js
@@ -25,6 +25,7 @@ async function _update(companyContact) {
   return CompanyContactModel.query().upsertGraph(
     {
       id: companyContact.id,
+      abstractionAlertLicences: companyContact.abstractionAlertLicences,
       abstractionAlerts: companyContact.abstractionAlerts,
       updatedBy: companyContact.updatedBy,
       updatedAt: today().toISOString(),

--- a/app/validators/company-contacts/setup/licences.validator.js
+++ b/app/validators/company-contacts/setup/licences.validator.js
@@ -8,6 +8,8 @@
 
 const Joi = require('joi')
 
+const errorMessage = 'Select the licences they should get water abstraction alerts emails for'
+
 /**
  * Validates data submitted for the '/company-contacts/setup/{sessionId}/licences' page
  *
@@ -18,7 +20,11 @@ const Joi = require('joi')
  */
 function go(payload) {
   const schema = Joi.object({
-    placeholder: Joi.required()
+    licences: Joi.array().min(1).required().messages({
+      'any.required': errorMessage,
+      'array.base': errorMessage,
+      'array.min': errorMessage
+    })
   })
 
   return schema.validate(payload, { abortEarly: false })

--- a/app/views/company-contacts/setup/licences.njk
+++ b/app/views/company-contacts/setup/licences.njk
@@ -1,10 +1,19 @@
 {% extends 'layout.njk' %}
 
+{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% block pageContent %}
   <form method="post">
     <input type="hidden" name="wrlsCrumb" value="{{wrlsCrumb}}"/>
+
+    {{ govukCheckboxes({
+      name: "licences",
+      hint: {
+        text: "Select all that apply"
+      },
+      items: licences
+    }) }}
 
     {{ govukButton({ text: "Continue", preventDoubleClick: true }) }}
   </form>

--- a/test/presenters/company-contacts/setup/licences.presenter.test.js
+++ b/test/presenters/company-contacts/setup/licences.presenter.test.js
@@ -8,16 +8,27 @@ const { describe, it, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
+const CustomersFixtures = require('../../../support/fixtures/customers.fixture.js')
+const { generateLicenceRef } = require('../../../support/helpers/licence.helper.js')
 const { generateUUID } = require('../../../../app/lib/general.lib.js')
 
 // Thing under test
 const LicencesPresenter = require('../../../../app/presenters/company-contacts/setup/licences.presenter.js')
 
 describe('Company Contacts - Setup - Licences Presenter', () => {
+  let company
+  let licence
   let session
 
   beforeEach(() => {
-    session = { id: generateUUID() }
+    company = CustomersFixtures.company()
+
+    licence = {
+      id: generateLicenceRef(),
+      licenceRef: generateUUID()
+    }
+
+    session = { id: generateUUID(), company, licences: [licence] }
   })
 
   describe('when called', () => {
@@ -29,7 +40,35 @@ describe('Company Contacts - Setup - Licences Presenter', () => {
           href: `/system/company-contacts/setup/${session.id}/abstraction-alerts`,
           text: 'Back'
         },
-        pageTitle: 'Select the licences they should get water abstraction alerts emails for'
+        licences: [
+          {
+            checked: false,
+            text: licence.licenceRef,
+            value: licence.id
+          }
+        ],
+        pageTitle: 'Select the licences they should get water abstraction alerts emails for',
+        pageTitleCaption: 'Tyrell Corporation'
+      })
+    })
+
+    describe('the "licences" property', () => {
+      describe('when there are existing "abstractionAlertLicences"', () => {
+        beforeEach(() => {
+          session.abstractionAlertLicences = [licence.id]
+        })
+
+        it('returns the matching licence as checked', () => {
+          const result = LicencesPresenter.go(session)
+
+          expect(result.licences).to.equal([
+            {
+              checked: true,
+              text: licence.licenceRef,
+              value: licence.id
+            }
+          ])
+        })
       })
     })
   })

--- a/test/presenters/company-contacts/setup/licences.presenter.test.js
+++ b/test/presenters/company-contacts/setup/licences.presenter.test.js
@@ -24,8 +24,8 @@ describe('Company Contacts - Setup - Licences Presenter', () => {
     company = CustomersFixtures.company()
 
     licence = {
-      id: generateLicenceRef(),
-      licenceRef: generateUUID()
+      id: generateUUID(),
+      licenceRef: generateLicenceRef()
     }
 
     session = { id: generateUUID(), company, licences: [licence] }

--- a/test/services/company-contacts/setup/create-company-contact.service.test.js
+++ b/test/services/company-contacts/setup/create-company-contact.service.test.js
@@ -24,10 +24,11 @@ describe('Company Contacts - Create Company Contact service', () => {
 
   before(async () => {
     companyContact = {
+      abstractionAlertLicences: null,
       abstractionAlerts: true,
+      createdBy: generateUUID(),
       email: 'bob@test.com',
-      name: 'Bob',
-      createdBy: generateUUID()
+      name: 'Bob'
     }
 
     company = await CompanyHelper.add()

--- a/test/services/company-contacts/setup/submit-abstraction-alerts.service.test.js
+++ b/test/services/company-contacts/setup/submit-abstraction-alerts.service.test.js
@@ -56,11 +56,37 @@ describe('Company Contacts - Setup - Abstraction Alerts Service', () => {
       expect(session.$update.called).to.be.true()
     })
 
-    it('continues the journey', async () => {
-      const result = await SubmitAbstractionAlertsService.go(session.id, payload)
+    describe('the redirect URL', () => {
+      describe('when "abstractionAlerts" is "yes"', () => {
+        it('redirects to the check page', async () => {
+          const result = await SubmitAbstractionAlertsService.go(session.id, payload)
 
-      expect(result).to.equal({
-        redirectUrl: `/system/company-contacts/setup/${session.id}/check`
+          expect(result).to.equal({ redirectUrl: `/system/company-contacts/setup/${session.id}/check` })
+        })
+      })
+
+      describe('when "abstractionAlerts" is "no"', () => {
+        beforeEach(() => {
+          payload = { abstractionAlerts: 'no' }
+        })
+
+        it('redirects to the check page', async () => {
+          const result = await SubmitAbstractionAlertsService.go(session.id, payload)
+
+          expect(result).to.equal({ redirectUrl: `/system/company-contacts/setup/${session.id}/check` })
+        })
+      })
+
+      describe('when "abstractionAlerts" is "some"', () => {
+        beforeEach(() => {
+          payload = { abstractionAlerts: 'some' }
+        })
+
+        it('redirects to the licences page', async () => {
+          const result = await SubmitAbstractionAlertsService.go(session.id, payload)
+
+          expect(result).to.equal({ redirectUrl: `/system/company-contacts/setup/${session.id}/licences` })
+        })
       })
     })
 

--- a/test/services/company-contacts/setup/submit-check.service.test.js
+++ b/test/services/company-contacts/setup/submit-check.service.test.js
@@ -82,6 +82,7 @@ describe('Company Contacts - Setup - Check Service', () => {
       expect(actualContact).to.equal([
         company.id,
         {
+          abstractionAlertLicences: null,
           abstractionAlerts: true,
           createdBy: auth.credentials.user.id,
           email: 'eric@test.com',
@@ -143,6 +144,43 @@ describe('Company Contacts - Setup - Check Service', () => {
       })
     })
 
+    describe('the "abstractionAlertLicences" property', () => {
+      describe('when "abstractionAlerts" is "some"', () => {
+        let abstractionAlertLicences
+
+        beforeEach(() => {
+          abstractionAlertLicences = [generateUUID(), generateUUID()]
+
+          session = SessionModelStub.build(Sinon, {
+            ...sessionData,
+            abstractionAlerts: 'some',
+            abstractionAlertLicences
+          })
+
+          fetchSessionStub.resolves(session)
+        })
+
+        it('persists "abstractionAlertLicences" as a JSON string', async () => {
+          await SubmitCheckService.go(session.id, yarStub, auth)
+
+          const actualContact = CreateCompanyContactService.go.args[0][1]
+          const expectedAbstractionAlertLicences = JSON.stringify(abstractionAlertLicences)
+
+          expect(actualContact.abstractionAlertLicences).to.equal(expectedAbstractionAlertLicences)
+        })
+      })
+
+      describe('when "abstractionAlerts" is not "some"', () => {
+        it('persists "abstractionAlertLicences" as null', async () => {
+          await SubmitCheckService.go(session.id, yarStub, auth)
+
+          const actualContact = CreateCompanyContactService.go.args[0][1]
+
+          expect(actualContact.abstractionAlertLicences).to.be.null()
+        })
+      })
+    })
+
     describe('the "email" property', () => {
       beforeEach(async () => {
         session = SessionModelStub.build(Sinon, { ...sessionData, email: 'ERICE@TEST.COM' })
@@ -186,6 +224,7 @@ describe('Company Contacts - Setup - Check Service', () => {
 
       expect(actualContact).to.equal({
         id: companyContact.id,
+        abstractionAlertLicences: null,
         abstractionAlerts: true,
         contactId: companyContact.contact.id,
         email: 'eric@test.com',
@@ -243,6 +282,43 @@ describe('Company Contacts - Setup - Check Service', () => {
           const [actualContact] = UpdateCompanyContactService.go.args[0]
 
           expect(actualContact.abstractionAlerts).to.be.false()
+        })
+      })
+    })
+
+    describe('the "abstractionAlertLicences" property', () => {
+      describe('when "abstractionAlerts" is "some"', () => {
+        let abstractionAlertLicences
+
+        beforeEach(() => {
+          abstractionAlertLicences = [generateUUID(), generateUUID()]
+
+          session = SessionModelStub.build(Sinon, {
+            ...sessionData,
+            abstractionAlerts: 'some',
+            abstractionAlertLicences
+          })
+
+          fetchSessionStub.resolves(session)
+        })
+
+        it('persists "abstractionAlertLicences" as a JSON string', async () => {
+          await SubmitCheckService.go(session.id, yarStub, auth)
+
+          const [actualContact] = UpdateCompanyContactService.go.args[0]
+          const expectedAbstractionAlertLicences = JSON.stringify(abstractionAlertLicences)
+
+          expect(actualContact.abstractionAlertLicences).to.equal(expectedAbstractionAlertLicences)
+        })
+      })
+
+      describe('when "abstractionAlerts" is not "some"', () => {
+        it('persists "abstractionAlertLicences" as null', async () => {
+          await SubmitCheckService.go(session.id, yarStub, auth)
+
+          const [actualContact] = UpdateCompanyContactService.go.args[0]
+
+          expect(actualContact.abstractionAlertLicences).to.be.null()
         })
       })
     })

--- a/test/services/company-contacts/setup/submit-licences.service.test.js
+++ b/test/services/company-contacts/setup/submit-licences.service.test.js
@@ -30,8 +30,8 @@ describe('Company Contacts - Setup - Licences Service', () => {
 
   beforeEach(() => {
     licence = {
-      id: generateLicenceRef(),
-      licenceRef: generateUUID()
+      id: generateUUID(),
+      licenceRef: generateLicenceRef()
     }
 
     company = CustomersFixtures.company()

--- a/test/services/company-contacts/setup/submit-licences.service.test.js
+++ b/test/services/company-contacts/setup/submit-licences.service.test.js
@@ -9,7 +9,10 @@ const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
+const CustomersFixtures = require('../../../support/fixtures/customers.fixture.js')
 const SessionModelStub = require('../../../support/stubs/session.stub.js')
+const { generateLicenceRef } = require('../../../support/helpers/licence.helper.js')
+const { generateUUID } = require('../../../../app/lib/general.lib.js')
 
 // Things we need to stub
 const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
@@ -18,17 +21,28 @@ const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 const SubmitLicencesService = require('../../../../app/services/company-contacts/setup/submit-licences.service.js')
 
 describe('Company Contacts - Setup - Licences Service', () => {
+  let company
+  let fetchSessionStub
+  let licence
   let payload
   let session
   let sessionData
 
   beforeEach(() => {
-    payload = { placeholder: 'change me' }
-    sessionData = {}
+    licence = {
+      id: generateLicenceRef(),
+      licenceRef: generateUUID()
+    }
+
+    company = CustomersFixtures.company()
+
+    payload = { licences: [licence.id] }
+
+    sessionData = { company, licences: [licence] }
 
     session = SessionModelStub.build(Sinon, sessionData)
 
-    Sinon.stub(FetchSessionDal, 'go').resolves(session)
+    fetchSessionStub = Sinon.stub(FetchSessionDal, 'go').resolves(session)
   })
 
   afterEach(() => {
@@ -39,7 +53,7 @@ describe('Company Contacts - Setup - Licences Service', () => {
     it('saves the submitted value', async () => {
       await SubmitLicencesService.go(session.id, payload)
 
-      expect(session).to.equal(session)
+      expect(session.abstractionAlertLicences).to.equal([licence.id])
       expect(session.$update.called).to.be.true()
     })
 
@@ -47,6 +61,24 @@ describe('Company Contacts - Setup - Licences Service', () => {
       const result = await SubmitLicencesService.go(session.id, payload)
 
       expect(result).to.equal({ redirectUrl: `/system/company-contacts/setup/${session.id}/check` })
+    })
+
+    describe('and the payload has one item (is not an array)', () => {
+      beforeEach(() => {
+        payload = { licences: licence.id }
+
+        sessionData = { company, licences: [licence] }
+
+        session = SessionModelStub.build(Sinon, sessionData)
+
+        fetchSessionStub.resolves(session)
+      })
+
+      it('saves the selected licences', async () => {
+        await SubmitLicencesService.go(session.id, payload)
+
+        expect(session.abstractionAlertLicences).to.equal([licence.id])
+      })
     })
   })
 
@@ -66,15 +98,23 @@ describe('Company Contacts - Setup - Licences Service', () => {
         error: {
           errorList: [
             {
-              href: '#placeholder',
-              text: '"placeholder" is required'
+              href: '#licences',
+              text: 'Select the licences they should get water abstraction alerts emails for'
             }
           ],
-          placeholder: {
-            text: '"placeholder" is required'
+          licences: {
+            text: 'Select the licences they should get water abstraction alerts emails for'
           }
         },
-        pageTitle: 'Select the licences they should get water abstraction alerts emails for'
+        licences: [
+          {
+            checked: false,
+            text: licence.licenceRef,
+            value: licence.id
+          }
+        ],
+        pageTitle: 'Select the licences they should get water abstraction alerts emails for',
+        pageTitleCaption: 'Tyrell Corporation'
       })
     })
   })

--- a/test/services/company-contacts/setup/submit-licences.service.test.js
+++ b/test/services/company-contacts/setup/submit-licences.service.test.js
@@ -22,7 +22,6 @@ const SubmitLicencesService = require('../../../../app/services/company-contacts
 
 describe('Company Contacts - Setup - Licences Service', () => {
   let company
-  let fetchSessionStub
   let licence
   let payload
   let session
@@ -42,7 +41,7 @@ describe('Company Contacts - Setup - Licences Service', () => {
 
     session = SessionModelStub.build(Sinon, sessionData)
 
-    fetchSessionStub = Sinon.stub(FetchSessionDal, 'go').resolves(session)
+    Sinon.stub(FetchSessionDal, 'go').resolves(session)
   })
 
   afterEach(() => {

--- a/test/services/company-contacts/setup/submit-licences.service.test.js
+++ b/test/services/company-contacts/setup/submit-licences.service.test.js
@@ -62,24 +62,6 @@ describe('Company Contacts - Setup - Licences Service', () => {
 
       expect(result).to.equal({ redirectUrl: `/system/company-contacts/setup/${session.id}/check` })
     })
-
-    describe('and the payload has one item (is not an array)', () => {
-      beforeEach(() => {
-        payload = { licences: licence.id }
-
-        sessionData = { company, licences: [licence] }
-
-        session = SessionModelStub.build(Sinon, sessionData)
-
-        fetchSessionStub.resolves(session)
-      })
-
-      it('saves the selected licences', async () => {
-        await SubmitLicencesService.go(session.id, payload)
-
-        expect(session.abstractionAlertLicences).to.equal([licence.id])
-      })
-    })
   })
 
   describe('when validation fails', () => {

--- a/test/services/company-contacts/setup/update-company-contact.service.test.js
+++ b/test/services/company-contacts/setup/update-company-contact.service.test.js
@@ -42,11 +42,12 @@ describe('Company Contacts - Update Company Contact service', () => {
     })
 
     companyContact = await CompanyContactHelper.add({
-      contactId: contact.id,
+      abstractionAlertLicences: null,
       abstractionAlerts: false,
+      contactId: contact.id,
       createdAt: seedDate,
-      updatedAt: seedDate,
-      licenceRoleId: licenceRole.id
+      licenceRoleId: licenceRole.id,
+      updatedAt: seedDate
     })
 
     user = UserHelper.select()

--- a/test/services/company-contacts/setup/view-licences.service.test.js
+++ b/test/services/company-contacts/setup/view-licences.service.test.js
@@ -15,14 +15,26 @@ const SessionModelStub = require('../../../support/stubs/session.stub.js')
 const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
+const CustomersFixtures = require('../../../support/fixtures/customers.fixture.js')
 const ViewLicencesService = require('../../../../app/services/company-contacts/setup/view-licences.service.js')
+const { generateLicenceRef } = require('../../../support/helpers/licence.helper.js')
+const { generateUUID } = require('../../../../app/lib/general.lib.js')
 
 describe('Company Contacts - Setup - Licences Service', () => {
+  let company
+  let licence
   let session
   let sessionData
 
   beforeEach(() => {
-    sessionData = {}
+    licence = {
+      id: generateLicenceRef(),
+      licenceRef: generateUUID()
+    }
+
+    company = CustomersFixtures.company()
+
+    sessionData = { company, licences: [licence] }
 
     session = SessionModelStub.build(Sinon, sessionData)
 
@@ -42,7 +54,15 @@ describe('Company Contacts - Setup - Licences Service', () => {
           href: `/system/company-contacts/setup/${session.id}/abstraction-alerts`,
           text: 'Back'
         },
-        pageTitle: 'Select the licences they should get water abstraction alerts emails for'
+        licences: [
+          {
+            checked: false,
+            text: licence.licenceRef,
+            value: licence.id
+          }
+        ],
+        pageTitle: 'Select the licences they should get water abstraction alerts emails for',
+        pageTitleCaption: 'Tyrell Corporation'
       })
     })
   })

--- a/test/services/company-contacts/setup/view-licences.service.test.js
+++ b/test/services/company-contacts/setup/view-licences.service.test.js
@@ -9,16 +9,16 @@ const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
+const CustomersFixtures = require('../../../support/fixtures/customers.fixture.js')
 const SessionModelStub = require('../../../support/stubs/session.stub.js')
+const { generateLicenceRef } = require('../../../support/helpers/licence.helper.js')
+const { generateUUID } = require('../../../../app/lib/general.lib.js')
 
 // Things we need to stub
 const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
-const CustomersFixtures = require('../../../support/fixtures/customers.fixture.js')
 const ViewLicencesService = require('../../../../app/services/company-contacts/setup/view-licences.service.js')
-const { generateLicenceRef } = require('../../../support/helpers/licence.helper.js')
-const { generateUUID } = require('../../../../app/lib/general.lib.js')
 
 describe('Company Contacts - Setup - Licences Service', () => {
   let company
@@ -28,8 +28,8 @@ describe('Company Contacts - Setup - Licences Service', () => {
 
   beforeEach(() => {
     licence = {
-      id: generateLicenceRef(),
-      licenceRef: generateUUID()
+      id: generateUUID(),
+      licenceRef: generateLicenceRef()
     }
 
     company = CustomersFixtures.company()

--- a/test/validators/company-contacts/setup/licences.validator.test.js
+++ b/test/validators/company-contacts/setup/licences.validator.test.js
@@ -14,7 +14,7 @@ describe('Company Contacts - Setup - Licences Validator', () => {
   let payload
 
   beforeEach(() => {
-    payload = { placeholder: '' }
+    payload = { licences: ['1'] }
   })
 
   describe('when called with valid data', () => {
@@ -27,16 +27,52 @@ describe('Company Contacts - Setup - Licences Validator', () => {
   })
 
   describe('when called with invalid data', () => {
-    beforeEach(() => {
-      payload = {}
+    describe('when no licences are selected', () => {
+      beforeEach(() => {
+        payload = {}
+      })
+
+      it('returns with errors', () => {
+        const result = LicencesValidator.go(payload)
+
+        expect(result.value).to.exist()
+        expect(result.error).to.exist()
+        expect(result.error.details[0].message).to.equal(
+          'Select the licences they should get water abstraction alerts emails for'
+        )
+      })
     })
 
-    it('returns with errors', () => {
-      const result = LicencesValidator.go(payload)
+    describe('when "licences" is an empty array', () => {
+      beforeEach(() => {
+        payload = { licences: [] }
+      })
 
-      expect(result.value).to.exist()
-      expect(result.error).to.exist()
-      expect(result.error.details[0].message).to.equal('"placeholder" is required')
+      it('returns with errors', () => {
+        const result = LicencesValidator.go(payload)
+
+        expect(result.value).to.exist()
+        expect(result.error).to.exist()
+        expect(result.error.details[0].message).to.equal(
+          'Select the licences they should get water abstraction alerts emails for'
+        )
+      })
+    })
+
+    describe('when "licences" is not an array', () => {
+      beforeEach(() => {
+        payload = { licences: 'licence' }
+      })
+
+      it('returns with errors', () => {
+        const result = LicencesValidator.go(payload)
+
+        expect(result.value).to.exist()
+        expect(result.error).to.exist()
+        expect(result.error.details[0].message).to.equal(
+          'Select the licences they should get water abstraction alerts emails for'
+        )
+      })
     })
   })
 })

--- a/test/validators/company-contacts/setup/licences.validator.test.js
+++ b/test/validators/company-contacts/setup/licences.validator.test.js
@@ -7,6 +7,9 @@ const Code = require('@hapi/code')
 const { describe, it, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
+// Test helpers
+const { generateUUID } = require('../../../../app/lib/general.lib.js')
+
 // Thing under test
 const LicencesValidator = require('../../../../app/validators/company-contacts/setup/licences.validator.js')
 
@@ -14,7 +17,7 @@ describe('Company Contacts - Setup - Licences Validator', () => {
   let payload
 
   beforeEach(() => {
-    payload = { licences: ['1'] }
+    payload = { licences: [generateUUID()] }
   })
 
   describe('when called with valid data', () => {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5630

 When a contact is set to receive alerts for 'some' licences, the journey now branches from the abstraction alerts page to a licences page.

  - Add licences checkbox list to the licences page, with items pre-checked from any existing session data
  - Fix redirect in submit-abstraction-alerts: 'some' routes to /licences, 'yes'/'no' route to /check
  - Save selected licences to session.abstractionAlertLicences in submit-licences
  - Pass abstractionAlertLicences through submit-check as a JSON string when 'some', or null otherwise, for both create and update paths
  - Persist abstractionAlertLicences in create-company-contact and update-company-contact services