### PR TITLE
Add licences to company contact details page

### DIFF
--- a/app/dal/company-contacts/fetch-abstraction-alert-licences.dal.js
+++ b/app/dal/company-contacts/fetch-abstraction-alert-licences.dal.js
@@ -1,0 +1,30 @@
+'use strict'
+
+/**
+ * Fetch all licences by abstraction alert licences ids
+ * @module AbstractionAlertLicencesDal
+ */
+
+const LicenceModel = require('../../models/licence.model.js')
+
+/**
+ * Fetch all licences by abstraction alert licences ids
+ *
+ * @param {string[]|null} abstractionAlertLicences - The UUIDs of the abstraction alert licences
+ *
+ * @returns {Promise<object[]>} An array of licences
+ */
+async function go(abstractionAlertLicences) {
+  if (abstractionAlertLicences === null) {
+    return []
+  }
+
+  return LicenceModel.query()
+    .select(['id', 'licenceRef', 'revokedDate', 'lapsedDate', 'expiredDate'])
+    .whereIn('id', abstractionAlertLicences)
+    .orderBy('licenceRef')
+}
+
+module.exports = {
+  go
+}

--- a/app/dal/company-contacts/fetch-abstraction-alert-licences.dal.js
+++ b/app/dal/company-contacts/fetch-abstraction-alert-licences.dal.js
@@ -1,14 +1,14 @@
 'use strict'
 
 /**
- * Fetch all licences by abstraction alert licences ids
+ * Fetch all licences for abstraction alert licences ids
  * @module AbstractionAlertLicencesDal
  */
 
 const LicenceModel = require('../../models/licence.model.js')
 
 /**
- * Fetch all licences by abstraction alert licences ids
+ * Fetch all licences for abstraction alert licences ids
  *
  * @param {string[]|null} abstractionAlertLicences - The UUIDs of the abstraction alert licences
  *

--- a/app/dal/company-contacts/fetch-abstraction-alert-licences.dal.js
+++ b/app/dal/company-contacts/fetch-abstraction-alert-licences.dal.js
@@ -2,7 +2,7 @@
 
 /**
  * Fetch all licences for abstraction alert licences ids
- * @module AbstractionAlertLicencesDal
+ * @module FetchAbstractionAlertLicencesDal
  */
 
 const LicenceModel = require('../../models/licence.model.js')

--- a/app/presenters/company-contacts/contact-details.presenter.js
+++ b/app/presenters/company-contacts/contact-details.presenter.js
@@ -13,10 +13,13 @@ const { formatEmail, formatLongDate } = require('../base.presenter.js')
  *
  * @param {module:CompanyModel} company - The customer from the companies table
  * @param {module:CompanyContactModel} companyContact - The customer contact from the company contacts table
+ * @param {object[]} licences - The licences linked to the abstraction alert licences
  *
  * @returns {object} The data formatted for the view template
  */
-function go(company, companyContact) {
+function go(company, companyContact, licences) {
+  const abstractionAlertType = companyContact.$abstractionAlertType()
+
   return {
     additionalContact: companyContact.licenceRole.name === 'additionalContact',
     backLink: {
@@ -24,10 +27,11 @@ function go(company, companyContact) {
       text: 'Go back to licence holder contacts'
     },
     contact: {
-      abstractionAlerts: _abstractionAlerts(companyContact),
+      abstractionAlertsLabel: abstractionAlertsLabel(abstractionAlertType),
       created: _created(companyContact),
       email: formatEmail(companyContact.contact.email),
       lastUpdated: _lastUpdated(companyContact),
+      licences: _licences(abstractionAlertType, licences),
       name: companyContact.contact.$name()
     },
     editContactLink: `/system/company-contacts/setup/${companyContact.id}/edit`,
@@ -35,12 +39,6 @@ function go(company, companyContact) {
     pageTitleCaption: company.name,
     removeContactLink: `/system/company-contacts/${companyContact.id}/remove`
   }
-}
-
-function _abstractionAlerts(companyContact) {
-  const abstractionAlerts = companyContact.$abstractionAlertType()
-
-  return abstractionAlertsLabel(abstractionAlerts)
 }
 
 function _created(companyContact) {
@@ -63,6 +61,15 @@ function _lastUpdated(companyContact) {
   return `${formattedDate} by ${companyContact.updatedByUser.username}`
 }
 
+function _licences(abstractionAlertType, licences) {
+  if (abstractionAlertType !== 'some') {
+    return []
+  }
+
+  return licences.map((licence) => {
+    return licence.licenceRef
+  })
+}
 module.exports = {
   go
 }

--- a/app/presenters/company-contacts/contact-details.presenter.js
+++ b/app/presenters/company-contacts/contact-details.presenter.js
@@ -18,22 +18,13 @@ const { formatEmail, formatLongDate } = require('../base.presenter.js')
  * @returns {object} The data formatted for the view template
  */
 function go(company, companyContact, licences) {
-  const abstractionAlertType = companyContact.$abstractionAlertType()
-
   return {
     additionalContact: companyContact.licenceRole.name === 'additionalContact',
     backLink: {
       href: `/system/companies/${company.id}/contacts`,
       text: 'Go back to licence holder contacts'
     },
-    contact: {
-      abstractionAlertsLabel: abstractionAlertsLabel(abstractionAlertType),
-      created: _created(companyContact),
-      email: formatEmail(companyContact.contact.email),
-      lastUpdated: _lastUpdated(companyContact),
-      licences: _licences(abstractionAlertType, licences),
-      name: companyContact.contact.$name()
-    },
+    contact: _contact(companyContact, licences),
     editContactLink: `/system/company-contacts/setup/${companyContact.id}/edit`,
     pageTitle: `Contact details for ${companyContact.contact.$name()}`,
     pageTitleCaption: company.name,
@@ -49,6 +40,19 @@ function _created(companyContact) {
   }
 
   return `${formattedDate} by ${companyContact.createdByUser.username}`
+}
+
+function _contact(companyContact, licences) {
+  const abstractionAlertType = companyContact.$abstractionAlertType()
+
+  return {
+    abstractionAlertsLabel: abstractionAlertsLabel(abstractionAlertType),
+    created: _created(companyContact),
+    email: formatEmail(companyContact.contact.email),
+    lastUpdated: _lastUpdated(companyContact),
+    licences: _licences(abstractionAlertType, licences),
+    name: companyContact.contact.$name()
+  }
 }
 
 function _lastUpdated(companyContact) {

--- a/app/services/company-contacts/view-contact-details.service.js
+++ b/app/services/company-contacts/view-contact-details.service.js
@@ -6,6 +6,7 @@
  * @module ViewContactDetailsService
  */
 
+const AbstractionAlertLicencesDal = require('../../dal/company-contacts/fetch-abstraction-alert-licences.dal.js')
 const ContactDetailsPresenter = require('../../presenters/company-contacts/contact-details.presenter.js')
 const FetchCompanyContactDetailsService = require('./fetch-company-contact-details.service.js')
 const FetchCompanyService = require('../companies/fetch-company.service.js')
@@ -26,7 +27,9 @@ async function go(id, auth, yar) {
 
   const company = await FetchCompanyService.go(companyContact.companyId)
 
-  const pageData = ContactDetailsPresenter.go(company, companyContact)
+  const licences = await AbstractionAlertLicencesDal.go(companyContact.abstractionAlertLicences)
+
+  const pageData = ContactDetailsPresenter.go(company, companyContact, licences)
 
   const notification = readFlashNotification(yar)
 

--- a/app/services/company-contacts/view-contact-details.service.js
+++ b/app/services/company-contacts/view-contact-details.service.js
@@ -6,8 +6,8 @@
  * @module ViewContactDetailsService
  */
 
-const AbstractionAlertLicencesDal = require('../../dal/company-contacts/fetch-abstraction-alert-licences.dal.js')
 const ContactDetailsPresenter = require('../../presenters/company-contacts/contact-details.presenter.js')
+const FetchAbstractionAlertLicencesDal = require('../../dal/company-contacts/fetch-abstraction-alert-licences.dal.js')
 const FetchCompanyContactDetailsService = require('./fetch-company-contact-details.service.js')
 const FetchCompanyService = require('../companies/fetch-company.service.js')
 const { readFlashNotification } = require('../../lib/general.lib.js')
@@ -27,7 +27,7 @@ async function go(id, auth, yar) {
 
   const company = await FetchCompanyService.go(companyContact.companyId)
 
-  const licences = await AbstractionAlertLicencesDal.go(companyContact.abstractionAlertLicences)
+  const licences = await FetchAbstractionAlertLicencesDal.go(companyContact.abstractionAlertLicences)
 
   const pageData = ContactDetailsPresenter.go(company, companyContact, licences)
 

--- a/app/views/company-contacts/contact-details.njk
+++ b/app/views/company-contacts/contact-details.njk
@@ -3,6 +3,32 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 
+{% from "govuk/components/details/macro.njk" import govukDetails %}
+
+{% from "macros/new-line-array-items.njk" import newLineArrayItems %}
+
+{% macro collapsibleList(items, label, threshold = 5) %}
+
+  {% if items.length > threshold %}
+    {{ govukDetails({
+      summaryText: items.length + " " + label,
+      html: newLineArrayItems(items) | safe,
+      classes: "govuk-!-margin-bottom-0 govuk-!-padding-bottom-0 govuk-!-padding-top-0"
+    }) }}
+  {% else %}
+    {{ newLineArrayItems(items) | safe }}
+  {% endif %}
+{% endmacro %}
+
+{% set abstractionAlertsHtml %}
+  {% if contact.licences.length %}
+    <p class="govuk-!-margin-bottom-3">{{ contact.abstractionAlertsLabel }}</p>
+    {{ collapsibleList(contact.licences, "Licences") }}
+  {% else %}
+    <p class="govuk-!-margin-bottom-1">{{ contact.abstractionAlertsLabel }}</p>
+  {% endif %}
+{% endset %}
+
 {% block pageContent %}
   {{ govukSummaryList({
     rows: [
@@ -16,7 +42,7 @@
       },
       {
         key: { text: "Water abstraction alerts" },
-        value: { text: contact.abstractionAlerts }
+        value: { html: abstractionAlertsHtml }
       },
       {
         key: { text: "Created" },

--- a/app/views/company-contacts/contact-details.njk
+++ b/app/views/company-contacts/contact-details.njk
@@ -3,22 +3,7 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 
-{% from "govuk/components/details/macro.njk" import govukDetails %}
-
-{% from "macros/new-line-array-items.njk" import newLineArrayItems %}
-
-{% macro collapsibleList(items, label, threshold = 5) %}
-
-  {% if items.length > threshold %}
-    {{ govukDetails({
-      summaryText: items.length + " " + label,
-      html: newLineArrayItems(items) | safe,
-      classes: "govuk-!-margin-bottom-0 govuk-!-padding-bottom-0 govuk-!-padding-top-0"
-    }) }}
-  {% else %}
-    {{ newLineArrayItems(items) | safe }}
-  {% endif %}
-{% endmacro %}
+{% from "macros/collapsible-list.njk" import collapsibleList %}
 
 {% set abstractionAlertsHtml %}
   {% if contact.licences.length %}

--- a/test/dal/company-contacts/fetch-abstraction-alert-licences.dal.test.js
+++ b/test/dal/company-contacts/fetch-abstraction-alert-licences.dal.test.js
@@ -1,0 +1,88 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, before, after } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Test helpers
+const LicenceHelper = require('../../support/helpers/licence.helper.js')
+const { generateUUID } = require('../../../app/lib/general.lib.js')
+
+// Thing under test
+const FetchAbstractionAlertLicencesDal = require('../../../app/dal/company-contacts/fetch-abstraction-alert-licences.dal.js')
+
+describe('Company Contacts - Fetch Abstraction Alert Licences Dal', () => {
+  let licence
+  let licenceA
+  let licenceB
+
+  before(async () => {
+    licence = await LicenceHelper.add()
+    licenceA = await LicenceHelper.add({ licenceRef: '01/111/AA' })
+    licenceB = await LicenceHelper.add({ licenceRef: '01/222/AA' })
+  })
+
+  after(async () => {
+    await licence.$query().delete()
+    await licenceA.$query().delete()
+    await licenceB.$query().delete()
+  })
+
+  describe('when there are matching licences', () => {
+    it('returns the licences', async () => {
+      const result = await FetchAbstractionAlertLicencesDal.go([licence.id])
+
+      expect(result).to.equal([
+        {
+          id: licence.id,
+          licenceRef: licence.licenceRef,
+          revokedDate: null,
+          lapsedDate: null,
+          expiredDate: null
+        }
+      ])
+    })
+  })
+
+  describe('when there are multiple matching licences', () => {
+    it('returns the licences ordered by licenceRef', async () => {
+      const result = await FetchAbstractionAlertLicencesDal.go([licenceB.id, licenceA.id])
+
+      expect(result).to.equal([
+        {
+          id: licenceA.id,
+          licenceRef: licenceA.licenceRef,
+          revokedDate: null,
+          lapsedDate: null,
+          expiredDate: null
+        },
+        {
+          id: licenceB.id,
+          licenceRef: licenceB.licenceRef,
+          revokedDate: null,
+          lapsedDate: null,
+          expiredDate: null
+        }
+      ])
+    })
+  })
+
+  describe('when abstractionAlertLicences is null', () => {
+    it('returns an empty array', async () => {
+      const result = await FetchAbstractionAlertLicencesDal.go(null)
+
+      expect(result).to.equal([])
+    })
+  })
+
+  describe('when none of the IDs match any licences', () => {
+    it('returns an empty array', async () => {
+      const result = await FetchAbstractionAlertLicencesDal.go([generateUUID()])
+
+      expect(result).to.equal([])
+    })
+  })
+})

--- a/test/presenters/company-contacts/contact-details.presenter.test.js
+++ b/test/presenters/company-contacts/contact-details.presenter.test.js
@@ -131,9 +131,6 @@ describe('Company Contacts - Contact Details presenter', () => {
 
         describe('when the abstractionAlertType is "some"', () => {
           beforeEach(() => {
-            companyContact.abstractionAlerts = true
-            companyContact.abstractionAlertLicences = [generateUUID()]
-
             licences = [
               {
                 id: generateUUID(),
@@ -143,6 +140,9 @@ describe('Company Contacts - Contact Details presenter', () => {
                 revokedDate: null
               }
             ]
+
+            companyContact.abstractionAlerts = true
+            companyContact.abstractionAlertLicences = [licences[0].id]
           })
 
           it('returns the licence refs', () => {

--- a/test/presenters/company-contacts/contact-details.presenter.test.js
+++ b/test/presenters/company-contacts/contact-details.presenter.test.js
@@ -9,6 +9,8 @@ const { expect } = Code
 
 // Test helpers
 const CustomersFixtures = require('../../support/fixtures/customers.fixture.js')
+const { generateLicenceRef } = require('../../support/helpers/licence.helper.js')
+const { generateUUID } = require('../../../app/lib/general.lib.js')
 
 // Thing under test
 const ContactDetailsPresenter = require('../../../app/presenters/company-contacts/contact-details.presenter.js')
@@ -16,16 +18,19 @@ const ContactDetailsPresenter = require('../../../app/presenters/company-contact
 describe('Company Contacts - Contact Details presenter', () => {
   let companyContact
   let company
+  let licences
 
   beforeEach(() => {
     companyContact = CustomersFixtures.companyContact()
 
     company = CustomersFixtures.company()
+
+    licences = []
   })
 
   describe('when called', () => {
     it('returns page data for the view', () => {
-      const result = ContactDetailsPresenter.go(company, companyContact)
+      const result = ContactDetailsPresenter.go(company, companyContact, licences)
 
       expect(result).to.equal({
         additionalContact: true,
@@ -34,10 +39,11 @@ describe('Company Contacts - Contact Details presenter', () => {
           text: 'Go back to licence holder contacts'
         },
         contact: {
-          abstractionAlerts: 'No',
+          abstractionAlertsLabel: 'No',
           created: '1 January 2022 by nexus6.hunter@offworld.net',
           email: 'rachael.tyrell@tyrellcorp.com',
           lastUpdated: '1 January 2022 by void.kampff@tyrell.com',
+          licences: [],
           name: 'Rachael Tyrell'
         },
         editContactLink: `/system/company-contacts/setup/${companyContact.id}/edit`,
@@ -51,7 +57,7 @@ describe('Company Contacts - Contact Details presenter', () => {
       describe('the "additionalContact" property', () => {
         describe('when the contact is an additional contact', () => {
           it('returns true', () => {
-            const result = ContactDetailsPresenter.go(company, companyContact)
+            const result = ContactDetailsPresenter.go(company, companyContact, licences)
 
             expect(result.additionalContact).to.be.true()
           })
@@ -63,7 +69,7 @@ describe('Company Contacts - Contact Details presenter', () => {
           })
 
           it('returns false', () => {
-            const result = ContactDetailsPresenter.go(company, companyContact)
+            const result = ContactDetailsPresenter.go(company, companyContact, licences)
 
             expect(result.additionalContact).to.be.false()
           })
@@ -73,7 +79,7 @@ describe('Company Contacts - Contact Details presenter', () => {
       describe('the "created" property', () => {
         describe('when there is "createdByUser"', () => {
           it('returns the created text with the created at date and the created by username', () => {
-            const result = ContactDetailsPresenter.go(company, companyContact)
+            const result = ContactDetailsPresenter.go(company, companyContact, licences)
 
             expect(result.contact.created).to.equal('1 January 2022 by nexus6.hunter@offworld.net')
           })
@@ -85,7 +91,7 @@ describe('Company Contacts - Contact Details presenter', () => {
           })
 
           it('returns the created text with the created at date', () => {
-            const result = ContactDetailsPresenter.go(company, companyContact)
+            const result = ContactDetailsPresenter.go(company, companyContact, licences)
 
             expect(result.contact.created).to.equal('1 January 2022')
           })
@@ -95,7 +101,7 @@ describe('Company Contacts - Contact Details presenter', () => {
       describe('the "lastUpdated" property', () => {
         describe('when there is "updatedByUser"', () => {
           it('returns the created text with the updated at date and the updated by username', () => {
-            const result = ContactDetailsPresenter.go(company, companyContact)
+            const result = ContactDetailsPresenter.go(company, companyContact, licences)
 
             expect(result.contact.lastUpdated).to.equal('1 January 2022 by void.kampff@tyrell.com')
           })
@@ -107,9 +113,42 @@ describe('Company Contacts - Contact Details presenter', () => {
           })
 
           it('returns the created text with the created at date', () => {
-            const result = ContactDetailsPresenter.go(company, companyContact)
+            const result = ContactDetailsPresenter.go(company, companyContact, licences)
 
             expect(result.contact.lastUpdated).to.equal('1 January 2022')
+          })
+        })
+      })
+
+      describe('the "licences" property', () => {
+        describe('when the abstractionAlertType is not "some"', () => {
+          it('returns an empty array', () => {
+            const result = ContactDetailsPresenter.go(company, companyContact, licences)
+
+            expect(result.contact.licences).to.equal([])
+          })
+        })
+
+        describe('when the abstractionAlertType is "some"', () => {
+          beforeEach(() => {
+            companyContact.abstractionAlerts = true
+            companyContact.abstractionAlertLicences = [generateUUID()]
+
+            licences = [
+              {
+                id: generateUUID(),
+                licenceRef: generateLicenceRef(),
+                lapsedDate: null,
+                expiredDate: null,
+                revokedDate: null
+              }
+            ]
+          })
+
+          it('returns the licence refs', () => {
+            const result = ContactDetailsPresenter.go(company, companyContact, licences)
+
+            expect(result.contact.licences).to.equal([licences[0].licenceRef])
           })
         })
       })

--- a/test/services/company-contacts/view-contact-details.service.test.js
+++ b/test/services/company-contacts/view-contact-details.service.test.js
@@ -13,6 +13,7 @@ const CustomersFixtures = require('../../support/fixtures/customers.fixture.js')
 const YarStub = require('../../support/stubs/yar.stub.js')
 
 // Things we need to stub
+const AbstractionAlertLicencesDal = require('../../../app/dal/company-contacts/fetch-abstraction-alert-licences.dal.js')
 const FetchCompanyContactDetailsService = require('../../../app/services/company-contacts/fetch-company-contact-details.service.js')
 const FetchCompanyService = require('../../../app/services/companies/fetch-company.service.js')
 
@@ -25,15 +26,16 @@ describe('Company Contacts - View Contact Details Service', () => {
   let companyContact
   let yarStub
 
-  beforeEach(async () => {
+  beforeEach(() => {
     auth = { credentials: { roles: [] } }
 
     companyContact = CustomersFixtures.companyContact()
 
     company = CustomersFixtures.company()
 
-    Sinon.stub(FetchCompanyService, 'go').returns(company)
-    Sinon.stub(FetchCompanyContactDetailsService, 'go').returns(companyContact)
+    Sinon.stub(AbstractionAlertLicencesDal, 'go').resolves([])
+    Sinon.stub(FetchCompanyService, 'go').resolves(company)
+    Sinon.stub(FetchCompanyContactDetailsService, 'go').resolves(companyContact)
 
     yarStub = YarStub.build(Sinon)
     yarStub.flash.returns([{ titleText: 'Updated', text: 'Contact details updated.' }])
@@ -60,10 +62,11 @@ describe('Company Contacts - View Contact Details Service', () => {
           text: 'Go back to licence holder contacts'
         },
         contact: {
-          abstractionAlerts: 'No',
+          abstractionAlertsLabel: 'No',
           created: '1 January 2022 by nexus6.hunter@offworld.net',
           email: 'rachael.tyrell@tyrellcorp.com',
           lastUpdated: '1 January 2022 by void.kampff@tyrell.com',
+          licences: [],
           name: 'Rachael Tyrell'
         },
         editContactLink: `/system/company-contacts/setup/${companyContact.id}/edit`,

--- a/test/services/company-contacts/view-contact-details.service.test.js
+++ b/test/services/company-contacts/view-contact-details.service.test.js
@@ -13,7 +13,7 @@ const CustomersFixtures = require('../../support/fixtures/customers.fixture.js')
 const YarStub = require('../../support/stubs/yar.stub.js')
 
 // Things we need to stub
-const AbstractionAlertLicencesDal = require('../../../app/dal/company-contacts/fetch-abstraction-alert-licences.dal.js')
+const FetchAbstractionAlertLicencesDal = require('../../../app/dal/company-contacts/fetch-abstraction-alert-licences.dal.js')
 const FetchCompanyContactDetailsService = require('../../../app/services/company-contacts/fetch-company-contact-details.service.js')
 const FetchCompanyService = require('../../../app/services/companies/fetch-company.service.js')
 
@@ -33,7 +33,7 @@ describe('Company Contacts - View Contact Details Service', () => {
 
     company = CustomersFixtures.company()
 
-    Sinon.stub(AbstractionAlertLicencesDal, 'go').resolves([])
+    Sinon.stub(FetchAbstractionAlertLicencesDal, 'go').resolves([])
     Sinon.stub(FetchCompanyService, 'go').resolves(company)
     Sinon.stub(FetchCompanyContactDetailsService, 'go').resolves(companyContact)
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5631

This change adds the licences to the company contact details page.

The licences are taken from the abstraction alert licences, as these licences could have been saved at any time, the licence may have ended, this edge case will be handle in another change. 

