### PR TITLE
Use handleOneOptionSelected in supplementary billing service

### DIFF
--- a/app/services/licences/supplementary/submit-mark-for-supplementary-billing.service.js
+++ b/app/services/licences/supplementary/submit-mark-for-supplementary-billing.service.js
@@ -11,6 +11,7 @@ const MarkForSupplementaryBillingPresenter = require('../../../presenters/licenc
 const PersistSupplementaryBillingFlagsService = require('./persist-supplementary-billing-flags.service.js')
 const SupplementaryYearValidator = require('../../../validators/licences/supplementary/supplementary-year.validator.js')
 const { formatValidationResult } = require('../../../presenters/base.presenter.js')
+const { handleOneOptionSelected } = require('../../../lib/submit-page.lib.js')
 
 /**
  * Handles the submission to mark a licence for supplementary billing.
@@ -25,14 +26,12 @@ const { formatValidationResult } = require('../../../presenters/base.presenter.j
  * @returns {Promise<object>} The licence marked for supplementary billing
  */
 async function go(licenceId, payload) {
+  handleOneOptionSelected(payload, 'supplementaryYears')
+
   const validationResult = _validate(payload)
 
   if (!validationResult) {
-    let { supplementaryYears } = payload
-
-    // If the user picked multiple years this comes through as an array. If they only picked one year it comes through
-    // as a string.
-    supplementaryYears = Array.isArray(supplementaryYears) ? supplementaryYears : [supplementaryYears]
+    const { supplementaryYears } = payload
 
     await _flagForBilling(supplementaryYears, licenceId)
 

--- a/app/validators/licences/supplementary/supplementary-year.validator.js
+++ b/app/validators/licences/supplementary/supplementary-year.validator.js
@@ -22,14 +22,10 @@ const ERROR_MESSAGE = 'Select at least one financial year'
  */
 function go(payload) {
   const schema = Joi.object({
-    supplementaryYears: Joi.array()
-      .items(Joi.string())
-      .single() // allows string to be treated as [string]
-      .required()
-      .messages({
-        'any.required': ERROR_MESSAGE,
-        'array.sparse': ERROR_MESSAGE
-      })
+    supplementaryYears: Joi.array().items(Joi.string()).required().messages({
+      'any.required': ERROR_MESSAGE,
+      'array.sparse': ERROR_MESSAGE
+    })
   })
 
   return schema.validate(payload, { abortEarly: true })

--- a/test/validators/licences/supplementary/supplementary-year.validator.test.js
+++ b/test/validators/licences/supplementary/supplementary-year.validator.test.js
@@ -16,7 +16,7 @@ describe('Supplementary Year validator', () => {
   describe('when valid data is provided', () => {
     describe('that has a single year', () => {
       beforeEach(() => {
-        payload = { supplementaryYears: '2025' }
+        payload = { supplementaryYears: ['2025'] }
       })
 
       it('confirms the data is valid', () => {


### PR DESCRIPTION
Use handleOneOptionSelected in supplementary billing service

 The submit service was manually normalising the supplementaryYears checkbox payload with a ternary (Array.isArray(x) ? x : [x]), duplicating the logic already centralised in handleOneOptionSelected. Replace it with the shared helper, matching the pattern used across all other submit services.

With the normalisation now happening before validation, the Joi .single() option in the validator (which coerced a string to an array) is no longer needed and has been removed. The validator test has been updated to reflect that a single-year selection now arrives as ['2025'] rather than '2025'.