### PR TITLE
Refactor company contacts setup services and dal

### DIFF
--- a/app/dal/company-contacts/setup/create-company-contact.dal.js
+++ b/app/dal/company-contacts/setup/create-company-contact.dal.js
@@ -2,7 +2,7 @@
 
 /**
  * Creates the company contact data for the '/company-contacts/{id}' pages
- * @module CreateCompanyContactService
+ * @module CreateCompanyContactDal
  */
 
 const CompanyContactModel = require('../../../models/company-contact.model.js')

--- a/app/dal/company-contacts/setup/fetch-company-contacts.dal.js
+++ b/app/dal/company-contacts/setup/fetch-company-contacts.dal.js
@@ -2,7 +2,7 @@
 
 /**
  * Fetches the company contacts data needed for the '/company-contacts/setup/{sessionId}/check' page
- * @module FetchCompanyContactsService
+ * @module FetchCompanyContactsDal
  */
 
 const CompanyContactModel = require('../../../models/company-contact.model.js')

--- a/app/dal/company-contacts/setup/update-company-contact.dal.js
+++ b/app/dal/company-contacts/setup/update-company-contact.dal.js
@@ -2,7 +2,7 @@
 
 /**
  * Update the company contact data for the '/company-contacts/{id}/check' page
- * @module UpdateCompanyContactService
+ * @module UpdateCompanyContactDal
  */
 
 const CompanyContactModel = require('../../../models/company-contact.model.js')

--- a/app/services/company-contacts/setup/submit-check.service.js
+++ b/app/services/company-contacts/setup/submit-check.service.js
@@ -6,10 +6,10 @@
  * @module SubmitCheckService
  */
 
-const CreateCompanyContactService = require('./create-company-contact.service.js')
+const CreateCompanyContactDal = require('../../../dal/company-contacts/setup/create-company-contact.dal.js')
 const DeleteSessionDal = require('../../../dal/delete-session.dal.js')
 const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
-const UpdateCompanyContactService = require('./update-company-contact.service.js')
+const UpdateCompanyContactDal = require('../../../dal/company-contacts/setup/update-company-contact.dal.js')
 const { flashNotification } = require('../../../lib/general.lib.js')
 
 /**
@@ -62,7 +62,7 @@ async function _createCompanyContact(session, auth, yar) {
     name: session.name
   }
 
-  await CreateCompanyContactService.go(session.company.id, companyContact)
+  await CreateCompanyContactDal.go(session.company.id, companyContact)
 
   flashNotification(yar, 'Contact added', `${session.name} was added to this company`)
 }
@@ -78,7 +78,7 @@ async function _updateCompanyContact(session, auth, yar) {
     updatedBy: auth.credentials.user.id
   }
 
-  await UpdateCompanyContactService.go(companyContact)
+  await UpdateCompanyContactDal.go(companyContact)
 
   flashNotification(yar, 'Updated', 'Contact details updated.')
 }

--- a/app/services/company-contacts/setup/submit-restore.service.js
+++ b/app/services/company-contacts/setup/submit-restore.service.js
@@ -8,7 +8,7 @@
 
 const DeleteSessionDal = require('../../../dal/delete-session.dal.js')
 const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
-const UpdateCompanyContactService = require('./update-company-contact.service.js')
+const UpdateCompanyContactDal = require('../../../dal/company-contacts/setup/update-company-contact.dal.js')
 const { flashNotification } = require('../../../lib/general.lib.js')
 
 /**
@@ -46,7 +46,7 @@ async function _updateCompanyContact(session, auth) {
     updatedBy: auth.credentials.user.id
   }
 
-  await UpdateCompanyContactService.go(companyContact)
+  await UpdateCompanyContactDal.go(companyContact)
 }
 
 module.exports = {

--- a/app/services/company-contacts/setup/view-check.service.js
+++ b/app/services/company-contacts/setup/view-check.service.js
@@ -7,7 +7,7 @@
  */
 
 const CheckPresenter = require('../../../presenters/company-contacts/setup/check.presenter.js')
-const FetchCompanyContactsService = require('./fetch-company-contacts.service.js')
+const FetchCompanyContactsDal = require('../../../dal/company-contacts/setup/fetch-company-contacts.dal.js')
 const FetchNotificationService = require('../fetch-notification.service.js')
 const FetchSessionDal = require('../../../dal/fetch-session.dal.js')
 const { markCheckPageVisited } = require('../../../lib/check-page.lib.js')
@@ -24,7 +24,7 @@ const { readFlashNotification } = require('../../../lib/general.lib.js')
 async function go(sessionId, yar) {
   const session = await FetchSessionDal.go(sessionId)
 
-  const companyContacts = await FetchCompanyContactsService.go(session.company.id, session.companyContact)
+  const companyContacts = await FetchCompanyContactsDal.go(session.company.id, session.companyContact)
 
   const sentNotification = await FetchNotificationService.go(session.email)
 

--- a/test/dal/company-contacts/setup/create-company-contact.dal.test.js
+++ b/test/dal/company-contacts/setup/create-company-contact.dal.test.js
@@ -15,9 +15,9 @@ const LicenceRoleHelper = require('../../../support/helpers/licence-role.helper.
 const { generateUUID } = require('../../../../app/lib/general.lib.js')
 
 // Thing under test
-const CreateCompanyContactService = require('../../../../app/services/company-contacts/setup/create-company-contact.service.js')
+const CreateCompanyContactDal = require('../../../../app/dal/company-contacts/setup/create-company-contact.dal.js')
 
-describe('Company Contacts - Create Company Contact service', () => {
+describe('Company Contacts - Create Company Contact dal', () => {
   let clock
   let companyContact
   let company
@@ -45,7 +45,7 @@ describe('Company Contacts - Create Company Contact service', () => {
 
   describe('when a new company contact is added', () => {
     it('inserts the company contact and links the company contact to the "additionalContact" licence role', async () => {
-      const result = await CreateCompanyContactService.go(company.id, companyContact)
+      const result = await CreateCompanyContactDal.go(company.id, companyContact)
 
       const licenceRole = LicenceRoleHelper.select('additionalContact')
 

--- a/test/dal/company-contacts/setup/fetch-company-contacts.dal.test.js
+++ b/test/dal/company-contacts/setup/fetch-company-contacts.dal.test.js
@@ -12,9 +12,9 @@ const CompanyContactHelper = require('../../../support/helpers/company-contact.h
 const ContactHelper = require('../../../support/helpers/contact.helper.js')
 
 // Thing under test
-const FetchCompanyContactsService = require('../../../../app/services/company-contacts/setup/fetch-company-contacts.service.js')
+const FetchCompanyContactsDal = require('../../../../app/dal/company-contacts/setup/fetch-company-contacts.dal.js')
 
-describe('Company Contacts - Setup - Fetch Company Contacts service', () => {
+describe('Company Contacts - Setup - Fetch Company Contacts dal', () => {
   let additionalCompanyContact
   let companyContact
   let companyContactToIgnore
@@ -41,7 +41,7 @@ describe('Company Contacts - Setup - Fetch Company Contacts service', () => {
 
   describe('when there are company contacts', () => {
     it('returns the matching company contacts', async () => {
-      const result = await FetchCompanyContactsService.go(companyContact.companyId, undefined)
+      const result = await FetchCompanyContactsDal.go(companyContact.companyId, undefined)
 
       expect(result).to.equal([
         {
@@ -72,7 +72,7 @@ describe('Company Contacts - Setup - Fetch Company Contacts service', () => {
       })
 
       it('returns the matching company contacts', async () => {
-        const result = await FetchCompanyContactsService.go(companyContact.companyId, companyContactToIgnore)
+        const result = await FetchCompanyContactsDal.go(companyContact.companyId, companyContactToIgnore)
 
         expect(result).to.equal([
           {

--- a/test/dal/company-contacts/setup/update-company-contact.dal.test.js
+++ b/test/dal/company-contacts/setup/update-company-contact.dal.test.js
@@ -16,9 +16,9 @@ const LicenceRoleHelper = require('../../../support/helpers/licence-role.helper.
 const UserHelper = require('../../../support/helpers/user.helper.js')
 
 // Thing under test
-const UpdateCompanyContactService = require('../../../../app/services/company-contacts/setup/update-company-contact.service.js')
+const UpdateCompanyContactDal = require('../../../../app/dal/company-contacts/setup/update-company-contact.dal.js')
 
-describe('Company Contacts - Update Company Contact service', () => {
+describe('Company Contacts - Update Company Contact dal', () => {
   let today
   let clock
   let companyContact
@@ -72,7 +72,7 @@ describe('Company Contacts - Update Company Contact service', () => {
 
   describe('when a updating a company contact', () => {
     it('updates the company contact and associated contact', async () => {
-      await UpdateCompanyContactService.go(updatedCompanyContact)
+      await UpdateCompanyContactDal.go(updatedCompanyContact)
 
       const updatedCompanyContactResult = await CompanyContactModel.query()
         .findById(companyContact.id)

--- a/test/services/company-contacts/setup/submit-check.service.test.js
+++ b/test/services/company-contacts/setup/submit-check.service.test.js
@@ -18,9 +18,9 @@ const { generateUUID } = require('../../../../app/lib/general.lib.js')
 const YarStub = require('../../../support/stubs/yar.stub.js')
 
 // Things we need to stub
-const CreateCompanyContactService = require('../../../../app/services/company-contacts/setup/create-company-contact.service.js')
+const CreateCompanyContactDal = require('../../../../app/dal/company-contacts/setup/create-company-contact.dal.js')
 const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
-const UpdateCompanyContactService = require('../../../../app/services/company-contacts/setup/update-company-contact.service.js')
+const UpdateCompanyContactDal = require('../../../../app/dal/company-contacts/setup/update-company-contact.dal.js')
 
 // Thing under test
 const SubmitCheckService = require('../../../../app/services/company-contacts/setup/submit-check.service.js')
@@ -39,8 +39,8 @@ describe('Company Contacts - Setup - Check Service', () => {
 
     company = CustomersFixtures.company()
 
-    Sinon.stub(CreateCompanyContactService, 'go').resolves()
-    Sinon.stub(UpdateCompanyContactService, 'go').resolves()
+    Sinon.stub(CreateCompanyContactDal, 'go').resolves()
+    Sinon.stub(UpdateCompanyContactDal, 'go').resolves()
 
     yarStub = YarStub.build(Sinon)
   })
@@ -77,7 +77,7 @@ describe('Company Contacts - Setup - Check Service', () => {
     it('persists the company contact details', async () => {
       await SubmitCheckService.go(session.id, yarStub, auth)
 
-      const actualContact = CreateCompanyContactService.go.args[0]
+      const actualContact = CreateCompanyContactDal.go.args[0]
 
       expect(actualContact).to.equal([
         company.id,
@@ -105,7 +105,7 @@ describe('Company Contacts - Setup - Check Service', () => {
         it('persists the "abstractionAlerts" as "true"', async () => {
           await SubmitCheckService.go(session.id, yarStub, auth)
 
-          const actualContact = CreateCompanyContactService.go.args[0][1]
+          const actualContact = CreateCompanyContactDal.go.args[0][1]
 
           expect(actualContact.abstractionAlerts).to.be.true()
         })
@@ -121,7 +121,7 @@ describe('Company Contacts - Setup - Check Service', () => {
         it('persists the "abstractionAlerts" as "true"', async () => {
           await SubmitCheckService.go(session.id, yarStub, auth)
 
-          const actualContact = CreateCompanyContactService.go.args[0][1]
+          const actualContact = CreateCompanyContactDal.go.args[0][1]
 
           expect(actualContact.abstractionAlerts).to.be.true()
         })
@@ -137,7 +137,7 @@ describe('Company Contacts - Setup - Check Service', () => {
         it('persists the "abstractionAlerts" as "false"', async () => {
           await SubmitCheckService.go(session.id, yarStub, auth)
 
-          const actualContact = CreateCompanyContactService.go.args[0][1]
+          const actualContact = CreateCompanyContactDal.go.args[0][1]
 
           expect(actualContact.abstractionAlerts).to.be.false()
         })
@@ -163,7 +163,7 @@ describe('Company Contacts - Setup - Check Service', () => {
         it('persists "abstractionAlertLicences" as a JSON string', async () => {
           await SubmitCheckService.go(session.id, yarStub, auth)
 
-          const actualContact = CreateCompanyContactService.go.args[0][1]
+          const actualContact = CreateCompanyContactDal.go.args[0][1]
           const expectedAbstractionAlertLicences = JSON.stringify(abstractionAlertLicences)
 
           expect(actualContact.abstractionAlertLicences).to.equal(expectedAbstractionAlertLicences)
@@ -174,7 +174,7 @@ describe('Company Contacts - Setup - Check Service', () => {
         it('persists "abstractionAlertLicences" as null', async () => {
           await SubmitCheckService.go(session.id, yarStub, auth)
 
-          const actualContact = CreateCompanyContactService.go.args[0][1]
+          const actualContact = CreateCompanyContactDal.go.args[0][1]
 
           expect(actualContact.abstractionAlertLicences).to.be.null()
         })
@@ -191,7 +191,7 @@ describe('Company Contacts - Setup - Check Service', () => {
       it('persists the "email" in lowercase', async () => {
         await SubmitCheckService.go(session.id, yarStub, auth)
 
-        const actualContact = CreateCompanyContactService.go.args[0][1]
+        const actualContact = CreateCompanyContactDal.go.args[0][1]
 
         expect(actualContact.email).to.equal('erice@test.com')
       })
@@ -220,7 +220,7 @@ describe('Company Contacts - Setup - Check Service', () => {
     it('persists the company contact details', async () => {
       await SubmitCheckService.go(session.id, yarStub, auth)
 
-      const [actualContact] = UpdateCompanyContactService.go.args[0]
+      const [actualContact] = UpdateCompanyContactDal.go.args[0]
 
       expect(actualContact).to.equal({
         id: companyContact.id,
@@ -247,7 +247,7 @@ describe('Company Contacts - Setup - Check Service', () => {
         it('persists the "abstractionAlerts" as "true"', async () => {
           await SubmitCheckService.go(session.id, yarStub, auth)
 
-          const [actualContact] = UpdateCompanyContactService.go.args[0]
+          const [actualContact] = UpdateCompanyContactDal.go.args[0]
 
           expect(actualContact.abstractionAlerts).to.be.true()
         })
@@ -263,7 +263,7 @@ describe('Company Contacts - Setup - Check Service', () => {
         it('persists the "abstractionAlerts" as "true"', async () => {
           await SubmitCheckService.go(session.id, yarStub, auth)
 
-          const [actualContact] = UpdateCompanyContactService.go.args[0]
+          const [actualContact] = UpdateCompanyContactDal.go.args[0]
 
           expect(actualContact.abstractionAlerts).to.be.true()
         })
@@ -279,7 +279,7 @@ describe('Company Contacts - Setup - Check Service', () => {
         it('persists the "abstractionAlerts" as "false"', async () => {
           await SubmitCheckService.go(session.id, yarStub, auth)
 
-          const [actualContact] = UpdateCompanyContactService.go.args[0]
+          const [actualContact] = UpdateCompanyContactDal.go.args[0]
 
           expect(actualContact.abstractionAlerts).to.be.false()
         })
@@ -305,7 +305,7 @@ describe('Company Contacts - Setup - Check Service', () => {
         it('persists "abstractionAlertLicences" as a JSON string', async () => {
           await SubmitCheckService.go(session.id, yarStub, auth)
 
-          const [actualContact] = UpdateCompanyContactService.go.args[0]
+          const [actualContact] = UpdateCompanyContactDal.go.args[0]
           const expectedAbstractionAlertLicences = JSON.stringify(abstractionAlertLicences)
 
           expect(actualContact.abstractionAlertLicences).to.equal(expectedAbstractionAlertLicences)
@@ -316,7 +316,7 @@ describe('Company Contacts - Setup - Check Service', () => {
         it('persists "abstractionAlertLicences" as null', async () => {
           await SubmitCheckService.go(session.id, yarStub, auth)
 
-          const [actualContact] = UpdateCompanyContactService.go.args[0]
+          const [actualContact] = UpdateCompanyContactDal.go.args[0]
 
           expect(actualContact.abstractionAlertLicences).to.be.null()
         })
@@ -334,7 +334,7 @@ describe('Company Contacts - Setup - Check Service', () => {
         it('persists the "email" in lowercase', async () => {
           await SubmitCheckService.go(session.id, yarStub, auth)
 
-          const [actualContact] = UpdateCompanyContactService.go.args[0]
+          const [actualContact] = UpdateCompanyContactDal.go.args[0]
 
           expect(actualContact.email).to.equal('erice@test.com')
         })

--- a/test/services/company-contacts/setup/submit-restore.service.test.js
+++ b/test/services/company-contacts/setup/submit-restore.service.test.js
@@ -19,7 +19,7 @@ const YarStub = require('../../../support/stubs/yar.stub.js')
 // Things we need to stub
 const DeleteSessionDal = require('../../../../app/dal/delete-session.dal.js')
 const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
-const UpdateCompanyContactService = require('../../../../app/services/company-contacts/setup/update-company-contact.service.js')
+const UpdateCompanyContactDal = require('../../../../app/dal/company-contacts/setup/update-company-contact.dal.js')
 
 // Thing under test
 const SubmitRestoreService = require('../../../../app/services/company-contacts/setup/submit-restore.service.js')
@@ -54,7 +54,7 @@ describe('Company Contacts - Setup - Submit Restore Service', () => {
 
     yarStub = YarStub.build(Sinon)
 
-    Sinon.stub(UpdateCompanyContactService, 'go').resolves()
+    Sinon.stub(UpdateCompanyContactDal, 'go').resolves()
     Sinon.stub(DeleteSessionDal, 'go').resolves()
   })
 
@@ -72,7 +72,7 @@ describe('Company Contacts - Setup - Submit Restore Service', () => {
     it('persists the company contact details', async () => {
       await SubmitRestoreService.go(session.id, yarStub, auth)
 
-      const [actualContact] = UpdateCompanyContactService.go.args[0]
+      const [actualContact] = UpdateCompanyContactDal.go.args[0]
 
       expect(actualContact).to.equal({
         id: companyContact.id,
@@ -104,7 +104,7 @@ describe('Company Contacts - Setup - Submit Restore Service', () => {
         it('persists the "abstractionAlerts" as "true"', async () => {
           await SubmitRestoreService.go(session.id, yarStub, auth)
 
-          const [actualContact] = UpdateCompanyContactService.go.args[0]
+          const [actualContact] = UpdateCompanyContactDal.go.args[0]
 
           expect(actualContact.abstractionAlerts).to.be.true()
         })
@@ -123,7 +123,7 @@ describe('Company Contacts - Setup - Submit Restore Service', () => {
         it('persists the "abstractionAlerts" as "false"', async () => {
           await SubmitRestoreService.go(session.id, yarStub, auth)
 
-          const [actualContact] = UpdateCompanyContactService.go.args[0]
+          const [actualContact] = UpdateCompanyContactDal.go.args[0]
 
           expect(actualContact.abstractionAlerts).to.be.false()
         })
@@ -144,7 +144,7 @@ describe('Company Contacts - Setup - Submit Restore Service', () => {
         it('persists the "email" in lowercase', async () => {
           await SubmitRestoreService.go(session.id, yarStub, auth)
 
-          const [actualContact] = UpdateCompanyContactService.go.args[0]
+          const [actualContact] = UpdateCompanyContactDal.go.args[0]
 
           expect(actualContact.email).to.equal('erice@test.com')
         })

--- a/test/services/company-contacts/setup/view-check.service.test.js
+++ b/test/services/company-contacts/setup/view-check.service.test.js
@@ -14,7 +14,7 @@ const SessionModelStub = require('../../../support/stubs/session.stub.js')
 const YarStub = require('../../../support/stubs/yar.stub.js')
 
 // Things we need to stub
-const FetchCompanyContactsService = require('../../../../app/services/company-contacts/setup/fetch-company-contacts.service.js')
+const FetchCompanyContactsDal = require('../../../../app/dal/company-contacts/setup/fetch-company-contacts.dal.js')
 const FetchNotificationService = require('../../../../app/services/company-contacts/fetch-notification.service.js')
 const FetchSessionDal = require('../../../../app/dal/fetch-session.dal.js')
 
@@ -26,6 +26,7 @@ describe('Company Contacts - Setup - Check Service', () => {
   let notification
   let session
   let yarStub
+  let stubFetchCompanyContactsDal
 
   beforeEach(async () => {
     company = CustomersFixtures.company()
@@ -38,6 +39,8 @@ describe('Company Contacts - Setup - Check Service', () => {
 
     Sinon.stub(FetchSessionDal, 'go').resolves(session)
 
+    stubFetchCompanyContactsDal = Sinon.stub(FetchCompanyContactsDal, 'go')
+
     yarStub = YarStub.build(Sinon)
     yarStub.flash.returns([{ title: 'Test', text: 'Notification' }])
   })
@@ -49,7 +52,7 @@ describe('Company Contacts - Setup - Check Service', () => {
   describe('when called', () => {
     describe('when there is no matching contact', () => {
       beforeEach(() => {
-        Sinon.stub(FetchCompanyContactsService, 'go').resolves(CustomersFixtures.companyContacts())
+        stubFetchCompanyContactsDal.resolves(CustomersFixtures.companyContacts())
       })
 
       it('returns page data for the view', async () => {
@@ -101,7 +104,7 @@ describe('Company Contacts - Setup - Check Service', () => {
         matchingContact.contact.email = 'eric@test.com'
         matchingContact.contact.contactType = 'department'
 
-        Sinon.stub(FetchCompanyContactsService, 'go').returns([matchingContact])
+        stubFetchCompanyContactsDal.returns([matchingContact])
       })
 
       it('updates the session', async () => {


### PR DESCRIPTION
We are moving service which comminnucate directly with the database into the DAL folder. This creates a seperation between services and external dependencies (in this case a database).

This change refactors the database services in the company contacts servcies into the dal folder (and tests).