### PR TITLE
Add licence fixture

### DIFF
--- a/app/presenters/licence.presenter.js
+++ b/app/presenters/licence.presenter.js
@@ -1,8 +1,9 @@
 'use strict'
 
 const PointModel = require('../models/point.model.js')
-const { formatAbstractionPeriod } = require('./base.presenter.js')
 const { formatAbstractionAmounts } = require('./licences/base-licences.presenter.js')
+const { formatAbstractionPeriod, formatLongDate } = require('./base.presenter.js')
+const { today } = require('../lib/general.lib.js')
 
 /**
  * Formats Licence condition types for the view
@@ -177,8 +178,43 @@ function _param(paramLabel, param, noteNumber) {
     value: param
   }
 }
+
+/**
+ *
+ * @param licence
+ */
+function licenceEndsWarning(licence) {
+  const ends = licence.$ends()
+
+  if (!ends || ends.date > today()) {
+    return null
+  }
+
+  const formattedDate = formatLongDate(ends.date)
+
+  if (ends.reason === 'revoked') {
+    return {
+      text: `This licence was revoked on ${formattedDate}`,
+      iconFallbackText: 'Warning'
+    }
+  }
+
+  if (ends.reason === 'lapsed') {
+    return {
+      text: `This licence lapsed on ${formattedDate}`,
+      iconFallbackText: 'Warning'
+    }
+  }
+
+  return {
+    text: `This licence expired on ${formattedDate}`,
+    iconFallbackText: 'Warning'
+  }
+}
+
 module.exports = {
   formatConditionTypes,
   formatLicencePoints,
-  formatLicencePurposes
+  formatLicencePurposes,
+  licenceEndsWarning
 }

--- a/app/presenters/licence.presenter.js
+++ b/app/presenters/licence.presenter.js
@@ -1,9 +1,8 @@
 'use strict'
 
 const PointModel = require('../models/point.model.js')
+const { formatAbstractionPeriod } = require('./base.presenter.js')
 const { formatAbstractionAmounts } = require('./licences/base-licences.presenter.js')
-const { formatAbstractionPeriod, formatLongDate } = require('./base.presenter.js')
-const { today } = require('../lib/general.lib.js')
 
 /**
  * Formats Licence condition types for the view
@@ -178,43 +177,8 @@ function _param(paramLabel, param, noteNumber) {
     value: param
   }
 }
-
-/**
- *
- * @param licence
- */
-function licenceEndsWarning(licence) {
-  const ends = licence.$ends()
-
-  if (!ends || ends.date > today()) {
-    return null
-  }
-
-  const formattedDate = formatLongDate(ends.date)
-
-  if (ends.reason === 'revoked') {
-    return {
-      text: `This licence was revoked on ${formattedDate}`,
-      iconFallbackText: 'Warning'
-    }
-  }
-
-  if (ends.reason === 'lapsed') {
-    return {
-      text: `This licence lapsed on ${formattedDate}`,
-      iconFallbackText: 'Warning'
-    }
-  }
-
-  return {
-    text: `This licence expired on ${formattedDate}`,
-    iconFallbackText: 'Warning'
-  }
-}
-
 module.exports = {
   formatConditionTypes,
   formatLicencePoints,
-  formatLicencePurposes,
-  licenceEndsWarning
+  formatLicencePurposes
 }

--- a/test/presenters/company-contacts/contact-details.presenter.test.js
+++ b/test/presenters/company-contacts/contact-details.presenter.test.js
@@ -9,9 +9,7 @@ const { expect } = Code
 
 // Test helpers
 const CustomersFixtures = require('../../support/fixtures/customers.fixture.js')
-const LicenceModel = require('../../../app/models/licence.model.js')
-const { generateLicenceRef } = require('../../support/helpers/licence.helper.js')
-const { generateUUID } = require('../../../app/lib/general.lib.js')
+const { licenceEnds } = require('../../support/fixtures/licence.fixture.js')
 const { yesterday } = require('../../support/general.js')
 
 // Thing under test
@@ -134,15 +132,7 @@ describe('Company Contacts - Contact Details presenter', () => {
 
         describe('when the abstractionAlertType is "some"', () => {
           beforeEach(() => {
-            licences = [
-              LicenceModel.fromJson({
-                id: generateUUID(),
-                licenceRef: generateLicenceRef(),
-                lapsedDate: null,
-                expiredDate: null,
-                revokedDate: null
-              })
-            ]
+            licences = [licenceEnds()]
 
             companyContact.abstractionAlerts = true
             companyContact.abstractionAlertLicences = [licences[0].id]
@@ -168,15 +158,7 @@ describe('Company Contacts - Contact Details presenter', () => {
 
       describe('when one or more licences have ended', () => {
         beforeEach(() => {
-          licences = [
-            LicenceModel.fromJson({
-              id: generateUUID(),
-              licenceRef: generateLicenceRef(),
-              lapsedDate: null,
-              expiredDate: yesterday(),
-              revokedDate: null
-            })
-          ]
+          licences = [licenceEnds(yesterday())]
         })
 
         it('returns a warning object', () => {

--- a/test/presenters/users/external/licences.presenter.test.js
+++ b/test/presenters/users/external/licences.presenter.test.js
@@ -8,9 +8,9 @@ const { describe, it, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const LicenceModel = require('../../../../app/models/licence.model.js')
 const UsersFixture = require('../../../support/fixtures/users.fixture.js')
 const { generateUUID, today } = require('../../../../app/lib/general.lib.js')
+const { licenceEnds } = require('../../../support/fixtures/licence.fixture.js')
 const { tomorrow } = require('../../../support/general.js')
 
 // Thing under test
@@ -153,13 +153,7 @@ function _licence(licenceRef, expiredDate, role) {
   const licenceVersionId = generateUUID()
   const licenceDocumentHeaderId = generateUUID()
 
-  const licence = LicenceModel.fromJson({
-    expiredDate,
-    id: generateUUID(),
-    lapsedDate: null,
-    licenceRef,
-    revokedDate: null
-  })
+  const licence = licenceEnds(expiredDate)
 
   licence.licenceVersions = [
     {

--- a/test/services/notices/setup/abstraction-alerts/determine-licence-monitoring-stations.service.test.js
+++ b/test/services/notices/setup/abstraction-alerts/determine-licence-monitoring-stations.service.test.js
@@ -9,9 +9,8 @@ const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const LicenceModel = require('../../../../../app/models/licence.model.js')
-const { generateLicenceRef } = require('../../../../support/helpers/licence.helper.js')
 const { generateUUID } = require('../../../../../app/lib/general.lib.js')
+const { licenceEnds } = require('../../../../support/fixtures/licence.fixture.js')
 const { yesterday } = require('../../../../support/general.js')
 
 // Things we need to stub
@@ -51,13 +50,7 @@ describe('Notices Setup - Abstraction Alerts - Determine Licence Monitoring Stat
         thresholdUnit: 'm3/s',
         thresholdValue: 100,
         latestNotification: null,
-        licence: LicenceModel.fromJson({
-          expiredDate: null,
-          id: generateUUID(),
-          lapsedDate: null,
-          licenceRef: generateLicenceRef(),
-          revokedDate: null
-        }),
+        licence: licenceEnds(),
         licenceVersionPurposeCondition: null
       },
       {
@@ -71,13 +64,7 @@ describe('Notices Setup - Abstraction Alerts - Determine Licence Monitoring Stat
         thresholdUnit: 'm3/s',
         thresholdValue: 100,
         latestNotification: null,
-        licence: LicenceModel.fromJson({
-          expiredDate: null,
-          id: generateUUID(),
-          lapsedDate: null,
-          licenceRef: generateLicenceRef(),
-          revokedDate: null
-        }),
+        licence: licenceEnds(),
         licenceVersionPurposeCondition: {
           id: generateUUID(),
           notes: 'I have a bad feeling about this'
@@ -90,13 +77,7 @@ describe('Notices Setup - Abstraction Alerts - Determine Licence Monitoring Stat
         abstractionPeriodStartMonth: 1,
         id: generateUUID(),
         latestNotification: null,
-        licence: LicenceModel.fromJson({
-          expiredDate: null,
-          id: generateUUID(),
-          lapsedDate: null,
-          licenceRef: generateLicenceRef(),
-          revokedDate: null
-        }),
+        licence: licenceEnds(),
         licenceVersionPurposeCondition: {
           id: generateUUID(),
           notes: '"                   "             "                    "'

--- a/test/support/fixtures/licence.fixture.js
+++ b/test/support/fixtures/licence.fixture.js
@@ -1,0 +1,28 @@
+'use strict'
+
+const LicenceModel = require('../../../app/models/licence.model.js')
+const { generateLicenceRef } = require('../helpers/licence.helper.js')
+const { generateUUID } = require('../../../app/lib/general.lib.js')
+
+/**
+ * When we check if a licence ends or has ended, we query the database and return the expected, revoked, and lapsed date.
+ *
+ * We would then use the 'ends' or 'ended' instance methods.
+ *
+ * In most cases the query will return the licence ref as well, so it is included here.
+ *
+ * @param {Date} endDate - a date to end the licence on (set the 'expiredDate')
+ *
+ * @returns {module:LicenceModel} A licence to be used in tests that uses the 'ends' or 'ended' instance method
+ */
+function licenceEnds(endDate = null) {
+  return LicenceModel.fromJson({
+    expiredDate: endDate,
+    id: generateUUID(),
+    lapsedDate: null,
+    licenceRef: generateLicenceRef(),
+    revokedDate: null
+  })
+}
+
+module.exports = { licenceEnds }

--- a/test/validators/licence-monitoring-station/setup/licence-number.validator.test.js
+++ b/test/validators/licence-monitoring-station/setup/licence-number.validator.test.js
@@ -8,10 +8,9 @@ const { describe, it, beforeEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const LicenceModel = require('../../../../app/models/licence.model.js')
-const { yesterday } = require('../../../support/general.js')
-const { generateUUID } = require('../../../../app/lib/general.lib.js')
 const { generateLicenceRef } = require('../../../support/helpers/licence.helper.js')
+const { licenceEnds } = require('../../../support/fixtures/licence.fixture.js')
+const { yesterday } = require('../../../support/general.js')
 
 // Thing under test
 const LicenceNumberValidator = require('../../../../app/validators/licence-monitoring-station/setup/licence-number.validator.js')
@@ -21,13 +20,7 @@ describe('Licence Monitoring Station Setup - Licence Number Validator', () => {
   let payload = {}
 
   beforeEach(() => {
-    licence = LicenceModel.fromJson({
-      expiredDate: null,
-      id: generateUUID(),
-      lapsedDate: null,
-      licenceRef: generateLicenceRef(),
-      revokedDate: null
-    })
+    licence = licenceEnds()
   })
 
   describe('when called with valid data', () => {
@@ -96,7 +89,7 @@ describe('Licence Monitoring Station Setup - Licence Number Validator', () => {
 
     describe('because the licence has ended', () => {
       beforeEach(() => {
-        licence.lapsedDate = yesterday()
+        licence = licenceEnds(yesterday())
 
         payload = {
           licenceRef: generateLicenceRef()


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5689

This change adds a licence fixture, this allows us to resue common test structures.

In this case we have been amending the code to handle when a licence ends or has ended, these rely on the same data (expected, revoked, and lapsed dates).

When we use the instance methods 'ends' or 'ended', we require these dates, we recently introduced an 'ended' modifier to return these dates which is progressively being used.