### PR TITLE
Handle no licences company contact page edit

### DIFF
--- a/app/services/company-contacts/setup/initiate-edit-session.service.js
+++ b/app/services/company-contacts/setup/initiate-edit-session.service.js
@@ -9,7 +9,6 @@ const CreateSessionDal = require('../../../dal/create-session.dal.js')
 const FetchCompanyContactDal = require('../../../dal/company-contacts/setup/fetch-company-contact.dal.js')
 const FetchCompanyLicencesDal = require('../../../dal/company-contacts/fetch-company-licences.dal.js')
 const { formatEmail } = require('../../../presenters/base.presenter.js')
-const { licences } = require('../../../../test/support/fixtures/customers.fixture.js')
 
 /**
  * Initiates the session record used for setting up an existing company contact

--- a/app/services/company-contacts/setup/initiate-edit-session.service.js
+++ b/app/services/company-contacts/setup/initiate-edit-session.service.js
@@ -9,6 +9,7 @@ const CreateSessionDal = require('../../../dal/create-session.dal.js')
 const FetchCompanyContactDal = require('../../../dal/company-contacts/setup/fetch-company-contact.dal.js')
 const FetchCompanyLicencesDal = require('../../../dal/company-contacts/fetch-company-licences.dal.js')
 const { formatEmail } = require('../../../presenters/base.presenter.js')
+const { licences } = require('../../../../test/support/fixtures/customers.fixture.js')
 
 /**
  * Initiates the session record used for setting up an existing company contact
@@ -22,10 +23,7 @@ async function go(companyContactId) {
 
   const licences = await FetchCompanyLicencesDal.go(companyContact.company.id)
 
-  const data = {
-    ..._formatDataForJourney(companyContact),
-    licences
-  }
+  const data = _formatDataForJourney(companyContact, licences)
 
   return CreateSessionDal.go(data)
 }
@@ -42,15 +40,18 @@ async function go(companyContactId) {
  *
  * @private
  */
-function _formatDataForJourney(companyContact) {
+function _formatDataForJourney(companyContact, licences) {
   const { abstractionAlertLicences, company, contact } = companyContact
+
+  const abstractionAlerts = companyContact.$abstractionAlertType()
 
   return {
     abstractionAlertLicences,
-    abstractionAlerts: companyContact.$abstractionAlertType(),
+    abstractionAlerts: licences.length > 0 ? abstractionAlerts : 'no',
     company,
     companyContact,
     email: formatEmail(contact.email),
+    licences,
     name: contact.$name()
   }
 }

--- a/test/services/company-contacts/setup/initiate-edit-session.service.test.js
+++ b/test/services/company-contacts/setup/initiate-edit-session.service.test.js
@@ -120,7 +120,7 @@ describe('Company Contacts - Setup - Initiate edit Session service', () => {
             stubFetchCompanyLicencesDal.resolves([])
           })
 
-          it('returns "some"', async () => {
+          it('returns "no"', async () => {
             const result = await InitiateEditSessionService.go(companyContact.id)
 
             const matchingSession = await SessionModel.query().findById(result.id)

--- a/test/services/company-contacts/setup/initiate-edit-session.service.test.js
+++ b/test/services/company-contacts/setup/initiate-edit-session.service.test.js
@@ -28,6 +28,7 @@ describe('Company Contacts - Setup - Initiate edit Session service', () => {
   let contact
   let licences
   let stubFetchCompanyContactDal
+  let stubFetchCompanyLicencesDal
 
   beforeEach(() => {
     company = CustomersFixtures.company()
@@ -44,8 +45,7 @@ describe('Company Contacts - Setup - Initiate edit Session service', () => {
     })
 
     stubFetchCompanyContactDal = Sinon.stub(FetchCompanyContactDal, 'go').returns(companyContact)
-
-    Sinon.stub(FetchCompanyLicencesDal, 'go').returns(licences)
+    stubFetchCompanyLicencesDal = Sinon.stub(FetchCompanyLicencesDal, 'go').returns(licences)
   })
 
   afterEach(() => {
@@ -85,12 +85,48 @@ describe('Company Contacts - Setup - Initiate edit Session service', () => {
           stubFetchCompanyContactDal.resolves(companyContact)
         })
 
-        it('returns "some"', async () => {
-          const result = await InitiateEditSessionService.go(companyContact.id)
+        describe('and there are active licences', () => {
+          describe('and at least one licence matches an "abstractionAlertLicences"', () => {
+            beforeEach(() => {
+              stubFetchCompanyLicencesDal.resolves([companyContact.abstractionAlertLicences[0].id])
+            })
 
-          const matchingSession = await SessionModel.query().findById(result.id)
+            it('returns "some"', async () => {
+              const result = await InitiateEditSessionService.go(companyContact.id)
 
-          expect(matchingSession.abstractionAlerts).to.equal('some')
+              const matchingSession = await SessionModel.query().findById(result.id)
+
+              expect(matchingSession.abstractionAlerts).to.equal('some')
+            })
+          })
+
+          describe('and no licences match the "abstractionAlertLicences"', () => {
+            beforeEach(() => {
+              stubFetchCompanyLicencesDal.resolves(generateUUID())
+            })
+
+            it('returns "some"', async () => {
+              const result = await InitiateEditSessionService.go(companyContact.id)
+
+              const matchingSession = await SessionModel.query().findById(result.id)
+
+              expect(matchingSession.abstractionAlerts).to.equal('some')
+            })
+          })
+        })
+
+        describe('and there are no active licences', () => {
+          beforeEach(() => {
+            stubFetchCompanyLicencesDal.resolves([])
+          })
+
+          it('returns "some"', async () => {
+            const result = await InitiateEditSessionService.go(companyContact.id)
+
+            const matchingSession = await SessionModel.query().findById(result.id)
+
+            expect(matchingSession.abstractionAlerts).to.equal('no')
+          })
         })
       })
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5631

It is possible for a company to have no 'active' licences. When this happens, we hide the 'show all licences' option so we don't show an empty page for licences.

This change updates the edit session to default the abstraction alert to null when there are no licences, overwiring the users' previous selection.