### PR TITLE
Add abstraction alerts some to contact details page

### DIFF
--- a/app/models/company-contact.model.js
+++ b/app/models/company-contact.model.js
@@ -58,6 +58,19 @@ class CompanyContactModel extends BaseModel {
       }
     }
   }
+
+  /**
+   * Maps the `abstractionAlerts` flag and linked licences to the journey string value ('yes', 'some', or 'no')
+   *
+   * @returns {string} 'yes', 'some', or 'no'
+   */
+  $abstractionAlertType() {
+    if (!this.abstractionAlerts) {
+      return 'no'
+    }
+
+    return this.abstractionAlertLicences ? 'some' : 'yes'
+  }
 }
 
 module.exports = CompanyContactModel

--- a/app/models/company-contact.model.js
+++ b/app/models/company-contact.model.js
@@ -62,14 +62,27 @@ class CompanyContactModel extends BaseModel {
   /**
    * Maps the `abstractionAlerts` flag and linked licences to the journey string value ('yes', 'some', or 'no')
    *
-   * @returns {string} 'yes', 'some', or 'no'
+   * @returns {object} The value and label for the abstraction alert type
    */
   $abstractionAlertType() {
     if (!this.abstractionAlerts) {
-      return 'no'
+      return {
+        value: 'no',
+        label: 'No'
+      }
     }
 
-    return this.abstractionAlertLicences ? 'some' : 'yes'
+    if (this.abstractionAlertLicences) {
+      return {
+        value: 'some',
+        label: 'Yes, for some licences'
+      }
+    }
+
+    return {
+      value: 'yes',
+      label: 'Yes, for all licences'
+    }
   }
 }
 

--- a/app/models/company-contact.model.js
+++ b/app/models/company-contact.model.js
@@ -62,27 +62,14 @@ class CompanyContactModel extends BaseModel {
   /**
    * Maps the `abstractionAlerts` flag and linked licences to the journey string value ('yes', 'some', or 'no')
    *
-   * @returns {object} The value and label for the abstraction alert type
+   * @returns {string} 'yes', 'some', or 'no'
    */
   $abstractionAlertType() {
     if (!this.abstractionAlerts) {
-      return {
-        value: 'no',
-        label: 'No'
-      }
+      return 'no'
     }
 
-    if (this.abstractionAlertLicences) {
-      return {
-        value: 'some',
-        label: 'Yes, for some licences'
-      }
-    }
-
-    return {
-      value: 'yes',
-      label: 'Yes, for all licences'
-    }
+    return this.abstractionAlertLicences ? 'some' : 'yes'
   }
 }
 

--- a/app/presenters/company-contacts/contact-details.presenter.js
+++ b/app/presenters/company-contacts/contact-details.presenter.js
@@ -5,6 +5,7 @@
  * @module ContactDetailsPresenter
  */
 
+const { abstractionAlertsLabel } = require('../crm.presenter.js')
 const { formatEmail, formatLongDate } = require('../base.presenter.js')
 
 /**
@@ -38,13 +39,8 @@ function go(company, companyContact) {
 
 function _abstractionAlerts(companyContact) {
   const abstractionAlerts = companyContact.$abstractionAlertType()
-  const abstractionAlertsText = {
-    no: 'No',
-    some: 'Yes, for some licences',
-    yes: 'Yes, for all licences'
-  }
 
-  return abstractionAlertsText[abstractionAlerts]
+  return abstractionAlertsLabel(abstractionAlerts)
 }
 
 function _created(companyContact) {

--- a/app/presenters/company-contacts/contact-details.presenter.js
+++ b/app/presenters/company-contacts/contact-details.presenter.js
@@ -23,7 +23,7 @@ function go(company, companyContact) {
       text: 'Go back to licence holder contacts'
     },
     contact: {
-      abstractionAlerts: _abstractionAlerts(companyContact),
+      abstractionAlerts: companyContact.$abstractionAlertType().label,
       created: _created(companyContact),
       email: formatEmail(companyContact.contact.email),
       lastUpdated: _lastUpdated(companyContact),
@@ -34,17 +34,6 @@ function go(company, companyContact) {
     pageTitleCaption: company.name,
     removeContactLink: `/system/company-contacts/${companyContact.id}/remove`
   }
-}
-
-function _abstractionAlerts(companyContact) {
-  const abstractionAlerts = companyContact.$abstractionAlertType()
-  const abstractionAlertsText = {
-    no: 'No',
-    some: 'Yes, for some licences',
-    yes: 'Yes, for all licences'
-  }
-
-  return abstractionAlertsText[abstractionAlerts]
 }
 
 function _created(companyContact) {

--- a/app/presenters/company-contacts/contact-details.presenter.js
+++ b/app/presenters/company-contacts/contact-details.presenter.js
@@ -23,7 +23,7 @@ function go(company, companyContact) {
       text: 'Go back to licence holder contacts'
     },
     contact: {
-      abstractionAlerts: companyContact.$abstractionAlertType().label,
+      abstractionAlerts: _abstractionAlerts(companyContact),
       created: _created(companyContact),
       email: formatEmail(companyContact.contact.email),
       lastUpdated: _lastUpdated(companyContact),
@@ -34,6 +34,17 @@ function go(company, companyContact) {
     pageTitleCaption: company.name,
     removeContactLink: `/system/company-contacts/${companyContact.id}/remove`
   }
+}
+
+function _abstractionAlerts(companyContact) {
+  const abstractionAlerts = companyContact.$abstractionAlertType()
+  const abstractionAlertsText = {
+    no: 'No',
+    some: 'Yes, for some licences',
+    yes: 'Yes, for all licences'
+  }
+
+  return abstractionAlertsText[abstractionAlerts]
 }
 
 function _created(companyContact) {

--- a/app/presenters/company-contacts/contact-details.presenter.js
+++ b/app/presenters/company-contacts/contact-details.presenter.js
@@ -23,7 +23,7 @@ function go(company, companyContact) {
       text: 'Go back to licence holder contacts'
     },
     contact: {
-      abstractionAlerts: companyContact.abstractionAlerts ? 'Yes' : 'No',
+      abstractionAlerts: _abstractionAlerts(companyContact),
       created: _created(companyContact),
       email: formatEmail(companyContact.contact.email),
       lastUpdated: _lastUpdated(companyContact),
@@ -34,6 +34,17 @@ function go(company, companyContact) {
     pageTitleCaption: company.name,
     removeContactLink: `/system/company-contacts/${companyContact.id}/remove`
   }
+}
+
+function _abstractionAlerts(companyContact) {
+  const abstractionAlerts = companyContact.$abstractionAlertType()
+  const abstractionAlertsText = {
+    no: 'No',
+    some: 'Yes, for some licences',
+    yes: 'Yes, for all licences'
+  }
+
+  return abstractionAlertsText[abstractionAlerts]
 }
 
 function _created(companyContact) {

--- a/app/presenters/company-contacts/setup/check.presenter.js
+++ b/app/presenters/company-contacts/setup/check.presenter.js
@@ -5,6 +5,8 @@
  * @module CheckPresenter
  */
 
+const { abstractionAlertsLabel } = require('../../crm.presenter.js')
+
 /**
  * Formats data for the '/company-contacts/setup/{sessionId}/check' page
  *
@@ -21,7 +23,7 @@ function go(session, savedCompanyContacts, sentNotification) {
   const matchingContact = _matchingContact(email, name, savedCompanyContacts)
 
   return {
-    abstractionAlerts: _abstractionAlerts(abstractionAlerts),
+    abstractionAlerts: abstractionAlertsLabel(abstractionAlerts),
     email,
     emailInUse: _emailInUse(sentNotification, companyContact),
     name,
@@ -37,16 +39,6 @@ function go(session, savedCompanyContacts, sentNotification) {
     matchingContact,
     warning: _warning(matchingContact)
   }
-}
-
-function _abstractionAlerts(abstractionAlerts) {
-  const abstractionAlertsText = {
-    no: 'No',
-    some: 'Yes, for some licences',
-    yes: 'Yes, for all licences'
-  }
-
-  return abstractionAlertsText[abstractionAlerts]
 }
 
 /**

--- a/app/presenters/crm.presenter.js
+++ b/app/presenters/crm.presenter.js
@@ -3,6 +3,23 @@
 const { roles } = require('../lib/static-lookups.lib.js')
 
 /**
+ * Returns the display label for an abstraction alerts value
+ *
+ * @param {string} abstractionAlerts - The abstraction alerts value ('no', 'some', or 'yes')
+ *
+ * @returns {string} The label for the abstraction alerts value
+ */
+function abstractionAlertsLabel(abstractionAlerts) {
+  const abstractionAlertsText = {
+    no: 'No',
+    some: 'Yes, for some licences',
+    yes: 'Yes, for all licences'
+  }
+
+  return abstractionAlertsText[abstractionAlerts]
+}
+
+/**
  * Format the contact for the contacts table
  *
  * @param {object} contact - the contact from the crm data
@@ -44,5 +61,6 @@ function _contactLink(contact, billingQueryArgs) {
 }
 
 module.exports = {
+  abstractionAlertsLabel,
   formatContact
 }

--- a/app/services/company-contacts/fetch-company-contact-details.service.js
+++ b/app/services/company-contacts/fetch-company-contact-details.service.js
@@ -22,6 +22,7 @@ async function _fetch(companyContactId) {
   return CompanyContactModel.query()
     .select([
       'companyContacts.id',
+      'companyContacts.abstractionAlertLicences',
       'companyContacts.abstractionAlerts',
       'companyContacts.companyId',
       'companyContacts.createdAt',

--- a/app/services/company-contacts/setup/initiate-edit-session.service.js
+++ b/app/services/company-contacts/setup/initiate-edit-session.service.js
@@ -49,7 +49,7 @@ function _formatDataForJourney(companyContact) {
 
   return {
     abstractionAlertLicences,
-    abstractionAlerts: companyContact.$abstractionAlertType(),
+    abstractionAlerts: companyContact.$abstractionAlertType().value,
     company,
     companyContact,
     email: formatEmail(contact.email),

--- a/app/services/company-contacts/setup/initiate-edit-session.service.js
+++ b/app/services/company-contacts/setup/initiate-edit-session.service.js
@@ -45,35 +45,16 @@ async function go(companyContactId) {
  * @private
  */
 function _formatDataForJourney(companyContact) {
-  const { abstractionAlertLicences, abstractionAlerts, company, contact } = companyContact
+  const { abstractionAlertLicences, company, contact } = companyContact
 
   return {
     abstractionAlertLicences,
-    abstractionAlerts: _abstractionAlerts(abstractionAlerts, abstractionAlertLicences),
+    abstractionAlerts: companyContact.$abstractionAlertType(),
     company,
     companyContact,
     email: formatEmail(contact.email),
     name: contact.$name()
   }
-}
-
-/**
- * Determines the abstraction alerts value for the session
- *
- * Maps the boolean `abstractionAlerts` flag from the company contact record to the string value used in the journey.
- * If the contact has alerts enabled and abstraction alert licences linked, they receive alerts for some licences only.
- * If no licences are linked, they receive alerts for all licences.
- *
- * @returns {string} 'yes', 'some', or 'no'
- *
- * @private
- */
-function _abstractionAlerts(abstractionAlerts, abstractionAlertLicences) {
-  if (!abstractionAlerts) {
-    return 'no'
-  }
-
-  return abstractionAlertLicences ? 'some' : 'yes'
 }
 
 module.exports = {

--- a/app/services/company-contacts/setup/initiate-edit-session.service.js
+++ b/app/services/company-contacts/setup/initiate-edit-session.service.js
@@ -49,7 +49,7 @@ function _formatDataForJourney(companyContact) {
 
   return {
     abstractionAlertLicences,
-    abstractionAlerts: companyContact.$abstractionAlertType().value,
+    abstractionAlerts: companyContact.$abstractionAlertType(),
     company,
     companyContact,
     email: formatEmail(contact.email),

--- a/test/models/company-contact.model.test.js
+++ b/test/models/company-contact.model.test.js
@@ -165,7 +165,10 @@ describe('Company Contacts model', () => {
       it('returns "no"', () => {
         const result = testRecord.$abstractionAlertType()
 
-        expect(result).to.equal('no')
+        expect(result).to.equal({
+          label: 'No',
+          value: 'no'
+        })
       })
     })
 
@@ -178,7 +181,10 @@ describe('Company Contacts model', () => {
         it('returns "yes"', () => {
           const result = testRecord.$abstractionAlertType()
 
-          expect(result).to.equal('yes')
+          expect(result).to.equal({
+            label: 'Yes, for all licences',
+            value: 'yes'
+          })
         })
       })
 
@@ -193,7 +199,10 @@ describe('Company Contacts model', () => {
         it('returns "some"', () => {
           const result = testRecord.$abstractionAlertType()
 
-          expect(result).to.equal('some')
+          expect(result).to.equal({
+            label: 'Yes, for some licences',
+            value: 'some'
+          })
         })
       })
     })

--- a/test/models/company-contact.model.test.js
+++ b/test/models/company-contact.model.test.js
@@ -173,14 +173,16 @@ describe('Company Contacts model', () => {
       before(async () => {
         testRecord = await CompanyContactHelper.add({ abstractionAlerts: true })
       })
+      
+      describe('and "abstractionAlertLicences" is null', () => {
+        it('returns "yes"', () => {
+          const result = testRecord.$abstractionAlertType()
 
-      it('returns "yes"', () => {
-        const result = testRecord.$abstractionAlertType()
-
-        expect(result).to.equal('yes')
+          expect(result).to.equal('yes')
+        })
       })
 
-      describe('and there are "abstractionAlertLicences"', () => {
+      describe('and "abstractionAlertLicences" is populated', () => {
         before(async () => {
           testRecord = await CompanyContactHelper.add({
             abstractionAlertLicences: JSON.stringify([generateUUID()]),

--- a/test/models/company-contact.model.test.js
+++ b/test/models/company-contact.model.test.js
@@ -165,10 +165,7 @@ describe('Company Contacts model', () => {
       it('returns "no"', () => {
         const result = testRecord.$abstractionAlertType()
 
-        expect(result).to.equal({
-          label: 'No',
-          value: 'no'
-        })
+        expect(result).to.equal('no')
       })
     })
 
@@ -181,10 +178,7 @@ describe('Company Contacts model', () => {
         it('returns "yes"', () => {
           const result = testRecord.$abstractionAlertType()
 
-          expect(result).to.equal({
-            label: 'Yes, for all licences',
-            value: 'yes'
-          })
+          expect(result).to.equal('yes')
         })
       })
 
@@ -199,10 +193,7 @@ describe('Company Contacts model', () => {
         it('returns "some"', () => {
           const result = testRecord.$abstractionAlertType()
 
-          expect(result).to.equal({
-            label: 'Yes, for some licences',
-            value: 'some'
-          })
+          expect(result).to.equal('some')
         })
       })
     })

--- a/test/models/company-contact.model.test.js
+++ b/test/models/company-contact.model.test.js
@@ -183,7 +183,7 @@ describe('Company Contacts model', () => {
       describe('and there are "abstractionAlertLicences"', () => {
         before(async () => {
           testRecord = await CompanyContactHelper.add({
-            abstractionAlertLicences: [generateUUID()],
+            abstractionAlertLicences: JSON.stringify([generateUUID()]),
             abstractionAlerts: true
           })
         })

--- a/test/models/company-contact.model.test.js
+++ b/test/models/company-contact.model.test.js
@@ -17,6 +17,7 @@ const LicenceRoleHelper = require('../support/helpers/licence-role.helper.js')
 const LicenceRoleModel = require('../../app/models/licence-role.model.js')
 const UserHelper = require('../support/helpers/user.helper.js')
 const UserModel = require('../../app/models/user.model.js')
+const { generateUUID } = require('../../app/lib/general.lib.js')
 
 // Thing under test
 const CompanyContactModel = require('../../app/models/company-contact.model.js')
@@ -154,6 +155,43 @@ describe('Company Contacts model', () => {
         expect(result.updatedByUser).to.be.an.instanceOf(UserModel)
         expect(result.updatedByUser).to.equal(testUpdatedByUser, {
           skip: ['createdAt', 'licenceEntityId', 'password', 'updatedAt', 'userData']
+        })
+      })
+    })
+  })
+
+  describe('$abstractionAlertType', () => {
+    describe('when "abstractionAlerts" is disabled', () => {
+      it('returns "no"', () => {
+        const result = testRecord.$abstractionAlertType()
+
+        expect(result).to.equal('no')
+      })
+    })
+
+    describe('when "abstractionAlerts" is enabled', () => {
+      before(async () => {
+        testRecord = await CompanyContactHelper.add({ abstractionAlerts: true })
+      })
+
+      it('returns "yes"', () => {
+        const result = testRecord.$abstractionAlertType()
+
+        expect(result).to.equal('yes')
+      })
+
+      describe('and there are "abstractionAlertLicences"', () => {
+        before(async () => {
+          testRecord = await CompanyContactHelper.add({
+            abstractionAlertLicences: [generateUUID()],
+            abstractionAlerts: true
+          })
+        })
+
+        it('returns "some"', () => {
+          const result = testRecord.$abstractionAlertType()
+
+          expect(result).to.equal('some')
         })
       })
     })

--- a/test/models/company-contact.model.test.js
+++ b/test/models/company-contact.model.test.js
@@ -173,7 +173,7 @@ describe('Company Contacts model', () => {
       before(async () => {
         testRecord = await CompanyContactHelper.add({ abstractionAlerts: true })
       })
-      
+
       describe('and "abstractionAlertLicences" is null', () => {
         it('returns "yes"', () => {
           const result = testRecord.$abstractionAlertType()

--- a/test/presenters/company-contacts/contact-details.presenter.test.js
+++ b/test/presenters/company-contacts/contact-details.presenter.test.js
@@ -9,6 +9,7 @@ const { expect } = Code
 
 // Test helpers
 const CustomersFixtures = require('../../support/fixtures/customers.fixture.js')
+const { generateUUID } = require('../../../app/lib/general.lib.js')
 
 // Thing under test
 const ContactDetailsPresenter = require('../../../app/presenters/company-contacts/contact-details.presenter.js')
@@ -48,6 +49,66 @@ describe('Company Contacts - Contact Details presenter', () => {
     })
 
     describe('the "contact" property', () => {
+      describe('the "abstractionAlerts" property', () => {
+        describe('when the contact has "abstractionAlerts" enabled', () => {
+          beforeEach(() => {
+            companyContact.abstractionAlerts = true
+          })
+
+          it('returns "Yes, for all licences"', () => {
+            const result = ContactDetailsPresenter.go(company, companyContact)
+
+            expect(result.contact.abstractionAlerts).to.equal('Yes, for all licences')
+          })
+
+          describe('and there are "abstractionAlertLicences"', () => {
+            beforeEach(() => {
+              companyContact.abstractionAlertLicences = [generateUUID()]
+            })
+
+            it('returns "Yes, for some licences"', () => {
+              const result = ContactDetailsPresenter.go(company, companyContact)
+
+              expect(result.contact.abstractionAlerts).to.equal('Yes, for some licences')
+            })
+          })
+        })
+
+        describe('when the contact has "abstractionAlerts" disabled', () => {
+          beforeEach(() => {
+            companyContact.abstractionAlerts = false
+          })
+
+          it('returns "No"', () => {
+            const result = ContactDetailsPresenter.go(company, companyContact)
+
+            expect(result.contact.abstractionAlerts).to.equal('No')
+          })
+        })
+      })
+
+      describe('the "additionalContact" property', () => {
+        describe('when the contact is an additional contact', () => {
+          it('returns true', () => {
+            const result = ContactDetailsPresenter.go(company, companyContact)
+
+            expect(result.additionalContact).to.be.true()
+          })
+        })
+
+        describe('when the contact is not an additional contact', () => {
+          beforeEach(() => {
+            companyContact.licenceRole.name = 'licenceHolder'
+          })
+
+          it('returns false', () => {
+            const result = ContactDetailsPresenter.go(company, companyContact)
+
+            expect(result.additionalContact).to.be.false()
+          })
+        })
+      })
+
       describe('the "created" property', () => {
         describe('when there is "createdByUser"', () => {
           it('returns the created text with the created at date and the created by username', () => {
@@ -66,28 +127,6 @@ describe('Company Contacts - Contact Details presenter', () => {
             const result = ContactDetailsPresenter.go(company, companyContact)
 
             expect(result.contact.created).to.equal('1 January 2022')
-          })
-        })
-      })
-
-      describe('the "abstractionAlerts" property', () => {
-        describe('when the contact is an additional contact', () => {
-          it('returns true', () => {
-            const result = ContactDetailsPresenter.go(company, companyContact)
-
-            expect(result.additionalContact).to.be.true()
-          })
-        })
-
-        describe('when the contact is not an additional contact', () => {
-          beforeEach(() => {
-            companyContact.licenceRole.name = 'licenceHolder'
-          })
-
-          it('returns false', () => {
-            const result = ContactDetailsPresenter.go(company, companyContact)
-
-            expect(result.additionalContact).to.be.false()
           })
         })
       })

--- a/test/presenters/company-contacts/contact-details.presenter.test.js
+++ b/test/presenters/company-contacts/contact-details.presenter.test.js
@@ -9,7 +9,6 @@ const { expect } = Code
 
 // Test helpers
 const CustomersFixtures = require('../../support/fixtures/customers.fixture.js')
-const { generateUUID } = require('../../../app/lib/general.lib.js')
 
 // Thing under test
 const ContactDetailsPresenter = require('../../../app/presenters/company-contacts/contact-details.presenter.js')
@@ -49,44 +48,6 @@ describe('Company Contacts - Contact Details presenter', () => {
     })
 
     describe('the "contact" property', () => {
-      describe('the "abstractionAlerts" property', () => {
-        describe('when the contact has "abstractionAlerts" enabled', () => {
-          beforeEach(() => {
-            companyContact.abstractionAlerts = true
-          })
-
-          it('returns "Yes, for all licences"', () => {
-            const result = ContactDetailsPresenter.go(company, companyContact)
-
-            expect(result.contact.abstractionAlerts).to.equal('Yes, for all licences')
-          })
-
-          describe('and there are "abstractionAlertLicences"', () => {
-            beforeEach(() => {
-              companyContact.abstractionAlertLicences = [generateUUID()]
-            })
-
-            it('returns "Yes, for some licences"', () => {
-              const result = ContactDetailsPresenter.go(company, companyContact)
-
-              expect(result.contact.abstractionAlerts).to.equal('Yes, for some licences')
-            })
-          })
-        })
-
-        describe('when the contact has "abstractionAlerts" disabled', () => {
-          beforeEach(() => {
-            companyContact.abstractionAlerts = false
-          })
-
-          it('returns "No"', () => {
-            const result = ContactDetailsPresenter.go(company, companyContact)
-
-            expect(result.contact.abstractionAlerts).to.equal('No')
-          })
-        })
-      })
-
       describe('the "additionalContact" property', () => {
         describe('when the contact is an additional contact', () => {
           it('returns true', () => {

--- a/test/presenters/company-contacts/setup/check.presenter.test.js
+++ b/test/presenters/company-contacts/setup/check.presenter.test.js
@@ -63,40 +63,6 @@ describe('Company Contacts - Setup - Check Presenter', () => {
       })
     })
 
-    describe('the "abstractionAlerts" property', () => {
-      describe('when "abstractionAlerts" is "yes"', () => {
-        it('returns "Yes, for all licences"', () => {
-          const result = CheckPresenter.go(session, savedCompanyContacts, sentNotification)
-
-          expect(result.abstractionAlerts).to.equal('Yes, for all licences')
-        })
-      })
-
-      describe('when "abstractionAlerts" is "some"', () => {
-        beforeEach(() => {
-          session.abstractionAlerts = 'some'
-        })
-
-        it('returns "Yes, for some licences"', () => {
-          const result = CheckPresenter.go(session, savedCompanyContacts, sentNotification)
-
-          expect(result.abstractionAlerts).to.equal('Yes, for some licences')
-        })
-      })
-
-      describe('when "abstractionAlerts" is "no"', () => {
-        beforeEach(() => {
-          session.abstractionAlerts = 'no'
-        })
-
-        it('returns "No"', () => {
-          const result = CheckPresenter.go(session, savedCompanyContacts, sentNotification)
-
-          expect(result.abstractionAlerts).to.equal('No')
-        })
-      })
-    })
-
     describe('the "emailInUse" property', () => {
       describe('when creating a new contact', () => {
         describe('and the email has not been used for notifications', () => {

--- a/test/presenters/crm.presenter.test.js
+++ b/test/presenters/crm.presenter.test.js
@@ -14,6 +14,32 @@ const { generateUUID } = require('../../app/lib/general.lib.js')
 const CRMPresenter = require('../../app/presenters/crm.presenter.js')
 
 describe('CRM presenter', () => {
+  describe('#abstractionAlertsLabel()', () => {
+    describe('when "abstractionAlerts" is "yes"', () => {
+      it('returns "Yes, for all licences"', () => {
+        const result = CRMPresenter.abstractionAlertsLabel('yes')
+
+        expect(result).to.equal('Yes, for all licences')
+      })
+    })
+
+    describe('when "abstractionAlerts" is "some"', () => {
+      it('returns "Yes, for some licences"', () => {
+        const result = CRMPresenter.abstractionAlertsLabel('some')
+
+        expect(result).to.equal('Yes, for some licences')
+      })
+    })
+
+    describe('when "abstractionAlerts" is "no"', () => {
+      it('returns "No"', () => {
+        const result = CRMPresenter.abstractionAlertsLabel('no')
+
+        expect(result).to.equal('No')
+      })
+    })
+  })
+
   describe('#formatContact()', () => {
     const billingQueryId = generateUUID()
 

--- a/test/services/company-contacts/fetch-company-contact-details.service.test.js
+++ b/test/services/company-contacts/fetch-company-contact-details.service.test.js
@@ -132,6 +132,7 @@ describe('Company Contacts - Fetch Company Contact Details service', () => {
 function _transformToFetchResult(companyContact, contact, user, licenceRole, abstractionAlertsCount = 0) {
   return {
     id: companyContact.id,
+    abstractionAlertLicences: null,
     abstractionAlerts: companyContact.abstractionAlerts,
     abstractionAlertsCount,
     companyId: companyContact.companyId,

--- a/test/services/company-contacts/setup/initiate-edit-session.service.test.js
+++ b/test/services/company-contacts/setup/initiate-edit-session.service.test.js
@@ -9,6 +9,7 @@ const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
+const CompanyContactModel = require('../../../../app/models/company-contact.model.js')
 const CustomersFixtures = require('../../../support/fixtures/customers.fixture.js')
 const SessionModel = require('../../../../app/models/session.model.js')
 const { generateUUID } = require('../../../../app/lib/general.lib.js')
@@ -34,13 +35,13 @@ describe('Company Contacts - Setup - Initiate edit Session service', () => {
 
     licences = [{ id: generateUUID(), licenceRef: generateLicenceRef() }]
 
-    companyContact = {
+    companyContact = CompanyContactModel.fromJson({
       id: generateUUID(),
       abstractionAlerts: false,
       abstractionAlertLicences: null,
       company,
       contact
-    }
+    })
 
     stubFetchCompanyContactDal = Sinon.stub(FetchCompanyContactDal, 'go').returns(companyContact)
 

--- a/test/support/fixtures/customers.fixture.js
+++ b/test/support/fixtures/customers.fixture.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const BillingAccountModel = require('../../../app/models/billing-account.model.js')
+const CompanyContactModel = require('../../../app/models/company-contact.model.js')
 const ContactModel = require('../../../app/models/contact.model.js')
 const LicenceModel = require('../../../app/models/licence.model.js')
 const { generateAccountNumber } = require('../helpers/billing-account.helper.js')
@@ -98,8 +99,9 @@ function companyAddress() {
  * @returns {module:CompanyContactModel} A company contact
  */
 function companyContact() {
-  return {
+  return CompanyContactModel.fromJson({
     id: generateUUID(),
+    abstractionAlertLicences: null,
     abstractionAlerts: false,
     companyId: generateUUID(),
     contact: contact(),
@@ -118,7 +120,7 @@ function companyContact() {
       id: generateUUID(),
       username: 'void.kampff@tyrell.com'
     }
-  }
+  })
 }
 
 /**


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5631

This adds the logic to show the updated text on the company contacts details page.

This will now show the text for an abstraction alert that is 'no', 'yes' or 'some'.

This also change adds the '$abstractionAlertType' instance method to the company contact model.

This gives us a single place to work out if an abstraction alert is 'no', 'yes' or 'some'.