### PR TITLE
Order of communications changes on refresh - Return logs

### DIFF
--- a/app/dal/return-logs/fetch-notifications.dal.js
+++ b/app/dal/return-logs/fetch-notifications.dal.js
@@ -29,7 +29,12 @@ async function _fetch(returnLogId, page) {
   return NotificationModel.query()
     .select(['createdAt', 'id', 'messageType', 'status'])
     .where('returnLogIds', '?', returnLogId)
-    .orderBy('createdAt', 'DESC')
+    .orderBy([
+      { column: 'createdAt', order: 'desc' },
+      { column: 'messageType', order: 'asc' },
+      { column: 'status', order: 'asc' },
+      { column: 'id', order: 'asc' }
+    ])
     .withGraphFetched('event')
     .modifyGraph('event', (builder) => {
       builder.select([

--- a/app/dal/return-logs/fetch-notifications.dal.js
+++ b/app/dal/return-logs/fetch-notifications.dal.js
@@ -2,7 +2,7 @@
 
 /**
  * Fetches data needed for the view '/system/return-logs/{id}/communications' page
- * @module FetchNotificationsService
+ * @module FetchNotificationsDal
  */
 
 const { ref } = require('objection')

--- a/app/services/return-logs/view-communications.service.js
+++ b/app/services/return-logs/view-communications.service.js
@@ -7,7 +7,7 @@
  */
 
 const CommunicationsPresenter = require('../../presenters/return-logs/communications.presenter.js')
-const FetchNotificationsService = require('./fetch-notifications.service.js')
+const FetchNotificationsDal = require('../../dal/return-logs/fetch-notifications.dal.js')
 const FetchReturnLogService = require('./fetch-return-log.service.js')
 const PaginatorPresenter = require('../../presenters/paginator.presenter.js')
 
@@ -22,7 +22,7 @@ const PaginatorPresenter = require('../../presenters/paginator.presenter.js')
 async function go(id, page) {
   const returnLog = await FetchReturnLogService.go(id)
 
-  const { notifications, totalNumber } = await FetchNotificationsService.go(id, page)
+  const { notifications, totalNumber } = await FetchNotificationsDal.go(id, page)
 
   const pageData = CommunicationsPresenter.go(returnLog, notifications)
 

--- a/test/dal/return-logs/fetch-notifications.dal.test.js
+++ b/test/dal/return-logs/fetch-notifications.dal.test.js
@@ -16,9 +16,9 @@ const NotificationsFixture = require('../../support/fixtures/notifications.fixtu
 const { generateLicenceRef } = require('../../support/helpers/licence.helper.js')
 
 // Thing under test
-const FetchNotificationsService = require('../../../app/services/return-logs/fetch-notifications.service.js')
+const FetchNotificationsDal = require('../../../app/dal/return-logs/fetch-notifications.dal.js')
 
-describe('Return Logs - Fetch Notifications service', () => {
+describe('Return Logs - Fetch Notifications DAL', () => {
   let notice
   let notification
 
@@ -38,7 +38,7 @@ describe('Return Logs - Fetch Notifications service', () => {
 
   describe('when the return log has notifications', () => {
     it('returns the matching notifications and the total', async () => {
-      const result = await FetchNotificationsService.go(notification.returnLogIds[0])
+      const result = await FetchNotificationsDal.go(notification.returnLogIds[0])
 
       expect(result).to.equal({
         notifications: [
@@ -62,7 +62,7 @@ describe('Return Logs - Fetch Notifications service', () => {
 
   describe('when the return log has no notifications', () => {
     it('returns an empty array and zero', async () => {
-      const result = await FetchNotificationsService.go('513f8813-3782-4c1b-a095-a078adf757f4')
+      const result = await FetchNotificationsDal.go('513f8813-3782-4c1b-a095-a078adf757f4')
 
       expect(result).to.equal({ notifications: [], totalNumber: 0 })
     })

--- a/test/services/return-logs/view-communications.service.test.js
+++ b/test/services/return-logs/view-communications.service.test.js
@@ -13,7 +13,7 @@ const { generateUUID } = require('../../../app/lib/general.lib.js')
 const { generateLicenceRef } = require('../../support/helpers/licence.helper.js')
 
 // Things we need to stub
-const FetchNotificationsService = require('../../../app/services/return-logs/fetch-notifications.service.js')
+const FetchNotificationsDal = require('../../../app/dal/return-logs/fetch-notifications.dal.js')
 const FetchReturnLogService = require('../../../app/services/return-logs/fetch-return-log.service.js')
 
 // Thing under test
@@ -34,7 +34,7 @@ describe('Return Logs - View Communications Service', () => {
     }
 
     Sinon.stub(FetchReturnLogService, 'go').returns(returnLog)
-    Sinon.stub(FetchNotificationsService, 'go').returns({
+    Sinon.stub(FetchNotificationsDal, 'go').returns({
       notifications: [],
       totalNumber: 0
     })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5674

Our QA team have spotted that when viewing communications, their order can sometimes be different. For example, view the table, select a notification to view, then return to the table, and the order is different.

Users expect the order to be consistent every time they view the page.

We are going to start with some housekeeping. Where we have a `fetch-notifications.service.js` (or something similar), move it into the DAL. For example, app/services/return-logs/fetch-notifications.service.js.

Then update all fetch-notifications.dal.js modules to order by:
- created at desc
- message type asc
- status asc
- id asc (id will always be unique, so as a method of last resort, it will ensure the order is always consistent).

This PR will focus on the Return Logs Communications `app/services/return-logs/fetch-notifications.service.js`.