### PR TITLE
Update Company contact default logic

### DIFF
--- a/app/services/company-contacts/setup/initiate-edit-session.service.js
+++ b/app/services/company-contacts/setup/initiate-edit-session.service.js
@@ -42,17 +42,32 @@ async function go(companyContactId) {
 function _formatDataForJourney(companyContact, licences) {
   const { abstractionAlertLicences, company, contact } = companyContact
 
-  const abstractionAlerts = companyContact.$abstractionAlertType()
-
   return {
     abstractionAlertLicences,
-    abstractionAlerts: licences.length > 0 ? abstractionAlerts : 'no',
+    abstractionAlerts: _abstractionAlerts(companyContact, licences),
     company,
     companyContact,
     email: formatEmail(contact.email),
     licences,
     name: contact.$name()
   }
+}
+
+/**
+ * Determines the resolved abstraction alert type based on the user's selection and the current active licences.
+ * - 'yes' - The contact wants alerts for any licence (including future ones).
+ * - 'some' - The contact wants alerts for specific licences. If all licences expire/end, this defaults to 'no'.
+ *
+ * @private
+ */
+function _abstractionAlerts(companyContact, licences) {
+  const abstractionAlertType = companyContact.$abstractionAlertType()
+
+  if (abstractionAlertType === 'some' && licences.length === 0) {
+    return 'no'
+  }
+
+  return abstractionAlertType
 }
 
 module.exports = {

--- a/test/services/company-contacts/setup/initiate-edit-session.service.test.js
+++ b/test/services/company-contacts/setup/initiate-edit-session.service.test.js
@@ -27,7 +27,6 @@ describe('Company Contacts - Setup - Initiate edit Session service', () => {
   let companyContact
   let contact
   let licences
-  let stubFetchCompanyContactDal
   let stubFetchCompanyLicencesDal
 
   beforeEach(() => {
@@ -44,8 +43,8 @@ describe('Company Contacts - Setup - Initiate edit Session service', () => {
       contact
     })
 
-    stubFetchCompanyContactDal = Sinon.stub(FetchCompanyContactDal, 'go').returns(companyContact)
-    stubFetchCompanyLicencesDal = Sinon.stub(FetchCompanyLicencesDal, 'go').returns(licences)
+    Sinon.stub(FetchCompanyContactDal, 'go').resolves(companyContact)
+    stubFetchCompanyLicencesDal = Sinon.stub(FetchCompanyLicencesDal, 'go').resolves(licences)
   })
 
   afterEach(() => {
@@ -71,53 +70,67 @@ describe('Company Contacts - Setup - Initiate edit Session service', () => {
   })
 
   describe('the "abstractionAlerts" property', () => {
-    describe('when the "abstractionAlerts" property is true', () => {
-      beforeEach(() => {
-        companyContact.abstractionAlerts = true
+    describe('and the company has active licences', () => {
+      describe('when the "abstractionAlerts" property is true', () => {
+        beforeEach(() => {
+          companyContact.abstractionAlerts = true
+        })
 
-        stubFetchCompanyContactDal.resolves(companyContact)
+        it('returns "yes"', async () => {
+          const result = await InitiateEditSessionService.go(companyContact.id)
+
+          const matchingSession = await SessionModel.query().findById(result.id)
+
+          expect(matchingSession.abstractionAlerts).to.equal('yes')
+        })
+
+        describe('and there are abstraction alert licences', () => {
+          beforeEach(() => {
+            companyContact.abstractionAlertLicences = [{ id: generateUUID(), licenceRef: generateLicenceRef() }]
+          })
+
+          it('returns "some"', async () => {
+            const result = await InitiateEditSessionService.go(companyContact.id)
+
+            const matchingSession = await SessionModel.query().findById(result.id)
+
+            expect(matchingSession.abstractionAlerts).to.equal('some')
+          })
+        })
       })
 
-      describe('and abstraction alert licences exist', () => {
+      describe('when the "abstractionAlerts" property is false', () => {
+        it('returns "no"', async () => {
+          const result = await InitiateEditSessionService.go(companyContact.id)
+
+          const matchingSession = await SessionModel.query().findById(result.id)
+
+          expect(matchingSession.abstractionAlerts).to.equal('no')
+        })
+      })
+    })
+
+    describe('and the company has no active licences', () => {
+      beforeEach(() => {
+        stubFetchCompanyLicencesDal.resolves([])
+      })
+
+      describe('when the "abstractionAlerts" property is true', () => {
         beforeEach(() => {
-          companyContact.abstractionAlertLicences = [{ id: generateUUID(), licenceRef: generateLicenceRef() }]
-
-          stubFetchCompanyContactDal.resolves(companyContact)
+          companyContact.abstractionAlerts = true
         })
 
-        describe('and there are active licences', () => {
-          describe('and at least one licence matches an "abstractionAlertLicences"', () => {
-            beforeEach(() => {
-              stubFetchCompanyLicencesDal.resolves([companyContact.abstractionAlertLicences[0].id])
-            })
+        it('returns "yes"', async () => {
+          const result = await InitiateEditSessionService.go(companyContact.id)
 
-            it('returns "some"', async () => {
-              const result = await InitiateEditSessionService.go(companyContact.id)
+          const matchingSession = await SessionModel.query().findById(result.id)
 
-              const matchingSession = await SessionModel.query().findById(result.id)
-
-              expect(matchingSession.abstractionAlerts).to.equal('some')
-            })
-          })
-
-          describe('and no licences match the "abstractionAlertLicences"', () => {
-            beforeEach(() => {
-              stubFetchCompanyLicencesDal.resolves(generateUUID())
-            })
-
-            it('returns "some"', async () => {
-              const result = await InitiateEditSessionService.go(companyContact.id)
-
-              const matchingSession = await SessionModel.query().findById(result.id)
-
-              expect(matchingSession.abstractionAlerts).to.equal('some')
-            })
-          })
+          expect(matchingSession.abstractionAlerts).to.equal('yes')
         })
 
-        describe('and there are no active licences', () => {
+        describe('and there are abstraction alert licences', () => {
           beforeEach(() => {
-            stubFetchCompanyLicencesDal.resolves([])
+            companyContact.abstractionAlertLicences = [{ id: generateUUID(), licenceRef: generateLicenceRef() }]
           })
 
           it('returns "no"', async () => {
@@ -130,24 +143,14 @@ describe('Company Contacts - Setup - Initiate edit Session service', () => {
         })
       })
 
-      describe('and no abstraction alert licences exist', () => {
-        it('returns "yes"', async () => {
+      describe('when the "abstractionAlerts" property is false', () => {
+        it('returns "no"', async () => {
           const result = await InitiateEditSessionService.go(companyContact.id)
 
           const matchingSession = await SessionModel.query().findById(result.id)
 
-          expect(matchingSession.abstractionAlerts).to.equal('yes')
+          expect(matchingSession.abstractionAlerts).to.equal('no')
         })
-      })
-    })
-
-    describe('when the "abstractionAlerts" property is false', () => {
-      it('returns "no"', async () => {
-        const result = await InitiateEditSessionService.go(companyContact.id)
-
-        const matchingSession = await SessionModel.query().findById(result.id)
-
-        expect(matchingSession.abstractionAlerts).to.equal('no')
       })
     })
   })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5631

We were seeing an issue where the user would select 'Yes, for all licences' for a company with no valid licences. This was defaulting the selection to 'No'.

This is not the expected behaviour.

When a user selects 'Yes, for all licences', that means all active licences; these could be added in the future and so should be included when sending abstraction alerts.

When a user selects 'Yes, for some licences' and there is no licence, we want to hide the option from the user and default the value to 'No'.

This change updates the logic to only default to 'No' when the user has selected 'some' licences.