### PR TITLE
Send Alternate notice in notification-status job

### DIFF
--- a/app/dal/jobs/notification-status/fetch-critical-notices.dal.js
+++ b/app/dal/jobs/notification-status/fetch-critical-notices.dal.js
@@ -24,7 +24,12 @@ async function go(noticeIds) {
     .whereExists(
       EventModel.relatedQuery('notifications')
         .where('status', 'error')
-        .whereIn('messageRef', ['renewal invitation', 'renewal invitation ad-hoc', 'returns invitation', 'returns invitation ad-hoc'])
+        .whereIn('messageRef', [
+          'renewal invitation',
+          'renewal invitation ad-hoc',
+          'returns invitation',
+          'returns invitation ad-hoc'
+        ])
         .where('contactType', 'primary user')
         .where('messageType', 'email')
         .whereNull('alternateNoticeId')

--- a/app/dal/jobs/notification-status/fetch-critical-notices.dal.js
+++ b/app/dal/jobs/notification-status/fetch-critical-notices.dal.js
@@ -23,7 +23,7 @@ async function go(noticeIds) {
     .whereExists(
       EventModel.relatedQuery('notifications')
         .where('status', 'error')
-        .whereIn('messageRef', ['renewal invitation', 'returns invitation'])
+        .whereIn('messageRef', ['renewal invitation', 'renewal invitation ad-hoc', 'returns invitation', 'returns invitation ad-hoc'])
         .where('contactType', 'primary user')
         .where('messageType', 'email')
         .whereNull('alternateNoticeId')

--- a/app/dal/jobs/notification-status/fetch-critical-notices.dal.js
+++ b/app/dal/jobs/notification-status/fetch-critical-notices.dal.js
@@ -1,0 +1,35 @@
+'use strict'
+
+/**
+ * Fetches details for each notice whose notifications have had their status checked by the notification-status job
+ * @module FetchCriticalNoticesDal
+ */
+
+const EventModel = require('../../../models/event.model.js')
+const { NoticeTypes } = require('../../../lib/static-lookups.lib.js')
+
+/**
+ * Fetches details for each notice whose notifications have had their status checked by the notification-status job
+ *
+ * @param {string[]} noticeIds - The UUIDs of the notices processed by the status check job
+ *
+ * @returns {Promise<void>}
+ */
+async function go(noticeIds) {
+  return EventModel.query()
+    .select('id', 'issuer', 'metadata', 'subtype')
+    .whereIn('subtype', [NoticeTypes.renewalInvitations.subType, NoticeTypes.invitations.subType])
+    .whereIn('id', noticeIds)
+    .whereExists(
+      EventModel.relatedQuery('notifications')
+        .where('status', 'error')
+        .whereIn('messageRef', ['renewal invitation', 'returns invitation'])
+        .where('contactType', 'primary user')
+        .where('messageType', 'email')
+        .whereNull('alternateNoticeId')
+    )
+}
+
+module.exports = {
+  go
+}

--- a/app/dal/jobs/notification-status/fetch-critical-notices.dal.js
+++ b/app/dal/jobs/notification-status/fetch-critical-notices.dal.js
@@ -13,7 +13,8 @@ const { NoticeTypes } = require('../../../lib/static-lookups.lib.js')
  *
  * @param {string[]} noticeIds - The UUIDs of the notices processed by the status check job
  *
- * @returns {Promise<void>}
+ * @returns {Promise<module:EventModel[]>} any matching notices which are critical, and contain errored notifications
+ * to primary users that have not been sent an alternate notification
  */
 async function go(noticeIds) {
   return EventModel.query()

--- a/app/services/jobs/notification-status/process-notification-status.service.js
+++ b/app/services/jobs/notification-status/process-notification-status.service.js
@@ -7,6 +7,7 @@
 
 const CheckNotificationStatusService = require('../../notifications/check-notification-status.service.js')
 const FetchNotificationsService = require('./fetch-notifications.service.js')
+const SendAlternateNoticesService = require('./send-alternate-notices.service.js')
 const UpdateNoticeService = require('../../notices/update-notice.service.js')
 const { calculateAndLogTimeTaken, currentTimeInNanoseconds } = require('../../../lib/general.lib.js')
 
@@ -45,6 +46,8 @@ async function go() {
     }
 
     await _updateEventErrorCount(notifications)
+
+    await SendAlternateNoticesService.go(notifications)
 
     calculateAndLogTimeTaken(startTime, 'Notification status job complete', { count: notifications.length })
   } catch (error) {

--- a/app/services/jobs/notification-status/send-alternate-notices.service.js
+++ b/app/services/jobs/notification-status/send-alternate-notices.service.js
@@ -1,0 +1,53 @@
+'use strict'
+
+/**
+ * Orchestrates sending alternate notices when a critical notice has failed notifications to primary users
+ * @module SendAlternateNoticesService
+ */
+
+const FetchCriticalNoticesDal = require('../../../dal/jobs/notification-status/fetch-critical-notices.dal.js')
+const SendAlternateNoticeService = require('../../notices/setup/send/send-alternate-notice.service.js')
+
+/**
+ * Orchestrates sending alternate notices when a critical notice has failed notifications to primary users
+ *
+ * Once the main job has completed checking and updating the status for any pending notifications, we need to check if
+ * any of them have failed and were for a critical notice type (renewals and returns invitations).
+ *
+ * Specifically, it's failed emails to primary users we care about. If these fail we are expected to send an alternate
+ * letter notification to the licence's licence holder recipient.
+ *
+ * When a user sends a notice through the UI, the system automatically does this check having sent all the notifications
+ * to Notify and then pausing. In 99% of cases, we'll know then whether an alternate notice is needed.
+ *
+ * But if Notify is under heavy lead, then some emails may still be 'pending' when that check happens, which means
+ * they'll be picked up by the notification-status job. This performs the same checks and sends the same alternate
+ * notice, and is a fall back for those rare times the failed email wasn't handled by the initial check.
+ *
+ * @param {module:NotificationModel[]} notifications - The notifications that have been checked for status by the
+ * notification-status job
+ */
+async function go(notifications) {
+  const noticeIds = _noticeIds(notifications)
+  const criticalNotices = await FetchCriticalNoticesDal.go(noticeIds)
+
+  if (criticalNotices.length === 0) {
+    return
+  }
+
+  for (const criticalNotice of criticalNotices) {
+    await SendAlternateNoticeService.go(criticalNotice)
+  }
+}
+
+function _noticeIds(notifications) {
+  const allNoticeIds = notifications.map((notification) => {
+    return notification.eventId
+  })
+
+  return [...new Set(allNoticeIds)]
+}
+
+module.exports = {
+  go
+}

--- a/test/dal/jobs/notification-status/fetch-critical-notices.dal.test.js
+++ b/test/dal/jobs/notification-status/fetch-critical-notices.dal.test.js
@@ -97,7 +97,7 @@ describe('Jobs - Notification Status - Fetch Critical Notices DAL', () => {
   })
 
   describe('when called', () => {
-    it('returns only the critical notices that have notifications with errors from those request', async () => {
+    it('returns only the critical notices that have notifications with errors from those request (scenario 1)', async () => {
       const results = await FetchCriticalNoticesDal.go(noticeIds)
 
       expect(results).to.include(EventModel.fromJson(
@@ -106,6 +106,36 @@ describe('Jobs - Notification Status - Fetch Critical Notices DAL', () => {
           issuer: criticalNoticeWithErrors.issuer,
           metadata: criticalNoticeWithErrors.metadata,
           subtype: criticalNoticeWithErrors.subtype
+        }
+      ))
+
+      // Scenario 2
+      expect(results).not.to.include(EventModel.fromJson(
+        {
+          id: standardNoticeWithErrors.id,
+          issuer: standardNoticeWithErrors.issuer,
+          metadata: standardNoticeWithErrors.metadata,
+          subtype: standardNoticeWithErrors.subtype
+        }
+      ))
+
+      // Scenario 3
+      expect(results).not.to.include(EventModel.fromJson(
+        {
+          id: criticalNoticeWithoutErrors.id,
+          issuer: criticalNoticeWithoutErrors.issuer,
+          metadata: criticalNoticeWithoutErrors.metadata,
+          subtype: criticalNoticeWithoutErrors.subtype
+        }
+      ))
+
+      // Scenario 4
+      expect(results).not.to.include(EventModel.fromJson(
+        {
+          id: standardNoticeWithoutErrors.id,
+          issuer: standardNoticeWithoutErrors.issuer,
+          metadata: standardNoticeWithoutErrors.metadata,
+          subtype: standardNoticeWithoutErrors.subtype
         }
       ))
     })

--- a/test/dal/jobs/notification-status/fetch-critical-notices.dal.test.js
+++ b/test/dal/jobs/notification-status/fetch-critical-notices.dal.test.js
@@ -1,0 +1,113 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, before, after } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Test helpers
+const EventHelper = require('../../../support/helpers/event.helper.js')
+const EventModel = require('../../../../app/models/event.model.js')
+const NoticesFixture = require('../../../support/fixtures/notices.fixture.js')
+const NotificationsFixture = require('../../../support/fixtures/notifications.fixture.js')
+const NotificationHelper = require('../../../support/helpers/notification.helper.js')
+
+// Thing under test
+const FetchCriticalNoticesDal = require('../../../../app/dal/jobs/notification-status/fetch-critical-notices.dal.js')
+
+describe('Jobs - Notification Status - Fetch Critical Notices DAL', () => {
+  let criticalNoticeWithErrors
+  let criticalNoticeWithoutErrors
+  let noticeIds
+  let notificationForCriticalNoticeWithErrors
+  let notificationForCriticalNoticeWithoutErrors
+  let notificationForStandardNoticeWithErrors
+  let notificationForStandardNoticeWithoutErrors
+  let standardNoticeWithErrors
+  let standardNoticeWithoutErrors
+
+  before(async () => {
+    // Scenario 1: Critical notice with notifications that have errors. This should be return by the DAL
+    let noticeData = NoticesFixture.renewalInvitation()
+
+    noticeData.metadata.recipients = 1
+    noticeData.overallStatus = 'error'
+    noticeData.statusCounts = { cancelled: 0, error: 1, pending: 0, returned: 0, sent: 0 }
+
+    criticalNoticeWithErrors = await EventHelper.add(noticeData)
+
+    let notificationData = NotificationsFixture.renewalInvitationEmail(criticalNoticeWithErrors)
+    notificationData.status = 'error'
+
+    notificationForCriticalNoticeWithErrors = await NotificationHelper.add(notificationData)
+
+    // Scenario 2: Standard notice with notifications that have errors. This should NOT be returned by the DAL
+    noticeData = NoticesFixture.returnsReminder()
+
+    noticeData.metadata.recipients = 1
+    noticeData.overallStatus = 'error'
+    noticeData.statusCounts = { cancelled: 0, error: 1, pending: 0, returned: 0, sent: 0 }
+
+    standardNoticeWithErrors = await EventHelper.add(noticeData)
+
+    notificationData = NotificationsFixture.returnsReminderEmail(standardNoticeWithErrors)
+    notificationData.status = 'error'
+
+    notificationForStandardNoticeWithErrors = await NotificationHelper.add(notificationData)
+
+    // Scenario 3: Critical notice with notifications that were successful. This should NOT be returned by the DAL
+    noticeData = NoticesFixture.returnsInvitation()
+    noticeData.overallStatus = 'sent'
+    noticeData.statusCounts = { cancelled: 0, error: 0, pending: 0, returned: 0, sent: 1 }
+
+    criticalNoticeWithoutErrors = await EventHelper.add(noticeData)
+
+    notificationData = NotificationsFixture.returnsInvitationEmail(criticalNoticeWithoutErrors)
+    notificationForCriticalNoticeWithoutErrors = await NotificationHelper.add(notificationData)
+
+    // Scenario 4: Standard notice with notifications that were successful. This should NOT be returned by the DAL
+    noticeData = NoticesFixture.returnsPaperForm()
+    noticeData.overallStatus = 'sent'
+    noticeData.statusCounts = { cancelled: 0, error: 0, pending: 0, returned: 0, sent: 1 }
+
+    standardNoticeWithoutErrors = await EventHelper.add(noticeData)
+
+    notificationData = NotificationsFixture.returnsReminderEmail(standardNoticeWithoutErrors)
+    notificationForStandardNoticeWithoutErrors = await NotificationHelper.add(notificationData)
+
+    noticeIds = [
+      criticalNoticeWithErrors.id,
+      standardNoticeWithErrors.id,
+      criticalNoticeWithoutErrors.id,
+      standardNoticeWithoutErrors.id
+    ]
+  })
+
+  after(async () => {
+    await notificationForCriticalNoticeWithErrors.$query().delete()
+    await notificationForCriticalNoticeWithoutErrors.$query().delete()
+    await notificationForStandardNoticeWithErrors.$query().delete()
+    await notificationForStandardNoticeWithoutErrors.$query().delete()
+    await criticalNoticeWithErrors.$query().delete()
+    await criticalNoticeWithoutErrors.$query().delete()
+    await standardNoticeWithErrors.$query().delete()
+    await standardNoticeWithoutErrors.$query().delete()
+  })
+
+  describe('when called', () => {
+    it('returns only the critical notices that have notifications with errors from those request', async () => {
+      const results = await FetchCriticalNoticesDal.go(noticeIds)
+
+      expect(results).to.include(EventModel.fromJson(
+        {
+          id: criticalNoticeWithErrors.id,
+          issuer: criticalNoticeWithErrors.issuer,
+          metadata: criticalNoticeWithErrors.metadata,
+          subtype: criticalNoticeWithErrors.subtype
+        }
+      ))
+    })
+  })
+})

--- a/test/dal/jobs/notification-status/fetch-critical-notices.dal.test.js
+++ b/test/dal/jobs/notification-status/fetch-critical-notices.dal.test.js
@@ -11,8 +11,8 @@ const { expect } = Code
 const EventHelper = require('../../../support/helpers/event.helper.js')
 const EventModel = require('../../../../app/models/event.model.js')
 const NoticesFixture = require('../../../support/fixtures/notices.fixture.js')
-const NotificationsFixture = require('../../../support/fixtures/notifications.fixture.js')
 const NotificationHelper = require('../../../support/helpers/notification.helper.js')
+const NotificationsFixture = require('../../../support/fixtures/notifications.fixture.js')
 
 // Thing under test
 const FetchCriticalNoticesDal = require('../../../../app/dal/jobs/notification-status/fetch-critical-notices.dal.js')

--- a/test/dal/jobs/notification-status/fetch-critical-notices.dal.test.js
+++ b/test/dal/jobs/notification-status/fetch-critical-notices.dal.test.js
@@ -100,44 +100,44 @@ describe('Jobs - Notification Status - Fetch Critical Notices DAL', () => {
     it('returns only the critical notices that have notifications with errors from those request (scenario 1)', async () => {
       const results = await FetchCriticalNoticesDal.go(noticeIds)
 
-      expect(results).to.include(EventModel.fromJson(
-        {
+      expect(results).to.include(
+        EventModel.fromJson({
           id: criticalNoticeWithErrors.id,
           issuer: criticalNoticeWithErrors.issuer,
           metadata: criticalNoticeWithErrors.metadata,
           subtype: criticalNoticeWithErrors.subtype
-        }
-      ))
+        })
+      )
 
       // Scenario 2
-      expect(results).not.to.include(EventModel.fromJson(
-        {
+      expect(results).not.to.include(
+        EventModel.fromJson({
           id: standardNoticeWithErrors.id,
           issuer: standardNoticeWithErrors.issuer,
           metadata: standardNoticeWithErrors.metadata,
           subtype: standardNoticeWithErrors.subtype
-        }
-      ))
+        })
+      )
 
       // Scenario 3
-      expect(results).not.to.include(EventModel.fromJson(
-        {
+      expect(results).not.to.include(
+        EventModel.fromJson({
           id: criticalNoticeWithoutErrors.id,
           issuer: criticalNoticeWithoutErrors.issuer,
           metadata: criticalNoticeWithoutErrors.metadata,
           subtype: criticalNoticeWithoutErrors.subtype
-        }
-      ))
+        })
+      )
 
       // Scenario 4
-      expect(results).not.to.include(EventModel.fromJson(
-        {
+      expect(results).not.to.include(
+        EventModel.fromJson({
           id: standardNoticeWithoutErrors.id,
           issuer: standardNoticeWithoutErrors.issuer,
           metadata: standardNoticeWithoutErrors.metadata,
           subtype: standardNoticeWithoutErrors.subtype
-        }
-      ))
+        })
+      )
     })
   })
 })

--- a/test/services/jobs/notification-status/process-notification-status.service.test.js
+++ b/test/services/jobs/notification-status/process-notification-status.service.test.js
@@ -16,6 +16,7 @@ const NotificationsFixture = require('../../../support/fixtures/notifications.fi
 const CheckNotificationStatusService = require('../../../../app/services/notifications/check-notification-status.service.js')
 const FetchNotificationsService = require('../../../../app/services/jobs/notification-status/fetch-notifications.service.js')
 const GlobalNotifierStub = require('../../../support/stubs/global-notifier.stub.js')
+const SendAlternateNoticesService = require('../../../../app/services/jobs/notification-status/send-alternate-notices.service.js')
 const UpdateNoticeService = require('../../../../app/services/notices/update-notice.service.js')
 
 // Thing under test
@@ -24,11 +25,13 @@ const ProcessNotificationStatusService = require('../../../../app/services/jobs/
 describe('Job - Notifications - Process Notification Status service', () => {
   let noticeA
   let noticeB
+  let notifications
   let notifierStub
+  let sendAlternateNoticesStub
   let updateEventStub
 
   beforeEach(async () => {
-    const notifications = []
+    notifications = []
 
     let notification
     // NOTE: We create multiple notifications a cross two notices so we can demonstrate that we are providing
@@ -52,6 +55,7 @@ describe('Job - Notifications - Process Notification Status service', () => {
     Sinon.stub(FetchNotificationsService, 'go').resolves(notifications)
 
     updateEventStub = Sinon.stub(UpdateNoticeService, 'go').resolves()
+    sendAlternateNoticesStub = Sinon.stub(SendAlternateNoticesService, 'go').resolves()
 
     // The service depends on GlobalNotifier to have been set. This happens in app/plugins/global-notifier.plugin.js
     // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
@@ -75,6 +79,13 @@ describe('Job - Notifications - Process Notification Status service', () => {
 
       expect(updateEventStub.called).to.be.true()
       expect(updateEventStub.firstCall.args[0]).to.equal([noticeA.id, noticeB.id])
+    })
+
+    it('checks whether any alternate notices need to be sent', async () => {
+      await ProcessNotificationStatusService.go()
+
+      expect(sendAlternateNoticesStub.called).to.be.true()
+      expect(sendAlternateNoticesStub.firstCall.args[0]).to.equal(notifications)
     })
 
     it('logs the time taken in milliseconds and seconds', async () => {

--- a/test/services/jobs/notification-status/send-alternate-notices.service.test.js
+++ b/test/services/jobs/notification-status/send-alternate-notices.service.test.js
@@ -1,0 +1,67 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Test helpers
+const { generateUUID } = require('../../../../app/lib/general.lib.js')
+
+// Things we need to stub
+const FetchCriticalNoticesDal = require('../../../../app/dal/jobs/notification-status/fetch-critical-notices.dal.js')
+const SendAlternateNoticeService = require('../../../../app/services/notices/setup/send/send-alternate-notice.service.js')
+
+// Thing under test
+const SendAlternateNoticesService = require('../../../../app/services/jobs/notification-status/send-alternate-notices.service.js')
+
+describe('Job - Notifications - Send Alternate Notices service', () => {
+  let criticalNotices
+  let notifications
+  let sendAlternateNoticeStub
+
+  beforeEach(async () => {
+    notifications = [
+      { id: generateUUID(), eventId: generateUUID() },
+      { id: generateUUID(), eventId: generateUUID() },
+      { id: generateUUID(), eventId: generateUUID() }
+    ]
+
+    sendAlternateNoticeStub = Sinon.stub(SendAlternateNoticeService, 'go').resolves()
+  })
+
+  afterEach(() => {
+    Sinon.restore()
+  })
+
+  describe('when the notifications are linked to critical notices with errors', () => {
+    beforeEach(() => {
+      criticalNotices = [{ id: notifications[1].eventId }, { id: notifications[2].eventId }]
+
+      Sinon.stub(FetchCriticalNoticesDal, 'go').resolves(criticalNotices)
+    })
+
+    it('sends an alternate notice', async () => {
+      await SendAlternateNoticesService.go(notifications)
+
+      expect(sendAlternateNoticeStub.called).to.be.true()
+      expect(sendAlternateNoticeStub.firstCall.args[0]).to.equal(criticalNotices[0])
+      expect(sendAlternateNoticeStub.secondCall.args[0]).to.equal(criticalNotices[1])
+    })
+  })
+
+  describe('when the notifications are not linked to critical notices with errors', () => {
+    beforeEach(() => {
+      Sinon.stub(FetchCriticalNoticesDal, 'go').resolves([])
+    })
+
+    it('does not send an alternate notice', async () => {
+      await SendAlternateNoticesService.go(notifications)
+
+      expect(sendAlternateNoticeStub.called).to.be.false()
+    })
+  })
+})


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5669

When we send a returns invitation or renewals invitation, we want to ensure that the 'licence holder' is notified.

Where a licence is registered, we opt to send the notification by email. We can check emails pretty soon after sending to confirm whether Notify was successful.

Where a returns or renewals invitation email fails, we want to follow up with an alternative notification: a letter to the licence holder.

So, when we create one of these notices, after sending all the notifications to Notify, we wait 5 seconds and then check whether any emails have failed. If they have, we create an alternate notice and letter notifications for the affected licences.

We recently put the renewal invitations job live, which automatically checks for and creates renewal invitations for expiring licences. Most expire on 31 March each year, and as we send them 300 days in advance, June 4th saw more than 800 renewal invitations sent.

There were some email failures, and these were picked up. But also some emails still had a `pending` status after the job and the alternate notice were complete. There is no guarantee that Notify will complete a large volume of emails in the pause we allow. But that is why we also have the 'notification-status' job.

However, it was observed that some of those pending emails subsequently failed, but since it only checks and updates the status, no alternative notification was sent for them.

This is a scenario we haven't catered for and should. We could just increase the pause, but not only would it mean users would have to wait longer to see if their notice has been successful (5 seconds is already pushing their patience!), but it still doesn't guarantee that all emails will have been processed by Notify.

Ideally, the 'notification-status' job should also perform the same check for notice type, and trigger an alternate notice when it identifies failed emails for returns and renewals invitations.

This change updates the job to do that.