### PR TITLE
Add warning for ended licences company details page

### DIFF
--- a/app/models/licence.model.js
+++ b/app/models/licence.model.js
@@ -9,7 +9,7 @@ const { Model } = require('objection')
 
 const BaseModel = require('./base.model.js')
 const { compareDates } = require('../lib/dates.lib.js')
-const { timestampForPostgres } = require('../lib/general.lib.js')
+const { timestampForPostgres, today } = require('../lib/general.lib.js')
 
 class LicenceModel extends BaseModel {
   static get tableName() {
@@ -265,6 +265,22 @@ class LicenceModel extends BaseModel {
     }
 
     return this.licenceVersions[0]
+  }
+
+  /**
+   * Determine if the licence has ended
+   *
+   * A licence is considered ended if any of its end dates (revoked, lapsed, or expired) are set and that date is today
+   * or in the past.
+   *
+   * @returns {boolean}
+   */
+  $ended() {
+    const endDates = [this.revokedDate, this.lapsedDate, this.expiredDate]
+
+    return endDates.some((date) => {
+      return date && date <= today()
+    })
   }
 
   /**

--- a/app/presenters/company-contacts/contact-details.presenter.js
+++ b/app/presenters/company-contacts/contact-details.presenter.js
@@ -28,7 +28,8 @@ function go(company, companyContact, licences) {
     editContactLink: `/system/company-contacts/setup/${companyContact.id}/edit`,
     pageTitle: `Contact details for ${companyContact.contact.$name()}`,
     pageTitleCaption: company.name,
-    removeContactLink: `/system/company-contacts/${companyContact.id}/remove`
+    removeContactLink: `/system/company-contacts/${companyContact.id}/remove`,
+    warning: _warning(licences)
   }
 }
 
@@ -74,6 +75,22 @@ function _licences(abstractionAlertType, licences) {
     return licence.licenceRef
   })
 }
+
+function _warning(licences) {
+  const endedLicences = licences.filter((licence) => {
+    return licence.$ended()
+  })
+
+  if (endedLicences.length === 0) {
+    return null
+  }
+
+  return {
+    text: 'One or more licences for abstraction alerts have ended. No alerts will be sent for these.',
+    iconFallbackText: 'Warning'
+  }
+}
+
 module.exports = {
   go
 }

--- a/test/models/licence.model.test.js
+++ b/test/models/licence.model.test.js
@@ -45,7 +45,7 @@ const UserModel = require('../../app/models/user.model.js')
 const WorkflowHelper = require('../support/helpers/workflow.helper.js')
 const WorkflowModel = require('../../app/models/workflow.model.js')
 const { generateUUID, today } = require('../../app/lib/general.lib.js')
-const { tomorrow } = require('../support/general.js')
+const { tomorrow, yesterday } = require('../support/general.js')
 
 // Thing under test
 const LicenceModel = require('../../app/models/licence.model.js')
@@ -665,6 +665,109 @@ describe('Licence model', () => {
             startDate: otherLicenceVersions[2].startDate,
             status: 'current'
           })
+        })
+      })
+    })
+  })
+
+  describe('$ended', () => {
+    let endedRecord
+    let expiredDate
+    let lapsedDate
+    let revokedDate
+
+    beforeEach(() => {
+      expiredDate = null
+      lapsedDate = null
+      revokedDate = null
+    })
+
+    describe('when a licence has ended', () => {
+      describe('because is has expired', () => {
+        beforeEach(() => {
+          expiredDate = yesterday()
+
+          endedRecord = LicenceModel.fromJson({ expiredDate, lapsedDate, revokedDate })
+        })
+
+        it('returns true', () => {
+          const result = endedRecord.$ended()
+
+          expect(result).to.be.true()
+        })
+      })
+
+      describe('because is has lapsed', () => {
+        beforeEach(() => {
+          lapsedDate = yesterday()
+
+          endedRecord = LicenceModel.fromJson({ expiredDate, lapsedDate, revokedDate })
+        })
+
+        it('returns true', () => {
+          const result = endedRecord.$ended()
+
+          expect(result).to.be.true()
+        })
+      })
+
+      describe('because is has been revoked', () => {
+        beforeEach(() => {
+          revokedDate = yesterday()
+
+          endedRecord = LicenceModel.fromJson({ expiredDate, lapsedDate, revokedDate })
+        })
+
+        it('returns true', () => {
+          const result = endedRecord.$ended()
+
+          expect(result).to.be.true()
+        })
+      })
+    })
+
+    describe('when a licence has not ended', () => {
+      describe('because an end date is in the future', () => {
+        beforeEach(() => {
+          expiredDate = tomorrow()
+
+          endedRecord = LicenceModel.fromJson({ expiredDate, lapsedDate, revokedDate })
+        })
+
+        it('returns false', () => {
+          const result = endedRecord.$ended()
+
+          expect(result).to.be.false()
+        })
+      })
+
+      describe('because an end date is today', () => {
+        beforeEach(() => {
+          revokedDate = today()
+
+          endedRecord = LicenceModel.fromJson({ expiredDate, lapsedDate, revokedDate })
+        })
+
+        it('returns true', () => {
+          const result = endedRecord.$ended()
+
+          expect(result).to.be.true()
+        })
+      })
+
+      describe('because all end dates are in the future', () => {
+        beforeEach(() => {
+          expiredDate = tomorrow()
+          lapsedDate = tomorrow()
+          revokedDate = tomorrow()
+
+          endedRecord = LicenceModel.fromJson({ expiredDate, lapsedDate, revokedDate })
+        })
+
+        it('returns false', () => {
+          const result = endedRecord.$ended()
+
+          expect(result).to.be.false()
         })
       })
     })

--- a/test/models/licence.model.test.js
+++ b/test/models/licence.model.test.js
@@ -724,6 +724,20 @@ describe('Licence model', () => {
           expect(result).to.be.true()
         })
       })
+
+      describe('because an end date is today', () => {
+        beforeEach(() => {
+          revokedDate = today()
+
+          endedRecord = LicenceModel.fromJson({ expiredDate, lapsedDate, revokedDate })
+        })
+
+        it('returns true', () => {
+          const result = endedRecord.$ended()
+
+          expect(result).to.be.true()
+        })
+      })
     })
 
     describe('when a licence has not ended', () => {
@@ -738,20 +752,6 @@ describe('Licence model', () => {
           const result = endedRecord.$ended()
 
           expect(result).to.be.false()
-        })
-      })
-
-      describe('because an end date is today', () => {
-        beforeEach(() => {
-          revokedDate = today()
-
-          endedRecord = LicenceModel.fromJson({ expiredDate, lapsedDate, revokedDate })
-        })
-
-        it('returns true', () => {
-          const result = endedRecord.$ended()
-
-          expect(result).to.be.true()
         })
       })
 

--- a/test/presenters/company-contacts/contact-details.presenter.test.js
+++ b/test/presenters/company-contacts/contact-details.presenter.test.js
@@ -9,8 +9,10 @@ const { expect } = Code
 
 // Test helpers
 const CustomersFixtures = require('../../support/fixtures/customers.fixture.js')
+const LicenceModel = require('../../../app/models/licence.model.js')
 const { generateLicenceRef } = require('../../support/helpers/licence.helper.js')
 const { generateUUID } = require('../../../app/lib/general.lib.js')
+const { yesterday } = require('../../support/general.js')
 
 // Thing under test
 const ContactDetailsPresenter = require('../../../app/presenters/company-contacts/contact-details.presenter.js')
@@ -47,6 +49,7 @@ describe('Company Contacts - Contact Details presenter', () => {
           name: 'Rachael Tyrell'
         },
         editContactLink: `/system/company-contacts/setup/${companyContact.id}/edit`,
+        warning: null,
         pageTitle: 'Contact details for Rachael Tyrell',
         pageTitleCaption: 'Tyrell Corporation',
         removeContactLink: `/system/company-contacts/${companyContact.id}/remove`
@@ -132,13 +135,13 @@ describe('Company Contacts - Contact Details presenter', () => {
         describe('when the abstractionAlertType is "some"', () => {
           beforeEach(() => {
             licences = [
-              {
+              LicenceModel.fromJson({
                 id: generateUUID(),
                 licenceRef: generateLicenceRef(),
                 lapsedDate: null,
                 expiredDate: null,
                 revokedDate: null
-              }
+              })
             ]
 
             companyContact.abstractionAlerts = true
@@ -149,6 +152,39 @@ describe('Company Contacts - Contact Details presenter', () => {
             const result = ContactDetailsPresenter.go(company, companyContact, licences)
 
             expect(result.contact.licences).to.equal([licences[0].licenceRef])
+          })
+        })
+      })
+    })
+
+    describe('the "warning" property', () => {
+      describe('when no licences have ended', () => {
+        it('returns null', () => {
+          const result = ContactDetailsPresenter.go(company, companyContact, licences)
+
+          expect(result.warning).to.be.null()
+        })
+      })
+
+      describe('when one or more licences have ended', () => {
+        beforeEach(() => {
+          licences = [
+            LicenceModel.fromJson({
+              id: generateUUID(),
+              licenceRef: generateLicenceRef(),
+              lapsedDate: null,
+              expiredDate: yesterday(),
+              revokedDate: null
+            })
+          ]
+        })
+
+        it('returns a warning object', () => {
+          const result = ContactDetailsPresenter.go(company, companyContact, licences)
+
+          expect(result.warning).to.equal({
+            text: 'One or more licences for abstraction alerts have ended. No alerts will be sent for these.',
+            iconFallbackText: 'Warning'
           })
         })
       })

--- a/test/services/company-contacts/view-contact-details.service.test.js
+++ b/test/services/company-contacts/view-contact-details.service.test.js
@@ -51,11 +51,6 @@ describe('Company Contacts - View Contact Details Service', () => {
 
       expect(result).to.equal({
         activeSecondaryNav: 'contact-details',
-        notification: {
-          text: 'Contact details updated.',
-          titleText: 'Updated'
-        },
-        roles: [],
         additionalContact: true,
         backLink: {
           href: `/system/companies/${company.id}/contacts`,
@@ -70,9 +65,15 @@ describe('Company Contacts - View Contact Details Service', () => {
           name: 'Rachael Tyrell'
         },
         editContactLink: `/system/company-contacts/setup/${companyContact.id}/edit`,
+        notification: {
+          text: 'Contact details updated.',
+          titleText: 'Updated'
+        },
         pageTitle: 'Contact details for Rachael Tyrell',
         pageTitleCaption: 'Tyrell Corporation',
-        removeContactLink: `/system/company-contacts/${companyContact.id}/remove`
+        removeContactLink: `/system/company-contacts/${companyContact.id}/remove`,
+        roles: [],
+        warning: null
       })
     })
   })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5631

When a licence has ended, if could still be 'saved' in the abstraction alert licences. When this is the case we want to show a warnign to the user.

This change adds a warning to the user when any licence from the abstraction alert licences has ended.

This change also introduces a '$ended' instance method for the lenience model.