### PR TITLE
Add company contact licences inline error

### DIFF
--- a/app/views/company-contacts/setup/licences.njk
+++ b/app/views/company-contacts/setup/licences.njk
@@ -8,6 +8,7 @@
     <input type="hidden" name="wrlsCrumb" value="{{wrlsCrumb}}"/>
 
     {{ govukCheckboxes({
+      errorMessage: error.licences if error.licences,
       name: "licences",
       hint: {
         text: "Select all that apply"


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5630

When implementing the original change we missed the inline error.

This change updates the licences page to show the inline error, following our standard pattern.