### PR TITLE
Update existing checkboxes to use bracket notation

### DIFF
--- a/app/lib/submit-page.lib.js
+++ b/app/lib/submit-page.lib.js
@@ -30,52 +30,6 @@ function clearFilters(payload, yar, filterKey) {
 }
 
 /**
- * Normalizes checkbox form data to always be an array
- *
- * HTML checkboxes behave inconsistently when submitted:
- * - No selection: property is undefined
- * - Single selection: property is a string
- * - Multiple selections: property is an array
- *
- * This helper ensures the property always exists as an array, making it easier to process checkbox data consistently
- * throughout the application.
- *
- * @param {object} payload - The form payload object to be modified in place
- * @param {string} key - The property name in the payload to normalize
- *
- * @returns {void} The payload object is modified directly
- *
- * @example
- * // No selection
- * const payload1 = {}
- * handleOneOptionSelected(payload1, 'options')
- * // payload1.options is now []
- *
- * @example
- * // Single selection
- * const payload2 = { options: 'value1' }
- * handleOneOptionSelected(payload2, 'options')
- * // payload2.options is now ['value1']
- *
- * @example
- * // Multiple selections (already an array, unchanged)
- * const payload3 = { options: ['value1', 'value2'] }
- * handleOneOptionSelected(payload3, 'options')
- * // payload3.options remains ['value1', 'value2']
- */
-function handleOneOptionSelected(payload, key) {
-  if (!payload?.[key]) {
-    payload[key] = []
-
-    return
-  }
-
-  if (!Array.isArray(payload?.[key])) {
-    payload[key] = [payload?.[key]]
-  }
-}
-
-/**
  * Retrieves saved filters from session storage and determines if any filters are active
  *
  * This function fetches filter data from the session using the provided key and checks whether any filter values
@@ -133,6 +87,5 @@ function processSavedFilters(yar, filterKey) {
 
 module.exports = {
   clearFilters,
-  handleOneOptionSelected,
   processSavedFilters
 }

--- a/app/services/bill-runs/review/submit-review.service.js
+++ b/app/services/bill-runs/review/submit-review.service.js
@@ -5,7 +5,7 @@
  * @module SubmitReviewService
  */
 
-const { clearFilters, handleOneOptionSelected } = require('../../../lib/submit-page.lib.js')
+const { clearFilters } = require('../../../lib/submit-page.lib.js')
 
 /**
  * Updates the session cookie with the filter data needed for the '/bill-runs/review/{id}' page
@@ -23,8 +23,8 @@ async function go(billRunId, payload, yar) {
     return
   }
 
-  handleOneOptionSelected(payload, 'issues')
-  handleOneOptionSelected(payload, 'progress')
+  payload.issues ??= []
+  payload.progress ??= []
 
   _save(payload, yar, filterKey)
 }

--- a/app/services/bill-runs/submit-index-bill-runs.service.js
+++ b/app/services/bill-runs/submit-index-bill-runs.service.js
@@ -12,7 +12,7 @@ const FetchRegionsService = require('./setup/fetch-regions.service.js')
 const IndexBillRunsPresenter = require('../../presenters/bill-runs/index-bill-runs.presenter.js')
 const IndexValidator = require('../../validators/bill-runs/index.validator.js')
 const PaginatorPresenter = require('../../presenters/paginator.presenter.js')
-const { clearFilters, handleOneOptionSelected } = require('../../lib/submit-page.lib.js')
+const { clearFilters } = require('../../lib/submit-page.lib.js')
 
 /**
  * Handles validation of the requested filters, saving them to the session else re-rendering the page if invalid
@@ -33,9 +33,9 @@ async function go(payload, yar, page) {
     return {}
   }
 
-  handleOneOptionSelected(payload, 'regions')
-  handleOneOptionSelected(payload, 'runTypes')
-  handleOneOptionSelected(payload, 'statuses')
+  payload.regions ??= []
+  payload.runTypes ??= []
+  payload.statuses ??= []
 
   const regions = await FetchRegionsService.go()
   const error = _validate(payload, regions)

--- a/app/services/licences/supplementary/submit-mark-for-supplementary-billing.service.js
+++ b/app/services/licences/supplementary/submit-mark-for-supplementary-billing.service.js
@@ -28,11 +28,7 @@ async function go(licenceId, payload) {
   const validationResult = _validate(payload)
 
   if (!validationResult) {
-    let { supplementaryYears } = payload
-
-    // If the user picked multiple years this comes through as an array. If they only picked one year it comes through
-    // as a string.
-    supplementaryYears = Array.isArray(supplementaryYears) ? supplementaryYears : [supplementaryYears]
+    const { supplementaryYears } = payload
 
     await _flagForBilling(supplementaryYears, licenceId)
 

--- a/app/services/notices/setup/abstraction-alerts/submit-alert-thresholds.service.js
+++ b/app/services/notices/setup/abstraction-alerts/submit-alert-thresholds.service.js
@@ -10,7 +10,6 @@ const AlertThresholdsPresenter = require('../../../../presenters/notices/setup/a
 const AlertThresholdsValidator = require('../../../../validators/notices/setup/alert-thresholds.validator.js')
 const FetchSessionDal = require('../../../../dal/fetch-session.dal.js')
 const { formatValidationResult } = require('../../../../presenters/base.presenter.js')
-const { handleOneOptionSelected } = require('../../../../lib/submit-page.lib.js')
 
 /**
  * Orchestrates validating the data for `/notices/setup/{sessionId}/abstraction-alerts/alert-thresholds` page
@@ -23,7 +22,7 @@ const { handleOneOptionSelected } = require('../../../../lib/submit-page.lib.js'
 async function go(sessionId, payload) {
   const session = await FetchSessionDal.go(sessionId)
 
-  handleOneOptionSelected(payload, 'alertThresholds')
+  payload.alertThresholds ??= []
 
   session.alertThresholds = payload.alertThresholds
 

--- a/app/services/notices/setup/submit-paper-return.service.js
+++ b/app/services/notices/setup/submit-paper-return.service.js
@@ -11,7 +11,6 @@ const GeneralLib = require('../../../lib/general.lib.js')
 const PaperReturnPresenter = require('../../../presenters/notices/setup/paper-return.presenter.js')
 const PaperReturnValidator = require('../../../validators/notices/setup/paper-return.validator.js')
 const { formatValidationResult } = require('../../../presenters/base.presenter.js')
-const { handleOneOptionSelected } = require('../../../lib/submit-page.lib.js')
 
 /**
  * Orchestrates validating the data for the `/notices/setup/{sessionId}/paper-return` page
@@ -24,8 +23,6 @@ const { handleOneOptionSelected } = require('../../../lib/submit-page.lib.js')
  */
 async function go(sessionId, payload, yar) {
   const session = await FetchSessionDal.go(sessionId)
-
-  handleOneOptionSelected(payload, 'returns')
 
   const error = _validate(payload)
 

--- a/app/services/notices/setup/submit-select-recipients.service.js
+++ b/app/services/notices/setup/submit-select-recipients.service.js
@@ -12,7 +12,6 @@ const GeneralLib = require('../../../lib/general.lib.js')
 const SelectRecipientsPresenter = require('../../../presenters/notices/setup/select-recipients.presenter.js')
 const SelectRecipientsValidator = require('../../../validators/notices/setup/select-recipients.validator.js')
 const { formatValidationResult } = require('../../../presenters/base.presenter.js')
-const { handleOneOptionSelected } = require('../../../lib/submit-page.lib.js')
 
 /**
  * Orchestrates validating the data for '/notices/setup/{sessionId}/select-recipients' page
@@ -25,8 +24,6 @@ const { handleOneOptionSelected } = require('../../../lib/submit-page.lib.js')
  */
 async function go(sessionId, payload, yar) {
   const session = await FetchSessionDal.go(sessionId)
-
-  handleOneOptionSelected(payload, 'recipients')
 
   const error = _validate(payload)
 

--- a/app/services/notices/submit-index-notices.service.js
+++ b/app/services/notices/submit-index-notices.service.js
@@ -10,7 +10,7 @@ const IndexValidator = require('../../validators/notices/index.validator.js')
 const NoticesIndexPresenter = require('../../presenters/notices/index-notices.presenter.js')
 const PaginatorPresenter = require('../../presenters/paginator.presenter.js')
 const { formatValidationResult } = require('../../presenters/base.presenter.js')
-const { clearFilters, handleOneOptionSelected } = require('../../lib/submit-page.lib.js')
+const { clearFilters } = require('../../lib/submit-page.lib.js')
 
 /**
  * Handles validation of the requested filters, saving them to the session else re-rendering the page if invalid
@@ -32,8 +32,8 @@ async function go(payload, yar, auth, page) {
     return {}
   }
 
-  handleOneOptionSelected(payload, 'noticeTypes')
-  handleOneOptionSelected(payload, 'statuses')
+  payload.noticeTypes ??= []
+  payload.statuses ??= []
 
   const error = _validate(payload)
 

--- a/app/services/return-versions/setup/submit-additional-submission-options.service.js
+++ b/app/services/return-versions/setup/submit-additional-submission-options.service.js
@@ -9,7 +9,6 @@ const AdditionalSubmissionOptionsPresenter = require('../../../presenters/return
 const AdditionalSubmissionOptionsValidator = require('../../../validators/return-versions/setup/additional-submission-options.validator.js')
 const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const { formatValidationResult } = require('../../../presenters/base.presenter.js')
-const { handleOneOptionSelected } = require('../../../lib/submit-page.lib.js')
 
 /**
  * Orchestrates validating the data for `/return-versions/setup/{sessionId}/additional-submission-options` page
@@ -29,8 +28,6 @@ const { handleOneOptionSelected } = require('../../../lib/submit-page.lib.js')
  */
 async function go(sessionId, payload, yar) {
   const session = await FetchSessionDal.go(sessionId)
-
-  handleOneOptionSelected(payload, 'additionalSubmissionOptions')
 
   const error = _validate(payload, session)
 

--- a/app/services/return-versions/setup/submit-agreements-exceptions.service.js
+++ b/app/services/return-versions/setup/submit-agreements-exceptions.service.js
@@ -10,7 +10,6 @@ const AgreementsExceptionsValidator = require('../../../validators/return-versio
 const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const GeneralLib = require('../../../lib/general.lib.js')
 const { formatValidationResult } = require('../../../presenters/base.presenter.js')
-const { handleOneOptionSelected } = require('../../../lib/submit-page.lib.js')
 
 /**
  * Orchestrates validating the data for `/return-versions/setup/{sessionId}/agreements-exceptions` page
@@ -31,8 +30,6 @@ const { handleOneOptionSelected } = require('../../../lib/submit-page.lib.js')
  */
 async function go(sessionId, requirementIndex, payload, yar) {
   const session = await FetchSessionDal.go(sessionId)
-
-  handleOneOptionSelected(payload, 'agreementsExceptions')
 
   const error = _validate(payload)
 

--- a/app/services/return-versions/setup/submit-points.service.js
+++ b/app/services/return-versions/setup/submit-points.service.js
@@ -12,7 +12,6 @@ const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const GeneralLib = require('../../../lib/general.lib.js')
 const PointsPresenter = require('../../../presenters/return-versions/setup/points.presenter.js')
 const PointsValidator = require('../../../validators/return-versions/setup/points.validator.js')
-const { handleOneOptionSelected } = require('../../../lib/submit-page.lib.js')
 
 /**
  * Orchestrates validating the data for `/return-versions/setup/{sessionId}/points` page
@@ -33,8 +32,6 @@ const { handleOneOptionSelected } = require('../../../lib/submit-page.lib.js')
  */
 async function go(sessionId, requirementIndex, payload, yar) {
   const session = await FetchSessionDal.go(sessionId)
-
-  handleOneOptionSelected(payload, 'points')
 
   const error = _validate(payload)
 

--- a/app/services/return-versions/setup/submit-purpose.service.js
+++ b/app/services/return-versions/setup/submit-purpose.service.js
@@ -11,7 +11,6 @@ const GeneralLib = require('../../../lib/general.lib.js')
 const PurposePresenter = require('../../../presenters/return-versions/setup/purpose.presenter.js')
 const PurposeValidation = require('../../../validators/return-versions/setup/purpose.validator.js')
 const { formatValidationResult } = require('../../../presenters/base.presenter.js')
-const { handleOneOptionSelected } = require('../../../lib/submit-page.lib.js')
 
 /**
  * Orchestrates validating the data for `/return-versions/setup/{sessionId}/purpose` page
@@ -34,7 +33,7 @@ async function go(sessionId, requirementIndex, payload, yar) {
   const session = await FetchSessionDal.go(sessionId)
   const licencePurposes = await FetchPurposesService.go(session.licenceVersion.id)
 
-  handleOneOptionSelected(payload, 'purposes')
+  payload.purposes ??= []
 
   const purposes = _combinePurposeDetails(payload, licencePurposes)
 

--- a/app/services/users/external/setup/submit-licences.service.js
+++ b/app/services/users/external/setup/submit-licences.service.js
@@ -12,7 +12,6 @@ const LicencesValidator = require('../../../../validators/users/external/setup/l
 const { checkUrl } = require('../../../../lib/check-page.lib.js')
 const { flashNotification } = require('../../../../lib/general.lib.js')
 const { formatValidationResult } = require('../../../../presenters/base.presenter.js')
-const { handleOneOptionSelected } = require('../../../../lib/submit-page.lib.js')
 
 /**
  * Orchestrates validating the data for the '/users/external/setup/{sessionId}/licences' page
@@ -26,7 +25,7 @@ const { handleOneOptionSelected } = require('../../../../lib/submit-page.lib.js'
 async function go(sessionId, payload, yar) {
   const session = await FetchSessionDal.go(sessionId)
 
-  handleOneOptionSelected(payload, 'licences')
+  payload.licences ??= []
 
   const payloadSelection = _payloadSelection(payload)
 

--- a/app/views/bill-runs/index.njk
+++ b/app/views/bill-runs/index.njk
@@ -48,7 +48,7 @@
           }
         },
         items: regionItems,
-        name: "regions"
+        name: "regions[]"
       }) }}
 
       {# Filter by run types #}
@@ -62,7 +62,7 @@
           }
         },
         items: runTypeItems,
-        name: "runTypes"
+        name: "runTypes[]"
       }) }}
 
       {# Filter by number #}
@@ -90,7 +90,7 @@
           }
         },
         items: statusItems,
-        name: "statuses"
+        name: "statuses[]"
       }) }}
 
       <div class="govuk-button-group">

--- a/app/views/bill-runs/review/review.njk
+++ b/app/views/bill-runs/review/review.njk
@@ -213,7 +213,7 @@
             value: "no-issues"
           }
         ],
-        name: "issues"
+        name: "issues[]"
       }) }}
 
       {# Filter by licence progress #}
@@ -234,7 +234,7 @@
             value: "inProgress"
           }
         ],
-        name: "progress"
+        name: "progress[]"
       }) }}
 
       {# Filter by licence status #}

--- a/app/views/licences/mark-for-supplementary-billing.njk
+++ b/app/views/licences/mark-for-supplementary-billing.njk
@@ -8,7 +8,7 @@
     <input type="hidden" name="wrlsCrumb" value="{{ wrlsCrumb }}" />
 
     {{ govukCheckboxes({
-      name: "supplementaryYears",
+      name: "supplementaryYears[]",
       hint: {
         text: "Select all that apply."
       },

--- a/app/views/notices/index.njk
+++ b/app/views/notices/index.njk
@@ -193,7 +193,7 @@
             value: "warning"
           }
         ],
-        name: "noticeTypes"
+        name: "noticeTypes[]"
       }) }}
 
       {# Filter by sent by #}
@@ -255,7 +255,7 @@
             value: 'sent'
           }
         ],
-        name: "statuses"
+        name: "statuses[]"
       }) }}
 
       <div class="govuk-button-group">

--- a/app/views/notices/setup/alert-thresholds.njk
+++ b/app/views/notices/setup/alert-thresholds.njk
@@ -8,7 +8,7 @@
     <input type="hidden" name="wrlsCrumb" value="{{wrlsCrumb}}"/>
 
     {{ govukCheckboxes({
-      name: "alertThresholds",
+      name: "alertThresholds[]",
       errorMessage: error.alertThresholds,
       items: thresholdOptions
     }) }}

--- a/app/views/notices/setup/paper-return.njk
+++ b/app/views/notices/setup/paper-return.njk
@@ -8,7 +8,7 @@
     <input type="hidden" name="wrlsCrumb" value="{{ wrlsCrumb }}" />
 
     {{ govukCheckboxes({
-      name: "returns",
+      name: "returns[]",
       errorMessage: error.returns,
       hint: {
         text: "Select all that apply"

--- a/app/views/notices/setup/select-recipients.njk
+++ b/app/views/notices/setup/select-recipients.njk
@@ -32,7 +32,7 @@
     <input type="hidden" name="wrlsCrumb" value="{{wrlsCrumb}}"/>
 
     {{ govukCheckboxes({
-      name: "recipients",
+      name: "recipients[]",
       errorMessage: error.recipients,
       hint: {
         classes: 'govuk-!-margin-bottom-7',

--- a/app/views/return-versions/setup/additional-submission-options.njk
+++ b/app/views/return-versions/setup/additional-submission-options.njk
@@ -8,7 +8,7 @@
     <input type="hidden" name="wrlsCrumb" value="{{wrlsCrumb}}"/>
 
     {{ govukCheckboxes({
-      name: 'additionalSubmissionOptions',
+      name: 'additionalSubmissionOptions[]',
       id: 'additionalSubmissionOptions',
       hint: {
         text: "Select all that apply"

--- a/app/views/return-versions/setup/agreements-exceptions.njk
+++ b/app/views/return-versions/setup/agreements-exceptions.njk
@@ -8,7 +8,7 @@
     <input type="hidden" name="wrlsCrumb" value="{{wrlsCrumb}}"/>
 
     {{ govukCheckboxes({
-      name: 'agreementsExceptions',
+      name: 'agreementsExceptions[]',
       id: 'agreementsExceptions',
       hint: {
         text: "Select all that apply"

--- a/app/views/return-versions/setup/points.njk
+++ b/app/views/return-versions/setup/points.njk
@@ -20,7 +20,7 @@
     {% endfor %}
 
     {{ govukCheckboxes({
-      name: "points",
+      name: "points[]",
       errorMessage: error.points,
       hint: {
         text: "Select all that apply"

--- a/app/views/return-versions/setup/purpose.njk
+++ b/app/views/return-versions/setup/purpose.njk
@@ -29,7 +29,7 @@
 
       {% set checkBoxItem = {
         id: 'purposes-' + checkIndex,
-        name: 'purposes',
+        name: 'purposes[]',
         value: purpose.id,
         text: purpose.description,
         checked: purpose.checked,
@@ -42,7 +42,7 @@
     {% endfor %}
 
     {{ govukCheckboxes({
-      name: "purposes",
+      name: "purposes[]",
       errorMessage: error.purposes,
       hint: {
         text: "Select all that apply"

--- a/app/views/users/external/setup/licences.njk
+++ b/app/views/users/external/setup/licences.njk
@@ -8,7 +8,7 @@
     <input type="hidden" name="wrlsCrumb" value="{{wrlsCrumb}}"/>
 
     {{ govukCheckboxes({
-      name: 'licences',
+      name: 'licences[]',
       id: 'licences',
       hint: {
         text: "Select all that apply"

--- a/test/lib/submit-page.lib.test.js
+++ b/test/lib/submit-page.lib.test.js
@@ -57,48 +57,6 @@ describe('SubmitPageLib', () => {
     })
   })
 
-  describe('#handleOneOptionSelected()', () => {
-    const key = 'propertyToCheck'
-
-    let payload
-
-    describe('when the payload is empty', () => {
-      before(() => {
-        payload = {}
-      })
-
-      it('adds the key to the payload as an empty array', () => {
-        SubmitPageLib.handleOneOptionSelected(payload, key)
-
-        expect(payload).to.equal({ propertyToCheck: [] })
-      })
-    })
-
-    describe('when the payload contains a string', () => {
-      before(() => {
-        payload = { propertyToCheck: 'checkBoxValue' }
-      })
-
-      it('returns the key in the payload with the string converted to an array', () => {
-        SubmitPageLib.handleOneOptionSelected(payload, key)
-
-        expect(payload).to.equal({ propertyToCheck: ['checkBoxValue'] })
-      })
-    })
-
-    describe('when the payload contains an array', () => {
-      before(() => {
-        payload = { propertyToCheck: ['checkBoxValue', 'anotherCheckBoxValue'] }
-      })
-
-      it('does not alter the payload', () => {
-        SubmitPageLib.handleOneOptionSelected(payload, key)
-
-        expect(payload).to.equal({ propertyToCheck: ['checkBoxValue', 'anotherCheckBoxValue'] })
-      })
-    })
-  })
-
   describe('#processSavedFilters()', () => {
     const filterKey = 'filterToProcess'
 

--- a/test/services/bill-runs/submit-index-bill-runs.service.test.js
+++ b/test/services/bill-runs/submit-index-bill-runs.service.test.js
@@ -97,9 +97,9 @@ describe('Bill Runs - Submit Index Bill Runs service', () => {
         expect(setArgs[1]).to.equal({ number: '1001', regions: [], runTypes: [], statuses: [], yearCreated: '2025' })
       })
 
-      describe('and a single "Run type" filter has been selected ("runTypes" is a string)', () => {
+      describe('and a single "Run type" filter has been selected', () => {
         beforeEach(() => {
-          payload = { runTypes: 'annual' }
+          payload = { runTypes: ['annual'] }
         })
 
         it('saves the state of the "Run type" filter as an array in the session', async () => {
@@ -118,7 +118,7 @@ describe('Bill Runs - Submit Index Bill Runs service', () => {
         })
       })
 
-      describe('and multiple "Run type" filters have been selected ("runTypes" is an array)', () => {
+      describe('and multiple "Run type" filters have been selected', () => {
         beforeEach(() => {
           payload = {
             runTypes: ['annual', 'supplementary']
@@ -141,9 +141,9 @@ describe('Bill Runs - Submit Index Bill Runs service', () => {
         })
       })
 
-      describe('and a single "Region" filter has been selected ("regions" is a string)', () => {
+      describe('and a single "Region" filter has been selected', () => {
         beforeEach(() => {
-          payload = { regions: '1d562e9a-2104-41d9-aa75-c008a7ec9059', yearCreated: '2025' }
+          payload = { regions: ['1d562e9a-2104-41d9-aa75-c008a7ec9059'], yearCreated: '2025' }
         })
 
         it('saves the state of the "Region" filter as an array in the session', async () => {
@@ -162,7 +162,7 @@ describe('Bill Runs - Submit Index Bill Runs service', () => {
         })
       })
 
-      describe('and multiple "Region" filters have been selected ("regions" is an array)', () => {
+      describe('and multiple "Region" filters have been selected', () => {
         beforeEach(() => {
           payload = {
             regions: ['1d562e9a-2104-41d9-aa75-c008a7ec9059', 'fd3d1154-c83d-4580-bcd6-46bfc380f233']
@@ -185,9 +185,9 @@ describe('Bill Runs - Submit Index Bill Runs service', () => {
         })
       })
 
-      describe('and a single "Status" filter has been selected ("statuses" is a string)', () => {
+      describe('and a single "Status" filter has been selected', () => {
         beforeEach(() => {
-          payload = { statuses: 'sent' }
+          payload = { statuses: ['sent'] }
         })
 
         it('saves the state of the "Status" filter as an array in the session', async () => {
@@ -206,7 +206,7 @@ describe('Bill Runs - Submit Index Bill Runs service', () => {
         })
       })
 
-      describe('and multiple "Status" filters have been selected ("statuses" is an array)', () => {
+      describe('and multiple "Status" filters have been selected', () => {
         beforeEach(() => {
           payload = {
             statuses: ['ready', 'review']

--- a/test/services/licences/supplementary/submit-mark-for-supplementary-billing.service.test.js
+++ b/test/services/licences/supplementary/submit-mark-for-supplementary-billing.service.test.js
@@ -38,7 +38,7 @@ describe('Submit Mark For Supplementary Billing Service', () => {
     describe('and only a single sroc year selected', () => {
       beforeEach(() => {
         payload = {
-          supplementaryYears: '2023'
+          supplementaryYears: ['2023']
         }
       })
 
@@ -108,7 +108,7 @@ describe('Submit Mark For Supplementary Billing Service', () => {
     describe('and only pre sroc years selected', () => {
       beforeEach(() => {
         payload = {
-          supplementaryYears: 'preSroc'
+          supplementaryYears: ['preSroc']
         }
       })
 

--- a/test/services/notices/setup/abstraction-alerts/submit-alert-thresholds.service.test.js
+++ b/test/services/notices/setup/abstraction-alerts/submit-alert-thresholds.service.test.js
@@ -56,7 +56,7 @@ describe('Notices - Setup - Abstraction Alerts - Submit Alert Thresholds service
       describe('and one threshold has been selected ', () => {
         beforeEach(() => {
           payload = {
-            alertThresholds: licenceMonitoringStations.one.thresholdGroup
+            alertThresholds: [licenceMonitoringStations.one.thresholdGroup]
           }
         })
 

--- a/test/services/notices/setup/submit-paper-return.service.test.js
+++ b/test/services/notices/setup/submit-paper-return.service.test.js
@@ -71,9 +71,9 @@ describe('Notices - Setup - Submit Paper Return service', () => {
       expect(result).to.equal({})
     })
 
-    describe('and the payload has one item (is not an array)', () => {
+    describe('and the payload has one item', () => {
       beforeEach(() => {
-        payload = { returns: dueReturn.returnLogId }
+        payload = { returns: [dueReturn.returnLogId] }
         sessionData = {}
 
         session = SessionModelStub.build(Sinon, sessionData)

--- a/test/services/notices/submit-index-notices.service.test.js
+++ b/test/services/notices/submit-index-notices.service.test.js
@@ -138,7 +138,7 @@ describe('Notices - Submit Index Notices service', () => {
 
       describe('including a single notice type selected', () => {
         beforeEach(() => {
-          payload.noticeTypes = 'stop'
+          payload.noticeTypes = ['stop']
         })
 
         it('returns a result that tells the controller to redirect to the index page', async () => {

--- a/test/services/return-versions/setup/submit-additional-submission-options.service.test.js
+++ b/test/services/return-versions/setup/submit-additional-submission-options.service.test.js
@@ -52,7 +52,7 @@ describe('Return Versions Setup - Submit Additional Submission Options service',
     describe('with no additional options ', () => {
       beforeEach(() => {
         payload = {
-          additionalSubmissionOptions: 'none'
+          additionalSubmissionOptions: ['none']
         }
       })
 
@@ -79,7 +79,7 @@ describe('Return Versions Setup - Submit Additional Submission Options service',
     describe('with multiple upload selected', () => {
       beforeEach(() => {
         payload = {
-          additionalSubmissionOptions: 'multiple-upload'
+          additionalSubmissionOptions: ['multiple-upload']
         }
       })
 
@@ -105,7 +105,7 @@ describe('Return Versions Setup - Submit Additional Submission Options service',
     describe('with quarterly returns selected', () => {
       beforeEach(() => {
         payload = {
-          additionalSubmissionOptions: 'quarterly-returns'
+          additionalSubmissionOptions: ['quarterly-returns']
         }
       })
 

--- a/test/services/return-versions/setup/submit-points.service.test.js
+++ b/test/services/return-versions/setup/submit-points.service.test.js
@@ -86,7 +86,7 @@ describe('Return Versions - Setup - Submit Points service', () => {
     describe('with a valid payload', () => {
       beforeEach(() => {
         payload = {
-          points: 'd03d7d7c-4e33-4b4d-ac9b-6ebac9a5e5f6'
+          points: ['d03d7d7c-4e33-4b4d-ac9b-6ebac9a5e5f6']
         }
 
         Sinon.stub(FetchPointsService, 'go').resolves(_points())

--- a/test/services/return-versions/setup/submit-purpose.service.test.js
+++ b/test/services/return-versions/setup/submit-purpose.service.test.js
@@ -186,7 +186,7 @@ describe('Return Versions - Setup - Submit Purpose service', () => {
       describe('because they entered an alias that is too long', () => {
         beforeEach(() => {
           payload = {
-            purposes: '14794d57-1acf-4c91-8b48-4b1ec68bfd6f',
+            purposes: ['14794d57-1acf-4c91-8b48-4b1ec68bfd6f'],
             'alias-14794d57-1acf-4c91-8b48-4b1ec68bfd6f':
               'THGBk2GM85EyXB54SsfenU2yWiKjDuPTcJCrPfTsSzojNvj6ciVmI3PXJ2fisQgXWfSI4ZPIqV5GLPtR15qbcw3Hamoeit764Cojz'
           }

--- a/test/services/users/external/setup/submit-licences.service.test.js
+++ b/test/services/users/external/setup/submit-licences.service.test.js
@@ -42,7 +42,7 @@ describe('Users - External - Setup - Submit Licences Service', () => {
 
   describe('when called with a valid payload', () => {
     beforeEach(() => {
-      payload = { licences: 'all' }
+      payload = { licences: ['all'] }
     })
 
     it('saves the submitted value', async () => {
@@ -76,7 +76,7 @@ describe('Users - External - Setup - Submit Licences Service', () => {
 
               fetchSessionStub.resolves(session)
 
-              payload = { licences: 'all' }
+              payload = { licences: ['all'] }
             })
 
             it('does not set a notification', async () => {
@@ -97,7 +97,7 @@ describe('Users - External - Setup - Submit Licences Service', () => {
 
                 fetchSessionStub.resolves(session)
 
-                payload = { licences: sessionData.licences[0].id }
+                payload = { licences: [sessionData.licences[0].id] }
               })
 
               it('sets a notification', async () => {
@@ -121,7 +121,7 @@ describe('Users - External - Setup - Submit Licences Service', () => {
 
                 fetchSessionStub.resolves(session)
 
-                payload = { licences: sessionData.licences[0].id }
+                payload = { licences: [sessionData.licences[0].id] }
               })
 
               it('sets a notification', async () => {
@@ -145,7 +145,7 @@ describe('Users - External - Setup - Submit Licences Service', () => {
 
                 fetchSessionStub.resolves(session)
 
-                payload = { licences: sessionData.licences[0].id }
+                payload = { licences: [sessionData.licences[0].id] }
               })
 
               it('sets a notification', async () => {


### PR DESCRIPTION
When a checkbox group uses a plain name (e.g. name="regions"), the browser's form submission behaviour is inconsistent:

- Nothing checked  → field absent from payload (undefined)
- One checked      → payload value is a string
- Multiple checked → payload value is an array

We previously handled this in each submit service by calling handleOneOptionSelected(), which normalised all three cases to an array. This commit takes the approach agreed on the dev call: appending [] to every checkbox name attribute (e.g. name="regions[]") so Hapi's body parser always coerces a selection into an array, removing the need for the helper entirely.

With bracket notation the three cases become:

- Nothing checked  → field still absent from payload (undefined)
- One checked      → payload value is a single-element array
- Multiple checked → payload value is an array

The undefined case is handled differently depending on context:

- Filter pages (bill-runs index/review, notices index) have no "required" validator on the checkbox fields, so undefined would flow through and be stored in the session. These services default the field to [] with ??= [] before saving.

- submit-alert-thresholds assigns payload.alertThresholds to the session object before calling the validator, so undefined would corrupt the in-memory session used to render the error page. ??= [] prevents that.

- submit-licences calls _payloadSelection() (which calls licences.includes()) before the validator runs. ??= [] prevents a TypeError on undefined.

- submit-purpose calls _combinePurposeDetails() (which iterates payload.purposes with for...of) before the validator runs. ??= [] prevents a TypeError on undefined.

- All other submit services validate first and only access the array when validation passes, so undefined is caught as a "required" error and no ??= [] is needed.

handleOneOptionSelected() is removed from submit-page.lib.js as it is no longer used anywhere.

Co-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>