### PR TITLE
Add licence ended check for abstraction alert notices

### DIFF
--- a/app/dal/monitoring-stations/fetch-monitoring-station-details.dal.js
+++ b/app/dal/monitoring-stations/fetch-monitoring-station-details.dal.js
@@ -2,7 +2,7 @@
 
 /**
  * Fetches the matching monitoring station and additional records needed for the view monitoring station page
- * @module FetchMonitoringStationDetailsService
+ * @module FetchMonitoringStationDetailsDal
  */
 
 const LicenceMonitoringStationModel = require('../../models/licence-monitoring-station.model.js')

--- a/app/services/monitoring-stations/fetch-monitoring-station-details.service.js
+++ b/app/services/monitoring-stations/fetch-monitoring-station-details.service.js
@@ -68,7 +68,7 @@ async function _fetchLicenceMonitoringStations(monitoringStationId) {
     ])
     .withGraphFetched('licence')
     .modifyGraph('licence', (licenceBuilder) => {
-      licenceBuilder.select(['id', 'licenceRef', 'revokedDate', 'expiredDate', 'lapsedDate'])
+      licenceBuilder.select(['id', 'licenceRef']).modify('ended')
     })
     .withGraphFetched('licenceVersionPurposeCondition')
     .modifyGraph('licenceVersionPurposeCondition', (licenceVersionPurposeConditionBuilder) => {

--- a/app/services/monitoring-stations/fetch-monitoring-station-details.service.js
+++ b/app/services/monitoring-stations/fetch-monitoring-station-details.service.js
@@ -68,7 +68,7 @@ async function _fetchLicenceMonitoringStations(monitoringStationId) {
     ])
     .withGraphFetched('licence')
     .modifyGraph('licence', (licenceBuilder) => {
-      licenceBuilder.select(['id', 'licenceRef'])
+      licenceBuilder.select(['id', 'licenceRef', 'revokedDate', 'expiredDate', 'lapsedDate'])
     })
     .withGraphFetched('licenceVersionPurposeCondition')
     .modifyGraph('licenceVersionPurposeCondition', (licenceVersionPurposeConditionBuilder) => {

--- a/app/services/monitoring-stations/view.service.js
+++ b/app/services/monitoring-stations/view.service.js
@@ -5,7 +5,7 @@
  * @module ViewService
  */
 
-const FetchMonitoringStationDetailsService = require('../monitoring-stations/fetch-monitoring-station-details.service.js')
+const FetchMonitoringStationDetailsDal = require('../../dal/monitoring-stations/fetch-monitoring-station-details.dal.js')
 const ViewPresenter = require('../../presenters/monitoring-stations/view.presenter.js')
 const { readFlashNotification } = require('../../lib/general.lib.js')
 
@@ -20,7 +20,7 @@ const { readFlashNotification } = require('../../lib/general.lib.js')
  */
 async function go(auth, monitoringStationId, yar) {
   const { licenceMonitoringStations, monitoringStation } =
-    await FetchMonitoringStationDetailsService.go(monitoringStationId)
+    await FetchMonitoringStationDetailsDal.go(monitoringStationId)
 
   const pageData = ViewPresenter.go(monitoringStation, licenceMonitoringStations, auth)
 

--- a/app/services/notices/setup/abstraction-alerts/determine-licence-monitoring-stations.service.js
+++ b/app/services/notices/setup/abstraction-alerts/determine-licence-monitoring-stations.service.js
@@ -5,7 +5,7 @@
  * @module DetermineLicenceMonitoringStationsService
  */
 
-const FetchMonitoringStationDetailsService = require('../../../monitoring-stations/fetch-monitoring-station-details.service.js')
+const FetchMonitoringStationDetailsDal = require('../../../../dal/monitoring-stations/fetch-monitoring-station-details.dal.js')
 
 /**
  * Orchestrates fetching and formatting the data needed for the Monitoring station journey
@@ -14,7 +14,7 @@ const FetchMonitoringStationDetailsService = require('../../../monitoring-statio
  * @returns {Promise<{object}>}
  */
 async function go(id) {
-  const { licenceMonitoringStations, monitoringStation } = await FetchMonitoringStationDetailsService.go(id)
+  const { licenceMonitoringStations, monitoringStation } = await FetchMonitoringStationDetailsDal.go(id)
 
   return {
     licenceMonitoringStations: _licenceMonitoringStations(licenceMonitoringStations),

--- a/app/services/notices/setup/abstraction-alerts/determine-licence-monitoring-stations.service.js
+++ b/app/services/notices/setup/abstraction-alerts/determine-licence-monitoring-stations.service.js
@@ -34,7 +34,11 @@ function _abstractionPeriod(licenceMonitoringStation) {
 }
 
 function _licenceMonitoringStations(licenceMonitoringStations) {
-  return licenceMonitoringStations.map((licenceMonitoringStation) => {
+  const licenceMonitoringStationsWithActiveLicence = licenceMonitoringStations.filter((licenceMonitoringStation) => {
+    return !licenceMonitoringStation.licence.$ended()
+  })
+
+  return licenceMonitoringStationsWithActiveLicence.map((licenceMonitoringStation) => {
     const { id, latestNotification, licence, measureType, restrictionType, thresholdUnit, thresholdValue } =
       licenceMonitoringStation
 

--- a/test/services/monitoring-stations/fetch-monitoring-station-details.service.test.js
+++ b/test/services/monitoring-stations/fetch-monitoring-station-details.service.test.js
@@ -19,9 +19,9 @@ const NotificationHelper = require('../../support/helpers/notification.helper.js
 const PointHelper = require('../../support/helpers/point.helper.js')
 
 // Thing under test
-const FetchMonitoringStationDetailsService = require('../../../app/services/monitoring-stations/fetch-monitoring-station-details.service.js')
+const FetchMonitoringStationDetailsDal = require('../../../app/dal/monitoring-stations/fetch-monitoring-station-details.dal.js')
 
-describe('Monitoring Stations - Fetch Monitoring Station Details service', () => {
+describe('Monitoring Stations - Fetch Monitoring Station Details Dal', () => {
   let monitoringStation
   let licenceMonitoringStationOne
   let licenceMonitoringStationTwo
@@ -100,7 +100,7 @@ describe('Monitoring Stations - Fetch Monitoring Station Details service', () =>
       })
 
       it('returns the matching monitoring station with its licence monitoring stations correctly ordered', async () => {
-        const result = await FetchMonitoringStationDetailsService.go(monitoringStation.id)
+        const result = await FetchMonitoringStationDetailsDal.go(monitoringStation.id)
 
         expect(result.monitoringStation).to.equal({
           catchmentName: null,
@@ -186,7 +186,7 @@ describe('Monitoring Stations - Fetch Monitoring Station Details service', () =>
 
     describe('but it has no tagged licences with restrictions', () => {
       it('returns the matching monitoring station with no licence monitoring stations', async () => {
-        const result = await FetchMonitoringStationDetailsService.go(monitoringStation.id)
+        const result = await FetchMonitoringStationDetailsDal.go(monitoringStation.id)
 
         expect(result.monitoringStation).to.equal({
           catchmentName: null,
@@ -205,7 +205,7 @@ describe('Monitoring Stations - Fetch Monitoring Station Details service', () =>
 
   describe('when no matching monitoring station exists', () => {
     it('returns empty values', async () => {
-      const result = await FetchMonitoringStationDetailsService.go('dfa47d48-0c98-4707-a5b8-820eb16c1dfd')
+      const result = await FetchMonitoringStationDetailsDal.go('dfa47d48-0c98-4707-a5b8-820eb16c1dfd')
 
       expect(result.monitoringStation).to.be.undefined()
       expect(result.licenceMonitoringStations).to.equal([])

--- a/test/services/monitoring-stations/fetch-monitoring-station-details.service.test.js
+++ b/test/services/monitoring-stations/fetch-monitoring-station-details.service.test.js
@@ -125,8 +125,11 @@ describe('Monitoring Stations - Fetch Monitoring Station Details service', () =>
             thresholdValue: 150,
             latestNotification: null,
             licence: {
+              expiredDate: null,
               id: licenceTwo.licence.id,
-              licenceRef: licenceTwo.licence.licenceRef
+              lapsedDate: null,
+              licenceRef: licenceTwo.licence.licenceRef,
+              revokedDate: null
             },
             licenceVersionPurposeCondition: null
           },
@@ -146,8 +149,11 @@ describe('Monitoring Stations - Fetch Monitoring Station Details service', () =>
               sendingAlertType: 'stop'
             },
             licence: {
+              expiredDate: null,
               id: licenceTwo.licence.id,
-              licenceRef: licenceTwo.licence.licenceRef
+              lapsedDate: null,
+              licenceRef: licenceTwo.licence.licenceRef,
+              revokedDate: null
             },
             licenceVersionPurposeCondition: null
           },
@@ -163,8 +169,11 @@ describe('Monitoring Stations - Fetch Monitoring Station Details service', () =>
             thresholdValue: 100,
             latestNotification: null,
             licence: {
+              expiredDate: null,
               id: licenceOne.licence.id,
-              licenceRef: licenceOne.licence.licenceRef
+              lapsedDate: null,
+              licenceRef: licenceOne.licence.licenceRef,
+              revokedDate: null
             },
             licenceVersionPurposeCondition: {
               id: licenceOne.purposeCondition.id,

--- a/test/services/monitoring-stations/view.service.test.js
+++ b/test/services/monitoring-stations/view.service.test.js
@@ -12,7 +12,7 @@ const { expect } = Code
 const YarStub = require('../../support/stubs/yar.stub.js')
 
 // Things we need to stub
-const FetchMonitoringStationDetailsService = require('../../../app/services/monitoring-stations/fetch-monitoring-station-details.service.js')
+const FetchMonitoringStationDetailsDal = require('../../../app/dal/monitoring-stations/fetch-monitoring-station-details.dal.js')
 
 // Thing under test
 const ViewService = require('../../../app/services/monitoring-stations/view.service.js')
@@ -63,7 +63,7 @@ describe('Monitoring Stations - View service', () => {
     yarStub = YarStub.build(Sinon)
     yarStub.flash.returns(['Tag removed for 99/999/9999'])
 
-    Sinon.stub(FetchMonitoringStationDetailsService, 'go').resolves({ licenceMonitoringStations, monitoringStation })
+    Sinon.stub(FetchMonitoringStationDetailsDal, 'go').resolves({ licenceMonitoringStations, monitoringStation })
   })
 
   afterEach(() => {

--- a/test/services/notices/setup/abstraction-alerts/determine-licence-monitoring-stations.service.test.js
+++ b/test/services/notices/setup/abstraction-alerts/determine-licence-monitoring-stations.service.test.js
@@ -15,7 +15,7 @@ const { generateUUID } = require('../../../../../app/lib/general.lib.js')
 const { yesterday } = require('../../../../support/general.js')
 
 // Things we need to stub
-const FetchMonitoringStationDetailsService = require('../../../../../app/services/monitoring-stations/fetch-monitoring-station-details.service.js')
+const FetchMonitoringStationDetailsDal = require('../../../../../app/dal/monitoring-stations/fetch-monitoring-station-details.dal.js')
 
 // Thing under test
 const DetermineLicenceMonitoringStationsService = require('../../../../../app/services/notices/setup/abstraction-alerts/determine-licence-monitoring-stations.service.js')
@@ -24,7 +24,7 @@ describe('Notices Setup - Abstraction Alerts - Determine Licence Monitoring Stat
   let licenceMonitoringStations
   let monitoringStation
   let monitoringStationId
-  let stubFetchMonitoringStationDetailsService
+  let stubFetchMonitoringStationDetailsDal
 
   beforeEach(() => {
     monitoringStationId = generateUUID()
@@ -108,7 +108,7 @@ describe('Notices Setup - Abstraction Alerts - Determine Licence Monitoring Stat
       }
     ]
 
-    stubFetchMonitoringStationDetailsService = Sinon.stub(FetchMonitoringStationDetailsService, 'go').resolves({
+    stubFetchMonitoringStationDetailsDal = Sinon.stub(FetchMonitoringStationDetailsDal, 'go').resolves({
       licenceMonitoringStations,
       monitoringStation
     })
@@ -198,7 +198,7 @@ describe('Notices Setup - Abstraction Alerts - Determine Licence Monitoring Stat
       licenceMonitoringStations[1].licence.revokedDate = yesterday()
       licenceMonitoringStations[2].licence.expiredDate = yesterday()
 
-      stubFetchMonitoringStationDetailsService.resolves({
+      stubFetchMonitoringStationDetailsDal.resolves({
         licenceMonitoringStations,
         monitoringStation
       })

--- a/test/services/notices/setup/abstraction-alerts/determine-licence-monitoring-stations.service.test.js
+++ b/test/services/notices/setup/abstraction-alerts/determine-licence-monitoring-stations.service.test.js
@@ -9,7 +9,10 @@ const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
+const LicenceModel = require('../../../../../app/models/licence.model.js')
+const { generateLicenceRef } = require('../../../../support/helpers/licence.helper.js')
 const { generateUUID } = require('../../../../../app/lib/general.lib.js')
+const { yesterday } = require('../../../../support/general.js')
 
 // Things we need to stub
 const FetchMonitoringStationDetailsService = require('../../../../../app/services/monitoring-stations/fetch-monitoring-station-details.service.js')
@@ -18,35 +21,43 @@ const FetchMonitoringStationDetailsService = require('../../../../../app/service
 const DetermineLicenceMonitoringStationsService = require('../../../../../app/services/notices/setup/abstraction-alerts/determine-licence-monitoring-stations.service.js')
 
 describe('Notices Setup - Abstraction Alerts - Determine Licence Monitoring Stations service', () => {
-  const monitoringStationId = generateUUID()
+  let licenceMonitoringStations
+  let monitoringStation
+  let monitoringStationId
+  let stubFetchMonitoringStationDetailsService
 
-  beforeEach(async () => {
-    const monitoringStation = {
+  beforeEach(() => {
+    monitoringStationId = generateUUID()
+
+    monitoringStation = {
       catchmentName: null,
       gridReference: 'TL2664640047',
-      id: 'f122d4bb-42bd-4af9-a081-1656f5a30b63',
+      id: generateUUID(),
       label: 'BUSY POINT',
       riverName: null,
       stationReference: null,
       wiskiId: null
     }
 
-    const licenceMonitoringStations = [
+    licenceMonitoringStations = [
       {
         abstractionPeriodEndDay: 31,
         abstractionPeriodEndMonth: 8,
         abstractionPeriodStartDay: 1,
         abstractionPeriodStartMonth: 4,
-        id: '3ee344db-784c-4d21-8d53-e50833f7e848',
+        id: generateUUID(),
         measureType: 'flow',
         restrictionType: 'reduce',
         thresholdUnit: 'm3/s',
         thresholdValue: 100,
         latestNotification: null,
-        licence: {
-          id: '3cd1481c-e96a-45fc-8f2b-1849564b95a5',
-          licenceRef: '01/01/01/6880'
-        },
+        licence: LicenceModel.fromJson({
+          expiredDate: null,
+          id: generateUUID(),
+          lapsedDate: null,
+          licenceRef: generateLicenceRef(),
+          revokedDate: null
+        }),
         licenceVersionPurposeCondition: null
       },
       {
@@ -54,18 +65,21 @@ describe('Notices Setup - Abstraction Alerts - Determine Licence Monitoring Stat
         abstractionPeriodEndMonth: 3,
         abstractionPeriodStartDay: 1,
         abstractionPeriodStartMonth: 1,
-        id: '0cfcfcb0-989e-481f-9cc1-10a69d82ff3f',
+        id: generateUUID(),
         measureType: 'level',
         restrictionType: 'reduce',
         thresholdUnit: 'm3/s',
         thresholdValue: 100,
         latestNotification: null,
-        licence: {
-          id: 'bcf94daa-50bc-4567-88a0-1f9e6cc79d42',
-          licenceRef: '02/02/02/3116'
-        },
+        licence: LicenceModel.fromJson({
+          expiredDate: null,
+          id: generateUUID(),
+          lapsedDate: null,
+          licenceRef: generateLicenceRef(),
+          revokedDate: null
+        }),
         licenceVersionPurposeCondition: {
-          id: '3f01d2d9-d23b-4697-b215-2ee3836feabb',
+          id: generateUUID(),
           notes: 'I have a bad feeling about this'
         }
       },
@@ -74,23 +88,30 @@ describe('Notices Setup - Abstraction Alerts - Determine Licence Monitoring Stat
         abstractionPeriodEndMonth: 3,
         abstractionPeriodStartDay: 1,
         abstractionPeriodStartMonth: 1,
-        id: '0cfcfcb0-989e-481f-9cc1-10a69d8434',
+        id: generateUUID(),
+        latestNotification: null,
+        licence: LicenceModel.fromJson({
+          expiredDate: null,
+          id: generateUUID(),
+          lapsedDate: null,
+          licenceRef: generateLicenceRef(),
+          revokedDate: null
+        }),
+        licenceVersionPurposeCondition: {
+          id: generateUUID(),
+          notes: '"                   "             "                    "'
+        },
         measureType: 'level',
         restrictionType: 'reduce',
         thresholdUnit: 'm3/s',
-        thresholdValue: 100,
-        latestNotification: null,
-        licence: {
-          id: '039dccde-432d-4255-b788-73ac86d90d92',
-          licenceRef: '02/02/02/3116'
-        },
-        licenceVersionPurposeCondition: {
-          id: '3f01d2d9-d23b-4697-b215-2ee3836feabb',
-          notes: '"                   "             "                    "'
-        }
+        thresholdValue: 100
       }
     ]
-    Sinon.stub(FetchMonitoringStationDetailsService, 'go').resolves({ licenceMonitoringStations, monitoringStation })
+
+    stubFetchMonitoringStationDetailsService = Sinon.stub(FetchMonitoringStationDetailsService, 'go').resolves({
+      licenceMonitoringStations,
+      monitoringStation
+    })
   })
 
   afterEach(() => {
@@ -107,59 +128,113 @@ describe('Notices Setup - Abstraction Alerts - Determine Licence Monitoring Stat
           abstractionPeriodEndMonth: 8,
           abstractionPeriodStartDay: 1,
           abstractionPeriodStartMonth: 4,
-          id: '3ee344db-784c-4d21-8d53-e50833f7e848',
+          id: licenceMonitoringStations[0].id,
+          latestNotification: null,
+          licence: {
+            expiredDate: null,
+            id: licenceMonitoringStations[0].licence.id,
+            lapsedDate: null,
+            licenceRef: licenceMonitoringStations[0].licence.licenceRef,
+            revokedDate: null
+          },
           measureType: 'flow',
-          restrictionType: 'reduce',
-          thresholdUnit: 'm3/s',
-          thresholdValue: 100,
-          latestNotification: null,
-          licence: {
-            id: '3cd1481c-e96a-45fc-8f2b-1849564b95a5',
-            licenceRef: '01/01/01/6880'
-          },
           notes: null,
-          thresholdGroup: 'flow-100-m3/s'
+          restrictionType: 'reduce',
+          thresholdGroup: 'flow-100-m3/s',
+          thresholdUnit: 'm3/s',
+          thresholdValue: 100
         },
         {
           abstractionPeriodEndDay: 31,
           abstractionPeriodEndMonth: 3,
           abstractionPeriodStartDay: 1,
           abstractionPeriodStartMonth: 1,
-          id: '0cfcfcb0-989e-481f-9cc1-10a69d82ff3f',
-          measureType: 'level',
-          restrictionType: 'reduce',
-          thresholdUnit: 'm3/s',
-          thresholdValue: 100,
+          id: licenceMonitoringStations[1].id,
           latestNotification: null,
           licence: {
-            id: 'bcf94daa-50bc-4567-88a0-1f9e6cc79d42',
-            licenceRef: '02/02/02/3116'
+            expiredDate: null,
+            id: licenceMonitoringStations[1].licence.id,
+            lapsedDate: null,
+            licenceRef: licenceMonitoringStations[1].licence.licenceRef,
+            revokedDate: null
           },
+          measureType: 'level',
           notes: 'I have a bad feeling about this',
-          thresholdGroup: 'level-100-m3/s'
+          restrictionType: 'reduce',
+          thresholdGroup: 'level-100-m3/s',
+          thresholdUnit: 'm3/s',
+          thresholdValue: 100
         },
         {
           abstractionPeriodEndDay: 31,
           abstractionPeriodEndMonth: 3,
           abstractionPeriodStartDay: 1,
           abstractionPeriodStartMonth: 1,
-          id: '0cfcfcb0-989e-481f-9cc1-10a69d8434',
-          measureType: 'level',
-          restrictionType: 'reduce',
-          thresholdUnit: 'm3/s',
-          thresholdValue: 100,
+          id: licenceMonitoringStations[2].id,
           latestNotification: null,
           licence: {
-            id: '039dccde-432d-4255-b788-73ac86d90d92',
-            licenceRef: '02/02/02/3116'
+            expiredDate: null,
+            id: licenceMonitoringStations[2].licence.id,
+            lapsedDate: null,
+            licenceRef: licenceMonitoringStations[2].licence.licenceRef,
+            revokedDate: null
           },
+          measureType: 'level',
           notes: '"                   "             "                    "',
-          thresholdGroup: 'level-100-m3/s'
+          restrictionType: 'reduce',
+          thresholdGroup: 'level-100-m3/s',
+          thresholdUnit: 'm3/s',
+          thresholdValue: 100
         }
       ],
       monitoringStationId,
       monitoringStationName: 'BUSY POINT',
       monitoringStationRiverName: null
+    })
+  })
+
+  describe('when a licence has ended', () => {
+    beforeEach(() => {
+      licenceMonitoringStations[1].licence.revokedDate = yesterday()
+      licenceMonitoringStations[2].licence.expiredDate = yesterday()
+
+      stubFetchMonitoringStationDetailsService.resolves({
+        licenceMonitoringStations,
+        monitoringStation
+      })
+    })
+
+    it('does not return ended licences', async () => {
+      const result = await DetermineLicenceMonitoringStationsService.go(monitoringStationId)
+
+      expect(result).to.equal({
+        licenceMonitoringStations: [
+          {
+            abstractionPeriodEndDay: 31,
+            abstractionPeriodEndMonth: 8,
+            abstractionPeriodStartDay: 1,
+            abstractionPeriodStartMonth: 4,
+            id: licenceMonitoringStations[0].id,
+            latestNotification: null,
+            licence: {
+              expiredDate: null,
+              id: licenceMonitoringStations[0].licence.id,
+              lapsedDate: null,
+              licenceRef: licenceMonitoringStations[0].licence.licenceRef,
+              revokedDate: null
+            },
+            measureType: 'flow',
+            notes: null,
+            restrictionType: 'reduce',
+            thresholdGroup: 'flow-100-m3/s',
+            thresholdUnit: 'm3/s',
+            thresholdValue: 100
+          }
+        ],
+        monitoringStationId,
+        monitoringStationName: 'BUSY POINT',
+        monitoringStationRiverName: null
+      })
     })
   })
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5683

We do not want to send abstracuiton alerts to ended licences.

This change adds a check if the licence has ended using the "$ended" modified and instance method.

This change also refactors the fetch service into the dal folder. 