### PR TITLE
Pin GitHub actions to commit SHAs instead of versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
     steps:
       # Downloads a copy of the code in your repository before running CI tests
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 #v6.0.3
         with:
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of SonarQube analysis
 
@@ -95,14 +95,14 @@ jobs:
           fi
 
       - name: Install Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e #v6.4.0
         with:
           node-version-file: '.nvmrc'
 
       # Speeds up workflows by reading the node modules from cache. Obviously you need to run it at least once, and the
       # cache will be updated should the package-lock.json file change
       - name: Cache Node modules
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae #v5.0.5
         with:
           # npm cache files are stored in `~/.npm` on Linux/macOS
           path: ~/.npm
@@ -118,7 +118,7 @@ jobs:
 
       # Run editorconfig check first. No point running the tests if there are issues with the format of the files
       - name: Run editorconfig check
-        uses: editorconfig-checker/action-editorconfig-checker@main
+        uses: editorconfig-checker/action-editorconfig-checker@840e866d93b8e032123c23bac69dece044d4d84c #v2.2.0
 
       - run: editorconfig-checker
 
@@ -141,13 +141,13 @@ jobs:
           npm test
 
       - name: Code coverage
-        uses: livewing/lcov-job-summary@v1.3.0
+        uses: livewing/lcov-job-summary@f61677de6678fb6f860c8d1d35c5b4540b64b1d3 #v1.3.0
         with:
           lcov: coverage/lcov.info
 
       - name: Analyze with SonarQube
         if: github.actor != 'dependabot[bot]'
-        uses: sonarsource/sonarqube-scan-action@master
+        uses: sonarsource/sonarqube-scan-action@713881670b6b3676cda39549040e2d88c70d582e #v8.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This is provided automatically by GitHub
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/shai-hulud-detect.yml
+++ b/.github/workflows/shai-hulud-detect.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       # Downloads a copy of the code in your repository by default
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 #v6.0.3
         with:
           ref: main
           path: project
@@ -22,7 +22,7 @@ jobs:
 
       # Checkout the security scanning repo we're using
       - name: Checkout scanner
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 #v6.0.3
         with:
           repository: Cobenian/shai-hulud-detect
           ref: main


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5675

Defra have updated its Continuous Integration (CI) standards, mandating that any GitHub actions used reference a specific commit SHA rather than a version.

This protects against attackers who gain access to a GitHub action and push a new, exploited version, hoping that those with automated updates install it.

So we are going to go through all water abstraction repositories. Where a .github/*/yml files exist, check for uses: in the steps and update them to be the latest commit SHA for the action instead.