### PR TITLE
Update company contact cancel page to show 'some' licences

### DIFF
--- a/app/presenters/company-contacts/setup/cancel.presenter.js
+++ b/app/presenters/company-contacts/setup/cancel.presenter.js
@@ -5,7 +5,7 @@
  * @module CancelPresenter
  */
 
-const { abstractionAlertsLabel, selectedLicences } = require('../../crm.presenter.js')
+const { abstractionAlertsLabel, selectedLiveLicences } = require('../../crm.presenter.js')
 
 /**
  * Formats data for the '/company-contacts/setup/{sessionId}/cancel' page
@@ -24,7 +24,7 @@ function go(session) {
       text: 'Back'
     },
     email,
-    licences: selectedLicences(licences, abstractionAlertLicences, abstractionAlerts),
+    licences: selectedLiveLicences(licences, abstractionAlertLicences, abstractionAlerts),
     name,
     pageTitle: _pageTitle(session),
     pageTitleCaption: company.name

--- a/app/presenters/company-contacts/setup/cancel.presenter.js
+++ b/app/presenters/company-contacts/setup/cancel.presenter.js
@@ -5,7 +5,7 @@
  * @module CancelPresenter
  */
 
-const { titleCase } = require('../../base.presenter.js')
+const { abstractionAlertsLabel, selectedLicences } = require('../../crm.presenter.js')
 
 /**
  * Formats data for the '/company-contacts/setup/{sessionId}/cancel' page
@@ -15,15 +15,16 @@ const { titleCase } = require('../../base.presenter.js')
  * @returns {object} The data formatted for the view template
  */
 function go(session) {
-  const { company, email, name, abstractionAlerts } = session
+  const { abstractionAlertLicences, abstractionAlerts, company, email, licences, name } = session
 
   return {
     backLink: {
       href: `/system/company-contacts/setup/${session.id}/check`,
       text: 'Back'
     },
-    abstractionAlerts: titleCase(abstractionAlerts),
+    abstractionAlertsLabel: abstractionAlertsLabel(abstractionAlerts),
     email,
+    licences: selectedLicences(licences, abstractionAlertLicences, abstractionAlerts),
     name,
     pageTitle: _pageTitle(session),
     pageTitleCaption: company.name

--- a/app/presenters/company-contacts/setup/cancel.presenter.js
+++ b/app/presenters/company-contacts/setup/cancel.presenter.js
@@ -18,11 +18,11 @@ function go(session) {
   const { abstractionAlertLicences, abstractionAlerts, company, email, licences, name } = session
 
   return {
+    abstractionAlertsLabel: abstractionAlertsLabel(abstractionAlerts),
     backLink: {
       href: `/system/company-contacts/setup/${session.id}/check`,
       text: 'Back'
     },
-    abstractionAlertsLabel: abstractionAlertsLabel(abstractionAlerts),
     email,
     licences: selectedLicences(licences, abstractionAlertLicences, abstractionAlerts),
     name,

--- a/app/presenters/company-contacts/setup/check.presenter.js
+++ b/app/presenters/company-contacts/setup/check.presenter.js
@@ -5,7 +5,7 @@
  * @module CheckPresenter
  */
 
-const { abstractionAlertsLabel, selectedLicences } = require('../../crm.presenter.js')
+const { abstractionAlertsLabel, selectedLiveLicences } = require('../../crm.presenter.js')
 
 /**
  * Formats data for the '/company-contacts/setup/{sessionId}/check' page
@@ -26,7 +26,7 @@ function go(session, savedCompanyContacts, sentNotification) {
     abstractionAlertsLabel: abstractionAlertsLabel(abstractionAlerts),
     email,
     emailInUse: _emailInUse(sentNotification, companyContact),
-    licences: selectedLicences(licences, abstractionAlertLicences, abstractionAlerts),
+    licences: selectedLiveLicences(licences, abstractionAlertLicences, abstractionAlerts),
     links: {
       abstractionAlerts: `/system/company-contacts/setup/${session.id}/abstraction-alerts`,
       cancel: `/system/company-contacts/setup/${session.id}/cancel`,

--- a/app/presenters/company-contacts/setup/check.presenter.js
+++ b/app/presenters/company-contacts/setup/check.presenter.js
@@ -5,7 +5,7 @@
  * @module CheckPresenter
  */
 
-const { abstractionAlertsLabel } = require('../../crm.presenter.js')
+const { abstractionAlertsLabel, selectedLicences } = require('../../crm.presenter.js')
 
 /**
  * Formats data for the '/company-contacts/setup/{sessionId}/check' page
@@ -29,7 +29,7 @@ function go(session, savedCompanyContacts, sentNotification) {
     name,
     pageTitle: 'Check contact',
     pageTitleCaption: company.name,
-    licences: _licences(licences, abstractionAlertLicences, abstractionAlerts),
+    licences: selectedLicences(licences, abstractionAlertLicences, abstractionAlerts),
     links: {
       abstractionAlerts: `/system/company-contacts/setup/${session.id}/abstraction-alerts`,
       cancel: `/system/company-contacts/setup/${session.id}/cancel`,
@@ -58,19 +58,6 @@ function _emailInUse(sentNotification, companyContact) {
   return null
 }
 
-function _licences(licences, abstractionAlertLicences, abstractionAlerts) {
-  if (abstractionAlerts !== 'some' || !abstractionAlertLicences?.length) {
-    return []
-  }
-
-  return licences
-    .filter((licence) => {
-      return abstractionAlertLicences.includes(licence.id)
-    })
-    .map((licence) => {
-      return licence.licenceRef
-    })
-}
 /*
  * Check if the contact already exists, if it does, then this is a match.
  *

--- a/app/presenters/company-contacts/setup/check.presenter.js
+++ b/app/presenters/company-contacts/setup/check.presenter.js
@@ -26,9 +26,6 @@ function go(session, savedCompanyContacts, sentNotification) {
     abstractionAlertsLabel: abstractionAlertsLabel(abstractionAlerts),
     email,
     emailInUse: _emailInUse(sentNotification, companyContact),
-    name,
-    pageTitle: 'Check contact',
-    pageTitleCaption: company.name,
     licences: selectedLicences(licences, abstractionAlertLicences, abstractionAlerts),
     links: {
       abstractionAlerts: `/system/company-contacts/setup/${session.id}/abstraction-alerts`,
@@ -38,6 +35,9 @@ function go(session, savedCompanyContacts, sentNotification) {
       restoreContact: matchingContact?.deletedAt ? `/system/company-contacts/setup/${session.id}/restore` : null
     },
     matchingContact,
+    name,
+    pageTitle: 'Check contact',
+    pageTitleCaption: company.name,
     warning: _warning(matchingContact, abstractionAlertLicences, abstractionAlerts)
   }
 }

--- a/app/presenters/crm.presenter.js
+++ b/app/presenters/crm.presenter.js
@@ -36,24 +36,39 @@ function formatContact(contact, billingQueryArgs) {
 }
 
 /**
- * Returns the licence references the user has selected to receive abstraction alerts for
+ * Compares a user's selected licences to 'live' ones for a company, and returns those that are live
  *
- * This is used to display the licence to the user.
+ * This is used in licence holder contact pages, where we need to show what licence a user has been assigned for a given
+ * notice type.
  *
- * @param {object[]} licences - The licences for the company
- * @param {string[]} abstractionAlertLicences - The IDs of the licences selected to receive abstraction alerts
- * @param {string} abstractionAlerts - The abstraction alerts value ('no', 'some', or 'yes')
+ * For example, licence holder contacts can be set to receive abstraction alerts. If the option has been set as 'yes'
+ * or 'no', then the calling page simply needs to show the setting, either 'Yes, all licences' or 'No'.
  *
- * @returns {string[]} The licence references the user has selected, or an empty array if not applicable
+ * If the option has been set to 'some', then the calling page will show 'Yes, some licences' alongside a list of the
+ * selected licence references.
+ *
+ * The complexity is that over time, licences can expire, lapse, or be revoked. When we show the selected licences, the
+ * intention is to make it clear which ones they will receive a notification for. So, we need to exclude those that are
+ * no longer 'live'.
+ *
+ * This function determines what the list of licence references should be, based on the settings of the user and the
+ * current 'live' licences for the licence holder.
+ *
+ * @param {object[]} liveLicences - The licences for the company
+ * @param {string[]} selectedLicences - The IDs of the selected licences the user should receive notifications for
+ * @param {string} noticeSetting - The notice setting ('no', 'some', or 'yes')
+ *
+ * @returns {string[]} The licence references of 'live' licences the user has selected, or an empty array if not
+ * applicable
  */
-function selectedLicences(licences, abstractionAlertLicences, abstractionAlerts) {
-  if (abstractionAlerts !== 'some' || !abstractionAlertLicences?.length) {
+function selectedLiveLicences(liveLicences, selectedLicences, noticeSetting) {
+  if (noticeSetting !== 'some' || !selectedLicences?.length) {
     return []
   }
 
-  return licences
+  return liveLicences
     .filter((licence) => {
-      return abstractionAlertLicences.includes(licence.id)
+      return selectedLicences.includes(licence.id)
     })
     .map((licence) => {
       return licence.licenceRef
@@ -88,5 +103,5 @@ function _contactLink(contact, billingQueryArgs) {
 module.exports = {
   abstractionAlertsLabel,
   formatContact,
-  selectedLicences
+  selectedLiveLicences
 }

--- a/app/presenters/crm.presenter.js
+++ b/app/presenters/crm.presenter.js
@@ -35,6 +35,31 @@ function formatContact(contact, billingQueryArgs) {
   }
 }
 
+/**
+ * Returns the licence references the user has selected to receive abstraction alerts for
+ *
+ * This is used to display the licence to the user.
+ *
+ * @param {object[]} licences - The licences for the company
+ * @param {string[]} abstractionAlertLicences - The IDs of the licences selected to receive abstraction alerts
+ * @param {string} abstractionAlerts - The abstraction alerts value ('no', 'some', or 'yes')
+ *
+ * @returns {string[]} The licence references the user has selected, or an empty array if not applicable
+ */
+function selectedLicences(licences, abstractionAlertLicences, abstractionAlerts) {
+  if (abstractionAlerts !== 'some' || !abstractionAlertLicences?.length) {
+    return []
+  }
+
+  return licences
+    .filter((licence) => {
+      return abstractionAlertLicences.includes(licence.id)
+    })
+    .map((licence) => {
+      return licence.licenceRef
+    })
+}
+
 function _contactLink(contact, billingQueryArgs) {
   const billingTypes = ['billing']
   const companyContactTypes = ['abstraction-alerts', 'additional-contact']
@@ -62,5 +87,6 @@ function _contactLink(contact, billingQueryArgs) {
 
 module.exports = {
   abstractionAlertsLabel,
-  formatContact
+  formatContact,
+  selectedLicences
 }

--- a/app/views/company-contacts/setup/cancel.njk
+++ b/app/views/company-contacts/setup/cancel.njk
@@ -3,7 +3,18 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 
+{% from "macros/collapsible-list.njk" import collapsibleList %}
+
 {% block pageContent %}
+
+  {% set abstractionAlertsHtml %}
+    {% if licences.length %}
+      <p class="govuk-!-margin-bottom-3">{{ abstractionAlertsLabel }}</p>
+      {{ collapsibleList(licences, "Licences") }}
+    {% else %}
+      <p class="govuk-!-margin-bottom-1">{{ abstractionAlertsLabel }}</p>
+    {% endif %}
+  {% endset %}
 
   {{ govukSummaryList({
     rows: [
@@ -17,7 +28,7 @@
       },
       {
         key: { text: "Water abstraction alerts" },
-        value: { html: abstractionAlerts }
+        value: { html: abstractionAlertsHtml }
       }
     ]
   }) }}

--- a/test/presenters/company-contacts/setup/cancel.presenter.test.js
+++ b/test/presenters/company-contacts/setup/cancel.presenter.test.js
@@ -10,18 +10,30 @@ const { expect } = Code
 // Test helpers
 const CustomersFixtures = require('../../../support/fixtures/customers.fixture.js')
 const { generateUUID } = require('../../../../app/lib/general.lib.js')
+const { licenceWithLicenceRefs } = require('../../../support/fixtures/licence.fixture.js')
 
 // Thing under test
 const CancelPresenter = require('../../../../app/presenters/company-contacts/setup/cancel.presenter.js')
 
 describe('Company Contacts - Setup - Cancel Presenter', () => {
   let company
+  let licences
   let session
 
   beforeEach(() => {
     company = CustomersFixtures.company()
 
-    session = { id: generateUUID(), company, abstractionAlerts: 'yes', name: 'Eric', email: 'eric@test.com' }
+    licences = licenceWithLicenceRefs()
+
+    session = {
+      abstractionAlertLicences: null,
+      abstractionAlerts: 'yes',
+      company,
+      email: 'eric@test.com',
+      id: generateUUID(),
+      licences,
+      name: 'Eric'
+    }
   })
 
   describe('when called', () => {
@@ -29,12 +41,13 @@ describe('Company Contacts - Setup - Cancel Presenter', () => {
       const result = CancelPresenter.go(session)
 
       expect(result).to.equal({
-        abstractionAlerts: 'Yes',
+        abstractionAlertsLabel: 'Yes, for all licences',
         backLink: {
           href: `/system/company-contacts/setup/${session.id}/check`,
           text: 'Back'
         },
         email: 'eric@test.com',
+        licences: [],
         name: 'Eric',
         pageTitle: 'You are about to cancel this contact',
         pageTitleCaption: 'Tyrell Corporation'

--- a/test/presenters/company-contacts/setup/cancel.presenter.test.js
+++ b/test/presenters/company-contacts/setup/cancel.presenter.test.js
@@ -10,7 +10,7 @@ const { expect } = Code
 // Test helpers
 const CustomersFixtures = require('../../../support/fixtures/customers.fixture.js')
 const { generateUUID } = require('../../../../app/lib/general.lib.js')
-const { licenceWithLicenceRefs } = require('../../../support/fixtures/licence.fixture.js')
+const { licence } = require('../../../support/fixtures/licence.fixture.js')
 
 // Thing under test
 const CancelPresenter = require('../../../../app/presenters/company-contacts/setup/cancel.presenter.js')
@@ -23,7 +23,7 @@ describe('Company Contacts - Setup - Cancel Presenter', () => {
   beforeEach(() => {
     company = CustomersFixtures.company()
 
-    licences = licenceWithLicenceRefs()
+    licences = [licence()]
 
     session = {
       abstractionAlertLicences: null,

--- a/test/presenters/company-contacts/setup/check.presenter.test.js
+++ b/test/presenters/company-contacts/setup/check.presenter.test.js
@@ -11,7 +11,7 @@ const { expect } = Code
 const CustomersFixtures = require('../../../support/fixtures/customers.fixture.js')
 const { yesterday } = require('../../../support/general.js')
 const { generateUUID } = require('../../../../app/lib/general.lib.js')
-const { licenceWithLicenceRefs } = require('../../../support/fixtures/licence.fixture.js')
+const { licence } = require('../../../support/fixtures/licence.fixture.js')
 
 // Thing under test
 const CheckPresenter = require('../../../../app/presenters/company-contacts/setup/check.presenter.js')
@@ -37,7 +37,7 @@ describe('Company Contacts - Setup - Check Presenter', () => {
     name = companyContact.contact.department
     email = companyContact.contact.email
 
-    licences = licenceWithLicenceRefs()
+    licences = [licence()]
 
     sentNotification = undefined
 

--- a/test/presenters/company-contacts/setup/check.presenter.test.js
+++ b/test/presenters/company-contacts/setup/check.presenter.test.js
@@ -9,8 +9,8 @@ const { expect } = Code
 
 // Test helpers
 const CustomersFixtures = require('../../../support/fixtures/customers.fixture.js')
-const { generateLicenceRef } = require('../../../support/helpers/licence.helper.js')
 const { generateUUID } = require('../../../../app/lib/general.lib.js')
+const { licenceWithLicenceRefs } = require('../../../support/fixtures/licence.fixture.js')
 const { yesterday } = require('../../../support/general.js')
 
 // Thing under test
@@ -37,7 +37,7 @@ describe('Company Contacts - Setup - Check Presenter', () => {
     name = companyContact.contact.department
     email = companyContact.contact.email
 
-    licences = [{ id: generateUUID(), licenceRef: generateLicenceRef() }]
+    licences = licenceWithLicenceRefs()
 
     sentNotification = undefined
 
@@ -123,87 +123,6 @@ describe('Company Contacts - Setup - Check Presenter', () => {
             expect(result.emailInUse).to.equal(
               'Notifications have been sent to this contact, so the email address cannot be changed.'
             )
-          })
-        })
-      })
-    })
-
-    describe('the "licences" property', () => {
-      describe('when the user is set to receive abstraction alerts for all licences ("yes")', () => {
-        it('returns an empty array', () => {
-          const result = CheckPresenter.go(session, savedCompanyContacts, sentNotification)
-
-          expect(result.licences).to.be.empty()
-        })
-      })
-
-      describe('when the user is set not to receive abstraction alerts ("no")', () => {
-        beforeEach(() => {
-          session.abstractionAlerts = 'no'
-        })
-
-        it('returns an empty array', () => {
-          const result = CheckPresenter.go(session, savedCompanyContacts, sentNotification)
-
-          expect(result.licences).to.be.empty()
-        })
-      })
-
-      describe('when the user is set to receive abstraction alerts for specific licences ("some")', () => {
-        beforeEach(() => {
-          session.abstractionAlerts = 'some'
-        })
-
-        describe('and there are no existing "abstractionAlertLicences"', () => {
-          beforeEach(() => {
-            session.abstractionAlertLicences = null
-          })
-
-          it('returns an empty array', () => {
-            const result = CheckPresenter.go(session, savedCompanyContacts, sentNotification)
-
-            expect(result.licences).to.be.empty()
-          })
-        })
-
-        describe('and there are "live" licences', () => {
-          describe('and the selected licences for the user matches the "live" licences', () => {
-            beforeEach(() => {
-              session.abstractionAlertLicences = [licences[0].id]
-            })
-
-            it('returns the matching licence references', () => {
-              const result = CheckPresenter.go(session, savedCompanyContacts, sentNotification)
-
-              expect(result.licences).to.equal([licences[0].licenceRef])
-            })
-          })
-
-          describe('but none of the selected licences for the user matches the "live" licences', () => {
-            beforeEach(() => {
-              session.abstractionAlertLicences = [generateUUID()]
-            })
-
-            it('returns an empty array', () => {
-              const result = CheckPresenter.go(session, savedCompanyContacts, sentNotification)
-
-              expect(result.licences).to.be.empty()
-            })
-          })
-        })
-
-        describe('but there are no "live" licences', () => {
-          beforeEach(() => {
-            session.licences = []
-            session.abstractionAlertLicences = [licences[0].id]
-          })
-
-          describe('even though the user has selected licences to receive abstraction alerts for', () => {
-            it('returns an empty array', () => {
-              const result = CheckPresenter.go(session, savedCompanyContacts, sentNotification)
-
-              expect(result.licences).to.be.empty()
-            })
           })
         })
       })

--- a/test/presenters/company-contacts/setup/check.presenter.test.js
+++ b/test/presenters/company-contacts/setup/check.presenter.test.js
@@ -9,9 +9,9 @@ const { expect } = Code
 
 // Test helpers
 const CustomersFixtures = require('../../../support/fixtures/customers.fixture.js')
+const { yesterday } = require('../../../support/general.js')
 const { generateUUID } = require('../../../../app/lib/general.lib.js')
 const { licenceWithLicenceRefs } = require('../../../support/fixtures/licence.fixture.js')
-const { yesterday } = require('../../../support/general.js')
 
 // Thing under test
 const CheckPresenter = require('../../../../app/presenters/company-contacts/setup/check.presenter.js')

--- a/test/presenters/crm.presenter.test.js
+++ b/test/presenters/crm.presenter.test.js
@@ -259,7 +259,7 @@ describe('CRM presenter', () => {
     })
   })
 
-  describe.only('#selectedLicences()', () => {
+  describe('#selectedLicences()', () => {
     let abstractionAlertLicences
     let abstractionAlerts
     let licences

--- a/test/presenters/crm.presenter.test.js
+++ b/test/presenters/crm.presenter.test.js
@@ -9,7 +9,7 @@ const { expect } = Code
 
 // Test helpers
 const { generateUUID } = require('../../app/lib/general.lib.js')
-const { licenceWithLicenceRefs } = require('../support/fixtures/licence.fixture.js')
+const { licence } = require('../support/fixtures/licence.fixture.js')
 
 // Thing under test
 const CRMPresenter = require('../../app/presenters/crm.presenter.js')
@@ -259,62 +259,109 @@ describe('CRM presenter', () => {
     })
   })
 
-  describe('#selectedLicences()', () => {
-    let abstractionAlertLicences
-    let abstractionAlerts
-    let licences
+  describe('#selectedLiveLicences()', () => {
+    let liveLicences
+    let noticeSetting
+    let selectedLicences
 
     beforeEach(() => {
-      abstractionAlertLicences = []
-      licences = licenceWithLicenceRefs()
+      selectedLicences = []
     })
 
-    describe('when the user is set to receive abstraction alerts for all licences ("yes")', () => {
+    describe('when there are "liveLicences"', () => {
       beforeEach(() => {
-        abstractionAlerts = 'yes'
+        liveLicences = [licence()]
       })
 
-      it('returns an empty array', () => {
-        const result = CRMPresenter.selectedLicences(licences, abstractionAlertLicences, abstractionAlerts)
+      describe('and the user is set to receive "some" notices', () => {
+        beforeEach(() => {
+          noticeSetting = 'some'
+        })
 
-        expect(result).to.be.empty()
-      })
-    })
-
-    describe('when the user is set not to receive abstraction alerts ("no")', () => {
-      beforeEach(() => {
-        abstractionAlerts = 'no'
-      })
-
-      it('returns an empty array', () => {
-        const result = CRMPresenter.selectedLicences(licences, abstractionAlertLicences, abstractionAlerts)
-
-        expect(result).to.be.empty()
-      })
-    })
-
-    describe('when the user is set to receive abstraction alerts for specific licences ("some")', () => {
-      beforeEach(() => {
-        abstractionAlerts = 'some'
-      })
-
-      describe('and there are no existing "abstractionAlertLicences"', () => {
         it('returns an empty array', () => {
-          const result = CRMPresenter.selectedLicences(licences, abstractionAlertLicences, abstractionAlerts)
+          const result = CRMPresenter.selectedLiveLicences(liveLicences, selectedLicences, noticeSetting)
+
+          expect(result).to.be.empty()
+        })
+
+        describe('and there are existing "selectedLicences"', () => {
+          describe('that match the "liveLicences"', () => {
+            beforeEach(() => {
+              selectedLicences = [liveLicences[0].id]
+            })
+
+            it('returns the matching licence references', () => {
+              const result = CRMPresenter.selectedLiveLicences(liveLicences, selectedLicences, noticeSetting)
+
+              expect(result).to.equal([liveLicences[0].licenceRef])
+            })
+          })
+
+          describe('that do not match the "liveLicences"', () => {
+            beforeEach(() => {
+              selectedLicences = [generateUUID()]
+            })
+
+            it('returns the matching licence references (none)', () => {
+              const result = CRMPresenter.selectedLiveLicences(liveLicences, selectedLicences, noticeSetting)
+
+              expect(result).to.equal([])
+            })
+          })
+        })
+      })
+
+      describe('and the user is set to receive something other than "some" notices', () => {
+        beforeEach(() => {
+          noticeSetting = 'yes'
+        })
+
+        it('returns an empty array', () => {
+          const result = CRMPresenter.selectedLiveLicences(liveLicences, selectedLicences, noticeSetting)
 
           expect(result).to.be.empty()
         })
       })
+    })
 
-      describe('and there are existing "abstractionAlertLicences"', () => {
+    describe('when there are no "liveLicences"', () => {
+      beforeEach(() => {
+        liveLicences = []
+      })
+
+      describe('and the user is set to receive "some" notices', () => {
         beforeEach(() => {
-          abstractionAlertLicences = [licences[0].id]
+          noticeSetting = 'some'
         })
 
-        it('returns the matching licence references', () => {
-          const result = CRMPresenter.selectedLicences(licences, abstractionAlertLicences, abstractionAlerts)
+        it('returns an empty array', () => {
+          const result = CRMPresenter.selectedLiveLicences(liveLicences, selectedLicences, noticeSetting)
 
-          expect(result).to.equal([licences[0].licenceRef])
+          expect(result).to.be.empty()
+        })
+
+        describe('and there are existing "selectedLicences"', () => {
+          beforeEach(() => {
+            selectedLicences = [generateUUID()]
+          })
+
+          it('returns an empty array', () => {
+            const result = CRMPresenter.selectedLiveLicences(liveLicences, selectedLicences, noticeSetting)
+
+            expect(result).to.be.empty()
+          })
+        })
+      })
+
+      describe('and the user is set to receive something other than "some" notices', () => {
+        beforeEach(() => {
+          noticeSetting = 'yes'
+        })
+
+        it('returns an empty array', () => {
+          const result = CRMPresenter.selectedLiveLicences(liveLicences, selectedLicences, noticeSetting)
+
+          expect(result).to.be.empty()
         })
       })
     })

--- a/test/presenters/crm.presenter.test.js
+++ b/test/presenters/crm.presenter.test.js
@@ -9,6 +9,7 @@ const { expect } = Code
 
 // Test helpers
 const { generateUUID } = require('../../app/lib/general.lib.js')
+const { licenceWithLicenceRefs } = require('../support/fixtures/licence.fixture.js')
 
 // Thing under test
 const CRMPresenter = require('../../app/presenters/crm.presenter.js')
@@ -253,6 +254,67 @@ describe('CRM presenter', () => {
               name: 'Rachael Tyrell'
             })
           })
+        })
+      })
+    })
+  })
+
+  describe.only('#selectedLicences()', () => {
+    let abstractionAlertLicences
+    let abstractionAlerts
+    let licences
+
+    beforeEach(() => {
+      abstractionAlertLicences = []
+      licences = licenceWithLicenceRefs()
+    })
+
+    describe('when the user is set to receive abstraction alerts for all licences ("yes")', () => {
+      beforeEach(() => {
+        abstractionAlerts = 'yes'
+      })
+
+      it('returns an empty array', () => {
+        const result = CRMPresenter.selectedLicences(licences, abstractionAlertLicences, abstractionAlerts)
+
+        expect(result).to.be.empty()
+      })
+    })
+
+    describe('when the user is set not to receive abstraction alerts ("no")', () => {
+      beforeEach(() => {
+        abstractionAlerts = 'no'
+      })
+
+      it('returns an empty array', () => {
+        const result = CRMPresenter.selectedLicences(licences, abstractionAlertLicences, abstractionAlerts)
+
+        expect(result).to.be.empty()
+      })
+    })
+
+    describe('when the user is set to receive abstraction alerts for specific licences ("some")', () => {
+      beforeEach(() => {
+        abstractionAlerts = 'some'
+      })
+
+      describe('and there are no existing "abstractionAlertLicences"', () => {
+        it('returns an empty array', () => {
+          const result = CRMPresenter.selectedLicences(licences, abstractionAlertLicences, abstractionAlerts)
+
+          expect(result).to.be.empty()
+        })
+      })
+
+      describe('and there are existing "abstractionAlertLicences"', () => {
+        beforeEach(() => {
+          abstractionAlertLicences = [licences[0].id]
+        })
+
+        it('returns the matching licence references', () => {
+          const result = CRMPresenter.selectedLicences(licences, abstractionAlertLicences, abstractionAlerts)
+
+          expect(result).to.equal([licences[0].licenceRef])
         })
       })
     })

--- a/test/services/company-contacts/setup/view-cancel.service.test.js
+++ b/test/services/company-contacts/setup/view-cancel.service.test.js
@@ -42,12 +42,13 @@ describe('Company Contacts - Setup - Cancel Service', () => {
       const result = await ViewCancelService.go(session.id)
 
       expect(result).to.equal({
-        abstractionAlerts: 'Yes',
+        abstractionAlertsLabel: 'Yes, for all licences',
         backLink: {
           href: `/system/company-contacts/setup/${session.id}/check`,
           text: 'Back'
         },
         email: 'eric@test.com',
+        licences: [],
         name: 'Eric',
         pageTitle: 'You are about to cancel this contact',
         pageTitleCaption: 'Tyrell Corporation'

--- a/test/support/fixtures/licence.fixture.js
+++ b/test/support/fixtures/licence.fixture.js
@@ -25,4 +25,25 @@ function licenceEnds(endDate = null) {
   })
 }
 
-module.exports = { licenceEnds }
+/**
+ * A licence with a licence ref
+ *
+ * @returns {LicenceModel} A licence with a licence ref
+ */
+function licenceWithLicenceRef() {
+  return LicenceModel.fromJson({
+    id: generateUUID(),
+    licenceRef: generateLicenceRef()
+  })
+}
+
+/**
+ * An array of licences with a licence ref
+ *
+ * @returns {LicenceModel[]} An array of licences with licence refs
+ */
+function licenceWithLicenceRefs() {
+  return [licenceWithLicenceRef()]
+}
+
+module.exports = { licenceEnds, licenceWithLicenceRefs }

--- a/test/support/fixtures/licence.fixture.js
+++ b/test/support/fixtures/licence.fixture.js
@@ -5,6 +5,23 @@ const { generateUUID } = require('../../../app/lib/general.lib.js')
 const { generateLicenceRef } = require('../helpers/licence.helper.js')
 
 /**
+ * Generates an instance of `LicenceModel` with an ID and a licence reference
+ *
+ * You can override or add additional properties by passing them in as an object
+ *
+ * @param {object} [data={}] - an object of properties to override or add to the licence
+ *
+ * @returns {module:LicenceModel} A licence with a licence ref
+ */
+function licence(data = {}) {
+  return LicenceModel.fromJson({
+    id: generateUUID(),
+    licenceRef: generateLicenceRef(),
+    ...data
+  })
+}
+
+/**
  * When we check if a licence ends or has ended, we query the database and return the expected, revoked, and lapsed date.
  *
  * We would then use the 'ends' or 'ended' instance methods.
@@ -16,34 +33,11 @@ const { generateLicenceRef } = require('../helpers/licence.helper.js')
  * @returns {module:LicenceModel} A licence to be used in tests that uses the 'ends' or 'ended' instance method
  */
 function licenceEnds(endDate = null) {
-  return LicenceModel.fromJson({
+  return licence({
     expiredDate: endDate,
-    id: generateUUID(),
     lapsedDate: null,
-    licenceRef: generateLicenceRef(),
     revokedDate: null
   })
 }
 
-/**
- * A licence with a licence ref
- *
- * @returns {LicenceModel} A licence with a licence ref
- */
-function licenceWithLicenceRef() {
-  return LicenceModel.fromJson({
-    id: generateUUID(),
-    licenceRef: generateLicenceRef()
-  })
-}
-
-/**
- * An array of licences with a licence ref
- *
- * @returns {LicenceModel[]} An array of licences with licence refs
- */
-function licenceWithLicenceRefs() {
-  return [licenceWithLicenceRef()]
-}
-
-module.exports = { licenceEnds, licenceWithLicenceRefs }
+module.exports = { licence, licenceEnds }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5630

We recently implemented a change to allow the user to select some licences to send abstraction alerts for.

We update the check page to show 'some' licences and to display the chosen licences, as the canel page closely mirros the check page we need to also update the canel page to match.

This change adds the 'some' licence logic to the cancel page.

Some logic has been lifted into reusable code for this and future changes.