### PR TITLE
Order of communications changes on refresh - Company contacts

### DIFF
--- a/app/dal/company-contacts/fetch-notifications.dal.js
+++ b/app/dal/company-contacts/fetch-notifications.dal.js
@@ -36,7 +36,12 @@ async function _fetch(email, page) {
     .whereNotNull('recipient')
     .where('recipient', email)
     .whereNotIn('messageRef', ignoreMessageRef)
-    .orderBy('createdAt', 'DESC')
+    .orderBy([
+      { column: 'createdAt', order: 'desc' },
+      { column: 'messageType', order: 'asc' },
+      { column: 'status', order: 'asc' },
+      { column: 'id', order: 'asc' }
+    ])
     .withGraphFetched('event')
     .modifyGraph('event', (builder) => {
       builder.select([

--- a/app/dal/company-contacts/fetch-notifications.dal.js
+++ b/app/dal/company-contacts/fetch-notifications.dal.js
@@ -2,7 +2,7 @@
 
 /**
  * Fetches data needed for the view '/system/company-contacts/{id}/communications' page
- * @module FetchNotificationsService
+ * @module FetchNotificationsDal
  */
 
 const { ref } = require('objection')

--- a/app/services/company-contacts/view-communications.service.js
+++ b/app/services/company-contacts/view-communications.service.js
@@ -9,7 +9,7 @@
 const CommunicationsPresenter = require('../../presenters/company-contacts/communications.presenter.js')
 const FetchCompanyContactDal = require('../../dal/company-contacts/fetch-company-contact.dal.js')
 const FetchCompanyService = require('../companies/fetch-company.service.js')
-const FetchNotificationsService = require('./fetch-notifications.service.js')
+const FetchNotificationsDal = require('../../dal/company-contacts/fetch-notifications.dal.js')
 const PaginatorPresenter = require('../../presenters/paginator.presenter.js')
 
 /**
@@ -25,7 +25,7 @@ async function go(id, page) {
 
   const company = await FetchCompanyService.go(companyContact.companyId)
 
-  const { notifications, totalNumber } = await FetchNotificationsService.go(companyContact.contact.email, page)
+  const { notifications, totalNumber } = await FetchNotificationsDal.go(companyContact.contact.email, page)
 
   const pageData = CommunicationsPresenter.go(company, companyContact, notifications)
 

--- a/test/dal/company-contacts/fetch-notifications.dal.test.js
+++ b/test/dal/company-contacts/fetch-notifications.dal.test.js
@@ -15,9 +15,9 @@ const NotificationsFixture = require('../../support/fixtures/notifications.fixtu
 const { generateUUID } = require('../../../app/lib/general.lib.js')
 
 // Thing under test
-const FetchNotificationsService = require('../../../app/services/company-contacts/fetch-notifications.service.js')
+const FetchNotificationsDal = require('../../../app/dal/company-contacts/fetch-notifications.dal.js')
 
-describe('Company contact - Fetch Notifications service', () => {
+describe('Company contact - Fetch Notifications DAL', () => {
   let notice
   let noticeTwo
   let notification
@@ -61,7 +61,7 @@ describe('Company contact - Fetch Notifications service', () => {
 
   describe('when the company contact has notifications', () => {
     it('returns the matching notifications', async () => {
-      const result = await FetchNotificationsService.go(email)
+      const result = await FetchNotificationsDal.go(email)
 
       expect(result).to.equal({
         notifications: [
@@ -101,7 +101,7 @@ describe('Company contact - Fetch Notifications service', () => {
     })
 
     it('returns no notifications', async () => {
-      const result = await FetchNotificationsService.go(email)
+      const result = await FetchNotificationsDal.go(email)
 
       expect(result).to.equal({
         notifications: [],
@@ -116,7 +116,7 @@ describe('Company contact - Fetch Notifications service', () => {
     })
 
     it('returns no notifications', async () => {
-      const result = await FetchNotificationsService.go(email)
+      const result = await FetchNotificationsDal.go(email)
 
       expect(result).to.equal({
         notifications: [],

--- a/test/services/company-contacts/view-communications.service.test.js
+++ b/test/services/company-contacts/view-communications.service.test.js
@@ -15,7 +15,7 @@ const { generateUUID } = require('../../../app/lib/general.lib.js')
 // Things we need to stub
 const FetchCompanyContactDal = require('../../../app/dal/company-contacts/fetch-company-contact.dal.js')
 const FetchCompanyService = require('../../../app/services/companies/fetch-company.service.js')
-const FetchNotificationsService = require('../../../app/services/company-contacts/fetch-notifications.service.js')
+const FetchNotificationsDal = require('../../../app/dal/company-contacts/fetch-notifications.dal.js')
 
 // Thing under test
 const ViewCommunicationsService = require('../../../app/services/company-contacts/view-communications.service.js')
@@ -37,7 +37,7 @@ describe('Company Contacts - View Communications Service', () => {
 
     Sinon.stub(FetchCompanyService, 'go').returns(company)
     Sinon.stub(FetchCompanyContactDal, 'go').returns(companyContact)
-    Sinon.stub(FetchNotificationsService, 'go').returns({
+    Sinon.stub(FetchNotificationsDal, 'go').returns({
       notifications: [],
       totalNumber: 0
     })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5674

Our QA team have spotted that when viewing communications, their order can sometimes be different. For example, view the table, select a notification to view, then return to the table, and the order is different.

Users expect the order to be consistent every time they view the page.

We are going to start with some housekeeping. Where we have a `fetch-notifications.service.js` (or something similar), move it into the DAL. For example, app/services/return-logs/fetch-notifications.service.js.

Then update all fetch-notifications.dal.js modules to order by:
- created at desc
- message type asc
- status asc
- id asc (id will always be unique, so as a method of last resort, it will ensure the order is always consistent).

This PR will focus on the Company Contacts Communications `app/services/company-contacts/fetch-notifications.service.js`.