### PR TITLE
Add licence ended modifier

### DIFF
--- a/app/models/licence.model.js
+++ b/app/models/licence.model.js
@@ -181,6 +181,10 @@ class LicenceModel extends BaseModel {
             ])
         })
       },
+      // ended modifier fetches the dates for a licence to determine if a licence has ended
+      ended(query) {
+        query.select(['expiredDate', 'lapsedDate', 'revokedDate'])
+      },
       // licenceHolder modifier fetches all the joined records needed to identify the licence holder
       licenceHolder(query) {
         query

--- a/test/models/licence.model.test.js
+++ b/test/models/licence.model.test.js
@@ -682,6 +682,22 @@ describe('Licence model', () => {
       revokedDate = null
     })
 
+    describe('when the "ended" modifier has been used', () => {
+      let testLicence
+
+      before(async () => {
+        testLicence = await LicenceModel.query().findById(testRecord.id).modify('ended')
+      })
+
+      it('returns the dates', () => {
+        expect(testLicence).to.equal({
+          expiredDate: null,
+          lapsedDate: null,
+          revokedDate: null
+        })
+      })
+    })
+
     describe('when a licence has ended', () => {
       describe('because is has expired', () => {
         beforeEach(() => {

--- a/test/models/licence.model.test.js
+++ b/test/models/licence.model.test.js
@@ -687,6 +687,7 @@ describe('Licence model', () => {
         const result = await LicenceModel.query().select(['id']).findById(testRecord.id).modify('ended')
 
         expect(result).to.equal({
+          id: testRecord.id,
           expiredDate: null,
           lapsedDate: null,
           revokedDate: null

--- a/test/models/licence.model.test.js
+++ b/test/models/licence.model.test.js
@@ -683,14 +683,10 @@ describe('Licence model', () => {
     })
 
     describe('when the "ended" modifier has been used', () => {
-      let testLicence
+      it('returns the dates', async () => {
+        const result = await LicenceModel.query().findById(testRecord.id).modify('ended')
 
-      before(async () => {
-        testLicence = await LicenceModel.query().findById(testRecord.id).modify('ended')
-      })
-
-      it('returns the dates', () => {
-        expect(testLicence).to.equal({
+        expect(result).to.equal({
           expiredDate: null,
           lapsedDate: null,
           revokedDate: null

--- a/test/models/licence.model.test.js
+++ b/test/models/licence.model.test.js
@@ -684,7 +684,7 @@ describe('Licence model', () => {
 
     describe('when the "ended" modifier has been used', () => {
       it('returns the dates', async () => {
-        const result = await LicenceModel.query().findById(testRecord.id).modify('ended')
+        const result = await LicenceModel.query().select(['id']).findById(testRecord.id).modify('ended')
 
         expect(result).to.equal({
           expiredDate: null,


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5683

This change adds an 'ended' modifier to the lcience model, this works alongside the 'ended' instance method to establish if a licence has ended.