### PR TITLE
Use checkUrl helper in presenter back link functions

### DIFF
--- a/app/presenters/licence-monitoring-station/setup/abstraction-period.presenter.js
+++ b/app/presenters/licence-monitoring-station/setup/abstraction-period.presenter.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { checkUrl } = require('../../../lib/check-page.lib.js')
+
 /**
  * Formats data for `/licence-monitoring-station/setup/{sessionId}/abstraction-period`
  * @module AbstractionPeriodPresenter
@@ -27,20 +29,17 @@ function go(session) {
     abstractionPeriodEndDay,
     abstractionPeriodStartMonth,
     abstractionPeriodEndMonth,
-    backLink: { href: _backLinkHref(session), text: 'Back' },
+    backLink: _backLink(session),
     monitoringStationLabel: label,
     pageTitle: `Enter an abstraction period for licence ${licenceRef}`
   }
 }
 
-function _backLinkHref(session) {
-  const { checkPageVisited, id } = session
-
-  if (checkPageVisited) {
-    return `/system/licence-monitoring-station/setup/${id}/check`
+function _backLink(session) {
+  return {
+    href: checkUrl(session, `/system/licence-monitoring-station/setup/${session.id}/full-condition`),
+    text: 'Back'
   }
-
-  return `/system/licence-monitoring-station/setup/${id}/full-condition`
 }
 
 module.exports = {

--- a/app/presenters/licence-monitoring-station/setup/full-condition.presenter.js
+++ b/app/presenters/licence-monitoring-station/setup/full-condition.presenter.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { checkUrl } = require('../../../lib/check-page.lib.js')
+
 /**
  * Formats data for `/licence-monitoring-station/setup/{sessionId}/full-condition`
  *
@@ -26,21 +28,11 @@ function go(session, conditions) {
       : `Select the full condition for licence ${licenceRef}`
 
   return {
-    backLink: _backLink(session),
+    backLink: checkUrl(session, `/system/licence-monitoring-station/setup/${session.id}/licence-number`),
     monitoringStationLabel: label,
     pageTitle,
     radioButtons
   }
-}
-
-function _backLink(session) {
-  const { checkPageVisited, id } = session
-
-  if (checkPageVisited) {
-    return `/system/licence-monitoring-station/setup/${id}/check`
-  }
-
-  return `/system/licence-monitoring-station/setup/${id}/licence-number`
 }
 
 function _generateRadioButtons(conditions, conditionId) {

--- a/app/presenters/licence-monitoring-station/setup/licence-number.presenter.js
+++ b/app/presenters/licence-monitoring-station/setup/licence-number.presenter.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { checkUrl } = require('../../../lib/check-page.lib.js')
+
 /**
  * Formats data for the `/licence-monitoring-station/setup/{sessionId}/licence-number` page
  * @module LicenceNumberPresenter
@@ -16,21 +18,11 @@ function go(session) {
   const { label, licenceRef } = session
 
   return {
-    backLink: _backLink(session),
+    backLink: checkUrl(session, `/system/licence-monitoring-station/setup/${session.id}/stop-or-reduce`),
     licenceRef,
     monitoringStationLabel: label,
     pageTitle: 'Enter the licence number this threshold applies to'
   }
-}
-
-function _backLink(session) {
-  const { checkPageVisited, id } = session
-
-  if (checkPageVisited) {
-    return `/system/licence-monitoring-station/setup/${id}/check`
-  }
-
-  return `/system/licence-monitoring-station/setup/${id}/stop-or-reduce`
 }
 
 module.exports = {

--- a/app/presenters/licence-monitoring-station/setup/stop-or-reduce.presenter.js
+++ b/app/presenters/licence-monitoring-station/setup/stop-or-reduce.presenter.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { checkUrl } = require('../../../lib/check-page.lib.js')
+
 /**
  * Formats data for the `/licence-monitoring-station/setup/{sessionId}/stop-or-reduce` page
  * @module StopOrReducePresenter
@@ -16,23 +18,13 @@ function go(session) {
   const { id: sessionId, label, stopOrReduce, reduceAtThreshold } = session
 
   return {
-    backLink: _backLink(session),
+    backLink: checkUrl(session, `/system/licence-monitoring-station/setup/${session.id}/threshold-and-unit`),
     monitoringStationLabel: label,
     pageTitle: 'Does the licence holder need to stop or reduce at this threshold?',
     reduceAtThreshold: reduceAtThreshold ?? null,
     sessionId,
     stopOrReduce: stopOrReduce ?? null
   }
-}
-
-function _backLink(session) {
-  const { checkPageVisited, id } = session
-
-  if (checkPageVisited) {
-    return `/system/licence-monitoring-station/setup/${id}/check`
-  }
-
-  return `/system/licence-monitoring-station/setup/${id}/threshold-and-unit`
 }
 
 module.exports = {

--- a/app/presenters/return-logs/setup/meter-provided.presenter.js
+++ b/app/presenters/return-logs/setup/meter-provided.presenter.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { checkUrl } = require('../../../lib/check-page.lib.js')
+
 /**
  * Format data for the `/return-log/setup/{sessionId}/meter-provided` page
  * @module MeterProvidedPresenter
@@ -16,7 +18,7 @@ function go(session) {
   const { id: sessionId, returnReference, meterProvided } = session
 
   return {
-    backLink: { href: _backLinkHref(session), text: 'Back' },
+    backLink: _backLink(session),
     meterProvided: meterProvided ?? null,
     pageTitle: 'Have meter details been provided?',
     pageTitleCaption: `Return reference ${returnReference}`,
@@ -24,14 +26,11 @@ function go(session) {
   }
 }
 
-function _backLinkHref(session) {
-  const { checkPageVisited, id } = session
-
-  if (checkPageVisited) {
-    return `/system/return-logs/setup/${id}/check`
+function _backLink(session) {
+  return {
+    href: checkUrl(session, `/system/return-logs/setup/${session.id}/units`),
+    text: 'Back'
   }
-
-  return `/system/return-logs/setup/${id}/units`
 }
 
 module.exports = {

--- a/app/presenters/return-logs/setup/reported.presenter.js
+++ b/app/presenters/return-logs/setup/reported.presenter.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { checkUrl } = require('../../../lib/check-page.lib.js')
+
 /**
  * Format data for the `/return-log/setup/{sessionId}/reported` page
  * @module ReportedPresenter
@@ -16,7 +18,7 @@ function go(session) {
   const { id: sessionId, returnReference, reported } = session
 
   return {
-    backLink: { href: _backLinkHref(session), text: 'Back' },
+    backLink: _backLink(session),
     pageTitle: 'How was this return reported?',
     pageTitleCaption: `Return reference ${returnReference}`,
     reported: reported ?? null,
@@ -24,14 +26,11 @@ function go(session) {
   }
 }
 
-function _backLinkHref(session) {
-  const { checkPageVisited, id } = session
-
-  if (checkPageVisited) {
-    return `/system/return-logs/setup/${id}/check`
+function _backLink(session) {
+  return {
+    href: checkUrl(session, `/system/return-logs/setup/${session.id}/submission`),
+    text: 'Back'
   }
-
-  return `/system/return-logs/setup/${id}/submission`
 }
 
 module.exports = {

--- a/app/presenters/return-logs/setup/start-reading.presenter.js
+++ b/app/presenters/return-logs/setup/start-reading.presenter.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { checkUrl } = require('../../../lib/check-page.lib.js')
+
 /**
  * Formats the data ready for presenting in the `/return-logs/setup/{sessionId}/start-reading` page
  * @module StartReadingPresenter
@@ -16,7 +18,7 @@ function go(session) {
   const { id: sessionId, returnReference, startReading } = session
 
   return {
-    backLink: { href: _backLinkHref(session), text: 'Back' },
+    backLink: _backLink(session),
     pageTitle: 'Enter the start meter reading',
     pageTitleCaption: `Return reference ${returnReference}`,
     sessionId,
@@ -24,14 +26,11 @@ function go(session) {
   }
 }
 
-function _backLinkHref(session) {
-  const { checkPageVisited, id } = session
-
-  if (checkPageVisited) {
-    return `/system/return-logs/setup/${id}/check`
+function _backLink(session) {
+  return {
+    href: checkUrl(session, `/system/return-logs/setup/${session.id}/reported`),
+    text: 'Back'
   }
-
-  return `/system/return-logs/setup/${id}/reported`
 }
 
 function _savedValue(startReading) {

--- a/app/presenters/return-logs/setup/submission.presenter.js
+++ b/app/presenters/return-logs/setup/submission.presenter.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { checkUrl } = require('../../../lib/check-page.lib.js')
+
 /**
  * Formats the data ready for presenting in the `/return-logs/setup/{sessionId}/submission` page
  * @module SubmissionPresenter
@@ -16,7 +18,7 @@ function go(session) {
   const { beenReceived, journey, returnReference } = session
 
   return {
-    backLink: { href: _backLinkHref(session), text: 'Back' },
+    backLink: _backLink(session),
     beenReceived,
     journey: journey ?? null,
     pageTitle: 'What do you want to do with this return?',
@@ -24,14 +26,11 @@ function go(session) {
   }
 }
 
-function _backLinkHref(session) {
-  const { checkPageVisited, id } = session
-
-  if (checkPageVisited) {
-    return `/system/return-logs/setup/${id}/check`
+function _backLink(session) {
+  return {
+    href: checkUrl(session, `/system/return-logs/setup/${session.id}/received`),
+    text: 'Back'
   }
-
-  return `/system/return-logs/setup/${id}/received`
 }
 
 module.exports = {

--- a/app/presenters/return-logs/setup/units.presenter.js
+++ b/app/presenters/return-logs/setup/units.presenter.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { checkUrl } = require('../../../lib/check-page.lib.js')
+
 /**
  * Format data for the `/return-log/setup/{sessionId}/units` page
  * @module UnitsPresenter
@@ -16,7 +18,7 @@ function go(session) {
   const { id: sessionId, returnReference, units } = session
 
   return {
-    backLink: { href: _backLinkHref(session), text: 'Back' },
+    backLink: _backLink(session),
     pageTitle: 'Which units were used?',
     pageTitleCaption: `Return reference ${returnReference}`,
     sessionId,
@@ -24,18 +26,16 @@ function go(session) {
   }
 }
 
-function _backLinkHref(session) {
-  const { checkPageVisited, id } = session
+function _backLink(session) {
+  const url =
+    session.reported === 'meterReadings'
+      ? `/system/return-logs/setup/${session.id}/start-reading`
+      : `/system/return-logs/setup/${session.id}/reported`
 
-  if (checkPageVisited) {
-    return `/system/return-logs/setup/${id}/check`
+  return {
+    href: checkUrl(session, url),
+    text: 'Back'
   }
-
-  if (session.reported === 'meterReadings') {
-    return `/system/return-logs/setup/${id}/start-reading`
-  }
-
-  return `/system/return-logs/setup/${id}/reported`
 }
 
 module.exports = {

--- a/app/presenters/return-versions/setup/no-returns-required.presenter.js
+++ b/app/presenters/return-versions/setup/no-returns-required.presenter.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { checkUrl } = require('../../../lib/check-page.lib.js')
+
 /**
  * Formats data for the `/return-versions/setup/{sessionId}/no-returns-required` page
  * @module NoReturnsRequiredPresenter
@@ -16,7 +18,7 @@ function go(session) {
   const { id: sessionId, licence, reason } = session
 
   return {
-    backLink: { href: _backLinkHref(session), text: 'Back' },
+    backLink: _backLink(session),
     licenceRef: licence.licenceRef,
     reason: reason || null,
     pageTitle: 'Why are no returns required?',
@@ -25,14 +27,11 @@ function go(session) {
   }
 }
 
-function _backLinkHref(session) {
-  const { checkPageVisited, id } = session
-
-  if (checkPageVisited) {
-    return `/system/return-versions/setup/${id}/check`
+function _backLink(session) {
+  return {
+    href: checkUrl(session, `/system/return-versions/setup/${session.id}/start-date`),
+    text: 'Back'
   }
-
-  return `/system/return-versions/setup/${id}/start-date`
 }
 
 module.exports = {

--- a/app/presenters/return-versions/setup/reason.presenter.js
+++ b/app/presenters/return-versions/setup/reason.presenter.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { checkUrl } = require('../../../lib/check-page.lib.js')
+
 /**
  * Formats data for the `/return-versions/setup/{sessionId}/reason` page
  * @module ReasonPresenter
@@ -16,7 +18,7 @@ function go(session) {
   const { id: sessionId, licence, reason } = session
 
   return {
-    backLink: { href: _backLinkHref(session), text: 'Back' },
+    backLink: _backLink(session),
     licenceRef: licence.licenceRef,
     pageTitle: 'Select the reason for the requirements for returns',
     pageTitleCaption: `Licence ${licence.licenceRef}`,
@@ -25,14 +27,11 @@ function go(session) {
   }
 }
 
-function _backLinkHref(session) {
-  const { checkPageVisited, id } = session
-
-  if (checkPageVisited) {
-    return `/system/return-versions/setup/${id}/check`
+function _backLink(session) {
+  return {
+    href: checkUrl(session, `/system/return-versions/setup/${session.id}/start-date`),
+    text: 'Back'
   }
-
-  return `/system/return-versions/setup/${id}/start-date`
 }
 
 module.exports = {


### PR DESCRIPTION
checkUrl() already existed in check-page.lib.js but was only used in a small number of presenters. The rest were still doing the check manually:

 ```
 if (checkPageVisited) {
    return `/system/xxx/setup/${id}/check`
  }
  return `/system/xxx/setup/${id}/next-page`
```

  This replaces that manual pattern with checkUrl() across 11 presenters in the licence-monitoring-station, return-logs, and return-versions journeys.

  - Replace manual checkPageVisited if/else in back link functions with checkUrl(session, url)
  - Move the back link object construction into a _backLink() helper so go() assigns backLink: _backLink(session) directly rather than inlining { href, text }
  - Remove the _backLink/_backLinkHref helper entirely where the call is simple enough to inline directly in go()