### PR TITLE
Only allow tagging an active licences for a monitoring station

### DIFF
--- a/app/dal/licence-monitoring-station/fetch-licence.dal.js
+++ b/app/dal/licence-monitoring-station/fetch-licence.dal.js
@@ -1,0 +1,25 @@
+'use strict'
+
+/**
+ * Fetches a licence for the given licence reference with the data needed to determine if it has ended.
+ *
+ * @module FetchLicenceDal
+ */
+
+const LicenceModel = require('../../models/licence.model.js')
+
+/**
+ * Fetches a licence for the given licence reference with the data needed to determine if it has ended.
+ *
+ * @param {string} licenceRef - The licence reference to fetch
+ *
+ * @returns {Promise<object>} The licence with the data needed to determine if it has ended (expiredDate,
+ * lapsedDate, revokedDate)
+ */
+async function go(licenceRef) {
+  return LicenceModel.query().where('licenceRef', licenceRef).select('id', 'licenceRef').modify('ended').first()
+}
+
+module.exports = {
+  go
+}

--- a/app/services/licence-monitoring-station/setup/submit-licence-number.service.js
+++ b/app/services/licence-monitoring-station/setup/submit-licence-number.service.js
@@ -6,8 +6,8 @@
  * @module SubmitLicenceNumberService
  */
 
+const FetchLicenceDal = require('../../../dal/licence-monitoring-station/fetch-licence.dal.js')
 const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
-const LicenceModel = require('../../../models/licence.model.js')
 const LicenceNumberPresenter = require('../../../presenters/licence-monitoring-station/setup/licence-number.presenter.js')
 const LicenceNumberValidator = require('../../../validators/licence-monitoring-station/setup/licence-number.validator.js')
 
@@ -22,7 +22,7 @@ const LicenceNumberValidator = require('../../../validators/licence-monitoring-s
 async function go(sessionId, payload) {
   const session = await FetchSessionDal.go(sessionId)
 
-  const licence = payload.licenceRef ? await _fetchLicence(payload.licenceRef) : null
+  const licence = payload.licenceRef ? await FetchLicenceDal.go(payload.licenceRef) : null
 
   const validationResult = await _validate(payload, licence)
 
@@ -48,10 +48,6 @@ async function go(sessionId, payload) {
   }
 }
 
-async function _fetchLicence(licenceRef) {
-  return LicenceModel.query().where('licenceRef', licenceRef).select('id', 'licenceRef').first()
-}
-
 async function _save(session, payload, licence) {
   session.licenceId = licence.id
   session.licenceRef = payload.licenceRef
@@ -66,9 +62,7 @@ function _submittedSessionData(session, payload) {
 }
 
 async function _validate(payload, licence) {
-  const licenceExists = !!licence
-
-  const validation = LicenceNumberValidator.go(payload, licenceExists)
+  const validation = LicenceNumberValidator.go(payload, licence)
 
   if (!validation.error) {
     return null

--- a/app/validators/helpers/is-false.validator.js
+++ b/app/validators/helpers/is-false.validator.js
@@ -4,20 +4,21 @@
  * Custom Joi validator that fails when the provided flag is true
  *
  * @param {boolean} booleanToCheck - Flag indicating whether validation should fail
+ * @param {string} [errorKey='custom.isFalse'] - The Joi error key to return on failure
  *
  * @returns {Function} Joi custom validator callback
  *
  * The returned callback:
  * - returns the validated field value when booleanToCheck is false
- * - returns helpers.error('custom.isFalse') when booleanToCheck is true
+ * - returns helpers.error(errorKey) when booleanToCheck is true, defaulting to 'custom.isFalse'
  */
-function isFalse(booleanToCheck) {
+function isFalse(booleanToCheck, errorKey = 'custom.isFalse') {
   return function (value, helpers) {
     if (booleanToCheck === false) {
       return value
     }
 
-    return helpers.error('custom.isFalse')
+    return helpers.error(errorKey)
   }
 }
 module.exports = {

--- a/app/validators/licence-monitoring-station/setup/licence-number.validator.js
+++ b/app/validators/licence-monitoring-station/setup/licence-number.validator.js
@@ -8,26 +8,31 @@
 
 const Joi = require('joi')
 
+const { isFalse } = require('../../helpers/is-false.validator.js')
+
 const ENTER_A_LICENCE_NUMBER_ERROR = 'Enter a licence number'
 
 /**
  * Validates data submitted for the `/licence-monitoring-station/setup/{sessionId}/licence-number` page
  *
  * @param {object} payload - The payload from the request to be validated
- * @param {boolean} licenceExists - the result of checking if the licence ref is present in the database
+ * @param {object|null} licence - the licence if it exists
  *
  * @returns {object} the result from calling Joi's schema.validate(). It will be an object with a `value:` property. If
  * any errors are found the `error:` property will also exist detailing what the issues were
  */
-function go(payload, licenceExists) {
+function go(payload, licence) {
+  const licenceExists = !!licence
+  const licenceHasEnded = licence?.$ended() ?? false
+
   const schema = Joi.object({
     licenceRef: Joi.string()
       .required()
-      .custom((value, helpers) => {
-        return _licenceExists(value, helpers, licenceExists)
-      }, 'Custom Licence Validation')
+      .custom(isFalse(!licenceExists, 'invalidLicence'))
+      .custom(isFalse(licenceHasEnded, 'licenceEnded'))
       .messages({
         invalidLicence: 'Licence could not be found',
+        licenceEnded: 'The licence has ended',
         'any.required': ENTER_A_LICENCE_NUMBER_ERROR,
         'any.only': ENTER_A_LICENCE_NUMBER_ERROR,
         'string.empty': ENTER_A_LICENCE_NUMBER_ERROR
@@ -35,14 +40,6 @@ function go(payload, licenceExists) {
   })
 
   return schema.validate(payload, { abortEarly: false })
-}
-
-function _licenceExists(value, helpers, licenceExists) {
-  if (licenceExists) {
-    return value
-  }
-
-  return helpers.error('invalidLicence')
 }
 
 module.exports = {

--- a/test/dal/licence-monitoring-station/fetch-licence.dal.test.js
+++ b/test/dal/licence-monitoring-station/fetch-licence.dal.test.js
@@ -1,0 +1,49 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, after, before } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Test helpers
+const LicenceHelper = require('../../support/helpers/licence.helper.js')
+const { generateUUID } = require('../../../app/lib/general.lib.js')
+
+// Thing under test
+const FetchLicenceDal = require('../../../app/dal/licence-monitoring-station/fetch-licence.dal.js')
+
+describe('Licence Monitoring Station - Fetch Licence DAL', () => {
+  let licence
+
+  before(async () => {
+    licence = await LicenceHelper.add()
+  })
+
+  after(async () => {
+    await licence.$query().delete()
+  })
+
+  describe('when the licence exists', () => {
+    it('returns the licence with the data needed to determine if it has ended', async () => {
+      const result = await FetchLicenceDal.go(licence.licenceRef)
+
+      expect(result).to.equal({
+        expiredDate: null,
+        id: licence.id,
+        lapsedDate: null,
+        licenceRef: licence.licenceRef,
+        revokedDate: null
+      })
+    })
+  })
+
+  describe('when the licence does not exist', () => {
+    it('returns undefined', async () => {
+      const result = await FetchLicenceDal.go(generateUUID())
+
+      expect(result).to.be.undefined()
+    })
+  })
+})

--- a/test/services/licence-monitoring-station/setup/submit-licence-number.service.test.js
+++ b/test/services/licence-monitoring-station/setup/submit-licence-number.service.test.js
@@ -9,23 +9,37 @@ const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const LicenceHelper = require('../../../support/helpers/licence.helper.js')
+const LicenceModel = require('../../../../app/models/licence.model.js')
 const SessionModelStub = require('../../../support/stubs/session.stub.js')
+const { generateUUID } = require('../../../../app/lib/general.lib.js')
+const { generateLicenceRef } = require('../../../support/helpers/licence.helper.js')
 
 // Things we need to stub
+const FetchLicenceDal = require('../../../../app/dal/licence-monitoring-station/fetch-licence.dal.js')
 const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
 // Thing under test
 const SubmitLicenceNumberService = require('../../../../app/services/licence-monitoring-station/setup/submit-licence-number.service.js')
 
 describe('Licence Monitoring Station Setup - Licence Number Service', () => {
+  let fetchLicenceStub
   let fetchSessionStub
+  let licence
   let payload
   let session
   let sessionData
 
   beforeEach(() => {
     payload = {}
+
+    licence = LicenceModel.fromJson({
+      expiredDate: null,
+      id: generateUUID(),
+      lapsedDate: null,
+      licenceRef: generateLicenceRef(),
+      revokedDate: null
+    })
+
     sessionData = {
       label: 'LABEL'
     }
@@ -33,6 +47,8 @@ describe('Licence Monitoring Station Setup - Licence Number Service', () => {
     session = SessionModelStub.build(Sinon, sessionData)
 
     fetchSessionStub = Sinon.stub(FetchSessionDal, 'go').resolves(session)
+
+    fetchLicenceStub = Sinon.stub(FetchLicenceDal, 'go').resolves(licence)
   })
 
   afterEach(() => {
@@ -41,10 +57,7 @@ describe('Licence Monitoring Station Setup - Licence Number Service', () => {
 
   describe('when called', () => {
     describe('and the licence exists', () => {
-      let licence
-
       beforeEach(async () => {
-        licence = await LicenceHelper.add()
         payload = { licenceRef: licence.licenceRef }
       })
 
@@ -140,6 +153,8 @@ describe('Licence Monitoring Station Setup - Licence Number Service', () => {
   describe('and the licence does not exist', () => {
     beforeEach(() => {
       payload = { licenceRef: '1234567890' }
+
+      fetchLicenceStub.resolves(null)
     })
 
     it('returns page data for the view, with errors', async () => {

--- a/test/validators/licence-monitoring-station/setup/licence-number.validator.test.js
+++ b/test/validators/licence-monitoring-station/setup/licence-number.validator.test.js
@@ -7,23 +7,38 @@ const Code = require('@hapi/code')
 const { describe, it, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
+// Test helpers
+const LicenceModel = require('../../../../app/models/licence.model.js')
+const { yesterday } = require('../../../support/general.js')
+const { generateUUID } = require('../../../../app/lib/general.lib.js')
+const { generateLicenceRef } = require('../../../support/helpers/licence.helper.js')
+
 // Thing under test
 const LicenceNumberValidator = require('../../../../app/validators/licence-monitoring-station/setup/licence-number.validator.js')
 
 describe('Licence Monitoring Station Setup - Licence Number Validator', () => {
-  let licenceExists
+  let licence
   let payload = {}
+
+  beforeEach(() => {
+    licence = LicenceModel.fromJson({
+      expiredDate: null,
+      id: generateUUID(),
+      lapsedDate: null,
+      licenceRef: generateLicenceRef(),
+      revokedDate: null
+    })
+  })
 
   describe('when called with valid data', () => {
     beforeEach(() => {
-      licenceExists = true
       payload = {
         licenceRef: '1234567890'
       }
     })
 
     it('returns with no errors', () => {
-      const result = LicenceNumberValidator.go(payload, licenceExists)
+      const result = LicenceNumberValidator.go(payload, licence)
 
       expect(result.value).to.exist()
       expect(result.error).not.to.exist()
@@ -37,7 +52,7 @@ describe('Licence Monitoring Station Setup - Licence Number Validator', () => {
       })
 
       it('returns with errors', () => {
-        const result = LicenceNumberValidator.go(payload)
+        const result = LicenceNumberValidator.go(payload, licence)
 
         expect(result.value).to.exist()
         expect(result.error).to.exist()
@@ -53,7 +68,7 @@ describe('Licence Monitoring Station Setup - Licence Number Validator', () => {
       })
 
       it('returns with errors', () => {
-        const result = LicenceNumberValidator.go(payload)
+        const result = LicenceNumberValidator.go(payload, licence)
 
         expect(result.value).to.exist()
         expect(result.error).to.exist()
@@ -63,18 +78,37 @@ describe('Licence Monitoring Station Setup - Licence Number Validator', () => {
 
     describe('because the licence number was not found', () => {
       beforeEach(() => {
-        licenceExists = false
+        licence = undefined
+
         payload = {
-          licenceRef: '1234567890'
+          licenceRef: generateLicenceRef()
         }
       })
 
       it('returns with errors', () => {
-        const result = LicenceNumberValidator.go(payload, licenceExists)
+        const result = LicenceNumberValidator.go(payload, licence)
 
         expect(result.value).to.exist()
         expect(result.error).to.exist()
         expect(result.error.details[0].message).to.equal('Licence could not be found')
+      })
+    })
+
+    describe('because the licence has ended', () => {
+      beforeEach(() => {
+        licence.lapsedDate = yesterday()
+
+        payload = {
+          licenceRef: generateLicenceRef()
+        }
+      })
+
+      it('returns with errors', () => {
+        const result = LicenceNumberValidator.go(payload, licence)
+
+        expect(result.value).to.exist()
+        expect(result.error).to.exist()
+        expect(result.error.details[0].message).to.equal('The licence has ended')
       })
     })
   })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5684

This change stops the user from tagging a licence that has ended.

We have also lifted out the fetch logic within the service and moved this into the dal, this is part of our ongoing effort to lift database logic out of services into the dal.