### PR TITLE
Fix internal user permissions validation error

### DIFF
--- a/app/validators/users/internal/setup/permissions.validator.js
+++ b/app/validators/users/internal/setup/permissions.validator.js
@@ -24,8 +24,8 @@ function go(payload) {
       .required()
       .valid(...Object.keys(userPermissions))
       .messages({
-        'any.required': 'Select a permission',
-        'any.only': 'Select a valid permission'
+        'any.required': 'Select permissions for the user',
+        'any.only': 'Select valid permissions for the user'
       })
   })
 

--- a/test/services/users/internal/setup/submit-permissions.service.test.js
+++ b/test/services/users/internal/setup/submit-permissions.service.test.js
@@ -142,12 +142,12 @@ describe('Users - Internal - Setup - Submit Permissions Service', () => {
         },
         error: {
           permission: {
-            text: 'Select a permission'
+            text: 'Select permissions for the user'
           },
           errorList: [
             {
               href: '#permission',
-              text: 'Select a permission'
+              text: 'Select permissions for the user'
             }
           ]
         },

--- a/test/validators/users/internal/setup/permissions.validator.test.js
+++ b/test/validators/users/internal/setup/permissions.validator.test.js
@@ -37,7 +37,7 @@ describe('Users - Internal - Setup - Permissions Validator', () => {
 
         expect(result.value).to.exist()
         expect(result.error).to.exist()
-        expect(result.error.details[0].message).to.equal('Select a permission')
+        expect(result.error.details[0].message).to.equal('Select permissions for the user')
       })
     })
 
@@ -51,7 +51,7 @@ describe('Users - Internal - Setup - Permissions Validator', () => {
 
         expect(result.value).to.exist()
         expect(result.error).to.exist()
-        expect(result.error.details[0].message).to.equal('Select a valid permission')
+        expect(result.error.details[0].message).to.equal('Select valid permissions for the user')
       })
     })
   })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5603

During QA it has been spotted the on the "Select permissions for the user" page that the error message is incorrect when no user has been selected.

It is currently displaying "Select a permission", when it should display "Select permissions for the user". This PR will fix that.