### PR TITLE
Handle no licences company contact page

### DIFF
--- a/app/presenters/company-contacts/setup/abstraction-alerts.presenter.js
+++ b/app/presenters/company-contacts/setup/abstraction-alerts.presenter.js
@@ -15,16 +15,17 @@ const { checkUrl } = require('../../../lib/check-page.lib.js')
  * @returns {object} The data formatted for the view template
  */
 function go(session) {
-  const { id: sessionId, company } = session
+  const { id: sessionId, company, licences } = session
 
   return {
+    abstractionAlerts: session.abstractionAlerts ?? null,
     backLink: {
       href: checkUrl(session, `/system/company-contacts/setup/${sessionId}/contact-email`),
       text: 'Back'
     },
     pageTitle: 'Should the contact get abstraction alerts?',
     pageTitleCaption: company.name,
-    abstractionAlerts: session.abstractionAlerts ?? null
+    showSomeLicences: licences.length > 0
   }
 }
 

--- a/app/views/company-contacts/setup/abstraction-alerts.njk
+++ b/app/views/company-contacts/setup/abstraction-alerts.njk
@@ -21,7 +21,7 @@
           value: "some",
           text: "Yes, for some licences",
           checked: abstractionAlerts === 'some'
-        },
+        } if showSomeLicences,
         {
           divider: "or"
         },

--- a/app/views/company-contacts/setup/abstraction-alerts.njk
+++ b/app/views/company-contacts/setup/abstraction-alerts.njk
@@ -24,7 +24,7 @@
         } if showSomeLicences,
         {
           divider: "or"
-        },
+        } if showSomeLicences,
         {
           value: "no",
           text: "No",

--- a/test/presenters/company-contacts/setup/abstraction-alerts.presenter.test.js
+++ b/test/presenters/company-contacts/setup/abstraction-alerts.presenter.test.js
@@ -21,7 +21,7 @@ describe('Company Contacts - Setup - Abstraction Alerts Presenter', () => {
   beforeEach(() => {
     company = CustomersFixtures.company()
 
-    session = { id: generateUUID(), company }
+    session = { id: generateUUID(), company, licences: [] }
   })
 
   describe('when called', () => {
@@ -35,7 +35,8 @@ describe('Company Contacts - Setup - Abstraction Alerts Presenter', () => {
           text: 'Back'
         },
         pageTitle: 'Should the contact get abstraction alerts?',
-        pageTitleCaption: 'Tyrell Corporation'
+        pageTitleCaption: 'Tyrell Corporation',
+        showSomeLicences: false
       })
     })
 
@@ -57,6 +58,28 @@ describe('Company Contacts - Setup - Abstraction Alerts Presenter', () => {
           const result = AbstractionAlertsPresenter.go(session)
 
           expect(result.abstractionAlerts).to.be.null()
+        })
+      })
+    })
+
+    describe('the "showSomeLicences" property', () => {
+      describe('when there are licences', () => {
+        beforeEach(() => {
+          session.licences = [generateUUID()]
+        })
+
+        it('returns true', () => {
+          const result = AbstractionAlertsPresenter.go(session)
+
+          expect(result.showSomeLicences).to.true()
+        })
+      })
+
+      describe('when there are no licences', () => {
+        it('returns false', () => {
+          const result = AbstractionAlertsPresenter.go(session)
+
+          expect(result.showSomeLicences).to.false()
         })
       })
     })

--- a/test/services/company-contacts/setup/submit-abstraction-alerts.service.test.js
+++ b/test/services/company-contacts/setup/submit-abstraction-alerts.service.test.js
@@ -30,7 +30,7 @@ describe('Company Contacts - Setup - Abstraction Alerts Service', () => {
   beforeEach(async () => {
     company = CustomersFixtures.company()
 
-    sessionData = { company }
+    sessionData = { company, licences: [] }
 
     payload = { abstractionAlerts: 'yes' }
 
@@ -47,7 +47,7 @@ describe('Company Contacts - Setup - Abstraction Alerts Service', () => {
 
   describe('when called', () => {
     it('saves the submitted value', async () => {
-      await SubmitAbstractionAlertsService.go(session.id, payload)
+      await SubmitAbstractionAlertsService.go(session.id, payload, yarStub)
 
       expect(session).to.equal({
         ...session,
@@ -59,7 +59,7 @@ describe('Company Contacts - Setup - Abstraction Alerts Service', () => {
     describe('the redirect URL', () => {
       describe('when "abstractionAlerts" is "yes"', () => {
         it('redirects to the check page', async () => {
-          const result = await SubmitAbstractionAlertsService.go(session.id, payload)
+          const result = await SubmitAbstractionAlertsService.go(session.id, payload, yarStub)
 
           expect(result).to.equal({ redirectUrl: `/system/company-contacts/setup/${session.id}/check` })
         })
@@ -71,7 +71,7 @@ describe('Company Contacts - Setup - Abstraction Alerts Service', () => {
         })
 
         it('redirects to the check page', async () => {
-          const result = await SubmitAbstractionAlertsService.go(session.id, payload)
+          const result = await SubmitAbstractionAlertsService.go(session.id, payload, yarStub)
 
           expect(result).to.equal({ redirectUrl: `/system/company-contacts/setup/${session.id}/check` })
         })
@@ -83,7 +83,7 @@ describe('Company Contacts - Setup - Abstraction Alerts Service', () => {
         })
 
         it('redirects to the licences page', async () => {
-          const result = await SubmitAbstractionAlertsService.go(session.id, payload)
+          const result = await SubmitAbstractionAlertsService.go(session.id, payload, yarStub)
 
           expect(result).to.equal({ redirectUrl: `/system/company-contacts/setup/${session.id}/licences` })
         })
@@ -146,7 +146,7 @@ describe('Company Contacts - Setup - Abstraction Alerts Service', () => {
     })
 
     it('returns page data for the view, with errors', async () => {
-      const result = await SubmitAbstractionAlertsService.go(session.id, payload)
+      const result = await SubmitAbstractionAlertsService.go(session.id, payload, yarStub)
 
       expect(result).to.equal({
         abstractionAlerts: null,
@@ -167,7 +167,8 @@ describe('Company Contacts - Setup - Abstraction Alerts Service', () => {
           }
         },
         pageTitle: 'Should the contact get abstraction alerts?',
-        pageTitleCaption: 'Tyrell Corporation'
+        pageTitleCaption: 'Tyrell Corporation',
+        showSomeLicences: false
       })
     })
   })

--- a/test/services/company-contacts/setup/view-abstraction-alerts.service.test.js
+++ b/test/services/company-contacts/setup/view-abstraction-alerts.service.test.js
@@ -26,7 +26,7 @@ describe('Company Contacts - Setup - Abstraction Alerts Service', () => {
   beforeEach(async () => {
     company = CustomersFixtures.company()
 
-    sessionData = { company }
+    sessionData = { company, licences: [] }
 
     session = SessionModelStub.build(Sinon, sessionData)
 
@@ -48,7 +48,8 @@ describe('Company Contacts - Setup - Abstraction Alerts Service', () => {
           text: 'Back'
         },
         pageTitle: 'Should the contact get abstraction alerts?',
-        pageTitleCaption: 'Tyrell Corporation'
+        pageTitleCaption: 'Tyrell Corporation',
+        showSomeLicences: false
       })
     })
   })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5631

It is possible for a company to have no 'active' licences. When this happens, we need to hide the 'show all licences' option so we don't show an empty page for licences.

This change checks if there are licences, if there is we show the 'Show all licences' option.