### PR TITLE
Stop users being able to edit themselves

### DIFF
--- a/app/controllers/users.controller.js
+++ b/app/controllers/users.controller.js
@@ -138,6 +138,7 @@ async function viewInternalCommunications(request, h) {
 
 async function viewInternalDetails(request, h) {
   const {
+    auth,
     params: { id }
   } = request
 
@@ -145,7 +146,7 @@ async function viewInternalDetails(request, h) {
     return _redirectToLegacy(id, h)
   }
 
-  const pageData = await ViewInternalDetailsService.go(id)
+  const pageData = await ViewInternalDetailsService.go(auth, id)
 
   return h.view('users/internal/details.njk', pageData)
 }

--- a/app/presenters/users/internal/details.presenter.js
+++ b/app/presenters/users/internal/details.presenter.js
@@ -11,12 +11,15 @@ const { formatLongDateTime, sentenceCase } = require('../../base.presenter.js')
 /**
  * Formats data for internal users on the `/users/internal/{id}/details` page
  *
+ * @param {object} auth - The auth object taken from `request.auth` containing user details
  * @param {module:UserModel} user - The user instance
  *
  * @returns {object} The data formatted for the view template
  */
-function go(user) {
+function go(auth, user) {
   const { id, username } = user
+
+  const status = user.$status()
 
   return {
     backLink: {
@@ -29,7 +32,8 @@ function go(user) {
     pageTitleCaption: username,
     permissions: user.$permissions().label,
     roles: _roles(user),
-    status: user.$status()
+    showEditButton: auth.credentials.user.id !== id && status !== 'disabled',
+    status
   }
 }
 

--- a/app/services/users/internal/view-details.service.js
+++ b/app/services/users/internal/view-details.service.js
@@ -11,13 +11,14 @@ const DetailsPresenter = require('../../../presenters/users/internal/details.pre
 /**
  * Orchestrates fetching and presenting internal user data for `/users/internal/{id}/details` page
  *
+ * @param {object} auth - The auth object taken from `request.auth` containing user details
  * @param {number} id - The user's ID
  *
  * @returns {Promise<object>} The view data for the internal user details page
  */
-async function go(id) {
+async function go(auth, id) {
   const internalUser = await FetchUserDetailsDal.go(id)
-  const pageData = DetailsPresenter.go(internalUser)
+  const pageData = DetailsPresenter.go(auth, internalUser)
 
   return {
     activeNavBar: 'users',

--- a/app/views/users/internal/details.njk
+++ b/app/views/users/internal/details.njk
@@ -24,7 +24,7 @@
     ]
   }) }}
 
-  {% if status !== 'disabled' %}
+  {% if showEditButton === true %}
     <form method="post">
       <input type="hidden" name="wrlsCrumb" value="{{wrlsCrumb}}"/>
 

--- a/test/controllers/users.controller.test.js
+++ b/test/controllers/users.controller.test.js
@@ -720,6 +720,7 @@ describe('Users controller', () => {
           pageTitleCaption: 'basic.access@wrls.gov.uk',
           permissions: 'Basic access',
           roles: [],
+          showEditButton: true,
           status: 'enabled'
         })
       })

--- a/test/presenters/users/internal/details.presenter.test.js
+++ b/test/presenters/users/internal/details.presenter.test.js
@@ -14,14 +14,16 @@ const UsersFixture = require('../../../support/fixtures/users.fixture.js')
 const DetailsPresenter = require('../../../../app/presenters/users/internal/details.presenter.js')
 
 describe('Users - Internal - Details Presenter', () => {
+  let auth
   let user
 
   beforeEach(() => {
+    auth = { credentials: { user: { id: '367e5f4b-07d1-460b-842f-adf8f5dad7ef' } } }
     user = UsersFixture.basicAccess()
   })
 
   it('correctly presents the data', () => {
-    const result = DetailsPresenter.go(user)
+    const result = DetailsPresenter.go(auth, user)
 
     expect(result).to.equal({
       backLink: {
@@ -34,6 +36,7 @@ describe('Users - Internal - Details Presenter', () => {
       pageTitleCaption: user.username,
       permissions: 'Basic access',
       roles: [],
+      showEditButton: true,
       status: 'enabled'
     })
   })
@@ -41,7 +44,7 @@ describe('Users - Internal - Details Presenter', () => {
   describe('the "lastSignedIn" property', () => {
     describe('when the lastLogin is not "null"', () => {
       it('returns the date and time of the last login', () => {
-        const result = DetailsPresenter.go(user)
+        const result = DetailsPresenter.go(auth, user)
 
         expect(result.lastSignedIn).to.equal('6 October 2022 at 10:00:00')
       })
@@ -53,7 +56,7 @@ describe('Users - Internal - Details Presenter', () => {
       })
 
       it('returns "Never signed in"', () => {
-        const result = DetailsPresenter.go(user)
+        const result = DetailsPresenter.go(auth, user)
 
         expect(result.lastSignedIn).to.equal('Never signed in')
       })
@@ -63,7 +66,7 @@ describe('Users - Internal - Details Presenter', () => {
   describe('the "roles" property', () => {
     describe('when the user has no group or user roles', () => {
       it('returns an empty array', () => {
-        const result = DetailsPresenter.go(user)
+        const result = DetailsPresenter.go(auth, user)
 
         expect(result.roles).to.equal([])
       })
@@ -77,7 +80,7 @@ describe('Users - Internal - Details Presenter', () => {
       })
 
       it('returns the "roles" for the group in sentence case, sorted by name', () => {
-        const result = DetailsPresenter.go(user)
+        const result = DetailsPresenter.go(auth, user)
 
         expect(result.roles).to.equal([
           {
@@ -100,7 +103,7 @@ describe('Users - Internal - Details Presenter', () => {
       })
 
       it('returns all "roles" in sentence case, sorted by name', () => {
-        const result = DetailsPresenter.go(user)
+        const result = DetailsPresenter.go(auth, user)
 
         expect(result.roles).to.equal([
           {
@@ -135,7 +138,7 @@ describe('Users - Internal - Details Presenter', () => {
       })
 
       it('returns the "roles" for the group in sentence case, sorted by name, with "unlink" mapped to "unregister"', () => {
-        const result = DetailsPresenter.go(user)
+        const result = DetailsPresenter.go(auth, user)
 
         expect(result.roles).to.equal([
           {
@@ -155,6 +158,40 @@ describe('Users - Internal - Details Presenter', () => {
             name: 'View charge versions'
           }
         ])
+      })
+    })
+  })
+
+  describe('the "showEditButton" property', () => {
+    describe('when the authorised user is different to the one being edited', () => {
+      it('returns "true"', () => {
+        const result = DetailsPresenter.go(auth, user)
+
+        expect(result.showEditButton).to.be.true()
+      })
+    })
+
+    describe('when the user being edited is disabled', () => {
+      beforeEach(() => {
+        user.enabled = false
+      })
+
+      it('returns "false"', () => {
+        const result = DetailsPresenter.go(auth, user)
+
+        expect(result.showEditButton).to.be.false()
+      })
+    })
+
+    describe('when the authorised user is the same as the one being edited', () => {
+      beforeEach(() => {
+        auth = { credentials: { user: { id: user.id } } }
+      })
+
+      it('returns "false"', () => {
+        const result = DetailsPresenter.go(auth, user)
+
+        expect(result.showEditButton).to.be.false()
       })
     })
   })

--- a/test/services/users/internal/view-details.service.test.js
+++ b/test/services/users/internal/view-details.service.test.js
@@ -19,6 +19,7 @@ const FetchUserDetailsDal = require('../../../../app/dal/users/internal/fetch-us
 const ViewDetailsService = require('../../../../app/services/users/internal/view-details.service.js')
 
 describe('Users - Internal - View Details service', () => {
+  const auth = { credentials: { user: { id: '367e5f4b-07d1-460b-842f-adf8f5dad7ef' } } }
   const user = UsersFixture.basicAccess()
 
   beforeEach(() => {
@@ -32,7 +33,7 @@ describe('Users - Internal - View Details service', () => {
 
   describe('when called', () => {
     it('returns page data for the internal user view', async () => {
-      const result = await ViewDetailsService.go(user.id)
+      const result = await ViewDetailsService.go(auth, user.id)
 
       expect(result).to.equal({
         activeNavBar: 'users',
@@ -47,6 +48,7 @@ describe('Users - Internal - View Details service', () => {
         pageTitleCaption: user.username,
         permissions: 'Basic access',
         roles: [],
+        showEditButton: true,
         status: 'enabled'
       })
     })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5678

A user should not be able to edit their own permissions, but is currently able to do so. This is potentially a security risk as it could allow a user to elevate their own permissions.

In this PR some functionality is going to be added that will hide the "Edit" button when a user is viewing their own user details, and prevent them from editing their own user record.