### PR TITLE
Fix for company contacts abs alerts edge case

### DIFF
--- a/app/presenters/company-contacts/setup/check.presenter.js
+++ b/app/presenters/company-contacts/setup/check.presenter.js
@@ -93,7 +93,8 @@ function _matchingContact(email, name, savedCompanyContacts) {
 }
 
 /*
- * Show the warning if the contact already exists.
+ * Show the warning if the contact already exists, or if the user has not selected any licences but has selected abstraction
+ * alert type "some".
  *
  * This variable is also used to show / hide the 'confirm' button, we do not allow a user to submit if the contact already
  * exists (when creating a company contact).

--- a/app/presenters/company-contacts/setup/check.presenter.js
+++ b/app/presenters/company-contacts/setup/check.presenter.js
@@ -18,10 +18,9 @@ const { abstractionAlertsLabel } = require('../../crm.presenter.js')
  * @returns {object} The data formatted for the view template
  */
 function go(session, savedCompanyContacts, sentNotification) {
-  const { company, email, name, abstractionAlerts, companyContact, licences, abstractionAlertLicences } = session
+  const { abstractionAlertLicences, abstractionAlerts, company, companyContact, email, licences, name } = session
 
   const matchingContact = _matchingContact(email, name, savedCompanyContacts)
-  const parsedAbstractionAlertLicences = !abstractionAlertLicences ? [] : abstractionAlertLicences
 
   return {
     abstractionAlertsLabel: abstractionAlertsLabel(abstractionAlerts),
@@ -30,7 +29,7 @@ function go(session, savedCompanyContacts, sentNotification) {
     name,
     pageTitle: 'Check contact',
     pageTitleCaption: company.name,
-    licences: _licences(licences, parsedAbstractionAlertLicences, abstractionAlerts),
+    licences: _licences(licences, abstractionAlertLicences, abstractionAlerts),
     links: {
       abstractionAlerts: `/system/company-contacts/setup/${session.id}/abstraction-alerts`,
       cancel: `/system/company-contacts/setup/${session.id}/cancel`,
@@ -39,7 +38,7 @@ function go(session, savedCompanyContacts, sentNotification) {
       restoreContact: matchingContact?.deletedAt ? `/system/company-contacts/setup/${session.id}/restore` : null
     },
     matchingContact,
-    warning: _warning(matchingContact, parsedAbstractionAlertLicences, abstractionAlerts)
+    warning: _warning(matchingContact, abstractionAlertLicences, abstractionAlerts)
   }
 }
 
@@ -60,9 +59,7 @@ function _emailInUse(sentNotification, companyContact) {
 }
 
 function _licences(licences, abstractionAlertLicences, abstractionAlerts) {
-  const abstractionAlertLicencesEmpty = abstractionAlertLicences.length === 0
-
-  if (abstractionAlerts !== 'some' || abstractionAlertLicencesEmpty) {
+  if (abstractionAlerts !== 'some' || !abstractionAlertLicences?.length) {
     return []
   }
 
@@ -102,9 +99,7 @@ function _matchingContact(email, name, savedCompanyContacts) {
  * exists (when creating a company contact).
  */
 function _warning(matchingContact, abstractionAlertLicences, abstractionAlerts) {
-  const abstractionAlertLicencesEmpty = abstractionAlertLicences.length === 0
-
-  if (abstractionAlerts === 'some' && abstractionAlertLicencesEmpty) {
+  if (abstractionAlerts === 'some' && !abstractionAlertLicences?.length) {
     return {
       text: 'Select the licences they should get water abstraction alert emails for or change should they get abstraction alerts.',
       iconFallbackText: 'Warning'

--- a/app/presenters/company-contacts/setup/check.presenter.js
+++ b/app/presenters/company-contacts/setup/check.presenter.js
@@ -21,6 +21,7 @@ function go(session, savedCompanyContacts, sentNotification) {
   const { company, email, name, abstractionAlerts, companyContact, licences, abstractionAlertLicences } = session
 
   const matchingContact = _matchingContact(email, name, savedCompanyContacts)
+  const parsedAbstractionAlertLicences = !abstractionAlertLicences ? [] : abstractionAlertLicences
 
   return {
     abstractionAlertsLabel: abstractionAlertsLabel(abstractionAlerts),
@@ -29,7 +30,7 @@ function go(session, savedCompanyContacts, sentNotification) {
     name,
     pageTitle: 'Check contact',
     pageTitleCaption: company.name,
-    licences: _licences(licences, abstractionAlertLicences, abstractionAlerts),
+    licences: _licences(licences, parsedAbstractionAlertLicences, abstractionAlerts),
     links: {
       abstractionAlerts: `/system/company-contacts/setup/${session.id}/abstraction-alerts`,
       cancel: `/system/company-contacts/setup/${session.id}/cancel`,
@@ -38,7 +39,7 @@ function go(session, savedCompanyContacts, sentNotification) {
       restoreContact: matchingContact?.deletedAt ? `/system/company-contacts/setup/${session.id}/restore` : null
     },
     matchingContact,
-    warning: _warning(matchingContact)
+    warning: _warning(matchingContact, parsedAbstractionAlertLicences, abstractionAlerts)
   }
 }
 
@@ -59,7 +60,9 @@ function _emailInUse(sentNotification, companyContact) {
 }
 
 function _licences(licences, abstractionAlertLicences, abstractionAlerts) {
-  if (abstractionAlerts !== 'some') {
+  const abstractionAlertLicencesEmpty = abstractionAlertLicences.length === 0
+
+  if (abstractionAlerts !== 'some' || abstractionAlertLicencesEmpty) {
     return []
   }
 
@@ -98,7 +101,16 @@ function _matchingContact(email, name, savedCompanyContacts) {
  * This variable is also used to show / hide the 'confirm' button, we do not allow a user to submit if the contact already
  * exists (when creating a company contact).
  */
-function _warning(matchingContact) {
+function _warning(matchingContact, abstractionAlertLicences, abstractionAlerts) {
+  const abstractionAlertLicencesEmpty = abstractionAlertLicences.length === 0
+
+  if (abstractionAlerts === 'some' && abstractionAlertLicencesEmpty) {
+    return {
+      text: 'Select the licences they should get water abstraction alert emails for or change should they get abstraction alerts.',
+      iconFallbackText: 'Warning'
+    }
+  }
+
   if (!matchingContact) {
     return null
   }

--- a/app/presenters/company-contacts/setup/licences.presenter.js
+++ b/app/presenters/company-contacts/setup/licences.presenter.js
@@ -5,8 +5,6 @@
  * @module LicencesPresenter
  */
 
-const { checkUrl } = require('../../../lib/check-page.lib.js')
-
 /**
  * Formats data for the '/company-contacts/setup/{sessionId}/licences' page
  *
@@ -19,7 +17,7 @@ function go(session) {
 
   return {
     backLink: {
-      href: checkUrl(session, `/system/company-contacts/setup/${sessionId}/abstraction-alerts`),
+      href: `/system/company-contacts/setup/${sessionId}/abstraction-alerts`,
       text: 'Back'
     },
     licences: _licences(licences, abstractionAlertLicences),

--- a/test/presenters/company-contacts/setup/check.presenter.test.js
+++ b/test/presenters/company-contacts/setup/check.presenter.test.js
@@ -16,7 +16,7 @@ const { yesterday } = require('../../../support/general.js')
 // Thing under test
 const CheckPresenter = require('../../../../app/presenters/company-contacts/setup/check.presenter.js')
 
-describe.only('Company Contacts - Setup - Check Presenter', () => {
+describe('Company Contacts - Setup - Check Presenter', () => {
   let company
   let companyContact
   let email

--- a/test/presenters/company-contacts/setup/check.presenter.test.js
+++ b/test/presenters/company-contacts/setup/check.presenter.test.js
@@ -166,7 +166,7 @@ describe.only('Company Contacts - Setup - Check Presenter', () => {
           })
         })
 
-        describe('and the licence holder has "live" licences', () => {
+        describe('and there are "live" licences', () => {
           describe('and the selected licences for the user matches the "live" licences', () => {
             beforeEach(() => {
               session.abstractionAlertLicences = [licences[0].id]
@@ -192,7 +192,7 @@ describe.only('Company Contacts - Setup - Check Presenter', () => {
           })
         })
 
-        describe('but the licence holder has no "live" licences', () => {
+        describe('but there are no "live" licences', () => {
           beforeEach(() => {
             session.licences = []
             session.abstractionAlertLicences = [licences[0].id]

--- a/test/presenters/company-contacts/setup/check.presenter.test.js
+++ b/test/presenters/company-contacts/setup/check.presenter.test.js
@@ -16,7 +16,7 @@ const { yesterday } = require('../../../support/general.js')
 // Thing under test
 const CheckPresenter = require('../../../../app/presenters/company-contacts/setup/check.presenter.js')
 
-describe('Company Contacts - Setup - Check Presenter', () => {
+describe.only('Company Contacts - Setup - Check Presenter', () => {
   let company
   let companyContact
   let email
@@ -42,7 +42,7 @@ describe('Company Contacts - Setup - Check Presenter', () => {
     sentNotification = undefined
 
     session = {
-      abstractionAlertLicences: [],
+      abstractionAlertLicences: null,
       abstractionAlerts: 'yes',
       company,
       email,
@@ -154,9 +154,9 @@ describe('Company Contacts - Setup - Check Presenter', () => {
           session.abstractionAlerts = 'some'
         })
 
-        describe('and "abstractionAlertLicences" has never been set in the session', () => {
+        describe('and there are no existing "abstractionAlertLicences"', () => {
           beforeEach(() => {
-            session.abstractionAlertLicences = undefined
+            session.abstractionAlertLicences = null
           })
 
           it('returns an empty array', () => {
@@ -255,22 +255,11 @@ describe('Company Contacts - Setup - Check Presenter', () => {
           session.abstractionAlerts = 'some'
         })
 
-        describe('and "abstractionAlertLicences" has never been set in the session', () => {
+        describe('and there are no "abstractionAlertLicences"', () => {
           beforeEach(() => {
-            session.abstractionAlertLicences = undefined
+            session.abstractionAlertLicences = null
           })
 
-          it('returns "select licences" warning', () => {
-            const result = CheckPresenter.go(session, savedCompanyContacts, sentNotification)
-
-            expect(result.warning).to.equal({
-              text: 'Select the licences they should get water abstraction alert emails for or change should they get abstraction alerts.',
-              iconFallbackText: 'Warning'
-            })
-          })
-        })
-
-        describe('and the user navigated back without selecting any licences', () => {
           it('returns "select licences" warning', () => {
             const result = CheckPresenter.go(session, savedCompanyContacts, sentNotification)
 

--- a/test/presenters/company-contacts/setup/check.presenter.test.js
+++ b/test/presenters/company-contacts/setup/check.presenter.test.js
@@ -138,6 +138,10 @@ describe('Company Contacts - Setup - Check Presenter', () => {
       })
 
       describe('when the user is set not to receive abstraction alerts ("no")', () => {
+        beforeEach(() => {
+          session.abstractionAlerts = 'no'
+        })
+
         it('returns an empty array', () => {
           const result = CheckPresenter.go(session, savedCompanyContacts, sentNotification)
 
@@ -148,6 +152,18 @@ describe('Company Contacts - Setup - Check Presenter', () => {
       describe('when the user is set to receive abstraction alerts for specific licences ("some")', () => {
         beforeEach(() => {
           session.abstractionAlerts = 'some'
+        })
+
+        describe('and "abstractionAlertLicences" has never been set in the session', () => {
+          beforeEach(() => {
+            session.abstractionAlertLicences = undefined
+          })
+
+          it('returns an empty array', () => {
+            const result = CheckPresenter.go(session, savedCompanyContacts, sentNotification)
+
+            expect(result.licences).to.be.empty()
+          })
         })
 
         describe('and the licence holder has "live" licences', () => {
@@ -164,6 +180,10 @@ describe('Company Contacts - Setup - Check Presenter', () => {
           })
 
           describe('but none of the selected licences for the user matches the "live" licences', () => {
+            beforeEach(() => {
+              session.abstractionAlertLicences = [generateUUID()]
+            })
+
             it('returns an empty array', () => {
               const result = CheckPresenter.go(session, savedCompanyContacts, sentNotification)
 
@@ -230,6 +250,38 @@ describe('Company Contacts - Setup - Check Presenter', () => {
     })
 
     describe('the "warning" property', () => {
+      describe('when the user has selected "Yes, for some licences" but not selected any licences', () => {
+        beforeEach(() => {
+          session.abstractionAlerts = 'some'
+        })
+
+        describe('and "abstractionAlertLicences" has never been set in the session', () => {
+          beforeEach(() => {
+            session.abstractionAlertLicences = undefined
+          })
+
+          it('returns "select licences" warning', () => {
+            const result = CheckPresenter.go(session, savedCompanyContacts, sentNotification)
+
+            expect(result.warning).to.equal({
+              text: 'Select the licences they should get water abstraction alert emails for or change should they get abstraction alerts.',
+              iconFallbackText: 'Warning'
+            })
+          })
+        })
+
+        describe('and the user navigated back without selecting any licences', () => {
+          it('returns "select licences" warning', () => {
+            const result = CheckPresenter.go(session, savedCompanyContacts, sentNotification)
+
+            expect(result.warning).to.equal({
+              text: 'Select the licences they should get water abstraction alert emails for or change should they get abstraction alerts.',
+              iconFallbackText: 'Warning'
+            })
+          })
+        })
+      })
+
       describe('when creating a new contact', () => {
         describe('and a contact with a matching name and email does not exist', () => {
           it('returns null', () => {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5630

We've spotted in our testing an edge case a users could get into that would previously cause an error.

The user is creating a new company contact and has selected 'No' for **Should the contact get abstraction alerts?**.

Then on the '/check' page, they opt to change this, and select 'Yes, for some licences'. When they click continue they will be taken to the **Select the licences they should get water abstraction alerts emails for** page.

Here is where it can become a problem. Rather than selecting any licences, they instead just click back. This will cause an error to be thrown because the '/check' page has seen `some` was the selected abstraction alert choice, so is then trying to filter an undefined array of licences.

The first fix is that the ****Select the licences** page should always go back to the **Should the contact get abstraction alerts?** page.

But when they click 'Back' there they will still be taken to the '/check' page and the error will still occur.

Our solution for this edge case is to make use of the functionality already built into the page. If we display a warning, the page will not display the 'Confirm' button, and the user will not be able to submit the form.

So, we update the check page presenter to also check for this scenario, and display a warning if the user has selected 'Yes, for some licences' but has not selected any licences.